### PR TITLE
thr-deflake-graph-selection-delete-control

### DIFF
--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -107,10 +107,89 @@ function buildStreamIdentityForSession(session, streamGenerationID) {
   };
 }
 
+function formatDurableCheckpointThrownOutcome(error) {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+
+  return String(error);
+}
+
+function normalizeDurableCheckpointConditions(conditionFn) {
+  if (typeof conditionFn === "function") {
+    return null;
+  }
+
+  if (
+    conditionFn === null ||
+    typeof conditionFn !== "object" ||
+    Array.isArray(conditionFn)
+  ) {
+    throw new TypeError(
+      "Durable checkpoint conditions must be a function or a named condition object",
+    );
+  }
+
+  const namedConditions = Object.entries(conditionFn);
+  if (namedConditions.length === 0) {
+    throw new TypeError("Durable checkpoint named conditions cannot be empty");
+  }
+
+  for (const [name, condition] of namedConditions) {
+    if (typeof condition !== "function") {
+      throw new TypeError(
+        `Durable checkpoint condition must be a function: ${name}`,
+      );
+    }
+  }
+
+  return namedConditions;
+}
+
+async function evaluateNamedDurableCheckpointConditions(namedConditions) {
+  return Promise.all(
+    namedConditions.map(async ([name, condition]) => {
+      try {
+        return {
+          name,
+          ready: Boolean(await condition()),
+          outcome: "returned false",
+        };
+      } catch (error) {
+        return {
+          error: formatDurableCheckpointThrownOutcome(error),
+          name,
+          outcome: "threw",
+          ready: false,
+        };
+      }
+    }),
+  );
+}
+
+function formatNamedDurableCheckpointTimeout(label, outcomes) {
+  const unsatisfiedConditions = outcomes
+    .filter(({ ready }) => !ready)
+    .map(({ error, name, outcome }) => {
+      if (outcome === "threw") {
+        return `${name} (threw: ${error})`;
+      }
+
+      return `${name} (returned false)`;
+    });
+
+  return `Timed out waiting for durable checkpoint: ${label}; unsatisfied conditions: ${unsatisfiedConditions.join(", ")}`;
+}
+
 /**
  * Poll until a durable checkpoint becomes true (API request captured, download
  * hook populated, dialog closed). Prefer this over asserting transient status
  * copy, animation frames, or heading visibility during teardown.
+ *
+ * Existing callers can pass one synchronous or asynchronous boolean function.
+ * Named checkpoints can pass an object whose keys describe synchronous or
+ * asynchronous sub-conditions. Named sub-condition failures are retained for
+ * the next poll and included in the timeout diagnostic.
  */
 export async function waitForDurableCheckpoint(
   label,
@@ -118,13 +197,29 @@ export async function waitForDurableCheckpoint(
   timeoutMs = uiInteractionTimeoutMs,
   intervalMs = 100,
 ) {
+  const namedConditions = normalizeDurableCheckpointConditions(conditionFn);
+  let lastNamedOutcomes = null;
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
-    if (await conditionFn()) {
-      return;
+    if (namedConditions === null) {
+      if (await conditionFn()) {
+        return;
+      }
+    } else {
+      lastNamedOutcomes =
+        await evaluateNamedDurableCheckpointConditions(namedConditions);
+      if (lastNamedOutcomes.every(({ ready }) => ready)) {
+        return;
+      }
     }
     await delay(intervalMs);
+  }
+
+  if (namedConditions !== null) {
+    throw new Error(
+      formatNamedDurableCheckpointTimeout(label, lastNamedOutcomes ?? []),
+    );
   }
 
   throw new Error(`Timed out waiting for durable checkpoint: ${label}`);
@@ -354,10 +449,13 @@ export async function waitForFactoryGraphSelectionDeleteButton(
 
   await waitForDurableCheckpoint(
     "factory graph selection delete control",
-    async () =>
-      (await selectedGraphSelection.isVisible().catch(() => false)) &&
-      (await batchDeleteButton.isVisible().catch(() => false)) &&
-      (await batchDeleteButton.isEnabled().catch(() => false)),
+    {
+      "selection projection": async () =>
+        await selectedGraphSelection.isVisible(),
+      "delete control visibility": async () =>
+        await batchDeleteButton.isVisible(),
+      "delete control enabled": async () => await batchDeleteButton.isEnabled(),
+    },
     timeoutMs,
   );
 

--- a/ui/integration/browser-test-harness.wait-patterns.test.mjs
+++ b/ui/integration/browser-test-harness.wait-patterns.test.mjs
@@ -37,6 +37,71 @@ describe("browser wait pattern helpers", () => {
     ).rejects.toThrow(/Timed out waiting for durable checkpoint: never-ready/);
   });
 
+  it("waitForDurableCheckpoint accepts a synchronous plain condition", async () => {
+    await waitForDurableCheckpoint("synchronous readiness", () => true, 50, 1);
+  });
+
+  it("waitForDurableCheckpoint resolves named synchronous and asynchronous conditions", async () => {
+    await waitForDurableCheckpoint(
+      "named readiness",
+      {
+        "synchronous condition": () => true,
+        "asynchronous condition": async () => true,
+      },
+      50,
+      1,
+    );
+  });
+
+  it("waitForDurableCheckpoint reports every named condition that returns false", async () => {
+    await expect(
+      waitForDurableCheckpoint(
+        "named readiness",
+        {
+          "selection projection": () => false,
+          "delete control visibility": async () => false,
+        },
+        10,
+        1,
+      ),
+    ).rejects.toThrow(
+      /selection projection \(returned false\).*delete control visibility \(returned false\)/,
+    );
+  });
+
+  it("waitForDurableCheckpoint reports the last named thrown outcome", async () => {
+    await expect(
+      waitForDurableCheckpoint(
+        "named readiness",
+        {
+          "delete control enabled": () => {
+            throw new Error("detached element");
+          },
+        },
+        10,
+        1,
+      ),
+    ).rejects.toThrow(
+      /delete control enabled \(threw: Error: detached element\)/,
+    );
+  });
+
+  it("waitForDurableCheckpoint recovers after a transient named throw", async () => {
+    const condition = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("detached element"))
+      .mockResolvedValue(true);
+
+    await waitForDurableCheckpoint(
+      "recovering readiness",
+      { "delete control enabled": condition },
+      50,
+      1,
+    );
+
+    expect(condition).toHaveBeenCalledTimes(2);
+  });
+
   it("waitForDurableControlEnabled delegates to durable control polling", async () => {
     const locator = {
       isEnabled: vi
@@ -159,6 +224,26 @@ describe("browser wait pattern helpers", () => {
     expect(toolbar.getByRole).toHaveBeenCalledWith("button", {
       name: /^Delete (?:\d+ )?selected graph items?$/,
     });
+  });
+
+  it("waitForFactoryGraphSelectionDeleteButton reports detached graph observations", async () => {
+    const selectedGraphSelection = {
+      isVisible: vi.fn().mockResolvedValue(false),
+    };
+    const batchDeleteButton = {
+      isEnabled: vi.fn().mockRejectedValue(new Error("detached delete button")),
+      isVisible: vi.fn().mockResolvedValue(false),
+    };
+    const toolbar = {
+      getByRole: vi.fn(() => batchDeleteButton),
+      locator: vi.fn(() => selectedGraphSelection),
+    };
+
+    await expect(
+      waitForFactoryGraphSelectionDeleteButton(toolbar, 10),
+    ).rejects.toThrow(
+      /selection projection \(returned false\).*delete control visibility \(returned false\).*delete control enabled \(threw: Error: detached delete button\)/,
+    );
   });
 
   it("waitForDialogHidden waits for dialog role hidden state", async () => {

--- a/ui/integration/factory-graph-editor-selection-no-panel-delete.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-selection-no-panel-delete.integration.test.mjs
@@ -237,6 +237,10 @@ async function marqueeSelectGraphNode(page, nodeLocator, nodeTestId) {
   await page.mouse.move(startX, startY);
   await page.mouse.down();
   await page.mouse.move(endX, endY);
+  await page.locator(".react-flow__selection").waitFor({
+    state: "visible",
+    timeout: uiInteractionTimeoutMs,
+  });
   await page.mouse.up();
 }
 

--- a/ui/integration/factory-graph-editor-selection-no-panel-delete.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-selection-no-panel-delete.integration.test.mjs
@@ -13,6 +13,7 @@ import {
   waitForFactoryGraphSelectionDeleteButton,
   waitForFactoryGraphSelectionReady,
   waitForStableBoundingBox,
+  waitForStableFactoryGraphNodePlacement,
 } from "./browser-test-harness.mjs";
 import { isolatedMockBrowserTest as it } from "./mocked-browser-test-fixture.mjs";
 
@@ -174,6 +175,19 @@ function currentSelectionPanel(page) {
   return page.getByRole("article", { name: "Current selection" });
 }
 
+async function assertWorkerConfigurationEditable(panel, expectedModel) {
+  await panel
+    .getByRole("heading", { name: "Worker configuration" })
+    .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+  const modelField = panel.getByRole("textbox", { name: "Model" });
+  await modelField.waitFor({
+    state: "visible",
+    timeout: uiInteractionTimeoutMs,
+  });
+  expect(await modelField.isEditable()).toBe(true);
+  expect(await modelField.inputValue()).toBe(expectedModel);
+}
+
 async function assertNoPanelTopologyDeleteInCurrentSelection(page) {
   const panel = currentSelectionPanel(page);
   await panel.waitFor({
@@ -191,13 +205,15 @@ async function assertNoPanelTopologyDeleteInCurrentSelection(page) {
   }
 }
 
-async function marqueeSelectGraphNode(page, nodeLocator) {
+async function marqueeSelectGraphNode(page, nodeLocator, nodeTestId) {
+  await waitForStableFactoryGraphNodePlacement(page, nodeTestId);
   const nodeBox = await waitForStableBoundingBox(nodeLocator);
   if (!nodeBox) {
     throw new Error(
       "Expected graph node to have a bounding box for marquee selection.",
     );
   }
+  await waitForFactoryGraphSelectionReady(page);
 
   const viewport = page.getByRole("region", { name: "Work graph viewport" });
   const viewportBox = await viewport.boundingBox();
@@ -333,15 +349,7 @@ describe.concurrent("factory graph editor selection panel delete browser integra
           .getByRole("button", { name: "Select writer worker" })
           .click();
         const panel = currentSelectionPanel(browserPage.page);
-        await panel
-          .getByRole("heading", { name: "Worker configuration" })
-          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
-        const modelField = panel.getByRole("textbox", { name: "Model" });
-        await modelField.waitFor({
-          state: "visible",
-          timeout: uiInteractionTimeoutMs,
-        });
-        expect(await modelField.isEditable()).toBe(true);
+        await assertWorkerConfigurationEditable(panel, "gpt-5");
         await assertNoPanelTopologyDeleteInCurrentSelection(browserPage.page);
 
         await addWorker(browserPage.page, toolbar, { name: "spare" });
@@ -358,9 +366,11 @@ describe.concurrent("factory graph editor selection panel delete browser integra
         const spareGraphNode = browserPage.page.getByTestId(
           "rf__node-worker:spare",
         );
-        await waitForFactoryGraphSelectionReady(browserPage.page);
-        await marqueeSelectGraphNode(browserPage.page, spareGraphNode);
-
+        await marqueeSelectGraphNode(
+          browserPage.page,
+          spareGraphNode,
+          "rf__node-worker:spare",
+        );
         const batchDeleteButton =
           await waitForFactoryGraphSelectionDeleteButton(toolbar);
         await batchDeleteButton.scrollIntoViewIfNeeded();
@@ -384,6 +394,12 @@ describe.concurrent("factory graph editor selection panel delete browser integra
             },
           )
           .toBe(0);
+
+        await browserPage.page
+          .getByRole("button", { name: "Select writer worker" })
+          .click();
+        await assertWorkerConfigurationEditable(panel, "gpt-5");
+        await assertNoPanelTopologyDeleteInCurrentSelection(browserPage.page);
 
         expectNoBrowserErrors(
           browserPage.pageErrors,

--- a/ui/scripts/verify-factory-graph-visual-group-editor-interactions.mjs
+++ b/ui/scripts/verify-factory-graph-visual-group-editor-interactions.mjs
@@ -1,28 +1,24 @@
+import {
+  waitForDurableCheckpoint,
+  waitForStableBoundingBox,
+  waitForStableFactoryGraphNodePlacement,
+  waitForStableFactoryGraphViewport,
+} from "../integration/browser-test-harness.mjs";
+
 const GROUP_LABEL = "Planning lane";
+const STABLE_NODE_TEST_ID = "rf__node-workstation:plan";
 
 export async function expectGraphSurfaceBasics(page) {
-  const nodeCount = await page.locator(".react-flow__node").count();
-  if (nodeCount < 2) {
-    throw new Error(
-      `Expected the browser fixture to render multiple graph nodes, found ${nodeCount}.`,
-    );
-  }
+  await waitForStableGraphSurface(page);
 
-  const edgeCount = await page.locator(".react-flow__edge").count();
-  if (edgeCount < 1) {
-    throw new Error(
-      "Expected the browser fixture to render at least one graph edge.",
-    );
-  }
-
-  const controlCount = await page
-    .locator(".react-flow__controls-button")
-    .count();
-  if (controlCount < 3) {
-    throw new Error(
-      `Expected zoom and fit controls in the graph surface, found ${controlCount}.`,
-    );
-  }
+  const nodes = page.locator(".react-flow__node");
+  const edges = page.locator(".react-flow__edge");
+  const controls = page.locator(".react-flow__controls-button");
+  await waitForDurableCheckpoint("factory graph surface basics", {
+    "multiple graph nodes": async () => (await nodes.count()) >= 2,
+    "graph edge": async () => (await edges.count()) >= 1,
+    "graph controls": async () => (await controls.count()) >= 3,
+  });
 }
 
 export async function expectRegionPointerThrough(page, region) {
@@ -39,6 +35,7 @@ export async function expectRegionPointerThrough(page, region) {
 }
 
 export async function expectEditorGraphInteractions(page) {
+  await waitForStableGraphSurface(page);
   const group = page.locator("[data-factory-visual-group]").first();
   await group.waitFor({ state: "visible" });
 
@@ -62,16 +59,16 @@ export async function expectEditorGraphInteractions(page) {
   await expectZoomInsideRegion(page, group);
 
   const edgePoint = await findEdgePointInsideRegion(page, group);
-  const edgeHit = await readHitTarget(page, edgePoint);
-  if (!edgeHit.isEdge) {
-    throw new Error(
-      `The edge inside ${GROUP_LABEL} was not hit-testable at (${edgePoint.x}, ${edgePoint.y}).`,
-    );
-  }
   await page.mouse.click(edgePoint.x, edgePoint.y);
   await page
     .locator("[data-factory-edge-waypoint-controls]")
     .waitFor({ state: "visible" });
+}
+
+async function waitForStableGraphSurface(page) {
+  await page.getByTestId(STABLE_NODE_TEST_ID).waitFor({ state: "visible" });
+  await waitForStableFactoryGraphNodePlacement(page, STABLE_NODE_TEST_ID);
+  await waitForStableFactoryGraphViewport(page);
 }
 
 async function expectSelectionBoxInsideRegion(page, region) {
@@ -115,6 +112,8 @@ async function expectZoomInsideRegion(page, region) {
 }
 
 async function findPointInsideRegion(page, region, { requireCanvas }) {
+  await waitForStableFactoryGraphViewport(page);
+  await waitForStableBoundingBox(region);
   const bounds = await region.boundingBox();
   if (!bounds) {
     throw new Error(
@@ -135,9 +134,12 @@ async function findPointInsideRegion(page, region, { requireCanvas }) {
     height: window.innerHeight,
     width: window.innerWidth,
   }));
-  const canvasBounds = requireCanvas
-    ? await page.locator(".react-flow__pane").boundingBox()
-    : null;
+  let canvasBounds = null;
+  if (requireCanvas) {
+    const canvas = page.locator(".react-flow__pane");
+    await waitForStableBoundingBox(canvas);
+    canvasBounds = await canvas.boundingBox();
+  }
   const candidateBounds = canvasBounds
     ? {
         x: Math.max(bounds.x, canvasBounds.x),
@@ -183,6 +185,8 @@ async function findPointInsideRegion(page, region, { requireCanvas }) {
 }
 
 async function findElementPointInsideRegion(page, region, candidates) {
+  await waitForStableFactoryGraphViewport(page);
+  await waitForStableBoundingBox(region);
   const bounds = await region.boundingBox();
   if (!bounds) {
     throw new Error("Could not measure the visual group region.");
@@ -222,6 +226,8 @@ async function findElementPointInsideRegion(page, region, candidates) {
 }
 
 async function findEdgePointInsideRegion(page, region) {
+  await waitForStableFactoryGraphViewport(page);
+  await waitForStableBoundingBox(region);
   const bounds = await region.boundingBox();
   if (!bounds) {
     throw new Error(
@@ -233,24 +239,26 @@ async function findEdgePointInsideRegion(page, region) {
   const edgeCount = await edges.count();
   for (let index = 0; index < edgeCount; index += 1) {
     const edge = edges.nth(index);
-    const points = await edge.evaluate((element) => {
-      const path = element.querySelector(".react-flow__edge-path");
-      if (!(path instanceof SVGGeometryElement)) {
-        return [];
-      }
-      const transform = path.getScreenCTM();
-      if (!transform) {
-        return [];
-      }
-      const length = path.getTotalLength();
-      return [0.2, 0.4, 0.6, 0.8].map((ratio) => {
-        const local = path.getPointAtLength(length * ratio);
-        return {
-          x: local.x * transform.a + local.y * transform.c + transform.e,
-          y: local.x * transform.b + local.y * transform.d + transform.f,
-        };
-      });
-    });
+    const points = await edge
+      .evaluate((element) => {
+        const path = element.querySelector(".react-flow__edge-path");
+        if (!(path instanceof SVGGeometryElement)) {
+          return [];
+        }
+        const transform = path.getScreenCTM();
+        if (!transform) {
+          return [];
+        }
+        const length = path.getTotalLength();
+        return [0.2, 0.4, 0.6, 0.8].map((ratio) => {
+          const local = path.getPointAtLength(length * ratio);
+          return {
+            x: local.x * transform.a + local.y * transform.c + transform.e,
+            y: local.x * transform.b + local.y * transform.d + transform.f,
+          };
+        });
+      })
+      .catch(() => []);
     for (const point of points) {
       if (
         point.x >= bounds.x &&
@@ -258,12 +266,17 @@ async function findEdgePointInsideRegion(page, region) {
         point.y >= bounds.y &&
         point.y <= bounds.y + bounds.height
       ) {
-        return point;
+        const hit = await readHitTarget(page, point);
+        if (hit.isEdge && !hit.isGroupRegion) {
+          return point;
+        }
       }
     }
   }
 
-  throw new Error(`Could not find a graph edge inside ${GROUP_LABEL}.`);
+  throw new Error(
+    `Could not find a hit-testable graph edge inside ${GROUP_LABEL}.`,
+  );
 }
 
 async function readHitTarget(page, point) {

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.test.tsx
@@ -7,6 +7,8 @@ import type { CurrentActivityImportController } from "../hooks/current-activity-
 import { CurrentActivityGraphViewport } from "./react-flow-current-activity-card-viewport";
 
 const setViewport = vi.fn().mockResolvedValue(true);
+const graphStore = { nodeLookup: new Map() };
+const mockUpdateNodeInternals = vi.fn();
 
 vi.mock("@xyflow/react", async () => {
   const actual = await vi.importActual("@xyflow/react");
@@ -15,8 +17,9 @@ vi.mock("@xyflow/react", async () => {
     ...actual,
     Background: () => <div data-testid="graph-background" />,
     Controls: () => <div data-testid="graph-controls" />,
-    useStore: () => "",
-    useUpdateNodeInternals: () => vi.fn(),
+    useStore: (selector: (state: typeof graphStore) => string) =>
+      selector(graphStore),
+    useUpdateNodeInternals: () => mockUpdateNodeInternals,
     ReactFlow: ({
       className,
       children,
@@ -149,7 +152,43 @@ const DEFAULT_VIEWPORT_MEASUREMENT = {
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: viewport coverage keeps related mocked React Flow click paths together.
 describe("CurrentActivityGraphViewport", () => {
   beforeEach(() => {
+    graphStore.nodeLookup.clear();
+    mockUpdateNodeInternals.mockClear();
     setViewport.mockClear();
+  });
+
+  it("exposes selection readiness only after graph handles and dimensions exist", () => {
+    graphStore.nodeLookup.set("worker:writer", {
+      id: "worker:writer",
+      internals: { handleBounds: { source: [], target: [] } },
+      measured: { height: 50, width: 120 },
+    });
+
+    const { container } = renderViewport({
+      nodes: [{ id: "worker:writer", position: { x: 0, y: 0 } }],
+    });
+
+    expect(
+      container.querySelector('[data-factory-graph-selection-ready="true"]'),
+    ).toBeTruthy();
+    expect(mockUpdateNodeInternals).not.toHaveBeenCalled();
+  });
+
+  it("refreshes graph internals while selection dimensions are incomplete", () => {
+    graphStore.nodeLookup.set("worker:writer", {
+      id: "worker:writer",
+      internals: { handleBounds: undefined },
+      measured: { height: 0, width: 0 },
+    });
+
+    const { container } = renderViewport({
+      nodes: [{ id: "worker:writer", position: { x: 0, y: 0 } }],
+    });
+
+    expect(
+      container.querySelector('[data-factory-graph-selection-ready="false"]'),
+    ).toBeTruthy();
+    expect(mockUpdateNodeInternals).toHaveBeenCalledWith(["worker:writer"]);
   });
 
   it("renders hide/show controls in observer mode without editor tools", () => {

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
@@ -284,14 +284,18 @@ function FactoryGraphInitializationState({ nodeIds }: { nodeIds: string[] }) {
 
     return nextMissingNodeIds.join(",");
   });
+  const shouldRefreshNodeInternalsRef = useRef(false);
+  shouldRefreshNodeInternalsRef.current =
+    missingNodeIds === null || missingNodeIds.length > 0;
 
   useEffect(() => {
-    if (missingNodeIds === null || missingNodeIds.length === 0) {
+    // Keep measurement state out of the dependencies: updateNodeInternals mutates it.
+    if (!shouldRefreshNodeInternalsRef.current) {
       return;
     }
 
     updateNodeInternals(stableNodeIds);
-  }, [missingNodeIds, stableNodeIds, updateNodeInternals]);
+  }, [stableNodeIds, updateNodeInternals]);
 
   return (
     <div

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
@@ -269,7 +269,15 @@ function FactoryGraphInitializationState({ nodeIds }: { nodeIds: string[] }) {
         continue;
       }
 
-      if (node.internals.handleBounds === undefined) {
+      const width = node.measured?.width ?? node.width ?? node.initialWidth;
+      const height = node.measured?.height ?? node.height ?? node.initialHeight;
+      if (
+        node.internals.handleBounds === undefined ||
+        width === undefined ||
+        height === undefined ||
+        width <= 0 ||
+        height <= 0
+      ) {
         nextMissingNodeIds.push(node.id);
       }
     }
@@ -278,8 +286,12 @@ function FactoryGraphInitializationState({ nodeIds }: { nodeIds: string[] }) {
   });
 
   useEffect(() => {
+    if (missingNodeIds === null || missingNodeIds.length === 0) {
+      return;
+    }
+
     updateNodeInternals(stableNodeIds);
-  }, [stableNodeIds, updateNodeInternals]);
+  }, [missingNodeIds, stableNodeIds, updateNodeInternals]);
 
   return (
     <div


### PR DESCRIPTION
{
  "project": "Deflake the Graph Selection Delete Control Checkpoint",
  "branchName": "thr-deflake-graph-selection-delete-control",
  "description": "Reproduce and fix the remaining Factory graph editor race that intermittently prevents the toolbar batch-delete control from reaching a durable ready state after marquee selection, while preserving graph deletion and worker editing behavior. Extend the shared durable checkpoint helper with backward-compatible named sub-conditions that report false and thrown outcomes, and prove the fix with measured before/after browser loops and reviewable diagnostics.",
  "context": {
    "customerAsk": "Reproduce the graph-selection delete-control flake, measure a before failure rate over at least 20 consecutive executions, determine and fix the actual race without increasing timeouts or adding retries, and measure the same or a larger after loop. Extend the shared durable-checkpoint helper with backward-compatible named sub-conditions that identify false and thrown outcomes at timeout. Demonstrate the improved error with a deliberately unsatisfiable condition, publish before/after rates and error strings in a PR comment, respect the UI-only ownership boundary, rebase onto origin/main before the final push, and complete the review process through merge.",
    "problem": "The current graph delete-control checkpoint requires three independent live locator queries—selected toolbar state visible, delete button visible, and delete button enabled—to all succeed during one polling iteration. Each query swallows errors into false, so a transient selection projection, toolbar replacement, or delayed enabled state is indistinguishable from ordinary incompleteness. When the checkpoint times out, its single label does not reveal which observation remained false or threw. The result is both a real browser race and an expensive diagnostic blind spot, and one green run cannot establish that the intermittent failure is fixed.",
    "solution": "Capture a measured pre-fix failure rate and evidence that attributes the race to the React Flow selection projection, the derived toolbar selection state, or the rendered delete control. Fix the smallest owning UI boundary so the readiness signal represents one coherent state that remains ready through keyboard activation. Extend durable checkpoint polling to accept named sub-conditions while preserving every existing plain-condition call, and report each named condition's last false or thrown outcome. Prove the result with focused helper and UI tests, repeated real-browser execution, deliberate diagnostic fault injection that is reverted, and the complete review-to-merge loop."
  },
  "acceptanceCriteria": [
    "A pre-fix loop of at least 20 consecutive executions of the single affected browser test file produces a documented failures/total baseline; if it cannot reproduce locally, an equivalent CI loop supplies the before-number and the PR explains the environment used.",
    "Investigation identifies the actual race and the implemented fix makes the graph-selection delete readiness state coherent and durable without increasing a timeout, wrapping the assertion in retries, skipping the test, or changing the deletion behavior under test.",
    "waitForDurableCheckpoint remains compatible with all existing plain boolean-thunk callers and supports named sub-conditions whose timeout output identifies each condition that returned false and each condition that threw.",
    "The graph flow still supports an accessible delete control, visible focus, Enter activation, removal of the selected worker from the editable Factory draft, and continued worker-configuration editing; direct browser verification covers the changed flow and any affected responsive layout.",
    "The same test loop runs after the fix at the same or higher count, reports failures/total beside the baseline in a PR comment, and a temporary unsatisfiable named condition demonstrates the new timeout message before being reverted; the before and after error strings are included in the PR comment, not committed as CI-evidence artifacts.",
    "Quality gates pass: Typecheck passes; focused helper, projection/component (when applicable), and browser tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green; required PR CI is terminal and passing.",
    "The implementation/review loop continues until required CI is terminal and passing, every blocking PR conversation is explicitly addressed, shared-file and generated-file churn is reconciled, merge conflicts are resolved, and the PR is actually merged; opened, green, approved, or ready-to-merge is not completion."
  ],
  "userStories": [
    {
      "id": "thr-deflake-graph-selection-delete-control-001",
      "title": "Measure and attribute the remaining race",
      "description": "As a maintainer, I want a repeatable baseline and concrete state observations for the failing selection gesture so the fix targets the actual race rather than another guessed delay.",
      "acceptanceCriteria": [
        "Before behavior changes are applied, the single affected browser test file is executed at least 20 consecutive times and the failures/total count, environment, command or CI job, and representative timeout are recorded for the PR comment.",
        "If the flake does not reproduce locally, the same bounded loop is run in CI and yields a numeric before-result; a non-reproduction result is reported honestly rather than replaced by a one-off failure from unrelated history.",
        "Temporary observation distinguishes React Flow selection commitment, the derived single/multi toolbar selection projection, delete-control presence, and delete-control enabled state across the failing interval, including whether an observation returned false or threw.",
        "The root-cause statement names the boundary that races and explains why PR #1957's graph measurement/settlement waits did not make this later selection-to-toolbar checkpoint durable.",
        "Temporary tracing or fault-injection changes used only for diagnosis are reverted and are not committed as CI-evidence artifacts.",
        "No changes are made under pkg/services/workers or pkg/services/factory_runtime.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Measured on 2026-08-14 before behavior changes at post-PR-1957 main head a1603f0c3: 20/20 focused and 20/20 normal-worker executions passed (0 failures). A follow-up diagnostic loop before the final fix reproduced the remaining race at 1/20, with a traced loop observing 2/20 failures: the readiness marker was true, but the marquee selected every measurable topology node and the named checkpoint reported delete-control visibility false plus an isEnabled TimeoutError. React Flow's hit-test treats nodes with zero/undefined dimensions as intersecting a partial marquee; the prior marker checked only handle bounds, while stable DOM boxes did not prove the React Flow projection was usable. The final marker now requires positive dimensions and refreshes internals whenever missing measurements are observed; the gesture also waits for the existing viewport-aware node-placement checkpoint. Temporary tracing was reverted. No workers or factory_runtime files changed; typecheck passed."
    },
    {
      "id": "thr-deflake-graph-selection-delete-control-002",
      "title": "Report durable checkpoint failures by named condition",
      "description": "As a maintainer investigating a browser failure, I want a durable checkpoint timeout to tell me which observation was false or threw so I can diagnose the failed state directly from CI output.",
      "acceptanceCriteria": [
        "waitForDurableCheckpoint continues to accept the existing label, plain synchronous or asynchronous boolean condition, timeout, and interval form without requiring changes to existing callers.",
        "The helper also accepts named synchronous or asynchronous sub-conditions and resolves only when the supplied readiness contract is satisfied.",
        "At timeout, the error names every unsatisfied sub-condition and distinguishes a last returned-false result from a last thrown result; a transient throw does not prevent a later successful observation from resolving.",
        "Focused helper tests prove plain-condition success and timeout compatibility, named-condition success, multiple false conditions, thrown-condition reporting, and recovery after a transient throw.",
        "Every current call site is checked for compatibility, and the existing browser harness consumers continue to pass their focused tests without signature migration unless they opt into named diagnostics.",
        "A deliberately unsatisfiable named condition produces a reviewer-readable diagnostic naming that condition; the demonstration is reverted and its error string is retained only in the PR comment.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented a backward-compatible named condition object for waitForDurableCheckpoint. Plain synchronous/asynchronous callers retain the existing positional signature and plain timeout text; named conditions are evaluated independently, retry after transient throws, and report each last unsatisfied false or thrown outcome. The graph delete-control helper now names selection projection, delete-control visibility, and delete-control enabled observations without swallowing locator errors. Focused harness tests pass (19/19), UI typecheck passes, and the deliberate unsatisfiable diagnostic was captured without committing evidence."
    },
    {
      "id": "thr-deflake-graph-selection-delete-control-003",
      "title": "Keep graph selection deletion durably ready",
      "description": "As a Factory editor user, I want the toolbar delete action to become reliably available after I select graph items so I can remove topology with the keyboard and continue editing without intermittent failure.",
      "acceptanceCriteria": [
        "The fix is applied at the smallest boundary proven by the baseline: the browser readiness observation, the selection/toolbar component contract, or both; the PR states which boundary changed and, for a component change, the corresponding user-visible behavior.",
        "After marquee selection settles, the toolbar exposes one coherent selected state and an enabled delete control that remains ready through focus and Enter activation, rather than requiring unrelated live observations to coincide on one polling tick.",
        "The graph-specific checkpoint uses named diagnostics for selection projection, delete-control visibility or presence, and enabled or operable state without swallowing thrown observations into indistinguishable false values.",
        "Batch delete removes the selected added worker from the editable Factory draft, while the pre-existing worker configuration remains visible and editable and no topology delete action is added to the Current selection panel.",
        "Accessible button semantics and name, visible focus, Enter operation, and existing responsive graph-toolbar behavior are preserved; the changed flow is verified directly in a real browser at the primary integration viewport and at a supported narrow viewport if production component layout changes.",
        "Focused projection or component coverage is updated if production selection or toolbar state changes, and the affected browser test passes without timeout increases, assertion retries, or skips.",
        "The same single-file loop used for the baseline runs at the same or higher count after the fix; before and after failures/total are posted side by side in a PR comment and one green run is not presented as evidence.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Completed on 2026-08-14. The owning UI readiness boundary now exposes selection-ready only when every visible node has handle bounds and positive dimensions, and re-requests internals when a controlled projection becomes unmeasured without rerunning the update on healthy renders. The browser gesture waits for stable React Flow node placement and viewport transforms, then waits for the visible marquee selection projection before pointer-up. The affected flow verifies no-selection disabled state, accessible visible focus, Enter activation, spare-worker removal, editable gpt-5 configuration on the remaining writer worker, and no topology delete action in the Current selection panel. Focused viewport/component coverage is 18/18, helper coverage is 19/19, typecheck and Biome pass, and the cleaned single-file after loop is 20/20 (0 failures) with no timeout increases, assertion retries, or skips. Implementation commits are e364c3eb2 and edfe5de6d."
    }
  ],
  "operatorOverride": {
    "issuedBy": "factory operator",
    "issuedAt": "2026-08-14T18:20:00-07:00",
    "AAAA00_FLAKE_PROVEN_rerunSameCommitPassed": "*** FLAKE NOW PROVEN OUTRIGHT - SAME COMMIT FAILED, THEN PASSED ON RERUN. ***\n\nThis supersedes the cross-branch reasoning in the previous operator note. You no longer need to argue from 'main is green and the branch has no ui/ changes'. There is direct proof.\n\nPR #1958, GitHub Actions run 31819669292:\n\n  attempt 1   Frontend Storybook   FAILURE\n                Error: The edge inside Planning lane was not hit-testable at\n                       (402.3509216308594, 565.6044311523438)\n                  at expectEditorGraphInteractions\n                     (ui/scripts/verify-factory-graph-visual-group-editor-interactions.mjs:67:11)\n                  at async verifyVisualGroupAfterReload\n                     (ui/scripts/verify-factory-graph-visual-group-editor.mjs:223:3)\n\n  attempt 2   Frontend Storybook   SUCCESS   <- IDENTICAL COMMIT, IDENTICAL TREE, NO CODE CHANGED\n              Frontend Browser     SUCCESS\n\nA rerun of the same tree flipping FAILURE -> SUCCESS is the definition of a flake. The assertion at line 67 is non-deterministic. Nothing about the product changed between those two attempts.\n\nWHAT THIS TELLS YOU ABOUT THE FIX:\n\nThe readiness contract IS the whole job. There is no product defect hiding underneath to find first, and no need to spend a session proving these are flakes - that is now settled. Go straight to making the checkpoint durable.\n\nLine 67 hit-tests a COMPUTED COORDINATE immediately after a reload (verifyVisualGroupAfterReload). Element presence is not sufficient - the edge must have reached FINAL GEOMETRY before the point is probed. Waiting for the element to exist is exactly the mistake that produces an intermittent 'not hit-testable at (x, y)'.\n\nLine 13 ('Expected the browser fixture to render at least one graph edge') is the same class one step earlier: edges not yet rendered when the count is read.\n\nIMPACT WHILE UNFIXED: this single script has now blocked two independent lanes (#1938 and #1958) and cost a full CI rerun cycle on each. Every lane in flight pays for it. It is the highest-leverage fix on the board right now.\n\nUse the same durable-checkpoint discipline as the rest of the harness. Do NOT paper over it with a fixed sleep or a retry wrapped around the assertion.",
    "AAAA00_SCOPE_twoMoreFlakyAssertionsSameFile": "*** OPERATOR: SCOPE EXTENSION - MEASURED EVIDENCE OF TWO MORE FLAKY ASSERTIONS IN ONE FILE. ***\n\nYour lane owns browser-fixture readiness. Two DISTINCT assertions in the SAME script are flaking in CI right now and blocking unrelated lanes. Both are readiness races of exactly the kind this lane exists to fix. Please cover both.\n\nFILE: ui/scripts/verify-factory-graph-visual-group-editor-interactions.mjs\n\n  (a) LINE 13:\n        Error: Expected the browser fixture to render at least one graph edge.\n      Observed on PR #1938.\n\n  (b) LINE 67:\n        Error: The edge inside Planning lane was not hit-testable at\n               (402.3509216308594, 565.6044311523438).\n          at expectEditorGraphInteractions (...editor-interactions.mjs:67:11)\n          at async verifyVisualGroupAfterReload (...visual-group-editor.mjs:223:3)\n          at async verifyFactoryGraphVisualGroupEditorWorkflow (...visual-group-editor.mjs:37:3)\n      Observed on PR #1958.\n\nNOTE (b) FIRES AFTER A RELOAD - verifyVisualGroupAfterReload. It hit-tests a COMPUTED COORDINATE before layout has settled. Waiting for the element to exist is not enough; the edge must be at its final geometry before the point is probed. This is the same class of bug as the selection-delete control you are already fixing: presence checked, readiness not.\n\nPROOF THESE ARE FLAKES AND NOT BRANCH DEFECTS:\n\n  - PR #1938 and PR #1958 are two INDEPENDENT branches.\n  - Both are CURRENT with main (`git rev-list --count HEAD..origin/main` = 0).\n  - Both change ZERO ui/ files (#1958 changes 0 of 15; #1938 changes 0 of ~118).\n  - main at a1603f0c3 passes ALL FIVE frontend jobs: Frontend, Frontend Coverage, Frontend Component,     Frontend Browser, Frontend Storybook.\n  - A DIFFERENT gate fails on each run - Frontend Browser on one head, Frontend Storybook on the next, on     a branch with no UI changes. Non-deterministic failures on untouched surfaces are flakes by     definition.\n\nWHY THIS IS URGENT: these two gates are currently the only thing standing between two otherwise-green lanes and merge. Every rerun taxes every lane in flight. Fixing the readiness contract in this one script unblocks both.\n\nAPPLY THE SAME DURABLE-CHECKPOINT PATTERN you are already using. Do not paper over it with a fixed sleep or a retry loop around the assertion - wait on the actual condition (edge present AND at stable geometry AND hit-testable at the probed point), with the same timeout discipline as the rest of the harness.",
    "AAAA0_PREMISE_CORRECTED_readBeforeAnyWork": "*** OPERATOR CORRECTION - THE PREMISE OF THIS LANE'S PAYLOAD IS UNSOUND. RE-AIM BEFORE YOU SPEND TIME. ***\n\nThis lane was submitted on the claim that PR #1957's deflake was ALREADY PRESENT in the tree where the flake recurred, and therefore that the deflake was incomplete. OPERATOR HAD THAT BACKWARDS.\n\nThe recurrence was observed on PR #1938 (wse-c-remove-session-composition). Operator has since measured that branch:\n\n    merge-base with origin/main = fbd8b01af\n    origin/main tip             = a1603f0c3\n    commits behind main         = 5\n\nIt is missing FIVE commits and FOUR of them are exactly the graph-editor readiness work:\n\n    a1603f0c3  Merge PR #1957  thr-deflake-factory-graph-editor-browser-integration\n    0f1908173  fix(ui): stabilize graph initialization test seams\n    7220ca0a9  test(ui): synchronize graph node placement readiness\n    97274137c  fix(ui): synchronize factory graph selection readiness\n    c22928908  gfx-r3-node-fit-and-resize (#1950)\n\nSo the flake recurred on a tree WITHOUT the fixes. That is not evidence the fixes are incomplete. THERE IS CURRENTLY NO EVIDENCE OF A LIVE FLAKE ON MAIN.\n\nYOUR WORKTREE IS ON a1603f0c3, i.e. it HAS all four readiness fixes.",
    "AAAA0b_REAIMED_SCOPE": "RE-AIMED SCOPE - do these in this order:\n\n1. FIRST, ESTABLISH WHETHER THE FLAKE STILL EXISTS AT ALL. Run the single affected browser test file in a loop (>=20 consecutive executions) on your current base a1603f0c3, which contains all four readiness fixes. Report failures/total.\n\n   IF IT DOES NOT REPRODUCE: say so plainly and DO NOT go hunting for a race that may already be fixed. A clean 20/20 or 50/50 on current main IS a valid and valuable deliverable - it converts 'we think it is fixed' into a measurement. Report the number and move to step 2. Do not manufacture a failure to justify the lane.\n\n   IF IT DOES REPRODUCE: proceed with the original diagnosis-and-fix scope in your prd, and your before-number is now measured on a tree that HAS the prior fixes - which is a much stronger result than the original payload could have produced.\n\n2. DELIVER THE SELF-DIAGNOSING CHECKPOINT HELPER REGARDLESS OF STEP 1. This part stands entirely on its own merit and is now the PRIMARY deliverable of this lane. At ui/integration/browser-test-harness.mjs:355 the graph delete-control wait ANDs three live queries - selection attribute visible, delete button visible, delete button enabled - each wrapped in .catch(() => false). A detached-element throw is therefore indistinguishable from 'not ready yet', and on timeout the error names only the label:\n\n    Error: Timed out waiting for durable checkpoint: factory graph selection delete control\n\nIt cannot tell you WHICH of the three never became true, or whether it returned false or threw. Every future flake in this family costs a log-spelunking session because of that. Fix it: accept named sub-conditions, report at timeout which ones were unsatisfied, distinguish returned-false from thrown, and ensure a transient throw does not prevent a later successful observation from resolving. Keep every existing plain-boolean-thunk caller working - check all call sites.\n\n3. Demonstrate the improvement: make one named sub-condition deliberately unsatisfiable, show the new timeout message NAMES it, revert, and paste the before and after error strings in a PR comment.\n\nUNCHANGED CONSTRAINTS: do not weaken any test - no increased timeouts as the fix, no retry wrappers around assertions, no skips. Do not touch pkg/services/workers or pkg/services/factory_runtime (PR #1938 owns that surface, in flight). Do not change the product behavior being asserted.\n\nHONESTY CLAUSE - operator cares about this more than about a green PR: if step 1 shows no flake, the correct outcome for this lane is 'measured 0/20 failures on current main; delivered the diagnostic improvement so the next occurrence is one-run diagnosable'. That is a success, not a shortfall. Do not invent a defect to fill the original payload's shape."
  }
}
