### PR TITLE
thr-deflake-workers-mock-drain

### DIFF
--- a/pkg/services/factory_sessions/internal/processlifecycle/plan.go
+++ b/pkg/services/factory_sessions/internal/processlifecycle/plan.go
@@ -229,7 +229,10 @@ func (state *applicationRuntimeLifecycle) startRuntime(ctx context.Context) erro
 		state.mu.Unlock()
 		return errors.New("start Factory Session runtime: already started")
 	}
-	runCtx, cancel := context.WithCancel(ctx)
+	// The lifecycle manager owns orderly unwind after activation returns. Keep
+	// the hosted runtime alive until that owner can stop it, otherwise parent
+	// cancellation can stop the runtime between this start and startWorkers.
+	runCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	state.runtimeCancel = cancel
 	state.mu.Unlock()
 
@@ -248,11 +251,18 @@ func (state *applicationRuntimeLifecycle) startWorkers(ctx context.Context) erro
 		state.mu.Unlock()
 		return errors.New("start Factory Session workers: runtime is not started")
 	}
+	if err := ctx.Err(); err != nil {
+		state.mu.Unlock()
+		return err
+	}
 	if state.workersCancel != nil || state.stopWorkersFn != nil {
 		state.mu.Unlock()
 		return errors.New("start Factory Session workers: already started")
 	}
-	workerCtx, cancel := context.WithCancel(ctx)
+	// Worker-sidecar startup is part of the same activation transaction as the
+	// runtime. Its context must not stop the runtime before startup has returned;
+	// cancellation is checked after acquisition and then unwound explicitly.
+	workerCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	state.workersCancel = cancel
 	state.mu.Unlock()
 
@@ -277,6 +287,9 @@ func (state *applicationRuntimeLifecycle) startWorkers(ctx context.Context) erro
 	state.mu.Lock()
 	state.stopWorkersFn = stop
 	state.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return errors.Join(err, state.stopWorkers(context.Background()))
+	}
 	return nil
 }
 

--- a/pkg/services/factory_sessions/internal/processlifecycle/plan.go
+++ b/pkg/services/factory_sessions/internal/processlifecycle/plan.go
@@ -224,10 +224,17 @@ type applicationRuntimeLifecycle struct {
 }
 
 func (state *applicationRuntimeLifecycle) startRuntime(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	state.mu.Lock()
 	if state.runtimeActive || state.runtimeCancel != nil {
 		state.mu.Unlock()
 		return errors.New("start Factory Session runtime: already started")
+	}
+	if err := ctx.Err(); err != nil {
+		state.mu.Unlock()
+		return err
 	}
 	// The lifecycle manager owns orderly unwind after activation returns. Keep
 	// the hosted runtime alive until that owner can stop it, otherwise parent

--- a/pkg/services/factory_sessions/internal/processlifecycle/plan_test.go
+++ b/pkg/services/factory_sessions/internal/processlifecycle/plan_test.go
@@ -7,8 +7,10 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/portpowered/infinite-you/pkg/initializer/lifecycle"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/roles"
 )
