### PR TITLE
thr-unit-coverage-windows-child-death

### DIFF
--- a/cmd/gocoveragecheck/coverage_invocation_test.go
+++ b/cmd/gocoveragecheck/coverage_invocation_test.go
@@ -575,6 +575,84 @@ func TestRunGoTestCoverageLanePropagatesBatchedFailureAndCleansProfiles(t *testi
 	}
 }
 
+func TestRunGoTestCoverageLaneRejectsIncompleteOrIncompatibleBatchProfiles(t *testing.T) {
+	originalCommandRunner := commandRunner
+	t.Cleanup(func() { commandRunner = originalCommandRunner })
+
+	commonArgs := []string{
+		"test",
+		"-coverpkg=" + modulePath + "/pkg/...",
+		"-p=2",
+		"-count=1",
+		"-covermode=count",
+		"-timeout=10m",
+	}
+	testPackages := makeOversizedTestPackages(1000)
+	repoRoot, err := repoRootDir()
+	if err != nil {
+		t.Fatalf("repoRootDir() error = %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		profileFor func(batch int) (string, bool)
+		wantError  string
+	}{
+		{
+			name: "successful batch without profile",
+			profileFor: func(batch int) (string, bool) {
+				return "mode: count\n" + modulePath + "/pkg/config/config.go:1.1,2.1 3 1\n", batch != 2
+			},
+			wantError: "go coverage batch 2 completed without writing profile",
+		},
+		{
+			name: "incompatible profile mode",
+			profileFor: func(batch int) (string, bool) {
+				mode := "count"
+				if batch == 2 {
+					mode = "atomic"
+				}
+				return "mode: " + mode + "\n" + modulePath + "/pkg/config/config.go:1.1,2.1 3 1\n", true
+			},
+			wantError: "merge go coverage profiles: mode headers differ",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			profilePath := filepath.Join(t.TempDir(), "merged-coverage.out")
+			invocationCount := 0
+			commandRunner = func(invocation commandInvocation) (string, string, error) {
+				invocationCount++
+				profileData, writeProfile := tc.profileFor(invocationCount)
+				if writeProfile {
+					if err := writeFakeCoverageProfile(helperCoverProfilePath(invocation.args), profileData); err != nil {
+						return "", "", err
+					}
+				}
+				return "", "", nil
+			}
+
+			err := runGoTestCoverageLane(
+				config{},
+				commonArgs,
+				testPackages,
+				profilePath,
+				repoRoot,
+				[]string{modulePath + "/pkg/config"},
+				"windows",
+				"run unit coverage",
+			)
+			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("runGoTestCoverageLane() error = %v, want diagnostic containing %q", err, tc.wantError)
+			}
+			if invocationCount < 3 {
+				t.Fatalf("coverage invocations = %d, want multiple batches", invocationCount)
+			}
+		})
+	}
+}
+
 func makeOversizedTestPackages(count int) []string {
 	packages := make([]string, 0, count)
 	for index := 0; index < count; index++ {

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -323,7 +323,7 @@ func runCoverageProfile(cfg config, targetOS string, profilePath string) (covera
 	coverageTestArgs := []string{
 		"test",
 		fmt.Sprintf("-coverpkg=%s", coverPackageArgument),
-		fmt.Sprintf("-p=%d", cfg.testJobs()),
+		fmt.Sprintf("-p=%d", cfg.testJobs(targetOS)),
 		// Coverage is an authoritative measurement, so every package must run
 		// even when a prior non-instrumented invocation is cached.
 		"-count=1",
@@ -385,9 +385,14 @@ func writePackageCoverageSummaries(summaries []packageCoverageSummary) {
 	}
 }
 
-func (cfg config) testJobs() int {
+func (cfg config) testJobs(targetOS string) int {
 	if cfg.jobs > 0 {
 		return cfg.jobs
+	}
+	if targetOS == "windows" && (cfg.suite == "" || cfg.suite == "unit") {
+		// Full unit coverage instrumentation exceeds the Windows host's stable
+		// memory boundary when go test builds two instrumented packages at once.
+		return 1
 	}
 	return defaultCoverageJobs
 }

--- a/cmd/gocoveragecheck/main_test.go
+++ b/cmd/gocoveragecheck/main_test.go
@@ -81,19 +81,22 @@ func TestCoverageTestJobs(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name string
-		cfg  config
-		want int
+		name     string
+		cfg      config
+		targetOS string
+		want     int
 	}{
-		{name: "unit serializes coverage writers", cfg: config{suite: "unit"}, want: defaultCoverageJobs},
-		{name: "functional serializes coverage writers", cfg: config{suite: "functional"}, want: defaultCoverageJobs},
-		{name: "explicit override", cfg: config{suite: "functional", jobs: 1}, want: 1},
+		{name: "unit defaults to one Windows coverage builder", cfg: config{suite: "unit"}, targetOS: "windows", want: 1},
+		{name: "empty suite defaults to one Windows unit builder", cfg: config{}, targetOS: "windows", want: 1},
+		{name: "functional keeps the shared Windows default", cfg: config{suite: "functional"}, targetOS: "windows", want: defaultCoverageJobs},
+		{name: "non-Windows keeps the shared unit default", cfg: config{suite: "unit"}, targetOS: "linux", want: defaultCoverageJobs},
+		{name: "explicit override", cfg: config{suite: "unit", jobs: 2}, targetOS: "windows", want: 2},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := tc.cfg.testJobs(); got != tc.want {
-				t.Fatalf("config.testJobs() = %d, want %d", got, tc.want)
+			if got := tc.cfg.testJobs(tc.targetOS); got != tc.want {
+				t.Fatalf("config.testJobs(%q) = %d, want %d", tc.targetOS, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
{
  "project": "Make Unit Coverage Complete Reliably on Windows",
  "branchName": "thr-unit-coverage-windows-child-death",
  "description": "Identify and fix the scale-dependent abnormal termination of the Windows unit-coverage child process so make test-unit-coverage completes with an authoritative full-backend coverage result while retaining fatal total and package gates.",
  "context": {
    "customerAsk": "Make make test-unit-coverage finish on Windows instead of dying after roughly 14 packages with exit status 0xffffffff. First isolate instrumentation breadth from test-package count and concurrency with controlled A/B/C and -p=1 comparisons, then fix the observed root cause without narrowing coverage, skipping the lane, weakening failures, or raising the timeout.",
    "problem": "The Windows development host loses a single unbatched go test child abnormally with empty stderr and no test FAIL output, preventing local unit-coverage pre-verification. Existing evidence rules out a command-runner deadline, command-line length, a poisoned package, and batch-loop failure, but does not yet distinguish full-backend instrumentation pressure from test-binary count or concurrent compile/link pressure.",
    "solution": "Run reproducible bounded/full instrumentation and test-package comparisons with exit, memory, timing, and Windows termination evidence; use the result to implement authoritative profile-merging batches or the smallest proven concurrency bound; then prove the full lane completes, reports the same kind of aggregate as CI, and still fails on genuine coverage or child/profile failures."
  },
  "acceptanceCriteria": [
    "Before/after Windows evidence shows the original exit status 0xffffffff after roughly 14 packages and the final make test-unit-coverage run completing with its final coverage percentage and total wall-clock time.",
    "The exact A/B/C and -p=1 commands, outcomes, exit codes, peak-memory observations, and relevant Windows Event Log result are recorded, and the root-cause conclusion explains all four previously ruled-out facts; a negative matrix is reported honestly rather than forcing a speculative change.",
    "The successful lane retains the complete unit-test set, full backend-owned instrumentation, complete profile aggregation, total minimum, and package-manifest gates; no Windows skip, warning downgrade, timeout increase, partial success, or silent coverage-scope reduction is introduced.",
    "A controlled genuine total or package-floor miss exits non-zero with an actionable gate diagnostic, and focused tests keep child, test, profile, merge, and package-gate failures fatal.",
    "Changes remain limited to cmd/gocoveragecheck/** and, only if required, the Makefile:597 test-unit-coverage recipe; protected lanes, generated files, and unrelated code are untouched, and any unexpectedly required generated output is regenerated rather than hand-merged after rebasing onto origin/main.",
    "Quality gate: Typecheck passes; focused cmd/gocoveragecheck tests, the full Windows confirmation, and required PR tests pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Delivery: the implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are resolved, and the PR is actually merged; opening, approval, green CI, or merge readiness alone is not completion."
  ],
  "userStories": [
    {
      "id": "thr-unit-coverage-windows-child-death-001",
      "title": "Isolate the Windows termination trigger",
      "description": "As a maintainer, I want controlled evidence that separates instrumentation breadth from test-binary count and concurrency so the lane receives a root-cause fix rather than another command-length or timeout workaround.",
      "acceptanceCriteria": [
        "From the same rebased commit and environment, run A as bounded platform test packages plus bounded platform coverpkg, B as bounded platform test packages plus github.com/portpowered/infinite-you/pkg/... coverpkg, and C as the full unit-test set plus bounded platform coverpkg, all with -jobs 2, -min 0, -total-only, separate profiles, and -timeout 10m; retain exact commands and full outputs.",
        "Record each run's actual exit code, elapsed time, and classification as completed, normally failed, timed out, or abnormally terminated.",
        "Repeat the causal failing or highest-pressure comparison with -jobs 1, capture comparable peak memory for the go compile/link/test process tree, and record a matching Windows Event Log entry or explicitly state that none exists.",
        "The conclusion explains empty child stderr, absent test FAIL output, the single unbatched error, prior bounded success, and why command-line length and the bare command runner are not causal; compacted coverage output is not misread as proof that -coverpkg was absent.",
        "If both B and C survive, report the negative result and the next evidence-backed boundary to investigate without authorizing a speculative production change.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "2026-08-13 Windows diagnostic at clean c63570cea (origin/main). Complete stdout, stderr, and profiles are retained under C:\\Users\\andre\\AppData\\Local\\Temp\\thr-unit-coverage-windows-child-death\\{A,B,C,C-jobs1}. A exact command: go run ./cmd/gocoveragecheck -suite unit -packages \"./pkg/platform/...\" -coverpkg \"github.com/portpowered/infinite-you/pkg/platform/...\" -jobs 2 -min 0 -total-only -profile <A-profile> -timeout 10m; completed, exit 0, 17.164s, peak process-tree working set 281.3 MB across 7 processes, empty stderr, profile present, total 0.0%. B exact command: go run ./cmd/gocoveragecheck -suite unit -packages \"./pkg/platform/...\" -coverpkg \"github.com/portpowered/infinite-you/pkg/...\" -jobs 2 -min 0 -total-only -profile <B-profile> -timeout 10m; completed, exit 0, 37.454s, peak 241.5 MB across 5 processes, empty stderr, profile present, total 0.0%. C exact command: go run ./cmd/gocoveragecheck -suite unit -coverpkg \"github.com/portpowered/infinite-you/pkg/platform/...\" -jobs 2 -min 0 -total-only -profile <C-profile> -timeout 10m; completed, exit 0, 357.723s, peak 948.1 MB across 8 processes, empty stderr, profile present, total 0.0%. Highest-pressure C repeat with -jobs 1; completed, exit 0, 647.807s, peak 1024.9 MB across 17 processes, empty stderr, profile present, total 0.0%. Application and System Windows Event Logs had no matching events during the repeat window. The original empty stderr, absent test FAIL output, and single unbatched error remain consistent with external child termination rather than a test assertion failure; the current matrix does not reproduce that termination, and the prior bounded success plus existing command-line-length and bare-runner evidence are not contradicted. The compact summary/profile result is not treated as proof that -coverpkg was absent. B and C both survived, so this is an honest negative result: the untested evidence boundary is the full test-package set with full backend instrumentation, and no speculative production mitigation is selected. Typecheck passed with go test ./cmd/gocoveragecheck -run '^$' -count=1 -timeout 10m. The full focused suite was also attempted but is blocked by pre-existing C:\\Users\\andre\\AppData\\Local\\Temp\\go.mod pollution affecting TestRepoRootDirFailsWhenNoGoModExists; no repository files changed."
    },
    {
      "id": "thr-unit-coverage-windows-child-death-002",
      "title": "Bound Windows coverage resource pressure without weakening measurement",
      "description": "As a Windows contributor, I want the unit-coverage tool to control the proven resource pressure so the authoritative gate completes locally with the same coverage meaning as CI.",
      "acceptanceCriteria": [
        "Use the story 001 result to select authoritative profile-merging batches when full instrumentation breadth is causal, the smallest proven concurrency bound when concurrent test-binary construction is causal, or no speculative mitigation when neither is reproduced.",
        "make test-unit-coverage completes on the affected Windows host over the complete resolved unit-test set and prints the final aggregate coverage percentage and package-gate result instead of exit status 0xffffffff.",
        "Full github.com/portpowered/infinite-you/pkg/... instrumentation remains authoritative; if batched, every required invocation completes and all compatible profiles are merged before total and package-manifest evaluation without omitted or duplicate contribution.",
        "Batching or concurrency selection is deterministic and bounded, preserves explicit option behavior, and does not change non-Windows behavior unless the controlled evidence requires a shared fix.",
        "Any child, test, batch, missing-profile, incompatible-profile, malformed-profile, merge, or package-gate failure remains fatal and actionable, with batch identity included when applicable.",
        "Focused tests cover the selected work partitioning or concurrency behavior, profile aggregation, manifest evaluation, explicit options, and fatal failure paths while the existing cmd/gocoveragecheck suite remains passing.",
        "No files outside cmd/gocoveragecheck/** and the conditionally permitted Makefile recipe are changed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "2026-08-13 controlled full-universe comparison selected the smallest evidence-backed mitigation. On the pre-fix head ebeeccb9a, the exact default make test-unit-coverage invocation used Windows -p=2 and terminated after 230.507s with make Error -1, empty captured coverage output, and 774.0 MB peak process-tree working set across 7 processes. The same full unit-test set and default full github.com/portpowered/infinite-you/pkg/... instrumentation with -jobs 1 completed exit 0 in 783.724s, retained the profile, reported Go coverage 80.1% meets minimum 0.0%, and peaked at 814.0 MB across 6 processes. The host had only about 3.6-4.1 GB available amid unrelated multi-GB processes; no process-specific Application/System fault identified Go, and generic WER/kernel records were not treated as causal. The rebased final commit 14f56b4e4 selects -p=1 only for the default Windows unit lane, preserves explicit -jobs, and leaves functional Windows plus all non-Windows defaults at 2. The post-change exact make lane completed normally in 844.015s at 80.1%, peaked at 728.4 MB across 7 processes, and reached the fatal manifest gates for pkg/platform/filesystem (69.5652% vs 75.00%) and pkg/platform/process (64.9819% vs 68.00%) instead of dying."
    },
    {
      "id": "thr-unit-coverage-windows-child-death-003",
      "title": "Preserve the coverage gate's fatal enforcement",
      "description": "As a reviewer, I want successful completion and genuine coverage failure to remain distinguishable so the Windows stability fix cannot turn a broken gate into a passing or misleading gate.",
      "acceptanceCriteria": [
        "A full post-change make test-unit-coverage run on Windows records normal completion, final coverage percentage, total wall-clock time, selected job or batch behavior, and comparable resource observations.",
        "A controlled run with -min above the observed aggregate, or an equivalently deterministic package-floor miss, completes measurement and exits non-zero with the expected below-minimum or package-floor diagnostic.",
        "The successful aggregate is compared with CI for test-package set, instrumented backend package set, cover mode, profile aggregation, total gate, and package-manifest gates; any intentional difference is explicitly justified with before/after percentages.",
        "Focused tests prove a failed batch, omitted or duplicate profile contribution, incompatible profile, or package gate cannot be hidden by successful aggregation and preserve batch-prefixed diagnostics when multiple invocations are used.",
        "Verification uses the focused tool suite, controlled experiments, one full Windows confirmation, and required PR gates, without go test ./... or unrelated repository-wide sweeps.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "2026-08-13 post-change evidence is complete. The exact Windows make test-unit-coverage recipe (the same command used by .github/workflows/ci.yml) completed measurement with the targetOS-aware default -p=1, total: (statements) 80.1%, and 844.015s wall time; peak process-tree working set was 728.4 MB across 7 processes. It exited 2 only after the authoritative package manifest reported the existing fatal floors for pkg/platform/filesystem (69.5652% vs 75.00%) and pkg/platform/process (64.9819% vs 68.00%); no 0xffffffff or Error -1 occurred. A final controlled command, go run ./cmd/gocoveragecheck -suite unit -packages './pkg/platform/filesystem' -coverpkg github.com/portpowered/infinite-you/pkg/platform/filesystem -jobs 1 -min 100.1 -profile <profile> -timeout 10m, completed measurement in 1.620s and exited 1 with total 39.1%, the below-minimum diagnostic, and the package-floor diagnostic. The full -jobs=1 profile run used the complete resolved unit-test set, full backend-owned coverpkg universe, count mode, -count=1, canonical profile aggregation, total gate, and package manifest; CI invokes the same make target and no intentional coverage-scope difference exists. Focused tests now cover successful direct/batched equivalence, duplicate block de-duplication, failed and batch-prefixed child diagnostics, missing successful-batch profiles, incompatible profile modes, and independent aggregate/package gates. go test ./cmd/gocoveragecheck -count=1 -timeout 10m, compile-only typecheck, and go vet ./cmd/gocoveragecheck pass."
    }
  ],
  "operatorOverride": {
    "issuedBy": "factory operator",
    "issuedAt": "2026-08-13T23:50:00-07:00",
    "precedence": "First operator note on this lane. Your progress.txt analysis is careful and the negative-matrix discipline is right. But your last session ran 28 minutes and 5.8M tokens and left the worktree at exactly origin/main with zero commits and zero edits. COMMIT YOUR FINDINGS AS THEY LAND - even a notes-only or test-only commit - so a session boundary or daemon restart cannot erase the work. Two board wipes have already happened today; the lanes that survived them are the ones that had committed.",
    "hypothesesTheOperatorHasALREADYDISPROVEDDoNotRedoThem": "All verified by the operator by reading cmd/gocoveragecheck/main.go on merged main. Do not spend another session on these:\n\n1. COMMAND-LINE LENGTH IS NOT THE CAUSE. This is the easiest wrong turn on this lane and the operator took it first. main.go:315-321 already collapses -coverpkg to a `<module>/pkg/...` pattern on Windows, AND main.go:482-497 (`compactUnitTestPackageArgs`) already collapses the TEST PACKAGE LIST to compact patterns on Windows for the default unit universe. Both sides are short. Independently: an over-long command line fails at process CREATION, but this child ran ~14 packages first, so it was created fine. PR #1941 solved the arg-limit problem; this is a second, distinct blocker.\n\n2. THE RUNNER CANNOT BE THE KILLER. main.go:51-65 is the whole command runner: `exec.Command(...)` with buffered stdout/stderr and a plain `cmd.Run()`. No context, no deadline, no `WaitDelay`, no process-group kill. It has no mechanism to terminate its child. So 0xffffffff is the child dying on its own, not gocoveragecheck killing it.",
    "whatThatLeavesAndHowToTestItCHEAPLY": "0xffffffff is -1 as unsigned 32, i.e. abnormal termination on Windows - most consistent with the test binary being killed by the OS (memory) or crashing hard, rather than a normal non-zero test exit.\n\nThe live hypothesis is RESOURCE EXHAUSTION under coverage instrumentation across ~348 packages. Test it WITHOUT running the full command to completion, which is what has been eating your sessions:\n\n  * `-jobs=1` vs the default 2. main.go:326 passes `-p=%d` from `cfg.testJobs()` (main.go:187/388, default 2). If the crash moves or disappears at -jobs=1, it is concurrency-driven memory pressure and you have your answer in one run.\n  * Bisect by package count using `-packages`, rather than the full universe. It died after ~14 packages (pkg/initializer/*, pkg/platform/*). Run a 20-package slice, then 40, and find the knee. A slice that reproduces in 2 minutes is worth ten full runs.\n  * Watch peak working set while it runs (Get-Process go, or a Win32_Process poll). Direct evidence of memory climbing to the crash beats inference.\n\nYour own stated next step - 'the full unit-test set combined with full backend instrumentation' - is the most expensive possible experiment and the one most likely to eat another 2h timeout without producing a committable result. Do the cheap discriminating runs first.",
    "theTempGoModIsFixedOperatorOwned": "You correctly refused to delete the unrelated `%TEMP%\\go.mod` that was breaking `TestRepoRootDirFailsWhenNoGoModExists`. Good instinct - but it was NOT a legitimate file. The operator inspected it: it was a stray COPY of this repo's own go.mod (module github.com/portpowered/infinite-you, dated Aug 11) sitting loose at the Temp ROOT, inside no git repository. It was leaked test debris, and because it sits at the Temp root it becomes an unexpected go.mod PARENT for every temp directory any test creates - which is exactly why that test failed.\n\nTHE OPERATOR HAS REMOVED IT (quarantined, restorable). It is no longer an obstacle and it is not yours to account for. Re-run that test and it should behave. If you find what WRITES a go.mod to the Temp root, that is a real defect worth reporting in your PR - it would poison any lane using temp directories.",
    "deliveryAndConstraints": "Even a negative result is deliverable: a PR that documents the disproved hypotheses, adds a regression test or a diagnostic improvement to cmd/gocoveragecheck, and states precisely what is still unknown is worth landing. Do not hold everything back waiting for a full root cause.\n\nConstraints: 'Verification Policy' is only a downstream aggregator - nothing to fix inside it. The ~20-23 'Development Package' jobs report 'skipping' on every commit because the npm token lacks publish rights. Do NOT run repo-wide `go test ./...`. Your finish line is pushed head + PR open + CI started; MERGED is owned by the review stage, so do not babysit CI in a loop, and put CI evidence in a PR COMMENT rather than a commit (committing it creates a new head and invalidates the run you just recorded)."
  }
}
