### PR TITLE
prosecheck-analyzers

### DIFF
--- a/cmd/prosecheck/analyzer.go
+++ b/cmd/prosecheck/analyzer.go
@@ -108,20 +108,6 @@ func Analyze(spans []Span, policy Policy) []Finding {
 	return SortFindings(findings)
 }
 
-// AnalyzeText is a small pure convenience entry point for callers that
-// already have one natural-language span. Structural adapters should provide
-// their own protected ranges instead of relying on lexical guesses.
-func AnalyzeText(sourcePath string, line, column int, class ContentClass, text string, policy Policy) []Finding {
-	return Analyze([]Span{{
-		SourcePath:  sourcePath,
-		StartLine:   line,
-		StartColumn: column,
-		Class:       class,
-		Text:        text,
-		Protected:   LexicalProtectedRanges(text),
-	}}, policy)
-}
-
 func analyzeSpan(span Span, policy Policy) []Finding {
 	if !utf8.ValidString(span.Text) {
 		return []Finding{parseFinding(span, "source span is not valid UTF-8", 0, 1)}

--- a/cmd/prosecheck/analyzer.go
+++ b/cmd/prosecheck/analyzer.go
@@ -1,0 +1,745 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	pathpkg "path"
+	"regexp"
+	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// TextRange is a half-open byte range in Span.Text. Adapters use it to mark
+// machine and technical text before rule evaluation.
+type TextRange struct {
+	Start int
+	End   int
+}
+
+// Suppression is a bounded, owner-approved exception for one rule. The
+// comment form understood by ParseSuppressionDirective is documented here:
+//
+//	<!-- prosecheck:ignore B-SEMICOLON reason="..." owner="..." review="..." -->
+//
+// An adapter should replace the parsed range with the exact source span that
+// the directive owns. A zero range is only valid for a parsed inline directive
+// while Analyze derives the remainder of its containing structural span.
+type Suppression struct {
+	RuleID      RuleID
+	StartOffset int
+	EndOffset   int
+	Reason      string
+	Owner       string
+	Review      string
+}
+
+// Span is one structurally classified natural-language block. It is the
+// boundary between source adapters and pure rule evaluation.
+type Span struct {
+	SourcePath   string
+	StartLine    int
+	StartColumn  int
+	Class        ContentClass
+	Text         string
+	Identity     string
+	Protected    []TextRange
+	Suppressions []Suppression
+}
+
+// Finding is the stable, actionable result emitted by the analyzer.
+type Finding struct {
+	RuleID       RuleID       `json:"ruleId"`
+	Severity     Severity     `json:"severity"`
+	SourcePath   string       `json:"sourcePath"`
+	StartLine    int          `json:"startLine"`
+	StartColumn  int          `json:"startColumn"`
+	EndLine      int          `json:"endLine"`
+	EndColumn    int          `json:"endColumn"`
+	ContentClass ContentClass `json:"contentClass"`
+	Excerpt      string       `json:"excerpt"`
+	Guidance     string       `json:"guidance"`
+	Fingerprint  string       `json:"fingerprint"`
+	Identity     string       `json:"identity,omitempty"`
+
+	startOffset int
+	endOffset   int
+}
+
+type candidate struct {
+	ruleID   RuleID
+	class    ContentClass
+	start    int
+	end      int
+	excerpt  string
+	guidance string
+}
+
+type directiveOccurrence struct {
+	start       int
+	end         int
+	suppression Suppression
+}
+
+// Analyze applies all supported deterministic rules to explicitly classified
+// spans. It copies no input state, performs no I/O, and returns one total-order
+// sorted result for every input enumeration order.
+func Analyze(spans []Span, policy Policy) []Finding {
+	findings := make([]Finding, 0)
+	for _, span := range spans {
+		findings = append(findings, analyzeSpan(span, policy)...)
+	}
+	return SortFindings(findings)
+}
+
+// AnalyzeText is a small pure convenience entry point for callers that
+// already have one natural-language span. Structural adapters should provide
+// their own protected ranges instead of relying on lexical guesses.
+func AnalyzeText(sourcePath string, line, column int, class ContentClass, text string, policy Policy) []Finding {
+	return Analyze([]Span{{
+		SourcePath:  sourcePath,
+		StartLine:   line,
+		StartColumn: column,
+		Class:       class,
+		Text:        text,
+		Protected:   LexicalProtectedRanges(text),
+	}}, policy)
+}
+
+func analyzeSpan(span Span, policy Policy) []Finding {
+	if !utf8.ValidString(span.Text) {
+		return []Finding{parseFinding(span, "source span is not valid UTF-8", 0, 1)}
+	}
+	if strings.TrimSpace(span.SourcePath) == "" {
+		return []Finding{parseFinding(span, "source path is empty", 0, 1)}
+	}
+	if !policy.knownClass(span.Class) {
+		return []Finding{parseFinding(span, fmt.Sprintf("unknown content class %q", span.Class), 0, 1)}
+	}
+
+	ranges, err := normalizedRanges(span.Protected, span.Text)
+	if err != nil {
+		return []Finding{parseFinding(span, err.Error(), 0, 1)}
+	}
+	masked := maskRanges(span.Text, ranges)
+	directives, directiveFindings := parseInlineDirectives(span, policy)
+	ranges = append(ranges, directiveRanges(directives)...)
+	masked = maskRanges(span.Text, ranges)
+
+	validSuppressions, suppressionFindings := validateSuppressions(span, policy, directives)
+	findings := append(directiveFindings, suppressionFindings...)
+	if span.Class == ContentClassTechnical || span.Class == ContentClassTerm {
+		return SortFindings(findings)
+	}
+
+	candidates := analyzeSentences(span, policy, masked)
+	candidates = append(candidates, analyzeParagraphs(span, policy, masked)...)
+	candidates = append(candidates, analyzePunctuation(span, policy, masked)...)
+	candidates = append(candidates, analyzeContractions(span, policy, masked)...)
+	candidates = append(candidates, analyzeTerms(span, policy, masked)...)
+
+	for _, item := range candidates {
+		if suppressed(item, validSuppressions) {
+			continue
+		}
+		findings = append(findings, findingFromCandidate(span, item))
+	}
+	return SortFindings(findings)
+}
+
+func analyzeSentences(span Span, policy Policy, masked string) []candidate {
+	var ruleID RuleID
+	limit := 0
+	switch span.Class {
+	case ContentClassProcedural:
+		ruleID = RuleProceduralSentenceLength
+		limit = 20
+	case ContentClassDescriptive:
+		ruleID = RuleDescriptiveSentenceLength
+		limit = 25
+	default:
+		return nil
+	}
+	rule, ok := policy.rule(ruleID)
+	if !ok || rule.Limit != limit {
+		return nil
+	}
+	var findings []candidate
+	for _, sentence := range sentenceRanges(masked) {
+		if words := naturalWordCount(masked[sentence.Start:sentence.End]); words > limit {
+			findings = append(findings, candidate{
+				ruleID:   ruleID,
+				class:    span.Class,
+				start:    sentence.Start,
+				end:      sentence.End,
+				excerpt:  span.Text[sentence.Start:sentence.End],
+				guidance: sentenceGuidance(ruleID, limit),
+			})
+		}
+	}
+	return findings
+}
+
+func analyzeParagraphs(span Span, policy Policy, masked string) []candidate {
+	if span.Class != ContentClassDescriptive {
+		return nil
+	}
+	if rule, ok := policy.rule(RuleDescriptiveParagraphLength); !ok || rule.Limit != 6 {
+		return nil
+	}
+	var findings []candidate
+	for _, paragraph := range paragraphRanges(masked) {
+		paragraphText := masked[paragraph.Start:paragraph.End]
+		sentences := sentenceRanges(paragraphText)
+		if len(sentences) <= 6 {
+			continue
+		}
+		findings = append(findings, candidate{
+			ruleID:   RuleDescriptiveParagraphLength,
+			class:    span.Class,
+			start:    paragraph.Start,
+			end:      paragraph.End,
+			excerpt:  span.Text[paragraph.Start:paragraph.End],
+			guidance: "Split the descriptive paragraph into no more than six sentences.",
+		})
+	}
+	return findings
+}
+
+func analyzePunctuation(span Span, policy Policy, masked string) []candidate {
+	if _, ok := policy.rule(RuleSemicolon); !ok {
+		return nil
+	}
+	var findings []candidate
+	for offset := 0; offset < len(masked); offset++ {
+		if masked[offset] != ';' {
+			continue
+		}
+		findings = append(findings, candidate{
+			ruleID:   RuleSemicolon,
+			class:    span.Class,
+			start:    offset,
+			end:      offset + 1,
+			excerpt:  span.Text[offset : offset+1],
+			guidance: "Replace the semicolon with a full stop or separate the two ideas.",
+		})
+	}
+	return findings
+}
+
+func analyzeContractions(span Span, policy Policy, masked string) []candidate {
+	if _, ok := policy.rule(RuleContraction); !ok {
+		return nil
+	}
+	var findings []candidate
+	for _, occurrence := range contractionOccurrences(masked) {
+		findings = append(findings, candidate{
+			ruleID:   RuleContraction,
+			class:    span.Class,
+			start:    occurrence.Start,
+			end:      occurrence.End,
+			excerpt:  span.Text[occurrence.Start:occurrence.End],
+			guidance: "Use the complete form instead of the contraction.",
+		})
+	}
+	return findings
+}
+
+type termMatch struct {
+	start       int
+	end         int
+	ruleID      RuleID
+	replacement string
+}
+
+func analyzeTerms(span Span, policy Policy, masked string) []candidate {
+	_, publicOK := policy.rule(RulePublicTerm)
+	_, caseOK := policy.rule(RuleTermCase)
+	if !publicOK && !caseOK {
+		return nil
+	}
+	matches := make([]termMatch, 0)
+	lowerMasked := strings.ToLower(masked)
+	for _, term := range policy.Terms {
+		if publicOK {
+			for _, alternative := range term.DiscouragedAlternatives {
+				if alternative.Status != "prohibited" {
+					continue
+				}
+				for _, start := range foldedOccurrences(lowerMasked, strings.ToLower(alternative.Text)) {
+					end := start + len(alternative.Text)
+					if isTermBoundary(masked, start, end) {
+						matches = append(matches, termMatch{
+							start: start, end: end, ruleID: RulePublicTerm,
+							replacement: alternative.Replacement,
+						})
+					}
+				}
+			}
+		}
+		if !caseOK || term.Category != "product-term" {
+			continue
+		}
+		for _, spelling := range termSpellings(term) {
+			for _, start := range foldedOccurrences(lowerMasked, strings.ToLower(spelling)) {
+				end := start + len(spelling)
+				if !isTermBoundary(masked, start, end) || masked[start:end] == spelling {
+					continue
+				}
+				matches = append(matches, termMatch{
+					start: start, end: end, ruleID: RuleTermCase,
+					replacement: spelling,
+				})
+			}
+		}
+	}
+
+	slices.SortStableFunc(matches, func(left, right termMatch) int {
+		if left.start != right.start {
+			return left.start - right.start
+		}
+		if left.end != right.end {
+			return right.end - left.end
+		}
+		return strings.Compare(string(left.ruleID), string(right.ruleID))
+	})
+	selected := make([]termMatch, 0, len(matches))
+	for _, match := range matches {
+		if len(selected) > 0 && match.start < selected[len(selected)-1].end {
+			continue
+		}
+		selected = append(selected, match)
+	}
+
+	findings := make([]candidate, 0, len(selected))
+	for _, match := range selected {
+		guidance := fmt.Sprintf("Use the approved customer term `%s`.", match.replacement)
+		if match.ruleID == RuleTermCase {
+			guidance = fmt.Sprintf("Use the canonical product-term spelling and capitalization `%s`.", match.replacement)
+		}
+		findings = append(findings, candidate{
+			ruleID: match.ruleID, class: span.Class,
+			start: match.start, end: match.end,
+			excerpt: span.Text[match.start:match.end], guidance: guidance,
+		})
+	}
+	return findings
+}
+
+func termSpellings(term Term) []string {
+	spellings := []string{term.Canonical}
+	for _, form := range []string{"singular", "plural"} {
+		if value := term.ApprovedForms[form]; value != "" && value != term.Canonical {
+			spellings = append(spellings, value)
+		}
+	}
+	slices.SortStableFunc(spellings, func(left, right string) int {
+		if len(left) != len(right) {
+			return len(right) - len(left)
+		}
+		return strings.Compare(strings.ToLower(left), strings.ToLower(right))
+	})
+	return spellings
+}
+
+func sentenceGuidance(ruleID RuleID, limit int) string {
+	if ruleID == RuleProceduralSentenceLength {
+		return fmt.Sprintf("Shorten the procedural sentence to %d natural-language words or fewer.", limit)
+	}
+	return fmt.Sprintf("Shorten the descriptive sentence to %d natural-language words or fewer.", limit)
+}
+
+func findingFromCandidate(span Span, item candidate) Finding {
+	path := normalizeSourcePath(span.SourcePath)
+	startLine, startColumn := spanPosition(span, item.start)
+	endLine, endColumn := spanPosition(span, item.end)
+	excerpt := boundedExcerpt(item.excerpt)
+	finding := Finding{
+		RuleID:       item.ruleID,
+		Severity:     SeverityBlocking,
+		SourcePath:   path,
+		StartLine:    startLine,
+		StartColumn:  startColumn,
+		EndLine:      endLine,
+		EndColumn:    endColumn,
+		ContentClass: item.class,
+		Excerpt:      excerpt,
+		Guidance:     item.guidance,
+		Identity:     strings.TrimSpace(span.Identity),
+		startOffset:  item.start,
+		endOffset:    item.end,
+	}
+	finding.Fingerprint = fingerprint(finding)
+	return finding
+}
+
+func parseFinding(span Span, message string, start, end int) Finding {
+	if end <= start {
+		end = start + 1
+	}
+	if end > len(span.Text) {
+		end = len(span.Text)
+	}
+	if end <= start {
+		end = start
+	}
+	item := candidate{
+		ruleID: RuleParse, class: span.Class, start: start, end: end,
+		excerpt: message, guidance: "Fix the source so the analyzer can safely extract every prose span.",
+	}
+	return findingFromCandidate(span, item)
+}
+
+func fingerprint(finding Finding) string {
+	parts := []string{
+		string(finding.RuleID), string(finding.Severity), finding.SourcePath,
+		finding.Identity, string(finding.ContentClass),
+		fmt.Sprint(finding.StartLine), fmt.Sprint(finding.StartColumn),
+		normalizeFingerprintText(finding.Excerpt),
+	}
+	digest := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+func normalizeSourcePath(value string) string {
+	value = strings.ReplaceAll(strings.TrimSpace(value), "\\", "/")
+	if value == "" {
+		return "<unknown>"
+	}
+	return pathpkg.Clean(value)
+}
+
+func normalizeFingerprintText(value string) string {
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	value = strings.ReplaceAll(value, "\r", "\n")
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func boundedExcerpt(value string) string {
+	value = normalizeFingerprintText(value)
+	const maxRunes = 160
+	runes := []rune(value)
+	if len(runes) <= maxRunes {
+		return value
+	}
+	return string(runes[:maxRunes-1]) + "…"
+}
+
+func spanPosition(span Span, offset int) (int, int) {
+	line := span.StartLine
+	column := span.StartColumn
+	if line < 1 {
+		line = 1
+	}
+	if column < 1 {
+		column = 1
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > len(span.Text) {
+		offset = len(span.Text)
+	}
+	for index := 0; index < offset; {
+		runeValue, size := utf8.DecodeRuneInString(span.Text[index:])
+		if runeValue == '\r' {
+			line++
+			column = 1
+			if index+size < offset && span.Text[index+size] == '\n' {
+				index += size
+				size = 1
+			}
+		} else if runeValue == '\n' {
+			if index == 0 || span.Text[index-1] != '\r' {
+				line++
+			}
+			column = 1
+		} else {
+			column++
+		}
+		index += size
+	}
+	return line, column
+}
+
+func normalizedRanges(ranges []TextRange, text string) ([]TextRange, error) {
+	copyRanges := append([]TextRange(nil), ranges...)
+	slices.SortStableFunc(copyRanges, func(left, right TextRange) int {
+		if left.Start != right.Start {
+			return left.Start - right.Start
+		}
+		return left.End - right.End
+	})
+	previousEnd := 0
+	for _, item := range copyRanges {
+		if item.Start < 0 || item.End <= item.Start || item.End > len(text) {
+			return nil, fmt.Errorf("protected range [%d,%d) is outside the source span", item.Start, item.End)
+		}
+		if !isUTF8Boundary(text, item.Start) || !isUTF8Boundary(text, item.End) {
+			return nil, fmt.Errorf("protected range [%d,%d) does not align to UTF-8 boundaries", item.Start, item.End)
+		}
+		if item.Start < previousEnd {
+			return nil, fmt.Errorf("protected ranges overlap at byte %d", item.Start)
+		}
+		previousEnd = item.End
+	}
+	return copyRanges, nil
+}
+
+func isUTF8Boundary(text string, offset int) bool {
+	return offset == 0 || offset == len(text) || utf8.RuneStart(text[offset])
+}
+
+func maskRanges(text string, ranges []TextRange) string {
+	masked := []byte(text)
+	for _, item := range ranges {
+		for index := item.Start; index < item.End; index++ {
+			switch masked[index] {
+			case '\n', '\r', '\t':
+			default:
+				masked[index] = ' '
+			}
+		}
+	}
+	return string(masked)
+}
+
+type byteRange struct {
+	Start int
+	End   int
+}
+
+func sentenceRanges(text string) []byteRange {
+	var ranges []byteRange
+	start := skipWhitespace(text, 0)
+	for start < len(text) {
+		end := len(text)
+		for index := start; index < len(text); {
+			runeValue, size := utf8.DecodeRuneInString(text[index:])
+			if runeValue == '.' || runeValue == '!' || runeValue == '?' {
+				end = index + size
+				for end < len(text) {
+					closing, closingSize := utf8.DecodeRuneInString(text[end:])
+					if !isClosingPunctuation(closing) {
+						break
+					}
+					end += closingSize
+				}
+				break
+			}
+			index += size
+		}
+		if end > start {
+			ranges = append(ranges, byteRange{Start: start, End: end})
+		}
+		start = skipWhitespace(text, end)
+	}
+	return ranges
+}
+
+func paragraphRanges(text string) []byteRange {
+	var ranges []byteRange
+	start := skipWhitespace(text, 0)
+	for start < len(text) {
+		end := len(text)
+		for index := start; index < len(text); {
+			if text[index] == '\n' {
+				next := index + 1
+				for next < len(text) && (text[next] == ' ' || text[next] == '\t' || text[next] == '\r') {
+					next++
+				}
+				if next < len(text) && text[next] == '\n' {
+					end = index
+					break
+				}
+			}
+			_, size := utf8.DecodeRuneInString(text[index:])
+			index += size
+		}
+		end = trimTrailingWhitespace(text, start, end)
+		if end > start {
+			ranges = append(ranges, byteRange{Start: start, End: end})
+		}
+		start = skipWhitespace(text, end)
+	}
+	return ranges
+}
+
+func naturalWordCount(text string) int {
+	count := 0
+	inWord := false
+	for index := 0; index < len(text); {
+		runeValue, size := utf8.DecodeRuneInString(text[index:])
+		if (runeValue == '\'' || runeValue == '’') && inWord && index+size < len(text) {
+			next, _ := utf8.DecodeRuneInString(text[index+size:])
+			if unicode.IsLetter(next) || unicode.IsDigit(next) {
+				index += size
+				continue
+			}
+		}
+		word := unicode.IsLetter(runeValue) || unicode.IsDigit(runeValue)
+		if word && !inWord {
+			count++
+		}
+		inWord = word
+		index += size
+	}
+	return count
+}
+
+func skipWhitespace(text string, start int) int {
+	for start < len(text) {
+		runeValue, size := utf8.DecodeRuneInString(text[start:])
+		if !unicode.IsSpace(runeValue) {
+			break
+		}
+		start += size
+	}
+	return start
+}
+
+func trimTrailingWhitespace(text string, start, end int) int {
+	for end > start {
+		runeValue, size := utf8.DecodeLastRuneInString(text[start:end])
+		if !unicode.IsSpace(runeValue) {
+			break
+		}
+		end -= size
+	}
+	return end
+}
+
+func isClosingPunctuation(value rune) bool {
+	switch value {
+	case '\'', '"', ')', ']', '}', '»', '”', '’':
+		return true
+	default:
+		return false
+	}
+}
+
+type occurrence struct {
+	Start int
+	End   int
+}
+
+func contractionOccurrences(text string) []occurrence {
+	var occurrences []occurrence
+	for index := 0; index < len(text); {
+		runeValue, size := utf8.DecodeRuneInString(text[index:])
+		if !unicode.IsLetter(runeValue) {
+			index += size
+			continue
+		}
+		start := index
+		index += size
+		for index < len(text) {
+			value, valueSize := utf8.DecodeRuneInString(text[index:])
+			if unicode.IsLetter(value) || value == '\'' || value == '’' {
+				index += valueSize
+				continue
+			}
+			break
+		}
+		word := strings.ToLower(strings.NewReplacer("’", "'").Replace(text[start:index]))
+		if strings.Contains(word, "'") && isContraction(word) {
+			occurrences = append(occurrences, occurrence{Start: start, End: index})
+		}
+	}
+	return occurrences
+}
+
+func isContraction(word string) bool {
+	switch word {
+	case "ain't", "aren't", "can't", "couldn't", "didn't", "doesn't", "don't", "hadn't", "hasn't", "haven't", "he'd", "he'll", "he's", "i'd", "i'll", "i'm", "i've", "isn't", "let's", "mightn't", "mustn't", "shan't", "she'd", "she'll", "she's", "shouldn't", "that's", "there'd", "there'll", "there's", "they'd", "they'll", "they're", "they've", "wasn't", "we'd", "we'll", "we're", "we've", "weren't", "what'll", "what's", "when's", "where'd", "where'll", "where's", "who'd", "who'll", "who's", "won't", "wouldn't", "you'd", "you'll", "you're", "you've":
+		return true
+	default:
+		return false
+	}
+}
+
+func foldedOccurrences(text, needle string) []int {
+	if needle == "" {
+		return nil
+	}
+	var occurrences []int
+	for start := 0; start <= len(text)-len(needle); {
+		index := strings.Index(text[start:], needle)
+		if index < 0 {
+			break
+		}
+		index += start
+		occurrences = append(occurrences, index)
+		start = index + 1
+	}
+	return occurrences
+}
+
+func isTermBoundary(text string, start, end int) bool {
+	if start > 0 {
+		previous, _ := utf8.DecodeLastRuneInString(text[:start])
+		if isIdentifierRune(previous) {
+			return false
+		}
+	}
+	if end < len(text) {
+		next, _ := utf8.DecodeRuneInString(text[end:])
+		if isIdentifierRune(next) {
+			return false
+		}
+	}
+	return true
+}
+
+func isIdentifierRune(value rune) bool {
+	return unicode.IsLetter(value) || unicode.IsDigit(value) || value == '_'
+}
+
+// LexicalProtectedRanges recognizes only unambiguous inline technical forms.
+// Structural adapters remain responsible for fenced blocks, JSON/YAML nodes,
+// command lines, and source-owned literals.
+func LexicalProtectedRanges(text string) []TextRange {
+	var ranges []TextRange
+	for index := 0; index < len(text); {
+		if text[index] != '`' {
+			index++
+			continue
+		}
+		end := strings.IndexByte(text[index+1:], '`')
+		if end < 0 {
+			break
+		}
+		end += index + 2
+		ranges = append(ranges, TextRange{Start: index, End: end})
+		index = end
+	}
+	urlPattern := regexp.MustCompile(`(?i)\b(?:https?|ftp)://[^\s<>()]+`)
+	for _, match := range urlPattern.FindAllStringIndex(text, -1) {
+		end := match[1]
+		for end > match[0] && strings.ContainsRune(".,;:!?", rune(text[end-1])) {
+			end--
+		}
+		if end > match[0] {
+			ranges = append(ranges, TextRange{Start: match[0], End: end})
+		}
+	}
+	slices.SortStableFunc(ranges, func(left, right TextRange) int {
+		if left.Start != right.Start {
+			return left.Start - right.Start
+		}
+		return left.End - right.End
+	})
+	merged := make([]TextRange, 0, len(ranges))
+	for _, item := range ranges {
+		if len(merged) == 0 || item.Start > merged[len(merged)-1].End {
+			merged = append(merged, item)
+			continue
+		}
+		if item.End > merged[len(merged)-1].End {
+			merged[len(merged)-1].End = item.End
+		}
+	}
+	return merged
+}

--- a/cmd/prosecheck/analyzer.go
+++ b/cmd/prosecheck/analyzer.go
@@ -356,12 +356,45 @@ func termAppliesToSpan(term Term, span Span) bool {
 		}
 		for _, termSurface := range term.Surfaces {
 			allowed := normalizeSurface(termSurface)
-			if allowed == source || strings.Contains(allowed, source) || strings.Contains(source, allowed) {
+			if surfaceSelectorMatchesTerm(source, allowed, term) {
 				return true
 			}
 		}
 	}
 	return false
+}
+
+func surfaceSelectorMatchesTerm(source, allowed string, term Term) bool {
+	if source == allowed {
+		return true
+	}
+	switch source {
+	case surfaceCLIHelp:
+		// CLI help is a deliberately narrow selector. It may match a
+		// canonical surface that explicitly contains CLI help, but it must
+		// not opt every CLI/status/API term into every authored field.
+		return strings.Contains(allowed, source)
+	case surfaceCustomerDocumentation:
+		// A generic Markdown document does not establish that an ordinary
+		// word such as "work" or "model" denotes the product resource. A
+		// specific command or structural surface can still opt the term in
+		// through an exact selector.
+		if ambiguousBroadDocumentationTerm(term) {
+			return false
+		}
+		return strings.Contains(allowed, source)
+	default:
+		return false
+	}
+}
+
+func ambiguousBroadDocumentationTerm(term Term) bool {
+	switch strings.ToLower(strings.TrimSpace(term.Canonical)) {
+	case "work", "model", "running", "active":
+		return true
+	default:
+		return false
+	}
 }
 
 func normalizeSurface(value string) string {

--- a/cmd/prosecheck/analyzer.go
+++ b/cmd/prosecheck/analyzer.go
@@ -39,12 +39,17 @@ type Suppression struct {
 // Span is one structurally classified natural-language block. It is the
 // boundary between source adapters and pure rule evaluation.
 type Span struct {
-	SourcePath   string
-	StartLine    int
-	StartColumn  int
-	Class        ContentClass
-	Text         string
-	Identity     string
+	SourcePath  string
+	StartLine   int
+	StartColumn int
+	Class       ContentClass
+	Text        string
+	Identity    string
+	// Surfaces are deterministic selectors for the canonical terminology
+	// register. Adapters provide them when the source structure establishes
+	// where the prose will be shown; an empty set declines ambiguous term
+	// findings rather than guessing at meaning.
+	Surfaces     []string
 	Protected    []TextRange
 	Suppressions []Suppression
 	positions    []sourcePosition
@@ -272,6 +277,9 @@ func analyzeTerms(span Span, policy Policy, masked string) []candidate {
 	matches := make([]termMatch, 0)
 	lowerMasked := strings.ToLower(masked)
 	for _, term := range policy.Terms {
+		if !termAppliesToSpan(term, span) {
+			continue
+		}
 		if publicOK {
 			for _, alternative := range term.DiscouragedAlternatives {
 				if alternative.Status != "prohibited" {
@@ -335,6 +343,29 @@ func analyzeTerms(span Span, policy Policy, masked string) []candidate {
 		})
 	}
 	return findings
+}
+
+func termAppliesToSpan(term Term, span Span) bool {
+	if len(term.Surfaces) == 0 || len(span.Surfaces) == 0 {
+		return false
+	}
+	for _, sourceSurface := range span.Surfaces {
+		source := normalizeSurface(sourceSurface)
+		if source == "" {
+			continue
+		}
+		for _, termSurface := range term.Surfaces {
+			allowed := normalizeSurface(termSurface)
+			if allowed == source || strings.Contains(allowed, source) || strings.Contains(source, allowed) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func normalizeSurface(value string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(value))), " ")
 }
 
 func termSpellings(term Term) []string {

--- a/cmd/prosecheck/analyzer.go
+++ b/cmd/prosecheck/analyzer.go
@@ -47,6 +47,15 @@ type Span struct {
 	Identity     string
 	Protected    []TextRange
 	Suppressions []Suppression
+	positions    []sourcePosition
+}
+
+// sourcePosition is an absolute source location for one byte boundary in a
+// span. Structured adapters use it when the authored representation encodes
+// text (for example, JSON string escapes) instead of storing it literally.
+type sourcePosition struct {
+	line   int
+	column int
 }
 
 // Finding is the stable, actionable result emitted by the analyzer.
@@ -428,6 +437,18 @@ func boundedExcerpt(value string) string {
 }
 
 func spanPosition(span Span, offset int) (int, int) {
+	if len(span.positions) > 0 {
+		if offset < 0 {
+			offset = 0
+		}
+		if offset >= len(span.positions) {
+			offset = len(span.positions) - 1
+		}
+		position := span.positions[offset]
+		if position.line > 0 && position.column > 0 {
+			return position.line, position.column
+		}
+	}
 	line := span.StartLine
 	column := span.StartColumn
 	if line < 1 {

--- a/cmd/prosecheck/cli_manifest.go
+++ b/cmd/prosecheck/cli_manifest.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -600,10 +599,23 @@ func (c *cliManifestCollector) addStringSpan(node *cliJSONValue, start, end int,
 		Class:       class,
 		Text:        text,
 		Identity:    cliManifestIdentity(context.commandID, context.inputID, context.jsonPath),
+		Surfaces:    cliManifestSurfaceSelectors(),
 		Protected:   cliProtectedRanges(text, c.literals),
 		positions:   positions,
 	}
 	c.spans = append(c.spans, span)
+}
+
+func cliManifestSurfaceSelectors() []string {
+	return []string{
+		surfaceCLIHelp,
+		surfaceCustomerDocumentation,
+		surfaceCLIReferenceDocumentation,
+		surfaceCLIAndCustomerDocumentation,
+		surfaceCLIAndAPIDocumentation,
+		surfaceProviderCLIAndAPIDoc,
+		surfaceModelCLIAndCustomerDoc,
+	}
 }
 
 func (c *cliManifestCollector) stringField(parent *cliJSONValue, key, path string, context cliManifestContext, required bool) (string, bool, *cliJSONValue) {
@@ -983,183 +995,4 @@ func uniqueCLIStrings(values []string) []string {
 		return strings.Compare(left, right)
 	})
 	return result
-}
-
-var (
-	cliFlagPattern        = regexp.MustCompile(`--[A-Za-z0-9][A-Za-z0-9-]*`)
-	cliShortFlagPattern   = regexp.MustCompile(`(?:^|[\s([<])-[A-Za-z][A-Za-z0-9-]*`)
-	cliPlaceholderPattern = regexp.MustCompile(`<[^>\r\n]{1,80}>`)
-	cliPathPattern        = regexp.MustCompile(`(?:\./|\.\./|~/|/|[A-Za-z]:[\\/])[^\s,;!?)]*`)
-	cliIdentifierPattern  = regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9]*(?:[._][A-Za-z0-9_-]+)+\b`)
-	cliCamelCasePattern   = regexp.MustCompile(`\b[A-Za-z]+[a-z][A-Z][A-Za-z0-9]*\b`)
-	cliSnakePattern       = regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)+\b`)
-	cliErrorCodePattern   = regexp.MustCompile(`\b(?:[A-Z][A-Z0-9]*[-_]){1,}[A-Z0-9]+\b`)
-	cliProviderPattern    = regexp.MustCompile(`(?i)\b(?:codex|cursor(?:-acp)?|openai|anthropic|ollama|gpt(?:-[A-Za-z0-9.]+)?)\b`)
-	cliStructuredPattern  = regexp.MustCompile(`^[- ]*[A-Za-z0-9_.-]+\s*:\s*(?:[\[{\"']|true\b|false\b|null\b|-?\d)`)
-	cliSchemePattern      = regexp.MustCompile(`(?i)\b(?:https?|ftp)://[^\s<>()]*`)
-	cliQuotedTechnical    = regexp.MustCompile(`(?i)"(?:error|fatal|usage|stdout|stderr):[^"\r\n]*"`)
-)
-
-func cliProtectedRanges(text string, literals []string) []TextRange {
-	ranges := append([]TextRange(nil), LexicalProtectedRanges(text)...)
-	ranges = append(ranges, cliRegexRanges(text, cliFlagPattern)...)
-	ranges = append(ranges, cliRegexRanges(text, cliShortFlagPattern)...)
-	ranges = append(ranges, cliRegexRanges(text, cliPlaceholderPattern)...)
-	ranges = append(ranges, cliRegexRanges(text, cliPathPattern)...)
-	ranges = append(ranges, cliRegexRanges(text, cliIdentifierPattern)...)
-	ranges = append(ranges, cliRegexRanges(text, cliCamelCasePattern)...)
-	ranges = append(ranges, cliRegexRanges(text, cliSnakePattern)...)
-	ranges = append(ranges, cliRegexRanges(text, cliErrorCodePattern)...)
-	ranges = append(ranges, cliRegexRanges(text, cliProviderPattern)...)
-	ranges = append(ranges, cliRegexRanges(text, cliSchemePattern)...)
-	ranges = append(ranges, markdownRouteRanges(text)...)
-	ranges = append(ranges, markdownCommandLineRanges(text)...)
-	ranges = append(ranges, cliCommandLiteralLineRanges(text, literals)...)
-	ranges = append(ranges, cliStructuredLineRanges(text)...)
-	ranges = append(ranges, cliQuotedOutputRanges(text)...)
-	ranges = append(ranges, cliRegexRanges(text, cliQuotedTechnical)...)
-	for _, literal := range literals {
-		ranges = append(ranges, cliLiteralRanges(text, literal)...)
-	}
-	return mergeCLIRanges(ranges)
-}
-
-func cliRegexRanges(text string, pattern *regexp.Regexp) []TextRange {
-	matches := pattern.FindAllStringIndex(text, -1)
-	ranges := make([]TextRange, 0, len(matches))
-	for _, match := range matches {
-		ranges = append(ranges, TextRange{Start: match[0], End: match[1]})
-	}
-	return ranges
-}
-
-func cliLiteralRanges(text, literal string) []TextRange {
-	if literal == "" || len(literal) > len(text) {
-		return nil
-	}
-	var ranges []TextRange
-	for search := 0; search <= len(text)-len(literal); {
-		index := strings.Index(text[search:], literal)
-		if index < 0 {
-			break
-		}
-		index += search
-		end := index + len(literal)
-		if cliLiteralBoundary(text, index, end, literal) {
-			ranges = append(ranges, TextRange{Start: index, End: end})
-		}
-		search = index + 1
-	}
-	return ranges
-}
-
-func cliLiteralBoundary(text string, start, end int, literal string) bool {
-	if len(literal) == 0 {
-		return false
-	}
-	if isIdentifierRune(rune(literal[0])) && start > 0 {
-		previous, _ := utf8.DecodeLastRuneInString(text[:start])
-		if isIdentifierRune(previous) {
-			return false
-		}
-	}
-	if isIdentifierRune(rune(literal[len(literal)-1])) && end < len(text) {
-		next, _ := utf8.DecodeRuneInString(text[end:])
-		if isIdentifierRune(next) {
-			return false
-		}
-	}
-	return true
-}
-
-func cliStructuredLineRanges(text string) []TextRange {
-	var ranges []TextRange
-	for start := 0; start < len(text); {
-		end := strings.IndexByte(text[start:], '\n')
-		if end < 0 {
-			end = len(text)
-		} else {
-			end += start
-		}
-		line := strings.TrimSpace(strings.TrimSuffix(text[start:end], "\r"))
-		if cliLooksLikeStructuredLine(line) {
-			ranges = append(ranges, TextRange{Start: start, End: end})
-		}
-		if end == len(text) {
-			break
-		}
-		start = end + 1
-	}
-	return ranges
-}
-
-func cliLooksLikeStructuredLine(line string) bool {
-	if line == "" || strings.HasPrefix(line, "#") {
-		return false
-	}
-	if strings.HasPrefix(line, "{") || strings.HasPrefix(line, "}") || strings.HasPrefix(line, "[") || strings.HasPrefix(line, "]") {
-		return true
-	}
-	if strings.Contains(line, `":`) || strings.Contains(line, "':") {
-		return true
-	}
-	return cliStructuredPattern.MatchString(line)
-}
-
-func cliQuotedOutputRanges(text string) []TextRange {
-	pattern := regexp.MustCompile(`(?im)^\s*(?:error|fatal|usage|exit status|stdout|stderr)\s*:\s*\S[^\r\n]*`)
-	return cliRegexRanges(text, pattern)
-}
-
-func cliCommandLiteralLineRanges(text string, literals []string) []TextRange {
-	var ranges []TextRange
-	for lineStart := 0; lineStart < len(text); {
-		lineEnd := strings.IndexByte(text[lineStart:], '\n')
-		if lineEnd < 0 {
-			lineEnd = len(text)
-		} else {
-			lineEnd += lineStart
-		}
-		line := strings.TrimSuffix(text[lineStart:lineEnd], "\r")
-		leading := len(line) - len(strings.TrimLeft(line, " \t"))
-		trimmed := line[leading:]
-		for _, literal := range literals {
-			if !strings.Contains(literal, " ") || !strings.HasPrefix(literal, "you ") || !strings.HasPrefix(trimmed, literal) {
-				continue
-			}
-			if cliLiteralBoundary(trimmed, 0, len(literal), literal) {
-				ranges = append(ranges, TextRange{Start: lineStart + leading, End: lineEnd})
-				break
-			}
-		}
-		if lineEnd == len(text) {
-			break
-		}
-		lineStart = lineEnd + 1
-	}
-	return ranges
-}
-
-func mergeCLIRanges(ranges []TextRange) []TextRange {
-	ordered := append([]TextRange(nil), ranges...)
-	slices.SortStableFunc(ordered, func(left, right TextRange) int {
-		if left.Start != right.Start {
-			return left.Start - right.Start
-		}
-		return left.End - right.End
-	})
-	merged := make([]TextRange, 0, len(ordered))
-	for _, item := range ordered {
-		if item.Start < 0 || item.End <= item.Start {
-			continue
-		}
-		if len(merged) == 0 || item.Start > merged[len(merged)-1].End {
-			merged = append(merged, item)
-			continue
-		}
-		if item.End > merged[len(merged)-1].End {
-			merged[len(merged)-1].End = item.End
-		}
-	}
-	return merged
 }

--- a/cmd/prosecheck/cli_manifest.go
+++ b/cmd/prosecheck/cli_manifest.go
@@ -1,0 +1,1133 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const authoredCLIManifestSuffix = "/contracts/cli/commands.json"
+
+type cliJSONKind uint8
+
+const (
+	cliJSONInvalid cliJSONKind = iota
+	cliJSONObject
+	cliJSONArray
+	cliJSONString
+	cliJSONNumber
+	cliJSONBoolean
+	cliJSONNull
+)
+
+type cliJSONField struct {
+	key   string
+	start int
+	value *cliJSONValue
+}
+
+type cliJSONValue struct {
+	kind              cliJSONKind
+	start             int
+	end               int
+	stringValue       string
+	decodedRawOffsets []int
+	fields            []cliJSONField
+	fieldIndex        map[string]int
+	elements          []*cliJSONValue
+}
+
+type cliJSONDocument struct {
+	sourcePath string
+	data       []byte
+	root       *cliJSONValue
+	positions  []sourcePosition
+}
+
+type cliJSONParser struct {
+	data   []byte
+	offset int
+}
+
+type cliJSONError struct {
+	offset  int
+	message string
+}
+
+func (e cliJSONError) Error() string {
+	return fmt.Sprintf("%s at byte %d", e.message, e.offset)
+}
+
+type cliManifestContext struct {
+	commandID string
+	inputID   string
+	jsonPath  string
+}
+
+type cliManifestExtraction struct {
+	spans    []Span
+	findings []Finding
+}
+
+type cliManifestCollector struct {
+	doc      *cliJSONDocument
+	literals []string
+	spans    []Span
+	findings []Finding
+}
+
+// AnalyzeCLIManifest extracts only authored customer-visible CLI prose and
+// sends the resulting spans through the same pure evaluator as Markdown.
+func AnalyzeCLIManifest(sourcePath string, data []byte, policy Policy) []Finding {
+	extraction := extractCLIManifest(sourcePath, data, policy)
+	findings := append([]Finding(nil), extraction.findings...)
+	findings = append(findings, Analyze(extraction.spans, policy)...)
+	return SortFindings(findings)
+}
+
+// ExtractCLIManifestSpans exposes the structural adapter for callers that
+// need to inspect the extracted, source-located spans directly. AnalyzeCLIManifest
+// retains partial spans and all safe parse findings when a field is malformed.
+func ExtractCLIManifestSpans(sourcePath string, data []byte) ([]Span, error) {
+	extraction := extractCLIManifest(sourcePath, data, Policy{})
+	if len(extraction.findings) > 0 {
+		return extraction.spans, errors.New(extraction.findings[0].Excerpt)
+	}
+	return extraction.spans, nil
+}
+
+func extractCLIManifest(sourcePath string, data []byte, policy Policy) cliManifestExtraction {
+	document, err := parseCLIManifestJSON(sourcePath, data)
+	if err != nil {
+		return cliManifestExtraction{findings: []Finding{cliManifestParseFinding(sourcePath, data, "", "", "", cliJSONErrorOffset(err), err.Error())}}
+	}
+	if document.root.kind != cliJSONObject {
+		return cliManifestExtraction{findings: []Finding{cliManifestParseFinding(sourcePath, data, "", "", "", document.root.start, "manifest root must be a JSON object")}}
+	}
+	commands, ok := document.root.field("commands")
+	if !ok {
+		return cliManifestExtraction{findings: []Finding{cliManifestParseFinding(sourcePath, data, "", "/commands", "", document.root.start, "JSON path /commands is required")}}
+	}
+	if commands.kind != cliJSONObject {
+		return cliManifestExtraction{findings: []Finding{cliManifestParseFinding(sourcePath, data, "", "/commands", "", commands.start, "JSON path /commands must be an object")}}
+	}
+
+	literals := append([]string(nil), cliManifestLiterals(document.root)...)
+	literals = append(literals, cliPolicyLiterals(policy)...)
+	literals = uniqueCLIStrings(literals)
+	collector := cliManifestCollector{doc: document, literals: literals}
+	for _, entry := range sortedCLIFields(commands) {
+		collector.visitCommand(entry)
+	}
+	return cliManifestExtraction{spans: collector.spans, findings: collector.findings}
+}
+
+func parseCLIManifestJSON(sourcePath string, data []byte) (*cliJSONDocument, error) {
+	if !utf8.Valid(data) {
+		return nil, cliJSONError{offset: 0, message: "CLI manifest is not valid UTF-8"}
+	}
+	parser := cliJSONParser{data: data}
+	parser.skipSpace()
+	root, err := parser.parseValue()
+	if err != nil {
+		return nil, err
+	}
+	parser.skipSpace()
+	if parser.offset != len(data) {
+		return nil, cliJSONError{offset: parser.offset, message: "unexpected data after the JSON document"}
+	}
+	return &cliJSONDocument{
+		sourcePath: sourcePath,
+		data:       append([]byte(nil), data...),
+		root:       root,
+		positions:  cliSourcePositions(data),
+	}, nil
+}
+
+func (p *cliJSONParser) parseValue() (*cliJSONValue, error) {
+	if p.offset >= len(p.data) {
+		return nil, p.failure("expected a JSON value")
+	}
+	switch p.data[p.offset] {
+	case '{':
+		return p.parseObject()
+	case '[':
+		return p.parseArray()
+	case '"':
+		return p.parseString()
+	case 't':
+		return p.parseLiteral("true", cliJSONBoolean)
+	case 'f':
+		return p.parseLiteral("false", cliJSONBoolean)
+	case 'n':
+		return p.parseLiteral("null", cliJSONNull)
+	default:
+		if p.data[p.offset] == '-' || (p.data[p.offset] >= '0' && p.data[p.offset] <= '9') {
+			return p.parseNumber()
+		}
+		return nil, p.failure("expected a JSON value")
+	}
+}
+
+func (p *cliJSONParser) parseObject() (*cliJSONValue, error) {
+	start := p.offset
+	p.offset++
+	value := &cliJSONValue{kind: cliJSONObject, start: start, fieldIndex: make(map[string]int)}
+	p.skipSpace()
+	if p.consume('}') {
+		value.end = p.offset
+		return value, nil
+	}
+	for {
+		if p.offset >= len(p.data) || p.data[p.offset] != '"' {
+			return nil, p.failure("object key must be a JSON string")
+		}
+		keyNode, err := p.parseString()
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := value.fieldIndex[keyNode.stringValue]; exists {
+			return nil, cliJSONError{offset: keyNode.start, message: fmt.Sprintf("duplicate object key %q", keyNode.stringValue)}
+		}
+		p.skipSpace()
+		if !p.consume(':') {
+			return nil, p.failure("object key must be followed by ':'")
+		}
+		p.skipSpace()
+		child, err := p.parseValue()
+		if err != nil {
+			return nil, err
+		}
+		value.fieldIndex[keyNode.stringValue] = len(value.fields)
+		value.fields = append(value.fields, cliJSONField{key: keyNode.stringValue, start: keyNode.start, value: child})
+		p.skipSpace()
+		if p.consume('}') {
+			value.end = p.offset
+			return value, nil
+		}
+		if !p.consume(',') {
+			return nil, p.failure("object member must be followed by ',' or '}'")
+		}
+		p.skipSpace()
+	}
+}
+
+func (p *cliJSONParser) parseArray() (*cliJSONValue, error) {
+	start := p.offset
+	p.offset++
+	value := &cliJSONValue{kind: cliJSONArray, start: start}
+	p.skipSpace()
+	if p.consume(']') {
+		value.end = p.offset
+		return value, nil
+	}
+	for {
+		child, err := p.parseValue()
+		if err != nil {
+			return nil, err
+		}
+		value.elements = append(value.elements, child)
+		p.skipSpace()
+		if p.consume(']') {
+			value.end = p.offset
+			return value, nil
+		}
+		if !p.consume(',') {
+			return nil, p.failure("array value must be followed by ',' or ']'")
+		}
+		p.skipSpace()
+	}
+}
+
+func (p *cliJSONParser) parseString() (*cliJSONValue, error) {
+	start := p.offset
+	p.offset++
+	for p.offset < len(p.data) {
+		switch p.data[p.offset] {
+		case '"':
+			p.offset++
+			var decoded string
+			if err := json.Unmarshal(p.data[start:p.offset], &decoded); err != nil {
+				return nil, cliJSONError{offset: start, message: fmt.Sprintf("invalid JSON string: %v", err)}
+			}
+			offsets, err := cliDecodedRawOffsets(p.data, start, p.offset, decoded)
+			if err != nil {
+				return nil, err
+			}
+			return &cliJSONValue{
+				kind:              cliJSONString,
+				start:             start,
+				end:               p.offset,
+				stringValue:       decoded,
+				decodedRawOffsets: offsets,
+			}, nil
+		case '\\':
+			if p.offset+1 >= len(p.data) {
+				return nil, p.failure("unterminated JSON escape")
+			}
+			if p.data[p.offset+1] == 'u' {
+				if p.offset+6 > len(p.data) {
+					return nil, p.failure("incomplete Unicode escape")
+				}
+				p.offset += 6
+				continue
+			}
+			p.offset += 2
+		case '\r', '\n':
+			return nil, p.failure("JSON strings cannot contain literal line breaks")
+		default:
+			if p.data[p.offset] < 0x20 {
+				return nil, p.failure("JSON strings cannot contain control characters")
+			}
+			_, size := utf8.DecodeRune(p.data[p.offset:])
+			if size == 1 && p.data[p.offset] >= 0x80 {
+				return nil, p.failure("JSON string contains invalid UTF-8")
+			}
+			p.offset += size
+		}
+	}
+	return nil, cliJSONError{offset: start, message: "unterminated JSON string"}
+}
+
+func (p *cliJSONParser) parseLiteral(literal string, kind cliJSONKind) (*cliJSONValue, error) {
+	start := p.offset
+	if !strings.HasPrefix(string(p.data[p.offset:]), literal) {
+		return nil, p.failure("invalid JSON literal")
+	}
+	p.offset += len(literal)
+	return &cliJSONValue{kind: kind, start: start, end: p.offset}, nil
+}
+
+func (p *cliJSONParser) parseNumber() (*cliJSONValue, error) {
+	start := p.offset
+	if p.data[p.offset] == '-' {
+		p.offset++
+	}
+	if p.offset >= len(p.data) {
+		return nil, p.failure("incomplete JSON number")
+	}
+	if p.data[p.offset] == '0' {
+		p.offset++
+	} else if p.data[p.offset] >= '1' && p.data[p.offset] <= '9' {
+		for p.offset < len(p.data) && p.data[p.offset] >= '0' && p.data[p.offset] <= '9' {
+			p.offset++
+		}
+	} else {
+		return nil, p.failure("invalid JSON number")
+	}
+	if p.consume('.') {
+		if p.offset >= len(p.data) || p.data[p.offset] < '0' || p.data[p.offset] > '9' {
+			return nil, p.failure("JSON number fraction requires digits")
+		}
+		for p.offset < len(p.data) && p.data[p.offset] >= '0' && p.data[p.offset] <= '9' {
+			p.offset++
+		}
+	}
+	if p.offset < len(p.data) && (p.data[p.offset] == 'e' || p.data[p.offset] == 'E') {
+		p.offset++
+		if p.offset < len(p.data) && (p.data[p.offset] == '+' || p.data[p.offset] == '-') {
+			p.offset++
+		}
+		if p.offset >= len(p.data) || p.data[p.offset] < '0' || p.data[p.offset] > '9' {
+			return nil, p.failure("JSON number exponent requires digits")
+		}
+		for p.offset < len(p.data) && p.data[p.offset] >= '0' && p.data[p.offset] <= '9' {
+			p.offset++
+		}
+	}
+	if !json.Valid(p.data[start:p.offset]) {
+		return nil, cliJSONError{offset: start, message: "invalid JSON number"}
+	}
+	return &cliJSONValue{kind: cliJSONNumber, start: start, end: p.offset}, nil
+}
+
+func (p *cliJSONParser) skipSpace() {
+	for p.offset < len(p.data) {
+		switch p.data[p.offset] {
+		case ' ', '\t', '\r', '\n':
+			p.offset++
+		default:
+			return
+		}
+	}
+}
+
+func (p *cliJSONParser) consume(value byte) bool {
+	if p.offset >= len(p.data) || p.data[p.offset] != value {
+		return false
+	}
+	p.offset++
+	return true
+}
+
+func (p *cliJSONParser) failure(message string) error {
+	return cliJSONError{offset: p.offset, message: message}
+}
+
+func cliJSONErrorOffset(err error) int {
+	var value cliJSONError
+	if errors.As(err, &value) {
+		return value.offset
+	}
+	return 0
+}
+
+func cliDecodedRawOffsets(data []byte, start, end int, decoded string) ([]int, error) {
+	offsets := make([]int, 0, len(decoded)+1)
+	for offset := start + 1; offset < end-1; {
+		rawStart := offset
+		if data[offset] != '\\' {
+			_, size := utf8.DecodeRune(data[offset : end-1])
+			if size == 0 || size == 1 && data[offset] >= 0x80 {
+				return nil, cliJSONError{offset: offset, message: "invalid UTF-8 in JSON string"}
+			}
+			for index := 0; index < size; index++ {
+				offsets = append(offsets, offset+index)
+			}
+			offset += size
+			continue
+		}
+		if offset+1 >= end-1 {
+			return nil, cliJSONError{offset: offset, message: "unterminated JSON escape"}
+		}
+		switch data[offset+1] {
+		case '"', '\\', '/', 'b', 'f', 'n', 'r', 't':
+			offsets = append(offsets, rawStart)
+			offset += 2
+		case 'u':
+			value, consumed, err := cliUnicodeEscape(data, offset, end-1)
+			if err != nil {
+				return nil, err
+			}
+			for range []byte(string(value)) {
+				offsets = append(offsets, rawStart)
+			}
+			offset += consumed
+		default:
+			return nil, cliJSONError{offset: offset, message: "invalid JSON escape"}
+		}
+	}
+	if len(offsets) != len(decoded) {
+		return nil, cliJSONError{offset: start, message: "JSON string decoding changed its byte length unexpectedly"}
+	}
+	offsets = append(offsets, end)
+	return offsets, nil
+}
+
+func cliUnicodeEscape(data []byte, offset, end int) (rune, int, error) {
+	if offset+6 > end || data[offset] != '\\' || data[offset+1] != 'u' {
+		return 0, 0, cliJSONError{offset: offset, message: "incomplete Unicode escape"}
+	}
+	value, ok := cliHexRune(data[offset+2 : offset+6])
+	if !ok {
+		return 0, 0, cliJSONError{offset: offset, message: "invalid Unicode escape"}
+	}
+	consumed := 6
+	if value >= 0xd800 && value <= 0xdbff {
+		if offset+consumed+6 > end || data[offset+consumed] != '\\' || data[offset+consumed+1] != 'u' {
+			return 0, 0, cliJSONError{offset: offset, message: "high surrogate is missing its low surrogate"}
+		}
+		low, ok := cliHexRune(data[offset+consumed+2 : offset+consumed+6])
+		if !ok || low < 0xdc00 || low > 0xdfff {
+			return 0, 0, cliJSONError{offset: offset, message: "invalid low surrogate"}
+		}
+		value = 0x10000 + ((value-0xd800)<<10 | (low - 0xdc00))
+		consumed += 6
+	} else if value >= 0xdc00 && value <= 0xdfff {
+		return 0, 0, cliJSONError{offset: offset, message: "low surrogate has no high surrogate"}
+	}
+	return value, consumed, nil
+}
+
+func cliHexRune(value []byte) (rune, bool) {
+	if len(value) != 4 {
+		return 0, false
+	}
+	var result rune
+	for _, item := range value {
+		result <<= 4
+		switch {
+		case item >= '0' && item <= '9':
+			result += rune(item - '0')
+		case item >= 'a' && item <= 'f':
+			result += rune(item-'a') + 10
+		case item >= 'A' && item <= 'F':
+			result += rune(item-'A') + 10
+		default:
+			return 0, false
+		}
+	}
+	return result, true
+}
+
+func cliSourcePositions(data []byte) []sourcePosition {
+	positions := make([]sourcePosition, len(data)+1)
+	line, column := 1, 1
+	for offset := 0; offset < len(data); {
+		positions[offset] = sourcePosition{line: line, column: column}
+		runeValue, size := utf8.DecodeRune(data[offset:])
+		if size == 0 {
+			size = 1
+		}
+		for index := 1; index < size && offset+index < len(data); index++ {
+			positions[offset+index] = sourcePosition{line: line, column: column}
+		}
+		switch runeValue {
+		case '\r':
+			line++
+			column = 1
+		case '\n':
+			if offset == 0 || data[offset-1] != '\r' {
+				line++
+			}
+			column = 1
+		default:
+			column++
+		}
+		offset += size
+	}
+	positions[len(data)] = sourcePosition{line: line, column: column}
+	return positions
+}
+
+func (value *cliJSONValue) field(key string) (*cliJSONValue, bool) {
+	if value == nil || value.kind != cliJSONObject {
+		return nil, false
+	}
+	index, ok := value.fieldIndex[key]
+	if !ok {
+		return nil, false
+	}
+	return value.fields[index].value, true
+}
+
+func sortedCLIFields(value *cliJSONValue) []cliJSONField {
+	if value == nil || value.kind != cliJSONObject {
+		return nil
+	}
+	fields := append([]cliJSONField(nil), value.fields...)
+	slices.SortStableFunc(fields, func(left, right cliJSONField) int {
+		return strings.Compare(left.key, right.key)
+	})
+	return fields
+}
+
+func cliManifestParseFinding(sourcePath string, data []byte, commandID, jsonPath, inputID string, offset int, message string) Finding {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(data) && len(data) > 0 {
+		offset = len(data) - 1
+	}
+	span := Span{
+		SourcePath:  sourcePath,
+		StartLine:   1,
+		StartColumn: 1,
+		Class:       ContentClassTechnical,
+		Text:        string(data),
+		Identity:    cliManifestIdentity(commandID, inputID, jsonPath),
+	}
+	return parseFinding(span, message, offset, offset+1)
+}
+
+func cliManifestIdentity(commandID, inputID, jsonPath string) string {
+	parts := make([]string, 0, 3)
+	if commandID != "" {
+		parts = append(parts, "command="+commandID)
+	}
+	if inputID != "" {
+		parts = append(parts, "input="+inputID)
+	}
+	if jsonPath != "" {
+		parts = append(parts, "json="+jsonPath)
+	}
+	return strings.Join(parts, ";")
+}
+
+func cliJSONPointer(parts ...string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.ReplaceAll(part, "~", "~0")
+		part = strings.ReplaceAll(part, "/", "~1")
+		result = append(result, part)
+	}
+	return "/" + strings.Join(result, "/")
+}
+
+func (c *cliManifestCollector) issue(node *cliJSONValue, context cliManifestContext, message string) {
+	offset := 0
+	if node != nil {
+		offset = node.start
+	}
+	c.findings = append(c.findings, cliManifestParseFinding(
+		c.doc.sourcePath,
+		c.doc.data,
+		context.commandID,
+		context.jsonPath,
+		context.inputID,
+		offset,
+		message,
+	))
+}
+
+func (c *cliManifestCollector) addStringSpan(node *cliJSONValue, start, end int, class ContentClass, context cliManifestContext) {
+	if node == nil || node.kind != cliJSONString || start < 0 || end > len(node.stringValue) || start >= end {
+		return
+	}
+	text := node.stringValue[start:end]
+	if strings.TrimSpace(text) == "" {
+		return
+	}
+	positions := make([]sourcePosition, len(text)+1)
+	for index := range positions {
+		rawOffset := node.decodedRawOffsets[start+index]
+		if rawOffset >= 0 && rawOffset < len(c.doc.positions) {
+			positions[index] = c.doc.positions[rawOffset]
+		}
+	}
+	span := Span{
+		SourcePath:  c.doc.sourcePath,
+		StartLine:   positions[0].line,
+		StartColumn: positions[0].column,
+		Class:       class,
+		Text:        text,
+		Identity:    cliManifestIdentity(context.commandID, context.inputID, context.jsonPath),
+		Protected:   cliProtectedRanges(text, c.literals),
+		positions:   positions,
+	}
+	c.spans = append(c.spans, span)
+}
+
+func (c *cliManifestCollector) stringField(parent *cliJSONValue, key, path string, context cliManifestContext, required bool) (string, bool, *cliJSONValue) {
+	field, ok := parent.field(key)
+	if !ok {
+		if required {
+			c.issue(parent, contextWithPath(context, path), fmt.Sprintf("JSON path %s is required and must be a string", path))
+		}
+		return "", false, nil
+	}
+	if field.kind != cliJSONString {
+		c.issue(field, contextWithPath(context, path), fmt.Sprintf("JSON path %s must be a string", path))
+		return "", false, field
+	}
+	if required && strings.TrimSpace(field.stringValue) == "" {
+		c.issue(field, contextWithPath(context, path), fmt.Sprintf("JSON path %s must not be empty", path))
+		return "", false, field
+	}
+	return field.stringValue, true, field
+}
+
+func contextWithPath(context cliManifestContext, path string) cliManifestContext {
+	context.jsonPath = path
+	return context
+}
+
+func (c *cliManifestCollector) visitCommand(entry cliJSONField) {
+	commandPath := cliJSONPointer("commands", entry.key)
+	if entry.value.kind != cliJSONObject {
+		c.issue(entry.value, cliManifestContext{jsonPath: commandPath}, fmt.Sprintf("JSON path %s must be a command object", commandPath))
+		return
+	}
+	visibility := c.recordVisibility(entry.value, commandPath, cliManifestContext{jsonPath: commandPath})
+	commandID, hasID, _ := c.stringField(entry.value, "id", cliJSONPointer("commands", entry.key, "id"), cliManifestContext{jsonPath: commandPath}, !visibility.hidden)
+	if !hasID || strings.TrimSpace(commandID) == "" {
+		commandID = entry.key
+	}
+	context := cliManifestContext{commandID: commandID, inputID: commandID, jsonPath: commandPath}
+	c.visitGuidanceFields(entry.value, context)
+	c.visitLifecycle(entry.value, context)
+	if visibility.hidden {
+		return
+	}
+
+	c.visitDocumentation(entry.value, context)
+	c.visitUsage(entry.value, context)
+	c.visitInputRecords(entry.value, context, "flags")
+	c.visitInputRecords(entry.value, context, "arguments")
+}
+
+type cliVisibility struct {
+	hidden bool
+}
+
+func (c *cliManifestCollector) recordVisibility(record *cliJSONValue, path string, context cliManifestContext) cliVisibility {
+	value, ok, field := c.stringField(record, "visibility", cliJSONPointerFromPath(path, "visibility"), context, false)
+	if !ok {
+		if field != nil {
+			return cliVisibility{}
+		}
+		return cliVisibility{}
+	}
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "hidden", "private", "internal":
+		return cliVisibility{hidden: true}
+	default:
+		return cliVisibility{}
+	}
+}
+
+func (c *cliManifestCollector) visitDocumentation(command *cliJSONValue, context cliManifestContext) {
+	documentationPath := cliJSONPointerFromPath(context.jsonPath, "documentation")
+	documentation, ok := command.field("documentation")
+	if !ok {
+		c.issue(command, contextWithPath(context, documentationPath), fmt.Sprintf("JSON path %s is required for a visible command", documentationPath))
+		return
+	}
+	if documentation.kind != cliJSONObject {
+		c.issue(documentation, contextWithPath(context, documentationPath), fmt.Sprintf("JSON path %s must be an object", documentationPath))
+		return
+	}
+	copyPath := cliJSONPointerFromPath(documentationPath, "documentation")
+	copy, ok := documentation.field("documentation")
+	if !ok {
+		c.issue(documentation, contextWithPath(context, copyPath), fmt.Sprintf("JSON path %s is required", copyPath))
+		return
+	}
+	if copy.kind != cliJSONObject {
+		c.issue(copy, contextWithPath(context, copyPath), fmt.Sprintf("JSON path %s must be an object", copyPath))
+		return
+	}
+	copyVisibility := c.recordVisibility(copy, copyPath, context)
+	if !copyVisibility.hidden {
+		c.visitDocumentationField(copy, context, "title", ContentClassLabel)
+		c.visitDocumentationField(copy, context, "description", ContentClassDescriptive)
+		c.visitDocumentationExamples(documentation, context, documentationPath)
+	}
+}
+
+func (c *cliManifestCollector) visitDocumentationField(copy *cliJSONValue, context cliManifestContext, key string, class ContentClass) {
+	fieldPath := cliJSONPointerFromPath(context.jsonPath, "documentation", "documentation", key)
+	field, ok := copy.field(key)
+	if !ok {
+		c.issue(copy, contextWithPath(context, fieldPath), fmt.Sprintf("JSON path %s is required", fieldPath))
+		return
+	}
+	if field.kind != cliJSONObject {
+		c.issue(field, contextWithPath(context, fieldPath), fmt.Sprintf("JSON path %s must be an object", fieldPath))
+		return
+	}
+	inputID, hasID, _ := c.stringField(field, "id", cliJSONPointerFromPath(fieldPath, "id"), context, false)
+	if !hasID || strings.TrimSpace(inputID) == "" {
+		inputID = context.commandID + "." + key
+	}
+	valuePath := cliJSONPointerFromPath(fieldPath, "canonicalEnglish")
+	value, ok, valueNode := c.stringField(field, "canonicalEnglish", valuePath, contextWithPath(context, valuePath), true)
+	if ok {
+		c.addStringSpan(valueNode, 0, len(value), class, cliManifestContext{
+			commandID: context.commandID,
+			inputID:   inputID,
+			jsonPath:  valuePath,
+		})
+	}
+}
+
+func (c *cliManifestCollector) visitDocumentationExamples(documentation *cliJSONValue, context cliManifestContext, documentationPath string) {
+	examplesPath := cliJSONPointerFromPath(documentationPath, "examples")
+	examples, ok := documentation.field("examples")
+	if !ok {
+		return
+	}
+	if examples.kind != cliJSONArray {
+		c.issue(examples, contextWithPath(context, examplesPath), fmt.Sprintf("JSON path %s must be an array of strings", examplesPath))
+		return
+	}
+	for index, example := range examples.elements {
+		path := cliJSONPointerFromPath(examplesPath, strconv.Itoa(index))
+		if example.kind != cliJSONString {
+			c.issue(example, contextWithPath(context, path), fmt.Sprintf("JSON path %s must be a string", path))
+			continue
+		}
+		c.addExampleComments(example, context.commandID, context.commandID+".documentation.example."+strconv.Itoa(index), path)
+	}
+}
+
+func (c *cliManifestCollector) visitUsage(command *cliJSONValue, context cliManifestContext) {
+	usagePath := cliJSONPointerFromPath(context.jsonPath, "usage")
+	usage, ok := command.field("usage")
+	if !ok {
+		return
+	}
+	if usage.kind != cliJSONObject {
+		c.issue(usage, contextWithPath(context, usagePath), fmt.Sprintf("JSON path %s must be an object", usagePath))
+		return
+	}
+	if line, ok, _ := c.stringField(usage, "line", cliJSONPointerFromPath(usagePath, "line"), context, false); ok {
+		_ = line
+	}
+	examplePath := cliJSONPointerFromPath(usagePath, "example")
+	example, ok := usage.field("example")
+	if !ok {
+		return
+	}
+	if example.kind != cliJSONString {
+		c.issue(example, contextWithPath(context, examplePath), fmt.Sprintf("JSON path %s must be a string", examplePath))
+		return
+	}
+	c.addExampleComments(example, context.commandID, context.commandID+".usage.example", examplePath)
+}
+
+func (c *cliManifestCollector) addExampleComments(node *cliJSONValue, commandID, inputID, path string) {
+	value := node.stringValue
+	for lineStart := 0; lineStart < len(value); {
+		lineEnd := strings.IndexByte(value[lineStart:], '\n')
+		if lineEnd < 0 {
+			lineEnd = len(value)
+		} else {
+			lineEnd += lineStart
+		}
+		contentEnd := lineEnd
+		if contentEnd > lineStart && value[contentEnd-1] == '\r' {
+			contentEnd--
+		}
+		cursor := lineStart
+		for cursor < contentEnd && (value[cursor] == ' ' || value[cursor] == '\t') {
+			cursor++
+		}
+		if cursor < contentEnd && value[cursor] == '#' {
+			contentStart := cursor + 1
+			if contentStart < contentEnd && value[contentStart] == ' ' {
+				contentStart++
+			}
+			c.addStringSpan(node, contentStart, contentEnd, ContentClassProcedural, cliManifestContext{
+				commandID: commandID,
+				inputID:   inputID,
+				jsonPath:  path,
+			})
+		}
+		if lineEnd == len(value) {
+			break
+		}
+		lineStart = lineEnd + 1
+	}
+}
+
+func (c *cliManifestCollector) visitInputRecords(command *cliJSONValue, context cliManifestContext, kind string) {
+	basePath := cliJSONPointerFromPath(context.jsonPath, kind)
+	records, ok := command.field(kind)
+	if !ok {
+		return
+	}
+	if records.kind != cliJSONObject {
+		c.issue(records, contextWithPath(context, basePath), fmt.Sprintf("JSON path %s must be an object", basePath))
+		return
+	}
+	for _, entry := range sortedCLIFields(records) {
+		path := cliJSONPointerFromPath(basePath, entry.key)
+		if entry.value.kind != cliJSONObject {
+			c.issue(entry.value, contextWithPath(context, path), fmt.Sprintf("JSON path %s must be an input object", path))
+			continue
+		}
+		inputID, hasID, _ := c.stringField(entry.value, "id", cliJSONPointerFromPath(path, "id"), context, false)
+		if !hasID || strings.TrimSpace(inputID) == "" {
+			inputID = entry.key
+		}
+		inputContext := cliManifestContext{commandID: context.commandID, inputID: inputID, jsonPath: path}
+		visibility := c.recordVisibility(entry.value, path, inputContext)
+		if usage, present, usageNode := c.stringField(entry.value, "usage", cliJSONPointerFromPath(path, "usage"), inputContext, false); present && !visibility.hidden {
+			c.addStringSpan(usageNode, 0, len(usage), ContentClassProcedural, cliManifestContext{
+				commandID: context.commandID,
+				inputID:   inputID,
+				jsonPath:  cliJSONPointerFromPath(path, "usage"),
+			})
+		}
+		c.visitGuidanceFields(entry.value, inputContext)
+		c.visitLifecycle(entry.value, inputContext)
+	}
+}
+
+func (c *cliManifestCollector) visitGuidanceFields(record *cliJSONValue, context cliManifestContext) {
+	for _, key := range []string{"deprecation", "deprecationMessage", "replacement", "replacementGuidance"} {
+		path := cliJSONPointerFromPath(context.jsonPath, key)
+		value, ok, node := c.stringField(record, key, path, context, false)
+		if !ok || strings.TrimSpace(value) == "" {
+			continue
+		}
+		c.addStringSpan(node, 0, len(value), cliGuidanceClass(value), cliManifestContext{
+			commandID: context.commandID,
+			inputID:   context.inputID + "." + key,
+			jsonPath:  path,
+		})
+	}
+}
+
+func (c *cliManifestCollector) visitLifecycle(record *cliJSONValue, context cliManifestContext) {
+	path := cliJSONPointerFromPath(context.jsonPath, "lifecycle")
+	lifecycle, ok := record.field("lifecycle")
+	if !ok {
+		return
+	}
+	if lifecycle.kind != cliJSONObject {
+		c.issue(lifecycle, contextWithPath(context, path), fmt.Sprintf("JSON path %s must be an object", path))
+		return
+	}
+	for _, key := range []string{"deprecated", "removed", "deprecation", "deprecationMessage", "replacement", "replacementGuidance"} {
+		valuePath := cliJSONPointerFromPath(path, key)
+		value, present, node := c.stringField(lifecycle, key, valuePath, context, false)
+		if present && strings.TrimSpace(value) != "" {
+			c.addStringSpan(node, 0, len(value), cliGuidanceClass(value), cliManifestContext{
+				commandID: context.commandID,
+				inputID:   context.inputID + "." + key,
+				jsonPath:  valuePath,
+			})
+		}
+	}
+	successorPath := cliJSONPointerFromPath(path, "successor")
+	successor, ok := lifecycle.field("successor")
+	if !ok {
+		return
+	}
+	if successor.kind != cliJSONObject {
+		c.issue(successor, contextWithPath(context, successorPath), fmt.Sprintf("JSON path %s must be an object", successorPath))
+		return
+	}
+	if target, present, _ := c.stringField(successor, "targetItemId", cliJSONPointerFromPath(successorPath, "targetItemId"), context, false); present {
+		_ = target
+	}
+	guidancePath := cliJSONPointerFromPath(successorPath, "canonicalEnglish")
+	guidance, present, node := c.stringField(successor, "canonicalEnglish", guidancePath, context, false)
+	if present && strings.TrimSpace(guidance) != "" {
+		c.addStringSpan(node, 0, len(guidance), cliGuidanceClass(guidance), cliManifestContext{
+			commandID: context.commandID,
+			inputID:   context.inputID + ".successor",
+			jsonPath:  guidancePath,
+		})
+	}
+}
+
+func cliGuidanceClass(value string) ContentClass {
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(value)), "use ") {
+		return ContentClassProcedural
+	}
+	return ContentClassDescriptive
+}
+
+func cliJSONPointerFromPath(path string, parts ...string) string {
+	if path == "" {
+		return cliJSONPointer(parts...)
+	}
+	return path + cliJSONPointer(parts...)
+}
+
+func cliManifestLiterals(root *cliJSONValue) []string {
+	var literals []string
+	var visit func(*cliJSONValue, string)
+	visit = func(value *cliJSONValue, key string) {
+		if value == nil {
+			return
+		}
+		switch value.kind {
+		case cliJSONString:
+			if cliLiteralField(key) {
+				literals = append(literals, value.stringValue)
+			}
+		case cliJSONObject:
+			for _, field := range value.fields {
+				visit(field.value, field.key)
+			}
+		case cliJSONArray:
+			for _, item := range value.elements {
+				visit(item, key)
+			}
+		}
+	}
+	visit(root, "")
+	return uniqueCLIStrings(literals)
+}
+
+func cliLiteralField(key string) bool {
+	switch key {
+	case "id", "name", "path", "long", "shorthand", "aliases", "targetItemId", "operationId", "code", "default":
+		return true
+	default:
+		return false
+	}
+}
+
+func cliPolicyLiterals(policy Policy) []string {
+	var literals []string
+	for _, term := range policy.Terms {
+		if term.Category != "command" && term.Category != "protected-literal" {
+			continue
+		}
+		literals = append(literals, term.Canonical)
+		for _, form := range term.ApprovedForms {
+			literals = append(literals, form)
+		}
+	}
+	return uniqueCLIStrings(literals)
+}
+
+func uniqueCLIStrings(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	slices.SortStableFunc(result, func(left, right string) int {
+		if len(left) != len(right) {
+			return len(right) - len(left)
+		}
+		return strings.Compare(left, right)
+	})
+	return result
+}
+
+var (
+	cliFlagPattern        = regexp.MustCompile(`--[A-Za-z0-9][A-Za-z0-9-]*`)
+	cliShortFlagPattern   = regexp.MustCompile(`(?:^|[\s([<])-[A-Za-z][A-Za-z0-9-]*`)
+	cliPlaceholderPattern = regexp.MustCompile(`<[^>\r\n]{1,80}>`)
+	cliPathPattern        = regexp.MustCompile(`(?:\./|\.\./|~/|/|[A-Za-z]:[\\/])[^\s,;!?)]*`)
+	cliIdentifierPattern  = regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9]*(?:[._][A-Za-z0-9_-]+)+\b`)
+	cliSnakePattern       = regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)+\b`)
+	cliErrorCodePattern   = regexp.MustCompile(`\b(?:[A-Z][A-Z0-9]*[-_]){1,}[A-Z0-9]+\b`)
+	cliProviderPattern    = regexp.MustCompile(`(?i)\b(?:codex|cursor(?:-acp)?|openai|anthropic|ollama|gpt(?:-[A-Za-z0-9.]+)?)\b`)
+	cliStructuredPattern  = regexp.MustCompile(`^[- ]*[A-Za-z0-9_.-]+\s*:\s*(?:[\[{\"']|true\b|false\b|null\b|-?\d)`)
+	cliSchemePattern      = regexp.MustCompile(`(?i)\b(?:https?|ftp)://[^\s<>()]*`)
+	cliQuotedTechnical    = regexp.MustCompile(`(?i)"(?:error|fatal|usage|stdout|stderr):[^"\r\n]*"`)
+)
+
+func cliProtectedRanges(text string, literals []string) []TextRange {
+	ranges := append([]TextRange(nil), LexicalProtectedRanges(text)...)
+	ranges = append(ranges, cliRegexRanges(text, cliFlagPattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliShortFlagPattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliPlaceholderPattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliPathPattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliIdentifierPattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliSnakePattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliErrorCodePattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliProviderPattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliSchemePattern)...)
+	ranges = append(ranges, markdownRouteRanges(text)...)
+	ranges = append(ranges, markdownCommandLineRanges(text)...)
+	ranges = append(ranges, cliStructuredLineRanges(text)...)
+	ranges = append(ranges, cliQuotedOutputRanges(text)...)
+	ranges = append(ranges, cliRegexRanges(text, cliQuotedTechnical)...)
+	for _, literal := range literals {
+		ranges = append(ranges, cliLiteralRanges(text, literal)...)
+	}
+	return mergeCLIRanges(ranges)
+}
+
+func cliRegexRanges(text string, pattern *regexp.Regexp) []TextRange {
+	matches := pattern.FindAllStringIndex(text, -1)
+	ranges := make([]TextRange, 0, len(matches))
+	for _, match := range matches {
+		ranges = append(ranges, TextRange{Start: match[0], End: match[1]})
+	}
+	return ranges
+}
+
+func cliLiteralRanges(text, literal string) []TextRange {
+	if literal == "" || len(literal) > len(text) {
+		return nil
+	}
+	var ranges []TextRange
+	for search := 0; search <= len(text)-len(literal); {
+		index := strings.Index(text[search:], literal)
+		if index < 0 {
+			break
+		}
+		index += search
+		end := index + len(literal)
+		if cliLiteralBoundary(text, index, end, literal) {
+			ranges = append(ranges, TextRange{Start: index, End: end})
+		}
+		search = index + 1
+	}
+	return ranges
+}
+
+func cliLiteralBoundary(text string, start, end int, literal string) bool {
+	if len(literal) == 0 {
+		return false
+	}
+	if isIdentifierRune(rune(literal[0])) && start > 0 {
+		previous, _ := utf8.DecodeLastRuneInString(text[:start])
+		if isIdentifierRune(previous) {
+			return false
+		}
+	}
+	if isIdentifierRune(rune(literal[len(literal)-1])) && end < len(text) {
+		next, _ := utf8.DecodeRuneInString(text[end:])
+		if isIdentifierRune(next) {
+			return false
+		}
+	}
+	return true
+}
+
+func cliStructuredLineRanges(text string) []TextRange {
+	var ranges []TextRange
+	for start := 0; start < len(text); {
+		end := strings.IndexByte(text[start:], '\n')
+		if end < 0 {
+			end = len(text)
+		} else {
+			end += start
+		}
+		line := strings.TrimSpace(strings.TrimSuffix(text[start:end], "\r"))
+		if cliLooksLikeStructuredLine(line) {
+			ranges = append(ranges, TextRange{Start: start, End: end})
+		}
+		if end == len(text) {
+			break
+		}
+		start = end + 1
+	}
+	return ranges
+}
+
+func cliLooksLikeStructuredLine(line string) bool {
+	if line == "" || strings.HasPrefix(line, "#") {
+		return false
+	}
+	if strings.HasPrefix(line, "{") || strings.HasPrefix(line, "}") || strings.HasPrefix(line, "[") || strings.HasPrefix(line, "]") {
+		return true
+	}
+	if strings.Contains(line, `":`) || strings.Contains(line, "':") {
+		return true
+	}
+	return cliStructuredPattern.MatchString(line)
+}
+
+func cliQuotedOutputRanges(text string) []TextRange {
+	pattern := regexp.MustCompile(`(?im)^\s*(?:error|fatal|usage|exit status|stdout|stderr)\s*:\s*\S[^\r\n]*`)
+	return cliRegexRanges(text, pattern)
+}
+
+func mergeCLIRanges(ranges []TextRange) []TextRange {
+	ordered := append([]TextRange(nil), ranges...)
+	slices.SortStableFunc(ordered, func(left, right TextRange) int {
+		if left.Start != right.Start {
+			return left.Start - right.Start
+		}
+		return left.End - right.End
+	})
+	merged := make([]TextRange, 0, len(ordered))
+	for _, item := range ordered {
+		if item.Start < 0 || item.End <= item.Start {
+			continue
+		}
+		if len(merged) == 0 || item.Start > merged[len(merged)-1].End {
+			merged = append(merged, item)
+			continue
+		}
+		if item.End > merged[len(merged)-1].End {
+			merged[len(merged)-1].End = item.End
+		}
+	}
+	return merged
+}

--- a/cmd/prosecheck/cli_manifest.go
+++ b/cmd/prosecheck/cli_manifest.go
@@ -944,7 +944,7 @@ func cliManifestLiterals(root *cliJSONValue) []string {
 
 func cliLiteralField(key string) bool {
 	switch key {
-	case "id", "name", "path", "long", "shorthand", "aliases", "targetItemId", "operationId", "code", "default":
+	case "id", "name", "path", "long", "shorthand", "aliases", "targetItemId", "operationId", "code", "default", "provider", "model", "providerName", "modelName", "event", "schema":
 		return true
 	default:
 		return false
@@ -991,6 +991,7 @@ var (
 	cliPlaceholderPattern = regexp.MustCompile(`<[^>\r\n]{1,80}>`)
 	cliPathPattern        = regexp.MustCompile(`(?:\./|\.\./|~/|/|[A-Za-z]:[\\/])[^\s,;!?)]*`)
 	cliIdentifierPattern  = regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9]*(?:[._][A-Za-z0-9_-]+)+\b`)
+	cliCamelCasePattern   = regexp.MustCompile(`\b[A-Za-z]+[a-z][A-Z][A-Za-z0-9]*\b`)
 	cliSnakePattern       = regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)+\b`)
 	cliErrorCodePattern   = regexp.MustCompile(`\b(?:[A-Z][A-Z0-9]*[-_]){1,}[A-Z0-9]+\b`)
 	cliProviderPattern    = regexp.MustCompile(`(?i)\b(?:codex|cursor(?:-acp)?|openai|anthropic|ollama|gpt(?:-[A-Za-z0-9.]+)?)\b`)
@@ -1006,12 +1007,14 @@ func cliProtectedRanges(text string, literals []string) []TextRange {
 	ranges = append(ranges, cliRegexRanges(text, cliPlaceholderPattern)...)
 	ranges = append(ranges, cliRegexRanges(text, cliPathPattern)...)
 	ranges = append(ranges, cliRegexRanges(text, cliIdentifierPattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliCamelCasePattern)...)
 	ranges = append(ranges, cliRegexRanges(text, cliSnakePattern)...)
 	ranges = append(ranges, cliRegexRanges(text, cliErrorCodePattern)...)
 	ranges = append(ranges, cliRegexRanges(text, cliProviderPattern)...)
 	ranges = append(ranges, cliRegexRanges(text, cliSchemePattern)...)
 	ranges = append(ranges, markdownRouteRanges(text)...)
 	ranges = append(ranges, markdownCommandLineRanges(text)...)
+	ranges = append(ranges, cliCommandLiteralLineRanges(text, literals)...)
 	ranges = append(ranges, cliStructuredLineRanges(text)...)
 	ranges = append(ranges, cliQuotedOutputRanges(text)...)
 	ranges = append(ranges, cliRegexRanges(text, cliQuotedTechnical)...)
@@ -1106,6 +1109,35 @@ func cliLooksLikeStructuredLine(line string) bool {
 func cliQuotedOutputRanges(text string) []TextRange {
 	pattern := regexp.MustCompile(`(?im)^\s*(?:error|fatal|usage|exit status|stdout|stderr)\s*:\s*\S[^\r\n]*`)
 	return cliRegexRanges(text, pattern)
+}
+
+func cliCommandLiteralLineRanges(text string, literals []string) []TextRange {
+	var ranges []TextRange
+	for lineStart := 0; lineStart < len(text); {
+		lineEnd := strings.IndexByte(text[lineStart:], '\n')
+		if lineEnd < 0 {
+			lineEnd = len(text)
+		} else {
+			lineEnd += lineStart
+		}
+		line := strings.TrimSuffix(text[lineStart:lineEnd], "\r")
+		leading := len(line) - len(strings.TrimLeft(line, " \t"))
+		trimmed := line[leading:]
+		for _, literal := range literals {
+			if !strings.Contains(literal, " ") || !strings.HasPrefix(literal, "you ") || !strings.HasPrefix(trimmed, literal) {
+				continue
+			}
+			if cliLiteralBoundary(trimmed, 0, len(literal), literal) {
+				ranges = append(ranges, TextRange{Start: lineStart + leading, End: lineEnd})
+				break
+			}
+		}
+		if lineEnd == len(text) {
+			break
+		}
+		lineStart = lineEnd + 1
+	}
+	return ranges
 }
 
 func mergeCLIRanges(ranges []TextRange) []TextRange {

--- a/cmd/prosecheck/cli_manifest.go
+++ b/cmd/prosecheck/cli_manifest.go
@@ -62,12 +62,6 @@ func (e cliJSONError) Error() string {
 	return fmt.Sprintf("%s at byte %d", e.message, e.offset)
 }
 
-type cliManifestContext struct {
-	commandID string
-	inputID   string
-	jsonPath  string
-}
-
 type cliManifestExtraction struct {
 	spans    []Span
 	findings []Finding
@@ -75,7 +69,7 @@ type cliManifestExtraction struct {
 
 type cliManifestCollector struct {
 	doc      *cliJSONDocument
-	literals []string
+	policy   Policy
 	spans    []Span
 	findings []Finding
 }
@@ -116,10 +110,7 @@ func extractCLIManifest(sourcePath string, data []byte, policy Policy) cliManife
 		return cliManifestExtraction{findings: []Finding{cliManifestParseFinding(sourcePath, data, "", "/commands", "", commands.start, "JSON path /commands must be an object")}}
 	}
 
-	literals := append([]string(nil), cliManifestLiterals(document.root)...)
-	literals = append(literals, cliPolicyLiterals(policy)...)
-	literals = uniqueCLIStrings(literals)
-	collector := cliManifestCollector{doc: document, literals: literals}
+	collector := cliManifestCollector{doc: document, policy: policy}
 	for _, entry := range sortedCLIFields(commands) {
 		collector.visitCommand(entry)
 	}
@@ -599,23 +590,11 @@ func (c *cliManifestCollector) addStringSpan(node *cliJSONValue, start, end int,
 		Class:       class,
 		Text:        text,
 		Identity:    cliManifestIdentity(context.commandID, context.inputID, context.jsonPath),
-		Surfaces:    cliManifestSurfaceSelectors(),
-		Protected:   cliProtectedRanges(text, c.literals),
+		Surfaces:    append([]string(nil), context.surfaces...),
+		Protected:   cliProtectedRanges(text, context.literals),
 		positions:   positions,
 	}
 	c.spans = append(c.spans, span)
-}
-
-func cliManifestSurfaceSelectors() []string {
-	return []string{
-		surfaceCLIHelp,
-		surfaceCustomerDocumentation,
-		surfaceCLIReferenceDocumentation,
-		surfaceCLIAndCustomerDocumentation,
-		surfaceCLIAndAPIDocumentation,
-		surfaceProviderCLIAndAPIDoc,
-		surfaceModelCLIAndCustomerDoc,
-	}
 }
 
 func (c *cliManifestCollector) stringField(parent *cliJSONValue, key, path string, context cliManifestContext, required bool) (string, bool, *cliJSONValue) {
@@ -653,7 +632,13 @@ func (c *cliManifestCollector) visitCommand(entry cliJSONField) {
 	if !hasID || strings.TrimSpace(commandID) == "" {
 		commandID = entry.key
 	}
-	context := cliManifestContext{commandID: commandID, inputID: commandID, jsonPath: commandPath}
+	context := cliManifestContext{
+		commandID: commandID,
+		inputID:   commandID,
+		jsonPath:  commandPath,
+		surfaces:  cliManifestSurfaceSelectors(c.policy, commandID),
+		literals:  c.commandLiterals(entry.value),
+	}
 	c.visitGuidanceFields(entry.value, context)
 	c.visitLifecycle(entry.value, context)
 	if visibility.hidden {
@@ -737,6 +722,8 @@ func (c *cliManifestCollector) visitDocumentationField(copy *cliJSONValue, conte
 			commandID: context.commandID,
 			inputID:   inputID,
 			jsonPath:  valuePath,
+			surfaces:  context.surfaces,
+			literals:  context.literals,
 		})
 	}
 }
@@ -757,7 +744,7 @@ func (c *cliManifestCollector) visitDocumentationExamples(documentation *cliJSON
 			c.issue(example, contextWithPath(context, path), fmt.Sprintf("JSON path %s must be a string", path))
 			continue
 		}
-		c.addExampleComments(example, context.commandID, context.commandID+".documentation.example."+strconv.Itoa(index), path)
+		c.addExampleComments(example, context, context.commandID+".documentation.example."+strconv.Itoa(index), path)
 	}
 }
 
@@ -783,10 +770,10 @@ func (c *cliManifestCollector) visitUsage(command *cliJSONValue, context cliMani
 		c.issue(example, contextWithPath(context, examplePath), fmt.Sprintf("JSON path %s must be a string", examplePath))
 		return
 	}
-	c.addExampleComments(example, context.commandID, context.commandID+".usage.example", examplePath)
+	c.addExampleComments(example, context, context.commandID+".usage.example", examplePath)
 }
 
-func (c *cliManifestCollector) addExampleComments(node *cliJSONValue, commandID, inputID, path string) {
+func (c *cliManifestCollector) addExampleComments(node *cliJSONValue, context cliManifestContext, inputID, path string) {
 	value := node.stringValue
 	for lineStart := 0; lineStart < len(value); {
 		lineEnd := strings.IndexByte(value[lineStart:], '\n')
@@ -808,11 +795,10 @@ func (c *cliManifestCollector) addExampleComments(node *cliJSONValue, commandID,
 			if contentStart < contentEnd && value[contentStart] == ' ' {
 				contentStart++
 			}
-			c.addStringSpan(node, contentStart, contentEnd, ContentClassProcedural, cliManifestContext{
-				commandID: commandID,
-				inputID:   inputID,
-				jsonPath:  path,
-			})
+			spanContext := context
+			spanContext.inputID = inputID
+			spanContext.jsonPath = path
+			c.addStringSpan(node, contentStart, contentEnd, ContentClassProcedural, spanContext)
 		}
 		if lineEnd == len(value) {
 			break
@@ -841,13 +827,21 @@ func (c *cliManifestCollector) visitInputRecords(command *cliJSONValue, context 
 		if !hasID || strings.TrimSpace(inputID) == "" {
 			inputID = entry.key
 		}
-		inputContext := cliManifestContext{commandID: context.commandID, inputID: inputID, jsonPath: path}
+		inputContext := cliManifestContext{
+			commandID: context.commandID,
+			inputID:   inputID,
+			jsonPath:  path,
+			surfaces:  context.surfaces,
+			literals:  c.inputLiterals(context, entry.value),
+		}
 		visibility := c.recordVisibility(entry.value, path, inputContext)
 		if usage, present, usageNode := c.stringField(entry.value, "usage", cliJSONPointerFromPath(path, "usage"), inputContext, false); present && !visibility.hidden {
 			c.addStringSpan(usageNode, 0, len(usage), ContentClassProcedural, cliManifestContext{
 				commandID: context.commandID,
 				inputID:   inputID,
 				jsonPath:  cliJSONPointerFromPath(path, "usage"),
+				surfaces:  inputContext.surfaces,
+				literals:  inputContext.literals,
 			})
 		}
 		c.visitGuidanceFields(entry.value, inputContext)
@@ -866,6 +860,8 @@ func (c *cliManifestCollector) visitGuidanceFields(record *cliJSONValue, context
 			commandID: context.commandID,
 			inputID:   context.inputID + "." + key,
 			jsonPath:  path,
+			surfaces:  context.surfaces,
+			literals:  context.literals,
 		})
 	}
 }
@@ -888,6 +884,8 @@ func (c *cliManifestCollector) visitLifecycle(record *cliJSONValue, context cliM
 				commandID: context.commandID,
 				inputID:   context.inputID + "." + key,
 				jsonPath:  valuePath,
+				surfaces:  context.surfaces,
+				literals:  context.literals,
 			})
 		}
 	}
@@ -910,6 +908,8 @@ func (c *cliManifestCollector) visitLifecycle(record *cliJSONValue, context cliM
 			commandID: context.commandID,
 			inputID:   context.inputID + ".successor",
 			jsonPath:  guidancePath,
+			surfaces:  context.surfaces,
+			literals:  context.literals,
 		})
 	}
 }
