### PR TITLE
CI evidence: factory-only routing

### DIFF
--- a/factory/ci-routing-evidence.txt
+++ b/factory/ci-routing-evidence.txt
@@ -1,0 +1,1 @@
+This isolated fixture verifies that factory-only changes are neutral to product verification.


### PR DESCRIPTION
Only changes factory/ci-routing-evidence.txt; base is ci-job-routing so the classifier should select no product verification.