@@ -19,6 +21,74 @@ type planRuntime struct {
 	workerErr      error
 	workerStop     factorysessions.RuntimeStop
 	runtimeStopErr error
+}
+
+type cancellationTransitionRuntime struct {
+	events []string
+
+	runtimeContext             context.Context
+	runtimeAliveAtStartReturn  bool
+	workerStopSawRuntimeCancel bool
+	workerStarts               int
+
+	startEntered  chan struct{}
+	releaseStart  chan struct{}
+	workerEntered chan struct{}
+	releaseWorker chan struct{}
+}
+
+func (runtime *cancellationTransitionRuntime) StartLifecycle(_, runCtx context.Context) error {
+	runtime.runtimeContext = runCtx
+	runtime.events = append(runtime.events, "runtime:start")
+	if runtime.startEntered != nil {
+		close(runtime.startEntered)
+		<-runtime.releaseStart
+	}
+	runtime.runtimeAliveAtStartReturn = runCtx.Err() == nil
+	return nil
+}
+
+func (runtime *cancellationTransitionRuntime) Start(ctx, runCtx context.Context) error {
+	return runtime.StartLifecycle(ctx, runCtx)
+}
+
+func (runtime *cancellationTransitionRuntime) StartWorkerLifecycle(ctx context.Context) (factorysessions.RuntimeStop, error) {
+	runtime.workerStarts++
+	runtime.events = append(runtime.events, "workers:start")
+	if runtime.workerEntered != nil {
+		close(runtime.workerEntered)
+		<-runtime.releaseWorker
+	}
+	return func(context.Context) error {
+		runtime.workerStopSawRuntimeCancel = runtime.runtimeContext.Err() != nil
+		runtime.events = append(runtime.events, "workers:stop")
+		return nil
+	}, nil
+}
+
+func (runtime *cancellationTransitionRuntime) StartWorkers(ctx context.Context) (factorysessions.RuntimeStop, error) {
+	return runtime.StartWorkerLifecycle(ctx)
+}
+
+func (*cancellationTransitionRuntime) CompleteStartup(context.Context) error { return nil }
+
+func (*cancellationTransitionRuntime) WaitForRuntime(context.Context) error { return nil }
+
+func (*cancellationTransitionRuntime) RunTransport(context.Context, http.Handler) error { return nil }
+
+func (runtime *cancellationTransitionRuntime) StopLifecycle(context.Context) error {
+	runtime.events = append(runtime.events, "runtime:stop")
+	return nil
+}
+
+func (runtime *cancellationTransitionRuntime) Stop(ctx context.Context) error {
+	return runtime.StopLifecycle(ctx)
+}
+
+func (*cancellationTransitionRuntime) FailStartup(err error) error { return err }
+
+func (*cancellationTransitionRuntime) CurrentRuntimeBundle() factoryruntime.HostedInstance {
+	return nil
 }
 
 func (runtime *planRuntime) Start(context.Context, context.Context) error {
@@ -214,6 +284,64 @@ func TestRuntimeLifecycleLeavesRuntimeUnwindAvailableAfterWorkerStartFailure(t *
 	}
 }
 
