### PR TITLE
thr-fix-functionallong-build-rot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,9 @@ jobs:
         if: matrix.suite == 'functional'
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Compile functionallong test packages
+        if: matrix.suite == 'unit'
+        run: make test-functional-long-compile
       - name: Build backend
         if: matrix.suite == 'unit'
         run: make build

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ endef
 .PHONY: fmt vet deps deps-tidy clean init typecheck release lint
 
 .PHONY: test test-full test-unit test-unit-fresh test-ci-workflows test-lane-audit test-maintenance test-integration test-contract test-stress test-release
-.PHONY: test-functional test-functional-fresh test-functional-long test-backend-functional functional-boundary-check functional-test-viz
+.PHONY: test-functional test-functional-fresh test-functional-long test-functional-long-compile test-backend-functional functional-boundary-check functional-test-viz
 .PHONY: test-ui-browser-integration test-ui-storybook-integration test-ui-durable-session-real-backend test-ui-performance ui-component-test
 .PHONY: test-unit-coverage test-functional-coverage test-backend-coverage test-coverage-go test-race
 .PHONY: test-backend-verification test-root-process-acceptance long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval
@@ -450,6 +450,11 @@ test-release:
 test-functional-long:
 	$(GO) test -tags=$(FUNCTIONAL_LONG_TAGS) $(FUNCTIONAL_LONG_PACKAGES) -count=1 -timeout $(GO_TEST_TIMEOUT)
 
+# Compile every functionallong-tagged functional package without running tests
+# or starting any of the long-test runtime dependencies.
+test-functional-long-compile:
+	$(GO) vet -tags=$(FUNCTIONAL_LONG_TAGS) $(FUNCTIONAL_LONG_PACKAGES)
+
 test-root-process-acceptance:
 	$(GO) test $(ROOT_PROCESS_ACCEPTANCE_PACKAGES) -count=1 -timeout $(ROOT_PROCESS_ACCEPTANCE_TIMEOUT)
 
@@ -721,6 +726,7 @@ verify-api:
 
 verify-build-contracts:
 	$(MAKE) typecheck
+	$(MAKE) test-functional-long-compile
 	$(MAKE) verify-build
 	$(MAKE) verify-lint
 	$(MAKE) verify-api
@@ -760,6 +766,7 @@ ci-typecheck:
 	$(MAKE) typecheck
 
 ci-verify-build-contracts: ci-typecheck
+	$(MAKE) test-functional-long-compile
 	$(MAKE) verify-build
 	$(MAKE) verify-lint
 	$(MAKE) verify-api

