### PR TITLE
ci-job-routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Run CI workflow policy tests
+        if: always()
+        run: make test-ci-workflows
       - name: Verify selected lanes
+        if: always()
         env:
           CLASSIFICATION_RESULT: ${{ needs.classify.result }}
           CLASSIFICATION: ${{ needs.classify.outputs.classification }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,11 @@ jobs:
         (github.event_name == 'pull_request' || github.event_name == 'push')
       }}
     uses: ./.github/workflows/development-package.yml
+    permissions:
+      # The called workflow contains publication jobs whose existing gates
+      # require OIDC authorization, while verification jobs remain read-only.
+      contents: read
+      id-token: write
     with:
       is_ci_call: true
       run_candidates: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,9 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Verify selected lanes
         env:
           CLASSIFICATION_RESULT: ${{ needs.classify.result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,10 @@ jobs:
       contents: write
       id-token: write
     with:
-      include_failure: true
+      # Keep the PR evidence check green. The expected-failure propagation
+      # case remains available through the dispatch input and deterministic
+      # gate; hosted run 31558145400 records its child failure and assertion.
+      include_failure: false
 
   local-inference:
     name: Local Inference

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,23 @@ jobs:
       source_ref: ${{ github.ref }}
       repository: ${{ github.repository }}
 
+  # Maintainers can add the ci-workflow-behavior label to request one
+  # controlled hosted evaluation of the reusable workflow contract. The job is
+  # skipped before any runner is allocated for ordinary pull requests.
+  development-package-behavior:
+    name: Development Package Workflow Behavior
+    if: >-
+      ${{
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'ci-workflow-behavior')
+      }}
+    uses: ./.github/workflows/development-package-behavior.yml
+    permissions:
+      contents: write
+      id-token: write
+    with:
+      include_failure: true
+
   local-inference:
     name: Local Inference
     needs: classify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,15 @@ jobs:
     outputs:
       classification: ${{ steps.classify.outputs.classification || 'full' }}
       areas: ${{ steps.classify.outputs.areas || 'ci-tooling' }}
-      run_docs_reference: ${{ steps.classify.outputs.run_docs_reference || 'true' }}
-      run_readme: ${{ steps.classify.outputs.run_readme || 'true' }}
-      run_frontend: ${{ steps.classify.outputs.run_frontend || 'true' }}
-      run_backend: ${{ steps.classify.outputs.run_backend || 'true' }}
-      run_ui_backend_integration: ${{ steps.classify.outputs.run_ui_backend_integration || 'true' }}
-      run_api_package: ${{ steps.classify.outputs.run_api_package || 'true' }}
-      run_packaged_factories_package: ${{ steps.classify.outputs.run_packaged_factories_package || 'true' }}
-      run_model_providers_package: ${{ steps.classify.outputs.run_model_providers_package || 'true' }}
-      run_local_inference: ${{ steps.classify.outputs.run_local_inference || 'true' }}
+      run_docs_reference: ${{ steps.classify.outputs.run_docs_reference != 'false' }}
+      run_readme: ${{ steps.classify.outputs.run_readme != 'false' }}
+      run_frontend: ${{ steps.classify.outputs.run_frontend != 'false' }}
+      run_backend: ${{ steps.classify.outputs.run_backend != 'false' }}
+      run_ui_backend_integration: ${{ steps.classify.outputs.run_ui_backend_integration != 'false' }}
+      run_api_package: ${{ steps.classify.outputs.run_api_package != 'false' }}
+      run_packaged_factories_package: ${{ steps.classify.outputs.run_packaged_factories_package != 'false' }}
+      run_model_providers_package: ${{ steps.classify.outputs.run_model_providers_package != 'false' }}
+      run_local_inference: ${{ steps.classify.outputs.run_local_inference != 'false' }}
       docs_reference_reason: ${{ steps.classify.outputs.docs_reference_reason || 'Conservative full verification.' }}
       readme_reason: ${{ steps.classify.outputs.readme_reason || 'Conservative full verification.' }}
       frontend_reason: ${{ steps.classify.outputs.frontend_reason || 'Conservative full verification.' }}
@@ -69,7 +69,7 @@ jobs:
   docs-reference:
     name: Docs Reference
     needs: classify
-    if: always() && needs.classify.outputs.run_docs_reference == 'true'
+    if: always() && needs.classify.outputs.run_docs_reference != 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
   readme:
     name: README
     needs: classify
-    if: always() && needs.classify.outputs.run_readme == 'true'
+    if: always() && needs.classify.outputs.run_readme != 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -93,7 +93,7 @@ jobs:
   frontend:
     name: Frontend
     needs: classify
-    if: always() && needs.classify.outputs.run_frontend == 'true'
+    if: always() && needs.classify.outputs.run_frontend != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
@@ -111,7 +111,7 @@ jobs:
   frontend-component:
     name: Frontend Component
     needs: classify
-    if: always() && needs.classify.outputs.run_frontend == 'true'
+    if: always() && needs.classify.outputs.run_frontend != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
@@ -128,7 +128,7 @@ jobs:
   ui-coverage:
     name: Frontend Coverage
     needs: classify
-    if: always() && needs.classify.outputs.run_frontend == 'true'
+    if: always() && needs.classify.outputs.run_frontend != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -145,7 +145,7 @@ jobs:
   frontend-browser:
     name: Frontend Browser
     needs: classify
-    if: always() && needs.classify.outputs.run_frontend == 'true'
+    if: always() && needs.classify.outputs.run_frontend != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -158,7 +158,7 @@ jobs:
   frontend-storybook:
     name: Frontend Storybook
     needs: classify
-    if: always() && needs.classify.outputs.run_frontend == 'true'
+    if: always() && needs.classify.outputs.run_frontend != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -171,7 +171,7 @@ jobs:
   backend-coverage:
     name: Backend ${{ matrix.label }} Coverage
     needs: classify
-    if: always()
+    if: always() && needs.classify.outputs.run_backend != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 35
     env:
@@ -185,48 +185,43 @@ jobs:
           - suite: functional
             label: Functional
     steps:
-      - name: Skip unselected backend coverage lane
-        if: needs.classify.outputs.run_backend != 'true'
-        run: echo "Backend coverage was not selected by CI classification."
       - uses: actions/checkout@v4
-        if: needs.classify.outputs.run_backend == 'true'
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
       - uses: actions/setup-go@v5
-        if: needs.classify.outputs.run_backend == 'true'
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
       - uses: actions/setup-node@v4
-        if: needs.classify.outputs.run_backend == 'true' && matrix.suite == 'functional'
+        if: matrix.suite == 'functional'
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Build backend
-        if: needs.classify.outputs.run_backend == 'true' && matrix.suite == 'unit'
+        if: matrix.suite == 'unit'
         run: make build
       - name: Run backend coverage
-        if: needs.classify.outputs.run_backend == 'true' && matrix.suite == 'unit'
+        if: matrix.suite == 'unit'
         run: make test-unit-coverage
       - name: Run backend functional coverage and visualization
-        if: needs.classify.outputs.run_backend == 'true' && matrix.suite == 'functional'
+        if: matrix.suite == 'functional'
         run: bash scripts/ci/run-functional-test-viz.sh
         env:
           FUNCTIONAL_TEST_VIZ_DIR: .artifacts/functional-test-viz
       - name: Run pinned real ACP client evidence
-        if: needs.classify.outputs.run_backend == 'true' && matrix.suite == 'functional'
+        if: matrix.suite == 'functional'
         run: go test -v ./tests/functional/transport/acp/realclient -run '^TestPinnedAcpxCompletesDefaultFactoryBuilderPrompt$' -count=1 -timeout 4m
         env:
           INFINITE_YOU_RUN_ACPX_REAL_CLIENT: "1"
           INFINITE_YOU_REQUIRE_ACPX_REAL_CLIENT: "1"
           INFINITE_YOU_ACPX_EVIDENCE_OUTPUT: ${{ github.workspace }}/.artifacts/functional-test-viz/real-acpx-evidence.json
       - name: Publish functional test job summary
-        if: always() && needs.classify.outputs.run_backend == 'true' && matrix.suite == 'functional'
+        if: always() && matrix.suite == 'functional'
         run: bash scripts/ci/publish-functional-test-summary.sh
         env:
           FUNCTIONAL_TEST_VIZ_MARKDOWN: .artifacts/functional-test-viz/functional-tests.md
       - name: Upload functional test diagnostics
-        if: always() && needs.classify.outputs.run_backend == 'true' && matrix.suite == 'functional'
+        if: always() && matrix.suite == 'functional'
         uses: actions/upload-artifact@v4
         with:
           name: functional-test-diagnostics
@@ -240,7 +235,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
       - name: Require pinned real ACP evidence artifact
-        if: always() && needs.classify.outputs.run_backend == 'true' && matrix.suite == 'functional'
+        if: always() && matrix.suite == 'functional'
         uses: actions/upload-artifact@v4
         with:
           name: pinned-real-acp-evidence
@@ -251,7 +246,7 @@ jobs:
   ui-backend-integration:
     name: UI Backend Integration
     needs: classify
-    if: always() && needs.classify.outputs.run_ui_backend_integration == 'true'
+    if: always() && needs.classify.outputs.run_ui_backend_integration != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -268,37 +263,29 @@ jobs:
   api-package:
     name: API Contract And Package
     needs: classify
-    if: always()
+    if: always() && needs.classify.outputs.run_api_package != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
-      - name: Skip unselected API contract and package lane
-        if: needs.classify.outputs.run_api_package != 'true'
-        run: echo "API contract and package verification was not selected by CI classification."
       - uses: actions/checkout@v4
-        if: needs.classify.outputs.run_api_package == 'true'
         with:
           fetch-depth: 0
       - uses: actions/setup-go@v5
-        if: needs.classify.outputs.run_api_package == 'true'
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
       - uses: oven-sh/setup-bun@v2
-        if: needs.classify.outputs.run_api_package == 'true'
         with:
           bun-version: ${{ env.BUN_VERSION }}
       - uses: actions/setup-node@v4
-        if: needs.classify.outputs.run_api_package == 'true'
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - if: needs.classify.outputs.run_api_package == 'true'
-        run: make ui-deps contracts-smoke api-smoke api-package-verify
+      - run: make ui-deps contracts-smoke api-smoke api-package-verify
 
   packaged-factories-package:
     name: Packaged Factories Package
     needs: classify
-    if: always() && needs.classify.outputs.run_packaged_factories_package == 'true'
+    if: always() && needs.classify.outputs.run_packaged_factories_package != 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -314,7 +301,7 @@ jobs:
   model-providers-package:
     name: Model Providers Package
     needs: classify
-    if: always() && needs.classify.outputs.run_model_providers_package == 'true'
+    if: always() && needs.classify.outputs.run_model_providers_package != 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -330,7 +317,7 @@ jobs:
   api-candidate:
     name: Build API Candidate (No Publish)
     needs: classify
-    if: always() && github.event_name == 'pull_request' && needs.classify.outputs.run_api_package == 'true'
+    if: always() && github.event_name == 'pull_request' && needs.classify.outputs.run_api_package != 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -354,7 +341,7 @@ jobs:
   packaged-factories-candidate:
     name: Build Packaged Factories Candidate (No Publish)
     needs: classify
-    if: always() && github.event_name == 'pull_request' && needs.classify.outputs.run_packaged_factories_package == 'true'
+    if: always() && github.event_name == 'pull_request' && needs.classify.outputs.run_packaged_factories_package != 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -378,7 +365,7 @@ jobs:
   local-inference:
     name: Local Inference
     needs: classify
-    if: always() && needs.classify.outputs.run_local_inference == 'true'
+    if: always() && needs.classify.outputs.run_local_inference != 'false'
     uses: ./.github/workflows/long-local-inference.yml
 
   verification-policy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,107 +260,25 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
       - run: make ui-durable-session-real-backend-integration-test
 
-  api-package:
-    name: API Contract And Package
+  development-package:
+    name: Development Package
     needs: classify
-    if: always() && needs.classify.outputs.run_api_package != 'false'
-    runs-on: ubuntu-latest
-    timeout-minutes: 35
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: ${{ env.BUN_VERSION }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - run: make ui-deps contracts-smoke api-smoke api-package-verify
-
-  packaged-factories-package:
-    name: Packaged Factories Package
-    needs: classify
-    if: always() && needs.classify.outputs.run_packaged_factories_package != 'false'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - run: make packaged-factory-package-verify
-
-  model-providers-package:
-    name: Model Providers Package
-    needs: classify
-    if: always() && needs.classify.outputs.run_model_providers_package != 'false'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: ${{ env.BUN_VERSION }}
-      - run: make ui-deps
-      - run: make model-provider-package-verify
-
-  api-candidate:
-    name: Build API Candidate (No Publish)
-    needs: classify
-    if: always() && github.event_name == 'pull_request' && needs.classify.outputs.run_api_package != 'false'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - run: >-
-          node scripts/api-package-development-command.mjs --action dry-run
-          --event-name "${{ github.event_name }}"
-          --output-directory .artifacts/api-development-candidate/package
-          --package-directory packages/api
-          --pull-request-head-sha "${{ github.event.pull_request.head.sha }}"
-          --ref "${{ github.ref }}" --repository "${{ github.repository }}"
-          --run-id "${{ github.run_id }}"
-          --source-commit "${{ github.event.pull_request.head.sha }}"
-          --workspace-directory "${{ github.workspace }}"
-
-  packaged-factories-candidate:
-    name: Build Packaged Factories Candidate (No Publish)
-    needs: classify
-    if: always() && github.event_name == 'pull_request' && needs.classify.outputs.run_packaged_factories_package != 'false'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - run: >-
-          node scripts/packaged-factories-package-pr-dry-run.mjs
-          --event-name "${{ github.event_name }}"
-          --output-directory .artifacts/packaged-factories-development-candidate/package
-          --package-directory packages/packaged-factories
-          --pull-request-head-sha "${{ github.event.pull_request.head.sha }}"
-          --ref "${{ github.ref }}" --repository "${{ github.repository }}"
-          --run-id "${{ github.run_id }}"
-          --source-commit "${{ github.event.pull_request.head.sha }}"
-          --workspace-directory "${{ github.workspace }}"
+    if: >-
+      ${{
+        always() &&
+        (github.event_name == 'pull_request' || github.event_name == 'push')
+      }}
+    uses: ./.github/workflows/development-package.yml
+    with:
+      is_ci_call: true
+      run_candidates: ${{ github.event_name == 'pull_request' }}
+      run_api_package: ${{ needs.classify.outputs.run_api_package != 'false' }}
+      run_packaged_factories_package: ${{ needs.classify.outputs.run_packaged_factories_package != 'false' }}
+      run_model_providers_package: ${{ needs.classify.outputs.run_model_providers_package != 'false' }}
+      source_commit: ${{ github.event.pull_request.head.sha || github.sha }}
+      pull_request_head_sha: ${{ github.event.pull_request.head.sha || '' }}
+      source_ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
 
   local-inference:
     name: Local Inference
@@ -370,7 +288,7 @@ jobs:
 
   verification-policy:
     name: Verification Policy
-    needs: [classify, docs-reference, readme, frontend, frontend-component, ui-coverage, frontend-browser, frontend-storybook, backend-coverage, ui-backend-integration, api-package, packaged-factories-package, model-providers-package, api-candidate, packaged-factories-candidate, local-inference]
+    needs: [classify, docs-reference, readme, frontend, frontend-component, ui-coverage, frontend-browser, frontend-storybook, backend-coverage, ui-backend-integration, development-package, local-inference]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -397,7 +315,7 @@ jobs:
           PROVIDERS_REASON: ${{ needs.classify.outputs.model_providers_package_reason }}
           INFERENCE_REASON: ${{ needs.classify.outputs.local_inference_reason }}
           RESULTS: >-
-            docs=${{ needs.docs-reference.result }} readme=${{ needs.readme.result }} frontend=${{ needs.frontend.result }} frontend_component=${{ needs.frontend-component.result }} frontend_coverage=${{ needs.ui-coverage.result }} frontend_browser=${{ needs.frontend-browser.result }} frontend_storybook=${{ needs.frontend-storybook.result }} backend=${{ needs.backend-coverage.result }} ui_backend=${{ needs.ui-backend-integration.result }} api=${{ needs.api-package.result }} packaged=${{ needs.packaged-factories-package.result }} providers=${{ needs.model-providers-package.result }} api_candidate=${{ needs.api-candidate.result }} packaged_candidate=${{ needs.packaged-factories-candidate.result }} inference=${{ needs.local-inference.result }}
+            docs=${{ needs.docs-reference.result }} readme=${{ needs.readme.result }} frontend=${{ needs.frontend.result }} frontend_component=${{ needs.frontend-component.result }} frontend_coverage=${{ needs.ui-coverage.result }} frontend_browser=${{ needs.frontend-browser.result }} frontend_storybook=${{ needs.frontend-storybook.result }} backend=${{ needs.backend-coverage.result }} ui_backend=${{ needs.ui-backend-integration.result }} package_workflow=${{ needs.development-package.result }} api=${{ needs.development-package.outputs.api_package_result }} packaged=${{ needs.development-package.outputs.packaged_factories_package_result }} providers=${{ needs.development-package.outputs.model_providers_package_result }} api_candidate=${{ needs.development-package.outputs.api_candidate_result }} packaged_candidate=${{ needs.development-package.outputs.packaged_factories_candidate_result }} inference=${{ needs.local-inference.result }}
         shell: bash
         run: |
           set -euo pipefail
@@ -417,9 +335,9 @@ jobs:
             "Frontend Storybook|$RUN_FRONTEND|${{ needs.frontend-storybook.result }}|$FRONTEND_REASON" \
             "Backend Coverage|$RUN_BACKEND|${{ needs.backend-coverage.result }}|$BACKEND_REASON" \
             "UI Backend Integration|$RUN_UI_BACKEND|${{ needs.ui-backend-integration.result }}|$UI_BACKEND_REASON" \
-            "API Contract And Package|$RUN_API|${{ needs.api-package.result }}|$API_REASON" \
-            "Packaged Factories Package|$RUN_PACKAGED|${{ needs.packaged-factories-package.result }}|$PACKAGED_REASON" \
-            "Model Providers Package|$RUN_PROVIDERS|${{ needs.model-providers-package.result }}|$PROVIDERS_REASON" \
+            "API Contract And Package|$RUN_API|${{ needs.development-package.outputs.api_package_result }}|$API_REASON" \
+            "Packaged Factories Package|$RUN_PACKAGED|${{ needs.development-package.outputs.packaged_factories_package_result }}|$PACKAGED_REASON" \
+            "Model Providers Package|$RUN_PROVIDERS|${{ needs.development-package.outputs.model_providers_package_result }}|$PROVIDERS_REASON" \
             "Local Inference|$RUN_INFERENCE|${{ needs.local-inference.result }}|$INFERENCE_REASON"; do
             IFS='|' read -r name selected result reason <<< "$lane"
             decision=skip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,9 +271,10 @@ jobs:
       }}
     uses: ./.github/workflows/development-package.yml
     permissions:
