### PR TITLE
Stream gocoveragecheck child output on demand

### DIFF
--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -286,6 +286,7 @@ func runGoTestCoverageLane(cfg config, commonArgs []string, testPackages []strin
 	if err != nil {
 		return err
 	}
+	configureCoverageInvocationStreaming(&plan, cfg.stream)
 
 	started := time.Now()
 	var stdout strings.Builder
@@ -363,6 +364,16 @@ func appendCoverageOutput(output *strings.Builder, chunk string) {
 
 func runCommand(invocation commandInvocation) (string, string, error) {
 	return commandRunner(invocation)
+}
+
+func configureCoverageInvocationStreaming(plan *coverageInvocationPlan, enabled bool) {
+	if !enabled {
+		return
+	}
+	for index := range plan.invocations {
+		plan.invocations[index].stdoutWriter = stdoutWriter
+		plan.invocations[index].stderrWriter = stderrWriter
+	}
 }
 
 func mergeGoTestFailureDetail(stderr string, stdout string) string {

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -28,10 +28,12 @@ var (
 )
 
 type commandInvocation struct {
-	name string
-	args []string
-	env  []string
-	dir  string
+	name         string
+	args         []string
+	env          []string
+	dir          string
+	stdoutWriter io.Writer
+	stderrWriter io.Writer
 }
 
 type commandRunnerFunc func(commandInvocation) (string, string, error)
@@ -58,8 +60,16 @@ var (
 		}
 		var stdout bytes.Buffer
 		var stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
+		if invocation.stdoutWriter == nil {
+			cmd.Stdout = &stdout
+		} else {
+			cmd.Stdout = io.MultiWriter(&stdout, invocation.stdoutWriter)
+		}
+		if invocation.stderrWriter == nil {
+			cmd.Stderr = &stderr
+		} else {
+			cmd.Stderr = io.MultiWriter(&stderr, invocation.stderrWriter)
+		}
 		err := cmd.Run()
 		return stdout.String(), stderr.String(), err
 	}
@@ -91,6 +101,7 @@ type config struct {
 	profile             string
 	short               bool
 	suite               string
+	stream              bool
 	timeout             time.Duration
 	totalOnly           bool
 }
@@ -204,6 +215,7 @@ func parseConfig() config {
 	flag.StringVar(&cfg.profile, "profile", "", "coverage profile output path; defaults to a temp file")
 	flag.BoolVar(&cfg.short, "short", true, "run with go test -short")
 	flag.StringVar(&cfg.suite, "suite", "unit", "test suite to execute when -packages is empty: unit or functional")
+	flag.BoolVar(&cfg.stream, "stream", false, "stream coverage-test child stdout and stderr to their output sinks while running")
 	flag.DurationVar(&cfg.timeout, "timeout", 5*time.Minute, "go test timeout")
 	flag.BoolVar(&cfg.totalOnly, "total-only", false, "disable package-local coverage gates while retaining per-package reporting")
 	flag.Parse()

--- a/cmd/gocoveragecheck/stream_test.go
+++ b/cmd/gocoveragecheck/stream_test.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	streamChildEnv       = "GOCOVERAGECHECK_STREAM_CHILD"
+	streamChildExitEnv   = "GOCOVERAGECHECK_STREAM_CHILD_EXIT"
+	streamChildStdoutOne = "stdout child chunk one\n"
+	streamChildStdoutTwo = "stdout child chunk two\n"
+	streamChildStderrOne = "stderr child chunk one\n"
+	streamChildStderrTwo = "stderr child chunk two\n"
+)
+
+func TestCommandRunnerStreamsCoverageChildOutputWithoutChangingCapturedBytes(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalExecCommand := execCommand
+	t.Cleanup(func() {
+		commandRunner = originalCommandRunner
+		execCommand = originalExecCommand
+	})
+
+	tests := []struct {
+		name       string
+		stream     bool
+		exitCode   int
+		wantStream bool
+	}{
+		{name: "buffered success", exitCode: 0},
+		{name: "streamed success", stream: true, exitCode: 0, wantStream: true},
+		{name: "buffered failure", exitCode: 7},
+		{name: "streamed failure", stream: true, exitCode: 7, wantStream: true},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			releaseReader, releaseWriter := io.Pipe()
+			t.Cleanup(func() { _ = releaseWriter.Close() })
+			execCommand = func(string, ...string) *exec.Cmd {
+				cmd := exec.Command(os.Args[0], "-test.run=TestGocoveragecheckStreamChildProcess", "--")
+				cmd.Stdin = releaseReader
+				return cmd
+			}
+			commandRunner = originalCommandRunner
+
+			stdoutSink := newStreamCapture(streamChildStdoutOne + streamChildStdoutTwo)
+			stderrSink := newStreamCapture(streamChildStderrOne + streamChildStderrTwo)
+			invocation := commandInvocation{
+				name: "coverage-test-child",
+				env: append(os.Environ(),
+					streamChildEnv+"=1",
+					streamChildExitEnv+"="+strconv.Itoa(tc.exitCode),
+				),
+			}
+			if tc.stream {
+				invocation.stdoutWriter = stdoutSink
+				invocation.stderrWriter = stderrSink
+			}
+
+			type commandResult struct {
+				stdout string
+				stderr string
+				err    error
+			}
+			resultCh := make(chan commandResult, 1)
+			go func() {
+				stdout, stderr, err := runCommand(invocation)
+				resultCh <- commandResult{stdout: stdout, stderr: stderr, err: err}
+			}()
+
+			if tc.wantStream {
+				waitForStreamCapture(t, stdoutSink.complete)
+				waitForStreamCapture(t, stderrSink.complete)
+				if got := stdoutSink.String(); got != streamChildStdoutOne+streamChildStdoutTwo {
+					t.Fatalf("streamed stdout before child completion = %q, want first two chunks", got)
+				}
+				if got := stderrSink.String(); got != streamChildStderrOne+streamChildStderrTwo {
+					t.Fatalf("streamed stderr before child completion = %q, want first two chunks", got)
+				}
+				select {
+				case result := <-resultCh:
+					t.Fatalf("child completed before release: %+v", result)
+				default:
+				}
+			}
+			if _, err := releaseWriter.Write([]byte{1}); err != nil {
+				t.Fatalf("release child: %v", err)
+			}
+			if err := releaseWriter.Close(); err != nil {
+				t.Fatalf("close child release: %v", err)
+			}
+
+			var result commandResult
+			select {
+			case result = <-resultCh:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for coverage child")
+			}
+			wantStdout := streamChildStdoutOne + streamChildStdoutTwo
+			wantStderr := streamChildStderrOne + streamChildStderrTwo
+			if result.stdout != wantStdout || result.stderr != wantStderr {
+				t.Fatalf("captured child output = (%q, %q), want byte-identical (%q, %q)", result.stdout, result.stderr, wantStdout, wantStderr)
+			}
+			if tc.exitCode == 0 && result.err != nil {
+				t.Fatalf("runCommand() error = %v, want nil", result.err)
+			}
+			if tc.exitCode != 0 && (result.err == nil || !strings.Contains(result.err.Error(), "exit status "+strconv.Itoa(tc.exitCode))) {
+				t.Fatalf("runCommand() error = %v, want exit status %d", result.err, tc.exitCode)
+			}
+			if tc.wantStream {
+				if got := stdoutSink.String(); got != wantStdout {
+					t.Fatalf("streamed stdout after child completion = %q, want %q", got, wantStdout)
+				}
+				if got := stderrSink.String(); got != wantStderr {
+					t.Fatalf("streamed stderr after child completion = %q, want %q", got, wantStderr)
+				}
+			} else {
+				if got := stdoutSink.String(); got != "" {
+					t.Fatalf("buffered stdout sink = %q, want no child bytes", got)
+				}
+				if got := stderrSink.String(); got != "" {
+					t.Fatalf("buffered stderr sink = %q, want no child bytes", got)
+				}
+			}
+		})
+	}
+}
+
+func TestGocoveragecheckStreamChildProcess(t *testing.T) {
+	if os.Getenv(streamChildEnv) != "1" {
+		return
+	}
+	_, _ = io.WriteString(os.Stdout, streamChildStdoutOne)
+	_, _ = io.WriteString(os.Stderr, streamChildStderrOne)
+	_, _ = io.WriteString(os.Stdout, streamChildStdoutTwo)
+	_, _ = io.WriteString(os.Stderr, streamChildStderrTwo)
+
+	var release [1]byte
+	if _, err := io.ReadFull(os.Stdin, release[:]); err != nil {
+		os.Exit(8)
+	}
+	exitCode, err := strconv.Atoi(os.Getenv(streamChildExitEnv))
+	if err != nil {
+		os.Exit(9)
+	}
+	os.Exit(exitCode)
+}
+
+func TestMainStreamFlagConfiguresOnlyCoverageChildOutput(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		stream bool
+	}{
+		{name: "omitted", stream: false},
+		{name: "enabled", stream: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotStdoutWriter io.Writer
+			var gotStderrWriter io.Writer
+			runner := func(invocation commandInvocation) (string, string, error) {
+				if len(invocation.args) == 0 || invocation.args[0] != "test" {
+					return "", "", fmt.Errorf("unexpected invocation: %v", invocation.args)
+				}
+				gotStdoutWriter = invocation.stdoutWriter
+				gotStderrWriter = invocation.stderrWriter
+				profilePath := helperCoverProfilePath(invocation.args)
+				if err := writeFakeCoverageProfile(profilePath, "mode: count\n"+modulePath+"/pkg/config/config.go:1.1,2.1 1 1\n"); err != nil {
+					return "", "", err
+				}
+				return "", "", nil
+			}
+			args := []string{
+				"-min=0",
+				"-total-only",
+				"-coverpkg=" + modulePath + "/pkg/config",
+				"-packages=./pkg/config",
+			}
+			if tc.stream {
+				args = append(args, "-stream")
+			}
+			_, stderr, exitCode := runMainForTest(t, args, runner)
+			if exitCode != 0 || stderr != "" {
+				t.Fatalf("main() result = exit %d, stderr %q, want success", exitCode, stderr)
+			}
+			if (gotStdoutWriter != nil) != tc.stream || (gotStderrWriter != nil) != tc.stream {
+				t.Fatalf("coverage invocation stream writers = (%v, %v), want enabled=%v", gotStdoutWriter != nil, gotStderrWriter != nil, tc.stream)
+			}
+		})
+	}
+}
+
+type streamCapture struct {
+	mu          sync.Mutex
+	data        bytes.Buffer
+	expectedLen int
+	complete    chan struct{}
+	once        sync.Once
+}
+
+func newStreamCapture(expected string) *streamCapture {
+	return &streamCapture{
+		expectedLen: len(expected),
+		complete:    make(chan struct{}),
+	}
+}
+
+func (w *streamCapture) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	n, err := w.data.Write(data)
+	if w.data.Len() >= w.expectedLen {
+		w.once.Do(func() { close(w.complete) })
+	}
+	return n, err
+}
+
+func (w *streamCapture) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.data.String()
+}
+
+func waitForStreamCapture(t *testing.T, written <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-written:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for streamed child output")
+	}
+}

