### PR TITLE
fix(gocoveragecheck): make the quarantine ratchet tier-aware

### DIFF
--- a/cmd/gocoveragecheck/functional_quarantine.go
+++ b/cmd/gocoveragecheck/functional_quarantine.go
@@ -155,10 +155,19 @@ func runFunctionalQuarantineRatchet(manifest functionalQuarantine, timeout time.
 		}
 
 		status := "expected"
-		if result.Observed == functionalQuarantineOutcomePass {
+		switch {
+		case result.Observed == functionalQuarantineOutcomePass:
 			status = "unexpected-pass"
 			failures = append(failures, fmt.Errorf("functional quarantine ratchet: selector %q passed unexpectedly (bucket=%s); remove or narrow this quarantine entry", functionalSelectorDisplay(entry), entry.Bucket))
-		} else if result.Observed != expected {
+		case result.Observed == expected:
+		case unmeasurableFunctionalQuarantineOutcome(short, expected, result.Observed):
+			// Under -short the selector never executes, so "did it fail?" is
+			// unmeasurable rather than answered. Treating that as a violation
+			// makes a GENUINELY FAILING entry impossible to validate on the PR
+			// tier, which runs -short while pushes do not. Report it and move
+			// on; unexpected-pass above still catches stale entries.
+			status = "unmeasurable-under-short"
+		default:
 			status = "unexpected-outcome"
 			failures = append(failures, fmt.Errorf("functional quarantine ratchet: selector %q observed %s, expected %s for bucket=%s; verify the quarantine bucket and precondition", functionalSelectorDisplay(entry), result.Observed, expected, entry.Bucket))
 		}
@@ -250,6 +259,21 @@ func parseFunctionalQuarantineOutcome(jsonOutput string, entry functionalQuarant
 	}
 	result.Observed = terminal.Action
 	return result, nil
+}
+
+// unmeasurableFunctionalQuarantineOutcome reports whether a quarantined
+// selector's outcome could not be measured because the run was short-mode.
+//
+// The functional tier differs between triggers: a pull request runs -short and
+// a push to the default branch does not. A test that self-skips under
+// testing.Short() is therefore observed as a skip on the PR tier no matter
+// whether it fails, so asserting expected=fail there asks an unanswerable
+// question. Only a GENUINELY FAILING entry is affected; an ENVIRONMENT-DEPENDENT
+// entry already expects a skip.
+func unmeasurableFunctionalQuarantineOutcome(short bool, expected, observed string) bool {
+	return short &&
+		expected == functionalQuarantineOutcomeFail &&
+		observed == functionalQuarantineOutcomeSkip
 }
 
 func expectedFunctionalQuarantineOutcome(bucket string) (string, error) {

--- a/cmd/gocoveragecheck/functional_quarantine_test.go
+++ b/cmd/gocoveragecheck/functional_quarantine_test.go
@@ -321,6 +321,61 @@ func TestFunctionalQuarantineRatchetAcceptsExpectedOutcomesIndependently(t *test
 	}
 }
 
