### PR TITLE
docs: plan backlog + claude-dynamic-workflows reference topic

### DIFF
--- a/docs/internal/development/plans/api-component-domain-structure.md
+++ b/docs/internal/development/plans/api-component-domain-structure.md
@@ -1,0 +1,656 @@
+# Domain-First OpenAPI Component Structure Plan
+
+## Status
+
+Proposed.
+
+## Problem Statement
+
+The authored OpenAPI component tree is organized primarily by component kind
+and broad technical categories instead of the customer contracts and product
+domains those components describe. Customers and contributors who start from a
+Factory configuration, operator configuration, Factory Session, Work request,
+or another public concept must search large mixed directories and reconstruct
+ownership from filenames and references.
+
+## Customer Ask
+
+Make the authored API schema layout traceable from customer-facing concepts.
+In particular, make the Factory configuration schema and the global/operator
+configuration schema independently discoverable, then apply the same ownership
+model to the remaining OpenAPI components without changing public API behavior.
+
+## Intended Outcome
+
+A reader can start from a customer concept and find, in one domain-owned
+directory:
+
+- the root schema or operation family;
+- the schemas, parameters, and responses owned by that domain;
+- the canonical source of truth when a standalone schema also exists;
+- the published OpenAPI component or package export; and
+- the production parser, validator, or service boundary that consumes it.
+
+The migration is an authoring-layout change. OpenAPI component names, REST
+operations, generated Go and TypeScript names, standalone JSON Schema
+identities, package exports, and runtime validation behavior remain stable.
+
+## Original Documents And Normative Inputs
+
+- `C:\Users\andre\work\portos\infinite-you\docs\internal\standards\code\planning-standards.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\internal\standards\code\code-review-standards.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\internal\standards\code\general-backend-standards.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\internal\development\development.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\architecture\data-model.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\architecture\packaged-structure.md`
+
+## Current State
+
+`api/components/` currently contains 515 component files:
+
+| Current directory | Files | Current role |
+| --- | ---: | --- |
+| `parameters/` | 27 | Parameters from several unrelated operations |
+| `responses/` | 14 | Shared and domain-specific HTTP responses |
+| `schemas/api/` | 192 | Requests, responses, status types, sessions, models, Work, and operator configuration |
+| `schemas/data-models/` | 132 | Factory authoring concepts mixed with runtime records |
+| `schemas/events/` and `schemas/events/payloads/` | 65 | Canonical Factory Event contracts |
+| `schemas/factory-world/` | 24 | Compatibility Factory visualization read models |
+| `schemas/model-providers/` | 23 | Provider catalog contracts |
+| `schemas/response-events/` and descendants | 32 | Ephemeral Factory response stream contracts |
+| `schemas/shared/` | 6 | Small cross-surface helpers |
+
+The two largest generic directories contain 324 of the 474 schema files. The
+Factory root currently has a transitive authored-fragment closure of roughly
+105 schema files, while the operator configuration root has eleven
+`GlobalConfig*` fragments. A new pair of folders inside the existing generic
+taxonomy would improve those roots locally but would not resolve the broader
+ownership ambiguity.
+
+There is also an important canonical-ownership distinction:
+
+- `api/openapi.yaml#/components/schemas/Factory`, authored from
+  `api/components/schemas/data-models/Factory.yaml`, is the canonical owner for
+  the standalone Factory configuration schema generated into
+  `contracts/config/factory.schema.json` and package projections.
+- `contracts/config/you-config.schema.json` is the canonical standalone
+  operator configuration schema. The `GlobalConfig*` OpenAPI fragments provide
+  generated transport types and must remain behaviorally aligned with it.
+- `internal/configcontractsmoke/family.go` records these separate ownership
+  paths and their production parsers and package projections.
+
+The plan must make this distinction explicit rather than implying that every
+file under `api/components/` is the canonical source for every published schema.
+
+## Goals
+
+- Organize authored components by public product domain before component kind.
+- Make Factory and operator configuration roots immediately discoverable.
+- Keep schemas close to the parameters and responses owned by the same API
+  domain.
+- Give every component one canonical authored owner and allow cross-domain
+  references without copying schemas.
+- Preserve all public component names, route contracts, schema identities,
+  package exports, and generated type names.
+- Migrate in dependency-aware, independently reviewable slices.
+- Replace the old `schemas/api` and `schemas/data-models` policy after all
+  components have an explicit owner.
+
+## Non-Goals
+
+- Renaming OpenAPI components, REST operations, fields, enums, or generated
+  types.
+- Redesigning Factory, operator configuration, session, event, Work, provider,
+  or model behavior.
+- Changing `@you-agent-factory/api` export specifiers.
+- Changing standalone JSON Schema `$id` values.
+- Making `GlobalConfig` the canonical standalone operator schema as part of
+  this structural migration.
+- Introducing duplicate compatibility copies at old component paths.
+- Adding a source-inventory or directory-topology test that proves only where
+  files live.
+- Reformatting or rewriting schema content unrelated to the move.
+
+## Structural Principles
+
+### 1. Domain First, Component Kind Second
+
+The first directory below `api/components/` names the owning customer or
+product domain. A domain may then contain `schemas/`, `parameters/`, and
+`responses/` as needed.
+
+This makes `factory-sessions/schemas/FactorySession.yaml` more informative than
+`schemas/api/FactorySession.yaml`, and keeps session parameters and error
+responses near the schemas used by the same operations.
+
+### 2. Configuration Roots Are First-Class Domains
+
+Factory configuration and operator configuration are separately loadable
+customer contracts. They receive separate top-level domains even when a schema
+is also registered in the bundled OpenAPI document for generation or HTTP use.
+
+Use `operator-config` rather than `global-config` for the directory name. The
+Operator Settings service and public documentation use operator configuration
+as the durable ownership term; `GlobalConfig` remains the stable OpenAPI and
+generated type name.
+
+### 3. Ownership Follows Meaning, Not Every Consumer
+
+A schema has one authored owner. Other domains reference it.
+
+- A value primarily authored inside `factory.json` belongs to
+  `factory-config`.
+- Runtime Work content and Work records belong to `work`, even when a Factory
+  configuration field references them.
+- Factory Session read models belong to `factory-sessions`, even when an event
+  carries one.
+- Neutral primitives used by unrelated domains may live under `shared`.
+
+`shared` is not a fallback for uncertain ownership. A component stays with the
+domain that defines its semantics whenever such an owner exists.
+
+### 4. Source Paths May Change; Public Identities Must Not
+
+`api/openapi-main.yaml` continues to register the same component keys. Moving a
+fragment changes its file `$ref`, not its public
+`#/components/schemas/<ComponentName>` identity. Relative references inside
+fragments are updated to their new canonical owners.
+
+### 5. Moves Must Not Leave Compatibility Copies
+
+The repository layout is not a supported API package surface. Files move to
+their new owner and old copies are deleted in the same slice. Package consumers
+continue to use only the declared exports documented by `packages/api`.
+
+## Target Component Tree
+
+```text
+api/components/
+  factory-config/
+    README.md
+    schemas/
+      Factory.yaml
+      common/
+      invocation/
+      orchestration/
+      inputs/
+      work-types/
+      resources/
+      workers/
+      workstations/
+      layout/
+      portability/
+
+  operator-config/
+    README.md
+    schemas/
+      GlobalConfig.yaml
+      defaults/
+      runtime/
+      workers/
+
+  factory-definitions/
+    schemas/
+    parameters/
+    responses/
+
+  factory-sessions/
+    schemas/
+    parameters/
+    responses/
+
+  work/
+    schemas/
+    parameters/
+    responses/
+
+  worker-sessions/
+    schemas/
+    parameters/
+    responses/
+
+  provider-sessions/
+    schemas/
+    parameters/
+    responses/
+
+  providers/
+    schemas/
+
+  models/
+    schemas/
+    parameters/
+    responses/
+
+  events/
+    schemas/
+      payloads/
+
+  response-events/
+    schemas/
+      content-blocks/
+      payloads/
+    parameters/
+    responses/
+
+  factory-visualization/
+    schemas/
+
+  shared/
+    schemas/
+    parameters/
+    responses/
+```
+
+Directories that have no owned component of a given kind are omitted. The
+tree is a target ownership model, not a requirement to create empty folders.
+
+## Ownership Map
+
+| Domain | Representative current contents | Target |
+| --- | --- | --- |
+| Factory configuration | `Factory`, `FactoryOrchestrator*`, `FactoryInvocation*`, authored guards, Work types/states, workers, workstations, layout, portability | `factory-config/` |
+| Operator configuration | `GlobalConfig*` | `operator-config/` |
+| Factory Definitions API | preview, validation, save, packaged catalog contracts and definition-owned errors | `factory-definitions/` |
+| Factory Sessions | `FactorySession*`, lifecycle controls, dispatch/artifact session reads, session parameters | `factory-sessions/` |
+| Work | `Work`, `WorkContent*`, invocation/submission/move/list request and response contracts, Work parameters | `work/` |
+| Worker Sessions | `WorkerSession*` and list/transcript contracts | `worker-sessions/` |
+| Provider Sessions | `ProviderSession*`, `LoadableProviderSession*` | `provider-sessions/` |
+| Providers | Provider catalog, capability, modality, tool, documentation, and deprecation contracts | `providers/` |
+| Models | `Model*`, `ManagedRuntime*`, resolved model bindings, model operations | `models/` |
+| Factory Events | Factory Event envelope, enums, diagnostics, payloads, and recording | `events/` |
+| Response Events | Factory response stream envelope, provenance, content blocks, payloads, stream parameters and errors | `response-events/` |
+| Factory visualization | Existing `FactoryWorld*` compatibility read models | `factory-visualization/` |
+| Shared transport primitives | general error, pagination, status, timestamps, maps, neutral resource usage/requirements | `shared/` when no domain owns the meaning |
+
+## Configuration Directory Index Contract
+
+Each configuration directory receives a concise `README.md`. This is customer
+and contributor navigation, not a generated artifact or a duplicate schema
+reference. Each index must state:
+
+- the customer configuration file and root schema;
+- the canonical schema owner;
+- the bundled OpenAPI component identity;
+- the standalone JSON Schema `$id`;
+- the supported `@you-agent-factory/api` export;
+- the production parser or mapping boundary;
+- the command customers use to validate the configuration; and
+- where the configuration's subfamilies are located.
+
+For Factory configuration, the index points to the OpenAPI `Factory` component
+as canonical and to the generated standalone Factory schema as its projection.
+For operator configuration, the index points to
+`contracts/config/you-config.schema.json` as canonical and explains that the
+OpenAPI `GlobalConfig*` fragments provide generated boundary types.
+
+## API And Contract Impact
+
+### Authored OpenAPI
+
+- Update file references in `api/openapi-main.yaml` without changing component
+  keys or component order.
+- Update relative fragment references to the new owner paths.
+- Preserve the requirement that every reusable component registered in
+  `openapi-main.yaml` is a single file `$ref` under `./components/`.
+
+### Bundled OpenAPI And Generated Clients
+
+The following generated artifacts must have no semantic change from source
+movement alone:
+
+- `api/openapi.yaml`
+- `pkg/transports/http/generated/server.gen.go`
+- `pkg/transports/http/client/client.gen.go`
+- `ui/src/api/generated/openapi.ts`
+
+If regeneration changes one of these artifacts beyond path-insensitive
+formatting, the slice must stop and explain the contract difference instead of
+accepting it as incidental reorganization.
+
+### Standalone Configuration Schemas
+
+Preserve:
+
+- `https://schemas.portpowered.com/you/config/factory.schema.json`;
+- `https://schemas.portpowered.com/you/config/you-config.schema.json`;
+- `@you-agent-factory/api/schemas/factory`;
+- `@you-agent-factory/api/schemas/you-config`; and
+- the packaged-factories Factory schema projections.
+
+The Factory standalone schema remains generated from the bundled OpenAPI
+`Factory` component graph. The operator schema remains canonically authored
+under `contracts/config/` during this plan.
+
+### Runtime And Services
+
+No service API or runtime behavior changes are planned. Production parsers and
+owners remain:
+
+- Factory configuration:
+  `pkg/transports/mapping/factoryconfig.FactoryConfigMapper.Expand` and the
+  Factory Definitions service boundary.
+- Operator configuration:
+  `pkg/services/operator_settings/transports/globalconfig.Decode` and the
+  Operator Settings service boundary.
+
+## Implementation Stories
+
+Each story below is intended to be a separate PR-sized slice unless measured
+reference churn shows that two adjacent, non-conflicting stories are safer to
+review together. Stories move source and update all references in the same PR;
+there is no intermediate compatibility-copy state.
+
+### 1. Establish The Domain-First Authoring Contract
+
+As a customer or contributor entering the API contract tree, I can identify the
+target owner for each public contract family before following individual
+schemas.
+
+This is a narrowly justified enabling story: repository documentation must
+define ownership before later file moves can be reviewed consistently.
+
+Acceptance criteria:
+
+- The target tree, placement rules, canonical ownership distinctions, and
+  supported public identities are documented in the canonical API authoring
+  guidance.
+- The guidance uses public vocabulary from `docs/architecture/data-model.md`.
+- The guidance says new schemas go directly to a domain owner rather than the
+  legacy `schemas/api` or `schemas/data-models` buckets.
+- No runtime, API, generated artifact, or package export changes in this story.
+
+### 2. Make Factory Configuration Independently Traceable
+
+As a Factory author, I can start at `factory-config/schemas/Factory.yaml` and
+follow schemas grouped by the sections I author in `factory.json`.
+
+Acceptance criteria:
+
+- `Factory.yaml` and Factory-authored component schemas move under
+  `factory-config/schemas/` and its customer-oriented subdirectories.
+- Schemas with a distinct canonical domain owner, such as runtime Work records,
+  are referenced from that owner rather than copied into Factory configuration.
+- The Factory configuration index maps the root, component identity, standalone
+  schema, package export, production mapper, validation command, and subfamilies.
+- A representative valid Factory configuration accepted before the move remains
+  accepted, and representative invalid enum, unknown-field, and malformed
+  configurations remain rejected with the same public outcomes.
+- Factory validation, flatten, expand, load, and save round trips remain
+  behaviorally unchanged.
+- The bundled `Factory` component and standalone Factory schema have no semantic
+  drift.
+- Generated Go and TypeScript API artifacts have no semantic drift.
+
+### 3. Make Operator Configuration Independently Traceable
+
+As an operator, I can start at the operator configuration directory and
+understand the complete `.you-agent-factory/config.json` contract, its
+canonical source, and its generated OpenAPI type projection.
+
+Acceptance criteria:
+
+- All `GlobalConfig*` OpenAPI fragments move under
+  `operator-config/schemas/` and its focused subdirectories.
+- The operator configuration index explicitly identifies
+  `contracts/config/you-config.schema.json` as the canonical standalone owner.
+- The OpenAPI component names and generated `GlobalConfig*` Go type names remain
+  unchanged.
+- Valid operator configuration remains accepted.
+- Unknown top-level fields, unknown nested fields, malformed JSON, and trailing
+  JSON values remain rejected by the production decoder.
+- Operator defaults, runtime settings, ACP settings, and worker presets retain
+  their schema parity and round-trip behavior.
+- The standalone schema `$id` and package export have no semantic drift.
+
+### 4. Group Factory Definition Operations With Their Contracts
+
+As a customer using Factory definition APIs, I can find preview, validation,
+save, catalog, and definition-specific failure contracts under one Factory
+Definitions owner.
+
+Acceptance criteria:
+
+- Factory preview, validation, save, packaged catalog, prompt validation, and
+  workflow-preview components move to `factory-definitions/` when they are
+  owned by Factory Definitions.
+- Definition-specific parameters and responses move with their schemas.
+- Current Factory read/save/create API operations continue to reference the
+  same public component identities and return the same status/schema pairs.
+- Focused Factory definition API contract tests pass with no generated-client
+  semantic drift.
+
+### 5. Group Factory Session Contracts Vertically
+
+As a customer operating Factory Sessions, I can find session open, execute,
+read, result, lifecycle control, dispatch, artifact, and session-specific error
+contracts under the Factory Sessions owner.
+
+Acceptance criteria:
+
+- `FactorySession*`, session lifecycle, durable execution, session dispatch and
+  artifact read contracts move to `factory-sessions/`.
+- Session parameters and session-specific responses move in the same slice.
+- Runtime dispatch and artifact value types are assigned to Factory Sessions or
+  another explicit domain owner and are not left in `data-models`.
+- Session route request and response component identities, response codes, and
+  generated client method signatures remain unchanged.
+- Existing direct source-path reads in contract tests are updated or, where the
+  bundled component already proves the behavior, replaced with bundled-contract
+  assertions rather than new topology assertions.
+- Focused session API and generated-client contract tests pass.
+
+### 6. Group Work And Worker Session Contracts
+
+As a customer submitting and inspecting Work, I can trace Work content,
+requests, relations, movement, listing, invocation, and Worker Session
+observations through their respective owners.
+
+Acceptance criteria:
+
+- Runtime `Work`, Work content, submission, invocation, movement, listing, and
+  Work-owned relation contracts move under `work/`.
+- Worker Session list, event, observation, replay, failure, and transcript
+  contracts move under `worker-sessions/`.
+- Work and Worker Session parameters and responses move with their domains.
+- Factory configuration references Work-owned schemas without duplicating them.
+- Work submission, invocation, listing, movement, and Worker Session read API
+  contracts remain unchanged in the bundled OpenAPI and generated clients.
+- Focused Work and Worker Session contract and smoke tests pass.
+
+### 7. Group Provider, Provider Session, And Model Contracts
+
+As a customer configuring or inspecting inference capabilities, I can navigate
+provider catalogs, provider sessions, managed runtimes, and models through
+separate domain owners.
+
+Acceptance criteria:
+
+- Provider catalog/capability schemas move from `model-providers` to
+  `providers/schemas/` without renaming public Provider components.
+- Provider Session schemas move from the generic API bucket to
+  `provider-sessions/`.
+- Model, managed runtime, pull, invocation, and resolved binding contracts move
+  to `models/`.
+- Shared provider identities referenced by Factory configuration retain one
+  explicit owner and are referenced rather than copied.
+- Provider and model REST operations, schema identities, generated types, and
+  package behavior remain unchanged.
+- Provider parity, model contract, and generated API checks pass.
+
+### 8. Complete Events, Response Events, Visualization, And Shared Ownership
+
+As a customer inspecting event or visualization contracts, I can distinguish
+canonical Factory Events, ephemeral Factory response events, compatibility
+visualization read models, and genuinely shared primitives by their top-level
+owners.
+
+Acceptance criteria:
+
+- Existing event families retain their envelope/payload separation while
+  moving to the domain-first top-level layout.
+- Factory Events and Factory response events remain separate public contract
+  families with unchanged discriminator mappings and payload coverage.
+- `factory-world` components move under `factory-visualization/` without
+  renaming `FactoryWorld*` components in this plan.
+- Remaining neutral schemas, parameters, and responses move under `shared/`;
+  domain-specific components do not remain there for convenience.
+- The legacy top-level `parameters/`, `responses/`, `schemas/api/`,
+  `schemas/data-models/`, `schemas/factory-world/`, and
+  `schemas/model-providers/` directories are empty and removed.
+- Event standalone schemas, bundled OpenAPI discriminators, generated clients,
+  and visualization contracts have no semantic drift.
+
+### 9. Close Documentation And Published-Contract Alignment
+
+As a package consumer or contributor, I can follow documentation from the
+customer contract to its canonical source and supported package export without
+depending on a retired repository path.
+
+Acceptance criteria:
+
+- Canonical development and architecture documentation describes the final
+  domain-first tree.
+- Maintained documentation and live test helpers no longer cite retired
+  component paths.
+- Historical plans or baselines are changed only when they function as current
+  instructions or executable inputs; archival evidence is not rewritten merely
+  for cosmetic consistency.
+- `packages/api/README.md` continues to document only supported exports and
+  warns consumers not to depend on package-internal or repository paths.
+- README and packaged documentation links remain valid where changed.
+
+## Verification Strategy
+
+### Per-Story Focused Checks
+
+Every component-move story runs:
+
+```text
+node scripts/run-quiet-api-command.js validate:main ./api/openapi-main.yaml
+make api-smoke
+```
+
+Configuration stories additionally run:
+
+```text
+make contracts-generate
+make contracts-check
+make config-contract-smoke
+make api-package-verify
+```
+
+Domain stories run the focused Go contract tests for the affected HTTP/service
+area. `make generate-api` is invoked only through the supported generation
+workflow; generated files are never hand-edited.
+
+### Generated-Artifact Evidence
+
+For a pure source-layout slice, review must confirm no semantic diff in:
+
+```text
+api/openapi.yaml
+pkg/transports/http/generated/server.gen.go
+pkg/transports/http/client/client.gen.go
+ui/src/api/generated/openapi.ts
+contracts/config/factory.schema.json
+packages/api/generated/schemas/factory.schema.json
+packages/api/generated/schemas/you-config.schema.json
+```
+
+Only artifacts affected by the slice need direct comparison, but Factory and
+operator configuration moves require their complete configuration projections.
+
+The plan does not add tests that scan source directories to enforce the target
+tree. Behavioral contract tests, deterministic regeneration, package consumer
+tests, and review of the authored source moves provide the evidence.
+
+### Broader Gates
+
+- Run `make verify-fast` on each PR-sized slice.
+- Run `make verify-pr` before merging each shared/public-contract PR.
+- Run `make interfaces-all` when a slice affects publishable contract or UI
+  package generation beyond the direct Go/dashboard OpenAPI outputs.
+- Run `make readme-check` when root README links change.
+
+## Project-Level Acceptance Criteria
+
+- A reader starting from Factory configuration can locate its root, authored
+  subfamilies, canonical schema, production mapper, validation command, and
+  supported package export without searching a generic schema bucket.
+- A reader starting from operator configuration can locate its root,
+  `GlobalConfig*` projection, canonical standalone schema, production decoder,
+  validation command, and supported package export without searching a generic
+  schema bucket.
+- Every remaining component has one documented domain owner.
+- No authored reusable schema remains under `schemas/api` or
+  `schemas/data-models`.
+- No old-path compatibility copies or duplicate schema owners remain.
+- Public OpenAPI component keys, operation IDs, route contracts, generated type
+  names, standalone schema `$id` values, and package exports remain stable.
+- Valid and invalid Factory and operator configuration cases retain their
+  production parser outcomes.
+- Bundled OpenAPI, generated clients, standalone schemas, and package
+  projections are deterministic and aligned with canonical sources.
+- Required lint, contract, generation, unit, integration, and PR verification
+  gates pass for every delivered slice.
+- Delivery continues until required CI is terminal and passing, all blocking
+  review feedback is explicitly addressed, merge conflicts are resolved, and
+  every in-scope PR is actually merged. Opening a PR, receiving approval, or
+  reaching green CI without merge is not completion.
+
+## Risks And Mitigations
+
+### Relative Reference Breakage
+
+Moving nested YAML files changes relative `$ref` depth. Move one ownership
+family at a time, update the root registrations and internal references in the
+same commit, and validate `openapi-main.yaml` before regeneration.
+
+### Generated Ordering Or Formatting Churn
+
+Keep component keys and their order in `openapi-main.yaml` unchanged during
+pure movement. Treat unexpected generated changes as a contract investigation,
+not acceptable move noise.
+
+### Canonical Owner Confusion
+
+Factory and operator configuration currently use different standalone schema
+ownership paths. Preserve that distinction in the two directory indexes and in
+`configcontractsmoke`; defer source unification to a separately planned
+behavior and tooling change.
+
+### Merge Conflict Volume
+
+`api/openapi-main.yaml` and shared fragment references are high-churn files.
+Sequence stories rather than implementing them concurrently, rebase each slice
+onto the latest merged predecessor, and regenerate after conflict resolution.
+
+### Overuse Of Shared Components
+
+Require reviewers to identify the semantic owner before accepting a component
+under `shared`. Cross-domain reuse alone is insufficient when one product
+domain defines the component's meaning.
+
+### Historical Documentation Churn
+
+Update normative guidance and active references. Do not rewrite historical
+audits, merged-plan evidence, or baselines unless they are executed or presented
+as current guidance.
+
+## Delivery Order
+
+1. Establish the documented ownership contract.
+2. Move Factory configuration.
+3. Move operator configuration.
+4. Move Factory Definitions operations.
+5. Move Factory Sessions.
+6. Move Work and Worker Sessions.
+7. Move Providers, Provider Sessions, and Models.
+8. Move Events, Response Events, Factory visualization, and shared primitives;
+   remove the retired generic directories.
+9. Complete documentation and package-consumer alignment.
+
+This order establishes the customer-requested configuration roots first, then
+migrates adjacent public domains while keeping each review centered on one
+observable navigation and contract-preservation outcome.

--- a/docs/internal/development/plans/api-reference-prose-examples-localization.md
+++ b/docs/internal/development/plans/api-reference-prose-examples-localization.md
@@ -1,0 +1,1044 @@
+# API Reference Prose, Examples, And Localization Plan
+
+## Status
+
+Proposed.
+
+## Problem statement
+
+The OpenAPI contract lists the REST operations and data shapes, but much of the
+reference text does not show customers how to complete a task. Most operations
+have summaries and descriptions, but few operations have named request and
+response examples. Some descriptions also expose internal terms or combine too
+many rules in one paragraph.
+
+The reference text has no complete stable identity model. This prevents a
+translator from translating one text resource without depending on its source
+file, line number, JSON pointer, or current English text.
+
+## Customer ask
+
+Make the API reference clear and useful. Add concise explanations, minimal
+examples, expected results, and relevant recovery guidance. Align the prose
+with the planned customer-writing standard and ASD-STE100 principles.
+
+Prepare the reference for localization. Give each localizable text resource a
+stable identity. Keep API names, payload fields, enum values, and other machine
+contracts unchanged.
+
+## Intended outcome
+
+A customer can select an API operation, understand when to use it, send a
+minimal valid request, interpret the response, and recover from common errors.
+The customer does not need source-code knowledge or internal Petri-net terms.
+
+An author can add or change English reference text in the canonical OpenAPI
+source. A translator can translate that text by stable ID. A documentation
+renderer can apply a locale catalog with explicit English fallback behavior.
+
+## Planning basis
+
+This plan follows these repository standards and active plans:
+
+- `docs/internal/standards/code/planning-standards.md`
+- `docs/internal/standards/code/code-review-standards.md`
+- `docs/internal/standards/code/general-backend-standards.md`
+- `docs/internal/standards/code/general-website-standards.md`, section 9
+- `docs/internal/standards/templates/task-templates.md`
+- `docs/architecture/data-model.md`
+- `docs/internal/development/plans/customer-prose-clarity-program.md`
+- `docs/internal/development/plans/customer-prose-standard-and-enforcement.md`
+- `docs/internal/development/plans/cli-and-reference-prose-migration.md`
+- `docs/internal/development/plans/public-documentation-prose-migration.md`
+- `docs/internal/development/plans/api-component-domain-structure.md`
+
+The customer-prose plans are proposed work in the current tree. This plan
+depends on their accepted writing profile and terminology register. It extends
+their scope to authored OpenAPI text and API examples.
+
+## External writing reference
+
+Use [ASD-STE100 Simplified Technical English, Issue 9](https://www.asd-ste100.org/assets/files/ASD-STE100_ISSUE9.pdf)
+as the controlled-language reference. Issue 9 was released on January 15,
+2025. The official site identifies it as the current issue.
+
+The implementation must also use the
+[official ASD-STE100 frequently asked questions](https://www.asd-ste100.org/STE_faq.html).
+The FAQ explains that software can assist a writer but cannot certify the text
+or replace technical and language review.
+
+The repository will claim alignment with the You customer technical-writing
+standard. It will not claim ASD-STE100 certification. The repository will not
+copy the ASD-STE100 controlled dictionary into source control.
+
+## Current-state snapshot
+
+The snapshot below describes the tree on August 10, 2026. It is planning
+evidence, not a permanent inventory assertion.
+
+| Surface | Current state | Behavior gap |
+| --- | ---: | --- |
+| REST operations | 48 | All have a summary and description, but many descriptions are dense contract notes. |
+| Operations with request media | 20 | Most lack a named, task-focused request example. |
+| Declared operation responses | 184 | Most success responses lack a representative named payload. |
+| Authored component fragments | 515 | Many descriptions explain shape but not customer purpose or field relationships. |
+| `example:` keys in authored OpenAPI | 7 | This is too small to teach the complete public surface. |
+| `examples:` keys in authored OpenAPI | 14 | Several are error examples. Coverage is not measured per operation or use case. |
+| Operations with `x-doc-id` | 1 | The field currently links one operation to a longer guide. It is not a localization identity. |
+
+The existing REST operation inventory records operation identity, summary
+presence, description presence, media types, responses, and `x-doc-id`. It
+does not measure example quality, text identity, or localization coverage.
+
+The repository already owns
+`contracts/common/documentation.schema.json`. That family-neutral contract
+defines stable documentation IDs and canonical English text. The OpenAPI plan
+must reuse its identity rules and suffix conventions where they fit. It must
+not create an unrelated key format.
+
+`api/openapi-main.yaml` and `api/components/` are the authored OpenAPI sources.
+`api/openapi.yaml`, generated clients, and files below package `generated/`
+directories are projections. Authors must not edit those projections.
+
+## Scope
+
+### In scope
+
+- OpenAPI `info`, tag, server, operation, parameter, request, response, schema,
+  property, enum-description, and example prose.
+- Stable text identity for each localizable OpenAPI object.
+- Named request, success-response, and relevant failure-response examples.
+- An OpenAPI prose and example coverage inventory.
+- Deterministic extraction of canonical English resources.
+- Locale catalogs and localized documentation projections.
+- Explicit locale fallback and translation coverage reports.
+- Prose checks for authored OpenAPI text.
+- Example validation against the bundled contract.
+- Focused API-owned behavioral tests for high-value runnable examples.
+- Publication of approved locale artifacts through the supported API package.
+
+### Out of scope
+
+- Changing REST paths, methods, operation IDs, payload fields, status codes, or
+  runtime behavior to improve the prose.
+- Localizing JSON keys, enum literals, error codes, identifiers, media types,
+  code samples, paths, or other machine text.
+- Adding runtime `Accept-Language` behavior to the product API.
+- Translating runtime error payloads unless a separate product contract
+  approves localized runtime messages.
+- Hand-editing generated OpenAPI, Go, TypeScript, or package artifacts.
+- Rewriting CLI help or packaged Markdown in this plan.
+- Publishing a machine translation as an approved customer locale.
+- Claiming that automated checks prove full ASD-STE100 conformance.
+- Moving OpenAPI components only to satisfy a directory layout.
+
+## API reference writing standard
+
+The accepted customer technical-writing standard remains the normative prose
+owner. The rules below specialize that standard for API reference text.
+
+### Operation summary
+
+An operation summary must state the action and primary resource. Use one short
+phrase. Start with an imperative verb when the renderer presents the summary as
+an action.
+
+Good example:
+
+```text
+Submit Work to one Factory Session
+```
+
+Weak example:
+
+```text
+Work endpoint
+```
+
+### Operation description
+
+An operation description must answer these questions when they apply:
+
+1. When does the customer use this operation?
+2. Which resource does the operation read or change?
+3. What prerequisite or selection rule applies?
+4. Is the operation idempotent?
+5. What result confirms success?
+6. Which common failure requires a different next action?
+
+Use short descriptive paragraphs. Put one topic in each paragraph. Put a
+necessary condition before the action or result that depends on it.
+
+Do not repeat every schema field in the operation description. Link the
+operation to reusable parameter and schema descriptions through the OpenAPI
+contract. Use `x-doc-id` only when a longer task guide owns necessary detail.
+
+### Parameters and fields
+
+A parameter or property description must state its meaning and relevant
+constraint. It must not only repeat the field name or type.
+
+Describe units, bounds, default behavior, omission behavior, and identity
+scope when they affect correct use. Keep validation language consistent with
+the runtime and schema.
+
+### Responses
+
+A response description must state the observable outcome. It must not only
+repeat the HTTP status phrase.
+
+Failure descriptions must state the relevant cause class and safe next action.
+Do not promise a retry when the runtime does not support one.
+
+### Streams and asynchronous operations
+
+Stream descriptions must state ordering, replay scope, cursor behavior,
+termination behavior, and recovery behavior. Use separate short paragraphs or
+a compact list. Do not compress the complete stream contract into one long
+sentence.
+
+Asynchronous operation descriptions must identify the accepted result, the
+poll or stream path, terminal states, and safe request-ID reuse behavior.
+
+### Protected machine text
+
+The prose checker and translators must preserve these values exactly:
+
+- HTTP methods and paths;
+- operation IDs and component names;
+- parameter and property names;
+- JSON and YAML keys;
+- enum values, status values, and error codes;
+- media types, event names, and schema versions;
+- shell commands, URLs, file paths, and identifiers; and
+- literal request and response payloads.
+
+Natural-language comments, example titles, and example explanations remain
+localizable. A literal runtime message inside an example remains protected.
+
+### Review duties
+
+Every migrated family requires two reviews:
+
+- A language reviewer checks the accepted writing profile and terminology.
+- A subject-matter reviewer checks API meaning and example behavior.
+
+Automated checks support these reviews. They do not replace them.
+
+## Example standard
+
+### Required operation examples
+
+Each operation must have the smallest useful example set for its behavior.
+The default requirement is:
+
+- one minimal request example when the operation accepts a request;
+- one representative success response example when the response has content;
+- one relevant failure example when recovery is not obvious; and
+- one stream-frame sequence for each public stream protocol.
+
+An operation can omit an example only with a recorded reason. Valid reasons
+include an empty response body or a binary payload that has a documented
+metadata example. The inventory must report every omission.
+
+### Example shape
+
+Use named OpenAPI `examples` entries for operation use cases. Do not use array
+position as example identity. Each example must have:
+
+- a stable machine name;
+- a concise localizable title;
+- a localizable explanation when the title is not sufficient;
+- the smallest payload that demonstrates the behavior;
+- values that satisfy the referenced schema; and
+- safe placeholder data with no credentials or host-specific paths.
+
+Use a schema-level `example` only for a context-independent representative
+value. Use operation-level named examples for customer tasks, edge cases, and
+request-response pairs.
+
+### Runnable samples
+
+The first renderer should show a `curl` sample for HTTP operations. Generate
+the command from the method, path, parameter values, media type, and canonical
+request example. Do not maintain a second handwritten payload inside the code
+sample.
+
+Later renderers can add language samples from the same structured example.
+Generated samples must use `http://localhost:7437` unless the operation needs a
+documented different server.
+
+### Example validation
+
+Structural validation must prove that each example matches its referenced
+schema. Behavioral validation must cover the highest-value customer journeys
+through the public HTTP boundary.
+
+Behavioral tests must not assert that every example value is a fixed runtime
+result. Tests must distinguish deterministic contract fields from generated
+identifiers, timestamps, ordering data, and environment-dependent values.
+
+## Stable text identity and localization contract
+
+### Separate link identity from text identity
+
+Keep `x-doc-id` for a link to a longer canonical guide. Do not use it as a
+translation key. Its current slash-based value also does not match the common
+documentation ID format.
+
+Add `x-text-id` as the stable item identity for one localizable OpenAPI object.
+Use the lowercase item-ID grammar from
+`contracts/common/documentation.schema.json`.
+
+Example:
+
+```yaml
+operationId: submitWorkBySessionId
+x-text-id: api.operation.submit-work-by-session-id
+summary: Submit Work to one Factory Session
+description: Submit one Work item to the selected live Factory Session.
+```
+
+The extraction tool derives field IDs from the item identity:
+
+```text
+api.operation.submit-work-by-session-id.title
+api.operation.submit-work-by-session-id.description
+```
+
+OpenAPI `summary` maps to the common documentation `title` role. OpenAPI
+`description` maps to the `description` role. This preserves the existing
+`.title` and `.description` suffix rules.
+
+### Identity rules
+
+Every text ID must meet these rules:
+
+- Use a public domain owner and resource meaning.
+- Do not include a locale, source path, line number, array position, or English
+  wording.
+- Do not depend only on the current HTTP route.
+- Remain stable when prose changes or a component file moves.
+- Remain stable when a renderer changes.
+- Never reuse a removed ID for a different meaning.
+- Record a successor when a public text resource is replaced.
+- Use one canonical owner for reused components.
+
+Recommended item-ID shapes are:
+
+```text
+api.info
+api.tag.factory-sessions
+api.operation.submit-work-by-session-id
+api.parameter.session-id
+api.response.bad-request
+api.schema.submit-work-request
+api.schema.submit-work-request.property.name
+api.schema.factory-session-status.value.running
+api.operation.submit-work-by-session-id.example.minimal-request
+```
+
+The examples show the grammar. The accepted identity registry must define the
+complete domain names before broad tagging starts.
+
+### Enum text
+
+OpenAPI 3.0 represents enum values as literals. The repository currently uses
+positional `x-enum-descriptions` lists. Add an ID map keyed by the exact enum
+literal. Do not identify enum text by list position.
+
+Example:
+
+```yaml
+x-enum-text-ids:
+  RUNNING: api.schema.factory-session-status.value.running.description
+```
+
+The validator must require exact agreement between enum literals, enum
+descriptions, and enum text IDs. A changed enum order must not change identity.
+
+### Example text
+
+Each named Example Object receives its own `x-text-id`. The extractor derives
+`.title` and `.description` IDs when those fields exist. The example payload
+does not become a translation resource.
+
+### Canonical English
+
+Canonical English stays in the authored OpenAPI YAML. Locale catalogs must not
+duplicate canonical English. The extractor creates a deterministic English
+resource projection from the bundled OpenAPI for tooling and package users.
+
+The extraction result must record:
+
+- text ID;
+- canonical English value;
+- content role;
+- OpenAPI item identity;
+- source location in the authored tree when available; and
+- a source digest for stale-translation detection.
+
+### Locale catalogs
+
+Approved translations live in domain-owned catalogs under
+`api/locales/<bcp47>/`. Use canonical BCP 47 tags. Split large catalogs by the
+same public domains used for text IDs.
+
+Each translation record contains the text ID and translated value. It may also
+contain the reviewed canonical source digest. It must not contain a second
+copy of the English source text.
+
+The locale registry must state:
+
+- locale tag and customer-facing name;
+- fallback locale;
+- review status;
+- included domain catalogs;
+- translated, stale, and missing counts; and
+- text direction when a renderer needs it.
+
+### Fallback and stale translations
+
+Canonical English is the required fallback. Apply fallback per complete text
+resource. Do not concatenate translated and English fragments.
+
+When canonical English changes, the source digest marks the translation stale.
+The default development check reports stale translations. A release policy
+decides whether an incomplete locale can ship. The renderer must identify
+fallback coverage in its build report.
+
+### Localized OpenAPI projection
+
+The canonical `api/openapi.yaml` remains the English machine contract and the
+source for Go and TypeScript generation. Client generation must never consume
+a localized projection.
+
+A focused documentation generator applies one approved locale catalog to the
+canonical bundle. It changes only localizable prose fields. It preserves every
+path, method, operation ID, schema, example payload, extension, and contract
+value.
+
+The API package can publish the canonical English resource catalog, the locale
+registry, approved translation catalogs, and localized reference bundles. Add
+public exports only after package contract and consumer tests define them.
+
+## Canonical ownership
+
+| Concern | Canonical owner | Notes |
+| --- | --- | --- |
+| English REST reference text | `api/openapi-main.yaml` and `api/components/` | Authored source. |
+| Stable documentation grammar | `contracts/common/documentation.schema.json` | Extend its reusable definitions when needed. |
+| OpenAPI text extension contract | A new contract under `contracts/api/` | Defines `x-text-id`, enum ID maps, catalogs, and compatibility rules. |
+| Translation catalogs | `api/locales/<bcp47>/` | Approved human translation only. |
+| English resource projection | Generated from bundled OpenAPI | Not an authoring source. |
+| Localized OpenAPI bundles | Generated from English plus locale catalogs | Documentation only. |
+| REST operation coverage inventory | `internal/contractinventory` and its command | Extend the existing deterministic inventory. |
+| Published API artifacts | `packages/api/generated/` | Generated projection. |
+| Product terminology | `docs/architecture/data-model.md` and the planned term register | Public vocabulary authority. |
+
+Repository tooling owns extraction, validation, and generation. This work does
+not add a product service or a `pkg/wire` dependency.
+
+## Coverage contract
+
+Extend the REST inventory or add one closely related documentation inventory.
+The inventory must report these facts for every operation:
+
+- stable operation text ID;
+- summary and description IDs;
+- request example names and IDs;
+- success response example names and IDs;
+- failure response example names and IDs;
+- missing example reasons;
+- linked guide ID when present;
+- unresolved or duplicate text IDs;
+- prose-check findings; and
+- locale coverage by approved locale.
+
+It must also report component-level text identity for reusable parameters,
+responses, schemas, properties, enum values, and examples.
+
+The report must be deterministic. Required CI must reject duplicate IDs,
+missing IDs in the accepted scope, stale translations, invalid examples, and
+new prose violations.
+
+Use an exact temporary baseline during migration. The baseline must permit only
+deletion during ordinary work. It must reach zero before this program closes.
+
+## Implementation planning standard
+
+Each implementation story must deliver one customer-visible API use case or
+one tightly bounded enabling contract. Do not split ordinary work into separate
+prose, ID, example, and test stories for the same operation family.
+
+### Migration unit
+
+One content migration task covers one of these units:
+
+- one operation family with approximately three to eight related operations;
+- one complete stream contract;
+- one reusable component family with no more than approximately 2,000 prose
+  words; or
+- one localization-tooling behavior with direct fixtures.
+
+Each operation-family task must update its descriptions, text IDs, examples,
+coverage record, and focused tests together.
+
+### Required task facts
+
+Before editing a family, the implementer must record:
+
+- the customer task;
+- the canonical service and data-model owner;
+- current request, response, status, and failure behavior;
+- existing examples and tests;
+- protected machine values;
+- linked long-form guide, if any; and
+- required language and subject-matter reviewers.
+
+### Required acceptance criteria
+
+Each content story must prove:
+
+- a customer can identify when to use the operation;
+- a minimal valid request is available when applicable;
+- a representative success result is available;
+- relevant recovery guidance is available;
+- every localizable text has a stable unique ID;
+- example payloads validate against the bundled schema;
+- high-value runnable examples match HTTP behavior;
+- public terminology matches the data model and term register;
+- generated artifacts are current; and
+- language and subject-matter review are recorded.
+
+### Delivery boundary
+
+Every story continues through required generation, focused tests, terminal
+green CI, resolution of blocking feedback, conflict resolution, and actual PR
+merge. Opening a PR or reaching green CI without merge is not completion.
+
+## Work stories
+
+### Story 1: Authors can identify and check every API text resource
+
+#### Observable behavior
+
+An author can add OpenAPI prose with one documented stable identity format.
+The repository reports duplicate, malformed, missing, or orphaned IDs at the
+authored source location.
+
+#### Acceptance criteria
+
+- The OpenAPI text extension and locale catalog contracts are documented and
+  schema-validated.
+- The contract reuses the common documentation item-ID grammar and title and
+  description suffixes.
+- `x-doc-id` remains a separate guide-link identity.
+- The checker covers operations, parameters, responses, schemas, properties,
+  enums, and named examples.
+- Generated and external-reference text is not treated as an authored source.
+- Duplicate IDs, source-derived IDs, malformed enum maps, and missing required
+  IDs have direct fixtures.
+- The initial exact baseline is reproducible and deletion-only.
+
+### Story 2: Documentation builders can render one locale safely
+
+#### Observable behavior
+
+A documentation builder can select an approved locale and receive a localized
+OpenAPI reference with field-level English fallback and a coverage report.
+
+#### Acceptance criteria
+
+- Canonical English is extracted deterministically from authored OpenAPI.
+- Locale catalogs use canonical BCP 47 tags and domain-owned files.
+- A test-only non-default locale fixture proves replacement, fallback, stale
+  source detection, and right-to-left metadata handling.
+- Localized projection changes only localizable prose fields.
+- Client generation continues to use only canonical `api/openapi.yaml`.
+- Repeated generation is byte-identical.
+- Missing and stale translation counts appear in a deterministic report.
+- No machine-translated locale is published as approved test evidence.
+
+### Story 3: Customers can submit, list, inspect, and move Work
+
+#### Observable behavior
+
+A customer can use the Work operation family to submit one item, upsert a Work
+Request, list Work, read one item, stage a file, and request a move.
+
+#### Acceptance criteria
+
+- Each Work operation states selection, identity, mutation, and idempotency
+  behavior where applicable.
+- Minimal request and success examples use one coherent Factory Session and
+  Work scenario.
+- The upsert example explains safe `request_id` reuse.
+- List examples explain filters, ordering, counts, and pagination without
+  internal token vocabulary.
+- Move examples identify conflict behavior and a safe next action.
+- Every localizable Work text and named example has a stable ID.
+- Examples validate and one submit-to-read HTTP scenario passes.
+
+### Story 4: Customers can start and operate a Factory Session
+
+#### Observable behavior
+
+A customer can choose open, synchronous, or asynchronous execution, then read
+results or apply a supported lifecycle control.
+
+#### Acceptance criteria
+
+- The family explains when to use open, synchronous, and asynchronous paths.
+- Examples show accepted, running, partial, and terminal result relationships.
+- Lifecycle examples explain valid preconditions and conflict outcomes.
+- Request-ID examples preserve the current retry and conflict contract.
+- Artifact and dispatch examples use stable identities from one coherent
+  scenario.
+- Every localizable Factory Session text has a stable ID.
+- Examples validate and focused session HTTP contract tests pass.
+
+### Story 5: Customers can consume event and response streams
+
+#### Observable behavior
+
+A customer can connect, process retained and live records, reconnect with a
+cursor, detect a retention gap, and stop at the documented terminal condition.
+
+#### Acceptance criteria
+
+- Factory Events, response events, and Worker Session events remain distinct.
+- Each stream uses short sections for ordering, cursor, retention, terminal,
+  and recovery behavior.
+- Named frame-sequence examples preserve exact event and payload literals.
+- Reconnect and stale-cursor examples identify the next safe request.
+- `x-doc-id` links only to the longer canonical stream guide.
+- Every localizable stream text and frame explanation has a stable ID.
+- Stream examples validate and focused replay/reconnect tests pass.
+
+### Story 6: Customers can validate and inspect Factory definitions
+
+#### Observable behavior
+
+A customer can preview or validate a Factory, read or save the Current
+Factory, and inspect packaged Factory entries with clear examples.
+
+#### Acceptance criteria
+
+- Preview, validation, read, and save descriptions use public Factory terms.
+- Examples distinguish a Factory definition from a live Factory Session.
+- Validation examples pair one invalid input with its actionable result.
+- Save examples state replacement and conflict behavior.
+- Packaged Factory examples preserve localized product metadata as data. They
+  do not confuse that runtime data with reference-page localization.
+- Every localizable definition text has a stable ID.
+- Examples validate and focused Factory definition API checks pass.
+
+### Story 7: Customers can inspect Workers, Providers, and Models
+
+#### Observable behavior
+
+A customer can inspect Worker Sessions and Provider Sessions, list or read
+Models, invoke a Model, and understand managed-runtime readiness and pull
+results.
+
+#### Acceptance criteria
+
+- Worker Session and Provider Session remain separate customer concepts.
+- Model examples state capability and readiness prerequisites.
+- Binary Model results include metadata guidance without embedding unsafe
+  binary values in YAML.
+- Provider and Worker Session examples protect provider-issued identifiers.
+- Every localizable family text has a stable ID.
+- Examples validate and focused inspection and model contract tests pass.
+
+### Story 8: Every public component explains its role
+
+#### Observable behavior
+
+A customer following an operation into a schema, property, enum, parameter, or
+response receives concise and consistent reference text.
+
+#### Acceptance criteria
+
+- Every public reusable component has a stable text identity.
+- Every required property description explains meaning or constraint.
+- Enum descriptions use exact literal-keyed identities.
+- Shared errors state cause classes and safe recovery without promising
+  unsupported behavior.
+- Internal implementation terms do not define public resources.
+- The component prose baseline reaches zero.
+- Generated Go and TypeScript contracts remain behaviorally unchanged.
+
+### Story 9: Package consumers can load localized reference artifacts
+
+#### Observable behavior
+
+A package consumer can resolve the canonical English resources, locale
+registry, approved catalogs, and approved localized OpenAPI bundles through
+documented package exports.
+
+#### Acceptance criteria
+
+- Package exports use stable subpaths and data-only artifacts.
+- The manifest records locale, digest, source version, and fallback metadata.
+- Tarball tests prove the exact artifact allowlist.
+- An isolated Node consumer resolves and reads every declared locale artifact.
+- English and localized bundles have identical machine contracts.
+- Unsupported internal package paths remain undocumented and unexported.
+- API package candidate and publication checks pass.
+
+### Story 10: The API reference baseline reaches zero
+
+#### Observable behavior
+
+Required CI rejects missing reference text, missing examples, invalid examples,
+missing IDs, stale translations, and new writing violations across the complete
+accepted public API scope.
+
+#### Acceptance criteria
+
+- Every operation and public component is migrated or has an approved bounded
+  exclusion.
+- Every exclusion has a reason, owner, and expiry.
+- The temporary documentation baseline is empty.
+- The English resource extraction and all approved locale projections are
+  deterministic.
+- The operation inventory has no undocumented example omission.
+- Required full-scope checks are blocking in CI.
+- A customer task study confirms that representative users can select, call,
+  and verify the high-value operations.
+
+## Dependency-aware delivery order
+
+1. Accept the customer-writing standard and product terminology register.
+2. Accept the OpenAPI text-ID, catalog, fallback, and compatibility contracts.
+3. Extend the inventory and add the exact migration baseline.
+4. Add canonical English extraction and localized projection fixtures.
+5. Migrate the Work operation family.
+6. Migrate Factory Session execution and lifecycle operations.
+7. Migrate stream operations as one separate high-risk family.
+8. Migrate Factory definition and validation operations.
+9. Migrate Worker Session, Provider Session, and Model operations.
+10. Migrate reusable component families in domain-sized slices.
+11. Publish approved locale artifacts after package contracts exist.
+12. Remove the baseline and enable full-scope blocking.
+
+The domain-first component structure plan and this plan both affect OpenAPI
+source references. Do not perform broad source moves and broad prose migration
+in parallel. Stable text IDs must survive any accepted file move.
+
+## Verification
+
+Use the narrowest checks for each story, then run the public-contract gates.
+
+Focused checks must include:
+
+- schema validation for text metadata and locale catalogs;
+- unit tests for ID parsing, uniqueness, extraction, fallback, and stale
+  translation detection;
+- fixture tests for every localizable OpenAPI object kind;
+- contract validation for every request and response example;
+- deterministic generation and drift tests;
+- prose checking against canonical English fields;
+- at least one non-default test locale path;
+- focused HTTP behavior tests for high-value runnable examples; and
+- package consumer tests when public exports change.
+
+Repository gates must include, as applicable:
+
+```text
+node scripts/run-quiet-api-command.js validate:main ./api/openapi-main.yaml
+make generate-api
+make api-smoke
+make interfaces-all
+make api-package-verify
+make verify-fast
+make verify-pr
+make lint
+```
+
+Run generation through supported Make targets. Review all generated diffs. Do
+not edit generated files directly.
+
+## Project-level acceptance criteria
+
+- Every public operation explains purpose, prerequisites, success, and relevant
+  recovery behavior.
+- Every applicable operation has a minimal request, representative success
+  response, and relevant failure example.
+- Every public localizable text has one stable unique ID.
+- Text IDs remain stable across wording changes, renderer changes, and source
+  file moves.
+- `x-doc-id` remains the identity for a linked long-form guide only.
+- Canonical English remains in authored OpenAPI source.
+- Locale catalogs contain translations by stable ID and do not duplicate the
+  English source corpus.
+- Field-level fallback, stale translation detection, and coverage reporting are
+  deterministic.
+- Localized projections do not change any machine contract.
+- Public prose follows the accepted customer-writing profile and data-model
+  vocabulary.
+- Every example validates against the bundled OpenAPI schema.
+- High-value examples have direct public HTTP behavior evidence.
+- The temporary API documentation baseline is empty.
+- Generated contracts and package artifacts are current.
+- Required CI is terminal and passing, blocking feedback and conflicts are
+  resolved, and every implementation PR is merged.
+
+## Risks and controls
+
+| Risk | Control |
+| --- | --- |
+| Simplified prose changes API meaning | Require subject-matter review and preserve contract tests. |
+| Text IDs follow source layout | Require explicit semantic IDs and move-stability fixtures. |
+| `x-doc-id` gains two incompatible meanings | Keep guide-link and text-resource identities separate. |
+| English exists in two canonical places | Keep English in OpenAPI and generate the English resource catalog. |
+| Translations become stale silently | Record source digests and report stale resources. |
+| Localized specs feed client generation | Keep localized output in a documentation-only generation path. |
+| Example payloads drift from schemas | Validate every example during API smoke. |
+| Example payloads expose secrets | Use reviewed safe fixtures and a secret-pattern check. |
+| Large prose changes create review fatigue | Limit each task to one operation or component family. |
+| File moves conflict with content migration | Sequence domain moves and prose work. Preserve semantic IDs. |
+| A checker is treated as STE certification | Keep the conformance claim bounded and require human review. |
+
+## Work-story task packets
+
+### Task packet: OpenAPI text identity and coverage contract
+
+# problem statement
+
+OpenAPI text resources have no complete stable identity or coverage contract,
+so authors cannot prepare the reference for localization safely.
+
+## customer ask
+
+Give every localizable API reference resource a stable identity and report
+missing, duplicate, malformed, or orphaned resources.
+
+## solution
+
+Define the OpenAPI text extension and locale contracts. Extend the REST
+documentation inventory and add an exact migration baseline.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\api-reference-prose-examples-localization.md`
+
+# changes
+
+## package changes
+
+- Add the focused API documentation contract under `contracts/api/`.
+- Extend `internal/contractinventory` and its command with documentation
+  coverage.
+- Add the exact deletion-only baseline under `contracts/testdata/baseline/` or
+  the accepted baseline owner.
+
+## contracts
+
+- Define `x-text-id`, enum text-ID maps, example text identity, locale catalog,
+  fallback, source digest, and compatibility rules.
+
+## services
+
+- None. This is deterministic repository tooling.
+
+## API changes
+
+- Add documentation-only OpenAPI extensions. Do not change runtime contracts.
+
+## tests
+
+- Add schema, extraction, uniqueness, malformed-ID, duplicate-ID, orphan,
+  enum-map, baseline, and deterministic-order fixtures.
+
+### Task packet: localized OpenAPI documentation projection
+
+# problem statement
+
+Stable text IDs alone do not let a renderer apply translations or report
+fallback and stale resources.
+
+## customer ask
+
+Build a localized API reference from an approved locale catalog without
+changing the machine contract or generated clients.
+
+## solution
+
+Extract canonical English resources and generate a documentation-only localized
+OpenAPI projection with field-level fallback and coverage reporting.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\api-reference-prose-examples-localization.md`
+
+# changes
+
+## package changes
+
+- Add a focused extraction and projection command under `cmd/` with pure logic
+  in a small repository-local package.
+- Add locale registry and test-only locale fixtures.
+- Add supported Make targets for generation and drift checking.
+
+## contracts
+
+- Preserve every non-prose OpenAPI value exactly.
+- Define locale selection, fallback, source digest, and coverage output.
+
+## services
+
+- None. The generator is build-time tooling.
+
+## API changes
+
+- None to runtime REST behavior or canonical generated clients.
+
+## tests
+
+- Add projection equality, fallback, stale-resource, right-to-left metadata,
+  deterministic generation, and machine-contract equivalence tests.
+
+### Task packet: one operation-family prose and example migration
+
+# problem statement
+
+One public operation family does not give customers clear purpose, minimal
+examples, expected results, recovery guidance, or stable text identities.
+
+## customer ask
+
+Use the selected operation family without guessing request shape, result
+meaning, or safe recovery behavior.
+
+## solution
+
+Rewrite and tag one family as a vertical customer-behavior slice. Add named
+request and response examples and validate them through the public contract.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\api-reference-prose-examples-localization.md`
+
+# changes
+
+## package changes
+
+- Update the selected operations in `api/openapi-main.yaml`.
+- Update only the reusable component fragments owned by that family.
+- Regenerate all affected API and package projections.
+
+## contracts
+
+- Preserve paths, methods, operation IDs, parameters, status codes, media
+  types, schemas, payload fields, and runtime behavior.
+- Add stable text IDs and validated named examples.
+
+## services
+
+- None unless a separate approved behavior defect requires a service change.
+
+## API changes
+
+- Improve documentation metadata and examples only.
+
+## tests
+
+- Run prose, ID, example-schema, OpenAPI, generation, and focused public HTTP
+  behavior tests for the family.
+
+### Task packet: one reusable component-family migration
+
+# problem statement
+
+One reusable schema, parameter, enum, or response family lacks clear prose or
+stable localization identities.
+
+## customer ask
+
+Follow an operation into its reusable components and understand field meaning,
+constraints, literals, and recovery behavior.
+
+## solution
+
+Migrate one domain-owned component family. Add stable identities and concise
+descriptions without changing the machine schema.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\api-reference-prose-examples-localization.md`
+
+# changes
+
+## package changes
+
+- Update one bounded component family under `api/components/`.
+- Regenerate affected OpenAPI, client, schema, and package projections.
+
+## contracts
+
+- Preserve component keys, property names, types, requirements, enum literals,
+  constraints, and discriminator behavior.
+- Add stable item and enum-value text identities.
+
+## services
+
+- None.
+
+## API changes
+
+- Improve component documentation only.
+
+## tests
+
+- Run prose, ID, enum-map, example, bundled-contract, generated-client, and
+  focused domain contract checks.
+
+### Task packet: publish approved locale artifacts
+
+# problem statement
+
+Package consumers cannot discover or load approved localized API reference
+artifacts through supported exports.
+
+## customer ask
+
+Install the API package and resolve the locale registry, approved catalogs, and
+localized reference bundles without inspecting package internals.
+
+## solution
+
+Add reviewed data-only exports and deterministic manifest metadata for approved
+locale artifacts.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\api-reference-prose-examples-localization.md`
+
+# changes
+
+## package changes
+
+- Update `packages/api` authored package metadata and README.
+- Generate approved locale artifacts and manifest records.
+- Update candidate and publication helpers when required.
+
+## contracts
+
+- Define stable package subpaths, locale metadata, artifact digests, fallback,
+  and compatibility behavior.
+
+## services
+
+- None. The package remains data-only.
+
+## API changes
+
+- Add package artifact exports only. Do not change runtime REST behavior.
+
+## tests
+
+- Add package contract, tarball allowlist, installed-consumer, digest,
+  candidate, and publication reconciliation tests.

--- a/docs/internal/development/plans/claude-dynamic-workflow-compatibility.md
+++ b/docs/internal/development/plans/claude-dynamic-workflow-compatibility.md
@@ -1,0 +1,627 @@
+# Claude Dynamic Workflow Compatibility Plan
+
+## Problem statement
+
+You Agent Factory already provides a durable JavaScript Factory runtime, but its
+authoring API and several execution semantics differ from the Claude Code
+`Workflow` contract closely enough that customers must learn two script APIs
+and an unmodified Claude workflow can execute with different concurrency or
+resume the wrong child results.
+
+## Customer ask
+
+Customers should be able to understand the Claude dynamic-workflow schema,
+compare it with You's shipped behavior, and eventually run Claude-compatible
+workflow sources through You without giving up canonical `FactorySession`,
+`Dispatch`, `FactoryArtifact`, and `FactoryEvent` behavior.
+
+## Solution
+
+Converge the supported You JavaScript surface on the Claude workflow script
+contract. Claude names, signatures, callback behavior, return values, and
+failure semantics become the canonical base. You-specific provider selection,
+presets, permissions, artifacts, checkpoints, TypeScript loading, structured
+log fields, and durable inspection remain additive extensions. Existing
+`agent.run` and object-form fan-out receive a bounded migration window rather
+than defining a permanent second dialect.
+
+Publish this as two related contract descriptors: `claude-workflow-v1` is the
+unchanged Claude base, and `you-workflow-v1` is a strict additive superset.
+Every field shared by the two descriptors has exactly the same validation,
+execution, return, and failure semantics. A source does not select a runtime
+mode: using a You-only field simply requires validation against the superset.
+
+All execution continues to create and return a `FactorySession`; Claude terms
+such as run and agent remain authoring aliases rather than new canonical
+resources. The top-level Claude Code tool payload is documented and mapped to
+the existing Factory Session source selectors, but exact flat-payload parity is
+not required to converge the JavaScript language itself.
+
+The work is intentionally ordered around observable behavior:
+
+1. Freeze the canonical JavaScript contract and executable fixtures.
+2. Parse Claude metadata and map existing Factory Session source selectors.
+3. Make child scheduling genuinely asynchronous before promising Claude
+   `parallel` or `pipeline` behavior.
+4. Add the Claude `agent()` signature and its structured-output, phase,
+   isolation, and agent-type behavior.
+5. Add deterministic prefix resume and one-level nested workflows on the shared
+   scheduler.
+6. Project the resulting progress and compatibility facts consistently through
+   REST, CLI, MCP, recordings, and the existing Factory Session dashboard.
+
+## Original document
+
+The supplied compatibility reference is
+`C:\Users\andre\claude-dynamic-workflows.md`. A customer-readable snapshot is
+packaged at `docs/reference/claude-dynamic-workflows.md`. The shipped You
+contract remains `docs/reference/javascript-workflows.md`.
+
+## Current-state comparison
+
+This inventory was taken from the working tree on 2026-08-10. The tree already
+contains uncommitted `skipPermissions` propagation and documentation changes;
+those changes are treated as observed in-progress behavior, not as merged
+baseline. The unrelated unresolved conflict in
+`docs/internal/baselines/backend-exemption-budget.json` is outside this plan.
+
+### What is already reusable
+
+- Source selection already supports inline source, explicit workflow files,
+  named workflows, `.claude/workflows/`, user workflows, package-relative
+  workflows, named JavaScript Factories, and built-ins.
+- JavaScript runs already use canonical durable Factory Sessions with sync and
+  async starts, session status/results, dispatches, artifacts, events,
+  lifecycle controls, recording, replay, and restart recovery.
+- The Goja runtime already binds `args`, host-resolved `meta`, `phase`, `log`,
+  `workflow.log`, `agent.run`, `parallel`, `pipeline`, `workflow.artifact`,
+  `workflow.checkpoint`, `workflow.resumeState`, `workflow.budget`, and
+  `workflow.final`.
+- Child execution already crosses Factory Runtime, Factory Sessions, Workers,
+  Providers, Provider Sessions, and Recordings instead of calling provider
+  processes directly from the VM.
+- The child request and provider bridge already carry dormant output-schema,
+  sandbox, writable-root, and related values internally, although the public
+  JavaScript child contract currently rejects most of them.
+- Effective policy already provides `maxAgents`, concurrency, duration, output,
+  artifact, model, effort, runner, and token-budget fields. The default is
+  read-only, 16 agents, and concurrency 4, with an absolute deployment planning
+  cap of 1000 agents.
+- The dashboard and generated API already understand JavaScript phase,
+  checkpoint, dispatch-count, artifact, and provider-session projections.
+
+### Compatibility matrix
+
+| Area | Claude `Workflow` contract | You working-tree behavior | Gap or decision |
+| --- | --- | --- | --- |
+| Start payload | Flat `script`, `scriptPath`, or `name`; optional JSON `args`, `resumeFromRunId`, ignored `title`/`description` | `FactorySessionExecutionRequest` uses `requestId` plus a nested source selector and object-shaped `args`; sync and async routes are explicit | Keep the canonical Factory Session request and document the direct selector mapping. Widen `args` to any JSON value. Consider an exact flat transport alias only after script convergence is proven. |
+| Background lifecycle | Always returns a run id immediately; completion is notified later | Async start returns a `sessionId`; clients poll or consume durable events. Sync start is also available | Async start is already the canonical equivalent. Let host adapters bridge terminal Factory Events into notifications; a Claude-shaped run-id alias is a deferred transport convenience. |
+| Source persistence | Every invocation persists source and returns an editable path | File sources remain files; durable sessions retain source identity/hash and artifacts, but inline source is not promised as an editable workflow path | Persist an internal source snapshot for every JavaScript run and optionally materialize a reusable workflow through an explicit save operation; never expose unrestricted internal paths. |
+| Metadata | Required pure `export const meta = {name, description, whenToUse?, phases?}` | `meta` is injected from request/factory metadata; `export` is rejected; packaged JavaScript uses a separate `@you-factory-meta` header | Parse and validate the pure Claude literal, remove the export from executable source, and merge it into resolved Factory metadata. Preserve the You header for native factories. |
+| Language | Plain JavaScript; TypeScript is rejected | JavaScript plus a bounded TypeScript stripping loader | JavaScript follows the canonical Claude contract. Keep bounded TypeScript as an explicitly documented You extension with the same runtime host API. |
+| Determinism | `Date.now`, `Math.random`, and argument-less `new Date()` are unavailable | `Date` is not on the allowed-global list, but `Math` is and `Math.random` is not specifically rejected | Add static and runtime member-level denial for nondeterministic built-ins across the canonical JavaScript surface and test computed-member bypasses. |
+| `agent` call | `agent(prompt, opts?)` | `agent.run({prompt, ...})` | Make `agent` a callable function object and deprecate `.run` after checked-in sources migrate. Both paths normalize into one child request during the migration window. |
+| Agent options | `label`, `phase`, `schema`, `model`, `effort`, `isolation: "worktree"`, `agentType` | `label`, `preset`, `executorProvider`, `modelProvider`, `model`, `reasoningEffort`, and in-progress `skipPermissions`; output schema and access values are internal only | Give the Claude fields their canonical meanings. Route schema through existing structured-output capability, isolation through Workers, and agent type through the configured Factory-agent/Worker-profile registry. Add the provider/preset/permission fields only in `you-workflow-v1`. |
+| Agent result | Text without schema, validated object with schema, `null` for skipped/terminal child failure | Structured envelope containing status, dispatch identity, output, and diagnostics; a direct child failure currently throws | Make text/object/null the canonical `agent()` result. Durable identity stays on Dispatch reads. Keep `agent.run` temporarily as a deprecated envelope-returning extension for migration. |
+| `parallel` | Concurrent thunks, hard barrier, per-thunk failure becomes `null`, whole call does not reject | Object child specs run concurrently, but function items are invoked serially; failure shapes differ | Replace blocking host execution with a VM event loop and scheduler. Thunks and Claude failure behavior become canonical; object child specs remain a You convenience extension. |
+| `pipeline` | Any number of stages; every item advances independently without cross-item barriers; later callbacks receive `(prev, item, index)` | One required and one optional stage; items run serially; results are per-stage status envelopes | Implement arbitrary stages and concurrent per-item chains with Claude result/failure behavior. Remove the status-envelope return from the canonical path after migrating checked-in workflows and fixtures. |
+| Phases and logs | Declared phases, runtime `phase`, per-agent `opts.phase`, labels, and narrator `log` | Runtime phases/logs exist and become ordered records; no parsed declared phases or explicit per-child phase | Persist declared phase summaries before execution and put explicit phase on the child request/dispatch so concurrent calls never race on global phase state. |
+| Nested workflows | `workflow(nameOrRef, args?)`, one nesting level, shared cap/budget/abort | `workflow` is a non-callable namespace for final/log/artifact/checkpoint/resume/budget | Make the namespace callable, keep its methods, resolve children through Factory Definitions/Runtime source services, and share the same scheduler, ledger, records, and cancellation context. |
+| Budget | Global `budget.total`, `spent()`, `remaining()` with hard stop for new agents | `workflow.budget()` returns a static policy snapshot; `maxTokens` is exposed but not a live global ledger | Defer live token accounting. Keep existing static policy budgets and hard agent/concurrency/duration caps; report the Claude `budget` global as unsupported until usage accounting is truthful. |
+| Resume | `resumeFromRunId` reuses the longest successful prefix whose authored `(prompt, opts)` calls match; a mismatch invalidates the suffix | Interrupted sessions replay completed child results by ordinal `dispatch-N`; call arguments are not compared. Checkpoint state is separately explicit | Persist an authored child-call signature and enforce prefix invalidation. Keep interrupted same-session resume and add explicit continuation lineage for completed or edited sessions. |
+| Caps | Concurrency `min(16, cores-2)`, 4096 items per `parallel`/`pipeline`, 1000 agents lifetime | Policy defaults to concurrency 4 and max agents 16; deployment cap defaults to 1000; there is no independent 4096-item guard | Add the 4096 item and 1000 lifetime guards. Treat You's effective Factory/session/provider policy as an allowed narrowing extension; decide separately whether the default concurrency should rise from 4. |
+| Files and MCP | Script has no host IO; children may use their allowed tools/MCP; worktree isolation is explicit | Script has no host IO; provider-backed children use Worker/Provider capabilities; access remains policy/provider dependent | Existing boundary is correct. Capability mismatch must fail before dispatch and docs must not promise every provider has the same tools. |
+| Streaming | No partial result in the caller; progress UI/logs only | Async sessions expose richer durable event and response-event streams plus polling | Treat You's event streams as a compatible superset. Do not inject partial child outputs into the caller result. |
+| Multimodal args | No native blob/image/audio parameter; agents may read referenced paths | Start `args` is object-shaped; child prompts can reference files subject to worker capabilities | Preserve indirect file-path behavior. Do not introduce binary VM globals. Widen invocation args to any JSON value without weakening source-owned args-schema validation. |
+| Explicit opt-in | Workflow invocation requires explicit user/session opt-in | A customer explicitly selects and starts a Factory/Factory Session | Already satisfied; no automatic workflow selection is added by this plan. |
+
+## Scope estimate
+
+The authored-source migration is modest. The current tree has 30 checked-in
+workflow sources across packaged factories, customer examples, and runtime
+fixtures: 40 `agent.run` calls, 11 `parallel` calls, and 3 `pipeline` calls.
+Only three first-party packaged Factories use JavaScript. Those call sites can
+be migrated mechanically once canonical return shapes are decided.
+
+The runtime behavior is the larger part. The JavaScript runtime/validation/source
+area contains about 40 Go files, and the focused functional orchestration lane
+contains 19 test files. Not every file changes, but concurrency, child results,
+resume, recordings, and projections cross several durable owners.
+
+| Lane | Relative size | Rough implementation effort | Why |
+| --- | --- | --- | --- |
+| Canonical contract, `meta`, JSON `args`, validation, and source migrations | Medium | 3–5 focused engineering days | Parser/descriptor work plus 30 small source migrations and contract fixtures. |
+| Non-blocking Goja scheduler, real `parallel`, and streaming per-item `pipeline` | Large | 6–10 days | The VM must remain single-threaded while child work and promise completions are concurrent, canceled, ordered, and race-tested. |
+| Canonical `agent()` results, schema support, and You provider extensions | Large | 5–8 days | Crosses Factory Runtime, Factory Sessions, Workers, Providers, capability checks, recordings, and failure translation. |
+| Call-signature resume safety | Medium–large | 4–7 days | Requires durable record versioning, prefix invalidation, restart/replay tests, and separation from checkpoint resume. |
+| One-level callable nested workflows | Medium | 3–5 days | Reuses source resolution and scheduler state but needs nested scope records, errors, and progress projection. |
+| Cross-surface contracts, docs, generated artifacts, and dashboard projection | Medium | 4–6 days | REST/MCP/CLI parity, generated clients, reference docs, and existing Factory Session UI tests. |
+
+The rough total is 25–40 focused engineering days, preferably delivered as
+five or six independently reviewable PRs. The first three lanes—enough for most
+Claude-authored fan-out, pipelines, phases, and structured output—are roughly
+14–23 days. Resume and nesting can follow without changing the canonical
+surface. Deferring live token-budget accounting avoids a separate provider-
+usage and aggregation program that would likely add at least one or two more
+cross-service PRs.
+
+## Compatibility decisions
+
+### One canonical script contract with You extensions
+
+- Publish `claude-workflow-v1` as the frozen base descriptor and
+  `you-workflow-v1` as `claude-workflow-v1` plus a closed `x-you` extension
+  section. These are documentation, validation, and capability-negotiation
+  contracts, not separate interpreters.
+- A workflow containing only Claude fields must satisfy
+  `claude-workflow-v1` unchanged. A workflow using any You-only field satisfies
+  `you-workflow-v1`; the overlapping surface is byte-for-byte the same authored
+  shape and has one implementation path.
+- Claude's workflow JavaScript surface is the base contract: pure exported
+  `meta`, callable `agent`, thunk-based `parallel`, streaming per-item
+  `pipeline`, `phase`, `log`, callable `workflow`, JSON `args`, and Claude
+  value/failure semantics.
+- You extensions add fields rather than fork behavior. The first extension set
+  is `preset`, `executorProvider`, `modelProvider`, `reasoningEffort`, and
+  `skipPermissions` on agent options, plus `workflow.artifact`,
+  `workflow.checkpoint`, `workflow.resumeState`, `workflow.final`, structured
+  log fields, and bounded TypeScript loading.
+- Prefer Claude option names when both exist. `effort` is canonical;
+  `reasoningEffort` is a You extension alias. `model` and `schema` are shared.
+- `agent.run(spec)` and object entries in `parallel` remain temporary migration
+  aliases for checked-in You workflows. New examples and packaged factories
+  use callable `agent` and Claude result shapes.
+- Preview reports unsupported fields and deprecated aliases before execution.
+  Provider adapters receive only normalized provider-neutral child requests and
+  never learn Claude- versus You-authored field names.
+
+The initial canonical option object is therefore:
+
+```javascript
+await agent("Review the proposed change", {
+  // Claude base contract
+  label: "review",
+  phase: "verify",
+  schema: REVIEW_SCHEMA,
+  model: "gpt-5.6",
+  effort: "high",
+  isolation: "worktree",
+  agentType: "code-reviewer",
+
+  // You extensions
+  preset: "careful-review",
+  executorProvider: "ACP",
+  modelProvider: "cursor-acp",
+  reasoningEffort: "high",
+  skipPermissions: false,
+});
+```
+
+- Claude fields keep Claude meanings and return behavior regardless of whether
+  You extensions are present.
+- `reasoningEffort` is a migration alias for existing You sources. New
+  sources use `effort`; supplying both with different values is a validation
+  error.
+- Explicit call fields override the selected `agentType`/`preset`, which override
+  operator/session defaults. Effective policy and provider capability checks
+  still narrow the result.
+- Unknown extension fields fail closed. Future provider controls are added to
+  this closed extension set only after their provider-neutral semantics exist.
+
+### Canonical execution and invocation
+
+- REST and MCP keep the existing Factory Session start operations and canonical
+  request. `INLINE_WORKFLOW`, `WORKFLOW_FILE`, and `WORKFLOW_NAME` map directly
+  to Claude's `script`, `scriptPath`, and `name` concepts.
+- Widen invocation `args` from object-only to any JSON value while retaining
+  source-owned JSON Schema validation. Existing object-shaped factory inputs
+  remain backward compatible.
+- Keep `requestId`, explicit sync/async choice, requested policy, and canonical
+  `sessionId` as You Factory extensions. They provide stronger idempotency and
+  durable lifecycle behavior without changing script semantics.
+- Defer an exact flat Claude Code tool-payload alias and `wf_...` response alias
+  until the canonical script fixtures run unchanged. Those are transport
+  conveniences and should not block the runtime convergence.
+- Host-specific fire-and-forget notifications remain transport behavior derived
+  from terminal Factory Events, not state owned by Factory Runtime.
+
+### Scheduler and Goja event loop
+
+The current `hostAgentRun` blocks until child execution completes and then
+returns an already-resolved promise. That must change before any concurrency
+parity claim.
+
+- A session-scoped scheduler owns lexical call indexes, queue state,
+  concurrency permits, item/lifetime limits, and abort propagation.
+- The Goja VM stays on one goroutine. Host calls enqueue work and return pending
+  promises. Worker goroutines execute injected child operations and send
+  completions to the VM event loop, which alone resolves promises and resumes
+  JavaScript callbacks.
+- Calling `parallel` thunks schedules each chain without awaiting the prior
+  thunk. Calling `pipeline` creates one independent chain per item. Ordered
+  result arrays use lexical item order, never completion order.
+- Queued, running, completed, skipped, and failed child states append canonical
+  runtime records and Factory Events as they change.
+- No package introduces a secondary dependency graph or service locator. The
+  scheduler is request-scoped state created by the injected Factory Runtime
+  implementation and calls already-injected Factory Sessions/Workers ports.
+
+### Child calls and structured output
+
+- The callable `agent(prompt, opts)` is canonical. Deprecated `agent.run(spec)`
+  shares its normalization and policy decision path during migration.
+- `opts.schema` is validated as JSON Schema during preview when literal and at
+  runtime when computed. It is serialized into the existing Worker/Provider
+  output-schema contract and its digest is recorded on the Dispatch.
+- Providers declare structured-output capability. Unsupported routes fail
+  before provider execution; no adapter silently downgrades to unvalidated
+  text.
+- The completed output is validated again at the Worker boundary. Canonical
+  `agent` receives text, a validated object, or `null`. Deprecated `agent.run`
+  may retain its durable envelope until checked-in consumers migrate.
+- `opts.phase` is copied onto the child record and wins over the current global
+  phase for that child only.
+- `opts.isolation: "worktree"` becomes a provider-neutral Worker isolation
+  request. Workers owns creation/cleanup and Providers owns truthful capability
+  mapping. Unsupported routes fail before execution.
+- `opts.agentType` resolves through an explicit Factory-agent or operator Worker
+  profile contract. Unknown types fail safely. It is not treated as a raw
+  provider prompt injection.
+- `opts.model` and `opts.effort` map to the existing model and reasoning-effort
+  selectors; omission inherits resolved session/worker settings.
+
+### Resume and replay safety
+
+- Every admitted child call stores a canonical authored-call digest covering
+  prompt plus normalized options, including schema and phase.
+  Raw prompts remain protected by existing artifact/audit policy.
+- Lexical call identity is allocated when work is scheduled, including within
+  parallel and pipeline chains.
+- Resume compares successful calls in order. Reuse stops permanently at the
+  first missing or mismatched call; all later calls execute live even if a
+  later digest happens to match.
+- Cached `null`, skipped, failed, canceled, or terminal-error calls are not
+  treated as successful prefix entries.
+- A continuation from a completed or edited run creates a new
+  Factory Session with explicit `resumedFromSessionId` lineage. Existing
+  interrupted-session resume remains same-session lifecycle recovery.
+- Checkpoint state remains an explicit You extension and is not confused with
+  Claude prefix caching.
+
+### Budget deferral
+
+- Do not add Claude's live `budget` global in the initial convergence. Current
+  provider usage is not yet complete enough to make `spent()` and `remaining()`
+  truthful across every route.
+- Retain `workflow.budget()` as a You extension that returns static effective
+  policy limits. Document that it is not Claude's live token ledger.
+- Enforce existing agent count, concurrency, duration, output-size, artifact,
+  model, and provider limits independently of live token accounting.
+- Add the live global later as its own vertically sliced project after provider
+  usage capture and session aggregation are authoritative. No placeholder
+  `spent() = 0` implementation is acceptable.
+
+## Work stories
+
+### Story 1 — Publish and lock the canonical JavaScript baseline
+
+As a customer evaluating migration, I can read the Claude schema snapshot next
+to the shipped You contract and tell which document describes which product.
+
+Acceptance criteria:
+
+- `you docs claude-dynamic-workflows` renders the supplied compatibility
+  snapshot with its snapshot date and an explicit link to the shipped You
+  contract.
+- `you docs javascript-workflows` remains the authoritative description of
+  currently supported You behavior and never implies that planned compatibility
+  fields have shipped.
+- A machine-readable manifest identifies every Claude-base global, function,
+  option, cap, failure rule, and return shape, then lists You extensions
+  separately as the versioned `claude-workflow-v1` and `you-workflow-v1`
+  descriptors.
+- Golden Claude-style workflow fixtures cover fan-out, pipeline, structured
+  output, phase metadata, nested workflow, and resume. A negative fixture makes
+  the deferred live `budget` global explicit.
+- Contract tests fail when the reference matrix, runtime descriptor, fixtures,
+  and public docs disagree.
+
+### Story 2 — Preview and run Claude-authored source
+
+As a workflow author, I can validate and start a Claude-style JavaScript file
+without rewriting its metadata declaration or source selector.
+
+Acceptance criteria:
+
+- Existing inline, file, and named source selectors accept Claude-authored
+  source and apply a 524,288-character inline-source limit.
+- A pure `export const meta` literal with required one-line name/description and
+  optional `whenToUse`/phases is extracted, validated, and projected before a
+  session starts.
+- Variables, calls, spreads, computed values, malformed phases, and phase/title
+  mismatches produce stable source diagnostics with authored line locations.
+- Nondeterministic time/random APIs are rejected before execution, including
+  computed member access that can be resolved statically. TypeScript remains an
+  explicitly documented You loader extension.
+- Start returns canonical Factory Session identity; async progress is readable
+  through existing session/event surfaces.
+- Inline source is durably snapshotted without exposing unrestricted host paths
+  or raw source on ordinary public reads.
+
+### Story 3 — Execute real concurrent barriers and pipelines
+
+As a workflow author, I observe Claude-compatible concurrency rather than
+serial execution hidden behind promises.
+
+Acceptance criteria:
+
+- `parallel([thunkA, thunkB])` admits both child chains before either provider
+  result is required and waits for all results before continuing.
+- One rejected/failed thunk yields `null` at its original index and does not
+  reject the canonical `parallel` call.
+- `pipeline(items, ...stages)` supports one or more stages, starts independent
+  item chains up to the effective concurrency cap, and lets one item enter a
+  later stage while another remains in an earlier stage.
+- Every stage receives `(previousResult, originalItem, index)`; the first stage
+  receives `undefined` as its previous result.
+- A failed stage short-circuits only that item to `null`; other items continue.
+- The 4096 item cap, 1000 agent lifetime cap, effective concurrency cap,
+  cancellation, and result ordering are deterministic under race and repeat-run
+  tests.
+- Object-form `parallel` remains a documented You extension. Checked-in callers
+  of the old pipeline status envelope are migrated to canonical raw/null results
+  before that envelope is removed.
+
+### Story 4 — Run canonical child agents with You extensions
+
+As a workflow author, I can use the documented Claude agent options and receive
+the documented value shape while operators retain durable child inspection.
+
+Acceptance criteria:
+
+- `agent(prompt, opts)` accepts the Claude base fields plus the closed You
+  extension fields and maps them through one shared child request.
+- Without schema, a successful canonical child resolves to final text.
+  With schema, it resolves to the validated JSON object.
+- Skipped or terminally failed children resolve to `null`, while
+  the associated Dispatch and safe failure detail remain inspectable.
+- Deprecated `agent.run(spec)` remains only for a documented migration window;
+  first-party packaged Factories, examples, and fixtures move to `agent()`.
+- Literal and computed schemas receive equivalent validation, capability
+  negotiation, provider transport, output validation, digest, event, recording,
+  and replay behavior.
+- Explicit phase, model, effort, worktree isolation, and agent type are applied
+  to only that child and remain visible in safe dispatch projections.
+- Unsupported provider capability combinations fail before the provider starts;
+  no route silently drops schema, isolation, agent type, or access requirements.
+
+### Story 5 — Resume the longest unchanged successful prefix
+
+As a workflow author iterating on a later stage, I can continue from prior
+successful child work without replaying stale results after a changed call.
+
+Acceptance criteria:
+
+- A continuation with identical source-relevant args and child call signatures
+  reuses every successful prior call without invoking a provider.
+- The first changed prompt or option executes live and disables reuse for the
+  entire suffix.
+- Concurrent calls use stable lexical identities independent of completion
+  order.
+- Prior failed, skipped, canceled, null, or incomplete calls execute live.
+- Resume lineage, cache hit/miss decision, call digest, source hash, args hash,
+  and reused Dispatch identity are durable and replayable without exposing raw
+  prompts or secrets.
+- Existing interrupted checkpoint resume still restores approved checkpoint
+  state and cannot accidentally use the new continuation path.
+
+### Story 6 — Compose one nested workflow within shared limits
+
+As a workflow author, I can compose one saved workflow without escaping parent
+limits.
+
+Acceptance criteria:
+
+- `workflow(nameOrRef, args)` returns the child workflow's value, uses normal
+  source lookup, and renders a nested progress group within the same parent
+  Factory Session.
+- The child shares concurrency, agent count, duration/output caps, abort signal,
+  effective policy, durable records, and artifact controls with its parent.
+- A child attempting another `workflow()` call fails with a stable nesting-depth
+  diagnostic. Unknown names, unreadable paths, and syntax errors are catchable
+  JavaScript errors.
+- You extensions `workflow.log`, `workflow.artifact`, `workflow.checkpoint`,
+  `workflow.resumeState`, `workflow.budget`, and `workflow.final` remain callable
+  properties on the canonical function object.
+- The Claude live `budget` global remains rejected with a stable unsupported-
+  global diagnostic until the deferred accounting project ships.
+
+### Story 7 — Inspect workflow progress everywhere
+
+As an operator, I can explain a workflow run through the same Factory Session
+surfaces used for native workflows.
+
+Acceptance criteria:
+
+- Declared phases exist in the initial read model; observed phase changes,
+  explicit child phase, label, queue state, nested group, usage, and terminal
+  outcome are derived from canonical Factory Events and durable records.
+- REST, CLI, MCP, recordings/replay, and the dashboard agree on session,
+  dispatch, phase, usage, resume-lineage, and artifact facts.
+- The Factory Session detail feature treats API/session data as canonical and
+  builds the progress tree as a projection; component state does not become a
+  second execution source of truth.
+- Existing shared status, disclosure, table/tree, tooltip, and action primitives
+  are reused; new copy lives in the feature message catalog and all controls are
+  keyboard accessible.
+- Mobile and desktop layouts can inspect phases and nested groups without
+  horizontal page scrolling, and high-volume child lists use bounded rendering.
+- The workflow view does not expose raw prompts, credentials, unrestricted
+  paths, provider payloads, or checkpoint bodies.
+
+## Changes
+
+### Package changes
+
+- Extend source metadata extraction and canonical JavaScript validation under
+  `pkg/services/factory_runtime/internal/services/orchestration/javascript/source/`
+  and `validation/`.
+- Add Claude-base call normalization, You-extension normalization, deprecation
+  handling, and manifest generation under the
+  JavaScript orchestration owner; keep the authored descriptor as the canonical
+  source for generated `contracts/javascript/runtime-api.json` artifacts.
+- Refactor `javascript/runtime` around a request-scoped scheduler/event loop.
+  Keep pure call normalization, limit decisions, signature hashing, and result
+  translation in small focused modules.
+- Extend JavaScript runtime child records with authored-call digest, explicit
+  phase, nested scope, and resume decision fields. Update strict
+  record decoding and migrations; older records must remain readable or fail
+  with an explicit incompatible-version diagnostic.
+- Extend Factory Sessions execution/resume composition to create continuation
+  lineage and persist runtime records before exposing projections.
+- Extend Workers with provider-neutral structured-output and worktree-isolation
+  requirements only where existing public Worker contracts do not already carry
+  them. Providers remains the owner of capability truth and native mapping.
+- Use Factory Definitions' JavaScript agent map and operator worker presets as
+  explicit injected inputs to agent-type resolution; do not introduce a global
+  runtime registry lookup.
+- Extend Recordings projections for call signatures, reuse decisions, and nested
+  scope without moving canonical ledger ownership into Factory
+  Runtime.
+- Extend `ui/src/features/factory-session-detail/` projections, hooks,
+  components, messages, and tests rather than creating a parallel workflow-run
+  feature.
+
+### Contracts
+
+- Publish `claude-workflow-v1` as the base JavaScript runtime descriptor and
+  `you-workflow-v1` as its strict additive superset, with You option/host
+  extensions in a closed `x-you` section.
+- Widen `FactorySessionExecutionRequest.args` to any JSON value while keeping
+  the existing source-selector and request-id contract.
+- Add canonical callable-agent option/result schemas and mark `agent.run` plus
+  legacy pipeline envelopes as deprecated migration aliases.
+- Add stable codes for invalid metadata, nondeterministic APIs,
+  item/lifetime limits, child capability mismatch, resume mismatch, and
+  nested-depth violation.
+- Add call-signature, resume-lineage, nested-scope, and explicit-phase fields
+  only to public projections that customers need to explain the run. Keep raw
+  source/prompt/checkpoint bodies artifact-owned and protected.
+- Define Claude limits as ceilings narrowed by effective Factory, session,
+  deployment, runner, and provider limits. You extensions never widen policy.
+- Version the JavaScript runtime record and descriptor contracts before changing
+  strict unions or resume hashing.
+
+### Services
+
+- Factory Definitions owns saved/named Factory and workflow source identity,
+  authored agents, metadata, and persistence.
+- Factory Runtime owns JavaScript validation, base/extension normalization,
+  scheduler decisions, phase/nested scope, child admission, limit checks, and
+  call-signature matching.
+- Factory Sessions owns durable start/resume/continuation lifecycle,
+  idempotency, canonical session lineage, and translation of admitted children
+  to Worker invocations.
+- Workers owns request-scoped child execution, worktree lifecycle, tool-policy
+  shaping, output validation, and retry policy.
+- Providers owns model/provider capability truth, structured-output transport,
+  provider permission/isolation mapping, usage capture, and one normalized
+  execution attempt.
+- Recordings owns the canonical Factory Event ledger, artifacts, replay, and
+  historical projections.
+- Factory Visualization and the dashboard consume canonical projections; they
+  do not infer scheduler state from local timers.
+
+### API changes
+
+- Author new request/response/projection components under `api/components/` and
+  compose them from `api/openapi-main.yaml`; do not edit bundled or generated
+  files directly.
+- Keep `POST /factory-sessions/async` and `/sync` as the execution operations.
+  Keep their canonical source-selector request shape and widen only `args` to
+  any JSON value.
+- Extend Factory preview and MCP source validation with canonical JavaScript
+  feature, extension, and deprecation diagnostics.
+- Extend MCP `you.factory_session.start_async`/`start_sync` schemas from the same
+  authored contract. Do not create a transport-only workflow state store.
+- Add CLI authoring flags only as adapters to the same input fields; CLI and API
+  return the same canonical Factory Session.
+- Refresh `api/openapi.yaml`, generated Go clients/servers, generated TypeScript,
+  MCP discovery, publishable API schemas, and the JavaScript runtime manifest
+  through repository generation targets.
+
+### Tests
+
+- Unit tests for metadata purity, source-size limits, arbitrary JSON args,
+  nondeterministic members, child
+  option normalization, JSON Schema validation, signature hashing, prefix
+  invalidation, item/lifetime caps, deprecation diagnostics, and depth
+  enforcement.
+- Runtime integration tests with a controllable child executor proving pending
+  promises, true thunk concurrency, independent pipeline advancement, ordered
+  results, barrier behavior, per-item failure isolation, cancellation, and VM
+  single-goroutine safety.
+- Race, stress, and repeat-run tests at 4096 items, 1000 admitted agents, mixed
+  completion order, nested workflows, and resume after
+  process restart. Use deterministic gates/channels, not sleeps.
+- Worker/Provider adapter tests that observe actual structured-output,
+  worktree/isolation, model/effort, permission, usage, and capability decisions
+  at injected command/ACP edges.
+- Factory Session/Recordings integration tests for persistence-before-
+  visibility, canonical events, source snapshots, continuation lineage,
+  call-signature reuse, replay, and older-record compatibility.
+- Functional scenarios under `tests/functional/orchestration/javascript/`
+  constructed through `root.BuildProcess` and `Process.Execute`, using only
+  `edges.Edges` replacements and provider command-runner mocks. Cover one
+  unmodified Claude fan-out, pipeline, structured-output, nested, and resumed
+  workflow, plus the expected diagnostic for a deferred live-budget workflow.
+- REST/MCP/CLI contract parity tests over the same fixtures, including async
+  start, notification/event bridging, status, dispatch, artifact, and result
+  reads.
+- UI projection, hook, component, localization, accessibility, responsive, and
+  focused browser tests for declared phases, queue state, nested groups, usage,
+  failure, and resume lineage.
+- Documentation smoke tests for both reference topics and executable examples.
+
+## Quality gates
+
+Use focused tests during each story, then run the relevant shared gates:
+
+- `go test ./pkg/services/factory_runtime/... ./pkg/services/factory_sessions/... ./pkg/services/workers/... ./pkg/services/providers/... ./pkg/services/recordings/...`
+- focused functional orchestration cells through `root.BuildProcess` and
+  `Process.Execute`
+- `make generate-api` for direct API/Go/dashboard changes, or
+  `make interfaces-all` when publishable schemas/clients change
+- `make api-smoke`
+- `make docs-reference-smoke`
+- `make ui-test` and `make ui-lint` when the progress projection changes
+- `go test -race` for the scheduler/runtime packages plus the explicit stress
+  lane
+- `make verify-fast`, followed by `make verify-pr`
+
+## Out of scope
+
+- Replacing canonical Factory/Factory Session vocabulary with Claude run/task
+  resources.
+- Exposing raw Node, Bun, filesystem, process, module, shell, network, secret,
+  or connector globals inside the JavaScript VM.
+- Guaranteeing identical tools or MCP authentication across providers that do
+  not declare those capabilities.
+- Token-level partial result streaming into the calling conversation.
+- Claude's live `budget.total`/`spent()`/`remaining()` accounting in the initial
+  convergence.
+- An exact flat clone of Claude Code's top-level `Workflow` tool payload before
+  the canonical script contract and fixtures are proven.
+- Native binary multimodal values in `args`; file-path references remain the
+  supported indirect mechanism.
+- More than one nested workflow level.
+- Opportunistic Petri-runtime, provider, CLI, or dashboard redesign unrelated
+  to compatibility behavior.
+
+## Delivery boundary
+
+The work is complete only after required CI is terminal and passing, generated
+artifacts are current, every blocking review conversation is addressed, merge
+conflicts are resolved without discarding concurrent work, and the pull request
+is actually merged. Opening a PR, pushing the implementation, obtaining
+approval, or reaching green CI without merge is not completion.

--- a/docs/internal/development/plans/cli-and-reference-prose-migration.md
+++ b/docs/internal/development/plans/cli-and-reference-prose-migration.md
@@ -1,0 +1,712 @@
+# CLI And Packaged Reference Prose Migration Plan
+
+## Status
+
+Proposed. Depends on the accepted customer-writing standard and blocking
+changed-prose check.
+
+## Problem statement
+
+Customers cannot reliably move from a goal to the correct CLI command and
+detailed guide because command help and packaged reference topics are dense,
+inconsistently structured, and sometimes expose internal implementation
+vocabulary.
+
+## Customer ask
+
+Rewrite the CLI and its packaged documentation so customers can rapidly
+understand the product, decompose goals into Work, submit that Work, verify the
+result, and find deeper guidance.
+
+## Intended outcome
+
+Every visible command answers three questions in order:
+
+1. What customer task does this command perform?
+2. What is the shortest correct invocation?
+3. How does the customer verify the result or get detailed help?
+
+Every packaged topic has one clear purpose, uses the canonical public data
+model, and presents task instructions before edge cases and exhaustive
+reference material.
+
+## Parent plan
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\customer-prose-clarity-program.md`
+
+## Dependency plan
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\customer-prose-standard-and-enforcement.md`
+
+## Scope
+
+### In scope
+
+- `contracts/cli/commands.json` authored help.
+- Authored handwritten help that cannot yet come from the command manifest.
+- Signature-aware Factory invocation help.
+- `docs/reference/*.md` packaged topics and their index.
+- Root help and focused human output fixtures affected by a journey.
+- Required generated CLI family artifacts.
+- Existing documentation, contract, and public CLI tests.
+- Direct customer task-study evidence.
+
+### Out of scope
+
+- Renaming commands or flags solely to make prose easier to write.
+- Changing JSON/NDJSON output, public schemas, exit codes, or compatibility
+  aliases.
+- Moving runtime policy into documentation.
+- Rewriting every topic in one PR.
+- Hand-editing generated CLI files.
+- Updating unrelated internal documentation.
+
+## Customer information architecture
+
+### Root and command help
+
+Visible help should use this order when applicable:
+
+1. One-sentence purpose.
+2. Recommended first command.
+3. Required prerequisite or target.
+4. Concise alternatives.
+5. Verification command.
+6. Route to `you docs <topic>` for detailed contracts and edge cases.
+
+Long help must not duplicate an entire packaged guide. It must contain enough
+information to select and run the command safely.
+
+### Packaged task guides
+
+Task-oriented topics should use this order when applicable:
+
+1. Purpose and audience.
+2. Prerequisites.
+3. Choose a task or shape.
+4. Minimal working procedure.
+5. Expected result and verification.
+6. Relevant failure recovery.
+7. Contract details and advanced variants.
+8. Related canonical topics.
+
+Reference-oriented topics may lead with a compact field or behavior table but
+must still include a shortest working path.
+
+### Examples
+
+Every example must:
+
+- state the customer goal;
+- use public vocabulary and canonical fields;
+- contain only the fields needed for that behavior unless labeled complete;
+- show the exact command;
+- show or describe the expected result; and
+- give the next verification command.
+
+Examples must not use repository-local paths as if they are installed-product
+paths unless the context explicitly identifies them as repository examples.
+
+## Canonical terminology
+
+All migrated prose must follow `docs/architecture/data-model.md` and the new
+customer technical-term register. In particular:
+
+- Use `Factory`, `Factory Session`, `Current Factory`, `Work`, and `Work
+  Request` for customer behavior.
+- Use `Worker Session` only for one supervised worker execution context.
+- Do not describe the public product primarily through CPN, place, marking,
+  transition, or token vocabulary.
+- Preserve literal schema and event names when the customer must type or parse
+  them.
+- Explain a literal once when its form differs from normal customer prose.
+
+## Migration unit
+
+One implementation task may change:
+
+- one complete customer journey across tightly coupled help and topics;
+- one command family with its directly owned help topic; or
+- one topic or no more than approximately 2,000 prose words from a larger
+  topic.
+
+An implementation task must not combine several unrelated topics merely
+because they are Markdown files. A partial migration must remove only the
+baseline findings that it actually fixes.
+
+## Work stories
+
+### Story 1: Customers can select the first command from root help
+
+#### Observable behavior
+
+Running `you` or `you --help` tells a customer how to start, submit, inspect,
+and find detailed documentation without exposing internal orchestration
+implementation as the product definition.
+
+#### Primary sources
+
+- `contracts/cli/commands.json` records for `you` and `you.docs`.
+- `docs/reference/agents.md` orientation and topic router.
+- Root help fixture and related tests.
+
+#### Acceptance criteria
+
+- The first screen identifies `run`, `server`, `submit`, `work`, and `docs` by
+  customer goal.
+- The root description uses customer-facing Factory vocabulary and contains no
+  unexplained CPN terminology.
+- A recommended command is visible for starting the Current Factory.
+- A recommended command is visible for submitting to a running Factory
+  Session.
+- A verification command is visible for submitted Work.
+- Root help remains side-effect-free and exits successfully.
+- `you docs agents` contains a concise goal-to-command router before detailed
+  contracts.
+- Prose checks, root help baselines, CLI manifest checks, and docs smoke pass.
+
+### Story 2: Customers can choose a Work decomposition shape
+
+#### Observable behavior
+
+A customer can determine whether a goal needs independent Work,
+dependency-ordered Work, or parent-child Work and can create the corresponding
+valid batch.
+
+#### Primary sources
+
+- `docs/reference/agents.md`.
+- `docs/reference/batch-inputs.md`.
+- `docs/reference/relationships.md`.
+- Relevant `submit batch` command help in `contracts/cli/commands.json`.
+
+#### Acceptance criteria
+
+- One compact decision table distinguishes independent, `DEPENDS_ON`, and
+  `PARENT_CHILD` Work.
+- Each shape has one minimal valid `FACTORY_REQUEST_BATCH` example.
+- Each batch uses a stable, non-empty `requestId` and canonical camelCase
+  fields.
+- The guidance distinguishes sequencing from containment.
+- The guidance states when a retry must reuse the same `requestId`.
+- Each procedure ends with `you submit batch` and a public verification path.
+- Existing relationship and batch contract tests confirm that the examples are
+  valid.
+- The affected baseline findings are removed.
+
+### Story 3: Customers can submit and verify Work without duplicate ingress
+
+#### Observable behavior
+
+A customer can choose unary or batch submission, target the intended Factory
+Session, and verify acceptance without confusing startup input, watched files,
+HTTP ingress, or repeated unary submission.
+
+#### Primary sources
+
+- `you submit` and `you submit batch` help.
+- `docs/reference/agents.md`.
+- `docs/reference/work.md`.
+- `docs/reference/sessions.md` routing sections.
+
+#### Acceptance criteria
+
+- The guidance gives one rule for choosing unary versus batch submission.
+- It clearly distinguishes a running Factory Session from local Factory files.
+- It explains default and explicit `--server` and `--session` targets once and
+  routes detailed ownership to `sessions`.
+- It identifies duplicate behavior for unary submit and idempotent behavior for
+  batch upsert.
+- Human success output routes to `you work show` when a Work ID exists and to a
+  narrowed list command otherwise.
+- JSON output remains machine-readable and unchanged unless a separate contract
+  change is approved.
+- Focused `root.BuildProcess` functional coverage proves one submit-and-verify
+  path through the CLI.
+
+### Story 4: Customers can select and verify a run shape
+
+#### Observable behavior
+
+A customer can distinguish Current Factory, explicit Factory, named Factory,
+continuous, hosted, replay, and mock-worker runs before starting execution.
+
+#### Primary sources
+
+- `you run` and `you server` help.
+- `docs/reference/run.md`.
+- `docs/reference/operations.md`.
+- `docs/reference/record-replay.md`.
+- `docs/reference/mock-workers.md`.
+
+#### Acceptance criteria
+
+- A compact task table maps each supported goal to one canonical invocation.
+- Prerequisites and lifecycle effects are stated before each invocation.
+- Current Factory selection is explained without internal implementation
+  vocabulary.
+- Continuous and hosted modes state who owns the listener and when it stops.
+- Recording defaults and artifact sensitivity remain accurate.
+- Each run procedure states its terminal or verification behavior.
+- Existing run help, recording, invocation, and terminal-policy tests pass.
+
+### Story 5: Customers can author and validate a Factory
+
+#### Observable behavior
+
+A customer can create the minimum Factory structure, validate it, run it, and
+understand the public roles of Work, Workers, and Workstations.
+
+#### Primary sources
+
+- `docs/reference/authoring-factories.md`.
+- `docs/reference/config.md`.
+- `docs/reference/factory-validation.md`.
+- Factory/config/init command-family help.
+
+#### Acceptance criteria
+
+- The shortest valid authoring path appears before comprehensive schema detail.
+- Each public noun has one consistent definition and role.
+- Validation is a required step immediately before first execution.
+- The minimum example uses canonical public fields and passes the validation
+  command in a focused fixture or smoke test.
+- Split and single-file layouts are clearly distinguished.
+- Failure guidance names observable validation output and the next correction
+  action.
+
+### Story 6: Customers can select execution components
+
+#### Observable behavior
+
+A customer can distinguish Worker, Workstation, Provider, Model, resource, and
+prompt-template responsibilities and route to the correct command or guide.
+
+#### Primary sources
+
+- Worker, Worker Session, Provider, and Model command families.
+- `docs/reference/workers.md`.
+- `docs/reference/workstations.md`.
+- `docs/reference/providers.md`.
+- `docs/reference/models.md`.
+- `docs/reference/resources.md`.
+- `docs/reference/templates.md`.
+
+#### Acceptance criteria
+
+- Each topic starts with its owned customer question and points to adjacent
+  owners without duplicating their complete contract.
+- `Worker` and `Worker Session` are not used interchangeably.
+- `Worker` and `Workstation` configuration responsibilities are distinct.
+- Provider and Model selection guidance preserves capability and readiness
+  caveats.
+- Every shown inspection command identifies its expected result.
+- Existing provider, model, worker, and docs tests remain passing.
+
+### Story 7: Customers can host and integrate the CLI
+
+#### Observable behavior
+
+A customer can distinguish HTTP/dashboard hosting, MCP hosting, ACP-agent
+hosting, and JavaScript workflow execution and can select the correct entry
+point.
+
+#### Primary sources
+
+- `serve`, `mcp`, and ACP command-family help.
+- `docs/reference/mcp.md`.
+- `docs/reference/serve-acp.md`.
+- `docs/reference/javascript-workflows.md`.
+- Applicable provider integration sections.
+
+#### Acceptance criteria
+
+- One router distinguishes the supported host and protocol shapes.
+- Each procedure states transport, process lifetime, prerequisite, and first
+  verification action.
+- Stdio requirements and stdout/stderr policy remain explicit where applicable.
+- JavaScript workflow execution routes through canonical Factory and Factory
+  Session surfaces.
+- Protocol smoke and documentation tests pass.
+
+### Story 8: Every remaining packaged topic conforms to the accepted profile
+
+#### Observable behavior
+
+Customers receive consistent purpose, procedure, result, recovery, and routing
+language in every packaged topic not completed by Stories 1–7.
+
+#### Execution rule
+
+Create one task per topic or per approximately 2,000-word section of a larger
+topic. Use current customer exposure and baseline severity to order the queue.
+
+#### Acceptance criteria for each task
+
+- The topic has one declared purpose and canonical concept owner.
+- The first working path appears before exhaustive detail.
+- Procedures state prerequisites, actions, expected results, and verification.
+- Descriptive sections use one topic per paragraph.
+- Cross-references use runnable `you docs <topic>` syntax in packaged output.
+- Code and schema examples remain byte-accurate where contract accuracy
+  requires it.
+- Automated findings for the migrated scope are zero.
+- A language reviewer and subject-matter reviewer record approval.
+- `make docs-reference-smoke` passes.
+
+## Topic migration queue
+
+The queue is dependency-aware. A topic may move earlier when active product
+work changes it, but the implementing task must still satisfy the per-topic
+acceptance criteria.
+
+### Priority A: orientation and Work decomposition
+
+- `agents.md`
+- `authoring-factories.md`
+- `batch-inputs.md`
+- `relationships.md`
+- `work.md`
+- `guards.md`
+
+### Priority B: execution and operation
+
+- `run.md`
+- `sessions.md`
+- `operations.md`
+- `record-replay.md`
+- `mock-workers.md`
+- `factory-validation.md`
+
+### Priority C: Factory components
+
+- `config.md`
+- `workstations.md`
+- `workers.md`
+- `resources.md`
+- `templates.md`
+- `authoring-agents-md.md`
+
+### Priority D: providers and integrations
+
+- `providers.md`
+- `models.md`
+- `mcp.md`
+- `serve-acp.md`
+- `javascript-workflows.md`
+- `orchestrators.md`
+
+### Priority E: catalogs and supporting reference
+
+- `packaged-factories.md`
+- `references.md`
+- `harnesses.md`
+- `the-zen-of-flow.md`
+- `README.md`
+
+Before implementation, confirm whether topics not currently listed in the
+packaged index are intentional public topics, maintainer-only pages, or stale
+content. Do not silently package or delete them as part of prose rewriting.
+
+## CLI family migration procedure
+
+For each command-family task:
+
+1. Capture the current public command tree, help, examples, flags, and required
+   facts.
+2. Identify the customer task and canonical detailed topic.
+3. Rewrite authored fields in `contracts/cli/commands.json`.
+4. Update only the minimum handwritten help that cannot be projected from the
+   manifest.
+5. Run `make cli-manifest-generate`.
+6. Review generated changes but do not edit them directly.
+7. Update behavioral goldens only after the new output passes subject-matter
+   and language review.
+8. Run CLI manifest, contract, focused behavior, prose, and documentation
+   checks.
+9. Remove only the corrected baseline entries.
+
+## Documentation migration procedure
+
+For each topic task:
+
+1. Record the audience, customer task, canonical concept owner, and required
+   facts.
+2. Capture runnable examples and current verification commands.
+3. Reorder content into the accepted topic pattern before sentence-level
+   rewriting.
+4. Rewrite one bounded section at a time without changing code or schema
+   literals.
+5. Validate examples through existing contracts or focused smoke fixtures.
+6. Run the prose checker and remove corrected baseline entries.
+7. Obtain language and subject-matter review.
+
+## Verification
+
+- Prose check for every changed canonical source.
+- `make docs-reference-smoke` for packaged topics.
+- `make cli-manifest-generate` and `make cli-manifest-check` for command help.
+- `make cli-contract-smoke` for CLI contract behavior.
+- Focused Cobra/root help and signature-aware help tests.
+- Focused `root.BuildProcess` functional tests for high-value customer journeys.
+- Contract validation for JSON/YAML examples.
+- Pre-change and post-change customer task study.
+- `make verify-fast`, `make lint`, and applicable PR verification before merge.
+
+## Project-level acceptance criteria
+
+- Every visible command family and packaged topic in scope has zero automated
+  findings and recorded manual review.
+- Root help and `you docs agents` route customers to start, submit, decompose,
+  verify, and find detailed help.
+- Independent, `DEPENDS_ON`, and `PARENT_CHILD` decomposition examples validate
+  against the shipped Work Request contract.
+- No migration changes JSON/NDJSON shape, exit codes, command names, flags,
+  compatibility aliases, or runtime behavior without separate approval.
+- All generated CLI artifacts are current.
+- The CLI/reference portion of the temporary baseline is empty.
+- The post-change customer task study meets the program targets.
+- Required CI is terminal and passing, all blocking review feedback is
+  addressed, conflicts are resolved, and each PR is merged.
+
+## Work-story task packets
+
+### Task packet: root orientation
+
+# problem statement
+
+Root help leads with internal implementation terminology and does not give the
+shortest goal-to-command route for common customer tasks.
+
+## customer ask
+
+Let a new customer select how to start, submit, inspect, or open detailed help
+from the first CLI screen.
+
+## solution
+
+Rewrite root and docs command help with customer-facing Factory vocabulary and
+align the top of the packaged agent-orientation guide to the same router.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\cli-and-reference-prose-migration.md`
+
+# changes
+
+## package changes
+
+- Update `you` and `you.docs` authored records in
+  `contracts/cli/commands.json`.
+- Update the orientation and topic-router sections of
+  `docs/reference/agents.md`.
+- Regenerate CLI family projections and update reviewed root help fixtures.
+
+## contracts
+
+- Preserve command identity, flags, aliases, exits, and output-channel policy.
+
+## services
+
+- None.
+
+## API changes
+
+- None.
+
+## tests
+
+- Update root help behavior/golden tests, CLI manifest checks, prose checks,
+  and packaged docs smoke.
+
+### Task packet: Work decomposition
+
+# problem statement
+
+Customers must assemble guidance from several topics to choose between
+independent, dependency-ordered, and parent-child Work.
+
+## customer ask
+
+Create a valid decomposition and submit it without guessing relationship
+semantics or retry behavior.
+
+## solution
+
+Add one decision path and three minimal validated batch examples across the
+canonical agent, batch-input, relationship, and submit-batch surfaces.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\cli-and-reference-prose-migration.md`
+
+# changes
+
+## package changes
+
+- Update bounded sections in `docs/reference/agents.md`,
+  `docs/reference/batch-inputs.md`, and `docs/reference/relationships.md`.
+- Update `you submit batch` authored help in `contracts/cli/commands.json`.
+- Regenerate affected CLI family artifacts.
+
+## contracts
+
+- Preserve `FACTORY_REQUEST_BATCH`, `requestId`, Work fields, and relationship
+  semantics.
+
+## services
+
+- None.
+
+## API changes
+
+- None.
+
+## tests
+
+- Validate all three example shapes, run CLI manifest/prose/docs checks, and
+  add or update one public batch-submit smoke path.
+
+### Task packet: submit and verify
+
+# problem statement
+
+Customers can confuse startup Work, unary submission, batch upsert, watched
+files, and API ingress, which can cause failed targeting or duplicate Work.
+
+## customer ask
+
+Choose the correct CLI ingress, target one Factory Session, and verify the
+accepted Work.
+
+## solution
+
+Align submit command help and the canonical Work/session documentation around
+one unary-versus-batch decision and one submit-to-verify loop.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\cli-and-reference-prose-migration.md`
+
+# changes
+
+## package changes
+
+- Update `you.submit`, `you.submit.batch`, and relevant Work command help.
+- Update bounded submission and routing sections in `agents.md`, `work.md`, and
+  `sessions.md`.
+- Regenerate CLI family artifacts.
+
+## contracts
+
+- Preserve unary duplicate behavior, batch idempotency, server/session routing,
+  human output facts, and JSON output shape.
+
+## services
+
+- None unless a separately discovered documentation defect requires an
+  approved runtime behavior fix.
+
+## API changes
+
+- None.
+
+## tests
+
+- Update CLI help/contract tests and add one `root.BuildProcess`
+  submit-and-verify functional scenario using public CLI observations.
+
+### Task packet: one command-family migration
+
+# problem statement
+
+One visible command family does not conform to the accepted customer-writing
+standard or route customers to its canonical detailed guide.
+
+## customer ask
+
+Understand and use the selected command family without reading unrelated
+implementation details.
+
+## solution
+
+Rewrite the selected family as one customer-behavior slice, regenerate its
+derived artifacts, and prove help and runtime contracts remain aligned.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\cli-and-reference-prose-migration.md`
+
+# changes
+
+## package changes
+
+- Update only the selected authored command-family records and directly owned
+  handwritten help.
+- Update the directly owned topic when routing facts must change.
+- Regenerate CLI family projections.
+
+## contracts
+
+- Preserve command identity, inputs, aliases, channels, exits, and generated
+  manifest shape.
+
+## services
+
+- None.
+
+## API changes
+
+- None.
+
+## tests
+
+- Run family-focused help tests, CLI manifest/contract checks, prose checks,
+  and the owned topic smoke tests.
+
+### Task packet: one packaged-topic migration
+
+# problem statement
+
+One packaged topic does not let customers complete its owned task through
+clear, progressively disclosed instructions.
+
+## customer ask
+
+Use the topic to complete one defined task and verify the result without
+searching overlapping guides.
+
+## solution
+
+Restructure and rewrite one topic or one bounded large-topic section, validate
+its examples, and remove its corrected prose baseline findings.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\cli-and-reference-prose-migration.md`
+
+# changes
+
+## package changes
+
+- Update one canonical `docs/reference` topic or one approximately 2,000-word
+  section.
+- Update the topic index only when ownership or routing changes.
+
+## contracts
+
+- Preserve literal commands, configuration fields, schemas, routes, and
+  customer-visible behavior.
+
+## services
+
+- None.
+
+## API changes
+
+- None.
+
+## tests
+
+- Validate runnable examples, run prose and docs-reference smoke checks, and
+  update focused documentation assertions only when required facts change.

--- a/docs/internal/development/plans/cli-command-shape-standardization.md
+++ b/docs/internal/development/plans/cli-command-shape-standardization.md
@@ -1,0 +1,578 @@
+# CLI Command Shape Standardization Plan
+
+## Status
+
+Proposed. This is a breaking public CLI contract migration. The repository is
+currently its own primary consumer, so the plan deliberately prefers one
+coherent command tree over compatibility aliases.
+
+## Problem statement
+
+The CLI has a strong manifest and drift-detection system, but it does not have
+an enforced command-language standard. As a result, individually reasonable
+commands have accumulated into an inconsistent whole:
+
+- protocol hosts use both `you serve acp` and `you mcp serve`, while the HTTP
+  host is the preferred noun command `you server`;
+- resource families mix singular (`factory`, `session`, `work`) and plural
+  (`models`, `providers`, `workers`, `worker-sessions`) names;
+- `session dispatches` exposes a low-value dispatch inventory without a useful
+  customer workflow and should not survive the breaking cleanup;
+- provider configuration is exposed under `workers acp`, despite Providers
+  owning provider identity, configuration, protocol, and adapter choice.
+
+The existing CLI contract protects whatever shape is authored, but it cannot
+say whether that shape is coherent. New commands can therefore pass contract
+checks while widening the vocabulary and hierarchy drift.
+
+## Customer ask
+
+Give the `you` CLI one predictable grammar so a customer can infer a command
+without memorizing family-specific exceptions. Breaking changes are accepted;
+do not preserve old paths merely because they already exist.
+
+## Intended outcome
+
+A customer can predict that:
+
+1. resource management uses the agreed public family noun, including singular
+   `worker-session`;
+2. workflow commands use one documented action family and consistent variants;
+3. bare `you server` keeps its HTTP/dashboard behavior and protocol hosts use
+   the predictable `you server acp|mcp` variants;
+4. established `init`, `factory`, and `session` command paths stay stable
+   except for `factory query` and the explicit removal of
+   `session dispatches`;
+5. existing arguments, flags, shorthands, defaults, and precedence remain
+   stable while command paths change; and
+6. the authored CLI manifest fails verification when a new command violates
+   these rules.
+
+## Governing sources
+
+- `docs/internal/standards/code/planning-standards.md` governs the shape and
+  delivery requirements of this plan.
+- `docs/internal/standards/code/code-review-standards.md` and
+  `docs/internal/standards/code/general-backend-standards.md` govern
+  implementation, public-contract proof, generated artifacts, and functional
+  testing.
+- `docs/architecture/data-model.md` owns public resource vocabulary.
+- `docs/architecture/architecture.md` and
+  `docs/architecture/packaged-structure.md` own service and transport
+  boundaries.
+- `contracts/cli/commands.json` remains the authored public CLI contract.
+- `docs/internal/development/plans/cli-and-reference-prose-migration.md`
+  remains the prose migration plan. It should consume the final command names
+  from this plan rather than independently renaming commands.
+
+## Audit scope and method
+
+The audit inspected the authored manifest, executable command-tree baseline,
+root help baseline, generated family declarations, compatibility ledgers,
+command construction and handler registration, packaged reference topics,
+functional scenario contracts, and the CLI-related Make targets.
+
+The current authored manifest contains 54 commands: 42 runnable commands and
+12 non-runnable grouping commands. It has no command aliases, no deprecated
+command records, and empty compatibility ledgers.
+
+This is a command-path, noun, verb, and help-vocabulary audit. Argument and flag
+renames, input remapping, output-mode changes, and runtime/API feature changes
+are explicitly out of scope.
+
+## Audit findings
+
+| Priority | Finding | Evidence | Required correction |
+| --- | --- | --- | --- |
+| P0 | Hosting has no single grammar. | `you server`, `you serve acp`, and `you mcp serve` represent peer long-running hosts. | Keep bare `you server` as the HTTP/dashboard host and place protocol variants at `you server acp|mcp`. |
+| P0 | Resource ownership is misleading. | `you workers acp add|delete` manages Provider integrations and calls Providers-owned behavior. | Move configuration to the singular `provider` family and remove the duplicate `workers` catalog. |
+| P1 | Family nouns are not systematic. | `factory`, `session`, and `work` coexist with `models`, `providers`, `workers`, and `worker-sessions`. | Use the singular `worker-session`, `provider`, and `model` families selected by the breaking map. |
+| P1 | Dispatch inventory has no useful customer job. | `you session dispatches <session-id>` exposes durable dispatch records but is not needed for the retained Session or Worker Session inspection workflows. | Remove the command without a successor. |
+| P1 | Current Factory inspection uses a generic read verb. | `you factory query` shows the Current Factory. | Rename only that leaf to `you factory show`, preserving output, failures, and inputs. |
+| P1 | Local rendering uses a broad verb without changing resource ownership. | `work visualize` reads a local batch and renders Mermaid; it does not inspect or mutate live Work. | Keep the behavior in `work`, rename the operation to `render`, and make its local-only behavior explicit. |
+| P2 | The contract checker enforces equality, not style. | The manifest, generated families, and Cobra tree can agree on an inconsistent new command. | Add a pure CLI-style evaluator and run it from `cli-manifest-check` and `cli-contract-smoke`. |
+| P2 | Public help still contains non-canonical language. | Root help defines the product as CPN-based and command titles vary in capitalization of Factory terms. | Apply canonical public vocabulary while each family moves; do not create a second prose-only rename. |
+
+## Target CLI language standard
+
+### 1. Command shapes
+
+Every public command must use one of these shapes:
+
+```text
+you <workflow> [variant] [operand] [flags]
+you <resource> <verb> [operand] [flags]
+you <resource> <subresource> <verb> [operand] [flags]
+```
+
+The approved top-level workflow families are `docs`, `run`, and `submit`.
+`server` is the one approved runnable host family: bare `you server` hosts the
+HTTP API/dashboard and its `acp` and `mcp` children host protocol variants. A
+new workflow or runnable noun family requires an explicit update to the CLI
+style policy; it must not be introduced as an undocumented exception.
+
+Resource and subresource tokens are lowercase kebab-case. New family names are
+singular unless the target tree records an explicit exception. The approved
+root resource families for this migration are `config`, `factory`, `model`,
+`provider`, `session`, `work`, `worker-session`, and the established root
+`init` command.
+
+### 2. Verb lexicon
+
+| Verb | Meaning | Do not substitute |
+| --- | --- | --- |
+| `list` | Return a collection, optionally filtered. | `query`, a plural collection noun |
+| `show` | Return one resource in families that already use or explicitly migrate to `show`. | New unreviewed synonyms |
+| `create` | Run an established resource or Factory Session creation operation. | New synonyms without an explicit decision |
+| `update` | Replace or modify an existing persisted resource. | `set`, `edit` |
+| `delete` | Run an established resource or Factory Session deletion operation. | New synonyms without an explicit decision |
+| `pause` / `resume` | Change a pausable runtime's lifecycle. | `stop` / `start` |
+| `add` | Add a member or integration where replacement semantics are explicit. | `create` when duplicate creation must fail |
+| `move` | Move Work to an authored state. | `update`, `transition` |
+| `render` | Convert a local source document to a presentation format without mutating runtime state. | `visualize`, `show` |
+| `validate`, `flatten`, `expand`, `invoke`, `pull`, `read`, `stream`, `replace-current` | Established domain operations retained on their existing families. | New synonyms without an explicit plan decision |
+
+### 3. Server grammar
+
+`server` is a runnable noun family. The bare command keeps the established HTTP
+API/dashboard behavior; child tokens select protocol hosts:
+
+```text
+you server
+you server acp
+you server mcp
+```
+
+Each command must state transport, process lifetime, stdout/stderr policy, and
+shutdown behavior. Bare `server` owns the Factory API and embedded dashboard
+listener; ACP and MCP remain stdio unless their contracts explicitly add
+another transport. `server` is an intentional command-language exception and
+must not be generalized into noun-only operations in other families.
+
+### 4. Input stability boundary
+
+This migration changes command paths, removes `session dispatches`, and updates
+help vocabulary. It preserves the current public input contract of every
+retained command:
+
+- root-global `--server` remains the shared server address input with its
+  current client and host behavior;
+- root-global `--json` remains the shared structured-output switch and is
+  inherited through commands that expose supported JSON behavior;
+- `--session` remains the preferred Factory Session input name;
+- Factory-root `--dir` remains unchanged;
+- all `run` argument and flag names, shorthands, defaults, conflicts, and
+  precedence remain unchanged;
+- all model invocation inputs, including `model invoke --output`, remain
+  unchanged;
+- Worker Session commands retain `--work-id`, `--provider`, `--kind`, `--id`,
+  `--output`, `--follow`, and `--replay-only` as applicable;
+- Provider integration and Work submission inputs retain their current names
+  and resolution behavior; and
+- hidden compatibility inputs and existing `--port` behavior are not removed
+  or redesigned by this project.
+
+Renaming a command updates stable command and handler identifiers as required,
+but it must not opportunistically rename an argument or flag. A separate plan
+and explicit approval are required for any future input-contract migration.
+
+### 5. Help and public vocabulary
+
+- Titles begin with the approved verb and name the canonical public resource.
+- Help describes customer-visible behavior before composition or package
+  details.
+- `Factory`, `Factory Session`, `Current Factory`, `Work`, `Work Request`,
+  `Worker Session`, and `Provider Session` follow
+  `docs/architecture/data-model.md`.
+- Public root help must not define the product through CPN, token, place,
+  transition, or marking terminology.
+- Every renamed command gives one shortest invocation and one verification or
+  follow-up command in its owned help or packaged topic.
+
+## Target command tree
+
+The target below is the complete naming decision for current public behavior.
+It is not permission to add unrelated resource operations.
+
+```text
+you
+├── config
+├── docs
+├── factory
+│   ├── create
+│   ├── delete
+│   ├── list
+│   ├── show
+│   ├── replace-current
+│   ├── update
+│   └── config
+│       ├── validate
+│       ├── flatten
+│       └── expand
+├── init
+├── session
+│   ├── create
+│   ├── delete
+│   ├── list
+│   ├── show
+│   ├── pause
+│   └── resume
+├── work
+│   ├── list
+│   ├── show
+│   ├── move
+│   ├── watch
+│   └── render
+├── worker-session
+│   ├── list
+│   ├── show
+│   ├── read
+│   └── stream
+├── provider
+│   ├── list
+│   ├── add
+│   └── delete
+├── model
+│   ├── list
+│   ├── show
+│   ├── invoke
+│   └── pull
+├── run
+├── submit
+│   └── batch
+└── server
+    ├── acp
+    └── mcp
+```
+
+`submit batch` uses Cobra's existing runnable-parent pattern: `submit`
+continues to submit one Work item, while `submit batch` upserts a batch-shaped
+Work Request. Its current positional, file, stdin, and inline JSON resolution
+behavior remains unchanged.
+
+`worker-session` retains the four existing `list`, `show`, `read`, and `stream`
+operations. Provider integration configuration still moves to `provider`; it
+does not move into `worker-session`.
+
+## Breaking command map
+
+| Current command | Target command | Disposition |
+| --- | --- | --- |
+| `you init` | unchanged | Preserve the established root initialization command. |
+| `you factory query` | `you factory show` | Use the established single-resource read verb. |
+| every other `you factory ...` command | unchanged | Preserve the rest of the Factory family, including `replace-current`. |
+| `you session create|delete|list|show|pause|resume` | unchanged | Preserve the existing Factory Session family and verbs. |
+| `you session dispatches` | removed | Delete the low-value command without a successor. |
+| `you work visualize` | `you work render` | Keep the behavior under Work and use the precise local transformation verb. |
+| `you worker-sessions list|show|read|stream` | `you worker-session list|show|read|stream` | Singularize the family and preserve all existing operations. |
+| `you workers list` | `you provider list` | Remove the overlapping filtered Provider catalog. |
+| `you workers acp add` | `you provider add` | Move provider configuration to Providers ownership. |
+| `you workers acp delete` | `you provider delete` | Move provider configuration to Providers ownership. |
+| `you providers list` | `you provider list` | Use the singular resource family. |
+| `you models list|invoke|pull` | `you model list|invoke|pull` | Use the singular resource family. |
+| `you models inspect` | `you model show` | Use the canonical single-resource read verb. |
+| `you server` | unchanged | Preserve the preferred bare HTTP/dashboard host. |
+| `you serve acp` | `you server acp` | Join the server family. |
+| `you mcp serve` | `you server mcp` | Join the server family. |
+| `you submit batch` | unchanged | Keep batch submission under the existing workflow family. |
+
+Commands not listed in the map retain their path and input contract. Changed
+families adopt only the command-path, help, and vocabulary rules in this plan.
+
+## Compatibility and release policy
+
+This migration intentionally does not add aliases or hidden executable copies
+of old command paths. Each migrated path is removed from the canonical
+manifest and production tree in the same change that adds its successor.
+
+Before implementation begins, record the complete moves and removals in
+`pkg/transports/cli/baseline/testdata/intentional_changes.md`,
+`contracts/cli/deprecated-commands.json`, and `contracts/cli/deprecated.json`.
+The ledger is planning evidence, not an instruction to keep compatibility
+commands alive.
+
+The release notes must contain the old-to-new command map. Old paths
+must fail as unknown commands after cutover, and tests must prove their absence.
+Generated files are regenerated from canonical sources and are never edited by
+hand.
+
+## Work stories
+
+### Story 1: Contributors receive an enforceable CLI language contract
+
+#### Observable behavior
+
+An authored command with an unapproved plural resource family, unapproved read
+synonym, or unapproved server shape fails the CLI contract check with a
+path-specific correction.
+
+#### Acceptance criteria
+
+- A versioned CLI style policy records workflow families, resource tokens,
+  approved verbs, the server exception, and explicitly allowed domain verbs.
+- A pure evaluator reports deterministic findings for command path and
+  help-vocabulary violations without constructing a second runtime graph.
+- Table-driven tests cover every rule and at least one valid synthetic command
+  for each approved shape.
+- Existing production findings are captured as a temporary, explicit baseline;
+  each later story removes only the findings it fixes.
+- `make cli-manifest-check` and `make cli-contract-smoke` run the evaluator.
+- The evaluator checks authored behavior and metadata, not repository file
+  topology.
+
+### Story 2: Customers find every host under one server family
+
+#### Observable behavior
+
+Customers use bare `you server` for HTTP/dashboard hosting and
+`you server acp|mcp` for protocol hosting, and can infer the peer commands from
+any one host's help.
+
+#### Acceptance criteria
+
+- Bare `you server` retains its existing HTTP API/dashboard behavior.
+- `you serve acp` and `you mcp serve` are absent; `you server acp` and
+  `you server mcp` preserve their behavior.
+- Each surface preserves its existing transport, runtime composition,
+  lifecycle, protocol frames, diagnostics channel, cancellation, and clean
+  shutdown behavior.
+- Bare HTTP hosting and both protocol children preserve their current global,
+  inherited, and local inputs, including root `--server` and `--json` behavior.
+- Root help and the server family give one three-row host router.
+- ACP and MCP stdio smoke tests prove stdout remains protocol-only.
+- HTTP host functional coverage uses `root.BuildProcess` and
+  `Process.Execute`; no second application graph is introduced.
+- Owned reference topics and generated CLI artifacts use only target paths.
+
+### Story 3: Customers retain initialization and use factory show
+
+#### Observable behavior
+
+Customers continue to use root `init` and the existing `factory` family, with
+only `factory query` becoming the clearer `factory show`.
+
+#### Acceptance criteria
+
+- `you init` remains a root command with its current behavior and inputs.
+- `you factory show` preserves the output, typed failures, side effects, and
+  inputs of `you factory query`.
+- `you factory create|delete|list|replace-current|update` remain at their
+  current paths.
+- `you factory config validate|flatten|expand` remain at their current paths.
+- Factory commands preserve their existing arguments, `--dir`, `--from`,
+  `--server`, `--session`, `--json`, and compatibility inputs as applicable.
+- Focused unit, HTTP mapping, CLI contract, and `root.BuildProcess` behavior
+  tests prove these paths did not drift.
+
+### Story 4: Customers no longer see the unused dispatch inventory
+
+#### Observable behavior
+
+Customers retain the established Factory Session commands without an unused
+`session dispatches` branch or a replacement under `worker-session`.
+
+#### Acceptance criteria
+
+- `session create|delete|list|show|pause|resume` remain unchanged in the
+  manifest, help, docs, scenarios, generated IDs, constructors, registries,
+  and baselines.
+- `session dispatches` is absent from the authored manifest, generated command
+  families, executable tree, completion, help, docs, scenarios, and baselines.
+- No `worker-session dispatches` successor is introduced.
+- Dispatch services and HTTP/API behavior remain unchanged; this story removes
+  only the public CLI command and its transport wiring.
+- Focused CLI absence tests prove the retired path is unknown while ordinary
+  Session and Worker Session commands remain functional.
+
+### Story 5: Customers submit and inspect Work and Work Requests without noun drift
+
+#### Observable behavior
+
+Customers use `submit` for one Work item, `submit batch` for a batch-shaped Work
+Request, and `work render` for a local dependency diagram without introducing
+a separate Work Request command family.
+
+#### Acceptance criteria
+
+- Unary submission retains `--name`, `--payload`, `--work-type-name`,
+  `--server`, and `--session` with their current requirements and precedence.
+- `submit batch` retains its current positional, `--file`, stdin, inline JSON,
+  `--dry-run`, `--server`, and `--session` behavior.
+- Work Request submission preserves current dry-run, idempotency, output, and
+  typed failure behavior.
+- `work render` remains read-only, contacts no server, and preserves
+  Mermaid and Markdown-Mermaid formats.
+- Renaming `work visualize` to `work render` preserves its
+  `<batch-file.json>`, `--format`, global flags, outputs, and local-only
+  behavior.
+- The old `work visualize` path is absent; `submit batch` remains canonical.
+- Submission, inspection, watch, and render functional scenarios and packaged
+  docs use target commands.
+
+### Story 6: Customers use the singular worker-session family
+
+#### Observable behavior
+
+Customers use `worker-session list|show|read|stream` under one singular family
+without learning new operations or a new input map.
+
+#### Acceptance criteria
+
+- `worker-session list` preserves required `--work-id` and optional `--session` and
+  `--output` behavior.
+- `worker-session show|read|stream` preserve the
+  existing `--provider`, `--kind`, `--id`, `--session`, and `--output` inputs.
+- `worker-session stream` also preserves `--follow` and `--replay-only`
+  behavior and their current conflict rules.
+- `show`, `read`, and `stream` preserve finite, replay-only, live,
+  terminal, gap, and cancellation behavior as applicable.
+- Root `--json` remains exposed through the normal inherited CLI contract;
+  command-local `--output` behavior remains unchanged.
+- Contract, projection, stream, CLI, and focused functional tests prove the
+  renamed paths without API or service-contract changes.
+
+### Story 7: Customers manage Providers and Models under their owning resources
+
+#### Observable behavior
+
+Customers use singular `provider` and `model` families; provider discovery and
+operator-configured ACP integration management no longer appear under
+`workers`.
+
+#### Acceptance criteria
+
+- `provider list` is the one complete catalog for built-in and
+  operator-configured providers, including availability, source, protocol,
+  and capabilities needed to replace `workers list`.
+- `provider add` preserves `--name`, `--transport`, and `--argument`, including
+  current validation and explicit replacement behavior.
+- `provider delete` preserves required `--name`, cannot delete immutable
+  built-in metadata, and reports the existing typed outcomes.
+- `model show` replaces `models inspect`; list, invoke, and pull behavior is
+  otherwise unchanged.
+- `model invoke` and every one of its existing inputs remain unchanged.
+- No Provider integration configuration remains under `worker-session`; that
+  family remains reserved for Worker Session inspection.
+- Provider/Model CLI service tests, generated manifests, docs, and relevant
+  functional scenarios pass.
+
+### Story 8: Every renamed command preserves the established input contract
+
+#### Observable behavior
+
+Customers can adopt the standardized command paths without relearning flags,
+arguments, shorthands, defaults, input precedence, or output selection.
+
+#### Acceptance criteria
+
+- Root-global `--server` remains unchanged across client and host behavior.
+- Root-global `--json` remains exposed through the inherited CLI contract and
+  keeps current command-specific behavior.
+- `--session` remains the preferred Factory Session input name.
+- Factory-root `--dir` remains unchanged.
+- Every `run` input remains byte-for-byte aligned with the pre-migration
+  authored contract, including `--factory`, `--named` / `-a`, and `--output`.
+- Every `model invoke` input remains unchanged.
+- Worker, Provider, Work, submit, and server input maps remain unchanged when
+  their command paths move.
+- Input precedence, environment/config bindings, shell completion, diagnostic
+  channels, exit codes, and sensitive-value handling remain explicit in the
+  authored contract.
+- The production style baseline is empty.
+
+### Story 9: Customers and maintainers see only the standardized CLI
+
+#### Observable behavior
+
+Root help, command help, packaged docs, examples, completion, scenarios, and
+published CLI metadata agree on the target tree, and old commands are absent.
+
+#### Acceptance criteria
+
+- Root help uses canonical Factory vocabulary and contains no unexplained CPN
+  implementation terminology.
+- Every renamed family updates its directly owned `docs/reference` topic and
+  goal-to-command routing.
+- README examples, functional scenario contracts, completion tests, baseline
+  fixtures, published package metadata, and internal active plans that
+  prescribe commands use the target paths.
+- Historical proposals may retain old command literals only when explicitly
+  labeled historical; active guidance must not route customers to them.
+- `rg`-based audit output for each retired path is either empty or contains
+  only an approved historical/migration record.
+- The intentional-change ledger is reconciled with the final executable tree.
+- Documentation smoke, CLI contract checks, generation checks, focused
+  functional tests, `make verify-fast`, `make lint`, and the applicable PR
+  verification tier pass.
+
+## Dependency-aware delivery order
+
+1. Land Story 1 so every subsequent family migration removes style findings.
+2. Land Stories 2 through 7 as vertically sliced family changes. Stories 3
+   through 7 may proceed independently after Story 1.
+3. Apply Story 8 as the whole-tree proof that no argument or flag drifted while
+   command paths moved.
+4. Complete Story 9 after all target paths exist; it is the final whole-tree
+   absence and routing proof, not a substitute for family-owned docs and tests.
+
+Each merged story must leave the canonical manifest, generated family metadata,
+executable tree, and changed documentation internally consistent. Temporary
+style exceptions are allowed only through the explicit migration baseline and
+must name the later story that removes them.
+
+## Verification
+
+Use the narrowest relevant proof in each story, then run the shared contract
+and generated-artifact checks:
+
+- `make cli-manifest-generate`
+- `make cli-manifest-check`
+- `make cli-contract-smoke`
+- focused tests in `pkg/transports/cli/...` and the owning service transport
+- focused `root.BuildProcess` plus `Process.Execute` functional tests for
+  customer-visible cross-boundary behavior
+- `make docs-reference-smoke` for changed packaged topics
+- `make verify-fast`
+- `make lint`
+- `make verify-pr` before merge when the implementation reaches PR scope
+
+Generation commands may update generated CLI artifacts, but implementation
+must review those diffs and must not edit generated files directly.
+
+## Project-level acceptance criteria
+
+- The target command tree is the only visible executable tree.
+- The CLI style evaluator reports zero unbaselined findings, and the temporary
+  production style baseline is empty.
+- All old command paths fail as unknown commands; no alias or hidden
+  compatibility command remains.
+- All current behavior has an explicit target path or an explicit retirement
+  decision in this plan.
+- Public resource names align with `docs/architecture/data-model.md`, and
+  service ownership aligns with the repository package boundaries.
+- CLI, HTTP, MCP, and ACP parity is preserved where shared contracts require
+  it; no service or API contract changes are introduced.
+- Authored manifests, generated families, published CLI metadata, completion,
+  help, docs, scenarios, and behavioral baselines are current.
+- Required CI is terminal and passing, all blocking review feedback is
+  addressed, merge conflicts are resolved, and every implementation PR is
+  actually merged. Opening a PR or reaching green CI without merge is not
+  project completion.
+
+## Out of scope
+
+- Adding new Factory, Work, Worker, Provider, or Model capabilities merely to
+  make every family symmetrical.
+- Changing runtime scheduling, event semantics, replay semantics, or
+  provider/model selection policy.
+- Renaming, removing, relocating, or changing the semantics of any argument,
+  flag, shorthand, default, source binding, precedence rule, or output selector
+  on a retained command.
+- Replacing root `--server` or `--json`, preferred `--session`, Factory-root
+  `--dir`, any `run` input, any `model invoke` input, or the current Worker
+  Session Provider Session identity inputs.
+- Changing OpenAPI, service contracts, or JSON/NDJSON schemas.
+- Rewriting all packaged documentation beyond directly affected command
+  routes and required canonical terminology.
+- Retaining compatibility aliases for hypothetical external consumers.
+- Hand-editing generated artifacts.

--- a/docs/internal/development/plans/customer-prose-clarity-program.md
+++ b/docs/internal/development/plans/customer-prose-clarity-program.md
@@ -1,0 +1,293 @@
+# Customer Prose Clarity Program
+
+## Status
+
+Proposed.
+
+## Problem statement
+
+Customers must read dense, inconsistent CLI help and documentation before they
+can select a command, decompose a goal into Work, or verify the result. The
+repository has canonical CLI and packaged-reference sources, but it has no
+normative customer-writing standard and no quality gate that checks the clarity
+of their prose.
+
+## Customer ask
+
+Make CLI prose and customer documentation clear, consistent, and suitable for
+customers who must quickly:
+
+- understand the purpose of the `you` CLI;
+- choose the correct command for a task;
+- decompose a goal into independent, ordered, or parent-child Work;
+- submit and verify that Work; and
+- move from concise command help to the correct detailed guide.
+
+Use a repository writing standard aligned with ASD-STE100 Simplified Technical
+English. Prevent the prose from returning to its current state after the first
+rewrite.
+
+## Intended outcome
+
+The CLI and its documentation use one customer-facing vocabulary and one
+progressive-disclosure pattern. A customer can start from `you`, select a task,
+run a correct command, and verify its effect without first learning internal
+Petri-net terminology or searching several overlapping guides.
+
+Authors receive an actionable, deterministic conformance report before review.
+Reviewers receive a separate checklist for rules that require linguistic and
+technical judgment. Required CI blocks new violations and the migration removes
+all temporary baseline entries from the accepted public scope.
+
+## Planning basis
+
+This program follows
+`docs/internal/standards/code/planning-standards.md`:
+
+- stories describe customer-visible comprehension and task-completion behavior;
+- enabling stories are limited to the standard and enforcement needed to make
+  that behavior durable;
+- implementation work is divided by customer journey or one bounded document,
+  not by a broad file-type rewrite;
+- acceptance criteria identify direct CLI, documentation, contract, and
+  comprehension evidence; and
+- delivery continues through required CI, blocking review feedback, conflict
+  resolution, and actual PR merge.
+
+## Current-state findings
+
+### Canonical sources
+
+| Surface | Canonical source | Current scale | Existing evidence |
+| --- | --- | ---: | --- |
+| Static CLI command help | `contracts/cli/commands.json` | 54 commands, 301 flag records, 23 argument records, approximately 6,300 prose words | CLI manifest generation/check, CLI contract smoke, root help baselines |
+| Packaged CLI reference | `docs/reference/*.md` | 29 Markdown files, approximately 65,000 words | Markdown structure check, embedding tests, CLI docs smoke |
+| Handwritten or dynamic CLI help | `pkg/transports/cli/**` and service-owned CLI adapters | Bounded exceptions outside the command manifest | Focused command tests and observable-output tests |
+| Human success, warning, and failure prose | CLI transport and service-owned CLI adapters | Distributed | Focused unit, contract, and functional tests |
+| Broader public documentation | Root and public `docs/`, `examples/`, and package guides | Not yet classified | README and specialty smoke checks |
+
+The scale figures are planning snapshots, not permanent inventory assertions.
+The implementation must recalculate them when it establishes the baseline.
+
+### Principal behavior gaps
+
+1. Root help describes a `CPN-based workflow factory`, although public surfaces
+   are required to hide the internal Petri-net implementation.
+2. Long descriptions mix orientation, operation, architecture, and exception
+   details before the customer receives a recommended first action.
+3. Work-decomposition guidance exists across `agents`, `batch-inputs`,
+   `relationships`, `work`, and command help, but the shortest route from a goal
+   to a valid batch is not consistently visible.
+4. Similar concepts use inconsistent capitalization, actor names, and verbs.
+5. The current Markdown checker validates encoding, final newlines, and code
+   fences but does not enforce customer-writing rules.
+6. Existing golden and substring tests can preserve required facts while also
+   preserving unclear sentence structures.
+
+## Standard posture
+
+The repository will initially claim that in-scope prose conforms to the You
+customer technical-writing standard, which is aligned with ASD-STE100 Issue 9.
+It must not make an unqualified ASD-STE100 certification claim unless the
+organization separately establishes the necessary trained review, source
+access, and legal approval.
+
+The standard will use applicable ASD-STE100 principles, including:
+
+- controlled and consistent terminology;
+- short procedural and descriptive sentences;
+- one instruction per procedural sentence;
+- active voice unless a documented descriptive exception applies;
+- gradual presentation of information;
+- one topic per paragraph;
+- bounded paragraph length; and
+- vertical lists for complex information.
+
+The repository will maintain only its product-specific technical terms and
+approved alternatives. It will not copy or redistribute the ASD-STE100
+controlled dictionary without explicit legal approval.
+
+## Scope
+
+### First release scope
+
+- Visible root and subcommand help.
+- Visible flag descriptions and authored help examples.
+- Signature-aware Factory invocation help.
+- Packaged `you docs` topics.
+- Human CLI success, warning, and failure messages touched by a migration
+  story.
+- Root/customer documentation that directly routes customers into the CLI.
+
+### Later public-documentation scope
+
+- Public guides outside `docs/reference/`.
+- Customer-facing example README files.
+- Publishable package README files.
+- Public architecture or concept pages that a customer must read to use the
+  product.
+
+### Out of scope
+
+- Rewriting source comments, test failure strings, internal development plans,
+  or maintainer-only architecture notes merely to increase an inventory count.
+- Changing command names, flags, request schemas, error codes, JSON keys, or
+  runtime behavior unless a separate behavior story approves that change.
+- Replacing the public product vocabulary with ASD aerospace terminology.
+- Treating a readability grade or an automated checker as proof of full
+  controlled-language conformance.
+- Copying the ASD-STE100 dictionary into source control.
+- Combining unrelated documentation corrections, API changes, or runtime
+  refactors with a prose-migration story.
+
+## Workstreams and child plans
+
+| Workstream | Plan | Primary outcome |
+| --- | --- | --- |
+| Normative rules and enforcement | `customer-prose-standard-and-enforcement.md` | Authors receive one standard, terminology register, checker, baseline, and CI gate. |
+| CLI and packaged-reference migration | `cli-and-reference-prose-migration.md` | Customers can discover, decompose, submit, inspect, and operate through concise CLI and packaged help. |
+| Broader public-documentation migration | `public-documentation-prose-migration.md` | Remaining customer documentation moves to the same standard without rewriting internal material. |
+
+## Customer journeys
+
+The program prioritizes these observable journeys:
+
+1. **Discover:** Run `you` and identify the correct next command.
+2. **Start:** Start the Current Factory or an explicitly selected Factory.
+3. **Decompose:** Represent a goal as independent Work, dependency-ordered Work,
+   or parent-child Work.
+4. **Submit:** Choose unary or batch submission and use the correct target.
+5. **Verify:** Confirm that submitted Work exists and inspect its state.
+6. **Operate:** Keep a Factory Session alive, diagnose failure, and recover.
+7. **Author:** Create and validate a Factory without relying on internal runtime
+   vocabulary.
+8. **Select execution:** Choose Workers, Workstations, Providers, Models, and
+   related integrations.
+
+## Program sequencing
+
+### Stage 1: Establish the contract
+
+Approve the customer-writing standard, product terminology register, public
+scope, conformance claim, and manual review checklist. Capture pre-change
+customer task measurements.
+
+### Stage 2: Add enforceable feedback
+
+Implement the prose checker, adapters, fixtures, baseline, and changed-prose
+gate. The checker becomes blocking before broad rewriting begins. Existing
+violations remain visible and cannot increase.
+
+### Stage 3: Correct the highest-value journeys
+
+Rewrite root orientation and the Work decomposition, submission, and
+verification journeys. Remove internal implementation vocabulary. Validate the
+commands and examples through the public CLI boundary.
+
+### Stage 4: Migrate command families and packaged topics
+
+Process one command family or one bounded topic slice at a time. Remove the
+corresponding baseline findings after automated and manual review.
+
+### Stage 5: Expand to broader public documentation
+
+Classify the remaining customer corpus, route duplicate content to canonical
+owners, and migrate it in task-oriented slices.
+
+### Stage 6: Close the baseline and validate comprehension
+
+Remove all temporary baseline entries in the accepted public scope, enable
+full-corpus blocking, rerun the customer task study, and publish maintainer
+guidance for future additions.
+
+## Measurement plan
+
+### Pre-change and post-change task study
+
+Use the same script with at least eight representative readers who did not
+author the affected prose. Give each participant these tasks without coaching:
+
+1. Identify how to start the Current Factory.
+2. Identify how to submit one Work item to a running Factory Session.
+3. Create a three-item batch in which one item depends on another.
+4. Represent one parent Work item with two child Work items.
+5. Identify how to verify a submitted Work item.
+6. Find the guide for Worker or Provider selection.
+
+Record:
+
+- whether the participant selected the correct first command;
+- whether the submitted batch shape and relationships are valid;
+- time to the first correct command;
+- task completion without assistance; and
+- each point at which terminology or routing caused hesitation.
+
+Release targets:
+
+- at least 80 percent of all tasks complete without assistance;
+- at least 90 percent correct first-command selection;
+- median time to the correct first command below 60 seconds; and
+- no repeated critical ambiguity that causes an unsafe, destructive, or
+  duplicate-submission path.
+
+The study is direct evidence for comprehension. Sentence counts and readability
+metrics are supporting evidence only.
+
+### Repository quality measures
+
+- New or changed in-scope prose has zero unbaselined blocking findings.
+- Baseline finding count decreases in every migration PR.
+- Every migrated surface has recorded human language-review evidence.
+- Every runnable example has a smoke test or a documented reason it cannot run
+  in CI.
+- All canonical and generated CLI artifacts remain synchronized.
+
+## Cross-cutting acceptance criteria
+
+- A customer can move from root help to the correct detailed guide without
+  encountering internal Petri-net vocabulary as the primary product model.
+- The decomposition path gives correct independent, `DEPENDS_ON`, and
+  `PARENT_CHILD` examples and identifies the verification command.
+- The normative standard defines procedural and descriptive prose, technical
+  terminology, exclusions, suppression policy, examples, and human-review
+  responsibilities.
+- Automated findings identify an exact source location, stable rule ID,
+  offending text, and a remediation hint.
+- Code fences, inline code, command invocations, API routes, identifiers, JSON
+  and YAML keys, error codes, and proper product names are not corrupted by
+  prose rewriting or false-positive auto-fixes.
+- CLI human prose changes do not change JSON output, exit behavior, flags,
+  request shapes, or compatibility aliases.
+- Generated CLI artifacts are regenerated from canonical sources and are never
+  hand-edited.
+- `docs-reference-smoke`, CLI manifest checks, CLI contract smoke, focused
+  behavior tests, `verify-fast`, and `lint` are terminal and passing where
+  applicable.
+- The accepted public scope has no temporary prose baseline when the program is
+  declared complete.
+- The post-change task study meets the release targets.
+- Required CI is terminal and passing, all blocking review feedback is
+  addressed, merge conflicts are resolved, and every delivery PR is actually
+  merged.
+
+## Risks and controls
+
+| Risk | Control |
+| --- | --- |
+| Simplification changes technical meaning | Require a subject-matter reviewer and preserve contract-focused tests. |
+| A checker is mistaken for full STE conformance | Separate deterministic checks from human language review and constrain the public claim. |
+| The vocabulary rule rejects valid product terms | Maintain a reviewed technical-term register with categories and approved usage. |
+| Code and contract tokens are rewritten | Parse Markdown and manifest structure; exclude code, identifiers, and machine contracts explicitly. |
+| One large rewrite becomes unreviewable | Limit a task to one customer journey, one command family, or approximately 2,000 prose words. |
+| A baseline becomes permanent debt | Require every migration PR to reduce it and make a zero baseline a program acceptance criterion. |
+| Golden tests preserve unclear wording | Test required facts and customer outcomes in addition to selected stable output fixtures. |
+| Documentation duplicates canonical contracts | Identify one concept owner and replace duplicate detail with task-oriented routing. |
+
+## Delivery loop
+
+Each child plan must deliver through focused implementation, generation where
+required, automated and manual review, terminal green CI, resolution of all
+blocking feedback and conflicts, and actual PR merge. Opening a PR, generating
+artifacts, obtaining approval, or reaching green CI without merge is not
+completion.
+

--- a/docs/internal/development/plans/customer-prose-standard-and-enforcement.md
+++ b/docs/internal/development/plans/customer-prose-standard-and-enforcement.md
@@ -1,0 +1,595 @@
+# Customer Prose Standard And Enforcement Plan
+
+## Status
+
+Proposed.
+
+## Problem statement
+
+Authors and reviewers cannot consistently determine whether customer-facing
+CLI and documentation prose is acceptable because the repository has no
+normative writing standard, no product terminology register, and no prose-aware
+quality gate.
+
+## Customer ask
+
+Create a durable writing and enforcement system, aligned with ASD-STE100, that
+makes CLI help and customer documentation easier to understand and prevents new
+prose regressions.
+
+## Intended outcome
+
+An author can run one repository command and receive actionable findings for
+all deterministic rules that apply to changed public prose. A reviewer can use
+one complementary checklist for semantic, vocabulary, and grammatical rules
+that require human judgment. The system protects commands, code, identifiers,
+and public contracts while it evaluates natural-language text.
+
+## Parent plan
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\customer-prose-clarity-program.md`
+
+## External references
+
+- [ASD-STE100 Simplified Technical English, Issue 9](https://www.asd-ste100.org/assets/files/ASD-STE100_ISSUE9.pdf)
+  is the controlled-language reference for the aligned repository profile.
+- [Official ASD-STE100 frequently asked questions](https://www.asd-ste100.org/STE_faq.html)
+  defines the role and limits of software, training, writing rules, and the
+  controlled dictionary.
+
+## Scope
+
+### In scope
+
+- A normative customer technical-writing standard.
+- A reviewed product terminology register.
+- A manual language-review checklist.
+- A deterministic prose-check command.
+- Markdown and CLI-manifest extraction.
+- Plain-text fixture support for observable CLI output.
+- A temporary, ratcheting baseline for existing violations.
+- Local Make targets and required CI integration.
+- Unit, fixture, integration, and drift tests.
+
+### Out of scope
+
+- Rewriting the current customer corpus in this plan.
+- Adding a network dependency to normal generation, tests, or CLI execution.
+- Redistributing the ASD-STE100 controlled dictionary.
+- Claiming that a checker certifies ASD-STE100 compliance.
+- Introducing a new product service, runtime dependency, or `pkg/wire`
+  construction path for a repository maintenance command.
+- Auto-rewriting prose in the first implementation.
+
+## Canonical ownership
+
+| Concern | Canonical owner | Notes |
+| --- | --- | --- |
+| Normative writing policy | `docs/internal/standards/writing/customer-technical-writing-standard.md` | Added to `docs/internal/standards/STANDARDS.md`. |
+| Product vocabulary | `docs/internal/standards/writing/customer-technical-terms.yaml` | Product-specific terms and approved alternatives only. |
+| Automated rule implementation | `cmd/prosecheck/` | Repository maintenance command with pure, directly tested analysis. |
+| Existing-debt baseline | `docs/internal/baselines/customer-prose.json` | Temporary exact-finding baseline; deletion-only after acceptance. |
+| CLI help source | `contracts/cli/commands.json` | Generated family projections remain derived. |
+| Packaged documentation source | `docs/reference/*.md` | Embedded by the existing docs path. |
+| CI entry points | `Makefile` and existing CI workflows | No second hidden enforcement path. |
+
+## Normative writing profile
+
+The standard must define at least these content classes.
+
+### Labels
+
+Labels include headings, table headers, command titles, and field names. They
+must be concise and use approved terminology. They are not required to form a
+complete sentence.
+
+### Procedural prose
+
+Procedural prose tells the customer to do a task. It must:
+
+- use no more than 20 words in a sentence;
+- contain one instruction per sentence unless actions must occur at the same
+  time;
+- use an imperative verb for the instruction;
+- put a necessary condition before the instruction;
+- identify the expected observable result; and
+- use an ordered or vertical list when sequence matters.
+
+### Descriptive prose
+
+Descriptive prose explains a concept, state, or result. It must:
+
+- use no more than 25 words in a sentence;
+- introduce information gradually;
+- keep one topic in each paragraph;
+- use no more than six sentences in a paragraph;
+- prefer active voice; and
+- use stable key words and phrases to connect related information.
+
+### Machine and technical text
+
+The standard must explicitly distinguish natural-language prose from:
+
+- code fences and inline code;
+- command invocations and shell operators;
+- JSON and YAML keys or values that are contract examples;
+- API methods and routes;
+- file paths, URLs, package paths, and identifiers;
+- schema, event, status, and error-code literals;
+- model and provider names;
+- quoted external output; and
+- generated artifacts.
+
+These elements are protected during analysis. Natural-language comments inside
+examples remain reviewable when the extractor can identify them safely.
+
+## Product terminology register
+
+Each term record should include:
+
+- canonical spelling and capitalization;
+- public definition;
+- category such as product term, technical noun, technical verb, acronym,
+  command, or protected literal;
+- approved plural or verb form where applicable;
+- discouraged or prohibited alternatives;
+- customer-facing usage example;
+- surfaces where the term is valid; and
+- owning architecture or contract reference.
+
+The initial register must cover at least:
+
+- Factory;
+- Factory Session;
+- Current Factory;
+- Work;
+- Work Request;
+- Worker;
+- Worker Session;
+- Workstation;
+- Provider;
+- Provider Session;
+- Model;
+- Recording;
+- Factory Event; and
+- customer-visible relationship and lifecycle names.
+
+It must also identify internal terms such as `CPN`, place, transition, marking,
+and token. Public prose may use these terms only in an explicitly internal or
+implementation-focused context.
+
+## Automated rule boundary
+
+### Blocking rules
+
+The first release must enforce deterministic rules for:
+
+- procedural sentence length;
+- descriptive sentence length;
+- descriptive paragraph length;
+- prohibited semicolons in natural-language prose;
+- contractions;
+- prohibited public terminology and approved replacements;
+- canonical product capitalization;
+- malformed or unknown suppression directives;
+- stale baseline findings;
+- new findings not present in the baseline; and
+- parse failures that would cause prose to be silently skipped.
+
+### Advisory rules
+
+Rules with acceptable false positives may report warnings but must not alone
+claim conformance:
+
+- probable passive voice;
+- multiple probable imperative actions in one sentence;
+- repeated vague pronouns;
+- nominalizations;
+- unregistered candidate technical terms; and
+- unusually dense headings, lists, or table cells.
+
+### Human-review rules
+
+A language and subject-matter reviewer must confirm:
+
+- vocabulary is approved or valid as a technical noun or technical verb;
+- each approved word uses the intended meaning and part of speech;
+- each sentence communicates one subject or instruction;
+- passive voice has a valid descriptive reason;
+- paragraphs introduce one topic in logical order;
+- simplification preserves technical and contract meaning;
+- examples match the shipped CLI and public schemas; and
+- warnings, destructive instructions, and failure recovery remain precise.
+
+## Extraction and classification
+
+The checker must parse structure instead of scanning raw text blindly.
+
+### Markdown adapter
+
+The adapter must emit source spans for headings, paragraphs, list items,
+admonitions, table cells, and natural-language comments. It must preserve file
+and line locations and exclude protected technical text.
+
+Classification must be deterministic. The implementation must use explicit
+document/block metadata or structural rules defined by the standard. It must
+not make a blocking procedural-versus-descriptive decision from an opaque
+language-model or probabilistic heuristic.
+
+### CLI-manifest adapter
+
+The adapter must inspect authored fields in `contracts/cli/commands.json`,
+including:
+
+- command titles;
+- command descriptions;
+- visible flag usage;
+- authored example comments; and
+- natural-language deprecation or replacement guidance.
+
+Commands and literal example lines are protected. The adapter must report the
+command ID and JSON source location with each finding.
+
+### Observable-output fixture adapter
+
+The adapter may inspect selected human-readable golden or baseline fixtures
+when those fixtures are the canonical evidence for runtime CLI output. It must
+not treat machine-readable JSON or NDJSON output as prose.
+
+Direct runtime messages that are not in an extractable canonical source remain
+subject to manual review and focused behavior tests until a later plan approves
+a safe centralization strategy.
+
+## Finding contract
+
+Each finding must contain:
+
+- stable rule ID;
+- severity;
+- source path;
+- start line and, when known, column;
+- content class;
+- bounded offending excerpt;
+- remediation guidance; and
+- stable normalized fingerprint for baseline comparison.
+
+Default terminal output must be concise and deterministic. A machine-readable
+JSON mode may be added for CI, but it must not be required for an author to
+understand a failure.
+
+## Baseline policy
+
+The initial audit will create exact fingerprints for accepted pre-existing
+findings. The baseline must:
+
+- contain no wildcard, file-wide, or directory-wide suppressions;
+- fail when an entry is stale;
+- fail when a changed excerpt no longer matches its fingerprint;
+- fail on every new finding;
+- permit only deletion during ordinary migration;
+- require a reason, owner, and expiry for any exceptional addition; and
+- reach zero for the accepted public scope before program completion.
+
+Moving a violation or replacing it with another violation is not baseline
+reduction.
+
+## Suppression policy
+
+Suppressions are for valid technical exceptions, not readability debt. A
+suppression must name one rule, one bounded source span, and a reason. Unknown,
+unbounded, nested, or stale suppressions fail the check. Generated files must
+be excluded through source classification, not repeated inline suppressions.
+
+## Work stories
+
+### Story 1: Authors can apply one normative writing contract
+
+#### Observable behavior
+
+An author can determine how to write a command description, procedure,
+explanation, product term, code example, and exception without relying on chat
+history or reviewer preference.
+
+#### Acceptance criteria
+
+- The standard is indexed from `docs/internal/standards/STANDARDS.md`.
+- It defines labels, procedures, descriptions, machine text, technical terms,
+  automated rules, human-review rules, and suppression policy.
+- It states the approved conformance claim and the conditions required before
+  a stronger ASD-STE100 claim.
+- It includes repository-specific good and bad examples.
+- The terminology register validates as structured data and covers the initial
+  public nouns.
+- Architecture/data-model owners review the terminology definitions.
+
+### Story 2: Maintainers receive exact findings for Markdown prose
+
+#### Observable behavior
+
+Running the prose check on a Markdown file returns deterministic file-and-line
+findings while leaving code, commands, identifiers, and schemas untouched.
+
+#### Acceptance criteria
+
+- Valid Markdown prose produces no findings.
+- Each supported violation produces the expected stable rule ID and source
+  span.
+- Fenced code, inline code, URLs, paths, JSON/YAML examples, and protected terms
+  have direct false-positive fixtures.
+- Mixed procedural and descriptive content is classified through documented,
+  deterministic metadata or structure.
+- Parse failures are blocking and identify the file.
+- Unit and fixture tests cover Windows and Unix line endings.
+
+### Story 3: Maintainers receive exact findings for CLI help
+
+#### Observable behavior
+
+Running the prose check on the authored CLI manifest identifies unclear command
+and flag help by stable command or input ID without inspecting generated Go.
+
+#### Acceptance criteria
+
+- All visible authored command titles, descriptions, flag usage, and example
+  comments are inspected.
+- Literal commands, placeholders, flags, URLs, routes, error codes, and default
+  values remain protected.
+- Findings include the stable command/input ID and canonical JSON location.
+- Hidden compatibility records follow an explicitly documented scope rule.
+- Generated CLI files are not authoring inputs.
+- CLI-manifest fixture tests cover valid, invalid, and excluded values.
+
+### Story 4: Existing debt cannot grow
+
+#### Observable behavior
+
+A contributor can change compliant prose normally, but CI rejects every new or
+moved violation and every stale baseline entry.
+
+#### Acceptance criteria
+
+- The initial full-scope report is reproducible.
+- The baseline records exact normalized findings rather than aggregate counts.
+- A new violation, changed violating excerpt, moved violation, stale entry, and
+  expired exception each have a failing test.
+- Deleting or correcting an existing violation requires deleting its stale
+  baseline entry.
+- The baseline report shows remaining findings by surface and rule.
+
+### Story 5: Required checks run through standard repository entry points
+
+#### Observable behavior
+
+Authors and CI use documented Make targets to check changed prose and the full
+accepted scope.
+
+#### Acceptance criteria
+
+- Focused and full-scope Make targets are documented.
+- The appropriate required lint or verification lane invokes the blocking
+  check.
+- `docs-reference-check` and CLI-manifest workflows remain authoritative for
+  their existing structural and generation responsibilities.
+- The prose checker does not access the network.
+- Check output is deterministic across repeated runs.
+- The command and package comply with backend complexity and test standards.
+
+## Verification
+
+- Unit tests for tokenization, sentence/paragraph counting, terminology,
+  classification, fingerprints, and suppressions.
+- Table-driven fixtures for Markdown and CLI-manifest extraction.
+- Integration tests for baseline comparison and repository configuration.
+- `go test ./cmd/prosecheck/...` or the final focused package equivalent.
+- `make docs-reference-smoke` after standard examples or packaged fixtures are
+  introduced.
+- `make cli-manifest-check` and `make cli-contract-smoke` for manifest adapter
+  fixtures that use production contracts.
+- `make verify-fast` and `make lint` before review.
+
+## Project-level acceptance criteria
+
+- The normative writing standard and terminology register are merged and
+  discoverable from the standards index.
+- Deterministic rules are enforced against Markdown and the authored CLI
+  manifest with direct false-positive coverage.
+- Human-only rules are not presented as mechanically certified.
+- Existing findings are captured by exact temporary baseline entries, and no
+  new violation can enter required CI.
+- The checker has no runtime product dependency, network dependency, hidden
+  global state, or generated authoring source.
+- Required focused tests, `verify-fast`, and `lint` are terminal and passing.
+- Delivery continues through blocking feedback, conflict resolution, terminal
+  green CI, and actual PR merge.
+
+## Work-story task packets
+
+Each packet below is an independently reviewable task. An implementation may
+split a packet further but must not combine it with unrelated cleanup.
+
+### Task packet: normative customer-writing standard
+
+# problem statement
+
+Authors and reviewers have no normative rule set for customer-facing CLI and
+documentation prose.
+
+## customer ask
+
+Define clear writing and product terminology rules aligned with ASD-STE100 so
+customers can understand commands and technical documentation quickly.
+
+## solution
+
+Add an indexed customer technical-writing standard, structured product-term
+register, and manual review checklist with explicit scope and conformance
+language.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\customer-prose-standard-and-enforcement.md`
+
+# changes
+
+## package changes
+
+- Add `docs/internal/standards/writing/customer-technical-writing-standard.md`.
+- Add `docs/internal/standards/writing/customer-technical-terms.yaml`.
+- Update `docs/internal/standards/STANDARDS.md`.
+
+## contracts
+
+- Define content classes, deterministic rules, human-review rules, protected
+  technical text, terminology records, and suppression policy.
+
+## services
+
+- None.
+
+## API changes
+
+- None.
+
+## tests
+
+- Validate the structured terminology register and all referenced standard
+  examples.
+
+### Task packet: Markdown prose analysis
+
+# problem statement
+
+The current Markdown linter cannot detect customer-writing violations or
+distinguish prose from protected technical text.
+
+## customer ask
+
+Give authors exact, trustworthy findings for customer-facing Markdown before
+review.
+
+## solution
+
+Implement a deterministic Markdown prose analyzer with source spans, content
+classification, protected-text handling, and focused rule tests.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\customer-prose-standard-and-enforcement.md`
+
+# changes
+
+## package changes
+
+- Add the focused `cmd/prosecheck` maintenance command and pure analyzer files.
+- Load the normative repository configuration and terminology register.
+
+## contracts
+
+- Define the finding, severity, content-class, source-span, and rule-ID values.
+
+## services
+
+- None. This is deterministic repository tooling, not a product service.
+
+## API changes
+
+- None.
+
+## tests
+
+- Add unit and Markdown fixture tests for every blocking rule and protected-text
+  class.
+
+### Task packet: CLI-manifest prose analysis
+
+# problem statement
+
+The canonical CLI manifest can preserve unclear command and flag help because
+its current checks validate contract shape rather than writing quality.
+
+## customer ask
+
+Report customer-writing violations from the authored CLI source without
+checking or editing generated projections.
+
+## solution
+
+Add a CLI-manifest adapter that extracts authored natural language, preserves
+stable command/input identity, and excludes literal command syntax.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\customer-prose-standard-and-enforcement.md`
+
+# changes
+
+## package changes
+
+- Extend `cmd/prosecheck` with canonical CLI-manifest extraction.
+- Reuse existing CLI contract loading where it does not introduce runtime
+  dependencies or duplicate validation policy.
+
+## contracts
+
+- Map findings to stable command, flag, argument, and documentation IDs.
+
+## services
+
+- None.
+
+## API changes
+
+- None.
+
+## tests
+
+- Add valid, invalid, protected-literal, hidden-record, and deterministic-order
+  manifest fixtures.
+
+### Task packet: prose baseline and CI gate
+
+# problem statement
+
+Blocking the complete existing corpus immediately would prevent ordinary work,
+while a non-blocking report would allow new violations to accumulate.
+
+## customer ask
+
+Stop new customer-prose regressions immediately and remove existing debt in
+measurable increments.
+
+## solution
+
+Add an exact-finding baseline, deletion-only ratchet, Make targets, and required
+CI integration.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\customer-prose-standard-and-enforcement.md`
+
+# changes
+
+## package changes
+
+- Add `docs/internal/baselines/customer-prose.json`.
+- Add focused and full-scope Make targets.
+- Integrate the blocking target into the appropriate existing verification
+  workflow.
+
+## contracts
+
+- Define exact baseline fingerprint, reason, owner, expiry, and stale-entry
+  behavior.
+
+## services
+
+- None.
+
+## API changes
+
+- None.
+
+## tests
+
+- Prove new, moved, changed, stale, wildcard, and expired findings fail while a
+  corrected finding requires baseline deletion.

--- a/docs/internal/development/plans/dashboard-ux-30-probe-results.md
+++ b/docs/internal/development/plans/dashboard-ux-30-probe-results.md
@@ -1,0 +1,144 @@
+---
+author: Agent Factory Team
+last-modified: 2026-08-10
+doc-id: agent-factory/plans/dashboard-ux-30-probe-results
+---
+
+# Dashboard UX 30-Probe Results
+
+## Outcome
+
+Thirty additional read-only probes decomposed the dashboard by bento card and
+functional seam. The probes confirm that the reported grouping, spacing,
+chart, submission, session-tab, and Worker Session problems are reproducible,
+and they identify the identity, state, persistence, accessibility, and scale
+contracts that must be fixed with them.
+
+This evidence is an input to
+`docs/internal/development/plans/dashboard-ux-probe-and-fix.md`. Graph visual
+grammar, graph-node sizing, group-region styling, and packaged renderer parity
+remain owned by
+`docs/internal/development/plans/factory-graph-visual-ux.md`.
+
+## Probe method and limitations
+
+- Probes were executed in staged parallel batches against repository source,
+  focused unit/component tests, OpenAPI fragments, service contracts, replay
+  projections, and existing browser stories.
+- Each probe was read-only. No repository source, Factory definition, Factory
+  Session, Work, upload, selection, or external resource was mutated.
+- Live browser execution was unavailable during this batch. Browser-sensitive
+  findings are therefore marked for explicit 320/390/640/768/desktop browser
+  acceptance rather than treated as visually proven.
+- Some graph-consuming Bun component suites could not start because the
+  checked-in components distribution references a missing `./graph-edge`
+  artifact. Passing focused suites and blocked suites are recorded separately;
+  a blocked suite is never counted as a product pass.
+
+## Probe matrix
+
+| # | Bento or function | Result | Highest-signal finding |
+| --- | --- | --- | --- |
+| 1 | Factory Session tabs | Fail | The backend can return a UUID session and its `~default` selector as separate rows; tabs also claim an empty `tabpanel` and reuse one active-stream status for every tab. |
+| 2 | Open/New Factory | Fail | Open and create are conflated behind manual path validation; the primary action can validate without starting and target rows open immediately instead of supporting select-then-confirm. |
+| 3 | Session controls | Fail | Pause is a client event-stream pause, not Factory Session lifecycle pause, and the UI does not truthfully distinguish Live from Historical mode. |
+| 4 | Work totals | Fail | Labels mix current Work gauges, dispatch attempts, and Work failures; the fixed four-column layout does not reflow at narrow widths. |
+| 5 | Factory graph observe mode | Fail | Nodes and viewport remain mutable in observe mode; concurrent Work can collapse by workstation; projection errors can escape without card-local recovery. |
+| 6 | Factory graph grouping | Fail | Groups are empty-first, disappear in observe/replay, block click-through, do not restore prior membership on undo, accept invalid geometry, and lack keyboard move/resize. |
+| 7 | Graph Add workflow | Fail | Unknown action IDs can create a Workstation, cancel leaves the tool active, errors lack field associations, and topology add is outside Undo/Redo. |
+| 8 | Connect/disconnect | Fail | Pending connection cannot be explicitly canceled, duplicates are silent, and connect/disconnect are outside the editor command history. |
+| 9 | Selection/delete | Fail | Observer/editor/group selection are inconsistent; successful cleanup can be applied after a failed confirmation; topology delete is not undoable. |
+| 10 | Editor save/reset/discard/history | Fail | History is layout-only, layout-only saves bypass stale protection, session changes can discard dirty state, and field edits appear uncommitted. |
+| 11 | Layout/move/resize/viewport | Fail | Observe-mode movement can commit authored positions, observe pan/zoom writes authored viewport, graph-node resize is unimplemented, and Fit ignores groups. |
+| 12 | Graph legend/controls | Fail | Legend omits important semantics, controls miss the 44 px target, disabled reasons are unreachable, overlays collide, and expanded legend content can obscure narrow canvases. |
+| 13 | Current Selection shell/spacing | Fail | The outer frame matches Trace, but internal sections use three incompatible spacing/divider contracts, fixed description columns, undersized controls, and weak narrow-width behavior. |
+| 14 | Workstation summary/config | Fail | Saving during active Work has no real confirmation/enforcement; summary and form read different state; provider metadata can remain tied to the previous worker. |
+| 15 | Workstation Active Work | Fail | Rows lose `(dispatch_id, work_id)` identity, can select the wrong concurrent attempt, use ambiguous counts/order, and keep aging in historical mode. |
+| 16 | Workstation Request history/detail | Fail | Only the first Work is shown, requests suppress attempt history, Worker Session identity is missing, and direct request detail drops Provider Session navigation. |
+| 17 | Selected Work/payload/relations | Fail | Work state/tags/lineage are incomplete, binary content has no safe retrieval path, malformed parts can disappear, relation navigation can silently no-op, and lists are unbounded. |
+| 18 | Worker Sessions | Fail | The backend has list/replay/observation foundations, but the UI never consumes them; provider-less sessions, exact Worker Session identity, resumable cursors, retries, and back/forward are absent. |
+| 19 | Provider Session | Fail | Query identity is sound, but origin context and entry points are incomplete; selection conflates content with dispatch origin; transcripts are unbounded and lack an explicit redaction/reveal policy. |
+| 20 | Terminal Work | Fail | Terminal rows are keyed by display label, so duplicate-name Work can collapse or select together; canceled states, stable recency, paging, and Worker Session links are absent. |
+| 21 | Factory outcomes chart | Fail | The Y-axis title is rendered twice, and the four series compare incompatible Work/dispatch populations under one `Work count` unit; no accessible data alternative exists. |
+| 22 | Submit Work composer/validation | Fail | Simple drafts can cross Factory Session boundaries, simple success is silent, status width is capped, file staging is unbounded, and initial Work state is not a supported choice. |
+| 23 | Submit Work files/status | Fail | No size/count policy, true upload progress, cancellation, idempotent receipt ledger, durable Work link, or opaque staging reference exists; whole files are base64-buffered in JSON. |
+| 24 | Trace shell/states/spacing | Fail | Shared outer spacing is correct, but real loading/error states are mostly unreachable, stale/reconnect states are absent, query identity is incomplete, and embedded graphs overflow/trap scroll. |
+| 25 | Trace relation graph | Fail | Sessionless caching can expose stale trace data, selected Work is not threaded into production, relation-only traces are hidden, relation types are visually indistinguishable, and no textual alternative exists. |
+| 26 | Trace workstation path/table | Fail | Positional fallback invents causality for out-of-order or parallel dispatches; rows and graph are unsynchronized and omit Worker Session/provider/timing/failure detail. |
+| 27 | Bento add/remove/duplicates | Fail | Duplicate Factory graph cards race singleton editor state; removal is immediately destructive; persisted duplicate IDs/singletons survive; instance IDs can be reused; duplicate limits are invisible. |
+| 28 | Bento drag/resize/persistence | Fail | Persistence accepts invalid geometry and overlaps, the 640–768 px band keeps unusable desktop geometry, movement is pointer-only, storage failures are silent, and layout scope is global. |
+| 29 | Cross-bento loading/reconnect/session switch | Fail | Retained data hides recovery failure, known-empty cannot be distinguished from loading, A-to-B switches can flash A data, historical mode is misdetected, and late stream callbacks can overwrite status. |
+| 30 | Cross-bento accessibility/localization/performance | Fail | No general per-card error boundary or keyboard layout editing exists; targets are often below 44 px; ja/ko fall back to English; unrelated cards rerender each second; dense inspectors are unbounded. |
+
+## Critical cross-cutting findings
+
+### Canonical identity must be carried end to end
+
+The highest-risk defects repeatedly replace immutable identity with display
+labels or partial keys. Required keys include Factory Session and stream
+generation for cached runtime state, `(dispatch_id, work_id)` for workstation
+activity, `workerSessionId` for Worker Session inspection, and `workId` for
+Terminal Work and relation navigation. Provider Session content identity must
+remain separate from optional dispatch/Work/Worker Session origin context.
+
+### Loading, empty, historical, stale, and failed are distinct states
+
+The dashboard currently infers state from the presence of cached rows. This can
+make retained offline data look live, keep zero-event sessions loading forever,
+hide recovery actions, and enable mutations while inspecting history. The
+stream identity must publish replay-ready/known-empty, freshness, gap,
+reconnecting, and retryable failure state to every dependent card.
+
+### Editor operations need one transactional document model
+
+Layout, topology, fields, selection, grouping, and viewport currently have
+different mutation and history rules. A single editor document and operation
+stream must define dirty state, stale-save protection, Undo/Redo, cancel,
+validation, session-change guards, and observe-mode immutability. Group visual
+behavior and node sizing stay in the graph-visual plan; the shared transaction
+seam belongs in the dashboard plan.
+
+### Bento persistence and lifecycle need an explicit contract
+
+Persisted layouts require versioned envelopes, identity and geometry
+sanitization, deterministic collision repair, documented operator/factory
+scope, error reporting, instance caps, and a dirty-aware add/remove lifecycle.
+Factory graph must be singleton until editor ownership is instance-scoped.
+
+### Inspection surfaces need bounded, safe presentation
+
+Terminal Work, Current Selection histories, Provider Session transcripts,
+Trace rows/graphs, and Work payloads can all render without meaningful bounds.
+They need pagination, virtualization, progressive disclosure, safe redaction
+and retrieval contracts, focus continuity, and measured render budgets.
+
+## Verification matrix generated by the probes
+
+The implementation plan must verify:
+
+- every canonical bento type, including two instances where policy permits;
+- 320, 390, 640, 768, and desktop widths, plus 200% zoom;
+- keyboard-only and touch operation, 44 px targets, reduced motion, forced
+  colors, focus restoration, and live announcements;
+- English, Simplified Chinese, Japanese, Korean, and a pseudo-long locale;
+- empty, loading, known-empty, stale, reconnecting, recovery-failed,
+  historical, current, and session-switch races;
+- duplicate display labels, concurrent dispatches, provider-less Worker
+  Sessions, multiple retries, canceled Work, relation-only traces, malformed
+  retained records, and duplicate persisted widget IDs; and
+- dense fixtures for graphs, terminal histories, traces, transcripts, Work
+  payloads, and many dashboard widgets with explicit time/memory budgets.
+
+## Immediate sequencing recommendation
+
+1. Fix canonical session/stream/history detection and prevent cross-session
+   stale rendering or mutation.
+2. Establish authoritative Worker Session identity, attempts, associations,
+   resumable observations, and dashboard consumers.
+3. Unify editor operation history and guard grouping/topology/layout saves.
+4. Add bento sanitization, singleton/duplicate policy, dirty-aware removal, and
+   per-card error isolation.
+5. Land the narrow Y-axis and Submit status width fixes while defining their
+   honest metric/submission-state contracts.
+6. Complete bounded inspection, responsive/accessibility, localization, and
+   measured performance work.

--- a/docs/internal/development/plans/dashboard-ux-30-probe-results.md
+++ b/docs/internal/development/plans/dashboard-ux-30-probe-results.md
@@ -9,136 +9,106 @@ doc-id: agent-factory/plans/dashboard-ux-30-probe-results
 ## Outcome
 
 Thirty additional read-only probes decomposed the dashboard by bento card and
-functional seam. The probes confirm that the reported grouping, spacing,
-chart, submission, session-tab, and Worker Session problems are reproducible,
-and they identify the identity, state, persistence, accessibility, and scale
-contracts that must be fixed with them.
+functional seam. They confirm the reported grouping, spacing, chart,
+submission, session-tab, and Worker Session problems and identify the identity,
+state, persistence, accessibility, and scale contracts that must be fixed with
+them.
 
-This evidence is an input to
+This evidence feeds
 `docs/internal/development/plans/dashboard-ux-probe-and-fix.md`. Graph visual
 grammar, graph-node sizing, group-region styling, and packaged renderer parity
 remain owned by
 `docs/internal/development/plans/factory-graph-visual-ux.md`.
 
-## Probe method and limitations
+## Method and limitations
 
-- Probes were executed in staged parallel batches against repository source,
-  focused unit/component tests, OpenAPI fragments, service contracts, replay
-  projections, and existing browser stories.
-- Each probe was read-only. No repository source, Factory definition, Factory
-  Session, Work, upload, selection, or external resource was mutated.
+- Probes ran in staged parallel batches over source, focused unit/component
+  tests, OpenAPI fragments, services, replay projections, and browser stories.
+- The batch was read-only: no source, Factory, Factory Session, Work, upload,
+  selection, or external resource was mutated.
 - Live browser execution was unavailable during this batch. Browser-sensitive
-  findings are therefore marked for explicit 320/390/640/768/desktop browser
-  acceptance rather than treated as visually proven.
-- Some graph-consuming Bun component suites could not start because the
-  checked-in components distribution references a missing `./graph-edge`
-  artifact. Passing focused suites and blocked suites are recorded separately;
-  a blocked suite is never counted as a product pass.
+  findings remain explicit acceptance work at 320/390/640/768/desktop.
+- Some graph-consuming Bun suites could not start because the checked-in
+  components distribution references a missing `./graph-edge` artifact. A
+  blocked suite is not counted as a product pass.
 
 ## Probe matrix
 
 | # | Bento or function | Result | Highest-signal finding |
 | --- | --- | --- | --- |
-| 1 | Factory Session tabs | Fail | The backend can return a UUID session and its `~default` selector as separate rows; tabs also claim an empty `tabpanel` and reuse one active-stream status for every tab. |
-| 2 | Open/New Factory | Fail | Open and create are conflated behind manual path validation; the primary action can validate without starting and target rows open immediately instead of supporting select-then-confirm. |
-| 3 | Session controls | Fail | Pause is a client event-stream pause, not Factory Session lifecycle pause, and the UI does not truthfully distinguish Live from Historical mode. |
-| 4 | Work totals | Fail | Labels mix current Work gauges, dispatch attempts, and Work failures; the fixed four-column layout does not reflow at narrow widths. |
-| 5 | Factory graph observe mode | Fail | Nodes and viewport remain mutable in observe mode; concurrent Work can collapse by workstation; projection errors can escape without card-local recovery. |
-| 6 | Factory graph grouping | Fail | Groups are empty-first, disappear in observe/replay, block click-through, do not restore prior membership on undo, accept invalid geometry, and lack keyboard move/resize. |
-| 7 | Graph Add workflow | Fail | Unknown action IDs can create a Workstation, cancel leaves the tool active, errors lack field associations, and topology add is outside Undo/Redo. |
-| 8 | Connect/disconnect | Fail | Pending connection cannot be explicitly canceled, duplicates are silent, and connect/disconnect are outside the editor command history. |
-| 9 | Selection/delete | Fail | Observer/editor/group selection are inconsistent; successful cleanup can be applied after a failed confirmation; topology delete is not undoable. |
-| 10 | Editor save/reset/discard/history | Fail | History is layout-only, layout-only saves bypass stale protection, session changes can discard dirty state, and field edits appear uncommitted. |
-| 11 | Layout/move/resize/viewport | Fail | Observe-mode movement can commit authored positions, observe pan/zoom writes authored viewport, graph-node resize is unimplemented, and Fit ignores groups. |
-| 12 | Graph legend/controls | Fail | Legend omits important semantics, controls miss the 44 px target, disabled reasons are unreachable, overlays collide, and expanded legend content can obscure narrow canvases. |
-| 13 | Current Selection shell/spacing | Fail | The outer frame matches Trace, but internal sections use three incompatible spacing/divider contracts, fixed description columns, undersized controls, and weak narrow-width behavior. |
-| 14 | Workstation summary/config | Fail | Saving during active Work has no real confirmation/enforcement; summary and form read different state; provider metadata can remain tied to the previous worker. |
-| 15 | Workstation Active Work | Fail | Rows lose `(dispatch_id, work_id)` identity, can select the wrong concurrent attempt, use ambiguous counts/order, and keep aging in historical mode. |
-| 16 | Workstation Request history/detail | Fail | Only the first Work is shown, requests suppress attempt history, Worker Session identity is missing, and direct request detail drops Provider Session navigation. |
-| 17 | Selected Work/payload/relations | Fail | Work state/tags/lineage are incomplete, binary content has no safe retrieval path, malformed parts can disappear, relation navigation can silently no-op, and lists are unbounded. |
-| 18 | Worker Sessions | Fail | The backend has list/replay/observation foundations, but the UI never consumes them; provider-less sessions, exact Worker Session identity, resumable cursors, retries, and back/forward are absent. |
-| 19 | Provider Session | Fail | Query identity is sound, but origin context and entry points are incomplete; selection conflates content with dispatch origin; transcripts are unbounded and lack an explicit redaction/reveal policy. |
-| 20 | Terminal Work | Fail | Terminal rows are keyed by display label, so duplicate-name Work can collapse or select together; canceled states, stable recency, paging, and Worker Session links are absent. |
-| 21 | Factory outcomes chart | Fail | The Y-axis title is rendered twice, and the four series compare incompatible Work/dispatch populations under one `Work count` unit; no accessible data alternative exists. |
-| 22 | Submit Work composer/validation | Fail | Simple drafts can cross Factory Session boundaries, simple success is silent, status width is capped, file staging is unbounded, and initial Work state is not a supported choice. |
-| 23 | Submit Work files/status | Fail | No size/count policy, true upload progress, cancellation, idempotent receipt ledger, durable Work link, or opaque staging reference exists; whole files are base64-buffered in JSON. |
-| 24 | Trace shell/states/spacing | Fail | Shared outer spacing is correct, but real loading/error states are mostly unreachable, stale/reconnect states are absent, query identity is incomplete, and embedded graphs overflow/trap scroll. |
-| 25 | Trace relation graph | Fail | Sessionless caching can expose stale trace data, selected Work is not threaded into production, relation-only traces are hidden, relation types are visually indistinguishable, and no textual alternative exists. |
-| 26 | Trace workstation path/table | Fail | Positional fallback invents causality for out-of-order or parallel dispatches; rows and graph are unsynchronized and omit Worker Session/provider/timing/failure detail. |
-| 27 | Bento add/remove/duplicates | Fail | Duplicate Factory graph cards race singleton editor state; removal is immediately destructive; persisted duplicate IDs/singletons survive; instance IDs can be reused; duplicate limits are invisible. |
-| 28 | Bento drag/resize/persistence | Fail | Persistence accepts invalid geometry and overlaps, the 640–768 px band keeps unusable desktop geometry, movement is pointer-only, storage failures are silent, and layout scope is global. |
-| 29 | Cross-bento loading/reconnect/session switch | Fail | Retained data hides recovery failure, known-empty cannot be distinguished from loading, A-to-B switches can flash A data, historical mode is misdetected, and late stream callbacks can overwrite status. |
-| 30 | Cross-bento accessibility/localization/performance | Fail | No general per-card error boundary or keyboard layout editing exists; targets are often below 44 px; ja/ko fall back to English; unrelated cards rerender each second; dense inspectors are unbounded. |
+| 1 | Factory Session tabs | Fail | A UUID session and its `~default` selector can render as two rows; tabs also claim an empty panel and reuse one stream status for all tabs. |
+| 2 | Open/New Factory | Fail | Open and create are conflated behind manual validation, and the primary action can validate without starting. |
+| 3 | Session controls | Fail | Pause controls the client event stream rather than Factory lifecycle, and Live versus Historical mode is not truthful. |
+| 4 | Work totals | Fail | Labels mix Work gauges, dispatch attempts, and Work failures; four fixed columns do not reflow. |
+| 5 | Factory graph observe | Fail | Nodes/viewport remain mutable, concurrent Work collapses by workstation, and graph errors can escape the card. |
+| 6 | Grouping | Fail | Groups are empty-first, disappear outside edit mode, block click-through, lose prior membership on undo, accept invalid geometry, and lack keyboard/cancel semantics. |
+| 7 | Graph Add | Fail | Unknown actions fall through to Workstation, cancel leaves Add active, errors lack associations, and add is outside Undo/Redo. |
+| 8 | Connect/disconnect | Fail | Pending connection lacks explicit cancel, duplicates are silent, and topology edits are outside history. |
+| 9 | Selection/delete | Fail | Observer/editor/group selection disagree, cleanup can run after failed confirmation, and delete is not undoable. |
+| 10 | Editor save/reset/history | Fail | History is layout-only, layout-only saves bypass stale protection, and session changes can discard dirty state. |
+| 11 | Move/resize/viewport | Fail | Observe movement/viewport can persist, graph-node resize is absent, cancel is incomplete, and Fit ignores groups. |
+| 12 | Legend/controls | Fail | Semantics are incomplete, targets are undersized, disabled reasons are unreachable, and overlays collide on narrow canvases. |
+| 13 | Current Selection spacing | Fail | The outer frame matches Trace, but inner sections use three incompatible spacing/divider contracts and fixed description columns. |
+| 14 | Workstation summary/config | Fail | Active-Work save has no real confirmation, summary and form read different state, and provider metadata can remain tied to the old worker. |
+| 15 | Active Work | Fail | Rows lose `(dispatch_id, work_id)` identity, can select the wrong attempt, and keep aging in history. |
+| 16 | Request history/detail | Fail | Only the first Work is shown, requests suppress attempt history, Worker Session identity is missing, and direct request detail drops Provider navigation. |
+| 17 | Selected Work/payload/relations | Fail | State/tags/lineage are incomplete, binary retrieval is undefined, malformed parts can disappear, and relation navigation can silently no-op. |
+| 18 | Worker Sessions | Fail | Backend foundations exist, but the UI does not consume them; provider-less identity, attempts, resumable cursors, detail, and history are absent. |
+| 19 | Provider Session | Fail | Origin context and entry points are incomplete; selection conflates content with dispatch; transcript rendering is unbounded and lacks a redaction policy. |
+| 20 | Terminal Work | Fail | Rows are keyed by display label, so duplicate-name Work can collapse/select together; canceled states, paging, and Worker links are absent. |
+| 21 | Factory outcomes chart | Fail | The Y-axis title renders twice, and series compare incompatible Work/dispatch populations under one unit. |
+| 22 | Submit composer | Fail | Simple drafts cross sessions, simple success is silent, status width is capped, and file staging is unbounded. |
+| 23 | Submit files/status | Fail | No size/count policy, progress/cancel, idempotent receipt ledger, durable Work link, or opaque staging reference exists. |
+| 24 | Trace shell/states | Fail | Real loading/error states are mostly unreachable, stale/reconnect is absent, identity is incomplete, and graphs overflow/trap scroll. |
+| 25 | Trace relation graph | Fail | Sessionless caching can show stale data, selected Work is not wired through, relation-only traces are hidden, and no textual alternative exists. |
+| 26 | Trace workstation path/table | Fail | Positional fallback invents causality for out-of-order/parallel dispatches; rows and graph are unsynchronized and omit execution detail. |
+| 27 | Bento add/remove/duplicates | Fail | Duplicate graph cards race singleton editor state; removal is destructive; invalid duplicate IDs/singletons survive; instance IDs can be reused. |
+| 28 | Bento drag/resize/persistence | Fail | Invalid geometry/overlap survives, 640–768 keeps cramped desktop geometry, movement is pointer-only, and storage scope/errors are undefined. |
+| 29 | Loading/reconnect/session switch | Fail | Retained data hides failure, known-empty is ambiguous, A-to-B can flash A data, history is misdetected, and late callbacks can overwrite status. |
+| 30 | Accessibility/localization/performance | Fail | No general card boundary or keyboard layout editing exists; targets miss 44 px; ja/ko fall back; unrelated cards tick; dense inspectors are unbounded. |
 
-## Critical cross-cutting findings
+## Cross-cutting conclusions
 
-### Canonical identity must be carried end to end
+### Carry canonical identity end to end
 
-The highest-risk defects repeatedly replace immutable identity with display
-labels or partial keys. Required keys include Factory Session and stream
-generation for cached runtime state, `(dispatch_id, work_id)` for workstation
-activity, `workerSessionId` for Worker Session inspection, and `workId` for
-Terminal Work and relation navigation. Provider Session content identity must
-remain separate from optional dispatch/Work/Worker Session origin context.
+Use Factory Session plus stream generation for runtime caches,
+`(dispatch_id, work_id)` for workstation activity, `workerSessionId` for Worker
+Session inspection, and `workId` for Terminal Work. Keep Provider Session
+content identity separate from optional origin context.
 
-### Loading, empty, historical, stale, and failed are distinct states
+### Model async state rather than infer it from rows
 
-The dashboard currently infers state from the presence of cached rows. This can
-make retained offline data look live, keep zero-event sessions loading forever,
-hide recovery actions, and enable mutations while inspecting history. The
-stream identity must publish replay-ready/known-empty, freshness, gap,
-reconnecting, and retryable failure state to every dependent card.
+Hydrating, known-empty, live, historical, stale, reconnecting, gap, and
+recovery-failed are distinct. Retained data must remain visible but marked
+stale, and mutation controls must remain disabled in historical mode.
 
-### Editor operations need one transactional document model
+### Use one transactional editor document
 
-Layout, topology, fields, selection, grouping, and viewport currently have
-different mutation and history rules. A single editor document and operation
-stream must define dirty state, stale-save protection, Undo/Redo, cancel,
-validation, session-change guards, and observe-mode immutability. Group visual
-behavior and node sizing stay in the graph-visual plan; the shared transaction
-seam belongs in the dashboard plan.
+Topology, fields, layout, selection, grouping, and viewport need one dirty,
+stale-save, cancel, validation, and Undo/Redo model. Group visual behavior stays
+in the graph-visual plan; the transaction seam belongs in the dashboard plan.
 
-### Bento persistence and lifecycle need an explicit contract
+### Give bento persistence a lifecycle contract
 
-Persisted layouts require versioned envelopes, identity and geometry
-sanitization, deterministic collision repair, documented operator/factory
-scope, error reporting, instance caps, and a dirty-aware add/remove lifecycle.
-Factory graph must be singleton until editor ownership is instance-scoped.
+Persisted layouts need versioning, scope, identity/geometry sanitization,
+collision repair, instance limits, dirty-aware removal, focus restoration, and
+error recovery. Factory graph must be singleton until ownership is per instance.
 
-### Inspection surfaces need bounded, safe presentation
+### Bound and isolate inspection
 
-Terminal Work, Current Selection histories, Provider Session transcripts,
-Trace rows/graphs, and Work payloads can all render without meaningful bounds.
-They need pagination, virtualization, progressive disclosure, safe redaction
-and retrieval contracts, focus continuity, and measured render budgets.
+Terminal Work, Current Selection, Provider transcripts, Trace, and payloads
+need pagination/windowing, safe retrieval/redaction, focus continuity, card-local
+error recovery, and measured render budgets.
 
-## Verification matrix generated by the probes
+## Required regression matrix
 
-The implementation plan must verify:
-
-- every canonical bento type, including two instances where policy permits;
-- 320, 390, 640, 768, and desktop widths, plus 200% zoom;
-- keyboard-only and touch operation, 44 px targets, reduced motion, forced
-  colors, focus restoration, and live announcements;
-- English, Simplified Chinese, Japanese, Korean, and a pseudo-long locale;
-- empty, loading, known-empty, stale, reconnecting, recovery-failed,
-  historical, current, and session-switch races;
-- duplicate display labels, concurrent dispatches, provider-less Worker
-  Sessions, multiple retries, canceled Work, relation-only traces, malformed
-  retained records, and duplicate persisted widget IDs; and
-- dense fixtures for graphs, terminal histories, traces, transcripts, Work
-  payloads, and many dashboard widgets with explicit time/memory budgets.
-
-## Immediate sequencing recommendation
-
-1. Fix canonical session/stream/history detection and prevent cross-session
-   stale rendering or mutation.
-2. Establish authoritative Worker Session identity, attempts, associations,
-   resumable observations, and dashboard consumers.
-3. Unify editor operation history and guard grouping/topology/layout saves.
-4. Add bento sanitization, singleton/duplicate policy, dirty-aware removal, and
-   per-card error isolation.
-5. Land the narrow Y-axis and Submit status width fixes while defining their
-   honest metric/submission-state contracts.
-6. Complete bounded inspection, responsive/accessibility, localization, and
-   measured performance work.
+- Every canonical bento type and every permitted duplicate.
+- 320/390/640/768/desktop, 200% zoom, keyboard, touch, forced colors, and
+  reduced motion.
+- en/zh-CN/ja/ko and pseudo-long copy.
+- Empty, loading, known-empty, stale, reconnecting, recovery-failed,
+  historical, current, and session-switch races.
+- Duplicate labels, concurrent dispatches, provider-less Worker Sessions,
+  retries, canceled Work, relation-only traces, malformed replay, and hostile
+  persisted layouts.
+- Dense graph/history/trace/transcript/payload and many-widget budgets.

--- a/docs/internal/development/plans/dashboard-ux-probe-and-fix.md
+++ b/docs/internal/development/plans/dashboard-ux-probe-and-fix.md
@@ -8,116 +8,69 @@ doc-id: agent-factory/plans/dashboard-ux-probe-and-fix
 
 ## Outcome
 
-Customers can open or create a Factory, understand the active Factory Session,
-inspect every concurrent Work and Worker Session, and use the Factory graph and
-dashboard widgets without duplicated labels, clipped feedback, phantom tabs,
-collapsed executions, misleading selection, or inaccessible controls.
-
-This plan turns the current UX defects into independently reviewable behavior
-stories. It is intentionally separate from
-`docs/internal/development/plans/factory-graph-visual-ux.md`, which remains the
-owner for the graph's visual grammar, node sizing, Work-count presentation,
-group-region styling, workstation semantic identity, and first-party topology
-hygiene.
+Customers can open or create a Factory, understand the exact active Factory
+Session and stream state, inspect every concurrent Work and Worker Session, use
+the Factory editor—including groups—as one predictable transaction, and arrange
+responsive dashboard widgets without duplicated labels, clipped feedback,
+phantom identities, stale cross-session data, or inaccessible controls.
 
 ## Customer problem
 
-The dashboard currently exposes several kinds of misleading state:
+The initial ten-probe audit and thirty additional bento/functionality probes
+found failures across every dashboard journey. The known duplicate chart label,
+capped submission notice, phantom `~default` tab, collapsed workstation
+sessions, broken grouping, and inconsistent inspection spacing are symptoms of
+larger contract gaps:
 
-- the Work outcome chart renders its Y-axis title twice;
-- Submit Work feedback is narrower than its card and some validation feedback
-  is duplicated;
-- the header can show a real Factory Session and a second `~default` alias as
-  if they were separate Factories;
-- workstation activity can collapse multiple concurrent dispatches to one;
-- Current Selection infers executions from Provider Sessions instead of
-  enumerating authoritative Worker Sessions;
-- the Worker Session event stream can expose Factory-event fallback records
-  without making the provenance difference explicit;
-- workstation Request history shows only the first Work in a multi-Work
-  dispatch and suppresses executions without Provider Sessions;
-- editor selection, undo, dragging, connection handles, and mobile toolbar
-  behavior do not form one consistent operation model;
-- persisted dashboard geometry accepts unsafe values and the 640–768 px layout
-  is neither compact nor editable; and
-- New Factory is hidden behind a failed-looking validation path.
+- display labels and partial keys substitute for canonical session, dispatch,
+  Work, Worker Session, and Provider Session identity;
+- loading, known-empty, historical, stale, reconnecting, and failed states are
+  inferred inconsistently from retained rows;
+- editor topology, fields, layout, selection, groups, and viewport have
+  incompatible history and save rules;
+- bento instance policy, persisted geometry, removal, responsive projection,
+  and keyboard manipulation are not one validated lifecycle; and
+- dense inspection, per-card failure isolation, locale completeness, touch
+  targets, and render budgets are incomplete.
 
-## Probe evidence
-
-The audit used an initial ten focused probes followed by thirty additional
-bento/functionality probes, run in staged parallel batches because the
-workspace supports four concurrent agents including the coordinator. The
-initial audit included a live desktop inspection against the running backend;
-the thirty-probe expansion used read-only source, contract, projection, and
-focused-test inspection because the live browser was unavailable during that
-batch.
-
-The complete additional matrix and its execution limitations are recorded in
+The full evidence matrix is
 `docs/internal/development/plans/dashboard-ux-30-probe-results.md`.
-
-| Priority | Finding | Direct evidence |
-| --- | --- | --- |
-| P1 | Duplicate Y-axis title | `work-chart.tsx` renders both a chart overlay label and a Recharts `YAxis` label; the live accessibility tree and geometry contained two `Work count` elements. |
-| P1 | Submit feedback does not fill its card | `submit-work-status-panel.tsx` uses `max-w-xl`; at the measured desktop layout the parent was 589 px while the panel stopped at 576 px. |
-| P1 | Phantom default session tab | The live header rendered a resolved UUID-backed session and a second `~default` entry. `session_listing.go` appends two live readers without identity reconciliation, and the UI preserves every row. |
-| P1 | Concurrent workstation activity collapses | `projectRuntime.ts` builds `workstation_activity_by_node_id` with `Object.fromEntries` keyed by `transitionID`, so later dispatches replace earlier dispatches on the same workstation. |
-| P1 | Worker Sessions are absent from the UI | The OpenAPI list/show/stream/transcript contract exists, but there is no handwritten Worker Sessions API module, hook, projection, or component consumer. |
-| P1 | Durable Worker Session association is discarded | The generated event exists, but `ui/src/api/events/types.ts` and `replayWorldState.ts` omit `DISPATCH_WORKER_SESSION_ASSOCIATION`. |
-| P1 | Worker Session stream provenance is misleading | The runtime-bound route can prefer dispatch-scoped Factory ledger records and label them `factory_event` instead of streaming the source-native Worker Sessions Events topic promised by the route. |
-| P1 | Workstation history loses Work and attempts | `workstation-request-history-section.tsx` reads only `work_items[0]`; request presence suppresses fallback run history; attempts without Provider Session identity are filtered out. |
-| P1 | Editor state is inconsistent | Undo/Redo only covers layout, observer selection can look selected while Delete reports no editor selection, and `nodesDraggable` is enabled outside edit mode. |
-| P1 | Persisted bento geometry is unsafe | The layout normalizer accepts negative coordinates, non-positive dimensions, out-of-grid widths, overlap, and duplicate custom IDs. |
-| P1 | Responsive/accessibility relationships are false or clipped | Session tabs control an empty `tabpanel`; the mobile editor toolbar clips trailing Save/Discard actions; 640–768 px keeps desktop geometry while disabling layout interaction. |
-| P1 | Submit Work contract and client behavior diverge | OpenAPI describes `name` as optional while server and dashboard reject missing/blank names; same-tick duplicate activation is not synchronously guarded. |
-| P1 | Drill-down context can combine unrelated identities | A directly selected trace is global bento state and can survive a Work change; direct request detail drops Provider Session selection callbacks; terminal rows use display labels instead of Work identity. |
-| P1 | Graph projection failures are not safely contained | Replay does not validate edge endpoints or expose an error state, while current/trace React Flow handlers throw every warning as fatal without a card-local boundary. |
-| P1 | Dense graph projections churn or scale quadratically | Package replay repeatedly scans occupancy/count/overlay arrays per node/edge, and live clock updates rebuild stable current-activity nodes and edges. |
-| P0 | Runtime caches and status can cross Factory Session boundaries | Trace query identity omits Factory Session/stream generation, session changes can render the prior active snapshot for one frame, and late EventSource callbacks can overwrite the new session's global status. |
-| P0 | Grouping is not an end-to-end editor feature | Groups disappear outside edit mode, opaque group bodies block graph interaction, reassignment undo loses prior membership, invalid geometry is accepted, and keyboard/cancel semantics are absent. |
-| P0 | Duplicate Factory graph cards race singleton editor state | The catalog permits duplicate graph widgets although every instance mounts the same session-scoped editor/controller bridge; removing one can clear another's handlers. |
-| P1 | Dashboard async state is neither shared nor truthful | Known-empty, retained-stale, reconnecting, recovery-failed, and historical states are unavailable or inconsistently inferred by individual cards. |
-| P1 | Inspection surfaces are unbounded | Terminal Work, Current Selection histories, Provider transcripts, Trace graphs/tables, and payload/relationship views can mount all retained data without pagination or virtualization. |
-| P1 | Advertised locale and accessibility contracts are incomplete | Japanese and Korean frequently fall back to English, many controls are below 44 px, layout editing is pointer-only, and no general per-widget error boundary exists. |
 
 ### Audit side effect
 
-While probing the Submit Work validation path, one audit interaction created a
-local `idea` Work request named `UX layout probe` with an empty optional text
-item. No cleanup is authorized by this plan; retain or remove that Work only by
-explicit operator choice.
+The initial audit created one local `idea` Work request named `UX layout probe`
+while exercising submission validation. This plan does not authorize cleanup;
+retain or remove it only by explicit operator choice. The additional thirty
+probes were read-only.
 
 ## Scope
 
 In scope:
 
-- Factory Session listing, identity reconciliation, singleton header context,
-  and explicit Open/New Factory flows;
-- Work outcome chart and Submit Work feedback/validation behavior;
-- selected-workstation concurrent activity, Work/Request enumeration, Worker
-  Session association, list, live updates, and optional Provider Session links;
-- graph editor operation history, selection semantics, observe-mode geometry,
-  connection workflow, and responsive toolbar behavior;
-- bento layout validation, minimum geometry, compact projection, duplicate
-  instance identity, keyboard manipulation, and persistence scope;
-- truthful tab semantics, stream status, reduced motion, touch targets, and
-  narrow trace visualization behavior; and
-- regression fixtures and browser evidence tying these surfaces together.
+- Factory Session identity, tabs, Open/New Factory, lifecycle/stream controls,
+  replay mode, reconnect, and session switching;
+- Work totals/outcomes, Submit Work, workstation activity/history, Terminal
+  Work, Selected Work, Worker Sessions, Provider Sessions, and Trace;
+- editor selection, topology/field/layout history, grouping transaction seam,
+  connection/cancel, save/reset/discard, and observe-mode immutability;
+- bento catalog, duplicate/singleton policy, add/remove, persistence, geometry,
+  responsive projection, keyboard/touch behavior, and failure isolation; and
+- accessibility, localization, safe payload presentation, bounded rendering,
+  browser evidence, generated contracts, and performance budgets.
 
 Out of scope:
 
-- redesigning the graph visual grammar already owned by
-  `factory-graph-visual-ux.md`;
-- replacing Factory Events, Factory definitions, Work, or Worker Sessions as
-  canonical state;
-- persisting React Flow or React Grid Layout objects as domain state;
-- broad dashboard restyling, unrelated copy sweeps, or new backend topology;
-- treating Provider Sessions as Worker Session identity; and
-- making process-local Worker Events durable Factory replay history.
+- re-owning graph visual grammar, group-region styling, graph-node sizing, and
+  packaged renderer parity from
+  `docs/internal/development/plans/factory-graph-visual-ux.md`;
+- treating Provider Sessions as Worker Session identity;
+- persisting React Flow or React Grid Layout objects as domain state; and
+- broad dashboard restyling unrelated to the probe matrix.
 
-## Architecture and state boundaries
+## Architecture and ownership
 
 ```text
-Factory definitions + Factory Sessions + Work + Worker Sessions
+Factory Definitions + Factory Sessions + Work + Worker Sessions
         | canonical service operations and authored OpenAPI
         v
 Recordings Factory Events       Worker Sessions -> Events topics
@@ -125,69 +78,60 @@ durable replay/history          source-native retained/live observations
         |                                  |
         +--------------+-------------------+
                        v
-typed UI API modules + event stores
+typed UI APIs + identity-keyed timeline/stream stores
                        |
                        v
-pure replay/activity/selection/editor/layout projections
+pure editor/activity/selection/layout projections
                        |
                        v
-React Flow, Recharts, React Grid Layout, tables, cards, and dialogs
-disposable UI-library state; never the domain source of truth
+bento cards, React Flow, charts, tables, dialogs
+disposable render state; never canonical product state
 ```
 
-Required ownership decisions:
-
-- Factory Sessions owns reconciliation of live session identities. `~default`
-  remains an accepted selector, not a second durable client identity.
-- Recordings owns durable Factory Event replay, including the dispatch-to-Worker
-  Session association.
-- Worker Sessions owns Worker Session identity and lifecycle; Events owns its
-  bounded source-native observation topic; Provider Sessions is optional detail.
-- Work owns Work and Work Request admission. Dashboard workstation requests are
-  dispatch-keyed read projections, not Work Request identity.
-- The Factory document and graph editor operation stream own editable graph
-  state. React Flow nodes, handles, edges, and measurements are reproducible
-  projections.
-- The bento layout store owns browser-local layout preference. React Grid Layout
-  and the compact one-column form are projections.
+- Factory Sessions owns canonical session identity. `~default` is an accepted
+  selector, not a second durable row.
+- Recordings owns durable Factory Event replay and dispatch-to-Worker Session
+  association. Worker Sessions owns Worker Session identity, attempts, and
+  observations; Provider Sessions remains optional detail.
+- Work owns admission/content. Workstation and Terminal Work views are
+  identity-preserving projections, never label-keyed canonical state.
+- The Factory editor document owns editable topology, fields, grouping, and
+  layout operations. React Flow state is reproducible projection state.
+- The bento layout store owns a scoped, versioned operator preference. Compact
+  React Grid Layout geometry is disposable and is not persisted.
 
 ## Delivery sequence
 
-1. Land the deterministic regression fixture and probe matrix.
-2. Land narrow presentation and contract corrections with no dependency on the
-   Worker Session work.
-3. Correct canonical session/activity/association projections.
-4. Expose and render authoritative Worker Sessions and complete workstation
-   history.
-5. Repair editor and bento operation models after their canonical boundaries
-   are covered by pure tests.
-6. Bound and isolate inspection surfaces, then complete locale coverage.
-7. Complete responsive, accessibility, browser, generated-contract, CI, review,
-   conflict-resolution, and merge gates.
+1. Land deterministic fixtures and the full regression matrix.
+2. Stop cross-session stale state and make stream/history status truthful.
+3. Reconcile Factory Session identity and preserve concurrent Work identity.
+4. Expose authoritative Worker Sessions and coherent inspection navigation.
+5. Unify editor transactions and complete the linked grouping work.
+6. Sanitize bento lifecycle/persistence and isolate widget failures.
+7. Land narrow chart/submission/spacing fixes with their honest contracts.
+8. Bound dense data, complete locales/accessibility, run browser/CI gates, and
+   merge each independently reviewable story.
 
 ## Work stories
 
-### Story 0: Establish the deterministic UX regression probe
+### Story 0: Establish the deterministic dashboard regression probe
 
 #### Problem statement
 
-The reported defects span live events, replay, concurrent dispatch, multiple
-identity types, graph-library behavior, and responsive layouts; isolated happy
-path fixtures cannot prove the fixes.
+The defects depend on concurrency, replay, duplicate identities, malformed
+persistence, dense data, and responsive geometry that happy-path fixtures omit.
 
 #### Customer ask
 
-Create one repeatable probe that reproduces the known problems and provides a
-stable baseline for every fix story.
+Create one repeatable baseline that proves every known defect before and after
+its owning fix.
 
 #### Solution
 
-Add a fixture-driven browser scenario containing duplicate default-session
-inputs, two concurrent dispatches on one workstation, a multi-Work dispatch,
-multiple Worker Sessions including one without a Provider Session, terminal and
-failed/canceled executions, a large grouped graph, dense inspector data, every
-canonical dashboard widget, and a permitted duplicate instance of each
-duplicate-capable widget.
+Build fixture-driven pure, component, and browser scenarios containing every
+canonical widget, permitted duplicates, duplicate session selectors, concurrent
+dispatches, multi-Work requests, provider-less/retried Worker Sessions,
+terminal states, grouped graphs, dense inspectors, and hostile stored layouts.
 
 #### Original document
 
@@ -197,18 +141,17 @@ duplicate-capable widget.
 
 ##### Package changes
 
-- Add the replay/browser fixture under the existing `ui/integration/` fixture
-  conventions and reuse feature-local test builders for pure projections.
-- Do not add production-only test seams or a second replay engine.
+- Add reusable builders under existing UI integration/component conventions;
+  do not add production-only test seams or a second replay implementation.
 
 ##### Contracts
 
-- Define expected identities by `factorySessionId`, `dispatch_id`, `work_id`,
-  and `workerSessionId`; do not key expected behavior by display text.
+- Expected rows use immutable IDs, not display text.
 
 ##### Services
 
-- Reuse public service operations and existing edge mocks; no new service.
+- Reuse `root.BuildProcess` and replace external effects only through
+  `edges.Edges` for functional fixtures.
 
 ##### API changes
 
@@ -216,36 +159,34 @@ duplicate-capable widget.
 
 ##### Tests
 
-- Probe 320, 390, 640, 768, and desktop widths; 200% zoom; keyboard and touch;
-  forced colors and reduced motion; en/zh-CN/ja/ko and pseudo-long copy; live,
-  historical, reconnect, recovery failure, known-empty, and session-switch
-  races; deliberate single-widget throw; dense-data and rerender budgets.
+- Cover 320/390/640/768/desktop, 200% zoom, keyboard/touch, forced colors,
+  reduced motion, en/zh-CN/ja/ko/pseudo-long copy, async states, session races,
+  a deliberate card throw, duplicate widgets, and dense render budgets.
 
 #### Acceptance criteria
 
-- The fixture reproduces the duplicate chart label, capped Submit status,
-  phantom session entry, collapsed concurrent activity, broken group journey,
-  incomplete history, stale cross-session state, unsafe duplicate graph card,
-  and Worker Session gap before fixes.
-- Expected row counts, stable ordering, navigation targets, accessible names,
-  and document-level overflow are asserted directly.
-- The fixture is deterministic in CI and uses no sleeps as its primary
-  synchronization strategy.
+- Every row in the thirty-probe matrix maps to a failing-before/passing-after
+  assertion or a linked graph-visual-plan assertion.
+- The fixture is deterministic, identity-keyed, CI-safe, and does not use sleeps
+  as its primary synchronization mechanism.
 
-### Story 1: Render one Work outcome axis and one plot grid
+### Story 1: Reconcile Factory Session identity and entry flows
 
 #### Problem statement
 
-The Work outcome chart repeats `Work count` and renders redundant grid layers.
+A UUID session and `~default` alias can render as separate tabs; tab semantics
+point at an empty panel; Open/New Factory and session controls misstate actions.
 
 #### Customer ask
 
-Make the chart visually and accessibly unambiguous.
+See one row per real Factory Session and intentionally open, create, inspect,
+pause the stream, or switch replay mode without misleading labels.
 
 #### Solution
 
-Choose one Y-axis-title owner and one grid contract inside the canonical Work
-chart component; keep chart data and series behavior unchanged.
+Canonicalize session listing at the service boundary, make Open and New Factory
+explicit select/confirm journeys, use navigation or truthful panel semantics,
+and label stream pause separately from runtime lifecycle and historical mode.
 
 #### Original document
 
@@ -255,16 +196,526 @@ chart component; keep chart data and series behavior unchanged.
 
 ##### Package changes
 
-- Update `ui/src/features/work-outcome/components/work-chart/work-chart.tsx`
-  and its component/Storybook contracts.
+- Update session listing, header tabs, Open/New dialogs, controls, focus,
+  keyboard ordering, active-only status, and responsive overflow behavior.
 
 ##### Contracts
 
-- Recharts remains a disposable rendering projection; no outcome model change.
+- `~default` remains a selector only; validation is non-mutating; stream pause
+  and Factory lifecycle pause are separate actions; Live/Historical is explicit.
 
 ##### Services
 
-- None.
+- Factory Sessions owns alias reconciliation and returned canonical identity.
+
+##### API changes
+
+- Extend responses only if canonical selector/resolved identity cannot be
+  expressed today; regenerate clients if changed.
+
+##### Tests
+
+- Alias plus UUID, singleton/multi-session, close/remap, keyboard tabs, Open
+  existing, Create preview, broken path, cancel/focus, stream pause, and
+  historical/current mode.
+
+#### Acceptance criteria
+
+- Each real session renders once and every action targets its canonical ID.
+- Validation never claims to start a Factory; create previews the exact target.
+- Tab/content/status semantics are truthful, keyboard operable, and non-color-only.
+
+### Story 2: Make stream, replay, and session-switch state truthful
+
+#### Problem statement
+
+Zero-event sessions can load forever, retained data hides recovery failure,
+historical mode is misdetected, and session A data/status can flash into B.
+
+#### Customer ask
+
+Know whether data is hydrating, empty, live, historical, stale, reconnecting, or
+failed, while keeping retained data visible and safe.
+
+#### Solution
+
+Key stream state by backend/session/logical session/generation, add replay-ready
+and freshness metadata, gate bento rendering on committed identity, guard late
+callbacks, and pass one canonical state model to every dependent card.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update event-stream lifecycle, timeline/world-view selection, bento snapshots,
+  Trace/Provider cache keys, stale banners, live regions, and retry actions.
+
+##### Contracts
+
+- State declares identity, hydrating, ready-known-empty, live, historical,
+  stale, reconnecting, gap, recovery-failed, last event, and retryability.
+
+##### Services
+
+- Factory Sessions/Events provides replay-ready or watermark semantics.
+
+##### API changes
+
+- Add a stream-ready/replay-watermark envelope if existing events cannot signal
+  completion; regenerate stream types.
+
+##### Tests
+
+- Zero-event readiness, retained offline/recovery, gap, live-history-live,
+  A-to-B same IDs, late A event/status, stale Trace/Provider state, and retry.
+
+#### Acceptance criteria
+
+- Retained data is visibly stale and never suppresses retry or failure.
+- Historical mode cannot mutate the Current Factory.
+- A switch cannot render, cache, select, or announce prior-session data.
+
+### Story 3: Define honest Work metrics and chart behavior
+
+#### Problem statement
+
+The outcomes chart repeats its Y-axis title and compares incompatible Work and
+dispatch populations; Work totals repeats the ambiguity and stays four columns.
+
+#### Customer ask
+
+Read one clear, comparable, localized set of Work metrics in totals and chart.
+
+#### Solution
+
+Define each metric's subject, aggregation, unit, and included outcomes; remove
+the duplicate label/grid, add localized axis/tooltip formatting and a textual
+data alternative, and reflow totals at narrow widths.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update outcome/totals projections, chart axis/legend/tooltip/summary,
+  keyboard inspection/zoom, indexed point building, and responsive totals.
+
+##### Contracts
+
+- Metrics declare Work versus dispatch, gauge versus cumulative, non-negative
+  integer units, and treatment of accepted/continue/rejected/failed/retry/cancel.
+
+##### Services
+
+- Factory Visualization owns a typed aggregate only if canonical events are
+  insufficient for one client projection.
+
+##### API changes
+
+- None unless backend-owned aggregates are required; then regenerate clients.
+
+##### Tests
+
+- Exactly one axis title/grid, metric truth table, zero/outlier/dense history,
+  selected tick, localized tooltip, accessible table, keyboard zoom, full-width
+  chart, and totals 2x2/1-column reflow.
+
+#### Acceptance criteria
+
+- Every number has one unambiguous subject, aggregation, and unit.
+- The chart fills its card and has one axis title plus an accessible data view.
+- Controls are keyboard operable, non-color-dependent, and at least 44 px.
+
+### Story 4: Make Submit Work session-safe, bounded, and traceable
+
+#### Problem statement
+
+Simple drafts can cross sessions, simple success is silent, rich status is
+capped by `max-w-xl`, file staging is unbounded whole-file base64 JSON, and
+accepted/duplicate/runtime state is not retained.
+
+#### Customer ask
+
+Submit to a visible destination, attach content safely, avoid duplicate retries,
+and keep a trustworthy receipt linking to Work and Trace.
+
+#### Solution
+
+Scope simple/rich draft and mutation state by exact session, make status full
+width, align validation and form IDs, enforce published upload limits with
+streaming/cancel, and keep a session-scoped idempotent receipt ledger.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update simple/rich composers, status panel, destination/receipt UI, form IDs,
+  file picker/drop/paste, progress/cancel/retry, and safe previews.
+
+##### Contracts
+
+- Align required name/state semantics; define types, size/count/total limits,
+  opaque staging tokens, cleanup, idempotency, and receipt lifecycle.
+
+##### Services
+
+- Work owns admission receipts and bounded content staging; host paths never
+  enter client references.
+
+##### API changes
+
+- Author changes in component fragments, replace unbounded JSON staging with
+  multipart/stream/chunks, and regenerate Go/TypeScript clients.
+
+##### Tests
+
+- A-to-B drafts and late completions, double submit, validation associations,
+  duplicate widget IDs, full-width status, file limits/types/sniffing,
+  progress/cancel/cleanup, ambiguous retry, receipt remount, and Work/Trace link.
+
+#### Acceptance criteria
+
+- Session A drafts/results never submit to or annotate B.
+- Status fills the card and every path shows one localized success/error state.
+- Staging is bounded, cancellable, path-opaque, and receipt identity is durable.
+
+### Story 5: Preserve exact concurrent and terminal Work identity
+
+#### Problem statement
+
+Workstation activity collapses by transition; Active Work and Terminal Work
+lose dispatch/Work identity, duplicate labels select together, canceled states
+are absent, and history is unbounded or ambiguously ordered.
+
+#### Customer ask
+
+See every concurrent and terminal Work item once and open its exact execution.
+
+#### Solution
+
+Project Work participation by `(dispatch_id, work_id)`, Terminal Work by
+`workId` plus terminal event, retain exact status/timing/failure/association,
+and index/sort/page projections deterministically.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update replay/runtime activity, Active Work, Terminal Work, Current Selection
+  actions, ordering, historical clocks, paging, and selection/history keys.
+
+##### Contracts
+
+- Labels are presentation only; completed, failed, canceled/interrupted, and
+  terminated remain explicit terminal outcomes.
+
+##### Services
+
+- Consume canonical Work, dispatch, recordings, and Worker Session associations.
+
+##### API changes
+
+- Extend terminal projection with IDs/status/timing/associations if current
+  label arrays cannot be replaced client-side; regenerate clients.
+
+##### Tests
+
+- Same workstation concurrency, duplicate names, one sibling completion,
+  cancellation, historical scrub, exact row navigation, ordering, pagination,
+  stale/loading/error, long labels, and Worker Session links.
+
+#### Acceptance criteria
+
+- Every participation/terminal Work appears once by immutable identity.
+- Completing one sibling does not remove another and history freezes elapsed time.
+- Rows open the exact Work, dispatch, trace, and Worker Sessions.
+
+### Story 6: Expose authoritative Worker Sessions end to end
+
+#### Problem statement
+
+The backend has Worker Session observations, replay, lifecycle, and optional
+provider identity, but the dashboard reconstructs lossy Provider Session rows
+and cannot inspect provider-less sessions or retries.
+
+#### Customer ask
+
+Enumerate and inspect every Worker Session for selected Work and the Current
+Factory Session, including attempts without Provider Sessions.
+
+#### Solution
+
+Make `workerSessionId` primary, expose exact detail and resumable events, model
+attempt chronology explicitly, add UI APIs/hooks/cards/history, and keep Provider
+Session as optional linked detail.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Extend Worker Sessions service/HTTP/mapping, recordings association replay,
+  generated clients, UI adapters, selection kind/history, list/detail/events.
+
+##### Contracts
+
+- Detail includes Work, dispatch attempts, workstation, timing, lifecycle,
+  failure, optional provider, cursor, gap/truncation, and replay completion.
+
+##### Services
+
+- Worker Sessions owns identity/attempts/observations; Events owns source-native
+  live retention; Recordings owns durable associations.
+
+##### API changes
+
+- Add exact ID-based detail/events and cursor-paged Factory Session list; keep
+  provider-reference lookup as compatibility; regenerate interfaces.
+
+##### Tests
+
+- Provider-less, concurrent sessions, multi-retry/provider switch, all terminal
+  states, live/replay, resume/gap, selected Work and session-wide lists,
+  back/forward, pagination, narrow/desktop.
+
+#### Acceptance criteria
+
+- Every Worker Session appears once by stable ID regardless of provider.
+- Attempt chronology preserves every dispatch and association.
+- Reconnect loses/duplicates no event and exposes gaps/known-empty/terminal state.
+
+### Story 7: Make workstation and inspection history complete
+
+#### Problem statement
+
+Request history shows only the first Work, suppresses attempts, omits Worker
+Session identity and output/mutation detail, and selected Work payload/relation
+views can silently lose or misnavigate data.
+
+#### Customer ask
+
+Inspect one coherent request/dispatch/Work/Worker Session timeline with safe
+payload and relation navigation.
+
+#### Solution
+
+Build a unified dispatch timeline with all Work, attempts, outputs, mutations,
+failures, Worker/Provider links, exact identity, typed async states, and bounded
+safe payload/relationship presentation.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update Current Selection projectors, request/detail sections, workstation
+  summary/config draft source, Active Work, payload/content rendering, relation
+  list/graph navigation, copy/download controls, and focus/history.
+
+##### Contracts
+
+- Dispatch/Work/Worker/Provider identities remain distinct; content exposes
+  bounded/redacted metadata and authorized retrieval rather than raw file URLs.
+
+##### Services
+
+- Work owns content/lineage; Worker/Provider Sessions own their details;
+  Factory Visualization may aggregate read-only timeline rows.
+
+##### API changes
+
+- Add missing worker session, tags/state/lineage, output/mutation, truncation, or
+  authorized artifact fields where projections cannot recover them.
+
+##### Tests
+
+- Multi-Work requests, request plus attempts, provider-less attempt, retries,
+  active-save guard, worker/provider change, malformed/unknown content, safe
+  artifact retrieval, unresolved/cyclic relations, typed states, and paging.
+
+#### Acceptance criteria
+
+- No request or attempt suppresses another; every Work participation is visible.
+- Summary and form use one draft source and active mutation has enforced policy.
+- Payload/relation views are bounded, safe, accessible, and never silently no-op.
+
+### Story 8: Keep Trace, Work, Worker, and Provider inspection coherent
+
+#### Problem statement
+
+Trace cache identity omits session generation, relation-only traces are hidden,
+positional fallback invents causality, selected Work is not wired through, and
+Provider Session content/context/navigation are inconsistent and unbounded.
+
+#### Customer ask
+
+Move through exact Work, dispatch, Trace, Worker Session, and Provider Session
+context with truthful causality and reliable back/forward.
+
+#### Solution
+
+Key Trace by full stream identity, use canonical predecessor dispatch IDs,
+thread selected Work/dispatch through graph/table, provide textual relations,
+and separate Provider content identity from optional origin context with bounded
+redacted transcript inspection.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update Trace query/selection, causal projection, relation/path graphs and
+  table sync, Provider selection/entry points, retry/cache/abort, transcript,
+  focus/history, and narrow graph shells.
+
+##### Contracts
+
+- Trace exposes canonical predecessor IDs, timing/status/provider/worker,
+  unresolved/truncated metadata; Provider content key is `{provider,kind,id}`
+  and origin is optional context.
+
+##### Services
+
+- Recordings owns causal Factory history; Worker/Provider Sessions own their
+  normalized details and redaction.
+
+##### API changes
+
+- Add predecessor/worker/truncation/redaction pagination fields if missing;
+  regenerate affected clients.
+
+##### Tests
+
+- A-to-B same IDs, relation-only trace, parallel/out-of-order/repeated paths,
+  missing predecessor gap, row/graph sync, textual relation list, every Provider
+  entry point, shared provider session, retry/abort, redaction, huge transcript.
+
+#### Acceptance criteria
+
+- Session switches cannot show old Trace/Provider content.
+- The UI never invents sequential causality for independent dispatches.
+- Graph and textual/table views share selection, identity, order, and context.
+
+### Story 9: Unify editor transactions and complete grouping
+
+#### Problem statement
+
+Editor history covers layout only; topology/fields/groups use different rules;
+observe mode can mutate authored geometry; group creation, visibility,
+click-through, membership undo, validation, cancel, and keyboard behavior fail.
+
+#### Customer ask
+
+Treat every edit—including grouping—as one predictable draft with complete
+Undo/Redo, save protection, cancel, and observe-mode immutability.
+
+#### Solution
+
+Create one editor document and domain command stream for topology, fields,
+layout, group membership, and viewport intent; guard dirty exits/session changes
+and stale saves. Implement group visuals/fit/sizing through the linked graph
+visual plan rather than duplicating renderer ownership here.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update editor document/history/operations, selection bridge, add/connect/delete,
+  group membership transaction, save/reset/discard, viewport policy, and guards.
+
+##### Contracts
+
+- Commands store domain transitions, not React Flow objects; all portable
+  changes set dirty/stale protection; group bounds are finite and positive.
+
+##### Services
+
+- Factory Definitions remains save/validation owner.
+
+##### API changes
+
+- None unless server validation lacks required group geometry constraints.
+
+##### Tests
+
+- Mixed topology/field/layout/group history, reassignment undo, duplicate/cycle,
+  cancel/pointercancel, failed confirmation, stale layout save, dirty session
+  switch, observe immutability, save/reload, and linked group browser journeys.
+
+#### Acceptance criteria
+
+- Undo/Redo restores the entire prior/next document in LIFO order.
+- Groups render in edit/observe/replay, do not block member/edge interaction,
+  validate geometry, and support pointer/keyboard cancel and manipulation.
+- Observe mode never persists node/group/viewport changes.
+
+### Story 10: Make graph interaction progressive and contained
+
+#### Problem statement
+
+Add/connect/delete/selection modes are inconsistent, pending connections cannot
+cancel, legends/controls omit semantics or collide, and React Flow failures can
+escape without local recovery.
+
+#### Customer ask
+
+Use discoverable graph actions with clear eligibility, keyboard/touch parity,
+safe overlays, and recovery that does not blank the dashboard.
+
+#### Solution
+
+Centralize typed graph actions and selection, expose progressive connection
+intent/cancel, union/validate endpoints, reserve overlay insets, complete legend
+semantics, and classify failures inside the graph card.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update action registry, dialogs/errors/focus, connection controller, handles,
+  selection/delete confirmation, toolbar/legend/controls, Fit/group bounds,
+  endpoint validation, and graph error boundary.
+
+##### Contracts
+
+- Unknown actions fail closed; every edge endpoint exists; duplicate/cycle
+  eligibility is explicit; only proven integrity diagnostics are fatal.
+
+##### Services
+
+- Existing Factory document save/validation remains authoritative.
 
 ##### API changes
 
@@ -272,34 +723,35 @@ chart component; keep chart data and series behavior unchanged.
 
 ##### Tests
 
-- Component assertion for exactly one visible/accessibility-tree Y-axis title
-  and one intended grid; browser geometry at narrow and desktop card sizes.
+- Unknown/add/cancel/focus, valid/duplicate/cycle connect, Escape/pointer cancel,
+  failed delete, keyboard/touch, 44 px controls, overlay geometry, complete
+  legend, empty/loading/error/retry, large graph adapter budget.
 
 #### Acceptance criteria
 
-- `Work count` is presented exactly once without clipping ticks or legend.
-- The chart remains readable at compact and desktop widths, with all series
-  toggle and zoom behavior unchanged.
+- Actions never silently fall through and pending gestures always cancel safely.
+- Toolbar, legend, controls, and notices remain reachable without covering data.
+- One graph projection/render failure stays inside its card with localized retry.
 
-### Story 2: Make Submit Work feedback full-width, singular, and session-safe
+### Story 11: Make bento lifecycle and persistence safe
 
 #### Problem statement
 
-Submit feedback is capped below card width, item errors can appear twice, and a
-late response from a previous session can overwrite the current form.
+Duplicate graph cards race singleton editor state, removal loses dirty work,
+persisted invalid/duplicate geometry survives, instance IDs are reused, layout
+scope/errors are silent, and 640–768 retains unusable desktop geometry.
 
 #### Customer ask
 
-Keep submission feedback aligned with the form and scoped to the submission
-that produced it.
+Add, remove, move, resize, reload, and reflow widgets without losing work,
+breaking identity, or requiring pointer input.
 
 #### Solution
 
-Remove the status width cap, give each validation error one authoritative
-location/association, scope both simple and rich drafts/mutations by exact
-Factory Session, show the destination and returned receipt, synchronously guard
-activation, and ignore or cancel responses whose initiating session generation
-is no longer active.
+Centralize widget metadata/policy, enforce graph singleton and instance caps,
+use versioned scoped persistence with sanitization/collision repair/monotonic
+IDs, add dirty-aware remove+undo/focus announcements, and provide keyboard/touch
+move/resize/cancel plus coherent compact layout through 768 px.
 
 #### Original document
 
@@ -309,54 +761,56 @@ is no longer active.
 
 ##### Package changes
 
-- Update `submit-work-status-panel.tsx`, `submit-work-card.tsx`, simple composer,
-  `use-submit-work-widget.ts`, and bento instance/form IDs; reuse shared status
-  and form primitives.
+- Update typed catalog, add/remove UI, layout schema/store/migrations/mutations,
+  AgentBento projection, focus/live region, collision policy, reduced motion,
+  storage errors/reset, and high-card-count placement.
 
 ##### Contracts
 
-- Keep local draft/mutation state separate from returned canonical
-  `requestId`/`traceId`.
+- Envelope defines version/scope/items/counter; IDs are unique and monotonic;
+  geometry is integer, positive, bounded, collision-repaired, and widget-specific.
 
 ##### Services
 
-- Work admission behavior is unchanged for this story.
+- None unless preferences move to operator settings after scope decision.
 
 ##### API changes
 
-- None for width, error presentation, same-tick guard, or session scoping.
+- None for local preference; use Operator Settings only by explicit product choice.
 
 ##### Tests
 
-- Width measurement, one-error announcement, duplicate-widget IDs,
-  double-click/Enter+click, simple and rich A-to-B draft isolation, visible
-  destination, simple success/trace receipt, late success/error after session
-  switch, retry, long locale/200% zoom, and narrow layout coverage.
+- Hostile JSON/IDs/geometry/overlap, migrations, storage failure, singleton/caps,
+  dirty remove/undo/focus, add announcement, pointer/keyboard/touch/cancel,
+  visual/DOM order, 320/390/640/768/desktop, reduced motion, and 100 cards.
 
 #### Acceptance criteria
 
-- Guidance, pending, success, validation, and error panels fill the card and
-  wrap without horizontal overflow.
-- Each error is announced once and is programmatically associated with its
-  recovery target.
-- One activation produces one client mutation; late session-A results do not
-  clear or annotate session B.
+- Reload yields unique IDs, valid non-overlapping geometry, one Add card, and
+  enforced singleton/caps with a recover/reset notice when sanitation occurs.
+- Removal cannot silently lose dirty editor/form/staged state and restores focus.
+- Compact layout is full width and usable through 768 without persisting it.
 
-### Story 3: Align the Submit Work public name contract
+### Story 12: Standardize widget spacing, accessibility, locales, and scale
 
 #### Problem statement
 
-Generated clients allow an omitted request name while server and dashboard
-behavior reject missing, empty, and whitespace-only names.
+Current Selection and Trace share an outer frame but use inconsistent inner
+rhythm; many controls miss 44 px; no general card error boundary exists; ja/ko
+often fall back to English; dense cards are unbounded; unrelated cards rerender
+on the one-second clock.
 
 #### Customer ask
 
-Make public, server, and dashboard validation agree.
+Use a coherent, resilient dashboard at every supported viewport, input mode,
+locale, zoom level, and session size.
 
 #### Solution
 
-Make `SubmitWorkRequest.name` required with matching semantic validation and
-regenerate every contract consumer.
+Adopt shared inspection-section/description-list/async-state primitives,
+per-card boundaries, complete locale catalogs, 44 px and keyboard/touch rules,
+responsive reflow/forced-color/reduced-motion recipes, bounded inspectors, and
+scoped clock subscriptions with measured budgets.
 
 #### Original document
 
@@ -366,1333 +820,68 @@ regenerate every contract consumer.
 
 ##### Package changes
 
-- Update authored OpenAPI fragments and matching Work admission/UI validation.
+- Migrate Current Selection/Trace sections, nested surfaces and descriptions;
+  add card boundary/status primitives; complete ja/ko and formatters; paginate or
+  virtualize Terminal/Trace/Provider/history; memoize cards and scope clocks.
 
 ##### Contracts
 
-- `name` is required and blank-only input is invalid across all entry points.
-- Preserve the existing, intentional header-only Work behavior: optional blank
-  text rows are omitted rather than transmitted as blank items.
+- Direct sections use 16 px block separation and 10 px internal gap; later
+  sections use one divider plus 16 px top; nested surfaces use 12 px padding;
+  descriptions stack below 640 and use 136 px labels above. Bounded reads expose
+  total/range/cursor/truncation.
 
 ##### Services
 
-- `pkg/services/work` remains the canonical admission owner.
+- Owning services provide cursor paging where client retention is not the
+  canonical complete set; technical diagnostics use stable codes.
 
 ##### API changes
 
-- Run `make generate-api` or `make interfaces-all` as required; never hand-edit
-  bundled OpenAPI or generated Go/TypeScript clients.
+- Add cursor/total/truncation/redaction fields only where required; regenerate
+  clients. Authored UI copy remains client-owned.
 
 ##### Tests
 
-- API contract, transport, generated-client, UI helper, and browser validation
-  cases for missing/empty/whitespace names and optional empty text content.
+- Every widget twice, unique IDs/headings, deliberate throw isolation, spacing
+  geometry, 44 px/tab/focus/live roles, forced colors/reduced motion, all locales
+  plus pseudo-long, 200% zoom, 20 widgets plus 1,000-row inspectors, rerender and
+  memory/commit budgets.
 
 #### Acceptance criteria
 
-- Every public client rejects or cannot construct the invalid name cases, and
-  server/UI outcomes remain equivalent.
-- Generated artifacts are drift-free and `make api-smoke` passes.
-
-### Story 4: Return and render each live Factory Session once
-
-#### Problem statement
-
-Two live-session readers can describe the same default session as a UUID and
-`~default`, and the header renders both rows as separate tabs.
-
-#### Customer ask
-
-Show one navigation entry for each real live Factory Session and no phantom
-Factory.
-
-#### Solution
-
-Reconcile live summaries by canonical session identity in the Factory Sessions
-owner, then render singleton context without exposing a routing alias as a
-second resource.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Correct `pkg/services/factory_sessions/transports/http/session_listing.go`
-  and the header session projection/components.
-
-##### Contracts
-
-- Preserve `~default` as an input selector; publish the resolved UUID when
-  known. Do not deduplicate by Factory name or path because distinct sessions
-  may target the same Factory.
-
-##### Services
-
-- Factory Sessions owns list reconciliation and session selection.
-
-##### API changes
-
-- No schema change.
-
-##### Tests
-
-- Exact duplicate, alias+UUID, one default, default+named, two sessions for one
-  Factory, close-to-single, and server response-count regressions.
-
-#### Acceptance criteria
-
-- One real default session yields one header context; default plus named yields
-  two; two distinct sessions targeting one Factory remain two.
-- Exactly one session uses concise current context rather than a misleading
-  one-item tab strip; Open another session remains reachable.
-
-### Story 5: Make Open Factory and New Factory explicit paths
-
-#### Problem statement
-
-Creation is available only after an action labelled Start Factory performs a
-validation-only request and produces a failed-looking state.
-
-#### Customer ask
-
-Let users intentionally open an existing Factory or create a new one.
-
-#### Solution
-
-Present explicit Open existing and Create new paths using the existing
-validation and `initNewFactory` operations, with destination preview and
-operation-specific errors.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Update `dashboard-session-tabs-open-dialog.tsx`,
-  `use-dashboard-session-tabs-state.ts`, and localized messages.
-
-##### Contracts
-
-- Keep `Factory` creation distinct from opening/selecting the resulting
-  `Factory Session` and its `Current Factory`.
-
-##### Services
-
-- Factory Sessions owns discovery/open; Factory Definitions owns scaffold
-  persistence.
-
-##### API changes
-
-- Reuse existing `POST /factory-sessions` fields; no new route or schema.
-
-##### Tests
-
-- Existing target, missing target, invalid/broken config, create preview,
-  create success, validation/scaffold/open failures, cancel, and keyboard flow.
-
-#### Acceptance criteria
-
-- Validation is visibly non-mutating and never described as starting a Factory.
-- Create previews the exact `<folder>/factory` destination, and success opens
-  and selects the returned session.
-- A broken existing Factory is never offered an overwrite-as-new shortcut.
-
-### Story 6: Preserve every concurrent workstation dispatch
-
-#### Problem statement
-
-Multiple active dispatches on the same workstation collapse to the last entry
-in `workstation_activity_by_node_id`.
-
-#### Customer ask
-
-Show all active Work at a workstation without unstable ordering or loss.
-
-#### Solution
-
-Aggregate activity by workstation into a deterministic dispatch-keyed
-collection rather than replacing entries by `transitionID`.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Correct `ui/src/features/timeline/state/timeline/projectRuntime.ts` and
-  downstream graph/current-selection projections.
-
-##### Contracts
-
-- Use `(dispatch_id, work_id)` for Work participation and preserve stable
-  workstation identity mapping across node ID, transition ID, and name fallback.
-
-##### Services
-
-- No service mutation; consume canonical Factory Events.
-
-##### API changes
-
-- None.
-
-##### Tests
-
-- Same-workstation concurrency, one sibling completion, equal timestamps,
-  replay order, node/transition divergence, and graph component proof.
-
-#### Acceptance criteria
-
-- Every concurrent dispatch remains visible and deterministically ordered.
-- Completing one dispatch removes only that dispatch; siblings remain.
-- Live and selected-tick replay produce the same projection.
-
-### Story 7: Project durable dispatch-to-Worker Session associations
-
-#### Problem statement
-
-The UI discards `DISPATCH_WORKER_SESSION_ASSOCIATION`, preventing durable
-correlation of Factory activity with Worker Session identity.
-
-#### Customer ask
-
-Keep the association needed to inspect the real execution session.
-
-#### Solution
-
-Add the generated event to typed UI handling and replay it into a durable
-dispatch-keyed association projection without copying source-native Worker
-observations into Factory replay state.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Update UI event types, `replayWorldState.ts`, runtime projections, and shared
-  replay package contracts only if the package owns this event vocabulary.
-
-##### Contracts
-
-- Association is durable Factory history; Worker observation records remain on
-  the Worker Session Events topic.
-
-##### Services
-
-- Recordings remains the Factory Event owner; Worker Sessions owns observation.
-
-##### API changes
-
-- None; generated payload already exists.
-
-##### Tests
-
-- Retained replay, reconnect, out-of-order canonicalization, duplicate
-  idempotency, terminal history, and conflicting-association diagnostics.
-
-#### Acceptance criteria
-
-- Every known association survives live delivery and replay and is addressable
-  by dispatch ID.
-- No Worker Session observation is silently promoted into durable Factory state.
-
-### Story 8: Stream truthful Worker Session Events
-
-#### Problem statement
-
-The current runtime-bound Worker Session route can prefer Factory ledger events
-while the public route promises the source-native Worker Session Events topic.
-
-#### Customer ask
-
-Make live Worker Session progress truthful about source, ordering, and history
-availability.
-
-#### Solution
-
-For live sessions, stream retained-then-live records from the exact Worker
-Session Events topic. For historical/restarted sessions, return an explicitly
-documented provenance/fallback or a typed source-history-unavailable outcome.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Correct the runtime Worker Session observation adapter and HTTP handler tests.
-
-##### Contracts
-
-- Define terminal, replay, source-failure, retention-gap, cancellation, and
-  restart semantics; never present Factory Events and source-native Events as
-  identical provenance.
-
-##### Services
-
-- Worker Sessions publishes to Events; Events supplies retained/live aggregate
-  order; Recordings remains historical Factory facts.
-
-##### API changes
-
-- No shape change if current delivery/provenance values can express the result.
-  Add a cursor/gap contract only if reconnect requirements prove it necessary.
-
-##### Tests
-
-- Interleaved sibling streams, terminal close, already-terminal replay, source
-  failure, retention gap, cancellation, restart, and server-bound SSE proof.
-
-#### Acceptance criteria
-
-- Sibling records never cross streams; terminal closes only the matching
-  session; complete retained records survive source failure.
-- The client can distinguish live source-native records from historical
-  Factory-event projection or explicit unavailability.
-
-### Story 9: Render every Worker Session for selected Work
-
-#### Problem statement
-
-Current Selection renders inferred Provider Session attempts and cannot show
-starting, script, concurrent, or terminal Worker Sessions independently.
-
-#### Customer ask
-
-Enumerate the authoritative Worker Sessions associated with selected Work.
-
-#### Solution
-
-Add a typed UI API/hook/feature using the existing work-scoped list and exact
-stream/show/transcript operations. Key rows by `workerSessionId` and expose a
-Provider Session link only when available.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Add `ui/src/api/worker-sessions/` and a focused Worker Sessions feature;
-  integrate it into selected Work/Current Selection without feature-wide
-  barrels.
-
-##### Contracts
-
-- Worker Session is execution identity; Provider Session is optional detail.
-  Stream state is keyed by `workerSessionId`, never only dispatch/workstation.
-
-##### Services
-
-- Reuse Worker Sessions and Provider Sessions public operations.
-
-##### API changes
-
-- No change for selected-Work enumeration. Factory-session-wide enumeration is
-  a separate follow-up unless a proven journey requires it.
-
-##### Tests
-
-- Multiple concurrent sessions, STARTING without provider, terminal
-  completed/failed/canceled, loading/empty/not-found/error/retry, interleaved
-  streams, reconnect dedupe, selection change, and unmount cleanup.
-
-#### Acceptance criteria
-
-- Every returned Worker Session is a separate stable row/card in API order.
-- One stream failure does not erase siblings; terminal rows remain inspectable.
-- Optional Provider Session/transcript actions never hide the Worker Session.
-
-### Story 10: Enumerate all Work and execution history for a workstation
-
-#### Problem statement
-
-Request history shows only `work_items[0]`, request presence suppresses other
-attempts, and attempts without Provider Sessions disappear.
-
-#### Customer ask
-
-Show complete active and historical workstation participation with reliable
-navigation.
-
-#### Solution
-
-Project Work participation by `(dispatch_id, work_id)`, deduplicate input/output
-overlap, join request summaries with authoritative Worker Sessions without
-mutual suppression, and add progressive history rendering if the measured
-fixture requires it.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Update Current Selection request helpers, workstation detail/history/active
-  components, selection history, and feature messages.
-
-##### Contracts
-
-- Preserve Work, dispatch request, Worker Session, and Provider Session
-  identities separately; label consumed and produced Work relationships.
-
-##### Services
-
-- Reuse Recordings projections, paginated Work, and work-scoped Worker Sessions.
-
-##### API changes
-
-- None unless the scale probe proves existing composition incomplete or an
-  unacceptable N+1 path.
-
-##### Tests
-
-- Multi-Work dispatch, input/output overlap, repeated Work across dispatches,
-  multiple Worker Sessions/retries, missing provider, deterministic order,
-  forward/back navigation, loading/error/empty, and large history.
-
-#### Acceptance criteria
-
-- Every distinct Work participation and Worker Session attempt is visible once
-  in the correct context.
-- Work and request actions open exact identities and preserve selection history.
-- Partial projection data is never presented as a definitive empty state.
-
-### Story 11: Unify graph editor command history and selection semantics
-
-#### Problem statement
-
-Generic Undo/Redo covers layout only, observer selection can look like editor
-selection while editor actions see nothing selected, and observer nodes remain
-draggable.
-
-#### Customer ask
-
-Make graph editing predictable across topology, layout, mode, and selection.
-
-#### Solution
-
-Represent topology, fields, and layout changes as one ordered editor document
-history; make runtime-inspection, group, and editor selection explicit; disable
-node and viewport persistence in observe mode. Group visual behavior, group
-fit-to-members, node sizing, and group-region styling remain owned by Stories
-3–4 of `factory-graph-visual-ux.md`; this story owns their shared transaction,
-dirty-state, stale-save, and Undo/Redo seam.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Update editable graph hooks, graph operations/history, selection gestures,
-  controls, view model, and viewport wiring.
-
-##### Contracts
-
-- History records domain commands/document transitions, never React Flow
-  objects. Save sets a baseline; Discard restores server state and clears
-  history.
-
-##### Services
-
-- Current Factory document save remains the mutation owner.
-
-##### API changes
-
-- None.
-
-##### Tests
-
-- Mixed add/connect/delete/field/move/group-membership/reset command order,
-  compound group reassignment undo, stale layout-only save rejection, dirty
-  session-change guards, redo invalidation, save/discard, mode transitions,
-  Escape/additive selection, and observe/editor drag browser proof.
-
-#### Acceptance criteria
-
-- Undo/Redo restores the complete prior/next editable Factory document in LIFO
-  order and button state matches available history.
-- Entering edit mode never leaves a node looking editor-selected while Delete
-  reports no selection.
-- Observer nodes cannot move; editor drag dispatches one layout operation.
-
-### Story 12: Make connection editing and editor controls progressive
-
-#### Problem statement
-
-Edit mode places every connection handle into a huge interaction surface with
-no clear Connect workflow, and the floating toolbar clips/overlays content.
-
-#### Customer ask
-
-Provide a discoverable, keyboard-operable connection flow and reachable draft
-actions at every supported viewport.
-
-#### Solution
-
-Activate connection targets only after an explicit source/focus intent, expose
-valid targets and cancellation, and give the editor toolbar safe canvas insets
-plus responsive wrapping/scroll/overflow behavior.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Update editor connection projection/controllers, React Flow wiring, controls,
-  floating surface, localized tooltips, and fit-view inset logic.
-
-##### Contracts
-
-- Every edge endpoint references a handle rendered by the same canonical
-  projection; connection completion dispatches a graph operation.
-
-##### Services
-
-- None beyond existing Factory document save.
-
-##### API changes
-
-- None.
-
-##### Tests
-
-- Valid/invalid targets, keyboard source/target/cancel, handle projection,
-  390/768/1280 toolbar geometry, dirty Save/Discard visibility, focus order,
-  and real React Flow browser interaction.
-
-#### Acceptance criteria
-
-- Handles do not all enter tab order before connection intent.
-- Escape cancels without changing the draft; successful connection updates the
-  canonical draft and never persists raw React Flow edges.
-- Save, Discard, and Leave remain visible/reachable and the toolbar does not
-  cover selectable graph content.
-
-### Story 13: Recover, project, and manipulate bento layouts safely
-
-#### Problem statement
-
-Unsafe persisted geometry and duplicate IDs can reach React Grid Layout; tablet
-widths retain cramped desktop columns; layout manipulation is pointer-only.
-
-#### Customer ask
-
-Keep the dashboard usable after reload and across viewport/input modes.
-
-#### Solution
-
-Normalize stored layouts into unique bounded geometry with content-specific
-minimums, define and enforce singleton/duplicate limits, codify the chosen
-operator/backend/factory preference scope, project one column across the
-unusable tablet gap without persisting compact geometry, and add keyboard
-reorder/resize plus dirty-aware add/remove operations.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Update bento schema/persistence/mutations/store, `agent-bento.tsx`, the typed
-  widget catalog, duplicate widget labels, remove/undo/focus behavior, and
-  layout action primitives. Treat Factory graph as singleton until editor
-  controller ownership is instance-scoped.
-
-##### Contracts
-
-- Browser-local layout uses a versioned envelope with explicit scope, monotonic
-  instance identity, unique IDs, singleton counts, positive integer bounds,
-  deterministic collision repair, and a recover/reset path. Widget contents
-  and selections remain Factory Session-scoped. React Grid Layout and compact
-  geometry remain disposable.
-
-##### Services
-
-- No backend service.
-
-##### API changes
-
-- None.
-
-##### Tests
-
-- Malformed/unsafe storage, duplicate IDs/singletons, overlap repair,
-  idempotent migration, capped duplicates, dirty remove confirmation, undo,
-  focus restoration and live announcements, pointer/keyboard/touch
-  move/resize/cancel, storage failure, two scopes, desktop to compact to
-  desktop, and every card at 320/390/640/768/1280.
-
-#### Acceptance criteria
-
-- Reload always yields unique IDs, positive bounded dimensions, no off-grid
-  cards, one add-widget card, and meaningful content minimums.
-- Compact projection is full-width, deterministic, non-persisting, and covers
-  the current 640–768 gap.
-- Keyboard users can move/resize and hear the resulting position/size; duplicate
-  widget instances have distinct visible and accessible names.
-
-### Story 14: Make session, trace, and motion accessibility truthful
-
-#### Problem statement
-
-Session tabs control an empty panel, all tabs share a color-only selected-stream
-status, tab reordering is pointer-only, narrow trace graphs can overflow, and
-shared loading/overlay motion ignores reduced-motion preference.
-
-#### Customer ask
-
-Make dashboard navigation and visualization usable by keyboard, screen reader,
-touch, zoom, and reduced-motion users.
-
-#### Solution
-
-Use truthful tab-panel or navigation semantics, scope status to the active
-session unless per-session state exists, add text/shape and keyboard reorder,
-make trace diagrams fit their cards with operable resizing, and gate shared
-motion primitives.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Update session tab components/messages, trace graph shells, shared feedback
-  and overlay primitives, and undersized touch controls.
-
-##### Contracts
-
-- Inactive session status is neutral unless real per-session stream state is
-  projected. Status is not communicated by color alone.
-
-##### Services
-
-- None.
-
-##### API changes
-
-- None for honest active-only stream status.
-
-##### Tests
-
-- Arrow/Home/End/keyboard reorder and announcements, NVDA/VoiceOver spot check,
-  reduced-motion emulation, 200% zoom/reflow, 320/390 trace overflow, labelled
-  pan/zoom/resize, and minimum 44 px touch hit areas for dense actions.
-
-#### Acceptance criteria
-
-- No tab controls an empty panel; selected content has a truthful programmatic
-  relationship or the selector uses navigation semantics.
-- Session state is accessible without color and does not falsely apply one
-  stream's status to inactive sessions.
-- Trace cards do not cause page-level overflow, and all essential interaction
-  has keyboard/touch equivalents.
-- Nonessential pulse, ping, dialog, popover, and skeleton motion is suppressed
-  under reduced motion while state remains perceivable.
-
-### Story 15: Keep Work, trace, request, Worker Session, and Provider Session inspection coherent
-
-#### Problem statement
-
-Trace selection can outlive its Work, direct request detail cannot open the same
-Provider Session exposed elsewhere, back/forward restores only base selection,
-and duplicate terminal Work labels can resolve to the wrong Work/dispatch.
-
-#### Customer ask
-
-Make every drill-down step preserve exact identity and return to a coherent
-inspection context.
-
-#### Solution
-
-Validate or clear trace/session sub-selection atomically when Work changes,
-route Provider Session selection through every attempt surface, store or
-deterministically reset inspection context in selection history, and project
-terminal outcomes by Work plus terminal dispatch/event identity rather than
-display label.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Update selection history, trace selection, direct request detail, Provider
-  Session correlation, terminal-work projection/list identity, and trace state
-  ordering.
-
-##### Contracts
-
-- Work uses `work_id`; request/execution uses `dispatch_id`; Worker Session uses
-  `workerSessionId`; Provider Session content uses `(provider, kind, id)` while
-  dispatch/attempt is navigation context; trace comes from Factory Event replay.
-
-##### Services
-
-- Work, Worker Sessions, Provider Sessions, and Recordings retain their existing
-  read ownership.
-
-##### API changes
-
-- Extend Factory Visualization/dashboard terminal outcome data with Work-ID and
-  terminal dispatch/event references if the existing label-only projection
-  cannot provide exact identity; regenerate all contract artifacts if changed.
-
-##### Tests
-
-- Work A → trace A2 → Work B, duplicate terminal labels, completed-to-failed
-  transition, direct request → Provider Session, identical Provider Session from
-  two dispatches, back/forward, replay removal, and trace loading/absent/error.
-
-#### Acceptance criteria
-
-- Current Selection and trace/session detail never show identities from
-  different Work contexts.
-- Every inference attempt with an available Provider Session offers the same
-  keyboard-operable inspection action from Work and request paths.
-- Terminal rows open the exact Work and dispatch even when labels repeat.
-- Back/Forward either restores the full valid inspection step or intentionally
-  returns to its base entity; focus moves to the restored heading.
-
-### Story 16: Validate, contain, and scale every Factory graph projection
-
-#### Problem statement
-
-Replay forwards unchecked node/handle endpoints, current/trace graphs treat all
-React Flow diagnostics as fatal, merged trace nodes can discard required
-handles, and dense/live projections perform avoidable full scans and rebuilds.
-
-#### Customer ask
-
-Keep observe, replay, and trace graphs truthful, recoverable, and responsive on
-large live Factories.
-
-#### Solution
-
-Share endpoint validation across graph modes, union trace handles by stable ID,
-classify and contain fatal projection failures within the affected card, index
-runtime overlays once, and preserve stable node/edge identities across
-clock-only updates. Keep visual grammar work in `factory-graph-visual-ux.md`.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Update package replay projection/surface, dashboard and trace endpoint error
-  classification/boundaries, trace relation merge, current-activity view-model
-  memoization, replay empty state, and viewport precedence.
-
-##### Contracts
-
-- Every edge endpoint must reference a handle rendered by its projected node.
-  React Flow diagnostics are classified; only proven integrity failures are
-  fatal. A valid authored viewport wins over automatic fit.
-
-##### Services
-
-- Recordings and Factory Visualization remain canonical history/presentation
-  sources; no service mutation.
-
-##### API changes
-
-- None proven.
-
-##### Tests
-
-- Missing node/source handle/target handle, duplicate node ID, trace handle
-  union/conflict, card-local fatal recovery, non-fatal warning logging, empty
-  replay, authored viewport/fallback fit/tick change, and sparse/dense 500-node
-  performance/render-count fixtures.
-
-#### Acceptance criteria
-
-- Invalid topology produces a localized actionable graph error without blanking
-  unrelated dashboard cards; non-fatal warnings do not crash the graph.
-- Trace endpoint merging preserves every valid handle and diagnoses conflicts.
-- Dense replay projection is approximately linear in nodes, edges, and overlay
-  entries; clock-only updates preserve unaffected node/edge identity, viewport,
-  selection, and layout.
-- A valid authored viewport is honored, selected-tick changes preserve user
-  navigation, and zero-node replay presents an explicit empty state.
-
-### Story 17: Enumerate Worker Sessions for the Current Factory Session
-
-#### Problem statement
-
-Story 9 exposes Worker Sessions only through selected Work, while operators
-also need to understand every starting, concurrent, provider-less, retried, and
-terminal Worker Session in the Current Factory Session.
-
-#### Customer ask
-
-Provide a complete Factory Session-wide Worker Sessions view without requiring
-the operator to discover and select each Work first.
-
-#### Solution
-
-Add a Factory Session-scoped Worker Session list and exact detail journey keyed
-by `workerSessionId`, with attempts, Work and dispatch associations, lifecycle,
-optional Provider Session links, resumable observations, and stable navigation.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Extend Worker Sessions service contracts, recordings-backed projections, HTTP
-  transport/mapping, generated clients, and add a dashboard API module, query
-  hooks, list/detail components, and `worker-session` selection-history kind.
-
-##### Contracts
-
-- Worker Session ID is primary identity. Attempts preserve every dispatch and
-  provider association or absence; Work, workstation, timing, state, failure,
-  cursor, truncation, and replay-complete metadata are explicit.
-
-##### Services
-
-- Worker Sessions owns identity, attempts, lifecycle, observations, and
-  transcript availability. Recordings supplies durable Factory associations;
-  Provider Sessions stays optional detail.
-
-##### API changes
-
-- Add exact Worker Session detail/events endpoints and Factory Session-scoped
-  cursor pagination. Keep provider-reference lookup only as compatibility.
-- Regenerate bundled OpenAPI plus Go and TypeScript clients.
-
-##### Tests
-
-- Provider-less sessions, two concurrent sessions for one Work, multi-attempt
-  retries/provider switches, every terminal state, live/replay ordering,
-  resumable cursor/gap, back/forward, pagination, and narrow/desktop journeys.
-
-#### Acceptance criteria
-
-- Every Worker Session in the Current Factory Session appears once by stable
-  ID, regardless of Provider Session availability.
-- Selecting a row restores its exact attempt/Work/dispatch context and survives
-  back/forward without substituting Provider Session identity.
-- Reconnect resumes without loss or duplication and explicitly reports gaps,
-  known-empty, terminal, unavailable, and replay-complete states.
-
-### Story 18: Make Provider Session inspection contextual, safe, and bounded
-
-#### Problem statement
-
-Provider Session content can be fetched reliably, but users cannot see its
-origin context, reach it from every attempt, recover a failed fetch, or safely
-inspect a large/raw transcript.
-
-#### Customer ask
-
-Open the same Provider Session consistently from Work, request, dispatch, and
-Worker Session history with enough context to understand and safely navigate it.
-
-#### Solution
-
-Separate Provider Session content identity from optional origin context; route
-all entry points through one inspector with breadcrumbs, history, retry,
-stale-while-refresh, bounded transcript presentation, and explicit server-side
-redaction/reveal rules.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Update Provider Session selection keys/state, request and Worker Session
-  entry points, detail panel, transcript renderer, cache/retry behavior, focus
-  restoration, and safe copy/reveal controls.
-
-##### Contracts
-
-- Content identity is `{provider, kind, id}`. Origin context is optional
-  `{factorySessionId, dispatchID, workID, workerSessionID}` and does not create
-  duplicate content identities.
-- Transcript payloads carry redaction/truncation metadata; ciphertext and raw
-  secret-bearing tool data are not displayed by default.
-
-##### Services
-
-- Provider Sessions owns normalized/redacted transcript inspection and bounded
-  pagination; Worker Sessions supplies optional origin association.
-
-##### API changes
-
-- Add cursor/truncation/redaction fields only where the existing detail contract
-  cannot provide bounded safe reads; regenerate affected interfaces.
-
-##### Tests
-
-- Every entry point, one Provider Session shared by two dispatches, retry and
-  abort, stale refresh, back/forward, redacted and revealable payloads, huge
-  transcript paging/windowing, 44 px controls, and narrow long-content layout.
-
-#### Acceptance criteria
-
-- The inspector always shows Provider Session identity and available origin
-  context without clearing equivalent content when only the origin changes.
-- Large transcripts do not mount or reveal all raw data by default; authorized
-  reveal and copy actions are explicit, audited by tests, and redaction-safe.
-- Fetch errors are recoverable and session switches cannot show prior-session
-  content.
-
-### Story 19: Give dashboard Work metrics coherent, accessible semantics
-
-#### Problem statement
-
-Removing the duplicate Y-axis label does not fix a chart that compares queued
-Work, active dispatches, accepted dispatches, and ever-failed Work under one
-ambiguous unit. The Work totals card repeats the ambiguity with four labels
-whose gauges and cumulative counts use different subjects.
-
-#### Customer ask
-
-Make every chart series and summary total comparable, understandable,
-localizable, and operable without relying on color or pointer hover.
-
-#### Solution
-
-Define each series' subject, aggregation, unit, and included outcomes; project
-honest metrics, expose a textual latest/selected-tick data alternative, localize
-numbers and tooltips, and provide keyboard-equivalent inspection and range
-controls.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Update materialized outcome and totals projections, Work totals labels/reflow,
-  chart model/legend/tooltip/axis, accessible summary/table, keyboard range
-  control, point indexing, and optional display-only downsampling.
-
-##### Contracts
-
-- Every metric declares Work versus dispatch subject, gauge versus cumulative
-  aggregation, non-negative integer unit, and treatment of ACCEPTED, CONTINUE,
-  REJECTED, FAILED, retry, and cancellation outcomes.
-
-##### Services
-
-- Keep projection client-side if canonical events are sufficient; otherwise
-  Factory Visualization owns a typed outcome aggregate rather than duplicating
-  metric policy in Recharts components.
-
-##### API changes
-
-- None unless a backend-owned materialized aggregate is selected; any new
-  schema must use explicit metric definitions and generated clients.
-
-##### Tests
-
-- One axis title, chart/totals metric truth table, zero/negative/decimal
-  rejection, 1e9 outlier, 512-sample dense history, selected historical tick,
-  localized tooltip/ticks, keyboard inspection/zoom, accessible data
-  alternative, Work totals 2x2/1-column reflow, and exact card/chart width at
-  320/390/640/desktop.
-
-#### Acceptance criteria
-
-- Every plotted value has one unambiguous subject, aggregation, unit, and
-  accessible textual representation.
-- The chart has exactly one Y-axis title and one intentional grid, fills its
-  content width, and remains usable for outliers and dense history.
-- Interactive controls are outside `role=img` semantics, keyboard operable,
-  non-color-dependent, and at least 44 px.
-
-### Story 20: Isolate widgets and standardize asynchronous recovery
-
-#### Problem statement
-
-Individual cards infer loading, empty, stale, reconnecting, historical, and
-failed state differently; a retained snapshot can hide recovery failure, and a
-single rendering exception can remove the whole dashboard.
-
-#### Customer ask
-
-Keep available data visible and honest during hydration or recovery, and keep
-one broken widget from taking down its siblings.
-
-#### Solution
-
-Publish identity-keyed stream freshness to all cards, add a shared async-state
-presentation contract and per-widget error boundary, and synchronously gate
-session/trace/provider state before rendering a new Factory Session.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Update stream/timeline/session lifecycle state, world-view selection, bento
-  snapshot props, Trace and Provider cache keys, shared status panels/live
-  regions, retry actions, and `DashboardWidgetErrorBoundary`.
-
-##### Contracts
-
-- Stream state is keyed by backend, Factory Session, logical session, and
-  generation and declares hydrating, ready-known-empty, live, historical,
-  stale, reconnecting, gap, recovery-failed, last-event time, and retryability.
-
-##### Services
-
-- Factory Sessions/Events expose a replay-ready or watermark signal sufficient
-  to distinguish known-empty from still-hydrating without guessing from rows.
-
-##### API changes
-
-- Add a stream-ready/replay-watermark envelope if the existing stream cannot
-  signal replay completion; regenerate stream types and clients.
-
-##### Tests
-
-- Zero-event readiness, retained offline/reconnect/recovery failure, cursor
-  gap, live-to-historical-to-live, A-to-B same IDs, late A event/status after B,
-  stale Trace/Provider selection, retry, and deliberate child throw isolation.
-
-#### Acceptance criteria
-
-- Retained data remains visible with an explicit stale/degraded label and retry;
-  it never appears live or hides terminal recovery failure.
-- Historical mode is derived from timeline state and cannot submit or edit the
-  Current Factory.
-- A Factory Session switch cannot render, select, cache, or announce data from
-  the previous identity, and one widget exception leaves siblings operational.
-
-### Story 21: Bound dense inspection and isolate render churn
-
-#### Problem statement
-
-Terminal Work, Current Selection, Provider transcripts, Trace graphs/tables,
-and payload/relationship views can render all retained data, while the global
-one-second clock reconstructs cards that do not depend on time.
-
-#### Customer ask
-
-Keep the dashboard responsive with long-running sessions, large traces,
-transcripts, histories, payloads, and many widget instances.
-
-#### Solution
-
-Define product-level page/window/preview thresholds, incremental data contracts,
-and render budgets; index repeated joins; subscribe only time-dependent cards
-to the clock; and virtualize or progressively disclose dense inspectors.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Add bounded list/transcript/table models, virtualization or pagination,
-  truncation diagnostics, indexed Work/attempt/relation joins, memoized card
-  boundaries, scoped clocks, occupancy-grid bento placement, and performance
-  fixtures.
-
-##### Contracts
-
-- Bounded reads expose total count, returned range/cursor, truncation, and
-  continuation. Rendering downsampling never changes accessible values or
-  canonical stored history.
-
-##### Services
-
-- Owning services provide cursor pagination for data that cannot be bounded
-  safely in the client; Events retention and Recordings durability remain
-  distinct.
-
-##### API changes
-
-- Add cursor/limit/total/truncation fields for Worker/Provider Sessions or other
-  inspectors only where local retained state is not the canonical full set.
-
-##### Tests
-
-- Twenty widgets plus 1,000 Terminal/Trace/Provider/history entries, long text
-  and binary metadata, 512 outcome samples, pagination/window focus continuity,
-  cancellation, memory bounds, commit-time budgets, and proof that clock ticks
-  do not rerender unrelated cards.
-
-#### Acceptance criteria
-
-- No dense inspector mounts an unbounded retained collection or blocks the main
-  thread with whole-file/stringify/quadratic projection work.
-- Pagination/window changes preserve exact identity, ordering, selection,
-  focus, stale state, and accessible count/range copy.
-- Time-independent widgets do not rerender on the one-second dashboard clock.
-
-### Story 22: Complete advertised dashboard locales and long-copy geometry
-
-#### Problem statement
-
-The product advertises English, Simplified Chinese, Japanese, and Korean, but
-many bento catalogs provide only English and Chinese, formatters sometimes
-ignore locale, and long-copy geometry is not systematically tested.
-
-#### Customer ask
-
-See complete, correctly formatted dashboard copy in every advertised locale
-without clipped controls, overlapping labels, or English fallback surprises.
-
-#### Solution
-
-Require complete message catalogs for every advertised locale, route all
-numbers/durations/outcomes through locale-aware formatters, and add pseudo-long
-geometry fixtures across every card and breakpoint.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Complete ja/ko catalogs, strengthen locale completeness checks, remove
-  hardcoded runtime copy, pass locale to Trace/chart formatters, and adopt
-  wrapping/reflow recipes for headings, legends, totals, controls, and forms.
-
-##### Contracts
-
-- Every selectable locale is required for every customer-facing dashboard
-  catalog. Technical/backend errors are normalized before presentation.
-
-##### Services
-
-- None unless server-provided diagnostics require stable localization keys.
-
-##### API changes
-
-- None for authored UI copy; use typed diagnostic codes instead of localizing
-  raw server strings if backend errors enter customer UI.
-
-##### Tests
-
-- Catalog completeness for en/zh-CN/ja/ko, locale-aware outcomes/durations/
-  numbers, pseudo-long strings, 320/390/640/768/desktop, 200% zoom, duplicate
-  cards, and error/loading/recovery copy.
-
-#### Acceptance criteria
-
-- No advertised locale falls back to English for authored dashboard messages.
-- Dates, durations, counts, outcomes, axes, tooltips, and statuses use the
-  active locale consistently.
-- Every bento card reflows without unintended page overflow or unreachable
-  actions under pseudo-long strings and 200% zoom.
-
-### Story 23: Bound attachment staging and preserve submission receipts
-
-#### Problem statement
-
-Submit Work buffers and base64-encodes whole files into JSON without size,
-count, concurrency, or type policy; staging references expose encoded host
-paths, and accepted/duplicate/runtime progress disappears with the component.
-
-#### Customer ask
-
-Attach supported content safely, understand upload and admission progress, and
-retain a trustworthy link to the submitted Work even across retries or remounts.
-
-#### Solution
-
-Publish and enforce upload policy at every boundary, use opaque streamed staging
-with bounded concurrency/progress/cancel, and keep a session-scoped submission
-receipt ledger keyed by a client request identity.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Update Work content staging, HTTP transport, generated clients, file picker,
-  drag/drop/paste, progress/cancel/retry, safe preview metadata, receipt/status
-  UI, Work/Trace navigation, and localized validation.
-
-##### Contracts
-
-- Define accepted MIME/content types, sniffing policy, per-file/total/count
-  limits, expiry and cleanup, opaque staging tokens, idempotency identity,
-  accepted-versus-duplicate outcome, and submission/runtime status vocabulary.
-
-##### Services
-
-- Work owns admission receipts and content staging policy. Staging never exposes
-  absolute server paths and cleans canceled/replaced/expired content.
-
-##### API changes
-
-- Replace unbounded base64 JSON staging with multipart, streaming, or bounded
-  chunked upload; expose upload limits, progress-compatible identity, opaque
-  references, idempotent request identity, and receipt fields. Regenerate all
-  affected contracts and clients.
-
-##### Tests
-
-- File/text/JSON/image/audio/binary policy, MIME mismatch, size/count/aggregate
-  limits, bounded parallelism, progress/cancel/cleanup, clipboard/drop,
-  ambiguous retry/idempotency, accepted/duplicate/runtime outcomes, remount,
-  session switch, multiple widgets, safe filename/token, and 320-to-desktop.
-
-#### Acceptance criteria
-
-- Unsupported or oversized content is rejected before expensive buffering and
-  at the server boundary with one localized, field-associated error.
-- Staging is cancellable, bounded, path-opaque, and does not copy whole large
-  files through byte-array, binary-string, base64, and JSON representations.
-- Every submission produces a session-scoped receipt showing request/Work/Trace
-  identity and accepted, duplicate, queued/running, succeeded, or failed state.
-
-### Story 24: Standardize Current Selection and Trace content rhythm
-
-#### Problem statement
-
-Current Selection and Trace share the same outer widget frame, but their inner
-sections mix incompatible margins, gaps, dividers, nested panels, fixed
-description columns, and minimum widths, producing visibly inconsistent rhythm
-and narrow-card clipping.
-
-#### Customer ask
-
-Make inspection cards feel like one coherent system while preserving readable
-hierarchy, scrolling, and compact reflow.
-
-#### Solution
-
-Keep the shared frame and introduce one inspection-section primitive and
-description-list responsive recipe with measurable spacing, divider, nesting,
-scroll, title, and touch-target rules used by Current Selection and Trace.
-
-#### Original document
-
-`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
-
-#### Changes
-
-##### Package changes
-
-- Add/refine shared inspection section, expandable section, nested surface, and
-  responsive description-list primitives; migrate Current Selection and Trace
-  shells/sections and remove duplicated utility-selector contracts.
-
-##### Contracts
-
-- Direct sections use 16 px block separation and 10 px internal gap; sections
-  after the first use one divider plus 16 px top spacing; nested surfaces use
-  12 px padding and the shared outline/radius; description lists stack below
-  640 px and use a 136 px label column above it; controls are at least 44 px.
-
-##### Services
-
-- None.
-
-##### API changes
-
-- None.
-
-##### Tests
-
-- Empty/loading/error/ready content, one and many sections, nested expansion,
-  long IDs/localized labels, scroll-owner assertions, focus continuity,
-  duplicate widgets, and exact geometry at 320/390/640/768/desktop and 200% zoom.
-
-#### Acceptance criteria
-
-- Current Selection and Trace use the same outer and inner spacing primitives;
-  no feature-local margin/divider override recreates a competing rhythm.
-- Titles, description values, graphs, tables, and actions reflow without
-  unintended page overflow, nested vertical scrolling, or clipped focus rings.
-- Visual hierarchy, semantic heading order, touch targets, and focus behavior
-  remain consistent across empty, loading, error, and dense ready states.
+- Current Selection and Trace use one measurable inner rhythm and scroll owner.
+- Every advertised locale is complete and every widget reflows without
+  unintended page overflow or unreachable actions.
+- One widget failure leaves siblings usable; dense data is bounded; clock ticks
+  do not rerender time-independent cards.
 
 ## Project-level acceptance criteria
 
-- Every known regression and each failure in the thirty-probe matrix is either
-  directly disproved by the owning story or explicitly linked to the owning
-  `factory-graph-visual-ux.md` acceptance criterion.
-- Canonical Factory Session, Work, dispatch, Worker Session, Provider Session,
-  Factory Event, and Events-topic identities remain distinct at every layer.
-- Complex graph/editor/bento surfaces keep canonical state, pure operations,
-  projections, and component wiring separately testable.
-- Network-backed surfaces expose identity-keyed hydrating, known-empty, ready,
-  historical, stale, reconnecting, gap, recovery-failed, retry, and success
-  states where applicable; retained data is never presented as fresh by
-  omission.
-- One widget failure does not blank sibling widgets; duplicated permitted
-  widgets keep unique DOM/form/disclosure identity, while singleton and maximum
-  instance policies are enforced before render.
-- Group creation, membership reassignment, observe-mode rendering, click-through,
-  invalid geometry rejection, cancel, save/reload, and compound Undo/Redo meet
-  the linked graph-visual and editor-transaction acceptance criteria.
-- No generated OpenAPI or client artifact is hand-edited; all contract changes
-  regenerate and pass drift checks.
-- New user-facing copy uses feature-owned complete en/zh-CN/ja/ko catalogs and
-  shared controls; locale-aware formatting and pseudo-long geometry pass.
-- Every canonical widget passes 320/390/640/768/desktop, 200% zoom, keyboard,
-  touch, screen-reader, forced-colors, reduced-motion, focus restoration, live
-  announcement, and selected-tick/session-switch evidence.
-- Dense/many-widget fixtures meet explicit render, memory, and pagination
-  budgets; the one-second clock does not rerender unrelated widgets.
-- Delivery continues through required CI until it is terminal and passing;
-  blocking review feedback is explicitly addressed, conflicts and generated
-  drift are resolved, and each PR is actually merged. Opening or approving a PR
-  is not completion.
+- Every probe failure is directly disproved by an owning story or linked
+  graph-visual-plan criterion.
+- Canonical Factory Session, stream generation, Work, dispatch, Worker Session,
+  Provider Session, Factory Event, and Events-topic identities remain distinct.
+- Network-backed cards expose truthful hydrating, known-empty, ready,
+  historical, stale, reconnecting, gap, recovery-failed, retry, and success.
+- Grouping passes create/membership/observe/click-through/validation/cancel/
+  save-reload/compound-history journeys with linked graph visual acceptance.
+- Every widget survives deliberate sibling failure, duplicate permitted
+  instances have unique accessible identity, and singleton/cap rules are
+  enforced before render.
+- Every widget passes 320/390/640/768/desktop, 200% zoom, keyboard, touch,
+  screen-reader, forced-colors, reduced-motion, focus restoration, live status,
+  en/zh-CN/ja/ko, and pseudo-long copy.
+- Generated OpenAPI/clients are regenerated from authored fragments; public
+  contract changes pass smoke/drift checks.
+- Dense/many-widget fixtures meet explicit render/memory/page budgets and
+  unrelated cards do not rerender on the global clock.
+- Delivery continues through terminal passing CI, blocking review resolution,
+  conflict/generated-drift resolution, and merged PRs.
 
 ## Verification plan
 
-Use the narrowest focused tests named in each story, then run the relevant final
-gates:
+Run story-focused tests first, then the relevant gates:
 
 ```text
 cd ui && bun run check
@@ -1709,25 +898,19 @@ make verify-fast
 make verify-pr
 ```
 
-Before relying on graph-consuming component suites, regenerate/build the
-components distribution and prove that the `graph-edge` export resolves; a
-suite that fails to start is a blocked verification lane, not a pass.
-
-For Worker Session and Factory Session service changes, also run focused Go
-service/transport tests and the appropriate functional server path. Functional
-tests must construct through `root.BuildProcess` and `Process.Execute` by
-default, prefer CLI for ordinary customer flows, replace external effects only
-through `edges.Edges`, and use deterministic observation rather than sleeps.
+Before relying on graph-consuming component suites, rebuild the components
+distribution and prove the `graph-edge` export resolves; a suite that cannot
+start is blocked, not passing. For service changes, run focused Go
+service/transport tests and functional paths through `root.BuildProcess` and
+`Process.Execute`, preferring deterministic observation over sleeps.
 
 ## Definition of done
 
-The program is done when a customer sees one real current Factory Session,
-opens or creates a Factory through an intentional path, reads one correct Work
-outcome chart, receives full-width session-safe submission feedback, sees every
-concurrent Work and Worker Session without Provider Session substitution, can
-trace exact Work/request/execution identities, edits the graph with coherent
-selection, grouping, save protection, and undo behavior, and uses isolated,
-bounded, localized dashboard widgets and layout navigation at supported
-viewports and input modes. All required tests and generated artifacts are
-current, CI and blocking review are resolved, conflicts are cleared, and the
-implementation PRs are merged.
+The program is done when a customer sees one canonical Current Factory Session,
+opens/creates intentionally, reads honest Work metrics, receives full-width
+session-safe submission receipts, sees every concurrent Work and Worker Session,
+traces exact causal identity, edits and groups through one protected history,
+and uses isolated, bounded, localized widgets and layouts at every supported
+viewport/input mode. Required generated artifacts and tests are current, CI and
+blocking review are resolved, conflicts are cleared, and implementation PRs are
+merged.

--- a/docs/internal/development/plans/dashboard-ux-probe-and-fix.md
+++ b/docs/internal/development/plans/dashboard-ux-probe-and-fix.md
@@ -1,0 +1,1733 @@
+---
+author: Agent Factory Team
+last-modified: 2026-08-10
+doc-id: agent-factory/plans/dashboard-ux-probe-and-fix
+---
+
+# Dashboard UX Probe And Fix Plan
+
+## Outcome
+
+Customers can open or create a Factory, understand the active Factory Session,
+inspect every concurrent Work and Worker Session, and use the Factory graph and
+dashboard widgets without duplicated labels, clipped feedback, phantom tabs,
+collapsed executions, misleading selection, or inaccessible controls.
+
+This plan turns the current UX defects into independently reviewable behavior
+stories. It is intentionally separate from
+`docs/internal/development/plans/factory-graph-visual-ux.md`, which remains the
+owner for the graph's visual grammar, node sizing, Work-count presentation,
+group-region styling, workstation semantic identity, and first-party topology
+hygiene.
+
+## Customer problem
+
+The dashboard currently exposes several kinds of misleading state:
+
+- the Work outcome chart renders its Y-axis title twice;
+- Submit Work feedback is narrower than its card and some validation feedback
+  is duplicated;
+- the header can show a real Factory Session and a second `~default` alias as
+  if they were separate Factories;
+- workstation activity can collapse multiple concurrent dispatches to one;
+- Current Selection infers executions from Provider Sessions instead of
+  enumerating authoritative Worker Sessions;
+- the Worker Session event stream can expose Factory-event fallback records
+  without making the provenance difference explicit;
+- workstation Request history shows only the first Work in a multi-Work
+  dispatch and suppresses executions without Provider Sessions;
+- editor selection, undo, dragging, connection handles, and mobile toolbar
+  behavior do not form one consistent operation model;
+- persisted dashboard geometry accepts unsafe values and the 640–768 px layout
+  is neither compact nor editable; and
+- New Factory is hidden behind a failed-looking validation path.
+
+## Probe evidence
+
+The audit used an initial ten focused probes followed by thirty additional
+bento/functionality probes, run in staged parallel batches because the
+workspace supports four concurrent agents including the coordinator. The
+initial audit included a live desktop inspection against the running backend;
+the thirty-probe expansion used read-only source, contract, projection, and
+focused-test inspection because the live browser was unavailable during that
+batch.
+
+The complete additional matrix and its execution limitations are recorded in
+`docs/internal/development/plans/dashboard-ux-30-probe-results.md`.
+
+| Priority | Finding | Direct evidence |
+| --- | --- | --- |
+| P1 | Duplicate Y-axis title | `work-chart.tsx` renders both a chart overlay label and a Recharts `YAxis` label; the live accessibility tree and geometry contained two `Work count` elements. |
+| P1 | Submit feedback does not fill its card | `submit-work-status-panel.tsx` uses `max-w-xl`; at the measured desktop layout the parent was 589 px while the panel stopped at 576 px. |
+| P1 | Phantom default session tab | The live header rendered a resolved UUID-backed session and a second `~default` entry. `session_listing.go` appends two live readers without identity reconciliation, and the UI preserves every row. |
+| P1 | Concurrent workstation activity collapses | `projectRuntime.ts` builds `workstation_activity_by_node_id` with `Object.fromEntries` keyed by `transitionID`, so later dispatches replace earlier dispatches on the same workstation. |
+| P1 | Worker Sessions are absent from the UI | The OpenAPI list/show/stream/transcript contract exists, but there is no handwritten Worker Sessions API module, hook, projection, or component consumer. |
+| P1 | Durable Worker Session association is discarded | The generated event exists, but `ui/src/api/events/types.ts` and `replayWorldState.ts` omit `DISPATCH_WORKER_SESSION_ASSOCIATION`. |
+| P1 | Worker Session stream provenance is misleading | The runtime-bound route can prefer dispatch-scoped Factory ledger records and label them `factory_event` instead of streaming the source-native Worker Sessions Events topic promised by the route. |
+| P1 | Workstation history loses Work and attempts | `workstation-request-history-section.tsx` reads only `work_items[0]`; request presence suppresses fallback run history; attempts without Provider Session identity are filtered out. |
+| P1 | Editor state is inconsistent | Undo/Redo only covers layout, observer selection can look selected while Delete reports no editor selection, and `nodesDraggable` is enabled outside edit mode. |
+| P1 | Persisted bento geometry is unsafe | The layout normalizer accepts negative coordinates, non-positive dimensions, out-of-grid widths, overlap, and duplicate custom IDs. |
+| P1 | Responsive/accessibility relationships are false or clipped | Session tabs control an empty `tabpanel`; the mobile editor toolbar clips trailing Save/Discard actions; 640–768 px keeps desktop geometry while disabling layout interaction. |
+| P1 | Submit Work contract and client behavior diverge | OpenAPI describes `name` as optional while server and dashboard reject missing/blank names; same-tick duplicate activation is not synchronously guarded. |
+| P1 | Drill-down context can combine unrelated identities | A directly selected trace is global bento state and can survive a Work change; direct request detail drops Provider Session selection callbacks; terminal rows use display labels instead of Work identity. |
+| P1 | Graph projection failures are not safely contained | Replay does not validate edge endpoints or expose an error state, while current/trace React Flow handlers throw every warning as fatal without a card-local boundary. |
+| P1 | Dense graph projections churn or scale quadratically | Package replay repeatedly scans occupancy/count/overlay arrays per node/edge, and live clock updates rebuild stable current-activity nodes and edges. |
+| P0 | Runtime caches and status can cross Factory Session boundaries | Trace query identity omits Factory Session/stream generation, session changes can render the prior active snapshot for one frame, and late EventSource callbacks can overwrite the new session's global status. |
+| P0 | Grouping is not an end-to-end editor feature | Groups disappear outside edit mode, opaque group bodies block graph interaction, reassignment undo loses prior membership, invalid geometry is accepted, and keyboard/cancel semantics are absent. |
+| P0 | Duplicate Factory graph cards race singleton editor state | The catalog permits duplicate graph widgets although every instance mounts the same session-scoped editor/controller bridge; removing one can clear another's handlers. |
+| P1 | Dashboard async state is neither shared nor truthful | Known-empty, retained-stale, reconnecting, recovery-failed, and historical states are unavailable or inconsistently inferred by individual cards. |
+| P1 | Inspection surfaces are unbounded | Terminal Work, Current Selection histories, Provider transcripts, Trace graphs/tables, and payload/relationship views can mount all retained data without pagination or virtualization. |
+| P1 | Advertised locale and accessibility contracts are incomplete | Japanese and Korean frequently fall back to English, many controls are below 44 px, layout editing is pointer-only, and no general per-widget error boundary exists. |
+
+### Audit side effect
+
+While probing the Submit Work validation path, one audit interaction created a
+local `idea` Work request named `UX layout probe` with an empty optional text
+item. No cleanup is authorized by this plan; retain or remove that Work only by
+explicit operator choice.
+
+## Scope
+
+In scope:
+
+- Factory Session listing, identity reconciliation, singleton header context,
+  and explicit Open/New Factory flows;
+- Work outcome chart and Submit Work feedback/validation behavior;
+- selected-workstation concurrent activity, Work/Request enumeration, Worker
+  Session association, list, live updates, and optional Provider Session links;
+- graph editor operation history, selection semantics, observe-mode geometry,
+  connection workflow, and responsive toolbar behavior;
+- bento layout validation, minimum geometry, compact projection, duplicate
+  instance identity, keyboard manipulation, and persistence scope;
+- truthful tab semantics, stream status, reduced motion, touch targets, and
+  narrow trace visualization behavior; and
+- regression fixtures and browser evidence tying these surfaces together.
+
+Out of scope:
+
+- redesigning the graph visual grammar already owned by
+  `factory-graph-visual-ux.md`;
+- replacing Factory Events, Factory definitions, Work, or Worker Sessions as
+  canonical state;
+- persisting React Flow or React Grid Layout objects as domain state;
+- broad dashboard restyling, unrelated copy sweeps, or new backend topology;
+- treating Provider Sessions as Worker Session identity; and
+- making process-local Worker Events durable Factory replay history.
+
+## Architecture and state boundaries
+
+```text
+Factory definitions + Factory Sessions + Work + Worker Sessions
+        | canonical service operations and authored OpenAPI
+        v
+Recordings Factory Events       Worker Sessions -> Events topics
+durable replay/history          source-native retained/live observations
+        |                                  |
+        +--------------+-------------------+
+                       v
+typed UI API modules + event stores
+                       |
+                       v
+pure replay/activity/selection/editor/layout projections
+                       |
+                       v
+React Flow, Recharts, React Grid Layout, tables, cards, and dialogs
+disposable UI-library state; never the domain source of truth
+```
+
+Required ownership decisions:
+
+- Factory Sessions owns reconciliation of live session identities. `~default`
+  remains an accepted selector, not a second durable client identity.
+- Recordings owns durable Factory Event replay, including the dispatch-to-Worker
+  Session association.
+- Worker Sessions owns Worker Session identity and lifecycle; Events owns its
+  bounded source-native observation topic; Provider Sessions is optional detail.
+- Work owns Work and Work Request admission. Dashboard workstation requests are
+  dispatch-keyed read projections, not Work Request identity.
+- The Factory document and graph editor operation stream own editable graph
+  state. React Flow nodes, handles, edges, and measurements are reproducible
+  projections.
+- The bento layout store owns browser-local layout preference. React Grid Layout
+  and the compact one-column form are projections.
+
+## Delivery sequence
+
+1. Land the deterministic regression fixture and probe matrix.
+2. Land narrow presentation and contract corrections with no dependency on the
+   Worker Session work.
+3. Correct canonical session/activity/association projections.
+4. Expose and render authoritative Worker Sessions and complete workstation
+   history.
+5. Repair editor and bento operation models after their canonical boundaries
+   are covered by pure tests.
+6. Bound and isolate inspection surfaces, then complete locale coverage.
+7. Complete responsive, accessibility, browser, generated-contract, CI, review,
+   conflict-resolution, and merge gates.
+
+## Work stories
+
+### Story 0: Establish the deterministic UX regression probe
+
+#### Problem statement
+
+The reported defects span live events, replay, concurrent dispatch, multiple
+identity types, graph-library behavior, and responsive layouts; isolated happy
+path fixtures cannot prove the fixes.
+
+#### Customer ask
+
+Create one repeatable probe that reproduces the known problems and provides a
+stable baseline for every fix story.
+
+#### Solution
+
+Add a fixture-driven browser scenario containing duplicate default-session
+inputs, two concurrent dispatches on one workstation, a multi-Work dispatch,
+multiple Worker Sessions including one without a Provider Session, terminal and
+failed/canceled executions, a large grouped graph, dense inspector data, every
+canonical dashboard widget, and a permitted duplicate instance of each
+duplicate-capable widget.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Add the replay/browser fixture under the existing `ui/integration/` fixture
+  conventions and reuse feature-local test builders for pure projections.
+- Do not add production-only test seams or a second replay engine.
+
+##### Contracts
+
+- Define expected identities by `factorySessionId`, `dispatch_id`, `work_id`,
+  and `workerSessionId`; do not key expected behavior by display text.
+
+##### Services
+
+- Reuse public service operations and existing edge mocks; no new service.
+
+##### API changes
+
+- None.
+
+##### Tests
+
+- Probe 320, 390, 640, 768, and desktop widths; 200% zoom; keyboard and touch;
+  forced colors and reduced motion; en/zh-CN/ja/ko and pseudo-long copy; live,
+  historical, reconnect, recovery failure, known-empty, and session-switch
+  races; deliberate single-widget throw; dense-data and rerender budgets.
+
+#### Acceptance criteria
+
+- The fixture reproduces the duplicate chart label, capped Submit status,
+  phantom session entry, collapsed concurrent activity, broken group journey,
+  incomplete history, stale cross-session state, unsafe duplicate graph card,
+  and Worker Session gap before fixes.
+- Expected row counts, stable ordering, navigation targets, accessible names,
+  and document-level overflow are asserted directly.
+- The fixture is deterministic in CI and uses no sleeps as its primary
+  synchronization strategy.
+
+### Story 1: Render one Work outcome axis and one plot grid
+
+#### Problem statement
+
+The Work outcome chart repeats `Work count` and renders redundant grid layers.
+
+#### Customer ask
+
+Make the chart visually and accessibly unambiguous.
+
+#### Solution
+
+Choose one Y-axis-title owner and one grid contract inside the canonical Work
+chart component; keep chart data and series behavior unchanged.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update `ui/src/features/work-outcome/components/work-chart/work-chart.tsx`
+  and its component/Storybook contracts.
+
+##### Contracts
+
+- Recharts remains a disposable rendering projection; no outcome model change.
+
+##### Services
+
+- None.
+
+##### API changes
+
+- None.
+
+##### Tests
+
+- Component assertion for exactly one visible/accessibility-tree Y-axis title
+  and one intended grid; browser geometry at narrow and desktop card sizes.
+
+#### Acceptance criteria
+
+- `Work count` is presented exactly once without clipping ticks or legend.
+- The chart remains readable at compact and desktop widths, with all series
+  toggle and zoom behavior unchanged.
+
+### Story 2: Make Submit Work feedback full-width, singular, and session-safe
+
+#### Problem statement
+
+Submit feedback is capped below card width, item errors can appear twice, and a
+late response from a previous session can overwrite the current form.
+
+#### Customer ask
+
+Keep submission feedback aligned with the form and scoped to the submission
+that produced it.
+
+#### Solution
+
+Remove the status width cap, give each validation error one authoritative
+location/association, scope both simple and rich drafts/mutations by exact
+Factory Session, show the destination and returned receipt, synchronously guard
+activation, and ignore or cancel responses whose initiating session generation
+is no longer active.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update `submit-work-status-panel.tsx`, `submit-work-card.tsx`, simple composer,
+  `use-submit-work-widget.ts`, and bento instance/form IDs; reuse shared status
+  and form primitives.
+
+##### Contracts
+
+- Keep local draft/mutation state separate from returned canonical
+  `requestId`/`traceId`.
+
+##### Services
+
+- Work admission behavior is unchanged for this story.
+
+##### API changes
+
+- None for width, error presentation, same-tick guard, or session scoping.
+
+##### Tests
+
+- Width measurement, one-error announcement, duplicate-widget IDs,
+  double-click/Enter+click, simple and rich A-to-B draft isolation, visible
+  destination, simple success/trace receipt, late success/error after session
+  switch, retry, long locale/200% zoom, and narrow layout coverage.
+
+#### Acceptance criteria
+
+- Guidance, pending, success, validation, and error panels fill the card and
+  wrap without horizontal overflow.
+- Each error is announced once and is programmatically associated with its
+  recovery target.
+- One activation produces one client mutation; late session-A results do not
+  clear or annotate session B.
+
+### Story 3: Align the Submit Work public name contract
+
+#### Problem statement
+
+Generated clients allow an omitted request name while server and dashboard
+behavior reject missing, empty, and whitespace-only names.
+
+#### Customer ask
+
+Make public, server, and dashboard validation agree.
+
+#### Solution
+
+Make `SubmitWorkRequest.name` required with matching semantic validation and
+regenerate every contract consumer.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update authored OpenAPI fragments and matching Work admission/UI validation.
+
+##### Contracts
+
+- `name` is required and blank-only input is invalid across all entry points.
+- Preserve the existing, intentional header-only Work behavior: optional blank
+  text rows are omitted rather than transmitted as blank items.
+
+##### Services
+
+- `pkg/services/work` remains the canonical admission owner.
+
+##### API changes
+
+- Run `make generate-api` or `make interfaces-all` as required; never hand-edit
+  bundled OpenAPI or generated Go/TypeScript clients.
+
+##### Tests
+
+- API contract, transport, generated-client, UI helper, and browser validation
+  cases for missing/empty/whitespace names and optional empty text content.
+
+#### Acceptance criteria
+
+- Every public client rejects or cannot construct the invalid name cases, and
+  server/UI outcomes remain equivalent.
+- Generated artifacts are drift-free and `make api-smoke` passes.
+
+### Story 4: Return and render each live Factory Session once
+
+#### Problem statement
+
+Two live-session readers can describe the same default session as a UUID and
+`~default`, and the header renders both rows as separate tabs.
+
+#### Customer ask
+
+Show one navigation entry for each real live Factory Session and no phantom
+Factory.
+
+#### Solution
+
+Reconcile live summaries by canonical session identity in the Factory Sessions
+owner, then render singleton context without exposing a routing alias as a
+second resource.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Correct `pkg/services/factory_sessions/transports/http/session_listing.go`
+  and the header session projection/components.
+
+##### Contracts
+
+- Preserve `~default` as an input selector; publish the resolved UUID when
+  known. Do not deduplicate by Factory name or path because distinct sessions
+  may target the same Factory.
+
+##### Services
+
+- Factory Sessions owns list reconciliation and session selection.
+
+##### API changes
+
+- No schema change.
+
+##### Tests
+
+- Exact duplicate, alias+UUID, one default, default+named, two sessions for one
+  Factory, close-to-single, and server response-count regressions.
+
+#### Acceptance criteria
+
+- One real default session yields one header context; default plus named yields
+  two; two distinct sessions targeting one Factory remain two.
+- Exactly one session uses concise current context rather than a misleading
+  one-item tab strip; Open another session remains reachable.
+
+### Story 5: Make Open Factory and New Factory explicit paths
+
+#### Problem statement
+
+Creation is available only after an action labelled Start Factory performs a
+validation-only request and produces a failed-looking state.
+
+#### Customer ask
+
+Let users intentionally open an existing Factory or create a new one.
+
+#### Solution
+
+Present explicit Open existing and Create new paths using the existing
+validation and `initNewFactory` operations, with destination preview and
+operation-specific errors.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update `dashboard-session-tabs-open-dialog.tsx`,
+  `use-dashboard-session-tabs-state.ts`, and localized messages.
+
+##### Contracts
+
+- Keep `Factory` creation distinct from opening/selecting the resulting
+  `Factory Session` and its `Current Factory`.
+
+##### Services
+
+- Factory Sessions owns discovery/open; Factory Definitions owns scaffold
+  persistence.
+
+##### API changes
+
+- Reuse existing `POST /factory-sessions` fields; no new route or schema.
+
+##### Tests
+
+- Existing target, missing target, invalid/broken config, create preview,
+  create success, validation/scaffold/open failures, cancel, and keyboard flow.
+
+#### Acceptance criteria
+
+- Validation is visibly non-mutating and never described as starting a Factory.
+- Create previews the exact `<folder>/factory` destination, and success opens
+  and selects the returned session.
+- A broken existing Factory is never offered an overwrite-as-new shortcut.
+
+### Story 6: Preserve every concurrent workstation dispatch
+
+#### Problem statement
+
+Multiple active dispatches on the same workstation collapse to the last entry
+in `workstation_activity_by_node_id`.
+
+#### Customer ask
+
+Show all active Work at a workstation without unstable ordering or loss.
+
+#### Solution
+
+Aggregate activity by workstation into a deterministic dispatch-keyed
+collection rather than replacing entries by `transitionID`.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Correct `ui/src/features/timeline/state/timeline/projectRuntime.ts` and
+  downstream graph/current-selection projections.
+
+##### Contracts
+
+- Use `(dispatch_id, work_id)` for Work participation and preserve stable
+  workstation identity mapping across node ID, transition ID, and name fallback.
+
+##### Services
+
+- No service mutation; consume canonical Factory Events.
+
+##### API changes
+
+- None.
+
+##### Tests
+
+- Same-workstation concurrency, one sibling completion, equal timestamps,
+  replay order, node/transition divergence, and graph component proof.
+
+#### Acceptance criteria
+
+- Every concurrent dispatch remains visible and deterministically ordered.
+- Completing one dispatch removes only that dispatch; siblings remain.
+- Live and selected-tick replay produce the same projection.
+
+### Story 7: Project durable dispatch-to-Worker Session associations
+
+#### Problem statement
+
+The UI discards `DISPATCH_WORKER_SESSION_ASSOCIATION`, preventing durable
+correlation of Factory activity with Worker Session identity.
+
+#### Customer ask
+
+Keep the association needed to inspect the real execution session.
+
+#### Solution
+
+Add the generated event to typed UI handling and replay it into a durable
+dispatch-keyed association projection without copying source-native Worker
+observations into Factory replay state.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update UI event types, `replayWorldState.ts`, runtime projections, and shared
+  replay package contracts only if the package owns this event vocabulary.
+
+##### Contracts
+
+- Association is durable Factory history; Worker observation records remain on
+  the Worker Session Events topic.
+
+##### Services
+
+- Recordings remains the Factory Event owner; Worker Sessions owns observation.
+
+##### API changes
+
+- None; generated payload already exists.
+
+##### Tests
+
+- Retained replay, reconnect, out-of-order canonicalization, duplicate
+  idempotency, terminal history, and conflicting-association diagnostics.
+
+#### Acceptance criteria
+
+- Every known association survives live delivery and replay and is addressable
+  by dispatch ID.
+- No Worker Session observation is silently promoted into durable Factory state.
+
+### Story 8: Stream truthful Worker Session Events
+
+#### Problem statement
+
+The current runtime-bound Worker Session route can prefer Factory ledger events
+while the public route promises the source-native Worker Session Events topic.
+
+#### Customer ask
+
+Make live Worker Session progress truthful about source, ordering, and history
+availability.
+
+#### Solution
+
+For live sessions, stream retained-then-live records from the exact Worker
+Session Events topic. For historical/restarted sessions, return an explicitly
+documented provenance/fallback or a typed source-history-unavailable outcome.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Correct the runtime Worker Session observation adapter and HTTP handler tests.
+
+##### Contracts
+
+- Define terminal, replay, source-failure, retention-gap, cancellation, and
+  restart semantics; never present Factory Events and source-native Events as
+  identical provenance.
+
+##### Services
+
+- Worker Sessions publishes to Events; Events supplies retained/live aggregate
+  order; Recordings remains historical Factory facts.
+
+##### API changes
+
+- No shape change if current delivery/provenance values can express the result.
+  Add a cursor/gap contract only if reconnect requirements prove it necessary.
+
+##### Tests
+
+- Interleaved sibling streams, terminal close, already-terminal replay, source
+  failure, retention gap, cancellation, restart, and server-bound SSE proof.
+
+#### Acceptance criteria
+
+- Sibling records never cross streams; terminal closes only the matching
+  session; complete retained records survive source failure.
+- The client can distinguish live source-native records from historical
+  Factory-event projection or explicit unavailability.
+
+### Story 9: Render every Worker Session for selected Work
+
+#### Problem statement
+
+Current Selection renders inferred Provider Session attempts and cannot show
+starting, script, concurrent, or terminal Worker Sessions independently.
+
+#### Customer ask
+
+Enumerate the authoritative Worker Sessions associated with selected Work.
+
+#### Solution
+
+Add a typed UI API/hook/feature using the existing work-scoped list and exact
+stream/show/transcript operations. Key rows by `workerSessionId` and expose a
+Provider Session link only when available.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Add `ui/src/api/worker-sessions/` and a focused Worker Sessions feature;
+  integrate it into selected Work/Current Selection without feature-wide
+  barrels.
+
+##### Contracts
+
+- Worker Session is execution identity; Provider Session is optional detail.
+  Stream state is keyed by `workerSessionId`, never only dispatch/workstation.
+
+##### Services
+
+- Reuse Worker Sessions and Provider Sessions public operations.
+
+##### API changes
+
+- No change for selected-Work enumeration. Factory-session-wide enumeration is
+  a separate follow-up unless a proven journey requires it.
+
+##### Tests
+
+- Multiple concurrent sessions, STARTING without provider, terminal
+  completed/failed/canceled, loading/empty/not-found/error/retry, interleaved
+  streams, reconnect dedupe, selection change, and unmount cleanup.
+
+#### Acceptance criteria
+
+- Every returned Worker Session is a separate stable row/card in API order.
+- One stream failure does not erase siblings; terminal rows remain inspectable.
+- Optional Provider Session/transcript actions never hide the Worker Session.
+
+### Story 10: Enumerate all Work and execution history for a workstation
+
+#### Problem statement
+
+Request history shows only `work_items[0]`, request presence suppresses other
+attempts, and attempts without Provider Sessions disappear.
+
+#### Customer ask
+
+Show complete active and historical workstation participation with reliable
+navigation.
+
+#### Solution
+
+Project Work participation by `(dispatch_id, work_id)`, deduplicate input/output
+overlap, join request summaries with authoritative Worker Sessions without
+mutual suppression, and add progressive history rendering if the measured
+fixture requires it.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update Current Selection request helpers, workstation detail/history/active
+  components, selection history, and feature messages.
+
+##### Contracts
+
+- Preserve Work, dispatch request, Worker Session, and Provider Session
+  identities separately; label consumed and produced Work relationships.
+
+##### Services
+
+- Reuse Recordings projections, paginated Work, and work-scoped Worker Sessions.
+
+##### API changes
+
+- None unless the scale probe proves existing composition incomplete or an
+  unacceptable N+1 path.
+
+##### Tests
+
+- Multi-Work dispatch, input/output overlap, repeated Work across dispatches,
+  multiple Worker Sessions/retries, missing provider, deterministic order,
+  forward/back navigation, loading/error/empty, and large history.
+
+#### Acceptance criteria
+
+- Every distinct Work participation and Worker Session attempt is visible once
+  in the correct context.
+- Work and request actions open exact identities and preserve selection history.
+- Partial projection data is never presented as a definitive empty state.
+
+### Story 11: Unify graph editor command history and selection semantics
+
+#### Problem statement
+
+Generic Undo/Redo covers layout only, observer selection can look like editor
+selection while editor actions see nothing selected, and observer nodes remain
+draggable.
+
+#### Customer ask
+
+Make graph editing predictable across topology, layout, mode, and selection.
+
+#### Solution
+
+Represent topology, fields, and layout changes as one ordered editor document
+history; make runtime-inspection, group, and editor selection explicit; disable
+node and viewport persistence in observe mode. Group visual behavior, group
+fit-to-members, node sizing, and group-region styling remain owned by Stories
+3–4 of `factory-graph-visual-ux.md`; this story owns their shared transaction,
+dirty-state, stale-save, and Undo/Redo seam.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update editable graph hooks, graph operations/history, selection gestures,
+  controls, view model, and viewport wiring.
+
+##### Contracts
+
+- History records domain commands/document transitions, never React Flow
+  objects. Save sets a baseline; Discard restores server state and clears
+  history.
+
+##### Services
+
+- Current Factory document save remains the mutation owner.
+
+##### API changes
+
+- None.
+
+##### Tests
+
+- Mixed add/connect/delete/field/move/group-membership/reset command order,
+  compound group reassignment undo, stale layout-only save rejection, dirty
+  session-change guards, redo invalidation, save/discard, mode transitions,
+  Escape/additive selection, and observe/editor drag browser proof.
+
+#### Acceptance criteria
+
+- Undo/Redo restores the complete prior/next editable Factory document in LIFO
+  order and button state matches available history.
+- Entering edit mode never leaves a node looking editor-selected while Delete
+  reports no selection.
+- Observer nodes cannot move; editor drag dispatches one layout operation.
+
+### Story 12: Make connection editing and editor controls progressive
+
+#### Problem statement
+
+Edit mode places every connection handle into a huge interaction surface with
+no clear Connect workflow, and the floating toolbar clips/overlays content.
+
+#### Customer ask
+
+Provide a discoverable, keyboard-operable connection flow and reachable draft
+actions at every supported viewport.
+
+#### Solution
+
+Activate connection targets only after an explicit source/focus intent, expose
+valid targets and cancellation, and give the editor toolbar safe canvas insets
+plus responsive wrapping/scroll/overflow behavior.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update editor connection projection/controllers, React Flow wiring, controls,
+  floating surface, localized tooltips, and fit-view inset logic.
+
+##### Contracts
+
+- Every edge endpoint references a handle rendered by the same canonical
+  projection; connection completion dispatches a graph operation.
+
+##### Services
+
+- None beyond existing Factory document save.
+
+##### API changes
+
+- None.
+
+##### Tests
+
+- Valid/invalid targets, keyboard source/target/cancel, handle projection,
+  390/768/1280 toolbar geometry, dirty Save/Discard visibility, focus order,
+  and real React Flow browser interaction.
+
+#### Acceptance criteria
+
+- Handles do not all enter tab order before connection intent.
+- Escape cancels without changing the draft; successful connection updates the
+  canonical draft and never persists raw React Flow edges.
+- Save, Discard, and Leave remain visible/reachable and the toolbar does not
+  cover selectable graph content.
+
+### Story 13: Recover, project, and manipulate bento layouts safely
+
+#### Problem statement
+
+Unsafe persisted geometry and duplicate IDs can reach React Grid Layout; tablet
+widths retain cramped desktop columns; layout manipulation is pointer-only.
+
+#### Customer ask
+
+Keep the dashboard usable after reload and across viewport/input modes.
+
+#### Solution
+
+Normalize stored layouts into unique bounded geometry with content-specific
+minimums, define and enforce singleton/duplicate limits, codify the chosen
+operator/backend/factory preference scope, project one column across the
+unusable tablet gap without persisting compact geometry, and add keyboard
+reorder/resize plus dirty-aware add/remove operations.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update bento schema/persistence/mutations/store, `agent-bento.tsx`, the typed
+  widget catalog, duplicate widget labels, remove/undo/focus behavior, and
+  layout action primitives. Treat Factory graph as singleton until editor
+  controller ownership is instance-scoped.
+
+##### Contracts
+
+- Browser-local layout uses a versioned envelope with explicit scope, monotonic
+  instance identity, unique IDs, singleton counts, positive integer bounds,
+  deterministic collision repair, and a recover/reset path. Widget contents
+  and selections remain Factory Session-scoped. React Grid Layout and compact
+  geometry remain disposable.
+
+##### Services
+
+- No backend service.
+
+##### API changes
+
+- None.
+
+##### Tests
+
+- Malformed/unsafe storage, duplicate IDs/singletons, overlap repair,
+  idempotent migration, capped duplicates, dirty remove confirmation, undo,
+  focus restoration and live announcements, pointer/keyboard/touch
+  move/resize/cancel, storage failure, two scopes, desktop to compact to
+  desktop, and every card at 320/390/640/768/1280.
+
+#### Acceptance criteria
+
+- Reload always yields unique IDs, positive bounded dimensions, no off-grid
+  cards, one add-widget card, and meaningful content minimums.
+- Compact projection is full-width, deterministic, non-persisting, and covers
+  the current 640–768 gap.
+- Keyboard users can move/resize and hear the resulting position/size; duplicate
+  widget instances have distinct visible and accessible names.
+
+### Story 14: Make session, trace, and motion accessibility truthful
+
+#### Problem statement
+
+Session tabs control an empty panel, all tabs share a color-only selected-stream
+status, tab reordering is pointer-only, narrow trace graphs can overflow, and
+shared loading/overlay motion ignores reduced-motion preference.
+
+#### Customer ask
+
+Make dashboard navigation and visualization usable by keyboard, screen reader,
+touch, zoom, and reduced-motion users.
+
+#### Solution
+
+Use truthful tab-panel or navigation semantics, scope status to the active
+session unless per-session state exists, add text/shape and keyboard reorder,
+make trace diagrams fit their cards with operable resizing, and gate shared
+motion primitives.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update session tab components/messages, trace graph shells, shared feedback
+  and overlay primitives, and undersized touch controls.
+
+##### Contracts
+
+- Inactive session status is neutral unless real per-session stream state is
+  projected. Status is not communicated by color alone.
+
+##### Services
+
+- None.
+
+##### API changes
+
+- None for honest active-only stream status.
+
+##### Tests
+
+- Arrow/Home/End/keyboard reorder and announcements, NVDA/VoiceOver spot check,
+  reduced-motion emulation, 200% zoom/reflow, 320/390 trace overflow, labelled
+  pan/zoom/resize, and minimum 44 px touch hit areas for dense actions.
+
+#### Acceptance criteria
+
+- No tab controls an empty panel; selected content has a truthful programmatic
+  relationship or the selector uses navigation semantics.
+- Session state is accessible without color and does not falsely apply one
+  stream's status to inactive sessions.
+- Trace cards do not cause page-level overflow, and all essential interaction
+  has keyboard/touch equivalents.
+- Nonessential pulse, ping, dialog, popover, and skeleton motion is suppressed
+  under reduced motion while state remains perceivable.
+
+### Story 15: Keep Work, trace, request, Worker Session, and Provider Session inspection coherent
+
+#### Problem statement
+
+Trace selection can outlive its Work, direct request detail cannot open the same
+Provider Session exposed elsewhere, back/forward restores only base selection,
+and duplicate terminal Work labels can resolve to the wrong Work/dispatch.
+
+#### Customer ask
+
+Make every drill-down step preserve exact identity and return to a coherent
+inspection context.
+
+#### Solution
+
+Validate or clear trace/session sub-selection atomically when Work changes,
+route Provider Session selection through every attempt surface, store or
+deterministically reset inspection context in selection history, and project
+terminal outcomes by Work plus terminal dispatch/event identity rather than
+display label.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update selection history, trace selection, direct request detail, Provider
+  Session correlation, terminal-work projection/list identity, and trace state
+  ordering.
+
+##### Contracts
+
+- Work uses `work_id`; request/execution uses `dispatch_id`; Worker Session uses
+  `workerSessionId`; Provider Session content uses `(provider, kind, id)` while
+  dispatch/attempt is navigation context; trace comes from Factory Event replay.
+
+##### Services
+
+- Work, Worker Sessions, Provider Sessions, and Recordings retain their existing
+  read ownership.
+
+##### API changes
+
+- Extend Factory Visualization/dashboard terminal outcome data with Work-ID and
+  terminal dispatch/event references if the existing label-only projection
+  cannot provide exact identity; regenerate all contract artifacts if changed.
+
+##### Tests
+
+- Work A → trace A2 → Work B, duplicate terminal labels, completed-to-failed
+  transition, direct request → Provider Session, identical Provider Session from
+  two dispatches, back/forward, replay removal, and trace loading/absent/error.
+
+#### Acceptance criteria
+
+- Current Selection and trace/session detail never show identities from
+  different Work contexts.
+- Every inference attempt with an available Provider Session offers the same
+  keyboard-operable inspection action from Work and request paths.
+- Terminal rows open the exact Work and dispatch even when labels repeat.
+- Back/Forward either restores the full valid inspection step or intentionally
+  returns to its base entity; focus moves to the restored heading.
+
+### Story 16: Validate, contain, and scale every Factory graph projection
+
+#### Problem statement
+
+Replay forwards unchecked node/handle endpoints, current/trace graphs treat all
+React Flow diagnostics as fatal, merged trace nodes can discard required
+handles, and dense/live projections perform avoidable full scans and rebuilds.
+
+#### Customer ask
+
+Keep observe, replay, and trace graphs truthful, recoverable, and responsive on
+large live Factories.
+
+#### Solution
+
+Share endpoint validation across graph modes, union trace handles by stable ID,
+classify and contain fatal projection failures within the affected card, index
+runtime overlays once, and preserve stable node/edge identities across
+clock-only updates. Keep visual grammar work in `factory-graph-visual-ux.md`.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update package replay projection/surface, dashboard and trace endpoint error
+  classification/boundaries, trace relation merge, current-activity view-model
+  memoization, replay empty state, and viewport precedence.
+
+##### Contracts
+
+- Every edge endpoint must reference a handle rendered by its projected node.
+  React Flow diagnostics are classified; only proven integrity failures are
+  fatal. A valid authored viewport wins over automatic fit.
+
+##### Services
+
+- Recordings and Factory Visualization remain canonical history/presentation
+  sources; no service mutation.
+
+##### API changes
+
+- None proven.
+
+##### Tests
+
+- Missing node/source handle/target handle, duplicate node ID, trace handle
+  union/conflict, card-local fatal recovery, non-fatal warning logging, empty
+  replay, authored viewport/fallback fit/tick change, and sparse/dense 500-node
+  performance/render-count fixtures.
+
+#### Acceptance criteria
+
+- Invalid topology produces a localized actionable graph error without blanking
+  unrelated dashboard cards; non-fatal warnings do not crash the graph.
+- Trace endpoint merging preserves every valid handle and diagnoses conflicts.
+- Dense replay projection is approximately linear in nodes, edges, and overlay
+  entries; clock-only updates preserve unaffected node/edge identity, viewport,
+  selection, and layout.
+- A valid authored viewport is honored, selected-tick changes preserve user
+  navigation, and zero-node replay presents an explicit empty state.
+
+### Story 17: Enumerate Worker Sessions for the Current Factory Session
+
+#### Problem statement
+
+Story 9 exposes Worker Sessions only through selected Work, while operators
+also need to understand every starting, concurrent, provider-less, retried, and
+terminal Worker Session in the Current Factory Session.
+
+#### Customer ask
+
+Provide a complete Factory Session-wide Worker Sessions view without requiring
+the operator to discover and select each Work first.
+
+#### Solution
+
+Add a Factory Session-scoped Worker Session list and exact detail journey keyed
+by `workerSessionId`, with attempts, Work and dispatch associations, lifecycle,
+optional Provider Session links, resumable observations, and stable navigation.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Extend Worker Sessions service contracts, recordings-backed projections, HTTP
+  transport/mapping, generated clients, and add a dashboard API module, query
+  hooks, list/detail components, and `worker-session` selection-history kind.
+
+##### Contracts
+
+- Worker Session ID is primary identity. Attempts preserve every dispatch and
+  provider association or absence; Work, workstation, timing, state, failure,
+  cursor, truncation, and replay-complete metadata are explicit.
+
+##### Services
+
+- Worker Sessions owns identity, attempts, lifecycle, observations, and
+  transcript availability. Recordings supplies durable Factory associations;
+  Provider Sessions stays optional detail.
+
+##### API changes
+
+- Add exact Worker Session detail/events endpoints and Factory Session-scoped
+  cursor pagination. Keep provider-reference lookup only as compatibility.
+- Regenerate bundled OpenAPI plus Go and TypeScript clients.
+
+##### Tests
+
+- Provider-less sessions, two concurrent sessions for one Work, multi-attempt
+  retries/provider switches, every terminal state, live/replay ordering,
+  resumable cursor/gap, back/forward, pagination, and narrow/desktop journeys.
+
+#### Acceptance criteria
+
+- Every Worker Session in the Current Factory Session appears once by stable
+  ID, regardless of Provider Session availability.
+- Selecting a row restores its exact attempt/Work/dispatch context and survives
+  back/forward without substituting Provider Session identity.
+- Reconnect resumes without loss or duplication and explicitly reports gaps,
+  known-empty, terminal, unavailable, and replay-complete states.
+
+### Story 18: Make Provider Session inspection contextual, safe, and bounded
+
+#### Problem statement
+
+Provider Session content can be fetched reliably, but users cannot see its
+origin context, reach it from every attempt, recover a failed fetch, or safely
+inspect a large/raw transcript.
+
+#### Customer ask
+
+Open the same Provider Session consistently from Work, request, dispatch, and
+Worker Session history with enough context to understand and safely navigate it.
+
+#### Solution
+
+Separate Provider Session content identity from optional origin context; route
+all entry points through one inspector with breadcrumbs, history, retry,
+stale-while-refresh, bounded transcript presentation, and explicit server-side
+redaction/reveal rules.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update Provider Session selection keys/state, request and Worker Session
+  entry points, detail panel, transcript renderer, cache/retry behavior, focus
+  restoration, and safe copy/reveal controls.
+
+##### Contracts
+
+- Content identity is `{provider, kind, id}`. Origin context is optional
+  `{factorySessionId, dispatchID, workID, workerSessionID}` and does not create
+  duplicate content identities.
+- Transcript payloads carry redaction/truncation metadata; ciphertext and raw
+  secret-bearing tool data are not displayed by default.
+
+##### Services
+
+- Provider Sessions owns normalized/redacted transcript inspection and bounded
+  pagination; Worker Sessions supplies optional origin association.
+
+##### API changes
+
+- Add cursor/truncation/redaction fields only where the existing detail contract
+  cannot provide bounded safe reads; regenerate affected interfaces.
+
+##### Tests
+
+- Every entry point, one Provider Session shared by two dispatches, retry and
+  abort, stale refresh, back/forward, redacted and revealable payloads, huge
+  transcript paging/windowing, 44 px controls, and narrow long-content layout.
+
+#### Acceptance criteria
+
+- The inspector always shows Provider Session identity and available origin
+  context without clearing equivalent content when only the origin changes.
+- Large transcripts do not mount or reveal all raw data by default; authorized
+  reveal and copy actions are explicit, audited by tests, and redaction-safe.
+- Fetch errors are recoverable and session switches cannot show prior-session
+  content.
+
+### Story 19: Give dashboard Work metrics coherent, accessible semantics
+
+#### Problem statement
+
+Removing the duplicate Y-axis label does not fix a chart that compares queued
+Work, active dispatches, accepted dispatches, and ever-failed Work under one
+ambiguous unit. The Work totals card repeats the ambiguity with four labels
+whose gauges and cumulative counts use different subjects.
+
+#### Customer ask
+
+Make every chart series and summary total comparable, understandable,
+localizable, and operable without relying on color or pointer hover.
+
+#### Solution
+
+Define each series' subject, aggregation, unit, and included outcomes; project
+honest metrics, expose a textual latest/selected-tick data alternative, localize
+numbers and tooltips, and provide keyboard-equivalent inspection and range
+controls.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update materialized outcome and totals projections, Work totals labels/reflow,
+  chart model/legend/tooltip/axis, accessible summary/table, keyboard range
+  control, point indexing, and optional display-only downsampling.
+
+##### Contracts
+
+- Every metric declares Work versus dispatch subject, gauge versus cumulative
+  aggregation, non-negative integer unit, and treatment of ACCEPTED, CONTINUE,
+  REJECTED, FAILED, retry, and cancellation outcomes.
+
+##### Services
+
+- Keep projection client-side if canonical events are sufficient; otherwise
+  Factory Visualization owns a typed outcome aggregate rather than duplicating
+  metric policy in Recharts components.
+
+##### API changes
+
+- None unless a backend-owned materialized aggregate is selected; any new
+  schema must use explicit metric definitions and generated clients.
+
+##### Tests
+
+- One axis title, chart/totals metric truth table, zero/negative/decimal
+  rejection, 1e9 outlier, 512-sample dense history, selected historical tick,
+  localized tooltip/ticks, keyboard inspection/zoom, accessible data
+  alternative, Work totals 2x2/1-column reflow, and exact card/chart width at
+  320/390/640/desktop.
+
+#### Acceptance criteria
+
+- Every plotted value has one unambiguous subject, aggregation, unit, and
+  accessible textual representation.
+- The chart has exactly one Y-axis title and one intentional grid, fills its
+  content width, and remains usable for outliers and dense history.
+- Interactive controls are outside `role=img` semantics, keyboard operable,
+  non-color-dependent, and at least 44 px.
+
+### Story 20: Isolate widgets and standardize asynchronous recovery
+
+#### Problem statement
+
+Individual cards infer loading, empty, stale, reconnecting, historical, and
+failed state differently; a retained snapshot can hide recovery failure, and a
+single rendering exception can remove the whole dashboard.
+
+#### Customer ask
+
+Keep available data visible and honest during hydration or recovery, and keep
+one broken widget from taking down its siblings.
+
+#### Solution
+
+Publish identity-keyed stream freshness to all cards, add a shared async-state
+presentation contract and per-widget error boundary, and synchronously gate
+session/trace/provider state before rendering a new Factory Session.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update stream/timeline/session lifecycle state, world-view selection, bento
+  snapshot props, Trace and Provider cache keys, shared status panels/live
+  regions, retry actions, and `DashboardWidgetErrorBoundary`.
+
+##### Contracts
+
+- Stream state is keyed by backend, Factory Session, logical session, and
+  generation and declares hydrating, ready-known-empty, live, historical,
+  stale, reconnecting, gap, recovery-failed, last-event time, and retryability.
+
+##### Services
+
+- Factory Sessions/Events expose a replay-ready or watermark signal sufficient
+  to distinguish known-empty from still-hydrating without guessing from rows.
+
+##### API changes
+
+- Add a stream-ready/replay-watermark envelope if the existing stream cannot
+  signal replay completion; regenerate stream types and clients.
+
+##### Tests
+
+- Zero-event readiness, retained offline/reconnect/recovery failure, cursor
+  gap, live-to-historical-to-live, A-to-B same IDs, late A event/status after B,
+  stale Trace/Provider selection, retry, and deliberate child throw isolation.
+
+#### Acceptance criteria
+
+- Retained data remains visible with an explicit stale/degraded label and retry;
+  it never appears live or hides terminal recovery failure.
+- Historical mode is derived from timeline state and cannot submit or edit the
+  Current Factory.
+- A Factory Session switch cannot render, select, cache, or announce data from
+  the previous identity, and one widget exception leaves siblings operational.
+
+### Story 21: Bound dense inspection and isolate render churn
+
+#### Problem statement
+
+Terminal Work, Current Selection, Provider transcripts, Trace graphs/tables,
+and payload/relationship views can render all retained data, while the global
+one-second clock reconstructs cards that do not depend on time.
+
+#### Customer ask
+
+Keep the dashboard responsive with long-running sessions, large traces,
+transcripts, histories, payloads, and many widget instances.
+
+#### Solution
+
+Define product-level page/window/preview thresholds, incremental data contracts,
+and render budgets; index repeated joins; subscribe only time-dependent cards
+to the clock; and virtualize or progressively disclose dense inspectors.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Add bounded list/transcript/table models, virtualization or pagination,
+  truncation diagnostics, indexed Work/attempt/relation joins, memoized card
+  boundaries, scoped clocks, occupancy-grid bento placement, and performance
+  fixtures.
+
+##### Contracts
+
+- Bounded reads expose total count, returned range/cursor, truncation, and
+  continuation. Rendering downsampling never changes accessible values or
+  canonical stored history.
+
+##### Services
+
+- Owning services provide cursor pagination for data that cannot be bounded
+  safely in the client; Events retention and Recordings durability remain
+  distinct.
+
+##### API changes
+
+- Add cursor/limit/total/truncation fields for Worker/Provider Sessions or other
+  inspectors only where local retained state is not the canonical full set.
+
+##### Tests
+
+- Twenty widgets plus 1,000 Terminal/Trace/Provider/history entries, long text
+  and binary metadata, 512 outcome samples, pagination/window focus continuity,
+  cancellation, memory bounds, commit-time budgets, and proof that clock ticks
+  do not rerender unrelated cards.
+
+#### Acceptance criteria
+
+- No dense inspector mounts an unbounded retained collection or blocks the main
+  thread with whole-file/stringify/quadratic projection work.
+- Pagination/window changes preserve exact identity, ordering, selection,
+  focus, stale state, and accessible count/range copy.
+- Time-independent widgets do not rerender on the one-second dashboard clock.
+
+### Story 22: Complete advertised dashboard locales and long-copy geometry
+
+#### Problem statement
+
+The product advertises English, Simplified Chinese, Japanese, and Korean, but
+many bento catalogs provide only English and Chinese, formatters sometimes
+ignore locale, and long-copy geometry is not systematically tested.
+
+#### Customer ask
+
+See complete, correctly formatted dashboard copy in every advertised locale
+without clipped controls, overlapping labels, or English fallback surprises.
+
+#### Solution
+
+Require complete message catalogs for every advertised locale, route all
+numbers/durations/outcomes through locale-aware formatters, and add pseudo-long
+geometry fixtures across every card and breakpoint.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Complete ja/ko catalogs, strengthen locale completeness checks, remove
+  hardcoded runtime copy, pass locale to Trace/chart formatters, and adopt
+  wrapping/reflow recipes for headings, legends, totals, controls, and forms.
+
+##### Contracts
+
+- Every selectable locale is required for every customer-facing dashboard
+  catalog. Technical/backend errors are normalized before presentation.
+
+##### Services
+
+- None unless server-provided diagnostics require stable localization keys.
+
+##### API changes
+
+- None for authored UI copy; use typed diagnostic codes instead of localizing
+  raw server strings if backend errors enter customer UI.
+
+##### Tests
+
+- Catalog completeness for en/zh-CN/ja/ko, locale-aware outcomes/durations/
+  numbers, pseudo-long strings, 320/390/640/768/desktop, 200% zoom, duplicate
+  cards, and error/loading/recovery copy.
+
+#### Acceptance criteria
+
+- No advertised locale falls back to English for authored dashboard messages.
+- Dates, durations, counts, outcomes, axes, tooltips, and statuses use the
+  active locale consistently.
+- Every bento card reflows without unintended page overflow or unreachable
+  actions under pseudo-long strings and 200% zoom.
+
+### Story 23: Bound attachment staging and preserve submission receipts
+
+#### Problem statement
+
+Submit Work buffers and base64-encodes whole files into JSON without size,
+count, concurrency, or type policy; staging references expose encoded host
+paths, and accepted/duplicate/runtime progress disappears with the component.
+
+#### Customer ask
+
+Attach supported content safely, understand upload and admission progress, and
+retain a trustworthy link to the submitted Work even across retries or remounts.
+
+#### Solution
+
+Publish and enforce upload policy at every boundary, use opaque streamed staging
+with bounded concurrency/progress/cancel, and keep a session-scoped submission
+receipt ledger keyed by a client request identity.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Update Work content staging, HTTP transport, generated clients, file picker,
+  drag/drop/paste, progress/cancel/retry, safe preview metadata, receipt/status
+  UI, Work/Trace navigation, and localized validation.
+
+##### Contracts
+
+- Define accepted MIME/content types, sniffing policy, per-file/total/count
+  limits, expiry and cleanup, opaque staging tokens, idempotency identity,
+  accepted-versus-duplicate outcome, and submission/runtime status vocabulary.
+
+##### Services
+
+- Work owns admission receipts and content staging policy. Staging never exposes
+  absolute server paths and cleans canceled/replaced/expired content.
+
+##### API changes
+
+- Replace unbounded base64 JSON staging with multipart, streaming, or bounded
+  chunked upload; expose upload limits, progress-compatible identity, opaque
+  references, idempotent request identity, and receipt fields. Regenerate all
+  affected contracts and clients.
+
+##### Tests
+
+- File/text/JSON/image/audio/binary policy, MIME mismatch, size/count/aggregate
+  limits, bounded parallelism, progress/cancel/cleanup, clipboard/drop,
+  ambiguous retry/idempotency, accepted/duplicate/runtime outcomes, remount,
+  session switch, multiple widgets, safe filename/token, and 320-to-desktop.
+
+#### Acceptance criteria
+
+- Unsupported or oversized content is rejected before expensive buffering and
+  at the server boundary with one localized, field-associated error.
+- Staging is cancellable, bounded, path-opaque, and does not copy whole large
+  files through byte-array, binary-string, base64, and JSON representations.
+- Every submission produces a session-scoped receipt showing request/Work/Trace
+  identity and accepted, duplicate, queued/running, succeeded, or failed state.
+
+### Story 24: Standardize Current Selection and Trace content rhythm
+
+#### Problem statement
+
+Current Selection and Trace share the same outer widget frame, but their inner
+sections mix incompatible margins, gaps, dividers, nested panels, fixed
+description columns, and minimum widths, producing visibly inconsistent rhythm
+and narrow-card clipping.
+
+#### Customer ask
+
+Make inspection cards feel like one coherent system while preserving readable
+hierarchy, scrolling, and compact reflow.
+
+#### Solution
+
+Keep the shared frame and introduce one inspection-section primitive and
+description-list responsive recipe with measurable spacing, divider, nesting,
+scroll, title, and touch-target rules used by Current Selection and Trace.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\dashboard-ux-probe-and-fix.md`
+
+#### Changes
+
+##### Package changes
+
+- Add/refine shared inspection section, expandable section, nested surface, and
+  responsive description-list primitives; migrate Current Selection and Trace
+  shells/sections and remove duplicated utility-selector contracts.
+
+##### Contracts
+
+- Direct sections use 16 px block separation and 10 px internal gap; sections
+  after the first use one divider plus 16 px top spacing; nested surfaces use
+  12 px padding and the shared outline/radius; description lists stack below
+  640 px and use a 136 px label column above it; controls are at least 44 px.
+
+##### Services
+
+- None.
+
+##### API changes
+
+- None.
+
+##### Tests
+
+- Empty/loading/error/ready content, one and many sections, nested expansion,
+  long IDs/localized labels, scroll-owner assertions, focus continuity,
+  duplicate widgets, and exact geometry at 320/390/640/768/desktop and 200% zoom.
+
+#### Acceptance criteria
+
+- Current Selection and Trace use the same outer and inner spacing primitives;
+  no feature-local margin/divider override recreates a competing rhythm.
+- Titles, description values, graphs, tables, and actions reflow without
+  unintended page overflow, nested vertical scrolling, or clipped focus rings.
+- Visual hierarchy, semantic heading order, touch targets, and focus behavior
+  remain consistent across empty, loading, error, and dense ready states.
+
+## Project-level acceptance criteria
+
+- Every known regression and each failure in the thirty-probe matrix is either
+  directly disproved by the owning story or explicitly linked to the owning
+  `factory-graph-visual-ux.md` acceptance criterion.
+- Canonical Factory Session, Work, dispatch, Worker Session, Provider Session,
+  Factory Event, and Events-topic identities remain distinct at every layer.
+- Complex graph/editor/bento surfaces keep canonical state, pure operations,
+  projections, and component wiring separately testable.
+- Network-backed surfaces expose identity-keyed hydrating, known-empty, ready,
+  historical, stale, reconnecting, gap, recovery-failed, retry, and success
+  states where applicable; retained data is never presented as fresh by
+  omission.
+- One widget failure does not blank sibling widgets; duplicated permitted
+  widgets keep unique DOM/form/disclosure identity, while singleton and maximum
+  instance policies are enforced before render.
+- Group creation, membership reassignment, observe-mode rendering, click-through,
+  invalid geometry rejection, cancel, save/reload, and compound Undo/Redo meet
+  the linked graph-visual and editor-transaction acceptance criteria.
+- No generated OpenAPI or client artifact is hand-edited; all contract changes
+  regenerate and pass drift checks.
+- New user-facing copy uses feature-owned complete en/zh-CN/ja/ko catalogs and
+  shared controls; locale-aware formatting and pseudo-long geometry pass.
+- Every canonical widget passes 320/390/640/768/desktop, 200% zoom, keyboard,
+  touch, screen-reader, forced-colors, reduced-motion, focus restoration, live
+  announcement, and selected-tick/session-switch evidence.
+- Dense/many-widget fixtures meet explicit render, memory, and pagination
+  budgets; the one-second clock does not rerender unrelated widgets.
+- Delivery continues through required CI until it is terminal and passing;
+  blocking review feedback is explicitly addressed, conflicts and generated
+  drift are resolved, and each PR is actually merged. Opening or approving a PR
+  is not completion.
+
+## Verification plan
+
+Use the narrowest focused tests named in each story, then run the relevant final
+gates:
+
+```text
+cd ui && bun run check
+cd ui && bun run check:localized-copy
+cd ui && bun run tsc
+cd ui && bun run test:unit
+cd ui && bun run test:component
+cd ui && bun run test:integration
+cd ui && bun run test:performance
+cd ui && bun run test-storybook
+cd ui && bun run storybook:responsive-check
+make api-smoke                    # stories that change OpenAPI
+make verify-fast
+make verify-pr
+```
+
+Before relying on graph-consuming component suites, regenerate/build the
+components distribution and prove that the `graph-edge` export resolves; a
+suite that fails to start is a blocked verification lane, not a pass.
+
+For Worker Session and Factory Session service changes, also run focused Go
+service/transport tests and the appropriate functional server path. Functional
+tests must construct through `root.BuildProcess` and `Process.Execute` by
+default, prefer CLI for ordinary customer flows, replace external effects only
+through `edges.Edges`, and use deterministic observation rather than sleeps.
+
+## Definition of done
+
+The program is done when a customer sees one real current Factory Session,
+opens or creates a Factory through an intentional path, reads one correct Work
+outcome chart, receives full-width session-safe submission feedback, sees every
+concurrent Work and Worker Session without Provider Session substitution, can
+trace exact Work/request/execution identities, edits the graph with coherent
+selection, grouping, save protection, and undo behavior, and uses isolated,
+bounded, localized dashboard widgets and layout navigation at supported
+viewports and input modes. All required tests and generated artifacts are
+current, CI and blocking review are resolved, conflicts are cleared, and the
+implementation PRs are merged.

--- a/docs/internal/development/plans/factory-graph-visual-ux.md
+++ b/docs/internal/development/plans/factory-graph-visual-ux.md
@@ -1,0 +1,1092 @@
+---
+author: Agent Factory Team
+last-modified: 2026-08-10
+doc-id: agent-factory/plans/factory-graph-visual-ux
+---
+
+# Factory Graph Visual UX Plan
+
+## Outcome
+
+Customers can read and edit a Factory graph without fighting narrow cards,
+truncated names, visually flat runtime state, misleading workstation kinds,
+disconnected Work states, or opaque grouping rectangles. The graph uses one
+consistent visual grammar for entity identity, workstation type and scheduling
+behavior, runtime status, selection, Work volume, node size, and authored
+groups.
+
+The intended visual direction is a dark, quiet canvas where inactive structure
+recedes, active or terminal state is immediately legible, important nodes have
+enough room for their names, dense Work becomes a large count, and groups read
+as colored regions behind the graph rather than panels placed on top of it.
+The first release uses well-rounded rectangular regions; an organic concave
+hull or free-form blob renderer is not required.
+
+## Customer problem
+
+The current graph exposes the Factory topology but makes it hard to understand
+at a glance:
+
+- inactive and active objects do not follow one strong, predictable color
+  hierarchy;
+- active styling is often limited to a border or glow and does not carry
+  enough visual weight at fit-to-view zoom;
+- Work is rendered as rows or dots until counts are already high, making busy
+  nodes visually noisy;
+- fixed, narrow dimensions truncate authored names and paths;
+- the graph collapses a workstation's runtime `type` and scheduling `behavior`
+  into one optional `workstation_kind` field, so logical moves, classifiers,
+  guarded loop breakers, and executable workstations can receive the wrong
+  icon, shape, or size;
+- package replay omits both legacy workstation-kind inputs and can therefore
+  infer the special exhaustion presentation for an ordinary workstation;
+- declared but disconnected Work states render as meaningful topology even
+  though no admission path, workstation route, invocation return, or implemented
+  lifecycle behavior can reach them;
+- the portable `FactoryLayoutNode.size` field exists but the graph does not
+  use it as an editor behavior;
+- visual groups use opaque rectangular fills and a full-surface hit target, so
+  they read as blocks and can compete with graph interaction; and
+- graph-specific color and shape decisions are distributed across semantic
+  node components rather than expressed as one reviewable visual contract.
+
+## Customer ask
+
+Make the Factory graph substantially easier to scan and edit:
+
+- when a Work-bearing node represents more than three Work items, replace the
+  item-level presentation with one large total count;
+- give default objects standardized colors and shapes;
+- give active objects a vivid, unmistakable treatment;
+- replace block-like group rendering with presentable, colorable regions that
+  make contrasting areas clear;
+- make workstation runtime type, scheduling behavior, and guarded control role
+  legible without conflating them;
+- remove or implement disconnected states in first-party Factory definitions so
+  every rendered Work state represents real customer behavior;
+- prevent names from being needlessly truncated; and
+- let users expand or resize nodes where the node family and content warrant
+  it.
+
+## Scope
+
+This plan applies to the canonical semantic Factory graph used by the current
+activity dashboard, observe/edit modes, and package-owned replay surfaces. It
+does not create or improve a parallel generic topology renderer. Shared node
+presentation belongs in `ui/packages/factory-graph`; the dashboard continues
+to own event streaming, Factory save mutations, editor-session control, and
+confirmation flows.
+
+The plan includes:
+
+- semantic graph color and shape roles;
+- a lossless workstation presentation projection covering runtime type,
+  scheduling behavior, and guarded logical-control role;
+- first-party packaged Factory topology hygiene and generated-catalog drift;
+- Work-volume presentation for work-state and workstation nodes;
+- content fitting, authored node resizing, undo/redo, save, and reload;
+- visual-group rendering, color selection, fit-to-members, and interaction;
+- observe/edit/replay parity; and
+- accessibility, reduced-motion, responsive, performance, package, and browser
+  evidence.
+
+## Product decisions
+
+These decisions remove ambiguity from implementation:
+
+1. **The threshold is strictly greater than three.** Counts of one through
+   three retain an item-level presentation. A count of four or more renders a
+   large total number.
+2. **The number is the total represented Work count.** It is not an overflow
+   value such as `+4`, and the numeric mode does not also render the first
+   three items.
+3. **Node identity and runtime status are separate visual layers.** A
+   workstation remains recognizably a workstation when idle, active, selected,
+   or failed. Selection must not erase the runtime status treatment.
+4. **Inactive nodes are quiet; active nodes are vivid.** Inactive structure
+   uses neutral surfaces and stable family icons. Active or processing nodes
+   use the graph active role with a stronger tinted surface, border, and glow.
+5. **Color is semantic and theme-backed.** No raw hex, arbitrary CSS color, or
+   persisted custom color is introduced. All graph roles map to the supported
+   palette and semantic token system.
+6. **Shape means card family, not decorative geometry.** The graph keeps
+   readable cards with predictable handles: compact support cards, standard
+   state/resource cards, and larger operational workstation cards. Icons,
+   labels, and status text supplement shape and color.
+7. **Saved size is portable layout metadata.** The existing
+   `FactoryLayoutNode.size` value is the authored source of truth. React Flow
+   width, height, measurements, and resize previews remain disposable
+   projections.
+8. **Groups are regions behind the graph.** The first implementation uses
+   translucent, generously rounded regions with an accent outline and label
+   chip. It does not require an organic hull algorithm.
+9. **Group interiors do not own the canvas.** Nodes, edges, selection, pan, and
+   zoom remain operable through a group. In edit mode the group label/outline
+   supplies selection and drag affordances; in observe mode the region is
+   non-interactive.
+10. **Motion is supplementary.** Active animation is disabled by reduced-motion
+    preferences while the static active surface, icon/status text, and border
+    remain legible.
+11. **Workstation type and behavior are independent facts.** `type` answers what
+    the workstation does (`AGENT_RUN`, `SCRIPT_RUN`, `LOGICAL_MOVE`,
+    `CLASSIFIER_WORKSTATION`, and the other public types). `behavior` answers how
+    it is scheduled (`STANDARD`, `REPEATER`, `CRON`, or `POLLER`). The graph must
+    not store or infer both through one `kind` value.
+12. **Guarded logical control is derived explicitly.** A loop breaker is a
+    `LOGICAL_MOVE` with a supported guard such as `VISIT_COUNT`; absence of
+    worker metadata is not evidence that a node is an exhaustion rule.
+13. **Unknown semantics use a neutral fallback.** A lossy historical or trace
+    source may render a generic workstation with an explicit unavailable
+    semantic label. It must never guess `exhaustion`, `repeater`, or another
+    special role from missing fields.
+14. **First-party graphs contain only behavioral states.** A packaged Factory
+    state must be reachable through submission/admission, workstation routing,
+    invocation return, or an implemented and directly tested lifecycle bridge.
+    A state that only appears in a diagram or future design note is not part of
+    the shipped graph.
+
+## Visual contract
+
+### Node identity and shape
+
+| Factory object | Shape family | Inactive presentation | Content behavior |
+| --- | --- | --- | --- |
+| Workstation | Large operational card | Neutral raised surface, solid semantic frame, workstation icon | Stable header plus Work body; both axes are resizable |
+| Work state | Standard state card | Neutral surface with lifecycle icon and state label | Width is resizable; content-fit may increase height for wrapped names |
+| Resource or constraint | Standard support card | Neutral surface with stable resource/constraint icon | Width is resizable; counts remain compact badges |
+| Worker or Work type | Compact support card | Neutral surface with family icon and concise type label | Width is resizable; height follows the compact family |
+| Document | Standard document card | Neutral surface with document icon | Both axes are resizable so label and path can wrap |
+
+The exact canvas-unit minimum, default, and maximum sizes must live in one
+package-owned size table. The values should be chosen through the graph
+Storybook fixtures so representative customer names fit without returning to
+the current narrow-card proportions.
+
+### Runtime and interaction state
+
+| State | Required treatment |
+| --- | --- |
+| Idle or inactive | Quiet neutral surface and border; family identity remains visible through icon and label |
+| Initial or queued | Info/waiting role, with text or icon in addition to color |
+| Active or processing | Vivid graph-active surface, high-contrast border, glow, and reduced-motion-safe activity cue |
+| Terminal or completed | Success surface, border, and terminal/completed icon or label |
+| Failed or rejected | Danger surface, border, and failed/rejected icon or label |
+| Selected | Focus/selection ring layered over the current runtime state rather than replacing it |
+| Validation error | Danger validation ring/message takes precedence, without changing the node family or hiding runtime content |
+| Muted by active-flow focus | Reduced emphasis that preserves readable text and accessible contrast |
+
+`active`, `processing`, `completed`, and `failed` are visual presentation
+roles, not new backend state. The projection maps existing workstation
+activity, active-flow highlights, and work-state categories into these roles.
+
+### Workstation semantic identity
+
+Workstation presentation has three independent axes:
+
+| Axis | Canonical source | Required graph treatment |
+| --- | --- | --- |
+| Runtime type | `Factory.workstations[].type` | Primary icon and role label for inference, agent, script, poller, classifier, or logical move |
+| Scheduling behavior | `Factory.workstations[].behavior`, defaulting to `STANDARD` | Secondary badge, border, or concise status treatment for standard, repeater, cron, or poller scheduling |
+| Guarded control role | `Factory.workstations[].guards` together with runtime type | Compact logical-control card; a supported visit-count guard renders as a loop breaker with its limit available to sighted and assistive-technology users |
+
+The authored Factory definition is canonical for all three axes. Selected-tick
+runtime topology supplies stable identity and activity overlays, not a competing
+semantic taxonomy. Adapters join the runtime workstation to the authored
+workstation by durable public id, falling back to the authored name only for
+legacy definitions without ids.
+
+## Architecture decision
+
+### Canonical state and projection boundaries
+
+```text
+FactoryDefinition
+  workstations[].id + type + behavior + guards
+  layout.nodes[].position + layout.nodes[].size
+  layout.groups[].bounds + color + nodeIds
+                    |
+selected-tick runtime snapshot
+  active routes + executions + Work/place counts + lifecycle state
+                    |
+                    v
+Factory graph state / pending editor layout
+  pure move, resize, fit, reset, group, undo, redo operations
+                    |
+                    v
+@you-agent-factory/factory-graph projection
+  workstation identity + semantic visual state + resolved node size
+  + Work presentation
+                    |
+                    v
+React Flow nodes, edges, measurements, resize preview, and group geometry
+  disposable and reproducible UI-library state
+```
+
+The source-of-truth rules are:
+
+- the Factory definition and selected-tick runtime snapshot remain canonical
+  for entity and runtime facts;
+- the Factory definition owns workstation type, scheduling behavior, and guard
+  configuration; runtime topology may identify the node but may not overwrite
+  those authored facts with a reduced `workstation_kind` heuristic;
+- the controlled editor layout draft remains canonical for unsaved position,
+  size, group, and viewport changes;
+- feature operations own resize, fit, reset, group fit, group move, group
+  resize, and save preparation;
+- the semantic package projection owns the mapping from canonical facts to
+  shape, surface, status, count mode, and React Flow dimensions;
+- React components render the projection and dispatch compact operations; and
+- components must not reconstruct Factory or layout state from measured DOM or
+  React Flow nodes when saving.
+
+### Size precedence
+
+The projection resolves node size in this order:
+
+1. a valid pending/persisted `layout.nodes[].size` authored by the user;
+2. a deterministic content-fit size for the node family and authored label;
+3. the centralized family default.
+
+Invalid, non-finite, non-positive, or out-of-family sizes are ignored for
+rendering and removed or normalized during save preparation. Older layouts
+without `size` continue to render from content-fit/default dimensions. No
+Factory layout schema-version bump or new OpenAPI shape is required because
+`FactoryLayoutNode.size` is already part of version 1.
+
+Runtime Work updates must not change a node's outer dimensions. Crossing from
+three to four Work items changes the body presentation, not the card geometry,
+so live updates do not cause graph jitter or edge churn.
+
+### Package and host ownership
+
+`ui/packages/factory-graph` owns:
+
+- the node-family shape and size vocabulary;
+- the protocol-neutral workstation presentation contract and safe unknown
+  fallback;
+- graph visual-state roles and semantic class resolution;
+- Work-volume presentation rules;
+- semantic node rendering and resize affordance primitives;
+- read-only group-region presentation; and
+- package-level fixtures and stories for the public graph contract.
+
+The dashboard Factory graph features own:
+
+- pending layout state and undo/redo history;
+- node resize/fit/reset and group operations;
+- React Flow interaction wiring and ephemeral drag/resize previews;
+- Factory save/reload and query-cache synchronization;
+- localized editor controls and notices; and
+- event/timeline selection and current detail-panel destinations.
+
+## Non-goals
+
+- Replacing Factory events, snapshots, or Factory definitions as canonical
+  state.
+- Changing scheduling, dispatch, Work, worker, or workstation semantics.
+- Inventing a new backend workstation taxonomy or changing the existing public
+  `WorkstationType` and `WorkstationKind` enums.
+- Redesigning Work-relation or unrelated graph surfaces. Trace views that render
+  Factory workstation nodes are in scope only for semantic parity or a neutral
+  fallback; their trace-specific topology is not redesigned.
+- Adding custom hex/RGB group colors or a free-form color picker.
+- Building a concave hull, freehand group outline, nested group model, or
+  topology-aware container node in the first release.
+- Rewriting the layered layout algorithm or edge-routing model.
+- Rendering every Work item inside a high-volume node.
+- Persisting hover, selection, animation phase, DOM measurements, or React Flow
+  internal state.
+- Adding avatars, worker portraits, or other reference-image decoration that
+  is not required by the customer ask.
+
+## Work stories
+
+### Story 1: Standardize node shapes, colors, and runtime emphasis
+
+#### Problem statement
+
+Customers cannot reliably distinguish stable object identity from runtime
+activity because shape, base color, active flow, lifecycle, selection, and
+validation styles are distributed and sometimes compete.
+
+#### Customer ask
+
+Give default objects standardized colors and shapes, and make active objects
+vibrantly colored.
+
+#### Solution
+
+Publish one graph visual-state resolver and one node-family shape/size
+vocabulary in the canonical Factory graph package. Render inactive cards on
+quiet neutral surfaces and layer queued, active, completed, failed, selected,
+validation, and muted treatments through documented precedence.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\factory-graph-visual-ux.md`
+
+#### Changes
+
+##### Package changes
+
+- Consolidate node visual-state mapping in
+  `ui/packages/factory-graph/src/semantic-node-style.ts` or a narrowly named
+  package-owned visual-state module.
+- Centralize node-family shape and default dimension roles currently split
+  between `semantic-node-shell.tsx`, semantic node components, and
+  `ui/src/features/factory-graph-editor/lib/editor/factory-graph-editor-layout.ts`.
+- Update `semantic-workstation-node.tsx`, `semantic-place-nodes.tsx`,
+  `semantic-support-nodes.tsx`, `semantic-doc-node.tsx`, and
+  `work-state-presentation.ts` to consume the shared resolver.
+- Add graph-specific semantic roles to `ui/src/styles.css` only where existing
+  surface/status roles cannot express the required active strength. Map every
+  new role to the existing palette foundations.
+- Keep semantic icons from the existing `GraphSemanticIcon` vocabulary and
+  keep typed handles in `FactoryGraphNodeShell`.
+
+##### Contracts
+
+- Define a package-owned, protocol-neutral visual-state value covering base
+  family, lifecycle/runtime status, selection, validation, active flow, and
+  muted state.
+- Define and test precedence so validation and selection remain visible while
+  active/completed/failed state is still recognizable.
+- Preserve the current node/handle projection contract; no Factory domain
+  schema is added.
+
+##### Services
+
+- No backend service changes. Existing runtime and Factory definition facts
+  are projected into visual roles.
+
+##### API changes
+
+- None. Do not edit generated OpenAPI clients.
+
+##### Tests
+
+- Package unit tests for every node family and visual-state precedence pair.
+- Component tests proving active, completed, failed, selected, validation, and
+  muted states are visible through class/attribute and semantic content.
+- Storybook states covering all node families across supported palette/theme
+  presets and reduced motion.
+- Contrast and keyboard-focus checks for active and selected nodes.
+
+#### Acceptance criteria
+
+- An idle graph uses a consistent quiet surface hierarchy and still identifies
+  each object family through shape, icon, and label.
+- Active/processing nodes are visibly stronger than idle nodes at normal and
+  fit-to-view zoom through surface, border, and glow—not a subtle border alone.
+- Initial/queued, active/processing, terminal/completed, and failed/rejected
+  states map consistently to info/waiting, graph-active, success, and danger
+  roles.
+- Selection and keyboard focus remain visible on every runtime state.
+- Reduced-motion users receive the same static state information without an
+  infinite animation.
+- Color is never the only state signal, and supported palettes meet the
+  repository's WCAG 2.2 AA target.
+
+### Story 2: Collapse high-volume Work into a large total count
+
+#### Problem statement
+
+Busy work-state and workstation nodes spend space on repeated dots, rows, and
+overflow markers, making the graph noisy and understating the actual Work
+volume.
+
+#### Customer ask
+
+When Work is beyond three items, make the graph node body a large number.
+
+#### Solution
+
+Create one pure Work-volume presentation rule shared by work-state and
+workstation node renderers. Counts one through three keep the useful item-level
+view. Counts of four or more replace the entire Work body with a visually
+dominant total count while preserving the node header, identity, status,
+handles, selection, and detail navigation.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\factory-graph-visual-ux.md`
+
+#### Changes
+
+##### Package changes
+
+- Replace the current `DOT_LIMIT = 10` behavior in
+  `ui/packages/factory-graph/src/semantic-place-nodes.tsx` with the shared
+  threshold contract.
+- Replace the current workstation `VISIBLE_WORK_ITEM_LIMIT` plus `+N`/dots
+  overflow in `semantic-workstation-node.tsx` with the same presentation rule.
+- Add a reusable large numeric Work marker owned by the Factory graph package;
+  do not introduce a dashboard-only duplicate.
+- Keep total-count and detail-action copy in the owning graph message catalog
+  for every supported locale.
+- Keep resource/constraint token badges out of this rule unless they represent
+  customer Work; resource capacity is not Work volume.
+
+##### Contracts
+
+- Define a pure presentation result for `empty`, `items`, and `total` modes.
+- Count unique represented Work IDs for workstation activity. Work-state nodes
+  use the canonical represented Work/place count already supplied by the
+  runtime projection.
+- The accessible label must state the total, such as `12 active items`, even
+  when the visual body is only `12`.
+
+##### Services
+
+- No backend changes. The rule consumes existing selected-tick runtime counts
+  and active executions.
+
+##### API changes
+
+- None.
+
+##### Tests
+
+- Pure boundary tests for counts 0, 1, 2, 3, 4, and a large count.
+- Component tests for work-state and workstation nodes proving that four does
+  not render three items plus an overflow marker.
+- Tests proving the visible number and accessible label contain the total,
+  not the remainder.
+- Tests proving the large-count body still activates the owning node/detail
+  action and leaves semantic handles intact.
+
+#### Acceptance criteria
+
+- Counts one through three render one through three item indicators or rows.
+- A count of four or more renders one large total number and no item rows,
+  dots, avatar-like markers, or `+N` suffix.
+- The Work node's name/icon/header remains visible so the number never loses
+  its Factory context.
+- Screen readers receive the total count and Work status in meaningful text.
+- Moving between three and four items during live execution does not change
+  the outer node dimensions or move connected edges.
+
+### Story 3: Fit long names and persist accessible node resizing
+
+#### Problem statement
+
+Fixed narrow node dimensions force names and document paths into truncation,
+and users cannot use the existing portable node-size contract to create a
+layout appropriate for their Factory.
+
+#### Customer ask
+
+Allow graph nodes to expand or resize as appropriate so authored names are
+readable.
+
+#### Solution
+
+Resolve a content-fit default for each node family, wrap labels safely, and
+add edit-mode resize, fit-to-content, and reset-size operations. Persist the
+result through the existing `layout.nodes[].size` field, include it in
+undo/redo and save/reload, and keep React Flow measurement changes as preview
+state only.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\factory-graph-visual-ux.md`
+
+#### Changes
+
+##### Package changes
+
+- Add a pure package-owned node-size resolver with per-family minimum, default,
+  and maximum bounds.
+- Update semantic title/label components to use wrapping and
+  `overflow-wrap:anywhere` where appropriate instead of unconditional
+  single-line `truncate`.
+- Provide a reusable selected-node resize affordance that can be enabled by the
+  edit-mode host without making the package own editor state.
+- Refresh node internals after committed size changes so every edge endpoint
+  remains attached to a handle rendered by the resized node.
+
+##### Contracts
+
+- Reuse the existing OpenAPI-generated `FactoryLayoutNode.size` contract as
+  the only durable node-size value.
+- Add pure layout operations for resize, fit-to-content, and reset-size under
+  `ui/src/features/factory-graph-editor/lib/layout/`.
+- Extend layout history commands so each committed size operation has one
+  inverse and participates in undo/redo.
+- Extend frontend layout validation/save preparation to reject or normalize
+  non-finite, non-positive, and out-of-family dimensions before projection or
+  persistence.
+- Resolve dimensions from pending layout state in
+  `current-activity-factory-graph-layout.ts` and the React Flow projection;
+  do not recover authored size from React Flow measurements during save.
+
+##### Services
+
+- The existing Factory definition save operation remains authoritative for
+  persisted layout metadata. No new service is introduced.
+
+##### API changes
+
+- No schema-shape change. `FactoryLayoutNode.size` already exists in
+  `api/components/schemas/data-models/FactoryLayoutNode.yaml` and generated Go
+  and TypeScript contracts.
+- If implementation discovers contract drift rather than merely consuming the
+  existing field, author the correction in `api/components/` and run
+  `make generate-api`; generated files must not be hand-edited.
+
+##### Tests
+
+- Pure tests for size precedence, per-family clamping, fit, reset, and invalid
+  saved values.
+- Layout history tests for resize undo/redo and for preserving unrelated node
+  position, group membership, and metadata.
+- Projection tests proving resolved width/height become the React Flow node's
+  width, height, initial size, and measurement contract.
+- Component tests for pointer resize plus keyboard-accessible `Fit to content`
+  and `Reset size` actions.
+- Save/reload tests proving size round-trips through the existing Factory
+  layout without topology changes.
+- Long-label stories for ordinary words, long unbroken identifiers, localized
+  labels, and document paths.
+
+#### Acceptance criteria
+
+- Representative workstation, Work-state, resource, worker, Work-type, and
+  document names are readable at their fitted/default size without the current
+  unconditional ellipsis.
+- A selected node in edit mode exposes pointer resize handles only on the axes
+  allowed by its family: workstation/document cards support both axes, while
+  compact support and state/resource cards prioritize horizontal sizing and
+  content-fit height.
+- Keyboard users can fit and reset a selected node without operating a pointer
+  drag handle.
+- Resizing is clamped, does not invert or collapse a node, updates edge handles,
+  and is undoable/redoable as one editor command.
+- Save, reload, observe mode, and replay use the authored size. Legacy layouts
+  without size use deterministic fitted/default dimensions.
+- Runtime status or Work-count updates do not overwrite an authored size.
+
+### Story 4: Replace block groups with colored, non-blocking graph regions
+
+#### Problem statement
+
+Authored visual groups currently render as opaque rectangular blocks with an
+interactive full surface. They compete with node/edge contrast and can obstruct
+normal canvas gestures instead of helping users understand related areas.
+
+#### Customer ask
+
+Make grouping visually presentable and colorable so contrasting parts of the
+Factory are obvious without requiring organic blob geometry.
+
+#### Solution
+
+Render saved groups as low-opacity, well-rounded regions behind nodes and
+edges, with a semantic accent outline/glow and a floating label chip. Make the
+interior click-through. In edit mode use the label and outline/resize affordance
+for selection and movement, support create-from-selection and fit-to-members,
+and persist the existing bounds/color/member contract.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\factory-graph-visual-ux.md`
+
+#### Changes
+
+##### Package changes
+
+- Add or move a read-only semantic group-region presentation into
+  `ui/packages/factory-graph` so observe, edit, and replay do not invent
+  separate group visuals.
+- Refactor
+  `factory-graph-visual-group-layer.tsx` to render group background beneath
+  nodes/edges and separate decorative surface from the edit hit targets.
+- Update `factory-graph-visual-group-controls.tsx` with `Fit to members` and
+  keyboard-operable size/fit behavior using existing shared action controls.
+- Add the new fit action, semantic color names, tooltips, and accessible labels
+  to `ui/src/features/factory-graph-editor/messages/editor.ts` rather than
+  hardcoding production copy in the group components.
+- Keep group label, color, membership, delete, move, and resize behavior in the
+  existing visual-group editor hook and pure layout operation boundary.
+
+##### Contracts
+
+- Continue using `layout.groups[].bounds`, `color`, and `nodeIds`; groups remain
+  presentation metadata, not topology/container nodes.
+- Standardize newly authored colors as neutral, primary, info, success,
+  warning, and danger semantic choices. Preserve the existing `outline` value
+  as a neutral read alias, and render unsupported legacy strings through a safe
+  neutral fallback rather than raw CSS.
+- Add a pure `fit group to members` operation that computes bounds from resolved
+  node sizes plus standardized padding.
+- When nodes are selected, `Create group` initializes membership and fitted
+  bounds from that selection. With no selected nodes, it retains the current
+  empty-at-viewport-center behavior.
+
+##### Services
+
+- No backend service changes. Existing Factory layout save/reload behavior
+  remains the persistence boundary.
+
+##### API changes
+
+- None. `FactoryLayoutGroup.color`, `bounds`, and `nodeIds` already support the
+  behavior. Do not add a topology relationship or custom-color field.
+
+##### Tests
+
+- Pure operation tests for fit-to-members with mixed node sizes, padding,
+  empty membership, missing legacy members, move, resize, and undo/redo.
+- Component tests proving the group interior is click-through while the label
+  and resize affordances are keyboard/pointer operable in edit mode.
+- Component tests proving observe-mode regions are non-interactive and render
+  beneath nodes and edges.
+- Palette tests for every supported semantic group color, `outline` alias, and
+  unsupported legacy fallback.
+- Extend the existing visual-group Storybook browser save check to cover
+  create-from-selection, fit, recolor, save, reload, and ordinary node/canvas
+  interaction through the region.
+
+#### Acceptance criteria
+
+- A saved group reads as a subtle colored region with a visible label and
+  accent boundary, not as an opaque card or panel.
+- Nodes, handles, edges, edge labels, selection boxes, pan, and zoom remain
+  usable inside the group region.
+- Saved groups are visible in observe and replay modes; edit-only controls are
+  not.
+- Users can select/move a group through its label/outline, resize it with a
+  pointer, and fit it to members through a keyboard-operable control.
+- Creating a group from selected nodes produces fitted bounds and membership
+  in one action.
+- Every newly authored group color uses a semantic token, survives save/reload,
+  and remains distinguishable through label/border as well as fill color.
+
+### Story 5: Preserve the new graph UX across live updates and host surfaces
+
+#### Problem statement
+
+A graph improvement is incomplete if observe/edit mode, historical replay,
+save/reload, package consumers, or high-volume live updates fall back to
+different renderers or visibly unstable geometry.
+
+#### Customer ask
+
+Keep the improved graph understandable while the Factory runs and wherever the
+canonical graph is embedded.
+
+#### Solution
+
+Wire every canonical host through the same package-owned visual-state,
+Work-volume, size, and read-only group presentation. Preserve node identity,
+viewport, selection, and authored geometry while runtime overlays update, and
+prove the result against the existing large-editor fixtures.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\factory-graph-visual-ux.md`
+
+#### Changes
+
+##### Package changes
+
+- Update `FactoryGraphReplaySurface`, current-activity, editor, and applicable
+  trace adapters to consume the same package visual contracts rather than
+  copying style/count or workstation-taxonomy logic.
+- Keep one semantic node registry and one set of handles across observe, edit,
+  and replay.
+- Add meaningful package/website Storybook states for inactive, active,
+  completed, failed, 1/3/4/large Work counts, long labels, authored sizes, and
+  colored groups, plus every workstation type/behavior/control-role family.
+- Extend renderer-path boundary checks if needed to prevent a dashboard-only
+  fallback implementation.
+
+##### Contracts
+
+- Runtime overlays may change status/count content but may not mutate authored
+  node positions, sizes, group bounds, or group membership.
+- Switching observe/edit mode or selected timeline tick preserves stable
+  semantic node IDs and handle IDs.
+
+##### Services
+
+- No service changes.
+
+##### API changes
+
+- None.
+
+##### Tests
+
+- Package-consumer tests proving the public Factory graph package renders the
+  same node state/count/size/group contract as the dashboard.
+- Current-activity graph semantic tests for live status transitions without
+  remount, geometry loss, or missing handles.
+- Existing large-editor performance tests extended to cover numeric Work mode,
+  authored mixed sizes, and multiple translucent groups.
+- Browser checks at mobile, tablet, and desktop sizes for pan/zoom, selection,
+  resize, group interaction, focus visibility, and reduced motion.
+- Packed-package verification to catch reliance on dashboard aliases or
+  unshipped styles.
+
+#### Acceptance criteria
+
+- Observe, edit, selected-tick replay, and the public package use the same
+  semantic node, workstation identity, state, count, size, and group
+  presentation.
+- Entering or leaving edit mode does not replace the graph renderer or lose
+  viewport, selection, authored size, or group display.
+- Live transitions between idle, active, completed, and failed update visual
+  state without moving unaffected nodes or disconnecting edges.
+- Large graphs remain within the existing repository performance budgets and
+  do not allocate one rendered marker per Work item once the count is above
+  three.
+- The package builds and works from a packed clean consumer, not only through
+  dashboard source aliases.
+
+### Story 6: Preserve workstation type, behavior, and guarded-control meaning
+
+#### Problem statement
+
+Customers cannot reliably tell what a workstation does or how it is scheduled.
+The current dashboard and package contracts overload `workstation_kind` with
+scheduling behavior, discard authored workstation `type`, and use missing
+worker/kind fields as an exhaustion heuristic. In the built-in goal Factory this
+makes the guarded `goal-loop-breaker` look like a large ordinary workstation,
+while replay sources can mislabel ordinary workstations as exhaustion rules.
+
+#### Customer ask
+
+Give every Factory graph enough workstation-kind behavior to distinguish
+execution, classification, logical routing, guarded loop breaking, repeating,
+cron, and polling wherever that graph is rendered.
+
+#### Solution
+
+Create one package-owned workstation semantic projection with independent
+runtime-type, scheduling-behavior, and guard-role fields. Build it from the full
+Factory definition and merge runtime activity by stable workstation identity.
+Use runtime type as the primary role, scheduling behavior as a secondary
+treatment, and supported guard configuration to derive compact control nodes.
+Remove every inference that turns absent metadata into a special role.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\factory-graph-visual-ux.md`
+
+#### Changes
+
+##### Package changes
+
+- Replace the overloaded semantic input in
+  `ui/packages/factory-graph/src/semantic-workstation-presentation.ts` with a
+  protocol-neutral value that carries authored workstation type, scheduling
+  behavior, and derived guarded-control role separately. Retain a temporary
+  read adapter for old `workstation_kind` package inputs only if a packed
+  consumer requires it; new projections must not write the compatibility shape.
+- Add primary icon/role presentations for the canonical workstation families:
+  inference run, agent run, script run, poller run, classifier, logical move,
+  and unknown. Keep legacy `MODEL_INVOKE` and `MODEL_WORKSTATION` values mapped
+  through the repository's existing taxonomy helpers rather than creating a
+  second enum table.
+- Render scheduling behavior as a secondary badge, border, or concise label so
+  `REPEATER`, `CRON`, and `POLLER` remain visible without replacing the primary
+  runtime-type identity.
+- Render guarded logical moves as compact control cards. A `VISIT_COUNT` guard
+  names the guarded workstation and visit limit in accessible text; an ordinary
+  `LOGICAL_MOVE` remains a logical router and is not styled as failure.
+- Make the unknown fallback explicit and neutral. Delete the heuristic in which
+  missing workstation kind plus missing worker type means `exhaustion`.
+- Ensure the semantic header cooperates with the Story 3 size and wrapping
+  resolver so a role badge never forces `execute-goal`, `goal-loop-breaker`, or
+  longer localized names back into ellipsis-only presentation.
+
+##### Contracts
+
+- Extend the package's `FactoryGraphWorkstationRef` replacement with separate
+  `workstationType`, `schedulingBehavior`, and `controlRole` semantics. The
+  exact names may follow package conventions, but a single `kind` string must
+  not represent more than one axis.
+- Project these fields from `Factory.workstations[]`. Join selected-tick runtime
+  topology/activity using authored workstation `id`; use `name` only as the
+  documented legacy fallback when the definition has no id.
+- Update current-activity, editor, replay/emulator, and trace workstation-node
+  adapters that use the shared semantic node. A trace source that cannot recover
+  the Factory definition supplies `unknown`, not a fabricated standard or
+  exhaustion role.
+- Keep React Flow node data disposable. Components render the semantic
+  projection and never recover authored type/behavior/guards from icon names,
+  CSS classes, or DOM measurements.
+
+##### Services
+
+- No runtime scheduling or service mutation changes are required. The
+  event-computed `snapshot.factory` and package `FactoryGraphSource.factory`
+  already carry the authored definition used by current activity and replay.
+- Do not extend the backend world-view contract merely to duplicate full
+  Factory-definition data. If a user-visible topology-only host is discovered
+  that cannot receive the definition, document that boundary and use the
+  neutral fallback in this lane.
+
+##### API changes
+
+- None. Reuse the existing generated `WorkstationType`, `WorkstationKind`,
+  `Workstation.type`, `Workstation.behavior`, and `Workstation.guards`
+  contracts. Do not hand-edit generated clients.
+
+##### Tests
+
+- Pure package tests for every supported runtime type crossed with `STANDARD`,
+  `REPEATER`, `CRON`, and `POLLER`, including lowercase legacy input,
+  undefined values, and unknown future strings.
+- Regression tests proving only a guarded `LOGICAL_MOVE` becomes a loop breaker
+  and missing metadata never becomes exhaustion.
+- Current-activity projection/component tests using the authored goal Factory
+  to prove `execute-goal` is an agent repeater and `goal-loop-breaker` is a
+  compact guarded logical control with full accessible names.
+- Replay package tests proving semantic metadata is resolved from
+  `FactoryGraphSource.factory`, and trace tests proving a lossy source uses the
+  neutral fallback.
+- Storybook/browser coverage at fit-to-view zoom for a mixed Factory containing
+  classifier, logical move, guarded loop breaker, inference, agent, script,
+  repeater, cron, and poller workstations.
+
+#### Acceptance criteria
+
+- Every user-visible Factory workstation node communicates runtime type through
+  an icon plus text or accessible label, and scheduling behavior through a
+  distinct secondary treatment.
+- `execute-goal` is visibly and accessibly both an agent-run workstation and a
+  repeater; neither fact overwrites the other.
+- `goal-loop-breaker` renders as a compact guarded logical-control node and
+  exposes its `VISIT_COUNT` target and limit without requiring selection.
+- Ordinary logical moves and classifiers are not presented as executable agent
+  workstations, and missing metadata never produces an exhaustion/loop-breaker
+  presentation.
+- Current activity observe/edit, selected-tick replay, the public package, and
+  every trace view using the shared workstation node either agree on semantics
+  or show the documented neutral fallback.
+- No backend scheduling behavior, public enum, or OpenAPI shape changes.
+
+### Story 7: Remove disconnected Work states from first-party graphs
+
+#### Problem statement
+
+The semantic graph faithfully renders every authored Work state, including
+states that no submitted Work, workstation route, invocation return, or
+implemented lifecycle bridge can reach. These nodes look operational and add
+edges/layout pressure even though they do not describe runtime behavior. The
+baseline audit found `goal:execute`; `loop-controller:stopped` and
+`scheduled-execution:skipped`; and `task:complete` plus `quorum-merge:init` in
+the quorum Factory as disconnected candidates requiring reconciliation.
+
+#### Customer ask
+
+Remove redundant operational states from the goal graph and apply the same
+hygiene rule to every first-party packaged Factory so rendered topology stays
+minimal and truthful.
+
+#### Solution
+
+Audit each authored packaged Factory through its parsed canonical definition.
+For every declared Work state, prove one concrete behavioral role: external
+admission, a workstation input or output route, an explicit invocation return,
+or a real lifecycle bridge backed by implementation and tests. Connect a state
+when the shipped product already promises that behavior; otherwise remove the
+state and update docs/fixtures. Add a semantic catalog check so disconnected
+states cannot silently return.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\factory-graph-visual-ux.md`
+
+#### Changes
+
+##### Package changes
+
+- Remove the unreferenced `goal:execute` state from
+  `packages/packaged-factories/factories/goal/factory.yaml`; the actual repeater
+  path remains `goal:init -> execute-goal -> goal:init|complete|blocked|failed`.
+- Reconcile every other disconnected candidate found by the catalog audit. A
+  promised loop stop/skip or quorum completion state is connected only when an
+  existing runtime operation already produces it and direct behavioral tests
+  prove that promise; otherwise delete it instead of leaving speculative graph
+  topology.
+- Regenerate `packages/packaged-factories/generated/` and its manifest through
+  `make packaged-factory-catalog-generate`; never edit generated catalog files
+  by hand.
+- Update `docs/reference/authoring-factories.md`, the goal docs smoke markers,
+  and affected packaged-family diagrams or examples so documentation lists only
+  the shipped state paths.
+
+##### Contracts
+
+- Define a catalog-only graph-state hygiene rule over canonical parsed Factory
+  definitions. A state is accounted for when it is an admitted initial state,
+  appears in workstation `inputs`, `outputs`, `onContinue`, `onRejection`,
+  `onFailure`, or `classificationRoutes[].outputs`, is selected by
+  `invocationReturn`, or is reached by a named implemented lifecycle bridge.
+- Do not make this a blanket public validation error for customer Factories in
+  this lane. First-party catalog minimality is stricter than the general
+  authoring contract, and JavaScript or externally controlled Factory models
+  may require a separate reachability policy.
+- The check reports the Factory slug and exact `workType:state` for each
+  disconnected state. Any lifecycle exception must point to a direct behavioral
+  test; comment-only allowlists are not accepted.
+
+##### Services
+
+- No service changes are expected for removing states that are proven
+  unreachable.
+- If the audit shows a documented first-party lifecycle state is supposed to be
+  produced but currently is not, stop that item from riding as graph cleanup and
+  plan the missing runtime behavior as a separate vertical product story. Do
+  not fake reachability in the projection or hide the state only in the UI.
+
+##### API changes
+
+- No schema shape changes. Generated packaged Factory artifacts and hashes must
+  be refreshed from authored sources.
+
+##### Tests
+
+- A focused catalog test over every
+  `packages/packaged-factories/factories/*/factory.yaml` that fails with exact
+  disconnected-state diagnostics.
+- Goal definition and docs tests proving `goal:execute` is absent while
+  `goal:init`, `goal:complete`, `goal:blocked`, and `goal:failed` remain and the
+  repeater routes are unchanged.
+- Existing invocation/runtime smoke coverage for each changed packaged Factory
+  to prove accepted, continued, blocked, failed, and explicit-return behavior is
+  unchanged.
+- Generated catalog drift and package-consumer checks proving authored YAML,
+  flattened JSON/YAML, manifest hashes, embedded Go assets, and published npm
+  artifacts agree.
+- A goal-Factory graph projection or browser fixture asserting that no
+  `work-state:goal:execute` node is rendered after the catalog update.
+
+#### Acceptance criteria
+
+- The built-in goal graph contains only `goal:init`, `goal:complete`,
+  `goal:blocked`, and `goal:failed`; the repeater and loop-breaker routes still
+  produce the same accepted, continue, blocked, and failed outcomes.
+- Every state in every first-party graph Factory has a machine-checked,
+  implemented behavioral role; the catalog check names and rejects a newly
+  introduced disconnected state.
+- State cleanup happens in the canonical authored Factory definition, not in a
+  UI visibility filter, so dashboard, editor, replay, CLI inspection, and
+  published package consumers agree.
+- Authored definitions, generated catalog artifacts, public reference docs, and
+  smoke expectations contain the same state inventory.
+- No unrelated runtime lifecycle feature is implemented as part of topology
+  cleanup.
+
+## Project-level acceptance criteria
+
+- Every Factory object family follows the documented shape and inactive color
+  grammar, with no parallel dashboard-only styling table.
+- Active/processing state is vivid and accessible across supported palettes;
+  completed and failed state remain semantically distinct.
+- Work-bearing nodes use item mode for one through three and a large total
+  number for four or more.
+- Long names can be fitted and nodes can be resized within family constraints;
+  size survives undo/redo, save, reload, observe mode, and replay.
+- Workstation runtime type, scheduling behavior, and guarded-control role remain
+  separate through canonical definition, package projection, and rendering;
+  missing data uses a neutral fallback.
+- The goal graph identifies `execute-goal` as an agent repeater, renders
+  `goal-loop-breaker` as compact guarded logical control, and contains no
+  disconnected `goal:execute` state.
+- Every first-party graph Factory passes the parsed disconnected-state catalog
+  check, and generated artifacts/docs match the cleaned authored definitions.
+- Groups render as translucent labeled regions behind the graph, remain
+  colorable with semantic tokens, and do not block node, edge, pan, zoom, or
+  selection interaction.
+- Canonical Factory/runtime/layout state, pure editor operations, package
+  projection, and React Flow component wiring remain distinct and directly
+  testable.
+- No new OpenAPI shape, backend runtime state, alternate renderer, or unrelated
+  graph redesign is introduced.
+- Localization, semantic-color, Tailwind-token, accessibility, reduced-motion,
+  responsive, package-boundary, and performance checks pass.
+- Delivery continues through required CI until it is terminal and passing;
+  blocking review feedback is addressed, conflicts are resolved, generated or
+  package drift is reconciled, and the pull request is actually merged. An open
+  or approved PR is not completion.
+
+## Verification plan
+
+Use focused package, operation, projection, and component tests within each
+story. Before merge, run the applicable final gates:
+
+```text
+cd ui && bun run --cwd packages/factory-graph verify
+cd ui && bun run check
+cd ui && bun run tsc
+cd ui && bun run test:unit
+cd ui && bun run test:component
+cd ui && bun run test:integration
+cd ui && bun run test:performance
+cd ui && bun run test-storybook
+cd ui && bun run storybook:responsive-check
+cd ui && bun run storybook:factory-graph-visual-group-save-check
+cd ui && bun run verify:public-packages
+make packaged-factory-catalog-generate
+make packaged-factory-catalog-check
+make packaged-factory-package-verify
+make docs-reference-smoke
+make verify-fast
+make verify-pr
+```
+
+Add one focused Factory graph visual-UX browser check if the existing visual
+group and responsive checks cannot directly prove:
+
+- the 3-to-4 Work threshold;
+- vivid active state with reduced-motion fallback;
+- long-name fit and pointer/keyboard resize;
+- workstation type/behavior/guard-role parity and the unknown fallback;
+- the cleaned goal graph without `goal:execute`;
+- resize save/reload;
+- group click-through, fit, recolor, and save/reload; and
+- observe/edit continuity at desktop and touch breakpoints.
+
+Visual QA must use representative large Factory fixtures rather than only
+isolated nodes. Capture at least idle, mixed-runtime-state, dense-Work,
+long-label, resized-layout, and multi-group states across the supported palette
+presets. Reviewers should compare information hierarchy and interaction, not
+pixel-match the supplied concept image.
+
+## Delivery order
+
+1. Clean the authored goal topology and land the first-party disconnected-state
+   catalog check so visual fixtures start from truthful canonical definitions.
+2. Land the package-owned workstation type/behavior/control-role contract and
+   remove missing-metadata special-role inference.
+3. Land the shared visual-state and node-family contract before changing every
+   semantic node.
+4. Land Work-volume compaction on the shared package contract.
+5. Land size resolution and label wrapping before exposing resize controls.
+6. Land resize operations, history, component wiring, and save/reload as one
+   vertical behavior slice.
+7. Land read-only group-region presentation before edit-only group controls.
+8. Land create-from-selection, fit-to-members, semantic colors, and group
+   persistence.
+9. Complete observe/edit/replay/trace parity, large-graph performance,
+   responsive and accessibility evidence, packaged-factory/catalog/docs drift
+   checks, public-package verification, blocking review resolution, terminal
+   green CI, conflict resolution, and merge.
+
+## Definition of done
+
+The work is complete when a customer can open a large Factory graph, understand
+which workstation type runs and how it is scheduled, distinguish guarded
+logical controls from executable workstations, trust that every rendered Work
+state is part of real shipped behavior, understand inactive versus
+active/completed/failed structure at a glance, see four or more Work items as a
+large total, read or fit long names, resize appropriate nodes and retain those
+sizes, and use colored groups that visually organize the canvas without
+obstructing it. The behavior must come from cleaned canonical Factory
+definitions, the canonical Factory graph package, and the controlled editor
+layout path; survive save/reload and replay; pass the listed quality gates; and
+be merged.

--- a/docs/internal/development/plans/factory-operation-nodes.md
+++ b/docs/internal/development/plans/factory-operation-nodes.md
@@ -1,0 +1,1430 @@
+# Factory Operation Nodes Plan
+
+## Status
+
+Proposed.
+
+## Problem
+
+Factory graphs can run workers, classify results, move Work, repeat, schedule
+cron Work, and express several specialized guard patterns. They do not yet
+provide a coherent customer-facing way to model common orchestration
+operations:
+
+- stateful stream selection such as skip, take, or pick-first;
+- exact-count Work generation and collection of several Work items of the same
+  type;
+- typed conditions over structured Work output;
+- deterministic random choice and seed generation;
+- timers and windows such as delay, debounce, throttle, and timeout; and
+- utilities such as tee, artifact creation, and bounded file writes; plus
+- a deliberately small external surface for file/email Work ingress, email
+  delivery, and outbound HTTP requests.
+
+Some of these behaviors exist internally as Petri arc cardinalities,
+parent/child guards, generated `FACTORY_REQUEST_BATCH` output, cron time tokens,
+or JavaScript `parallel()` / `pipeline()`. They are hard to compose in an
+authored graph because each uses a different special-case contract. The result
+is that customers must understand internal topology or write a script for
+behaviors that should be ordinary graph nodes.
+
+## Customer Ask
+
+Customers should be able to author bounded, replayable operation nodes for
+stream selection, structured routing, fan-out, fan-in, aggregation, randomness,
+time, and utility effects. External ingress/capability nodes should be a closed
+allowlist rather than a general integration catalog. Together, those nodes
+should be sufficient to build, among other workflows:
+
+1. an evolutionary Factory that creates a population, evaluates it, selects and
+   mixes candidates, and repeats for a configured number of rounds; and
+2. a leaderboard Factory that runs up to a configured number of autonomous
+   agents, gives each agent isolated branch/notes state, evaluates submissions,
+   updates standings, and stops after a global execution ceiling.
+
+## Current Baseline
+
+The implementation plan must extend, rather than duplicate, these current
+capabilities:
+
+- `FactoryWorkstationConfig` already distinguishes worker runs,
+  `LOGICAL_MOVE`, classifiers, cron, and pollers.
+- The internal Petri scheduler already supports `ONE`, `N`, `ALL`,
+  `ALL_TERMINAL`, and `ZERO_OR_MORE` cardinalities.
+- Generated worker output can already admit bounded Work batches with lineage
+  and `DEPENDS_ON` relationships.
+- `ALL_CHILDREN_COMPLETE`, `ANY_CHILD_FAILED`, `MATCHES_FIELDS`, `SAME_NAME`,
+  `SAME_TRACE_ID`, and `VISIT_COUNT` guards provide several narrow correlations.
+- Work has canonical typed content, including JSON content parts, plus payload,
+  tags, trace identity, parent identity, and relationships.
+- Factory Runtime already receives clock and randomness implementations through
+  explicit boundaries; the browser emulator already uses deterministic virtual
+  time and seeded identities.
+- JavaScript Factories already expose `agent.run()`, `parallel()`, `pipeline()`,
+  phases, checkpoints, and bounded child policy. They remain the escape hatch
+  for algorithms that do not fit the built-in catalog.
+
+## n8n Core-Node Review
+
+This plan also reviews the current [n8n core-node catalog](https://docs.n8n.io/integrations/builtin/core-nodes/)
+as a mature workflow-authoring reference. The goal is semantic coverage, not
+name-for-name compatibility. n8n processes generic item lists and integrates
+many external systems directly; You Agent Factory owns typed Work, worker and
+provider execution, Factory Sessions, Automations, canonical Factory Events,
+and replay. A node that is “core” in n8n may therefore belong in an existing
+service here rather than in the operation runtime.
+
+Detailed comparison used the documented semantics of n8n's
+[Aggregate](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.aggregate/),
+[Merge](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.merge/),
+[Limit](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.limit/),
+[Remove Duplicates](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.removeduplicates/),
+[Sort](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.sort/),
+[Split Out](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.splitout/),
+[Loop Over Items](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches/),
+[Summarize](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.summarize/),
+[Compare Datasets](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.comparedatasets/),
+[Wait](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.wait/),
+[Edit Fields](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.set/),
+[Rename Keys](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.renamekeys/),
+[Date & Time](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.datetime/),
+[Stop And Error](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.stopanderror/),
+[Local File Trigger](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.localfiletrigger/),
+[Email Trigger (IMAP)](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.emailreadimap/),
+[Send Email](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.sendemail/),
+[HTTP Request](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/),
+[Data Table](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.datatable/),
+[Convert to File](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.converttofile/),
+and [Extract From File](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.extractfromfile/).
+
+### Adopt as operation semantics
+
+| n8n concept | Factory operation decision | Adaptation for this repository |
+| --- | --- | --- |
+| No Operation | `PASS` | Preserve typed Work and lineage; emit a canonical operation fact; create no worker dispatch. |
+| Filter, If, Switch | `FILTER` and ordered `SWITCH` | Use typed predicates and named false/default routes. `If` is the two-route `SWITCH` presentation, not a distinct runtime kind. |
+| Limit | `TAKE` plus closed-collection `LIMIT` | Streaming take-first closes after N; take-last requires a closed/bounded collection and cannot pretend future items are known. |
+| Remove Duplicates | `DISTINCT` | Support selected keys and bounded within-collection/session history. Cross-session history is deferred until a durable owner exists. |
+| Sort | `SORT` and seeded `SHUFFLE` | Require typed keys, explicit null ordering, stable tie-breakers, and recorded randomness rather than JavaScript string coercion. |
+| Split Out | `SPLIT` | Convert a selected JSON array/content collection into atomic child Work with deterministic index and lineage. |
+| Loop Over Items | `BATCH` | Release bounded groups to a loop route and emit a done route after the registered collection is exhausted; require termination and iteration ceilings. |
+| Aggregate | `COLLECT` plus `MERGE_CONTENT` | Separate waiting/collection semantics from output shaping; support selected fields, list flattening, and missing/null policy. |
+| Summarize | `REDUCE` | Add average, count-unique, concatenate, and group-by to count/sum/min/max/latest/top-K. |
+| Merge | `JOIN` plus append/collection modes | Support append, keyed inner/left/right/full joins, and positional zip with explicit duplicate/clash policy. Defer SQL and unbounded Cartesian products. |
+| Compare Datasets | `DIFF` | Emit only-left, equal, changed, and only-right routes with typed match keys and explicit field comparison policy. |
+| Edit Fields, Rename Keys | `PROJECT` | Set, copy, remove, and rename selected typed fields. No arbitrary expression or regex engine is embedded in the contract. |
+| Stop And Error | `FAIL` | End the scoped Work or Factory path with a stable code, sanitized message/details, and canonical failure event. |
+| Date & Time | `DATE_TIME` | Parse, format, add/subtract, extract, round, and calculate differences using explicit timezone and locale policy; current-time reads use the injected clock. |
+| Wait after interval/at time | `DELAY` / timed `WAIT` | Record deadlines and use the injected clock. External webhook/form resume is a separate durable-session feature. |
+| Read/Write Files | `WRITE_ARTIFACT` / bounded `WRITE_FILE` | Use authorized roots, atomic/idempotent effects, quotas, and replayable metadata. |
+
+### Retain only an explicit ingress and capability allowlist
+
+The n8n catalog does not establish a general integrations backlog for this
+product. Near-term external ingress and effect nodes are limited to the
+following allowlist:
+
+| Approved surface | Public shape | Repository owner/answer |
+| --- | --- | --- |
+| Local file watch | `FILE_WATCH` Automation | `pkg/services/automations` observes bounded create/modify/delete changes under authorized roots and admits mapped Work through `pkg/services/work`. It is not a mid-graph polling operation. |
+| Email receive | `EMAIL_RECEIVE` Automation | Automations observes one configured mailbox/folder/filter, checkpoints provider message identity, and admits bounded message/attachment content as Work. |
+| Email send | `SEND_EMAIL` effect operation | An explicit effect node sends one bounded, fully rendered message through a credential reference and records provider delivery metadata. It is not a generic connector or arbitrary command. |
+| Outbound HTTP request | `HTTP_REQUEST` effect operation | An explicit effect node performs one policy-constrained request and emits a bounded response/result. It is outbound only; it does not create an inbound webhook trigger. |
+
+`FILE_WATCH` and `EMAIL_RECEIVE` are Work ingress, so their durable cursor,
+deduplication, schedule/push observation, backpressure, and admission policy
+belong to Automations and Work. `SEND_EMAIL` and `HTTP_REQUEST` are explicit,
+recorded effects and therefore remain outside the pure predicate/collection
+kernel. None of these contracts creates a generic connector registry, dynamic
+plugin node, or arbitrary network/process execution surface.
+
+Existing product entry points and internal capabilities remain supported, but
+are not promoted into new user-authored nodes by this plan. In particular,
+native CLI/API/MCP/ACP invocation is not a "trigger node"; existing cron and
+poller behavior is not expanded; Worker worktrees are not a generic Git node;
+and `SCRIPT_RUN` compatibility is not an Execute Command node.
+
+AI transforms, chat, evaluation, and semantic guardrails continue to use the
+existing `INFERENCE_RUN`, `AGENT_RUN`, classifier, output-schema, provider, and
+model contracts. JavaScript Factory orchestration remains the escape hatch for
+bespoke code. A deterministic operation must never hide an inference call.
+
+### Defer or exclude from the core operation program
+
+| n8n concept | Decision |
+| --- | --- |
+| Data Table | Defer. A cross-Factory mutable table needs a durable domain owner, authorization, schema/versioning, query, retention, and event/replay relationship; operation-local state is not that database. |
+| Wait on webhook/form | Defer until durable Factory Session suspension/resume and one-time authenticated correlation are product contracts. The current process-local queue cannot safely emulate n8n's database-offloaded wait. |
+| Activation, Manual, Schedule, RSS, SSE, Webhook, form, workflow, evaluation, error, chat, MCP-server, and vendor-specific triggers | Exclude as new node kinds. Preserve existing native invocation and automation behavior where already supported, but do not broaden the ingress catalog beyond `FILE_WATCH` and `EMAIL_RECEIVE` in this plan. |
+| Respond to Webhook, chat response, and form response | Exclude. They imply durable external correlation and a product interaction surface that is not part of the approved ingress/effect allowlist. |
+| Execute Command, Git, SSH, FTP, GraphQL, LDAP, RSS Read, MCP Client, and vendor/service integrations | Exclude as capability nodes. Existing internal uses keep their current owners, but this plan adds no generic command, connector, protocol, or credential-driven integration surface. |
+| Execute Sub-workflow and its trigger | Exclude from this program. Child-Factory invocation would require an explicit Factory Sessions/Runtime contract for recursion, budget, cancellation, results, and lineage. |
+| Execution Data | Do not add a node. Factory Events, recordings, projections, logs, metrics, and tags remain the observability surfaces. |
+| Cross-execution deduplication | Defer with Data Table/durable state ownership. Initial `DISTINCT` is bounded to a Factory Session or explicit input collection. |
+| SQL Merge and custom-code Sort | Exclude from built-ins. Typed joins/sorts cover the stable cases; JavaScript remains the escape hatch. |
+| All-possible-combination Merge | Defer unless a bounded use case justifies it; Cartesian growth must have prospective output and byte ceilings before execution. |
+| Compression, HTML, Markdown, XML, CSV/spreadsheet/PDF/file extraction and conversion | Add later as `ENCODE_CONTENT` / `DECODE_CONTENT` adapters owned with Work content/materialization, one format family at a time. Do not make a large codec bundle a prerequisite for orchestration operations. |
+| Crypto, JWT, and TOTP | Defer to security/credential-owned capabilities. Seeded orchestration randomness is not cryptographic randomness, signing, token issuance, or secret custody. |
+| Edit Image | Use model/media services or a dedicated capability; it is not a general orchestration primitive. |
+| Debug Helper | Keep test/debug fixtures outside the public production-node catalog. |
+| n8n administration node | Not applicable; Factory Definition/Session and operator-setting APIs already own this product's administration. |
+
+The resulting principle is: adopt nodes that perform deterministic routing,
+collection, transformation, bounded state, or time over Work; permit only the
+four named ingress/effect surfaces above; and exclude other trigger and
+integration nodes instead of implying a future connector catalog.
+
+## Goals
+
+- Make common orchestration behavior readable and editable as first-class
+  Factory graph nodes.
+- Give stateful nodes explicit scope, ordering, buffering, closure, and overflow
+  semantics.
+- Make structured predicates typed, fail-closed, and reusable by guards and
+  conditional routing.
+- Generate and collect exact or bounded sets of same-type Work without repeated
+  hand-authored inputs or hidden prompt protocols.
+- Keep time, randomness, filesystem IO, and mutable operator state deterministic
+  or explicitly recorded so live execution and replay agree.
+- Admit Work from authorized file changes and received email, and support only
+  the explicitly approved email-send and outbound-HTTP external effects.
+- Preserve Work identity, content, lineage, relationships, and terminal failure
+  behavior across every operation.
+- Provide safe bounds, backpressure, diagnostics, and UI validation before a
+  Factory runs.
+- Prove the catalog with evolutionary and leaderboard packaged examples.
+
+## Non-Goals
+
+- Reimplement all of RxJS or expose an arbitrary stream-programming language in
+  Factory JSON/YAML.
+- Expose Petri places, tokens, arcs, or markings as customer-facing operation
+  configuration.
+- Add arbitrary Go templates, JavaScript, shell commands, or regular expressions
+  to guards as a shortcut around a typed predicate contract.
+- Replace JavaScript Factories. Complex bespoke algorithms can still use the
+  JavaScript orchestrator and its existing bounded child primitives.
+- Make operation nodes a second Work store, event ledger, artifact store, or
+  scheduler.
+- Add RSS, SSE, webhook, form, chat, MCP, vendor, database, shell, Git, SSH,
+  FTP, GraphQL, LDAP, or other generalized trigger/integration nodes. Existing
+  native transports, automation behavior, worktrees, and script runners are not
+  removed, but this plan does not expand them into graph-node families.
+- Build a generic connector marketplace, capability registry, credential
+  broker, or arbitrary request/command node. `SEND_EMAIL` and `HTTP_REQUEST`
+  are closed, independently governed contracts.
+- Promise recovery of unrelated in-flight provider execution. Operation state
+  will be replayable, but broader Factory Session restart guarantees remain the
+  responsibility of Factory Sessions and Factory Runtime recovery.
+
+## Product Model
+
+### One workerless operation workstation
+
+Add one public workerless workstation type, `OPERATION`, rather than a separate
+runtime workstation type for every utility. Its configuration is carried by a
+new `builtin` object:
+
+```yaml
+workstations:
+  - id: first-valid-result
+    name: first-valid-result
+    type: OPERATION
+    builtin:
+      kind: TAKE
+      count:
+        literal: 1
+      scope:
+        kind: TRACE
+    inputs:
+      - id: candidate
+        workType: candidate
+        state: evaluated
+    outputs:
+      - id: selected
+        workType: candidate
+        state: selected
+      - id: overflow
+        workType: candidate
+        state: not-selected
+```
+
+`operation` remains the existing provider-neutral model operation field used by
+`MODEL_INVOKE`; it is not overloaded for built-in graph behavior. `builtin.kind`
+is a generated public enum and `builtin.config` is a discriminated contract for
+the selected kind.
+
+An operation is compiled by Factory Definitions into the existing
+transport-neutral Factory Runtime model. The internal Petri compiler may use
+arcs, cardinalities, guards, and system tokens to execute it, but those remain
+implementation details.
+
+### Stable ports and collection inputs
+
+Add an optional stable `id` to workstation inputs and outputs. Guard references,
+predicate input references, UI handles, and operation routes use the port ID.
+Existing definitions without IDs retain their current generated binding names.
+
+An operation input can declare collection behavior without repeating the same
+Work type:
+
+```yaml
+inputs:
+  - id: candidates
+    workType: candidate
+    state: evaluated
+    collection:
+      mode: EXACT
+      count:
+        invocationArgument: populationSize
+      groupBy:
+        source: PARENT_ID
+```
+
+Supported collection modes are `ONE`, `EXACT`, `AT_LEAST`, `ALL_REGISTERED`,
+and `UNTIL_CLOSED`. `ALL_REGISTERED` uses an explicit generated-child
+registration as its denominator; it never guesses completion from the Work
+currently visible in one state.
+
+### Shared value sources
+
+Counts, durations, keys, seeds, and other scalar settings use one bounded value
+source contract:
+
+- `literal`: an authored JSON scalar;
+- `invocationArgument`: one normalized Factory invocation argument;
+- `selector`: a value selected from one named input; or
+- `default`: an optional fallback used only when the primary source is absent.
+
+Validation defines the required output type, minimum, maximum, and whether a
+fallback is allowed for each use. Missing, malformed, non-finite, negative, or
+out-of-policy values fail before partial Work or effects are produced.
+
+### Structured selectors and predicates
+
+Selectors address canonical Work fields, tags, invocation arguments, or a
+canonical content part. JSON content uses RFC 6901 JSON Pointer after selecting
+the part by stable slot or label. A selector never relies on map insertion order
+or an ambiguous “first JSON object” when several parts match.
+
+Predicates form a small typed tree:
+
+- boolean composition: `ALL`, `ANY`, `NOT`;
+- presence/type: `EXISTS`, `IS_NULL`, `TYPE_IS`;
+- comparison: `EQ`, `NE`, `LT`, `LTE`, `GT`, `GTE`;
+- collection/text: `CONTAINS`, `STARTS_WITH`, `ENDS_WITH`, `IN`;
+- schema: `JSON_SCHEMA_VALID` using an authored or bundled schema reference; and
+- operands: literal, invocation argument, or selector from a named input.
+
+Comparisons do not coerce strings into numbers or booleans. An absent path,
+wrong type, invalid schema, or ambiguous content part fails closed and produces
+a structured diagnostic. Sensitive invocation arguments cannot be projected
+into events, output content, paths, or UI previews.
+
+Pure predicates can be attached as readiness guards, but conditional business
+routing should use `SWITCH` or `FILTER`. A false readiness guard leaves Work
+waiting; a conditional operation explicitly routes false/unmatched Work and
+therefore does not strand it accidentally.
+
+### Stateful operation scope and ordering
+
+Every stateful operation declares a scope:
+
+- `TRACE` (default): workstation plus canonical chaining trace;
+- `PARENT`: workstation plus parent Work identity;
+- `SESSION`: workstation plus Factory Session; or
+- `VALUE`: workstation plus a typed selected partition key.
+
+Items are observed in canonical Factory Event sequence order, with Work ID as a
+stable tie-breaker when one accepted event contains several items. Provider
+completion timing is not re-sorted later. Each state change records its scope
+key, selected Work IDs, prior version, next version, and outcome.
+
+Stateful operations must declare or inherit bounds for buffered items, bytes,
+open groups, timers, generated Work, and total firings. Reaching a bound routes
+to an explicit overflow/failure output or fails the operation with a stable
+code; it never silently drops Work.
+
+### Deterministic time and randomness
+
+Runtime time comes from the injected Factory Runtime clock. Timed operations
+record scheduled, canceled, and fired timer facts with logical deadline and
+operation scope. Tests and emulator execution advance an injected/virtual clock
+and do not sleep.
+
+A Factory Session has one recorded root random seed. A caller may supply it;
+otherwise a platform random source creates it once and the accepted seed is
+recorded before use. Each random operation derives a substream from the root
+seed, workstation ID, scope key, and firing ordinal. The chosen value or order is
+recorded in the operation event, so replay projects the choice instead of
+sampling again.
+
+Randomness is an operation, not a guard side effect. Re-evaluating a readiness
+guard must never consume random state or change its answer merely because the
+scheduler inspected it again.
+
+### Canonical operation facts
+
+Recordings remains the canonical Factory Event ledger. Add the minimum public
+facts needed to explain and replay operation behavior:
+
+- `OPERATION_APPLIED`: kind, workstation, scope, consumed/observed Work,
+  selected route, derived values, state version, and related Work Request IDs;
+- `OPERATION_TIMER_SCHEDULED`, `OPERATION_TIMER_CANCELED`, and
+  `OPERATION_TIMER_FIRED` for durable time decisions; and
+- `OPERATION_EFFECT_COMPLETED` / `OPERATION_EFFECT_FAILED` for external effects
+  with idempotency identity and artifact/file metadata.
+
+Canonical `WORK_REQUEST`, `WORK_STATE_CHANGE`, relationship, and artifact facts
+remain authoritative for Work and artifact state. Operation facts reference
+those records rather than duplicating their complete payloads. Replay does not
+rerun predicates, randomness, timers, or filesystem writes.
+
+## Operation Catalog
+
+The catalog lands in capability groups. Every operation has an explicit success
+route, explicit non-selected/failure routes where applicable, deterministic
+ordering, bounded configuration, and a UI editor.
+
+| Group | Kinds | Observable behavior |
+| --- | --- | --- |
+| Routing | `PASS`, `FILTER`, `SWITCH`, `TEE`, `FAIL` | Move, conditionally route, copy lineage, or terminate with an explicit failure without a worker dispatch. |
+| Selection | `SKIP`, `TAKE`, `LIMIT`, `DISTINCT`, `SORT` | Select/order Work according to scoped accepted-item history or one explicitly closed collection. `TAKE` with count 1 is pick-first. |
+| Fan-out | `GENERATE`, `SPLIT`, `BATCH` | Create an exact bounded child population, split a selected array into children, or release registered members in bounded batches. |
+| Fan-in | `COLLECT` | Wait for exact, quorum, all-registered, or closed groups and emit a stable ordered collection. |
+| Combine | `JOIN`, `DIFF` | Append/zip/key-join bounded collections or route their keyed equal/changed/one-sided members. |
+| Transform | `PROJECT`, `MERGE_CONTENT`, `DATE_TIME` | Build canonical typed Work content, merge a collection, or perform explicit timezone-aware date/time transformations. |
+| Aggregate | `REDUCE` | Maintain bounded built-in aggregates: count, count-unique, sum, average, min, max, concatenate, latest-by-key, group-by, and top-K. |
+| Random | `RANDOM_VALUE`, `SHUFFLE`, `SAMPLE` | Produce seeded values or deterministic permutations/samples. |
+| Time | `DELAY`, `WAIT`, `DEBOUNCE`, `THROTTLE`, `TIMEOUT` | Route Work according to recorded deadlines and scoped activity. Initial `WAIT` supports interval or absolute time, not webhook/form resume. |
+| Effects | `WRITE_ARTIFACT`, `WRITE_FILE`, `SEND_EMAIL`, `HTTP_REQUEST` | Perform one explicitly approved, bounded side effect and emit a recorded result with idempotency, retry, and failure policy. |
+
+`REDUCE` is intentionally a catalog of built-in reducers, not a customer-coded
+function. A reducer outside that set belongs in a JavaScript Factory until it
+has stable semantics worth promoting.
+
+### Important per-kind semantics
+
+- `SKIP(n)` routes the first `n` items in a scope to `skipped`, then later items
+  to `selected`.
+- `TAKE(n)` routes the first `n` items to `selected`, closes the scoped gate, and
+  routes later items to `overflow`. `TAKE(1)` is the canonical pick-first node.
+- `DISTINCT` requires a typed key selector and a bounded retention policy:
+  session lifetime, count window, time window, or one closed input collection.
+- `LIMIT` operates on a closed collection and can retain its first or last N
+  members. Streaming pick-first remains `TAKE`; streaming “last N” is invalid
+  because the future collection is not yet known.
+- `SORT` requires typed keys, direction, null placement, and a stable Work-ID
+  tie-breaker. Seeded random ordering is `SHUFFLE`, not an implicit sort mode.
+- `TEE` emits one derived Work item per declared output, preserving a common
+  parent/trace and assigning deterministic child identities. It is not an
+  aliasing reference to one mutable token.
+- `GENERATE` resolves its count before producing anything, validates the full
+  prospective batch, then atomically admits exactly that many children with
+  deterministic `index`, `generation`, `seed`, parent, and spawned-by metadata.
+- `COLLECT` groups by trace, parent, or selected key; selects members in stable
+  event order; emits once per group unless configured for sliding updates; and
+  declares whether source Work is consumed or observed.
+- `SPLIT` selects one bounded JSON array and atomically creates one child per
+  member, with optional projection of the other parent fields. `BATCH` releases
+  registered members in fixed-size groups and emits `done` only after every
+  member is accounted for or explicitly failed.
+- `JOIN` supports append, positional zip, and typed key joins with explicit
+  inner/left/right/full output, multiple-match, unpaired-item, deep/shallow
+  field-clash, and output-size policies. It does not accept SQL.
+- `DIFF` shares the key and comparison engine with `JOIN` but emits named
+  only-left, equal, changed, and only-right routes instead of one merged set.
+- `SWITCH` evaluates ordered cases and requires a default route unless the
+  author explicitly selects fail-on-no-match.
+- `REDUCE(top-K)` requires a numeric score selector, stable descending order,
+  deterministic tie-breaker, and maximum retained count. `latest-by-key`
+  requires both key and ordering selectors. Group-by and count-unique have
+  explicit missing/null policies and maximum group/cardinality bounds.
+- `DATE_TIME` requires an explicit input format/timezone when parsing is not
+  unambiguous, uses the Factory/session timezone only when selected, and reads
+  “now” through the injected clock.
+- `DEBOUNCE` retains the latest item and routes replaced items to `superseded`;
+  `THROTTLE` routes suppressed items to `suppressed`; `TIMEOUT` has separate
+  completed and timed-out routes.
+- `FAIL` records a stable non-sensitive error code plus bounded message/details,
+  then follows the Work/Factory failure policy; it cannot fabricate a success
+  output.
+- `WRITE_ARTIFACT` writes through the Recordings artifact operation.
+  `WRITE_FILE` writes atomically under an explicitly authorized Factory/session
+  root, rejects traversal and unsafe symlinks, and declares `FAIL`, `REPLACE`, or
+  ordered `APPEND` collision policy. It emits artifact/file metadata instead of
+  hiding the side effect.
+- `SEND_EMAIL` renders bounded recipients, subject, body, and attachments from
+  typed selectors; uses an opaque credential reference; rejects secret
+  material in recorded output; and records an idempotency key plus sanitized
+  provider delivery identity. Automatic retry is allowed only when the adapter
+  can preserve at-most-once intent or reconcile an ambiguous result.
+- `HTTP_REQUEST` uses an allowed method, validated URL, bounded headers/body,
+  opaque credential reference, redirect policy, timeout, response-size limit,
+  and explicit status/body output mapping. Network policy must address private
+  address ranges, DNS rebinding, unsafe redirects, TLS, and sensitive header
+  redaction. Automatic retries default to idempotent methods only unless the
+  author supplies an adapter-supported idempotency contract.
+
+### Approved Work ingress
+
+Ingress remains outside the `OPERATION` workstation catalog because it creates
+Work from external observations rather than transforming already-admitted
+Work:
+
+- `FILE_WATCH` watches explicit authorized roots and event kinds with glob,
+  debounce/coalescing, stable cursor, size/content policy, and a Work template.
+  Restart and duplicate filesystem notifications must not admit duplicate Work
+  for the same checkpointed observation.
+- `EMAIL_RECEIVE` observes an explicit account, mailbox/folder, and supported
+  filter with a durable provider cursor and message-identity deduplication. It
+  maps headers, text/HTML bodies, and quota-checked attachments into typed Work,
+  redacts credentials, and exposes malformed/oversized/dead-letter outcomes.
+
+Both ingress kinds use the existing Automation lifecycle and Work admission
+contracts. They do not execute inside Factory Runtime, and replay of a Factory
+Session never polls the filesystem or mailbox again.
+
+## Architecture And Ownership
+
+### Factory Definitions
+
+`pkg/services/factory_definitions` owns the authored operation schemas,
+normalization, validation, compatibility behavior, and compilation request. Its
+private contract and validation code should gain operation values rather than a
+new top-level product service.
+
+Validation must cover:
+
+- operation kind/config discrimination;
+- required and allowed ports per kind;
+- stable unique port IDs and valid references;
+- selector and predicate typing;
+- count/duration/buffer limits;
+- required false, overflow, timeout, superseded, and failure routes;
+- bounded state and effect policy;
+- illegal worker, prompt, model, cron, classifier, or operation combinations;
+- cycles that can fire synchronously without a configured bound; and
+- portability of schema and file references.
+
+### Factory Runtime
+
+`pkg/services/factory_runtime` owns operation execution policy and exposes only
+transport-neutral Factory behavior. Add an internal operation runtime under the
+Factory Runtime owner with focused pure packages for selectors, predicates,
+value resolution, and reducers, plus stateful executors for selection, groups,
+timers, randomness, and effects.
+
+The orchestration compiler maps `OPERATION` nodes into runtime transitions. The
+scheduler continues to own atomic enablement and claims. The operation runtime
+returns proposed Work mutations, Work Request admissions, timer changes, and
+effects; the normal event-first loop accepts and records them. Operations do not
+mutate canonical world state directly.
+
+### Work
+
+`pkg/services/work` remains the owner of Work Request admission, typed content,
+lineage, relationships, and materialization. `GENERATE`, `TEE`, `COLLECT`,
+`PROJECT`, and `MERGE_CONTENT` call narrow injected Work service operations or
+pure Work value contracts; they do not create a parallel operation-owned Work
+model.
+
+Generated and derived Work must preserve trace lineage, declare
+`PARENT_CHILD` / `SPAWNED_BY` relationships where applicable, and use atomic
+batch admission. Existing worker-emitted generated Work remains supported and
+uses the same validation/limit policy.
+
+### Recordings And Platform
+
+`pkg/services/recordings` owns operation event persistence, replay projections,
+and session artifacts. `pkg/platform/clock`, platform randomness, and focused
+portable file, mail, and HTTP implementations provide policy-free effects.
+Factory Runtime chooses operation policy; Platform must not choose Work,
+Factory, scheduling, recipient/endpoint authorization, retry, path, or collision
+policy.
+
+All service and effect dependencies are injected directly once through the
+canonical `pkg/wire` graph. No operation registry may become a service locator,
+secondary injector, or runtime constructor graph.
+
+### Automations, Workers, And JavaScript
+
+- Automations continues to own existing external cron, watcher, poller, and
+  hosted-source Work admission. This plan adds or hardens only `FILE_WATCH` and
+  `EMAIL_RECEIVE`; it does not add new trigger families. Intra-session
+  delay/window timers belong to Factory Runtime.
+- Workers continues to own agent worktrees, prompts, provider dispatch, and
+  request-scoped execution. Operation nodes are workerless.
+- JavaScript Factories continue to use `parallel()` / `pipeline()` for bespoke
+  dynamic algorithms. Built-ins and JavaScript must converge on the same Work,
+  dispatch, event, budget, artifact, and replay contracts rather than maintain
+  separate copies of selection or file policy.
+
+### Expected implementation surfaces
+
+The exact file split should stay within package file-count limits, but the
+implementation is expected to extend these current owners rather than create a
+new top-level package family:
+
+| Surface | Current files/directories to extend | Expected new focused code |
+| --- | --- | --- |
+| Authored contracts | `pkg/services/factory_definitions/internal/contracts/factory_config.go`, `contracts_root.go` | Focused operation contract files at the Factory Definitions root/private contract boundary. |
+| Definition validation | `pkg/services/factory_definitions/internal/services/validation/impl/`, `internal/services/validation/internal/topology/` | Operation discrimination, selector/predicate, port, bounds, and cycle rules beside existing topology validation. |
+| Runtime compilation | `pkg/services/factory_runtime/internal/services/orchestration/definitionmapping/mapper.go` | Operation mapping helpers/tests that lower public config into runtime transitions without exposing Petri types publicly. |
+| Scheduling/runtime | `pkg/services/factory_runtime/internal/services/orchestration/scheduler/`, `runtime/`, `subsystems/` | An `operations/` internal area split by pure evaluation, scoped state, timers, and effects; avoid growing existing large files. |
+| Work/lineage | `pkg/services/work/admission_contract.go`, `contracts.go`, `lineage_contract.go` | Narrow admission/materialization value contracts only where the current Work root lacks the required operation call. |
+| Events/replay | `pkg/services/factory_definitions/internal/contracts/factory_events.go`, Factory Runtime recording/projection contracts, `pkg/services/recordings/` projections | Operation event payloads and state reducers; no duplicate ledger. |
+| Approved ingress | `pkg/services/automations/`, `pkg/services/work/` admission contracts | `FILE_WATCH` hardening plus focused `EMAIL_RECEIVE` observation, durable cursor/deduplication, mapping, quota, and dead-letter behavior; no generic trigger registry. |
+| Approved external effects | Factory Runtime effects, `pkg/services/edges/`, focused `pkg/platform/` adapters | Narrow mail-send and outbound-HTTP ports with injected implementations, authorization/redaction, idempotency, retry, and bounded response/delivery results; no connector service locator. |
+| OpenAPI | `api/components/schemas/data-models/Workstation.yaml`, `WorkstationIO.yaml`, `WorkstationType.yaml`, guard schemas, `api/components/schemas/events/FactoryEvent*.yaml` | New operation schemas under `api/components/schemas/data-models/` and operation projection schemas under the owning event/world families. |
+| Packaged schema | `packages/packaged-factories/schemas/factory.schema.yaml` and generated package artifacts | Generated operation definitions and authored example Factories; generated JSON/YAML remains generated. |
+| Editor operations | `ui/src/features/current-factory-definition/lib/`, `ui/src/features/current-selection/workstation-selection/editing/` | Pure operation-node mutations, validation, and React Flow projection adapters under feature-owned `lib/` / `editing/` directories. |
+| Editor components | `ui/src/features/current-selection/workstation-selection/components/editable/`, feature message catalogs | Kind-specific fields composed from shared form/action primitives; no parallel canonical schema in component state. |
+| Emulator | `ui/packages/factory-emulator/src/`, schema and frozen runtime references | Hosted-parity implementations for the declared deterministic subset only. |
+| Functional proof | `tests/functional/orchestration/`, `tests/stress/` | Root-built operation scenarios and bounded concurrency/time/effect stress cells. |
+
+## API, Generated Contracts, And Compatibility
+
+Author changes in `api/openapi-main.yaml` and `api/components/`:
+
+- add `OPERATION` to `WorkstationType`;
+- add `Workstation.builtin` and the operation kind/config schemas;
+- add stable `id` and optional `collection` to `WorkstationIO`;
+- add selector, value-source, predicate, scope, limit, route, aggregation, timer,
+  random, artifact, file-effect, email-send, and HTTP-request schemas;
+- add `FILE_WATCH` and `EMAIL_RECEIVE` Automation schemas without adding a
+  general trigger or connector union;
+- extend guard schemas with a pure structured predicate attachment;
+- add operation event payloads and replay projection state; and
+- preserve existing `operation` / model-invoke, legacy Workstation, and guard
+  decoding.
+
+Run `make generate-api` for the direct OpenAPI and generated Go/dashboard
+clients. Run `make interfaces-all` when publishable contracts, packaged Factory
+schemas, or UI package clients change. Never hand-edit generated outputs.
+
+Compatibility rules:
+
+- Existing Factories behave identically when `builtin` and port IDs are absent.
+- `LOGICAL_MOVE` remains supported; no automatic rewrite to `PASS` occurs.
+- Existing specialized fan-in guards remain supported. New authoring and docs
+  prefer `COLLECT` after parity is proven.
+- Existing worker-emitted Work batches remain supported. `GENERATE` provides a
+  prompt-independent option, not a replacement requirement.
+- Unknown operation kinds and unsupported emulator kinds fail validation with
+  precise paths rather than degrading to `LOGICAL_MOVE`.
+
+## Dashboard And Graph Editor
+
+The canonical editable source remains the generated Factory definition held by
+the current-Factory feature. React Flow nodes, handles, badges, and summaries
+are disposable projections from that definition plus explicit UI state.
+
+Add feature-owned operations for:
+
+- add an operation node from the node palette;
+- change operation kind while preserving only compatible configuration;
+- add/remove/reorder switch routes and predicate groups;
+- set value sources, selectors, scope, cardinality, bounds, and effect policy;
+- connect/disconnect stable input and output ports;
+- validate/save through the existing current-Factory mutation path; and
+- show server validation without reconstructing canonical state from React
+  Flow.
+
+The UI should group operations as Routing, Selection, Fan-out/in, Transform,
+Aggregate, Random, Time, and Effects. Each editor shows only the fields and
+ports valid for its kind, plus a concise semantic preview such as “take first 1
+per trace; overflow → not-selected.” Side-effect nodes prominently show the
+relevant authorized root, credential reference, destination policy, retry, and
+idempotency behavior. Automation authoring exposes only the approved file-watch
+and email-receive ingress additions from this plan.
+
+Reuse existing shared controls, dialogs, selects, fields, action rows, and
+status treatments. All new copy belongs to feature-owned message catalogs.
+Operation forms and graph handles must be keyboard-operable, mobile-friendly,
+and explicit about loading, validation, save failure, and stale definition
+state.
+
+## Work Stories
+
+Each story is a vertically sliced, independently reviewable behavior. A story
+includes its authored schema, backend behavior, generated contracts, editor
+support, documentation, and focused tests when those surfaces are part of the
+behavior.
+
+### OPS-001: Add and run a pass-through operation node
+
+As a Factory author, I can add an `OPERATION` workstation with `PASS`, save it,
+run Work through it without a worker dispatch, and inspect the resulting
+operation and Work events.
+
+Acceptance criteria:
+
+- Factory JSON/YAML, OpenAPI, generated Go/TypeScript clients, packaged schema,
+  import/export, and graph projection preserve `type: OPERATION`, `builtin`, and
+  stable port IDs.
+- Definition validation rejects workers, prompts, models, cron config, or
+  missing/duplicate ports on a `PASS` operation with precise field paths.
+- `PASS` applies through the event-first runtime, preserves Work content and
+  lineage, and emits no Worker or Provider dispatch.
+- The editor can add, connect, inspect, save, reload, and delete the node while
+  canonical Factory state remains the source of truth.
+- Old definitions and `LOGICAL_MOVE` behavior remain unchanged.
+- Contract, definition, runtime/replay, UI operation/projection/component, and
+  one root-built functional test pass.
+
+### OPS-002: Route structured output with typed predicates
+
+As a Factory author, I can select a JSON field from Work content and use typed
+conditions to route Work through `FILTER` or ordered `SWITCH` cases.
+
+Acceptance criteria:
+
+- Selectors can address stable content slot/label plus JSON Pointer, canonical
+  Work fields, tags, and non-sensitive invocation arguments.
+- Predicate validation rejects missing inputs, ambiguous content parts, invalid
+  pointers, incompatible operand types, unsupported operators, and sensitive
+  value exposure before execution.
+- `SWITCH` chooses the first matching case in authored order and uses its
+  required default/fail policy when no case matches.
+- `FILTER` visibly routes pass and fail; a false condition does not leave Work
+  silently waiting.
+- A case/default route may target `FAIL`, which records the configured stable
+  error code and sanitized bounded details and produces no success Work.
+- Pure predicate guards reuse the same evaluator, fail closed, and create no
+  time, random, or IO side effects.
+- Replay yields the recorded route without reevaluating the predicate.
+- Editor predicate operations, projections, accessible controls, contract
+  tests, evaluator unit tests, runtime integration tests, and functional JSON
+  routing tests pass.
+
+### OPS-003: Tee Work to several explicit branches
+
+As a Factory author, I can use `TEE` to emit one derived Work item on each named
+output with deterministic identity and common lineage.
+
+Acceptance criteria:
+
+- A tee requires at least two unique output ports and validates the complete
+  derived batch before emitting anything.
+- Output order is authored port order; each child has a unique deterministic ID,
+  common parent/trace identity, and declared output type/state.
+- Per-output propagation can preserve input content or use an authored
+  projection without sharing mutable state between branches.
+- Partial output admission is impossible; an invalid destination or capacity
+  limit produces no children.
+- UI handle projection and a browser interaction prove one connection per
+  stable output port.
+- Work admission, lineage, replay, editor, and functional branch tests pass.
+
+### OPS-004: Skip, take, pick-first, and deduplicate scoped Work
+
+As a Factory author, I can select Work according to prior items observed by one
+node and scope.
+
+Acceptance criteria:
+
+- `SKIP`, `TAKE`, and `DISTINCT` implement the ordering and route semantics in
+  this plan; `TAKE(1)` is documented and labeled as pick-first in the editor.
+- Default scope is trace; parent, session, and selected-value scopes isolate
+  state exactly as documented.
+- Multiple scheduler eligibility checks do not increment state; only one
+  accepted operation application advances the state version.
+- Every non-selected item follows the configured skipped/overflow/duplicate
+  route, and bounds cannot cause silent loss.
+- Recorded operation state reconstructs counts, closed gates, and retained
+  distinct keys on replay.
+- Unit, repeated-run, concurrent-arrival, replay, UI, and root-built functional
+  tests cover counts 0/1/N, independent scopes, duplicates, and overflow.
+
+### OPS-005: Generate an exact bounded population
+
+As a Factory author, I can use `GENERATE` to create exactly the configured
+number of child Work items without asking a worker to emit a special JSON
+batch.
+
+Acceptance criteria:
+
+- Count resolves from a literal, invocation argument, or structured selector
+  and is validated against positive configured and system ceilings before any
+  child is admitted.
+- The template can set name, Work type/state, typed content, tags, and
+  relationships from parent data, deterministic index, generation, and derived
+  seed values.
+- The entire generated batch is atomically validated/admitted through Work and
+  carries parent, spawned-by, trace, request, and generation provenance.
+- Replaying the same accepted facts reconstructs the same identities and order;
+  retrying an applied idempotency key does not duplicate the population.
+- Zero-count behavior is explicit (`ALLOW_EMPTY` or `REJECT`) and cannot leave a
+  later all-children collector waiting on an unknown denominator.
+- Editor template/count previews and package, runtime, Work admission,
+  failure-path, and functional tests pass for 0, 1, typical N, and over-limit N.
+
+### OPS-006: Collect and merge same-type Work
+
+As a Factory author, I can wait for an exact count, quorum, all registered
+children, or explicit close signal and consume/observe the stable collection in
+one node.
+
+Acceptance criteria:
+
+- One collection input can bind several Work items of the same type/state; the
+  author does not repeat identical inputs or refer to an internal arc.
+- Group keys, denominator source, collection mode, consume/observe mode,
+  timeout/overflow behavior, and late-arrival behavior are explicit.
+- `ALL_REGISTERED` uses completed child registration from `GENERATE` or existing
+  generated Work metadata, including zero-child completion.
+- `EXACT(N)` never fires with fewer than N and deterministically selects the
+  earliest N when more are ready; remaining Work follows declared late/overflow
+  policy.
+- `MERGE_CONTENT` emits canonical content as ordered JSON array, object-by-key,
+  or text concatenation with explicit separator and maximum output bytes.
+- Child failure can route an observed parent/group failure without waiting
+  forever for successful members.
+- Same-type cardinality, out-of-order completion, duplicate keys, zero children,
+  failure, replay, editor, and functional tests pass.
+
+### OPS-007: Maintain bounded aggregates and leaderboards
+
+As a Factory author, I can use `REDUCE` to summarize a collection or maintain a
+bounded count, numeric aggregate, grouped projection, latest value, or
+deterministic top-K projection.
+
+Acceptance criteria:
+
+- Reducer kinds have discriminated typed configs and bounded retained state;
+  arbitrary customer code is not accepted.
+- Count, count-unique, sum, average, min, max, concatenate, and append modes
+  define strict input types plus missing/null behavior; optional group-by emits
+  stable groups under an explicit maximum group count.
+- `top-K` requires key and numeric score selectors, stable score ordering, a
+  documented tie-breaker, and an update policy for a repeated key.
+- The node can emit on every accepted update or only on explicit close/window
+  completion without mutating already emitted Work.
+- Invalid scores, duplicate-policy violations, capacity exhaustion, and output
+  size overflow take explicit failure routes.
+- Operation/replay projections expose aggregate size, version, last update, and
+  sanitized summary without leaking complete sensitive payloads.
+- Unit property tests, concurrent update tests, replay tests, UI configuration,
+  and a functional top-K scenario pass.
+
+### OPS-008: Generate reproducible random values and samples
+
+As a Factory author, I can create a seed/value, shuffle a collection, or sample
+N members and reproduce the result from the same recorded seed.
+
+Acceptance criteria:
+
+- A supplied root seed is normalized and recorded; an omitted seed is generated
+  once through an injected source and recorded before use.
+- Substreams are isolated by workstation, scope, and firing ordinal, so adding a
+  random node elsewhere does not perturb an existing node's choices.
+- `RANDOM_VALUE` supports bounded integer, decimal, boolean, stable identifier,
+  and choice-from-list outputs; every range rejects invalid or empty bounds.
+- `SHUFFLE` and `SAMPLE` operate on a stable input collection, sample without
+  replacement by default, and reject N larger than the population unless an
+  explicit replacement policy allows it.
+- Guard reevaluation consumes no random state; replay reads recorded choices and
+  does not call the random source.
+- Seed parity, substream isolation, distribution smoke (not brittle exact
+  frequency), replay, editor, emulator, and functional tests pass.
+
+### OPS-009: Apply wait, delay, debounce, throttle, and timeout with virtual time
+
+As a Factory author, I can make routing depend on time without scripts, sleeps,
+or cron-only topology.
+
+Acceptance criteria:
+
+- Durations and absolute deadlines resolve through the shared value-source
+  contract and enforce valid minimum/maximum policy before scheduling.
+- `WAIT` supports an interval or specified instant; `DELAY`, `DEBOUNCE`,
+  `THROTTLE`, and `TIMEOUT` implement the selected, superseded/suppressed,
+  completed, and timed-out routes documented above.
+- Webhook/form/external-signal resume is rejected by this story rather than
+  providing a process-local imitation of a durable suspended session.
+- Timer identities and deadlines are stable per operation scope; cancel, pause,
+  session close, and retry behavior are explicit and idempotent.
+- Factory Runtime uses its injected clock/scheduler; package and functional
+  tests advance fake time deterministically and contain no synchronization
+  sleeps.
+- Recorded timer facts and operation state rebuild pending/terminal timer
+  projections; restart recovery does not fire the same accepted deadline twice.
+- Timer count, buffered bytes, and open-scope limits apply backpressure with
+  observable diagnostics.
+- Editor duration/scope previews, race/repeated-run tests, replay tests, and
+  root-built functional tests pass.
+
+### OPS-010: Write artifacts and authorized files
+
+As a Factory author, I can persist selected Work content as a session artifact
+or an explicitly authorized file and route success/failure metadata.
+
+Acceptance criteria:
+
+- `WRITE_ARTIFACT` uses the Recordings artifact contract and returns a stable
+  artifact reference that is visible in session history and invocation results.
+- `WRITE_FILE` is limited to a declared Factory/session root, normalizes and
+  validates resolved paths, rejects traversal and unsafe symlinks, and never
+  accepts a sensitive value in a path.
+- `FAIL`, atomic `REPLACE`, and serialized deterministic `APPEND` collision
+  policies have distinct validated behavior; a failed write never reports
+  success or a partial completed effect.
+- An idempotency identity prevents duplicate writes after retry/recovery, and
+  completed replay does not touch the filesystem.
+- Size, file count, extension/content-type, and total artifact quotas are
+  enforced before or during bounded streaming with explicit failure records.
+- Filesystem effects are provided through an injected narrow edge and platform
+  implementation; focused effect, security, failure-injection, replay, editor,
+  and functional tests pass.
+
+### OPS-011: Complete operation authoring, diagnostics, and observability
+
+As a Factory author or operator, I can understand why an operation is waiting,
+selected a route, reached a bound, scheduled a timer, or failed an effect.
+
+Acceptance criteria:
+
+- Definition preview reports resolved ports, required routes, value-source type,
+  state scope, maximum fan-out/buffer/timers/effects, and side-effect capability.
+- Runtime projections show kind, state version, open group/timer counts, last
+  applied event, and stable failure code without exposing sensitive values.
+- Service operations log accepted intent and terminal outcome with session,
+  workstation, kind, scope digest, duration, and failure classification.
+- Metrics cover applications, route counts, wait duration, buffers, generated
+  Work, timer drift, bound failures, effect latency/failure, and replay
+  divergence.
+- Dashboard loading, empty, stale, validation-error, runtime-error, and success
+  states are explicit and accessible on mobile and desktop.
+- Focused component/browser tests prove a third-party graph interaction
+  dispatches a feature operation and visibly updates the canonical projection.
+
+### OPS-012: Bring the deterministic emulator to declared parity
+
+As a package consumer, I can preflight and emulate the documented deterministic
+operation subset without mistaking unsupported effects for hosted support.
+
+Acceptance criteria:
+
+- Compatibility inspection lists each supported/unsupported operation kind and
+  exact config path before any events are written.
+- The first parity tier supports pure routing, selection, tee, generate,
+  collect/merge, aggregate, seeded random, and virtual-time operations.
+- File effects remain unsupported or use a caller-supplied bounded sink; the
+  emulator never writes host files implicitly.
+- Frozen hosted-runtime references compare selected Work, operation routes,
+  state versions, derived values, timer ticks, generated identities, lineage,
+  and terminal projections at every logical tick.
+- Same seed and command sequence are byte-stable; changed seed changes only
+  random-derived decisions and their downstream effects.
+- Package verify and installed-consumer checks pass.
+
+### OPS-013: Split a structured collection into child Work
+
+As a Factory author, I can select a bounded JSON array and split it into one
+lineage-linked Work item per member.
+
+Acceptance criteria:
+
+- `SPLIT` requires one unambiguous array selector and validates the entire array,
+  prospective Work count, projected content, output bytes, and destination
+  before admitting any child.
+- Each child receives deterministic index, parent, trace, spawned-by, and request
+  identity; optional selected/all parent fields are copied through typed
+  projections rather than mutable object aliasing.
+- Empty arrays follow explicit allow-empty/done or reject behavior and register a
+  known zero-child denominator for downstream collection.
+- Non-array, sparse/invalid member, over-count, and over-byte inputs emit no
+  partial batch and take a stable failure route.
+- Editor selector/projection previews, Work admission/lineage tests, replay, and
+  root-built functional tests cover empty, one, N, malformed, and over-limit
+  arrays.
+
+### OPS-014: Process a registered collection in bounded batches
+
+As a Factory author, I can release a known collection in fixed-size batches,
+loop each batch through downstream work, and take a done route only when all
+members are accounted for.
+
+Acceptance criteria:
+
+- `BATCH` resolves a positive bounded batch size and operates over an explicit
+  registered or closed collection; it never treats currently visible Work as an
+  unknowable complete population.
+- Every member is released exactly once per batch execution in stable order,
+  unless an explicit reset starts a new version of the registered collection.
+- The node exposes current batch index, member indices, remaining count, and
+  no-items-left state as typed operation metadata without hidden mutable context.
+- The `done` route fires only after every member succeeds or follows the
+  configured member-failure policy; loop iteration and reset counts have hard
+  ceilings that prevent infinite synchronous loops.
+- Concurrency/resource limits can throttle downstream processing without
+  changing batch membership or duplicating Work.
+- Fake-worker functional tests cover uneven final batches, size 1/N, reset,
+  member failure, cancellation, backpressure, replay, and loop exhaustion.
+
+### OPS-015: Sort and limit a closed collection
+
+As a Factory author, I can sort a bounded collection by typed keys and keep its
+first or last N members deterministically.
+
+Acceptance criteria:
+
+- `SORT` supports ordered typed key clauses, ascending/descending direction,
+  explicit null placement, strict type comparison, and stable Work-ID
+  tie-breaking.
+- `LIMIT` accepts first/last selection only after its input collection is
+  explicitly closed; streaming first-N remains `TAKE`, and streaming last-N is
+  rejected during validation.
+- Non-selected members follow an explicit overflow route or are retained only
+  when the author chooses observe mode; no item disappears implicitly.
+- Random ordering is represented by seeded `SHUFFLE` and cannot be selected as
+  an unrecorded sort mode.
+- Unit/property tests cover numeric/string/date ordering, ties, nulls, N=0/1/
+  greater-than-size, ascending/descending, replay, and UI configuration.
+
+### OPS-016: Join bounded Work collections
+
+As a Factory author, I can append, positionally zip, or key-join several bounded
+collections with explicit clash and unmatched-item behavior.
+
+Acceptance criteria:
+
+- `JOIN` waits for every declared input collection to close and supports append,
+  positional zip, and typed inner/left/right/full key joins.
+- Multiple matches, unpaired members, shallow/deep field clashes, input
+  precedence, missing/null keys, and maximum output count/bytes are explicit and
+  validated.
+- Append preserves authored input then member order; zip uses stable member
+  position; key joins use strict typed equality and stable input/Work-ID order.
+- SQL, fuzzy type coercion, and unbounded all-pairs combinations are not accepted
+  by the built-in contract.
+- Any prospective Cartesian/duplicate expansion is bounded before output; a
+  violation emits no partial joined Work.
+- Join-mode unit tests, same-key duplicate tests, out-of-order arrival/replay,
+  editor projection, and root-built functional tests pass.
+
+### OPS-017: Compare two datasets and route their differences
+
+As a Factory author, I can compare two closed Work collections by typed keys and
+route only-left, equal, changed, and only-right members separately.
+
+Acceptance criteria:
+
+- `DIFF` reuses the strict key and duplicate-match semantics of `JOIN` while
+  separately configuring compared/ignored fields and changed-value output.
+- Four stable named routes receive deterministic ordered results: `onlyLeft`,
+  `equal`, `changed`, and `onlyRight`.
+- Changed items can retain left, right, selected-field mix, or both versions
+  through typed projections; there is no fuzzy coercion default.
+- Duplicate keys, missing keys, ignored fields, nested objects, large datasets,
+  output bounds, and failure routes have direct unit/integration evidence.
+- Replay produces the recorded diff without recomputing it, and editor/browser
+  coverage proves each stable port can be connected and saved.
+
+### OPS-018: Transform dates and times explicitly
+
+As a Factory author, I can parse, format, add/subtract, extract, round, compare,
+or obtain the current time under an explicit timezone policy.
+
+Acceptance criteria:
+
+- `DATE_TIME` supports parse/format, add, subtract, extract part, round,
+  difference, and current-time modes with typed input/output contracts.
+- Ambiguous input formats and timezone-less values follow explicit reject or
+  configured-timezone behavior; locale/timezone settings are recorded in the
+  operation fact.
+- Calendar arithmetic and duration arithmetic are distinct where daylight
+  saving or month length can change the result.
+- Current-time mode uses the injected clock and records the accepted instant;
+  replay never reads the wall clock.
+- Unit tests cover UTC, a daylight-saving transition, leap day, invalid dates,
+  rounding boundaries, negative differences, fake-clock replay, and editor
+  configuration.
+
+### OPS-019: Prove the catalog with an evolutionary Factory
+
+Publish an example or packaged Factory that optimizes a population for a bounded
+number of rounds using graph operations rather than hidden runtime fixtures.
+
+Acceptance criteria:
+
+- Invocation accepts request, population size, rounds, elite count, and optional
+  seed; all derived call and Work counts are rejected before execution if they
+  exceed effective policy.
+- `GENERATE` or `SPLIT` creates the initial population, workers produce
+  schema-validated candidates/scores, `COLLECT` waits for the registered
+  generation, `SORT`/`LIMIT` or `top-K` selects elites, and seeded `SAMPLE`
+  forms deterministic parent pairs.
+- Agent/model work performs domain-specific mutation/crossover; built-in
+  operations own count, grouping, selection, time, and randomness rather than
+  prompts pretending to be the scheduler.
+- Each generation has explicit parent/generation lineage and cannot mix results
+  from another trace or round.
+- The loop ends after exactly the requested rounds and returns the best candidate
+  plus score/provenance; failure, cancellation, invalid score, and budget
+  exhaustion cannot return a partial success.
+- Tests cover population 1, typical N, multiple rounds, fixed-seed repeatability,
+  out-of-order evaluation completion, evaluator failure, and final replay.
+
+### OPS-020: Prove the catalog with an autonomous leaderboard Factory
+
+Publish an example or packaged Factory that runs a bounded autonomous agent
+pool, evaluates branch submissions, maintains standings, and stops at a global
+execution ceiling.
+
+Acceptance criteria:
+
+- Invocation accepts agent count, maximum total executions, per-agent iteration
+  ceiling, evaluator settings, and optional seed; policy validates all derived
+  concurrency and call bounds before dispatch.
+- `GENERATE` creates stable competitor Work, existing worker/worktree templates
+  give each competitor isolated branch identity, and each iteration receives
+  only that competitor's notes/artifact history.
+- `WRITE_ARTIFACT` or authorized `WRITE_FILE` maintains a bounded per-competitor
+  notesheet; `TEE` sends a submission both to evaluation and the competitor's
+  next-step path.
+- Schema-validated evaluator output updates a deterministic `top-K` leaderboard
+  by competitor key. Repeated submissions update the configured competitor
+  record rather than creating ambiguous duplicates.
+- Session-scoped `TAKE(maxTotalExecutions)` and per-competitor scoped `TAKE`
+  gates enforce both ceilings under concurrent completions. Overflow routes end
+  cleanly; no extra agent dispatch starts after a gate closes.
+- Each iteration uses a new deterministic branch/worktree name when configured,
+  preserves the prior branch reference in Work metadata, and never lets one
+  competitor write another competitor's notes.
+- The result includes standings, winning branch/artifact, execution counts, and
+  evaluation provenance. Tests cover concurrency, ties, evaluator failure,
+  notes isolation, global/per-agent ceiling races, cancellation, and replay.
+
+### OPS-021: Harden file-watch Work ingress
+
+As a Factory author, I can admit Work from authorized filesystem changes without
+creating duplicate or unbounded Work when watchers restart or coalesce events.
+
+Acceptance criteria:
+
+- The existing filesystem-watcher Automation is represented as the explicit
+  `FILE_WATCH` ingress kind; no second watcher implementation or mid-graph
+  polling operation is introduced.
+- Configuration declares authorized roots, include/exclude globs, supported
+  create/modify/delete event kinds, debounce/coalescing behavior, maximum file
+  size, content/materialization policy, and the target Work template.
+- Paths are normalized under authorized roots and reject traversal, unsafe
+  symlinks, special files, and sensitive values in emitted metadata.
+- A durable cursor/checkpoint plus stable observation identity prevents
+  duplicate Work admission across duplicate notifications and restart; rename,
+  rapid-write, deleted-before-read, and watcher-overflow behavior is explicit.
+- Backpressure, admission failure, malformed/oversized content, and dead-letter
+  behavior produce observable Automation and Work outcomes without silently
+  dropping events.
+- Focused watcher, restart, deduplication, path-security, load, Work-admission,
+  API/editor, and root-built functional tests pass.
+
+### OPS-022: Add email-receive Work ingress
+
+As a Factory author, I can turn received email into typed Work through one
+bounded, checkpointed Automation contract.
+
+Acceptance criteria:
+
+- `EMAIL_RECEIVE` declares an account credential reference, mailbox/folder,
+  supported provider filter, observation mode/interval, initial cursor policy,
+  attachment policy, content limits, and target Work template.
+- Credential values never enter Factory definitions, Work content, Factory
+  Events, logs, diagnostics, or replay snapshots; only opaque references and
+  sanitized account identity may be recorded.
+- Provider message identity and a durable mailbox cursor prevent duplicate Work
+  admission after retries/restarts while allowing an operator-visible replay or
+  reprocess action to create an intentional new admission identity.
+- The mapper exposes a documented typed envelope for selected headers,
+  addresses, dates, text/HTML bodies, and quota-checked attachment references;
+  missing multipart variants and malformed messages have explicit policy.
+- Poll/push failures, authentication expiry, rate limiting, oversized messages,
+  unsafe attachments, Work admission failure, and dead-letter outcomes are
+  bounded and observable.
+- Adapter-contract, cursor/deduplication, MIME/mapping, secret-redaction,
+  restart, API/editor, and root-built functional tests pass without requiring a
+  generic email/connector framework.
+
+### OPS-023: Send email through an explicit effect node
+
+As a Factory author, I can send a bounded email from Work and route a recorded
+delivery result without invoking an arbitrary command or connector.
+
+Acceptance criteria:
+
+- `SEND_EMAIL` has a closed schema for credential reference, from/reply-to,
+  recipients, subject, text/HTML body, approved attachment references, headers,
+  timeout, and success/failure routes; typed selectors may supply values but
+  cannot read prohibited sensitive fields.
+- Definition validation enforces recipient, message, attachment, and header
+  limits and rejects header injection, unsafe attachment paths, raw secret
+  values, and unsupported provider options before execution.
+- The effect uses a narrow injected mail-send port. It does not expose shell,
+  arbitrary provider SDK calls, dynamic node installation, or a generic
+  connector registry.
+- The accepted intent is recorded before sending and terminal output contains a
+  sanitized provider delivery identity/status. An explicit idempotency policy
+  prevents blind resend after ambiguous completion; replay never sends mail.
+- Retry is bounded and classification-aware; authentication, policy rejection,
+  rate limiting, timeout, ambiguous result, and permanent delivery failure have
+  stable failure codes and routes.
+- Contract, validation, adapter, idempotency/failure-injection, replay,
+  redaction, editor, and root-built functional tests pass.
+
+### OPS-024: Perform an outbound HTTP request through an explicit effect node
+
+As a Factory author, I can call an approved HTTP endpoint and map its bounded
+response into Work without gaining a general network or command surface.
+
+Acceptance criteria:
+
+- `HTTP_REQUEST` has a closed schema for method, URL/value source, query,
+  headers, bounded body, opaque credential reference, timeout, redirect policy,
+  response-size limit, accepted status policy, response mapping, and
+  success/failure routes.
+- URL and network policy is evaluated for the initial request and every
+  redirect/DNS resolution; it rejects disallowed schemes, user-info secrets,
+  unauthorized hosts/ports, private/link-local/metadata destinations where not
+  explicitly permitted, DNS rebinding, invalid TLS, and credential forwarding
+  across origins.
+- Sensitive request fields and response headers are redacted from events, logs,
+  diagnostics, and Work unless an explicit safe mapping allows a non-secret
+  value. Bodies and responses honor byte/content-type/materialization quotas.
+- The accepted intent and idempotency identity are recorded before the request;
+  replay never repeats network IO. Retries default to idempotent methods and
+  require an adapter-supported idempotency contract for non-idempotent methods.
+- DNS, connection, TLS, timeout, redirect, rate-limit, status, decode,
+  oversize, cancellation, and ambiguous-result failures have stable
+  classification and bounded behavior.
+- Contract, validation, SSRF/redirect/DNS-rebinding, redaction,
+  idempotency/failure-injection, replay, editor, and root-built functional tests
+  pass. No inbound webhook or generic connector node is added.
+
+### OPS-025: Publish migration guidance and complete delivery
+
+Document operation authoring and migrate only selected maintained examples where
+the new node is materially clearer than the specialized guard topology.
+
+Acceptance criteria:
+
+- `you docs` covers operation concepts, selector/predicate syntax, scope,
+  ordering, bounds, time, randomness, effects, failure routes, and complete
+  YAML examples.
+- Documentation distinguishes `OPERATION` graph nodes, provider/model
+  `operation`, JavaScript Factories, the two approved external Automation
+  ingress kinds, the two approved network effects, and internal Petri
+  machinery.
+- The capability guide states the closed allowlist (`FILE_WATCH`,
+  `EMAIL_RECEIVE`, `SEND_EMAIL`, and `HTTP_REQUEST`) and explicitly states that
+  the reviewed n8n trigger/integration catalog is not a planned connector
+  backlog.
+- A migration table maps common old shapes to new nodes: worker-emitted static
+  batch → `GENERATE`, all-children guard → `COLLECT`, logical branch copies →
+  `TEE`, JSON-array prompt expansion → `SPLIT`, manual rate-limit loop →
+  `BATCH`, repeated merge inputs → `JOIN`, and structured classifier prompt →
+  `SWITCH` only when no inference is required.
+- Existing examples are not mechanically rewritten; behavior/replay parity is
+  proven before each intentional migration.
+- API smoke, docs smoke, README checks when touched, packaged Factory generation
+  and package verification, frontend verification, backend lint/tests, and the
+  relevant functional/stress tiers pass.
+
+## Dependency-Aware Delivery Sequence
+
+1. OPS-001 establishes the public operation host, stable ports, event envelope,
+   editor projection, and compatibility boundary.
+2. OPS-002 establishes shared selectors/predicates and explicit conditional
+   routing.
+3. OPS-003 delivers stateless multi-route derivation.
+4. OPS-004 establishes scoped state and replay, which later window and ceiling
+   behavior reuse.
+5. OPS-005 establishes prompt-independent atomic fan-out and child registration.
+6. OPS-006 establishes same-type collection and fan-in.
+7. OPS-007 establishes reusable bounded reducers.
+8. OPS-008 adds deterministic random substreams over stable collections.
+9. OPS-009 adds durable timer state after scoped state/replay is proven.
+10. OPS-010 adds controlled effects after event/idempotency semantics are proven.
+11. OPS-011 completes cross-catalog diagnostics and UI hardening.
+12. OPS-012 adds emulator parity from frozen hosted-runtime behavior.
+13. OPS-013 adds array-to-Work splitting on the fan-out/admission foundation.
+14. OPS-014 adds bounded batch-loop behavior over registered collections.
+15. OPS-015 adds deterministic closed-collection sort and limit behavior.
+16. OPS-016 adds typed joins after collection closure and ordering are stable.
+17. OPS-017 reuses join keys/comparison for four-route dataset differences.
+18. OPS-018 adds explicit date/time transformations over the injected clock and
+    shared typed projection contract.
+19. OPS-019 and OPS-020 prove composition in the evolutionary and leaderboard
+    Factories after their required collection operations are complete.
+20. OPS-021 hardens the existing file watcher at the Automations/Work admission
+    boundary and can proceed after shared Work admission limits are fixed.
+21. OPS-022 adds the only new external ingress family, email receive, reusing
+    the Automation cursor, deduplication, and Work admission behavior.
+22. OPS-023 adds the allowlisted email-send effect after the OPS-010 effect
+    envelope, idempotency, and replay rules are stable.
+23. OPS-024 adds the allowlisted outbound HTTP effect on the same foundation,
+    with its additional network-security policy proven independently.
+24. OPS-025 publishes migration and allowlist guidance and completes the release
+    surface.
+
+OPS-003 can proceed alongside early pure-predicate work after OPS-001. OPS-013
+can proceed after Work batch admission in OPS-005, while OPS-015 can proceed
+after collection ordering is fixed in OPS-006. Timers, date/time helpers, and
+filesystem effects should not block shipping the pure routing/fan-out/fan-in
+catalog. OPS-021 and OPS-022 are an Automations/Work ingress lane; OPS-023 and
+OPS-024 are an effect lane. Neither lane authorizes work on any other n8n
+trigger, integration, or connector.
+
+## Verification Strategy
+
+### Unit and contract
+
+- Selector/predicate parsing, type checking, missing/ambiguous values, and
+  sensitive-value restrictions.
+- Value source resolution, numeric/duration bounds, and default rules.
+- Definition discrimination, port compatibility, illegal field combinations,
+  synchronous-cycle limits, generated contract parity, and import/export.
+- Pure operation functions for route, projection, merge, reducer, seed
+  derivation, random sampling, and path policy.
+- Closed-schema validation for file/email ingress, email send, and outbound HTTP
+  requests, including credential-reference and destination policy.
+
+### Package integration
+
+- Compiler mapping from authored operations to runtime transitions.
+- Atomic Work claims/admission, same-type cardinality, generated-child
+  registration, lineage, and relationships.
+- Scoped state under concurrent eligibility/application, cancellation, and
+  replay.
+- Timer scheduling/cancellation/firing with fake clocks.
+- Artifact/file effect idempotency, partial failure, quotas, traversal, and
+  symlink handling through explicit fakes.
+- File-watch and email-receive cursor/deduplication, restart, bounded mapping,
+  admission failure, backpressure, and secret-redaction behavior.
+- Mail-send and outbound-HTTP adapter contracts, authorization, redaction,
+  idempotency, ambiguous completion, retry classification, cancellation, and
+  replay-without-IO behavior.
+- Recording live/replay projection equivalence for every stateful/effect kind.
+
+### Functional
+
+Functional application tests construct through `root.BuildProcess`, execute
+ordinary customer paths through `Process.Execute` and the CLI, and replace only
+exact external effects through `edges.Edges`. They use injected clocks and
+file/mail/HTTP edges instead of sleeps or custom in-process application graphs.
+
+Required scenarios:
+
+- structured switch with pass/default/failure;
+- tee with atomic derived Work and lineage;
+- skip/take under concurrent arrivals and independent scopes;
+- exact generate/split/collect with zero, one, N, malformed structured input,
+  out-of-order completion, and child failure;
+- bounded batches with an uneven final batch, downstream backpressure, member
+  failure, and done routing;
+- closed-collection typed sort/first-last limit with ties and nulls;
+- append/zip/inner/outer joins and four-route dataset diff with duplicate keys;
+- top-K with ties and repeated competitor keys;
+- seeded sample repeatability;
+- date/time parsing/arithmetic across a daylight-saving boundary and replayed
+  current time;
+- delay/wait/debounce/throttle/timeout with deterministic clock advancement;
+- artifact/file success, permission failure, retry, and replay without IO;
+- file-watch duplicate/restart and email-receive cursor/restart admission;
+- email-send success, rejection, ambiguous completion, and replay without send;
+- outbound HTTP success, status/timeout/oversize failure, SSRF/redirect
+  rejection, idempotent retry, and replay without request; and
+- the evolutionary and leaderboard Factories.
+
+### Stress and race
+
+- thousands of scoped counters/groups with bounded memory;
+- large allowed fan-out/fan-in and output-byte limits;
+- concurrent group completion and global/per-key `TAKE` closure;
+- timer cancellation/firing races and session shutdown;
+- serialized append and idempotent effect retry;
+- watcher/mailbox event bursts under Work-admission backpressure;
+- concurrent mail/HTTP effect ceilings, cancellation, and ambiguous results;
+- replay of long operation histories; and
+- cancellation/backpressure while generated Work or timers are queued.
+
+### Frontend and browser
+
+- Pure feature-operation tests for add/remove/connect/disconnect/change-kind,
+  route ordering, predicate editing, and save preparation.
+- Projection tests that map canonical Factory operations and stable ports into
+  React Flow nodes/handles.
+- Mutation tests for validation failure, stale definition, retry, and generated
+  contract handling.
+- Focused component tests for palette, operation form, predicate builder, bound
+  warnings, effect policy, and only the four approved external surfaces.
+- Browser tests for add/connect/save/reload and a running operation's projected
+  route/state, at mobile and desktop breakpoints with keyboard/a11y checks.
+
+## Quality Gates
+
+Use the narrowest focused package and UI commands per story, then broaden for
+shared/public surfaces:
+
+```sh
+make generate-api
+make interfaces-all             # when publishable schemas/clients change
+make api-smoke
+make packaged-factory-catalog-generate
+make packaged-factory-catalog-check
+make packaged-factory-package-verify
+make docs-reference-smoke
+make ui-test
+make ui-lint
+make verify-fast
+make lint
+make verify-pr                  # high-risk shared runtime/replay releases
+```
+
+Run focused Go package tests before broad targets. Run race/stress and repeated
+execution for scheduler, timer, grouping, randomness, and effect stories. When
+the editor changes, visually inspect the graph in a browser in addition to
+automated tests.
+
+## Project Acceptance Criteria
+
+- A customer can author and run every operation in the catalog without using
+  internal Petri vocabulary or a prompt-defined scheduling protocol.
+- Skip/pick-first, exact generation, same-type collection, structured
+  conditionals, seeded randomness, time windows, tee, and bounded file/artifact
+  writes have explicit happy, false/overflow, failure, cancellation, and replay
+  semantics.
+- Split, batch, sort/limit, typed join/diff, aggregation, explicit failure, and
+  date/time behavior cover the high-value deterministic n8n-style data-flow
+  semantics without importing SQL, arbitrary expressions, a generic datastore,
+  or the broader n8n integration catalog into Factory Runtime.
+- External ingress/effects are limited to `FILE_WATCH`, `EMAIL_RECEIVE`,
+  `SEND_EMAIL`, and outbound `HTTP_REQUEST`; their authorization, credentials,
+  bounds, cursor/idempotency, redaction, failure, restart, and replay behavior is
+  explicit and tested.
+- No new RSS, SSE, webhook, form, chat, MCP, vendor, database, shell, Git, SSH,
+  FTP, GraphQL, LDAP, sub-workflow, or generic connector/capability node is
+  delivered or implied by this plan.
+- Operation scope, ordering, bounds, timer behavior, random seed derivation, and
+  effect policy are visible in authored config and runtime diagnostics.
+- Work, Factory Events, Recordings, artifacts, and generated API contracts remain
+  canonical; no operation-owned shadow state escapes as a second product model.
+- Existing Factory definitions and JavaScript workflows remain compatible.
+- The evolutionary and leaderboard Factories run within configured population,
+  round, concurrency, execution, time, and artifact limits and reproduce their
+  recorded decisions.
+- Required contract, unit, integration, functional, stress/race, frontend,
+  browser, package, docs, lint, and generated-artifact checks pass.
+- Delivery for every implementation PR continues until required CI is terminal
+  and passing, all blocking review feedback is explicitly addressed, conflicts
+  and shared-file drift are resolved, and the PR is actually merged. An opened,
+  approved, or green-but-unmerged PR is not complete.
+
+## Delivery Loop
+
+Each story should normally be one PR. For every PR, continue implementation and
+review until required CI is terminal and green, blocking review conversations
+are addressed, conflicts are resolved, generated artifacts are current, and the
+PR is merged. Record follow-up work only when it is independently valuable and
+does not weaken the current story's acceptance criteria.

--- a/docs/internal/development/plans/human-in-the-loop-approval-workstations.md
+++ b/docs/internal/development/plans/human-in-the-loop-approval-workstations.md
@@ -1,0 +1,711 @@
+# Human-in-the-Loop Approval Workstations Plan
+
+## Status
+
+Proposed.
+
+## Problem statement
+
+The Factory can be made to stop near a human-review state, but it cannot author,
+observe, resolve, replay, and functionally prove a real human approval gate as
+one first-class Workstation behavior.
+
+## Customer ask
+
+Make human-in-the-loop (HITL) loops a supported graph-Factory behavior by
+providing:
+
+- a workerless workstation/node that waits for an explicit human approval or
+  rejection and then follows the authored route;
+- CLI behavior for discovering and resolving pending approvals, including an
+  attached `you run` interaction;
+- canonical Factory Events that distinguish a request for human approval from
+  the eventual decision; and
+- high-value functional tests that prove approval, rejection/rework, event
+  ordering, replay, cancellation, and CLI behavior through the customer process
+  boundary.
+
+## Current-state findings
+
+The reported gap is confirmed.
+
+1. **There is no human workstation type.** The authored `WorkstationType`
+   contract currently contains inference, agent, script, poller, model,
+   logical-move, and classifier variants, but no human gate. Existing taxonomy
+   and worker-compatibility branches recognize only those current types; no
+   runtime binding creates a pending human interaction.
+2. **“Needs human” is a naming convention, not a domain fact.** Work states
+   have only `INITIAL`, `PROCESSING`, `TERMINAL`, and `FAILED` categories.
+   Invocation and Factory Session projections classify Work as needing a human
+   by searching for the exact authored state name `needs-human`. A differently
+   named review state has no equivalent meaning, and a state with that name has
+   no typed approval request, allowed decision, actor, or decision history.
+3. **The existing approval lifecycle is unrelated.**
+   `POST /factory-sessions/{session_id}/approve`, `AWAITING_APPROVAL`, and
+   `approvalPreviewId` approve durable JavaScript orchestrator policy. They do
+   not approve Work at a graph workstation and must not be reused or renamed for
+   HITL Work.
+4. **The CLI has only a generic escape hatch.** `you work move <work-id>
+   <state-name>` can relocate non-dispatched Work to any authored state, but it
+   does not discover a pending approval, validate that the caller chose one of
+   the gate's allowed decisions, require a rejection reason, or correlate the
+   action to the gate that requested it. Because the CLI calls the HTTP move
+   endpoint, production moves are also recorded as source `api`; the declared
+   `cli` source is exercised only by lower-level tests.
+5. **The canonical event stream cannot express the interaction.** The Factory
+   event vocabulary has `WORK_STATE_CHANGE` for generic operator/cascade moves
+   and dispatch events for Worker execution, but it has no “human approval
+   requested” or “human approval resolved” event. `WorkStateChangeEventPayload`
+   records only from/to state, source, optional trigger Work, and a free-form
+   reason. It cannot prove which Workstation asked, which choices were offered,
+   who decided, whether the result was approve/reject/cancel, or whether a retry
+   was idempotent.
+6. **`you work watch` is not HITL observation.** Its v1 reducer emits only
+   `WORK_STATE_CHANGE` records. Ordinary workstation routing is represented by
+   dispatch facts, and no pending-human record exists for the reducer to show.
+7. **One-shot invocation stops instead of looping.** The invocation wait loop
+   turns exact-name `needs-human` Work into terminal
+   `INVOCATION_NEEDS_HUMAN`; `you run` then presents a failure and releases its
+   owned Factory Session. There is no attached prompt or external-wait mode
+   that keeps the invocation alive for a decision.
+8. **Functional coverage proves adjacent behavior only.** The suite proves
+   generic `you work move`, Work watch transitions, model-produced reviewer and
+   classifier outcomes, and JavaScript policy lifecycle controls. It contains
+   no functional scenario with a human workstation, pending approval read,
+   human decision event, reject-then-approve loop, or replayed pending gate.
+9. **Generated and frontend consumers will require deliberate compatibility
+   work.** The dashboard editor, event projections, publishable client, replay
+   package, and emulator enumerate current workstation and event types. Adding
+   enum values without updating those consumers will create either compile
+   failures or silent unsupported behavior.
+
+## Solution
+
+Add a graph-only, workerless `HUMAN_APPROVAL` Workstation type and a canonical
+session-scoped Human Approval resource. Reaching the workstation creates a
+durable pending approval instead of invoking Workers or Providers. Approving
+produces the ordinary accepted route; rejecting produces the ordinary
+`onRejection` route, allowing the same Work to return later and create a new
+approval request.
+
+This is not a fifth Work state category. Pending-human status is derived from a
+canonical approval request associated with the Work and Workstation, not from
+an authored state name. Existing factories that use a state literally named
+`needs-human` retain their current diagnostic compatibility, but that convention
+is documented as a recovery signal rather than supported HITL execution.
+
+### Authored node contract
+
+Use this public shape:
+
+```json
+{
+  "id": "release-approval",
+  "name": "release-approval",
+  "description": {
+    "type": "LOCALIZABLE_ASSET",
+    "value": "Confirm that the release candidate may be published."
+  },
+  "behavior": "STANDARD",
+  "type": "HUMAN_APPROVAL",
+  "inputs": [{ "workType": "release", "state": "awaiting-approval" }],
+  "outputs": [{ "workType": "release", "state": "approved" }],
+  "onRejection": [{ "workType": "release", "state": "changes-requested" }]
+}
+```
+
+Contract rules:
+
+- `HUMAN_APPROVAL` is supported only by the graph/Petri orchestrator in this
+  plan. JavaScript workflows do not acquire an implicit approval API.
+- The node is workerless. `worker`, `runner`, provider/model operation fields,
+  prompt files, output schemas/contracts, execution limits, environment,
+  worktree, resources, `classificationRoutes`, `onContinue`, and `onFailure`
+  are rejected rather than ignored.
+- `description` is required and is the concise, localizable instruction shown
+  to the operator. Work content and expected artifacts remain available through
+  the existing Work read instead of being copied into the event payload.
+- At least one `input`, one approval `output`, and one `onRejection` output are
+  required. The node uses the existing topology checks for Work type/state
+  compatibility and supported input arity.
+- Approval preserves the consumed Work payload; rejection preserves it and adds
+  no hidden Work tags. Decision reason and actor belong to the approval event,
+  not to mutable payload metadata.
+- Each firing creates a new approval ID. A rejection loop that returns the same
+  Work to the node therefore creates a new request and retains the earlier
+  decision in history.
+
+### Runtime behavior
+
+When a `HUMAN_APPROVAL` transition is selected:
+
+1. Factory Runtime claims the input Work through the normal dispatch-admission
+   boundary so another transition cannot consume it concurrently.
+2. It records the ordinary `DISPATCH_REQUEST`, then records exactly one
+   `HUMAN_APPROVAL_REQUESTED` event with a stable approval ID.
+3. It leaves the dispatch pending without calling Workers, Worker Sessions,
+   Providers, Models, scripts, or runner selection. Pending approval consumes no
+   declared runtime resource capacity.
+4. An accepted human-decision command records exactly one
+   `HUMAN_APPROVAL_RESOLVED` event. The event re-enters Factory Runtime as the
+   result of the pending workstation request.
+5. `APPROVED` produces an accepted `DISPATCH_RESPONSE` and follows `outputs`;
+   `REJECTED` produces a rejected `DISPATCH_RESPONSE` and follows
+   `onRejection`. The existing transition/result pipeline remains the only code
+   that applies output Work mutations.
+6. Session cancellation or termination resolves an outstanding request as
+   `CANCELED` and follows the existing dispatch interruption path; it does not
+   synthesize approval or rejection.
+
+The pending request projection is keyed by `approvalId` and joins the request
+event to the effective Factory topology. It contains
+`factorySessionId`, `dispatchId`, `workstationId`, `workstationName`, ordered
+`workIds`, description, status, request event identity/sequence/time, and
+available decisions. The resolved projection additionally contains outcome,
+decision request ID, source, safe actor label when supplied, reason when
+supplied, and resolution event identity/sequence/time.
+
+Decision admission is serialized with dispatch cancellation and session
+shutdown. Exactly one terminal outcome wins. Repeating the same request ID and
+normalized decision returns the original result; reusing it with a different
+decision or reason is a conflict. A late decision against an already resolved
+approval returns the recorded terminal result for an exact replay and a typed
+conflict otherwise.
+
+### Canonical Factory Events
+
+Add two event types rather than overloading `WORK_STATE_CHANGE` or the existing
+session policy-approval event:
+
+```text
+DISPATCH_REQUEST
+  -> HUMAN_APPROVAL_REQUESTED
+  -> HUMAN_APPROVAL_RESOLVED
+  -> DISPATCH_RESPONSE
+```
+
+`HUMAN_APPROVAL_REQUESTED` contains:
+
+- `approvalId`, `dispatchId`, `workstationId`, `workstationName`;
+- fixed available decisions `APPROVE` and `REJECT`; and
+- request status `PENDING`.
+
+The localized Workstation description is already part of the effective Factory
+snapshot. Reads and presentation join it by stable Workstation ID instead of
+copying mutable display text into the event.
+
+Authoritative session, request, trace, sequence, time, and ordered Work IDs stay
+in `FactoryEvent.context` where applicable.
+
+`HUMAN_APPROVAL_RESOLVED` contains:
+
+- `approvalId`, `dispatchId`, and outcome `APPROVED`, `REJECTED`, or `CANCELED`;
+- decision source `cli`, `api`, or `attached-cli`;
+- optional safe actor label and reason; and
+- the original request event ID/sequence needed to audit the pair.
+
+The events do not contain raw Work payloads, credentials, terminal input, or
+provider data. Recordings validates pair ordering, rejects an orphan or second
+conflicting resolution, and rebuilds pending/resolved approval projections from
+history. Recording export/import, reconnect, historical reads, and dashboard
+replay preserve the events unchanged.
+
+### REST and CLI behavior
+
+Add these session-scoped REST operations:
+
+```text
+GET  /factory-sessions/{session_id}/human-approvals
+GET  /factory-sessions/{session_id}/human-approvals/{approval_id}
+POST /factory-sessions/{session_id}/human-approvals/{approval_id}/decision
+```
+
+List defaults to pending requests and supports explicit status filtering. The
+decision body contains `requestId`, `decision`, optional `actor`, and optional
+`reason`. Reject requires a non-empty reason; approve permits one. Responses
+return the canonical approval projection and links to the Factory Session,
+Work, Workstation/current Factory, events, and the decision operation when
+pending.
+
+Add these manifest-authored CLI commands:
+
+```text
+you work approval list [--session <session-id>] [--status pending|resolved]
+you work approval show <approval-id> [--session <session-id>]
+you work approval approve <approval-id> [--reason <text>] [--request-id <id>]
+you work approval reject <approval-id> --reason <text> [--request-id <id>]
+```
+
+Human output identifies the approval, Workstation, related Work, decision, and
+next inspection command. `--json` returns the API-shaped contract. Diagnostics
+remain on stderr and sensitive Work content is never echoed implicitly.
+`you work move` remains a generic recovery operation; it does not resolve or
+close a pending approval and cannot move Work claimed by that pending dispatch.
+
+Add `you run --human-approval auto|prompt|external|fail`:
+
+- `auto` is the default. It selects `prompt` only for human output with an
+  interactive input terminal and when invocation input did not consume stdin;
+  otherwise it selects `fail`.
+- `prompt` renders pending requests in canonical sequence order to the
+  diagnostic terminal, reads approve/reject and an optional/required reason,
+  and submits the decision through the injected Work service. It rejects JSON,
+  NDJSON/response-stream, quiet, non-interactive, and stdin-as-invocation-input
+  combinations before runtime startup.
+- `external` keeps the invocation waiting for REST/CLI decisions and requires
+  `--with-server`; normal timeout and cancellation still apply.
+- `fail` preserves non-interactive compatibility by returning
+  `INVOCATION_NEEDS_HUMAN`, now with `approvalId`, Workstation, Work, and
+  inspection/decision links derived from a real pending request.
+
+The attached prompt uses a bounded queue outside the event-append call stack so
+terminal input cannot block Recordings or the runtime tick. Multiple concurrent
+requests are prompted one at a time by canonical sequence; external mode may
+resolve independent requests concurrently.
+
+The existing `you session approve` gap for JavaScript policy approval is not
+part of this plan. HITL commands live under Work and use Human Approval IDs so
+the two approval concepts remain unambiguous.
+
+### Dashboard and package compatibility
+
+The canonical editable state remains the generated `Factory`/`Workstation`
+document. Existing current-selection workstation operations own type changes,
+validation, save preparation, and server mutation. React Flow nodes and handles
+remain disposable projections from that canonical document.
+
+- Add `HUMAN_APPROVAL` to the localized workstation-type catalog and editable
+  validation rules.
+- Project one approval output handle and one rejection handle using the same
+  semantic handle IDs consumed by saved edges.
+- Render a distinct human-approval label/icon and pending/resolved status using
+  existing shared node/status primitives; do not add a dashboard decision
+  mutation in this first CLI-focused delivery.
+- Project canonical approval events into timeline and current-activity state so
+  a pending node remains visibly waiting and a resolved node shows its outcome.
+- Teach `@you-agent-factory/factory-replay` the two event kinds.
+- Make `@you-agent-factory/factory-emulator` report `HUMAN_APPROVAL` as an
+  explicit unsupported external-interaction capability until an injected
+  decision source is designed; it must not auto-approve or silently run it as a
+  normal agent node.
+
+## Original document
+
+There is no earlier standalone product plan for this request. This plan records
+the repository audit and is constrained by:
+
+- `C:\Users\andre\work\portos\infinite-you\AGENTS.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\architecture\architecture.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\architecture\structures.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\architecture\data-model.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\architecture\packaged-structure.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\internal\standards\code\planning-standards.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\internal\standards\code\code-review-standards.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\internal\standards\code\general-backend-standards.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\internal\standards\code\general-website-standards.md`
+
+## Work stories
+
+### HITL-001: Author and validate a human approval node
+
+As a Factory author, I can add a `HUMAN_APPROVAL` Workstation with explicit
+approve and reject routes, so the Factory definition states where a human must
+decide without binding a fake Worker.
+
+Acceptance criteria:
+
+- JSON and YAML Factory definitions accept `HUMAN_APPROVAL` and preserve it
+  through load, validate, save, split/inline layout, export/import, and generated
+  public schemas.
+- Valid nodes require a stable ID, non-empty localized description, input,
+  approval output, and rejection output.
+- Worker, runner, provider/model, prompt, environment, worktree, resource,
+  classifier, continue, and failure fields are rejected with field-specific
+  diagnostics.
+- The compiler produces a workerless runtime transition and never creates a
+  Workers runtime binding for this node.
+- The editor changes only the canonical Factory document through existing
+  workstation draft/type/save operations; its React Flow node and approve/reject
+  handles are reproducible projections with matching edge handle IDs.
+- Type-change, validation, save-preparation, projection, localized-label, and
+  focused component tests pass, including one non-default locale.
+- `make generate-api` and `make interfaces-all` produce current Go,
+  TypeScript, JSON Schema, and publishable package artifacts without hand edits.
+
+### HITL-002: Observe a durable pending approval
+
+As an operator, I can see exactly which Workstation and Work are waiting for my
+decision, so I do not infer human work from a state name or a stalled queue.
+
+Acceptance criteria:
+
+- Selecting a human node claims its input once, records `DISPATCH_REQUEST`
+  followed by exactly one `HUMAN_APPROVAL_REQUESTED`, and invokes no Worker,
+  Worker Session, Provider, Model, script, or runner.
+- The event has a stable approval ID, canonical session/dispatch/Work
+  correlation, allowed decisions, and no copied Work payload; the read model
+  resolves the localized description from the effective Factory snapshot.
+- Pending approval keeps the Factory Session live and prevents the same Work
+  from being consumed by another transition or moved through generic
+  `you work move`.
+- REST list/get and `you work approval list/show` return the same pending
+  projection in human and JSON modes, including Work and event links.
+- Work and Factory Session inspection identify the real pending approval and
+  `INVOCATION_NEEDS_HUMAN` context uses it; legacy exact-name fallback remains
+  distinguishable when no approval request exists.
+- Recordings live and replay projections agree on pending state, and reconnect
+  from before or after the request never duplicates it.
+- Runtime admission, projection, REST mapping, CLI rendering, replay, and
+  no-provider-call tests pass.
+
+### HITL-003: Approve or reject through one idempotent decision contract
+
+As an operator, I can approve or reject a pending request and have the Factory
+follow only the corresponding authored route.
+
+Acceptance criteria:
+
+- REST and `you work approval approve/reject` call one Work-owned service-root
+  operation with explicit session, approval, request, decision, actor, and
+  reason values.
+- Approve records `HUMAN_APPROVAL_RESOLVED(APPROVED)` before one accepted
+  `DISPATCH_RESPONSE`, preserves input payload, and emits only `outputs`.
+- Reject requires a reason, records
+  `HUMAN_APPROVAL_RESOLVED(REJECTED)` before one rejected
+  `DISPATCH_RESPONSE`, preserves input payload, and emits only `onRejection`.
+- A rejection route that loops back eventually creates a new approval ID; a
+  later approval completes normally while both decisions remain auditable.
+- Same-body request-ID retry returns the original result without new events or
+  routing. Changed-body reuse, unknown approval, wrong session, malformed
+  decision, missing rejection reason, and competing resolution return typed,
+  safe outcomes without mutation.
+- Concurrent approve/reject attempts have one winner, one terminal dispatch
+  result, and race/repeated-run coverage.
+- Service operations log accepted intent and terminal outcome with safe stable
+  identifiers and duration, without logging Work content or terminal input.
+
+### HITL-004: Complete attached and externally operated CLI loops
+
+As a CLI user, I can either answer a human gate in the `you run` terminal or
+leave it open for a second CLI/API operator without losing stdout contracts.
+
+Acceptance criteria:
+
+- `--human-approval auto` prompts only in compatible interactive human-output
+  runs and otherwise preserves the explicit fail behavior.
+- Prompt mode renders requests in canonical sequence order, accepts only
+  approve/reject, requires a rejection reason, retries invalid terminal input
+  without mutating runtime state, and prints the final primary result only after
+  the Factory reaches its authored result.
+- Prompting never writes UI text into JSON/NDJSON stdout and all new visible
+  copy follows the owning CLI message/catalog conventions.
+- Unsupported combinations fail before opening a Factory Session or invoking a
+  provider.
+- External mode requires a bound server, remains cancellable, respects the
+  invocation timeout, and completes after a separate approval CLI command.
+- Fail mode returns `INVOCATION_NEEDS_HUMAN` with approval context and leaves no
+  false success output.
+- A bounded asynchronous prompt queue prevents event append/tick deadlock and
+  handles cancellation while waiting for terminal input.
+- Focused CLI unit/integration tests and root-built functional tests cover
+  prompt approve, prompt reject-then-approve, external approval, headless fail,
+  invalid input, timeout, and Ctrl-C cancellation.
+
+### HITL-005: Preserve approval truth through cancellation, restart, and replay
+
+As an operator or auditor, I can restart or replay a Factory Session and see the
+same pending or resolved human decision without re-prompting completed work.
+
+Acceptance criteria:
+
+- Restart after `HUMAN_APPROVAL_REQUESTED` reconstructs one pending request and
+  accepts a later decision without starting another dispatch.
+- Restart after `HUMAN_APPROVAL_RESOLVED` but before or after
+  `DISPATCH_RESPONSE` reconciles exactly one route/result and never asks the
+  human twice.
+- Session cancel/terminate wins atomically against a decision, records a
+  canceled resolution plus ordinary dispatch interruption, and never emits an
+  accepted/rejected route after cancellation wins.
+- Recording validation rejects orphaned, mismatched, reordered, and conflicting
+  approval event pairs with safe diagnostics.
+- Export/import, historical tick inspection, replay packages, dashboard
+  timeline/current-activity projections, and live reconnect retain the same
+  request/decision correlation and outcome.
+- The emulator fails compatibility inspection before event mutation and names
+  human approval as an unsupported external interaction.
+- Replay, recovery, race, malformed-recording, frontend projection, and package
+  compatibility tests pass.
+
+### HITL-006: Publish and functionally prove the supported contract
+
+As a customer, I can follow one documented example and trust that the shipped
+CLI, API, events, and runtime perform a real human approval loop.
+
+Acceptance criteria:
+
+- Add a maintained example Factory with a human approval node whose rejection
+  route returns Work for changes and whose later approval reaches a terminal
+  result.
+- `you docs workstations`, `you docs work`, `you docs run`, and `you docs
+  sessions` explain authoring, pending inspection, attached/external operation,
+  event ordering, idempotency, cancellation, and the distinction from
+  JavaScript policy approval and generic `work move`.
+- New functional scenarios live under
+  `tests/functional/workstations/human_approval/`, construct through
+  `root.BuildProcess`, execute ordinary customer paths through
+  `Process.Execute` and the CLI, and replace only exact external effects through
+  `edges.Edges`.
+- Functional proof covers no-worker request creation, list/show, approve to
+  terminal, reject-then-approve loop, attached prompt, external decision,
+  canonical event order/content, request-ID retry, competing decision,
+  cancellation, and restart/replay.
+- Tests use deterministic event observation and injected edges, contain no
+  sleeps or timeout-padded polling as their synchronization strategy, and do not
+  use `--with-mock-workers` outside the workers/mock feature cells.
+- API smoke, docs smoke, generated-artifact checks, focused Go/UI/package
+  tests, race/repeated-run checks, lint, and PR verification pass.
+
+## Changes
+
+### Package changes
+
+- Extend authored Factory contracts under `api/components/schemas/data-models/`,
+  `pkg/services/factory_definitions/internal/contracts/`, validation taxonomy,
+  compilation/loading, layout, clone, and persistence paths for
+  `HUMAN_APPROVAL`.
+- Add a narrow Factory Runtime human-approval admission and resolution contract
+  at `pkg/services/factory_runtime`; keep Petri claim, pending dispatch,
+  idempotency, cancellation, and result re-entry under its existing private
+  orchestration packages.
+- Extend the Work service root with approval list/get/decision operations.
+  Implement session resolution and Recordings-backed reads under
+  `pkg/services/work/internal/`; do not expose engine state or call private
+  Factory Runtime implementations.
+- Extend Recordings event contracts, validation, append paths, reducers,
+  projection clones, export/import, and replay under
+  `pkg/services/recordings/`. Recordings remains the canonical Factory Event
+  ledger; `pkg/services/events` is not used as approval storage.
+- Update Factory Sessions invocation observation/wait policy so real pending
+  approvals support fail, attached-prompt, and external-wait modes without
+  weakening timeout, cancellation, or session cleanup.
+- Add Work-owned HTTP adapters and CLI adapters; keep top-level HTTP/CLI code
+  focused on composition and generated command wiring.
+- Extend `pkg/services/factory_visualization` and frontend/package replay
+  projections from canonical events. Do not create a second mutable approval
+  store in UI state.
+- Update the dashboard's existing current-selection workstation draft,
+  validation, mutation/save, localized enum, and React Flow projection paths.
+  Reuse shared node/status/form primitives and keep the graph library state
+  disposable.
+- Compose new public service dependencies once through owning `wire/` providers
+  and `pkg/wire`; do not add a dependency bag, service locator, child injector,
+  runtime callback registry, or out-of-`wire` production construction.
+
+### Contracts
+
+- Define `Human Approval` in `docs/architecture/data-model.md` as one
+  pending-or-resolved operator decision for a Workstation dispatch within a
+  Factory Session, linked to the affected Work. Keep JavaScript policy approval
+  terminology explicitly separate.
+- Add `HUMAN_APPROVAL` to `WorkstationType` and document graph-only support.
+- Add request, status, decision, outcome, list/read, and decision-response
+  schemas for the Human Approval resource.
+- Add `HUMAN_APPROVAL_REQUESTED` and `HUMAN_APPROVAL_RESOLVED` to
+  `FactoryEventType`, their payload union/discriminator mappings, canonical Go
+  contracts, portable schemas, and published client types.
+- Add optional pending-approval context and links to Work, Factory Session stop
+  diagnostics, and `INVOCATION_NEEDS_HUMAN` without changing the meaning of
+  JavaScript `AWAITING_APPROVAL`.
+- Preserve `agent-factory.event.v1` only if the two additive enum/payload
+  variants satisfy the repository's compatibility policy; otherwise introduce
+  a deliberate event schema version and migration rather than silently
+  changing a closed consumer contract.
+- Keep decision source semantic (`cli`, `api`, `attached-cli`) and separate from
+  transport-derived generic work-move source.
+- Regenerate, never hand-edit, `api/openapi.yaml`, generated Go server/client,
+  dashboard OpenAPI types, publishable API/client schemas, CLI manifest output,
+  and MCP discovery artifacts that derive from the changed contract.
+
+### Services
+
+- **Factory Definitions** owns what constitutes a valid human workstation and
+  how it compiles into a workerless graph transition.
+- **Factory Runtime** owns selection, Work claim, pending execution state,
+  decision admission against that state, cancellation races, and re-entry into
+  ordinary transition routing.
+- **Work** owns the customer-facing Human Approval resource and decision
+  operation because the decision acts on Work held by a Workstation.
+- **Recordings** owns canonical approval events, ordering validation, durable
+  replay, and pending/resolved read projections.
+- **Factory Sessions** owns invocation wait-mode behavior and session lifecycle
+  coordination, not approval truth.
+- **Workers/Worker Sessions/Providers/Models** receive no human-workstation
+  dispatch and own no approval state.
+- **Factory Visualization/UI packages** consume canonical contracts and events
+  for presentation only.
+
+### API changes
+
+- Author the three Human Approval routes in `api/openapi-main.yaml` and their
+  component parameters, schemas, responses, error outcomes, and examples under
+  `api/components/`.
+- Map handlers through the Work service contract and keep decision validation
+  in the owning service rather than duplicating it in HTTP and CLI.
+- Add typed errors for approval/session not found, already resolved,
+  idempotency conflict, invalid decision, rejection reason required, session
+  terminal, and decision/cancellation conflict.
+- Update API contract tests, generated-client fixtures, schema inventories,
+  public package manifests, and `make api-smoke` expectations.
+- Do not reuse `/factory-sessions/{session_id}/approve` or its
+  `FactorySessionApproveRequest`; that route remains JavaScript policy approval.
+
+### Tests
+
+- Factory Definition unit/contract tests for valid graph nodes, every forbidden
+  field family, YAML/JSON parity, split/inline persistence, and compiler output.
+- Factory Runtime package integration tests for one pending request, no Worker
+  call, approve/reject routing, loop request identity, payload preservation,
+  idempotency, cancellation race, and result/event order.
+- Recordings tests for append validation, live/replay parity, pending/resolved
+  projections, reconnect, export/import, malformed pairs, and event-kind parity.
+- Work service and HTTP/CLI adapter tests for mapping, safe typed errors, human
+  and JSON output, status filters, request IDs, and reason validation.
+- Factory Sessions/CLI tests for invocation modes, stdout/stderr separation,
+  TTY/input conflicts, prompt queue cancellation, timeout, and cleanup.
+- Frontend operation, validation, projection, mutation, localization, component,
+  replay-package, and explicit emulator-compatibility tests.
+- Root-built functional scenarios under
+  `tests/functional/workstations/human_approval/` as specified by HITL-006.
+- Race or repeated-run coverage for competing approve/reject/cancel and replay
+  reconciliation. Add stress coverage only if the implementation introduces a
+  shared pending-approval queue or high-volume projection path.
+
+## Dependency-aware delivery sequence
+
+1. **HITL-001** establishes the authored type, strict validation, generated
+   contract, compiler behavior, and editor projection used by every later
+   story.
+2. **HITL-002** establishes pending runtime truth, request events, projections,
+   and read-only CLI/API inspection.
+3. **HITL-003** adds the one idempotent decision operation and ordinary
+   approve/reject routing.
+4. **HITL-004** composes that operation into attached and external `you run`
+   behavior after the decision contract is stable.
+5. **HITL-005** hardens cancellation, restart, replay, dashboard projections,
+   and package consumers against the established event sequence.
+6. **HITL-006** publishes the example/docs and completes the cross-boundary
+   functional proof before release.
+
+HITL-001 editor projection work can proceed alongside backend compiler work
+after the schema is fixed. HITL-005 frontend replay work can proceed alongside
+backend recovery work after the event payloads and ordering invariants are
+fixed. Decision mutation UI is intentionally deferred; it is independently
+valuable and is not required to deliver the requested CLI-operated loop.
+
+## Verification strategy
+
+### Focused backend and contract
+
+- Run focused Go tests for Factory Definitions, Factory Runtime, Work,
+  Recordings, Factory Sessions, HTTP mapping, CLI adapters, and visualization.
+- Run `make generate-api`, `make interfaces-all`, and `make api-smoke` for the
+  public contract and generated consumers.
+- Run event-kind inventory/parity, portable recording validation, package
+  schema, CLI-manifest generation, and generated-artifact stability checks.
+- Run focused `go test -race` or repeated execution for resolution/cancellation
+  races and recovery idempotency.
+
+### Functional
+
+Functional tests construct through `root.BuildProcess` and execute through
+`Process.Execute` by default. They enter through CLI for ordinary customer
+flows, use REST only for API-owned parity assertions, and replace exact external
+effects only through `edges.Edges`. They use canonical event subscriptions and
+process readiness signals instead of sleeps.
+
+Required functional cells:
+
+- valid human node reaches one pending request with zero provider calls;
+- list/show returns the same request observed on the Factory event stream;
+- CLI approve reaches the authored terminal output;
+- CLI reject returns Work for rework, creates a new approval ID, then approve
+  completes;
+- attached prompt completes without corrupting stdout;
+- external mode completes after a second CLI invocation resolves the request;
+- headless fail returns `INVOCATION_NEEDS_HUMAN` with no false success;
+- exact request-ID retry produces no duplicate decision or route;
+- competing decision/cancel produces one winner and one terminal dispatch fact;
+- restart/replay reconstructs pending and resolved cases without a second
+  prompt; and
+- canonical event order and safe payload content match the public schemas.
+
+### Frontend and packages
+
+- Test canonical Factory draft operations and save preparation for type changes
+  to/from `HUMAN_APPROVAL`.
+- Test React Flow projection handle IDs and visible node state from canonical
+  definition/event inputs.
+- Test event reducers with pending, approved, rejected, canceled, replayed, and
+  malformed sequences.
+- Test localized type/status copy, keyboard-visible node detail behavior, and
+  mobile/desktop presentation of pending state.
+- Run package client/replay/emulator verification and confirm emulator rejection
+  is explicit before mutation.
+
+## Quality gates
+
+Use the narrowest focused checks during each story, then run the shared/public
+gates before merge:
+
+```sh
+make generate-api
+make interfaces-all
+make api-smoke
+make docs-reference-smoke
+make ui-test
+make ui-lint
+make verify-fast
+make lint
+make verify-pr
+```
+
+Also run focused race/repeated-run commands for decision/cancellation and the
+targeted functional package under
+`tests/functional/workstations/human_approval/`. Visually inspect the editor and
+running pending/resolved node at mobile and desktop sizes when the dashboard
+projection changes.
+
+## Project acceptance criteria
+
+- A Factory author can create a workerless `HUMAN_APPROVAL` node with explicit
+  approve and reject routes, and invalid execution fields fail validation.
+- Reaching the node creates one durable pending Human Approval with no Worker or
+  Provider execution.
+- CLI/API inspection and decision operations use one canonical approval ID and
+  one Work-owned contract.
+- Approval and rejection follow only their authored routes; rejection can loop
+  back and later approval can complete with distinct auditable request IDs.
+- Factory Events explicitly and safely record request and resolution in stable
+  order, and Recordings replay reconstructs pending/resolved truth.
+- `you run` supports attached prompt, external wait, and compatibility fail
+  modes without corrupting stdout, leaking sensitive content, or stranding
+  session lifecycle.
+- Generic `you work move` and JavaScript policy approval remain distinct and
+  cannot silently resolve a Human Approval.
+- Dashboard/editor and publishable package consumers handle the new type/events
+  deliberately; the emulator fails explicitly rather than auto-approving.
+- Required unit, integration, contract, functional, replay, race, frontend,
+  package, docs, generation, lint, and CI checks pass.
+- Delivery for every implementation PR continues until required CI is terminal
+  and passing, all blocking review feedback is explicitly addressed, conflicts
+  and shared-file/generated-artifact drift are resolved, and the PR is actually
+  merged. An opened, approved, or green-but-unmerged PR is not complete.
+
+## Delivery loop
+
+Each work story should normally be one independently reviewable PR. For every
+PR, continue implementation and review until required CI is terminal and green,
+blocking review conversations are addressed, conflicts are resolved, generated
+artifacts are current, and the PR is merged. Follow-up work may be split out
+only when it is independently valuable and does not weaken the current story's
+observable acceptance criteria.

--- a/docs/internal/development/plans/javascript-workflow-file-operations-plan.md
+++ b/docs/internal/development/plans/javascript-workflow-file-operations-plan.md
@@ -1,0 +1,400 @@
+# JavaScript Workflow Read-Only File Operations Plan
+
+## Status
+
+Proposed. This document is an implementation plan only. It is intentionally
+separate from child Provider permission-bypass work.
+
+## Problem statement
+
+The JavaScript workflow VM exposes no filesystem API. Static validation rejects
+the `fs` root and runtime construction binds no filesystem object. As a result,
+a workflow cannot:
+
+- list files available in its project;
+- inspect a file directly;
+- validate text, binary, or multimedia headers and metadata; or
+- prepare a file for a future inference input without first asking an agent to
+  invoke its own `readFile` tool.
+
+The required first surface is deliberately small and read-only: list one
+directory, open one regular file, read bounded bytes, and close the file. Its
+file value must also leave a clean future path for passing images, audio, video,
+or binary data directly to inference without serializing the full payload
+through prompts, JavaScript JSON, or agent tool output.
+
+## Customer outcome
+
+A workflow can discover and inspect project files through a bounded,
+project-relative host API while `READ_ONLY` continues to prohibit filesystem
+mutation, process execution, module loading, and network access.
+
+## Current-state findings
+
+- `pkg/services/factory_runtime/internal/services/orchestration/javascript/validation/globals.go`
+  explicitly rejects `fs`.
+- `runtime/globals.go` documents and enforces a VM with no host filesystem
+  object.
+- Factory Runtime already receives injected `ReadDir`, `ReadFile`, and `Stat`
+  seams for source loading and input watching, but those interfaces do not own a
+  script-visible capability contract.
+- Factory Sessions already knows the project root used for child working
+  directories, while `JavaScriptRuntimeRequest` has no approved read root or
+  filesystem capability.
+- Canonical Work content already supports image, audio, and binary content using
+  content URLs and MIME types. Codex image execution already materializes local
+  content and passes a path to the Provider.
+- `agent.run` cannot currently accept Work content or a workflow-owned file
+  value.
+
+## Product decisions
+
+1. Bounded project reads are part of `READ_ONLY`; no dangerous permission bypass
+   is required.
+2. The public API is a host-provided global `fs` namespace, not Node/Bun/Deno
+   module compatibility.
+3. The approved root is supplied by Factory Session/runtime composition and is
+   never script-authored.
+4. Paths are project-relative. Absolute paths, traversal, symlink escape, device
+   files, named pipes, and sockets are rejected before data is returned.
+5. The initial operations are only `fs.list`, `fs.open`, `OpenFile.read`, and
+   `OpenFile.close`.
+6. `fs.list` is non-recursive and deterministic.
+7. `OpenFile` is an opaque, non-forgeable, runtime-local capability. It cannot be
+   serialized, checkpointed, recorded, or returned as JSON.
+8. Reads return `Uint8Array` and support offset/length ranges so validation does
+   not require loading large media in full.
+9. Explicit `close()` is recommended and idempotent. Runtime cleanup closes all
+   leaked handles on success, failure, cancellation, and timeout.
+10. Read limits are explicit policy facts and zero never means unbounded.
+
+## Recommended authoring UX
+
+```javascript
+const entries = await fs.list("./media");
+const candidate = entries.find((entry) => entry.kind === "file");
+
+const file = await fs.open(candidate.path);
+try {
+  const header = await file.read({offset: 0, length: 4096});
+
+  return {
+    name: file.name,
+    size: file.size,
+    contentType: file.contentType,
+    headerBytes: Array.from(header),
+  };
+} finally {
+  await file.close();
+}
+```
+
+Initial contract shape:
+
+```typescript
+type FileEntry = {
+  name: string;
+  path: string;
+  kind: "file" | "directory" | "symlink";
+};
+
+type OpenFile = {
+  readonly name: string;
+  readonly path: string;
+  readonly size: number;
+  readonly contentType: string;
+  read(options?: {offset?: number; length?: number}): Promise<Uint8Array>;
+  close(): Promise<void>;
+};
+
+declare const fs: {
+  list(path: string): Promise<FileEntry[]>;
+  open(path: string): Promise<OpenFile>;
+};
+```
+
+`fs.list("")` and `fs.list(".")` address the approved project root. Results are
+sorted lexicographically by normalized name and expose normalized relative
+paths, never unrestricted host paths.
+
+`file.read()` reads the whole file only when it fits both the per-read and
+per-workflow budgets. Offset/length reads are the expected pattern for large
+media validation.
+
+## Future direct multimedia handoff
+
+The initial file-operations delivery does not change `agent.run`. The opaque
+handle should support this compatible follow-up without changing `fs.open`:
+
+```javascript
+const image = await fs.open("./media/frame.png");
+try {
+  return await agent.run({
+    prompt: "Describe this frame and flag visual defects.",
+    content: [{type: "image", source: image}],
+  });
+} finally {
+  await image.close();
+}
+```
+
+Factory Runtime would validate that `source` is a live handle owned by the
+current workflow, map it to canonical Work content, and let Workers/Providers
+materialize or consume it through existing content boundaries. The JavaScript
+heap would not base64-encode the complete media payload and the agent would not
+need a separate file-reading tool call.
+
+## UX comparison
+
+| Shape | Advantages | Costs | Decision |
+| --- | --- | --- | --- |
+| `fs.list`, `fs.open`, `file.read`, `file.close` | Small, explicit, supports bounded binary reads, and provides a stable future media source. | Requires handle lifecycle and cleanup semantics. | Recommended. |
+| `fs.readFile(path)` returning full bytes | Familiar and concise. | Encourages whole-file copies and provides no durable handle for direct inference handoff. | Defer as an optional auto-closing convenience. |
+| Raw path strings in `agent.run` | Minimal syntax. | Re-resolves mutable paths, creates time-of-check/time-of-use races, and can bypass the workflow capability. | Reject. |
+| Base64 or data URLs | Serializable and provider-neutral. | Copies large media through Goja, JSON, events, and logs. | Reject for local files. |
+| `require("fs")` or `node:fs/promises` | Familiar Node API. | Implies module loading and a much larger compatibility/security surface. | Reject for this slice. |
+
+## Work stories
+
+### Story 1 — Project-relative directory listing
+
+As a workflow author, I can discover files within the current project without
+receiving write, process, module, or network access.
+
+Acceptance criteria:
+
+- `await fs.list(relativePath)` returns a non-recursive, lexicographically sorted
+  list of detached `FileEntry` values.
+- Empty path and `"."` resolve to the approved project root.
+- Absolute paths, traversal, and symlink escape fail with stable diagnostics
+  before the escaped target is read.
+- Missing paths, non-directories, permission failures, unavailable filesystem,
+  and entry-budget exhaustion have stable codes and bounded messages.
+- Results expose normalized relative paths and kinds, never unrestricted host
+  paths.
+- Listing does not follow directory symlinks recursively.
+- Factory Session and standalone CLI compositions behave equivalently.
+
+### Story 2 — Bounded open and metadata
+
+As a workflow author, I can open a regular project file and inspect safe metadata
+without exposing the underlying host descriptor or absolute path.
+
+Acceptance criteria:
+
+- `await fs.open(relativePath)` accepts only regular files contained by the
+  approved root after symlink resolution.
+- Absolute paths, root escape, directories, devices, pipes, and sockets fail
+  before a handle is returned.
+- Metadata includes normalized relative path, basename, byte size, and
+  best-effort content type; unknown types use `application/octet-stream`.
+- Content type is advisory and never substitutes for byte validation.
+- Handles are non-forgeable and owned by one runtime instance.
+- The maximum-open-handles budget is enforced before opening another file.
+
+### Story 3 — Bounded binary reads
+
+As a workflow author, I can validate file contents or multimedia headers without
+loading unbounded data into the JavaScript VM.
+
+Acceptance criteria:
+
+- `await file.read()` returns `Uint8Array`.
+- Optional offset and length are non-negative safe integers; invalid ranges fail
+  before I/O.
+- Reads stop at EOF and never return more bytes than requested.
+- Whole-file reads fail when the file exceeds the per-read budget.
+- Per-read and cumulative workflow byte budgets are enforced deterministically;
+  zero or omitted limits never mean unlimited.
+- Cancellation prevents further reads and returns the existing runtime
+  cancellation outcome.
+- File bytes never enter logs, runtime records, recordings, checkpoints, or
+  diagnostics.
+
+### Story 4 — Deterministic close and cleanup
+
+As a workflow author, I can release a file explicitly, and the runtime prevents
+descriptor leaks if my code does not reach `finally`.
+
+Acceptance criteria:
+
+- `await file.close()` closes the host resource and is idempotent.
+- Reads after close fail with a stable `file closed` diagnostic.
+- Runtime success, script error, unresolved final, timeout, and cancellation all
+  close every remaining handle before `Run` returns.
+- One handle cannot be used by a sibling workflow, resumed VM, artifact,
+  checkpoint, log field, or final result.
+- Checkpoint resume starts with an empty handle registry; prior OS resources are
+  never reconstructed.
+
+### Story 5 — Observable and replaceable file effects
+
+As an operator and test author, I can inspect safe access facts and replace all
+filesystem effects without touching the host filesystem.
+
+Acceptance criteria:
+
+- Factory Runtime owns root/path policy, handle lifecycle, budgets, and
+  script-visible behavior.
+- Platform owns the policy-free local filesystem implementation.
+- `root.BuildProcess` accepts one exact JavaScript workflow filesystem edge for
+  list, stat, regular-file open/read/close, and symlink resolution.
+- Runtime records include operation, normalized relative path, byte counts,
+  outcome, and diagnostic code, but no bytes or absolute paths.
+- Preview reports filesystem availability and effective budgets without
+  performing I/O.
+- Historical replay displays recorded access facts and never re-opens files.
+- Documentation states that resumed execution may observe changed project files
+  unless content was staged as canonical Work content or an artifact.
+
+### Story 6 — Future-ready media handle
+
+As a future workflow author, I can pass an already-open file to inference without
+changing the filesystem API or copying the full payload through JavaScript JSON.
+
+Acceptance criteria for the seam delivered now:
+
+- Each handle has a private runtime-local identity and internal resolver for
+  liveness, ownership, resolved path, size, and content type.
+- No public path-string escape hatch is added to `agent.run`.
+- The handle can later map to canonical image, audio, or binary Work content
+  without Provider-specific types in the JavaScript runtime.
+- Future dispatch ownership can retain or snapshot the source safely if script
+  cleanup closes the author-facing handle.
+
+The future `agent.run({content})` contract and Provider video capability work are
+not required in this implementation plan.
+
+### Story 7 — Published JavaScript contract and docs
+
+As a customer, I can discover the complete read-only file API and its limits.
+
+Acceptance criteria:
+
+- The authored symbol catalog, call-behavior descriptor, schemas, examples,
+  errors, and generated package projection agree on `fs` and `OpenFile`.
+- `OpenFile` is documented as an opaque returned value, not a constructible
+  global.
+- Static validation accepts only published `fs` and handle members and continues
+  to reject writes, `require`, `node:fs`, process, shell, network, and package
+  APIs.
+- `you docs javascript-workflows` includes a copy-paste `try/finally` example and
+  explains project-root confinement and read budgets.
+
+## Implementation plan
+
+### Contracts and policy
+
+- Add `fs` to supported JavaScript globals and define the closed `fs.list`,
+  `fs.open`, `OpenFile.read`, and `OpenFile.close` shapes.
+- Remove only the host-provided `fs` root from the blanket forbidden map;
+  continue rejecting module-based filesystem access and unsupported members.
+- Add stable diagnostics for invalid path, root escape, unsupported file kind,
+  invalid range, closed handle, unavailable filesystem, I/O failure, and budget
+  exhaustion.
+- Add effective-policy limits for maximum open handles, entries per listing,
+  bytes per read, and cumulative bytes read. Include them in normalization,
+  hashing, preview, and recording projections.
+
+### JavaScript runtime host
+
+- Add the host implementation under
+  `pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/`.
+- Bind one `fs` namespace and handle registry per Goja VM.
+- Keep path normalization, root checks, symlink containment, ownership,
+  accounting, and safe diagnostics in Factory Runtime.
+- Return Goja `ArrayBuffer`/`Uint8Array` values without converting binary data to
+  JSON or base64.
+- Create and settle Goja values only on the VM-owning execution path.
+- Close the registry on every terminal runtime path.
+
+### Filesystem edge and composition
+
+- Publish a focused `JavaScriptFileSystem` port from Factory Runtime rather than
+  reusing source-loader or input-watcher interfaces by accident.
+- Expose only directory listing, stat, regular-file open/read/close, and symlink
+  resolution effects.
+- Add the exact replacement to `pkg/services/edges/definition.go`; compose the
+  production `pkg/platform/filesystem` adapter in `pkg/wire`.
+- Supply the filesystem and already-known `projectRoot` through Factory Sessions
+  runtime construction. Scripts never choose the root.
+- Use the same adapter and confinement rules for Factory Session and standalone
+  `you run script.js` execution.
+
+### Contracts, observations, and docs
+
+- Update canonical JavaScript call-behavior and runtime-api sources, then
+  regenerate derived artifacts.
+- Add safe file-access runtime records and preserve them through recordings and
+  historical replay without replay-time I/O.
+- Update packaged JavaScript workflow reference docs.
+
+### Media handoff seam
+
+- Brand handles with private runtime-owned identities.
+- Retain sufficient internal metadata for a future canonical Work content
+  mapping: resolved path, normalized relative path, content type, size, and
+  lifecycle state.
+- Do not add `agent.run.content` or Provider video support in this delivery.
+
+## API and data changes
+
+- No new REST or MCP operation is required.
+- If effective-policy projections expose read budgets, author the OpenAPI changes
+  under `api/openapi-main.yaml` and `api/components/` and regenerate clients.
+- Add access-record fields only to canonical source contracts.
+- Never persist OS handles, absolute paths, or raw file bytes.
+
+## Test plan
+
+- Static validation tests for valid `fs` use and rejected modules, writes,
+  process, shell, and network APIs.
+- Runtime tests with injected filesystems for sorted listing, metadata,
+  full/partial reads, typed arrays, EOF, budgets, close, use-after-close,
+  cancellation, and automatic cleanup.
+- Windows and POSIX path tests for absolute paths, volume names, separators,
+  traversal, case behavior, symlink escape, and special files.
+- Factory Session integration tests proving root selection and equal
+  canonical/standalone behavior.
+- Recording/replay tests proving safe metadata retention and zero replay I/O.
+- Contract and packaged CLI documentation smoke tests.
+- Leak tests for success, script failure, unresolved final, timeout, and
+  cancellation.
+
+## Quality gates
+
+- `go test ./pkg/services/factory_runtime/...`
+- `go test ./pkg/services/factory_sessions/internal/execution/...`
+- focused functional JavaScript orchestration tests through
+  `root.BuildProcess` and injected edges
+- `make javascript-contract-smoke`
+- `make contracts-check`
+- `make docs-reference-smoke`
+- `make api-smoke` when public projections change
+- `make verify-fast`, followed by `make verify-pr`
+
+## Out of scope
+
+- `skipPermissions` propagation or Provider bypass behavior; see
+  `docs/internal/development/plans/javascript-workflow-permissions-plan.md`.
+- Filesystem writes, create, rename, delete, chmod, watch, recursive traversal,
+  globbing, or arbitrary host roots.
+- Node/Bun/Deno filesystem compatibility or package/module loading.
+- Direct process, shell, network, connector, environment-variable, or secret
+  APIs.
+- Returning, checkpointing, recording, or serializing open handles or raw bytes.
+- `agent.run({content})`, video Provider negotiation, or dashboard media preview.
+- Unrelated input-watcher, source-loading, Work staging, or Petri refactoring.
+
+## Original documents
+
+- `docs/internal/development/plans/dynamic-workflows/dynamic-workflow-design.md`
+- `docs/internal/standards/code/planning-standards.md`
+
+## Delivery boundary
+
+Implementation is complete only when the runtime behavior, injected filesystem
+edge, Factory Session and standalone compositions, safe observations, replay,
+published contracts, generated artifacts, documentation, and required CI are
+terminal and passing; blocking review feedback and conflicts are resolved; and
+the pull request is merged.

--- a/docs/internal/development/plans/javascript-workflow-permissions-plan.md
+++ b/docs/internal/development/plans/javascript-workflow-permissions-plan.md
@@ -1,0 +1,204 @@
+# JavaScript Child Permission Override Plan
+
+## Status
+
+Proposed. This document is an implementation plan only.
+
+## Problem statement
+
+JavaScript workflows can author `agent.run({skipPermissions: true})`, but the
+behavior is not consistent or fully published:
+
+- The canonical Factory Session path carries the value through Factory Runtime,
+  Worker Sessions, Workers, and Providers.
+- The standalone JavaScript direct child executor records the value but drops it
+  before constructing `workers.ProviderInferenceRequest`.
+- Native Claude, Codex, Agy, and ACP routes already have provider-specific
+  bypass behavior.
+- The JavaScript runtime accepts and validates the boolean, but the published
+  JavaScript call-behavior contract omits it.
+- Its precedence relative to JavaScript `policy.mode` is implicit.
+
+Workflow authors need one explicit, child-scoped break-glass control that works
+the same way in every supported JavaScript execution composition.
+
+## Customer outcome
+
+An author can set `skipPermissions: true` for one child to deliberately bypass
+that child's Provider approval and sandbox restrictions regardless of
+JavaScript policy mode. The override does not alter sibling behavior or disable
+routing and resource controls.
+
+## Product decisions
+
+1. `skipPermissions?: boolean` remains the public field.
+2. `true` is valid under every recognized `policy.mode` and overrides Provider
+   approval and sandbox restrictions for that child.
+3. The override does not mutate Factory Session policy or affect siblings.
+4. Model/reasoning allowlists, fanout, concurrency, duration, token, and other
+   resource budgets continue to apply.
+5. Omission and `false` preserve the effective policy and Provider defaults.
+6. The field does not grant direct JavaScript VM filesystem, process, module,
+   shell, or network access. Those capabilities have separate contracts.
+7. A Provider route that cannot truthfully honor the bypass fails before child
+   execution rather than silently ignoring it.
+
+## Recommended authoring UX
+
+```javascript
+const result = await agent.run({
+  label: "autonomous-operator",
+  prompt: "Complete the operation without interactive approval.",
+  skipPermissions: true,
+});
+```
+
+The boolean is intentionally visually loud and localized to the child request.
+No additional policy-mode change is required.
+
+## UX comparison
+
+| Shape | Advantages | Costs | Decision |
+| --- | --- | --- | --- |
+| `skipPermissions: true` on `agent.run` | Already accepted, concise, child-scoped, and clearly signals danger. | Provider-specific semantics often bypass both approvals and sandboxing. | Retain and make consistent. |
+| Workflow-wide `skipPermissions` | Concise for fully autonomous workflows. | Easy to grant accidentally and difficult to attribute to one child. | Reject. Authors opt in per child. |
+| New `DANGER_FULL_ACCESS` policy mode | Makes danger visible in policy projection. | Conflates a workflow/session default with a one-child Provider override. | Do not require it for this field. |
+| Nested `permissions` object | Extensible. | Adds a second vocabulary before bounded permission semantics are established. | Defer. |
+
+## Work stories
+
+### Story 1 — Standalone and Factory Session parity
+
+As a JavaScript workflow author, I receive the same permission-bypass behavior
+whether the workflow runs through a canonical Factory Session or the supported
+standalone JavaScript composition.
+
+Acceptance criteria:
+
+- A boolean value is preserved from static or dynamically constructed
+  `agent.run` objects through normalization and dispatch.
+- The standalone direct child executor copies the field into
+  `workers.ProviderInferenceRequest`.
+- The canonical Factory Runtime and Worker Sessions path remains equivalent.
+- Omission and `false` arrive at Providers as false.
+- Focused tests prove the value at the Provider boundary, not only on an
+  intermediate Factory Runtime struct.
+
+### Story 2 — Explicit override precedence
+
+As a workflow author, I can deliberately override permission and sandbox
+restrictions for one child under any JavaScript policy mode without changing
+unrelated policy controls.
+
+Acceptance criteria:
+
+- Every recognized `policy.mode` accepts `skipPermissions: true`.
+- Permission and sandbox denials do not reject that child solely because of the
+  effective policy mode.
+- Model/reasoning allowlists and resource budgets continue to reject requests
+  that exceed them.
+- Siblings that omit the field continue to use normal policy evaluation.
+- The override never becomes mutable session-global state.
+- Resume and replay preserve the authored value on the corresponding dispatch.
+
+### Story 3 — Provider capability truth
+
+As an operator, I receive the requested bypass or a clear pre-execution failure;
+the system never silently degrades it.
+
+Acceptance criteria:
+
+- Claude, Codex, and Agy command construction emits the exact supported bypass
+  flag when requested.
+- ACP permission selection chooses the existing bypass behavior when requested.
+- A Provider without bypass support fails before starting the child attempt with
+  a stable capability diagnostic.
+- Diagnostics identify the Provider capability mismatch without exposing the
+  prompt, credentials, or raw command line.
+
+### Story 4 — Published and observable contract
+
+As an author or operator, I can discover and inspect whether permission bypass
+was requested and used.
+
+Acceptance criteria:
+
+- Static and dynamic validation accept only a boolean; non-boolean values fail
+  before dispatch with the existing safe field-level diagnostic.
+- The authored JavaScript symbol catalog, call-behavior descriptor, schemas,
+  examples, errors, and generated package projection include the field.
+- CLI reference docs describe the field as a dangerous child-level override
+  that does not disable routing or resource limits.
+- Dispatch records, events, recordings, and replay retain the boolean without
+  exposing Provider command lines or sensitive payloads.
+- Preview may warn about a literal `true` value but does not reject it because of
+  policy mode.
+
+## Implementation plan
+
+### Contracts and validation
+
+- Keep `skipPermissions` in the closed JavaScript child field set and make its
+  policy precedence explicit in Factory Runtime's orchestrator contract.
+- Add the optional boolean and its typed error case to the authored JavaScript
+  call-behavior descriptor and `contracts/javascript/runtime-api.json`.
+- Regenerate derived contract artifacts from canonical sources.
+
+### Runtime and execution
+
+- Preserve the existing canonical Factory Runtime/Worker Sessions propagation.
+- Copy `SkipPermissions` in
+  `pkg/services/factory_sessions/internal/execution/direct_child_executor.go`.
+- Keep Provider-specific flags and ACP permission behavior owned by Providers.
+- Add capability detection or a stable unsupported outcome before Provider
+  execution where a route cannot honor the request.
+
+### Observation and documentation
+
+- Preserve the boolean in JavaScript child records and canonical dispatch/event
+  projections through recording and replay.
+- Update `docs/reference/javascript-workflows.md` and
+  `docs/reference/orchestrators.md` with the exact precedence and limitations.
+
+## Test plan
+
+- JavaScript normalization tests for omission, false, true, and non-boolean
+  dynamic values.
+- Factory Session integration tests for canonical and standalone execution.
+- Provider adapter tests that inspect Claude/Codex/Agy command arguments and ACP
+  permission decisions.
+- Policy tests proving the override applies under every mode while routing and
+  resource limits remain enforced.
+- Recording/replay tests proving child scoping and retained observation.
+- JavaScript contract and packaged CLI documentation smoke tests.
+
+## Quality gates
+
+- `go test ./pkg/services/factory_runtime/...`
+- `go test ./pkg/services/factory_sessions/internal/execution/...`
+- `go test ./pkg/services/providers/...`
+- `make javascript-contract-smoke`
+- `make contracts-check`
+- `make docs-reference-smoke`
+- `make verify-fast`, followed by `make verify-pr`
+
+## Out of scope
+
+- Direct JavaScript filesystem operations; see
+  `docs/internal/development/plans/javascript-workflow-file-operations-plan.md`.
+- Workspace-write roots, filesystem mutation, shell/process access, network
+  globals, secrets, or connectors.
+- A workflow-wide permission bypass default.
+- Unrelated Provider, Worker, or Petri orchestration refactoring.
+
+## Original documents
+
+- `docs/internal/development/plans/dynamic-workflows/dynamic-workflow-design.md`
+- `docs/internal/standards/code/planning-standards.md`
+
+## Delivery boundary
+
+Implementation is complete only when canonical and standalone execution,
+Provider behavior, published contracts, generated artifacts, documentation,
+recording/replay behavior, and required CI are terminal and passing; blocking
+review feedback and conflicts are resolved; and the pull request is merged.

--- a/docs/internal/development/plans/linear-github-poller-validation-plan.md
+++ b/docs/internal/development/plans/linear-github-poller-validation-plan.md
@@ -1,0 +1,885 @@
+# Linear and GitHub Poller Validation Plan
+
+## Status
+
+Proposed.
+
+## Problem statement
+
+The Factory runtime contains a partially exercised hosted Linear poller and a
+generic script-poller path, but customers and operators cannot yet prove from
+the product that a configured poller can authenticate, collect the intended
+external changes, admit exactly-once Work across polling and restart, and
+explain its current health. GitHub has no first-class hosted poller contract.
+
+## Customer ask
+
+Make hosted-source polling trustworthy by:
+
+- validating the existing Linear integration against a controlled real Linear
+  workspace as well as deterministic test doubles;
+- exposing poller configuration and runtime health in the dashboard;
+- making configuration safely editable without exposing credentials;
+- adding a first-class GitHub poller that invokes the `gh` CLI through the
+  repository's injected command-runner boundary; and
+- retaining repeatable test evidence for success, filtering, deduplication,
+  restart, cancellation, authentication failure, rate limiting, and malformed
+  provider responses.
+
+For this plan, “GitHub poller using the `gh` CLI as a function” means an
+Automations-owned hosted-source adapter that builds and invokes a controlled
+`gh` command through an injected command runner. It does not mean asking users
+to author shell glue or interpolating untrusted Factory fields into a shell
+command. If the intended product shape is instead a reusable authored Factory
+function, that should be resolved before Story 4 without changing the Linear
+validation work.
+
+## Security prerequisite
+
+The Linear personal API key supplied with the request must be revoked and
+replaced before any test execution. It was transmitted in conversation text
+and must be treated as exposed. The replacement must never be committed,
+included in a fixture, passed on a command line, printed in logs, captured in a
+golden, or rendered in the dashboard.
+
+Live tests will receive credentials only through the existing `auth.secretRef`
+resolution path. Developer machines may resolve the reference from an
+`INFINITE_YOU_SECRET_<NORMALIZED_REF>` environment variable or a mode-`0600`
+runtime secret file. CI will use a protected secret and an isolated test
+environment. Errors, command requests, HTTP recordings, and status projections
+must prove that resolved secret values are redacted.
+
+## Current repository findings
+
+The repository already has more implementation than the original request
+assumed:
+
+- Factory Definitions and OpenAPI define `HOSTED_WORKER`, provider `LINEAR`,
+  `auth.secretRef`, poll interval, team/state filters, Work mapping, and an
+  optional assignee claim field.
+- The worker editor renders and edits every current hosted Linear field, maps
+  server validation errors to those fields, and persists them through the
+  canonical Factory Definition mutation.
+- Automations owns hosted-source polling, GraphQL request construction,
+  provider-side team/state filtering, cursor pagination, issue-to-Work mapping,
+  atomic checkpoint files, secret resolution, supervision, and cancellation.
+- Unit tests cover filtered submissions, pagination, checkpoint recovery,
+  duplicate suppression, submission failure, secret precedence, redaction,
+  retry, and cancellation.
+- A functional test starts a real runtime against an `httptest` Linear server
+  and observes admitted Work.
+- The Automations root and a typed HTTP adapter expose detached lifecycle and
+  status operations internally, but those operations are not authored as
+  public OpenAPI paths and are not available in the dashboard.
+- Existing functional poller coverage uses an HTTP server helper,
+  `UseMockWorkers`, channel timeouts, and a test-owned secret file. It is useful
+  characterization evidence but does not satisfy the repository's current
+  preferred functional-test construction for new coverage.
+- There is no real-provider test lane, provider contract fixture harvested
+  from Linear, operator-visible last-poll outcome, or GitHub hosted-provider
+  implementation.
+- Script pollers can already run `gh` indirectly if a user supplies a script,
+  but this provides no typed GitHub configuration, normalized payload,
+  provider-specific checkpoint semantics, readiness probe, or dashboard
+  health.
+
+Baseline observed while writing this plan on 2026-08-10:
+
+```text
+go test ./pkg/services/automations/... ./tests/functional/automations ./tests/functional/workstations/poller
+  PASS
+
+bunx --no-install vitest run \
+  src/features/current-selection/worker-selection/components/editable/fields/worker-editable-configuration-hosted-fields.test.tsx \
+  src/features/current-selection/worker-selection/lib/worker-editable-validation.test.ts \
+  src/api/factory-definition/api.test.ts
+  3 files, 73 tests PASS
+```
+
+## External contracts checked
+
+- Linear documents its GraphQL endpoint, personal-key Authorization header,
+  GraphQL error-array handling, provider-side filtering guidance, and preference
+  for updated-first polling in its
+  [GraphQL getting-started guide](https://linear.app/developers/graphql).
+- Linear documents Relay-style `first`/`after` pagination, `hasNextPage`,
+  `endCursor`, and `updatedAt` ordering in its
+  [pagination guide](https://linear.app/developers/pagination).
+- GitHub CLI documents JSON issue fields and repository/filter arguments in
+  [`gh issue list`](https://cli.github.com/manual/gh_issue_list).
+- GitHub CLI documents GraphQL invocation and cursor pagination requirements in
+  [`gh api`](https://cli.github.com/manual/gh_api).
+- GitHub documents `GH_TOKEN` as the non-interactive authentication environment
+  for CLI automation in
+  [Using GitHub CLI in workflows](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-github-cli).
+
+## Intended outcome
+
+A customer can configure a Linear or GitHub poller in a Factory Definition,
+validate its non-secret settings and credentials, run or start it, see its
+sanitized live health, and observe external issues or pull requests arrive as
+canonical Work exactly once per external version. Restart resumes from a
+durable checkpoint. Provider outages and malformed responses degrade the
+individual source with actionable status without leaking credentials or
+silently losing acknowledged Work.
+
+The same provider-neutral lifecycle and observation model serves Linear and
+GitHub. Provider-specific adapters retain responsibility for API/CLI invocation
+and payload mapping; Automations remains the owner of polling, checkpoint,
+reconciliation, and invocation-schedule policy.
+
+## Scope
+
+### In scope
+
+- A repeatable, opt-in live Linear conformance lane against a dedicated test
+  workspace and team.
+- Corrections found by the live Linear exercise, including provider-aware retry
+  and explicit bootstrap/checkpoint semantics.
+- A public Automation Source API for configured-source inventory, sanitized
+  configuration, readiness/probe, lifecycle control, and runtime observation.
+- A dashboard Automation Sources view plus integration with the existing worker
+  editor.
+- A GitHub hosted-source provider implemented with `gh` through an injected
+  command runner.
+- GitHub issues and pull requests in one configured repository for v1, with
+  explicit resource-type, state, label, and Work mapping filters.
+- Deterministic unit, integration, contract, functional, UI, failure, restart,
+  and live-provider evidence.
+- Customer documentation and a non-secret example Factory for each provider.
+
+### Out of scope
+
+- Writing back to Linear or GitHub from admitted Work.
+- General bidirectional synchronization or conflict resolution.
+- Webhook ingestion; polling is the behavior under validation. Linear's own
+  guidance prefers webhooks for broad production update flows, so a future
+  webhook lane may replace frequent polling without changing Work mapping.
+- Arbitrary GitHub search syntax or arbitrary `gh` flags in Factory
+  Definitions. V1 uses typed fields to avoid command injection and unstable
+  output contracts.
+- Polling multiple GitHub repositories from one source. Customers configure
+  one source per repository so identity, status, and checkpoints stay clear.
+- Persisting credential values in Factory Definitions or returning them from
+  any API.
+- Making live third-party tests part of the ordinary offline PR gate.
+
+## Canonical state and ownership
+
+| Concern | Canonical owner | Projection or effect boundary |
+| --- | --- | --- |
+| Authored provider, filters, mapping, interval, bootstrap policy, and secret reference | Factory Definitions | OpenAPI Factory document and existing worker editor |
+| Source lifecycle, poll policy, observation, reconciliation, and checkpoint decision | `pkg/services/automations` | Public Automations root |
+| Linear GraphQL request/response translation | Automations hosted-sources Linear adapter | Injected HTTP doer |
+| GitHub query and output translation | Automations hosted-sources GitHub adapter | Dedicated `HostedGitHubCommandRunner` edge invoking `gh` directly |
+| Canonical Work admission and duplicate/upsert behavior | Work service | Automations uses the public Work submission contract |
+| Runtime source health | Automations source observation state | HTTP/CLI projections and dashboard query cache |
+| Dashboard edit state | Feature-owned worker draft operations | A draft only; the saved Factory Definition remains canonical |
+| Dashboard source list/status | Automations API response | A read projection; it does not mutate Factory Definition state |
+| Checkpoint persistence | Automations-owned checkpoint contract | Atomic filesystem implementation supplied through `edges.Edges` |
+| Secrets | Operator environment or runtime secret file | Resolver returns a value only to the provider effect call |
+
+The dashboard must not merge runtime status into the saved Factory document.
+Editing uses the existing Factory Definition save operation. Probe/start/stop
+use Automations operations. Query invalidation joins those views without
+creating a second UI-owned source of truth.
+
+## Proposed public behavior
+
+### Source identity and configuration
+
+Every poller source has a stable identity derived from the Factory Session,
+poller workstation, and worker. Mutable display names must not be the only
+durable identity when public IDs are available.
+
+The Linear configuration keeps the current fields and adds an explicit
+bootstrap policy:
+
+- `LATEST_ONLY`: establish a checkpoint without importing pre-existing issues;
+- `BACKFILL`: admit matching existing issues up to a required bounded limit.
+
+There must be no implicit unbounded first-run import. Existing definitions that
+omit the field retain a documented compatibility default chosen and locked by
+contract tests before implementation proceeds.
+
+The GitHub configuration should contain:
+
+- repository identity in canonical `owner/name` form;
+- resource types: `ISSUE`, `PULL_REQUEST`, or both;
+- optional states and labels expressed as typed arrays;
+- poll interval and explicit bootstrap policy/backfill limit;
+- deterministic Work type/state mapping; and
+- `auth.secretRef`, resolved to `GH_TOKEN` only for the child command.
+
+The adapter invokes `gh api graphql` or an equivalently stable `gh` JSON
+surface with an explicit repository and selected fields. `gh api graphql`
+supports cursor pagination when the query accepts an end cursor and requests
+page information. The implementation must parse raw JSON itself and must not
+depend on locale-sensitive terminal text, user aliases, the current Git remote,
+or ambient interactive authentication.
+
+### Source observation
+
+Each source status response should include only safe facts:
+
+- identity, provider, configured desired state, and observed lifecycle state;
+- current opaque checkpoint/version;
+- last attempt, last success, and next scheduled attempt timestamps;
+- consecutive failure count and retry-after timestamp;
+- last result counts: fetched, matched, submitted, duplicate, and rejected;
+- typed last error category and sanitized actionable message; and
+- readiness prerequisites such as missing `gh`, unresolved secret, invalid
+  repository, or inaccessible Linear team.
+
+It must never include a resolved credential, Authorization header, child
+process environment, complete command line containing secrets, or raw provider
+body that might contain private data.
+
+### Probe and run-once
+
+Add an explicit provider probe that validates dependency availability,
+credential resolution, remote access, configured team/repository and filters,
+and response decoding without admitting Work or advancing a checkpoint.
+
+Add a run-once operation for deterministic operator verification. It executes
+one normal poll cycle, uses the same checkpoint/admission path as supervision,
+returns sanitized counts, and cannot overlap another cycle for the same source.
+This avoids treating “wait for the background loop” as the only test method.
+
+Probe and run-once are external side effects and must be labeled as such in the
+API and dashboard. Saving a Factory Definition remains inert.
+
+## Work stories
+
+### Story 1: Lock provider-neutral poll semantics
+
+As a customer, I can predict what the first poll, repeated poll, concurrent
+poll, and restarted poll will admit.
+
+Acceptance criteria:
+
+- Bootstrap behavior is explicit and bounded; compatibility behavior for
+  existing Linear definitions is documented and tested.
+- A source version is identified by provider item ID plus update version/time,
+  with a deterministic tie-breaker for equal timestamps.
+- A checkpoint advances only after all matched Work in the cycle receives a
+  terminal accepted or duplicate admission outcome.
+- Rejected or unavailable admission does not skip the provider version.
+- Repeating a cycle or restarting from the committed checkpoint does not admit
+  another Work version.
+- Two run-once/background attempts for one source cannot race checkpoint
+  advancement or duplicate admission.
+- Cancellation stops network/process work and all supervised goroutines join.
+
+Evidence:
+
+- Table-driven pure ordering/checkpoint tests including equal timestamps,
+  update-to-an-existing-ID, empty pages, multi-page checkpoint search, and
+  backfill bounds.
+- Integration tests with an injected clock, checkpoint store, and Work
+  submitter; no sleeps or timeout-padded polling loops.
+- Race/stress coverage for run-once versus supervision and checkpoint commit.
+
+### Story 2: Prove and harden the Linear adapter
+
+As a customer, I can trust that a configured Linear source uses the documented
+API correctly and degrades safely when Linear is unavailable.
+
+Acceptance criteria:
+
+- Requests use `https://api.linear.app/graphql`, the correct personal-key
+  Authorization form, Relay cursor pagination, `updatedAt` ordering, and
+  provider-side team/state filtering.
+- A GraphQL `errors` array fails the cycle even when HTTP status is 200 or
+  partial data is present.
+- 401/403, 429/rate-limited, 5xx, timeout, malformed JSON, missing/null required
+  fields, and pagination anomalies map to typed safe outcomes.
+- Rate limiting honors provider delay metadata when available; other retry uses
+  bounded exponential backoff with jitter and a production-safe minimum. The
+  current 25-250 ms restart loop is not retained for live provider failures.
+- The poller emits deterministic Work ID, trace/version identity, payload, tags,
+  mapping, and optional assignee claim data.
+- Logs include source identity, latency/outcome, counts, and retry decision but
+  not API keys or private issue bodies.
+
+Evidence:
+
+- A stateful fake Linear GraphQL server that verifies the exact request and
+  exercises every page and failure class.
+- Sanitized contract fixtures derived from real Linear responses, with all
+  tenant/user/content values replaced.
+- Existing Linear unit and supervisor tests retained or rewritten around the
+  provider-neutral semantics instead of topology assertions.
+
+### Story 3: Exercise Linear live without making CI flaky
+
+As a maintainer, I can run one command against the dedicated Linear test
+workspace and receive a self-cleaning conformance report.
+
+Acceptance criteria:
+
+- The test refuses to run unless an explicit live-test flag, test workspace
+  identity, and secret reference are supplied.
+- The harness discovers and prints only non-secret team/state identifiers,
+  creates a uniquely marked test issue, and records cleanup ownership.
+- A matching issue is admitted with the expected Work identity, state, payload,
+  and tags.
+- An unchanged second poll produces no new Work; an issue update produces
+  exactly one new external version; restart from the checkpoint produces no
+  duplicate.
+- A non-matching team/state issue is not admitted.
+- Cancellation shuts the source down cleanly and a subsequent start resumes.
+- Cleanup closes/archives or deletes all items created by the run even after a
+  failed assertion. Cleanup failure is reported with the marker needed for
+  manual repair.
+- Test output and retained artifacts are scanned for the resolved secret.
+
+Evidence:
+
+- An opt-in live test target such as `make test-live-linear` outside ordinary
+  PR CI.
+- A scheduled/manual protected CI job using the dedicated test workspace,
+  concurrency group, least-privilege replacement credential, and retained
+  sanitized report.
+- A short checked-in runbook with setup, expected output, cleanup, and token
+  rotation steps.
+
+### Story 4: Add a GitHub `gh` hosted-source adapter
+
+As a customer, I can poll one GitHub repository for changed issues and pull
+requests without authoring a custom script.
+
+Acceptance criteria:
+
+- `GITHUB` is a supported hosted-worker provider with a provider-specific,
+  generated Factory Definition/OpenAPI contract.
+- Configuration supports repository, resource types, typed filters, interval,
+  bootstrap/backfill policy, and Work mapping.
+- The adapter calls `gh` through a directly injected, dedicated
+  `HostedGitHubCommandRunner` edge,
+  passes the token only in `GH_TOKEN`, selects explicit JSON fields, and never
+  invokes a shell.
+- Missing executable, unsupported `gh` version, unauthenticated/unauthorized
+  access, missing repository, rate limit, timeout/cancellation, non-zero exit,
+  stderr content, malformed JSON, and pagination failure are typed and safely
+  observable.
+- Issues and pull requests have distinct stable Work identities and normalized
+  payloads; updates generate one new trace/version and unchanged items do not.
+- The adapter does not rely on current directory Git remotes, user aliases,
+  terminal locale, or existing `gh auth login` state.
+- GitHub Enterprise hostname support is either included explicitly and tested
+  or rejected with a clear validation message in v1.
+
+Evidence:
+
+- Command-runner fixture tests assert exact executable, argument array,
+  environment, work directory, cancellation, stdout parsing, and stderr
+  redaction.
+- Golden normalized issue/PR payloads from sanitized `gh` JSON fixtures.
+- Multi-page, equal-timestamp, issue-versus-PR, filter, checkpoint, restart, and
+  concurrent-cycle tests shared with Linear where semantics are identical.
+- One functional `root.BuildProcess` path with the dedicated command-runner effect
+  replaced only through `edges.Edges`.
+
+### Story 5: Expose source inventory, health, probe, and lifecycle publicly
+
+As an operator, I can inspect and control configured sources without reading
+logs or checkpoint files.
+
+Acceptance criteria:
+
+- Authored OpenAPI paths and schemas expose list/get status, probe, run-once,
+  start, stop, and wait operations through the Automations service root.
+- Inventory is derived from the selected/current Factory Definition while live
+  observation remains Automations-owned session state.
+- Responses use stable provider-neutral values and typed failures; no HTTP
+  handler reaches into private hosted-source implementations.
+- CLI commands expose equivalent customer behavior and deterministic JSON.
+- Start/stop/run-once operations are idempotent or return an explicit conflict
+  for an unsafe overlap.
+- Generated Go and TypeScript artifacts, HTTP handlers/mappings, CLI adapters,
+  and contract examples remain aligned.
+
+Evidence:
+
+- Service operation tests, domain-to-HTTP/CLI mapping tests, OpenAPI contract
+  tests, error/status mapping tests, and CLI/API parity fixtures.
+- Functional customer flows built with `root.BuildProcess` and
+  `Process.Execute`, preferring CLI over HTTP except for API-owned contract
+  cells.
+- Safe structured-operation logging tests for every mutating or live-effect
+  operation.
+
+### Story 6: Make pollers operable in the dashboard
+
+As an operator, I can configure a source, validate it, and understand whether
+it is working from the dashboard.
+
+Acceptance criteria:
+
+- An Automation Sources view lists configured sources with provider,
+  workstation/worker, desired and observed state, last success, next attempt,
+  counts, and an actionable sanitized failure summary.
+- Selecting a source links to the existing worker editor; the current Linear
+  fields are retained rather than reimplemented.
+- The editor adds GitHub fields using generated types and shared form
+  primitives, with typed selectors for resource types and filters.
+- Secret input edits only the reference. The UI never fetches, reveals, or
+  tests the credential value directly.
+- Probe, run-once, start, and stop actions use Automations mutations with clear
+  pending, success, failure, stale-session, and conflict states.
+- Status refreshes from the API/query cache and does not become component-local
+  canonical state.
+- Empty, loading, disconnected, stopped, degraded, and running states are
+  accessible, keyboard operable, localized, and usable at narrow viewports.
+
+Evidence:
+
+- Pure draft and projection tests; hook/mutation and query-invalidation tests;
+  focused component tests for forms, statuses, and actions; and one browser
+  interaction from edit/save through probe/run-once result.
+- Accessibility checks for labels, descriptions, live status announcements,
+  focus restoration, and disabled/busy controls.
+- Manual browser inspection at desktop and narrow viewport sizes against the
+  deterministic fake-provider backend.
+
+### Story 7: Publish examples, operations guidance, and ongoing conformance
+
+As a customer and maintainer, I can set up and troubleshoot either provider
+without guessing about secrets, filters, first-run behavior, or test scope.
+
+Acceptance criteria:
+
+- Public reference docs explain poller workstation/worker relationships,
+  secret references, bootstrap/backfill, mappings, checkpoints, lifecycle,
+  probe/run-once, and safe troubleshooting.
+- Examples contain placeholder secret references only and include Linear plus
+  GitHub issue/PR configurations.
+- Maintainer docs distinguish offline deterministic gates from opt-in live
+  conformance and document test-account ownership and cleanup.
+- A compatibility note explains the first-run behavior of existing Linear
+  definitions.
+- Live Linear and GitHub jobs have an explicit owner, rotation schedule,
+  concurrency control, failure notification, and quarantine policy; a broken
+  external service does not silently disable the lane.
+
+Evidence:
+
+- `make docs-reference-smoke`, example validation, and generated example/schema
+  checks.
+- A recorded successful run of each live-provider lane before release.
+
+## Test matrix
+
+| Behavior | Pure/unit | Provider integration | `root.BuildProcess` functional | UI/browser | Live provider |
+| --- | --- | --- | --- | --- | --- |
+| Config validation and generated contract | Yes | No | CLI validate/save | Form validation/save | Probe config |
+| First-run latest-only/backfill | Yes | Stateful fake | Run-once | Result summary | Yes |
+| Provider filtering | Yes | Exact query/command | Admitted Work | Config/status | Yes |
+| Pagination and equal-time ordering | Yes | Multi-page fake | Representative case | No | Bounded sample |
+| No-change duplicate suppression | Yes | Two cycles | Restart case | Counts | Yes |
+| Existing item updated | Yes | Versioned fixture | Work upsert/lineage | Counts/detail link | Yes |
+| Checkpoint commit after admission | Yes | Submit failure | Restart recovery | Failure status | Yes |
+| Authentication/authorization failure | Error mapping | 401/403 or command exit | Safe CLI error | Safe action error | Dedicated negative probe |
+| Rate limit/backoff | Policy | 429/provider fixture | Deterministic clock | Retry status | Observe only; do not induce load |
+| Malformed/partial response | Decoder | Fixture | Safe failure | Degraded status | No |
+| Cancellation and shutdown | Supervisor | Blocking effect | Process lifecycle | Stop action | Yes |
+| Secret non-disclosure | Redactor | Headers/env/log capture | Output scan | DOM/network fixture scan | Artifact scan |
+| Missing `gh`/bad version | GitHub adapter | Command edge | CLI readiness | Prerequisite status | Environment probe |
+
+## Live Linear protocol
+
+1. Revoke the credential shared with the request and provision a replacement
+   for the dedicated `youagentfactory` test workspace.
+2. Create a dedicated test team/project and two workflow states: one matching
+   and one excluded. Do not use customer or personal production issues.
+3. Configure the Factory with a unique source ID, a conservative interval, and
+   `LATEST_ONLY`; run probe and record the discovered non-secret IDs.
+4. Create a uniquely marked issue after the checkpoint is established.
+5. Run one cycle and assert the complete admitted Work contract and source
+   status counts.
+6. Run again unchanged and assert zero new admission.
+7. Update title/body/state/assignee in controlled subcases and assert exactly
+   one new external version plus correct claim behavior.
+8. Restart the Factory Session from the durable checkpoint and assert no
+   duplicate.
+9. Create an excluded issue and prove provider/local filtering does not admit
+   it.
+10. Exercise a deliberately invalid secret reference through probe, verify the
+    typed/redacted error, then restore the valid reference.
+11. Stop the source and verify no new poll; start it and verify resume.
+12. Clean up every marked issue and scan logs/reports for the resolved key.
+
+Live testing must not intentionally trigger Linear rate limits. Rate-limit and
+outage behavior belongs to deterministic fakes; the live lane only verifies
+normal provider compatibility and a bounded authentication failure.
+
+## Live GitHub protocol
+
+1. Use a dedicated private repository and a fine-grained token limited to
+   metadata and read/write test issues/pull requests as required by the harness.
+2. Resolve the token from `auth.secretRef` into `GH_TOKEN`; verify probe reports
+   the expected `gh` version and repository access without exposing auth state.
+3. Establish a `LATEST_ONLY` checkpoint, create a uniquely marked issue and a
+   small test pull request, and run one cycle.
+4. Assert distinct normalized Work identities, mappings, payloads, tags, and
+   source status counts.
+5. Repeat unchanged, update each resource once, and restart from checkpoint to
+   prove no-change suppression and update versioning.
+6. Verify label/state/resource-type filters with excluded fixtures.
+7. Run negative probes for an inaccessible repository and invalid token in an
+   isolated invocation.
+8. Close the pull request and issues, remove its test branch, and scan all
+   retained artifacts for the token.
+
+## API and generated-artifact changes
+
+Expected authored changes:
+
+- Extend `HostedWorkerProvider` with `GITHUB`.
+- Add provider-specific GitHub config, resource type, mapping, filter, and
+  bootstrap-policy component fragments.
+- Add provider-neutral Automation Source identity/config summary,
+  observation/result, probe, run-once, and lifecycle request/response schemas.
+- Add Automations paths and operation IDs to `api/openapi-main.yaml`.
+- Extend the authored Worker schema with `github` configuration.
+
+Expected generated and handwritten consumers:
+
+- `api/openapi.yaml`;
+- generated Go HTTP server/client contracts;
+- `ui/src/api/generated/openapi.ts` and publishable UI client artifacts;
+- Automations HTTP mappings/handlers and CLI manifest/handlers;
+- Factory Definition decoders, validators, clone/compile/persistence paths;
+- existing worker-editor draft operations and the new Automation Sources
+  projection/hooks/components.
+
+Use `make generate-api` for direct contract consumers and
+`make interfaces-all` when publishable package schemas or clients change.
+Generated files must not be hand-edited.
+
+## Verification gates
+
+During implementation, run the narrowest package and feature tests for each
+story. Before merge, the expected shared gates are:
+
+```text
+go test ./pkg/services/automations/...
+go test ./pkg/services/factory_definitions/...
+go test ./pkg/transports/cli/...
+go test ./pkg/transports/http/...
+go test ./tests/functional/automations/...
+go test ./tests/functional/workstations/poller/...
+
+make generate-api
+make interfaces-all
+make api-smoke
+make docs-reference-smoke
+make ui-test
+make ui-lint
+make verify-fast
+make verify-pr
+make build-all
+
+make test-live-linear   # opt-in/protected environment only
+make test-live-github   # opt-in/protected environment only
+```
+
+New functional tests must construct with `root.BuildProcess` and execute with
+`Process.Execute` by default, prefer CLI for ordinary customer flows, and
+replace HTTP, command, filesystem, clock, and submission effects only through
+the exact `edges.Edges` ports. They must not add `MockWorkers` outside its
+owning test cells or use sleeps/timeouts where deterministic observation and
+injected clocks can prove the behavior.
+
+## Delivery sequencing
+
+1. Story 1 fixes semantics before either provider accumulates more behavior.
+2. Stories 2 and 3 prove Linear offline and live; correctness findings feed
+   back into the shared semantics.
+3. Story 4 adds GitHub against the now-proven provider-neutral contract.
+4. Story 5 publishes lifecycle/health operations once both adapters can project
+   the same observation model.
+5. Story 6 builds the dashboard over the public API and extends the existing
+   editor for GitHub.
+6. Story 7 finalizes customer examples, operator runbooks, and recurring live
+   conformance.
+
+Stories 1-3 are the minimum Linear confidence milestone. Story 4 can be a
+separate PR series. Stories 5-6 should be vertically sliced by observable
+operation where practical rather than delivered as one backend PR followed by
+one UI PR.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Exposed credential enters history or logs | Revoke before use; secret references only; automated output/artifact scans; redaction tests |
+| First poll imports an unexpected backlog | Explicit latest-only/backfill policy and mandatory bound |
+| Checkpoint advances before Work is durable | Commit only after terminal accepted/duplicate admissions; failure/restart tests |
+| Same timestamp or provider reorder loses work | Stable ID tie-breaker and multi-page/equal-time fixtures |
+| Fast restart loop hammers Linear/GitHub | Provider-aware delay, bounded exponential backoff, jitter, and visible retry time |
+| Live tests become flaky or destructive | Dedicated accounts, unique markers, serialized jobs, conservative intervals, cleanup ledger, offline PR gate |
+| `gh` behavior varies by locale/config/version | Explicit JSON fields, minimum supported version, controlled args/env, no shell/current-remote dependence |
+| Command injection through repository/filter fields | Typed validation and argument-array execution; no arbitrary query/flags or shell interpolation |
+| UI becomes a second source of truth | Factory Definition owns config; Automations owns observation; UI keeps only drafts/query projections |
+| Provider-private data leaks through status | Typed summaries/counts; sanitized errors; never return raw bodies/stdout/stderr |
+| OpenAPI, Go, and TypeScript drift | Authored components plus generation and parity gates |
+
+## Project-level acceptance criteria
+
+- The replacement Linear key is used only through a secret reference and the
+  originally shared key has been revoked.
+- Linear deterministic and live lanes prove matching admission, no-change
+  suppression, update versioning, filtering, checkpoint restart, cancellation,
+  and secret redaction.
+- GitHub issues and pull requests produce the same provider-neutral lifecycle
+  and checkpoint guarantees through an injected, shell-free `gh` invocation.
+- Customers can edit provider configuration, probe it, run one cycle, control
+  lifecycle, and inspect safe health from supported CLI/API/dashboard surfaces.
+- Factory Definitions remain canonical for authored configuration;
+  Automations remains canonical for runtime polling state; Work remains
+  canonical for admission.
+- The ordinary PR gate is deterministic and network-independent; protected
+  live jobs provide real compatibility evidence without becoming an excuse to
+  omit provider fakes.
+- All required focused tests, generated-artifact checks, documentation checks,
+  `verify-pr`, and relevant build gates are terminal and passing.
+- Delivery continues through blocking review feedback, conflict resolution,
+  terminal green CI, and actual PR merge. A pushed branch, open PR, approval,
+  or green CI without merge is not completion.
+
+## Work-story task packets
+
+Every implementation task submitted to You Agent Factory workers must retain
+the headings below and point back to this plan.
+
+### Task packet: provider-neutral poll semantics
+
+# problem statement
+
+Current hosted polling does not publish an explicit bounded first-run policy or
+a provider-neutral version/checkpoint contract.
+
+## customer ask
+
+Make first poll, repeated poll, concurrent poll, and restart behavior
+predictable before adding another provider.
+
+## solution
+
+Define shared bootstrap, external-version ordering, checkpoint commit, cycle
+exclusion, retry observation, and cancellation behavior in Automations.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\linear-github-poller-validation-plan.md`
+
+# changes
+
+## package changes
+
+- Extend Automations contracts and hosted-source internals without moving Work
+  admission or Factory Definition ownership.
+
+## contracts
+
+- Add bootstrap/backfill and safe cycle-observation values.
+
+## services
+
+- Implement provider-neutral checkpoint/version and cycle-exclusion policy.
+
+## API changes
+
+- Extend authored Factory worker config for bootstrap behavior and regenerate
+  consumers.
+
+## tests
+
+- Add pure ordering, checkpoint, admission failure, concurrency, restart, and
+  cancellation coverage.
+
+### Task packet: Linear conformance and hardening
+
+# problem statement
+
+The Linear adapter passes mocked tests but has no live conformance evidence and
+uses an unsafe production retry floor.
+
+## customer ask
+
+Prove Linear compatibility and safe failure behavior against documented and
+real responses.
+
+## solution
+
+Build a stateful GraphQL contract server, harden decoding/retry/observability,
+and add a protected self-cleaning live test lane.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\linear-github-poller-validation-plan.md`
+
+# changes
+
+## package changes
+
+- Harden the Automations-owned Linear adapter and live-test support.
+
+## contracts
+
+- Preserve existing Linear public fields while locking bootstrap and typed
+  failure behavior.
+
+## services
+
+- Use provider-aware backoff and safe operation observations.
+
+## API changes
+
+- No provider-specific lifecycle API; Linear projects the shared observation.
+
+## tests
+
+- Add exact GraphQL, response fixture, retry, log-redaction, root-composition,
+  and opt-in live Linear tests.
+
+### Task packet: GitHub `gh` hosted source
+
+# problem statement
+
+GitHub polling requires user-authored scripts and lacks typed config,
+normalization, checkpoint behavior, and readiness diagnostics.
+
+## customer ask
+
+Poll GitHub issues and pull requests as a first-class hosted source using the
+`gh` CLI.
+
+## solution
+
+Add a GITHUB hosted provider and Automations adapter that invokes controlled
+JSON `gh` commands through the injected command runner.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\linear-github-poller-validation-plan.md`
+
+# changes
+
+## package changes
+
+- Add GitHub config/validation/clone/compile paths and an Automations-owned
+  GitHub adapter wired through a dedicated `HostedGitHubCommandRunner` process
+  edge.
+
+## contracts
+
+- Add repository, resource type, filters, mapping, interval, bootstrap, and
+  provider enum values.
+
+## services
+
+- Add `gh` probe, collection, normalization, and supervision behind the shared
+  hosted-source service.
+
+## API changes
+
+- Extend Worker OpenAPI and regenerate Go/TypeScript/package consumers.
+
+## tests
+
+- Add exact command request, JSON fixtures, errors, pagination, filters,
+  checkpoint/restart, functional, and opt-in live GitHub coverage.
+
+### Task packet: public source operations
+
+# problem statement
+
+Operators cannot inspect or control configured pollers through public product
+surfaces.
+
+## customer ask
+
+List, probe, run once, start, stop, wait for, and inspect Automation Sources.
+
+## solution
+
+Publish provider-neutral Automations operations through authored OpenAPI and
+equivalent CLI commands.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\linear-github-poller-validation-plan.md`
+
+# changes
+
+## package changes
+
+- Extend the Automations root, HTTP adapter, CLI adapter, and safe operation
+  logging.
+
+## contracts
+
+- Add inventory, observation, probe, run-once, and lifecycle values.
+
+## services
+
+- Derive inventory from current Factory config and observation from
+  Automations runtime state.
+
+## API changes
+
+- Author Automations paths/components and regenerate all consumers.
+
+## tests
+
+- Add service, mapping, error, CLI/API parity, OpenAPI, and standards-compliant
+  functional coverage.
+
+### Task packet: dashboard poller operations
+
+# problem statement
+
+The dashboard can edit current Linear fields but cannot expose source inventory
+or live operational health and has no GitHub form.
+
+## customer ask
+
+Configure, validate, run, control, and troubleshoot pollers from the website.
+
+## solution
+
+Add an Automation Sources view over the public API, retain the existing Linear
+editor, and add GitHub fields and source actions using shared UI primitives.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\linear-github-poller-validation-plan.md`
+
+# changes
+
+## package changes
+
+- Add feature-owned API adapters, projections, hooks, operations, localized
+  messages, and components.
+
+## contracts
+
+- Consume generated Factory Definition and Automations schemas without UI-only
+  domain types.
+
+## services
+
+- Keep config mutation in the Factory Definition save operation and live
+  actions in Automations mutations.
+
+## API changes
+
+- No dashboard-only endpoints; use the generated public API.
+
+## tests
+
+- Add draft/projection, hook/mutation, component, accessibility, responsive,
+  and browser-flow evidence.

--- a/docs/internal/development/plans/live-factory-session-controls.md
+++ b/docs/internal/development/plans/live-factory-session-controls.md
@@ -1,0 +1,571 @@
+# Live Factory Session Resource and Workstation Controls Plan
+
+## Status
+
+Proposed.
+
+## Problem statement
+
+An active Factory Session cannot currently change resource capacity or enable or
+disable an authored workstation without replacing or restarting its Factory
+Runtime, and the existing replacement and lifecycle-control paths do not provide
+one durable, revisioned timeline that both Petri and JavaScript execution can
+reconstruct safely.
+
+## Customer ask
+
+Provide explicit, session-scoped CLI and API controls that:
+
+- set a resource's capacity by its stable resource ID, such as `reviewers`;
+- enable or disable a workstation by its stable workstation ID, regardless of
+  whether the workstation is cron-triggered, ordinarily scheduled, or backed by
+  another supported workstation behavior;
+- increase throughput without restarting the Factory Session;
+- reduce capacity only by removing resource units that are currently available;
+- never terminate or interrupt a workstation dispatch to satisfy a resource
+  reduction or workstation disable request; and
+- record successful changes on the canonical Factory Session event timeline so
+  pause, resume, restart, replay, CLI inspection, and dashboard projections agree.
+
+## Current-state findings
+
+- Factory definition save currently requires an idle runtime and replaces the
+  hosted runtime rather than updating one active session revision.
+- `FACTORY_CHANGE` already carries a complete replacement Factory snapshot and
+  the Recordings world-state reducer already treats it as canonical structure.
+- The hosted replacement path writes a change boundary into both the old and
+  replacement histories, and a publication error is reported without aborting
+  the replacement. It is not a sufficiently strong transaction boundary for
+  live controls.
+- Runtime resource observation already distinguishes `ResourceID`,
+  `InUseCount`, and `AvailableCount`; this is sufficient to enforce an
+  available-only reduction without exposing internal Petri tokens publicly.
+- Resource and workstation `id` fields are optional in the authored Factory
+  contract. Live controls must target `id` only and must not silently fall back
+  to mutable display names.
+- JavaScript `parallel()` currently creates a fixed semaphore from the policy
+  concurrency for one call. Increasing a resource cannot release already
+  waiting children until JavaScript child dispatch admission uses a shared,
+  resizable session resource controller.
+- Durable JavaScript resume already persists runtime records, checkpoint
+  summaries, and canonical events, but the current pause operation changes
+  status and saves a snapshot without actually suspending the running VM.
+
+## Solution
+
+Introduce one Factory Sessions-owned live-change operation that serializes
+resource and workstation controls with dispatch admission and records them on a
+stable Factory Session timeline. Typed CLI and API operations remain concise,
+but map into the same revisioned domain request.
+
+### ID-addressed CLI
+
+Use singular resource and workstation command families, and name positional
+arguments as IDs in help, errors, and JSON:
+
+```text
+you session resource set <resource-id> <capacity> [session-id]
+you session workstation enable <workstation-id> [session-id]
+you session workstation disable <workstation-id> [session-id]
+```
+
+Examples:
+
+```text
+you session resource set reviewers 8 session-alpha
+you session workstation disable nightly-review session-alpha
+you session workstation enable nightly-review session-alpha
+```
+
+In the first example, `reviewers` is the value of `Resource.id`; it is not a
+resource display name. Likewise, `nightly-review` is `Workstation.id`. An
+authored resource or workstation without an ID is not live-controllable until
+the author adds one. Name fallback, case-insensitive matching, and ambiguous
+ID-or-name resolution are explicitly unsupported.
+
+The commands inherit global `--json`, `--server`, `--verbose`, and `--debug`
+behavior. They also accept `--request-id`, `--if-revision`, and `--reason`.
+The CLI generates a request ID and reads/sends the current revision when those
+values are omitted.
+
+### Resource capacity rule
+
+For current capacity `C`, in-use count `U`, available count `A = C - U`, and
+requested capacity `R`:
+
+- `R > C`: add `R - C` available units and admit the change.
+- `R == C`: return `NO_OP`; do not append a Factory event or increment the
+  Factory revision.
+- `U <= R < C`: remove `C - R` currently available units and admit the change.
+- `R < U`: reject with `RESOURCE_CAPACITY_IN_USE`; do not mutate capacity,
+  terminate a dispatch, append a Factory change, or increment the revision.
+- `R < 0`: reject validation. Runtime capacity zero is allowed only when
+  `U == 0`; it blocks new resource acquisition until capacity is raised.
+
+The reduction is therefore immediate or rejected. This plan does not introduce
+a `DRAINING` resource status, delayed capacity request, forced lease revocation,
+or dispatch cancellation.
+
+Capacity evaluation and dispatch resource acquisition must share one serialized
+admission boundary. In a race, either the reduction commits first and the later
+dispatch waits, or the dispatch acquires first and the now-invalid reduction is
+rejected. The invariant `capacity >= inUse` must always hold.
+
+For the Petri orchestrator, the implementation may add or remove idle internal
+resource units, but token vocabulary remains internal. Removal must be
+deterministic and replayable. For JavaScript, child dispatches that declare the
+resource ID acquire the same session-scoped resource lease. Raising `reviewers`
+must be able to admit waiting JavaScript children in an already-running
+workflow; a newly allocated fixed semaphore per `parallel()` call is not
+sufficient.
+
+### Workstation enable and disable rule
+
+Workstation state is session-scoped desired state addressed by
+`Workstation.id`:
+
+- disabling fences new dispatch requests for that workstation after the
+  committed Factory-change sequence;
+- dispatch requests already present before that sequence continue to their
+  ordinary terminal outcome;
+- eligible or queued Work remains durable and may dispatch after re-enable;
+- disabling never sends terminate, cancel, or interrupt to an active dispatch;
+- cron, watcher, and poller sidecars reconcile the workstation's enabled state
+  through Automations rather than receiving a cron-specific public command;
+- a cron trigger durably admitted before disable remains ordinary Work, while a
+  trigger after disable is not admitted; and
+- enabling or disabling the already-desired state returns `NO_OP` without a
+  Factory event or revision increment.
+
+JavaScript-only child agents are not implicitly treated as workstations. The
+workstation command requires an authored workstation ID in the Current Factory.
+Sessions without that ID return `WORKSTATION_NOT_FOUND`; the implementation must
+not reinterpret an agent ID, worker name, label, or JavaScript task label as a
+workstation ID.
+
+### Canonical Factory Session timeline
+
+The authored Factory remains the persisted baseline. Each successful
+session-scoped control creates a new immutable Current Factory revision for that
+Factory Session. The effective snapshot includes the updated resource capacity
+or workstation enabled state and is reconstructible from canonical Factory
+events.
+
+Use the following event progression:
+
+```text
+FACTORY_CHANGE_REQUEST
+    -> FACTORY_CHANGE
+    -> or FACTORY_CHANGE_FAILED
+```
+
+- `FACTORY_CHANGE_REQUEST` records an admitted, idempotent request with
+  `requestId`, `changeId`, `expectedRevision`, target ID, operation, requested
+  value, actor/source, and safe reason.
+- Existing `FACTORY_CHANGE` remains the sole success boundary. Extend its
+  payload additively with `changeId`, `previousRevision`, `revision`,
+  `effectiveAtSequence`, and `scope: FACTORY_SESSION`, while retaining the full
+  effective Factory snapshot.
+- `FACTORY_CHANGE_FAILED` closes a previously admitted request that could not
+  be committed. It carries a stable code, stage, retryability, safe message,
+  and unchanged revision. It never exposes stack traces, secrets, command
+  lines, or provider payloads.
+
+Malformed inputs, missing sessions, missing IDs, stale revisions, negative
+capacity, `R < U`, terminal sessions, and exact no-ops are resolved before
+request admission and do not enter the canonical Factory timeline. Once a
+`FACTORY_CHANGE_REQUEST` is appended, recovery must eventually produce either
+`FACTORY_CHANGE` or `FACTORY_CHANGE_FAILED`. A repeated request ID with the same
+normalized body returns the original result; reuse with a different body is a
+conflict.
+
+Every effect-bearing event, dispatch request, JavaScript checkpoint, and
+session snapshot must carry or resolve the effective Factory revision. A
+dispatch admitted before `effectiveAtSequence` retains its original revision;
+the change is never applied retroactively to an active dispatch.
+
+### Pause, resume, and restart behavior
+
+Live changes are accepted in `RUNNING` or durably `PAUSED` sessions and rejected
+while another lifecycle/change transition is committing. Terminal and
+historical replay sessions remain immutable.
+
+A real pause boundary must fence new automation and dispatch admission, settle
+or durably classify mediated in-flight work, persist a resumable checkpoint and
+event cursor, and only then publish accepted `PAUSED` state. It must not claim
+the session is paused while JavaScript continues creating effects.
+
+Because arbitrary Goja stack serialization is not a supported primitive,
+JavaScript pause/resume uses engine-managed safe points and the existing
+completed-dispatch replay strategy. Checkpoints are bound to source hash,
+arguments digest, policy hash, Factory revision, and canonical event cursor.
+Resume reconstructs the last successful Factory revision before reopening
+automation or dispatch admission.
+
+A change made while paused is recorded as the next Factory revision and is in
+force before resume. Restart recovery replays any unclosed change request
+idempotently, resolves it, reconstructs resource/workstation state, and then
+allows the session to resume. Source, argument, orchestrator kind, topology,
+guard, worker/provider binding, and semantic JavaScript policy changes remain
+outside this live-control contract and require the existing idle replacement
+path or a new Factory Session.
+
+## Original document
+
+There is no earlier standalone product plan for this request. This plan records
+the clarified design and is constrained by:
+
+- `C:\Users\andre\work\portos\infinite-you\docs\architecture\architecture.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\architecture\structures.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\architecture\data-model.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\architecture\packaged-structure.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\internal\standards\code\planning-standards.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\internal\standards\code\general-backend-standards.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\internal\standards\code\code-review-standards.md`
+
+## Work stories
+
+### Story 1 — Revisioned live-change admission
+
+As an operator, I receive one idempotent, ordered outcome when I request a live
+Factory Session change, so retries, reconnects, and process restarts cannot
+duplicate or lose the change.
+
+Acceptance criteria:
+
+- Factory Sessions exposes one service-root live-change operation and owns
+  request normalization, request-ID replay, expected-revision checks, session
+  lifecycle checks, and serialization with dispatch admission.
+- An admitted request produces exactly one request event and exactly one
+  terminal success or failure event in canonical sequence order.
+- `FACTORY_CHANGE` advances the revision exactly once and contains the complete
+  effective Factory snapshot; rejection and no-op leave the revision unchanged.
+- A crash after the request event but before its terminal event is recovered
+  idempotently without duplicating resources, sidecars, dispatches, or events.
+- Event projections, retained response streams, recording export/import, and
+  reconnect cursors preserve the change boundary and request correlation.
+- Operation logs record accepted intent and terminal outcome with session ID,
+  request ID, change ID, revision, operation kind, and target ID, without
+  sensitive payloads.
+
+### Story 2 — Set resource capacity by resource ID
+
+As an operator, I can increase or safely reduce the capacity of resource ID
+`reviewers` on an active Factory Session without restarting it or interrupting
+work already using that resource.
+
+Acceptance criteria:
+
+- `you session resource set reviewers <capacity> [session-id]` and the matching
+  API operation target `Resource.id` only; mutable `name` is presentation data
+  and is never a fallback lookup key.
+- Increasing capacity makes new capacity available in the same session and can
+  increase throughput for waiting Petri and resource-bound JavaScript child
+  dispatches.
+- Reducing capacity succeeds only when `requestedCapacity >= inUse` and removes
+  exactly the required number of currently available units.
+- A request below `inUse` returns `RESOURCE_CAPACITY_IN_USE` with
+  `resourceId`, `currentCapacity`, `requestedCapacity`, `inUse`, `available`,
+  and `minimumAllowedCapacity`; runtime state and Factory revision are
+  unchanged.
+- No resource change path invokes dispatch cancel, interrupt, or terminate.
+- Capacity zero succeeds only when no unit is in use and prevents new
+  acquisition until capacity is raised.
+- Human and JSON output report resource ID, previous/requested capacity,
+  in-use/available counts, outcome, revision, and links without using
+  `reviewers` as though it were a display name.
+
+### Story 3 — Enable and disable by workstation ID
+
+As an operator, I can disable or enable a workstation by ID so future work is
+fenced without terminating a dispatch that already started.
+
+Acceptance criteria:
+
+- `you session workstation disable <workstation-id> [session-id]` and `enable`
+  target `Workstation.id` only and return a typed missing-ID diagnostic when no
+  matching authored workstation exists.
+- Disabling commits one Factory revision and prevents new dispatch requests for
+  the workstation after that event sequence.
+- Active dispatches continue unchanged and publish their ordinary result; no
+  lifecycle interruption is synthesized.
+- Eligible Work remains visible while disabled and becomes schedulable after
+  re-enable.
+- Automations reconciles cron, watcher, and poller sources from the same
+  workstation enabled state; no cron-specific public operation is added.
+- Fake-clock cron coverage proves disabled boundaries emit no new scheduled
+  Work, re-enable resumes at a later valid boundary, and each nominal boundary
+  emits at most once.
+- A JavaScript agent/label that happens to equal the requested workstation ID
+  is not accepted unless an authored workstation with that ID exists.
+
+### Story 4 — Pause, resume, and restart preserve live controls
+
+As an operator, I can pause or restart a Factory Session after a live change and
+resume with exactly the last committed resource and workstation configuration.
+
+Acceptance criteria:
+
+- Accepted pause is published only after new admission is fenced and a durable,
+  revision-bound recovery point exists.
+- JavaScript cannot create a new child dispatch after accepted `PAUSED` state;
+  completed mediated child results are replayed rather than reinvoked on resume.
+- A resource or workstation change committed while paused is effective before
+  resumed scheduling or automation begins.
+- Restart reconstructs the latest Factory revision, resource capacity,
+  workstation enabled state, and request-id replay result from durable records.
+- Checkpoint source, arguments, policy, Factory revision, and event cursor are
+  validated before JavaScript resume contacts a Worker or Provider.
+- Corrupt, incomplete, or incompatible recovery facts produce a typed safe
+  failure and do not silently revert to the authored baseline or start a second
+  dispatch.
+
+### Story 5 — Inspect and document the effective controls
+
+As an operator, I can inspect the effective Factory revision and understand why
+a live control was applied, rejected, or treated as a no-op.
+
+Acceptance criteria:
+
+- Session and Factory world reads expose the effective revision, resource ID,
+  total/in-use/available capacity, workstation ID, and enabled state.
+- The dashboard projects canonical API/event state and does not keep a second
+  editable source of truth in graph component state.
+- Existing graph nodes use the established visual/status primitives to show a
+  disabled workstation and resource capacity; no cron-only control is rendered.
+- `you docs` reference material documents ID targeting, the available-only
+  reduction rule, capacity zero, no-op behavior, revision conflicts, and the
+  guarantee that active dispatches are never terminated by these controls.
+- CLI, REST, generated clients, MCP exposure if added, recordings, and UI use
+  the same stable outcome and error vocabulary.
+
+# Changes
+
+## Package changes
+
+- Add Factory Sessions root contracts for live Factory changes, typed outcomes,
+  stable errors, request-id replay, and effective revision reads under
+  `pkg/services/factory_sessions/`; implement private coordination under its
+  `internal/` tree.
+- Add an orchestration-neutral, session-scoped resource admission capability at
+  the Factory Runtime root. Petri and JavaScript implementations consume that
+  contract without exposing tokens, markings, Goja records, or local
+  semaphores to Factory Sessions.
+- Serialize resource acquisition and capacity mutation at the owning runtime
+  service boundary; keep the comparison and error construction pure and
+  directly unit-testable.
+- Extend JavaScript agent/child configuration only as needed to declare resource
+  ID requirements, and acquire leases at child-dispatch admission rather than
+  once per `parallel()` invocation.
+- Add workstation enabled-state reconciliation to Factory Runtime scheduling and
+  Automations sidecar ownership. Automations remains responsible for starting
+  and stopping cron, watcher, and poller sources.
+- Extend Recordings canonical event contracts and reducers for request/failure
+  events and revisioned `FACTORY_CHANGE` success while preserving full-snapshot
+  replay.
+- Extend Factory Visualization projections from canonical Factory world/session
+  reads; graph rendering must not mutate runtime state directly.
+- Add authored CLI manifest source, handlers, mappings, and HTTP client calls
+  under `pkg/transports/cli`; regenerate CLI manifest output rather than editing
+  `pkg/transports/cli/generated/` by hand.
+- Compose new service dependencies once through owning `wire/` providers and
+  `pkg/wire`; do not introduce a service locator, constructor bag, runtime
+  lookup callback, or alternate process graph.
+
+## Contracts
+
+- Resource targets are `resourceId`; workstation targets are `workstationId`.
+  Both resolve only the public `id` field.
+- Add an effective Factory revision to live-change requests, outcomes, relevant
+  event context/payloads, Factory Session reads, checkpoints, and dispatch
+  admission facts.
+- Add optional workstation `enabled` state to the effective Factory snapshot,
+  defaulting to true. Preserve compatibility for authored factories that omit
+  it.
+- Keep authored resource capacity validation separate from the session runtime
+  override rule if authored capacity must remain positive; live capacity zero
+  has the explicit operational meaning described above.
+- Add stable outcomes `APPLIED` and `NO_OP`, and stable errors including
+  `RESOURCE_NOT_FOUND`, `RESOURCE_ID_REQUIRED`,
+  `RESOURCE_CAPACITY_IN_USE`, `WORKSTATION_NOT_FOUND`,
+  `WORKSTATION_ID_REQUIRED`, `REVISION_CONFLICT`,
+  `SESSION_TRANSITION_IN_PROGRESS`, `TERMINAL_SESSION`, and
+  `CHANGE_APPLICATION_FAILED`.
+- A successful resource or workstation operation is represented by
+  `FACTORY_CHANGE`; rejected and no-op requests do not masquerade as successful
+  Factory changes.
+
+## Services
+
+- Factory Sessions owns command admission, lifecycle eligibility, effective
+  revisions, idempotency, durable change coordination, and recovery ordering.
+- Factory Runtime owns live resource acquisition/capacity application and
+  workstation dispatch eligibility through orchestration-neutral contracts.
+- Automations owns reconciliation of enabled workstation sources, including
+  cron, watcher, poller, and invocation-schedule behavior.
+- Recordings owns canonical request, success, failure, replay, and projection
+  behavior.
+- Factory Definitions owns authored ID validation and effective Factory snapshot
+  shape, but does not mutate a live session.
+- Transports and mapping packages own CLI/HTTP/MCP representations and do not
+  choose capacity or workstation policy.
+
+## API changes
+
+- Add an idempotent capacity operation under
+  `/factory-sessions/{session_id}/resources/{resource_id}/capacity` with
+  `capacity`, `requestId`, `expectedRevision`, and optional `reason`.
+- Add an idempotent workstation-state operation under
+  `/factory-sessions/{session_id}/workstations/{workstation_id}/state` with
+  `enabled`, `requestId`, `expectedRevision`, and optional `reason`.
+- Return typed applied/no-op results with previous/current values, revision,
+  request/change IDs, and canonical inspection links.
+- Map malformed values to `400`, missing IDs/sessions to `404`, revision and
+  in-use conflicts to `409`, terminal/transition-state rejection to the existing
+  lifecycle-compatible conflict shape, and admitted application failure to a
+  bounded `5xx` response correlated with `FACTORY_CHANGE_FAILED`.
+- Author changes in `api/openapi-main.yaml` and `api/components/`, update HTTP
+  handlers and mapping, and regenerate `api/openapi.yaml`, generated Go clients
+  and servers, and `ui/src/api/generated/openapi.ts`. Do not hand-edit generated
+  files.
+
+## Tests
+
+### Unit and package integration
+
+- Table-test the capacity decision matrix, including increase, no-op, reduction
+  to `inUse`, reduction below `inUse`, zero with and without use, negative
+  capacity, overflow, stale revision, missing ID, and request-ID replay.
+- Test that capacity mutation and dispatch acquisition share one serialization
+  boundary and can never produce `inUse > capacity`.
+- Test deterministic Petri idle-resource removal and replay without exposing
+  token vocabulary in public results.
+- Test JavaScript resource acquisition with waiting children and prove a live
+  increase releases additional children in the same workflow execution.
+- Test workstation eligibility for standard, logical, cron, watcher, and poller
+  behaviors, including active-dispatch completion after disable.
+- Test event reducers and durable snapshots for request/success/failure order,
+  revision advancement, no-op/rejection absence, restart recovery, and
+  checkpoint revision validation.
+- Test CLI manifest parsing, ID-named help/usage, human output, JSON output,
+  exit codes, request correlation, and HTTP error mapping.
+- Add OpenAPI discriminator/union, generated-client, event-kind parity, and
+  UI projection/operation tests when those surfaces change.
+
+### Functional tests
+
+Place new scenarios under behavior-owned packages rather than the deletion-only
+`tests/functional/runtime_api` package:
+
+- `tests/functional/resources/session_controls/` for active capacity increase,
+  available-only reduction, in-use conflict, capacity zero, and Petri/JavaScript
+  admission behavior;
+- `tests/functional/workstations/controls/` for disable/enable, active dispatch
+  non-termination, queued Work, and generic workstation ID behavior;
+- extend `tests/functional/workstations/cron/` for fake-clock disable/re-enable
+  boundaries through the workstation command rather than a cron-specific API;
+- extend `tests/functional/events/factory_events/` for change ordering,
+  correlation, revision, cursor reconnect, failure closure, and absence on
+  rejection/no-op; and
+- extend `tests/functional/sessions/restart/` and
+  `tests/functional/cli/session_resume/` for post-change restart and
+  pause/change/resume reconstruction.
+
+Required high-value functional cells:
+
+1. Start with resource ID `reviewers` at capacity one, hold the first real
+   provider-backed dispatch at an injected command-runner barrier, submit more
+   Work, set capacity to two through the CLI, and observe a second dispatch
+   begin without changing Factory Session identity or restarting the process.
+2. Start capacity three with one dispatch in use, set capacity to one, and prove
+   the active dispatch completes normally while total capacity becomes one.
+3. Start capacity two with two dispatches in use, request capacity one, and
+   prove the CLI returns `RESOURCE_CAPACITY_IN_USE`, both dispatches complete
+   normally, no interrupt/terminate event exists, and the Factory revision and
+   capacity remain unchanged.
+4. Race a dispatch acquisition against a capacity reduction repeatedly and
+   prove the only outcomes are “reduction commits and dispatch waits” or
+   “dispatch acquires and reduction is rejected.”
+5. Disable a standard workstation by ID while one dispatch is active, submit
+   more eligible Work, prove the active dispatch completes and no new dispatch
+   begins, then enable it and observe the queued Work dispatch.
+6. Disable a cron workstation by ID, advance the injected clock, prove no new
+   scheduled Work is admitted, enable it, advance to a later valid boundary,
+   and prove exactly one trigger occurs.
+7. Run a JavaScript workflow whose parallel children require resource ID
+   `reviewers`, increase capacity while children wait, and prove throughput
+   changes within the same durable Factory Session.
+8. Commit resource and workstation changes, pause or interrupt at a durable
+   JavaScript safe point, reconstruct with a fresh process, resume, and prove
+   the latest revision is retained without repeating a completed child.
+
+All functional application tests must follow the repository standards:
+
+- construct through `root.BuildProcess` and execute through `Process.Execute`;
+- invoke the public CLI for ordinary customer flows, using HTTP only for
+  API-owned contract or explicit parity cells;
+- replace external effects only through `edges.Edges`, preferring
+  `ProviderCommandRunner` and command/process edge mocks;
+- use mocked Codex or another real provider command shape instead of
+  `--with-mock-workers` outside the workers/mock-owned test area;
+- coordinate blocked and released dispatches with deterministic injected
+  barriers, event cursors, fake clocks, or edge observations rather than sleeps
+  or timeout-padded polling; and
+- assert only public CLI, session, Work, Factory Event, generated API, or
+  injected-edge observations, never internal engine snapshots.
+
+### Stress and failure-mode evidence
+
+- Add targeted race/repeat coverage for simultaneous capacity updates,
+  resource acquisition/release, duplicate request IDs, workstation toggles,
+  cron boundaries, pause, and restart.
+- Inject persistence failure before and after request-event append and prove
+  every admitted request eventually closes without a partially visible
+  revision.
+- Inject Automations reconciliation failure and prove the session reports a
+  bounded failed/degraded outcome without silently enabling a disabled source.
+- Track capacity-change latency, failures, conflicts, current utilization, and
+  workstation reconciliation failures through structured metrics/logs suitable
+  for saturation diagnosis.
+
+## Quality gates
+
+Use focused package tests during implementation, then run the applicable public
+and generated-contract gates:
+
+- `go test ./pkg/services/factory_sessions/... ./pkg/services/factory_runtime/... ./pkg/services/automations/... ./pkg/services/recordings/... ./pkg/transports/cli/...`
+- targeted `go test -race` for the resource admission and workstation control
+  packages
+- focused functional packages through their `root.BuildProcess` +
+  `Process.Execute` harnesses
+- `make generate-api`
+- `make interfaces-all` when publishable/generated contract shapes change
+- `make api-smoke`
+- `make docs-reference-smoke`
+- `make ui-test` and `make ui-lint` when dashboard projections/actions change
+- `make test-functional`
+- `make test-stress` for the concurrency cells
+- `make verify-fast`, followed by `make verify-pr`
+- `make build-all` before delivery of the public CLI/API/client surface
+
+## Out of scope
+
+- A cron-specific enable/disable CLI or API.
+- Name-based resource or workstation targeting.
+- Deferred resource draining, pending lower-capacity requests, forced resource
+  revocation, or cancellation/termination of dispatches to satisfy capacity.
+- Treating JavaScript agents, worker names, labels, or task labels as authored
+  workstation IDs.
+- Live topology, Work type/state, relation, guard, worker/provider/model,
+  JavaScript source/arguments, or orchestrator-kind replacement.
+- Mutating completed sessions or historical replay projections.
+- An unrelated graph-editor redesign; UI work is limited to projecting and
+  invoking the canonical controls.
+
+## Delivery boundary
+
+The work is complete only after required CI is terminal and passing, all
+blocking review feedback is explicitly addressed, merge conflicts are resolved,
+generated artifacts are confirmed current, and the pull request is actually
+merged. Opening a PR, pushing the implementation, obtaining approval, or
+reaching green CI without merge is not completion.

--- a/docs/internal/development/plans/node-consumable-docs-package.md
+++ b/docs/internal/development/plans/node-consumable-docs-package.md
@@ -1,0 +1,307 @@
+# problem statement
+
+The canonical customer documentation is exposed through `you docs`, but Node
+consumers cannot install the same documentation as a versioned package for use
+by a future static site or other build-time tooling.
+
+## customer ask
+
+Publish the existing packaged CLI documentation as an npm package so a Node
+repository can consume it without copying or separately maintaining the
+Markdown.
+
+## solution
+
+Create a data-only package at `packages/docs` named
+`@you-agent-factory/docs`. The package will publish the exact canonical topic
+surface exposed by `you docs`, together with a generated manifest containing
+topic order, descriptions, aliases, artifact paths, and content digests.
+
+Keep `docs/reference/*.md` authoritative for content and keep the existing CLI
+topic registry in `pkg/transports/cli/docs` authoritative for exposure, order,
+descriptions, and aliases. Generate the npm publication projection from the
+registry's `TopicIndexEntries()` and `Markdown()` operations so packaged topic
+content remains byte-equivalent to `you docs <topic>`.
+
+The initial package is a framework-neutral build-time input. It will not own a
+Markdown renderer, React components, browser state, static-site routing, or
+link rewriting. A later static site can resolve and read the manifest and raw
+Markdown through stable npm package exports.
+
+# original document
+
+The customer-visible and planning references for this work are:
+
+- `C:\Users\andre\work\portos\infinite-you\docs\reference\README.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\reference\embed.go`
+- `C:\Users\andre\work\portos\infinite-you\pkg\transports\cli\docs\docs.go`
+- `C:\Users\andre\work\portos\infinite-you\docs\internal\standards\code\planning-standards.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\architecture\packaged-structure.md`
+
+# changes
+
+## package changes
+
+### Public package shape
+
+Add `packages/docs` with the following authored and generated boundaries:
+
+```text
+packages/docs/
+  package.json
+  README.md
+  LICENSE.md
+  generated/
+    manifest.json
+    topics/
+      <canonical-topic>.md
+```
+
+The proposed package identity is `@you-agent-factory/docs`. Its publication
+allowlist must contain only the package metadata, maintainer README, license,
+generated manifest, and canonical generated topic files. It must have no
+runtime dependencies, executable entrypoint, lifecycle scripts, or browser
+assumptions.
+
+The proposed public exports are:
+
+```json
+{
+  "./manifest": "./generated/manifest.json",
+  "./topics/*": "./generated/topics/*.md"
+}
+```
+
+Canonical topic names are stable package subpaths. Compatibility aliases are
+manifest metadata that point consumers to canonical topics; they do not create
+duplicate Markdown artifacts.
+
+### Generated publication projection
+
+Add a focused generator, such as `cmd/docsreferencepackagegenerate`, that reads
+the existing CLI docs registry through its public operations and writes the
+deterministic package projection. The generator must support both generation
+and drift-check modes.
+
+Add Make targets with these responsibilities:
+
+- `docs-package-generate` refreshes the generated manifest and topic files.
+- `docs-package-check` fails when the checked-in projection differs from the
+  canonical CLI docs surface.
+- `docs-package-verify` runs generation drift, package contract, tarball
+  inventory, and installed-consumer verification.
+
+Include docs package generation in `build-all`. Include projection drift in
+`docs-reference-smoke` so a maintainer editing canonical Markdown receives an
+actionable failure without needing to know the npm publication topology.
+
+Update `docs/reference/README.md`, `docs/README.md`, and
+`docs/architecture/packaged-structure.md` to describe the generated npm
+projection while retaining `docs/reference/` as the only authored content
+tree.
+
+### Candidate and publication flow
+
+Follow the existing root data-package candidate pattern used by
+`@you-agent-factory/api` and `@you-agent-factory/packaged-factories`:
+
+- add focused docs-package pack, contract, consumer, candidate, registry,
+  dry-run, and publication helpers or parameterize an existing shared helper
+  where that keeps the resulting behavior simpler;
+- build a no-publish candidate on relevant pull requests;
+- add `@you-agent-factory/docs` to the complete tagged-release package set;
+- preserve the reviewed tarball and candidate evidence between preparation
+  and publication;
+- reconcile immutable registry versions and verify the installed published
+  package after publication.
+
+Update `cmd/ciclassify` so changes under `docs/reference/`, `packages/docs/`,
+the docs generator, and docs-package release scripts select the docs reference
+and docs package verification lanes as applicable. Update CI's verification
+policy so a skipped, failed, or cancelled required docs package lane cannot be
+reported as successful.
+
+## contracts
+
+Introduce the following public npm contract:
+
+- package name: `@you-agent-factory/docs`;
+- stable manifest export: `@you-agent-factory/docs/manifest`;
+- stable topic exports:
+  `@you-agent-factory/docs/topics/<canonical-topic>`;
+- manifest format: `you-agent-factory.docs/v1`;
+- topic content: raw Markdown byte-equivalent to the canonical
+  `you docs <topic>` result;
+- alias behavior: manifest aliases identify their canonical topic and do not
+  create independent content authorities.
+
+The proposed manifest shape is:
+
+```json
+{
+  "formatVersion": "you-agent-factory.docs/v1",
+  "sourceCommit": "added to publication candidates",
+  "topics": [
+    {
+      "name": "config",
+      "description": "Operator initialization and Factory validation...",
+      "aliases": [],
+      "path": "generated/topics/config.md",
+      "sha256": "..."
+    }
+  ]
+}
+```
+
+The source projection may omit `sourceCommit`; candidate preparation must add
+the reviewed source commit using the same provenance convention as the other
+root data packages. Topic names, order, descriptions, aliases, paths, and
+digests must be deterministic.
+
+Removing or renaming a canonical topic, changing an export subpath, or changing
+the manifest format is a public compatibility change. Supplemental files under
+`docs/reference/` that are not exposed by `you docs`, including maintainer
+indexes and non-topic pages, are outside the initial package contract.
+
+## services
+
+No product service is added or changed. The generator is repository tooling,
+and the npm package is a publication projection. The Factory runtime, Factory
+Sessions, Work, Workers, Providers, Recordings, Events, and other service
+owners remain unchanged.
+
+## API changes
+
+There are no REST, OpenAPI, CLI command, MCP, ACP, or dashboard API changes.
+The CLI's observable topic behavior must remain unchanged and serves as the
+parity authority for the new package.
+
+## tests
+
+Add focused tests that prove:
+
+- the manifest contains every canonical `you docs` topic exactly once and in
+  the same display order;
+- descriptions and aliases match `TopicIndexEntries()`;
+- every generated topic is byte-equivalent to `Markdown(topic)`;
+- every manifest digest matches its generated Markdown artifact;
+- generation is deterministic and check mode reports added, removed, or
+  changed artifacts clearly;
+- `npm pack` contains the exact reviewed positive allowlist and every declared
+  export target;
+- an isolated Node project can install the real tarball, resolve the manifest,
+  resolve every canonical topic through its package export, and read the raw
+  Markdown;
+- the isolated consumer can use alias metadata to select the canonical topic;
+- candidate preparation records the requested version, source commit,
+  inventory, contract digest, and tarball digest without mutating source
+  package files;
+- pull-request dry runs never publish;
+- registry reconciliation rejects conflicting immutable versions and verifies
+  an already-matching or newly published package;
+- the tagged release candidate contains the exact complete public package set,
+  including `@you-agent-factory/docs` once;
+- CI classification selects both reference-doc and docs-package verification
+  when canonical topics change, and selects the docs-package lane for
+  package-only or release-helper changes.
+
+# work stories
+
+## story 1: install and read the exposed documentation
+
+As a Node build-tool author, I can install `@you-agent-factory/docs`, discover
+the supported topics, and read any canonical topic so I can use the same
+documentation that ships in the CLI.
+
+Acceptance criteria:
+
+- A registry-format tarball installs successfully into an isolated Node
+  project.
+- `@you-agent-factory/docs/manifest` resolves to valid
+  `you-agent-factory.docs/v1` JSON.
+- Every canonical manifest entry resolves through
+  `@you-agent-factory/docs/topics/<name>`.
+- Every resolved Markdown artifact exactly matches `you docs <name>`.
+- Topic order, descriptions, and aliases match the CLI topic index.
+- Unsupported and supplemental repository documents are not accidentally
+  exposed as canonical topic exports.
+
+## story 2: edit documentation in one canonical location
+
+As a documentation maintainer, I can edit the existing canonical Markdown or
+CLI topic registry and deterministically regenerate the npm projection so I do
+not maintain a second authored documentation tree.
+
+Acceptance criteria:
+
+- `docs-package-generate` produces the complete projection from the current
+  CLI registry and embedded Markdown.
+- Repeated generation produces no diff.
+- `docs-package-check` succeeds on a current projection and fails with
+  actionable paths when the projection is stale.
+- Adding, removing, reordering, or renaming a CLI topic changes the manifest
+  and generated inventory without a manually maintained second topic list.
+- `docs-reference-smoke` exercises projection parity.
+
+## story 3: review a real package candidate before publication
+
+As a reviewer, I can rely on pull-request CI to build and consume the exact
+docs tarball that would be published so package-boundary and generated-content
+regressions block delivery.
+
+Acceptance criteria:
+
+- Relevant pull requests run `docs-package-verify` and build a no-publish
+  candidate from the pull request head commit.
+- Candidate evidence identifies the package, version, source commit, inventory,
+  contract digest, and artifact digest.
+- The candidate is installed and read from a clean Node consumer rather than
+  through repository-relative paths or workspace links.
+- CI classification and verification-policy tests prove that relevant changes
+  cannot skip the required docs lanes.
+- No pull-request path can invoke npm publication.
+
+## story 4: publish and verify the reviewed package
+
+As a Node consumer, I can install the docs package version associated with a
+You Agent Factory release so documentation and CLI behavior are sourced from
+the same reviewed commit.
+
+Acceptance criteria:
+
+- Tagged release preparation includes `@you-agent-factory/docs` exactly once at
+  the release version.
+- Publication validates preserved evidence and source commit before contacting
+  the registry.
+- Existing matching immutable versions are accepted only when their digest
+  matches the candidate; conflicts fail safely.
+- A newly published package is installed from the registry and passes the same
+  manifest and topic consumer checks as the pull-request tarball.
+- Publication changes do not alter the behavior or version alignment of the
+  existing API, packaged Factory, or frontend packages.
+
+# verification and delivery
+
+The implementation should run the narrowest focused checks during development
+and finish with at least:
+
+```text
+make docs-reference-smoke
+make docs-package-verify
+make public-release-package-smoke
+go test ./cmd/docsreferencepackagegenerate/... ./pkg/transports/cli/docs/...
+```
+
+If `build-all`, CI classification, or tagged-release composition changes, run
+their focused tests and the broader required PR verification tier as well.
+
+The npm package name must be reserved and the repository's existing trusted
+publication workflow must be configured as an npm trusted publisher for
+`@you-agent-factory/docs`. This registry-side configuration is an external
+delivery prerequisite.
+
+Delivery is complete only after required CI is terminal and passing, all
+blocking review feedback is addressed, merge conflicts are resolved, the
+trusted-publisher prerequisite is confirmed, and the pull request is actually
+merged. Opening a pull request, publishing a candidate, or reaching green CI
+without merge is not completion.

--- a/docs/internal/development/plans/otel-projection-implementation-plan.md
+++ b/docs/internal/development/plans/otel-projection-implementation-plan.md
@@ -1,0 +1,836 @@
+---
+author: Agent Factory Team
+last-modified: 2026-08-10
+doc-id: agent-factory/plans/otel-projection
+---
+
+# OpenTelemetry Projection Implementation Plan
+
+## Outcome
+
+Customers can enable an OpenTelemetry Protocol (OTLP) destination and receive
+Factory operational metrics and execution traces that align with the
+`you metrics` vocabulary. The projection uses Analytics as its only product
+data dependency. Analytics obtains monetary valuation from Costs and combines
+it with existing Factory Session, Worker Session, Work, and recording facts.
+
+OpenTelemetry is an export projection, not a new source of truth. Export loss,
+cardinality limits, sampling, or an unavailable collector cannot change
+Factory execution, canonical history, cost accounting, or `you metrics`
+results.
+
+## Customer problem
+
+Customers can inspect You-owned runtime metrics artifacts and will eventually
+be able to query `you metrics`, but they cannot send the same Factory evidence
+to an existing OpenTelemetry backend. Without a supported projection they must
+maintain custom adapters, cannot correlate slow metric samples to Work and
+dispatch traces, and may define provider or token dimensions inconsistently.
+
+## Customer ask
+
+Provide an OTel projection shaped above the analytical service graph:
+
+```text
+OTel Projection
+  -> Analytics
+       -> Costs
+            -> existing usage and session facts
+       -> Factory Sessions
+       -> Worker Sessions
+       -> Work
+       -> Recordings
+```
+
+These services are read-oriented utility layers above the existing domain
+owners. They do not move lifecycle, execution, Work lineage, provider usage, or
+Factory event ownership out of the current services.
+
+## Entry prerequisites
+
+This plan is specifically for the OTel projection. Its implementation starts
+only after these separately owned prerequisites are available:
+
+1. `pkg/services/costs` exposes exact, currency-aware valuation and coverage
+   results without treating missing prices or usage as zero.
+2. `pkg/services/analytics` is constructed with a narrow Costs capability and
+   narrow read capabilities from the existing domain services.
+3. Analytics can produce deterministic operational observations from canonical
+   session and Work history.
+
+If those prerequisites have not landed, they must be delivered through their
+own plans and reviewed service contracts first. This plan may add the narrow
+Analytics export capability needed by OTel, but it must not absorb the general
+Costs or Analytics implementation.
+
+## Architecture decision
+
+### Dependency direction
+
+```text
+pkg/services/otel_projection
+  -> pkg/services/analytics (TelemetryReader capability only)
+  -> OTLPSender external-effect port
+  -> ProjectionCheckpointStore external-effect port
+  -> injected clock and logger
+
+pkg/services/analytics
+  -> pkg/services/costs
+  -> narrow existing read capabilities
+
+pkg/services/costs
+  -> narrow existing usage, model, provider, and session facts
+```
+
+The following dependencies are prohibited:
+
+- OTel Projection importing Costs directly.
+- OTel Projection importing Factory Sessions, Worker Sessions, Work,
+  Recordings, Providers, or their internal implementations.
+- Analytics or Costs importing OTel types.
+- Existing domain services importing Analytics, Costs, or OTel Projection.
+- Construction outside the owning `wire/` provider or canonical `pkg/wire`
+  graph.
+- A global OTel provider, service locator, secondary injector, or lazy service
+  construction path.
+
+A package-boundary regression check should enforce the most important parts of
+this direction rather than relying only on review memory.
+
+### Ownership
+
+| Owner | Responsibility |
+|---|---|
+| Factory Sessions | Factory Session lifecycle, dispatch association, live and durable reads. |
+| Worker Sessions | Provider execution observations, normalized usage, transcripts, and execution identity. |
+| Work | Work identity, admission, state, trace/chaining lineage, and relations. |
+| Recordings | Canonical Factory Event ledger, replay, and historical projections. |
+| Costs | Rate resolution, exact monetary values, currencies, coverage, and valuation provenance. |
+| Analytics | Cohorts, durations, distributions, critical-path facts, rework/revisit classification, and cost-enriched analytical observations. |
+| OTel Projection | OTel naming, signal mapping, cardinality policy, cursors, export lifecycle, and projection diagnostics. |
+| Platform OTLP adapter | Policy-free OTLP serialization, connection, and one-attempt network transport. |
+
+OTel Projection owns only its destination checkpoint and export status. It
+does not own the analytical observations it reads.
+
+## Canonical state and projection boundaries
+
+The projection reads an Analytics-owned, protocol-neutral batch contract. The
+contract must preserve observation timestamps and relationships without
+exposing OTel SDK or protobuf types:
+
+```go
+type TelemetryReader interface {
+    ReadTelemetry(context.Context, TelemetryReadRequest) (TelemetryBatch, error)
+}
+```
+
+The exact public names can change during contract review, but the capability
+must provide:
+
+- an opaque input cursor;
+- a bounded batch size;
+- a stable observation watermark;
+- metric observations with kind, unit, time window, value or distribution,
+  low-cardinality dimensions, and optional exemplar references;
+- trace observations with operation identity, timestamps, parent or link
+  relationships, outcome, and safe attributes;
+- cost observations already enriched by Analytics through Costs;
+- explicit coverage and unavailable classifications; and
+- a next cursor that is advanced only after successful export.
+
+Analytics must not pre-render OTLP. OTel Projection owns the mapping from these
+neutral facts into OTel resources, scopes, metrics, spans, links, and
+exemplars.
+
+## Initial signal contract
+
+### Metrics
+
+The first release exports observed base measurements. Percentages, rates, and
+percentiles are derived by the receiving backend or Analytics rather than
+emitted as independently aggregatable measurements.
+
+| Metric | OTel kind | Unit | Required dimensions |
+|---|---|---|---|
+| `you.factory.session.duration` | Histogram | `s` | factory, revision, outcome, orchestrator kind |
+| `you.work.cycle.duration` | Histogram | `s` | factory, revision, Work type, outcome |
+| `you.dispatch.queue.duration` | Histogram | `s` | factory, workstation, worker, outcome |
+| `you.dispatch.execution.duration` | Histogram | `s` | factory, workstation, worker, outcome |
+| `you.dispatch.attempts` | Counter | `{attempt}` | factory, workstation, worker, outcome |
+| `you.dispatch.retries` | Counter | `{retry}` | factory, workstation, worker, reason |
+| `you.work.revisits` | Counter | `{revisit}` | factory, Work type, stage |
+| `you.work.completed` | Counter | `{work}` | factory, revision, Work type, outcome |
+| `you.dispatch.in_flight` | UpDownCounter | `{dispatch}` | factory, workstation |
+| `you.analytics.coverage` | Gauge | `1` | fact kind and availability status |
+| `you.cost.amount` | Histogram | `1` | currency, valuation kind, billing provider |
+
+`you.cost.amount` is a telemetry approximation represented as an OTel numeric
+value. Costs remains authoritative for exact decimals, applied pricebooks, and
+historical currency facts. Unknown or unpriced usage is excluded from the
+amount and represented through coverage/status measurements; it is never
+exported as zero cost.
+
+Provider operations use the pinned OTel GenAI semantic conventions where they
+fit, including:
+
+- `gen_ai.client.operation.duration`;
+- `gen_ai.client.token.usage`;
+- `gen_ai.provider.name`;
+- request and response model attributes supported by the selected convention
+  version; and
+- input/output token types defined by that version.
+
+Cache-read, cache-write, and reasoning-token details use the pinned GenAI
+conventions when available. Any necessary `you.*` extension must be documented
+and versioned instead of silently redefining a standard attribute.
+
+### Metric cardinality policy
+
+Allowed metric dimensions are controlled catalog values such as:
+
+- Factory name and immutable effective revision;
+- orchestrator kind;
+- Work type and terminal outcome;
+- workstation and authored Worker name;
+- provider and resolved model;
+- dispatch outcome or bounded reason class;
+- currency and valuation kind; and
+- coverage fact/status.
+
+The following values must not be metric attributes:
+
+- Factory Session ID;
+- Worker Session ID;
+- Work ID;
+- Dispatch ID;
+- trace ID or chaining trace ID;
+- prompt, response, tool arguments, artifact paths, or payload content; and
+- raw error messages.
+
+Those identifiers belong on spans, links, exemplars, or safe diagnostic logs.
+The OTel adapter must configure an explicit cardinality limit and expose
+overflow/drop diagnostics.
+
+### Traces
+
+The initial trace projection provides:
+
+- one bounded Work-lineage trace for customer Work that crosses dispatches or
+  Factory Sessions;
+- dispatch spans for queued-to-terminal execution attempts;
+- Worker Session spans when a distinct supervised execution context is known;
+- GenAI client spans for provider operations;
+- span links for fan-in, predecessor Work, and cross-session continuation;
+- safe outcome, Factory revision, provider, model, Work type, workstation, and
+  Worker attributes; and
+- exemplars that connect latency or token histograms to representative spans.
+
+Long-running Factory Sessions are not represented by indefinitely open root
+spans. A completed bounded session may receive a terminal summary span, while
+continuously running sessions are correlated through safe session attributes,
+Work traces, and lifecycle observations.
+
+OTel logs and prompt/response content export are out of scope for the initial
+release. Canonical Factory Events remain available through Recordings and the
+session event APIs.
+
+## Configuration contract
+
+OTLP export is disabled by default. Add a distinct `runtime.otel` operator
+configuration rather than overloading the existing rolling `runtime.metrics`
+artifact settings:
+
+```json
+{
+  "runtime": {
+    "otel": {
+      "enabled": true,
+      "endpoint": "https://collector.example.com",
+      "protocol": "grpc",
+      "signals": ["metrics", "traces"],
+      "exportInterval": "30s",
+      "timeout": "10s",
+      "startFrom": "latest",
+      "backfillWindow": "0s"
+    }
+  }
+}
+```
+
+Required behavior:
+
+- accept reviewed OTLP/gRPC and OTLP/HTTP protobuf values;
+- support the applicable standard `OTEL_EXPORTER_OTLP_*` environment settings
+  with documented precedence against operator configuration;
+- obtain authorization headers from the approved secret-safe environment path;
+- never print header values or credentials in status, logs, errors, or JSON;
+- validate endpoint, protocol, durations, signals, and backfill policy before
+  starting the exporter;
+- begin from the current Analytics watermark by default;
+- require explicit configuration for retained-history backfill; and
+- preserve the existing file-backed runtime metrics artifact independently.
+
+The authored OpenAPI fragments, operator settings contracts, generated Go and
+TypeScript clients, and global configuration schema must remain synchronized.
+Generated files must not be hand-edited.
+
+## Export lifecycle and failure behavior
+
+`pkg/wire` constructs Costs, then Analytics, then OTel Projection, passing the
+same service instances directly. `pkg/initializer` starts and stops the already
+constructed projection lifecycle.
+
+The projection loop must:
+
+1. request a bounded Analytics batch after the committed cursor;
+2. map the batch deterministically to OTel signals;
+3. export with an explicit deadline;
+4. commit the next cursor only after the destination accepts the batch;
+5. retry transient failures with bounded exponential backoff and jitter;
+6. classify permanent rejection without retrying indefinitely;
+7. expose lag, rejection, retry, overflow, and last-success diagnostics; and
+8. flush within a bounded shutdown deadline.
+
+Exporter failure must never block or fail Factory Session, Worker Session,
+Work, recording, Costs, or Analytics operations. Because the projection pulls
+from retained analytical facts, it should prefer lag over an unbounded
+in-memory queue. If the Analytics retention window overtakes the committed
+cursor, the projection records an explicit gap and resumes according to the
+configured gap policy rather than silently claiming complete export.
+
+Checkpoint identity includes a sanitized destination fingerprint, signal set,
+projection schema version, and Analytics stream identity. Changing those
+values creates a new projection lineage instead of applying an incompatible
+cursor.
+
+## Status experience
+
+Add a read-only diagnostic surface under the unified metrics namespace:
+
+```bash
+you metrics otel status
+you --json metrics otel status
+```
+
+The status reports:
+
+- enabled/disabled and lifecycle state;
+- sanitized endpoint authority and protocol;
+- enabled signals;
+- projection and pinned semantic-convention versions;
+- current Analytics watermark and committed cursor age;
+- last attempt and last successful export times;
+- exported metric-point and span counts;
+- retry, rejection, cardinality-overflow, and gap counts;
+- last sanitized failure classification; and
+- whether shutdown has a pending flush.
+
+If CLI commands are server-backed, add the corresponding read-only OpenAPI
+operation and generated clients. Status reads must not trigger an export,
+retry, backfill, or configuration mutation.
+
+## Non-goals
+
+- Replacing canonical Factory Events or recordings with OTel.
+- Querying an arbitrary OTel backend to implement `you metrics`.
+- Making Costs depend on Analytics or OTel Projection.
+- Exporting cost forecasts as observed metrics.
+- Exporting prompts, responses, tool arguments, secrets, or artifacts.
+- Supporting OTel logs in the first release.
+- Automatically classifying every graph loop as rework.
+- Building dashboards for a specific OTel vendor.
+- Removing the existing rolling runtime metrics JSONL artifact.
+- Claiming exactly-once delivery across collector or network failures.
+
+## Work stories
+
+### Story 1: Publish a cursorable Analytics telemetry feed
+
+#### Problem statement
+
+OTel Projection cannot consume Analytics without a bounded, deterministic, and
+protocol-neutral observation contract.
+
+#### Customer ask
+
+Allow OTel Projection to obtain cost-enriched metric and trace observations
+without reaching through Analytics into lower-level services.
+
+#### Solution
+
+Add a narrow Analytics `TelemetryReader` capability with cursors, timestamps,
+watermarks, coverage, distributions, relationships, and safe dimensions.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\otel-projection-implementation-plan.md`
+
+#### Changes
+
+##### Package changes
+
+- Add the root Analytics telemetry read contract and private projection logic
+  under `pkg/services/analytics`.
+- Keep Costs enrichment inside Analytics.
+- Add a package-boundary guard preventing OTel Projection from importing lower
+  service roots.
+
+##### Contracts
+
+- Define cursor, batch, watermark, observation, distribution, relationship,
+  coverage, and unavailable-status values.
+- Define clone/detach behavior for every returned collection.
+
+##### Services
+
+- Analytics exposes deterministic reads from its already-injected dependencies.
+- OTel Projection receives only the narrow reader capability.
+
+##### API changes
+
+- None; this is an internal service-root capability.
+
+##### Tests
+
+- Unit tests for deterministic ordering, cursor continuation, timestamp
+  preservation, cost enrichment, and unavailable facts.
+- Integration tests proving Analytics calls Costs while OTel Projection does
+  not.
+- Boundary tests proving prohibited imports fail the repository check.
+
+#### Acceptance criteria
+
+- Re-reading the same cursor against unchanged facts returns an equivalent
+  detached batch.
+- A successful next-cursor read neither mutates nor consumes canonical events.
+- Unknown cost remains explicitly unpriced in the batch.
+- Analytics and its tests contain no OTel SDK or OTLP protobuf types.
+
+### Story 2: Export the initial OTel metric catalog
+
+#### Problem statement
+
+Customers cannot send Factory duration, queue, reliability, token, cost, and
+coverage measurements to an OTel backend with stable semantics.
+
+#### Customer ask
+
+Export aggregatable Factory and GenAI measurements with controlled dimensions.
+
+#### Solution
+
+Implement deterministic metric mapping in `pkg/services/otel_projection`, use
+the pinned GenAI conventions where applicable, and send mapped batches through
+an injected exporter effect.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\otel-projection-implementation-plan.md`
+
+#### Changes
+
+##### Package changes
+
+- Add OTel Projection root contracts, internal metric mapper, metric catalog,
+  and focused construction provider.
+- Add a policy-free OTLP sender implementation under `pkg/platform` only if
+  the chosen official library does not already provide the exact injectable
+  adapter needed by the service.
+
+##### Contracts
+
+- Define projection request/result, exporter batch, signal counts, semantic
+  version, and sanitized failure classification.
+
+##### Services
+
+- OTel Projection maps Analytics observations without adding pricing or
+  analytical policy.
+
+##### API changes
+
+- None in this story.
+
+##### Tests
+
+- Golden mapping tests for every initial metric, unit, kind, and allowed
+  dimension.
+- Regression tests rejecting high-cardinality entity IDs from metric points.
+- Cost tests covering multiple currencies, estimated/actual status, and
+  unpriced usage.
+- GenAI convention compatibility tests pinned to the selected schema version.
+
+#### Acceptance criteria
+
+- A representative Analytics batch produces collector-valid metric data.
+- Percentages and percentiles are not emitted as mergeable base metrics.
+- Every metric has a documented unit, kind, description, and bounded dimension
+  set.
+- Cost output is labeled by currency and valuation kind and never invents a
+  value for unknown usage.
+
+### Story 3: Export Work, dispatch, Worker Session, and provider traces
+
+#### Problem statement
+
+Aggregate metrics cannot explain which Work path or dispatch caused an outlier.
+
+#### Customer ask
+
+Correlate Factory performance measurements with navigable OTel traces.
+
+#### Solution
+
+Project Work lineage into bounded traces, attempts into dispatch spans,
+supervised execution into Worker Session spans, and model calls into GenAI
+client spans. Use links for fan-in and cross-session continuation and exemplars
+for metric-to-trace navigation.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\otel-projection-implementation-plan.md`
+
+#### Changes
+
+##### Package changes
+
+- Add private trace identity, relationship, mapping, and exemplar modules under
+  OTel Projection.
+
+##### Contracts
+
+- Extend exporter batches with spans, links, events, status, and exemplar
+  references without exposing content fields.
+
+##### Services
+
+- OTel Projection derives trace topology only from Analytics-provided
+  relationships.
+
+##### API changes
+
+- None in this story.
+
+##### Tests
+
+- Trace-tree and span-link tests for sequential, parallel, fan-in, retry, and
+  cross-session Work fixtures.
+- Tests proving continuously running Factory Sessions do not create indefinitely
+  open root spans.
+- Privacy tests proving prompts, responses, tool arguments, headers, and raw
+  errors are absent.
+- Exemplar tests linking a metric point to the expected trace/span identity.
+
+#### Acceptance criteria
+
+- A representative Work lineage is navigable from Work through dispatch and
+  provider spans.
+- Fan-in and predecessor relationships use links rather than false parenting.
+- Entity identifiers appear only on permitted span/link/exemplar surfaces.
+- Trace timestamps reproduce the recorded operation intervals rather than the
+  later export time.
+
+### Story 4: Configure and operate a real OTLP exporter safely
+
+#### Problem statement
+
+Mapped signals are not useful until operators can configure a supported OTLP
+destination with predictable lifecycle and failure behavior.
+
+#### Customer ask
+
+Enable OTel export without making Factory execution depend on collector health.
+
+#### Solution
+
+Add `runtime.otel` settings, standard environment resolution, injected OTLP
+network transport, bounded retry/backoff, and initializer-managed startup and
+shutdown.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\otel-projection-implementation-plan.md`
+
+#### Changes
+
+##### Package changes
+
+- Extend Operator Settings authored/document/effective contracts.
+- Add the exact OTLP network effect to `pkg/services/edges` when required for
+  functional replacement.
+- Compose exporter, Analytics reader, clock, logger, and lifecycle once in
+  `pkg/wire`.
+
+##### Contracts
+
+- Add enabled, endpoint, protocol, signal, interval, timeout, start, and
+  backfill settings with validation and precedence.
+
+##### Services
+
+- OTel Projection runs one bounded background export loop.
+- The external adapter performs one cancellation-aware network attempt per
+  call; projection policy owns retries.
+
+##### API changes
+
+- Author `runtime.otel` OpenAPI configuration fragments and regenerate every
+  required Go, TypeScript, schema, and publishable client artifact.
+
+##### Tests
+
+- Settings decode/encode/normalization/precedence tests.
+- Disabled-mode tests proving no network or background export activity.
+- Timeout, transient failure, permanent rejection, cancellation, retry, and
+  shutdown-flush tests with deterministic clocks/effects.
+- A functional test through `root.BuildProcess` and `Process.Execute`, replacing
+  only the exact exporter effect through `edges.Edges`.
+
+#### Acceptance criteria
+
+- Valid OTLP/gRPC and OTLP/HTTP configurations export successfully.
+- Invalid configuration fails before exporter lifecycle activation with an
+  actionable error.
+- Collector failure is visible but does not fail or delay domain operations.
+- Credentials never appear in logs, status, errors, test snapshots, or API
+  output.
+- Shutdown completes within the configured bound whether the collector is
+  healthy, slow, or unavailable.
+
+### Story 5: Resume projection with durable checkpoints and explicit gaps
+
+#### Problem statement
+
+Process restart or collector outage can otherwise duplicate retained signals
+or silently omit an interval.
+
+#### Customer ask
+
+Resume export predictably and make any unavoidable gap visible.
+
+#### Solution
+
+Persist a destination-scoped Analytics cursor only after successful export,
+support explicit retained-history backfill, and report expired-cursor gaps.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\otel-projection-implementation-plan.md`
+
+#### Changes
+
+##### Package changes
+
+- Add an OTel Projection-owned checkpoint contract and a policy-free durable
+  store adapter under `pkg/platform`.
+- Keep destination fingerprinting and gap policy in OTel Projection.
+
+##### Contracts
+
+- Define checkpoint identity, committed cursor, watermark, schema version,
+  first-start policy, gap outcome, and reset reason.
+
+##### Services
+
+- Projection commits after accepted export and resumes from the last committed
+  cursor.
+
+##### API changes
+
+- Include checkpoint and gap facts in the later status contract.
+
+##### Tests
+
+- Restart tests for successful resume, failed-batch retry, destination change,
+  schema change, retained cursor expiry, and explicit backfill.
+- Concurrency tests proving only one loop advances a destination checkpoint.
+- Corrupt-checkpoint tests with fail-closed recovery diagnostics.
+
+#### Acceptance criteria
+
+- A failed export never advances the cursor.
+- An ordinary restart resumes after the last accepted batch.
+- First enablement starts at `latest` unless backfill is explicit.
+- Cursor expiry produces a visible gap count and reason.
+- The contract promises at-least-once attempts, not impossible end-to-end
+  exactly-once delivery.
+
+### Story 6: Expose OTel projection status through `you metrics`
+
+#### Problem statement
+
+Operators cannot tell whether export is disabled, healthy, lagging, rejecting
+data, overflowing cardinality, or missing retained history.
+
+#### Customer ask
+
+Inspect OTel projection health from the same metrics command namespace.
+
+#### Solution
+
+Add read-only service status, OpenAPI mapping, and human/JSON CLI output for
+`you metrics otel status`.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\otel-projection-implementation-plan.md`
+
+#### Changes
+
+##### Package changes
+
+- Add status operation and detached result types at the OTel Projection root.
+- Add service-owned CLI/HTTP adapters and top-level protocol composition.
+
+##### Contracts
+
+- Define lifecycle, destination, signals, versions, lag, counts, timestamps,
+  gap, and sanitized failure fields.
+
+##### Services
+
+- Status reads immutable snapshots and causes no exporter side effect.
+
+##### API changes
+
+- Add the read-only status operation and authored schemas under
+  `api/components/`, then regenerate all required clients.
+- Add `you metrics otel status` to the authored CLI manifest and generated
+  command artifacts.
+
+##### Tests
+
+- Service tests for disabled, healthy, retrying, lagging, rejected, overflow,
+  gap, and shutdown states.
+- CLI golden tests for human and JSON output.
+- HTTP contract tests for the same states and secret redaction.
+- CLI-first functional proof through the canonical process graph.
+
+#### Acceptance criteria
+
+- Human output identifies the effective state and next operator action.
+- JSON contains stable fields and classifications suitable for automation.
+- Endpoint credentials and configured headers are absent.
+- Reading status does not export, flush, retry, reset, or advance a cursor.
+
+### Story 7: Prove collector interoperability and publish the convention
+
+#### Problem statement
+
+An internally valid mapping can still fail against a real collector or drift
+without a published semantic contract.
+
+#### Customer ask
+
+Trust that exported telemetry is accepted by standard OTel tooling and remains
+stable across releases.
+
+#### Solution
+
+Publish the custom `you.*` metric/span catalog, pin schema versions, add a
+collector interoperability smoke test, and document configuration,
+cardinality, privacy, and migration behavior.
+
+#### Original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\otel-projection-implementation-plan.md`
+
+#### Changes
+
+##### Package changes
+
+- Add versioned semantic-convention/catalog data owned by OTel Projection.
+- Add a focused interoperability fixture under
+  `tests/functional/observability/otel/`.
+
+##### Contracts
+
+- Record projection schema URL/version and pinned GenAI convention version in
+  exported scopes and status.
+
+##### Services
+
+- No new service behavior beyond version publication and compatibility
+  validation.
+
+##### API changes
+
+- Document OTel configuration and status in the canonical reference topic.
+- Keep generated CLI/API documentation synchronized.
+
+##### Tests
+
+- Validate representative metrics and traces through a supported OTel
+  Collector configuration without contacting an external service.
+- Add schema/catalog drift checks and sanitized golden payloads.
+- Run contract, generation, docs, package-boundary, race/stress, and PR
+  verification appropriate to the changed surfaces.
+
+#### Acceptance criteria
+
+- A supported collector accepts the representative OTLP metrics and traces.
+- The catalog documents every custom name, unit, kind, dimension, and
+  stability level.
+- Convention changes require an explicit version/migration update.
+- Public documentation explains that OTel is a lossy projection and canonical
+  Analytics/Costs results remain authoritative.
+
+## Project-level acceptance criteria
+
+- The production dependency graph is OTel Projection → Analytics → Costs, with
+  no reverse or bypass dependency.
+- Existing session, Work, Worker Session, and recording services retain their
+  current canonical responsibilities.
+- OTel export is disabled by default and performs no network calls when
+  disabled.
+- Collector failure cannot fail, block, or mutate Factory execution or
+  canonical analytical results.
+- Metrics use controlled cardinality; entity IDs appear only on traces, links,
+  exemplars, and safe diagnostics.
+- Exact costs and currencies remain Costs-owned; OTel monetary values are
+  clearly approximate telemetry projections.
+- OpenAPI, CLI manifests, generated Go/TypeScript clients, schemas, and
+  published documentation remain synchronized.
+- Focused unit, package integration, contract, functional, race/stress, and
+  collector interoperability evidence passes.
+- Delivery continues through required CI until it is terminal and passing;
+  blocking review feedback is addressed, conflicts are resolved, generated
+  drift is reconciled, and the pull request is actually merged. Opening or
+  approving the PR is not completion.
+
+## Verification plan
+
+Use the narrowest focused commands during each story, then broaden before
+merge. Expected final gates include, as applicable:
+
+```text
+go test ./pkg/services/analytics/... ./pkg/services/otel_projection/...
+go test -race ./pkg/services/otel_projection/...
+go test ./pkg/services/operator_settings/... ./pkg/transports/...
+go test ./tests/functional/observability/otel/...
+make generate-api
+make api-smoke
+make docs-reference-smoke
+make pkg-boundary
+make pkg-file-count
+make verify-pr
+```
+
+The implementation should add a bounded stress case covering sustained
+Analytics batches, slow collector responses, retry backoff, checkpoint safety,
+and shutdown. Tests must use deterministic clocks and injected effects rather
+than sleep-based synchronization.
+
+## Delivery order
+
+1. Land the prerequisite Costs service contract and behavior.
+2. Land the prerequisite Analytics service and Costs dependency.
+3. Publish the cursorable Analytics telemetry feed.
+4. Land metrics mapping before network lifecycle.
+5. Add traces, links, and exemplars.
+6. Add configuration and the real OTLP adapter.
+7. Add durable checkpoints and backfill/gap behavior.
+8. Add status CLI/API and customer documentation.
+9. Complete collector interoperability, stress verification, blocking review
+   resolution, terminal green CI, conflict resolution, and merge.

--- a/docs/internal/development/plans/provider-harness-capability-catalog-plan.md
+++ b/docs/internal/development/plans/provider-harness-capability-catalog-plan.md
@@ -1,0 +1,1028 @@
+# Provider Harness Capability Catalog Plan
+
+## Status
+
+Proposed.
+
+## Problem statement
+
+Customers cannot reliably compare model and execution-harness pairings because
+the Providers catalog richly describes only the three native integrations,
+while packaged ACP integrations have launch commands but no authored model,
+modality, tool, evidence, or protocol-support facts.
+
+## Customer ask
+
+Publish a complete, machine-readable inventory that helps customers choose a
+provider harness and model based on:
+
+- whether the harness uses ACP or a native adapter;
+- the input and output modalities the harness can carry;
+- the modalities supported by each known model;
+- the tools the harness provides out of the box or through configuration;
+- the difference between static documented support, an unknown fact, and a
+  capability observed from a live installed ACP agent; and
+- the complete set of ACP harnesses the product intentionally supports, with each
+  harness owning enough implementation detail to differ from every other ACP
+  harness.
+
+The initial must-prove examples supplied with the request are:
+
+- Antigravity/Gemini can accept video and audio through MP4 files and can
+  generate images.
+- Codex accepts image input and can generate images.
+- Grok CLI supports video and image generation.
+- ACP support differs by harness and must be explicit.
+- Qwen Code and applicable Qwen models support video input.
+
+These examples are acceptance fixtures to verify against primary documentation
+and executable conformance evidence; the catalog must not turn an unverified
+claim into `supported` merely because it appeared in a plan.
+
+## Current repository findings
+
+The repository already contains much of the required foundation:
+
+- `ProviderManifest` supports exact model IDs, directional text/image/audio/
+  video facts, transports, named tools, known limits, support posture, and
+  discovery prerequisites.
+- `packages/model-providers/providers/` authors rich manifests for
+  `antigravity`, `claude`, and `codex` and generates the public catalog and
+  schemas.
+- `you providers list --json` exposes models, modalities, tools, and limits for
+  descriptors that contain those facts.
+- `pkg/services/providers/internal/services/builtins/wire/catalog.json`
+  contains 20 packaged ACP launch entries.
+- The official [ACP Registry](https://github.com/agentclientprotocol/registry)
+  can help discover candidate agents and basic distribution metadata, but its
+  published format intentionally lacks the model, modality, tool, evidence,
+  execution-policy, and adapter detail You needs. It cannot be the product
+  source of truth.
+
+The principal gaps are:
+
+1. Native provider metadata and ACP launch metadata have separate authored
+   sources.
+2. ACP descriptors are synthesized with one generic optimistic capability set;
+   their models, modalities, tools, limits, support posture, and evidence are
+   empty.
+3. `supported` and `unsupported` exist, but `unknown` and `conditional` do not.
+   An empty model or tool list therefore cannot state whether the harness has
+   none, uses runtime discovery, or has not been researched.
+4. Model modalities currently represent an end-to-end provider/model fact but
+   cannot independently express what the harness can transport and what the
+   selected model can understand or emit.
+5. `file_path` cannot explain relevant constraints such as accepted media
+   types, containers, resource-link delivery, or tool-mediated output.
+6. Tool support cannot distinguish built-in/default tools from optional,
+   user-configured, external, or unknown tools.
+7. The CLI `show` projection, HTTP mapping, and MCP schema expose less metadata
+   than the domain descriptor and CLI list JSON.
+8. ACP initialize negotiation is retained internally after a successful run,
+   but it is not represented as a separate observed capability layer in
+   customer discovery.
+
+## Intended outcome
+
+The Providers service remains the single identity, catalog, selection, and
+execution authority. Each provider descriptor explicitly describes the
+execution harness, its static capability evidence, its model catalog posture,
+and any separately observed runtime facts. Generated packages, CLI output, HTTP
+mapping, and MCP tools project the same information without launching a
+provider during ordinary catalog discovery.
+
+A customer can answer questions such as:
+
+- “Which harness/model pairings can accept video input?”
+- “Which of those also have a built-in image-generation tool?”
+- “Is this harness ACP-based, natively adapted, or only cataloged?”
+- “Is the claim documented, live-observed, conditional on the selected model,
+  or still unknown?”
+- “What installation command or prerequisite applies on my platform?”
+
+The product will filter for compatible pairings and explain uncertainty; it
+will not claim to rank subjective model quality.
+
+## Scope
+
+### In scope
+
+- Extending the existing provider manifest and Providers-owned descriptor.
+- Unifying native and packaged ACP metadata behind the generated provider
+  catalog.
+- Making each directory below `packages/model-providers/providers/` the
+  complete authored source for one native or ACP harness, including its public
+  facts and harness-specific runtime inputs.
+- Migrating every ACP harness the product intentionally ships into that package
+  structure and adding new ACP harnesses through the same contribution path.
+- An optional maintainer tool that reads the ACP registry to scaffold partial
+  candidate metadata; generated candidates have no authority until reviewed
+  and completed as provider packages.
+- Preserving all existing provider identities, aliases, and persisted worker
+  configuration behavior.
+- Full, deterministic CLI JSON and human projections, including a compatibility
+  query for model/harness selection.
+- Aligning provider package schemas/types, Providers domain projection, HTTP
+  and MCP mappings, generated artifacts, docs, and focused tests.
+- Optional live inspection of an installed ACP harness, with observations kept
+  separate from static authored claims.
+
+### Out of scope
+
+- Automatically downloading or installing arbitrary binary ACP agents.
+- Automatically trusting every capability statement in third-party marketing
+  or the ACP registry.
+- Ranking providers by quality, price, speed, or benchmark score.
+- Treating a model-family name as proof that every model in that family has the
+  same modalities.
+- A dashboard picker in the first delivery lane. The API/types must permit a
+  later UI without introducing UI-owned provider truth.
+- Renaming Providers to Harnesses or adding a parallel harness registry.
+- Treating ACP-registry membership as a requirement for inclusion, support, or
+  removal.
+
+## Canonical data and ownership
+
+| Concern | Canonical owner | Notes |
+| --- | --- | --- |
+| Provider identity, aliases, selection, descriptor, and one-attempt execution | `pkg/services/providers` | No second harness catalog or registry. |
+| Authored public manifest vocabulary | OpenAPI component fragments under `api/components/schemas/model-providers/` | `api/openapi.yaml` and language clients remain generated. |
+| One harness's complete authored definition | `packages/model-providers/providers/<provider-id>/` | The directory owns public metadata, harness kind, runtime launch/adapter configuration, capabilities, evidence, and harness-local fixtures. |
+| Supported provider inventory | The set of valid provider package directories | A provider exists because You authors and reviews its package, not because a remote registry lists it. |
+| Optional external discovery metadata | Maintainer-time import output, initially from the ACP registry | Scaffolding input only; never read by runtime, normal generation, or CI as authority. |
+| Public generated provider catalog | `packages/model-providers/generated/catalog.json` | Generated; never hand-edited. |
+| Runtime native/ACP projection | Generated from provider package directories | Replaces separately authored command-only or adapter-registration inventories where practical. |
+| Static customer discovery | Providers Catalog service | Side-effect-free and marked `unverified` for machine readiness. |
+| Live ACP observations | Providers ACP service and a Providers-owned inspection result | Never overwrite the authored static maximum or become durable truth without a separately approved persistence design. |
+
+### Provider package shape
+
+Each provider directory is a small package boundary, not merely one row in a
+global catalog. A package may contain:
+
+```text
+packages/model-providers/providers/<provider-id>/
+  provider.yaml              # public identity, support, models, modalities, tools
+  harness.yaml               # discriminated native_cli/acp execution definition
+  evidence.yaml              # bounded evidence records referenced by public facts
+  README.md                  # maintainer notes and primary-source links
+  testdata/                  # sanitized handshake/output/capability fixtures
+```
+
+The exact file split may be simplified when a provider is small, but the
+directory is the ownership boundary and generator input. A provider-specific
+harness definition may express different commands, flags, environment rules,
+session behavior, output fidelity, permission behavior, model discovery, and
+ACP quirks without widening one global ACP record into a lowest-common-
+denominator schema. Shared schema vocabulary describes comparable customer
+facts; provider-local files preserve the implementation detail needed to
+execute and verify that harness.
+
+The generator discovers package directories, validates each package as a
+cohesive unit, and produces detached public and runtime projections. No global
+overlay is allowed to silently change an individual provider package's
+capabilities or execution behavior.
+
+### Harness-specific runtime ownership
+
+The provider package also owns the declarative binding to the Providers
+runtime implementation that executes it. The common contract should be a
+discriminated envelope, not one flattened ACP configuration:
+
+```yaml
+implementation:
+  kind: native_adapter | acp_agent
+  profile: qwen-acp
+  launch:
+    command: qwen
+    arguments: [--acp]
+  promptContent:
+    video: resource_link
+    audio: resource_link
+  modelDiscovery: session_config
+  sessionResume: acp_load_session
+  permissions: acp_request_permission
+```
+
+The profile name is a validated binding, not a service locator. Concrete
+execution code remains owned by `pkg/services/providers` and constructed by
+`pkg/wire`; the provider package supplies the data and selects an already
+registered typed implementation. Construction must fail when an executable
+provider package references no implementation or when an implementation has no
+owning provider package.
+
+Provider packages may differ in:
+
+- executable/package-runner and platform-specific launch shapes;
+- prompt attachment encoding, supported MIME types, and file/resource-link
+  behavior;
+- model discovery and model-selection mechanisms;
+- session creation, resume, and reconnect behavior;
+- permission/authentication handling;
+- response-fidelity and tool-event normalization;
+- default timeouts, working-directory behavior, and environment requirements;
+  and
+- harness-local conformance fixtures and known limits.
+
+Reusable ACP protocol transport remains shared. Provider-specific behavior is
+expressed by typed profiles or focused adapters, never by inferring behavior
+from the provider name and never by a global map outside the provider package
+generation path.
+
+## Proposed contract
+
+The exact field names should be finalized in the OpenAPI review, but the
+contract must preserve the following semantics.
+
+### 1. Harness integration facts
+
+Add a provider-level harness object:
+
+```yaml
+harness:
+  kind: native_cli | acp
+  transports: [stdio]
+  acp:
+    support: supported | unsupported | unknown
+    protocolVersions: [1]
+    initialization: retained_daemon | per_attempt
+  launch:
+    posture: bundled | package_runner | installed_executable | catalog_only
+    platformSupport: [darwin-aarch64, linux-x86_64, windows-x86_64]
+  externalCatalogReferences:
+    - kind: acp_registry
+      id: qwen-code
+```
+
+Requirements:
+
+- ACP support is a typed fact, never inferred from an `-acp` suffix.
+- External catalog references are optional provenance/discovery links. They do
+  not define the canonical ID, launch behavior, support level, or capability
+  facts. Existing IDs such as `cursor-acp`, `gemini-acp`, and `droid-acp`
+  remain accepted.
+- A provider package can be present as `catalog_only` when its harness
+  implementation is intentionally documented but cannot yet be launched by
+  the current local execution contract.
+- Static catalog readiness remains `unverified`; a packaged command is not
+  evidence that its executable or authentication is ready.
+
+### 2. Explicit support state and evidence
+
+Extend modality, tool, and protocol facts to use:
+
+```text
+supported | unsupported | conditional | unknown
+```
+
+`conditional` must name the condition, normally the selected model, provider
+account feature, platform, or operator configuration. `unknown` is a positive
+data value and must never be collapsed into an absent array or `unsupported`.
+
+Add bounded evidence records and references:
+
+```yaml
+evidence:
+  - id: qwen-video-docs-2026-08
+    kind: primary_documentation | protocol_probe | conformance_fixture | maintainer_assertion
+    url: https://...
+    verifiedAt: 2026-08-10
+    harnessVersion: 1.2.3
+```
+
+Every `supported`, `unsupported`, or `conditional` modality and every supported
+tool must cite at least one evidence record. `unknown` requires no evidence.
+The generator validates evidence references, dates, and bounded descriptions;
+it does not make network calls.
+
+### 3. Harness and model modalities
+
+Keep model modalities, and add the harness-level routes needed to determine
+end-to-end compatibility:
+
+```yaml
+harnessModalities:
+  - direction: input
+    modality: video
+    support: supported
+    mechanisms: [file_path]
+    mediaTypes: [video/mp4]
+    fileExtensions: [.mp4]
+    evidenceRefs: [agy-video-fixture]
+```
+
+The route vocabulary must distinguish at least:
+
+- inline content;
+- file path;
+- ACP resource link or embedded content, if implemented;
+- tool-mediated output; and
+- none.
+
+Model records retain directional modalities and gain the same support/evidence
+semantics. Add a provider-level model-catalog posture:
+
+```text
+exact | runtime_discovered | operator_selected | unknown
+```
+
+An empty `models` array therefore has an explicit meaning. A model/harness
+pairing supports a modality only when both layers support a compatible route.
+If either layer is `unknown`, the effective result is `unknown`; if either is
+`unsupported`, the effective result is `unsupported`; conditional facts retain
+their explanation.
+
+Image generation must not be misrepresented as native image output when it is
+available only through a tool. In that case, the harness declares an
+image-generation tool whose output modality is image and the model's direct
+output modality remains truthful.
+
+### 4. Tool availability
+
+Extend named tools beyond `supported`/`unsupported`:
+
+```yaml
+tools:
+  - name: image_generation
+    support: supported
+    availability: built_in | optional | operator_configured | external | unknown
+    enabledByDefault: true | false | null
+    outputModalities: [image]
+    description: Generate an image through the harness-provided tool.
+    evidenceRefs: [codex-imagegen-docs]
+```
+
+Use stable provider-neutral tool names for matching, with optional native names
+as aliases. The initial vocabulary should include the existing `filesystem`,
+`shell`, and `web_search` names and add only evidenced categories needed by the
+seed providers, such as `image_generation`, `video_generation`, `browser`, and
+`mcp`. Do not claim tools inherited only from the host Codex environment as
+provider-harness defaults unless the shipped integration actually supplies
+them.
+
+### 5. Static versus observed ACP capabilities
+
+Static manifest facts answer what a maintained provider version is evidenced
+to support. A live inspection result answers what one installed process
+negotiated at a point in time:
+
+```yaml
+observed:
+  source: acp_initialize
+  observedAt: 2026-08-10T12:34:56Z
+  protocolVersion: 1
+  harnessVersion: 1.2.3
+  capabilities: {...}
+```
+
+Plain `you providers list` remains inert. A separate explicit inspection
+operation may launch the provider and must report authentication, executable,
+timeout, and protocol failures without mutating the static catalog. The
+operation must advertise only ACP fields actually present in the protocol;
+model modality and tool claims still require their own evidence when ACP does
+not negotiate them.
+
+### 6. Custom ACP integrations
+
+Operator-configured ACP entries continue to work. Unless the operator also
+selects a known catalog identity, their model catalog, modalities, and tools are
+`unknown`. The runtime must remove the current generic ACP descriptor that
+optimistically claims image input, streaming, reasoning, tools, file changes,
+plans, and usage for every custom command.
+
+## Provider package and optional ACP import policy
+
+1. The set of valid directories below `packages/model-providers/providers/` is
+   the complete supported inventory. Normal generation walks those directories
+   and has no network dependency.
+2. Move the current packaged ACP launch entries into individual provider
+   packages. Their runtime commands, aliases, protocol posture, modality/tool
+   facts, and tests must be owned by the same package.
+3. A new provider is added by contributing a complete provider package and
+   passing its schema, evidence, projection, and harness conformance checks.
+   ACP-registry membership is neither necessary nor sufficient.
+4. Provide an optional maintainer command such as `you-dev providers import-acp`
+   that fetches or accepts an ACP-registry document and emits candidate package
+   scaffolds or a comparison report into a temporary/output directory.
+5. Imported fields are restricted to facts the external source actually owns,
+   such as display name, website, repository, distribution, and suggested
+   command. Capability, support, readiness, and implementation fields are
+   emitted as unknown/TODO and require local review.
+6. The import tool never edits existing provider packages, never makes a
+   provider selectable, never updates generated artifacts, and is not invoked
+   by ordinary builds or CI.
+7. Existing canonical IDs and aliases remain resolvable in worker configs,
+   Factory definitions, recordings, and provider-session references. An
+   optional external catalog reference can document a related upstream entry
+   without changing You's identity.
+8. Local packages remain supported or deprecated according to You's evidence
+   and maintenance policy. No package is added, changed, or removed solely
+   because a remote registry changed.
+
+## Customer surfaces
+
+### Catalog listing and detail
+
+- `you providers list` shows a compact deterministic summary suitable for the
+  expanded inventory: identity, harness kind, support posture, readiness,
+  model-catalog posture, and high-level known modality/tool counts.
+- `you providers show <id>` becomes the complete human detail view and includes
+  every fact present in JSON.
+- `you providers list --json` and `you providers show <id> --json` emit the
+  complete typed descriptor with explicit empty arrays and explicit unknown
+  states.
+- `you workers list` continues to focus on selectable execution integrations;
+  catalog-only entries remain discoverable through `you providers` without
+  pretending they can run.
+
+If changing the current verbose human `list` output is judged too disruptive,
+retain it for compatibility and add a compact flag first. JSON field additions
+must follow the repository's public-contract compatibility policy.
+
+### Pair compatibility query
+
+Add a pure, side-effect-free Providers operation and CLI projection, for
+example:
+
+```text
+you providers match --input video --output image --tool image_generation
+you providers match --interface acp --input video --json
+```
+
+Matching uses AND semantics across requested constraints and returns each
+candidate harness/model pair with:
+
+- `compatible`, `conditional`, `unknown`, or `incompatible` outcome;
+- the harness route and model fact used for each modality;
+- tool availability and whether it is built in;
+- evidence references; and
+- reasons for conditional, unknown, or rejected candidates.
+
+The operation does not rank model intelligence or silently exclude unknown
+facts. Default human output may show compatible and conditional candidates;
+JSON includes all evaluated candidates and reasons.
+
+### Programmatic consumers
+
+- Extend the published model-provider schemas and generated TypeScript types.
+- Keep Providers root values detached and clone-safe.
+- Bring the existing Providers HTTP list/get mapping and MCP list/get schemas
+  to full descriptor parity.
+- If REST provider discovery is promoted to the public OpenAPI paths, add it as
+  a separately reviewed API behavior with generated Go/TypeScript clients and
+  contract tests; do not expose an undocumented transport-only shape.
+- A later dashboard consumes generated API types and projections. It must not
+  import or recreate the catalog as UI-owned state.
+
+## Implementation stories
+
+### Story 1: Publish a truthful provider-harness capability contract
+
+As a catalog consumer, I can distinguish harness capabilities, model
+capabilities, built-in tools, ACP support, conditions, unknown facts, and
+evidence so that an absent fact is never mistaken for support.
+
+Acceptance criteria:
+
+- OpenAPI component fragments define harness kind, ACP metadata, model-catalog
+  posture, support states, modality routes/media types, tool availability, and
+  evidence records.
+- The generated Provider Manifest and Provider Catalog schemas reject duplicate
+  facts, dangling evidence references, unsupported route/support combinations,
+  unqualified conditional facts, and direct/tool-mediated output
+  contradictions.
+- `antigravity`, `claude`, and `codex` migrate without losing their current
+  exact model IDs, efforts, limits, prerequisites, or response-fidelity facts.
+- The five seed examples are represented only after a primary source or
+  checked conformance fixture verifies them.
+- Generated OpenAPI, Go, TypeScript, provider catalog, and package artifacts are
+  current and are not hand-edited.
+
+Evidence:
+
+- Schema/generator unit tests for every enum and invalid combination.
+- Golden catalog tests for supported, unsupported, conditional, and unknown
+  modality/tool cases.
+- Existing provider projection and CLI capability tests updated to prove no
+  fact loss.
+
+### Story 2: Package every supported ACP harness without breaking identities
+
+As a customer, I can discover every ACP harness the product intentionally supports,
+with its own implementation and capability definition, while only verified
+launch mappings are selectable.
+
+Acceptance criteria:
+
+- Every current packaged ACP entry is migrated into exactly one provider
+  package directory with its launch behavior, aliases, protocol posture,
+  runtime implementation profile, capability facts, evidence, and
+  harness-local fixtures.
+- All 20 current packaged ACP identities continue to resolve, either as stable
+  canonical IDs or documented aliases, and persisted worker configuration does
+  not require migration.
+- A newly supported ACP harness is added only through a reviewed provider
+  package; an optional import scaffold is insufficient to publish it.
+- A package whose execution integration is incomplete can be intentionally
+  visible as `catalog-only` with unknown capability facts and actionable
+  documentation/prerequisites.
+- Selectable ACP entries derive their runtime command projection from the same
+  provider package used for discovery.
+- Build-time validation rejects selectable packages with missing runtime
+  implementation bindings and registered provider implementations with no
+  owning package.
+- Ordinary list/get construction does not fetch an external catalog, launch an
+  agent, inspect the filesystem, or open a network connection.
+
+Evidence:
+
+- Provider-package discovery, completeness, and generated-projection drift
+  tests.
+- Table-driven legacy ID and alias resolution tests.
+- Catalog/runtime projection parity tests.
+- Harness-profile registration and provider-local conformance fixtures for
+  attachment mapping, model selection, session behavior, and response fidelity
+  where those behaviors differ.
+- A functional `root.BuildProcess` providers-list test that proves zero provider
+  command executions.
+
+### Story 3: Expose one complete descriptor across CLI, HTTP, MCP, and custom ACP
+
+As a customer or automation author, I receive the same provider-harness facts
+from every supported discovery surface.
+
+Acceptance criteria:
+
+- CLI list/show human and JSON outputs include harness, model-catalog,
+  modality, tool, evidence, support-posture, readiness, and prerequisite facts
+  with deterministic ordering.
+- Providers HTTP mapping and MCP list/get result schemas include the complete
+  descriptor rather than the current reduced identity/capability subset.
+- A configured custom ACP command is selectable but reports unknown models,
+  modalities, and tools instead of the generic optimistic ACP capabilities.
+- Static discovery reports readiness `unverified` until an explicit probe or
+  execution produces observed readiness facts.
+- Unknown, conditional, unsupported, and supported values survive every
+  projection unchanged.
+
+Evidence:
+
+- Domain-to-CLI, domain-to-HTTP, and domain-to-MCP contract tests over the same
+  fixture.
+- JSON-schema validation of CLI/MCP/API examples where applicable.
+- Functional CLI discovery tests for native, packaged ACP, catalog-only, and
+  custom ACP entries.
+
+### Story 4: Match model and harness pairings by requested capabilities
+
+As a customer choosing an execution configuration, I can ask which
+harness/model pairs satisfy required modalities and tools and see why uncertain
+or incompatible candidates do not fully match.
+
+Acceptance criteria:
+
+- A pure Providers operation evaluates harness routes, model facts, tool
+  availability, and model-catalog posture without I/O.
+- The CLI supports ACP/native, input modality, output modality, and tool
+  constraints with documented AND semantics.
+- A tool-mediated image output does not satisfy a request for direct model
+  image output unless the request permits tool-mediated output.
+- Dynamic or unknown model catalogs return conditional/unknown candidates
+  rather than fabricated model IDs or false incompatibility.
+- The seed cases produce the expected evidenced candidates after their facts
+  are verified.
+
+Evidence:
+
+- Table-driven pure matching tests covering supported, conditional, unknown,
+  unsupported, route mismatch, tool-mediated output, and dynamic models.
+- CLI human/JSON contract tests with deterministic result and explanation
+  ordering.
+- One functional match invocation through `root.BuildProcess`.
+
+### Story 5: Inspect live ACP negotiation without corrupting static truth
+
+As an operator, I can explicitly inspect an installed ACP agent and compare its
+negotiated protocol capabilities with the static catalog before assigning real
+work.
+
+Acceptance criteria:
+
+- Inspection is an explicit operation; ordinary list, show, and match remain
+  side-effect-free.
+- The result records protocol version, observed timestamp, sanitized harness
+  version when available, and negotiated ACP capabilities.
+- Timeout, missing executable, authentication, malformed protocol, and version
+  mismatch outcomes are typed and actionable without leaking command lines,
+  credentials, or raw stderr.
+- Observed facts are returned separately and never rewrite authored capability
+  metadata.
+- ACP fields not negotiated by the protocol remain static or unknown; the
+  inspection does not infer video/model/tool support from unrelated flags.
+
+Evidence:
+
+- ACP command-runner edge fixtures for success and each failure class.
+- Concurrency coverage proving inspection cannot race or corrupt an in-flight
+  retained daemon/session.
+- Structured safe-operation logging tests.
+
+### Story 6: Make catalog maintenance and customer guidance durable
+
+As a maintainer and customer, I can add or update provider packages
+reproducibly and understand how to interpret support, unknown facts, tools, and
+pair matching.
+
+Acceptance criteria:
+
+- An optional ACP-registry import command emits partial candidate scaffolds or
+  a comparison report without modifying canonical provider packages.
+- Offline package validation and generation checks prove that provider package
+  definitions and all generated public/runtime projections agree.
+- The model-provider package README/support guide and `you docs providers` /
+  `you docs harnesses` describe the source/evidence model, catalog-only entries,
+  live observations, pairing query, and custom ACP unknown behavior.
+- Documentation includes verified Antigravity, Codex, Grok, and Qwen examples
+  without claiming capabilities broader than the evidence.
+- Generated catalog/schema/package files and runtime ACP projection remain in
+  sync after a clean generation run.
+
+Evidence:
+
+- Import-tool unit tests over a frozen ACP-registry fixture prove that only
+  basic discovery/distribution fields are copied and all unsupported facts
+  remain unknown/TODO.
+- Provider-package discovery and generation tests run without network access.
+- `make docs-reference-smoke` and model-provider package verification.
+- A manual review of human CLI output at the full inventory size on Windows and
+  one Unix-like platform.
+
+## Delivery sequencing
+
+1. Story 1 establishes semantics and migrates the current rich native entries.
+2. Story 2 moves ACP inventory into the canonical generation path and preserves
+   compatibility.
+3. Story 3 exposes the completed data consistently and removes optimistic
+   custom-ACP defaults.
+4. Story 4 adds side-effect-free compatibility matching once catalog truth is
+   trustworthy.
+5. Story 5 adds explicit live observation as a separate, higher-risk behavior.
+6. Story 6 completes maintenance automation and customer guidance; its docs
+   should evolve alongside earlier stories and be finalized after behavior is
+   stable.
+
+Stories 1-3 form the minimum useful release. Story 4 is the customer-selection
+outcome. Story 5 may ship separately because it introduces process and
+concurrency risk; it is not a prerequisite for truthful static discovery.
+
+## API and generated-artifact changes
+
+Expected authored contract changes include:
+
+- `api/components/schemas/model-providers/ProviderManifest.yaml`
+- `ProviderModel.yaml`, `ProviderModality*.yaml`, and `ProviderTool*.yaml`
+- new harness, evidence, model-catalog-posture, route, availability, and
+  pairing-result component fragments
+- the matching component references in `api/openapi-main.yaml`
+
+Expected generated or projected outputs include:
+
+- `api/openapi.yaml`
+- generated Go/TypeScript OpenAPI types when the components are consumed there
+- `packages/model-providers/generated/*.json`
+- `packages/model-providers/types/*.d.ts`
+- `packages/model-providers/generated/catalog.json`
+- the runtime packaged ACP launch projection
+- CLI generated command manifests if new `match` or `inspect` commands are
+  added
+
+The implementation must use the repository generation targets and must not
+hand-edit these outputs.
+
+## Test and verification plan
+
+Use the narrowest useful checks during each story, then the public/shared gates
+before merge:
+
+```text
+go test ./internal/providercatalog/...
+go test ./packages/model-providers/...
+go test ./pkg/services/providers/...
+go test ./pkg/transports/cli/...
+go test ./tests/functional/providers/...
+make generate-api
+make provider-catalog-generate
+make provider-catalog-check
+make model-provider-package-generate
+make model-provider-package-check
+make docs-reference-smoke
+make api-smoke                 # when a public REST surface changes
+make verify-fast
+make verify-pr
+make build-all
+```
+
+Required behavioral coverage:
+
+- deterministic offline generation and drift detection;
+- complete modality matrix validation for text/image/audio/video in both
+  directions, including unknown and conditional values;
+- harness/model route intersection and tool-mediated outputs;
+- duplicate/colliding provider package IDs, external references, and aliases;
+- every valid provider package accounted for exactly once in public and runtime
+  projections;
+- all legacy ACP IDs still resolving;
+- no process or network side effects from static discovery/matching;
+- custom ACP facts remaining unknown;
+- live inspection failure classification, cancellation, safe logging, and
+  concurrency isolation;
+- CLI human/JSON, HTTP, and MCP projection parity; and
+- generated schema/package/runtime projection parity.
+
+Functional tests must construct through `root.BuildProcess` and execute through
+`Process.Execute`, prefer CLI entry for customer flows, replace provider
+process effects through `edges.Edges` command-runner seams, and avoid sleeps in
+favor of deterministic fixtures.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Capability facts age quickly | Require evidence date/version, make unknown explicit, and review provider packages independently. |
+| A global schema collapses meaningful harness differences | Make the provider directory the package boundary and use discriminated harness definitions plus provider-local fixtures. |
+| External registry churn leaks into the product | Treat imports as optional scaffolding only; normal generation reads provider packages and remains offline. |
+| Provider IDs collide with external catalog IDs | Store optional external references separately and preserve local canonical IDs/aliases. |
+| Harness support is confused with model support | Keep separate harness routes and model modalities; derive pairing results by intersection. |
+| Image generation is confused with direct image output | Represent tool-mediated output on the tool and require match callers to allow it. |
+| Large human output becomes unusable | Make `show` the complete detail view and provide filtering/matching while retaining compatible list behavior. |
+| Generic custom ACP claims remain misleading | Default custom entries to unknown and add optional live inspection. |
+| A remote import becomes a production dependency | Restrict network access to an explicit maintainer tool; generated/runtime code reads provider packages only. |
+
+## Project-level acceptance criteria
+
+- The Providers service remains the only canonical catalog/selection/execution
+  owner.
+- Every valid directory below `packages/model-providers/providers/` appears
+  exactly once in the generated public catalog and, where executable, exactly
+  once in the runtime registration projection.
+- Provider package directories, not the ACP registry or a global overlay, own
+  harness-specific launch, capability, model, tool, evidence, and conformance
+  facts.
+- Existing ACP identities and aliases continue to resolve from persisted
+  configurations and Factory definitions.
+- Customers can distinguish native versus ACP harnesses, harness versus model
+  modality support, direct versus tool-mediated output, built-in versus
+  configured tools, and static versus observed facts.
+- Unsupported, conditional, and unknown are never collapsed into one another.
+- Plain discovery and matching are side-effect-free.
+- CLI JSON, published package types/catalog, HTTP mapping, and MCP schemas agree
+  on the descriptor contract.
+- Required focused checks, generated-artifact checks, `verify-pr`, and relevant
+  package/API/docs gates are terminal and passing.
+- Delivery continues through blocking review feedback, conflict resolution,
+  terminal green CI, and actual PR merge. Opening a PR or reaching green CI
+  without merge is not completion.
+
+## Work-story task packets
+
+Each implementation task submitted to You Agent Factory workers must use the
+repository task template. The packets below are the minimum independently
+reviewable units; an implementation PR may split a packet further but must not
+combine unrelated cleanup.
+
+### Task packet: capability contract
+
+# problem statement
+
+Provider manifests cannot distinguish harness support, model support,
+conditional/unknown facts, tool availability, or evidence.
+
+## customer ask
+
+Publish truthful model/harness modalities, tools, and ACP support for automated
+and human provider selection.
+
+## solution
+
+Extend the authored OpenAPI provider-manifest vocabulary, generator semantics,
+and native manifests with separate harness/model facts and evidence.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\provider-harness-capability-catalog-plan.md`
+
+# changes
+
+## package changes
+
+- Extend authored provider schemas and `internal/providercatalog` validation.
+- Migrate current native provider manifests and regenerate package artifacts.
+
+## contracts
+
+- Add harness kind/ACP metadata, support states, modality routes, model-catalog
+  posture, tool availability, and evidence records.
+
+## services
+
+- Extend the Providers descriptor/projection without adding a new registry.
+
+## API changes
+
+- Regenerate OpenAPI and generated consumers from component fragments.
+
+## tests
+
+- Add schema, semantic-validation, projection, and native golden tests.
+
+### Task packet: provider-packaged ACP inventory
+
+# problem statement
+
+The command-only ACP catalog is incomplete and separate from public provider
+capability truth.
+
+## customer ask
+
+Discover all ACP harnesses You intentionally packages without breaking current
+provider names or pretending every entry is executable.
+
+## solution
+
+Migrate every shipped ACP harness into its own provider package and derive both
+public descriptors and runtime launch mappings from those package directories.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\provider-harness-capability-catalog-plan.md`
+
+# changes
+
+## package changes
+
+- Add harness/evidence files, typed runtime-profile bindings, and provider-local
+  fixtures to the current ACP provider packages.
+- Add provider-package discovery/generator checks and optional ACP import
+  scaffolding.
+- Replace the independently authored runtime ACP inventory with a generated
+  projection.
+
+## contracts
+
+- Add discriminated ACP harness internals, optional external catalog
+  references, distribution/platform, and catalog-only posture without changing
+  Providers canonical identity ownership.
+
+## services
+
+- Project ACP descriptors, typed implementation-profile bindings, and launch
+  registrations from the same provider package while keeping execution code in
+  the Providers service.
+
+## API changes
+
+- Publish every provider-packaged ACP descriptor through the existing catalog
+  contract.
+
+## tests
+
+- Add provider-package completeness, runtime-profile registration,
+  harness-local conformance, drift, alias compatibility, no-side-effect,
+  optional-import, and projection parity tests.
+
+### Task packet: discovery parity and custom ACP truth
+
+# problem statement
+
+CLI show, HTTP, and MCP omit rich provider facts, and custom ACP integrations
+receive unsupported optimistic claims.
+
+## customer ask
+
+Consume the same truthful capability metadata from every discovery surface.
+
+## solution
+
+Project the complete Providers descriptor everywhere and make unresearched
+custom ACP capability fields explicitly unknown.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\provider-harness-capability-catalog-plan.md`
+
+# changes
+
+## package changes
+
+- Extend CLI list/show renderers and JSON shapes.
+- Extend HTTP mappings and MCP schemas/results.
+
+## contracts
+
+- Preserve every support/evidence state across projections with deterministic
+  ordering and explicit empty arrays.
+
+## services
+
+- Replace generic custom-ACP capability synthesis with unknown facts.
+
+## API changes
+
+- Align existing provider discovery transports; add public OpenAPI paths only
+  through a separately reviewed API contract if required.
+
+## tests
+
+- Add shared-fixture CLI/HTTP/MCP parity and functional custom-ACP discovery
+  coverage.
+
+### Task packet: provider pairing match
+
+# problem statement
+
+Raw metadata still forces customers to manually intersect harness routes,
+model modalities, and tool availability.
+
+## customer ask
+
+Identify harness/model pairings that satisfy required modalities and tools.
+
+## solution
+
+Add a pure Providers pairing evaluator and a deterministic `you providers
+match` CLI projection with explicit uncertainty and rejection reasons.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\provider-harness-capability-catalog-plan.md`
+
+# changes
+
+## package changes
+
+- Add Providers match request/result values and pure evaluation logic.
+- Add CLI manifest, handler, human output, and JSON output.
+
+## contracts
+
+- Define constraints, AND semantics, result status, evidence, and direct versus
+  tool-mediated output behavior.
+
+## services
+
+- Expose matching through the Providers service root; perform no I/O.
+
+## API changes
+
+- Add MCP/HTTP match only if those transports are part of the accepted customer
+  behavior for the story.
+
+## tests
+
+- Add table-driven evaluator, CLI contract, and one `root.BuildProcess`
+  functional test.
+
+### Task packet: live ACP inspection
+
+# problem statement
+
+Static metadata cannot prove what one installed ACP process negotiates, while
+ordinary discovery must remain inert.
+
+## customer ask
+
+Explicitly inspect installed ACP protocol support before assigning work.
+
+## solution
+
+Add a separate Providers inspection operation that reports sanitized live ACP
+observations without rewriting static catalog truth.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\provider-harness-capability-catalog-plan.md`
+
+# changes
+
+## package changes
+
+- Add inspection request/result values, CLI surface, and safe failure mapping.
+
+## contracts
+
+- Separate static facts from timestamped ACP initialize observations.
+
+## services
+
+- Reuse the injected ACP service/command edges and retained negotiation state;
+  do not add a second process manager.
+
+## API changes
+
+- Expose inspection only on explicitly accepted transports and document its
+  process side effect.
+
+## tests
+
+- Add command-runner fixtures, failure classification, cancellation,
+  concurrency, and safe logging tests.

--- a/docs/internal/development/plans/public-documentation-prose-migration.md
+++ b/docs/internal/development/plans/public-documentation-prose-migration.md
@@ -1,0 +1,411 @@
+# Public Documentation Prose Migration Plan
+
+## Status
+
+Proposed. Begins after the writing standard, prose gate, and highest-priority
+CLI journeys are merged.
+
+## Problem statement
+
+Customer-facing documentation outside the packaged CLI reference uses mixed
+structures, terminology, and levels of detail. The repository does not yet
+classify which documents are public customer guidance, which source owns each
+concept, or which writing-quality gate applies to each public surface.
+
+## Customer ask
+
+Apply the same clear technical-writing standard to the broader customer
+documentation without rewriting maintainer-only material or creating duplicate
+sources of truth.
+
+## Intended outcome
+
+Every public document has a named audience, task, canonical concept owner, and
+verification path. Customers encounter the same terminology and task sequence
+whether they begin in the root README, a public guide, an example, a package
+README, or `you docs`.
+
+## Parent plan
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\customer-prose-clarity-program.md`
+
+## Dependencies
+
+- `customer-prose-standard-and-enforcement.md` is merged and blocking changed
+  prose.
+- Root orientation and Work decomposition stories from
+  `cli-and-reference-prose-migration.md` are merged.
+- Canonical public terminology is approved.
+
+## Scope
+
+### Candidate public surfaces
+
+- Root `README.md` and public routing material.
+- `docs/README.md`.
+- Customer guides and concept pages under `docs/` that are not packaged
+  `you docs` topics.
+- Customer-facing README files under `examples/`.
+- Publishable package README files under `packages/`.
+- Factory-local customer examples and overview documentation that ship as
+  examples or packaged content.
+
+### Explicitly excluded by default
+
+- `docs/internal/**` standards, baselines, development plans, process notes,
+  and maintainer inventories.
+- Source comments and test failure strings.
+- Generated documentation and generated contract artifacts.
+- Third-party or quoted text.
+- Historical design records not linked from public customer routes.
+
+An excluded document can enter scope only through a reviewed classification
+change. A file path alone must not determine whether a document is public.
+
+## Public-document classification
+
+The initial inventory must classify each candidate document as one of:
+
+| Class | Meaning | Required action |
+| --- | --- | --- |
+| Public router | Directs customers to canonical task or reference owners. | Keep concise; remove duplicated contracts. |
+| Public task guide | Teaches one customer task from prerequisite through verification. | Migrate to the task-guide pattern. |
+| Public concept reference | Defines one customer concept or contract. | Migrate to the descriptive/reference pattern. |
+| Public example guide | Explains a runnable example and its expected result. | Validate the example and migrate its instructions. |
+| Publishable package guide | Documents an installed package surface. | Align terminology and validate package commands. |
+| Maintainer-only | Supports repository development rather than product use. | Exclude from the public prose gate. |
+| Generated | Derived from a canonical source. | Exclude from authoring; verify drift only. |
+| Stale or duplicate candidate | Has no unique public responsibility. | Route, archive, or delete only through a separate reviewed documentation change. |
+
+The classification must record audience, owned task or concept, canonical
+source, public entry points, and responsible package or documentation owner.
+It must not become a test that freezes every file in the repository.
+
+## Canonical-source rules
+
+- `docs/reference/` remains the canonical source for packaged `you docs`
+  topics.
+- OpenAPI fragments remain canonical for public HTTP schemas.
+- `contracts/cli/commands.json` remains canonical for static CLI command
+  metadata.
+- `docs/architecture/data-model.md` remains canonical for public resource
+  vocabulary unless a later architecture decision replaces it.
+- Root README material routes to detailed owners and does not duplicate long
+  task guides.
+- Example guides may explain their specific Factory names and files but must
+  route general product contracts to their canonical owner.
+- Package README files own package installation and consumption behavior, not
+  the complete product model.
+
+## Prioritization model
+
+Score candidate migration work by:
+
+1. Customer exposure: linked from root, release, package, or CLI entry points.
+2. Task frequency: used during setup, Work submission, verification, or common
+   operation.
+3. Error cost: unclear guidance can cause duplicate Work, wrong targets,
+   destructive action, insecure configuration, or failed deployment.
+4. Terminology drift: conflicts with the public data model or packaged help.
+5. Content duplication: repeats a contract maintained elsewhere.
+6. Change activity: likely to receive new customer-facing edits.
+
+High exposure and high error cost move first. Word count alone does not set
+priority.
+
+## Migration unit
+
+One implementation story covers:
+
+- one public router;
+- one complete task guide;
+- one concept-reference section;
+- one runnable example and its README; or
+- no more than approximately 2,000 prose words from a larger document.
+
+A story can update a small set of inbound links when that is necessary to make
+the migrated document the clear canonical route. It must not absorb unrelated
+content cleanup.
+
+## Work stories
+
+### Story 1: Maintainers can identify the public customer corpus
+
+#### Observable behavior
+
+An author can determine whether a document is subject to the customer-writing
+standard and which source owns its task or concept.
+
+#### Acceptance criteria
+
+- Every candidate entry point has one reviewed classification.
+- The inventory records audience, task/concept, owner, canonical source, and
+  public inbound routes.
+- Generated and internal files are explicitly excluded without broad path-only
+  assumptions.
+- The inventory identifies duplicate candidates but does not delete or move
+  them.
+- The prose checker can consume the accepted public scope deterministically.
+- Adding an unclassified document to a known public entry point fails or emits
+  a blocking classification finding.
+
+### Story 2: Customers receive a concise repository entry point
+
+#### Observable behavior
+
+A customer can use the root README to identify the product, install or build
+the CLI, run the shortest start path, and open the correct detailed guide.
+
+#### Acceptance criteria
+
+- The root README states the customer problem and product outcome before
+  architecture detail.
+- Setup and first-run procedures use tested commands and expected results.
+- The README routes decomposition, submission, operation, authoring, and
+  integration detail to canonical owners.
+- Long duplicated contracts are removed or replaced by concise routing.
+- `make readme-check` and all linked-example smoke checks pass.
+- The migrated README has zero prose findings and recorded language and
+  subject-matter review.
+
+### Story 3: Customers can run each promoted example
+
+#### Observable behavior
+
+A customer can select a promoted example, understand its purpose, run its
+documented commands, and verify the expected result.
+
+#### Acceptance criteria for each example
+
+- The README defines the example-specific goal and prerequisites.
+- Product-wide contracts route to packaged or public canonical references.
+- Commands use paths valid from the stated working directory.
+- Input files validate against current schemas.
+- A smoke test proves the shortest example path when external-provider behavior
+  can be replaced through approved edges.
+- Provider-dependent or platform-dependent steps state the limitation and safe
+  alternative.
+- The example guide has zero prose findings.
+
+### Story 4: Package consumers receive focused installation and consumption guidance
+
+#### Observable behavior
+
+A package consumer can install or resolve the package, use its supported public
+surface, and identify unsupported internal paths.
+
+#### Acceptance criteria for each package
+
+- The README states the package audience and supported exports.
+- Installation and consumption examples match the packaged artifact.
+- Generated paths are described as generated and not as authoring sources.
+- Unsupported internal paths and version assumptions remain explicit.
+- Package verification or tarball-consumer tests validate shown commands and
+  exports.
+- The package guide uses the common product terminology and has zero prose
+  findings.
+
+### Story 5: Public concept and architecture pages use one customer model
+
+#### Observable behavior
+
+A customer reading public concept material encounters the same Factory, Factory
+Session, and Work model used by the CLI and API.
+
+#### Acceptance criteria
+
+- Each migrated page identifies whether it is customer-facing or maintainer
+  architecture guidance.
+- Customer-facing sections lead with public resources and observable behavior.
+- Internal Petri-net terms appear only in explicitly internal explanations.
+- Duplicate definitions route to `data-model.md` or another approved canonical
+  owner.
+- API and CLI examples remain contract-accurate.
+- The migrated scope has zero prose findings and recorded reviews.
+
+### Story 6: The public documentation baseline reaches zero
+
+#### Observable behavior
+
+Required CI rejects every deterministic customer-prose violation in the full
+classified public corpus without consulting a temporary debt baseline.
+
+#### Acceptance criteria
+
+- Every classified public document has been migrated, reclassified with
+  evidence, or removed through a separate approved change.
+- The public-document baseline contains no findings.
+- Full-scope prose checking is blocking in required CI.
+- Stale classifications, suppressions, and inbound public links fail focused
+  checks.
+- The post-migration customer task study meets the program targets.
+
+## Verification
+
+- Prose check for the classified public scope.
+- `make readme-check` for root README changes.
+- `make docs-reference-smoke` when packaged routes or topics change.
+- Schema/contract validation for example inputs.
+- Focused package verification for publishable package guides.
+- Focused `root.BuildProcess` functional scenarios for promoted CLI examples.
+- Link and source-owner checks without adding broad runtime filesystem scans.
+- `make verify-fast`, `make lint`, and applicable PR verification.
+
+## Project-level acceptance criteria
+
+- The public documentation corpus is explicitly classified by audience,
+  responsibility, and canonical owner.
+- Root and public router documents remain concise and do not duplicate long
+  canonical guides.
+- Promoted example commands and inputs are validated through the appropriate
+  public contract or smoke surface.
+- Public concepts use the same customer vocabulary as CLI help, packaged docs,
+  OpenAPI, and `data-model.md`.
+- Generated and maintainer-only documents are not treated as public authoring
+  sources.
+- The classified public corpus has zero temporary baseline findings.
+- Required checks and the post-change comprehension study pass.
+- Required CI is terminal and passing, blocking feedback and conflicts are
+  resolved, and every implementation PR is merged.
+
+## Work-story task packets
+
+### Task packet: classify the public documentation corpus
+
+# problem statement
+
+The repository cannot enforce customer-writing rules broadly because it has no
+reviewed boundary between public, maintainer-only, generated, and duplicate
+documentation.
+
+## customer ask
+
+Apply the writing standard to all customer documentation without rewriting
+internal or generated material.
+
+## solution
+
+Create a reviewed public-document classification that records audience, task or
+concept, canonical owner, entry points, and enforcement scope.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\public-documentation-prose-migration.md`
+
+# changes
+
+## package changes
+
+- Add the bounded public-document classification under
+  `docs/internal/standards/writing/` or the approved standards-owned location.
+- Teach the prose checker to consume the accepted scope.
+
+## contracts
+
+- Define classification values, required ownership fields, and stale-entry
+  behavior.
+
+## services
+
+- None.
+
+## API changes
+
+- None.
+
+## tests
+
+- Add classification validation, public-entry-point coverage, generated-file
+  exclusion, and stale-entry fixtures.
+
+### Task packet: root public routing
+
+# problem statement
+
+The repository entry point can force customers through duplicated detail before
+they reach the first supported CLI task.
+
+## customer ask
+
+Understand the product, complete the shortest setup/start path, and find the
+canonical guide for the next task.
+
+## solution
+
+Rewrite the root README as a concise public router with verified installation,
+first-run, result, and next-step guidance.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\public-documentation-prose-migration.md`
+
+# changes
+
+## package changes
+
+- Update the root `README.md` and only the inbound links necessary to preserve
+  canonical routing.
+
+## contracts
+
+- Preserve shipped commands, public names, install paths, and linked canonical
+  owners.
+
+## services
+
+- None.
+
+## API changes
+
+- None.
+
+## tests
+
+- Run `make readme-check`, prose checks, link checks, and the shortest supported
+  first-run smoke path.
+
+### Task packet: one public guide or example migration
+
+# problem statement
+
+One classified public guide or example does not provide a clear task,
+canonical route, runnable procedure, and verification result.
+
+## customer ask
+
+Complete the guide's owned customer task without relying on duplicated or
+internal-only documentation.
+
+## solution
+
+Migrate one guide, example, package README, or bounded large-document section
+to the customer-writing standard and validate its public commands and inputs.
+
+# original document
+
+`C:\Users\andre\work\portos\infinite-you\docs\internal\development\plans\public-documentation-prose-migration.md`
+
+# changes
+
+## package changes
+
+- Update one classified public surface and the minimum canonical-routing links.
+- Remove only the baseline findings corrected by the task.
+
+## contracts
+
+- Preserve literal CLI, API, schema, package, and Factory behavior.
+
+## services
+
+- None unless a separately approved behavior defect is discovered.
+
+## API changes
+
+- None.
+
+## tests
+
+- Run prose checks and the surface-owned README, package, schema, example, or
+  functional verification.
+

--- a/docs/internal/development/plans/remote-acp-operations.md
+++ b/docs/internal/development/plans/remote-acp-operations.md
@@ -1,0 +1,689 @@
+# Remote ACP Operations Implementation Plan
+
+## Status
+
+Proposed.
+
+## Problem statement
+
+Customers can run supported unary You CLI operations against a selected server,
+but an ACP editor can only launch You as a local stdio child process, so it
+cannot use the Factories, Chat Sessions, Events, and Factory Sessions owned by a
+remote You server.
+
+## Customer ask
+
+Allow an existing ACP client that launches `you serve acp` over stdio to use a
+remote You server while preserving the same ACP session, streaming, control,
+and Factory behavior as local operation.
+
+The customer-facing command is:
+
+```text
+you --remote --server <uri> serve acp
+```
+
+The local `you` process remains the stdio child expected by the ACP client. It
+bridges that connection to the selected remote server. The remote server owns
+the ACP connection's Chat Sessions, Events, Factory Sessions, Factory catalog,
+worker execution, and lifecycle state.
+
+## Solution
+
+Add a WebSocket ACP endpoint to the existing You server and make remote
+`you serve acp` a thin, full-duplex stdio-to-WebSocket bridge. Extract the
+existing ACP request dispatch and connection lifecycle from newline-specific
+stdio framing so the local stdio adapter and remote WebSocket adapter execute
+one protocol implementation over the same service contracts.
+
+The bridge forwards ACP JSON-RPC messages to exactly the selected endpoint. It
+does not build a second Chat Sessions or Factory execution graph, translate ACP
+into a collection of REST operations, retry non-idempotent messages, substitute
+another endpoint, or fall back to local execution.
+
+The first release assumes an operator-secured network boundary and a workspace
+that is visible at the same absolute path on the remote host. Authentication,
+secret handling, arbitrary local-to-remote path mapping, file synchronization,
+and horizontally durable Chat Sessions are separate follow-ons.
+
+## Original documents
+
+- `C:\Users\andre\work\portos\infinite-you\docs\internal\projects\acp-client\final-proposal.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\internal\projects\acp-program\README.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\reference\serve-acp.md`
+- `C:\Users\andre\work\portos\infinite-you\docs\internal\standards\code\planning-standards.md`
+- Git ref `dwro-s1-remote-placement-flags:prd.json`, which supplies the
+  prerequisite root `--remote`, endpoint-only `--server`, command placement,
+  and no-fallback behavior.
+- ACP active RFD: `https://agentclientprotocol.com/rfds/streamable-http-websocket-transport`
+
+## Intended outcome
+
+An operator runs a long-lived You server behind a trusted tunnel or an
+operator-managed secured reverse proxy. An ACP editor continues to launch a
+local child process, but configures it as:
+
+```json
+{
+  "command": "/absolute/path/to/you",
+  "args": [
+    "--remote",
+    "--server",
+    "https://you.example.test",
+    "serve",
+    "acp"
+  ]
+}
+```
+
+The local process connects to `wss://you.example.test/acp`, preserves ACP
+messages in both directions, and keeps stdout reserved for newline-delimited
+ACP JSON-RPC. Factory discovery, target selection, prompt execution, response
+streaming, control, and in-process reconnect behavior come from the remote
+server.
+
+```mermaid
+flowchart LR
+    client["ACP editor or client"]
+    bridge["Local you serve acp\nstdio bridge"]
+    endpoint["Remote You /acp\nWebSocket endpoint"]
+    chat["Remote Chat Sessions and Events"]
+    factory["Remote Factory Sessions and Workers"]
+
+    client <-->|"ACP JSON-RPC over stdio"| bridge
+    bridge <-->|"ACP JSON-RPC over WebSocket"| endpoint
+    endpoint --> chat
+    chat --> factory
+```
+
+## Decisions
+
+### D1 — The remote server owns ACP state
+
+The local bridge owns only its stdio and WebSocket connection resources. The
+remote process owns connection identity, Chat Sessions, target episodes, turns,
+attachments, Events topics, Factory Sessions, Factory target resolution, and
+provider execution.
+
+The bridge must not construct or invoke the local `acp.Server` after remote
+placement has been selected. This preserves one canonical state owner and makes
+remote target enumeration use the server's installed Factories and Operator
+Settings rather than the local machine's home.
+
+### D2 — WebSocket is the first remote transport
+
+The first release implements the WebSocket profile at `/acp`. It does not
+implement the Streamable HTTP POST/GET/DELETE profile. The ACP remote transport
+RFD permits a server to support only WebSocket, while clients that implement
+remote ACP are expected to support it.
+
+Because the RFD is active rather than completed, implementation must pin the
+reviewed RFD revision or date in the transport contract and retain committed
+conformance fixtures. Customer documentation describes this remote transport
+as preview until the upstream profile stabilizes.
+
+### D3 — One ACP connection engine, two framing adapters
+
+ACP negotiation, envelope validation, request identity, session methods,
+prompt dispatch, notifications, control, response correlation, attachment
+cleanup, and safe error mapping have one implementation under
+`pkg/transports/acp`.
+
+Stdio owns complete newline-delimited frames. WebSocket owns complete text
+frames. Neither adapter reimplements ACP method dispatch or imports service
+internals. Concurrent writes are serialized by the connection adapter so one
+response or notification is one complete protocol frame.
+
+### D4 — Remote placement never falls back
+
+When `--remote` is selected, endpoint parsing, network connection, WebSocket
+upgrade, protocol negotiation, remote shutdown, and transport failures remain
+remote failures. The command does not invoke the local ACP server, start an HTTP
+listener, select the default endpoint, or retry through local services.
+
+The bridge does not automatically resend an in-flight `session/prompt`,
+control, or other non-idempotent ACP message after disconnect. A customer or
+client may open a new connection and use supported load or resume behavior.
+
+### D5 — Workspace paths are shared-path-only in the first release
+
+The bridge forwards `cwd` and `additionalDirectories` unchanged. The remote
+server interprets them as absolute paths on the remote host. Session admission
+rejects a path that is unavailable or unusable on the remote host before
+Factory or provider execution begins.
+
+The product does not silently substitute the server home, process working
+directory, Factory directory, or another workspace. Cross-platform prefix
+mapping, repository cloning, file synchronization, and remote workspace leases
+are out of scope for this plan.
+
+### D6 — Session durability remains process-scoped
+
+Chat Sessions and Events remain in-memory and process-scoped. A network
+disconnect may be followed by `session/load` or `session/resume` only while the
+same server process retains that session. The first deployment model is one
+server process or operator-provided sticky routing. Cross-process failover and
+external session storage are not introduced.
+
+### D7 — Secrets and authentication are out of scope
+
+This plan does not add bearer tokens, secret references, ACP login/logout,
+mTLS, credential rotation, multi-tenant authorization, or authentication
+middleware.
+
+The You listener remains loopback-oriented. Remote access is documented for a
+trusted network, VPN, SSH tunnel, or operator-managed TLS/authenticating reverse
+proxy. The product must not describe the unauthenticated endpoint as safe for
+direct public-internet exposure. Non-loopback endpoint URIs use `wss`; plain
+`ws` is accepted only for loopback and deterministic tests.
+
+## Scope
+
+### In scope
+
+- WebSocket ACP upgrade at the transport-owned `/acp` route.
+- A framing-neutral ACP connection engine shared by stdio and WebSocket.
+- Remote placement for `you serve acp` through the authored CLI manifest.
+- A local stdio-to-WebSocket bridge using the exact selected `--server` URI.
+- Full-duplex forwarding of requests, responses, notifications, and
+  server-originated requests.
+- Exact no-fallback placement and transport diagnostics.
+- Same-path remote workspace validation.
+- Explicit disconnect, close, cancellation, load, and resume behavior.
+- Bounded frame size, output buffering, backpressure, and cleanup behavior.
+- ACP transport conformance fixtures and stdio/WebSocket parity evidence.
+- Focused functional, race, repeat, real-client, help, and documentation proof.
+
+### Out of scope
+
+- Authentication, authorization, secrets, bearer tokens, ACP auth methods, and
+  credential storage.
+- Direct wildcard binding or a new public server deployment system.
+- Streamable HTTP ACP.
+- ACP protocol v2 migration.
+- Durable Chat Sessions or Events storage.
+- Cross-process session failover without sticky routing.
+- Automatic reconnect or replay of in-flight ACP messages.
+- Local-to-remote workspace prefix mapping, Git cloning, file synchronization,
+  remote workspaces, or workspace leases.
+- New Factory, Worker, Provider, or event vocabularies.
+- Translating ACP into one-shot `you run` or ordinary REST client calls.
+- Opportunistic cleanup outside the ACP and server-composition paths needed by
+  the observable behavior.
+
+## Canonical ownership
+
+| Concern | Owner | Required boundary |
+| --- | --- | --- |
+| ACP negotiation, envelopes, connection dispatch, projections, and framing contracts | `pkg/transports/acp` | Protocol behavior remains transport-owned and service-neutral. |
+| WebSocket upgrade and frame transport | `pkg/transports/acp` mounted by HTTP composition | The generated REST server does not own ACP policy. |
+| CLI placement and stdio bridge selection | `pkg/transports/cli` | Normalize placement once and select either local ACP serving or the injected remote bridge. |
+| Chat Session, target episode, turn, attachment, and control state | `pkg/services/chat_sessions` | The remote server's service is canonical. |
+| Source-native ordered delivery | `pkg/services/events` | Remains in-memory and process-scoped. |
+| Factory execution and controls | `pkg/services/factory_sessions` and `pkg/services/factory_runtime` | The ACP transport consumes existing public capabilities. |
+| Factory target discovery | `pkg/services/factory_definitions` through Chat Sessions catalog contracts | Remote installed Factories are authoritative. |
+| Production construction | `pkg/wire` | One inert graph; no command-local or connection-local injection pass. |
+| Activation and shutdown | `pkg/initializer` | Listener, bridge, connections, and runtime roles are joined through existing lifecycle ownership. |
+
+## Changes
+
+### Package changes
+
+- `pkg/transports/acp`
+  - Introduce an internal connection abstraction that reads and writes complete
+    JSON-RPC messages independently of newline or WebSocket framing.
+  - Move shared dispatch, request correlation, prompt concurrency, attachment
+    cleanup, and connection terminalization behind that abstraction.
+  - Keep stdio as an adapter with the current newline and partial-frame
+    behavior.
+  - Add a WebSocket server adapter and a WebSocket client/bridge adapter.
+  - Add endpoint resolution, frame-limit, close-classification, and
+    conformance-fixture coverage.
+- `pkg/transports/http`
+  - Mount the injected ACP WebSocket handler at `/acp` before the generated
+    not-found path.
+  - Keep REST adapters and generated OpenAPI handlers unchanged unless review
+    identifies a required route-description artifact.
+- `pkg/transports/cli`
+  - Stop suppressing `--remote` and `--server` for `you serve acp` once the
+    remote bridge exists; continue suppressing unrelated `--json`.
+  - Resolve local versus remote ACP behavior from the authored placement
+    contract before I/O.
+  - Preserve protocol-only stdout and sanitized stderr outcomes.
+- `pkg/wire`
+  - Construct the shared ACP connection engine, stdio server, WebSocket
+    handler, and remote bridge client from explicit collaborators.
+  - Inject the same remote ACP handler into the server route and the same local
+    ACP server into local stdio operation.
+- `pkg/initializer`
+  - Reuse existing lifecycle roles where possible; add only the narrow opening
+    or joining capability required to ensure WebSocket connections and bridge
+    resources terminate with the selected command/server.
+- `contracts/cli` and generated CLI artifacts
+  - Change `you.serve.acp` placement from `local-only` to `dual`.
+  - Project persistent `--remote` and `--server` into help and command metadata.
+  - Declare network side effects for remote mode and stable remote transport
+    errors.
+- `docs/reference/serve-acp.md`
+  - Add remote client configuration, trusted-boundary requirements, endpoint
+    resolution, workspace constraints, reconnect limits, diagnostics, and
+    troubleshooting.
+- Architecture documentation
+  - Reconcile ACP transport ownership and remote connection flow without
+    changing Chat Sessions, Events, or Factory resource vocabulary.
+
+### Contracts
+
+#### CLI contract
+
+```text
+you serve acp
+```
+
+Serves the locally composed ACP authority over stdio exactly as today.
+
+```text
+you --remote --server <uri> serve acp
+```
+
+Serves stdio toward the caller and bridges to the selected remote ACP endpoint.
+
+Rules:
+
+- `--remote` may appear wherever persistent root flags are accepted.
+- `--server` is the exact remote You base URI; `/acp` is joined to its existing
+  base path by one tested resolver.
+- `https` resolves to `wss`; loopback `http` may resolve to `ws`.
+- URI userinfo, fragments, malformed schemes, missing authority, and
+  non-loopback plaintext endpoints are rejected before stdin is consumed.
+- Remote placement never starts a local listener or local ACP authority.
+- `--json` remains unsupported because stdout is already the ACP protocol
+  stream.
+
+#### WebSocket endpoint contract
+
+- Route: `GET /acp` with WebSocket upgrade.
+- One WebSocket text frame contains one complete ACP JSON-RPC message.
+- The first client message must be `initialize`.
+- Text frames are accepted up to the named maximum frame size.
+- Binary, fragmented-over-limit, malformed, or unsupported messages receive a
+  bounded protocol or connection outcome without downstream side effects.
+- The server mints connection identity and preserves JSON-RPC request IDs.
+- Writes from prompt streaming, request responses, notifications, and future
+  server-originated requests are serialized into complete frames.
+- Connection close detaches connection-owned attachments and joins
+  connection-owned work without deleting retained process-scoped Chat Session
+  state.
+
+#### Workspace contract
+
+- `cwd` and every `additionalDirectories` entry remain required absolute paths.
+- Paths are evaluated on the remote host without rewriting.
+- An unavailable or unusable path fails session new/load/resume before Factory
+  or provider side effects.
+- Factory-pinned-root mismatch remains a typed admission failure.
+- Documentation states that local and remote hosts must share the relevant
+  paths for this release.
+
+#### Failure contract
+
+Stable failure families must distinguish at least:
+
+- invalid remote endpoint;
+- insecure non-loopback endpoint;
+- connection refused or endpoint unreachable;
+- WebSocket upgrade rejected;
+- remote connection closed;
+- remote workspace unavailable;
+- unsupported remote frame;
+- remote output/backpressure limit reached; and
+- ordinary ACP protocol rejection returned by the remote agent.
+
+Diagnostics may identify the sanitized endpoint authority and failure family.
+They must not echo ACP frames, prompts, provider commands, unsafe paths, URI
+userinfo, cookies, or response bodies.
+
+### Services
+
+No product service is introduced. Chat Sessions, Events, Factory Sessions,
+Factory Runtime, Factory Definitions, Workers, Providers, and Operator Settings
+retain their existing responsibilities.
+
+The only new operational capabilities are transport adapters:
+
+- an ACP connection engine shared by local and remote serving;
+- a WebSocket agent-side connection adapter; and
+- a WebSocket client-side bridge selected by CLI placement.
+
+These capabilities are constructed once in `pkg/wire` and receive explicit
+dependencies. They are not service locators, dependency bags, secondary
+injectors, or alternate domain APIs.
+
+### API changes
+
+The You HTTP host gains the transport-owned `/acp` WebSocket upgrade route.
+This route carries the upstream ACP JSON-RPC schema rather than a new You REST
+resource. The WebSocket-only first slice does not add a parallel OpenAPI model
+for Chat Sessions or duplicate ACP message schemas in You's public REST
+components.
+
+If implementation review determines that the route must appear in a generated
+public API description, author the source contract under `api/openapi-main.yaml`
+and components first, regenerate all required outputs, and include
+`make generate-api` plus `make api-smoke`. Generated files must never be edited
+directly.
+
+## Work stories
+
+### RACP-001 — Serve the canonical ACP lifecycle over WebSocket
+
+As an operator, I want the running You server to accept ACP WebSocket
+connections so remote clients use the same Factories and session authority as
+the server.
+
+Acceptance criteria:
+
+- A WebSocket client can complete `initialize`, `session/new`, target
+  selection, one streamed `session/prompt`, and terminal response through
+  `/acp`.
+- Equivalent stdio and WebSocket transcripts produce the same normalized ACP
+  capabilities, target options, session behavior, updates, stop reason, and
+  error outcomes; only transport connection metadata may differ.
+- Target enumeration and Factory execution come from the remote process's
+  canonical Factory Definitions, Chat Sessions, Events, and Factory Sessions
+  instances.
+- A connection constructs no service, runtime graph, or alternate state store.
+- A missing or malformed initialize message, unsupported protocol version,
+  invalid frame, or failed upgrade creates no Chat Session or Factory side
+  effect.
+- Connection close detaches connection-owned attachments and returns only after
+  connection-owned goroutines and writes have stopped.
+- Focused package, composition, and functional tests prove the WebSocket path
+  without weakening existing stdio behavior.
+
+### RACP-002 — Bridge a stdio ACP client to exactly one remote server
+
+As an ACP editor user, I want my existing child-process configuration to target
+a remote You server without changing editors or risking silent local execution.
+
+Acceptance criteria:
+
+- `you --remote --server <uri> serve acp` connects to exactly the resolved
+  `<uri>/acp` WebSocket endpoint and begins forwarding complete ACP messages in
+  both directions.
+- The authored CLI manifest declares `you.serve.acp` as dual placement, exposes
+  inherited `--remote` and `--server`, retains protocol-only stdout, and
+  documents the remote invocation.
+- The remote target list and session IDs observed by the client are the values
+  returned by the remote server; local installed Factories and local Chat
+  Sessions are not consulted.
+- Invalid endpoint configuration, connection refusal, timeout, failed upgrade,
+  or mid-connection remote failure never calls the local ACP server, starts a
+  listener, or selects a different endpoint.
+- Clean stdin EOF closes the remote connection and exits successfully after
+  joined cleanup; context cancellation produces the documented cancellation
+  outcome.
+- Diagnostics are bounded and stderr-only, and stdout contains only complete
+  ACP protocol frames.
+- Direct CLI tests and one process-boundary functional test prove exact endpoint
+  selection, no fallback, stdio fidelity, EOF, cancellation, and exit status.
+
+### RACP-003 — Reject an unavailable remote workspace before execution
+
+As a remote ACP user, I want the server to use the intended shared workspace or
+fail clearly so work never runs in an unrelated directory.
+
+Acceptance criteria:
+
+- `session/new`, `session/load`, and `session/resume` evaluate the supplied
+  `cwd` and `additionalDirectories` on the remote host without bridge-side
+  rewriting.
+- A valid shared absolute path becomes the Factory Session working root and is
+  observable at the provider-command edge.
+- A missing, inaccessible, non-directory, relative, or otherwise unusable path
+  returns a typed remote workspace failure before Factory or provider
+  execution.
+- The server never substitutes its home, process working directory, Factory
+  directory, or another session's workspace.
+- An authored Factory root that conflicts with the requested workspace retains
+  the existing typed mismatch outcome.
+- Functional tests use temporary shared paths and public/provider-edge
+  observations; they do not inspect internal runtime state.
+
+### RACP-004 — Preserve control and session behavior across network lifecycle
+
+As an ACP user, I want cancel, close, load, and resume to target the intended
+remote session even when the transport disconnects or requests overlap.
+
+Acceptance criteria:
+
+- A cancel notification sent while `session/prompt` is in flight reaches the
+  captured remote turn and produces an observable cancellation effect at the
+  provider-command edge.
+- The canceled request's control intent cannot affect a subsequently admitted
+  turn.
+- Two sessions on one connection and two connections reusing the same JSON-RPC
+  IDs remain isolated by remote connection and session identity.
+- A mid-prompt disconnect returns a bounded failure and never automatically
+  resends the prompt or creates a second Factory/provider invocation.
+- A new connection can load or resume a retained session while the same server
+  process owns it; another process reports the session as unknown rather than
+  fabricating or importing state.
+- Session close, bridge cancellation, and server shutdown stop admitting new
+  work and join connection-owned resources.
+- Race and repeated functional coverage proves prompt/cancel, disconnect,
+  reconnect, close, and multi-session isolation.
+
+### RACP-005 — Bound remote ACP traffic and slow consumers
+
+As an operator, I want remote ACP connections to have deterministic resource
+limits so one malformed or slow client cannot stall Factory execution or grow
+memory without bound.
+
+Acceptance criteria:
+
+- The transport defines named limits for inbound frame bytes, outbound queued
+  messages, and connection shutdown time; no unexplained inline limits are
+  introduced.
+- Concurrent responses and notifications are written as complete, untorn
+  frames with correct JSON-RPC correlation.
+- Binary frames, oversized text frames, malformed frames, and queue overflow
+  produce bounded outcomes without creating additional domain side effects.
+- A slow or stopped client cannot block canonical Factory execution or Events
+  publication indefinitely.
+- Repeated connect/disconnect and slow-consumer scenarios leave no leaked
+  goroutines, attachments, listeners, or provider processes.
+- Package stress tests and focused `-race`/repeat functional evidence cover the
+  relevant concurrency and backpressure paths without arbitrary sleeps.
+
+### RACP-006 — Publish and independently prove the remote ACP workflow
+
+As a customer, I want complete setup and troubleshooting guidance plus
+independent-client proof so I can configure remote ACP without relying on
+repository internals.
+
+Acceptance criteria:
+
+- `you docs serve-acp`, executable help, and examples document local and remote
+  command forms, `/acp` resolution, trusted-boundary requirements, WSS versus
+  loopback WS, shared-path workspaces, no-fallback failures, process-scoped
+  reconnect behavior, and current non-goals.
+- Documentation clearly states that You does not add authentication or secret
+  handling in this release and that direct public exposure is unsupported.
+- A pinned independent ACP client completes initialize, session creation,
+  remote Factory selection, one streamed prompt, one terminal response, and
+  session close through local stdio bridge -> remote WebSocket server.
+- The independent scenario observes exactly one deterministic provider-command
+  invocation and complete process-tree cleanup.
+- Retained CI evidence contains only revision, client/protocol versions,
+  connection/session identifiers, target identity, bounded counts, cleanup,
+  and terminal outcomes; it contains no prompt, response, frame, provider
+  argument, environment value, or host path.
+- Documentation smoke, CLI help baselines, conformance fixtures, and required
+  real-client CI pass.
+
+## Dependency-aware sequencing
+
+```mermaid
+flowchart TD
+    S1["DWRO S1\nplacement and endpoint vocabulary"]
+    R1["RACP-001\nWebSocket ACP endpoint"]
+    R2["RACP-002\nstdio remote bridge"]
+    R3["RACP-003\nremote workspace validation"]
+    R4["RACP-004\ncontrol and reconnect lifecycle"]
+    R5["RACP-005\nlimits and backpressure"]
+    R6["RACP-006\ndocs and independent client"]
+
+    S1 --> R1
+    S1 --> R2
+    R1 --> R2
+    R1 --> R3
+    R2 --> R3
+    R2 --> R4
+    R3 --> R4
+    R1 --> R5
+    R4 --> R6
+    R5 --> R6
+```
+
+RACP-001 establishes protocol parity and the server endpoint before the CLI
+claims remote support. RACP-002 makes the endpoint usable by existing stdio
+clients. Workspace behavior then becomes explicit before broader lifecycle and
+real-client claims. Resource hardening can proceed after the connection
+contract exists, and the final customer documentation and independent proof
+consume all preceding behavior.
+
+## Tests
+
+### Construction rules
+
+- Functional application tests construct through `root.BuildProcess` and call
+  `Process.Execute` by default.
+- A built `you` binary is used only for the final OS-level child-process,
+  stdio, signal, exit-code, and process-tree interoperability proof.
+- Ordinary customer flows enter through CLI. Direct WebSocket entry is used
+  only for the ACP transport-owned endpoint contract and explicit
+  stdio/WebSocket parity cells.
+- External effects are replaced only through `edges.Edges`, using
+  `ProviderCommandRunner` and sanitized provider-shaped fixtures.
+- Tests do not use `MockWorkers` outside the workers/mock feature area.
+- Synchronization uses listener readiness, successful WebSocket upgrade,
+  controlled provider-edge signals, committed Events records, or explicit
+  terminal lifecycle outcomes. Arbitrary sleeps and timeout-padded polling are
+  prohibited.
+- Transport concurrency, cancel, disconnect, and backpressure paths run under
+  `-race` and repeat modes.
+
+### Functional matrix
+
+| ID | Path | Observable scenario | Required evidence |
+| --- | --- | --- | --- |
+| RACP-FT-001 | `transport/acp_remote` | WebSocket initialize | `/acp` upgrades; implemented capabilities match stdio; no domain side effect before valid initialize. |
+| RACP-FT-002 | `factory/acp_projection` | Remote Factory prompt | Remote target selected; streamed update and terminal response observed; exactly one provider invocation. |
+| RACP-FT-003 | `sessions/chat_remote` | Remote authority | Remote Factory catalog/profile wins over deliberately different local catalog/profile. |
+| RACP-FT-004 | `transport/acp_remote` | Stdio bridge happy path | Protocol-only stdin/stdout bridge completes initialize, new, prompt, and close. |
+| RACP-FT-005 | `transport/acp_remote` | Exact endpoint and no fallback | Selected test server receives the upgrade; default/local server and local ACP service observe zero calls. |
+| RACP-FT-006 | `transport/acp_remote` | Remote endpoint failures | Invalid URI, refusal, timeout, and rejected upgrade produce stable diagnostics and zero local fallback. |
+| RACP-FT-007 | `sessions/chat_remote` | Cancel during prompt | Cancel reaches the provider edge while prompt is blocked; captured turn cancels; later turn is unaffected. |
+| RACP-FT-008 | `sessions/chat_remote` | Multi-session isolation | Two remote sessions stream isolated updates over one connection. |
+| RACP-FT-009 | `transport/acp_remote` | Connection identity isolation | Independent connections reuse JSON-RPC IDs without response or control collision. |
+| RACP-FT-010 | `transport/acp_remote` | Mid-prompt disconnect | One visible failure, no automatic resend, no duplicate Factory/provider invocation, joined cleanup. |
+| RACP-FT-011 | `sessions/chat_remote` | Load/resume same process | New connection loads/resumes retained session with stable session/item identity where supported. |
+| RACP-FT-012 | `sessions/chat_remote` | Load on different process | Explicit unknown-session failure; no fabricated or imported history. |
+| RACP-FT-013 | `sessions/chat_remote` | Shared workspace | Exact remote `cwd` reaches provider edge and produced effects stay under that path. |
+| RACP-FT-014 | `sessions/chat_remote` | Unavailable workspace | Admission fails before Factory/provider execution with no fallback directory. |
+| RACP-FT-015 | `transport/acp_remote` | Clean EOF and cancellation | EOF closes cleanly; context cancellation closes both streams and preserves documented exit classification. |
+| RACP-FT-016 | `transport/acp_remote` | Slow consumer | Factory/provider completion is not indefinitely blocked; bounded connection outcome and cleanup observed. |
+| RACP-FT-017 | `transport/acp_remote` | Oversized/binary frame | Bounded rejection, zero session/Factory side effects, connection remains or closes according to declared contract. |
+| RACP-FT-018 | `transport/acp_remote` | Server shutdown | Listener, connections, attachments, runtime, and provider process are joined before command return. |
+| RACP-FT-019 | `transport/acp_remote/realclient` | Pinned independent client | Client -> stdio bridge -> remote WebSocket -> provider edge succeeds once and retains sanitized evidence. |
+
+### Package and contract evidence
+
+- Pure endpoint-resolution tests cover base paths, `/acp` joining, `http`/`https`
+  conversion, loopback plaintext policy, userinfo, fragments, malformed URLs,
+  and safe authority diagnostics.
+- Shared connection-engine tests run one committed ACP corpus through stdio and
+  WebSocket frame harnesses and compare normalized results.
+- Existing stdio framing, prompt concurrency, cancel, close, load, resume,
+  attachment, response-bridge, and wire-recorder tests remain passing.
+- CLI manifest/schema tests prove placement vocabulary, inherited flags,
+  relationships, help, channels, side effects, and generated-artifact parity.
+- HTTP composition tests prove `/acp` is mounted before generated not-found
+  routing and does not disturb REST/dashboard routes.
+- Wire tests prove local and remote ACP transports receive the canonical service
+  singletons.
+- Frame, writer, queue, disconnect, and shutdown tests prove bounded resource
+  behavior directly before functional coverage.
+
+### Quality gates
+
+The implementation plan must run the narrowest relevant gates first and then
+the shared verification tiers:
+
+```text
+go test ./pkg/transports/acp/... ./pkg/transports/cli/... ./pkg/transports/http/... ./pkg/wire/... -count=1
+go test -race ./pkg/transports/acp/... -count=1
+go test ./tests/functional/transport/acp_remote/... -count=1
+go test ./tests/functional/sessions/chat_remote/... -count=1
+go test ./tests/functional/factory/acp_projection/... -count=1
+make contracts-validate
+make cli-manifest-check
+make docs-reference-smoke
+make verify-fast
+make verify-pr
+```
+
+If the authored OpenAPI contract changes, also run:
+
+```text
+make generate-api
+make api-smoke
+```
+
+Generated CLI or API artifacts must be refreshed from their authored sources
+and checked for drift. The change must add no new `backend-size`,
+`pkg-file-count`, `pkg-boundary`, or `pkg-structure` finding in affected
+packages.
+
+## Project acceptance criteria
+
+- An existing stdio-only ACP client can configure one local
+  `you --remote --server <uri> serve acp` child process and complete the
+  supported ACP lifecycle against a remote You server.
+- The remote process is the sole authority for target discovery, Chat Sessions,
+  Events, Factory Sessions, controls, and provider execution.
+- Local and remote ACP produce contract-equivalent supported protocol behavior.
+- Remote placement uses exactly the selected endpoint and never falls back to
+  local execution or another endpoint.
+- Requests, responses, notifications, streaming updates, and cancel flow in
+  both directions without torn frames or identity collision.
+- Workspace paths are interpreted on the remote host exactly as supplied, and
+  unavailable paths fail before execution without directory substitution.
+- Disconnect never silently replays a non-idempotent message or duplicates a
+  Factory/provider invocation.
+- Slow consumers, oversized frames, malformed frames, shutdown, and repeated
+  reconnects have bounded, leak-free outcomes.
+- Help and reference documentation state the trusted-boundary, shared-path,
+  WebSocket-preview, process-scoped-session, and no-authentication limitations.
+- Focused unit, package integration, functional, race/repeat, and independent
+  real-client evidence pass, along with the relevant generated-contract,
+  documentation, lint, and PR verification gates.
+- The implementation/review loop continues until required CI is terminal and
+  passing, every blocking PR conversation is explicitly addressed, merge
+  conflicts and shared/generated-file churn are resolved against current
+  `main`, and the PR is actually merged. Opening a PR, obtaining approval, or
+  reaching green CI without merge is not completion.
+
+## Follow-ons
+
+These are deliberately not hidden inside the first remote ACP delivery:
+
+- authenticated endpoint profiles and secret references;
+- standardized ACP authentication when the selected protocol version supports
+  the required customer flow;
+- Streamable HTTP ACP and upstream RFD stabilization reconciliation;
+- explicit local-to-remote workspace mapping;
+- server-managed checkout/workspace leases and file synchronization;
+- durable Chat Session storage, multi-process routing, and failover; and
+- resumable remote message streams with defined replay identifiers.

--- a/docs/internal/development/plans/session-and-work-analytics-customer-how-to.md
+++ b/docs/internal/development/plans/session-and-work-analytics-customer-how-to.md
@@ -1,0 +1,734 @@
+---
+author: Agent Factory Team
+last-modified: 2026-08-10
+doc-id: agent-factory/proposals/session-work-analytics-how-to
+---
+
+# Measure Factory Performance
+
+> Proposed customer guide. The metrics commands described here
+> are a target CLI contract and are not yet part of the shipped CLI. Promote
+> this material into the appropriate `docs/reference/` topics when the API and
+> CLI behavior is implemented.
+
+Use performance reports to move from a single execution to longer-term Factory
+improvement:
+
+1. Explain where one Factory Session spent its time.
+2. Follow one piece of Work through its attempts, iterations, and sessions.
+3. Find workers, workstations, and states that create recurring delays.
+4. Compare cohorts to determine whether a Factory graph change improved the
+   result.
+
+Cost remains a separate backend concern but is one customer-facing metrics
+lens. Use `you metrics session <session-id> --lens cost` for monetary and token
+valuation. Other lenses cover time, throughput, reliability, quality, rework,
+and distributions.
+
+## Command overview
+
+```text
+you metrics session <session-id> [--lens <lens>]...
+  [--by-work] [--by-worker] [--by-dispatch]
+you metrics work <work-id> --session <session-id> [--lineage] [--timeline]
+you metrics worker-session <worker-session-id>
+
+you metrics summary [filters] [--lens <lens>]...
+you metrics bottlenecks [filters]
+you metrics distribution --metric <metric> [filters] [--group-by <dimension>]
+you metrics trend --metric <metric> [filters] --interval day|week|month
+you metrics explain session <session-id> --metric <metric>
+you metrics coverage [filters]
+you metrics regressions [filters] --against previous|revision:<digest>
+you metrics check --policy <path> [filters]
+you metrics catalog [--lens <lens>]
+
+you metrics compare revisions --factory <factory> \
+  --baseline <factory-revision> --candidate <factory-revision> [filters]
+you metrics compare periods \
+  --baseline <from>..<until> --candidate <from>..<until> [filters]
+```
+
+The command families have deliberately different scopes:
+
+- `you metrics session` explains one Factory Session.
+- `you metrics work` explains one Work item or its cross-session lineage.
+- `you metrics summary`, `trend`, and related commands analyze cohorts.
+- `--lens cost` adds the focused monetary lens without creating another
+  top-level command family.
+
+Use global `--json` for machine-readable output. `--verbose` remains reserved
+for command diagnostics on stderr and does not add analytical dimensions.
+
+## Choose one or more lenses
+
+The scope says which executions to measure. A lens says which questions to
+answer. `--lens` is repeatable so customers can compose one report without
+learning separate command families:
+
+```bash
+you metrics session <session-id> \
+  --lens flow \
+  --lens reliability \
+  --lens cost
+```
+
+| Lens | Questions answered |
+|---|---|
+| `overview` | What happened, how much Work completed, and where did time go? |
+| `flow` | How long did Work wait and execute, and what was the critical path? |
+| `reliability` | How often did attempts fail, retry, revisit, or require rework? |
+| `cost` | What token usage and monetary valuation were recorded or forecast? |
+| `quality` | Did the result pass customer-defined acceptance or evaluation criteria? |
+| `capacity` | Were configured workers or workstations saturated? |
+
+`overview` is the default for entity and summary commands. Cost, quality, and
+capacity remain explicitly unavailable when their required facts are absent;
+requesting a lens never turns missing data into zero.
+
+## 1. Explain one Factory Session
+
+Start with the default operational summary:
+
+```bash
+you metrics session <session-id>
+```
+
+Example:
+
+```text
+Factory Session fs-review-042 metrics as of 2026-08-10 14:32 PDT
+
+STATUS                         SUCCEEDED
+ELAPSED WALL TIME              18m 42s
+ACTIVE SESSION TIME            17m 03s
+PAUSED TIME                     1m 39s
+DISTINCT WORK ITEMS                  8
+DISPATCH ATTEMPTS                   19
+WORKER SESSIONS                     17
+MAX CONCURRENT EXECUTIONS            4
+SUMMED EXECUTION TIME           41m 08s
+SUMMED QUEUE TIME                6m 21s
+RETRIES                              2
+WORK REVISITS                        3
+FIRST-PASS YIELD                  62.5%
+
+TIME CONTRIBUTION       DURATION    SHARE OF WALL TIME
+Queue                     6m 21s     34.0%
+Critical-path execution  11m 04s     59.2%
+Paused                     1m 17s      6.8%
+Unclassified                  0s      0.0%
+```
+
+Summed execution time can exceed elapsed wall time because workers execute in
+parallel. It answers "how much execution occurred?" rather than "how long did
+the customer wait?" The critical path explains the portion of wall time that
+actually constrained session completion.
+
+For a running session, durations end at the report's `as of` time. Running and
+queued attempts are shown separately and are not presented as completed
+duration samples.
+
+## 2. Attribute session time to workers
+
+Add `--by-worker` to group dispatch execution by configured Worker identity:
+
+```bash
+you metrics session <session-id> --by-worker
+```
+
+```text
+WORKER             SESSIONS  ATTEMPTS  QUEUE P50  RUN P50  RUN P95  SUCCESS  REVISITS
+planner                   2         2        8s     1m 42s    2m 01s    100.0%       0
+reviewer                  9        11       31s     2m 14s    4m 48s     81.8%       3
+repairer                  6         6       12s     1m 09s    2m 36s     83.3%       0
+```
+
+`SESSIONS` counts distinct Worker Sessions. `ATTEMPTS` counts dispatch
+executions, including retries. These values can differ when a Worker Session
+continues across several dispatch attempts or when an interrupted attempt is
+reconciled.
+
+The default grouping is the authored Worker. Use `--by-dispatch` when every
+execution attempt matters, or `--by-work` when the customer-visible Work item
+is the useful unit.
+
+Combine views when investigating a specific session:
+
+```bash
+you metrics session <session-id> --by-work --by-worker --by-dispatch
+```
+
+## 3. Inspect queue and execution time per dispatch
+
+Use `--by-dispatch` for the most granular session timeline:
+
+```bash
+you metrics session <session-id> --by-dispatch
+```
+
+```text
+DISPATCH       WORK       WORKSTATION  WORKER    ATTEMPT  QUEUE  EXECUTION  OUTCOME
+dispatch-101   work-17    plan         planner         1     8s      1m 42s  ACCEPTED
+dispatch-102   work-17    review       reviewer        1    44s      3m 16s  REJECTED
+dispatch-108   work-17    repair       repairer        1    12s      1m 09s  ACCEPTED
+dispatch-113   work-17    review       reviewer        2    19s      2m 07s  ACCEPTED
+```
+
+This view distinguishes:
+
+- queue time: dispatch queued until worker execution starts;
+- execution time: worker execution starts until the attempt terminates;
+- attempt number: repeated execution for the same Work and stage;
+- outcome: accepted, continued, rejected, failed, interrupted, or canceled.
+
+Failed and canceled attempts still contribute execution and queue time. They
+must not disappear from totals merely because they did not produce successful
+Work.
+
+## 4. Explain one piece of Work
+
+Work identifiers are interpreted in a Factory Session scope. Start with the
+session in which the Work was observed:
+
+```bash
+you metrics work <work-id> --session <session-id>
+```
+
+```text
+Work work-17 metrics
+
+TYPE                         release-review
+CURRENT STATE                shipped (TERMINAL)
+CYCLE TIME                   13m 48s
+TIME IN QUEUE                 1m 23s
+TIME IN EXECUTION             8m 14s
+TIME IN STATES                4m 11s
+DISPATCH ATTEMPTS                  4
+WORKER SESSIONS                    4
+RETRIES                            0
+STATE REVISITS                     1
+FIRST-PASS                         no
+FACTORY SESSIONS                   1
+```
+
+Cycle time begins when the Work is admitted and ends when it first reaches a
+terminal Work state. For non-terminal Work, the command reports elapsed cycle
+time as of the query time and labels it `RUNNING`.
+
+Add `--timeline` to show state residence, queue, and worker execution in event
+order:
+
+```bash
+you metrics work <work-id> --session <session-id> --timeline
+```
+
+## 5. Follow Work across Factory Sessions
+
+A Work ID identifies one Work record. Use `--lineage` when the customer wants
+the broader logical piece of work represented by its trace and chaining
+lineage:
+
+```bash
+you metrics work <work-id> --session <origin-session-id> --lineage
+```
+
+```text
+Lineage trace-incident-284
+
+FACTORY SESSIONS                   3
+WORK RECORDS                       7
+DISPATCH ATTEMPTS                 16
+END-TO-END CYCLE TIME         2h 18m
+EXECUTION TIME                1h 06m
+QUEUE TIME                      31m
+RETRIES                           2
+STATE REVISITS                    4
+TERMINAL RESULT            SUCCEEDED
+```
+
+Cross-session association must use recorded Work lineage such as `traceId`,
+`currentChainingTraceId`, and predecessor trace IDs. Similar names or payloads
+are not sufficient evidence that two Work records represent the same logical
+piece of work.
+
+## 6. Read the operational summary over time
+
+Use `you metrics summary` for a population rather than one execution:
+
+```bash
+you metrics summary --factory customer-support --since 30d
+```
+
+```text
+Analytics summary
+Window: 2026-07-11T00:00:00Z through 2026-08-10T14:32:00Z
+Filter: factory=customer-support
+
+FACTORY SESSIONS                       286
+TERMINAL FACTORY SESSIONS              271
+OPEN FACTORY SESSIONS                   15
+WORK ADMITTED                        2,814
+WORK COMPLETED                       2,641
+WORK COMPLETION RATE                 93.9%
+FIRST-PASS YIELD                     78.4%
+RETRY RATE                            6.2%
+REVISIT RATE                         11.7%
+THROUGHPUT                       88.0/day
+
+METRIC                         P50       P90       P95       MAX    SAMPLES
+Session wall time            12m 08s   31m 42s   44m 10s   2h 18m       271
+Work cycle time               4m 21s   13m 08s   18m 40s   1h 02m     2,641
+Dispatch queue time               18s     1m 41s    3m 09s      22m     6,902
+Dispatch execution time       1m 06s    4m 14s    6m 37s      41m     6,755
+```
+
+The report always prints its time window, filters, sample counts, and coverage.
+Open observations are counted but excluded from terminal-duration
+distributions unless the command explicitly says otherwise.
+
+Common filters include:
+
+```text
+--factory <name>
+--factory-revision <digest>
+--work-type <name>
+--workstation <name>
+--worker <name>
+--provider <id>
+--model <id>
+--status <status>
+--since <duration-or-time>
+--until <time>
+```
+
+## 7. Measure Work flow and rework
+
+Use the Work view to compare cycle time, first-pass yield, retries, and repeated
+processing:
+
+```bash
+you metrics summary \
+  --factory customer-support \
+  --since 30d \
+  --lens flow \
+  --lens reliability \
+  --group-by work-type
+```
+
+```text
+WORK TYPE        COMPLETED  CYCLE P50  CYCLE P95  FIRST PASS  RETRY  REVISIT
+question             1,842      2m 18s      8m 04s       91.2%    2.1%     4.8%
+incident               603     11m 42s     38m 51s       62.7%   10.6%    22.4%
+release-review         196     18m 09s     51m 20s       54.1%   14.8%    31.6%
+```
+
+The default report uses `revisit`, not `rework`, for graph-derived loops. A
+revisit means Work entered a previously visited non-terminal state or repeated
+an already visited processing stage. Some Factory graphs intentionally iterate,
+so a revisit is not automatically waste.
+
+Report a true `rework rate` only when the Factory definition or recorded
+outcome explicitly classifies a route or state as rework. When that
+classification is absent, the CLI prints `REWORK: unclassified` instead of
+renaming every loop as rework.
+
+## 8. Compare workers and workstations
+
+Use the workers view for execution capacity and reliability:
+
+```bash
+you metrics summary \
+  --factory customer-support \
+  --since 14d \
+  --lens flow \
+  --lens reliability \
+  --group-by workstation
+```
+
+```text
+WORKSTATION  ATTEMPTS  QUEUE P50  QUEUE P95  RUN P50  RUN P95  FAILURE  REVISIT
+triage          2,204         7s         31s       42s    1m 38s      1.2%     2.4%
+review            918        39s       4m 12s    2m 17s    8m 44s      6.8%    18.1%
+repair            311        18s       1m 09s    3m 02s   10m 27s      8.4%    12.9%
+```
+
+Grouping by `worker` uses the authored Worker identity. Grouping by `model` or
+`provider` explains execution-channel differences. Individual Worker Session
+IDs remain a drilldown dimension, not a useful default cohort.
+
+## 9. Find likely bottlenecks
+
+Use the bottleneck report to rank constrained stages and show the evidence for
+the ranking:
+
+```bash
+you metrics bottlenecks --factory customer-support --since 14d
+```
+
+```text
+RANK  STAGE    SIGNALS                                  QUEUE P95  CYCLE SHARE  SAMPLES
+1     review   high queue, high critical-path share       4m 12s        41.8%      918
+2     repair   long-tail execution, elevated failures     1m 09s        19.6%      311
+3     approve  low throughput, frequent blocked time         22s        14.1%      204
+```
+
+A bottleneck row is a diagnosis candidate, not proof of causation. The report
+should expose its component signals:
+
+- queue-time distribution;
+- execution-time distribution;
+- time spent on the critical path;
+- throughput and arrival rate;
+- failure, retry, and revisit contribution;
+- blocked or approval waiting time; and
+- capacity saturation, only when configured capacity is known.
+
+Unknown capacity must not be presented as zero utilization.
+
+## 10. Inspect one distribution
+
+Use a distribution command instead of relying on a single average:
+
+```bash
+you metrics distribution \
+  --metric work.cycle-time \
+  --factory customer-support \
+  --since 30d \
+  --group-by factory-revision
+```
+
+Default distribution output includes sample count, minimum, p50, p90, p95,
+maximum, arithmetic mean, and coverage. JSON output additionally contains the
+exact bucket boundaries or quantile method used by the service.
+
+Useful metric names include:
+
+```text
+session.wall-time
+session.active-time
+work.cycle-time
+work.queue-time
+dispatch.queue-time
+dispatch.execution-time
+work.iterations
+work.revisits
+worker.failure-rate
+worker.retry-rate
+```
+
+## 11. Follow a trend
+
+Use trend reports to see whether a metric changed gradually or only during a
+short-lived event:
+
+```bash
+you metrics trend \
+  --metric work.cycle-time \
+  --factory customer-support \
+  --since 90d \
+  --interval week \
+  --group-by factory-revision
+```
+
+```text
+WEEK          REVISION       SAMPLES  P50       P95       COMPLETION
+2026-06-08    sha256:81a...      402   8m 14s    28m 09s        89.6%
+2026-06-15    sha256:81a...      438   7m 58s    27m 41s        90.1%
+2026-06-22    sha256:b93...      451   6m 02s    19m 10s        94.3%
+2026-06-29    sha256:b93...      469   5m 47s    18m 32s        94.8%
+```
+
+Do not infer that the revision caused the change merely because the dates
+align. Compare workload mix, providers, models, and sample sizes before drawing
+that conclusion.
+
+## 12. Compare Factory graph revisions
+
+Every Factory Session used for revision comparison must record an immutable
+digest of its effective compiled Factory definition. A mutable Factory name or
+the server's current edit version is not enough.
+
+Compare two revisions of the same Factory:
+
+```bash
+you metrics compare revisions \
+  --factory customer-support \
+  --baseline sha256:81a... \
+  --candidate sha256:b93... \
+  --since 90d
+```
+
+```text
+Factory revision comparison: customer-support
+
+METRIC                    BASELINE     CANDIDATE       CHANGE       ASSESSMENT
+Completed Work                 840           920        +9.5%       context
+Completion rate              89.8%         94.6%       +4.8 pp      improved
+First-pass yield             68.1%         81.7%      +13.6 pp      improved
+Work cycle p50              8m 14s        5m 51s       -29.0%       improved
+Work cycle p95             28m 09s       18m 47s       -33.3%       improved
+Queue time p95              5m 44s        2m 38s       -54.1%       improved
+Retry rate                    9.2%          5.1%       -4.1 pp      improved
+Revisit rate                 18.6%         10.4%       -8.2 pp      improved
+
+Coverage: baseline 96.8%, candidate 98.1%
+Warnings: candidate processed 12% fewer incident-type Work items
+```
+
+Rate changes use percentage points (`pp`). Duration and count changes use
+relative percentages. The report includes sample sizes, coverage, and workload
+mix warnings so a small or materially different cohort is not presented as a
+conclusive improvement.
+
+## 13. Compare time periods
+
+Use period comparison when there was an operational change without a new graph
+revision, such as worker capacity, provider, or model changes:
+
+```bash
+you metrics compare periods \
+  --factory customer-support \
+  --baseline 2026-06-01..2026-06-30 \
+  --candidate 2026-07-01..2026-07-31
+```
+
+Period boundaries are interpreted as UTC in machine-readable input unless an
+explicit offset is present. Human output prints the effective boundaries and
+timezone before the results.
+
+## 14. Use JSON for further analysis
+
+Every view supports global `--json`:
+
+```bash
+you --json metrics bottlenecks \
+  --factory customer-support \
+  --since 30d > bottlenecks.json
+```
+
+JSON consumers should retain:
+
+- effective filters and time boundaries;
+- the report's `asOf` timestamp;
+- sample and excluded counts;
+- event and duration coverage;
+- Factory revision digests;
+- metric definitions and units;
+- quantile method; and
+- warnings or unavailable classifications.
+
+Do not compare unlabeled values from reports produced under different filters,
+metric definitions, or revision identities.
+
+## Metric definitions
+
+| Metric | Definition |
+|---|---|
+| Session wall time | Session start until terminal event, or `asOf` for a running session. |
+| Active session time | Wall time minus recorded paused intervals. |
+| Work cycle time | Work admission until its first terminal Work state. |
+| Dispatch queue time | Dispatch queued until worker execution starts. |
+| Dispatch execution time | Worker execution start until the attempt terminates. |
+| Summed execution time | Sum of dispatch execution durations; may exceed wall time under concurrency. |
+| Critical-path execution | Execution intervals that constrain observed end-to-end completion. |
+| Retry | A new attempt explicitly retrying a failed, timed-out, or interrupted dispatch. |
+| Revisit | Work repeats a previously visited non-terminal state or processing stage. |
+| Iteration | A completed pass through a declared iterative stage or loop. |
+| First-pass yield | Terminal successful Work without a retry, revisit, or classified rework step. |
+| Throughput | Terminal Work count divided by the effective observation window. |
+| Rework | A route or state explicitly classified as rework by the Factory contract. |
+
+## Missing and partial data
+
+Reports must distinguish zero from unavailable. Each report includes coverage
+for the facts it needs, such as queue timestamps, execution timestamps, Work
+lineage, terminal events, and Factory revision identity.
+
+Examples:
+
+- A dispatch with no start timestamp has unknown queue and execution time.
+- Running Work has elapsed cycle time but no completed cycle-time sample.
+- Work without trace lineage cannot be joined safely across sessions.
+- A session without an effective Factory digest appears under `unknown
+  revision` and is excluded from revision comparison.
+- A workstation without configured capacity has no saturation percentage.
+
+## Explain a surprising result
+
+Use `explain` to rank the recorded contributors to one metric:
+
+```bash
+you metrics explain session <session-id> --metric session.wall-time
+```
+
+```text
+Largest observed contributors to session.wall-time
+
+1. review queue                         4m 12s  22.5% of wall time
+2. reviewer execution on work-17       3m 16s  17.5% of wall time
+3. approval blocked interval            2m 41s  14.4% of wall time
+4. repair-to-review revisit             1m 28s   7.9% of wall time
+
+Coverage: 97.6% of wall time classified
+```
+
+An explanation describes observed contribution and correlation. It must not
+claim that changing the highest-ranked contributor will cause an equal
+improvement.
+
+## Check metrics data health
+
+Use coverage before trusting a comparison or automating a threshold:
+
+```bash
+you metrics coverage --factory customer-support --since 30d
+```
+
+```text
+FACT                         COVERAGE  MISSING  EFFECT
+Factory revision identity       98.2%       51  revision comparisons exclude rows
+Dispatch queued timestamp       99.7%       19  queue distributions are partial
+Worker start timestamp          97.9%      145  execution distributions are partial
+Work trace lineage              92.4%      214  cross-session Work joins are partial
+Quality outcome                 61.8%    1,075  quality comparisons are not representative
+```
+
+Coverage is itself a first-class metric. Reports should link their warnings to
+the relevant coverage row instead of merely printing `partial`.
+
+## Detect and gate regressions
+
+Find recent changes that exceed configured noise and sample-size thresholds:
+
+```bash
+you metrics regressions \
+  --factory customer-support \
+  --since 7d \
+  --against previous
+```
+
+```text
+METRIC                  BASELINE  CURRENT  CHANGE   CONFIDENCE  STATUS
+Work cycle p95           18m 47s  24m 13s  +28.9%   sufficient  regressed
+First-pass yield           81.7%    80.9%  -0.8 pp  insufficient unchanged
+Review queue p95          2m 38s   4m 09s  +57.6%   sufficient  regressed
+```
+
+For CI or Factory promotion, evaluate a checked-in policy:
+
+```bash
+you metrics check \
+  --policy ./factory/metrics-policy.yaml \
+  --factory-revision <candidate-revision>
+```
+
+A policy can require minimum sample size and coverage, set upper or lower
+bounds, and choose whether insufficient evidence fails the check. Human output
+explains every failed rule; JSON returns stable rule identifiers for
+automation. This makes performance and reliability regressions reviewable in
+the same workflow as Factory graph changes.
+
+## Keep quality beside speed and cost
+
+Factories should not appear to improve merely because they became faster or
+cheaper while producing worse results. The quality lens should accept recorded
+customer outcomes such as approval, evaluator score, escaped defect, or task
+success:
+
+```bash
+you metrics compare revisions \
+  --factory customer-support \
+  --baseline <old-revision> \
+  --candidate <new-revision> \
+  --lens flow \
+  --lens cost \
+  --lens quality
+```
+
+Quality metrics require a named rubric and version. Scores from different
+rubric versions are shown separately unless the customer explicitly defines
+them as comparable.
+
+## Discover available metrics and dimensions
+
+Use the catalog instead of guessing metric names:
+
+```bash
+you metrics catalog
+you metrics catalog --lens reliability
+```
+
+The catalog reports each metric's stable identifier, unit, direction of
+improvement, required facts, supported groupings, and availability. This also
+supports shell completion for `--metric`, `--group-by`, and `--lens`.
+
+## Additional high-value extensions
+
+The unified namespace leaves room for several capabilities without adding new
+top-level command families:
+
+- `you metrics watch session <id>` refreshes the same session report while it
+  runs, preserving a stable table layout and `asOf` time.
+- Named cohorts let teams save reviewed filters such as production incidents
+  and reuse them in summaries, trends, comparisons, and checks.
+- `--match-by work-type,priority` makes revision comparisons balance known
+  workload dimensions before reporting a change.
+- `--top`, `--sort`, and repeated `--where` filters support drilldown without
+  exporting every event.
+- CSV and NDJSON output complement API-shaped JSON for notebooks and data
+  warehouses.
+- Revision and deployment annotations appear on trend reports so changes can
+  be correlated with observed movement.
+- A future capacity forecast can estimate queue growth under a specified Work
+  arrival rate, while clearly separating simulation from observed metrics.
+
+## Common workflows
+
+Explain why one session was slow:
+
+```bash
+you metrics session <session-id> --by-worker --by-dispatch
+```
+
+Follow a piece of Work through repeated or cross-session processing:
+
+```bash
+you metrics work <work-id> --session <session-id> --lineage --timeline
+```
+
+Find recurring operational bottlenecks:
+
+```bash
+you metrics bottlenecks --factory <factory-name> --since 30d
+```
+
+Check whether a graph revision improved performance:
+
+```bash
+you metrics compare revisions \
+  --factory <factory-name> \
+  --baseline <old-revision> \
+  --candidate <new-revision> \
+  --since 90d
+```
+
+Inspect operational and monetary lenses for the same session:
+
+```bash
+you metrics session <session-id> \
+  --lens flow \
+  --lens reliability \
+  --lens cost \
+  --by-work \
+  --by-worker
+```
+
+## Product boundary
+
+The CLI presents one `you metrics` namespace even though the implementation
+uses separate services. The metrics transport delegates operational and cohort
+queries to Analytics and monetary valuation to Costs, then composes requested
+lenses. Factory Sessions, Worker Sessions, Work, and Recordings remain the
+authoritative sources of lifecycle, usage, and lineage facts rather than
+calculating analytical results themselves.

--- a/docs/internal/development/plans/session-cost-customer-how-to.md
+++ b/docs/internal/development/plans/session-cost-customer-how-to.md
@@ -1,0 +1,351 @@
+---
+author: Agent Factory Team
+last-modified: 2026-08-10
+doc-id: agent-factory/proposals/session-cost-how-to
+---
+
+# Measure Factory Session Costs
+
+> Proposed customer guide. The cost lens and report flags described here
+> are a target CLI contract and are not yet part of the shipped CLI. Promote
+> this material into `docs/reference/sessions.md` when the corresponding API
+> and CLI behavior is implemented.
+
+Use Factory Session cost reports to answer three questions:
+
+1. How much has this Factory Session consumed so far?
+2. How much could its currently pending work cost?
+3. Which providers, models, Worker Sessions, or dispatches account for that
+   usage?
+
+A session-scoped cost report values one Factory Session execution; the
+separate Costs service owns the calculation. A Factory definition does not
+have an accrued cost until it runs in a Factory Session.
+
+For elapsed time, queue time, iterations, rework, bottlenecks, distributions,
+and cross-session Factory comparisons, use the proposed performance guide in
+`session-and-work-analytics-customer-how-to.md`.
+
+## Command overview
+
+```text
+you session list [--scope live|persisted|all] [--terminal]
+you metrics session <session-id> --lens cost \
+  [--forecast] [--by-worker] [--by-dispatch]
+```
+
+The default cost report shows accrued cost and token usage grouped by provider
+and model. Add `--forecast` for the projected incremental cost of work that is
+already queued or in flight. Add `--by-worker` or `--by-dispatch` when you need
+to attribute the total to individual execution units.
+
+Use global `--json` for machine-readable output:
+
+```bash
+you --json metrics session <session-id> --lens cost
+```
+
+`--verbose` remains reserved for command diagnostics on stderr. It does not
+change the contents of a cost report.
+
+## 1. Find the Factory Session
+
+List sessions currently known to the running host:
+
+```bash
+you session list
+```
+
+The default scope is `live`. Use it when you are monitoring work that is
+running now:
+
+```bash
+you session list --scope live
+```
+
+Use `--scope all` when you do not yet know whether a session is live or
+persisted:
+
+```bash
+you session list --scope all
+```
+
+Copy the Factory Session ID from the list output. Use that exact ID for every
+later cost, status, dispatch, artifact, and result command.
+
+## 2. Measure accrued cost
+
+Read the current cost report for one session:
+
+```bash
+you metrics session <session-id> --lens cost
+```
+
+For example:
+
+```bash
+you metrics session dur-sess-release-review-001 --lens cost
+```
+
+The default report should contain:
+
+- the accrued monetary valuation, grouped by currency;
+- whether that valuation is actual, estimated, mixed, or incomplete;
+- total input, cached-input, output, and reasoning-output tokens;
+- input/output share of total, cached/uncached share of input, and reasoning
+  share of output;
+- cost and token totals by billing provider; and
+- cost and token totals by resolved model.
+
+Example output:
+
+```text
+Factory session dur-sess-release-review-001 cost as of 2026-08-10 11:42 PDT
+
+Accrued valuation:  $1.284300 USD (mixed actual/estimated)
+Usage coverage:     9 of 10 Worker Sessions
+Pricing coverage:   8 of 10 Worker Sessions
+Unpriced:           2 Worker Sessions
+
+TOKENS              COUNT    SHARE
+Input             142,000    85.5% of total
+  Cached           61,000    43.0% of input
+  Uncached         81,000    57.0% of input
+Output              24,000    14.5% of total
+  Reasoning          9,000    37.5% of output
+
+BILLING PROVIDER  COST        TOKENS    SHARE OF KNOWN COST
+openai             $1.102300    142,000    85.8%
+anthropic          $0.182000     24,000    14.2%
+
+MODEL                         COST        INPUT     OUTPUT
+openai/gpt-5.2                $0.942300     99,000     18,000
+openai/gpt-5.2-mini           $0.160000     22,000      3,000
+anthropic/claude-sonnet       $0.182000     21,000      3,000
+```
+
+The reported amount is the priced portion of the session. If usage or pricing
+is unavailable, the command must identify the missing coverage instead of
+treating it as zero cost.
+
+Token categories are not all peers. Cached input is a subset of input, and
+reasoning output is normally a subset of output. The report therefore uses
+explicit denominators rather than adding every displayed row into one pie.
+When a provider's usage semantics do not support a reliable denominator, the
+corresponding percentage is shown as unavailable.
+
+## 3. Measure projected session cost
+
+Add `--forecast` to include the estimated incremental cost of dispatches that
+are already queued or in flight:
+
+```bash
+you metrics session <session-id> --lens cost --forecast
+```
+
+Example:
+
+```text
+Accrued valuation:  $1.284300 USD
+Pending estimate:   $0.030000-$0.090000 USD
+Projected total:    $1.314300-$1.374300 USD
+Forecast basis:     2 queued dispatches, resolved models, configured token limits
+```
+
+The forecast is a range, not a promise. A Factory can run workers concurrently,
+take guarded branches, or retry failed work, so there may be no single exact
+"next" cost.
+
+The pending estimate covers only work the runtime already knows about. It does
+not attempt to predict unselected future branches. When a queued dispatch has
+no resolved model, price, or usable token limit, the report marks the forecast
+as partial or unavailable.
+
+For a terminal historical session, `--forecast` reports that there is no
+pending work. The accrued amount remains the session's historical valuation.
+
+## 4. Enumerate persisted and historical sessions
+
+List Factory Sessions retained outside the live workspace:
+
+```bash
+you session list --scope persisted
+```
+
+Persisted sessions can include terminal sessions and recoverable interrupted
+sessions. To list only sessions whose lifecycle has ended, add `--terminal`:
+
+```bash
+you session list --scope persisted --terminal
+```
+
+`--terminal` is shorthand for the terminal lifecycle states:
+
+- `SUCCEEDED`
+- `FAILED`
+- `CANCELED`
+- `TIMED_OUT`
+- `INTERRUPTED`
+- `TERMINATED`
+
+The CLI should prefer `--scope persisted --terminal` over a separate
+`--historical` flag. Persistence and lifecycle are different filters: a
+persisted session can still be recoverable, while `--terminal` clearly states
+that the customer wants completed history.
+
+After selecting a historical session, inspect it with the same cost command:
+
+```bash
+you metrics session <historical-session-id> --lens cost
+```
+
+Historical cost reports are reconstructed from the session's canonical usage
+history. Their applied price snapshot must not change when the current price
+book changes.
+
+## 5. Read reports with multiple currencies
+
+The default report does not silently convert currencies. If a session contains
+valuations in more than one currency, it shows one subtotal per ISO 4217
+currency code:
+
+```text
+Accrued valuation:
+  $1.284300 USD
+  €0.240000 EUR
+Combined total:     unavailable (multiple currencies)
+```
+
+Customers may compare or convert those subtotals outside the CLI. A future
+explicit conversion option must report the exchange-rate source and effective
+time; without those facts, adding unlike currencies would produce a misleading
+total.
+
+## 6. Attribute cost to Worker Sessions
+
+Use `--by-worker` to identify which Worker Sessions account for the total:
+
+```bash
+you metrics session <session-id> --lens cost --by-worker
+```
+
+The report adds one row per Worker Session, including its state, provider,
+model, token usage, valuation, and coverage status:
+
+```text
+WORKER SESSION             STATE       PROVIDER/MODEL          TOKENS    COST
+dispatch-plan              COMPLETED   openai/gpt-5.2          42,100    $0.318200
+dispatch-review            COMPLETED   anthropic/claude-sonnet 18,400    $0.182000
+dispatch-repair            FAILED      openai/gpt-5.2-mini      7,900    $0.041100
+```
+
+Failed, canceled, and retried workers can still incur usage. Their cost must
+remain in the report when the provider performed billable work.
+
+## 7. Attribute cost to dispatches
+
+Use `--by-dispatch` when you need orchestration-level attribution:
+
+```bash
+you metrics session <session-id> --lens cost --by-dispatch
+```
+
+This view groups usage by Factory Session dispatch. It is useful for comparing
+workflow phases, workstations, retries, or repeated steps:
+
+```text
+DISPATCH                    PHASE       STATUS      TOKENS    COST
+dispatch-plan               planning    COMPLETED   42,100    $0.318200
+dispatch-review             review      COMPLETED   18,400    $0.182000
+dispatch-repair             repair      FAILED       7,900    $0.041100
+```
+
+Worker Session and dispatch are distinct identities. A dispatch describes an
+orchestration step; a Worker Session describes one supervised worker execution
+context. Use both flags when both sections are needed:
+
+```bash
+you metrics session <session-id> --lens cost --by-worker --by-dispatch
+```
+
+## 8. Use JSON in scripts and reports
+
+Request the API-shaped report with global `--json`:
+
+```bash
+you --json metrics session <session-id> --lens cost
+```
+
+Include forecasts and detailed attribution when needed:
+
+```bash
+you --json metrics session <session-id> --lens cost \
+  --forecast \
+  --by-worker \
+  --by-dispatch
+```
+
+List terminal persisted sessions as JSON before selecting an ID:
+
+```bash
+you --json session list --scope persisted --terminal
+```
+
+Automation should read monetary amounts as decimal strings and retain the
+reported currency, valuation kind, price-book version, and coverage fields. Do
+not assume an absent or unpriced amount is zero.
+
+## How to interpret the report
+
+| Field | Meaning |
+|---|---|
+| Accrued valuation | Priced usage recorded so far, grouped by currency. |
+| Actual | The provider reported a monetary charge. |
+| Estimated | The CLI valued reported tokens using a recorded price snapshot. |
+| Mixed | The total contains more than one valuation kind. |
+| Unpriced | Usage exists, but no defensible monetary valuation is available. |
+| Usage coverage | Worker Sessions for which normalized usage was recorded. |
+| Pricing coverage | Worker Sessions whose recorded usage could be valued. |
+| Pending estimate | Estimated incremental cost of known queued or in-flight work. |
+| Projected total | Accrued valuation plus the pending estimate range. |
+| Cached share | Cached-input tokens divided by total input tokens. |
+| Uncached share | Non-cached input tokens divided by total input tokens. |
+| Reasoning share | Reasoning-output tokens divided by total output tokens. |
+
+Provider subscriptions and locally hosted models require special care. A
+subscription-backed invocation may have no marginal per-request bill even when
+its tokens have a retail-equivalent value. A local model may consume hardware
+resources without a configured dollar rate. The report should label these
+cases rather than declaring them free.
+
+## Common workflows
+
+Check a running session:
+
+```bash
+you session list --scope live
+you metrics session <session-id> --lens cost --forecast
+```
+
+Find a prior execution and inspect its final cost:
+
+```bash
+you session list --scope persisted --terminal
+you metrics session <session-id> --lens cost
+```
+
+Investigate an unexpectedly expensive session:
+
+```bash
+you metrics session <session-id> --lens cost --by-worker --by-dispatch
+you session dispatches <session-id>
+```
+
+Export a complete machine-readable report:
+
+```bash
+you --json metrics session <session-id> --lens cost \
+  --forecast \
+  --by-worker \
+  --by-dispatch > session-cost.json
+```


### PR DESCRIPTION
Operator-submitted: 24 development plan documents (lane sourcing for the factory) plus registration of the claude-dynamic-workflows reference topic (focused docs tests pass locally). Docs + docs-wiring only.