### PR TITLE
Align Graph Node Reload Settlement with the Saved Layout Contract

### DIFF
--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -336,15 +336,97 @@ function graphNodePlacementSamplesEqual(left, right) {
   );
 }
 
+const settledGraphNodePlacementSampleCount = 3;
+
+function formatGraphNodePlacementNumber(value) {
+  return Number.isFinite(value) ? value.toFixed(2) : String(value);
+}
+
+function graphNodePlacementViewportViolation(sample) {
+  if (!sample) {
+    return null;
+  }
+
+  const nodeCenter = {
+    x: sample.node.x + sample.node.width / 2,
+    y: sample.node.y + sample.node.height / 2,
+  };
+  const viewport = {
+    bottom: sample.viewport.y + sample.viewport.height,
+    left: sample.viewport.x,
+    right: sample.viewport.x + sample.viewport.width,
+    top: sample.viewport.y,
+  };
+  const violations = [];
+
+  if (nodeCenter.x < viewport.left) {
+    violations.push({
+      axis: "x",
+      boundary: "left edge",
+      direction: "left of",
+      overshootPx: viewport.left - nodeCenter.x,
+    });
+  }
+  if (nodeCenter.x > viewport.right) {
+    violations.push({
+      axis: "x",
+      boundary: "right edge",
+      direction: "right of",
+      overshootPx: nodeCenter.x - viewport.right,
+    });
+  }
+  if (nodeCenter.y < viewport.top) {
+    violations.push({
+      axis: "y",
+      boundary: "top edge",
+      direction: "above",
+      overshootPx: viewport.top - nodeCenter.y,
+    });
+  }
+  if (nodeCenter.y > viewport.bottom) {
+    violations.push({
+      axis: "y",
+      boundary: "bottom edge",
+      direction: "below",
+      overshootPx: nodeCenter.y - viewport.bottom,
+    });
+  }
+
+  if (violations.length === 0) {
+    return null;
+  }
+
+  return {
+    nodeCenter,
+    viewport,
+    violations,
+  };
+}
+
 function graphNodePlacementIsWithinViewport(sample) {
-  const nodeCenterX = sample.node.x + sample.node.width / 2;
-  const nodeCenterY = sample.node.y + sample.node.height / 2;
-  return (
-    nodeCenterX >= sample.viewport.x &&
-    nodeCenterX <= sample.viewport.x + sample.viewport.width &&
-    nodeCenterY >= sample.viewport.y &&
-    nodeCenterY <= sample.viewport.y + sample.viewport.height
-  );
+  return graphNodePlacementViewportViolation(sample) === null;
+}
+
+function formatGraphNodePlacementViewportViolation(
+  nodeTestId,
+  pollCount,
+  stableSampleCount,
+  violation,
+) {
+  const outOfRangeAxes = violation.violations
+    .map(
+      ({ axis, boundary, direction, overshootPx }) =>
+        `${axis} ${direction} ${boundary} by ${formatGraphNodePlacementNumber(overshootPx)}px`,
+    )
+    .join("; ");
+
+  return [
+    `Settled graph node placement cannot satisfy viewport visibility for ${nodeTestId}`,
+    `after ${stableSampleCount} consecutive byte-identical samples at poll ${pollCount}`,
+    `node center=(${formatGraphNodePlacementNumber(violation.nodeCenter.x)}, ${formatGraphNodePlacementNumber(violation.nodeCenter.y)})`,
+    `viewport edges={left=${formatGraphNodePlacementNumber(violation.viewport.left)}, right=${formatGraphNodePlacementNumber(violation.viewport.right)}, top=${formatGraphNodePlacementNumber(violation.viewport.top)}, bottom=${formatGraphNodePlacementNumber(violation.viewport.bottom)}}`,
+    `out-of-range axes: ${outOfRangeAxes}`,
+  ].join("; ");
 }
 
 /**
@@ -361,6 +443,7 @@ export async function waitForStableFactoryGraphNodePlacement(
   let previousSample = null;
   let stableSample = null;
   let pollCount = 0;
+  let stableSampleCount = 0;
 
   await waitForDurableCheckpoint(
     `factory graph node placement: ${nodeTestId}`,
@@ -402,16 +485,35 @@ export async function waitForStableFactoryGraphNodePlacement(
         }, nodeTestId)
         .catch(() => null);
       const stable = graphNodePlacementSamplesEqual(previousSample, nextSample);
+      stableSampleCount = stable ? stableSampleCount + 1 : nextSample ? 1 : 0;
+      const viewportViolation = graphNodePlacementViewportViolation(nextSample);
       const withinViewport = Boolean(
         nextSample && graphNodePlacementIsWithinViewport(nextSample),
       );
+      const terminalDiagnostic =
+        stableSampleCount >= settledGraphNodePlacementSampleCount &&
+        viewportViolation
+          ? formatGraphNodePlacementViewportViolation(
+              nodeTestId,
+              pollCount,
+              stableSampleCount,
+              viewportViolation,
+            )
+          : null;
       onObservation?.({
         nextSample,
         pollCount,
         stable,
+        stableSampleCount,
+        terminalDiagnostic,
+        viewportViolation,
         withinViewport,
       });
       previousSample = nextSample;
+
+      if (terminalDiagnostic) {
+        throw new Error(terminalDiagnostic);
+      }
 
       if (!stable || !nextSample || !withinViewport) {
         return false;

--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -430,8 +430,10 @@ function formatGraphNodePlacementViewportViolation(
 }
 
 /**
- * Wait until a graph node's DOM geometry and both React Flow transforms settle
- * while its center is inside the visible graph viewport.
+ * Wait until a graph node's DOM geometry and both React Flow transforms settle.
+ * Viewport visibility is required by default, but callers that are proving a
+ * saved flow position can opt into geometry-only settlement when camera
+ * framing is an independent shared-layout concern.
  */
 export async function waitForStableFactoryGraphNodePlacement(
   page,
@@ -439,6 +441,7 @@ export async function waitForStableFactoryGraphNodePlacement(
   timeoutMs = uiInteractionTimeoutMs,
   intervalMs = 100,
   onObservation,
+  { requireViewportVisibility = true } = {},
 ) {
   let previousSample = null;
   let stableSample = null;
@@ -491,6 +494,7 @@ export async function waitForStableFactoryGraphNodePlacement(
         nextSample && graphNodePlacementIsWithinViewport(nextSample),
       );
       const terminalDiagnostic =
+        requireViewportVisibility &&
         stableSampleCount >= settledGraphNodePlacementSampleCount &&
         viewportViolation
           ? formatGraphNodePlacementViewportViolation(
@@ -515,7 +519,11 @@ export async function waitForStableFactoryGraphNodePlacement(
         throw new Error(terminalDiagnostic);
       }
 
-      if (!stable || !nextSample || !withinViewport) {
+      if (
+        !stable ||
+        !nextSample ||
+        (requireViewportVisibility && !withinViewport)
+      ) {
         return false;
       }
 

--- a/ui/integration/browser-test-harness.wait-patterns.test.mjs
+++ b/ui/integration/browser-test-harness.wait-patterns.test.mjs
@@ -185,6 +185,118 @@ describe("factory graph wait helpers", () => {
   });
 });
 
+describe("settled graph node placement wait helper", () => {
+  it("fails fast with geometry when a settled node is outside the viewport", async () => {
+    const sample = {
+      node: { height: 80, width: 20, x: -80, y: 400.57 },
+      nodeTransform: "translate(-80px, 400.57px)",
+      viewport: { height: 408.31, width: 500, x: 0, y: 0 },
+      viewportTransform: "matrix(1, 0, 0, 1, 0, 0)",
+    };
+    const observations = [];
+    const page = {
+      evaluate: vi.fn().mockResolvedValue(sample),
+    };
+    const startedAt = performance.now();
+    let thrownError;
+
+    try {
+      await waitForStableFactoryGraphNodePlacement(
+        page,
+        "rf__node-resource:extra-gpu",
+        10_000,
+        100,
+        (observation) => observations.push(observation),
+      );
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError.message).toContain(
+      "Settled graph node placement cannot satisfy viewport visibility for rf__node-resource:extra-gpu",
+    );
+    expect(thrownError.message).toContain("node center=(-70.00, 440.57)");
+    expect(thrownError.message).toContain(
+      "viewport edges={left=0.00, right=500.00, top=0.00, bottom=408.31}",
+    );
+    expect(thrownError.message).toContain(
+      "x left of left edge by 70.00px; y below bottom edge by 32.26px",
+    );
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
+    expect(page.evaluate).toHaveBeenCalledTimes(3);
+    expect(observations).toHaveLength(3);
+    expect(observations.at(-1)).toMatchObject({
+      pollCount: 3,
+      stable: true,
+      stableSampleCount: 3,
+      terminalDiagnostic: thrownError.message,
+      viewportViolation: expect.objectContaining({
+        violations: expect.arrayContaining([
+          expect.objectContaining({ axis: "x", direction: "left of" }),
+          expect.objectContaining({ axis: "y", direction: "below" }),
+        ]),
+      }),
+      withinViewport: false,
+    });
+  });
+
+  it("keeps polling when the node geometry is missing", async () => {
+    const page = {
+      evaluate: vi.fn().mockResolvedValue(null),
+    };
+
+    await expect(
+      waitForStableFactoryGraphNodePlacement(
+        page,
+        "rf__node-resource:missing",
+        25,
+        1,
+      ),
+    ).rejects.toThrow(
+      "Timed out waiting for durable checkpoint: factory graph node placement: rf__node-resource:missing",
+    );
+    expect(page.evaluate.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("keeps polling while changing geometry has not settled", async () => {
+    const samples = [
+      {
+        node: { height: 80, width: 20, x: 100, y: 100 },
+        nodeTransform: "translate(100px, 100px)",
+        viewport: { height: 400, width: 500, x: 0, y: 0 },
+        viewportTransform: "matrix(1, 0, 0, 1, 0, 0)",
+      },
+      {
+        node: { height: 80, width: 20, x: 101, y: 100 },
+        nodeTransform: "translate(101px, 100px)",
+        viewport: { height: 400, width: 500, x: 0, y: 0 },
+        viewportTransform: "matrix(1, 0, 0, 1, 0, 0)",
+      },
+    ];
+    let sampleIndex = 0;
+    const page = {
+      evaluate: vi.fn().mockImplementation(async () => {
+        const sample = samples[sampleIndex % samples.length];
+        sampleIndex += 1;
+        return sample;
+      }),
+    };
+
+    await expect(
+      waitForStableFactoryGraphNodePlacement(
+        page,
+        "rf__node-resource:changing",
+        25,
+        1,
+      ),
+    ).rejects.toThrow(
+      "Timed out waiting for durable checkpoint: factory graph node placement: rf__node-resource:changing",
+    );
+    expect(page.evaluate.mock.calls.length).toBeGreaterThan(1);
+  });
+});
+
 describe("browser wait pattern helpers", () => {
   it("waitForFactoryGraphSelectionReady waits for measured graph internals", async () => {
     const readinessMarker = {

--- a/ui/integration/browser-test-harness.wait-patterns.test.mjs
+++ b/ui/integration/browser-test-harness.wait-patterns.test.mjs
@@ -183,6 +183,37 @@ describe("factory graph wait helpers", () => {
     );
     expect(page.evaluate).toHaveBeenCalledTimes(3);
   });
+
+  it("can settle a saved flow position without requiring camera framing", async () => {
+    const sample = {
+      node: { height: 80, width: 20, x: 120, y: 400.57 },
+      nodeTransform: "translate(120px, 400.57px)",
+      viewport: { height: 408.31, width: 500, x: 0, y: 0 },
+      viewportTransform: "matrix(1, 0, 0, 1, 0, 0)",
+    };
+    const observations = [];
+    const page = {
+      evaluate: vi.fn().mockResolvedValue(sample),
+    };
+
+    await expect(
+      waitForStableFactoryGraphNodePlacement(
+        page,
+        "rf__node-resource:extra-gpu",
+        500,
+        1,
+        (observation) => observations.push(observation),
+        { requireViewportVisibility: false },
+      ),
+    ).resolves.toEqual(sample);
+    expect(page.evaluate).toHaveBeenCalledTimes(2);
+    expect(observations.at(-1)).toMatchObject({
+      stable: true,
+      stableSampleCount: 2,
+      terminalDiagnostic: null,
+      withinViewport: false,
+    });
+  });
 });
 
 describe("settled graph node placement wait helper", () => {

--- a/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
@@ -833,6 +833,9 @@ async function waitForTrackedFactoryGraphNodePlacement(page, nodeTestId) {
         const signature = JSON.stringify({
           nextSample: observation.nextSample,
           stable: observation.stable,
+          stableSampleCount: observation.stableSampleCount,
+          terminalDiagnostic: observation.terminalDiagnostic,
+          viewportViolation: observation.viewportViolation,
           withinViewport: observation.withinViewport,
         });
         if (signature !== previousSignature && observations.length < 80) {

--- a/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
@@ -816,7 +816,11 @@ async function endSaveActivationTrace(
   );
 }
 
-async function waitForTrackedFactoryGraphNodePlacement(page, nodeTestId) {
+async function waitForTrackedFactoryGraphNodePlacement(
+  page,
+  nodeTestId,
+  options,
+) {
   const observations = [];
   let previousSignature = null;
   let errorMessage = null;
@@ -843,6 +847,7 @@ async function waitForTrackedFactoryGraphNodePlacement(page, nodeTestId) {
           previousSignature = signature;
         }
       },
+      options,
     );
   } catch (error) {
     errorMessage = String(error);
@@ -1245,9 +1250,12 @@ describe.concurrent("factory graph editor node placement browser integration", (
           server,
         );
         await enterGraphEditor(browserPage.page);
+        // Shared-layout camera restoration is independent of the node's saved
+        // flow position; this barrier proves the latter after reload.
         await waitForTrackedFactoryGraphNodePlacement(
           browserPage.page,
           resourceTestId,
+          { requireViewportVisibility: false },
         );
         await waitForFactoryGraphSelectionReady(browserPage.page);
         const reloadedFlowPosition = await readNodeFlowPosition(


### PR DESCRIPTION
{
  "project": "Align Graph Node Reload Settlement with the Saved Layout Contract",
  "branchName": "thr-graph-node-placement-reload-wait-overconstrained",
  "description": "Restore the required Frontend Browser lane by aligning the manually dragged node post-reload wait with the graph editor's evidence-backed saved-layout camera contract, preserving the full drag/save/round-trip proof, and making settled-but-impossible viewport placement fail in under one second with actionable geometry instead of timing out after roughly 33.5 seconds.",
  "context": {
    "customerAsk": "Decide from the graph editor restore code, shared-layout tests, and gfx-r3 / PR #1950 whether reload must frame a restored dragged node or whether camera visibility is independent; deliver the corresponding product or test correction, preserve all meaningful persistence assertions, and add immediate numeric diagnostics for a settled viewport violation without timeouts, retries, tolerance changes, or quarantine.",
    "problem": "The required Frontend Browser check is red on main because the manually dragged node shared-layout test uses viewport visibility as part of a post-reload settlement barrier. The failing node and viewport were byte-identical and stable by poll two, but the node center Y remained about 440.57 while the viewport bottom was about 408.31, so the helper performed roughly 90 useless polls before an opaque 33.5-second timeout. The drag, single save, persisted payload, persisted dragged position, and changed-from-initial assertions had already passed, and the next assertion only reads the restored flow position.",
    "solution": "First establish whether saved shared layout promises restored camera framing. If it does, fix only the graph editor layout/camera restore path and assert restored framing; if it does not, leave product behavior unchanged and remove viewport visibility only from this post-reload settlement barrier. In both cases preserve the existing persistence assertions. Independently, after three consecutive byte-identical stable samples, fail a still-unsatisfied viewport condition immediately with node center, viewport bounds, failing axis, direction, and pixel overshoot while retaining normal polling for missing, changing, or not-yet-stable samples.",
    "conclusion": {
      "selection": "(b)",
      "statement": "The saved shared-layout contract restores the saved camera exactly when viewport metadata exists; it does not promise that every restored node is automatically reframed into that camera after its flow position changes. The product path therefore remains unchanged. Only the manually dragged node test's post-reload barrier uses geometry-only settlement, while pre-reload placement checks and all persistence assertions retain their existing behavior.",
      "evidence": [
        "Saved-layout viewport restore path: https://github.com/portpowered/you-agent-factory/blob/main/ui/src/features/workflow-activity/lib/layout/use-canonical-layout-viewport-sync.ts#L21-L57; canonical metadata calls React Flow setViewport, and absent metadata falls back to fitView.",
        "Existing shared-layout coverage: https://github.com/portpowered/you-agent-factory/blob/main/ui/src/features/workflow-activity/components/activity-card/react-flow-current-activity-card-viewport-editor-layout.test.tsx#L130-L158; it proves saved viewport projection and explicit viewport persistence independently of node placement.",
        "gfx-r3 / PR #1950 evidence: https://github.com/portpowered/you-agent-factory/pull/1950 and its placement correction https://github.com/portpowered/you-agent-factory/commit/90c3eddb2f920d318eef7879ccca3e787ca76c97; the change addressed fitted-node placement bounds, not camera framing or viewport restoration."
      ]
    }
  },
  "acceptanceCriteria": [
    "The PR description selects conclusion (a) or (b), cites the saved-layout viewport restore path, existing shared-layout coverage, and gfx-r3 / PR #1950, and the implementation matches that evidence.",
    "The manually dragged node shared-layout test passes at least five consecutive focused browser runs, with pass count, per-run durations, and before/after node-placement file wall time reported in a PR comment.",
    "The regression still meaningfully proves a material drag, exactly one save, the extra-gpu persisted payload, persisted position matching the dragged position, persisted position differing from the initial position, and reloaded position matching the persisted position, without changing any tolerance.",
    "A settled viewport violation fails in under one second with the node center, viewport bounds, failing axis or axes, direction, and pixel overshoot, while missing, changing, and not-yet-stable samples retain normal polling; a temporary uncommitted scratch run demonstrates the message in a PR comment.",
    "Changes remain within the owned node-placement integration test and harness helpers plus, only for conclusion (a), the graph editor layout/camera restore path and focused tests; no pkg/, tests/functional/, unrelated integration tests, quarantine or coverage manifests, timeouts, retries, reruns, or tolerances change.",
    "Typecheck, focused browser tests, make ui-test, and make ui-lint pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are resolved, and the PR is actually merged; the implementation stage owns the final pushed head, open PR, started CI, and addressed blocking feedback, while the review stage owns terminal passing CI and merge, and CI evidence is posted only in PR comments, never commits."
  ],
  "userStories": [
    {
      "id": "thr-graph-node-placement-reload-wait-overconstrained-001",
      "title": "Fail fast on settled impossible viewport placement",
      "description": "As a maintainer diagnosing graph browser failures, I want a settled node that cannot satisfy viewport visibility to fail immediately with its geometry so that I can act on the real condition instead of waiting for an uninformative timeout.",
      "acceptanceCriteria": [
        "After three consecutive byte-identical stable samples, a still-false viewport condition throws without waiting for the durable-checkpoint timeout.",
        "The error identifies the node, computed center coordinates, viewport rectangle or edges, every out-of-range axis, direction, and readable pixel overshoot; the recorded regression geometry reports Y about 440.57 as about 32.25px below bottom 408.31.",
        "The settled-unsatisfiable path completes in under one second at the normal polling interval.",
        "Missing, changing, and not-yet-stable samples retain the existing timeout and interval polling behavior.",
        "Observation tracing retains poll count, stable state, viewport state, and the new terminal diagnostic.",
        "A temporary uncommitted scratch run forces the viewport condition false, and its exact message and duration are posted in a PR comment without committing the scratch change.",
        "Direct browser verification covers both normal placement and the forced settled-unsatisfiable path.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented the three-sample settled viewport fast-fail and geometry diagnostic, retained generic polling for missing/changing samples, and extended observation tracing. Focused harness tests pass 22/22 and typecheck passes; the focused normal node-placement browser file passed 4/4. A temporary real-browser forced path reached the terminal error in 214–229ms with center/viewport/overshoot diagnostics; scratch code was removed. The enclosing scratch flow then exposed the existing post-reload visibility barrier owned by story ...-002."
    },
    {
      "id": "thr-graph-node-placement-reload-wait-overconstrained-002",
      "title": "Honor the graph editor reload camera contract",
      "description": "As a graph editor user, I want a manually dragged node and the applicable shared-layout camera behavior to restore consistently after reload so that my saved layout round-trips without a false browser failure or a hidden visibility defect.",
      "acceptanceCriteria": [
        "The worker inspects the canonical layout viewport save and restore behavior, existing shared-layout tests, and gfx-r3 / PR #1950, selects conclusion (a) or (b), and cites the evidence and reasoning in the PR description before changing reload behavior.",
        "For conclusion (a), reload frames restored nodes according to the established contract and focused browser coverage asserts restored flow position and camera framing; for conclusion (b), product behavior remains unchanged and only the post-reload barrier stops requiring visibility while still waiting for stable geometry.",
        "The browser test still proves a material drag, exactly one save, the extra-gpu persisted payload, saved position matching the dragged position, saved position differing from the initial position, and reloaded position matching the saved position with the unchanged tolerance.",
        "The focused browser test passes at least five consecutive times, with pass count, per-run durations, and before/after node-placement file wall time posted in a PR comment.",
        "No timeout, retry, rerun, quarantine, skip, flaky marker, tolerance increase, or weakening of the persistence assertions is used.",
        "If product camera behavior changes, direct browser verification covers restored framing, keyboard Fit, semantic and keyboard access, and representative narrow and desktop viewports; otherwise the PR states that these visible UI behaviors are unchanged.",
        "Direct browser verification confirms the post-reload round-trip behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Selected conclusion (b) from the saved viewport restore path, shared-layout coverage, and gfx-r3 / PR #1950 evidence; the product camera path is unchanged. Added an explicit geometry-only settlement option and used it only after reload in the manually dragged-node browser test, preserving default viewport visibility for pre-reload placement and every persistence assertion. Focused harness coverage passes 23/23; typecheck, make ui-test (3018 Vitest + 210 Bun tests), and make ui-lint pass. The focused browser file passed 4/4 in five consecutive final-head runs with observed wall times 15.5s, 19.8s, 22.4s, 12.0s, and 15.2s; the pre-change focused-file wall time was 26.3s."
    }
  ]
}
