### PR TITLE
thr-setup-workspace-shared-stash-race

### DIFF
--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 
 IMMUTABLE_OBJECT_ID = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
+SNAPSHOT_REF_PREFIX = "refs/factory-snapshots/"
 
 
 def run_git(*args, cwd=None, check=True, env=None):
@@ -76,6 +77,40 @@ def require_git_output(result, description):
 def immutable_object_id(value):
     """Return True only for a complete SHA-1 or SHA-256 object identifier."""
     return bool(IMMUTABLE_OBJECT_ID.fullmatch(value))
+
+
+def snapshot_ref_name(snapshot_id):
+    """Return the private recovery ref for an immutable snapshot ID."""
+    return f"{SNAPSHOT_REF_PREFIX}{snapshot_id}"
+
+
+def anchor_snapshot(repo_path, snapshot_id):
+    """Keep a captured snapshot reachable without touching the stash stack."""
+    ref_name = snapshot_ref_name(snapshot_id)
+    result = run_git(
+        "update-ref", ref_name, snapshot_id, "",
+        cwd=repo_path, check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"failed to anchor snapshot {snapshot_id} at {ref_name}: "
+            f"{command_failure_details(result)}"
+        )
+
+
+def remove_snapshot_anchor(repo_path, snapshot_id, scope_label):
+    """Delete only the expected private ref after a successful restore."""
+    ref_name = snapshot_ref_name(snapshot_id)
+    result = run_git(
+        "update-ref", "-d", ref_name, snapshot_id,
+        cwd=repo_path, check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"{scope_label} sync restored snapshot {snapshot_id}, but could "
+            f"not remove its private recovery ref {ref_name}; the snapshot "
+            f"remains anchored: {command_failure_details(result)}"
+        )
 
 
 def temporary_index_path():
@@ -190,7 +225,8 @@ def stash_local_changes(repo_path, label):
     The snapshot has a working-tree commit, an index commit, and, when needed,
     an untracked-files commit as its third parent. It is never added to the
     shared refs/stash stack, so its complete object ID remains stable while
-    other worktrees create ordinary stashes.
+    other worktrees create ordinary stashes. A private recovery ref keeps the
+    snapshot reachable until restoration succeeds.
     """
     if not working_tree_has_local_changes(repo_path):
         return None
@@ -222,6 +258,7 @@ def stash_local_changes(repo_path, label):
             )
             parents.append(untracked_commit)
         snapshot_id = commit_tree(repo_path, tracked_tree, parents, label)
+        anchor_snapshot(repo_path, snapshot_id)
     except (OSError, RuntimeError) as error:
         raise RuntimeError(
             f"failed to capture local changes as snapshot: {error}"
@@ -258,7 +295,7 @@ def verify_snapshot(repo_path, snapshot_id, scope_label):
 
 
 def restore_stashed_changes(repo_path, snapshot_id, scope_label):
-    """Restore a snapshot by object ID and preserve it on failure."""
+    """Restore a snapshot by object ID and preserve its recovery ref on failure."""
     if snapshot_id is None:
         return
 
@@ -295,6 +332,8 @@ def restore_stashed_changes(repo_path, snapshot_id, scope_label):
                 f"{snapshot_id} failed; the snapshot was preserved with the "
                 f"unrestored changes: {details}"
             )
+
+    remove_snapshot_anchor(repo_path, snapshot_id, scope_label)
 
 
 def read_prd(prd_path):

--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -11,20 +11,26 @@ Exit 0 on success (stdout = JSON blob), exit 1 on failure (stderr = stage-specif
 """
 
 import json