@@ -926,73 +926,4 @@ func cliJSONPointerFromPath(path string, parts ...string) string {
 		return cliJSONPointer(parts...)
 	}
 	return path + cliJSONPointer(parts...)
-}
-
-func cliManifestLiterals(root *cliJSONValue) []string {
-	var literals []string
-	var visit func(*cliJSONValue, string)
-	visit = func(value *cliJSONValue, key string) {
-		if value == nil {
-			return
-		}
-		switch value.kind {
-		case cliJSONString:
-			if cliLiteralField(key) {
-				literals = append(literals, value.stringValue)
-			}
-		case cliJSONObject:
-			for _, field := range value.fields {
-				visit(field.value, field.key)
-			}
-		case cliJSONArray:
-			for _, item := range value.elements {
-				visit(item, key)
-			}
-		}
-	}
-	visit(root, "")
-	return uniqueCLIStrings(literals)
-}
-
-func cliLiteralField(key string) bool {
-	switch key {
-	case "id", "name", "path", "long", "shorthand", "aliases", "targetItemId", "operationId", "code", "default", "provider", "model", "providerName", "modelName", "event", "schema":
-		return true
-	default:
-		return false
-	}
-}
-
-func cliPolicyLiterals(policy Policy) []string {
-	var literals []string
-	for _, term := range policy.Terms {
-		if term.Category != "command" && term.Category != "protected-literal" {
-			continue
-		}
-		literals = append(literals, term.Canonical)
-		for _, form := range term.ApprovedForms {
-			literals = append(literals, form)
-		}
-	}
-	return uniqueCLIStrings(literals)
-}
-
-func uniqueCLIStrings(values []string) []string {
-	seen := make(map[string]bool, len(values))
-	result := make([]string, 0, len(values))
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" || seen[value] {
-			continue
-		}
-		seen[value] = true
-		result = append(result, value)
-	}
-	slices.SortStableFunc(result, func(left, right string) int {
-		if len(left) != len(right) {
-			return len(right) - len(left)
-		}
-		return strings.Compare(left, right)
-	})
-	return result
 }

