### PR TITLE
engine-review-rejection-classification

### DIFF
--- a/pkg/services/factory_definitions/internal/services/invocation_policy/decisionenvelope/service.go
+++ b/pkg/services/factory_definitions/internal/services/invocation_policy/decisionenvelope/service.go
@@ -209,6 +209,28 @@ func FailedWorkResultFromDecisionEnvelopeError(
 		Outcome:      MalformedEnvelopeFailureOutcome,
 		Error:        message,
 		Feedback:     partial.Feedback,
+		FailureMetadata: &workerexecution.WorkFailureMetadata{
+			Family: workerexecution.WorkFailureFamilyTerminal,
+			Type:   workerexecution.WorkFailureTypeUnknown,
+		},
+		Diagnostics: decisionEnvelopeCompletionValidationDiagnostics(),
+	}
+}
+
+// decisionEnvelopeCompletionValidationDiagnostics records that a cleanly
+// readable worker response did not satisfy the required decision payload.
+// The raw response and parser error remain on the transient WorkResult only;
+// Worker Sessions uses these bounded facts for its public classification.
+func decisionEnvelopeCompletionValidationDiagnostics() *workerexecution.WorkDiagnostics {
+	return &workerexecution.WorkDiagnostics{
+		Provider: &workerexecution.ProviderDiagnostic{
+			ResponseMetadata: map[string]string{
+				workerexecution.ProviderResponseMetadataFailureFamily:         string(workerexecution.WorkFailureFamilyTerminal),
+				workerexecution.ProviderResponseMetadataFailureType:           string(workerexecution.WorkFailureTypeUnknown),
+				workerexecution.ProviderResponseMetadataFailureOperation:      "completion_validation",
+				workerexecution.ProviderResponseMetadataFailureClassification: "missing_required_output",
+			},
+		},
 	}
 }
 

--- a/pkg/services/factory_definitions/internal/services/invocation_policy/wire/wire_test.go
+++ b/pkg/services/factory_definitions/internal/services/invocation_policy/wire/wire_test.go
@@ -77,6 +77,26 @@ func TestNewService_DecisionEnvelopeContractThroughNestedOwner(t *testing.T) {
 	if result.Feedback != "Ship it." {
 		t.Fatalf("WorkResultFromDecisionEnvelopeJSONOrFailed() feedback = %q, want %q", result.Feedback, "Ship it.")
 	}
+
+	malformed := decisionEnvelopes.WorkResultFromDecisionEnvelopeJSONOrFailed(
+		"dispatch-incomplete",
+		"transition-incomplete",
+		"<COMPLETE>",
+	)
+	if malformed.Outcome != workerexecution.OutcomeFailed {
+		t.Fatalf("incomplete envelope outcome = %q, want FAILED", malformed.Outcome)
+	}
+	if malformed.FailureMetadata == nil || malformed.FailureMetadata.Type != workerexecution.WorkFailureTypeUnknown {
+		t.Fatalf("incomplete envelope failure metadata = %#v, want terminal unknown", malformed.FailureMetadata)
+	}
+	if malformed.Diagnostics == nil || malformed.Diagnostics.Provider == nil {
+		t.Fatalf("incomplete envelope diagnostics = %#v, want structured completion diagnostics", malformed.Diagnostics)
+	}
+	metadata := malformed.Diagnostics.Provider.ResponseMetadata
+	if metadata[workerexecution.ProviderResponseMetadataFailureOperation] != "completion_validation" ||
+		metadata[workerexecution.ProviderResponseMetadataFailureClassification] != "missing_required_output" {
+		t.Fatalf("incomplete envelope diagnostics = %#v, want bounded completion-validation facts", metadata)
+	}
 }
 
 func TestNewService_GoalRoutingDecisionEnvelopeThroughNestedOwner(t *testing.T) {

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_result_hook.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_result_hook.go
@@ -494,14 +494,21 @@ func recordedObservationState(outcome string) workersessions.State {
 	}
 }
 