-
+import os
+import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
-def run_git(*args, cwd=None, check=True):
+IMMUTABLE_OBJECT_ID = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
+
+
+def run_git(*args, cwd=None, check=True, env=None):
     """Run a git command, returning stdout. Raises on failure if check=True."""
     result = subprocess.run(
         ["git"] + list(args),
         cwd=cwd,
         capture_output=True,
         text=True,
+        env=env,
     )
     if check and result.returncode != 0:
         raise RuntimeError(
@@ -52,36 +58,218 @@ def working_tree_has_local_changes(repo_path):
     return bool(status.stdout.strip())
 
 
-def stash_local_changes(repo_path, label):
-    """Stash local changes and return the top stash ref, or None when clean."""
-    if not working_tree_has_local_changes(repo_path):
-        return None
+def command_failure_details(result):
+    """Return useful stderr/stdout text from a failed git command."""
+    return (result.stderr or result.stdout).strip() or "no details available"
 
+
+def require_git_output(result, description):
+    """Return non-empty command output or raise a contextual error."""
+    if result.returncode != 0:
+        raise RuntimeError(f"{description}: {command_failure_details(result)}")
+    output = result.stdout.strip()
+    if not output:
+        raise RuntimeError(f"{description}: git returned no object identifier")
+    return output
+
+
+def immutable_object_id(value):
+    """Return True only for a complete SHA-1 or SHA-256 object identifier."""
+    return bool(IMMUTABLE_OBJECT_ID.fullmatch(value))
+
+
+def temporary_index_path():
+    """Create a path for a temporary Git index without leaving an empty file."""
+    file_descriptor, path = tempfile.mkstemp(prefix="setup-workspace-index-")
+    os.close(file_descriptor)
+    temporary_path = Path(path)
+    temporary_path.unlink()
+    return temporary_path
+
+
+def git_index_path(repo_path):
+    """Resolve the worktree-specific index path used by Git."""
+    result = run_git("rev-parse", "--git-path", "index", cwd=repo_path)
+    index_path = Path(result.stdout.strip())
+    if not index_path.is_absolute():
+        index_path = repo_path / index_path
+    return index_path
+
+
+def environment_with_index(index_path):
+    """Return an environment that directs Git commands to index_path."""
+    environment = os.environ.copy()
+    environment["GIT_INDEX_FILE"] = str(index_path)
+    return environment
+
+
+def working_tree_tree(repo_path):
+    """Write the tracked working-tree state to an immutable tree object."""
+    temporary_path = temporary_index_path()
+    try:
+        source_index = git_index_path(repo_path)
+        if source_index.exists():
+            shutil.copy2(source_index, temporary_path)
+        else:
+            run_git(
+                "read-tree", "HEAD", cwd=repo_path,
+                env=environment_with_index(temporary_path),
+            )
+
+        environment = environment_with_index(temporary_path)
+        run_git("add", "-u", cwd=repo_path, env=environment)
+        return require_git_output(
+            run_git("write-tree", cwd=repo_path, env=environment),
+            "failed to capture the tracked working tree",
+        )
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def untracked_paths(repo_path):
+    """Return non-ignored untracked paths as Git pathspec arguments."""
     result = run_git(
-        "stash", "push", "--include-untracked", "--message", label,
-        cwd=repo_path, check=False,
+        "ls-files", "--others", "--exclude-standard", "-z",
+        cwd=repo_path,
+        check=False,
     )
     if result.returncode != 0:
         raise RuntimeError(
-            "failed to stash local changes: "
-            f"{(result.stderr or result.stdout).strip()}"
+            f"failed to enumerate untracked files: {command_failure_details(result)}"
+        )
+    return [path for path in result.stdout.split("\0") if path]
+
+
+def untracked_tree(repo_path, paths):
+    """Write the captured untracked files to an immutable tree object."""
+    temporary_path = temporary_index_path()
+    try:
+        environment = environment_with_index(temporary_path)
+        run_git("read-tree", "--empty", cwd=repo_path, env=environment)
+        run_git("add", "--", *paths, cwd=repo_path, env=environment)
+        return require_git_output(
+            run_git("write-tree", cwd=repo_path, env=environment),
+            "failed to capture untracked files",
+        )
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def commit_tree(repo_path, tree, parents, message):
+    """Create a dangling commit that owns one part of a local snapshot."""
+    args = ["commit-tree", tree]
+    for parent in parents:
+        args.extend(["-p", parent])
+    args.extend(["-m", message])
+    object_id = require_git_output(
+        run_git(*args, cwd=repo_path, check=False),
+        f"failed to create snapshot object for {message}",
+    )
+    if not immutable_object_id(object_id):
+        raise RuntimeError(
+            f"failed to create snapshot object for {message}: "
+            f"invalid object identifier {object_id!r}"
+        )
+    return object_id
+
+
+def clear_local_changes(repo_path, snapshot_id):
+    """Remove the captured state from the worktree before synchronization."""
+    for args in (("reset", "--hard", "HEAD"), ("clean", "-fd")):
+        result = run_git(*args, cwd=repo_path, check=False)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"failed to clear local changes for snapshot {snapshot_id}: "
+                f"{command_failure_details(result)}"
+            )
+
+
+def stash_local_changes(repo_path, label):
+    """Capture local changes in a stack-independent commit snapshot.
+
+    The snapshot has a working-tree commit, an index commit, and, when needed,
+    an untracked-files commit as its third parent. It is never added to the
+    shared refs/stash stack, so its complete object ID remains stable while
+    other worktrees create ordinary stashes.
+    """
+    if not working_tree_has_local_changes(repo_path):
+        return None
+
+    try:
+        head = require_git_output(
+            run_git("rev-parse", "HEAD", cwd=repo_path, check=False),
+            "failed to resolve HEAD while capturing local changes",
+        )
+        index_tree = require_git_output(
+            run_git("write-tree", cwd=repo_path, check=False),
+            "failed to capture the staged index",
+        )
+        index_commit = commit_tree(
+            repo_path,
+            index_tree,
+            [head],
+            f"index for {label}",
+        )
+        tracked_tree = working_tree_tree(repo_path)
+        paths = untracked_paths(repo_path)
+        parents = [head, index_commit]
+        if paths:
+            untracked_commit = commit_tree(
+                repo_path,
+                untracked_tree(repo_path, paths),
+                [],
+                f"untracked files for {label}",
+            )
+            parents.append(untracked_commit)
+        snapshot_id = commit_tree(repo_path, tracked_tree, parents, label)
+    except (OSError, RuntimeError) as error:
+        raise RuntimeError(
+            f"failed to capture local changes as snapshot: {error}"
+        ) from error
+
+    try:
+        clear_local_changes(repo_path, snapshot_id)
+    except RuntimeError as error:
+        raise RuntimeError(
+            f"failed to prepare synchronization with snapshot {snapshot_id}: {error}"
+        ) from error
+
+    return snapshot_id
+
+
+def verify_snapshot(repo_path, snapshot_id, scope_label):
+    """Verify that snapshot_id is a complete commit object before applying it."""
+    if not immutable_object_id(snapshot_id):
+        raise RuntimeError(
+            f"{scope_label} sync could not verify snapshot {snapshot_id}: "
+            "the identifier is not a complete immutable object ID"
         )
 
