### PR TITLE
test(cli-process): tolerate intentional stdout closure

### DIFF
--- a/tests/functional/transport/cli/process/hard_kill_successor_test.go
+++ b/tests/functional/transport/cli/process/hard_kill_successor_test.go
@@ -210,7 +210,8 @@ func (process *hardKillCLIProcess) stopWith(terminate func() error) error {
 	if process == nil || process.command == nil {
 		return nil
 	}
-	if err := process.killWith(terminate); err != nil {
+	terminated, err := process.killWith(terminate)
+	if err != nil {
 		return err
 	}
 	if _, exited := process.waitForExit(hardKillProcessExitTimeout); !exited {
@@ -220,7 +221,12 @@ func (process *hardKillCLIProcess) stopWith(terminate func() error) error {
 	if !scanned {
 		return fmt.Errorf("stdout scanner did not finish within %s", hardKillProcessExitTimeout)
 	}
-	if scanErr != nil {
+	// Cmd.Wait closes a StdoutPipe after reaping the child. When this helper's
+	// intentional termination wins that ordering race, the scanner can observe
+	// the terminal descriptor close as fs.ErrClosed instead of EOF. The process
+	// has already been reaped here, so accept only that expected terminal error;
+	// every other scanner error remains actionable.
+	if scanErr != nil && !(terminated && errors.Is(scanErr, os.ErrClosed)) {
 		return fmt.Errorf("stdout scanner: %w", scanErr)
 	}
 	return nil
@@ -230,17 +236,18 @@ func (process *hardKillCLIProcess) kill() error {
 	if process == nil || process.command == nil || process.command.Process == nil {
 		return nil
 	}
-	return process.killWith(process.command.Process.Kill)
+	_, err := process.killWith(process.command.Process.Kill)
+	return err
 }
 
-func (process *hardKillCLIProcess) killWith(terminate func() error) error {
+func (process *hardKillCLIProcess) killWith(terminate func() error) (bool, error) {
 	if process.command.Process == nil || process.command.ProcessState != nil {
-		return nil
+		return false, nil
 	}
 	if err := terminate(); err != nil && !errors.Is(err, os.ErrProcessDone) {
-		return fmt.Errorf("kill process: %w", err)
+		return false, fmt.Errorf("kill process: %w", err)
 	}
-	return nil
+	return true, nil
 }
 
 func (process *hardKillCLIProcess) waitForExit(timeout time.Duration) (error, bool) {


### PR DESCRIPTION
{
  "project": "Deflake the CLI Hard-Kill Successor Contention Test",
  "branchName": "thr-deflake-cli-hardkill-successor",
  "description": "Make TestCLISuccessorAfterHardKillReportsPreRuntimeStagingContention deterministic by correcting the test-owned race between intentional predecessor termination, Cmd.Wait pipe closure, and stdout scanning while preserving the complete successor staging-contention diagnostic and avoiding unrelated production or ACP changes.",
  "context": {
    "customerAsk": "Ship the smallest correct fix in tests/functional/transport/cli/process so the merged-main hard-kill successor failure stops blocking concurrent lanes. Preserve proof of the complete pre-runtime staging-contention diagnostic, use observable synchronization rather than sleeps or retries, and change production CLI behavior only if direct diagnosis proves production teardown owns the race.",
    "problem": "Merged-main run 31655058195 and unrelated PR #1912 job 94309777768 and PR #1914 job 94329598343 all fail before the successor assertion because the intentionally hard-killed predecessor's stdout scanner can observe 'file already closed' when Cmd.Wait reaps the process and closes StdoutPipe. The harness treats this expected terminal teardown ordering as a product failure, leaving Backend Functional Coverage red for unrelated work.",
    "solution": "Confirm and document the losing teardown order, then minimally correct the hard-kill test observation path by avoiding its unnecessary stdout pipe/scanner or by accepting os.ErrClosed only after intentional termination and process reaping. Keep unexpected read and shutdown failures fatal, launch the successor only after observable staging acquisition and predecessor teardown, retain every contention and resource-preservation assertion, and prove the result with repeated race, package, and CI execution."
  },
  "acceptanceCriteria": [
    "The PR body records the losing order between intentional predecessor termination, Cmd.Wait, stdout descriptor closure, and scanner completion, and explicitly states whether the race is test-only or genuinely in production teardown.",
    "Intentional predecessor teardown no longer fails solely because its stdout reader observes terminal descriptor closure, while unexpected output-read errors, failure to terminate, and failure to reap remain actionable failures without sleeps, retries, or timeout padding as synchronization.",
    "The successor still fails before runtime and reports the staging path, outcome=indeterminate-contention, owner_liveness=indeterminate, predecessor PID, process-verification instruction, and targeted removal instruction while preserving backend scope and retained staging ownership.",
    "go test ./tests/functional/transport/cli/process/ -run TestCLISuccessorAfterHardKillReportsPreRuntimeStagingContention -count=5 -race passes, the full package passes with go test ./tests/functional/transport/cli/process/ -count=2, and Backend Functional Coverage is green on the final head.",
    "The PR remains one focused change under approximately 10 changed files, production CLI behavior changes only if a demonstrated production teardown defect requires it, and the unrelated ACP stdio-serialization and packaged-ACP-profile failures remain untouched.",
    "Typecheck passes; tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are reconciled against current main, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "thr-deflake-cli-hardkill-successor-001",
      "title": "Make intentional hard-kill teardown deterministic",
      "description": "As a maintainer, I want the test harness to distinguish expected terminal stdout closure from a real output-read failure so that intentional predecessor teardown cannot hide the successor contention behavior.",
      "acceptanceCriteria": [
        "Identify in the implementation and PR body the exact losing event order that produces 'read |0: file already closed' and explain why the correction makes that order harmless without masking non-terminal or unexpected reader failures.",
        "The predecessor reaches a complete observable staging-ownership checkpoint, is intentionally hard-killed, and is reaped before the successor begins; deadlines remain failure guards and no sleep, retry, or timeout increase is added as readiness logic.",
        "The hard-kill path either avoids the unnecessary stdout pipe/scanner or accepts a closed descriptor only when it follows intentional termination; unexpected scanner errors, incomplete capture, or an un-reaped process remain failures with stdout, stderr, and process state.",
        "Production CLI process behavior remains unchanged unless direct evidence proves the teardown race is in production; any necessary production change is explicitly disclosed, minimal, and directly tested.",
        "go test ./tests/functional/transport/cli/process/ -run TestCLISuccessorAfterHardKillReportsPreRuntimeStagingContention -count=5 -race passes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented the test-owned teardown correction and passed the focused -count=5 -race command. The final PR body must record the intentional kill -> Cmd.Wait reap/StdoutPipe close -> scanner os.ErrClosed order and state that production CLI behavior is unchanged."
    },
    {
      "id": "thr-deflake-cli-hardkill-successor-002",
      "title": "Preserve and prove the successor contention contract",
      "description": "As an operator, I want a successor launched after a hard kill to keep reporting the complete actionable staging-contention diagnostic so that deterministic test teardown does not weaken the customer-facing safety contract.",
      "acceptanceCriteria": [
        "The test continues to assert that the successor exits unsuccessfully before printing Dashboard URL and reports the retained staging path, indeterminate-contention outcome, indeterminate owner liveness, predecessor PID, process-verification instruction, and targeted removal instruction.",
        "The test continues to prove that the successor preserves the predecessor's backend scope, does not remove the retained staging resource, and does not change staging ownership resources.",
        "The focused race command passes with -count=5, and go test ./tests/functional/transport/cli/process/ -count=2 passes without reader teardown failures or orphaned CLI processes.",
        "Backend Functional Coverage is terminal and green on the final PR head, with the preserved diagnostic assertion shown in the PR body.",
        "No changes address TestProvidersACPSerializesConcurrentPromptsOnOneStdioConnection or TestPackagedACPProfilesUseSharedConformanceBehavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Verified the successor still fails before runtime with the complete staging path, outcome=indeterminate-contention, owner_liveness=indeterminate, predecessor PID, process-verification instruction, and targeted removal instruction; it preserves backend scope, retained staging, and ownership resources. Focused -count=5 -race and package -count=2 pass; go vet and typecheck pass. Backend Functional Coverage and required CI remain final-head checks for the PR."
    }
  ]
}
