### PR TITLE
coverage-floor-epsilon

### DIFF
--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/exec"
 	"path"
@@ -39,6 +40,7 @@ const modulePath = "github.com/portpowered/infinite-you"
 const defaultPackageCoverageBaselinePath = "docs/internal/baselines/go-coverage-package-baseline.txt"
 const defaultFunctionalPackageCoverageBaselinePath = "docs/internal/baselines/go-functional-coverage-package-baseline.txt"
 const defaultPackageCoverageMin = 80.0
+const defaultPackageFloorEpsilon = 0.25
 const defaultCoverageJobs = 2
 
 var (
@@ -67,23 +69,24 @@ var (
 )
 
 type config struct {
-	covermode        string
-	coverpkg         string
-	jobs             int
-	generateManifest string
-	updateManifest   string
-	packageManifest  string
-	jsonOutput       string
-	timingOutput     string
-	min              float64
-	packageBaseline  string
-	packageMin       float64
-	packages         string
-	profile          string
-	short            bool
-	suite            string
-	timeout          time.Duration
-	totalOnly        bool
+	covermode           string
+	coverpkg            string
+	jobs                int
+	generateManifest    string
+	updateManifest      string
+	packageManifest     string
+	jsonOutput          string
+	timingOutput        string
+	min                 float64
+	packageBaseline     string
+	packageMin          float64
+	packageFloorEpsilon float64
+	packages            string
+	profile             string
+	short               bool
+	suite               string
+	timeout             time.Duration
+	totalOnly           bool
 }
 
 type coverageResult struct {
@@ -94,6 +97,7 @@ type coverageResult struct {
 	packageGates                 map[string]packageCoverageGate
 	zeroCoveragePackages         []string
 	packageMinimumFailures       []string
+	packageMinimumWarnings       []string
 }
 
 type packageCoverageTotals struct {
@@ -160,6 +164,9 @@ func execute(cfg config) error {
 	if err := writeCoverageSummaryJSON(cfg.jsonOutput, result); err != nil {
 		return err
 	}
+	for _, warning := range result.packageMinimumWarnings {
+		fmt.Fprintln(stderrWriter, warning)
+	}
 
 	if len(failures) > 0 {
 		return errors.New(strings.Join(failures, "\n"))
@@ -181,6 +188,7 @@ func parseConfig() config {
 	flag.Float64Var(&cfg.min, "min", 0, "minimum total statement coverage percentage")
 	flag.StringVar(&cfg.packageBaseline, "package-baseline", "", "newline-delimited list of backend packages temporarily exempt from the per-package minimum coverage gate; defaults by suite")
 	flag.Float64Var(&cfg.packageMin, "package-min", defaultPackageCoverageMin, "minimum statement coverage required for each non-baselined backend package")
+	flag.Float64Var(&cfg.packageFloorEpsilon, "package-floor-epsilon", defaultPackageFloorEpsilon, "allowed manifest package-floor drift in percentage points; only applies with -package-manifest")
 	flag.StringVar(&cfg.packages, "packages", "", "space-separated go test package patterns; overrides -suite package discovery")
 	flag.StringVar(&cfg.profile, "profile", "", "coverage profile output path; defaults to a temp file")
 	flag.BoolVar(&cfg.short, "short", true, "run with go test -short")
@@ -200,6 +208,9 @@ func validateConfig(cfg config) error {
 	}
 	if manifestOperations > 1 {
 		return errors.New("configure go coverage: choose only one of -generate-manifest, -update-manifest, or -package-manifest")
+	}
+	if cfg.packageFloorEpsilon < 0 || math.IsNaN(cfg.packageFloorEpsilon) || math.IsInf(cfg.packageFloorEpsilon, 0) {
+		return fmt.Errorf("configure go coverage: -package-floor-epsilon must be a finite non-negative percentage-point value (got %v); set it to 0 or greater", cfg.packageFloorEpsilon)
 	}
 	return nil
 }
@@ -307,7 +318,7 @@ func run(cfg config) (coverageResult, error) {
 		if err != nil {
 			return coverageResult{}, err
 		}
-		result.packageMinimumFailures = checkCoverageManifest(manifest, result.packageTotals, cfg.packageManifest)
+		result.packageMinimumFailures, result.packageMinimumWarnings = checkCoverageManifestWithEpsilon(manifest, result.packageTotals, cfg.packageManifest, cfg.packageFloorEpsilon)
 		result.packageGates = packageGatesFromManifest(manifest)
 	} else if legacyPackageGateEnabled {
 		result.packageGates = packageGatesFromLegacyMin(result.packageSummaries, cfg.packageCoverageMin(), baselinePackages)

--- a/cmd/gocoveragecheck/main_entrypoint_test.go
+++ b/cmd/gocoveragecheck/main_entrypoint_test.go
@@ -118,6 +118,180 @@ func TestMainReportsPassingCoverageWithoutFailing(t *testing.T) {
 	}
 }
 
+func TestMainPackageManifestEpsilonCases(t *testing.T) {
+	configPackage := modulePath + "/pkg/config"
+	cases := []struct {
+		name        string
+		minimum     string
+		epsilon     string
+		wantExit    int
+		wantWarning bool
+		wantFailure bool
+	}{
+		{name: "default boundary warning", minimum: "0.25", wantWarning: true},
+		{name: "beyond default epsilon", minimum: "0.26", wantExit: 1, wantFailure: true},
+		{name: "strict zero", minimum: "0.25", epsilon: "0", wantExit: 1, wantFailure: true},
+		{name: "exact floor", minimum: "0.00"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			manifestPath := writePackageMinimumManifest(t, "unit", configPackage, tc.minimum)
+			args := []string{
+				"-min=0",
+				"-suite=unit",
+				"-package-manifest=" + manifestPath,
+				"-coverpkg=" + configPackage,
+				"-packages=./pkg/config",
+			}
+			if tc.epsilon != "" {
+				args = append(args, "-package-floor-epsilon="+tc.epsilon)
+			}
+			_, stderr, exitCode := runMainForTest(t, args, fakeGoCoverageCommandWithMeasuredZeroConfig)
+
+			if exitCode != tc.wantExit {
+				t.Fatalf("main() exit code = %d, want %d; stderr=%q", exitCode, tc.wantExit, stderr)
+			}
+			if tc.wantWarning {
+				got := stderr
+				for _, want := range []string{
+					"package coverage warning: tolerated drift",
+					"package=" + configPackage,
+					"lane=unit",
+					"expected-minimum=0.25%",
+					"actual=0.0000%",
+					"delta=-0.2500 percentage-points",
+					"epsilon=0.2500 percentage-points",
+				} {
+					if !strings.Contains(got, want) {
+						t.Fatalf("main() stderr = %q, want warning containing %q", got, want)
+					}
+				}
+				if strings.Contains(got, "update-manifest") {
+					t.Fatalf("main() stderr = %q, did not expect failure remediation", got)
+				}
+			} else if stderr != "" && !tc.wantFailure {
+				t.Fatalf("main() stderr = %q, want empty stderr", stderr)
+			}
+			if tc.wantFailure {
+				got := stderr
+				if !strings.Contains(got, "package coverage regression: package="+configPackage) || !strings.Contains(got, "-update-manifest") {
+					t.Fatalf("main() stderr = %q, want regression and remediation", got)
+				}
+				if strings.Contains(got, "drift tolerated") {
+					t.Fatalf("main() stderr = %q, did not expect tolerated warning", got)
+				}
+			}
+		})
+	}
+}
+
+func TestMainRejectsNegativePackageFloorEpsilonBeforeCoverageWork(t *testing.T) {
+	called := false
+	_, stderr, exitCode := runMainForTest(t, []string{"-package-floor-epsilon=-0.01"}, func(commandInvocation) (string, string, error) {
+		called = true
+		return "", "", nil
+	})
+
+	if called {
+		t.Fatal("main() started coverage work for invalid epsilon")
+	}
+	if exitCode != 1 {
+		t.Fatalf("main() exit code = %d, want 1", exitCode)
+	}
+	if !strings.Contains(stderr, "finite non-negative percentage-point value") || !strings.Contains(stderr, "set it to 0 or greater") {
+		t.Fatalf("main() stderr = %q, want actionable epsilon diagnostic", stderr)
+	}
+}
+
+func TestMainUpdateManifestIgnoresEpsilonForRejectAndRaise(t *testing.T) {
+	configPackage := modulePath + "/pkg/config"
+	cases := []struct {
+		name       string
+		minimum    string
+		command    commandRunnerFunc
+		wantExit   int
+		wantStatus string
+	}{
+		{name: "rejects decrease at epsilon boundary", minimum: "0.25", command: fakeGoCoverageCommandWithMeasuredZeroConfig, wantExit: 1, wantStatus: "status=rejected"},
+		{name: "raises improved floor", minimum: "80.00", command: fakeGoCoverageCommandPassing, wantStatus: "status=raised"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			manifestPath := writePackageMinimumManifest(t, "unit", configPackage, tc.minimum)
+			before, err := os.ReadFile(manifestPath)
+			if err != nil {
+				t.Fatalf("read manifest before update: %v", err)
+			}
+			args := []string{
+				"-min=0",
+				"-suite=unit",
+				"-update-manifest=" + manifestPath,
+				"-package-floor-epsilon=0.25",
+				"-coverpkg=" + configPackage,
+				"-packages=./pkg/config",
+			}
+			stdout, stderr, exitCode := runMainForTest(t, args, tc.command)
+
+			if exitCode != tc.wantExit {
+				t.Fatalf("main() exit code = %d, want %d; stderr=%q", exitCode, tc.wantExit, stderr)
+			}
+			if !strings.Contains(stdout, tc.wantStatus) {
+				t.Fatalf("main() stdout = %q, want %q", stdout, tc.wantStatus)
+			}
+			after, err := os.ReadFile(manifestPath)
+			if err != nil {
+				t.Fatalf("read manifest after update: %v", err)
+			}
+			if tc.wantExit == 1 {
+				if string(after) != string(before) {
+					t.Fatalf("rejected update mutated manifest:\n%s\n---\n%s", before, after)
+				}
+				return
+			}
+			if !strings.Contains(string(after), `"minimum": 100.00`) {
+				t.Fatalf("raised manifest = %s, want 100.00 floor", after)
+			}
+		})
+	}
+}
+
+func runMainForTest(t *testing.T, args []string, runner commandRunnerFunc) (string, string, int) {
+	t.Helper()
+	originalArgs := os.Args
+	originalFlagSet := flag.CommandLine
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	originalExit := exitFunc
+	defer func() {
+		os.Args = originalArgs
+		flag.CommandLine = originalFlagSet
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+		exitFunc = originalExit
+	}()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := 0
+	flag.CommandLine = flag.NewFlagSet("gocoveragecheck", flag.ExitOnError)
+	os.Args = append([]string{"gocoveragecheck"}, args...)
+	commandRunner = runner
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+	exitFunc = func(code int) {
+		exitCode = code
+	}
+
+	main()
+	return stdout.String(), stderr.String(), exitCode
+}
+
 func TestMainFailsWhenZeroCoveragePackagesDetectedViaFailf(t *testing.T) {
 	originalArgs := os.Args
 	originalFlagSet := flag.CommandLine

--- a/cmd/gocoveragecheck/main_fake_process_test.go
+++ b/cmd/gocoveragecheck/main_fake_process_test.go
@@ -14,6 +14,10 @@ func fakeGoCoverageCommand(invocation commandInvocation) (string, string, error)
 	return fakeGoCommandByScenario("coverage-default", invocation.name, invocation.args...)
 }
 
+func fakeGoCoverageCommandWithMeasuredZeroConfig(invocation commandInvocation) (string, string, error) {
+	return fakeGoCommandByScenario("coverage-measured-zero-config", invocation.name, invocation.args...)
+}
+
 func fakeGoCoverageCommandPassing(invocation commandInvocation) (string, string, error) {
 	return fakeGoCommandByScenario("coverage-passing", invocation.name, invocation.args...)
 }
@@ -93,7 +97,7 @@ func fakeGoTestScenario(scenario string, args []string) (string, string, error) 
 			return "", "", fmt.Errorf("missing -coverprofile")
 		}
 		switch scenario {
-		case "coverage-passing", "coverage-cover-fails-with-stderr", "coverage-cover-fails-with-stdout", "coverage-cover-fails-without-detail", "coverage-temp-profile", "coverage-test-fails-without-detail":
+		case "coverage-passing", "coverage-cover-fails-with-stderr", "coverage-cover-fails-with-stdout", "coverage-cover-fails-without-detail", "coverage-measured-zero-config", "coverage-temp-profile", "coverage-test-fails-without-detail":
 			if err := writeFakeCoverageProfile(profilePath, strings.Join([]string{
 				"mode: count",
 				modulePath + "/pkg/config/config.go:1.1,2.1 3 1",
@@ -101,6 +105,15 @@ func fakeGoTestScenario(scenario string, args []string) (string, string, error) 
 				"",
 			}, "\n")); err != nil {
 				return "", "", err
+			}
+			if scenario == "coverage-measured-zero-config" {
+				if err := writeFakeCoverageProfile(profilePath, strings.Join([]string{
+					"mode: count",
+					modulePath + "/pkg/config/config.go:1.1,2.1 3 0",
+					"",
+				}, "\n")); err != nil {
+					return "", "", err
+				}
 			}
 		case "coverage-with-coverpkg-ok-summary", "coverage-with-ok-summary", "coverage-default":
 			if err := writeFakeCoverageProfile(profilePath, strings.Join([]string{
@@ -116,7 +129,7 @@ func fakeGoTestScenario(scenario string, args []string) (string, string, error) 
 		}
 
 		switch scenario {
-		case "coverage-passing":
+		case "coverage-passing", "coverage-measured-zero-config":
 			return modulePath + "/pkg/config\t\tcoverage: 75.0% of statements\n", "", nil
 		case "coverage-temp-profile":
 			if err := writeTempProfileMarkerOrErr(profilePath); err != nil {
@@ -151,7 +164,7 @@ func fakeGoTestScenario(scenario string, args []string) (string, string, error) 
 	}
 
 	switch scenario {
-	case "coverage-passing", "coverage-cover-fails-with-stderr", "coverage-cover-fails-with-stdout", "coverage-cover-fails-without-detail", "coverage-temp-profile":
+	case "coverage-passing", "coverage-cover-fails-with-stderr", "coverage-cover-fails-with-stdout", "coverage-cover-fails-without-detail", "coverage-measured-zero-config", "coverage-temp-profile":
 		return modulePath + "/pkg/config\t\tcoverage: 100.0% of statements\n" +
 			modulePath + "/pkg/service\t\tcoverage: 100.0% of statements\n", "", nil
 	case "coverage-test-fails-without-detail":

--- a/cmd/gocoveragecheck/main_test.go
+++ b/cmd/gocoveragecheck/main_test.go
@@ -183,6 +183,17 @@ func TestValidateConfigRejectsConflictingManifestOperations(t *testing.T) {
 	}
 }
 
+func TestValidateConfigRejectsInvalidPackageFloorEpsilon(t *testing.T) {
+	t.Parallel()
+
+	for _, epsilon := range []float64{-0.01, -1} {
+		err := validateConfig(config{packageFloorEpsilon: epsilon})
+		if err == nil || !strings.Contains(err.Error(), "-package-floor-epsilon must be a finite non-negative percentage-point value") {
+			t.Fatalf("validateConfig(%v) error = %v, want actionable epsilon diagnostic", epsilon, err)
+		}
+	}
+}
+
 func TestFindInsufficientCoveragePackagesSkipsBaselinedPackages(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/gocoveragecheck/manifest.go
+++ b/cmd/gocoveragecheck/manifest.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
 	"slices"
 	"strconv"
@@ -243,7 +244,13 @@ func readCoverageManifestFile(filename string, lane string, measuredPackages []s
 }
 
 func checkCoverageManifest(manifest coverageManifest, totals map[string]packageCoverageTotals, manifestPath string) []string {
+	failures, _ := checkCoverageManifestWithEpsilon(manifest, totals, manifestPath, 0)
+	return failures
+}
+
+func checkCoverageManifestWithEpsilon(manifest coverageManifest, totals map[string]packageCoverageTotals, manifestPath string, epsilon float64) ([]string, []string) {
 	failures := make([]string, 0)
+	warnings := make([]string, 0)
 	for _, entry := range manifest.Packages {
 		if entry.Exception != nil {
 			continue
@@ -258,12 +265,34 @@ func checkCoverageManifest(manifest coverageManifest, totals map[string]packageC
 			actualPercent = float64(actual.coveredStatements) * 100 / float64(actual.totalStatements)
 		}
 		expectedPercent := float64(minimum) / 100
+		if coverageFloorDriftWithinEpsilon(minimum, actual, epsilon) {
+			warnings = append(warnings, fmt.Sprintf(
+				"package coverage warning: tolerated drift: package=%s lane=%s expected-minimum=%s%% actual=%.4f%% delta=%+.4f percentage-points epsilon=%.4f percentage-points",
+				entry.Package, manifest.Lane, minimum.String(), actualPercent, actualPercent-expectedPercent, epsilon,
+			))
+			continue
+		}
 		failures = append(failures, fmt.Sprintf(
 			"package coverage regression: package=%s lane=%s expected-minimum=%s%% actual=%.4f%% delta=%+.4f percentage-points; restore coverage before running `go run ./cmd/gocoveragecheck -suite %s -profile <coverage-profile> -update-manifest %s`",
 			entry.Package, manifest.Lane, minimum.String(), actualPercent, actualPercent-expectedPercent, manifest.Lane, manifestPath,
 		))
 	}
-	return failures
+	return failures, warnings
+}
+
+func coverageFloorDriftWithinEpsilon(minimum coverageFloor, actual packageCoverageTotals, epsilon float64) bool {
+	if actual.totalStatements <= 0 || epsilon <= 0 {
+		return false
+	}
+
+	expected := new(big.Rat).SetFrac64(int64(minimum), 100)
+	measured := new(big.Rat).SetFrac64(int64(actual.coveredStatements)*100, int64(actual.totalStatements))
+	drift := new(big.Rat).Sub(expected, measured)
+	epsilonRatio, ok := new(big.Rat).SetString(strconv.FormatFloat(epsilon, 'f', -1, 64))
+	if !ok {
+		return false
+	}
+	return drift.Cmp(epsilonRatio) <= 0
 }
 
 func validateCoverageLane(lane string) error {

--- a/cmd/gocoveragecheck/manifest_test.go
+++ b/cmd/gocoveragecheck/manifest_test.go
@@ -262,3 +262,78 @@ func TestCheckCoverageManifestControlledProfilesForBothLanes(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckCoverageManifestAppliesRawStatementEpsilon(t *testing.T) {
+	t.Parallel()
+
+	importPath := modulePath + "/pkg/config"
+	manifest := coverageManifest{
+		Version: coverageManifestVersion,
+		Lane:    "unit",
+		Packages: []coverageManifestEntry{
+			{Package: importPath, Minimum: json.RawMessage("80.00")},
+		},
+	}
+	cases := []struct {
+		name             string
+		totals           packageCoverageTotals
+		epsilon          float64
+		wantFailure      bool
+		wantWarningDelta string
+	}{
+		{
+			name:             "inside epsilon",
+			totals:           packageCoverageTotals{coveredStatements: 319, totalStatements: 400},
+			epsilon:          0.25,
+			wantWarningDelta: "delta=-0.2500 percentage-points",
+		},
+		{
+			name:        "beyond epsilon",
+			totals:      packageCoverageTotals{coveredStatements: 318, totalStatements: 400},
+			epsilon:     0.25,
+			wantFailure: true,
+		},
+		{
+			name:    "exact floor",
+			totals:  packageCoverageTotals{coveredStatements: 4, totalStatements: 5},
+			epsilon: 0.25,
+		},
+		{
+			name:        "strict zero",
+			totals:      packageCoverageTotals{coveredStatements: 319, totalStatements: 400},
+			epsilon:     0,
+			wantFailure: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			failures, warnings := checkCoverageManifestWithEpsilon(
+				manifest,
+				map[string]packageCoverageTotals{importPath: tc.totals},
+				"minimums.json",
+				tc.epsilon,
+			)
+			if got := len(failures) > 0; got != tc.wantFailure {
+				t.Fatalf("failures = %v, want failure=%t", failures, tc.wantFailure)
+			}
+			if tc.wantWarningDelta == "" {
+				if len(warnings) != 0 {
+					t.Fatalf("warnings = %v, want none", warnings)
+				}
+				return
+			}
+			if len(warnings) != 1 || !strings.Contains(warnings[0], tc.wantWarningDelta) {
+				t.Fatalf("warnings = %v, want one warning containing %q", warnings, tc.wantWarningDelta)
+			}
+			if !strings.Contains(warnings[0], "package="+importPath+" lane=unit expected-minimum=80.00% actual=79.7500%") ||
+				!strings.Contains(warnings[0], "epsilon=0.2500 percentage-points") {
+				t.Fatalf("warning = %q, want package, lane, floor, actual, and epsilon", warnings[0])
+			}
+			if !strings.Contains(warnings[0], "warning") || strings.Contains(warnings[0], "update-manifest") {
+				t.Fatalf("warning = %q, did not expect update remediation", warnings[0])
+			}
+		})
+	}
+}

--- a/cmd/gocoveragecheck/manifest_update_test.go
+++ b/cmd/gocoveragecheck/manifest_update_test.go
@@ -93,14 +93,14 @@ func TestUpdateCoverageManifestFileRejectsDecreaseWithoutAnyMutation(t *testing.
 	}
 
 	updates, err := updateCoverageManifestFile(filename, "unit", map[string]packageCoverageTotals{
-		alpha: {coveredStatements: 79, totalStatements: 100},
+		alpha: {coveredStatements: 319, totalStatements: 400},
 		beta:  {coveredStatements: 3, totalStatements: 5},
 	}, []string{beta, alpha})
 	if err == nil || !strings.Contains(err.Error(), "rejected one or more floor decreases") {
 		t.Fatalf("updateCoverageManifestFile() error = %v, want rejected decrease", err)
 	}
 	wantUpdates := []string{
-		"package coverage update: package=" + alpha + " lane=unit status=rejected old=80.00% candidate=79.00%",
+		"package coverage update: package=" + alpha + " lane=unit status=rejected old=80.00% candidate=79.75%",
 		"package coverage update: package=" + beta + " lane=unit status=raised old=50.00% candidate=60.00%",
 	}
 	if got := coverageManifestUpdateStrings(updates); !slices.Equal(got, wantUpdates) {


### PR DESCRIPTION
{
  "project": "gocoveragecheck Package-Floor Drift Tolerance",
  "branchName": "coverage-floor-epsilon",
  "description": "Add a configurable 0.25 percentage-point default epsilon to manifest-backed per-package coverage enforcement so insignificant negative drift exits successfully with a package-specific warning, while meaningful regressions and the monotonic manifest ratchet retain their current behavior.",
  "context": {
    "customerAsk": "Stop insignificant manifest-floor drift from failing CI while retaining clear diagnostics and strict enforcement for meaningful regressions. Make the tolerance configurable, preserve the current manifest update and upward-ratchet behavior, and prove the CLI contract with controlled manifest/profile fixtures.",
    "problem": "The per-package manifest gate currently fails every negative delta, so coverage measurement noise from regeneration or test-shape churn repeatedly consumes full implementation and review iterations even when no behavior was lost.",
    "solution": "Apply a configurable enforcement-only epsilon, defaulting to 0.25 percentage points: exact-floor and above-floor results pass silently, negative deltas within or exactly at epsilon pass with a warning on stderr, and larger deltas retain the current failure and remediation output. Keep manifest generation and update planning isolated from epsilon so all decreases remain rejected and improvements still raise floors."
  },
  "acceptanceCriteria": [
    "With the default 0.25 percentage-point epsilon, a measured package below its manifest floor by no more than 0.25 percentage points exits successfully and prints a warning to stderr naming the package, lane, expected floor, actual coverage, delta, and active epsilon.",
    "The package-floor epsilon is configurable as a non-negative percentage-point value; setting it to 0 restores strict failure for every negative delta, and invalid negative values are rejected with an actionable configuration error.",
    "A package below its manifest floor by more than the configured epsilon exits non-zero and retains the existing package coverage regression diagnostic and -update-manifest remediation message.",
    "Coverage exactly at or above the manifest floor exits successfully without a tolerated-drift warning.",
    "-update-manifest does not apply epsilon: every candidate floor decrease remains rejected without rewriting the manifest, while improved coverage raises the floor as before.",
    "Controlled fixture manifest/profile cases prove CLI exit code and output for inside-epsilon warning, beyond-epsilon failure, exact-floor pass, strict-zero configuration, rejected decrease, and upward ratchet behavior.",
    "Typecheck passes; focused cmd/gocoveragecheck tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green; required PR CI is terminal and passing.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file churn are resolved against current main, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "coverage-floor-epsilon-001",
      "title": "Tolerate and report insignificant package-floor drift",
      "description": "As a maintainer, I want small, configurable per-package coverage drift to warn without failing so measurement churn does not consume a full implementation cycle while meaningful coverage regressions remain blocked.",
      "acceptanceCriteria": [
        "gocoveragecheck accepts a package-floor epsilon in percentage points, defaults it to 0.25, applies it only with manifest-floor enforcement, and rejects negative values before running coverage work.",
        "For a package with actual below floor and floor minus actual no greater than epsilon, the CLI exits 0 and writes a stable warning to stderr containing package, lane, expected-minimum, actual, signed delta, and epsilon; the warning omits the failure remediation instruction.",
        "For a package with floor minus actual greater than epsilon, the CLI exits non-zero and emits the same regression classification and restore-before--update-manifest remediation message used before this change.",
        "A package exactly at its floor or above it exits 0 without a drift warning; an epsilon of 0 makes every negative delta fail.",
        "Epsilon comparison uses measured statement totals without prematurely rounding the actual percentage, including correct behavior at the exact epsilon boundary.",
        "-update-manifest ignores epsilon: a candidate decrease, even within epsilon, is rejected and leaves the manifest byte-for-byte unchanged; an increase still raises the stored floor and reports the existing update status.",
        "Table-driven unit tests cover inside-epsilon pass-with-warning, exact-boundary pass-with-warning, beyond-epsilon failure, exact-floor pass, strict-zero behavior, invalid configuration, rejected update, and upward ratchet.",
        "CLI-level behavioral tests use controlled fixture manifest/profile inputs and assert exit code plus stdout/stderr for each required case without depending on repository-wide live coverage values.",
        "The change remains limited to the coverage checker, its focused fixtures/tests, and at most a concise usage note; it introduces no manifest schema change, baseline edits, generated artifacts, refactor, or unrelated cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": false,
      "notes": "Implementation and focused verification are complete; PR publication and required CI startup remain."
    }
  ]
}
