### PR TITLE
fix(factory): copy operator standing rules into each lane worktree

### DIFF
--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -422,6 +422,34 @@ def copy_prd_files(prd_json_path, prd_md_path, worktree_path):
     return dest_json, dest_md
 
 
+# Operator-authored standing rules that lane payloads reference by this exact
+# repo-relative path. The file lives under the gitignored docs/temp tree, so a
+# fresh worktree never contains it and the payload pointer would dangle. Copy it
+# in alongside the PRD so every lane can actually read its own rules.
+STANDING_RULES_RELPATH = Path("docs") / "temp" / "scale-program-rules.md"
+
+
+def copy_standing_rules(repo_root, worktree_path):
+    """Copy the operator standing-rules doc into the worktree, if it exists.
+
+    Returns the destination path, or None when the source is absent. Never
+    fatal: a missing or unreadable rules doc must not block workspace setup.
+    """
+    source = repo_root / STANDING_RULES_RELPATH
+    if not source.is_file():
+        return None
+
+    dest = worktree_path / STANDING_RULES_RELPATH
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(str(source), str(dest))
+    except OSError as e:
+        print(f"Standing-rules copy skipped: {e}", file=sys.stderr)
+        return None
+
+    return dest
+
+
 def main():
     if len(sys.argv) != 2:
         print(f"Usage: {sys.argv[0]} <prd-name>", file=sys.stderr)
@@ -481,6 +509,9 @@ def main():
         print(f"PRD copy failed: {e}", file=sys.stderr)
         sys.exit(1)
 
+    # Copy the operator standing-rules doc referenced by lane payloads.
+    dest_rules = copy_standing_rules(repo_root, worktree_dir)
+
     # Output result.
     result = {
         "status": "ready",
@@ -488,6 +519,7 @@ def main():
         "branch": branch,
         "prd_path": str(dest_json),
         "prd_md_path": str(dest_md) if dest_md else None,
+        "standing_rules_path": str(dest_rules) if dest_rules else None,
         "reused": reused,
     }
     print(json.dumps(result, indent=2))


### PR DESCRIPTION
## Problem

Every scale-program lane payload names `docs/temp/scale-program-rules.md` as mandatory reading. `docs/temp/**` is gitignored, and each lane runs in its own `git worktree`, so **that file does not exist in any worktree** — verified against six live lane worktrees, all `MISSING`. Workers have been following a dangling pointer for the whole program, which is why the contention protocol (rebase-and-regenerate, never hand-merge generated files), the registered baseline-flake families, and the delivery contract kept getting rediscovered or ignored lane by lane.

## Change

`setup-workspace.py` already copies `prd.json`/`prd.md` into the new worktree. Copy the standing-rules doc the same way, at the exact repo-relative path the payloads reference, and surface it as `standing_rules_path` in the script's JSON result.

Best-effort by design: a missing source is a silent no-op, and an `OSError` is reported to stderr and skipped rather than failing setup — a lane must never lose its worktree over an operator doc. The destination is inside the gitignored `docs/temp` tree, so the copy cannot enter any lane's PR diff.

## Verification

Exercised `copy_standing_rules` directly against temp roots:

- source present → copied to `<worktree>/docs/temp/scale-program-rules.md` with parents created, content identical;
- source absent → returns `None`, creates nothing;
- unwritable destination → prints `Standing-rules copy skipped: ...` and returns `None` instead of raising.

Live worktrees were also backfilled by hand so in-flight lanes get the doc without waiting on this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)