### PR TITLE
Tighten workstation discipline: review waits on CI, process never owns merge, visit cap 12

### DIFF
--- a/factory/factory.json
+++ b/factory/factory.json
@@ -820,7 +820,7 @@
     {
       "guards": [
         {
-          "maxVisits": 50,
+          "maxVisits": 12,
           "type": "VISIT_COUNT",
           "workstation": "process"
         }

--- a/factory/workstations/process/AGENTS.md
+++ b/factory/workstations/process/AGENTS.md
@@ -9,7 +9,7 @@ You are an autonomous coding agent working on a software project.
 5. if there exists a PR already, then please check the comments on said pr, address them, then resubmit a new pr based on the latest feedback.
 
 17. Respond finally as follows:
-17.1. Respond `<COMPLETE>` only when all items in the PRD have been marked as passes:true, all relevant PR conversation comments have been addressed, and the PR has been updated to the latest commits so the task is ready to move into review.
+17.1. Respond `<COMPLETE>` only when all items in the PRD have been marked as passes:true, all relevant PR conversation comments have been addressed, and the PR has been updated to the latest commits so the task is ready to move into review. READY FOR REVIEW means: final head pushed, PR open, required CI STARTED on that head. It does NOT mean merged and does NOT mean CI finished — the review workstation owns terminal CI and the merge. If your PRD's acceptance criteria mention "merged", that is the overall work item's finish line owned by review, never a reason for you to keep looping.
 17.2. Respond `<CONTINUE>` when you completed this iteration but the task still has remaining story work, unresolved feedback, or PR follow-up; this is ordinary partial progress and should stay on the process continue path, not the review rejection path.
 17.3. Do not use rejection to mean "more executor work remains". In this workflow, true rejection is reserved for the review workstation sending work back after review.
 
@@ -17,7 +17,25 @@ You are an autonomous coding agent working on a software project.
 
 - Work on ONE story per iteration
 - Commit frequently
-- Keep CI green
+- Keep CI green: fix failures your diff caused. If a required check fails on a
+  test in a package your diff does not touch and it reproduces on the base
+  SHA, record the run URL + test name in a PR COMMENT, rerun failed jobs ONCE,
+  and move on — baseline flakes are owned by dedicated deflake lanes; do not
+  burn your session re-proving them.
+- NEVER commit CI results, audit notes, or verification records onto your
+  branch: each such commit creates a new head, invalidates the CI run it
+  describes, and restarts CI. Evidence about a CI run belongs in a PR comment.
+  After your final validation push, the only permitted new commits are actual
+  code or review fixes.
+- CI watching: at most ONE bounded watcher per head (`gh pr checks <n> --watch
+  --interval 180` or one `gh run watch`). Never poll `gh run view` in a tight
+  loop. One rerun of failed jobs per unchanged head, maximum.
+- Sync with origin/main ONLY immediately before your final push, when GitHub
+  reports a real conflict, or when the reviewer asks. New commits on main are
+  not by themselves a reason for another sync pass.
+- prd.json and progress.txt are untracked worktree scaffolding and must NEVER
+  appear in your PR diff. Never `git add -f` them. If your branch already
+  tracks them from an old base, `git rm` them during your next rebase.
 - Read the Codebase Patterns section in progress.txt before starting
 - When adding or revising tests, prefer observable runtime, API, CLI, UI, or
   emitted-event assertions.
@@ -25,6 +43,11 @@ You are an autonomous coding agent working on a software project.
   command or route inventories unless those surfaces are the actual user-visible contract under test.
 
 ## Progress Report Format
+
+Keep each entry CONCISE: what changed, current blocker, next step — not CI
+transcripts or audit narratives. If progress.txt exceeds ~500 lines, compact
+it first: keep the `## Codebase Patterns` section, entries for the current
+story, and the last ~5 entries; delete the rest.
 
 APPEND to progress.txt (never replace, always append):
 ```

--- a/factory/workstations/review/AGENTS.md
+++ b/factory/workstations/review/AGENTS.md
@@ -23,6 +23,10 @@ You are processing work item {{ (index .Inputs 0).WorkID }} of type {{ (index .I
    - approve only when the change is correct, adequately tested, and within the defined expectations
    - for PRs that change functional tests under `tests/functional/...`, apply the construction preferences from [general-backend-standards.md §6](../../../docs/internal/standards/code/general-backend-standards.md#6-testing-strategy-and-test-pyramid) and request changes (`BLOCKING`) when any preference is violated without a documented, in-scope exception:
 4. Run: gh pr diff $prNumber  — to see the full diff
+4.1. If the diff contains `prd.json` or `progress.txt`, that is BLOCKING:
+   these are untracked worktree scaffolding (deleted from main 2026-08-11,
+   PR #1886) and must be removed from the branch (`git rm` during rebase)
+   before merge. State this as the exact fix in your comment.
 5. Read the changed files to understand the implementation in full
 6. Read surrounding codebase code (the code the PR touches) to check for pattern conformance
 
@@ -46,9 +50,24 @@ If the change involves modification to the website, you should use the playwrigh
 
 ### Step 2.1 — Reconcile CI state before commenting
 - Check the live required PR checks on the current head with `gh pr view --json headRefOid,mergeStateStatus,statusCheckRollup` and `gh pr checks`.
-- If required checks are still `PENDING`, `QUEUED`, or `IN_PROGRESS`, do not post a new PR conversation comment yet just to say CI is still running.
-- Wait for CI to complete before posting the review summary unless you already found a concrete code or acceptance-criteria issue that is independent of the unfinished CI state.
-- If a required workflow appears stale or frozen for an unusually long time on the same step, verify that from the live GitHub run surfaces first. In that case, do not submit a new review comment just to narrate the wait; leave the branch on the review loop until CI reaches a terminal state or there is real review feedback to deliver.
+- If required checks are still `PENDING`, `QUEUED`, or `IN_PROGRESS`, WAIT for
+  them in this session with ONE bounded watcher: `gh pr checks <n> --watch
+  --interval 180` (give it up to ~45 minutes). Do your code reading (Steps 1,
+  3, 4) while it runs. Do not post a comment just to say CI is running, and do
+  not end the session with `<REJECTED>` merely because CI was pending when you
+  started — that routes the work back to the processor, which has nothing to
+  do, and burns a process/review round trip.
+- Only if checks are STILL non-terminal after the bounded wait: end with
+  `<REJECTED>` without posting a comment, so the loop re-enters review later.
+- Known-baseline flake policy: if a required check fails ONLY on a test in a
+  package the PR diff does not touch, and that test is a known baseline flake
+  (see the deflake lane list in docs/temp/scale-program-rules.md in the root
+  repo, or verify it reproduces on the base SHA), rerun the failed jobs ONCE
+  (`gh run rerun <id> --failed`) and watch again. If it greens, proceed. If
+  the same untouched-package flake fails twice, post ONE comment naming the
+  test and the owning deflake lane, state explicitly "NO EXECUTOR ACTION
+  REQUIRED — waiting on baseline deflake", and end `<REJECTED>`. Never demand
+  code changes for a baseline flake in a package the diff does not touch.
 
 ### Step 3 — Verify project acceptance criteria
 


### PR DESCRIPTION
Operator change accompanying the 2026-08-11 daemon restart (already live in the running daemon; this PR makes main match).

- **process/AGENTS.md** — `<COMPLETE>` = ready for review (final head pushed, PR open, required CI started); merge is owned by review. Forbids committing CI evidence onto the branch, limits CI watching to one bounded watcher + one rerun per unchanged head, restricts main-sync to final-push time, bans prd.json/progress.txt from PR diffs, adds progress.txt compaction guidance.
- **review/AGENTS.md** — pending CI now means wait in-session with one bounded watcher (~45 min) instead of instant `<REJECTED>` round-trips; known-baseline flakes in untouched packages get one rerun then an explicit no-executor-action comment; prd.json/progress.txt in the diff is a named BLOCKING with the exact fix.
- **factory.json** — executor-loop-breaker maxVisits 50 → 12 (measured: runaway lanes burn ~31 agent-hours before the old cap fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)