### PR TITLE
thr-deflake-pause-resume-lifecycle-wait

### DIFF
--- a/tests/functional/sessions/controls/helpers_test.go
+++ b/tests/functional/sessions/controls/helpers_test.go
@@ -3,6 +3,7 @@ package sessioncontrols_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -27,6 +28,48 @@ const (
 	interruptedInspectWorkTypeName      = "goal"
 	interruptedInspectReviewWorkstation = "review-goal"
 )
+
+func openPauseResumeLifecycleEventStream(
+	t *testing.T,
+	server *support.FunctionalAPIServer,
+) *support.FactoryEventStream {
+	t.Helper()
+
+	retained := server.GetFactoryEvents(t)
+	if len(retained) == 0 {
+		t.Fatal("canonical Factory Event history is empty before pause/resume controls")
+	}
+
+	// Open without a cursor so the retained prefix flushes the SSE handshake.
+	// Then consume through the last event in the committed snapshot. Events
+	// published between that snapshot and the subscription remain queued after
+	// this point, so the lifecycle assertion has a stable observation boundary.
+	lastRetainedEventID := retained[len(retained)-1].Id
+	stream := support.OpenFactoryEventStreamAt(
+		t,
+		support.DefaultSessionEventsURL(server.URL()),
+	)
+	deadline := time.Now().Add(pauseResumeDurableStatusTimeout)
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			t.Fatalf(
+				"timed out establishing Factory Event observation point after retained event %q",
+				lastRetainedEventID,
+			)
+		}
+		event, ok := stream.TryNextEvent(remaining)
+		if !ok {
+			t.Fatalf(
+				"Factory Event stream closed before observation point at retained event %q",
+				lastRetainedEventID,
+			)
+		}
+		if event.Id == lastRetainedEventID {
+			return stream
+		}
+	}
+}
 
 func pauseResumeControlsFactoryDirWithBusyLoop(t *testing.T) string {
 	t.Helper()
@@ -520,6 +563,99 @@ func dispatchObservationIndexForWorkAtWorkstation(
 		}
 	}
 	return -1, false