-    return "stash@{0}"
+    result = run_git(
+        "cat-file", "-e", f"{snapshot_id}^{{commit}}",
+        cwd=repo_path,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"{scope_label} sync could not verify snapshot {snapshot_id}: "
+            f"{command_failure_details(result)}"
+        )
 
 
-def restore_stashed_changes(repo_path, stash_ref, scope_label):
-    """Restore a stashed worktree and keep the stash entry on failure."""
-    if stash_ref is None:
+def restore_stashed_changes(repo_path, snapshot_id, scope_label):
+    """Restore a snapshot by object ID and preserve it on failure."""
+    if snapshot_id is None:
         return
 
+    verify_snapshot(repo_path, snapshot_id, scope_label)
     apply_result = run_git(
-        "stash", "apply", "--index", stash_ref,
+        "stash", "apply", "--index", snapshot_id,
         cwd=repo_path, check=False,
     )
     if apply_result.returncode != 0:
         fallback_result = run_git(
-            "stash", "apply", stash_ref,
+            "stash", "apply", snapshot_id,
             cwd=repo_path, check=False,
         )
         if fallback_result.returncode != 0:
@@ -89,25 +277,24 @@ def restore_stashed_changes(repo_path, stash_ref, scope_label):
             if not details:
                 details = (apply_result.stderr or apply_result.stdout).strip()
             # A failed apply leaves a half-applied, possibly conflicted tree.
-            # Unmerged index entries make every later `git stash push` fail,
+            # Unmerged index entries make every later snapshot capture fail,
             # which wedges all future workspace setups until a human cleans
-            # the root checkout. Reset back to a clean tree; the stash entry
-            # still holds the full residue. `git clean` honors .gitignore, so
-            # ignored operator files (docs/temp, tasks/todo) are untouched.
-            run_git("reset", "--hard", "HEAD", cwd=repo_path, check=False)
-            run_git("clean", "-fd", cwd=repo_path, check=False)
+            # the root checkout. Reset back to a clean tree; the snapshot
+            # object still holds the full residue. `git clean` honors
+            # .gitignore, so ignored operator files (docs/temp, tasks/todo)
+            # are untouched.
+            cleanup_details = []
+            for args in (("reset", "--hard", "HEAD"), ("clean", "-fd")):
+                cleanup_result = run_git(*args, cwd=repo_path, check=False)
+                if cleanup_result.returncode != 0:
+                    cleanup_details.append(command_failure_details(cleanup_result))
+            if cleanup_details:
+                details = f"{details}; cleanup also failed: {'; '.join(cleanup_details)}"
             raise RuntimeError(
-                f"{scope_label} sync succeeded, but restoring stashed changes failed; "
-                f"the working tree was reset to clean and {stash_ref} was "
-                f"preserved with the unrestored changes: {details}"
+                f"{scope_label} sync succeeded, but restoring snapshot "
+                f"{snapshot_id} failed; the snapshot was preserved with the "
+                f"unrestored changes: {details}"
             )
-
-    drop_result = run_git("stash", "drop", stash_ref, cwd=repo_path, check=False)
-    if drop_result.returncode != 0:
-        raise RuntimeError(
-            f"{scope_label} sync restored local changes, but failed to drop "
-            f"{stash_ref}: {(drop_result.stderr or drop_result.stdout).strip()}"
-        )
 
 
 def read_prd(prd_path):
@@ -192,8 +379,8 @@ def confirm_ref_matches(repo_path, ref_name, expected_sha):
 
 
 def sync_checked_out_main_with_stash(repo_root, remote_sha):
