### PR TITLE
Distinguish Agent-Run Provider Failures from Harness Failures

### DIFF
--- a/api/components/schemas/api/WorkerSessionFailure.yaml
+++ b/api/components/schemas/api/WorkerSessionFailure.yaml
@@ -3,6 +3,7 @@ additionalProperties: false
 required:
   - kind
   - detail
+  - agentRunFailureClass
   - providerFailureKind
   - providerContinuationFailureKind
   - providerContinuationOutcome
@@ -13,6 +14,10 @@ properties:
   detail:
     type: string
     description: Customer-safe failure detail derived by Worker Sessions.
+  agentRunFailureClass:
+    type: string
+    nullable: true
+    description: Optional bounded Workers-owned agent-run class distinguishing provider and harness failures.
   providerFailureKind:
     type: string
     nullable: true

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2901,6 +2901,7 @@ components:
       required:
         - kind
         - detail
+        - agentRunFailureClass
         - providerFailureKind
         - providerContinuationFailureKind
         - providerContinuationOutcome
@@ -2911,6 +2912,10 @@ components:
         detail:
           type: string
           description: Customer-safe failure detail derived by Worker Sessions.
+        agentRunFailureClass:
+          type: string
+          nullable: true
+          description: Optional bounded Workers-owned agent-run class distinguishing provider and harness failures.
         providerFailureKind:
           type: string
           nullable: true

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -211,7 +211,7 @@
       "path": "generated/mcp/tools.json"
     },
     "generated.openapi.openapi": {
-      "artifactHash": "582033f47e5ece067d0e78255f4f0542cb3dc23131c6e71f58fe03581b8fd29d",
+      "artifactHash": "13003b1c77f930edb130ed45aab726fc25618d3f348f07ec3fe29ab572c334fc",
       "documentation": {
         "documentation": {
           "description": {
@@ -228,7 +228,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.openapi.openapi",
-        "sourceHash": "582033f47e5ece067d0e78255f4f0542cb3dc23131c6e71f58fe03581b8fd29d",
+        "sourceHash": "13003b1c77f930edb130ed45aab726fc25618d3f348f07ec3fe29ab572c334fc",
         "visibility": "public"
       },
       "family": "openapi",

--- a/packages/api/generated/openapi/openapi.yaml
+++ b/packages/api/generated/openapi/openapi.yaml
@@ -2901,6 +2901,7 @@ components:
       required:
         - kind
         - detail
+        - agentRunFailureClass
         - providerFailureKind
         - providerContinuationFailureKind
         - providerContinuationOutcome
@@ -2911,6 +2912,10 @@ components:
         detail:
           type: string
           description: Customer-safe failure detail derived by Worker Sessions.
+        agentRunFailureClass:
+          type: string
+          nullable: true
+          description: Optional bounded Workers-owned agent-run class distinguishing provider and harness failures.
         providerFailureKind:
           type: string
           nullable: true

--- a/pkg/services/worker_sessions/internal/service/classify.go
+++ b/pkg/services/worker_sessions/internal/service/classify.go
@@ -84,6 +84,9 @@ func terminalForWorkResult(
 	workResult workers.WorkResult,
 ) workersessions.TerminalResult {
 	terminal := failedTerminal(kind, detail)
+	if terminal.Cause != nil {
+		terminal.Cause.AgentRunFailureClass = agentRunFailureClassFromWorkDiagnostics(workResult.Diagnostics)
+	}
 	terminal.Cause.ProviderFailureKind,
 		terminal.Cause.ProviderContinuationFailureKind,
 		terminal.Cause.ProviderContinuationOutcome = workersessions.SanitizeProviderFailureClassification(
@@ -471,12 +474,33 @@ func normalizeCommittedTerminal(state workersessions.State, result workersession
 			cause.ProviderContinuationFailureKind,
 			cause.ProviderContinuationOutcome,
 		)
+		cause.AgentRunFailureClass = sanitizeAgentRunFailureClass(cause.AgentRunFailureClass)
 		return workersessions.TerminalResult{
 			Outcome: workersessions.TerminalOutcomeFailed,
 			Cause:   &cause,
 		}
 	default:
 		return result
+	}
+}
+
+func agentRunFailureClassFromWorkDiagnostics(diagnostics *workers.WorkDiagnostics) string {
+	if diagnostics == nil {
+		return ""
+	}
+	diagnostic := workers.SafeAgentRunDiagnosticFromWorkDiagnostics(diagnostics)
+	if diagnostic == nil {
+		return ""
+	}
+	return sanitizeAgentRunFailureClass(diagnostic.FailureClass)
+}
+
+func sanitizeAgentRunFailureClass(class string) string {
+	switch class {
+	case workers.AgentRunFailureClassProvider, workers.AgentRunFailureClassHarness:
+		return class
+	default:
+		return ""
 	}
 }
 
@@ -514,9 +538,10 @@ func causeKindString(cause *workersessions.FailureCause) string {
 // W3 terminal record. Failure fields are additive and carry only the already
 // normalized Worker Sessions classification.
 type terminalSessionPayload struct {
-	Status        string `json:"status,omitempty"`
-	FailureCause  string `json:"failureCause,omitempty"`
-	FailureDetail string `json:"failureDetail,omitempty"`
+	Status               string `json:"status,omitempty"`
+	FailureCause         string `json:"failureCause,omitempty"`
+	FailureDetail        string `json:"failureDetail,omitempty"`
+	AgentRunFailureClass string `json:"agentRunFailureClass,omitempty"`
 }
 
 // terminalPhase is the pure mapping from a committed Worker Session State to
@@ -551,6 +576,7 @@ func terminalDraft(state workersessions.State, result workersessions.TerminalRes
 	if result.Cause != nil {
 		payload.FailureCause = string(result.Cause.Kind)
 		payload.FailureDetail = result.Cause.Detail
+		payload.AgentRunFailureClass = result.Cause.AgentRunFailureClass
 	}
 	payloadJSON, _ := json.Marshal(payload)
 	return workers.Draft{

--- a/pkg/services/worker_sessions/internal/service/internal_test.go
+++ b/pkg/services/worker_sessions/internal/service/internal_test.go
@@ -902,6 +902,45 @@ func TestClassifyTerminal_FailureMetadataPresentAlongsideSensitiveRawText_UsesOn
 	}
 }
 
+func TestClassifyTerminal_PreservesOnlyBoundedAgentRunProviderAndHarnessClasses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		class string
+		want  string
+	}{
+		{name: "provider", class: workers.AgentRunFailureClassProvider, want: workers.AgentRunFailureClassProvider},
+		{name: "harness", class: workers.AgentRunFailureClassHarness, want: workers.AgentRunFailureClassHarness},
+		{name: "unknown class", class: "agent_run_failure_with_secret", want: ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			terminal := classifyTerminal(nil, workers.WorkstationDispatchResult{Result: workers.WorkResult{
+				Outcome: workers.OutcomeFailed,
+				Diagnostics: &workers.WorkDiagnostics{Metadata: map[string]string{
+					workers.AgentRunMetadataExecutionBehavior: workers.AgentRunExecutionBehavior,
+					workers.AgentRunMetadataFailureClass:      test.class,
+				}},
+			}})
+			if terminal.Cause == nil {
+				t.Fatal("terminal cause = nil, want failed cause")
+			}
+			if terminal.Cause.Kind != workersessions.FailureCauseWorkersExecutionFailure {
+				t.Fatalf("terminal cause kind = %q, want generic Workers execution failure", terminal.Cause.Kind)
+			}
+			if terminal.Cause.AgentRunFailureClass != test.want {
+				t.Fatalf("agent-run failure class = %q, want %q", terminal.Cause.AgentRunFailureClass, test.want)
+			}
+			if err := terminal.Cause.Validate(); err != nil {
+				t.Fatalf("terminal cause validation = %v, want nil", err)
+			}
+		})
+	}
+}
+
 // TestClassifyTerminal_ExecutorPanicWithSensitiveRawEvidence_ClassifiesCorrectlyWithoutLeakingDetail
 // proves executor-panic classification still works from raw evidence text
 // (isExecutorPanicEvidence legitimately inspects it), while Detail itself

--- a/pkg/services/worker_sessions/terminal.go
+++ b/pkg/services/worker_sessions/terminal.go
@@ -7,6 +7,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/portpowered/infinite-you/pkg/services/providers"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
 )
 
 // TerminalOutcome is the exact two-value W2 vocabulary for a committed
