### PR TITLE
thr-coverage-regression-names-package-not-statements

### DIFF
--- a/cmd/gocoveragecheck/coverage_blocks.go
+++ b/cmd/gocoveragecheck/coverage_blocks.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+const maxUncoveredCoverageBlocks = 25
+
+type coverageBlock struct {
+	canonicalPath  string
+	importPath     string
+	rangeSpec      string
+	statementCount int
+	executionCount int
+}
+
+func uncoveredCoverageBlocks(coverageBlocks map[string]coverageBlock, importPath string) []coverageBlock {
+	blocks := make([]coverageBlock, 0)
+	for _, block := range coverageBlocks {
+		if block.importPath != importPath || block.executionCount != 0 {
+			continue
+		}
+		blocks = append(blocks, block)
+	}
+	slices.SortFunc(blocks, compareCoverageBlocks)
+	return blocks
+}
+
+func compareCoverageBlocks(left coverageBlock, right coverageBlock) int {
+	if comparison := strings.Compare(left.canonicalPath, right.canonicalPath); comparison != 0 {
+		return comparison
+	}
+	leftLine, leftColumn := coverageBlockStartPosition(left)
+	rightLine, rightColumn := coverageBlockStartPosition(right)
+	if leftLine != rightLine {
+		return leftLine - rightLine
+	}
+	if leftColumn != rightColumn {
+		return leftColumn - rightColumn
+	}
+	return strings.Compare(left.rangeSpec, right.rangeSpec)
+}
+
+func coverageBlockStartPosition(block coverageBlock) (int, int) {
+	start := block.rangeSpec
+	if separator := strings.IndexByte(start, ','); separator >= 0 {
+		start = start[:separator]
+	}
+	separator := strings.IndexByte(start, '.')
+	if separator < 0 {
+		line, _ := strconv.Atoi(start)
+		return line, 0
+	}
+	line, _ := strconv.Atoi(start[:separator])
+	column, _ := strconv.Atoi(start[separator+1:])
+	return line, column
+}
+
+func formatUncoveredCoverageBlocks(coverageBlocks map[string]coverageBlock, importPath string) string {
+	blocks := uncoveredCoverageBlocks(coverageBlocks, importPath)
+	if len(blocks) == 0 {
+		return ""
+	}
+	limit := min(len(blocks), maxUncoveredCoverageBlocks)
+	entries := make([]string, 0, limit)
+	for _, block := range blocks[:limit] {
+		filePath := strings.TrimPrefix(block.canonicalPath, modulePath+"/")
+		statementLabel := "statements"
+		if block.statementCount == 1 {
+			statementLabel = "statement"
+		}
+		entries = append(entries, fmt.Sprintf("%s:%d (%d %s)", filePath, coverageBlockStartLine(block), block.statementCount, statementLabel))
+	}
+	detail := "uncovered blocks: " + strings.Join(entries, ", ")
+	if omitted := len(blocks) - limit; omitted > 0 {
+		detail += fmt.Sprintf(", ... and %d more", omitted)
+	}
+	return detail
+}
+
+func coverageBlockStartLine(block coverageBlock) int {
+	line, _ := coverageBlockStartPosition(block)
+	return line
+}

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -44,6 +44,7 @@ const defaultFunctionalPackageCoverageBaselinePath = "docs/internal/baselines/go
 const defaultPackageCoverageMin = 80.0
 const defaultPackageFloorEpsilon = 0.25
 const defaultCoverageJobs = 2
