### PR TITLE
build: bound default Go lane parallelism to the host's share

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ define run_timed_step
 endef
 
 
-.PHONY: default build install bundle-api print-go-parallelism
+.PHONY: default default-pipeline-banner build install bundle-api print-go-parallelism
 .PHONY: fmt vet deps deps-tidy clean init typecheck release lint
 
 .PHONY: test test-full test-unit test-unit-fresh test-ci-workflows test-lane-audit test-maintenance test-integration test-contract test-stress test-release
@@ -226,7 +226,13 @@ endef
 # Make implementation that still launched real work. These aggregators remain
 # serialized to preserve the old stop-on-failure behavior even with -j.
 .NOTPARALLEL: default test
-default: generate-api ui-deps ui-build build test lint
+# Bare `make` runs the complete generation, frontend, build, test, and lint
+# pipeline. Use `make build` when only the Go binary is needed.
+default: default-pipeline-banner generate-api ui-deps ui-build build test lint
+
+default-pipeline-banner:
+	@echo "Bare make runs: generate-api, ui-deps, ui-build, build, test, lint."
+	@echo "For only the Go binary, run: make build."
 
 # Print the derived values without starting a toolchain process. This is useful
 # for controlled host-capacity probes, for example:

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@ BINARY_NAME := you
 CMD_PATH    := ./cmd/factory/
 BIN_DIR     := bin
 GO          ?= go
-INSTALL_DIR := $(or $(GOBIN),$(shell $(GO) env GOPATH)/bin)
+INSTALL_DIR = $(or $(GOBIN),$(shell $(GO) env GOPATH)/bin)
 NPM         ?= npm
+NODE        ?= node
 ifeq ($(OS),Windows_NT)
 BUN_BIN     := $(shell where.exe bun >/dev/null 2>&1 && echo bun)
 else
@@ -132,6 +133,10 @@ LINT_CHECKER_DRIVER_PACKAGE := ./cmd/lintcheck
 LINT_CHECKER_DRIVER ?=
 LINT_LANE_PACKAGE := ./cmd/lintlane
 LINT_JOBS ?= $(GO_LANE_BUDGET)
+# Keep the recursive command available to lintlane without spelling the
+# special $(MAKE) variable in this recipe; GNU Make executes such recipes
+# during -n so recursive builds can receive the dry-run flag.
+LINT_MAKE ?= $(MAKE)
 LINT_TARGETS ?= ui-lint ui-deadcode vet backend-size pkg-maint pkg-file-count pkg-boundary pkg-structure package-target-manifest-check packaged-factory-source-check packaged-factory-consumption-check packaged-factory-catalog-check provider-catalog-check model-provider-package-check durable-runtime-construction-check logging-boundary-check compatibility-alias-check retired-surface-check ownership-inventory-check deadcode
 
 define run_lint_checker
@@ -215,13 +220,13 @@ endef
 .PHONY: ui-package-client-build ui-package-components-build ui-package-emulator-build ui-package-replay-build ui-package-visualizers-build ui-packages-build ui-dashboard-build ui-build-all build-all
 
 
-default:
-	$(MAKE) generate-api
-	$(MAKE) ui-deps
-	$(MAKE) ui-build
-	$(MAKE) build
-	$(MAKE) test
-	$(MAKE) lint
+# Keep the default pipeline as an ordinary ordered dependency graph. Recipe-
+# level $(MAKE) invocations are special to GNU Make and execute during -n so
+# that recursive builds can receive the dry-run flag; on the measured Windows
+# Make implementation that still launched real work. These aggregators remain
+# serialized to preserve the old stop-on-failure behavior even with -j.
+.NOTPARALLEL: default test
+default: generate-api ui-deps ui-build build test lint
 
 # Print the derived values without starting a toolchain process. This is useful
 # for controlled host-capacity probes, for example:
@@ -249,7 +254,7 @@ install:
 	$(GO) build $(GO_BUILD_FLAGS) -o $(INSTALL_DIR)/$(BINARY_NAME) $(CMD_PATH)
 
 bundle-api:
-	node scripts/run-quiet-api-command.js bundle:rest ./api/openapi-main.yaml ./api/openapi.yaml
+	$(NODE) scripts/run-quiet-api-command.js bundle:rest ./api/openapi-main.yaml ./api/openapi.yaml
 
 generate-api: bundle-api generate-go-api generate-ui-api
 
@@ -262,7 +267,7 @@ generate-go-client-api:
 	$(GO) generate -run=client -tags=interfaces ./pkg/transports/http
 
 generate-ui-api:
