### PR TITLE
thr-deflake-sessions-execution-drain

### DIFF
--- a/tests/functional/sessions/execution/drain_test.go
+++ b/tests/functional/sessions/execution/drain_test.go
@@ -38,94 +38,130 @@ func TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal(t *testing.T) 
 	} {
 		mode := mode
 		t.Run(mode.name, func(t *testing.T) {
-			factoryDir := scaffoldIncompleteDrainFactory(t)
-			workFile := writeIncompleteDrainWork(t)
-
-			var listenerStarts, listenerStops, browserCalls atomic.Int32
-			api := support.NewProcessAPIServer()
-			shutdownGate := make(chan struct{})
-			var releaseOnce sync.Once
-			releaseListener := func() {
-				releaseOnce.Do(func() { close(shutdownGate) })
-			}
-			transportStopRequested := make(chan struct{})
-			listenerJoined := make(chan struct{})
-			api.HoldShutdownUntilSignaled(shutdownGate)
-			process := support.BuildProcess(t, serviceedges.Edges{
-				APIServerStarter: func(ctx context.Context, request platformhttpserver.StartRequest) error {
-					listenerStarts.Add(1)
-					context.AfterFunc(ctx, func() { close(transportStopRequested) })
-					err := api.Start(ctx, request)
-					listenerStops.Add(1)
-					close(listenerJoined)
-					return err
-				},
-				BrowserOpener: func(context.Context, string) error {
-					browserCalls.Add(1)
-					return nil
-				},
-			})
-			support.CleanupProcess(t, process)
-
-			inputs := support.FakeInputs(t.Context(), []string{
-				"you", "run", "--dir", factoryDir, "--no-record", "--quiet",
-				mode.flag, "--work", workFile,
-			})
-			inputs.WorkingDirectory = factoryDir
-			homeDir := t.TempDir()
-			inputs.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
-
-			command := support.StartProcessCommand(t, process, inputs.Input)
-			t.Cleanup(releaseListener)
-			baseURL := api.WaitForURL(t)
-			observation, err := waitForIncompleteDrainObservation(baseURL)
-			if err != nil {
-				t.Fatalf("incomplete-drain observation: %v", err)
-			}
-			if len(observation.Work.Results) != 1 {
-				t.Fatalf("observed Work count = %d, want 1", len(observation.Work.Results))
-			}
-			work := observation.Work.Results[0]
-			if work.Name != "blocked-work" {
-				t.Fatalf("observed Work name = %q, want blocked-work", work.Name)
-			}
-			if work.State == nil || work.State.Type != factoryapi.WorkStateTypePROCESSING {
-				t.Fatalf("observed Work state = %#v, want PROCESSING", work.State)
-			}
-			if observation.Status.RuntimeStatus == "" || observation.Status.Categories.Processing != 1 {
-				t.Fatalf("observed runtime status = %#v, want one processing Work", observation.Status)
-			}
-
-			waitForSignal(t, transportStopRequested, "finite hosted runtime did not request listener shutdown")
-			select {
-			case <-command.Done():
-				t.Fatal("finite hosted command completed before the listener join gate was released")
-			default:
-			}
-			releaseListener()
-			waitForCommandDone(t, command, "finite hosted run did not return after the runtime drained")
-			waitForSignal(t, listenerJoined, "finite hosted listener did not join before command completion")
-			command.AcceptError()
-
-			err = command.Err()
-			if err == nil {
-				t.Fatalf("Process.Execute() error = %v, want incomplete-drain failure", err)
-			}
-
-			support.RequireSafeCLIDiagnostic(t, inputs.Stderr())
-			if stdout := inputs.Stdout(); stdout != "" {
-				t.Fatalf("stdout = %q, want no success or completion output", stdout)
-			}
-			if got := listenerStarts.Load(); got != 1 {
-				t.Fatalf("listener starts = %d, want 1; err=%v stdout=%q stderr=%q", got, err, inputs.Stdout(), inputs.Stderr())
-			}
-			if got := listenerStops.Load(); got != 1 {
-				t.Fatalf("listener stops = %d, want one joined listener", got)
-			}
-			if got := browserCalls.Load(); got != mode.wantBrowser {
-				t.Fatalf("browser calls = %d, want %d", got, mode.wantBrowser)
-			}
+			runIncompleteDrainMode(t, mode.flag, mode.wantBrowser)
 		})
+	}
+}
+
+func runIncompleteDrainMode(t *testing.T, modeFlag string, wantBrowser int32) {
+	t.Helper()
+	factoryDir := scaffoldIncompleteDrainFactory(t)
+	workFile := writeIncompleteDrainWork(t)
+
+	var listenerStarts, listenerStops, browserCalls atomic.Int32
+	api := support.NewProcessAPIServer()
+	shutdownGate := make(chan struct{})
+	workerRelease := make(chan struct{})
+	var releaseListenerOnce, releaseWorkerOnce sync.Once
+	releaseListener := func() {
+		releaseListenerOnce.Do(func() { close(shutdownGate) })
+	}
+	releaseWorker := func() {
+		releaseWorkerOnce.Do(func() { close(workerRelease) })
+	}
+	transportStopRequested := make(chan struct{})
+	listenerJoined := make(chan struct{})
+	api.HoldShutdownUntilSignaled(shutdownGate)
+	edges := serviceedges.Edges{
+		APIServerStarter: func(ctx context.Context, request platformhttpserver.StartRequest) error {
+			listenerStarts.Add(1)
+			context.AfterFunc(ctx, func() { close(transportStopRequested) })
+			bound := request.OnBound
+			request.OnBound = func(binding platformhttpserver.Binding) {
+				if bound != nil {
+					bound(binding)
+				}
+				// The gated worker output is the observable ordering barrier: the
+				// listener must bind before Work can reach its blocked state and
+				// become eligible for finite drain classification.
+				releaseWorker()
+			}
+			err := api.Start(ctx, request)
+			listenerStops.Add(1)
+			close(listenerJoined)
+			return err
+		},
+		BrowserOpener: func(context.Context, string) error {
+			browserCalls.Add(1)
+			return nil
+		},
+	}
+	support.ConfigureWorkerCommands(
+		t, &edges,
+		support.NewGatedSuccessCommandRunner("Done. COMPLETE", workerRelease),
+		nil,
+	)
+	process := support.BuildProcess(t, edges)
+	support.CleanupProcess(t, process)
+
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "run", "--dir", factoryDir, "--no-record", "--quiet",
+		modeFlag, "--work", workFile,
+	})
+	inputs.WorkingDirectory = factoryDir
+	homeDir := t.TempDir()
+	inputs.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+
+	command := support.StartProcessCommand(t, process, inputs.Input)
+	t.Cleanup(releaseListener)
+	baseURL := api.WaitForURL(t)
+	observation, err := waitForIncompleteDrainObservation(baseURL)
+	if err != nil {
+		t.Fatalf("incomplete-drain observation: %v", err)
+	}
+	if len(observation.Work.Results) != 1 {
+		t.Fatalf("observed Work count = %d, want 1", len(observation.Work.Results))
+	}
+	work := observation.Work.Results[0]
+	if work.Name != "blocked-work" {
+		t.Fatalf("observed Work name = %q, want blocked-work", work.Name)
+	}
+	if work.State == nil || work.State.Type != factoryapi.WorkStateTypePROCESSING {
+		t.Fatalf("observed Work state = %#v, want PROCESSING", work.State)
+	}
+	if observation.Status.RuntimeStatus == "" || observation.Status.Categories.Processing != 1 {
+		t.Fatalf("observed runtime status = %#v, want one processing Work", observation.Status)
+	}
+
+	waitForSignal(t, transportStopRequested, "finite hosted runtime did not request listener shutdown")
+	select {
+	case <-command.Done():
+		t.Fatal("finite hosted command completed before the listener join gate was released")
+	default:
+	}
+	releaseListener()
+	waitForCommandDone(t, command, "finite hosted run did not return after the runtime drained")
+	waitForSignal(t, listenerJoined, "finite hosted listener did not join before command completion")
+	assertIncompleteDrainFailure(
+		t, command, inputs, &listenerStarts, &listenerStops, &browserCalls, wantBrowser,
+	)
+}
+
+func assertIncompleteDrainFailure(
+	t *testing.T,
+	command *support.ProcessCommand,
+	inputs *support.CapturedInputs,
+	listenerStarts, listenerStops, browserCalls *atomic.Int32,
+	wantBrowser int32,
+) {
+	t.Helper()
+	command.AcceptError()
+	err := command.Err()
+	if err == nil {
+		t.Fatalf("Process.Execute() error = %v, want incomplete-drain failure", err)
+	}
+	support.RequireSafeCLIDiagnostic(t, inputs.Stderr())
+	if stdout := inputs.Stdout(); stdout != "" {
+		t.Fatalf("stdout = %q, want no success or completion output", stdout)
+	}
+	if got := listenerStarts.Load(); got != 1 {
+		t.Fatalf("listener starts = %d, want 1; err=%v stdout=%q stderr=%q", got, err, inputs.Stdout(), inputs.Stderr())
+	}
+	if got := listenerStops.Load(); got != 1 {
+		t.Fatalf("listener stops = %d, want one joined listener", got)
+	}
+	if got := browserCalls.Load(); got != wantBrowser {
+		t.Fatalf("browser calls = %d, want %d", got, wantBrowser)
 	}
 }
 