@@ -93,6 +94,10 @@ func (k FailureCauseKind) Valid() bool {
 type FailureCause struct {
 	Kind   FailureCauseKind
 	Detail string
+	// AgentRunFailureClass preserves the bounded Workers-owned distinction
+	// between provider and harness failures when the failed attempt used an
+	// agent-run workstation. It is empty for other Worker Session failures.
+	AgentRunFailureClass string
 	// ProviderFailureKind carries the Providers-owned operational failure
 	// classification for a continuation attempt when one exists. It is empty
 	// for failures that did not reach a provider continuation.
@@ -124,6 +129,9 @@ func (c FailureCause) Validate() error {
 	if utf8.RuneCountInString(trimmed) > MaxFailureCauseDetailRunes {
 		return fmt.Errorf("%w: failure detail exceeds %d runes", ErrInvalidFailureCause, MaxFailureCauseDetailRunes)
 	}
+	if !validAgentRunFailureClass(c.AgentRunFailureClass) {
+		return fmt.Errorf("%w: invalid agent-run failure class", ErrInvalidFailureCause)
+	}
 	providerFailureKind, continuationFailureKind, continuationOutcome := SanitizeProviderFailureClassification(
 		c.ProviderFailureKind,
 		c.ProviderContinuationFailureKind,
@@ -135,6 +143,15 @@ func (c FailureCause) Validate() error {
 		return fmt.Errorf("%w: invalid provider continuation classification", ErrInvalidFailureCause)
 	}
 	return nil
+}
+
+func validAgentRunFailureClass(class string) bool {
+	switch class {
+	case "", workers.AgentRunFailureClassProvider, workers.AgentRunFailureClassHarness:
+		return true
+	default:
+		return false
+	}
 }
 
 // SanitizeProviderFailureClassification keeps only the closed

--- a/pkg/services/worker_sessions/terminal_test.go
+++ b/pkg/services/worker_sessions/terminal_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/portpowered/infinite-you/pkg/services/providers"
 	workersessions "github.com/portpowered/infinite-you/pkg/services/worker_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
 )
 
 func TestTerminalOutcome_Valid(t *testing.T) {
@@ -48,6 +49,38 @@ func TestFailureCause_Validate_RejectsUnknownKind(t *testing.T) {
 	}
 	if err := (workersessions.FailureCause{Kind: workersessions.FailureCauseExecutorPanic, Detail: "executor failed"}).Validate(); err != nil {
 		t.Errorf("Validate() = %v, want nil", err)
+	}
+}
+
+func TestFailureCause_Validate_AcceptsKnownAgentRunFailureClasses(t *testing.T) {
+	tests := []struct {
+		name  string
+		class string
+		want  error
+	}{
+		{name: "not an agent run", class: "", want: nil},
+		{name: "provider", class: workers.AgentRunFailureClassProvider, want: nil},
+		{name: "harness", class: workers.AgentRunFailureClassHarness, want: nil},
+		{name: "unknown", class: "agent_run_unknown_failure", want: workersessions.ErrInvalidFailureCause},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := (workersessions.FailureCause{
+				Kind:                 workersessions.FailureCauseWorkersExecutionFailure,
+				Detail:               "agent run failed",
+				AgentRunFailureClass: tt.class,
+			}).Validate()
+			if tt.want == nil {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("Validate() = %v, want %v", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/services/worker_sessions/transports/cli/list.go
+++ b/pkg/services/worker_sessions/transports/cli/list.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/portpowered/infinite-you/pkg/services/workers"
 	"github.com/portpowered/infinite-you/pkg/transports/cli/clidiag"
 	"github.com/portpowered/infinite-you/pkg/transports/cli/clihttp"
 	"github.com/portpowered/infinite-you/pkg/transports/cli/cliserver"
@@ -323,8 +324,12 @@ func renderList(output io.Writer, result factoryapi.ListWorkerSessionsResponse) 
 			state = "-"
 		}
 		failure := "-"
-		if session.Failure != nil && session.Failure.Kind != "" {
-			failure = session.Failure.Kind
+		if session.Failure != nil {
+			if class := safeAgentRunFailureClass(session.Failure.AgentRunFailureClass); class != nil {
+				failure = *class
+			} else if session.Failure.Kind != "" {
+				failure = session.Failure.Kind
+			}
 		}
 		if _, err := fmt.Fprintf(
 			output,
@@ -343,6 +348,26 @@ func renderList(output io.Writer, result factoryapi.ListWorkerSessionsResponse) 
 		}
 	}
 	return nil
+}
+
+func safeAgentRunFailureClass(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	class := safeAgentRunFailureClassValue(*value)
+	if class == "" {
+		return nil
+	}
+	return &class
+}
+
+func safeAgentRunFailureClassValue(class string) string {
+	switch class {
+	case workers.AgentRunFailureClassProvider, workers.AgentRunFailureClassHarness:
+		return class
+	default:
+		return ""
+	}
 }
 
 func formatTokens(usage *factoryapi.ProviderSessionTokenUsage) string {

--- a/pkg/services/worker_sessions/transports/cli/list_test.go
+++ b/pkg/services/worker_sessions/transports/cli/list_test.go
@@ -90,7 +90,15 @@ func TestListHumanRendersLabelsTokensDurationAndFailure(t *testing.T) {
 				ProviderSession:          &factoryapi.WorkerSessionProviderSessionRef{Provider: "codex", Kind: "session_id", Id: "provider-session-1"},
 				WorkIds:                  []string{"work-1"}, State: factoryapi.WorkerSessionObservationState("FAILED"),
 				DurationMillis: int64Ptr(2500), TokenUsage: &factoryapi.ProviderSessionTokenUsage{TotalTokens: intPtr(17)},
-				Failure: &factoryapi.WorkerSessionFailure{Kind: "WORKERS_EXECUTION_FAILURE", Detail: "safe detail"},
+				Failure: &factoryapi.WorkerSessionFailure{Kind: "WORKERS_EXECUTION_FAILURE", Detail: "safe detail", AgentRunFailureClass: stringPtrForTest("agent_run_provider_failure")},
+			},
+			{
+				WorkerSessionId: "worker-session-2", AttemptId: "attempt-2",
+				ProviderSessionAvailable: true,
+				ProviderSession:          &factoryapi.WorkerSessionProviderSessionRef{Provider: "codex", Kind: "session_id", Id: "provider-session-2"},
+				WorkIds:                  []string{"work-1"}, State: factoryapi.WorkerSessionObservationState("FAILED"),
+				DurationMillis: int64Ptr(2500), TokenUsage: &factoryapi.ProviderSessionTokenUsage{TotalTokens: intPtr(17)},
+				Failure: &factoryapi.WorkerSessionFailure{Kind: "WORKERS_EXECUTION_FAILURE", Detail: "safe detail", AgentRunFailureClass: stringPtrForTest("agent_run_harness_failure")},
 			},
 		}})
 	}))
