### PR TITLE
thr-root-checkout-acquires-silent-revert-of-latest-merge

### DIFF
--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -487,24 +487,30 @@ def confirm_ref_matches(repo_path, ref_name, expected_sha):
         )
 
 
-def ancestor_commits(repo_path, head_sha):
-    """Return every commit reachable behind head_sha, excluding head_sha."""
+def ancestor_commit_trees(repo_path, head_sha):
+    """Return reachable ancestor commit/tree pairs without per-commit Git calls."""
     result = run_git(
-        "rev-list", "--parents", head_sha,
+        "log", "--format=%H%x00%T", "--no-decorate", head_sha,
         cwd=repo_path, check=False,
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"root main sync could not inspect ancestors of {head_sha}: "
+            f"root main sync could not inspect ancestor trees of {head_sha}: "
             f"{command_failure_details(result)}"
         )
 
-    commits = []
+    commit_trees = []
     for line in result.stdout.splitlines():
-        commit = line.split(maxsplit=1)[0] if line.strip() else ""
-        if commit and commit != head_sha:
-            commits.append(commit)
-    return commits
+        values = line.split("\0")
+        if len(values) != 2 or not all(immutable_object_id(value) for value in values):
+            raise RuntimeError(
+                f"root main sync received an invalid ancestor commit/tree pair for "
+                f"{head_sha}: {line!r}"
+            )
+        commit, tree = values
+        if commit != head_sha:
+            commit_trees.append((commit, tree))
+    return commit_trees
 
 
 def tree_for_revision(repo_path, revision, description):
@@ -559,14 +565,7 @@ def verify_no_ancestor_residue(repo_path):
     if not local_states:
         return
 
-    ancestor_trees = [
-        (ancestor_sha, tree_for_revision(
-            repo_path,
-            ancestor_sha,
-            f"root main sync could not capture ancestor {ancestor_sha} tree",
-        ))
-        for ancestor_sha in ancestor_commits(repo_path, head_sha)
-    ]
+    ancestor_trees = ancestor_commit_trees(repo_path, head_sha)
     findings = []
     for state_name, state_tree in local_states:
         for ancestor_sha, ancestor_tree in ancestor_trees:

--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -10,6 +10,7 @@ into the worktree root, and prints a JSON result to stdout.
 Exit 0 on success (stdout = JSON blob), exit 1 on failure (stderr = stage-specific error).
 """
 
+import contextlib
 import json
 import os
 import re
@@ -17,11 +18,16 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
+import time
 from pathlib import Path
 
 
 IMMUTABLE_OBJECT_ID = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
 SNAPSHOT_REF_PREFIX = "refs/factory-snapshots/"
+ROOT_SYNC_LOCK_FILENAME = "setup-workspace-root-sync.lock"
+_ROOT_SYNC_THREAD_LOCKS = {}
+_ROOT_SYNC_THREAD_LOCKS_GUARD = threading.Lock()
 
 
 def run_git(*args, cwd=None, check=True, env=None):
@@ -111,6 +117,69 @@ def remove_snapshot_anchor(repo_path, snapshot_id, scope_label):
             f"not remove its private recovery ref {ref_name}; the snapshot "
             f"remains anchored: {command_failure_details(result)}"
         )
+
+
+def root_sync_lock_path(repo_path):
+    """Return the persistent lock path shared by root-sync invocations."""
+    common_dir = require_git_output(
+        run_git(
+            "rev-parse", "--git-common-dir", cwd=repo_path, check=False,
+        ),
+        "failed to resolve Git common directory for root sync lock",
+    )
+    common_path = Path(common_dir)
+    if not common_path.is_absolute():
+        common_path = Path(repo_path) / common_path
+    return common_path.resolve() / ROOT_SYNC_LOCK_FILENAME
+
+
+def root_sync_thread_lock(lock_path):
+    """Return the in-process lock for one repository's root sync path."""
+    lock_key = os.path.normcase(str(lock_path))
+    with _ROOT_SYNC_THREAD_LOCKS_GUARD:
+        return _ROOT_SYNC_THREAD_LOCKS.setdefault(lock_key, threading.Lock())
+
+
+@contextlib.contextmanager
+def root_sync_lock(repo_path):
+    """Own root synchronization across threads and setup-workspace processes."""
+    lock_path = root_sync_lock_path(repo_path)
+    thread_lock = root_sync_thread_lock(lock_path)
+    with thread_lock:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("a+b") as lock_file:
+            lock_file.seek(0, os.SEEK_END)
+            if lock_file.tell() == 0:
+                lock_file.write(b"\0")
+                lock_file.flush()
+
+            if os.name == "nt":
+                import msvcrt
+
+                while True:
+                    lock_file.seek(0)
+                    try:
+                        msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+                        break
+                    except OSError:
+                        time.sleep(0.05)
+            else:
+                import fcntl
+
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+
+            try:
+                yield
+            finally:
+                if os.name == "nt":
+                    import msvcrt
+
+                    lock_file.seek(0)
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 def temporary_index_path():
@@ -418,6 +487,12 @@ def confirm_ref_matches(repo_path, ref_name, expected_sha):
 
 
 def sync_checked_out_main_with_stash(repo_root, remote_sha):
