### PR TITLE
thr-hardkill-findprocess-release

### DIFF
--- a/tests/functional/transport/cli/process/hard_kill_successor_process_nonwindows_lifecycle_test.go
+++ b/tests/functional/transport/cli/process/hard_kill_successor_process_nonwindows_lifecycle_test.go
@@ -1,0 +1,229 @@
+//go:build !windows
+
+package process_test
+
+import (
+	"errors"
+	"os"
+	"sync"
+	"syscall"
+	"testing"
+)
+
+func TestNewHardKillProcessControlReleasesAfterInitialStopFailure(t *testing.T) {
+	stopErr := errors.New("stop failed")
+	releaseErr := errors.New("release failed")
+	process := &fakeHardKillProcess{
+		signalErrors: map[os.Signal]error{syscall.SIGSTOP: stopErr},
+		releaseErr:   releaseErr,
+	}
+
+	control, err := newHardKillProcessControl(process)
+	if control.resume != nil || control.terminate != nil {
+		t.Fatalf("initial stop failure returned a terminal control: %#v", control)
+	}
+	if !errors.Is(err, stopErr) {
+		t.Fatalf("initial stop error = %v, want %v", err, stopErr)
+	}
+	if !errors.Is(err, releaseErr) {
+		t.Fatalf("initial stop error = %v, want release error %v", err, releaseErr)
+	}
+	if got := process.releaseCount(); got != 1 {
+		t.Fatalf("release count = %d, want 1", got)
+	}
+	if got := process.signalCount(syscall.SIGSTOP); got != 1 {
+		t.Fatalf("SIGSTOP count = %d, want 1", got)
+	}
+}
+
+func TestNewHardKillProcessControlReleasesAfterFirstTerminalOperation(t *testing.T) {
+	signalErr := errors.New("signal failed")
+	releaseErr := errors.New("release failed")
+	tests := []struct {
+		name          string
+		terminal      func(hardKillProcessControl) error
+		signalErr     error
+		killErr       error
+		releaseErr    error
+		wantSignal    os.Signal
+		wantKillCount int
+		wantErrs      []error
+	}{
+		{
+			name:       "resume succeeds",
+			terminal:   func(control hardKillProcessControl) error { return control.resume() },
+			wantSignal: syscall.SIGCONT,
+		},
+		{
+			name:       "resume joins signal and release failures",
+			terminal:   func(control hardKillProcessControl) error { return control.resume() },
+			signalErr:  signalErr,
+			releaseErr: releaseErr,
+			wantSignal: syscall.SIGCONT,
+			wantErrs:   []error{signalErr, releaseErr},
+		},
+		{
+			name:       "resume returns release-only failure",
+			terminal:   func(control hardKillProcessControl) error { return control.resume() },
+			releaseErr: releaseErr,
+			wantSignal: syscall.SIGCONT,
+			wantErrs:   []error{releaseErr},
+		},
+		{
+			name:          "terminate succeeds",
+			terminal:      func(control hardKillProcessControl) error { return control.terminate() },
+			wantKillCount: 1,
+		},
+		{
+			name:          "terminate joins kill and release failures",
+			terminal:      func(control hardKillProcessControl) error { return control.terminate() },
+			killErr:       signalErr,
+			releaseErr:    releaseErr,
+			wantErrs:      []error{signalErr, releaseErr},
+			wantKillCount: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			process := &fakeHardKillProcess{
+				signalErrors: map[os.Signal]error{syscall.SIGCONT: test.signalErr},
+				killErr:      test.killErr,
+				releaseErr:   test.releaseErr,
+			}
+			control, err := newHardKillProcessControl(process)
+			if err != nil {
+				t.Fatalf("create control: %v", err)
+			}
+
+			if got := test.terminal(control); !sameErrorSet(got, test.wantErrs...) {
+				t.Fatalf("first terminal operation error = %v, want errors %v", got, test.wantErrs)
+			}
+			if got := test.terminal(control); got != nil {
+				t.Fatalf("repeated terminal operation error = %v, want nil", got)
+			}
+			if got := process.releaseCount(); got != 1 {
+				t.Fatalf("release count = %d, want 1", got)
+			}
+			if got := process.signalCount(syscall.SIGSTOP); got != 1 {
+				t.Fatalf("SIGSTOP count = %d, want 1", got)
+			}
+			if test.wantSignal != nil {
+				if got := process.signalCount(test.wantSignal); got != 1 {
+					t.Fatalf("terminal signal count = %d, want 1", got)
+				}
+			}
+			if got := process.killCount(); got != test.wantKillCount {
+				t.Fatalf("kill count = %d, want %d", got, test.wantKillCount)
+			}
+		})
+	}
+}
+
+func TestNewHardKillProcessControlCoordinatesCompetingTerminalOperations(t *testing.T) {
+	process := &fakeHardKillProcess{}
+	control, err := newHardKillProcessControl(process)
+	if err != nil {
+		t.Fatalf("create control: %v", err)
+	}
+
+	const callers = 32
+	var waitGroup sync.WaitGroup
+	errorsCh := make(chan error, callers)
+	waitGroup.Add(callers)
+	for index := 0; index < callers; index++ {
+		go func(index int) {
+			defer waitGroup.Done()
+			if index%2 == 0 {
+				errorsCh <- control.resume()
+				return
+			}
+			errorsCh <- control.terminate()
+		}(index)
+	}
+	waitGroup.Wait()
+	close(errorsCh)
+	for err := range errorsCh {
+		if err != nil {
+			t.Fatalf("competing terminal operation error = %v, want nil", err)
+		}
+	}
+
+	terminalSignals := process.signalCount(syscall.SIGCONT)
+	if got := process.killCount(); terminalSignals+got != 1 {
+		t.Fatalf("terminal operation count = %d, want 1", terminalSignals+got)
+	}
+	if got := process.releaseCount(); got != 1 {
+		t.Fatalf("release count = %d, want 1", got)
+	}
+}
+
+func sameErrorSet(got error, want ...error) bool {
+	if len(want) == 0 {
+		return got == nil
+	}
+	if got == nil {
+		return false
+	}
+	for _, wantErr := range want {
+		if !errors.Is(got, wantErr) {
+			return false
+		}
+	}
+	return true
+}
+
+type fakeHardKillProcess struct {
+	mu           sync.Mutex
+	signalErrors map[os.Signal]error
+	signalCalls  []os.Signal
+	killErr      error
+	killCalls    int
+	releaseErr   error
+	releaseCalls int
+}
+
+func (process *fakeHardKillProcess) Signal(signal os.Signal) error {
+	process.mu.Lock()
+	defer process.mu.Unlock()
+	process.signalCalls = append(process.signalCalls, signal)
+	return process.signalErrors[signal]
+}
+
+func (process *fakeHardKillProcess) Kill() error {
+	process.mu.Lock()
+	defer process.mu.Unlock()
+	process.killCalls++
+	return process.killErr
+}
+
+func (process *fakeHardKillProcess) Release() error {
+	process.mu.Lock()
+	defer process.mu.Unlock()
+	process.releaseCalls++
+	return process.releaseErr
+}
+
+func (process *fakeHardKillProcess) signalCount(want os.Signal) int {
+	process.mu.Lock()
+	defer process.mu.Unlock()
+	count := 0
+	for _, got := range process.signalCalls {
+		if got == want {
+			count++
+		}
+	}
+	return count
+}
+
+func (process *fakeHardKillProcess) killCount() int {
+	process.mu.Lock()
+	defer process.mu.Unlock()
+	return process.killCalls
+}
+
+func (process *fakeHardKillProcess) releaseCount() int {
+	process.mu.Lock()
+	defer process.mu.Unlock()
+	return process.releaseCalls
+}