-	cd ui && node ./scripts/generate-openapi-types.mjs ../api/openapi.yaml src/api/generated/openapi.ts
+	cd ui && $(NODE) ./scripts/generate-openapi-types.mjs ../api/openapi.yaml src/api/generated/openapi.ts
 
 # Interface generation is split by consumer so callers can refresh only UI
 # artifacts or all generated interfaces without relying on prerequisite order.
@@ -435,12 +440,10 @@ docs-reference-smoke:
 readme-check:
 	$(GO) run ./cmd/readmecheck
 
-test:
-	$(MAKE) test-unit
-	$(MAKE) test-ci-workflows
+test: test-unit test-ci-workflows
 
 test-ci-workflows:
-	node --test scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs
+	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs
 
 test-full:
 	$(GO) test ./... -timeout $(GO_TEST_TIMEOUT)
@@ -682,7 +685,7 @@ artifact-contract-closeout:
 	$(GO) test -tags=$(FUNCTIONAL_LONG_TAGS) ./tests/functional/workers/script -run "TestWorkerPublicContractSmoke_" -count=1 -timeout $(GO_TEST_TIMEOUT)
 
 lint:
-	$(GO) run $(LINT_LANE_PACKAGE) -make "$(MAKE)" -jobs "$(LINT_JOBS)" -go "$(GO)" -cache-dir "$(LINT_CHECKER_CACHE_DIR)" $(if $(LINT_CHECKER_DRIVER),-checker-driver "$(LINT_CHECKER_DRIVER)",-checker-package "$(LINT_CHECKER_DRIVER_PACKAGE)") -- $(LINT_TARGETS)
+	$(GO) run $(LINT_LANE_PACKAGE) -make "$(LINT_MAKE)" -jobs "$(LINT_JOBS)" -go "$(GO)" -cache-dir "$(LINT_CHECKER_CACHE_DIR)" $(if $(LINT_CHECKER_DRIVER),-checker-driver "$(LINT_CHECKER_DRIVER)",-checker-package "$(LINT_CHECKER_DRIVER_PACKAGE)") -- $(LINT_TARGETS)
 
 backend-size:
 	$(call run_lint_checker,./cmd/backendsizecheck,-root "$(BACKEND_SIZE_ROOT)")

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,51 @@ UI_SCRIPT   := $(if $(BUN_BIN),$(BUN_BIN) run,$(NPM) run)
 UI_EXEC     := $(if $(BUN_BIN),$(BUN_BIN) x,$(NPM) exec)
 UI_INSTALL  := $(if $(BUN_BIN),$(BUN_BIN) install,$(NPM) install --no-package-lock)
 FUNCTIONAL_DEFAULT_PACKAGES := ./tests/functional/...
-FUNCTIONAL_DEFAULT_JOBS ?= 8
-UNIT_DEFAULT_JOBS ?= 32
+
+# Keep the default Go work claimed by each factory lane bounded when several
+# lanes share one host. GO_LANE_BUDGET is max(2, logical CPUs /
+# YOU_EXPECTED_CONCURRENT_LANES). Both inputs are overridable for controlled
+# probes and CI-specific capacity, while invalid detected values safely select
+# two jobs.
+YOU_EXPECTED_CONCURRENT_LANES ?= 4
+ifeq ($(OS),Windows_NT)
+YOU_LOGICAL_CPUS ?= $(strip $(NUMBER_OF_PROCESSORS))
+else
+YOU_LOGICAL_CPUS ?= $(strip $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || nproc 2>/dev/null))
+endif
+
+define decimal_remainder
+$(strip $(subst 0,,$(subst 1,,$(subst 2,,$(subst 3,,$(subst 4,,$(subst 5,,$(subst 6,,$(subst 7,,$(subst 8,,$(subst 9,,$(1))))))))))))
+endef
+
+define positive_decimal
+$(if $(strip $(1)),$(if $(call decimal_remainder,$(1)),,$(if $(filter 0,$(strip $(1))),,$(strip $(1)))),)
+endef
+
+ifeq ($(OS),Windows_NT)
+define compute_go_lane_budget
+$(strip $(or $(shell cmd.exe /d /v:on /c "set /a result=$(1)/$(2) >nul & if !result! LSS 2 (echo 2) else (echo !result!)"),2))
+endef
+else
+define compute_go_lane_budget
+$(strip $(or $(shell budget=$$(expr $(1) / $(2) 2>/dev/null); if test -z "$$budget" || test "$$budget" -lt 2; then printf '2'; else printf '%s' "$$budget"; fi),2))
+endef
+endif
+
+ifndef GO_LANE_BUDGET
+ifneq ($(call positive_decimal,$(YOU_LOGICAL_CPUS)),)
+ifneq ($(call positive_decimal,$(YOU_EXPECTED_CONCURRENT_LANES)),)
+GO_LANE_BUDGET := $(call compute_go_lane_budget,$(YOU_LOGICAL_CPUS),$(YOU_EXPECTED_CONCURRENT_LANES))
+else
+GO_LANE_BUDGET := 2
+endif
+else
+GO_LANE_BUDGET := 2
+endif
+endif
+
+FUNCTIONAL_DEFAULT_JOBS ?= $(GO_LANE_BUDGET)
+UNIT_DEFAULT_JOBS ?= $(GO_LANE_BUDGET)
 FUNCTIONAL_LONG_TAGS ?= functionallong
 FUNCTIONAL_LONG_PACKAGES := ./tests/functional/...
 STRESS_DEFAULT_PACKAGES := ./tests/stress/...