-func recordedFailure(detail *workers.FailureDetail, metadata *workers.WorkFailureMetadata, state workersessions.State) *workersessions.FailureCause {
+func recordedFailure(outcome workers.WorkOutcome, detail *workers.FailureDetail, metadata *workers.WorkFailureMetadata, state workersessions.State) *workersessions.FailureCause {
 	if !state.Terminal() || state == workersessions.StateCompleted {
 		return nil
 	}
-	return &workersessions.FailureCause{Kind: workersessions.FailureCauseWorkersExecutionFailure, Detail: recordedFailureDetail(detail, metadata), ProviderFailureKind: recordedProviderFailureKind(detail)}
+	kind := workersessions.FailureCauseWorkersExecutionFailure
+	if outcome == workers.OutcomeRejected {
+		kind = workersessions.FailureCauseRejected
+	}
+	return &workersessions.FailureCause{Kind: kind, Detail: recordedFailureDetail(kind, detail, metadata), ProviderFailureKind: recordedProviderFailureKind(detail)}
 }
 
-func recordedFailureDetail(detail *workers.FailureDetail, metadata *workers.WorkFailureMetadata) string {
+func recordedFailureDetail(kind workersessions.FailureCauseKind, detail *workers.FailureDetail, metadata *workers.WorkFailureMetadata) string {
+	if kind == workersessions.FailureCauseRejected {
+		return "the Workers result was rejected by the business review"
+	}
 	if metadata != nil {
 		family, familyKnown := recordedFailureFamily(metadata.Family)
 		typ, typeKnown := recordedFailureType(metadata.Type)

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_result_hook.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_result_hook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -495,19 +496,50 @@ func recordedObservationState(outcome string) workersessions.State {
 }
 
 func recordedFailure(outcome workers.WorkOutcome, detail *workers.FailureDetail, metadata *workers.WorkFailureMetadata, state workersessions.State) *workersessions.FailureCause {
+	return recordedFailureWithDiagnostics(outcome, detail, metadata, state, nil)
+}
+
+func recordedFailureWithDiagnostics(
+	outcome workers.WorkOutcome,
+	detail *workers.FailureDetail,
+	metadata *workers.WorkFailureMetadata,
+	state workersessions.State,
+	diagnostics *workers.SafeWorkDiagnostics,
+) *workersessions.FailureCause {
 	if !state.Terminal() || state == workersessions.StateCompleted {
 		return nil
 	}
 	kind := workersessions.FailureCauseWorkersExecutionFailure
 	if outcome == workers.OutcomeRejected {
 		kind = workersessions.FailureCauseRejected
+	} else if recordedIncompleteOutput(diagnostics) {
+		kind = workersessions.FailureCauseIncompleteOutput
 	}
 	return &workersessions.FailureCause{Kind: kind, Detail: recordedFailureDetail(kind, detail, metadata), ProviderFailureKind: recordedProviderFailureKind(detail)}
+}
+
+func recordedIncompleteOutput(diagnostics *workers.SafeWorkDiagnostics) bool {
+	if diagnostics == nil || diagnostics.Provider == nil {
+		return false
+	}
+	metadata := diagnostics.Provider.ResponseMetadata
+	if strings.ToLower(strings.TrimSpace(metadata[workerexecution.ProviderResponseMetadataFailureOperation])) != "completion_validation" {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(metadata[workerexecution.ProviderResponseMetadataFailureClassification])) {
+	case "contradictory_completion", "missing_completion_evidence", "missing_required_output":
+		return true
+	default:
+		return false
+	}
 }
 
 func recordedFailureDetail(kind workersessions.FailureCauseKind, detail *workers.FailureDetail, metadata *workers.WorkFailureMetadata) string {
 	if kind == workersessions.FailureCauseRejected {
 		return "the Workers result was rejected by the business review"
+	}
+	if kind == workersessions.FailureCauseIncompleteOutput {
+		return "the Workers result did not include the required final output"
 	}
 	if metadata != nil {
 		family, familyKnown := recordedFailureFamily(metadata.Family)

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover.go
@@ -909,7 +909,7 @@ func recordedDispatchFact(
 		fact.startedAt = firstRecordedTime(dispatch.StartedAt, fact.startedAt)
 		fact.endedAt = recordedDispatchEnd(dispatch, events, dispatchID)
 		fact.workIDs = firstRecordedWorkIDs(dispatch.WorkItemIDs, fact.workIDs)
-		fact.failure = recordedFailure(dispatch.Result.FailureDetail, dispatch.Result.FailureMetadata, fact.state)
+		fact.failure = recordedFailure(workers.WorkOutcome(dispatch.Result.Outcome), dispatch.Result.FailureDetail, dispatch.Result.FailureMetadata, fact.state)
 		fact.provider = cloneProviderMetadata(dispatch.ProviderSession)
 	}
 	for _, provider := range providerSessions {
@@ -918,7 +918,7 @@ func recordedDispatchFact(
 		}
 		fact.provider = cloneProviderMetadata(&provider.ProviderSession)
 		fact.workIDs = firstRecordedWorkIDs(provider.WorkItemIDs, fact.workIDs)
-		fact.failure = firstRecordedFailure(fact.failure, recordedFailure(provider.FailureDetail, nil, fact.state))
+		fact.failure = firstRecordedFailure(fact.failure, recordedFailure(workers.OutcomeFailed, provider.FailureDetail, nil, fact.state))
 		break
 	}
 	return fact

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover.go
@@ -909,7 +909,13 @@ func recordedDispatchFact(
 		fact.startedAt = firstRecordedTime(dispatch.StartedAt, fact.startedAt)
 		fact.endedAt = recordedDispatchEnd(dispatch, events, dispatchID)
 		fact.workIDs = firstRecordedWorkIDs(dispatch.WorkItemIDs, fact.workIDs)
-		fact.failure = recordedFailure(workers.WorkOutcome(dispatch.Result.Outcome), dispatch.Result.FailureDetail, dispatch.Result.FailureMetadata, fact.state)
+		fact.failure = recordedFailureWithDiagnostics(
+			workers.WorkOutcome(dispatch.Result.Outcome),
+			dispatch.Result.FailureDetail,
+			dispatch.Result.FailureMetadata,
+			fact.state,
+			dispatch.Diagnostics,
+		)
 		fact.provider = cloneProviderMetadata(dispatch.ProviderSession)
 	}
 	for _, provider := range providerSessions {
@@ -918,7 +924,13 @@ func recordedDispatchFact(
 		}
 		fact.provider = cloneProviderMetadata(&provider.ProviderSession)
 		fact.workIDs = firstRecordedWorkIDs(provider.WorkItemIDs, fact.workIDs)
-		fact.failure = firstRecordedFailure(fact.failure, recordedFailure(workers.OutcomeFailed, provider.FailureDetail, nil, fact.state))
+		fact.failure = firstRecordedFailure(fact.failure, recordedFailureWithDiagnostics(
+			workers.OutcomeFailed,
+			provider.FailureDetail,
+			nil,
+			fact.state,
+			provider.Diagnostics,
+		))
 		break
 	}
 	return fact

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover_test.go
@@ -695,10 +695,29 @@ func TestRecordedDispatchFailureProjection(t *testing.T) {
 	if fact.state != workersessions.StateFailed || fact.provider == nil || len(fact.workIDs) != 1 || fact.failure == nil {
 		t.Fatalf("recordedDispatchFact() = %#v", fact)
 	}
+	rejectedCompletion := completed
+	rejectedCompletion.DispatchID = "dispatch-rejected"
+	rejectedCompletion.Result.Outcome = string(workers.OutcomeRejected)
+	rejectedFact := recordedDispatchFact(
+		"dispatch-rejected",
+		recordedDispatchAssociation{workerSessionID: "worker-rejected", turnID: "turn-rejected", eventTime: base},
+		nil,
+		map[string]interfaces.FactoryWorldDispatchCompletion{"dispatch-rejected": rejectedCompletion},
+		nil,
+		nil,
+		nil,
+	)
+	rejectedObservation := recordedObservationFromFact(rejectedFact, nil)
+	if rejectedObservation.State != workersessions.StateFailed || rejectedObservation.Failure == nil || rejectedObservation.Failure.Kind != workersessions.FailureCauseRejected {
+		t.Fatalf("recorded rejection observation = %#v, want bounded REJECTED failure classification", rejectedObservation)
+	}
+	if err := rejectedObservation.Validate(); err != nil {
+		t.Fatalf("recorded rejection observation validation = %v", err)
+	}
 	if recordedObservationState(string(workers.OutcomeAccepted)) != workersessions.StateCompleted || recordedObservationState(string(workers.OutcomeContinue)) != workersessions.StateCompleted || recordedObservationState(string(workers.OutcomeRejected)) != workersessions.StateFailed || recordedObservationState("unknown") != workersessions.StateFailed {
 		t.Fatal("recordedObservationState() mapping is incorrect")
 	}
-	if recordedFailure(nil, nil, workersessions.StateRunning) != nil {
+	if recordedFailure(workers.OutcomeFailed, nil, nil, workersessions.StateRunning) != nil {
 		t.Fatal("recordedFailure(active) returned a failure")
 	}
 }
@@ -706,9 +725,13 @@ func TestRecordedDispatchFailureProjection(t *testing.T) {
 func TestRecordedFailureMappingBranches(t *testing.T) {
 	failureDetail := &workers.FailureDetail{Reason: workers.WorkFailureTypeAuthFailure}
 	for _, reason := range []workers.WorkFailureType{workers.WorkFailureTypeAuthFailure, workers.WorkFailureTypeTimeout, workers.WorkFailureTypeThrottled, workers.WorkFailureTypeMisconfigured, workers.WorkFailureTypeUnknown, workers.WorkFailureTypeStructuredOutputSchemaViolation} {
-		if failure := recordedFailure(failureDetail, &workers.WorkFailureMetadata{Family: workers.WorkFailureFamilyTerminal, Type: reason}, workersessions.StateFailed); failure == nil || failure.Detail == "" {
+		if failure := recordedFailure(workers.OutcomeFailed, failureDetail, &workers.WorkFailureMetadata{Family: workers.WorkFailureFamilyTerminal, Type: reason}, workersessions.StateFailed); failure == nil || failure.Detail == "" {
 			t.Fatalf("recordedFailure(%q) = %#v", reason, failure)
 		}
+	}
+	rejected := recordedFailure(workers.OutcomeRejected, nil, nil, workersessions.StateFailed)
+	if rejected == nil || rejected.Kind != workersessions.FailureCauseRejected {
+		t.Fatalf("recordedFailure(REJECTED) = %#v, want bounded REJECTED classification", rejected)
 	}
 	if recordedProviderFailureKind(&workers.FailureDetail{Reason: workers.WorkFailureTypeAuthFailure}) != providers.ExecuteFailureKindAuthentication || recordedProviderFailureKind(&workers.FailureDetail{Reason: workers.WorkFailureTypeTimeout}) != providers.ExecuteFailureKindTimeout || recordedProviderFailureKind(&workers.FailureDetail{Reason: workers.WorkFailureTypeThrottled}) != providers.ExecuteFailureKindThrottled || recordedProviderFailureKind(&workers.FailureDetail{Reason: workers.WorkFailureTypeMisconfigured}) != providers.ExecuteFailureKindMisconfigured || recordedProviderFailureKind(nil) != "" {
 		t.Fatal("recordedProviderFailureKind() mapping is incorrect")
@@ -731,10 +754,10 @@ func TestRecordedFailureKindAndTypeBranches(t *testing.T) {
 }
 
 func TestRecordedFailureDetailFallback(t *testing.T) {
-	if recordedFailureDetail(nil, nil) == "" || recordedFailureDetail(nil, &workers.WorkFailureMetadata{Family: "foreign", Type: "foreign"}) == "" {
+	if recordedFailureDetail(workersessions.FailureCauseWorkersExecutionFailure, nil, nil) == "" || recordedFailureDetail(workersessions.FailureCauseWorkersExecutionFailure, nil, &workers.WorkFailureMetadata{Family: "foreign", Type: "foreign"}) == "" {
 		t.Fatal("recordedFailureDetail() returned an empty fallback")
 	}
-	if got := recordedFailureDetail(nil, &workers.WorkFailureMetadata{Family: "", Type: workers.WorkFailureTypeTimeout}); got != "family=unknown type=timeout" {
+	if got := recordedFailureDetail(workersessions.FailureCauseWorkersExecutionFailure, nil, &workers.WorkFailureMetadata{Family: "", Type: workers.WorkFailureTypeTimeout}); got != "family=unknown type=timeout" {
 		t.Fatalf("recordedFailureDetail(empty family) = %q", got)
 	}
 }

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -331,75 +330,6 @@ func TestRecordedWorkerSessionObservation_ListsHistoricalAttemptsInChronological
 	}
 	if result.Observations[1].AttemptID != "dispatch-late" || result.Observations[1].TurnID != "turn-late" {
 		t.Fatalf("late recorded observation = %#v, want dispatch-late/turn-late", result.Observations[1])
-	}
-}
-
-func TestRecordedWorkerSessionObservation_PreservesIncompleteOutputFromReplay(t *testing.T) {
-	base := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
-	workID := "work-recorded-incomplete"
-	dispatchID := "dispatch-recorded-incomplete"
-	events := []interfaces.FactoryEvent{
-		{
-			Context: interfaces.FactoryEventContext{
-				Tick: 1, Sequence: 1, EventTime: base,
-				DispatchID: stringPointerForRecordedTest(dispatchID),
-				WorkIDs:    stringSliceForRecordedTest([]string{workID}),
-			},
-			Id:      "incomplete-request",
-			Type:    interfaces.FactoryEventTypeDispatchRequest,
-			Payload: mustMarshalRecordedTest(t, interfaces.DispatchRequestEventPayload{}),
-		},
-		{
-			Context: interfaces.FactoryEventContext{
-				Tick: 1, Sequence: 2, EventTime: base.Add(time.Second),
-				DispatchID: stringPointerForRecordedTest(dispatchID),
-			},
-			Id: "incomplete-association", Type: interfaces.FactoryEventTypeDispatchWorkerSessionAssoc,
-			Payload: mustMarshalRecordedTest(t, interfaces.DispatchWorkerSessionAssociationEventPayload{
-				WorkerSessionID: "worker-recorded-incomplete",
-			}),
-		},
-		{
-			Context: interfaces.FactoryEventContext{
-				Tick: 2, Sequence: 3, EventTime: base.Add(2 * time.Second),
-				DispatchID: stringPointerForRecordedTest(dispatchID),
-			},
-			Id: "incomplete-response", Type: interfaces.FactoryEventTypeDispatchResponse,
-		},
-	}
-	diagnostics := &workers.SafeWorkDiagnostics{Provider: &workers.SafeProviderDiagnostic{ResponseMetadata: map[string]string{
-		workers.ProviderResponseMetadataFailureOperation:      "completion_validation",
-		workers.ProviderResponseMetadataFailureClassification: "missing_required_output",
-	}}}
-	service := newRecordedWorkerSessionObservation(
-		nil,
-		&recordingfixtures.ScriptedRuntimeLedger{Events: events},
-		func(_ []interfaces.FactoryEvent, _ int) (interfaces.FactoryWorldState, error) {
-			return interfaces.FactoryWorldState{
-				WorkItemsByID: map[string]work.FactoryWorkItem{workID: {ID: workID}},
-				CompletedDispatches: []interfaces.FactoryWorldDispatchCompletion{{
-					DispatchID: dispatchID, StartedAt: base, CompletedAt: base.Add(2 * time.Second), WorkItemIDs: []string{workID},
-					Result: interfaces.WorkstationResult{Outcome: string(workers.OutcomeFailed)}, Diagnostics: diagnostics,
-				}},
-			}, nil
-		},
-		platformclock.Real{},
-		nil,
-	)
-
-	result, err := service.ListObservations(context.Background(), workersessions.ListObservationsRequest{WorkID: workID})
-	if err != nil || len(result.Observations) != 1 {
-		t.Fatalf("ListObservations() = %#v, %v; want one replayed observation", result, err)
-	}
-	observation := result.Observations[0]
-	if observation.Failure == nil || observation.Failure.Kind != workersessions.FailureCauseIncompleteOutput {
-		t.Fatalf("replayed observation failure = %#v, want INCOMPLETE_OUTPUT", observation.Failure)
-	}
-	if strings.Contains(observation.Failure.Detail, "missing_required_output") || strings.Contains(observation.Failure.Detail, "transcript") {
-		t.Fatalf("replayed failure detail = %q, want bounded safe detail", observation.Failure.Detail)
-	}
-	if err := observation.Validate(); err != nil {
-		t.Fatalf("replayed observation validation = %v", err)
 	}
 }
 
@@ -750,65 +680,6 @@ func TestRecordedObservationListBranches(t *testing.T) {
 	}
 	if !acceptableLiveObservationError(nil) || !acceptableLiveObservationError(workersessions.ErrObservationProjectionUnavailable) || !acceptableLiveObservationError(workersessions.ErrObservationWorkNotFound) || acceptableLiveObservationError(errors.New("other")) {
 		t.Fatal("acceptableLiveObservationError() classification is incorrect")
-	}
-}
-
-func TestRecordedDispatchFailureProjection(t *testing.T) {
-	base := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
-	failureDetail := &workers.FailureDetail{Reason: workers.WorkFailureTypeAuthFailure}
-	metadata := &workers.WorkFailureMetadata{Family: workers.WorkFailureFamilyRetryable, Type: workers.WorkFailureTypeTimeout}
-	providerMetadata := &workers.ProviderSessionMetadata{Provider: "codex", Kind: providers.SessionIDKind, ID: "provider-session-1"}
-	completed := interfaces.FactoryWorldDispatchCompletion{DispatchID: "dispatch-1", StartedAt: base, CompletedAt: base.Add(2 * time.Second), WorkItemIDs: []string{"work-1"}, Result: interfaces.WorkstationResult{Outcome: string(workers.OutcomeFailed), FailureDetail: failureDetail, FailureMetadata: metadata}, ProviderSession: providerMetadata}
-	active := interfaces.FactoryWorldDispatch{DispatchID: "dispatch-1", StartedAt: base.Add(time.Second), WorkItemIDs: []string{"work-2"}}
-	providerRecords := []interfaces.FactoryWorldProviderSessionRecord{{DispatchID: "dispatch-1", ProviderSession: *providerMetadata, WorkItemIDs: []string{"work-3"}, FailureDetail: failureDetail}}
-	fact := recordedDispatchFact("dispatch-1", recordedDispatchAssociation{workerSessionID: "worker-1", turnID: "turn-1", eventTime: base}, map[string]recordedDispatchRequest{"dispatch-1": {workIDs: []string{"work-1"}, startedAt: base}}, map[string]interfaces.FactoryWorldDispatchCompletion{"dispatch-1": completed}, providerRecords, map[string]interfaces.FactoryWorldDispatch{"dispatch-1": active}, nil)
-	if fact.state != workersessions.StateFailed || fact.provider == nil || len(fact.workIDs) != 1 || fact.failure == nil {
-		t.Fatalf("recordedDispatchFact() = %#v", fact)
-	}
-	rejectedCompletion := completed
-	rejectedCompletion.DispatchID = "dispatch-rejected"
-	rejectedCompletion.Result.Outcome = string(workers.OutcomeRejected)
-	rejectedFact := recordedDispatchFact(
-		"dispatch-rejected",
-		recordedDispatchAssociation{workerSessionID: "worker-rejected", turnID: "turn-rejected", eventTime: base},
-		nil,
-		map[string]interfaces.FactoryWorldDispatchCompletion{"dispatch-rejected": rejectedCompletion},
-		nil,
-		nil,
-		nil,
-	)
-	rejectedObservation := recordedObservationFromFact(rejectedFact, nil)
-	if rejectedObservation.State != workersessions.StateFailed || rejectedObservation.Failure == nil || rejectedObservation.Failure.Kind != workersessions.FailureCauseRejected {
-		t.Fatalf("recorded rejection observation = %#v, want bounded REJECTED failure classification", rejectedObservation)
-	}
-	if err := rejectedObservation.Validate(); err != nil {
-		t.Fatalf("recorded rejection observation validation = %v", err)
-	}
-	if recordedObservationState(string(workers.OutcomeAccepted)) != workersessions.StateCompleted || recordedObservationState(string(workers.OutcomeContinue)) != workersessions.StateCompleted || recordedObservationState(string(workers.OutcomeRejected)) != workersessions.StateFailed || recordedObservationState("unknown") != workersessions.StateFailed {
-		t.Fatal("recordedObservationState() mapping is incorrect")
-	}
-	if recordedFailure(workers.OutcomeFailed, nil, nil, workersessions.StateRunning) != nil {
-		t.Fatal("recordedFailure(active) returned a failure")
-	}
-	incompleteDiagnostics := &workers.SafeWorkDiagnostics{Provider: &workers.SafeProviderDiagnostic{ResponseMetadata: map[string]string{
-		workers.ProviderResponseMetadataFailureOperation:      "completion_validation",
-		workers.ProviderResponseMetadataFailureClassification: "missing_completion_evidence",
-	}}}
-	incomplete := completed
-	incomplete.DispatchID = "dispatch-incomplete"
-	incomplete.Diagnostics = incompleteDiagnostics
-	incompleteFact := recordedDispatchFact(
-		"dispatch-incomplete",
-		recordedDispatchAssociation{workerSessionID: "worker-incomplete", eventTime: base},
-		nil,
-		map[string]interfaces.FactoryWorldDispatchCompletion{"dispatch-incomplete": incomplete},
-		nil,
-		nil,
-		nil,
-	)
-	incompleteObservation := recordedObservationFromFact(incompleteFact, nil)
-	if incompleteObservation.Failure == nil || incompleteObservation.Failure.Kind != workersessions.FailureCauseIncompleteOutput {
-		t.Fatalf("recorded incomplete observation = %#v, want bounded INCOMPLETE_OUTPUT failure", incompleteObservation)
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -330,6 +331,75 @@ func TestRecordedWorkerSessionObservation_ListsHistoricalAttemptsInChronological
 	}
 	if result.Observations[1].AttemptID != "dispatch-late" || result.Observations[1].TurnID != "turn-late" {
 		t.Fatalf("late recorded observation = %#v, want dispatch-late/turn-late", result.Observations[1])
+	}
+}
+
+func TestRecordedWorkerSessionObservation_PreservesIncompleteOutputFromReplay(t *testing.T) {
+	base := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	workID := "work-recorded-incomplete"
+	dispatchID := "dispatch-recorded-incomplete"
+	events := []interfaces.FactoryEvent{
+		{
+			Context: interfaces.FactoryEventContext{
+				Tick: 1, Sequence: 1, EventTime: base,
+				DispatchID: stringPointerForRecordedTest(dispatchID),
+				WorkIDs:    stringSliceForRecordedTest([]string{workID}),
+			},
+			Id:      "incomplete-request",
+			Type:    interfaces.FactoryEventTypeDispatchRequest,
+			Payload: mustMarshalRecordedTest(t, interfaces.DispatchRequestEventPayload{}),
+		},
+		{
+			Context: interfaces.FactoryEventContext{
+				Tick: 1, Sequence: 2, EventTime: base.Add(time.Second),
+				DispatchID: stringPointerForRecordedTest(dispatchID),
+			},
+			Id: "incomplete-association", Type: interfaces.FactoryEventTypeDispatchWorkerSessionAssoc,
+			Payload: mustMarshalRecordedTest(t, interfaces.DispatchWorkerSessionAssociationEventPayload{
+				WorkerSessionID: "worker-recorded-incomplete",
+			}),
+		},
+		{
+			Context: interfaces.FactoryEventContext{
+				Tick: 2, Sequence: 3, EventTime: base.Add(2 * time.Second),
+				DispatchID: stringPointerForRecordedTest(dispatchID),
+			},
+			Id: "incomplete-response", Type: interfaces.FactoryEventTypeDispatchResponse,
+		},
+	}
+	diagnostics := &workers.SafeWorkDiagnostics{Provider: &workers.SafeProviderDiagnostic{ResponseMetadata: map[string]string{
+		workers.ProviderResponseMetadataFailureOperation:      "completion_validation",
+		workers.ProviderResponseMetadataFailureClassification: "missing_required_output",
+	}}}
+	service := newRecordedWorkerSessionObservation(
+		nil,
+		&recordingfixtures.ScriptedRuntimeLedger{Events: events},
+		func(_ []interfaces.FactoryEvent, _ int) (interfaces.FactoryWorldState, error) {
+			return interfaces.FactoryWorldState{
+				WorkItemsByID: map[string]work.FactoryWorkItem{workID: {ID: workID}},
+				CompletedDispatches: []interfaces.FactoryWorldDispatchCompletion{{
+					DispatchID: dispatchID, StartedAt: base, CompletedAt: base.Add(2 * time.Second), WorkItemIDs: []string{workID},
+					Result: interfaces.WorkstationResult{Outcome: string(workers.OutcomeFailed)}, Diagnostics: diagnostics,
+				}},
+			}, nil
+		},
+		platformclock.Real{},
+		nil,
+	)
+
+	result, err := service.ListObservations(context.Background(), workersessions.ListObservationsRequest{WorkID: workID})
+	if err != nil || len(result.Observations) != 1 {
+		t.Fatalf("ListObservations() = %#v, %v; want one replayed observation", result, err)
+	}
+	observation := result.Observations[0]
+	if observation.Failure == nil || observation.Failure.Kind != workersessions.FailureCauseIncompleteOutput {
+		t.Fatalf("replayed observation failure = %#v, want INCOMPLETE_OUTPUT", observation.Failure)
+	}
+	if strings.Contains(observation.Failure.Detail, "missing_required_output") || strings.Contains(observation.Failure.Detail, "transcript") {
+		t.Fatalf("replayed failure detail = %q, want bounded safe detail", observation.Failure.Detail)
+	}
+	if err := observation.Validate(); err != nil {
+		t.Fatalf("replayed observation validation = %v", err)
 	}
 }
 
@@ -719,6 +789,26 @@ func TestRecordedDispatchFailureProjection(t *testing.T) {
 	}
 	if recordedFailure(workers.OutcomeFailed, nil, nil, workersessions.StateRunning) != nil {
 		t.Fatal("recordedFailure(active) returned a failure")
+	}
+	incompleteDiagnostics := &workers.SafeWorkDiagnostics{Provider: &workers.SafeProviderDiagnostic{ResponseMetadata: map[string]string{
+		workers.ProviderResponseMetadataFailureOperation:      "completion_validation",
+		workers.ProviderResponseMetadataFailureClassification: "missing_completion_evidence",
+	}}}
+	incomplete := completed
+	incomplete.DispatchID = "dispatch-incomplete"
+	incomplete.Diagnostics = incompleteDiagnostics
+	incompleteFact := recordedDispatchFact(
+		"dispatch-incomplete",
+		recordedDispatchAssociation{workerSessionID: "worker-incomplete", eventTime: base},
+		nil,
+		map[string]interfaces.FactoryWorldDispatchCompletion{"dispatch-incomplete": incomplete},
+		nil,
+		nil,
+		nil,
+	)
+	incompleteObservation := recordedObservationFromFact(incompleteFact, nil)
+	if incompleteObservation.Failure == nil || incompleteObservation.Failure.Kind != workersessions.FailureCauseIncompleteOutput {
+		t.Fatalf("recorded incomplete observation = %#v, want bounded INCOMPLETE_OUTPUT failure", incompleteObservation)
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_terminal_semantics_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_terminal_semantics_test.go
@@ -2,16 +2,157 @@ package runtime
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/portpowered/infinite-you/internal/testutil/recordingfixtures"
+	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factory "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	dispatchplanning "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/dispatch_planning"
+	"github.com/portpowered/infinite-you/pkg/services/providers"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	workersessions "github.com/portpowered/infinite-you/pkg/services/worker_sessions"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 )
+
+func TestRecordedWorkerSessionObservation_PreservesIncompleteOutputFromReplay(t *testing.T) {
+	base := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	workID := "work-recorded-incomplete"
+	dispatchID := "dispatch-recorded-incomplete"
+	events := []interfaces.FactoryEvent{
+		{
+			Context: interfaces.FactoryEventContext{
+				Tick: 1, Sequence: 1, EventTime: base,
+				DispatchID: stringPointerForRecordedTest(dispatchID),
+				WorkIDs:    stringSliceForRecordedTest([]string{workID}),
+			},
+			Id:      "incomplete-request",
+			Type:    interfaces.FactoryEventTypeDispatchRequest,
+			Payload: mustMarshalRecordedTest(t, interfaces.DispatchRequestEventPayload{}),
+		},
+		{
+			Context: interfaces.FactoryEventContext{
+				Tick: 1, Sequence: 2, EventTime: base.Add(time.Second),
+				DispatchID: stringPointerForRecordedTest(dispatchID),
+			},
+			Id: "incomplete-association", Type: interfaces.FactoryEventTypeDispatchWorkerSessionAssoc,
+			Payload: mustMarshalRecordedTest(t, interfaces.DispatchWorkerSessionAssociationEventPayload{
+				WorkerSessionID: "worker-recorded-incomplete",
+			}),
+		},
+		{
+			Context: interfaces.FactoryEventContext{
+				Tick: 2, Sequence: 3, EventTime: base.Add(2 * time.Second),
+				DispatchID: stringPointerForRecordedTest(dispatchID),
+			},
+			Id: "incomplete-response", Type: interfaces.FactoryEventTypeDispatchResponse,
+		},
+	}
+	diagnostics := &workers.SafeWorkDiagnostics{Provider: &workers.SafeProviderDiagnostic{ResponseMetadata: map[string]string{
+		workers.ProviderResponseMetadataFailureOperation:      "completion_validation",
+		workers.ProviderResponseMetadataFailureClassification: "missing_required_output",
+	}}}
+	service := newRecordedWorkerSessionObservation(
+		nil,
+		&recordingfixtures.ScriptedRuntimeLedger{Events: events},
+		func(_ []interfaces.FactoryEvent, _ int) (interfaces.FactoryWorldState, error) {
+			return interfaces.FactoryWorldState{
+				WorkItemsByID: map[string]work.FactoryWorkItem{workID: {ID: workID}},
+				CompletedDispatches: []interfaces.FactoryWorldDispatchCompletion{{
+					DispatchID: dispatchID, StartedAt: base, CompletedAt: base.Add(2 * time.Second), WorkItemIDs: []string{workID},
+					Result: interfaces.WorkstationResult{Outcome: string(workers.OutcomeFailed)}, Diagnostics: diagnostics,
+				}},
+			}, nil
+		},
+		platformclock.Real{},
+		nil,
+	)
+
+	result, err := service.ListObservations(context.Background(), workersessions.ListObservationsRequest{WorkID: workID})
+	if err != nil || len(result.Observations) != 1 {
+		t.Fatalf("ListObservations() = %#v, %v; want one replayed observation", result, err)
+	}
+	observation := result.Observations[0]
+	if observation.Failure == nil || observation.Failure.Kind != workersessions.FailureCauseIncompleteOutput {
+		t.Fatalf("replayed observation failure = %#v, want INCOMPLETE_OUTPUT", observation.Failure)
+	}
+	if strings.Contains(observation.Failure.Detail, "missing_required_output") || strings.Contains(observation.Failure.Detail, "transcript") {
+		t.Fatalf("replayed failure detail = %q, want bounded safe detail", observation.Failure.Detail)
+	}
+	if err := observation.Validate(); err != nil {
+		t.Fatalf("replayed observation validation = %v", err)
+	}
+}
+
+func TestRecordedDispatchFailureProjection(t *testing.T) {
+	base := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	failureDetail := &workers.FailureDetail{Reason: workers.WorkFailureTypeAuthFailure}
+	metadata := &workers.WorkFailureMetadata{Family: workers.WorkFailureFamilyRetryable, Type: workers.WorkFailureTypeTimeout}
+	providerMetadata := &workers.ProviderSessionMetadata{Provider: "codex", Kind: providers.SessionIDKind, ID: "provider-session-1"}
+	completed := interfaces.FactoryWorldDispatchCompletion{DispatchID: "dispatch-1", StartedAt: base, CompletedAt: base.Add(2 * time.Second), WorkItemIDs: []string{"work-1"}, Result: interfaces.WorkstationResult{Outcome: string(workers.OutcomeFailed), FailureDetail: failureDetail, FailureMetadata: metadata}, ProviderSession: providerMetadata}
+	active := interfaces.FactoryWorldDispatch{DispatchID: "dispatch-1", StartedAt: base.Add(time.Second), WorkItemIDs: []string{"work-2"}}
+	providerRecords := []interfaces.FactoryWorldProviderSessionRecord{{DispatchID: "dispatch-1", ProviderSession: *providerMetadata, WorkItemIDs: []string{"work-3"}, FailureDetail: failureDetail}}
+	fact := recordedDispatchFact("dispatch-1", recordedDispatchAssociation{workerSessionID: "worker-1", turnID: "turn-1", eventTime: base}, map[string]recordedDispatchRequest{"dispatch-1": {workIDs: []string{"work-1"}, startedAt: base}}, map[string]interfaces.FactoryWorldDispatchCompletion{"dispatch-1": completed}, providerRecords, map[string]interfaces.FactoryWorldDispatch{"dispatch-1": active}, nil)
+	if fact.state != workersessions.StateFailed || fact.provider == nil || len(fact.workIDs) != 1 || fact.failure == nil {
+		t.Fatalf("recordedDispatchFact() = %#v", fact)
+	}
+	rejectedCompletion := completed
+	rejectedCompletion.DispatchID = "dispatch-rejected"
+	rejectedCompletion.Result.Outcome = string(workers.OutcomeRejected)
+	rejectedFact := recordedDispatchFact(
+		"dispatch-rejected",
+		recordedDispatchAssociation{workerSessionID: "worker-rejected", turnID: "turn-rejected", eventTime: base},
+		nil,
+		map[string]interfaces.FactoryWorldDispatchCompletion{"dispatch-rejected": rejectedCompletion},
+		nil,
+		nil,
+		nil,
+	)
+	rejectedObservation := recordedObservationFromFact(rejectedFact, nil)
+	if rejectedObservation.State != workersessions.StateFailed || rejectedObservation.Failure == nil || rejectedObservation.Failure.Kind != workersessions.FailureCauseRejected {
+		t.Fatalf("recorded rejection observation = %#v, want bounded REJECTED failure classification", rejectedObservation)
+	}
+	if err := rejectedObservation.Validate(); err != nil {
+		t.Fatalf("recorded rejection observation validation = %v", err)
+	}
+	if recordedObservationState(string(workers.OutcomeAccepted)) != workersessions.StateCompleted || recordedObservationState(string(workers.OutcomeContinue)) != workersessions.StateCompleted || recordedObservationState(string(workers.OutcomeRejected)) != workersessions.StateFailed || recordedObservationState("unknown") != workersessions.StateFailed {
+		t.Fatal("recordedObservationState() mapping is incorrect")
+	}
+	if recordedFailure(workers.OutcomeFailed, nil, nil, workersessions.StateRunning) != nil {
+		t.Fatal("recordedFailure(active) returned a failure")
+	}
+}
+
+func TestRecordedDispatchIncompleteOutputProjection(t *testing.T) {
+	base := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	completed := interfaces.FactoryWorldDispatchCompletion{
+		DispatchID: "dispatch-incomplete", StartedAt: base, CompletedAt: base.Add(2 * time.Second),
+		Result: interfaces.WorkstationResult{Outcome: string(workers.OutcomeFailed)},
+	}
+	incompleteDiagnostics := &workers.SafeWorkDiagnostics{Provider: &workers.SafeProviderDiagnostic{ResponseMetadata: map[string]string{
+		workers.ProviderResponseMetadataFailureOperation:      "completion_validation",
+		workers.ProviderResponseMetadataFailureClassification: "missing_completion_evidence",
+	}}}
+	incomplete := completed
+	incomplete.DispatchID = "dispatch-incomplete"
+	incomplete.Diagnostics = incompleteDiagnostics
+	incompleteFact := recordedDispatchFact(
+		"dispatch-incomplete",
+		recordedDispatchAssociation{workerSessionID: "worker-incomplete", eventTime: base},
+		nil,
+		map[string]interfaces.FactoryWorldDispatchCompletion{"dispatch-incomplete": incomplete},
+		nil,
+		nil,
+		nil,
+	)
+	incompleteObservation := recordedObservationFromFact(incompleteFact, nil)
+	if incompleteObservation.Failure == nil || incompleteObservation.Failure.Kind != workersessions.FailureCauseIncompleteOutput {
+		t.Fatalf("recorded incomplete observation = %#v, want bounded INCOMPLETE_OUTPUT failure", incompleteObservation)
+	}
+}
 
 // TestFactoryImpl_DirectAndChildDispatchPreserveIdenticalTerminalOutcomeMapping
 // is the W4 story 002 cutover-preservation proof: a direct Runtime-root

--- a/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_history_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_history_test.go
@@ -120,6 +120,30 @@ func TestBuildHistory_MergesSharedLineageVisitCountsWithMaxNotSum(t *testing.T) 
 	}
 }
 
+func TestBuildHistory_IncompleteOutputRemainsConsecutiveFailure(t *testing.T) {
+	consumed := []factorytoken.Token{{
+		Color: factorytoken.Color{WorkID: "review-1", WorkTypeID: "review"},
+		History: factorytoken.History{
+			ConsecutiveFailures: map[string]int{"review": 1},
+		},
+	}}
+
+	history := buildHistory(consumed, &workerexecution.WorkResult{
+		TransitionID: "review",
+		Outcome:      workerexecution.OutcomeFailed,
+		Diagnostics: &workerexecution.WorkDiagnostics{Provider: &workerexecution.ProviderDiagnostic{
+			ResponseMetadata: map[string]string{
+				workerexecution.ProviderResponseMetadataFailureOperation:      "completion_validation",
+				workerexecution.ProviderResponseMetadataFailureClassification: "missing_required_output",
+			},
+		}},
+	}, "review-1")
+
+	if got := history.ConsecutiveFailures["review"]; got != 2 {
+		t.Fatalf("ConsecutiveFailures[review] = %d, want 2 for INCOMPLETE_OUTPUT", got)
+	}
+}
+
 func TestBuildHistory_ExcludesDifferentWorkOnSharedTrace(t *testing.T) {
 	const sharedTrace = "batch-trace"
 	consumed := []factorytoken.Token{

--- a/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_transitioner.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_transitioner.go
@@ -487,7 +487,9 @@ func resolveWorkResult(transition *petri.Transition, result *workerexecution.Wor
 		feedback:                    result.Feedback,
 		failureMetadata:             result.FailureMetadata,
 	}
-	if workstation, ok := runtimeWorkstation(transition.Name, runtimeConfig); ok && workstation != nil && len(workstation.StopWords) > 0 {
+	if workstation, ok := runtimeWorkstation(transition.Name, runtimeConfig); ok && workstation != nil &&
+		len(workstation.StopWords) > 0 &&
+		strings.TrimSpace(workstation.OutcomeFormat) != interfaces.WorkstationOutcomeFormatDecisionEnvelope {
 		resolved.outcome = evaluateStopWords(workstation.StopWords, result.Output)
 	}
 	return resolved

--- a/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_transitioner_classifier_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_transitioner_classifier_test.go
@@ -91,6 +91,35 @@ func TestTransitioner_ClassifierUnknownLabelUsesImplicitNormalizedFailureArc(t *
 	}
 }
 
+func TestResolveWorkResult_DecisionEnvelopePreservesExplicitRejectionOverStopWords(t *testing.T) {
+	transition := &petri.Transition{
+		ID:   "transition-id",
+		Name: "review-station",
+	}
+	result := &workerexecution.WorkResult{
+		DispatchID:   "dispatch-1",
+		TransitionID: "transition-id",
+		Outcome:      workerexecution.OutcomeRejected,
+		Feedback:     "add the missing release date",
+	}
+
+	resolved := resolveWorkResult(transition, result, runtimefixtures.RuntimeWorkstationLookupFixture{
+		Workstations: map[string]*interfaces.FactoryWorkstationConfig{
+			"review-station": {
+				OutcomeFormat: interfaces.WorkstationOutcomeFormatDecisionEnvelope,
+				StopWords:     []string{"DONE"},
+			},
+		},
+	})
+
+	if resolved.outcome != workerexecution.OutcomeRejected {
+		t.Fatalf("resolved outcome = %s, want REJECTED", resolved.outcome)
+	}
+	if resolved.feedback != result.Feedback {
+		t.Fatalf("resolved feedback = %q, want %q", resolved.feedback, result.Feedback)
+	}
+}
+
 func newClassifierTransitionerFixture(now time.Time) *TransitionerSubsystem {
 	net := &state.Net{
 		Places: map[string]*petri.Place{

--- a/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_transitioner_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_transitioner_test.go
@@ -413,35 +413,6 @@ func TestResolveWorkResult_RuntimeConfigStopWordsFailMissingMarker(t *testing.T)
 	}
 }
 
-func TestResolveWorkResult_DecisionEnvelopePreservesExplicitRejectionOverStopWords(t *testing.T) {
-	transition := &petri.Transition{
-		ID:   "transition-id",
-		Name: "review-station",
-	}
-	result := &workerexecution.WorkResult{
-		DispatchID:   "dispatch-1",
-		TransitionID: "transition-id",
-		Outcome:      workerexecution.OutcomeRejected,
-		Feedback:     "add the missing release date",
-	}
-
-	resolved := resolveWorkResult(transition, result, runtimefixtures.RuntimeWorkstationLookupFixture{
-		Workstations: map[string]*interfaces.FactoryWorkstationConfig{
-			"review-station": {
-				OutcomeFormat: interfaces.WorkstationOutcomeFormatDecisionEnvelope,
-				StopWords:     []string{"DONE"},
-			},
-		},
-	})
-
-	if resolved.outcome != workerexecution.OutcomeRejected {
-		t.Fatalf("resolved outcome = %s, want REJECTED", resolved.outcome)
-	}
-	if resolved.feedback != result.Feedback {
-		t.Fatalf("resolved feedback = %q, want %q", resolved.feedback, result.Feedback)
-	}
-}
-
 func TestResolveWorkResult_MissingRuntimeConfigPreservesOriginalOutcome(t *testing.T) {
 	transition := &petri.Transition{
 		ID: "runtime-station-id",

--- a/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_transitioner_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_transitioner_test.go
@@ -413,6 +413,35 @@ func TestResolveWorkResult_RuntimeConfigStopWordsFailMissingMarker(t *testing.T)
 	}
 }
 
+func TestResolveWorkResult_DecisionEnvelopePreservesExplicitRejectionOverStopWords(t *testing.T) {
+	transition := &petri.Transition{
+		ID:   "transition-id",
+		Name: "review-station",
+	}
+	result := &workerexecution.WorkResult{
+		DispatchID:   "dispatch-1",
+		TransitionID: "transition-id",
+		Outcome:      workerexecution.OutcomeRejected,
+		Feedback:     "add the missing release date",
+	}
+
+	resolved := resolveWorkResult(transition, result, runtimefixtures.RuntimeWorkstationLookupFixture{
+		Workstations: map[string]*interfaces.FactoryWorkstationConfig{
+			"review-station": {
+				OutcomeFormat: interfaces.WorkstationOutcomeFormatDecisionEnvelope,
+				StopWords:     []string{"DONE"},
+			},
+		},
+	})
+
+	if resolved.outcome != workerexecution.OutcomeRejected {
+		t.Fatalf("resolved outcome = %s, want REJECTED", resolved.outcome)
+	}
+	if resolved.feedback != result.Feedback {
+		t.Fatalf("resolved feedback = %q, want %q", resolved.feedback, result.Feedback)
+	}
+}
+
 func TestResolveWorkResult_MissingRuntimeConfigPreservesOriginalOutcome(t *testing.T) {
 	transition := &petri.Transition{
 		ID: "runtime-station-id",

--- a/pkg/services/worker_sessions/internal/service/classify.go
+++ b/pkg/services/worker_sessions/internal/service/classify.go
@@ -61,7 +61,21 @@ func classifyTerminal(
 			return terminalForDispatchResult(kind, detail, workResult, dispatchErr)
 		}
 		return workersessions.TerminalResult{Outcome: workersessions.TerminalOutcomeCompleted}
-	default: // workers.OutcomeRejected, workers.OutcomeFailed
+	case workers.OutcomeRejected:
+		// A cleanly completed rejection is a normal business result. Keep the
+		// Worker's rejection route and feedback untouched; Worker Sessions
+		// records the bounded classification so inspection does not confuse it
+		// with an execution failure.
+		if dispatchErr == nil && dispatchResult.TerminalOutcome != workers.WorkstationDispatchTerminalOutcomeFailed {
+			return terminalForDispatchResult(
+				workersessions.FailureCauseRejected,
+				safeDetailForDispatchError(workersessions.FailureCauseRejected, workResult, nil, false),
+				workResult,
+				nil,
+			)
+		}
+		fallthrough
+	default: // workers.OutcomeFailed and contradictory/unknown outcomes
 		kind := workersessions.FailureCauseWorkersExecutionFailure
 		switch {
 		case isExecutorPanicEvidence(dispatchErr, workResult):
@@ -253,6 +267,7 @@ func rawDetail(err error) string {
 var genericFailureDetail = map[workersessions.FailureCauseKind]string{
 	workersessions.FailureCauseStartFailure:            "the attempt could not be handed off to Workers",
 	workersessions.FailureCauseWorkersExecutionFailure: "the Workers execution result was not successful",
+	workersessions.FailureCauseRejected:                "the Workers result was rejected by the business review",
 	workersessions.FailureCauseIncompleteOutput:        "the Workers result did not include the required final output",
 	workersessions.FailureCauseAdapterFailure:          "the Workers adapter reported a failure",
 	workersessions.FailureCauseExecutorPanic:           "the Workers executor reported a panic",

--- a/pkg/services/worker_sessions/internal/service/classify.go
+++ b/pkg/services/worker_sessions/internal/service/classify.go
@@ -68,6 +68,8 @@ func classifyTerminal(
 			kind = workersessions.FailureCauseExecutorPanic
 		case dispatchErr != nil:
 			kind = workersessions.FailureCauseAdapterFailure
+		case isIncompleteOutputEvidence(workResult):
+			kind = workersessions.FailureCauseIncompleteOutput
 		}
 		return terminalForDispatchResult(
 			kind,
@@ -75,6 +77,23 @@ func classifyTerminal(
 			workResult,
 			dispatchErr,
 		)
+	}
+}
+
+// isIncompleteOutputEvidence recognizes only the Workers-owned structured
+// completion-validation facts. The raw WorkResult output and error are not
+// inspected here: a readable output-contract failure is classified by the
+// diagnostics emitted at the Worker boundary, while process and transcript
+// failures retain the ordinary execution-failure kind.
+func isIncompleteOutputEvidence(workResult workers.WorkResult) bool {
+	if strings.ToLower(strings.TrimSpace(diagnosticValue(workResult.Diagnostics, "failure_operation"))) != "completion_validation" {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(diagnosticValue(workResult.Diagnostics, "failure_classification"))) {
+	case "contradictory_completion", "missing_completion_evidence", "missing_required_output":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -234,6 +253,7 @@ func rawDetail(err error) string {
 var genericFailureDetail = map[workersessions.FailureCauseKind]string{
 	workersessions.FailureCauseStartFailure:            "the attempt could not be handed off to Workers",
 	workersessions.FailureCauseWorkersExecutionFailure: "the Workers execution result was not successful",
+	workersessions.FailureCauseIncompleteOutput:        "the Workers result did not include the required final output",
 	workersessions.FailureCauseAdapterFailure:          "the Workers adapter reported a failure",
 	workersessions.FailureCauseExecutorPanic:           "the Workers executor reported a panic",
 	workersessions.FailureCauseEventPublicationFailure: "the Worker Session opening record could not be published",
@@ -400,6 +420,7 @@ var knownFailureClassifications = map[string]struct{}{
 	"canceled":                    {},
 	"contradictory_completion":    {},
 	"missing_completion_evidence": {},
+	"missing_required_output":     {},
 	"parse":                       {},
 	"resource_limit":              {},
 	"storage":                     {},

--- a/pkg/services/worker_sessions/internal/service/internal_test.go
+++ b/pkg/services/worker_sessions/internal/service/internal_test.go
@@ -887,6 +887,29 @@ func TestClassifyTerminal_CleanRejectedWorkResultUsesBoundedRejectionCause(t *te
 	}
 }
 
+func TestClassifyTerminal_RejectedWithFailedDispatchFallsThroughToExecutionFailure(t *testing.T) {
+	terminal := classifyTerminal(nil, workers.WorkstationDispatchResult{
+		TerminalOutcome: workers.WorkstationDispatchTerminalOutcomeFailed,
+		Result:          workers.WorkResult{Outcome: workers.OutcomeRejected},
+	})
+	if terminal.Cause == nil || terminal.Cause.Kind != workersessions.FailureCauseWorkersExecutionFailure {
+		t.Fatalf("terminal cause = %#v, want WORKERS_EXECUTION_FAILURE", terminal.Cause)
+	}
+}
+
+func TestClassifyTerminal_UnknownCompletionClassificationRemainsExecutionFailure(t *testing.T) {
+	terminal := classifyTerminal(nil, workers.WorkstationDispatchResult{Result: workers.WorkResult{
+		Outcome: workers.OutcomeFailed,
+		Diagnostics: &workers.WorkDiagnostics{Provider: &workers.ProviderDiagnostic{ResponseMetadata: map[string]string{
+			workers.ProviderResponseMetadataFailureOperation:      "completion_validation",
+			workers.ProviderResponseMetadataFailureClassification: "unrecognized_completion_fact",
+		}}},
+	}})
+	if terminal.Cause == nil || terminal.Cause.Kind != workersessions.FailureCauseWorkersExecutionFailure {
+		t.Fatalf("terminal cause = %#v, want WORKERS_EXECUTION_FAILURE", terminal.Cause)
+	}
+}
+
 func TestClassifyTerminal_SuccessWithFailedDispatchUsesExplicitFailureCause(t *testing.T) {
 	terminal := classifyTerminal(nil, workers.WorkstationDispatchResult{
 		TerminalOutcome: workers.WorkstationDispatchTerminalOutcomeFailed,

--- a/pkg/services/worker_sessions/internal/service/internal_test.go
+++ b/pkg/services/worker_sessions/internal/service/internal_test.go
@@ -862,6 +862,31 @@ func TestTerminalDraft_IncompleteOutputPreservesBoundedFailureKind(t *testing.T)
 	}
 }
 
+func TestClassifyTerminal_CleanRejectedWorkResultUsesBoundedRejectionCause(t *testing.T) {
+	terminal := classifyTerminal(nil, workers.WorkstationDispatchResult{
+		TerminalOutcome: workers.WorkstationDispatchTerminalOutcomeCompleted,
+		Result: workers.WorkResult{
+			Outcome:  workers.OutcomeRejected,
+			Feedback: "raw reviewer feedback remains on the Work result",
+		},
+	})
+	if terminal.Outcome != workersessions.TerminalOutcomeFailed || terminal.Cause == nil {
+		t.Fatalf("terminal = %#v, want failed Worker Session projection with cause", terminal)
+	}
+	if terminal.Cause.Kind != workersessions.FailureCauseRejected {
+		t.Fatalf("terminal cause kind = %q, want REJECTED", terminal.Cause.Kind)
+	}
+	if terminal.Cause.Detail != genericFailureDetail[workersessions.FailureCauseRejected] {
+		t.Fatalf("terminal cause detail = %q, want bounded generic rejection detail", terminal.Cause.Detail)
+	}
+	if strings.Contains(terminal.Cause.Detail, "raw reviewer feedback") {
+		t.Fatalf("terminal cause detail leaked reviewer feedback: %q", terminal.Cause.Detail)
+	}
+	if err := terminal.Validate(); err != nil {
+		t.Fatalf("terminal.Validate() = %v, want nil", err)
+	}
+}
+
 func TestClassifyTerminal_SuccessWithFailedDispatchUsesExplicitFailureCause(t *testing.T) {
 	terminal := classifyTerminal(nil, workers.WorkstationDispatchResult{
 		TerminalOutcome: workers.WorkstationDispatchTerminalOutcomeFailed,

--- a/pkg/services/worker_sessions/internal/service/internal_test.go
+++ b/pkg/services/worker_sessions/internal/service/internal_test.go
@@ -785,6 +785,83 @@ func TestClassifyTerminal_ProviderSessionInspectionFailureRetainsSafeCauseContex
 	}
 }
 
+func TestClassifyTerminal_IncompleteOutputUsesStructuredCompletionFacts(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		classification string
+		putInMetadata  bool
+	}{
+		{name: "missing completion evidence", classification: "missing_completion_evidence", putInMetadata: true},
+		{name: "missing required output", classification: "missing_required_output"},
+		{name: "contradictory completion", classification: "contradictory_completion"},
+	}
+	for _, test := range cases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			diagnostics := &workers.WorkDiagnostics{}
+			if test.putInMetadata {
+				diagnostics.Metadata = map[string]string{
+					"failure_operation":      "completion_validation",
+					"failure_classification": test.classification,
+				}
+			} else {
+				diagnostics.Provider = &workers.ProviderDiagnostic{
+					ResponseMetadata: map[string]string{
+						"failure_operation":      "completion_validation",
+						"failure_classification": test.classification,
+					},
+				}
+			}
+			terminal := classifyTerminal(nil, workers.WorkstationDispatchResult{Result: workers.WorkResult{
+				Outcome:     workers.OutcomeFailed,
+				Error:       "raw prompt=secret provider transcript must not be exposed",
+				Diagnostics: diagnostics,
+			}})
+
+			if terminal.Outcome != workersessions.TerminalOutcomeFailed || terminal.Cause == nil {
+				t.Fatalf("terminal = %#v, want failed result with cause", terminal)
+			}
+			if terminal.Cause.Kind != workersessions.FailureCauseIncompleteOutput {
+				t.Fatalf("terminal cause kind = %q, want INCOMPLETE_OUTPUT", terminal.Cause.Kind)
+			}
+			if strings.Contains(terminal.Cause.Detail, "secret") || !strings.Contains(terminal.Cause.Detail, "completion_validation") {
+				t.Fatalf("terminal cause detail = %q, want safe completion-validation context", terminal.Cause.Detail)
+			}
+			if err := terminal.Validate(); err != nil {
+				t.Fatalf("terminal.Validate() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestTerminalDraft_IncompleteOutputPreservesBoundedFailureKind(t *testing.T) {
+	draft, err := terminalDraft(
+		workersessions.StateFailed,
+		workersessions.TerminalResult{
+			Outcome: workersessions.TerminalOutcomeFailed,
+			Cause: &workersessions.FailureCause{
+				Kind:   workersessions.FailureCauseIncompleteOutput,
+				Detail: genericFailureDetail[workersessions.FailureCauseIncompleteOutput],
+			},
+		},
+		"dispatch-incomplete-output",
+	)
+	if err != nil {
+		t.Fatalf("terminalDraft() error = %v, want nil", err)
+	}
+	var payload terminalSessionPayload
+	if err := json.Unmarshal(draft.Payload, &payload); err != nil {
+		t.Fatalf("terminal payload decode error = %v", err)
+	}
+	if payload.FailureCause != string(workersessions.FailureCauseIncompleteOutput) {
+		t.Fatalf("terminal payload failureCause = %q, want INCOMPLETE_OUTPUT", payload.FailureCause)
+	}
+}
+
 func TestClassifyTerminal_SuccessWithFailedDispatchUsesExplicitFailureCause(t *testing.T) {
 	terminal := classifyTerminal(nil, workers.WorkstationDispatchResult{
 		TerminalOutcome: workers.WorkstationDispatchTerminalOutcomeFailed,

--- a/pkg/services/worker_sessions/terminal.go
+++ b/pkg/services/worker_sessions/terminal.go
@@ -54,6 +54,11 @@ const (
 	// boundary returned a WorkResult classified as failed for an ordinary
 	// business or system reason, with no executor-panic evidence.
 	FailureCauseWorkersExecutionFailure FailureCauseKind = "WORKERS_EXECUTION_FAILURE"
+	// FailureCauseRejected reports that Workers cleanly completed with the
+	// business-level rejection outcome. The Work result remains a normal
+	// rejection for Factory routing; this classification only describes the
+	// terminal Worker Session projection.
+	FailureCauseRejected FailureCauseKind = "REJECTED"
 	// FailureCauseIncompleteOutput reports that Workers completed a readable
 	// attempt but did not produce the required final output contract.
 	FailureCauseIncompleteOutput FailureCauseKind = "INCOMPLETE_OUTPUT"
@@ -73,10 +78,10 @@ const (
 	FailureCauseEventPublicationFailure FailureCauseKind = "EVENT_PUBLICATION_FAILURE"
 )
 
-// Valid reports whether k is one of the six bounded W2+W3 failure kinds.
+// Valid reports whether k is one of the seven bounded W2+W3 failure kinds.
 func (k FailureCauseKind) Valid() bool {
 	switch k {
-	case FailureCauseStartFailure, FailureCauseWorkersExecutionFailure, FailureCauseAdapterFailure,
+	case FailureCauseStartFailure, FailureCauseWorkersExecutionFailure, FailureCauseRejected, FailureCauseAdapterFailure,
 		FailureCauseIncompleteOutput, FailureCauseExecutorPanic, FailureCauseEventPublicationFailure:
 		return true
 	default:

--- a/pkg/services/worker_sessions/terminal.go
+++ b/pkg/services/worker_sessions/terminal.go
@@ -54,6 +54,9 @@ const (
 	// boundary returned a WorkResult classified as failed for an ordinary
 	// business or system reason, with no executor-panic evidence.
 	FailureCauseWorkersExecutionFailure FailureCauseKind = "WORKERS_EXECUTION_FAILURE"
+	// FailureCauseIncompleteOutput reports that Workers completed a readable
+	// attempt but did not produce the required final output contract.
+	FailureCauseIncompleteOutput FailureCauseKind = "INCOMPLETE_OUTPUT"
 	// FailureCauseAdapterFailure reports that the injected Workers boundary
 	// returned a failed WorkResult accompanied by a non-nil adapter error
 	// that is not executor-panic evidence.
@@ -70,11 +73,11 @@ const (
 	FailureCauseEventPublicationFailure FailureCauseKind = "EVENT_PUBLICATION_FAILURE"
 )
 
-// Valid reports whether k is one of the five bounded W2+W3 failure kinds.
+// Valid reports whether k is one of the six bounded W2+W3 failure kinds.
 func (k FailureCauseKind) Valid() bool {
 	switch k {
 	case FailureCauseStartFailure, FailureCauseWorkersExecutionFailure, FailureCauseAdapterFailure,
-		FailureCauseExecutorPanic, FailureCauseEventPublicationFailure:
+		FailureCauseIncompleteOutput, FailureCauseExecutorPanic, FailureCauseEventPublicationFailure:
 		return true
 	default:
 		return false
@@ -239,7 +242,7 @@ func (r TerminalResult) Validate() error {
 
 var (
 	// ErrInvalidFailureCause reports a FailureCause naming a value outside
-	// the four bounded W2 failure kinds.
+	// the bounded W2+W3 failure kinds.
 	ErrInvalidFailureCause = errors.New("worker session: invalid failure cause")
 	// ErrInvalidTerminalResult reports a TerminalResult, or a terminal
 	// Session, whose Outcome/Cause combination violates the terminal

--- a/pkg/services/worker_sessions/terminal_test.go
+++ b/pkg/services/worker_sessions/terminal_test.go
@@ -27,6 +27,7 @@ func TestFailureCauseKind_Valid(t *testing.T) {
 	valid := []workersessions.FailureCauseKind{
 		workersessions.FailureCauseStartFailure,
 		workersessions.FailureCauseWorkersExecutionFailure,
+		workersessions.FailureCauseRejected,
 		workersessions.FailureCauseIncompleteOutput,
 		workersessions.FailureCauseAdapterFailure,
 		workersessions.FailureCauseExecutorPanic,

--- a/pkg/services/worker_sessions/terminal_test.go
+++ b/pkg/services/worker_sessions/terminal_test.go
@@ -27,6 +27,7 @@ func TestFailureCauseKind_Valid(t *testing.T) {
 	valid := []workersessions.FailureCauseKind{
 		workersessions.FailureCauseStartFailure,
 		workersessions.FailureCauseWorkersExecutionFailure,
+		workersessions.FailureCauseIncompleteOutput,
 		workersessions.FailureCauseAdapterFailure,
 		workersessions.FailureCauseExecutorPanic,
 		workersessions.FailureCauseEventPublicationFailure,

--- a/pkg/services/worker_sessions/transports/cli/list_test.go
+++ b/pkg/services/worker_sessions/transports/cli/list_test.go
@@ -126,6 +126,56 @@ func TestListHumanRendersLabelsTokensDurationAndFailure(t *testing.T) {
 	}
 }
 
+func TestListPreservesDistinctBoundedFailureKindsInHumanAndJSON(t *testing.T) {
+	kinds := []string{"REJECTED", "INCOMPLETE_OUTPUT", "WORKERS_EXECUTION_FAILURE"}
+	observations := make([]factoryapi.WorkerSessionObservation, 0, len(kinds))
+	for _, kind := range kinds {
+		observations = append(observations, factoryapi.WorkerSessionObservation{
+			WorkerSessionId: "worker-session-" + kind,
+			AttemptId:       "attempt-" + kind,
+			WorkIds:         []string{"work-1"},
+			State:           factoryapi.WorkerSessionObservationState("FAILED"),
+			Failure:         &factoryapi.WorkerSessionFailure{Kind: kind, Detail: "safe bounded detail"},
+		})
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(factoryapi.ListWorkerSessionsResponse{Sessions: observations})
+	}))
+	defer server.Close()
+
+	var humanOutput bytes.Buffer
+	if err := NewList(testHTTPProtocol(t))(ListConfig{
+		Context: context.Background(), Server: server.URL, WorkID: "work-1", Output: &humanOutput,
+	}); err != nil {
+		t.Fatalf("human List() error = %v", err)
+	}
+	for _, kind := range kinds {
+		if !strings.Contains(humanOutput.String(), kind) {
+			t.Fatalf("human output %q missing failure kind %q", humanOutput.String(), kind)
+		}
+	}
+
+	var jsonOutput bytes.Buffer
+	if err := NewList(testHTTPProtocol(t))(ListConfig{
+		Context: context.Background(), Server: server.URL, WorkID: "work-1", OutputFormat: "json", Output: &jsonOutput,
+	}); err != nil {
+		t.Fatalf("JSON List() error = %v", err)
+	}
+	var document factoryapi.ListWorkerSessionsResponse
+	if err := json.Unmarshal(jsonOutput.Bytes(), &document); err != nil {
+		t.Fatalf("decode JSON output: %v; output=%q", err, jsonOutput.String())
+	}
+	if len(document.Sessions) != len(kinds) {
+		t.Fatalf("JSON session count = %d, want %d", len(document.Sessions), len(kinds))
+	}
+	for index, kind := range kinds {
+		if document.Sessions[index].Failure == nil || document.Sessions[index].Failure.Kind != kind {
+			t.Fatalf("JSON session %d failure = %#v, want %q", index, document.Sessions[index].Failure, kind)
+		}
+	}
+}
+
 func TestListHumanRendersKnownWorkWithoutSessions(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/services/worker_sessions/transports/cli/list_test.go
+++ b/pkg/services/worker_sessions/transports/cli/list_test.go
@@ -27,11 +27,12 @@ func TestListJSONUsesStableSessionDocumentAndNullOptionals(t *testing.T) {
 				WorkerSessionId: "worker-session-1", AttemptId: "attempt-1",
 				ProviderSessionAvailable: true,
 				ProviderSession:          &factoryapi.WorkerSessionProviderSessionRef{Provider: "codex", Kind: "session_id", Id: "provider-session-1"},
-				WorkIds:                  []string{"work-1"}, State: factoryapi.WorkerSessionObservationState("COMPLETED"),
+				WorkIds:                  []string{"work-1"}, State: factoryapi.WorkerSessionObservationState("FAILED"),
 				DurationBasis:  factoryapi.WorkerSessionObservationDurationBasis("RECORDED_TIMESTAMPS"),
 				Transcript:     factoryapi.WorkerSessionObservationTranscript("AVAILABLE"),
 				DurationMillis: int64Ptr(2500),
 				TokenUsage:     &factoryapi.ProviderSessionTokenUsage{TotalTokens: intPtr(17)},
+				Failure:        &factoryapi.WorkerSessionFailure{Kind: "INCOMPLETE_OUTPUT", Detail: "safe incomplete-output detail"},
 			},
 			{
 				WorkerSessionId: "worker-session-2", AttemptId: "attempt-2",
@@ -77,6 +78,9 @@ func TestListJSONUsesStableSessionDocumentAndNullOptionals(t *testing.T) {
 	}
 	if got := string(document.Sessions[0]["tokenUsage"]); !strings.Contains(got, `"totalTokens":17`) {
 		t.Fatalf("session 1 tokenUsage = %s, want totalTokens 17", got)
+	}
+	if got := string(document.Sessions[0]["failure"]); !strings.Contains(got, `"kind":"INCOMPLETE_OUTPUT"`) {
+		t.Fatalf("session 1 failure = %s, want INCOMPLETE_OUTPUT", got)
 	}
 }
 

--- a/pkg/services/worker_sessions/transports/http/handler_test.go
+++ b/pkg/services/worker_sessions/transports/http/handler_test.go
@@ -54,6 +54,60 @@ func TestListWorkerSessionsBySessionIDProjectsPopulatedObservation(t *testing.T)
 	assertPopulatedListResponse(t, recorder.Body.Bytes(), total)
 }
 
+func TestListWorkerSessionsBySessionIDPreservesBoundedFailureKinds(t *testing.T) {
+	kinds := []workersessions.FailureCauseKind{
+		workersessions.FailureCauseRejected,
+		workersessions.FailureCauseIncompleteOutput,
+		workersessions.FailureCauseWorkersExecutionFailure,
+	}
+	observations := make([]workersessions.Observation, 0, len(kinds))
+	for _, kind := range kinds {
+		observations = append(observations, workersessions.Observation{
+			WorkerSessionID: "worker-session-" + string(kind),
+			AttemptID:       "attempt-" + string(kind),
+			WorkIDs:         []string{"work-1"},
+			State:           workersessions.StateFailed,
+			DurationBasis:   workersessions.DurationBasisRecordedTimestamps,
+			Transcript:      workersessions.TranscriptAvailabilityUnavailable,
+			Failure:         &workersessions.FailureCause{Kind: kind, Detail: "safe bounded detail"},
+		})
+	}
+	service := &fakeObservationService{result: workersessions.ListObservationsResult{Observations: observations}}
+	handler := NewHandler(NewAdapter(service, workServiceStub{}), zap.NewNop())
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", "/factory-sessions/session-1/worker-sessions?workId=work-1", nil)
+
+	handler.ListWorkerSessionsBySessionId(
+		recorder,
+		request,
+		factoryapi.SessionID("session-1"),
+		factoryapi.ListWorkerSessionsBySessionIdParams{WorkId: "work-1"},
+	)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response factoryapi.ListWorkerSessionsResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Sessions) != len(kinds) {
+		t.Fatalf("session count = %d, want %d", len(response.Sessions), len(kinds))
+	}
+	gotKinds := make(map[string]bool, len(response.Sessions))
+	for _, session := range response.Sessions {
+		if session.Failure == nil {
+			t.Fatalf("session %q has no failure classification", session.WorkerSessionId)
+		}
+		gotKinds[session.Failure.Kind] = true
+	}
+	for _, kind := range kinds {
+		if !gotKinds[string(kind)] {
+			t.Fatalf("response failure kinds = %#v, missing %q", gotKinds, kind)
+		}
+	}
+}
+
 func assertPopulatedListResponse(t *testing.T, payload []byte, total int) {
 	t.Helper()
 	var response factoryapi.ListWorkerSessionsResponse

--- a/pkg/services/worker_sessions/transports/http/handler_test.go
+++ b/pkg/services/worker_sessions/transports/http/handler_test.go
@@ -190,7 +190,8 @@ func TestGetWorkerSessionObservationBySessionIDProjectsFailureDiagnostics(t *tes
 	total := 17
 	duration := int64(2500)
 	failure := &workersessions.FailureCause{
-		Kind: workersessions.FailureCauseWorkersExecutionFailure, Detail: "provider exited with status 1",
+		Kind:                 workersessions.FailureCauseIncompleteOutput,
+		Detail:               "the Workers result did not include the required final output",
 		AgentRunFailureClass: workers.AgentRunFailureClassProvider,
 		ProviderFailureKind:  providers.ExecuteFailureKindDependency,
 	}
@@ -241,7 +242,8 @@ func assertFailureObservationIdentity(t *testing.T, response factoryapi.WorkerSe
 
 func assertFailureObservationCause(t *testing.T, response factoryapi.WorkerSessionObservation) {
 	t.Helper()
-	if response.Failure == nil || response.Failure.Detail != "provider exited with status 1" || response.Failure.ProviderFailureKind == nil ||
+	if response.Failure == nil || response.Failure.Kind != string(workersessions.FailureCauseIncompleteOutput) ||
+		response.Failure.Detail != "the Workers result did not include the required final output" || response.Failure.ProviderFailureKind == nil ||
 		response.Failure.AgentRunFailureClass == nil || *response.Failure.AgentRunFailureClass != workers.AgentRunFailureClassProvider {
 		t.Fatalf("failure = %#v, want structured failure diagnostics", response.Failure)
 	}

--- a/pkg/services/workers/internal/diagnostics/codec.go
+++ b/pkg/services/workers/internal/diagnostics/codec.go
@@ -425,6 +425,7 @@ var safeFailureClassificationValues = map[string]struct{}{
 	"canceled":                    {},
 	"contradictory_completion":    {},
 	"missing_completion_evidence": {},
+	"missing_required_output":     {},
 	"parse":                       {},
 	"resource_limit":              {},
 	"storage":                     {},

--- a/pkg/services/workers/internal/diagnostics/safe_test.go
+++ b/pkg/services/workers/internal/diagnostics/safe_test.go
@@ -159,6 +159,33 @@ func TestSafeWorkDiagnosticsBoundsFailureMetadataAndKeepsCorrelation(t *testing.
 	}
 }
 
+func TestSafeWorkDiagnosticsPreservesIncompleteOutputClassification(t *testing.T) {
+	t.Parallel()
+
+	diagnostics := &WorkDiagnostics{Provider: &ProviderDiagnostic{ResponseMetadata: map[string]string{
+		"failure_operation":      "completion_validation",
+		"failure_classification": "missing_required_output",
+	}}}
+	safe := SafeWorkDiagnosticsFromWorkDiagnostics(diagnostics)
+	if safe == nil || safe.Provider == nil {
+		t.Fatalf("safe diagnostics = %#v, want provider diagnostics", safe)
+	}
+	if got := safe.Provider.ResponseMetadata["failure_classification"]; got != "missing_required_output" {
+		t.Fatalf("safe failure classification = %q, want missing_required_output", got)
+	}
+	payload, err := SafeWorkDiagnosticsEventPayload(safe)
+	if err != nil {
+		t.Fatalf("SafeWorkDiagnosticsEventPayload() error = %v", err)
+	}
+	replayed, err := WorkDiagnosticsFromSafeEventPayload(payload)
+	if err != nil {
+		t.Fatalf("WorkDiagnosticsFromSafeEventPayload() error = %v", err)
+	}
+	if replayed == nil || replayed.Provider == nil || replayed.Provider.ResponseMetadata["failure_classification"] != "missing_required_output" {
+		t.Fatalf("replayed diagnostics = %#v, want incomplete-output classification", replayed)
+	}
+}
+
 func TestWorkDiagnosticsFromSafeEventPayloadDecodesCamelCaseWireShape(t *testing.T) {
 	t.Parallel()
 	diagnostics, err := WorkDiagnosticsFromSafeEventPayload(json.RawMessage(`{

--- a/pkg/services/workers/internal/services/workstations/executor/agent.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agent.go
@@ -291,7 +291,7 @@ func decisionEnvelopeWorkResult(
 		resp.Content,
 	)
 	result.ProviderSession = workerexecution.CloneProviderSessionMetadata(resp.ProviderSession)
-	result.Diagnostics = diagnostics
+	result.Diagnostics = mergeWorkDiagnostics(diagnostics, result.Diagnostics)
 	result.Metrics = agentWorkMetrics(start, retryCount, clock)
 	return result
 }
@@ -312,7 +312,7 @@ func goalRoutingEnvelopeWorkResult(
 			resp.Content,
 		)
 	result.ProviderSession = workerexecution.CloneProviderSessionMetadata(resp.ProviderSession)
-	result.Diagnostics = diagnostics
+	result.Diagnostics = mergeWorkDiagnostics(diagnostics, result.Diagnostics)
 	result.Metrics = agentWorkMetrics(start, retryCount, clock)
 	return result
 }
@@ -404,7 +404,7 @@ func (ae *AgentExecutor) workResultForInferenceResponse(request workerexecution.
 				Error:           "structured output schema violation: " + parseErr.Error(),
 				FailureMetadata: structuredOutputSchemaViolationMetadata(),
 				ProviderSession: workerexecution.CloneProviderSessionMetadata(resp.ProviderSession),
-				Diagnostics:     diagnostics,
+				Diagnostics:     completionValidationDiagnostics(diagnostics, "missing_required_output"),
 				Metrics:         metrics,
 			}, nil
 		}

--- a/pkg/services/workers/internal/services/workstations/executor/agent_test.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agent_test.go
@@ -29,6 +29,65 @@ type agentMockProvider struct {
 
 type staticRuntimeConfig = runtimefixtures.RuntimeConfigLookupFixture
 
+type decisionEnvelopeExecutorFixture struct {
+	result workerexecution.WorkResult
+}
+
+func (decisionEnvelopeExecutorFixture) UsesDecisionEnvelopeOutcome(*workerconfig.FactoryWorkstationConfig) bool {
+	return true
+}
+
+func (decisionEnvelopeExecutorFixture) UsesGoalRoutingDecisionEnvelope(*workerconfig.FactoryWorkstationConfig) bool {
+	return false
+}
+
+func (fixture decisionEnvelopeExecutorFixture) WorkResultFromDecisionEnvelopeJSONOrFailed(string, string, string) workerexecution.WorkResult {
+	return fixture.result
+}
+
+func (decisionEnvelopeExecutorFixture) WorkResultFromGoalRoutingDecisionEnvelopeJSONOrFailed(string, string, string) workerexecution.WorkResult {
+	return workerexecution.WorkResult{}
+}
+
+func TestDecisionEnvelopeWorkResultMergesCompletionValidationDiagnostics(t *testing.T) {
+	base := &workerexecution.WorkDiagnostics{Provider: &workerexecution.ProviderDiagnostic{
+		ResponseMetadata: map[string]string{
+			workerexecution.ProviderResponseMetadataFailureOperation: "provider_inference",
+		},
+	}}
+	parsed := workerexecution.WorkResult{
+		Outcome: workerexecution.OutcomeFailed,
+		Diagnostics: &workerexecution.WorkDiagnostics{Provider: &workerexecution.ProviderDiagnostic{
+			ResponseMetadata: map[string]string{
+				workerexecution.ProviderResponseMetadataFailureOperation:      "completion_validation",
+				workerexecution.ProviderResponseMetadataFailureClassification: "missing_required_output",
+			},
+		}},
+	}
+
+	result := decisionEnvelopeWorkResult(
+		decisionEnvelopeExecutorFixture{result: parsed},
+		workerexecution.WorkstationExecutionRequest{Dispatch: work.WorkDispatch{
+			DispatchID:   "dispatch-incomplete",
+			TransitionID: "transition-review",
+		}},
+		workerexecution.InferenceResponse{Content: "<COMPLETE>"},
+		base,
+		0,
+		time.Now(),
+		time.Now,
+	)
+
+	if result.Diagnostics == nil || result.Diagnostics.Provider == nil {
+		t.Fatalf("Diagnostics = %#v, want merged diagnostics", result.Diagnostics)
+	}
+	metadata := result.Diagnostics.Provider.ResponseMetadata
+	if metadata[workerexecution.ProviderResponseMetadataFailureOperation] != "completion_validation" ||
+		metadata[workerexecution.ProviderResponseMetadataFailureClassification] != "missing_required_output" {
+		t.Fatalf("completion diagnostics = %#v, want parser facts preserved over base diagnostics", metadata)
+	}
+}
+
 func TestAgentExecutor_UsesInjectedClockForWorkMetrics(t *testing.T) {
 	times := []time.Time{
 		time.Date(2026, time.July, 20, 12, 0, 0, 0, time.UTC),

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/executor.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/executor.go
@@ -129,7 +129,7 @@ func (executor *AgentRunExecutor) Execute(ctx context.Context, request workerexe
 				request.Dispatch.TransitionID,
 				harnessResult.FinalText,
 			)
-		result.Diagnostics = agentRunDiagnostics(toolMetadata)
+		result.Diagnostics = mergeAgentRunDiagnostics(agentRunDiagnostics(toolMetadata), result.Diagnostics)
 		duration := executor.clockNow().Sub(start)
 		result.Metrics = workerexecution.WorkMetrics{Duration: duration}
 		executor.recordAgentRunResponse(request.Dispatch, result, duration, harnessResult.Messages)
@@ -144,7 +144,7 @@ func (executor *AgentRunExecutor) Execute(ctx context.Context, request workerexe
 				request.Dispatch.TransitionID,
 				harnessResult.FinalText,
 			)
-		result.Diagnostics = agentRunDiagnostics(toolMetadata)
+		result.Diagnostics = mergeAgentRunDiagnostics(agentRunDiagnostics(toolMetadata), result.Diagnostics)
 		duration := executor.clockNow().Sub(start)
 		result.Metrics = workerexecution.WorkMetrics{Duration: duration}
 		executor.recordAgentRunResponse(request.Dispatch, result, duration, harnessResult.Messages)

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/failure.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/failure.go
@@ -45,6 +45,44 @@ func agentRunDiagnostics(extra map[string]string) *workerexecution.WorkDiagnosti
 	return &workerexecution.WorkDiagnostics{Metadata: metadata}
 }
 
+// mergeAgentRunDiagnostics keeps the agent-run execution facts while
+// preserving structured result diagnostics emitted by an output validator.
+// In particular, decision-envelope validation facts must survive the
+// agent-run projection so Worker Sessions can classify a clean incomplete
+// response without inspecting the transcript.
+func mergeAgentRunDiagnostics(base, overlay *workerexecution.WorkDiagnostics) *workerexecution.WorkDiagnostics {
+	if base == nil {
+		return workerexecution.CloneWorkDiagnostics(overlay)
+	}
+	merged := workerexecution.CloneWorkDiagnostics(base)
+	if overlay == nil {
+		return merged
+	}
+	overlay = workerexecution.CloneWorkDiagnostics(overlay)
+	if overlay.RenderedPrompt != nil {
+		merged.RenderedPrompt = overlay.RenderedPrompt
+	}
+	if overlay.Provider != nil {
+		merged.Provider = overlay.Provider
+	}
+	if overlay.Invocation != nil {
+		merged.Invocation = overlay.Invocation
+	}
+	if overlay.Command != nil {
+		merged.Command = overlay.Command
+	}
+	if overlay.Panic != nil {
+		merged.Panic = overlay.Panic
+	}
+	for key, value := range overlay.Metadata {
+		if merged.Metadata == nil {
+			merged.Metadata = make(map[string]string)
+		}
+		merged.Metadata[key] = value
+	}
+	return merged
+}
+
 func failureClassForError(err error) string {
 	if err == nil {
 		return ""

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/failure_test.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/failure_test.go
@@ -17,6 +17,27 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/work"
 )
 
+func TestMergeAgentRunDiagnosticsPreservesCompletionValidationFacts(t *testing.T) {
+	t.Parallel()
+
+	merged := mergeAgentRunDiagnostics(
+		agentRunDiagnostics(map[string]string{"tool_call_count": "1"}),
+		&workerexecution.WorkDiagnostics{Provider: &workerexecution.ProviderDiagnostic{
+			ResponseMetadata: map[string]string{
+				workerexecution.ProviderResponseMetadataFailureOperation:      "completion_validation",
+				workerexecution.ProviderResponseMetadataFailureClassification: "missing_required_output",
+			},
+		}},
+	)
+	if merged == nil || merged.Metadata["execution_behavior"] != "agent_run" || merged.Metadata["tool_call_count"] != "1" {
+		t.Fatalf("merged agent-run diagnostics = %#v, want agent-run metadata", merged)
+	}
+	if merged.Provider == nil || merged.Provider.ResponseMetadata[workerexecution.ProviderResponseMetadataFailureOperation] != "completion_validation" ||
+		merged.Provider.ResponseMetadata[workerexecution.ProviderResponseMetadataFailureClassification] != "missing_required_output" {
+		t.Fatalf("merged completion diagnostics = %#v, want completion-validation facts", merged)
+	}
+}
+
 func TestFailureClassForError_ModelhostLeaseDenied(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/workers/internal/services/workstations/executor/diagnostics.go
+++ b/pkg/services/workers/internal/services/workstations/executor/diagnostics.go
@@ -105,6 +105,26 @@ func completionValidationDiagnostics(base *workerexecution.WorkDiagnostics, clas
 	return diagnostics
 }
 
+func validateWorkstationCompletion(
+	request workerexecution.WorkstationExecutionRequest,
+	result workerexecution.WorkResult,
+) workerexecution.WorkResult {
+	if result.Outcome == workerexecution.OutcomeFailed && result.FailureMetadata != nil &&
+		result.FailureMetadata.Type == workerexecution.WorkFailureTypeStructuredOutputSchemaViolation {
+		result.Diagnostics = completionValidationDiagnostics(result.Diagnostics, "missing_required_output")
+	}
+	if result.Outcome != workerexecution.OutcomeAccepted || request.OutputContract == "" {
+		return result
+	}
+	if contractErr := validateOutputContract(result.Output, request.OutputContract); contractErr != nil {
+		result.Outcome = workerexecution.OutcomeFailed
+		result.Error = "output contract failed: " + contractErr.Error()
+		result.FailureMetadata = structuredOutputFailureMetadata()
+		result.Diagnostics = completionValidationDiagnostics(result.Diagnostics, "missing_required_output")
+	}
+	return result
+}
+
 func setSafeFailureMetadata(diagnostics *workerexecution.WorkDiagnostics, err error) {
 	if diagnostics == nil || diagnostics.Provider == nil {
 		return

--- a/pkg/services/workers/internal/services/workstations/executor/workstation_executor.go
+++ b/pkg/services/workers/internal/services/workstations/executor/workstation_executor.go
@@ -754,18 +754,7 @@ func (we *WorkstationExecutor) executeInnerWorker(ctx context.Context, request w
 		}, nil
 	}
 	result = attachStructuredResult(request, result)
-	if result.Outcome == workerexecution.OutcomeFailed && result.FailureMetadata != nil &&
-		result.FailureMetadata.Type == workerexecution.WorkFailureTypeStructuredOutputSchemaViolation {
-		result.Diagnostics = completionValidationDiagnostics(result.Diagnostics, "missing_required_output")
-	}
-	if result.Outcome == workerexecution.OutcomeAccepted && request.OutputContract != "" {
-		if contractErr := validateOutputContract(result.Output, request.OutputContract); contractErr != nil {
-			result.Outcome = workerexecution.OutcomeFailed
-			result.Error = "output contract failed: " + contractErr.Error()
-			result.FailureMetadata = structuredOutputFailureMetadata()
-			result.Diagnostics = completionValidationDiagnostics(result.Diagnostics, "missing_required_output")
-		}
-	}
+	result = validateWorkstationCompletion(request, result)
 
 	logger.Info("workstation: executor result",
 		WorkLogFields(request.Dispatch.Execution,

--- a/pkg/services/workers/internal/services/workstations/executor/workstation_executor.go
+++ b/pkg/services/workers/internal/services/workstations/executor/workstation_executor.go
@@ -754,11 +754,16 @@ func (we *WorkstationExecutor) executeInnerWorker(ctx context.Context, request w
 		}, nil
 	}
 	result = attachStructuredResult(request, result)
+	if result.Outcome == workerexecution.OutcomeFailed && result.FailureMetadata != nil &&
+		result.FailureMetadata.Type == workerexecution.WorkFailureTypeStructuredOutputSchemaViolation {
+		result.Diagnostics = completionValidationDiagnostics(result.Diagnostics, "missing_required_output")
+	}
 	if result.Outcome == workerexecution.OutcomeAccepted && request.OutputContract != "" {
 		if contractErr := validateOutputContract(result.Output, request.OutputContract); contractErr != nil {
 			result.Outcome = workerexecution.OutcomeFailed
 			result.Error = "output contract failed: " + contractErr.Error()
 			result.FailureMetadata = structuredOutputFailureMetadata()
+			result.Diagnostics = completionValidationDiagnostics(result.Diagnostics, "missing_required_output")
 		}
 	}
 

--- a/tests/functional/factory/packaged/review/helpers_test.go
+++ b/tests/functional/factory/packaged/review/helpers_test.go
@@ -128,6 +128,41 @@ func setPackagedReviewWorkerModel(t *testing.T, factoryDir, model string) {
 	}
 }
 
+func configurePackagedReviewRejectionClassification(t *testing.T, factoryDir string) {
+	t.Helper()
+
+	path := filepath.Join(factoryDir, "factory.json")
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read materialized factory: %v", err)
+	}
+	var factory map[string]any
+	if err := json.Unmarshal(payload, &factory); err != nil {
+		t.Fatalf("decode materialized factory: %v", err)
+	}
+	workstations, ok := factory["workstations"].([]any)
+	if !ok {
+		t.Fatal("materialized factory workstations are not an array")
+	}
+	for _, raw := range workstations {
+		workstation, ok := raw.(map[string]any)
+		if !ok || workstation["name"] != "review-review-work" {
+			continue
+		}
+		workstation["stopWords"] = []any{"COMPLETE"}
+		workstation["limits"] = map[string]any{"maxRetries": float64(3)}
+		updated, err := json.Marshal(factory)
+		if err != nil {
+			t.Fatalf("encode materialized factory: %v", err)
+		}
+		if err := os.WriteFile(path, updated, 0o644); err != nil {
+			t.Fatalf("write materialized factory: %v", err)
+		}
+		return
+	}
+	t.Fatal("materialized factory does not contain review-review-work workstation")
+}
+
 func assertPackagedReviewProviderInvocations(
 	t *testing.T,
 	requests []platformprocess.CommandRequest,

--- a/tests/functional/factory/packaged/review/invocation_test.go
+++ b/tests/functional/factory/packaged/review/invocation_test.go
@@ -66,6 +66,45 @@ func TestPackagedReviewRejectionCarriesFeedback(t *testing.T) {
 	}
 }
 
+// TestPackagedReviewThreeCleanRejectionsDoNotTripFailureBreaker proves that
+// explicit, cleanly exited reviewer decisions remain on the authored
+// rejection route even when legacy stop words and a consecutive-failure limit
+// are present on the materialized workstation configuration.
+func TestPackagedReviewThreeCleanRejectionsDoNotTripFailureBreaker(t *testing.T) {
+	runner := support.NewShapedProviderCommandRunner(
+		platformprocess.CommandResult{Stdout: []byte("first candidate")},
+		platformprocess.CommandResult{Stdout: []byte(`{"decision":"REJECTED","feedback":"add the release date"}`)},
+		platformprocess.CommandResult{Stdout: []byte("second candidate")},
+		platformprocess.CommandResult{Stdout: []byte(`{"decision":"REJECTED","feedback":"add the owner"}`)},
+		platformprocess.CommandResult{Stdout: []byte("third candidate")},
+		platformprocess.CommandResult{Stdout: []byte(`{"decision":"REJECTED","feedback":"add the rollback plan"}`)},
+		platformprocess.CommandResult{Stdout: []byte("fourth candidate")},
+		platformprocess.CommandResult{Stdout: []byte(`{"decision":"ACCEPTED","output":"approved fourth candidate"}`)},
+	)
+
+	response := runPackagedReviewCLIJSONInvocationWithFactorySetup(
+		t,
+		runner,
+		configurePackagedReviewRejectionClassification,
+		"write the release notes",
+	)
+	assertPackagedReviewCompletedWithText(t, response, "approved fourth candidate")
+	if got := runner.CallCount(); got != 8 {
+		t.Fatalf("provider invocation count = %d, want four work/review round trips", got)
+	}
+
+	requests := runner.Requests()
+	for index, wantFeedback := range map[int]string{
+		2: "add the release date",
+		4: "add the owner",
+		6: "add the rollback plan",
+	} {
+		if prompt := providerCommandPrompt(requests[index]); !strings.Contains(prompt, wantFeedback) {
+			t.Fatalf("work prompt %d = %q, want reviewer feedback %q", index, prompt, wantFeedback)
+		}
+	}
+}
+
 // TestPackagedReviewRejectionHonorsMaterializedAndFlaggedProviderSettings proves
 // packaged @you/review rejection-then-approval through the public CLI honors
 // materialized worker model configuration and default worker model provider

--- a/tests/functional/workflow/config_driven_retry_loop_breaker_test.go
+++ b/tests/functional/workflow/config_driven_retry_loop_breaker_test.go
@@ -5,11 +5,79 @@ import (
 	"time"
 
 	"github.com/portpowered/infinite-you/internal/testutil"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
 	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
+
+func TestConfigDrivenRetryLoopBreaker_TripsAfterThreeProcessFailures(t *testing.T) {
+	dir := support.ScaffoldFactory(t, map[string]any{
+		"name": "process_failure_breaker",
+		"workTypes": []any{map[string]any{
+			"name": "task",
+			"states": []any{
+				map[string]any{"name": "init", "type": "INITIAL"},
+				map[string]any{"name": "complete", "type": "TERMINAL"},
+				map[string]any{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []any{map[string]any{"name": "processor"}},
+		"workstations": []map[string]any{{
+			"name":   "process",
+			"worker": "processor",
+			"inputs": []any{map[string]any{"workType": "task", "state": "init"}},
+			"outputs": []any{map[string]any{
+				"workType": "task",
+				"state":    "complete",
+			}},
+			"onFailure": []any{map[string]any{
+				"workType": "task",
+				"state":    "init",
+			}},
+			"limits": map[string]any{"maxRetries": 3},
+		}},
+	})
+	testutil.WriteSeedFile(t, dir, "task", []byte(`{"title":"process failure breaker"}`))
+	support.WriteAgentConfig(t, dir, "processor", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "test-model"))
+
+	runner := support.NewShapedProviderCommandRunner(
+		platformprocess.CommandResult{ExitCode: 1, Stderr: []byte("first process failed")},
+		platformprocess.CommandResult{ExitCode: 1, Stderr: []byte("second process failed")},
+		platformprocess.CommandResult{ExitCode: 1, Stderr: []byte("third process failed")},
+	)
+	_, listed, events := support.RunFactoryToCompletionWithEdgesAndObservations(
+		t,
+		dir,
+		serviceedges.Edges{ProviderCommandRunner: runner},
+		15*time.Second,
+	)
+
+	assertWorkflowSessionPlaces(t, listed, map[string]int{
+		"task:failed":   1,
+		"task:init":     0,
+		"task:complete": 0,
+	})
+	if got := runner.CallCount(); got != 3 {
+		t.Fatalf("provider command calls = %d, want three consecutive process failures", got)
+	}
+
+	observations := support.ObserveDispatchEvents(t, events)
+	processFailures := 0
+	for _, observation := range observations {
+		if observation.Request.TransitionId == "process" && observation.Response != nil {
+			if observation.Response.Outcome != factoryapi.WorkOutcomeFailed {
+				t.Errorf("process response outcome = %q, want FAILED", observation.Response.Outcome)
+			}
+			processFailures++
+		}
+	}
+	if processFailures != 3 {
+		t.Fatalf("failed process dispatches = %d, want three counted failures", processFailures)
+	}
+}
 
 func TestConfigDrivenRetryLoopBreaker_TerminatesAfterMaxRetries(t *testing.T) {
 	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "retry_exhaustion"))


### PR DESCRIPTION
{
  "project": "Engine Review Rejection and Incomplete-Output Classification",
  "branchName": "engine-review-rejection-classification",
  "description": "Separate legitimate clean-exit reviewer changes requests, incomplete clean-exit final output, and real process or transcript failures across Factory Runtime and Worker Sessions. Route REJECTED normally without breaker counting, surface missing required output as INCOMPLETE_OUTPUT, reserve WORKERS_EXECUTION_FAILURE for execution failures, preserve breaker protection for counted failures, and make you worker-sessions list distinguish all three cases.",
  "context": {
    "customerAsk": "Own the transitioner outcome-classification and circuit-breaker counting path plus Worker Sessions failure-kind surfacing. Prove that three consecutive clean-exit review rejections stay on the rejection route without failing Work, three consecutive process failures still trip the breaker, a bare stop token with missing required payload surfaces as INCOMPLETE_OUTPUT, and you worker-sessions list distinguishes all three classifications. Do not change workstation prompts, Factory guards, provider adapters, review maxVisits, or genuine-failure REPEATER behavior.",
    "problem": "Operator evidence from 2026-08-11 and 2026-08-12 found that valid clean-exit reviewer rejections, readable clean-exit output containing only a stop token without the expected structured payload, and real process kills could all surface as WORKERS_EXECUTION_FAILURE. Three legitimate changes-requested verdicts could therefore amplify into task:failed through the consecutive-failure breaker, while operators had to inspect transcripts to distinguish an ordinary business result, an output-contract failure, and an infrastructure failure.",
    "solution": "Classify each attempt from explicit structured facts before transition routing and history accounting. A clean-exit explicit reviewer verdict remains the REJECTED Work outcome and session result classification and does not count toward the breaker. A readable clean-exit response missing the required stop-token or structured payload becomes FAILED with INCOMPLETE_OUTPUT and counts. Non-zero exit, external or timeout kill, and malformed or unreadable transcript remain FAILED with WORKERS_EXECUTION_FAILURE and count. Preserve these bounded classifications through Worker Sessions events, replay, HTTP mapping, and CLI human and JSON list output without reopening raw transcripts."
  },
  "acceptanceCriteria": [
    "A functional test drives three consecutive clean-exit explicit reviewer REJECTED verdicts and proves the Work item is not failed, each result follows the authored rejection route, and the transition's consecutive-failure count does not reach the breaker threshold.",
    "A readable clean-exit final message containing only the configured stop token, without the required structured payload, produces a failed attempt classified as INCOMPLETE_OUTPUT and is visible with that classification in Worker Sessions list output.",
    "Three consecutive process-level failures, including a representative non-zero exit or external or timeout kill, still increment transition failure history and trip the configured consecutive-failure circuit breaker.",
    "you worker-sessions list presents REJECTED, INCOMPLETE_OUTPUT, and WORKERS_EXECUTION_FAILURE as distinct bounded values in the FAILURE column, and machine-readable output preserves the same classification without unsafe raw content.",
    "Review maxVisits semantics and genuine-failure REPEATER behavior remain unchanged; workstation prompts, Factory guard definitions, provider adapters, and unrelated classification or retry paths are not modified.",
    "Quality gate: typecheck and focused tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Root prd.json and progress.txt do not appear in the PR diff.",
    "Delivery: the implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are resolved against current main, and the PR is actually merged; an opened, green, approved, or merge-ready PR is not complete."
  ],
  "userStories": [
    {
      "id": "engine-review-rejection-classification-001",
      "title": "Preserve clean review rejection as a normal result",
      "description": "As a Factory operator, I want a reviewer that cleanly requests changes to produce a rejection result rather than an execution failure so valid review feedback cannot trip the failure breaker.",
      "acceptanceCriteria": [
        "A review attempt that exits with code zero and yields an explicit valid REJECTED verdict is classified as the bounded REJECTED result, not WORKERS_EXECUTION_FAILURE, regardless of substantive feedback or an empty optional output field.",
        "The token follows the workstation's existing rejection route and retains the reviewer feedback needed by the next review round-trip.",
        "Three consecutive clean-exit REJECTED verdicts for the same review transition do not fail the Work item and do not increment that transition's consecutive-failure breaker count.",
        "A functional regression enters through root.BuildProcess and Process.Execute, uses the command-runner edge to supply three deterministic reviewer responses, and observes the rejection route and non-failed Work state without fixed sleeps.",
        "Accepted and continue results retain their existing routes and failure-count reset behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "engine-review-rejection-classification-002",
      "title": "Surface incomplete clean-exit output distinctly",
      "description": "As an operator, I want a cleanly exited worker that stops without the required final payload to report INCOMPLETE_OUTPUT so I can distinguish an output-contract failure from an infrastructure failure.",
      "acceptanceCriteria": [
        "A readable clean-exit final message containing a configured bare stop token but missing the required structured payload is a failed Work result with bounded classification INCOMPLETE_OUTPUT, not REJECTED or WORKERS_EXECUTION_FAILURE.",
        "Equivalent readable clean-exit completion-validation cases that lack the required stop-token or payload structure use the same INCOMPLETE_OUTPUT classification; raw prompt, transcript, command, credential, or provider text is not copied into the public detail.",
        "INCOMPLETE_OUTPUT contributes to the review transition's consecutive-failure count and retains the existing genuine-failure routing and retry policy.",
        "The Worker Session observation, terminal event, HTTP representation, and JSON list output preserve INCOMPLETE_OUTPUT as one bounded classification through replay and projection.",
        "Focused Workers, Worker Sessions, mapping or contract, and runtime history tests prove the classification and counting behavior from structured completion diagnostics rather than transcript-text heuristics.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Structured completion-validation facts now classify failed clean exits as INCOMPLETE_OUTPUT through Worker Sessions, history, replay, HTTP, and CLI projections."
    },
    {
      "id": "engine-review-rejection-classification-003",
      "title": "Keep real execution failures breaker-counted",
      "description": "As an operator, I want real process and transcript failures to remain breaker-counted execution failures so a broken review worker cannot loop indefinitely.",
      "acceptanceCriteria": [
        "Non-zero process exit, external process kill, timeout force-kill, and malformed or unreadable transcript cases on the owned path are classified as WORKERS_EXECUTION_FAILURE, while existing more specific non-target failure kinds remain unchanged.",
        "Each WORKERS_EXECUTION_FAILURE increments the affected transition's consecutive-failure history according to existing retry semantics.",
        "A functional regression drives three consecutive deterministic process-level failures and proves the configured breaker fires and the Work item reaches its existing failed outcome.",
        "A later successful, continue, or valid rejected result resets or clears consecutive failure history according to its normal outcome, without changing total review round-trip accounting.",
        "The process-failure functional test uses the command-runner edge and observable events or Work state, with bounded deadlines only as hang guards and no provider-adapter changes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added a root-built functional regression using the ProviderCommandRunner edge: three non-zero process exits increment failure history, trip maxRetries, leave task:failed, and produce no fourth process call."
    },
    {
      "id": "engine-review-rejection-classification-004",
      "title": "Distinguish review outcomes in Worker Sessions list",
      "description": "As an operator, I want the Worker Sessions list to show the bounded review result classification so I can triage a changes request, incomplete output, or infrastructure failure without opening transcripts.",
      "acceptanceCriteria": [
        "Human-readable you worker-sessions list renders REJECTED, INCOMPLETE_OUTPUT, and WORKERS_EXECUTION_FAILURE distinctly in the FAILURE column for representative recorded sessions.",
        "JSON output exposes the same bounded classification for each representative session and retains stable null or empty behavior for sessions without a classification.",
        "List loading errors retain the existing typed CLI error behavior, an empty result still prints the existing empty state, and successful mixed results keep one row per Worker Session.",
        "CLI and HTTP contract tests prove the three values without inspecting transcript files or asserting command or route registration inventories.",
        "The presentation remains readable in terminal widths supported by the existing table renderer, and no browser-visible dashboard behavior is introduced.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Added bounded REJECTED Worker Session classification for live and recorded projections, with mixed HTTP and human/JSON CLI coverage preserving distinct values and stable empty/error behavior."
    }
  ]
}