+func TestFunctionalQuarantineRatchetTreatsShortSkipAsUnmeasurableForFailureBucket(t *testing.T) {
+	originalRunner := commandRunner
+	originalStdout := stdoutWriter
+	t.Cleanup(func() {
+		commandRunner = originalRunner
+		stdoutWriter = originalStdout
+	})
+
+	packagePath := modulePath + "/tests/functional/shortskipped"
+	entry := functionalQuarantineEntry{
+		Package:  packagePath,
+		Test:     "TestKnownFailureGuardedByShort",
+		Bucket:   functionalBucketFailure,
+		Reason:   "known defect; reproduced on the same machine at tip and parent",
+		FollowUp: "fix the defect and remove this entry",
+	}
+
+	var stdout bytes.Buffer
+	stdoutWriter = &stdout
+	commandRunner = func(invocation commandInvocation) (string, string, error) {
+		return marshalFunctionalTimingEvents(
+			goTestTimingEvent{Action: "start", Package: packagePath},
+			goTestTimingEvent{Action: "skip", Package: packagePath, Test: entry.Test},
+			goTestTimingEvent{Action: timingOutcomeSkip, Package: packagePath},
+		), "", nil
+	}
+
+	manifest := functionalQuarantine{Entries: []functionalQuarantineEntry{entry}}
+
+	// short=true is the pull-request tier. The selector self-skips under
+	// testing.Short(), so whether it fails cannot be observed and must not be
+	// reported as a bucket violation.
+	if err := runFunctionalQuarantineRatchet(manifest, time.Minute, true, t.TempDir()); err != nil {
+		t.Fatalf("runFunctionalQuarantineRatchet(short=true) error = %v, want a GENUINELY FAILING entry to survive an unmeasurable short-mode skip", err)
+	}
+	wantStatus := `bucket=GENUINELY FAILING expected=fail observed=skip status=unmeasurable-under-short`
+	if !strings.Contains(stdout.String(), wantStatus) {
+		t.Fatalf("ratchet stdout = %q, want substring %q", stdout.String(), wantStatus)
+	}
+
+	// short=false is the push tier, where the selector does execute. A skip
+	// there is a genuine bucket mismatch and must still fail closed.
+	stdout.Reset()
+	err := runFunctionalQuarantineRatchet(manifest, time.Minute, false, t.TempDir())
+	if err == nil {
+		t.Fatal("runFunctionalQuarantineRatchet(short=false) error = nil, want an unexpected-outcome failure when the selector skips on the full tier")
+	}
+	if !strings.Contains(err.Error(), "observed skip, expected fail") {
+		t.Fatalf("runFunctionalQuarantineRatchet(short=false) error = %v, want an observed/expected mismatch diagnostic", err)
+	}
+	if !strings.Contains(stdout.String(), "status=unexpected-outcome") {
+		t.Fatalf("ratchet stdout = %q, want status=unexpected-outcome on the full tier", stdout.String())
+	}
+}
+
 func TestFunctionalQuarantineRatchetRejectsUnexpectedPass(t *testing.T) {
 	originalRunner := commandRunner
 	originalStdout := stdoutWriter


### PR DESCRIPTION
## Problem

The functional quarantine ratchet cannot validate a `GENUINELY FAILING` entry on the pull-request tier, so any PR that quarantines a genuinely-failing test fails the gate no matter how honest its manifest is.

`.github/workflows/ci.yml:234-237` sets the tier by trigger:

```
FUNCTIONAL_TEST_TIER: push && 'merge-full' || 'pr-short'
FUNCTIONAL_SHORT:     push && 'false'      || 'true'
```

`runFunctionalQuarantineRatchet` threads `short` through to `runFunctionalQuarantineSelector`, so the selector really does run with `-short`. But `expectedFunctionalQuarantineOutcome(entry.Bucket)` depends only on the bucket. A test that self-skips under `testing.Short()` is therefore observed as a skip while the ratchet expects a fail, and the mismatch is treated as a violation.

Observed on #1964, job `94890234691`. Every `GENUINELY FAILING` entry logged:

```
bucket=GENUINELY FAILING expected=fail observed=skip status=unexpected-outcome detail=""
```

while every `ENVIRONMENT-DEPENDENT` entry logged `expected=skip observed=skip status=expected`. The job had **no failing test and no coverage regression** — it ended at `##[error]Process completed with exit code 2` purely from this mismatch.

This is the third distinct defect this repo has hit from the PR-vs-push tier asymmetry.

## Fix

Under `-short` the selector never executes, so "did it fail?" is *unmeasurable* rather than answered. Treating unmeasurable as violated is the bug. The ratchet now reports `status=unmeasurable-under-short` for that one combination and continues.

The gate is not weakened:

- `unexpected-pass` remains fatal. That is the real ratchet — it is what catches an entry that has been fixed and should be removed, and it is measurable on both tiers.
- The full tier (`push`, no `-short`) still fails closed on an observed skip, so a mislabelled bucket is still caught where it can be caught.
- `ENVIRONMENT-DEPENDENT` is untouched; it already expects a skip.

## Why not relabel the buckets instead

Relabelling those entries `ENVIRONMENT-DEPENDENT` would turn #1964 green, but it would be false: they are reproducible failures with error codes, not environment dependence. That laundering is exactly what the quarantine manifest exists to prevent. The gate is at fault here, not the buckets.

## Verification

New test `TestFunctionalQuarantineRatchetTreatsShortSkipAsUnmeasurableForFailureBucket` asserts both tiers from one manifest: `short=true` survives with `status=unmeasurable-under-short`, and `short=false` still returns an error with `status=unexpected-outcome`.

Confirmed RED before the fix by neutering the new helper — the failure reproduces the CI symptom verbatim:

```
runFunctionalQuarantineRatchet(short=true) error = functional quarantine ratchet:
selector "…#TestKnownFailureGuardedByShort" observed skip, expected fail
for bucket=GENUINELY FAILING; verify the quarantine bucket and precondition
```

GREEN with the fix: `ok github.com/portpowered/infinite-you/cmd/gocoveragecheck 11.743s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)