### PR TITLE
thr-acp-prompt-delegation-regression-from-wse-c

### DIFF
--- a/pkg/services/workers/internal/service/agent_loop.go
+++ b/pkg/services/workers/internal/service/agent_loop.go
@@ -54,11 +54,14 @@ func (s *Service) agentLoopRunner(
 ) workers.Runner {
 	if providerOverride != nil && identity == runners.AgentIdentity &&
 		!usesACPProvider(request.Target.ExecutorProvider) {
-		return workerrecording.NewProviderRunner(
-			workerexecutor.RunnerFromProvider(providerOverride),
-			request.Input.InferenceEventRecorder,
-			s.clock,
-		)
+		return agentLoopProviderOverrideRunner{
+			runner: workerrecording.NewProviderRunner(
+				workerexecutor.RunnerFromProvider(providerOverride),
+				request.Input.InferenceEventRecorder,
+				s.clock,
+			),
+			decisionEnvelopes: s.decisionEnvelopes,
+		}
 	}
 	return agentLoopRunnerFunc(func(
 		turnCtx context.Context,

--- a/pkg/services/workers/internal/service/agent_loop_result.go
+++ b/pkg/services/workers/internal/service/agent_loop_result.go
@@ -1,0 +1,137 @@
+package service
+
+import (
+	"context"
+	"strings"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+// agentLoopProviderOverrideRunner keeps the process-scoped provider override
+// on the same output-policy path as the registered Agent runner. The override
+// is an effect seam only; Factory Definitions remains the decision-envelope
+// owner for the structured result.
+type agentLoopProviderOverrideRunner struct {
+	runner            workers.Runner
+	decisionEnvelopes factorydefinitions.DecisionEnvelopeService
+}
+
+func (runner agentLoopProviderOverrideRunner) Execute(
+	ctx context.Context,
+	request workers.RunnerExecutionRequest,
+) (workers.RunnerExecutionResult, error) {
+	result, err := runner.runner.Execute(ctx, request)
+	if err != nil {
+		return result, err
+	}
+	if !usesDecisionEnvelopeRequest(request) {
+		return normalizeProviderOverrideResult(result, request), nil
+	}
+	if runner.decisionEnvelopes == nil {
+		return result, errMisconfigured(
+			"agent decision-envelope service is required for decision-envelope output",
+		)
+	}
+	return normalizeDetachedDecisionEnvelope(result, request, runner.decisionEnvelopes)
+}
+
+func usesDecisionEnvelopeRequest(request workers.RunnerExecutionRequest) bool {
+	return request.DecisionEnvelope || strings.EqualFold(
+		strings.TrimSpace(request.OutputFormat),
+		factorydefinitions.DecisionEnvelopeOutcomeFormat,
+	)
+}
+
+func normalizeDetachedDecisionEnvelope(
+	result workers.RunnerExecutionResult,
+	request workers.RunnerExecutionRequest,
+	decisionEnvelopes factorydefinitions.DecisionEnvelopeService,
+) (workers.RunnerExecutionResult, error) {
+	parsed := decisionEnvelopeWorkResult(decisionEnvelopes, request, result.Content)
+	result.Outcome = parsed.Outcome
+	result.Feedback = strings.TrimSpace(parsed.Feedback)
+	result.Classification = parsed.SelectedClassificationLabel
+	result.RecordedOutputWork = parsed.RecordedOutputWork
+	result.Diagnostics = mergeRunnerDecisionEnvelopeDiagnostics(result.Diagnostics, parsed.Diagnostics)
+	if strings.TrimSpace(parsed.Error) != "" {
+		failureType := workers.WorkFailureTypeUnknown
+		if parsed.FailureMetadata != nil && strings.TrimSpace(string(parsed.FailureMetadata.Type)) != "" {
+			failureType = parsed.FailureMetadata.Type
+		}
+		failure := workers.NewProviderError(
+			failureType,
+			boundedDetachedDecisionEnvelopeMessage(parsed.Error),
+			nil,
+		)
+		failure.ProviderSession = workers.CloneProviderSessionMetadata(result.ProviderSession)
+		failure.Diagnostics = workers.CloneWorkDiagnostics(result.Diagnostics)
+		return result, failure
+	}
+	result.Content = strings.TrimSpace(parsed.Output)
+	return result, nil
+}
+
+func decisionEnvelopeWorkResult(
+	decisionEnvelopes factorydefinitions.DecisionEnvelopeService,
+	request workers.RunnerExecutionRequest,
+	raw string,
+) workers.WorkResult {
+	if request.GoalRoutingDecisionEnvelope {
+		return decisionEnvelopes.WorkResultFromGoalRoutingDecisionEnvelopeJSONOrFailed(
+			request.Dispatch.DispatchID,
+			request.Dispatch.TransitionID,
+			raw,
+		)
+	}
+	return decisionEnvelopes.WorkResultFromDecisionEnvelopeJSONOrFailed(
+		request.Dispatch.DispatchID,
+		request.Dispatch.TransitionID,
+		raw,
+	)
+}
+
+func mergeRunnerDecisionEnvelopeDiagnostics(
+	base *workers.WorkDiagnostics,
+	envelope *workers.WorkDiagnostics,
+) *workers.WorkDiagnostics {
+	if envelope == nil {
+		return base
+	}
+	merged := workers.CloneWorkDiagnostics(base)
+	if merged == nil {
+		return workers.CloneWorkDiagnostics(envelope)
+	}
+	overlay := workers.CloneWorkDiagnostics(envelope)
+	if overlay.Provider != nil {
+		if merged.Provider == nil {
+			merged.Provider = overlay.Provider
+		} else {
+			if merged.Provider.ResponseMetadata == nil {
+				merged.Provider.ResponseMetadata = make(map[string]string, len(overlay.Provider.ResponseMetadata))
+			}
+			for key, value := range overlay.Provider.ResponseMetadata {
+				merged.Provider.ResponseMetadata[key] = value
+			}
+		}
+	}
+	if overlay.Metadata != nil {
+		if merged.Metadata == nil {
+			merged.Metadata = make(map[string]string, len(overlay.Metadata))
+		}
+		for key, value := range overlay.Metadata {
+			merged.Metadata[key] = value
+		}
+	}
+	return merged
+}
+
+func boundedDetachedDecisionEnvelopeMessage(message string) string {
+	message = strings.TrimSpace(message)
+	const maxRunes = 512
+	runes := []rune(message)
+	if len(runes) <= maxRunes {
+		return message
+	}
+	return string(runes[:maxRunes])
+}

--- a/pkg/services/workers/internal/service/service.go
+++ b/pkg/services/workers/internal/service/service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/providers"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	"github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners"
@@ -30,6 +31,9 @@ type Service struct {
 	// declares Tools.AgentLoop. It is immutable process configuration; the loop
 	// itself keeps no state between Execute calls.
 	agentRunHarness agentrun.HarnessAdapter
+	// decisionEnvelopes is the Factory Definitions owner used when a detached
+	// provider override replaces the registered Agent runner.
+	decisionEnvelopes factorydefinitions.DecisionEnvelopeService
 }
 
 // New constructs an inert Execute capability. Construction performs no runner
@@ -56,6 +60,7 @@ func New(
 		temporaryFiles,
 		nil,
 		nil,
+		nil,
 		factoryDocs...,
 	)
 }
@@ -75,6 +80,7 @@ func NewWithProviderOverride(
 	temporaryFiles workers.TemporaryFileSystem,
 	providerOverride workers.Provider,
 	agentRunHarness agentrun.HarnessAdapter,
+	decisionEnvelopes factorydefinitions.DecisionEnvelopeService,
 	factoryDocs ...workers.FactoryDocsLoader,
 ) (*Service, error) {
 	return newService(
@@ -88,6 +94,7 @@ func NewWithProviderOverride(
 		temporaryFiles,
 		providerOverride,
 		agentRunHarness,
+		decisionEnvelopes,
 		factoryDocs...,
 	)
 }
@@ -103,6 +110,7 @@ func newService(
 	temporaryFiles workers.TemporaryFileSystem,
 	providerOverride workers.Provider,
 	agentRunHarness agentrun.HarnessAdapter,
+	decisionEnvelopes factorydefinitions.DecisionEnvelopeService,
 	factoryDocs ...workers.FactoryDocsLoader,
 ) (*Service, error) {
 	if runnerService == nil {
@@ -116,16 +124,17 @@ func newService(
 		docsLoader = factoryDocs[0]
 	}
 	return &Service{
-		runners:          runnerService,
-		providers:        providersService,
-		providerOverride: providerOverride,
-		observe:          observe,
-		logger:           logging.EnsureLogger(logger),
-		clock:            clock,
-		worktree:         worktree,
-		worktreeRelease:  worktreeRelease,
-		temporaryFiles:   temporaryFiles,
-		factoryDocs:      docsLoader,
-		agentRunHarness:  agentRunHarness,
+		runners:           runnerService,
+		providers:         providersService,
+		providerOverride:  providerOverride,
+		observe:           observe,
+		logger:            logging.EnsureLogger(logger),
+		clock:             clock,
+		worktree:          worktree,
+		worktreeRelease:   worktreeRelease,
+		temporaryFiles:    temporaryFiles,
+		factoryDocs:       docsLoader,
+		agentRunHarness:   agentRunHarness,
+		decisionEnvelopes: decisionEnvelopes,
 	}, nil
 }

--- a/pkg/services/workers/wire/stateless_execute_test.go
+++ b/pkg/services/workers/wire/stateless_execute_test.go
@@ -241,6 +241,73 @@ func TestNewServiceExecuteUsesProcessProviderOverrideForAgentRequests(t *testing
 	}
 }
 
+func TestNewServiceExecuteDetachedAgentRunPreservesGoalDecisionEnvelope(t *testing.T) {
+	t.Parallel()
+
+	input := newStatelessConstructionInputs()
+	override := &statelessProviderOverride{
+		content: `{"decision":"ACCEPTED","feedback":"ready","output":"ship"}`,
+	}
+	service, err := NewService(
+		input.agentDependencies,
+		input.scriptConfig,
+		input.scriptDependencies,
+		input.inferenceConfig,
+		input.inferenceDependencies,
+		nil,
+		nil,
+		func() time.Time { return time.Unix(1, 0) },
+		nil,
+		nil,
+		nil,
+		nil,
+		override,
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	result, err := service.Execute(context.Background(), workers.ExecuteRequest{
+		Correlation: workers.ExecutionCorrelation{
+			FactorySessionID: "session-goal",
+			RuntimeID:        "runtime-goal",
+			GenerationID:     "generation-goal",
+			DispatchID:       "dispatch-goal",
+			AttemptID:        "attempt-goal",
+		},
+		Target: workers.ExecutionTarget{
+			WorkerName:      runners.AgentIdentity,
+			WorkstationName: "execute-goal",
+			RunnerID:        runners.AgentIdentity,
+			Provider:        workers.ProviderReference{ID: string(providers.IDCodex)},
+			Prompt:          workers.PromptPolicy{UserMessage: "complete this goal"},
+			Tools: workers.ToolPolicy{
+				AgentLoop: true,
+			},
+			Output: workers.OutputPolicy{
+				Format:                      factorydefinitions.DecisionEnvelopeOutcomeFormat,
+				DecisionEnvelope:            true,
+				GoalRoutingDecisionEnvelope: true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result.Outcome != workers.ExecutionOutcomeAccepted {
+		t.Fatalf("outcome = %q, failure = %#v, want ACCEPTED", result.Outcome, result.Failure)
+	}
+	if len(result.Output.Primary) != 1 || result.Output.Primary[0].Text != "ship" {
+		t.Fatalf("output = %#v, want the decision-envelope primary output", result.Output)
+	}
+	if result.Output.Feedback != "ready" || result.Output.Classification != "accepted" {
+		t.Fatalf("output metadata = %#v, want feedback and goal classification", result.Output)
+	}
+	if override.calls.Load() != 1 {
+		t.Fatalf("provider override calls = %d, want one detached AGENT_RUN attempt", override.calls.Load())
+	}
+}
+
 type statelessTestFixture struct {
 	service  workers.Service
 	provider *statelessTestProviders
@@ -582,6 +649,7 @@ type statelessTestProviders struct {
 type statelessProviderOverride struct {
 	calls   atomic.Int32
 	request workers.ProviderInferenceRequest
+	content string
 }
 
 func (provider *statelessProviderOverride) Infer(
@@ -590,8 +658,12 @@ func (provider *statelessProviderOverride) Infer(
 ) (workers.InferenceResponse, error) {
 	provider.calls.Add(1)
 	provider.request = request
+	content := provider.content
+	if content == "" {
+		content = "override output\n<COMPLETE>"
+	}
 	return workers.InferenceResponse{
-		Content: "override output\n<COMPLETE>",
+		Content: content,
 		ProviderSession: &workers.ProviderSessionMetadata{
 			Provider: "codex",
 			Kind:     "session-id",
@@ -702,5 +774,9 @@ func (double statelessDecisionEnvelopeDouble) WorkResultFromGoalRoutingDecisionE
 	transitionID string,
 	raw string,
 ) workers.WorkResult {
-	return double.WorkResultFromDecisionEnvelopeJSONOrFailed(dispatchID, transitionID, raw)
+	result := double.WorkResultFromDecisionEnvelopeJSONOrFailed(dispatchID, transitionID, raw)
+	if result.Outcome == workers.OutcomeAccepted {
+		result.SelectedClassificationLabel = "accepted"
+	}
+	return result
 }

--- a/pkg/services/workers/wire/wire.go
+++ b/pkg/services/workers/wire/wire.go
@@ -105,6 +105,7 @@ func NewService(
 		temporaryFiles,
 		providerOverride,
 		agentrun.NewLibraryHarnessAdapter(agentToolFiles),
+		agentDependencies.DecisionEnvelopes,
 		scriptDependencies.FactoryDocs,
 	)
 	if err != nil {


### PR DESCRIPTION
{
  "project": "Restore ACP prompt delegation through detached AGENT_RUN dispatch",
  "branchName": "thr-acp-prompt-delegation-regression-from-wse-c",
  "description": "Restore the ACP prompt-delegation behavior regressed by PR #1938 with a smallest-correct fix in the Workers-owned detached AGENT_RUN dispatch path. Preserve the packaged goal decision-envelope outcome so delegated prompts complete instead of routing goal work to failure, add a focused Workers-level regression guard, retain the existing ACP lifecycle guarantees, and deliver the change through terminal CI, review, conflict reconciliation, and merge.",
  "context": {
    "customerAsk": "Fix the deterministic three-test ACP prompt-delegation regression introduced by PR #1938. This lane owns only the Workers-side ACP/detached AGENT_RUN dispatch correction and focused coverage, must preserve the seven ACP behaviors #1938 repaired, and must respect the listed concurrent-PR file ownership exclusions.",
    "problem": "At merge commit fdc0bbf99, all three TestACPPromptDelegation* functional tests fail deterministically although they pass at first parent e97b1a8f6. ACP returns INVOCATION_RUNTIME_FAILURE because valid goal work reaches goal:failed before a primary result exists. The packaged goal suite passes, localizing the defect to detached Workers execution: the execute-goal AGENT_RUN dispatch fails or its decision-envelope result is lost or misclassified. PR functional CI runs in short mode, so an otherwise green PR does not prove these tests ran.",
    "solution": "Record the baseline 3/3 failure, capture the underlying Workers dispatch or outcome-classification reason, and add a focused test near the failing detached AGENT_RUN behavior that is red without the fix. Correct the earliest Workers-owned boundary that loses valid request, execution, or structured outcome data while preserving existing ownership, contracts, explicit state, cancellation, and injected side-effect boundaries. Add safe structured diagnostics only if the inner reason is otherwise unavailable, then prove the focused test, all three ACP prompt-delegation behaviors, the packaged goal suite, and the Workers package are green."
  },
  "acceptanceCriteria": [
    "On the branch point, go test ./tests/functional/chat_sessions/root_composition -run '^TestACPPromptDelegation' -count=1 is recorded failing 3/3; after the fix, the same command passes 3/3, and both results are posted in PR comments rather than committed evidence.",
    "A focused test nearer the changed Workers behavior than the functional suite fails without the fix and passes with it, proving that an ACP-equivalent detached AGENT_RUN dispatch returns a successful, classifiable decision-envelope result instead of a failed workstation outcome.",
    "Successful later ACP turns reuse the original Factory Session; redelivery makes no second Factory dispatch; and a concurrent prompt is rejected as busy with no Factory dispatch, with the existing functional assertions left intact.",
    "go test ./tests/functional/factory/packaged/goal/... -count=1 and go test ./pkg/services/workers/... -count=1 pass, and no unrelated ACP test, quarantine entry, packaged Factory definition, UI behavior, generated artifact, or concurrent-owner file is changed.",
    "The final change is rebased onto current origin/main before the final push; if PR #1961 lands and conflicts in its owned agentrun tool-policy files, main is accepted as authoritative and the scoped tests are rerun instead of hand-merging those files.",
    "Quality gate: typecheck, focused and required tests, and required CI pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Delivery: the implementation/review loop continues until required CI is terminal and passing on the final head, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file churn are resolved, and the PR is actually merged; an opened, green, approved, or merge-ready PR is not complete."
  ],
  "userStories": [
    {
      "id": "thr-acp-prompt-delegation-regression-from-wse-c-001",
      "title": "Restore detached AGENT_RUN completion",
      "description": "As an ACP user, I want delegated goal execution to produce a successful classifiable outcome so my prompt returns a final result instead of an internal invocation failure.",
      "acceptanceCriteria": [
        "The pre-change failure is reproduced through the existing TestACPPromptDelegation* command, and investigation captures the actual Workers dispatch or outcome-classification failure beneath INVOCATION_RUNTIME_FAILURE.",
        "A focused test near the Workers path exercises the ACP-equivalent detached AGENT_RUN request, execution, and decision-envelope result boundary; it is red without the fix and green with the fix.",
        "The corrected path returns the successful structured outcome required for classification routes to fire and does not route otherwise-valid goal work to its failure state.",
        "The fix preserves existing Workers request/result contracts, explicit state and cancellation behavior, and side effects through existing injected execution boundaries; it introduces no secondary composition or special ACP-only dependency path.",
        "If existing diagnostics cannot expose the inner failure, the owning Workers operation emits safe structured context sufficient to distinguish dispatch failure from outcome-classification failure without logging prompts, credentials, raw provider commands, or other sensitive payloads.",
        "The change remains the smallest root-cause fix and does not modify executor.go or tools.go tool-policy behavior owned by PR #1961.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Threaded the existing Factory Definitions decision-envelope owner through detached provider-override AGENT_RUN execution and added a focused Workers wire regression. Focused, full Workers, packaged goal, ACP prompt-delegation, and Workers vet checks pass locally."
    },
    {
      "id": "thr-acp-prompt-delegation-regression-from-wse-c-002",
      "title": "Preserve ACP delegation lifecycle behavior",
      "description": "As an ACP user, I want retries and overlapping turns to preserve session and dispatch guarantees after the execution fix so delegation remains correct beyond the first successful response.",
      "acceptanceCriteria": [
        "TestACPPromptDelegationStartsOneFactorySessionAndReusesItForLaterTurns returns successful final results, starts exactly one Factory Session, and reuses it for later turns.",
        "TestACPPromptDelegationRedeliveredRequestMakesNoSecondFactoryDispatch returns the established result for a redelivered request without a second Factory dispatch.",
        "TestACPPromptDelegationConcurrentPromptRejectsAsBusyWithNoFactoryDispatch rejects the overlapping prompt as busy and performs no Factory dispatch for that rejected prompt.",
        "The three existing functional tests remain unweakened and pass together with -count=1; the packaged goal suite and the full Workers package also pass with -count=1.",
        "Before/after functional and focused-test red/green evidence is posted in PR comments and refers to the tested commits without creating an evidence-only commit.",
        "No entry is added to tests/functional/functional-quarantine.json, and no unrelated ACP failure is changed, skipped, relaxed, or claimed as fixed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": false,
      "notes": ""
    }
  ]
}