--- a/cmd/prosecheck/cli_manifest_context.go
+++ b/cmd/prosecheck/cli_manifest_context.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"slices"
+	"strings"
+	"unicode"
+)
+
+type cliManifestContext struct {
+	commandID string
+	inputID   string
+	jsonPath  string
+	surfaces  []string
+	literals  []string
+}
+
+func cliManifestSurfaceSelectors(policy Policy, commandID string) []string {
+	surfaces := []string{surfaceCLIHelp}
+	for _, term := range policy.Terms {
+		if cliCommandSubjectMatches(commandID, term) {
+			surfaces = append(surfaces, term.Surfaces...)
+		}
+	}
+	return uniqueCLIStrings(surfaces)
+}
+
+func cliCommandSubjectMatches(commandID string, term Term) bool {
+	words := strings.FieldsFunc(strings.ToLower(commandID), func(value rune) bool {
+		return !unicode.IsLetter(value) && !unicode.IsDigit(value)
+	})
+	if len(words) == 0 {
+		return false
+	}
+	for _, spelling := range termSpellings(term) {
+		spellingWords := strings.FieldsFunc(strings.ToLower(spelling), func(value rune) bool {
+			return !unicode.IsLetter(value) && !unicode.IsDigit(value)
+		})
+		if len(spellingWords) == 0 || len(words) < len(spellingWords) {
+			continue
+		}
+		for start := 0; start <= len(words)-len(spellingWords); start++ {
+			matched := true
+			for index, word := range spellingWords {
+				if words[start+index] != word {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (c *cliManifestCollector) commandLiterals(command *cliJSONValue) []string {
+	literals := cliManifestLiterals(command)
+	literals = append(literals, cliPolicyLiterals(c.policy)...)
+	return uniqueCLIStrings(literals)
+}
+
+func (c *cliManifestCollector) inputLiterals(context cliManifestContext, input *cliJSONValue) []string {
+	literals := append([]string(nil), context.literals...)
+	literals = append(literals, cliManifestLiterals(input)...)
+	return uniqueCLIStrings(literals)
+}
+
+func cliManifestLiterals(root *cliJSONValue) []string {
+	var literals []string
+	var visit func(*cliJSONValue, string)
+	visit = func(value *cliJSONValue, key string) {
+		if value == nil {
+			return
+		}
+		switch value.kind {
+		case cliJSONString:
+			if cliLiteralField(key) {
+				literals = append(literals, value.stringValue)
+			}
+		case cliJSONObject:
+			for _, field := range value.fields {
+				visit(field.value, field.key)
+			}
+		case cliJSONArray:
+			for _, item := range value.elements {
+				visit(item, key)
+			}
+		}
+	}
+	visit(root, "")
+	return uniqueCLIStrings(literals)
+}
+
+func cliLiteralField(key string) bool {
+	switch key {
+	case "id", "name", "path", "long", "shorthand", "aliases", "targetItemId", "operationId", "code", "default", "provider", "model", "providerName", "modelName", "event", "schema":
+		return true
+	default:
+		return false
+	}
+}
+
+func cliPolicyLiterals(policy Policy) []string {
+	var literals []string
+	for _, term := range policy.Terms {
+		if term.Category != "command" && term.Category != "protected-literal" {
+			continue
+		}
+		literals = append(literals, term.Canonical)
+		for _, form := range term.ApprovedForms {
+			literals = append(literals, form)
+		}
+	}
+	return uniqueCLIStrings(literals)
+}
+
+func uniqueCLIStrings(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	slices.SortStableFunc(result, func(left, right string) int {
+		if len(left) != len(right) {
+			return len(right) - len(left)
+		}
+		return strings.Compare(left, right)
+	})
+	return result
+}

--- a/cmd/prosecheck/cli_manifest_protection.go
+++ b/cmd/prosecheck/cli_manifest_protection.go
@@ -52,26 +52,6 @@ func cliRegexRanges(text string, pattern *regexp.Regexp) []TextRange {
 	return ranges
 }
 
-func cliLiteralRanges(text, literal string) []TextRange {
-	if literal == "" || len(literal) > len(text) {
-		return nil
-	}
-	var ranges []TextRange
-	for search := 0; search <= len(text)-len(literal); {
-		index := strings.Index(text[search:], literal)
-		if index < 0 {
-			break
-		}
-		index += search
-		end := index + len(literal)
-		if cliLiteralBoundary(text, index, end, literal) {
-			ranges = append(ranges, TextRange{Start: index, End: end})
-		}
-		search = index + 1
-	}
-	return ranges
-}
-
 func cliLiteralBoundary(text string, start, end int, literal string) bool {
 	if len(literal) == 0 {
 		return false

--- a/cmd/prosecheck/cli_manifest_protection.go
+++ b/cmd/prosecheck/cli_manifest_protection.go
@@ -40,9 +40,6 @@ func cliProtectedRanges(text string, literals []string) []TextRange {
 	ranges = append(ranges, cliStructuredLineRanges(text)...)
 	ranges = append(ranges, cliQuotedOutputRanges(text)...)
 	ranges = append(ranges, cliRegexRanges(text, cliQuotedTechnical)...)
-	for _, literal := range literals {
-		ranges = append(ranges, cliLiteralRanges(text, literal)...)
-	}
 	return mergeCLIRanges(ranges)
 }
 

--- a/cmd/prosecheck/cli_manifest_protection.go
+++ b/cmd/prosecheck/cli_manifest_protection.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"regexp"
+	"slices"
+	"strings"
+	"unicode/utf8"
+)
+
+var (
+	cliFlagPattern        = regexp.MustCompile(`--[A-Za-z0-9][A-Za-z0-9-]*`)
+	cliShortFlagPattern   = regexp.MustCompile(`(?:^|[\s([<])-[A-Za-z][A-Za-z0-9-]*`)
+	cliPlaceholderPattern = regexp.MustCompile(`<[^>\r\n]{1,80}>`)
+	cliPathPattern        = regexp.MustCompile(`(?:\./|\.\./|~/|/|[A-Za-z]:[\\/])[^\s,;!?)]*`)
+	cliIdentifierPattern  = regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9]*(?:[._][A-Za-z0-9_-]+)+\b`)
+	cliCamelCasePattern   = regexp.MustCompile(`\b[A-Za-z]+[a-z][A-Z][A-Za-z0-9]*\b`)
+	cliSnakePattern       = regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)+\b`)
+	cliErrorCodePattern   = regexp.MustCompile(`\b(?:[A-Z][A-Z0-9]*[-_]){1,}[A-Z0-9]+\b`)
+	cliProviderPattern    = regexp.MustCompile(`(?i)\b(?:codex|cursor(?:-acp)?|openai|anthropic|ollama|gpt(?:-[A-Za-z0-9.]+)?)\b`)
+	cliStructuredPattern  = regexp.MustCompile(`^[- ]*[A-Za-z0-9_.-]+\s*:\s*(?:[\[{\"']|true\b|false\b|null\b|-?\d)`)
+	cliSchemePattern      = regexp.MustCompile(`(?i)\b(?:https?|ftp)://[^\s<>()]*`)
+	cliQuotedTechnical    = regexp.MustCompile(`(?i)"(?:error|fatal|usage|stdout|stderr):[^"\r\n]*"`)
+)
+
+func cliProtectedRanges(text string, literals []string) []TextRange {
+	ranges := append([]TextRange(nil), LexicalProtectedRanges(text)...)
+	ranges = append(ranges, cliRegexRanges(text, cliFlagPattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliShortFlagPattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliPlaceholderPattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliPathPattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliIdentifierPattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliCamelCasePattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliSnakePattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliErrorCodePattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliProviderPattern)...)
+	ranges = append(ranges, cliRegexRanges(text, cliSchemePattern)...)
+	ranges = append(ranges, markdownRouteRanges(text)...)
+	ranges = append(ranges, markdownCommandLineRanges(text)...)
+	ranges = append(ranges, cliCommandLiteralLineRanges(text, literals)...)
+	ranges = append(ranges, cliStructuredLineRanges(text)...)
+	ranges = append(ranges, cliQuotedOutputRanges(text)...)
+	ranges = append(ranges, cliRegexRanges(text, cliQuotedTechnical)...)
+	for _, literal := range literals {
+		ranges = append(ranges, cliLiteralRanges(text, literal)...)
+	}
+	return mergeCLIRanges(ranges)
+}
+
+func cliRegexRanges(text string, pattern *regexp.Regexp) []TextRange {
+	matches := pattern.FindAllStringIndex(text, -1)
+	ranges := make([]TextRange, 0, len(matches))
+	for _, match := range matches {
+		ranges = append(ranges, TextRange{Start: match[0], End: match[1]})
+	}
+	return ranges
+}
+
+func cliLiteralRanges(text, literal string) []TextRange {
+	if literal == "" || len(literal) > len(text) {
+		return nil
+	}
+	var ranges []TextRange
+	for search := 0; search <= len(text)-len(literal); {
+		index := strings.Index(text[search:], literal)
+		if index < 0 {
+			break
+		}
+		index += search
+		end := index + len(literal)
+		if cliLiteralBoundary(text, index, end, literal) {
+			ranges = append(ranges, TextRange{Start: index, End: end})
+		}
+		search = index + 1
+	}
+	return ranges
+}
+
+func cliLiteralBoundary(text string, start, end int, literal string) bool {
+	if len(literal) == 0 {
+		return false
+	}
+	if isIdentifierRune(rune(literal[0])) && start > 0 {
+		previous, _ := utf8.DecodeLastRuneInString(text[:start])
+		if isIdentifierRune(previous) {
+			return false
+		}
+	}
+	if isIdentifierRune(rune(literal[len(literal)-1])) && end < len(text) {
+		next, _ := utf8.DecodeRuneInString(text[end:])
+		if isIdentifierRune(next) {
+			return false
+		}
+	}
+	return true
+}
+
+func cliStructuredLineRanges(text string) []TextRange {
+	var ranges []TextRange
+	for start := 0; start < len(text); {
+		end := strings.IndexByte(text[start:], '\n')
+		if end < 0 {
+			end = len(text)
+		} else {
+			end += start
+		}
+		line := strings.TrimSpace(strings.TrimSuffix(text[start:end], "\r"))
+		if cliLooksLikeStructuredLine(line) {
+			ranges = append(ranges, TextRange{Start: start, End: end})
+		}
+		if end == len(text) {
+			break
+		}
+		start = end + 1
+	}
+	return ranges
+}
+
+func cliLooksLikeStructuredLine(line string) bool {
+	if line == "" || strings.HasPrefix(line, "#") {
+		return false
+	}
+	if strings.HasPrefix(line, "{") || strings.HasPrefix(line, "}") || strings.HasPrefix(line, "[") || strings.HasPrefix(line, "]") {
+		return true
+	}
+	if strings.Contains(line, `":`) || strings.Contains(line, "':") {
+		return true
+	}
+	return cliStructuredPattern.MatchString(line)
+}
+
+func cliQuotedOutputRanges(text string) []TextRange {
+	pattern := regexp.MustCompile(`(?im)^\s*(?:error|fatal|usage|exit status|stdout|stderr)\s*:\s*\S[^\r\n]*`)
+	return cliRegexRanges(text, pattern)
+}
+
+func cliCommandLiteralLineRanges(text string, literals []string) []TextRange {
+	var ranges []TextRange
+	for lineStart := 0; lineStart < len(text); {
+		lineEnd := strings.IndexByte(text[lineStart:], '\n')
+		if lineEnd < 0 {
+			lineEnd = len(text)
+		} else {
+			lineEnd += lineStart
+		}
+		line := strings.TrimSuffix(text[lineStart:lineEnd], "\r")
+		leading := len(line) - len(strings.TrimLeft(line, " \t"))
+		trimmed := line[leading:]
+		for _, literal := range literals {
+			if !strings.Contains(literal, " ") || !strings.HasPrefix(literal, "you ") || !strings.HasPrefix(trimmed, literal) {
+				continue
+			}
+			if cliLiteralBoundary(trimmed, 0, len(literal), literal) {
+				ranges = append(ranges, TextRange{Start: lineStart + leading, End: lineEnd})
+				break
+			}
+		}
+		if lineEnd == len(text) {
+			break
+		}
+		lineStart = lineEnd + 1
+	}
+	return ranges
+}
+
+func mergeCLIRanges(ranges []TextRange) []TextRange {
+	ordered := append([]TextRange(nil), ranges...)
+	slices.SortStableFunc(ordered, func(left, right TextRange) int {
+		if left.Start != right.Start {
+			return left.Start - right.Start
+		}
+		return left.End - right.End
+	})
+	merged := make([]TextRange, 0, len(ordered))
+	for _, item := range ordered {
+		if item.Start < 0 || item.End <= item.Start {
+			continue
+		}
+		if len(merged) == 0 || item.Start > merged[len(merged)-1].End {
+			merged = append(merged, item)
+			continue
+		}
+		if item.End > merged[len(merged)-1].End {
+			merged[len(merged)-1].End = item.End
+		}
+	}
+	return merged
+}

--- a/cmd/prosecheck/cli_manifest_test.go
+++ b/cmd/prosecheck/cli_manifest_test.go
@@ -81,6 +81,21 @@ const cliManifestFixture = `{
   }
 }`
 
+const ambiguousCLIManifestFixture = `{
+  "commands": {
+    "you.status": {
+      "id": "you.status",
+      "visibility": "visible",
+      "documentation": {
+        "documentation": {
+          "title": {"id": "you.status.title", "canonicalEnglish": "Status"},
+          "description": {"id": "you.status.description", "canonicalEnglish": "The active service is running before you place the file."}
+        }
+      }
+    }
+  }
+}`
+
 func TestAnalyzeCLIManifestExtractsVisibleFieldsAndLifecycleGuidance(t *testing.T) {
 	policy := loadRepositoryPolicy(t)
 	findings := AnalyzeCLIManifest(`.\contracts\cli\commands.json`, []byte(cliManifestFixture), policy)
@@ -161,6 +176,14 @@ func TestAnalyzeCLIManifestProtectsAuthoredTechnicalLiterals(t *testing.T) {
 	findings := AnalyzeCLIManifest("contracts/cli/commands.json", []byte(fixture), policy)
 	if len(findings) != 0 {
 		t.Fatalf("technical CLI literals produced findings: %#v", findings)
+	}
+}
+
+func TestAnalyzeCLIManifestDeclinesAmbiguousRegisterTermsOutsideTheirSurfaces(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	findings := AnalyzeCLIManifest("contracts/cli/commands.json", []byte(ambiguousCLIManifestFixture), policy)
+	if len(findings) != 0 {
+		t.Fatalf("ambiguous ordinary words produced terminology findings: %#v", findings)
 	}
 }
 
@@ -251,5 +274,13 @@ func TestRunDispatchesAuthoredCLIManifestAndRejectsGeneratedProjection(t *testin
 	err = run([]string{"-standard", standardPath, "-terms", termsPath, generated}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "generated CLI projection") {
 		t.Fatalf("run(generated projection) error = %v, want explicit authoring-input rejection", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	t.Chdir(root)
+	err = run([]string{"-standard", standardPath, "-terms", termsPath, "packages/api/generated/cli/commands.json"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "generated CLI projection") {
+		t.Fatalf("run(repo-relative generated projection) error = %v, want rejection before read", err)
 	}
 }

--- a/cmd/prosecheck/cli_manifest_test.go
+++ b/cmd/prosecheck/cli_manifest_test.go
@@ -96,6 +96,33 @@ const ambiguousCLIManifestFixture = `{
   }
 }`
 
+const scopedLiteralCLIManifestFixture = `{
+  "commands": {
+    "you.status": {
+      "id": "you.status",
+      "visibility": "visible",
+      "documentation": {
+        "documentation": {
+          "title": {"id": "you.status.title", "canonicalEnglish": "Status"},
+          "description": {"id": "you.status.description", "canonicalEnglish": "The active service is running before you place the file."}
+        }
+      }
+    },
+    "you.work": {
+      "id": "you.work",
+      "visibility": "visible",
+      "name": "work",
+      "documentation": {
+        "documentation": {
+          "title": {"id": "you.work.title", "canonicalEnglish": "work"},
+          "description": {"id": "you.work.description", "canonicalEnglish": "Inspect work before you submit the next item."}
+        }
+      },
+      "usage": {"example": "  # you work --help\n"}
+    }
+  }
+}`
+
 func TestAnalyzeCLIManifestExtractsVisibleFieldsAndLifecycleGuidance(t *testing.T) {
 	policy := loadRepositoryPolicy(t)
 	findings := AnalyzeCLIManifest(`.\contracts\cli\commands.json`, []byte(cliManifestFixture), policy)
@@ -184,6 +211,30 @@ func TestAnalyzeCLIManifestDeclinesAmbiguousRegisterTermsOutsideTheirSurfaces(t 
 	findings := AnalyzeCLIManifest("contracts/cli/commands.json", []byte(ambiguousCLIManifestFixture), policy)
 	if len(findings) != 0 {
 		t.Fatalf("ambiguous ordinary words produced terminology findings: %#v", findings)
+	}
+}
+
+func TestAnalyzeCLIManifestScopesLiteralsAndRetainsCommandSubjectTerms(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	findings := AnalyzeCLIManifest("contracts/cli/commands.json", []byte(scopedLiteralCLIManifestFixture), policy)
+	var workFindings int
+	for _, finding := range findings {
+		if strings.Contains(finding.Identity, "command=you.status") {
+			if finding.RuleID == RuleTermCase || finding.RuleID == RulePublicTerm {
+				t.Fatalf("status prose produced ambiguous terminology finding: %#v", finding)
+			}
+		}
+		if strings.Contains(finding.Identity, "command=you.work") && finding.RuleID == RuleTermCase && finding.Excerpt == "work" {
+			workFindings++
+		}
+	}
+	if workFindings == 0 {
+		t.Fatalf("command subject lost product Work term finding: %#v", findings)
+	}
+	for _, finding := range findings {
+		if strings.Contains(finding.Identity, "you.work.usage.example") {
+			t.Fatalf("command example literal was analyzed as prose: %#v", finding)
+		}
 	}
 }
 

--- a/cmd/prosecheck/cli_manifest_test.go
+++ b/cmd/prosecheck/cli_manifest_test.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const cliManifestFixture = `{
+  "formatVersion": "1.0.0",
+  "rootPath": "you",
+  "commands": {
+    "you.good": {
+      "id": "you.good",
+      "visibility": "visible",
+      "documentation": {
+        "documentation": {
+          "visibility": "public",
+          "title": {
+            "id": "you.good.title",
+            "canonicalEnglish": "Start Factory"
+          },
+          "description": {
+            "id": "you.good.description",
+            "canonicalEnglish": "The Factory doesn't stop."
+          }
+        },
+        "examples": [
+          "you good --flag <value>"
+        ]
+      },
+      "usage": {
+        "line": "you good",
+        "example": "  # The Factory doesn't stop.\n  you good --flag <value>\n"
+      },
+      "flags": {
+        "you.good.flag.server": {
+          "id": "you.good.flag.server",
+          "visibility": "visible",
+          "usage": "Use --server; continue."
+        }
+      },
+      "arguments": {
+        "you.good.arg.0": {
+          "id": "you.good.arg.0",
+          "visibility": "visible",
+          "name": "factory-path",
+          "usage": "Use the path."
+        }
+      },
+      "lifecycle": {
+        "state": "active"
+      }
+    },
+    "you.hidden": {
+      "id": "you.hidden",
+      "visibility": "hidden",
+      "documentation": {
+        "documentation": {
+          "title": {
+            "id": "you.hidden.title",
+            "canonicalEnglish": "The Factory doesn't stop."
+          },
+          "description": {
+            "id": "you.hidden.description",
+            "canonicalEnglish": "The hidden command doesn't stop."
+          }
+        }
+      },
+      "lifecycle": {
+        "state": "deprecated",
+        "successor": {
+          "targetItemId": "you.good",
+          "canonicalEnglish": "Use the old command; replace it."
+        }
+      }
+    }
+  }
+}`
+
+func TestAnalyzeCLIManifestExtractsVisibleFieldsAndLifecycleGuidance(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	findings := AnalyzeCLIManifest(`.\contracts\cli\commands.json`, []byte(cliManifestFixture), policy)
+	if len(findings) != 4 {
+		t.Fatalf("AnalyzeCLIManifest() returned %d findings: %#v", len(findings), findings)
+	}
+
+	want := []struct {
+		rule     RuleID
+		class    ContentClass
+		excerpt  string
+		inputID  string
+		jsonPath string
+	}{
+		{RuleContraction, ContentClassDescriptive, "doesn't", "you.good.description", "/commands/you.good/documentation/documentation/description/canonicalEnglish"},
+		{RuleContraction, ContentClassProcedural, "doesn't", "you.good.usage.example", "/commands/you.good/usage/example"},
+		{RuleSemicolon, ContentClassProcedural, ";", "you.good.flag.server", "/commands/you.good/flags/you.good.flag.server/usage"},
+		{RuleSemicolon, ContentClassProcedural, ";", "you.hidden.successor", "/commands/you.hidden/lifecycle/successor/canonicalEnglish"},
+	}
+	for index, expected := range want {
+		finding := findings[index]
+		if finding.RuleID != expected.rule || finding.ContentClass != expected.class || finding.Excerpt != expected.excerpt {
+			t.Fatalf("finding %d = %#v, want rule=%s class=%s excerpt=%q", index, finding, expected.rule, expected.class, expected.excerpt)
+		}
+		if !strings.Contains(finding.Identity, "command=") || !strings.Contains(finding.Identity, "input="+expected.inputID) || !strings.Contains(finding.Identity, "json="+expected.jsonPath) {
+			t.Fatalf("finding %d identity = %q, want command, input, and JSON location %q", index, finding.Identity, expected.jsonPath)
+		}
+		if finding.SourcePath != "contracts/cli/commands.json" || finding.StartLine < 1 || finding.StartColumn < 1 || finding.EndLine < finding.StartLine || finding.EndColumn < 1 {
+			t.Fatalf("finding %d source location = %#v, want normalized manifest location", index, finding)
+		}
+		assertStableFingerprint(t, finding)
+	}
+	if strings.Contains(findings[0].Identity, "you.hidden") || strings.Contains(findings[1].Identity, "you.hidden") {
+		t.Fatalf("hidden command documentation was analyzed: %#v", findings)
+	}
+}
+
+func TestExtractCLIManifestSpansPreservesAuthoredInputsAndLocations(t *testing.T) {
+	spans, err := ExtractCLIManifestSpans("contracts/cli/commands.json", []byte(cliManifestFixture))
+	if err != nil {
+		t.Fatalf("ExtractCLIManifestSpans() error = %v", err)
+	}
+	want := map[string]struct {
+		class ContentClass
+		line  int
+	}{
+		"json=/commands/you.good/documentation/documentation/title/canonicalEnglish":       {ContentClassLabel, 13},
+		"json=/commands/you.good/documentation/documentation/description/canonicalEnglish": {ContentClassDescriptive, 17},
+		"json=/commands/you.good/usage/example":                                            {ContentClassProcedural, 26},
+		"json=/commands/you.good/flags/you.good.flag.server/usage":                         {ContentClassProcedural, 32},
+		"json=/commands/you.good/arguments/you.good.arg.0/usage":                           {ContentClassProcedural, 40},
+		"json=/commands/you.hidden/lifecycle/successor/canonicalEnglish":                   {ContentClassProcedural, 66},
+	}
+	seen := make(map[string]bool, len(spans))
+	for _, span := range spans {
+		for suffix, expected := range want {
+			if !strings.HasSuffix(span.Identity, suffix) {
+				continue
+			}
+			seen[suffix] = true
+			if span.Class != expected.class || span.StartLine != expected.line || span.StartColumn < 1 || len(span.Protected) == 0 && strings.Contains(span.Text, "--") {
+				t.Fatalf("span %q = %#v, want class=%s line=%d and known column", suffix, span, expected.class, expected.line)
+			}
+		}
+	}
+	for suffix := range want {
+		if !seen[suffix] {
+			t.Fatalf("missing extracted span ending in %q: %#v", suffix, spans)
+		}
+	}
+}
+
+func TestAnalyzeCLIManifestProtectsAuthoredTechnicalLiterals(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	fixture := strings.ReplaceAll(cliManifestFixture, "The Factory doesn't stop.", "Use you good --flag <value> at https://example.com/api and POST /factory-sessions with FACTORY_REQUEST_BATCH, codex, -d \\\"error: doesn't stop\\\".")
+	fixture = strings.Replace(fixture, "Use --server; continue.", "Use --server at ./factory/factory.json with error INVOCATION_INPUT_SOURCE_CONFLICT.", 1)
+	fixture = strings.Replace(fixture, "Use the old command; replace it.", "Use you good --flag <value> at https://example.com/api.", 1)
+	findings := AnalyzeCLIManifest("contracts/cli/commands.json", []byte(fixture), policy)
+	if len(findings) != 0 {
+		t.Fatalf("technical CLI literals produced findings: %#v", findings)
+	}
+}
+
+func TestAnalyzeCLIManifestReportsAllSafeParseFailuresAndContinues(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	fixture := `{
+  "commands": {
+    "bad": {
+      "id": "bad",
+      "visibility": "visible",
+      "documentation": 7,
+      "flags": {
+        "bad.flag": "not an object"
+      }
+    },
+    "good": {
+      "id": "good",
+      "visibility": "visible",
+      "documentation": {
+        "documentation": {
+          "title": {"id": "good.title", "canonicalEnglish": "Good"},
+          "description": {"id": "good.description", "canonicalEnglish": "The Factory doesn't stop."}
+        }
+      }
+    }
+  }
+}`
+	findings := AnalyzeCLIManifest("contracts/cli/commands.json", []byte(fixture), policy)
+	var parseCount, contractionCount int
+	for _, finding := range findings {
+		if finding.RuleID == RuleParse {
+			parseCount++
+		}
+		if finding.RuleID == RuleContraction {
+			contractionCount++
+		}
+	}
+	if parseCount != 2 || contractionCount != 1 {
+		t.Fatalf("parse/valid findings = %#v, want two B-PARSE findings and one valid-command contraction", findings)
+	}
+	for _, finding := range findings {
+		if finding.RuleID == RuleParse && !strings.Contains(finding.Identity, "command=bad") {
+			t.Fatalf("parse finding identity = %q, want bad command identity", finding.Identity)
+		}
+	}
+
+	malformed := []byte(`{"commands":{"you.bad":`)
+	findings = AnalyzeCLIManifest("contracts/cli/commands.json", malformed, policy)
+	if len(findings) != 1 || findings[0].RuleID != RuleParse || !strings.Contains(findings[0].SourcePath, "contracts/cli/commands.json") {
+		t.Fatalf("malformed JSON findings = %#v, want one manifest-scoped B-PARSE finding", findings)
+	}
+}
+
+func TestAnalyzeCLIManifestIsReadOnlyAndStableAcrossLineEndingsAndRepeatedRuns(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	data := []byte(cliManifestFixture)
+	before := append([]byte(nil), data...)
+	first := AnalyzeCLIManifest("contracts/cli/commands.json", data, policy)
+	second := AnalyzeCLIManifest("contracts/cli/commands.json", data, policy)
+	if !reflect.DeepEqual(first, second) || !bytes.Equal(data, before) {
+		t.Fatalf("repeated analysis changed output or input: first=%#v second=%#v inputChanged=%t", first, second, !bytes.Equal(data, before))
+	}
+
+	windows := strings.ReplaceAll(cliManifestFixture, "\n", "\r\n")
+	windowFindings := AnalyzeCLIManifest("contracts/cli/commands.json", []byte(windows), policy)
+	if !reflect.DeepEqual(first, windowFindings) {
+		t.Fatalf("line endings changed findings:\nLF=%#v\r\nCRLF=%#v", first, windowFindings)
+	}
+}
+
+func TestRunDispatchesAuthoredCLIManifestAndRejectsGeneratedProjection(t *testing.T) {
+	root := t.TempDir()
+	authored := filepath.Join(root, "contracts", "cli", "commands.json")
+	if err := os.MkdirAll(filepath.Dir(authored), 0o700); err != nil {
+		t.Fatalf("mkdir manifest fixture: %v", err)
+	}
+	if err := os.WriteFile(authored, []byte(cliManifestFixture), 0o600); err != nil {
+		t.Fatalf("write manifest fixture: %v", err)
+	}
+	standardPath, termsPath := repositoryPolicyPaths(t)
+	var stdout, stderr bytes.Buffer
+	err := run([]string{"-standard", standardPath, "-terms", termsPath, authored}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "found 4 blocking finding") || stdout.Len() != 0 || !strings.Contains(stderr.String(), "[B-CONTRACTION]") {
+		t.Fatalf("run(authored manifest) = err %v stdout %q stderr %q", err, stdout.String(), stderr.String())
+	}
+
+	generated := filepath.Join(root, "packages", "api", "generated", "cli", "commands.json")
+	err = run([]string{"-standard", standardPath, "-terms", termsPath, generated}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "generated CLI projection") {
+		t.Fatalf("run(generated projection) error = %v, want explicit authoring-input rejection", err)
+	}
+}

--- a/cmd/prosecheck/command_test.go
+++ b/cmd/prosecheck/command_test.go
@@ -17,6 +17,14 @@ type commandResult struct {
 	err    string
 }
 
+const mixedCrossAdapterGolden = `contracts/cli/commands.json:17:46 [B-CONTRACTION] descriptive: doesn't — Use the complete form instead of the contraction. (sha256:b16908890b2b74caa40231cbf8d779a37bcc4c06c076574e3bd220fbcb46b6ec)
+contracts/cli/commands.json:26:37 [B-CONTRACTION] procedural: doesn't — Use the complete form instead of the contraction. (sha256:44e0bec9761ea197fdf779e24b6b1196361547873ffa15a7cba2c6b86d1bef6d)
+contracts/cli/commands.json:32:33 [B-SEMICOLON] procedural: ; — Replace the semicolon with a full stop or separate the two ideas. (sha256:396f8e54707d485ce0f451850d2b8f550a31981e573e94a9c1f825c73dfded7f)
+contracts/cli/commands.json:66:51 [B-SEMICOLON] procedural: ; — Replace the semicolon with a full stop or separate the two ideas. (sha256:8b4a488a18edb0f85425a31169b62cf4695df8eb7a1e8b9c042abeca684f49e2)
+docs/guide.md:3:13 [B-CONTRACTION] descriptive: doesn't — Use the complete form instead of the contraction. (sha256:d0fa3040e1c1715b4b77170d6a44e734feb25d339c25df5c0e4eaa4d7085f7a6)
+docs/guide.md:3:25 [B-SEMICOLON] descriptive: ; — Replace the semicolon with a full stop or separate the two ideas. (sha256:844ec784321746a85031a8744b840756d2756b6a5d37f1b829dd9e613970b6f2)
+`
+
 func TestRunCrossAdapterFixtureHasStableMergedOutput(t *testing.T) {
 	standardPath, termsPath := writeCommandFixtures(t,
 		[]byte("# Guide\n\nThe service doesn't stop; now.\n"),
@@ -35,33 +43,8 @@ func TestRunCrossAdapterFixtureHasStableMergedOutput(t *testing.T) {
 		t.Fatalf("mixed fixture stdout = %q, want empty stdout", first.stdout)
 	}
 
-	standard, err := os.ReadFile(standardPath)
-	if err != nil {
-		t.Fatalf("read writing standard: %v", err)
-	}
-	terms, err := os.ReadFile(termsPath)
-	if err != nil {
-		t.Fatalf("read terminology register: %v", err)
-	}
-	policy, err := LoadPolicy(standard, terms)
-	if err != nil {
-		t.Fatalf("LoadPolicy(): %v", err)
-	}
-	manifest, err := os.ReadFile("contracts/cli/commands.json")
-	if err != nil {
-		t.Fatalf("read CLI fixture: %v", err)
-	}
-	markdown, err := os.ReadFile("docs/guide.md")
-	if err != nil {
-		t.Fatalf("read Markdown fixture: %v", err)
-	}
-	expectedFindings := append(AnalyzeCLIManifest("contracts/cli/commands.json", manifest, policy), AnalyzeMarkdown("docs/guide.md", markdown, policy)...)
-	var expected bytes.Buffer
-	if err := RenderFindings(&expected, expectedFindings); err != nil {
-		t.Fatalf("RenderFindings(expected): %v", err)
-	}
-	if first.stderr != expected.String() {
-		t.Fatalf("mixed fixture stderr differs from exact merged findings:\nwant=%q\ngot=%q", expected.String(), first.stderr)
+	if first.stderr != mixedCrossAdapterGolden {
+		t.Fatalf("mixed fixture stderr differs from independent golden:\nwant=%q\ngot=%q", mixedCrossAdapterGolden, first.stderr)
 	}
 
 	lines := strings.Split(strings.TrimSuffix(first.stderr, "\n"), "\n")

--- a/cmd/prosecheck/command_test.go
+++ b/cmd/prosecheck/command_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type commandResult struct {
+	stdout string
+	stderr string
+	err    string
+}
+
+func TestRunCrossAdapterFixtureHasStableMergedOutput(t *testing.T) {
+	standardPath, termsPath := writeCommandFixtures(t,
+		[]byte("# Guide\n\nThe service doesn't stop; now.\n"),
+		[]byte(cliManifestFixture),
+	)
+
+	first := runCommandFixture(t, standardPath, termsPath, "docs/guide.md", "contracts/cli/commands.json")
+	second := runCommandFixture(t, standardPath, termsPath, "contracts/cli/commands.json", "docs/guide.md")
+	if first != second {
+		t.Fatalf("input enumeration order changed command result:\nfirst=%#v\nsecond=%#v", first, second)
+	}
+	if first.err == "" || !strings.Contains(first.err, "found 6 blocking finding") {
+		t.Fatalf("mixed fixture error = %q, want six blocking findings", first.err)
+	}
+	if first.stdout != "" {
+		t.Fatalf("mixed fixture stdout = %q, want empty stdout", first.stdout)
+	}
+
+	standard, err := os.ReadFile(standardPath)
+	if err != nil {
+		t.Fatalf("read writing standard: %v", err)
+	}
+	terms, err := os.ReadFile(termsPath)
+	if err != nil {
+		t.Fatalf("read terminology register: %v", err)
+	}
+	policy, err := LoadPolicy(standard, terms)
+	if err != nil {
+		t.Fatalf("LoadPolicy(): %v", err)
+	}
+	manifest, err := os.ReadFile("contracts/cli/commands.json")
+	if err != nil {
+		t.Fatalf("read CLI fixture: %v", err)
+	}
+	markdown, err := os.ReadFile("docs/guide.md")
+	if err != nil {
+		t.Fatalf("read Markdown fixture: %v", err)
+	}
+	expectedFindings := append(AnalyzeCLIManifest("contracts/cli/commands.json", manifest, policy), AnalyzeMarkdown("docs/guide.md", markdown, policy)...)
+	var expected bytes.Buffer
+	if err := RenderFindings(&expected, expectedFindings); err != nil {
+		t.Fatalf("RenderFindings(expected): %v", err)
+	}
+	if first.stderr != expected.String() {
+		t.Fatalf("mixed fixture stderr differs from exact merged findings:\nwant=%q\ngot=%q", expected.String(), first.stderr)
+	}
+
+	lines := strings.Split(strings.TrimSuffix(first.stderr, "\n"), "\n")
+	wantOrder := []string{
+		"contracts/cli/commands.json:17:",
+		"contracts/cli/commands.json:26:",
+		"contracts/cli/commands.json:32:",
+		"contracts/cli/commands.json:66:",
+		"docs/guide.md:3:13 [B-CONTRACTION]",
+		"docs/guide.md:3:25 [B-SEMICOLON]",
+	}
+	if len(lines) != len(wantOrder) {
+		t.Fatalf("mixed fixture rendered %d lines, want %d: %q", len(lines), len(wantOrder), first.stderr)
+	}
+	for index, prefix := range wantOrder {
+		if !strings.HasPrefix(lines[index], prefix) {
+			t.Fatalf("rendered finding %d = %q, want prefix %q", index, lines[index], prefix)
+		}
+	}
+}
+
+func TestRunValidCrossAdapterFixtureIsStableReadOnlyAndOffline(t *testing.T) {
+	validManifest := strings.ReplaceAll(cliManifestFixture, "The Factory doesn't stop.", "The Factory is ready at https://example.com/api.")
+	validManifest = strings.ReplaceAll(validManifest, "Use --server; continue.", "Use --server and continue.")
+	validManifest = strings.ReplaceAll(validManifest, "Use the old command; replace it.", "Use the old command and replace it.")
+	standardPath, termsPath := writeCommandFixtures(t,
+		[]byte("# Guide\n\nUse `CPN; don't` at https://example.com/api.\n"),
+		[]byte(validManifest),
+	)
+
+	manifestBefore, manifestInfoBefore := snapshotCommandFixture(t, "contracts/cli/commands.json")
+	markdownBefore, markdownInfoBefore := snapshotCommandFixture(t, "docs/guide.md")
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = commandFailingTransport{}
+	t.Cleanup(func() { http.DefaultTransport = previousTransport })
+
+	first := runCommandFixture(t, standardPath, termsPath, "contracts/cli/commands.json", "docs/guide.md")
+	second := runCommandFixture(t, standardPath, termsPath, "contracts/cli/commands.json", "docs/guide.md")
+	if first != second {
+		t.Fatalf("repeated valid runs changed command result:\nfirst=%#v\nsecond=%#v", first, second)
+	}
+	if first.err != "" || first.stdout != "prosecheck passed (2 input(s))\n" || first.stderr != "" {
+		t.Fatalf("valid fixture result = %#v, want success with stable stdout", first)
+	}
+
+	manifestAfter, manifestInfoAfter := snapshotCommandFixture(t, "contracts/cli/commands.json")
+	markdownAfter, markdownInfoAfter := snapshotCommandFixture(t, "docs/guide.md")
+	if !bytes.Equal(manifestBefore, manifestAfter) || !bytes.Equal(markdownBefore, markdownAfter) {
+		t.Fatal("valid command run changed fixture bytes")
+	}
+	if manifestInfoBefore != manifestInfoAfter || markdownInfoBefore != markdownInfoAfter {
+		t.Fatalf("valid command run changed fixture metadata:\nbefore=%#v\nafter=%#v", []commandFixtureMetadata{manifestInfoBefore, markdownInfoBefore}, []commandFixtureMetadata{manifestInfoAfter, markdownInfoAfter})
+	}
+}
+
+func writeCommandFixtures(t *testing.T, markdown, manifest []byte) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	t.Chdir(root)
+	if err := os.MkdirAll(filepath.Dir("docs/guide.md"), 0o700); err != nil {
+		t.Fatalf("mkdir Markdown fixture: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir("contracts/cli/commands.json"), 0o700); err != nil {
+		t.Fatalf("mkdir CLI fixture: %v", err)
+	}
+	if err := os.WriteFile("docs/guide.md", markdown, 0o600); err != nil {
+		t.Fatalf("write Markdown fixture: %v", err)
+	}
+	if err := os.WriteFile("contracts/cli/commands.json", manifest, 0o600); err != nil {
+		t.Fatalf("write CLI fixture: %v", err)
+	}
+	standardPath, termsPath := repositoryPolicyPaths(t)
+	return standardPath, termsPath
+}
+
+func runCommandFixture(t *testing.T, standardPath, termsPath string, inputs ...string) commandResult {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	err := run(append([]string{"-standard", standardPath, "-terms", termsPath}, inputs...), &stdout, &stderr)
+	result := commandResult{stdout: stdout.String(), stderr: stderr.String()}
+	if err != nil {
+		result.err = err.Error()
+	}
+	return result
+}
+
+type commandFixtureMetadata struct {
+	name    string
+	mode    os.FileMode
+	size    int64
+	modTime time.Time
+	isDir   bool
+}
+
+func snapshotCommandFixture(t *testing.T, path string) ([]byte, commandFixtureMetadata) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", path, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat fixture %s: %v", path, err)
+	}
+	return data, commandFixtureMetadata{
+		name:    info.Name(),
+		mode:    info.Mode(),
+		size:    info.Size(),
+		modTime: info.ModTime(),
+		isDir:   info.IsDir(),
+	}
+}
+
+type commandFailingTransport struct{}
+
+func (commandFailingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("unexpected network access from prosecheck")
+}

--- a/cmd/prosecheck/golden_test.go
+++ b/cmd/prosecheck/golden_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// findingGolden contains every exported field in the Finding contract. The
+// expected values below are authored independently from the evaluator so a
+// refactor cannot make the oracle follow the implementation automatically.
+type findingGolden struct {
+	RuleID       RuleID
+	Severity     Severity
+	SourcePath   string
+	StartLine    int
+	StartColumn  int
+	EndLine      int
+	EndColumn    int
+	ContentClass ContentClass
+	Excerpt      string
+	Guidance     string
+	Fingerprint  string
+	Identity     string
+}
+
+func projectGolden(findings []Finding) []findingGolden {
+	result := make([]findingGolden, 0, len(findings))
+	for _, finding := range findings {
+		result = append(result, findingGolden{
+			RuleID:       finding.RuleID,
+			Severity:     finding.Severity,
+			SourcePath:   finding.SourcePath,
+			StartLine:    finding.StartLine,
+			StartColumn:  finding.StartColumn,
+			EndLine:      finding.EndLine,
+			EndColumn:    finding.EndColumn,
+			ContentClass: finding.ContentClass,
+			Excerpt:      finding.Excerpt,
+			Guidance:     finding.Guidance,
+			Fingerprint:  finding.Fingerprint,
+			Identity:     finding.Identity,
+		})
+	}
+	return result
+}
+
+func assertGoldenFindings(t *testing.T, got []Finding, want []findingGolden) {
+	t.Helper()
+	if projected := projectGolden(got); !reflect.DeepEqual(projected, want) {
+		t.Fatalf("findings differ from independent golden:\n got=%#v\nwant=%#v", projected, want)
+	}
+}
+
+func TestAnalyzeUsesIndependentGoldenForEverySupportedRule(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	spans := []Span{
+		{SourcePath: "golden/procedural.md", StartLine: 2, StartColumn: 3, Class: ContentClassProcedural, Text: "Run the command and inspect the result before you continue with the next required operation for this workflow today very carefully."},
+		{SourcePath: "golden/descriptive.md", StartLine: 3, StartColumn: 2, Class: ContentClassDescriptive, Text: "The service returns a detailed result that explains how the requested operation changes the current object and reports the observable state after completion for review today."},
+		{SourcePath: "golden/paragraph.md", StartLine: 4, StartColumn: 1, Class: ContentClassDescriptive, Text: "First sentence. Second sentence. Third sentence. Fourth sentence. Fifth sentence. Sixth sentence. Seventh sentence."},
+		{SourcePath: "golden/semicolon.md", StartLine: 5, StartColumn: 1, Class: ContentClassDescriptive, Text: "One idea; another idea."},
+		{SourcePath: "golden/contraction.md", StartLine: 6, StartColumn: 1, Class: ContentClassDescriptive, Text: "The service doesn't stop."},
+		{SourcePath: "golden/public-term.md", StartLine: 7, StartColumn: 1, Class: ContentClassDescriptive, Text: "The CPN is internal.", Surfaces: []string{surfaceCustomerDocumentation}},
+		{SourcePath: "golden/term-case.md", StartLine: 8, StartColumn: 1, Class: ContentClassDescriptive, Text: "the factory starts.", Surfaces: []string{surfaceCustomerDocumentation}},
+		{SourcePath: "golden/suppression.md", StartLine: 9, StartColumn: 1, Class: ContentClassDescriptive, Text: `<!-- prosecheck:ignore B-SEMICOLON owner="Docs" review="2026-12-31" -->`},
+		{SourcePath: "golden/parse.md", StartLine: 10, StartColumn: 1, Class: ContentClass("unknown"), Text: "unsafe"},
+	}
+	want := []findingGolden{
+		{RuleID: RuleContraction, Severity: SeverityBlocking, SourcePath: "golden/contraction.md", StartLine: 6, StartColumn: 13, EndLine: 6, EndColumn: 20, ContentClass: ContentClassDescriptive, Excerpt: "doesn't", Guidance: "Use the complete form instead of the contraction.", Fingerprint: "sha256:680e950532c42bc9baa12b73ad0c974a08680e1bc50966d31baa423afcce4fa0"},
+		{RuleID: RuleDescriptiveSentenceLength, Severity: SeverityBlocking, SourcePath: "golden/descriptive.md", StartLine: 3, StartColumn: 2, EndLine: 3, EndColumn: 176, ContentClass: ContentClassDescriptive, Excerpt: "The service returns a detailed result that explains how the requested operation changes the current object and reports the observable state after completion fo…", Guidance: "Shorten the descriptive sentence to 25 natural-language words or fewer.", Fingerprint: "sha256:57a2299c4bc33fdea9d90e89876e0253c2f2e954de49a348d7482a20ef4c4a34"},
+		{RuleID: RuleDescriptiveParagraphLength, Severity: SeverityBlocking, SourcePath: "golden/paragraph.md", StartLine: 4, StartColumn: 1, EndLine: 4, EndColumn: 116, ContentClass: ContentClassDescriptive, Excerpt: "First sentence. Second sentence. Third sentence. Fourth sentence. Fifth sentence. Sixth sentence. Seventh sentence.", Guidance: "Split the descriptive paragraph into no more than six sentences.", Fingerprint: "sha256:fb4efc51c36a81b1d304a3bf0e1653291cbc9f96b5392d1357694c4969a7162a"},
+		{RuleID: RuleParse, Severity: SeverityBlocking, SourcePath: "golden/parse.md", StartLine: 10, StartColumn: 1, EndLine: 10, EndColumn: 2, ContentClass: ContentClass("unknown"), Excerpt: `unknown content class "unknown"`, Guidance: "Fix the source so the analyzer can safely extract every prose span.", Fingerprint: "sha256:6964251ae6d290f4a4b8eaa5c0840bf7bb04fea73b35facaf6ca7b225ab5fcc5"},
+		{RuleID: RuleProceduralSentenceLength, Severity: SeverityBlocking, SourcePath: "golden/procedural.md", StartLine: 2, StartColumn: 3, EndLine: 2, EndColumn: 134, ContentClass: ContentClassProcedural, Excerpt: "Run the command and inspect the result before you continue with the next required operation for this workflow today very carefully.", Guidance: "Shorten the procedural sentence to 20 natural-language words or fewer.", Fingerprint: "sha256:92323a28fe678d6e2b14a81b8c7465099c631606bd8a84166383ece436817638"},
+		{RuleID: RulePublicTerm, Severity: SeverityBlocking, SourcePath: "golden/public-term.md", StartLine: 7, StartColumn: 5, EndLine: 7, EndColumn: 8, ContentClass: ContentClassDescriptive, Excerpt: "CPN", Guidance: "Use the approved customer term `Factory`.", Fingerprint: "sha256:86ab589f51aa90c3c434f6717872be26a46a3dab416bb59ef9a0d57b87be0933"},
+		{RuleID: RuleSemicolon, Severity: SeverityBlocking, SourcePath: "golden/semicolon.md", StartLine: 5, StartColumn: 9, EndLine: 5, EndColumn: 10, ContentClass: ContentClassDescriptive, Excerpt: ";", Guidance: "Replace the semicolon with a full stop or separate the two ideas.", Fingerprint: "sha256:fd84b1d99b6513e13b8d92d902e5f959bbe1ced4396214974202c8bb08bc2fa2"},
+		{RuleID: RuleSuppression, Severity: SeverityBlocking, SourcePath: "golden/suppression.md", StartLine: 9, StartColumn: 1, EndLine: 9, EndColumn: 72, ContentClass: ContentClassDescriptive, Excerpt: `<!-- prosecheck:ignore B-SEMICOLON owner="Docs" review="2026-12-31" -->`, Guidance: "Use one known rule, a bounded span, and a reason, owner, and review point.", Fingerprint: "sha256:f5d9b75baa67ea0658d9231b28a950d8bc9bbc710c30be4788de25f64f104c29"},
+		{RuleID: RuleTermCase, Severity: SeverityBlocking, SourcePath: "golden/term-case.md", StartLine: 8, StartColumn: 5, EndLine: 8, EndColumn: 12, ContentClass: ContentClassDescriptive, Excerpt: "factory", Guidance: "Use the canonical product-term spelling and capitalization `Factory`.", Fingerprint: "sha256:74d8b144092270e4c5c379c615f12c18546c2e2fe217bbb4892eac88d9601bd5"},
+	}
+	assertGoldenFindings(t, Analyze(spans, policy), want)
+}
+
+func TestLoadPolicyPreservesCanonicalTermSurfaces(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	for _, term := range policy.Terms {
+		if term.Canonical != "Factory" {
+			continue
+		}
+		want := []string{"Factory authoring and validation", "CLI help and customer documentation", "Public factory definition API"}
+		if !reflect.DeepEqual(term.Surfaces, want) {
+			t.Fatalf("Factory surfaces = %#v, want %#v", term.Surfaces, want)
+		}
+		return
+	}
+	t.Fatal("Factory term was not loaded")
+}
+
+func TestAnalyzeMarkdownUsesIndependentGolden(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	want := []findingGolden{
+		{RuleID: RuleContraction, Severity: SeverityBlocking, SourcePath: "docs/guide.md", StartLine: 3, StartColumn: 13, EndLine: 3, EndColumn: 20, ContentClass: ContentClassDescriptive, Excerpt: "doesn't", Guidance: "Use the complete form instead of the contraction.", Fingerprint: "sha256:d0fa3040e1c1715b4b77170d6a44e734feb25d339c25df5c0e4eaa4d7085f7a6"},
+		{RuleID: RuleSemicolon, Severity: SeverityBlocking, SourcePath: "docs/guide.md", StartLine: 3, StartColumn: 25, EndLine: 3, EndColumn: 26, ContentClass: ContentClassDescriptive, Excerpt: ";", Guidance: "Replace the semicolon with a full stop or separate the two ideas.", Fingerprint: "sha256:844ec784321746a85031a8744b840756d2756b6a5d37f1b829dd9e613970b6f2"},
+	}
+	assertGoldenFindings(t, AnalyzeMarkdown("docs/guide.md", []byte("# Guide\n\nThe service doesn't stop; now.\n"), policy), want)
+}
+
+func TestAnalyzeCLIManifestUsesIndependentGolden(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	want := []findingGolden{
+		{RuleID: RuleContraction, Severity: SeverityBlocking, SourcePath: "contracts/cli/commands.json", StartLine: 17, StartColumn: 46, EndLine: 17, EndColumn: 53, ContentClass: ContentClassDescriptive, Excerpt: "doesn't", Guidance: "Use the complete form instead of the contraction.", Fingerprint: "sha256:b16908890b2b74caa40231cbf8d779a37bcc4c06c076574e3bd220fbcb46b6ec", Identity: "command=you.good;input=you.good.description;json=/commands/you.good/documentation/documentation/description/canonicalEnglish"},
+		{RuleID: RuleContraction, Severity: SeverityBlocking, SourcePath: "contracts/cli/commands.json", StartLine: 26, StartColumn: 37, EndLine: 26, EndColumn: 44, ContentClass: ContentClassProcedural, Excerpt: "doesn't", Guidance: "Use the complete form instead of the contraction.", Fingerprint: "sha256:44e0bec9761ea197fdf779e24b6b1196361547873ffa15a7cba2c6b86d1bef6d", Identity: "command=you.good;input=you.good.usage.example;json=/commands/you.good/usage/example"},
+		{RuleID: RuleSemicolon, Severity: SeverityBlocking, SourcePath: "contracts/cli/commands.json", StartLine: 32, StartColumn: 33, EndLine: 32, EndColumn: 34, ContentClass: ContentClassProcedural, Excerpt: ";", Guidance: "Replace the semicolon with a full stop or separate the two ideas.", Fingerprint: "sha256:396f8e54707d485ce0f451850d2b8f550a31981e573e94a9c1f825c73dfded7f", Identity: "command=you.good;input=you.good.flag.server;json=/commands/you.good/flags/you.good.flag.server/usage"},
+		{RuleID: RuleSemicolon, Severity: SeverityBlocking, SourcePath: "contracts/cli/commands.json", StartLine: 66, StartColumn: 51, EndLine: 66, EndColumn: 52, ContentClass: ContentClassProcedural, Excerpt: ";", Guidance: "Replace the semicolon with a full stop or separate the two ideas.", Fingerprint: "sha256:8b4a488a18edb0f85425a31169b62cf4695df8eb7a1e8b9c042abeca684f49e2", Identity: "command=you.hidden;input=you.hidden.successor;json=/commands/you.hidden/lifecycle/successor/canonicalEnglish"},
+	}
+	assertGoldenFindings(t, AnalyzeCLIManifest("contracts/cli/commands.json", []byte(cliManifestFixture), policy), want)
+}
+
+func TestParseFindingsUseIndependentGoldens(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	markdownWant := []findingGolden{{RuleID: RuleParse, Severity: SeverityBlocking, SourcePath: "docs/broken.md", StartLine: 1, StartColumn: 1, EndLine: 1, EndColumn: 2, ContentClass: ContentClassTechnical, Excerpt: "unclosed ``` code fence at line 2", Guidance: "Fix the source so the analyzer can safely extract every prose span.", Fingerprint: "sha256:890cd3c55ea64fc74c0b4369c9890d10de91298f7d96a8ef4c61a94c9769793a"}}
+	cliWant := []findingGolden{{RuleID: RuleParse, Severity: SeverityBlocking, SourcePath: "contracts/cli/commands.json", StartLine: 1, StartColumn: 23, EndLine: 1, EndColumn: 24, ContentClass: ContentClassTechnical, Excerpt: "expected a JSON value at byte 23", Guidance: "Fix the source so the analyzer can safely extract every prose span.", Fingerprint: "sha256:780fbdbbdfb043fb8e4e60615baf3f63ca0df2ab0d24d07aac79669074932dd6"}}
+	assertGoldenFindings(t, AnalyzeMarkdown("docs/broken.md", []byte("```sh\n# comment\n"), policy), markdownWant)
+	assertGoldenFindings(t, AnalyzeCLIManifest("contracts/cli/commands.json", []byte(`{"commands":{"you.bad":`), policy), cliWant)
+}
+
+func TestLineEndingFindingsMatchIndependentGolden(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	want := []findingGolden{{RuleID: RuleContraction, Severity: SeverityBlocking, SourcePath: "docs/guide.md", StartLine: 3, StartColumn: 13, EndLine: 3, EndColumn: 20, ContentClass: ContentClassDescriptive, Excerpt: "doesn't", Guidance: "Use the complete form instead of the contraction.", Fingerprint: "sha256:d0fa3040e1c1715b4b77170d6a44e734feb25d339c25df5c0e4eaa4d7085f7a6"}}
+	unix := AnalyzeMarkdown("docs/guide.md", []byte("# Guide\n\nThe service doesn't stop.\n"), policy)
+	windows := AnalyzeMarkdown("docs/guide.md", []byte("# Guide\r\n\r\nThe service doesn't stop.\r\n"), policy)
+	assertGoldenFindings(t, unix, want)
+	assertGoldenFindings(t, windows, want)
+}

--- a/cmd/prosecheck/main.go
+++ b/cmd/prosecheck/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -28,9 +29,8 @@ func main() {
 	}
 }
 
-// run is the executable boundary for the core story. It accepts explicit
-// already-classified text files; Markdown and CLI-manifest structural
-// extraction are intentionally added by their later stories.
+// run is the executable boundary. Markdown files are structurally extracted;
+// other files retain the explicit content-class behavior used by the core.
 func run(args []string, stdout, stderr io.Writer) error {
 	cfg, err := parseConfig(args, stderr)
 	if err != nil {
@@ -50,10 +50,20 @@ func run(args []string, stdout, stderr io.Writer) error {
 	}
 
 	spans := make([]Span, 0, len(cfg.inputs))
+	var adapterFindings []Finding
 	for _, input := range cfg.inputs {
 		data, readErr := os.ReadFile(input)
 		if readErr != nil {
 			return fmt.Errorf("read prose input %s: %w", input, readErr)
+		}
+		if isMarkdownInput(input) {
+			markdownSpans, parseErr := ExtractMarkdownSpans(input, data)
+			if parseErr != nil {
+				adapterFindings = append(adapterFindings, markdownParseFinding(input, data, parseErr.Error()))
+				continue
+			}
+			spans = append(spans, markdownSpans...)
+			continue
 		}
 		spans = append(spans, Span{
 			SourcePath:  input,
@@ -65,15 +75,21 @@ func run(args []string, stdout, stderr io.Writer) error {
 		})
 	}
 
-	findings := Analyze(spans, policy)
+	findings := append(adapterFindings, Analyze(spans, policy)...)
+	findings = SortFindings(findings)
 	if len(findings) == 0 {
-		_, err = fmt.Fprintf(stdout, "prosecheck passed (%d input(s))\n", len(spans))
+		_, err = fmt.Fprintf(stdout, "prosecheck passed (%d input(s))\n", len(cfg.inputs))
 		return err
 	}
 	if err = RenderFindings(stderr, findings); err != nil {
 		return fmt.Errorf("render findings: %w", err)
 	}
 	return fmt.Errorf("prosecheck found %d blocking finding(s)", len(findings))
+}
+
+func isMarkdownInput(path string) bool {
+	extension := strings.ToLower(filepath.Ext(path))
+	return extension == ".md" || extension == ".markdown"
 }
 
 func parseConfig(args []string, stderr io.Writer) (config, error) {

--- a/cmd/prosecheck/main.go
+++ b/cmd/prosecheck/main.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+const (
+	defaultStandardPath = "docs/internal/standards/writing/customer-technical-writing-standard.md"
+	defaultTermsPath    = "docs/internal/standards/writing/customer-technical-terms.yaml"
+)
+
+type config struct {
+	standardPath string
+	termsPath    string
+	class        ContentClass
+	inputs       []string
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+// run is the executable boundary for the core story. It accepts explicit
+// already-classified text files; Markdown and CLI-manifest structural
+// extraction are intentionally added by their later stories.
+func run(args []string, stdout, stderr io.Writer) error {
+	cfg, err := parseConfig(args, stderr)
+	if err != nil {
+		return err
+	}
+	standard, err := os.ReadFile(cfg.standardPath)
+	if err != nil {
+		return fmt.Errorf("read writing standard %s: %w", cfg.standardPath, err)
+	}
+	terms, err := os.ReadFile(cfg.termsPath)
+	if err != nil {
+		return fmt.Errorf("read terminology register %s: %w", cfg.termsPath, err)
+	}
+	policy, err := LoadPolicy(standard, terms)
+	if err != nil {
+		return fmt.Errorf("load prose policy: %w", err)
+	}
+
+	spans := make([]Span, 0, len(cfg.inputs))
+	for _, input := range cfg.inputs {
+		data, readErr := os.ReadFile(input)
+		if readErr != nil {
+			return fmt.Errorf("read prose input %s: %w", input, readErr)
+		}
+		spans = append(spans, Span{
+			SourcePath:  input,
+			StartLine:   1,
+			StartColumn: 1,
+			Class:       cfg.class,
+			Text:        string(data),
+			Protected:   LexicalProtectedRanges(string(data)),
+		})
+	}
+
+	findings := Analyze(spans, policy)
+	if len(findings) == 0 {
+		_, err = fmt.Fprintf(stdout, "prosecheck passed (%d input(s))\n", len(spans))
+		return err
+	}
+	if err = RenderFindings(stderr, findings); err != nil {
+		return fmt.Errorf("render findings: %w", err)
+	}
+	return fmt.Errorf("prosecheck found %d blocking finding(s)", len(findings))
+}
+
+func parseConfig(args []string, stderr io.Writer) (config, error) {
+	flags := flag.NewFlagSet("prosecheck", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	standardPath := flags.String("standard", defaultStandardPath, "path to the canonical writing standard")
+	termsPath := flags.String("terms", defaultTermsPath, "path to the canonical terminology register")
+	class := flags.String("class", string(ContentClassDescriptive), "content class: label, procedural, or descriptive")
+	if err := flags.Parse(args); err != nil {
+		return config{}, err
+	}
+	if flags.NArg() == 0 {
+		return config{}, errors.New("usage: prosecheck [flags] <text-file> [...]")
+	}
+	parsedClass := ContentClass(strings.TrimSpace(*class))
+	switch parsedClass {
+	case ContentClassLabel, ContentClassProcedural, ContentClassDescriptive:
+	default:
+		return config{}, fmt.Errorf("unsupported prose content class %q", *class)
+	}
+	return config{
+		standardPath: *standardPath,
+		termsPath:    *termsPath,
+		class:        parsedClass,
+		inputs:       append([]string(nil), flags.Args()...),
+	}, nil
+}

--- a/cmd/prosecheck/main.go
+++ b/cmd/prosecheck/main.go
@@ -52,9 +52,16 @@ func run(args []string, stdout, stderr io.Writer) error {
 	spans := make([]Span, 0, len(cfg.inputs))
 	var adapterFindings []Finding
 	for _, input := range cfg.inputs {
+		if isGeneratedCLIProjection(input) {
+			return fmt.Errorf("generated CLI projection %s is not an authored prosecheck input", input)
+		}
 		data, readErr := os.ReadFile(input)
 		if readErr != nil {
 			return fmt.Errorf("read prose input %s: %w", input, readErr)
+		}
+		if isCLIManifestInput(input) {
+			adapterFindings = append(adapterFindings, AnalyzeCLIManifest(input, data, policy)...)
+			continue
 		}
 		if isMarkdownInput(input) {
 			markdownSpans, parseErr := ExtractMarkdownSpans(input, data)
@@ -90,6 +97,16 @@ func run(args []string, stdout, stderr io.Writer) error {
 func isMarkdownInput(path string) bool {
 	extension := strings.ToLower(filepath.Ext(path))
 	return extension == ".md" || extension == ".markdown"
+}
+
+func isCLIManifestInput(path string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(filepath.Clean(path), "\\", "/"))
+	return normalized == strings.TrimPrefix(authoredCLIManifestSuffix, "/") || strings.HasSuffix(normalized, authoredCLIManifestSuffix)
+}
+
+func isGeneratedCLIProjection(path string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(filepath.Clean(path), "\\", "/"))
+	return strings.HasSuffix(normalized, "/packages/api/generated/cli/commands.json")
 }
 
 func parseConfig(args []string, stderr io.Writer) (config, error) {

--- a/cmd/prosecheck/main.go
+++ b/cmd/prosecheck/main.go
@@ -78,6 +78,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 			StartColumn: 1,
 			Class:       cfg.class,
 			Text:        string(data),
+			Surfaces:    []string{surfaceCustomerDocumentation},
 			Protected:   LexicalProtectedRanges(string(data)),
 		})
 	}
@@ -106,7 +107,8 @@ func isCLIManifestInput(path string) bool {
 
 func isGeneratedCLIProjection(path string) bool {
 	normalized := strings.ToLower(strings.ReplaceAll(filepath.Clean(path), "\\", "/"))
-	return strings.HasSuffix(normalized, "/packages/api/generated/cli/commands.json")
+	const generatedPath = "packages/api/generated/cli/commands.json"
+	return normalized == generatedPath || strings.HasSuffix(normalized, "/"+generatedPath)
 }
 
 func parseConfig(args []string, stderr io.Writer) (config, error) {

--- a/cmd/prosecheck/main_test.go
+++ b/cmd/prosecheck/main_test.go
@@ -132,6 +132,7 @@ func TestAnalyzeReportsEverySupportedBlockingRule(t *testing.T) {
 				StartColumn: 2,
 				Class:       tt.class,
 				Text:        tt.text,
+				Surfaces:    []string{surfaceCustomerDocumentation},
 			}}, policy)
 			if len(findings) != 1 {
 				t.Fatalf("Analyze() returned %d findings: %#v", len(findings), findings)
@@ -212,6 +213,7 @@ func TestAnalyzeReportsLineAndColumnAcrossCRLF(t *testing.T) {
 		StartColumn: 3,
 		Class:       ContentClassDescriptive,
 		Text:        "A safe sentence.\r\nfactory starts.",
+		Surfaces:    []string{surfaceCustomerDocumentation},
 	}}, policy)
 	if len(findings) != 1 {
 		t.Fatalf("Analyze() findings = %#v, want one term-case finding", findings)
@@ -441,6 +443,14 @@ func TestMarkdownMetadataProvidesExplicitClassificationAndBoundedSuppression(t *
 	findings := AnalyzeMarkdown("docs/metadata.md", []byte(content), policy)
 	if len(findings) != 1 || findings[0].RuleID != RuleProceduralSentenceLength || findings[0].ContentClass != ContentClassProcedural || findings[0].StartLine != 2 {
 		t.Fatalf("metadata findings = %#v, want one procedural-length finding on line 2", findings)
+	}
+}
+
+func TestAnalyzeMarkdownDeclinesAmbiguousRegisterTermsOutsideTheirSurfaces(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	findings := AnalyzeMarkdown("docs/ambiguous.md", []byte("The active service is running before you place the file.\n"), policy)
+	if len(findings) != 0 {
+		t.Fatalf("ambiguous ordinary words produced terminology findings: %#v", findings)
 	}
 }
 

--- a/cmd/prosecheck/main_test.go
+++ b/cmd/prosecheck/main_test.go
@@ -454,6 +454,52 @@ func TestAnalyzeMarkdownDeclinesAmbiguousRegisterTermsOutsideTheirSurfaces(t *te
 	}
 }
 
+func TestMarkdownSurfaceContextKeepsProductTermsBounded(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	internal := AnalyzeMarkdown("docs/architecture/ambiguous.md", []byte("Workers are things that can do work.\n"), policy)
+	for _, finding := range internal {
+		if finding.RuleID == RuleTermCase || finding.RuleID == RulePublicTerm {
+			t.Fatalf("internal architecture prose produced product terminology finding: %#v", finding)
+		}
+	}
+	reference := AnalyzeMarkdown("docs/reference/ambiguous.md", []byte("The model worker is described here.\n"), policy)
+	for _, finding := range reference {
+		if finding.RuleID == RuleTermCase || finding.RuleID == RulePublicTerm {
+			t.Fatalf("reference prose produced ambiguous product terminology finding: %#v", finding)
+		}
+	}
+	customer := AnalyzeMarkdown("docs/guide.md", []byte("the factory starts.\n"), policy)
+	if len(customer) != 1 || customer[0].RuleID != RuleTermCase || customer[0].Excerpt != "factory" {
+		t.Fatalf("customer prose lost positive product-term finding: %#v", customer)
+	}
+}
+
+func TestAnalyzeMarkdownProtectsRequiredTechnicalFixtureMatrix(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	cases := []struct {
+		name      string
+		technical string
+	}{
+		{name: "shell operators", technical: "$ go test ./cmd/prosecheck && go vet ./cmd/prosecheck || exit 1"},
+		{name: "file and package paths", technical: "Read ./pkg/services/factory_runtime/internal/runner.go and github.com/portpowered/infinite-you/pkg/services."},
+		{name: "identifiers", technical: "Keep FactoryEvent and FACTORY_REQUEST_BATCH unchanged."},
+		{name: "schema and event literals", technical: "The FactoryResponseEvent schema carries the event payload."},
+		{name: "JSON contract example", technical: `{"event":"FactoryEvent","state":"active; doesn't stop"}`},
+		{name: "YAML contract example", technical: "state: active; message: doesn't stop"},
+		{name: "model and provider names", technical: "Use gpt-5 with OpenAI and anthropic."},
+		{name: "quoted external output", technical: `error: doesn't stop; external output`},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			content := testCase.technical + "\n\nThe service doesn't stop.\n"
+			findings := AnalyzeMarkdown("docs/technical-matrix.md", []byte(content), policy)
+			if len(findings) != 1 || findings[0].RuleID != RuleContraction || findings[0].Excerpt != "doesn't" || findings[0].StartLine != 3 {
+				t.Fatalf("technical fixture findings = %#v, want only adjacent prose contraction", findings)
+			}
+		})
+	}
+}
+
 func TestRunReadsExplicitInputsAndKeepsOutputStable(t *testing.T) {
 	root := t.TempDir()
 	standardPath, termsPath := repositoryPolicyPaths(t)

--- a/cmd/prosecheck/main_test.go
+++ b/cmd/prosecheck/main_test.go
@@ -1,0 +1,377 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestLoadPolicyConsumesCanonicalWritingSources(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+
+	for _, class := range []ContentClass{
+		ContentClassLabel,
+		ContentClassProcedural,
+		ContentClassDescriptive,
+		ContentClassTechnical,
+		ContentClassTerm,
+	} {
+		if policy.ContentClasses[class] == "" {
+			t.Fatalf("policy content class %q was not loaded", class)
+		}
+	}
+	for _, ruleID := range []RuleID{
+		RuleProceduralSentenceLength,
+		RuleDescriptiveSentenceLength,
+		RuleDescriptiveParagraphLength,
+		RuleSemicolon,
+		RuleContraction,
+		RulePublicTerm,
+		RuleTermCase,
+		RuleSuppression,
+		RuleParse,
+	} {
+		rule, ok := policy.Rules[ruleID]
+		if !ok || !rule.Supported || rule.Severity != SeverityBlocking {
+			t.Fatalf("policy rule %q = %#v, want supported blocking rule", ruleID, rule)
+		}
+	}
+	if policy.Rules[RuleBaselineNew].Supported || policy.Rules[RuleBaselineStale].Supported {
+		t.Fatal("baseline rules must remain outside the story 001 analyzer")
+	}
+	if !containsTerm(policy.Terms, "Factory") || !containsTerm(policy.Terms, "CPN") {
+		t.Fatal("policy did not load the canonical product and internal terminology records")
+	}
+}
+
+func TestLoadPolicyRejectsIncompleteCanonicalSources(t *testing.T) {
+	standard := []byte("### Labels\n### Procedural prose\n### Descriptive prose\n### Machine and technical text\n### Technical terms\n")
+	terms := []byte("version: 1\nterms: []\n")
+	if _, err := LoadPolicy(standard, terms); err == nil || !strings.Contains(err.Error(), "no rule IDs") {
+		t.Fatalf("LoadPolicy() error = %v, want missing-rule error", err)
+	}
+
+	standard = []byte("### Labels\n### Procedural prose\n### Descriptive prose\n### Machine and technical text\n### Technical terms\n- **B-PROC-20:** rule\n- **B-DESC-25:** rule\n- **B-PARA-6:** rule\n- **B-SEMICOLON:** rule\n- **B-CONTRACTION:** rule\n- **B-TERM-PUBLIC:** rule\n- **B-TERM-CASE:** rule\n- **B-LITERAL:** rule\n- **B-SUPPRESSION:** rule\n- **B-BASELINE-STALE:** rule\n- **B-BASELINE-NEW:** rule\n- **B-PARSE:** rule\n")
+	if _, err := LoadPolicy(standard, terms); err == nil || !strings.Contains(err.Error(), "no terms") {
+		t.Fatalf("LoadPolicy() error = %v, want empty-terms error", err)
+	}
+}
+
+func TestAnalyzeReportsEverySupportedBlockingRule(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	tests := []struct {
+		name        string
+		class       ContentClass
+		text        string
+		wantRule    RuleID
+		wantExcerpt string
+	}{
+		{
+			name:        "procedural sentence length",
+			class:       ContentClassProcedural,
+			text:        "Run the command and inspect the result before you continue with the next required operation for this workflow today very carefully.",
+			wantRule:    RuleProceduralSentenceLength,
+			wantExcerpt: "Run the command and inspect the result before you continue with the next required operation for this workflow today very carefully.",
+		},
+		{
+			name:        "descriptive sentence length",
+			class:       ContentClassDescriptive,
+			text:        "The service returns a detailed result that explains how the requested operation changes the current object and reports the observable state after completion for review today.",
+			wantRule:    RuleDescriptiveSentenceLength,
+			wantExcerpt: "The service returns a detailed result that explains how the requested operation changes the current object and reports the observable state after completion for review today.",
+		},
+		{
+			name:        "descriptive paragraph length",
+			class:       ContentClassDescriptive,
+			text:        "First sentence. Second sentence. Third sentence. Fourth sentence. Fifth sentence. Sixth sentence. Seventh sentence.",
+			wantRule:    RuleDescriptiveParagraphLength,
+			wantExcerpt: "First sentence. Second sentence. Third sentence. Fourth sentence. Fifth sentence. Sixth sentence. Seventh sentence.",
+		},
+		{
+			name:        "semicolon",
+			class:       ContentClassDescriptive,
+			text:        "One idea; another idea.",
+			wantRule:    RuleSemicolon,
+			wantExcerpt: ";",
+		},
+		{
+			name:        "contraction",
+			class:       ContentClassDescriptive,
+			text:        "The service doesn't stop.",
+			wantRule:    RuleContraction,
+			wantExcerpt: "doesn't",
+		},
+		{
+			name:        "prohibited public term",
+			class:       ContentClassDescriptive,
+			text:        "The CPN is internal.",
+			wantRule:    RulePublicTerm,
+			wantExcerpt: "CPN",
+		},
+		{
+			name:        "canonical term case",
+			class:       ContentClassDescriptive,
+			text:        "the factory starts.",
+			wantRule:    RuleTermCase,
+			wantExcerpt: "factory",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := Analyze([]Span{{
+				SourcePath:  "docs/guide.md",
+				StartLine:   3,
+				StartColumn: 2,
+				Class:       tt.class,
+				Text:        tt.text,
+			}}, policy)
+			if len(findings) != 1 {
+				t.Fatalf("Analyze() returned %d findings: %#v", len(findings), findings)
+			}
+			finding := findings[0]
+			if finding.RuleID != tt.wantRule || finding.Severity != SeverityBlocking || finding.ContentClass != tt.class {
+				t.Fatalf("finding identity = %#v, want rule=%s severity=%s class=%s", finding, tt.wantRule, SeverityBlocking, tt.class)
+			}
+			if finding.SourcePath != "docs/guide.md" || finding.StartLine != 3 {
+				t.Fatalf("finding source = %#v, want normalized path on line 3", finding)
+			}
+			if finding.Excerpt != boundedExcerpt(tt.wantExcerpt) || finding.Guidance == "" {
+				t.Fatalf("finding excerpt/guidance = %q / %q, want excerpt %q and guidance", finding.Excerpt, finding.Guidance, boundedExcerpt(tt.wantExcerpt))
+			}
+			assertStableFingerprint(t, finding)
+		})
+	}
+}
+
+func TestAnalyzeCountsAContractionAsOneNaturalLanguageWord(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	text := "Use this command when you don't need to inspect the result before continuing with the next step in the workflow."
+	findings := Analyze([]Span{{
+		SourcePath: "docs/procedure.md",
+		Class:      ContentClassProcedural,
+		Text:       text,
+	}}, policy)
+	if len(findings) != 1 || findings[0].RuleID != RuleContraction {
+		t.Fatalf("findings = %#v, want only B-CONTRACTION at the twenty-word boundary", findings)
+	}
+}
+
+func TestAnalyzeProtectsTechnicalRangesAndTechnicalSpans(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	text := "The CPN; don't stop."
+	findings := Analyze([]Span{{
+		SourcePath:  "docs/protected.md",
+		StartLine:   1,
+		StartColumn: 1,
+		Class:       ContentClassDescriptive,
+		Text:        text,
+		Protected: []TextRange{
+			{Start: 4, End: 7},
+			{Start: 7, End: 15},
+		},
+	}}, policy)
+	if len(findings) != 0 {
+		t.Fatalf("protected ranges produced findings: %#v", findings)
+	}
+
+	findings = Analyze([]Span{{
+		SourcePath:  "docs/technical.md",
+		StartLine:   1,
+		StartColumn: 1,
+		Class:       ContentClassTechnical,
+		Text:        "The CPN; don't stop.",
+	}}, policy)
+	if len(findings) != 0 {
+		t.Fatalf("technical span produced findings: %#v", findings)
+	}
+
+	findings = Analyze([]Span{{
+		SourcePath: "docs/protected.md",
+		Class:      ContentClassDescriptive,
+		Text:       text,
+		Protected:  []TextRange{{Start: 4, End: 8}, {Start: 7, End: 15}},
+	}}, policy)
+	if len(findings) != 1 || findings[0].RuleID != RuleParse {
+		t.Fatalf("overlapping ranges = %#v, want one B-PARSE finding", findings)
+	}
+}
+
+func TestAnalyzeReportsLineAndColumnAcrossCRLF(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	findings := Analyze([]Span{{
+		SourcePath:  `./docs\guide.md`,
+		StartLine:   4,
+		StartColumn: 3,
+		Class:       ContentClassDescriptive,
+		Text:        "A safe sentence.\r\nfactory starts.",
+	}}, policy)
+	if len(findings) != 1 {
+		t.Fatalf("Analyze() findings = %#v, want one term-case finding", findings)
+	}
+	if findings[0].RuleID != RuleTermCase || findings[0].SourcePath != "docs/guide.md" || findings[0].StartLine != 5 || findings[0].StartColumn != 1 {
+		t.Fatalf("finding location = %#v, want docs/guide.md:5:1", findings[0])
+	}
+}
+
+func TestAnalyzeSupportsBoundedSuppressionsAndRejectsMalformedDirectives(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	valid := `<!-- prosecheck:ignore B-SEMICOLON reason="contract wording" owner="Docs" review="2026-12-31" -->
+One idea; another idea.`
+	if findings := Analyze([]Span{{SourcePath: "docs/guide.md", Class: ContentClassDescriptive, Text: valid}}, policy); len(findings) != 0 {
+		t.Fatalf("valid suppression produced findings: %#v", findings)
+	}
+
+	for _, text := range []string{
+		`<!-- prosecheck:ignore B-SEMICOLON owner="Docs" review="2026-12-31" --> One; two.`,
+		`<!-- prosecheck:ignore B-NOT-A-RULE reason="why" owner="Docs" review="2026-12-31" --> One; two.`,
+	} {
+		findings := Analyze([]Span{{SourcePath: "docs/guide.md", Class: ContentClassDescriptive, Text: text}}, policy)
+		if len(findings) != 2 || findings[0].RuleID != RuleSuppression || findings[1].RuleID != RuleSemicolon || findings[0].SourcePath != "docs/guide.md" {
+			t.Fatalf("malformed suppression findings = %#v, want B-SUPPRESSION plus the unsuppressed semicolon", findings)
+		}
+	}
+
+	if _, err := ParseSuppressionDirective(`<!-- prosecheck:ignore B-SEMICOLON reason="why" owner="Docs" -->`); err == nil {
+		t.Fatal("ParseSuppressionDirective accepted a directive without review")
+	}
+}
+
+func TestAnalyzeOrderingRenderingAndFingerprintsAreDeterministic(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	spans := []Span{
+		{SourcePath: `b\two.md`, StartLine: 2, StartColumn: 1, Class: ContentClassDescriptive, Text: "One; two."},
+		{SourcePath: `a\one.md`, StartLine: 3, StartColumn: 1, Class: ContentClassDescriptive, Text: "The service doesn't stop."},
+	}
+	first := Analyze(spans, policy)
+	second := Analyze([]Span{spans[1], spans[0]}, policy)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("reordered spans changed findings:\nfirst=%#v\nsecond=%#v", first, second)
+	}
+	if len(first) != 2 || first[0].SourcePath != "a/one.md" || first[1].SourcePath != "b/two.md" {
+		t.Fatalf("findings = %#v, want a/one.md before b/two.md", first)
+	}
+	var output bytes.Buffer
+	if err := RenderFindings(&output, first); err != nil {
+		t.Fatalf("RenderFindings() error = %v", err)
+	}
+	if !strings.Contains(output.String(), "[B-CONTRACTION]") || !strings.Contains(output.String(), "[B-SEMICOLON]") {
+		t.Fatalf("rendered output = %q, want both stable rule IDs", output.String())
+	}
+	for _, finding := range first {
+		assertStableFingerprint(t, finding)
+	}
+
+	unix := Analyze([]Span{{SourcePath: "docs/guide.md", Class: ContentClassDescriptive, Text: "One; two.\n"}}, policy)
+	windows := Analyze([]Span{{SourcePath: "docs/guide.md", Class: ContentClassDescriptive, Text: "One; two.\r\n"}}, policy)
+	if len(unix) != 1 || len(windows) != 1 || unix[0].Fingerprint != windows[0].Fingerprint {
+		t.Fatalf("line-ending fingerprints differ: unix=%#v windows=%#v", unix, windows)
+	}
+}
+
+func TestLexicalProtectedRangesProtectInlineCodeAndURLs(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	text := "Use `CPN; don't` or https://example.com/path; now."
+	findings := Analyze([]Span{{
+		SourcePath: "docs/guide.md",
+		Class:      ContentClassDescriptive,
+		Text:       text,
+		Protected:  LexicalProtectedRanges(text),
+	}}, policy)
+	if len(findings) != 1 || findings[0].RuleID != RuleSemicolon || findings[0].Excerpt != ";" {
+		t.Fatalf("lexical protection findings = %#v, want only trailing semicolon", findings)
+	}
+}
+
+func TestRunReadsExplicitInputsAndKeepsOutputStable(t *testing.T) {
+	root := t.TempDir()
+	standardPath, termsPath := repositoryPolicyPaths(t)
+	validPath := filepath.Join(root, "valid.txt")
+	invalidPath := filepath.Join(root, "invalid.txt")
+	if err := os.WriteFile(validPath, []byte("The service is ready."), 0o600); err != nil {
+		t.Fatalf("write valid input: %v", err)
+	}
+	if err := os.WriteFile(invalidPath, []byte("One; two."), 0o600); err != nil {
+		t.Fatalf("write invalid input: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := run([]string{"-standard", standardPath, "-terms", termsPath, validPath}, &stdout, &stderr); err != nil {
+		t.Fatalf("run(valid) error = %v", err)
+	}
+	if stdout.String() != "prosecheck passed (1 input(s))\n" || stderr.Len() != 0 {
+		t.Fatalf("run(valid) output = stdout %q stderr %q", stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	err := run([]string{"-standard", standardPath, "-terms", termsPath, invalidPath}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "found 1 blocking finding") {
+		t.Fatalf("run(invalid) error = %v, want blocking finding error", err)
+	}
+	if stdout.Len() != 0 || !strings.Contains(stderr.String(), "[B-SEMICOLON]") {
+		t.Fatalf("run(invalid) output = stdout %q stderr %q", stdout.String(), stderr.String())
+	}
+}
+
+func loadRepositoryPolicy(t *testing.T) Policy {
+	t.Helper()
+	standardPath, termsPath := repositoryPolicyPaths(t)
+	standard, err := os.ReadFile(standardPath)
+	if err != nil {
+		t.Fatalf("read writing standard: %v", err)
+	}
+	terms, err := os.ReadFile(termsPath)
+	if err != nil {
+		t.Fatalf("read terminology register: %v", err)
+	}
+	policy, err := LoadPolicy(standard, terms)
+	if err != nil {
+		t.Fatalf("LoadPolicy(): %v", err)
+	}
+	return policy
+}
+
+func repositoryPolicyPaths(t *testing.T) (string, string) {
+	t.Helper()
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
+	return filepath.Join(root, "docs", "internal", "standards", "writing", "customer-technical-writing-standard.md"), filepath.Join(root, "docs", "internal", "standards", "writing", "customer-technical-terms.yaml")
+}
+
+func containsTerm(terms []Term, canonical string) bool {
+	for _, term := range terms {
+		if term.Canonical == canonical {
+			return true
+		}
+	}
+	return false
+}
+
+func assertStableFingerprint(t *testing.T, finding Finding) {
+	t.Helper()
+	if !strings.HasPrefix(finding.Fingerprint, "sha256:") || len(finding.Fingerprint) != len("sha256:")+64 {
+		t.Fatalf("fingerprint = %q, want sha256 hex", finding.Fingerprint)
+	}
+	if _, err := hex.DecodeString(strings.TrimPrefix(finding.Fingerprint, "sha256:")); err != nil {
+		t.Fatalf("fingerprint %q is not hex: %v", finding.Fingerprint, err)
+	}
+	recomputed := sha256.Sum256([]byte(strings.Join([]string{
+		string(finding.RuleID), string(finding.Severity), finding.SourcePath,
+		finding.Identity, string(finding.ContentClass),
+		strconv.Itoa(finding.StartLine), strconv.Itoa(finding.StartColumn), finding.Excerpt,
+	}, "\x00")))
+	if finding.Fingerprint != "sha256:"+hex.EncodeToString(recomputed[:]) {
+		t.Fatalf("fingerprint = %q is not derived from normalized finding fields", finding.Fingerprint)
+	}
+}

--- a/cmd/prosecheck/main_test.go
+++ b/cmd/prosecheck/main_test.go
@@ -290,6 +290,160 @@ func TestLexicalProtectedRangesProtectInlineCodeAndURLs(t *testing.T) {
 	}
 }
 
+func TestExtractMarkdownSpansCoversSupportedStructures(t *testing.T) {
+	content := strings.Join([]string{
+		"# Guide",
+		"",
+		"The description explains the current state.",
+		"",
+		"1. Run the command and inspect the result.",
+		"- A descriptive list item.",
+		"",
+		"> [!NOTE]",
+		"> The note explains the current state.",
+		"",
+		"!!! warning",
+		"",
+		"   The warning explains the recovery path.",
+		"",
+		"| Name | Description |",
+		"| --- | --- |",
+		"| Factory | A saved definition. |",
+		"",
+		"<!-- The comment explains the current state. -->",
+		"",
+		"```sh",
+		"# Start the local server before sending the request.",
+		"you server --listen 127.0.0.1:7437",
+		"```",
+	}, "\n")
+
+	spans, err := ExtractMarkdownSpans("docs/guide.md", []byte(content))
+	if err != nil {
+		t.Fatalf("ExtractMarkdownSpans() error = %v", err)
+	}
+	if len(spans) != 12 {
+		t.Fatalf("ExtractMarkdownSpans() returned %d spans: %#v", len(spans), spans)
+	}
+	want := []struct {
+		text  string
+		class ContentClass
+		line  int
+		col   int
+	}{
+		{"Guide", ContentClassLabel, 1, 3},
+		{"The description explains the current state.", ContentClassDescriptive, 3, 1},
+		{"Run the command and inspect the result.", ContentClassProcedural, 5, 4},
+		{"A descriptive list item.", ContentClassDescriptive, 6, 3},
+		{"The note explains the current state.", ContentClassDescriptive, 9, 3},
+		{"The warning explains the recovery path.", ContentClassDescriptive, 13, 4},
+		{"Name", ContentClassLabel, 15, 3},
+		{"Description", ContentClassLabel, 15, 10},
+		{"Factory", ContentClassDescriptive, 17, 3},
+		{"A saved definition.", ContentClassDescriptive, 17, 13},
+		{"The comment explains the current state.", ContentClassDescriptive, 19, 6},
+		{"Start the local server before sending the request.", ContentClassProcedural, 22, 3},
+	}
+	for index, expected := range want {
+		if spans[index].Text != expected.text || spans[index].Class != expected.class || spans[index].StartLine != expected.line || spans[index].StartColumn != expected.col {
+			t.Fatalf("span %d = %#v, want text=%q class=%s at %d:%d", index, spans[index], expected.text, expected.class, expected.line, expected.col)
+		}
+	}
+}
+
+func TestMarkdownAdmonitionVariantsExtractNaturalContent(t *testing.T) {
+	content := strings.Join([]string{
+		"> [!NOTE] A note explains the current state.",
+		"",
+		":::warning",
+		"A warning explains the recovery path.",
+		":::",
+	}, "\n")
+	spans, err := ExtractMarkdownSpans("docs/admonitions.md", []byte(content))
+	if err != nil {
+		t.Fatalf("ExtractMarkdownSpans() error = %v", err)
+	}
+	if len(spans) != 2 || spans[0].Text != "A note explains the current state." || spans[1].Text != "A warning explains the recovery path." {
+		t.Fatalf("admonition spans = %#v, want both natural-language bodies", spans)
+	}
+}
+
+func TestAnalyzeMarkdownProtectsTechnicalTextAndReportsNaturalProse(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	content := strings.Join([]string{
+		"Keep `CPN; don't` and `POST /factory-sessions/sync` exact.",
+		"The service doesn't stop; now.",
+		"",
+		"```sh",
+		"# Start the local server before sending the request.",
+		"you server --listen 127.0.0.1:7437",
+		"```",
+	}, "\n")
+	findings := AnalyzeMarkdown("docs/guide.md", []byte(content), policy)
+	if len(findings) != 2 {
+		t.Fatalf("AnalyzeMarkdown() returned %d findings: %#v", len(findings), findings)
+	}
+	if findings[0].RuleID != RuleContraction || findings[0].StartLine != 2 || findings[0].Excerpt != "doesn't" {
+		t.Fatalf("first Markdown finding = %#v, want contraction on line 2", findings[0])
+	}
+	if findings[1].RuleID != RuleSemicolon || findings[1].StartLine != 2 || findings[1].Excerpt != ";" {
+		t.Fatalf("second Markdown finding = %#v, want semicolon on line 2", findings[1])
+	}
+	for _, finding := range findings {
+		assertStableFingerprint(t, finding)
+	}
+}
+
+func TestMarkdownLinkDestinationProtectionKeepsLabelNatural(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	findings := AnalyzeMarkdown("docs/links.md", []byte("the [factory](./factory.json) starts."), policy)
+	if len(findings) != 1 || findings[0].RuleID != RuleTermCase || findings[0].Excerpt != "factory" || findings[0].StartColumn != 6 {
+		t.Fatalf("link findings = %#v, want visible label term-case at column 6", findings)
+	}
+}
+
+func TestAnalyzeMarkdownBlocksOnUnsafeDocumentsAndNormalizesLineEndings(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	broken := AnalyzeMarkdown("docs/broken.md", []byte("```sh\n# comment\n"), policy)
+	if len(broken) != 1 || broken[0].RuleID != RuleParse || broken[0].SourcePath != "docs/broken.md" || !strings.Contains(broken[0].Excerpt, "unclosed") {
+		t.Fatalf("unclosed Markdown fence findings = %#v, want one file-scoped B-PARSE finding", broken)
+	}
+	invalid := AnalyzeMarkdown("docs/invalid.md", []byte{0xff, '\n'}, policy)
+	if len(invalid) != 1 || invalid[0].RuleID != RuleParse || invalid[0].SourcePath != "docs/invalid.md" {
+		t.Fatalf("invalid UTF-8 findings = %#v, want one file-scoped B-PARSE finding", invalid)
+	}
+	for name, source := range map[string]string{
+		"inline code": "Keep `an unclosed literal in prose.",
+		"table":       "| Name | Description |\n| --- |",
+	} {
+		findings := AnalyzeMarkdown("docs/"+name+".md", []byte(source), policy)
+		if len(findings) != 1 || findings[0].RuleID != RuleParse {
+			t.Fatalf("%s parse findings = %#v, want one B-PARSE finding", name, findings)
+		}
+	}
+
+	unix := AnalyzeMarkdown("docs/guide.md", []byte("# Guide\n\nThe service doesn't stop.\n"), policy)
+	windows := AnalyzeMarkdown("docs/guide.md", []byte("# Guide\r\n\r\nThe service doesn't stop.\r\n"), policy)
+	if !reflect.DeepEqual(unix, windows) {
+		t.Fatalf("line endings changed Markdown findings:\nunix=%#v\nwindows=%#v", unix, windows)
+	}
+}
+
+func TestMarkdownMetadataProvidesExplicitClassificationAndBoundedSuppression(t *testing.T) {
+	policy := loadRepositoryPolicy(t)
+	content := strings.Join([]string{
+		"<!-- prosecheck:class procedural -->",
+		"Run the command and inspect the result before you continue with the next required operation for this workflow today very carefully now.",
+		"",
+		"<!-- prosecheck:ignore B-SEMICOLON reason=\"contract wording\" owner=\"Docs\" review=\"2026-12-31\" -->",
+		"One; two.",
+	}, "\n")
+	findings := AnalyzeMarkdown("docs/metadata.md", []byte(content), policy)
+	if len(findings) != 1 || findings[0].RuleID != RuleProceduralSentenceLength || findings[0].ContentClass != ContentClassProcedural || findings[0].StartLine != 2 {
+		t.Fatalf("metadata findings = %#v, want one procedural-length finding on line 2", findings)
+	}
+}
+
 func TestRunReadsExplicitInputsAndKeepsOutputStable(t *testing.T) {
 	root := t.TempDir()
 	standardPath, termsPath := repositoryPolicyPaths(t)
@@ -318,6 +472,23 @@ func TestRunReadsExplicitInputsAndKeepsOutputStable(t *testing.T) {
 	}
 	if stdout.Len() != 0 || !strings.Contains(stderr.String(), "[B-SEMICOLON]") {
 		t.Fatalf("run(invalid) output = stdout %q stderr %q", stdout.String(), stderr.String())
+	}
+}
+
+func TestRunDispatchesMarkdownInputs(t *testing.T) {
+	root := t.TempDir()
+	standardPath, termsPath := repositoryPolicyPaths(t)
+	path := filepath.Join(root, "guide.md")
+	if err := os.WriteFile(path, []byte("# Guide\r\n\r\nThe service doesn't stop.\r\n"), 0o600); err != nil {
+		t.Fatalf("write Markdown input: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	err := run([]string{"-standard", standardPath, "-terms", termsPath, path}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "found 1 blocking finding") {
+		t.Fatalf("run(Markdown) error = %v, want blocking finding error", err)
+	}
+	if stdout.Len() != 0 || !strings.Contains(stderr.String(), ":3:13 [B-CONTRACTION]") {
+		t.Fatalf("run(Markdown) output = stdout %q stderr %q", stdout.String(), stderr.String())
 	}
 }
 

--- a/cmd/prosecheck/markdown.go
+++ b/cmd/prosecheck/markdown.go
@@ -1,0 +1,1212 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// ExtractMarkdownSpans extracts the natural-language spans that can be safely
+// classified from one Markdown document. It keeps source line boundaries and
+// source columns so the pure analyzer can report findings against authored
+// Markdown rather than against a rendered copy.
+func ExtractMarkdownSpans(sourcePath string, data []byte) ([]Span, error) {
+	if !utf8.Valid(data) {
+		return nil, fmt.Errorf("Markdown source is not valid UTF-8")
+	}
+	parser := newMarkdownParser(sourcePath, string(data))
+	if err := validateMarkdownInlineCode(parser.lines); err != nil {
+		return nil, err
+	}
+	if err := parser.parse(); err != nil {
+		return nil, err
+	}
+	return parser.spans, nil
+}
+
+// AnalyzeMarkdown is the pure adapter-plus-analyzer entry point used by
+// callers that already loaded one Markdown document.
+func AnalyzeMarkdown(sourcePath string, data []byte, policy Policy) []Finding {
+	spans, err := ExtractMarkdownSpans(sourcePath, data)
+	if err != nil {
+		return []Finding{markdownParseFinding(sourcePath, data, err.Error())}
+	}
+	return Analyze(spans, policy)
+}
+
+type markdownLine struct {
+	number int
+	start  int
+	end    int
+	next   int
+	text   string
+}
+
+type markdownParser struct {
+	sourcePath string
+	source     string
+	lines      []markdownLine
+	spans      []Span
+
+	pendingClass        ContentClass
+	hasPendingClass     bool
+	pendingSuppressions []Suppression
+}
+
+func newMarkdownParser(sourcePath, source string) *markdownParser {
+	return &markdownParser{
+		sourcePath: sourcePath,
+		source:     source,
+		lines:      splitMarkdownLines(source),
+	}
+}
+
+func splitMarkdownLines(source string) []markdownLine {
+	if source == "" {
+		return nil
+	}
+	lines := make([]markdownLine, 0, strings.Count(source, "\n")+1)
+	start := 0
+	for start < len(source) {
+		next := strings.IndexByte(source[start:], '\n')
+		lineNext := len(source)
+		if next >= 0 {
+			lineNext = start + next + 1
+		}
+		end := lineNext
+		if end > start && source[end-1] == '\n' {
+			end--
+		}
+		if end > start && source[end-1] == '\r' {
+			end--
+		}
+		lines = append(lines, markdownLine{
+			number: len(lines) + 1,
+			start:  start,
+			end:    end,
+			next:   lineNext,
+			text:   source[start:end],
+		})
+		if next < 0 {
+			break
+		}
+		start = lineNext
+	}
+	return lines
+}
+
+func (p *markdownParser) parse() error {
+	index, err := p.skipFrontMatter()
+	if err != nil {
+		return err
+	}
+	for index < len(p.lines) {
+		if isMarkdownBlank(p.lines[index].text) {
+			index++
+			continue
+		}
+		if next, handled, err := p.consumeFence(index); handled {
+			if err != nil {
+				return err
+			}
+			index = next
+			continue
+		}
+		if next, handled, err := p.consumeHTMLComment(index); handled {
+			if err != nil {
+				return err
+			}
+			index = next
+			continue
+		}
+		if isIndentedCodeLine(p.lines[index].text) {
+			index = skipIndentedCode(p.lines, index)
+			continue
+		}
+		if next, ok := p.consumeHeading(index); ok {
+			index = next
+			continue
+		}
+		if next, ok, err := p.consumeTable(index); ok {
+			if err != nil {
+				return err
+			}
+			index = next
+			continue
+		}
+		if next, ok, err := p.consumeAdmonition(index); ok {
+			if err != nil {
+				return err
+			}
+			index = next
+			continue
+		}
+		if next, ok := p.consumeList(index); ok {
+			index = next
+			continue
+		}
+		if isMarkdownHorizontalRule(p.lines[index].text) || isMarkdownReferenceDefinition(p.lines[index].text) {
+			index++
+			continue
+		}
+		if next, ok := p.consumeParagraph(index); ok {
+			index = next
+			continue
+		}
+		return fmt.Errorf("unsupported Markdown structure at line %d", p.lines[index].number)
+	}
+	return nil
+}
+
+func (p *markdownParser) skipFrontMatter() (int, error) {
+	if len(p.lines) == 0 || strings.TrimSpace(strings.TrimPrefix(p.lines[0].text, "\ufeff")) != "---" {
+		return 0, nil
+	}
+	if len(p.lines) == 1 || !looksLikeFrontMatter(p.lines[1].text) {
+		return 0, nil
+	}
+	for index := 1; index < len(p.lines); index++ {
+		if strings.TrimSpace(p.lines[index].text) != "---" && strings.TrimSpace(p.lines[index].text) != "..." {
+			continue
+		}
+		return index + 1, nil
+	}
+	return 0, fmt.Errorf("unclosed YAML front matter")
+}
+
+func looksLikeFrontMatter(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.Contains(trimmed, ":") || strings.HasPrefix(trimmed, "{")
+}
+
+type markdownFence struct {
+	marker byte
+	length int
+	info   string
+}
+
+func (p *markdownParser) consumeFence(index int) (int, bool, error) {
+	fence, ok := markdownFenceStart(p.lines[index].text)
+	if !ok {
+		return index, false, nil
+	}
+	for cursor := index + 1; cursor < len(p.lines); cursor++ {
+		if !markdownFenceClose(p.lines[cursor].text, fence) {
+			if comment, commentStart, ok := codeComment(p.lines[cursor].text); ok {
+				p.addSpan([]markdownLine{p.lines[cursor]}, commentStart, ContentClassProcedural, comment)
+			}
+			continue
+		}
+		return cursor + 1, true, nil
+	}
+	return index, true, fmt.Errorf("unclosed %s code fence at line %d", strings.Repeat(string(fence.marker), fence.length), p.lines[index].number)
+}
+
+func markdownFenceStart(line string) (markdownFence, bool) {
+	indent := leadingSpaces(line)
+	if indent > 3 || len(line) < indent+3 {
+		return markdownFence{}, false
+	}
+	marker := line[indent]
+	if marker != '`' && marker != '~' {
+		return markdownFence{}, false
+	}
+	length := 0
+	for indent+length < len(line) && line[indent+length] == marker {
+		length++
+	}
+	if length < 3 {
+		return markdownFence{}, false
+	}
+	return markdownFence{marker: marker, length: length, info: strings.TrimSpace(line[indent+length:])}, true
+}
+
+func markdownFenceClose(line string, fence markdownFence) bool {
+	indent := leadingSpaces(line)
+	if indent > 3 || len(line) < indent+fence.length {
+		return false
+	}
+	for offset := 0; offset < fence.length; offset++ {
+		if line[indent+offset] != fence.marker {
+			return false
+		}
+	}
+	return strings.TrimSpace(line[indent+fence.length:]) == ""
+}
+
+func validateMarkdownInlineCode(lines []markdownLine) error {
+	var fence *markdownFence
+	openLength := 0
+	for _, line := range lines {
+		if fence != nil {
+			if markdownFenceClose(line.text, *fence) {
+				fence = nil
+			}
+			continue
+		}
+		if nextFence, ok := markdownFenceStart(line.text); ok {
+			fence = &nextFence
+			continue
+		}
+		for index := 0; index < len(line.text); {
+			if line.text[index] == '\\' && index+1 < len(line.text) {
+				index += 2
+				continue
+			}
+			if line.text[index] != '`' {
+				index++
+				continue
+			}
+			end := index
+			for end < len(line.text) && line.text[end] == '`' {
+				end++
+			}
+			runLength := end - index
+			if openLength == 0 {
+				openLength = runLength
+			} else if openLength == runLength {
+				openLength = 0
+			}
+			index = end
+		}
+	}
+	if fence != nil {
+		return fmt.Errorf("unclosed %s code fence at line %d", strings.Repeat(string(fence.marker), fence.length), lines[len(lines)-1].number)
+	}
+	if openLength != 0 {
+		return fmt.Errorf("unclosed inline code span")
+	}
+	return nil
+}
+
+func codeComment(line string) (string, int, bool) {
+	indent := leadingSpaces(line)
+	text := line[indent:]
+	markerLength := 0
+	switch {
+	case strings.HasPrefix(text, "#"):
+		markerLength = 1
+	case strings.HasPrefix(text, "//"):
+		markerLength = 2
+	default:
+		return "", 0, false
+	}
+	start := indent + markerLength
+	for start < len(line) && (line[start] == ' ' || line[start] == '\t') {
+		start++
+	}
+	comment := strings.TrimSpace(line[start:])
+	if !looksLikeNaturalComment(comment) {
+		return "", 0, false
+	}
+	return comment, start, true
+}
+
+func looksLikeNaturalComment(comment string) bool {
+	if comment == "" || strings.HasPrefix(comment, "!") || strings.HasPrefix(comment, "#include") {
+		return false
+	}
+	if strings.HasPrefix(strings.ToLower(comment), "todo:") || strings.HasPrefix(strings.ToLower(comment), "nolint") {
+		return false
+	}
+	for _, value := range comment {
+		if unicode.IsLetter(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *markdownParser) consumeHTMLComment(index int) (int, bool, error) {
+	line := p.lines[index]
+	open := strings.Index(line.text, "<!--")
+	if open < 0 || strings.TrimSpace(line.text[:open]) != "" {
+		return index, false, nil
+	}
+	closeLine, close := findHTMLCommentClose(p.lines, index, open)
+	if !close {
+		return index, true, fmt.Errorf("unclosed HTML comment at line %d", line.number)
+	}
+	raw := p.source[line.start+open : p.lines[closeLine].end]
+	body := htmlCommentBody(raw)
+	if class, ok, err := parseMarkdownClassDirective(body); ok {
+		if err != nil {
+			return closeLine + 1, true, err
+		}
+		p.pendingClass = class
+		p.hasPendingClass = true
+		return closeLine + 1, true, nil
+	}
+	if strings.Contains(strings.ToLower(body), "prosecheck:ignore") {
+		suppression, err := ParseSuppressionDirective(raw)
+		if err != nil {
+			p.addMalformedComment(raw, line, open)
+		} else {
+			p.pendingSuppressions = append(p.pendingSuppressions, suppression)
+		}
+		return closeLine + 1, true, nil
+	}
+	if strings.Contains(strings.ToLower(body), "prosecheck:") {
+		return closeLine + 1, true, fmt.Errorf("unsupported prosecheck directive at line %d", line.number)
+	}
+	comment := strings.TrimSpace(body)
+	if comment != "" {
+		start := open + len("<!--")
+		for start < len(line.text) && (line.text[start] == ' ' || line.text[start] == '\t') {
+			start++
+		}
+		p.addTextSpan(line, start, ContentClassDescriptive, comment)
+	}
+	return closeLine + 1, true, nil
+}
+
+func findHTMLCommentClose(lines []markdownLine, start, open int) (int, bool) {
+	for index := start; index < len(lines); index++ {
+		from := 0
+		if index == start {
+			from = open + len("<!--")
+		}
+		if strings.Index(lines[index].text[from:], "-->") >= 0 {
+			return index, true
+		}
+	}
+	return 0, false
+}
+
+func htmlCommentBody(raw string) string {
+	body := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(raw), "<!--"), "-->"))
+	return body
+}
+
+func parseMarkdownClassDirective(body string) (ContentClass, bool, error) {
+	trimmed := strings.TrimSpace(body)
+	lower := strings.ToLower(trimmed)
+	if !strings.HasPrefix(lower, "prosecheck:") {
+		return "", false, nil
+	}
+	rest := strings.TrimSpace(trimmed[len("prosecheck:"):])
+	if strings.HasPrefix(strings.ToLower(rest), "ignore") {
+		return "", false, nil
+	}
+	if strings.HasPrefix(strings.ToLower(rest), "class") {
+		rest = strings.TrimSpace(rest[len("class"):])
+		if strings.HasPrefix(rest, "=") {
+			rest = strings.TrimSpace(rest[1:])
+		}
+		class := ContentClass(strings.ToLower(rest))
+		switch class {
+		case ContentClassLabel, ContentClassProcedural, ContentClassDescriptive, ContentClassTechnical, ContentClassTerm:
+			return class, true, nil
+		default:
+			return "", true, fmt.Errorf("unsupported prosecheck content class %q", rest)
+		}
+	}
+	class := ContentClass(strings.ToLower(rest))
+	switch class {
+	case ContentClassLabel, ContentClassProcedural, ContentClassDescriptive, ContentClassTechnical, ContentClassTerm:
+		return class, true, nil
+	default:
+		return "", false, nil
+	}
+}
+
+func (p *markdownParser) addMalformedComment(raw string, line markdownLine, open int) {
+	start := open
+	span := Span{
+		SourcePath:  p.sourcePath,
+		StartLine:   line.number,
+		StartColumn: runeColumn(line.text[:start]) + 1,
+		Class:       p.pendingContentClass(ContentClassDescriptive),
+		Text:        raw,
+		Protected:   markdownProtectedRanges(raw),
+	}
+	p.spans = append(p.spans, span)
+	p.clearPending()
+}
+
+func (p *markdownParser) consumeHeading(index int) (int, bool) {
+	line := p.lines[index]
+	if heading, start, ok := markdownATXHeading(line.text); ok {
+		p.addTextSpan(line, start, ContentClassLabel, heading)
+		return index + 1, true
+	}
+	if index+1 < len(p.lines) && !isMarkdownBlank(line.text) && isSetextUnderline(p.lines[index+1].text) {
+		start := leadingSpaces(line.text)
+		p.addTextSpan(line, start, ContentClassLabel, strings.TrimSpace(line.text[start:]))
+		return index + 2, true
+	}
+	return index, false
+}
+
+func markdownATXHeading(line string) (string, int, bool) {
+	indent := leadingSpaces(line)
+	if indent > 3 || len(line) <= indent || line[indent] != '#' {
+		return "", 0, false
+	}
+	count := 0
+	for indent+count < len(line) && line[indent+count] == '#' {
+		count++
+	}
+	if count == 0 || count > 6 || (indent+count < len(line) && line[indent+count] != ' ' && line[indent+count] != '\t') {
+		return "", 0, false
+	}
+	start := indent + count
+	for start < len(line) && (line[start] == ' ' || line[start] == '\t') {
+		start++
+	}
+	end := len(line)
+	for end > start && (line[end-1] == ' ' || line[end-1] == '\t') {
+		end--
+	}
+	if end > start && line[end-1] == '#' {
+		trimmed := end
+		for trimmed > start && line[trimmed-1] == '#' {
+			trimmed--
+		}
+		if trimmed == start || (trimmed > start && (line[trimmed-1] == ' ' || line[trimmed-1] == '\t')) {
+			end = trimmed
+			for end > start && (line[end-1] == ' ' || line[end-1] == '\t') {
+				end--
+			}
+		}
+	}
+	if end <= start {
+		return "", 0, false
+	}
+	return line[start:end], start, true
+}
+
+func isSetextUnderline(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if len(trimmed) < 3 {
+		return false
+	}
+	return strings.Trim(trimmed, "=") == "" || strings.Trim(trimmed, "-") == ""
+}
+
+func (p *markdownParser) consumeTable(index int) (int, bool, error) {
+	if index+1 >= len(p.lines) {
+		return index, false, nil
+	}
+	header := splitMarkdownTableCells(p.lines[index].text)
+	separator := splitMarkdownTableCells(p.lines[index+1].text)
+	if len(header) < 2 || len(header) != len(separator) || !tableSeparatorCells(p.lines[index+1].text, separator) {
+		if looksLikeMarkdownTable(p.lines, index) {
+			return index, true, fmt.Errorf("malformed Markdown table at line %d", p.lines[index].number)
+		}
+		return index, false, nil
+	}
+	end := index + 2
+	for end < len(p.lines) && !isMarkdownBlank(p.lines[end].text) && strings.Contains(p.lines[end].text, "|") {
+		cells := splitMarkdownTableCells(p.lines[end].text)
+		if len(cells) != len(header) {
+			return index, true, fmt.Errorf("Markdown table row at line %d has %d cells; expected %d", p.lines[end].number, len(cells), len(header))
+		}
+		end++
+	}
+	p.addTableRow(p.lines[index], header, ContentClassLabel)
+	for row := index + 2; row < end; row++ {
+		p.addTableRow(p.lines[row], splitMarkdownTableCells(p.lines[row].text), ContentClassDescriptive)
+	}
+	return end, true, nil
+}
+
+type markdownCell struct {
+	start int
+	end   int
+}
+
+func splitMarkdownTableCells(line string) []markdownCell {
+	var cells []markdownCell
+	start := 0
+	inCode := false
+	escaped := false
+	for index := 0; index < len(line); index++ {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if line[index] == '\\' {
+			escaped = true
+			continue
+		}
+		if line[index] == '`' {
+			inCode = !inCode
+			continue
+		}
+		if line[index] == '|' && !inCode {
+			cells = append(cells, markdownCell{start: start, end: index})
+			start = index + 1
+		}
+	}
+	cells = append(cells, markdownCell{start: start, end: len(line)})
+	if len(cells) > 0 && strings.TrimSpace(line[cells[0].start:cells[0].end]) == "" && strings.HasPrefix(strings.TrimSpace(line), "|") {
+		cells = cells[1:]
+	}
+	if len(cells) > 0 && strings.TrimSpace(line[cells[len(cells)-1].start:cells[len(cells)-1].end]) == "" && strings.HasSuffix(strings.TrimSpace(line), "|") {
+		cells = cells[:len(cells)-1]
+	}
+	return cells
+}
+
+func tableSeparatorCells(line string, cells []markdownCell) bool {
+	if len(cells) == 0 {
+		return false
+	}
+	for _, cell := range cells {
+		if !isTableSeparatorCell(line[cell.start:cell.end]) {
+			return false
+		}
+	}
+	return true
+}
+
+func looksLikeMarkdownTable(lines []markdownLine, index int) bool {
+	if index+1 >= len(lines) || !strings.Contains(lines[index].text, "|") || !strings.Contains(lines[index+1].text, "|") {
+		return false
+	}
+	return strings.Contains(lines[index+1].text, "-")
+}
+
+func isTableSeparatorCell(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	trimmed = strings.TrimPrefix(trimmed, ":")
+	trimmed = strings.TrimSuffix(trimmed, ":")
+	return len(trimmed) >= 3 && strings.Trim(trimmed, "-") == ""
+}
+
+func (p *markdownParser) addTableRow(line markdownLine, cells []markdownCell, class ContentClass) {
+	for _, cell := range cells {
+		start, end := trimMarkdownCell(line.text, cell.start, cell.end)
+		if start >= end {
+			continue
+		}
+		p.addTextSpan(line, start, class, line.text[start:end])
+	}
+}
+
+func trimMarkdownCell(line string, start, end int) (int, int) {
+	for start < end && (line[start] == ' ' || line[start] == '\t') {
+		start++
+	}
+	for end > start && (line[end-1] == ' ' || line[end-1] == '\t') {
+		end--
+	}
+	return start, end
+}
+
+func (p *markdownParser) consumeAdmonition(index int) (int, bool, error) {
+	if isQuoteLine(p.lines[index].text) {
+		return p.consumeQuote(index)
+	}
+	if isContainerAdmonition(p.lines[index].text) {
+		return p.consumeContainerAdmonition(index)
+	}
+	if !isDirectiveAdmonition(p.lines[index].text) {
+		return index, false, nil
+	}
+	start := index + 1
+	for start < len(p.lines) && isMarkdownBlank(p.lines[start].text) {
+		start++
+	}
+	if start >= len(p.lines) || leadingSpaces(p.lines[start].text) < 3 {
+		return index, true, fmt.Errorf("admonition at line %d has no indented body", p.lines[index].number)
+	}
+	end := start
+	for end < len(p.lines) {
+		if isMarkdownBlank(p.lines[end].text) {
+			if end+1 < len(p.lines) && leadingSpaces(p.lines[end+1].text) >= 3 {
+				end++
+				continue
+			}
+			break
+		}
+		if leadingSpaces(p.lines[end].text) >= 3 {
+			end++
+			continue
+		}
+		break
+	}
+	firstStart := leadingSpaces(p.lines[start].text)
+	p.addSpan(p.lines[start:end], firstStart, ContentClassDescriptive, p.lines[start].text[firstStart:])
+	return end, true, nil
+}
+
+func (p *markdownParser) consumeContainerAdmonition(index int) (int, bool, error) {
+	for end := index + 1; end < len(p.lines); end++ {
+		if strings.TrimSpace(p.lines[end].text) != ":::" {
+			continue
+		}
+		start := index + 1
+		for start < end && isMarkdownBlank(p.lines[start].text) {
+			start++
+		}
+		if start < end {
+			firstStart := leadingSpaces(p.lines[start].text)
+			p.addSpan(p.lines[start:end], firstStart, ContentClassDescriptive, p.lines[start].text[firstStart:])
+		}
+		return end + 1, true, nil
+	}
+	return index, true, fmt.Errorf("unclosed container admonition at line %d", p.lines[index].number)
+}
+
+func (p *markdownParser) consumeQuote(index int) (int, bool, error) {
+	end := index
+	for end < len(p.lines) && isQuoteLine(p.lines[end].text) {
+		end++
+	}
+	first := index
+	for first < end {
+		contentStart, content := quoteContent(p.lines[first].text)
+		if markerText, markerOffset, ok := inlineAdmonitionContent(content); ok {
+			p.addTextSpan(p.lines[first], contentStart+markerOffset, ContentClassDescriptive, markerText)
+			first++
+			continue
+		}
+		if strings.TrimSpace(content) != "" && !isAdmonitionMarker(content) {
+			p.addSpan(p.lines[first:end], contentStart, ContentClassDescriptive, content)
+			return end, true, nil
+		}
+		first++
+	}
+	return end, true, nil
+}
+
+func isQuoteLine(line string) bool {
+	indent := leadingSpaces(line)
+	return indent <= 3 && indent < len(line) && line[indent] == '>'
+}
+
+func quoteContent(line string) (int, string) {
+	indent := leadingSpaces(line)
+	start := indent + 1
+	if start < len(line) && line[start] == ' ' {
+		start++
+	}
+	return start, line[start:]
+}
+
+func isAdmonitionMarker(content string) bool {
+	trimmed := strings.TrimSpace(content)
+	if strings.HasPrefix(trimmed, "[!") {
+		return strings.Contains(trimmed, "]")
+	}
+	return strings.HasPrefix(trimmed, "**Note:**") || strings.HasPrefix(trimmed, "**Warning:**") || strings.HasPrefix(trimmed, "**Tip:**")
+}
+
+func isDirectiveAdmonition(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "!!! ") || strings.HasPrefix(trimmed, "!!!\t") || isContainerAdmonition(line)
+}
+
+func isContainerAdmonition(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, ":::") && trimmed != ":::"
+}
+
+func inlineAdmonitionContent(content string) (string, int, bool) {
+	trimmed := strings.TrimSpace(content)
+	if !strings.HasPrefix(trimmed, "[!") {
+		return "", 0, false
+	}
+	close := strings.IndexByte(trimmed, ']')
+	if close < 0 {
+		return "", 0, false
+	}
+	start := strings.Index(content, trimmed) + close + 1
+	for start < len(content) && (content[start] == ' ' || content[start] == '\t') {
+		start++
+	}
+	if start >= len(content) {
+		return "", 0, false
+	}
+	return content[start:], start, true
+}
+
+func (p *markdownParser) consumeList(index int) (int, bool) {
+	indent, ordered, start, ok := markdownListMarker(p.lines[index].text)
+	if !ok {
+		return index, false
+	}
+	end := index + 1
+	for end < len(p.lines) {
+		if _, _, _, nextItem := markdownListMarker(p.lines[end].text); nextItem {
+			nextIndent, _, _, _ := markdownListMarker(p.lines[end].text)
+			if nextIndent <= indent {
+				break
+			}
+			break
+		}
+		if isMarkdownBlank(p.lines[end].text) {
+			if end+1 < len(p.lines) && leadingSpaces(p.lines[end+1].text) > indent {
+				end++
+				continue
+			}
+			break
+		}
+		if leadingSpaces(p.lines[end].text) <= indent {
+			break
+		}
+		end++
+	}
+	class := ContentClassDescriptive
+	if ordered {
+		class = ContentClassProcedural
+	}
+	p.addSpan(p.lines[index:end], start, class, p.lines[index].text[start:])
+	return end, true
+}
+
+func markdownListMarker(line string) (int, bool, int, bool) {
+	indent := leadingSpaces(line)
+	if indent > 3 || indent >= len(line) {
+		return 0, false, 0, false
+	}
+	if line[indent] == '-' || line[indent] == '*' || line[indent] == '+' {
+		start := indent + 1
+		if start < len(line) && (line[start] == ' ' || line[start] == '\t') {
+			for start < len(line) && (line[start] == ' ' || line[start] == '\t') {
+				start++
+			}
+			return indent, false, start, true
+		}
+		return 0, false, 0, false
+	}
+	digitStart := indent
+	for digitStart < len(line) && line[digitStart] >= '0' && line[digitStart] <= '9' {
+		digitStart++
+	}
+	if digitStart == indent || digitStart >= len(line) || (line[digitStart] != '.' && line[digitStart] != ')') {
+		return 0, false, 0, false
+	}
+	start := digitStart + 1
+	if start >= len(line) || (line[start] != ' ' && line[start] != '\t') {
+		return 0, false, 0, false
+	}
+	for start < len(line) && (line[start] == ' ' || line[start] == '\t') {
+		start++
+	}
+	return indent, true, start, true
+}
+
+func (p *markdownParser) consumeParagraph(index int) (int, bool) {
+	end := index + 1
+	for end < len(p.lines) {
+		if isMarkdownBlank(p.lines[end].text) || markdownStructuralStart(p.lines, end) {
+			break
+		}
+		if isIndentedCodeLine(p.lines[end].text) {
+			break
+		}
+		end++
+	}
+	line := p.lines[index]
+	start := leadingSpaces(line.text)
+	if start >= len(line.text) {
+		return end, false
+	}
+	p.addSpan(p.lines[index:end], start, ContentClassDescriptive, line.text[start:])
+	return end, true
+}
+
+func markdownStructuralStart(lines []markdownLine, index int) bool {
+	if _, ok := markdownFenceStart(lines[index].text); ok {
+		return true
+	}
+	if strings.TrimSpace(lines[index].text) == "<!--" || strings.HasPrefix(strings.TrimSpace(lines[index].text), "<!--") {
+		return true
+	}
+	if _, _, ok := markdownATXHeading(lines[index].text); ok {
+		return true
+	}
+	if _, _, _, ok := markdownListMarker(lines[index].text); ok {
+		return true
+	}
+	if isQuoteLine(lines[index].text) || isDirectiveAdmonition(lines[index].text) || isMarkdownHorizontalRule(lines[index].text) {
+		return true
+	}
+	if index+1 < len(lines) {
+		header := splitMarkdownTableCells(lines[index].text)
+		separator := splitMarkdownTableCells(lines[index+1].text)
+		if (len(header) >= 2 && len(header) == len(separator) && tableSeparatorCells(lines[index+1].text, separator)) || looksLikeMarkdownTable(lines, index) {
+			return true
+		}
+	}
+	if index+1 < len(lines) && isSetextUnderline(lines[index+1].text) {
+		return true
+	}
+	return false
+}
+
+func (p *markdownParser) addSpan(lines []markdownLine, firstStart int, fallbackClass ContentClass, firstText string) {
+	if len(lines) == 0 {
+		return
+	}
+	text := joinMarkdownLines(p.source, lines, firstStart)
+	if strings.TrimSpace(firstText) == "" || strings.TrimSpace(text) == "" {
+		return
+	}
+	class := p.pendingContentClass(fallbackClass)
+	suppressions := append([]Suppression(nil), p.pendingSuppressions...)
+	for index := range suppressions {
+		suppressions[index].StartOffset = 0
+		suppressions[index].EndOffset = len(text)
+	}
+	span := Span{
+		SourcePath:   p.sourcePath,
+		StartLine:    lines[0].number,
+		StartColumn:  runeColumn(lines[0].text[:firstStart]) + 1,
+		Class:        class,
+		Text:         text,
+		Protected:    markdownProtectedRanges(text),
+		Suppressions: suppressions,
+	}
+	p.spans = append(p.spans, span)
+	p.clearPending()
+}
+
+func (p *markdownParser) addTextSpan(line markdownLine, start int, fallbackClass ContentClass, text string) {
+	if strings.TrimSpace(text) == "" {
+		return
+	}
+	class := p.pendingContentClass(fallbackClass)
+	suppressions := append([]Suppression(nil), p.pendingSuppressions...)
+	for index := range suppressions {
+		suppressions[index].StartOffset = 0
+		suppressions[index].EndOffset = len(text)
+	}
+	p.spans = append(p.spans, Span{
+		SourcePath:   p.sourcePath,
+		StartLine:    line.number,
+		StartColumn:  runeColumn(line.text[:start]) + 1,
+		Class:        class,
+		Text:         text,
+		Protected:    markdownProtectedRanges(text),
+		Suppressions: suppressions,
+	})
+	p.clearPending()
+}
+
+func (p *markdownParser) pendingContentClass(fallback ContentClass) ContentClass {
+	if p.hasPendingClass {
+		return p.pendingClass
+	}
+	return fallback
+}
+
+func (p *markdownParser) clearPending() {
+	p.pendingClass = ""
+	p.hasPendingClass = false
+	p.pendingSuppressions = nil
+}
+
+func joinMarkdownLines(source string, lines []markdownLine, firstStart int) string {
+	var builder strings.Builder
+	for index, line := range lines {
+		start := 0
+		if index == 0 {
+			start = firstStart
+		}
+		if start < 0 || start > len(line.text) {
+			start = 0
+		}
+		builder.WriteString(line.text[start:])
+		if index+1 < len(lines) {
+			builder.WriteString(source[line.end:line.next])
+		}
+	}
+	return builder.String()
+}
+
+func markdownParseFinding(sourcePath string, data []byte, message string) Finding {
+	return parseFinding(Span{
+		SourcePath:  sourcePath,
+		StartLine:   1,
+		StartColumn: 1,
+		Class:       ContentClassTechnical,
+		Text:        string(data),
+	}, message, 0, 1)
+}
+
+func leadingSpaces(value string) int {
+	count := 0
+	for count < len(value) && (value[count] == ' ' || value[count] == '\t') {
+		count++
+	}
+	return count
+}
+
+func runeColumn(value string) int {
+	return utf8.RuneCountInString(value)
+}
+
+func isMarkdownBlank(value string) bool {
+	return strings.TrimSpace(value) == ""
+}
+
+func isIndentedCodeLine(value string) bool {
+	return strings.HasPrefix(value, "    ") || strings.HasPrefix(value, "\t")
+}
+
+func skipIndentedCode(lines []markdownLine, index int) int {
+	for index < len(lines) && (isMarkdownBlank(lines[index].text) || isIndentedCodeLine(lines[index].text)) {
+		index++
+	}
+	return index
+}
+
+func isMarkdownHorizontalRule(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if len(trimmed) < 3 {
+		return false
+	}
+	for _, marker := range []string{"-", "*", "_"} {
+		if strings.Trim(trimmed, marker) == "" {
+			return true
+		}
+	}
+	return false
+}
+
+func isMarkdownReferenceDefinition(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "[") && strings.Contains(trimmed, "]:")
+}
+
+func markdownProtectedRanges(text string) []TextRange {
+	ranges := append([]TextRange(nil), LexicalProtectedRanges(text)...)
+	ranges = append(ranges, markdownLinkRanges(text)...)
+	ranges = append(ranges, markdownHTMLRanges(text)...)
+	ranges = append(ranges, markdownRouteRanges(text)...)
+	ranges = append(ranges, markdownCommandLineRanges(text)...)
+	ranges = append(ranges, markdownStructuredLineRanges(text)...)
+	ranges = append(ranges, markdownQuotedOutputRanges(text)...)
+	ranges = append(ranges, markdownTechnicalTokenRanges(text)...)
+	return mergeMarkdownRanges(ranges)
+}
+
+func markdownLinkRanges(text string) []TextRange {
+	var ranges []TextRange
+	for search := 0; search < len(text); {
+		start := strings.Index(text[search:], "](")
+		if start < 0 {
+			break
+		}
+		start += search + 1
+		end := start + 1
+		depth := 1
+		for end < len(text) && depth > 0 {
+			if text[end] == '\\' {
+				end += 2
+				continue
+			}
+			switch text[end] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+			}
+			end++
+		}
+		if depth == 0 {
+			ranges = append(ranges, TextRange{Start: start, End: end})
+		}
+		search = end
+	}
+	return ranges
+}
+
+func markdownHTMLRanges(text string) []TextRange {
+	var ranges []TextRange
+	for search := 0; search < len(text); {
+		start := strings.IndexByte(text[search:], '<')
+		if start < 0 {
+			break
+		}
+		start += search
+		end := strings.IndexByte(text[start+1:], '>')
+		if end < 0 {
+			break
+		}
+		end += start + 2
+		raw := text[start:end]
+		if !strings.HasPrefix(raw, "<!--") || !strings.Contains(strings.ToLower(raw), "prosecheck:ignore") {
+			ranges = append(ranges, TextRange{Start: start, End: end})
+		}
+		search = end
+	}
+	return ranges
+}
+
+func markdownRouteRanges(text string) []TextRange {
+	pattern := regexp.MustCompile(`(?i)\b(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+[^\s]+`)
+	var ranges []TextRange
+	for _, match := range pattern.FindAllStringIndex(text, -1) {
+		end := match[1]
+		for end > match[0] && strings.ContainsRune(".,;:!?)]}", rune(text[end-1])) {
+			end--
+		}
+		ranges = append(ranges, TextRange{Start: match[0], End: end})
+	}
+	return ranges
+}
+
+func markdownCommandLineRanges(text string) []TextRange {
+	pattern := regexp.MustCompile(`(?im)^\s*(?:\$\s*)?(?:(?:you\s+(?:run|server|docs|factory|submit|session|work|init|serve|config|help|version)\b)|(?:git\s+(?:add|branch|checkout|commit|diff|log|pull|push|status)\b)|(?:go\s+(?:build|fmt|run|test|vet)\b)|(?:make\s+\S+)|(?:npm|pnpm|bun)\s+(?:install|run|test|exec|build)\b|(?:curl|wget|docker|kubectl|gh)\b)[^\r\n]*`)
+	var ranges []TextRange
+	for _, match := range pattern.FindAllStringIndex(text, -1) {
+		start := match[0]
+		for start < match[1] && (text[start] == ' ' || text[start] == '\t') {
+			start++
+		}
+		ranges = append(ranges, TextRange{Start: start, End: match[1]})
+	}
+	return ranges
+}
+
+func markdownStructuredLineRanges(text string) []TextRange {
+	var ranges []TextRange
+	start := 0
+	for start < len(text) {
+		end := strings.IndexByte(text[start:], '\n')
+		if end < 0 {
+			end = len(text)
+		} else {
+			end += start
+		}
+		line := strings.TrimSpace(strings.TrimSuffix(text[start:end], "\r"))
+		jsonArray := strings.HasPrefix(line, "[") && (strings.HasSuffix(line, "]") && strings.ContainsAny(line, "{}\"") || strings.Contains(line, `":`))
+		if strings.HasPrefix(line, "{") || strings.HasPrefix(line, "}") || jsonArray || strings.HasPrefix(line, "]") || strings.Contains(line, `":`) {
+			ranges = append(ranges, TextRange{Start: start, End: end})
+		}
+		if end == len(text) {
+			break
+		}
+		start = end + 1
+	}
+	return ranges
+}
+
+func markdownQuotedOutputRanges(text string) []TextRange {
+	pattern := regexp.MustCompile(`(?im)^\s*(?:\$\s*|(?:error|fatal|usage|exit status|stdout|stderr)\s*:)\S[^\r\n]*`)
+	var ranges []TextRange
+	for _, match := range pattern.FindAllStringIndex(text, -1) {
+		ranges = append(ranges, TextRange{Start: match[0], End: match[1]})
+	}
+	return ranges
+}
+
+func markdownTechnicalTokenRanges(text string) []TextRange {
+	var ranges []TextRange
+	for start := 0; start < len(text); {
+		for start < len(text) && unicode.IsSpace(rune(text[start])) {
+			start++
+		}
+		if start >= len(text) {
+			break
+		}
+		end := start
+		for end < len(text) && !unicode.IsSpace(rune(text[end])) {
+			end++
+		}
+		if strings.Contains(text[start:end], "](") {
+			start = end
+			continue
+		}
+		trimmedStart, trimmedEnd := trimTechnicalPunctuation(text, start, end)
+		if trimmedStart < trimmedEnd && (isMarkdownTechnicalToken(text[trimmedStart:trimmedEnd]) || isMarkdownMachineValue(text, trimmedStart, trimmedEnd)) {
+			ranges = append(ranges, TextRange{Start: trimmedStart, End: trimmedEnd})
+		}
+		start = end
+	}
+	return ranges
+}
+
+func isMarkdownMachineValue(text string, start, end int) bool {
+	context := start - 1
+	for context >= 0 && (text[context] == ' ' || text[context] == '\t') {
+		context--
+	}
+	if context < 0 || (text[context] != '=' && text[context] != ':') {
+		return false
+	}
+	value := text[start:end]
+	if value == "true" || value == "false" || value == "null" {
+		return true
+	}
+	for _, runeValue := range value {
+		if !unicode.IsDigit(runeValue) && runeValue != '.' && runeValue != '-' {
+			return false
+		}
+	}
+	return value != ""
+}
+
+func trimTechnicalPunctuation(text string, start, end int) (int, int) {
+	for start < end && strings.ContainsRune("\"'([{<", rune(text[start])) {
+		start++
+	}
+	for end > start && strings.ContainsRune("\"'.,;:!?)]}>", rune(text[end-1])) {
+		end--
+	}
+	return start, end
+}
+
+func isMarkdownTechnicalToken(value string) bool {
+	if value == "" || strings.Contains(value, "https://") || strings.Contains(value, "http://") {
+		return false
+	}
+	if strings.HasPrefix(value, "--") || strings.HasPrefix(value, "./") || strings.HasPrefix(value, "../") || strings.HasPrefix(value, "/") || strings.HasPrefix(value, "~\\") {
+		return true
+	}
+	if strings.HasPrefix(value, "B-") && strings.Contains(value, "-") {
+		return true
+	}
+	if strings.ContainsAny(value, "/\\") {
+		return true
+	}
+	upper, lower := 0, 0
+	mixedCase := false
+	for index, value := range value {
+		switch {
+		case unicode.IsUpper(value):
+			upper++
+			if index > 0 {
+				mixedCase = true
+			}
+		case unicode.IsLower(value):
+			lower++
+		}
+	}
+	if strings.Contains(value, "_") {
+		return true
+	}
+	return mixedCase && upper > 0 && lower > 0
+}
+
+func mergeMarkdownRanges(ranges []TextRange) []TextRange {
+	ordered := append([]TextRange(nil), ranges...)
+	slices.SortStableFunc(ordered, func(left, right TextRange) int {
+		if left.Start != right.Start {
+			return left.Start - right.Start
+		}
+		return left.End - right.End
+	})
+	merged := make([]TextRange, 0, len(ordered))
+	for _, item := range ordered {
+		if item.Start < 0 || item.End <= item.Start {
+			continue
+		}
+		if len(merged) == 0 || item.Start > merged[len(merged)-1].End {
+			merged = append(merged, item)
+			continue
+		}
+		if item.End > merged[len(merged)-1].End {
+			merged[len(merged)-1].End = item.End
+		}
+	}
+	return merged
+}

--- a/cmd/prosecheck/markdown.go
+++ b/cmd/prosecheck/markdown.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	"regexp"
-	"slices"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -35,6 +33,15 @@ func AnalyzeMarkdown(sourcePath string, data []byte, policy Policy) []Finding {
 		return []Finding{markdownParseFinding(sourcePath, data, err.Error())}
 	}
 	return Analyze(spans, policy)
+}
+
+func markdownSurfaceSelectors(sourcePath string) []string {
+	surfaces := []string{surfaceCustomerDocumentation}
+	path := normalizeSourcePath(sourcePath)
+	if strings.Contains(path, "/reference/") {
+		surfaces = append(surfaces, surfaceCLIReferenceDocumentation)
+	}
+	return surfaces
 }
 
 type markdownLine struct {
@@ -421,6 +428,7 @@ func (p *markdownParser) addMalformedComment(raw string, line markdownLine, open
 		StartColumn: runeColumn(line.text[:start]) + 1,
 		Class:       p.pendingContentClass(ContentClassDescriptive),
 		Text:        raw,
+		Surfaces:    markdownSurfaceSelectors(p.sourcePath),
 		Protected:   markdownProtectedRanges(raw),
 	}
 	p.spans = append(p.spans, span)
@@ -861,6 +869,7 @@ func (p *markdownParser) addSpan(lines []markdownLine, firstStart int, fallbackC
 		StartColumn:  runeColumn(lines[0].text[:firstStart]) + 1,
 		Class:        class,
 		Text:         text,
+		Surfaces:     markdownSurfaceSelectors(p.sourcePath),
 		Protected:    markdownProtectedRanges(text),
 		Suppressions: suppressions,
 	}
@@ -884,6 +893,7 @@ func (p *markdownParser) addTextSpan(line markdownLine, start int, fallbackClass
 		StartColumn:  runeColumn(line.text[:start]) + 1,
 		Class:        class,
 		Text:         text,
+		Surfaces:     markdownSurfaceSelectors(p.sourcePath),
 		Protected:    markdownProtectedRanges(text),
 		Suppressions: suppressions,
 	})
@@ -974,239 +984,4 @@ func isMarkdownHorizontalRule(line string) bool {
 func isMarkdownReferenceDefinition(line string) bool {
 	trimmed := strings.TrimSpace(line)
 	return strings.HasPrefix(trimmed, "[") && strings.Contains(trimmed, "]:")
-}
-
-func markdownProtectedRanges(text string) []TextRange {
-	ranges := append([]TextRange(nil), LexicalProtectedRanges(text)...)
-	ranges = append(ranges, markdownLinkRanges(text)...)
-	ranges = append(ranges, markdownHTMLRanges(text)...)
-	ranges = append(ranges, markdownRouteRanges(text)...)
-	ranges = append(ranges, markdownCommandLineRanges(text)...)
-	ranges = append(ranges, markdownStructuredLineRanges(text)...)
-	ranges = append(ranges, markdownQuotedOutputRanges(text)...)
-	ranges = append(ranges, markdownTechnicalTokenRanges(text)...)
-	return mergeMarkdownRanges(ranges)
-}
-
-func markdownLinkRanges(text string) []TextRange {
-	var ranges []TextRange
-	for search := 0; search < len(text); {
-		start := strings.Index(text[search:], "](")
-		if start < 0 {
-			break
-		}
-		start += search + 1
-		end := start + 1
-		depth := 1
-		for end < len(text) && depth > 0 {
-			if text[end] == '\\' {
-				end += 2
-				continue
-			}
-			switch text[end] {
-			case '(':
-				depth++
-			case ')':
-				depth--
-			}
-			end++
-		}
-		if depth == 0 {
-			ranges = append(ranges, TextRange{Start: start, End: end})
-		}
-		search = end
-	}
-	return ranges
-}
-
-func markdownHTMLRanges(text string) []TextRange {
-	var ranges []TextRange
-	for search := 0; search < len(text); {
-		start := strings.IndexByte(text[search:], '<')
-		if start < 0 {
-			break
-		}
-		start += search
-		end := strings.IndexByte(text[start+1:], '>')
-		if end < 0 {
-			break
-		}
-		end += start + 2
-		raw := text[start:end]
-		if !strings.HasPrefix(raw, "<!--") || !strings.Contains(strings.ToLower(raw), "prosecheck:ignore") {
-			ranges = append(ranges, TextRange{Start: start, End: end})
-		}
-		search = end
-	}
-	return ranges
-}
-
-func markdownRouteRanges(text string) []TextRange {
-	pattern := regexp.MustCompile(`(?i)\b(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+[^\s]+`)
-	var ranges []TextRange
-	for _, match := range pattern.FindAllStringIndex(text, -1) {
-		end := match[1]
-		for end > match[0] && strings.ContainsRune(".,;:!?)]}", rune(text[end-1])) {
-			end--
-		}
-		ranges = append(ranges, TextRange{Start: match[0], End: end})
-	}
-	return ranges
-}
-
-func markdownCommandLineRanges(text string) []TextRange {
-	pattern := regexp.MustCompile(`(?im)^\s*(?:\$\s*)?(?:(?:you\s+(?:run|server|docs|factory|submit|session|work|init|serve|config|help|version)\b)|(?:git\s+(?:add|branch|checkout|commit|diff|log|pull|push|status)\b)|(?:go\s+(?:build|fmt|run|test|vet)\b)|(?:make\s+\S+)|(?:npm|pnpm|bun)\s+(?:install|run|test|exec|build)\b|(?:curl|wget|docker|kubectl|gh)\b)[^\r\n]*`)
-	var ranges []TextRange
-	for _, match := range pattern.FindAllStringIndex(text, -1) {
-		start := match[0]
-		for start < match[1] && (text[start] == ' ' || text[start] == '\t') {
-			start++
-		}
-		ranges = append(ranges, TextRange{Start: start, End: match[1]})
-	}
-	return ranges
-}
-
-func markdownStructuredLineRanges(text string) []TextRange {
-	var ranges []TextRange
-	start := 0
-	for start < len(text) {
-		end := strings.IndexByte(text[start:], '\n')
-		if end < 0 {
-			end = len(text)
-		} else {
-			end += start
-		}
-		line := strings.TrimSpace(strings.TrimSuffix(text[start:end], "\r"))
-		jsonArray := strings.HasPrefix(line, "[") && (strings.HasSuffix(line, "]") && strings.ContainsAny(line, "{}\"") || strings.Contains(line, `":`))
-		if strings.HasPrefix(line, "{") || strings.HasPrefix(line, "}") || jsonArray || strings.HasPrefix(line, "]") || strings.Contains(line, `":`) {
-			ranges = append(ranges, TextRange{Start: start, End: end})
-		}
-		if end == len(text) {
-			break
-		}
-		start = end + 1
-	}
-	return ranges
-}
-
-func markdownQuotedOutputRanges(text string) []TextRange {
-	pattern := regexp.MustCompile(`(?im)^\s*(?:\$\s*|(?:error|fatal|usage|exit status|stdout|stderr)\s*:)\S[^\r\n]*`)
-	var ranges []TextRange
-	for _, match := range pattern.FindAllStringIndex(text, -1) {
-		ranges = append(ranges, TextRange{Start: match[0], End: match[1]})
-	}
-	return ranges
-}
-
-func markdownTechnicalTokenRanges(text string) []TextRange {
-	var ranges []TextRange
-	for start := 0; start < len(text); {
-		for start < len(text) && unicode.IsSpace(rune(text[start])) {
-			start++
-		}
-		if start >= len(text) {
-			break
-		}
-		end := start
-		for end < len(text) && !unicode.IsSpace(rune(text[end])) {
-			end++
-		}
-		if strings.Contains(text[start:end], "](") {
-			start = end
-			continue
-		}
-		trimmedStart, trimmedEnd := trimTechnicalPunctuation(text, start, end)
-		if trimmedStart < trimmedEnd && (isMarkdownTechnicalToken(text[trimmedStart:trimmedEnd]) || isMarkdownMachineValue(text, trimmedStart, trimmedEnd)) {
-			ranges = append(ranges, TextRange{Start: trimmedStart, End: trimmedEnd})
-		}
-		start = end
-	}
-	return ranges
-}
-
-func isMarkdownMachineValue(text string, start, end int) bool {
-	context := start - 1
-	for context >= 0 && (text[context] == ' ' || text[context] == '\t') {
-		context--
-	}
-	if context < 0 || (text[context] != '=' && text[context] != ':') {
-		return false
-	}
-	value := text[start:end]
-	if value == "true" || value == "false" || value == "null" {
-		return true
-	}
-	for _, runeValue := range value {
-		if !unicode.IsDigit(runeValue) && runeValue != '.' && runeValue != '-' {
-			return false
-		}
-	}
-	return value != ""
-}
-
-func trimTechnicalPunctuation(text string, start, end int) (int, int) {
-	for start < end && strings.ContainsRune("\"'([{<", rune(text[start])) {
-		start++
-	}
-	for end > start && strings.ContainsRune("\"'.,;:!?)]}>", rune(text[end-1])) {
-		end--
-	}
-	return start, end
-}
-
-func isMarkdownTechnicalToken(value string) bool {
-	if value == "" || strings.Contains(value, "https://") || strings.Contains(value, "http://") {
-		return false
-	}
-	if strings.HasPrefix(value, "--") || strings.HasPrefix(value, "./") || strings.HasPrefix(value, "../") || strings.HasPrefix(value, "/") || strings.HasPrefix(value, "~\\") {
-		return true
-	}
-	if strings.HasPrefix(value, "B-") && strings.Contains(value, "-") {
-		return true
-	}
-	if strings.ContainsAny(value, "/\\") {
-		return true
-	}
-	upper, lower := 0, 0
-	mixedCase := false
-	for index, value := range value {
-		switch {
-		case unicode.IsUpper(value):
-			upper++
-			if index > 0 {
-				mixedCase = true
-			}
-		case unicode.IsLower(value):
-			lower++
-		}
-	}
-	if strings.Contains(value, "_") {
-		return true
-	}
-	return mixedCase && upper > 0 && lower > 0
-}
-
-func mergeMarkdownRanges(ranges []TextRange) []TextRange {
-	ordered := append([]TextRange(nil), ranges...)
-	slices.SortStableFunc(ordered, func(left, right TextRange) int {
-		if left.Start != right.Start {
-			return left.Start - right.Start
-		}
-		return left.End - right.End
-	})
-	merged := make([]TextRange, 0, len(ordered))
-	for _, item := range ordered {
-		if item.Start < 0 || item.End <= item.Start {
-			continue
-		}
-		if len(merged) == 0 || item.Start > merged[len(merged)-1].End {
-			merged = append(merged, item)
-			continue
-		}
-		if item.End > merged[len(merged)-1].End {
-			merged[len(merged)-1].End = item.End
-		}
-	}
-	return merged
 }

--- a/cmd/prosecheck/markdown.go
+++ b/cmd/prosecheck/markdown.go
@@ -36,12 +36,17 @@ func AnalyzeMarkdown(sourcePath string, data []byte, policy Policy) []Finding {
 }
 
 func markdownSurfaceSelectors(sourcePath string) []string {
-	surfaces := []string{surfaceCustomerDocumentation}
 	path := normalizeSourcePath(sourcePath)
-	if strings.Contains(path, "/reference/") {
-		surfaces = append(surfaces, surfaceCLIReferenceDocumentation)
+	if strings.Contains(path, "/architecture/") || strings.HasPrefix(path, "architecture/") {
+		return []string{surfaceInternalArchitecture}
 	}
-	return surfaces
+	if strings.Contains(path, "/internal/") || strings.HasPrefix(path, "internal/") || strings.HasPrefix(path, "pkg/") || strings.HasPrefix(path, "cmd/") {
+		return []string{surfaceImplementationRuntimePackages}
+	}
+	if strings.Contains(path, "/reference/") {
+		return []string{surfaceCLIReferenceDocumentation}
+	}
+	return []string{surfaceCustomerDocumentation}
 }
 
 type markdownLine struct {

--- a/cmd/prosecheck/markdown_protection.go
+++ b/cmd/prosecheck/markdown_protection.go
@@ -7,6 +7,12 @@ import (
 	"unicode"
 )
 
+var (
+	markdownProviderPattern = regexp.MustCompile(`(?i)\b(?:codex|cursor(?:-acp)?|openai|anthropic|ollama)\b`)
+	markdownModelPattern    = regexp.MustCompile(`(?i)\b(?:gpt(?:-[a-z0-9.]+)+|claude(?:-[a-z0-9.]+)+|llama[0-9.]*|mistral(?:-[a-z0-9.]+)+|qwen[0-9.]*|gemma(?:-[a-z0-9.]+)+)\b`)
+	markdownYAMLKeyPattern  = regexp.MustCompile(`(?i)^\s*(?:-\s*)?(?:event|schema|state|status|type|kind|code|id|name|provider|model|route|path|method|operationid|error|message|default|value|version)\s*:\s*\S`)
+)
+
 func markdownProtectedRanges(text string) []TextRange {
 	ranges := append([]TextRange(nil), LexicalProtectedRanges(text)...)
 	ranges = append(ranges, markdownLinkRanges(text)...)
@@ -16,7 +22,18 @@ func markdownProtectedRanges(text string) []TextRange {
 	ranges = append(ranges, markdownStructuredLineRanges(text)...)
 	ranges = append(ranges, markdownQuotedOutputRanges(text)...)
 	ranges = append(ranges, markdownTechnicalTokenRanges(text)...)
+	ranges = append(ranges, markdownRegexRanges(text, markdownProviderPattern)...)
+	ranges = append(ranges, markdownRegexRanges(text, markdownModelPattern)...)
 	return mergeMarkdownRanges(ranges)
+}
+
+func markdownRegexRanges(text string, pattern *regexp.Regexp) []TextRange {
+	matches := pattern.FindAllStringIndex(text, -1)
+	ranges := make([]TextRange, 0, len(matches))
+	for _, match := range matches {
+		ranges = append(ranges, TextRange{Start: match[0], End: match[1]})
+	}
+	return ranges
 }
 
 func markdownLinkRanges(text string) []TextRange {
@@ -110,7 +127,7 @@ func markdownStructuredLineRanges(text string) []TextRange {
 		}
 		line := strings.TrimSpace(strings.TrimSuffix(text[start:end], "\r"))
 		jsonArray := strings.HasPrefix(line, "[") && (strings.HasSuffix(line, "]") && strings.ContainsAny(line, "{}\"") || strings.Contains(line, `":`))
-		if strings.HasPrefix(line, "{") || strings.HasPrefix(line, "}") || jsonArray || strings.HasPrefix(line, "]") || strings.Contains(line, `":`) {
+		if strings.HasPrefix(line, "{") || strings.HasPrefix(line, "}") || jsonArray || strings.HasPrefix(line, "]") || strings.Contains(line, `":`) || markdownYAMLKeyPattern.MatchString(line) {
 			ranges = append(ranges, TextRange{Start: start, End: end})
 		}
 		if end == len(text) {
@@ -122,7 +139,7 @@ func markdownStructuredLineRanges(text string) []TextRange {
 }
 
 func markdownQuotedOutputRanges(text string) []TextRange {
-	pattern := regexp.MustCompile(`(?im)^\s*(?:\$\s*|(?:error|fatal|usage|exit status|stdout|stderr)\s*:)\S[^\r\n]*`)
+	pattern := regexp.MustCompile(`(?im)^\s*(?:\$\s*|(?:error|fatal|usage|exit status|stdout|stderr)\s*:\s*)\S[^\r\n]*`)
 	var ranges []TextRange
 	for _, match := range pattern.FindAllStringIndex(text, -1) {
 		ranges = append(ranges, TextRange{Start: match[0], End: match[1]})

--- a/cmd/prosecheck/markdown_protection.go
+++ b/cmd/prosecheck/markdown_protection.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"regexp"
+	"slices"
+	"strings"
+	"unicode"
+)
+
+func markdownProtectedRanges(text string) []TextRange {
+	ranges := append([]TextRange(nil), LexicalProtectedRanges(text)...)
+	ranges = append(ranges, markdownLinkRanges(text)...)
+	ranges = append(ranges, markdownHTMLRanges(text)...)
+	ranges = append(ranges, markdownRouteRanges(text)...)
+	ranges = append(ranges, markdownCommandLineRanges(text)...)
+	ranges = append(ranges, markdownStructuredLineRanges(text)...)
+	ranges = append(ranges, markdownQuotedOutputRanges(text)...)
+	ranges = append(ranges, markdownTechnicalTokenRanges(text)...)
+	return mergeMarkdownRanges(ranges)
+}
+
+func markdownLinkRanges(text string) []TextRange {
+	var ranges []TextRange
+	for search := 0; search < len(text); {
+		start := strings.Index(text[search:], "](")
+		if start < 0 {
+			break
+		}
+		start += search + 1
+		end := start + 1
+		depth := 1
+		for end < len(text) && depth > 0 {
+			if text[end] == '\\' {
+				end += 2
+				continue
+			}
+			switch text[end] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+			}
+			end++
+		}
+		if depth == 0 {
+			ranges = append(ranges, TextRange{Start: start, End: end})
+		}
+		search = end
+	}
+	return ranges
+}
+
+func markdownHTMLRanges(text string) []TextRange {
+	var ranges []TextRange
+	for search := 0; search < len(text); {
+		start := strings.IndexByte(text[search:], '<')
+		if start < 0 {
+			break
+		}
+		start += search
+		end := strings.IndexByte(text[start+1:], '>')
+		if end < 0 {
+			break
+		}
+		end += start + 2
+		raw := text[start:end]
+		if !strings.HasPrefix(raw, "<!--") || !strings.Contains(strings.ToLower(raw), "prosecheck:ignore") {
+			ranges = append(ranges, TextRange{Start: start, End: end})
+		}
+		search = end
+	}
+	return ranges
+}
+
+func markdownRouteRanges(text string) []TextRange {
+	pattern := regexp.MustCompile(`(?i)\b(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+[^\s]+`)
+	var ranges []TextRange
+	for _, match := range pattern.FindAllStringIndex(text, -1) {
+		end := match[1]
+		for end > match[0] && strings.ContainsRune(".,;:!?)]}", rune(text[end-1])) {
+			end--
+		}
+		ranges = append(ranges, TextRange{Start: match[0], End: end})
+	}
+	return ranges
+}
+
+func markdownCommandLineRanges(text string) []TextRange {
+	pattern := regexp.MustCompile(`(?im)^\s*(?:\$\s*)?(?:(?:you\s+(?:run|server|docs|factory|submit|session|work|init|serve|config|help|version)\b)|(?:git\s+(?:add|branch|checkout|commit|diff|log|pull|push|status)\b)|(?:go\s+(?:build|fmt|run|test|vet)\b)|(?:make\s+\S+)|(?:npm|pnpm|bun)\s+(?:install|run|test|exec|build)\b|(?:curl|wget|docker|kubectl|gh)\b)[^\r\n]*`)
+	var ranges []TextRange
+	for _, match := range pattern.FindAllStringIndex(text, -1) {
+		start := match[0]
+		for start < match[1] && (text[start] == ' ' || text[start] == '\t') {
+			start++
+		}
+		ranges = append(ranges, TextRange{Start: start, End: match[1]})
+	}
+	return ranges
+}
+
+func markdownStructuredLineRanges(text string) []TextRange {
+	var ranges []TextRange
+	start := 0
+	for start < len(text) {
+		end := strings.IndexByte(text[start:], '\n')
+		if end < 0 {
+			end = len(text)
+		} else {
+			end += start
+		}
+		line := strings.TrimSpace(strings.TrimSuffix(text[start:end], "\r"))
+		jsonArray := strings.HasPrefix(line, "[") && (strings.HasSuffix(line, "]") && strings.ContainsAny(line, "{}\"") || strings.Contains(line, `":`))
+		if strings.HasPrefix(line, "{") || strings.HasPrefix(line, "}") || jsonArray || strings.HasPrefix(line, "]") || strings.Contains(line, `":`) {
+			ranges = append(ranges, TextRange{Start: start, End: end})
+		}
+		if end == len(text) {
+			break
+		}
+		start = end + 1
+	}
+	return ranges
+}
+
+func markdownQuotedOutputRanges(text string) []TextRange {
+	pattern := regexp.MustCompile(`(?im)^\s*(?:\$\s*|(?:error|fatal|usage|exit status|stdout|stderr)\s*:)\S[^\r\n]*`)
+	var ranges []TextRange
+	for _, match := range pattern.FindAllStringIndex(text, -1) {
+		ranges = append(ranges, TextRange{Start: match[0], End: match[1]})
+	}
+	return ranges
+}
+
+func markdownTechnicalTokenRanges(text string) []TextRange {
+	var ranges []TextRange
+	for start := 0; start < len(text); {
+		for start < len(text) && unicode.IsSpace(rune(text[start])) {
+			start++
+		}
+		if start >= len(text) {
+			break
+		}
+		end := start
+		for end < len(text) && !unicode.IsSpace(rune(text[end])) {
+			end++
+		}
+		if strings.Contains(text[start:end], "](") {
+			start = end
+			continue
+		}
+		trimmedStart, trimmedEnd := trimTechnicalPunctuation(text, start, end)
+		if trimmedStart < trimmedEnd && (isMarkdownTechnicalToken(text[trimmedStart:trimmedEnd]) || isMarkdownMachineValue(text, trimmedStart, trimmedEnd)) {
+			ranges = append(ranges, TextRange{Start: trimmedStart, End: trimmedEnd})
+		}
+		start = end
+	}
+	return ranges
+}
+
+func isMarkdownMachineValue(text string, start, end int) bool {
+	context := start - 1
+	for context >= 0 && (text[context] == ' ' || text[context] == '\t') {
+		context--
+	}
+	if context < 0 || (text[context] != '=' && text[context] != ':') {
+		return false
+	}
+	value := text[start:end]
+	if value == "true" || value == "false" || value == "null" {
+		return true
+	}
+	for _, runeValue := range value {
+		if !unicode.IsDigit(runeValue) && runeValue != '.' && runeValue != '-' {
+			return false
+		}
+	}
+	return value != ""
+}
+
+func trimTechnicalPunctuation(text string, start, end int) (int, int) {
+	for start < end && strings.ContainsRune("\"'([{<", rune(text[start])) {
+		start++
+	}
+	for end > start && strings.ContainsRune("\"'.,;:!?)]}>", rune(text[end-1])) {
+		end--
+	}
+	return start, end
+}
+
+func isMarkdownTechnicalToken(value string) bool {
+	if value == "" || strings.Contains(value, "https://") || strings.Contains(value, "http://") {
+		return false
+	}
+	if strings.HasPrefix(value, "--") || strings.HasPrefix(value, "./") || strings.HasPrefix(value, "../") || strings.HasPrefix(value, "/") || strings.HasPrefix(value, "~\\") {
+		return true
+	}
+	if strings.HasPrefix(value, "B-") && strings.Contains(value, "-") {
+		return true
+	}
+	if strings.ContainsAny(value, "/\\") {
+		return true
+	}
+	upper, lower := 0, 0
+	mixedCase := false
+	for index, value := range value {
+		switch {
+		case unicode.IsUpper(value):
+			upper++
+			if index > 0 {
+				mixedCase = true
+			}
+		case unicode.IsLower(value):
+			lower++
+		}
+	}
+	if strings.Contains(value, "_") {
+		return true
+	}
+	return mixedCase && upper > 0 && lower > 0
+}
+
+func mergeMarkdownRanges(ranges []TextRange) []TextRange {
+	ordered := append([]TextRange(nil), ranges...)
+	slices.SortStableFunc(ordered, func(left, right TextRange) int {
+		if left.Start != right.Start {
+			return left.Start - right.Start
+		}
+		return left.End - right.End
+	})
+	merged := make([]TextRange, 0, len(ordered))
+	for _, item := range ordered {
+		if item.Start < 0 || item.End <= item.Start {
+			continue
+		}
+		if len(merged) == 0 || item.Start > merged[len(merged)-1].End {
+			merged = append(merged, item)
+			continue
+		}
+		if item.End > merged[len(merged)-1].End {
+			merged[len(merged)-1].End = item.End
+		}
+	}
+	return merged
+}

--- a/cmd/prosecheck/policy.go
+++ b/cmd/prosecheck/policy.go
@@ -1,0 +1,361 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ContentClass is the canonical purpose of an authored text span.
+type ContentClass string
+
+const (
+	ContentClassLabel       ContentClass = "label"
+	ContentClassProcedural  ContentClass = "procedural"
+	ContentClassDescriptive ContentClass = "descriptive"
+	ContentClassTechnical   ContentClass = "technical"
+	ContentClassTerm        ContentClass = "technical-term"
+)
+
+// RuleID identifies one deterministic rule from the repository writing standard.
+type RuleID string
+
+const (
+	RuleProceduralSentenceLength   RuleID = "B-PROC-20"
+	RuleDescriptiveSentenceLength  RuleID = "B-DESC-25"
+	RuleDescriptiveParagraphLength RuleID = "B-PARA-6"
+	RuleSemicolon                  RuleID = "B-SEMICOLON"
+	RuleContraction                RuleID = "B-CONTRACTION"
+	RulePublicTerm                 RuleID = "B-TERM-PUBLIC"
+	RuleTermCase                   RuleID = "B-TERM-CASE"
+	RuleLiteral                    RuleID = "B-LITERAL"
+	RuleSuppression                RuleID = "B-SUPPRESSION"
+	RuleBaselineStale              RuleID = "B-BASELINE-STALE"
+	RuleBaselineNew                RuleID = "B-BASELINE-NEW"
+	RuleParse                      RuleID = "B-PARSE"
+)
+
+// Severity is intentionally expressed in the standard's blocking/advisory
+// vocabulary. Story 001 only emits blocking deterministic findings.
+type Severity string
+
+const SeverityBlocking Severity = "blocking"
+
+// Rule describes the policy data needed by the pure evaluator. The rule ID,
+// applicability, and threshold are checked against the canonical writing
+// standard while loading the policy.
+type Rule struct {
+	ID        RuleID
+	Severity  Severity
+	Supported bool
+	Classes   []ContentClass
+	Limit     int
+}
+
+// Alternative is one terminology-register spelling that must be replaced on
+// customer-facing prose surfaces.
+type Alternative struct {
+	Text        string
+	Status      string
+	Replacement string
+}
+
+// Term is the evaluator's immutable view of one terminology-register record.
+type Term struct {
+	Canonical               string
+	Category                string
+	ApprovedForms           map[string]string
+	DiscouragedAlternatives []Alternative
+}
+
+// Policy is the canonical policy snapshot used by Analyze. It contains no
+// filesystem handles or other mutable runtime state.
+type Policy struct {
+	ContentClasses map[ContentClass]string
+	Rules          map[RuleID]Rule
+	Terms          []Term
+}
+
+type ruleSpec struct {
+	id        RuleID
+	classes   []ContentClass
+	limit     int
+	supported bool
+}
+
+func canonicalRuleSpecs() []ruleSpec {
+	natural := []ContentClass{
+		ContentClassLabel,
+		ContentClassProcedural,
+		ContentClassDescriptive,
+	}
+	return []ruleSpec{
+		{id: RuleProceduralSentenceLength, classes: []ContentClass{ContentClassProcedural}, limit: 20, supported: true},
+		{id: RuleDescriptiveSentenceLength, classes: []ContentClass{ContentClassDescriptive}, limit: 25, supported: true},
+		{id: RuleDescriptiveParagraphLength, classes: []ContentClass{ContentClassDescriptive}, limit: 6, supported: true},
+		{id: RuleSemicolon, classes: natural, supported: true},
+		{id: RuleContraction, classes: natural, supported: true},
+		{id: RulePublicTerm, classes: natural, supported: true},
+		{id: RuleTermCase, classes: natural, supported: true},
+		{id: RuleLiteral, supported: false},
+		{id: RuleSuppression, supported: true},
+		{id: RuleBaselineStale, supported: false},
+		{id: RuleBaselineNew, supported: false},
+		{id: RuleParse, supported: true},
+	}
+}
+
+// LoadPolicy parses the repository's normative Markdown standard and YAML
+// terminology register. The evaluator receives this snapshot explicitly so
+// rule analysis remains pure and does not discover policy through globals.
+func LoadPolicy(standard, terminology []byte) (Policy, error) {
+	classes, err := parseCanonicalContentClasses(string(standard))
+	if err != nil {
+		return Policy{}, err
+	}
+	ruleIDs, err := parseCanonicalRuleIDs(string(standard))
+	if err != nil {
+		return Policy{}, err
+	}
+	terms, err := parseTerminologyRegister(terminology)
+	if err != nil {
+		return Policy{}, err
+	}
+
+	rules := make(map[RuleID]Rule)
+	for _, spec := range canonicalRuleSpecs() {
+		if !ruleIDs[spec.id] {
+			return Policy{}, fmt.Errorf("writing standard is missing rule %s", spec.id)
+		}
+		rules[spec.id] = Rule{
+			ID:        spec.id,
+			Severity:  SeverityBlocking,
+			Supported: spec.supported,
+			Classes:   append([]ContentClass(nil), spec.classes...),
+			Limit:     spec.limit,
+		}
+	}
+
+	return Policy{ContentClasses: classes, Rules: rules, Terms: terms}, nil
+}
+
+func parseCanonicalContentClasses(standard string) (map[ContentClass]string, error) {
+	pattern := regexp.MustCompile(`(?mi)^###\s+([^\r\n]+?)\s*$`)
+	classes := make(map[ContentClass]string)
+	for _, match := range pattern.FindAllStringSubmatch(standard, -1) {
+		name := strings.TrimSpace(match[1])
+		var class ContentClass
+		switch strings.ToLower(name) {
+		case "labels":
+			class = ContentClassLabel
+		case "procedural prose":
+			class = ContentClassProcedural
+		case "descriptive prose":
+			class = ContentClassDescriptive
+		case "machine and technical text":
+			class = ContentClassTechnical
+		case "technical terms":
+			class = ContentClassTerm
+		default:
+			continue
+		}
+		classes[class] = name
+	}
+
+	for _, class := range []ContentClass{
+		ContentClassLabel,
+		ContentClassProcedural,
+		ContentClassDescriptive,
+		ContentClassTechnical,
+		ContentClassTerm,
+	} {
+		if _, ok := classes[class]; !ok {
+			return nil, fmt.Errorf("writing standard is missing content class %q", class)
+		}
+	}
+	return classes, nil
+}
+
+func parseCanonicalRuleIDs(standard string) (map[RuleID]bool, error) {
+	pattern := regexp.MustCompile(`(?m)^[[:space:]]*-[[:space:]]+\*\*([A-Z][A-Z0-9-]*):\*\*`)
+	ruleIDs := make(map[RuleID]bool)
+	for _, match := range pattern.FindAllStringSubmatch(standard, -1) {
+		ruleIDs[RuleID(match[1])] = true
+	}
+	if len(ruleIDs) == 0 {
+		return nil, fmt.Errorf("writing standard contains no rule IDs")
+	}
+	return ruleIDs, nil
+}
+
+type terminologyDocument struct {
+	Version int                 `yaml:"version"`
+	Schema  yaml.Node           `yaml:"schema"`
+	Terms   []terminologyRecord `yaml:"terms"`
+}
+
+type terminologyRecord struct {
+	Canonical               string            `yaml:"canonical"`
+	Definition              string            `yaml:"definition"`
+	Category                string            `yaml:"category"`
+	ApprovedForms           approvedForms     `yaml:"approvedForms"`
+	DiscouragedAlternatives []termAlternative `yaml:"discouragedAlternatives"`
+	Example                 string            `yaml:"example"`
+	Surfaces                []string          `yaml:"surfaces"`
+	Owner                   string            `yaml:"owner"`
+}
+
+type approvedForms struct {
+	Singular *string `yaml:"singular"`
+	Plural   *string `yaml:"plural"`
+	Verb     *string `yaml:"verb"`
+}
+
+type termAlternative struct {
+	Text        string `yaml:"text"`
+	Status      string `yaml:"status"`
+	Replacement string `yaml:"replacement"`
+}
+
+func parseTerminologyRegister(data []byte) ([]Term, error) {
+	var document terminologyDocument
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&document); err != nil {
+		return nil, fmt.Errorf("decode terminology register: %w", err)
+	}
+	if document.Version != 1 {
+		return nil, fmt.Errorf("unsupported terminology register version %d", document.Version)
+	}
+	if len(document.Terms) == 0 {
+		return nil, fmt.Errorf("terminology register has no terms")
+	}
+
+	knownValues := make(map[string]bool)
+	for _, record := range document.Terms {
+		canonical := strings.TrimSpace(record.Canonical)
+		if canonical == "" {
+			return nil, fmt.Errorf("terminology register contains an empty canonical term")
+		}
+		if err := validateTerminologyRecord(record, canonical); err != nil {
+			return nil, err
+		}
+		knownValues[canonical] = true
+		for _, value := range []*string{record.ApprovedForms.Singular, record.ApprovedForms.Plural, record.ApprovedForms.Verb} {
+			if value != nil && strings.TrimSpace(*value) != "" {
+				knownValues[strings.TrimSpace(*value)] = true
+			}
+		}
+	}
+
+	terms := make([]Term, 0, len(document.Terms))
+	seen := make(map[string]bool)
+	for _, record := range document.Terms {
+		canonical := strings.TrimSpace(record.Canonical)
+		key := strings.ToLower(canonical)
+		if seen[key] {
+			return nil, fmt.Errorf("terminology register repeats canonical term %q", canonical)
+		}
+		seen[key] = true
+		if !allowedTermCategory(record.Category) {
+			return nil, fmt.Errorf("term %q has unsupported category %q", canonical, record.Category)
+		}
+		forms := make(map[string]string)
+		for name, value := range map[string]*string{
+			"singular": record.ApprovedForms.Singular,
+			"plural":   record.ApprovedForms.Plural,
+			"verb":     record.ApprovedForms.Verb,
+		} {
+			if value != nil {
+				trimmed := strings.TrimSpace(*value)
+				if trimmed == "" {
+					return nil, fmt.Errorf("term %q has an empty %s form", canonical, name)
+				}
+				forms[name] = trimmed
+			}
+		}
+
+		alternatives := make([]Alternative, 0, len(record.DiscouragedAlternatives))
+		for _, alternative := range record.DiscouragedAlternatives {
+			item := Alternative{
+				Text:        strings.TrimSpace(alternative.Text),
+				Status:      strings.TrimSpace(alternative.Status),
+				Replacement: strings.TrimSpace(alternative.Replacement),
+			}
+			if item.Text == "" || item.Replacement == "" {
+				return nil, fmt.Errorf("term %q has an incomplete alternative", canonical)
+			}
+			if item.Status != "discouraged" && item.Status != "prohibited" {
+				return nil, fmt.Errorf("term %q alternative %q has unsupported status %q", canonical, item.Text, item.Status)
+			}
+			if item.Text == item.Replacement || !knownValues[item.Replacement] {
+				return nil, fmt.Errorf("term %q alternative %q has invalid replacement %q", canonical, item.Text, item.Replacement)
+			}
+			alternatives = append(alternatives, item)
+		}
+		slices.SortStableFunc(alternatives, func(left, right Alternative) int {
+			if len(left.Text) != len(right.Text) {
+				return len(right.Text) - len(left.Text)
+			}
+			return strings.Compare(strings.ToLower(left.Text), strings.ToLower(right.Text))
+		})
+		terms = append(terms, Term{
+			Canonical:               canonical,
+			Category:                strings.TrimSpace(record.Category),
+			ApprovedForms:           forms,
+			DiscouragedAlternatives: alternatives,
+		})
+	}
+
+	slices.SortStableFunc(terms, func(left, right Term) int {
+		if len(left.Canonical) != len(right.Canonical) {
+			return len(right.Canonical) - len(left.Canonical)
+		}
+		return strings.Compare(strings.ToLower(left.Canonical), strings.ToLower(right.Canonical))
+	})
+	return terms, nil
+}
+
+func validateTerminologyRecord(record terminologyRecord, canonical string) error {
+	if strings.TrimSpace(record.Definition) == "" {
+		return fmt.Errorf("term %q has an empty definition", canonical)
+	}
+	if strings.TrimSpace(record.Example) == "" {
+		return fmt.Errorf("term %q has an empty example", canonical)
+	}
+	if len(record.Surfaces) == 0 {
+		return fmt.Errorf("term %q has no valid surfaces", canonical)
+	}
+	for _, surface := range record.Surfaces {
+		if strings.TrimSpace(surface) == "" {
+			return fmt.Errorf("term %q has an empty surface", canonical)
+		}
+	}
+	if strings.TrimSpace(record.Owner) == "" {
+		return fmt.Errorf("term %q has an empty owner", canonical)
+	}
+	return nil
+}
+
+func allowedTermCategory(category string) bool {
+	switch category {
+	case "product-term", "technical-noun", "technical-verb", "acronym", "command", "protected-literal":
+		return true
+	default:
+		return false
+	}
+}
+
+func (policy Policy) rule(id RuleID) (Rule, bool) {
+	rule, ok := policy.Rules[id]
+	return rule, ok && rule.Supported
+}
+
+func (policy Policy) knownClass(class ContentClass) bool {
+	_, ok := policy.ContentClasses[class]
+	return ok
+}

--- a/cmd/prosecheck/policy.go
+++ b/cmd/prosecheck/policy.go
@@ -74,13 +74,15 @@ type Term struct {
 }
 
 const (
-	surfaceCustomerDocumentation       = "customer documentation"
-	surfaceCLIHelp                     = "cli help"
-	surfaceCLIReferenceDocumentation   = "cli and reference documentation"
-	surfaceCLIAndCustomerDocumentation = "cli and customer documentation"
-	surfaceCLIAndAPIDocumentation      = "cli and api documentation"
-	surfaceProviderCLIAndAPIDoc        = "provider cli and api documentation"
-	surfaceModelCLIAndCustomerDoc      = "model cli and customer documentation"
+	surfaceCustomerDocumentation         = "customer documentation"
+	surfaceCLIHelp                       = "cli help"
+	surfaceCLIReferenceDocumentation     = "cli and reference documentation"
+	surfaceCLIAndCustomerDocumentation   = "cli and customer documentation"
+	surfaceCLIAndAPIDocumentation        = "cli and api documentation"
+	surfaceProviderCLIAndAPIDoc          = "provider cli and api documentation"
+	surfaceModelCLIAndCustomerDoc        = "model cli and customer documentation"
+	surfaceInternalArchitecture          = "explicitly internal architecture material"
+	surfaceImplementationRuntimePackages = "implementation-focused runtime packages"
 )
 
 // Policy is the canonical policy snapshot used by Analyze. It contains no

--- a/cmd/prosecheck/policy.go
+++ b/cmd/prosecheck/policy.go
@@ -70,7 +70,18 @@ type Term struct {
 	Category                string
 	ApprovedForms           map[string]string
 	DiscouragedAlternatives []Alternative
+	Surfaces                []string
 }
+
+const (
+	surfaceCustomerDocumentation       = "customer documentation"
+	surfaceCLIHelp                     = "cli help"
+	surfaceCLIReferenceDocumentation   = "cli and reference documentation"
+	surfaceCLIAndCustomerDocumentation = "cli and customer documentation"
+	surfaceCLIAndAPIDocumentation      = "cli and api documentation"
+	surfaceProviderCLIAndAPIDoc        = "provider cli and api documentation"
+	surfaceModelCLIAndCustomerDoc      = "model cli and customer documentation"
+)
 
 // Policy is the canonical policy snapshot used by Analyze. It contains no
 // filesystem handles or other mutable runtime state.
@@ -308,6 +319,7 @@ func parseTerminologyRegister(data []byte) ([]Term, error) {
 			Category:                strings.TrimSpace(record.Category),
 			ApprovedForms:           forms,
 			DiscouragedAlternatives: alternatives,
+			Surfaces:                append([]string(nil), record.Surfaces...),
 		})
 	}
 

--- a/cmd/prosecheck/render.go
+++ b/cmd/prosecheck/render.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+)
+
+// SortFindings returns a copy in the analyzer's documented total order:
+// normalized source path, source line, source column, rule ID, content class,
+// structured identity, excerpt, and fingerprint. No map or input order can
+// affect the terminal result.
+func SortFindings(findings []Finding) []Finding {
+	ordered := append([]Finding(nil), findings...)
+	slices.SortStableFunc(ordered, func(left, right Finding) int {
+		if result := strings.Compare(left.SourcePath, right.SourcePath); result != 0 {
+			return result
+		}
+		if left.StartLine != right.StartLine {
+			return left.StartLine - right.StartLine
+		}
+		if left.StartColumn != right.StartColumn {
+			return left.StartColumn - right.StartColumn
+		}
+		if result := strings.Compare(string(left.RuleID), string(right.RuleID)); result != 0 {
+			return result
+		}
+		if result := strings.Compare(string(left.ContentClass), string(right.ContentClass)); result != 0 {
+			return result
+		}
+		if result := strings.Compare(left.Identity, right.Identity); result != 0 {
+			return result
+		}
+		if result := strings.Compare(left.Excerpt, right.Excerpt); result != 0 {
+			return result
+		}
+		return strings.Compare(left.Fingerprint, right.Fingerprint)
+	})
+	return ordered
+}
+
+// RenderFindings emits one concise, stable diagnostic per line. The output is
+// intended for authors; Finding remains the machine-readable contract.
+func RenderFindings(writer io.Writer, findings []Finding) error {
+	for _, finding := range SortFindings(findings) {
+		if _, err := fmt.Fprintf(writer, "%s:%d:%d [%s] %s: %s — %s (%s)\n",
+			finding.SourcePath,
+			finding.StartLine,
+			finding.StartColumn,
+			finding.RuleID,
+			finding.ContentClass,
+			finding.Excerpt,
+			finding.Guidance,
+			finding.Fingerprint,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/prosecheck/suppression.go
+++ b/cmd/prosecheck/suppression.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+const suppressionPrefix = "prosecheck:ignore"
+
+// ParseSuppressionDirective parses the bounded machine-readable exception
+// comment accepted by the analyzer. It intentionally does not decide whether
+// the rule exists; that requires the canonical Policy supplied to Analyze.
+func ParseSuppressionDirective(raw string) (Suppression, error) {
+	trimmed := strings.TrimSpace(raw)
+	if !strings.HasPrefix(trimmed, "<!--") || !strings.HasSuffix(trimmed, "-->") {
+		return Suppression{}, fmt.Errorf("suppression directive must be an HTML comment")
+	}
+	inner := strings.TrimSpace(trimmed[len("<!--") : len(trimmed)-len("-->")])
+	if len(inner) < len(suppressionPrefix) || !strings.EqualFold(inner[:len(suppressionPrefix)], suppressionPrefix) {
+		return Suppression{}, fmt.Errorf("suppression directive must start with %q", suppressionPrefix)
+	}
+	remaining := strings.TrimSpace(inner[len(suppressionPrefix):])
+	if remaining == "" {
+		return Suppression{}, fmt.Errorf("suppression directive is missing a rule ID")
+	}
+	rule, remaining := takeToken(remaining)
+	if !validRuleToken(rule) {
+		return Suppression{}, fmt.Errorf("suppression directive has invalid rule ID %q", rule)
+	}
+	attributes, err := parseSuppressionAttributes(remaining)
+	if err != nil {
+		return Suppression{}, err
+	}
+	for _, key := range []string{"reason", "owner", "review"} {
+		if strings.TrimSpace(attributes[key]) == "" {
+			return Suppression{}, fmt.Errorf("suppression directive is missing %s", key)
+		}
+	}
+	return Suppression{
+		RuleID:      RuleID(rule),
+		Reason:      attributes["reason"],
+		Owner:       attributes["owner"],
+		Review:      attributes["review"],
+		StartOffset: -1,
+		EndOffset:   -1,
+	}, nil
+}
+
+func parseInlineDirectives(span Span, policy Policy) ([]directiveOccurrence, []Finding) {
+	var directives []directiveOccurrence
+	var findings []Finding
+	for search := 0; search < len(span.Text); {
+		start := strings.Index(span.Text[search:], "<!--")
+		if start < 0 {
+			break
+		}
+		start += search
+		endRelative := strings.Index(span.Text[start+len("<!--"):], "-->")
+		if endRelative < 0 {
+			findings = append(findings, suppressionFinding(span, "unterminated suppression directive", start, len(span.Text)))
+			break
+		}
+		end := start + len("<!--") + endRelative + len("-->")
+		raw := span.Text[start:end]
+		inner := strings.ToLower(raw)
+		if strings.Contains(inner, "prosecheck:") {
+			suppression, err := ParseSuppressionDirective(raw)
+			if err != nil {
+				findings = append(findings, suppressionFinding(span, err.Error(), start, end))
+			} else {
+				directives = append(directives, directiveOccurrence{
+					start:       start,
+					end:         end,
+					suppression: suppression,
+				})
+			}
+		}
+		search = end
+	}
+	return directives, findings
+}
+
+func validateSuppressions(span Span, policy Policy, directives []directiveOccurrence) ([]Suppression, []Finding) {
+	suppressions := append([]Suppression(nil), span.Suppressions...)
+	for _, directive := range directives {
+		suppression := directive.suppression
+		suppression.StartOffset = directive.end
+		suppression.EndOffset = len(span.Text)
+		suppressions = append(suppressions, suppression)
+	}
+
+	valid := make([]Suppression, 0, len(suppressions))
+	var findings []Finding
+	for _, suppression := range suppressions {
+		if err := validateSuppression(suppression, policy, len(span.Text)); err != nil {
+			start := suppression.StartOffset
+			if start < 0 || start >= len(span.Text) {
+				start = 0
+			}
+			end := suppression.EndOffset
+			if end <= start || end > len(span.Text) {
+				end = minInt(len(span.Text), start+1)
+			}
+			findings = append(findings, suppressionFinding(span, err.Error(), start, end))
+			continue
+		}
+		valid = append(valid, suppression)
+	}
+	return valid, findings
+}
+
+func validateSuppression(suppression Suppression, policy Policy, textLength int) error {
+	if _, ok := policy.rule(suppression.RuleID); !ok {
+		return fmt.Errorf("suppression names unknown or unsupported rule %q", suppression.RuleID)
+	}
+	if suppression.StartOffset < 0 || suppression.EndOffset <= suppression.StartOffset || suppression.EndOffset > textLength {
+		return fmt.Errorf("suppression for %s must cover one bounded source span", suppression.RuleID)
+	}
+	if strings.TrimSpace(suppression.Reason) == "" || strings.TrimSpace(suppression.Owner) == "" || strings.TrimSpace(suppression.Review) == "" {
+		return fmt.Errorf("suppression for %s must include reason, owner, and review", suppression.RuleID)
+	}
+	return nil
+}
+
+func directiveRanges(directives []directiveOccurrence) []TextRange {
+	ranges := make([]TextRange, 0, len(directives))
+	for _, directive := range directives {
+		ranges = append(ranges, TextRange{Start: directive.start, End: directive.end})
+	}
+	return ranges
+}
+
+func suppressed(item candidate, suppressions []Suppression) bool {
+	for _, suppression := range suppressions {
+		if suppression.RuleID == item.ruleID && item.start >= suppression.StartOffset && item.end <= suppression.EndOffset {
+			return true
+		}
+	}
+	return false
+}
+
+func suppressionFinding(span Span, message string, start, end int) Finding {
+	item := candidate{
+		ruleID: RuleSuppression, class: span.Class, start: start, end: end,
+		excerpt:  span.Text[start:end],
+		guidance: "Use one known rule, a bounded span, and a reason, owner, and review point.",
+	}
+	if strings.TrimSpace(item.excerpt) == "" {
+		item.excerpt = message
+	}
+	return findingFromCandidate(span, item)
+}
+
+func parseSuppressionAttributes(remaining string) (map[string]string, error) {
+	attributes := make(map[string]string)
+	remaining = strings.TrimSpace(remaining)
+	for remaining != "" {
+		key, afterKey := takeToken(remaining)
+		if key == "" || afterKey == remaining || !strings.HasPrefix(afterKey, "=") {
+			return nil, fmt.Errorf("suppression attribute must use key=\"value\" syntax")
+		}
+		if _, exists := attributes[key]; exists {
+			return nil, fmt.Errorf("suppression attribute %q is repeated", key)
+		}
+		valueText := strings.TrimSpace(afterKey[1:])
+		if !strings.HasPrefix(valueText, "\"") {
+			return nil, fmt.Errorf("suppression attribute %q must use a quoted value", key)
+		}
+		endQuote := strings.IndexByte(valueText[1:], '"')
+		if endQuote < 0 {
+			return nil, fmt.Errorf("suppression attribute %q has an unterminated value", key)
+		}
+		endQuote++
+		value := valueText[1:endQuote]
+		if key != "reason" && key != "owner" && key != "review" {
+			return nil, fmt.Errorf("suppression attribute %q is unknown", key)
+		}
+		attributes[key] = value
+		remaining = strings.TrimSpace(valueText[endQuote+1:])
+	}
+	return attributes, nil
+}
+
+func takeToken(value string) (string, string) {
+	value = strings.TrimSpace(value)
+	for index, runeValue := range value {
+		if runeValue == '=' || runeValue == ' ' || runeValue == '\t' || runeValue == '\r' || runeValue == '\n' {
+			return value[:index], value[index:]
+		}
+	}
+	return value, ""
+}
+
+func validRuleToken(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, runeValue := range value {
+		if (runeValue < 'A' || runeValue > 'Z') && runeValue != '-' && (runeValue < '0' || runeValue > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func minInt(left, right int) int {
+	if left < right {
+		return left
+	}
+	return right
+}


### PR DESCRIPTION
{
  "project": "Deterministic Prosecheck Analyzers",
  "branchName": "prosecheck-analyzers",
  "description": "Implement Stories 2 and 3 of the customer prose enforcement plan as a focused cmd/prosecheck maintenance command with a pure deterministic finding and rule-analysis core, structural Markdown extraction, read-only extraction from contracts/cli/commands.json, protected-technical-text handling, exact fixture suites, and byte-identical repeated output. The project consumes the upstream writing standard and terminology register and explicitly excludes baseline and CI wiring.",
  "lastIteration": {
    "status": "complete",
    "summary": "All four stories remain complete; PR #1895 is open on the pushed final head with implementation feedback cleared and the registered untouched baseline-flake exception recorded.",
    "verification": "On 2026-08-12 00:23 -07:00, local HEAD and origin/prosecheck-analyzers matched f5a2037f4ecc5d3b41753f9216c3a5d504de2634. PR #1895 remained open, non-draft, mergeable, and titled prosecheck-analyzers with the PRD JSON as its body. The UTF-8 thread-aware inspection found zero review submissions and zero unresolved inline threads; recent blocking conversation comments explicitly require no executor action. Required run 31565339622 is terminal; its only red required checks are Backend Functional Coverage and dependent Verification Policy for the operator-registered untouched tests/functional/providers/acp and tests/functional/sessions/execution baseline-flake families. No executor code commit or CI rerun is needed."
  },
  "context": {
    "customerAsk": "Give maintainers exact, trustworthy prose findings for customer-facing Markdown and authored CLI help by implementing the deterministic analyzer core and the Markdown and CLI-manifest adapters. The CLI manifest is a read-only authoring input; generated CLI projections are not analyzed or edited.",
    "problem": "The writing standard has no enforcement implementation. Raw text scanning would produce false positives in protected technical content, lose structural content classification, and make findings unstable across platforms or repeated runs. Existing CLI contract checks validate manifest structure, not writing quality, and generated Go is not the canonical authoring source.",
    "solution": "Add a self-contained repository maintenance command under cmd/prosecheck whose analysis is pure apart from explicit input reads and terminal output. Use the upstream standard and terminology register as canonical policy inputs. Extract natural-language spans structurally from Markdown and from the authored CLI manifest, protect technical text, apply deterministic rules, and render stable findings. Prove behavior with exact-output fixture suites, false-positive fixtures, platform line-ending cases, parse-failure cases, and repeated-run byte comparisons."
  },
  "acceptanceCriteria": [
    "Running prosecheck on the fixture corpus reports every supported deterministic prose violation with the exact expected stable rule ID, severity, source span, content class, excerpt, guidance, and fingerprint, while compliant prose reports no findings.",
    "Markdown extraction covers headings, paragraphs, list items, admonitions, table cells, and safely identifiable natural-language comments; direct fixtures prove that protected technical text is not reported and that parse failures block with the affected file identified.",
    "CLI-manifest extraction reads contracts/cli/commands.json without modifying it, covers every specified authored customer-visible field, reports stable command or input identity plus canonical JSON location, and excludes generated projections and protected CLI literals.",
    "Repeated runs over identical inputs, including mixed Markdown and CLI-manifest inputs presented in different enumeration orders and with Windows or Unix line endings, produce byte-identical deterministically ordered output.",
    "The implementation remains focused repository tooling under cmd/prosecheck, uses the upstream writing standard and terminology register as canonical policy, performs no network access, introduces no product service or runtime dependency, and includes no baseline or CI/Make/workflow wiring.",
    "Quality gates pass: typecheck, focused analyzer and fixture tests, and required PR CI; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are reconciled against current main, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "prosecheck-analyzers-001",
      "title": "Report stable findings from deterministic prose rules",
      "description": "As a maintainer, I want the prose checker to apply the canonical deterministic writing rules and return actionable findings so that I can correct violations without interpreting unstable or incomplete output.",
      "acceptanceCriteria": [
        "The analyzer consumes the upstream canonical content classes, rule IDs, terminology, and suppression syntax instead of defining a competing writing policy.",
        "Supported blocking analysis covers procedural and descriptive sentence length, descriptive paragraph length, semicolons in natural-language prose, contractions, prohibited terminology and approved replacements, canonical product capitalization, and malformed or unknown suppression directives; baseline comparison rules remain out of scope.",
        "Each finding contains stable rule ID, severity, normalized source path, start line and known column, content class, bounded offending excerpt, actionable remediation guidance, and a stable normalized fingerprint.",
        "Findings have a documented total ordering independent of map iteration, filesystem enumeration, or concurrent evaluation, and terminal rendering is concise and stable.",
        "Compliant classified prose produces no findings, and unit fixtures reproduce each supported rule's complete expected finding exactly.",
        "Analysis logic has no network access, process-global mutable state, or implicit repository writes; read and output effects are isolated at the command boundary.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented the pure cmd/prosecheck core and thin executable boundary. LoadPolicy consumes the canonical writing-standard content classes and rule IDs plus the YAML terminology register; Analyze covers procedural/descriptive sentence and paragraph limits, semicolons, contractions, prohibited terms, canonical term case, bounded suppression validation, protected ranges, stable findings, fingerprints, ordering, terminal rendering, and canonical terminology surface applicability. Baseline rules remain unsupported in this story. Focused tests cover every supported rule, compliant text, protected technical spans, CRLF locations, malformed and unknown suppressions, deterministic input order, line endings, lexical code/URL protection, and command exit/output behavior. `go test ./cmd/prosecheck`, `go test -race ./cmd/prosecheck`, `go vet ./cmd/prosecheck`, `go build ./cmd/prosecheck`, and `git diff --check` passed. Markdown and CLI-manifest extraction remain for stories 002 and 003."
    },
    {
      "id": "prosecheck-analyzers-002",
      "title": "Analyze Markdown while protecting technical text",
      "description": "As a documentation maintainer, I want exact findings for natural-language Markdown while technical literals remain untouched so that prose checks are trustworthy enough to act on.",
      "acceptanceCriteria": [
        "Running the command on Markdown extracts headings, paragraphs, list items, admonitions, table cells, and safely identifiable natural-language comments with correct file, line, and known-column spans.",
        "Mixed procedural and descriptive content is classified only through the canonical explicit metadata or documented structural rules; no probabilistic or opaque language-model decision can create a blocking classification.",
        "Fenced code, inline code, command invocations, shell operators, URLs, file and package paths, identifiers, API routes, schema and event literals, JSON/YAML contract examples, model/provider names, and quoted external output have direct fixtures proving that protected content is not reported.",
        "A malformed or unsupported document that cannot be safely analyzed produces a blocking parse finding that identifies the file instead of silently skipping prose.",
        "Equivalent Windows and Unix line-ending fixtures produce the same logical findings and correct source lines.",
        "Valid, violating, protected-text, mixed-classification, and parse-failure fixtures assert complete exact output, including stable ordering when one file contains multiple findings.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented the deterministic Markdown adapter and automatic `.md`/`.markdown` command dispatch. ExtractMarkdownSpans preserves source lines and known columns for headings, paragraphs, ordered and unordered list items, GitHub/MkDocs/Docusaurus-style admonitions, GFM table cells, standalone natural-language HTML comments, and safely identifiable comments inside fenced code. Structural metadata supports explicit `prosecheck:class` classification and bounded suppression attachment. Fenced/indented code, inline code, URLs, link destinations, commands and shell lines, paths, routes, identifiers, JSON/YAML-like lines, quoted output, and technical tokens are protected before Analyze; malformed UTF-8, unclosed fences/comments/inline code, malformed tables, and unsupported directives produce file-scoped B-PARSE findings. Focused observable tests cover exact span locations/classes, protected literals, visible link labels, metadata/suppression behavior, CRLF equivalence, parse failures, repeated runs, race testing, vet, build, and diff check. Review follow-up adds path-aware customer/reference/internal terminology selectors and direct protection fixtures for shell operators, paths, identifiers, schema/event literals, JSON/YAML examples, model/provider names, and quoted output. Story 003 CLI-manifest extraction and story 004 cross-adapter command fixtures remain." 
    },
    {
      "id": "prosecheck-analyzers-003",
      "title": "Analyze authored CLI help from the read-only manifest",
      "description": "As a CLI maintainer, I want prose findings tied to stable command and input identities so that I can improve the canonical help source without inspecting or changing generated Go.",
      "acceptanceCriteria": [
        "The adapter reads the authored contracts/cli/commands.json input without writing it and inspects every visible authored command title, command description, flag usage string, authored example comment, and natural-language deprecation or replacement guidance.",
        "Literal commands and example command lines, placeholders, flags, URLs, routes, error codes, identifiers, and default values remain protected, with a direct false-positive fixture for each class.",
        "Every CLI finding includes the stable command ID and, where applicable, flag, argument, or documentation input ID, plus the canonical JSON location and source line/known column.",
        "Hidden compatibility records are excluded when they have no customer-visible prose; any natural-language deprecation or replacement guidance that is surfaced to customers remains in scope, and fixtures prove both outcomes.",
        "Malformed JSON or an authored field whose shape prevents safe extraction produces a blocking parse finding tied to the manifest and does not silently omit the remaining failure.",
        "Valid, invalid, protected-literal, hidden-record, malformed-input, and deterministic-order manifest fixtures assert complete exact findings; generated CLI files are neither read as authoring inputs nor modified.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented the read-only authored CLI-manifest adapter and automatic contracts/cli/commands.json dispatch. A source-preserving JSON parser extracts visible command titles/descriptions, flag and argument usage, documentation/usage example comments, and lifecycle deprecation or successor guidance; hidden records without customer-visible guidance are excluded. Findings carry stable command/input identities plus canonical JSON-pointer locations, physical source line/column mappings through escaped JSON strings, and deterministic fingerprints. CLI commands, flags, placeholders, URLs, routes, paths, identifiers, schema/error literals, provider names, defaults, and structured/quoted output are protected before Analyze. Malformed JSON and malformed selected field shapes emit manifest-scoped B-PARSE findings while safe sibling records continue; generated CLI projections are rejected before input reads for both relative and absolute paths, and terminology surfaces suppress ambiguous ordinary words. Review follow-up scopes manifest literals to the current command/input context and command-line spans, derives narrow command-subject selectors, and proves ordinary `work`/`model`/lifecycle words remain unreported while product Work findings still fire. Fixtures cover exact extraction locations/classes, findings, protected literals, hidden/lifecycle behavior, parse continuation, CRLF/repeat stability, read-only input, command dispatch, generated-input rejection, and ambiguous-surface false positives. go test ./cmd/prosecheck, go test -race ./cmd/prosecheck, go vet ./cmd/prosecheck, go build ./cmd/prosecheck, git diff --check, and the ratcheted backend/package gates passed. Story 004 cross-adapter command fixtures remains."
    },
    {
      "id": "prosecheck-analyzers-004",
      "title": "Prove deterministic command behavior across adapters",
      "description": "As a reviewer, I want end-to-end evidence that the command produces the same result for the same authored content so that findings remain reviewable across machines and repeated runs.",
      "acceptanceCriteria": [
        "A command-level fixture run containing both Markdown and CLI-manifest findings renders results in the documented total order and returns a non-success status when blocking findings or parse failures exist.",
        "A command-level valid fixture run emits no findings and returns success.",
        "Running the same corpus twice produces byte-identical standard output, standard error, and exit status.",
        "Presenting the same explicit inputs in a different enumeration order produces byte-identical output.",
        "Tests prove that the command does not change the bytes or metadata-observable contents of contracts/cli/commands.json or any analyzed fixture and does not access the network.",
        "Focused verification remains limited to analyzer behavior and fixtures; it does not add a baseline, baseline comparison, Make target, required workflow, or broad unrelated cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Added command-level cross-adapter fixture coverage. Mixed Markdown and authored CLI-manifest inputs assert literal exact merged terminal bytes, documented path/line/rule ordering, blocking status, and byte-identical results under reversed input enumeration. Independent complete finding goldens cover every supported rule, adapter locations and identities, valid/protected zero findings, parse failures, and LF/CRLF equivalence. A valid protected-literal corpus asserts success, repeated-run stability, unchanged fixture bytes and observable metadata, and no network access through a fail-fast HTTP transport guard. Focused go test, race test, vet, build, diff-check, backend-size, pkg-maint, pkg-file-count, and pkg-structure pass; no baseline, CI, Make, workflow, or generated wiring was added."
    }
  ]
}