--- a/tests/functional/transport/cli/process/hard_kill_successor_process_nonwindows_test.go
+++ b/tests/functional/transport/cli/process/hard_kill_successor_process_nonwindows_test.go
@@ -9,40 +9,44 @@ import (
 	"syscall"
 )
 
+type hardKillProcessHandle interface {
+	Signal(os.Signal) error
+	Kill() error
+	Release() error
+}
+
 func suspendHardKillProcess(pid int) (hardKillProcessControl, error) {
 	process, err := os.FindProcess(pid)
 	if err != nil {
 		return hardKillProcessControl{}, err
 	}
+	return newHardKillProcessControl(process)
+}
+
+func newHardKillProcessControl(process hardKillProcessHandle) (hardKillProcessControl, error) {
 	if err := process.Signal(syscall.SIGSTOP); err != nil {
 		return hardKillProcessControl{}, errors.Join(err, process.Release())
 	}
 
 	var mu sync.Mutex
-	released := false
-	resume := func() error {
+	terminal := false
+	terminalOperation := func(signal func() error) error {
 		mu.Lock()
 		defer mu.Unlock()
-		if released {
+		if terminal {
 			return nil
 		}
-		signalErr := process.Signal(syscall.SIGCONT)
-		releaseErr := process.Release()
-		released = true
-		return errors.Join(signalErr, releaseErr)
+		terminal = true
+		return errors.Join(signal(), process.Release())
 	}
-	terminate := func() error {
-		mu.Lock()
-		defer mu.Unlock()
-		if released {
-			return nil
-		}
-		killErr := process.Kill()
-		releaseErr := process.Release()
-		released = true
-		return errors.Join(killErr, releaseErr)
-	}
-	return hardKillProcessControl{resume: resume, terminate: terminate}, nil
+	return hardKillProcessControl{
+		resume: func() error {
+			return terminalOperation(func() error { return process.Signal(syscall.SIGCONT) })
+		},
+		terminate: func() error {
+			return terminalOperation(process.Kill)
+		},
+	}, nil
 }
 
 func isPreRuntimeStagingMetadataUnavailable(error) bool {


### PR DESCRIPTION
{
  "project": "Deterministically Release the Non-Windows Hard-Kill Process Handle",
  "branchName": "thr-hardkill-findprocess-release",
  "description": "Make the non-Windows CLI hard-kill functional-test control the explicit owner of the os.FindProcess result and release that handle exactly once on every terminal path. Initial SIGSTOP failure releases immediately; the first resume or terminate operation signals and releases while later calls safely do nothing. Preserve signal and cleanup errors, retain all hard-kill assertions, and prove the correction with focused repeated Linux race coverage and full process-package plain and coverage runs.",
  "context": {
    "customerAsk": "Resolve the resource-lifecycle follow-up from PR #1884 by deterministically releasing the os.FindProcess handle owned by the non-Windows hard-kill test helper. Release on initial SIGSTOP failure and exactly once after the first resume or terminate operation, preserve useful signal and release errors, retain all hard-kill assertions, and prove the result through focused repeated Linux race coverage and full process-package plain and coverage runs. Keep prd.json and progress.txt out of the PR diff.",
    "problem": "The non-Windows helper obtains an independently owned *os.Process with os.FindProcess, uses it to send SIGSTOP, but never calls Wait or Release on that object. The later exec.Cmd.Wait reaps a different Process instance. With Go 1.25 on Linux, each successful lookup can retain a pidfd until nondeterministic runtime cleanup, and the initial SIGSTOP failure path leaks the lookup handle too.",
    "solution": "Give a small non-Windows lifecycle control exclusive ownership of the FindProcess value. Release immediately when initial SIGSTOP fails. For a successful control, coordinate resume and terminate so the first terminal operation sends SIGCONT or kills through the owned handle and then releases exactly once, while later calls are no-ops. Compose signal and release failures without losing the signal failure, retain the separate exec.Cmd wait/reap lifecycle, and verify the unchanged hard-kill behavior under Linux repetition, race, plain-package, and coverage-package runs."
  },
  "acceptanceCriteria": [
    "Every successful non-Windows os.FindProcess acquisition has one explicit owner and one deterministic Release: initial SIGSTOP failure releases before return, and a returned control releases after its first terminal operation.",
    "Resume and terminate are coordinated so the first terminal call sends exactly one SIGCONT or kill action and then releases the owned handle; all later terminal calls are safe no-ops and cannot signal or release again.",
    "When signaling and release both fail, the returned error preserves the signal failure and reports the release failure; a release-only failure is also returned, and no error is invented when both operations succeed.",
    "The focused hard-kill successor test passes repeatedly on Linux, including with -race, and the full CLI process functional package passes both plain and -cover runs without weakening its staging-contention, retained-resource, or diagnostic assertions.",
    "The implementation remains limited to this functional test helper's process-handle lifecycle and directly affected behavioral coverage; prd.json and progress.txt never appear in the PR diff, and no unrelated cleanup, production behavior, public contract, frontend, or generated artifact changes are included.",
    "Typecheck passes; tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file ownership are resolved against current main, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "thr-hardkill-findprocess-release-001",
      "title": "Make the non-Windows suspension control own one terminal release",
      "description": "As a maintainer running the hard-kill functional scenario, I want the non-Windows suspension control to close its independently acquired process handle on every terminal path so repeated checkpoints do not retain OS resources.",
      "acceptanceCriteria": [
        "If os.FindProcess succeeds but initial SIGSTOP fails, the helper calls Release before returning and reports the stop failure together with any release failure.",
        "A successfully returned control exclusively owns the FindProcess value until either resume or terminate is called.",
        "The first resume call sends SIGCONT and then calls Release exactly once, even when signaling fails.",
        "The first terminate call kills through the owned FindProcess value and then calls Release exactly once, even when killing fails.",
        "Resume and terminate coordinate shared terminal state so only the first terminal call signals and releases; subsequent or competing calls are safe no-ops.",
        "Error composition preserves a signal failure as the primary operational failure, includes a simultaneous release failure, returns a release-only failure when applicable, and returns nil when both actions succeed.",
        "The hard-kill observation path uses the terminal control without changing when the predecessor is resumed, killed, or reaped through its separate exec.Cmd lifecycle.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Completed 2026-08-11. The non-Windows helper now gives the os.FindProcess result one explicit lifecycle owner: initial SIGSTOP failure joins the stop and Release errors, while a mutex-coordinated first resume or terminate signals/kills, releases exactly once, and makes later terminal calls no-ops. Focused fake-handle coverage proves initial-stop cleanup, resume/terminate cleanup, signal-plus-release and release-only errors, repeated calls, and competing terminal calls. Windows package vet passed; Linux/amd64 package compilation passed; the focused lifecycle tests passed 10/10 plain and 10/10 under -race. Story 002 remains for focused hard-kill repetition and full process-package plain/coverage evidence."
    },
    {
      "id": "thr-hardkill-findprocess-release-002",
      "title": "Prove resource-safe hard-kill behavior without weakening assertions",
      "description": "As a reviewer, I want repeated race and package-level evidence so I can verify that the handle is released deterministically while the hard-kill regression continues to prove the same CLI behavior.",
      "acceptanceCriteria": [
        "Focused behavioral coverage exercises initial-stop failure, resume, terminate, repeated terminal calls, and signal-plus-release error reporting, and demonstrates one release for each acquired handle without relying on source scanning or helper-inventory tests.",
        "TestCLISuccessorAfterHardKillReportsPreRuntimeStagingContention passes repeatedly on a Linux runner in a focused plain run and a focused -race run.",
        "The full tests/functional/transport/cli/process package passes once in plain mode and once with -cover.",
        "The hard-kill test still proves the complete pre-runtime contention diagnostic, retained staging resource, unchanged backend scope, absence of invented ownership files, and that the successor does not reach runtime; assertions are not removed, relaxed, or replaced with a generic non-zero-exit check.",
        "Review confirms every FindProcess acquisition in the changed non-Windows control reaches exactly one explicit Release terminal path, while the distinct exec.Cmd.Process remains reaped through Wait.",
        "Verification evidence is reported in the PR conversation rather than committed as prd.json, progress.txt, generated logs, or CI-evidence-only commits.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Completed 2026-08-11. Focused lifecycle coverage exercises initial-stop failure, resume, terminate, repeated terminal calls, signal-plus-release and release-only failures, and competing terminal calls; each fake acquisition released exactly once. On Linux/amd64, TestCLISuccessorAfterHardKillReportsPreRuntimeStagingContention passed 10/10 plain and 10/10 with -race, and the full tests/functional/transport/cli/process package passed in plain and -cover modes. UI typecheck passed after restoring the existing Bun dependencies. The hard-kill assertions and two-process Wait/reap lifecycle remain unchanged."
    }
  ]
}