-    """Temporarily stash local changes, sync main, then restore the stash."""
-    stash_ref = stash_local_changes(
+    """Temporarily snapshot local changes, sync main, then restore them."""
+    snapshot_id = stash_local_changes(
         repo_root,
         "setup-workspace root sync",
     )
@@ -205,11 +392,13 @@ def sync_checked_out_main_with_stash(repo_root, remote_sha):
         confirm_ref_matches(repo_root, "HEAD", remote_sha)
         confirm_ref_matches(repo_root, "refs/heads/main", remote_sha)
     finally:
-        restore_stashed_changes(repo_root, stash_ref, "root main")
+        restore_stashed_changes(repo_root, snapshot_id, "root main")
 
+    if snapshot_id is None:
+        return f"synced checked-out main to {remote_sha[:8]}"
     return (
-        f"stashed local changes, synced checked-out main to {remote_sha[:8]}, "
-        "then restored the stash"
+        f"stashed local changes in snapshot {snapshot_id[:8]}, "
+        f"synced checked-out main to {remote_sha[:8]}, then restored the snapshot"
     )
 
 
@@ -340,7 +529,7 @@ def sync_reused_worktree_branch(repo_root, worktree_path, branch):
         return "skipped (branch has no origin ref)"
 
     upstream_ref = branch_upstream_ref(worktree_path, branch)
-    stash_ref = stash_local_changes(
+    snapshot_id = stash_local_changes(
         worktree_path,
         f"setup-workspace worktree sync {branch}",
     )
@@ -348,8 +537,11 @@ def sync_reused_worktree_branch(repo_root, worktree_path, branch):
         pull_result = run_git("pull", "--ff-only", cwd=worktree_path, check=False)
         if pull_result.returncode == 0:
             confirm_worktree_upstream_head(worktree_path, branch, upstream_ref)
-            if stash_ref is not None:
-                return "stashed local changes, fast-forwarded from upstream, then restored the stash"
+            if snapshot_id is not None:
+                return (
+                    f"stashed local changes in snapshot {snapshot_id[:8]}, "
+                    "fast-forwarded from upstream, then restored the snapshot"
+                )
             return "fast-forwarded from upstream"
 
         stderr = pull_result.stderr.strip()
@@ -367,12 +559,14 @@ def sync_reused_worktree_branch(repo_root, worktree_path, branch):
 
         run_git("reset", "--hard", upstream_ref, cwd=worktree_path)
         confirm_worktree_upstream_head(worktree_path, branch, upstream_ref)
+        if snapshot_id is None:
+            return "fetch/reset --hard to upstream after pull --ff-only failed"
         return (
-            "stashed local changes, then fetch/reset --hard to upstream "
-            "after pull --ff-only failed"
+            f"stashed local changes in snapshot {snapshot_id[:8]}, then "
+            "fetch/reset --hard to upstream after pull --ff-only failed"
         )
     finally:
-        restore_stashed_changes(worktree_path, stash_ref, f"worktree branch {branch}")
+        restore_stashed_changes(worktree_path, snapshot_id, f"worktree branch {branch}")
 
 
 def create_or_reuse_worktree(repo_root, branch, worktree_path):

--- a/tests/factory/scripts/test_setup_workspace_sync.py
+++ b/tests/factory/scripts/test_setup_workspace_sync.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Regression tests for setup-workspace sync_main quiet-skip behavior."""
 
+import contextlib
+import io
 import importlib.util
 import json
 import subprocess
@@ -323,6 +325,117 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             "M\tREADME.md\n",
         )
         self.assertTrue((local_repo / "owned-untracked.txt").exists())
+        self.assertFalse((local_repo / "interfering-only.txt").exists())
+
+        restored_foreign = git(
+            ["stash", "apply", interfering_stash[0]],
+            local_repo,
+        )
+        self.assertEqual(restored_foreign.returncode, 0, restored_foreign.stderr)
+        self.assertEqual(
+            (local_repo / "interfering-only.txt").read_text(encoding="utf-8"),
+            "foreign stash\n",
+        )
+        self.assertEqual(stash_list(local_repo), [interfering_stash[0], *stack_before])
+
+    def test_setup_exits_nonzero_when_owned_snapshot_is_missing_before_restore(self):
+        local_repo = self.repo_path / "local"
+        setup_repo_with_origin_main_ahead(local_repo, self.repo_path)
+        git(["checkout", "main"], local_repo)
+
+        (local_repo / "pre-existing.txt").write_text(
+            "pre-existing\n",
+            encoding="utf-8",
+        )
+        git(
+            [
+                "stash",
+                "push",
+                "--include-untracked",
+                "--message",
+                "pre-existing",
+            ],
+            local_repo,
+        )
+        stack_before = stash_list(local_repo)
+
+        tasks_dir = local_repo / "tasks" / "todo"
+        tasks_dir.mkdir(parents=True)
+        (local_repo / ".git" / "info" / "exclude").write_text(
+            "tasks/\n",
+            encoding="utf-8",
+        )
+        prd_name = "missing-snapshot-prd"
+        (tasks_dir / f"{prd_name}.json").write_text(
+            json.dumps({"branchName": prd_name}),
+            encoding="utf-8",
+        )
+
+        (local_repo / "README.md").write_text("owned unstaged\n", encoding="utf-8")
+        staged_file = local_repo / "owned-staged.txt"
+        staged_file.write_text("owned staged\n", encoding="utf-8")
+        git(["add", "owned-staged.txt"], local_repo)
+        (local_repo / "owned-untracked.txt").write_text(
+            "owned untracked\n",
+            encoding="utf-8",
+        )
+
+        original_root = self.module.get_repo_root
+        original_restore = self.module.restore_stashed_changes
+        original_argv = self.module.sys.argv
+        captured_snapshot = []
+        interfering_stash = []
+
+        def invalidate_snapshot(repo_path, snapshot_id, scope_label):
+            captured_snapshot.append(snapshot_id)
+            (repo_path / "interfering-only.txt").write_text(
+                "foreign stash\n",
+                encoding="utf-8",
+            )
+            git(
+                [
+                    "stash",
+                    "push",
+                    "--include-untracked",
+                    "--message",
+                    "interfering stash",
+                ],
+                repo_path,
+            )
+            interfering_stash.append(
+                git(["rev-parse", "refs/stash"], repo_path).stdout.strip()
+            )
+            git(["prune", "--expire=now"], repo_path)
+            snapshot_check = git(
+                ["cat-file", "-e", f"{snapshot_id}^{{commit}}"],
+                repo_path,
+                check=False,
+            )
+            self.assertNotEqual(snapshot_check.returncode, 0)
+            return original_restore(repo_path, snapshot_id, scope_label)
+
+        self.module.get_repo_root = lambda: local_repo
+        self.module.restore_stashed_changes = invalidate_snapshot
+        self.module.sys.argv = ["setup-workspace.py", prd_name]
+        stderr = io.StringIO()
+        try:
+            with contextlib.redirect_stderr(stderr):
+                with self.assertRaises(SystemExit) as exit_context:
+                    self.module.main()
+        finally:
+            self.module.get_repo_root = original_root
+            self.module.restore_stashed_changes = original_restore
+            self.module.sys.argv = original_argv
+
+        self.assertEqual(exit_context.exception.code, 1)
+        self.assertEqual(len(captured_snapshot), 1)
+        self.assertEqual(len(interfering_stash), 1)
+        snapshot_id = captured_snapshot[0]
+        self.assertIn(
+            f"Root sync failed: root main sync could not verify snapshot {snapshot_id}",
+            stderr.getvalue(),
+        )
+        self.assertEqual(stash_list(local_repo), [interfering_stash[0], *stack_before])
         self.assertFalse((local_repo / "interfering-only.txt").exists())
 
         restored_foreign = git(

--- a/tests/factory/scripts/test_setup_workspace_sync.py
+++ b/tests/factory/scripts/test_setup_workspace_sync.py
@@ -405,6 +405,15 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             interfering_stash.append(
                 git(["rev-parse", "refs/stash"], repo_path).stdout.strip()
             )
+            git(
+                [
+                    "update-ref",
+                    "-d",
+                    self.module.snapshot_ref_name(snapshot_id),
+                    snapshot_id,
+                ],
+                repo_path,
+            )
             git(["prune", "--expire=now"], repo_path)
             snapshot_check = git(
                 ["cat-file", "-e", f"{snapshot_id}^{{commit}}"],
@@ -448,6 +457,109 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             "foreign stash\n",
         )
         self.assertEqual(stash_list(local_repo), [interfering_stash[0], *stack_before])
+
+    def test_anchored_snapshot_survives_prune_and_is_removed_after_restore(self):
+        local_repo = self.repo_path / "local"
+        local_repo.mkdir()
+        init_local_repo(local_repo)
+
+        (local_repo / "README.md").write_text(
+            "owned unstaged\n",
+            encoding="utf-8",
+        )
+        staged_file = local_repo / "owned-staged.txt"
+        staged_file.write_text("owned staged\n", encoding="utf-8")
+        git(["add", "owned-staged.txt"], local_repo)
+        (local_repo / "owned-untracked.txt").write_text(
+            "owned untracked\n",
+            encoding="utf-8",
+        )
+
+        snapshot_id = self.module.stash_local_changes(local_repo, "anchor lifecycle")
+        snapshot_ref = self.module.snapshot_ref_name(snapshot_id)
+
+        self.assertEqual(
+            git(["show-ref", "--verify", "--hash", snapshot_ref], local_repo).stdout.strip(),
+            snapshot_id,
+        )
+        self.assertIn(
+            snapshot_ref,
+            git(
+                [
+                    "for-each-ref",
+                    "--format=%(refname)",
+                    "refs/factory-snapshots/",
+                ],
+                local_repo,
+            ).stdout.splitlines(),
+        )
+
+        git(["prune", "--expire=now"], local_repo)
+        self.assertEqual(
+            git(
+                ["cat-file", "-e", f"{snapshot_id}^{{commit}}"],
+                local_repo,
+                check=False,
+            ).returncode,
+            0,
+        )
+
+        self.module.restore_stashed_changes(local_repo, snapshot_id, "anchor lifecycle")
+
+        self.assertNotEqual(
+            git(["show-ref", "--verify", "--hash", snapshot_ref], local_repo, check=False).returncode,
+            0,
+        )
+        self.assertEqual(
+            git(["diff", "--cached", "--name-status"], local_repo).stdout,
+            "A\towned-staged.txt\n",
+        )
+        self.assertEqual(
+            git(["diff", "--name-status"], local_repo).stdout,
+            "M\tREADME.md\n",
+        )
+        self.assertEqual(
+            (local_repo / "owned-untracked.txt").read_text(encoding="utf-8"),
+            "owned untracked\n",
+        )
+
+    def test_failed_restore_keeps_snapshot_anchor_for_recovery(self):
+        local_repo = self.repo_path / "local"
+        local_repo.mkdir()
+        init_local_repo(local_repo)
+
+        owned_untracked = local_repo / "owned-untracked.txt"
+        owned_untracked.write_text("owned untracked\n", encoding="utf-8")
+        snapshot_id = self.module.stash_local_changes(local_repo, "failed restore")
+        snapshot_ref = self.module.snapshot_ref_name(snapshot_id)
+
+        owned_untracked.write_text("foreign conflicting file\n", encoding="utf-8")
+        with self.assertRaisesRegex(RuntimeError, f"snapshot {snapshot_id} failed"):
+            self.module.restore_stashed_changes(local_repo, snapshot_id, "failed restore")
+
+        self.assertEqual(
+            git(["show-ref", "--verify", "--hash", snapshot_ref], local_repo).stdout.strip(),
+            snapshot_id,
+        )
+        git(["prune", "--expire=now"], local_repo)
+        self.assertEqual(
+            git(
+                ["cat-file", "-e", f"{snapshot_id}^{{commit}}"],
+                local_repo,
+                check=False,
+            ).returncode,
+            0,
+        )
+
+        self.module.restore_stashed_changes(local_repo, snapshot_id, "failed restore recovery")
+        self.assertEqual(
+            owned_untracked.read_text(encoding="utf-8"),
+            "owned untracked\n",
+        )
+        self.assertNotEqual(
+            git(["show-ref", "--verify", "--hash", snapshot_ref], local_repo, check=False).returncode,
+            0,
+        )
 
     def test_sync_main_fast_forwards_main_without_pull_on_dirty_tree(self):
         local_repo = self.repo_path / "local"
@@ -662,6 +774,18 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
                     stdout="applied\n",
                     stderr="",
                 )
+            if args == (
+                "update-ref",
+                "-d",
+                self.module.snapshot_ref_name(snapshot_id),
+                snapshot_id,
+            ):
+                return subprocess.CompletedProcess(
+                    ["git", *args],
+                    0,
+                    stdout="",
+                    stderr="",
+                )
             return original_run_git(*args, **kwargs)
 
         self.module.run_git = fake_run_git
@@ -677,6 +801,15 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
         self.assertEqual(recorded[0], ("cat-file", "-e", f"{snapshot_id}^{{commit}}"))
         self.assertEqual(recorded[1], ("stash", "apply", "--index", snapshot_id))
         self.assertEqual(recorded[2], ("stash", "apply", snapshot_id))
+        self.assertEqual(
+            recorded[3],
+            (
+                "update-ref",
+                "-d",
+                self.module.snapshot_ref_name(snapshot_id),
+                snapshot_id,
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/factory/scripts/test_setup_workspace_sync.py
+++ b/tests/factory/scripts/test_setup_workspace_sync.py
@@ -48,6 +48,10 @@ def git(args, cwd, check=True):
     )
 
 
+def stash_list(repo_path):
+    return git(["stash", "list", "--format=%H"], repo_path).stdout.splitlines()
+
+
 def setup_repo_with_origin_main_ahead(local_repo, repo_root):
     """Create a bare remote ahead of local main; local repo on a feature branch."""
     bare_remote = repo_root / "remote.git"
@@ -246,11 +250,91 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
                 for args in recorded
             )
         )
-        self.assertTrue(any(args[:2] == ("stash", "push") for args in recorded))
+        self.assertFalse(any(args[:2] == ("stash", "push") for args in recorded))
         self.assertTrue(any(args[:2] == ("stash", "apply") for args in recorded))
-        self.assertTrue(any(args[:2] == ("stash", "drop") for args in recorded))
+        self.assertFalse(any(args[:2] == ("stash", "drop") for args in recorded))
+        self.assertTrue(any(args and args[0] == "commit-tree" for args in recorded))
+        self.assertFalse(
+            any("stash@{" in str(argument) for args in recorded for argument in args)
+        )
         self.assertTrue(any(args[:2] == ("pull", "--ff-only") for args in recorded))
         self.assertEqual(head_before, local_main_sha_before)
+
+    def test_restores_owned_snapshot_when_another_stash_is_created_before_restore(self):
+        local_repo = self.repo_path / "local"
+        setup_repo_with_origin_main_ahead(local_repo, self.repo_path)
+        git(["checkout", "main"], local_repo)
+
+        (local_repo / "pre-existing.txt").write_text("pre-existing\n", encoding="utf-8")
+        git(
+            ["stash", "push", "--include-untracked", "--message", "pre-existing"],
+            local_repo,
+        )
+        stack_before = stash_list(local_repo)
+
+        (local_repo / "README.md").write_text("owned unstaged\n", encoding="utf-8")
+        (local_repo / "owned-staged.txt").write_text("owned staged\n", encoding="utf-8")
+        git(["add", "owned-staged.txt"], local_repo)
+        (local_repo / "owned-untracked.txt").write_text(
+            "owned untracked\n",
+            encoding="utf-8",
+        )
+        remote_sha = git(
+            ["rev-parse", "refs/remotes/origin/main"],
+            local_repo,
+        ).stdout.strip()
+
+        original_restore = self.module.restore_stashed_changes
+        interfering_stash = []
+
+        def create_interfering_stash(repo_path, snapshot_id, scope_label):
+            (repo_path / "interfering-only.txt").write_text(
+                "foreign stash\n",
+                encoding="utf-8",
+            )
+            git(
+                [
+                    "stash",
+                    "push",
+                    "--include-untracked",
+                    "--message",
+                    "interfering stash",
+                ],
+                repo_path,
+            )
+            interfering_stash.append(git(["rev-parse", "refs/stash"], repo_path).stdout.strip())
+            return original_restore(repo_path, snapshot_id, scope_label)
+
+        self.module.restore_stashed_changes = create_interfering_stash
+        try:
+            outcome = self.module.sync_checked_out_main_with_stash(local_repo, remote_sha)
+        finally:
+            self.module.restore_stashed_changes = original_restore
+
+        self.assertIn("restored", outcome)
+        self.assertEqual(len(interfering_stash), 1)
+        self.assertEqual(stash_list(local_repo), [interfering_stash[0], *stack_before])
+        self.assertEqual(
+            git(["diff", "--cached", "--name-status"], local_repo).stdout,
+            "A\towned-staged.txt\n",
+        )
+        self.assertEqual(
+            git(["diff", "--name-status"], local_repo).stdout,
+            "M\tREADME.md\n",
+        )
+        self.assertTrue((local_repo / "owned-untracked.txt").exists())
+        self.assertFalse((local_repo / "interfering-only.txt").exists())
+
+        restored_foreign = git(
+            ["stash", "apply", interfering_stash[0]],
+            local_repo,
+        )
+        self.assertEqual(restored_foreign.returncode, 0, restored_foreign.stderr)
+        self.assertEqual(
+            (local_repo / "interfering-only.txt").read_text(encoding="utf-8"),
+            "foreign stash\n",
+        )
+        self.assertEqual(stash_list(local_repo), [interfering_stash[0], *stack_before])
 
     def test_sync_main_fast_forwards_main_without_pull_on_dirty_tree(self):
         local_repo = self.repo_path / "local"
@@ -437,10 +521,18 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
     def test_restore_stashed_changes_falls_back_when_index_apply_conflicts(self):
         recorded = []
         original_run_git = self.module.run_git
+        snapshot_id = "a" * 40
 
         def fake_run_git(*args, **kwargs):
             recorded.append(args)
-            if args == ("stash", "apply", "--index", "stash@{0}"):
+            if args == ("cat-file", "-e", f"{snapshot_id}^{{commit}}"):
+                return subprocess.CompletedProcess(
+                    ["git", *args],
+                    0,
+                    stdout="",
+                    stderr="",
+                )
+            if args == ("stash", "apply", "--index", snapshot_id):
                 return subprocess.CompletedProcess(
                     ["git", *args],
                     1,
@@ -450,18 +542,11 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
                         "Try without --index."
                     ),
                 )
-            if args == ("stash", "apply", "stash@{0}"):
+            if args == ("stash", "apply", snapshot_id):
                 return subprocess.CompletedProcess(
                     ["git", *args],
                     0,
                     stdout="applied\n",
-                    stderr="",
-                )
-            if args == ("stash", "drop", "stash@{0}"):
-                return subprocess.CompletedProcess(
-                    ["git", *args],
-                    0,
-                    stdout="dropped\n",
                     stderr="",
                 )
             return original_run_git(*args, **kwargs)
@@ -470,15 +555,15 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
         try:
             self.module.restore_stashed_changes(
                 self.repo_path,
-                "stash@{0}",
+                snapshot_id,
                 "root main",
             )
         finally:
             self.module.run_git = original_run_git
 
-        self.assertEqual(recorded[0], ("stash", "apply", "--index", "stash@{0}"))
-        self.assertEqual(recorded[1], ("stash", "apply", "stash@{0}"))
-        self.assertEqual(recorded[2], ("stash", "drop", "stash@{0}"))
+        self.assertEqual(recorded[0], ("cat-file", "-e", f"{snapshot_id}^{{commit}}"))
+        self.assertEqual(recorded[1], ("stash", "apply", "--index", snapshot_id))
+        self.assertEqual(recorded[2], ("stash", "apply", snapshot_id))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
{
  "project": "Isolate Setup-Workspace Snapshots from the Shared Stash Stack",
  "branchName": "thr-setup-workspace-shared-stash-race",
  "description": "Make workspace setup restore exactly the local changes it captured even when another worktree creates a stash during synchronization. Replace positional stash identity with an immutable, run-owned snapshot, preserve staged, unstaged, and untracked state, fail loudly when that snapshot cannot be verified or restored, and prove the behavior only in throwaway repositories without modifying existing operator stashes or concurrent lanes.",
  "context": {
    "customerAsk": "Correct the shared-stash race in factory/scripts/setup-workspace.py with a minimal change and direct regression tests. Prefer a snapshot created without pushing onto the repository stash stack, never use a positional stash@{N} identifier, name an unavailable snapshot in the failure, leave the 41 existing evidence stashes untouched, and exercise Git behavior only in temporary repositories.",
    "problem": "Workspace setup pushes local changes and records stash@{0} before an intervening fetch and fast-forward. Because the stash stack is shared by every worktree, another lane can move the stack head, causing setup to apply and drop foreign work while orphaning its own snapshot. Operator evidence includes 41 orphaned entries, recovered foreign work, and a stale staged root tree capable of reverting merged changes.",
    "solution": "Capture temporary local state as an immutable object ID owned by the current run, preferably through a stack-independent dangling snapshot after validating staged, unstaged, and untracked semantics in a throwaway repository. Restore only that ID, avoid normal-path shared-stack push, pop, and drop operations, validate snapshot identity before use, and abort with a snapshot-naming diagnostic when verification or restoration fails. If a transient stack entry is unavoidable to preserve the full established state contract, identify and clean it only by matching its immutable object ID, never by position."
  },
  "acceptanceCriteria": [
    "A deterministic throwaway-repository regression test creates the setup snapshot, pushes an unrelated stash before restoration, and fails against the current positional implementation but passes after the fix; setup restores only its own staged, unstaged, and untracked content while the interfering stash remains unchanged and usable.",
    "Root-main synchronization and reused-worktree synchronization identify temporary local state only by an immutable snapshot object ID; no positional stash@{N} reference identifies a snapshot anywhere under factory/scripts/, as verified with a scoped text search reported in the PR.",
    "The successful setup path leaves the temporary test repository's pre-existing and interfering stash list identical in object IDs, references, order, and count, and implementation work leaves the live repository's existing stash list and 41 recorded evidence entries unchanged.",
    "When the captured snapshot is missing, invalid, or cannot be verified, setup exits non-zero before proceeding and its stage-specific diagnostic includes the snapshot identifier without applying or deleting an unrelated stash.",
    "Existing observable setup behavior remains intact: staged, unstaged, and untracked changes are restored with their index state, clean workspaces require no snapshot, main and reused branches follow their current fast-forward and skip decisions, and worktree branching and PRD copying are unchanged.",
    "Quality gate: Typecheck passes; focused setup-workspace tests and required repository tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Delivery: the implementation stage finishes when it has pushed its final head, the PR is open, CI has started, and all blocking review feedback is addressed; the review stage owns driving CI to terminal-and-passing and merging the PR. The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file reconciliation are complete, and the PR is actually merged. CI-run evidence is posted in PR comments and never committed."
  ],
  "userStories": [
    {
      "id": "thr-setup-workspace-shared-stash-race-001",
      "title": "Restore the run-owned snapshot during concurrent stash activity",
      "description": "As a factory operator, I want each workspace setup to restore only the local state it captured so concurrent lanes cannot exchange, destroy, or orphan one another's work.",
      "acceptanceCriteria": [
        "A focused test runs entirely in a newly created temporary Git repository and deterministically inserts an unrelated stash after setup captures its snapshot but before setup restores it.",
        "The focused test is recorded failing against the current implementation because positional selection targets the unrelated top entry, then passing on the corrected implementation.",
        "After restoration, the setup-owned tracked content, staged-versus-unstaged index state, and untracked content exactly match their pre-sync state, and no content from the unrelated stash appears in the working tree.",
        "The unrelated stash and any pre-existing stash retain the same immutable object IDs, references, order, count, and restorable content after setup completes.",
        "Root-main sync and reused-worktree sync use the same immutable snapshot behavior without changing their current fetch, fast-forward, fallback, skip, branch, or worktree decisions.",
        "The normal snapshot lifecycle does not push, pop, or drop a shared stash entry; if preserving established untracked behavior makes a transient entry unavoidable, every apply and cleanup decision matches its captured object ID and never relies on stack position.",
        "The live repository stash stack is not used for testing or manual trials; its before/after count and identity are reported unchanged from read-only observation only.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented stack-independent immutable snapshot capture and restore with deterministic concurrent-stash regression coverage."
    },
    {
      "id": "thr-setup-workspace-shared-stash-race-002",
      "title": "Abort when the owned snapshot cannot be verified",
      "description": "As a factory operator, I want restoration to stop with an identifiable error when its snapshot is unavailable so setup never silently continues with another lane's or an incomplete tree.",
      "acceptanceCriteria": [
        "A focused temporary-repository test removes or invalidates the captured immutable snapshot before restoration and proves setup exits non-zero.",
        "The reported root-sync or worktree-preparation failure names the exact snapshot identifier and distinguishes snapshot verification or restoration failure from unrelated fetch and fast-forward failures.",
        "The failure path does not apply, pop, drop, reorder, or rewrite any unrelated stash entry, and the test proves the interfering stash remains restorable with its original content.",
        "A failed indexed restore may use the established non-index fallback only for the same verified immutable snapshot; neither attempt may resolve snapshot identity through stash@{N}.",
        "Existing safe handling for a half-applied or conflicted tree remains bounded to the affected temporary repository and preserves the owned snapshot when recovery is possible.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added throwaway-repository coverage proving missing snapshots fail root sync with the full immutable ID while concurrent stash entries remain unchanged and restorable."
    }
  ]
}