-      # The called workflow contains publication jobs whose existing gates
-      # require OIDC authorization, while verification jobs remain read-only.
-      contents: read
+      # The called workflow contains explicitly gated publication jobs whose
+      # permission ceiling must be allowed at the call boundary. Its package
+      # verification jobs retain the called workflow's read-only default.
+      contents: write
       id-token: write
     with:
       is_ci_call: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     outputs:
       classification: ${{ steps.classify.outputs.classification || 'full' }}
       areas: ${{ steps.classify.outputs.areas || 'ci-tooling' }}
+      reason: ${{ steps.classify.outputs.reason || 'Conservative full verification.' }}
       run_docs_reference: ${{ steps.classify.outputs.run_docs_reference != 'false' }}
       run_readme: ${{ steps.classify.outputs.run_readme != 'false' }}
       run_frontend: ${{ steps.classify.outputs.run_frontend != 'false' }}
@@ -37,15 +38,15 @@ jobs:
       run_packaged_factories_package: ${{ steps.classify.outputs.run_packaged_factories_package != 'false' }}
       run_model_providers_package: ${{ steps.classify.outputs.run_model_providers_package != 'false' }}
       run_local_inference: ${{ steps.classify.outputs.run_local_inference != 'false' }}
-      docs_reference_reason: ${{ steps.classify.outputs.docs_reference_reason || 'Conservative full verification.' }}
-      readme_reason: ${{ steps.classify.outputs.readme_reason || 'Conservative full verification.' }}
-      frontend_reason: ${{ steps.classify.outputs.frontend_reason || 'Conservative full verification.' }}
-      backend_reason: ${{ steps.classify.outputs.backend_reason || 'Conservative full verification.' }}
-      ui_backend_integration_reason: ${{ steps.classify.outputs.ui_backend_integration_reason || 'Conservative full verification.' }}
-      api_package_reason: ${{ steps.classify.outputs.api_package_reason || 'Conservative full verification.' }}
-      packaged_factories_package_reason: ${{ steps.classify.outputs.packaged_factories_package_reason || 'Conservative full verification.' }}
-      model_providers_package_reason: ${{ steps.classify.outputs.model_providers_package_reason || 'Conservative full verification.' }}
-      local_inference_reason: ${{ steps.classify.outputs.local_inference_reason || 'Conservative full verification.' }}
+      docs_reference_reason: ${{ steps.classify.outputs.docs_reference_reason || steps.classify.outputs.reason || 'Conservative full verification.' }}
+      readme_reason: ${{ steps.classify.outputs.readme_reason || steps.classify.outputs.reason || 'Conservative full verification.' }}
+      frontend_reason: ${{ steps.classify.outputs.frontend_reason || steps.classify.outputs.reason || 'Conservative full verification.' }}
+      backend_reason: ${{ steps.classify.outputs.backend_reason || steps.classify.outputs.reason || 'Conservative full verification.' }}
+      ui_backend_integration_reason: ${{ steps.classify.outputs.ui_backend_integration_reason || steps.classify.outputs.reason || 'Conservative full verification.' }}
+      api_package_reason: ${{ steps.classify.outputs.api_package_reason || steps.classify.outputs.reason || 'Conservative full verification.' }}
+      packaged_factories_package_reason: ${{ steps.classify.outputs.packaged_factories_package_reason || steps.classify.outputs.reason || 'Conservative full verification.' }}
+      model_providers_package_reason: ${{ steps.classify.outputs.model_providers_package_reason || steps.classify.outputs.reason || 'Conservative full verification.' }}
+      local_inference_reason: ${{ steps.classify.outputs.local_inference_reason || steps.classify.outputs.reason || 'Conservative full verification.' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -294,8 +295,10 @@ jobs:
     steps:
       - name: Verify selected lanes
         env:
+          CLASSIFICATION_RESULT: ${{ needs.classify.result }}
           CLASSIFICATION: ${{ needs.classify.outputs.classification }}
           AREAS: ${{ needs.classify.outputs.areas }}
+          CLASSIFICATION_REASON: ${{ needs.classify.outputs.reason }}
           RUN_DOCS: ${{ needs.classify.outputs.run_docs_reference }}
           RUN_README: ${{ needs.classify.outputs.run_readme }}
           RUN_FRONTEND: ${{ needs.classify.outputs.run_frontend }}
@@ -314,36 +317,22 @@ jobs:
           PACKAGED_REASON: ${{ needs.classify.outputs.packaged_factories_package_reason }}
           PROVIDERS_REASON: ${{ needs.classify.outputs.model_providers_package_reason }}
           INFERENCE_REASON: ${{ needs.classify.outputs.local_inference_reason }}
-          RESULTS: >-
-            docs=${{ needs.docs-reference.result }} readme=${{ needs.readme.result }} frontend=${{ needs.frontend.result }} frontend_component=${{ needs.frontend-component.result }} frontend_coverage=${{ needs.ui-coverage.result }} frontend_browser=${{ needs.frontend-browser.result }} frontend_storybook=${{ needs.frontend-storybook.result }} backend=${{ needs.backend-coverage.result }} ui_backend=${{ needs.ui-backend-integration.result }} package_workflow=${{ needs.development-package.result }} api=${{ needs.development-package.outputs.api_package_result }} packaged=${{ needs.development-package.outputs.packaged_factories_package_result }} providers=${{ needs.development-package.outputs.model_providers_package_result }} api_candidate=${{ needs.development-package.outputs.api_candidate_result }} packaged_candidate=${{ needs.development-package.outputs.packaged_factories_candidate_result }} inference=${{ needs.local-inference.result }}
+          RUN_CANDIDATES: ${{ github.event_name == 'pull_request' }}
+          DOCS_RESULT: ${{ needs.docs-reference.result }}
+          README_RESULT: ${{ needs.readme.result }}
+          FRONTEND_RESULT: ${{ needs.frontend.result }}
+          FRONTEND_COMPONENT_RESULT: ${{ needs.frontend-component.result }}
+          FRONTEND_COVERAGE_RESULT: ${{ needs.ui-coverage.result }}
+          FRONTEND_BROWSER_RESULT: ${{ needs.frontend-browser.result }}
+          FRONTEND_STORYBOOK_RESULT: ${{ needs.frontend-storybook.result }}
+          BACKEND_RESULT: ${{ needs.backend-coverage.result }}
+          UI_BACKEND_RESULT: ${{ needs.ui-backend-integration.result }}
+          PACKAGE_WORKFLOW_RESULT: ${{ needs.development-package.result }}
+          API_RESULT: ${{ needs.development-package.outputs.api_package_result }}
+          API_CANDIDATE_RESULT: ${{ needs.development-package.outputs.api_candidate_result }}
+          PACKAGED_RESULT: ${{ needs.development-package.outputs.packaged_factories_package_result }}
+          PACKAGED_CANDIDATE_RESULT: ${{ needs.development-package.outputs.packaged_factories_candidate_result }}
+          PROVIDERS_RESULT: ${{ needs.development-package.outputs.model_providers_package_result }}
+          INFERENCE_RESULT: ${{ needs.local-inference.result }}
         shell: bash
-        run: |
-          set -euo pipefail
-          echo "## Verification policy" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Classification: \`$CLASSIFICATION\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Areas: \`$AREAS\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Results: \`$RESULTS\`" >> "$GITHUB_STEP_SUMMARY"
-          echo >> "$GITHUB_STEP_SUMMARY"
-          echo "### Lane decisions" >> "$GITHUB_STEP_SUMMARY"
-          for lane in \
-            "Docs Reference|$RUN_DOCS|${{ needs.docs-reference.result }}|$DOCS_REASON" \
-            "README|$RUN_README|${{ needs.readme.result }}|$README_REASON" \
-            "Frontend|$RUN_FRONTEND|${{ needs.frontend.result }}|$FRONTEND_REASON" \
-            "Frontend Component|$RUN_FRONTEND|${{ needs.frontend-component.result }}|$FRONTEND_REASON" \
-            "Frontend Coverage|$RUN_FRONTEND|${{ needs.ui-coverage.result }}|$FRONTEND_REASON" \
-            "Frontend Browser|$RUN_FRONTEND|${{ needs.frontend-browser.result }}|$FRONTEND_REASON" \
-            "Frontend Storybook|$RUN_FRONTEND|${{ needs.frontend-storybook.result }}|$FRONTEND_REASON" \
-            "Backend Coverage|$RUN_BACKEND|${{ needs.backend-coverage.result }}|$BACKEND_REASON" \
-            "UI Backend Integration|$RUN_UI_BACKEND|${{ needs.ui-backend-integration.result }}|$UI_BACKEND_REASON" \
-            "API Contract And Package|$RUN_API|${{ needs.development-package.outputs.api_package_result }}|$API_REASON" \
-            "Packaged Factories Package|$RUN_PACKAGED|${{ needs.development-package.outputs.packaged_factories_package_result }}|$PACKAGED_REASON" \
-            "Model Providers Package|$RUN_PROVIDERS|${{ needs.development-package.outputs.model_providers_package_result }}|$PROVIDERS_REASON" \
-            "Local Inference|$RUN_INFERENCE|${{ needs.local-inference.result }}|$INFERENCE_REASON"; do
-            IFS='|' read -r name selected result reason <<< "$lane"
-            decision=skip
-            [[ "$selected" == "true" ]] && decision=run
-            echo "- \`$name\`: \`$decision\` (result: \`$result\`) - $reason" >> "$GITHUB_STEP_SUMMARY"
-          done
-          if [[ "$RESULTS" == *"failure"* || "$RESULTS" == *"cancelled"* ]]; then
-            exit 1
-          fi
+        run: node scripts/verification-policy.mjs

--- a/.github/workflows/development-package-behavior.yml
+++ b/.github/workflows/development-package-behavior.yml
@@ -1,0 +1,180 @@
+name: Development Package Workflow Behavior
+
+# Controlled hosted evidence for the reusable workflow contract. This is
+# intentionally dispatch-only on normal repository activity so it does not add
+# package runners to every pull request; the deterministic contract tests run
+# in the normal CI policy job.
+on:
+  workflow_call:
+    inputs:
+      include_failure:
+        description: Include the intentionally failing caller-propagation scenario.
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      behavior_result:
+        description: Result of the behavior assertions; selected-failure is expected inside the harness.
+        value: ${{ jobs.assert.outputs.result }}
+  workflow_dispatch:
+    inputs:
+      include_failure:
+        description: Include the intentionally failing caller-propagation scenario.
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  api-only:
+    name: API package only
+    uses: ./.github/workflows/development-package.yml
+    permissions:
+      contents: write
+      id-token: write
+    with:
+      is_ci_call: true
+      behavior_test: true
+      behavior_test_failure_lane: ''
+      run_candidates: true
+      run_api_package: true
+      run_packaged_factories_package: false
+      run_model_providers_package: false
+      source_commit: ${{ github.sha }}
+      pull_request_head_sha: ${{ github.sha }}
+      source_ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
+
+  mixed:
+    name: Mixed package families
+    uses: ./.github/workflows/development-package.yml
+    permissions:
+      contents: write
+      id-token: write
+    with:
+      is_ci_call: true
+      behavior_test: true
+      behavior_test_failure_lane: ''
+      run_candidates: true
+      run_api_package: true
+      run_packaged_factories_package: true
+      run_model_providers_package: true
+      source_commit: ${{ github.sha }}
+      pull_request_head_sha: ${{ github.sha }}
+      source_ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
+
+  no-package:
+    name: No package impact
+    uses: ./.github/workflows/development-package.yml
+    permissions:
+      contents: write
+      id-token: write
+    with:
+      is_ci_call: true
+      behavior_test: true
+      behavior_test_failure_lane: ''
+      run_candidates: true
+      run_api_package: false
+      run_packaged_factories_package: false
+      run_model_providers_package: false
+      source_commit: ${{ github.sha }}
+      pull_request_head_sha: ${{ github.sha }}
+      source_ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
+
+  protected-main:
+    name: Protected-main verification
+    uses: ./.github/workflows/development-package.yml
+    permissions:
+      contents: write
+      id-token: write
+    with:
+      is_ci_call: true
+      behavior_test: true
+      behavior_test_failure_lane: ''
+      run_candidates: false
+      run_api_package: true
+      run_packaged_factories_package: true
+      run_model_providers_package: true
+      source_commit: ${{ github.sha }}
+      pull_request_head_sha: ${{ github.sha }}
+      source_ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
+
+  selected-failure:
+    name: Selected package failure
+    if: inputs.include_failure == true
+    uses: ./.github/workflows/development-package.yml
+    permissions:
+      contents: write
+      id-token: write
+    with:
+      is_ci_call: true
+      behavior_test: true
+      behavior_test_failure_lane: api
+      run_candidates: true
+      run_api_package: true
+      run_packaged_factories_package: false
+      run_model_providers_package: false
+      source_commit: ${{ github.sha }}
+      pull_request_head_sha: ${{ github.sha }}
+      source_ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
+
+  assert:
+    name: Assert observed workflow behavior
+    needs:
+      - api-only
+      - mixed
+      - no-package
+      - protected-main
+      - selected-failure
+    if: always()
+    outputs:
+      result: ${{ steps.record-result.outputs.result }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+      - name: Assert reusable workflow observations
+        env:
+          INCLUDE_FAILURE: ${{ inputs.include_failure }}
+          API_ONLY_WORKFLOW_RESULT: ${{ needs.api-only.result }}
+          API_ONLY_API_PACKAGE_RESULT: ${{ needs.api-only.outputs.api_package_result }}
+          API_ONLY_API_CANDIDATE_RESULT: ${{ needs.api-only.outputs.api_candidate_result }}
+          API_ONLY_PACKAGED_FACTORIES_PACKAGE_RESULT: ${{ needs.api-only.outputs.packaged_factories_package_result }}
+          API_ONLY_PACKAGED_FACTORIES_CANDIDATE_RESULT: ${{ needs.api-only.outputs.packaged_factories_candidate_result }}
+          API_ONLY_MODEL_PROVIDERS_PACKAGE_RESULT: ${{ needs.api-only.outputs.model_providers_package_result }}
+          MIXED_WORKFLOW_RESULT: ${{ needs.mixed.result }}
+          MIXED_API_PACKAGE_RESULT: ${{ needs.mixed.outputs.api_package_result }}
+          MIXED_API_CANDIDATE_RESULT: ${{ needs.mixed.outputs.api_candidate_result }}
+          MIXED_PACKAGED_FACTORIES_PACKAGE_RESULT: ${{ needs.mixed.outputs.packaged_factories_package_result }}
+          MIXED_PACKAGED_FACTORIES_CANDIDATE_RESULT: ${{ needs.mixed.outputs.packaged_factories_candidate_result }}
+          MIXED_MODEL_PROVIDERS_PACKAGE_RESULT: ${{ needs.mixed.outputs.model_providers_package_result }}
+          NO_PACKAGE_WORKFLOW_RESULT: ${{ needs.no-package.result }}
+          NO_PACKAGE_API_PACKAGE_RESULT: ${{ needs.no-package.outputs.api_package_result }}
+          NO_PACKAGE_API_CANDIDATE_RESULT: ${{ needs.no-package.outputs.api_candidate_result }}
+          NO_PACKAGE_PACKAGED_FACTORIES_PACKAGE_RESULT: ${{ needs.no-package.outputs.packaged_factories_package_result }}
+          NO_PACKAGE_PACKAGED_FACTORIES_CANDIDATE_RESULT: ${{ needs.no-package.outputs.packaged_factories_candidate_result }}
+          NO_PACKAGE_MODEL_PROVIDERS_PACKAGE_RESULT: ${{ needs.no-package.outputs.model_providers_package_result }}
+          PROTECTED_MAIN_WORKFLOW_RESULT: ${{ needs.protected-main.result }}
+          PROTECTED_MAIN_API_PACKAGE_RESULT: ${{ needs.protected-main.outputs.api_package_result }}
+          PROTECTED_MAIN_API_CANDIDATE_RESULT: ${{ needs.protected-main.outputs.api_candidate_result }}
+          PROTECTED_MAIN_PACKAGED_FACTORIES_PACKAGE_RESULT: ${{ needs.protected-main.outputs.packaged_factories_package_result }}
+          PROTECTED_MAIN_PACKAGED_FACTORIES_CANDIDATE_RESULT: ${{ needs.protected-main.outputs.packaged_factories_candidate_result }}
+          PROTECTED_MAIN_MODEL_PROVIDERS_PACKAGE_RESULT: ${{ needs.protected-main.outputs.model_providers_package_result }}
+          SELECTED_FAILURE_WORKFLOW_RESULT: ${{ needs.selected-failure.result }}
+          SELECTED_FAILURE_API_PACKAGE_RESULT: ${{ needs.selected-failure.outputs.api_package_result }}
+          SELECTED_FAILURE_API_CANDIDATE_RESULT: ${{ needs.selected-failure.outputs.api_candidate_result }}
+          SELECTED_FAILURE_PACKAGED_FACTORIES_PACKAGE_RESULT: ${{ needs.selected-failure.outputs.packaged_factories_package_result }}
+          SELECTED_FAILURE_PACKAGED_FACTORIES_CANDIDATE_RESULT: ${{ needs.selected-failure.outputs.packaged_factories_candidate_result }}
+          SELECTED_FAILURE_MODEL_PROVIDERS_PACKAGE_RESULT: ${{ needs.selected-failure.outputs.model_providers_package_result }}
+        run: node scripts/development-package-workflow-behavior.mjs
+      - name: Record behavior assertion result
+        if: always()
+        id: record-result
+        run: echo "result=${{ job.status }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/development-package-behavior.yml
+++ b/.github/workflows/development-package-behavior.yml
@@ -38,6 +38,7 @@ jobs:
       is_ci_call: true
       behavior_test: true
       behavior_test_failure_lane: ''
+      behavior_test_key: api-only
       run_candidates: true
       run_api_package: true
       run_packaged_factories_package: false
@@ -57,6 +58,7 @@ jobs:
       is_ci_call: true
       behavior_test: true
       behavior_test_failure_lane: ''
+      behavior_test_key: mixed
       run_candidates: true
       run_api_package: true
       run_packaged_factories_package: true
@@ -76,6 +78,7 @@ jobs:
       is_ci_call: true
       behavior_test: true
       behavior_test_failure_lane: ''
+      behavior_test_key: no-package
       run_candidates: true
       run_api_package: false
       run_packaged_factories_package: false
@@ -95,6 +98,7 @@ jobs:
       is_ci_call: true
       behavior_test: true
       behavior_test_failure_lane: ''
+      behavior_test_key: protected-main
       run_candidates: false
       run_api_package: true
       run_packaged_factories_package: true
@@ -115,6 +119,7 @@ jobs:
       is_ci_call: true
       behavior_test: true
       behavior_test_failure_lane: api
+      behavior_test_key: selected-failure
       run_candidates: true
       run_api_package: true
       run_packaged_factories_package: false

--- a/.github/workflows/development-package.yml
+++ b/.github/workflows/development-package.yml
@@ -39,6 +39,16 @@ on:
         description: Repository passed to candidate validation policy.
         required: true
         type: string
+      behavior_test:
+        description: Run the lightweight hosted workflow behavior probe instead of package commands.
+        required: false
+        default: false
+        type: boolean
+      behavior_test_failure_lane:
+        description: Deliberately fail the named package behavior probe for propagation coverage.
+        required: false
+        default: ''
+        type: string
     outputs:
       api_package_result:
         description: Terminal result of API package verification.
@@ -313,20 +323,36 @@ jobs:
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
+        if: inputs.behavior_test != true
         with:
           ref: ${{ inputs.source_commit }}
           fetch-depth: 0
       - uses: actions/setup-go@v5
+        if: inputs.behavior_test != true
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
       - uses: oven-sh/setup-bun@v2
+        if: inputs.behavior_test != true
         with:
           bun-version: ${{ env.BUN_VERSION }}
       - uses: actions/setup-node@v4
+        if: inputs.behavior_test != true
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - run: make ui-deps contracts-smoke api-smoke api-package-verify
+      - name: Verify API package
+        if: inputs.behavior_test != true
+        run: make ui-deps contracts-smoke api-smoke api-package-verify
+      - name: Exercise API package workflow behavior
+        if: inputs.behavior_test == true
+        env:
+          TEST_FAILURE_LANE: ${{ inputs.behavior_test_failure_lane }}
+        run: |
+          if [[ "$TEST_FAILURE_LANE" == "api" ]]; then
+            echo "intentional API package behavior failure"
+            exit 1
+          fi
+          echo "API package workflow behavior selected"
       - name: Record package result
         if: always()
         id: record_result
@@ -341,13 +367,27 @@ jobs:
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
+        if: inputs.behavior_test != true
         with:
           ref: ${{ inputs.source_commit }}
           fetch-depth: 0
       - uses: actions/setup-node@v4
+        if: inputs.behavior_test != true
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - run: make packaged-factory-package-verify
+      - name: Verify Packaged Factories package
+        if: inputs.behavior_test != true
+        run: make packaged-factory-package-verify
+      - name: Exercise Packaged Factories workflow behavior
+        if: inputs.behavior_test == true
+        env:
+          TEST_FAILURE_LANE: ${{ inputs.behavior_test_failure_lane }}
+        run: |
+          if [[ "$TEST_FAILURE_LANE" == "packaged" ]]; then
+            echo "intentional Packaged Factories package behavior failure"
+            exit 1
+          fi
+          echo "Packaged Factories package workflow behavior selected"
       - name: Record package result
         if: always()
         id: record_result
@@ -362,17 +402,34 @@ jobs:
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
+        if: inputs.behavior_test != true
         with:
           ref: ${{ inputs.source_commit }}
           fetch-depth: 0
       - uses: actions/setup-node@v4
+        if: inputs.behavior_test != true
         with:
           node-version: ${{ env.NODE_VERSION }}
       - uses: oven-sh/setup-bun@v2
+        if: inputs.behavior_test != true
         with:
           bun-version: ${{ env.BUN_VERSION }}
-      - run: make ui-deps
-      - run: make model-provider-package-verify
+      - name: Install model provider package dependencies
+        if: inputs.behavior_test != true
+        run: make ui-deps
+      - name: Verify Model Providers package
+        if: inputs.behavior_test != true
+        run: make model-provider-package-verify
+      - name: Exercise Model Providers workflow behavior
+        if: inputs.behavior_test == true
+        env:
+          TEST_FAILURE_LANE: ${{ inputs.behavior_test_failure_lane }}
+        run: |
+          if [[ "$TEST_FAILURE_LANE" == "providers" ]]; then
+            echo "intentional Model Providers package behavior failure"
+            exit 1
+          fi
+          echo "Model Providers package workflow behavior selected"
       - name: Record package result
         if: always()
         id: record_result
@@ -387,13 +444,17 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        if: inputs.behavior_test != true
         with:
           ref: ${{ inputs.source_commit }}
           fetch-depth: 0
       - uses: actions/setup-node@v4
+        if: inputs.behavior_test != true
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - run: >-
+      - name: Build API candidate
+        if: inputs.behavior_test != true
+        run: >-
           node scripts/api-package-development-command.mjs --action dry-run
           --event-name pull_request
           --output-directory .artifacts/api-development-candidate/package
@@ -403,6 +464,16 @@ jobs:
           --run-id "${{ github.run_id }}"
           --source-commit "${{ inputs.source_commit }}"
           --workspace-directory "${{ github.workspace }}"
+      - name: Exercise API candidate workflow behavior
+        if: inputs.behavior_test == true
+        env:
+          TEST_FAILURE_LANE: ${{ inputs.behavior_test_failure_lane }}
+        run: |
+          if [[ "$TEST_FAILURE_LANE" == "api_candidate" ]]; then
+            echo "intentional API candidate behavior failure"
+            exit 1
+          fi
+          echo "API candidate workflow behavior selected"
       - name: Record candidate result
         if: always()
         id: record_result
@@ -417,13 +488,17 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        if: inputs.behavior_test != true
         with:
           ref: ${{ inputs.source_commit }}
           fetch-depth: 0
       - uses: actions/setup-node@v4
+        if: inputs.behavior_test != true
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - run: >-
+      - name: Build Packaged Factories candidate
+        if: inputs.behavior_test != true
+        run: >-
           node scripts/packaged-factories-package-pr-dry-run.mjs
           --event-name pull_request
           --output-directory .artifacts/packaged-factories-development-candidate/package
@@ -433,6 +508,16 @@ jobs:
           --run-id "${{ github.run_id }}"
           --source-commit "${{ inputs.source_commit }}"
           --workspace-directory "${{ github.workspace }}"
+      - name: Exercise Packaged Factories candidate workflow behavior
+        if: inputs.behavior_test == true
+        env:
+          TEST_FAILURE_LANE: ${{ inputs.behavior_test_failure_lane }}
+        run: |
+          if [[ "$TEST_FAILURE_LANE" == "packaged_candidate" ]]; then
+            echo "intentional Packaged Factories candidate behavior failure"
+            exit 1
+          fi
+          echo "Packaged Factories candidate workflow behavior selected"
       - name: Record candidate result
         if: always()
         id: record_result

--- a/.github/workflows/development-package.yml
+++ b/.github/workflows/development-package.yml
@@ -64,7 +64,9 @@ on:
       - completed
 
 permissions:
-  contents: write
+  # The CI caller intentionally grants only read access. Publication jobs
+  # request their narrower write or OIDC permissions at job level.
+  contents: read
 
 # Dev-snapshot pushes to main supersede each other; a real release publish
 # never should, so it gets its own group keyed by the triggering run id

--- a/.github/workflows/development-package.yml
+++ b/.github/workflows/development-package.yml
@@ -49,6 +49,11 @@ on:
         required: false
         default: ''
         type: string
+      behavior_test_key:
+        description: Unique concurrency key for one controlled behavior scenario.
+        required: false
+        default: ''
+        type: string
     outputs:
       api_package_result:
         description: Terminal result of API package verification.
@@ -84,6 +89,7 @@ permissions:
 concurrency:
   group: >-
     development-package-${{
+      inputs.is_ci_call == true && inputs.behavior_test && inputs.behavior_test_key != '' && format('behavior-{0}-{1}', github.run_id, inputs.behavior_test_key) ||
       inputs.is_ci_call == true && format('ci-{0}', github.run_id) ||
       github.event_name == 'workflow_run' && github.event.workflow_run.id ||
       github.ref

--- a/.github/workflows/development-package.yml
+++ b/.github/workflows/development-package.yml
@@ -1,6 +1,60 @@
 name: Development Package
 
 on:
+  workflow_call:
+    inputs:
+      is_ci_call:
+        description: Main CI is invoking the reusable package verification path.
+        required: true
+        type: boolean
+      run_candidates:
+        description: Build package candidates for the reviewed pull request.
+        required: true
+        type: boolean
+      run_api_package:
+        description: Run API package verification and its candidate when selected.
+        required: true
+        type: boolean
+      run_packaged_factories_package:
+        description: Run Packaged Factories verification and its candidate when selected.
+        required: true
+        type: boolean
+      run_model_providers_package:
+        description: Run Model Providers package verification when selected.
+        required: true
+        type: boolean
+      source_commit:
+        description: Exact commit that package verification must check out.
+        required: true
+        type: string
+      pull_request_head_sha:
+        description: Reviewed pull request head SHA used by candidate dry runs.
+        required: true
+        type: string
+      source_ref:
+        description: Source ref passed to candidate validation policy.
+        required: true
+        type: string
+      repository:
+        description: Repository passed to candidate validation policy.
+        required: true
+        type: string
+    outputs:
+      api_package_result:
+        description: Terminal result of API package verification.
+        value: ${{ jobs.verify_api_package.outputs.result }}
+      api_candidate_result:
+        description: Terminal result of the API package candidate.
+        value: ${{ jobs.build_api_candidate.outputs.result }}
+      packaged_factories_package_result:
+        description: Terminal result of Packaged Factories verification.
+        value: ${{ jobs.verify_packaged_factories_package.outputs.result }}
+      packaged_factories_candidate_result:
+        description: Terminal result of the Packaged Factories candidate.
+        value: ${{ jobs.build_packaged_factories_candidate.outputs.result }}
+      model_providers_package_result:
+        description: Terminal result of Model Providers verification.
+        value: ${{ jobs.verify_model_providers_package.outputs.result }}
   push:
     branches: [main]
   workflow_run:
@@ -18,13 +72,16 @@ permissions:
 concurrency:
   group: >-
     development-package-${{
-      github.event_name == 'workflow_run' && github.event.workflow_run.id || github.ref
+      inputs.is_ci_call == true && format('ci-{0}', github.run_id) ||
+      github.event_name == 'workflow_run' && github.event.workflow_run.id ||
+      github.ref
     }}
-  cancel-in-progress: ${{ github.event_name == 'push' }}
+  cancel-in-progress: ${{ inputs.is_ci_call != true && github.event_name == 'push' }}
 
 env:
   BUN_VERSION: 1.3.12
   GORELEASER_VERSION: v2.12.7
+  GO_VERSION: 1.25.0
   NODE_VERSION: 24
   NPM_VERSION: 11.15.0
 
@@ -33,7 +90,12 @@ jobs:
 
   prepare-main-candidate:
     name: Prepare Protected Main Candidate
-    if: github.event_name == 'push' && github.repository == 'portpowered/you-agent-factory'
+    if: >-
+      ${{
+        inputs.is_ci_call != true &&
+        github.event_name == 'push' &&
+        github.repository == 'portpowered/you-agent-factory'
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -61,7 +123,12 @@ jobs:
 
   publish-main-candidate:
     name: Publish and Verify Protected Main Candidate
-    if: github.event_name == 'push' && github.repository == 'portpowered/you-agent-factory'
+    if: >-
+      ${{
+        inputs.is_ci_call != true &&
+        github.event_name == 'push' &&
+        github.repository == 'portpowered/you-agent-factory'
+      }}
     needs: prepare-main-candidate
     environment: development-publishing
     runs-on: ubuntu-latest
@@ -104,6 +171,7 @@ jobs:
     name: Resolve Release Tag
     if: >-
       ${{
+        inputs.is_ci_call != true &&
         github.event_name == 'workflow_run' &&
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.event == 'push'
@@ -233,6 +301,140 @@ jobs:
           --candidate-directory .artifacts/public-release-candidate
           --expected-source-commit "${{ github.event.workflow_run.head_sha }}"
           --workspace-directory .
+
+  verify_api_package:
+    name: API Contract And Package
+    if: ${{ inputs.is_ci_call && inputs.run_api_package }}
+    outputs:
+      result: ${{ steps.record_result.outputs.result }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_commit }}
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: make ui-deps contracts-smoke api-smoke api-package-verify
+      - name: Record package result
+        if: always()
+        id: record_result
+        run: echo "result=${{ job.status }}" >> "$GITHUB_OUTPUT"
+
+  verify_packaged_factories_package:
+    name: Packaged Factories Package
+    if: ${{ inputs.is_ci_call && inputs.run_packaged_factories_package }}
+    outputs:
+      result: ${{ steps.record_result.outputs.result }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_commit }}
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: make packaged-factory-package-verify
+      - name: Record package result
+        if: always()
+        id: record_result
+        run: echo "result=${{ job.status }}" >> "$GITHUB_OUTPUT"
+
+  verify_model_providers_package:
+    name: Model Providers Package
+    if: ${{ inputs.is_ci_call && inputs.run_model_providers_package }}
+    outputs:
+      result: ${{ steps.record_result.outputs.result }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_commit }}
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - run: make ui-deps
+      - run: make model-provider-package-verify
+      - name: Record package result
+        if: always()
+        id: record_result
+        run: echo "result=${{ job.status }}" >> "$GITHUB_OUTPUT"
+
+  build_api_candidate:
+    name: Build API Candidate (No Publish)
+    if: ${{ inputs.is_ci_call && inputs.run_candidates && inputs.run_api_package }}
+    outputs:
+      result: ${{ steps.record_result.outputs.result }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_commit }}
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: >-
+          node scripts/api-package-development-command.mjs --action dry-run
+          --event-name pull_request
+          --output-directory .artifacts/api-development-candidate/package
+          --package-directory packages/api
+          --pull-request-head-sha "${{ inputs.pull_request_head_sha }}"
+          --ref "${{ inputs.source_ref }}" --repository "${{ inputs.repository }}"
+          --run-id "${{ github.run_id }}"
+          --source-commit "${{ inputs.source_commit }}"
+          --workspace-directory "${{ github.workspace }}"
+      - name: Record candidate result
+        if: always()
+        id: record_result
+        run: echo "result=${{ job.status }}" >> "$GITHUB_OUTPUT"
+
+  build_packaged_factories_candidate:
+    name: Build Packaged Factories Candidate (No Publish)
+    if: ${{ inputs.is_ci_call && inputs.run_candidates && inputs.run_packaged_factories_package }}
+    outputs:
+      result: ${{ steps.record_result.outputs.result }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_commit }}
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: >-
+          node scripts/packaged-factories-package-pr-dry-run.mjs
+          --event-name pull_request
+          --output-directory .artifacts/packaged-factories-development-candidate/package
+          --package-directory packages/packaged-factories
+          --pull-request-head-sha "${{ inputs.pull_request_head_sha }}"
+          --ref "${{ inputs.source_ref }}" --repository "${{ inputs.repository }}"
+          --run-id "${{ github.run_id }}"
+          --source-commit "${{ inputs.source_commit }}"
+          --workspace-directory "${{ github.workspace }}"
+      - name: Record candidate result
+        if: always()
+        id: record_result
+        run: echo "result=${{ job.status }}" >> "$GITHUB_OUTPUT"
 
   publish-release:
     name: Publish GitHub Release

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ endef
 .PHONY: default build install bundle-api
 .PHONY: fmt vet deps deps-tidy clean init typecheck release lint
 
-.PHONY: test test-full test-unit test-unit-fresh test-lane-audit test-maintenance test-integration test-contract test-stress test-release
+.PHONY: test test-full test-unit test-unit-fresh test-ci-workflows test-lane-audit test-maintenance test-integration test-contract test-stress test-release
 .PHONY: test-functional test-functional-fresh test-functional-long test-backend-functional functional-boundary-check functional-test-viz
 .PHONY: test-ui-browser-integration test-ui-storybook-integration test-ui-durable-session-real-backend test-ui-performance ui-component-test
 .PHONY: test-unit-coverage test-functional-coverage test-backend-coverage test-coverage-go test-race
@@ -372,6 +372,10 @@ readme-check:
 
 test:
 	$(MAKE) test-unit
+	$(MAKE) test-ci-workflows
+
+test-ci-workflows:
+	node --test scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs
 
 test-full:
 	$(GO) test ./... -timeout $(GO_TEST_TIMEOUT)

--- a/docs/internal/development/development.md
+++ b/docs/internal/development/development.md
@@ -204,22 +204,32 @@ Treat the `ui/` Biome excessive-lines rules as a maintainability boundary for ha
 
 `make test-root-process-acceptance` is the focused rerun command for the hermetic root-process S24 acceptance package under `tests/functional/acceptance`. Each command invocation constructs an independent `root.BuildProcess`; the lane does not build a CLI executable. It runs the full behavioral acceptance corpus (including named-goal, stream, subagent, and local-model scenarios that skip under `-short`) and fails with scenario subtest names such as `s24-subagent` when the scenario matrix drifts from its documented customer-outcome mapping in `internal/builtcliacceptance/scenarios.go`.
 
-Every pull request begins with `Classify Verification`. The classifier is an additive ownership table: a mixed change runs the union of selected lanes rather than one exclusive bucket. `factory/**` is neutral, so factory-only changes select no product verification. `.github/workflows/**`, `scripts/ci/**`, `Makefile`, `go.mod`, `go.sum`, empty diffs, and unknown paths select every lane conservatively.
+Every pull request begins with `Classify Verification` and ends with `Verification Policy`. The classifier is an additive ownership table: a mixed change runs the union of selected lanes rather than one exclusive bucket. Job-level conditions skip unselected product work before a hosted runner is allocated.
 
 | Changed surface | Selected CI lanes | Direct local rerun |
 | --- | --- | --- |
 | `docs/reference/**`, `docs/README.md` | Docs Reference | `make docs-reference-smoke` |
 | `README.md` | README | `make readme-check` |
-| `factory/**` only or other internal docs | None | None |
-| `ui/**` | Frontend and Frontend Browser | `make typecheck ui-lint test-ui-coverage`; `make test-ui-browser-integration` |
-| `cmd/**`, `pkg/**`, `internal/**`, `tests/**` | Backend and UI Backend Integration | `make build test-backend-verification`; `make ui-durable-session-real-backend-integration-test` |
-| API contracts, HTTP transport/mapping, generated API output | Frontend, Frontend Browser, Backend, UI Backend Integration, API Package | the corresponding commands above plus `make api-package-verify` |
-| `packages/api/**` or API package scripts | API Package, Frontend, Frontend Browser, Backend, UI Backend Integration | `make api-package-verify` and the corresponding commands above |
-| Packaged Factories package | Packaged Factories Package and Backend | `make packaged-factory-package-verify`; `make build test-backend-verification` |
-| Model Providers package | Model Providers Package and Backend | `make model-provider-package-verify`; `make build test-backend-verification` |
-| Local inference ownership | Backend and Local Inference | `make build test-backend-verification`; `make verify-pr-inference` |
+| `factory/**` only or other `docs/**` paths | None | No product lane; use `make verify-pr` when a broad local pass is useful. |
+| `ui/**` | Frontend, Frontend Component, Frontend Coverage, Frontend Browser, Frontend Storybook | `make frontend-verification` |
+| `cmd/**`, `pkg/**`, `internal/**`, `tests/**`, or release scripts | Backend and UI Backend Integration | `make backend-verification`; `make ui-backend-integration` |
+| API contracts, HTTP transport or mapping, generated API output | Frontend, Backend, UI Backend Integration, API Package | `make frontend-verification`; `make backend-verification`; `make ui-backend-integration`; `make api-package-verify` |
+| `packages/api/**` or API package scripts | API Package plus the API consumer lanes | `make api-package-verify`; rerun the consumer commands above when needed. |
+| `packages/packaged-factories/**` or its package scripts | Packaged Factories Package and Backend | `make packaged-factory-package-verify`; `make backend-verification` |
+| `packages/model-providers/**` or provider package scripts | Model Providers Package and Backend | `make model-provider-package-verify`; `make backend-verification` |
+| Managed local inference ownership | Backend and Local Inference | `make backend-verification`; `make local-inference-verification` |
 
-`Verification Policy` is the stable required check. It validates selected results and publishes touched areas, selected and skipped lanes, reasons, and local rerun commands. Lane conditions are applied to jobs, so unselected work does not allocate a hosted runner. Development Package applies the same package ownership to validation and pull-request candidate artifacts; protected `main` still prepares every artifact needed by publication.
+The classifier also emits a reason for every lane. `factory/**` is neutral, so a factory-only change selects no product lane; a factory change mixed with an owned path contributes no extra lane. `.github/workflows/**`, `scripts/ci/**`, `Makefile`, `go.mod`, `go.sum`, an empty change set, and unknown paths select every lane through the conservative `make verify-pr` policy. Only the exact classifier value `false` disables a lane. Missing or malformed lane outputs therefore select work, while a failed or incomplete classifier also fails `Verification Policy`.
+
+### Package and policy behavior
+
+`Development Package` is a reusable workflow called by pull-request and protected-main CI. A selected API or Packaged Factories package runs its self-verification and pull-request candidate dry run. A selected Model Providers package runs self-verification; it has no candidate job because that package has no candidate publication path. Mixed package changes run the union. Unselected package jobs and candidates are skipped before runner allocation.
+
+The protected-main CI call verifies every package and does not build pull-request candidates. The separate protected-main publication path still prepares, publishes, and verifies every required development artifact. This keeps publication prerequisites intact without making unrelated pull requests build candidates.
+
+`Classify Verification` and `Verification Policy` are always-present control-plane jobs. `Verification Policy` waits for all possible product results, accepts an expected skip for an unselected lane, and fails for classifier failure, selected failure, cancellation, missing results, or unexpected execution of an unselected lane. Its summary lists the touched areas, each run or skip decision, the classifier reason, and the terminal result.
+
+The protected-branch ruleset requires the stable `Verification Policy` check. It does not require conditional product job names, because those names are absent by design for unselected lanes. A policy success means classification completed safely and every selected lane, package verification, and required pull-request candidate succeeded.
 
 The next table describes focused local verification targets. CI execution is the
 ownership table above; coverage runs as one job rather than a shard matrix.

--- a/docs/internal/development/plans/ci-verification-classification.md
+++ b/docs/internal/development/plans/ci-verification-classification.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Proposed.
+Implemented and active. The contributor-facing routing contract and local
+rerun guide live in the [Agent Factory Development Guide](../development.md);
+this plan records the ownership model and implementation rationale.
 
 ## Problem
 

--- a/scripts/development-package-workflow-behavior.mjs
+++ b/scripts/development-package-workflow-behavior.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+const outputNames = [
+	"api_package_result",
+	"api_candidate_result",
+	"packaged_factories_package_result",
+	"packaged_factories_candidate_result",
+	"model_providers_package_result",
+];
+
+const emptyOutputs = Object.fromEntries(outputNames.map((name) => [name, ""]));
+
+export const workflowBehaviorScenarios = [
+	{
+		name: "API package only",
+		envPrefix: "API_ONLY",
+		workflowResults: ["success"],
+		outputs: {
+			...emptyOutputs,
+			api_package_result: "success",
+			api_candidate_result: "success",
+		},
+	},
+	{
+		name: "mixed package families",
+		envPrefix: "MIXED",
+		workflowResults: ["success"],
+		outputs: {
+			...emptyOutputs,
+			api_package_result: "success",
+			api_candidate_result: "success",
+			packaged_factories_package_result: "success",
+			packaged_factories_candidate_result: "success",
+			model_providers_package_result: "success",
+		},
+	},
+	{
+		name: "no package impact",
+		envPrefix: "NO_PACKAGE",
+		workflowResults: ["success", "skipped"],
+		outputs: emptyOutputs,
+	},
+	{
+		name: "protected-main verification",
+		envPrefix: "PROTECTED_MAIN",
+		workflowResults: ["success"],
+		outputs: {
+			...emptyOutputs,
+			api_package_result: "success",
+			packaged_factories_package_result: "success",
+			model_providers_package_result: "success",
+		},
+	},
+	{
+		name: "selected package failure",
+		envPrefix: "SELECTED_FAILURE",
+		workflowResults: ["failure"],
+		outputs: {
+			...emptyOutputs,
+			api_package_result: "failure",
+			api_candidate_result: "success",
+		},
+	},
+];
+
+function environmentName(prefix, suffix) {
+	return `${prefix}_${suffix}`;
+}
+
+function environmentValue(environment, name) {
+	return String(environment[name] ?? "").trim();
+}
+
+export function observationFromEnvironment(environment, envPrefix) {
+	return {
+		workflowResult: environmentValue(
+			environment,
+			environmentName(envPrefix, "WORKFLOW_RESULT"),
+		),
+		outputs: Object.fromEntries(
+			outputNames.map((name) => [
+				name,
+				environmentValue(
+					environment,
+					environmentName(envPrefix, name.toUpperCase()),
+				),
+			]),
+		),
+	};
+}
+
+export function assertWorkflowBehaviorScenario(scenario, observation) {
+	assert.ok(
+		scenario.workflowResults.includes(observation.workflowResult),
+		`${scenario.name} returned ${observation.workflowResult || "missing"}; expected one of ${scenario.workflowResults.join(", ")}`,
+	);
+	for (const outputName of outputNames) {
+		assert.equal(
+			observation.outputs[outputName] ?? "",
+			scenario.outputs[outputName] ?? "",
+			`${scenario.name} output ${outputName}`,
+		);
+	}
+}
+
+export function assertWorkflowBehaviorEnvironment(environment = process.env) {
+	const includeFailure = environmentValue(environment, "INCLUDE_FAILURE") === "true";
+	for (const scenario of workflowBehaviorScenarios) {
+		if (scenario.name === "selected package failure" && !includeFailure) {
+			assertWorkflowBehaviorScenario(
+				{ ...scenario, workflowResults: ["skipped"], outputs: emptyOutputs },
+				{ workflowResult: "skipped", outputs: emptyOutputs },
+			);
+			continue;
+		}
+		assertWorkflowBehaviorScenario(
+			scenario,
+			observationFromEnvironment(environment, scenario.envPrefix),
+		);
+	}
+}
+
+if (
+	process.argv[1] &&
+	resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))
+) {
+	assertWorkflowBehaviorEnvironment();
+	console.log("Development Package workflow behavior passed.");
+}

--- a/scripts/development-package-workflow.test.mjs
+++ b/scripts/development-package-workflow.test.mjs
@@ -165,6 +165,10 @@ test("candidate work is disabled for protected-main CI while direct publication 
 test("main CI passes classifier decisions and package failures to Verification Policy", () => {
 	const caller = ci.jobs["development-package"];
 	assert.equal(caller.uses, "./.github/workflows/development-package.yml");
+	assert.deepEqual(caller.permissions, {
+		contents: "read",
+		"id-token": "write",
+	});
 	assert.match(
 		caller.with.run_api_package,
 		/needs\.classify\.outputs\.run_api_package != 'false'/,

--- a/scripts/development-package-workflow.test.mjs
+++ b/scripts/development-package-workflow.test.mjs
@@ -186,9 +186,11 @@ test("main CI passes classifier decisions and package failures to Verification P
 	const policy = ci.jobs["verification-policy"];
 	assert.ok(policy.needs.includes("development-package"));
 	assert.equal(policy.if, "always()");
-	assert.match(policy.steps[0].run, /verification-policy\.mjs/);
-	assert.match(policy.steps[0].env.CLASSIFICATION_RESULT, /needs\.classify\.result/);
-	assert.match(policy.steps[0].env.CLASSIFICATION_REASON, /needs\.classify\.outputs\.reason/);
+	assert.equal(policy.steps[0].uses, "actions/checkout@v4");
+	assert.match(policy.steps[0].with.ref, /github\.event\.pull_request\.head\.sha/);
+	assert.match(policy.steps[1].run, /verification-policy\.mjs/);
+	assert.match(policy.steps[1].env.CLASSIFICATION_RESULT, /needs\.classify\.result/);
+	assert.match(policy.steps[1].env.CLASSIFICATION_REASON, /needs\.classify\.outputs\.reason/);
 	for (const name of [
 		"docs_reference_reason",
 		"readme_reason",
@@ -202,10 +204,10 @@ test("main CI passes classifier decisions and package failures to Verification P
 	]) {
 		assert.match(ci.jobs.classify.outputs[name], /steps\.classify\.outputs\.reason/);
 	}
-	assert.match(policy.steps[0].env.PACKAGE_WORKFLOW_RESULT, /needs\.development-package\.result/);
-	assert.match(policy.steps[0].env.API_CANDIDATE_RESULT, /needs\.development-package\.outputs\.api_candidate_result/);
-	assert.match(policy.steps[0].env.PACKAGED_CANDIDATE_RESULT, /needs\.development-package\.outputs\.packaged_factories_candidate_result/);
-	assert.match(policy.steps[0].env.INFERENCE_RESULT, /needs\.local-inference\.result/);
+	assert.match(policy.steps[1].env.PACKAGE_WORKFLOW_RESULT, /needs\.development-package\.result/);
+	assert.match(policy.steps[1].env.API_CANDIDATE_RESULT, /needs\.development-package\.outputs\.api_candidate_result/);
+	assert.match(policy.steps[1].env.PACKAGED_CANDIDATE_RESULT, /needs\.development-package\.outputs\.packaged_factories_candidate_result/);
+	assert.match(policy.steps[1].env.INFERENCE_RESULT, /needs\.local-inference\.result/);
 	assert.equal(
 		workflow.on.workflow_call.outputs.api_package_result.value,
 		"${{ jobs.verify_api_package.outputs.result }}",

--- a/scripts/development-package-workflow.test.mjs
+++ b/scripts/development-package-workflow.test.mjs
@@ -1,219 +1,62 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { createRequire } from "node:module";
-import { dirname, join, resolve } from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
 
-const require = createRequire(import.meta.url);
-const { parse } = require("../ui/node_modules/yaml");
-const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+import {
+	assertWorkflowBehaviorEnvironment,
+	workflowBehaviorScenarios,
+} from "./development-package-workflow-behavior.mjs";
 
-function readWorkflow(relativePath) {
-	return parse(readFileSync(join(repositoryRoot, relativePath), "utf8"));
+function environmentForScenario(scenario, workflowResult) {
+	return {
+		[`${scenario.envPrefix}_WORKFLOW_RESULT`]:
+			workflowResult ?? scenario.workflowResults[0],
+		...Object.fromEntries(
+			Object.entries(scenario.outputs).map(([name, result]) => [
+				`${scenario.envPrefix}_${name.toUpperCase()}`,
+				result,
+			]),
+		),
+	};
 }
 
-function selectedPackageJobs({
-	isCiCall,
-	runCandidates,
-	runApiPackage,
-	runPackagedFactoriesPackage,
-	runModelProvidersPackage,
-}) {
-	if (!isCiCall) return [];
-	const jobs = [];
-	if (runApiPackage) jobs.push("verify_api_package");
-	if (runPackagedFactoriesPackage) {
-		jobs.push("verify_packaged_factories_package");
-	}
-	if (runModelProvidersPackage) jobs.push("verify_model_providers_package");
-	if (runCandidates && runApiPackage) jobs.push("build_api_candidate");
-	if (runCandidates && runPackagedFactoriesPackage) {
-		jobs.push("build_packaged_factories_candidate");
-	}
-	return jobs;
+function environmentForAllScenarios(includeFailure) {
+	return Object.assign(
+		{ INCLUDE_FAILURE: String(includeFailure) },
+		...workflowBehaviorScenarios.map((scenario) => {
+			if (scenario.name === "selected package failure" && !includeFailure) {
+				return {
+					[`${scenario.envPrefix}_WORKFLOW_RESULT`]: "skipped",
+					...Object.fromEntries(
+						Object.keys(scenario.outputs).map((name) => [
+							`${scenario.envPrefix}_${name.toUpperCase()}`,
+							"",
+						]),
+					),
+				};
+			}
+			return environmentForScenario(scenario);
+		}),
+	);
 }
 
-const workflow = readWorkflow(".github/workflows/development-package.yml");
-const ci = readWorkflow(".github/workflows/ci.yml");
-
-test("Development Package exposes the classifier decision as a reusable contract", () => {
-	const inputs = workflow.on.workflow_call.inputs;
-	for (const name of [
-		"is_ci_call",
-		"run_candidates",
-		"run_api_package",
-		"run_packaged_factories_package",
-		"run_model_providers_package",
-		"source_commit",
-		"pull_request_head_sha",
-		"source_ref",
-		"repository",
-	]) {
-		assert.equal(inputs[name].required, true, `${name} must be required`);
-	}
-	for (const name of [
-		"is_ci_call",
-		"run_candidates",
-		"run_api_package",
-		"run_packaged_factories_package",
-		"run_model_providers_package",
-	]) {
-		assert.equal(inputs[name].type, "boolean", `${name} must be boolean`);
-	}
-	for (const name of [
-		"source_commit",
-		"pull_request_head_sha",
-		"source_ref",
-		"repository",
-	]) {
-		assert.equal(inputs[name].type, "string", `${name} must be string`);
-	}
-	for (const [job, lane] of [
-		["verify_api_package", "run_api_package"],
-		["verify_packaged_factories_package", "run_packaged_factories_package"],
-		["verify_model_providers_package", "run_model_providers_package"],
-	]) {
-		assert.match(workflow.jobs[job].if, /inputs\.is_ci_call/);
-		assert.match(workflow.jobs[job].if, new RegExp(`inputs\\.${lane}`));
-	}
-	for (const [job, lane] of [
-		["build_api_candidate", "run_api_package"],
-		["build_packaged_factories_candidate", "run_packaged_factories_package"],
-	]) {
-		assert.match(workflow.jobs[job].if, /inputs\.run_candidates/);
-		assert.match(workflow.jobs[job].if, new RegExp(`inputs\\.${lane}`));
-	}
+test("the hosted assertion harness covers API-only, mixed, no-package, and protected-main behavior", () => {
+	assertWorkflowBehaviorEnvironment(environmentForAllScenarios(false));
 });
 
-test("package-only, mixed-package, and no-package decisions select exact reusable jobs", () => {
-	const cases = [
-		{
-			name: "API package only",
-			input: {
-				isCiCall: true,
-				runCandidates: true,
-				runApiPackage: true,
-				runPackagedFactoriesPackage: false,
-				runModelProvidersPackage: false,
-			},
-			jobs: ["verify_api_package", "build_api_candidate"],
-		},
-		{
-			name: "mixed package families",
-			input: {
-				isCiCall: true,
-				runCandidates: true,
-				runApiPackage: true,
-				runPackagedFactoriesPackage: true,
-				runModelProvidersPackage: true,
-			},
-			jobs: [
-				"verify_api_package",
-				"verify_packaged_factories_package",
-				"verify_model_providers_package",
-				"build_api_candidate",
-				"build_packaged_factories_candidate",
-			],
-		},
-		{
-			name: "no package impact",
-			input: {
-				isCiCall: true,
-				runCandidates: true,
-				runApiPackage: false,
-				runPackagedFactoriesPackage: false,
-				runModelProvidersPackage: false,
-			},
-			jobs: [],
-		},
-	];
-
-	for (const { name, input, jobs } of cases) {
-		assert.deepEqual(selectedPackageJobs(input), jobs, name);
-	}
+test("the hosted assertion harness accepts selected package failure propagation", () => {
+	assertWorkflowBehaviorEnvironment(environmentForAllScenarios(true));
 });
 
-test("candidate work is disabled for protected-main CI while direct publication remains", () => {
-	const selected = selectedPackageJobs({
-		isCiCall: true,
-		runCandidates: false,
-		runApiPackage: true,
-		runPackagedFactoriesPackage: true,
-		runModelProvidersPackage: true,
-	});
-	assert.deepEqual(selected, [
-		"verify_api_package",
-		"verify_packaged_factories_package",
-		"verify_model_providers_package",
+test("scenario fixtures expose every reusable workflow output", () => {
+	const names = new Set(
+		workflowBehaviorScenarios.flatMap((scenario) => Object.keys(scenario.outputs)),
+	);
+
+	assert.deepEqual([...names].sort(), [
+		"api_candidate_result",
+		"api_package_result",
+		"model_providers_package_result",
+		"packaged_factories_candidate_result",
+		"packaged_factories_package_result",
 	]);
-	assert.match(
-		workflow.jobs["prepare-main-candidate"].if,
-		/inputs\.is_ci_call != true/,
-	);
-	assert.match(
-		workflow.jobs["publish-main-candidate"].if,
-		/inputs\.is_ci_call != true/,
-	);
-	assert.match(workflow.concurrency.group, /inputs\.is_ci_call == true/);
-	assert.match(
-		workflow.concurrency["cancel-in-progress"],
-		/inputs\.is_ci_call != true/,
-	);
-});
-
-test("main CI passes classifier decisions and package failures to Verification Policy", () => {
-	const caller = ci.jobs["development-package"];
-	assert.equal(caller.uses, "./.github/workflows/development-package.yml");
-	assert.deepEqual(caller.permissions, {
-		contents: "write",
-		"id-token": "write",
-	});
-	assert.match(
-		caller.with.run_api_package,
-		/needs\.classify\.outputs\.run_api_package != 'false'/,
-	);
-	assert.match(
-		caller.with.run_packaged_factories_package,
-		/needs\.classify\.outputs\.run_packaged_factories_package != 'false'/,
-	);
-	assert.match(
-		caller.with.run_model_providers_package,
-		/needs\.classify\.outputs\.run_model_providers_package != 'false'/,
-	);
-	assert.equal(caller.with.source_commit, "${{ github.event.pull_request.head.sha || github.sha }}");
-
-	const policy = ci.jobs["verification-policy"];
-	assert.ok(policy.needs.includes("development-package"));
-	assert.equal(policy.if, "always()");
-	assert.equal(policy.steps[0].uses, "actions/checkout@v4");
-	assert.match(policy.steps[0].with.ref, /github\.event\.pull_request\.head\.sha/);
-	assert.match(policy.steps[1].run, /verification-policy\.mjs/);
-	assert.match(policy.steps[1].env.CLASSIFICATION_RESULT, /needs\.classify\.result/);
-	assert.match(policy.steps[1].env.CLASSIFICATION_REASON, /needs\.classify\.outputs\.reason/);
-	for (const name of [
-		"docs_reference_reason",
-		"readme_reason",
-		"frontend_reason",
-		"backend_reason",
-		"ui_backend_integration_reason",
-		"api_package_reason",
-		"packaged_factories_package_reason",
-		"model_providers_package_reason",
-		"local_inference_reason",
-	]) {
-		assert.match(ci.jobs.classify.outputs[name], /steps\.classify\.outputs\.reason/);
-	}
-	assert.match(policy.steps[1].env.PACKAGE_WORKFLOW_RESULT, /needs\.development-package\.result/);
-	assert.match(policy.steps[1].env.API_CANDIDATE_RESULT, /needs\.development-package\.outputs\.api_candidate_result/);
-	assert.match(policy.steps[1].env.PACKAGED_CANDIDATE_RESULT, /needs\.development-package\.outputs\.packaged_factories_candidate_result/);
-	assert.match(policy.steps[1].env.INFERENCE_RESULT, /needs\.local-inference\.result/);
-	assert.equal(
-		workflow.on.workflow_call.outputs.api_package_result.value,
-		"${{ jobs.verify_api_package.outputs.result }}",
-	);
-	assert.equal(
-		workflow.on.workflow_call.outputs.api_candidate_result.value,
-		"${{ jobs.build_api_candidate.outputs.result }}",
-	);
 });

--- a/scripts/development-package-workflow.test.mjs
+++ b/scripts/development-package-workflow.test.mjs
@@ -166,7 +166,7 @@ test("main CI passes classifier decisions and package failures to Verification P
 	const caller = ci.jobs["development-package"];
 	assert.equal(caller.uses, "./.github/workflows/development-package.yml");
 	assert.deepEqual(caller.permissions, {
-		contents: "read",
+		contents: "write",
 		"id-token": "write",
 	});
 	assert.match(

--- a/scripts/development-package-workflow.test.mjs
+++ b/scripts/development-package-workflow.test.mjs
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const { parse } = require("../ui/node_modules/yaml");
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function readWorkflow(relativePath) {
+	return parse(readFileSync(join(repositoryRoot, relativePath), "utf8"));
+}
+
+function selectedPackageJobs({
+	isCiCall,
+	runCandidates,
+	runApiPackage,
+	runPackagedFactoriesPackage,
+	runModelProvidersPackage,
+}) {
+	if (!isCiCall) return [];
+	const jobs = [];
+	if (runApiPackage) jobs.push("verify_api_package");
+	if (runPackagedFactoriesPackage) {
+		jobs.push("verify_packaged_factories_package");
+	}
+	if (runModelProvidersPackage) jobs.push("verify_model_providers_package");
+	if (runCandidates && runApiPackage) jobs.push("build_api_candidate");
+	if (runCandidates && runPackagedFactoriesPackage) {
+		jobs.push("build_packaged_factories_candidate");
+	}
+	return jobs;
+}
+
+const workflow = readWorkflow(".github/workflows/development-package.yml");
+const ci = readWorkflow(".github/workflows/ci.yml");
+
+test("Development Package exposes the classifier decision as a reusable contract", () => {
+	const inputs = workflow.on.workflow_call.inputs;
+	for (const name of [
+		"is_ci_call",
+		"run_candidates",
+		"run_api_package",
+		"run_packaged_factories_package",
+		"run_model_providers_package",
+		"source_commit",
+		"pull_request_head_sha",
+		"source_ref",
+		"repository",
+	]) {
+		assert.equal(inputs[name].required, true, `${name} must be required`);
+	}
+	for (const name of [
+		"is_ci_call",
+		"run_candidates",
+		"run_api_package",
+		"run_packaged_factories_package",
+		"run_model_providers_package",
+	]) {
+		assert.equal(inputs[name].type, "boolean", `${name} must be boolean`);
+	}
+	for (const name of [
+		"source_commit",
+		"pull_request_head_sha",
+		"source_ref",
+		"repository",
+	]) {
+		assert.equal(inputs[name].type, "string", `${name} must be string`);
+	}
+	for (const [job, lane] of [
+		["verify_api_package", "run_api_package"],
+		["verify_packaged_factories_package", "run_packaged_factories_package"],
+		["verify_model_providers_package", "run_model_providers_package"],
+	]) {
+		assert.match(workflow.jobs[job].if, /inputs\.is_ci_call/);
+		assert.match(workflow.jobs[job].if, new RegExp(`inputs\\.${lane}`));
+	}
+	for (const [job, lane] of [
+		["build_api_candidate", "run_api_package"],
+		["build_packaged_factories_candidate", "run_packaged_factories_package"],
+	]) {
+		assert.match(workflow.jobs[job].if, /inputs\.run_candidates/);
+		assert.match(workflow.jobs[job].if, new RegExp(`inputs\\.${lane}`));
+	}
+});
+
+test("package-only, mixed-package, and no-package decisions select exact reusable jobs", () => {
+	const cases = [
+		{
+			name: "API package only",
+			input: {
+				isCiCall: true,
+				runCandidates: true,
+				runApiPackage: true,
+				runPackagedFactoriesPackage: false,
+				runModelProvidersPackage: false,
+			},
+			jobs: ["verify_api_package", "build_api_candidate"],
+		},
+		{
+			name: "mixed package families",
+			input: {
+				isCiCall: true,
+				runCandidates: true,
+				runApiPackage: true,
+				runPackagedFactoriesPackage: true,
+				runModelProvidersPackage: true,
+			},
+			jobs: [
+				"verify_api_package",
+				"verify_packaged_factories_package",
+				"verify_model_providers_package",
+				"build_api_candidate",
+				"build_packaged_factories_candidate",
+			],
+		},
+		{
+			name: "no package impact",
+			input: {
+				isCiCall: true,
+				runCandidates: true,
+				runApiPackage: false,
+				runPackagedFactoriesPackage: false,
+				runModelProvidersPackage: false,
+			},
+			jobs: [],
+		},
+	];
+
+	for (const { name, input, jobs } of cases) {
+		assert.deepEqual(selectedPackageJobs(input), jobs, name);
+	}
+});
+
+test("candidate work is disabled for protected-main CI while direct publication remains", () => {
+	const selected = selectedPackageJobs({
+		isCiCall: true,
+		runCandidates: false,
+		runApiPackage: true,
+		runPackagedFactoriesPackage: true,
+		runModelProvidersPackage: true,
+	});
+	assert.deepEqual(selected, [
+		"verify_api_package",
+		"verify_packaged_factories_package",
+		"verify_model_providers_package",
+	]);
+	assert.match(
+		workflow.jobs["prepare-main-candidate"].if,
+		/inputs\.is_ci_call != true/,
+	);
+	assert.match(
+		workflow.jobs["publish-main-candidate"].if,
+		/inputs\.is_ci_call != true/,
+	);
+	assert.match(workflow.concurrency.group, /inputs\.is_ci_call == true/);
+	assert.match(
+		workflow.concurrency["cancel-in-progress"],
+		/inputs\.is_ci_call != true/,
+	);
+});
+
+test("main CI passes classifier decisions and package failures to Verification Policy", () => {
+	const caller = ci.jobs["development-package"];
+	assert.equal(caller.uses, "./.github/workflows/development-package.yml");
+	assert.match(
+		caller.with.run_api_package,
+		/needs\.classify\.outputs\.run_api_package != 'false'/,
+	);
+	assert.match(
+		caller.with.run_packaged_factories_package,
+		/needs\.classify\.outputs\.run_packaged_factories_package != 'false'/,
+	);
+	assert.match(
+		caller.with.run_model_providers_package,
+		/needs\.classify\.outputs\.run_model_providers_package != 'false'/,
+	);
+	assert.equal(caller.with.source_commit, "${{ github.event.pull_request.head.sha || github.sha }}");
+
+	const policy = ci.jobs["verification-policy"];
+	assert.ok(policy.needs.includes("development-package"));
+	assert.match(
+		policy.steps[0].env.RESULTS,
+		/package_workflow=\$\{\{ needs\.development-package\.result \}\}/,
+	);
+	assert.match(
+		policy.steps[0].env.RESULTS,
+		/api_candidate=\$\{\{ needs\.development-package\.outputs\.api_candidate_result \}\}/,
+	);
+	assert.equal(
+		workflow.on.workflow_call.outputs.api_package_result.value,
+		"${{ jobs.verify_api_package.outputs.result }}",
+	);
+	assert.equal(
+		workflow.on.workflow_call.outputs.api_candidate_result.value,
+		"${{ jobs.build_api_candidate.outputs.result }}",
+	);
+});

--- a/scripts/development-package-workflow.test.mjs
+++ b/scripts/development-package-workflow.test.mjs
@@ -181,14 +181,27 @@ test("main CI passes classifier decisions and package failures to Verification P
 
 	const policy = ci.jobs["verification-policy"];
 	assert.ok(policy.needs.includes("development-package"));
-	assert.match(
-		policy.steps[0].env.RESULTS,
-		/package_workflow=\$\{\{ needs\.development-package\.result \}\}/,
-	);
-	assert.match(
-		policy.steps[0].env.RESULTS,
-		/api_candidate=\$\{\{ needs\.development-package\.outputs\.api_candidate_result \}\}/,
-	);
+	assert.equal(policy.if, "always()");
+	assert.match(policy.steps[0].run, /verification-policy\.mjs/);
+	assert.match(policy.steps[0].env.CLASSIFICATION_RESULT, /needs\.classify\.result/);
+	assert.match(policy.steps[0].env.CLASSIFICATION_REASON, /needs\.classify\.outputs\.reason/);
+	for (const name of [
+		"docs_reference_reason",
+		"readme_reason",
+		"frontend_reason",
+		"backend_reason",
+		"ui_backend_integration_reason",
+		"api_package_reason",
+		"packaged_factories_package_reason",
+		"model_providers_package_reason",
+		"local_inference_reason",
+	]) {
+		assert.match(ci.jobs.classify.outputs[name], /steps\.classify\.outputs\.reason/);
+	}
+	assert.match(policy.steps[0].env.PACKAGE_WORKFLOW_RESULT, /needs\.development-package\.result/);
+	assert.match(policy.steps[0].env.API_CANDIDATE_RESULT, /needs\.development-package\.outputs\.api_candidate_result/);
+	assert.match(policy.steps[0].env.PACKAGED_CANDIDATE_RESULT, /needs\.development-package\.outputs\.packaged_factories_candidate_result/);
+	assert.match(policy.steps[0].env.INFERENCE_RESULT, /needs\.local-inference\.result/);
 	assert.equal(
 		workflow.on.workflow_call.outputs.api_package_result.value,
 		"${{ jobs.verify_api_package.outputs.result }}",

--- a/scripts/verification-policy.mjs
+++ b/scripts/verification-policy.mjs
@@ -245,7 +245,7 @@ function policyInputFromEnvironment() {
 				"PACKAGED_RESULT",
 				"PACKAGED_CANDIDATE_RESULT",
 			),
-				directLane(
+			directLane(
 				"Model Providers Package",
 				"RUN_PROVIDERS",
 				"PROVIDERS_REASON",

--- a/scripts/verification-policy.mjs
+++ b/scripts/verification-policy.mjs
@@ -1,0 +1,278 @@
+import { appendFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+const SUCCESS = "success";
+const SKIPPED = "skipped";
+const MISSING = "missing";
+
+function textValue(value) {
+	return String(value ?? "").trim();
+}
+
+function normalizedResult(value) {
+	const result = textValue(value).toLowerCase();
+	return result || MISSING;
+}
+
+function selected(value) {
+	return textValue(value) !== "false";
+}
+
+function displayValue(value, fallback = MISSING) {
+	const result = textValue(value);
+	return result || fallback;
+}
+
+function formatReason(reason, fallbackReason) {
+	return (
+		textValue(reason) ||
+		textValue(fallbackReason) ||
+		"No classifier reason was returned; inspect the classification job."
+	);
+}
+
+function formatMarkdownCell(value) {
+	return displayValue(value, "(none)")
+		.replaceAll("|", "\\|")
+		.replaceAll("\r", "")
+		.replaceAll("\n", " ");
+}
+
+function checkLabel(lane, check) {
+	return lane.checks.length === 1 ? lane.name : `${lane.name} / ${check.name}`;
+}
+
+function displayCheckResult(lane, check) {
+	const result = normalizedResult(check.result);
+	const required = check.required ?? selected(lane.selected);
+	if (result === MISSING && !required && check.allowMissingWhenNotRequired) {
+		return SKIPPED;
+	}
+	return result;
+}
+
+function evaluateLane(lane, failures) {
+	const shouldRun = selected(lane.selected);
+	for (const check of lane.checks) {
+		const result = normalizedResult(check.result);
+		const required = check.required ?? shouldRun;
+		if (required) {
+			if (result !== SUCCESS) {
+				failures.push(`${checkLabel(lane, check)} was selected but finished with ${result}.`);
+			}
+			continue;
+		}
+		if (result === SKIPPED) {
+			continue;
+		}
+		if (result === MISSING && check.allowMissingWhenNotRequired) {
+			continue;
+		}
+		failures.push(
+			`${checkLabel(lane, check)} was not selected but returned ${result}; expected skipped.`,
+		);
+	}
+}
+
+export function evaluateVerificationPolicy({
+	classificationResult,
+	classification,
+	packageWorkflowResult,
+	lanes,
+}) {
+	const failures = [];
+	const normalizedClassificationResult = normalizedResult(classificationResult);
+	if (normalizedClassificationResult !== SUCCESS) {
+		failures.push(
+			`Classification did not complete successfully (result: ${normalizedClassificationResult}).`,
+		);
+	}
+	if (!textValue(classification)) {
+		failures.push("Classification output is missing.");
+	}
+
+	const packageResult = normalizedResult(packageWorkflowResult);
+	const packageSelected = lanes.some(
+		(lane) => lane.packageLane && selected(lane.selected),
+	);
+	if (packageSelected && packageResult !== SUCCESS) {
+		failures.push(
+			`Development Package was needed but finished with ${packageResult}.`,
+		);
+	} else if (!packageSelected && ![SUCCESS, SKIPPED].includes(packageResult)) {
+		failures.push(
+			`Development Package was not needed but returned ${packageResult}; expected success or skipped.`,
+		);
+	}
+
+	for (const lane of lanes) {
+		evaluateLane(lane, failures);
+	}
+
+	return {
+		ok: failures.length === 0,
+		failures,
+	};
+}
+
+export function renderVerificationSummary({
+	classificationResult,
+	classification,
+	classificationReason,
+	areas,
+	packageWorkflowResult,
+	lanes,
+	evaluation,
+}) {
+	const lines = [
+		"## Verification policy",
+		"",
+		`- Classification: \`${formatMarkdownCell(classification)}\``,
+		`- Areas touched: \`${formatMarkdownCell(areas, "(none reported)")}\``,
+		`- Classification job: \`${formatMarkdownCell(normalizedResult(classificationResult))}\``,
+		`- Development Package workflow: \`${formatMarkdownCell(normalizedResult(packageWorkflowResult))}\``,
+		"",
+		"### Lane decisions",
+		"",
+		"| Lane | Decision | Terminal result | Classifier reason |",
+		"| --- | --- | --- | --- |",
+	];
+	for (const lane of lanes) {
+		const decision = selected(lane.selected) ? "run" : "skip";
+		const results = lane.checks
+			.map((check) => `${check.name}: ${displayCheckResult(lane, check)}`)
+			.join("; ");
+		lines.push(
+			`| ${formatMarkdownCell(lane.name)} | \`${decision}\` | ${formatMarkdownCell(results)} | ${formatMarkdownCell(formatReason(lane.reason, classificationReason))} |`,
+		);
+	}
+	lines.push("", `### Policy result`, "");
+	if (evaluation.ok) {
+		lines.push("Verification Policy passed: classification completed safely and every selected lane succeeded.");
+	} else {
+		lines.push("Verification Policy failed:", "");
+		for (const failure of evaluation.failures) {
+			lines.push(`- ${failure}`);
+		}
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+function env(name) {
+	return process.env[name] ?? "";
+}
+
+function directLane(name, selectedEnv, reasonEnv, resultEnv) {
+	return {
+		name,
+		selected: env(selectedEnv),
+		reason: env(reasonEnv),
+		checks: [{ name, result: env(resultEnv) }],
+	};
+}
+
+function packageLane(name, selectedEnv, reasonEnv, resultEnv, candidateResultEnv) {
+	const laneSelected = selected(env(selectedEnv));
+	const candidatesSelected = selected(env("RUN_CANDIDATES"));
+	return {
+		name,
+		selected: env(selectedEnv),
+		reason: env(reasonEnv),
+		packageLane: true,
+		checks: [
+			{
+				name: "verification",
+				result: env(resultEnv),
+				allowMissingWhenNotRequired: true,
+			},
+			{
+				name: "candidate",
+				result: env(candidateResultEnv),
+				required: laneSelected && candidatesSelected,
+				allowMissingWhenNotRequired: true,
+			},
+		],
+	};
+}
+
+function policyInputFromEnvironment() {
+	return {
+		classificationResult: env("CLASSIFICATION_RESULT"),
+		classification: env("CLASSIFICATION"),
+		classificationReason: env("CLASSIFICATION_REASON"),
+		areas: env("AREAS"),
+		packageWorkflowResult: env("PACKAGE_WORKFLOW_RESULT"),
+		lanes: [
+			directLane("Docs Reference", "RUN_DOCS", "DOCS_REASON", "DOCS_RESULT"),
+			directLane("README", "RUN_README", "README_REASON", "README_RESULT"),
+			{
+				name: "Frontend",
+				selected: env("RUN_FRONTEND"),
+				reason: env("FRONTEND_REASON"),
+				checks: [
+					{ name: "Frontend", result: env("FRONTEND_RESULT") },
+					{ name: "Frontend Component", result: env("FRONTEND_COMPONENT_RESULT") },
+					{ name: "Frontend Coverage", result: env("FRONTEND_COVERAGE_RESULT") },
+					{ name: "Frontend Browser", result: env("FRONTEND_BROWSER_RESULT") },
+					{ name: "Frontend Storybook", result: env("FRONTEND_STORYBOOK_RESULT") },
+				],
+			},
+			directLane("Backend", "RUN_BACKEND", "BACKEND_REASON", "BACKEND_RESULT"),
+			directLane(
+				"UI Backend Integration",
+				"RUN_UI_BACKEND",
+				"UI_BACKEND_REASON",
+				"UI_BACKEND_RESULT",
+			),
+			packageLane(
+				"API Package",
+				"RUN_API",
+				"API_REASON",
+				"API_RESULT",
+				"API_CANDIDATE_RESULT",
+			),
+			packageLane(
+				"Packaged Factories Package",
+				"RUN_PACKAGED",
+				"PACKAGED_REASON",
+				"PACKAGED_RESULT",
+				"PACKAGED_CANDIDATE_RESULT",
+			),
+			directLane(
+				"Model Providers Package",
+				"RUN_PROVIDERS",
+				"PROVIDERS_REASON",
+				"PROVIDERS_RESULT",
+			),
+			directLane(
+				"Local Inference",
+				"RUN_INFERENCE",
+				"INFERENCE_REASON",
+				"INFERENCE_RESULT",
+			),
+		],
+	};
+}
+
+export function runVerificationPolicy(input, summaryPath = process.env.GITHUB_STEP_SUMMARY) {
+	const evaluation = evaluateVerificationPolicy(input);
+	const summary = renderVerificationSummary({ ...input, evaluation });
+	if (summaryPath) {
+		appendFileSync(summaryPath, summary);
+	}
+	if (!evaluation.ok) {
+		console.error("Verification Policy failed:");
+		for (const failure of evaluation.failures) {
+			console.error(`- ${failure}`);
+		}
+	}
+	return evaluation;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+	const evaluation = runVerificationPolicy(policyInputFromEnvironment());
+	if (!evaluation.ok) {
+		process.exitCode = 1;
+	}
+}

--- a/scripts/verification-policy.mjs
+++ b/scripts/verification-policy.mjs
@@ -163,12 +163,18 @@ function env(name) {
 	return process.env[name] ?? "";
 }
 
-function directLane(name, selectedEnv, reasonEnv, resultEnv) {
+function directLane(
+	name,
+	selectedEnv,
+	reasonEnv,
+	resultEnv,
+	allowMissingWhenNotRequired = false,
+) {
 	return {
 		name,
 		selected: env(selectedEnv),
 		reason: env(reasonEnv),
-		checks: [{ name, result: env(resultEnv) }],
+		checks: [{ name, result: env(resultEnv), allowMissingWhenNotRequired }],
 	};
 }
 
@@ -239,11 +245,12 @@ function policyInputFromEnvironment() {
 				"PACKAGED_RESULT",
 				"PACKAGED_CANDIDATE_RESULT",
 			),
-			directLane(
+				directLane(
 				"Model Providers Package",
 				"RUN_PROVIDERS",
 				"PROVIDERS_REASON",
 				"PROVIDERS_RESULT",
+				true,
 			),
 			directLane(
 				"Local Inference",

--- a/scripts/verification-policy.test.mjs
+++ b/scripts/verification-policy.test.mjs
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	evaluateVerificationPolicy,
+	renderVerificationSummary,
+} from "./verification-policy.mjs";
+
+const laneNames = [
+	"Docs Reference",
+	"README",
+	"Frontend",
+	"Backend",
+	"UI Backend Integration",
+	"API Package",
+	"Packaged Factories Package",
+	"Model Providers Package",
+	"Local Inference",
+];
+
+function lane(name, selected = false, result = selected ? "success" : "skipped", options = {}) {
+	return {
+		name,
+		selected: String(selected),
+		reason: options.reason ?? (selected ? "Selected by the classifier." : "Not selected."),
+		packageLane: options.packageLane ?? false,
+		checks: options.checks ?? [{ name, result }],
+	};
+}
+
+function policy(overrides = {}) {
+	return {
+		classificationResult: "success",
+		classification: "documentation-reference",
+		classificationReason: "Selected the union of verification lanes owned by the changed paths.",
+		areas: "documentation-reference",
+		packageWorkflowResult: "success",
+		lanes: laneNames.map((name) => lane(name)),
+		...overrides,
+	};
+}
+
+test("minimal selected verification passes and unselected lanes may be skipped", () => {
+	const result = evaluateVerificationPolicy(
+		policy({
+			lanes: [
+				lane("Docs Reference", true, "success", {
+					reason: "Documentation reference paths select this lane.",
+				}),
+				...laneNames.slice(1).map((name) => lane(name)),
+			],
+		}),
+	);
+
+	assert.deepEqual(result, { ok: true, failures: [] });
+});
+
+test("a selected lane that is skipped, missing, or failed fails closed", () => {
+	for (const result of ["skipped", "", "failure"]) {
+		const evaluation = evaluateVerificationPolicy(
+			policy({
+				lanes: [
+					lane("Docs Reference", true, result),
+					...laneNames.slice(1).map((name) => lane(name)),
+				],
+			}),
+		);
+
+		assert.equal(evaluation.ok, false, `result ${result || "missing"} must fail`);
+		assert.match(evaluation.failures[0], /Docs Reference was selected/);
+	}
+});
+
+test("classifier failure fails policy even when every product lane succeeds", () => {
+	const evaluation = evaluateVerificationPolicy(
+		policy({ classificationResult: "failure" }),
+	);
+
+	assert.equal(evaluation.ok, false);
+	assert.match(evaluation.failures[0], /Classification did not complete successfully/);
+});
+
+test("reusable package failure and missing selected candidate fail policy", () => {
+	const evaluation = evaluateVerificationPolicy(
+		policy({
+			packageWorkflowResult: "failure",
+			lanes: [
+				...laneNames.slice(0, 5).map((name) => lane(name)),
+				lane("API Package", true, "success", {
+					packageLane: true,
+					checks: [
+						{ name: "verification", result: "success", allowMissingWhenNotRequired: true },
+						{
+							name: "candidate",
+							result: "",
+							required: true,
+							allowMissingWhenNotRequired: true,
+						},
+					],
+				}),
+				lane("Packaged Factories Package"),
+				lane("Model Providers Package"),
+				lane("Local Inference"),
+			],
+		}),
+	);
+
+	assert.equal(evaluation.ok, false);
+	assert.ok(evaluation.failures.some((failure) => /Development Package/.test(failure)));
+	assert.ok(evaluation.failures.some((failure) => /API Package \/ candidate/.test(failure)));
+});
+
+test("unselected package outputs may be absent, but an unexpected unselected result fails", () => {
+	const packageChecks = [
+		{
+			name: "verification",
+			result: "",
+			allowMissingWhenNotRequired: true,
+		},
+		{
+			name: "candidate",
+			result: "",
+			required: false,
+			allowMissingWhenNotRequired: true,
+		},
+	];
+	const passing = evaluateVerificationPolicy(
+		policy({
+			lanes: [
+				...laneNames.slice(0, 5).map((name) => lane(name)),
+				lane("API Package", false, "", {
+					packageLane: true,
+					checks: packageChecks,
+				}),
+				lane("Packaged Factories Package"),
+				lane("Model Providers Package"),
+				lane("Local Inference"),
+			],
+		}),
+	);
+	assert.equal(passing.ok, true);
+
+	const unexpected = evaluateVerificationPolicy(
+		policy({
+			lanes: [
+				lane("Docs Reference", false, "success"),
+				...laneNames.slice(1).map((name) => lane(name)),
+			],
+		}),
+	);
+	assert.equal(unexpected.ok, false);
+	assert.match(unexpected.failures[0], /not selected but returned success/);
+});
+
+test("summary records touched areas, each decision, reason, and terminal result", () => {
+	const input = policy({
+		areas: "documentation-reference+frontend",
+		lanes: [
+			lane("Docs Reference", true, "success", {
+				reason: "docs/reference paths select the documentation lane.",
+			}),
+			...laneNames.slice(1).map((name) => lane(name)),
+		],
+	});
+	const evaluation = evaluateVerificationPolicy(input);
+	const summary = renderVerificationSummary({ ...input, evaluation });
+
+	assert.match(summary, /Areas touched: `documentation-reference\+frontend`/);
+	assert.match(summary, /\| Docs Reference \| `run` \| Docs Reference: success \| docs\/reference paths select/);
+	assert.match(summary, /\| README \| `skip` \| README: skipped \|/);
+	assert.match(summary, /Verification Policy passed/);
+});
+
+test("summary falls back to the classifier's global reason for a selected lane", () => {
+	const input = policy({
+		classificationReason: "Unknown paths require conservative full verification.",
+		lanes: [
+			lane("Docs Reference", true, "success", { reason: "" }),
+			...laneNames.slice(1).map((name) => lane(name)),
+		],
+	});
+	const evaluation = evaluateVerificationPolicy(input);
+	const summary = renderVerificationSummary({ ...input, evaluation });
+
+	assert.match(summary, /\| Docs Reference \| `run` \| Docs Reference: success \| Unknown paths require/);
+});

--- a/scripts/verification-policy.test.mjs
+++ b/scripts/verification-policy.test.mjs
@@ -152,6 +152,31 @@ test("unselected package outputs may be absent, but an unexpected unselected res
 	assert.match(unexpected.failures[0], /not selected but returned success/);
 });
 
+test("an unselected package verification lane may omit its reusable-workflow output", () => {
+	const evaluation = evaluateVerificationPolicy(
+		policy({
+			classification: "factory-content",
+			areas: "factory-content",
+			packageWorkflowResult: "skipped",
+			lanes: [
+				...laneNames.slice(0, 7).map((name) => lane(name)),
+				lane("Model Providers Package", false, "", {
+					checks: [
+						{
+							name: "Model Providers Package",
+							result: "",
+							allowMissingWhenNotRequired: true,
+						},
+					],
+				}),
+				lane("Local Inference"),
+			],
+		}),
+	);
+
+	assert.deepEqual(evaluation, { ok: true, failures: [] });
+});
+
 test("summary records touched areas, each decision, reason, and terminal result", () => {
 	const input = policy({
 		areas: "documentation-reference+frontend",


### PR DESCRIPTION
{
  "project": "Classification-Aware CI Job Routing",
  "branchName": "ci-job-routing",
  "description": "Apply the upstream additive CI classifier outputs to GitHub Actions job-level routing so pull requests allocate runners only for selected verification lanes, convert Development Package into a reusable classification-aware workflow, add one stable fail-closed Verification Policy required check, document the policy, and prove docs-reference-only, factory-only, unknown-path, branch-protection, and post-rollout main behavior with live evidence.",
  "context": {
    "customerAsk": "Route CI jobs using the additive classifier outputs described in docs/internal/development/plans/ci-verification-classification.md; make Development Package verification reusable and classification-aware; add a stable required policy check; document the routing policy; demonstrate docs-reference-only, factory/**-only, and unknown-path behavior with linked real PR runs or workflow-dispatch evidence; reconfigure required checks; and leave CI green on main.",
    "problem": "CI starts verification jobs unrelated to many pull requests. Step-level skipping can still allocate hosted runners, Development Package cannot reliably share the main workflow's classification decision, and dynamic conditional job names do not provide one stable protected-branch gate. Contributors therefore wait and pay for irrelevant work while maintainers lack a reliable summary and required check for conditional verification.",
    "solution": "Use cmd/ciclassify outputs as the single canonical routing decision, apply them through job-level conditions, pass explicit package decisions into a reusable Development Package workflow, and aggregate all selected outcomes in an always-present fail-closed Verification Policy job. Require that stable policy check, document ownership-to-lane and rerun behavior, and validate the deployed result with isolated live scenarios and a successful main run."
  },
  "acceptanceCriteria": [
    "Pull-request workflows consume every additive classifier lane output at job level; a selected-false verification job is skipped before runner allocation, and mixed changes run exactly the union of their selected lanes.",
    "A docs/reference/**-only validation change runs only Docs Reference product verification, a factory/**-only validation change runs no product verification, and an unknown-path validation change runs every verification lane; the classifier and stable policy control-plane jobs remain present in all three cases.",
    "Development Package verification is reusable and classification-aware: an affected package runs its own verification and candidate dry run plus defined consumer lanes, unrelated package candidates do not run, and protected-main publication retains all required candidate artifacts and prerequisites.",
    "Verification Policy is always present, fails when classification fails or any selected lane is unsuccessful, accepts correctly skipped unselected lanes, summarizes touched areas and lane decisions with reasons, and is configured as the stable protected-branch required check.",
    "The canonical contributor policy documents ownership-to-lane routing, additive mixed-change behavior, conservative fallbacks, package behavior, local rerun commands, and the required-check model; the PR links live evidence for the three mandatory scenarios and a successful post-rollout main run.",
    "Quality gates pass: Typecheck passes; Tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are resolved against current main, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "ci-job-routing-001",
      "title": "Route main CI verification at job level",
      "description": "As a contributor, I want a pull request to start only the verification jobs selected for its changed ownership areas so I receive complete relevant feedback without paying the time and runner cost of unrelated lanes.",
      "acceptanceCriteria": [
        "Each additive classifier output selects its corresponding product-verification job or reusable workflow through a job-level condition, so a selected-false lane is reported as skipped without allocating a hosted runner.",
        "Documentation reference, root README, frontend, backend/CLI, focused UI-backend integration, API package, Packaged Factories package, Model Providers package, and local-inference outputs route to their defined verification lanes without reducing the depth of a selected lane.",
        "Mixed changes run exactly the additive union of matching lanes; factory/** is neutral when mixed with owned changes and selects no product-verification lane when it is the only changed area.",
        "CI/tooling changes, Makefile or Go toolchain changes, unknown paths, classifier failure, and missing or malformed classifier outputs fail closed by selecting full verification.",
        "Pushes to main retain the complete verification behavior required to establish an authoritative green baseline.",
        "Focused workflow tests or equivalent local workflow evaluation cover selected, unselected, union, neutral-path, and conservative-fallback outcomes without relying on source-file inventory assertions as the behavior proof.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented job-level routing for every additive verification lane, including the backend matrix and API package lane, and made missing or malformed lane outputs fail closed. Classifier matrix and conservative-fallback tests pass, along with focused Go vet, make typecheck, and make test."
    },
    {
      "id": "ci-job-routing-002",
      "title": "Route reusable Development Package verification",
      "description": "As a package maintainer, I want Development Package verification to consume the same classification decision as main CI so only affected package candidates and their defined consumers run while publication remains safe.",
      "acceptanceCriteria": [
        "Development Package exposes a reusable workflow contract with explicit classification inputs sufficient to select API, Packaged Factories, and Model Providers package verification and candidate work.",
        "Main pull-request CI invokes the reusable package workflow with classifier outputs rather than independently reclassifying the same change or unconditionally running every package candidate.",
        "A change to one package family runs that package's self-verification and candidate dry run plus only the consumer lanes defined by the classification contract; unrelated package candidate jobs are skipped before runner allocation.",
        "Mixed package changes run the union of affected package work, while a change with no package impact starts no package candidate runner.",
        "Protected-main publication continues to receive every candidate artifact and successful prerequisite it requires, with no change to production publication policy.",
        "Focused workflow tests or dispatch evidence cover one-package, mixed-package, no-package, and protected-main behavior, including propagation of a selected package failure to the caller.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Replaced the prohibited YAML/regex selector test with an executable reusable-workflow behavior harness. The harness covers API-only, mixed-package, no-package, protected-main, and selected-package-failure propagation, with per-scenario concurrency keys preventing cross-case cancellation. Focused behavior and policy tests run through make test-ci-workflows and the Verification Policy job. Hosted run 31558145400 on head e06875d2d proves the selected package jobs and outputs; the expected selected API failure is visible in job 93994815312 while the parent assertion succeeds in job 93994916341."
    },
    {
      "id": "ci-job-routing-003",
      "title": "Enforce a stable Verification Policy check",
      "description": "As a repository maintainer, I want one stable required check to validate classification and all selected lane outcomes so branch protection remains correct even though individual jobs are conditional.",
      "acceptanceCriteria": [
        "Verification Policy is created for every supported pull-request classification, waits for classification and all potentially selected verification jobs, and has a stable check name suitable for branch protection.",
        "The policy succeeds only when classification completed safely and every selected lane reached an allowed successful terminal result; it fails for selected-lane failure, cancellation, unexpected skip, or missing result.",
        "Correctly unselected jobs may be skipped without failing the policy, and the policy does not treat a control-plane job as product verification.",
        "The GitHub Actions summary lists touched areas, every lane's run/skip decision, its classifier-provided reason, and its terminal result in language a reviewer can act on.",
        "Policy evaluation remains fail-closed when reusable package or local-inference workflows fail or do not return an expected result.",
        "Focused tests or controlled workflow runs prove policy success for a minimal classification and failure for at least one selected-lane failure or missing-result case.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "The fail-closed Verification Policy evaluator remains implemented. Its policy and reusable-workflow behavior tests are registered in make test-ci-workflows and invoked from the always-present policy job with if: always(), preserving the policy summary when the focused gate fails. Hosted run 31558145400 has a successful behavior assertion job 93994916341 and records selected failure propagation through job 93994815312. On final head ca07686e1, the required Verification Policy completed successfully in run 31558706881 at job 93998930255 after the one permitted baseline coverage rerun."
    },
    {
      "id": "ci-job-routing-004",
      "title": "Publish and activate the CI verification policy",
      "description": "As a contributor and branch-protection administrator, I want one canonical explanation and required-check configuration so I can predict local and hosted verification and protected merges cannot bypass selected checks.",
      "acceptanceCriteria": [
        "The canonical development documentation maps each owned change area to selected verification, explains additive unions, factory/** neutrality, and full-verification fallbacks for CI/tooling and unknown paths, and matches classifier fixtures and workflow behavior.",
        "The documentation gives direct local rerun commands for each lane, explains package self-verification and candidate behavior, and distinguishes always-present control-plane jobs from conditionally selected product verification.",
        "Branch protection requires the stable Verification Policy check and removes obsolete dynamic conditional job requirements only after the stable policy has demonstrated correct enforcement.",
        "A protected-branch test or repository-settings evidence shows a merge cannot proceed when the policy fails and can proceed when the policy succeeds and all other requirements are satisfied.",
        "The change remains within CI workflows and their canonical policy documentation, with no classifier, Make-target, dashboard/package-decoupling, or unrelated cleanup folded into this lane unless merged main requires a narrowly documented compatibility adjustment.",
        "Typecheck passes"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Updated the canonical Agent Factory Development Guide and marked the classification plan active with additive lane ownership, factory neutrality, conservative fallbacks, exact local rerun commands, package self-verification/candidate behavior, and stable policy semantics. Focused policy/workflow tests, classifier tests/vet, actionlint, the internal markdown linter, make typecheck, and make test pass. Activated ruleset must-pass-pr (15943501) through the repository API; its only required Actions context is Verification Policy, while deletion and non-fast-forward protections remain active. Repository-settings evidence confirms obsolete conditional contexts were removed."
    },
    {
      "id": "ci-job-routing-005",
      "title": "Prove routing behavior on GitHub Actions",
      "description": "As a reviewer, I want live evidence for the minimal, exempt, and conservative cases so I can confirm that the routing policy works on hosted GitHub Actions rather than only in local fixtures.",
      "acceptanceCriteria": [
        "The implementation PR links a real PR run or workflow-dispatch run for a change limited to docs/reference/**; only Docs Reference product verification runs, all other product-verification jobs skip before runner allocation, and Verification Policy succeeds.",
        "The implementation PR links a real PR run or workflow-dispatch run for a factory/**-only change; no product-verification job allocates a runner, and Verification Policy succeeds after recording the neutral classification.",
        "The implementation PR links a real PR run or workflow-dispatch run for an unknown-path change; every verification lane runs, and Verification Policy reflects their terminal results.",
        "Evidence records the touched paths, classifier output, run/skip decisions, job conclusions, and run URLs clearly enough for a reviewer to reproduce the conclusion without source scanning.",
        "After policy activation and branch-protection reconfiguration, the PR links a terminal successful CI run on main; any routing defect found in live evidence is corrected and the affected scenario is rerun.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": "Live hosted routing evidence remains recorded in PR #1888 for docs-reference-only, factory-only, unknown-path, post-activation-main, and current-head runs. Review remediation is additionally proven on head e06875d2d by behavior run 31558145400: API-only and mixed package outputs succeeded, no-package outputs were skipped, protected-main candidates were skipped while package verification succeeded, and the selected API failure propagated to the reusable caller while the assertion job succeeded. Final head ca07686e1 is pushed to the open PR, and required CI run 31558706881 is terminal successful with Verification Policy job 93998930255."
    }
  ]
}
