### PR TITLE
thr-acp-serve-shutdown-error-identity

### DIFF
--- a/pkg/transports/cli/root.go
+++ b/pkg/transports/cli/root.go
@@ -447,6 +447,9 @@ func executeCommandResult(diagnostics *clidiag.DiagnosticWriter, err error) erro
 	if err == nil {
 		return nil
 	}
+	if errors.Is(err, context.Canceled) {
+		return executeCommandFailure(diagnostics, err)
+	}
 	if diagnostics != nil && diagnostics.DiagnosticRendered() {
 		return err
 	}
@@ -457,14 +460,19 @@ func executeCommandFailure(diagnostics io.Writer, err error) error {
 	if err == nil {
 		return nil
 	}
+	// Cancellation is a process-control sentinel, not a command failure. Keep
+	// its identity independent of whether a command already rendered a
+	// diagnostic before returning it.
+	if errors.Is(err, context.Canceled) {
+		if !clidiag.DiagnosticRendered(diagnostics) {
+			_, _ = fmt.Fprintln(diagnostics, "Error: context canceled")
+			clidiag.MarkDiagnosticRendered(diagnostics)
+		}
+		return context.Canceled
+	}
 	normalized := clidiag.Normalize(err)
 	if clidiag.DiagnosticRendered(diagnostics) {
 		return err
-	}
-	if errors.Is(err, context.Canceled) {
-		_, _ = fmt.Fprintln(diagnostics, "Error: context canceled")
-		clidiag.MarkDiagnosticRendered(diagnostics)
-		return normalized
 	}
 	clidiag.WriteFailure(diagnostics, normalized)
 	return normalized

--- a/pkg/transports/cli/root_serve_test.go
+++ b/pkg/transports/cli/root_serve_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -13,6 +14,7 @@ import (
 
 	startupcli "github.com/portpowered/infinite-you/pkg/initializer/process"
 	acpwire "github.com/portpowered/infinite-you/pkg/transports/acp/wire"
+	"github.com/portpowered/infinite-you/pkg/transports/cli/clidiag"
 	"github.com/spf13/pflag"
 )
 
@@ -306,6 +308,51 @@ func TestServeACPCommand_CancellationPropagatesFromProcessContext(t *testing.T) 
 
 	if err := root.Execute(); !errors.Is(err, context.Canceled) {
 		t.Fatalf("Execute() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestExecuteCommandResultPreservesCancellationIdentityAfterDiagnosticStateChanges(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		err      error
+		rendered bool
+	}{
+		{name: "unrendered", err: context.Canceled},
+		{name: "wrapped unrendered", err: fmt.Errorf("ACP server stopped: %w", context.Canceled)},
+		{name: "already rendered", err: fmt.Errorf("ACP server stopped: %w", context.Canceled), rendered: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stderr bytes.Buffer
+			diagnostics := clidiag.NewDiagnosticWriter(&stderr)
+			if tc.rendered {
+				if !clidiag.WriteFailure(diagnostics, &clidiag.Failure{
+					Code:    "ACP_TEST_FAILURE",
+					Message: "already rendered",
+				}) {
+					t.Fatal("WriteFailure() = false, want a rendered diagnostic")
+				}
+			}
+			beforeCancellation := stderr.String()
+
+			got := executeCommandResult(diagnostics, tc.err)
+			if got != context.Canceled {
+				t.Fatalf("executeCommandResult() = %T %v, want context.Canceled by identity", got, got)
+			}
+
+			if tc.rendered {
+				if stderr.String() != beforeCancellation {
+					t.Fatalf("already-rendered stderr changed from %q to %q, want no duplicate diagnostic", beforeCancellation, stderr.String())
+				}
+				return
+			}
+			if got := stderr.String(); got != "Error: context canceled\n" {
+				t.Fatalf("unrendered cancellation stderr = %q, want exact cancellation diagnostic", got)
+			}
+		})
 	}
 }
 

