### PR TITLE
CI evidence: docs/reference-only routing

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -160,3 +160,5 @@ Use these canonical concept owners when you need the current contract.
 - [Author AGENTS.md](authoring-agents-md.md)
 - [Batch inputs](batch-inputs.md)
 - [Templates](templates.md)
+
+<!-- Isolated CI routing evidence fixture. -->


### PR DESCRIPTION
Only changes docs/reference/README.md; base is ci-job-routing so the classifier should select Docs Reference only.