### PR TITLE
docs(plans): add factory engine E26 known issues and work relationship mutation plans

### DIFF
--- a/docs/internal/development/plans/factory-engine-e26-known-issues.md
+++ b/docs/internal/development/plans/factory-engine-e26-known-issues.md
@@ -1,0 +1,583 @@
+# Factory Engine Fixes From E26 Factory-Authoring Feedback
+
+---
+author: andreas abdi
+status: proposed
+verified-against: `main` @ `0f3c19544` (2026-08-13)
+source: `factories/translation/KNOWN-ISSUES.md` @ `9a8dfc8` (mangaka-cli), E26 rounds 6-9
+---
+
+# problem statement
+
+A customer building a real multi-phase Factory hit seven behaviours they read as
+engine contract violations; four are genuine engine gaps, and the diagnostic
+surfaces were thin enough that each one cost hours of recording-JSON spelunking
+rather than minutes.
+
+## customer ask
+
+Fan-in, batch lineage, and re-submission should behave the way the reference
+docs describe, and when a Factory stops making progress the runtime should say
+why instead of requiring the author to reconstruct enablement by hand.
+
+## solution
+
+Close the four real engine gaps (A4 verification, A6 cross-batch parent
+lineage, A7 silent re-upsert, C1-C4 diagnostics), add one authoring-time
+validation rule that would have prevented two of the reported stalls outright,
+and keep every new mechanism out of the customer-facing vocabulary except the
+single field that customers must actually type.
+
+# original document
+
+`C:\Users\andre\work\translate\manga-image-translator\mangaka-cli\factories\translation\KNOWN-ISSUES.md`
+(rendered as the "Factory known issues - E26 r6-r9" artifact). Sections A and C
+of that document are engine-owned and in scope here. Sections B, D, and E are
+customer-factory-owned and are explicitly out of scope.
+
+---
+
+## Baseline verification (do this before writing code)
+
+This plan describes `main` as of `0f3c19544`. Plan documents are snapshots.
+Before starting any story, confirm the baseline still holds:
+
+- `git log --oneline -5` and re-read the cited file:line anchors in each story.
+- If an anchor has moved or the behaviour already changed, stop and re-scope
+  that story rather than implementing against a stale premise.
+
+Two items from the source document are **already resolved on `main`** and must
+not be re-implemented:
+
+| Item | Disposition |
+|---|---|
+| A1 - `ALL_CHILDREN_COMPLETE` vacuous for submitted `PARENT_CHILD` | Fixed 2026-08-08 by `88127e409`, `525a9f854`, `6344b0311`. `Marking.ParentChildRegistrations` (`pkg/services/factory_runtime/internal/orchestrators/petri/marking.go:16-34`) is the reverse index by parent, and `ParentChildRegistrationSet.Complete` makes the guard fail closed on an empty set. |
+| A2 - work payload does not survive `AGENT_RUN` | Not a defect. `workPropagation` defaults to `OUTPUT_AS_PAYLOAD`, which replaces the downstream payload with worker output (`token_transformer/transformer.go:213-226`). Documented at `docs/reference/workstations.md:225-248`. Customer-side configuration. |
+
+A3 (`TIMED_OUT` bypassing an explicit `onFailure`) is **deferred, not
+scheduled**: a script timeout maps to `WorkOutcome = FAILED`
+(`workers/internal/services/workstations/executor/script_test.go:477-491`) and
+`onFailure` is documented as covering timeouts
+(`docs/reference/workstations.md:219`), so the reported behaviour is not
+reproducible from the current code. It re-enters this plan only if S1's
+methodology produces a minimal repro.
+
+---
+
+## Scope
+
+**In scope.** Engine behaviour in `infinite-you` only: per-input guard
+evaluation on logical workstations, authoring-time route validation,
+enablement diagnostics, work-request re-submission reporting, cross-batch
+parent lineage, and three read-surface gaps.
+
+**Out of scope.** Everything in the customer's factory (sections B, D, E of the
+source document): their closer design, payload cache, work-name conventions,
+failure-lane shape, artifact assertions, hot-reload discipline, disk pruning,
+and their red `main`. No opportunistic refactors of `scheduler`,
+`definitionmapping`, or `requestadmission` beyond what each story names.
+
+---
+
+# changes
+
+## Story sequence
+
+Ordered so each story establishes contract or invariant that later stories
+depend on. S1-S2 are independent and can start immediately; S9 must land
+before S10.
+
+| # | Behaviour | Depends on |
+|---|---|---|
+| S1 | Logical workstations honour per-input fan-in guards | - |
+| S2 | Authoring rejects states that no workstation can consume | - |
+| S3 | The runtime records why a workstation was not enabled | - |
+| S4 | `you work explain` reports working / blocked / no-route | S3 |
+| S5 | Re-submitting a request id reports that it added nothing | - |
+| S6 | `you work list --json` returns real payloads | - |
+| S7 | Script stderr appears in the runtime log | - |
+| S8 | Visit counts are readable without opening a recording | - |
+| S9 | A parent stops accepting children once its fan-in can select it | - |
+| S10 | A child can name a parent submitted in an earlier request | S9 |
+
+---
+
+## S1 - Logical workstations honour per-input fan-in guards
+
+**Behaviour.** A `LOGICAL_MOVE` workstation carrying an
+`ALL_CHILDREN_COMPLETE` per-input guard stays disabled until every registered
+child is terminal, exactly as a worker-backed workstation does.
+
+**Why this is a characterization story first.** The reported constraint is
+"guards only evaluate on worker-backed stations," which forces authors into
+no-op `/usr/bin/true` workers. That gate is not present in any path I can find:
+`mapper.go:97` calls `applyInputGuards` for every workstation unconditionally;
+`topology_rules.go:638-766` applies no logical exclusion to per-input guard
+validation; and `enablement.go:166-185` builds the full `RuntimeGuardContext`,
+including `ParentChildRegistrations`, with no worker-type branch. The reporting
+factory hit this before A1's fix landed, when the fan-in guard failed closed for
+an unrelated reason - indistinguishable from "guards don't fire here."
+
+Write the test first. If it passes, the story closes as a permanent regression
+guard plus a docs line. If it fails, the failure localises the real gate and the
+fix follows in the same story.
+
+**Acceptance criteria.**
+- A functional test authors a `LOGICAL_MOVE` workstation with a parent input and
+  an `ALL_CHILDREN_COMPLETE` guarded child input, registers three children, and
+  asserts the transition is not enabled while any child is non-terminal.
+- The same test asserts the transition becomes enabled on the tick after the
+  third child reaches a terminal place, and consumes all three.
+- An `ANY_CHILD_FAILED` variant asserts the parallel behaviour for one failed
+  child.
+- If the assertions fail against `main`, the story additionally lands the
+  narrowest change that makes them pass, and the change does not alter
+  worker-backed guard behaviour (existing `scheduler` and `definitionmapping`
+  suites stay green without modification).
+
+**Tests.**
+- `pkg/services/factory_runtime/internal/services/orchestration/scheduler/enablement_test.go` - unit-level enablement over a logical transition with a guarded arc.
+- `tests/functional/factory/` - one end-to-end fan-in through a logical closer, asserting the parent's outbound state only after all children complete.
+
+**Docs.**
+- `docs/reference/workstations.md` - state plainly that per-input guards are
+  evaluated on `LOGICAL_MOVE` workstations, and that the existing
+  `LOGICAL_MOVE` exclusion at line 263 applies to implicit failure-arc
+  normalization only. That line was read as covering guards.
+- `docs/reference/guards.md` - matching sentence on the per-input guard contract.
+
+---
+
+## S2 - Authoring rejects states that no workstation can consume
+
+**Behaviour.** Loading a Factory whose configuration produces work into a state
+that no workstation input consumes, and which is not terminal or failed, emits a
+validation finding naming the state and the workstations that produce it.
+
+**Why.** Two of the reported stalls have this single root cause. A3's chapter
+hung in `*-dispatched` because nothing consumed `*-set: failed`; A7's deadlock
+was a marking with no enabled transition. Both were discovered at 3am from a
+quiescent runtime. Both are statically detectable at load. `topology_rules.go`
+already owns the `Finding` / `Severity` / `Path` / `Rule` machinery this needs.
+
+**Acceptance criteria.**
+- A Factory with an output, `onFailure`, `onRejection`, or `onContinue` route
+  into a non-terminal, non-failed state that appears in no workstation
+  `inputs[]` produces a finding with a stable rule id (for example
+  `state-has-no-consumer`), the state path, and the producing workstation names.
+- Terminal and failed states never produce the finding.
+- A state consumed only by a `LOGICAL_MOVE` workstation counts as consumed.
+- Severity is warning, not error: existing valid Factories that intentionally
+  park work must keep loading. The finding must appear in `you` validation
+  output where other topology findings appear.
+- The packaged factories under `packages/packaged-factories/factories/` load
+  without new findings, or the finding is corrected before the story lands.
+
+**Tests.**
+- `pkg/services/factory_definitions/internal/services/validation/impl/topology_guards_test.go` - positive case, terminal-state negative case, failed-state negative case, logical-consumer negative case.
+- `tests/functional/factory/packaged/` - assert every packaged factory loads with no `state-has-no-consumer` finding.
+
+**Docs.**
+- `docs/reference/authoring-factories.md` - document the finding, what triggers
+  it, and the two ways to resolve it (route the state, or mark it terminal).
+
+---
+
+## S3 - The runtime records why a workstation was not enabled
+
+**Behaviour.** When the scheduler declines to enable a transition, the reason is
+retained as structured data on the tick rather than only formatted into a debug
+log line.
+
+**Why.** `enablement.go` already computes five distinct reasons and discards
+them into `logger.Debug` with `fmt.Sprintf`:
+
+```
+:87   "no input arcs"
+:118  "insufficient tokens for unguarded arc %q (place %s, cardinality %d, candidates %d)"
+:154  "dependency guard failed for selected binding"
+:190  "guard failed for arc %q (place %s, candidates %d)"
+:199  "insufficient tokens after guard for arc %q (place %s, cardinality %d, matched %d)"
+```
+
+This is an enabling story: it produces no customer-visible behaviour by itself,
+and is kept deliberately small because S4 is the behaviour that pays for it.
+
+**Acceptance criteria.**
+- A `DisablementReason` value type carries at minimum: a stable reason code, the
+  transition id, the arc key, the place id, the candidate count, and, where the
+  reason is guard-related, the guard type.
+- All five existing reason sites produce that value; no reason site continues to
+  exist only as an interpolated string.
+- The most recent reason per transition is readable from the tick's engine
+  state, with the projection bounded so a long-running session does not
+  accumulate unbounded reason history.
+- Existing debug log output remains, sourced from the structured value.
+- `TestEnablementEvaluator_LogsDisabledGuardFailed` and the disabled-count
+  assertions at `enablement_test.go:596` keep passing without modification.
+
+**Tests.**
+- `pkg/services/factory_runtime/internal/services/orchestration/scheduler/enablement_test.go` - one case per reason code asserting the emitted value's fields, not its formatted text.
+- A replay test near `pkg/services/recordings/internal/projections/` if the projection is persisted, asserting reasons do not alter replay determinism.
+
+**Docs.** None. Internal projection with no customer surface.
+
+---
+
+## S4 - `you work explain` reports working, blocked, or no-route
+
+**Behaviour.** For a given work id, the CLI reports which of three states it is
+in, and for the blocked case names the workstation, arc, and reason:
+
+- **working** - an active dispatch holds this work
+- **blocked** - candidate workstations exist but each is disabled, with reasons
+- **no route** - no workstation input matches this work's type and state
+
+**Why.** This is the question the reporting factory could not answer for hours:
+"the chapter sat in `capture-dispatched` with a `joined` set, no command
+explained enablement... distinguishing working from stalled from no-route-exists
+took log spelunking."
+
+**Acceptance criteria.**
+- `you work explain <work-id>` prints the classification and, when blocked, one
+  line per candidate workstation with the reason code and the blocking arc.
+- The no-route case names the work type and state and states that no workstation
+  consumes it, matching S2's rule so the two surfaces agree.
+- A work item with an in-flight dispatch reports working and names the
+  workstation and dispatch id.
+- `--json` emits the same information in a stable machine-readable shape.
+- An unknown work id exits non-zero with a specific message.
+
+**Tests.**
+- `pkg/transports/cli/work/` - unit coverage per classification against a fixture runtime.
+- `tests/functional/transport/cli/` - end-to-end: submit work that cannot route, assert the no-route classification; hold a resource so a workstation is capacity-blocked, assert blocked with the reason.
+- `tests/functional/smoke/cli_docs_smoke_test.go` - the new topic resolves if a docs topic is added.
+
+**Docs.**
+- `docs/reference/work.md` - the command, its three outcomes, and when to reach
+  for it.
+- `docs/reference/` topic index and `pkg/transports/cli/baseline/testdata/docs_topic_index.txt` if a topic is added.
+
+---
+
+## S5 - Re-submitting a request id reports that it added nothing
+
+**Behaviour.** Submitting a `FACTORY_REQUEST_BATCH` whose `requestId` and work
+names have already been admitted reports how many work items were newly created
+and how many already existed, instead of reporting a count indistinguishable
+from a successful first submission.
+
+**Why.** `requestadmission/normalize.go:304` mints `batch-<requestId>-<name>`
+when `workId` is omitted, so replaying a request id collides on every id. The
+submission returns the pre-existing work and prints work ids, so it reads as
+success at the call site. In the reported incident this stranded a live chapter
+through a designed rework path: the re-dispatch minted nothing and the previous
+attempt's tokens were already terminal, leaving a marking with no enabled
+transition and no visible failure.
+
+**Acceptance criteria.**
+- The submit result distinguishes created work from pre-existing work, and the
+  CLI prints both counts.
+- Re-submitting an identical request exits non-zero, or exits zero with an
+  unmistakable "0 created, N already existed" line - pick one and apply it
+  consistently across CLI, HTTP, and MCP submission surfaces.
+- A partially overlapping request (some names new, some already admitted) is
+  reported accurately rather than rounded to all-or-nothing.
+- The behaviour is identical across `you submit batch`, the HTTP upsert
+  endpoint, and the MCP tool, per the CLI/API equivalence rule.
+- `--dry-run` reports the same counts without creating work.
+
+**Contracts.** The submit response shape gains created/pre-existing counts. This
+touches `api/components/schemas/` and regenerates
+`pkg/transports/http/generated/server.gen.go`,
+`pkg/transports/http/client/client.gen.go`, and `ui/src/api/generated/openapi.ts`.
+Run `make generate-api` and `make interfaces-all`; do not hand-edit generated
+files.
+
+**Tests.**
+- `pkg/services/work/internal/requestadmission/submit_test.go` - created vs pre-existing accounting, including partial overlap.
+- `tests/functional/work/transports/cli/submit/batch_contract/` - CLI reporting and exit code.
+- `pkg/transports/http/contracttests/` - response shape.
+- One functional test asserting CLI and HTTP report identical counts for the same re-submission.
+
+**Docs.**
+- `docs/reference/batch-inputs.md` - `requestId` reuse semantics and what the
+  counts mean.
+- `docs/reference/relationships.md:348-359` - the normalization section states
+  that ids are generated as `batch-<requestId>-<work-name>`; add the consequence
+  for re-submission.
+
+---
+
+## S6 - `you work list --json` returns real payloads
+
+**Behaviour.** `payload` in work listings carries the work's actual payload, or
+the key is absent when there is none. It is never a null that implies an empty
+payload on work whose payload is intact.
+
+**Why.** `Work.payload` is declared in `api/components/schemas/data-models/Work.yaml:41`
+but the read model never projects it. During the reported A2 investigation the
+null read as corroborating evidence for a payload-loss theory that was wrong,
+and helped a wrong root cause survive into two releases.
+
+**Acceptance criteria.**
+- Listing work with a non-empty payload returns that payload.
+- Work with no payload omits the key rather than emitting null.
+- If projecting payloads is rejected on response-size grounds, the key is
+  removed from the schema instead, and the docs say where to read payloads.
+  Silent null is not an acceptable end state either way.
+
+**Contracts.** Either outcome changes `Work.yaml` and regenerates Go and
+TypeScript clients. `make generate-api`, `make interfaces-all`.
+
+**Tests.**
+- `pkg/services/work/internal/read_test.go` - projection carries payload.
+- `pkg/transports/cli/work/list_test.go` - JSON output for both present and absent payload.
+- `pkg/transports/http/contracttests/` - schema alignment.
+
+**Docs.**
+- `docs/reference/work.md` - what `payload` contains in list responses.
+
+---
+
+## S7 - Script stderr appears in the runtime log
+
+**Behaviour.** When a script worker exits non-zero or times out, its stderr is
+visible in the runtime log alongside the exit code.
+
+**Why.** The runtime log records `exit_code` but not stderr. The traceback that
+explained the reported failure existed only inside the recording artifact under
+`~/.you-agent-factory/recordings/`, reachable by walking JSON. The data is
+already carried: `SafeCommandDiagnostic` has a `Stderr` field
+(`pkg/services/workers/internal/service/normalize.go:231`).
+
+**Acceptance criteria.**
+- A failing script worker logs stderr at the failure site, bounded to a
+  documented maximum length with truncation marked.
+- Timeout failures log whatever stderr was captured before the kill.
+- Successful dispatches do not log stderr at info level.
+- The existing redaction posture is preserved: `normalize.go:225-226`
+  deliberately omits stdin and env from persisted diagnostics, and this story
+  must not widen what is persisted, only what is logged from already-safe
+  diagnostics.
+
+**Tests.**
+- `pkg/services/workers/internal/services/workstations/executor/script_test.go` - stderr present on the failure path, truncation applied at the boundary.
+- One functional test asserting a failing script's stderr reaches runtime log output.
+
+**Docs.**
+- `docs/reference/workers.md` - what a failing script worker logs and where the
+  full record still lives.
+
+---
+
+## S8 - Visit counts are readable without opening a recording
+
+**Behaviour.** The number of times a work item has visited a workstation is
+readable from the CLI.
+
+**Why.** `VISIT_COUNT` guards prove the runtime tracks this, and the customer's
+own rework scoping reads `History.TotalVisits`. Nothing in
+`pkg/transports/cli` references it, so answering "how many times has this page
+looped through review" meant counting events in recording JSON.
+
+**Acceptance criteria.**
+- Work detail output includes total visits and per-workstation visit counts.
+- `--json` includes the same values under stable keys.
+- Work that has never been dispatched reports zero rather than omitting the
+  field.
+
+**Contracts.** If visit counts are added to the API work shape, update
+`api/components/schemas/data-models/Work.yaml` and regenerate.
+
+**Tests.**
+- `pkg/transports/cli/work/` - rendering for zero, single, and repeated visits.
+- `pkg/services/recordings/internal/projections/` - projection correctness across a replayed rework loop.
+
+**Docs.**
+- `docs/reference/work.md` and `docs/reference/guards.md` - cross-reference the
+  visit counts that `VISIT_COUNT` guards act on.
+
+---
+
+## S9 - A parent stops accepting children once its fan-in can select it
+
+**Behaviour.** A parent work item accepts new `PARENT_CHILD` children while it
+sits in any state its fan-in workstation does not consume. The first time it
+occupies a state that a parent-aware fan-in workstation takes as its parent
+input, the child set is sealed; a later request that tries to attach a child to
+that parent is rejected with a specific diagnostic.
+
+**Why this story exists, and why it comes before S10.** Today's fan-in
+correctness rests on batch atomicity. `marking.go:47-50` says completion is
+recorded separately "so callers can add every child from an atomic request
+before exposing the set to the scheduler," and the projection deliberately
+reopens on a late registration (`marking_test.go:226-228`). That is safe only
+because a submitted `PARENT_CHILD` batch must contain both endpoints, so every
+child of a parent arrives in one atomic admission. S10 removes that guarantee.
+Without a sealing rule, a batch could append a child to a set the fan-in has
+already fired on, and `ALL_CHILDREN_COMPLETE` would silently have joined a
+partial set - the exact class of bug A1 was just fixed to prevent.
+
+### Design: sealing without a customer-facing field
+
+The constraint is that customers must not learn about child-set completion.
+No `childSetComplete`, no `expectedChildCount`, no new authoring vocabulary.
+
+**The customer already declares the set is closed - by where the parent sits.**
+`docs/reference/relationships.md:287` instructs authors to "place the parent in
+the waiting `state` consumed by the parent-aware fan-in workstation." That
+placement is the declaration. A parent parked in a state no fan-in consumes is
+still collecting; a parent that has arrived in the fan-in's parent input place
+is, by the author's own topology, ready to join. Nothing else needs to be said,
+and moving a parent between states is something authors already express with an
+ordinary workstation.
+
+So the rule is:
+
+| Phase | Condition | Child admission |
+|---|---|---|
+| Open | Parent occupies no place bound as a parent input of a parent-aware transition | Accepted; appends to the ordered registration |
+| Sealed | Parent has occupied such a place at least once | Rejected with a specific diagnostic |
+
+**Two flags, not one.** `Complete` must keep its current meaning - "the current
+admission request finished recording its children" - because it legitimately
+oscillates false to true per request and the reopening behaviour is tested.
+Sealing is a second, monotone, internal flag on
+`ParentChildRegistrationSet`. It only ever transitions once. The fan-in guard
+reads sealed; `Complete` remains the intra-request barrier it is today.
+
+**The single-batch case is unchanged.** Customers submitting parent and children
+in one batch place the parent directly into the fan-in's waiting state, so the
+parent lands in a parent input place on the admission tick and the set seals
+immediately. Behaviour is identical to today, which is what backward
+compatibility requires.
+
+**Rejected alternatives**, recorded so this is not relitigated:
+
+- `childSetComplete: true` on the final batch - exactly the customer-facing
+  surface that was ruled out, and it fails open: forgetting it leaves a set that
+  never seals.
+- `expectedChildCount: N` on the parent - requires the author to know N before
+  submitting any children, which defeats multi-request attachment, and a wrong N
+  deadlocks silently. Worst of the options.
+- Quiescence or timeout sealing ("seal when no request has touched this parent
+  for T") - **disqualified**. This repo's model is event-replay-canonical;
+  recordings must replay deterministically, and a wall-clock-dependent seal
+  makes replay dependent on scheduling.
+- Seal when the first child reaches a terminal state - races with a slow
+  submitter and changes the atomic case's behaviour.
+
+**Acceptance criteria.**
+- `ParentChildRegistrationSet` carries a monotone sealed flag distinct from
+  `Complete`, and sealing is recorded from the marking when a parent token
+  enters a place bound as a parent input arc of a transition carrying a
+  parent-aware guard.
+- Sealing is derived from canonical facts, contains no wall-clock input, and
+  survives replay: replaying a recording reconstructs the same sealed state at
+  the same tick.
+- The fan-in guard requires the set to be sealed; an unsealed set with all
+  visible children terminal does not enable the join.
+- The existing atomic single-batch fan-in continues to work with no
+  configuration change, proven by the existing fan-in functional coverage
+  passing unmodified.
+- The sealed flag appears in no OpenAPI schema, no CLI output, and no reference
+  doc. Its only customer-visible consequence is S10's rejection message.
+
+**Tests.**
+- `pkg/services/factory_runtime/internal/orchestrators/petri/marking_test.go` - sealing is monotone; a post-seal registration attempt does not mutate the set.
+- `pkg/services/factory_runtime/internal/orchestrators/petri/guard_test.go` - `AllWithParentGuard` fails closed on an unsealed set with all children terminal, and passes once sealed.
+- `pkg/services/recordings/internal/replay/` - a recording containing a parent that collects across ticks replays to identical sealed state.
+- `tests/functional/factory/` - the existing single-batch fan-in path, unchanged, still joins.
+
+**Docs.** None in `docs/reference/`. This story is deliberately invisible; S10
+documents the one observable consequence in behavioural language.
+
+---
+
+## S10 - A child can name a parent submitted in an earlier request
+
+**Behaviour.** A `PARENT_CHILD` relation in a submitted batch may target a work
+item that already exists, by work id, instead of requiring the parent to be
+declared in the same batch.
+
+**Why.** The reported factory had to carry the set parent inside its children's
+batch on every dispatch, which forced attempt-scoped work-name schemes and made
+rework dispatches mint a parallel parent each time. The intra-batch rule exists
+for a real reason - work names are not unique across requests, which is why
+`relationships.md:30-42` scopes relation endpoints to one batch's name
+namespace - so the fix is to resolve by id, not to widen name resolution.
+
+`relationships.md:339` currently reserves the field: "Do not use `targetWorkId`
+in submitted batch relations." This story turns that reservation on, for
+`PARENT_CHILD` only.
+
+**`DEPENDS_ON` is explicitly not widened.** Cross-request prerequisite ordering
+would require cycle detection against live Factory state rather than against one
+batch's relation set, which is a materially larger change with no reported
+customer need.
+
+**Acceptance criteria.**
+- A `PARENT_CHILD` relation may carry `targetWorkId` naming an existing work
+  item; the child is admitted with that parent's lineage and joins the parent's
+  registered child set.
+- Supplying both `targetWorkName` and `targetWorkId` on one relation rejects the
+  whole batch with a message naming the conflict.
+- `targetWorkId` naming a work item that does not exist rejects the whole batch.
+- `targetWorkId` naming a parent whose set is already sealed (S9) rejects the
+  whole batch with a message that explains the cause in customer terms - the
+  parent has already reached the state its fan-in consumes - without naming
+  sealing, registrations, or projections.
+- `targetWorkId` on a `DEPENDS_ON` relation continues to be rejected, with the
+  existing message.
+- Whole-batch rejection semantics hold: no partial work and no partial lineage
+  is created on any rejection path.
+- Behaviour is identical across CLI, HTTP, and MCP submission surfaces.
+
+**Contracts.** `api/components/schemas/` batch relation shape gains
+`targetWorkId`. Regenerate with `make generate-api` and `make interfaces-all`;
+update `pkg/transports/mapping` mappers and normalizers and the contract tests.
+Run `make api-smoke`.
+
+**Tests.**
+- `pkg/services/work/internal/requestadmission/normalize_test.go` - accepts id-targeted `PARENT_CHILD`; rejects both-fields, unknown id, sealed parent, and `DEPENDS_ON` with an id.
+- `pkg/services/work/internal/lineagegraph/` - lineage derivation for a cross-request parent.
+- `tests/functional/factory/batch/batch_characterization_test.go` - a parent submitted in request 1, children attached across requests 2 and 3, then a workstation moves the parent into the fan-in's waiting state and the join fires over all children.
+- One functional test asserting a post-seal attach is rejected with the documented message and creates no work.
+- `pkg/transports/http/contracttests/` - relation schema.
+
+**Docs.**
+- `docs/reference/relationships.md` - replace the blanket "Do not use
+  `targetWorkId`" line with the `PARENT_CHILD`-only rule; add `targetWorkId` to
+  the source/target semantics table; add the rejection to the whole-batch
+  validation table. State the observable rule in customer vocabulary: *a parent
+  stops accepting new children once it reaches the state its fan-in workstation
+  consumes.* Do not describe sealing, registrations, or the projection.
+- `docs/reference/batch-inputs.md` - field table entry for `targetWorkId`.
+
+---
+
+## Quality gates
+
+Per story, narrowest useful tier first, broadening with blast radius:
+
+| Story | Required |
+|---|---|
+| S1, S3, S9 | `make test`, `make lint` |
+| S2 | `make test`, `make lint`, packaged-factory load coverage |
+| S4, S7, S8 | `make test`, `make lint`, `make docs-reference-smoke` |
+| S5, S6, S10 | `make interfaces-all`, `make test`, `make lint`, `make api-smoke`, `make verify-pr` |
+
+All stories: generated files stay in sync with their source contracts and are
+never hand-edited. Stories touching event replay, dispatch lifecycle, or
+projections (S3, S5, S9) add or update projection and replay tests near the
+affected package.
+
+## Delivery
+
+A story is complete only when required CI is terminal and passing, blocking PR
+conversation feedback has been explicitly addressed, merge conflicts are
+resolved, and **the PR is merged**. Opening a PR, pushing the latest
+implementation, obtaining approval, or reaching green CI without merge does not
+count as completion. Shared-file and baseline churn is reconciled through the
+same loop.

--- a/docs/internal/development/plans/work-relationship-mutation.md
+++ b/docs/internal/development/plans/work-relationship-mutation.md
@@ -1,0 +1,401 @@
+# Operator Mutation Of Work Relationships
+
+---
+author: andreas abdi
+status: proposed
+verified-against: `main` @ `0f3c19544` (2026-08-13)
+related: `docs/internal/development/plans/factory-engine-e26-known-issues.md`
+---
+
+# problem statement
+
+Work relationships can only be declared at admission inside one batch, so an
+operator cannot attach a dependency or a parent to work that already exists, and
+cannot remove a relationship that has become wrong - including when a stale
+relationship is the reason a live Factory Session is deadlocked.
+
+## customer ask
+
+Manipulate Work relationships against live state from the CLI: add a
+relationship between existing Work, remove one, and see what a Work item is
+currently related to - without re-submitting a batch and without restarting a
+run.
+
+## solution
+
+Promote the existing `RELATIONSHIP_CHANGE_REQUEST` canonical event from an
+admission-only side effect into the single mechanism for relationship state,
+read through a fold rather than an accumulation. Expose attach, detach, and list
+over a **generic relationship type** with per-type parameter validation that
+mirrors the batch contract exactly. Apply mutations at tick boundaries so
+replay and quiescence stay deterministic, and prove acyclicity against live
+state before applying.
+
+# original document
+
+`docs/internal/development/plans/factory-engine-e26-known-issues.md` - this plan
+is the follow-on discussed alongside it. The deadlock that motivates the
+recovery case is item A7 of
+`C:\Users\andre\work\translate\manga-image-translator\mangaka-cli\factories\translation\KNOWN-ISSUES.md`.
+
+---
+
+## Baseline verification (do this before writing code)
+
+Plan documents are snapshots. Confirm before starting:
+
+- `FactoryEventTypeRelationshipChangeRequest` still exists in the event
+  vocabulary (`pkg/services/recordings/contracts.go:375`) and is still emitted
+  only from the batch path (`internal/events/event_history.go:382-411`).
+- `ErrMoveWorkRequestAlreadyApplied` and `WorkStateChangeSource`
+  (`pkg/services/work/contracts.go:11-14, 499-506`) still describe the operator
+  mutation posture this plan copies.
+- The per-type relation semantics table at `docs/reference/relationships.md:46-51`
+  still defines the rules R2 must mirror.
+
+## What already exists, and what this plan adds
+
+| Already present | Added here |
+|---|---|
+| `RELATIONSHIP_CHANGE_REQUEST` canonical event with a full relation payload | An operation discriminator, and emission from a non-admission path |
+| Operator mutation posture: request id, idempotency, source attribution (`MoveWorkForSession`) | The same posture applied to relationships |
+| Batch-scoped `DEPENDS_ON` cycle rejection (`internal/lineagegraph/dependency_graph.go`) | Cycle detection against live Factory state |
+| Relations exposed on tokens and in `.Relations` for templates | Those consumers reading a folded view instead of an accumulation |
+| Tick-boundary application of queued token injection (`engine/engine.go:874`) | The same queueing for relationship mutations |
+
+## Dependency on the engine known-issues plan
+
+- **S9 (parent set sealing) must land first.** Attaching a `PARENT_CHILD`
+  relation to a parent whose fan-in has already selected it is the same hazard
+  S9 exists to prevent. This plan reuses that rule and must not invent a second
+  one.
+- **R4 depends on S3/S4** (structured disablement reasons and `you work explain`).
+- **This plan unblocks a later S10 widening.** S10 deliberately keeps
+  `DEPENDS_ON` name-scoped because cross-request cycle detection was out of
+  scope there. R2 delivers that machinery. Widening S10 is a follow-on decision,
+  not part of either plan as written.
+
+## Scope
+
+**In scope.** Attach, detach, and list of mutable relationship types against
+live Work; live-state cycle detection; folded relations projection; tick-boundary
+application; CLI, HTTP, and MCP parity.
+
+**Out of scope.** Editing authored Factory topology. Bulk or query-based
+mutation (`rm --all-depends-on`). Relationship types that are not
+author-declarable. Changing batch admission semantics beyond what the folded
+projection requires.
+
+---
+
+# changes
+
+## Story sequence
+
+| # | Behaviour | Depends on |
+|---|---|---|
+| R1 | `you work relation list` reports a Work item's current relationships | - |
+| R2 | An operator attaches a relationship of any mutable type between existing Work | R1, S9 |
+| R3 | An operator detaches a relationship with a recorded reason | R1, R2 |
+| R4 | `--dry-run` reports the enablement change a mutation would cause | R2, R3, S3, S4 |
+
+---
+
+## R1 - `you work relation list` reports current relationships
+
+**Behaviour.** `you work relation list <work-id>` prints the relationships
+currently attached to that Work item: type, target, and for `DEPENDS_ON` the
+required state and whether it is currently satisfied. Relationship state is
+derived by folding relationship-change events rather than by accumulating
+attachments.
+
+**Why the fold ships here and not with detach.** R3 introduces supersession, and
+a projection that accumulates attaches cannot represent it. Landing the fold
+first means R3 adds one event kind rather than rewriting every consumer, and it
+means the read path is correct by construction before anything can produce a
+detach. With no detach events in existence the fold is output-identical to
+today, so this story is safe to land alone.
+
+**The consumer that matters.** `.Relations` is exposed to prompt templates
+(`docs/reference/templates.md`). A relation that survives in a template after
+being detached would silently feed an agent stale lineage. Every `.Relations`
+read path must consume the folded view, not the raw event stream or a cached
+token field.
+
+**Acceptance criteria.**
+- `you work relation list <work-id>` prints each relationship with type, target
+  work id, and target display identity; `DEPENDS_ON` rows additionally show the
+  required state and whether the target currently satisfies it.
+- Work with no relationships prints an explicit empty result, not a blank.
+- `--json` emits a stable shape.
+- An unknown work id exits non-zero with a specific message.
+- Relations are produced by a fold over relationship-change events; no consumer
+  reads an accumulated relation set. Enumerate the `.Relations` consumers
+  (templates, CLI work show, HTTP work read, world-state projection) and point
+  each at the folded view.
+- Output is byte-identical to the current `you work show` relation summary for
+  every existing recording, proving the fold is a faithful refactor.
+
+**Tests.**
+- `pkg/services/recordings/internal/projections/` - fold reconstructs identical relation state for existing recordings; ordering is deterministic.
+- `pkg/transports/cli/work/` - list rendering for empty, single, multi-relation, and satisfied/unsatisfied `DEPENDS_ON`.
+- `pkg/services/recordings/internal/replay/` - replay of an existing recording yields unchanged relation state.
+- A template-rendering test asserting `.Relations` is sourced from the folded view.
+
+**Docs.**
+- `docs/reference/work.md` - the `relation list` command.
+- `docs/reference/relationships.md` - a short "reading current relationships"
+  section pointing at the command.
+
+---
+
+## R2 - An operator attaches a relationship between existing Work
+
+**Behaviour.**
+
+```
+you work relation add --source <work-id> --type <TYPE> --target <work-id> \
+                      [--required-state <state>] [--request-id <id>]
+```
+
+The relationship is applied at the next tick boundary, recorded as a canonical
+relationship-change event, and reported with a typed result that names the tick
+it applied at or the reason it did not.
+
+**Generic type, not per-type flags.** The domain model is already generic -
+`FactoryRelation` carries `Type`, `SourceWorkID`, `TargetWorkID`,
+`RequiredState`. The CLI takes `--type` and validates parameters per type,
+mirroring `docs/reference/relationships.md:46-51` exactly so the mutation
+contract and the batch contract cannot drift:
+
+| `--type` | `--target` means | `--required-state` |
+|---|---|---|
+| `DEPENDS_ON` | The prerequisite; source waits for it | Optional, defaults to `complete`; must name a state on the target's work type |
+| `PARENT_CHILD` | The parent; source is the child | **Must be omitted**; supplying it rejects the request |
+| `SAME_NAME` | - | Rejected: a workstation input guard, not a relation |
+| `SPAWNED_BY` | - | Rejected: runtime-derived, not author-declarable |
+
+A new relation type becomes mutable by adding a row to that table and its
+validation, not by adding a CLI flag.
+
+**Cycle detection in the general case.** Acyclicity is proven against live
+Factory state before the mutation is queued.
+
+- `DEPENDS_ON` forms a graph where an edge source to target means *source waits
+  for target*. Adding edge `S -> T` closes a cycle **iff `T` can already reach
+  `S`**. That is a single reachability query bounded by the subgraph reachable
+  from `T`, not a topological sort of every Work item - the check is incremental
+  because the existing graph is already known acyclic.
+- `PARENT_CHILD` is checked separately: a Work item must not become its own
+  ancestor. Walk the ancestor chain from the proposed parent and reject if it
+  reaches the child.
+- **The two are deliberately not unified.** A `DEPENDS_ON` edge and a
+  `PARENT_CHILD` edge do not compose into a deadlock; parent lineage does not
+  gate dispatch, it feeds fan-in guards. State this in the code comment so a
+  later reader does not "fix" it into a single graph.
+- Traversal is bounded, and **exceeding the bound rejects rather than allows**.
+  Fail closed.
+- Detection is deterministic and side-effect-free; it runs during admission and
+  must not depend on wall clock, map iteration order, or scheduler timing.
+
+**Typed result payload.** Every outcome, success or failure, returns:
+
+```
+{ requestId, applied, tick, relation: {type, sourceWorkId, targetWorkId, requiredState},
+  failure: { code, message, details } }
+```
+
+Initial failure codes, each with the detail a caller needs to act:
+
+| Code | `details` carries |
+|---|---|
+| `WORK_NOT_FOUND` | Which of source/target was missing, and the id |
+| `RELATION_ALREADY_EXISTS` | The existing relation and the tick it was attached |
+| `RELATION_TYPE_NOT_MUTABLE` | The rejected type and the list of mutable types |
+| `RELATION_PARAMETER_INVALID` | The offending parameter and the per-type rule it broke |
+| `DEPENDENCY_CYCLE` | The **ordered work-id path** that closes the cycle |
+| `PARENT_ANCESTRY_CYCLE` | The ordered ancestry path |
+| `PARENT_SET_SEALED` | The parent id and the state it reached that sealed it (S9) |
+| `TARGET_TERMINAL` | The target id and its terminal state |
+| `REQUEST_ALREADY_APPLIED` | The tick the original request applied at |
+
+The cycle path is the point of this shape: a caller told "cycle detected" learns
+nothing, and a caller told `page-04 -> page-02 -> page-09 -> page-04` can fix it.
+
+**Idempotency and the anti-A7 posture.** `--request-id` is optional and defaults
+to a deterministic hash of the operation. Re-applying a request id returns
+`applied: false` with `REQUEST_ALREADY_APPLIED` and the original tick. The CLI
+exits zero **only** when `applied` is true. A re-run that changed nothing must
+never be indistinguishable from a re-run that did something - that is exactly
+the failure mode item A7 records.
+
+**Quiescence and tick-boundary application.** Mutations are queued and applied
+between ticks, the same way token injection is (`engine/engine.go:874`). The
+mutation is never written directly to the marking and then recorded; the event
+is emitted and the projection follows it. A mutation may be issued against a
+quiescent session and against work with an in-flight dispatch: it applies from
+the next tick and does not retroactively affect a running dispatch. Waking a
+quiescent Factory is an expected outcome, not an error.
+
+**Acceptance criteria.**
+- Attaching each mutable type between two existing Work items succeeds, reports
+  the applied tick, and the relationship is visible in `relation list`.
+- Per-type parameter rules are enforced exactly as the batch contract enforces
+  them, including `--required-state` rejection on `PARENT_CHILD` and required-state
+  validation against the target work type's states.
+- `SAME_NAME` and `SPAWNED_BY` are rejected with `RELATION_TYPE_NOT_MUTABLE`.
+- A `DEPENDS_ON` that would close a cycle against live state is rejected with the
+  ordered path; the graph is unchanged and no event is emitted.
+- A `PARENT_CHILD` naming a sealed parent is rejected with `PARENT_SET_SEALED`
+  and a message in customer vocabulary, consistent with S10's wording.
+- Re-issuing an identical request id reports `REQUEST_ALREADY_APPLIED` with the
+  original tick and exits non-zero.
+- Behaviour is identical across CLI, HTTP, and MCP.
+- Replaying a recording that contains an operator attach reconstructs identical
+  relation state at the same tick.
+- Attaching against a quiescent session with a satisfiable dependency wakes the
+  session on the following tick.
+
+**Contracts.** New HTTP endpoint and MCP tool; OpenAPI schemas for the request,
+result, and failure shapes; an operation discriminator on the relationship-change
+event payload, where an absent operation reads as attach so existing recordings
+keep replaying. `make generate-api`, `make interfaces-all`, `make api-smoke`.
+Operator request ids share the request-id namespace used for event ids
+(`<prefix>/<requestID>/<index>`) and must be prefixed so they cannot collide with
+batch request ids.
+
+**Tests.**
+- `pkg/services/work/internal/lineagegraph/` - reachability-based cycle detection: no-cycle accept, direct cycle, transitive cycle with the correct path, ancestry cycle, traversal-bound rejection, determinism across repeated runs.
+- `pkg/services/work/` - per-type parameter validation table, one case per rule.
+- `pkg/transports/cli/work/` - result rendering per failure code, exit codes.
+- `pkg/transports/http/contracttests/` - request/result/failure schema.
+- `pkg/services/recordings/internal/replay/` - operator attach replays to identical state.
+- `tests/functional/factory/` - attach against a quiescent session enables a transition on the next tick; attach against work with an in-flight dispatch does not disturb it.
+- One functional test asserting CLI and HTTP return identical results for the same request.
+
+**Docs.**
+- `docs/reference/relationships.md` - a mutation section: the generic type
+  surface, the per-type parameter table, tick-boundary application, and the
+  failure codes. Keep the existing batch-authoring content authoritative for
+  batch relations.
+- `docs/reference/work.md` - the command and its exit-code rule.
+
+---
+
+## R3 - An operator detaches a relationship with a recorded reason
+
+**Behaviour.**
+
+```
+you work relation rm --source <work-id> --type <TYPE> --target <work-id> \
+                     --reason "<text>" [--request-id <id>]
+```
+
+`--reason` is **mandatory**. The detach is recorded as a superseding
+relationship-change event carrying the reason and operator attribution, and the
+relation disappears from the folded view from that tick forward.
+
+**Why detach is the loud one.** Attach can only ever add a constraint. Detach
+removes one, and can enable a transition the authored topology intended to gate.
+It is also the recovery path - the A7 deadlock is resolved by dropping a stale
+blocking relationship on a live run - which means it will be used at the worst
+possible moment by someone under pressure. The reason is not bureaucracy; it is
+the only record of why the graph no longer matches the topology.
+
+**Events are not deleted.** The detach is a new fact that supersedes an earlier
+one. R1's fold is what makes this representable.
+
+**Acceptance criteria.**
+- Detaching an existing relationship succeeds, reports the applied tick, and the
+  relation is absent from `relation list` and from `.Relations` in templates from
+  that tick forward.
+- Omitting `--reason` fails before any state is touched, with a message saying
+  the reason is required.
+- The reason and the operator source (`cli` / `api`) appear on the recorded event
+  and in relationship history output.
+- Detaching a relationship that does not exist returns `RELATION_NOT_FOUND`.
+- Detaching a `PARENT_CHILD` relation whose parent set is sealed is rejected with
+  `PARENT_SET_SEALED`. There is no `--force`: the fan-in has already selected the
+  set, and permitting the detach would retroactively invalidate a join that
+  already fired.
+- Re-issuing an identical request id reports `REQUEST_ALREADY_APPLIED`; exit zero
+  only when `applied` is true.
+- Replaying a recording containing attach then detach then attach on the same
+  relation reconstructs the correct final state, and reconstructs the correct
+  intermediate state at each intervening tick.
+- Recordings produced before this story replay unchanged.
+
+**Contracts.** Detach shares R2's endpoint family, result shape, and failure
+codes, adding `RELATION_NOT_FOUND` and a required reason field. Regenerate.
+
+**Tests.**
+- `pkg/services/recordings/internal/projections/` - fold over attach/detach/attach; supersession ordering under equal ticks.
+- `pkg/services/recordings/internal/replay/` - intermediate-state correctness at each tick, and unchanged replay of pre-existing recordings.
+- `pkg/transports/cli/work/` - missing reason, not-found, sealed-parent rejection.
+- A template test asserting a detached relation is absent from `.Relations`.
+- `tests/functional/factory/` - the recovery case end to end: a session blocked on a dependency, detach with a reason, the blocked workstation dispatches on the next tick.
+
+**Docs.**
+- `docs/reference/relationships.md` - the detach contract, the mandatory reason,
+  and a plain statement that detaching can enable a workstation the authored
+  topology intended to gate.
+- `docs/reference/record-replay.md` - relationship state is a fold over
+  relationship-change events; detach supersedes rather than deletes.
+
+---
+
+## R4 - `--dry-run` reports the enablement change a mutation would cause
+
+**Behaviour.** `--dry-run` on attach or detach reports what the mutation would
+do without applying it, including which workstations would become enabled or
+disabled on the next tick.
+
+**Why this is the story that makes the feature safe.** Without it, detaching a
+relationship on a live run is a guess. With it the operator loop closes:
+`you work explain` says why the work is stuck, `relation rm --dry-run` says
+whether removing the relation unsticks it, `relation rm --reason` applies it.
+It is also cheap here because it is S3's disablement-reason evaluation run
+against a hypothetical relation set - the explain machinery and the mutation
+machinery are the same machinery.
+
+**Acceptance criteria.**
+- `--dry-run` runs every validation R2 and R3 run, including cycle detection, and
+  reports the same failure codes without emitting an event or mutating state.
+- On a mutation that would succeed, output names the workstations whose
+  enablement would change and the disablement reason that would be cleared or
+  introduced, using S3's reason codes.
+- Output states plainly when enablement would not change.
+- `--dry-run` never advances a tick and never wakes a quiescent session.
+- `--json` emits the same information.
+
+**Tests.**
+- `pkg/services/factory_runtime/internal/services/orchestration/scheduler/` - hypothetical evaluation does not mutate the evaluator or the marking.
+- `pkg/transports/cli/work/` - dry-run rendering for enable, disable, and no-change.
+- `tests/functional/factory/` - dry-run on the R3 recovery case predicts the enablement that the real detach then produces.
+
+**Docs.**
+- `docs/reference/relationships.md` and `docs/reference/work.md` - the dry-run
+  workflow, presented as the recommended path before any detach.
+
+---
+
+## Quality gates
+
+| Story | Required |
+|---|---|
+| R1 | `make test`, `make lint`, `make docs-reference-smoke` |
+| R2, R3 | `make interfaces-all`, `make test`, `make lint`, `make api-smoke`, `make verify-pr`, `make docs-reference-smoke` |
+| R4 | `make test`, `make lint`, `make docs-reference-smoke` |
+
+All stories touch event replay and projections, so each adds or updates replay
+and projection coverage near the affected package. Generated files stay in sync
+with their source contracts and are never hand-edited.
+
+## Delivery
+
+A story is complete only when required CI is terminal and passing, blocking PR
+conversation feedback has been explicitly addressed, merge conflicts are
+resolved, and **the PR is merged**. Opening a PR, pushing the latest
+implementation, obtaining approval, or reaching green CI without merge does not
+count as completion. Shared-file and baseline churn is reconciled through the
+same delivery loop.


### PR DESCRIPTION
Adds two internal planning documents under `docs/internal/development/plans/`.

## Why this exists

These two documents were sitting as an **unpushed local commit on the root checkout's `main`**. That matters mechanically, not just cosmetically:

`factory/scripts/setup-workspace.py` creates each new lane worktree with `git worktree add -b <branch> <path> main` — branching from **local** `main`, not `origin/main`. It also skips the root sync entirely when local `main` is not a fast-forward behind `origin/main` (the `skipped (local main is not a fast-forward behind origin/main)` path).

So while that commit sat unpushed, every newly created lane inherited it and would have carried these 1306 lines into its own pull request diff. Two lanes were verified to have already done so. The standing "rebase onto origin/main before your final push" rule does not clear it either, because the rebase replays that commit along with the lane's own work.

Landing these docs removes the contamination at the source and lets the root checkout fast-forward cleanly again.

## Scope note — one file was deliberately excluded

The original local commit also touched `docs/internal/development/plans/dashboard-scrollbar-consistency.md`. That file is **not** in this PR.

A different document already occupies that path on `main`: a 68-line delivery contract landed by the `dash-scrollbar-consistency` lane. The local copy was a 322-line planning document that happened to share the filename. Including it would have replaced merged, delivered work with an older planning draft — a silent regression. The merged version is left untouched.

## Contents

| File | Lines | What it is |
|---|---|---|
| `factory-engine-e26-known-issues.md` | 583 | Factory engine E26 known-issues analysis |
| `work-relationship-mutation.md` | 401 | Work relationship mutation plan |

Documentation only — no code, no generated artifacts, no test or coverage surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)