+const maxUncoveredCoverageBlocks = 25
 
 var (
 	defaultCoveragePatterns                   = []string{"./pkg/..."}
@@ -110,6 +111,7 @@ type config struct {
 type coverageResult struct {
 	actual                       float64
 	insufficientCoveragePackages []packageCoverageSummary
+	coverageBlocks               map[string]coverageBlock
 	packageTotals                map[string]packageCoverageTotals
 	packageSummaries             []packageCoverageSummary
 	packageGates                 map[string]packageCoverageGate
@@ -403,7 +405,7 @@ func runCoverageProfile(cfg config, targetOS string, profilePath string) (covera
 			}
 			return coverageResult{}, err
 		}
-		result.packageMinimumFailures, result.packageMinimumWarnings = checkCoverageManifestWithEpsilon(manifest, result.packageTotals, cfg.packageManifest, cfg.packageFloorEpsilon)
+		result.packageMinimumFailures, result.packageMinimumWarnings = checkCoverageManifestWithEpsilonAndBlocks(manifest, result.packageTotals, cfg.packageManifest, cfg.packageFloorEpsilon, result.coverageBlocks)
 		result.packageGates = packageGatesFromManifest(manifest)
 	} else if legacyPackageGateEnabled {
 		result.packageGates = packageGatesFromLegacyMin(result.packageSummaries, cfg.packageCoverageMin(), baselinePackages)
@@ -615,10 +617,11 @@ func parseTotalCoverage(report string) (float64, string, error) {
 }
 
 func evaluateCoverage(_ string, _ string, profilePath string, repoRoot string, coverPackages []string, minCoverage float64, baselinePackages map[string]struct{}, packageGate ...bool) (coverageResult, string, error) {
-	packageTotals, err := readCoverageProfileTotals(profilePath, repoRoot)
+	coverageBlocks, err := readCoverageProfileBlocks(profilePath, repoRoot)
 	if err != nil {
 		return coverageResult{}, "", err
 	}
+	packageTotals := coverageTotals(coverageBlocks)
 	actual, totalLine := calculateTotalCoverage(packageTotals, coverPackages)
 	packageGateEnabled := len(packageGate) == 0 || packageGate[0]
 	packageSummaries := summarizePackageCoverageFromTotals(packageTotals, coverPackages)
@@ -631,6 +634,7 @@ func evaluateCoverage(_ string, _ string, profilePath string, repoRoot string, c
 	return coverageResult{
 		actual:                       actual,
 		insufficientCoveragePackages: insufficientCoveragePackages,
+		coverageBlocks:               coverageBlocks,
 		packageTotals:                packageTotals,
 		packageSummaries:             packageSummaries,
 		zeroCoveragePackages:         zeroCoveragePackages,
@@ -655,6 +659,14 @@ func readPackageCoverageBaseline(path string) (map[string]struct{}, error) {
 }
 
 func readCoverageProfileTotals(profilePath string, repoRoot string) (map[string]packageCoverageTotals, error) {
+	coverageBlocks, err := readCoverageProfileBlocks(profilePath, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	return coverageTotals(coverageBlocks), nil
+}
+
+func readCoverageProfileBlocks(profilePath string, repoRoot string) (map[string]coverageBlock, error) {
 	profile, err := os.Open(profilePath)
 	if err != nil {
 		return nil, fmt.Errorf("read go coverage profile: %w", err)
@@ -665,7 +677,7 @@ func readCoverageProfileTotals(profilePath string, repoRoot string) (map[string]
 	if err != nil {
 		return nil, err
 	}
-	return coverageTotals(coverageBlocks), nil
+	return coverageBlocks, nil
 }
 
 func calculateTotalCoverage(packageTotals map[string]packageCoverageTotals, coverPackages []string) (float64, string) {
@@ -967,6 +979,75 @@ func coverageImportPath(filePath string, repoRoot string) (string, error) {
 		return "", err
 	}
 	return path.Dir(canonicalFilePath), nil
+}
+
+func uncoveredCoverageBlocks(coverageBlocks map[string]coverageBlock, importPath string) []coverageBlock {
+	blocks := make([]coverageBlock, 0)
+	for _, block := range coverageBlocks {
+		if block.importPath != importPath || block.executionCount != 0 {
+			continue
+		}
+		blocks = append(blocks, block)
+	}
+	slices.SortFunc(blocks, compareCoverageBlocks)
+	return blocks
+}
+
+func compareCoverageBlocks(left coverageBlock, right coverageBlock) int {
+	if comparison := strings.Compare(left.canonicalPath, right.canonicalPath); comparison != 0 {
+		return comparison
+	}
+	leftLine, leftColumn := coverageBlockStartPosition(left)
+	rightLine, rightColumn := coverageBlockStartPosition(right)
+	if leftLine != rightLine {
+		return leftLine - rightLine
+	}
+	if leftColumn != rightColumn {
+		return leftColumn - rightColumn
+	}
+	return strings.Compare(left.rangeSpec, right.rangeSpec)
+}
+
+func coverageBlockStartPosition(block coverageBlock) (int, int) {
+	start := block.rangeSpec
+	if separator := strings.IndexByte(start, ','); separator >= 0 {
+		start = start[:separator]
+	}
+	separator := strings.IndexByte(start, '.')
+	if separator < 0 {
+		line, _ := strconv.Atoi(start)
+		return line, 0
+	}
+	line, _ := strconv.Atoi(start[:separator])
+	column, _ := strconv.Atoi(start[separator+1:])
+	return line, column
+}
+
+func formatUncoveredCoverageBlocks(coverageBlocks map[string]coverageBlock, importPath string) string {
+	blocks := uncoveredCoverageBlocks(coverageBlocks, importPath)
+	if len(blocks) == 0 {
+		return ""
+	}
+	limit := min(len(blocks), maxUncoveredCoverageBlocks)
+	entries := make([]string, 0, limit)
+	for _, block := range blocks[:limit] {
+		filePath := strings.TrimPrefix(block.canonicalPath, modulePath+"/")
+		statementLabel := "statements"
+		if block.statementCount == 1 {
+			statementLabel = "statement"
+		}
+		entries = append(entries, fmt.Sprintf("%s:%d (%d %s)", filePath, coverageBlockStartLine(block), block.statementCount, statementLabel))
+	}
+	detail := "uncovered blocks: " + strings.Join(entries, ", ")
+	if omitted := len(blocks) - limit; omitted > 0 {
+		detail += fmt.Sprintf(", ... and %d more", omitted)
+	}
+	return detail
+}
+
+func coverageBlockStartLine(block coverageBlock) int {
+	line, _ := coverageBlockStartPosition(block)
+	return line
 }
 
 func formatZeroCoverageFailure(packages []string) string {

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -44,7 +44,6 @@ const defaultFunctionalPackageCoverageBaselinePath = "docs/internal/baselines/go
 const defaultPackageCoverageMin = 80.0
 const defaultPackageFloorEpsilon = 0.25
 const defaultCoverageJobs = 2
-const maxUncoveredCoverageBlocks = 25
 
 var (
 	defaultCoveragePatterns                   = []string{"./pkg/..."}
@@ -128,14 +127,6 @@ type packageCoverageTotals struct {
 type packageCoverageSummary struct {
 	importPath string
 	coverage   float64
-}
-
-type coverageBlock struct {
-	canonicalPath  string
-	importPath     string
-	rangeSpec      string
-	statementCount int
-	executionCount int
 }
 
 func main() {
@@ -979,75 +970,6 @@ func coverageImportPath(filePath string, repoRoot string) (string, error) {
 		return "", err
 	}
 	return path.Dir(canonicalFilePath), nil
-}
-
-func uncoveredCoverageBlocks(coverageBlocks map[string]coverageBlock, importPath string) []coverageBlock {
-	blocks := make([]coverageBlock, 0)
-	for _, block := range coverageBlocks {
-		if block.importPath != importPath || block.executionCount != 0 {
-			continue
-		}
-		blocks = append(blocks, block)
-	}
-	slices.SortFunc(blocks, compareCoverageBlocks)
-	return blocks
-}
-
-func compareCoverageBlocks(left coverageBlock, right coverageBlock) int {
-	if comparison := strings.Compare(left.canonicalPath, right.canonicalPath); comparison != 0 {
-		return comparison
-	}
-	leftLine, leftColumn := coverageBlockStartPosition(left)
-	rightLine, rightColumn := coverageBlockStartPosition(right)
-	if leftLine != rightLine {
-		return leftLine - rightLine
-	}
-	if leftColumn != rightColumn {
-		return leftColumn - rightColumn
-	}
-	return strings.Compare(left.rangeSpec, right.rangeSpec)
-}
-
-func coverageBlockStartPosition(block coverageBlock) (int, int) {
-	start := block.rangeSpec
-	if separator := strings.IndexByte(start, ','); separator >= 0 {
-		start = start[:separator]
-	}
-	separator := strings.IndexByte(start, '.')
-	if separator < 0 {
-		line, _ := strconv.Atoi(start)
-		return line, 0
-	}
-	line, _ := strconv.Atoi(start[:separator])
-	column, _ := strconv.Atoi(start[separator+1:])
-	return line, column
-}
-
-func formatUncoveredCoverageBlocks(coverageBlocks map[string]coverageBlock, importPath string) string {
-	blocks := uncoveredCoverageBlocks(coverageBlocks, importPath)
-	if len(blocks) == 0 {
-		return ""
-	}
-	limit := min(len(blocks), maxUncoveredCoverageBlocks)
-	entries := make([]string, 0, limit)
-	for _, block := range blocks[:limit] {
-		filePath := strings.TrimPrefix(block.canonicalPath, modulePath+"/")
-		statementLabel := "statements"
-		if block.statementCount == 1 {
-			statementLabel = "statement"
-		}
-		entries = append(entries, fmt.Sprintf("%s:%d (%d %s)", filePath, coverageBlockStartLine(block), block.statementCount, statementLabel))
-	}
-	detail := "uncovered blocks: " + strings.Join(entries, ", ")
-	if omitted := len(blocks) - limit; omitted > 0 {
-		detail += fmt.Sprintf(", ... and %d more", omitted)
-	}
-	return detail
-}
-
-func coverageBlockStartLine(block coverageBlock) int {
-	line, _ := coverageBlockStartPosition(block)
-	return line
 }
 
 func formatZeroCoverageFailure(packages []string) string {

--- a/cmd/gocoveragecheck/main_fake_process_test.go
+++ b/cmd/gocoveragecheck/main_fake_process_test.go
@@ -18,6 +18,10 @@ func fakeGoCoverageCommandWithMeasuredZeroConfig(invocation commandInvocation) (
 	return fakeGoCommandByScenario("coverage-measured-zero-config", invocation.name, invocation.args...)
 }
 
+func fakeGoCoverageCommandWithRootObservationRegression(invocation commandInvocation) (string, string, error) {
+	return fakeGoCommandByScenario("coverage-rootobservation-regression", invocation.name, invocation.args...)
+}
+
 func fakeGoCoverageCommandPassing(invocation commandInvocation) (string, string, error) {
 	return fakeGoCommandByScenario("coverage-passing", invocation.name, invocation.args...)
 }
@@ -115,6 +119,20 @@ func fakeGoTestScenario(scenario string, args []string) (string, string, error) 
 					return "", "", err
 				}
 			}
+		case "coverage-rootobservation-regression":
+			if err := writeFakeCoverageProfile(profilePath, strings.Join([]string{
+				"mode: count",
+				modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:51.1,52.1 8 1",
+				modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:41.1,42.1 1 0",
+				modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:1.1,2.1 10 1",
+				modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:21.1,22.1 1 0",
+				modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:61.1,62.1 6 1",
+				modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:31.3,32.1 7 1",
+				modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:11.1,12.1 12 1",
+				"",
+			}, "\n")); err != nil {
+				return "", "", err
+			}
 		case "coverage-with-coverpkg-ok-summary", "coverage-with-ok-summary", "coverage-default":
 			if err := writeFakeCoverageProfile(profilePath, strings.Join([]string{
 				"mode: count",
@@ -131,6 +149,8 @@ func fakeGoTestScenario(scenario string, args []string) (string, string, error) 
 		switch scenario {
 		case "coverage-passing", "coverage-measured-zero-config":
 			return modulePath + "/pkg/config\t\tcoverage: 75.0% of statements\n", "", nil
+		case "coverage-rootobservation-regression":
+			return modulePath + "/pkg/services/factory_runtime/internal/rootobservation\t\tcoverage: 95.6% of statements\n", "", nil
 		case "coverage-temp-profile":
 			if err := writeTempProfileMarkerOrErr(profilePath); err != nil {
 				return "", "", err

--- a/cmd/gocoveragecheck/main_fake_process_test.go
+++ b/cmd/gocoveragecheck/main_fake_process_test.go
@@ -120,17 +120,7 @@ func fakeGoTestScenario(scenario string, args []string) (string, string, error) 
 				}
 			}
 		case "coverage-rootobservation-regression":
-			if err := writeFakeCoverageProfile(profilePath, strings.Join([]string{
-				"mode: count",
-				modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:51.1,52.1 8 1",
-				modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:41.1,42.1 1 0",
-				modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:1.1,2.1 10 1",
-				modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:21.1,22.1 1 0",
-				modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:61.1,62.1 6 1",
-				modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:31.3,32.1 7 1",
-				modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:11.1,12.1 12 1",
-				"",
-			}, "\n")); err != nil {
+			if err := writeRootObservationRegressionProfile(profilePath); err != nil {
 				return "", "", err
 			}
 		case "coverage-with-coverpkg-ok-summary", "coverage-with-ok-summary", "coverage-default":
@@ -192,6 +182,20 @@ func fakeGoTestScenario(scenario string, args []string) (string, string, error) 
 	default:
 		return "", "", fmt.Errorf("unexpected go test scenario: %s", scenario)
 	}
+}
+
+func writeRootObservationRegressionProfile(profilePath string) error {
+	return writeFakeCoverageProfile(profilePath, strings.Join([]string{
+		"mode: count",
+		modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:51.1,52.1 8 1",
+		modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:41.1,42.1 1 0",
+		modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:1.1,2.1 10 1",
+		modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:21.1,22.1 1 0",
+		modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:61.1,62.1 6 1",
+		modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:31.3,32.1 7 1",
+		modulePath + "/pkg/services/factory_runtime/internal/rootobservation/project.go:11.1,12.1 12 1",
+		"",
+	}, "\n"))
 }
 
 func fakeGoToolScenario(scenario string, args []string) (string, string, error) {

--- a/cmd/gocoveragecheck/main_run_test.go
+++ b/cmd/gocoveragecheck/main_run_test.go
@@ -193,6 +193,54 @@ func TestExecuteReportsUncoveredBlocksForManifestRegression(t *testing.T) {
 	}
 }
 
+func TestExecuteReportsRootObservationCoverageRegressionWithExactCountsAndBlocks(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	defer func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	}()
+
+	rootObservationPackage := modulePath + "/pkg/services/factory_runtime/internal/rootobservation"
+	manifestPath := writePackageMinimumManifest(t, "unit", rootObservationPackage, "100.00")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeGoCoverageCommandWithRootObservationRegression
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	err := execute(config{
+		min:             0,
+		suite:           "unit",
+		coverpkg:        rootObservationPackage,
+		packages:        "./pkg/services/factory_runtime/internal/rootobservation",
+		packageManifest: manifestPath,
+	})
+	if err == nil {
+		t.Fatal("execute() unexpectedly succeeded")
+	}
+
+	wantFailure := "package coverage regression: package=" + rootObservationPackage +
+		" lane=unit expected-minimum=100.00% actual=95.5556% delta=-4.4444 percentage-points covered=43/45 statements; " +
+		"uncovered blocks: pkg/services/factory_runtime/internal/rootobservation/project.go:21 (1 statement), " +
+		"pkg/services/factory_runtime/internal/rootobservation/project.go:41 (1 statement); " +
+		"restore coverage before running `go run ./cmd/gocoveragecheck -suite unit -profile <coverage-profile> -update-manifest " + manifestPath + "`"
+	if err.Error() != wantFailure {
+		t.Fatalf("execute() error = %q, want exact regression diagnostic %q", err, wantFailure)
+	}
+	if strings.Count(err.Error(), "uncovered blocks:") != 1 || strings.Count(err.Error(), "(1 statement)") != 2 {
+		t.Fatalf("execute() error = %q, want exactly two uncovered blocks", err)
+	}
+	if !strings.Contains(stdout.String(), rootObservationPackage+"\tcoverage: 95.6% of statements") {
+		t.Fatalf("execute() stdout = %q, want rootobservation package summary", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+	}
+}
+
 func TestExecuteDoesNotReportPackageSummariesWhenMeasurementFails(t *testing.T) {
 	originalCommandRunner := commandRunner
 	originalStdout := stdoutWriter

--- a/cmd/gocoveragecheck/main_run_test.go
+++ b/cmd/gocoveragecheck/main_run_test.go
@@ -147,6 +147,52 @@ func TestExecuteReportsPackageSummariesForCompleteManifest(t *testing.T) {
 	}
 }
 
+func TestExecuteReportsUncoveredBlocksForManifestRegression(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	defer func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	}()
+
+	configPackage := modulePath + "/pkg/config"
+	manifestPath := writePackageMinimumManifest(t, "unit", configPackage, "100.00")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeGoCoverageCommandWithMeasuredZeroConfig
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	err := execute(config{
+		min:             0,
+		suite:           "unit",
+		coverpkg:        configPackage,
+		packages:        "./pkg/config",
+		packageManifest: manifestPath,
+	})
+	if err == nil {
+		t.Fatal("execute() unexpectedly succeeded")
+	}
+	for _, want := range []string{
+		"package coverage regression: package=" + configPackage,
+		"lane=unit expected-minimum=100.00%",
+		"uncovered blocks: pkg/config/config.go:1 (3 statements)",
+		"restore coverage before running `go run ./cmd/gocoveragecheck",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("execute() error = %q, want diagnostic containing %q", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), "pkg/service") {
+		t.Fatalf("execute() error = %q, did not expect another package's uncovered blocks", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+	}
+}
+
 func TestExecuteDoesNotReportPackageSummariesWhenMeasurementFails(t *testing.T) {
 	originalCommandRunner := commandRunner
 	originalStdout := stdoutWriter

--- a/cmd/gocoveragecheck/manifest.go
+++ b/cmd/gocoveragecheck/manifest.go
@@ -344,8 +344,14 @@ func checkCoverageManifestWithEpsilonAndBlocks(manifest coverageManifest, totals
 			continue
 		}
 		diagnostic := fmt.Sprintf(
-			"package coverage regression: package=%s lane=%s expected-minimum=%s%% actual=%.4f%% delta=%+.4f percentage-points",
-			entry.Package, manifest.Lane, minimum.String(), actualPercent, actualPercent-expectedPercent,
+			"package coverage regression: package=%s lane=%s expected-minimum=%s%% actual=%.4f%% delta=%+.4f percentage-points covered=%d/%d statements",
+			entry.Package,
+			manifest.Lane,
+			minimum.String(),
+			actualPercent,
+			actualPercent-expectedPercent,
+			actual.coveredStatements,
+			actual.totalStatements,
 		)
 		if uncovered := formatUncoveredCoverageBlocks(coverageBlocks, entry.Package); uncovered != "" {
 			diagnostic += "; " + uncovered

--- a/cmd/gocoveragecheck/manifest.go
+++ b/cmd/gocoveragecheck/manifest.go
@@ -316,6 +316,10 @@ func checkCoverageManifest(manifest coverageManifest, totals map[string]packageC
 }
 
 func checkCoverageManifestWithEpsilon(manifest coverageManifest, totals map[string]packageCoverageTotals, manifestPath string, epsilon float64) ([]string, []string) {
+	return checkCoverageManifestWithEpsilonAndBlocks(manifest, totals, manifestPath, epsilon, nil)
+}
+
+func checkCoverageManifestWithEpsilonAndBlocks(manifest coverageManifest, totals map[string]packageCoverageTotals, manifestPath string, epsilon float64, coverageBlocks map[string]coverageBlock) ([]string, []string) {
 	failures := make([]string, 0)
 	warnings := make([]string, 0)
 	for _, entry := range manifest.Packages {
@@ -339,9 +343,16 @@ func checkCoverageManifestWithEpsilon(manifest coverageManifest, totals map[stri
 			))
 			continue
 		}
-		failures = append(failures, fmt.Sprintf(
-			"package coverage regression: package=%s lane=%s expected-minimum=%s%% actual=%.4f%% delta=%+.4f percentage-points; restore coverage before running `go run ./cmd/gocoveragecheck -suite %s -profile <coverage-profile> -update-manifest %s`",
-			entry.Package, manifest.Lane, minimum.String(), actualPercent, actualPercent-expectedPercent, manifest.Lane, manifestPath,
+		diagnostic := fmt.Sprintf(
+			"package coverage regression: package=%s lane=%s expected-minimum=%s%% actual=%.4f%% delta=%+.4f percentage-points",
+			entry.Package, manifest.Lane, minimum.String(), actualPercent, actualPercent-expectedPercent,
+		)
+		if uncovered := formatUncoveredCoverageBlocks(coverageBlocks, entry.Package); uncovered != "" {
+			diagnostic += "; " + uncovered
+		}
+		failures = append(failures, diagnostic+fmt.Sprintf(
+			"; restore coverage before running `go run ./cmd/gocoveragecheck -suite %s -profile <coverage-profile> -update-manifest %s`",
+			manifest.Lane, manifestPath,
 		))
 	}
 	return failures, warnings

--- a/cmd/gocoveragecheck/manifest_test.go
+++ b/cmd/gocoveragecheck/manifest_test.go
@@ -252,10 +252,12 @@ func TestCheckCoverageManifestControlledProfilesForBothLanes(t *testing.T) {
 				t.Fatalf("regression failures = %v, want two", failures)
 			}
 			if !strings.Contains(failures[0], "package="+alpha+" lane="+lane+" expected-minimum=80.00% actual=79.0000% delta=-1.0000") ||
+				!strings.Contains(failures[0], "covered=79/100 statements") ||
 				!strings.Contains(failures[0], "-update-manifest minimums.json") {
 				t.Fatalf("first regression = %q, want complete actionable diagnostic", failures[0])
 			}
-			if !strings.Contains(failures[1], "package="+beta+" lane="+lane+" expected-minimum=75.00% actual=74.0000% delta=-1.0000") {
+			if !strings.Contains(failures[1], "package="+beta+" lane="+lane+" expected-minimum=75.00% actual=74.0000% delta=-1.0000") ||
+				!strings.Contains(failures[1], "covered=74/100 statements") {
 				t.Fatalf("second regression = %q, want complete diagnostic", failures[1])
 			}
 			if !slices.IsSorted(failures) {
@@ -486,6 +488,9 @@ func TestCheckCoverageManifestAppliesRawStatementEpsilon(t *testing.T) {
 			if !strings.Contains(warnings[0], "package="+importPath+" lane=unit expected-minimum=80.00% actual=79.7500%") ||
 				!strings.Contains(warnings[0], "epsilon=0.2500 percentage-points") {
 				t.Fatalf("warning = %q, want package, lane, floor, actual, and epsilon", warnings[0])
+			}
+			if strings.Contains(warnings[0], "covered=") {
+				t.Fatalf("warning = %q, did not expect exact statement counts", warnings[0])
 			}
 			if !strings.Contains(warnings[0], "warning") || strings.Contains(warnings[0], "update-manifest") {
 				t.Fatalf("warning = %q, did not expect update remediation", warnings[0])

--- a/cmd/gocoveragecheck/manifest_test.go
+++ b/cmd/gocoveragecheck/manifest_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -261,6 +262,115 @@ func TestCheckCoverageManifestControlledProfilesForBothLanes(t *testing.T) {
 				t.Fatalf("regression failures are not in stable package order: %v", failures)
 			}
 		})
+	}
+}
+
+func TestCheckCoverageManifestReportsOrderedPackageUncoveredBlocksWithCap(t *testing.T) {
+	t.Parallel()
+
+	importPath := modulePath + "/pkg/config"
+	otherImportPath := modulePath + "/pkg/service"
+	manifest := coverageManifest{
+		Version: coverageManifestVersion,
+		Lane:    "unit",
+		Packages: []coverageManifestEntry{
+			{Package: importPath, Minimum: json.RawMessage("100.00")},
+		},
+	}
+	coverageBlocks := map[string]coverageBlock{
+		"z": {
+			canonicalPath:  modulePath + "/pkg/config/z.go",
+			importPath:     importPath,
+			rangeSpec:      "9.1,10.1",
+			statementCount: 3,
+		},
+		"a-late": {
+			canonicalPath:  modulePath + "/pkg/config/a.go",
+			importPath:     importPath,
+			rangeSpec:      "20.2,21.1",
+			statementCount: 2,
+		},
+		"a-early": {
+			canonicalPath:  modulePath + "/pkg/config/a.go",
+			importPath:     importPath,
+			rangeSpec:      "20.1,20.2",
+			statementCount: 1,
+		},
+		"covered": {
+			canonicalPath:  modulePath + "/pkg/config/covered.go",
+			importPath:     importPath,
+			rangeSpec:      "1.1,2.1",
+			statementCount: 4,
+			executionCount: 1,
+		},
+		"other-package": {
+			canonicalPath:  modulePath + "/pkg/service/other.go",
+			importPath:     otherImportPath,
+			rangeSpec:      "2.1,3.1",
+			statementCount: 7,
+		},
+	}
+
+	failures, warnings := checkCoverageManifestWithEpsilonAndBlocks(
+		manifest,
+		map[string]packageCoverageTotals{importPath: {coveredStatements: 5, totalStatements: 10}},
+		"minimums.json",
+		0,
+		coverageBlocks,
+	)
+	if len(warnings) != 0 || len(failures) != 1 {
+		t.Fatalf("checkCoverageManifestWithEpsilonAndBlocks() = failures %v, warnings %v; want one failure and no warnings", failures, warnings)
+	}
+
+	failure := failures[0]
+	wantDetail := "uncovered blocks: pkg/config/a.go:20 (1 statement), pkg/config/a.go:20 (2 statements), pkg/config/z.go:9 (3 statements)"
+	if !strings.Contains(failure, wantDetail) {
+		t.Fatalf("failure = %q, want ordered uncovered detail %q", failure, wantDetail)
+	}
+	if strings.Contains(failure, "covered.go") || strings.Contains(failure, "pkg/service/other.go") {
+		t.Fatalf("failure = %q, did not expect covered or other-package blocks", failure)
+	}
+	if !strings.Contains(failure, "restore coverage before running `go run ./cmd/gocoveragecheck") {
+		t.Fatalf("failure = %q, want existing remediation wording", failure)
+	}
+
+	tooManyBlocks := make(map[string]coverageBlock, maxUncoveredCoverageBlocks+2)
+	for index := 0; index < maxUncoveredCoverageBlocks+2; index++ {
+		tooManyBlocks[fmt.Sprintf("block-%d", index)] = coverageBlock{
+			canonicalPath:  fmt.Sprintf("%s/pkg/config/file-%02d.go", modulePath, index),
+			importPath:     importPath,
+			rangeSpec:      "1.1,2.1",
+			statementCount: 1,
+		}
+	}
+	failures, _ = checkCoverageManifestWithEpsilonAndBlocks(
+		manifest,
+		map[string]packageCoverageTotals{importPath: {coveredStatements: 1, totalStatements: 2}},
+		"minimums.json",
+		0,
+		tooManyBlocks,
+	)
+	if len(failures) != 1 || !strings.Contains(failures[0], "... and 2 more") {
+		t.Fatalf("capped failures = %v, want exact omitted-block tail", failures)
+	}
+	if got := strings.Count(failures[0], "(1 statement)"); got != maxUncoveredCoverageBlocks {
+		t.Fatalf("capped failure = %q, contains %d block entries; want %d", failures[0], got, maxUncoveredCoverageBlocks)
+	}
+
+	warningsManifest := manifest
+	warningsManifest.Packages = []coverageManifestEntry{{Package: importPath, Minimum: json.RawMessage("80.00")}}
+	failures, warnings = checkCoverageManifestWithEpsilonAndBlocks(
+		warningsManifest,
+		map[string]packageCoverageTotals{importPath: {coveredStatements: 79, totalStatements: 100}},
+		"minimums.json",
+		1,
+		coverageBlocks,
+	)
+	if len(failures) != 0 || len(warnings) != 1 {
+		t.Fatalf("tolerated result = failures %v, warnings %v; want no failure and one warning", failures, warnings)
+	}
+	if strings.Contains(warnings[0], "uncovered blocks") {
+		t.Fatalf("warning = %q, did not expect uncovered-block detail", warnings[0])
 	}
 }
 

--- a/cmd/gocoveragecheck/manifest_test.go
+++ b/cmd/gocoveragecheck/manifest_test.go
@@ -267,9 +267,83 @@ func TestCheckCoverageManifestControlledProfilesForBothLanes(t *testing.T) {
 	}
 }
 
-func TestCheckCoverageManifestReportsOrderedPackageUncoveredBlocksWithCap(t *testing.T) {
+func TestCheckCoverageManifestReportsOrderedPackageUncoveredBlocks(t *testing.T) {
 	t.Parallel()
 
+	manifest, coverageBlocks, importPath := uncoveredBlockManifestFixture()
+	failures, warnings := checkCoverageManifestWithEpsilonAndBlocks(
+		manifest,
+		map[string]packageCoverageTotals{importPath: {coveredStatements: 5, totalStatements: 10}},
+		"minimums.json",
+		0,
+		coverageBlocks,
+	)
+	if len(warnings) != 0 || len(failures) != 1 {
+		t.Fatalf("checkCoverageManifestWithEpsilonAndBlocks() = failures %v, warnings %v; want one failure and no warnings", failures, warnings)
+	}
+
+	failure := failures[0]
+	wantDetail := "uncovered blocks: pkg/config/a.go:20 (1 statement), pkg/config/a.go:20 (2 statements), pkg/config/z.go:9 (3 statements)"
+	if !strings.Contains(failure, wantDetail) {
+		t.Fatalf("failure = %q, want ordered uncovered detail %q", failure, wantDetail)
+	}
+	if strings.Contains(failure, "covered.go") || strings.Contains(failure, "pkg/service/other.go") {
+		t.Fatalf("failure = %q, did not expect covered or other-package blocks", failure)
+	}
+	if !strings.Contains(failure, "restore coverage before running `go run ./cmd/gocoveragecheck") {
+		t.Fatalf("failure = %q, want existing remediation wording", failure)
+	}
+}
+
+func TestCheckCoverageManifestCapsUncoveredBlocks(t *testing.T) {
+	t.Parallel()
+
+	manifest, _, importPath := uncoveredBlockManifestFixture()
+	tooManyBlocks := make(map[string]coverageBlock, maxUncoveredCoverageBlocks+2)
+	for index := 0; index < maxUncoveredCoverageBlocks+2; index++ {
+		tooManyBlocks[fmt.Sprintf("block-%d", index)] = coverageBlock{
+			canonicalPath:  fmt.Sprintf("%s/pkg/config/file-%02d.go", modulePath, index),
+			importPath:     importPath,
+			rangeSpec:      "1.1,2.1",
+			statementCount: 1,
+		}
+	}
+	failures, _ := checkCoverageManifestWithEpsilonAndBlocks(
+		manifest,
+		map[string]packageCoverageTotals{importPath: {coveredStatements: 1, totalStatements: 2}},
+		"minimums.json",
+		0,
+		tooManyBlocks,
+	)
+	if len(failures) != 1 || !strings.Contains(failures[0], "... and 2 more") {
+		t.Fatalf("capped failures = %v, want exact omitted-block tail", failures)
+	}
+	if got := strings.Count(failures[0], "(1 statement)"); got != maxUncoveredCoverageBlocks {
+		t.Fatalf("capped failure = %q, contains %d block entries; want %d", failures[0], got, maxUncoveredCoverageBlocks)
+	}
+}
+
+func TestCheckCoverageManifestToleratedDriftOmitsUncoveredBlocks(t *testing.T) {
+	t.Parallel()
+
+	manifest, coverageBlocks, importPath := uncoveredBlockManifestFixture()
+	manifest.Packages = []coverageManifestEntry{{Package: importPath, Minimum: json.RawMessage("80.00")}}
+	failures, warnings := checkCoverageManifestWithEpsilonAndBlocks(
+		manifest,
+		map[string]packageCoverageTotals{importPath: {coveredStatements: 79, totalStatements: 100}},
+		"minimums.json",
+		1,
+		coverageBlocks,
+	)
+	if len(failures) != 0 || len(warnings) != 1 {
+		t.Fatalf("tolerated result = failures %v, warnings %v; want no failure and one warning", failures, warnings)
+	}
+	if strings.Contains(warnings[0], "uncovered blocks") {
+		t.Fatalf("warning = %q, did not expect uncovered-block detail", warnings[0])
+	}
+}
+
+func uncoveredBlockManifestFixture() (coverageManifest, map[string]coverageBlock, string) {
 	importPath := modulePath + "/pkg/config"
 	otherImportPath := modulePath + "/pkg/service"
 	manifest := coverageManifest{
@@ -312,68 +386,7 @@ func TestCheckCoverageManifestReportsOrderedPackageUncoveredBlocksWithCap(t *tes
 			statementCount: 7,
 		},
 	}
-
-	failures, warnings := checkCoverageManifestWithEpsilonAndBlocks(
-		manifest,
-		map[string]packageCoverageTotals{importPath: {coveredStatements: 5, totalStatements: 10}},
-		"minimums.json",
-		0,
-		coverageBlocks,
-	)
-	if len(warnings) != 0 || len(failures) != 1 {
-		t.Fatalf("checkCoverageManifestWithEpsilonAndBlocks() = failures %v, warnings %v; want one failure and no warnings", failures, warnings)
-	}
-
-	failure := failures[0]
-	wantDetail := "uncovered blocks: pkg/config/a.go:20 (1 statement), pkg/config/a.go:20 (2 statements), pkg/config/z.go:9 (3 statements)"
-	if !strings.Contains(failure, wantDetail) {
-		t.Fatalf("failure = %q, want ordered uncovered detail %q", failure, wantDetail)
-	}
-	if strings.Contains(failure, "covered.go") || strings.Contains(failure, "pkg/service/other.go") {
-		t.Fatalf("failure = %q, did not expect covered or other-package blocks", failure)
-	}
-	if !strings.Contains(failure, "restore coverage before running `go run ./cmd/gocoveragecheck") {
-		t.Fatalf("failure = %q, want existing remediation wording", failure)
-	}
-
-	tooManyBlocks := make(map[string]coverageBlock, maxUncoveredCoverageBlocks+2)
-	for index := 0; index < maxUncoveredCoverageBlocks+2; index++ {
-		tooManyBlocks[fmt.Sprintf("block-%d", index)] = coverageBlock{
-			canonicalPath:  fmt.Sprintf("%s/pkg/config/file-%02d.go", modulePath, index),
-			importPath:     importPath,
-			rangeSpec:      "1.1,2.1",
-			statementCount: 1,
-		}
-	}
-	failures, _ = checkCoverageManifestWithEpsilonAndBlocks(
-		manifest,
-		map[string]packageCoverageTotals{importPath: {coveredStatements: 1, totalStatements: 2}},
-		"minimums.json",
-		0,
-		tooManyBlocks,
-	)
-	if len(failures) != 1 || !strings.Contains(failures[0], "... and 2 more") {
-		t.Fatalf("capped failures = %v, want exact omitted-block tail", failures)
-	}
-	if got := strings.Count(failures[0], "(1 statement)"); got != maxUncoveredCoverageBlocks {
-		t.Fatalf("capped failure = %q, contains %d block entries; want %d", failures[0], got, maxUncoveredCoverageBlocks)
-	}
-
-	warningsManifest := manifest
-	warningsManifest.Packages = []coverageManifestEntry{{Package: importPath, Minimum: json.RawMessage("80.00")}}
-	failures, warnings = checkCoverageManifestWithEpsilonAndBlocks(
-		warningsManifest,
-		map[string]packageCoverageTotals{importPath: {coveredStatements: 79, totalStatements: 100}},
-		"minimums.json",
-		1,
-		coverageBlocks,
-	)
-	if len(failures) != 0 || len(warnings) != 1 {
-		t.Fatalf("tolerated result = failures %v, warnings %v; want no failure and one warning", failures, warnings)
-	}
-	if strings.Contains(warnings[0], "uncovered blocks") {
-		t.Fatalf("warning = %q, did not expect uncovered-block detail", warnings[0])
-	}
+	return manifest, coverageBlocks, importPath
 }
 
 func TestValidateCoverageManifestReportsAllMissingPackagesWithMeasurements(t *testing.T) {


### PR DESCRIPTION
{
  "project": "Name Uncovered Statements in Package Coverage Regressions",
  "branchName": "thr-coverage-regression-names-package-not-statements",
  "description": "Improve gocoveragecheck package-floor failure diagnostics so backend contributors can identify uncovered code directly from CI. Hard regressions retain their existing package, lane, floor, percentage, delta, and remediation wording, add exact covered/total statement counts, and list only the failed package's uncovered blocks in deterministic file-and-position order with a 25-entry cap. Coverage calculations, baselines, exceptions, tolerated drift, incomplete-manifest behavior, and pass/fail decisions remain unchanged. Before: package coverage regression: package=github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/rootobservation lane=unit expected-minimum=100.00% actual=95.5556% delta=-4.4444 percentage-points. After: the same regression adds covered=43/45 statements and uncovered blocks: pkg/services/factory_runtime/internal/rootobservation/project.go:21 (1 statement), pkg/services/factory_runtime/internal/rootobservation/project.go:41 (1 statement). Uncovered-block detail is capped at 25 entries with an exact ... and N more tail. Original feature diff stat: 5 files changed, 334 insertions(+), 7 deletions(-). Final diff stat after the mechanical size/layout follow-up against origin/main: 6 files changed, 368 insertions(+), 15 deletions(-); docs/internal/baselines/** is untouched.",
  "context": {
    "customerAsk": "When a package falls below its configured coverage floor, report which coverage-profile blocks are uncovered and show the integer covered/total statement counts behind the percentage. Prove the behavior with a rootobservation-shaped fixture in which a package at a 100.00% floor measures 43 of 45 statements and has two known uncovered blocks.",
    "problem": "Backend Unit Coverage currently reports the failing package and percentage but not the uncovered statements. The observed rootobservation failure reported 95.5556% against a 100.00% floor, forcing a contributor to rerun coverage locally and inspect the profile to discover two uncovered statements. This cost recurs because 74 manifest packages sit at exactly 100.00%, including active composition surfaces, while the drift epsilon cannot absorb even one uncovered statement in small packages.",
    "solution": "Use the already parsed in-memory coverage profile to add exact covered/total counts and the failed package's uncovered blocks to hard-regression diagnostics. Sort blocks by file path, start line, and start column; render jump-friendly file:line entries with statement counts; emit at most 25 entries with an exact remainder tail; and preserve all established wording and gate semantics. Prove the result with exact assertions against a 43-of-45 fixture."
  },
  "acceptanceCriteria": [
    "Every hard package coverage regression includes only the failed package's uncovered blocks ordered by file path, start line, and start column, rendered in file:line form with each block's statement count.",
    "At most 25 uncovered blocks are printed per failed package; additional blocks produce an exact `... and N more` tail, while tolerated-drift warnings print no uncovered-block detail.",
    "The regression line adds exact covered and total statement counts while retaining the existing package, lane, expected-minimum, actual percentage, delta, percentage-point, and remediation wording.",
    "A profile fixture representing a package at a 100.00% floor with 43 of 45 statements covered asserts the exact two uncovered file-and-line locations and their statement counts in the emitted failure.",
    "Coverage calculations and pass/fail classifications are unchanged, incomplete-manifest behavior delivered by PR #1933 is not duplicated, and no manifest floor or exception changes.",
    "The PR description contains before/after failure text, states the 25-block cap, and includes final diff-stat evidence that docs/internal/baselines/** is untouched; CI-run evidence is posted only as PR comments and never committed.",
    "Quality gates provide direct evidence from focused cmd/gocoveragecheck tests, relevant broader Go tests, and typecheck; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, every blocking PR conversation is explicitly addressed, merge conflicts and shared-file churn are resolved, and the PR is actually merged; implementation ends at final head pushed, PR open, CI started, and blocking feedback addressed, while review owns terminal passing CI and merge."
  ],
  "userStories": [
    {
      "id": "thr-coverage-regression-names-package-not-statements-001",
      "title": "Name uncovered blocks for failed packages",
      "description": "As a backend contributor, I want a package coverage regression to name the uncovered source blocks so I can repair coverage directly from the CI failure.",
      "acceptanceCriteria": [
        "Each package that fails its configured floor prints only that package's uncovered coverage blocks from the profile already used for the gate decision.",
        "Each block is rendered in jump-friendly file:line form and includes the number of statements represented by that coverage block.",
        "Blocks are ordered deterministically by file path, start line, then start column, including when profile input order differs.",
        "Output is capped at 25 blocks per failed package and, when truncated, ends with `... and N more` where N is the exact number omitted.",
        "Tolerated-drift warnings and passing packages do not print uncovered-block detail.",
        "Existing hard-regression, tolerated-warning, and passing classifications remain unchanged for identical inputs.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implementation and focused assertions are committed in 7f3b70ee2; the mechanical backend-size split is 507988e1e and the coverage-test size cleanup is d791440b4. Focused cmd/gocoveragecheck tests previously passed with default vet/typecheck using an isolated Go build cache; the follow-up attempt exceeded its bounded local timeout while unrelated Go builds were active."
    },
    {
      "id": "thr-coverage-regression-names-package-not-statements-002",
      "title": "Report exact covered and total counts",
      "description": "As a backend contributor, I want the regression line to show covered and total statements alongside percentages so I can understand the size of the gap without reverse-calculating rounded values.",
      "acceptanceCriteria": [
        "A hard regression reports the exact covered and total statement counts used to calculate its existing actual percentage; the observed 43-of-45 shape is represented as 43 covered and 45 total.",
        "The existing package coverage regression, package, lane, expected-minimum, actual percentage, delta, percentage-point, and remediation wording remains present and in the established form; counts are additive rather than replacements.",
        "Existing output-contract tests are deliberately updated to assert the additive count fields without relaxing established wording.",
        "Tolerated-drift and pass/fail decisions are unchanged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Hard-regression diagnostics now append exact covered/total statement counts while preserving the established package, lane, floor, percentage, delta, percentage-point, and remediation wording. Existing manifest output-contract assertions cover both failing packages, and tolerated-drift assertions verify counts remain absent. Focused cmd/gocoveragecheck tests pass."
    },
    {
      "id": "thr-coverage-regression-names-package-not-statements-003",
      "title": "Prove the complete diagnostic on a 43-of-45 fixture",
      "description": "As a reviewer, I want a realistic regression fixture with known uncovered locations so I can verify that the diagnostic is actionable and remains stable.",
      "acceptanceCriteria": [
        "A count-mode coverage profile fixture models a rootobservation-shaped package with a 100.00% minimum, 43 covered statements, 45 total statements, and exactly two uncovered blocks at explicit file and line locations.",
        "The behavioral test asserts package identity, the 100.00% expected minimum, 43/45 counts, 95.5556% actual value, -4.4444 percentage-point delta, and the exact two fixture block locations with their statement counts.",
        "The fixture or a focused companion case proves ordering independent of profile input order and proves the 25-entry cap with the exact omitted count.",
        "A focused companion assertion proves tolerated drift does not emit uncovered-block details.",
        "Tests exercise the observable reporting path rather than source topology, command inventories, baseline contents, or internal registration structure.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added an observable execute-path count-mode fixture for the rootobservation-shaped package with 43 covered of 45 statements and exactly two uncovered blocks. The test asserts the package, lane, 100.00% floor, 95.5556% actual, -4.4444 percentage-point delta, 43/45 counts, exact file-and-line entries, and existing remediation wording; companion assertions already cover ordering, the 25-block cap, and tolerated-drift suppression. Focused cmd/gocoveragecheck and rootobservation package tests pass. Rebased the completed six-file implementation onto origin/main and pushed head d0e01d967; PR #1980 is open and required CI has started."
    }
  ],
  "operatorOverride": {
    "issuedBy": "factory operator",
    "issuedAt": "2026-08-15T16:20:00Z",
    "AAAA00_THE_ONLY_CURRENT_OVERRIDE": "PRECONDITION IS NOW SATISFIED. #1987 IS MERGED. REBASE AND HAND TO REVIEW.\nTHIS IS A REBASE TASK, NOT AN IMPLEMENTATION TASK. WRITE NO PRODUCT CODE.\n\norigin/main is now 46dda7b34 and it contains the merge of PR #1987\n(thr-acp-output-observed-before-complete). The earlier instruction to \"stop and\nwait if #1987 is not merged\" no longer applies - proceed.\n\nPROBLEM: This lane's task token was killed by the review circuit breaker after\nthree consecutive BLOCKING reviews on the unchanged head d0e01d967. The\nrejections were NOT for a defect in this PR. PR #1980 is OPEN and CODE-COMPLETE.\nThe worktree already exists and prd.json is already present. DO NOT replan and\nDO NOT rewrite the PRD.\n\n=== THE BLOCKER WAS NEVER YOURS, AND IT IS NOW FIXED ON MAIN ===\n\nThree CI attempts on the IDENTICAL head d0e01d967 produced TWO DIFFERENT failing\ntests, both in tests/functional/chat_sessions/root_composition, both asserting\nACP terminal-event ordering:\n\n    attempt 1 -> TestJavaScriptFactoryChildrenAreVisibleAsWorkers      1021 pass / 1 fail\n    attempt 2 -> TestJavaScriptFactoryChildrenAreVisibleAsWorkers      1021 pass / 1 fail\n    attempt 3 -> TestPackagedJavaScriptFactoryCompletesOneACPPromptTurn 1021 pass / 1 fail\n\nAll three ran selected-packages=139 selected-tests=1022. Identical bytes\nproducing different failing tests proves the failure is NONDETERMINISTIC, so no\ndeterministic defect in your diff can explain it. Your diff is 6 files under\ncmd/gocoveragecheck/, a coverage REPORTING tool that does not link into the ACP\nruntime and cannot influence response-event ordering.\n\nThat race was owned by #1987 and #1987 IS NOW MERGED. Main was red on Backend\nFunctional Coverage for three consecutive merges with three faces of the same\nrace - a named assertion failure at d9fe93996, panic: test timed out after 10m0s\nat c1db27524, and neither at 1079482c9. #1987's branch ran that surface clean.\n\nAfter you rebase, that failure should be gone. If it is, you are done.\n\n=== YOUR LAST RUN SAID \"ZERO COVERAGE REGRESSIONS\". THAT WAS SILENCE, NOT A PASS ===\n\nThis matters especially to you, because it is the exact defect your PR exists to\nfix. Job 94985509255 reported NO coverage regression lines - but it also had a\nfailing test. The coverage gate exits on test failure BEFORE evaluating package\nfloors, so it printed nothing about coverage at all. That silence is\nindistinguishable from a clean result and it is NOT evidence of one.\n\nSo after rebasing, do NOT conclude your coverage is fine because the log is\nquiet. Confirm the run reports ZERO FAILING TESTS first; only then does its\ncoverage output carry information.\n\n=== WHAT TO DO. FOUR STEPS. ===\n\n 1. git fetch origin\n 2. Rebase this branch onto origin/main (46dda7b34). Your PR touches only\n    cmd/gocoveragecheck/, so conflicts are unlikely. If a generated artifact\n    conflicts, NEVER hand-merge it - rerun its generator on the rebased tree and\n    commit the output.\n 3. Push the rebased head. Confirm CI starts.\n 4. Hand to review.\n\n=== EXPLICIT NON-GOALS. EACH WILL EARN A REJECTION. ===\n\n  - Do NOT modify product code or tests to make an ACP ordering test pass.\n  - Do NOT lower, repin, quarantine or edit any coverage manifest or baseline\n    minimum.\n  - Do NOT re-litigate the accepted design. The reviewer's correctness and\n    maintainability findings were ALL explicitly cleared.\n  - Do NOT widen scope beyond cmd/gocoveragecheck/.\n  - Do NOT commit prd.json or progress.txt.\n  - Do NOT put CI evidence in a commit. Evidence goes in a PR COMMENT - a commit\n    creates a new head and invalidates the run it cites.\n\n=== A RED CHECK YOU DID NOT CAUSE IS NOT A REASON TO CHANGE CODE ===\n\nThis rule stands generally, but note that the specific example in my earlier\nrestoration is now STALE: the Frontend Browser failure on\nfactory-graph-editor-node-placement.integration.test.mjs has since been fixed and\nmerged by its own lane. Do not go looking for it.\n\nThe general procedure still applies to ANY red check outside cmd/gocoveragecheck/:\ncompare against main before reacting.\n\n    gh api \"repos/portpowered/you-agent-factory/actions/runs?branch=main&per_page=10\" \\\n      --jq '.workflow_runs[]|select(.name==\"CI\")|\"\\(.id)\\t\\(.conclusion)\\t\\(.head_sha[0:9])\"'\n\nIf main is red on the same job and the same test, say so in a PR COMMENT with\nboth run IDs and STOP. Do not modify anything to work around it.\n\n=== ACCEPTANCE ===\n\norigin/main contains #1987 (it does); this branch is rebased onto it with\nbehind=0; the rebase is content-preserving (verify with git range-diff and say so\nin the PR conversation); the new head is pushed; CI has started; Backend\nFunctional Coverage reports 0 failing tests. MERGED is owned by the review stage,\nnot by this stage.\n\n=== WHAT KILLED THIS LANE THE FIRST TIME ===\n\nThe review breaker counts RE-HANDS OF AN UNCHANGED HEAD. Churn without a real\nchange is the specific thing that kills you. A rebase IS a real change, so this\nhand is safe - but do not follow it with speculative edits chasing someone else's\nfailure.\n"
  }
}
