### PR TITLE
wsr-008-legacy-compat

### DIFF
--- a/pkg/services/factory_sessions/contracts.go
+++ b/pkg/services/factory_sessions/contracts.go
@@ -10,6 +10,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/models"
 	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	workersessions "github.com/portpowered/infinite-you/pkg/services/worker_sessions"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
@@ -136,12 +137,15 @@ type RuntimeHTTPServices struct {
 // artifact, result, and ordered-event facts as the ordinary inspection
 // surfaces while making its read-only and redaction boundaries explicit.
 type HistoricalReplayInspection struct {
-	Session    SessionReadResult
-	Events     EventReadResult
-	Artifacts  ListArtifactsResult
-	Result     ResultReadResult
-	Checkpoint *HistoricalReplayCheckpoint
-	Redaction  HistoricalReplayRedaction
+	Session   SessionReadResult
+	Events    EventReadResult
+	Artifacts ListArtifactsResult
+	Result    ResultReadResult
+	// WorkerHistory is derived from the recording schema. Legacy recordings
+	// report an explicit unavailable outcome instead of an empty history.
+	WorkerHistory recordings.PortableRecordingWorkerHistory
+	Checkpoint    *HistoricalReplayCheckpoint
+	Redaction     HistoricalReplayRedaction
 }
 
 // HistoricalReplayCheckpoint is the public checkpoint summary available from

--- a/pkg/services/factory_sessions/internal/execution/javascript_runtime_validation_test.go
+++ b/pkg/services/factory_sessions/internal/execution/javascript_runtime_validation_test.go
@@ -1,12 +1,14 @@
 package factorysessionexecution
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"github.com/portpowered/infinite-you/internal/testutil/factoryruntimefixtures"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factory "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
 	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
 	"os"
 	"path/filepath"
@@ -881,6 +883,7 @@ func TestJavaScriptRuntimeServiceWriteRecordingUsesCanonicalSnapshotAndCorrelate
 	if strings.Contains(string(encoded), "checkpoint-secret") || strings.Contains(string(encoded), "raw-state") {
 		t.Fatalf("recording leaked runtime state: %s", encoded)
 	}
+	assertCurrentPortableRecordingExport(t, encoded)
 	badPath := filepath.Join(t.TempDir(), "missing", "\x00invalid")
 	err = service.WriteRecording(context.Background(), sessionID, badPath)
 	var recordingErr *RecordingError
@@ -890,5 +893,21 @@ func TestJavaScriptRuntimeServiceWriteRecordingUsesCanonicalSnapshotAndCorrelate
 	read, readErr := service.GetSession(context.Background(), sessionID)
 	if readErr != nil || read.Status != LifecycleStatusSucceeded {
 		t.Fatalf("live session changed after recording failure: read=%#v err=%v", read, readErr)
+	}
+}
+
+func assertCurrentPortableRecordingExport(t *testing.T, encoded []byte) {
+	t.Helper()
+	portable, err := recordings.DecodePortableRecording(bytes.NewReader(encoded))
+	if err != nil {
+		t.Fatalf("DecodePortableRecording: %v", err)
+	}
+	if portable.SchemaVersion != recordings.PortableRecordingSchemaV3 ||
+		portable.ReplayCompatibilityVersion != recordings.PortableRecordingReplayCompatibilityV1 {
+		t.Fatalf("recording compatibility = %q/%q, want current schema/replay versions", portable.SchemaVersion, portable.ReplayCompatibilityVersion)
+	}
+	if portable.WorkerHistory == nil || portable.WorkerHistory.Availability != recordings.PortableRecordingWorkerHistoryUnavailable ||
+		portable.WorkerHistory.Reason != recordings.PortableRecordingWorkerHistoryReasonNotCaptured {
+		t.Fatalf("recording Worker history = %#v, want explicit unavailable outcome", portable.WorkerHistory)
 	}
 }

--- a/pkg/services/factory_sessions/internal/execution/recordingreplay/replay.go
+++ b/pkg/services/factory_sessions/internal/execution/recordingreplay/replay.go
@@ -13,12 +13,13 @@ import (
 // RecordingReplayProjection is the complete public inspection surface restored
 // from a portable recording. It intentionally has no live execution controls.
 type RecordingReplayProjection struct {
-	Session    fse.SessionReadResult
-	Events     fse.EventReadResult
-	Artifacts  fse.ListArtifactsResult
-	Result     fse.ResultReadResult
-	Checkpoint *CheckpointReadModel
-	Redaction  recording.PortableRecordingRedactionMetadata
+	Session       fse.SessionReadResult
+	Events        fse.EventReadResult
+	Artifacts     fse.ListArtifactsResult
+	Result        fse.ResultReadResult
+	WorkerHistory recording.PortableRecordingWorkerHistory
+	Checkpoint    *CheckpointReadModel
+	Redaction     recording.PortableRecordingRedactionMetadata
 }
 
 type CheckpointReadModel struct {
@@ -42,12 +43,6 @@ func ReplayRecording(value recording.PortableRecording) (RecordingReplayProjecti
 	if err := recording.ValidatePortableRecording(value); err != nil {
 		return RecordingReplayProjection{}, err
 	}
-	if value.Result == nil {
-		return RecordingReplayProjection{}, &recording.PortableRecordingDiagnostic{
-			Code: recording.PortableRecordingCodeInvalidSummary, Area: "result", Path: "result",
-			Message: "recording has no referenced public result data; migrate or re-record the session",
-		}
-	}
 
 	artifacts := replayArtifactSummaries(value.Artifacts)
 	result := replayResultProjection(value, artifacts)
@@ -57,12 +52,13 @@ func ReplayRecording(value recording.PortableRecording) (RecordingReplayProjecti
 		return RecordingReplayProjection{}, err
 	}
 	return RecordingReplayProjection{
-		Session:    session,
-		Events:     fse.EventReadResult{SessionID: value.Session.ID, Events: events},
-		Artifacts:  fse.ListArtifactsResult{SessionID: value.Session.ID, Artifacts: artifacts},
-		Result:     result,
-		Checkpoint: replayCheckpoint(value.Checkpoint),
-		Redaction:  value.Redaction,
+		Session:       session,
+		Events:        fse.EventReadResult{SessionID: value.Session.ID, Events: events},
+		Artifacts:     fse.ListArtifactsResult{SessionID: value.Session.ID, Artifacts: artifacts},
+		Result:        result,
+		WorkerHistory: recording.NormalizePortableRecordingWorkerHistory(value),
+		Checkpoint:    replayCheckpoint(value.Checkpoint),
+		Redaction:     value.Redaction,
 	}, nil
 }
 
@@ -79,8 +75,11 @@ func replaySessionRead(value recording.PortableRecording, result fse.ResultReadR
 		SessionID: value.Session.ID, Status: status, OrchestratorKind: value.Session.OrchestratorKind,
 		ResolvedSource: fse.ResolvedSource{SourceRef: value.Source.Ref, SourceHash: value.Source.Hash},
 		SourceHash:     value.Source.Hash, Policy: fse.PolicyProjection{EffectiveHash: value.PolicyHash},
-		Usage: fse.EmptySessionUsage(), ResultSummary: &fse.ResultSummary{ResultStatus: string(result.ResultStatus)},
+		Usage:        fse.EmptySessionUsage(),
 		ArtifactRefs: refs, ArtifactCount: len(refs), Links: fse.InspectionLinksForSession(value.Session.ID, true),
+	}
+	if value.Result != nil {
+		session.ResultSummary = &fse.ResultSummary{ResultStatus: string(result.ResultStatus)}
 	}
 	session.Lifecycle = replayLifecycle(value.Events)
 	if result.Failure != nil {
@@ -119,13 +118,17 @@ func replayResultProjection(value recording.PortableRecording, artifacts []fse.A
 	result := value.Result
 	projected := fse.ResultReadResult{
 		SessionID: value.Session.ID, SessionStatus: fse.LifecycleStatus(value.Session.Status),
-		ResultStatus: fse.ResultStatus(result.Status), Mode: fse.ResultMode(result.Mode),
-		PrimaryResult: append(json.RawMessage(nil), result.PrimaryResult...),
-		ArtifactIDs:   append([]string(nil), result.ArtifactIDs...),
 	}
 	if projected.SessionStatus == "COMPLETED" {
 		projected.SessionStatus = fse.LifecycleStatusSucceeded
 	}
+	if result == nil {
+		return projected
+	}
+	projected.ResultStatus = fse.ResultStatus(result.Status)
+	projected.Mode = fse.ResultMode(result.Mode)
+	projected.PrimaryResult = append(json.RawMessage(nil), result.PrimaryResult...)
+	projected.ArtifactIDs = append([]string(nil), result.ArtifactIDs...)
 	artifactByID := make(map[string]fse.ArtifactSummary, len(artifacts))
 	for _, artifact := range artifacts {
 		artifactByID[artifact.ID] = artifact

--- a/pkg/services/factory_sessions/internal/execution/recordingreplay/replay_test.go
+++ b/pkg/services/factory_sessions/internal/execution/recordingreplay/replay_test.go
@@ -1,13 +1,16 @@
 package recordingreplay
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/portpowered/infinite-you/internal/testpath"
 	fse "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/execution"
 	recording "github.com/portpowered/infinite-you/pkg/services/recordings"
 )
@@ -116,6 +119,100 @@ func TestReplayRecordingRestoresResumedHistoryAndFinalAvailability(t *testing.T)
 		t.Fatalf("resumed lifecycle/result = %#v %#v", got.Session.Lifecycle, got.Result)
 	}
 	assertRecordedInspectionParity(t, value, got)
+}
+
+func TestReplayRecordingPreservesLegacyFactsAndReportsWorkerHistoryUnavailable(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"valid-v1.json", "valid-v2.json", "valid-v2-checkpoint.json"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assertLegacyReplayFixture(t, name)
+		})
+	}
+}
+
+func assertLegacyReplayFixture(t *testing.T, name string) {
+	t.Helper()
+	value := loadVersionPinnedRecordingFixture(t, name)
+	first := replayVersionPinnedFixture(t, value)
+	second := replayVersionPinnedFixture(t, value)
+	assertStableWorkerHistory(t, first, second)
+	assertLegacyWorkerHistory(t, first)
+	assertLegacyFactorySessionFacts(t, value, first)
+	assertLegacyResultAbsence(t, value, first)
+	assertInspectionWorkerHistory(t, first)
+}
+
+func replayVersionPinnedFixture(t *testing.T, value recording.PortableRecording) RecordingReplayProjection {
+	t.Helper()
+	projection, err := ReplayRecording(value)
+	if err != nil {
+		t.Fatalf("ReplayRecording() error = %v", err)
+	}
+	return projection
+}
+
+func assertStableWorkerHistory(t *testing.T, first, second RecordingReplayProjection) {
+	t.Helper()
+	if !reflect.DeepEqual(first.WorkerHistory, second.WorkerHistory) {
+		t.Fatalf("Worker history changed across replay: first=%#v second=%#v", first.WorkerHistory, second.WorkerHistory)
+	}
+}
+
+func assertLegacyWorkerHistory(t *testing.T, projection RecordingReplayProjection) {
+	t.Helper()
+	if projection.WorkerHistory.Availability != recording.PortableRecordingWorkerHistoryUnavailable ||
+		projection.WorkerHistory.Reason != recording.PortableRecordingWorkerHistoryReasonLegacySchema {
+		t.Fatalf("Worker history = %#v, want unavailable legacy outcome", projection.WorkerHistory)
+	}
+}
+
+func assertLegacyFactorySessionFacts(t *testing.T, value recording.PortableRecording, projection RecordingReplayProjection) {
+	t.Helper()
+	if projection.Session.SessionID != value.Session.ID ||
+		projection.Session.ResolvedSource.SourceRef != value.Source.Ref ||
+		len(projection.Events.Events) != len(value.Events) ||
+		len(projection.Artifacts.Artifacts) != len(value.Artifacts) {
+		t.Fatalf("legacy Factory Session facts were not preserved: %#v", projection)
+	}
+}
+
+func assertLegacyResultAbsence(t *testing.T, value recording.PortableRecording, projection RecordingReplayProjection) {
+	t.Helper()
+	if value.Result != nil {
+		return
+	}
+	if projection.Session.ResultSummary != nil || projection.Result.ResultStatus != "" ||
+		projection.Result.Availability != nil || projection.Result.Failure != nil {
+		t.Fatalf("schema-1 fabricated result facts: session=%#v result=%#v", projection.Session, projection.Result)
+	}
+}
+
+func assertInspectionWorkerHistory(t *testing.T, projection RecordingReplayProjection) {
+	t.Helper()
+	inspection := NewService(projection).Inspection()
+	if !reflect.DeepEqual(inspection.WorkerHistory, projection.WorkerHistory) {
+		t.Fatalf("inspection Worker history = %#v, want %#v", inspection.WorkerHistory, projection.WorkerHistory)
+	}
+}
+
+func loadVersionPinnedRecordingFixture(t *testing.T, name string) recording.PortableRecording {
+	t.Helper()
+	path := testpath.MustRepoPathFromCaller(
+		t,
+		0,
+		"pkg", "services", "recordings", "internal", "artifacts", "testdata", name,
+	)
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %q: %v", name, err)
+	}
+	value, err := recording.DecodePortableRecording(bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("decode fixture %q: %v", name, err)
+	}
+	return value
 }
 
 func buildLifecycleRecording(t *testing.T, status string, resumed bool) recording.PortableRecording {

--- a/pkg/services/factory_sessions/internal/execution/recordingreplay/replay_test.go
+++ b/pkg/services/factory_sessions/internal/execution/recordingreplay/replay_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/portpowered/infinite-you/internal/testpath"
 	fse "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/execution"
 	recording "github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
 )
 
 func TestReplayRecordingRestoresCompletedPublicReadModelsWithoutLiveExecution(t *testing.T) {
@@ -130,6 +131,32 @@ func TestReplayRecordingPreservesLegacyFactsAndReportsWorkerHistoryUnavailable(t
 			assertLegacyReplayFixture(t, name)
 		})
 	}
