### PR TITLE
thr-functional-runner-contract-test-leaks-ambient-short

### DIFF
--- a/tests/functional/observability/verification/functional_runner_contract_test.go
+++ b/tests/functional/observability/verification/functional_runner_contract_test.go
@@ -107,6 +107,7 @@ sleep 2
 		fmt.Sprintf("FUNCTIONAL_TEST_BUDGET=%s", "0.1s"),
 		"FUNCTIONAL_TEST_TIER=pr-short",
 		"FUNCTIONAL_TEST_TRIGGER=pull_request",
+		"FUNCTIONAL_SHORT=true",
 		fmt.Sprintf("MAKE_BIN=%s", makePath),
 	)
 	if err == nil {

--- a/tests/functional/observability/verification/makefile_helpers_test.go
+++ b/tests/functional/observability/verification/makefile_helpers_test.go
@@ -185,7 +185,7 @@ func runScript(repoRoot string, scriptPath string, env ...string) (string, error
 		cmd = exec.Command(scriptPath)
 	}
 	cmd.Dir = repoRoot
-	cmd.Env = append(os.Environ(), env...)
+	cmd.Env = append(minimalScriptEnvironment(), env...)
 
 	var output bytes.Buffer
 	cmd.Stdout = &output
@@ -193,6 +193,14 @@ func runScript(repoRoot string, scriptPath string, env ...string) (string, error
 
 	err := cmd.Run()
 	return output.String(), err
+}
+
+func minimalScriptEnvironment() []string {
+	path, ok := os.LookupEnv("PATH")
+	if !ok {
+		return []string{}
+	}
+	return []string{"PATH=" + path}
 }
 
 func assertOutputOrder(t *testing.T, output string, markers ...string) {

--- a/tests/functional/observability/verification/script_environment_contract_test.go
+++ b/tests/functional/observability/verification/script_environment_contract_test.go
@@ -1,0 +1,49 @@
+//go:build !windows
+
+package verification
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunScriptEnvironment_IsolatesAmbientContractVariables(t *testing.T) {
+	repoRoot := t.TempDir()
+	scriptPath := writeExecutableScript(t, "print-script-environment", `#!/bin/sh
+printf 'parent-only=%s\n' "${FUNCTIONAL_PARENT_ONLY_SENTINEL:-unset}"
+printf 'artifact-root=%s\n' "${ARTIFACT_ROOT:-unset}"
+printf 'github-run-id=%s\n' "${GITHUB_RUN_ID:-unset}"
+printf 'short=%s\n' "${FUNCTIONAL_SHORT:-unset}"
+printf 'explicit=%s\n' "${FUNCTIONAL_EXPLICIT_SENTINEL:-unset}"
+`)
+
+	for _, ambientShort := range []string{"true", "false"} {
+		t.Run("ambient FUNCTIONAL_SHORT="+ambientShort, func(t *testing.T) {
+			t.Setenv("FUNCTIONAL_PARENT_ONLY_SENTINEL", "ambient-only")
+			t.Setenv("ARTIFACT_ROOT", "ambient-artifact")
+			t.Setenv("GITHUB_RUN_ID", "ambient-github")
+			t.Setenv("FUNCTIONAL_SHORT", ambientShort)
+
+			output, err := runScript(
+				repoRoot,
+				scriptPath,
+				"FUNCTIONAL_EXPLICIT_SENTINEL=explicit",
+			)
+			if err != nil {
+				t.Fatalf("run environment probe: %v\n%s", err, output)
+			}
+
+			for _, expected := range []string{
+				"parent-only=unset",
+				"artifact-root=unset",
+				"github-run-id=unset",
+				"short=unset",
+				"explicit=explicit",
+			} {
+				if !strings.Contains(output, expected) {
+					t.Fatalf("environment probe missing %q:\n%s", expected, output)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
{
  "project": "Hermetic Functional Runner Contract Tests",
  "branchName": "thr-functional-runner-contract-test-leaks-ambient-short",
  "description": "Make the functional runner timeout contract and sibling script verification tests hermetic so a simulated pr-short invocation reports and enforces short=true regardless of the ambient CI tier, while preserving the exact runner log and timeout-diagnostics contract.",
  "context": {
    "customerAsk": "Repair TestFunctionalTestVizLaneScriptSmoke_TimesOutAndRetainsDiagnostics within tests/functional/observability/verification/** so its result is independent of ambient FUNCTIONAL_SHORT, audit sibling script tests for the same leak, add a tier-independent guard, reproduce the reported split before implementation, and prove both ambient cases pass afterward.",
    "problem": "The shared runScript helper copies os.Environ() into every child. The timeout test simulates tier=pr-short and trigger=pull_request but omits FUNCTIONAL_SHORT, so it inherits true on pull-request jobs and false on pushes to main. Its fixed short=true log assertion therefore passes on PRs and deterministically fails after merge even though the production script and workflow are correct.",
    "solution": "Explicitly supply FUNCTIONAL_SHORT=true for the simulated pr-short timeout scenario, audit and repair same-shaped omissions among sibling script contract tests, and make the shared script-test child environment minimal and explicit. Preserve the literal log assertion and prove the test passes with both true and false in the parent environment while a deliberately ambient-only dependency is caught."
  },
  "acceptanceCriteria": [
    "Before code changes, focused runs with ambient FUNCTIONAL_SHORT=true and FUNCTIONAL_SHORT=false reproduce the measured pass and exact short=false contract failure respectively; if they do not, implementation stops and the diagnosis is re-scoped from the measured result.",
    "After the change, the focused timeout test passes with ambient FUNCTIONAL_SHORT=true and FUNCTIONAL_SHORT=false while still requiring the exact tier=pr-short trigger=pull_request short=true budget=0.1s selection=subtractive header and retained timeout diagnostics.",
    "Every sibling runScript caller in tests/functional/observability/verification is audited for asserted behavior derived from unprovided ambient variables, with checked callers, findings, same-shaped fixes, and justified unchanged cases reported in the PR.",
    "A child-observable guard proves a parent-only contract variable is not inherited and fails when an ambient-only dependency is deliberately reintroduced, independent of CI tier.",
    "Changes remain confined to tests/functional/observability/verification/** and do not relax the assertion or modify the runner script, workflow, quarantine manifest, coverage checker, or other live lanes' surfaces.",
    "Typecheck and focused tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing on the final head, all blocking PR conversation feedback is explicitly addressed, conflicts are resolved, and the PR is merged; implementation owns final-head push, open PR, started CI, and addressed blocking feedback, while review owns terminal passing CI and merge, and CI evidence is posted only in PR comments, never commits."
  ],
  "userStories": [
    {
      "id": "thr-functional-runner-contract-test-leaks-ambient-short-001",
      "title": "Make the simulated short-tier timeout contract independent of its parent job",
      "description": "As a maintainer, I want the functional runner timeout contract test to declare the short mode it simulates so that the same contract is verified on pull requests and pushes to main.",
      "acceptanceCriteria": [
        "Before implementation, the exact focused test passes with ambient FUNCTIONAL_SHORT=true and fails with ambient FUNCTIONAL_SHORT=false because the retained log reports short=false; both outputs are pasted into the PR description or a PR comment.",
        "The simulated pr-short timeout invocation explicitly supplies FUNCTIONAL_SHORT=true and continues to require the literal tier=pr-short trigger=pull_request short=true budget=0.1s selection=subtractive log contract.",
        "After implementation, the same focused test passes under both ambient values without weakening timeout exit-code, inventory, quarantine, or retained-diagnostics assertions; both outputs are pasted into the PR description or a PR comment.",
        "Sibling tests in the owned package are audited for asserted behavior controlled by ambient variables they omit, and the PR records what was checked, same-shaped fixes, and any deliberately unchanged cases with justification.",
        "No runner script, workflow tier variable, quarantine manifest, coverage checker, or out-of-lane surface is changed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Reproduced before implementation on Linux via WSL: ambient FUNCTIONAL_SHORT=true passed; false failed with retained short=false. Added FUNCTIONAL_SHORT=true to the simulated pr-short timeout caller. Audited all 11 runScript callers: this was the only asserted ambient-controlled omission; the others provide asserted inputs or intentionally test defaults/absence. Focused and full owned-package tests pass with ambient true and false."
    },
    {
      "id": "thr-functional-runner-contract-test-leaks-ambient-short-002",
      "title": "Isolate script contract children from ambient CI variables",
      "description": "As a maintainer, I want script contract children to start from an explicit minimal environment so that missing test inputs cannot silently adopt values from the CI tier running the test.",
      "acceptanceCriteria": [
        "Script contract children receive only the minimal process environment needed to execute the script plus variables explicitly supplied by each test; arbitrary parent FUNCTIONAL_*, artifact, and GitHub job variables are not inherited.",
        "Existing sibling script contract behaviors continue to pass with required execution dependencies and each scenario's inputs supplied explicitly.",
        "A focused behavioral regression test sets a sentinel contract variable only in the parent environment and proves the child does not observe it unless explicitly supplied.",
        "Deliberately restoring an ambient-only dependency causes the guard to fail under both ambient short-mode values, and the demonstration is reported without committing the deliberate break.",
        "The environment isolation remains a test-only side-effect boundary in the owned package and does not alter production scripts or process behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Changed runScript to pass only PATH plus explicitly supplied variables. Added TestRunScriptEnvironment_IsolatesAmbientContractVariables, which executes a child script under ambient FUNCTIONAL_SHORT=true and false and proves FUNCTIONAL_*, ARTIFACT_ROOT, and GITHUB_RUN_ID parent values are absent while an explicit value remains visible. Audited all 11 runScript callers; all required inputs are explicit, so no sibling caller changes were needed. Focused and full owned-package tests pass under both ambient values. Temporarily restoring os.Environ made the guard fail under both values; that deliberate regression was restored and is not committed."
    }
  ]
}