+    """Own, sync, and restore a checked-out root ``main`` invocation."""
+    with root_sync_lock(repo_root):
+        return _sync_checked_out_main_with_stash(repo_root, remote_sha)
+
+
+def _sync_checked_out_main_with_stash(repo_root, remote_sha):
     """Temporarily snapshot local changes, sync main, then restore them."""
     snapshot_id = stash_local_changes(
         repo_root,
@@ -442,6 +517,12 @@ def sync_checked_out_main_with_stash(repo_root, remote_sha):
 
 
 def sync_main(repo_root):
+    """Own one complete root-main synchronization invocation."""
+    with root_sync_lock(repo_root):
+        return _sync_main(repo_root)
+
+
+def _sync_main(repo_root):
     """Best-effort root main sync without disturbing the working tree.
 
     Uses fetch plus refs/heads/main fast-forward when safe instead of git pull,
@@ -485,8 +566,8 @@ def sync_main(repo_root):
     if not can_fast_forward_main(repo_root, local_sha, remote_sha):
         return "skipped (local main is not a fast-forward behind origin/main)"
 
-    if current_branch(repo_root) == "main" and working_tree_has_local_changes(repo_root):
-        return sync_checked_out_main_with_stash(repo_root, remote_sha)
+    if current_branch(repo_root) == "main":
+        return _sync_checked_out_main_with_stash(repo_root, remote_sha)
 
     run_git("update-ref", "refs/heads/main", remote_sha, cwd=repo_root)
     return (

--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -26,6 +26,7 @@ from pathlib import Path
 IMMUTABLE_OBJECT_ID = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
 SNAPSHOT_REF_PREFIX = "refs/factory-snapshots/"
 ROOT_SYNC_LOCK_FILENAME = "setup-workspace-root-sync.lock"
+MAX_ANCESTOR_RESIDUE_PATHS = 20
 _ROOT_SYNC_THREAD_LOCKS = {}
 _ROOT_SYNC_THREAD_LOCKS_GUARD = threading.Lock()
 
@@ -486,6 +487,128 @@ def confirm_ref_matches(repo_path, ref_name, expected_sha):
         )
 
 
+def ancestor_commits(repo_path, head_sha):
+    """Return every commit reachable behind head_sha, excluding head_sha."""
+    result = run_git(
+        "rev-list", "--parents", head_sha,
+        cwd=repo_path, check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"root main sync could not inspect ancestors of {head_sha}: "
+            f"{command_failure_details(result)}"
+        )
+
+    commits = []
+    for line in result.stdout.splitlines():
+        commit = line.split(maxsplit=1)[0] if line.strip() else ""
+        if commit and commit != head_sha:
+            commits.append(commit)
+    return commits
+
+
+def tree_for_revision(repo_path, revision, description):
+    """Return an immutable tree ID for a Git revision."""
+    return require_git_output(
+        run_git("rev-parse", f"{revision}^{{tree}}", cwd=repo_path, check=False),
+        description,
+    )
+
+
+def tracked_path_summary(repo_path, head_sha, ancestor_sha):
+    """Return a bounded path-only summary of the current/ancestor difference."""
+    result = run_git(
+        "diff", "--no-ext-diff", "--no-renames", "--name-status",
+        head_sha, ancestor_sha, cwd=repo_path, check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"root main sync could not summarize ancestor residue between "
+            f"{head_sha} and {ancestor_sha}: {command_failure_details(result)}"
+        )
+
+    paths = [line for line in result.stdout.splitlines() if line]
+    if not paths:
+        return "tracked tree differs without a named path"
+    if len(paths) > MAX_ANCESTOR_RESIDUE_PATHS:
+        remaining = len(paths) - MAX_ANCESTOR_RESIDUE_PATHS
+        paths = [*paths[:MAX_ANCESTOR_RESIDUE_PATHS], f"... ({remaining} more paths)"]
+    return ", ".join(paths)
+
+
+def verify_no_ancestor_residue(repo_path):
+    """Reject tracked checkout state that exactly matches an ancestor tree."""
+    head_sha = require_git_output(
+        run_git("rev-parse", "HEAD", cwd=repo_path, check=False),
+        "root main sync could not resolve current HEAD",
+    )
+    head_tree = tree_for_revision(
+        repo_path, head_sha, "root main sync could not capture current HEAD tree",
+    )
+    index_tree = require_git_output(
+        run_git("write-tree", cwd=repo_path, check=False),
+        "root main sync could not capture the synchronized index tree",
+    )
+    worktree_tree = working_tree_tree(repo_path)
+
+    local_states = []
+    if index_tree != head_tree:
+        local_states.append(("index", index_tree))
+    if worktree_tree != head_tree:
+        local_states.append(("working tree", worktree_tree))
+    if not local_states:
+        return
+
+    ancestor_trees = [
+        (ancestor_sha, tree_for_revision(
+            repo_path,
+            ancestor_sha,
+            f"root main sync could not capture ancestor {ancestor_sha} tree",
+        ))
+        for ancestor_sha in ancestor_commits(repo_path, head_sha)
+    ]
+    findings = []
+    for state_name, state_tree in local_states:
+        for ancestor_sha, ancestor_tree in ancestor_trees:
+            if state_tree == ancestor_tree:
+                paths = tracked_path_summary(repo_path, head_sha, ancestor_sha)
+                findings.append(
+                    f"{state_name} tree {state_tree} matches ancestor "
+                    f"{ancestor_sha} (tree {ancestor_tree}); paths: {paths}"
+                )
+                break
+
+    if findings:
+        raise RuntimeError(
+            "root main post-sync ancestor-residue guard rejected tracked "
+            f"local state while HEAD is {head_sha}: {' | '.join(findings)}. "
+            "The checkout was not reset or cleaned; preserve it for recovery."
+        )
+
+
+def verify_root_after_restore(repo_root, snapshot_id):
+    """Run the root residue guard and preserve a snapshot when it rejects."""
+    try:
+        verify_no_ancestor_residue(repo_root)
+    except RuntimeError as error:
+        if snapshot_id is None:
+            raise RuntimeError(
+                f"{error}; no root snapshot was captured for automatic recovery"
+            ) from error
+
+        recovery_ref = snapshot_ref_name(snapshot_id)
+        try:
+            anchor_snapshot(repo_root, snapshot_id)
+        except RuntimeError as anchor_error:
+            raise RuntimeError(
+                f"{error}; could not preserve recovery snapshot {recovery_ref}: "
+                f"{anchor_error}"
+            ) from error
+        raise RuntimeError(
+            f"{error}; recovery snapshot preserved at {recovery_ref}"
+        ) from error
+
+
 def sync_checked_out_main_with_stash(repo_root, remote_sha):
     """Own, sync, and restore a checked-out root ``main`` invocation."""
     with root_sync_lock(repo_root):
@@ -507,6 +630,8 @@ def _sync_checked_out_main_with_stash(repo_root, remote_sha):
         confirm_ref_matches(repo_root, "refs/heads/main", remote_sha)
     finally:
         restore_stashed_changes(repo_root, snapshot_id, "root main")
+
+    verify_root_after_restore(repo_root, snapshot_id)
 
     if snapshot_id is None:
         return f"synced checked-out main to {remote_sha[:8]}"
@@ -561,6 +686,8 @@ def _sync_main(repo_root):
 
     local_sha = run_git("rev-parse", "refs/heads/main", cwd=repo_root).stdout.strip()
     if local_sha == remote_sha:
+        if current_branch(repo_root) == "main":
+            verify_root_after_restore(repo_root, None)
         return "already up to date"
 
     if not can_fast_forward_main(repo_root, local_sha, remote_sha):

--- a/tests/factory/scripts/test_setup_workspace_root_residue.py
+++ b/tests/factory/scripts/test_setup_workspace_root_residue.py
@@ -11,9 +11,10 @@ the checked-out index and worktree along with ``main``.
 import contextlib
 import importlib.util
 import json
+import multiprocessing
+import queue
 import subprocess
 import tempfile
-import threading
 import unittest
 from pathlib import Path
 
@@ -167,6 +168,59 @@ def tree_report(module, repo_path):
 
 def report_message(label, report):
     return f"{label}: {json.dumps(report, sort_keys=True)}"
+
+
+def run_root_sync_process(
+    repo_path,
+    role,
+    owner_at_boundary,
+    competitor_attempted,
+    competitor_acquired,
+    owner_release,
+    competitor_release,
+    completed,
+    result_queue,
+):
+    """Run one sync invocation with process-safe ordering instrumentation."""
+    module = load_setup_workspace_module()
+    original_run_git = module.run_git
+    original_root_sync_lock = module.root_sync_lock
+
+    if role == "owner":
+        boundary_seen = False
+
+        def coordinate_owner(*args, **kwargs):
+            nonlocal boundary_seen
+            if not boundary_seen and args[:2] == ("pull", "--ff-only"):
+                boundary_seen = True
+                owner_at_boundary.set()
+                if not competitor_attempted.wait(10):
+                    raise RuntimeError("competitor did not attempt root sync")
+                if not owner_release.wait(10):
+                    raise RuntimeError("owner release was not signaled")
+            return original_run_git(*args, **kwargs)
+
+        module.run_git = coordinate_owner
+    elif role == "competitor":
+        @contextlib.contextmanager
+        def coordinate_competitor(repo):
+            competitor_attempted.set()
+            with original_root_sync_lock(repo):
+                competitor_acquired.set()
+                if not competitor_release.wait(10):
+                    raise RuntimeError("competitor release was not signaled")
+                yield
+
+        module.root_sync_lock = coordinate_competitor
+    else:
+        raise ValueError(f"unknown root sync process role: {role}")
+
+    try:
+        result_queue.put((role, "ok", module.sync_main(Path(repo_path))))
+    except BaseException as error:  # report child failures in the parent test
+        result_queue.put((role, "error", f"{type(error).__name__}: {error}"))
+    finally:
+        completed.set()
 
 
 class SetupWorkspaceRootResidueTest(unittest.TestCase):
@@ -683,8 +737,10 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
         self.assertEqual(report["main"], remote_sha, report_message("setup", report))
         self.assertIn("merged.txt", report["porcelain"])
 
-    def test_controlled_overlapping_syncs_serialize_root_sync_and_preserve_state(self):
-        """A competing invocation waits for the owner's full restore cycle."""
+    def test_controlled_overlapping_process_syncs_serialize_root_sync_and_preserve_state(
+        self,
+    ):
+        """Separate setup processes cannot overlap root capture and restore."""
         local, _upstream, remote_sha = create_remote_repository(
             self.root / "overlap", remote_ahead=True,
         )
@@ -692,91 +748,112 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
             "operator data\n", encoding="utf-8",
         )
 
