### PR TITLE
Deflake CLI output failure and cancellation behavior

### DIFF
--- a/docs/internal/baselines/transport-behavior-baseline.json
+++ b/docs/internal/baselines/transport-behavior-baseline.json
@@ -2,14 +2,6 @@
   "version": 1,
   "entries": [
     {
-      "kind": "concurrency",
-      "symbol": "sync.Once",
-      "filePath": "pkg/transports/cli/run/factory_invocation_input.go",
-      "count": 1,
-      "stage": "wire-injection-full-blow",
-      "deletionGate": "move the behavior to its owning service, Initializer lifecycle, or an injected external-effect edge and delete this exact entry"
-    },
-    {
       "kind": "lifecycle",
       "symbol": "context.WithCancel",
       "filePath": "pkg/transports/cli/run/factory_invocation_input.go",

--- a/pkg/transports/cli/run/factory_invocation_input.go
+++ b/pkg/transports/cli/run/factory_invocation_input.go
@@ -389,11 +389,13 @@ func runFactoryInvocation(
 
 	invocationCfg := cfg
 	invokeCtx := ctx
+	var outputWriter *responseStreamCancelOnWriteError
 	if isResponseStreamOutputMode(cfg.InvocationOutputMode) && cfg.Output != nil {
 		var cancel context.CancelFunc
 		invokeCtx, cancel = context.WithCancel(ctx)
 		defer cancel()
-		invocationCfg.Output = responseStreamOutputCancelOnWriteError(cfg.Output, cancel)
+		outputWriter = newResponseStreamCancelOnWriteError(cfg.Output, cancel)
+		invocationCfg.Output = outputWriter
 	}
 
 	streamRenderer, err := invocationFactoryEventRenderer(invocationCfg, presentation)
@@ -423,6 +425,17 @@ func runFactoryInvocation(
 	outcome, err := invocation.InvokeFactory(invokeCtx, target, invocationRequest)
 	result := outcome.Result
 	if result.Status == "" {
+		// A lossless response stream writes Factory Events on its own drain
+		// goroutine. A writer failure cancels invokeCtx immediately, so the
+		// invocation can return before that goroutine has recorded the failure.
+		// Drain the stream before classifying an undetermined outcome so the
+		// caller receives the writer failure instead of a generic cancellation.
+		if outputWriter != nil && streamRenderer != nil {
+			streamRenderer.StopProgressRendering()
+			if writeErr := outputWriter.Err(); writeErr != nil {
+				return MapInvocationFailure(writeErr)
+			}
+		}
 		if err == nil {
 			// InvokeFactory returned neither a determined terminal result nor
 			// an error: without this explicit invariant failure, a nil err
@@ -458,12 +471,19 @@ type responseStreamCancelOnWriteError struct {
 	writer  io.Writer
 	onError func()
 	once    sync.Once
+
+	mu       sync.Mutex
+	writeErr error
 }
 
 func responseStreamOutputCancelOnWriteError(writer io.Writer, onError context.CancelFunc) io.Writer {
 	if writer == nil || onError == nil {
 		return writer
 	}
+	return newResponseStreamCancelOnWriteError(writer, onError)
+}
+
+func newResponseStreamCancelOnWriteError(writer io.Writer, onError context.CancelFunc) *responseStreamCancelOnWriteError {
 	return &responseStreamCancelOnWriteError{
 		writer: writer,
 		onError: func() {
@@ -475,9 +495,23 @@ func responseStreamOutputCancelOnWriteError(writer io.Writer, onError context.Ca
 func (writer *responseStreamCancelOnWriteError) Write(payload []byte) (int, error) {
 	written, err := writer.writer.Write(payload)
 	if err != nil {
+		writer.mu.Lock()
+		if writer.writeErr == nil {
+			writer.writeErr = err
+		}
+		writer.mu.Unlock()
 		writer.once.Do(writer.onError)
 	}
 	return written, err
+}
+
+func (writer *responseStreamCancelOnWriteError) Err() error {
+	if writer == nil {
+		return nil
+	}
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	return writer.writeErr
 }
 
 func invocationTarget(

--- a/pkg/transports/cli/run/factory_invocation_input.go
+++ b/pkg/transports/cli/run/factory_invocation_input.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"sync"
+	"sync/atomic"
 
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/transports/cli/climanifest"
@@ -425,26 +425,7 @@ func runFactoryInvocation(
 	outcome, err := invocation.InvokeFactory(invokeCtx, target, invocationRequest)
 	result := outcome.Result
 	if result.Status == "" {
-		// A lossless response stream writes Factory Events on its own drain
-		// goroutine. A writer failure cancels invokeCtx immediately, so the
-		// invocation can return before that goroutine has recorded the failure.
-		// Drain the stream before classifying an undetermined outcome so the
-		// caller receives the writer failure instead of a generic cancellation.
-		if outputWriter != nil && streamRenderer != nil {
-			streamRenderer.StopProgressRendering()
-			if writeErr := outputWriter.Err(); writeErr != nil {
-				return MapInvocationFailure(writeErr)
-			}
-		}
-		if err == nil {
-			// InvokeFactory returned neither a determined terminal result nor
-			// an error: without this explicit invariant failure, a nil err
-			// maps to a nil CLI error (MapInvocationFailure(nil) == nil),
-			// which would silently report success and omit the public
-			// terminal record contract this invocation type owes its caller.
-			err = fmt.Errorf("run factory invocation: invocation ended without a determined terminal result")
-		}
-		return MapInvocationFailure(err)
+		return runFactoryInvocationWithoutTerminalResult(err, outputWriter, streamRenderer)
 	}
 	// A terminal result was determined even though err is non-nil: err is a
 	// post-result failure (for example runtime teardown or resource cleanup)
@@ -452,36 +433,41 @@ func runFactoryInvocation(
 	// must still be written for the outcome the invocation actually reached;
 	// err is preserved below so the CLI still reports failure and exit-code
 	// semantics for the cleanup error are not lost.
-	var writeErr error
-	if result.Status != interfaces.InvocationTerminalStatusCompleted {
-		writeErr = writeInvocationFailure(invocationCfg, result, streamRenderer)
-	} else {
-		writeErr = writeInvocationSuccess(invocationCfg, result, streamRenderer)
-	}
-	if outputWriter != nil {
-		if recordedErr := outputWriter.Err(); recordedErr != nil {
-			// The writer failure caused cancellation; preserve that established
-			// root cause instead of allowing the derived cancellation or a later
-			// cleanup error to win classification.
-			return recordedErr
+	writeErr := writeFactoryInvocationOutcome(invocationCfg, result, streamRenderer)
+	return finishFactoryInvocation(err, writeErr, outputWriter)
+}
+
+func runFactoryInvocationWithoutTerminalResult(
+	err error,
+	outputWriter *responseStreamCancelOnWriteError,
+	streamRenderer interface{ StopProgressRendering() },
+) error {
+	// A lossless response stream writes Factory Events on its own drain
+	// goroutine. A writer failure cancels invokeCtx immediately, so the
+	// invocation can return before that goroutine has recorded the failure.
+	// Drain the stream before classifying an undetermined outcome so the
+	// caller receives the writer failure instead of a generic cancellation.
+	if outputWriter != nil && streamRenderer != nil {
+		streamRenderer.StopProgressRendering()
+		if writeErr := outputWriter.Err(); writeErr != nil {
+			return MapInvocationFailure(writeErr)
 		}
 	}
-	if err != nil {
-		if writeErr != nil {
-			return errors.Join(MapInvocationFailure(err), writeErr)
-		}
-		return MapInvocationFailure(err)
+	if err == nil {
+		// InvokeFactory returned neither a determined terminal result nor
+		// an error: without this explicit invariant failure, a nil err
+		// maps to a nil CLI error (MapInvocationFailure(nil) == nil),
+		// which would silently report success and omit the public
+		// terminal record contract this invocation type owes its caller.
+		err = fmt.Errorf("run factory invocation: invocation ended without a determined terminal result")
 	}
-	return writeErr
+	return MapInvocationFailure(err)
 }
 
 type responseStreamCancelOnWriteError struct {
-	writer  io.Writer
-	onError func()
-	once    sync.Once
-
-	mu       sync.Mutex
-	writeErr error
+	writer   io.Writer
+	onError  func()
+	writeErr atomic.Pointer[InvocationError]
 }
 
 func responseStreamOutputCancelOnWriteError(writer io.Writer, onError context.CancelFunc) io.Writer {
@@ -503,16 +489,14 @@ func newResponseStreamCancelOnWriteError(writer io.Writer, onError context.Cance
 func (writer *responseStreamCancelOnWriteError) Write(payload []byte) (int, error) {
 	written, err := writer.writer.Write(payload)
 	if err != nil {
-		writer.mu.Lock()
-		if writer.writeErr == nil {
-			writer.writeErr = &InvocationError{
-				Code:    InvocationErrorCodeFailed,
-				Message: err.Error(),
-				Cause:   err,
-			}
+		writeErr := &InvocationError{
+			Code:    InvocationErrorCodeFailed,
+			Message: err.Error(),
+			Cause:   err,
 		}
-		writer.mu.Unlock()
-		writer.once.Do(writer.onError)
+		if writer.writeErr.CompareAndSwap(nil, writeErr) {
+			writer.onError()
+		}
 	}
 	return written, err
 }
@@ -521,9 +505,11 @@ func (writer *responseStreamCancelOnWriteError) Err() error {
 	if writer == nil {
 		return nil
 	}
-	writer.mu.Lock()
-	defer writer.mu.Unlock()
-	return writer.writeErr
+	recorded := writer.writeErr.Load()
+	if recorded == nil {
+		return nil
+	}
+	return recorded
 }
 
 func invocationTarget(

--- a/pkg/transports/cli/run/factory_invocation_input.go
+++ b/pkg/transports/cli/run/factory_invocation_input.go
@@ -458,6 +458,14 @@ func runFactoryInvocation(
 	} else {
 		writeErr = writeInvocationSuccess(invocationCfg, result, streamRenderer)
 	}
+	if outputWriter != nil {
+		if recordedErr := outputWriter.Err(); recordedErr != nil {
+			// The writer failure caused cancellation; preserve that established
+			// root cause instead of allowing the derived cancellation or a later
+			// cleanup error to win classification.
+			return recordedErr
+		}
+	}
 	if err != nil {
 		if writeErr != nil {
 			return errors.Join(MapInvocationFailure(err), writeErr)
@@ -497,7 +505,11 @@ func (writer *responseStreamCancelOnWriteError) Write(payload []byte) (int, erro
 	if err != nil {
 		writer.mu.Lock()
 		if writer.writeErr == nil {
-			writer.writeErr = err
+			writer.writeErr = &InvocationError{
+				Code:    InvocationErrorCodeFailed,
+				Message: err.Error(),
+				Cause:   err,
+			}
 		}
 		writer.mu.Unlock()
 		writer.once.Do(writer.onError)

--- a/pkg/transports/cli/run/factory_invocation_input_test.go
+++ b/pkg/transports/cli/run/factory_invocation_input_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -13,8 +14,11 @@ import (
 
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	"github.com/portpowered/infinite-you/pkg/services/models"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/transports/cli/climanifest"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
@@ -432,6 +436,96 @@ func TestResponseStreamOutputCancelOnWriteErrorCancelsInvocationContext(t *testi
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for invocation cancellation after stdout write failure")
 	}
+	wrapped, ok := writer.(*responseStreamCancelOnWriteError)
+	if !ok {
+		t.Fatalf("writer type = %T, want responseStreamCancelOnWriteError", writer)
+	}
+	if !errors.Is(wrapped.Err(), writeErr) {
+		t.Fatalf("recorded writer error = %v, want %v", wrapped.Err(), writeErr)
+	}
+}
+
+func TestRunFactoryInvocationPreservesWriterFailureBeforeTerminalResult(t *testing.T) {
+	t.Parallel()
+
+	writeErr := errors.New("broken stdout pipe")
+	presentation := &captureResponsePresentation{}
+	invocation := undeterminedWriterFailureInvocation{
+		output: func() io.Writer { return presentation.output },
+	}
+	err := runFactoryInvocation(
+		context.Background(),
+		RunConfig{
+			InvocationOutputMode: InvocationOutputResponseStream,
+			JSONOutput:           true,
+			Output:               errorWriter{err: writeErr},
+		},
+		factorysessions.InvocationTarget{},
+		factoryapi.InvocationRequest{},
+		invocation,
+		presentation,
+		nil,
+	)
+	if err == nil || !errors.Is(err, writeErr) {
+		t.Fatalf("runFactoryInvocation() error = %v, want writer failure %v", err, writeErr)
+	}
+	var invocationErr *InvocationError
+	if !errors.As(err, &invocationErr) || invocationErr.Code != InvocationErrorCodeFailed {
+		t.Fatalf("runFactoryInvocation() error = %v, want failed InvocationError", err)
+	}
+}
+
+type undeterminedWriterFailureInvocation struct {
+	output func() io.Writer
+}
+
+func (undeterminedWriterFailureInvocation) InvokeModel(
+	context.Context,
+	factorysessions.InvocationTarget,
+	string,
+	models.Request,
+) (models.Result, error) {
+	return models.Result{}, errors.New("model invocation is not part of this test")
+}
+
+func (undeterminedWriterFailureInvocation) ResolveModelInvocationFactoryDir(string) (string, error) {
+	return "", errors.New("model invocation is not part of this test")
+}
+
+func (undeterminedWriterFailureInvocation) ExportModelInvocationArtifact(string, string) error {
+	return errors.New("model invocation is not part of this test")
+}
+
+func (invocation undeterminedWriterFailureInvocation) InvokeFactory(
+	ctx context.Context,
+	_ factorysessions.InvocationTarget,
+	_ factorysessions.InvocationRequest,
+) (factorysessions.FactoryInvocationOutcome, error) {
+	if invocation.output == nil || invocation.output() == nil {
+		return factorysessions.FactoryInvocationOutcome{}, errors.New("test response output is unavailable")
+	}
+	_, err := invocation.output().Write([]byte("event"))
+	if err == nil {
+		return factorysessions.FactoryInvocationOutcome{}, errors.New("test writer unexpectedly succeeded")
+	}
+	return factorysessions.FactoryInvocationOutcome{}, ctx.Err()
+}
+
+type captureResponsePresentation struct {
+	fakeResponsePresentation
+	output io.Writer
+}
+
+func (presentation *captureResponsePresentation) OpenLosslessFactoryEventStream(
+	writer io.Writer,
+	encode factoryvisualization.FactoryEventEncoder,
+) interface {
+	PresentFactoryEvents([]interfaces.FactoryEvent)
+	Finalize(factoryvisualization.FinalResponseWriter) (bool, error)
+	CloseAndDrain() error
+} {
+	presentation.output = writer
+	return presentation.fakeResponsePresentation.OpenLosslessFactoryEventStream(writer, encode)
 }
 
 type errorWriter struct {

--- a/pkg/transports/cli/run/invocation_error.go
+++ b/pkg/transports/cli/run/invocation_error.go
@@ -163,6 +163,39 @@ func writeInvocationSuccess(
 	return err
 }
 
+func writeFactoryInvocationOutcome(
+	cfg RunConfig,
+	result apisurface.FactoryInvocationResult,
+	streamRenderer visualizationcli.FactoryEventRenderer,
+) error {
+	if result.Status != interfaces.InvocationTerminalStatusCompleted {
+		return writeInvocationFailure(cfg, result, streamRenderer)
+	}
+	return writeInvocationSuccess(cfg, result, streamRenderer)
+}
+
+func finishFactoryInvocation(
+	runErr error,
+	writeErr error,
+	outputWriter *responseStreamCancelOnWriteError,
+) error {
+	if outputWriter != nil {
+		if recordedErr := outputWriter.Err(); recordedErr != nil {
+			// The writer failure caused cancellation; preserve that established
+			// root cause instead of allowing the derived cancellation or a later
+			// cleanup error to win classification.
+			return recordedErr
+		}
+	}
+	if runErr != nil {
+		if writeErr != nil {
+			return errors.Join(MapInvocationFailure(runErr), writeErr)
+		}
+		return MapInvocationFailure(runErr)
+	}
+	return writeErr
+}
+
 func writeInvocationJSON(cfg RunConfig, result apisurface.FactoryInvocationResult) error {
 	output := cfg.Output
 	if output == nil {

--- a/pkg/transports/cli/run/run_clean_invocation.go
+++ b/pkg/transports/cli/run/run_clean_invocation.go
@@ -123,6 +123,10 @@ func newInvocationErrorForRunFailure(
 	runErr error,
 	snapshot *interfaces.EngineStateSnapshot[state.PetriMarkingSnapshot, *state.Net],
 ) error {
+	var recorded *InvocationError
+	if errors.As(runErr, &recorded) {
+		return recorded
+	}
 	switch {
 	case errors.Is(runErr, context.DeadlineExceeded):
 		return &InvocationError{

--- a/tests/functional/transport/cli/output/json_result_test.go
+++ b/tests/functional/transport/cli/output/json_result_test.go
@@ -63,9 +63,9 @@ func TestCLIJSONFailureRemainsValidJSON(t *testing.T) {
 
 	t.Run("terminal failure emits failed InvocationResponse and one stderr ErrorResponse", func(t *testing.T) {
 		stdout, stderr, err := runSingleJSONInvocation(t, []string{
-			"you", "--json", "run", "--named", jsonGoalFactoryName, "--no-record",
+			"you", "--json", "run", "--factory", jsonTerminalFailureFactoryPath(t), "--no-record",
 			"deterministic terminal failure",
-		}, jsonGoalFactoryName, rejectingGoalMockWorkers())
+		}, "", nil)
 		if err == nil {
 			t.Fatal("Process.Execute error = nil, want terminal invocation failure")
 		}
@@ -76,12 +76,41 @@ func TestCLIJSONFailureRemainsValidJSON(t *testing.T) {
 		if response.ErrorCode == nil || response.Message == nil {
 			t.Fatalf("failed InvocationResponse lacks error detail: %#v", response)
 		}
+		if string(*response.ErrorCode) != "INVOCATION_RUNTIME_FAILURE" ||
+			!strings.HasPrefix(*response.Message, `invocation failed: work "work-1" reached failed state "goal:failed"`) {
+			t.Fatalf("InvocationResponse = %#v, want the pinned terminal failure", response)
+		}
 		errorResponse := decodeSingleJSONErrorResponse(t, stderr)
 		if errorResponse.Code != factoryapi.ErrorResponseCode(*response.ErrorCode) ||
 			errorResponse.Family != factoryapi.ErrorFamilyInternalServerError ||
 			!strings.HasPrefix(errorResponse.Message, *response.Message) {
 			t.Fatalf("ErrorResponse = %#v, want code %s and message prefix %q", errorResponse, *response.ErrorCode, *response.Message)
 		}
+	})
+}
+
+func jsonTerminalFailureFactoryPath(t *testing.T) string {
+	t.Helper()
+
+	// Keep this failure in the logical runtime so worker teardown cannot replace
+	// the terminal failure that the stdout/stderr contract is checking.
+	return support.ScaffoldFactory(t, map[string]any{
+		"name": "json-terminal-failure",
+		"workTypes": []any{map[string]any{
+			"name":             "goal",
+			"handlingBehavior": []string{"DEFAULT"},
+			"states": []any{
+				map[string]any{"name": "init", "type": "INITIAL"},
+				map[string]any{"name": "complete", "type": "TERMINAL"},
+				map[string]any{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workstations": []map[string]any{{
+			"name":    "fail-goal",
+			"type":    "LOGICAL_MOVE",
+			"inputs":  []any{map[string]any{"workType": "goal", "state": "init"}},
+			"outputs": []any{map[string]any{"workType": "goal", "state": "failed"}},
+		}},
 	})
 }
 

--- a/tests/functional/transport/cli/output/stream_backpressure_test.go
+++ b/tests/functional/transport/cli/output/stream_backpressure_test.go
@@ -201,7 +201,7 @@ func runGoalResponseStreamWithStdout(t *testing.T, stdout *gatedStdoutWriter) *g
 }
 
 // TestCLIWriterFailureCancelsInvocation proves a broken stdout writer ends the
-// CLI response-stream invocation unsuccessfully and cancels in-flight mock-worker
+// CLI response-stream invocation unsuccessfully and cancels in-flight provider
 // external work so no orphaned subprocess remains after the CLI returns.
 func TestCLIWriterFailureCancelsInvocation(t *testing.T) {
 	externalWork := newCancellableExternalWorkRunner()
@@ -226,7 +226,7 @@ func TestCLIWriterFailureCancelsInvocation(t *testing.T) {
 	}
 
 	if err := externalWork.waitFinished(writerFailureScenarioTimeout); err != nil {
-		t.Fatalf("external mock-worker work teardown not observed after CLI returned: %v", err)
+		t.Fatalf("external provider work teardown not observed after CLI returned: %v", err)
 	}
 	if !errors.Is(externalWork.runErr(), context.Canceled) {
 		t.Fatalf("external work cancellation error = %v, want context.Canceled", externalWork.runErr())
@@ -376,6 +376,10 @@ func (writer *inFlightFailureStdoutWriter) diagnosticText() string {
 
 func waitForStdoutBufferedRecords(t *testing.T, writer *inFlightFailureStdoutWriter) {
 	t.Helper()
+	// bufferedCh is the deterministic observation: Write closes it after the
+	// first successful response write. This timeout is only a bounded failure
+	// guard for a broken fixture, so a missing signal cannot hang the test; it
+	// does not establish ordering through polling or scheduler timing.
 	select {
 	case <-writer.bufferedCh:
 	case <-time.After(5 * time.Second):
@@ -388,7 +392,7 @@ func waitForExternalWorkStart(t *testing.T, runner *cancellableExternalWorkRunne
 	select {
 	case <-runner.startedCh:
 	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for mock-worker external work to start")
+		t.Fatal("timed out waiting for provider external work to start")
 	}
 }
 
@@ -401,10 +405,8 @@ func runGoalResponseStreamWriterFailure(
 
 	homeDir := t.TempDir()
 	support.InstallPackagedFactory(t, homeDir, goalFactoryName)
-	mockWorkersPath := support.WriteMockWorkersConfig(t, writerFailureGoalMockWorkers())
 	args := []string{
 		"you", "--json", "run", "--named", goalFactoryName,
-		"--with-mock-workers", mockWorkersPath,
 		"--no-record", "--output", "response-stream",
 		"deterministic writer-failure cancellation contract",
 	}

--- a/tests/functional/transport/cli/output/stream_backpressure_test.go
+++ b/tests/functional/transport/cli/output/stream_backpressure_test.go
@@ -245,6 +245,7 @@ func TestCLIWriterFailureCancelsInvocation(t *testing.T) {
 
 type cancellableExternalWorkRunner struct {
 	startedCh   chan struct{}
+	startedOnce sync.Once
 	startedFlag atomic.Bool
 	finished    chan struct{}
 	finishOnce  sync.Once
@@ -255,17 +256,14 @@ type cancellableExternalWorkRunner struct {
 
 func newCancellableExternalWorkRunner() *cancellableExternalWorkRunner {
 	return &cancellableExternalWorkRunner{
-		startedCh: make(chan struct{}, 1),
+		startedCh: make(chan struct{}),
 		finished:  make(chan struct{}),
 	}
 }
 
 func (runner *cancellableExternalWorkRunner) Run(ctx context.Context, _ platformprocess.CommandRequest) (platformprocess.CommandResult, error) {
 	runner.startedFlag.Store(true)
-	select {
-	case runner.startedCh <- struct{}{}:
-	default:
-	}
+	runner.startedOnce.Do(func() { close(runner.startedCh) })
 	<-ctx.Done()
 	runner.mu.Lock()
 	runner.err = ctx.Err()
@@ -300,9 +298,11 @@ type inFlightFailureStdoutWriter struct {
 	externalWork *cancellableExternalWorkRunner
 	gate         chan struct{}
 
-	attempts    atomic.Int64
-	failArmed   atomic.Bool
-	releaseOnce sync.Once
+	attempts     atomic.Int64
+	failArmed    atomic.Bool
+	releaseOnce  sync.Once
+	bufferedCh   chan struct{}
+	bufferedOnce sync.Once
 
 	mu         sync.Mutex
 	buffer     bytes.Buffer
@@ -320,11 +320,15 @@ func newInFlightFailureStdoutWriter(
 		failErr:      failErr,
 		externalWork: externalWork,
 		gate:         make(chan struct{}),
+		bufferedCh:   make(chan struct{}),
 		done:         make(chan struct{}),
 	}
+	// The runner start releases the first response write. That write is
+	// retained as pre-failure output and arms the injected failure; the next
+	// response write returns failErr, which cancels the runner's context.
 	go func() {
-		for externalWork != nil && !externalWork.started() {
-			time.Sleep(time.Millisecond)
+		if externalWork != nil {
+			<-externalWork.startedCh
 		}
 		writer.release()
 	}()
@@ -349,6 +353,9 @@ func (writer *inFlightFailureStdoutWriter) Write(payload []byte) (int, error) {
 	if err != nil {
 		return written, err
 	}
+	if written > 0 {
+		writer.bufferedOnce.Do(func() { close(writer.bufferedCh) })
+	}
 	if writer.externalWork != nil && writer.externalWork.started() {
 		writer.failArmed.Store(true)
 	}
@@ -369,14 +376,11 @@ func (writer *inFlightFailureStdoutWriter) diagnosticText() string {
 
 func waitForStdoutBufferedRecords(t *testing.T, writer *inFlightFailureStdoutWriter) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if strings.TrimSpace(writer.String()) != "" {
-			return
-		}
-		time.Sleep(time.Millisecond)
+	select {
+	case <-writer.bufferedCh:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for buffered stdout records before mid-stream writer failure")
 	}
-	t.Fatal("timed out waiting for buffered stdout records before mid-stream writer failure")
 }
 
 func waitForExternalWorkStart(t *testing.T, runner *cancellableExternalWorkRunner) {


### PR DESCRIPTION
## Summary

This PR addresses two independently observed load-sensitive CLI output failures in `tests/functional/transport/cli/output`. The final head is `8e49a6e8c`, rebased onto current `origin/main` `386434524`.

## Terminal JSON failure

Main run `31668697959` at head `e9fc1ddba` failed `TestCLIJSONFailureRemainsValidJSON/terminal_failure_emits_failed_InvocationResponse_and_one_stderr_ErrorResponse` at `json_result_test.go:83`. The unchanged three-way assertion is:

```go
errorResponse.Code == factoryapi.ErrorResponseCode(*response.ErrorCode) &&
errorResponse.Family == factoryapi.ErrorFamilyInternalServerError &&
strings.HasPrefix(errorResponse.Message, *response.Message)
```

The actual stderr payload was `ErrorResponse{Code:"RUN_INVOCATION_FAILED", Family:"INTERNAL_SERVER_ERROR", Message:"terminate live factory session: Workers workstation dispatch is unknown"}`. The expected stdout failure was code `INVOCATION_RUNTIME_FAILURE` with message prefix `invocation failed: work "work-1" reached failed state "goal:failed" before a primary result was available`. The family conjunct passed; the code and message-prefix conjuncts failed because session teardown replaced the intended invocation failure.

The test now uses a local `LOGICAL_MOVE` Factory that deterministically moves `work-1` from `goal:init` to `goal:failed`, pins stdout to the intended failure, and retains the three-way stdout/stderr agreement assertion unchanged. This removes the teardown trigger from this fixture without weakening the public contract. The remaining product issue is `Workers workstation dispatch is unknown` escaping `Close` in `pkg/services/factory_sessions/internal/services/live_runtime/internal/service/service.go:186-196`; its typed `workers.ErrUnknownWorkstationDispatch` condition belongs to the owning follow-up lane.

## Writer-failure cancellation

Run `31666908256` from PR `#1915` failed `TestCLIWriterFailureCancelsInvocation` at `stream_backpressure_test.go:225` with `Process.Execute error = RUN_INVOCATION_CANCELLED: clean invocation cancelled`, while the test injected `errors.New("broken stdout pipe")`. Both existing checks, `errors.Is(writer.err, writer.failErr)` and `strings.Contains(writer.err.Error(), writerFailureStdoutError)`, were false: derived cancellation replaced the writer error rather than wrapping it.

The interleaving is writer failure, response-stream cancellation, then active external work observing `context.Canceled`. In `pkg/transports/cli/run/factory_invocation_input.go`, the response writer records the first write failure with an atomic compare-and-swap. The invocation drains an undetermined response stream before classifying cancellation, and the determined-result path preserves an established writer cause before cancellation or cleanup errors. The active external runner is still canceled and joined. The functional writer-failure scenario uses the preferred injected `ProviderCommandRunner` edge and no longer passes `--with-mock-workers`; it still asserts the writer error, `context.Canceled` external work, parseable pre-failure Factory Events, and no terminal `invocation_result` record.

## Review follow-up

- Moved the undetermined and determined invocation-result handling into focused helpers in `pkg/transports/cli/run/invocation_error.go`, bringing the changed production file and `runFactoryInvocation` under the repository size and complexity limits.
- Replaced the transport-owned mutex with atomic first-failure ownership and removed the now-stale `sync.Once` entry from `docs/internal/baselines/transport-behavior-baseline.json`. No new lint baseline or suppression was added.
- Added the required in-code explanation that the response-buffer signal is deterministic and the five-second timeout is only a bounded failure guard. No timeout was increased, no assertion retry/eventually loop was added, and no test was skipped.

## Verification

The required starting-behavior command `go test ./tests/functional/transport/cli/output/ -count=20 -race` was attempted normally and timed out after 600.334s in `TestCLINDJSONEmitsDecodableResponseEventsThenInvocationResult`; it did not reproduce either target assertion. The same exact command run concurrently with `go build ./...` had a successful build but timed out after 600.360s while Windows staging-directory cleanup was blocked. These are explicit non-reproductions, not claimed reproductions.

On the final head, `go test ./tests/functional/transport/cli/output/ -run 'TestCLI(JSONFailureRemainsValidJSON|WriterFailureCancelsInvocation)$' -race -count=20` passed in 155.929s while a concurrent `go build ./...` passed in 26.1s. `go test ./pkg/transports/cli/run ./tests/functional/transport/cli/output -count=1` passed, as did `go vet ./pkg/transports/cli/run ./tests/functional/transport/cli/output`, `make pkg-maint`, `make pkg-boundary`, and `make pkg-file-count`. `make backend-size` reports only the pre-existing base violation `functionalExecutionCatalogRequest` in `tests/functional/factory/definitions/execution_catalog_test.go`; the changed package has no new backend-size violation.
