### PR TITLE
test: bound checkpoint deletion proof build

### DIFF
--- a/pkg/services/factory_runtime/checkpoint_deletion_proof_test.go
+++ b/pkg/services/factory_runtime/checkpoint_deletion_proof_test.go
@@ -2,12 +2,19 @@ package factory_test
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	factory "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+const (
+	externalConsumerProofBuildMaxDuration = 60 * time.Second
+	externalConsumerProofBuildCleanupTime = 5 * time.Second
 )
 
 // DEL-RUN-CKPT proof: CaptureCheckpoint, LoadCheckpoint, and RestoreCheckpoint
@@ -35,10 +42,26 @@ func TestServiceDoesNotExposeDeletedCheckpointMethods(t *testing.T) {
 // ./...`, and normal package discovery never compile it as part of this
 // module; only this test compiles it, on purpose, expecting failure.
 func TestExternalConsumerCannotCallDeletedCheckpointMethods(t *testing.T) {
-	t.Parallel()
+	// Keep the compiler proof serial with the package's other tests. The nested
+	// Go build can contend with the package test binary for the Windows build
+	// cache, so parallel scheduling turns a slow compile into an unbounded wait.
+	buildContext, cancel := externalConsumerProofBuildContext(t)
+	defer cancel()
 
-	cmd := exec.Command("go", "build", "./testdata/checkpointdeletionproof")
+	cmd := exec.CommandContext(buildContext, "go", "build", "./testdata/checkpointdeletionproof")
+	// Give the nested build private cache and temporary-build directories. The
+	// external proof may run beside other package builds, and sharing those
+	// directories was the observed source of Windows lock contention.
+	cmd.Env = append(os.Environ(), "GOCACHE="+t.TempDir(), "GOTMPDIR="+t.TempDir())
+	// CommandContext kills the go process when the proof deadline expires.
+	// WaitDelay bounds the reap and pipe cleanup so orphaned compiler output
+	// cannot keep CombinedOutput blocked after cancellation.
+	cmd.WaitDelay = externalConsumerProofBuildCleanupTime
 	output, err := cmd.CombinedOutput()
+	if contextErr := buildContext.Err(); contextErr != nil {
+		childDeadline, _ := buildContext.Deadline()
+		t.Fatalf("external-consumer checkpoint deletion proof build ended with %v; child was killed and reaped at its %s deadline: %v\nbuild output:\n%s", contextErr, childDeadline.Format(time.RFC3339Nano), err, output)
+	}
 	if err == nil {
 		t.Fatalf("expected compilation of testdata/checkpointdeletionproof to fail because CaptureCheckpoint/LoadCheckpoint/RestoreCheckpoint no longer exist on factory.Service, but the build succeeded")
 	}
@@ -52,6 +75,27 @@ func TestExternalConsumerCannotCallDeletedCheckpointMethods(t *testing.T) {
 	if !strings.Contains(got, "undefined") {
 		t.Errorf("expected an undefined-method compiler diagnostic, got build output:\n%s", got)
 	}
+}
+
+func externalConsumerProofBuildContext(t *testing.T) (context.Context, context.CancelFunc) {
+	t.Helper()
+
+	testDeadline, hasTestDeadline := t.Deadline()
+	if !hasTestDeadline {
+		return context.WithTimeout(context.Background(), externalConsumerProofBuildMaxDuration)
+	}
+
+	now := time.Now()
+	childDeadline := testDeadline.Add(-externalConsumerProofBuildCleanupTime)
+	maxChildDeadline := now.Add(externalConsumerProofBuildMaxDuration)
+	if childDeadline.After(maxChildDeadline) {
+		childDeadline = maxChildDeadline
+	}
+	if !childDeadline.After(now) {
+		t.Fatalf("external-consumer checkpoint deletion proof has no time left for a bounded child build and cleanup before the test deadline")
+	}
+
+	return context.WithDeadline(context.Background(), childDeadline)
 }
 
 // externalConsumerPeer implements factory.Service using only the surviving


### PR DESCRIPTION
{
  "project": "Bound the Checkpoint Deletion Proof Child Build",
  "branchName": "thr-deflake-checkpoint-proof-unbounded-child-build",
  "description": "Deflake the Factory Runtime external-consumer checkpoint deletion proof on Windows by correcting the measured nested-build contention, enforcing a child-process deadline and cleanup, and retaining compiler-diagnostic proof that CaptureCheckpoint, LoadCheckpoint, and RestoreCheckpoint are absent. The focused test must change from a 150-second outer-timeout panic to deterministic bounded completion, with repeated-run, full-package, and deliberate failure-sensitivity evidence, without production or adjacent-lane changes.",
  "context": {
    "customerAsk": "Bound and deflake TestExternalConsumerCannotCallDeletedCheckpointMethods so it cannot hang Windows local test runs, investigate why its nested go build stalls, preserve the external-consumer negative-compilation proof for CaptureCheckpoint, LoadCheckpoint, and RestoreCheckpoint, and provide repeated timing and proof-sensitivity evidence while changing only the owned test and a strictly required existing fixture.",
    "problem": "On Windows 11 with Go 1.25.0, the parallel test starts a nested go build with exec.Command and CombinedOutput, leaving the direct child on an infinite operating-system wait. Shared build or module resource contention is the leading hypothesis. The reproduced focused command does not fail promptly; it hangs until the outer test binary panics at 150 seconds, blocking local review gates for unrelated changes.",
    "solution": "Measure serial, parallel, and cache/temp-isolation behavior; apply the narrowest harness correction supported by the evidence; and, if a subprocess remains, execute it with a context deadline derived from the test deadline, capped at 60 seconds with cleanup margin, then kill and reap it on timeout. Preserve the fixture under testdata and require a non-timeout compiler failure whose diagnostics identify all three removed selectors as undefined. Verify 10 consecutive focused passes, deliberate proof failure when compilation is made possible, and completion of the full Factory Runtime package test."
  },
  "acceptanceCriteria": [
    "On Windows 11 with Go 1.25.0, the focused test changes from a reproduced 150-second outer-test panic to a pass or actionable child-timeout failure within 75 seconds; any retained child deadline is no later than 60 seconds and leaves cleanup margin before the outer test deadline.",
    "A retained external command is context-bounded, and timeout handling kills and reaps the child before the test returns; timeout or cancellation is diagnostically distinct from the expected negative compilation result.",
    "The proof still requires testdata/checkpointdeletionproof compilation to fail and requires undefined-method diagnostics naming CaptureCheckpoint, LoadCheckpoint, and RestoreCheckpoint; successful compilation fails the test.",
    "The focused test passes 10 consecutive times on the affected Windows host with pass count and slowest observed duration reported, a deliberate compile-success experiment fails the proof as designed and is reverted, and the full pkg/services/factory_runtime package test completes without an outer timeout panic.",
    "The measured cause and selected correction are reported; scope remains confined to pkg/services/factory_runtime/checkpoint_deletion_proof_test.go and a strictly required existing fixture, with no production, internal runtime, worker, provider, generated, or unrelated changes.",
    "Quality gates pass with focused typecheck/compile validation and tests; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Repository-wide go test and coverage sweeps are not required.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file reconciliation are complete, and the PR is actually merged; open, green, approved, or ready-to-merge is not complete."
  ],
  "userStories": [
    {
      "id": "thr-deflake-checkpoint-proof-unbounded-child-build-001",
      "title": "Bound and deflake the external-consumer proof",
      "description": "As a Windows contributor, I want the external-consumer checkpoint deletion proof to finish deterministically so a stuck nested toolchain cannot block local Factory Runtime tests indefinitely.",
      "acceptanceCriteria": [
        "Controlled focused measurements compare relevant serial/parallel and cache/temp-isolation variants, and the selected remedy is tied to the observed cause; if cache or lock contention is concluded, the supporting evidence is recorded.",
        "On Windows 11 with Go 1.25.0, the focused test returns a pass or actionable timeout failure within 75 seconds instead of reaching the outer 150-second panic.",
        "If the nested build remains, its context deadline is derived from the test deadline, capped at 60 seconds, reserves cleanup time, and timeout handling kills and reaps the process before returning.",
        "A child timeout or cancellation fails with a diagnostic identifying the nested proof build and deadline outcome and is not mistaken for expected compiler rejection.",
        "The test remains a negative external-consumer compilation proof: successful fixture compilation fails the test, while expected rejection must identify CaptureCheckpoint, LoadCheckpoint, and RestoreCheckpoint as undefined.",
        "The fixture remains under testdata and no production code, internal runtime code, worker code, provider code, generated artifact, or unrelated file is changed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented the bounded test-only harness correction: the proof is serialized, nested GOCACHE/GOTMPDIR are isolated with t.TempDir, the child deadline is derived from t.Deadline and capped at 60s with a 5s cleanup margin, and CommandContext plus WaitDelay provides kill/reap diagnostics distinct from expected compiler rejection. The existing fixture remains unchanged and the focused proof passed with all three undefined-method diagnostics; Story 002 remains open for repeated-run, deliberate-success, and full-package evidence."
    },
    {
      "id": "thr-deflake-checkpoint-proof-unbounded-child-build-002",
      "title": "Prove repeated stability and failure sensitivity",
      "description": "As a reviewer, I want repeated timing and deliberate failure evidence so I can distinguish a real hang fix from a lucky single pass or a weakened proof.",
      "acceptanceCriteria": [
        "The focused test passes 10 consecutive times on the affected Windows host; evidence reports 10/10 and the slowest observed wall-clock duration, with every run below the 75-second bound.",
        "A temporary controlled change that restores one deleted method for the fixture or otherwise makes the fixture compile causes the proof to fail because successful compilation is forbidden; the change is reverted and the failure output is reported.",
        "go test ./pkg/services/factory_runtime/ completes on the affected host without panicking on its timeout, and its result and wall-clock duration are reported.",
        "Focused evidence records the pre-change 150-second timeout panic, post-change timings, and the measured conclusion about parallel/cache/module-lock contention or the alternative cause found.",
        "The final diff contains no temporary proof-weakening experiment, generated artifact, CI-evidence commit, or change outside the owned test and strictly required fixture.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Evidence complete on Windows 10.0.26200 with Go 1.25.0: the isolated compiled test binary passed 10/10 focused runs, slowest 11.129s and total 102.155s, all below the 75s bound. A temporary fixture compile-success variant correctly failed the proof in 9.771s with the explicit successful-build diagnostic, and the fixture was restored unchanged. The full go test ./pkg/services/factory_runtime/ passed in 25.146s (package-reported 10.129s); focused vet and formatting checks passed. Combined with the recorded pre-change 150s outer timeout and shared-cache contention measurements, the evidence supports serialized proof execution plus private GOCACHE/GOTMPDIR as the correction."
    }
  ]
}