-        snapshot_captured = threading.Event()
-        competitor_attempted = threading.Event()
-        competitor_acquired = threading.Event()
-        release_owner = threading.Event()
-        owner_result = []
-        competitor_result = []
-        original_run_git = self.module.run_git
-        original_root_sync_lock = self.module.root_sync_lock
-
-        def coordinate_lock(repo_path):
-            lock_context = original_root_sync_lock(repo_path)
-            if threading.current_thread().name != "root-sync-competitor":
-                return lock_context
-
-            @contextlib.contextmanager
-            def instrumented_lock():
-                competitor_attempted.set()
-                with lock_context:
-                    competitor_acquired.set()
-                    yield
-
-            return instrumented_lock()
-
-        def coordinate_owner(*args, **kwargs):
-            if (
-                threading.current_thread().name == "root-sync-owner"
-                and args[:2] == ("pull", "--ff-only")
-            ):
-                snapshot_captured.set()
-                # These bounded waits are only deadlock guards.  The events,
-                # not elapsed time, determine the invocation ordering.
-                if not competitor_attempted.wait(10):
-                    raise RuntimeError("competitor did not attempt root sync")
-                if competitor_acquired.is_set():
-                    raise RuntimeError("competitor acquired root sync too early")
-                if not release_owner.wait(10):
-                    raise RuntimeError("owner release was not signaled")
-            return original_run_git(*args, **kwargs)
-
-        self.module.run_git = coordinate_owner
-        self.module.root_sync_lock = coordinate_lock
-
-        def owner_sync():
-            try:
-                owner_result.append(self.module.sync_main(local))
-            except BaseException as error:  # report thread failures in test
-                owner_result.append(error)
-
-        def competitor_sync():
-            try:
-                competitor_result.append(self.module.sync_main(local))
-            except BaseException as error:  # report thread failures in test
-                competitor_result.append(error)
-
-        owner = threading.Thread(target=owner_sync, name="root-sync-owner")
-        competitor = threading.Thread(
-            target=competitor_sync, name="root-sync-competitor",
+        context = multiprocessing.get_context("spawn")
+        owner_at_boundary = context.Event()
+        competitor_attempted = context.Event()
+        competitor_acquired = context.Event()
+        owner_release = context.Event()
+        competitor_release = context.Event()
+        owner_completed = context.Event()
+        competitor_completed = context.Event()
+        result_queue = context.Queue()
+        owner = context.Process(
+            target=run_root_sync_process,
+            args=(
+                str(local),
+                "owner",
+                owner_at_boundary,
+                competitor_attempted,
+                competitor_acquired,
+                owner_release,
+                competitor_release,
+                owner_completed,
+                result_queue,
+            ),
         )
-        owner.start()
+        competitor = context.Process(
+            target=run_root_sync_process,
+            args=(
+                str(local),
+                "competitor",
+                owner_at_boundary,
+                competitor_attempted,
+                competitor_acquired,
+                owner_release,
+                competitor_release,
+                competitor_completed,
+                result_queue,
+            ),
+        )
+
+        owner_started = False
+        competitor_started = False
         try:
+            owner.start()
+            owner_started = True
             self.assertTrue(
-                snapshot_captured.wait(10),
+                owner_at_boundary.wait(10),
                 "owner did not reach the capture/restore boundary",
             )
             competitor.start()
+            competitor_started = True
             self.assertTrue(
                 competitor_attempted.wait(10),
                 "competitor did not attempt to acquire root sync",
             )
-            self.assertFalse(competitor_acquired.is_set())
-            release_owner.set()
+            # The owner is held at an explicit Git boundary. This bounded
+            # event wait is only a deadlock guard; the event ordering, not a
+            # sleep, proves whether the competitor entered the critical
+            # section before the owner released it. Removing the OS lock makes
+            # competitor_acquired fire here even though the owner is held.
+            self.assertFalse(
+                competitor_acquired.wait(1),
+                "competitor entered root sync before the owner released it",
+            )
+            owner_release.set()
+            self.assertTrue(
+                owner_completed.wait(10),
+                "owner did not complete root sync after release",
+            )
+            self.assertTrue(
+                competitor_acquired.wait(10),
+                "competitor did not acquire root sync after owner completion",
+            )
+            competitor_release.set()
+            self.assertTrue(
+                competitor_completed.wait(10),
+                "competitor did not complete root sync after release",
+            )
         finally:
-            owner.join(10)
-            competitor.join(10)
-            self.module.run_git = original_run_git
-            self.module.root_sync_lock = original_root_sync_lock
+            owner_release.set()
+            competitor_release.set()
+            if owner_started:
+                owner.join(10)
+            if competitor_started:
+                competitor.join(10)
+            if owner_started and owner.is_alive():
+                owner.terminate()
+                owner.join(10)
+            if competitor_started and competitor.is_alive():
+                competitor.terminate()
+                competitor.join(10)
 
-        self.assertFalse(owner.is_alive(), "owner sync did not finish")
-        self.assertFalse(competitor.is_alive(), "competitor sync did not finish")
-        self.assertEqual(len(owner_result), 1)
-        if isinstance(owner_result[0], BaseException):
-            raise owner_result[0]
-        self.assertEqual(len(competitor_result), 1)
-        if isinstance(competitor_result[0], BaseException):
-            raise competitor_result[0]
+        if owner_started:
+            self.assertFalse(owner.is_alive(), "owner sync did not finish")
+        if competitor_started:
+            self.assertFalse(competitor.is_alive(), "competitor sync did not finish")
+
+        results = {}
+        for _ in range(2):
+            try:
+                role, status, detail = result_queue.get(timeout=2)
+            except queue.Empty as error:
+                self.fail(f"root sync process did not report a result: {error}")
+            results[role] = (status, detail)
+        result_queue.close()
+        result_queue.join_thread()
+        self.assertEqual(results["owner"][0], "ok", results)
+        self.assertEqual(results["competitor"][0], "ok", results)
 
         final_report = tree_report(self.module, local)
         self.assertEqual(final_report["head"], remote_sha, report_message("final", final_report))

--- a/tests/factory/scripts/test_setup_workspace_root_residue.py
+++ b/tests/factory/scripts/test_setup_workspace_root_residue.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Disposable-repository reproductions for root setup-workspace residue.
+
+These tests intentionally characterize the pre-fix root-sync behavior.  The
+important ordering is observable Git state, not stash-stack identity:
+invocation A captures and clears local state, invocation B observes the
+temporarily clean checked-out ``main`` and takes the update-ref-only branch,
+then invocation A restores its untracked snapshot.  Updating the branch ref
+does not update the checked-out index or worktree, so HEAD can point at the
+new commit while the index still equals its parent.
+"""
+
+import importlib.util
+import json
+import subprocess
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "factory" / "scripts" / "setup-workspace.py"
+
+
+def load_setup_workspace_module():
+    spec = importlib.util.spec_from_file_location(
+        "setup_workspace_root_residue", SCRIPT_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def git(args, cwd, check=True):
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def init_repository(repo_path):
+    git(["init", "-b", "main"], repo_path)
+    git(
+        ["config", "user.email", "setup-workspace-test@example.com"],
+        repo_path,
+    )
+    git(["config", "user.name", "Setup Workspace Test"], repo_path)
+    (repo_path / "README.md").write_text("base\n", encoding="utf-8")
+    git(["add", "README.md"], repo_path)
+    git(["commit", "-m", "base"], repo_path)
+
+
+def create_remote_repository(root, remote_ahead):
+    """Create a local main checkout at P and optionally push merge commit M."""
+    root.mkdir(parents=True, exist_ok=True)
+    remote = root / "remote.git"
+    remote.mkdir()
+    git(["init", "--bare", "-b", "main"], remote)
+
+    upstream = root / "upstream"
+    upstream.mkdir()
+    init_repository(upstream)
+    git(["remote", "add", "origin", str(remote)], upstream)
+    git(["push", "-u", "origin", "main"], upstream)
+
+    (upstream / "merged.txt").write_text("latest merge\n", encoding="utf-8")
+    git(["add", "merged.txt"], upstream)
+    git(["commit", "-m", "latest merge"], upstream)
+    merge_sha = git(["rev-parse", "HEAD"], upstream).stdout.strip()
+    if remote_ahead:
+        git(["push", "origin", "main"], upstream)
+
+    local = root / "local"
+    git(["clone", str(remote), local.name], root)
+    if remote_ahead:
+        git(["reset", "--hard", "HEAD^"], local)
+        git(["fetch", "origin"], local)
+
+    return local, upstream, merge_sha
+
+
+def tree_report(module, repo_path):
+    """Return the observable checkout state used by each reproduction."""
+    private_refs = {}
+    refs = git(
+        [
+            "for-each-ref",
+            "--format=%(refname) %(objectname)",
+            "refs/factory-snapshots/",
+        ],
+        repo_path,
+    ).stdout
+    for line in refs.splitlines():
+        ref_name, object_id = line.split(maxsplit=1)
+        private_refs[ref_name] = object_id
+
+    return {
+        "head": git(["rev-parse", "HEAD"], repo_path).stdout.strip(),
+        "main": git(["rev-parse", "refs/heads/main"], repo_path).stdout.strip(),
+        "porcelain": git(["status", "--porcelain=v1"], repo_path).stdout,
+        "index_tree": git(["write-tree"], repo_path).stdout.strip(),
+        "worktree_tree": module.working_tree_tree(repo_path),
+        "head_tree": git(["rev-parse", "HEAD:"], repo_path).stdout.strip(),
+        "ancestor_tree": git(["rev-parse", "HEAD^:"], repo_path).stdout.strip(),
+        "private_refs": private_refs,
+    }
+
+
+def report_message(label, report):
+    return f"{label}: {json.dumps(report, sort_keys=True)}"
+
+
+class SetupWorkspaceRootResidueTest(unittest.TestCase):
+    def setUp(self):
+        self.module = load_setup_workspace_module()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_root_state_matrix_reports_current_and_ancestor_identity(self):
+        """Characterize clean, dirty, staged, and stale-anchor root starts."""
+        scenarios = (
+            ("clean", None),
+            ("untracked-only", "untracked"),
+            ("modified-tracked", "modified"),
+            ("staged", "staged"),
+            ("stale-private-ref", "stale"),
+        )
+
+        for label, initial_state in scenarios:
+            with self.subTest(start=label):
+                scenario_root = self.root / label
+                scenario_root.mkdir()
+                local, _upstream, remote_sha = create_remote_repository(
+                    scenario_root, remote_ahead=True,
+                )
+                expected_private_refs = {}
+
+                if initial_state == "untracked":
+                    (local / "operator-untracked.txt").write_text(
+                        "operator data\n", encoding="utf-8",
+                    )
+                elif initial_state == "modified":
+                    (local / "README.md").write_text(
+                        "operator edit\n", encoding="utf-8",
+                    )
+                elif initial_state == "staged":
+                    (local / "operator-staged.txt").write_text(
+                        "operator staged\n", encoding="utf-8",
+                    )
+                    git(["add", "operator-staged.txt"], local)
+                elif initial_state == "stale":
+                    (local / "stale-only.txt").write_text(
+                        "recoverable stale snapshot\n", encoding="utf-8",
+                    )
+                    stale_snapshot = self.module.stash_local_changes(
+                        local, "stale private snapshot",
+                    )
+                    expected_private_refs = {
+                        self.module.snapshot_ref_name(stale_snapshot): stale_snapshot,
+                    }
+
+                outcome = self.module.sync_main(local)
+                report = tree_report(self.module, local)
+                self.assertEqual(
+                    report["head"], remote_sha,
+                    report_message(f"{label} outcome={outcome}", report),
+                )
+                self.assertEqual(
+                    report["main"], remote_sha,
+                    report_message(f"{label} outcome={outcome}", report),
+                )
+                self.assertEqual(
+                    report["private_refs"], expected_private_refs,
+                    report_message(f"{label} outcome={outcome}", report),
+                )
+
+                if label in {"clean", "stale-private-ref"}:
+                    # This is the preserved occurrence shape: refs and HEAD
+                    # are current, but the checked-out index/worktree remain
+                    # byte-identical to the parent and stage the merge-added
+                    # file as a deletion.
+                    self.assertEqual(
+                        report["index_tree"], report["ancestor_tree"],
+                        report_message(label, report),
+                    )
+                    self.assertEqual(
+                        report["worktree_tree"], report["ancestor_tree"],
+                        report_message(label, report),
+                    )
+                    self.assertEqual(
+                        report["porcelain"], "D  merged.txt\n",
+                        report_message(label, report),
+                    )
+                    if label == "stale-private-ref":
+                        self.assertNotIn(
+                            "stale-only.txt", report["porcelain"],
+                        )
+                        self.assertFalse((local / "stale-only.txt").exists())
+                elif label == "untracked-only":
+                    self.assertEqual(
+                        report["index_tree"], report["head_tree"],
+                        report_message(label, report),
+                    )
+                    self.assertEqual(
+                        report["worktree_tree"], report["head_tree"],
+                        report_message(label, report),
+                    )
+                    self.assertEqual(
+                        report["porcelain"], "?? operator-untracked.txt\n",
+                        report_message(label, report),
+                    )
+                elif label == "modified-tracked":
+                    self.assertEqual(
+                        report["index_tree"], report["head_tree"],
+                        report_message(label, report),
+                    )
+                    self.assertNotEqual(
+                        report["worktree_tree"], report["head_tree"],
+                        report_message(label, report),
+                    )
+                    self.assertEqual(
+                        report["porcelain"], " M README.md\n",
+                        report_message(label, report),
+                    )
+                elif label == "staged":
+                    self.assertNotEqual(
+                        report["index_tree"], report["head_tree"],
+                        report_message(label, report),
+                    )
+                    self.assertEqual(
+                        report["worktree_tree"], report["index_tree"],
+                        report_message(label, report),
+                    )
+                    self.assertEqual(
+                        report["porcelain"], "A  operator-staged.txt\n",
+                        report_message(label, report),
+                    )
+
+    def test_remote_advance_between_snapshot_capture_and_restore_is_reported(self):
+        """Prove snapshot restore across a remote change in a throwaway repo."""
+        local, upstream, merge_sha = create_remote_repository(
+            self.root / "remote-advance", remote_ahead=False,
+        )
+        (local / "README.md").write_text("operator edit\n", encoding="utf-8")
+        (local / "operator-staged.txt").write_text(
+            "operator staged\n", encoding="utf-8",
+        )
+        git(["add", "operator-staged.txt"], local)
+        (local / "operator-untracked.txt").write_text(
+            "operator data\n", encoding="utf-8",
+        )
+
+        original_run_git = self.module.run_git
+        pushed = []
+
+        def push_remote_before_restore(*args, **kwargs):
+            if args[:2] == ("pull", "--ff-only") and not pushed:
+                git(["push", "origin", "main"], upstream)
+                pushed.append(True)
+            return original_run_git(*args, **kwargs)
+
+        self.module.run_git = push_remote_before_restore
+        try:
+            outcome = self.module.sync_checked_out_main_with_stash(local, merge_sha)
+        finally:
+            self.module.run_git = original_run_git
+
+        report = tree_report(self.module, local)
+        self.assertTrue(pushed, report_message(outcome, report))
+        self.assertEqual(report["head"], merge_sha, report_message(outcome, report))
+        self.assertEqual(report["main"], merge_sha, report_message(outcome, report))
+        self.assertEqual(
+            report["porcelain"],
+            " M README.md\nA  operator-staged.txt\n?? operator-untracked.txt\n",
+            report_message(outcome, report),
+        )
+        self.assertEqual(report["private_refs"], {}, report_message(outcome, report))
+        self.assertNotEqual(report["head_tree"], report["index_tree"])
+        self.assertNotEqual(report["index_tree"], report["worktree_tree"])
+
+    def test_controlled_overlapping_syncs_reproduce_ancestor_staged_residue(self):
+        """Capture/clear A, update-ref-only B, then restore A deterministically."""
+        local, _upstream, remote_sha = create_remote_repository(
+            self.root / "overlap", remote_ahead=True,
+        )
+        (local / "overlap-untracked.txt").write_text(
+            "operator data\n", encoding="utf-8",
+        )
+
+        snapshot_captured = threading.Event()
+        competitor_finished = threading.Event()
+        release_owner = threading.Event()
+        owner_result = []
+        original_run_git = self.module.run_git
+
+        def coordinate_owner(*args, **kwargs):
+            if (
+                threading.current_thread().name == "root-sync-owner"
+                and args[:2] == ("pull", "--ff-only")
+            ):
+                snapshot_captured.set()
+                # These bounded waits are only deadlock guards.  The events,
+                # not elapsed time, determine the invocation ordering.
+                if not competitor_finished.wait(10):
+                    raise RuntimeError("competitor did not finish root sync")
+                if not release_owner.wait(10):
+                    raise RuntimeError("owner release was not signaled")
+            return original_run_git(*args, **kwargs)
+
+        self.module.run_git = coordinate_owner
+
+        def owner_sync():
+            try:
+                owner_result.append(self.module.sync_main(local))
+            except BaseException as error:  # report thread failures in test
+                owner_result.append(error)
+
+        owner = threading.Thread(target=owner_sync, name="root-sync-owner")
+        owner.start()
+        competitor_report = None
+        competitor_error = None
+        try:
+            self.assertTrue(
+                snapshot_captured.wait(10),
+                "owner did not reach the capture/restore boundary",
+            )
+            try:
+                competitor_outcome = self.module.sync_main(local)
+                competitor_report = tree_report(self.module, local)
+            except BaseException as error:  # preserve cleanup before failing
+                competitor_error = error
+            finally:
+                competitor_finished.set()
+                release_owner.set()
+        finally:
+            owner.join(10)
+            self.module.run_git = original_run_git
+
+        self.assertFalse(owner.is_alive(), "owner sync did not finish")
+        if competitor_error is not None:
+            raise competitor_error
+        self.assertEqual(len(owner_result), 1)
+        if isinstance(owner_result[0], BaseException):
+            raise owner_result[0]
+
+        self.assertEqual(competitor_report["head"], remote_sha)
+        self.assertEqual(competitor_report["main"], remote_sha)
+        self.assertEqual(competitor_report["index_tree"], competitor_report["ancestor_tree"])
+        self.assertEqual(competitor_report["worktree_tree"], competitor_report["ancestor_tree"])
+        self.assertEqual(competitor_report["porcelain"], "D  merged.txt\n")
+
+        final_report = tree_report(self.module, local)
+        self.assertEqual(final_report["head"], remote_sha, report_message("final", final_report))
+        self.assertEqual(final_report["main"], remote_sha, report_message("final", final_report))
+        self.assertEqual(
+            final_report["index_tree"], final_report["ancestor_tree"],
+            report_message("final", final_report),
+        )
+        self.assertEqual(
+            final_report["porcelain"],
+            "D  merged.txt\n?? overlap-untracked.txt\n",
+            report_message("final", final_report),
+        )
+        self.assertEqual(final_report["private_refs"], {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/factory/scripts/test_setup_workspace_root_residue.py
+++ b/tests/factory/scripts/test_setup_workspace_root_residue.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
-"""Disposable-repository reproductions for root setup-workspace residue.
+"""Disposable-repository regressions for root setup-workspace synchronization.
 
-These tests intentionally characterize the pre-fix root-sync behavior.  The
-important ordering is observable Git state, not stash-stack identity:
-invocation A captures and clears local state, invocation B observes the
-temporarily clean checked-out ``main`` and takes the update-ref-only branch,
-then invocation A restores its untracked snapshot.  Updating the branch ref
-does not update the checked-out index or worktree, so HEAD can point at the
-new commit while the index still equals its parent.
+The scenarios retain the observable ordering that reproduced the incident:
+one invocation owns a temporarily cleared checked-out ``main`` while another
+invocation attempts to synchronize the same root.  The fixed behavior keeps
+the second invocation outside that capture-through-restore cycle and updates
+the checked-out index and worktree along with ``main``.
 """
 
+import contextlib
 import importlib.util
 import json
 import subprocess
@@ -182,21 +181,16 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
                 )
 
                 if label in {"clean", "stale-private-ref"}:
