### PR TITLE
thr-deflake-storybook-session-keyboard-assertions

### DIFF
--- a/ui/scripts/verify-dashboard-session-reconciliation-browser.mjs
+++ b/ui/scripts/verify-dashboard-session-reconciliation-browser.mjs
@@ -9,6 +9,17 @@ const viewports = [
   { height: 900, label: "desktop", width: 1440 },
 ];
 
+async function waitForSelectedTab(tab, failureMessage) {
+  try {
+    await tab
+      .locator("xpath=..")
+      .getByRole("tab", { selected: true })
+      .waitFor({ state: "visible" });
+  } catch {
+    throw new Error(failureMessage);
+  }
+}
+
 async function verifyViewport(browser, viewport) {
   const context = await browser.newContext({ viewport });
   const page = await context.newPage();
@@ -59,17 +70,15 @@ async function verifyViewport(browser, viewport) {
     const tabs = navigation.getByRole("tab");
     await tabs.first().focus();
     await page.keyboard.press("End");
-    if ((await tabs.nth(1).getAttribute("aria-selected")) !== "true") {
-      throw new Error(
-        `End key did not select the last session at ${viewport.label}.`,
-      );
-    }
+    await waitForSelectedTab(
+      tabs.last(),
+      `End key did not select the last session at ${viewport.label}.`,
+    );
     await page.keyboard.press("Home");
-    if ((await tabs.first().getAttribute("aria-selected")) !== "true") {
-      throw new Error(
-        `Home key did not restore the first session at ${viewport.label}.`,
-      );
-    }
+    await waitForSelectedTab(
+      tabs.first(),
+      `Home key did not restore the first session at ${viewport.label}.`,
+    );
 
     await page.getByRole("button", { name: "Fail refresh" }).click();
     await page

--- a/ui/scripts/verify-dashboard-session-switching-storybook-responsive.mjs
+++ b/ui/scripts/verify-dashboard-session-switching-storybook-responsive.mjs
@@ -12,8 +12,12 @@ export async function verifyDashboardSessionSwitching(
     page.getByRole("button", { name: /Beta Story/ }),
     "Beta session active work item",
   );
-  const betaSelected = await betaTab.getAttribute("aria-selected");
-  if (betaSelected !== "true") {
+  try {
+    await expectVisible(
+      page.getByRole("tab", { name: "beta", selected: true }),
+      "Beta session tab selection",
+    );
+  } catch {
     throw new Error("Beta session tab was not selected after switching.");
   }
 


### PR DESCRIPTION
{
  "project": "Deflake Dashboard Session Keyboard Assertions",
  "branchName": "thr-deflake-storybook-session-keyboard-assertions",
  "description": "Synchronize the dashboard session Storybook keyboard assertions with the rendered aria-selected state so asynchronous React commits cannot cause false failures. Preserve exact End, Home, and beta-session selection behavior and diagnostics; keep changes confined to the two owned verifier scripts; and prove both stability and failure sensitivity with repeated focused browser evidence.",
  "context": {
    "customerAsk": "Replace the one-shot aria-selected reads in the dashboard session reconciliation and responsive session-switching Storybook verifiers with bounded, auto-retrying waits for the same exact selected-state condition. Preserve the assertions and diagnostic messages, do not change dashboard or session components, run the affected reconciliation check at least 10 consecutive times, and demonstrate with a reverted negative control that a genuine keyboard-selection failure is still detected.",
    "problem": "CI run 31736819179 failed on main at SHA 06a893209 because the reconciliation script reported that End did not select the last desktop session, then an identical rerun on the same SHA passed. The script presses End or Home and immediately samples aria-selected with one-shot getAttribute calls, allowing the read to race React's asynchronous state commit and render. The responsive beta-session assertion contains the same lower-risk sampling pattern after a visibility barrier. The downstream Verification Policy result only aggregates the Storybook failure, and product components are not implicated by the current evidence.",
    "solution": "After each affected keyboard or click interaction, use a Playwright web-first assertion or equivalent condition-based locator/page wait to retry until the intended tab exposes aria-selected=\"true\" or the existing bounded timeout expires. Retain the current custom errors and viewport labels, use the last-tab locator only when behavior-preserving for the fixture, forbid sleeps or weakened assertions, and keep the implementation limited to the two verifier scripts. Validate with focused tests, at least 10 consecutive browser-check passes, and a reverted deliberately wrong expectation that still fails."
  },
  "acceptanceCriteria": [
    "In the reconciliation browser check, the one-shot reads immediately following End and Home are replaced by bounded, auto-retrying waits for the same intended tabs to expose aria-selected=\"true\"; keyboard interactions, mobile/desktop coverage, and existing viewport-labelled failure messages remain intact.",
    "In the responsive session-switching verifier, the one-shot beta-tab aria-selected read is replaced by a bounded retry of the same exact selected-state condition, without claiming this secondary assertion caused the reported CI failure.",
    "The committed diff is limited to ui/scripts/verify-dashboard-session-reconciliation-browser.mjs and ui/scripts/verify-dashboard-session-switching-storybook-responsive.mjs; dashboard/session components remain unchanged, and any reproducible product keyboard-navigation race is reported with evidence for a separate lane rather than patched here.",
    "No assertion is deleted, skipped, weakened, or allowed to accept a value other than \"true\"; no arbitrary sleep, fixed-duration wait, or global-timeout increase is introduced.",
    "The focused reconciliation Storybook browser check passes at least 10 consecutive executions, and a temporary deliberate mismatch in the selected-tab expectation makes the check fail with the relevant keyboard-selection diagnostic before being reverted; the before/after change, pass count, and negative-control result are recorded in a PR comment rather than committed as CI evidence.",
    "Quality gates pass: Typecheck passes, focused Biome checks on the two touched scripts pass, affected focused tests and the Storybook browser check pass, there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts are resolved, the branch is reconciled with current origin/main, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "thr-deflake-storybook-session-keyboard-assertions-001",
      "title": "Observe committed End and Home selection state",
      "description": "As a maintainer, I want the reconciliation check to wait for the session tab selection produced by End and Home so asynchronous rendering cannot create a false failure while genuine keyboard regressions remain visible.",
      "acceptanceCriteria": [
        "After focus moves to the first session tab and End is pressed, the check retries until the last fixture tab has aria-selected=\"true\" or the existing bounded timeout expires.",
        "After Home is pressed, the check retries until the first session tab has aria-selected=\"true\" or the existing bounded timeout expires.",
        "A timeout or genuinely wrong selection still produces the existing End key did not select the last session at <viewport>. or Home key did not restore the first session at <viewport>. diagnostic as applicable.",
        "The intended final tab is addressed with tabs.last() when that is equivalent for the current two-tab fixture; otherwise tabs.nth(1) remains and the PR explains why changing it would alter fixture behavior.",
        "No fixed sleep, assertion weakening, assertion skip, or timeout increase is used for synchronization.",
        "The focused reconciliation Storybook browser check passes at least 10 consecutive times across its mobile and desktop viewports.",
        "A temporary, deliberately incorrect selected-tab expectation causes the focused browser check to fail with the expected keyboard-selection diagnostic, and the experiment is reverted before the implementation is committed.",
        "If direct browser investigation reproducibly shows End or Home failing to commit selection after a condition-based wait, the PR reports the product race and evidence without modifying product components in this lane.",
        "Typecheck passes",
        "Tests pass",
        "Direct browser verification passes in supported Chrome or Edge tooling; unavailable Firefox or WebKit revisions are not treated as blockers."
      ],
      "priority": 1,
      "passes": true,
      "notes": "Replaced the one-shot End/Home aria-selected reads with Playwright locator waits scoped to the exact last/first tab shell and selected:true role condition; existing viewport diagnostics remain unchanged. Focused Biome, TypeScript typecheck, syntax, a final mobile/desktop browser pass, 10 consecutive exact verifier executions, and a reverted wrong-target negative control passed as required. No product component race was reproducible."
    },
    {
      "id": "thr-deflake-storybook-session-keyboard-assertions-002",
      "title": "Observe committed session-switch selection state",
      "description": "As a maintainer, I want the responsive session-switching verifier to wait for the clicked beta tab's selected state so this adjacent assertion cannot fail from the same one-shot sampling pattern.",
      "acceptanceCriteria": [
        "After the beta tab is clicked and its active-work content becomes visible, the verifier retries until that exact beta tab has aria-selected=\"true\" or the existing bounded timeout expires.",
        "A genuinely unselected beta tab still fails with Beta session tab was not selected after switching.; the assertion is not deleted, skipped, weakened, or replaced by content visibility alone.",
        "The change is described as consistency hardening, not as the root cause of CI run 31736819179.",
        "No arbitrary sleep, fixed-duration wait, global-timeout increase, product-component edit, or unrelated refactor is introduced.",
        "The existing focused test that invokes the session-switching verifier passes with the synchronized assertion behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Replaced the responsive verifier's one-shot beta aria-selected read with a bounded expectVisible wait on the exact beta tab role locator constrained by selected:true; preserved the existing diagnostic and made no product changes. Focused verifier test, focused Biome, syntax, and UI typecheck passed. The broader header test still has two unrelated pre-existing mock-shape failures, and the direct static session story's own play fixture fails before this verifier reaches the beta assertion."
    }
  ]
}
