### PR TITLE
thr-deflake-factory-graph-editor-browser-integration

### DIFF
--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -145,6 +145,87 @@ export async function waitForDurableControlEnabled(
   );
 }
 
+function boundingBoxesEqual(left, right) {
+  return (
+    left !== null &&
+    right !== null &&
+    left.x === right.x &&
+    left.y === right.y &&
+    left.width === right.width &&
+    left.height === right.height
+  );
+}
+
+/** Wait until a browser element reports the same geometry on two observations. */
+export async function waitForStableBoundingBox(
+  locator,
+  timeoutMs = uiInteractionTimeoutMs,
+  intervalMs = 100,
+) {
+  let previousBox = null;
+  let stableBox = null;
+
+  await waitForDurableCheckpoint(
+    "stable bounding box",
+    async () => {
+      const nextBox = await locator.boundingBox().catch(() => null);
+      const stable = boundingBoxesEqual(previousBox, nextBox);
+      previousBox = nextBox;
+
+      if (!stable) {
+        return false;
+      }
+
+      stableBox = nextBox;
+      return true;
+    },
+    timeoutMs,
+    intervalMs,
+  );
+
+  return stableBox;
+}
+
+/** Wait until React Flow has measured every graph node for selection gestures. */
+export async function waitForFactoryGraphSelectionReady(
+  page,
+  timeoutMs = uiInteractionTimeoutMs,
+) {
+  const readinessMarker = page.locator(
+    '[data-factory-graph-selection-ready="true"]',
+  );
+
+  await waitForDurableCheckpoint(
+    "factory graph selection readiness",
+    async () => (await readinessMarker.count()) > 0,
+    timeoutMs,
+  );
+}
+
+/** Wait for the graph selection projection and its enabled batch-delete action. */
+export async function waitForFactoryGraphSelectionDeleteButton(
+  toolbar,
+  timeoutMs = uiInteractionTimeoutMs,
+) {
+  const selectedGraphSelection = toolbar.locator(
+    '[data-toolbar-graph-selection="single"], [data-toolbar-graph-selection="multi"]',
+  );
+  const batchDeleteButton = toolbar.getByRole("button", {
+    name: /^Delete (?:\d+ )?selected graph items?$/,
+  });
+
+  await waitForDurableCheckpoint(
+    "factory graph selection delete control",
+    async () =>
+      (await selectedGraphSelection.isVisible().catch(() => false)) &&
+      (await batchDeleteButton.isVisible().catch(() => false)) &&
+      (await batchDeleteButton.isEnabled().catch(() => false)),
+    timeoutMs,
+  );
+
+  return batchDeleteButton;
+}
+
 /**
  * Wait for a Radix/dialog surface to close using dialog role state instead of
  * heading copy that may unmount asynchronously.

--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -186,6 +186,144 @@ export async function waitForStableBoundingBox(
   return stableBox;
 }
 
+/** Wait until React Flow has committed the same viewport transform twice. */
+export async function waitForStableFactoryGraphViewport(
+  page,
+  timeoutMs = uiInteractionTimeoutMs,
+  intervalMs = 100,
+) {
+  const flowViewport = page.locator(
+    "[data-current-activity-flow] .react-flow__viewport",
+  );
+  let previousTransform = null;
+  let stableTransform = null;
+
+  await waitForDurableCheckpoint(
+    "factory graph viewport settlement",
+    async () => {
+      const nextTransform = await flowViewport
+        .evaluate((element) => window.getComputedStyle(element).transform)
+        .catch(() => null);
+      const stable =
+        nextTransform !== null && nextTransform === previousTransform;
+      previousTransform = nextTransform;
+
+      if (!stable) {
+        return false;
+      }
+
+      stableTransform = nextTransform;
+      return true;
+    },
+    timeoutMs,
+    intervalMs,
+  );
+
+  return stableTransform;
+}
+
+function graphNodePlacementSamplesEqual(left, right) {
+  if (!left || !right) {
+    return false;
+  }
+
+  return (
+    left.nodeTransform === right.nodeTransform &&
+    left.viewportTransform === right.viewportTransform &&
+    left.node.x === right.node.x &&
+    left.node.y === right.node.y &&
+    left.node.width === right.node.width &&
+    left.node.height === right.node.height &&
+    left.viewport.x === right.viewport.x &&
+    left.viewport.y === right.viewport.y &&
+    left.viewport.width === right.viewport.width &&
+    left.viewport.height === right.viewport.height
+  );
+}
+
+function graphNodePlacementIsWithinViewport(sample) {
+  const nodeCenterX = sample.node.x + sample.node.width / 2;
+  const nodeCenterY = sample.node.y + sample.node.height / 2;
+  return (
+    nodeCenterX >= sample.viewport.x &&
+    nodeCenterX <= sample.viewport.x + sample.viewport.width &&
+    nodeCenterY >= sample.viewport.y &&
+    nodeCenterY <= sample.viewport.y + sample.viewport.height
+  );
+}
+
+/**
+ * Wait until a graph node's DOM geometry and both React Flow transforms settle
+ * while its center is inside the visible graph viewport.
+ */
+export async function waitForStableFactoryGraphNodePlacement(
+  page,
+  nodeTestId,
+  timeoutMs = uiInteractionTimeoutMs,
+  intervalMs = 100,
+) {
+  let previousSample = null;
+  let stableSample = null;
+
+  await waitForDurableCheckpoint(
+    `factory graph node placement: ${nodeTestId}`,
+    async () => {
+      const nextSample = await page
+        .evaluate((testId) => {
+          const target = [...document.querySelectorAll("[data-testid]")].find(
+            (element) => element.getAttribute("data-testid") === testId,
+          );
+          const flowNode = target?.closest(".react-flow__node");
+          const graphSurface = target?.closest("[data-current-activity-flow]");
+          const flowViewport = flowNode
+            ?.closest(".react-flow")
+            ?.querySelector(".react-flow__viewport");
+
+          if (!target || !flowNode || !graphSurface || !flowViewport) {
+            return null;
+          }
+
+          const nodeBox = target.getBoundingClientRect();
+          const viewportBox = graphSurface.getBoundingClientRect();
+          return {
+            node: {
+              height: nodeBox.height,
+              width: nodeBox.width,
+              x: nodeBox.x,
+              y: nodeBox.y,
+            },
+            nodeTransform: window.getComputedStyle(flowNode).transform,
+            viewport: {
+              height: viewportBox.height,
+              width: viewportBox.width,
+              x: viewportBox.x,
+              y: viewportBox.y,
+            },
+            viewportTransform: window.getComputedStyle(flowViewport).transform,
+          };
+        }, nodeTestId)
+        .catch(() => null);
+      const stable = graphNodePlacementSamplesEqual(previousSample, nextSample);
+      previousSample = nextSample;
+
+      if (
+        !stable ||
+        !nextSample ||
+        !graphNodePlacementIsWithinViewport(nextSample)
+      ) {
+        return false;
+      }
+
+      stableSample = nextSample;
+      return true;
+    },
+    timeoutMs,
+    intervalMs,
+  );
+
+  return stableSample;
+}
+
 /** Wait until React Flow has measured every graph node for selection gestures. */
 export async function waitForFactoryGraphSelectionReady(
   page,

--- a/ui/integration/browser-test-harness.wait-patterns.test.mjs
+++ b/ui/integration/browser-test-harness.wait-patterns.test.mjs
@@ -13,6 +13,9 @@ import {
   waitForDialogHidden,
   waitForDurableCheckpoint,
   waitForDurableControlEnabled,
+  waitForFactoryGraphSelectionDeleteButton,
+  waitForFactoryGraphSelectionReady,
+  waitForStableBoundingBox,
 } from "./browser-test-harness.mjs";
 
 describe("browser wait pattern helpers", () => {
@@ -43,6 +46,61 @@ describe("browser wait pattern helpers", () => {
     await waitForDurableControlEnabled(locator, uiInteractionTimeoutMs);
 
     expect(locator.isEnabled).toHaveBeenCalledTimes(2);
+  });
+
+  it("waitForStableBoundingBox observes two matching geometry samples", async () => {
+    const stableBox = { height: 40, width: 80, x: 12, y: 24 };
+    const locator = {
+      boundingBox: vi
+        .fn()
+        .mockResolvedValueOnce({ ...stableBox, x: 8 })
+        .mockResolvedValue(stableBox),
+    };
+
+    await expect(waitForStableBoundingBox(locator, 500, 1)).resolves.toEqual(
+      stableBox,
+    );
+    expect(locator.boundingBox).toHaveBeenCalledTimes(3);
+  });
+
+  it("waitForFactoryGraphSelectionReady waits for measured graph internals", async () => {
+    const readinessMarker = {
+      count: vi.fn().mockResolvedValueOnce(0).mockResolvedValue(1),
+    };
+    const page = {
+      locator: vi.fn(() => readinessMarker),
+    };
+
+    await waitForFactoryGraphSelectionReady(page, 500);
+
+    expect(page.locator).toHaveBeenCalledWith(
+      '[data-factory-graph-selection-ready="true"]',
+    );
+    expect(readinessMarker.count).toHaveBeenCalledTimes(2);
+  });
+
+  it("waitForFactoryGraphSelectionDeleteButton waits for the selected enabled control", async () => {
+    const selectedGraphSelection = {
+      isVisible: vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true),
+    };
+    const batchDeleteButton = {
+      isEnabled: vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true),
+      isVisible: vi.fn().mockResolvedValue(true),
+    };
+    const toolbar = {
+      getByRole: vi.fn(() => batchDeleteButton),
+      locator: vi.fn(() => selectedGraphSelection),
+    };
+
+    await expect(
+      waitForFactoryGraphSelectionDeleteButton(toolbar, 500),
+    ).resolves.toBe(batchDeleteButton);
+    expect(toolbar.locator).toHaveBeenCalledWith(
+      '[data-toolbar-graph-selection="single"], [data-toolbar-graph-selection="multi"]',
+    );
+    expect(toolbar.getByRole).toHaveBeenCalledWith("button", {
+      name: /^Delete (?:\d+ )?selected graph items?$/,
+    });
   });
 
   it("waitForDialogHidden waits for dialog role hidden state", async () => {
@@ -88,7 +146,9 @@ describe("browser wait pattern helpers", () => {
       expect,
     );
   });
+});
 