-                    # This is the preserved occurrence shape: refs and HEAD
-                    # are current, but the checked-out index/worktree remain
-                    # byte-identical to the parent and stage the merge-added
-                    # file as a deletion.
                     self.assertEqual(
-                        report["index_tree"], report["ancestor_tree"],
+                        report["index_tree"], report["head_tree"],
                         report_message(label, report),
                     )
                     self.assertEqual(
-                        report["worktree_tree"], report["ancestor_tree"],
+                        report["worktree_tree"], report["head_tree"],
                         report_message(label, report),
                     )
                     self.assertEqual(
-                        report["porcelain"], "D  merged.txt\n",
-                        report_message(label, report),
+                        report["porcelain"], "", report_message(label, report),
                     )
                     if label == "stale-private-ref":
                         self.assertNotIn(
@@ -285,8 +279,8 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
         self.assertNotEqual(report["head_tree"], report["index_tree"])
         self.assertNotEqual(report["index_tree"], report["worktree_tree"])
 
-    def test_controlled_overlapping_syncs_reproduce_ancestor_staged_residue(self):
-        """Capture/clear A, update-ref-only B, then restore A deterministically."""
+    def test_controlled_overlapping_syncs_serialize_root_sync_and_preserve_state(self):
+        """A competing invocation waits for the owner's full restore cycle."""
         local, _upstream, remote_sha = create_remote_repository(
             self.root / "overlap", remote_ahead=True,
         )
@@ -295,10 +289,27 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
         )
 
         snapshot_captured = threading.Event()