--- a/tests/functional/transport/cli/process/acp_shutdown_test.go
+++ b/tests/functional/transport/cli/process/acp_shutdown_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
+const acpShutdownReadTimeout = 30 * time.Second
+
 // TestACPServeCancellationPreservesContextCanceledIdentityThroughProcess
 // drives the real customer boundary through root.BuildProcess and
 // Process.Execute. The read-start signal makes cancellation deterministic:
@@ -56,7 +58,7 @@ func TestACPServeCancellationPreservesContextCanceledIdentityThroughProcess(t *t
 	// read-start channel is the deterministic synchronization point.
 	select {
 	case <-readStarted.started:
-	case <-time.After(5 * time.Second):
+	case <-time.After(acpShutdownReadTimeout):
 		t.Fatal("ACP server did not begin reading stdin before timeout")
 	}
 	cancel()
@@ -74,7 +76,7 @@ func TestACPServeCancellationPreservesContextCanceledIdentityThroughProcess(t *t
 		}
 	// The timeout only guards against a regression that fails to unwind the
 	// blocked stdin read after cancellation.
-	case <-time.After(5 * time.Second):
+	case <-time.After(acpShutdownReadTimeout):
 		t.Fatal("Process.Execute() did not return after ACP cancellation")
 	}
 }

--- a/tests/functional/transport/cli/process/acp_shutdown_test.go
+++ b/tests/functional/transport/cli/process/acp_shutdown_test.go
@@ -1,0 +1,104 @@
+package process_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/root"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestACPServeCancellationPreservesContextCanceledIdentityThroughProcess
+// drives the real customer boundary through root.BuildProcess and
+// Process.Execute. The read-start signal makes cancellation deterministic:
+// the ACP scanner is already blocked on stdin before the context is canceled,
+// so the command's cancellation cleanup must both unblock the read and return
+// the cancellation sentinel unchanged.
+func TestACPServeCancellationPreservesContextCanceledIdentityThroughProcess(t *testing.T) {
+	process, err := root.BuildProcess(context.Background(), serviceedges.Edges{})
+	if err != nil {
+		t.Fatalf("root.BuildProcess() error = %v", err)
+	}
+	support.CleanupProcess(t, process)
+
+	stdinReader, stdinWriter := io.Pipe()
+	readStarted := newACPShutdownReadSignal(stdinReader)
+	t.Cleanup(func() {
+		_ = stdinWriter.Close()
+		_ = stdinReader.Close()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	homeDir := t.TempDir()
+	workingDirectory := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- process.Execute(root.Input{
+			Args:             []string{"you", "serve", "acp"},
+			Env:              append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir),
+			Stdin:            readStarted,
+			Stdout:           &stdout,
+			Stderr:           &stderr,
+			Context:          ctx,
+			WorkingDirectory: workingDirectory,
+		})
+	}()
+
+	// The timeout only guards against a genuine startup/read hang; the
+	// read-start channel is the deterministic synchronization point.
+	select {
+	case <-readStarted.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ACP server did not begin reading stdin before timeout")
+	}
+	cancel()
+
+	select {
+	case got := <-done:
+		if got != context.Canceled {
+			t.Fatalf("Process.Execute() error = %T %v, want context.Canceled by identity", got, got)
+		}
+		if got := stderr.String(); got != "Error: context canceled\n" {
+			t.Fatalf("canceled ACP stderr = %q, want exact cancellation diagnostic", got)
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("canceled ACP stdout = %q, want no protocol output", stdout.String())
+		}
+	// The timeout only guards against a regression that fails to unwind the
+	// blocked stdin read after cancellation.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Process.Execute() did not return after ACP cancellation")
+	}
+}
+
+type acpShutdownReadSignal struct {
+	reader  io.Reader
+	closer  io.Closer
+	once    sync.Once
+	started chan struct{}
+}
+
+func newACPShutdownReadSignal(stream io.ReadCloser) *acpShutdownReadSignal {
+	return &acpShutdownReadSignal{
+		reader:  stream,
+		closer:  stream,
+		started: make(chan struct{}),
+	}
+}
+
+func (r *acpShutdownReadSignal) Read(p []byte) (int, error) {
+	r.once.Do(func() { close(r.started) })
+	return r.reader.Read(p)
+}
+
+func (r *acpShutdownReadSignal) Close() error {
+	return r.closer.Close()
+}