@@ -105,7 +113,8 @@ func TestListHumanRendersLabelsTokensDurationAndFailure(t *testing.T) {
 	}
 	for _, want := range []string{
 		"PROVIDER\tKIND\tSESSION ID\tWORK ID\tATTEMPT\tSTATE\tTOKENS\tDURATION\tFAILURE",
-		"codex\tsession_id\tprovider-session-1\twork-1\tattempt-1\tFAILED\t17\t2.5s\tWORKERS_EXECUTION_FAILURE",
+		"codex\tsession_id\tprovider-session-1\twork-1\tattempt-1\tFAILED\t17\t2.5s\tagent_run_provider_failure",
+		"codex\tsession_id\tprovider-session-2\twork-1\tattempt-2\tFAILED\t17\t2.5s\tagent_run_harness_failure",
 	} {
 		if !strings.Contains(output.String(), want) {
 			t.Fatalf("output %q missing %q", output.String(), want)

--- a/pkg/services/worker_sessions/transports/cli/show.go
+++ b/pkg/services/worker_sessions/transports/cli/show.go
@@ -253,9 +253,9 @@ func writeFailure(output io.Writer, failure *factoryapi.WorkerSessionFailure) er
 		_, err := fmt.Fprintln(output, "Failure:\tunavailable")
 		return err
 	}
-	if _, err := fmt.Fprintf(output, "Failure:\tkind=%s detail=%s provider-kind=%s continuation-kind=%s continuation-outcome=%s\n",
+	if _, err := fmt.Fprintf(output, "Failure:\tkind=%s detail=%s provider-kind=%s continuation-kind=%s continuation-outcome=%s agent-run-class=%s\n",
 		stringOrDashPtr(failure.Kind), stringOrDashPtr(failure.Detail), stringOrDash(failure.ProviderFailureKind),
-		stringOrDash(failure.ProviderContinuationFailureKind), stringOrDash(failure.ProviderContinuationOutcome)); err != nil {
+		stringOrDash(failure.ProviderContinuationFailureKind), stringOrDash(failure.ProviderContinuationOutcome), stringOrDash(safeAgentRunFailureClass(failure.AgentRunFailureClass))); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/services/worker_sessions/transports/cli/show_test.go
+++ b/pkg/services/worker_sessions/transports/cli/show_test.go
@@ -77,7 +77,7 @@ func TestShowHumanRendersFailureAndParseDiagnostics(t *testing.T) {
 			DurationMillis: int64Ptr(2500), DurationBasis: generated.WorkerSessionObservationDurationBasisRECORDEDTIMESTAMPS,
 			Transcript: generated.WorkerSessionObservationTranscriptAVAILABLE,
 			TokenUsage: &generated.ProviderSessionTokenUsage{TotalTokens: intPtr(17)},
-			Failure:    &generated.WorkerSessionFailure{Kind: "WORKERS_EXECUTION_FAILURE", Detail: "safe failure detail", ProviderFailureKind: stringPtrForTest("dependency")},
+			Failure:    &generated.WorkerSessionFailure{Kind: "WORKERS_EXECUTION_FAILURE", Detail: "safe failure detail", ProviderFailureKind: stringPtrForTest("dependency"), AgentRunFailureClass: stringPtrForTest("agent_run_provider_failure")},
 			Parse:      generated.WorkerSessionParseDiagnostics{EventCount: 3, Errors: []generated.WorkerSessionParseDiagnostic{{Code: "provider_session_parse_error", LineNumber: 2, Message: "malformed event"}}},
 		})
 	}))