--- a/cmd/gocoveragecheck/stream_test.go
+++ b/cmd/gocoveragecheck/stream_test.go
@@ -222,6 +222,96 @@ func TestMainStreamFlagConfiguresOnlyCoverageChildOutput(t *testing.T) {
 	}
 }
 
+func TestCompletedCoverageStreamModePreservesCoverageAndVerdict(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	t.Cleanup(func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	})
+
+	configPackage := modulePath + "/pkg/config"
+	for _, tc := range []struct {
+		name string
+		min  float64
+	}{
+		{name: "passing", min: 80},
+		{name: "failing", min: 101},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			observations := make([]completedCoverageObservation, 0, 2)
+			for _, stream := range []bool{false, true} {
+				var stdout bytes.Buffer
+				var stderr bytes.Buffer
+				stdoutWriter = &stdout
+				stderrWriter = &stderr
+				commandRunner = func(invocation commandInvocation) (string, string, error) {
+					childStdout, childStderr, err := fakeGoCoverageCommandPassing(invocation)
+					if invocation.stdoutWriter != nil {
+						if _, writeErr := io.WriteString(invocation.stdoutWriter, childStdout); writeErr != nil {
+							return childStdout, childStderr, writeErr
+						}
+					}
+					if invocation.stderrWriter != nil {
+						if _, writeErr := io.WriteString(invocation.stderrWriter, childStderr); writeErr != nil {
+							return childStdout, childStderr, writeErr
+						}
+					}
+					return childStdout, childStderr, err
+				}
+
+				runErr := execute(config{
+					min:       tc.min,
+					totalOnly: true,
+					coverpkg:  configPackage,
+					packages:  "./pkg/config",
+					stream:    stream,
+				})
+				match := totalCoveragePattern.FindStringSubmatch(stdout.String())
+				if len(match) != 2 {
+					t.Fatalf("stream=%v stdout = %q, want total coverage percentage", stream, stdout.String())
+				}
+				observations = append(observations, completedCoverageObservation{
+					stream:     stream,
+					percentage: match[1],
+					verdict:    errorString(runErr),
+				})
+				if stderr.Len() != 0 {
+					t.Fatalf("stream=%v stderr = %q, want empty", stream, stderr.String())
+				}
+			}
+
+			if observations[0].percentage != observations[1].percentage {
+				t.Fatalf("coverage percentage buffered=%q, streamed=%q, want identical", observations[0].percentage, observations[1].percentage)
+			}
+			if observations[0].verdict != observations[1].verdict {
+				t.Fatalf("coverage verdict buffered=%q, streamed=%q, want identical", observations[0].verdict, observations[1].verdict)
+			}
+			if tc.min <= 100 && observations[0].verdict != "" {
+				t.Fatalf("buffered verdict = %q, want pass", observations[0].verdict)
+			}
+			if tc.min > 100 && observations[0].verdict == "" {
+				t.Fatal("buffered verdict unexpectedly passed")
+			}
+		})
+	}
+}
+
+type completedCoverageObservation struct {
+	stream     bool
+	percentage string
+	verdict    string
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
 type streamCapture struct {
 	mu          sync.Mutex
 	data        bytes.Buffer

--- a/cmd/gocoveragecheck/stream_test.go
+++ b/cmd/gocoveragecheck/stream_test.go
@@ -22,6 +22,19 @@ const (
 	streamChildStderrTwo = "stderr child chunk two\n"
 )
 
+type streamChildTestCase struct {
+	name       string
+	stream     bool
+	exitCode   int
+	wantStream bool
+}
+
+type streamCommandResult struct {
+	stdout string
+	stderr string
+	err    error
+}
+
 func TestCommandRunnerStreamsCoverageChildOutputWithoutChangingCapturedBytes(t *testing.T) {
 	originalCommandRunner := commandRunner
 	originalExecCommand := execCommand
@@ -30,12 +43,7 @@ func TestCommandRunnerStreamsCoverageChildOutputWithoutChangingCapturedBytes(t *
 		execCommand = originalExecCommand
 	})
 
-	tests := []struct {
-		name       string
-		stream     bool
-		exitCode   int
-		wantStream bool
-	}{
+	tests := []streamChildTestCase{
 		{name: "buffered success", exitCode: 0},
 		{name: "streamed success", stream: true, exitCode: 0, wantStream: true},
 		{name: "buffered failure", exitCode: 7},
@@ -43,96 +51,111 @@ func TestCommandRunnerStreamsCoverageChildOutputWithoutChangingCapturedBytes(t *
 	}
 	for _, tc := range tests {
 		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			releaseReader, releaseWriter := io.Pipe()
-			t.Cleanup(func() { _ = releaseWriter.Close() })
-			execCommand = func(string, ...string) *exec.Cmd {
-				cmd := exec.Command(os.Args[0], "-test.run=TestGocoveragecheckStreamChildProcess", "--")
-				cmd.Stdin = releaseReader
-				return cmd
-			}
-			commandRunner = originalCommandRunner
+		t.Run(tc.name, func(t *testing.T) { runStreamChildCase(t, originalCommandRunner, tc) })
+	}
+}
 
-			stdoutSink := newStreamCapture(streamChildStdoutOne + streamChildStdoutTwo)
-			stderrSink := newStreamCapture(streamChildStderrOne + streamChildStderrTwo)
-			invocation := commandInvocation{
-				name: "coverage-test-child",
-				env: append(os.Environ(),
-					streamChildEnv+"=1",
-					streamChildExitEnv+"="+strconv.Itoa(tc.exitCode),
-				),
-			}
-			if tc.stream {
-				invocation.stdoutWriter = stdoutSink
-				invocation.stderrWriter = stderrSink
-			}
+func runStreamChildCase(t *testing.T, runner commandRunnerFunc, tc streamChildTestCase) {
+	stdoutSink := newStreamCapture(streamChildStdoutOne + streamChildStdoutTwo)
+	stderrSink := newStreamCapture(streamChildStderrOne + streamChildStderrTwo)
+	resultCh, releaseWriter := startStreamChild(t, runner, tc, stdoutSink, stderrSink)
+	if tc.wantStream {
+		assertStreamVisibleBeforeCompletion(t, resultCh, stdoutSink, stderrSink)
+	}
+	if _, err := releaseWriter.Write([]byte{1}); err != nil {
+		t.Fatalf("release child: %v", err)
+	}
+	if err := releaseWriter.Close(); err != nil {
+		t.Fatalf("close child release: %v", err)
+	}
+	result := waitForStreamChild(t, resultCh)
+	assertStreamChildResult(t, tc, result, stdoutSink, stderrSink)
+}
 
-			type commandResult struct {
-				stdout string
-				stderr string
-				err    error
-			}
-			resultCh := make(chan commandResult, 1)
-			go func() {
-				stdout, stderr, err := runCommand(invocation)
-				resultCh <- commandResult{stdout: stdout, stderr: stderr, err: err}
-			}()
+func startStreamChild(t *testing.T, runner commandRunnerFunc, tc streamChildTestCase, stdoutSink *streamCapture, stderrSink *streamCapture) (<-chan streamCommandResult, *io.PipeWriter) {
+	t.Helper()
+	releaseReader, releaseWriter := io.Pipe()
+	t.Cleanup(func() { _ = releaseWriter.Close() })
+	execCommand = func(string, ...string) *exec.Cmd {
+		cmd := exec.Command(os.Args[0], "-test.run=TestGocoveragecheckStreamChildProcess", "--")
+		cmd.Stdin = releaseReader
+		return cmd
+	}
+	commandRunner = runner
+	invocation := commandInvocation{
+		name: "coverage-test-child",
+		env: append(os.Environ(),
+			streamChildEnv+"=1",
+			streamChildExitEnv+"="+strconv.Itoa(tc.exitCode),
+		),
+	}
+	if tc.stream {
+		invocation.stdoutWriter = stdoutSink
+		invocation.stderrWriter = stderrSink
+	}
+	resultCh := make(chan streamCommandResult, 1)
+	go func() {
+		stdout, stderr, err := runCommand(invocation)
+		resultCh <- streamCommandResult{stdout: stdout, stderr: stderr, err: err}
+	}()
+	return resultCh, releaseWriter
+}
 
-			if tc.wantStream {
-				waitForStreamCapture(t, stdoutSink.complete)
-				waitForStreamCapture(t, stderrSink.complete)
-				if got := stdoutSink.String(); got != streamChildStdoutOne+streamChildStdoutTwo {
-					t.Fatalf("streamed stdout before child completion = %q, want first two chunks", got)
-				}
-				if got := stderrSink.String(); got != streamChildStderrOne+streamChildStderrTwo {
-					t.Fatalf("streamed stderr before child completion = %q, want first two chunks", got)
-				}
-				select {
-				case result := <-resultCh:
-					t.Fatalf("child completed before release: %+v", result)
-				default:
-				}
-			}
-			if _, err := releaseWriter.Write([]byte{1}); err != nil {
-				t.Fatalf("release child: %v", err)
-			}
-			if err := releaseWriter.Close(); err != nil {
-				t.Fatalf("close child release: %v", err)
-			}
+func assertStreamVisibleBeforeCompletion(t *testing.T, resultCh <-chan streamCommandResult, stdoutSink *streamCapture, stderrSink *streamCapture) {
+	t.Helper()
+	waitForStreamCapture(t, stdoutSink.complete)
+	waitForStreamCapture(t, stderrSink.complete)
+	if got := stdoutSink.String(); got != streamChildStdoutOne+streamChildStdoutTwo {
+		t.Fatalf("streamed stdout before child completion = %q, want first two chunks", got)
+	}
+	if got := stderrSink.String(); got != streamChildStderrOne+streamChildStderrTwo {
+		t.Fatalf("streamed stderr before child completion = %q, want first two chunks", got)
+	}
+	select {
+	case result := <-resultCh:
+		t.Fatalf("child completed before release: %+v", result)
+	default:
+	}
+}
 
-			var result commandResult
-			select {
-			case result = <-resultCh:
-			case <-time.After(5 * time.Second):
-				t.Fatal("timed out waiting for coverage child")
-			}
-			wantStdout := streamChildStdoutOne + streamChildStdoutTwo
-			wantStderr := streamChildStderrOne + streamChildStderrTwo
-			if result.stdout != wantStdout || result.stderr != wantStderr {
-				t.Fatalf("captured child output = (%q, %q), want byte-identical (%q, %q)", result.stdout, result.stderr, wantStdout, wantStderr)
-			}
-			if tc.exitCode == 0 && result.err != nil {
-				t.Fatalf("runCommand() error = %v, want nil", result.err)
-			}
-			if tc.exitCode != 0 && (result.err == nil || !strings.Contains(result.err.Error(), "exit status "+strconv.Itoa(tc.exitCode))) {
-				t.Fatalf("runCommand() error = %v, want exit status %d", result.err, tc.exitCode)
-			}
-			if tc.wantStream {
-				if got := stdoutSink.String(); got != wantStdout {
-					t.Fatalf("streamed stdout after child completion = %q, want %q", got, wantStdout)
-				}
-				if got := stderrSink.String(); got != wantStderr {
-					t.Fatalf("streamed stderr after child completion = %q, want %q", got, wantStderr)
-				}
-			} else {
-				if got := stdoutSink.String(); got != "" {
-					t.Fatalf("buffered stdout sink = %q, want no child bytes", got)
-				}
-				if got := stderrSink.String(); got != "" {
-					t.Fatalf("buffered stderr sink = %q, want no child bytes", got)
-				}
-			}
-		})
+func waitForStreamChild(t *testing.T, resultCh <-chan streamCommandResult) streamCommandResult {
+	t.Helper()
+	select {
+	case result := <-resultCh:
+		return result
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for coverage child")
+		return streamCommandResult{}
+	}
+}
+
+func assertStreamChildResult(t *testing.T, tc streamChildTestCase, result streamCommandResult, stdoutSink *streamCapture, stderrSink *streamCapture) {
+	t.Helper()
+	wantStdout := streamChildStdoutOne + streamChildStdoutTwo
+	wantStderr := streamChildStderrOne + streamChildStderrTwo
+	if result.stdout != wantStdout || result.stderr != wantStderr {
+		t.Fatalf("captured child output = (%q, %q), want byte-identical (%q, %q)", result.stdout, result.stderr, wantStdout, wantStderr)
+	}
+	if tc.exitCode == 0 && result.err != nil {
+		t.Fatalf("runCommand() error = %v, want nil", result.err)
+	}
+	if tc.exitCode != 0 && (result.err == nil || !strings.Contains(result.err.Error(), "exit status "+strconv.Itoa(tc.exitCode))) {
+		t.Fatalf("runCommand() error = %v, want exit status %d", result.err, tc.exitCode)
+	}
+	if tc.wantStream {
+		if got := stdoutSink.String(); got != wantStdout {
+			t.Fatalf("streamed stdout after child completion = %q, want %q", got, wantStdout)
+		}
+		if got := stderrSink.String(); got != wantStderr {
+			t.Fatalf("streamed stderr after child completion = %q, want %q", got, wantStderr)
+		}
+		return
+	}
+	if got := stdoutSink.String(); got != "" {
+		t.Fatalf("buffered stdout sink = %q, want no child bytes", got)
+	}
+	if got := stderrSink.String(); got != "" {
+		t.Fatalf("buffered stderr sink = %q, want no child bytes", got)
 	}
 }
 
@@ -230,10 +253,10 @@ func (w *streamCapture) String() string {
 	return w.data.String()
 }
 
-func waitForStreamCapture(t *testing.T, written <-chan struct{}) {
+func waitForStreamCapture(t *testing.T, complete <-chan struct{}) {
 	t.Helper()
 	select {
-	case <-written:
+	case <-complete:
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for streamed child output")
 	}


### PR DESCRIPTION
{
  "project": "Stream gocoveragecheck Child Output on Demand",
  "branchName": "thr-coverage-runner-stream-child-output",
  "description": "Add an explicit, default-off streaming mode to gocoveragecheck so long-running coverage-test child stdout and stderr are observable before the child exits, while preserving byte-for-byte buffered copies and leaving all coverage calculations, policies, and verdicts unchanged.",
  "context": {
    "customerAsk": "Make the coverage runner optionally tee coverage-test child stdout and stderr to its existing output sinks as the child writes them, while preserving the buffered output consumed by existing coverage logic. Keep streaming off by default, retain the commandRunnerFunc and execCommand seams, and prove interrupted-run diagnostics plus completed-result parity.",
    "problem": "cmd/gocoveragecheck currently buffers both child streams only in memory until cmd.Run returns. Two interrupted Windows make test-unit-coverage probes each captured only the Make recipe echo and zero child lines, so a stopped, hung, timed-out, or abnormally terminated multi-hundred-package run reveals neither progress nor the package near failure.",
    "solution": "Add a default-off -stream flag, propagate it explicitly only to coverage-test child invocations, and tee each enabled child stream to its corresponding existing sink and its unchanged in-memory buffer. Preserve separate byte-for-byte captured strings for parsing and diagnostics, and verify default behavior, interruption visibility, and result parity without changing concurrency, profile merging, baselines, manifests, or coverage policy."
  },
  "acceptanceCriteria": [
    "With -stream enabled, interrupting a real coverage run after child progress begins leaves captured output containing at least one real ok <package> or test line; the PR evidence names the command, the package count reached, and contrasts it with the measured before state of only the Make recipe echo and zero child lines.",
    "Without -stream, including when the flag is omitted, child stdout and stderr remain buffer-only until the child returns and externally captured output matches the current default behavior.",
    "For a child that writes known content to both streams, streaming on and off return byte-for-byte identical buffered stdout and stderr strings, and streamed bytes go to their corresponding existing output sinks without cross-routing.",
    "A completing focused coverage run produces the same coverage percentage and pass/fail verdict with streaming on and off; if missing covdata.exe blocks profile processing, the PR reports the block plainly and relies on focused tests plus buffered-copy parity without claiming an unobserved number.",
    "The commandRunnerFunc and execCommand seams remain supported, and the diff does not alter testJobs/-p concurrency, covdata/profile merging, coverage calculations, baselines, manifests, Makefile coverage minimums, generated files, or surfaces outside cmd/gocoveragecheck and its tests.",
    "Quality gates pass: Typecheck passes; Tests pass for cmd/gocoveragecheck; make pkg-file-count does not rise; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are resolved against current origin/main, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "thr-coverage-runner-stream-child-output-001",
      "title": "Stream child output without changing captured bytes",
      "description": "As an operator, I want an explicit streaming mode for coverage-test child output so I can see progress and diagnostics during a long run without changing the data the tool later evaluates.",
      "acceptanceCriteria": [
        "gocoveragecheck -stream forwards each coverage-test child's stdout to stdoutWriter and stderr to stderrWriter as data is written, before the child returns.",
        "Omitting -stream, or explicitly disabling it, retains buffer-only execution and emits no child bytes through the streaming sinks while the child is running.",
        "A deterministic fake-child regression test writes multiple known chunks to both streams and proves that returned stdout and stderr are byte-for-byte identical with streaming enabled and disabled.",
        "The same test proves streamed stdout and stderr reach only their corresponding sink and are observable before child completion, including when the child exits with an error.",
        "Existing tests that replace commandRunner or execCommand continue to work through the unchanged commandRunnerFunc contract; streaming policy is explicit on the coverage-test invocation rather than hidden in parsing or global coverage policy.",
        "Coverage parsing, result formatting, profile handling, package gates, timing/variance behavior, and JSON output receive the same captured content as before.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added default-off -stream coverage-child teeing, preserved commandRunnerFunc and execCommand seams, and added chunked success/failure byte-parity and flag-propagation tests. Focused package tests and vet pass."
    },
    {
      "id": "thr-coverage-runner-stream-child-output-002",
      "title": "Prove interrupted diagnostics and unchanged coverage results",
      "description": "As a maintainer, I want direct evidence from interrupted and completed coverage runs so I can trust that streaming improves diagnosability without changing coverage decisions.",
      "acceptanceCriteria": [
        "A real -stream coverage run is interrupted only after output contains at least one real ok <package> or test line; retained evidence states the exact command and the number of packages observed before interruption.",
        "The evidence explicitly contrasts the streamed result with the measured default-off before state: one Make recipe echo line and zero child-output lines from each of two prior interrupted probes.",
        "A focused completing coverage case run with streaming off and on reports the same coverage percentage and the same pass/fail verdict, with commands and results recorded in the PR comment rather than committed as an evidence artifact.",
        "If missing covdata.exe prevents a completing coverage result, the PR identifies go: no such tool \"covdata\" as an environment block, does not edit or work around the Go installation, and does not claim an unobserved percentage; focused tests and byte-parity evidence still pass.",
        "The final diff remains limited to cmd/gocoveragecheck and its tests, does not raise the package-file-count baseline, and contains no coverage profiles or other generated probe artifacts.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added completed-run coverage percentage/verdict parity regression coverage. Real evidence: two default-off Make probes were interrupted after 20s with one recipe echo and zero child ok lines each; go run ... -stream was interrupted after one child ok line for pkg/initializer/application appeared before completion; focused ./pkg/initializer/application runs reported 79.9% and pass with streaming off and on. Focused tests, full Go vet, typecheck, pkg-maint, pkg-file-count, and pkg-structure pass. Existing backend-size and broader lint baseline/deadcode findings remain outside this diff."
    }
  ]
}