-        competitor_finished = threading.Event()
+        competitor_attempted = threading.Event()
+        competitor_acquired = threading.Event()
         release_owner = threading.Event()
         owner_result = []
+        competitor_result = []
         original_run_git = self.module.run_git
+        original_root_sync_lock = self.module.root_sync_lock
+
+        def coordinate_lock(repo_path):
+            lock_context = original_root_sync_lock(repo_path)
+            if threading.current_thread().name != "root-sync-competitor":
+                return lock_context
+
+            @contextlib.contextmanager
+            def instrumented_lock():
+                competitor_attempted.set()
+                with lock_context:
+                    competitor_acquired.set()
+                    yield
+
+            return instrumented_lock()
 
         def coordinate_owner(*args, **kwargs):
             if (
@@ -308,13 +319,16 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
                 snapshot_captured.set()
                 # These bounded waits are only deadlock guards.  The events,
                 # not elapsed time, determine the invocation ordering.
-                if not competitor_finished.wait(10):
-                    raise RuntimeError("competitor did not finish root sync")
+                if not competitor_attempted.wait(10):
+                    raise RuntimeError("competitor did not attempt root sync")
+                if competitor_acquired.is_set():
+                    raise RuntimeError("competitor acquired root sync too early")
                 if not release_owner.wait(10):
                     raise RuntimeError("owner release was not signaled")
             return original_run_git(*args, **kwargs)
 
         self.module.run_git = coordinate_owner
+        self.module.root_sync_lock = coordinate_lock
 
         def owner_sync():
             try:
@@ -322,50 +336,54 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
             except BaseException as error:  # report thread failures in test
                 owner_result.append(error)
 
+        def competitor_sync():
+            try:
+                competitor_result.append(self.module.sync_main(local))
+            except BaseException as error:  # report thread failures in test
+                competitor_result.append(error)
+
         owner = threading.Thread(target=owner_sync, name="root-sync-owner")
+        competitor = threading.Thread(
+            target=competitor_sync, name="root-sync-competitor",
+        )
         owner.start()
-        competitor_report = None
-        competitor_error = None
         try:
             self.assertTrue(
                 snapshot_captured.wait(10),
                 "owner did not reach the capture/restore boundary",
             )
-            try:
-                competitor_outcome = self.module.sync_main(local)
-                competitor_report = tree_report(self.module, local)
-            except BaseException as error:  # preserve cleanup before failing
-                competitor_error = error
-            finally:
-                competitor_finished.set()
-                release_owner.set()
+            competitor.start()
+            self.assertTrue(
+                competitor_attempted.wait(10),
+                "competitor did not attempt to acquire root sync",
+            )
+            self.assertFalse(competitor_acquired.is_set())
+            release_owner.set()
         finally:
             owner.join(10)
+            competitor.join(10)
             self.module.run_git = original_run_git
+            self.module.root_sync_lock = original_root_sync_lock
 
         self.assertFalse(owner.is_alive(), "owner sync did not finish")
-        if competitor_error is not None:
-            raise competitor_error
+        self.assertFalse(competitor.is_alive(), "competitor sync did not finish")
         self.assertEqual(len(owner_result), 1)
         if isinstance(owner_result[0], BaseException):
             raise owner_result[0]
-
-        self.assertEqual(competitor_report["head"], remote_sha)
-        self.assertEqual(competitor_report["main"], remote_sha)
-        self.assertEqual(competitor_report["index_tree"], competitor_report["ancestor_tree"])
-        self.assertEqual(competitor_report["worktree_tree"], competitor_report["ancestor_tree"])
-        self.assertEqual(competitor_report["porcelain"], "D  merged.txt\n")
+        self.assertEqual(len(competitor_result), 1)
+        if isinstance(competitor_result[0], BaseException):
+            raise competitor_result[0]
 
         final_report = tree_report(self.module, local)
         self.assertEqual(final_report["head"], remote_sha, report_message("final", final_report))
         self.assertEqual(final_report["main"], remote_sha, report_message("final", final_report))
         self.assertEqual(
-            final_report["index_tree"], final_report["ancestor_tree"],
+            final_report["index_tree"], final_report["head_tree"],
             report_message("final", final_report),
         )
         self.assertEqual(
             final_report["porcelain"],
-            "D  merged.txt\n?? overlap-untracked.txt\n",
+            "?? overlap-untracked.txt\n",
             report_message("final", final_report),
         )
         self.assertEqual(final_report["private_refs"], {})

--- a/tests/factory/scripts/test_setup_workspace_root_residue.py
+++ b/tests/factory/scripts/test_setup_workspace_root_residue.py
@@ -91,6 +91,44 @@ def create_remote_repository(root, remote_ahead):
     return local, upstream, merge_sha
 
 
+def create_linear_history(repo_path, commit_count):
+    """Add a linear commit history in one Git process for scaling coverage."""
+    parent = git(["rev-parse", "HEAD"], repo_path).stdout.strip()
+    stream = bytearray()
+    next_mark = 1
+    for commit_number in range(commit_count):
+        blob_mark = next_mark
+        commit_mark = next_mark + 1
+        next_mark += 2
+        path = f"history-{commit_number}.txt"
+        contents = f"history {commit_number}\n".encode("utf-8")
+        message = contents
+        stream.extend(f"blob\nmark :{blob_mark}\ndata {len(contents)}\n".encode())
+        stream.extend(contents)
+        stream.extend(
+            (
+                "commit refs/heads/main\n"
+                f"mark :{commit_mark}\n"
+                "author Setup Workspace Test <setup-workspace-test@example.com> 0 +0000\n"
+                "committer Setup Workspace Test <setup-workspace-test@example.com> 0 +0000\n"
+                f"data {len(message)}\n"
+            ).encode()
+        )
+        stream.extend(message)
+        stream.extend(f"from {parent}\nM 100644 :{blob_mark} {path}\n".encode())
+        parent = f":{commit_mark}"
+    stream.extend(b"done\n")
+    result = subprocess.run(
+        ["git", "fast-import"],
+        cwd=repo_path,
+        input=bytes(stream),
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stderr.decode("utf-8", errors="replace"))
+    git(["reset", "--hard", "HEAD"], repo_path)
+
+
 def configure_operator_ignores(repo_path):
     """Model the ignored operator paths that root sync must never remove."""
     exclude_path = repo_path / ".git" / "info" / "exclude"
@@ -516,6 +554,37 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
         self.assertEqual(report["index_tree"], report["head_tree"])
         self.assertNotEqual(report["worktree_tree"], report["head_tree"])
         self.assertEqual(report["porcelain"], " M README.md\n")
+
+    def test_guard_uses_bounded_git_invocations_for_long_dirty_history(self):
+        """A legitimate edit does not spawn Git once for every ancestor."""
+        local, _upstream, remote_sha = create_remote_repository(
+            self.root / "guard-long-history", remote_ahead=True,
+        )
+        git(["reset", "--hard", remote_sha], local)
+        create_linear_history(local, 80)
+
+        (local / "README.md").write_text("legitimate operator edit\n", encoding="utf-8")
+        original_run_git = self.module.run_git
+        invocations = []
+
+        def counting_run_git(*args, **kwargs):
+            invocations.append(args)
+            return original_run_git(*args, **kwargs)
+
+        self.module.run_git = counting_run_git
+        try:
+            self.module.verify_no_ancestor_residue(local)
+        finally:
+            self.module.run_git = original_run_git
+
+        self.assertLessEqual(
+            len(invocations), 10,
+            f"ancestor guard spawned too many Git processes: {invocations}",
+        )
+        self.assertEqual(
+            git(["status", "--porcelain"], local).stdout,
+            " M README.md\n",
+        )
 
     def test_sync_guard_preserves_snapshot_anchor_when_restore_leaves_ancestor_residue(self):
         """Guard failure keeps the captured snapshot available for recovery."""

--- a/tests/factory/scripts/test_setup_workspace_root_residue.py
+++ b/tests/factory/scripts/test_setup_workspace_root_residue.py
@@ -41,6 +41,15 @@ def git(args, cwd, check=True):
     )
 
 
