### PR TITLE
thr-fix-makefile-nul-litter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GO          ?= go
 INSTALL_DIR := $(or $(GOBIN),$(shell $(GO) env GOPATH)/bin)
 NPM         ?= npm
 ifeq ($(OS),Windows_NT)
-BUN_BIN     := $(shell where.exe bun >NUL 2>NUL && echo bun)
+BUN_BIN     := $(shell where.exe bun >/dev/null 2>&1 && echo bun)
 else
 BUN_BIN     := $(shell command -v bun 2>/dev/null)
 endif


### PR DESCRIPTION
{
  "project": "Stop Makefile NUL Litter on Windows",
  "branchName": "thr-fix-makefile-nul-litter",
  "description": "Prevent Windows Makefile toolchain detection from creating a literal NUL file when GNU make executes the Bun probe through POSIX sh, while preserving the existing Bun detection and Bun-over-npm UI toolchain choice and supplying direct reproduction, before/after, equivalence, and targeted audit evidence.",
  "context": {
    "customerAsk": "Stop every Makefile evaluation on Windows from creating a literal NUL file, preserve the resolved BUN_BIN value and UI_SCRIPT package-manager selection, reproduce the failure before editing, verify the correction on the Windows host, report all targeted cmd-style redirection matches and dispositions, respect concurrent-lane ownership, and deliver the focused change through review, CI, conflict resolution, and merge.",
    "problem": "The Windows BUN_BIN probe uses cmd.exe-style >NUL redirection, but GNU make runs the expression through Git Bash or another POSIX sh where NUL is an ordinary filename. Each evaluation can leave a 33-byte NUL file containing the Bun path. That invalid Windows filename breaks tree-walking operations including git stash --include-untracked, which can cause stash-based workspace setup to fail as a silent plan:failed. A careless fix could also empty BUN_BIN and silently switch all UI commands from Bun to npm.",
    "solution": "Reproduce and capture the current artifact in an isolated scratch location, then use null-device redirection understood by the actual POSIX shell while retaining the established success and failure semantics of Bun detection. Explicitly compare BUN_BIN and UI_SCRIPT before and after with Bun installed, document the Bun-absent npm fallback, prove the corrected probe creates no artifact, classify all targeted redirection search matches by executing shell, and change only confirmed in-scope occurrences."
  },
  "acceptanceCriteria": [
    "Before-change evidence from an isolated Windows scratch run shows the same make or POSIX-shell Bun probe creating a literal NUL file, including its 33-byte size and Bun-path content.",
    "After the correction, the same invocation in a clean scratch checkout completes without creating a NUL file or another redirection artifact.",
    "With Bun installed, explicit output shows that BUN_BIN remains identically non-empty and UI_SCRIPT remains Bun-selected before and after; the evidence also states that Bun absence leaves BUN_BIN empty and selects npm.",
    "A targeted search of the Makefile, scripts, factory/scripts, CI workflow files, and .mk fragments reports every >NUL, > NUL, 2>NUL, and NUL 2>&1 occurrence and its disposition, and only occurrences confirmed to execute under POSIX sh are corrected.",
    "The implementation does not change package-manager preference, restructure the Makefile, clean existing worktree artifacts, alter contracts or generated artifacts, or modify any explicitly excluded concurrent-lane surface.",
    "Quality gates pass: typecheck, focused behavioral verification, and make verify-fast; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are reconciled according to lane ownership, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "thr-fix-makefile-nul-litter-001",
      "title": "Preserve Bun selection without creating NUL",
      "description": "As a Windows maintainer, I want Makefile toolchain detection to discard probe output through the shell's real null device so routine make invocations do not poison worktrees or silently switch the UI package manager.",
      "acceptanceCriteria": [
        "Before editing, an isolated Windows reproduction captures the literal NUL artifact created by the current probe, its 33-byte size, and its Bun-path content.",
        "After the correction, repeating the same invocation in a clean scratch checkout creates no literal NUL file or substitute redirection artifact.",
        "With Bun installed, explicit before/after output shows identical non-empty BUN_BIN and Bun-selected UI_SCRIPT values.",
        "When Bun is absent, the probe yields an empty BUN_BIN and UI_SCRIPT continues to select npm, and the PR explains why the chosen command preserves this outcome.",
        "The PR records each targeted cmd-style redirection search match and whether it was corrected or retained, with the shell context justifying the disposition.",
        "Only in-scope shell-invalid redirection is changed; concurrent-lane ownership and all non-goals remain intact.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Changed only Makefile:8 from cmd-style NUL redirection to POSIX /dev/null redirection. Before-change Windows Git Bash reproduction created a 33-byte NUL file containing C:\\Users\\andre\\.bun\\bin\\bun.exe\\r\\n while resolving BUN_BIN=bun and UI_SCRIPT=bun run. After-change clean scratch probes created no entries: Bun installed remained BUN_BIN=bun/UI_SCRIPT=bun run, and Bun absent remained BUN_BIN empty/UI_SCRIPT=npm run. Targeted audit found only Makefile:8 across Makefile, scripts, factory/scripts, .github workflow files, and .mk fragments; it was corrected because GNU make executes the Windows shell function through POSIX sh in the reproduction. make typecheck and make verify-fast passed. make lint ran; UI lint and vet passed, while six unrelated baseline checks reported existing findings outside this diff (ui-deadcode, backend-size, package-target-manifest-check, packaged-factory-consumption-check, ownership-inventory-check, deadcode)."
    }
  ]
}