+}
+
+func TestReplayRecordingPreservesCurrentWorkerHistoryFacts(t *testing.T) {
+	t.Parallel()
+	value := loadVersionPinnedRecordingFixture(t, "valid-v3-worker-history.json")
+	first := replayVersionPinnedFixture(t, value)
+	second := replayVersionPinnedFixture(t, value)
+	assertStableWorkerHistory(t, first, second)
+	history := first.WorkerHistory
+	if history.Availability != recording.PortableRecordingWorkerHistoryAvailable ||
+		history.WorkerPortableRecording == nil || len(history.Records) != 3 {
+		t.Fatalf("Worker history = %#v, want available ordered history", history)
+	}
+	if history.Lifecycle.Terminal == nil || history.Lifecycle.Terminal.Status != "COMPLETED" ||
+		history.Correlation.FactorySessionID != value.Session.ID || history.Correlation.DispatchID != "dispatch-current-001" {
+		t.Fatalf("Worker lifecycle/correlation = %#v", history)
+	}
+	if history.Records[1].Provenance.Fidelity != workers.FidelityNormalized ||
+		history.Records[1].Provenance.Delivery != workers.DeliveryNativeStream {
+		t.Fatalf("Worker fidelity facts = %#v", history.Records[1])
+	}
+	if first.Session.SessionID != value.Session.ID || len(first.Events.Events) != len(value.Events) ||
+		first.Result.ResultStatus != fse.ResultStatusFinal {
+		t.Fatalf("Factory Session projection = %#v", first)
+	}
+	assertInspectionWorkerHistory(t, first)
 }
 
 func assertLegacyReplayFixture(t *testing.T, name string) {

--- a/pkg/services/factory_sessions/internal/execution/recordingreplay/service.go
+++ b/pkg/services/factory_sessions/internal/execution/recordingreplay/service.go
@@ -26,10 +26,11 @@ func (s *Service) Inspection() factorysessions.HistoricalReplayInspection {
 		return factorysessions.HistoricalReplayInspection{}
 	}
 	inspection := factorysessions.HistoricalReplayInspection{
-		Session:   s.projection.Session,
-		Events:    s.projection.Events,
-		Artifacts: s.projection.Artifacts,
-		Result:    s.projection.Result,
+		Session:       s.projection.Session,
+		Events:        s.projection.Events,
+		Artifacts:     s.projection.Artifacts,
+		Result:        s.projection.Result,
+		WorkerHistory: s.projection.WorkerHistory,
 		Redaction: factorysessions.HistoricalReplayRedaction{
 			RuntimeStateOmitted:        s.projection.Redaction.RuntimeStateOmitted,
 			CheckpointBodiesOmitted:    s.projection.Redaction.CheckpointBodiesOmitted,

--- a/pkg/services/recordings/contracts.go
+++ b/pkg/services/recordings/contracts.go
@@ -146,6 +146,8 @@ type (
 	PortableRecordingCanonicalFacts                            = recordingcontracts.PortableRecordingCanonicalFacts
 	PortableRecordingCanonicalResult                           = recordingcontracts.PortableRecordingCanonicalResult
 	PortableRecordingCheckpointSummary                         = recordingcontracts.PortableRecordingCheckpointSummary
+	PortableRecordingCodec                                     = recordingcontracts.PortableRecordingCodec
+	PortableRecordingCompatibilityPolicy                       = recordingcontracts.PortableRecordingCompatibilityPolicy
 	PortableRecordingDiagnostic                                = recordingcontracts.PortableRecordingDiagnostic
 	PortableRecordingDiagnosticCode                            = recordingcontracts.PortableRecordingDiagnosticCode
 	PortableRecordingEventSummary                              = recordingcontracts.PortableRecordingEventSummary
@@ -357,6 +359,13 @@ const (
 )
 
 const (
+	PortableRecordingCodeUnsupportedSchema          = recordingcontracts.PortableRecordingCodeUnsupportedSchema
+	PortableRecordingCompatibilityAction            = recordingcontracts.PortableRecordingCompatibilityAction
+	PortableRecordingSchemaV3                       = recordingcontracts.PortableRecordingSchemaV3
+	PortableRecordingWorkerHistoryReasonNotCaptured = recordingcontracts.PortableRecordingWorkerHistoryReasonNotCaptured
+)
+
+const (
 	PortableRecordingWorkerHistoryAvailable          = recordingcontracts.PortableRecordingWorkerHistoryAvailable
 	PortableRecordingWorkerHistoryUnavailable        = recordingcontracts.PortableRecordingWorkerHistoryUnavailable
 	PortableRecordingWorkerHistoryReasonLegacySchema = recordingcontracts.PortableRecordingWorkerHistoryReasonLegacySchema
@@ -407,10 +416,14 @@ var (
 	NewFactoryEvent                                    = recordingcontracts.NewFactoryEvent
 	BuildFactoryWorldWorkstationRequestProjectionSlice = recordingcontracts.BuildFactoryWorldWorkstationRequestProjectionSlice
 	BuildPortableRecording                             = recordingcontracts.BuildPortableRecording
+	CurrentPortableRecordingCodec                      = recordingcontracts.CurrentPortableRecordingCodec
 	DecodePortableRecording                            = recordingcontracts.DecodePortableRecording
+	DecodePortableRecordingWithVersions                = recordingcontracts.DecodePortableRecordingWithVersions
 	FactoryMetadataWarnings                            = recordingcontracts.FactoryMetadataWarnings
 	NormalizePortableRecordingWorkerHistory            = recordingcontracts.NormalizePortableRecordingWorkerHistory
+	NewPortableRecordingCodec                          = recordingcontracts.NewPortableRecordingCodec
 	ValidatePortableRecording                          = recordingcontracts.ValidatePortableRecording
+	ValidatePortableRecordingWithVersions              = recordingcontracts.ValidatePortableRecordingWithVersions
 )
 
 // Service is the singular cross-service Recordings authority.

--- a/pkg/services/recordings/contracts.go
+++ b/pkg/services/recordings/contracts.go
@@ -154,6 +154,8 @@ type (
 	PortableRecordingResult                                    = recordingcontracts.PortableRecordingResult
 	PortableRecordingSessionSummary                            = recordingcontracts.PortableRecordingSessionSummary
 	PortableRecordingSourceSummary                             = recordingcontracts.PortableRecordingSourceSummary
+	PortableRecordingWorkerHistory                             = recordingcontracts.PortableRecordingWorkerHistory
+	PortableRecordingWorkerHistoryAvailability                 = recordingcontracts.PortableRecordingWorkerHistoryAvailability
 	PortableRecordingWriter                                    = recordingcontracts.PortableRecordingWriter
 	ProjectionService                                          = recordingcontracts.ProjectionService
 	ReadPortableArtifactRequest                                = recordingcontracts.ReadPortableArtifactRequest
@@ -354,6 +356,13 @@ const (
 	WorldStateViewSchemaV1                        = recordingcontracts.WorldStateViewSchemaV1
 )
 
+const (
+	PortableRecordingWorkerHistoryAvailable          = recordingcontracts.PortableRecordingWorkerHistoryAvailable
+	PortableRecordingWorkerHistoryUnavailable        = recordingcontracts.PortableRecordingWorkerHistoryUnavailable
+	PortableRecordingWorkerHistoryReasonLegacySchema = recordingcontracts.PortableRecordingWorkerHistoryReasonLegacySchema
+	PortableRecordingWorkerHistoryUnavailableReason  = recordingcontracts.PortableRecordingWorkerHistoryUnavailableReason
+)
+
 var (
 	CloneFactoryWorldDispatchCompletion                = recordingcontracts.CloneFactoryWorldDispatchCompletion
 	CloneFactoryWorldInferenceAttemptsByDispatchID     = recordingcontracts.CloneFactoryWorldInferenceAttemptsByDispatchID
@@ -400,6 +409,7 @@ var (
 	BuildPortableRecording                             = recordingcontracts.BuildPortableRecording
 	DecodePortableRecording                            = recordingcontracts.DecodePortableRecording
 	FactoryMetadataWarnings                            = recordingcontracts.FactoryMetadataWarnings
+	NormalizePortableRecordingWorkerHistory            = recordingcontracts.NormalizePortableRecordingWorkerHistory
 	ValidatePortableRecording                          = recordingcontracts.ValidatePortableRecording
 )
 

--- a/pkg/services/recordings/contracts.go
+++ b/pkg/services/recordings/contracts.go
@@ -324,12 +324,16 @@ const (
 	KindJavaScriptFactorySession                  = recordingcontracts.KindJavaScriptFactorySession
 	PortableArtifactIntegritySHA256               = recordingcontracts.PortableArtifactIntegritySHA256
 	PortableArtifactSchemaV1                      = recordingcontracts.PortableArtifactSchemaV1
+	PortableRecordingCurrentSchemaVersion         = recordingcontracts.PortableRecordingCurrentSchemaVersion
 	PortableRecordingCodeInvalidDigest            = recordingcontracts.PortableRecordingCodeInvalidDigest
 	PortableRecordingCodeInvalidIdentity          = recordingcontracts.PortableRecordingCodeInvalidIdentity
 	PortableRecordingCodeInvalidSummary           = recordingcontracts.PortableRecordingCodeInvalidSummary
 	PortableRecordingCodeInvalidOrder             = recordingcontracts.PortableRecordingCodeInvalidOrder
 	PortableRecordingCodeMalformedContract        = recordingcontracts.PortableRecordingCodeMalformedContract
 	PortableRecordingCodeUnsupportedVersion       = recordingcontracts.PortableRecordingCodeUnsupportedVersion
+	PortableRecordingReplayCompatibilityV1        = recordingcontracts.PortableRecordingReplayCompatibilityV1
+	PortableRecordingSchemaV1                     = recordingcontracts.PortableRecordingSchemaV1
+	PortableRecordingSchemaV2                     = recordingcontracts.PortableRecordingSchemaV2
 	RecordingActive                               = recordingcontracts.RecordingActive
 	RecordingFailed                               = recordingcontracts.RecordingFailed
 	RecordingFinalized                            = recordingcontracts.RecordingFinalized

--- a/pkg/services/recordings/internal/artifacts/contract.go
+++ b/pkg/services/recordings/internal/artifacts/contract.go
@@ -21,6 +21,7 @@ type (
 	ResultProjection   = recordings.PortableRecordingResult
 	FailureSummary     = recordings.PortableRecordingFailureSummary
 	AvailabilityDetail = recordings.PortableRecordingAvailability
+	WorkerHistory      = recordings.PortableRecordingWorkerHistory
 	RedactionMetadata  = recordings.PortableRecordingRedactionMetadata
 
 	DiagnosticCode = recordings.PortableRecordingDiagnosticCode
@@ -42,6 +43,7 @@ type (
 const (
 	CodeMalformedContract  = recordings.PortableRecordingCodeMalformedContract
 	CodeUnsupportedVersion = recordings.PortableRecordingCodeUnsupportedVersion
+	CodeUnsupportedSchema  = recordings.PortableRecordingCodeUnsupportedSchema
 	CodeInvalidIdentity    = recordings.PortableRecordingCodeInvalidIdentity
 	CodeInvalidDigest      = recordings.PortableRecordingCodeInvalidDigest
 	CodeInvalidSummary     = recordings.PortableRecordingCodeInvalidSummary

--- a/pkg/services/recordings/internal/artifacts/contract.go
+++ b/pkg/services/recordings/internal/artifacts/contract.go
@@ -6,8 +6,8 @@ import recordings "github.com/portpowered/infinite-you/pkg/services/recordings"
 
 const (
 	KindJavaScriptFactorySession = recordings.KindJavaScriptFactorySession
-	CurrentSchemaVersion         = "2"
-	ReplayCompatibilityVersion   = "1"
+	CurrentSchemaVersion         = recordings.PortableRecordingCurrentSchemaVersion
+	ReplayCompatibilityVersion   = recordings.PortableRecordingReplayCompatibilityV1
 	MaxSecretsRedacted           = 1_000_000
 )
 

--- a/pkg/services/recordings/internal/artifacts/testdata/valid-v2-checkpoint.json
+++ b/pkg/services/recordings/internal/artifacts/testdata/valid-v2-checkpoint.json
@@ -1,0 +1,18 @@
+{
+  "recordingKind": "you.factory-session.javascript.recording",
+  "schemaVersion": "2",
+  "replayCompatibilityVersion": "1",
+  "session": {"id": "session-js-checkpoint-001", "status": "COMPLETED", "orchestratorKind": "JAVASCRIPT"},
+  "source": {"ref": "workflow/checkpoint.js", "hash": "sha256:5555555555555555555555555555555555555555555555555555555555555555"},
+  "argumentsDigest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+  "policyHash": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+  "artifacts": [{"id": "artifact-checkpoint", "kind": "CHECKPOINT", "visibility": "PUBLIC", "label": "Approval", "contentHash": "sha256:8888888888888888888888888888888888888888888888888888888888888888", "sizeBytes": 12, "createdAt": "2026-07-12T13:00:01Z"}],
+  "events": [
+    {"id": "event-started", "type": "SESSION_STARTED", "sequence": 0, "timestamp": "2026-07-12T13:00:00Z"},
+    {"id": "event-checkpoint", "type": "JAVASCRIPT_CHECKPOINT_REF", "sequence": 1, "timestamp": "2026-07-12T13:00:01Z", "artifactIds": ["artifact-checkpoint"], "checkpointId": "checkpoint-public-1"},
+    {"id": "event-completed", "type": "SESSION_COMPLETED", "sequence": 2, "timestamp": "2026-07-12T13:00:02Z", "artifactIds": ["artifact-checkpoint"]}
+  ],
+  "checkpoint": {"id": "checkpoint-public-1", "label": "Approval", "summary": "Waiting for operator input", "timestamp": "2026-07-12T13:00:01Z", "artifactId": "artifact-checkpoint"},
+  "result": {"status": "FINAL", "mode": "final", "artifactIds": ["artifact-checkpoint"]},
+  "redaction": {"runtimeStateOmitted": true, "checkpointBodiesOmitted": true, "providerTranscriptsOmitted": true, "childDispatchesOmitted": true, "secretsRedacted": 1}
+}

--- a/pkg/services/recordings/internal/artifacts/testdata/valid-v3-worker-history.json
+++ b/pkg/services/recordings/internal/artifacts/testdata/valid-v3-worker-history.json
@@ -1,0 +1,33 @@
+{
+  "recordingKind": "you.factory-session.javascript.recording",
+  "schemaVersion": "3",
+  "replayCompatibilityVersion": "1",
+  "session": {"id": "session-current-worker-001", "status": "COMPLETED", "orchestratorKind": "JAVASCRIPT"},
+  "source": {"ref": "workflow/current-worker.js", "hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111"},
+  "argumentsDigest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+  "policyHash": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+  "artifacts": [],
+  "events": [
+    {"id": "event-started", "type": "SESSION_STARTED", "sequence": 0, "timestamp": "2026-08-12T13:00:00Z"},
+    {"id": "event-completed", "type": "SESSION_COMPLETED", "sequence": 1, "timestamp": "2026-08-12T13:00:01Z"}
+  ],
+  "result": {"status": "FINAL", "mode": "final"},
+  "workerHistory": {
+    "availability": "AVAILABLE",
+    "reason": "",
+    "recordingKind": "you.worker-session.recording",
+    "schemaVersion": "1",
+    "replayCompatibilityVersion": "1",
+    "identity": {"recordingId": "worker-recording-current-001", "workerSessionId": "worker-session-current-001", "topic": "worker-session/worker-session-current-001/events"},
+    "lifecycle": {"status": "COMPLETED", "openingTimestamp": "2026-08-12T13:00:00Z", "terminal": {"position": 3, "phase": "COMPLETED", "status": "COMPLETED"}},
+    "correlation": {"factorySessionId": "session-current-worker-001", "recordingId": "worker-recording-current-001", "dispatchId": "dispatch-current-001", "turnId": "turn-current-001", "traceId": "trace-current-001", "workIds": ["work-current-001"], "attemptId": "attempt-current-001", "attempt": 1, "attemptReason": "INITIAL", "providerSelection": {"runnerId": "codex"}},
+    "provider": {"provider": "codex"},
+    "records": [
+      {"position": 1, "sourceType": "worker_session_lifecycle", "sourceId": "worker-session-current-001", "sourceSequence": 1, "sourceEventId": "started", "schemaId": "workers.draft.v1", "kind": "SESSION", "phase": "STARTED", "provenance": {"delivery": "SYNTHESIZED", "fidelity": "LIFECYCLE_ONLY", "nativeEventType": "worker_session_lifecycle", "provider": "codex", "representation": "NOTIFICATION"}, "dispatchId": "dispatch-current-001", "turnId": "turn-current-001", "payload": {"kind": "SESSION", "phase": "STARTED", "provenance": {"delivery": "SYNTHESIZED", "fidelity": "LIFECYCLE_ONLY", "nativeEventType": "worker_session_lifecycle", "provider": "codex", "representation": "NOTIFICATION"}, "payload": {"status": "STARTING", "startedAt": "2026-08-12T13:00:00Z", "workerSessionId": "worker-session-current-001", "factorySessionId": "session-current-worker-001", "recordingId": "worker-recording-current-001", "dispatchId": "dispatch-current-001", "turnId": "turn-current-001", "traceId": "trace-current-001", "workIds": ["work-current-001"], "attemptId": "attempt-current-001", "attempt": 1, "attemptReason": "INITIAL", "providerSelection": {"runnerId": "codex"}}, "dispatchId": "dispatch-current-001", "turnId": "turn-current-001"}},
+      {"position": 2, "sourceType": "worker_observation", "sourceId": "worker-session-current-001", "sourceSequence": 1, "sourceEventId": "worker/1", "schemaId": "workers.draft.v1", "kind": "MESSAGE", "phase": "COMPLETED", "provenance": {"delivery": "NATIVE_STREAM", "fidelity": "NORMALIZED", "nativeEventType": "message.completed", "provider": "codex", "representation": "SNAPSHOT"}, "dispatchId": "dispatch-current-001", "turnId": "turn-current-001", "itemId": "message-current-001", "payload": {"kind": "MESSAGE", "phase": "COMPLETED", "provenance": {"delivery": "NATIVE_STREAM", "fidelity": "NORMALIZED", "nativeEventType": "message.completed", "provider": "codex", "representation": "SNAPSHOT"}, "payload": {"role": "assistant", "contentBlocks": [{"kind": "TEXT", "text": "done"}]}, "dispatchId": "dispatch-current-001", "turnId": "turn-current-001", "itemId": "message-current-001"}},
+      {"position": 3, "sourceType": "worker_session_lifecycle", "sourceId": "worker-session-current-001", "sourceSequence": 2, "sourceEventId": "terminal", "schemaId": "workers.draft.v1", "kind": "SESSION", "phase": "COMPLETED", "provenance": {"delivery": "SYNTHESIZED", "fidelity": "LIFECYCLE_ONLY", "nativeEventType": "worker_session_lifecycle", "provider": "codex", "representation": "NOTIFICATION"}, "dispatchId": "dispatch-current-001", "payload": {"kind": "SESSION", "phase": "COMPLETED", "provenance": {"delivery": "SYNTHESIZED", "fidelity": "LIFECYCLE_ONLY", "nativeEventType": "worker_session_lifecycle", "provider": "codex", "representation": "NOTIFICATION"}, "payload": {"status": "COMPLETED"}, "dispatchId": "dispatch-current-001"}}
+    ],
+    "integrity": {"algorithm": "sha256", "digest": "sha256:92dc2304831962e4b85d573e00db160c0c3e6e19a0ae99c34515993d8bac0976"}
+  },
+  "redaction": {"runtimeStateOmitted": true, "checkpointBodiesOmitted": true, "providerTranscriptsOmitted": true, "childDispatchesOmitted": true, "secretsRedacted": 0}
+}

--- a/pkg/services/recordings/internal/artifacts/validate_test.go
+++ b/pkg/services/recordings/internal/artifacts/validate_test.go
@@ -8,14 +8,17 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/portpowered/infinite-you/pkg/services/events"
 	recordings "github.com/portpowered/infinite-you/pkg/services/recordings"
 	recording "github.com/portpowered/infinite-you/pkg/services/recordings/internal/artifacts"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
 )
 
 func TestContractFixtures(t *testing.T) {
 	t.Parallel()
-	for _, name := range []string{"valid-v2.json", "valid-v2-checkpoint.json", "valid-v1.json"} {
+	for _, name := range []string{"valid-v3-worker-history.json", "valid-v2.json", "valid-v2-checkpoint.json", "valid-v1.json"} {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -54,6 +57,46 @@ func TestVersionPinnedSchemaV2CheckpointFixturePreservesFactorySessionFacts(t *t
 	})
 }
 
+func TestVersionPinnedSchemaV3FixturePreservesFactorySessionAndWorkerFacts(t *testing.T) {
+	t.Parallel()
+	value, err := loadFixture("valid-v3-worker-history.json")
+	if err != nil {
+		t.Fatalf("DecodeAndValidate() error = %v", err)
+	}
+	assertCurrentFixtureFactoryFacts(t, value)
+	assertCurrentFixtureWorkerFacts(t, value)
+	assertVersionPinnedJSONRoundTrip(t, value)
+}
+
+func assertCurrentFixtureFactoryFacts(t *testing.T, value recordings.PortableRecording) {
+	t.Helper()
+	if value.SchemaVersion != recordings.PortableRecordingSchemaV3 ||
+		value.ReplayCompatibilityVersion != recordings.PortableRecordingReplayCompatibilityV1 {
+		t.Fatalf("compatibility = %q/%q", value.SchemaVersion, value.ReplayCompatibilityVersion)
+	}
+	if value.Session.ID != "session-current-worker-001" || value.Source.Ref != "workflow/current-worker.js" ||
+		len(value.Events) != 2 || value.Events[0].Sequence != 0 || value.Events[1].Sequence != 1 {
+		t.Fatalf("Factory Session facts = %#v", value)
+	}
+}
+
+func assertCurrentFixtureWorkerFacts(t *testing.T, value recordings.PortableRecording) {
+	t.Helper()
+	history := value.WorkerHistory
+	if history == nil || history.Availability != recordings.PortableRecordingWorkerHistoryAvailable ||
+		history.WorkerPortableRecording == nil || len(history.Records) != 3 {
+		t.Fatalf("Worker history = %#v, want available ordered history", history)
+	}
+	if history.Lifecycle.Terminal == nil || history.Lifecycle.Terminal.Status != "COMPLETED" ||
+		history.Correlation.FactorySessionID != value.Session.ID || history.Correlation.DispatchID != "dispatch-current-001" {
+		t.Fatalf("Worker lifecycle/correlation = %#v", history)
+	}
+	if history.Records[1].Provenance.Fidelity != workers.FidelityNormalized ||
+		history.Records[1].Provenance.Delivery != workers.DeliveryNativeStream {
+		t.Fatalf("Worker fidelity facts = %#v", history.Records[1])
+	}
+}
+
 func TestLegacyFixturesNormalizeWorkerHistoryAsUnavailable(t *testing.T) {
 	t.Parallel()
 	for _, name := range []string{"valid-v1.json", "valid-v2.json", "valid-v2-checkpoint.json"} {
@@ -82,6 +125,228 @@ func TestLegacyFixturesNormalizeWorkerHistoryAsUnavailable(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCurrentBuildDeclaresWorkerHistoryCapabilityAndOldReaderRejectsIt(t *testing.T) {
+	t.Parallel()
+	facts := recordings.PortableRecordingCanonicalFacts{
+		SessionID:        "session-current-001",
+		Status:           "COMPLETED",
+		OrchestratorKind: "JAVASCRIPT",
+		SourceRef:        "workflow/current.js",
+		SourceHash:       digestForTest('1'),
+		PolicyHash:       digestForTest('2'),
+		Events: []json.RawMessage{
+			json.RawMessage(`{"id":"event-started","type":"SESSION_STARTED","context":{"sequence":0,"eventTime":"2026-08-12T12:00:00Z"},"payload":{}}`),
+			json.RawMessage(`{"id":"event-completed","type":"SESSION_COMPLETED","context":{"sequence":1,"eventTime":"2026-08-12T12:00:01Z"},"payload":{}}`),
+		},
+		Result: &recordings.PortableRecordingCanonicalResult{Status: "FINAL", Mode: "final"},
+	}
+	value, err := recordings.BuildPortableRecording(facts)
+	if err != nil {
+		t.Fatalf("BuildPortableRecording() error = %v", err)
+	}
+	assertCurrentUnavailableRecording(t, value)
+	payload := marshalPortableRecording(t, value)
+	assertCurrentPortableRoundTrip(t, value, payload)
+	assertOldReaderRejectsCurrentRecording(t, payload)
+}
+
+func assertCurrentUnavailableRecording(t *testing.T, value recordings.PortableRecording) {
+	t.Helper()
+	if value.SchemaVersion != recordings.PortableRecordingSchemaV3 || value.ReplayCompatibilityVersion != recordings.PortableRecordingReplayCompatibilityV1 {
+		t.Fatalf("compatibility = %q/%q", value.SchemaVersion, value.ReplayCompatibilityVersion)
+	}
+	if value.WorkerHistory == nil || value.WorkerHistory.Availability != recordings.PortableRecordingWorkerHistoryUnavailable || value.WorkerHistory.Reason != recordings.PortableRecordingWorkerHistoryReasonNotCaptured {
+		t.Fatalf("Worker history = %#v, want explicit current unavailable outcome", value.WorkerHistory)
+	}
+}
+
+func marshalPortableRecording(t *testing.T, value recordings.PortableRecording) []byte {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	return payload
+}
+
+func assertCurrentPortableRoundTrip(t *testing.T, value recordings.PortableRecording, payload []byte) {
+	t.Helper()
+	decoded, err := recordings.DecodePortableRecording(bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("current DecodePortableRecording() error = %v", err)
+	}
+	if !reflect.DeepEqual(decoded, value) {
+		t.Fatalf("current round trip changed facts:\nwant=%#v\ngot=%#v", value, decoded)
+	}
+}
+
+func assertOldReaderRejectsCurrentRecording(t *testing.T, payload []byte) {
+	t.Helper()
+	oldReader := recordings.NewPortableRecordingCodec(
+		[]string{recordings.PortableRecordingSchemaV1, recordings.PortableRecordingSchemaV2},
+		[]string{recordings.PortableRecordingReplayCompatibilityV1},
+	)
+	got, err := oldReader.Decode(bytes.NewReader(payload))
+	if !reflect.DeepEqual(got, recordings.PortableRecording{}) {
+		t.Fatalf("old-reader result = %#v, want no partial recording", got)
+	}
+	var diagnostic *recordings.PortableRecordingDiagnostic
+	if !errors.As(err, &diagnostic) {
+		t.Fatalf("old-reader error = %T %v, want typed diagnostic", err, err)
+	}
+	if diagnostic.Code != recordings.PortableRecordingCodeUnsupportedSchema || diagnostic.Path != "schemaVersion" || diagnostic.EncounteredVersion != recordings.PortableRecordingSchemaV3 || diagnostic.Action != recordings.PortableRecordingCompatibilityAction {
+		t.Fatalf("old-reader diagnostic = %#v", diagnostic)
+	}
+	if !reflect.DeepEqual(diagnostic.SupportedVersions, []string{recordings.PortableRecordingSchemaV1, recordings.PortableRecordingSchemaV2}) {
+		t.Fatalf("old-reader supported versions = %#v", diagnostic.SupportedVersions)
+	}
+}
+
+func TestUnsupportedReplayCompatibilityHasSeparateTypedDiagnostic(t *testing.T) {
+	t.Parallel()
+	value, err := loadFixture("valid-v2.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &document); err != nil {
+		t.Fatal(err)
+	}
+	document["replayCompatibilityVersion"] = json.RawMessage(`"99"`)
+	payload, err = json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = recordings.DecodePortableRecording(bytes.NewReader(payload))
+	var diagnostic *recordings.PortableRecordingDiagnostic
+	if !errors.As(err, &diagnostic) {
+		t.Fatalf("error = %T %v, want typed diagnostic", err, err)
+	}
+	if diagnostic.Code != recordings.PortableRecordingCodeUnsupportedVersion || diagnostic.Path != "replayCompatibilityVersion" || diagnostic.EncounteredVersion != "99" || diagnostic.Action != recordings.PortableRecordingCompatibilityAction {
+		t.Fatalf("diagnostic = %#v", diagnostic)
+	}
+}
+
+func TestCurrentFixturePreservesAvailableWorkerHistoryFacts(t *testing.T) {
+	t.Parallel()
+	factorySessionID := "session-current-worker-001"
+	history := availableWorkerHistory(t, factorySessionID)
+	facts := recordings.PortableRecordingCanonicalFacts{
+		SessionID:        factorySessionID,
+		Status:           "COMPLETED",
+		OrchestratorKind: "JAVASCRIPT",
+		SourceRef:        "workflow/current-worker.js",
+		SourceHash:       digestForTest('1'),
+		PolicyHash:       digestForTest('2'),
+		Events: []json.RawMessage{
+			json.RawMessage(`{"id":"event-started","type":"SESSION_STARTED","context":{"sequence":0,"eventTime":"2026-08-12T13:00:00Z"},"payload":{}}`),
+			json.RawMessage(`{"id":"event-completed","type":"SESSION_COMPLETED","context":{"sequence":1,"eventTime":"2026-08-12T13:00:01Z"},"payload":{}}`),
+		},
+		Result:        &recordings.PortableRecordingCanonicalResult{Status: "FINAL", Mode: "final"},
+		WorkerHistory: history,
+	}
+	value, err := recordings.BuildPortableRecording(facts)
+	if err != nil {
+		t.Fatalf("BuildPortableRecording() error = %v", err)
+	}
+	if value.WorkerHistory == nil || value.WorkerHistory.Availability != recordings.PortableRecordingWorkerHistoryAvailable || value.WorkerHistory.WorkerPortableRecording == nil {
+		t.Fatalf("Worker history = %#v, want available detached recording", value.WorkerHistory)
+	}
+	if len(value.WorkerHistory.Records) != 3 || value.WorkerHistory.Lifecycle.Terminal == nil || value.WorkerHistory.Correlation.FactorySessionID != factorySessionID {
+		t.Fatalf("Worker history facts = %#v, want ordered records/lifecycle/correlation", value.WorkerHistory)
+	}
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	decoded, err := recordings.DecodePortableRecording(bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("DecodePortableRecording() error = %v", err)
+	}
+	if decoded.WorkerHistory == nil || len(decoded.WorkerHistory.Records) != 3 || decoded.WorkerHistory.Records[1].Provenance.Fidelity != workers.FidelityNormalized {
+		t.Fatalf("decoded Worker history = %#v, want ordered fidelity facts", decoded.WorkerHistory)
+	}
+	if !reflect.DeepEqual(recordings.NormalizePortableRecordingWorkerHistory(value), recordings.NormalizePortableRecordingWorkerHistory(decoded)) {
+		t.Fatalf("normalized Worker history changed across round trip")
+	}
+}
+
+func availableWorkerHistory(t *testing.T, factorySessionID string) *recordings.PortableRecordingWorkerHistory {
+	t.Helper()
+	workerSessionID := "worker-session-current-001"
+	topic := events.Topic("worker-session/" + workerSessionID + "/events")
+	startedAt := time.Date(2026, 8, 12, 13, 0, 0, 0, time.UTC)
+	openingPayload := workers.SessionPayload{
+		Status: "STARTING", StartedAt: &startedAt, WorkerSessionID: workerSessionID,
+		FactorySessionID: factorySessionID, RecordingID: "worker-recording-current-001",
+		DispatchID: "dispatch-current-001", TurnID: "turn-current-001", TraceID: "trace-current-001",
+		WorkIDs: []string{"work-current-001"}, AttemptID: "attempt-current-001", Attempt: 1,
+		AttemptReason:     workers.AttemptReasonInitial,
+		ProviderSelection: &workers.SessionProviderSelection{RunnerID: "codex"},
+	}
+	opening := workerHistoryRecord(t, topic, 1, "worker_session_lifecycle", workerSessionID, 1, "started", workers.Draft{
+		Kind: workers.KindSession, Phase: workers.PhaseStarted,
+		Provenance: workerLifecycleProvenance("codex"), Payload: mustJSON(t, openingPayload),
+		DispatchID: openingPayload.DispatchID, TurnID: openingPayload.TurnID,
+	})
+	message := workerHistoryRecord(t, topic, 2, "worker_observation", workerSessionID, 1, "worker/1", workers.Draft{
+		Kind: workers.KindMessage, Phase: workers.PhaseCompleted,
+		Provenance: workers.Provenance{
+			Delivery: workers.DeliveryNativeStream, Fidelity: workers.FidelityNormalized,
+			NativeEventType: "message.completed", Provider: "codex", Representation: workers.RepresentationSnapshot,
+		}, Payload: mustJSON(t, workers.MessagePayload{Role: "assistant", ContentBlocks: []workers.ContentBlock{{Kind: workers.ContentBlockText, Text: "done"}}}),
+		DispatchID: openingPayload.DispatchID, TurnID: openingPayload.TurnID, ItemID: "message-current-001",
+	})
+	terminal := workerHistoryRecord(t, topic, 3, "worker_session_lifecycle", workerSessionID, 2, "terminal", workers.Draft{
+		Kind: workers.KindSession, Phase: workers.PhaseCompleted,
+		Provenance: workerLifecycleProvenance("codex"), Payload: mustJSON(t, map[string]string{"status": "COMPLETED"}),
+		DispatchID: openingPayload.DispatchID,
+	})
+	snapshot := recordings.WorkerRecordingSnapshot{
+		RecordingID: "worker-recording-current-001",
+		Sessions: []recordings.WorkerSessionRecordingSnapshot{{
+			WorkerSessionID: workerSessionID, Topic: topic, Status: recordings.WorkerRecordingStatusCompleted,
+			LastPosition: 3, Records: []events.Record{opening, message, terminal},
+		}},
+	}
+	portable, err := (recordings.WorkerRecordingCodec{}).BuildWorkerPortableRecording(snapshot)
+	if err != nil {
+		t.Fatalf("BuildWorkerPortableRecording() error = %v", err)
+	}
+	return &recordings.PortableRecordingWorkerHistory{
+		Availability:            recordings.PortableRecordingWorkerHistoryAvailable,
+		WorkerPortableRecording: &portable,
+	}
+}
+
+func workerHistoryRecord(t *testing.T, topic events.Topic, position events.AggregateSequence, sourceType, sourceID string, sourceSequence events.SourceSequence, sourceEventID string, draft workers.Draft) events.Record {
+	t.Helper()
+	return events.Record{
+		ID: events.RecordID{Topic: topic, Position: position}, SourceType: events.SourceType(sourceType), SourceID: events.SourceID(sourceID),
+		SourceSequence: sourceSequence, SourceEventID: events.SourceEventID(sourceEventID), SchemaID: "workers.draft.v1", Payload: mustJSON(t, draft),
+	}
+}
+
+func workerLifecycleProvenance(provider string) workers.Provenance {
+	return workers.Provenance{
+		Delivery: workers.DeliverySynthesized, Fidelity: workers.FidelityLifecycleOnly,
+		NativeEventType: "worker_session_lifecycle", Provider: provider, Representation: workers.RepresentationNotification,
+	}
+}
+
+func mustJSON(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return payload
 }
 
 type versionPinnedFixtureExpectation struct {
@@ -139,6 +404,25 @@ func assertVersionPinnedRoundTrip(t *testing.T, value recording.Recording) {
 	}
 	if !reflect.DeepEqual(value, decoded) {
 		t.Fatalf("round-trip changed versioned facts:\nwant=%#v\ngot=%#v", value, decoded)
+	}
+}
+
+func assertVersionPinnedJSONRoundTrip(t *testing.T, value recording.Recording) {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	decoded, err := recording.DecodeAndValidate(bytes.NewReader(encoded))
+	if err != nil {
+		t.Fatalf("round-trip DecodeAndValidate() error = %v", err)
+	}
+	reencoded, err := json.Marshal(decoded)
+	if err != nil {
+		t.Fatalf("re-marshal() error = %v", err)
+	}
+	if !bytes.Equal(encoded, reencoded) {
+		t.Fatalf("round-trip changed canonical JSON:\nwant=%s\ngot=%s", encoded, reencoded)
 	}
 }
 
@@ -216,6 +500,29 @@ func TestUnsupportedCompatibilityIsRejectedBeforeMalformedBody(t *testing.T) {
 	if len(diagnostic.SupportedVersions) != 1 || diagnostic.SupportedVersions[0] != recording.ReplayCompatibilityVersion {
 		t.Fatalf("supported versions = %#v", diagnostic.SupportedVersions)
 	}
+}
+
+func TestMissingVersionHeaderRemainsMalformed(t *testing.T) {
+	t.Parallel()
+	value, err := loadFixture("valid-v2.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &document); err != nil {
+		t.Fatal(err)
+	}
+	delete(document, "schemaVersion")
+	payload, err = json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = recordings.DecodePortableRecording(bytes.NewReader(payload))
+	assertDiagnostic(t, err, recording.CodeMalformedContract, "schemaVersion")
 }
 
 func TestValidationRejectsEventOrderingAndUnknownArtifactReferences(t *testing.T) {

--- a/pkg/services/recordings/internal/artifacts/validate_test.go
+++ b/pkg/services/recordings/internal/artifacts/validate_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"testing"
 
+	recordings "github.com/portpowered/infinite-you/pkg/services/recordings"
 	recording "github.com/portpowered/infinite-you/pkg/services/recordings/internal/artifacts"
 )
 
@@ -51,6 +52,36 @@ func TestVersionPinnedSchemaV2CheckpointFixturePreservesFactorySessionFacts(t *t
 		schemaVersion: "2", sessionID: "session-js-checkpoint-001", sourceRef: "workflow/checkpoint.js",
 		eventIDs: []string{"event-started", "event-checkpoint", "event-completed"}, artifactCount: 1, result: true, checkpoint: true,
 	})
+}
+
+func TestLegacyFixturesNormalizeWorkerHistoryAsUnavailable(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"valid-v1.json", "valid-v2.json", "valid-v2-checkpoint.json"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			value, err := loadFixture(name)
+			if err != nil {
+				t.Fatalf("DecodeAndValidate() error = %v", err)
+			}
+			got := recordings.NormalizePortableRecordingWorkerHistory(value)
+			if got.Availability != recordings.PortableRecordingWorkerHistoryUnavailable ||
+				got.Reason != recordings.PortableRecordingWorkerHistoryReasonLegacySchema {
+				t.Fatalf("Worker history = %#v, want unavailable legacy outcome", got)
+			}
+			encoded, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("Marshal Worker history: %v", err)
+			}
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal(encoded, &fields); err != nil {
+				t.Fatalf("decode Worker history projection: %v", err)
+			}
+			if len(fields) != 2 {
+				t.Fatalf("legacy Worker history fields = %#v, want availability and reason only", fields)
+			}
+		})
+	}
 }
 
 type versionPinnedFixtureExpectation struct {

--- a/pkg/services/recordings/internal/artifacts/validate_test.go
+++ b/pkg/services/recordings/internal/artifacts/validate_test.go
@@ -2,9 +2,11 @@ package artifacts_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	recording "github.com/portpowered/infinite-you/pkg/services/recordings/internal/artifacts"
@@ -12,7 +14,7 @@ import (
 
 func TestContractFixtures(t *testing.T) {
 	t.Parallel()
-	for _, name := range []string{"valid-v2.json", "valid-v1.json"} {
+	for _, name := range []string{"valid-v2.json", "valid-v2-checkpoint.json", "valid-v1.json"} {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -25,6 +27,139 @@ func TestContractFixtures(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVersionPinnedSchemaV1FixturePreservesFactorySessionFacts(t *testing.T) {
+	t.Parallel()
+	assertVersionPinnedFixture(t, "valid-v1.json", versionPinnedFixtureExpectation{
+		schemaVersion: "1", sessionID: "session-historical-001", sourceRef: "workflow/historical.js",
+		eventIDs: []string{"event-historical-1"},
+	})
+}
+
+func TestVersionPinnedSchemaV2FixturePreservesFactorySessionFacts(t *testing.T) {
+	t.Parallel()
+	assertVersionPinnedFixture(t, "valid-v2.json", versionPinnedFixtureExpectation{
+		schemaVersion: "2", sessionID: "session-js-001", sourceRef: "workflow/example.js",
+		eventIDs: []string{"event-1", "event-2"}, artifactCount: 1, result: true,
+	})
+}
+
+func TestVersionPinnedSchemaV2CheckpointFixturePreservesFactorySessionFacts(t *testing.T) {
+	t.Parallel()
+	assertVersionPinnedFixture(t, "valid-v2-checkpoint.json", versionPinnedFixtureExpectation{
+		schemaVersion: "2", sessionID: "session-js-checkpoint-001", sourceRef: "workflow/checkpoint.js",
+		eventIDs: []string{"event-started", "event-checkpoint", "event-completed"}, artifactCount: 1, result: true, checkpoint: true,
+	})
+}
+
+type versionPinnedFixtureExpectation struct {
+	schemaVersion string
+	sessionID     string
+	sourceRef     string
+	eventIDs      []string
+	artifactCount int
+	result        bool
+	checkpoint    bool
+}
+
+func assertVersionPinnedFixture(t *testing.T, name string, want versionPinnedFixtureExpectation) {
+	t.Helper()
+	value, err := loadFixture(name)
+	if err != nil {
+		t.Fatalf("DecodeAndValidate() error = %v", err)
+	}
+	if value.SchemaVersion != want.schemaVersion || value.ReplayCompatibilityVersion != recording.ReplayCompatibilityVersion {
+		t.Fatalf("compatibility = %q/%q", value.SchemaVersion, value.ReplayCompatibilityVersion)
+	}
+	if value.Session.ID != want.sessionID || value.Source.Ref != want.sourceRef {
+		t.Fatalf("identity/source = %#v/%#v", value.Session, value.Source)
+	}
+	if len(value.Events) != len(want.eventIDs) || len(value.Artifacts) != want.artifactCount {
+		t.Fatalf("summary counts = events:%d artifacts:%d", len(value.Events), len(value.Artifacts))
+	}
+	for index, eventID := range want.eventIDs {
+		if value.Events[index].ID != eventID || value.Events[index].Sequence != int64(index) {
+			t.Fatalf("event[%d] = %#v, want %q at sequence %d", index, value.Events[index], eventID, index)
+		}
+	}
+	if (value.Result != nil) != want.result || (value.Checkpoint != nil) != want.checkpoint {
+		t.Fatalf("versioned optional facts = result:%t checkpoint:%t", value.Result != nil, value.Checkpoint != nil)
+	}
+	if value.Redaction != (recording.RedactionMetadata{
+		RuntimeStateOmitted: true, CheckpointBodiesOmitted: true,
+		ProviderTranscriptsOmitted: true, ChildDispatchesOmitted: true,
+		SecretsRedacted: value.Redaction.SecretsRedacted,
+	}) {
+		t.Fatalf("redaction metadata = %#v", value.Redaction)
+	}
+	assertVersionPinnedRoundTrip(t, value)
+}
+
+func assertVersionPinnedRoundTrip(t *testing.T, value recording.Recording) {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	decoded, err := recording.DecodeAndValidate(bytes.NewReader(encoded))
+	if err != nil {
+		t.Fatalf("round-trip DecodeAndValidate() error = %v", err)
+	}
+	if !reflect.DeepEqual(value, decoded) {
+		t.Fatalf("round-trip changed versioned facts:\nwant=%#v\ngot=%#v", value, decoded)
+	}
+}
+
+func TestSupportedSchemaCorruptionKeepsItsOwnedDiagnostic(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		code   recording.DiagnosticCode
+		path   string
+		mutate func(*recording.Recording)
+	}{
+		{name: "identity", code: recording.CodeInvalidIdentity, path: "session.id", mutate: func(value *recording.Recording) { value.Session.ID = "" }},
+		{name: "digest", code: recording.CodeInvalidDigest, path: "source.hash", mutate: func(value *recording.Recording) { value.Source.Hash = "sha256:not-a-digest" }},
+		{name: "order", code: recording.CodeInvalidOrder, path: "events[1].sequence", mutate: func(value *recording.Recording) { value.Events[1].Sequence = value.Events[0].Sequence }},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			value, err := loadFixture("valid-v2.json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.mutate(&value)
+			payload, err := json.Marshal(value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = recording.DecodeAndValidate(bytes.NewReader(payload))
+			assertDiagnostic(t, err, test.code, test.path)
+		})
+	}
+
+	value, err := loadFixture("valid-v2.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &document); err != nil {
+		t.Fatal(err)
+	}
+	document["unsupportedField"] = json.RawMessage(`true`)
+	payload, err = json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = recording.DecodeAndValidate(bytes.NewReader(payload))
+	assertDiagnostic(t, err, recording.CodeMalformedContract, "")
 }
 
 func TestMalformedFixtureReturnsTypedAreaDiagnostic(t *testing.T) {

--- a/pkg/services/recordings/internal/contracts/portable_recording.go
+++ b/pkg/services/recordings/internal/contracts/portable_recording.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"io/fs"
 	"time"
+
+	workerrecording "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/worker_capture"
 )
 
 const (
@@ -17,13 +19,26 @@ const (
 	// PortableRecordingSchemaV2 adds the required public result projection while
 	// preserving the established Factory Session and event summaries.
 	PortableRecordingSchemaV2 = "2"
+	// PortableRecordingSchemaV3 adds the explicit Worker-history outcome and,
+	// when available, the detached canonical Worker recording. Earlier schema
+	// versions retain their original meaning and cannot carry this field.
+	PortableRecordingSchemaV3 = "3"
 	// PortableRecordingCurrentSchemaVersion is the version emitted by the
-	// pre-Worker-history Factory Session exporter.
-	PortableRecordingCurrentSchemaVersion = PortableRecordingSchemaV2
+	// Worker-history-capable Factory Session exporter.
+	PortableRecordingCurrentSchemaVersion = PortableRecordingSchemaV3
 
 	// PortableRecordingReplayCompatibilityV1 identifies the replay vocabulary
-	// supported by both shipped Factory Session recording schemas.
+	// shared by every shipped Factory Session recording schema.
 	PortableRecordingReplayCompatibilityV1 = "1"
+
+	// PortableRecordingWorkerHistoryReasonNotCaptured is the explicit outcome
+	// used by a new export that has the Worker-history-capable schema but no
+	// canonical Worker capture to attach.
+	PortableRecordingWorkerHistoryReasonNotCaptured = "CANONICAL_WORKER_HISTORY_NOT_CAPTURED"
+
+	// PortableRecordingCompatibilityAction is safe, stable guidance for a
+	// reader that cannot consume a recording's declared version.
+	PortableRecordingCompatibilityAction = "UPGRADE_READER_OR_MIGRATE_RECORDING_TO_A_SUPPORTED_VERSION"
 
 	// portableRecordingMaxSecretsRedacted bounds the aggregate count exposed by
 	// a recording. Counts at or above this limit are reported as the limit.
@@ -31,7 +46,9 @@ const (
 )
 
 var (
-	portableRecordingSupportedSchemaVersions = []string{PortableRecordingSchemaV1, PortableRecordingSchemaV2}
+	portableRecordingSupportedSchemaVersions = []string{
+		PortableRecordingSchemaV1, PortableRecordingSchemaV2, PortableRecordingSchemaV3,
+	}
 	portableRecordingSupportedReplayVersions = []string{PortableRecordingReplayCompatibilityV1}
 )
 
@@ -49,6 +66,7 @@ type PortableRecording struct {
 	Events                     []PortableRecordingEventSummary     `json:"events"`
 	Checkpoint                 *PortableRecordingCheckpointSummary `json:"checkpoint,omitempty"`
 	Result                     *PortableRecordingResult            `json:"result,omitempty"`
+	WorkerHistory              *PortableRecordingWorkerHistory     `json:"workerHistory,omitempty"`
 	Redaction                  PortableRecordingRedactionMetadata  `json:"redaction"`
 }
 
@@ -123,13 +141,17 @@ const (
 )
 
 // PortableRecordingWorkerHistory is the detached Worker-history availability
-// projection for a Factory Session recording. Legacy schemas intentionally
+// projection for a Factory Session recording. The embedded Worker recording
+// is flattened into this object so callers can inspect ordered records and
+// their lifecycle, correlation, provenance, and fidelity facts without a
+// second envelope or a live service dependency. Legacy schemas intentionally
 // contain only the unavailable outcome and its compatibility reason; they do
 // not acquire fabricated records, terminal, fidelity, provider, or complete
 // facts while being read.
 type PortableRecordingWorkerHistory struct {
 	Availability PortableRecordingWorkerHistoryAvailability `json:"availability"`
 	Reason       string                                     `json:"reason"`
+	*workerrecording.WorkerPortableRecording
 }
 
 // NormalizePortableRecordingWorkerHistory maps the shipped pre-Worker-history
@@ -142,9 +164,54 @@ func NormalizePortableRecordingWorkerHistory(recording PortableRecording) Portab
 			Availability: PortableRecordingWorkerHistoryUnavailable,
 			Reason:       PortableRecordingWorkerHistoryReasonLegacySchema,
 		}
+	case PortableRecordingSchemaV3:
+		if recording.WorkerHistory == nil {
+			return PortableRecordingWorkerHistory{}
+		}
+		return clonePortableRecordingWorkerHistory(*recording.WorkerHistory)
 	default:
 		return PortableRecordingWorkerHistory{}
 	}
+}
+
+func clonePortableRecordingWorkerHistory(
+	history PortableRecordingWorkerHistory,
+) PortableRecordingWorkerHistory {
+	clone := history
+	if history.WorkerPortableRecording != nil {
+		recording := cloneWorkerPortableRecording(*history.WorkerPortableRecording)
+		clone.WorkerPortableRecording = &recording
+	}
+	return clone
+}
+
+func cloneWorkerPortableRecording(
+	recording workerrecording.WorkerPortableRecording,
+) workerrecording.WorkerPortableRecording {
+	clone := recording
+	clone.Records = append([]workerrecording.WorkerPortableRecord(nil), recording.Records...)
+	for index := range clone.Records {
+		clone.Records[index].Payload = append(json.RawMessage(nil), recording.Records[index].Payload...)
+		clone.Records[index].Provenance = recording.Records[index].Provenance
+	}
+	clone.Correlation.WorkIDs = append([]string(nil), recording.Correlation.WorkIDs...)
+	if recording.Correlation.Continuation != nil {
+		continuation := *recording.Correlation.Continuation
+		clone.Correlation.Continuation = &continuation
+	}
+	if recording.Correlation.ProviderSelection != nil {
+		selection := *recording.Correlation.ProviderSelection
+		clone.Correlation.ProviderSelection = &selection
+	}
+	if recording.Lifecycle.OpeningTimestamp != nil {
+		timestamp := *recording.Lifecycle.OpeningTimestamp
+		clone.Lifecycle.OpeningTimestamp = &timestamp
+	}
+	if recording.Lifecycle.Terminal != nil {
+		terminal := *recording.Lifecycle.Terminal
+		clone.Lifecycle.Terminal = &terminal
+	}
+	return clone
 }
 
 // PortableRecordingFailureSummary exposes a safe failure summary.
@@ -178,6 +245,7 @@ type PortableRecordingDiagnosticCode string
 const (
 	PortableRecordingCodeMalformedContract  PortableRecordingDiagnosticCode = "MALFORMED_RECORDING_CONTRACT"
 	PortableRecordingCodeUnsupportedVersion PortableRecordingDiagnosticCode = "UNSUPPORTED_REPLAY_COMPATIBILITY_VERSION"
+	PortableRecordingCodeUnsupportedSchema  PortableRecordingDiagnosticCode = "UNSUPPORTED_RECORDING_SCHEMA_VERSION"
 	PortableRecordingCodeInvalidIdentity    PortableRecordingDiagnosticCode = "INVALID_RECORDING_IDENTITY"
 	PortableRecordingCodeInvalidDigest      PortableRecordingDiagnosticCode = "INVALID_RECORDING_DIGEST"
 	PortableRecordingCodeInvalidSummary     PortableRecordingDiagnosticCode = "INVALID_RECORDING_SUMMARY"
@@ -186,11 +254,13 @@ const (
 
 // PortableRecordingDiagnostic reports one validation failure area.
 type PortableRecordingDiagnostic struct {
-	Code              PortableRecordingDiagnosticCode `json:"code"`
-	Area              string                          `json:"area"`
-	Path              string                          `json:"path,omitempty"`
-	Message           string                          `json:"message"`
-	SupportedVersions []string                        `json:"supportedVersions,omitempty"`
+	Code               PortableRecordingDiagnosticCode `json:"code"`
+	Area               string                          `json:"area"`
+	Path               string                          `json:"path,omitempty"`
+	Message            string                          `json:"message"`
+	EncounteredVersion string                          `json:"encounteredVersion,omitempty"`
+	SupportedVersions  []string                        `json:"supportedVersions,omitempty"`
+	Action             string                          `json:"action,omitempty"`
 }
 
 func (diagnostic *PortableRecordingDiagnostic) Error() string {
@@ -214,6 +284,7 @@ type PortableRecordingCanonicalFacts struct {
 	Events                              []json.RawMessage
 	Checkpoint                          *PortableRecordingCanonicalCheckpoint
 	Result                              *PortableRecordingCanonicalResult
+	WorkerHistory                       *PortableRecordingWorkerHistory
 }
 
 // PortableRecordingCanonicalCheckpoint carries canonical checkpoint facts.

--- a/pkg/services/recordings/internal/contracts/portable_recording.go
+++ b/pkg/services/recordings/internal/contracts/portable_recording.go
@@ -9,17 +9,30 @@ import (
 const (
 	// KindJavaScriptFactorySession identifies the portable JavaScript Factory
 	// Session recording contract.
-	KindJavaScriptFactorySession  = "you.factory-session.javascript.recording"
-	portableRecordingSchemaV2     = "2"
-	portableRecordingReplayCompat = "1"
+	KindJavaScriptFactorySession = "you.factory-session.javascript.recording"
+
+	// PortableRecordingSchemaV1 is the first shipped Factory Session recording
+	// schema. It intentionally permits a recording without a result projection.
+	PortableRecordingSchemaV1 = "1"
+	// PortableRecordingSchemaV2 adds the required public result projection while
+	// preserving the established Factory Session and event summaries.
+	PortableRecordingSchemaV2 = "2"
+	// PortableRecordingCurrentSchemaVersion is the version emitted by the
+	// pre-Worker-history Factory Session exporter.
+	PortableRecordingCurrentSchemaVersion = PortableRecordingSchemaV2
+
+	// PortableRecordingReplayCompatibilityV1 identifies the replay vocabulary
+	// supported by both shipped Factory Session recording schemas.
+	PortableRecordingReplayCompatibilityV1 = "1"
+
 	// portableRecordingMaxSecretsRedacted bounds the aggregate count exposed by
 	// a recording. Counts at or above this limit are reported as the limit.
 	portableRecordingMaxSecretsRedacted int64 = 1_000_000
 )
 
 var (
-	portableRecordingSupportedSchemaVersions = []string{"1", portableRecordingSchemaV2}
-	portableRecordingSupportedReplayVersions = []string{portableRecordingReplayCompat}
+	portableRecordingSupportedSchemaVersions = []string{PortableRecordingSchemaV1, PortableRecordingSchemaV2}
+	portableRecordingSupportedReplayVersions = []string{PortableRecordingReplayCompatibilityV1}
 )
 
 // PortableRecording is the privacy-bounded JavaScript Factory Session recording

--- a/pkg/services/recordings/internal/contracts/portable_recording.go
+++ b/pkg/services/recordings/internal/contracts/portable_recording.go
@@ -108,6 +108,45 @@ type PortableRecordingResult struct {
 	Availability  *PortableRecordingAvailability   `json:"availability,omitempty"`
 }
 
+// PortableRecordingWorkerHistoryAvailability identifies whether a portable
+// recording can make a canonical Worker-history claim.
+type PortableRecordingWorkerHistoryAvailability string
+
+const (
+	PortableRecordingWorkerHistoryAvailable   PortableRecordingWorkerHistoryAvailability = "AVAILABLE"
+	PortableRecordingWorkerHistoryUnavailable PortableRecordingWorkerHistoryAvailability = "UNAVAILABLE"
+
+	// PortableRecordingWorkerHistoryReasonLegacySchema is stable compatibility
+	// metadata for recordings that predate canonical Worker-history capture.
+	PortableRecordingWorkerHistoryReasonLegacySchema = "SCHEMA_DID_NOT_RECORD_CANONICAL_WORKER_HISTORY"
+	PortableRecordingWorkerHistoryUnavailableReason  = PortableRecordingWorkerHistoryReasonLegacySchema
+)
+
+// PortableRecordingWorkerHistory is the detached Worker-history availability
+// projection for a Factory Session recording. Legacy schemas intentionally
+// contain only the unavailable outcome and its compatibility reason; they do
+// not acquire fabricated records, terminal, fidelity, provider, or complete
+// facts while being read.
+type PortableRecordingWorkerHistory struct {
+	Availability PortableRecordingWorkerHistoryAvailability `json:"availability"`
+	Reason       string                                     `json:"reason"`
+}
+
+// NormalizePortableRecordingWorkerHistory maps the shipped pre-Worker-history
+// schemas to their honest read-time outcome. It is pure and does not consult
+// Workers, Providers, Events, or provider transcripts.
+func NormalizePortableRecordingWorkerHistory(recording PortableRecording) PortableRecordingWorkerHistory {
+	switch recording.SchemaVersion {
+	case PortableRecordingSchemaV1, PortableRecordingSchemaV2:
+		return PortableRecordingWorkerHistory{
+			Availability: PortableRecordingWorkerHistoryUnavailable,
+			Reason:       PortableRecordingWorkerHistoryReasonLegacySchema,
+		}
+	default:
+		return PortableRecordingWorkerHistory{}
+	}
+}
+
 // PortableRecordingFailureSummary exposes a safe failure summary.
 type PortableRecordingFailureSummary struct {
 	Reason                 string `json:"reason"`

--- a/pkg/services/recordings/internal/contracts/portable_recording_build.go
+++ b/pkg/services/recordings/internal/contracts/portable_recording_build.go
@@ -50,6 +50,7 @@ func BuildPortableRecording(facts PortableRecordingCanonicalFacts) (PortableReco
 			SecretsRedacted: secretsRedacted,
 		},
 	}
+	value.WorkerHistory = buildPortableRecordingWorkerHistory(facts.WorkerHistory)
 	if facts.Checkpoint != nil {
 		value.Checkpoint = &PortableRecordingCheckpointSummary{
 			ID: facts.Checkpoint.ID, Label: facts.Checkpoint.Label, Summary: facts.Checkpoint.Summary,
@@ -69,6 +70,19 @@ func BuildPortableRecording(facts PortableRecordingCanonicalFacts) (PortableReco
 		}
 	}
 	return value, ValidatePortableRecording(value)
+}
+
+func buildPortableRecordingWorkerHistory(
+	history *PortableRecordingWorkerHistory,
+) *PortableRecordingWorkerHistory {
+	if history == nil {
+		return &PortableRecordingWorkerHistory{
+			Availability: PortableRecordingWorkerHistoryUnavailable,
+			Reason:       PortableRecordingWorkerHistoryReasonNotCaptured,
+		}
+	}
+	clone := clonePortableRecordingWorkerHistory(*history)
+	return &clone
 }
 
 func saturatingPortableRecordingSecretsRedacted(total, count int64) int64 {

--- a/pkg/services/recordings/internal/contracts/portable_recording_build.go
+++ b/pkg/services/recordings/internal/contracts/portable_recording_build.go
@@ -36,8 +36,8 @@ func BuildPortableRecording(facts PortableRecordingCanonicalFacts) (PortableReco
 		return PortableRecording{}, err
 	}
 	value := PortableRecording{
-		RecordingKind: KindJavaScriptFactorySession, SchemaVersion: portableRecordingSchemaV2,
-		ReplayCompatibilityVersion: portableRecordingReplayCompat,
+		RecordingKind: KindJavaScriptFactorySession, SchemaVersion: PortableRecordingCurrentSchemaVersion,
+		ReplayCompatibilityVersion: PortableRecordingReplayCompatibilityV1,
 		Session: PortableRecordingSessionSummary{
 			ID: facts.SessionID, Status: facts.Status, OrchestratorKind: facts.OrchestratorKind,
 		},

--- a/pkg/services/recordings/internal/contracts/portable_recording_validate.go
+++ b/pkg/services/recordings/internal/contracts/portable_recording_validate.go
@@ -1,6 +1,7 @@
 package contracts
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -15,18 +16,33 @@ var portableRecordingSHA256Pattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 
 // DecodePortableRecording decodes and validates one portable recording document.
 func DecodePortableRecording(reader io.Reader) (PortableRecording, error) {
-	decoder := json.NewDecoder(reader)
+	document, err := decodePortableRecordingDocument(reader)
+	if err != nil {
+		return PortableRecording{}, portableRecordingDiagnostic(
+			PortableRecordingCodeMalformedContract, "document", "", "decode recording: "+err.Error(),
+		)
+	}
+	header, err := decodePortableRecordingHeader(document)
+	if err != nil {
+		return PortableRecording{}, portableRecordingDiagnostic(
+			PortableRecordingCodeMalformedContract, "document", "", "decode recording header: "+err.Error(),
+		)
+	}
+	// A missing version header is still a malformed document. Let the strict
+	// decoder inspect the complete envelope first so unknown fields and other
+	// structural corruption are not misclassified as unsupported versions.
+	if header.SchemaVersion != "" && header.ReplayCompatibilityVersion != "" {
+		if err := validatePortableRecordingCompatibility(header.RecordingKind, header.SchemaVersion, header.ReplayCompatibilityVersion); err != nil {
+			return PortableRecording{}, err
+		}
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(document))
 	decoder.DisallowUnknownFields()
 	var recording PortableRecording
 	if err := decoder.Decode(&recording); err != nil {
 		return PortableRecording{}, portableRecordingDiagnostic(
 			PortableRecordingCodeMalformedContract, "document", "", "decode recording: "+err.Error(),
-		)
-	}
-	var trailing any
-	if err := decoder.Decode(&trailing); err != io.EOF {
-		return PortableRecording{}, portableRecordingDiagnostic(
-			PortableRecordingCodeMalformedContract, "document", "", "recording must contain exactly one JSON document",
 		)
 	}
 	if err := ValidatePortableRecording(recording); err != nil {
@@ -35,9 +51,39 @@ func DecodePortableRecording(reader io.Reader) (PortableRecording, error) {
 	return recording, nil
 }
 
+type portableRecordingHeader struct {
+	RecordingKind              string `json:"recordingKind"`
+	SchemaVersion              string `json:"schemaVersion"`
+	ReplayCompatibilityVersion string `json:"replayCompatibilityVersion"`
+}
+
+func decodePortableRecordingDocument(reader io.Reader) ([]byte, error) {
+	if reader == nil {
+		return nil, fmt.Errorf("recording reader is required")
+	}
+	decoder := json.NewDecoder(reader)
+	var document json.RawMessage
+	if err := decoder.Decode(&document); err != nil {
+		return nil, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return nil, fmt.Errorf("recording must contain exactly one JSON document")
+	}
+	return document, nil
+}
+
+func decodePortableRecordingHeader(document []byte) (portableRecordingHeader, error) {
+	var header portableRecordingHeader
+	if err := json.Unmarshal(document, &header); err != nil {
+		return portableRecordingHeader{}, err
+	}
+	return header, nil
+}
+
 // ValidatePortableRecording validates one portable recording document.
 func ValidatePortableRecording(recording PortableRecording) error {
-	if err := validatePortableRecordingCompatibility(recording); err != nil {
+	if err := validatePortableRecordingCompatibilityForValue(recording); err != nil {
 		return err
 	}
 	if err := validatePortableRecordingSession(recording); err != nil {
@@ -96,12 +142,10 @@ func validatePortableRecordingCheckpoint(recording PortableRecording) error {
 }
 
 func validatePortableRecordingResult(recording PortableRecording) error {
+	if err := validatePortableRecordingVersionSpecificFields(recording); err != nil {
+		return err
+	}
 	if recording.Result == nil {
-		if recording.SchemaVersion == portableRecordingSchemaV2 {
-			return portableRecordingDiagnostic(
-				PortableRecordingCodeInvalidSummary, "result", "result", "is required for the current schema version",
-			)
-		}
 		return nil
 	}
 	result := recording.Result
@@ -153,14 +197,16 @@ func validatePortableRecordingResult(recording PortableRecording) error {
 	return nil
 }
 
-func validatePortableRecordingCompatibility(recording PortableRecording) error {
-	if recording.RecordingKind != KindJavaScriptFactorySession {
+func validatePortableRecordingCompatibility(
+	recordingKind, schemaVersion, replayCompatibilityVersion string,
+) error {
+	if recordingKind != KindJavaScriptFactorySession {
 		return portableRecordingDiagnostic(
 			PortableRecordingCodeInvalidIdentity, "identity", "recordingKind",
 			fmt.Sprintf("must be %q", KindJavaScriptFactorySession),
 		)
 	}
-	if !slices.Contains(portableRecordingSupportedReplayVersions, recording.ReplayCompatibilityVersion) {
+	if !slices.Contains(portableRecordingSupportedReplayVersions, replayCompatibilityVersion) {
 		return &PortableRecordingDiagnostic{
 			Code: PortableRecordingCodeUnsupportedVersion, Area: "compatibility",
 			Path:              "replayCompatibilityVersion",
@@ -168,7 +214,7 @@ func validatePortableRecordingCompatibility(recording PortableRecording) error {
 			SupportedVersions: slices.Clone(portableRecordingSupportedReplayVersions),
 		}
 	}
-	if !slices.Contains(portableRecordingSupportedSchemaVersions, recording.SchemaVersion) {
+	if !slices.Contains(portableRecordingSupportedSchemaVersions, schemaVersion) {
 		return &PortableRecordingDiagnostic{
 			Code: PortableRecordingCodeUnsupportedVersion, Area: "compatibility", Path: "schemaVersion",
 			Message:           "unsupported recording schema version; migrate the recording before replay",
@@ -176,6 +222,30 @@ func validatePortableRecordingCompatibility(recording PortableRecording) error {
 		}
 	}
 	return nil
+}
+
+func validatePortableRecordingCompatibilityForValue(recording PortableRecording) error {
+	return validatePortableRecordingCompatibility(
+		recording.RecordingKind, recording.SchemaVersion, recording.ReplayCompatibilityVersion,
+	)
+}
+
+func validatePortableRecordingVersionSpecificFields(recording PortableRecording) error {
+	switch recording.SchemaVersion {
+	case PortableRecordingSchemaV1:
+		// Schema 1 predates the result projection. An omitted result is part of
+		// its contract and must not be defaulted into a success or failure.
+		return nil
+	case PortableRecordingSchemaV2:
+		if recording.Result == nil {
+			return portableRecordingDiagnostic(
+				PortableRecordingCodeInvalidSummary, "result", "result", "is required for the current schema version",
+			)
+		}
+		return nil
+	default:
+		return validatePortableRecordingCompatibilityForValue(recording)
+	}
 }
 
 func validatePortableRecordingSession(recording PortableRecording) error {

--- a/pkg/services/recordings/internal/contracts/portable_recording_validate.go
+++ b/pkg/services/recordings/internal/contracts/portable_recording_validate.go
@@ -10,12 +10,55 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+
+	workerrecording "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/worker_capture"
 )
 
 var portableRecordingSHA256Pattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 
 // DecodePortableRecording decodes and validates one portable recording document.
 func DecodePortableRecording(reader io.Reader) (PortableRecording, error) {
+	return CurrentPortableRecordingCodec().Decode(reader)
+}
+
+// PortableRecordingCompatibilityPolicy defines the versions understood by a
+// reader. Keeping the policy as a value makes an older-reader compatibility
+// harness deterministic without changing the current Recordings policy.
+type PortableRecordingCompatibilityPolicy struct {
+	SupportedSchemaVersions              []string
+	SupportedReplayCompatibilityVersions []string
+}
+
+// PortableRecordingCodec is a strict, version-pinned portable recording
+// reader/validator. It has no persistence or replay side effects.
+type PortableRecordingCodec struct {
+	policy PortableRecordingCompatibilityPolicy
+}
+
+// NewPortableRecordingCodec constructs a reader with an explicit compatibility
+// matrix. Callers that need the current reader should use
+// CurrentPortableRecordingCodec instead.
+func NewPortableRecordingCodec(
+	schemaVersions, replayCompatibilityVersions []string,
+) PortableRecordingCodec {
+	return PortableRecordingCodec{policy: PortableRecordingCompatibilityPolicy{
+		SupportedSchemaVersions:              normalizePortableRecordingVersions(schemaVersions),
+		SupportedReplayCompatibilityVersions: normalizePortableRecordingVersions(replayCompatibilityVersions),
+	}}
+}
+
+// CurrentPortableRecordingCodec returns the Recordings reader for all shipped
+// Factory Session recording schemas.
+func CurrentPortableRecordingCodec() PortableRecordingCodec {
+	return NewPortableRecordingCodec(
+		portableRecordingSupportedSchemaVersions,
+		portableRecordingSupportedReplayVersions,
+	)
+}
+
+// Decode decodes and validates one document against the codec's pinned policy.
+func (codec PortableRecordingCodec) Decode(reader io.Reader) (PortableRecording, error) {
+	policy := codec.effectivePolicy()
 	document, err := decodePortableRecordingDocument(reader)
 	if err != nil {
 		return PortableRecording{}, portableRecordingDiagnostic(
@@ -28,11 +71,13 @@ func DecodePortableRecording(reader io.Reader) (PortableRecording, error) {
 			PortableRecordingCodeMalformedContract, "document", "", "decode recording header: "+err.Error(),
 		)
 	}
-	// A missing version header is still a malformed document. Let the strict
-	// decoder inspect the complete envelope first so unknown fields and other
-	// structural corruption are not misclassified as unsupported versions.
+	// An incomplete version header must remain a malformed document. Let the
+	// strict decoder inspect the complete envelope first so the value validator
+	// can report the missing field instead of classifying it as unsupported.
 	if header.SchemaVersion != "" && header.ReplayCompatibilityVersion != "" {
-		if err := validatePortableRecordingCompatibility(header.RecordingKind, header.SchemaVersion, header.ReplayCompatibilityVersion); err != nil {
+		if err := validatePortableRecordingCompatibilityWithPolicy(
+			policy, header.RecordingKind, header.SchemaVersion, header.ReplayCompatibilityVersion,
+		); err != nil {
 			return PortableRecording{}, err
 		}
 	}
@@ -45,10 +90,63 @@ func DecodePortableRecording(reader io.Reader) (PortableRecording, error) {
 			PortableRecordingCodeMalformedContract, "document", "", "decode recording: "+err.Error(),
 		)
 	}
-	if err := ValidatePortableRecording(recording); err != nil {
+	if err := codec.Validate(recording); err != nil {
 		return PortableRecording{}, err
 	}
 	return recording, nil
+}
+
+// Validate validates one detached recording against the codec's pinned policy.
+func (codec PortableRecordingCodec) Validate(recording PortableRecording) error {
+	return validatePortableRecording(recording, codec.effectivePolicy())
+}
+
+// DecodePortableRecordingWithVersions is a convenience for compatibility
+// tests and migration tools that need a version-pinned reader without keeping
+// a codec value.
+func DecodePortableRecordingWithVersions(
+	reader io.Reader, schemaVersions, replayCompatibilityVersions []string,
+) (PortableRecording, error) {
+	return NewPortableRecordingCodec(schemaVersions, replayCompatibilityVersions).Decode(reader)
+}
+
+// ValidatePortableRecordingWithVersions validates a detached recording against
+// an explicit compatibility matrix.
+func ValidatePortableRecordingWithVersions(
+	recording PortableRecording, schemaVersions, replayCompatibilityVersions []string,
+) error {
+	return NewPortableRecordingCodec(schemaVersions, replayCompatibilityVersions).Validate(recording)
+}
+
+func (codec PortableRecordingCodec) effectivePolicy() PortableRecordingCompatibilityPolicy {
+	policy := codec.policy
+	if len(policy.SupportedSchemaVersions) == 0 {
+		policy.SupportedSchemaVersions = slices.Clone(portableRecordingSupportedSchemaVersions)
+	}
+	if len(policy.SupportedReplayCompatibilityVersions) == 0 {
+		policy.SupportedReplayCompatibilityVersions = slices.Clone(portableRecordingSupportedReplayVersions)
+	}
+	return policy
+}
+
+func normalizePortableRecordingVersions(versions []string) []string {
+	if len(versions) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(versions))
+	seen := make(map[string]struct{}, len(versions))
+	for _, version := range versions {
+		version = strings.TrimSpace(version)
+		if version == "" {
+			continue
+		}
+		if _, exists := seen[version]; exists {
+			continue
+		}
+		seen[version] = struct{}{}
+		result = append(result, version)
+	}
+	return result
 }
 
 type portableRecordingHeader struct {
@@ -83,7 +181,14 @@ func decodePortableRecordingHeader(document []byte) (portableRecordingHeader, er
 
 // ValidatePortableRecording validates one portable recording document.
 func ValidatePortableRecording(recording PortableRecording) error {
-	if err := validatePortableRecordingCompatibilityForValue(recording); err != nil {
+	return CurrentPortableRecordingCodec().Validate(recording)
+}
+
+func validatePortableRecording(
+	recording PortableRecording,
+	policy PortableRecordingCompatibilityPolicy,
+) error {
+	if err := validatePortableRecordingCompatibilityForValue(policy, recording); err != nil {
 		return err
 	}
 	if err := validatePortableRecordingSession(recording); err != nil {
@@ -197,7 +302,8 @@ func validatePortableRecordingResult(recording PortableRecording) error {
 	return nil
 }
 
-func validatePortableRecordingCompatibility(
+func validatePortableRecordingCompatibilityWithPolicy(
+	policy PortableRecordingCompatibilityPolicy,
 	recordingKind, schemaVersion, replayCompatibilityVersion string,
 ) error {
 	if recordingKind != KindJavaScriptFactorySession {
@@ -206,26 +312,44 @@ func validatePortableRecordingCompatibility(
 			fmt.Sprintf("must be %q", KindJavaScriptFactorySession),
 		)
 	}
-	if !slices.Contains(portableRecordingSupportedReplayVersions, replayCompatibilityVersion) {
+	if strings.TrimSpace(schemaVersion) == "" {
+		return portableRecordingDiagnostic(
+			PortableRecordingCodeMalformedContract, "compatibility", "schemaVersion", "is required",
+		)
+	}
+	if strings.TrimSpace(replayCompatibilityVersion) == "" {
+		return portableRecordingDiagnostic(
+			PortableRecordingCodeMalformedContract, "compatibility", "replayCompatibilityVersion", "is required",
+		)
+	}
+	if !slices.Contains(policy.SupportedReplayCompatibilityVersions, replayCompatibilityVersion) {
 		return &PortableRecordingDiagnostic{
 			Code: PortableRecordingCodeUnsupportedVersion, Area: "compatibility",
-			Path:              "replayCompatibilityVersion",
-			Message:           "unsupported replay compatibility version; use a supported version or migrate the recording",
-			SupportedVersions: slices.Clone(portableRecordingSupportedReplayVersions),
+			Path:               "replayCompatibilityVersion",
+			Message:            "unsupported replay compatibility version; upgrade the reader or migrate the recording to a supported version",
+			EncounteredVersion: replayCompatibilityVersion,
+			SupportedVersions:  slices.Clone(policy.SupportedReplayCompatibilityVersions),
+			Action:             PortableRecordingCompatibilityAction,
 		}
 	}
-	if !slices.Contains(portableRecordingSupportedSchemaVersions, schemaVersion) {
+	if !slices.Contains(policy.SupportedSchemaVersions, schemaVersion) {
 		return &PortableRecordingDiagnostic{
-			Code: PortableRecordingCodeUnsupportedVersion, Area: "compatibility", Path: "schemaVersion",
-			Message:           "unsupported recording schema version; migrate the recording before replay",
-			SupportedVersions: slices.Clone(portableRecordingSupportedSchemaVersions),
+			Code: PortableRecordingCodeUnsupportedSchema, Area: "compatibility", Path: "schemaVersion",
+			Message:            "unsupported recording schema version; upgrade the reader or migrate the recording to a supported version",
+			EncounteredVersion: schemaVersion,
+			SupportedVersions:  slices.Clone(policy.SupportedSchemaVersions),
+			Action:             PortableRecordingCompatibilityAction,
 		}
 	}
 	return nil
 }
 
-func validatePortableRecordingCompatibilityForValue(recording PortableRecording) error {
-	return validatePortableRecordingCompatibility(
+func validatePortableRecordingCompatibilityForValue(
+	policy PortableRecordingCompatibilityPolicy,
+	recording PortableRecording,
+) error {
+	return validatePortableRecordingCompatibilityWithPolicy(
+		policy,
 		recording.RecordingKind, recording.SchemaVersion, recording.ReplayCompatibilityVersion,
 	)
 }
@@ -235,16 +359,98 @@ func validatePortableRecordingVersionSpecificFields(recording PortableRecording)
 	case PortableRecordingSchemaV1:
 		// Schema 1 predates the result projection. An omitted result is part of
 		// its contract and must not be defaulted into a success or failure.
+		if recording.WorkerHistory != nil {
+			return portableRecordingDiagnostic(
+				PortableRecordingCodeInvalidSummary, "compatibility", "workerHistory",
+				"Worker history is only supported by the current schema version; export the recording again",
+			)
+		}
 		return nil
 	case PortableRecordingSchemaV2:
+		if recording.WorkerHistory != nil {
+			return portableRecordingDiagnostic(
+				PortableRecordingCodeInvalidSummary, "compatibility", "workerHistory",
+				"Worker history is only supported by the current schema version; export the recording again",
+			)
+		}
 		if recording.Result == nil {
 			return portableRecordingDiagnostic(
 				PortableRecordingCodeInvalidSummary, "result", "result", "is required for the current schema version",
 			)
 		}
 		return nil
+	case PortableRecordingSchemaV3:
+		if recording.Result == nil {
+			return portableRecordingDiagnostic(
+				PortableRecordingCodeInvalidSummary, "result", "result", "is required for the current schema version",
+			)
+		}
+		return validatePortableRecordingWorkerHistory(recording)
 	default:
-		return validatePortableRecordingCompatibilityForValue(recording)
+		return validatePortableRecordingCompatibilityForValue(
+			PortableRecordingCompatibilityPolicy{
+				SupportedSchemaVersions:              portableRecordingSupportedSchemaVersions,
+				SupportedReplayCompatibilityVersions: portableRecordingSupportedReplayVersions,
+			}, recording,
+		)
+	}
+}
+
+func validatePortableRecordingWorkerHistory(recording PortableRecording) error {
+	history := recording.WorkerHistory
+	if history == nil {
+		return portableRecordingDiagnostic(
+			PortableRecordingCodeInvalidSummary, "workerHistory", "workerHistory",
+			"is required for the current schema version",
+		)
+	}
+	switch history.Availability {
+	case PortableRecordingWorkerHistoryUnavailable:
+		if history.WorkerPortableRecording != nil {
+			return portableRecordingDiagnostic(
+				PortableRecordingCodeInvalidSummary, "workerHistory", "workerHistory.recording",
+				"must be absent when Worker history is unavailable",
+			)
+		}
+		if strings.TrimSpace(history.Reason) == "" {
+			return portableRecordingDiagnostic(
+				PortableRecordingCodeInvalidSummary, "workerHistory", "workerHistory.reason",
+				"is required when Worker history is unavailable",
+			)
+		}
+		return nil
+	case PortableRecordingWorkerHistoryAvailable:
+		if history.WorkerPortableRecording == nil {
+			return portableRecordingDiagnostic(
+				PortableRecordingCodeInvalidSummary, "workerHistory", "workerHistory.recording",
+				"is required when Worker history is available",
+			)
+		}
+		if strings.TrimSpace(history.Reason) != "" {
+			return portableRecordingDiagnostic(
+				PortableRecordingCodeInvalidSummary, "workerHistory", "workerHistory.reason",
+				"must be absent when Worker history is available",
+			)
+		}
+		if err := (workerrecording.WorkerRecordingCodec{}).ValidateWorkerPortableRecording(*history.WorkerPortableRecording); err != nil {
+			return portableRecordingDiagnostic(
+				PortableRecordingCodeInvalidSummary, "workerHistory", "workerHistory",
+				"contains an invalid canonical Worker recording",
+			)
+		}
+		factorySessionID := strings.TrimSpace(history.Correlation.FactorySessionID)
+		if factorySessionID != "" && factorySessionID != recording.Session.ID {
+			return portableRecordingDiagnostic(
+				PortableRecordingCodeInvalidIdentity, "workerHistory", "workerHistory.correlation.factorySessionId",
+				"does not match the Factory Session identity",
+			)
+		}
+		return nil
+	default:
+		return portableRecordingDiagnostic(
+			PortableRecordingCodeInvalidSummary, "workerHistory", "workerHistory.availability",
+			"must be AVAILABLE or UNAVAILABLE",
+		)
 	}
 }
 

--- a/pkg/services/recordings/internal/replay_artifact_capability.go
+++ b/pkg/services/recordings/internal/replay_artifact_capability.go
@@ -354,8 +354,10 @@ func replayArtifactDiagnosticFromPortable(
 		return replayInputDependencyDiagnostic()
 	}
 	result := recordings.ReplayArtifactDiagnostic{
-		Area: diagnostic.Area,
-		Path: safeReplayArtifactDiagnosticPath(diagnostic.Path),
+		Area:               diagnostic.Area,
+		Path:               safeReplayArtifactDiagnosticPath(diagnostic.Path),
+		EncounteredVersion: diagnostic.EncounteredVersion,
+		Action:             diagnostic.Action,
 	}
 	switch diagnostic.Code {
 	case recordings.PortableRecordingCodeMalformedContract:
@@ -364,6 +366,10 @@ func replayArtifactDiagnosticFromPortable(
 	case recordings.PortableRecordingCodeUnsupportedVersion:
 		result.Code = recordings.ReplayArtifactDiagnosticUnsupportedVersion
 		result.Message = "recording uses an unsupported replay compatibility version"
+		result.SupportedVersions = slices.Clone(diagnostic.SupportedVersions)
+	case recordings.PortableRecordingCodeUnsupportedSchema:
+		result.Code = recordings.ReplayArtifactDiagnosticUnsupportedSchema
+		result.Message = "recording uses an unsupported schema version"
 		result.SupportedVersions = slices.Clone(diagnostic.SupportedVersions)
 	case recordings.PortableRecordingCodeInvalidIdentity:
 		result.Code = recordings.ReplayArtifactDiagnosticInvalidIdentity

--- a/pkg/services/recordings/replay_artifact_capability.go
+++ b/pkg/services/recordings/replay_artifact_capability.go
@@ -323,6 +323,7 @@ type ReplayArtifactDiagnosticCode string
 const (
 	ReplayArtifactDiagnosticMalformed             ReplayArtifactDiagnosticCode = "MALFORMED_REPLAY_ARTIFACT"
 	ReplayArtifactDiagnosticUnsupportedVersion    ReplayArtifactDiagnosticCode = "UNSUPPORTED_REPLAY_COMPATIBILITY_VERSION"
+	ReplayArtifactDiagnosticUnsupportedSchema     ReplayArtifactDiagnosticCode = "UNSUPPORTED_RECORDING_SCHEMA_VERSION"
 	ReplayArtifactDiagnosticInvalidIdentity       ReplayArtifactDiagnosticCode = "INVALID_RECORDING_IDENTITY"
 	ReplayArtifactDiagnosticInvalidSummary        ReplayArtifactDiagnosticCode = "INVALID_RECORDING_SUMMARY"
 	ReplayArtifactDiagnosticInvalidIntegrity      ReplayArtifactDiagnosticCode = "INVALID_REPLAY_ARTIFACT_INTEGRITY"
@@ -340,11 +341,13 @@ const (
 // never a customer filesystem path. SupportedVersions is present only when a
 // compatibility failure can name supported values.
 type ReplayArtifactDiagnostic struct {
-	Code              ReplayArtifactDiagnosticCode
-	Area              string
-	Path              string
-	Message           string
-	SupportedVersions []string
+	Code               ReplayArtifactDiagnosticCode
+	Area               string
+	Path               string
+	Message            string
+	EncounteredVersion string
+	SupportedVersions  []string
+	Action             string
 }
 
 // Error renders only the stable, safe diagnostic facts.

--- a/pkg/services/recordings/wire/replay_input_test.go
+++ b/pkg/services/recordings/wire/replay_input_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	recordings "github.com/portpowered/infinite-you/pkg/services/recordings"
 	recordingswire "github.com/portpowered/infinite-you/pkg/services/recordings/wire"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
 )
 
 func TestReplayInputLoaderClassifiesPortableRecording(t *testing.T) {
@@ -44,6 +45,40 @@ func TestReplayInputLoaderClassifiesPortableRecording(t *testing.T) {
 	}
 	if got := result.Portable.Session.ID; got != "session-js-001" {
 		t.Fatalf("Portable.Session.ID = %q, want session-js-001", got)
+	}
+}
+
+func TestReplayInputLoaderLoadsCurrentWorkerHistoryExport(t *testing.T) {
+	t.Parallel()
+
+	path := testpath.MustRepoPathFromCaller(
+		t,
+		0,
+		"pkg", "services", "recordings", "internal", "artifacts", "testdata", "valid-v3-worker-history.json",
+	)
+	loader := recordingswire.NewReplayInputLoader(
+		recordings.RecordingReadFile(os.ReadFile),
+		func(string) (*recordings.ReplayArtifact, error) {
+			t.Fatal("legacy loader must not be called for a current portable recording")
+			return nil, nil
+		},
+		logging.NoopLogger{},
+	)
+	result, err := loader.LoadReplayInput(recordings.LoadReplayInputRequest{Path: path})
+	if err != nil {
+		t.Fatalf("LoadReplayInput() error = %v", err)
+	}
+	if result.Portable == nil || result.Portable.SchemaVersion != recordings.PortableRecordingSchemaV3 {
+		t.Fatalf("Portable = %#v, want current schema", result.Portable)
+	}
+	history := result.Portable.WorkerHistory
+	if history == nil || history.Availability != recordings.PortableRecordingWorkerHistoryAvailable ||
+		history.WorkerPortableRecording == nil || len(history.Records) != 3 {
+		t.Fatalf("Worker history = %#v, want available ordered history", history)
+	}
+	if history.Correlation.FactorySessionID != result.Portable.Session.ID ||
+		history.Records[1].Provenance.Fidelity != workers.FidelityNormalized {
+		t.Fatalf("Worker correlation/fidelity = %#v", history)
 	}
 }
 
@@ -204,7 +239,7 @@ func TestReplayInputLoaderPublishesDetachedSafeDiagnostic(t *testing.T) {
 
 	loader := recordingswire.NewReplayInputLoader(
 		func(string) ([]byte, error) {
-			return []byte(`{"recordingKind":"` + recordings.KindJavaScriptFactorySession + `","replayCompatibilityVersion":"99"}`), nil
+			return []byte(`{"recordingKind":"` + recordings.KindJavaScriptFactorySession + `","schemaVersion":"2","replayCompatibilityVersion":"99"}`), nil
 		},
 		nil,
 		logging.NoopLogger{},
@@ -225,6 +260,29 @@ func TestReplayInputLoaderPublishesDetachedSafeDiagnostic(t *testing.T) {
 	second := requireReplayInputDiagnostic(t, err)
 	if second.Path == "mutated" || second.SupportedVersions[0] == "mutated" {
 		t.Fatalf("later diagnostic observed caller mutation: %#v", second)
+	}
+}
+
+func TestReplayInputLoaderClassifiesUnsupportedSchemaSeparately(t *testing.T) {
+	t.Parallel()
+
+	loader := recordingswire.NewReplayInputLoader(
+		func(string) ([]byte, error) {
+			return []byte(`{"recordingKind":"` + recordings.KindJavaScriptFactorySession + `","schemaVersion":"99","replayCompatibilityVersion":"1","secret":"provider output"}`), nil
+		},
+		nil,
+		logging.NoopLogger{},
+	)
+
+	_, err := loader.LoadReplayInput(recordings.LoadReplayInputRequest{Path: "recording.json"})
+	diagnostic := requireReplayInputDiagnostic(t, err)
+	if diagnostic.Code != recordings.ReplayArtifactDiagnosticUnsupportedSchema ||
+		diagnostic.Area != "compatibility" || diagnostic.Path != "schemaVersion" ||
+		diagnostic.EncounteredVersion != "99" || diagnostic.Action != recordings.PortableRecordingCompatibilityAction {
+		t.Fatalf("diagnostic = %#v, want unsupported-schema compatibility facts", diagnostic)
+	}
+	if len(diagnostic.SupportedVersions) == 0 || strings.Contains(diagnostic.Message, "provider output") {
+		t.Fatalf("diagnostic = %#v, want supported versions without payload content", diagnostic)
 	}
 }
 

--- a/pkg/transports/cli/run/run.go
+++ b/pkg/transports/cli/run/run.go
@@ -575,6 +575,14 @@ func emitHistoricalReplayInspection(
 	); err != nil {
 		return fmt.Errorf("write historical replay inspection: %w", err)
 	}
+	if _, err := fmt.Fprintf(
+		output,
+		"Worker history: %s (reason=%s)\n",
+		inspection.WorkerHistory.Availability,
+		inspection.WorkerHistory.Reason,
+	); err != nil {
+		return fmt.Errorf("write historical replay inspection: %w", err)
+	}
 	if inspection.Checkpoint != nil {
 		if _, err := fmt.Fprintf(
 			output,

--- a/pkg/transports/cli/run/run_test.go
+++ b/pkg/transports/cli/run/run_test.go
@@ -26,9 +26,32 @@ import (
 	"github.com/portpowered/infinite-you/pkg/platform/metrics"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	runtimehost "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
 	recordingscli "github.com/portpowered/infinite-you/pkg/services/recordings/transports/cli"
 )
+
+func TestEmitHistoricalReplayInspectionIncludesLegacyWorkerHistoryOutcome(t *testing.T) {
+	t.Parallel()
+	var output bytes.Buffer
+	err := emitHistoricalReplayInspection(&output, factorysessions.HistoricalReplayInspection{
+		Session: factorysessions.SessionReadResult{
+			SessionID: "legacy-session", Status: factorysessions.LifecycleStatusFailed,
+			ResolvedSource: factorysessions.ResolvedSource{SourceRef: "workflow/legacy.js"},
+		},
+		WorkerHistory: recordings.PortableRecordingWorkerHistory{
+			Availability: recordings.PortableRecordingWorkerHistoryUnavailable,
+			Reason:       recordings.PortableRecordingWorkerHistoryReasonLegacySchema,
+		},
+	})
+	if err != nil {
+		t.Fatalf("emitHistoricalReplayInspection() error = %v", err)
+	}
+	want := "Worker history: UNAVAILABLE (reason=SCHEMA_DID_NOT_RECORD_CANONICAL_WORKER_HISTORY)"
+	if !strings.Contains(output.String(), want) {
+		t.Fatalf("historical replay output = %q, want %q", output.String(), want)
+	}
+}
 
 type stubFactoryService struct {
 	run                   func(context.Context) error

--- a/tests/functional/recordings/root_composition/portable_replay_execution_test.go
+++ b/tests/functional/recordings/root_composition/portable_replay_execution_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/portpowered/infinite-you/internal/testpath"
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	"github.com/portpowered/infinite-you/pkg/root"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
@@ -31,6 +32,62 @@ func TestPortableReplayInspectionExecutesThroughRootProcess(t *testing.T) {
 
 	output := functionalExecutePortableReplay(t, process)
 	functionalAssertPortableReplayInspection(t, output, calls)
+}
+
+// TestWSRFT016RecordingCompatibilityThroughCustomerFacingReplayPath proves
+// that the root-composed replay command keeps legacy recordings readable and
+// carries the current Worker-history outcome through historical inspection.
+//
+// WSR-FT-016: legacy/current fixture load, honest legacy Worker-history
+// unavailability, current Worker-history preservation, and no live execution.
+func TestWSRFT016RecordingCompatibilityThroughCustomerFacingReplayPath(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range []struct {
+		name          string
+		fixture       string
+		wantSession   string
+		wantStatus    string
+		wantWorker    string
+		wantEventLine string
+	}{
+		{
+			name: "legacy-schema-v2", fixture: "valid-v2.json", wantSession: "session-js-001",
+			wantStatus: "SUCCEEDED", wantWorker: "Worker history: UNAVAILABLE (reason=SCHEMA_DID_NOT_RECORD_CANONICAL_WORKER_HISTORY)",
+			wantEventLine: "Events: 2",
+		},
+		{
+			name: "current-schema-v3-worker-history", fixture: "valid-v3-worker-history.json", wantSession: "session-current-worker-001",
+			wantStatus: "SUCCEEDED", wantWorker: "Worker history: AVAILABLE (reason=)", wantEventLine: "Events: 2",
+		},
+	} {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			payloadPath := testpath.MustRepoPathFromCaller(
+				t, 0, "pkg", "services", "recordings", "internal", "artifacts", "testdata", testCase.fixture,
+			)
+			payload, err := os.ReadFile(payloadPath)
+			if err != nil {
+				t.Fatalf("read fixture %q: %v", testCase.fixture, err)
+			}
+			calls := &functionalReplayLiveConstructionCalls{}
+			process := support.BuildProcess(t, functionalPortableReplayEdges(t, payload, calls))
+			output := functionalExecutePortableReplay(t, process)
+			if calls.replayReads.Load() != 1 || calls.providerRuns.Load() != 0 || calls.scriptRuns.Load() != 0 ||
+				calls.sessionIDRequests.Load() != 0 || calls.hostBindings.Load() != 0 {
+				t.Fatalf("replay/live calls = reads:%d provider:%d script:%d sessionID:%d host:%d", calls.replayReads.Load(), calls.providerRuns.Load(), calls.scriptRuns.Load(), calls.sessionIDRequests.Load(), calls.hostBindings.Load())
+			}
+			for _, want := range []string{
+				"Replayed Factory Session: " + testCase.wantSession,
+				"Status: " + testCase.wantStatus,
+				testCase.wantWorker,
+				testCase.wantEventLine,
+			} {
+				if !bytes.Contains([]byte(output), []byte(want)) {
+					t.Fatalf("WSR-FT-016 replay output = %q, want %q", output, want)
+				}
+			}
+		})
+	}
 }
 
 type functionalReplayLiveConstructionCalls struct {
@@ -116,6 +173,7 @@ func functionalAssertPortableReplayInspection(
 		"Source: workflow/example.js",
 		"Status: SUCCEEDED",
 		"Result: FINAL",
+		"Worker history: UNAVAILABLE (reason=CANONICAL_WORKER_HISTORY_NOT_CAPTURED)",
 		"Artifacts: 1",
 		"Artifact: artifact-1 (CHECKPOINT)",
 		"Checkpoint: checkpoint-1 (Waiting for operator input)",


### PR DESCRIPTION
{
  "project": "WSR-008 Legacy Recordings Remain Honest and Readable",
  "branchName": "wsr-008-legacy-compat",
  "description": "Implement WSR-008 of the Worker Session Recordings program so every previously supported recording schema remains readable, legacy artifacts report canonical Worker history as explicitly unavailable rather than empty or complete, and new Worker-history-capable exports use a distinct schema version with actionable unsupported-version diagnostics for older readers. WSR-FT-016 and version-pinned compatibility fixtures provide the required evidence.",
  "context": {
    "customerAsk": "Customers need existing recording artifacts to remain readable after Worker history is added to exports. Old artifacts must not be reinterpreted as containing an empty or complete Worker timeline, new artifacts must declare their schema version, and an older reader must explain clearly when it cannot consume that version. The required evidence is WSR-FT-016 plus compatibility fixtures for each supported legacy and current schema version.",
    "problem": "A decoder can deserialize a pre-Worker-history artifact with a zero-value collection and incorrectly report that no Worker activity occurred or that history is complete. A newly exported artifact can also be partially accepted by an older reader or rejected with a generic error that does not identify the incompatible version or supported alternatives. These outcomes make historical inspection dishonest and upgrades difficult to diagnose.",
    "solution": "Keep version dispatch and compatibility policy under Recordings ownership. Preserve strict decoding and validation for every shipped schema, normalize legacy artifacts to an explicit Worker-history UNAVAILABLE outcome with no fabricated records or completion claim, emit Worker-history-capable exports under one new schema version, and reject unknown or newer versions without partial output using a typed diagnostic that identifies the encountered version, reader-supported versions, and an upgrade-or-migration action. Prove the compatibility matrix with WSR-FT-016 and immutable fixtures."
  },
  "acceptanceCriteria": [
    "Every recording schema version supported before WSR-008 continues to decode and validate from a version-pinned fixture while preserving its established Factory Session behavior.",
    "A valid legacy artifact that predates canonical Worker history yields an explicit Worker-history UNAVAILABLE outcome with a stable compatibility reason, no Worker records, and no empty, available, complete, or failed history claim.",
    "New exports use one explicit next schema version for the Worker-history-capable contract, carry a truthful Worker-history availability/result, and do not change the meaning of an older schema version.",
    "An unknown or newer schema version returns a typed unsupported-version diagnostic identifying the rejected version, reader-supported versions, and an upgrade-or-migration action, with no partial artifact, replay facts, or Worker history.",
    "WSR-FT-016 and focused compatibility fixtures prove legacy readability, honest unavailable Worker history, current export versioning, old-reader rejection, and deterministic diagnostics through customer-facing recording load/export behavior.",
    "Typecheck passes and tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared/generated-file churn are resolved against current main, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "wsr-008-legacy-compat-001",
      "title": "Keep every shipped recording version readable",
      "description": "As a customer retaining historical recordings, I want every previously supported schema version to keep decoding and validating so that an upgrade does not strand my Factory Session history.",
      "acceptanceCriteria": [
        "One immutable fixture for each previously supported schema version decodes and validates successfully through the production Recordings reader.",
        "Each decoded fixture preserves the established Factory Session identity, source, ordered event and artifact summaries, checkpoint/result semantics when present, redaction metadata, and replay compatibility for that version.",
        "Version-specific defaults are applied only according to the artifact's declared version; no legacy fixture is silently rewritten as the new schema or required to contain fields introduced later.",
        "Corrupt content labeled as a supported version returns its owned malformed, identity, digest, summary, order, or integrity outcome rather than being misclassified as unsupported.",
        "Focused Recordings codec/validation compatibility tests pass.",
        "Typecheck passes.",
        "Tests pass."
      ],
      "priority": 1,
      "passes": true,
      "notes": "Completed. Recordings now exposes explicit shipped schema/replay constants, performs strict version-aware decoding while preserving malformed-input classification, and verifies immutable schema-1/schema-2/checkpoint fixtures plus supported-schema corruption through the production decoder. Focused Recordings and Factory Session execution suites pass."
    },
    {
      "id": "wsr-008-legacy-compat-002",
      "title": "Report legacy Worker history as unavailable",
      "description": "As a customer inspecting a recording created before Worker history was captured, I want the reader to say that Worker history is unavailable so that absence of evidence is not presented as an empty or completed execution.",
      "acceptanceCriteria": [
        "Loading any valid pre-Worker-history schema produces the explicit Worker-history availability state UNAVAILABLE with a stable reason indicating that the artifact schema did not record canonical Worker history.",
        "The legacy projection contains no fabricated Worker records, terminal record, fidelity claim, provider attribution, completeness flag, or empty-history success claim.",
        "Factory Session events, results, and other facts that the legacy artifact does contain remain available and unchanged; unavailable Worker history does not make the whole artifact invalid.",
        "Repeated decode and replay of the same fixture returns the same availability state and reason without consulting Workers, Providers, Events, or a provider transcript.",
        "Focused normalization/projection and replay tests pass.",
        "Typecheck passes.",
        "Tests pass."
      ],
      "priority": 2,
      "passes": true,
      "notes": "Completed. Legacy schema-1/schema-2 recordings now normalize through the pure Recordings-owned compatibility projection to UNAVAILABLE with stable reason SCHEMA_DID_NOT_RECORD_CANONICAL_WORKER_HISTORY. Replay preserves Factory Session events, results, artifacts, and schema-1's omitted result without fabricating Worker or result claims; historical inspection and CLI expose the outcome. Fixture-backed normalization, replay, inspection, and output tests pass."
    },
    {
      "id": "wsr-008-legacy-compat-003",
      "title": "Version new exports and diagnose unsupported readers",
      "description": "As a customer exchanging a newly exported recording, I want its Worker-history contract to be explicitly versioned and incompatibility errors to tell me what to do so that readers never silently misinterpret it.",
      "acceptanceCriteria": [
        "New exports declare one explicit next schema version and the supported replay-compatibility version; the new version is used only for the contract that can truthfully represent canonical Worker-history availability and content.",
        "A current reader decodes and validates the new export, preserving its Worker-history availability, ordered records when available, lifecycle/correlation/provenance/fidelity facts, and established Factory Session recording facts.",
        "A version-pinned old-reader compatibility harness rejects the new export before projecting version-specific fields and returns no partial artifact, replay plan, result, or Worker history.",
        "The unsupported-schema diagnostic has a stable typed code and path and exposes the encountered version, the old reader's supported versions, and an actionable instruction to upgrade the reader or migrate/export the artifact to a supported version; it does not expose payload or provider content.",
        "Unsupported schema, unsupported replay compatibility, and malformed supported-schema inputs remain separately classifiable.",
        "WSR-FT-016 passes through the customer-facing recording export/load path and compatibility fixtures cover current-reader/legacy-artifact, current-reader/current-artifact, and old-reader/current-artifact combinations.",
        "Typecheck passes.",
        "Tests pass."
      ],
      "priority": 3,
      "passes": true,
      "notes": "Completed. PortableRecording now emits schema 3 with explicit Worker-history availability, validates and replays available Worker records without losing lifecycle/correlation/provenance/fidelity facts, and keeps legacy schema semantics unchanged. Version-pinned current/legacy fixtures, WSR-FT-016 root replay coverage, current export/load checks, old-reader no-partial-output rejection, separate schema/replay/malformed diagnostics, typecheck, tests, and repository gates pass; PR review/CI remains external to this executor lane."
    }
  ]
}
