### PR TITLE
thr-ci-runs-no-backend-lint-suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,26 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
+      - name: Verify Backend Lint event selection
+        env:
+          BACKEND_LINT_EVENT_NAME: ${{ github.event_name }}
+          BACKEND_LINT_REF: ${{ github.ref }}
+          BACKEND_LINT_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          BACKEND_LINT_SHA: ${{ github.sha }}
+        run: |
+          node --input-type=module <<'NODE'
+          import { selectBackendLint } from './scripts/ci/backend-lint-workflow.mjs';
+          const selection = selectBackendLint({
+            eventName: process.env.BACKEND_LINT_EVENT_NAME,
+            ref: process.env.BACKEND_LINT_REF,
+            pullRequestHeadSha: process.env.BACKEND_LINT_PR_HEAD_SHA,
+            sha: process.env.BACKEND_LINT_SHA,
+          });
+          if (!selection.selected || !selection.headSha) {
+            throw new Error(`Backend Lint was not selected for its hosted event: ${JSON.stringify(selection)}`);
+          }
+          console.log(`Backend Lint selected at ${selection.headSha}`);
+          NODE
       - name: Install UI dependencies for canonical UI lint targets
         if: always()
         run: make ui-deps
@@ -333,7 +353,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('node:fs');
-            const marker = '<!-- backend-lint-report -->';
+            const { upsertBackendLintComment } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/ci/backend-lint-workflow.mjs`);
             const body = fs.readFileSync(process.env.BACKEND_LINT_COMMENT_FILE, 'utf8');
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
@@ -341,22 +361,20 @@ jobs:
               issue_number: context.issue.number,
               per_page: 100,
             });
-            const existing = comments.find((comment) =>
-              comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker),
-            );
-            if (existing) {
+            const publication = upsertBackendLintComment(comments, body);
+            if (publication.action === 'update') {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
+                comment_id: publication.commentId,
+                body: publication.body,
               });
             } else {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body,
+                body: publication.body,
               });
             }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,9 +274,9 @@ jobs:
       contents: read
       pull-requests: write
     env:
-      LINT_REPORT_FILE: ${{ runner.temp }}/backend-lint-report.json
-      LINT_LOG_FILE: ${{ runner.temp }}/backend-lint.log
-      LINT_COMMENT_FILE: ${{ runner.temp }}/backend-lint-comment.md
+      LINT_REPORT_FILE: .artifacts/backend-lint/report.json
+      LINT_LOG_FILE: .artifacts/backend-lint/lint.log
+      LINT_COMMENT_FILE: .artifacts/backend-lint/comment.md
     steps:
       - uses: actions/checkout@v4
         with:
@@ -299,6 +299,7 @@ jobs:
         shell: bash
         run: |
           set +e
+          mkdir -p .artifacts/backend-lint
           make LINT_REPORT_FILE="$LINT_REPORT_FILE" lint 2>&1 | tee "$LINT_LOG_FILE"
           status=${PIPESTATUS[0]}
           printf 'exit_code=%s\n' "$status" >> "$GITHUB_OUTPUT"
@@ -317,9 +318,9 @@ jobs:
         with:
           name: backend-lint-diagnostics
           path: |
-            ${{ runner.temp }}/backend-lint-report.json
-            ${{ runner.temp }}/backend-lint.log
-            ${{ runner.temp }}/backend-lint-comment.md
+            .artifacts/backend-lint/report.json
+            .artifacts/backend-lint/lint.log
+            .artifacts/backend-lint/comment.md
           if-no-files-found: warn
           retention-days: 14
       - name: Publish Backend Lint inventory to the pull request

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,99 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  backend-lint:
+    name: Backend Lint
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      LINT_REPORT_FILE: ${{ runner.temp }}/backend-lint-report.json
+      LINT_LOG_FILE: ${{ runner.temp }}/backend-lint.log
+      LINT_COMMENT_FILE: ${{ runner.temp }}/backend-lint-comment.md
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - name: Install UI dependencies for canonical UI lint targets
+        if: always()
+        run: make ui-deps
+      - name: Run complete canonical Backend Lint inventory
+        id: run-backend-lint
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          set +e
+          make LINT_REPORT_FILE="$LINT_REPORT_FILE" lint 2>&1 | tee "$LINT_LOG_FILE"
+          status=${PIPESTATUS[0]}
+          printf 'exit_code=%s\n' "$status" >> "$GITHUB_OUTPUT"
+          exit "$status"
+      - name: Render Backend Lint summary and gate
+        if: always()
+        run: >-
+          node scripts/ci/backend-lint-report.mjs
+          --report "$LINT_REPORT_FILE"
+          --log "$LINT_LOG_FILE"
+          --summary "$GITHUB_STEP_SUMMARY"
+          --comment "$LINT_COMMENT_FILE"
+      - name: Upload complete Backend Lint diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-lint-diagnostics
+          path: |
+            ${{ runner.temp }}/backend-lint-report.json
+            ${{ runner.temp }}/backend-lint.log
+            ${{ runner.temp }}/backend-lint-comment.md
+          if-no-files-found: warn
+          retention-days: 14
+      - name: Publish Backend Lint inventory to the pull request
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          BACKEND_LINT_COMMENT_FILE: ${{ env.LINT_COMMENT_FILE }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('node:fs');
+            const marker = '<!-- backend-lint-report -->';
+            const body = fs.readFileSync(process.env.BACKEND_LINT_COMMENT_FILE, 'utf8');
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker),
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
   ui-backend-integration:
     name: UI Backend Integration
     needs: classify
@@ -330,7 +423,7 @@ jobs:
 
   verification-policy:
     name: Verification Policy
-    needs: [classify, docs-reference, readme, frontend, frontend-component, ui-coverage, frontend-browser, frontend-storybook, backend-coverage, ui-backend-integration, development-package]
+    needs: [classify, docs-reference, readme, frontend, frontend-component, ui-coverage, frontend-browser, frontend-storybook, backend-coverage, backend-lint, ui-backend-integration, development-package]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -372,6 +465,9 @@ jobs:
           FRONTEND_BROWSER_RESULT: ${{ needs.frontend-browser.result }}
           FRONTEND_STORYBOOK_RESULT: ${{ needs.frontend-storybook.result }}
           BACKEND_RESULT: ${{ needs.backend-coverage.result }}
+          RUN_BACKEND_LINT: "true"
+          BACKEND_LINT_REASON: "The complete canonical LINT_TARGETS inventory is required on every pull request and push to main."
+          BACKEND_LINT_RESULT: ${{ needs.backend-lint.result }}
           UI_BACKEND_RESULT: ${{ needs.ui-backend-integration.result }}
           PACKAGE_WORKFLOW_RESULT: ${{ needs.development-package.result }}
           API_RESULT: ${{ needs.development-package.outputs.api_package_result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,7 @@ jobs:
       LINT_REPORT_FILE: .artifacts/backend-lint/report.json
       LINT_LOG_FILE: .artifacts/backend-lint/lint.log
       LINT_COMMENT_FILE: .artifacts/backend-lint/comment.md
+      BACKEND_LINT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ LINT_JOBS ?= $(GO_LANE_BUDGET)
 # special $(MAKE) variable in this recipe; GNU Make executes such recipes
 # during -n so recursive builds can receive the dry-run flag.
 LINT_MAKE ?= $(MAKE)
+LINT_REPORT_FILE ?=
 LINT_TARGETS ?= ui-lint ui-deadcode vet backend-size pkg-maint pkg-file-count pkg-boundary pkg-structure package-target-manifest-check packaged-factory-source-check packaged-factory-consumption-check packaged-factory-catalog-check provider-catalog-check model-provider-package-check durable-runtime-construction-check logging-boundary-check compatibility-alias-check retired-surface-check ownership-inventory-check deadcode
 
 define run_lint_checker
@@ -449,7 +450,7 @@ readme-check:
 test: test-unit test-ci-workflows
 
 test-ci-workflows:
-	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs
+	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs scripts/ci/backend-lint-report.test.mjs scripts/ci/backend-lint-workflow.test.mjs
 
 test-full:
 	$(GO) test ./... -timeout $(GO_TEST_TIMEOUT)
@@ -691,7 +692,7 @@ artifact-contract-closeout:
 	$(GO) test -tags=$(FUNCTIONAL_LONG_TAGS) ./tests/functional/workers/script -run "TestWorkerPublicContractSmoke_" -count=1 -timeout $(GO_TEST_TIMEOUT)
 
 lint:
-	$(GO) run $(LINT_LANE_PACKAGE) -make "$(LINT_MAKE)" -jobs "$(LINT_JOBS)" -go "$(GO)" -cache-dir "$(LINT_CHECKER_CACHE_DIR)" $(if $(LINT_CHECKER_DRIVER),-checker-driver "$(LINT_CHECKER_DRIVER)",-checker-package "$(LINT_CHECKER_DRIVER_PACKAGE)") -- $(LINT_TARGETS)
+	$(GO) run $(LINT_LANE_PACKAGE) -make "$(LINT_MAKE)" -jobs "$(LINT_JOBS)" -go "$(GO)" -cache-dir "$(LINT_CHECKER_CACHE_DIR)" $(if $(LINT_REPORT_FILE),-report-file "$(LINT_REPORT_FILE)",) $(if $(LINT_CHECKER_DRIVER),-checker-driver "$(LINT_CHECKER_DRIVER)",-checker-package "$(LINT_CHECKER_DRIVER_PACKAGE)") -- $(LINT_TARGETS)
 
 backend-size:
 	$(call run_lint_checker,./cmd/backendsizecheck,-root "$(BACKEND_SIZE_ROOT)")

--- a/cmd/backendsizecheck/main.go
+++ b/cmd/backendsizecheck/main.go
@@ -76,6 +76,7 @@ func run(cfg config, stdout io.Writer, stderr io.Writer) error {
 		for _, difference := range budgetDifferences {
 			fmt.Fprintln(stderr, exemptionbudget.FormatDifference(difference))
 		}
+		fmt.Fprintf(stderr, "LINT_VIOLATION_COUNT: %d\n", len(budgetDifferences))
 		return fmt.Errorf("[agent-factory:backend-size] found %d exemption budget violation(s)", len(budgetDifferences))
 	}
 
@@ -95,6 +96,7 @@ func run(cfg config, stdout io.Writer, stderr io.Writer) error {
 		}
 		fmt.Fprintf(stderr, "%s | function %s in %s has %d lines (limit %d)\n", finding.packagePath, finding.function, finding.filePath, finding.actual, finding.limit)
 	}
+	fmt.Fprintf(stderr, "LINT_VIOLATION_COUNT: %d\n", len(violations))
 	return fmt.Errorf("[agent-factory:backend-size] found %d size violation(s)", len(violations))
 }
 

--- a/cmd/backendsizecheck/main_test.go
+++ b/cmd/backendsizecheck/main_test.go
@@ -221,10 +221,9 @@ func TestRunRejectsAllUnregisteredDirectivesInDeterministicOrder(t *testing.T) {
 	want := strings.Join([]string{
 		"exemption budget rule=backendsizecheck:ignore-file target=pkg/zeta/z.go is unregistered; add a sorted docs/internal/baselines/backend-exemption-budget.json entry with a non-empty owner and actionable removalReason",
 		"exemption budget rule=backendsizecheck:ignore-function target=cmd/alpha/main.go#main is unregistered; add a sorted docs/internal/baselines/backend-exemption-budget.json entry with a non-empty owner and actionable removalReason",
-		"",
 	}, "\n")
-	if got := stderr.String(); got != want {
-		t.Fatalf("run() stderr = %q, want deterministic diagnostics %q", got, want)
+	if got := stderr.String(); !strings.HasPrefix(got, want+"\n") || !strings.HasSuffix(got, "LINT_VIOLATION_COUNT: 2\n") {
+		t.Fatalf("run() stderr = %q, want deterministic diagnostics followed by count marker", got)
 	}
 }
 

--- a/cmd/deadcodecheck/main.go
+++ b/cmd/deadcodecheck/main.go
@@ -56,7 +56,9 @@ func run(_ []string, stdout io.Writer, stderr io.Writer) int {
 	baseline := normalizeReport(string(baselineBytes))
 	if baseline != actual {
 		fmt.Fprintf(stderr, "deadcode baseline drift detected; review %s and update %s when intentional\n", currentPath, baselinePath)
-		fmt.Fprintf(stderr, "baseline findings: %d, current findings: %d\n", countFindings(baseline), countFindings(actual))
+		currentFindings := countFindings(actual)
+		fmt.Fprintf(stderr, "baseline findings: %d, current findings: %d\n", countFindings(baseline), currentFindings)
+		fmt.Fprintf(stderr, "LINT_VIOLATION_COUNT: %d\n", currentFindings)
 		return 1
 	}
 

--- a/cmd/lintlane/main.go
+++ b/cmd/lintlane/main.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 )
 
 const defaultLintJobs = 4
@@ -22,14 +23,16 @@ type config struct {
 	checkerPackage  string
 	checkerCacheDir string
 	goTool          string
+	reportFile      string
 	jobs            int
 	targets         []string
 }
 
 type targetResult struct {
-	target string
-	output string
-	err    error
+	target   string
+	output   string
+	err      error
+	duration time.Duration
 }
 
 type targetRunner func(makeTool, target string, stdout, stderr io.Writer) error
@@ -49,6 +52,7 @@ func main() {
 }
 
 func run(args []string, stdout, stderr io.Writer) int {
+	started := time.Now()
 	cfg, err := parseConfig(args, stderr)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
@@ -70,6 +74,12 @@ func run(args []string, stdout, stderr io.Writer) int {
 	}
 	defer cleanup()
 	results := runTargets(cfg.makeTool, cfg.targets, cfg.jobs, runner)
+	if cfg.reportFile != "" {
+		if err := writeReportFile(cfg.reportFile, cfg.jobs, time.Since(started), results); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+	}
 	if err := writeReport(stdout, results); err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
@@ -85,6 +95,7 @@ func parseConfig(args []string, stderr io.Writer) (config, error) {
 	checkerPackage := flags.String("checker-package", "", "checker driver package to compile once for this lint lane")
 	checkerCacheDir := flags.String("cache-dir", ".cache/lint-checkers", "directory for temporary lint lane executables")
 	goTool := flags.String("go", "go", "Go executable used to compile the lint checker driver")
+	reportFile := flags.String("report-file", "", "JSON file for the complete per-target lint report")
 	jobs := flags.Int("jobs", defaultLintJobs, "maximum number of lint targets to run concurrently")
 	if err := flags.Parse(args); err != nil {
 		return config{}, err
@@ -104,6 +115,9 @@ func parseConfig(args []string, stderr io.Writer) (config, error) {
 	if strings.TrimSpace(*goTool) == "" {
 		return config{}, errors.New("go tool must not be empty")
 	}
+	if strings.TrimSpace(*reportFile) == "" && *reportFile != "" {
+		return config{}, errors.New("report file must not be empty")
+	}
 	if *jobs < 1 {
 		return config{}, fmt.Errorf("lint job limit must be positive, got %d", *jobs)
 	}
@@ -122,6 +136,7 @@ func parseConfig(args []string, stderr io.Writer) (config, error) {
 		checkerPackage:  *checkerPackage,
 		checkerCacheDir: *checkerCacheDir,
 		goTool:          *goTool,
+		reportFile:      *reportFile,
 		jobs:            *jobs,
 		targets:         targets,
 	}, nil
@@ -182,9 +197,15 @@ func runTargets(makeTool string, targets []string, jobs int, runner targetRunner
 		go func() {
 			defer workers.Done()
 			for item := range work {
+				started := time.Now()
 				output := &lockedBuffer{}
 				err := runner(makeTool, item.target, output, output)
-				results[item.index] = targetResult{target: item.target, output: output.String(), err: err}
+				results[item.index] = targetResult{
+					target:   item.target,
+					output:   output.String(),
+					err:      err,
+					duration: time.Since(started),
+				}
 			}
 		}()
 	}

--- a/cmd/lintlane/main_test.go
+++ b/cmd/lintlane/main_test.go
@@ -123,13 +123,15 @@ func TestRunSuccessReportsUnambiguousResult(t *testing.T) {
 	}
 }
 
-func TestRunWritesCompleteJSONReportWhenTargetsFail(t *testing.T) {
+func TestRunContinuesAfterEarlyFailureAndWritesCompleteJSONReport(t *testing.T) {
 	original := executeTarget
 	t.Cleanup(func() { executeTarget = original })
+	var started []string
 	executeTarget = func(_, target string, stdout, _ io.Writer) error {
+		started = append(started, target)
 		fmt.Fprintf(stdout, "diagnostic:%s\n", target)
-		if target == "broken" {
-			fmt.Fprintln(stdout, "LINT_VIOLATION_COUNT: 3")
+		if target == "first" {
+			fmt.Fprintln(stdout, "LINT_VIOLATION_COUNT: 1")
 			return errors.New("controlled failure")
 		}
 		return nil
@@ -137,8 +139,11 @@ func TestRunWritesCompleteJSONReportWhenTargetsFail(t *testing.T) {
 
 	reportPath := filepath.Join(t.TempDir(), "backend-lint.json")
 	var stdout, stderr bytes.Buffer
-	if code := run([]string{"-report-file", reportPath, "-jobs", "2", "clean", "broken"}, &stdout, &stderr); code == 0 {
+	if code := run([]string{"-report-file", reportPath, "-jobs", "1", "first", "second", "third"}, &stdout, &stderr); code == 0 {
 		t.Fatalf("run() exit code = 0, want failed target; stdout = %q", stdout.String())
+	}
+	if !slices.Equal(started, []string{"first", "second", "third"}) {
+		t.Fatalf("targets started = %v, want the runner to continue after first failure", started)
 	}
 	data, err := os.ReadFile(reportPath)
 	if err != nil {
@@ -148,17 +153,27 @@ func TestRunWritesCompleteJSONReportWhenTargetsFail(t *testing.T) {
 	if err := json.Unmarshal(data, &report); err != nil {
 		t.Fatalf("decode report: %v; data = %s", err, data)
 	}
-	if report.Version != 1 || report.Jobs != 2 || len(report.Targets) != 2 {
-		t.Fatalf("report metadata = %+v, want version 1, jobs 2, and two targets", report)
+	if report.Version != 1 || report.Jobs != 1 || len(report.Targets) != 3 {
+		t.Fatalf("report metadata = %+v, want version 1, jobs 1, and three targets", report)
 	}
-	if report.Targets[0].Name != "clean" || report.Targets[0].Status != "pass" || report.Targets[0].Output != "diagnostic:clean\n" {
-		t.Fatalf("clean target report = %+v", report.Targets[0])
+	for index, target := range report.Targets {
+		if target.DurationMillis < 0 {
+			t.Fatalf("target %q duration = %d, want a reported wall time", target.Name, target.DurationMillis)
+		}
+		if target.Name != started[index] {
+			t.Fatalf("report target[%d] = %q, want execution order %q", index, target.Name, started[index])
+		}
 	}
-	if report.Targets[1].Name != "broken" || report.Targets[1].Status != "fail" || report.Targets[1].Error != "controlled failure" {
-		t.Fatalf("broken target report = %+v", report.Targets[1])
+	if report.Targets[0].Status != "fail" || report.Targets[0].Error != "controlled failure" {
+		t.Fatalf("first target report = %+v", report.Targets[0])
 	}
-	if report.Targets[1].ViolationCount == nil || *report.Targets[1].ViolationCount != 3 || report.Targets[1].ViolationCountSource != "checker-marker" {
-		t.Fatalf("broken target violation count = %+v, want checker marker count 3", report.Targets[1])
+	if report.Targets[0].ViolationCount == nil || *report.Targets[0].ViolationCount != 1 || report.Targets[0].ViolationCountSource != "checker-marker" {
+		t.Fatalf("first target violation count = %+v, want checker marker count 1", report.Targets[0])
+	}
+	for _, target := range report.Targets[1:] {
+		if target.Status != "pass" || target.ViolationCount == nil || *target.ViolationCount != 0 || target.ViolationCountSource != "successful-check" {
+			t.Fatalf("successful target report = %+v, want pass with zero violations", target)
+		}
 	}
 }
 

--- a/cmd/lintlane/main_test.go
+++ b/cmd/lintlane/main_test.go
@@ -129,6 +129,7 @@ func TestRunWritesCompleteJSONReportWhenTargetsFail(t *testing.T) {
 	executeTarget = func(_, target string, stdout, _ io.Writer) error {
 		fmt.Fprintf(stdout, "diagnostic:%s\n", target)
 		if target == "broken" {
+			fmt.Fprintln(stdout, "LINT_VIOLATION_COUNT: 3")
 			return errors.New("controlled failure")
 		}
 		return nil
@@ -155,6 +156,30 @@ func TestRunWritesCompleteJSONReportWhenTargetsFail(t *testing.T) {
 	}
 	if report.Targets[1].Name != "broken" || report.Targets[1].Status != "fail" || report.Targets[1].Error != "controlled failure" {
 		t.Fatalf("broken target report = %+v", report.Targets[1])
+	}
+	if report.Targets[1].ViolationCount == nil || *report.Targets[1].ViolationCount != 3 || report.Targets[1].ViolationCountSource != "checker-marker" {
+		t.Fatalf("broken target violation count = %+v, want checker marker count 3", report.Targets[1])
+	}
+}
+
+func TestCheckerViolationCountRequiresOneNonnegativeMachineReadableMarker(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		text  string
+		count int
+		valid bool
+	}{
+		{name: "valid", text: "diagnostic\nLINT_VIOLATION_COUNT: 4\n", count: 4, valid: true},
+		{name: "missing", text: "diagnostic\n", valid: false},
+		{name: "duplicate", text: "LINT_VIOLATION_COUNT: 1\nLINT_VIOLATION_COUNT: 1\n", valid: false},
+		{name: "negative", text: "LINT_VIOLATION_COUNT: -1\n", valid: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			count, ok := checkerViolationCount(test.text)
+			if ok != test.valid || (ok && count != test.count) {
+				t.Fatalf("checkerViolationCount(%q) = (%d, %v), want (%d, %v)", test.text, count, ok, test.count, test.valid)
+			}
+		})
 	}
 }
 

--- a/cmd/lintlane/main_test.go
+++ b/cmd/lintlane/main_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -118,6 +120,41 @@ func TestRunSuccessReportsUnambiguousResult(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("success stderr = %q", stderr.String())
+	}
+}
+
+func TestRunWritesCompleteJSONReportWhenTargetsFail(t *testing.T) {
+	original := executeTarget
+	t.Cleanup(func() { executeTarget = original })
+	executeTarget = func(_, target string, stdout, _ io.Writer) error {
+		fmt.Fprintf(stdout, "diagnostic:%s\n", target)
+		if target == "broken" {
+			return errors.New("controlled failure")
+		}
+		return nil
+	}
+
+	reportPath := filepath.Join(t.TempDir(), "backend-lint.json")
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"-report-file", reportPath, "-jobs", "2", "clean", "broken"}, &stdout, &stderr); code == 0 {
+		t.Fatalf("run() exit code = 0, want failed target; stdout = %q", stdout.String())
+	}
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	var report lintReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("decode report: %v; data = %s", err, data)
+	}
+	if report.Version != 1 || report.Jobs != 2 || len(report.Targets) != 2 {
+		t.Fatalf("report metadata = %+v, want version 1, jobs 2, and two targets", report)
+	}
+	if report.Targets[0].Name != "clean" || report.Targets[0].Status != "pass" || report.Targets[0].Output != "diagnostic:clean\n" {
+		t.Fatalf("clean target report = %+v", report.Targets[0])
+	}
+	if report.Targets[1].Name != "broken" || report.Targets[1].Status != "fail" || report.Targets[1].Error != "controlled failure" {
+		t.Fatalf("broken target report = %+v", report.Targets[1])
 	}
 }
 

--- a/cmd/lintlane/report.go
+++ b/cmd/lintlane/report.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type lintReport struct {
+	Version             int                `json:"version"`
+	Jobs                int                `json:"jobs"`
+	TotalDurationMillis int64              `json:"totalDurationMillis"`
+	Targets             []lintReportTarget `json:"targets"`
+}
+
+type lintReportTarget struct {
+	Name           string `json:"name"`
+	Status         string `json:"status"`
+	DurationMillis int64  `json:"durationMillis"`
+	Output         string `json:"output"`
+	Error          string `json:"error,omitempty"`
+}
+
+func writeReportFile(path string, jobs int, total time.Duration, results []targetResult) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("lint report file must not be empty")
+	}
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("create lint report directory: %w", err)
+	}
+
+	report := lintReport{
+		Version:             1,
+		Jobs:                jobs,
+		TotalDurationMillis: total.Milliseconds(),
+		Targets:             make([]lintReportTarget, 0, len(results)),
+	}
+	for _, result := range results {
+		target := lintReportTarget{
+			Name:           result.target,
+			Status:         reportStatus(result.err),
+			DurationMillis: result.duration.Milliseconds(),
+			Output:         result.output,
+		}
+		if result.err != nil {
+			target.Error = result.err.Error()
+		}
+		report.Targets = append(report.Targets, target)
+	}
+
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode lint report: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write lint report %s: %w", path, err)
+	}
+	return nil
+}
+
+func reportStatus(err error) string {
+	if err != nil {
+		return "fail"
+	}
+	return "pass"
+}

--- a/cmd/lintlane/report.go
+++ b/cmd/lintlane/report.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -17,11 +18,34 @@ type lintReport struct {
 }
 
 type lintReportTarget struct {
-	Name           string `json:"name"`
-	Status         string `json:"status"`
-	DurationMillis int64  `json:"durationMillis"`
-	Output         string `json:"output"`
-	Error          string `json:"error,omitempty"`
+	Name                 string `json:"name"`
+	Status               string `json:"status"`
+	DurationMillis       int64  `json:"durationMillis"`
+	Output               string `json:"output"`
+	Error                string `json:"error,omitempty"`
+	ViolationCount       *int   `json:"violationCount,omitempty"`
+	ViolationCountSource string `json:"violationCountSource,omitempty"`
+}
+
+const violationCountMarker = "LINT_VIOLATION_COUNT:"
+
+func checkerViolationCount(output string) (int, bool) {
+	var count *int
+	for _, line := range strings.Split(output, "\n") {
+		value, ok := strings.CutPrefix(strings.TrimSpace(line), violationCountMarker)
+		if !ok {
+			continue
+		}
+		parsed, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil || parsed < 0 || count != nil {
+			return 0, false
+		}
+		count = &parsed
+	}
+	if count == nil {
+		return 0, false
+	}
+	return *count, true
 }
 
 func writeReportFile(path string, jobs int, total time.Duration, results []targetResult) error {
@@ -45,6 +69,14 @@ func writeReportFile(path string, jobs int, total time.Duration, results []targe
 			Status:         reportStatus(result.err),
 			DurationMillis: result.duration.Milliseconds(),
 			Output:         result.output,
+		}
+		if result.err == nil {
+			count := 0
+			target.ViolationCount = &count
+			target.ViolationCountSource = "successful-check"
+		} else if count, ok := checkerViolationCount(result.output); ok {
+			target.ViolationCount = &count
+			target.ViolationCountSource = "checker-marker"
 		}
 		if result.err != nil {
 			target.Error = result.err.Error()

--- a/cmd/ownershipinventorycheck/main.go
+++ b/cmd/ownershipinventorycheck/main.go
@@ -45,6 +45,7 @@ func run(root string, stdout, stderr io.Writer) int {
 		)
 		fmt.Fprintf(stderr, "[ownership-inventory-check] inventory report: %#v\n", report.Inventory)
 		fmt.Fprintf(stderr, "[ownership-inventory-check] path-lease report: %#v\n", report.PathLease)
+		fmt.Fprintf(stderr, "LINT_VIOLATION_COUNT: %d\n", report.Inventory.ViolationCount()+report.PathLease.ViolationCount())
 		return 1
 	}
 	fmt.Fprintln(stdout, "[ownership-inventory-check] ownership inventory and path-lease freeze verified")

--- a/cmd/packagedfactoryconsumptioncheck/main.go
+++ b/cmd/packagedfactoryconsumptioncheck/main.go
@@ -44,7 +44,7 @@ var allowedPackagedFactoriesImporters = map[string]struct{}{
 }
 
 var allowedCatalogLoaderFiles = map[string]struct{}{
-	"pkg/wire/profiles.go": {},
+	"pkg/wire/profiles.go":                   {},
 	"pkg/transports/http/handlers_models.go": {},
 	"pkg/services/factory_definitions/internal/services/distribution/goal/prompt_drift.go": {},
 }
@@ -74,7 +74,7 @@ func run(cfg config, stdout io.Writer) error {
 	}
 	sort.Strings(violations)
 	if len(violations) > 0 {
-		return fmt.Errorf("%s consumption boundary failed:\n- %s", diagnosticPrefix, strings.Join(violations, "\n- "))
+		return fmt.Errorf("%s consumption boundary failed:\nLINT_VIOLATION_COUNT: %d\n- %s", diagnosticPrefix, len(violations), strings.Join(violations, "\n- "))
 	}
 	fmt.Fprintf(
 		stdout,

--- a/cmd/packagetargetmanifestcheck/inventory.go
+++ b/cmd/packagetargetmanifestcheck/inventory.go
@@ -97,11 +97,11 @@ func validateInventory(repoRoot string, inventory []string) error {
 		missing, extra := diffStringSets(live, inventory)
 		switch {
 		case len(missing) > 0 && len(extra) > 0:
-			return fmt.Errorf("inventory does not match live production packages; missing example %q; extra example %q", missing[0], extra[0])
+			return fmt.Errorf("inventory does not match live production packages; missing example %q; extra example %q\nLINT_VIOLATION_COUNT: %d", missing[0], extra[0], len(missing)+len(extra))
 		case len(missing) > 0:
-			return fmt.Errorf("inventory is missing production package %q", missing[0])
+			return fmt.Errorf("inventory is missing production package %q\nLINT_VIOLATION_COUNT: %d", missing[0], len(missing))
 		case len(extra) > 0:
-			return fmt.Errorf("inventory contains unknown package %q", extra[0])
+			return fmt.Errorf("inventory contains unknown package %q\nLINT_VIOLATION_COUNT: %d", extra[0], len(extra))
 		default:
 			return fmt.Errorf("inventory order does not match stable-sorted live production packages")
 		}

--- a/internal/ownershipinventory/path_lease_freeze.go
+++ b/internal/ownershipinventory/path_lease_freeze.go
@@ -67,6 +67,28 @@ type PathLeaseFreezeReport struct {
 	ManifestError             string
 }
 
+// ViolationCount returns the number of independently reported path-lease
+// findings represented by this validation report.
+func (r PathLeaseFreezeReport) ViolationCount() int {
+	count := len(r.MissingPackets) + len(r.EmptyExclusivePathPackets) + len(r.PortfolioHoldConflicts)
+	if r.InvalidFormatVersion {
+		count++
+	}
+	if r.MissingSourceInventory {
+		count++
+	}
+	if r.UnstablePacketSort {
+		count++
+	}
+	if r.OverlappingActiveLeases {
+		count++
+	}
+	if r.ManifestError != "" {
+		count++
+	}
+	return count
+}
+
 // OK reports whether path-lease freeze validation found no defects.
 func (r PathLeaseFreezeReport) OK() bool {
 	return len(r.MissingPackets) == 0 &&
@@ -281,5 +303,3 @@ func freezePathPrefix(prefix, path string) bool {
 	remainder := path[len(prefix):]
 	return strings.HasPrefix(remainder, "/")
 }
-
-

--- a/internal/ownershipinventory/types.go
+++ b/internal/ownershipinventory/types.go
@@ -252,6 +252,66 @@ type Report struct {
 	ReusedFND01Seed               bool
 }
 
+// ViolationCount returns the number of independently reported inventory
+// findings. Structured list entries count individually; boolean gate failures
+// count once each so a consolidated diagnostic cannot hide added debt.
+func (r Report) ViolationCount() int {
+	return countStrings(
+		r.MissingPackages,
+		r.UnexpectedPackages,
+		r.DuplicatePackages,
+		r.InvalidMappings,
+		r.MissingSeedServices,
+		r.MissingAdditionalRoots,
+		r.MissingOwnerRationales,
+		r.MissingNestedRationales,
+		r.InvalidRationaleFields,
+		r.MissingResponsibilityClusters,
+		r.MissingCrossServiceEdges,
+		r.UnexpectedCrossServiceEdges,
+		r.InvalidEdgeClassifications,
+		r.InvalidBidirectionalEdges,
+		r.MissingNamedOwners,
+		r.UnconfirmedNamedOwners,
+		r.InvalidNamedOwnerMaps,
+		r.MissingMisplacedGuards,
+		r.InvalidMisplacedGuards,
+		r.MissingPublicSurfaces,
+		r.InvalidPublicSurfaces,
+		r.MissingOwnedRoles,
+		r.InvalidOwnedRoles,
+	) + countFlags(
+		r.MissingCrossServiceEdgeTable,
+		r.MissingProcessEdgesException,
+		r.UnstableSort,
+		r.UnstableRationaleSort,
+		r.UnstableResponsibilitySort,
+		r.UnstableEdgeSort,
+		r.UnstableNamedOwnerSort,
+		r.UnstableMisplacedGuardSort,
+		r.UnstablePublicSurfaceSort,
+		r.UnstableOwnedRoleSort,
+	)
+}
+
+func countStrings(groups ...[]string) int {
+	count := 0
+	for _, group := range groups {
+		count += len(group)
+	}
+	return count
+}
+
+func countFlags(flags ...bool) int {
+	count := 0
+	for _, flag := range flags {
+		if flag {
+			count++
+		}
+	}
+	return count
+}
+
 // OK reports whether validation found no defects.
 func (r Report) OK() bool {
 	return len(r.MissingPackages) == 0 &&

--- a/internal/ownershipinventory/validate_test.go
+++ b/internal/ownershipinventory/validate_test.go
@@ -33,6 +33,21 @@ func TestValidateFailsWhenProductionPackageMissing(t *testing.T) {
 	}
 }
 
+func TestViolationCountCountsStructuredFindingsIndividually(t *testing.T) {
+	report := ownershipinventory.Report{
+		MissingPackages:             []string{"pkg/a", "pkg/b"},
+		MissingCrossServiceEdges:    []string{"runtime->models", "recordings->events"},
+		UnexpectedCrossServiceEdges: []string{"workers->sessions"},
+	}
+	if got := report.ViolationCount(); got != 5 {
+		t.Fatalf("ViolationCount() = %d, want 5 structured findings", got)
+	}
+	report.MissingPackages = append(report.MissingPackages, "pkg/c")
+	if got := report.ViolationCount(); got != 6 {
+		t.Fatalf("ViolationCount() after one added package = %d, want 6", got)
+	}
+}
+
 func TestValidateFailsWhenPackageDuplicated(t *testing.T) {
 	inventory, packages := loadedInventoryAndPackages(t)
 	dup := inventory.Packages[0]

--- a/pkg/root/backend_lint_proof_test.go
+++ b/pkg/root/backend_lint_proof_test.go
@@ -1,0 +1,1 @@
+package root

--- a/pkg/root/backend_lint_proof_test.go
+++ b/pkg/root/backend_lint_proof_test.go
@@ -1,1 +1,0 @@
-package root

--- a/scripts/ci/backend-lint-policy.mjs
+++ b/scripts/ci/backend-lint-policy.mjs
@@ -20,22 +20,22 @@ export const BACKEND_LINT_ALLOWANCES = Object.freeze({
 		removalCondition: "Split the two oversized tests without changing the checker limit, then delete this allowance when hosted backend-size passes.",
 	},
 	"package-target-manifest-check": {
-		baselineViolationCount: 3,
-		reason: "The current package inventory omits the factory_definitions runtime_snapshot package entries.",
+		baselineViolationCount: 5,
+		reason: "The current package inventory omits five production package entries from the live tree, including the factory_definitions runtime_snapshot migration paths.",
 		ownerOrLane: "Factory Definitions package inventory remediation lane",
 		deadline: "2026-10-15",
 		removalCondition: "Reconcile the package inventory with the production tree, then delete this allowance when hosted package-target-manifest-check passes.",
 	},
 	"packaged-factory-consumption-check": {
-		baselineViolationCount: 4,
-		reason: "The migration-ledger matrix directly imports packaged-factories instead of using the catalog boundary.",
+		baselineViolationCount: 1,
+		reason: "The migration-ledger matrix has one direct packaged-factories import instead of using the catalog boundary.",
 		ownerOrLane: "Packaged-factory consumption-boundary remediation lane",
 		deadline: "2026-10-15",
 		removalCondition: "Route the matrix through the Factory Definitions catalog boundary, then delete this allowance when hosted packaged-factory-consumption-check passes.",
 	},
 	"ownership-inventory-check": {
-		baselineViolationCount: 5,
-		reason: "The 2026-08-08 packaged-service-structure migration debt leaves the ownership inventory and cross-service edges incomplete.",
+		baselineViolationCount: 16,
+		reason: "The 2026-08-08 packaged-service-structure migration debt has 9 missing package entries, 5 missing cross-service edges, and 2 unexpected edges.",
 		ownerOrLane: "Packaged-service structure migration / ownership inventory lane",
 		deadline: "2026-10-31",
 		removalCondition: "Reconcile the migrated package and edge inventory, then delete this allowance when hosted ownership-inventory-check passes.",
@@ -53,6 +53,9 @@ function allowanceStatus(target, allowance) {
 	if (target.status === "pass") {
 		return "clean";
 	}
+	if (!Number.isSafeInteger(target.violationCount) || target.violationCount < 0) {
+		return "unmeasured";
+	}
 	if (!allowance) {
 		return "new failure";
 	}
@@ -66,7 +69,11 @@ export function evaluateBackendLintPolicy(targets) {
 	const evaluatedTargets = targets.map((target) => {
 		const allowance = BACKEND_LINT_ALLOWANCES[target.name];
 		const status = allowanceStatus(target, allowance);
-		if (status === "new failure") {
+		if (status === "unmeasured") {
+			failures.push(
+				`${target.name} failed without a reliable machine-readable violation count; its baseline allowance cannot be applied.`,
+			);
+		} else if (status === "new failure") {
 			failures.push(
 				`${target.name} failed with ${target.violationCount} reported violation(s); no baseline allowance exists.`,
 			);

--- a/scripts/ci/backend-lint-policy.mjs
+++ b/scripts/ci/backend-lint-policy.mjs
@@ -1,0 +1,109 @@
+export const BACKEND_LINT_BASELINE_SOURCE =
+	"Hosted Backend Lint run 31868290619 on 2026-08-15 (baseline head 2746c037fd4e061b04df83ec434bf6fe11276038)";
+
+// These are measured current-main failures, not extra capacity. A failing
+// checker is allowed only while its observed count remains at or below the
+// recorded count; a clean checker and any unlisted failure remain gated.
+export const BACKEND_LINT_ALLOWANCES = Object.freeze({
+	"ui-deadcode": {
+		baselineViolationCount: 11,
+		reason: "The hosted baseline found pre-existing unused frontend test-support fixtures.",
+		ownerOrLane: "Frontend dead-code cleanup lane",
+		deadline: "2026-09-30",
+		removalCondition: "Remove the unused fixtures, then delete this allowance when hosted ui-deadcode reports zero violations.",
+	},
+	"backend-size": {
+		baselineViolationCount: 2,
+		reason: "Two pre-existing tests exceed the unchanged 100-line function limit.",
+		ownerOrLane: "Backend-size remediation lane; preserve cmd/gocoveragecheck ownership from PR #1980",
+		deadline: "2026-09-30",
+		removalCondition: "Split the two oversized tests without changing the checker limit, then delete this allowance when hosted backend-size passes.",
+	},
+	"package-target-manifest-check": {
+		baselineViolationCount: 3,
+		reason: "The current package inventory omits the factory_definitions runtime_snapshot package entries.",
+		ownerOrLane: "Factory Definitions package inventory remediation lane",
+		deadline: "2026-10-15",
+		removalCondition: "Reconcile the package inventory with the production tree, then delete this allowance when hosted package-target-manifest-check passes.",
+	},
+	"packaged-factory-consumption-check": {
+		baselineViolationCount: 4,
+		reason: "The migration-ledger matrix directly imports packaged-factories instead of using the catalog boundary.",
+		ownerOrLane: "Packaged-factory consumption-boundary remediation lane",
+		deadline: "2026-10-15",
+		removalCondition: "Route the matrix through the Factory Definitions catalog boundary, then delete this allowance when hosted packaged-factory-consumption-check passes.",
+	},
+	"ownership-inventory-check": {
+		baselineViolationCount: 5,
+		reason: "The 2026-08-08 packaged-service-structure migration debt leaves the ownership inventory and cross-service edges incomplete.",
+		ownerOrLane: "Packaged-service structure migration / ownership inventory lane",
+		deadline: "2026-10-31",
+		removalCondition: "Reconcile the migrated package and edge inventory, then delete this allowance when hosted ownership-inventory-check passes.",
+	},
+	deadcode: {
+		baselineViolationCount: 580,
+		reason: "The hosted baseline reports 580 existing dead-code findings against the repository baseline.",
+		ownerOrLane: "Repository dead-code cleanup lane",
+		deadline: "2026-12-31",
+		removalCondition: "Remove or review the existing findings and update the source baseline intentionally, then delete this allowance when hosted deadcode reports zero drift.",
+	},
+});
+
+function allowanceStatus(target, allowance) {
+	if (target.status === "pass") {
+		return "clean";
+	}
+	if (!allowance) {
+		return "new failure";
+	}
+	return target.violationCount <= allowance.baselineViolationCount
+		? "allowed"
+		: "exceeded";
+}
+
+export function evaluateBackendLintPolicy(targets) {
+	const failures = [];
+	const evaluatedTargets = targets.map((target) => {
+		const allowance = BACKEND_LINT_ALLOWANCES[target.name];
+		const status = allowanceStatus(target, allowance);
+		if (status === "new failure") {
+			failures.push(
+				`${target.name} failed with ${target.violationCount} reported violation(s); no baseline allowance exists.`,
+			);
+		} else if (status === "exceeded") {
+			failures.push(
+				`${target.name} reported ${target.violationCount} violation(s), exceeding its baseline allowance of ${allowance.baselineViolationCount}.`,
+			);
+		}
+
+		return {
+			...target,
+			policyStatus: status,
+			baselineViolationCount: allowance?.baselineViolationCount ?? null,
+			allowance,
+		};
+	});
+
+	for (const name of Object.keys(BACKEND_LINT_ALLOWANCES)) {
+		if (!evaluatedTargets.some((target) => target.name === name)) {
+			failures.push(`${name} has a baseline allowance but was not observed in the lint report.`);
+		}
+	}
+
+	const allowances = Object.entries(BACKEND_LINT_ALLOWANCES).map(([name, allowance]) => {
+		const target = evaluatedTargets.find((item) => item.name === name);
+		return {
+			name,
+			...allowance,
+			observedViolationCount: target?.violationCount ?? null,
+			status: target ? allowanceStatus(target, allowance) : "not observed",
+		};
+	});
+
+	return {
+		ok: failures.length === 0,
+		failures,
+		targets: evaluatedTargets,
+		allowances,
+	};
+}

--- a/scripts/ci/backend-lint-policy.mjs
+++ b/scripts/ci/backend-lint-policy.mjs
@@ -1,12 +1,12 @@
 export const BACKEND_LINT_BASELINE_SOURCE =
-	"Hosted Backend Lint run 31868290619 on 2026-08-15 (baseline head 2746c037fd4e061b04df83ec434bf6fe11276038)";
+	"Hosted Backend Lint run 31870641599 on 2026-08-15 (rebased current-main baseline head 925e9d74a7702bd6b562812fb8db4ac47348bb4f)";
 
 // These are measured current-main failures, not extra capacity. A failing
 // checker is allowed only while its observed count remains at or below the
 // recorded count; a clean checker and any unlisted failure remain gated.
 export const BACKEND_LINT_ALLOWANCES = Object.freeze({
 	"ui-deadcode": {
-		baselineViolationCount: 11,
+		baselineViolationCount: 12,
 		reason: "The hosted baseline found pre-existing unused frontend test-support fixtures.",
 		ownerOrLane: "Frontend dead-code cleanup lane",
 		deadline: "2026-09-30",

--- a/scripts/ci/backend-lint-policy.mjs
+++ b/scripts/ci/backend-lint-policy.mjs
@@ -1,13 +1,13 @@
 export const BACKEND_LINT_BASELINE_SOURCE =
-	"Hosted Backend Lint run 31870641599 on 2026-08-15 (rebased current-main baseline head 925e9d74a7702bd6b562812fb8db4ac47348bb4f)";
+	"Hosted Backend Lint run 31873961077 on 2026-08-15 (semantic baseline observed on rebased head 3e625b9a10f3edc9550786d26798cce165d7adc6)";
 
 // These are measured current-main failures, not extra capacity. A failing
 // checker is allowed only while its observed count remains at or below the
 // recorded count; a clean checker and any unlisted failure remain gated.
 export const BACKEND_LINT_ALLOWANCES = Object.freeze({
 	"ui-deadcode": {
-		baselineViolationCount: 12,
-		reason: "The hosted baseline found pre-existing unused frontend test-support fixtures.",
+		baselineViolationCount: 4,
+		reason: "The hosted semantic baseline found four pre-existing unused frontend test-support fixtures.",
 		ownerOrLane: "Frontend dead-code cleanup lane",
 		deadline: "2026-09-30",
 		removalCondition: "Remove the unused fixtures, then delete this allowance when hosted ui-deadcode reports zero violations.",

--- a/scripts/ci/backend-lint-report.mjs
+++ b/scripts/ci/backend-lint-report.mjs
@@ -2,6 +2,11 @@ import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 
+import {
+	BACKEND_LINT_BASELINE_SOURCE,
+	evaluateBackendLintPolicy,
+} from "./backend-lint-policy.mjs";
+
 const REPORT_VERSION = 1;
 const DIAGNOSTIC_PREVIEW_LIMIT = 4000;
 export const BACKEND_LINT_COMMENT_MARKER = "<!-- backend-lint-report -->";
@@ -76,6 +81,8 @@ export function summarizeBackendLintReport(report, options = {}) {
 			error: reportErrorSummary(options.error, options.log),
 			totalDurationMillis: 0,
 			jobs: null,
+			baselineSource: BACKEND_LINT_BASELINE_SOURCE,
+			allowances: [],
 		};
 	}
 
@@ -92,14 +99,14 @@ export function summarizeBackendLintReport(report, options = {}) {
 			error: textValue(target.error),
 		};
 	});
-	const failures = targets
-		.filter((target) => target.status !== "pass")
-		.map((target) => `${target.name} failed with ${target.violationCount} reported violation(s).`);
+	const policy = evaluateBackendLintPolicy(targets);
 
 	return {
-		ok: failures.length === 0,
-		targets,
-		failures,
+		ok: policy.ok,
+		targets: policy.targets,
+		failures: policy.failures,
+		baselineSource: BACKEND_LINT_BASELINE_SOURCE,
+		allowances: policy.allowances,
 		totalDurationMillis: numericValue(report.totalDurationMillis),
 		jobs: Number.isInteger(report.jobs) ? report.jobs : null,
 	};
@@ -121,29 +128,58 @@ function preview(text) {
 	return `${safe.slice(0, DIAGNOSTIC_PREVIEW_LIMIT)}\n... truncated; full output is in the uploaded artifact.`;
 }
 
+function formatMarkdownCell(value) {
+	return textValue(value)
+		.replaceAll("|", "\\|")
+		.replaceAll("\r", "")
+		.replaceAll("\n", " ") || "(none)";
+}
+
 export function renderBackendLintSummary(summary) {
 	const lines = [
 		"## Backend Lint",
 		"",
 		`- Result: \`${summary.ok ? "passed" : "failed"}\``,
 		`- Canonical checkers observed: \`${summary.targets.length}\``,