### PR DESCRIPTION
{
  "project": "Preserve ACP Shutdown Cancellation Identity at the CLI Boundary",
  "branchName": "thr-acp-serve-shutdown-error-identity",
  "description": "Measure the environment and shutdown ordering that make you serve acp return a normalized CLI_COMMAND_FAILED wrapper, establish the intended contract from sibling boundaries, and preserve context.Canceled identity through root.BuildProcess and Process.Execute without changing stderr, exit codes, or unrelated CLI diagnostics.",
  "context": {
    "customerAsk": "Reproduce and explain why ACP shutdown sometimes returns CLI_COMMAND_FAILED instead of context.Canceled; determine the correct contract from sibling behavior; implement only the evidence-supported correction; add a direct root.BuildProcess and Process.Execute boundary test; keep all nine root-composition tests strict and passing; preserve stderr and exit codes; assess non-ACP CLI blast radius; rebase onto origin/main before the final push; and keep CI evidence in PR comments rather than commits.",
    "problem": "The ACP sanitizer documents that cancellation sentinels are returned unchanged, but the shared CLI command-failure boundary can return either the original cancellation or a normalized clidiag.Failure depending on whether a diagnostic was already marked rendered. Linux push-tier CI observed the wrapper in nine tests sharing one cleanup assertion, while a limited Windows run at the same commit passed, so the differing condition must be measured before any fix is selected.",
    "solution": "Observe the real ACP shutdown path under controlled platform, ordering, timing, and parallelism conditions; record returned identity, errors.Is behavior, diagnostic-render state, and cancel/close order; decide the contract using the ACP sanitizer, process exit classification, clidiag behavior, and other Process.Execute embedders; then, only if justified, make cancellation identity independent of diagnostic rendering and prove it with direct application-boundary and focused blast-radius tests while preserving exact diagnostics and exit behavior."
  },
  "acceptanceCriteria": [
    "A PR comment records baseline measurements for passing and failing shutdown paths, including environment, command, returned error value and identity, errors.Is result, diagnostic-render state at the command-failure boundary, and cancellation versus stdin-close ordering; the evidence identifies the differing condition or explicitly states that no failing condition was reproduced.",
    "The PR explains which side of the contract is wrong using the ACP sanitizer promise, cmd/factory exit classification, CLI diagnostic normalization behavior, and a documented search of other root.BuildProcess and Process.Execute embedders and cancellation assertions; no production fix is committed if the evidence cannot justify one.",
    "For the established cancellation contract, you serve acp returns context.Canceled by identity, or nil when shutdown completes cleanly, regardless of prior diagnostic-render state, while stderr remains exactly Error: context canceled when rendered and the declared cancellation exit code is unchanged.",
    "A direct root.BuildProcess plus Process.Execute regression test is demonstrated failing on the broken baseline and passing after the change, exercises the diagnostic-render condition responsible for the CI failure, and fails if cancellation identity becomes a CLI_COMMAND_FAILED wrapper again.",
    "All nine named root-composition tests pass with their shared strict cleanup assertion no weaker than today, and focused blast-radius coverage proves non-cancellation coded and uncoded failures retain their existing safe diagnostic text, returned diagnostic contracts, and single-render behavior; the final implementation stays within owned surfaces and is rebased onto origin/main before the final push.",
    "Quality gate: Typecheck passes; focused and required tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Delivery continues through the implementation/review loop until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file reconciliation are complete, and the PR is actually merged. The implementation stage finishes when its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. The review stage owns driving CI to terminal-and-passing and owns the merge. CI-run evidence is placed in PR comments and never in a commit."
  ],
  "userStories": [
    {
      "id": "thr-acp-serve-shutdown-error-identity-001",
      "title": "Measure the shutdown branch and establish the cancellation contract",
      "description": "As a maintainer, I want measured evidence for the passing and failing ACP shutdown paths and a sibling-contract decision so that the implementation corrects a proven boundary defect rather than a source-reading hypothesis.",
      "acceptanceCriteria": [
        "At baseline commit 2e6e34982 or its behaviorally equivalent pre-fix revision, the real root.BuildProcess plus Process.Execute ACP shutdown path is observed under controlled variations of platform availability, cancel/pipe-close order, timing, and parallel execution sufficient to test the operator's hypotheses.",
        "For each passing and failing observation, evidence captures the concrete returned error value and identity, whether errors.Is(err, context.Canceled) is true, whether the diagnostic writer was already marked rendered when command-failure handling ran, and whether stdin closed before or after cancellation.",
        "The investigation identifies what makes diagnostic-render state differ; if no failing path can be reproduced, the PR comment states the tested matrix, observed results, and remaining unproven condition, and no speculative production fix is committed.",
        "The contract decision cites the ACP sanitizer's unchanged-sentinel promise, cmd/factory's errors.Is exit classification, clidiag.Failure and normalization behavior, and the observed expectations of other root.BuildProcess and Process.Execute embedders and cancellation tests.",
        "Temporary instrumentation is removed before the final implementation head; measurement and CI evidence is posted in PR comments and never committed as a progress note.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Measured on Windows/amd64 and WSL Linux/amd64 with Go 1.25.0 using the real root.BuildProcess plus Process.Execute path. Cancellation-first with a deterministic io.Pipe returned *clidiag.Failure (CLI_COMMAND_FAILED: command failed: context canceled), identity false, errors.Is(context.Canceled) true, rendered-before-boundary false, and stderr exactly Error: context canceled\\n; closing stdin first returned nil. Repeated cross-platform runs were stable. The proven defect is shared CLI normalization before cancellation handling; temporary instrumentation was removed. Baseline evidence and contract rationale will be posted in the PR conversation when the implementation PR is opened."
    },
    {
      "id": "thr-acp-serve-shutdown-error-identity-002",
      "title": "Return a stable ACP cancellation identity without changing diagnostics",
      "description": "As an ACP embedder, I want orderly server cancellation to return the documented sentinel consistently so that shutdown handling does not depend on whether output happened to be rendered first.",
      "acceptanceCriteria": [
        "A direct behavioral regression test drives you serve acp through root.BuildProcess and Process.Execute, reaches the measured failing diagnostic state, and is shown returning CLI_COMMAND_FAILED on the broken baseline before the production correction.",
        "After the correction, the same scenario returns context.Canceled by identity; a complementary already-rendered scenario returns the same identity, and clean shutdown may still return nil where that existing behavior applies.",
        "Cancellation emits exactly the existing customer-facing stderr line Error: context canceled when the boundary owns rendering it, does not duplicate a previously rendered diagnostic, and retains the existing declared cancellation exit code.",
        "Focused boundary tests show that non-cancellation coded errors remain unchanged, uncoded errors still normalize to the existing safe CLI_COMMAND_FAILED contract, and diagnostic-render state does not cause duplicate output or leak underlying payloads.",
        "The nine affected root-composition tests pass with the shared cleanup assertion unchanged or, if touched, with the exact change justified as equally strict rather than a weakening.",
        "The PR states the blast-radius search and focused checks performed for commands outside ACP, changes no out-of-scope lane surface, includes no broad CLI cleanup, and rebases onto origin/main before the final push.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented and verified the evidence-supported CLI boundary correction. executeCommandResult and executeCommandFailure preserve context.Canceled by identity before clidiag.Normalize, keep exact Error: context canceled\n output when the boundary renders, and do not duplicate already-rendered diagnostics. The direct root.BuildProcess plus Process.Execute ACP mid-read regression failed on the broken baseline as *clidiag.Failure and passes repeatedly after the fix. Focused CLI/ACP and non-ACP coded/uncoded tests pass. The selected root-composition run had eight passes and one untouched pre-existing duplicate-final-text failure; broad command-inventory/ownership fixture failures also reproduce baseline drift and are documented for PR review rather than changed here."
    }
  ]
}