@@ -88,7 +131,7 @@ LINT_CHECKER_FALLBACK ?= 0
 LINT_CHECKER_DRIVER_PACKAGE := ./cmd/lintcheck
 LINT_CHECKER_DRIVER ?=
 LINT_LANE_PACKAGE := ./cmd/lintlane
-LINT_JOBS ?= 4
+LINT_JOBS ?= $(GO_LANE_BUDGET)
 LINT_TARGETS ?= ui-lint ui-deadcode vet backend-size pkg-maint pkg-file-count pkg-boundary pkg-structure package-target-manifest-check packaged-factory-source-check packaged-factory-consumption-check packaged-factory-catalog-check provider-catalog-check model-provider-package-check durable-runtime-construction-check logging-boundary-check compatibility-alias-check retired-surface-check ownership-inventory-check deadcode
 
 define run_lint_checker
@@ -129,7 +172,7 @@ define run_timed_step
 endef
 
 
-.PHONY: default build install bundle-api
+.PHONY: default build install bundle-api print-go-parallelism
 .PHONY: fmt vet deps deps-tidy clean init typecheck release lint
 
 .PHONY: test test-full test-unit test-unit-fresh test-ci-workflows test-lane-audit test-maintenance test-integration test-contract test-stress test-release
@@ -179,6 +222,17 @@ default:
 	$(MAKE) build
 	$(MAKE) test
 	$(MAKE) lint
+
+# Print the derived values without starting a toolchain process. This is useful
+# for controlled host-capacity probes, for example:
+#   make -s print-go-parallelism YOU_LOGICAL_CPUS=24 YOU_EXPECTED_CONCURRENT_LANES=4
+print-go-parallelism:
+	@echo "YOU_LOGICAL_CPUS=$(YOU_LOGICAL_CPUS) YOU_EXPECTED_CONCURRENT_LANES=$(YOU_EXPECTED_CONCURRENT_LANES)"
+	@echo "GO_LANE_BUDGET=$(GO_LANE_BUDGET)"
+	@echo "UNIT_DEFAULT_JOBS=$(UNIT_DEFAULT_JOBS)"
+	@echo "FUNCTIONAL_DEFAULT_JOBS=$(FUNCTIONAL_DEFAULT_JOBS)"
+	@echo "LINT_JOBS=$(LINT_JOBS)"
+	@echo "UNITLANE_DEFAULT_JOBS=$(GO_LANE_BUDGET)"
 
 # Local pre-push guidance: run both independent Go coverage reports before
 # pushing. A build or typecheck does not substitute for either completed run.

