### PR TITLE
docs(factory): attribute the delivery loop's two halves to the stages that own them

### DIFF
--- a/factory/workstations/plan/AGENTS.md
+++ b/factory/workstations/plan/AGENTS.md
@@ -31,6 +31,25 @@ blocking PR conversation feedback is explicitly addressed, merge conflicts are
 resolved, and the PR is merged. A PR that is merely opened, green, approved, or
 ready to merge is not complete.
 
+That contract belongs to the lane as a whole, and the `Delivery Loop` section
+must attribute its two halves to the two stages that actually own them:
+
+- The **implementation stage** finishes when it has pushed its final head, the
+  PR is open, CI has started, and all blocking review feedback is addressed.
+- The **review stage** owns driving CI to terminal-and-passing and owns the
+  merge itself.
+
+Never phrase an acceptance criterion so that the implementation stage owns
+"CI is green" or "the PR is merged". The implementer cannot merge, so a
+criterion worded that way makes it wait on an outcome it does not control: it
+re-runs CI for hours and commits progress notes about the run it is watching.
+Each such commit creates a new head, which invalidates the very run it just
+recorded, and the loop restarts. This has cost tens of agent-hours on a single
+lane.
+
+For the same reason, every plan must state that evidence about a CI run goes in
+a PR comment and never in a commit.
+
 When the ask touches backend, plan for clear package ownership, explicit state,
 isolated side effects, aligned contracts, and direct verification at the right
 test layer.


### PR DESCRIPTION
## Problem

`factory/workstations/plan/AGENTS.md` requires every PRD to carry a `Delivery Loop` section stating the cycle continues until CI is terminal-and-passing and the PR is merged. That is correct **for the lane**, but it never says which *stage* owns which half — so it renders into `acceptanceCriteria` that the process worker reads as its own checklist.

Observed on a lane planned today, acceptance criterion 7, despite the payload explicitly scoping the processor's finish line short of it:

> The implementation/review loop continues until required CI is terminal and passing…

## Why it costs real time

The implementer **cannot merge** — the review stage owns that. So a criterion worded this way makes the implementer wait on an outcome it does not control. It re-runs CI for hours and commits progress notes about the run it is watching. Each such commit creates a new head, which **invalidates the very run it just recorded**, and the loop restarts. This has cost tens of agent-hours on a single lane.

## Change

Splits the contract so each half is attributed to the stage that owns it:

- **Implementation stage** finishes at: final head pushed + PR open + CI started + blocking review feedback addressed.
- **Review stage** owns driving CI to terminal-and-passing, and owns the merge.

Also requires every plan to state that CI evidence goes in a **PR comment, never in a commit** — which is the mechanism that closes the invalidation loop.

The lane-level contract is unchanged: a PR that is merely opened, green, approved, or ready to merge is still not complete.

## Scope

One file, prose only. No behavior change in Go, the API, or the UI.

Workstation prompts are not hot-reloaded, so this takes effect at the next daemon restart rather than immediately.