+		`- Clean checkers gated: \`${summary.targets.filter((target) => target.policyStatus === "clean").length}\``,
+		`- Allowed baseline debt: \`${summary.targets.filter((target) => target.policyStatus === "allowed").length}\` checker(s) within measured limits`,
+		`- Baseline source: ${summary.baselineSource || "not recorded"}`,
 		`- LINT_JOBS: \`${summary.jobs ?? "unknown"}\``,
 		`- Total Backend Lint wall time: \`${formatDuration(summary.totalDurationMillis)}\``,
 		"",
-		"| Checker | Result | Violations | Wall time |",
-		"| --- | --- | ---: | ---: |",
+		"| Checker | Result | Violations | Wall time | Policy |",
+		"| --- | --- | ---: | ---: | --- |",
 	];
 	for (const target of summary.targets) {
 		lines.push(
-			`| ${target.name} | \`${target.status}\` | ${target.violationCount} | ${formatDuration(target.durationMillis)} |`,
+			`| ${target.name} | \`${target.status}\` | ${target.violationCount} | ${formatDuration(target.durationMillis)} | ${target.policyStatus || "unknown"} |`,
 		);
 	}
 
-	if (summary.failures.length > 0) {
+	lines.push(
+		"",
+		"### Baseline allowances",
+		"",
+		"Allowances are capped measured debt; they do not permit new checker failures or growth.",
+		"",
+		"| Checker | Baseline | Observed | Status | Reason | Owner/remediation lane | Deadline | Removal condition |",
+		"| --- | ---: | ---: | --- | --- | --- | --- | --- |",
+	);
+	for (const allowance of summary.allowances || []) {
+		lines.push(
+			`| ${allowance.name} | ${allowance.baselineViolationCount} | ${allowance.observedViolationCount ?? "not observed"} | ${allowance.status} | ${formatMarkdownCell(allowance.reason)} | ${formatMarkdownCell(allowance.ownerOrLane)} | ${allowance.deadline} | ${formatMarkdownCell(allowance.removalCondition)} |`,
+		);
+	}
+	if (!(summary.allowances || []).length) {
+		lines.push("| (none) | — | — | — | No baseline allowances loaded. | — | — | — |");
+	}
+
+	const failedTargets = summary.targets.filter((target) => target.status !== "pass");
+	if (failedTargets.length > 0) {
 		lines.push("", "### Failed checker diagnostics", "");
-		for (const target of summary.targets.filter((item) => item.status !== "pass")) {
+		for (const target of failedTargets) {
 			lines.push(
-				`<details><summary>${target.name}: ${target.violationCount} reported violation(s)</summary>`,
+				`<details><summary>${target.name}: ${target.violationCount} reported violation(s) (${target.policyStatus || "ungated"})</summary>`,
 				"",
 				"```text",
 				preview(target.output || target.error),

--- a/scripts/ci/backend-lint-report.mjs
+++ b/scripts/ci/backend-lint-report.mjs
@@ -206,7 +206,7 @@ function runCli() {
 	const markdown = renderBackendLintSummary(summary);
 	appendFileSync(summaryPath, markdown);
 	writeFileSync(commentPath, renderBackendLintComment(summary, {
-		headSha: process.env.GITHUB_SHA,
+		headSha: process.env.BACKEND_LINT_HEAD_SHA || process.env.GITHUB_SHA,
 		runUrl: process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
 			? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
 			: "",

--- a/scripts/ci/backend-lint-report.mjs
+++ b/scripts/ci/backend-lint-report.mjs
@@ -1,0 +1,221 @@
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+const REPORT_VERSION = 1;
+const DIAGNOSTIC_PREVIEW_LIMIT = 4000;
+export const BACKEND_LINT_COMMENT_MARKER = "<!-- backend-lint-report -->";
+
+function textValue(value) {
+	return String(value ?? "").trim();
+}
+
+function numericValue(value, fallback = 0) {
+	const number = Number(value);
+	return Number.isFinite(number) ? number : fallback;
+}
+
+function normalizedStatus(value) {
+	return ["pass", "passed", "success"].includes(textValue(value).toLowerCase())
+		? "pass"
+		: "fail";
+}
+
+function explicitViolationCount(output) {
+	const currentFindings = /current findings\s*:\s*(\d+)/i.exec(output);
+	if (currentFindings) {
+		return Number(currentFindings[1]);
+	}
+
+	const matches = [
+		...output.matchAll(
+			/(?:found|reported|detected)\s+(\d+)\s+[^\n]*(?:violation|finding|error|issue)/gi,
+		),
+	];
+	if (matches.length > 0) {
+		return Number(matches.at(-1)[1]);
+	}
+	return null;
+}
+
+function diagnosticLineCount(output) {
+	const lines = output
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0)
+		.filter((line) => !line.startsWith("====="))
+		.filter((line) => !line.startsWith("command error:"))
+		.filter((line) => !/^exit status \d+$/i.test(line));
+	return Math.max(1, lines.length);
+}
+
+export function countViolations(target) {
+	if (normalizedStatus(target?.status) === "pass") {
+		return { count: 0, source: "successful-check" };
+	}
+
+	const output = textValue(target?.output);
+	const explicit = explicitViolationCount(output);
+	if (explicit !== null) {
+		return { count: explicit, source: "checker-output" };
+	}
+	return { count: diagnosticLineCount(output), source: "diagnostic-lines" };
+}
+
+function reportErrorSummary(error, log) {
+	const details = textValue(error) || textValue(log);
+	return details ? `Backend Lint could not produce its report: ${details}` : "Backend Lint did not produce a report.";
+}
+
+export function summarizeBackendLintReport(report, options = {}) {
+	if (!report || report.version !== REPORT_VERSION || !Array.isArray(report.targets)) {
+		return {
+			ok: false,
+			targets: [],
+			failures: [reportErrorSummary(options.error, options.log)],
+			error: reportErrorSummary(options.error, options.log),
+			totalDurationMillis: 0,
+			jobs: null,
+		};
+	}
+
+	const targets = report.targets.map((target) => {
+		const status = normalizedStatus(target.status);
+		const violation = countViolations(target);
+		return {
+			name: textValue(target.name) || "(unnamed checker)",
+			status,
+			violationCount: violation.count,
+			violationSource: violation.source,
+			durationMillis: numericValue(target.durationMillis),
+			output: textValue(target.output),
+			error: textValue(target.error),
+		};
+	});
+	const failures = targets
+		.filter((target) => target.status !== "pass")
+		.map((target) => `${target.name} failed with ${target.violationCount} reported violation(s).`);
+
+	return {
+		ok: failures.length === 0,
+		targets,
+		failures,
+		totalDurationMillis: numericValue(report.totalDurationMillis),
+		jobs: Number.isInteger(report.jobs) ? report.jobs : null,
+	};
+}
+
+export function formatDuration(milliseconds) {
+	const duration = Math.max(0, numericValue(milliseconds));
+	if (duration < 1000) {
+		return `${Math.round(duration)}ms`;
+	}
+	return `${(duration / 1000).toFixed(2)}s`;
+}
+
+function preview(text) {
+	const safe = textValue(text).replaceAll("```", "``\\`");
+	if (safe.length <= DIAGNOSTIC_PREVIEW_LIMIT) {
+		return safe || "(no checker output was captured)";
+	}
+	return `${safe.slice(0, DIAGNOSTIC_PREVIEW_LIMIT)}\n... truncated; full output is in the uploaded artifact.`;
+}
+
+export function renderBackendLintSummary(summary) {
+	const lines = [
+		"## Backend Lint",
+		"",
+		`- Result: \`${summary.ok ? "passed" : "failed"}\``,
+		`- Canonical checkers observed: \`${summary.targets.length}\``,
+		`- LINT_JOBS: \`${summary.jobs ?? "unknown"}\``,
+		`- Total Backend Lint wall time: \`${formatDuration(summary.totalDurationMillis)}\``,
+		"",
+		"| Checker | Result | Violations | Wall time |",
+		"| --- | --- | ---: | ---: |",
+	];
+	for (const target of summary.targets) {
+		lines.push(
+			`| ${target.name} | \`${target.status}\` | ${target.violationCount} | ${formatDuration(target.durationMillis)} |`,
+		);
+	}
+
+	if (summary.failures.length > 0) {
+		lines.push("", "### Failed checker diagnostics", "");
+		for (const target of summary.targets.filter((item) => item.status !== "pass")) {
+			lines.push(
+				`<details><summary>${target.name}: ${target.violationCount} reported violation(s)</summary>`,
+				"",
+				"```text",
+				preview(target.output || target.error),
+				"```",
+				"",
+				"</details>",
+				"",
+			);
+		}
+	}
+
+	if (summary.error) {
+		lines.push("", `> ${summary.error}`);
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+export function renderBackendLintComment(summary, metadata = {}) {
+	const lines = [BACKEND_LINT_COMMENT_MARKER, renderBackendLintSummary(summary).trim()];
+	if (textValue(metadata.headSha)) {
+		lines.push(`- Hosted head: \`${textValue(metadata.headSha)}\``);
+	}
+	if (textValue(metadata.runUrl)) {
+		lines.push(`- Hosted run: ${textValue(metadata.runUrl)}`);
+	}
+	return `${lines.join("\n\n")}\n`;
+}
+
+function readReport(reportPath, logPath) {
+	let log = "";
+	if (logPath) {
+		try {
+			log = readFileSync(logPath, "utf8");
+		} catch {
+			log = "";
+		}
+	}
+	try {
+		return { report: JSON.parse(readFileSync(reportPath, "utf8")), log };
+	} catch (error) {
+		return { report: null, log, error: error.message };
+	}
+}
+
+function optionValue(args, name) {
+	const index = args.indexOf(name);
+	if (index === -1 || !args[index + 1]) {
+		throw new Error(`missing ${name} value`);
+	}
+	return args[index + 1];
+}
+
+function runCli() {
+	const args = process.argv.slice(2);
+	const reportPath = optionValue(args, "--report");
+	const summaryPath = optionValue(args, "--summary");
+	const commentPath = optionValue(args, "--comment");
+	const input = readReport(reportPath, args.includes("--log") ? optionValue(args, "--log") : "");
+	const summary = summarizeBackendLintReport(input.report, input);
+	const markdown = renderBackendLintSummary(summary);
+	appendFileSync(summaryPath, markdown);
+	writeFileSync(commentPath, renderBackendLintComment(summary, {
+		headSha: process.env.GITHUB_SHA,
+		runUrl: process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
+			? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+			: "",
+	}));
+	if (!summary.ok) {
+		process.exitCode = 1;
+	}
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+	runCli();
+}

--- a/scripts/ci/backend-lint-report.mjs
+++ b/scripts/ci/backend-lint-report.mjs
@@ -26,32 +26,23 @@ function normalizedStatus(value) {
 		: "fail";
 }
 
-function explicitViolationCount(output) {
-	const currentFindings = /current findings\s*:\s*(\d+)/i.exec(output);
-	if (currentFindings) {
-		return Number(currentFindings[1]);
+function machineReadableViolationCount(target) {
+	if (Number.isSafeInteger(target?.violationCount) && target.violationCount >= 0) {
+		return {
+			count: target.violationCount,
+			source: target.violationCountSource || "checker-report",
+		};
 	}
 
-	const matches = [
-		...output.matchAll(
-			/(?:found|reported|detected)\s+(\d+)\s+[^\n]*(?:violation|finding|error|issue)/gi,
-		),
-	];
-	if (matches.length > 0) {
-		return Number(matches.at(-1)[1]);
+	const matches = textValue(target?.output).match(/^\s*LINT_VIOLATION_COUNT:\s*(\d+)\s*$/gim) || [];
+	if (matches.length !== 1) {
+		return null;
 	}
-	return null;
-}
-
-function diagnosticLineCount(output) {
-	const lines = output
-		.split(/\r?\n/)
-		.map((line) => line.trim())
-		.filter((line) => line.length > 0)
-		.filter((line) => !line.startsWith("====="))
-		.filter((line) => !line.startsWith("command error:"))
-		.filter((line) => !/^exit status \d+$/i.test(line));
-	return Math.max(1, lines.length);
+	const count = Number(matches[0].replace(/^\s*LINT_VIOLATION_COUNT:\s*/i, ""));
+	if (!Number.isSafeInteger(count) || count < 0) {
+		return null;
+	}
+	return { count, source: "checker-marker" };
 }
 
 export function countViolations(target) {
@@ -59,12 +50,11 @@ export function countViolations(target) {
 		return { count: 0, source: "successful-check" };
 	}
 
-	const output = textValue(target?.output);
-	const explicit = explicitViolationCount(output);
-	if (explicit !== null) {
-		return { count: explicit, source: "checker-output" };
+	const measured = machineReadableViolationCount(target);
+	if (measured) {
+		return measured;
 	}
-	return { count: diagnosticLineCount(output), source: "diagnostic-lines" };
+	return { count: null, source: "unavailable" };
 }
 
 function reportErrorSummary(error, log) {
@@ -152,7 +142,7 @@ export function renderBackendLintSummary(summary) {
 	];
 	for (const target of summary.targets) {
 		lines.push(
-			`| ${target.name} | \`${target.status}\` | ${target.violationCount} | ${formatDuration(target.durationMillis)} | ${target.policyStatus || "unknown"} |`,
+			`| ${target.name} | \`${target.status}\` | ${target.violationCount ?? "unknown"} | ${formatDuration(target.durationMillis)} | ${target.policyStatus || "unknown"} |`,
 		);
 	}
 
@@ -179,7 +169,7 @@ export function renderBackendLintSummary(summary) {
 		lines.push("", "### Failed checker diagnostics", "");
 		for (const target of failedTargets) {
 			lines.push(
-				`<details><summary>${target.name}: ${target.violationCount} reported violation(s) (${target.policyStatus || "ungated"})</summary>`,
+				`<details><summary>${target.name}: ${target.violationCount ?? "unknown"} reported violation(s) (${target.policyStatus || "ungated"})</summary>`,
 				"",
 				"```text",
 				preview(target.output || target.error),

--- a/scripts/ci/backend-lint-report.test.mjs
+++ b/scripts/ci/backend-lint-report.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	BACKEND_LINT_COMMENT_MARKER,
+	countViolations,
+	renderBackendLintComment,
+	renderBackendLintSummary,
+	summarizeBackendLintReport,
+} from "./backend-lint-report.mjs";
+
+function report(overrides = {}) {
+	return {
+		version: 1,
+		jobs: 4,
+		totalDurationMillis: 12345,
+		targets: [
+			{
+				name: "clean-check",
+				status: "pass",
+				durationMillis: 1200,
+				output: "checker passed",
+			},
+			{
+				name: "broken-check",
+				status: "fail",
+				durationMillis: 3400,
+				output: "[agent-factory:broken] found 2 rule violation(s)\nfile.go:12",
+			},
+			{
+				name: "second-broken-check",
+				status: "fail",
+				durationMillis: 700,
+				output: "- first diagnostic\n- second diagnostic",
+			},
+		],
+		...overrides,
+	};
+}
+
+test("mixed hosted results retain the complete inventory and derive counts", () => {
+	const summary = summarizeBackendLintReport(report());
+
+	assert.equal(summary.ok, false);
+	assert.deepEqual(summary.targets.map((target) => target.name), [
+		"clean-check",
+		"broken-check",
+		"second-broken-check",
+	]);
+	assert.deepEqual(summary.targets.map((target) => target.violationCount), [0, 2, 2]);
+	assert.match(renderBackendLintSummary(summary), /Total Backend Lint wall time: `12\.35s`/);
+	assert.match(renderBackendLintSummary(summary), /\| clean-check \| `pass` \| 0 \|/);
+	assert.match(renderBackendLintSummary(summary), /\| broken-check \| `fail` \| 2 \|/);
+	assert.match(renderBackendLintSummary(summary), /Failed checker diagnostics/);
+});
+
+test("a successful checker always reports zero violations", () => {
+	assert.deepEqual(
+		countViolations({ status: "success", output: "found 99 stale words" }),
+		{ count: 0, source: "successful-check" },
+	);
+});
+
+test("missing or malformed hosted reports fail closed", () => {
+	const summary = summarizeBackendLintReport(null, {
+		error: "ENOENT",
+		log: "make lint could not start",
+	});
+
+	assert.equal(summary.ok, false);
+	assert.equal(summary.targets.length, 0);
+	assert.match(renderBackendLintSummary(summary), /could not produce its report/);
+});
+
+test("PR publication includes a stable marker and hosted identity", () => {
+	const comment = renderBackendLintComment(summarizeBackendLintReport(report()), {
+		headSha: "abc123",
+		runUrl: "https://github.com/example/repo/actions/runs/42",
+	});
+
+	assert.match(comment, new RegExp(BACKEND_LINT_COMMENT_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+	assert.match(comment, /Hosted head: `abc123`/);
+	assert.match(comment, /actions\/runs\/42/);
+});

--- a/scripts/ci/backend-lint-report.test.mjs
+++ b/scripts/ci/backend-lint-report.test.mjs
@@ -78,7 +78,7 @@ test("a measured baseline failure is reported but allowed at its recorded count"
 		targets: baselineTargets({
 			"ui-deadcode": {
 				status: "fail",
-				output: "Frontend dead-code baseline drift detected\nLINT_VIOLATION_COUNT: 12\ncurrent findings: 12",
+				output: "Frontend dead-code baseline drift detected\nLINT_VIOLATION_COUNT: 4\ncurrent findings: 4",
 			},
 		}),
 	}));
@@ -87,7 +87,7 @@ test("a measured baseline failure is reported but allowed at its recorded count"
 	assert.equal(summary.ok, true);
 	assert.equal(summary.targets.find((target) => target.name === "ui-deadcode").policyStatus, "allowed");
 	assert.match(markdown, /Allowed baseline debt: `1` checker\(s\) within measured limits/);
-	assert.match(markdown, /\| ui-deadcode \| 12 \| 12 \| allowed \|/);
+	assert.match(markdown, /\| ui-deadcode \| 4 \| 4 \| allowed \|/);
 });
 
 test("baseline growth fails the gate instead of being hidden by an allowance", () => {
@@ -101,7 +101,7 @@ test("baseline growth fails the gate instead of being hidden by an allowance", (
 	}));
 
 	assert.equal(summary.ok, false);
-	assert.match(summary.failures.join("\n"), /ui-deadcode reported 13 violation\(s\), exceeding its baseline allowance of 12/);
+	assert.match(summary.failures.join("\n"), /ui-deadcode reported 13 violation\(s\), exceeding its baseline allowance of 4/);
 });
 
 test("a newly failing clean checker is gated immediately", () => {

--- a/scripts/ci/backend-lint-report.test.mjs
+++ b/scripts/ci/backend-lint-report.test.mjs
@@ -78,7 +78,7 @@ test("a measured baseline failure is reported but allowed at its recorded count"
 		targets: baselineTargets({
 			"ui-deadcode": {
 				status: "fail",
-				output: "Frontend dead-code baseline drift detected; current findings: 11",
+				output: "Frontend dead-code baseline drift detected; current findings: 12",
 			},
 		}),
 	}));
@@ -87,7 +87,7 @@ test("a measured baseline failure is reported but allowed at its recorded count"
 	assert.equal(summary.ok, true);
 	assert.equal(summary.targets.find((target) => target.name === "ui-deadcode").policyStatus, "allowed");
 	assert.match(markdown, /Allowed baseline debt: `1` checker\(s\) within measured limits/);
-	assert.match(markdown, /\| ui-deadcode \| 11 \| 11 \| allowed \|/);
+	assert.match(markdown, /\| ui-deadcode \| 12 \| 12 \| allowed \|/);
 });
 
 test("baseline growth fails the gate instead of being hidden by an allowance", () => {
@@ -95,13 +95,13 @@ test("baseline growth fails the gate instead of being hidden by an allowance", (
 		targets: baselineTargets({
 			"ui-deadcode": {
 				status: "fail",
-				output: "Frontend dead-code baseline drift detected; current findings: 12",
+				output: "Frontend dead-code baseline drift detected; current findings: 13",
 			},
 		}),
 	}));
 
 	assert.equal(summary.ok, false);
-	assert.match(summary.failures.join("\n"), /ui-deadcode reported 12 violation\(s\), exceeding its baseline allowance of 11/);
+	assert.match(summary.failures.join("\n"), /ui-deadcode reported 13 violation\(s\), exceeding its baseline allowance of 12/);
 });
 
 test("a newly failing clean checker is gated immediately", () => {

--- a/scripts/ci/backend-lint-report.test.mjs
+++ b/scripts/ci/backend-lint-report.test.mjs
@@ -26,13 +26,13 @@ function report(overrides = {}) {
 				name: "broken-check",
 				status: "fail",
 				durationMillis: 3400,
-				output: "[agent-factory:broken] found 2 rule violation(s)\nfile.go:12",
+				output: "[agent-factory:broken] found 2 rule violation(s)\nLINT_VIOLATION_COUNT: 2\nfile.go:12",
 			},
 			{
 				name: "second-broken-check",
 				status: "fail",
 				durationMillis: 700,
-				output: "- first diagnostic\n- second diagnostic",
+				output: "- first diagnostic\nLINT_VIOLATION_COUNT: 2\n- second diagnostic",
 			},
 		],
 		...overrides,
@@ -78,7 +78,7 @@ test("a measured baseline failure is reported but allowed at its recorded count"
 		targets: baselineTargets({
 			"ui-deadcode": {
 				status: "fail",
-				output: "Frontend dead-code baseline drift detected; current findings: 12",
+				output: "Frontend dead-code baseline drift detected\nLINT_VIOLATION_COUNT: 12\ncurrent findings: 12",
 			},
 		}),
 	}));
@@ -95,7 +95,7 @@ test("baseline growth fails the gate instead of being hidden by an allowance", (
 		targets: baselineTargets({
 			"ui-deadcode": {
 				status: "fail",
-				output: "Frontend dead-code baseline drift detected; current findings: 13",
+				output: "Frontend dead-code baseline drift detected\nLINT_VIOLATION_COUNT: 13\ncurrent findings: 13",
 			},
 		}),
 	}));
@@ -112,7 +112,7 @@ test("a newly failing clean checker is gated immediately", () => {
 				name: "new-clean-check",
 				status: "fail",
 				durationMillis: 100,
-				output: "found 1 new violation(s)",
+				output: "found 1 new violation(s)\nLINT_VIOLATION_COUNT: 1",
 			},
 		],
 	}));
@@ -126,6 +126,38 @@ test("a successful checker always reports zero violations", () => {
 		countViolations({ status: "success", output: "found 99 stale words" }),
 		{ count: 0, source: "successful-check" },
 	);
+});
+
+test("a failed checker without a machine-readable count fails closed", () => {
+	const summary = summarizeBackendLintReport(report({
+		targets: baselineTargets({
+			"ownership-inventory-check": {
+				status: "fail",
+				output: "Report{MissingPackages:[]string{\"pkg/a\", \"pkg/b\"}}",
+			},
+		}),
+	}));
+
+	assert.equal(summary.ok, false);
+	assert.equal(summary.targets.find((target) => target.name === "ownership-inventory-check").violationCount, null);
+	assert.match(summary.failures.join("\n"), /without a reliable machine-readable violation count/);
+});
+
+test("structured finding growth exceeds the ownership allowance even on one diagnostic line", () => {
+	const ownershipTarget = (count) => ({
+		status: "fail",
+		output: `inventory report: Report{MissingPackages:[]string{${Array.from({ length: count }, (_, index) => `\"finding-${index}\"`).join(", ")}}}\nLINT_VIOLATION_COUNT: ${count}`,
+	});
+	const baseline = summarizeBackendLintReport(report({
+		targets: baselineTargets({ "ownership-inventory-check": ownershipTarget(16) }),
+	}));
+	const grown = summarizeBackendLintReport(report({
+		targets: baselineTargets({ "ownership-inventory-check": ownershipTarget(17) }),
+	}));
+
+	assert.equal(baseline.ok, true);
+	assert.equal(grown.ok, false);
+	assert.match(grown.failures.join("\n"), /ownership-inventory-check reported 17 violation\(s\), exceeding its baseline allowance of 16/);
 });
 
 test("missing or malformed hosted reports fail closed", () => {

--- a/scripts/ci/backend-lint-report.test.mjs
+++ b/scripts/ci/backend-lint-report.test.mjs
@@ -8,6 +8,7 @@ import {
 	renderBackendLintSummary,
 	summarizeBackendLintReport,
 } from "./backend-lint-report.mjs";
+import { BACKEND_LINT_ALLOWANCES } from "./backend-lint-policy.mjs";
 
 function report(overrides = {}) {
 	return {
@@ -38,6 +39,16 @@ function report(overrides = {}) {
 	};
 }
 
+function baselineTargets(overrides = {}) {
+	return Object.entries(BACKEND_LINT_ALLOWANCES).map(([name]) => ({
+		name,
+		status: "pass",
+		durationMillis: 100,
+		output: "checker passed",
+		...overrides[name],
+	}));
+}
+
 test("mixed hosted results retain the complete inventory and derive counts", () => {
 	const summary = summarizeBackendLintReport(report());
 
@@ -52,6 +63,62 @@ test("mixed hosted results retain the complete inventory and derive counts", () 
 	assert.match(renderBackendLintSummary(summary), /\| clean-check \| `pass` \| 0 \|/);
 	assert.match(renderBackendLintSummary(summary), /\| broken-check \| `fail` \| 2 \|/);
 	assert.match(renderBackendLintSummary(summary), /Failed checker diagnostics/);
+});
+
+test("all clean current-main checkers pass the baseline policy", () => {
+	const summary = summarizeBackendLintReport(report({ targets: baselineTargets() }));
+
+	assert.equal(summary.ok, true);
+	assert.equal(summary.failures.length, 0);
+	assert.equal(summary.targets.filter((target) => target.policyStatus === "clean").length, 6);
+});
+
+test("a measured baseline failure is reported but allowed at its recorded count", () => {
+	const summary = summarizeBackendLintReport(report({
+		targets: baselineTargets({
+			"ui-deadcode": {
+				status: "fail",
+				output: "Frontend dead-code baseline drift detected; current findings: 11",
+			},
+		}),
+	}));
+	const markdown = renderBackendLintSummary(summary);
+
+	assert.equal(summary.ok, true);
+	assert.equal(summary.targets.find((target) => target.name === "ui-deadcode").policyStatus, "allowed");
+	assert.match(markdown, /Allowed baseline debt: `1` checker\(s\) within measured limits/);
+	assert.match(markdown, /\| ui-deadcode \| 11 \| 11 \| allowed \|/);
+});
+
+test("baseline growth fails the gate instead of being hidden by an allowance", () => {
+	const summary = summarizeBackendLintReport(report({
+		targets: baselineTargets({
+			"ui-deadcode": {
+				status: "fail",
+				output: "Frontend dead-code baseline drift detected; current findings: 12",
+			},
+		}),
+	}));
+
+	assert.equal(summary.ok, false);
+	assert.match(summary.failures.join("\n"), /ui-deadcode reported 12 violation\(s\), exceeding its baseline allowance of 11/);
+});
+
+test("a newly failing clean checker is gated immediately", () => {
+	const summary = summarizeBackendLintReport(report({
+		targets: [
+			...baselineTargets(),
+			{
+				name: "new-clean-check",
+				status: "fail",
+				durationMillis: 100,
+				output: "found 1 new violation(s)",
+			},
+		],
+	}));
+
+	assert.equal(summary.ok, false);
+	assert.match(summary.failures.join("\n"), /new-clean-check failed with 1 reported violation\(s\); no baseline allowance exists/);
 });
 
 test("a successful checker always reports zero violations", () => {

--- a/scripts/ci/backend-lint-workflow.mjs
+++ b/scripts/ci/backend-lint-workflow.mjs
@@ -19,33 +19,6 @@ export function selectBackendLint({
 	};
 }
 
-export async function executeLintInventory(targets, runTarget) {
-	if (!Array.isArray(targets) || typeof runTarget !== "function") {
-		throw new TypeError("lint inventory requires targets and a runner");
-	}
-
-	const results = await Promise.all(
-		targets.map(async (name) => {
-			try {
-				const result = await runTarget(name);
-				return { name, status: "pass", ...result };
-			} catch (error) {
-				return {
-					name,
-					status: "fail",
-					output: "",
-					error: String(error?.message || error),
-				};
-			}
-		}),
-	);
-
-	return {
-		targets: results,
-		failed: results.filter((result) => result.status !== "pass"),
-	};
-}
-
 export function upsertBackendLintComment(comments, body, options = {}) {
 	const botLogin = options.botLogin || "github-actions[bot]";
 	const marker = options.marker || BACKEND_LINT_COMMENT_MARKER;

--- a/scripts/ci/backend-lint-workflow.mjs
+++ b/scripts/ci/backend-lint-workflow.mjs
@@ -1,0 +1,59 @@
+import { BACKEND_LINT_COMMENT_MARKER } from "./backend-lint-report.mjs";
+
+export const BACKEND_LINT_EVENTS = Object.freeze(["pull_request", "push"]);
+
+export function selectBackendLint({
+	eventName = "",
+	ref = "",
+	pullRequestHeadSha = "",
+	sha = "",
+} = {}) {
+	const selected =
+		eventName === "pull_request" ||
+		(eventName === "push" && ref === "refs/heads/main");
+	const headSha = String(pullRequestHeadSha || sha).trim();
+	return {
+		selected,
+		headSha,
+		checkoutRef: selected ? headSha : "",
+	};
+}
+
+export async function executeLintInventory(targets, runTarget) {
+	if (!Array.isArray(targets) || typeof runTarget !== "function") {
+		throw new TypeError("lint inventory requires targets and a runner");
+	}
+
+	const results = await Promise.all(
+		targets.map(async (name) => {
+			try {
+				const result = await runTarget(name);
+				return { name, status: "pass", ...result };
+			} catch (error) {
+				return {
+					name,
+					status: "fail",
+					output: "",
+					error: String(error?.message || error),
+				};
+			}
+		}),
+	);
+
+	return {
+		targets: results,
+		failed: results.filter((result) => result.status !== "pass"),
+	};
+}
+
+export function upsertBackendLintComment(comments, body, options = {}) {
+	const botLogin = options.botLogin || "github-actions[bot]";
+	const marker = options.marker || BACKEND_LINT_COMMENT_MARKER;
+	const existing = (comments || []).find(
+		(comment) => comment.user?.login === botLogin && comment.body?.includes(marker),
+	);
+	if (existing) {
+		return { action: "update", commentId: existing.id, body };
+	}
+	return { action: "create", body };
+}

--- a/scripts/ci/backend-lint-workflow.test.mjs
+++ b/scripts/ci/backend-lint-workflow.test.mjs
@@ -20,6 +20,7 @@ test("Backend Lint publishes the hosted inventory and feeds Verification Policy"
 	assert.match(workflow, /pull-requests: write/);
 	assert.match(workflow, /uses: actions\/github-script@v7/);
 	assert.match(workflow, /backend-lint-report/);
+	assert.match(workflow, /continue-on-error: true/);
 	assert.match(workflow, /needs: \[classify,[^\n]*backend-lint/);
 	assert.match(workflow, /RUN_BACKEND_LINT: "true"/);
 	assert.match(workflow, /BACKEND_LINT_RESULT: \$\{\{ needs\.backend-lint\.result \}\}/);

--- a/scripts/ci/backend-lint-workflow.test.mjs
+++ b/scripts/ci/backend-lint-workflow.test.mjs
@@ -3,7 +3,6 @@ import test from "node:test";
 
 import { evaluateVerificationPolicy } from "../verification-policy.mjs";
 import {
-	executeLintInventory,
 	selectBackendLint,
 	upsertBackendLintComment,
 } from "./backend-lint-workflow.mjs";
@@ -37,21 +36,6 @@ test("selects pull requests and pushes to main at the tested head", () => {
 	);
 });
 
-test("continues the complete inventory after one checker fails", async () => {
-	const started = [];
-	const result = await executeLintInventory(["first", "second", "third"], async (target) => {
-		started.push(target);
-		if (target === "first") {
-			throw new Error("controlled checker failure");
-		}
-		return { output: `${target} passed` };
-	});
-
-	assert.deepEqual(started, ["first", "second", "third"]);
-	assert.deepEqual(result.targets.map((target) => target.status), ["fail", "pass", "pass"]);
-	assert.equal(result.failed[0].error, "controlled checker failure");
-});
-
 test("publishes a complete report by creating or updating the marked bot comment", () => {
 	const body = renderBackendLintComment(
 		summarizeBackendLintReport({
@@ -72,8 +56,9 @@ test("publishes a complete report by creating or updating the marked bot comment
 		{ headSha: "tested-head", runUrl: "https://example.test/run/1" },
 	);
 	assert.match(body, new RegExp(BACKEND_LINT_COMMENT_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
-	assert.match(body, /ui-lint/);
-	assert.match(body, /broken-check/);
+	assert.match(body, /\| ui-lint \| `pass` \| 0 \| 1\.00s \| clean \|/);
+	assert.match(body, /\| broken-check \| `fail` \| 1 \| 1\.50s \| new failure \|/);
+	assert.match(body, /Total Backend Lint wall time: `2\.50s`/);
 
 	assert.deepEqual(upsertBackendLintComment([], body), { action: "create", body });
 	assert.deepEqual(

--- a/scripts/ci/backend-lint-workflow.test.mjs
+++ b/scripts/ci/backend-lint-workflow.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const workflow = readFileSync(new URL("../../.github/workflows/ci.yml", import.meta.url), "utf8");
+
+test("Backend Lint is selected for pull requests and pushes to main", () => {
+	assert.match(workflow, /^  pull_request:\s*$/m);
+	assert.match(workflow, /^  push:\r?\n    branches: \[main\]\s*$/m);
+	assert.match(workflow, /^  backend-lint:\r?\n/m);
+	assert.match(
+		workflow,
+		/if: github\.event_name == 'pull_request' \|\| github\.event_name == 'push'/,
+	);
+	assert.match(workflow, /ref: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}/);
+});
+
+test("Backend Lint publishes the hosted inventory and feeds Verification Policy", () => {
+	assert.match(workflow, /pull-requests: write/);
+	assert.match(workflow, /uses: actions\/github-script@v7/);
+	assert.match(workflow, /backend-lint-report/);
+	assert.match(workflow, /needs: \[classify,[^\n]*backend-lint/);
+	assert.match(workflow, /RUN_BACKEND_LINT: "true"/);
+	assert.match(workflow, /BACKEND_LINT_RESULT: \$\{\{ needs\.backend-lint\.result \}\}/);
+});

--- a/scripts/ci/backend-lint-workflow.test.mjs
+++ b/scripts/ci/backend-lint-workflow.test.mjs
@@ -1,27 +1,111 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import test from "node:test";
 
-const workflow = readFileSync(new URL("../../.github/workflows/ci.yml", import.meta.url), "utf8");
+import { evaluateVerificationPolicy } from "../verification-policy.mjs";
+import {
+	executeLintInventory,
+	selectBackendLint,
+	upsertBackendLintComment,
+} from "./backend-lint-workflow.mjs";
+import {
+	BACKEND_LINT_COMMENT_MARKER,
+	renderBackendLintComment,
+	summarizeBackendLintReport,
+} from "./backend-lint-report.mjs";
 
-test("Backend Lint is selected for pull requests and pushes to main", () => {
-	assert.match(workflow, /^  pull_request:\s*$/m);
-	assert.match(workflow, /^  push:\r?\n    branches: \[main\]\s*$/m);
-	assert.match(workflow, /^  backend-lint:\r?\n/m);
-	assert.match(
-		workflow,
-		/if: github\.event_name == 'pull_request' \|\| github\.event_name == 'push'/,
+test("selects pull requests and pushes to main at the tested head", () => {
+	assert.deepEqual(
+		selectBackendLint({
+			eventName: "pull_request",
+			ref: "refs/pull/42/merge",
+			pullRequestHeadSha: "pr-head",
+			sha: "merge-sha",
+		}),
+		{ selected: true, headSha: "pr-head", checkoutRef: "pr-head" },
 	);
-	assert.match(workflow, /ref: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}/);
-	assert.match(workflow, /BACKEND_LINT_HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}/);
+	assert.deepEqual(
+		selectBackendLint({
+			eventName: "push",
+			ref: "refs/heads/main",
+			sha: "main-head",
+		}),
+		{ selected: true, headSha: "main-head", checkoutRef: "main-head" },
+	);
+	assert.equal(
+		selectBackendLint({ eventName: "push", ref: "refs/heads/feature", sha: "feature-head" }).selected,
+		false,
+	);
 });
 
-test("Backend Lint publishes the hosted inventory and feeds Verification Policy", () => {
-	assert.match(workflow, /pull-requests: write/);
-	assert.match(workflow, /uses: actions\/github-script@v7/);
-	assert.match(workflow, /backend-lint-report/);
-	assert.match(workflow, /continue-on-error: true/);
-	assert.match(workflow, /needs: \[classify,[^\n]*backend-lint/);
-	assert.match(workflow, /RUN_BACKEND_LINT: "true"/);
-	assert.match(workflow, /BACKEND_LINT_RESULT: \$\{\{ needs\.backend-lint\.result \}\}/);
+test("continues the complete inventory after one checker fails", async () => {
+	const started = [];
+	const result = await executeLintInventory(["first", "second", "third"], async (target) => {
+		started.push(target);
+		if (target === "first") {
+			throw new Error("controlled checker failure");
+		}
+		return { output: `${target} passed` };
+	});
+
+	assert.deepEqual(started, ["first", "second", "third"]);
+	assert.deepEqual(result.targets.map((target) => target.status), ["fail", "pass", "pass"]);
+	assert.equal(result.failed[0].error, "controlled checker failure");
+});
+
+test("publishes a complete report by creating or updating the marked bot comment", () => {
+	const body = renderBackendLintComment(
+		summarizeBackendLintReport({
+			version: 1,
+			jobs: 2,
+			totalDurationMillis: 2500,
+			targets: [
+				{ name: "ui-lint", status: "pass", durationMillis: 1000, output: "pass" },
+				{
+					name: "broken-check",
+					status: "fail",
+					durationMillis: 1500,
+					violationCount: 1,
+					output: "LINT_VIOLATION_COUNT: 1\nchecker output",
+				},
+			],
+		}),
+		{ headSha: "tested-head", runUrl: "https://example.test/run/1" },
+	);
+	assert.match(body, new RegExp(BACKEND_LINT_COMMENT_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+	assert.match(body, /ui-lint/);
+	assert.match(body, /broken-check/);
+
+	assert.deepEqual(upsertBackendLintComment([], body), { action: "create", body });
+	assert.deepEqual(
+		upsertBackendLintComment(
+			[
+				{ id: 17, user: { login: "reviewer" }, body },
+				{ id: 19, user: { login: "github-actions[bot]" }, body: `${BACKEND_LINT_COMMENT_MARKER}\nold` },
+			],
+			body,
+		),
+		{ action: "update", commentId: 19, body },
+	);
+});
+
+test("required-result propagation rejects every non-success Backend Lint result", () => {
+	const policyFor = (result) =>
+		evaluateVerificationPolicy({
+			classificationResult: "success",
+			classification: "full",
+			packageWorkflowResult: "success",
+			lanes: [
+				{
+					name: "Backend Lint",
+					selected: "true",
+					reason: "The canonical lint inventory is required.",
+					checks: [{ name: "Backend Lint", result }],
+				},
+			],
+		});
+
+	assert.equal(policyFor("success").ok, true);
+	for (const result of ["skipped", "cancelled", "timed_out", "failure"]) {
+		assert.equal(policyFor(result).ok, false, `${result} must fail the required lane`);
+	}
 });

--- a/scripts/ci/backend-lint-workflow.test.mjs
+++ b/scripts/ci/backend-lint-workflow.test.mjs
@@ -13,6 +13,7 @@ test("Backend Lint is selected for pull requests and pushes to main", () => {
 		/if: github\.event_name == 'pull_request' \|\| github\.event_name == 'push'/,
 	);
 	assert.match(workflow, /ref: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}/);
+	assert.match(workflow, /BACKEND_LINT_HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}/);
 });
 
 test("Backend Lint publishes the hosted inventory and feeds Verification Policy", () => {

--- a/scripts/verification-policy.mjs
+++ b/scripts/verification-policy.mjs
@@ -226,6 +226,12 @@ function policyInputFromEnvironment() {
 			},
 			directLane("Backend", "RUN_BACKEND", "BACKEND_REASON", "BACKEND_RESULT"),
 			directLane(
+				"Backend Lint",
+				"RUN_BACKEND_LINT",
+				"BACKEND_LINT_REASON",
+				"BACKEND_LINT_RESULT",
+			),
+			directLane(
 				"UI Backend Integration",
 				"RUN_UI_BACKEND",
 				"UI_BACKEND_REASON",

--- a/scripts/verification-policy.test.mjs
+++ b/scripts/verification-policy.test.mjs
@@ -72,19 +72,21 @@ test("a selected lane that is skipped, missing, or failed fails closed", () => {
 });
 
 test("required Backend Lint fails the policy when its hosted job is skipped", () => {
-	const evaluation = evaluateVerificationPolicy(
-		policy({
-			lanes: [
-				...laneNames.filter((name) => name !== "Backend Lint").map((name) => lane(name)),
-				lane("Backend Lint", true, "skipped", {
-					reason: "The canonical lint inventory is required on every pull request.",
-				}),
-			],
-		}),
-	);
+	for (const result of ["skipped", "cancelled", "timed_out", "failure"]) {
+		const evaluation = evaluateVerificationPolicy(
+			policy({
+				lanes: [
+					...laneNames.filter((name) => name !== "Backend Lint").map((name) => lane(name)),
+					lane("Backend Lint", true, result, {
+						reason: "The canonical lint inventory is required on every pull request.",
+					}),
+				],
+			}),
+		);
 
-	assert.equal(evaluation.ok, false);
-	assert.ok(evaluation.failures.some((failure) => /Backend Lint was selected/.test(failure)));
+		assert.equal(evaluation.ok, false, `${result} must fail the required policy lane`);
+		assert.ok(evaluation.failures.some((failure) => /Backend Lint was selected/.test(failure)));
+	}
 });
 
 test("classifier failure fails policy even when every product lane succeeds", () => {

--- a/scripts/verification-policy.test.mjs
+++ b/scripts/verification-policy.test.mjs
@@ -11,6 +11,7 @@ const laneNames = [
 	"README",
 	"Frontend",
 	"Backend",
+	"Backend Lint",
 	"UI Backend Integration",
 	"API Package",
 	"Packaged Factories Package",
@@ -68,6 +69,22 @@ test("a selected lane that is skipped, missing, or failed fails closed", () => {
 		assert.equal(evaluation.ok, false, `result ${result || "missing"} must fail`);
 		assert.match(evaluation.failures[0], /Docs Reference was selected/);
 	}
+});
+
+test("required Backend Lint fails the policy when its hosted job is skipped", () => {
+	const evaluation = evaluateVerificationPolicy(
+		policy({
+			lanes: [
+				...laneNames.filter((name) => name !== "Backend Lint").map((name) => lane(name)),
+				lane("Backend Lint", true, "skipped", {
+					reason: "The canonical lint inventory is required on every pull request.",
+				}),
+			],
+		}),
+	);
+
+	assert.equal(evaluation.ok, false);
+	assert.ok(evaluation.failures.some((failure) => /Backend Lint was selected/.test(failure)));
 });
 
 test("classifier failure fails policy even when every product lane succeeds", () => {

--- a/ui/scripts/check-deadcode-baseline.ts
+++ b/ui/scripts/check-deadcode-baseline.ts
@@ -103,6 +103,7 @@ process.stderr.write(
 process.stderr.write(
   "Remove the unused code or intentionally update the reviewed baseline.\n",
 );
+process.stderr.write(`LINT_VIOLATION_COUNT: ${added.length + removed.length}\n`);
 process.exit(1);
 
 function normalizeReport(report: KnipReport): NormalizedIssue[] {


### PR DESCRIPTION
{
  "project": "Gate Backend Lint in Pull-Request CI",
  "branchName": "thr-ci-runs-no-backend-lint-suite",
  "description": "Add a required Linux Backend Lint CI lane that inventories every canonical lint checker, strictly gates checks that are clean on current main, ratchets explicitly enumerated pre-existing debt without making main red, and reports hosted violation counts and wall time. The intent is to replace reviewer-only lint enforcement with repeatable CI measurement while leaving checker rules, limits, unrelated debt, and existing contention-owned Makefile behavior unchanged.",
  "context": {
    "customerAsk": "Run the repository's complete backend lint suite in hosted pull-request CI, use the first CI run to inventory every checker, gate clean checks immediately, time-box and enumerate pre-existing failures, prove a real violation turns CI red, report wall time, and keep main green without running the suite on the contended workstation.",
    "problem": "No current workflow invokes make lint, backend-size, or LINT_TARGETS, so a pull request can introduce a backend lint violation and still show zero failing CI checks. PR #1980 demonstrated this when a Go file grew beyond the backend-size limit and only human review detected it; local measurement is also impractical under measured workstation contention.",
    "solution": "Add a required Backend Lint job to the primary Linux CI workflow and verification-policy aggregate. Execute every canonical lint target independently, publish per-checker outcomes, checker-owned machine-readable violation counts, diagnostics, and total wall time, strictly fail clean-on-main checks, and represent only measured pre-existing failures as explicit baseline allowances with owners, deadlines, and removal conditions that cannot hide new debt. Targets without a reliable count fail closed instead of falling back to diagnostic-line counts. The required check keeps the repository's Backend Lint contract while intentionally running the complete canonical LINT_TARGETS inventory, including ui-lint and ui-deadcode; the PR labels those frontend findings and defers only measured frontend dead-code cleanup without modifying unrelated UI debt. Validate the gate with a temporary hosted violation and keep all CI-run evidence in PR comments."
  },
  "acceptanceCriteria": [
    "Pull requests and pushes to main run a required Linux Backend Lint job, and Verification Policy treats a skipped, cancelled, timed-out, or failed required lint lane as non-passing.",
    "The first hosted run executes the complete canonical lint-target inventory despite individual failures and reports each checker with pass/fail and violation count plus total Backend Lint wall time in a PR comment.",
    "Every checker clean on current main is gated immediately, and a deliberate temporary violation demonstrably fails Backend Lint with actionable output before being removed from the final implementation head.",
    "Every checker failing on current main is explicitly enumerated in a time-boxed allowance with measured baseline count, reason, owner or remediation lane, deadline, and objective removal condition, and the allowance cannot conceal new violations.",
    "Checker rules and limits, PR #1980's cmd/gocoveragecheck ownership, PR #1982's GO_LANE_BUDGET derivation and concurrency changes, and tests/functional/functional-quarantine.json remain unchanged by this lane.",
    "Quality gate: Typecheck passes, Tests pass, no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Delivery: the implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file contention are reconciled, and the PR is actually merged; CI-run evidence is posted in PR comments and never committed."
  ],
  "userStories": [
    {
      "id": "thr-ci-runs-no-backend-lint-suite-001",
      "title": "Produce a complete hosted lint inventory",
      "description": "As a maintainer, I want CI to execute and summarize every configured lint checker independently so I can see the actual enforcement baseline without relying on an impractical workstation run.",
      "acceptanceCriteria": [
        "A Linux Backend Lint run is triggered for pull requests and pushes to main, checks out the exact tested head, uses the repository Go version and cache, and honors the canonical LINT_JOBS concurrency control.",
        "The hosted run covers ui-lint, ui-deadcode, vet, backend-size, pkg-maint, pkg-file-count, pkg-boundary, pkg-structure, package-target-manifest-check, packaged-factory-source-check, packaged-factory-consumption-check, packaged-factory-catalog-check, provider-catalog-check, model-provider-package-check, durable-runtime-construction-check, logging-boundary-check, compatibility-alias-check, retired-surface-check, ownership-inventory-check, and deadcode, or the exact canonical LINT_TARGETS replacement present after rebasing.",
        "One checker failure does not prevent remaining checkers from running, and the summary reports each checker's pass/fail outcome and violation count derived from hosted output.",
        "The summary reports total Backend Lint wall time and preserves enough per-checker output to diagnose a failure without reproducing it locally.",
        "The first-run inventory and timing are posted as a PR comment, and CI-run evidence is never committed to the repository.",
        "Focused CI workflow behavior tests prove selection for pull requests and pushes to main and publication of the complete inventory after failures.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
    "notes": "Hosted PR run 31868290619 executed all 20 canonical LINT_TARGETS despite failures, reported pass/fail status, derived violation counts, per-checker durations, LINT_JOBS=4, total wall time 125.04s, and actionable diagnostics in the marked PR comment. The run checked out the exact PR head; follow-up commit a9d125318 corrected the comment to identify that tested head rather than the pull-request merge SHA. The follow-up implementation adds checker-owned LINT_VIOLATION_COUNT markers, fail-closed handling for missing or ambiguous counts, behavioral workflow tests for selection/publication/policy, and production cmd/lintlane coverage proving continuation after an early checker failure. Final head 6739fc430 has required CI run 31874801548 started."
    },
    {
      "id": "thr-ci-runs-no-backend-lint-suite-002",
      "title": "Ratchet clean checks and enumerate existing debt",
      "description": "As a maintainer, I want clean lint rules to block regressions while pre-existing failures remain narrowly visible and scheduled for removal so enabling CI does not make main red.",
      "acceptanceCriteria": [
        "Every checker passing on the hosted current-main measurement is in the required gating set, including backend-size, pkg-maint, pkg-file-count, pkg-structure, and vet when they remain green at the rebased baseline.",
        "Every checker failing on the hosted current-main measurement is named individually in an allowance containing its baseline violation count, concise reason, owner or remediation work item, deadline, and objective removal condition.",
        "Allowed baseline debt remains reported, does not fail main solely for already-recorded violations, and cannot make an increased violation count or a newly violating clean checker pass.",
        "The known pkg-boundary packaged-service-structure migration debt recorded on 2026-08-08 is treated as pre-existing debt if reproduced by hosted CI, without requiring blanket make lint success.",
        "Verification Policy requires Backend Lint whenever expected and rejects failed, cancelled, timed-out, or unexpectedly skipped results.",
        "Focused CI workflow behavior tests cover a clean result, a gated-check failure, allowed baseline debt, debt growth beyond its allowance, and required-job result propagation.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
    "notes": "Added a six-entry current-main baseline policy: clean checkers remain gated, the measured failures are allowed only at or below their recorded counts, and each allowance reports its reason, remediation lane, deadline, and removal condition. Allowance growth and newly failing clean checkers fail closed; missing or ambiguous machine-readable counts fail closed; Verification Policy propagation now covers failed, cancelled, timed-out, and skipped required jobs. The latest semantic hosted caps are ui-deadcode 4, backend-size 2, package-target-manifest-check 5, packaged-factory-consumption-check 1, ownership-inventory-check 16, and deadcode 580. `make test-ci-workflows`, focused Go tests, actionlint, and formatting checks pass. Final head 6739fc430 has required CI run 31874801548 started."
    },
    {
      "id": "thr-ci-runs-no-backend-lint-suite-003",
      "title": "Prove the lint gate rejects a real regression",
      "description": "As a reviewer, I want hosted evidence that a real lint regression turns the pull request red and that the final branch removes the regression so the new gate is proven rather than inferred from workflow text.",
      "acceptanceCriteria": [
        "A deliberate temporary violation of a checker gated on current main is pushed and Backend Lint fails on that head for the intended checker.",
        "A PR comment identifies the failing hosted run and head, quotes the actionable failing output, and distinguishes the intentional proof from baseline debt without committing CI evidence.",
        "The temporary violation is removed before the final implementation head with no checker rule change, raised limit, per-file exemption, or unrelated debt repair.",
        "A later hosted run on the final implementation head starts with the proof violation absent, and the implementation stage creates no progress-note commits while waiting for CI.",
        "The final PR description enumerates immediately gated and deferred checkers, each deferral's reason and removal condition, and measured job wall time, with a concrete follow-up split proposal if runtime materially harms pull-request turnaround.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
    "notes": "Hosted proof run 31869691219 on head 8f8e78bc8 demonstrated that the clean-gated pkg-file-count checker fails Backend Lint for a real regression: pkg/root reached 16 files against the unchanged 15-file limit and the report emitted one package file-count baseline violation. The proof was recorded in PR comment 5301006666, then the temporary backend_lint_proof_test.go file was removed in cleanup commit 7f5cd2603 with no checker or unrelated production changes. Immediately gated checkers are ui-lint, vet, pkg-maint, pkg-file-count, pkg-boundary, pkg-structure, packaged-factory-source-check, packaged-factory-catalog-check, provider-catalog-check, model-provider-package-check, durable-runtime-construction-check, logging-boundary-check, compatibility-alias-check, and retired-surface-check. Deferred capped allowances are now semantically measured as ui-deadcode 4, backend-size 2, package-target-manifest-check 5, packaged-factory-consumption-check 1, ownership-inventory-check 16, and deadcode 580. The follow-up regression demo showed the old diagnostic-line fallback miss one additional structured finding; the new checker-owned marker test detects it and fails closed. Final head 6739fc430 has required CI run 31874801548 started."
    }
  ],
  "reviewFollowUp": {
    "status": "ready-for-review",
    "blockers": [
      "Replaced diagnostic-line counting with checker-owned machine-readable counts and fail-closed handling; affected allowances were remeasured.",
      "Replaced the workflow YAML source scan with behavioral tests for event selection, failure continuation, complete publication, and required-result propagation."
    ],
    "remeasuredViolationCounts": {
      "ui-deadcode": 12,
      "backend-size": 2,
      "package-target-manifest-check": 5,
      "packaged-factory-consumption-check": 1,
      "ownership-inventory-check": 16,
      "deadcode": 580
    },
    "hostedRerun": {
      "runId": 31873961077,
      "head": "3e625b9a10f3edc9550786d26798cce165d7adc6",
      "status": "started",
      "requiredChecks": [
        "Backend Lint",
        "Classify Verification"
      ]
    }
  },
  "operatorOverride": {
    "issuedBy": "factory operator",
    "issuedAt": "2026-08-15T11:35:00Z",
    "AAAA00_THE_ONLY_CURRENT_OVERRIDE": "*** THIS IS THE ONLY CURRENT OPERATOR OVERRIDE. ALL PREVIOUS ENTRIES ARE DELETED. ***\n\n=== YOUR CI IS GREEN. THAT IS NOT YOUR PROBLEM. TWO CODE BLOCKERS ARE. ===\n\nHead 63b25c735 is CLEAN - every check green, mergeStateStatus CLEAN. Do NOT spend another minute on\nCI, do NOT rerun anything, do NOT rebase to chase a gate. You were REJECTED on CONTENT, twice, and\nyou have pushed NOTHING since. Re-handing this head earns a third rejection and trips the review\ncircuit breaker (3 consecutive failures per transition).\n\nBoth blockers are correct. I read them and I agree with the reviewer. Fix them.\n\n--- BLOCKER 1: a diagnostic LINE count is not a FINDING count ---\n\nscripts/ci/backend-lint-report.mjs:46-67 falls back to diagnosticLineCount.\n\nThis is the exact failure mode your own lane exists to prevent: THE MEASUREMENT CONDITION MUST EQUAL\nTHE FAILURE CONDITION. A checker can add packages, edges, or findings INSIDE one consolidated\ndiagnostic line - the allowance never moves, and real growth passes a gate that reports it as\nunchanged. You would be shipping a ratchet that cannot detect the thing it ratchets.\n\nREQUIRED FIX, in this order:\n  1. Consume checker-provided or machine-readable FINDING COUNTS. If a checker emits structured\n     output, parse it.\n  2. Where no reliable count exists, FAIL CLOSED. Do not silently fall back to counting lines. An\n     unmeasurable target must be loud, not optimistic.\n  3. REMEASURE every affected allowance after switching to true counts - the current numbers were\n     produced by the wrong measurement and are not trustworthy.\n  4. Add a REGRESSION TEST where ONE additional finding inside consolidated structured output\n     EXCEEDS the allowance. Write it, watch it FAIL against the current line-count implementation,\n     then fix and watch it pass. A guard you have never seen fail is not evidence.\n\n--- BLOCKER 2: a source-scanning meta test ---\n\nscripts/ci/backend-lint-workflow.test.mjs:1-27 reads ci.yml and regex-matches triggers, permissions,\njob registration, and environment wiring. That asserts that TEXT EXISTS, not that BEHAVIOR HAPPENS.\nIt passes against a workflow that is wired correctly and never runs. Repository standards prohibit\ntests that merely scan source, inventories, or route lists.\n\nREQUIRED FIX: replace it with BEHAVIORAL coverage that executes the workflow selection/publication\nboundary and asserts observable outcomes:\n  - PR selection and push selection each produce the expected target set;\n  - execution CONTINUES after a checker failure rather than aborting the remaining targets;\n  - publication is COMPLETE (every target reports a status and a wall time);\n  - the required result PROPAGATES so Verification Policy can reject it.\nDelete the meta test in the same commit that adds the behavioral one.\n\n=== WHAT ALREADY PASSED - DO NOT REDO ===\n\nPRs and pushes to main run Backend Lint, and Verification Policy rejects failed/skipped/cancelled/\ntimed-out required results - PASS. Clean-on-main checks are gated, and hosted run 31869691219 proves\nthe temporary pkg-file-count regression failed with actionable output while the proof file is absent\nfrom the final diff - PASS. Allowances carry reason, owner/lane, deadline, and removal condition -\nthe only defect there is the line-count fallback feeding them.\n\nYour decision to KEEP the full canonical 20-target LINT_TARGETS inventory, including ui-lint and\nui-deadcode, and to document it as a repository-wide inventory so a frontend finding is not\nmisattributed as a Go-only rule, was the RIGHT call. Keep it. That is settled.\n\n=== STANDING RULES ===\n\nRebase onto origin/main before your final push - main is now b1a7ac8a0.\nNever hand-merge generated files - rerun the generator on the rebased tree and commit the output.\nNever run bare `git stash` or `git stash pop` - the stash stack is SHARED across every concurrent\nworktree in this repository. Use `mv` to park a diff.\nCI evidence goes in PR COMMENTS, never in a commit - a commit creates a new head and invalidates the\nrun you recorded.\nDo NOT commit prd.json or progress.txt.\nDo NOT run `make test`, `make verify-fast`, or the coverage lanes on this host - it is heavily\noversubscribed. Focused node/vitest runs on scripts/ci are what you need.\n\nYOUR FINISH LINE: both blockers fixed, the reintroduction demo for the new regression test reported\nin the PR conversation, final head pushed, CI started. MERGED is owned by the review stage."
  }
}
