### PR TITLE
test(cli-process): tolerate reaped-pipe close in bounded-failure wait

### DIFF
--- a/tests/functional/transport/cli/process/hard_kill_successor_test.go
+++ b/tests/functional/transport/cli/process/hard_kill_successor_test.go
@@ -190,7 +190,14 @@ func (process *hardKillCLIProcess) waitForBoundedFailure(t testing.TB, role stri
 	if !scanned {
 		t.Fatalf("%s stdout scanner did not finish within %s: stdout=%q stderr=%q process=%s", role, hardKillProcessExitTimeout, process.stdoutText(), process.stderrText(), process.processState())
 	}
-	if scanErr != nil {
+	// waitForExit above already reaped the child, so Cmd.Wait has closed the
+	// StdoutPipe by this point. The scanner can therefore observe that terminal
+	// descriptor close as fs.ErrClosed instead of EOF, the same race stopWith
+	// tolerates when this helper's own termination wins it. Here the process is
+	// known to have exited on its own, so accept only that expected terminal
+	// error; every other scanner error remains actionable. Truncated output stays
+	// detectable because callers still assert on stdout contents.
+	if scanErr != nil && !(exited && errors.Is(scanErr, os.ErrClosed)) {
 		t.Fatalf("%s stdout scanner failed: %v; stdout=%q stderr=%q process=%s", role, scanErr, process.stdoutText(), process.stderrText(), process.processState())
 	}
 	if waitErr == nil {


### PR DESCRIPTION
Operator fix for a residual gap in #1917 that is currently taxing an unrelated lane.

## What broke

PR #1910 (`btrc-p2b-work-recordings-roots`), run `31667102093`, had exactly one failing test — in a package its diff does not touch, on a branch that already contains current `origin/main`:

```
tests/functional/transport/cli/process
  TestCLISuccessorAfterHardKillReportsPreRuntimeStagingContention
  hard_kill_successor_test.go:88: successor stdout scanner failed:
    read |0: file already closed
```

## Why #1917 did not cover it

#1917 diagnosed the race correctly: `exec.Cmd.Wait` closes a `StdoutPipe` after reaping the child, so the scanner can observe that terminal descriptor close as `fs.ErrClosed` rather than a clean EOF. It tolerated exactly that error in `hardKillCLIProcess.stopWith`, gated on `terminated` — this helper's own termination having won the race.

The same race exists at a second call site. `waitForBoundedFailure` hard-failed on *any* scanner error, and that is the path used when the process is expected to exit **on its own**, which is precisely what this test's successor does by design. No intentional terminate is involved there, so #1917's `terminated` guard never applies — but `Cmd.Wait` still closes the pipe, via `waitForExit`.

## The change

One site, gated on the child being confirmed reaped:

```go
if scanErr != nil && !(exited && errors.Is(scanErr, os.ErrClosed)) {
```

`exited` is guaranteed true at that point (the `!exited` branch above `t.Fatalf`s), so the guard is there to keep the invariant visible rather than to add a runtime condition — a future reordering cannot silently broaden the tolerance.

This is not a new convention. `waitForScannerCompletion` in `fixtures_test.go:251` already tolerates `os.ErrClosed` for this same race, with the same reasoning in its comment. `waitForBoundedFailure` was the one site in the package that never got it.

## Why this does not weaken the test

Tolerating the close does not let truncated output through. The caller still asserts on stdout contents — that it does **not** contain `Dashboard URL:`, and that it **does** contain `stagingPath`, `outcome=indeterminate-contention`, `owner_liveness=indeterminate`, and `owner_pid=<predecessor pid>`. A scanner that closed early and lost output fails those assertions independently. The bounded-failure assertion (`successorErr != nil`) is untouched.

No timeout widened, no retry loop, no `t.Skip`, no baseline entry. Diff is 8 insertions in one test file.

## Verification

```
go vet ./tests/functional/transport/cli/process/                       # clean
go test ./tests/functional/transport/cli/process/ \
  -run TestCLISuccessorAfterHardKillReportsPreRuntimeStagingContention \
  -count=5 -v                                                          # 5/5 PASS
```

Confirmed executing rather than skipping (`--- PASS ... (3.76s)`, 5 PASS lines at `-count=5`).

I did not reproduce the failure locally without the fix — it is load-sensitive and did not surface on this host. The argument for the fix is structural: it is the same race #1917 already documented, at a call site whose precondition (`Cmd.Wait` has reaped the child) makes the closed-pipe read the expected terminal condition.

Taken operator-side rather than assigned to a lane for the same reason as the `pkg/wire` floor repin in #1918: it is a shared gate, it is a few lines, and every lane that rebases pays for it. Noted on #1910 so that lane does not chase it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)