### PR TITLE
thr-coverage-gate-enumerate-missing

### DIFF
--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -314,7 +314,7 @@ func run(cfg config) (coverageResult, error) {
 		if !filepath.IsAbs(manifestPath) {
 			manifestPath = filepath.Join(repoRoot, manifestPath)
 		}
-		manifest, err := readCoverageManifestFile(manifestPath, cfg.suite, packageImportPaths(result.packageSummaries))
+		manifest, err := readCoverageManifestFileWithTotals(manifestPath, cfg.suite, packageImportPaths(result.packageSummaries), result.packageTotals)
 		if err != nil {
 			return coverageResult{}, err
 		}

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -131,6 +131,10 @@ func execute(cfg config) error {
 	}
 	result, err := run(cfg)
 	if err != nil {
+		var validationErr *coverageManifestValidationError
+		if errors.As(err, &validationErr) {
+			writePackageCoverageSummaries(result.packageSummaries)
+		}
 		return err
 	}
 
@@ -143,9 +147,7 @@ func execute(cfg config) error {
 	}
 	failures = append(failures, result.packageMinimumFailures...)
 
-	for _, summary := range result.packageSummaries {
-		fmt.Fprintf(stdoutWriter, "%s\tcoverage: %.1f%% of statements\n", summary.importPath, summary.coverage)
-	}
+	writePackageCoverageSummaries(result.packageSummaries)
 	if cfg.generateManifest != "" {
 		if err := createCoverageManifest(cfg.generateManifest, cfg.suite, result.packageTotals, packageImportPaths(result.packageSummaries)); err != nil {
 			return err
@@ -309,6 +311,7 @@ func run(cfg config) (coverageResult, error) {
 	if err != nil {
 		return coverageResult{}, err
 	}
+	fmt.Fprintln(stdoutWriter, totalLine)
 	if !cfg.totalOnly && strings.TrimSpace(cfg.packageManifest) != "" {
 		manifestPath := cfg.packageManifest
 		if !filepath.IsAbs(manifestPath) {
@@ -316,6 +319,10 @@ func run(cfg config) (coverageResult, error) {
 		}
 		manifest, err := readCoverageManifestFileWithTotals(manifestPath, cfg.suite, packageImportPaths(result.packageSummaries), result.packageTotals)
 		if err != nil {
+			var validationErr *coverageManifestValidationError
+			if errors.As(err, &validationErr) {
+				return result, err
+			}
 			return coverageResult{}, err
 		}
 		result.packageMinimumFailures, result.packageMinimumWarnings = checkCoverageManifestWithEpsilon(manifest, result.packageTotals, cfg.packageManifest, cfg.packageFloorEpsilon)
@@ -323,8 +330,13 @@ func run(cfg config) (coverageResult, error) {
 	} else if legacyPackageGateEnabled {
 		result.packageGates = packageGatesFromLegacyMin(result.packageSummaries, cfg.packageCoverageMin(), baselinePackages)
 	}
-	fmt.Fprintln(stdoutWriter, totalLine)
 	return result, nil
+}
+
+func writePackageCoverageSummaries(summaries []packageCoverageSummary) {
+	for _, summary := range summaries {
+		fmt.Fprintf(stdoutWriter, "%s\tcoverage: %.1f%% of statements\n", summary.importPath, summary.coverage)
+	}
 }
 
 func (cfg config) testJobs() int {

--- a/cmd/gocoveragecheck/main_run_test.go
+++ b/cmd/gocoveragecheck/main_run_test.go
@@ -63,6 +63,122 @@ func TestExecuteReportsPassingCoverage(t *testing.T) {
 	}
 }
 
+func TestExecuteReportsPackageSummariesWhenManifestValidationFails(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	defer func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	}()
+
+	configPackage := modulePath + "/pkg/config"
+	servicePackage := modulePath + "/pkg/service"
+	manifestPath := writePackageMinimumManifest(t, "unit", configPackage, "100.00")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeGoCoverageCommandPassing
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	err := execute(config{
+		min:             0,
+		suite:           "unit",
+		coverpkg:        strings.Join([]string{configPackage, servicePackage}, ","),
+		packages:        "./pkg/config",
+		packageManifest: manifestPath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "measured unit package \""+servicePackage+"\" has no manifest entry") {
+		t.Fatalf("execute() error = %v, want missing-manifest validation failure", err)
+	}
+
+	wantSummaries := configPackage + "\tcoverage: 100.0% of statements\n" + servicePackage + "\tcoverage: 100.0% of statements\n"
+	if got := stdout.String(); !strings.Contains(got, "total: (statements) 100.0%") || !strings.Contains(got, wantSummaries) {
+		t.Fatalf("execute() stdout = %q, want total and exact package summaries", got)
+	}
+	if strings.Contains(stdout.String(), "meets minimum") {
+		t.Fatalf("execute() stdout = %q, did not expect success message", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+	}
+}
+
+func TestExecuteReportsPackageSummariesForCompleteManifest(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	defer func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	}()
+
+	configPackage := modulePath + "/pkg/config"
+	manifestPath := writePackageMinimumManifest(t, "unit", configPackage, "100.00")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeGoCoverageCommandPassing
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	err := execute(config{
+		min:             0,
+		suite:           "unit",
+		coverpkg:        configPackage,
+		packages:        "./pkg/config",
+		packageManifest: manifestPath,
+	})
+	if err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+
+	got := stdout.String()
+	wantSummary := configPackage + "\tcoverage: 100.0% of statements\n"
+	if strings.Count(got, wantSummary) != 1 {
+		t.Fatalf("execute() stdout = %q, want one package summary %q", got, wantSummary)
+	}
+	if !strings.Contains(got, "Go coverage 100.0% meets minimum 0.0%.") {
+		t.Fatalf("execute() stdout = %q, want success message", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+	}
+}
+
+func TestExecuteDoesNotReportPackageSummariesWhenMeasurementFails(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	defer func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	}()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeGoCoverageCommandTestFailsWithoutDetail
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	err := execute(config{
+		min:      0,
+		coverpkg: modulePath + "/pkg/config",
+		packages: "./pkg/config",
+	})
+	if err == nil {
+		t.Fatal("execute() unexpectedly succeeded")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("execute() stdout = %q, want no package summaries without a valid measurement", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+	}
+}
+
 func TestExecuteTotalOnlyReportsIndependentSuiteCoverageWithPackageSummaries(t *testing.T) {
 	originalCommandRunner := commandRunner
 	originalStdout := stdoutWriter

--- a/cmd/gocoveragecheck/manifest.go
+++ b/cmd/gocoveragecheck/manifest.go
@@ -133,6 +133,10 @@ func readCoverageManifest(data []byte, expectedLane string, measuredPackages []s
 	return readCoverageManifestAt(data, expectedLane, measuredPackages, time.Now().UTC())
 }
 
+func readCoverageManifestWithTotals(data []byte, expectedLane string, measuredPackages []string, measuredTotals map[string]packageCoverageTotals) (coverageManifest, error) {
+	return readCoverageManifestAtModeWithTotals(data, expectedLane, measuredPackages, time.Now().UTC(), true, measuredTotals)
+}
+
 func readCoverageManifestAt(data []byte, expectedLane string, measuredPackages []string, now time.Time) (coverageManifest, error) {
 	return readCoverageManifestAtMode(data, expectedLane, measuredPackages, now, true)
 }
@@ -142,6 +146,10 @@ func readCoverageManifestForUpdate(data []byte, expectedLane string, measuredPac
 }
 
 func readCoverageManifestAtMode(data []byte, expectedLane string, measuredPackages []string, now time.Time, requireComplete bool) (coverageManifest, error) {
+	return readCoverageManifestAtModeWithTotals(data, expectedLane, measuredPackages, now, requireComplete, nil)
+}
+
+func readCoverageManifestAtModeWithTotals(data []byte, expectedLane string, measuredPackages []string, now time.Time, requireComplete bool, measuredTotals map[string]packageCoverageTotals) (coverageManifest, error) {
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
 	var manifest coverageManifest
@@ -151,7 +159,7 @@ func readCoverageManifestAtMode(data []byte, expectedLane string, measuredPackag
 	if err := ensureJSONEOF(decoder); err != nil {
 		return coverageManifest{}, err
 	}
-	if err := validateCoverageManifestAtMode(manifest, expectedLane, measuredPackages, now, requireComplete); err != nil {
+	if err := validateCoverageManifestAtModeWithTotals(manifest, expectedLane, measuredPackages, now, requireComplete, measuredTotals); err != nil {
 		return coverageManifest{}, err
 	}
 	return manifest, nil
@@ -175,7 +183,15 @@ func validateCoverageManifestAt(manifest coverageManifest, expectedLane string, 
 	return validateCoverageManifestAtMode(manifest, expectedLane, measuredPackages, now, true)
 }
 
+func validateCoverageManifestAtWithTotals(manifest coverageManifest, expectedLane string, measuredPackages []string, now time.Time, measuredTotals map[string]packageCoverageTotals) error {
+	return validateCoverageManifestAtModeWithTotals(manifest, expectedLane, measuredPackages, now, true, measuredTotals)
+}
+
 func validateCoverageManifestAtMode(manifest coverageManifest, expectedLane string, measuredPackages []string, now time.Time, requireComplete bool) error {
+	return validateCoverageManifestAtModeWithTotals(manifest, expectedLane, measuredPackages, now, requireComplete, nil)
+}
+
+func validateCoverageManifestAtModeWithTotals(manifest coverageManifest, expectedLane string, measuredPackages []string, now time.Time, requireComplete bool, measuredTotals map[string]packageCoverageTotals) error {
 	if manifest.Version != coverageManifestVersion {
 		return fmt.Errorf("validate go coverage manifest: version %d is unsupported; expected %d", manifest.Version, coverageManifestVersion)
 	}
@@ -217,13 +233,43 @@ func validateCoverageManifestAtMode(manifest coverageManifest, expectedLane stri
 		previous = entry.Package
 	}
 	if requireComplete {
-		for _, importPath := range measuredPackages {
+		missing := make([]string, 0)
+		for importPath := range measured {
 			if _, ok := seen[importPath]; !ok {
-				return fmt.Errorf("validate go coverage manifest: measured %s package %q has no manifest entry", expectedLane, importPath)
+				missing = append(missing, importPath)
 			}
+		}
+		if len(missing) > 0 {
+			slices.Sort(missing)
+			return formatMissingCoverageManifestEntries(expectedLane, missing, measuredTotals)
 		}
 	}
 	return nil
+}
+
+func formatMissingCoverageManifestEntries(lane string, missing []string, measuredTotals map[string]packageCoverageTotals) error {
+	lines := make([]string, 0, len(missing))
+	for _, importPath := range missing {
+		line := fmt.Sprintf("- measured %s package %q has no manifest entry", lane, importPath)
+		if measuredTotals != nil {
+			totals := measuredTotals[importPath]
+			switch {
+			case totals.totalStatements == 0 && totals.coveredStatements == 0:
+				line += "; no measurable statements"
+			case totals.totalStatements > 0:
+				floor, err := coverageFloorFromTotals(totals)
+				if err != nil {
+					line += fmt.Sprintf("; measured coverage unavailable: %v", err)
+				} else {
+					line += fmt.Sprintf("; measured coverage %s%%", floor)
+				}
+			default:
+				line += "; measured coverage unavailable"
+			}
+		}
+		lines = append(lines, line)
+	}
+	return fmt.Errorf("validate go coverage manifest: measured %s packages have no manifest entry:\n%s", lane, strings.Join(lines, "\n"))
 }
 
 func dateOnlyUTC(value time.Time) time.Time {
@@ -232,11 +278,20 @@ func dateOnlyUTC(value time.Time) time.Time {
 }
 
 func readCoverageManifestFile(filename string, lane string, measuredPackages []string) (coverageManifest, error) {
+	return readCoverageManifestFileWithTotals(filename, lane, measuredPackages, nil)
+}
+
+func readCoverageManifestFileWithTotals(filename string, lane string, measuredPackages []string, measuredTotals map[string]packageCoverageTotals) (coverageManifest, error) {
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		return coverageManifest{}, fmt.Errorf("read %s go coverage manifest: %w", lane, err)
 	}
-	manifest, err := readCoverageManifest(data, lane, measuredPackages)
+	var manifest coverageManifest
+	if measuredTotals == nil {
+		manifest, err = readCoverageManifest(data, lane, measuredPackages)
+	} else {
+		manifest, err = readCoverageManifestWithTotals(data, lane, measuredPackages, measuredTotals)
+	}
 	if err != nil {
 		return coverageManifest{}, err
 	}

--- a/cmd/gocoveragecheck/manifest.go
+++ b/cmd/gocoveragecheck/manifest.go
@@ -40,6 +40,18 @@ type coverageManifestException struct {
 	RemovalGate   string `json:"removalGate"`
 }
 
+type coverageManifestValidationError struct {
+	err error
+}
+
+func (err *coverageManifestValidationError) Error() string {
+	return err.err.Error()
+}
+
+func (err *coverageManifestValidationError) Unwrap() error {
+	return err.err
+}
+
 func createCoverageManifest(filename string, lane string, totals map[string]packageCoverageTotals, packages []string) error {
 	manifest, err := newCoverageManifest(lane, totals, packages)
 	if err != nil {
@@ -160,7 +172,7 @@ func readCoverageManifestAtModeWithTotals(data []byte, expectedLane string, meas
 		return coverageManifest{}, err
 	}
 	if err := validateCoverageManifestAtModeWithTotals(manifest, expectedLane, measuredPackages, now, requireComplete, measuredTotals); err != nil {
-		return coverageManifest{}, err
+		return coverageManifest{}, &coverageManifestValidationError{err: err}
 	}
 	return manifest, nil
 }

--- a/cmd/gocoveragecheck/manifest_test.go
+++ b/cmd/gocoveragecheck/manifest_test.go
@@ -263,6 +263,51 @@ func TestCheckCoverageManifestControlledProfilesForBothLanes(t *testing.T) {
 	}
 }
 
+func TestValidateCoverageManifestReportsAllMissingPackagesWithMeasurements(t *testing.T) {
+	t.Parallel()
+
+	alpha := modulePath + "/pkg/alpha"
+	beta := modulePath + "/pkg/beta"
+	zeta := modulePath + "/pkg/zeta"
+	manifest := coverageManifest{
+		Version: coverageManifestVersion,
+		Lane:    "functional",
+		Packages: []coverageManifestEntry{
+			{Package: alpha, Minimum: json.RawMessage("80.00")},
+		},
+	}
+	err := validateCoverageManifestAtWithTotals(
+		manifest,
+		"functional",
+		[]string{zeta, alpha, beta},
+		time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC),
+		map[string]packageCoverageTotals{
+			beta: {coveredStatements: 2, totalStatements: 3},
+			zeta: {},
+		},
+	)
+	if err == nil {
+		t.Fatal("validateCoverageManifestAtWithTotals() unexpectedly succeeded")
+	}
+
+	message := err.Error()
+	if !strings.Contains(message, "measured functional packages have no manifest entry") {
+		t.Fatalf("missing-entry error = %q, want functional lane diagnostic", message)
+	}
+	if strings.Count(message, "has no manifest entry") != 2 {
+		t.Fatalf("missing-entry error = %q, want one line per missing package", message)
+	}
+	if !strings.Contains(message, `measured functional package "`+beta+`" has no manifest entry; measured coverage 66.66%`) {
+		t.Fatalf("missing-entry error = %q, want truncated two-decimal beta measurement", message)
+	}
+	if !strings.Contains(message, `measured functional package "`+zeta+`" has no manifest entry; no measurable statements`) {
+		t.Fatalf("missing-entry error = %q, want no-measurable-statements classification", message)
+	}
+	if strings.Index(message, beta) > strings.Index(message, zeta) {
+		t.Fatalf("missing packages are not sorted by import path: %q", message)
+	}
+}
+
 func TestCheckCoverageManifestAppliesRawStatementEpsilon(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/gocoveragecheck/manifest_test.go
+++ b/cmd/gocoveragecheck/manifest_test.go
@@ -139,6 +139,7 @@ func TestReadCoverageManifestValidatesContract(t *testing.T) {
 		{name: "invalid percentage", manifest: `{"version":1,"lane":"unit","packages":[{"package":"` + configPackage + `","minimum":100.01}]}`, measured: []string{configPackage}, want: "between 0.00 and 100.00"},
 		{name: "imprecise percentage", manifest: `{"version":1,"lane":"unit","packages":[{"package":"` + configPackage + `","minimum":80.0}]}`, measured: []string{configPackage}, want: "exactly two decimal places"},
 		{name: "both entry forms", manifest: `{"version":1,"lane":"unit","packages":[{"package":"` + configPackage + `","minimum":80.00,"exception":{"kind":"migration"}}]}`, measured: []string{configPackage}, want: "exactly one"},
+		{name: "neither entry form", manifest: `{"version":1,"lane":"unit","packages":[{"package":"` + configPackage + `"}]}`, measured: []string{configPackage}, want: "exactly one"},
 		{name: "malformed exception", manifest: `{"version":1,"lane":"unit","packages":[{"package":"` + configPackage + `","exception":{"kind":"coverage","justification":"low coverage","owner":"team","deadline":"soon","removalGate":"more tests"}}]}`, measured: []string{configPackage}, want: "must be measurement or migration"},
 		{name: "unknown field", manifest: `{"version":1,"lane":"unit","unknown":true,"packages":[]}`, measured: nil, want: "unknown field"},
 	}


### PR DESCRIPTION
{
  "project": "Exhaustive Go Coverage Manifest Diagnostics",
  "branchName": "thr-coverage-gate-enumerate-missing",
  "description": "Change cmd/gocoveragecheck reporting so one incomplete-manifest run lists every missing measured package in deterministic order, includes the two-decimal measured coverage or an explicit no-measurable-statements classification for each, and still prints the established per-package stdout report. Preserve manifest policy, measured trees, existing validation behavior, pass/fail semantics, and the strict cmd/gocoveragecheck-only ownership boundary.",
  "context": {
    "customerAsk": "Make incomplete unit and functional Go coverage manifests actionable in one run by reporting all missing packages with the measurement needed to author each entry and by printing the established per-package report even when validation fails. Preserve recognizable error wording, existing validation behavior, gate semantics, and the lane's exclusive ownership of cmd/gocoveragecheck/**.",
    "problem": "Completeness validation returns on the first missing package, and execute returns the manifest error before printing package summaries. Contributors who add parent, internal, and wire packages learn about them one CI round at a time and then need another run to discover their coverage floors. PR #1915 required four rounds, while eleven upcoming BTRC/WSE lanes are expected to create similar separately measured package shapes.",
    "solution": "Use the coverage totals already computed before manifest validation to build one sorted completeness error containing every missing package and its actionable two-decimal coverage or no-measurable-statements classification. Preserve the measured result alongside a validation error so execute can emit the existing exact stdout package report before returning the same failure. Add focused behavioral compatibility coverage and demonstrate the workflow with a temporary copy of a real baseline, without editing canonical baselines or any surface outside cmd/gocoveragecheck/**."
  },
  "acceptanceCriteria": [
    "An incomplete unit or functional manifest with multiple missing measured packages fails once and reports every missing package, sorted by import path and one per line, while naming the active lane and retaining the searchable phrase `has no manifest entry`.",
    "Each missing-package line reports the active profile's measured coverage to two decimal places when statements are measurable or explicitly says there are no measurable statements so authors can distinguish a measurement exception from a numeric minimum.",
    "When manifest validation fails after successful measurement, all available package summaries are written to the existing stdout writer using the exact format `%s\\tcoverage: %.1f%% of statements\\n`, while complete manifests retain established successful behavior.",
    "Existing manifest validation messages and precedence remain intact for duplicate packages, out-of-sort-order entries, both or neither entry forms, out-of-range minimums, and unknown lanes; trees retain their current pass/fail exit status.",
    "The implementation changes only cmd/gocoveragecheck/** and does not edit either baseline JSON file, .github workflows, pkg/**, tests/**, ui/**, measured trees, manifest values, or manifest generation/update behavior.",
    "Focused cmd/gocoveragecheck tests, the short Go suite, make test-unit-coverage, and make test-functional-coverage pass; Typecheck passes; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green; any existing cmd/gocoveragecheck coverage floor remains satisfied.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts are resolved, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "thr-coverage-gate-enumerate-missing-001",
      "title": "Report every missing package with an actionable measurement",
      "description": "As a contributor adding Go packages, I want one manifest validation failure to list every missing package with its measured coverage classification so I can add all correct entries without repeated discovery runs.",
      "acceptanceCriteria": [
        "A manifest missing N measured packages produces one validation error that names all N packages rather than returning after the first.",
        "Missing packages are listed one per line in ascending import-path order regardless of measured-package input order.",
        "The leading diagnostic names the active unit or functional lane and retains the exact searchable phrase `has no manifest entry`.",
        "A missing package with measurable statements shows its coverage to two decimal places using the same coverage totals and floor semantics used for manifest enforcement.",
        "A missing package with zero measurable statements is explicitly labeled as having no measurable statements and is not presented as ordinary 0.00% coverage.",
        "Focused tests cover multiple missing packages, unsorted input, numeric measurements, and the no-measurable-statements case.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented sorted exhaustive missing-package diagnostics with two-decimal coverage floors or explicit no-measurable-statements classifications. Focused checker tests, go vet, and make typecheck pass; the unchanged full package suite still hits the machine's pre-existing Temp\\go.mod repo-root test failure."
    },
    {
      "id": "thr-coverage-gate-enumerate-missing-002",
      "title": "Print package coverage summaries when manifest validation fails",
      "description": "As a contributor diagnosing a coverage-gate failure, I want the normal per-package report even on an incomplete manifest so the failed run remains useful to me and existing output consumers.",
      "acceptanceCriteria": [
        "If coverage measurement succeeds but manifest validation fails, execute writes every available package summary to the configured stdout writer before returning the validation error.",
        "Every failure-path summary uses the exact established format `%s\\tcoverage: %.1f%% of statements\\n`, including its tab, precision, wording, and newline.",
        "Package summaries remain on stdout, while the manifest validation error remains the returned failure surfaced through the existing error path.",
        "The checker does not report package summaries when measurement itself fails and no valid coverage result exists.",
        "Complete-manifest runs retain the established report, success message, and exit behavior without duplicate summary lines.",
        "Focused execution tests capture configured writers and prove both validation-failure and complete-manifest behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented typed manifest-validation partial results so execute emits the total and exact per-package stdout report before returning the unchanged validation failure. Added focused validation-failure, complete-manifest, and measurement-failure execution tests; make test and make typecheck pass, with the unchanged root-discovery test remaining environment-sensitive."
    },
    {
      "id": "thr-coverage-gate-enumerate-missing-003",
      "title": "Preserve gate compatibility and prove the one-run workflow",
      "description": "As a coverage-gate operator, I want direct regression and real-profile evidence that richer diagnostics do not weaken enforcement so I can rely on the checker across all concurrent package-sealing lanes.",
      "acceptanceCriteria": [
        "Focused behavioral tests prove that a fully registered manifest still passes and retains its established observable output and exit behavior.",
        "Focused tests prove the current messages still fire for a duplicate package, an out-of-sort-order entry, both minimum and exception, neither minimum nor exception, a minimum outside 0.00-100.00, and an unknown lane.",
        "Using a temporary copy of a real unit or functional baseline with two or three entries removed, one checker run reports all removed packages together in sorted order with numeric measurements or explicit no-measurable-statements markers while stdout still contains the package report.",
        "The real-profile command and captured output are posted in a PR comment and are not committed; canonical baseline files remain untouched.",
        "make test-unit-coverage and make test-functional-coverage pass unchanged with complete manifests, and the PR records whether cmd/gocoveragecheck has its own coverage floor and confirms it remains satisfied when applicable.",
        "The final implementation diff remains limited to cmd/gocoveragecheck/** with no unrelated cleanup or generation/update feature work.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added the missing minimum-or-exception compatibility regression. Focused checker tests, go vet, make test, make typecheck, and cmd/gocoveragecheck coverage (88.6%) pass. A disposable copy of the real functional baseline with the first three entries removed produced one exit-1 diagnostic listing all three in sorted order (no measurable statements, 72.91%, 77.23%) and 549 exact stdout summaries; canonical baseline SHA256 stayed unchanged. make test-unit-coverage is blocked on Windows command-line length and unrelated baseline failures in pkg/transports/cli and pkg/transports/http; make test-functional-coverage reaches the gate but retains the existing pkg/platform/filesystem floor regression."
    }
  ]
}