--- a/cmd/unitlane/main.go
+++ b/cmd/unitlane/main.go
@@ -64,7 +64,7 @@ func run() error {
 func parseConfig() config {
 	var cfg config
 	flag.IntVar(&cfg.count, "count", 0, "go test -count value; zero preserves Go's content-addressed test cache")
-	flag.IntVar(&cfg.jobs, "jobs", 32, "go test -p value")
+	flag.IntVar(&cfg.jobs, "jobs", defaultUnitLaneJobs(), "go test -p value")
 	flag.StringVar(&cfg.root, "root", "./pkg/...", "go list package pattern for unit test discovery")
 	flag.BoolVar(&cfg.short, "short", true, "run with go test -short")
 	flag.DurationVar(&cfg.timeout, "timeout", 5*time.Minute, "go test timeout")

--- a/cmd/unitlane/main_test.go
+++ b/cmd/unitlane/main_test.go
@@ -239,11 +239,94 @@ func writeTestPackageFile(t *testing.T, root, relativeDir string) {
 
 func TestParseConfigDefaultsToShortMode(t *testing.T) {
 	restoreArgsFlagsAndCommand(t)
+	t.Setenv(logicalCPUsEnv, "24")
+	t.Setenv(expectedConcurrentLanesEnv, "4")
 	os.Args = []string{"unitlane"}
 	flag.CommandLine = flag.NewFlagSet("unitlane", flag.ContinueOnError)
 
 	got := parseConfig()
-	if got != (config{count: 0, jobs: 32, root: "./pkg/...", short: true, timeout: 5 * time.Minute, vet: false, timingOutput: ""}) {
-		t.Fatalf("parseConfig() = %+v, expected count: %v, jobs: %v", got, 0, 32)
+	if got != (config{count: 0, jobs: 6, root: "./pkg/...", short: true, timeout: 5 * time.Minute, vet: false, timingOutput: ""}) {
+		t.Fatalf("parseConfig() = %+v, expected count: %v, jobs: %v", got, 0, 6)
+	}
+}
+
+func TestBoundedUnitLaneJobs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		logicalCPUs   int
+		expectedLanes string
+		want          int
+	}{
+		{name: "24 CPUs divided across four lanes", logicalCPUs: 24, expectedLanes: "4", want: 6},
+		{name: "four CPUs keep the floor", logicalCPUs: 4, expectedLanes: "4", want: 2},
+		{name: "CPU detection failure uses the floor", logicalCPUs: 0, expectedLanes: "4", want: 2},
+		{name: "invalid divisor uses the floor", logicalCPUs: 24, expectedLanes: "invalid", want: 2},
+		{name: "zero divisor uses the floor", logicalCPUs: 24, expectedLanes: "0", want: 2},
+		{name: "valid divisor override wins", logicalCPUs: 24, expectedLanes: "6", want: 4},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := boundedUnitLaneJobs(test.logicalCPUs, test.expectedLanes); got != test.want {
+				t.Fatalf("boundedUnitLaneJobs(%d, %q) = %d, want %d", test.logicalCPUs, test.expectedLanes, got, test.want)
+			}
+		})
+	}
+}
+
+func TestUnitLaneDefaultReadsControlledHostInputs(t *testing.T) {
+	restoreArgsFlagsAndCommand(t)
+	t.Setenv(logicalCPUsEnv, "24")
+	t.Setenv(expectedConcurrentLanesEnv, "4")
+
+	if got := defaultUnitLaneJobs(); got != 6 {
+		t.Fatalf("defaultUnitLaneJobs() = %d, want 6", got)
+	}
+}
+
+func TestUnitLaneDefaultUsesFourLaneDivisorWhenUnset(t *testing.T) {
+	restoreArgsFlagsAndCommand(t)
+	t.Setenv(logicalCPUsEnv, "24")
+	original, wasSet := os.LookupEnv(expectedConcurrentLanesEnv)
+	if err := os.Unsetenv(expectedConcurrentLanesEnv); err != nil {
+		t.Fatalf("unset %s: %v", expectedConcurrentLanesEnv, err)
+	}
+	t.Cleanup(func() {
+		if wasSet {
+			_ = os.Setenv(expectedConcurrentLanesEnv, original)
+			return
+		}
+		_ = os.Unsetenv(expectedConcurrentLanesEnv)
+	})
+
+	if got := defaultUnitLaneJobs(); got != 6 {
+		t.Fatalf("defaultUnitLaneJobs() with unset divisor = %d, want 6", got)
+	}
+}
+
+func TestParseConfigExplicitJobsRemainAuthoritative(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{name: "positive override", args: []string{"unitlane", "-jobs=9"}, want: 9},
+		{name: "existing minimum clamp", args: []string{"unitlane", "-jobs=0"}, want: 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			restoreArgsFlagsAndCommand(t)
+			t.Setenv(logicalCPUsEnv, "24")
+			t.Setenv(expectedConcurrentLanesEnv, "4")
+			os.Args = test.args
+			flag.CommandLine = flag.NewFlagSet("unitlane", flag.ContinueOnError)
+
+			if got := parseConfig().jobs; got != test.want {
+				t.Fatalf("parseConfig().jobs = %d, want %d", got, test.want)
+			}
+		})
 	}
 }