+}
+
+func waitForPauseResumeLifecycleControlEvents(
+	t *testing.T,
+	stream *support.FactoryEventStream,
+	timeout time.Duration,
+) {
+	t.Helper()
+
+	wantOperations := []factoryapi.FactorySessionLifecycleControlKind{
+		factoryapi.FactorySessionLifecycleControlKindPause,
+		factoryapi.FactorySessionLifecycleControlKindResume,
+	}
+	var observed []factoryapi.FactoryEvent
+	deadline := time.Now().Add(timeout)
+	for len(observed) < len(wantOperations) {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			failPauseResumeLifecycleControlWait(t, "deadline expired", observed)
+		}
+
+		// The stream is the synchronization primitive. The deadline bounds only
+		// missing durable evidence; it does not poll Work projection state or add
+		// a sleep-based success path.
+		event, ok := stream.TryNextEvent(remaining)
+		if !ok {
+			failPauseResumeLifecycleControlWait(t, "event stream closed or deadline expired", observed)
+		}
+		if event.Type != factoryapi.FactoryEventTypeSessionLifecycleControl {
+			continue
+		}
+
+		observed = append(observed, event)
+		payload, err := event.Payload.AsSessionLifecycleControlEventPayload()
+		if err != nil {
+			failPauseResumeLifecycleControlWait(
+				t,
+				fmt.Sprintf("malformed SESSION_LIFECYCLE_CONTROL payload: %v", err),
+				observed,
+			)
+		}
+		wantOperation := wantOperations[len(observed)-1]
+		if payload.Operation != wantOperation ||
+			payload.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+			failPauseResumeLifecycleControlWait(
+				t,
+				fmt.Sprintf(
+					"observed operation=%q outcome=%q; want accepted %q",
+					payload.Operation,
+					payload.Outcome,
+					wantOperation,
+				),
+				observed,
+			)
+		}
+	}
+
+	assertPauseResumeLifecycleControlEvents(t, observed)
+}
+
+func failPauseResumeLifecycleControlWait(
+	t *testing.T,
+	reason string,
+	observed []factoryapi.FactoryEvent,
+) {
+	t.Helper()
+
+	history := make([]string, 0, len(observed))
+	for _, event := range observed {
+		payload, err := event.Payload.AsSessionLifecycleControlEventPayload()
+		if err != nil {
+			history = append(history, fmt.Sprintf(
+				"id=%q sequence=%d malformed_payload=%v",
+				event.Id,
+				event.Context.Sequence,
+				err,
+			))
+			continue
+		}
+		history = append(history, fmt.Sprintf(
+			"id=%q sequence=%d operation=%q outcome=%q occurredAt=%s",
+			event.Id,
+			event.Context.Sequence,
+			payload.Operation,
+			payload.Outcome,
+			payload.OccurredAt.UTC().Format(time.RFC3339Nano),
+		))
+	}
+	t.Fatalf(
+		"pause/resume durable lifecycle event wait failed: %s; expected accepted operations in order [PAUSE, RESUME]; observed lifecycle-event history: %v",
+		reason,
+		history,
+	)
 }
 
 func filterSessionLifecycleControlEvents(events []factoryapi.FactoryEvent) []factoryapi.FactoryEvent {

--- a/tests/functional/sessions/controls/pause_resume_test.go
+++ b/tests/functional/sessions/controls/pause_resume_test.go
@@ -4,8 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
@@ -194,9 +196,20 @@ func TestResumedFactorySessionDrainsBufferedWorkInOrder(t *testing.T) {
 // Factory Events in chronological order with public control operation kinds.
 func TestPauseResumeEmitsDurableLifecycleEvents(t *testing.T) {
 	factoryDir := support.ScaffoldFactory(t, pauseResumeControlsFactoryConfig())
+	support.WriteAgentConfig(
+		t,
+		factoryDir,
+		"mock-worker",
+		support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"),
+	)
+	runner := support.NewShapedProviderCommandRunner(platformprocess.CommandResult{
+		Stdout: []byte("buffered task accepted COMPLETE"),
+	})
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
-		FactoryDir:     factoryDir,
-		UseMockWorkers: true,
+		FactoryDir: factoryDir,
+		Edges: serviceedges.Edges{
+			ProviderCommandRunner: runner,
+		},
 	})
 	defer server.Stop(t)
 

--- a/tests/functional/sessions/controls/pause_resume_test.go
+++ b/tests/functional/sessions/controls/pause_resume_test.go
@@ -202,6 +202,7 @@ func TestPauseResumeEmitsDurableLifecycleEvents(t *testing.T) {
 
 	baseURL := server.URL()
 	sessionID := factorysessions.DefaultSessionID
+	eventStream := openPauseResumeLifecycleEventStream(t, server)
 
 	pause := postSessionLifecycleControl(
 		t,
@@ -235,15 +236,11 @@ func TestPauseResumeEmitsDurableLifecycleEvents(t *testing.T) {
 		t.Fatalf("resume response = %#v, want accepted resume", resume)
 	}
 
-	waitForSessionWorkIDsAtCustomerState(
+	waitForPauseResumeLifecycleControlEvents(
 		t,
-		baseURL,
-		[]string{workID},
-		support.WorkCustomerLocation("task", "complete"),
-		pauseResumeDrainWaitTimeout,
+		eventStream,
+		pauseResumeDurableStatusTimeout,
 	)
-
-	assertPauseResumeLifecycleControlEvents(t, server.GetFactoryEvents(t))
 }
 
 // TestInterruptedWorkInspectSurfacesDispatchAndStopSummary proves work stopped


### PR DESCRIPTION
{
  "project": "Deflake Pause/Resume Durable Lifecycle Event Verification",
  "branchName": "thr-deflake-pause-resume-lifecycle-wait",
  "description": "Make TestPauseResumeEmitsDurableLifecycleEvents deterministically observe the durable pause and resume Factory Events it asserts instead of gating on an unrelated Work listing projection, while preserving failure sensitivity and respecting the active Factory Sessions lane.",
  "context": {
    "customerAsk": "Deflake TestPauseResumeEmitsDurableLifecycleEvents without skipping, weakening, quarantining, retrying the whole test, or increasing its timeout; classify the failure using direct evidence, run at least 20 consecutive focused passes, and prove with a reverted fault injection that missing durable lifecycle records still fail meaningfully.",
    "problem": "The captured same-SHA flake failed after 30.63 seconds even though the submitted Work existed. The test currently polls the public Work listing projection for task:complete before reading the canonical retained Factory Event stream, so unrelated projection or processing latency can block an assertion whose actual contract is durable pause/resume lifecycle events.",
    "solution": "Establish a stable observation point on the canonical Factory Event surface and await the scenario's accepted PAUSE then RESUME durable records in order. Keep bounded event-specific failure diagnostics, avoid changing the shared Work-state wait helper, and stop with PR evidence rather than touching prohibited product packages if investigation identifies a genuine product race."
  },
  "acceptanceCriteria": [
    "The PR states the captured before condition—one intermittent 30.63-second failure on PR #1949 head 66b5d5cd followed by a passing same-SHA rerun—and identifies the old Work-listing poll surface versus the canonical Factory Event assertion surface.",
    "Evidence explicitly selects the harness-defect or product-race hypothesis; a harness finding changes only the owned test or an exclusively called helper, while a product finding stops implementation and is reported in a PR comment without edits under pkg/services/factory_sessions/**, pkg/services/workers/**, or providers/**.",
    "The test observes typed, accepted PAUSE and RESUME SESSION_LIFECYCLE_CONTROL records in chronological order from the canonical durable Factory Event surface without using Work completion as event readiness.",
    "The final change does not skip, delete, weaken, quarantine, timeout-pad, sleep-pad, or whole-test-retry the assertion and does not alter any helper shared with other tests' timing semantics.",
    "At least 20 consecutive focused runs pass and the PR reports the exact pass count and slowest duration; a reverted fault injection that prevents or discards durable lifecycle records makes the test fail with a meaningful event-specific diagnostic.",
    "Typecheck passes; focused tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts are resolved, and the PR is merged; opening, pushing, approval, or ready-to-merge status is not completion."
  ],
  "userStories": [
    {
      "id": "thr-deflake-pause-resume-lifecycle-wait-001",
      "title": "Synchronize the test with its durable event contract",
      "description": "As a maintainer relying on functional CI, I want the pause/resume lifecycle-event test to wait on the canonical durable event signal so unrelated Work projection latency cannot cause a false failure.",
      "acceptanceCriteria": [
        "The investigation records whether accepted pause/resume responses and durable lifecycle records are observable while the Work listing still lags, and explicitly concludes whether evidence supports a harness synchronization defect or product race.",
        "When evidence supports a harness defect, the test observes the scenario's PAUSE then RESUME SESSION_LIFECYCLE_CONTROL records from the canonical public retained/live Factory Event surface after a stable observation point.",
        "Success no longer depends on buffered Work reaching task:complete, while the buffered submission remains part of the pause/resume scenario.",
        "Missing, malformed, rejected, or incorrectly ordered lifecycle records produce diagnostics containing expected operations and relevant observed lifecycle-event history.",
        "The shared Work-state wait helper retains its current semantics; any new helper is exclusive to this lifecycle assertion and uses a deadline only for failure rather than sleep or timeout padding as its success mechanism.",
        "No production contract, generated artifact, or prohibited Factory Sessions, Workers, or Providers path changes; a product-race finding stops implementation and is handed off with PR evidence.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented the harness synchronization fix. The test now establishes a stable retained/live canonical Factory Event observation point and waits for typed accepted PAUSE then RESUME SESSION_LIFECYCLE_CONTROL records in stream order, with event-specific diagnostics. Focused functional test passed; no production, generated, shared Work-wait, Factory Sessions, Workers, or Providers paths changed. Evidence supports a harness synchronization defect because the old readiness gate was the Work listing projection rather than the durable event assertion surface."
    },
    {
      "id": "thr-deflake-pause-resume-lifecycle-wait-002",
      "title": "Prove repeatability and preserve regression sensitivity",
      "description": "As a reviewer, I want repeat-run and negative-control evidence so I can distinguish a real deflake from a test that merely became less likely or less able to fail.",
      "acceptanceCriteria": [
        "The focused test passes at least 20 consecutive runs on the final implementation, and the PR reports the exact pass count and slowest observed duration.",
        "A temporary and reverted fault injection prevents or discards durable lifecycle-control records before assertion, and the focused test fails with a diagnostic identifying the missing pause/resume evidence.",
        "The fault injection is absent from the final diff, does not weaken the final assertion, and does not change shared helpers or other suites' timing behavior.",
        "Verification uses the single focused functional test and its package as needed, not repository-wide go test ./... or the known-broken Windows unit-coverage sweep.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Final implementation passed 20 consecutive focused runs (20 pass events, 0 failures); the slowest observed test duration was 1.23s. A temporary fault injection discarded the durable accepted PAUSE record before assertion; the focused test failed with exit 1 and an event-specific diagnostic showing observed RESUME, expected accepted [PAUSE, RESUME], and the observed lifecycle-event history. The injection was reverted and a final focused run passed in 0.62s. Verification used only the focused functional test; no fault-injection code remains in the diff."
    }
  ]
}