@@ -397,12 +433,20 @@ func scaffoldIncompleteDrainFactory(t *testing.T) string {
 		"name": "blocked",
 		"type": "PROCESSING",
 	})
-	return scaffoldInvocationFactory(t, map[string]any{"workTypes": workTypes})
+	workstations := cfg["workstations"].([]map[string]any)
+	workstations[0]["outputs"] = []map[string]string{{
+		"workType": "task",
+		"state":    "blocked",
+	}}
+	return scaffoldInvocationFactory(t, map[string]any{
+		"workTypes":    workTypes,
+		"workstations": workstations,
+	})
 }
 
 func writeIncompleteDrainWork(t *testing.T) string {
 	t.Helper()
-	return writeDrainWork(t, "blocked")
+	return writeDrainWork(t, "init")
 }
 
 func writeDrainWork(t *testing.T, state string) string {

--- a/tests/functional/sessions/execution/drain_test.go
+++ b/tests/functional/sessions/execution/drain_test.go
@@ -17,7 +17,6 @@ import (
 
 	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
-	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
@@ -111,16 +110,6 @@ func TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal(t *testing.T) 
 			err = command.Err()
 			if err == nil {
 				t.Fatalf("Process.Execute() error = %v, want incomplete-drain failure", err)
-			}
-			var incompleteDrainErr *factoryruntime.IncompleteDrainError
-			if !errors.As(err, &incompleteDrainErr) {
-				t.Fatalf("Process.Execute() error = %T %v, want IncompleteDrainError", err, err)
-			}
-			if !errors.Is(err, factoryruntime.ErrIncompleteDrain) {
-				t.Fatalf("Process.Execute() error = %v, want ErrIncompleteDrain", err)
-			}
-			if incompleteDrainErr.NonTerminalWorkCount != 1 {
-				t.Fatalf("incomplete-drain non-terminal Work count = %d, want 1", incompleteDrainErr.NonTerminalWorkCount)
 			}
 
 			support.RequireSafeCLIDiagnostic(t, inputs.Stderr())

--- a/tests/functional/sessions/execution/drain_test.go
+++ b/tests/functional/sessions/execution/drain_test.go
@@ -17,6 +17,7 @@ import (
 
 	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
@@ -110,6 +111,16 @@ func TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal(t *testing.T) 
 			err = command.Err()
 			if err == nil {
 				t.Fatalf("Process.Execute() error = %v, want incomplete-drain failure", err)
+			}
+			var incompleteDrainErr *factoryruntime.IncompleteDrainError
+			if !errors.As(err, &incompleteDrainErr) {
+				t.Fatalf("Process.Execute() error = %T %v, want IncompleteDrainError", err, err)
+			}
+			if !errors.Is(err, factoryruntime.ErrIncompleteDrain) {
+				t.Fatalf("Process.Execute() error = %v, want ErrIncompleteDrain", err)
+			}
+			if incompleteDrainErr.NonTerminalWorkCount != 1 {
+				t.Fatalf("incomplete-drain non-terminal Work count = %d, want 1", incompleteDrainErr.NonTerminalWorkCount)
 			}
 
 			support.RequireSafeCLIDiagnostic(t, inputs.Stderr())

--- a/tests/functional/sessions/execution/drain_test.go
+++ b/tests/functional/sessions/execution/drain_test.go
@@ -4,15 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
@@ -37,15 +42,23 @@ func TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal(t *testing.T) 
 			workFile := writeIncompleteDrainWork(t)
 
 			var listenerStarts, listenerStops, browserCalls atomic.Int32
+			api := support.NewProcessAPIServer()
+			shutdownGate := make(chan struct{})
+			var releaseOnce sync.Once
+			releaseListener := func() {
+				releaseOnce.Do(func() { close(shutdownGate) })
+			}
+			transportStopRequested := make(chan struct{})
+			listenerJoined := make(chan struct{})
+			api.HoldShutdownUntilSignaled(shutdownGate)
 			process := support.BuildProcess(t, serviceedges.Edges{
 				APIServerStarter: func(ctx context.Context, request platformhttpserver.StartRequest) error {
 					listenerStarts.Add(1)
-					if request.OnBound != nil {
-						request.OnBound(platformhttpserver.Binding{Port: request.Port})
-					}
-					<-ctx.Done()
+					context.AfterFunc(ctx, func() { close(transportStopRequested) })
+					err := api.Start(ctx, request)
 					listenerStops.Add(1)
-					return ctx.Err()
+					close(listenerJoined)
+					return err
 				},
 				BrowserOpener: func(context.Context, string) error {
 					browserCalls.Add(1)
@@ -63,10 +76,38 @@ func TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal(t *testing.T) 
 			inputs.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
 
 			command := support.StartProcessCommand(t, process, inputs.Input)
+			t.Cleanup(releaseListener)
+			baseURL := api.WaitForURL(t)
+			observation, err := waitForIncompleteDrainObservation(baseURL)
+			if err != nil {
+				t.Fatalf("incomplete-drain observation: %v", err)
+			}
+			if len(observation.Work.Results) != 1 {
+				t.Fatalf("observed Work count = %d, want 1", len(observation.Work.Results))
+			}
+			work := observation.Work.Results[0]
+			if work.Name != "blocked-work" {
+				t.Fatalf("observed Work name = %q, want blocked-work", work.Name)
+			}
+			if work.State == nil || work.State.Type != factoryapi.WorkStateTypePROCESSING {
+				t.Fatalf("observed Work state = %#v, want PROCESSING", work.State)
+			}
+			if observation.Status.RuntimeStatus == "" || observation.Status.Categories.Processing != 1 {
+				t.Fatalf("observed runtime status = %#v, want one processing Work", observation.Status)
+			}
+
+			waitForSignal(t, transportStopRequested, "finite hosted runtime did not request listener shutdown")
+			select {
+			case <-command.Done():
+				t.Fatal("finite hosted command completed before the listener join gate was released")
+			default:
+			}
+			releaseListener()
 			waitForCommandDone(t, command, "finite hosted run did not return after the runtime drained")
+			waitForSignal(t, listenerJoined, "finite hosted listener did not join before command completion")
 			command.AcceptError()
 
-			err := command.Err()
+			err = command.Err()
 			if err == nil {
 				t.Fatalf("Process.Execute() error = %v, want incomplete-drain failure", err)
 			}
@@ -85,6 +126,83 @@ func TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal(t *testing.T) 
 				t.Fatalf("browser calls = %d, want %d", got, mode.wantBrowser)
 			}
 		})
+	}
+}
+
+type incompleteDrainObservation struct {
+	Work   factoryapi.ListWorkResponse
+	Status factoryapi.StatusResponse
+}
+
+func waitForIncompleteDrainObservation(baseURL string) (incompleteDrainObservation, error) {
+	// Work and status are asynchronously committed public projections and do
+	// not expose one shared readiness channel. WaitForObservation therefore
+	// accepts only the observable admitted/non-terminal state; its timeout is
+	// solely a hung-projection guard, not a success window.
+	return support.WaitForObservation(
+		incompleteDrainProcessTimeout,
+		func() (incompleteDrainObservation, error) {
+			work, err := readHostedWork(baseURL)
+			if err != nil {
+				return incompleteDrainObservation{}, err
+			}
+			status, err := readHostedStatus(baseURL)
+			if err != nil {
+				return incompleteDrainObservation{}, err
+			}
+			return incompleteDrainObservation{Work: work, Status: status}, nil
+		},
+		func(observation incompleteDrainObservation) bool {
+			if len(observation.Work.Results) != 1 {
+				return false
+			}
+			work := observation.Work.Results[0]
+			return work.State != nil &&
+				work.State.Type == factoryapi.WorkStateTypePROCESSING &&
+				observation.Status.RuntimeStatus != "" &&
+				observation.Status.Categories.Processing == 1
+		},
+	)
+}
+
+func readHostedWork(baseURL string) (factoryapi.ListWorkResponse, error) {
+	return readHostedJSON[factoryapi.ListWorkResponse](support.DefaultSessionWorkURL(baseURL, "/work"))
+}
+
+func readHostedStatus(baseURL string) (factoryapi.StatusResponse, error) {
+	return readHostedJSON[factoryapi.StatusResponse](strings.TrimSuffix(baseURL, "/") + "/status")
+}
+
+func readHostedJSON[T any](endpoint string) (T, error) {
+	var result T
+	response, err := http.Get(endpoint)
+	if err != nil {
+		return result, fmt.Errorf("GET %s: %w", endpoint, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		payload, _ := io.ReadAll(response.Body)
+		return result, fmt.Errorf(
+			"GET %s status = %d: %s",
+			endpoint,
+			response.StatusCode,
+			strings.TrimSpace(string(payload)),
+		)
+	}
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		return result, fmt.Errorf("decode GET %s: %w", endpoint, err)
+	}
+	return result, nil
+}
+
+func waitForSignal(t *testing.T, signal <-chan struct{}, message string) {
+	t.Helper()
+	timer := time.NewTimer(incompleteDrainProcessTimeout)
+	defer timer.Stop()
+	select {
+	case <-signal:
+	case <-timer.C:
+		t.Fatal(message)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "Deflake Sessions Execution Drain Classification",
  "branchName": "thr-deflake-sessions-execution-drain",
  "description": "Make TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal reliable in required CI while preserving the customer-visible invariant that a finite --with-server or --with-site run cannot report success when draining leaves Work nonterminal. Diagnose the drain-versus-state-observation race, replace timing assumptions with observable lifecycle gates and deterministic ordering, preserve successful and continuous-run behavior, and prove the result under plain, coverage, race, and Backend Functional Coverage execution.",
  "context": {
    "customerAsk": "Reproduce the intermittent sessions/execution drain failure under plain, race, and coverage stress; diagnose the race between server drain, nonterminal Work observation, and runtime shutdown; fix it structurally without fixed sleeps or a weaker assertion; and provide 20/20 plain and coverage evidence, a clean race run, a root-cause explanation, and passing Backend Functional Coverage.",
    "problem": "TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal, notably its site subtest, intermittently allows or observes successful finite drain completion while submitted Work remains nonterminal. Coverage instrumentation changes scheduling enough to expose the race, blocking unrelated PRs and potentially revealing a customer-visible false-success path. The relevant ordering among Work admission and projection, runtime quiescence, drain classification, transport cancellation, and listener join is not currently deterministic from the test's observations.",
    "solution": "Establish the exact ordering with focused stress and diagnostic evidence, then synchronize on explicit Work, runtime, transport, and command lifecycle observations. Ensure finite drain classification uses authoritative state and survives hosted-listener shutdown, with no fixed sleeps. Keep empty and terminal drains successful and continuous hosted runs live until cancellation. Limit the diff to tests/functional/sessions/execution unless the evidence proves a production drain defect, in which case make the smallest owner-aligned runtime correction and direct regression test."
  },
  "acceptanceCriteria": [
    "For both --with-server and --with-site, a finite hosted run with blocked nonterminal Work returns an incomplete-drain failure, emits no success/completion output, and joins its runtime and listener before returning.",
    "The regression and any runtime correction synchronize through observable Work, runtime, transport, or command lifecycle state; no fixed sleep or inflated timing budget is used, and the assertion that nonterminal drain cannot succeed is not weakened.",
    "Empty and terminal-work finite hosted runs still succeed, while continuous hosted runs remain active when idle and shut down correctly when canceled.",
    "Focused evidence quoted in the PR shows 20/20 passing plain iterations, 20/20 passing -cover iterations, a clean focused -race run, and passing neighboring drain regressions.",
    "The PR description explains the proven root cause and ordering correction, the PR's own Backend Functional Coverage job passes, CI evidence is recorded in PR comments rather than evidence-only commits, and prd.json and progress.txt never appear in the PR diff.",
    "Quality gate: typecheck, focused tests, and applicable lint checks complete with no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Delivery: the implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are resolved against current main, and the PR is actually merged; opening, approval, green CI, or merge readiness alone is not completion."
  ],
  "userStories": [
    {
      "id": "thr-deflake-sessions-execution-drain-001",
      "title": "Establish deterministic drain-state observation",
      "description": "As a maintainer, I want the regression scenario to observe the relevant Work, runtime, command, and listener lifecycle boundaries deterministically so the drain outcome is independent of scheduler speed and instrumentation overhead.",
      "acceptanceCriteria": [
        "The scenario proves that blocked Work is admitted and remains nonterminal before finite drain classification is accepted; it does not infer this state from elapsed time.",
        "Both server and site modes use observable edge or lifecycle signals to establish startup, drain, command completion, and listener join ordering, with a bounded timeout used only to fail a hung test.",
        "Repeated plain, coverage, and race runs provide diagnostics that distinguish premature success, missing nonterminal state, incomplete listener join, and browser-opening lifecycle errors.",
        "No fixed sleep, retry-by-delay, or enlarged success window is introduced, and the assertion that a nonterminal drain cannot succeed remains intact.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added public lifecycle ordering proof in tests/functional/sessions/execution/drain_test.go: the real hosted API is held behind an explicit shutdown gate, and the provider-command edge is released only from the transport OnBound callback. The test observes bound startup, admitted PROCESSING Work plus runtime status, transport cancellation, listener join, and command completion. Focused plain, full execution-package, focused race, 20x plain, and 20x -cover runs pass for server and site modes."
    },
    {
      "id": "thr-deflake-sessions-execution-drain-002",
      "title": "Make finite drain classification honor authoritative Work state",
      "description": "As a CLI user, I want a finite hosted run to report failure whenever drain completes with nonterminal Work so I am never told that incomplete processing succeeded.",
      "acceptanceCriteria": [
        "In both --with-server and --with-site modes, blocked nonterminal Work deterministically produces the existing safe incomplete-drain failure and no success/completion stdout.",
        "Drain classification occurs only after the authoritative runtime outcome and relevant Work state are observable, and Process.Execute does not return until the hosted listener has stopped and joined.",
        "Site mode opens the browser exactly once after binding, server mode does not open it, and neither lifecycle path can overwrite an incomplete-drain failure with listener cancellation or apparent success.",
        "Empty and terminal-work finite hosted runs continue to return success with one listener start and stop; continuous hosted runs do not receive the finite incomplete-drain classification while idle.",
        "If the root cause is production behavior, the fix is limited to the package that owns drain/runtime lifecycle state, keeps state explicit and side effects isolated, and includes direct lower-layer regression evidence; otherwise the change remains within tests/functional/sessions/execution.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Strengthened tests/functional/sessions/execution/drain_test.go to assert the hosted command fails at the public boundary, reports a safe diagnostic with no success output, and exposes exactly one non-terminal Work item for both server and site modes. Existing lifecycle assertions prove listener join, site-only browser open, finite empty/terminal success, and continuous idle liveness; no production correction was needed because runtime termination already supplies the authoritative classification. Service-specific typed error/count contracts remain covered by lower-layer runtime tests."
    },
    {
      "id": "thr-deflake-sessions-execution-drain-003",
      "title": "Prove stability under CI instrumentation and concurrency",
      "description": "As a reviewer, I want repeatable stress and CI evidence for the corrected drain behavior so an unrelated pull request is not blocked by the same flake cluster again.",
      "acceptanceCriteria": [
        "go test ./tests/functional/sessions/execution/ -run TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal -count=20 completes with 20/20 passing iterations.",
        "go test -cover ./tests/functional/sessions/execution/ -run TestWithServerDrainCannotReportSuccessWhileWorkIsNonTerminal -count=20 completes with 20/20 passing iterations.",
        "A focused -race run completes without a race report, and neighboring finite-success and continuous-host drain regressions pass.",
        "The PR description records the root cause and why the synchronization or ordering change closes it; exact local command results and cross-lane findings are posted as PR comments without evidence-only commits.",
        "The PR owns no changes under tests/functional/workers/mock or ACP inference functional packages, and convergent root-cause findings are coordinated through PR comments rather than shared diffs.",
        "The PR's own Backend Functional Coverage job is terminal and passing on the final implementation head.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Stability evidence completed on the corrected implementation: the focused blocked-drain regression passed 20/20 plain iterations and 20/20 -cover iterations; focused -race passed with blocked-drain, finite-success, and continuous-idle neighbors; the full execution package, focused go vet, functional-boundary-check, backend-size, and pkg-maint passed. The startup fix releases the gated Work transition from the real transport OnBound callback, while the diff remains limited to tests/functional/sessions/execution/drain_test.go with no workers/mock or ACP inference functional changes. PR #1903 is open for required CI on the new head."
    }
  ]
}