--- a/cmd/unitlane/parallelism.go
+++ b/cmd/unitlane/parallelism.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+const (
+	defaultUnitLaneJobCount        = 2
+	defaultExpectedConcurrentLanes = 4
+	expectedConcurrentLanesEnv     = "YOU_EXPECTED_CONCURRENT_LANES"
+	logicalCPUsEnv                 = "YOU_LOGICAL_CPUS"
+)
+
+// defaultUnitLaneJobs applies the same bounded host-share policy as the
+// Makefile. YOU_LOGICAL_CPUS is an optional controlled-probe override; normal
+// execution uses the runtime's logical CPU count.
+func defaultUnitLaneJobs() int {
+	logicalCPUs := runtime.NumCPU()
+	if raw, ok := os.LookupEnv(logicalCPUsEnv); ok {
+		parsed, valid := positiveDecimal(raw)
+		if !valid {
+			return defaultUnitLaneJobCount
+		}
+		logicalCPUs = parsed
+	}
+
+	expectedLanes := strconv.Itoa(defaultExpectedConcurrentLanes)
+	if raw, ok := os.LookupEnv(expectedConcurrentLanesEnv); ok {
+		expectedLanes = raw
+	}
+	return boundedUnitLaneJobs(logicalCPUs, expectedLanes)
+}
+
+func boundedUnitLaneJobs(logicalCPUs int, expectedLanes string) int {
+	divisor, valid := positiveDecimal(expectedLanes)
+	if logicalCPUs < 1 || !valid {
+		return defaultUnitLaneJobCount
+	}
+
+	jobs := logicalCPUs / divisor
+	if jobs < defaultUnitLaneJobCount {
+		return defaultUnitLaneJobCount
+	}
+	return jobs
+}
+
+func positiveDecimal(raw string) (int, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, false
+	}
+	for _, char := range raw {
+		if char < '0' || char > '9' {
+			return 0, false
+		}
+	}
+
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < 1 {
+		return 0, false
+	}
+	return value, true
+}

--- a/docs/internal/development/development.md
+++ b/docs/internal/development/development.md
@@ -153,8 +153,14 @@ unit command enumerates only
 specialized packages. Code under `cmd/`, `internal/`, `tests/`, root
 `contracts/`, and the Go UI embed package is intentionally outside unit
 discovery. `make test-lane-audit` verifies that every required Go test package
-has one primary owner. Unit package concurrency defaults to 32 and remains
-overridable with `UNIT_DEFAULT_JOBS`. The fast unit lane schedules only packages
+has one primary owner. Unit, functional, and lint package concurrency defaults
+to the bounded `GO_LANE_BUDGET`: `max(2, logical CPUs /
+YOU_EXPECTED_CONCURRENT_LANES)`, with the divisor defaulting to 4. The
+`UNIT_DEFAULT_JOBS`, `FUNCTIONAL_DEFAULT_JOBS`, and `LINT_JOBS` variables remain
+independently overridable. Direct `cmd/unitlane` execution applies the same
+host/divisor policy (with `YOU_LOGICAL_CPUS` available for controlled probes),
+while an explicit `-jobs` value remains authoritative and still clamps to one
+when below one. The fast unit lane schedules only packages
 that contain Go tests and disables `go test`'s duplicate implicit vet pass;
 `make lint` and the required PR verification tier continue to run `go vet ./...`.
 The normal `make test` loop retains Go's content-addressed test cache, so

--- a/scripts/default-pipeline.test.mjs
+++ b/scripts/default-pipeline.test.mjs
@@ -11,6 +11,10 @@ const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const defaultPipelineBanner = "Bare make runs: generate-api, ui-deps, ui-build, build, test, lint.";
 const binaryOnlyGuidance = "For only the Go binary, run: make build.";
 
+function makeArgumentPath(path) {
+	return path.replaceAll("\\", "/");
+}
+
 async function createHarness(t, failMatch = "") {
 	const root = await mkdtemp(join(os.tmpdir(), "you-default-pipeline-"));
 	const bin = join(root, "bin");
@@ -30,7 +34,7 @@ async function createHarness(t, failMatch = "") {
 		].join("\n") + "\n",
 	);
 
