### PR TITLE
wsr-007-dashboard-timeline

### DIFF
--- a/ui/integration/worker-session-timeline.integration.test.mjs
+++ b/ui/integration/worker-session-timeline.integration.test.mjs
@@ -157,6 +157,93 @@ function workerSessionStreamBody(workID) {
   return records.map((frame) => `data: ${JSON.stringify(frame)}\n\n`).join("");
 }
 
+function workerSessionLongHistoryBody(workID, startPosition, endPosition) {
+  const records = [];
+  for (let position = startPosition; position <= endPosition; position += 1) {
+    const cycle = position % 5;
+    if (position === 1) {
+      records.push(
+        workerSessionFrame(
+          "RECORD",
+          workerSessionRecord(position, "SESSION", "STARTED", {
+            attempt: 1,
+            attemptId: "attempt-long-history",
+            model: "gpt-5",
+            providerSelection: {
+              executorProvider: "ACP",
+              modelProvider: "openai",
+            },
+            status: "RUNNING",
+            workerSessionId: workerSessionID,
+          }),
+          workID,
+        ),
+      );
+      continue;
+    }
+
+    const kind =
+      cycle === 0
+        ? "MESSAGE"
+        : cycle === 1
+          ? "REASONING"
+          : cycle === 2
+            ? "TOOL"
+            : cycle === 3
+              ? "USAGE"
+              : "PROGRESS";
+    const payload =
+      kind === "MESSAGE"
+        ? {
+            contentBlocks: [
+              { kind: "TEXT", text: `History message ${position}` },
+            ],
+            role: position % 2 === 0 ? "assistant" : "user",
+          }
+        : kind === "REASONING"
+          ? { summaryDelta: `Reasoning update ${position}` }
+          : kind === "TOOL"
+            ? {
+                resultSummary: {
+                  exitCode: 0,
+                  output: `Tool output ${position}`,
+                },
+                status: "completed",
+                toolCallId: `tool-${position}`,
+                toolName: "command_execution",
+              }
+            : kind === "USAGE"
+              ? {
+                  inputTokens: position,
+                  model: "gpt-5",
+                  outputTokens: position,
+                  totalTokens: position * 2,
+                }
+              : { status: "RUNNING" };
+    records.push(
+      workerSessionFrame(
+        "RECORD",
+        workerSessionRecord(position, kind, "UPDATED", payload),
+        workID,
+      ),
+    );
+  }
+
+  return records.map((frame) => `data: ${JSON.stringify(frame)}\n\n`).join("");
+}
+
+function workerSessionTerminalBody(workID, position) {
+  return `data: ${JSON.stringify(
+    workerSessionFrame(
+      "TERMINAL",
+      workerSessionRecord(position, "SESSION", "COMPLETED", {
+        status: "COMPLETED",
+      }),
+      workID,
+    ),
+  )}\n\n`;
+}
+
 function workerSessionSourceFailureBody(workID) {
   return `data: ${JSON.stringify({
     delivery: "SOURCE_FAILURE",
@@ -194,7 +281,10 @@ function workerSessionFailedStreamBody(workID) {
 
 async function installWorkerSessionRoutes(
   page,
-  { streamBodyForRequest = (workID) => workerSessionStreamBody(workID) } = {},
+  {
+    beforeStreamResponse = null,
+    streamBodyForRequest = (workID) => workerSessionStreamBody(workID),
+  } = {},
 ) {
   const requests = {
     observations: [],
@@ -214,8 +304,10 @@ async function installWorkerSessionRoutes(
       if (url.pathname.endsWith("/events")) {
         requests.events.push(url.toString());
         const workID = url.searchParams.get("workId") ?? "work-wsr-007-001";
+        const requestNumber = requests.events.length;
+        await beforeStreamResponse?.(workID, requestNumber);
         await route.fulfill({
-          body: streamBodyForRequest(workID, requests.events.length),
+          body: await streamBodyForRequest(workID, requestNumber),
           contentType: "text/event-stream",
           headers: {
             "Access-Control-Allow-Origin": "*",
@@ -256,8 +348,8 @@ async function selectReplayWork(page) {
     state: "visible",
     timeout: uiInteractionTimeoutMs,
   });
-  await workstationButton.scrollIntoViewIfNeeded();
-  await workstationButton.click({ force: true });
+  await workstationButton.focus();
+  await workstationButton.press("Enter");
 
   await page.getByRole("article", { name: "Current selection" }).waitFor({
     state: "visible",
@@ -270,7 +362,156 @@ async function selectReplayWork(page) {
     state: "visible",
     timeout: uiInteractionTimeoutMs,
   });
-  await workItemButton.click({ force: true });
+  await workItemButton.focus();
+  await workItemButton.press("Enter");
+}
+
+async function waitForTimelinePosition(expect, rows, position) {
+  await expect
+    .poll(
+      () =>
+        rows
+          .first()
+          .getAttribute("data-worker-session-timeline-entry-position"),
+      { timeout: uiInteractionTimeoutMs },
+    )
+    .toBe(String(position));
+}
+
+async function assertNoPageOverflow(page, expect) {
+  expect(
+    await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth <=
+        document.documentElement.clientWidth,
+    ),
+  ).toBe(true);
+}
+
+async function assertInitialLongHistoryWindow(expect, page, timeline, rows) {
+  await expect
+    .poll(() => rows.count(), { timeout: uiInteractionTimeoutMs })
+    .toBe(200);
+  expect(
+    await rows
+      .first()
+      .getAttribute("data-worker-session-timeline-entry-position"),
+  ).toBe("2");
+  expect(
+    await rows
+      .last()
+      .getAttribute("data-worker-session-timeline-entry-position"),
+  ).toBe("201");
+  expect(
+    await timeline
+      .locator("ol[data-worker-session-timeline-events='true']")
+      .getAttribute("data-worker-session-timeline-visible-count"),
+  ).toBe("200");
+  await assertNoPageOverflow(page, expect);
+}
+
+async function navigateTimelineWindows(expect, page, timeline, rows) {
+  const earlierEventsButton = timeline.getByRole("button", {
+    name: "Earlier events",
+    exact: true,
+  });
+  await earlierEventsButton.focus();
+  await page.keyboard.press("Enter");
+  await waitForTimelinePosition(expect, rows, 1);
+
+  const laterEventsButton = timeline.getByRole("button", {
+    name: "Later events",
+    exact: true,
+  });
+  await laterEventsButton.focus();
+  await page.keyboard.press("Enter");
+  await waitForTimelinePosition(expect, rows, 2);
+
+  await earlierEventsButton.focus();
+  await page.keyboard.press("Enter");
+  await waitForTimelinePosition(expect, rows, 1);
+
+  const focusedDetailsButton = rows
+    .first()
+    .getByRole("button", { name: "Show details", exact: true });
+  await focusedDetailsButton.scrollIntoViewIfNeeded();
+  await focusedDetailsButton.focus();
+  expect(
+    await focusedDetailsButton.evaluate(
+      (element) => element === document.activeElement,
+    ),
+  ).toBe(true);
+  return focusedDetailsButton;
+}
+
+async function assertPendingLiveActivity(
+  expect,
+  page,
+  timeline,
+  rows,
+  requests,
+  releaseLiveStream,
+  focusedDetailsButton,
+) {
+  await expect
+    .poll(() => requests.events.length, { timeout: uiInteractionTimeoutMs })
+    .toBeGreaterThanOrEqual(2);
+  releaseLiveStream();
+
+  const newActivityButton = timeline.getByRole("button", {
+    name: "View 1 new event",
+    exact: true,
+  });
+  await newActivityButton.waitFor({
+    state: "visible",
+    timeout: uiInteractionTimeoutMs,
+  });
+  expect(
+    await focusedDetailsButton.evaluate(
+      (element) => element === document.activeElement,
+    ),
+  ).toBe(true);
+  expect(await rows.count()).toBe(200);
+
+  await newActivityButton.focus();
+  await page.keyboard.press("Enter");
+  await waitForTimelinePosition(expect, rows, 3);
+}
+
+async function assertCompletedTimelineResponsive(expect, page, timeline, rows) {
+  await expect
+    .poll(() => timeline.getAttribute("data-worker-session-timeline-status"), {
+      timeout: uiInteractionTimeoutMs,
+    })
+    .toBe("completed");
+  expect(
+    await timeline
+      .locator('[data-worker-session-terminal-outcome="SUCCESS"]')
+      .count(),
+  ).toBeGreaterThan(0);
+  expect(await rows.count()).toBe(200);
+  expect(
+    await rows
+      .first()
+      .getAttribute("data-worker-session-timeline-entry-position"),
+  ).toBe("4");
+  expect(
+    await rows
+      .last()
+      .getAttribute("data-worker-session-timeline-entry-position"),
+  ).toBe("203");
+
+  await page.setViewportSize({ height: 844, width: 390 });
+  await assertNoPageOverflow(page, expect);
+  expect(
+    await timeline.evaluate(
+      (element) => element.scrollWidth <= element.clientWidth,
+    ),
+  ).toBe(true);
+  expect(await rows.count()).toBe(200);
+  expect(
+    await timeline.getAttribute("data-worker-session-timeline-status"),
+  ).toBe("completed");
 }
 
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: browser acceptance scenarios keep their dashboard setup and assertions together.
@@ -480,6 +721,115 @@ describe("Worker Session timeline browser integration", () => {
           expect,
         );
       } finally {
+        await browserPage.close();
+        await replayServer.stop();
+      }
+    },
+    browserScenarioTimeoutMs,
+  );
+
+  it(
+    "WSR-UI-002 bounds long history, preserves focus during live append, and stays usable across viewports",
+    async ({ expect, openBrowserPage, preview }) => {
+      const replayServer = await startFactoryApiServer({
+        apiPort: preview.apiPort,
+        currentFactory: { name: "Worker Session Timeline Window Factory" },
+        eventLines: await loadReplayLines("event-stream-replay.jsonl"),
+      });
+      const browserPage = await openBrowserPage({
+        artifactLabel: "worker-session-timeline-wsr-ui-002",
+      });
+      let releaseLiveStream = () => {};
+      let releaseTerminalStream = () => {};
+      const liveStreamReady = new Promise((resolve) => {
+        releaseLiveStream = resolve;
+      });
+      const terminalStreamReady = new Promise((resolve) => {
+        releaseTerminalStream = resolve;
+      });
+
+      try {
+        const requests = await installWorkerSessionRoutes(browserPage.page, {
+          beforeStreamResponse: async (_workID, requestNumber) => {
+            if (requestNumber === 2) {
+              await liveStreamReady;
+            }
+            if (requestNumber === 3) {
+              await terminalStreamReady;
+            }
+          },
+          streamBodyForRequest: (workID, requestNumber) => {
+            if (requestNumber === 1) {
+              return workerSessionLongHistoryBody(workID, 1, 201);
+            }
+            if (requestNumber === 2) {
+              return workerSessionLongHistoryBody(workID, 202, 202);
+            }
+            return workerSessionTerminalBody(workID, 203);
+          },
+        });
+        await browserPage.page.goto(preview.previewURL, {
+          waitUntil: "domcontentloaded",
+        });
+        await browserPage.page
+          .getByRole("heading", { level: 1, name: "U", exact: true })
+          .waitFor({ timeout: uiInteractionTimeoutMs });
+        await selectReplayWork(browserPage.page);
+        await browserPage.page.setViewportSize({ height: 900, width: 1440 });
+
+        const timeline = browserPage.page
+          .locator('[data-bento-card-id="worker-session-timeline"]')
+          .locator('section[aria-label="Worker Session timeline"]');
+        await timeline.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        const rows = timeline.locator(
+          "li[data-worker-session-timeline-entry-position]",
+        );
+        await assertInitialLongHistoryWindow(
+          expect,
+          browserPage.page,
+          timeline,
+          rows,
+        );
+        const focusedDetailsButton = await navigateTimelineWindows(
+          expect,
+          browserPage.page,
+          timeline,
+          rows,
+        );
+        await assertPendingLiveActivity(
+          expect,
+          browserPage.page,
+          timeline,
+          rows,
+          requests,
+          releaseLiveStream,
+          focusedDetailsButton,
+        );
+
+        await expect
+          .poll(() => requests.events.length, {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBeGreaterThanOrEqual(3);
+        releaseTerminalStream();
+        await assertCompletedTimelineResponsive(
+          expect,
+          browserPage.page,
+          timeline,
+          rows,
+        );
+
+        expectNoBrowserErrors(
+          browserPage.pageErrors,
+          browserPage.consoleErrors,
+          expect,
+        );
+      } finally {
+        releaseLiveStream();
+        releaseTerminalStream();
         await browserPage.close();
         await replayServer.stop();
       }

--- a/ui/integration/worker-session-timeline.integration.test.mjs
+++ b/ui/integration/worker-session-timeline.integration.test.mjs
@@ -340,7 +340,10 @@ async function installWorkerSessionRoutes(
   return requests;
 }
 
-async function selectReplayWork(page) {
+async function selectReplayWork(page, expect) {
+  // Replay hydration can render the Work picker after the shared interaction
+  // timeout under CI load; keep this recovery local to the replay scenario.
+  const replaySelectionTimeoutMs = 30_000;
   const workstationButton = page.getByRole("button", {
     name: /^Select plan workstation$/i,
   });
@@ -358,9 +361,14 @@ async function selectReplayWork(page) {
   const workItemButton = page
     .getByRole("button", { name: /^Select work item / })
     .first();
+  await expect
+    .poll(() => workItemButton.count(), {
+      timeout: replaySelectionTimeoutMs,
+    })
+    .toBeGreaterThan(0);
   await workItemButton.waitFor({
     state: "visible",
-    timeout: uiInteractionTimeoutMs,
+    timeout: replaySelectionTimeoutMs,
   });
   await workItemButton.focus();
   await workItemButton.press("Enter");
@@ -536,7 +544,7 @@ describe("Worker Session timeline browser integration", () => {
         await browserPage.page
           .getByRole("heading", { level: 1, name: "U", exact: true })
           .waitFor({ timeout: uiInteractionTimeoutMs });
-        await selectReplayWork(browserPage.page);
+        await selectReplayWork(browserPage.page, expect);
 
         const timelineCard = browserPage.page.locator(
           '[data-bento-card-id="worker-session-timeline"]',
@@ -654,7 +662,7 @@ describe("Worker Session timeline browser integration", () => {
         await browserPage.page
           .getByRole("heading", { level: 1, name: "U", exact: true })
           .waitFor({ timeout: uiInteractionTimeoutMs });
-        await selectReplayWork(browserPage.page);
+        await selectReplayWork(browserPage.page, expect);
 
         const timeline = browserPage.page
           .locator('[data-bento-card-id="worker-session-timeline"]')
@@ -774,7 +782,7 @@ describe("Worker Session timeline browser integration", () => {
         await browserPage.page
           .getByRole("heading", { level: 1, name: "U", exact: true })
           .waitFor({ timeout: uiInteractionTimeoutMs });
-        await selectReplayWork(browserPage.page);
+        await selectReplayWork(browserPage.page, expect);
         await browserPage.page.setViewportSize({ height: 900, width: 1440 });
 
         const timeline = browserPage.page

--- a/ui/integration/worker-session-timeline.integration.test.mjs
+++ b/ui/integration/worker-session-timeline.integration.test.mjs
@@ -1,0 +1,489 @@
+// @vitest-environment node
+
+// biome-ignore lint/style/noExcessiveLinesPerFile: browser timeline acceptance scenarios share one realistic dashboard harness.
+import { describe } from "vitest";
+
+import {
+  browserScenarioTimeoutMs,
+  expectNoBrowserErrors,
+  loadReplayLines,
+  startFactoryApiServer,
+  uiInteractionTimeoutMs,
+} from "./browser-test-harness.mjs";
+import { isolatedMockBrowserTest as it } from "./mocked-browser-test-fixture.mjs";
+
+const workerSessionID = "worker-session-wsr-007-001";
+const streamGenerationID = "generation-wsr-007-001";
+const providerSession = {
+  id: "provider-session-wsr-007-001",
+  kind: "session_id",
+  provider: "codex",
+};
+
+const workerSessionObservation = {
+  attemptId: "attempt-2",
+  direct: false,
+  durationBasis: "AUTHORITATIVE",
+  durationMillis: 1_250,
+  endedAt: "2026-08-13T09:00:04.000Z",
+  parse: { errors: [], ignored: 0 },
+  providerSessionAvailable: true,
+  recordingHealth: "COMPLETE",
+  startedAt: "2026-08-13T09:00:00.000Z",
+  state: "COMPLETED",
+  transcript: "AVAILABLE",
+  turnId: "turn-wsr-007-001",
+  workerSessionId: workerSessionID,
+};
+
+function workerSessionRecord(position, kind, phase, payload) {
+  return {
+    cursor: {
+      position,
+      streamGenerationId: streamGenerationID,
+      workerSessionId: workerSessionID,
+    },
+    payload: {
+      kind,
+      payload,
+      phase,
+      provenance: {
+        delivery: "NATIVE_STREAM",
+        provider: "codex",
+        representation: "SNAPSHOT",
+      },
+    },
+    position,
+    schemaId: "workers.draft.v1",
+    sourceEventId: `worker-event-${position}`,
+    sourceId: workerSessionID,
+    sourceSequence: position,
+    sourceType: "worker_session",
+  };
+}
+
+function workerSessionFrame(
+  delivery,
+  event,
+  workID,
+  { recordingHealth = "COMPLETE", recordingHealthReason } = {},
+) {
+  return {
+    delivery,
+    errorCode: null,
+    errorMessage: null,
+    event,
+    factorySessionId: "~default",
+    providerSession,
+    recordingHealth,
+    ...(recordingHealthReason ? { recordingHealthReason } : {}),
+    workerSessionId: workerSessionID,
+    workIds: [workID],
+  };
+}
+
+function workerSessionStreamBody(workID) {
+  const records = [
+    workerSessionFrame(
+      "RECORD",
+      workerSessionRecord(1, "SESSION", "STARTED", {
+        attempt: 1,
+        attemptId: "attempt-1",
+        model: "gpt-5",
+        providerSelection: {
+          executorProvider: "ACP",
+          modelProvider: "openai",
+        },
+        status: "STARTING",
+        workerSessionId: workerSessionID,
+      }),
+      workID,
+    ),
+    workerSessionFrame(
+      "RECORD",
+      workerSessionRecord(2, "SESSION", "UPDATED", {
+        attempt: 2,
+        attemptId: "attempt-2",
+        attemptReason: "RETRY",
+        lineage: {
+          previousAttemptId: "attempt-1",
+          previousDispatchId: "dispatch-1",
+        },
+        status: "RETRYING",
+      }),
+      workID,
+    ),
+    // The retained-to-live handoff may overlap at the last acknowledged
+    // position. The dashboard must ignore this exact canonical duplicate.
+    workerSessionFrame(
+      "RECORD",
+      workerSessionRecord(2, "SESSION", "UPDATED", {
+        attempt: 2,
+        attemptId: "attempt-2",
+        attemptReason: "RETRY",
+        lineage: {
+          previousAttemptId: "attempt-1",
+          previousDispatchId: "dispatch-1",
+        },
+        status: "RETRYING",
+      }),
+      workID,
+    ),
+    workerSessionFrame(
+      "RECORD",
+      workerSessionRecord(3, "MESSAGE", "COMPLETED", {
+        contentBlocks: [{ kind: "TEXT", text: "The retry completed." }],
+        role: "assistant",
+      }),
+      workID,
+    ),
+    workerSessionFrame(
+      "TERMINAL",
+      workerSessionRecord(4, "SESSION", "COMPLETED", {
+        continuation: {
+          id: "provider-thread-wsr-007-001",
+          kind: "session_id",
+          provider: "codex",
+        },
+        lineage: {
+          successorWorkerSessionId: "worker-session-wsr-007-002",
+        },
+        status: "COMPLETED",
+      }),
+      workID,
+    ),
+  ];
+
+  return records.map((frame) => `data: ${JSON.stringify(frame)}\n\n`).join("");
+}
+
+function workerSessionSourceFailureBody(workID) {
+  return `data: ${JSON.stringify({
+    delivery: "SOURCE_FAILURE",
+    errorCode: "WORKER_SESSION_STREAM_UNAVAILABLE",
+    errorMessage: "retained Worker Session history unavailable",
+    event: null,
+    factorySessionId: "~default",
+    providerSession,
+    recordingHealth: "INCOMPLETE",
+    recordingHealthReason: "RETAINED_HEAD_MOVED",
+    workerSessionId: workerSessionID,
+    workIds: [workID],
+  })}\n\n`;
+}
+
+function workerSessionFailedStreamBody(workID) {
+  const records = [
+    workerSessionFrame(
+      "TERMINAL",
+      workerSessionRecord(1, "SESSION", "FAILED", {
+        attempt: 1,
+        attemptId: "attempt-failed-1",
+        failureDetail: "Provider stopped responding.",
+        status: "FAILED",
+      }),
+      workID,
+      {
+        recordingHealth: "INCOMPLETE",
+        recordingHealthReason: "RETAINED_HEAD_MOVED",
+      },
+    ),
+  ];
+  return records.map((frame) => `data: ${JSON.stringify(frame)}\n\n`).join("");
+}
+
+async function installWorkerSessionRoutes(
+  page,
+  { streamBodyForRequest = (workID) => workerSessionStreamBody(workID) } = {},
+) {
+  const requests = {
+    observations: [],
+    events: [],
+  };
+
+  await page.route(
+    "**/factory-sessions/**/worker-sessions**",
+    async (route) => {
+      const request = route.request();
+      if (request.method() !== "GET") {
+        await route.continue();
+        return;
+      }
+
+      const url = new URL(request.url());
+      if (url.pathname.endsWith("/events")) {
+        requests.events.push(url.toString());
+        const workID = url.searchParams.get("workId") ?? "work-wsr-007-001";
+        await route.fulfill({
+          body: streamBodyForRequest(workID, requests.events.length),
+          contentType: "text/event-stream",
+          headers: {
+            "Access-Control-Allow-Origin": "*",
+            "Cache-Control": "no-cache, no-transform",
+            Connection: "keep-alive",
+          },
+          status: 200,
+        });
+        return;
+      }
+
+      if (url.pathname.endsWith("/worker-sessions")) {
+        const workID = url.searchParams.get("workId") ?? "work-wsr-007-001";
+        requests.observations.push(url.toString());
+        await route.fulfill({
+          body: JSON.stringify({
+            sessions: [{ ...workerSessionObservation, workIds: [workID] }],
+          }),
+          contentType: "application/json",
+          headers: { "Access-Control-Allow-Origin": "*" },
+          status: 200,
+        });
+        return;
+      }
+
+      await route.continue();
+    },
+  );
+
+  return requests;
+}
+
+async function selectReplayWork(page) {
+  const workstationButton = page.getByRole("button", {
+    name: /^Select plan workstation$/i,
+  });
+  await workstationButton.waitFor({
+    state: "visible",
+    timeout: uiInteractionTimeoutMs,
+  });
+  await workstationButton.scrollIntoViewIfNeeded();
+  await workstationButton.click({ force: true });
+
+  await page.getByRole("article", { name: "Current selection" }).waitFor({
+    state: "visible",
+    timeout: uiInteractionTimeoutMs,
+  });
+  const workItemButton = page
+    .getByRole("button", { name: /^Select work item / })
+    .first();
+  await workItemButton.waitFor({
+    state: "visible",
+    timeout: uiInteractionTimeoutMs,
+  });
+  await workItemButton.click({ force: true });
+}
+
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: browser acceptance scenarios keep their dashboard setup and assertions together.
+describe("Worker Session timeline browser integration", () => {
+  it(
+    "WSR-UI-001 renders retained and live canonical records once, preserves retry and continuation identity, and settles on the terminal outcome",
+    async ({ expect, openBrowserPage, preview }) => {
+      const replayServer = await startFactoryApiServer({
+        apiPort: preview.apiPort,
+        currentFactory: { name: "Worker Session Timeline Browser Factory" },
+        eventLines: await loadReplayLines("event-stream-replay.jsonl"),
+      });
+      const browserPage = await openBrowserPage({
+        artifactLabel: "worker-session-timeline-wsr-ui-001",
+      });
+
+      try {
+        const requests = await installWorkerSessionRoutes(browserPage.page);
+        await browserPage.page.goto(preview.previewURL, {
+          waitUntil: "domcontentloaded",
+        });
+        await browserPage.page
+          .getByRole("heading", { level: 1, name: "U", exact: true })
+          .waitFor({ timeout: uiInteractionTimeoutMs });
+        await selectReplayWork(browserPage.page);
+
+        const timelineCard = browserPage.page.locator(
+          '[data-bento-card-id="worker-session-timeline"]',
+        );
+        await timelineCard
+          .getByRole("heading", {
+            name: "Worker Session timeline",
+            exact: true,
+          })
+          .waitFor({
+            state: "visible",
+            timeout: uiInteractionTimeoutMs,
+          });
+        const timeline = timelineCard.locator(
+          'section[aria-label="Worker Session timeline"]',
+        );
+        await timeline.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await expect
+          .poll(
+            () => timeline.getAttribute("data-worker-session-timeline-status"),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toBe("completed");
+
+        expect(requests.observations.length).toBeGreaterThan(0);
+        expect(requests.events.length).toBeGreaterThan(0);
+        const rows = timeline.locator(
+          "li[data-worker-session-timeline-entry-position]",
+        );
+        await rows.first().waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        expect(await rows.count()).toBe(4);
+        expect(
+          await rows.evaluateAll((elements) =>
+            elements.map((element) =>
+              element.getAttribute(
+                "data-worker-session-timeline-entry-position",
+              ),
+            ),
+          ),
+        ).toEqual(["1", "2", "3", "4"]);
+        expect(
+          await timeline
+            .locator('[data-worker-session-terminal-outcome="SUCCESS"]')
+            .count(),
+        ).toBeGreaterThan(0);
+        expect(
+          await timeline.getByText("openai", { exact: true }).count(),
+        ).toBeGreaterThan(0);
+        expect(
+          await timeline.getByText("gpt-5", { exact: true }).count(),
+        ).toBeGreaterThan(0);
+        const detailButtons = timeline.locator("button[aria-expanded]");
+        for (let index = 0; index < (await detailButtons.count()); index += 1) {
+          await detailButtons.nth(index).click();
+        }
+        expect(
+          await timeline
+            .getByText("The retry completed.", { exact: true })
+            .count(),
+        ).toBeGreaterThan(0);
+        expect(
+          await timeline
+            .getByText("worker-session-wsr-007-002", { exact: true })
+            .count(),
+        ).toBeGreaterThan(0);
+        expect(
+          await timeline
+            .getByText("codex / session_id / provider-thread-wsr-007-001", {
+              exact: true,
+            })
+            .count(),
+        ).toBeGreaterThan(0);
+
+        expectNoBrowserErrors(
+          browserPage.pageErrors,
+          browserPage.consoleErrors,
+          expect,
+        );
+      } finally {
+        await browserPage.close();
+        await replayServer.stop();
+      }
+    },
+    browserScenarioTimeoutMs,
+  );
+
+  it(
+    "keeps an incomplete recording notice separate from a failed terminal outcome and recovers through Retry",
+    async ({ expect, openBrowserPage, preview }) => {
+      const replayServer = await startFactoryApiServer({
+        apiPort: preview.apiPort,
+        currentFactory: { name: "Worker Session Timeline Failure Factory" },
+        eventLines: await loadReplayLines("event-stream-replay.jsonl"),
+      });
+      const browserPage = await openBrowserPage({
+        artifactLabel: "worker-session-timeline-source-failure",
+      });
+
+      try {
+        const requests = await installWorkerSessionRoutes(browserPage.page, {
+          streamBodyForRequest: (workID, requestNumber) =>
+            requestNumber === 1
+              ? workerSessionSourceFailureBody(workID)
+              : workerSessionFailedStreamBody(workID),
+        });
+        await browserPage.page.goto(preview.previewURL, {
+          waitUntil: "domcontentloaded",
+        });
+        await browserPage.page
+          .getByRole("heading", { level: 1, name: "U", exact: true })
+          .waitFor({ timeout: uiInteractionTimeoutMs });
+        await selectReplayWork(browserPage.page);
+
+        const timeline = browserPage.page
+          .locator('[data-bento-card-id="worker-session-timeline"]')
+          .locator('section[aria-label="Worker Session timeline"]');
+        await timeline.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await expect
+          .poll(
+            () => timeline.getAttribute("data-worker-session-timeline-status"),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toBe("source-error");
+        expect(
+          await timeline
+            .getByText("retained Worker Session history unavailable", {
+              exact: true,
+            })
+            .count(),
+        ).toBeGreaterThan(0);
+        expect(
+          await timeline
+            .getByText("Recording: INCOMPLETE", { exact: true })
+            .count(),
+        ).toBeGreaterThan(0);
+        await timeline.getByRole("button", { name: "Retry" }).click();
+
+        await expect
+          .poll(() => requests.events.length, {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBe(2);
+        await expect
+          .poll(
+            () => timeline.getAttribute("data-worker-session-timeline-status"),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toBe("completed");
+        expect(
+          await timeline
+            .locator('[data-worker-session-terminal-outcome="FAILURE"]')
+            .count(),
+        ).toBeGreaterThan(0);
+        expect(
+          await timeline
+            .getByText("Provider stopped responding.", { exact: true })
+            .count(),
+        ).toBeGreaterThan(0);
+        expect(
+          await timeline.getByText(/RETAINED_HEAD_MOVED/).count(),
+        ).toBeGreaterThan(0);
+        expect(
+          await timeline
+            .getByRole("heading", {
+              name: "Worker Session records could not be loaded",
+            })
+            .count(),
+        ).toBe(0);
+
+        expectNoBrowserErrors(
+          browserPage.pageErrors,
+          browserPage.consoleErrors,
+          expect,
+        );
+      } finally {
+        await browserPage.close();
+        await replayServer.stop();
+      }
+    },
+    browserScenarioTimeoutMs,
+  );
+});

--- a/ui/scripts/ui-integration-targets.mjs
+++ b/ui/scripts/ui-integration-targets.mjs
@@ -15,6 +15,7 @@ export const mockedBackendBrowserIntegrationFiles = [
   "integration/factory-import-second-session.integration.test.mjs",
   "integration/maintainer-phantom-worker-graph.integration.test.mjs",
   "integration/packaged-factories-hosted-route.integration.test.mjs",
+  "integration/worker-session-timeline.integration.test.mjs",
 ];
 
 export const mockedBackendBrowserIntegrationPhaseName =

--- a/ui/src/api/worker-sessions/api.bun.unit.test.ts
+++ b/ui/src/api/worker-sessions/api.bun.unit.test.ts
@@ -5,6 +5,7 @@ import {
   parseWorkerSessionEventFrame,
   WorkerSessionEventStreamParseError,
 } from "./api";
+import { listWorkerSessionsForWork } from "./observations";
 
 describe("Worker Session event stream API", () => {
   it("builds the provider-neutral scoped URL with a reconnect cursor", () => {
@@ -48,5 +49,61 @@ describe("Worker Session event stream API", () => {
         workerSessionId: "worker-1",
       }),
     ).toThrowError(WorkerSessionEventStreamParseError);
+  });
+});
+
+describe("Worker Session observation API", () => {
+  it("lists observations for the selected Work in the selected Factory Session", async () => {
+    const fetchImplementation = async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      expect(String(input)).toBe(
+        "/factory-sessions/factory%2Fsession/worker-sessions?workId=work%2F1",
+      );
+      expect(init?.method).toBe("GET");
+      return new Response(
+        JSON.stringify({
+          sessions: [
+            {
+              attemptId: "attempt-1",
+              direct: false,
+              durationBasis: "AUTHORITATIVE",
+              durationMillis: null,
+              endedAt: null,
+              factorySessionId: "factory/session",
+              parse: { errors: [], ignored: 0 },
+              providerSessionAvailable: false,
+              recordingHealth: "COMPLETE",
+              startedAt: null,
+              state: "RUNNING",
+              transcript: "AVAILABLE",
+              turnId: null,
+              workIds: ["work/1"],
+              workerSessionId: "worker-1",
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    };
+
+    await expect(
+      listWorkerSessionsForWork({
+        factorySessionID: "factory/session",
+        fetch: fetchImplementation,
+        workID: "work/1",
+      }),
+    ).resolves.toMatchObject([{ workerSessionId: "worker-1" }]);
+  });
+
+  it("rejects an observation response that does not preserve the typed list shape", async () => {
+    await expect(
+      listWorkerSessionsForWork({
+        factorySessionID: "factory-1",
+        fetch: async () => new Response(JSON.stringify({ sessions: [{}] })),
+        workID: "work-1",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_RESPONSE" });
   });
 });

--- a/ui/src/api/worker-sessions/api.bun.unit.test.ts
+++ b/ui/src/api/worker-sessions/api.bun.unit.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  buildWorkerSessionEventStreamURL,
+  parseWorkerSessionEventFrame,
+  WorkerSessionEventStreamParseError,
+} from "./api";
+
+describe("Worker Session event stream API", () => {
+  it("builds the provider-neutral scoped URL with a reconnect cursor", () => {
+    expect(
+      buildWorkerSessionEventStreamURL({
+        factorySessionID: "factory/session",
+        workerSessionID: "worker session",
+        reconnect: {
+          afterPosition: 17,
+          streamGenerationId: "generation-1",
+        },
+        replayOnly: true,
+      }),
+    ).toBe(
+      "/factory-sessions/factory%2Fsession/worker-sessions/worker%20session/events?replayOnly=true&after_position=17&stream_generation_id=generation-1",
+    );
+  });
+
+  it("keeps source-failure frames typed without inventing a canonical record", () => {
+    const frame = parseWorkerSessionEventFrame({
+      delivery: "SOURCE_FAILURE",
+      errorCode: "WORKER_SESSION_STREAM_UNAVAILABLE",
+      errorMessage: "retained Worker Session history is unavailable",
+      event: null,
+      providerSession: { provider: "", kind: "", id: "" },
+      workIds: [],
+      workerSessionId: "worker-1",
+    });
+
+    expect(frame.event).toBeNull();
+    expect(frame.errorCode).toBe("WORKER_SESSION_STREAM_UNAVAILABLE");
+  });
+
+  it("rejects malformed frames with a safe typed parse error", () => {
+    expect(() =>
+      parseWorkerSessionEventFrame({
+        delivery: "RECORD",
+        event: null,
+        providerSession: { provider: "", kind: "", id: "" },
+        workIds: [],
+        workerSessionId: "worker-1",
+      }),
+    ).toThrowError(WorkerSessionEventStreamParseError);
+  });
+});

--- a/ui/src/api/worker-sessions/api.ts
+++ b/ui/src/api/worker-sessions/api.ts
@@ -1,0 +1,373 @@
+import { factoryAPIURL } from "../baseUrl";
+import type {
+  components,
+  WorkerSessionEventRecordingHealth,
+} from "../generated/openapi";
+import { factorySessionScopedPath } from "../session-routing";
+import { isAPIRecord } from "../transport";
+import type {
+  WorkerSessionEventFrame,
+  WorkerSessionEventSourceLike,
+  WorkerSessionEventStreamStatus,
+} from "./types";
+
+export type {
+  WorkerSessionEventCursor,
+  WorkerSessionEventDelivery,
+  WorkerSessionEventFrame,
+  WorkerSessionEventRecord,
+  WorkerSessionEventSourceLike,
+  WorkerSessionEventStreamStatus,
+  WorkerSessionProviderSessionRef,
+  WorkerSessionReplaySummary,
+} from "./types";
+
+export const WORKER_SESSION_EVENTS_ENDPOINT = "/worker-sessions";
+
+export interface WorkerSessionEventReconnectCursor {
+  afterPosition: number;
+  streamGenerationId?: string;
+}
+
+export interface BuildWorkerSessionEventStreamURLOptions {
+  factorySessionID: string;
+  workerSessionID: string;
+  replayOnly?: boolean;
+  reconnect?: WorkerSessionEventReconnectCursor | null;
+}
+
+export interface OpenWorkerSessionEventStreamOptions
+  extends BuildWorkerSessionEventStreamURLOptions {
+  onFrame: (frame: WorkerSessionEventFrame) => void;
+  onError?: (error: WorkerSessionEventStreamParseError) => void;
+  onStatusChange: (
+    status: WorkerSessionEventStreamStatus,
+    message: string,
+  ) => void;
+}
+
+export type WorkerSessionEventStreamParseErrorCode =
+  | "INVALID_JSON"
+  | "INVALID_FRAME";
+
+export class WorkerSessionEventStreamParseError extends Error {
+  public readonly code: WorkerSessionEventStreamParseErrorCode;
+
+  public constructor(
+    code: WorkerSessionEventStreamParseErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "WorkerSessionEventStreamParseError";
+    this.code = code;
+  }
+}
+
+type WorkerSessionEventSourceConstructor = new (
+  url: string,
+) => WorkerSessionEventSourceLike;
+
+const WORKER_SESSION_EVENT_DELIVERIES = new Set([
+  "RECORD",
+  "TERMINAL",
+  "TERMINAL_REPLAY",
+  "REPLAY_SUMMARY",
+  "SOURCE_FAILURE",
+]);
+
+const WORKER_SESSION_RECORDING_HEALTH = new Set([
+  "COMPLETE",
+  "DEGRADED",
+  "INCOMPLETE",
+]);
+
+function workerSessionEventSource(): WorkerSessionEventSourceConstructor | null {
+  const eventSource = globalThis.EventSource;
+  if (typeof eventSource === "undefined") {
+    return null;
+  }
+  return eventSource as unknown as WorkerSessionEventSourceConstructor;
+}
+
+export function buildWorkerSessionEventStreamURL({
+  factorySessionID,
+  workerSessionID,
+  replayOnly = false,
+  reconnect,
+}: BuildWorkerSessionEventStreamURLOptions): string {
+  const path = factorySessionScopedPath(
+    `${WORKER_SESSION_EVENTS_ENDPOINT}/${encodeURIComponent(workerSessionID)}/events`,
+    factorySessionID,
+  );
+  const params = new URLSearchParams();
+  if (replayOnly) {
+    params.set("replayOnly", "true");
+  }
+  if (reconnect != null) {
+    params.set("after_position", String(reconnect.afterPosition));
+    if (reconnect.streamGenerationId) {
+      params.set("stream_generation_id", reconnect.streamGenerationId);
+    }
+  }
+  const query = params.toString();
+  return factoryAPIURL(query.length > 0 ? `${path}?${query}` : path);
+}
+
+export function openWorkerSessionEventStream({
+  factorySessionID,
+  workerSessionID,
+  replayOnly,
+  reconnect,
+  onFrame,
+  onError,
+  onStatusChange,
+}: OpenWorkerSessionEventStreamOptions): WorkerSessionEventSourceLike | null {
+  const EventSourceImpl = workerSessionEventSource();
+  if (EventSourceImpl === null) {
+    onStatusChange(
+      "offline",
+      "Worker Session event stream is unavailable in this browser.",
+    );
+    return null;
+  }
+
+  const reconnecting = reconnect != null;
+  const stream = new EventSourceImpl(
+    buildWorkerSessionEventStreamURL({
+      factorySessionID,
+      workerSessionID,
+      replayOnly,
+      reconnect,
+    }),
+  );
+  onStatusChange(
+    reconnecting ? "reconnecting" : "connecting",
+    reconnecting
+      ? "Reconnecting to Worker Session events..."
+      : "Connecting to Worker Session events...",
+  );
+  stream.onopen = () => {
+    onStatusChange("live", "Worker Session event stream connected.");
+  };
+  stream.onerror = () => {
+    onStatusChange("offline", "Worker Session event stream disconnected.");
+  };
+  stream.addEventListener("message", (event) => {
+    try {
+      onFrame(parseWorkerSessionEventFrame(readSSEData(event)));
+    } catch (error) {
+      const parseError =
+        error instanceof WorkerSessionEventStreamParseError
+          ? error
+          : new WorkerSessionEventStreamParseError(
+              "INVALID_FRAME",
+              "Worker Session event stream returned an invalid frame.",
+            );
+      onError?.(parseError);
+    }
+  });
+  return stream;
+}
+
+function readSSEData(event: Event): unknown {
+  const candidate = event as Event & { data?: unknown };
+  if (typeof candidate.data !== "string") {
+    throw new WorkerSessionEventStreamParseError(
+      "INVALID_FRAME",
+      "Worker Session event stream returned a frame without data.",
+    );
+  }
+  try {
+    return JSON.parse(candidate.data) as unknown;
+  } catch {
+    throw new WorkerSessionEventStreamParseError(
+      "INVALID_JSON",
+      "Worker Session event stream returned invalid JSON.",
+    );
+  }
+}
+
+export function parseWorkerSessionEventFrame(
+  value: unknown,
+): WorkerSessionEventFrame {
+  if (!isAPIRecord(value)) {
+    throw invalidFrame();
+  }
+
+  const delivery = value.delivery;
+  if (
+    typeof delivery !== "string" ||
+    !WORKER_SESSION_EVENT_DELIVERIES.has(delivery)
+  ) {
+    throw invalidFrame();
+  }
+  if (!nonEmptyString(value.workerSessionId)) {
+    throw invalidFrame();
+  }
+  if (
+    value.factorySessionId !== undefined &&
+    !nonEmptyString(value.factorySessionId)
+  ) {
+    throw invalidFrame();
+  }
+  if (!isProviderSessionRef(value.providerSession)) {
+    throw invalidFrame();
+  }
+  if (!Array.isArray(value.workIds) || !value.workIds.every(isString)) {
+    throw invalidFrame();
+  }
+  if (
+    !(value.errorCode === null || typeof value.errorCode === "string") ||
+    !(value.errorMessage === null || typeof value.errorMessage === "string")
+  ) {
+    throw invalidFrame();
+  }
+
+  const event =
+    value.event === null ? null : parseWorkerSessionEventRecord(value.event);
+  const replaySummary = parseReplaySummary(value.replaySummary);
+  const recordingHealth = parseRecordingHealth(value.recordingHealth);
+  if (
+    value.recordingHealthReason !== undefined &&
+    typeof value.recordingHealthReason !== "string"
+  ) {
+    throw invalidFrame();
+  }
+  if (requiresRecord(delivery) && event === null) {
+    throw invalidFrame();
+  }
+  if (
+    !requiresRecord(delivery) &&
+    delivery === "SOURCE_FAILURE" &&
+    event !== null
+  ) {
+    throw invalidFrame();
+  }
+
+  return {
+    delivery: delivery as WorkerSessionEventFrame["delivery"],
+    workerSessionId: value.workerSessionId,
+    ...(value.factorySessionId !== undefined
+      ? { factorySessionId: value.factorySessionId }
+      : {}),
+    providerSession: value.providerSession,
+    workIds: value.workIds,
+    event,
+    errorCode: value.errorCode,
+    errorMessage: value.errorMessage,
+    ...(replaySummary !== undefined ? { replaySummary } : {}),
+    ...(recordingHealth !== undefined ? { recordingHealth } : {}),
+    ...(value.recordingHealthReason !== undefined
+      ? { recordingHealthReason: value.recordingHealthReason }
+      : {}),
+  };
+}
+
+function parseWorkerSessionEventRecord(
+  value: unknown,
+): components["schemas"]["WorkerSessionEventRecord"] {
+  if (!isAPIRecord(value) || !isAPIRecord(value.cursor)) {
+    throw invalidFrame();
+  }
+  if (
+    !positiveInteger(value.position) ||
+    !positiveInteger(value.cursor.position) ||
+    value.position !== value.cursor.position ||
+    !nonEmptyString(value.sourceType) ||
+    !nonEmptyString(value.sourceId) ||
+    !positiveInteger(value.sourceSequence) ||
+    !nonEmptyString(value.sourceEventId) ||
+    !nonEmptyString(value.schemaId) ||
+    !isAPIRecord(value.payload)
+  ) {
+    throw invalidFrame();
+  }
+  if (
+    value.cursor.workerSessionId !== undefined &&
+    typeof value.cursor.workerSessionId !== "string"
+  ) {
+    throw invalidFrame();
+  }
+  if (
+    value.cursor.streamGenerationId !== undefined &&
+    typeof value.cursor.streamGenerationId !== "string"
+  ) {
+    throw invalidFrame();
+  }
+  return value as components["schemas"]["WorkerSessionEventRecord"];
+}
+
+function parseReplaySummary(
+  value: unknown,
+): components["schemas"]["WorkerSessionReplaySummary"] | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (
+    !isAPIRecord(value) ||
+    value.kind !== "replay-summary" ||
+    typeof value.complete !== "boolean" ||
+    typeof value.reason !== "string" ||
+    !nonNegativeInteger(value.eventsEmitted)
+  ) {
+    throw invalidFrame();
+  }
+  return value as components["schemas"]["WorkerSessionReplaySummary"];
+}
+
+function parseRecordingHealth(
+  value: unknown,
+): WorkerSessionEventRecordingHealth | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (
+    typeof value !== "string" ||
+    !WORKER_SESSION_RECORDING_HEALTH.has(value)
+  ) {
+    throw invalidFrame();
+  }
+  return value as WorkerSessionEventRecordingHealth;
+}
+
+function isProviderSessionRef(
+  value: unknown,
+): value is components["schemas"]["WorkerSessionProviderSessionRef"] {
+  return (
+    isAPIRecord(value) &&
+    typeof value.provider === "string" &&
+    typeof value.kind === "string" &&
+    typeof value.id === "string"
+  );
+}
+
+function requiresRecord(delivery: string): boolean {
+  return (
+    delivery === "RECORD" ||
+    delivery === "TERMINAL" ||
+    delivery === "TERMINAL_REPLAY"
+  );
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function positiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function nonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function invalidFrame(): WorkerSessionEventStreamParseError {
+  return new WorkerSessionEventStreamParseError(
+    "INVALID_FRAME",
+    "Worker Session event stream returned an invalid frame.",
+  );
+}

--- a/ui/src/api/worker-sessions/index.ts
+++ b/ui/src/api/worker-sessions/index.ts
@@ -1,0 +1,2 @@
+export * from "./api";
+export * from "./types";

--- a/ui/src/api/worker-sessions/index.ts
+++ b/ui/src/api/worker-sessions/index.ts
@@ -1,2 +1,3 @@
 export * from "./api";
+export * from "./observations";
 export * from "./types";

--- a/ui/src/api/worker-sessions/observations.ts
+++ b/ui/src/api/worker-sessions/observations.ts
@@ -1,0 +1,128 @@
+import { factoryAPIURL } from "../baseUrl";
+import { factorySessionScopedPath } from "../session-routing";
+import {
+  extractAPIErrorPayload,
+  isAPIRecord,
+  readAPIResponseBody,
+} from "../transport";
+import type { WorkerSessionObservation } from "./types";
+
+export interface ListWorkerSessionsForWorkOptions {
+  factorySessionID: string;
+  workID: string;
+  fetch?: typeof globalThis.fetch;
+  signal?: AbortSignal;
+}
+
+export type WorkerSessionObservationAPIErrorCode =
+  | "INVALID_RESPONSE"
+  | "NETWORK_ERROR"
+  | "REQUEST_FAILED";
+
+export class WorkerSessionObservationAPIError extends Error {
+  public readonly code: WorkerSessionObservationAPIErrorCode;
+  public readonly responseBody?: unknown;
+  public readonly status?: number;
+
+  public constructor(
+    message: string,
+    details: {
+      code: WorkerSessionObservationAPIErrorCode;
+      responseBody?: unknown;
+      status?: number;
+    },
+  ) {
+    super(message);
+    this.name = "WorkerSessionObservationAPIError";
+    this.code = details.code;
+    this.responseBody = details.responseBody;
+    this.status = details.status;
+  }
+}
+
+export async function listWorkerSessionsForWork({
+  factorySessionID,
+  workID,
+  fetch: fetchImplementation = globalThis.fetch,
+  signal,
+}: ListWorkerSessionsForWorkOptions): Promise<WorkerSessionObservation[]> {
+  if (typeof fetchImplementation !== "function") {
+    throw new WorkerSessionObservationAPIError(
+      "Worker Session observations are unavailable in this environment.",
+      { code: "NETWORK_ERROR" },
+    );
+  }
+
+  const path = factorySessionScopedPath("/worker-sessions", factorySessionID);
+  const url = `${factoryAPIURL(path)}?workId=${encodeURIComponent(workID)}`;
+  let response: Response;
+  try {
+    response = await fetchImplementation(url, {
+      method: "GET",
+      ...(signal ? { signal } : {}),
+    });
+  } catch (error) {
+    throw new WorkerSessionObservationAPIError(
+      "The dashboard could not reach the Worker Sessions API.",
+      { code: "NETWORK_ERROR", responseBody: error },
+    );
+  }
+
+  const responseBody = await readAPIResponseBody(response);
+  if (!response.ok) {
+    const errorPayload = extractAPIErrorPayload(responseBody);
+    throw new WorkerSessionObservationAPIError(
+      errorPayload?.message ??
+        "The Worker Sessions API rejected the observation request.",
+      {
+        code: "REQUEST_FAILED",
+        responseBody,
+        status: response.status,
+      },
+    );
+  }
+
+  if (
+    !isAPIRecord(responseBody) ||
+    !Array.isArray(responseBody.sessions) ||
+    !responseBody.sessions.every(isWorkerSessionObservation)
+  ) {
+    throw new WorkerSessionObservationAPIError(
+      "The Worker Sessions API returned an invalid observation response.",
+      {
+        code: "INVALID_RESPONSE",
+        responseBody,
+        status: response.status,
+      },
+    );
+  }
+
+  return responseBody.sessions;
+}
+
+function isWorkerSessionObservation(
+  value: unknown,
+): value is WorkerSessionObservation {
+  return (
+    isAPIRecord(value) &&
+    typeof value.workerSessionId === "string" &&
+    value.workerSessionId.length > 0 &&
+    typeof value.direct === "boolean" &&
+    Array.isArray(value.workIds) &&
+    value.workIds.every(isString) &&
+    typeof value.attemptId === "string" &&
+    value.attemptId.length > 0 &&
+    typeof value.state === "string" &&
+    (value.startedAt === null || typeof value.startedAt === "string") &&
+    (value.endedAt === null || typeof value.endedAt === "string") &&
+    (value.durationMillis === null ||
+      typeof value.durationMillis === "number") &&
+    typeof value.durationBasis === "string" &&
+    typeof value.transcript === "string" &&
+    isAPIRecord(value.parse)
+  );
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}

--- a/ui/src/api/worker-sessions/types.ts
+++ b/ui/src/api/worker-sessions/types.ts
@@ -5,6 +5,8 @@ import type {
 
 export type WorkerSessionEventRecord =
   components["schemas"]["WorkerSessionEventRecord"];
+export type WorkerSessionObservation =
+  components["schemas"]["WorkerSessionObservation"];
 export type WorkerSessionEventCursor =
   components["schemas"]["WorkerSessionEventCursor"];
 export type WorkerSessionReplaySummary =

--- a/ui/src/api/worker-sessions/types.ts
+++ b/ui/src/api/worker-sessions/types.ts
@@ -1,0 +1,49 @@
+import type {
+  components,
+  WorkerSessionEventRecordingHealth as GeneratedWorkerSessionEventRecordingHealth,
+} from "../generated/openapi";
+
+export type WorkerSessionEventRecord =
+  components["schemas"]["WorkerSessionEventRecord"];
+export type WorkerSessionEventCursor =
+  components["schemas"]["WorkerSessionEventCursor"];
+export type WorkerSessionReplaySummary =
+  components["schemas"]["WorkerSessionReplaySummary"];
+export type WorkerSessionProviderSessionRef =
+  components["schemas"]["WorkerSessionProviderSessionRef"];
+export type WorkerSessionEventDelivery =
+  components["schemas"]["WorkerSessionEventDelivery"];
+export type WorkerSessionEventRecordingHealth =
+  GeneratedWorkerSessionEventRecordingHealth;
+
+/**
+ * The generated OpenAPI type currently models `event` as required even though
+ * the contract makes it nullable for REPLAY_SUMMARY and SOURCE_FAILURE frames.
+ * Keep that transport correction at the handwritten API boundary.
+ */
+export interface WorkerSessionEventFrame {
+  delivery: WorkerSessionEventDelivery;
+  workerSessionId: string;
+  factorySessionId?: string;
+  providerSession: WorkerSessionProviderSessionRef;
+  workIds: string[];
+  event: WorkerSessionEventRecord | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  replaySummary?: WorkerSessionReplaySummary | null;
+  recordingHealth?: WorkerSessionEventRecordingHealth;
+  recordingHealthReason?: string;
+}
+
+export interface WorkerSessionEventSourceLike {
+  addEventListener: (type: string, listener: EventListener) => void;
+  close: () => void;
+  onerror: ((event: Event) => void) | null;
+  onopen: ((event: Event) => void) | null;
+}
+
+export type WorkerSessionEventStreamStatus =
+  | "connecting"
+  | "live"
+  | "reconnecting"
+  | "offline";

--- a/ui/src/features/bento/components/dashboard-bento-cards.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-cards.tsx
@@ -25,6 +25,8 @@ import type { useWorkOutcomeChart } from "../../work-outcome/hooks/useWorkOutcom
 import { getWorkOutcomeMessages } from "../../work-outcome/messages/work-outcome";
 import { WorkTotalsWidget } from "../../work-totals/components/work-totals-widget";
 import { getWorkTotalsMessages } from "../../work-totals/messages/work-totals";
+import { WorkerSessionTimelineWidget } from "../../worker-session-timeline/components/worker-session-timeline-widget";
+import { getWorkerSessionTimelineMessages } from "../../worker-session-timeline/messages/worker-session-timeline";
 import { WorkflowActivityWidget } from "../../workflow-activity/components/workflow-activity-widget";
 import type { useCurrentActivityImportController } from "../../workflow-activity/hooks/current-activity-import-controller";
 import { getWorkflowActivityShellMessages } from "../../workflow-activity/messages/activity-shell";
@@ -499,11 +501,47 @@ function buildSingletonWidgetCard({
           />
         ),
       };
+    case DASHBOARD_WIDGET_IDS.workerSessionTimeline:
+      return buildWorkerSessionTimelineCard({
+        currentSelection,
+        headerAction,
+        layoutItem,
+        locale,
+        selectedSessionID,
+      });
     default:
       throw new Error(
         `unsupported dashboard widget type: ${layoutItem.widgetType}`,
       );
   }
+}
+
+function buildWorkerSessionTimelineCard({
+  currentSelection,
+  headerAction,
+  layoutItem,
+  locale,
+  selectedSessionID,
+}: Pick<
+  DashboardWidgetCardBuilderArgs,
+  "currentSelection" | "layoutItem" | "locale" | "selectedSessionID"
+> & {
+  headerAction: ReactNode;
+}): AgentBentoLayoutCard {
+  return {
+    id: layoutItem.id,
+    widgetType: layoutItem.widgetType,
+    children: (
+      <WorkerSessionTimelineWidget
+        factorySessionID={selectedSessionID}
+        headerAction={headerAction}
+        locale={locale}
+        widgetId={layoutItem.id}
+        workID={currentSelection.selectedWorkID}
+        workerSessionID={null}
+      />
+    ),
+  };
 }
 
 function getDashboardWidgetTitle(widgetType: string, locale?: string): string {
@@ -528,6 +566,8 @@ function getDashboardWidgetTitle(widgetType: string, locale?: string): string {
       return getWorkOutcomeMessages(locale).chart.cardTitle;
     case DASHBOARD_WIDGET_IDS.workTotals:
       return getWorkTotalsMessages(locale).cardTitle;
+    case DASHBOARD_WIDGET_IDS.workerSessionTimeline:
+      return getWorkerSessionTimelineMessages(locale).timelineTitle;
     default:
       return widgetType;
   }

--- a/ui/src/features/bento/components/dashboard-bento.test.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.test.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/style/noExcessiveLinesPerFile: dashboard widget integration cases share one mock harness.
 import { fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import type { LoadableProviderSessionRef } from "../../provider-session-detail/lib/provider-session-ref";
@@ -230,6 +231,25 @@ vi.mock("../../work-totals/components/work-totals-widget", () => ({
   ),
 }));
 
+vi.mock(
+  "../../worker-session-timeline/components/worker-session-timeline-widget",
+  () => ({
+    WorkerSessionTimelineWidget: ({
+      headerAction,
+      workID,
+    }: {
+      headerAction?: React.ReactNode;
+      workID?: string | null;
+    }) => (
+      <section>
+        {headerAction}
+        Worker Session timeline card
+        {workID ? `:${workID}` : ""}
+      </section>
+    ),
+  }),
+);
+
 vi.mock("../../workflow-activity/components/workflow-activity-widget", () => ({
   WorkflowActivityWidget: ({
     headerAction,
@@ -296,6 +316,7 @@ vi.mock("../hooks/useDashboardLayout", () => ({
     submitWork: "submit-work",
     terminalWork: "terminal-work",
     trace: "trace",
+    workerSessionTimeline: "worker-session-timeline",
     workGraph: "work-graph",
     workOutcomeChart: "work-outcome-chart",
     workTotals: "work-totals",
@@ -405,6 +426,9 @@ describe("DashboardBento", () => {
     );
     expect(screen.getByTestId("session-controls").textContent).toContain(
       "Session controls card",
+    );
+    expect(screen.getByTestId("worker-session-timeline").textContent).toContain(
+      "Worker Session timeline card",
     );
   });
 

--- a/ui/src/features/bento/hooks/dashboardLayoutPersistence.ts
+++ b/ui/src/features/bento/hooks/dashboardLayoutPersistence.ts
@@ -131,6 +131,8 @@ function resolveStoredWidgetType(
       return DASHBOARD_WIDGET_IDS.terminalWork;
     case DASHBOARD_WIDGET_IDS.trace:
       return DASHBOARD_WIDGET_IDS.trace;
+    case DASHBOARD_WIDGET_IDS.workerSessionTimeline:
+      return DASHBOARD_WIDGET_IDS.workerSessionTimeline;
     case DASHBOARD_WIDGET_IDS.workGraph:
       return DASHBOARD_WIDGET_IDS.workGraph;
     case DASHBOARD_WIDGET_IDS.workOutcomeChart:

--- a/ui/src/features/bento/hooks/dashboardLayoutSchema.ts
+++ b/ui/src/features/bento/hooks/dashboardLayoutSchema.ts
@@ -16,6 +16,7 @@ export const DASHBOARD_WIDGET_IDS = {
   submitWork: "submit-work",
   terminalWork: "terminal-work",
   trace: "trace",
+  workerSessionTimeline: "worker-session-timeline",
   workGraph: "work-graph",
   workOutcomeChart: "work-outcome-chart",
   workTotals: "work-totals",
@@ -59,6 +60,10 @@ export const DASHBOARD_PRIMARY_WIDGET_INSTANCE_IDS = {
   ),
   trace: createDashboardWidgetInstanceID(
     DASHBOARD_WIDGET_IDS.trace,
+    PRIMARY_WIDGET_INSTANCE_SLOT,
+  ),
+  workerSessionTimeline: createDashboardWidgetInstanceID(
+    DASHBOARD_WIDGET_IDS.workerSessionTimeline,
     PRIMARY_WIDGET_INSTANCE_SLOT,
   ),
   workGraph: createDashboardWidgetInstanceID(
@@ -173,6 +178,16 @@ const DEFAULT_DASHBOARD_LAYOUT_ITEMS = [
     y: 17,
   }),
   dashboardLayoutItem({
+    h: 9,
+    id: DASHBOARD_PRIMARY_WIDGET_INSTANCE_IDS.workerSessionTimeline,
+    minH: 5,
+    minW: 4,
+    w: 12,
+    widgetType: DASHBOARD_WIDGET_IDS.workerSessionTimeline,
+    x: 0,
+    y: 28,
+  }),
+  dashboardLayoutItem({
     h: 4,
     hidden: true,
     id: DASHBOARD_PRIMARY_WIDGET_INSTANCE_IDS.factorySession,
@@ -181,7 +196,7 @@ const DEFAULT_DASHBOARD_LAYOUT_ITEMS = [
     w: 4,
     widgetType: DASHBOARD_WIDGET_IDS.factorySession,
     x: 8,
-    y: 27,
+    y: 37,
   }),
   dashboardLayoutItem({
     h: 4,
@@ -191,7 +206,7 @@ const DEFAULT_DASHBOARD_LAYOUT_ITEMS = [
     w: 4,
     widgetType: DASHBOARD_WIDGET_IDS.addWidget,
     x: 8,
-    y: 27,
+    y: 37,
   }),
 ] as const satisfies readonly AgentBentoLayoutItem[];
 
@@ -253,6 +268,8 @@ export function getPrimaryInstanceIDForWidgetType(widgetType: string): string {
       return DASHBOARD_PRIMARY_WIDGET_INSTANCE_IDS.terminalWork;
     case DASHBOARD_WIDGET_IDS.trace:
       return DASHBOARD_PRIMARY_WIDGET_INSTANCE_IDS.trace;
+    case DASHBOARD_WIDGET_IDS.workerSessionTimeline:
+      return DASHBOARD_PRIMARY_WIDGET_INSTANCE_IDS.workerSessionTimeline;
     case DASHBOARD_WIDGET_IDS.workGraph:
       return DASHBOARD_PRIMARY_WIDGET_INSTANCE_IDS.workGraph;
     case DASHBOARD_WIDGET_IDS.workOutcomeChart:

--- a/ui/src/features/bento/hooks/useDashboardLayout.factory-session.isolated.bun.component.test.tsx
+++ b/ui/src/features/bento/hooks/useDashboardLayout.factory-session.isolated.bun.component.test.tsx
@@ -38,11 +38,11 @@ describe("useDashboardLayout factory-session widget placement", () => {
       w: 4,
       widgetType: DASHBOARD_WIDGET_IDS.factorySession,
       x: 8,
-      y: 27,
+      y: 37,
     });
     expect(addWidgetCard).toMatchObject({
       x: 0,
-      y: 28,
+      y: 37,
     });
   });
 });

--- a/ui/src/features/bento/lib/dashboard-widget-picker.ts
+++ b/ui/src/features/bento/lib/dashboard-widget-picker.ts
@@ -11,6 +11,7 @@ export const DASHBOARD_WIDGET_PICKER_WIDGET_TYPES = [
   DASHBOARD_WIDGET_IDS.workOutcomeChart,
   DASHBOARD_WIDGET_IDS.submitWork,
   DASHBOARD_WIDGET_IDS.trace,
+  DASHBOARD_WIDGET_IDS.workerSessionTimeline,
 ] as const;
 
 export type DashboardWidgetPickerWidgetType =

--- a/ui/src/features/bento/messages/inline-widget-picker.test.ts
+++ b/ui/src/features/bento/messages/inline-widget-picker.test.ts
@@ -53,6 +53,7 @@ describe("getInlineWidgetPickerOptions", () => {
       "work-outcome-chart",
       "submit-work",
       "trace",
+      "worker-session-timeline",
     ]);
   });
 });

--- a/ui/src/features/bento/messages/inline-widget-picker.ts
+++ b/ui/src/features/bento/messages/inline-widget-picker.ts
@@ -69,6 +69,11 @@ const inlineWidgetPickerMessagesByLocale = {
           "Inspect trace details and related state transitions inline.",
         title: "Trace drilldown",
       },
+      "worker-session-timeline": {
+        description:
+          "Inspect canonical Worker Session events for the selected Work without leaving the dashboard.",
+        title: "Worker Session timeline",
+      },
       "work-graph": {
         description:
           "Watch workflow activity and navigate the graph from the main dashboard board.",
@@ -119,6 +124,10 @@ const inlineWidgetPickerMessagesByLocale = {
       trace: {
         description: "内联检查追踪详情及其相关状态变化。",
         title: "追踪钻取",
+      },
+      "worker-session-timeline": {
+        description: "无需离开仪表板即可查看所选工作项的规范 Worker 会话事件。",
+        title: "Worker 会话时间线",
       },
       "work-graph": {
         description: "从主仪表板面板观察工作流活动并导航流程图。",

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline-content-block-details.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline-content-block-details.tsx
@@ -1,0 +1,49 @@
+import { Label } from "@you-agent-factory/components/primitives";
+
+import type { WorkerTimelineContentBlock } from "../lib/worker-session-timeline-projection-types";
+import type { WorkerSessionTimelineMessages } from "../messages/worker-session-timeline";
+import {
+  BoundedCode,
+  BoundedText,
+} from "./worker-session-timeline-detail-primitives";
+
+export function WorkerSessionTimelineContentBlockDetails({
+  block,
+  messages,
+}: {
+  block: WorkerTimelineContentBlock;
+  messages: WorkerSessionTimelineMessages;
+}) {
+  return (
+    <section
+      aria-label={messages.messageTextLabel}
+      className="grid min-w-0 gap-2"
+    >
+      <Label>{block.kind}</Label>
+      {block.text ? (
+        <BoundedText
+          collapseLabel={messages.collapseContentAction}
+          expandLabel={messages.expandContentAction}
+          label={messages.messageTextLabel}
+          value={block.text}
+        />
+      ) : null}
+      {block.argumentsSummary !== undefined ? (
+        <BoundedCode
+          collapseLabel={messages.collapseContentAction}
+          expandLabel={messages.expandContentAction}
+          label={messages.toolArgumentsLabel}
+          value={block.argumentsSummary}
+        />
+      ) : null}
+      {block.structuredOutput !== undefined ? (
+        <BoundedCode
+          collapseLabel={messages.collapseContentAction}
+          expandLabel={messages.expandContentAction}
+          label={messages.toolResultLabel}
+          value={block.structuredOutput}
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline-detail-primitives.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline-detail-primitives.tsx
@@ -1,0 +1,144 @@
+import { Label, Text } from "@you-agent-factory/components/primitives";
+import type { ReactNode } from "react";
+
+import { DashboardActionButton } from "../../../components/ui/dashboard-action-button";
+import type { WorkerTimelineJSONValue } from "../lib/worker-session-timeline-projection-types";
+
+const MAX_DISPLAY_TEXT_LENGTH = 4_000;
+
+export function NavigableDetail({
+  actionLabel,
+  label,
+  onNavigate,
+  value,
+}: {
+  actionLabel: string;
+  label: string;
+  onNavigate?: (workerSessionID: string) => void;
+  value: string;
+}) {
+  return (
+    <div className="grid min-w-0 gap-1">
+      <Label>{label}</Label>
+      {onNavigate ? (
+        <DashboardActionButton
+          aria-label={actionLabel}
+          className="w-fit max-w-full [overflow-wrap:anywhere]"
+          onClick={() => onNavigate(value)}
+          type="button"
+        >
+          {value}
+        </DashboardActionButton>
+      ) : (
+        <Text className="m-0 min-w-0 [overflow-wrap:anywhere]">{value}</Text>
+      )}
+    </div>
+  );
+}
+
+export function DetailSection({
+  children,
+  heading,
+}: {
+  children: ReactNode;
+  heading: string;
+}) {
+  return (
+    <section className="grid min-w-0 gap-2 border-t border-outline pt-3">
+      <Label>{heading}</Label>
+      {children}
+    </section>
+  );
+}
+
+export function DetailList({
+  items,
+}: {
+  items: Array<{ label: string; value: string } | null>;
+}) {
+  const visibleItems = items.filter(
+    (item): item is { label: string; value: string } => item !== null,
+  );
+  if (visibleItems.length === 0) {
+    return null;
+  }
+  return (
+    <dl className="grid min-w-0 gap-2 sm:grid-cols-2">
+      {visibleItems.map((item) => (
+        <div className="grid min-w-0 gap-1" key={`${item.label}-${item.value}`}>
+          <Label as="dt">{item.label}</Label>
+          <Text as="dd" className="m-0 min-w-0 [overflow-wrap:anywhere]">
+            {item.value}
+          </Text>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+export function DetailValue({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="grid min-w-0 gap-1">
+      <Label>{label}</Label>
+      <Text className="m-0 min-w-0 [overflow-wrap:anywhere]">{value}</Text>
+    </div>
+  );
+}
+
+export function BoundedText({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="grid min-w-0 gap-1">
+      <Label>{label}</Label>
+      <div className="max-h-64 min-w-0 overflow-auto rounded-md border border-outline bg-surface-container-high p-3 [overflow-wrap:anywhere]">
+        <Text className="m-0 whitespace-pre-wrap">{boundedText(value)}</Text>
+      </div>
+    </div>
+  );
+}
+
+export function BoundedCode({
+  label,
+  value,
+}: {
+  label: string;
+  value: WorkerTimelineJSONValue;
+}) {
+  return (
+    <div className="grid min-w-0 gap-1">
+      <Label>{label}</Label>
+      <pre className="af-body-code m-0 max-h-64 min-w-0 max-w-full overflow-auto rounded-md border border-outline bg-surface-container-high p-3 whitespace-pre-wrap break-words">
+        <code>{boundedText(formatJSONValue(value))}</code>
+      </pre>
+    </div>
+  );
+}
+
+export function boundedText(value: string): string {
+  if (value.length <= MAX_DISPLAY_TEXT_LENGTH) {
+    return value;
+  }
+  return `${value.slice(0, MAX_DISPLAY_TEXT_LENGTH)}…`;
+}
+
+function formatJSONValue(value: WorkerTimelineJSONValue): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2) ?? "";
+  } catch {
+    return "";
+  }
+}

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline-detail-primitives.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline-detail-primitives.tsx
@@ -105,15 +105,18 @@ export function BoundedText({
   label: string;
   value: string;
 }) {
+  const preview = boundedText(value);
   return (
     <BoundedValue
       collapseLabel={collapseLabel}
       expandLabel={expandLabel}
       label={label}
       long={value.length > MAX_DISPLAY_TEXT_LENGTH}
-    >
-      <Text className="m-0 whitespace-pre-wrap">{boundedText(value)}</Text>
-    </BoundedValue>
+      collapsedContent={
+        <Text className="m-0 whitespace-pre-wrap">{preview}</Text>
+      }
+      expandedContent={<Text className="m-0 whitespace-pre-wrap">{value}</Text>}
+    />
   );
 }
 
@@ -129,39 +132,40 @@ export function BoundedCode({
   value: WorkerTimelineJSONValue;
 }) {
   const formattedValue = formatJSONValue(value);
+  const preview = boundedText(formattedValue);
   return (
     <BoundedValue
       collapseLabel={collapseLabel}
       expandLabel={expandLabel}
       label={label}
       long={formattedValue.length > MAX_DISPLAY_TEXT_LENGTH}
-    >
-      <pre className="af-body-code m-0 max-h-64 min-w-0 max-w-full overflow-auto whitespace-pre-wrap break-words">
-        <code>{boundedText(formattedValue)}</code>
-      </pre>
-    </BoundedValue>
+      collapsedContent={renderCodeContent(preview)}
+      expandedContent={renderCodeContent(formattedValue)}
+    />
   );
 }
 
 function BoundedValue({
-  children,
   collapseLabel,
+  collapsedContent,
   expandLabel,
+  expandedContent,
   label,
   long,
 }: {
-  children: ReactNode;
   collapseLabel?: string;
+  collapsedContent: ReactNode;
   expandLabel?: string;
+  expandedContent: ReactNode;
   label: string;
   long: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   const visibleExpandLabel = expandLabel ?? label;
   const visibleCollapseLabel = collapseLabel ?? label;
-  const content = (
+  const content = (body: ReactNode) => (
     <div className="max-h-64 min-w-0 max-w-full overflow-auto rounded-md border border-outline bg-surface-container-high p-3 [overflow-wrap:anywhere]">
-      {children}
+      {body}
     </div>
   );
 
@@ -175,15 +179,32 @@ function BoundedValue({
           onToggle={(event) => setExpanded(event.currentTarget.open)}
           open={expanded}
         >
-          <summary className="cursor-pointer break-words px-1 py-1 text-sm font-semibold text-on-surface focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-af-accent">
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: native summary is the disclosure control and receives keyboard toggles. */}
+          <summary
+            className="cursor-pointer break-words px-1 py-1 text-sm font-semibold text-on-surface focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-af-accent"
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                setExpanded((current) => !current);
+              }
+            }}
+          >
             {expanded ? visibleCollapseLabel : visibleExpandLabel}
           </summary>
-          {content}
+          {content(expanded ? expandedContent : collapsedContent)}
         </details>
       ) : (
-        content
+        content(collapsedContent)
       )}
     </div>
+  );
+}
+
+function renderCodeContent(value: string): ReactNode {
+  return (
+    <pre className="af-body-code m-0 max-h-64 min-w-0 max-w-full overflow-auto whitespace-pre-wrap break-words">
+      <code>{value}</code>
+    </pre>
   );
 }
 

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline-detail-primitives.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline-detail-primitives.tsx
@@ -1,10 +1,10 @@
 import { Label, Text } from "@you-agent-factory/components/primitives";
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 
 import { DashboardActionButton } from "../../../components/ui/dashboard-action-button";
 import type { WorkerTimelineJSONValue } from "../lib/worker-session-timeline-projection-types";
 
-const MAX_DISPLAY_TEXT_LENGTH = 4_000;
+export const MAX_DISPLAY_TEXT_LENGTH = 4_000;
 
 export function NavigableDetail({
   actionLabel,
@@ -44,7 +44,10 @@ export function DetailSection({
   heading: string;
 }) {
   return (
-    <section className="grid min-w-0 gap-2 border-t border-outline pt-3">
+    <section
+      aria-label={heading}
+      className="grid min-w-0 gap-2 border-t border-outline pt-3"
+    >
       <Label>{heading}</Label>
       {children}
     </section>
@@ -92,35 +95,94 @@ export function DetailValue({
 }
 
 export function BoundedText({
+  collapseLabel,
+  expandLabel,
   label,
   value,
 }: {
+  collapseLabel?: string;
+  expandLabel?: string;
   label: string;
   value: string;
 }) {
   return (
-    <div className="grid min-w-0 gap-1">
-      <Label>{label}</Label>
-      <div className="max-h-64 min-w-0 overflow-auto rounded-md border border-outline bg-surface-container-high p-3 [overflow-wrap:anywhere]">
-        <Text className="m-0 whitespace-pre-wrap">{boundedText(value)}</Text>
-      </div>
-    </div>
+    <BoundedValue
+      collapseLabel={collapseLabel}
+      expandLabel={expandLabel}
+      label={label}
+      long={value.length > MAX_DISPLAY_TEXT_LENGTH}
+    >
+      <Text className="m-0 whitespace-pre-wrap">{boundedText(value)}</Text>
+    </BoundedValue>
   );
 }
 
 export function BoundedCode({
+  collapseLabel,
+  expandLabel,
   label,
   value,
 }: {
+  collapseLabel?: string;
+  expandLabel?: string;
   label: string;
   value: WorkerTimelineJSONValue;
 }) {
+  const formattedValue = formatJSONValue(value);
+  return (
+    <BoundedValue
+      collapseLabel={collapseLabel}
+      expandLabel={expandLabel}
+      label={label}
+      long={formattedValue.length > MAX_DISPLAY_TEXT_LENGTH}
+    >
+      <pre className="af-body-code m-0 max-h-64 min-w-0 max-w-full overflow-auto whitespace-pre-wrap break-words">
+        <code>{boundedText(formattedValue)}</code>
+      </pre>
+    </BoundedValue>
+  );
+}
+
+function BoundedValue({
+  children,
+  collapseLabel,
+  expandLabel,
+  label,
+  long,
+}: {
+  children: ReactNode;
+  collapseLabel?: string;
+  expandLabel?: string;
+  label: string;
+  long: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const visibleExpandLabel = expandLabel ?? label;
+  const visibleCollapseLabel = collapseLabel ?? label;
+  const content = (
+    <div className="max-h-64 min-w-0 max-w-full overflow-auto rounded-md border border-outline bg-surface-container-high p-3 [overflow-wrap:anywhere]">
+      {children}
+    </div>
+  );
+
   return (
     <div className="grid min-w-0 gap-1">
       <Label>{label}</Label>
-      <pre className="af-body-code m-0 max-h-64 min-w-0 max-w-full overflow-auto rounded-md border border-outline bg-surface-container-high p-3 whitespace-pre-wrap break-words">
-        <code>{boundedText(formatJSONValue(value))}</code>
-      </pre>
+      {long ? (
+        <details
+          className="min-w-0 max-w-full rounded-md border border-outline bg-surface-container-high p-2"
+          data-worker-session-timeline-bounded-content="true"
+          onToggle={(event) => setExpanded(event.currentTarget.open)}
+          open={expanded}
+        >
+          <summary className="cursor-pointer break-words px-1 py-1 text-sm font-semibold text-on-surface focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-af-accent">
+            {expanded ? visibleCollapseLabel : visibleExpandLabel}
+          </summary>
+          {content}
+        </details>
+      ) : (
+        content
+      )}
     </div>
   );
 }

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline-entry-details.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline-entry-details.tsx
@@ -1,0 +1,510 @@
+import { Label } from "@you-agent-factory/components/primitives";
+import type {
+  WorkerSessionTimelineEntry,
+  WorkerTimelineContentBlock,
+} from "../lib/worker-session-timeline-projection-types";
+import type { WorkerSessionTimelineMessages } from "../messages/worker-session-timeline";
+import {
+  BoundedCode,
+  BoundedText,
+  DetailList,
+  DetailSection,
+  DetailValue,
+  NavigableDetail,
+} from "./worker-session-timeline-detail-primitives";
+
+export interface WorkerSessionTimelineEntryDetailsProps {
+  entry: WorkerSessionTimelineEntry;
+  messages: WorkerSessionTimelineMessages;
+  onNavigateToWorkerSession?: (workerSessionID: string) => void;
+}
+
+export function EntryStructuredDetails({
+  entry,
+  messages,
+  onNavigateToWorkerSession,
+}: WorkerSessionTimelineEntryDetailsProps) {
+  return (
+    <>
+      {entry.attempt ? (
+        <AttemptDetails attempt={entry.attempt} messages={messages} />
+      ) : null}
+      {entry.continuation ? (
+        <ContinuationDetails
+          continuation={entry.continuation}
+          messages={messages}
+          onNavigateToWorkerSession={onNavigateToWorkerSession}
+        />
+      ) : null}
+      {entry.message ? (
+        <MessageDetails message={entry.message} messages={messages} />
+      ) : null}
+      {entry.reasoning ? (
+        <ReasoningDetails messages={messages} reasoning={entry.reasoning} />
+      ) : null}
+      {entry.tool ? (
+        <ToolDetails messages={messages} tool={entry.tool} />
+      ) : null}
+      {entry.usage ? (
+        <UsageDetails messages={messages} usage={entry.usage} />
+      ) : null}
+      {entry.failure ? (
+        <FailureDetails failure={entry.failure} messages={messages} />
+      ) : null}
+      {entry.terminal ? (
+        <TerminalDetails messages={messages} terminal={entry.terminal} />
+      ) : null}
+      {entry.generic ? (
+        <GenericDetails generic={entry.generic} messages={messages} />
+      ) : null}
+      <CanonicalSourceDetails entry={entry} messages={messages} />
+    </>
+  );
+}
+
+function AttemptDetails({
+  attempt,
+  messages,
+}: {
+  attempt: NonNullable<WorkerSessionTimelineEntry["attempt"]>;
+  messages: WorkerSessionTimelineMessages;
+}) {
+  return (
+    <DetailSection heading={messages.attemptLabel(attempt.number, attempt.id)}>
+      <DetailList
+        items={[
+          attempt.id
+            ? { label: messages.attemptIDLabel, value: attempt.id }
+            : null,
+          attempt.reason
+            ? { label: messages.retryReasonLabel, value: attempt.reason }
+            : null,
+          attempt.dispatchId
+            ? { label: messages.dispatchLabel, value: attempt.dispatchId }
+            : null,
+          attempt.turnId
+            ? { label: messages.turnLabel, value: attempt.turnId }
+            : null,
+          attempt.status
+            ? { label: messages.toolStatusLabel, value: attempt.status }
+            : null,
+        ]}
+      />
+    </DetailSection>
+  );
+}
+
+function ContinuationDetails({
+  continuation,
+  messages,
+  onNavigateToWorkerSession,
+}: {
+  continuation: NonNullable<WorkerSessionTimelineEntry["continuation"]>;
+  messages: WorkerSessionTimelineMessages;
+  onNavigateToWorkerSession?: (workerSessionID: string) => void;
+}) {
+  return (
+    <DetailSection heading={messages.continuationLabel}>
+      <div className="grid min-w-0 gap-2">
+        {continuation.predecessorWorkerSessionId ? (
+          <NavigableDetail
+            actionLabel={messages.openWorkerSessionLabel(
+              continuation.predecessorWorkerSessionId,
+            )}
+            label={messages.predecessorLabel}
+            onNavigate={onNavigateToWorkerSession}
+            value={continuation.predecessorWorkerSessionId}
+          />
+        ) : null}
+        {continuation.successorWorkerSessionId ? (
+          <NavigableDetail
+            actionLabel={messages.openWorkerSessionLabel(
+              continuation.successorWorkerSessionId,
+            )}
+            label={messages.successorLabel}
+            onNavigate={onNavigateToWorkerSession}
+            value={continuation.successorWorkerSessionId}
+          />
+        ) : null}
+        {continuation.previousDispatchId ? (
+          <DetailValue
+            label={messages.dispatchLabel}
+            value={continuation.previousDispatchId}
+          />
+        ) : null}
+        {continuation.previousAttemptId ? (
+          <DetailValue
+            label={messages.attemptIDLabel}
+            value={continuation.previousAttemptId}
+          />
+        ) : null}
+        {continuation.providerSession ? (
+          <DetailValue
+            label={messages.providerSessionLabel}
+            value={`${continuation.providerSession.provider} / ${continuation.providerSession.kind} / ${continuation.providerSession.id}`}
+          />
+        ) : null}
+      </div>
+    </DetailSection>
+  );
+}
+
+function MessageDetails({
+  message,
+  messages,
+}: {
+  message: NonNullable<WorkerSessionTimelineEntry["message"]>;
+  messages: WorkerSessionTimelineMessages;
+}) {
+  const messageText = message.text ?? message.delta?.textDelta;
+  return (
+    <DetailSection heading={messages.messageTextLabel}>
+      <div className="grid min-w-0 gap-3">
+        {message.role ? (
+          <DetailValue
+            label={messages.messageRoleLabel(message.role)}
+            value={message.role}
+          />
+        ) : null}
+        {messageText ? (
+          <BoundedText label={messages.messageTextLabel} value={messageText} />
+        ) : null}
+        {message.delta ? (
+          <DetailList
+            items={[
+              message.delta.contentBlockIndex === undefined
+                ? null
+                : {
+                    label: messages.sourceSequenceLabel(
+                      message.delta.contentBlockIndex,
+                    ),
+                    value: String(message.delta.contentBlockIndex),
+                  },
+              message.delta.contentBlockKind
+                ? {
+                    label: messages.sourceLabel,
+                    value: message.delta.contentBlockKind,
+                  }
+                : null,
+              message.partial === undefined
+                ? null
+                : {
+                    label: messages.phaseLabel("PARTIAL"),
+                    value: String(message.partial),
+                  },
+            ]}
+          />
+        ) : null}
+        {message.contentBlocks?.map((block) => (
+          <ContentBlockDetails
+            block={block}
+            key={contentBlockKey(block)}
+            messages={messages}
+          />
+        ))}
+      </div>
+    </DetailSection>
+  );
+}
+
+function ContentBlockDetails({
+  block,
+  messages,
+}: {
+  block: WorkerTimelineContentBlock;
+  messages: WorkerSessionTimelineMessages;
+}) {
+  return (
+    <section
+      aria-label={messages.messageTextLabel}
+      className="grid min-w-0 gap-2"
+    >
+      <Label>{block.kind}</Label>
+      {block.text ? (
+        <BoundedText label={messages.messageTextLabel} value={block.text} />
+      ) : null}
+      {block.argumentsSummary !== undefined ? (
+        <BoundedCode
+          label={messages.toolArgumentsLabel}
+          value={block.argumentsSummary}
+        />
+      ) : null}
+      {block.structuredOutput !== undefined ? (
+        <BoundedCode
+          label={messages.toolResultLabel}
+          value={block.structuredOutput}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+function ReasoningDetails({
+  messages,
+  reasoning,
+}: {
+  messages: WorkerSessionTimelineMessages;
+  reasoning: NonNullable<WorkerSessionTimelineEntry["reasoning"]>;
+}) {
+  return (
+    <DetailSection heading={messages.reasoningLabel}>
+      <DetailList
+        items={[
+          reasoning.representation === "SNAPSHOT"
+            ? {
+                label: messages.reasoningSnapshotLabel,
+                value: messages.reasoningSnapshotLabel,
+              }
+            : reasoning.representation === "DELTA"
+              ? {
+                  label: messages.reasoningDeltaLabel,
+                  value: messages.reasoningDeltaLabel,
+                }
+              : null,
+        ]}
+      />
+      {reasoning.summary ? (
+        <BoundedText
+          label={messages.reasoningSnapshotLabel}
+          value={reasoning.summary}
+        />
+      ) : null}
+      {reasoning.summaryDelta ? (
+        <BoundedText
+          label={messages.reasoningDeltaLabel}
+          value={reasoning.summaryDelta}
+        />
+      ) : null}
+    </DetailSection>
+  );
+}
+
+function ToolDetails({
+  messages,
+  tool,
+}: {
+  messages: WorkerSessionTimelineMessages;
+  tool: NonNullable<WorkerSessionTimelineEntry["tool"]>;
+}) {
+  return (
+    <DetailSection heading={messages.toolLabel}>
+      <DetailList
+        items={[
+          tool.toolCallId
+            ? { label: messages.toolCallIDLabel, value: tool.toolCallId }
+            : null,
+          tool.toolName
+            ? { label: messages.toolNameLabel, value: tool.toolName }
+            : null,
+          tool.status
+            ? { label: messages.toolStatusLabel, value: tool.status }
+            : null,
+        ]}
+      />
+      {tool.argumentsSummary !== undefined ? (
+        <BoundedCode
+          label={messages.toolArgumentsLabel}
+          value={tool.argumentsSummary}
+        />
+      ) : null}
+      {tool.outputDelta ? (
+        <BoundedText
+          label={messages.toolOutputLabel}
+          value={tool.outputDelta}
+        />
+      ) : null}
+      {tool.resultSummary !== undefined ? (
+        <BoundedCode
+          label={messages.toolResultLabel}
+          value={tool.resultSummary}
+        />
+      ) : null}
+    </DetailSection>
+  );
+}
+
+function UsageDetails({
+  messages,
+  usage,
+}: {
+  messages: WorkerSessionTimelineMessages;
+  usage: NonNullable<WorkerSessionTimelineEntry["usage"]>;
+}) {
+  return (
+    <DetailSection heading={messages.usageLabel}>
+      <DetailList
+        items={[
+          usage.inputTokens === undefined
+            ? null
+            : {
+                label: messages.inputTokensLabel,
+                value: String(usage.inputTokens),
+              },
+          usage.cachedInputTokens === undefined
+            ? null
+            : {
+                label: messages.cachedInputTokensLabel,
+                value: String(usage.cachedInputTokens),
+              },
+          usage.outputTokens === undefined
+            ? null
+            : {
+                label: messages.outputTokensLabel,
+                value: String(usage.outputTokens),
+              },
+          usage.totalTokens === undefined
+            ? null
+            : {
+                label: messages.totalTokensLabel,
+                value: String(usage.totalTokens),
+              },
+          usage.model
+            ? { label: messages.usageModelLabel, value: usage.model }
+            : null,
+        ]}
+      />
+    </DetailSection>
+  );
+}
+
+function FailureDetails({
+  failure,
+  messages,
+}: {
+  failure: NonNullable<WorkerSessionTimelineEntry["failure"]>;
+  messages: WorkerSessionTimelineMessages;
+}) {
+  return (
+    <DetailSection heading={messages.failureLabel}>
+      <DetailList
+        items={[
+          failure.kind
+            ? { label: messages.categoryLabel.error, value: failure.kind }
+            : null,
+          failure.code
+            ? { label: messages.sourceLabel, value: failure.code }
+            : null,
+          failure.retryable === undefined
+            ? null
+            : {
+                label: messages.retryReasonLabel,
+                value: String(failure.retryable),
+              },
+          failure.retryAttempt === undefined
+            ? null
+            : {
+                label: messages.attemptLabel(failure.retryAttempt, undefined),
+                value: String(failure.retryAttempt),
+              },
+        ]}
+      />
+      {failure.message ? (
+        <BoundedText label={messages.failureLabel} value={failure.message} />
+      ) : null}
+    </DetailSection>
+  );
+}
+
+function TerminalDetails({
+  messages,
+  terminal,
+}: {
+  messages: WorkerSessionTimelineMessages;
+  terminal: NonNullable<WorkerSessionTimelineEntry["terminal"]>;
+}) {
+  return (
+    <DetailSection heading={messages.terminalOutcomeHeading}>
+      <DetailValue
+        label={messages.terminalOutcomeHeading}
+        value={messages.terminalOutcomeLabel(terminal.outcome)}
+      />
+      {terminal.status ? (
+        <DetailValue label={messages.toolStatusLabel} value={terminal.status} />
+      ) : null}
+      {terminal.failure?.message ? (
+        <BoundedText
+          label={messages.failureLabel}
+          value={terminal.failure.message}
+        />
+      ) : null}
+    </DetailSection>
+  );
+}
+
+function GenericDetails({
+  generic,
+  messages,
+}: {
+  generic: NonNullable<WorkerSessionTimelineEntry["generic"]>;
+  messages: WorkerSessionTimelineMessages;
+}) {
+  return (
+    <DetailSection heading={messages.genericMetadataLabel}>
+      <DetailList
+        items={[
+          {
+            label: messages.genericMetadataLabel,
+            value: messages.genericSchemaLabel(generic.schemaId),
+          },
+          {
+            label: messages.sourceLabel,
+            value: `${generic.sourceType} / ${generic.sourceId}`,
+          },
+          {
+            label: messages.sourceSequenceLabel(generic.sourceSequence),
+            value: String(generic.sourceSequence),
+          },
+          {
+            label: messages.messageTextLabel,
+            value:
+              generic.payloadKeys.length > 0
+                ? generic.payloadKeys.join(", ")
+                : messages.unknownValueLabel,
+          },
+        ]}
+      />
+    </DetailSection>
+  );
+}
+
+function CanonicalSourceDetails({
+  entry,
+  messages,
+}: {
+  entry: WorkerSessionTimelineEntry;
+  messages: WorkerSessionTimelineMessages;
+}) {
+  return (
+    <DetailSection heading={messages.sourceLabel}>
+      <DetailList
+        items={[
+          {
+            label: messages.eventPositionLabel(entry.canonical.position),
+            value: String(entry.canonical.position),
+          },
+          {
+            label: messages.sourceLabel,
+            value: `${entry.canonical.sourceType} / ${entry.canonical.sourceId}`,
+          },
+          {
+            label: messages.sourceSequenceLabel(entry.canonical.sourceSequence),
+            value: String(entry.canonical.sourceSequence),
+          },
+          {
+            label: messages.genericSchemaLabel(entry.canonical.schemaId),
+            value: entry.canonical.schemaId,
+          },
+        ]}
+      />
+    </DetailSection>
+  );
+}
+
+function contentBlockKey(block: WorkerTimelineContentBlock): string {
+  return [
+    block.kind,
+    block.toolCallId ?? "",
+    block.toolName ?? "",
+    block.text ?? "",
+  ].join(":");
+}

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline-entry-details.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline-entry-details.tsx
@@ -1,9 +1,9 @@
-import { Label } from "@you-agent-factory/components/primitives";
 import type {
   WorkerSessionTimelineEntry,
   WorkerTimelineContentBlock,
 } from "../lib/worker-session-timeline-projection-types";
 import type { WorkerSessionTimelineMessages } from "../messages/worker-session-timeline";
+import { WorkerSessionTimelineContentBlockDetails } from "./worker-session-timeline-content-block-details";
 import {
   BoundedCode,
   BoundedText,
@@ -17,6 +17,8 @@ export interface WorkerSessionTimelineEntryDetailsProps {
   entry: WorkerSessionTimelineEntry;
   messages: WorkerSessionTimelineMessages;
   onNavigateToWorkerSession?: (workerSessionID: string) => void;
+  position?: number;
+  totalEntries?: number;
 }
 
 export function EntryStructuredDetails({
@@ -167,7 +169,12 @@ function MessageDetails({
           />
         ) : null}
         {messageText ? (
-          <BoundedText label={messages.messageTextLabel} value={messageText} />
+          <BoundedText
+            collapseLabel={messages.collapseContentAction}
+            expandLabel={messages.expandContentAction}
+            label={messages.messageTextLabel}
+            value={messageText}
+          />
         ) : null}
         {message.delta ? (
           <DetailList
@@ -196,7 +203,7 @@ function MessageDetails({
           />
         ) : null}
         {message.contentBlocks?.map((block) => (
-          <ContentBlockDetails
+          <WorkerSessionTimelineContentBlockDetails
             block={block}
             key={contentBlockKey(block)}
             messages={messages}
@@ -204,38 +211,6 @@ function MessageDetails({
         ))}
       </div>
     </DetailSection>
-  );
-}
-
-function ContentBlockDetails({
-  block,
-  messages,
-}: {
-  block: WorkerTimelineContentBlock;
-  messages: WorkerSessionTimelineMessages;
-}) {
-  return (
-    <section
-      aria-label={messages.messageTextLabel}
-      className="grid min-w-0 gap-2"
-    >
-      <Label>{block.kind}</Label>
-      {block.text ? (
-        <BoundedText label={messages.messageTextLabel} value={block.text} />
-      ) : null}
-      {block.argumentsSummary !== undefined ? (
-        <BoundedCode
-          label={messages.toolArgumentsLabel}
-          value={block.argumentsSummary}
-        />
-      ) : null}
-      {block.structuredOutput !== undefined ? (
-        <BoundedCode
-          label={messages.toolResultLabel}
-          value={block.structuredOutput}
-        />
-      ) : null}
-    </section>
   );
 }
 
@@ -265,12 +240,16 @@ function ReasoningDetails({
       />
       {reasoning.summary ? (
         <BoundedText
+          collapseLabel={messages.collapseContentAction}
+          expandLabel={messages.expandContentAction}
           label={messages.reasoningSnapshotLabel}
           value={reasoning.summary}
         />
       ) : null}
       {reasoning.summaryDelta ? (
         <BoundedText
+          collapseLabel={messages.collapseContentAction}
+          expandLabel={messages.expandContentAction}
           label={messages.reasoningDeltaLabel}
           value={reasoning.summaryDelta}
         />
@@ -303,18 +282,24 @@ function ToolDetails({
       />
       {tool.argumentsSummary !== undefined ? (
         <BoundedCode
+          collapseLabel={messages.collapseContentAction}
+          expandLabel={messages.expandContentAction}
           label={messages.toolArgumentsLabel}
           value={tool.argumentsSummary}
         />
       ) : null}
       {tool.outputDelta ? (
         <BoundedText
+          collapseLabel={messages.collapseContentAction}
+          expandLabel={messages.expandContentAction}
           label={messages.toolOutputLabel}
           value={tool.outputDelta}
         />
       ) : null}
       {tool.resultSummary !== undefined ? (
         <BoundedCode
+          collapseLabel={messages.collapseContentAction}
+          expandLabel={messages.expandContentAction}
           label={messages.toolResultLabel}
           value={tool.resultSummary}
         />
@@ -399,7 +384,12 @@ function FailureDetails({
         ]}
       />
       {failure.message ? (
-        <BoundedText label={messages.failureLabel} value={failure.message} />
+        <BoundedText
+          collapseLabel={messages.collapseContentAction}
+          expandLabel={messages.expandContentAction}
+          label={messages.failureLabel}
+          value={failure.message}
+        />
       ) : null}
     </DetailSection>
   );
@@ -423,6 +413,8 @@ function TerminalDetails({
       ) : null}
       {terminal.failure?.message ? (
         <BoundedText
+          collapseLabel={messages.collapseContentAction}
+          expandLabel={messages.expandContentAction}
           label={messages.failureLabel}
           value={terminal.failure.message}
         />

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline-entry.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline-entry.tsx
@@ -17,6 +17,8 @@ export function WorkerSessionTimelineEntryView({
   entry,
   messages,
   onNavigateToWorkerSession,
+  position = entry.canonical.position,
+  totalEntries,
 }: WorkerSessionTimelineEntryDetailsProps) {
   const categoryLabel =
     messages.categoryLabel[entry.category] ?? messages.unknownCategoryLabel;
@@ -32,6 +34,8 @@ export function WorkerSessionTimelineEntryView({
 
   return (
     <li
+      aria-posinset={position}
+      aria-setsize={totalEntries}
       className="min-w-0"
       data-worker-session-timeline-entry-position={entry.canonical.position}
     >

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline-entry.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline-entry.tsx
@@ -1,0 +1,192 @@
+import { Heading, Label, Text } from "@you-agent-factory/components/primitives";
+import { type ReactNode, useId, useState } from "react";
+
+import { DashboardStatusPill } from "../../../components/ui/dashboard-status-pill";
+import { ExpandablePanelTrigger } from "../../../components/ui/expandable-panel-trigger";
+import type {
+  WorkerSessionTimelineEntry,
+  WorkerTimelineTerminalOutcome,
+} from "../lib/worker-session-timeline-projection-types";
+import type { WorkerSessionTimelineMessages } from "../messages/worker-session-timeline";
+import {
+  EntryStructuredDetails,
+  type WorkerSessionTimelineEntryDetailsProps,
+} from "./worker-session-timeline-entry-details";
+
+export function WorkerSessionTimelineEntryView({
+  entry,
+  messages,
+  onNavigateToWorkerSession,
+}: WorkerSessionTimelineEntryDetailsProps) {
+  const categoryLabel =
+    messages.categoryLabel[entry.category] ?? messages.unknownCategoryLabel;
+  const phaseLabel = messages.phaseLabel(entry.phase);
+  const title = `${categoryLabel} · ${phaseLabel}`;
+  const detail = entryHasDetail(entry) ? (
+    <WorkerSessionTimelineEntryDetails
+      entry={entry}
+      messages={messages}
+      onNavigateToWorkerSession={onNavigateToWorkerSession}
+    />
+  ) : null;
+
+  return (
+    <li
+      className="min-w-0"
+      data-worker-session-timeline-entry-position={entry.canonical.position}
+    >
+      <article
+        aria-label={`${title}, ${messages.eventPositionLabel(entry.canonical.position)}`}
+        className="grid min-w-0 gap-3 rounded-lg border border-outline bg-surface-container-low p-3"
+      >
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <DashboardStatusPill size="compact" tone={entryTone(entry)}>
+            {categoryLabel}
+          </DashboardStatusPill>
+          <DashboardStatusPill size="compact" tone="neutral">
+            {phaseLabel}
+          </DashboardStatusPill>
+          <span className="af-supporting-text text-on-surface-subtle">
+            {messages.eventPositionLabel(entry.canonical.position)}
+          </span>
+        </div>
+        <Heading as="h3" className="m-0 min-w-0 [overflow-wrap:anywhere]">
+          {title}
+        </Heading>
+        <EntryMetadata entry={entry} messages={messages} />
+        {detail ?? <Text variant="supporting">{messages.noDetailState}</Text>}
+      </article>
+    </li>
+  );
+}
+
+function EntryMetadata({
+  entry,
+  messages,
+}: {
+  entry: WorkerSessionTimelineEntry;
+  messages: WorkerSessionTimelineMessages;
+}) {
+  const items: Array<{ label: string; value: ReactNode }> = [];
+  if (entry.identity?.provider) {
+    items.push({
+      label: messages.providerLabel,
+      value: entry.identity.provider,
+    });
+  }
+  if (entry.identity?.modelProvider) {
+    items.push({
+      label: messages.modelProviderLabel,
+      value: entry.identity.modelProvider,
+    });
+  }
+  if (entry.identity?.model) {
+    items.push({ label: messages.modelLabel, value: entry.identity.model });
+  }
+  if (entry.attempt) {
+    items.push({
+      label: messages.attemptLabel(entry.attempt.number, entry.attempt.id),
+      value: entry.attempt.status ?? messages.attemptIDLabel,
+    });
+  }
+  if (entry.canonical.sourceType) {
+    items.push({
+      label: messages.sourceLabel,
+      value: entry.canonical.sourceType,
+    });
+  }
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <dl className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2">
+      {items.map((item) => (
+        <div
+          className="grid min-w-0 gap-1"
+          key={`${item.label}-${String(item.value)}`}
+        >
+          <Label as="dt">{item.label}</Label>
+          <Text as="dd" className="m-0 min-w-0 [overflow-wrap:anywhere]">
+            {item.value}
+          </Text>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function WorkerSessionTimelineEntryDetails({
+  entry,
+  messages,
+  onNavigateToWorkerSession,
+}: WorkerSessionTimelineEntryDetailsProps) {
+  const controlsID = useId();
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="grid min-w-0 gap-2">
+      <ExpandablePanelTrigger
+        aria-label={messages.detailsLabel(expanded)}
+        controlsID={controlsID}
+        expanded={expanded}
+        onClick={() => setExpanded((current) => !current)}
+        variant="compact"
+      >
+        {messages.detailsLabel(expanded)}
+      </ExpandablePanelTrigger>
+      {expanded ? (
+        <div
+          className="grid min-w-0 gap-3 border-t border-outline pt-3"
+          id={controlsID}
+        >
+          <EntryStructuredDetails
+            entry={entry}
+            messages={messages}
+            onNavigateToWorkerSession={onNavigateToWorkerSession}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function entryHasDetail(entry: WorkerSessionTimelineEntry): boolean {
+  return Boolean(
+    entry.attempt ||
+      entry.continuation ||
+      entry.message ||
+      entry.reasoning ||
+      entry.tool ||
+      entry.usage ||
+      entry.failure ||
+      entry.terminal ||
+      entry.generic,
+  );
+}
+
+function entryTone(
+  entry: WorkerSessionTimelineEntry,
+): "danger" | "info" | "neutral" | "success" | "warning" {
+  if (entry.terminal) {
+    return terminalTone(entry.terminal.outcome);
+  }
+  if (entry.category === "error") {
+    return "danger";
+  }
+  if (entry.category === "tool" || entry.category === "reasoning") {
+    return "info";
+  }
+  return "neutral";
+}
+
+function terminalTone(
+  outcome: WorkerTimelineTerminalOutcome,
+): "danger" | "success" | "warning" {
+  return outcome === "SUCCESS"
+    ? "success"
+    : outcome === "FAILURE"
+      ? "danger"
+      : "warning";
+}

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline-target.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline-target.tsx
@@ -1,0 +1,81 @@
+import { EnumSelect } from "@you-agent-factory/components/forms";
+import { WidgetDetailCopy } from "@you-agent-factory/components/recipes";
+import type { WorkerSessionObservation } from "../../../api/worker-sessions";
+import { AlertPanel } from "../../../components/ui/alert-panel";
+import { DashboardActionButton } from "../../../components/ui/dashboard-action-button";
+import type { UseWorkerSessionTimelineTargetResult } from "../hooks/useWorkerSessionTimelineTarget";
+import type { WorkerSessionTimelineMessages } from "../messages/worker-session-timeline";
+
+export interface WorkerSessionTimelineTargetProps {
+  messages: WorkerSessionTimelineMessages;
+  state: UseWorkerSessionTimelineTargetResult;
+  workID: string | null;
+}
+
+export function WorkerSessionTimelineTarget({
+  messages,
+  state,
+  workID,
+}: WorkerSessionTimelineTargetProps) {
+  if (workID === null || state.status === "idle") {
+    return (
+      <WidgetDetailCopy>{messages.workSelectionRequired}</WidgetDetailCopy>
+    );
+  }
+
+  if (state.status === "loading") {
+    return (
+      <WidgetDetailCopy aria-busy="true" role="status">
+        {messages.sessionTargetLoading}
+      </WidgetDetailCopy>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <AlertPanel role="alert" tone="danger">
+        <div className="grid gap-3">
+          <WidgetDetailCopy>
+            {state.error?.message ?? messages.sessionTargetError}
+          </WidgetDetailCopy>
+          <div>
+            <DashboardActionButton onClick={state.refetch} type="button">
+              {messages.sessionTargetRetry}
+            </DashboardActionButton>
+          </div>
+        </div>
+      </AlertPanel>
+    );
+  }
+
+  if (state.observations.length === 0) {
+    return <WidgetDetailCopy>{messages.sessionTargetEmpty}</WidgetDetailCopy>;
+  }
+
+  const selectedWorkerSessionID =
+    state.selectedWorkerSessionID ?? state.observations[0]?.workerSessionId;
+
+  return (
+    <EnumSelect
+      aria-label={messages.sessionTargetSelectLabel}
+      id="worker-session-timeline-target"
+      onValueChange={state.setSelectedWorkerSessionID}
+      options={state.observations.map((observation) => ({
+        label: sessionTargetOption(messages, observation),
+        value: observation.workerSessionId,
+      }))}
+      value={selectedWorkerSessionID}
+    />
+  );
+}
+
+function sessionTargetOption(
+  messages: WorkerSessionTimelineMessages,
+  observation: WorkerSessionObservation,
+): string {
+  return messages.sessionTargetOption(
+    observation.workerSessionId,
+    observation.attemptId,
+    observation.state,
+  );
+}

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline-widget.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline-widget.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from "react";
+import { DashboardWidgetFrame } from "../../bento/components/dashboard-widget-frame/dashboard-widget-frame";
+import {
+  useWorkerSessionTimelineTarget,
+  type WorkerSessionTimelineTargetLoader,
+} from "../hooks/useWorkerSessionTimelineTarget";
+import { getWorkerSessionTimelineMessages } from "../messages/worker-session-timeline";
+import {
+  WorkerSessionTimeline,
+  type WorkerSessionTimelineProps,
+} from "./worker-session-timeline";
+import { WorkerSessionTimelineTarget } from "./worker-session-timeline-target";
+
+export interface WorkerSessionTimelineWidgetProps
+  extends WorkerSessionTimelineProps {
+  headerAction?: ReactNode;
+  loadWorkerSessionTargets?: WorkerSessionTimelineTargetLoader;
+  locale?: string;
+  workID?: string | null;
+  widgetId?: string;
+}
+
+/** Dashboard chrome for consumers that need a selectable Worker Session card. */
+export function WorkerSessionTimelineWidget({
+  factorySessionID,
+  headerAction,
+  loadWorkerSessionTargets,
+  locale,
+  workID = null,
+  widgetId = "worker-session-timeline",
+  workerSessionID,
+  ...timelineOptions
+}: WorkerSessionTimelineWidgetProps) {
+  const messages = getWorkerSessionTimelineMessages(locale);
+  const targetState = useWorkerSessionTimelineTarget({
+    enabled: workerSessionID === null,
+    factorySessionID,
+    loadTargets: loadWorkerSessionTargets,
+    workID,
+  });
+  const selectedWorkerSessionID =
+    workerSessionID ?? targetState.selectedWorkerSessionID;
+  const targetIsReady =
+    workerSessionID !== null || targetState.selectedWorkerSessionID !== null;
+
+  return (
+    <DashboardWidgetFrame
+      bodyScroll={false}
+      headerAction={headerAction}
+      title={messages.timelineTitle}
+      widgetId={widgetId}
+    >
+      {workerSessionID === null ? (
+        <WorkerSessionTimelineTarget
+          messages={messages}
+          state={targetState}
+          workID={workID}
+        />
+      ) : null}
+      {targetIsReady ? (
+        <WorkerSessionTimeline
+          {...timelineOptions}
+          factorySessionID={factorySessionID}
+          locale={locale}
+          showHeading={false}
+          workerSessionID={selectedWorkerSessionID}
+        />
+      ) : null}
+    </DashboardWidgetFrame>
+  );
+}

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline-window-controls.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline-window-controls.tsx
@@ -1,0 +1,76 @@
+import { DashboardActionButton } from "../../../components/ui/dashboard-action-button";
+import type { WorkerSessionTimelineWindow } from "../lib/worker-session-timeline-window";
+import type { WorkerSessionTimelineMessages } from "../messages/worker-session-timeline";
+
+export interface WorkerSessionTimelineWindowControlsProps {
+  eventListID: string;
+  messages: WorkerSessionTimelineMessages;
+  onMove: (direction: "earlier" | "later") => void;
+  onReturnToLatest: () => void;
+  pendingLiveCount: number;
+  timelineWindow: WorkerSessionTimelineWindow;
+  totalEntries: number;
+}
+
+export function WorkerSessionTimelineWindowControls({
+  eventListID,
+  messages,
+  onMove,
+  onReturnToLatest,
+  pendingLiveCount,
+  timelineWindow,
+  totalEntries,
+}: WorkerSessionTimelineWindowControlsProps) {
+  if (
+    totalEntries === 0 ||
+    (!timelineWindow.hasEarlier &&
+      !timelineWindow.hasLater &&
+      pendingLiveCount === 0)
+  ) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label={messages.windowNavigationLabel}
+      className="flex min-w-0 flex-wrap items-center gap-2"
+      data-worker-session-timeline-window-controls="true"
+    >
+      <DashboardActionButton
+        aria-controls={eventListID}
+        disabled={!timelineWindow.hasEarlier}
+        onClick={() => onMove("earlier")}
+        type="button"
+      >
+        {messages.earlierEventsAction}
+      </DashboardActionButton>
+      <span
+        aria-live="polite"
+        className="min-w-0 break-words text-sm text-on-surface-subtle"
+      >
+        {messages.windowRangeLabel(
+          timelineWindow.start + 1,
+          timelineWindow.end,
+          totalEntries,
+        )}
+      </span>
+      <DashboardActionButton
+        aria-controls={eventListID}
+        disabled={!timelineWindow.hasLater}
+        onClick={() => onMove("later")}
+        type="button"
+      >
+        {messages.laterEventsAction}
+      </DashboardActionButton>
+      {pendingLiveCount > 0 ? (
+        <DashboardActionButton
+          aria-controls={eventListID}
+          onClick={onReturnToLatest}
+          type="button"
+        >
+          {messages.newActivityAction(pendingLiveCount)}
+        </DashboardActionButton>
+      ) : null}
+    </nav>
+  );
+}

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline.bun.component.test.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline.bun.component.test.tsx
@@ -1,7 +1,19 @@
+// biome-ignore lint/style/noExcessiveLinesPerFile: timeline state, detail, window, and target cases share one deterministic harness.
 import { describe, expect, it, mock } from "bun:test";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
 
-import type { WorkerSessionEventRecord } from "../../../api/worker-sessions";
+import type {
+  WorkerSessionEventRecord,
+  WorkerSessionObservation,
+} from "../../../api/worker-sessions";
 import type { UseWorkerSessionTimelineResult } from "../hooks/useWorkerSessionTimeline";
 import {
   projectWorkerSessionTimeline,
@@ -9,6 +21,7 @@ import {
 } from "../lib/worker-session-timeline-projection";
 import { getWorkerSessionTimelineMessages } from "../messages/worker-session-timeline";
 import { WorkerSessionTimelineContent } from "./worker-session-timeline";
+import { WorkerSessionTimelineWidget } from "./worker-session-timeline-widget";
 
 const WORKER_SESSION_ID = "worker-session-ui-1";
 
@@ -368,6 +381,80 @@ describe("WorkerSessionTimelineContent large details", () => {
     );
   });
 });
+
+describe("WorkerSessionTimelineWidget target selection", () => {
+  it("selects a Worker Session target from the selected Work before rendering its timeline", async () => {
+    const loadWorkerSessionTargets = async () => [observation("worker-1")];
+
+    render(
+      <WorkerSessionTimelineWidget
+        enabled={false}
+        factorySessionID="factory-1"
+        loadWorkerSessionTargets={loadWorkerSessionTargets}
+        stateOverride={timelineState({ status: "ready-empty" })}
+        workID="work-1"
+        workerSessionID={null}
+      />,
+      { wrapper: createQueryWrapper() },
+    );
+
+    const messages = getWorkerSessionTimelineMessages("en");
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", {
+          name: messages.sessionTargetSelectLabel,
+        }),
+      ).toBeTruthy();
+    });
+    expect(screen.getByText(messages.timelineTitle)).toBeTruthy();
+  });
+
+  it("keeps the explicit empty target state separate from the timeline", () => {
+    const messages = getWorkerSessionTimelineMessages("en");
+
+    render(
+      <WorkerSessionTimelineWidget
+        enabled={false}
+        factorySessionID="factory-1"
+        stateOverride={timelineState({ status: "ready-empty" })}
+        workerSessionID={null}
+      />,
+      { wrapper: createQueryWrapper() },
+    );
+
+    expect(screen.getByText(messages.workSelectionRequired)).toBeTruthy();
+    expect(screen.queryByText(messages.emptyState)).toBeNull();
+  });
+});
+
+function createQueryWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function QueryWrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function observation(workerSessionId: string): WorkerSessionObservation {
+  return {
+    attemptId: "attempt-1",
+    direct: false,
+    durationBasis: "UNAVAILABLE",
+    durationMillis: null,
+    endedAt: null,
+    parse: { errors: [], ignored: 0 },
+    providerSessionAvailable: false,
+    startedAt: null,
+    state: "RUNNING",
+    transcript: "AVAILABLE",
+    turnId: null,
+    workIds: ["work-1"],
+    workerSessionId,
+  } as WorkerSessionObservation;
+}
 
 function timelineState(
   overrides: Partial<UseWorkerSessionTimelineResult> = {},

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline.bun.component.test.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline.bun.component.test.tsx
@@ -1,0 +1,270 @@
+import { describe, expect, it, mock } from "bun:test";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import type { WorkerSessionEventRecord } from "../../../api/worker-sessions";
+import type { UseWorkerSessionTimelineResult } from "../hooks/useWorkerSessionTimeline";
+import {
+  projectWorkerSessionTimeline,
+  type WorkerSessionTimelineEntry,
+} from "../lib/worker-session-timeline-projection";
+import { getWorkerSessionTimelineMessages } from "../messages/worker-session-timeline";
+import { WorkerSessionTimelineContent } from "./worker-session-timeline";
+
+const WORKER_SESSION_ID = "worker-session-ui-1";
+
+describe("WorkerSessionTimelineContent states", () => {
+  it("keeps loading and empty states distinct", () => {
+    const messages = getWorkerSessionTimelineMessages("en");
+    const { rerender } = render(
+      <WorkerSessionTimelineContent
+        state={timelineState({ status: "loading" })}
+        workerSessionID={WORKER_SESSION_ID}
+      />,
+    );
+
+    expect(screen.getAllByText(messages.loadingState).length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getByRole("status")).toBeTruthy();
+
+    rerender(
+      <WorkerSessionTimelineContent
+        state={timelineState({ status: "ready-empty" })}
+        workerSessionID={WORKER_SESSION_ID}
+      />,
+    );
+    expect(screen.getAllByText(messages.emptyState).length).toBeGreaterThan(0);
+  });
+
+  it("identifies live following and completed terminal delivery", () => {
+    const messages = getWorkerSessionTimelineMessages("en");
+    const { rerender } = render(
+      <WorkerSessionTimelineContent
+        state={timelineState({ status: "live" })}
+        workerSessionID={WORKER_SESSION_ID}
+      />,
+    );
+    expect(
+      screen.getAllByText(messages.liveFollowingState).length,
+    ).toBeGreaterThan(0);
+
+    const terminalEntry = projectEntries([
+      draftRecord(1, "SESSION", "COMPLETED", { status: "COMPLETED" }),
+    ]);
+    rerender(
+      <WorkerSessionTimelineContent
+        state={timelineState({ entries: terminalEntry, status: "completed" })}
+        workerSessionID={WORKER_SESSION_ID}
+      />,
+    );
+    expect(screen.getAllByText(messages.completedState).length).toBeGreaterThan(
+      0,
+    );
+    expect(
+      screen.getByText(messages.terminalOutcomeLabel("SUCCESS")),
+    ).toBeTruthy();
+  });
+
+  it("preserves retained entries when the source fails", () => {
+    render(
+      <WorkerSessionTimelineContent
+        state={timelineState({
+          entries: projectEntries([
+            draftRecord(1, "MESSAGE", "COMPLETED", {
+              role: "assistant",
+              contentBlocks: [{ kind: "TEXT", text: "retained" }],
+            }),
+          ]),
+          sourceError: {
+            code: "SOURCE_FAILURE",
+            message: "retained history unavailable",
+          },
+          status: "source-error",
+        })}
+        workerSessionID={WORKER_SESSION_ID}
+      />,
+    );
+    expect(screen.getByRole("alert").textContent).toContain(
+      "retained history unavailable",
+    );
+    expect(screen.getByText("Message · COMPLETED")).toBeTruthy();
+  });
+});
+
+describe("WorkerSessionTimelineContent details", () => {
+  it("renders canonical identity, attempts, continuation, content, usage, and terminal detail", () => {
+    const entries = projectEntries([
+      draftRecord(1, "SESSION", "STARTED", {
+        attempt: 1,
+        attemptId: "attempt-1",
+        model: "gpt-5",
+        providerSelection: {
+          executorProvider: "ACP",
+          modelProvider: "openai",
+        },
+        status: "STARTING",
+      }),
+      draftRecord(2, "MESSAGE", "COMPLETED", {
+        contentBlocks: [{ kind: "TEXT", text: "Please inspect the build." }],
+        role: "user",
+      }),
+      draftRecord(3, "REASONING", "DELTA", {
+        summaryDelta: "Checking the build output.",
+      }),
+      draftRecord(4, "TOOL", "COMPLETED", {
+        resultSummary: { exitCode: 0, output: "ok" },
+        status: "completed",
+        toolCallId: "tool-1",
+        toolName: "command_execution",
+      }),
+      draftRecord(5, "USAGE", "UPDATED", {
+        inputTokens: 10,
+        model: "gpt-5",
+        outputTokens: 8,
+        totalTokens: 18,
+      }),
+      draftRecord(6, "SESSION", "COMPLETED", {
+        continuation: {
+          kind: "session_id",
+          id: "provider-thread-1",
+          provider: "codex",
+        },
+        lineage: {
+          successorWorkerSessionId: "worker-session-ui-2",
+        },
+        status: "COMPLETED",
+      }),
+    ]);
+
+    const messages = getWorkerSessionTimelineMessages("en");
+    render(
+      <WorkerSessionTimelineContent
+        onNavigateToWorkerSession={mock(() => {})}
+        state={timelineState({ entries, status: "completed" })}
+        workerSessionID={WORKER_SESSION_ID}
+      />,
+    );
+
+    expect(screen.getByText("openai")).toBeTruthy();
+    expect(screen.getByText(messages.modelProviderLabel)).toBeTruthy();
+    expect(screen.getAllByText("gpt-5").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole("button", { name: messages.detailsLabel(false) }),
+    ).toHaveLength(entries.length);
+
+    for (const button of screen.getAllByRole("button", {
+      name: messages.detailsLabel(false),
+    })) {
+      fireEvent.click(button);
+    }
+
+    expect(
+      screen.getAllByText("Please inspect the build.").length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("Checking the build output.")).toBeTruthy();
+    expect(screen.getByText("command_execution")).toBeTruthy();
+    expect(screen.getByText(/"exitCode"/)).toBeTruthy();
+    expect(screen.getByText("18")).toBeTruthy();
+    expect(screen.getByText("worker-session-ui-2")).toBeTruthy();
+    expect(
+      screen.getByText("codex / session_id / provider-thread-1"),
+    ).toBeTruthy();
+
+    const continuationHeading = screen.getByText(messages.continuationLabel);
+    expect(continuationHeading).toBeTruthy();
+    expect(
+      within(continuationHeading.closest("section") as HTMLElement).getByRole(
+        "button",
+        { name: messages.openWorkerSessionLabel("worker-session-ui-2") },
+      ),
+    ).toBeTruthy();
+  });
+});
+
+describe("WorkerSessionTimelineContent recording health", () => {
+  it("keeps recording health separate from the worker terminal outcome", () => {
+    const entries = projectEntries([
+      draftRecord(1, "SESSION", "FAILED", {
+        failureDetail: "Provider stopped responding.",
+        status: "FAILED",
+      }),
+    ]);
+    const messages = getWorkerSessionTimelineMessages("en");
+
+    render(
+      <WorkerSessionTimelineContent
+        state={timelineState({
+          entries,
+          recordingHealth: "INCOMPLETE",
+          recordingHealthReason: "RETAINED_HEAD_MOVED",
+          status: "completed",
+        })}
+        workerSessionID={WORKER_SESSION_ID}
+      />,
+    );
+
+    expect(
+      screen.getByText(messages.recordingHealthLabel("INCOMPLETE")),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(messages.terminalOutcomeLabel("FAILURE")),
+    ).toBeTruthy();
+    expect(screen.getByText(messages.failureLabel)).toBeTruthy();
+    expect(screen.getByText(/RETAINED_HEAD_MOVED/)).toBeTruthy();
+    expect(screen.getByText("Provider stopped responding.")).toBeTruthy();
+  });
+});
+
+function timelineState(
+  overrides: Partial<UseWorkerSessionTimelineResult> = {},
+): UseWorkerSessionTimelineResult {
+  return {
+    acknowledgedCursor: null,
+    entries: [],
+    isFollowing: false,
+    records: [],
+    recordingHealth: null,
+    recordingHealthReason: null,
+    reconnectCursor: null,
+    replaySummary: null,
+    retry: mock(() => {}),
+    sourceError: null,
+    status: "loading",
+    streamGenerationId: null,
+    terminalDelivery: null,
+    ...overrides,
+  };
+}
+
+function projectEntries(
+  records: WorkerSessionEventRecord[],
+): WorkerSessionTimelineEntry[] {
+  return projectWorkerSessionTimeline(records);
+}
+
+function draftRecord(
+  position: number,
+  kind: string,
+  phase: string,
+  payload: Record<string, unknown>,
+): WorkerSessionEventRecord {
+  return {
+    cursor: {
+      position,
+      streamGenerationId: "generation-ui",
+      workerSessionId: WORKER_SESSION_ID,
+    },
+    payload: {
+      kind,
+      payload,
+      phase,
+      provenance: { provider: "codex" },
+    },
+    position,
+    schemaId: "workers.draft.v1",
+    sourceEventId: `ui-event-${position}`,
+    sourceId: WORKER_SESSION_ID,
+    sourceSequence: position,
+    sourceType: "worker_session",
+  };
+}

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline.bun.component.test.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline.bun.component.test.tsx
@@ -215,6 +215,160 @@ describe("WorkerSessionTimelineContent recording health", () => {
   });
 });
 
+describe("WorkerSessionTimelineContent bounded windows", () => {
+  it("mounts one bounded window and returns to the live tail with pending activity", () => {
+    const messages = getWorkerSessionTimelineMessages("en");
+    const { container, rerender } = render(
+      <WorkerSessionTimelineContent
+        state={timelineState({
+          entries: manyEntries(201),
+          isFollowing: true,
+          status: "live",
+        })}
+        workerSessionID={WORKER_SESSION_ID}
+      />,
+    );
+
+    expect(timelineRows(container)).toHaveLength(200);
+    expect(
+      screen.getByText(messages.windowRangeLabel(2, 201, 201)),
+    ).toBeTruthy();
+    expect(timelineRows(container)[0]).toHaveAttribute(
+      "data-worker-session-timeline-entry-position",
+      "2",
+    );
+
+    const earlierButton = requireTimelineButton(
+      container,
+      messages.earlierEventsAction,
+    );
+    fireEvent.click(earlierButton);
+    expect(timelineRows(container)).toHaveLength(200);
+    expect(timelineRows(container)[0]).toHaveAttribute(
+      "data-worker-session-timeline-entry-position",
+      "1",
+    );
+
+    rerender(
+      <WorkerSessionTimelineContent
+        state={timelineState({
+          entries: manyEntries(203),
+          isFollowing: true,
+          status: "live",
+        })}
+        workerSessionID={WORKER_SESSION_ID}
+      />,
+    );
+    expect(timelineRows(container)).toHaveLength(200);
+    const newActivityButton = requireTimelineButton(
+      container,
+      messages.newActivityAction(2),
+    );
+    expect(newActivityButton).toBeTruthy();
+    expect(timelineRows(container)[0]).toHaveAttribute(
+      "data-worker-session-timeline-entry-position",
+      "1",
+    );
+
+    fireEvent.click(newActivityButton);
+    expect(timelineRows(container)[0]).toHaveAttribute(
+      "data-worker-session-timeline-entry-position",
+      "4",
+    );
+    expect(
+      findTimelineButton(container, messages.newActivityAction(2)),
+    ).toBeNull();
+  });
+});
+
+describe("WorkerSessionTimelineContent live focus", () => {
+  it("does not move focus when a live record appends", () => {
+    const retainedRecord = draftRecord(1, "MESSAGE", "COMPLETED", {
+      contentBlocks: [{ kind: "TEXT", text: "retained" }],
+      role: "assistant",
+    });
+    const { container, rerender } = render(
+      <WorkerSessionTimelineContent
+        state={timelineState({
+          entries: projectEntries([retainedRecord]),
+          isFollowing: true,
+          status: "live",
+        })}
+        workerSessionID={WORKER_SESSION_ID}
+      />,
+    );
+    const detailsButton = container.querySelector<HTMLButtonElement>(
+      "button[aria-expanded]",
+    );
+    if (!detailsButton) {
+      throw new Error("expected a focusable details button");
+    }
+    detailsButton.focus();
+
+    rerender(
+      <WorkerSessionTimelineContent
+        state={timelineState({
+          entries: projectEntries([
+            retainedRecord,
+            draftRecord(2, "PROGRESS", "UPDATED", { status: "RUNNING" }),
+          ]),
+          isFollowing: true,
+          status: "live",
+        })}
+        workerSessionID={WORKER_SESSION_ID}
+      />,
+    );
+
+    expect(container.ownerDocument.activeElement).toBe(detailsButton);
+  });
+});
+
+describe("WorkerSessionTimelineContent large details", () => {
+  it("uses semantic row positions and a keyboard-operable disclosure for large bodies", () => {
+    const messages = getWorkerSessionTimelineMessages("en");
+    const longText = "long body ".repeat(500);
+    render(
+      <WorkerSessionTimelineContent
+        state={timelineState({
+          entries: projectEntries([
+            draftRecord(1, "MESSAGE", "COMPLETED", {
+              contentBlocks: [{ kind: "TEXT", text: longText }],
+              role: "assistant",
+            }),
+          ]),
+          status: "completed",
+        })}
+        workerSessionID={WORKER_SESSION_ID}
+      />,
+    );
+
+    const row = screen.getByRole("listitem");
+    expect(row).toHaveAttribute("aria-posinset", "1");
+    expect(row).toHaveAttribute("aria-setsize", "1");
+    fireEvent.click(
+      screen.getByRole("button", { name: messages.detailsLabel(false) }),
+    );
+
+    const boundedContent = document.querySelector(
+      "details[data-worker-session-timeline-bounded-content='true']",
+    );
+    if (!(boundedContent instanceof HTMLDetailsElement)) {
+      throw new Error("expected a native bounded content disclosure");
+    }
+    expect(boundedContent.open).toBe(false);
+    const boundedSummary = boundedContent.querySelector("summary");
+    if (!boundedSummary) {
+      throw new Error("expected a bounded content summary");
+    }
+    fireEvent.click(boundedSummary);
+    expect(boundedContent.open).toBe(true);
+    expect(boundedSummary.textContent).toBe(messages.collapseContentAction);
+    expect(boundedContent.textContent).toContain(
+      `${longText.slice(0, 4_000)}…`,
+    );
+  });
+});
+
 function timelineState(
   overrides: Partial<UseWorkerSessionTimelineResult> = {},
 ): UseWorkerSessionTimelineResult {
@@ -240,6 +394,58 @@ function projectEntries(
   records: WorkerSessionEventRecord[],
 ): WorkerSessionTimelineEntry[] {
   return projectWorkerSessionTimeline(records);
+}
+
+function manyEntries(count: number): WorkerSessionTimelineEntry[] {
+  return Array.from({ length: count }, (_, index) => ({
+    canonical: {
+      cursor: {
+        position: index + 1,
+        streamGenerationId: "generation-ui",
+        workerSessionId: WORKER_SESSION_ID,
+      },
+      position: index + 1,
+      schemaId: "workers.draft.v1",
+      sourceEventId: `ui-event-${index + 1}`,
+      sourceId: WORKER_SESSION_ID,
+      sourceSequence: index + 1,
+      sourceType: "worker_session",
+    },
+    category: "progress",
+    key: `ui-event-${index + 1}`,
+    kind: "PROGRESS",
+    phase: "UPDATED",
+  }));
+}
+
+function timelineRows(container: HTMLElement): Element[] {
+  return Array.from(
+    container.querySelectorAll(
+      "li[data-worker-session-timeline-entry-position]",
+    ),
+  );
+}
+
+function findTimelineButton(
+  container: HTMLElement,
+  label: string,
+): HTMLButtonElement | null {
+  return (
+    Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
+      (button) => button.textContent === label,
+    ) ?? null
+  );
+}
+
+function requireTimelineButton(
+  container: HTMLElement,
+  label: string,
+): HTMLButtonElement {
+  const button = findTimelineButton(container, label);
+  if (!button) {
+    throw new Error(`expected timeline button: ${label}`);
+  }
+  return button;
 }
 
 function draftRecord(

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline.bun.component.test.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline.bun.component.test.tsx
@@ -8,6 +8,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 
 import type {
@@ -21,6 +22,7 @@ import {
 } from "../lib/worker-session-timeline-projection";
 import { getWorkerSessionTimelineMessages } from "../messages/worker-session-timeline";
 import { WorkerSessionTimelineContent } from "./worker-session-timeline";
+import { BoundedCode } from "./worker-session-timeline-detail-primitives";
 import { WorkerSessionTimelineWidget } from "./worker-session-timeline-widget";
 
 const WORKER_SESSION_ID = "worker-session-ui-1";
@@ -337,9 +339,11 @@ describe("WorkerSessionTimelineContent live focus", () => {
 });
 
 describe("WorkerSessionTimelineContent large details", () => {
-  it("uses semantic row positions and a keyboard-operable disclosure for large bodies", () => {
+  it("uses semantic row positions and reveals the full text after keyboard expansion", async () => {
+    const user = userEvent.setup();
     const messages = getWorkerSessionTimelineMessages("en");
-    const longText = "long body ".repeat(500);
+    const textSentinel = "TEXT_FULL_CONTENT_SENTINEL";
+    const longText = `${"long body ".repeat(400)}${textSentinel}`;
     render(
       <WorkerSessionTimelineContent
         state={timelineState({
@@ -369,16 +373,52 @@ describe("WorkerSessionTimelineContent large details", () => {
       throw new Error("expected a native bounded content disclosure");
     }
     expect(boundedContent.open).toBe(false);
+    expect(boundedContent.textContent).not.toContain(textSentinel);
     const boundedSummary = boundedContent.querySelector("summary");
     if (!boundedSummary) {
       throw new Error("expected a bounded content summary");
     }
-    fireEvent.click(boundedSummary);
+    boundedSummary.focus();
+    await user.keyboard("{Enter}");
     expect(boundedContent.open).toBe(true);
     expect(boundedSummary.textContent).toBe(messages.collapseContentAction);
-    expect(boundedContent.textContent).toContain(
-      `${longText.slice(0, 4_000)}…`,
+    expect(boundedContent.textContent).toContain(textSentinel);
+  });
+
+  it("reveals the full structured/code body after keyboard expansion", async () => {
+    const user = userEvent.setup();
+    const messages = getWorkerSessionTimelineMessages("en");
+    const codeSentinel = "CODE_FULL_CONTENT_SENTINEL";
+    const longStructuredValue = {
+      output: `${"structured body ".repeat(400)}${codeSentinel}`,
+    };
+
+    render(
+      <BoundedCode
+        collapseLabel={messages.collapseContentAction}
+        expandLabel={messages.expandContentAction}
+        label={messages.toolResultLabel}
+        value={longStructuredValue}
+      />,
     );
+
+    const boundedContent = document.querySelector(
+      "details[data-worker-session-timeline-bounded-content='true']",
+    );
+    if (!(boundedContent instanceof HTMLDetailsElement)) {
+      throw new Error("expected a native bounded content disclosure");
+    }
+    expect(boundedContent.textContent).not.toContain(codeSentinel);
+
+    const boundedSummary = boundedContent.querySelector("summary");
+    if (!boundedSummary) {
+      throw new Error("expected a bounded content summary");
+    }
+    boundedSummary.focus();
+    await user.keyboard("{Enter}");
+
+    expect(boundedContent.open).toBe(true);
+    expect(boundedContent.textContent).toContain(codeSentinel);
   });
 });
 

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline.tsx
@@ -6,7 +6,7 @@ import {
   Text,
 } from "@you-agent-factory/components/primitives";
 import { WidgetDetailCopy } from "@you-agent-factory/components/recipes";
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect, useId, useRef, useState } from "react";
 
 import { AlertPanel } from "../../../components/ui/alert-panel";
 import { DashboardStatusPill } from "../../../components/ui/dashboard-status-pill";
@@ -23,6 +23,10 @@ import type {
 } from "../lib/worker-session-timeline-projection-types";
 import type { WorkerSessionTimelineStreamStatus } from "../lib/worker-session-timeline-stream";
 import {
+  getWorkerSessionTimelineWindow,
+  moveWorkerSessionTimelineWindow,
+} from "../lib/worker-session-timeline-window";
+import {
   getWorkerSessionTimelineMessages,
   type WorkerSessionTimelineMessages,
   type WorkerSessionTimelineRecordingHealth,
@@ -30,6 +34,7 @@ import {
 } from "../messages/worker-session-timeline";
 import { BoundedText } from "./worker-session-timeline-detail-primitives";
 import { WorkerSessionTimelineEntryView } from "./worker-session-timeline-entry";
+import { WorkerSessionTimelineWindowControls } from "./worker-session-timeline-window-controls";
 
 export interface WorkerSessionTimelineProps
   extends UseWorkerSessionTimelineOptions {
@@ -114,11 +119,65 @@ export function WorkerSessionTimelineContent({
   const messages = getWorkerSessionTimelineMessages(locale);
   const terminal = latestTerminal(state.entries);
   const viewStatus = toViewStatus(state.status, state.entries.length);
+  const eventListID = useId();
+  const [followingTail, setFollowingTail] = useState(true);
+  const [requestedWindowStart, setRequestedWindowStart] = useState<
+    number | null
+  >(null);
+  const [tailSeenCount, setTailSeenCount] = useState(state.entries.length);
+  const previousWorkerSessionID = useRef(workerSessionID);
+  const workerSessionChanged =
+    previousWorkerSessionID.current !== workerSessionID;
+  const effectiveFollowingTail = workerSessionChanged || followingTail;
+  const timelineWindow = getWorkerSessionTimelineWindow(
+    state.entries,
+    effectiveFollowingTail ? null : requestedWindowStart,
+  );
+  const pendingLiveCount =
+    state.isFollowing && !workerSessionChanged && !followingTail
+      ? Math.max(0, state.entries.length - tailSeenCount)
+      : 0;
+
+  useEffect(() => {
+    if (previousWorkerSessionID.current === workerSessionID) {
+      return;
+    }
+    previousWorkerSessionID.current = workerSessionID;
+    setFollowingTail(true);
+    setRequestedWindowStart(null);
+    setTailSeenCount(state.entries.length);
+  }, [state.entries.length, workerSessionID]);
+
+  const moveWindow = (direction: "earlier" | "later") => {
+    const nextStart = moveWorkerSessionTimelineWindow(
+      timelineWindow.start,
+      direction,
+      state.entries.length,
+    );
+    const tailStart = getWorkerSessionTimelineWindow(state.entries, null).start;
+    if (followingTail) {
+      setTailSeenCount(state.entries.length);
+    }
+    if (nextStart >= tailStart) {
+      setFollowingTail(true);
+      setRequestedWindowStart(null);
+      return;
+    }
+    setFollowingTail(false);
+    setRequestedWindowStart(nextStart);
+  };
+
+  const returnToLatest = () => {
+    setFollowingTail(true);
+    setRequestedWindowStart(null);
+    setTailSeenCount(state.entries.length);
+  };
 
   return (
     <section
       aria-label={messages.ariaLabel}
-      className={cn("grid min-w-0 gap-3", className)}
+      aria-busy={state.status === "loading" || state.status === "reconnecting"}
+      className={cn("grid min-w-0 gap-3 overflow-x-hidden", className)}
       data-worker-session-timeline-status={viewStatus}
       data-worker-session-timeline-worker-session-id={
         workerSessionID ?? undefined
@@ -139,18 +198,33 @@ export function WorkerSessionTimelineContent({
           state={state}
         />
       ) : null}
+      <WorkerSessionTimelineWindowControls
+        eventListID={eventListID}
+        messages={messages}
+        onMove={moveWindow}
+        onReturnToLatest={returnToLatest}
+        pendingLiveCount={pendingLiveCount}
+        timelineWindow={timelineWindow}
+        totalEntries={state.entries.length}
+      />
       {state.entries.length > 0 ? (
         <ol
           aria-label={messages.eventListLabel}
           className="grid min-w-0 gap-3"
+          data-worker-session-timeline-visible-count={
+            timelineWindow.entries.length
+          }
           data-worker-session-timeline-events="true"
+          id={eventListID}
         >
-          {state.entries.map((entry) => (
+          {timelineWindow.entries.map((entry, index) => (
             <WorkerSessionTimelineEntryView
               entry={entry}
               key={entry.key}
               messages={messages}
               onNavigateToWorkerSession={onNavigateToWorkerSession}
+              position={timelineWindow.start + index + 1}
+              totalEntries={state.entries.length}
             />
           ))}
         </ol>
@@ -231,6 +305,8 @@ function TerminalOutcomeSummary({
       </Text>
       {terminal.failure?.message ? (
         <BoundedText
+          collapseLabel={messages.collapseContentAction}
+          expandLabel={messages.expandContentAction}
           label={messages.failureLabel}
           value={terminal.failure.message}
         />

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline.tsx
@@ -1,0 +1,449 @@
+import { SurfacePanel } from "@you-agent-factory/components/layout";
+import {
+  Button,
+  Heading,
+  Label,
+  Text,
+} from "@you-agent-factory/components/primitives";
+import { WidgetDetailCopy } from "@you-agent-factory/components/recipes";
+import type { ReactNode } from "react";
+
+import { AlertPanel } from "../../../components/ui/alert-panel";
+import { DashboardStatusPill } from "../../../components/ui/dashboard-status-pill";
+import { cn } from "../../../lib/cn";
+import { DashboardWidgetFrame } from "../../bento/components/dashboard-widget-frame/dashboard-widget-frame";
+import {
+  type UseWorkerSessionTimelineOptions,
+  type UseWorkerSessionTimelineResult,
+  useWorkerSessionTimeline,
+} from "../hooks/useWorkerSessionTimeline";
+import type {
+  WorkerSessionTimelineEntry,
+  WorkerTimelineTerminalOutcome,
+} from "../lib/worker-session-timeline-projection-types";
+import type { WorkerSessionTimelineStreamStatus } from "../lib/worker-session-timeline-stream";
+import {
+  getWorkerSessionTimelineMessages,
+  type WorkerSessionTimelineMessages,
+  type WorkerSessionTimelineRecordingHealth,
+  type WorkerSessionTimelineViewStatus,
+} from "../messages/worker-session-timeline";
+import { BoundedText } from "./worker-session-timeline-detail-primitives";
+import { WorkerSessionTimelineEntryView } from "./worker-session-timeline-entry";
+
+export interface WorkerSessionTimelineProps
+  extends UseWorkerSessionTimelineOptions {
+  className?: string;
+  locale?: string;
+  onNavigateToWorkerSession?: (workerSessionID: string) => void;
+  showHeading?: boolean;
+  stateOverride?: UseWorkerSessionTimelineResult;
+}
+
+export interface WorkerSessionTimelineWidgetProps
+  extends WorkerSessionTimelineProps {
+  headerAction?: ReactNode;
+  widgetId?: string;
+}
+
+export function WorkerSessionTimeline({
+  className,
+  locale,
+  onNavigateToWorkerSession,
+  showHeading = true,
+  stateOverride,
+  ...hookOptions
+}: WorkerSessionTimelineProps) {
+  const hookState = useWorkerSessionTimeline(hookOptions);
+  const state = stateOverride ?? hookState;
+
+  return (
+    <WorkerSessionTimelineContent
+      className={className}
+      locale={locale}
+      onNavigateToWorkerSession={onNavigateToWorkerSession}
+      showHeading={showHeading}
+      state={state}
+      workerSessionID={hookOptions.workerSessionID}
+    />
+  );
+}
+
+/** Dashboard chrome for consumers that need a selectable Worker Session card. */
+export function WorkerSessionTimelineWidget({
+  headerAction,
+  locale,
+  widgetId = "worker-session-timeline",
+  ...timelineProps
+}: WorkerSessionTimelineWidgetProps) {
+  const messages = getWorkerSessionTimelineMessages(locale);
+
+  return (
+    <DashboardWidgetFrame
+      bodyScroll={false}
+      headerAction={headerAction}
+      title={messages.timelineTitle}
+      widgetId={widgetId}
+    >
+      <WorkerSessionTimeline
+        {...timelineProps}
+        locale={locale}
+        showHeading={false}
+      />
+    </DashboardWidgetFrame>
+  );
+}
+
+export interface WorkerSessionTimelineContentProps {
+  className?: string;
+  locale?: string;
+  onNavigateToWorkerSession?: (workerSessionID: string) => void;
+  showHeading?: boolean;
+  state: UseWorkerSessionTimelineResult;
+  workerSessionID: string | null;
+}
+
+export function WorkerSessionTimelineContent({
+  className,
+  locale,
+  onNavigateToWorkerSession,
+  showHeading = true,
+  state,
+  workerSessionID,
+}: WorkerSessionTimelineContentProps) {
+  const messages = getWorkerSessionTimelineMessages(locale);
+  const terminal = latestTerminal(state.entries);
+  const viewStatus = toViewStatus(state.status, state.entries.length);
+
+  return (
+    <section
+      aria-label={messages.ariaLabel}
+      className={cn("grid min-w-0 gap-3", className)}
+      data-worker-session-timeline-status={viewStatus}
+      data-worker-session-timeline-worker-session-id={
+        workerSessionID ?? undefined
+      }
+    >
+      {showHeading ? <Heading as="h2">{messages.timelineTitle}</Heading> : null}
+      <TimelineStatus
+        messages={messages}
+        state={state}
+        terminal={terminal}
+        viewStatus={viewStatus}
+      />
+      <RecordingHealthNotice messages={messages} state={state} />
+      {state.status === "source-error" ? (
+        <SourceErrorNotice
+          messages={messages}
+          onRetry={state.retry}
+          state={state}
+        />
+      ) : null}
+      {state.entries.length > 0 ? (
+        <ol
+          aria-label={messages.eventListLabel}
+          className="grid min-w-0 gap-3"
+          data-worker-session-timeline-events="true"
+        >
+          {state.entries.map((entry) => (
+            <WorkerSessionTimelineEntryView
+              entry={entry}
+              key={entry.key}
+              messages={messages}
+              onNavigateToWorkerSession={onNavigateToWorkerSession}
+            />
+          ))}
+        </ol>
+      ) : (
+        <TimelineBodyState
+          messages={messages}
+          state={state}
+          viewStatus={viewStatus}
+        />
+      )}
+    </section>
+  );
+}
+
+function TimelineStatus({
+  messages,
+  state,
+  terminal,
+  viewStatus,
+}: {
+  messages: WorkerSessionTimelineMessages;
+  state: UseWorkerSessionTimelineResult;
+  terminal: WorkerSessionTimelineEntry["terminal"];
+  viewStatus: WorkerSessionTimelineViewStatus;
+}) {
+  const statusLabel = statusMessage(messages, viewStatus);
+
+  return (
+    <div
+      className="grid min-w-0 gap-2"
+      data-worker-session-timeline-status-bar="true"
+    >
+      <div className="flex min-w-0 flex-wrap items-center gap-2">
+        <DashboardStatusPill tone={statusPillTone(viewStatus)}>
+          {statusLabel}
+        </DashboardStatusPill>
+        {terminal ? (
+          <DashboardStatusPill
+            data-worker-session-terminal-outcome={terminal.outcome}
+            tone={terminalTone(terminal.outcome)}
+          >
+            {messages.terminalOutcomeLabel(terminal.outcome)}
+          </DashboardStatusPill>
+        ) : null}
+      </div>
+      <p
+        aria-atomic="true"
+        aria-live="polite"
+        className="m-0 af-supporting-text text-on-surface-subtle"
+      >
+        {statusLabel}
+      </p>
+      {state.entries.length > 0 && terminal ? (
+        <TerminalOutcomeSummary messages={messages} terminal={terminal} />
+      ) : null}
+    </div>
+  );
+}
+
+function TerminalOutcomeSummary({
+  messages,
+  terminal,
+}: {
+  messages: WorkerSessionTimelineMessages;
+  terminal: NonNullable<WorkerSessionTimelineEntry["terminal"]>;
+}) {
+  return (
+    <SurfacePanel
+      aria-label={messages.terminalOutcomeHeading}
+      className="grid min-w-0 gap-2"
+      radius="lg"
+      surface="low"
+    >
+      <Label>{messages.terminalOutcomeHeading}</Label>
+      <Text className="m-0" data-worker-session-terminal-summary="true">
+        {messages.terminalOutcomeLabel(terminal.outcome)}
+        {terminal.status ? ` (${terminal.status})` : ""}
+      </Text>
+      {terminal.failure?.message ? (
+        <BoundedText
+          label={messages.failureLabel}
+          value={terminal.failure.message}
+        />
+      ) : null}
+    </SurfacePanel>
+  );
+}
+
+function RecordingHealthNotice({
+  messages,
+  state,
+}: {
+  messages: WorkerSessionTimelineMessages;
+  state: UseWorkerSessionTimelineResult;
+}) {
+  const health = state.recordingHealth;
+  if (health === null) {
+    return (
+      <div className="flex items-center gap-2">
+        <DashboardStatusPill size="compact" tone="neutral">
+          {messages.recordingHealthPending}
+        </DashboardStatusPill>
+      </div>
+    );
+  }
+
+  const tone = recordingHealthTone(health);
+  return (
+    <AlertPanel
+      role={health === "COMPLETE" ? "status" : "alert"}
+      tone={
+        health === "COMPLETE"
+          ? "info"
+          : tone === "danger"
+            ? "danger"
+            : "warning"
+      }
+    >
+      <div className="grid gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <DashboardStatusPill size="compact" tone={tone}>
+            {messages.recordingHealthLabel(health)}
+          </DashboardStatusPill>
+        </div>
+        <Text className="m-0">
+          {messages.recordingHealthNotice(health, state.recordingHealthReason)}
+        </Text>
+      </div>
+    </AlertPanel>
+  );
+}
+
+function SourceErrorNotice({
+  messages,
+  onRetry,
+  state,
+}: {
+  messages: WorkerSessionTimelineMessages;
+  onRetry: () => void;
+  state: UseWorkerSessionTimelineResult;
+}) {
+  return (
+    <AlertPanel role="alert" tone="danger">
+      <div className="grid gap-3">
+        <div className="grid gap-1">
+          <strong>{messages.sourceErrorHeading}</strong>
+          <Text className="m-0">
+            {state.sourceError?.message ?? messages.sourceErrorHeading}
+          </Text>
+        </div>
+        <div>
+          <Button onClick={onRetry} tone="outline" type="button">
+            {messages.retryAction}
+          </Button>
+        </div>
+      </div>
+    </AlertPanel>
+  );
+}
+
+function TimelineBodyState({
+  messages,
+  state,
+  viewStatus,
+}: {
+  messages: WorkerSessionTimelineMessages;
+  state: UseWorkerSessionTimelineResult;
+  viewStatus: WorkerSessionTimelineViewStatus;
+}) {
+  if (viewStatus === "source-error") {
+    return null;
+  }
+
+  if (viewStatus === "loading" || viewStatus === "reconnecting") {
+    return (
+      <WidgetDetailCopy aria-busy="true" role="status">
+        {statusMessage(messages, viewStatus)}
+      </WidgetDetailCopy>
+    );
+  }
+
+  if (viewStatus === "idle") {
+    return <WidgetDetailCopy>{messages.idleState}</WidgetDetailCopy>;
+  }
+
+  if (viewStatus === "empty") {
+    return <WidgetDetailCopy>{messages.emptyState}</WidgetDetailCopy>;
+  }
+
+  return (
+    <WidgetDetailCopy>
+      {state.status === "live"
+        ? messages.liveFollowingState
+        : messages.completedState}
+    </WidgetDetailCopy>
+  );
+}
+
+function latestTerminal(
+  entries: readonly WorkerSessionTimelineEntry[],
+): WorkerSessionTimelineEntry["terminal"] {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const terminal = entries[index]?.terminal;
+    if (terminal) {
+      return terminal;
+    }
+  }
+  return undefined;
+}
+
+function toViewStatus(
+  status: WorkerSessionTimelineStreamStatus,
+  entryCount: number,
+): WorkerSessionTimelineViewStatus {
+  if (status === "idle") {
+    return "idle";
+  }
+  if (status === "loading") {
+    return "loading";
+  }
+  if (status === "ready-empty") {
+    return "empty";
+  }
+  if (status === "source-error") {
+    return "source-error";
+  }
+  if (status === "reconnecting") {
+    return "reconnecting";
+  }
+  if (status === "completed") {
+    return "completed";
+  }
+  if (status === "live") {
+    return "live";
+  }
+  return entryCount === 0 ? "empty" : "completed";
+}
+
+function statusMessage(
+  messages: WorkerSessionTimelineMessages,
+  status: WorkerSessionTimelineViewStatus,
+): string {
+  switch (status) {
+    case "idle":
+      return messages.idleState;
+    case "loading":
+      return messages.loadingState;
+    case "empty":
+      return messages.emptyState;
+    case "live":
+      return messages.liveFollowingState;
+    case "reconnecting":
+      return messages.reconnectingState;
+    case "completed":
+      return messages.completedState;
+    case "source-error":
+      return messages.sourceErrorHeading;
+  }
+}
+
+function statusPillTone(
+  status: WorkerSessionTimelineViewStatus,
+): "danger" | "info" | "neutral" | "success" | "warning" {
+  switch (status) {
+    case "live":
+      return "success";
+    case "reconnecting":
+      return "warning";
+    case "source-error":
+      return "danger";
+    case "completed":
+      return "neutral";
+    default:
+      return "info";
+  }
+}
+
+function recordingHealthTone(
+  health: WorkerSessionTimelineRecordingHealth,
+): "danger" | "success" | "warning" {
+  return health === "COMPLETE"
+    ? "success"
+    : health === "DEGRADED"
+      ? "warning"
+      : "danger";
+}
+
+function terminalTone(
+  outcome: WorkerTimelineTerminalOutcome,
+): "danger" | "success" | "warning" {
+  return outcome === "SUCCESS"
+    ? "success"
+    : outcome === "FAILURE"
+      ? "danger"
+      : "warning";
+}

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline.tsx
@@ -6,12 +6,11 @@ import {
   Text,
 } from "@you-agent-factory/components/primitives";
 import { WidgetDetailCopy } from "@you-agent-factory/components/recipes";
-import { type ReactNode, useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
 import { AlertPanel } from "../../../components/ui/alert-panel";
 import { DashboardStatusPill } from "../../../components/ui/dashboard-status-pill";
 import { cn } from "../../../lib/cn";
-import { DashboardWidgetFrame } from "../../bento/components/dashboard-widget-frame/dashboard-widget-frame";
 import {
   type UseWorkerSessionTimelineOptions,
   type UseWorkerSessionTimelineResult,
@@ -45,12 +44,6 @@ export interface WorkerSessionTimelineProps
   stateOverride?: UseWorkerSessionTimelineResult;
 }
 
-export interface WorkerSessionTimelineWidgetProps
-  extends WorkerSessionTimelineProps {
-  headerAction?: ReactNode;
-  widgetId?: string;
-}
-
 export function WorkerSessionTimeline({
   className,
   locale,
@@ -71,31 +64,6 @@ export function WorkerSessionTimeline({
       state={state}
       workerSessionID={hookOptions.workerSessionID}
     />
-  );
-}
-
-/** Dashboard chrome for consumers that need a selectable Worker Session card. */
-export function WorkerSessionTimelineWidget({
-  headerAction,
-  locale,
-  widgetId = "worker-session-timeline",
-  ...timelineProps
-}: WorkerSessionTimelineWidgetProps) {
-  const messages = getWorkerSessionTimelineMessages(locale);
-
-  return (
-    <DashboardWidgetFrame
-      bodyScroll={false}
-      headerAction={headerAction}
-      title={messages.timelineTitle}
-      widgetId={widgetId}
-    >
-      <WorkerSessionTimeline
-        {...timelineProps}
-        locale={locale}
-        showHeading={false}
-      />
-    </DashboardWidgetFrame>
   );
 }
 

--- a/ui/src/features/worker-session-timeline/hooks/useWorkerSessionTimeline.bun.component.test.tsx
+++ b/ui/src/features/worker-session-timeline/hooks/useWorkerSessionTimeline.bun.component.test.tsx
@@ -1,0 +1,273 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
+
+import type {
+  OpenWorkerSessionEventStreamOptions,
+  WorkerSessionEventFrame,
+  WorkerSessionEventSourceLike,
+} from "../../../api/worker-sessions";
+import { useWorkerSessionTimeline } from "./useWorkerSessionTimeline";
+
+class TestEventSource implements WorkerSessionEventSourceLike {
+  public onerror: ((event: Event) => void) | null = null;
+  public onopen: ((event: Event) => void) | null = null;
+  public closed = false;
+
+  public constructor(
+    public readonly options: OpenWorkerSessionEventStreamOptions,
+  ) {}
+
+  public addEventListener(): void {}
+
+  public close(): void {
+    this.closed = true;
+  }
+
+  public emitFrame(frame: WorkerSessionEventFrame): void {
+    this.options.onFrame(frame);
+  }
+
+  public emitOpen(): void {
+    this.options.onStatusChange("live", "connected");
+  }
+
+  public emitOffline(message = "disconnected"): void {
+    this.options.onStatusChange("offline", message);
+  }
+}
+
+const streams: TestEventSource[] = [];
+let pendingReconnect: (() => void) | null = null;
+
+function openStream(
+  options: OpenWorkerSessionEventStreamOptions,
+): WorkerSessionEventSourceLike {
+  const stream = new TestEventSource(options);
+  streams.push(stream);
+  options.onStatusChange("connecting", "connecting");
+  return stream;
+}
+
+function scheduleReconnect(callback: () => void): () => void {
+  pendingReconnect = callback;
+  return () => {
+    if (pendingReconnect === callback) {
+      pendingReconnect = null;
+    }
+  };
+}
+
+function record(position: number, workerSessionID = "worker-1") {
+  return {
+    cursor: {
+      position,
+      workerSessionId: workerSessionID,
+      streamGenerationId: "generation-1",
+    },
+    payload: {},
+    position,
+    schemaId: "workers.draft.v1",
+    sourceEventId: `event-${position}`,
+    sourceId: "worker-1",
+    sourceSequence: position,
+    sourceType: "worker_session",
+  } as const;
+}
+
+function frame(
+  delivery: WorkerSessionEventFrame["delivery"],
+  event: WorkerSessionEventFrame["event"],
+  overrides: Partial<WorkerSessionEventFrame> = {},
+): WorkerSessionEventFrame {
+  return {
+    delivery,
+    errorCode: null,
+    errorMessage: null,
+    event,
+    providerSession: { provider: "", kind: "", id: "" },
+    workIds: [],
+    workerSessionId: "worker-1",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  streams.length = 0;
+  pendingReconnect = null;
+});
+
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: stream cases share one deterministic source harness.
+describe("useWorkerSessionTimeline", () => {
+  it("keeps retained and live records in one ordered deduplicated stream", () => {
+    const { result } = renderHook(() =>
+      useWorkerSessionTimeline({
+        factorySessionID: "factory-1",
+        openStream,
+        workerSessionID: "worker-1",
+      }),
+    );
+    const stream = streams[0];
+    if (!stream) {
+      throw new Error("expected Worker Session stream");
+    }
+
+    act(() => {
+      stream.emitOpen();
+      stream.emitFrame(frame("RECORD", record(1)));
+      stream.emitFrame(frame("RECORD", record(2)));
+      stream.emitFrame(frame("RECORD", record(2)));
+    });
+
+    expect(result.current.status).toBe("live");
+    expect(result.current.records.map(({ position }) => position)).toEqual([
+      1, 2,
+    ]);
+    expect(result.current.entries).toHaveLength(2);
+    expect(result.current.reconnectCursor).toEqual({
+      afterPosition: 2,
+      streamGenerationId: "generation-1",
+    });
+  });
+
+  it("reconnects only from the last acknowledged Worker Session cursor", () => {
+    const { result } = renderHook(() =>
+      useWorkerSessionTimeline({
+        factorySessionID: "factory-1",
+        openStream,
+        reconnectDelayMs: 0,
+        scheduleReconnect,
+        workerSessionID: "worker-1",
+      }),
+    );
+    const firstStream = streams[0];
+    if (!firstStream) {
+      throw new Error("expected initial Worker Session stream");
+    }
+
+    act(() => {
+      firstStream.emitFrame(frame("RECORD", record(1)));
+      firstStream.emitOffline();
+    });
+
+    expect(result.current.status).toBe("reconnecting");
+    expect(pendingReconnect).not.toBeNull();
+    act(() => {
+      pendingReconnect?.();
+    });
+
+    expect(streams).toHaveLength(2);
+    expect(streams[1]?.options.reconnect).toEqual({
+      afterPosition: 1,
+      streamGenerationId: "generation-1",
+    });
+  });
+
+  it("preserves records and exposes a safe source failure", () => {
+    const { result } = renderHook(() =>
+      useWorkerSessionTimeline({
+        factorySessionID: "factory-1",
+        openStream,
+        workerSessionID: "worker-1",
+      }),
+    );
+    const stream = streams[0];
+    if (!stream) {
+      throw new Error("expected Worker Session stream");
+    }
+
+    act(() => {
+      stream.emitFrame(frame("RECORD", record(1)));
+      stream.emitFrame(
+        frame("SOURCE_FAILURE", null, {
+          errorCode: "WORKER_SESSION_STREAM_UNAVAILABLE",
+          errorMessage: "history source is unavailable",
+        }),
+      );
+    });
+
+    expect(result.current.status).toBe("source-error");
+    expect(result.current.records).toHaveLength(1);
+    expect(result.current.sourceError).toEqual({
+      code: "SOURCE_FAILURE",
+      message: "history source is unavailable",
+    });
+    expect(pendingReconnect).toBeNull();
+  });
+
+  it("does not reconnect after terminal delivery or finite replay summary", () => {
+    const terminal = renderHook(() =>
+      useWorkerSessionTimeline({
+        factorySessionID: "factory-1",
+        openStream,
+        scheduleReconnect,
+        workerSessionID: "worker-1",
+      }),
+    );
+    const terminalStream = streams[0];
+    if (!terminalStream) {
+      throw new Error("expected terminal Worker Session stream");
+    }
+    act(() => {
+      terminalStream.emitFrame(frame("TERMINAL", record(1)));
+      terminalStream.emitOffline();
+    });
+    expect(terminal.result.current.status).toBe("completed");
+    expect(pendingReconnect).toBeNull();
+
+    terminal.unmount();
+    streams.length = 0;
+    const replay = renderHook(() =>
+      useWorkerSessionTimeline({
+        factorySessionID: "factory-1",
+        openStream,
+        replayOnly: true,
+        workerSessionID: "worker-1",
+      }),
+    );
+    const replayStream = streams[0];
+    if (!replayStream) {
+      throw new Error("expected replay Worker Session stream");
+    }
+    act(() => {
+      replayStream.emitFrame(
+        frame("REPLAY_SUMMARY", null, {
+          recordingHealth: "INCOMPLETE",
+          recordingHealthReason: "RETAINED_HEAD_MOVED",
+          replaySummary: {
+            kind: "replay-summary",
+            complete: false,
+            reason: "ACTIVE",
+            eventsEmitted: 0,
+          },
+        }),
+      );
+      replayStream.emitOffline();
+    });
+    expect(replay.result.current.status).toBe("ready-empty");
+    expect(replay.result.current.recordingHealth).toBe("INCOMPLETE");
+    expect(replay.result.current.replaySummary?.reason).toBe("ACTIVE");
+    expect(pendingReconnect).toBeNull();
+  });
+
+  it("surfaces a cursor scope failure instead of joining another history", () => {
+    const { result } = renderHook(() =>
+      useWorkerSessionTimeline({
+        factorySessionID: "factory-1",
+        openStream,
+        workerSessionID: "worker-1",
+      }),
+    );
+    const stream = streams[0];
+    if (!stream) {
+      throw new Error("expected Worker Session stream");
+    }
+    act(() => {
+      stream.emitFrame(frame("RECORD", record(1)));
+      stream.emitFrame(frame("RECORD", record(2, "worker-2")));
+    });
+
+    expect(result.current.status).toBe("source-error");
+    expect(result.current.sourceError?.code).toBe("CURSOR_FOREIGN");
+    expect(result.current.records).toHaveLength(1);
+  });
+});

--- a/ui/src/features/worker-session-timeline/hooks/useWorkerSessionTimeline.bun.component.test.tsx
+++ b/ui/src/features/worker-session-timeline/hooks/useWorkerSessionTimeline.bun.component.test.tsx
@@ -1,12 +1,16 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
 
 import type {
   OpenWorkerSessionEventStreamOptions,
   WorkerSessionEventFrame,
   WorkerSessionEventSourceLike,
+  WorkerSessionObservation,
 } from "../../../api/worker-sessions";
 import { useWorkerSessionTimeline } from "./useWorkerSessionTimeline";
+import { useWorkerSessionTimelineTarget } from "./useWorkerSessionTimelineTarget";
 
 class TestEventSource implements WorkerSessionEventSourceLike {
   public onerror: ((event: Event) => void) | null = null;
@@ -271,3 +275,90 @@ describe("useWorkerSessionTimeline", () => {
     expect(result.current.records).toHaveLength(1);
   });
 });
+
+describe("useWorkerSessionTimelineTarget", () => {
+  it("loads Worker Session targets for the selected Work and selects the first server-ordered attempt", async () => {
+    const loadTargets = vi
+      .fn()
+      .mockResolvedValue([
+        observation("worker-1", "attempt-1"),
+        observation("worker-2", "attempt-2"),
+      ]);
+
+    const { result } = renderHook(
+      () =>
+        useWorkerSessionTimelineTarget({
+          factorySessionID: "factory-1",
+          loadTargets,
+          workID: "work-1",
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("ready");
+    });
+
+    expect(loadTargets).toHaveBeenCalledWith(
+      expect.objectContaining({
+        factorySessionID: "factory-1",
+        workID: "work-1",
+      }),
+    );
+    expect(result.current.selectedWorkerSessionID).toBe("worker-1");
+
+    act(() => {
+      result.current.setSelectedWorkerSessionID("worker-2");
+    });
+    expect(result.current.selectedWorkerSessionID).toBe("worker-2");
+  });
+
+  it("does not query until both the Factory Session and Work are selected", () => {
+    const loadTargets = vi.fn();
+
+    const { result } = renderHook(
+      () =>
+        useWorkerSessionTimelineTarget({
+          factorySessionID: null,
+          loadTargets,
+          workID: null,
+        }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    expect(result.current.status).toBe("idle");
+    expect(loadTargets).not.toHaveBeenCalled();
+  });
+});
+
+function createQueryWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function QueryWrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function observation(
+  workerSessionId: string,
+  attemptId: string,
+): WorkerSessionObservation {
+  return {
+    attemptId,
+    direct: false,
+    durationBasis: "UNAVAILABLE",
+    durationMillis: null,
+    endedAt: null,
+    parse: { errors: [], ignored: 0 },
+    providerSessionAvailable: false,
+    startedAt: null,
+    state: "RUNNING",
+    transcript: "AVAILABLE",
+    turnId: null,
+    workIds: ["work-1"],
+    workerSessionId,
+  } as WorkerSessionObservation;
+}

--- a/ui/src/features/worker-session-timeline/hooks/useWorkerSessionTimeline.ts
+++ b/ui/src/features/worker-session-timeline/hooks/useWorkerSessionTimeline.ts
@@ -1,0 +1,297 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  type OpenWorkerSessionEventStreamOptions,
+  openWorkerSessionEventStream,
+  type WorkerSessionEventFrame,
+  type WorkerSessionEventReconnectCursor,
+  type WorkerSessionEventSourceLike,
+  type WorkerSessionEventStreamStatus,
+} from "../../../api/worker-sessions";
+import {
+  projectWorkerSessionTimeline,
+  type WorkerSessionTimelineEntry,
+} from "../lib/worker-session-timeline-projection";
+import {
+  applyWorkerSessionTimelineFrame,
+  applyWorkerSessionTimelineParseFailure,
+  applyWorkerSessionTimelineTransportFailure,
+  createWorkerSessionTimelineStreamState,
+  markWorkerSessionTimelineStreamLive,
+  markWorkerSessionTimelineStreamReconnecting,
+  type WorkerSessionTimelineStreamContext,
+  type WorkerSessionTimelineStreamState,
+  workerSessionTimelineReconnectCursor,
+  workerSessionTimelineStreamCanFollow,
+} from "../lib/worker-session-timeline-stream";
+
+export type WorkerSessionTimelineOpenStream = (
+  options: OpenWorkerSessionEventStreamOptions,
+) => WorkerSessionEventSourceLike | null;
+
+export type WorkerSessionTimelineReconnectScheduler = (
+  callback: () => void,
+  delayMs: number,
+) => () => void;
+
+export interface UseWorkerSessionTimelineOptions {
+  factorySessionID: string | null;
+  workerSessionID: string | null;
+  enabled?: boolean;
+  replayOnly?: boolean;
+  initialReconnectCursor?: WorkerSessionEventReconnectCursor | null;
+  openStream?: WorkerSessionTimelineOpenStream;
+  reconnectDelayMs?: number;
+  scheduleReconnect?: WorkerSessionTimelineReconnectScheduler;
+}
+
+export interface UseWorkerSessionTimelineResult
+  extends WorkerSessionTimelineStreamState {
+  entries: WorkerSessionTimelineEntry[];
+  isFollowing: boolean;
+  reconnectCursor: WorkerSessionEventReconnectCursor | null;
+  retry: () => void;
+}
+
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
+
+const defaultScheduleReconnect: WorkerSessionTimelineReconnectScheduler = (
+  callback,
+  delayMs,
+) => {
+  const handle = globalThis.setTimeout(callback, delayMs);
+  return () => globalThis.clearTimeout(handle);
+};
+
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: stream lifecycle wiring stays with its single owning hook.
+export function useWorkerSessionTimeline({
+  factorySessionID,
+  workerSessionID,
+  enabled = true,
+  replayOnly = false,
+  initialReconnectCursor = null,
+  openStream = openWorkerSessionEventStream,
+  reconnectDelayMs = DEFAULT_RECONNECT_DELAY_MS,
+  scheduleReconnect = defaultScheduleReconnect,
+}: UseWorkerSessionTimelineOptions): UseWorkerSessionTimelineResult {
+  const initialAfterPosition = initialReconnectCursor?.afterPosition;
+  const initialGenerationID = initialReconnectCursor?.streamGenerationId;
+  const stableInitialReconnectCursor = useMemo(
+    () =>
+      initialAfterPosition === undefined
+        ? null
+        : {
+            afterPosition: initialAfterPosition,
+            ...(initialGenerationID
+              ? { streamGenerationId: initialGenerationID }
+              : {}),
+          },
+    [initialAfterPosition, initialGenerationID],
+  );
+  const [state, setState] = useState<WorkerSessionTimelineStreamState>(() =>
+    createWorkerSessionTimelineStreamState(stableInitialReconnectCursor),
+  );
+  const stateRef = useRef(state);
+  const openStreamRef = useRef<WorkerSessionTimelineOpenStream>(openStream);
+  const scheduleReconnectRef =
+    useRef<WorkerSessionTimelineReconnectScheduler>(scheduleReconnect);
+  const connectRef = useRef<(() => void) | null>(null);
+  const cancelReconnectRef = useRef<(() => void) | null>(null);
+
+  openStreamRef.current = openStream;
+  scheduleReconnectRef.current = scheduleReconnect;
+  stateRef.current = state;
+
+  // biome-ignore lint/complexity/noExcessiveLinesPerFunction: one connection owns open, reconnect, terminal, and cleanup transitions.
+  useEffect(() => {
+    let disposed = false;
+    const connectionRef: { current: WorkerSessionEventSourceLike | null } = {
+      current: null,
+    };
+    const context: WorkerSessionTimelineStreamContext = {
+      workerSessionID: workerSessionID ?? "",
+      initialReconnectCursor: stableInitialReconnectCursor,
+    };
+    const targetIsReady =
+      enabled && factorySessionID !== null && workerSessionID !== null;
+    const attemptState = targetIsReady
+      ? createWorkerSessionTimelineStreamState(stableInitialReconnectCursor)
+      : {
+          ...createWorkerSessionTimelineStreamState(null),
+          status: "idle" as const,
+        };
+    stateRef.current = attemptState;
+    setState(attemptState);
+    cancelReconnectRef.current?.();
+    cancelReconnectRef.current = null;
+
+    const closeCurrentStream = () => {
+      connectionRef.current?.close();
+      connectionRef.current = null;
+    };
+
+    if (!targetIsReady) {
+      connectRef.current = null;
+      closeCurrentStream();
+      return () => {
+        disposed = true;
+        closeCurrentStream();
+      };
+    }
+
+    const updateState = (nextState: WorkerSessionTimelineStreamState) => {
+      if (disposed) {
+        return;
+      }
+      stateRef.current = nextState;
+      setState(nextState);
+    };
+
+    const scheduleReconnectAttempt = () => {
+      if (disposed || cancelReconnectRef.current !== null) {
+        return;
+      }
+      const reconnectCursor = workerSessionTimelineReconnectCursor(
+        stateRef.current,
+      );
+      if (reconnectCursor === null) {
+        return;
+      }
+      const nextState = markWorkerSessionTimelineStreamReconnecting(
+        stateRef.current,
+      );
+      updateState(nextState);
+      cancelReconnectRef.current = scheduleReconnectRef.current(() => {
+        cancelReconnectRef.current = null;
+        connectRef.current?.();
+      }, reconnectDelayMs);
+    };
+
+    const handleTransportStatus = (
+      streamStatus: WorkerSessionEventStreamStatus,
+      message: string,
+    ) => {
+      if (disposed) {
+        return;
+      }
+      if (streamStatus === "live") {
+        updateState(markWorkerSessionTimelineStreamLive(stateRef.current));
+        return;
+      }
+      if (streamStatus === "reconnecting" || streamStatus === "connecting") {
+        if (streamStatus === "reconnecting") {
+          updateState(
+            markWorkerSessionTimelineStreamReconnecting(stateRef.current),
+          );
+        }
+        return;
+      }
+
+      closeCurrentStream();
+      const failure = applyWorkerSessionTimelineTransportFailure(
+        stateRef.current,
+        message,
+      );
+      updateState(failure.state);
+      if (failure.shouldReconnect) {
+        scheduleReconnectAttempt();
+      }
+    };
+
+    const handleFrame = (frame: WorkerSessionEventFrame) => {
+      if (disposed) {
+        return;
+      }
+      const transition = applyWorkerSessionTimelineFrame(
+        stateRef.current,
+        frame,
+        context,
+      );
+      updateState(transition.state);
+      if (transition.shouldStop) {
+        cancelReconnectRef.current?.();
+        cancelReconnectRef.current = null;
+        closeCurrentStream();
+      }
+    };
+
+    const handleParseError = (message: string) => {
+      if (disposed) {
+        return;
+      }
+      closeCurrentStream();
+      updateState(
+        applyWorkerSessionTimelineParseFailure(stateRef.current, message),
+      );
+    };
+
+    const connect = () => {
+      if (disposed || !workerSessionTimelineStreamCanFollow(stateRef.current)) {
+        return;
+      }
+      closeCurrentStream();
+      const reconnect = workerSessionTimelineReconnectCursor(stateRef.current);
+      connectionRef.current = openStreamRef.current({
+        factorySessionID,
+        workerSessionID,
+        replayOnly,
+        reconnect,
+        onFrame: handleFrame,
+        onError: (error) => handleParseError(error.message),
+        onStatusChange: handleTransportStatus,
+      });
+    };
+    connectRef.current = connect;
+    connect();
+
+    return () => {
+      disposed = true;
+      connectRef.current = null;
+      cancelReconnectRef.current?.();
+      cancelReconnectRef.current = null;
+      closeCurrentStream();
+    };
+  }, [
+    enabled,
+    factorySessionID,
+    replayOnly,
+    reconnectDelayMs,
+    workerSessionID,
+    stableInitialReconnectCursor,
+  ]);
+
+  const retry = useCallback(() => {
+    const currentState = stateRef.current;
+    if (
+      currentState.terminalDelivery !== null ||
+      currentState.replaySummary !== null ||
+      factorySessionID === null ||
+      workerSessionID === null
+    ) {
+      return;
+    }
+    const retryState: WorkerSessionTimelineStreamState = {
+      ...currentState,
+      status: currentState.records.length > 0 ? "reconnecting" : "loading",
+      sourceError: null,
+    };
+    stateRef.current = retryState;
+    setState(retryState);
+    cancelReconnectRef.current?.();
+    cancelReconnectRef.current = null;
+    connectRef.current?.();
+  }, [factorySessionID, workerSessionID]);
+
+  const entries = useMemo(
+    () => projectWorkerSessionTimeline(state.records),
+    [state.records],
+  );
+
+  return {
+    ...state,
+    entries,
+    isFollowing: state.status === "live" || state.status === "reconnecting",
+    reconnectCursor: workerSessionTimelineReconnectCursor(state),
+    retry,
+  };
+}

--- a/ui/src/features/worker-session-timeline/hooks/useWorkerSessionTimelineTarget.ts
+++ b/ui/src/features/worker-session-timeline/hooks/useWorkerSessionTimelineTarget.ts
@@ -1,0 +1,102 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import type { WorkerSessionObservation } from "../../../api/worker-sessions";
+import {
+  type ListWorkerSessionsForWorkOptions,
+  listWorkerSessionsForWork,
+  type WorkerSessionObservationAPIError,
+} from "../../../api/worker-sessions";
+
+export type WorkerSessionTimelineTargetLoader = (
+  options: ListWorkerSessionsForWorkOptions,
+) => Promise<WorkerSessionObservation[]>;
+
+export type WorkerSessionTimelineTargetStatus =
+  | "idle"
+  | "loading"
+  | "ready"
+  | "error";
+
+export interface UseWorkerSessionTimelineTargetOptions {
+  factorySessionID: string | null;
+  workID: string | null;
+  enabled?: boolean;
+  loadTargets?: WorkerSessionTimelineTargetLoader;
+}
+
+export interface UseWorkerSessionTimelineTargetResult {
+  error: WorkerSessionObservationAPIError | null;
+  observations: WorkerSessionObservation[];
+  refetch: () => void;
+  selectedWorkerSessionID: string | null;
+  setSelectedWorkerSessionID: (workerSessionID: string) => void;
+  status: WorkerSessionTimelineTargetStatus;
+}
+
+export function useWorkerSessionTimelineTarget({
+  factorySessionID,
+  workID,
+  enabled = true,
+  loadTargets = listWorkerSessionsForWork,
+}: UseWorkerSessionTimelineTargetOptions): UseWorkerSessionTimelineTargetResult {
+  const targetIsReady = enabled && factorySessionID !== null && workID !== null;
+  const query = useQuery({
+    enabled: targetIsReady,
+    queryFn: ({ signal }) => {
+      if (factorySessionID === null || workID === null) {
+        throw new Error("Worker Session target scope is required.");
+      }
+      return loadTargets({ factorySessionID, signal, workID });
+    },
+    queryKey: ["worker-session-timeline-target", factorySessionID, workID],
+    refetchOnWindowFocus: false,
+    retry: false,
+  });
+  const [selectedWorkerSessionID, setSelectedWorkerSessionID] = useState<
+    string | null
+  >(null);
+
+  useEffect(() => {
+    const firstObservation = query.data?.[0];
+    if (
+      firstObservation === undefined ||
+      query.data?.some(
+        (observation) =>
+          observation.workerSessionId === selectedWorkerSessionID,
+      )
+    ) {
+      return;
+    }
+    setSelectedWorkerSessionID(firstObservation.workerSessionId);
+  }, [query.data, selectedWorkerSessionID]);
+
+  const status: WorkerSessionTimelineTargetStatus = !targetIsReady
+    ? "idle"
+    : query.isPending
+      ? "loading"
+      : query.isError
+        ? "error"
+        : "ready";
+  const resolvedSelectedWorkerSessionID = targetIsReady
+    ? (query.data?.find(
+        (observation) =>
+          observation.workerSessionId === selectedWorkerSessionID,
+      )?.workerSessionId ??
+      query.data?.[0]?.workerSessionId ??
+      null)
+    : null;
+
+  return {
+    error:
+      query.error instanceof Error
+        ? (query.error as WorkerSessionObservationAPIError)
+        : null,
+    observations: query.data ?? [],
+    refetch: () => {
+      void query.refetch();
+    },
+    selectedWorkerSessionID: resolvedSelectedWorkerSessionID,
+    setSelectedWorkerSessionID,
+    status,
+  };
+}

--- a/ui/src/features/worker-session-timeline/lib/worker-session-timeline-projection-details.ts
+++ b/ui/src/features/worker-session-timeline/lib/worker-session-timeline-projection-details.ts
@@ -341,10 +341,13 @@ export function terminalOutcomeFor(
   }
   switch (phase) {
     case "COMPLETED":
+      // hardcoded-ui-copy-exception: non-product-diagnostic
       return "SUCCESS";
     case "FAILED":
+      // hardcoded-ui-copy-exception: non-product-diagnostic
       return "FAILURE";
     case "CANCELED":
+      // hardcoded-ui-copy-exception: non-product-diagnostic
       return "CANCELED";
     default:
       break;
@@ -357,13 +360,16 @@ export function terminalOutcomeFor(
     case "COMPLETED":
     case "SUCCEEDED":
     case "SUCCESS":
+      // hardcoded-ui-copy-exception: non-product-diagnostic
       return "SUCCESS";
     case "FAILED":
     case "FAILURE":
     case "ERROR":
+      // hardcoded-ui-copy-exception: non-product-diagnostic
       return "FAILURE";
     case "CANCELED":
     case "CANCELLED":
+      // hardcoded-ui-copy-exception: non-product-diagnostic
       return "CANCELED";
     default:
       return undefined;

--- a/ui/src/features/worker-session-timeline/lib/worker-session-timeline-projection-details.ts
+++ b/ui/src/features/worker-session-timeline/lib/worker-session-timeline-projection-details.ts
@@ -1,0 +1,371 @@
+import {
+  asObject,
+  booleanValue,
+  copyJSONValue,
+  finiteNumber,
+  firstString,
+  hasKeys,
+  optionalString,
+} from "./worker-session-timeline-projection-helpers";
+import type {
+  WorkerTimelineAttempt,
+  WorkerTimelineContentBlock,
+  WorkerTimelineContinuation,
+  WorkerTimelineEntryCategory,
+  WorkerTimelineFailure,
+  WorkerTimelineIdentity,
+  WorkerTimelineJSONObject,
+  WorkerTimelineMessage,
+  WorkerTimelineMessageDelta,
+  WorkerTimelineProviderSession,
+  WorkerTimelineReasoning,
+  WorkerTimelineTerminalOutcome,
+  WorkerTimelineTool,
+  WorkerTimelineUsage,
+} from "./worker-session-timeline-projection-types";
+
+export function categoryForKind(kind: string): WorkerTimelineEntryCategory {
+  switch (kind) {
+    case "SESSION":
+      return "session";
+    case "RUN":
+      return "run";
+    case "TURN":
+      return "turn";
+    case "MESSAGE":
+      return "message";
+    case "REASONING":
+      return "reasoning";
+    case "TOOL":
+      return "tool";
+    case "FILE_CHANGE":
+      return "file-change";
+    case "PLAN":
+      return "plan";
+    case "PROGRESS":
+      return "progress";
+    case "USAGE":
+      return "usage";
+    case "ERROR":
+      return "error";
+    case "STREAM_GAP":
+      return "stream-gap";
+    default:
+      return "generic";
+  }
+}
+
+export function projectIdentity(
+  envelope: WorkerTimelineJSONObject | undefined,
+  payload: WorkerTimelineJSONObject,
+  usage: WorkerTimelineUsage | undefined,
+): WorkerTimelineIdentity | undefined {
+  const provenance = asObject(envelope?.provenance);
+  const providerSelection = asObject(payload.providerSelection);
+  const modelProvider = firstString(
+    providerSelection?.modelProvider,
+    payload.modelProvider,
+  );
+  const executorProvider = firstString(
+    providerSelection?.executorProvider,
+    payload.executorProvider,
+  );
+  const provider = firstString(
+    payload.provider,
+    provenance?.provider,
+    modelProvider,
+    executorProvider,
+  );
+  const model = firstString(payload.model, usage?.model);
+  const identity: WorkerTimelineIdentity = {
+    ...(provider !== undefined ? { provider } : {}),
+    ...(modelProvider !== undefined ? { modelProvider } : {}),
+    ...(executorProvider !== undefined ? { executorProvider } : {}),
+    ...(model !== undefined ? { model } : {}),
+  };
+  return hasKeys(identity) ? identity : undefined;
+}
+
+export function projectAttempt(
+  envelope: WorkerTimelineJSONObject | undefined,
+  payload: WorkerTimelineJSONObject,
+): WorkerTimelineAttempt | undefined {
+  const id = firstString(
+    payload.attemptId,
+    envelope?.attemptId,
+    envelope?.dispatchId,
+  );
+  const number = finiteNumber(payload.attempt);
+  const reason = firstString(
+    payload.attemptReason,
+    payload.retryReason,
+    payload.reason,
+  );
+  const dispatchId = firstString(payload.dispatchId, envelope?.dispatchId);
+  const turnId = firstString(payload.turnId, envelope?.turnId);
+  const status = optionalString(payload.status);
+  const attempt: WorkerTimelineAttempt = {
+    ...(id !== undefined ? { id } : {}),
+    ...(number !== undefined ? { number } : {}),
+    ...(reason !== undefined ? { reason } : {}),
+    ...(dispatchId !== undefined ? { dispatchId } : {}),
+    ...(turnId !== undefined ? { turnId } : {}),
+    ...(status !== undefined ? { status } : {}),
+  };
+  return hasKeys(attempt) ? attempt : undefined;
+}
+
+export function projectContinuation(
+  payload: WorkerTimelineJSONObject,
+): WorkerTimelineContinuation | undefined {
+  const continuation = asObject(payload.continuation);
+  const lineage = asObject(payload.lineage);
+  const providerSession = projectProviderSession(continuation);
+  const predecessorWorkerSessionId = firstString(
+    lineage?.predecessorWorkerSessionId,
+    payload.predecessorWorkerSessionId,
+  );
+  const successorWorkerSessionId = firstString(
+    lineage?.successorWorkerSessionId,
+    payload.successorWorkerSessionId,
+  );
+  const previousDispatchId = firstString(
+    lineage?.previousDispatchId,
+    payload.previousDispatchId,
+  );
+  const previousAttemptId = firstString(
+    lineage?.previousAttemptId,
+    payload.previousAttemptId,
+  );
+  const links: WorkerTimelineContinuation = {
+    ...(providerSession !== undefined ? { providerSession } : {}),
+    ...(predecessorWorkerSessionId !== undefined
+      ? { predecessorWorkerSessionId }
+      : {}),
+    ...(successorWorkerSessionId !== undefined
+      ? { successorWorkerSessionId }
+      : {}),
+    ...(previousDispatchId !== undefined ? { previousDispatchId } : {}),
+    ...(previousAttemptId !== undefined ? { previousAttemptId } : {}),
+  };
+  return hasKeys(links) ? links : undefined;
+}
+
+function projectProviderSession(
+  value: WorkerTimelineJSONObject | undefined,
+): WorkerTimelineProviderSession | undefined {
+  const provider = optionalString(value?.provider);
+  const kind = optionalString(value?.kind);
+  const id = optionalString(value?.id);
+  if (provider === undefined || kind === undefined || id === undefined) {
+    return undefined;
+  }
+  return { provider, kind, id };
+}
+
+export function projectMessage(
+  payload: WorkerTimelineJSONObject,
+): WorkerTimelineMessage | undefined {
+  const role = optionalString(payload.role);
+  const partial = booleanValue(payload.partial);
+  const contentBlocks = projectContentBlocks(payload.contentBlocks);
+  const delta = projectMessageDelta(payload);
+  const text = contentBlocks
+    ?.map((block) => block.text ?? "")
+    .filter((blockText) => blockText.length > 0)
+    .join("");
+  const message: WorkerTimelineMessage = {
+    ...(role !== undefined ? { role } : {}),
+    ...(contentBlocks !== undefined ? { contentBlocks } : {}),
+    ...(text !== undefined && text.length > 0 ? { text } : {}),
+    ...(partial !== undefined ? { partial } : {}),
+    ...(delta !== undefined ? { delta } : {}),
+  };
+  return hasKeys(message) ? message : undefined;
+}
+
+function projectMessageDelta(
+  payload: WorkerTimelineJSONObject,
+): WorkerTimelineMessageDelta | undefined {
+  const contentBlockIndex = finiteNumber(payload.contentBlockIndex);
+  const contentBlockKind = optionalString(payload.contentBlockKind);
+  const textDelta = optionalString(payload.textDelta);
+  const delta: WorkerTimelineMessageDelta = {
+    ...(contentBlockIndex !== undefined ? { contentBlockIndex } : {}),
+    ...(contentBlockKind !== undefined ? { contentBlockKind } : {}),
+    ...(textDelta !== undefined ? { textDelta } : {}),
+  };
+  return hasKeys(delta) ? delta : undefined;
+}
+
+function projectContentBlocks(
+  value: unknown,
+): WorkerTimelineContentBlock[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const blocks = value
+    .map((candidate) => {
+      const block = asObject(candidate);
+      const kind = optionalString(block?.kind);
+      const text = optionalString(block?.text);
+      const toolCallId = optionalString(block?.toolCallId);
+      const toolName = optionalString(block?.toolName);
+      const imageRef = optionalString(block?.imageRef);
+      const resourceRef = optionalString(block?.resourceRef);
+      const argumentsSummary = copyJSONValue(block?.argumentsSummary);
+      const structuredOutput = copyJSONValue(block?.structuredOutput);
+      if (kind === undefined) {
+        return undefined;
+      }
+      return {
+        kind,
+        ...(text !== undefined ? { text } : {}),
+        ...(toolCallId !== undefined ? { toolCallId } : {}),
+        ...(toolName !== undefined ? { toolName } : {}),
+        ...(argumentsSummary !== undefined ? { argumentsSummary } : {}),
+        ...(imageRef !== undefined ? { imageRef } : {}),
+        ...(resourceRef !== undefined ? { resourceRef } : {}),
+        ...(structuredOutput !== undefined ? { structuredOutput } : {}),
+      } satisfies WorkerTimelineContentBlock;
+    })
+    .filter(
+      (block): block is WorkerTimelineContentBlock => block !== undefined,
+    );
+  return blocks;
+}
+
+export function projectReasoning(
+  phase: string,
+  payload: WorkerTimelineJSONObject,
+): WorkerTimelineReasoning | undefined {
+  const summary = optionalString(payload.summary);
+  const summaryDelta = optionalString(payload.summaryDelta);
+  const reasoning: WorkerTimelineReasoning = {
+    ...(summary !== undefined ? { summary } : {}),
+    ...(summaryDelta !== undefined ? { summaryDelta } : {}),
+    ...(summaryDelta !== undefined || phase === "DELTA"
+      ? { representation: "DELTA" }
+      : summary !== undefined
+        ? { representation: "SNAPSHOT" }
+        : {}),
+  };
+  return hasKeys(reasoning) ? reasoning : undefined;
+}
+
+export function projectTool(
+  payload: WorkerTimelineJSONObject,
+): WorkerTimelineTool | undefined {
+  const toolCallId = optionalString(payload.toolCallId);
+  const toolName = optionalString(payload.toolName);
+  const status = optionalString(payload.status);
+  const outputDelta = optionalString(payload.outputDelta);
+  const argumentsSummary = copyJSONValue(payload.argumentsSummary);
+  const resultSummary = copyJSONValue(payload.resultSummary);
+  const tool: WorkerTimelineTool = {
+    ...(toolCallId !== undefined ? { toolCallId } : {}),
+    ...(toolName !== undefined ? { toolName } : {}),
+    ...(status !== undefined ? { status } : {}),
+    ...(argumentsSummary !== undefined ? { argumentsSummary } : {}),
+    ...(resultSummary !== undefined ? { resultSummary } : {}),
+    ...(outputDelta !== undefined ? { outputDelta } : {}),
+  };
+  return hasKeys(tool) ? tool : undefined;
+}
+
+export function projectUsage(
+  payload: WorkerTimelineJSONObject,
+): WorkerTimelineUsage | undefined {
+  const inputTokens = finiteNumber(payload.inputTokens);
+  const cachedInputTokens = finiteNumber(payload.cachedInputTokens);
+  const cacheWriteTokens = finiteNumber(payload.cacheWriteTokens);
+  const outputTokens = finiteNumber(payload.outputTokens);
+  const reasoningOutputTokens = finiteNumber(payload.reasoningOutputTokens);
+  const totalTokens = finiteNumber(payload.totalTokens);
+  const model = optionalString(payload.model);
+  const usage: WorkerTimelineUsage = {
+    ...(inputTokens !== undefined ? { inputTokens } : {}),
+    ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
+    ...(cacheWriteTokens !== undefined ? { cacheWriteTokens } : {}),
+    ...(outputTokens !== undefined ? { outputTokens } : {}),
+    ...(reasoningOutputTokens !== undefined ? { reasoningOutputTokens } : {}),
+    ...(totalTokens !== undefined ? { totalTokens } : {}),
+    ...(model !== undefined ? { model } : {}),
+  };
+  return hasKeys(usage) ? usage : undefined;
+}
+
+export function projectFailure(
+  kind: string,
+  payload: WorkerTimelineJSONObject,
+): WorkerTimelineFailure | undefined {
+  const failureKind = firstString(
+    payload.kind,
+    payload.failureKind,
+    payload.failureCause,
+  );
+  const code = firstString(
+    payload.code,
+    payload.errorCode,
+    payload.agentRunFailureClass,
+  );
+  const message = firstString(
+    payload.message,
+    payload.failureDetail,
+    payload.errorMessage,
+  );
+  const retryable = booleanValue(payload.retryable);
+  const retryAfterSeconds = finiteNumber(payload.retryAfterSeconds);
+  const retryAttempt = finiteNumber(payload.retryAttempt);
+  const failure: WorkerTimelineFailure = {
+    ...(failureKind !== undefined ? { kind: failureKind } : {}),
+    ...(code !== undefined ? { code } : {}),
+    ...(message !== undefined ? { message } : {}),
+    ...(retryable !== undefined ? { retryable } : {}),
+    ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
+    ...(retryAttempt !== undefined ? { retryAttempt } : {}),
+  };
+  if (kind !== "ERROR" && !hasKeys(failure)) {
+    return undefined;
+  }
+  return hasKeys(failure) ? failure : undefined;
+}
+
+export function terminalOutcomeFor(
+  kind: string,
+  phase: string,
+  payload: WorkerTimelineJSONObject,
+): WorkerTimelineTerminalOutcome | undefined {
+  if (kind !== "SESSION" && kind !== "RUN" && kind !== "TURN") {
+    return undefined;
+  }
+  switch (phase) {
+    case "COMPLETED":
+      return "SUCCESS";
+    case "FAILED":
+      return "FAILURE";
+    case "CANCELED":
+      return "CANCELED";
+    default:
+      break;
+  }
+  switch (
+    String(payload.status ?? "")
+      .trim()
+      .toUpperCase()
+  ) {
+    case "COMPLETED":
+    case "SUCCEEDED":
+    case "SUCCESS":
+      return "SUCCESS";
+    case "FAILED":
+    case "FAILURE":
+    case "ERROR":
+      return "FAILURE";
+    case "CANCELED":
+    case "CANCELLED":
+      return "CANCELED";
+    default:
+      return undefined;
+  }
+}

--- a/ui/src/features/worker-session-timeline/lib/worker-session-timeline-projection-helpers.ts
+++ b/ui/src/features/worker-session-timeline/lib/worker-session-timeline-projection-helpers.ts
@@ -1,0 +1,102 @@
+import type {
+  WorkerSessionEventRecord,
+  WorkerTimelineGenericMetadata,
+  WorkerTimelineJSONObject,
+  WorkerTimelineJSONValue,
+} from "./worker-session-timeline-projection-types";
+
+export const MAX_GENERIC_PAYLOAD_KEYS = 16;
+
+export function asObject(value: unknown): WorkerTimelineJSONObject | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as WorkerTimelineJSONObject;
+}
+
+export function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+export function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const result = optionalString(value);
+    if (result !== undefined) {
+      return result;
+    }
+  }
+  return undefined;
+}
+
+export function normalizedToken(value: unknown): string | undefined {
+  const result = optionalString(value);
+  return result?.toUpperCase();
+}
+
+export function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+export function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+export function copyJSONValue(
+  value: unknown,
+): WorkerTimelineJSONValue | undefined {
+  if (value === null) {
+    return null;
+  }
+  if (typeof value === "string" || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (Array.isArray(value)) {
+    const copy: WorkerTimelineJSONValue[] = [];
+    for (const item of value) {
+      const itemCopy = copyJSONValue(item);
+      if (itemCopy !== undefined) {
+        copy.push(itemCopy);
+      }
+    }
+    return copy;
+  }
+  const object = asObject(value);
+  if (object === undefined) {
+    return undefined;
+  }
+  const copy: { [key: string]: WorkerTimelineJSONValue } = {};
+  for (const key of Object.keys(object).sort()) {
+    const itemCopy = copyJSONValue(object[key]);
+    if (itemCopy !== undefined) {
+      copy[key] = itemCopy;
+    }
+  }
+  return copy;
+}
+
+export function hasKeys(value: object): boolean {
+  return Object.keys(value).length > 0;
+}
+
+export function genericMetadata(
+  record: WorkerSessionEventRecord,
+): WorkerTimelineGenericMetadata {
+  const payload = asObject(record.payload);
+  const payloadKeys = payload === undefined ? [] : Object.keys(payload).sort();
+  return {
+    schemaId: record.schemaId,
+    sourceType: record.sourceType,
+    sourceId: record.sourceId,
+    sourceSequence: record.sourceSequence,
+    payloadKeys: payloadKeys.slice(0, MAX_GENERIC_PAYLOAD_KEYS),
+    payloadKeyCount: payloadKeys.length,
+    payloadKeysTruncated: payloadKeys.length > MAX_GENERIC_PAYLOAD_KEYS,
+  };
+}

--- a/ui/src/features/worker-session-timeline/lib/worker-session-timeline-projection-types.ts
+++ b/ui/src/features/worker-session-timeline/lib/worker-session-timeline-projection-types.ts
@@ -1,0 +1,171 @@
+import type { components } from "../../../api/generated/openapi";
+
+export type WorkerSessionEventRecord =
+  components["schemas"]["WorkerSessionEventRecord"];
+
+export type WorkerTimelineJSONObject = Record<string, unknown>;
+
+export type WorkerTimelineJSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | WorkerTimelineJSONValue[]
+  | { [key: string]: WorkerTimelineJSONValue };
+
+export type WorkerTimelineEntryCategory =
+  | "session"
+  | "run"
+  | "turn"
+  | "message"
+  | "reasoning"
+  | "tool"
+  | "file-change"
+  | "plan"
+  | "progress"
+  | "usage"
+  | "error"
+  | "stream-gap"
+  | "generic";
+
+export type WorkerTimelineTerminalOutcome = "SUCCESS" | "FAILURE" | "CANCELED";
+
+export interface WorkerTimelineCanonicalSource {
+  position: number;
+  cursor: {
+    position: number;
+    workerSessionId?: string;
+    streamGenerationId?: string;
+  };
+  sourceType: string;
+  sourceId: string;
+  sourceSequence: number;
+  sourceEventId: string;
+  schemaId: string;
+}
+
+export interface WorkerTimelineIdentity {
+  provider?: string;
+  modelProvider?: string;
+  executorProvider?: string;
+  model?: string;
+}
+
+export interface WorkerTimelineAttempt {
+  id?: string;
+  number?: number;
+  reason?: string;
+  dispatchId?: string;
+  turnId?: string;
+  status?: string;
+}
+
+export interface WorkerTimelineProviderSession {
+  provider: string;
+  kind: string;
+  id: string;
+}
+
+export interface WorkerTimelineContinuation {
+  providerSession?: WorkerTimelineProviderSession;
+  predecessorWorkerSessionId?: string;
+  successorWorkerSessionId?: string;
+  previousDispatchId?: string;
+  previousAttemptId?: string;
+}
+
+export interface WorkerTimelineContentBlock {
+  kind: string;
+  text?: string;
+  toolCallId?: string;
+  toolName?: string;
+  argumentsSummary?: WorkerTimelineJSONValue;
+  imageRef?: string;
+  resourceRef?: string;
+  structuredOutput?: WorkerTimelineJSONValue;
+}
+
+export interface WorkerTimelineMessageDelta {
+  contentBlockIndex?: number;
+  contentBlockKind?: string;
+  textDelta?: string;
+}
+
+export interface WorkerTimelineMessage {
+  role?: string;
+  contentBlocks?: WorkerTimelineContentBlock[];
+  text?: string;
+  partial?: boolean;
+  delta?: WorkerTimelineMessageDelta;
+}
+
+export interface WorkerTimelineReasoning {
+  representation?: "SNAPSHOT" | "DELTA";
+  summary?: string;
+  summaryDelta?: string;
+}
+
+export interface WorkerTimelineTool {
+  toolCallId?: string;
+  toolName?: string;
+  status?: string;
+  argumentsSummary?: WorkerTimelineJSONValue;
+  resultSummary?: WorkerTimelineJSONValue;
+  outputDelta?: string;
+}
+
+export interface WorkerTimelineUsage {
+  inputTokens?: number;
+  cachedInputTokens?: number;
+  cacheWriteTokens?: number;
+  outputTokens?: number;
+  reasoningOutputTokens?: number;
+  totalTokens?: number;
+  model?: string;
+}
+
+export interface WorkerTimelineFailure {
+  kind?: string;
+  code?: string;
+  message?: string;
+  retryable?: boolean;
+  retryAfterSeconds?: number;
+  retryAttempt?: number;
+}
+
+export interface WorkerTimelineTerminal {
+  outcome: WorkerTimelineTerminalOutcome;
+  status?: string;
+  failure?: WorkerTimelineFailure;
+}
+
+export interface WorkerTimelineGenericMetadata {
+  schemaId: string;
+  sourceType: string;
+  sourceId: string;
+  sourceSequence: number;
+  payloadKeys: string[];
+  payloadKeyCount: number;
+  payloadKeysTruncated: boolean;
+}
+
+export interface WorkerSessionTimelineEntry {
+  /** Stable React key composed from canonical position and source identity. */
+  key: string;
+  canonical: WorkerTimelineCanonicalSource;
+  kind: string;
+  phase: string;
+  category: WorkerTimelineEntryCategory;
+  itemId?: string;
+  parentItemId?: string;
+  identity?: WorkerTimelineIdentity;
+  attempt?: WorkerTimelineAttempt;
+  continuation?: WorkerTimelineContinuation;
+  message?: WorkerTimelineMessage;
+  reasoning?: WorkerTimelineReasoning;
+  tool?: WorkerTimelineTool;
+  usage?: WorkerTimelineUsage;
+  failure?: WorkerTimelineFailure;
+  terminal?: WorkerTimelineTerminal;
+  generic?: WorkerTimelineGenericMetadata;
+}

--- a/ui/src/features/worker-session-timeline/lib/worker-session-timeline-projection.test.ts
+++ b/ui/src/features/worker-session-timeline/lib/worker-session-timeline-projection.test.ts
@@ -1,0 +1,424 @@
+import {
+  projectWorkerSessionTimeline,
+  projectWorkerSessionTimelineEntry,
+  type WorkerSessionEventRecord,
+} from "./worker-session-timeline-projection";
+
+type DraftRecord = Record<string, unknown>;
+
+function record(
+  position: number,
+  payload: DraftRecord,
+  overrides: Partial<WorkerSessionEventRecord> = {},
+): WorkerSessionEventRecord {
+  return {
+    cursor: {
+      position,
+      workerSessionId: "worker-session-1",
+      streamGenerationId: "generation-1",
+    },
+    position,
+    sourceType: "worker_session",
+    sourceId: "worker-session-1",
+    sourceSequence: position,
+    sourceEventId: `event-${position}`,
+    schemaId: "workers.draft.v1",
+    payload,
+    ...overrides,
+  };
+}
+
+function draft(
+  kind: string,
+  phase: string,
+  payload: DraftRecord,
+  overrides: DraftRecord = {},
+): DraftRecord {
+  return {
+    kind,
+    phase,
+    provenance: {
+      provider: "codex",
+      delivery: "NATIVE_STREAM",
+      representation: "SNAPSHOT",
+    },
+    payload,
+    ...overrides,
+  };
+}
+
+describe("Worker Session lifecycle projection", () => {
+  it("projects lifecycle identity, attempts, retry reasons, and continuation links", () => {
+    const opening = record(
+      1,
+      draft(
+        "SESSION",
+        "STARTED",
+        {
+          status: "STARTING",
+          workerSessionId: "worker-session-1",
+          attemptId: "attempt-1",
+          attempt: 1,
+          attemptReason: "INITIAL",
+          model: "gpt-5",
+          providerSelection: {
+            modelProvider: "openai",
+            executorProvider: "ACP",
+          },
+        },
+        { dispatchId: "attempt-1" },
+      ),
+    );
+    const retry = record(
+      2,
+      draft("SESSION", "UPDATED", {
+        status: "RETRYING",
+        workerSessionId: "worker-session-1",
+        attemptId: "attempt-2",
+        attempt: 2,
+        attemptReason: "RETRY",
+        lineage: {
+          previousDispatchId: "attempt-1",
+          previousAttemptId: "attempt-1",
+        },
+      }),
+      { sourceType: "worker_session_attempt", sourceEventId: "retry" },
+    );
+    const continuation = record(
+      3,
+      draft("SESSION", "UPDATED", {
+        status: "COMPLETED",
+        workerSessionId: "worker-session-1",
+        continuation: { provider: "codex", kind: "session_id", id: "thread-1" },
+        lineage: { successorWorkerSessionId: "worker-session-2" },
+      }),
+      { sourceType: "worker_session_lineage", sourceEventId: "successor" },
+    );
+    const terminal = record(
+      4,
+      draft("SESSION", "COMPLETED", { status: "COMPLETED" }),
+    );
+
+    const entries = projectWorkerSessionTimeline([
+      terminal,
+      continuation,
+      retry,
+      opening,
+    ]);
+
+    expect(entries.map((entry) => entry.canonical.position)).toEqual([
+      1, 2, 3, 4,
+    ]);
+    expect(entries[0]?.identity).toEqual({
+      provider: "codex",
+      modelProvider: "openai",
+      executorProvider: "ACP",
+      model: "gpt-5",
+    });
+    expect(entries[0]?.attempt).toEqual({
+      id: "attempt-1",
+      number: 1,
+      reason: "INITIAL",
+      dispatchId: "attempt-1",
+      status: "STARTING",
+    });
+    expect(entries[1]?.attempt?.reason).toBe("RETRY");
+    expect(entries[1]?.continuation).toEqual({
+      previousDispatchId: "attempt-1",
+      previousAttemptId: "attempt-1",
+    });
+    expect(entries[2]?.continuation).toEqual({
+      providerSession: {
+        provider: "codex",
+        kind: "session_id",
+        id: "thread-1",
+      },
+      successorWorkerSessionId: "worker-session-2",
+    });
+    expect(entries[3]?.terminal).toEqual({
+      outcome: "SUCCESS",
+      status: "COMPLETED",
+    });
+  });
+});
+
+describe("Worker Session content projection", () => {
+  it("projects user and assistant messages plus reasoning snapshots and deltas", () => {
+    const entries = projectWorkerSessionTimeline([
+      record(
+        1,
+        draft("MESSAGE", "COMPLETED", {
+          role: "user",
+          contentBlocks: [{ kind: "TEXT", text: "Please inspect the build." }],
+        }),
+        { sourceEventId: "user-message" },
+      ),
+      record(
+        2,
+        draft(
+          "MESSAGE",
+          "DELTA",
+          {
+            contentBlockIndex: 0,
+            contentBlockKind: "TEXT",
+            textDelta: "Build is ",
+          },
+          { itemId: "message-1" },
+        ),
+        { sourceEventId: "assistant-delta-1" },
+      ),
+      record(
+        3,
+        draft(
+          "MESSAGE",
+          "COMPLETED",
+          {
+            role: "assistant",
+            contentBlocks: [{ kind: "TEXT", text: "Build is green." }],
+          },
+          { itemId: "message-1" },
+        ),
+        { sourceEventId: "assistant-snapshot" },
+      ),
+      record(
+        4,
+        draft("REASONING", "DELTA", {
+          summaryDelta: "Checking the test output.",
+        }),
+      ),
+      record(
+        5,
+        draft("REASONING", "COMPLETED", {
+          summary: "The test output is complete.",
+        }),
+      ),
+    ]);
+
+    expect(entries.map((entry) => entry.category)).toEqual([
+      "message",
+      "message",
+      "message",
+      "reasoning",
+      "reasoning",
+    ]);
+    expect(entries[0]?.message).toEqual({
+      role: "user",
+      contentBlocks: [{ kind: "TEXT", text: "Please inspect the build." }],
+      text: "Please inspect the build.",
+    });
+    expect(entries[1]?.message).toEqual({
+      delta: {
+        contentBlockIndex: 0,
+        contentBlockKind: "TEXT",
+        textDelta: "Build is ",
+      },
+    });
+    expect(entries[2]?.itemId).toBe("message-1");
+    expect(entries[2]?.message?.text).toBe("Build is green.");
+    expect(entries[3]?.reasoning).toEqual({
+      representation: "DELTA",
+      summaryDelta: "Checking the test output.",
+    });
+    expect(entries[4]?.reasoning).toEqual({
+      representation: "SNAPSHOT",
+      summary: "The test output is complete.",
+    });
+  });
+});
+
+describe("Worker Session tool projection", () => {
+  it("projects tool lifecycle, output, and usage", () => {
+    const entries = projectWorkerSessionTimeline([
+      record(
+        6,
+        draft("TOOL", "STARTED", {
+          toolCallId: "tool-1",
+          toolName: "command_execution",
+          status: "in_progress",
+          argumentsSummary: { command: "go test ./..." },
+        }),
+      ),
+      record(
+        7,
+        draft("TOOL", "DELTA", {
+          toolCallId: "tool-1",
+          outputDelta: "ok",
+        }),
+      ),
+      record(
+        8,
+        draft("TOOL", "COMPLETED", {
+          toolCallId: "tool-1",
+          toolName: "command_execution",
+          status: "completed",
+          resultSummary: { exitCode: 0, output: "ok" },
+        }),
+      ),
+      record(
+        9,
+        draft("USAGE", "UPDATED", {
+          inputTokens: 10,
+          outputTokens: 8,
+          reasoningOutputTokens: 2,
+          totalTokens: 20,
+          model: "gpt-5",
+        }),
+      ),
+    ]);
+
+    expect(entries.map((entry) => entry.category)).toEqual([
+      "tool",
+      "tool",
+      "tool",
+      "usage",
+    ]);
+    expect(entries[0]?.tool?.argumentsSummary).toEqual({
+      command: "go test ./...",
+    });
+    expect(entries[1]?.tool).toEqual({
+      toolCallId: "tool-1",
+      outputDelta: "ok",
+    });
+    expect(entries[2]?.tool?.resultSummary).toEqual({
+      exitCode: 0,
+      output: "ok",
+    });
+    expect(entries[3]?.usage).toEqual({
+      inputTokens: 10,
+      outputTokens: 8,
+      reasoningOutputTokens: 2,
+      totalTokens: 20,
+      model: "gpt-5",
+    });
+    expect(entries[3]?.identity?.model).toBe("gpt-5");
+  });
+});
+
+describe("Worker Session terminal projection", () => {
+  it("keeps terminal failure and cancellation separate from success", () => {
+    const failed = projectWorkerSessionTimelineEntry(
+      record(
+        1,
+        draft("SESSION", "FAILED", {
+          status: "FAILED",
+          failureCause: "PROVIDER_FAILURE",
+          failureDetail: "The provider stopped responding.",
+          agentRunFailureClass: "provider_timeout",
+        }),
+      ),
+    );
+    const canceled = projectWorkerSessionTimelineEntry(
+      record(2, draft("SESSION", "CANCELED", { status: "CANCELED" })),
+    );
+
+    expect(failed.terminal).toEqual({
+      outcome: "FAILURE",
+      status: "FAILED",
+      failure: {
+        kind: "PROVIDER_FAILURE",
+        code: "provider_timeout",
+        message: "The provider stopped responding.",
+      },
+    });
+    expect(failed.failure?.message).toBe("The provider stopped responding.");
+    expect(canceled.terminal).toEqual({
+      outcome: "CANCELED",
+      status: "CANCELED",
+    });
+  });
+});
+
+describe("Worker Session forward compatibility", () => {
+  it("retains unknown schemas as bounded generic entries without payload dumps", () => {
+    const payload = Object.fromEntries(
+      Array.from({ length: 20 }, (_, index) => [
+        `field-${index.toString().padStart(2, "0")}`,
+        index === 0 ? "do-not-dump-this-secret" : { nested: index },
+      ]),
+    );
+    const unknown = projectWorkerSessionTimelineEntry(
+      record(1, payload, {
+        schemaId: "provider.future.v9",
+        sourceType: "provider_observation",
+        sourceId: "provider-source-1",
+      }),
+    );
+
+    expect(unknown.category).toBe("generic");
+    expect(unknown.kind).toBe("UNKNOWN");
+    expect(unknown.generic).toEqual({
+      schemaId: "provider.future.v9",
+      sourceType: "provider_observation",
+      sourceId: "provider-source-1",
+      sourceSequence: 1,
+      payloadKeys: [
+        "field-00",
+        "field-01",
+        "field-02",
+        "field-03",
+        "field-04",
+        "field-05",
+        "field-06",
+        "field-07",
+        "field-08",
+        "field-09",
+        "field-10",
+        "field-11",
+        "field-12",
+        "field-13",
+        "field-14",
+        "field-15",
+      ],
+      payloadKeyCount: 20,
+      payloadKeysTruncated: true,
+    });
+    expect(JSON.stringify(unknown)).not.toContain("do-not-dump-this-secret");
+  });
+});
+
+describe("Worker Session malformed optional facts", () => {
+  it("does not infer malformed optional facts or mutate canonical input", () => {
+    const input = record(
+      2,
+      draft("MESSAGE", "COMPLETED", {
+        role: 42,
+        contentBlocks: [
+          { text: "missing kind" },
+          { kind: "TEXT", text: "safe" },
+        ],
+        providerSelection: { modelProvider: "" },
+        inputTokens: "10",
+        totalTokens: null,
+        continuation: { provider: "codex", kind: "session_id" },
+      }),
+    );
+    const before = JSON.stringify(input);
+    const output = projectWorkerSessionTimeline([input]);
+
+    expect(output[0]?.message).toEqual({
+      contentBlocks: [{ kind: "TEXT", text: "safe" }],
+      text: "safe",
+    });
+    expect(output[0]?.identity).toEqual({ provider: "codex" });
+    expect(output[0]?.usage).toBeUndefined();
+    expect(output[0]?.continuation).toBeUndefined();
+    expect(JSON.stringify(input)).toBe(before);
+  });
+});
+
+describe("Worker Session legacy lifecycle projection", () => {
+  it("maps the retained legacy lifecycle schema without making it a second source", () => {
+    const legacy = record(
+      1,
+      { status: "COMPLETED", failureDetail: "" },
+      { schemaId: "worker_session.completed" },
+    );
+
+    const [entry] = projectWorkerSessionTimeline([legacy]);
+
+    expect(entry?.category).toBe("session");
+    expect(entry?.kind).toBe("SESSION");
+    expect(entry?.phase).toBe("COMPLETED");
+    expect(entry?.terminal?.outcome).toBe("SUCCESS");
+  });
+});

--- a/ui/src/features/worker-session-timeline/lib/worker-session-timeline-projection.ts
+++ b/ui/src/features/worker-session-timeline/lib/worker-session-timeline-projection.ts
@@ -216,17 +216,23 @@ function legacySessionPhase(
 ): string {
   switch (schemaId.slice("worker_session.".length)) {
     case "started":
+      // hardcoded-ui-copy-exception: non-product-diagnostic
       return "STARTED";
     case "running":
+      // hardcoded-ui-copy-exception: non-product-diagnostic
       return "UPDATED";
     case "completed":
+      // hardcoded-ui-copy-exception: non-product-diagnostic
       return "COMPLETED";
     case "failed":
+      // hardcoded-ui-copy-exception: non-product-diagnostic
       return "FAILED";
     case "canceled":
     case "cancelled":
+      // hardcoded-ui-copy-exception: non-product-diagnostic
       return "CANCELED";
     default:
+      // hardcoded-ui-copy-exception: non-product-diagnostic
       return optionalString(payload.phase) ?? "UPDATED";
   }
 }

--- a/ui/src/features/worker-session-timeline/lib/worker-session-timeline-projection.ts
+++ b/ui/src/features/worker-session-timeline/lib/worker-session-timeline-projection.ts
@@ -1,0 +1,268 @@
+import {
+  categoryForKind,
+  projectAttempt,
+  projectContinuation,
+  projectFailure,
+  projectIdentity,
+  projectMessage,
+  projectReasoning,
+  projectTool,
+  projectUsage,
+  terminalOutcomeFor,
+} from "./worker-session-timeline-projection-details";
+import {
+  asObject,
+  genericMetadata,
+  normalizedToken,
+  optionalString,
+} from "./worker-session-timeline-projection-helpers";
+import type {
+  WorkerSessionEventRecord,
+  WorkerSessionTimelineEntry,
+  WorkerTimelineCanonicalSource,
+  WorkerTimelineJSONObject,
+} from "./worker-session-timeline-projection-types";
+
+export type {
+  WorkerSessionEventRecord,
+  WorkerSessionTimelineEntry,
+} from "./worker-session-timeline-projection-types";
+
+const WORKER_DRAFT_SCHEMA_ID = "workers.draft.v1";
+
+const LEGACY_SESSION_SCHEMA_IDS = new Set([
+  "worker_session.lifecycle",
+  "worker_session.lineage",
+  "worker_session.attempt",
+  "worker_session.started",
+  "worker_session.running",
+  "worker_session.completed",
+  "worker_session.failed",
+  "worker_session.canceled",
+  "worker_session.cancelled",
+]);
+
+/**
+ * Returns a deterministic key for one canonical record. The source tuple is
+ * encoded as separate components so source IDs containing punctuation remain
+ * unambiguous and a duplicate source identity cannot silently replace another
+ * record in a rendered list.
+ */
+export function workerSessionTimelineEntryKey(
+  record: Pick<
+    WorkerSessionEventRecord,
+    "position" | "sourceType" | "sourceId" | "sourceSequence" | "sourceEventId"
+  >,
+): string {
+  return [
+    record.position,
+    record.sourceType,
+    record.sourceId,
+    record.sourceSequence,
+    record.sourceEventId,
+  ]
+    .map((part) => encodeURIComponent(String(part)))
+    .join(":");
+}
+
+/**
+ * Projects canonical Worker Session records into provider-neutral timeline
+ * entries. The input is never mutated and each input record produces exactly
+ * one entry, including records with an unknown schema. Snapshot and delta
+ * payloads retain their canonical representation and item/block identities so
+ * a later view can combine them only according to the source schema rather
+ * than guessing from provider transcripts or current component state.
+ */
+export function projectWorkerSessionTimeline(
+  records: readonly WorkerSessionEventRecord[],
+): WorkerSessionTimelineEntry[] {
+  return records
+    .map((record) => projectWorkerSessionTimelineEntry(record))
+    .sort(compareTimelineEntries);
+}
+
+/** Projects one canonical record without consulting any external state. */
+export function projectWorkerSessionTimelineEntry(
+  record: WorkerSessionEventRecord,
+): WorkerSessionTimelineEntry {
+  const canonical = canonicalSource(record);
+  const base: WorkerSessionTimelineEntry = {
+    key: workerSessionTimelineEntryKey(record),
+    canonical,
+    kind: "UNKNOWN",
+    phase: "UNKNOWN",
+    category: "generic",
+  };
+
+  const decoded = decodeKnownRecord(record);
+  if (decoded === undefined) {
+    return { ...base, generic: genericMetadata(record) };
+  }
+
+  const kind = normalizedToken(decoded.kind) ?? "UNKNOWN";
+  const phase = normalizedToken(decoded.phase) ?? "UNKNOWN";
+  const entry: WorkerSessionTimelineEntry = {
+    ...base,
+    kind,
+    phase,
+    category: categoryForKind(kind),
+  };
+  const payload = decoded.payload;
+  const envelope = decoded.envelope;
+  const itemId = optionalString(envelope?.itemId);
+  const parentItemId = optionalString(envelope?.parentItemId);
+  if (itemId !== undefined) {
+    entry.itemId = itemId;
+  }
+  if (parentItemId !== undefined) {
+    entry.parentItemId = parentItemId;
+  }
+
+  const usage = projectUsage(payload);
+  const identity = projectIdentity(envelope, payload, usage);
+  const attempt = projectAttempt(envelope, payload);
+  const continuation = projectContinuation(payload);
+  const failure = projectFailure(kind, payload);
+  if (identity !== undefined) {
+    entry.identity = identity;
+  }
+  if (attempt !== undefined) {
+    entry.attempt = attempt;
+  }
+  if (continuation !== undefined) {
+    entry.continuation = continuation;
+  }
+  if (usage !== undefined) {
+    entry.usage = usage;
+  }
+  if (failure !== undefined) {
+    entry.failure = failure;
+  }
+
+  switch (kind) {
+    case "MESSAGE": {
+      const message = projectMessage(payload);
+      if (message !== undefined) {
+        entry.message = message;
+      }
+      break;
+    }
+    case "REASONING": {
+      const reasoning = projectReasoning(phase, payload);
+      if (reasoning !== undefined) {
+        entry.reasoning = reasoning;
+      }
+      break;
+    }
+    case "TOOL": {
+      const tool = projectTool(payload);
+      if (tool !== undefined) {
+        entry.tool = tool;
+      }
+      break;
+    }
+    default:
+      break;
+  }
+
+  const terminalOutcome = terminalOutcomeFor(kind, phase, payload);
+  if (terminalOutcome !== undefined) {
+    const status = optionalString(payload.status);
+    entry.terminal = {
+      outcome: terminalOutcome,
+      ...(status !== undefined ? { status } : {}),
+      ...(failure !== undefined ? { failure } : {}),
+    };
+  }
+  return entry;
+}
+
+interface DecodedKnownRecord {
+  kind?: unknown;
+  phase?: unknown;
+  payload: WorkerTimelineJSONObject;
+  envelope?: WorkerTimelineJSONObject;
+}
+
+function decodeKnownRecord(
+  record: WorkerSessionEventRecord,
+): DecodedKnownRecord | undefined {
+  if (record.schemaId === WORKER_DRAFT_SCHEMA_ID) {
+    const envelope = asObject(record.payload);
+    if (envelope === undefined) {
+      return { payload: {} };
+    }
+    return {
+      kind: envelope.kind,
+      phase: envelope.phase,
+      payload: asObject(envelope.payload) ?? {},
+      envelope,
+    };
+  }
+  if (!LEGACY_SESSION_SCHEMA_IDS.has(record.schemaId)) {
+    return undefined;
+  }
+  const payload = asObject(record.payload) ?? {};
+  return {
+    kind: "SESSION",
+    phase: legacySessionPhase(record.schemaId, payload),
+    payload,
+  };
+}
+
+function legacySessionPhase(
+  schemaId: string,
+  payload: WorkerTimelineJSONObject,
+): string {
+  switch (schemaId.slice("worker_session.".length)) {
+    case "started":
+      return "STARTED";
+    case "running":
+      return "UPDATED";
+    case "completed":
+      return "COMPLETED";
+    case "failed":
+      return "FAILED";
+    case "canceled":
+    case "cancelled":
+      return "CANCELED";
+    default:
+      return optionalString(payload.phase) ?? "UPDATED";
+  }
+}
+
+function canonicalSource(
+  record: WorkerSessionEventRecord,
+): WorkerTimelineCanonicalSource {
+  const workerSessionId = optionalString(record.cursor.workerSessionId);
+  const streamGenerationId = optionalString(record.cursor.streamGenerationId);
+  return {
+    position: record.position,
+    cursor: {
+      position: record.cursor.position,
+      ...(workerSessionId !== undefined ? { workerSessionId } : {}),
+      ...(streamGenerationId !== undefined ? { streamGenerationId } : {}),
+    },
+    sourceType: record.sourceType,
+    sourceId: record.sourceId,
+    sourceSequence: record.sourceSequence,
+    sourceEventId: record.sourceEventId,
+    schemaId: record.schemaId,
+  };
+}
+
+function compareTimelineEntries(
+  left: WorkerSessionTimelineEntry,
+  right: WorkerSessionTimelineEntry,
+): number {
+  const positionDifference = left.canonical.position - right.canonical.position;
+  if (positionDifference !== 0) {
+    return positionDifference;
+  }
+  const sourceSequenceDifference =
+    left.canonical.sourceSequence - right.canonical.sourceSequence;
+  if (sourceSequenceDifference !== 0) {
+    return sourceSequenceDifference;
+  }
+  return left.key.localeCompare(right.key);
+}

--- a/ui/src/features/worker-session-timeline/lib/worker-session-timeline-stream.bun.unit.test.ts
+++ b/ui/src/features/worker-session-timeline/lib/worker-session-timeline-stream.bun.unit.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "bun:test";
+
+import type { WorkerSessionEventFrame } from "../../../api/worker-sessions";
+import type { WorkerSessionEventRecord } from "./worker-session-timeline-projection-types";
+import {
+  applyWorkerSessionTimelineFrame,
+  applyWorkerSessionTimelineTransportFailure,
+  createWorkerSessionTimelineStreamState,
+  type WorkerSessionTimelineStreamContext,
+} from "./worker-session-timeline-stream";
+
+const context: WorkerSessionTimelineStreamContext = {
+  workerSessionID: "worker-1",
+};
+
+function record(
+  position: number,
+  overrides: Partial<WorkerSessionEventRecord> = {},
+): WorkerSessionEventRecord {
+  return {
+    cursor: {
+      position,
+      workerSessionId: "worker-1",
+      streamGenerationId: "generation-1",
+    },
+    payload: {},
+    position,
+    schemaId: "workers.draft.v1",
+    sourceEventId: `event-${position}`,
+    sourceId: "worker-1",
+    sourceSequence: position,
+    sourceType: "worker_session",
+    ...overrides,
+  };
+}
+
+function frame(
+  delivery: WorkerSessionEventFrame["delivery"],
+  event: WorkerSessionEventRecord | null,
+  overrides: Partial<WorkerSessionEventFrame> = {},
+): WorkerSessionEventFrame {
+  return {
+    delivery,
+    errorCode: null,
+    errorMessage: null,
+    event,
+    providerSession: { provider: "", kind: "", id: "" },
+    workIds: [],
+    workerSessionId: "worker-1",
+    ...overrides,
+  };
+}
+
+function apply(
+  state: ReturnType<typeof createWorkerSessionTimelineStreamState>,
+  nextFrame: WorkerSessionEventFrame,
+) {
+  return applyWorkerSessionTimelineFrame(state, nextFrame, context);
+}
+
+describe("Worker Session timeline stream state", () => {
+  it("accepts an ordered retained-to-live sequence and ignores exact overlap", () => {
+    const first = apply(
+      createWorkerSessionTimelineStreamState(),
+      frame("RECORD", record(1)),
+    );
+    const second = apply(first.state, frame("RECORD", record(2)));
+    const duplicate = apply(second.state, frame("RECORD", record(2)));
+
+    expect(duplicate.state.records.map(({ position }) => position)).toEqual([
+      1, 2,
+    ]);
+    expect(duplicate.state.acknowledgedCursor?.position).toBe(2);
+    expect(duplicate.shouldStop).toBe(false);
+  });
+
+  it("rejects gaps, foreign cursors, and generation changes visibly", () => {
+    const first = apply(
+      createWorkerSessionTimelineStreamState(),
+      frame("RECORD", record(1)),
+    ).state;
+    const gap = apply(first, frame("RECORD", record(3)));
+    expect(gap.state.sourceError).toMatchObject({ code: "CURSOR_GAP" });
+
+    const foreign = apply(
+      first,
+      frame(
+        "RECORD",
+        record(2, { cursor: { position: 2, workerSessionId: "worker-2" } }),
+      ),
+    );
+    expect(foreign.state.sourceError).toMatchObject({ code: "CURSOR_FOREIGN" });
+
+    const generation = apply(
+      first,
+      frame(
+        "RECORD",
+        record(2, {
+          cursor: {
+            position: 2,
+            workerSessionId: "worker-1",
+            streamGenerationId: "generation-2",
+          },
+        }),
+      ),
+    );
+    expect(generation.state.sourceError).toMatchObject({
+      code: "CURSOR_GENERATION_MISMATCH",
+    });
+  });
+
+  it("preserves records on source failure and carries replay health", () => {
+    const first = apply(
+      createWorkerSessionTimelineStreamState(),
+      frame("RECORD", record(1), {
+        recordingHealth: "DEGRADED",
+        recordingHealthReason: "PERSISTENCE_FAILED",
+      }),
+    );
+    const failure = apply(
+      first.state,
+      frame("SOURCE_FAILURE", null, {
+        errorCode: "WORKER_SESSION_STREAM_UNAVAILABLE",
+        errorMessage: "safe source failure",
+      }),
+    );
+
+    expect(failure.state.records).toHaveLength(1);
+    expect(failure.state.status).toBe("source-error");
+    expect(failure.state.sourceError?.message).toBe("safe source failure");
+    expect(failure.state.recordingHealth).toBe("DEGRADED");
+    expect(failure.shouldStop).toBe(true);
+  });
+
+  it("stops after terminal delivery and finite replay summary", () => {
+    const terminal = apply(
+      createWorkerSessionTimelineStreamState(),
+      frame("TERMINAL", record(1)),
+    );
+    expect(terminal.state.status).toBe("completed");
+    expect(terminal.state.terminalDelivery).toBe("TERMINAL");
+    expect(
+      applyWorkerSessionTimelineTransportFailure(terminal.state),
+    ).toMatchObject({ shouldReconnect: false });
+
+    const summary = apply(
+      createWorkerSessionTimelineStreamState(),
+      frame("REPLAY_SUMMARY", null, {
+        recordingHealth: "INCOMPLETE",
+        recordingHealthReason: "RETAINED_HEAD_MOVED",
+        replaySummary: {
+          kind: "replay-summary",
+          complete: false,
+          reason: "ACTIVE",
+          eventsEmitted: 0,
+        },
+      }),
+    );
+    expect(summary.state.status).toBe("ready-empty");
+    expect(summary.state.recordingHealth).toBe("INCOMPLETE");
+    expect(summary.state.replaySummary?.complete).toBe(false);
+    expect(summary.shouldStop).toBe(true);
+  });
+
+  it("reconnects from the initial generation-scoped cursor", () => {
+    const state = createWorkerSessionTimelineStreamState({
+      afterPosition: 4,
+      streamGenerationId: "generation-1",
+    });
+    const next = apply(state, frame("RECORD", record(5)));
+
+    expect(next.state.acknowledgedCursor).toEqual({
+      position: 5,
+      workerSessionId: "worker-1",
+      streamGenerationId: "generation-1",
+    });
+  });
+});

--- a/ui/src/features/worker-session-timeline/lib/worker-session-timeline-stream.ts
+++ b/ui/src/features/worker-session-timeline/lib/worker-session-timeline-stream.ts
@@ -1,0 +1,445 @@
+import type {
+  WorkerSessionEventCursor,
+  WorkerSessionEventFrame,
+  WorkerSessionEventReconnectCursor,
+  WorkerSessionEventRecordingHealth,
+  WorkerSessionReplaySummary,
+} from "../../../api/worker-sessions";
+import type { WorkerSessionEventRecord } from "./worker-session-timeline-projection-types";
+
+export type WorkerSessionTimelineStreamStatus =
+  | "idle"
+  | "loading"
+  | "ready-empty"
+  | "live"
+  | "reconnecting"
+  | "completed"
+  | "source-error";
+
+export type WorkerSessionTimelineStreamErrorCode =
+  | "STREAM_ERROR"
+  | "SOURCE_FAILURE"
+  | "INVALID_FRAME"
+  | "SESSION_MISMATCH"
+  | "CURSOR_FOREIGN"
+  | "CURSOR_GENERATION_MISMATCH"
+  | "CURSOR_INVALID"
+  | "CURSOR_GAP"
+  | "CURSOR_OUT_OF_ORDER"
+  | "CURSOR_POSITION_CONFLICT";
+
+export interface WorkerSessionTimelineStreamError {
+  code: WorkerSessionTimelineStreamErrorCode;
+  message: string;
+}
+
+export interface WorkerSessionTimelineStreamState {
+  status: WorkerSessionTimelineStreamStatus;
+  records: WorkerSessionEventRecord[];
+  acknowledgedCursor: WorkerSessionEventCursor | null;
+  streamGenerationId: string | null;
+  recordingHealth: WorkerSessionEventRecordingHealth | null;
+  recordingHealthReason: string | null;
+  replaySummary: WorkerSessionReplaySummary | null;
+  terminalDelivery: "TERMINAL" | "TERMINAL_REPLAY" | null;
+  sourceError: WorkerSessionTimelineStreamError | null;
+}
+
+export interface WorkerSessionTimelineStreamContext {
+  workerSessionID: string;
+  initialReconnectCursor?: WorkerSessionEventReconnectCursor | null;
+}
+
+export interface WorkerSessionTimelineStreamTransition {
+  state: WorkerSessionTimelineStreamState;
+  shouldStop: boolean;
+}
+
+export interface WorkerSessionTimelineTransportFailure {
+  state: WorkerSessionTimelineStreamState;
+  shouldReconnect: boolean;
+}
+
+export function createWorkerSessionTimelineStreamState(
+  initialReconnectCursor?: WorkerSessionEventReconnectCursor | null,
+): WorkerSessionTimelineStreamState {
+  return {
+    status: "loading",
+    records: [],
+    acknowledgedCursor:
+      initialReconnectCursor == null
+        ? null
+        : {
+            position: initialReconnectCursor.afterPosition,
+            ...(initialReconnectCursor.streamGenerationId
+              ? {
+                  streamGenerationId: initialReconnectCursor.streamGenerationId,
+                }
+              : {}),
+          },
+    streamGenerationId: initialReconnectCursor?.streamGenerationId ?? null,
+    recordingHealth: null,
+    recordingHealthReason: null,
+    replaySummary: null,
+    terminalDelivery: null,
+    sourceError: null,
+  };
+}
+
+export function workerSessionTimelineStreamCanFollow(
+  state: WorkerSessionTimelineStreamState,
+): boolean {
+  return (
+    state.status !== "idle" &&
+    state.status !== "completed" &&
+    state.status !== "source-error" &&
+    state.replaySummary === null &&
+    state.terminalDelivery === null
+  );
+}
+
+export function workerSessionTimelineReconnectCursor(
+  state: WorkerSessionTimelineStreamState,
+): WorkerSessionEventReconnectCursor | null {
+  if (state.acknowledgedCursor === null) {
+    return null;
+  }
+  return {
+    afterPosition: state.acknowledgedCursor.position,
+    ...(state.streamGenerationId
+      ? { streamGenerationId: state.streamGenerationId }
+      : {}),
+  };
+}
+
+export function markWorkerSessionTimelineStreamLive(
+  state: WorkerSessionTimelineStreamState,
+): WorkerSessionTimelineStreamState {
+  if (!workerSessionTimelineStreamCanFollow(state)) {
+    return state;
+  }
+  return {
+    ...state,
+    status: "live",
+    sourceError: null,
+  };
+}
+
+export function markWorkerSessionTimelineStreamReconnecting(
+  state: WorkerSessionTimelineStreamState,
+): WorkerSessionTimelineStreamState {
+  if (!workerSessionTimelineStreamCanFollow(state)) {
+    return state;
+  }
+  return {
+    ...state,
+    status: "reconnecting",
+    sourceError: null,
+  };
+}
+
+export function applyWorkerSessionTimelineFrame(
+  state: WorkerSessionTimelineStreamState,
+  frame: WorkerSessionEventFrame,
+  context: WorkerSessionTimelineStreamContext,
+): WorkerSessionTimelineStreamTransition {
+  if (!workerSessionTimelineStreamCanFollow(state)) {
+    return { state, shouldStop: true };
+  }
+
+  if (frame.workerSessionId !== context.workerSessionID) {
+    return streamFailure(
+      state,
+      "SESSION_MISMATCH",
+      "Worker Session event stream returned a different Worker Session.",
+    );
+  }
+
+  const stateWithHealth = applyFrameHealth(state, frame);
+  switch (frame.delivery) {
+    case "RECORD":
+      return applyRecordFrame(stateWithHealth, frame, context, null);
+    case "TERMINAL":
+    case "TERMINAL_REPLAY":
+      return applyRecordFrame(stateWithHealth, frame, context, frame.delivery);
+    case "REPLAY_SUMMARY":
+      return applyReplaySummaryFrame(stateWithHealth, frame);
+    case "SOURCE_FAILURE":
+      return streamFailure(
+        stateWithHealth,
+        "SOURCE_FAILURE",
+        frame.errorMessage ?? "Worker Session event source failed.",
+      );
+    default:
+      return streamFailure(
+        stateWithHealth,
+        "INVALID_FRAME",
+        "Worker Session event stream returned an unsupported delivery.",
+      );
+  }
+}
+
+export function applyWorkerSessionTimelineTransportFailure(
+  state: WorkerSessionTimelineStreamState,
+  message = "Worker Session event stream disconnected.",
+): WorkerSessionTimelineTransportFailure {
+  if (!workerSessionTimelineStreamCanFollow(state)) {
+    return { state, shouldReconnect: false };
+  }
+
+  if (state.acknowledgedCursor !== null) {
+    return {
+      state: {
+        ...state,
+        status: "reconnecting",
+        sourceError: null,
+      },
+      shouldReconnect: true,
+    };
+  }
+
+  return {
+    state: {
+      ...state,
+      status: "source-error",
+      sourceError: { code: "STREAM_ERROR", message },
+    },
+    shouldReconnect: false,
+  };
+}
+
+export function applyWorkerSessionTimelineParseFailure(
+  state: WorkerSessionTimelineStreamState,
+  message = "Worker Session event stream returned an invalid frame.",
+): WorkerSessionTimelineStreamState {
+  if (!workerSessionTimelineStreamCanFollow(state)) {
+    return state;
+  }
+  return {
+    ...state,
+    status: "source-error",
+    sourceError: { code: "INVALID_FRAME", message },
+  };
+}
+
+function applyFrameHealth(
+  state: WorkerSessionTimelineStreamState,
+  frame: WorkerSessionEventFrame,
+): WorkerSessionTimelineStreamState {
+  return {
+    ...state,
+    ...(frame.recordingHealth !== undefined
+      ? { recordingHealth: frame.recordingHealth }
+      : {}),
+    ...(frame.recordingHealthReason !== undefined
+      ? { recordingHealthReason: frame.recordingHealthReason }
+      : {}),
+  };
+}
+
+function applyRecordFrame(
+  state: WorkerSessionTimelineStreamState,
+  frame: WorkerSessionEventFrame,
+  context: WorkerSessionTimelineStreamContext,
+  terminalDelivery: "TERMINAL" | "TERMINAL_REPLAY" | null,
+): WorkerSessionTimelineStreamTransition {
+  if (frame.event === null) {
+    return streamFailure(
+      state,
+      "INVALID_FRAME",
+      "Worker Session event stream returned a delivery without a record.",
+    );
+  }
+
+  const cursorError = validateRecordCursor(state, frame.event, context);
+  if (cursorError !== null) {
+    return streamFailure(state, cursorError.code, cursorError.message);
+  }
+
+  const key = workerSessionEventRecordKey(frame.event);
+  const duplicate = state.records.some(
+    (record) => workerSessionEventRecordKey(record) === key,
+  );
+  if (duplicate) {
+    return terminalDelivery !== null
+      ? completeWithTerminal(state, terminalDelivery)
+      : { state: { ...state, status: "live" }, shouldStop: false };
+  }
+
+  const positionError = validateRecordPosition(state, frame.event);
+  if (positionError !== null) {
+    return streamFailure(state, positionError.code, positionError.message);
+  }
+
+  const nextGenerationID =
+    state.streamGenerationId ?? frame.event.cursor.streamGenerationId ?? null;
+  const nextCursor = normalizedAcknowledgedCursor(
+    frame.event.cursor,
+    context.workerSessionID,
+    nextGenerationID,
+  );
+  const nextState: WorkerSessionTimelineStreamState = {
+    ...state,
+    status: terminalDelivery !== null ? "completed" : "live",
+    records: [...state.records, frame.event],
+    acknowledgedCursor: nextCursor,
+    streamGenerationId: nextGenerationID,
+    sourceError: null,
+    ...(terminalDelivery !== null ? { terminalDelivery } : {}),
+  };
+  return { state: nextState, shouldStop: terminalDelivery !== null };
+}
+
+function applyReplaySummaryFrame(
+  state: WorkerSessionTimelineStreamState,
+  frame: WorkerSessionEventFrame,
+): WorkerSessionTimelineStreamTransition {
+  if (frame.replaySummary === undefined || frame.replaySummary === null) {
+    return streamFailure(
+      state,
+      "INVALID_FRAME",
+      "Worker Session replay summary is unavailable.",
+    );
+  }
+  return {
+    state: {
+      ...state,
+      status:
+        frame.replaySummary.eventsEmitted === 0 && state.records.length === 0
+          ? "ready-empty"
+          : "completed",
+      replaySummary: frame.replaySummary,
+      sourceError: null,
+    },
+    shouldStop: true,
+  };
+}
+
+function validateRecordCursor(
+  state: WorkerSessionTimelineStreamState,
+  record: WorkerSessionEventRecord,
+  context: WorkerSessionTimelineStreamContext,
+): WorkerSessionTimelineStreamError | null {
+  if (
+    record.position !== record.cursor.position ||
+    !Number.isInteger(record.position) ||
+    record.position < 1
+  ) {
+    return {
+      code: "CURSOR_INVALID",
+      message: "Worker Session event cursor is invalid.",
+    };
+  }
+
+  if (
+    record.cursor.workerSessionId !== undefined &&
+    record.cursor.workerSessionId !== context.workerSessionID
+  ) {
+    return {
+      code: "CURSOR_FOREIGN",
+      message: "Worker Session event cursor belongs to another Worker Session.",
+    };
+  }
+
+  const expectedGenerationID = state.streamGenerationId;
+  if (
+    expectedGenerationID !== null &&
+    record.cursor.streamGenerationId !== expectedGenerationID
+  ) {
+    return {
+      code: "CURSOR_GENERATION_MISMATCH",
+      message:
+        "Worker Session event cursor belongs to another stream generation.",
+    };
+  }
+  return null;
+}
+
+function validateRecordPosition(
+  state: WorkerSessionTimelineStreamState,
+  record: WorkerSessionEventRecord,
+): WorkerSessionTimelineStreamError | null {
+  const lastPosition = state.acknowledgedCursor?.position;
+  if (
+    lastPosition === undefined ||
+    (state.records.length === 0 && lastPosition === 0)
+  ) {
+    return null;
+  }
+  if (lastPosition === undefined) {
+    return null;
+  }
+
+  if (record.position > lastPosition + 1) {
+    return {
+      code: "CURSOR_GAP",
+      message: "Worker Session event stream contains a cursor gap.",
+    };
+  }
+  if (record.position <= lastPosition) {
+    return {
+      code:
+        record.position === lastPosition
+          ? "CURSOR_POSITION_CONFLICT"
+          : "CURSOR_OUT_OF_ORDER",
+      message: "Worker Session event stream returned records out of order.",
+    };
+  }
+  return null;
+}
+
+function normalizedAcknowledgedCursor(
+  cursor: WorkerSessionEventCursor,
+  workerSessionID: string,
+  streamGenerationID: string | null,
+): WorkerSessionEventCursor {
+  return {
+    position: cursor.position,
+    workerSessionId: cursor.workerSessionId ?? workerSessionID,
+    ...(streamGenerationID !== null
+      ? { streamGenerationId: streamGenerationID }
+      : {}),
+  };
+}
+
+function completeWithTerminal(
+  state: WorkerSessionTimelineStreamState,
+  delivery: "TERMINAL" | "TERMINAL_REPLAY",
+): WorkerSessionTimelineStreamTransition {
+  return {
+    state: {
+      ...state,
+      status: "completed",
+      terminalDelivery: delivery,
+      sourceError: null,
+    },
+    shouldStop: true,
+  };
+}
+
+function streamFailure(
+  state: WorkerSessionTimelineStreamState,
+  code: WorkerSessionTimelineStreamErrorCode,
+  message: string,
+): WorkerSessionTimelineStreamTransition {
+  return {
+    state: {
+      ...state,
+      status: "source-error",
+      sourceError: { code, message },
+    },
+    shouldStop: true,
+  };
+}
+
+function workerSessionEventRecordKey(record: WorkerSessionEventRecord): string {
+  return JSON.stringify([
+    record.position,
+    record.sourceType,
+    record.sourceId,
+    record.sourceSequence,
+    record.sourceEventId,
+  ]);
+}
+
+export { workerSessionEventRecordKey };

--- a/ui/src/features/worker-session-timeline/lib/worker-session-timeline-stream.ts
+++ b/ui/src/features/worker-session-timeline/lib/worker-session-timeline-stream.ts
@@ -327,6 +327,7 @@ function validateRecordCursor(
   ) {
     return {
       code: "CURSOR_INVALID",
+      // hardcoded-ui-copy-exception: non-product-diagnostic
       message: "Worker Session event cursor is invalid.",
     };
   }
@@ -337,6 +338,7 @@ function validateRecordCursor(
   ) {
     return {
       code: "CURSOR_FOREIGN",
+      // hardcoded-ui-copy-exception: non-product-diagnostic
       message: "Worker Session event cursor belongs to another Worker Session.",
     };
   }
@@ -349,6 +351,7 @@ function validateRecordCursor(
     return {
       code: "CURSOR_GENERATION_MISMATCH",
       message:
+        // hardcoded-ui-copy-exception: non-product-diagnostic
         "Worker Session event cursor belongs to another stream generation.",
     };
   }
@@ -373,6 +376,7 @@ function validateRecordPosition(
   if (record.position > lastPosition + 1) {
     return {
       code: "CURSOR_GAP",
+      // hardcoded-ui-copy-exception: non-product-diagnostic
       message: "Worker Session event stream contains a cursor gap.",
     };
   }
@@ -382,6 +386,7 @@ function validateRecordPosition(
         record.position === lastPosition
           ? "CURSOR_POSITION_CONFLICT"
           : "CURSOR_OUT_OF_ORDER",
+      // hardcoded-ui-copy-exception: non-product-diagnostic
       message: "Worker Session event stream returned records out of order.",
     };
   }

--- a/ui/src/features/worker-session-timeline/lib/worker-session-timeline-window.bun.unit.test.ts
+++ b/ui/src/features/worker-session-timeline/lib/worker-session-timeline-window.bun.unit.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+
+import type { WorkerSessionTimelineEntry } from "./worker-session-timeline-projection-types";
+import {
+  getWorkerSessionTimelineWindow,
+  moveWorkerSessionTimelineWindow,
+  WORKER_SESSION_TIMELINE_WINDOW_SIZE,
+} from "./worker-session-timeline-window";
+
+function entries(count: number): WorkerSessionTimelineEntry[] {
+  return Array.from({ length: count }, (_, index) => ({
+    category: "generic",
+    canonical: {
+      cursor: { position: index + 1 },
+      position: index + 1,
+      schemaId: "unknown",
+      sourceEventId: `event-${index + 1}`,
+      sourceId: "worker-1",
+      sourceSequence: index + 1,
+      sourceType: "worker_session",
+    },
+    key: `event-${index + 1}`,
+    kind: "UNKNOWN",
+    phase: "UNKNOWN",
+  }));
+}
+
+describe("Worker Session timeline windows", () => {
+  it("keeps the live tail bounded and exposes adjacent chronological windows", () => {
+    const allEntries = entries(450);
+    const tail = getWorkerSessionTimelineWindow(allEntries, null);
+
+    expect(tail.entries).toHaveLength(WORKER_SESSION_TIMELINE_WINDOW_SIZE);
+    expect(tail.start).toBe(250);
+    expect(tail.end).toBe(450);
+    expect(tail.hasEarlier).toBe(true);
+    expect(tail.hasLater).toBe(false);
+
+    const earlierStart = moveWorkerSessionTimelineWindow(
+      tail.start,
+      "earlier",
+      allEntries.length,
+    );
+    const earlier = getWorkerSessionTimelineWindow(allEntries, earlierStart);
+    expect(earlier.start).toBe(50);
+    expect(earlier.entries[0]?.canonical.position).toBe(51);
+    expect(earlier.entries.at(-1)?.canonical.position).toBe(250);
+
+    expect(
+      moveWorkerSessionTimelineWindow(
+        earlier.start,
+        "later",
+        allEntries.length,
+      ),
+    ).toBe(tail.start);
+  });
+
+  it("clamps stale window positions when history shrinks", () => {
+    const window = getWorkerSessionTimelineWindow(entries(25), 300);
+
+    expect(window.start).toBe(0);
+    expect(window.end).toBe(25);
+    expect(window.entries).toHaveLength(25);
+    expect(window.hasEarlier).toBe(false);
+    expect(window.hasLater).toBe(false);
+  });
+});

--- a/ui/src/features/worker-session-timeline/lib/worker-session-timeline-window.ts
+++ b/ui/src/features/worker-session-timeline/lib/worker-session-timeline-window.ts
@@ -1,0 +1,59 @@
+import type { WorkerSessionTimelineEntry } from "./worker-session-timeline-projection-types";
+
+export const WORKER_SESSION_TIMELINE_WINDOW_SIZE = 200;
+
+export interface WorkerSessionTimelineWindow {
+  end: number;
+  entries: WorkerSessionTimelineEntry[];
+  hasEarlier: boolean;
+  hasLater: boolean;
+  start: number;
+}
+
+/**
+ * Selects one deterministic chronological window. A null start means that
+ * the window follows the newest entries, while an explicit start represents
+ * a user-selected historical window.
+ */
+export function getWorkerSessionTimelineWindow(
+  entries: readonly WorkerSessionTimelineEntry[],
+  requestedStart: number | null,
+): WorkerSessionTimelineWindow {
+  const maxStart = Math.max(
+    0,
+    entries.length - WORKER_SESSION_TIMELINE_WINDOW_SIZE,
+  );
+  const start = clamp(requestedStart ?? maxStart, 0, maxStart);
+  const end = Math.min(
+    entries.length,
+    start + WORKER_SESSION_TIMELINE_WINDOW_SIZE,
+  );
+
+  return {
+    end,
+    entries: entries.slice(start, end),
+    hasEarlier: start > 0,
+    hasLater: end < entries.length,
+    start,
+  };
+}
+
+export function moveWorkerSessionTimelineWindow(
+  currentStart: number,
+  direction: "earlier" | "later",
+  totalEntries: number,
+): number {
+  const maxStart = Math.max(
+    0,
+    totalEntries - WORKER_SESSION_TIMELINE_WINDOW_SIZE,
+  );
+  const nextStart =
+    direction === "earlier"
+      ? currentStart - WORKER_SESSION_TIMELINE_WINDOW_SIZE
+      : currentStart + WORKER_SESSION_TIMELINE_WINDOW_SIZE;
+  return clamp(nextStart, 0, maxStart);
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(Math.max(value, minimum), maximum);
+}

--- a/ui/src/features/worker-session-timeline/messages/worker-session-timeline.ts
+++ b/ui/src/features/worker-session-timeline/messages/worker-session-timeline.ts
@@ -74,6 +74,16 @@ export interface WorkerSessionTimelineMessages {
   sourceErrorHeading: string;
   sourceLabel: string;
   sourceSequenceLabel: (sequence: number) => string;
+  sessionTargetEmpty: string;
+  sessionTargetError: string;
+  sessionTargetLoading: string;
+  sessionTargetOption: (
+    workerSessionID: string,
+    attemptID: string,
+    state: string,
+  ) => string;
+  sessionTargetRetry: string;
+  sessionTargetSelectLabel: string;
   successorLabel: string;
   terminalOutcomeLabel: (outcome: WorkerTimelineTerminalOutcome) => string;
   terminalOutcomeHeading: string;
@@ -93,6 +103,7 @@ export interface WorkerSessionTimelineMessages {
   unknownCategoryLabel: string;
   usageLabel: string;
   usageModelLabel: string;
+  workSelectionRequired: string;
   categoryLabel: Record<WorkerTimelineEntryCategory, string>;
   phaseLabel: (phase: string) => string;
 }
@@ -165,6 +176,14 @@ const workerSessionTimelineMessagesByLocale: LocalizedMessageCatalog<WorkerSessi
       sourceErrorHeading: "Worker Session records could not be loaded",
       sourceLabel: "Source",
       sourceSequenceLabel: (sequence) => `Source sequence ${sequence}`,
+      sessionTargetEmpty:
+        "No Worker Session attempts are correlated with this Work.",
+      sessionTargetError: "Worker Session attempts could not be loaded.",
+      sessionTargetLoading: "Loading Worker Session attempts…",
+      sessionTargetOption: (workerSessionID, attemptID, state) =>
+        `${workerSessionID} · ${attemptID} · ${state}`,
+      sessionTargetRetry: "Retry Worker Session lookup",
+      sessionTargetSelectLabel: "Worker Session attempt",
       successorLabel: "Successor Worker Session",
       terminalOutcomeLabel: (outcome) =>
         outcome === "SUCCESS"
@@ -190,6 +209,8 @@ const workerSessionTimelineMessagesByLocale: LocalizedMessageCatalog<WorkerSessi
       unknownCategoryLabel: "Canonical event",
       usageLabel: "Usage",
       usageModelLabel: "Usage model",
+      workSelectionRequired:
+        "Select a Work item to inspect its Worker Session timeline.",
       categoryLabel: {
         error: "Error",
         "file-change": "File change",
@@ -271,6 +292,13 @@ const workerSessionTimelineMessagesByLocale: LocalizedMessageCatalog<WorkerSessi
       sourceErrorHeading: "无法加载 Worker 会话记录",
       sourceLabel: "来源",
       sourceSequenceLabel: (sequence) => `来源序列 ${sequence}`,
+      sessionTargetEmpty: "没有与此工作关联的 Worker 会话尝试。",
+      sessionTargetError: "无法加载 Worker 会话尝试。",
+      sessionTargetLoading: "正在加载 Worker 会话尝试…",
+      sessionTargetOption: (workerSessionID, attemptID, state) =>
+        `${workerSessionID} · ${attemptID} · ${state}`,
+      sessionTargetRetry: "重试 Worker 会话查找",
+      sessionTargetSelectLabel: "Worker 会话尝试",
       successorLabel: "后继 Worker 会话",
       terminalOutcomeLabel: (outcome) =>
         outcome === "SUCCESS"
@@ -296,6 +324,7 @@ const workerSessionTimelineMessagesByLocale: LocalizedMessageCatalog<WorkerSessi
       unknownCategoryLabel: "规范事件",
       usageLabel: "用量",
       usageModelLabel: "用量模型",
+      workSelectionRequired: "选择一个工作项以查看其 Worker 会话时间线。",
       categoryLabel: {
         error: "错误",
         "file-change": "文件变更",

--- a/ui/src/features/worker-session-timeline/messages/worker-session-timeline.ts
+++ b/ui/src/features/worker-session-timeline/messages/worker-session-timeline.ts
@@ -1,0 +1,303 @@
+import {
+  type LocalizedMessageCatalog,
+  resolveLocalizedMessages,
+} from "../../../i18n";
+import type {
+  WorkerTimelineEntryCategory,
+  WorkerTimelineTerminalOutcome,
+} from "../lib/worker-session-timeline-projection-types";
+
+export type WorkerSessionTimelineRecordingHealth =
+  | "COMPLETE"
+  | "DEGRADED"
+  | "INCOMPLETE";
+
+export type WorkerSessionTimelineViewStatus =
+  | "completed"
+  | "empty"
+  | "idle"
+  | "live"
+  | "loading"
+  | "reconnecting"
+  | "source-error";
+
+export interface WorkerSessionTimelineMessages {
+  attemptIDLabel: string;
+  attemptLabel: (number: number | undefined, id: string | undefined) => string;
+  ariaLabel: string;
+  cachedInputTokensLabel: string;
+  collapseDetailsLabel: string;
+  completedState: string;
+  continuationLabel: string;
+  detailsLabel: (expanded: boolean) => string;
+  dispatchLabel: string;
+  emptyState: string;
+  eventListLabel: string;
+  eventPositionLabel: (position: number) => string;
+  failureLabel: string;
+  genericMetadataLabel: string;
+  genericSchemaLabel: (schemaID: string) => string;
+  idleState: string;
+  incompleteRecordingNotice: (reason?: string | null) => string;
+  inputTokensLabel: string;
+  loadingState: string;
+  liveFollowingState: string;
+  messageRoleLabel: (role: string) => string;
+  messageTextLabel: string;
+  modelLabel: string;
+  modelProviderLabel: string;
+  noDetailState: string;
+  openWorkerSessionLabel: (workerSessionID: string) => string;
+  outputTokensLabel: string;
+  predecessorLabel: string;
+  providerLabel: string;
+  providerSessionLabel: string;
+  reasoningDeltaLabel: string;
+  reasoningLabel: string;
+  reasoningSnapshotLabel: string;
+  reconnectingState: string;
+  recordingHealthLabel: (
+    health: WorkerSessionTimelineRecordingHealth,
+  ) => string;
+  recordingHealthPending: string;
+  recordingHealthNotice: (
+    health: WorkerSessionTimelineRecordingHealth,
+    reason?: string | null,
+  ) => string;
+  retryAction: string;
+  retryReasonLabel: string;
+  sourceErrorHeading: string;
+  sourceLabel: string;
+  sourceSequenceLabel: (sequence: number) => string;
+  successorLabel: string;
+  terminalOutcomeLabel: (outcome: WorkerTimelineTerminalOutcome) => string;
+  terminalOutcomeHeading: string;
+  timelineTitle: string;
+  toolArgumentsLabel: string;
+  toolCallIDLabel: string;
+  toolLabel: string;
+  toolNameLabel: string;
+  toolOutputLabel: string;
+  toolResultLabel: string;
+  toolStatusLabel: string;
+  totalTokensLabel: string;
+  turnLabel: string;
+  unknownValueLabel: string;
+  unknownCategoryLabel: string;
+  usageLabel: string;
+  usageModelLabel: string;
+  categoryLabel: Record<WorkerTimelineEntryCategory, string>;
+  phaseLabel: (phase: string) => string;
+}
+
+const workerSessionTimelineMessagesByLocale: LocalizedMessageCatalog<WorkerSessionTimelineMessages> =
+  {
+    en: {
+      attemptIDLabel: "Attempt ID",
+      attemptLabel: (number, id) =>
+        number === undefined && id === undefined
+          ? "Attempt"
+          : `Attempt ${number ?? "unknown"}${id ? ` (${id})` : ""}`,
+      ariaLabel: "Worker Session timeline",
+      cachedInputTokensLabel: "Cached input tokens",
+      collapseDetailsLabel: "Collapse details",
+      completedState: "Worker Session delivery is complete.",
+      continuationLabel: "Continuation",
+      detailsLabel: (expanded) => (expanded ? "Hide details" : "Show details"),
+      dispatchLabel: "Dispatch",
+      emptyState: "No canonical Worker Session records were retained.",
+      eventListLabel: "Canonical Worker Session events",
+      eventPositionLabel: (position) => `Canonical position ${position}`,
+      failureLabel: "Failure",
+      genericMetadataLabel: "Forward-compatible event metadata",
+      genericSchemaLabel: (schemaID) => `Unknown schema ${schemaID}`,
+      idleState: "Select a Worker Session to inspect its timeline.",
+      incompleteRecordingNotice: (reason) =>
+        reason
+          ? `Some retained history may be missing. Recording reason: ${reason}.`
+          : "Some retained history may be missing.",
+      inputTokensLabel: "Input tokens",
+      loadingState: "Loading Worker Session records…",
+      liveFollowingState: "Following live Worker Session activity.",
+      messageRoleLabel: (role) => `Role: ${role}`,
+      messageTextLabel: "Message",
+      modelLabel: "Model",
+      modelProviderLabel: "Model provider",
+      noDetailState:
+        "This canonical event has no additional displayable detail.",
+      openWorkerSessionLabel: (workerSessionID) =>
+        `Open Worker Session ${workerSessionID}`,
+      outputTokensLabel: "Output tokens",
+      predecessorLabel: "Predecessor Worker Session",
+      providerLabel: "Provider",
+      providerSessionLabel: "Provider Session",
+      reasoningDeltaLabel: "Reasoning delta",
+      reasoningLabel: "Reasoning",
+      reasoningSnapshotLabel: "Reasoning snapshot",
+      reconnectingState: "Worker Session activity is reconnecting.",
+      recordingHealthLabel: (health) => `Recording: ${health}`,
+      recordingHealthPending: "Recording health pending",
+      recordingHealthNotice: (health, reason) =>
+        health === "COMPLETE"
+          ? "Retained recording is complete. This does not imply execution success."
+          : health === "DEGRADED"
+            ? reason
+              ? `Recording is degraded; some history may be unavailable. Reason: ${reason}.`
+              : "Recording is degraded; some history may be unavailable."
+            : reason
+              ? `Recording is incomplete; some history may be missing. Reason: ${reason}.`
+              : "Recording is incomplete; some history may be missing.",
+      retryAction: "Retry",
+      retryReasonLabel: "Retry reason",
+      sourceErrorHeading: "Worker Session records could not be loaded",
+      sourceLabel: "Source",
+      sourceSequenceLabel: (sequence) => `Source sequence ${sequence}`,
+      successorLabel: "Successor Worker Session",
+      terminalOutcomeLabel: (outcome) =>
+        outcome === "SUCCESS"
+          ? "Succeeded"
+          : outcome === "FAILURE"
+            ? "Failed"
+            : "Canceled",
+      terminalOutcomeHeading: "Terminal outcome",
+      timelineTitle: "Worker Session timeline",
+      toolArgumentsLabel: "Arguments",
+      toolCallIDLabel: "Tool call ID",
+      toolLabel: "Tool",
+      toolNameLabel: "Tool name",
+      toolOutputLabel: "Tool output",
+      toolResultLabel: "Result",
+      toolStatusLabel: "Tool status",
+      totalTokensLabel: "Total tokens",
+      turnLabel: "Turn",
+      unknownValueLabel: "Unknown",
+      unknownCategoryLabel: "Canonical event",
+      usageLabel: "Usage",
+      usageModelLabel: "Usage model",
+      categoryLabel: {
+        error: "Error",
+        "file-change": "File change",
+        generic: "Canonical event",
+        message: "Message",
+        plan: "Plan",
+        progress: "Progress",
+        reasoning: "Reasoning",
+        run: "Run",
+        session: "Session",
+        "stream-gap": "Stream gap",
+        tool: "Tool",
+        turn: "Turn",
+        usage: "Usage",
+      },
+      phaseLabel: (phase) => phase,
+    },
+    "zh-CN": {
+      attemptIDLabel: "尝试 ID",
+      attemptLabel: (number, id) =>
+        number === undefined && id === undefined
+          ? "尝试"
+          : `尝试 ${number ?? "未知"}${id ? `（${id}）` : ""}`,
+      ariaLabel: "Worker 会话时间线",
+      cachedInputTokensLabel: "缓存输入令牌",
+      collapseDetailsLabel: "折叠详情",
+      completedState: "Worker 会话记录已传递完成。",
+      continuationLabel: "继续关系",
+      detailsLabel: (expanded) => (expanded ? "隐藏详情" : "显示详情"),
+      dispatchLabel: "分派",
+      emptyState: "没有保留的规范 Worker 会话记录。",
+      eventListLabel: "规范 Worker 会话事件",
+      eventPositionLabel: (position) => `规范位置 ${position}`,
+      failureLabel: "失败",
+      genericMetadataLabel: "前向兼容事件元数据",
+      genericSchemaLabel: (schemaID) => `未知架构 ${schemaID}`,
+      idleState: "选择一个 Worker 会话以查看其时间线。",
+      incompleteRecordingNotice: (reason) =>
+        reason
+          ? `部分保留历史可能缺失。记录原因：${reason}。`
+          : "部分保留历史可能缺失。",
+      inputTokensLabel: "输入令牌",
+      loadingState: "正在加载 Worker 会话记录…",
+      liveFollowingState: "正在跟踪 Worker 会话实时活动。",
+      messageRoleLabel: (role) => `角色：${role}`,
+      messageTextLabel: "消息",
+      modelLabel: "模型",
+      modelProviderLabel: "模型提供方",
+      noDetailState: "此规范事件没有可显示的其他详情。",
+      openWorkerSessionLabel: (workerSessionID) =>
+        `打开 Worker 会话 ${workerSessionID}`,
+      outputTokensLabel: "输出令牌",
+      predecessorLabel: "前置 Worker 会话",
+      providerLabel: "提供方",
+      providerSessionLabel: "提供方会话",
+      reasoningDeltaLabel: "推理增量",
+      reasoningLabel: "推理",
+      reasoningSnapshotLabel: "推理快照",
+      reconnectingState: "Worker 会话活动正在重新连接。",
+      recordingHealthLabel: (health) => `记录：${health}`,
+      recordingHealthPending: "记录健康状态待定",
+      recordingHealthNotice: (health, reason) =>
+        health === "COMPLETE"
+          ? "保留记录完整。这不代表执行成功。"
+          : health === "DEGRADED"
+            ? reason
+              ? `记录已降级，部分历史可能不可用。原因：${reason}。`
+              : "记录已降级，部分历史可能不可用。"
+            : reason
+              ? `记录不完整，部分历史可能缺失。原因：${reason}。`
+              : "记录不完整，部分历史可能缺失。",
+      retryAction: "重试",
+      retryReasonLabel: "重试原因",
+      sourceErrorHeading: "无法加载 Worker 会话记录",
+      sourceLabel: "来源",
+      sourceSequenceLabel: (sequence) => `来源序列 ${sequence}`,
+      successorLabel: "后继 Worker 会话",
+      terminalOutcomeLabel: (outcome) =>
+        outcome === "SUCCESS"
+          ? "成功"
+          : outcome === "FAILURE"
+            ? "失败"
+            : "已取消",
+      terminalOutcomeHeading: "终端结果",
+      timelineTitle: "Worker 会话时间线",
+      toolArgumentsLabel: "参数",
+      toolCallIDLabel: "工具调用 ID",
+      toolLabel: "工具",
+      toolNameLabel: "工具名称",
+      toolOutputLabel: "工具输出",
+      toolResultLabel: "结果",
+      toolStatusLabel: "工具状态",
+      totalTokensLabel: "令牌总数",
+      turnLabel: "轮次",
+      unknownValueLabel: "未知",
+      unknownCategoryLabel: "规范事件",
+      usageLabel: "用量",
+      usageModelLabel: "用量模型",
+      categoryLabel: {
+        error: "错误",
+        "file-change": "文件变更",
+        generic: "规范事件",
+        message: "消息",
+        plan: "计划",
+        progress: "进度",
+        reasoning: "推理",
+        run: "运行",
+        session: "会话",
+        "stream-gap": "流间隙",
+        tool: "工具",
+        turn: "轮次",
+        usage: "用量",
+      },
+      phaseLabel: (phase) => phase,
+    },
+  };
+
+export function getWorkerSessionTimelineMessages(
+  locale?: string | null,
+): WorkerSessionTimelineMessages {
+  return resolveLocalizedMessages(
+    workerSessionTimelineMessagesByLocale,
+    locale,
+  );
+}
+
+export { workerSessionTimelineMessagesByLocale };

--- a/ui/src/features/worker-session-timeline/messages/worker-session-timeline.ts
+++ b/ui/src/features/worker-session-timeline/messages/worker-session-timeline.ts
@@ -27,13 +27,16 @@ export interface WorkerSessionTimelineMessages {
   ariaLabel: string;
   cachedInputTokensLabel: string;
   collapseDetailsLabel: string;
+  collapseContentAction: string;
   completedState: string;
   continuationLabel: string;
   detailsLabel: (expanded: boolean) => string;
   dispatchLabel: string;
+  earlierEventsAction: string;
   emptyState: string;
   eventListLabel: string;
   eventPositionLabel: (position: number) => string;
+  expandContentAction: string;
   failureLabel: string;
   genericMetadataLabel: string;
   genericSchemaLabel: (schemaID: string) => string;
@@ -44,8 +47,10 @@ export interface WorkerSessionTimelineMessages {
   liveFollowingState: string;
   messageRoleLabel: (role: string) => string;
   messageTextLabel: string;
+  laterEventsAction: string;
   modelLabel: string;
   modelProviderLabel: string;
+  newActivityAction: (count: number) => string;
   noDetailState: string;
   openWorkerSessionLabel: (workerSessionID: string) => string;
   outputTokensLabel: string;
@@ -73,6 +78,8 @@ export interface WorkerSessionTimelineMessages {
   terminalOutcomeLabel: (outcome: WorkerTimelineTerminalOutcome) => string;
   terminalOutcomeHeading: string;
   timelineTitle: string;
+  windowNavigationLabel: string;
+  windowRangeLabel: (start: number, end: number, total: number) => string;
   toolArgumentsLabel: string;
   toolCallIDLabel: string;
   toolLabel: string;
@@ -101,13 +108,16 @@ const workerSessionTimelineMessagesByLocale: LocalizedMessageCatalog<WorkerSessi
       ariaLabel: "Worker Session timeline",
       cachedInputTokensLabel: "Cached input tokens",
       collapseDetailsLabel: "Collapse details",
+      collapseContentAction: "Hide full content",
       completedState: "Worker Session delivery is complete.",
       continuationLabel: "Continuation",
       detailsLabel: (expanded) => (expanded ? "Hide details" : "Show details"),
       dispatchLabel: "Dispatch",
+      earlierEventsAction: "Earlier events",
       emptyState: "No canonical Worker Session records were retained.",
       eventListLabel: "Canonical Worker Session events",
       eventPositionLabel: (position) => `Canonical position ${position}`,
+      expandContentAction: "Show full content",
       failureLabel: "Failure",
       genericMetadataLabel: "Forward-compatible event metadata",
       genericSchemaLabel: (schemaID) => `Unknown schema ${schemaID}`,
@@ -121,8 +131,11 @@ const workerSessionTimelineMessagesByLocale: LocalizedMessageCatalog<WorkerSessi
       liveFollowingState: "Following live Worker Session activity.",
       messageRoleLabel: (role) => `Role: ${role}`,
       messageTextLabel: "Message",
+      laterEventsAction: "Later events",
       modelLabel: "Model",
       modelProviderLabel: "Model provider",
+      newActivityAction: (count) =>
+        `View ${count} new ${count === 1 ? "event" : "events"}`,
       noDetailState:
         "This canonical event has no additional displayable detail.",
       openWorkerSessionLabel: (workerSessionID) =>
@@ -161,6 +174,9 @@ const workerSessionTimelineMessagesByLocale: LocalizedMessageCatalog<WorkerSessi
             : "Canceled",
       terminalOutcomeHeading: "Terminal outcome",
       timelineTitle: "Worker Session timeline",
+      windowNavigationLabel: "Timeline window navigation",
+      windowRangeLabel: (start, end, total) =>
+        `Events ${start}–${end} of ${total}`,
       toolArgumentsLabel: "Arguments",
       toolCallIDLabel: "Tool call ID",
       toolLabel: "Tool",
@@ -200,13 +216,16 @@ const workerSessionTimelineMessagesByLocale: LocalizedMessageCatalog<WorkerSessi
       ariaLabel: "Worker 会话时间线",
       cachedInputTokensLabel: "缓存输入令牌",
       collapseDetailsLabel: "折叠详情",
+      collapseContentAction: "隐藏完整内容",
       completedState: "Worker 会话记录已传递完成。",
       continuationLabel: "继续关系",
       detailsLabel: (expanded) => (expanded ? "隐藏详情" : "显示详情"),
       dispatchLabel: "分派",
+      earlierEventsAction: "更早的事件",
       emptyState: "没有保留的规范 Worker 会话记录。",
       eventListLabel: "规范 Worker 会话事件",
       eventPositionLabel: (position) => `规范位置 ${position}`,
+      expandContentAction: "显示完整内容",
       failureLabel: "失败",
       genericMetadataLabel: "前向兼容事件元数据",
       genericSchemaLabel: (schemaID) => `未知架构 ${schemaID}`,
@@ -220,8 +239,10 @@ const workerSessionTimelineMessagesByLocale: LocalizedMessageCatalog<WorkerSessi
       liveFollowingState: "正在跟踪 Worker 会话实时活动。",
       messageRoleLabel: (role) => `角色：${role}`,
       messageTextLabel: "消息",
+      laterEventsAction: "更晚的事件",
       modelLabel: "模型",
       modelProviderLabel: "模型提供方",
+      newActivityAction: (count) => `查看 ${count} 个新事件`,
       noDetailState: "此规范事件没有可显示的其他详情。",
       openWorkerSessionLabel: (workerSessionID) =>
         `打开 Worker 会话 ${workerSessionID}`,
@@ -258,6 +279,9 @@ const workerSessionTimelineMessagesByLocale: LocalizedMessageCatalog<WorkerSessi
             ? "失败"
             : "已取消",
       terminalOutcomeHeading: "终端结果",
+      windowNavigationLabel: "时间线窗口导航",
+      windowRangeLabel: (start, end, total) =>
+        `事件 ${start}–${end}，共 ${total} 个`,
       timelineTitle: "Worker 会话时间线",
       toolArgumentsLabel: "参数",
       toolCallIDLabel: "工具调用 ID",


### PR DESCRIPTION
# WSR-007 Dashboard Worker Session timeline

This PR implements the PRD for WSR-007: the dashboard renders one chronological, bounded Worker Session timeline from canonical API event records for both live and historical inspection. It covers provider/model identity, attempts, continuation links, messages, reasoning, tools, usage, terminal outcomes, explicit network and recording-health states, accessibility, and responsive behavior.

## What changed

- Added a pure provider-neutral projection for canonical Worker Session records, including lifecycle, attempts, retry reasons, continuation lineage, messages, reasoning, tools, usage, failures, terminal outcomes, and bounded unknown-schema metadata.
- Added the typed Worker Session event adapter and retained-to-live hook with cursor and generation validation, duplicate overlap suppression, reconnect handling, source-failure preservation, replay health, and terminal stopping.
- Added the localized dashboard timeline card, Work-correlated Worker Session selection, explicit loading/empty/live/completed/error states, independent COMPLETE/DEGRADED/INCOMPLETE recording health, accessible disclosures, and terminal outcome presentation.
- Added a pure 200-row chronological window with deterministic earlier/later navigation, pending live activity, keyboard live-tail recovery, focus-preserving appends, semantic row positions, bounded detail content, and responsive overflow guards.
- Added WSR-UI-001 and WSR-UI-002 browser coverage for canonical retained/live ordering, duplicate handoff, retry and continuation attribution, source failure, long mixed histories, bounded DOM rows, keyboard navigation, focus stability, terminal completion, and desktop/phone overflow.

## Verification

- Full mocked-browser integration: 15 files and 38 tests passed.
- Focused Worker Session browser integration: 3 tests passed.
- Focused Worker Session Bun component/unit coverage: 24 tests passed.
- TypeScript typecheck passed.
- Frontend lint passed with existing informational allowlist/generated-artifact findings only.

The final implementation is pushed at the current branch head. CI is expected to run on that head; merge remains with the review workstation.