+func TestRuntimeLifecycleKeepsRuntimeAliveUntilCanceledStartupUnwinds(t *testing.T) {
+	runtime := &cancellationTransitionRuntime{
+		startEntered: make(chan struct{}),
+		releaseStart: make(chan struct{}),
+	}
+	plan := requiredPlanWithEvents(t, runtime, &runtime.events)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runDone := make(chan error, 1)
+	go func() { runDone <- lifecycle.NewManager().Run(ctx, plan) }()
+
+	awaitLifecycleSignal(t, runtime.startEntered)
+	cancel()
+	close(runtime.releaseStart)
+	if err := <-runDone; err != nil {
+		t.Fatalf("Run error = %v, want cancellation to unwind cleanly", err)
+	}
+	if !runtime.runtimeAliveAtStartReturn {
+		t.Fatal("runtime context was canceled before the startup transition returned")
+	}
+	if runtime.workerStarts != 0 {
+		t.Fatalf("worker starts = %d, want no worker acquisition after cancellation", runtime.workerStarts)
+	}
+}
+
+func TestRuntimeLifecycleDrainsWorkerAcquisitionBeforeRuntimeShutdown(t *testing.T) {
+	runtime := &cancellationTransitionRuntime{
+		workerEntered: make(chan struct{}),
+		releaseWorker: make(chan struct{}),
+	}
+	plan := requiredPlanWithEvents(t, runtime, &runtime.events)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runDone := make(chan error, 1)
+	go func() { runDone <- lifecycle.NewManager().Run(ctx, plan) }()
+
+	awaitLifecycleSignal(t, runtime.workerEntered)
+	cancel()
+	close(runtime.releaseWorker)
+	if err := <-runDone; err != nil {
+		t.Fatalf("Run error = %v, want cancellation to unwind cleanly", err)
+	}
+	if runtime.workerStopSawRuntimeCancel {
+		t.Fatal("worker acquisition was stopped after the runtime context was canceled")
+	}
+}
+
+func awaitLifecycleSignal(t *testing.T, signal <-chan struct{}) {
+	t.Helper()
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-signal:
+	case <-timer.C:
+		t.Fatal("timed out waiting for lifecycle transition")
+	}
+}
+
 func TestRuntimeLifecycleUnwindsFailedRuntimeStart(t *testing.T) {
 	startErr := errors.New("start failed")
 	stopErr := errors.New("stop failed")
@@ -372,11 +500,15 @@ func TestDirectJavaScriptLifecycleRejectsMissingCompletion(t *testing.T) {
 }
 
 func requiredPlan(t *testing.T, runtime *planRuntime) lifecycle.Plan {
+	return requiredPlanWithEvents(t, runtime, &runtime.events)
+}
+
+func requiredPlanWithEvents(t *testing.T, runtime roles.ProcessRuntime, events *[]string) lifecycle.Plan {
 	t.Helper()
 	plan, err := BuildLifecyclePlan(roles.LifecyclePlanRequest{
 		Runtime: runtime,
 		Components: factorysessions.BoundProcessComponents{
-			Transport: &planComponent{name: "transport", events: &runtime.events},
+			Transport: &planComponent{name: "transport", events: events},
 		},
 	})
 	if err != nil {

--- a/pkg/services/factory_sessions/internal/processlifecycle/plan_test.go
+++ b/pkg/services/factory_sessions/internal/processlifecycle/plan_test.go
@@ -284,6 +284,20 @@ func TestRuntimeLifecycleLeavesRuntimeUnwindAvailableAfterWorkerStartFailure(t *
 	}
 }
 
+func TestRuntimeLifecycleRejectsPreActivationCancellationBeforeRuntimeAcquisition(t *testing.T) {
+	runtime := &planRuntime{}
+	plan := requiredPlan(t, runtime)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := lifecycle.NewManager().Run(ctx, plan); err != nil {
+		t.Fatalf("Run error = %v, want canceled activation to unwind quietly", err)
+	}
+	if len(runtime.events) != 0 {
+		t.Fatalf("runtime events = %v, want no runtime acquisition after pre-activation cancellation", runtime.events)
+	}
+}
+
 func TestRuntimeLifecycleKeepsRuntimeAliveUntilCanceledStartupUnwinds(t *testing.T) {
 	runtime := &cancellationTransitionRuntime{
 		startEntered: make(chan struct{}),

--- a/tests/functional/workers/mock/plain_batch_drain_test.go
+++ b/tests/functional/workers/mock/plain_batch_drain_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -120,6 +121,56 @@ func TestPlainBatchDrainPreservesFiniteAndContinuousCounterexamples(t *testing.T
 			t.Fatalf("continuous plain stderr = %q, want empty or the cancellation diagnostic", stderr)
 		}
 	})
+}
+
+func TestPlainBatchDrainRejectsCancellationBeforeRuntimeActivation(t *testing.T) {
+	factoryDir := scaffoldPlainBatchDrainFactory(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	inputs := plainBatchInputs(t, factoryDir, "", true)
+	inputs.Input.Context = ctx
+
+	process := support.BuildProcess(t, serviceedges.Edges{
+		FactorySessionIDGenerator: func() string {
+			cancel()
+			return "preactivation-canceled-session"
+		},
+	})
+	support.CleanupProcess(t, process)
+
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf("canceled continuous plain batch error = %v; stdout=%q stderr=%q", err, inputs.Stdout(), inputs.Stderr())
+	}
+	if inputs.Stdout() != "" || inputs.Stderr() != "" {
+		t.Fatalf("canceled pre-activation output = stdout:%q stderr:%q, want quiet output", inputs.Stdout(), inputs.Stderr())
+	}
+}
+
+func TestPlainBatchDrainStopsAfterWorkerActivationCancellation(t *testing.T) {
+	factoryDir := scaffoldPlainBatchDrainFactory(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	inputs := support.FakeInputs(ctx, []string{
+		"you", "run", "--dir", factoryDir, "--continuously", "--with-server", "--no-record", "--quiet",
+	})
+	inputs.WorkingDirectory = factoryDir
+	homeDir := t.TempDir()
+	inputs.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+
+	process := support.BuildProcess(t, serviceedges.Edges{
+		FactoryRuntimeInputDirectoryWalker: func(string, fs.WalkDirFunc) error {
+			cancel()
+			return nil
+		},
+	})
+	support.CleanupProcess(t, process)
+
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf("canceled service-mode plain batch error = %v; stdout=%q stderr=%q", err, inputs.Stdout(), inputs.Stderr())
+	}
+	if inputs.Stdout() != "" || inputs.Stderr() != "" {
+		t.Fatalf("canceled post-activation output = stdout:%q stderr:%q, want quiet output", inputs.Stdout(), inputs.Stderr())
+	}
 }
 
 func plainBatchInputs(t *testing.T, factoryDir, workFile string, continuous bool) *support.CapturedInputs {


### PR DESCRIPTION
{
  "project": "Deflake Workers Mock Continuous-Idle Drain Shutdown",
  "branchName": "thr-deflake-workers-mock-drain",
  "description": "Diagnose and eliminate the intermittent shutdown race in TestPlainBatchDrainPreservesFiniteAndContinuousCounterexamples/continuous_idle by ordering command drain, cancellation, runtime stop, and process cleanup through observable lifecycle conditions, preserving every finite and continuous counterexample assertion, and proving 20-of-20 plain and coverage stability plus a clean race run and required CI through merge.",
  "context": {
    "customerAsk": "Deflake TestPlainBatchDrainPreservesFiniteAndContinuousCounterexamples/continuous_idle in the functional workers/mock package. Reproduce it with 20 repeated runs in plain, coverage-instrumented, and race-enabled forms; determine whether continuous-idle drain, cancellation, cleanup ordering, shared runtime reuse, or a recent lifecycle change allows Process.Execute to overlap a stopped Factory Runtime; fix the proven cause structurally without fixed sleeps or weaker assertions; quote 20-of-20 plain and coverage results and a clean race result in the PR; and obtain a passing Backend Functional Coverage check. The root prd.json and progress.txt scaffolding files must never appear in the PR diff.",
    "problem": "GitHub Actions run 31563063650, job 94009351809, failed on PR #1878 at head 47bd755b in an untouched workers/mock package with Process.Execute() after shutdown and start runtime sidecar: factory runtime is already stopped, while a reviewer observed 10 of 10 passes at base 609d091d. The asynchronous continuous-idle command, cancellation, command stop, test cleanup, Factory Runtime teardown, and process close can be scheduled so execution or sidecar startup overlaps a runtime that has begun stopping. The corrected investigation also reproduced a pre-activation order: cancellation reaches lifecycle.Manager.Run before the runtime component starts, but startRuntime acquires the runtime with a canceled readiness context; runtime startup then unwinds while the lifecycle transaction can report the stopped-runtime failure. Coverage slowdown or CI load exposes these nondeterministic lifecycle orders, blocking unrelated pull requests and making required functional coverage unreliable.",
    "solution": "Establish a before-fix matrix with the exact plain -count=20, coverage -cover -count=20, and race-enabled commands. Correlate command start, idle observation, cancellation, Process.Execute completion, runtime stop, and process close to identify the losing order and whether it is test-local or production-owned. Give one owner responsibility for drain and teardown, reject pre-activation cancellation before runtime acquisition, keep runtime and worker-sidecar contexts lifecycle-owned through activation, and synchronize on authoritative lifecycle completion so no execution starts or remains active against a stopped runtime. Use timeouts only as bounded failure guards. Preserve finite success, continuous-idle liveness, cancellation, quiet output, and all counterexample assertions. Change production code only if direct evidence proves a genuine owning lifecycle defect, then prove sustained local and CI stability and deliver through merge."
  },
  "acceptanceCriteria": [
    "The PR description explains the exact root cause, including the competing actors, the losing order between command execution or drain and runtime shutdown, why coverage or CI scheduling exposes it, and why the correction makes that order deterministic; if natural stress does not reproduce the failure, a controlled scheduling gate or diagnostic demonstrates the unsafe order.",
    "The continuous-idle scenario remains running while idle, shuts down cleanly after cancellation, emits no unexpected output, and never attempts to start or continue execution against a Factory Runtime that is stopping or stopped; the empty and terminal-work finite scenarios still complete successfully and quietly.",
    "Synchronization uses observable runtime, command, drain, or shutdown completion conditions with timeouts only as bounded failure guards; no fixed sleep, assertion retry, skip, quarantine, timeout-only padding, or weakened counterexample assertion is introduced.",
    "The exact named test passes 20 of 20 with the plain command and 20 of 20 with coverage instrumentation, and its race-enabled run is clean; command lines and results are quoted or attached in the PR without committing one-off evidence files.",
    "The PR's own Backend Functional Coverage check is terminal and passing; the implementation stays within tests/functional/workers/mock unless evidence proves a genuine production shutdown race, any production correction is minimal and owned by the responsible service, and root prd.json and progress.txt do not appear in the PR diff.",
    "Typecheck and tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are resolved against current origin/main, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "thr-deflake-workers-mock-drain-001",
      "title": "Establish the shutdown race cause",
      "description": "As a maintainer, I want reproducible lifecycle evidence for the continuous-idle failure so that the implementation removes the proven race instead of masking it.",
      "acceptanceCriteria": [
        "Before changing behavior, run go test ./tests/functional/workers/mock/ -run TestPlainBatchDrainPreservesFiniteAndContinuousCounterexamples -count=20, the same command with -cover, and the same test with -race; retain the command, environment, pass/fail count, and observed failure phase for the PR evidence.",
        "The diagnosis identifies who owns command start, idle observation, drain or cancellation, Process.Execute completion, Factory Runtime stop, and process close, and names the exact losing event order that can produce start runtime sidecar: factory runtime is already stopped.",
        "The investigation distinguishes test cleanup overlap, shared runtime reuse across subtests, and a production runtime lifecycle defect using observed behavior; recent plain-batch-drain, live-change-admission, structured-worker-results, and webhook lifecycle changes are considered only as causal candidates, not assumed causes.",
        "If 20-run stress does not naturally reproduce the failure, a deterministic scheduling gate or bounded diagnostic proves the unsafe ordering and would fail when that ordering is restored.",
        "The planned correction remains inside tests/functional/workers/mock unless the evidence proves a production-owned shutdown race; no unrelated package cleanup, generated artifact, root prd.json, root progress.txt, or one-off evidence log is included in the PR diff.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Completed the before-fix matrix before changing behavior. `go test ./tests/functional/workers/mock/ -run TestPlainBatchDrainPreservesFiniteAndContinuousCounterexamples -count=20` passed 20/20; the exact `go test -cover ./tests/functional/workers/mock/ -run TestPlainBatchDrainPreservesFiniteAndContinuousCounterexamples -count=20` reproduced `continuous_idle` failure locally during system initialization under coverage; and `go test -race ./tests/functional/workers/mock/ -run TestPlainBatchDrainPreservesFiniteAndContinuousCounterexamples -count=20` passed 20/20. Focused typecheck/test compilation passed on Go 1.25.0. CI run 31563063650 attempt 1 recorded the later exact failure `CLI_COMMAND_FAILED: command failed: start runtime sidecar: factory runtime is already stopped`. `StartProcessCommand` owns the cancellable Process.Execute goroutine; the test owns only the bounded negative-liveness observation and cancellation; lifecycle owns runtime then workers-sidecar startup; Process.Execute completion is joined before CleanupProcess closes the process. Each subtest builds an isolated process, so there is no shared-runtime reuse, and cleanup ordering is command join then process close. The losing order is cancellation after runtime startup but before the lifecycle manager advances safely to workers-sidecar startup: the runtime run context stops the Factory, then StartLiveRuntimeSidecars observes an already-stopped runtime. The coverage failure is the earlier same-trigger variant where the arbitrary idle timer fires during initialization. Recent plain-batch-drain, admission, structured-result, and webhook changes are not on the failing path; natural stress reproduced the unsafe order, so no controlled gate was required. Story 002 will apply the minimal owning-lifecycle/readiness correction."
    },
    {
      "id": "thr-deflake-workers-mock-drain-002",
      "title": "Make continuous-idle drain and shutdown deterministic",
      "description": "As a contributor, I want continuous-idle execution to drain and stop through one authoritative lifecycle order so that slower scheduling cannot run work against an already stopped Factory Runtime.",
      "acceptanceCriteria": [
        "The continuous-idle command is known to be active before its negative-liveness observation is accepted, and cancellation waits for authoritative command or drain completion before runtime or process teardown can proceed.",
        "No Process.Execute call or runtime-sidecar startup can begin after the relevant Factory Runtime enters stopping or stopped state, and repeated cleanup remains safe without lifecycle ownership racing between the command and the test.",
        "continuous_idle still proves the run does not exit while idle, accepts only the established cancellation outcome, emits no stdout, and emits no stderr other than the permitted cancellation diagnostic.",
        "The empty and terminal work subtests still prove finite plain batches return successfully with quiet output, and none of the counterexample-preservation assertions are removed, broadened, or weakened.",
        "Synchronization observes command, runtime, drain, or shutdown state; any deadline is only a bounded failure guard, with no new fixed sleep, assertion retry, skip, quarantine, or timeout-only padding.",
        "If production code changes because a genuine runtime race is proven, the change is the smallest correction in the owning Factory Runtime, Factory Sessions, initializer, or process lifecycle boundary; state remains explicit, side effects isolated, contracts aligned, and focused owning-package regression evidence is added.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Corrected the Factory Sessions process lifecycle so the hosted runtime and worker-sidecar acquisition use lifecycle-owned child contexts until activation returns; cancellation is rejected before runtime acquisition and before worker acquisition, then drained after acquisition before runtime stop. Added deterministic processlifecycle regressions for pre-activation cancellation, cancellation after runtime start, and cancellation during worker startup. `go test ./pkg/services/factory_sessions/internal/processlifecycle`, its race run, and `go vet ./pkg/services/factory_sessions/internal/processlifecycle` pass. The exact functional target passes 20/20 plain, 20/20 with coverage, and 20/20 with race."
    },
    {
      "id": "thr-deflake-workers-mock-drain-003",
      "title": "Prove stability and deliver the correction",
      "description": "As a maintainer, I want sustained local and CI evidence through merge so that the workers/mock package becomes a trustworthy required gate again.",
      "acceptanceCriteria": [
        "go test ./tests/functional/workers/mock/ -run TestPlainBatchDrainPreservesFiniteAndContinuousCounterexamples -count=20 passes 20 of 20.",
        "go test -cover ./tests/functional/workers/mock/ -run TestPlainBatchDrainPreservesFiniteAndContinuousCounterexamples -count=20 passes 20 of 20 under the coverage slowdown implicated by required CI.",
        "go test -race ./tests/functional/workers/mock/ -run TestPlainBatchDrainPreservesFiniteAndContinuousCounterexamples -count=20 passes without a race report or intermittent lifecycle failure.",
        "The PR quotes or attaches the exact commands, results, environment, and root-cause explanation in its description or comments; CI evidence is not committed, and root prd.json and progress.txt are absent from the PR diff.",
        "The PR's own Backend Functional Coverage check is terminal and passing on the final implementation head; only actual code or review fixes create a later head.",
        "Immediately before final push, the branch is synchronized with current origin/main; later synchronization occurs only for a real conflict or reviewer request, generated files are never hand-merged, and conflicts are resolved without reverting merged concurrent work.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "On Go 1.25.0 after the latest feedback correction, local stability is complete: `go test ./tests/functional/workers/mock/ -run TestPlainBatchDrainPreservesFiniteAndContinuousCounterexamples -count=20` passed 20/20; `go test -cover ./tests/functional/workers/mock/ -run TestPlainBatchDrainPreservesFiniteAndContinuousCounterexamples -count=20` passed 20/20; and the exact `go test -race ./tests/functional/workers/mock/ -run TestPlainBatchDrainPreservesFiniteAndContinuousCounterexamples -count=20` passed 20/20 with no race report or lifecycle failure. Added functional coverage regressions for pre-activation and post-worker-acquisition cancellation; both pass 20/20, and the targeted coverage profile executes both new returns. Owning-package tests, race tests, and vet pass for `pkg/services/factory_sessions/internal/processlifecycle`. Required run `31572557126` on final head `77bd32783` is terminal and passing: Backend Functional Coverage passed the changed package ratchet and the full functional suite, and Verification Policy passed. The earlier full-lane timing flakes were recorded in PR #1902 and cleared by the permitted rerun. No one-off evidence files were created, and the PR remains open for review."
    }
  ]
}