@@ -91,7 +91,7 @@ func TestShowHumanRendersFailureAndParseDiagnostics(t *testing.T) {
 	for _, want := range []string{
 		"Worker Session ID:\tworker-session-1", "Work IDs:\twork-1", "State:\tFAILED", "Duration:\t2.5s",
 		"Token usage:\tinput=- cached-input=- cache-write=- output=- reasoning=- total=17",
-		"Failure:\tkind=WORKERS_EXECUTION_FAILURE detail=safe failure detail provider-kind=dependency",
+		"Failure:\tkind=WORKERS_EXECUTION_FAILURE detail=safe failure detail provider-kind=dependency", "agent-run-class=agent_run_provider_failure",
 		"Parse diagnostics:\tevents=3 malformed=0 unknown=0 errors=1",
 		"Parse error 1:\tcode=provider_session_parse_error line=2 message=malformed event",
 	} {

--- a/pkg/services/worker_sessions/transports/http/handler_test.go
+++ b/pkg/services/worker_sessions/transports/http/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/providers"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	workersessions "github.com/portpowered/infinite-you/pkg/services/worker_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"go.uber.org/zap"
 )
@@ -190,7 +191,8 @@ func TestGetWorkerSessionObservationBySessionIDProjectsFailureDiagnostics(t *tes
 	duration := int64(2500)
 	failure := &workersessions.FailureCause{
 		Kind: workersessions.FailureCauseWorkersExecutionFailure, Detail: "provider exited with status 1",
-		ProviderFailureKind: providers.ExecuteFailureKindDependency,
+		AgentRunFailureClass: workers.AgentRunFailureClassProvider,
+		ProviderFailureKind:  providers.ExecuteFailureKindDependency,
 	}
 	service := &fakeObservationService{getResult: workersessions.Observation{
 		WorkerSessionID:          "worker-session-1",
@@ -239,7 +241,8 @@ func assertFailureObservationIdentity(t *testing.T, response factoryapi.WorkerSe
 
 func assertFailureObservationCause(t *testing.T, response factoryapi.WorkerSessionObservation) {
 	t.Helper()
-	if response.Failure == nil || response.Failure.Detail != "provider exited with status 1" || response.Failure.ProviderFailureKind == nil {
+	if response.Failure == nil || response.Failure.Detail != "provider exited with status 1" || response.Failure.ProviderFailureKind == nil ||
+		response.Failure.AgentRunFailureClass == nil || *response.Failure.AgentRunFailureClass != workers.AgentRunFailureClassProvider {
 		t.Fatalf("failure = %#v, want structured failure diagnostics", response.Failure)
 	}
 }

--- a/pkg/services/worker_sessions/transports/http/mapping.go
+++ b/pkg/services/worker_sessions/transports/http/mapping.go
@@ -335,12 +335,22 @@ func WorkerSessionObservationToAPI(observation workersessions.Observation) facto
 		result.Failure = &factoryapi.WorkerSessionFailure{
 			Kind:                            string(observation.Failure.Kind),
 			Detail:                          observation.Failure.Detail,
+			AgentRunFailureClass:            stringPtrIfNonEmpty(safeAgentRunFailureClass(observation.Failure.AgentRunFailureClass)),
 			ProviderFailureKind:             stringPtrIfNonEmpty(string(observation.Failure.ProviderFailureKind)),
 			ProviderContinuationFailureKind: stringPtrIfNonEmpty(string(observation.Failure.ProviderContinuationFailureKind)),
 			ProviderContinuationOutcome:     stringPtrIfNonEmpty(string(observation.Failure.ProviderContinuationOutcome)),
 		}
 	}
 	return result
+}
+
+func safeAgentRunFailureClass(class string) string {
+	switch class {
+	case workers.AgentRunFailureClassProvider, workers.AgentRunFailureClassHarness:
+		return class
+	default:
+		return ""
+	}
 }
 
 func workerSessionParseDiagnosticsToAPI(value workersessions.ParseDiagnostics) factoryapi.WorkerSessionParseDiagnostics {

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/executor_test.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/executor_test.go
@@ -267,6 +267,55 @@ func TestAgentRunExecutor_HarnessFailureSurfacesAgentRunFailureClass(t *testing.
 	}
 }
 
+func TestAgentRunExecutor_ProviderFailureSurfacesProviderClassAndSafeType(t *testing.T) {
+	t.Parallel()
+
+	rawProviderPayload := "provider response contained a secret payload"
+	providerErr := workerexecution.NewProviderError(
+		workerexecution.WorkFailureTypeInternalServerError,
+		"temporary provider failure",
+		errors.New(rawProviderPayload),
+	)
+	harness := &recordingHarnessAdapter{err: providerErr}
+	executor := NewAgentRunExecutorWithDependencies(
+		staticRuntimeConfig{
+			Workers: map[string]*interfaces.FactoryWorkerConfig{
+				"agent-worker": {Type: interfaces.WorkerTypeAgent},
+			},
+		},
+		&stubRunner{}, nil,
+
+		harness, nil, time.Now)
+
+	result, err := executor.Execute(context.Background(), testAgentRunRequest())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.Outcome != workerexecution.OutcomeFailed {
+		t.Fatalf("Outcome = %s, want %s", result.Outcome, workerexecution.OutcomeFailed)
+	}
+	if result.Diagnostics == nil {
+		t.Fatal("Diagnostics = nil, want provider failure diagnostics")
+	}
+	if got := result.Diagnostics.Metadata[DiagnosticFailureClass]; got != FailureClassProvider {
+		t.Fatalf("failure class = %q, want %q", got, FailureClassProvider)
+	}
+	if got := result.Diagnostics.Metadata[DiagnosticProviderFailureType]; got != string(workerexecution.WorkFailureTypeInternalServerError) {
+		t.Fatalf("provider failure type = %q, want %q", got, workerexecution.WorkFailureTypeInternalServerError)
+	}
+	if !strings.HasPrefix(result.Error, "agent run provider failure:") ||
+		!strings.Contains(result.Error, string(workerexecution.WorkFailureTypeInternalServerError)) {
+		t.Fatalf("Error = %q, want safe provider failure wording", result.Error)
+	}
+	if strings.Contains(result.Error, rawProviderPayload) || strings.Contains(result.Error, "agent run harness failure:") {
+		t.Fatalf("Error = %q, leaked provider payload or harness wording", result.Error)
+	}
+	if result.FailureMetadata == nil || result.FailureMetadata.Family != workerexecution.WorkFailureFamilyRetryable ||
+		result.FailureMetadata.Type != workerexecution.WorkFailureTypeInternalServerError {
+		t.Fatalf("FailureMetadata = %#v, want retryable internal server error", result.FailureMetadata)
+	}
+}
+
 func TestAgentRunExecutor_ModelhostLeaseDeniedSurfacesAgentRunLeaseFailureClass(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/executor_test.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/executor_test.go
@@ -303,6 +303,9 @@ func TestAgentRunExecutor_ProviderFailureSurfacesProviderClassAndSafeType(t *tes
 	if got := result.Diagnostics.Metadata[DiagnosticProviderFailureType]; got != string(workerexecution.WorkFailureTypeInternalServerError) {
 		t.Fatalf("provider failure type = %q, want %q", got, workerexecution.WorkFailureTypeInternalServerError)
 	}
+	if got := result.Diagnostics.Metadata[DiagnosticRecoveryAction]; got != "retry the agent run after the provider recovers" {
+		t.Fatalf("provider recovery action = %q, want retry guidance", got)
+	}
 	if !strings.HasPrefix(result.Error, "agent run provider failure:") ||
 		!strings.Contains(result.Error, string(workerexecution.WorkFailureTypeInternalServerError)) {
 		t.Fatalf("Error = %q, want safe provider failure wording", result.Error)

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/failure.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/failure.go
@@ -18,8 +18,8 @@ const (
 	DiagnosticProviderFailureType = "provider_failure_type"
 	DiagnosticRecoveryAction      = "recovery_action"
 
-	FailureClassProvider       = "agent_run_provider_failure"
-	FailureClassHarnessRuntime = "agent_run_harness_failure"
+	FailureClassProvider       = workerexecution.AgentRunFailureClassProvider
+	FailureClassHarnessRuntime = workerexecution.AgentRunFailureClassHarness
 	FailureClassCanceled       = "agent_run_canceled"
 	FailureClassTimeout        = "agent_run_timeout"
 	FailureClassLeaseDenied    = "agent_run_lease_denied"

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/failure.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/failure.go
@@ -178,6 +178,9 @@ func safeProviderFailureSummary(providerErr *workerexecution.ProviderError) stri
 }
 
 func recoveryActionForError(err error) string {
+	if providerErr := normalizedProviderErrorForAgentRun(err); providerErr != nil {
+		return recoveryActionForProviderFailure(providerErr)
+	}
 	if errors.Is(err, models.ErrHostCapacityExhausted) {
 		return "retry later or increase managed runtime resource capacity"
 	}
@@ -192,6 +195,21 @@ func recoveryActionForError(err error) string {
 		return "resolve the managed runtime failure before retrying the agent run"
 	}
 	return ""
+}
+
+func recoveryActionForProviderFailure(providerErr *workerexecution.ProviderError) string {
+	metadata := workerexecution.WorkFailureMetadataFromProviderError(providerErr)
+	if metadata == nil {
+		return ""
+	}
+	switch metadata.Family {
+	case workerexecution.WorkFailureFamilyRetryable:
+		return "retry the agent run after the provider recovers"
+	case workerexecution.WorkFailureFamilyThrottle:
+		return "retry after provider capacity or rate limiting recovers"
+	default:
+		return ""
+	}
 }
 
 func recoveryActionForReadiness(readiness models.ReadinessState) string {

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/failure.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/failure.go
@@ -14,9 +14,11 @@ const (
 	DiagnosticExecutionBehavior = "execution_behavior"
 	ExecutionBehaviorAgentRun   = "agent_run"
 
-	DiagnosticFailureClass   = "failure_class"
-	DiagnosticRecoveryAction = "recovery_action"
+	DiagnosticFailureClass        = "failure_class"
+	DiagnosticProviderFailureType = "provider_failure_type"
+	DiagnosticRecoveryAction      = "recovery_action"
 
+	FailureClassProvider       = "agent_run_provider_failure"
 	FailureClassHarnessRuntime = "agent_run_harness_failure"
 	FailureClassCanceled       = "agent_run_canceled"
 	FailureClassTimeout        = "agent_run_timeout"
@@ -27,6 +29,8 @@ const (
 	FailureClassToolPolicy     = "agent_run_tool_policy_violation"
 	FailureClassToolRuntime    = "agent_run_tool_failure"
 )
+
+const maxAgentRunProviderFailureTypeLength = 64
 
 func agentRunDiagnostics(extra map[string]string) *workerexecution.WorkDiagnostics {
 	metadata := map[string]string{
@@ -50,6 +54,9 @@ func failureClassForError(err error) string {
 	}
 	if class, ok := modelhostFailureClass(err); ok {
 		return class
+	}
+	if normalizedProviderErrorForAgentRun(err) != nil {
+		return FailureClassProvider
 	}
 	if errors.Is(err, context.Canceled) {
 		return FailureClassCanceled
@@ -104,19 +111,70 @@ func formatAgentRunError(err error) string {
 		return "agent run tool policy violation: " + safeToolPolicyFailureSummary(err)
 	case FailureClassToolRuntime:
 		return "agent run tool failure: " + safeToolRuntimeFailureSummary(err)
+	case FailureClassProvider:
+		return "agent run provider failure: " + safeProviderFailureSummary(normalizedProviderErrorForAgentRun(err))
 	default:
 		return "agent run harness failure: " + err.Error()
 	}
 }
 
 func agentRunFailureDiagnostics(err error) map[string]string {
+	class := failureClassForError(err)
 	diagnostics := map[string]string{
-		DiagnosticFailureClass: failureClassForError(err),
+		DiagnosticFailureClass: class,
+	}
+	if class == FailureClassProvider {
+		if providerErr := normalizedProviderErrorForAgentRun(err); providerErr != nil {
+			diagnostics[DiagnosticProviderFailureType] = string(safeProviderFailureType(providerErr))
+		}
 	}
 	if action := recoveryActionForError(err); action != "" {
 		diagnostics[DiagnosticRecoveryAction] = action
 	}
 	return diagnostics
+}
+
+func normalizedProviderErrorForAgentRun(err error) *workerexecution.ProviderError {
+	if err == nil {
+		return nil
+	}
+	var providerErr *workerexecution.ProviderError
+	if errors.As(err, &providerErr) && providerErr != nil {
+		return providerErr
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil
+	}
+	return workerexecution.NormalizeProviderExecutionError(err)
+}
+
+func safeProviderFailureType(providerErr *workerexecution.ProviderError) workerexecution.WorkFailureType {
+	if providerErr == nil {
+		return workerexecution.WorkFailureTypeUnknown
+	}
+	typ := providerErr.Type
+	if len([]rune(string(typ))) > maxAgentRunProviderFailureTypeLength {
+		return workerexecution.WorkFailureTypeUnknown
+	}
+	switch typ {
+	case workerexecution.WorkFailureTypeAuthFailure,
+		workerexecution.WorkFailureTypePermanentBadRequest,
+		workerexecution.WorkFailureTypeThrottled,
+		workerexecution.WorkFailureTypeInternalServerError,
+		workerexecution.WorkFailureTypeTimeout,
+		workerexecution.WorkFailureTypeUnknown,
+		workerexecution.WorkFailureTypeMisconfigured,
+		workerexecution.WorkFailureTypeCommandLineTooLong,
+		workerexecution.WorkFailureTypeMissingExecutable,
+		workerexecution.WorkFailureTypeStructuredOutputSchemaViolation:
+		return typ
+	default:
+		return workerexecution.WorkFailureTypeUnknown
+	}
+}
+
+func safeProviderFailureSummary(providerErr *workerexecution.ProviderError) string {
+	return "provider error: " + string(safeProviderFailureType(providerErr))
 }
 
 func recoveryActionForError(err error) string {

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/failure_test.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/failure_test.go
@@ -132,6 +132,78 @@ func TestFailureMetadataForError_PreservesRetryableProviderFailure(t *testing.T)
 	}
 }
 
+func TestAgentRunProviderFailureRecoveryUsesCanonicalFamily(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		failureType   workerexecution.WorkFailureType
+		wantFamily    workerexecution.WorkFailureFamily
+		wantRetryable bool
+		wantRecovery  string
+	}{
+		{
+			name:          "dependency or overload normalized as internal server error",
+			failureType:   workerexecution.WorkFailureTypeInternalServerError,
+			wantFamily:    workerexecution.WorkFailureFamilyRetryable,
+			wantRetryable: true,
+			wantRecovery:  "retry the agent run after the provider recovers",
+		},
+		{
+			name:          "provider timeout",
+			failureType:   workerexecution.WorkFailureTypeTimeout,
+			wantFamily:    workerexecution.WorkFailureFamilyRetryable,
+			wantRetryable: true,
+			wantRecovery:  "retry the agent run after the provider recovers",
+		},
+		{
+			name:          "rate limited provider",
+			failureType:   workerexecution.WorkFailureTypeThrottled,
+			wantFamily:    workerexecution.WorkFailureFamilyThrottle,
+			wantRetryable: true,
+			wantRecovery:  "retry after provider capacity or rate limiting recovers",
+		},
+		{
+			name:        "authentication failure",
+			failureType: workerexecution.WorkFailureTypeAuthFailure,
+			wantFamily:  workerexecution.WorkFailureFamilyTerminal,
+		},
+		{
+			name:        "permanent invalid request",
+			failureType: workerexecution.WorkFailureTypePermanentBadRequest,
+			wantFamily:  workerexecution.WorkFailureFamilyTerminal,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := workerexecution.NewProviderError(
+				test.failureType,
+				"normalized provider failure",
+				errors.New("provider payload must not become recovery guidance"),
+			)
+			metadata := failureMetadataForError(err)
+			if metadata == nil || metadata.Family != test.wantFamily || metadata.Type != test.failureType {
+				t.Fatalf("failure metadata = %#v, want family %q and type %q", metadata, test.wantFamily, test.failureType)
+			}
+			decision := workerexecution.FailureDecisionFromMetadata(metadata)
+			if decision.Retryable != test.wantRetryable || decision.Terminal != !test.wantRetryable {
+				t.Fatalf("failure decision = %#v, want retryable=%t and terminal=%t", decision, test.wantRetryable, !test.wantRetryable)
+			}
+
+			diagnostics := agentRunFailureDiagnostics(err)
+			if got := diagnostics[DiagnosticRecoveryAction]; got != test.wantRecovery {
+				t.Fatalf("recovery action = %q, want %q", got, test.wantRecovery)
+			}
+			if test.wantRecovery == "" && strings.Contains(diagnostics[DiagnosticRecoveryAction], "retry") {
+				t.Fatalf("terminal provider failure received retry guidance: %q", diagnostics[DiagnosticRecoveryAction])
+			}
+		})
+	}
+}
+
 func TestAgentRunFailureDiagnostics_ProviderFailurePreservesSafeType(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/failure_test.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/failure_test.go
@@ -1,6 +1,7 @@
 package agentrun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -128,6 +129,42 @@ func TestFailureMetadataForError_PreservesRetryableProviderFailure(t *testing.T)
 	if metadata == nil || metadata.Family != workerexecution.WorkFailureFamilyRetryable ||
 		metadata.Type != workerexecution.WorkFailureTypeInternalServerError {
 		t.Fatalf("metadata = %#v, want retryable internal server error", metadata)
+	}
+}
+
+func TestAgentRunFailureDiagnostics_ProviderFailurePreservesSafeType(t *testing.T) {
+	t.Parallel()
+
+	rawProviderPayload := "provider response contained a secret payload"
+	err := workerexecution.NewProviderError(
+		workerexecution.WorkFailureTypeInternalServerError,
+		"temporary provider failure",
+		errors.New(rawProviderPayload),
+	)
+	diagnostics := agentRunFailureDiagnostics(err)
+	if diagnostics[DiagnosticFailureClass] != FailureClassProvider {
+		t.Fatalf("failure class = %q, want %q", diagnostics[DiagnosticFailureClass], FailureClassProvider)
+	}
+	if diagnostics[DiagnosticProviderFailureType] != string(workerexecution.WorkFailureTypeInternalServerError) {
+		t.Fatalf("provider failure type = %q, want %q", diagnostics[DiagnosticProviderFailureType], workerexecution.WorkFailureTypeInternalServerError)
+	}
+	formatted := formatAgentRunError(err)
+	if !strings.HasPrefix(formatted, "agent run provider failure:") {
+		t.Fatalf("formatAgentRunError() = %q, want provider prefix", formatted)
+	}
+	if !strings.Contains(formatted, string(workerexecution.WorkFailureTypeInternalServerError)) {
+		t.Fatalf("formatAgentRunError() = %q, want normalized provider type", formatted)
+	}
+	if strings.Contains(formatted, rawProviderPayload) {
+		t.Fatalf("formatAgentRunError() leaked raw provider payload: %q", formatted)
+	}
+}
+
+func TestFailureClassForError_RawDeadlineRemainsAgentRunTimeout(t *testing.T) {
+	t.Parallel()
+
+	if got := failureClassForError(context.DeadlineExceeded); got != FailureClassTimeout {
+		t.Fatalf("failureClassForError() = %q, want %q", got, FailureClassTimeout)
 	}
 }
 

--- a/pkg/services/workers/safe_diagnostics.go
+++ b/pkg/services/workers/safe_diagnostics.go
@@ -25,6 +25,13 @@ type SafeProviderDiagnostic struct {
 const (
 	AgentRunExecutionBehavior = "agent_run"
 
+	// AgentRunFailureClassProvider identifies an agent run that failed while
+	// executing a normalized provider request.
+	AgentRunFailureClassProvider = "agent_run_provider_failure"
+	// AgentRunFailureClassHarness identifies an agent run that failed in the
+	// harness rather than in a normalized provider request.
+	AgentRunFailureClassHarness = "agent_run_harness_failure"
+
 	AgentRunMetadataExecutionBehavior = "execution_behavior"
 	AgentRunMetadataFailureClass      = "failure_class"
 	AgentRunMetadataRecoveryAction    = "recovery_action"

--- a/pkg/transports/http/client/client.gen.go
+++ b/pkg/transports/http/client/client.gen.go
@@ -7479,6 +7479,9 @@ type WorkerSessionExecutionMetadata struct {
 
 // WorkerSessionFailure defines model for WorkerSessionFailure.
 type WorkerSessionFailure struct {
+	// AgentRunFailureClass Optional bounded Workers-owned agent-run class distinguishing provider and harness failures.
+	AgentRunFailureClass *string `json:"agentRunFailureClass"`
+
 	// Detail Customer-safe failure detail derived by Worker Sessions.
 	Detail string `json:"detail"`
 

--- a/pkg/transports/http/generated/server.gen.go
+++ b/pkg/transports/http/generated/server.gen.go
@@ -7481,6 +7481,9 @@ type WorkerSessionExecutionMetadata struct {
 
 // WorkerSessionFailure defines model for WorkerSessionFailure.
 type WorkerSessionFailure struct {
+	// AgentRunFailureClass Optional bounded Workers-owned agent-run class distinguishing provider and harness failures.
+	AgentRunFailureClass *string `json:"agentRunFailureClass"`
+
 	// Detail Customer-safe failure detail derived by Worker Sessions.
 	Detail string `json:"detail"`
 

--- a/ui/packages/client/src/generated/openapi.ts
+++ b/ui/packages/client/src/generated/openapi.ts
@@ -1362,6 +1362,8 @@ export interface components {
       kind: string;
       /** @description Customer-safe failure detail derived by Worker Sessions. */
       detail: string;
+      /** @description Optional bounded Workers-owned agent-run class distinguishing provider and harness failures. */
+      agentRunFailureClass: string | null;
       /** @description Optional bounded Providers failure classification. */
       providerFailureKind: string | null;
       /** @description Optional bounded continuation rejection classification. */

--- a/ui/src/api/generated/openapi.ts
+++ b/ui/src/api/generated/openapi.ts
@@ -1356,6 +1356,8 @@ export interface components {
       kind: string;
       /** @description Customer-safe failure detail derived by Worker Sessions. */
       detail: string;
+      /** @description Optional bounded Workers-owned agent-run class distinguishing provider and harness failures. */
+      agentRunFailureClass: string | null;
       /** @description Optional bounded Providers failure classification. */
       providerFailureKind: string | null;
       /** @description Optional bounded continuation rejection classification. */


### PR DESCRIPTION
{
  "project": "Distinguish Agent-Run Provider Failures from Harness Failures",
  "branchName": "harness-provider-error-failure-class",
  "description": "Classify normalized provider execution errors with a dedicated agent-run provider failure class, preserve their normalized type and retry/throttle/terminal family, render safe provider-specific wording and recovery guidance, retain the genuine harness fallback, and expose the distinction in Worker Session operator output.",
  "context": {
    "customerAsk": "Classify provider-side agent-run failures as provider failures rather than harness failures; retain the normalized provider error type; render provider-specific wording; preserve retryable, throttle, and terminal families; provide appropriate recovery guidance; and make provider failures distinguishable from harness failures in you worker-sessions list.",
    "problem": "The agent-run path already derives correct WorkFailureMetadata from normalized provider errors, but its diagnostic classifier has no provider branch. Provider failures therefore fall through to agent_run_harness_failure and receive the agent run harness failure prefix, which obscures transient provider incidents and misdirects operator triage.",
    "solution": "Use the existing Workers-owned provider normalization before the harness fallback, emit agent_run_provider_failure plus bounded normalized provider-type metadata, format a safe agent run provider failure message, derive recovery guidance from the existing failure family, preserve genuine harness classification, and project the classified distinction to Worker Session CLI output without changing provider adapters or transitioner/breaker policy."
  },
  "acceptanceCriteria": [
    "A normalized provider internal_server_error produces diagnostic class agent_run_provider_failure, retains type internal_server_error, uses the retryable Work failure family, and renders a message beginning agent run provider failure:.",
    "A normalized rate-limited or throttled provider error uses the throttle family, while authentication and permanent-invalid-request provider errors remain terminal.",
    "Retryable and throttled provider failures receive retry-oriented recovery guidance, while terminal provider failures do not receive misleading retry guidance.",
    "A genuine non-provider agent-run harness error still produces agent_run_harness_failure and agent run harness failure: wording.",
    "The you worker-sessions list FAILURE presentation distinguishes provider failures from harness failures using customer-safe classified data.",
    "Typecheck and focused tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file churn are resolved against current main, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "harness-provider-error-failure-class-001",
      "title": "Identify and describe provider failures accurately",
      "description": "As an operator, I want an agent run that fails because of its provider to carry a provider-specific class, normalized type, and message so that I do not investigate it as a harness defect.",
      "acceptanceCriteria": [
        "A synthetic normalized internal_server_error driven through the agent-run failure path produces failure_class=agent_run_provider_failure, not agent_run_harness_failure.",
        "Provider diagnostic metadata carries the normalized type internal_server_error in a bounded stable field adjacent to the diagnostic failure class.",
        "The recorded error begins agent run provider failure: and identifies the normalized provider error without exposing raw provider payloads.",
        "Provider classification takes precedence over the generic harness fallback while preserving existing tool, model-host, cancellation, and deadline classifications.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added agent_run_provider_failure classification, bounded provider_failure_type diagnostics, safe provider-prefixed wording, and executor coverage while preserving raw cancellation/deadline and existing tool/model-host precedence. Focused agent-run and Workers tests pass."
    },
    {
      "id": "harness-provider-error-failure-class-002",
      "title": "Preserve provider retry, throttle, and terminal behavior",
      "description": "As a factory operator, I want provider failures to retain the correct behavioral family and recovery guidance so that transient outages can recover while permanent configuration or request failures stop safely.",
      "acceptanceCriteria": [
        "Normalized internal_server_error, overload or dependency, and timeout provider failures use the retryable family and include retry-oriented recovery guidance.",
        "A normalized rate-limited or throttled provider failure uses the throttle family and includes guidance to retry after provider capacity or rate limiting recovers.",
        "Normalized authentication and permanent-invalid-request provider failures remain terminal and do not receive misleading retry guidance.",
        "Family and type come from the existing Workers provider normalization contract; agent-run does not create a competing provider taxonomy or alter transitioner or breaker counting.",
        "Table-driven behavioral coverage proves representative retryable, throttle, and terminal provider cases.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Derived agent-run recovery guidance from the canonical Workers provider failure family: retryable internal_server_error/timeout failures receive retry guidance, throttled failures receive capacity/rate-limit guidance, and terminal authentication/permanent-invalid-request failures receive no misleading retry guidance. Added table-driven coverage; focused agent-run, Workers, and runner normalization tests pass."
    },
    {
      "id": "harness-provider-error-failure-class-003",
      "title": "Preserve the harness fallback and expose the distinction to operators",
      "description": "As an operator inspecting Worker Sessions, I want provider and harness failures to be distinguishable in session diagnostics and CLI output so that triage starts with the correct subsystem.",
      "acceptanceCriteria": [
        "A genuine harness error such as malformed transcript handling that is not a normalized provider error still records agent_run_harness_failure and a message beginning agent run harness failure:.",
        "An executor-level regression test drives a synthetic provider internal_server_error through the failed Work result and verifies the provider class, provider-prefixed message, normalized type, retryable family, and recovery action together.",
        "Worker Session projection preserves customer-safe classified data needed to distinguish provider and harness failures without exposing raw provider output or credentials.",
        "you worker-sessions list renders distinguishable FAILURE values for otherwise comparable provider-failure and harness-failure records, with focused CLI behavioral coverage for both rows.",
        "Any narrowly required projection adjustment remains an adapter of Workers-owned classification and introduces no retry, transition, or breaker policy.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Preserved the bounded Workers-owned agent-run provider/harness class through Worker Session terminal state, terminal records, HTTP projection, and CLI output; unknown class values are dropped at the projection boundaries. Added service, HTTP, show, and list coverage for provider and harness rows, and regenerated API/package/UI contracts. Focused Go tests and UI typecheck pass."
    }
  ]
}
