### PR TITLE
thr-graph-editor-drag-observation-is-not-a-drag

### DIFF
--- a/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
@@ -12,6 +12,7 @@ import {
   selectLabeledComboboxOption,
   startFactoryApiServer,
   uiInteractionTimeoutMs,
+  waitForFactoryGraphSelectionReady,
   waitForStableFactoryGraphNodePlacement,
   waitForStableFactoryGraphViewport,
 } from "./browser-test-harness.mjs";
@@ -376,13 +377,45 @@ function savedLayoutNodePosition(factory, nodeId) {
   );
 }
 
-async function readNodeScreenPosition(page, nodeTestId) {
-  const box = await page.getByTestId(nodeTestId).boundingBox();
-  if (!box) {
-    return null;
+async function draggableNodeStartPoint(page, nodeTestId, nodeBox) {
+  const point = await page.evaluate(
+    ({ box, testId }) => {
+      const target = [...document.querySelectorAll("[data-testid]")].find(
+        (element) => element.getAttribute("data-testid") === testId,
+      );
+      const flowNode = target?.closest(".react-flow__node");
+      if (!flowNode) {
+        throw new Error(`Expected React Flow node for ${testId}.`);
+      }
+
+      const rect = flowNode.getBoundingClientRect();
+      const candidates = [
+        { x: rect.right - 4, y: rect.top + rect.height / 2 },
+        { x: rect.left + 4, y: rect.top + rect.height / 2 },
+        { x: rect.left + rect.width / 2, y: rect.top + 4 },
+        { x: rect.left + rect.width / 2, y: rect.bottom - 4 },
+        { x: box.x + box.width - 4, y: box.y + box.height / 2 },
+      ];
+
+      for (const candidate of candidates) {
+        const hit = document.elementFromPoint(candidate.x, candidate.y);
+        if (hit && flowNode.contains(hit) && !hit.closest(".nodrag")) {
+          return candidate;
+        }
+      }
+
+      throw new Error(
+        `Expected a draggable surface inside ${testId}; all candidate points were nodrag controls.`,
+      );
+    },
+    { box: nodeBox, testId: nodeTestId },
+  );
+
+  if (!point) {
+    throw new Error(`Expected a draggable start point for ${nodeTestId}.`);
   }
 
-  return { x: box.x, y: box.y };
+  return point;
 }
 
 async function addResource(page, toolbar, { capacity = "1", name }) {
@@ -415,29 +448,48 @@ async function dragNodeByOffset(page, nodeTestId, deltaX, deltaY) {
     throw new Error(`Expected bounding boxes for ${nodeTestId} drag.`);
   }
 
-  const startX = nodeBox.x + nodeBox.width / 2;
-  const startY = nodeBox.y + nodeBox.height / 2;
-  await page.mouse.move(startX, startY);
+  const startPoint = await draggableNodeStartPoint(page, nodeTestId, nodeBox);
+  await page.mouse.move(startPoint.x, startPoint.y);
   await page.mouse.down();
-  await page.mouse.move(startX + deltaX, startY + deltaY, { steps: 16 });
+  await page.mouse.move(startPoint.x + deltaX, startPoint.y + deltaY, {
+    steps: 16,
+  });
+  const midDragFlowPosition = await readNodeFlowPosition(page, nodeTestId);
   await page.mouse.up();
 
-  const mouseFlowPosition = await readNodeFlowPosition(page, nodeTestId);
+  const postMouseUpFlowPosition = await readNodeFlowPosition(page, nodeTestId);
+  const midDragDistancePx = flowPositionDistance(
+    initialFlowPosition,
+    midDragFlowPosition,
+  );
+  const postMouseUpDistancePx = flowPositionDistance(
+    initialFlowPosition,
+    postMouseUpFlowPosition,
+  );
   if (
-    initialFlowPosition &&
-    mouseFlowPosition &&
-    !flowPositionsMatchWithinTolerance(initialFlowPosition, mouseFlowPosition)
+    midDragDistancePx === null ||
+    midDragDistancePx <= persistedFlowPositionTolerancePx ||
+    postMouseUpDistancePx === null ||
+    postMouseUpDistancePx <= persistedFlowPositionTolerancePx
   ) {
-    return;
+    throw new Error(
+      `Mouse drag did not produce the required flow displacement: ${JSON.stringify(
+        {
+          initialFlowPosition,
+          midDragFlowPosition,
+          midDragDistancePx,
+          postMouseUpFlowPosition,
+          postMouseUpDistancePx,
+        },
+      )}`,
+    );
   }
 
-  await node.focus();
-  for (let step = 0; step < Math.ceil(Math.abs(deltaX) / 10); step += 1) {
-    await page.keyboard.press(deltaX > 0 ? "ArrowRight" : "ArrowLeft");
-  }
-  for (let step = 0; step < Math.ceil(Math.abs(deltaY) / 10); step += 1) {
-    await page.keyboard.press(deltaY > 0 ? "ArrowDown" : "ArrowUp");
-  }
+  return {
+    initialFlowPosition,
+    midDragFlowPosition,
+    postMouseUpFlowPosition,
+  };
 }
 
 async function saveGraphDraft(page, toolbar, expect) {
@@ -712,67 +764,33 @@ describe.concurrent("factory graph editor node placement browser integration", (
 
         const toolbar = await enterGraphEditor(browserPage.page);
         await addResource(browserPage.page, toolbar, { name: "extra-gpu" });
-        await browserPage.page
-          .getByTestId("rf__node-resource:extra-gpu")
-          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
-
-        const initialFlowPosition = await readNodeFlowPosition(
+        const resourceTestId = "rf__node-resource:extra-gpu";
+        await waitForStableFactoryGraphNodePlacement(
           browserPage.page,
-          "rf__node-resource:extra-gpu",
+          resourceTestId,
         );
-        const initialScreenPosition = await readNodeScreenPosition(
-          browserPage.page,
-          "rf__node-resource:extra-gpu",
-        );
-        expect(initialFlowPosition ?? initialScreenPosition).not.toBeNull();
+        await waitForFactoryGraphSelectionReady(browserPage.page);
 
-        await dragNodeByOffset(
+        const dragObservation = await dragNodeByOffset(
           browserPage.page,
-          "rf__node-resource:extra-gpu",
-          160,
+          resourceTestId,
           120,
+          80,
         );
-
-        await expect
-          .poll(
-            async () => {
-              const nextFlowPosition = await readNodeFlowPosition(
-                browserPage.page,
-                "rf__node-resource:extra-gpu",
-              );
-              const nextScreenPosition = await readNodeScreenPosition(
-                browserPage.page,
-                "rf__node-resource:extra-gpu",
-              );
-              if (!nextScreenPosition || !initialScreenPosition) {
-                return null;
-              }
-
-              const movedOnScreen =
-                Math.abs(nextScreenPosition.x - initialScreenPosition.x) >
-                  flowPositionTolerancePx ||
-                Math.abs(nextScreenPosition.y - initialScreenPosition.y) >
-                  flowPositionTolerancePx;
-              const movedInFlow =
-                initialFlowPosition &&
-                nextFlowPosition &&
-                !flowPositionsMatchWithinTolerance(
-                  initialFlowPosition,
-                  nextFlowPosition,
-                );
-
-              return movedOnScreen || movedInFlow
-                ? { flow: nextFlowPosition, screen: nextScreenPosition }
-                : null;
-            },
-            { timeout: uiInteractionTimeoutMs },
-          )
-          .not.toBeNull();
-
-        const draggedFlowPosition = await readNodeFlowPosition(
-          browserPage.page,
-          "rf__node-resource:extra-gpu",
-        );
+        const {
+          initialFlowPosition,
+          midDragFlowPosition,
+          postMouseUpFlowPosition: draggedFlowPosition,
+        } = dragObservation;
+        expect(initialFlowPosition).not.toBeNull();
+        expect(midDragFlowPosition).not.toBeNull();
+        expect(draggedFlowPosition).not.toBeNull();
+        expect(
+          flowPositionDistance(initialFlowPosition, midDragFlowPosition),
+        ).toBeGreaterThan(persistedFlowPositionTolerancePx);
+        expect(
+          flowPositionDistance(initialFlowPosition, draggedFlowPosition),
+        ).toBeGreaterThan(persistedFlowPositionTolerancePx);
 
         await saveGraphDraft(browserPage.page, toolbar, expect);
         await expect
@@ -801,9 +819,36 @@ describe.concurrent("factory graph editor node placement browser integration", (
             persistedFlowPositionTolerancePx,
           ),
         ).toBe(true);
-        // The mouse path currently reports no flow displacement and falls back to
-        // Arrow keys; verify initial-vs-persisted movement in
-        // thr-graph-editor-drag-observation-is-not-a-drag.
+        // This independent check rejects a save that restores the initial
+        // position, even when a nearer-but-wrong persisted position is within
+        // the dragged-position tolerance.
+        expect(
+          flowPositionDistance(initialFlowPosition, persistedPosition),
+        ).toBeGreaterThan(persistedFlowPositionTolerancePx);
+
+        await browserPage.page.reload({ waitUntil: "domcontentloaded" });
+        await waitForDashboardReady(
+          browserPage.page,
+          preview.previewURL,
+          server,
+        );
+        await enterGraphEditor(browserPage.page);
+        await waitForStableFactoryGraphNodePlacement(
+          browserPage.page,
+          resourceTestId,
+        );
+        await waitForFactoryGraphSelectionReady(browserPage.page);
+        const reloadedFlowPosition = await readNodeFlowPosition(
+          browserPage.page,
+          resourceTestId,
+        );
+        expect(
+          flowPositionsMatchWithinTolerance(
+            reloadedFlowPosition,
+            persistedPosition,
+            persistedFlowPositionTolerancePx,
+          ),
+        ).toBe(true);
         expectNoBrowserErrors(
           browserPage.pageErrors,
           browserPage.consoleErrors,

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
@@ -269,8 +269,11 @@ function FactoryGraphInitializationState({ nodeIds }: { nodeIds: string[] }) {
         continue;
       }
 
-      const width = node.measured?.width ?? node.width ?? node.initialWidth;
-      const height = node.measured?.height ?? node.height ?? node.initialHeight;
+      // React Flow's drag position calculation requires measured dimensions.
+      // Configured or initial dimensions are enough to render a node but do
+      // not mean that its internals are ready for pointer interaction.
+      const width = node.measured?.width;
+      const height = node.measured?.height;
       if (
         node.internals.handleBounds === undefined ||
         width === undefined ||

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.component.test.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.component.test.ts
@@ -250,8 +250,10 @@ describe("useCurrentActivityGraphViewModel node positions", () => {
       result.current.nodes.find(
         (node) => node.id === "work-state:story:queued",
       );
+    const initialMeasured = workStateNode()?.measured;
 
     expect(workStateNode()?.position).toEqual({ x: 120, y: 80 });
+    expect(initialMeasured).toEqual({ height: 120, width: 140 });
 
     act(() => {
       result.current.handleNodesChange([
@@ -268,6 +270,7 @@ describe("useCurrentActivityGraphViewModel node positions", () => {
     });
 
     expect(workStateNode()).toMatchObject({
+      measured: initialMeasured,
       position: { x: 999, y: 999 },
       selected: true,
     });

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
@@ -405,19 +405,22 @@ function useCurrentActivityGraphNodePresentation(
         ({
           initialHeight: _initialHeight,
           initialWidth: _initialWidth,
-          measured: _measured,
           ...node
-        }) => ({
-          ...node,
-          ...(dimensionsByNodeId.has(node.id)
-            ? {
-                height: dimensionsByNodeId.get(node.id)?.height,
-                width: dimensionsByNodeId.get(node.id)?.width,
-              }
-            : {}),
-          position: transientPositionsByNodeId.get(node.id) ?? node.position,
-          selected: graphSelection.isNodeSelected(node.id),
-        }),
+        }) => {
+          const resizedDimensions = dimensionsByNodeId.get(node.id);
+          return {
+            ...node,
+            ...(resizedDimensions
+              ? {
+                  height: resizedDimensions.height,
+                  measured: resizedDimensions,
+                  width: resizedDimensions.width,
+                }
+              : {}),
+            position: transientPositionsByNodeId.get(node.id) ?? node.position,
+            selected: graphSelection.isNodeSelected(node.id),
+          };
+        },
       ),
     [baseNodes, dimensionsByNodeId, graphSelection, transientPositionsByNodeId],
   );


### PR DESCRIPTION
{
  "project": "Make the Graph Editor Drag Persistence Test Observe a Real Drag",
  "branchName": "thr-graph-editor-drag-observation-is-not-a-drag",
  "description": "Repair the graph editor node-placement browser integration test so it measures and persists a genuine mouse-driven React Flow node displacement instead of silently substituting arrow-key nudges. The work records initial, mid-drag, post-mouse-up, and post-save positions before and after the correction, diagnoses the failed gesture or stale observation from run evidence, produces movement comfortably greater than the fixed 80 px persistence tolerance, and adds an independent assertion proving the persisted node did not return to its initial position.",
  "context": {
    "customerAsk": "After PR #1966 lands, repair the owned dragNodeByOffset, readNodeFlowPosition, and 'persists a manually dragged node position' integration-test behavior so a real measured mouse drag, not a silent keyboard fallback, moves the node; post four-position before/after and repetition evidence in PR comments; add an independent non-vacuous persistence assertion; and deliver through the implementation/review loop to actual merge without timing or tolerance padding.",
    "problem": "The test's mouse sequence currently produces approximately 0 px measured flow displacement, after which dragNodeByOffset silently presses ArrowRight and ArrowDown. The green test therefore proves keyboard nudging and persistence while claiming to prove pointer dragging. Prior tolerance-based assertion changes were contradictory or mathematically vacuous because no measured drag existed and Chebyshev distance obeys the triangle inequality.",
    "solution": "On a baseline containing PR #1966, instrument a focused browser run to record initial, mid-drag, post-mouse-up, and persisted positions and identify the branch that moves the node. Use that evidence to correct the gesture or observation boundary, or minimally fix product drag behavior only if proven defective. Require a mouse-driven displacement comfortably above 80 px, prevent keyboard substitution from passing the drag test, retain dragged-to-persisted proximity, and independently assert that the persisted position remains more than 80 px from the initial position."
  },
  "acceptanceCriteria": [
    "PR #1966 is present on the branch baseline before implementation is finalized; if work began earlier, the final head is rebased onto origin/main and main is authoritative for conflicts in ui/integration/factory-graph-editor-node-placement.integration.test.mjs.",
    "A PR comment records the initial, mid-drag, immediate post-mouse-up, and post-save persisted flow positions before and after the correction; before evidence shows approximately 0 px initial-to-dragged displacement and after evidence shows mouse-driven displacement comfortably greater than 80 px.",
    "The focused test cannot pass through silent arrow-key substitution: the fallback is removed or substitution is explicit and fails this drag-specific scenario, with the decision and rationale documented.",
    "The persisted position remains within persistedFlowPositionTolerancePx (80 px) of the dragged position and is independently more than 80 px from the initial position, with PR reasoning showing the latter assertion is not implied by the former and can fail independently.",
    "Focused repeated real-browser runs and a negative regression check provide direct behavior evidence without new sleeps, timeout increases, polling padding, skips, quarantine changes, or changes to flowPositionTolerancePx (8 px) or persistedFlowPositionTolerancePx (80 px).",
    "Scope stays in ui/integration/factory-graph-editor-node-placement.integration.test.mjs unless run evidence proves a genuine product defect requiring one minimal owning UI file; tests/functional/functional-quarantine.json, cmd/gocoveragecheck, and pkg/services/workers/** remain untouched.",
    "Quality gate: Typecheck passes; Tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green; required focused integration evidence and required CI run on the final head.",
    "Delivery: the implementation stage pushes its final head, opens the PR, starts CI, and addresses blocking review feedback; the review stage drives CI to terminal-and-passing and merges; the loop continues until all blocking PR feedback is addressed, conflicts are resolved, and the PR is actually merged, with CI evidence in PR comments and never in commits."
  ],
  "userStories": [
    {
      "id": "thr-graph-editor-drag-observation-is-not-a-drag-001",
      "title": "Measure the pointer drag lifecycle before changing it",
      "description": "As a maintainer, I want direct position observations across the drag and save lifecycle so the correction is based on browser evidence rather than tolerance reasoning.",
      "acceptanceCriteria": [
        "On a baseline containing PR #1966, a focused real-browser run records the node's initial flow position, mid-drag position between mouse-down and mouse-up, position immediately after mouse-up, and persisted position after save/reload.",
        "The baseline evidence reports Chebyshev displacements, identifies whether the mouse branch or keyboard fallback caused the first movement, and reproduces approximately 0 px initial-to-dragged movement when the reported defect is present.",
        "Run evidence distinguishes a stale or commit-only observer from a failed gesture by comparing available mid-drag, post-mouse-up, rendered-node, and saved observations, and the diagnosed cause is recorded in the PR.",
        "Temporary diagnostics introduce no timing dependency and are removed unless retained output is necessary to make future interaction-substitution failures explicit.",
        "If the harness cannot produce or reliably observe a pointer drag, implementation stops and reports the measured blocker instead of weakening the test.",
        "Typecheck passes",
        "Tests pass",
        "Direct browser verification confirms the focused baseline behavior"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Measured on PR #1966 baseline dc5052245. Focused browser evidence: initial, mid-drag, and immediate post-mouse-up flow positions were (339.739, 444.870); persisted flow was (339.739130..., 444.869565...), with approximately 0.001 px rounding. The helper selected keyboard-fallback; the later screen-only observation changed y from 600.25 to 376.25 while flow and saved positions stayed fixed, diagnosing a failed pointer gesture plus misleading screen observation. Temporary diagnostics were removed. The baseline build/typecheck and focused browser test passed."
    },
    {
      "id": "thr-graph-editor-drag-observation-is-not-a-drag-002",
      "title": "Make mouse movement produce an observed node displacement",
      "description": "As a graph editor customer and test maintainer, I want the pointer path itself to move the node so drag persistence coverage exercises the same interaction a user performs.",
      "acceptanceCriteria": [
        "The corrected pointer sequence or corrected flow-position observation measures initial-to-post-mouse-up displacement comfortably greater than 80 px before save.",
        "Evidence confirms the mouse path caused movement; arrow-key fallback is removed, or any retained fallback reports substitution and cannot satisfy the drag-specific test.",
        "The correction follows the evidenced cause, such as a draggable target, deterministic drag-start pre-move, or correct React Flow observation boundary, and does not change either tolerance.",
        "If evidence proves a real product drag defect, the smallest owning product change restores pointer dragging while preserving keyboard accessibility and unrelated loading, empty, error, success, and responsive states.",
        "No new sleep, timeout increase, arbitrary wait padding, skip, or quarantine is introduced.",
        "Typecheck passes",
        "Tests pass",
        "Direct browser verification confirms pointer-driven node movement at the test's supported viewport"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Removed the silent keyboard fallback and early return. Evidence showed the center pointer landed inside the shared GraphNodeButton's nodrag/nopan content, so the test now chooses a deterministic non-nodrag surface on the React Flow node. The focused browser run also exposed a real product defect: transient display-node updates stripped React Flow's measured dimensions, causing error 015 after the first pointer move. The smallest owning UI fix preserves measured dimensions through transient projection updates and keeps the readiness marker tied to actual measurements. UI build/typecheck, focused unit coverage (28 tests), and three repeated focused browser runs passed; no tolerances, waits, or quarantine files changed."
    },
    {
      "id": "thr-graph-editor-drag-observation-is-not-a-drag-003",
      "title": "Prove the dragged position persists independently",
      "description": "As a reviewer, I want a regression assertion grounded in the observed drag so the test fails when saving restores the wrong position even if dragged-to-persisted proximity still passes.",
      "acceptanceCriteria": [
        "After save/reload, the persisted position remains within 80 px Chebyshev distance of the post-mouse-up dragged position.",
        "One explicit assertion requires the persisted position to be more than 80 px Chebyshev distance from the initial position and is not the vacuous d(initial,persisted) >= d(initial,dragged) - 80 form or an algebraic equivalent.",
        "The PR gives a concrete counterexample or equivalent argument showing dragged-to-persisted proximity can pass while initial-to-persisted separation fails.",
        "A PR comment records the four after-fix positions, derived distances, interaction branch, and focused repetition results from the final head; CI and repetition evidence is never committed as progress notes.",
        "Focused repetition passes without timing padding, and a deliberate regression or equivalent negative check proves the independent assertion fails when persistence incorrectly restores the initial position.",
        "Typecheck passes",
        "Tests pass",
        "Direct browser verification confirms save/reload restores the node at the dragged location"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added an independent initial-to-persisted Chebyshev assertion and an actual page reload check. Final pointer-path evidence on three repeated runs: initial-to-mid/post-up distances were 98.261/98.261 px, 107.608/115.434 px, and 97.391/105.869 px; saved positions stayed within 0.001 px of post-up and reload restored the saved location. A deliberate midpoint-save regression passed dragged-to-saved proximity but failed the independent assertion at 58.5325 > 80. The focused browser run has zero non-benign page or console errors, including React Flow error 015; typecheck, build, Biome, and focused component tests pass. Manual in-app browser control was unavailable, so direct evidence is from the repository's real Playwright browser harness."
    }
  ],
  "operatorOverride": {
    "issuedBy": "factory operator",
    "issuedAt": "2026-08-15T00:05:00Z",
    "AAAA00_THE_ONLY_CURRENT_OVERRIDE": "*** THIS IS THE ONLY CURRENT OPERATOR OVERRIDE. ALL PREVIOUS ENTRIES ARE DELETED. ***\nAnything not restated below is NO LONGER IN FORCE. In particular the earlier\n\"reset your branch\" directive is DONE - you already reset onto origin/main and\nthe duplicated commit is gone. Do not redo it.\n\n=== YOUR DIAGNOSIS IS CONFIRMED BY INDEPENDENT EVIDENCE. KEEP GOING. ===\n\nYou changed the readiness check in\nui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx\nfrom\n\n    const width = node.measured?.width ?? node.width ?? node.initialWidth;\n\nto require node.measured specifically. The operator has now confirmed that this\nis the real cause, from CI evidence you have not seen.\n\nTHE EVIDENCE. The `Frontend Browser` job on main fails intermittently, and it\nfails on YOUR test:\n\n  FAIL integration/factory-graph-editor-node-placement.integration.test.mjs\n       > persists a manually dragged node position in the saved shared layout\n\n  AssertionError: expected [ ...(16) ] to deeply equal []\n  CurrentActivityGraphEndpointError: React Flow factory graph endpoint error 015:\n    It seems that you are trying to drag a node that is not initialized.\n    Please use onNodesChange as explained in the docs.\n\nSixteen occurrences of React Flow error 015, caught by expectNoBrowserErrors.\nReact Flow is explicitly refusing to drag the node BECAUSE IT IS NOT\nINITIALIZED. That is exactly the condition your change fixes: while the\n`?? node.width ?? node.initialWidth` fallback stood, a node with configured\ndimensions was excluded from missingNodeIds, updateNodeInternals was never\ncalled for it, node.measured was never populated, and React Flow's drag path\nbailed out with error 015.\n\nThis also explains the whole shape of the bug: the drag does nothing, your\nhelper silently falls back to Arrow keys, the position assertions usually pass\nanyway, and the ONLY surviving symptom is console noise that trips\nexpectNoBrowserErrors at random. That is why it reads as a flake on main\ninstead of as a broken feature.\n\n=== WHAT THIS CHANGES FOR YOU ===\n\n1. You now have a HARD, objective acceptance signal. Do not settle for\n   \"the test passes\". Require: ZERO occurrences of React Flow error 015 during\n   the drag test. Assert it explicitly and say so in your PR.\n\n2. Your fix is worth more than the test. This is an intermittent main-breaking\n   failure, and it is plausibly a REAL dashboard defect - if a node with\n   configured dimensions is never measured, a user cannot drag it either. Check\n   whether that reproduces in the app, and state your finding either way. If it\n   does reproduce, say so prominently in the PR; that makes this a product fix,\n   not a test fix.\n\n3. Because you are tightening a readiness gate, other graph browser tests will\n   now wait longer for genuine measurement. That is correct, but watch for\n   newly-surfaced timeouts elsewhere in the graph browser suite and report any\n   you see rather than loosening the gate again.\n\n=== STILL REQUIRED (unchanged) ===\n\n- The Arrow-key fallback and the silent early return in dragNodeByOffset must be\n  GONE. A helper that silently substitutes a different interaction is worse than\n  a failing test.\n- The test must perform a real pointer drag and observe flow displacement, with\n  a before/after measurement posted.\n- Demonstrate the test now FAILS when dragging is broken: deliberately break it,\n  show the failure, restore it. A drag test that cannot fail is the defect you\n  are removing.\n- Remove your temporary instrumentation (the window.__graphDragDiagnostics event\n  recorder) before the final head, or convert it into something deliberate and\n  justified. Do not ship debug scaffolding.\n\n=== REBASE - THIS CHANGED WHILE YOU WERE WORKING ===\n\nPR #1966 MERGED and main has moved twice. Current origin/main is 343f0ab8b.\n\n  git fetch origin && git rebase origin/main\n\n#1966 already DELETED the vacuous persistedMovementLowerBoundPx block from your\ntest file and left a comment pointing at YOUR lane. KEEP that deletion. Do NOT\nre-add the block. You may replace its pointer comment with the real assertion\nonce your drag genuinely moves the node - that is the whole point of the\nhandoff.\n\n=== NOT YOURS ===\n\nDo NOT touch cmd/gocoveragecheck/**, tests/functional/functional-quarantine.json\n(lane thr-quarantine-ratchet-unexpected-pass-on-main, PR #1968),\nfactory/scripts/** (lane thr-setup-workspace-shared-stash-race), or\npkg/services/workers/** (lane thr-model-response-event-lost-on-factory-work-path).\n\nDo NOT chase main's other red: Backend Functional Coverage and\nLong Local Inference (linux) are owned by other live lanes.\n\nNever run bare `git stash` or `git stash pop` - the stash stack is shared across\nevery concurrent worktree in this repository.\n\n=== DELIVERY ===\n\nYour finish line is: final head pushed + PR open + CI started + review feedback\naddressed. MERGED is owned by the review stage. CI evidence goes in PR comments,\nnever in a commit."
  }
}
