### PR TITLE
Make unit coverage runnable on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ endef
 .PHONY: test test-full test-unit test-unit-fresh test-ci-workflows test-lane-audit test-maintenance test-integration test-contract test-stress test-release
 .PHONY: test-functional test-functional-fresh test-functional-long test-functional-long-compile test-backend-functional functional-boundary-check functional-test-viz
 .PHONY: test-ui-browser-integration test-ui-storybook-integration test-ui-durable-session-real-backend test-ui-performance ui-component-test
-.PHONY: test-unit-coverage test-functional-coverage test-backend-coverage test-coverage-go test-race
+.PHONY: test-unit-coverage test-functional-coverage coverage-help test-backend-coverage test-coverage-go test-race
 .PHONY: test-backend-verification test-root-process-acceptance long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval
 .PHONY: frontend-verification backend-verification ui-backend-integration local-inference-verification
 
@@ -176,6 +176,14 @@ default:
 	$(MAKE) build
 	$(MAKE) test
 	$(MAKE) lint
+
+# Local pre-push guidance: run both independent Go coverage reports before
+# pushing. A build or typecheck does not substitute for either completed run.
+coverage-help:
+	$(info Local pre-push checks: run both independent Go coverage reports before pushing.)
+	$(info   make test-unit-coverage       backend unit/package coverage report)
+	$(info   make test-functional-coverage independent functional coverage report)
+	$(info A build or typecheck alone does not replace either completed coverage run.)
 
 build:
 	$(GO) build $(GO_BUILD_FLAGS) -o $(BIN_DIR)/$(BINARY_NAME) $(CMD_PATH)

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -34,12 +35,17 @@ func buildCoverageTestArgs(commonArgs []string, profilePath string, timingEnable
 
 // buildCoverageInvocationPlan keeps the ordinary one-process invocation on
 // every platform unless a Windows command would exceed the conservative bound.
-// Windows batches retain all fixed go test flags and execute each resolved test
-// package exactly once. Each batch writes an isolated profile that the caller
-// merges with mergeCoverageProfiles after execution, including profiles from
-// failed subprocesses when they were produced.
-func buildCoverageInvocationPlan(commonArgs []string, testPackages []string, profilePath string, timingEnabled bool, targetOS string) (coverageInvocationPlan, error) {
-	directArgs := buildCoverageTestArgs(commonArgs, profilePath, timingEnabled, testPackages)
+// A compactPackageArgs set is used only for that direct invocation; if it does
+// not fit, Windows batches retain all fixed go test flags and execute each
+// resolved test package exactly once. Each batch writes an isolated profile
+// that the caller merges with mergeCoverageProfiles after execution, including
+// profiles from failed subprocesses when they were produced.
+func buildCoverageInvocationPlan(commonArgs []string, testPackages []string, profilePath string, timingEnabled bool, targetOS string, compactPackageArgs ...[]string) (coverageInvocationPlan, error) {
+	directPackageArgs := testPackages
+	if len(compactPackageArgs) > 0 && len(compactPackageArgs[0]) > 0 {
+		directPackageArgs = compactPackageArgs[0]
+	}
+	directArgs := buildCoverageTestArgs(commonArgs, profilePath, timingEnabled, directPackageArgs)
 	if targetOS != "windows" || coverageCommandFitsWindowsLimit(directArgs) {
 		return coverageInvocationPlan{
 			invocations: []commandInvocation{{
@@ -112,6 +118,126 @@ func appendCoverageInvocation(plan *coverageInvocationPlan, commonArgs []string,
 	})
 }
 
+// compactGoPackagePatterns returns disjoint Go package patterns whose expansion
+// is exactly selectedPackages. The allPackages input is the package universe
+// used to prove that a pattern does not pull an excluded lane into go test.
+func compactGoPackagePatterns(allPackages []string, selectedPackages []string, packageRoot string) ([]string, error) {
+	allSet, selectedSet, err := buildGoPackageSets(allPackages, selectedPackages, packageRoot)
+	if err != nil {
+		return nil, err
+	}
+	patterns := collectCompactGoPackagePatterns(allSet, selectedSet, packageRoot)
+	if err := validateCompactGoPackagePatterns(patterns, allSet, selectedSet); err != nil {
+		return nil, err
+	}
+	return patterns, nil
+}
+
+func buildGoPackageSets(allPackages []string, selectedPackages []string, packageRoot string) (map[string]struct{}, map[string]struct{}, error) {
+	if strings.TrimSpace(packageRoot) == "" {
+		return nil, nil, errors.New("compact go package patterns: package root is empty")
+	}
+
+	allSet := make(map[string]struct{}, len(allPackages))
+	for _, packagePath := range allPackages {
+		packagePath = strings.TrimSpace(packagePath)
+		if packagePath != "" {
+			allSet[packagePath] = struct{}{}
+		}
+	}
+	selectedSet := make(map[string]struct{}, len(selectedPackages))
+	for _, packagePath := range selectedPackages {
+		packagePath = strings.TrimSpace(packagePath)
+		if packagePath == "" {
+			continue
+		}
+		if !strings.HasPrefix(packagePath, packageRoot) || (len(packagePath) > len(packageRoot) && packagePath[len(packageRoot)] != '/') {
+			return nil, nil, fmt.Errorf("compact go package patterns: selected package %q is outside root %q", packagePath, packageRoot)
+		}
+		if _, ok := allSet[packagePath]; !ok {
+			return nil, nil, fmt.Errorf("compact go package patterns: selected package %q is missing from package universe", packagePath)
+		}
+		selectedSet[packagePath] = struct{}{}
+	}
+	if len(selectedSet) == 0 {
+		return nil, nil, errors.New("compact go package patterns: no selected packages")
+	}
+	return allSet, selectedSet, nil
+}
+
+func collectCompactGoPackagePatterns(allSet map[string]struct{}, selectedSet map[string]struct{}, packageRoot string) []string {
+	patterns := make([]string, 0)
+	var visit func(string)
+	visit = func(prefix string) {
+		descendants := make([]string, 0)
+		for packagePath := range allSet {
+			if packagePath == prefix || strings.HasPrefix(packagePath, prefix+"/") {
+				descendants = append(descendants, packagePath)
+			}
+		}
+		if len(descendants) == 0 {
+			return
+		}
+		allSelected := true
+		for _, packagePath := range descendants {
+			if _, ok := selectedSet[packagePath]; !ok {
+				allSelected = false
+				break
+			}
+		}
+		if allSelected {
+			patterns = append(patterns, prefix+"/...")
+			return
+		}
+		if _, ok := selectedSet[prefix]; ok {
+			patterns = append(patterns, prefix)
+		}
+
+		children := make(map[string]struct{})
+		for _, packagePath := range descendants {
+			if packagePath == prefix {
+				continue
+			}
+			rest := strings.TrimPrefix(packagePath, prefix+"/")
+			child := strings.SplitN(rest, "/", 2)[0]
+			children[child] = struct{}{}
+		}
+		childNames := make([]string, 0, len(children))
+		for child := range children {
+			childNames = append(childNames, child)
+		}
+		sort.Strings(childNames)
+		for _, child := range childNames {
+			visit(prefix + "/" + child)
+		}
+	}
+	visit(packageRoot)
+	sort.Strings(patterns)
+	return patterns
+}
+
+func validateCompactGoPackagePatterns(patterns []string, allSet map[string]struct{}, selectedSet map[string]struct{}) error {
+	matched := make(map[string]struct{}, len(selectedSet))
+	for _, pattern := range patterns {
+		subtree := strings.HasSuffix(pattern, "/...")
+		prefix := strings.TrimSuffix(pattern, "/...")
+		for packagePath := range allSet {
+			if packagePath == prefix || (subtree && strings.HasPrefix(packagePath, prefix+"/")) {
+				matched[packagePath] = struct{}{}
+			}
+		}
+	}
+	if len(matched) != len(selectedSet) {
+		return fmt.Errorf("compact go package patterns: selected %d packages but patterns match %d (%v)", len(selectedSet), len(matched), patterns)
+	}
+	for packagePath := range matched {
+		if _, ok := selectedSet[packagePath]; !ok {
+			return fmt.Errorf("compact go package patterns: pattern set includes unselected package %q", packagePath)
+		}
+	}
+	return nil
+}
+
 func batchProfilePath(batchDir string, index int) string {
 	return filepath.Join(batchDir, fmt.Sprintf("coverage-%06d.out", index))
 }
@@ -154,9 +280,9 @@ func windowsCommandLineArgLength(arg string) int {
 // cfg.timingOutput is set, it combines every batch's -json stdout before
 // writing the timing summary, so a failed or crashed lane still leaves
 // trustworthy (possibly incomplete) diagnostics on disk.
-func runGoTestCoverageLane(cfg config, commonArgs []string, testPackages []string, profilePath string, repoRoot string, coverPackages []string, targetOS string, failurePrefix string) error {
+func runGoTestCoverageLane(cfg config, commonArgs []string, testPackages []string, profilePath string, repoRoot string, coverPackages []string, targetOS string, failurePrefix string, compactPackageArgs ...[]string) error {
 	timingEnabled := strings.TrimSpace(cfg.timingOutput) != ""
-	plan, err := buildCoverageInvocationPlan(commonArgs, testPackages, profilePath, timingEnabled, targetOS)
+	plan, err := buildCoverageInvocationPlan(commonArgs, testPackages, profilePath, timingEnabled, targetOS, compactPackageArgs...)
 	if err != nil {
 		return err
 	}

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Windows CreateProcess accepts a command line of at most 32,767 UTF-16 code
+// units. Keep coverage commands well below that limit because the final
+// executable path and escaped arguments are not known until process launch.
+// The length calculation below is intentionally an upper bound, not a claim
+// about the exact command-line encoding used by os/exec.
+const windowsCoverageCommandLineLimit = 24_000
+
+type coverageInvocationPlan struct {
+	invocations  []commandInvocation
+	profilePaths []string
+	cleanup      func() error
+}
+
+func buildCoverageTestArgs(commonArgs []string, profilePath string, timingEnabled bool, testPackages []string) []string {
+	args := append([]string(nil), commonArgs...)
+	args = append(args, fmt.Sprintf("-coverprofile=%s", profilePath))
+	if timingEnabled {
+		args = append(args, "-json")
+	}
+	return append(args, testPackages...)
+}
+
+// buildCoverageInvocationPlan keeps the ordinary one-process invocation on
+// every platform unless a Windows command would exceed the conservative bound.
+// Windows batches retain all fixed go test flags and execute each resolved test
+// package exactly once. Each batch writes an isolated profile that the caller
+// merges with mergeCoverageProfiles after all subprocesses succeed.
+func buildCoverageInvocationPlan(commonArgs []string, testPackages []string, profilePath string, timingEnabled bool, targetOS string) (coverageInvocationPlan, error) {
+	directArgs := buildCoverageTestArgs(commonArgs, profilePath, timingEnabled, testPackages)
+	if targetOS != "windows" || coverageCommandFitsWindowsLimit(directArgs) {
+		return coverageInvocationPlan{
+			invocations: []commandInvocation{{
+				name: "go",
+				args: directArgs,
+				env:  os.Environ(),
+			}},
+			profilePaths: []string{profilePath},
+			cleanup:      func() error { return nil },
+		}, nil
+	}
+
+	if len(testPackages) == 0 {
+		return coverageInvocationPlan{}, fmt.Errorf(
+			"prepare go coverage lane: command line is %d characters, above the safe Windows limit of %d, and no test packages are available to batch",
+			windowsCommandLine(directArgs), windowsCoverageCommandLineLimit,
+		)
+	}
+
+	batchDir, err := os.MkdirTemp("", "gocoveragecheck-batches-*")
+	if err != nil {
+		return coverageInvocationPlan{}, fmt.Errorf("create temporary go coverage batch directory: %w", err)
+	}
+	cleanupBatchDir := func() error {
+		return os.RemoveAll(batchDir)
+	}
+
+	plan := coverageInvocationPlan{cleanup: cleanupBatchDir}
+	currentBatch := make([]string, 0)
+	for _, testPackage := range testPackages {
+		candidateBatch := append(append([]string(nil), currentBatch...), testPackage)
+		candidateProfile := batchProfilePath(batchDir, len(plan.invocations))
+		candidateArgs := buildCoverageTestArgs(commonArgs, candidateProfile, timingEnabled, candidateBatch)
+		if coverageCommandFitsWindowsLimit(candidateArgs) {
+			currentBatch = candidateBatch
+			continue
+		}
+
+		if len(currentBatch) == 0 {
+			return coverageInvocationPlan{}, errors.Join(
+				coverageCommandTooLongError(testPackage, candidateArgs),
+				cleanupBatchDir(),
+			)
+		}
+
+		appendCoverageInvocation(&plan, commonArgs, candidateProfile, timingEnabled, currentBatch)
+		currentBatch = []string{testPackage}
+		candidateProfile = batchProfilePath(batchDir, len(plan.invocations))
+		candidateArgs = buildCoverageTestArgs(commonArgs, candidateProfile, timingEnabled, currentBatch)
+		if !coverageCommandFitsWindowsLimit(candidateArgs) {
+			return coverageInvocationPlan{}, errors.Join(
+				coverageCommandTooLongError(testPackage, candidateArgs),
+				cleanupBatchDir(),
+			)
+		}
+	}
+
+	if len(currentBatch) > 0 {
+		appendCoverageInvocation(&plan, commonArgs, batchProfilePath(batchDir, len(plan.invocations)), timingEnabled, currentBatch)
+	}
+	return plan, nil
+}
+
+func appendCoverageInvocation(plan *coverageInvocationPlan, commonArgs []string, profilePath string, timingEnabled bool, testPackages []string) {
+	plan.profilePaths = append(plan.profilePaths, profilePath)
+	plan.invocations = append(plan.invocations, commandInvocation{
+		name: "go",
+		args: buildCoverageTestArgs(commonArgs, profilePath, timingEnabled, testPackages),
+		env:  os.Environ(),
+	})
+}
+
+func batchProfilePath(batchDir string, index int) string {
+	return filepath.Join(batchDir, fmt.Sprintf("coverage-%06d.out", index))
+}
+
+func coverageCommandFitsWindowsLimit(args []string) bool {
+	return windowsCommandLine(args) <= windowsCoverageCommandLineLimit
+}
+
+func coverageCommandTooLongError(testPackage string, args []string) error {
+	return fmt.Errorf(
+		"prepare go coverage lane: command for test package %q is %d characters, above the safe Windows limit of %d; shorten the coverage package or test package arguments",
+		testPackage, windowsCommandLine(args), windowsCoverageCommandLineLimit,
+	)
+}
+
+func windowsCommandLine(args []string) int {
+	commandName := "go"
+	if resolved, err := exec.LookPath(commandName); err == nil {
+		commandName = resolved
+	}
+
+	length := windowsCommandLineArgLength(commandName)
+	for _, arg := range args {
+		length++ // separator between command-line arguments
+		length += windowsCommandLineArgLength(arg)
+	}
+	return length
+}
+
+// windowsCommandLineArgLength is deliberately conservative. It charges every
+// argument for quotes and escaped backslashes, even when the actual argument
+// would not need quoting, and uses UTF-8 byte length as an upper bound for the
+// ASCII-heavy paths and package names in this command.
+func windowsCommandLineArgLength(arg string) int {
+	return 2 + len(arg) + strings.Count(arg, `\`) + 2*strings.Count(arg, `"`)
+}

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Windows CreateProcess accepts a command line of at most 32,767 UTF-16 code
@@ -35,7 +36,8 @@ func buildCoverageTestArgs(commonArgs []string, profilePath string, timingEnable
 // every platform unless a Windows command would exceed the conservative bound.
 // Windows batches retain all fixed go test flags and execute each resolved test
 // package exactly once. Each batch writes an isolated profile that the caller
-// merges with mergeCoverageProfiles after all subprocesses succeed.
+// merges with mergeCoverageProfiles after execution, including profiles from
+// failed subprocesses when they were produced.
 func buildCoverageInvocationPlan(commonArgs []string, testPackages []string, profilePath string, timingEnabled bool, targetOS string) (coverageInvocationPlan, error) {
 	directArgs := buildCoverageTestArgs(commonArgs, profilePath, timingEnabled, testPackages)
 	if targetOS != "windows" || coverageCommandFitsWindowsLimit(directArgs) {
@@ -145,4 +147,113 @@ func windowsCommandLine(args []string) int {
 // ASCII-heavy paths and package names in this command.
 func windowsCommandLineArgLength(arg string) int {
 	return 2 + len(arg) + strings.Count(arg, `\`) + 2*strings.Count(arg, `"`)
+}
+
+// runGoTestCoverageLane runs the coverage invocation once on short command
+// lines, or in deterministic test-package batches when Windows needs it. When
+// cfg.timingOutput is set, it combines every batch's -json stdout before
+// writing the timing summary, so a failed or crashed lane still leaves
+// trustworthy (possibly incomplete) diagnostics on disk.
+func runGoTestCoverageLane(cfg config, commonArgs []string, testPackages []string, profilePath string, repoRoot string, coverPackages []string, targetOS string, failurePrefix string) error {
+	timingEnabled := strings.TrimSpace(cfg.timingOutput) != ""
+	plan, err := buildCoverageInvocationPlan(commonArgs, testPackages, profilePath, timingEnabled, targetOS)
+	if err != nil {
+		return err
+	}
+
+	started := time.Now()
+	var stdout strings.Builder
+	var stderr strings.Builder
+	var laneErr error
+	succeeded := make([]bool, len(plan.invocations))
+	for index, invocation := range plan.invocations {
+		batchStdout, batchStderr, commandErr := runCommand(invocation)
+		appendCoverageOutput(&stdout, batchStdout)
+		appendCoverageOutput(&stderr, batchStderr)
+		if commandErr == nil {
+			succeeded[index] = true
+			continue
+		}
+
+		detail := mergeGoTestFailureDetail(batchStderr, batchStdout)
+		batchFailurePrefix := failurePrefix
+		if len(plan.invocations) > 1 {
+			batchFailurePrefix = fmt.Sprintf("%s (batch %d/%d)", failurePrefix, index+1, len(plan.invocations))
+		}
+		if detail != "" {
+			laneErr = errors.Join(laneErr, fmt.Errorf("%s: %w\n%s", batchFailurePrefix, commandErr, detail))
+		} else {
+			laneErr = errors.Join(laneErr, fmt.Errorf("%s: %w", batchFailurePrefix, commandErr))
+		}
+	}
+	wallSeconds := time.Since(started).Seconds()
+
+	var timingWriteErr error
+	if timingEnabled {
+		summary := buildFunctionalTimingSummary(stdout.String(), testPackages, wallSeconds)
+		timingWriteErr = writeFunctionalTimingSummaryJSON(cfg.timingOutput, summary)
+	}
+
+	var mergeErr error
+	if len(plan.profilePaths) > 1 {
+		availableProfiles, availabilityErr := availableBatchCoverageProfiles(plan.profilePaths, succeeded)
+		mergeErr = availabilityErr
+		if len(availableProfiles) > 0 {
+			mergeErr = errors.Join(mergeErr, mergeCoverageProfiles(availableProfiles, profilePath, repoRoot, coverPackages))
+		}
+	}
+
+	return errors.Join(laneErr, timingWriteErr, mergeErr, plan.cleanup())
+}
+
+func availableBatchCoverageProfiles(profilePaths []string, succeeded []bool) ([]string, error) {
+	available := make([]string, 0, len(profilePaths))
+	var profileErr error
+	for index, profilePath := range profilePaths {
+		_, err := os.Stat(profilePath)
+		switch {
+		case err == nil:
+			available = append(available, profilePath)
+		case os.IsNotExist(err) && !succeeded[index]:
+			// A failed go test subprocess may not have written a profile.
+		case os.IsNotExist(err):
+			profileErr = errors.Join(profileErr, fmt.Errorf("go coverage batch %d completed without writing profile %q", index+1, profilePath))
+		default:
+			profileErr = errors.Join(profileErr, fmt.Errorf("inspect go coverage batch profile %q: %w", profilePath, err))
+		}
+	}
+	return available, profileErr
+}
+
+func appendCoverageOutput(output *strings.Builder, chunk string) {
+	if chunk == "" {
+		return
+	}
+	if output.Len() > 0 {
+		output.WriteByte('\n')
+	}
+	output.WriteString(chunk)
+}
+
+func runCommand(invocation commandInvocation) (string, string, error) {
+	return commandRunner(invocation)
+}
+
+func mergeGoTestFailureDetail(stderr string, stdout string) string {
+	stderr = strings.TrimSpace(compactCoverageOutput(stderr))
+	stdout = strings.TrimSpace(compactCoverageOutput(stdout))
+	switch {
+	case stdout == "":
+		return stderr
+	case stderr == "":
+		return stdout
+	case strings.Contains(stdout, "\nFAIL") || strings.Contains(stdout, "--- FAIL:"):
+		return stdout + "\n" + stderr
+	default:
+		return stderr + "\n" + stdout
+	}
+}
+
+func compactCoverageOutput(output string) string {
+	return coveragePackageListPattern.ReplaceAllString(output, "$1")
 }

--- a/cmd/gocoveragecheck/coverage_invocation_test.go
+++ b/cmd/gocoveragecheck/coverage_invocation_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestBuildCoverageInvocationPlanBatchesOversizedWindowsCommand(t *testing.T) {
+	commonArgs := []string{
+		"test",
+		"-coverpkg=" + modulePath + "/pkg/...",
+		"-p=2",
+		"-count=1",
+		"-short",
+		"-covermode=count",
+		"-timeout=10m",
+	}
+	testPackages := make([]string, 0, 500)
+	for index := 0; index < 500; index++ {
+		testPackages = append(testPackages, modulePath+"/pkg/coverage_test_"+strings.Repeat("x", 32)+strconv.Itoa(index))
+	}
+	profilePath := filepath.Join(t.TempDir(), "coverage.out")
+	legacyArgs := buildCoverageTestArgs(commonArgs, profilePath, false, testPackages)
+	if got := windowsCommandLine(legacyArgs); got <= windowsCoverageCommandLineLimit {
+		t.Fatalf("old single invocation length = %d, want it above safe limit %d", got, windowsCoverageCommandLineLimit)
+	}
+
+	plan, err := buildCoverageInvocationPlan(commonArgs, testPackages, profilePath, false, "windows")
+	if err != nil {
+		t.Fatalf("buildCoverageInvocationPlan() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if cleanupErr := plan.cleanup(); cleanupErr != nil {
+			t.Fatalf("cleanup batch profiles: %v", cleanupErr)
+		}
+	})
+
+	if len(plan.invocations) < 2 {
+		t.Fatalf("planned invocations = %d, want batching for oversized command", len(plan.invocations))
+	}
+	if len(plan.profilePaths) != len(plan.invocations) {
+		t.Fatalf("profile paths = %d, invocations = %d, want one profile per invocation", len(plan.profilePaths), len(plan.invocations))
+	}
+
+	seen := make(map[string]int, len(testPackages))
+	for index, invocation := range plan.invocations {
+		if got := windowsCommandLine(invocation.args); got > windowsCoverageCommandLineLimit {
+			t.Fatalf("invocation %d length = %d, want <= safe limit %d", index, got, windowsCoverageCommandLineLimit)
+		}
+		batchProfile := helperCoverProfilePath(invocation.args)
+		if batchProfile == "" || batchProfile == profilePath {
+			t.Fatalf("invocation %d profile = %q, want isolated batch profile", index, batchProfile)
+		}
+		if got := plan.profilePaths[index]; got != batchProfile {
+			t.Fatalf("profilePaths[%d] = %q, invocation profile = %q", index, got, batchProfile)
+		}
+		for _, testPackage := range testPackages {
+			if slicesContains(invocation.args, testPackage) {
+				seen[testPackage]++
+			}
+		}
+	}
+
+	if len(seen) != len(testPackages) {
+		t.Fatalf("planned package count = %d, want %d", len(seen), len(testPackages))
+	}
+	for _, testPackage := range testPackages {
+		if seen[testPackage] != 1 {
+			t.Fatalf("test package %q appears %d times, want exactly once", testPackage, seen[testPackage])
+		}
+	}
+
+	batchDir := filepath.Dir(plan.profilePaths[0])
+	if _, err := os.Stat(batchDir); err != nil {
+		t.Fatalf("batch directory stat error = %v, want it to exist before cleanup", err)
+	}
+	if err := plan.cleanup(); err != nil {
+		t.Fatalf("plan cleanup error = %v", err)
+	}
+	if _, err := os.Stat(batchDir); !os.IsNotExist(err) {
+		t.Fatalf("batch directory still exists after cleanup, stat error = %v", err)
+	}
+	plan.cleanup = func() error { return nil }
+}
+
+func TestBuildCoverageInvocationPlanRejectsSingleOversizedWindowsPackage(t *testing.T) {
+	commonArgs := []string{
+		"test",
+		"-coverpkg=" + strings.Repeat("example.com/backend/", 1200),
+		"-p=2",
+		"-count=1",
+	}
+	testPackage := modulePath + "/pkg/one-oversized-package"
+	profilePath := filepath.Join(t.TempDir(), "coverage.out")
+
+	_, err := buildCoverageInvocationPlan(commonArgs, []string{testPackage}, profilePath, false, "windows")
+	if err == nil {
+		t.Fatal("buildCoverageInvocationPlan() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "above the safe Windows limit") || !strings.Contains(err.Error(), testPackage) {
+		t.Fatalf("buildCoverageInvocationPlan() error = %q, want package and bound diagnostic", err)
+	}
+}
+
+func TestRunForOSBatchesAndMergesCoverageProfiles(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	t.Cleanup(func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	configPackage := modulePath + "/pkg/config"
+	servicePackage := modulePath + "/pkg/service"
+	testPackages := makeOversizedTestPackages(500)
+	profilePath := filepath.Join(t.TempDir(), "merged-coverage.out")
+	var invocations []commandInvocation
+	commandRunner = func(invocation commandInvocation) (string, string, error) {
+		if len(invocation.args) == 0 || invocation.args[0] != "test" {
+			return "", "", errors.New("unexpected command in batched coverage test")
+		}
+		if got := windowsCommandLine(invocation.args); got > windowsCoverageCommandLineLimit {
+			return "", "", errors.New("batched coverage command exceeded safe Windows limit")
+		}
+		invocations = append(invocations, invocation)
+		batchIndex := len(invocations)
+		coverage := strings.Join([]string{
+			"mode: count",
+			configPackage + "/config.go:1.1,2.1 3 " + strconv.Itoa(batchIndex-1),
+			servicePackage + "/factory.go:1.1,2.1 5 0",
+			"",
+		}, "\n")
+		return "", "", writeFakeCoverageProfile(helperCoverProfilePath(invocation.args), coverage)
+	}
+
+	result, err := runForOS(config{
+		min:       0,
+		totalOnly: true,
+		coverpkg:  strings.Join([]string{configPackage, servicePackage}, ","),
+		packages:  strings.Join(testPackages, " "),
+		profile:   profilePath,
+	}, "windows")
+	if err != nil {
+		t.Fatalf("runForOS() error = %v", err)
+	}
+	if len(invocations) < 2 {
+		t.Fatalf("coverage invocations = %d, want multiple Windows batches", len(invocations))
+	}
+	if result.actual != 37.5 {
+		t.Fatalf("merged coverage = %v, want 37.5", result.actual)
+	}
+	if result.packageTotals[configPackage] != (packageCoverageTotals{coveredStatements: 3, totalStatements: 3}) {
+		t.Fatalf("config totals = %+v, want 3/3", result.packageTotals[configPackage])
+	}
+	if result.packageTotals[servicePackage] != (packageCoverageTotals{coveredStatements: 0, totalStatements: 5}) {
+		t.Fatalf("service totals = %+v, want 0/5", result.packageTotals[servicePackage])
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	if _, err := os.Stat(profilePath); err != nil {
+		t.Fatalf("merged profile stat error = %v", err)
+	}
+	for _, invocation := range invocations {
+		batchProfile := helperCoverProfilePath(invocation.args)
+		if _, err := os.Stat(filepath.Dir(batchProfile)); !os.IsNotExist(err) {
+			t.Fatalf("batch directory for %q still exists, stat error = %v", batchProfile, err)
+		}
+	}
+}
+
+func makeOversizedTestPackages(count int) []string {
+	packages := make([]string, 0, count)
+	for index := 0; index < count; index++ {
+		packages = append(packages, modulePath+"/pkg/coverage_test_"+strings.Repeat("x", 32)+strconv.Itoa(index))
+	}
+	return packages
+}

--- a/cmd/gocoveragecheck/coverage_invocation_test.go
+++ b/cmd/gocoveragecheck/coverage_invocation_test.go
@@ -381,7 +381,7 @@ func TestRunGoTestCoverageLanePropagatesBatchedFailureAndCleansProfiles(t *testi
 		"-covermode=count",
 		"-timeout=10m",
 	}
-	testPackages := makeOversizedTestPackages(500)
+	testPackages := makeOversizedTestPackages(1000)
 	profilePath := filepath.Join(t.TempDir(), "merged-coverage.out")
 	repoRoot, err := repoRootDir()
 	if err != nil {
@@ -421,8 +421,28 @@ func TestRunGoTestCoverageLanePropagatesBatchedFailureAndCleansProfiles(t *testi
 	if !strings.Contains(err.Error(), "run unit coverage (batch 2/") || !strings.Contains(err.Error(), "synthetic subprocess failure") {
 		t.Fatalf("runGoTestCoverageLane() error = %q, want batch context and subprocess detail", err)
 	}
-	if len(invocations) != 2 {
-		t.Fatalf("coverage invocations = %d, want stop after second batch failure", len(invocations))
+	if len(invocations) < 3 {
+		t.Fatalf("coverage invocations = %d, want later batches after second-batch failure", len(invocations))
+	}
+	seen := make(map[string]int, len(testPackages))
+	for _, invocation := range invocations {
+		for _, testPackage := range testPackages {
+			if slicesContains(invocation.args, testPackage) {
+				seen[testPackage]++
+			}
+		}
+	}
+	for _, testPackage := range testPackages {
+		if seen[testPackage] != 1 {
+			t.Fatalf("test package %q invoked %d times, want exactly once across failed lane", testPackage, seen[testPackage])
+		}
+	}
+	profileData, readErr := os.ReadFile(profilePath)
+	if readErr != nil {
+		t.Fatalf("merged failure profile read error = %v, want profiles from completed batches", readErr)
+	}
+	if got, want := string(profileData), "mode: count\n"+modulePath+"/pkg/config/config.go:1.1,2.1 3 1\n"; got != want {
+		t.Fatalf("merged failure profile = %q, want deterministic completed-batch profile %q", got, want)
 	}
 	if batchDir == "" {
 		t.Fatal("batch directory was not captured")

--- a/cmd/gocoveragecheck/coverage_invocation_test.go
+++ b/cmd/gocoveragecheck/coverage_invocation_test.go
@@ -12,6 +12,89 @@ import (
 	"testing"
 )
 
+func TestCompactGoPackagePatternsPreserveSelectedPackageSet(t *testing.T) {
+	root := "example.com/project/pkg"
+	allPackages := []string{
+		root + "/alpha",
+		root + "/alpha/one",
+		root + "/alpha/two",
+		root + "/beta",
+		root + "/beta/excluded",
+		root + "/gamma/one",
+		root + "/gamma/two",
+	}
+	selectedPackages := []string{
+		root + "/alpha",
+		root + "/alpha/one",
+		root + "/alpha/two",
+		root + "/beta",
+		root + "/gamma/one",
+		root + "/gamma/two",
+	}
+
+	patterns, err := compactGoPackagePatterns(allPackages, selectedPackages, root)
+	if err != nil {
+		t.Fatalf("compactGoPackagePatterns() error = %v", err)
+	}
+	want := []string{root + "/alpha/...", root + "/beta", root + "/gamma/..."}
+	if !reflect.DeepEqual(patterns, want) {
+		t.Fatalf("compactGoPackagePatterns() = %v, want %v", patterns, want)
+	}
+
+	matched := make(map[string]struct{})
+	for _, pattern := range patterns {
+		subtree := strings.HasSuffix(pattern, "/...")
+		prefix := strings.TrimSuffix(pattern, "/...")
+		for _, packagePath := range allPackages {
+			if packagePath == prefix || (subtree && strings.HasPrefix(packagePath, prefix+"/")) {
+				matched[packagePath] = struct{}{}
+			}
+		}
+	}
+	if len(matched) != len(selectedPackages) {
+		t.Fatalf("compact patterns matched %d packages, want %d", len(matched), len(selectedPackages))
+	}
+	for _, packagePath := range selectedPackages {
+		if _, ok := matched[packagePath]; !ok {
+			t.Fatalf("compact patterns omitted selected package %q", packagePath)
+		}
+	}
+	if _, ok := matched[root+"/beta/excluded"]; ok {
+		t.Fatal("compact patterns included excluded package")
+	}
+}
+
+func TestCompactUnitTestPackageArgsUsesExactPackageUniverse(t *testing.T) {
+	originalCommandRunner := commandRunner
+	t.Cleanup(func() { commandRunner = originalCommandRunner })
+
+	root := modulePath + "/pkg"
+	allPackages := []string{
+		root + "/alpha",
+		root + "/alpha/one",
+		root + "/alpha/two",
+		root + "/beta",
+		root + "/beta/excluded",
+	}
+	commandRunner = func(invocation commandInvocation) (string, string, error) {
+		if len(invocation.args) == 0 || invocation.args[0] != "list" {
+			return "", "", fmt.Errorf("unexpected package-list invocation: %v", invocation.args)
+		}
+		lines := make([]string, 0, len(allPackages))
+		for _, packagePath := range allPackages {
+			lines = append(lines, packagePath+"\t1")
+		}
+		return strings.Join(lines, "\n"), "", nil
+	}
+
+	selectedPackages := []string{root + "/alpha", root + "/alpha/one", root + "/alpha/two", root + "/beta"}
+	patterns := compactUnitTestPackageArgs(config{}, selectedPackages, "windows")
+	want := []string{root + "/alpha/...", root + "/beta"}
+	if !reflect.DeepEqual(patterns, want) {
+		t.Fatalf("compactUnitTestPackageArgs() = %v, want %v", patterns, want)
+	}
+}
+
 func TestBuildCoverageInvocationPlanBatchesOversizedWindowsCommand(t *testing.T) {
 	commonArgs := []string{
 		"test",
@@ -131,6 +214,46 @@ func TestOversizedWindowsInvocationFailsBeforeBoundedPlanPasses(t *testing.T) {
 		if err := rejectOversizedInvocation(invocation); err != nil {
 			t.Fatalf("bounded invocation %d failed process-length check: %v", index, err)
 		}
+	}
+}
+
+func TestBuildCoverageInvocationPlanUsesBoundedCompactPackageArguments(t *testing.T) {
+	commonArgs := []string{
+		"test",
+		"-coverpkg=" + modulePath + "/pkg/...",
+		"-p=2",
+		"-count=1",
+		"-short",
+		"-covermode=count",
+		"-timeout=10m",
+	}
+	testPackages := makeOversizedTestPackages(500)
+	compactPackageArgs := []string{modulePath + "/pkg/initializer/...", modulePath + "/pkg/root/..."}
+	profilePath := filepath.Join(t.TempDir(), "coverage.out")
+
+	plan, err := buildCoverageInvocationPlan(commonArgs, testPackages, profilePath, false, "windows", compactPackageArgs)
+	if err != nil {
+		t.Fatalf("buildCoverageInvocationPlan() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if cleanupErr := plan.cleanup(); cleanupErr != nil {
+			t.Errorf("cleanup compact invocation plan: %v", cleanupErr)
+		}
+	})
+	if len(plan.invocations) != 1 {
+		t.Fatalf("planned invocations = %d, want one compact invocation", len(plan.invocations))
+	}
+	invocation := plan.invocations[0]
+	if got := windowsCommandLine(invocation.args); got > windowsCoverageCommandLineLimit {
+		t.Fatalf("compact invocation length = %d, want <= safe limit %d", got, windowsCoverageCommandLineLimit)
+	}
+	for _, packageArg := range compactPackageArgs {
+		if !slicesContains(invocation.args, packageArg) {
+			t.Fatalf("compact invocation args = %v, missing package pattern %q", invocation.args, packageArg)
+		}
+	}
+	if slicesContains(invocation.args, testPackages[0]) {
+		t.Fatalf("compact invocation unexpectedly contains concrete package %q", testPackages[0])
 	}
 }
 

--- a/cmd/gocoveragecheck/coverage_invocation_test.go
+++ b/cmd/gocoveragecheck/coverage_invocation_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -86,6 +88,50 @@ func TestBuildCoverageInvocationPlanBatchesOversizedWindowsCommand(t *testing.T)
 		t.Fatalf("batch directory still exists after cleanup, stat error = %v", err)
 	}
 	plan.cleanup = func() error { return nil }
+}
+
+func TestOversizedWindowsInvocationFailsBeforeBoundedPlanPasses(t *testing.T) {
+	commonArgs := []string{
+		"test",
+		"-coverpkg=" + modulePath + "/pkg/...",
+		"-p=2",
+		"-count=1",
+		"-short",
+		"-covermode=count",
+		"-timeout=10m",
+	}
+	testPackages := makeOversizedTestPackages(500)
+	profilePath := filepath.Join(t.TempDir(), "coverage.out")
+	legacyArgs := buildCoverageTestArgs(commonArgs, profilePath, false, testPackages)
+	if got := windowsCommandLine(legacyArgs); got <= windowsCoverageCommandLineLimit {
+		t.Fatalf("legacy invocation length = %d, want it above safe limit %d", got, windowsCoverageCommandLineLimit)
+	}
+
+	rejectOversizedInvocation := func(invocation commandInvocation) error {
+		if windowsCommandLine(invocation.args) > windowsCoverageCommandLineLimit {
+			return errors.New("fork/exec go.exe: The filename or extension is too long")
+		}
+		return nil
+	}
+	if err := rejectOversizedInvocation(commandInvocation{name: "go", args: legacyArgs}); err == nil || !strings.Contains(err.Error(), "The filename or extension is too long") {
+		t.Fatalf("legacy invocation error = %v, want Windows process-length failure", err)
+	}
+
+	plan, err := buildCoverageInvocationPlan(commonArgs, testPackages, profilePath, false, "windows")
+	if err != nil {
+		t.Fatalf("buildCoverageInvocationPlan() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if cleanupErr := plan.cleanup(); cleanupErr != nil {
+			t.Errorf("cleanup bounded invocation plan: %v", cleanupErr)
+		}
+	})
+
+	for index, invocation := range plan.invocations {
+		if err := rejectOversizedInvocation(invocation); err != nil {
+			t.Fatalf("bounded invocation %d failed process-length check: %v", index, err)
+		}
+	}
 }
 
 func TestBuildCoverageInvocationPlanRejectsSingleOversizedWindowsPackage(t *testing.T) {
@@ -181,10 +227,226 @@ func TestRunForOSBatchesAndMergesCoverageProfiles(t *testing.T) {
 	}
 }
 
+func TestRunForOSKeepsCoverageResultsIdenticalAcrossDirectAndBatchedProfiles(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	t.Cleanup(func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	})
+
+	configPackage := modulePath + "/pkg/config"
+	servicePackage := modulePath + "/pkg/service"
+	coverPackages := []string{configPackage, servicePackage}
+	testPackages := makeOversizedTestPackages(500)
+	manifestPath := writeCoverageEquivalenceManifest(t, configPackage, servicePackage)
+	profile := strings.Join([]string{
+		"mode: count",
+		configPackage + "/config.go:1.1,2.1 4 0",
+		configPackage + "/config.go:1.1,2.1 4 2",
+		configPackage + "/config.go:3.1,4.1 6 0",
+		servicePackage + "/factory.go:1.1,2.1 8 1",
+		"",
+	}, "\n")
+
+	direct, err := runCoverageEquivalenceScenario(t, "linux", manifestPath, coverPackages, testPackages, profile)
+	if err != nil {
+		t.Fatalf("direct runForOS() error = %v", err)
+	}
+	batched, err := runCoverageEquivalenceScenario(t, "windows", manifestPath, coverPackages, testPackages, profile)
+	if err != nil {
+		t.Fatalf("batched runForOS() error = %v", err)
+	}
+
+	if len(direct.invocations) != 1 {
+		t.Fatalf("direct invocations = %d, want one", len(direct.invocations))
+	}
+	if len(batched.invocations) < 2 {
+		t.Fatalf("batched invocations = %d, want multiple", len(batched.invocations))
+	}
+	if direct.output != batched.output || direct.output != "total: (statements) 66.7%\n" {
+		t.Fatalf("direct output = %q, batched output = %q, want identical 66.7%% total", direct.output, batched.output)
+	}
+	if !bytes.Equal(direct.profile, batched.profile) {
+		t.Fatalf("canonical coverage profiles differ:\ndirect=%s\nbatched=%s", direct.profile, batched.profile)
+	}
+	assertCoverageEquivalence(t, direct.result, batched.result, configPackage, servicePackage)
+}
+
+func assertCoverageEquivalence(t *testing.T, direct coverageResult, batched coverageResult, configPackage string, servicePackage string) {
+	t.Helper()
+	if direct.actual != batched.actual {
+		t.Fatalf("actual coverage direct=%v, batched=%v, want identical", direct.actual, batched.actual)
+	}
+	if !reflect.DeepEqual(direct.packageTotals, batched.packageTotals) {
+		t.Fatalf("package totals differ:\ndirect=%v\nbatched=%v", direct.packageTotals, batched.packageTotals)
+	}
+	if !reflect.DeepEqual(direct.packageSummaries, batched.packageSummaries) {
+		t.Fatalf("package summaries differ:\ndirect=%v\nbatched=%v", direct.packageSummaries, batched.packageSummaries)
+	}
+	if !reflect.DeepEqual(direct.insufficientCoveragePackages, batched.insufficientCoveragePackages) ||
+		!reflect.DeepEqual(direct.zeroCoveragePackages, batched.zeroCoveragePackages) ||
+		!reflect.DeepEqual(direct.packageMinimumFailures, batched.packageMinimumFailures) ||
+		!reflect.DeepEqual(direct.packageMinimumWarnings, batched.packageMinimumWarnings) ||
+		!reflect.DeepEqual(direct.packageGates, batched.packageGates) {
+		t.Fatalf("coverage gate results differ:\ndirect=%+v\nbatched=%+v", direct, batched)
+	}
+
+	wantTotals := map[string]packageCoverageTotals{
+		configPackage:  {coveredStatements: 4, totalStatements: 10},
+		servicePackage: {coveredStatements: 8, totalStatements: 8},
+	}
+	if !reflect.DeepEqual(direct.packageTotals, wantTotals) {
+		t.Fatalf("package totals = %v, want %v", direct.packageTotals, wantTotals)
+	}
+	wantSummaries := []packageCoverageSummary{
+		{importPath: configPackage, coverage: 40},
+		{importPath: servicePackage, coverage: 100},
+	}
+	if !reflect.DeepEqual(direct.packageSummaries, wantSummaries) {
+		t.Fatalf("package summaries = %v, want %v", direct.packageSummaries, wantSummaries)
+	}
+	if len(direct.packageMinimumFailures) != 1 || !strings.Contains(direct.packageMinimumFailures[0], "package="+configPackage) {
+		t.Fatalf("package minimum failures = %v, want the uncovered package gate failure", direct.packageMinimumFailures)
+	}
+	if direct.packageGates[configPackage].Floor == nil || *direct.packageGates[configPackage].Floor != 41 {
+		t.Fatalf("config package gate = %+v, want 41%% floor", direct.packageGates[configPackage])
+	}
+}
+
+type coverageEquivalenceRun struct {
+	result      coverageResult
+	output      string
+	invocations []commandInvocation
+	profile     []byte
+}
+
+func runCoverageEquivalenceScenario(t *testing.T, targetOS string, manifestPath string, coverPackages []string, testPackages []string, profile string) (coverageEquivalenceRun, error) {
+	t.Helper()
+	var invocations []commandInvocation
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+	commandRunner = func(invocation commandInvocation) (string, string, error) {
+		if len(invocation.args) == 0 || invocation.args[0] != "test" {
+			return "", "", fmt.Errorf("unexpected command in coverage equivalence test: %v", invocation.args)
+		}
+		if targetOS == "windows" && !coverageCommandFitsWindowsLimit(invocation.args) {
+			return "", "", errors.New("bounded coverage invocation exceeded safe Windows limit")
+		}
+		invocations = append(invocations, invocation)
+		if err := writeFakeCoverageProfile(helperCoverProfilePath(invocation.args), profile); err != nil {
+			return "", "", err
+		}
+		return "", "", nil
+	}
+
+	profilePath := filepath.Join(t.TempDir(), targetOS+"-coverage.out")
+	result, err := runForOS(config{
+		min:                 0,
+		suite:               "unit",
+		coverpkg:            strings.Join(coverPackages, ","),
+		packages:            strings.Join(testPackages, " "),
+		packageManifest:     manifestPath,
+		packageFloorEpsilon: 0.25,
+		profile:             profilePath,
+	}, targetOS)
+	if err != nil {
+		return coverageEquivalenceRun{result: result, output: stdout.String(), invocations: invocations}, err
+	}
+	profileData, err := os.ReadFile(profilePath)
+	if err != nil {
+		return coverageEquivalenceRun{}, err
+	}
+	return coverageEquivalenceRun{
+		result:      result,
+		output:      stdout.String(),
+		invocations: invocations,
+		profile:     profileData,
+	}, nil
+}
+
+func TestRunGoTestCoverageLanePropagatesBatchedFailureAndCleansProfiles(t *testing.T) {
+	originalCommandRunner := commandRunner
+	t.Cleanup(func() { commandRunner = originalCommandRunner })
+
+	commonArgs := []string{
+		"test",
+		"-coverpkg=" + modulePath + "/pkg/...",
+		"-p=2",
+		"-count=1",
+		"-covermode=count",
+		"-timeout=10m",
+	}
+	testPackages := makeOversizedTestPackages(500)
+	profilePath := filepath.Join(t.TempDir(), "merged-coverage.out")
+	repoRoot, err := repoRootDir()
+	if err != nil {
+		t.Fatalf("repoRootDir() error = %v", err)
+	}
+
+	var invocations []commandInvocation
+	var batchDir string
+	commandRunner = func(invocation commandInvocation) (string, string, error) {
+		invocations = append(invocations, invocation)
+		batchProfile := helperCoverProfilePath(invocation.args)
+		if batchDir == "" {
+			batchDir = filepath.Dir(batchProfile)
+		}
+		if len(invocations) == 2 {
+			return "", "synthetic subprocess failure", errors.New("exit status 23")
+		}
+		if err := writeFakeCoverageProfile(batchProfile, "mode: count\n"+modulePath+"/pkg/config/config.go:1.1,2.1 3 1\n"); err != nil {
+			return "", "", err
+		}
+		return "", "", nil
+	}
+
+	err = runGoTestCoverageLane(
+		config{},
+		commonArgs,
+		testPackages,
+		profilePath,
+		repoRoot,
+		[]string{modulePath + "/pkg/config"},
+		"windows",
+		"run unit coverage",
+	)
+	if err == nil {
+		t.Fatal("runGoTestCoverageLane() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "run unit coverage (batch 2/") || !strings.Contains(err.Error(), "synthetic subprocess failure") {
+		t.Fatalf("runGoTestCoverageLane() error = %q, want batch context and subprocess detail", err)
+	}
+	if len(invocations) != 2 {
+		t.Fatalf("coverage invocations = %d, want stop after second batch failure", len(invocations))
+	}
+	if batchDir == "" {
+		t.Fatal("batch directory was not captured")
+	}
+	if _, statErr := os.Stat(batchDir); !os.IsNotExist(statErr) {
+		t.Fatalf("batch directory still exists after failure, stat error = %v", statErr)
+	}
+}
+
 func makeOversizedTestPackages(count int) []string {
 	packages := make([]string, 0, count)
 	for index := 0; index < count; index++ {
 		packages = append(packages, modulePath+"/pkg/coverage_test_"+strings.Repeat("x", 32)+strconv.Itoa(index))
 	}
 	return packages
+}
+
+func writeCoverageEquivalenceManifest(t *testing.T, configPackage string, servicePackage string) string {
+	t.Helper()
+	manifestPath := filepath.Join(t.TempDir(), "coverage-minimums.json")
+	manifest := fmt.Sprintf(`{"version":1,"lane":"unit","packages":[{"package":%q,"minimum":41.00},{"package":%q,"minimum":100.00}]}
+`, configPackage, servicePackage)
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write coverage equivalence manifest: %v", err)
+	}
+	return manifestPath
 }

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -268,6 +268,10 @@ func (cfg config) packageCoverageMin() float64 {
 }
 
 func run(cfg config) (coverageResult, error) {
+	return runForOS(cfg, runtime.GOOS)
+}
+
+func runForOS(cfg config, targetOS string) (result coverageResult, runErr error) {
 	profilePath := cfg.profile
 	cleanup := func() error { return nil }
 	if profilePath == "" {
@@ -276,16 +280,24 @@ func run(cfg config) (coverageResult, error) {
 			return coverageResult{}, fmt.Errorf("create temp coverage profile: %w", err)
 		}
 		profilePath = file.Name()
-		if err := file.Close(); err != nil {
-			return coverageResult{}, fmt.Errorf("close temp coverage profile: %w", err)
-		}
 		cleanup = func() error {
 			return os.Remove(profilePath)
 		}
+		defer func() {
+			if cleanupErr := cleanup(); cleanupErr != nil {
+				runErr = errors.Join(runErr, fmt.Errorf("remove temporary coverage profile: %w", cleanupErr))
+			}
+		}()
+		if err := file.Close(); err != nil {
+			return coverageResult{}, fmt.Errorf("close temp coverage profile: %w", err)
+		}
+	} else {
+		defer func() {
+			if cleanupErr := cleanup(); cleanupErr != nil {
+				runErr = errors.Join(runErr, fmt.Errorf("remove temporary coverage profile: %w", cleanupErr))
+			}
+		}()
 	}
-	defer func() {
-		_ = cleanup()
-	}()
 
 	coverPackages, testPackages, err := resolveCoverageLane(cfg)
 	if err != nil {
@@ -296,14 +308,14 @@ func run(cfg config) (coverageResult, error) {
 		return coverageResult{}, err
 	}
 	coverPackageArgument := strings.Join(coverPackages, ",")
-	if runtime.GOOS == "windows" && strings.TrimSpace(cfg.coverpkg) == "" {
+	if targetOS == "windows" && strings.TrimSpace(cfg.coverpkg) == "" {
 		// A fully expanded backend package list exceeds Windows' command-line
 		// limit. A package pattern keeps the invocation to one logical coverage
 		// pass; the resolved list above remains authoritative for profile
 		// filtering, reporting, and package gates.
 		coverPackageArgument = modulePath + "/pkg/..."
 	}
-	mergedTestArgs := []string{
+	coverageTestArgs := []string{
 		"test",
 		fmt.Sprintf("-coverpkg=%s", coverPackageArgument),
 		fmt.Sprintf("-p=%d", cfg.testJobs()),
@@ -312,19 +324,14 @@ func run(cfg config) (coverageResult, error) {
 		"-count=1",
 	}
 	if cfg.short {
-		mergedTestArgs = append(mergedTestArgs, "-short")
+		coverageTestArgs = append(coverageTestArgs, "-short")
 	}
-	mergedTestArgs = append(mergedTestArgs,
+	coverageTestArgs = append(coverageTestArgs,
 		fmt.Sprintf("-covermode=%s", cfg.covermode),
 		fmt.Sprintf("-timeout=%s", cfg.timeout),
 	)
 
-	mergedTestArgs = append(mergedTestArgs, fmt.Sprintf("-coverprofile=%s", profilePath))
-	if strings.TrimSpace(cfg.timingOutput) != "" {
-		mergedTestArgs = append(mergedTestArgs, "-json")
-	}
-	mergedTestArgs = append(mergedTestArgs, testPackages...)
-	if err := runGoTestCoverageLane(cfg, mergedTestArgs, testPackages, "run go test coverage lane"); err != nil {
+	if err := runGoTestCoverageLane(cfg, coverageTestArgs, testPackages, profilePath, repoRoot, coverPackages, targetOS, "run go test coverage lane"); err != nil {
 		return coverageResult{}, err
 	}
 	if err := canonicalizeCoverageProfile(profilePath, repoRoot, coverPackages); err != nil {
@@ -387,39 +394,67 @@ func packageCoverageBaselinePackages(cfg config, repoRoot string) (map[string]st
 	return readPackageCoverageBaseline(baselinePath)
 }
 
-// runGoTestCoverageLane runs the merged go test coverage invocation once. When
-// cfg.timingOutput is set, it also captures package timing from the same
-// process's -json stdout and writes the timing summary before returning,
-// regardless of whether the go test invocation itself failed, so a failed or
-// crashed lane still leaves trustworthy (possibly incomplete) timing
-// diagnostics on disk.
-func runGoTestCoverageLane(cfg config, args []string, testPackages []string, failurePrefix string) error {
+// runGoTestCoverageLane runs the coverage invocation once on short command
+// lines, or in deterministic test-package batches when Windows needs it. When
+// cfg.timingOutput is set, it combines every batch's -json stdout before
+// writing the timing summary, so a failed or crashed lane still leaves
+// trustworthy (possibly incomplete) diagnostics on disk.
+func runGoTestCoverageLane(cfg config, commonArgs []string, testPackages []string, profilePath string, repoRoot string, coverPackages []string, targetOS string, failurePrefix string) error {
 	timingEnabled := strings.TrimSpace(cfg.timingOutput) != ""
+	plan, err := buildCoverageInvocationPlan(commonArgs, testPackages, profilePath, timingEnabled, targetOS)
+	if err != nil {
+		return err
+	}
+
 	started := time.Now()
-	stdout, stderr, err := runCommand(commandInvocation{
-		name: "go",
-		args: args,
-		env:  os.Environ(),
-	})
+	var stdout strings.Builder
+	var stderr strings.Builder
+	var laneErr error
+	for index, invocation := range plan.invocations {
+		batchStdout, batchStderr, commandErr := runCommand(invocation)
+		appendCoverageOutput(&stdout, batchStdout)
+		appendCoverageOutput(&stderr, batchStderr)
+		if commandErr == nil {
+			continue
+		}
+
+		detail := mergeGoTestFailureDetail(stderr.String(), stdout.String())
+		batchFailurePrefix := failurePrefix
+		if len(plan.invocations) > 1 {
+			batchFailurePrefix = fmt.Sprintf("%s (batch %d/%d)", failurePrefix, index+1, len(plan.invocations))
+		}
+		if detail != "" {
+			laneErr = fmt.Errorf("%s: %w\n%s", batchFailurePrefix, commandErr, detail)
+		} else {
+			laneErr = fmt.Errorf("%s: %w", batchFailurePrefix, commandErr)
+		}
+		break
+	}
 	wallSeconds := time.Since(started).Seconds()
 
 	var timingWriteErr error
 	if timingEnabled {
-		summary := buildFunctionalTimingSummary(stdout, testPackages, wallSeconds)
+		summary := buildFunctionalTimingSummary(stdout.String(), testPackages, wallSeconds)
 		timingWriteErr = writeFunctionalTimingSummaryJSON(cfg.timingOutput, summary)
 	}
 
-	if err != nil {
-		detail := mergeGoTestFailureDetail(stderr, stdout)
-		var testErr error
-		if detail != "" {
-			testErr = fmt.Errorf("%s: %w\n%s", failurePrefix, err, detail)
-		} else {
-			testErr = fmt.Errorf("%s: %w", failurePrefix, err)
+	if laneErr == nil && len(plan.profilePaths) > 1 {
+		if mergeErr := mergeCoverageProfiles(plan.profilePaths, profilePath, repoRoot, coverPackages); mergeErr != nil {
+			laneErr = mergeErr
 		}
-		return errors.Join(testErr, timingWriteErr)
 	}
-	return timingWriteErr
+
+	return errors.Join(laneErr, timingWriteErr, plan.cleanup())
+}
+
+func appendCoverageOutput(output *strings.Builder, chunk string) {
+	if chunk == "" {
+		return
+	}
+	if output.Len() > 0 {
+		output.WriteByte('\n')
+	}
+	output.WriteString(chunk)
 }
 
 func runCommand(invocation commandInvocation) (string, string, error) {

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -336,7 +336,8 @@ func runCoverageProfile(cfg config, targetOS string, profilePath string) (covera
 		fmt.Sprintf("-timeout=%s", cfg.timeout),
 	)
 
-	if err := runGoTestCoverageLane(cfg, coverageTestArgs, testPackages, profilePath, repoRoot, coverPackages, targetOS, "run go test coverage lane"); err != nil {
+	testPackageArgs := compactUnitTestPackageArgs(cfg, testPackages, targetOS)
+	if err := runGoTestCoverageLane(cfg, coverageTestArgs, testPackages, profilePath, repoRoot, coverPackages, targetOS, "run go test coverage lane", testPackageArgs); err != nil {
 		return coverageResult{}, err
 	}
 	if err := canonicalizeCoverageProfile(profilePath, repoRoot, coverPackages); err != nil {
@@ -476,6 +477,23 @@ func listGoPackages(patterns []string, include func(string) bool, requireNonTest
 		return nil, errors.New("resolve go coverage lane: no packages matched")
 	}
 	return packages, nil
+}
+
+func compactUnitTestPackageArgs(cfg config, testPackages []string, targetOS string) []string {
+	// The compact patterns are safe only for the default unit package universe:
+	// custom package lists and functional packages retain their existing args.
+	if targetOS != "windows" || (cfg.suite != "" && cfg.suite != "unit") || strings.TrimSpace(cfg.packages) != "" {
+		return nil
+	}
+	allPackages, err := listGoPackages([]string{"./pkg/..."}, func(string) bool { return true }, false)
+	if err != nil {
+		return nil
+	}
+	patterns, err := compactGoPackagePatterns(allPackages, testPackages, modulePath+"/pkg")
+	if err != nil {
+		return nil
+	}
+	return patterns
 }
 
 func parseGoListPackageLine(line string) (string, int, bool) {

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -272,33 +272,38 @@ func run(cfg config) (coverageResult, error) {
 }
 
 func runForOS(cfg config, targetOS string) (result coverageResult, runErr error) {
-	profilePath := cfg.profile
-	cleanup := func() error { return nil }
-	if profilePath == "" {
-		file, err := os.CreateTemp("", "go-coverage-*.out")
-		if err != nil {
-			return coverageResult{}, fmt.Errorf("create temp coverage profile: %w", err)
-		}
-		profilePath = file.Name()
-		cleanup = func() error {
-			return os.Remove(profilePath)
-		}
-		defer func() {
-			if cleanupErr := cleanup(); cleanupErr != nil {
-				runErr = errors.Join(runErr, fmt.Errorf("remove temporary coverage profile: %w", cleanupErr))
-			}
-		}()
-		if err := file.Close(); err != nil {
-			return coverageResult{}, fmt.Errorf("close temp coverage profile: %w", err)
-		}
-	} else {
-		defer func() {
-			if cleanupErr := cleanup(); cleanupErr != nil {
-				runErr = errors.Join(runErr, fmt.Errorf("remove temporary coverage profile: %w", cleanupErr))
-			}
-		}()
+	profilePath, cleanup, err := prepareCoverageProfile(cfg.profile)
+	if err != nil {
+		return coverageResult{}, err
 	}
+	defer func() {
+		if cleanupErr := cleanup(); cleanupErr != nil {
+			runErr = errors.Join(runErr, fmt.Errorf("remove temporary coverage profile: %w", cleanupErr))
+		}
+	}()
+	return runCoverageProfile(cfg, targetOS, profilePath)
+}
 
+func prepareCoverageProfile(profilePath string) (string, func() error, error) {
+	if profilePath != "" {
+		return profilePath, func() error { return nil }, nil
+	}
+	file, err := os.CreateTemp("", "go-coverage-*.out")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temp coverage profile: %w", err)
+	}
+	profilePath = file.Name()
+	cleanup := func() error { return os.Remove(profilePath) }
+	if err := file.Close(); err != nil {
+		return "", nil, errors.Join(
+			fmt.Errorf("close temp coverage profile: %w", err),
+			cleanup(),
+		)
+	}
+	return profilePath, cleanup, nil
+}
+
+func runCoverageProfile(cfg config, targetOS string, profilePath string) (coverageResult, error) {
 	coverPackages, testPackages, err := resolveCoverageLane(cfg)
 	if err != nil {
 		return coverageResult{}, err
@@ -392,92 +397,6 @@ func packageCoverageBaselinePackages(cfg config, repoRoot string) (map[string]st
 		baselinePath = filepath.Join(repoRoot, baselinePath)
 	}
 	return readPackageCoverageBaseline(baselinePath)
-}
-
-// runGoTestCoverageLane runs the coverage invocation once on short command
-// lines, or in deterministic test-package batches when Windows needs it. When
-// cfg.timingOutput is set, it combines every batch's -json stdout before
-// writing the timing summary, so a failed or crashed lane still leaves
-// trustworthy (possibly incomplete) diagnostics on disk.
-func runGoTestCoverageLane(cfg config, commonArgs []string, testPackages []string, profilePath string, repoRoot string, coverPackages []string, targetOS string, failurePrefix string) error {
-	timingEnabled := strings.TrimSpace(cfg.timingOutput) != ""
-	plan, err := buildCoverageInvocationPlan(commonArgs, testPackages, profilePath, timingEnabled, targetOS)
-	if err != nil {
-		return err
-	}
-
-	started := time.Now()
-	var stdout strings.Builder
-	var stderr strings.Builder
-	var laneErr error
-	for index, invocation := range plan.invocations {
-		batchStdout, batchStderr, commandErr := runCommand(invocation)
-		appendCoverageOutput(&stdout, batchStdout)
-		appendCoverageOutput(&stderr, batchStderr)
-		if commandErr == nil {
-			continue
-		}
-
-		detail := mergeGoTestFailureDetail(stderr.String(), stdout.String())
-		batchFailurePrefix := failurePrefix
-		if len(plan.invocations) > 1 {
-			batchFailurePrefix = fmt.Sprintf("%s (batch %d/%d)", failurePrefix, index+1, len(plan.invocations))
-		}
-		if detail != "" {
-			laneErr = fmt.Errorf("%s: %w\n%s", batchFailurePrefix, commandErr, detail)
-		} else {
-			laneErr = fmt.Errorf("%s: %w", batchFailurePrefix, commandErr)
-		}
-		break
-	}
-	wallSeconds := time.Since(started).Seconds()
-
-	var timingWriteErr error
-	if timingEnabled {
-		summary := buildFunctionalTimingSummary(stdout.String(), testPackages, wallSeconds)
-		timingWriteErr = writeFunctionalTimingSummaryJSON(cfg.timingOutput, summary)
-	}
-
-	if laneErr == nil && len(plan.profilePaths) > 1 {
-		if mergeErr := mergeCoverageProfiles(plan.profilePaths, profilePath, repoRoot, coverPackages); mergeErr != nil {
-			laneErr = mergeErr
-		}
-	}
-
-	return errors.Join(laneErr, timingWriteErr, plan.cleanup())
-}
-
-func appendCoverageOutput(output *strings.Builder, chunk string) {
-	if chunk == "" {
-		return
-	}
-	if output.Len() > 0 {
-		output.WriteByte('\n')
-	}
-	output.WriteString(chunk)
-}
-
-func runCommand(invocation commandInvocation) (string, string, error) {
-	return commandRunner(invocation)
-}
-
-func mergeGoTestFailureDetail(stderr string, stdout string) string {
-	stderr = strings.TrimSpace(compactCoverageOutput(stderr))
-	stdout = strings.TrimSpace(compactCoverageOutput(stdout))
-	switch {
-	case stdout == "":
-		return stderr
-	case stderr == "":
-		return stdout
-	case strings.Contains(stdout, "\nFAIL") || strings.Contains(stdout, "--- FAIL:"):
-		return stdout + "\n" + stderr
-	default:
-		return stderr + "\n" + stdout
-	}
-}
-
-func compactCoverageOutput(output string) string {
-	return coveragePackageListPattern.ReplaceAllString(output, "$1")
 }
 
 func resolveCoverageLane(cfg config) ([]string, []string, error) {


### PR DESCRIPTION
{
  "project": "Make the Unit Coverage Gate Runnable Locally on Windows",
  "branchName": "thr-coverage-unit-lane-windows-arglimit",
  "description": "Make make test-unit-coverage execute to completion on Windows without changing the tests, instrumented statement population, package or total coverage numbers, manifests, epsilon, or gate policy. Measure the current oversized command, use a provably equivalent bounded invocation strategy, add direct regression and numerical-equivalence evidence, preserve functional coverage and concurrent variance work, and document both local pre-push coverage targets.",
  "context": {
    "customerAsk": "Make make test-unit-coverage run locally on the Windows worker host without changing what coverage is measured or required. Reproduce and quantify the failure first, prove same-commit before/after per-package equivalence, protect the safe argument bound with a regression test, keep functional coverage unchanged, preserve the concurrent variance lane, and document that both coverage targets are expected before pushing.",
    "problem": "On clean main commit 0f3c19544, make test-unit-coverage failed before any test executed with fork/exec go.exe: The filename or extension is too long. The unit lane expands its test packages and large -coverpkg set into one process command line beyond the roughly 32,767-character Windows limit. Every factory worker uses this host, so unit coverage regressions are discovered one CI round at a time; recent backend PRs needed 6-9 failed CI runs while package floors moved by -0.2759 to -2.9508 percentage points.",
    "solution": "Rebase onto authoritative main, reproduce the failure, and record the approximate composed length. Then keep each coverage process below a documented conservative Windows bound using the simplest strategy that proves an identical selected statement population and identical same-commit package totals: prefer a compact -coverpkg pattern when equivalent, otherwise batch tests and deterministically merge canonical coverage blocks. Add focused behavioral regression tests, verify both real coverage targets and make verify-fast, publish evidence in the PR, and never change coverage manifests or policy."
  },
  "acceptanceCriteria": [
    "Before implementation, the rebased baseline reproduces the Windows unit-lane failure with The filename or extension is too long, records that no test executed, and reports the approximate composed command-line length; if authoritative main no longer reproduces it, implementation stops and reports the changed condition rather than guessing.",
    "After implementation, make test-unit-coverage runs to completion on Windows, emits per-package results, and every spawned coverage command remains below the documented safe Windows bound.",
    "A same-commit comparison proves identical selected statement populations, package covered/total counts, per-package percentages, total percentage, manifest decisions, and exit behavior before and after; any numerical movement rejects the approach.",
    "make test-functional-coverage continues to run locally with identical package and total results, and neither lane changes its tests, manifests, floors, 0.25 percentage-point epsilon, or pass/fail policy.",
    "Focused regression coverage demonstrates the old oversized unit invocation failing and the bounded strategy passing with deterministic profile/result handling and actionable failure propagation.",
    "Scope remains confined to cmd/gocoveragecheck, the owned Makefile coverage/help surface, and PR evidence; coverage manifests, ui, pkg/services, pkg/wire, pkg/transports, and unrelated cleanup remain untouched, and merged variance work is retained.",
    "Typecheck and tests pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green; make test-unit-coverage, make test-functional-coverage, make verify-fast, and required CI complete successfully.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file churn are resolved, and the PR is actually merged; opened, green, approved, or ready-to-merge is not complete."
  ],
  "userStories": [
    {
      "id": "thr-coverage-unit-lane-windows-arglimit-001",
      "title": "Establish the Windows failure and equivalence baseline",
      "description": "As an implementer, I need a reproducible size measurement and same-commit coverage baseline so the fix addresses the observed operating-system failure without silently redefining coverage.",
      "acceptanceCriteria": [
        "Rebase onto current origin/main before collecting evidence and retain all merged gocoveragecheck variance behavior rather than reverting or replacing it.",
        "On Windows, make test-unit-coverage reproduces The filename or extension is too long before tests execute, and PR evidence records the approximate composed process command-line length and measurement method.",
        "If the failure cannot be reproduced on authoritative main, stop implementation and report the commit, command, host, observed output, and likely superseding behavior instead of applying a speculative fix.",
        "On the same baseline commit in an environment or lane where the current invocation completes, capture deterministic package covered/total statement counts, displayed percentages, total percentage, gate outcome, and functional-lane results for comparison.",
        "Evidence is stored in the PR body or comment, not committed as a generated or one-off repository artifact.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Baseline commit 0f3c19544 is already origin/main. Windows make test-unit-coverage reproduced before any test output: fork/exec go.exe: The filename or extension is too long. Measured with the resolved 571 unit test-package args, 549 selected cover packages, executable path, separators, and a representative temp profile path: compact current invocation ~52,558 characters; prior fully expanded coverpkg composition ~102,561; conservative bound reference 24,000. Same-commit Linux WSL run completed with 94,786/118,193 statements, 80.2%, manifest gate pass, and 549 package results. Same-commit functional run produced 134 pass, 2 fail, and 11 skip package timing results and no coverage summary because two pre-existing functional tests failed. Focused cmd/gocoveragecheck tests pass when run with an isolated temporary directory; the default host has an unrelated C:\\Users\\andre\\AppData\\Local\\Temp\\go.mod that breaks the negative repo-root test."
    },
    {
      "id": "thr-coverage-unit-lane-windows-arglimit-002",
      "title": "Run the unit coverage measurement below the Windows argument bound",
      "description": "As a Windows-hosted worker, I want the unit coverage target to complete locally with the same measurement contract as CI so I can detect regressions before pushing.",
      "acceptanceCriteria": [
        "make test-unit-coverage completes test execution and reports package and total coverage on Windows without a process-creation argument-length error.",
        "Every spawned coverage invocation stays below a named conservative Windows command-line bound, accounting for executable, arguments, separators, quoting, and variable-length profile paths rather than relying on one checkout path.",
        "The implementation preserves the resolved unit test-package set, selected backend coverage-package set, covermode, count=1, jobs, short mode, timeout, profile/output behavior, manifest enforcement, epsilon, and failure semantics.",
        "A compact package pattern is used only when comparison proves the same selected source-block population; if batching is used, each test package executes exactly once and merged blocks represent the union of covered statements without double-counting denominators.",
        "Temporary resources are uniquely scoped, closed, and removed on success and failure, and subprocess failures retain actionable lane context without masking cleanup errors.",
        "Existing functional timing, JSON, and concurrent variance behavior remain intact.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented a conservative 24,000-character Windows command-line upper bound that includes the resolved go executable, separators, escaping allowance, and actual profile paths. Default unit lanes now derive 174 disjoint Go package patterns proven against the full package universe to represent all 571 selected packages, so the original single process and scheduling are preserved; concrete deterministic batching remains the fallback for custom or uncompactable lanes. Existing batching continues later packages after ordinary subprocess failure, merges available profiles, preserves functional timing aggregation, and cleans temporary resources. Host-independent regression coverage passes. Native Windows make test-unit-coverage reached all package reports in one bounded invocation and produced 80.1% total coverage; the unchanged manifest then rejected pre-existing platform/filesystem (69.5652% < 75.00%) and platform/process (64.9819% < 68.00%) floors, so no manifests or policy were changed."
    },
    {
      "id": "thr-coverage-unit-lane-windows-arglimit-003",
      "title": "Prevent argument-length and coverage-equivalence regressions",
      "description": "As a reviewer, I want direct behavioral tests for bounded invocation and identical coverage results so future package growth cannot reintroduce the Windows failure or shift coverage floors silently.",
      "acceptanceCriteria": [
        "A focused regression test constructs a representative unit lane large enough to cross the safe bound under the old composition, demonstrates the old oversized behavior failing, and demonstrates the selected strategy producing only bounded invocations.",
        "Tests assert observable invocation inputs and results without scanning source topology, enforcing command-registration inventories, or depending on the current count of repository packages.",
        "Profile and result tests prove identical selected package totals, percentages, total coverage, and gate decisions for representative covered, uncovered, duplicate-block, and subprocess-failure cases.",
        "A same-commit real-lane comparison reports zero differences for all package covered/total counts and percentages, and the successful unit-run tail plus explicit comparison are included in the PR.",
        "make test-functional-coverage completes and its same-commit comparison reports zero numerical differences.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": false,
      "notes": "Added observable regression coverage for the legacy oversized Windows invocation, exact compact package-universe expansion, bounded-plan success, canonical profile handling, exact-once fallback batching, and actionable failures. The synthetic direct-versus-batched profile test requires byte-identical canonical filtered profiles plus identical package totals, percentages, total coverage, manifest gates, failure decisions, and zero-coverage results. Default Windows unit execution now stays in one bounded process, eliminating batching as a source of real-lane variance; native Windows unit coverage reaches 80.1% reporting without the old error, and functional coverage remains on its unchanged direct path at 57.0% before the unchanged filesystem floor. PR #1941 remains open with no unresolved inline threads. The latest blocking review rejects the supplied real-lane comparison because unit totals moved from 80.1907066468% to 80.2000135373% and functional covered statements moved from 62,939 to 62,957 across 15 packages. Those movements are consistent with the repository's intentional scheduling-sensitive functional variance, and changing that lane to force equality would violate the preservation requirement. Focused tests, isolated-temp checker tests, vet, coverage-help, and diff checks pass on this iteration; story remains passes:false pending an operator-approved acceptance-criterion revision or genuinely zero-diff real-lane evidence. Required CI run 31738240921 is terminal and green after the one permitted rerun of the untouched functional timeout, but it does not change this story's acceptance status."
    },
    {
      "id": "thr-coverage-unit-lane-windows-arglimit-004",
      "title": "Publish the local coverage workflow and deliver safely",
      "description": "As a contributor, I want clear pre-push coverage guidance and a conflict-safe delivery path so I can run both authoritative Go coverage lanes locally and trust the merged result.",
      "acceptanceCriteria": [
        "Developer-facing Makefile help states that both make test-unit-coverage and make test-functional-coverage are expected locally before pushing and distinguishes their independent reports.",
        "The guidance is concise, works on Windows, and does not claim that compilation or typechecking substitutes for completed coverage execution.",
        "The PR is opened by the third implementation iteration and contains the measured Windows before failure, approximate command length, successful after tail, implementation-choice rationale, same-commit equivalence comparison, and unchanged functional-lane evidence.",
        "Immediately before the final push, rebase onto origin/main; for gocoveragecheck or variance conflicts, take main's authoritative version and re-apply only this lane's bounded-invocation changes on top.",
        "No generated file is hand-merged, and CI evidence is posted in a PR comment rather than committed so it does not create a new head and invalidate the result.",
        "Typecheck passes"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Added cross-platform make coverage-help output and inline Makefile guidance that names make test-unit-coverage and make test-functional-coverage as independent pre-push reports and states that build/typecheck alone is insufficient. After rebasing onto origin/main, make coverage-help, the unchanged coverage dry-run, go test ./cmd/gocoveragecheck, go vet ./cmd/gocoveragecheck, make typecheck, and make verify-fast pass. No generated or one-off evidence files were added; coverage evidence is kept in the PR conversation."
    }
  ]
}
