### PR TITLE
fix(factory): reset root tree when setup-workspace stash restore fails

### DIFF
--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -88,9 +88,18 @@ def restore_stashed_changes(repo_path, stash_ref, scope_label):
             details = (fallback_result.stderr or fallback_result.stdout).strip()
             if not details:
                 details = (apply_result.stderr or apply_result.stdout).strip()
+            # A failed apply leaves a half-applied, possibly conflicted tree.
+            # Unmerged index entries make every later `git stash push` fail,
+            # which wedges all future workspace setups until a human cleans
+            # the root checkout. Reset back to a clean tree; the stash entry
+            # still holds the full residue. `git clean` honors .gitignore, so
+            # ignored operator files (docs/temp, tasks/todo) are untouched.
+            run_git("reset", "--hard", "HEAD", cwd=repo_path, check=False)
+            run_git("clean", "-fd", cwd=repo_path, check=False)
             raise RuntimeError(
                 f"{scope_label} sync succeeded, but restoring stashed changes failed; "
-                f"{stash_ref} was preserved: {details}"
+                f"the working tree was reset to clean and {stash_ref} was "
+                f"preserved with the unrestored changes: {details}"
             )
 
     drop_result = run_git("stash", "drop", stash_ref, cwd=repo_path, check=False)


### PR DESCRIPTION
## Problem

`restore_stashed_changes` in `factory/scripts/setup-workspace.py` raises on a double `stash apply` failure but leaves the root checkout **half-applied and conflicted**. Unmerged index entries then make every later `git stash push` fail, so every subsequent workspace setup errors out until a human cleans the root repo.

Observed live (2026-08-11): the root checkout sat conflicted on `packages/api/generated/manifest.json` for ~10 hours, `refs/heads/main` froze 237 commits behind origin (new worktrees branch from this ref), and `dwro-s34-invoke-continue` failed workspace setup twice (05:06, 07:01 daemon log) before manual recovery.

## Solution

On double apply failure, reset the working tree to clean HEAD (`git reset --hard` + `git clean -fd`) before raising. Nothing is lost: the stash entry still preserves the full unrestored residue, and `git clean` honors `.gitignore`, so operator files under `docs/temp/` and `tasks/todo/` are untouched.

## Acceptance

- Failure path leaves `git status --porcelain` empty in the root checkout, so the next sync/setup proceeds normally instead of wedging.
- Stash entry with the conflicting residue remains in `git stash list` for manual inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)