+def git_bytes(args, cwd, check=True):
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=check,
+        capture_output=True,
+    )
+
+
 def init_repository(repo_path):
     git(["init", "-b", "main"], repo_path)
     git(
@@ -80,6 +89,15 @@ def create_remote_repository(root, remote_ahead):
         git(["fetch", "origin"], local)
 
     return local, upstream, merge_sha
+
+
+def configure_operator_ignores(repo_path):
+    """Model the ignored operator paths that root sync must never remove."""
+    exclude_path = repo_path / ".git" / "info" / "exclude"
+    exclude_path.write_text(
+        "docs/temp/\ntasks/todo/\n/prd.json\n/progress.txt\n.claude/\n",
+        encoding="utf-8",
+    )
 
 
 def tree_report(module, repo_path):
@@ -278,6 +296,177 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
         self.assertEqual(report["private_refs"], {}, report_message(outcome, report))
         self.assertNotEqual(report["head_tree"], report["index_tree"])
         self.assertNotEqual(report["index_tree"], report["worktree_tree"])
+
+    def test_sync_preserves_operator_bytes_and_ignored_files(self):
+        """Preserve every supported local state while checked-out main advances."""
+        local, _upstream, remote_sha = create_remote_repository(
+            self.root / "preserve-operator-work", remote_ahead=True,
+        )
+        configure_operator_ignores(local)
+
+        staged_bytes = b"staged bytes\x00\xff\n"
+        unstaged_bytes = b"unstaged bytes\x01\xfe\n"
+        (local / "README.md").write_bytes(staged_bytes)
+        git(["add", "README.md"], local)
+        (local / "README.md").write_bytes(unstaged_bytes)
+
+        untracked_bytes = b"untracked bytes\x02\xfd\n"
+        (local / "operator-untracked.bin").write_bytes(untracked_bytes)
+
+        ignored_files = {
+            local / "docs" / "temp" / "operator-notes.bin": b"ignored docs\x03\xfc\n",
+            local / "tasks" / "todo" / "operator-prd.json": b"ignored tasks\x04\xfb\n",
+            local / "prd.json": b"ignored root prd\x05\xfa\n",
+            local / "progress.txt": b"ignored progress\x06\xf9\n",
+        }
+        for path, contents in ignored_files.items():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(contents)
+
+        outcome = self.module.sync_main(local)
+        report = tree_report(self.module, local)
+
+        self.assertEqual(report["head"], remote_sha, report_message(outcome, report))
+        self.assertEqual(report["main"], remote_sha, report_message(outcome, report))
+        self.assertEqual(
+            git_bytes(["show", ":README.md"], local).stdout,
+            staged_bytes,
+            report_message(outcome, report),
+        )
+        self.assertEqual(
+            (local / "README.md").read_bytes(),
+            unstaged_bytes,
+            report_message(outcome, report),
+        )
+        self.assertEqual(
+            (local / "operator-untracked.bin").read_bytes(),
+            untracked_bytes,
+            report_message(outcome, report),
+        )
+        self.assertEqual(
+            report["porcelain"],
+            "MM README.md\n?? operator-untracked.bin\n",
+            report_message(outcome, report),
+        )
+        for path, contents in ignored_files.items():
+            self.assertEqual(path.read_bytes(), contents)
+        self.assertEqual(report["private_refs"], {})
+        self.assertEqual(git(["stash", "list"], local).stdout, "")
+
+    def test_sync_preserves_ignored_only_root_without_snapshot(self):
+        """Ignored operator files survive the no-local-snapshot sync path."""
+        local, _upstream, remote_sha = create_remote_repository(
+            self.root / "ignored-only", remote_ahead=True,
+        )
+        configure_operator_ignores(local)
+        ignored_files = {
+            local / "docs" / "temp" / "operator-notes.txt": b"docs temp\n",
+            local / "tasks" / "todo" / "operator-prd.json": b"tasks todo\n",
+            local / "prd.json": b"root prd\n",
+            local / "progress.txt": b"progress\n",
+        }
+        for path, contents in ignored_files.items():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(contents)
+
+        outcome = self.module.sync_main(local)
+        report = tree_report(self.module, local)
+
+        self.assertEqual(report["head"], remote_sha, report_message(outcome, report))
+        self.assertEqual(report["main"], remote_sha, report_message(outcome, report))
+        self.assertEqual(report["porcelain"], "", report_message(outcome, report))
+        self.assertEqual(report["private_refs"], {})
+        for path, contents in ignored_files.items():
+            self.assertEqual(path.read_bytes(), contents)
+
+    def test_lane_creation_and_reuse_follow_upstream_without_root_residue(self):
+        """Lane setup stays on its upstream branch after root synchronization."""
+        local, upstream, remote_sha = create_remote_repository(
+            self.root / "lane-behavior", remote_ahead=True,
+        )
+        configure_operator_ignores(local)
+        lane = "lane-preservation"
+        git(["checkout", "-b", lane], upstream)
+        (upstream / "lane.txt").write_text("lane base\n", encoding="utf-8")
+        git(["add", "lane.txt"], upstream)
+        git(["commit", "-m", "create lane branch"], upstream)
+        git(["push", "-u", "origin", lane], upstream)
+        git(["fetch", "origin"], local)
+
+        root_only_file = local / "root-only-untracked.txt"
+        root_only_file.write_bytes(b"root only\n")
+        tasks_dir = local / "tasks" / "todo"
+        tasks_dir.mkdir(parents=True, exist_ok=True)
+        (tasks_dir / f"{lane}.json").write_text(
+            json.dumps({"branchName": lane}), encoding="utf-8",
+        )
+
+        first = subprocess.run(
+            ["python", str(SCRIPT_PATH), lane],
+            cwd=local,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(first.returncode, 0, first.stderr)
+        first_payload = json.loads(first.stdout)
+        worktree = Path(first_payload["worktree"])
+        lane_sha = git(["rev-parse", f"origin/{lane}"], local).stdout.strip()
+        self.assertEqual(git(["rev-parse", "HEAD"], worktree).stdout.strip(), lane_sha)
+        self.assertEqual(
+            git(["rev-parse", f"refs/heads/{lane}"], worktree).stdout.strip(),
+            lane_sha,
+        )
+        self.assertEqual(
+            git(["rev-parse", f"origin/{lane}"], worktree).stdout.strip(),
+            lane_sha,
+        )
+        self.assertFalse((worktree / root_only_file.name).exists())
+        self.assertEqual(
+            git(["rev-parse", "HEAD"], local).stdout.strip(), remote_sha,
+        )
+        self.assertEqual(
+            git(["rev-parse", "refs/heads/main"], local).stdout.strip(),
+            remote_sha,
+        )
+
+        marker = worktree / "lane-local-marker.txt"
+        marker.write_bytes(b"keep lane marker\n")
+        (upstream / "lane-next.txt").write_bytes(b"lane next\n")
+        git(["add", "lane-next.txt"], upstream)
+        git(["commit", "-m", "advance lane branch"], upstream)
+        git(["push", "origin", lane], upstream)
+        git(["fetch", "origin"], local)
+
+        second = subprocess.run(
+            ["python", str(SCRIPT_PATH), lane],
+            cwd=local,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(second.returncode, 0, second.stderr)
+        second_payload = json.loads(second.stdout)
+        self.assertTrue(second_payload["reused"])
+        lane_next_sha = git(["rev-parse", f"origin/{lane}"], local).stdout.strip()
+        self.assertEqual(git(["rev-parse", "HEAD"], worktree).stdout.strip(), lane_next_sha)
+        self.assertEqual(
+            git(["rev-parse", f"refs/heads/{lane}"], worktree).stdout.strip(),
+            lane_next_sha,
+        )
+        self.assertEqual(
+            git(["rev-parse", f"origin/{lane}"], worktree).stdout.strip(),
+            lane_next_sha,
+        )
+        self.assertEqual(marker.read_bytes(), b"keep lane marker\n")
+        self.assertFalse((worktree / root_only_file.name).exists())
+        self.assertEqual(
+            git(["rev-parse", "HEAD"], local).stdout.strip(), remote_sha,
+        )
+        self.assertEqual(
+            git(["status", "--porcelain"], local).stdout,
+            f"?? {root_only_file.name}\n",
+        )
 
     def test_guard_rejects_ancestor_equivalent_index_and_worktree_without_repairing(self):
         """Reject a current HEAD whose tracked checkout exactly equals its parent."""

--- a/tests/factory/scripts/test_setup_workspace_root_residue.py
+++ b/tests/factory/scripts/test_setup_workspace_root_residue.py
@@ -279,6 +279,152 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
         self.assertNotEqual(report["head_tree"], report["index_tree"])
         self.assertNotEqual(report["index_tree"], report["worktree_tree"])
 
+    def test_guard_rejects_ancestor_equivalent_index_and_worktree_without_repairing(self):
+        """Reject a current HEAD whose tracked checkout exactly equals its parent."""
+        local, _upstream, remote_sha = create_remote_repository(
+            self.root / "guard-residue", remote_ahead=True,
+        )
+        git(["reset", "--hard", remote_sha], local)
+        git(["read-tree", "--reset", "-u", "HEAD^"], local)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"root main post-sync ancestor-residue guard rejected tracked local state",
+        ) as raised:
+            self.module.verify_no_ancestor_residue(local)
+
+        report = tree_report(self.module, local)
+        self.assertEqual(report["head"], remote_sha, report_message("guard", report))
+        self.assertEqual(report["main"], remote_sha, report_message("guard", report))
+        self.assertEqual(
+            report["index_tree"], report["ancestor_tree"],
+            report_message("guard", report),
+        )
+        self.assertEqual(
+            report["worktree_tree"], report["ancestor_tree"],
+            report_message("guard", report),
+        )
+        self.assertIn("merged.txt", report["porcelain"])
+        self.assertIn("merged.txt", str(raised.exception))
+        self.assertIn(remote_sha, str(raised.exception))
+        self.assertIn(report["head"], str(raised.exception))
+        self.assertNotIn("latest merge", str(raised.exception))
+
+    def test_guard_accepts_current_content_and_legitimate_non_ancestor_edit(self):
+        """Current content and an ordinary edit do not look like old code."""
+        local, _upstream, remote_sha = create_remote_repository(
+            self.root / "guard-legitimate", remote_ahead=True,
+        )
+        git(["reset", "--hard", remote_sha], local)
+
+        self.module.verify_no_ancestor_residue(local)
+
+        (local / "README.md").write_text("operator edit\n", encoding="utf-8")
+        self.module.verify_no_ancestor_residue(local)
+
+        report = tree_report(self.module, local)
+        self.assertEqual(report["head"], remote_sha, report_message("legitimate", report))
+        self.assertEqual(report["index_tree"], report["head_tree"])
+        self.assertNotEqual(report["worktree_tree"], report["head_tree"])
+        self.assertEqual(report["porcelain"], " M README.md\n")
+
+    def test_sync_guard_preserves_snapshot_anchor_when_restore_leaves_ancestor_residue(self):
+        """Guard failure keeps the captured snapshot available for recovery."""
+        local, _upstream, remote_sha = create_remote_repository(
+            self.root / "guard-recovery", remote_ahead=True,
+        )
+        (local / "operator-untracked.txt").write_text(
+            "operator data\n", encoding="utf-8",
+        )
+
+        original_restore = self.module.restore_stashed_changes
+        captured_snapshot = []
+
+        def induce_residue(repo_path, snapshot_id, scope_label):
+            original_restore(repo_path, snapshot_id, scope_label)
+            captured_snapshot.append(snapshot_id)
+            git(["read-tree", "--reset", "-u", "HEAD^"], repo_path)
+
+        self.module.restore_stashed_changes = induce_residue
+        try:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"recovery snapshot preserved at refs/factory-snapshots/",
+            ) as raised:
+                self.module.sync_main(local)
+        finally:
+            self.module.restore_stashed_changes = original_restore
+
+        self.assertEqual(len(captured_snapshot), 1)
+        snapshot_id = captured_snapshot[0]
+        report = tree_report(self.module, local)
+        self.assertEqual(report["head"], remote_sha, report_message("recovery", report))
+        self.assertEqual(report["main"], remote_sha, report_message("recovery", report))
+        self.assertEqual(
+            report["private_refs"],
+            {self.module.snapshot_ref_name(snapshot_id): snapshot_id},
+            report_message("recovery", report),
+        )
+        self.assertIn("merged.txt", report["porcelain"])
+        self.assertIn(self.module.snapshot_ref_name(snapshot_id), str(raised.exception))
+
+    def test_sync_guard_checks_residue_when_main_is_already_current(self):
+        """A previous silent residue is rejected even when no fast-forward is needed."""
+        local, _upstream, remote_sha = create_remote_repository(
+            self.root / "guard-current", remote_ahead=True,
+        )
+        git(["reset", "--hard", remote_sha], local)
+        git(["read-tree", "--reset", "-u", "HEAD^"], local)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"no root snapshot was captured for automatic recovery",
+        ):
+            self.module.sync_main(local)
+
+        report = tree_report(self.module, local)
+        self.assertEqual(report["head"], remote_sha, report_message("current", report))
+        self.assertEqual(report["main"], remote_sha, report_message("current", report))
+        self.assertIn("merged.txt", report["porcelain"])
+        self.assertEqual(report["private_refs"], {})
+
+    def test_setup_stops_before_lane_creation_on_ancestor_residue(self):
+        """The integrated guard fails before the requested lane is prepared."""
+        local, _upstream, remote_sha = create_remote_repository(
+            self.root / "guard-setup", remote_ahead=True,
+        )
+        git(["reset", "--hard", remote_sha], local)
+        git(["read-tree", "--reset", "-u", "HEAD^"], local)
+
+        prd_name = "ancestor-residue-prd"
+        tasks_dir = local / "tasks" / "todo"
+        tasks_dir.mkdir(parents=True)
+        (tasks_dir / f"{prd_name}.json").write_text(
+            json.dumps({"branchName": prd_name}),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            ["python3", str(SCRIPT_PATH), prd_name],
+            cwd=local,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("Root sync failed:", result.stderr)
+        self.assertIn("ancestor-residue guard", result.stderr)
+        self.assertIn("merged.txt", result.stderr)
+        self.assertFalse(
+            (local / ".claude" / "worktrees" / prd_name).exists(),
+            result.stderr,
+        )
+        report = tree_report(self.module, local)
+        self.assertEqual(report["head"], remote_sha, report_message("setup", report))
+        self.assertEqual(report["main"], remote_sha, report_message("setup", report))
+        self.assertIn("merged.txt", report["porcelain"])
+
     def test_controlled_overlapping_syncs_serialize_root_sync_and_preserve_state(self):
         """A competing invocation waits for the owner's full restore cycle."""
         local, _upstream, remote_sha = create_remote_repository(


### PR DESCRIPTION
{
  "project": "Prevent Root Checkout Sync from Silently Restoring an Ancestor Revision",
  "branchName": "thr-root-checkout-acquires-silent-revert-of-latest-merge",
  "description": "Reproduce and eliminate the workspace-setup failure that leaves the operator's root checkout at the correct main HEAD while silently staging content from an ancestor revision. Make the root capture-through-restore cycle safe across concurrent setup invocations, integrate a loud post-sync ancestor-content guard, and preserve legitimate staged, unstaged, untracked, and ignored operator work.",
  "context": {
    "customerAsk": "Determine why the operator's root checkout twice acquired a staged revert of the latest merged PR after workspace setup activity, reproduce the defect in disposable repositories, fix the responsible root-sync path, add an integrated post-sync ancestor-content guard, preserve legitimate dirty-root work and ignored files, avoid the shared stash stack, keep the PR limited to reproduction/cause/fix/guard, and deliver it through review and actual merge.",
    "problem": "On 2026-08-15 the root checkout twice advanced HEAD and refs/heads/main correctly while its index silently became byte-identical to the parent of the latest merge, including deletion of a file introduced by that merge. Completed snapshot restoration left no stash entry or private snapshot ref, so local reads and verification exercised old code while Git history appeared current. PR #1969 removed positional stash addressing but did not prevent the recurrence, and current tests do not pin the full initial-state matrix, controlled concurrent invocation ordering, stale private refs, or ancestor-equivalent residue detection.",
    "solution": "Use deterministic disposable-repository scenarios to advance origin/main between snapshot capture and restore for clean, untracked-only, modified-tracked, staged, stale-ref, and overlapping-invocation starts; identify the exact harmful ordering and code path; give each root sync exclusive ownership of capture, fast-forward, restore, verification, and anchor cleanup; and verify after restoration that tracked index or working-tree modifications/deletions do not exactly match an ancestor. Fail non-destructively with recovery details on residue while preserving legitimate local and ignored files and leaving lane worktree behavior unchanged."
  },
  "acceptanceCriteria": [
    "A deterministic disposable-repository reproduction reports outcomes for clean, untracked-only, modified-tracked, staged, and stale-snapshot-ref starts and identifies the exact single- or multi-invocation ordering that produces the staged ancestor revert before the fix.",
    "The root-cause statement names the responsible workspace-setup code path and state ordering, explains how previous-commit content reached the root, and confirms or evidence-based revives the partially refuted untracked-only hypothesis without repeating the positional-stash audit from PR #1969.",
    "After the fix, overlapping workspace-setup invocations cannot cross-restore, overwrite, clean, or remove one another's root snapshot state, and successful sync leaves root HEAD and refs/heads/main at the intended remote commit.",
    "The integrated post-sync verification rejects deliberately induced tracked index or working-tree residue that exactly matches an ancestor, exits non-zero with actionable recovery details, and passes for current synchronized content.",
    "Legitimate staged and unstaged tracked edits, non-ignored untracked files, and ignored operator files survive root sync with their intended content and status; stale private snapshot refs remain recoverable and are never implicitly applied by another invocation.",
    "Lane worktree creation/reuse remains behaviorally unchanged, no shared git stash or git stash pop operation is introduced, no out-of-scope live-lane or observability-victim surface is modified, and adjacent defects are deferred.",
    "Quality gates pass: typecheck, focused workspace-setup tests, and required broader tests; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file churn are resolved, and the PR is actually merged; CI-run evidence is placed in PR comments and never in commits."
  ],
  "userStories": [
    {
      "id": "thr-root-checkout-acquires-silent-revert-of-latest-merge-001",
      "title": "Reproduce and classify the root residue",
      "description": "As a maintainer diagnosing workspace setup, I want a deterministic disposable-repository scenario for each relevant root state and invocation ordering so the actual cause is proven before synchronization behavior changes.",
      "acceptanceCriteria": [
        "The reproduction advances origin/main between root snapshot capture and restore without running against the operator's checkout.",
        "Clean, untracked-only, modified-tracked, staged, and stale-private-ref starts each report final HEAD, refs/heads/main, porcelain status, relevant index/worktree blob identity, and remaining private snapshot anchors.",
        "A controlled overlap of two setup invocations uses deterministic coordination rather than timing-only sleeps and isolates the exact ordering that creates, or conclusively does not create, ancestor-equivalent staged residue.",
        "The reproduced residue matches the preserved occurrence shape: HEAD is current while affected index content equals an ancestor, including the added-file/deletion case.",
        "The evidence distinguishes genuine tracked modifications from untracked-only state and supports a specific root-cause statement without re-auditing positional stash addressing.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added tests/factory/scripts/test_setup_workspace_root_residue.py with real disposable Git repositories covering clean, untracked-only, modified-tracked, staged, stale-private-ref, remote-advance, and deterministic overlapping root-sync starts. Root cause: sync_main's checked-out-main clean branch uses update-ref for refs/heads/main without updating the index/worktree; when invocation B enters after invocation A clears its snapshot, B observes a temporarily clean root and leaves the ancestor tree staged while A later restores only its untracked snapshot."
    },
    {
      "id": "thr-root-checkout-acquires-silent-revert-of-latest-merge-002",
      "title": "Make root synchronization invocation-safe",
      "description": "As an operator creating lanes concurrently, I want each root synchronization to own its complete capture-through-restore cycle so another setup invocation cannot make my root contain an ancestor revision.",
      "acceptanceCriteria": [
        "The proven harmful ordering is eliminated: overlapping setup invocations sharing a root cannot interleave capture, clearing, fast-forward, restoration, verification, or anchor cleanup in a way that cross-applies or loses local state.",
        "Snapshot identity and lifecycle remain explicit per invocation; an invocation restores and removes only the snapshot it captured, and a stale private snapshot ref is not selected or applied by a later invocation.",
        "On successful synchronization, root HEAD and refs/heads/main both resolve to the intended remote commit before workspace creation continues.",
        "Failure or interruption preserves the owned snapshot anchor and reports stable recovery information without silently discarding, resetting, or attributing another invocation's state to itself.",
        "The implementation continues to avoid the shared stash stack and keeps Git/process side effects isolated through the existing command boundary.",
        "The deterministic overlap regression passes repeatedly without timing-dependent coordination.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Made root sync invocation-safe with a repository-scoped persistent OS lock plus same-process locking. Checked-out main now always uses the snapshot/pull/restore path, including clean and stale-private-ref starts, so HEAD, refs/heads/main, index, and worktree advance together. The review-fix overlap regression now uses two spawned processes and event coordination, proves the competitor cannot acquire root sync until the owner restores and releases it, preserves final operator state, and fails when the OS lock is temporarily disabled. Focused sync, residue, failure, Python compilation, and diff checks pass."
    },
    {
      "id": "thr-root-checkout-acquires-silent-revert-of-latest-merge-003",
      "title": "Fail loudly on ancestor-equivalent root residue",
      "description": "As an operator relying on local verification, I want workspace setup to stop when a synchronized root contains exact ancestor content so I never unknowingly test the previous revision.",
      "acceptanceCriteria": [
        "After checked-out-main sync and local-state restoration, the setup script examines tracked modified/deleted index and working-tree states for exact equivalence with an ancestor rather than relying only on HEAD and branch-ref equality.",
        "A deliberately induced case with current HEAD, ancestor-equal modified blobs, and an ancestor-shaped added-file deletion exits non-zero before lane setup continues.",
        "Failure output identifies the root-sync stage, suspect paths or a bounded actionable summary, current and matching ancestor identities, and preserved recovery evidence without exposing file contents.",
        "Detection does not automatically reset, clean, commit, or otherwise destroy the suspect root state.",
        "Current synchronized content, ordinary clean roots, and legitimate local edits that do not match ancestor content pass the guard.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added an integrated post-restore guard in factory/scripts/setup-workspace.py. It compares tracked index and working-tree trees against reachable ancestors, reports bounded path-only residue with current and matching commit/tree IDs, runs even when checked-out main is already current, and never resets or cleans the suspect checkout. Guard failures preserve the owned snapshot anchor for recovery. Ancestor commit/tree pairs now come from one formatted revision walk instead of one Git process per reachable commit, with long-history coverage proving legitimate dirty roots remain practical. Added disposable-repository coverage for direct residue, legitimate edits, recovery-anchor preservation, already-current residue, and subprocess setup stopping before lane creation. py_compile, diff check, the root-residue suite (12 tests), sync suite (15 tests), and failure suite (5 tests) pass; the adjacent worktree suite retains the documented baseline standing_rules_path key mismatch."
    },
    {
      "id": "thr-root-checkout-acquires-silent-revert-of-latest-merge-004",
      "title": "Preserve legitimate operator work and lane behavior",
      "description": "As an operator with intentional local root changes, I want safe synchronization and residue detection to preserve my work and existing lane setup behavior while preventing silent old-code verification.",
      "acceptanceCriteria": [
        "A disposable sync preserves representative staged and unstaged tracked edits byte-for-byte and retains their intended index versus working-tree status after main advances.",
        "Non-ignored untracked files survive the capture/restore cycle, while ignored operator files such as docs/temp, tasks/todo, prd.json, and progress.txt remain untouched.",
        "Clean and untracked-only roots advance without acquiring tracked modifications or deletions, confirming whether the untracked-only hypothesis remains refuted.",
        "Existing lane worktree creation and reuse scenarios still resolve lane HEAD and branch refs from their upstream and do not inherit root residue.",
        "Focused regression coverage proves successful sync, guarded failure, recovery-anchor behavior, and preservation outcomes without modifying observability victim tests or other live-lane surfaces.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Added disposable checked-out-main coverage for byte-for-byte staged/unstaged tracked edits, non-ignored untracked files, ignored docs/temp and tasks/todo files, root prd.json/progress.txt, and no-snapshot ignored-only sync. Added end-to-end lane creation/reuse assertions that HEAD, refs/heads/<lane>, and origin/<lane> remain aligned while root-only residue stays out of the lane. Focused root-residue suite (11 tests), sync suite (15 tests), Python compilation, and diff checks pass; the adjacent worktree suite retains the documented baseline standing_rules_path expected-key mismatch."
    }
  ]
}