+describe("browser harness server", () => {
   it("serves sync preflight responses with the required identity set", async () => {
     const server = await startFactoryApiServer({
       apiPort: 3921,

--- a/ui/integration/browser-test-harness.wait-patterns.test.mjs
+++ b/ui/integration/browser-test-harness.wait-patterns.test.mjs
@@ -16,6 +16,8 @@ import {
   waitForFactoryGraphSelectionDeleteButton,
   waitForFactoryGraphSelectionReady,
   waitForStableBoundingBox,
+  waitForStableFactoryGraphNodePlacement,
+  waitForStableFactoryGraphViewport,
 } from "./browser-test-harness.mjs";
 
 describe("browser wait pattern helpers", () => {
@@ -62,7 +64,63 @@ describe("browser wait pattern helpers", () => {
     );
     expect(locator.boundingBox).toHaveBeenCalledTimes(3);
   });
+});
 
+describe("factory graph wait helpers", () => {
+  it("waitForStableFactoryGraphViewport observes two matching transforms", async () => {
+    const flowViewport = {
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce("matrix(1, 0, 0, 1, 0, 0)")
+        .mockResolvedValue("matrix(1, 0, 0, 1, 20, -12)"),
+    };
+    const page = {
+      locator: vi.fn(() => flowViewport),
+    };
+
+    await expect(waitForStableFactoryGraphViewport(page, 500, 1)).resolves.toBe(
+      "matrix(1, 0, 0, 1, 20, -12)",
+    );
+    expect(page.locator).toHaveBeenCalledWith(
+      "[data-current-activity-flow] .react-flow__viewport",
+    );
+    expect(flowViewport.evaluate).toHaveBeenCalledTimes(3);
+  });
+
+  it("waitForStableFactoryGraphNodePlacement observes settled geometry and transforms", async () => {
+    const sample = {
+      node: { height: 120, width: 180, x: 420, y: 260 },
+      nodeTransform: "translate(420px, 260px)",
+      viewport: { height: 720, width: 1280, x: 0, y: 0 },
+      viewportTransform: "matrix(1, 0, 0, 1, -80, 40)",
+    };
+    const page = {
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ...sample,
+          node: { ...sample.node, x: 1200 },
+        })
+        .mockResolvedValue(sample),
+    };
+
+    await expect(
+      waitForStableFactoryGraphNodePlacement(
+        page,
+        "rf__node-workstation:review",
+        500,
+        1,
+      ),
+    ).resolves.toEqual(sample);
+    expect(page.evaluate).toHaveBeenCalledWith(
+      expect.any(Function),
+      "rf__node-workstation:review",
+    );
+    expect(page.evaluate).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("browser wait pattern helpers", () => {
   it("waitForFactoryGraphSelectionReady waits for measured graph internals", async () => {
     const readinessMarker = {
       count: vi.fn().mockResolvedValueOnce(0).mockResolvedValue(1),

--- a/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
@@ -12,6 +12,8 @@ import {
   selectLabeledComboboxOption,
   startFactoryApiServer,
   uiInteractionTimeoutMs,
+  waitForStableFactoryGraphNodePlacement,
+  waitForStableFactoryGraphViewport,
 } from "./browser-test-harness.mjs";
 import { waitForDashboardReady } from "./factory-name-preservation-browser-helpers.mjs";
 import { isolatedMockBrowserTest as it } from "./mocked-browser-test-fixture.mjs";
@@ -498,19 +500,17 @@ describe.concurrent("factory graph editor node placement browser integration", (
 
         const toolbar = await enterGraphEditor(browserPage.page);
         await panGraphViewport(browserPage.page, -220, 160);
+        await waitForStableFactoryGraphViewport(browserPage.page);
 
         await addWorkstation(browserPage.page, toolbar, {
           body: "Review the drafted story.",
           name: "review",
         });
 
-        const workstationNode = browserPage.page.getByTestId(
+        await waitForStableFactoryGraphNodePlacement(
+          browserPage.page,
           "rf__node-workstation:review",
         );
-        await workstationNode.waitFor({
-          state: "visible",
-          timeout: uiInteractionTimeoutMs,
-        });
 
         const viewportMetrics = await viewportScreenMetrics(browserPage.page);
         const addedWorkstationCenter = await nodeScreenCenter(
@@ -563,26 +563,20 @@ describe.concurrent("factory graph editor node placement browser integration", (
         const toolbar = await enterGraphEditor(browserPage.page);
         await addWorker(browserPage.page, toolbar, { name: "center-anchor" });
 
-        const anchorNode = browserPage.page.getByTestId(
+        await waitForStableFactoryGraphNodePlacement(
+          browserPage.page,
           "rf__node-worker:center-anchor",
         );
-        await anchorNode.waitFor({
-          state: "visible",
-          timeout: uiInteractionTimeoutMs,
-        });
 
         await addWorkstation(browserPage.page, toolbar, {
           body: "Review the drafted story.",
           name: "review",
         });
 
-        const workstationNode = browserPage.page.getByTestId(
+        await waitForStableFactoryGraphNodePlacement(
+          browserPage.page,
           "rf__node-workstation:review",
         );
-        await workstationNode.waitFor({
-          state: "visible",
-          timeout: uiInteractionTimeoutMs,
-        });
 
         const anchorBox = await nodeBoundingBox(
           browserPage.page,
@@ -631,6 +625,7 @@ describe.concurrent("factory graph editor node placement browser integration", (
 
         const toolbar = await enterGraphEditor(browserPage.page);
         await panGraphViewport(browserPage.page, -180, 140);
+        await waitForStableFactoryGraphViewport(browserPage.page);
 
         await addWorkstation(browserPage.page, toolbar, {
           body: "Review the drafted story.",
@@ -638,9 +633,10 @@ describe.concurrent("factory graph editor node placement browser integration", (
         });
 
         const workstationTestId = "rf__node-workstation:review";
-        await browserPage.page
-          .getByTestId(workstationTestId)
-          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+        await waitForStableFactoryGraphNodePlacement(
+          browserPage.page,
+          workstationTestId,
+        );
 
         const positionBeforeSave = await readNodeFlowPosition(
           browserPage.page,

--- a/ui/integration/factory-graph-editor-selection-no-panel-delete.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-selection-no-panel-delete.integration.test.mjs
@@ -10,6 +10,9 @@ import {
   selectLabeledComboboxOption,
   startFactoryApiServer,
   uiInteractionTimeoutMs,
+  waitForFactoryGraphSelectionDeleteButton,
+  waitForFactoryGraphSelectionReady,
+  waitForStableBoundingBox,
 } from "./browser-test-harness.mjs";
 import { isolatedMockBrowserTest as it } from "./mocked-browser-test-fixture.mjs";
 
@@ -189,7 +192,7 @@ async function assertNoPanelTopologyDeleteInCurrentSelection(page) {
 }
 
 async function marqueeSelectGraphNode(page, nodeLocator) {
-  const nodeBox = await nodeLocator.boundingBox();
+  const nodeBox = await waitForStableBoundingBox(nodeLocator);
   if (!nodeBox) {
     throw new Error(
       "Expected graph node to have a bounding box for marquee selection.",
@@ -355,14 +358,20 @@ describe.concurrent("factory graph editor selection panel delete browser integra
         const spareGraphNode = browserPage.page.getByTestId(
           "rf__node-worker:spare",
         );
+        await waitForFactoryGraphSelectionReady(browserPage.page);
         await marqueeSelectGraphNode(browserPage.page, spareGraphNode);
 
-        const batchDeleteButton = toolbar.getByRole("button", {
-          name: "Delete selected graph item",
-        });
+        const batchDeleteButton =
+          await waitForFactoryGraphSelectionDeleteButton(toolbar);
         await batchDeleteButton.scrollIntoViewIfNeeded();
         expect(await batchDeleteButton.isDisabled()).toBe(false);
-        await batchDeleteButton.click();
+        await batchDeleteButton.focus();
+        expect(
+          await batchDeleteButton.evaluate(
+            (button) => button === document.activeElement,
+          ),
+        ).toBe(true);
+        await batchDeleteButton.press("Enter");
 
         await expect
           .poll(

--- a/ui/src/features/workflow-activity/components/activity-card/react-flow-current-activity-card-viewport-editor-layout.test.tsx
+++ b/ui/src/features/workflow-activity/components/activity-card/react-flow-current-activity-card-viewport-editor-layout.test.tsx
@@ -7,6 +7,7 @@ import { CurrentActivityGraphViewport } from "../react-flow-current-activity-car
 
 vi.mock("@xyflow/react", async () => {
   const actual = await vi.importActual("@xyflow/react");
+  const { ReactFlowProvider } = actual;
 
   return {
     ...actual,
@@ -58,47 +59,49 @@ vi.mock("@xyflow/react", async () => {
       }, [onInit, onMoveEnd]);
 
       return (
-        <div
-          className={className}
-          data-default-viewport={JSON.stringify(defaultViewport ?? null)}
-          data-fit-view={String(fitView ?? false)}
-          data-testid="mock-react-flow"
-        >
-          <button
-            onClick={() => onMoveEnd?.(null, { x: 12, y: 34, zoom: 1.25 })}
-            type="button"
+        <ReactFlowProvider>
+          <div
+            className={className}
+            data-default-viewport={JSON.stringify(defaultViewport ?? null)}
+            data-fit-view={String(fitView ?? false)}
+            data-testid="mock-react-flow"
           >
-            pan-viewport
-          </button>
-          <button
-            onClick={() => {
-              const draggedNodes = (nodes ?? []).filter(
-                (node) => node.selected,
-              );
-              const primaryNode = draggedNodes[0] ?? nodes?.[0];
-              if (!primaryNode) {
-                return;
-              }
+            <button
+              onClick={() => onMoveEnd?.(null, { x: 12, y: 34, zoom: 1.25 })}
+              type="button"
+            >
+              pan-viewport
+            </button>
+            <button
+              onClick={() => {
+                const draggedNodes = (nodes ?? []).filter(
+                  (node) => node.selected,
+                );
+                const primaryNode = draggedNodes[0] ?? nodes?.[0];
+                if (!primaryNode) {
+                  return;
+                }
 
-              onNodeDragStart?.(null, primaryNode, nodes ?? []);
-              onNodeDragStop?.(
-                null,
-                {
-                  ...primaryNode,
-                  position: {
-                    x: primaryNode.position.x + 16,
-                    y: primaryNode.position.y + 8,
+                onNodeDragStart?.(null, primaryNode, nodes ?? []);
+                onNodeDragStop?.(
+                  null,
+                  {
+                    ...primaryNode,
+                    position: {
+                      x: primaryNode.position.x + 16,
+                      y: primaryNode.position.y + 8,
+                    },
                   },
-                },
-                nodes ?? [],
-              );
-            }}
-            type="button"
-          >
-            drag-selected-nodes
-          </button>
-          {children}
-        </div>
+                  nodes ?? [],
+                );
+              }}
+              type="button"
+            >
+              drag-selected-nodes
+            </button>
+            {children}
+          </div>
+        </ReactFlowProvider>
       );
     },
   };

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-edit-mode-onrejection-edge.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-edit-mode-onrejection-edge.test.tsx
@@ -32,6 +32,7 @@ const reportedReactFlowErrors: Array<{ errorId: string; message: string }> = [];
 
 vi.mock("@xyflow/react", async () => {
   const actual = await vi.importActual("@xyflow/react");
+  const { ReactFlowProvider } = actual;
 
   return {
     ...actual,
@@ -55,14 +56,16 @@ vi.mock("@xyflow/react", async () => {
       });
 
       return (
-        <div data-testid="mock-react-flow">
-          <ul aria-label="Rendered graph edges">
-            {(edges ?? []).map((edge) => (
-              <li key={edge.id}>{edge.id}</li>
-            ))}
-          </ul>
-          {children}
-        </div>
+        <ReactFlowProvider>
+          <div data-testid="mock-react-flow">
+            <ul aria-label="Rendered graph edges">
+              {(edges ?? []).map((edge) => (
+                <li key={edge.id}>{edge.id}</li>
+              ))}
+            </ul>
+            {children}
+          </div>
+        </ReactFlowProvider>
       );
     },
   };

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport-errors.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport-errors.test.tsx
@@ -21,6 +21,7 @@ let reactFlowErrorToReport: { errorId: string; message: string } | null = null;
 
 vi.mock("@xyflow/react", async () => {
   const actual = await vi.importActual("@xyflow/react");
+  const { ReactFlowProvider } = actual;
 
   return {
     ...actual,
@@ -50,14 +51,16 @@ vi.mock("@xyflow/react", async () => {
       });
 
       return (
-        <div data-testid="mock-react-flow">
-          <ul aria-label="Rendered graph edges">
-            {(edges ?? []).map((edge) => (
-              <li key={edge.id}>{edge.id}</li>
-            ))}
-          </ul>
-          {children}
-        </div>
+        <ReactFlowProvider>
+          <div data-testid="mock-react-flow">
+            <ul aria-label="Rendered graph edges">
+              {(edges ?? []).map((edge) => (
+                <li key={edge.id}>{edge.id}</li>
+              ))}
+            </ul>
+            {children}
+          </div>
+        </ReactFlowProvider>
       );
     },
   };

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport-visual-groups.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport-visual-groups.test.tsx
@@ -63,6 +63,7 @@ vi.mock(
 
 vi.mock("@xyflow/react", async () => {
   const actual = await vi.importActual("@xyflow/react");
+  const { ReactFlowProvider } = actual;
 
   return {
     ...actual,
@@ -85,7 +86,11 @@ vi.mock("@xyflow/react", async () => {
         });
       }, [onInit]);
 
-      return <div data-testid="mock-react-flow">{children}</div>;
+      return (
+        <ReactFlowProvider>
+          <div data-testid="mock-react-flow">{children}</div>
+        </ReactFlowProvider>
+      );
     },
   };
 });

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.test.tsx
@@ -15,6 +15,8 @@ vi.mock("@xyflow/react", async () => {
     ...actual,
     Background: () => <div data-testid="graph-background" />,
     Controls: () => <div data-testid="graph-controls" />,
+    useStore: () => "",
+    useUpdateNodeInternals: () => vi.fn(),
     ReactFlow: ({
       className,
       children,

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
@@ -253,7 +253,11 @@ function factoryGraphEdgeIdForRenderedEdge(nodes: Node[], edge: Edge) {
  */
 function FactoryGraphInitializationState({ nodeIds }: { nodeIds: string[] }) {
   const updateNodeInternals = useUpdateNodeInternals();
-  const stableNodeIds = useMemo(() => nodeIds, [nodeIds]);
+  const nodeIdKey = nodeIds.join(",");
+  const stableNodeIds = useMemo(
+    () => (nodeIdKey === "" ? [] : nodeIdKey.split(",")),
+    [nodeIdKey],
+  );
   const missingNodeIds = useStore((state) => {
     if (state.nodeLookup.size === 0) {
       return null;
@@ -822,6 +826,7 @@ export function CurrentActivityGraphViewport({
               proOptions={{ hideAttribution: true }}
             >
               <FactoryGraphInitializationState
+                key="factory-graph-initialization"
                 nodeIds={nodes.map((node) => node.id)}
               />
               <DashboardGraphBackground key="factory-graph-background" />

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
@@ -12,6 +12,8 @@ import {
   type OnSelectionChangeFunc,
   ReactFlow,
   type ReactFlowInstance,
+  useStore,
+  useUpdateNodeInternals,
   type XYPosition,
 } from "@xyflow/react";
 import { FactoryGraphGroupRegionLayer } from "@you-agent-factory/factory-graph/group-regions";
@@ -21,6 +23,7 @@ import {
   type MutableRefObject,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
 } from "react";
 import {
@@ -241,6 +244,48 @@ function factoryGraphEdgeIdForRenderedEdge(nodes: Node[], edge: Edge) {
     nodes,
     edge.source,
   )}->${factoryGraphNodeIdForRenderedNode(nodes, edge.target)}`;
+}
+
+/**
+ * React Flow treats an unmeasured node as intersecting every marquee. Refresh
+ * the disposable projection's internals after controlled nodes mount, then
+ * expose the actual measurement state for browser interaction synchronization.
+ */
+function FactoryGraphInitializationState({ nodeIds }: { nodeIds: string[] }) {
+  const updateNodeInternals = useUpdateNodeInternals();
+  const stableNodeIds = useMemo(() => nodeIds, [nodeIds]);
+  const missingNodeIds = useStore((state) => {
+    if (state.nodeLookup.size === 0) {
+      return null;
+    }
+
+    const nextMissingNodeIds: string[] = [];
+    for (const node of state.nodeLookup.values()) {
+      if (node.hidden) {
+        continue;
+      }
+
+      if (node.internals.handleBounds === undefined) {
+        nextMissingNodeIds.push(node.id);
+      }
+    }
+
+    return nextMissingNodeIds.join(",");
+  });
+
+  useEffect(() => {
+    updateNodeInternals(stableNodeIds);
+  }, [stableNodeIds, updateNodeInternals]);
+
+  return (
+    <div
+      aria-hidden="true"
+      data-factory-graph-selection-ready={String(
+        missingNodeIds !== null && missingNodeIds.length === 0,
+      )}
+      style={{ display: "none" }}
+    />
+  );
 }
 
 type CurrentActivityGraphViewportAddControls = {
@@ -776,6 +821,9 @@ export function CurrentActivityGraphViewport({
               }}
               proOptions={{ hideAttribution: true }}
             >
+              <FactoryGraphInitializationState
+                nodeIds={nodes.map((node) => node.id)}
+              />
               <DashboardGraphBackground key="factory-graph-background" />
               {!editorControls.isEditing && visualGroups.length > 0 ? (
                 <FactoryGraphGroupRegionLayer

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.coverage.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.coverage.test.tsx
@@ -34,6 +34,7 @@ const {
   actualBuildGraphLayoutRef,
   mockBuildGraphLayout,
   mockImportController,
+  mockUpdateNodeInternals,
 } = vi.hoisted(() => ({
   actualBuildGraphLayoutRef: { current: null as BuildGraphLayout | null },
   mockBuildGraphLayout: vi.fn(),
@@ -50,10 +51,12 @@ const {
     onDragOver: vi.fn(),
     onDrop: vi.fn(),
   },
+  mockUpdateNodeInternals: vi.fn(),
 }));
 
 vi.mock("@xyflow/react", async () => {
   const actual = await vi.importActual("@xyflow/react");
+  const { ReactFlowProvider } = actual;
 
   return {
     ...actual,
@@ -79,6 +82,7 @@ vi.mock("@xyflow/react", async () => {
         data-testid="graph-controls"
       />
     ),
+    useUpdateNodeInternals: () => mockUpdateNodeInternals,
     ReactFlow: ({
       children,
       connectionLineStyle,
@@ -128,71 +132,73 @@ vi.mock("@xyflow/react", async () => {
       };
 
       return (
-        <div data-testid="mock-react-flow">
-          <output data-testid="edges-focusable">
-            {String(edgesFocusable ?? false)}
-          </output>
-          <output data-testid="connection-line-style">
-            {JSON.stringify(connectionLineStyle ?? null)}
-          </output>
-          <output data-testid="valid-workstation-output">
-            {String(
-              isValidConnection?.({
-                source: "workstation:review",
-                sourceHandle: "workstation-output-source",
-                target: "work-state:story:done",
-                targetHandle: "work-state-input-target",
-              }) ?? false,
-            )}
-          </output>
-          <output data-testid="invalid-workstation-output">
-            {String(
-              isValidConnection?.({
-                source: "workstation:review",
-                sourceHandle: "workstation-output-source",
-                target: "work-state:story:done",
-                targetHandle: "workstation-input-source",
-              }) ?? false,
-            )}
-          </output>
-          <button
-            onClick={() =>
-              onConnect?.({
-                source: "workstation:review",
-                sourceHandle: "workstation-output-source",
-                target: "work-state:story:done",
-                targetHandle: "work-state-input-target",
-              })
-            }
-            type="button"
-          >
-            Trigger connect
-          </button>
-          <button
-            onClick={() => onEdgeClick?.(null, { id: "edge-review-done" })}
-            type="button"
-          >
-            Trigger edge click
-          </button>
-          <button
-            onClick={() => onNodeClick?.(null, { id: "workstation:review" })}
-            type="button"
-          >
-            Trigger node click
-          </button>
-          <button
-            onClick={() =>
-              onNodeDragStop?.(null, {
-                ...draggedNode,
-                position: { x: 320, y: 180 },
-              })
-            }
-            type="button"
-          >
-            Trigger drag stop
-          </button>
-          {children}
-        </div>
+        <ReactFlowProvider>
+          <div data-testid="mock-react-flow">
+            <output data-testid="edges-focusable">
+              {String(edgesFocusable ?? false)}
+            </output>
+            <output data-testid="connection-line-style">
+              {JSON.stringify(connectionLineStyle ?? null)}
+            </output>
+            <output data-testid="valid-workstation-output">
+              {String(
+                isValidConnection?.({
+                  source: "workstation:review",
+                  sourceHandle: "workstation-output-source",
+                  target: "work-state:story:done",
+                  targetHandle: "work-state-input-target",
+                }) ?? false,
+              )}
+            </output>
+            <output data-testid="invalid-workstation-output">
+              {String(
+                isValidConnection?.({
+                  source: "workstation:review",
+                  sourceHandle: "workstation-output-source",
+                  target: "work-state:story:done",
+                  targetHandle: "workstation-input-source",
+                }) ?? false,
+              )}
+            </output>
+            <button
+              onClick={() =>
+                onConnect?.({
+                  source: "workstation:review",
+                  sourceHandle: "workstation-output-source",
+                  target: "work-state:story:done",
+                  targetHandle: "work-state-input-target",
+                })
+              }
+              type="button"
+            >
+              Trigger connect
+            </button>
+            <button
+              onClick={() => onEdgeClick?.(null, { id: "edge-review-done" })}
+              type="button"
+            >
+              Trigger edge click
+            </button>
+            <button
+              onClick={() => onNodeClick?.(null, { id: "workstation:review" })}
+              type="button"
+            >
+              Trigger node click
+            </button>
+            <button
+              onClick={() =>
+                onNodeDragStop?.(null, {
+                  ...draggedNode,
+                  position: { x: 320, y: 180 },
+                })
+              }
+              type="button"
+            >
+              Trigger drag stop
+            </button>
+            {children}
+          </div>
+        </ReactFlowProvider>
       );
     },
   };
@@ -361,6 +367,7 @@ describe("ReactFlowCurrentActivityCard coverage", () => {
 
   beforeEach(() => {
     mockBuildGraphLayout.mockReset();
+    mockUpdateNodeInternals.mockReset();
     HTMLElement.prototype.getBoundingClientRect = () =>
       ({
         bottom: 720,
@@ -541,6 +548,46 @@ describe("ReactFlowCurrentActivityCard coverage", () => {
     expect(screen.getByTestId("connection-line-style").textContent).toContain(
       '"stroke":"var(--color-primary)"',
     );
+  });
+
+  it("refreshes graph internals only when the rendered node IDs change", async () => {
+    const nodes: Parameters<typeof CurrentActivityGraphViewport>[0]["nodes"] = [
+      {
+        data: { kind: "workstation" },
+        id: "workstation:review",
+        position: { x: 0, y: 0 },
+        type: "workstation",
+      },
+    ];
+
+    const rendered = renderViewport({ nodes });
+
+    await waitFor(() => {
+      expect(mockUpdateNodeInternals).toHaveBeenCalledTimes(1);
+    });
+    expect(mockUpdateNodeInternals).toHaveBeenLastCalledWith([
+      "workstation:review",
+    ]);
+
+    rendered.rerenderWithNodes(nodes.map((node) => ({ ...node })));
+    expect(mockUpdateNodeInternals).toHaveBeenCalledTimes(1);
+
+    rendered.rerenderWithNodes([
+      ...nodes,
+      {
+        data: { kind: "work-state" },
+        id: "work-state:story:done",
+        position: { x: 240, y: 0 },
+        type: "workState",
+      },
+    ]);
+    await waitFor(() => {
+      expect(mockUpdateNodeInternals).toHaveBeenCalledTimes(2);
+    });
+    expect(mockUpdateNodeInternals).toHaveBeenLastCalledWith([
+      "workstation:review",
+      "work-state:story:done",
+    ]);
   });
 
   it("renders the compact editor toolbar inside the graph card without duplicate add controls", () => {
@@ -881,60 +928,73 @@ function renderViewport({
   >[0]["onEditorNodeClick"];
 }) {
   const flowContainerRef = { current: null as HTMLElement | null };
+  type ViewportNodes = Parameters<
+    typeof CurrentActivityGraphViewport
+  >[0]["nodes"];
 
-  return render(
-    <CurrentActivityGraphViewport
-      addControls={{
-        actions: addMenuActions,
-        isMenuOpen: false,
-        setMenuOpen: vi.fn(),
-        startAction: onAddAction,
-      }}
-      editorControls={{
-        activeTool,
-        canInteract: editorMode,
-        discardPendingChanges: vi.fn(),
-        isEditing: editorMode,
-        selectTool: vi.fn(),
-        toggleMode: vi.fn(),
-      }}
-      edges={[]}
-      flowContainerRef={flowContainerRef}
-      handleNodesChange={vi.fn()}
-      hasPendingChanges={false}
-      headingID="test-heading"
-      layoutControls={{
-        canMoveLayout: includeMoveLayoutNode,
-        canRedo: false,
-        canUndo: false,
-        initialFitViewKey: "full-graph",
-        initialFitViewOptions: { padding: 0.18 },
-        moveNode: moveLayoutNode,
-        moveNodesByDelta: vi.fn(),
-        redo: vi.fn(),
-        reset: vi.fn(),
-        undo: vi.fn(),
-        updateViewport: vi.fn(),
-      }}
-      imports={mockImportController}
-      nodeTypes={{}}
-      nodes={nodes}
-      onConnect={onConnect}
-      onEditorEdgeClick={onEditorEdgeClick}
-      onEditorNodeClick={onEditorNodeClick}
-      saveControls={{ canSave: false, requestConfirmation: vi.fn() }}
-      visibilityControls={{
-        hiddenNodeClasses: new Set(),
-        isDirty: false,
-        isMenuOpen: false,
-        preset: "all",
-        resetPreferences: vi.fn(),
-        setMenuOpen: vi.fn(),
-        setPreset: vi.fn(),
-        toggleHiddenNodeClass: vi.fn(),
-      }}
-    />,
-  );
+  function TestViewport({ nodes: nextNodes }: { nodes: ViewportNodes }) {
+    return (
+      <CurrentActivityGraphViewport
+        addControls={{
+          actions: addMenuActions,
+          isMenuOpen: false,
+          setMenuOpen: vi.fn(),
+          startAction: onAddAction,
+        }}
+        editorControls={{
+          activeTool,
+          canInteract: editorMode,
+          discardPendingChanges: vi.fn(),
+          isEditing: editorMode,
+          selectTool: vi.fn(),
+          toggleMode: vi.fn(),
+        }}
+        edges={[]}
+        flowContainerRef={flowContainerRef}
+        handleNodesChange={vi.fn()}
+        hasPendingChanges={false}
+        headingID="test-heading"
+        layoutControls={{
+          canMoveLayout: includeMoveLayoutNode,
+          canRedo: false,
+          canUndo: false,
+          initialFitViewKey: "full-graph",
+          initialFitViewOptions: { padding: 0.18 },
+          moveNode: moveLayoutNode,
+          moveNodesByDelta: vi.fn(),
+          redo: vi.fn(),
+          reset: vi.fn(),
+          undo: vi.fn(),
+          updateViewport: vi.fn(),
+        }}
+        imports={mockImportController}
+        nodeTypes={{}}
+        nodes={nextNodes}
+        onConnect={onConnect}
+        onEditorEdgeClick={onEditorEdgeClick}
+        onEditorNodeClick={onEditorNodeClick}
+        saveControls={{ canSave: false, requestConfirmation: vi.fn() }}
+        visibilityControls={{
+          hiddenNodeClasses: new Set(),
+          isDirty: false,
+          isMenuOpen: false,
+          preset: "all",
+          resetPreferences: vi.fn(),
+          setMenuOpen: vi.fn(),
+          setPreset: vi.fn(),
+          toggleHiddenNodeClass: vi.fn(),
+        }}
+      />
+    );
+  }
+
+  const rendered = render(<TestViewport nodes={nodes} />);
+  return {
+    ...rendered,
+    rerenderWithNodes: (nextNodes: ViewportNodes) => {
+      rendered.rerender(<TestViewport nodes={nextNodes} />);
+    },
+  };
 }
 
 function createConnectionDraftState() {


### PR DESCRIPTION
{
  "project": "Deflake Factory Graph Editor Browser Integration",
  "branchName": "thr-deflake-factory-graph-editor-browser-integration",
  "description": "Restore trustworthy Frontend Browser CI by reproducing and measuring the load-sensitive factory graph editor race, then synchronizing selection deletion and viewport-aware node placement on their actual observable readiness conditions without increasing timeouts, adding sleeps, or weakening node-resize keyboard guards.",
  "context": {
    "customerAsk": "Deflake ui/integration/factory-graph-editor-selection-no-panel-delete.integration.test.mjs and ui/integration/factory-graph-editor-node-placement.integration.test.mjs, plus a genuinely shared synchronization helper if appropriate. Reproduce first, identify the raced wait, apply a condition-based synchronization or narrowly scoped settling fix, report before/after failure rates and duration, preserve PR #1950's node-resize keyboard guards, and obtain green Frontend Browser CI.",
    "problem": "Main CI run 31791754643 failed both executions of the identical c22928908 tree, but a different graph-editor browser test timed out each time while the same tree was green on PR #1950 and the preceding main commit was green. The scattered single-test failures under runner load indicate an asynchronous readiness race around graph rendering, layout, viewport, or persistence, making main CI ambiguous for every delivery lane.",
    "solution": "Run both specs repeatedly until the race is reproduced and measured, trace the editor state that actually gates each interaction, and wait on stable UI, committed layout/viewport geometry, or completed persistence as evidence dictates. Correct the smallest production settling behavior only if it is the measured cause, retain canonical Factory state and React Flow projection boundaries, and prove 10 consecutive green iterations plus stable suite duration and final green CI."
  },
  "acceptanceCriteria": [
    "Before implementation changes, run both named specs for at least 10 iterations until at least one local failure is reproduced, and record attempts, failures, failure rates, traces, and a comparable duration baseline alongside the known two-of-two failed main executions at c22928908.",
    "Identify and document the raced wait and its actual observable gating condition; synchronize on that condition without increasing local or global timeouts, adding sleeps or arbitrary waitForTimeout calls, inflating retries, skipping or quarantining tests, or marking tests flaky.",
    "After the fix, both named specs pass in each of 10 consecutive local iterations with explicit per-spec counts, graph batch deletion leaves worker configuration editable, and a workstation added after panning settles near the visible viewport center.",
    "Report comparable before/after wall-clock and aggregate test durations with no meaningful regression attributable to the fix, using the supplied CI baseline of 86.49 seconds duration and 178.31 seconds aggregate tests as context.",
    "Frontend Browser is terminal and green on the final PR head, and PR #1950's node-resize keyboard guards remain intact and are not reverted or weakened.",
    "Typecheck, focused browser tests, relevant frontend tests, and lint evidence pass, with no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are reconciled, and the PR is actually merged; opened, green, approved, or ready-to-merge alone is not complete."
  ],
  "userStories": [
    {
      "id": "thr-deflake-factory-graph-editor-browser-integration-001",
      "title": "Reproduce and isolate the asynchronous race",
      "description": "As a maintainer, I want a measured local reproduction and an identified readiness condition so that the fix targets the actual race instead of masking runner load.",
      "acceptanceCriteria": [
        "Run the two named browser specs repeatedly for at least 10 iterations before changing implementation, continue until at least one local failure is observed, and record per-spec attempts, failures, failure rates, relevant traces, and a comparable pre-change duration.",
        "Evidence distinguishes whether toolbar readiness, React Flow projection or layout settlement, viewport commitment, node-size validation, or persistence completion gates the failing interaction.",
        "Define an observable synchronization gate that directly permits the next interaction and does not rely on sleeps, waitForTimeout, larger locator or global timeouts, skips, quarantine, retry inflation, or flaky annotations.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Pre-change reproduction completed on 2026-08-14 at c22928908 before implementation changes. The combined mocked-browser runner executed both specs for 10 iterations (selection: 10 attempts, 3 failures, 30%; placement: 10 attempts, 2 failures, 20%; 4/10 combined iterations had at least one target failure; 5 failed test instances across 60 executed tests). Selection failures consistently stopped at selection-no-panel-delete.integration.test.mjs:363 while scrolling the selected-delete button because the toolbar had already returned to its no-selection projection; placement failures stopped at node-placement.integration.test.mjs:523 because the visible workstation node was still at the stale async React Flow layout position after panning. Representative traces are retained in ignored ui/tmp/factory-graph-baseline-selection and ui/tmp/factory-graph-baseline-combined artifacts. Combined Vitest durations were 10.81-34.85s per iteration, 184.57s aggregate (shell wall time 192.071s); the supplied CI context remains 86.49s wall / 178.31s aggregate and main run 31791754643 had 2/2 failures on this tree. The graph code confirms the raced wait: toolbar visibility and target-node visibility precede the async topology-layout cache settling, while the add controller consumes the last React state viewport report. The observable gates for follow-up stories are: selection mode must be single/multi and the accessible batch-delete button must be enabled; placement must observe the target node's settled screen geometry inside the current viewport and its committed flow transform, with save-response payload checks covering persistence. No timeout, sleep, retry, skip, quarantine, or node-resize guard change was made. `bun run typecheck` passed; the isolated focused run was 6/6 green, while the required load-sensitive loop intentionally exposed the baseline race."
    },
    {
      "id": "thr-deflake-factory-graph-editor-browser-integration-002",
      "title": "Make selection batch deletion wait for editor readiness",
      "description": "As a factory editor user, I want selected topology deletion to remain reliable while graph rendering and persistence settle so that I can remove stages and immediately continue editing worker configuration.",
      "acceptanceCriteria": [
        "The selection-delete flow waits for the measured readiness gate before interacting with the toolbar and does not attempt deletion against an unstable, covered, detached, or incorrectly disabled control.",
        "Selecting the intended graph topology and invoking batch delete stages the expected removal, and the remaining worker configuration stays editable.",
        "The toolbar exposes the correct accessible disabled state with no selection and enabled state with deletable selection; keyboard operation and visible focus continue to work.",
        "Verify the no-selection and selected-success states directly in a real browser at the supported integration-test viewport.",
        "No global timeout configuration under ui/scripts or Vitest configuration changes, and no arbitrary delay is added.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Completed on 2026-08-14. The measured race was React Flow marquee selection running while visible graph nodes still lacked internal handle bounds; its hit-test treats those unmeasured nodes as intersecting the entire marquee. The graph projection now refreshes React Flow internals after controlled nodes mount, exposes the measured readiness state, and the browser flow waits for that state plus two matching target-node geometry samples. Batch-delete readiness requires single/multi selection, visible control, and enabled state. The browser assertion verifies no-selection disabled state, keyboard focus plus Enter activation, staged spare-worker removal, and editable remaining worker configuration. Ten consecutive selection-spec iterations passed (10/10, 0 failures); typecheck, Biome, and 27 focused unit/component tests passed. No timeout, sleep, retry, or resize-keyboard-guard change was made."
    },
    {
      "id": "thr-deflake-factory-graph-editor-browser-integration-003",
      "title": "Make viewport-aware node placement wait for settled geometry",
      "description": "As a factory editor user, I want a newly added workstation to appear near the center of the viewport I am viewing after panning so that graph editing remains spatially predictable under rendering load.",
      "acceptanceCriteria": [
        "After panning, node creation observes the committed viewport and settled node or layout geometry before placement is asserted or a dependent interaction begins.",
        "A newly added workstation appears within the existing accepted tolerance of the visible viewport center and remains there after graph projection and layout settlement.",
        "If production settling changes, canonical Factory definition state remains authoritative, React Flow geometry remains a reproducible projection, and the change stays limited to the measured cause.",
        "Existing loading, empty, error, and success behavior and supported desktop layout behavior are preserved.",
        "PR #1950's node-resize keyboard guards are not reverted or weakened, and their existing regression coverage remains green.",
        "Verify the panned-placement behavior directly in a real browser.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Completed on 2026-08-14. The browser harness now waits for the committed React Flow viewport transform after panning, then waits for the added node's screen geometry, node transform, viewport transform, and in-viewport center to match across observations. The panned placement, collision nudge, and saved-payload flows use the gate before assertions or dependent reads. The unchanged post-story-002 baseline reproduced 1/10 focused placement iterations failing at node-placement.integration.test.mjs:523 (10%); after the fix, 10/10 iterations passed (40/40 test cases, 0 failures). Aggregate Vitest duration improved from 109.57s to 105.45s and shell wall time from 117.7s to 112.8s. Typecheck, 17 focused harness/integration tests, and Biome passed. No production settling behavior, timeout, sleep, retry, or PR #1950 resize guard changed."
    },
    {
      "id": "thr-deflake-factory-graph-editor-browser-integration-004",
      "title": "Prove stable and timely browser behavior",
      "description": "As a delivery owner, I want repeated reliability and duration evidence on the completed fix so that Frontend Browser CI can again be trusted without slowing every lane.",
      "acceptanceCriteria": [
        "Both named specs pass together in 10 consecutive post-change local iterations, with attempts, passes, failures, and failure rates reported for each spec.",
        "Run the relevant browser suite after the focused loop and report comparable before and after wall-clock and aggregate test durations without committing CI-evidence-only changes.",
        "The post-change suite does not regress meaningfully from the measured local baseline or supplied CI context; quantify and explain any environmental variance.",
        "Frontend Browser is terminal and green on the final PR head, and the PR description or comment names the old raced wait, the new gating condition, and why it is correct.",
        "Rebase onto current origin/main before final push, reconcile conflicts without hand-merging generated output, and keep unrelated cleanup out of the lane.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Completed on 2026-08-14. Ten consecutive combined focused iterations passed: selection 10/10 attempts, 10/10 passes, 0 failures (0%); placement 10/10 attempts, 10/10 passes, 0 failures (0%); 60/60 target test cases green with zero stderr output. Post-change focused timing was 155.206s wall-clock across the ten iterations and 148.07s aggregate Vitest duration, versus the pre-change 192.071s wall / 184.57s aggregate baseline (-19.2% / -19.8%). The full mocked-backend browser suite passed 16 files and 39 tests in 45.30s Vitest duration with 109.03s aggregate test time; the production UI build completed in 45.78s. Typecheck, full UI lint, and 29 focused frontend tests passed. No timeout, sleep, retry, quarantine, or PR #1950 resize-keyboard-guard change was made; final PR CI evidence is required after the final push."
    }
  ]
}
