### PR TITLE
CI evidence: unknown-path routing

### DIFF
--- a/ci-routing-evidence-unknown.txt
+++ b/ci-routing-evidence-unknown.txt
@@ -1,0 +1,1 @@
+This isolated fixture verifies the conservative unknown-path fallback.


### PR DESCRIPTION
Only changes ci-routing-evidence-unknown.txt; base is ci-job-routing so the classifier should conservatively select every lane.