--- a/tests/functional/bootstrap_portability/helpers_functionallong_test.go
+++ b/tests/functional/bootstrap_portability/helpers_functionallong_test.go
@@ -16,8 +16,9 @@ import (
 func (fs *functionalAPIServer) SubmitWork(t *testing.T, workTypeID string, payload json.RawMessage) string {
 	t.Helper()
 
+	name := "bootstrap-portability-submit"
 	req := factoryapi.SubmitWorkRequest{
-		Name:         "bootstrap-portability-submit",
+		Name:         &name,
 		WorkTypeName: workTypeID,
 		Payload:      payload,
 	}

--- a/tests/functional/guards_batch/partial_batch_long_test.go
+++ b/tests/functional/guards_batch/partial_batch_long_test.go
@@ -181,7 +181,7 @@ Process the input task.
 func TestPartialBatch_ThrottledProviderFailureWithoutAuthoredGuardEventuallyFails(t *testing.T) {
 	support.SkipLongFunctional(t, "slow partial-batch throttled-provider failure sweep")
 	dir, runner := throttledProviderFailureFixture(t)
-	_, listedWork := support.RunFactoryToCompletionWithEdgesAndWork(t, dir, serviceedges.Edges{
+	_, listed := support.RunFactoryToCompletionWithEdgesAndWork(t, dir, serviceedges.Edges{
 		ProviderCommandRunner: runner,
 	}, 5*time.Second)
 	assertGuardSessionPlaces(t, listed, map[string]int{"task:failed": 1, "task:init": 0, "task:complete": 0})
@@ -190,7 +190,7 @@ func TestPartialBatch_ThrottledProviderFailureWithoutAuthoredGuardEventuallyFail
 		t.Fatalf("expected provider runner called 4 times, got %d", runner.CallCount())
 	}
 
-	assertListedFailedWorkID(t, listedWork, "work-provider-throttle-requeue")
+	assertListedFailedWorkID(t, listed, "work-provider-throttle-requeue")
 }
 
 func throttledProviderFailureFixture(t *testing.T) (string, *testutil.ProviderCommandRunner) {

--- a/tests/functional/observability/verification/makefile_helpers_test.go
+++ b/tests/functional/observability/verification/makefile_helpers_test.go
@@ -108,6 +108,57 @@ func writeMakeEchoScript(t *testing.T, label string) string {
 	return filepath.ToSlash(path)
 }
 
+func writeFunctionallongFixture(t *testing.T, repoRoot string, invalid bool) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp(repoRoot, ".functionallong-gate-")
+	if err != nil {
+		t.Fatalf("create functionallong fixture directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Errorf("remove functionallong fixture directory: %v", err)
+		}
+	})
+
+	source := strings.Join([]string{
+		"//go:build functionallong",
+		"",
+		"package functionallongfixture",
+		"",
+		"func compiledOnly() string {",
+		"\treturn \"compiled\"",
+		"}",
+	}, "\n") + "\n"
+	if invalid {
+		source += "\nvar _ = functionallongCompileGateIntentionalError\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, "fixture_functionallong.go"), []byte(source), 0o644); err != nil {
+		t.Fatalf("write functionallong fixture source: %v", err)
+	}
+
+	testSource := strings.Join([]string{
+		"//go:build functionallong",
+		"",
+		"package functionallongfixture",
+		"",
+		"import \"testing\"",
+		"",
+		"func TestCompileOnlyGateMustNotExecute(t *testing.T) {",
+		"\tt.Fatal(\"the functionallong compile gate must not execute tests\")",
+		"}",
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "fixture_functionallong_test.go"), []byte(testSource), 0o644); err != nil {
+		t.Fatalf("write functionallong fixture test: %v", err)
+	}
+
+	relativePath, err := filepath.Rel(repoRoot, dir)
+	if err != nil {
+		t.Fatalf("make functionallong fixture path relative: %v", err)
+	}
+	return "./" + filepath.ToSlash(relativePath)
+}
+
 func writeExecutableScript(t *testing.T, label string, body string) string {
 	t.Helper()
 	requirePOSIXShell(t)

--- a/tests/functional/observability/verification/verify_tier_contract_test.go
+++ b/tests/functional/observability/verification/verify_tier_contract_test.go
@@ -14,56 +14,36 @@ import (
 	"github.com/portpowered/infinite-you/internal/testutil"
 )
 
-// TestFunctionalLongCompileCommandSmoke_UsesTaggedVet proves the compile-only
-// functionallong gate invokes tagged vet over the complete functional package
-// surface without executing a test command.
-func TestFunctionalLongCompileCommandSmoke_UsesTaggedVet(t *testing.T) {
+// TestFunctionalLongCompileGate_UsesRealTaggedFixtureOutcome proves the
+// compile-only gate observes real tagged source without executing the test.
+func TestFunctionalLongCompileGate_UsesRealTaggedFixtureOutcome(t *testing.T) {
 	repoRoot := testutil.MustRepoPath(t, ".")
 	makefilePath := writeVerifyFastWrapperMakefile(t, repoRoot, nil)
-	goStub := writeMakeEchoScript(t, "stub-go-functionallong")
 
+	validPackage := writeFunctionallongFixture(t, repoRoot, false)
 	output, err := runMakefileTargetWithArgs(
 		repoRoot,
 		makefilePath,
-		"GO="+goStub,
+		"FUNCTIONAL_LONG_PACKAGES="+validPackage,
 		"test-functional-long-compile",
 	)
 	if err != nil {
-		t.Fatalf("run test-functional-long-compile wrapper: %v\n%s", err, output)
+		t.Fatalf("valid tagged fixture failed compile-only gate: %v\n%s", err, output)
 	}
 
-	if !strings.Contains(output, "stub-go-functionallong:vet -tags=functionallong ./tests/functional/...") {
-		t.Fatalf("compile-only gate did not invoke tagged vet over the functional surface:\n%s", output)
-	}
-	if strings.Contains(output, " test ") {
-		t.Fatalf("compile-only gate unexpectedly invoked go test:\n%s", output)
-	}
-}
-
-// TestVerifyBuildContractsSmoke_RunsFunctionallongCompile proves the normal
-// build-contract verification tier owns the tagged compile gate.
-func TestVerifyBuildContractsSmoke_RunsFunctionallongCompile(t *testing.T) {
-	repoRoot := testutil.MustRepoPath(t, ".")
-	makefilePath := writeVerifyFastWrapperMakefile(t, repoRoot, map[string]string{
-		"typecheck":                    "@printf '%s\\n' 'stub:typecheck'\n",
-		"test-functional-long-compile": "@printf '%s\\n' 'stub:test-functional-long-compile'\n",
-		"verify-build":                 "@printf '%s\\n' 'stub:verify-build'\n",
-		"verify-lint":                  "@printf '%s\\n' 'stub:verify-lint'\n",
-		"verify-api":                   "@printf '%s\\n' 'stub:verify-api'\n",
-	})
-
-	output, err := runMakefileTarget(repoRoot, makefilePath, "verify-build-contracts")
-	if err != nil {
-		t.Fatalf("run verify-build-contracts wrapper: %v\n%s", err, output)
-	}
-
-	assertOutputOrder(t, output,
-		"stub:typecheck",
-		"stub:test-functional-long-compile",
-		"stub:verify-build",
-		"stub:verify-lint",
-		"stub:verify-api",
+	invalidPackage := writeFunctionallongFixture(t, repoRoot, true)
+	output, err = runMakefileTargetWithArgs(
+		repoRoot,
+		makefilePath,
+		"FUNCTIONAL_LONG_PACKAGES="+invalidPackage,
+		"test-functional-long-compile",
 	)
+	if err == nil {
+		t.Fatalf("invalid tagged fixture unexpectedly passed compile-only gate:\n%s", output)
+	}
+	if !strings.Contains(output, "functionallongCompileGateIntentionalError") {
+		t.Fatalf("compile-only gate failed without reporting the invalid tagged fixture:\n%s", output)
+	}
 }
 
 // TestFunctionalLaneTargetsSeparateCachedAndFreshModes proves the two public

--- a/tests/functional/observability/verification/verify_tier_contract_test.go
+++ b/tests/functional/observability/verification/verify_tier_contract_test.go
@@ -14,12 +14,64 @@ import (
 	"github.com/portpowered/infinite-you/internal/testutil"
 )
 
+// TestFunctionalLongCompileCommandSmoke_UsesTaggedVet proves the compile-only
+// functionallong gate invokes tagged vet over the complete functional package
+// surface without executing a test command.
+func TestFunctionalLongCompileCommandSmoke_UsesTaggedVet(t *testing.T) {
+	repoRoot := testutil.MustRepoPath(t, ".")
+	makefilePath := writeVerifyFastWrapperMakefile(t, repoRoot, nil)
+	goStub := writeMakeEchoScript(t, "stub-go-functionallong")
+
+	output, err := runMakefileTargetWithArgs(
+		repoRoot,
+		makefilePath,
+		"GO="+goStub,
+		"test-functional-long-compile",
+	)
+	if err != nil {
+		t.Fatalf("run test-functional-long-compile wrapper: %v\n%s", err, output)
+	}
+
+	if !strings.Contains(output, "stub-go-functionallong:vet -tags=functionallong ./tests/functional/...") {
+		t.Fatalf("compile-only gate did not invoke tagged vet over the functional surface:\n%s", output)
+	}
+	if strings.Contains(output, " test ") {
+		t.Fatalf("compile-only gate unexpectedly invoked go test:\n%s", output)
+	}
+}
+
+// TestVerifyBuildContractsSmoke_RunsFunctionallongCompile proves the normal
+// build-contract verification tier owns the tagged compile gate.
+func TestVerifyBuildContractsSmoke_RunsFunctionallongCompile(t *testing.T) {
+	repoRoot := testutil.MustRepoPath(t, ".")
+	makefilePath := writeVerifyFastWrapperMakefile(t, repoRoot, map[string]string{
+		"typecheck":                    "@printf '%s\\n' 'stub:typecheck'\n",
+		"test-functional-long-compile": "@printf '%s\\n' 'stub:test-functional-long-compile'\n",
+		"verify-build":                 "@printf '%s\\n' 'stub:verify-build'\n",
+		"verify-lint":                  "@printf '%s\\n' 'stub:verify-lint'\n",
+		"verify-api":                   "@printf '%s\\n' 'stub:verify-api'\n",
+	})
+
+	output, err := runMakefileTarget(repoRoot, makefilePath, "verify-build-contracts")
+	if err != nil {
+		t.Fatalf("run verify-build-contracts wrapper: %v\n%s", err, output)
+	}
+
+	assertOutputOrder(t, output,
+		"stub:typecheck",
+		"stub:test-functional-long-compile",
+		"stub:verify-build",
+		"stub:verify-lint",
+		"stub:verify-api",
+	)
+}
+
 // TestFunctionalLaneTargetsSeparateCachedAndFreshModes proves the two public
 // Make targets keep the same boundary and runner settings while selecting
 // Go's cache mode versus explicit execution.
 func TestFunctionalLaneTargetsSeparateCachedAndFreshModes(t *testing.T) {
 	repoRoot := testutil.MustRepoPath(t, ".")
-fakeGo := writeExecutableScript(t, "fake-go-functional-lane", `#!/bin/sh
+	fakeGo := writeExecutableScript(t, "fake-go-functional-lane", `#!/bin/sh
 if [ "$1" = "run" ]; then
   printf '%s\n' "$*" >> "$FUNCTIONAL_LANE_ARGS"
 fi

--- a/tests/functional/providers/cli_timeout_companion_smoke_long_test.go
+++ b/tests/functional/providers/cli_timeout_companion_smoke_long_test.go
@@ -53,9 +53,9 @@ Execute the script.
 
 	close(runner.releaseCh)
 	support.WaitForTerminalStatus(t, server.URL(), timeoutCompanionRunTimeout)
-	session := support.GetDefaultSession(t, server.URL())
+	listed := support.ListDefaultSessionWork(t, server.URL())
 	assertSessionPlaces(t, listed, map[string]int{"task:done": 1, "task:init": 0, "task:failed": 0})
-	assertListedWorkIdentity(t, support.ListDefaultSessionWork(t, server.URL()), "done", workID, "task", traceID, nil)
+	assertListedWorkIdentity(t, listed, "done", workID, "task", traceID, nil)
 	assertDispatchOutcomeSequence(t, server.GetFactoryEvents(t), []factoryapi.WorkOutcome{
 		factoryapi.WorkOutcomeFailed,
 		factoryapi.WorkOutcomeAccepted,

--- a/tests/functional/replay_contracts/replay_factory_only_serialization_smoke_long_test.go
+++ b/tests/functional/replay_contracts/replay_factory_only_serialization_smoke_long_test.go
@@ -177,7 +177,7 @@ func assertFactoryOnlyWorkstation(t *testing.T, workstations []factoryapi.Workst
 	t.Helper()
 
 	for _, workstation := range workstations {
-		if workstation.Name != name || workstation.Worker != worker {
+		if workstation.Name != name || workstation.Worker == nil || *workstation.Worker != worker {
 			continue
 		}
 		if stringPointerValue(workstation.Type) != interfaces.WorkstationTypeAgent {

--- a/tests/functional/runtime_api/topology_projection_smoke_long_test.go
+++ b/tests/functional/runtime_api/topology_projection_smoke_long_test.go
@@ -121,7 +121,7 @@ func assertTopologyWorkstation(t *testing.T, factory factoryapi.Factory, name, w
 		t.Fatal("public RUN_REQUEST Factory has no workstations")
 	}
 	for _, workstation := range *factory.Workstations {
-		if workstation.Name == name && workstation.Worker == workerName {
+		if workstation.Name == name && workstation.Worker != nil && *workstation.Worker == workerName {
 			if !reflect.DeepEqual(topologyRouteIDs(workstation.OnContinue), wantContinue) {
 				t.Fatalf("workstation %q continue routes = %#v, want %#v", name, topologyRouteIDs(workstation.OnContinue), wantContinue)
 			}

--- a/tests/functional/workflow/review_retry_exhaustion_long_test.go
+++ b/tests/functional/workflow/review_retry_exhaustion_long_test.go
@@ -33,7 +33,7 @@ func TestReviewRetryLoopBreaker_TerminatesAfterMaxRetries(t *testing.T) {
 		},
 	})
 	support.WaitForTerminalStatus(t, server.URL(), 10*time.Second)
-	session := support.GetDefaultSession(t, server.URL())
+	listed := support.ListDefaultSessionWork(t, server.URL())
 
 	if got := len(support.ProviderCallsForWorker(provider, "swe")); got != 3 {
 		t.Errorf("expected swe called 3 times, got %d", got)


### PR DESCRIPTION
{   "project": "Repair and Continuously Compile the functionallong Test Surface",   "branchName": "thr-fix-functionallong-build-rot",   "description": "Repair all six known compile errors hidden behind the functionallong build tag and add a fast compile-only check to a normal CI tier so future contract or helper changes cannot silently rot long functional tests, without changing product behavior or the intentional nullable Worker contract.",   "context": {     "customerAsk": "Clear the current long-local-inference compile regression, repair all six known errors across the complete functionallong test surface, preserve the assertions whose inputs were accidentally dropped, and make normal CI compile the tagged packages without running long tests, models, inference, network access, or approval-gated work.",     "problem": "Normal CI did not compile functionallong files, so PR #1914 remained green even though its intentional Worker *string contract change made two tagged comparisons invalid. The long local inference job on main da497b940 now fails in runtime_api, while a full check over the 20 tagged directories reveals six errors across five packages: three nullable-string mismatches and three undefined listed bindings, four of which predate the current regression.",     "solution": "First apply and verify the nil-safe runtime API comparison that clears the red package. Then align the remaining optional-worker uses with the generated contract, treating nil as not matching a named worker, and restore each lost listed binding from the existing package-local execution result without removing its assertion. Finally, wire a dependency-free compile-only functionallong check into an existing normal verification tier and prove it fails on the temporarily restored regression and passes on the corrected tree."   },   "acceptanceCriteria": [     "go vet -tags=functionallong over all 20 directories containing functionallong files reports zero errors, down from the six errors measured at da497b940; the PR body records the exact before and after command output.",     "All three optional-string sites compile with correct nullable semantics: a named-worker match requires a non-nil pointer with the expected value, and the bootstrap request supplies a string pointer using the package's local idiom without changing the generated contract.",     "The guards batch, workflow, and providers long tests each restore the correct listed binding, and every existing assertion that consumes that value remains active; the PR body explicitly states the restored binding and preserved assertion for each site.",     "A compile-only functionallong gate runs in an existing normal CI tier without running tests, local models, inference, model pulls, llama-server, network services, or approval-gated work; temporarily restoring the original runtime API comparison makes the gate fail, and restoring the fix makes it pass, with both outcomes recorded in PR prose or a PR comment.",     "The diff contains no product-code changes, generated contract edits, deleted or skipped tests, or changes under pkg/services/models/**, pkg/services/factory_runtime/internal/services/orchestration/runtime/**, tests/functional/workers/invoke_continue/**, or the recording/replay activation path; any generated-file conflict is resolved by rebasing and regeneration, never hand-merging.",     "Typecheck and relevant tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Local Inference / Long Local Inference (linux) is green on the PR head when approval is available; otherwise the PR plainly states that it could not run and provides the complete local tagged-vet evidence without claiming that main's unrelated failures were fixed.",     "The implementation/review loop continues until required CI is terminal and passing on the final head, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are reconciled against current main, and the single PR is actually merged; opened, green, approved, or ready-to-merge is not complete."   ],   "userStories": [     {       "id": "thr-fix-functionallong-build-rot-001",       "title": "Restore nullable-worker compatibility in tagged tests",       "description": "As a maintainer, I want tagged tests to interpret optional Worker fields safely so the intentional workerless Workstation contract does not break long-test compilation or create false named-worker matches.",       "acceptanceCriteria": [         "The runtime API site is fixed first with a nil-safe equality check equivalent to workstation.Worker != nil && *workstation.Worker == workerName, and go vet -tags=functionallong ./tests/functional/runtime_api/ reports zero errors before the other packages are changed.",         "The replay-contract comparison treats a nil Worker as not matching a named worker and accepts only a non-nil pointer whose value equals the expected worker.",         "The bootstrap portability request supplies Worker as a pointer using an existing local idiom or the address of a local value, without adding a new shared helper.",         "The nullable generated contract remains unchanged and workerless HUMAN_APPROVAL Workstations remain valid.",         "Tests pass",         "Typecheck passes"       ],       "priority": 1,       "passes": true,       "notes": "Fixed the runtime API and replay named-worker comparisons with explicit nil-safe pointer checks, and populated the bootstrap SubmitWorkRequest optional Name through a local string pointer. Focused tagged vet and compile-only tests pass for all three packages."     },     {       "id": "thr-fix-functionallong-build-rot-002",       "title": "Restore lost long-test result bindings without weakening coverage",       "description": "As a maintainer, I want the guards batch, workflow, and providers tagged scenarios to retain the session results they already assert so those behavioral checks compile and continue detecting incorrect terminal Work state.",       "acceptanceCriteria": [         "Each of the three undefined listed sites receives its value from the package-local execution or list operation that represents the scenario's completed session, following the corresponding untagged sibling's return-binding pattern.",         "The existing assertWorkflowSessionPlaces or equivalent Work-state assertion remains present and consumes the restored listed value in every affected scenario.",         "No assertion is deleted, weakened, skipped, or replaced with a source-structure or inventory check.",         "Focused tagged compilation reports no undefined listed errors in guards batch, workflow, or providers.",         "Tests pass",         "Typecheck passes"       ],       "priority": 2,       "passes": true,       "notes": "Restored the three package-local Work-list bindings in guards_batch, providers, and workflow while preserving every existing place, identity, and failed-Work assertion. Focused tagged vet and compile-only tests pass, and the full functionallong vet surface is clean across all 20 tagged directories."     },     {       "id": "thr-fix-functionallong-build-rot-003",       "title": "Gate tagged-test compilation in normal CI",       "description": "As a contributor, I want normal CI to compile every functionallong package quickly so incompatible contract or helper changes fail on the introducing pull request instead of a later specialty job.",       "acceptanceCriteria": [         "An existing normal verification tier invokes a clearly named compile-only target that covers every directory containing functionallong files and returns nonzero for any tagged compile or vet error.",         "The gate performs no test execution and needs no model runtime, local inference, model download, network access, environment opt-in, or long-test approval.",         "On the repaired tree, the gate succeeds and go vet -tags=functionallong over all 20 tagged directories reports zero errors.",         "With only the original runtime API Worker == workerName regression temporarily reintroduced locally, the new normal-tier gate fails on the pointer/string mismatch; after restoring the nil-safe comparison, the same gate passes. Exact commands and outcomes are placed in PR prose or a PR comment, not committed to the branch.",         "Inspection of test build constraints confirms that functionallong is the uncovered specialized positive tag; existing OS-specific windows, !windows, and Unix constraints remain covered by platform CI and are not broadened by this lane.",         "Tests pass",         "Typecheck passes"       ],       "priority": 3,       "passes": true,       "notes": "Added test-functional-long-compile using go vet -tags=functionallong over ./tests/functional/..., wired it into verify-build-contracts and the hosted unit verification matrix, and added Makefile contract coverage. The repaired gate passes; temporarily restoring the original runtime API pointer/string comparison makes the same gate fail with the expected vet error, then passes again after restoration. Full Linux verification-package tests and CI policy tests pass."     }   ] }  
## Review follow-up and required validation evidence

### Blocking meta-test feedback addressed

- Removed `TestFunctionalLongCompileCommandSmoke_UsesTaggedVet`, which stubbed `go` and asserted a command string.
- Removed `TestVerifyBuildContractsSmoke_RunsFunctionallongCompile`, which stubbed Make prerequisites and asserted target order.
- Added `TestFunctionalLongCompileGate_UsesRealTaggedFixtureOutcome`, which invokes the real `test-functional-long-compile` target against temporary module-local `functionallong` fixtures. The valid fixture contains a test that calls `t.Fatal` if executed, so its passing compile-gate run proves tests are not run; the invalid fixture contains `functionallongCompileGateIntentionalError`, and the same real gate must return a non-zero result and report that identifier.

### Full tagged-vet before/after evidence

At baseline commit `da497b940`, the exact command produced these six errors:

```text
go vet -tags=functionallong ./tests/functional/...
# github.com/portpowered/infinite-you/tests/functional/bootstrap_portability
# [github.com/portpowered/infinite-you/tests/functional/bootstrap_portability]
vet: tests/functional/bootstrap_portability/helpers_functionallong_test.go:20:17: cannot use "bootstrap-portability-submit" (untyped string constant) as *string value in struct literal
# github.com/portpowered/infinite-you/tests/functional/guards_batch
# [github.com/portpowered/infinite-you/tests/functional/guards_batch]
vet: tests/functional/guards_batch/partial_batch_long_test.go:187:30: undefined: listed
# github.com/portpowered/infinite-you/tests/functional/providers
# [github.com/portpowered/infinite-you/tests/functional/providers]
vet: tests/functional/providers/cli_timeout_companion_smoke_long_test.go:57:25: undefined: listed
# github.com/portpowered/infinite-you/tests/functional/replay_contracts
# [github.com/portpowered/infinite-you/tests/functional/replay_contracts]
vet: tests/functional/replay_contracts/replay_factory_only_serialization_smoke_long_test.go:180:56: invalid operation: workstation.Worker != worker (mismatched types *string and string)
# github.com/portpowered/infinite-you/tests/functional/workflow
# [github.com/portpowered/infinite-you/tests/functional/workflow]
vet: tests/functional/workflow/review_retry_exhaustion_long_test.go:45:33: undefined: listed
# github.com/portpowered/infinite-you/tests/functional/runtime_api
# [github.com/portpowered/infinite-you/tests/functional/runtime_api]
vet: tests/functional/runtime_api/topology_projection_smoke_long_test.go:124:56: invalid operation: workstation.Worker == workerName (mismatched types *string and string)
```

On the repaired tree, the exact compile-only target command and output are:

```text
make test-functional-long-compile
go vet -tags=functionallong ./tests/functional/...
```

This exits 0 and emits no vet diagnostics. The direct tagged-vet command over the complete 20-directory surface also exits 0.

### Restored Work bindings and preserved assertions

- Guards batch: `TestPartialBatch_ThrottledProviderFailureWithoutAuthoredGuardEventuallyFails` restores `_, listed := support.RunFactoryToCompletionWithEdgesAndWork(t, dir, serviceedges.Edges{ProviderCommandRunner: runner}, 5*time.Second)`. The existing `assertGuardSessionPlaces(t, listed, ...)` and `assertListedFailedWorkID(t, listed, "work-provider-throttle-requeue")` assertions remain active.
- Workflow: `TestReviewRetryLoopBreaker_TerminatesAfterMaxRetries` restores `listed := support.ListDefaultSessionWork(t, server.URL())` after terminal observation. The existing `assertWorkflowSessionPlaces(t, listed, ...)` assertion remains active, along with the public dispatch-route assertion.
- Providers: `TestIntegrationSmoke_ScriptTimeoutCompanionRequeuesBeforeLaterCompletion` restores `listed := support.ListDefaultSessionWork(t, server.URL())` after terminal observation. The existing `assertSessionPlaces(t, listed, ...)`, `assertListedWorkIdentity(t, listed, ...)`, and dispatch-outcome-sequence assertions remain active.

### Local verification

- `go test ./tests/functional/observability/verification -count=1` — pass in Ubuntu WSL.
- `go test ./tests/functional/observability/verification -count=1 -run TestFunctionalLongCompileGate_UsesRealTaggedFixtureOutcome` — pass in Ubuntu WSL.
- `make test-functional-long-compile` — pass in Ubuntu WSL.
- `make test-ci-workflows` — pass.