### PR TITLE
thr-deflake-runtimelog-and-workmove-report

### DIFF
--- a/pkg/services/work/transports/cli/move.go
+++ b/pkg/services/work/transports/cli/move.go
@@ -129,7 +129,10 @@ func (service *service) Move(cfg MoveConfig) error {
 		return fmt.Errorf("move work failed (%d)", resp.StatusCode)
 	}
 
-	newState := stateNameFromWork(moved)
+	// The move response is a read-after-write projection and may already show
+	// scheduler progress. Report the successful operator-applied target rather
+	// than allowing that later state to replace the requested transition.
+	newState := stateName
 	clidiag.Printf(
 		cfg.Diagnostics,
 		cfg.Verbose,

--- a/pkg/services/work/transports/cli/move.go
+++ b/pkg/services/work/transports/cli/move.go
@@ -129,10 +129,7 @@ func (service *service) Move(cfg MoveConfig) error {
 		return fmt.Errorf("move work failed (%d)", resp.StatusCode)
 	}
 
-	// The move response is a read-after-write projection and may already show
-	// scheduler progress. Report the successful operator-applied target rather
-	// than allowing that later state to replace the requested transition.
-	newState := stateName
+	// The response may already reflect scheduler progress; report the requested target.
 	clidiag.Printf(
 		cfg.Diagnostics,
 		cfg.Verbose,
@@ -142,13 +139,13 @@ func (service *service) Move(cfg MoveConfig) error {
 		response.Duration.Milliseconds(),
 		cfg.WorkID,
 		previousState,
-		newState,
+		stateName,
 	)
 
 	result := MoveSuccessResult{
 		WorkID:        cfg.WorkID,
 		PreviousState: previousState,
-		NewState:      newState,
+		NewState:      stateName,
 		SessionID:     clidiag.SessionLabel(cfg.SessionID),
 		EndpointPath:  moveEndpoint.Path,
 	}

--- a/pkg/services/work/transports/cli/service_parity_test.go
+++ b/pkg/services/work/transports/cli/service_parity_test.go
@@ -240,12 +240,12 @@ func TestConstructedService_MoveHumanOutputPreservesMoveSummary(t *testing.T) {
 		case r.Method == http.MethodGet:
 			writeJSONResponse(t, w, factoryapi.Work{
 				WorkId: stringPtr("work-move-1"),
-				State:  &factoryapi.WorkState{Name: "init", Type: factoryapi.WorkStateTypeINITIAL},
+				State:  &factoryapi.WorkState{Name: "failed", Type: factoryapi.WorkStateTypeFAILED},
 			})
 		case r.Method == http.MethodPost:
 			writeJSONResponse(t, w, factoryapi.Work{
 				WorkId: stringPtr("work-move-1"),
-				State:  &factoryapi.WorkState{Name: "complete", Type: factoryapi.WorkStateTypeTERMINAL},
+				State:  &factoryapi.WorkState{Name: "processing", Type: factoryapi.WorkStateTypePROCESSING},
 			})
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
@@ -259,7 +259,7 @@ func TestConstructedService_MoveHumanOutputPreservesMoveSummary(t *testing.T) {
 		Context:   context.Background(),
 		Server:    strings.TrimSuffix(srv.URL, "/"),
 		WorkID:    "work-move-1",
-		StateName: "complete",
+		StateName: "init",
 		Output:    &out,
 		HTTP:      testHTTPProtocol(t),
 	})
@@ -269,8 +269,8 @@ func TestConstructedService_MoveHumanOutputPreservesMoveSummary(t *testing.T) {
 
 	want := "" +
 		"Work ID:\twork-move-1\n" +
-		"Previous state:\tinit\n" +
-		"New state:\tcomplete\n" +
+		"Previous state:\tfailed\n" +
+		"New state:\tinit\n" +
 		"Session ID:\t~default\n"
 	if got := out.String(); got != want {
 		t.Fatalf("output = %q, want %q", got, want)
@@ -290,7 +290,7 @@ func TestConstructedService_MoveJSONOutputEmitsStableEnvelope(t *testing.T) {
 		case r.Method == http.MethodPost:
 			writeJSONResponse(t, w, factoryapi.Work{
 				WorkId: stringPtr("work-move-1"),
-				State:  &factoryapi.WorkState{Name: "init", Type: factoryapi.WorkStateTypeINITIAL},
+				State:  &factoryapi.WorkState{Name: "processing", Type: factoryapi.WorkStateTypePROCESSING},
 			})
 		}
 	}))

--- a/tests/functional/runtime_api/api_runtime_log_policy_test.go
+++ b/tests/functional/runtime_api/api_runtime_log_policy_test.go
@@ -2,17 +2,24 @@ package runtime_api
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/portpowered/infinite-you/internal/testutil"
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	runtimeAPILogObservationTimeout  = 2 * time.Second
+	runtimeAPILogObservationInterval = 10 * time.Millisecond
 )
 
 func TestFunctionalAPIServer_UsesProductionRuntimeFileLoggingDefault(t *testing.T) {
@@ -103,22 +110,48 @@ func collectRuntimeLogFiles(t *testing.T, dir string) []string {
 func requireRuntimeAPILogMessage(t *testing.T, path, message string) map[string]any {
 	t.Helper()
 
+	// The status endpoint can become ready before the asynchronous runtime-log
+	// appender flushes its startup record. Observe only the target file and
+	// message at a bounded interval so this test does not sleep or retry the
+	// whole application scenario.
+	deadline := time.NewTimer(runtimeAPILogObservationTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(runtimeAPILogObservationInterval)
+	defer ticker.Stop()
+
+	for {
+		record, found, err := readRuntimeAPILogMessage(path, message)
+		if err != nil {
+			t.Fatalf("observe runtime log %q for msg %q: %v", path, message, err)
+		}
+		if found {
+			return record
+		}
+
+		select {
+		case <-ticker.C:
+		case <-deadline.C:
+			t.Fatalf("timed out after %s waiting for runtime log %q to contain msg %q", runtimeAPILogObservationTimeout, path, message)
+		}
+	}
+}
+
+func readRuntimeAPILogMessage(path, message string) (map[string]any, bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("ReadFile(%s): %v", path, err)
+		return nil, false, fmt.Errorf("read file: %w", err)
 	}
-	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+	for lineNumber, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
 		var record map[string]any
 		if err := json.Unmarshal([]byte(line), &record); err != nil {
-			t.Fatalf("runtime log line is not structured JSON: %v\nline: %s", err, line)
+			return nil, false, fmt.Errorf("decode structured JSON at line %d: %w; line: %s", lineNumber+1, err, line)
 		}
 		if record["msg"] == message {
-			return record
+			return record, true, nil
 		}
 	}
-	t.Fatalf("runtime log %s missing msg %q", path, message)
-	return nil
+	return nil, false, nil
 }


### PR DESCRIPTION
{
  "project": "Deflake Runtime-Log Startup Observation and Work-Move Reporting",
  "branchName": "thr-deflake-runtimelog-and-workmove-report",
  "description": "Make two shared backend functional behaviors deterministic: wait boundedly for the exact structured runtime startup record instead of reading the rolling log once, and make `you work move` report the operator-applied transition rather than a later scheduler-advanced Work state. Preserve assertion strength, existing command errors and routing, functional coverage numbers, and strict lane boundaries while providing repeat-run evidence through actual PR merge.",
  "context": {
    "customerAsk": "Deflake TestFunctionalAPIServer_RuntimeLogDirectoryIsAProcessInput and TestWorkRecoveryActivatesThroughRootBuildProcessAfterLifecycle. Reproduce both measured failures before changing behavior, replace the runtime log's single-shot read with a bounded exact-record wait, prove what value `you work move` renders, make Work move reporting deterministic without weakening the exact transition, report duplicate-pattern and before/after evidence, preserve coverage numbers, and complete the implementation/review/CI/merge loop.",
    "problem": "A newly created rolling runtime log can exist before the asynchronous appender has flushed the `factory started` record, but the functional helper reads it only once. Separately, the Work move command renders New state from the HTTP move-and-read response, which may already show `processing` after a successful requested move to initial state `init`; this misreports the applied transition and races the exact functional expectation. These are plain functional failures, not coverage regressions, and they create shared CI instability.",
    "solution": "Capture focused repeat-run evidence on the unchanged tree; replace only the runtime startup-record assertion with a bounded poll for the exact structured message while retaining the exact-one-file and three-field checks; make successful Work move human and JSON output use the normalized requested target as the applied New state while preserving the prefetched previous state and existing failures; add a regression where the response has already advanced; inspect and report genuine sibling log-helper occurrences; and verify stable repetitions, unchanged functional coverage, fast gates, required CI, review, conflict resolution, and merge."
  },
  "acceptanceCriteria": [
    "Before implementation, PR evidence quotes both measured CI failures and records the focused -count and/or -race reproduction command and observed failure count for each, explicitly stating when a timing-dependent failure does not reproduce locally.",
    "Runtime-log startup verification waits within a bounded deadline for the exact `factory started` record, retains the exact-one-log-file assertion and exact runtime_log_path, runtime_log_root, and runtime_log_appender checks, and introduces no bare sleep, skip, blanket retry, or weakened assertion.",
    "After a successful `you work move <id> <state>`, human and JSON output report the applied requested state as New state even if the returned or current Work has already advanced; any additionally surfaced current state is distinctly labeled and never overwrites the applied transition.",
    "Focused regression coverage deterministically proves `failed -> init` reporting while the runtime can immediately advance to `processing`, and the investigation reports whether identical asynchronous-log single-read helpers exist elsewhere under tests/functional.",
    "The diff does not modify cmd/gocoveragecheck/**, docs/internal/baselines/*.json, coverage floors, manifests, epsilon, ui/**, service composition or wiring under pkg/services/**, pkg/wire, transport composition, generated contracts, or unrelated tests and harnesses.",
    "The same focused repetition commands pass consistently after the change, make test-functional-coverage and make verify-fast pass, per-package coverage numbers are unchanged, and typecheck and tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are resolved against current main, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "thr-deflake-runtimelog-and-workmove-report-001",
      "title": "Observe the exact startup record deterministically",
      "description": "As a maintainer relying on backend functional CI, I need startup-log verification to tolerate only the real appender flush interval so a healthy process is not reported as missing its structured startup record.",
      "acceptanceCriteria": [
        "On the unchanged tree, run the focused runtime API test repeatedly and/or with the race detector and record the exact command, run count, and observed failures, or explicitly record that the locally timing-dependent failure did not reproduce.",
        "The assertion observes the target log until the exact `msg: factory started` record appears or a bounded deadline expires, using a repository-consistent polling interval and an in-code justification for observing the asynchronous appender.",
        "The test still requires exactly one runtime log under the configured directory and exactly matches runtime_log_path, runtime_log_root, and runtime_log_appender on the startup record.",
        "Malformed JSON and non-retryable read failures fail with actionable diagnostics, and deadline failure identifies the log path and missing message.",
        "No bare sleep, t.Skip, blanket whole-test retry, relaxed file count, or relaxed message or field assertion is introduced.",
        "The investigation reports whether another functional helper performs the identical single-read assertion against an asynchronously written runtime log, and only confirmed identical occurrences are corrected.",
        "The post-change focused repetition command passes consistently.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Baseline command `go test ./tests/functional/runtime_api -run '^TestFunctionalAPIServer_RuntimeLogDirectoryIsAProcessInput$' -count=12 -timeout=10m` passed all 12 unchanged runs locally, so the timing-dependent failure did not reproduce. The target helper now polls the exact log path/message every 10ms for a bounded 2s deadline, preserving exact-one-file and runtime_log_path/runtime_log_root/runtime_log_appender assertions; read and malformed-JSON failures include path/message/line diagnostics. Post-change command passed all 12 runs and `go test -race ./tests/functional/runtime_api -run '^TestFunctionalAPIServer_RuntimeLogDirectoryIsAProcessInput$' -count=3 -timeout=10m` passed all 3 race runs. Investigation found no identical asynchronous-log startup single-read helper elsewhere under tests/functional."
    },
    {
      "id": "thr-deflake-runtimelog-and-workmove-report-002",
      "title": "Report the operator-applied Work transition",
      "description": "As an operator, I need `you work move` to report the transition it applied so immediate scheduler progress cannot make the command look ignored, overridden, or raced.",
      "acceptanceCriteria": [
        "On the unchanged tree, run the focused recovery/root-composition test repeatedly and/or with the race detector and record the exact command, run count, and observed init versus processing outcomes, or explicitly record that the measured failure did not reproduce locally.",
        "PR evidence traces the command through its pre-move read, HTTP move request, move-and-read response, and rendered result, and explicitly identifies whether the previously rendered value was the applied target or a subsequent current-state read.",
        "After a successful request for failed -> init, human output contains `Previous state:\tfailed` and `New state:\tinit` even when the response or current Work is already processing.",
        "JSON output uses the same applied-transition semantics: previousState is the prefetched state and newState is the requested, successfully applied target state.",
        "If current post-move state is also exposed, it uses a separate unambiguous field or line and never replaces newState; additional current-state reporting is not required.",
        "Focused CLI transport coverage simulates a successful move whose response Work has already advanced and fails against the old behavior; the owned functional recovery test continues to assert the exact failed -> init transition and eventual terminal completion.",
        "Existing invalid arguments, not-found, invalid-state, duplicate request-id, cancellation, output-writer, session routing, diagnostics, and HTTP failure behavior remain unchanged.",
        "The fix is confined to the narrow Work move command/reporting path and its tests and does not change Work service composition, pkg/wire, HTTP or transport composition, generated contracts, or unrelated backend surfaces.",
        "The post-change focused repetition command passes consistently.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Baseline command `go test ./tests/functional/work/root_composition -run '^TestWorkRecoveryActivatesThroughRootBuildProcessAfterLifecycle$' -count=12 -timeout=10m` passed all 12 unchanged runs, so the timing-dependent failure did not reproduce locally. Traced the CLI path as pre-move GET for previousState, POST move request, and rendering from the POST Work response; the response is a later scheduler-advanced projection. The implementation now reports the normalized requested target as newState while preserving the prefetched previous state and existing error/routing behavior. Human and JSON transport regressions simulate failed -> init with a POST response already at processing. Post-change focused command passed 12/12; race-focused `go test -race ./tests/functional/work/root_composition -run '^TestWorkRecoveryActivatesThroughRootBuildProcessAfterLifecycle$' -count=3 -timeout=10m` passed 3/3; `make verify-fast` passed. `make test-functional-coverage` ran but hit one unrelated orchestration/petri/guards TestDependsOnSecondaryJoinedInput failure; the focused rerun passed 3/3, consistent with a baseline flake. PR #1939 is open at final head 60b067801 with required CI started and no review comments."
    }
  ]
}
