### PR TITLE
btrc-p2b: add the shared Recordings runtime root

### DIFF
--- a/pkg/services/factory_runtime/execution_contracts.go
+++ b/pkg/services/factory_runtime/execution_contracts.go
@@ -17,6 +17,9 @@ import (
 type CompletionRecorder func(interfaces.FactoryCompletionRecord)
 type PetriMutationRecorder func(sessionID string, mutations []interfaces.TokenMutationRecord) error
 type FactoryEventRecorder func(interfaces.FactoryEvent)
+// RuntimeLedgerFactory remains a compatibility seam until the Factory
+// Sessions opening cutover removes the legacy factories in the next stack
+// slice.
 type RuntimeLedgerFactory func(recordings.InitialStructureSource, func() time.Time, interfaces.RuntimeDefinitionLookup) recordings.RuntimeEventLedger
 
 type SubmissionHook interface {

--- a/pkg/services/factory_runtime/internal/assembly.go
+++ b/pkg/services/factory_runtime/internal/assembly.go
@@ -86,8 +86,7 @@ func (a *Assembly) Assemble(
 	completionFactory func(string) func(string),
 	petriMutationRecorder factoryruntime.PetriMutationRecorder,
 	worldStateProjector factoryruntime.WorldStateProjector,
-	runtimeLedgerFactory factoryruntime.RuntimeLedgerFactory,
-	runtimeRecorderFactory recordings.RuntimeRecorderFactory,
+	recordingsRuntime recordings.RuntimeOpening,
 	initialFactorySnapshot factorydefinitions.InitialFactorySnapshotFactory,
 	dir string,
 	factoryRootDir string,
@@ -95,7 +94,6 @@ func (a *Assembly) Assemble(
 	loadedFactory factorydefinitions.MutableLoadedFactorySource,
 	runtimeInstanceID string,
 	replayArtifact *factorydefinitions.ReplayArtifact,
-	replayExecutionFactory recordings.ReplayExecutionFactory,
 	automationService automations.Service,
 	serviceMode bool,
 ) (
@@ -154,20 +152,19 @@ func (a *Assembly) Assemble(
 		completionFactory,
 		petriMutationRecorder,
 		worldStateProjector,
-		runtimeLedgerFactory,
-		runtimeRecorderFactory,
+		recordingsRuntime,
 		loadFactory,
 		initialFactorySnapshot,
 	)
 	if err != nil {
 		return nil, nil, factoryruntime.SessionBuildSpec{}, nil, nil, err
 	}
-	if replayExecutionFactory == nil {
+	if recordingsRuntime == nil {
 		return nil, nil, factoryruntime.SessionBuildSpec{}, nil, nil, fmt.Errorf(
-			"Recordings replay execution factory is required",
+			"Recordings runtime opening is required",
 		)
 	}
-	replayProvider, replayCommandRunner, replayHooks, completionPlanner, err := replayExecutionFactory(
+	replayProvider, replayCommandRunner, replayHooks, completionPlanner, err := recordingsRuntime.ReplayExecution(
 		replayArtifact,
 	)
 	if err != nil {

--- a/pkg/services/factory_runtime/internal/build.go
+++ b/pkg/services/factory_runtime/internal/build.go
@@ -121,13 +121,12 @@ func (f *RuntimeFactory) Build(
 	backendScopeID string,
 	clock factory.Clock,
 	recordPath string,
-	recording recordings.RuntimeRecorder,
 	initialFactory *interfaces.FactorySnapshot,
 	submissionHooks []factory.SubmissionHook,
 	completionPlanner factory.CompletionDeliveryPlanner,
 	petriMutationRecorder factory.PetriMutationRecorder,
 	worldStateProjector factory.WorldStateProjector,
-	newRuntimeLedger factory.RuntimeLedgerFactory,
+	recordingsRuntime recordings.RuntimeOpening,
 	loadWorkerExecutors func(recordings.WorkerEventRecorder, *zap.Logger) (map[string]workers.WorkerExecutor, error),
 	workerService runtimeWorkstationService,
 	providerInvocation workers.WorkstationRequestExecutor,
@@ -203,9 +202,14 @@ func (f *RuntimeFactory) Build(
 		return nil, err
 	}
 	bundleBuilt := false
+	runtimeScopeOwned := false
+	var runtimeScopeRecorder recordings.RuntimeRecorder
 	defer func() {
 		if !bundleBuilt {
 			_ = factoryhost.CloseBundleSinks(logSink, metricsSink)
+			if runtimeScopeOwned && runtimeScopeRecorder != nil {
+				_ = runtimeScopeRecorder.Finalize(clock.Now().UTC())
+			}
 		}
 	}()
 	net, err := f.compileOrchestrationNet(ctx, dir, loadedFactoryCfg.FactoryConfig(), logger)
@@ -214,10 +218,32 @@ func (f *RuntimeFactory) Build(
 	}
 
 	effectiveFactoryRunnerID := effectiveFactoryRunnerID(runnerID, loadedFactoryCfg.FactoryConfig())
-	if newRuntimeLedger == nil {
-		return nil, fmt.Errorf("Recordings runtime ledger factory is required")
+	if recordingsRuntime == nil {
+		return nil, fmt.Errorf("Recordings runtime opening is required")
 	}
-	eventHistory := newRuntimeLedger(net, clock.Now, loadedFactoryCfg)
+	loaded, ok := loadedFactoryCfg.(interfaces.LoadedFactorySource)
+	if !ok || loaded == nil {
+		return nil, fmt.Errorf("loaded Factory source is required for Recordings runtime scope")
+	}
+	opened, openErr := recordingsRuntime.OpenRuntime(ctx, recordings.RuntimeScopeRequest{
+		Topology:         net,
+		Definitions:      loadedFactoryCfg,
+		LoadedFactory:    loaded,
+		Now:              clock.Now,
+		RecordingID:      runtimeInstanceID,
+		RecordPath:       recordPath,
+		FactorySessionID: sessionID,
+	})
+	if openErr != nil {
+		return nil, openErr
+	}
+	eventHistory := opened.Ledger
+	recording := opened.Recorder
+	runtimeScopeRecorder = opened.Recorder
+	runtimeScopeOwned = opened.Recorder != nil
+	if eventHistory == nil {
+		return nil, fmt.Errorf("Recordings runtime ledger is required")
+	}
 	eventHistory.SetFactoryRunnerOverride(effectiveFactoryRunnerID)
 	if initialFactory != nil {
 		eventHistory.SetInitialStructureFactory(initialFactory)

--- a/pkg/services/factory_runtime/internal/build_test.go
+++ b/pkg/services/factory_runtime/internal/build_test.go
@@ -34,15 +34,12 @@ func TestBuild_ConstructsRecordingsRootLedgerAndHostingCapabilities(t *testing.T
 
 	ledger := &recordingfixtures.ScriptedRuntimeLedger{GenerationID: "runtime-recordings-root"}
 	var capturedSource recordings.InitialStructureSource
-	ledgerFactory := factory.RuntimeLedgerFactory(func(
-		source recordings.InitialStructureSource,
-		_ func() time.Time,
-		_ interfaces.RuntimeDefinitionLookup,
-	) recordings.RuntimeEventLedger {
-		capturedSource = source
-		return ledger
-	})
 	recorder := &runtimeRecordingsRecorderStub{}
+	runtimeOpening := &testRuntimeOpeningStub{
+		ledger:         ledger,
+		recorder:       recorder,
+		capturedSource: &capturedSource,
+	}
 
 	bundle, err := testRuntimeFactory().Build(
 		context.Background(), dir, dir, "~default",
@@ -51,8 +48,8 @@ func TestBuild_ConstructsRecordingsRootLedgerAndHostingCapabilities(t *testing.T
 		factoryinternal.RuntimeFileLoggingPolicyDisabled,
 		factoryinternal.RuntimeMetricsPolicyDisabled, "", factory.RuntimeMetricsStorageConfig{},
 		loaded, "runtime-recordings-root", "", clockwork.NewFakeClock(),
-		"/recordings/session.json", recorder, nil, nil, nil, nil, nil,
-		ledgerFactory,
+		"/recordings/session.json", nil, nil, nil, nil, nil,
+		runtimeOpening,
 		func(recordings.WorkerEventRecorder, *zap.Logger) (map[string]workers.WorkerExecutor, error) {
 			return nil, nil
 		},
@@ -92,9 +89,9 @@ func TestBuild_ConstructsRunnableBundleWithoutRootService(t *testing.T) {
 		"", factory.RuntimeLogStorageConfig{},
 		factoryinternal.RuntimeFileLoggingPolicyDisabled,
 		factoryinternal.RuntimeMetricsPolicyDisabled, "", factory.RuntimeMetricsStorageConfig{},
-		loaded, "runtime-test", "", clockwork.NewFakeClock(), "", nil, nil, nil, nil, nil,
+		loaded, "runtime-test", "", clockwork.NewFakeClock(), "", nil, nil, nil, nil,
 		nil,
-		newTestRuntimeLedger,
+		testRuntimeOpening(newTestRuntimeLedger),
 		func(recordings.WorkerEventRecorder, *zap.Logger) (map[string]workers.WorkerExecutor, error) {
 			return nil, nil
 		},
@@ -135,9 +132,9 @@ func TestBuild_ProductionObservabilityPoliciesEnableRuntimeSinksByDefault(t *tes
 		"", interfaces.RuntimeModeBatch, false, nil, nil, nil, false, nil, nil,
 		logDir, factory.RuntimeLogStorageConfig{},
 		"", "", metricsDir, factory.RuntimeMetricsStorageConfig{},
-		loaded, "runtime-observability", "", clockwork.NewFakeClock(), "", nil, nil, nil, nil, nil,
+		loaded, "runtime-observability", "", clockwork.NewFakeClock(), "", nil, nil, nil, nil,
 		nil,
-		newTestRuntimeLedger,
+		testRuntimeOpening(newTestRuntimeLedger),
 		func(recordings.WorkerEventRecorder, *zap.Logger) (map[string]workers.WorkerExecutor, error) {
 			return nil, nil
 		},
@@ -178,9 +175,9 @@ func TestBuild_ProductionObservabilityPoliciesEnableRuntimeSinksByDefault(t *tes
 		factoryinternal.RuntimeFileLoggingPolicyDisabled,
 		factoryinternal.RuntimeMetricsPolicyDisabled,
 		metricsDir, factory.RuntimeMetricsStorageConfig{},
-		loaded, "runtime-disabled", "", clockwork.NewFakeClock(), "", nil, nil, nil, nil, nil,
+		loaded, "runtime-disabled", "", clockwork.NewFakeClock(), "", nil, nil, nil, nil,
 		nil,
-		newTestRuntimeLedger,
+		testRuntimeOpening(newTestRuntimeLedger),
 		func(recordings.WorkerEventRecorder, *zap.Logger) (map[string]workers.WorkerExecutor, error) {
 			return nil, nil
 		},
@@ -485,6 +482,53 @@ func newTestRuntimeLedger(
 ) recordings.RuntimeEventLedger {
 	return &recordingfixtures.ScriptedRuntimeLedger{}
 }
+
+func testRuntimeOpening(
+	ledgerFactory func(
+		recordings.InitialStructureSource,
+		func() time.Time,
+		interfaces.RuntimeDefinitionLookup,
+	) recordings.RuntimeEventLedger,
+) recordings.RuntimeOpening {
+	return &testRuntimeOpeningStub{ledgerFactory: ledgerFactory}
+}
+
+type testRuntimeOpeningStub struct {
+	ledger         recordings.RuntimeEventLedger
+	ledgerFactory  func(recordings.InitialStructureSource, func() time.Time, interfaces.RuntimeDefinitionLookup) recordings.RuntimeEventLedger
+	recorder       recordings.RuntimeRecorder
+	capturedSource *recordings.InitialStructureSource
+}
+
+func (opening *testRuntimeOpeningStub) OpenRuntime(
+	_ context.Context,
+	request recordings.RuntimeScopeRequest,
+) (recordings.RuntimeScopeResult, error) {
+	if opening.capturedSource != nil {
+		*opening.capturedSource = request.Topology
+	}
+	ledger := opening.ledger
+	if opening.ledgerFactory != nil {
+		ledger = opening.ledgerFactory(request.Topology, request.Now, request.Definitions)
+	}
+	return recordings.RuntimeScopeResult{Ledger: ledger, Recorder: opening.recorder}, nil
+}
+
+func (*testRuntimeOpeningStub) Projection() recordings.ProjectionService { return nil }
+
+func (*testRuntimeOpeningStub) ReplayClock(*recordings.ReplayArtifact) recordings.Clock { return nil }
+
+func (*testRuntimeOpeningStub) ReplayExecution(
+	*recordings.ReplayArtifact,
+) (workers.Provider, workers.CommandRunner, []recordings.ReplayHook, recordings.CompletionDeliveryPlanner, error) {
+	return nil, nil, nil, nil, nil
+}
+
+func (*testRuntimeOpeningStub) LoadReplayInput(recordings.LoadReplayInputRequest) (recordings.LoadReplayInputResult, error) {
+	return recordings.LoadReplayInputResult{}, nil
+}
+
+var _ recordings.RuntimeOpening = (*testRuntimeOpeningStub)(nil)
 
 func testRuntimeLoggerFactory(*zap.Logger, bool) factory.Logger { return factory.NoopLogger{} }
 

--- a/pkg/services/factory_runtime/internal/host/bundle.go
+++ b/pkg/services/factory_runtime/internal/host/bundle.go
@@ -167,6 +167,16 @@ func (r *Bundle) RecordingLedger() recordings.Ledger {
 	return r.EventHistory
 }
 
+// FinalizeRecording closes the runtime-owned Recordings scope during partial
+// Factory Session unwind. Normal runtime shutdown reaches the same idempotent
+// recorder through host.FinalizeArtifacts.
+func (r *Bundle) FinalizeRecording(finishedAt time.Time) error {
+	if r == nil || r.Recording == nil {
+		return nil
+	}
+	return r.Recording.Finalize(finishedAt)
+}
+
 func (r *Bundle) CloseArtifacts() error {
 	if r == nil {
 		return nil

--- a/pkg/services/factory_runtime/internal/orchestration_cutover_parity_test.go
+++ b/pkg/services/factory_runtime/internal/orchestration_cutover_parity_test.go
@@ -114,9 +114,9 @@ func TestBuildThroughOrchestrationPreservesRunnablePetriTopology(t *testing.T) {
 		"", factory.RuntimeLogStorageConfig{},
 		factoryinternal.RuntimeFileLoggingPolicyDisabled,
 		factoryinternal.RuntimeMetricsPolicyDisabled, "", factory.RuntimeMetricsStorageConfig{},
-		loaded, "runtime-cutover", "", clockwork.NewFakeClock(), "", nil, nil, nil, nil, nil,
+		loaded, "runtime-cutover", "", clockwork.NewFakeClock(), "", nil, nil, nil, nil,
 		nil,
-		newTestRuntimeLedger,
+		testRuntimeOpening(newTestRuntimeLedger),
 		func(recordings.WorkerEventRecorder, *zap.Logger) (map[string]workers.WorkerExecutor, error) {
 			return nil, nil
 		},
@@ -177,9 +177,9 @@ func TestBuildThroughOrchestrationOpensInlineJavaScriptFactory(t *testing.T) {
 		"", factory.RuntimeLogStorageConfig{},
 		factoryinternal.RuntimeFileLoggingPolicyDisabled,
 		factoryinternal.RuntimeMetricsPolicyDisabled, "", factory.RuntimeMetricsStorageConfig{},
-		loaded, "runtime-cutover-js", "", clockwork.NewFakeClock(), "", nil, nil, nil, nil, nil,
+		loaded, "runtime-cutover-js", "", clockwork.NewFakeClock(), "", nil, nil, nil, nil,
 		nil,
-		newTestRuntimeLedger,
+		testRuntimeOpening(newTestRuntimeLedger),
 		func(recordings.WorkerEventRecorder, *zap.Logger) (map[string]workers.WorkerExecutor, error) {
 			return nil, nil
 		},

--- a/pkg/services/factory_runtime/internal/runtime_build.go
+++ b/pkg/services/factory_runtime/internal/runtime_build.go
@@ -22,6 +22,19 @@ type ProgressPublisherFactory func(string) workers.ProgressPublisher
 type DispatchCompletionFactory func(string) func(string)
 type InitialFactorySnapshotFactory = factorydefinitions.InitialFactorySnapshotFactory
 
+type runtimeOpeningWithFlush struct {
+	recordings.RuntimeOpening
+	flushInterval time.Duration
+}
+
+func (opening runtimeOpeningWithFlush) OpenRuntime(
+	ctx context.Context,
+	request recordings.RuntimeScopeRequest,
+) (recordings.RuntimeScopeResult, error) {
+	request.FlushInterval = opening.flushInterval
+	return opening.RuntimeOpening.OpenRuntime(ctx, request)
+}
+
 // newRuntimeBuild constructs the canonical runtime-build service from decomposed process
 // configuration and domain collaborators.
 // backendsizecheck:ignore-function service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption.
@@ -70,8 +83,7 @@ func NewRuntimeBuild(
 	completionFactory DispatchCompletionFactory,
 	petriMutationRecorder factory.PetriMutationRecorder,
 	worldStateProjector factory.WorldStateProjector,
-	runtimeLedgerFactory factory.RuntimeLedgerFactory,
-	runtimeRecorderFactory recordings.RuntimeRecorderFactory,
+	recordingsRuntime recordings.RuntimeOpening,
 	loadFactory factory.LoadedFactoryLoader,
 	initialFactorySnapshot InitialFactorySnapshotFactory,
 ) (*runtimebuild.Service, error) {
@@ -161,8 +173,7 @@ func NewRuntimeBuild(
 				runtimeFactory,
 				dispatchCompleted,
 				worldStateProjector,
-				runtimeLedgerFactory,
-				runtimeRecorderFactory,
+				recordingsRuntime,
 				initialFactorySnapshot,
 			)
 		},
@@ -203,8 +214,7 @@ func buildBundle(
 	runtimeFactory *RuntimeFactory,
 	dispatchCompleted func(string),
 	worldStateProjector factory.WorldStateProjector,
-	runtimeLedgerFactory factory.RuntimeLedgerFactory,
-	runtimeRecorderFactory recordings.RuntimeRecorderFactory,
+	recordingsRuntime recordings.RuntimeOpening,
 	initialFactorySnapshot InitialFactorySnapshotFactory,
 ) (*factoryhost.Bundle, error) {
 	loadedFactoryCfg, ok := spec.LoadedFactoryCfg.(factorydefinitions.LoadedFactorySource)
@@ -218,18 +228,8 @@ func buildBundle(
 	if sessionID == "" {
 		return nil, fmt.Errorf("default Factory Session ID is required")
 	}
-	if runtimeRecorderFactory == nil {
-		return nil, fmt.Errorf("Recordings runtime recorder factory is required")
-	}
-	recording, err := runtimeRecorderFactory(
-		recordFlushInterval,
-		loadedFactoryCfg,
-		spec.Clock.Now,
-		spec.RuntimeInstanceID,
-		spec.RecordPath,
-	)
-	if err != nil {
-		return nil, err
+	if recordingsRuntime == nil {
+		return nil, fmt.Errorf("Recordings runtime opening is required")
 	}
 	var initialFactory *factorydefinitions.FactorySnapshot
 	var snapshotErr error
@@ -256,6 +256,7 @@ func buildBundle(
 	// against the Factory Session stream. An absent factory leaves the route
 	// unbound, which is how a runtime declares it hosts no such Worker.
 	var providerInvocation workers.WorkstationRequestExecutor
+	var err error
 	if providerInvocationFactory != nil {
 		providerInvocation, err = providerInvocationFactory(
 			spec.ProviderCommandRunner,
@@ -291,13 +292,15 @@ func buildBundle(
 		strings.TrimSpace(backendScopeID),
 		spec.Clock,
 		spec.RecordPath,
-		recording,
 		initialFactory,
 		spec.SubmissionHooks,
 		spec.CompletionPlanner,
 		spec.PetriMutationRecorder,
 		worldStateProjector,
-		runtimeLedgerFactory,
+		runtimeOpeningWithFlush{
+			RuntimeOpening: recordingsRuntime,
+			flushInterval:  recordFlushInterval,
+		},
 		func(history recordings.WorkerEventRecorder, logger *zap.Logger) (map[string]workers.WorkerExecutor, error) {
 			return loadWorkerOptions(
 				workerExecution,

--- a/pkg/services/recordings/contracts.go
+++ b/pkg/services/recordings/contracts.go
@@ -255,6 +255,7 @@ type (
 	RuntimeScopeRequest                                        = recordingcontracts.RuntimeScopeRequest
 	RuntimeScopeResult                                         = recordingcontracts.RuntimeScopeResult
 	RuntimeRecorder                                            = recordingcontracts.RuntimeRecorder
+	RuntimeRecorderFactory                                     = recordingcontracts.RuntimeRecorderFactory
 	SessionLifecycleControlInput                               = recordingcontracts.SessionLifecycleControlInput
 	SimpleDashboardActiveExecution                             = recordingcontracts.SimpleDashboardActiveExecution
 	SimpleDashboardQueryRequest                                = recordingcontracts.SimpleDashboardQueryRequest

--- a/pkg/services/recordings/contracts.go
+++ b/pkg/services/recordings/contracts.go
@@ -252,8 +252,9 @@ type (
 	RuntimeEventLedger                                         = recordingcontracts.RuntimeEventLedger
 	RuntimeLedger                                              = recordingcontracts.RuntimeLedger
 	RuntimeOpeningRequest                                      = recordingcontracts.RuntimeOpeningRequest
+	RuntimeScopeRequest                                        = recordingcontracts.RuntimeScopeRequest
+	RuntimeScopeResult                                         = recordingcontracts.RuntimeScopeResult
 	RuntimeRecorder                                            = recordingcontracts.RuntimeRecorder
-	RuntimeRecorderFactory                                     = recordingcontracts.RuntimeRecorderFactory
 	SessionLifecycleControlInput                               = recordingcontracts.SessionLifecycleControlInput
 	SimpleDashboardActiveExecution                             = recordingcontracts.SimpleDashboardActiveExecution
 	SimpleDashboardQueryRequest                                = recordingcontracts.SimpleDashboardQueryRequest
@@ -308,6 +309,21 @@ type (
 	WorldStateView                                             = recordingcontracts.WorldStateView
 	WorldStateViewSchemaVersion                                = recordingcontracts.WorldStateViewSchemaVersion
 )
+
+// RuntimeOpening is the Recordings-owned capability used while Factory
+// Runtime opens a private runtime scope. Replay input loading remains on the
+// same process root so Factory Sessions cannot construct a second Recordings
+// graph for historical replay.
+type RuntimeOpening interface {
+	recordingcontracts.RuntimeOpening
+	ReplayInputLoader
+}
+
+// Root is the complete process-scoped Recordings authority.
+type Root interface {
+	Service
+	RuntimeOpening
+}
 
 const (
 	CheckpointResumabilityStatusResumable         = recordingcontracts.CheckpointResumabilityStatusResumable

--- a/pkg/services/recordings/internal/contracts/contracts.go
+++ b/pkg/services/recordings/internal/contracts/contracts.go
@@ -142,6 +142,54 @@ type RuntimeOpeningRequest struct {
 	FlushInterval time.Duration
 }
 
+// RuntimeScopeRequest contains the runtime-owned values Recordings needs to
+// open one private event stream. The process graph supplies the Recordings
+// root once; callers provide only the topology, identity, clock, and loaded
+// definition values for this runtime.
+type RuntimeScopeRequest struct {
+	Topology         InitialStructureSource
+	Definitions      interfaces.RuntimeDefinitionLookup
+	LoadedFactory    interfaces.LoadedFactorySource
+	Now              func() time.Time
+	RecordingID      string
+	RecordPath       string
+	FlushInterval    time.Duration
+	FactorySessionID string
+}
+
+// RuntimeScopeResult returns the runtime event ledger and optional recorder
+// owned by the shared Recordings root. The ledger and recorder are runtime
+// capabilities, not construction collaborators; they are acquired and
+// finalized by the root's scope owner.
+type RuntimeScopeResult struct {
+	Ledger   RuntimeEventLedger
+	Recorder RuntimeRecorder
+	Scope    RecordingScopeRef
+}
+
+// RuntimeOpening is the Recordings-owned capability used by Factory Runtime
+// and Factory Sessions while opening a runtime. It keeps replay construction,
+// projection selection, and live scope acquisition on the one process root.
+type RuntimeOpening interface {
+	OpenRuntime(context.Context, RuntimeScopeRequest) (RuntimeScopeResult, error)
+	Projection() ProjectionService
+	ReplayClock(*ReplayArtifact) Clock
+	ReplayExecution(*ReplayArtifact) (
+		workerexecution.Provider,
+		workerexecution.CommandRunner,
+		[]ReplayHook,
+		CompletionDeliveryPlanner,
+		error,
+	)
+}
+
+// Root is the complete process-scoped Recordings authority. Runtime opening
+// is an owner capability of this same value, never a second service graph.
+type Root interface {
+	Service
+	RuntimeOpening
+}
+
 // CanonicalEventID is the Recordings-owned identity of one accepted Factory
 // event.
 type CanonicalEventID string
@@ -1627,16 +1675,6 @@ type RuntimeRecorder interface {
 	// final synchronous flush. Repeated calls return the first terminal result.
 	Finalize(time.Time) error
 }
-
-// RuntimeRecorderFactory constructs one session-scoped replay recorder from
-// root Factory Definition contracts.
-type RuntimeRecorderFactory func(
-	time.Duration,
-	interfaces.LoadedFactorySource,
-	func() time.Time,
-	string,
-	string,
-) (RuntimeRecorder, error)
 
 // ReplayExecutionFactory constructs the replay-specific provider, command
 // runner, hooks, and completion policy consumed by existing Factory Runtime

--- a/pkg/services/recordings/internal/contracts/contracts.go
+++ b/pkg/services/recordings/internal/contracts/contracts.go
@@ -1676,6 +1676,16 @@ type RuntimeRecorder interface {
 	Finalize(time.Time) error
 }
 
+// RuntimeRecorderFactory is retained for the compatibility opening seam until
+// Factory Sessions consumes RuntimeOpening directly.
+type RuntimeRecorderFactory func(
+	time.Duration,
+	interfaces.LoadedFactorySource,
+	func() time.Time,
+	string,
+	string,
+) (RuntimeRecorder, error)
+
 // ReplayExecutionFactory constructs the replay-specific provider, command
 // runner, hooks, and completion policy consumed by existing Factory Runtime
 // callers. It is not the peer-facing replay seam; peers use neutral plans and

--- a/pkg/services/recordings/internal/core.go
+++ b/pkg/services/recordings/internal/core.go
@@ -41,6 +41,12 @@ type combinedService struct {
 	scopeIssuer string
 	nextScopeID uint64
 	scopeByRef  map[recordings.RecordingScopeRef]*recordingScopeBinding
+
+	runtimeRouter          *runtimeLedgerRouter
+	runtimeSnapshotCapture factorydefinitions.LoadedFactorySnapshotCapturer
+	replaySnapshotDecoder  factorydefinitions.FactorySnapshotJSONDecoder
+	replayConfigDecoder    factorydefinitions.ReplayRuntimeConfigDecoder
+	replayInputs           recordings.ReplayInputLoader
 }
 
 var _ recordings.Service = (*combinedService)(nil)

--- a/pkg/services/recordings/internal/events/contracts.go
+++ b/pkg/services/recordings/internal/events/contracts.go
@@ -11,14 +11,6 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/work"
 )
 
-// RuntimeLedgerFactory constructs session-scoped canonical ledgers.
-type RuntimeLedgerFactory func(
-	recordings.InitialStructureSource,
-	func() time.Time,
-	string,
-	interfaces.RuntimeDefinitionLookup,
-) recordings.RuntimeEventLedger
-
 // NewRuntimeLedger exposes the concrete event ledger through its public port.
 func NewRuntimeLedger(
 	topology recordings.InitialStructureSource,

--- a/pkg/services/recordings/internal/runtime_opening.go
+++ b/pkg/services/recordings/internal/runtime_opening.go
@@ -1,0 +1,347 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+// NewRuntimeRoot constructs the one process-scoped Recordings root. Runtime
+// ledgers and lifecycle bindings are acquired through OpenRuntime; no caller
+// receives a constructor for those private resources.
+func NewRuntimeRoot(
+	targets recordings.LiveRecordingTargetPlanner,
+	writeFile func(string, []byte) error,
+	publication interface {
+		Publish(context.Context, string, []byte) error
+		Read(context.Context, string) ([]byte, error)
+	},
+	captureSnapshot factorydefinitions.LoadedFactorySnapshotCapturer,
+	decodeSnapshot factorydefinitions.FactorySnapshotJSONDecoder,
+	decodeRuntimeConfig factorydefinitions.ReplayRuntimeConfigDecoder,
+	replayInputs recordings.ReplayInputLoader,
+	clocks ...recordings.RecordingClock,
+) recordings.Root {
+	router := newRuntimeLedgerRouter()
+	projection := NewProjectionService()
+	var writer recordings.RecordingSnapshotWriter
+	var tickers recordings.RecordingFlushTickerFactory
+	if writeFile != nil {
+		writer = NewReplayRecordingSnapshotWriter(writeFile)
+		tickers = NewRecordingFlushTickerFactory()
+	}
+	service := NewServiceWithLifecycleEffects(
+		router,
+		projection,
+		targets,
+		writer,
+		tickers,
+		publication,
+		clocks...,
+	)
+	root, ok := service.(*combinedService)
+	if !ok || root == nil {
+		return nil
+	}
+	root.runtimeRouter = router
+	root.runtimeSnapshotCapture = captureSnapshot
+	root.replaySnapshotDecoder = decodeSnapshot
+	root.replayConfigDecoder = decodeRuntimeConfig
+	root.replayInputs = replayInputs
+	return root
+}
+
+var _ recordings.Root = (*combinedService)(nil)
+
+func (service *combinedService) Projection() recordings.ProjectionService {
+	if service == nil {
+		return nil
+	}
+	return service.ProjectionService
+}
+
+func (service *combinedService) ReplayClock(
+	artifact *recordings.ReplayArtifact,
+) recordings.Clock {
+	return NewReplayClock(artifact)
+}
+
+func (service *combinedService) ReplayExecution(
+	artifact *recordings.ReplayArtifact,
+) (
+	workers.Provider,
+	workers.CommandRunner,
+	[]recordings.ReplayHook,
+	recordings.CompletionDeliveryPlanner,
+	error,
+) {
+	if service == nil {
+		return nil, nil, nil, nil, fmt.Errorf("Recordings runtime opening is unavailable")
+	}
+	return NewReplayExecution(
+		artifact,
+		service.replaySnapshotDecoder,
+		service.replayConfigDecoder,
+	)
+}
+
+// LoadReplayInput keeps path-based replay classification on the Recordings
+// root while retaining the narrow pre-ledger capability used by loading.
+func (service *combinedService) LoadReplayInput(
+	request recordings.LoadReplayInputRequest,
+) (recordings.LoadReplayInputResult, error) {
+	if service == nil || service.replayInputs == nil {
+		return recordings.LoadReplayInputResult{}, recordings.ErrMissingReplayArtifact
+	}
+	return service.replayInputs.LoadReplayInput(request)
+}
+
+// OpenRuntime acquires the runtime-owned ledger and, when recording is
+// enabled, binds its recorder to this root's shared lifecycle owner.
+func (service *combinedService) OpenRuntime(
+	ctx context.Context,
+	request recordings.RuntimeScopeRequest,
+) (recordings.RuntimeScopeResult, error) {
+	if service == nil || service.runtimeRouter == nil {
+		return recordings.RuntimeScopeResult{}, fmt.Errorf("Recordings runtime opening is unavailable")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return recordings.RuntimeScopeResult{}, err
+	}
+	if request.Topology == nil {
+		return recordings.RuntimeScopeResult{}, fmt.Errorf("Recordings runtime topology is required")
+	}
+	if request.Now == nil {
+		return recordings.RuntimeScopeResult{}, fmt.Errorf("Recordings runtime clock is required")
+	}
+	streamGenerationID := strings.TrimSpace(request.RecordingID)
+	if streamGenerationID == "" {
+		streamGenerationID = "recordings-runtime"
+	}
+	streamGenerationID += "-" + strings.TrimSpace(request.FactorySessionID)
+	ledger := NewRuntimeLedger(
+		request.Topology,
+		request.Now,
+		streamGenerationID,
+		request.Definitions,
+	)
+	if ledger == nil {
+		return recordings.RuntimeScopeResult{}, fmt.Errorf("Recordings runtime ledger is unavailable")
+	}
+	routeKey := strings.TrimSpace(request.FactorySessionID)
+	if routeKey == "" {
+		routeKey = ledger.StreamGenerationID()
+	}
+	if err := service.runtimeRouter.register(routeKey, ledger); err != nil {
+		return recordings.RuntimeScopeResult{}, err
+	}
+	cleanupRoute := true
+	defer func() {
+		if cleanupRoute {
+			service.runtimeRouter.unregister(routeKey, ledger)
+		}
+	}()
+
+	if strings.TrimSpace(request.RecordPath) == "" {
+		cleanupRoute = false
+		return recordings.RuntimeScopeResult{
+			Ledger:   ledger,
+			Recorder: &runtimeScopeRecorder{owner: service, routeKey: routeKey, ledger: ledger},
+		}, nil
+	}
+	if service.runtimeSnapshotCapture == nil {
+		return recordings.RuntimeScopeResult{}, fmt.Errorf("Recordings runtime snapshot capture is required")
+	}
+	recorder, err := NewLifecycleRuntimeRecorder(
+		request.FlushInterval,
+		request.LoadedFactory,
+		request.Now,
+		request.RecordingID,
+		request.RecordPath,
+		service.runtimeSnapshotCapture,
+	)
+	if err != nil {
+		return recordings.RuntimeScopeResult{}, err
+	}
+	if recorder == nil {
+		return recordings.RuntimeScopeResult{}, fmt.Errorf("Recordings runtime recorder is unavailable")
+	}
+	lifecycleRecorder, ok := recorder.(*lifecycleRuntimeRecorder)
+	if !ok || lifecycleRecorder == nil {
+		return recordings.RuntimeScopeResult{}, fmt.Errorf("Recordings runtime recorder has unsupported implementation")
+	}
+	binder, ok := recorder.(recordings.RuntimeRecordingBinder)
+	if !ok {
+		return recordings.RuntimeScopeResult{}, fmt.Errorf("Recordings runtime recorder cannot bind")
+	}
+	if err := binder.BindRecordingLifecycle(
+		recordings.RecordingLifecycle(service),
+		requestScope(request),
+	); err != nil {
+		if lifecycleRecorder.recordingID != "" {
+			_, _ = service.FinishRecording(recordings.FinishRecordingRequest{
+				RecordingID: recordings.RecordingID(lifecycleRecorder.recordingID),
+				FinishedAt:  request.Now().UTC(),
+			})
+		}
+		return recordings.RuntimeScopeResult{}, fmt.Errorf("bind Recordings runtime scope: %w", err)
+	}
+	ref := service.newRecordingScope()
+	binding := &recordingScopeBinding{
+		recordingID: recordings.RecordingID(lifecycleRecorder.recordingID),
+		eventScope:  lifecycleRecorder.scope,
+		replayPlans: make(map[recordings.ReplayPlanHandle]struct{}),
+	}
+	service.scopeMu.Lock()
+	service.scopeByRef[ref] = binding
+	service.scopeMu.Unlock()
+	cleanupRoute = false
+	return recordings.RuntimeScopeResult{
+		Ledger: ledger,
+		Recorder: &runtimeScopeRecorder{
+			inner: recorder, owner: service, scope: ref, routeKey: routeKey, ledger: ledger,
+		},
+		Scope: ref,
+	}, nil
+}
+
+func requestScope(request recordings.RuntimeScopeRequest) recordings.CanonicalEventScope {
+	return recordings.CanonicalEventScope{FactorySessionID: strings.TrimSpace(request.FactorySessionID)}
+}
+
+// closeRuntimeRecordingScope records the terminal state already produced by
+// the runtime recorder and closes its opaque scope without calling Finish a
+// second time. The runtime recorder owns terminal-event emission and lifecycle
+// finalization; this method only closes the root-owned scope bookkeeping.
+func (service *combinedService) closeRuntimeRecordingScope(
+	ctx context.Context,
+	ref recordings.RecordingScopeRef,
+	finalizeErr error,
+) error {
+	if service == nil || ref.IsZero() {
+		return finalizeErr
+	}
+	binding, err := service.recordingScope(ref)
+	if err != nil {
+		return errors.Join(finalizeErr, err)
+	}
+	binding.mu.Lock()
+	defer binding.mu.Unlock()
+	if binding.closed {
+		return errors.Join(finalizeErr, binding.finalizeErr)
+	}
+	if err := recordingScopeContext(ctx).Err(); err != nil {
+		return errors.Join(finalizeErr, err)
+	}
+	if !binding.finalized {
+		binding.finalized = true
+		binding.finalizeErr = finalizeErr
+		status, statusErr := service.scopeStatus(ref, binding)
+		binding.finalizeErr = errors.Join(binding.finalizeErr, statusErr)
+		if statusErr == nil {
+			binding.terminal = status
+		}
+	}
+	binding.closed = true
+	return errors.Join(finalizeErr, binding.finalizeErr)
+}
+
+type runtimeScopeRecorder struct {
+	mu          sync.Mutex
+	inner       recordings.RuntimeRecorder
+	owner       *combinedService
+	scope       recordings.RecordingScopeRef
+	routeKey    string
+	ledger      recordings.RuntimeEventLedger
+	finalized   bool
+	finalizeErr error
+}
+
+func (recorder *runtimeScopeRecorder) Start(ctx context.Context) {
+	if recorder != nil && recorder.inner != nil {
+		recorder.inner.Start(ctx)
+	}
+}
+
+func (recorder *runtimeScopeRecorder) Stop() {
+	if recorder != nil && recorder.inner != nil {
+		recorder.inner.Stop()
+	}
+}
+
+func (recorder *runtimeScopeRecorder) RecordEvent(event recordings.FactoryEvent) {
+	if recorder != nil && recorder.inner != nil {
+		recorder.inner.RecordEvent(event)
+	}
+}
+
+func (recorder *runtimeScopeRecorder) RecordError(err error) {
+	if recorder != nil && recorder.inner != nil {
+		recorder.inner.RecordError(err)
+	}
+}
+
+func (recorder *runtimeScopeRecorder) Flush() error {
+	if recorder == nil || recorder.inner == nil {
+		return nil
+	}
+	return recorder.inner.Flush()
+}
+
+func (recorder *runtimeScopeRecorder) Err() error {
+	if recorder == nil {
+		return nil
+	}
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	var recorderErr error
+	if recorder.inner != nil {
+		recorderErr = recorder.inner.Err()
+	}
+	return errors.Join(recorder.finalizeErr, recorderErr)
+}
+
+func (recorder *runtimeScopeRecorder) Finish(finishedAt time.Time) {
+	_ = recorder.Finalize(finishedAt)
+}
+
+func (recorder *runtimeScopeRecorder) Finalize(finishedAt time.Time) error {
+	if recorder == nil {
+		return nil
+	}
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	if recorder.finalized {
+		err := recorder.finalizeErr
+		return err
+	}
+	recorder.finalized = true
+
+	var finalizeErr error
+	if recorder.inner != nil {
+		finalizeErr = recorder.inner.Finalize(finishedAt)
+	}
+	var closeErr error
+	if !recorder.scope.IsZero() && recorder.owner != nil {
+		closeErr = recorder.owner.closeRuntimeRecordingScope(
+			context.Background(), recorder.scope, finalizeErr,
+		)
+	}
+	if recorder.owner != nil && recorder.owner.runtimeRouter != nil {
+		recorder.owner.runtimeRouter.unregister(recorder.routeKey, recorder.ledger)
+	}
+	recorder.finalizeErr = errors.Join(finalizeErr, closeErr)
+	return errors.Join(finalizeErr, closeErr)
+}
+
+var _ recordings.RuntimeRecorder = (*runtimeScopeRecorder)(nil)

--- a/pkg/services/recordings/internal/runtime_opening_test.go
+++ b/pkg/services/recordings/internal/runtime_opening_test.go
@@ -1,0 +1,150 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+)
+
+func TestRuntimeRootKeepsConcurrentLedgersIsolatedAndReleasesRoutes(t *testing.T) {
+	root := NewRuntimeRoot(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	if root == nil {
+		t.Fatal("NewRuntimeRoot() returned nil")
+	}
+	topology := runtimeOpeningTopology{}
+	now := func() time.Time { return time.Unix(1_700_000_000, 0).UTC() }
+
+	first, err := root.OpenRuntime(context.Background(), recordings.RuntimeScopeRequest{
+		Topology:         topology,
+		Now:              now,
+		RecordingID:      "recording-one",
+		FactorySessionID: "session-one",
+	})
+	if err != nil {
+		t.Fatalf("OpenRuntime(first): %v", err)
+	}
+	second, err := root.OpenRuntime(context.Background(), recordings.RuntimeScopeRequest{
+		Topology:         topology,
+		Now:              now,
+		RecordingID:      "recording-two",
+		FactorySessionID: "session-two",
+	})
+	if err != nil {
+		t.Fatalf("OpenRuntime(second): %v", err)
+	}
+	if first.Ledger == second.Ledger {
+		t.Fatal("OpenRuntime returned the same ledger for concurrent sessions")
+	}
+
+	first.Ledger.RecordRunRequest()
+	if got := len(first.Ledger.CanonicalEvents()); got != 1 {
+		t.Fatalf("first ledger events = %d, want 1", got)
+	}
+	if got := len(second.Ledger.CanonicalEvents()); got != 0 {
+		t.Fatalf("second ledger events = %d, want 0 before its own append", got)
+	}
+
+	finishedAt := now().Add(time.Second)
+	if err := first.Recorder.Finalize(finishedAt); err != nil {
+		t.Fatalf("Finalize(first): %v", err)
+	}
+	if err := first.Recorder.Finalize(finishedAt.Add(time.Second)); err != nil {
+		t.Fatalf("Finalize(first) second call: %v", err)
+	}
+	if _, err := root.SubscribeFrom(context.Background(), recordings.SubscribeRequest{
+		Scope: recordings.CanonicalEventScope{FactorySessionID: "session-one"},
+	}); !errors.Is(err, recordings.ErrReconnectCursorUnavailable) {
+		t.Fatalf("Subscribe(closed first session) = %v, want isolated route failure", err)
+	}
+
+	second.Ledger.RecordRunRequest()
+	if got := len(second.Ledger.CanonicalEvents()); got != 1 {
+		t.Fatalf("second ledger events = %d, want 1", got)
+	}
+	if err := second.Recorder.Finalize(finishedAt); err != nil {
+		t.Fatalf("Finalize(second): %v", err)
+	}
+}
+
+func TestRuntimeRootActiveRecordingOwnsOpaqueScopeAndFinalizesOnce(t *testing.T) {
+	snapshot, err := factorydefinitions.NewFactorySnapshot(map[string]any{
+		"id": "runtime-opening-test",
+	})
+	if err != nil {
+		t.Fatalf("NewFactorySnapshot: %v", err)
+	}
+	root := NewRuntimeRoot(
+		nil,
+		nil,
+		nil,
+		func(
+			factorydefinitions.FactorySnapshotSource,
+			string,
+			map[string]string,
+		) (*factorydefinitions.FactorySnapshot, error) {
+			return snapshot, nil
+		},
+		nil,
+		nil,
+		nil,
+	)
+	now := func() time.Time { return time.Unix(1_700_000_100, 0).UTC() }
+	opened, err := root.OpenRuntime(context.Background(), recordings.RuntimeScopeRequest{
+		Topology:         runtimeOpeningTopology{},
+		Now:              now,
+		RecordingID:      "recording-active",
+		RecordPath:       "recording.json",
+		FactorySessionID: "session-active",
+	})
+	if err != nil {
+		t.Fatalf("OpenRuntime(active): %v", err)
+	}
+	if opened.Scope.IsZero() {
+		t.Fatal("OpenRuntime(active) returned a zero scope")
+	}
+	status, err := root.QueryRecordingStatus(recordings.RecordingStatusRequest{
+		RecordingID: "recording-active",
+	})
+	if err != nil {
+		t.Fatalf("QueryRecordingStatus(active): %v", err)
+	}
+	if status.Status.AcceptedEvents != 1 {
+		t.Fatalf("active recording events = %d, want initial snapshot event", status.Status.AcceptedEvents)
+	}
+
+	finishedAt := now().Add(time.Second)
+	if err := opened.Recorder.Finalize(finishedAt); err != nil {
+		t.Fatalf("Finalize(active): %v", err)
+	}
+	if err := opened.Recorder.Finalize(finishedAt.Add(time.Second)); err != nil {
+		t.Fatalf("Finalize(active) second call: %v", err)
+	}
+	status, err = root.QueryRecordingStatus(recordings.RecordingStatusRequest{
+		RecordingID: "recording-active",
+	})
+	if err != nil {
+		t.Fatalf("QueryRecordingStatus(finalized): %v", err)
+	}
+	if status.Status.State != recordings.RecordingFinalized || status.Status.AcceptedEvents != 2 {
+		t.Fatalf("finalized active recording = %#v, want FINALIZED with initial and terminal events", status.Status)
+	}
+	if _, err := root.QueryRecordingScope(context.Background(), recordings.QueryRecordingScopeRequest{
+		Scope: opened.Scope,
+	}); !errors.Is(err, recordings.ErrRecordingScopeClosed) {
+		t.Fatalf("QueryRecordingScope(closed): %v, want closed-scope error", err)
+	}
+}
+
+type runtimeOpeningTopology struct{}
+
+func (runtimeOpeningTopology) RecordingInitialStructure(
+	...factorydefinitions.RuntimeDefinitionLookup,
+) recordings.InitialStructurePayload {
+	return recordings.InitialStructurePayload{}
+}
+
+var _ recordings.InitialStructureSource = runtimeOpeningTopology{}

--- a/pkg/services/recordings/internal/runtime_router.go
+++ b/pkg/services/recordings/internal/runtime_router.go
@@ -1,0 +1,207 @@
+package internal
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	recordingevents "github.com/portpowered/infinite-you/pkg/services/recordings/internal/events"
+)
+
+// runtimeLedgerRouter keeps the public Recordings root stable while routing
+// session-scoped event operations to the private runtime ledgers it owns.
+// The fallback ledger preserves the root contract for callers that append
+// factory-wide events before a runtime scope has been opened.
+type runtimeLedgerRouter struct {
+	mu            sync.RWMutex
+	fallback      recordings.Ledger
+	routes        map[string]recordings.RuntimeEventLedger
+	recorders     []func(interfaces.FactoryEvent)
+	typeRecorders []func(interfaces.FactoryEventType)
+}
+
+func newRuntimeLedgerRouter() *runtimeLedgerRouter {
+	fallback := recordingevents.NewRuntimeLedger(nil, time.Now, "recordings-root", nil)
+	return &runtimeLedgerRouter{
+		fallback: fallback,
+		routes:   make(map[string]recordings.RuntimeEventLedger),
+	}
+}
+
+func (router *runtimeLedgerRouter) register(
+	scope string,
+	ledger recordings.RuntimeEventLedger,
+) error {
+	if router == nil || ledger == nil {
+		return recordings.ErrInvalidRecordingScope
+	}
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		scope = ledger.StreamGenerationID()
+	}
+	router.mu.Lock()
+	router.routes[scope] = ledger
+	recorders := append([]func(interfaces.FactoryEvent){}, router.recorders...)
+	typeRecorders := append([]func(interfaces.FactoryEventType){}, router.typeRecorders...)
+	router.mu.Unlock()
+	for _, recorder := range recorders {
+		ledger.AddEventRecorder(recorder)
+	}
+	for _, recorder := range typeRecorders {
+		ledger.AddEventTypeRecorder(recorder)
+	}
+	return nil
+}
+
+func (router *runtimeLedgerRouter) unregister(
+	scope string,
+	ledger recordings.RuntimeEventLedger,
+) {
+	if router == nil || ledger == nil {
+		return
+	}
+	scope = strings.TrimSpace(scope)
+	router.mu.Lock()
+	current, ok := router.routes[scope]
+	if ok && current != nil && current.StreamGenerationID() == ledger.StreamGenerationID() {
+		delete(router.routes, scope)
+	}
+	router.mu.Unlock()
+}
+
+func (router *runtimeLedgerRouter) route(scope string) recordings.Ledger {
+	if router == nil {
+		return nil
+	}
+	scope = strings.TrimSpace(scope)
+	router.mu.RLock()
+	defer router.mu.RUnlock()
+	if scope != "" {
+		return router.routes[scope]
+	}
+	if len(router.routes) == 1 {
+		for _, ledger := range router.routes {
+			return ledger
+		}
+	}
+	return router.fallback
+}
+
+func (router *runtimeLedgerRouter) CanonicalEvents() []interfaces.FactoryEvent {
+	if router == nil {
+		return nil
+	}
+	router.mu.RLock()
+	ledgers := make([]recordings.RuntimeEventLedger, 0, len(router.routes))
+	for _, ledger := range router.routes {
+		ledgers = append(ledgers, ledger)
+	}
+	fallback := router.fallback
+	router.mu.RUnlock()
+	if len(ledgers) == 0 {
+		return fallback.CanonicalEvents()
+	}
+	events := make([]interfaces.FactoryEvent, 0)
+	for _, ledger := range ledgers {
+		events = append(events, ledger.CanonicalEvents()...)
+	}
+	sort.SliceStable(events, func(left, right int) bool {
+		return events[left].Context.EventTime.Before(events[right].Context.EventTime)
+	})
+	return events
+}
+
+func (router *runtimeLedgerRouter) Subscribe(
+	ctx context.Context,
+	reconnect *interfaces.FactoryEventReconnectCursor,
+	scope interfaces.FactoryEventReconnectScope,
+) (interfaces.FactoryEventStream, error) {
+	ledger := router.route(scope.SessionID)
+	if ledger == nil {
+		return interfaces.FactoryEventStream{}, recordings.ErrReconnectCursorUnavailable
+	}
+	return ledger.Subscribe(ctx, reconnect, scope)
+}
+
+func (router *runtimeLedgerRouter) StreamGenerationID() string {
+	if router == nil {
+		return ""
+	}
+	router.mu.RLock()
+	defer router.mu.RUnlock()
+	if len(router.routes) == 1 {
+		for _, ledger := range router.routes {
+			return ledger.StreamGenerationID()
+		}
+	}
+	if router.fallback == nil {
+		return ""
+	}
+	return router.fallback.StreamGenerationID()
+}
+
+func (router *runtimeLedgerRouter) AddEventRecorder(
+	recorder func(interfaces.FactoryEvent),
+) {
+	if router == nil || recorder == nil {
+		return
+	}
+	router.mu.Lock()
+	router.recorders = append(router.recorders, recorder)
+	ledgers := make([]recordings.RuntimeEventLedger, 0, len(router.routes))
+	for _, ledger := range router.routes {
+		ledgers = append(ledgers, ledger)
+	}
+	fallback := router.fallback
+	router.mu.Unlock()
+	if fallback != nil {
+		fallback.AddEventRecorder(recorder)
+	}
+	for _, ledger := range ledgers {
+		ledger.AddEventRecorder(recorder)
+	}
+}
+
+func (router *runtimeLedgerRouter) AddEventTypeRecorder(
+	recorder func(interfaces.FactoryEventType),
+) {
+	if router == nil || recorder == nil {
+		return
+	}
+	router.mu.Lock()
+	router.typeRecorders = append(router.typeRecorders, recorder)
+	ledgers := make([]recordings.RuntimeEventLedger, 0, len(router.routes))
+	for _, ledger := range router.routes {
+		ledgers = append(ledgers, ledger)
+	}
+	fallback := router.fallback
+	router.mu.Unlock()
+	if fallback != nil {
+		fallback.AddEventTypeRecorder(recorder)
+	}
+	for _, ledger := range ledgers {
+		ledger.AddEventTypeRecorder(recorder)
+	}
+}
+
+func (router *runtimeLedgerRouter) AppendRecordedEvent(
+	event interfaces.FactoryEvent,
+) {
+	if router == nil {
+		return
+	}
+	scope := ""
+	if event.Context.SessionID != nil {
+		scope = strings.TrimSpace(*event.Context.SessionID)
+	}
+	ledger := router.route(scope)
+	if ledger != nil {
+		ledger.AppendRecordedEvent(event)
+	}
+}
+
+var _ recordings.Ledger = (*runtimeLedgerRouter)(nil)

--- a/pkg/services/recordings/wire/providers.go
+++ b/pkg/services/recordings/wire/providers.go
@@ -58,6 +58,50 @@ func NewReplayInputLoader(
 	return recordingsinternal.NewReplayInputLoader(readFile, loadLegacy, logger)
 }
 
+// NewRuntimeRoot constructs the singular process-scoped Recordings authority.
+// Runtime ledgers, projection use, replay collaborators, and recording
+// lifecycle state are acquired through the returned root's RuntimeOpening
+// capability rather than through opening-local constructors.
+func NewRuntimeRoot(
+	targets recordings.LiveRecordingTargetPlanner,
+	writeFile func(string, []byte) error,
+	makeDirectories recordings.RecordingMakeDirectories,
+	createTemporaryFile recordings.RecordingCreateTemporaryFile,
+	removePath recordings.RecordingRemovePath,
+	renamePath recordings.RecordingRenamePath,
+	readFile recordings.RecordingReadFile,
+	captureSnapshot factorydefinitions.LoadedFactorySnapshotCapturer,
+	decodeSnapshot factorydefinitions.FactorySnapshotJSONDecoder,
+	decodeRuntimeConfig factorydefinitions.ReplayRuntimeConfigDecoder,
+	replayInputs recordings.ReplayInputLoader,
+	clocks ...recordings.RecordingClock,
+) (recordings.Root, error) {
+	publication, err := recordingsinternal.NewPortableArtifactPublication(
+		makeDirectories,
+		createTemporaryFile,
+		removePath,
+		renamePath,
+		readFile,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("construct Recordings publication: %w", err)
+	}
+	root := recordingsinternal.NewRuntimeRoot(
+		targets,
+		writeFile,
+		publication,
+		captureSnapshot,
+		decodeSnapshot,
+		decodeRuntimeConfig,
+		replayInputs,
+		clocks...,
+	)
+	if root == nil {
+		return nil, fmt.Errorf("construct Recordings: runtime root rejected its dependencies")
+	}
+	return root, nil
+}
+
 // NewProjectionService constructs the Recordings projection capability for
 // process-graph composition.
 func NewProjectionService() recordings.ProjectionService {


### PR DESCRIPTION
Stack slice for btrc-p2b-work-recordings-roots-004ab.

This dependent slice is intentionally kept below the repository's roughly-20-file delivery target. The final named PR carries the complete PRD and is based on this slice.