-	const toolNames = ["go", "node", "npm", "make"];
+	const toolNames = ["go", "node", "npm", "nested-make"];
 	const toolPaths = {};
 	for (const tool of toolNames) {
 		const filename = platform === "win32" ? `${tool}.cmd` : tool;
@@ -61,10 +65,10 @@ function runMake(harness, extraArgs = []) {
 		"--no-print-directory",
 		"-f",
 		join(repositoryRoot, "Makefile"),
-		`GO=${harness.toolPaths.go}`,
-		`NODE=${harness.toolPaths.node}`,
-		`NPM=${harness.toolPaths.npm}`,
-		`MAKE=${harness.toolPaths.make}`,
+		`GO=${makeArgumentPath(harness.toolPaths.go)}`,
+		`NODE=${makeArgumentPath(harness.toolPaths.node)}`,
+		`NPM=${makeArgumentPath(harness.toolPaths.npm)}`,
+		`MAKE=${makeArgumentPath(harness.toolPaths["nested-make"])}`,
 		"BUN_BIN=",
 		"YOU_LOGICAL_CPUS=4",
 		"YOU_EXPECTED_CONCURRENT_LANES=4",
@@ -91,7 +95,7 @@ async function toolEvents(logPath) {
 
 function phaseForEvent(event) {
 	const [tool, command = ""] = event.split("|", 2);
-	if (tool === "make") return "nested-make";
+	if (tool === "nested-make") return "nested-make";
 	if (tool === "node" && (command.includes("bundle:rest") || command.includes("generate-openapi-types"))) return "generate-api";
 	if (tool === "npm" && command.startsWith("exec --package")) return "generate-api";
 	if (tool === "go" && command.startsWith("generate ")) return "generate-api";

--- a/scripts/default-pipeline.test.mjs
+++ b/scripts/default-pipeline.test.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { delimiter, dirname, join } from "node:path";
+import { env, execPath, platform } from "node:process";
+import { spawnSync } from "node:child_process";
+import os from "node:os";
+import test from "node:test";
+
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+async function createHarness(t, failMatch = "") {
+	const root = await mkdtemp(join(os.tmpdir(), "you-default-pipeline-"));
+	const bin = join(root, "bin");
+	const logPath = join(root, "tool-events.log");
+	await mkdir(bin);
+	t.after(() => rm(root, { recursive: true, force: true }));
+
+	const toolScript = join(root, "fake-tool.mjs");
+	await writeFile(
+		toolScript,
+		[
+			'import { appendFileSync } from "node:fs";',
+			"const [tool, ...args] = process.argv.slice(2);",
+			"const command = args.join(\" \" );",
+			"appendFileSync(process.env.FAKE_LOG, `${tool}|${command}\\n`);",
+			"if (process.env.FAKE_FAIL_MATCH && command.includes(process.env.FAKE_FAIL_MATCH)) process.exit(23);",
+		].join("\n") + "\n",
+	);
+
+	const toolNames = ["go", "node", "npm", "make"];
+	const toolPaths = {};
+	for (const tool of toolNames) {
+		const filename = platform === "win32" ? `${tool}.cmd` : tool;
+		const path = join(bin, filename);
+		const body =
+			platform === "win32"
+				? `@echo off\r\n"${execPath}" "%~dp0..\\fake-tool.mjs" ${tool} %*\r\nexit /b %errorlevel%\r\n`
+				: `#!/bin/sh\nexec "$NODE_EXE" "$FAKE_TOOL_SCRIPT" ${tool} "$@"\n`;
+		await writeFile(path, body, { mode: 0o755 });
+		if (platform !== "win32") await chmod(path, 0o755);
+		toolPaths[tool] = path;
+	}
+
+	const harnessEnv = {
+		...env,
+		FAKE_FAIL_MATCH: failMatch,
+		FAKE_LOG: logPath,
+		FAKE_TOOL_SCRIPT: toolScript,
+		NODE_EXE: execPath,
+		PATH: `${bin}${delimiter}${env.PATH ?? ""}`,
+		...(platform === "win32" ? { PATHEXT: ".CMD;.EXE;.BAT" } : {}),
+	};
+	return { harnessEnv, logPath, toolPaths };
+}
+
+function runMake(harness, extraArgs = []) {
+	const args = [
+		"--no-print-directory",
+		"-f",
+		join(repositoryRoot, "Makefile"),
+		`GO=${harness.toolPaths.go}`,
+		`NODE=${harness.toolPaths.node}`,
+		`NPM=${harness.toolPaths.npm}`,
+		`MAKE=${harness.toolPaths.make}`,
+		"BUN_BIN=",
+		"YOU_LOGICAL_CPUS=4",
+		"YOU_EXPECTED_CONCURRENT_LANES=4",
+		"LINT_TARGETS=lint-sentinel",
+		...extraArgs,
+		"default",
+	];
+	return spawnSync(platform === "win32" ? "make.exe" : "make", args, {
+		cwd: repositoryRoot,
+		env: harness.harnessEnv,
+		encoding: "utf8",
+	});
+}
+
+async function toolEvents(logPath) {
+	try {
+		const contents = await readFile(logPath, "utf8");
+		return contents.trim() === "" ? [] : contents.trim().split(/\r?\n/);
+	} catch (error) {
+		if (error.code === "ENOENT") return [];
+		throw error;
+	}
+}
+
+function phaseForEvent(event) {
+	const [tool, command = ""] = event.split("|", 2);
+	if (tool === "make") return "nested-make";
+	if (tool === "node" && (command.includes("bundle:rest") || command.includes("generate-openapi-types"))) return "generate-api";
+	if (tool === "npm" && command.startsWith("exec --package")) return "generate-api";
+	if (tool === "go" && command.startsWith("generate ")) return "generate-api";
+	if (tool === "npm" && command.startsWith("install")) return "ui-deps";
+	if (tool === "npm" && command === "run build") return "ui-build";
+	if (tool === "go" && command.startsWith("build ")) return "build";
+	if (tool === "go" && command.includes("./cmd/unitlane")) return "test";
+	if (tool === "node" && command.startsWith("--test ")) return "test";
+	if (tool === "go" && command.includes("./cmd/lintlane")) return "lint";
+	return "unknown";
+}
+
+function assertDefaultPhaseOrder(events) {
+	const phases = events.map(phaseForEvent);
+	assert.ok(!phases.includes("unknown"), `unclassified tool events: ${events.join("\\n")}`);
+	assert.deepEqual(
+		[...new Set(phases)],
+		["generate-api", "ui-deps", "ui-build", "build", "test", "lint"],
+	);
+	assert.equal(phases.filter((phase) => phase === "ui-deps").length, 1);
+	assert.equal(phases.filter((phase) => phase === "ui-build").length, 1);
+	assert.equal(phases.filter((phase) => phase === "build").length, 1);
+	assert.equal(phases.filter((phase) => phase === "test").length, 2);
+	assert.equal(phases.filter((phase) => phase === "lint").length, 1);
+}
+
+function requireMake(t) {
+	const result = spawnSync(platform === "win32" ? "make.exe" : "make", ["--version"], { encoding: "utf8" });
+	if (result.error) {
+		t.skip(`GNU Make is unavailable: ${result.error.message}`);
+		return false;
+	}
+	return true;
+}
+
+test("bare make executes the six default phases once in order", async (t) => {
+	if (!requireMake(t)) return;
+	const harness = await createHarness(t);
+	const result = runMake(harness);
+	assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+	const events = await toolEvents(harness.logPath);
+	assertDefaultPhaseOrder(events);
+});
+
+test("bare make stops later phases when an earlier phase fails", async (t) => {
+	if (!requireMake(t)) return;
+	const harness = await createHarness(t, "build ");
+	const result = runMake(harness);
+	assert.notEqual(result.status, 0, `${result.stdout}\n${result.stderr}`);
+	const phases = (await toolEvents(harness.logPath)).map(phaseForEvent);
+	assert.deepEqual(
+		[...new Set(phases)],
+		["generate-api", "ui-deps", "ui-build", "build"],
+	);
+	assert.ok(!phases.includes("test"), `test phase ran after build failure: ${phases.join(", ")}`);
+	assert.ok(!phases.includes("lint"), `lint phase ran after build failure: ${phases.join(", ")}`);
+});
+
+test("make -n default emits all phases without running tool or nested-make processes", async (t) => {
+	if (!requireMake(t)) return;
+	const harness = await createHarness(t);
+	const result = runMake(harness, ["-n"]);
+	assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+	const events = await toolEvents(harness.logPath);
+	assert.deepEqual(events, [], `dry run started attributable tools: ${events.join("\\n")}`);
+	for (const marker of [
+		"bundle:rest",
+		"generate-openapi-types",
+		"install",
+		"run build",
+		"cmd/factory",
+		"cmd/unitlane",
+		"scripts/development-package-workflow.test.mjs",
+		"cmd/lintlane",
+	]) {
+		assert.ok(result.stdout.includes(marker), `dry run omitted ${marker}`);
+	}
+});

--- a/scripts/default-pipeline.test.mjs
+++ b/scripts/default-pipeline.test.mjs
@@ -8,6 +8,8 @@ import os from "node:os";
 import test from "node:test";
 
 const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const defaultPipelineBanner = "Bare make runs: generate-api, ui-deps, ui-build, build, test, lint.";
+const binaryOnlyGuidance = "For only the Go binary, run: make build.";
 
 async function createHarness(t, failMatch = "") {
 	const root = await mkdtemp(join(os.tmpdir(), "you-default-pipeline-"));
@@ -130,6 +132,8 @@ test("bare make executes the six default phases once in order", async (t) => {
 	const harness = await createHarness(t);
 	const result = runMake(harness);
 	assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+	assert.ok(result.stdout.includes(defaultPipelineBanner), `missing default pipeline banner: ${result.stdout}`);
+	assert.ok(result.stdout.includes(binaryOnlyGuidance), `missing binary-only guidance: ${result.stdout}`);
 	const events = await toolEvents(harness.logPath);
 	assertDefaultPhaseOrder(events);
 });
@@ -156,6 +160,8 @@ test("make -n default emits all phases without running tool or nested-make proce
 	const events = await toolEvents(harness.logPath);
 	assert.deepEqual(events, [], `dry run started attributable tools: ${events.join("\\n")}`);
 	for (const marker of [
+		defaultPipelineBanner,
+		binaryOnlyGuidance,
 		"bundle:rest",
 		"generate-openapi-types",
 		"install",


### PR DESCRIPTION
## Summary

This PR bounds per-invocation Go parallelism for concurrent factory lanes, makes the six-phase default Make pipeline safe to inspect with `make -n`, and discloses the cost of bare `make`.

The operator's decisive measurement is the reason for the change: on the measured 24-logical-core host, a warm `go build ./pkg/platform/clock` (48 dependencies) took 1,683.37 seconds while `go build ./cmd/factory` (833 dependencies) exceeded 1,559 seconds. That 17x difference in dependency volume with the same wall-time cost indicates a fixed per-invocation queueing cost, not compilation volume. The old concurrency product was 16 executor slots x 32 unitlane jobs x Go's 24-package build parallelism, allowing roughly 512 competing package workers; the new default reduces the unit package-worker ceiling to 16 x 6 = 96.

## What changed

- Make derives a shared `GO_LANE_BUDGET` as `max(2, logical CPUs / YOU_EXPECTED_CONCURRENT_LANES)`, with divisor 4 by default, Windows and non-Windows CPU detection, safe fallback 2, and preserved `?=` overrides for unit, functional, and lint jobs.
- Direct `cmd/unitlane` execution uses the same host/divisor-derived default while explicit `-jobs` values remain authoritative and values below one still clamp to one.
- `default` and `test` use ordered, serialized dependency graphs. The lint child-Make command is passed through `LINT_MAKE` so the recipe does not trigger GNU Make's recursive dry-run behavior. Default-path Node commands remain overridable and the unused GOPATH parse lookup is deferred.
- Bare `make` begins with a cross-shell banner naming `generate-api`, `ui-deps`, `ui-build`, `build`, `test`, and `lint`, and points binary-only users to `make build`. The banner is a phony prerequisite, so it appears in `make -n` without executing any work.
- The command-level regression harness runs real Make with fake Go, Node, npm, and Make executables and verifies phase order, stop-on-failure, banner/guidance output, and zero attributable tool or nested-Make events during `make -n`.

## Verification

- `make -s print-go-parallelism YOU_LOGICAL_CPUS=24 YOU_EXPECTED_CONCURRENT_LANES=4` -> 6/6/6/6.
- `make -s print-go-parallelism YOU_LOGICAL_CPUS=4 YOU_EXPECTED_CONCURRENT_LANES=4` -> 2/2/2/2.
- `node --test scripts/default-pipeline.test.mjs` -> 3 passed on the final rebased head.
- `make --no-print-directory test-ci-workflows` -> 14 passed.
- `make --no-print-directory typecheck` -> passed on the final rebased head.
- Isolated `make --no-print-directory -n default` -> status 0 in 1.7 seconds; printed the banner, binary-only guidance, and all six phase commands without starting the toolchain. The focused harness also observes an empty attributable-tool event log.
- A contemporaneous Windows process sample around the earlier `make.exe --no-print-directory -n default` observed no attributable Go, Node, Bun, or nested Make child.
- The shared-host warm before/after factory-build timing is inconclusive because contention is bursty and concurrent lanes were active; this PR makes no unsupported wall-time improvement claim. The operator's measured before/after process evidence and arithmetic are the primary performance justification.

Story 001, story 002, and story 003 are complete in the lane PRD. No inference-owned workflow or factory executor-slot settings were changed. Required CI and terminal merge remain review-stage outcomes.