### PR TITLE
Review/process prompts: merged-PR short-circuit, hard CI-watch cap, convergence rule

### DIFF
--- a/factory/workstations/process/AGENTS.md
+++ b/factory/workstations/process/AGENTS.md
@@ -7,6 +7,7 @@ You are an autonomous coding agent working on a software project.
 3. If there is task items that are not yet complete, please implement the task as much as possible. Then update the progress.txt/prd.json.
 4. If all tasks are done, please submit a PR via the gh CLI. Make named {{ (index .Inputs 0).Name }}. Set the description as the prd.json file that we used.
 5. if there exists a PR already, then please check the comments on said pr, address them, then resubmit a new pr based on the latest feedback.
+6. If the PR for this work item is already MERGED, the lane is DONE: respond `<COMPLETE>` immediately. Ignore any "post-merge follow-up" or post-merge blocking comments — those belong to new work items filed by the operator, never to this lane. Do not push new commits to a merged branch.
 
 17. Respond finally as follows:
 17.1. Respond `<COMPLETE>` only when all items in the PRD have been marked as passes:true, all relevant PR conversation comments have been addressed, and the PR has been updated to the latest commits so the task is ready to move into review. READY FOR REVIEW means: final head pushed, PR open, required CI STARTED on that head. It does NOT mean merged and does NOT mean CI finished — the review workstation owns terminal CI and the merge. If your PRD's acceptance criteria mention "merged", that is the overall work item's finish line owned by review, never a reason for you to keep looping.

--- a/factory/workstations/review/AGENTS.md
+++ b/factory/workstations/review/AGENTS.md
@@ -4,6 +4,15 @@ You are a code reviewer agent.
 
 You are processing work item {{ (index .Inputs 0).WorkID }} of type {{ (index .Inputs 0).WorkTypeID }} that is relative to the work item named {{ (index .Inputs 0).Name }}.
 
+### Step 0 — Merged-PR short-circuit (do this FIRST)
+Run `gh pr view <pr> --json state`. If the PR state is MERGED, this work item
+is FINISHED: end your response immediately with `<COMPLETE>`. Do not re-review
+the merged head, do not run tests, do not post any comment, and never raise
+blocking findings against a merged PR. If you believe a defect exists in the
+merged code, name it briefly in your final response text (before the marker)
+so the operator can file a NEW work item — it is never a reason to reject or
+loop this lane.
+
 ### Step 1 — Gather context
 1. Read prd.json to understand what was implemented
 2. Use PR conversation comments as the single feedback channel for this workflow:
@@ -33,6 +42,11 @@ You are processing work item {{ (index .Inputs 0).WorkID }} of type {{ (index .I
 ### Step 2 — Run quality checks
 Run: make test
 Report any failures. Failing checks are a BLOCKING issue.
+Scope exception: if a previous review pass recorded a green `make test` for
+the CURRENT head in the PR conversation, or required CI enforces the full
+suite on this head, you may instead run only the test packages the diff
+touches (state which you ran). Do not spend the whole session re-running an
+already-verified full suite.
 
 Known-baseline lint policy (recorded 2026-08-08): `make lint` cannot
 currently pass end-to-end on main — the `pkg-boundary` target carries
@@ -52,8 +66,11 @@ If the change involves modification to the website, you should use the playwrigh
 - Check the live required PR checks on the current head with `gh pr view --json headRefOid,mergeStateStatus,statusCheckRollup` and `gh pr checks`.
 - If required checks are still `PENDING`, `QUEUED`, or `IN_PROGRESS`, WAIT for
   them in this session with ONE bounded watcher: `gh pr checks <n> --watch
-  --interval 180` (give it up to ~45 minutes). Do your code reading (Steps 1,
-  3, 4) while it runs. Do not post a comment just to say CI is running, and do
+  --interval 180`. HARD CAP: at most 45 minutes of watching in this session,
+  one watcher invocation, never restarted. Sessions killed at the 2h timeout
+  count as review FAILURES and trip the circuit breaker — budget your session
+  to finish well before that. Do your code reading (Steps 1, 3, 4) while the
+  watcher runs. Do not post a comment just to say CI is running, and do
   not end the session with `<REJECTED>` merely because CI was pending when you
   started — that routes the work back to the processor, which has nothing to
   do, and burns a process/review round trip.
@@ -92,6 +109,17 @@ quality-rule violation and ask for behavioral coverage instead.
 Check the PR directly against the review rules above and confirm whether it
 meets them. Every review comment must be actionable and must clearly signal
 whether it is BLOCKING or non-blocking.
+
+### Step 4.2 — Convergence rule for repeat reviews
+Reviews must CONVERGE, not expand. Read the prior review comments first. On a
+repeat review of the same PR, only two kinds of findings may be BLOCKING:
+(a) a previously-flagged blocker that is still unfixed, and (b) a defect
+introduced by commits pushed since the last review. Do NOT raise new blockers
+against code that already existed and survived an earlier review pass —
+record such discoveries as explicitly NON-BLOCKING follow-ups for the
+operator to file separately. From the third review pass onward the decision
+bar is: MERGE unless an unfixed previously-flagged blocker or red required CI
+remains.
 
 ### Step 5 - handle feedback
 


### PR DESCRIPTION
Stops the observed review loops (prompt hot-reload makes this live per-dispatch; this PR makes main match the operating copy):

- **Merged-PR short-circuit** (review Step 0 + process rule 6): a MERGED PR ends the lane immediately with `<COMPLETE>`; post-merge findings become new work items instead of re-blocking the lane (trigger: #1884 post-merge loop).
- **Hard 45-min CI-watch cap**: prevents reviewer sessions from running into the 2h kill, which counts as a failure and feeds the circuit breaker.
- **make test scope exception** when the current head is already verified green — the full-suite rerun was pushing sessions past 1h.
- **Convergence rule**: repeat reviews may only block on previously-flagged unfixed blockers or defects in new commits; from the third pass, merge unless such a blocker or red CI remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)