### PR TITLE
fix: make Windows lane budgets shell-safe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,29 +33,60 @@ define decimal_remainder
 $(strip $(subst 0,,$(subst 1,,$(subst 2,,$(subst 3,,$(subst 4,,$(subst 5,,$(subst 6,,$(subst 7,,$(subst 8,,$(subst 9,,$(1))))))))))))
 endef
 
+define nonzero_decimal
+$(strip $(subst 0,,$(1)))
+endef
+
 define positive_decimal
-$(if $(strip $(1)),$(if $(call decimal_remainder,$(1)),,$(if $(filter 0,$(strip $(1))),,$(strip $(1)))),)
+$(if $(strip $(1)),$(if $(call decimal_remainder,$(1)),,$(if $(call nonzero_decimal,$(1)),$(strip $(1)),)),)
 endef
 
 ifeq ($(OS),Windows_NT)
+ifneq (,$(or $(findstring /sh,$(SHELL)),$(findstring /bash,$(SHELL))))
+# GNU Make uses the effective SHELL for $(shell), so use POSIX arithmetic when
+# Windows Make is running through sh.exe or bash.exe. Calling cmd.exe here
+# makes MSYS shells return the cmd banner and prompt instead of the result.
 define compute_go_lane_budget
-$(strip $(or $(shell cmd.exe /d /v:on /c "set /a result=$(1)/$(2) >nul & if !result! LSS 2 (echo 2) else (echo !result!)"),2))
+$(strip $(shell budget=$$(expr $(1) / $(2) 2>/dev/null); if test "$$budget" -ge 2 2>/dev/null; then printf '%s' "$$budget"; elif test "$$budget" = 0 || test "$$budget" = 1; then printf '2'; fi))
 endef
 else
+# The native Windows Make shell is cmd.exe when no POSIX shell is selected.
+# Keep the command's raw stdout for the validation guard below.
 define compute_go_lane_budget
-$(strip $(or $(shell budget=$$(expr $(1) / $(2) 2>/dev/null); if test -z "$$budget" || test "$$budget" -lt 2; then printf '2'; else printf '%s' "$$budget"; fi),2))
+$(strip $(shell cmd.exe /d /v:on /c "set /a result=$(1)/$(2) >nul & if !result! LSS 2 (echo 2) else (echo !result!)"))
+endef
+endif
+else
+define compute_go_lane_budget
+$(strip $(shell budget=$$(expr $(1) / $(2) 2>/dev/null); if test "$$budget" -ge 2 2>/dev/null; then printf '%s' "$$budget"; elif test "$$budget" = 0 || test "$$budget" = 1; then printf '2'; fi))
 endef
 endif
 
 ifndef GO_LANE_BUDGET
 ifneq ($(call positive_decimal,$(YOU_LOGICAL_CPUS)),)
 ifneq ($(call positive_decimal,$(YOU_EXPECTED_CONCURRENT_LANES)),)
-GO_LANE_BUDGET := $(call compute_go_lane_budget,$(YOU_LOGICAL_CPUS),$(YOU_EXPECTED_CONCURRENT_LANES))
+GO_LANE_BUDGET_COMPUTED ?= $(call compute_go_lane_budget,$(YOU_LOGICAL_CPUS),$(YOU_EXPECTED_CONCURRENT_LANES))
+ifneq ($(call positive_decimal,$(GO_LANE_BUDGET_COMPUTED)),)
+GO_LANE_BUDGET := $(call positive_decimal,$(GO_LANE_BUDGET_COMPUTED))
+else
+$(warning GO_LANE_BUDGET received invalid computed value '$(GO_LANE_BUDGET_COMPUTED)'; using 2)
+GO_LANE_BUDGET := 2
+endif
 else
 GO_LANE_BUDGET := 2
 endif
 else
 GO_LANE_BUDGET := 2
+endif
+endif
+
+ifdef GO_LANE_BUDGET
+GO_LANE_BUDGET_VALIDATED := $(call positive_decimal,$(GO_LANE_BUDGET))
+ifneq ($(GO_LANE_BUDGET_VALIDATED),)
+override GO_LANE_BUDGET := $(GO_LANE_BUDGET_VALIDATED)
+else
+$(warning GO_LANE_BUDGET received invalid override '$(GO_LANE_BUDGET)'; using 2)
+override GO_LANE_BUDGET := 2
 endif
 endif
 
@@ -453,7 +484,7 @@ readme-check:
 test: test-unit test-ci-workflows
 
 test-ci-workflows:
-	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs scripts/ci/backend-lint-report.test.mjs scripts/ci/backend-lint-workflow.test.mjs
+	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs scripts/ci/lane-budget.test.mjs scripts/ci/backend-lint-report.test.mjs scripts/ci/backend-lint-workflow.test.mjs
 
 test-full:
 	$(GO) test ./... -timeout $(GO_TEST_TIMEOUT)

--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,12 @@ ifeq ($(OS),Windows_NT)
 endif
 
 # Go's build cache is content-addressed and already includes the inputs that
-# determine a package's compiled output. Keep the default cache-enabled for
-# worktrees; callers can set GO_BUILD_FLAGS=-a for an explicit comparison.
+# determine a package's compiled output. Local CLI builds do not consume Go's
+# repository VCS metadata, so skip that probe by default. Keep this option
+# separate from GO_BUILD_FLAGS so callers can restore stamping explicitly with
+# GO_LOCAL_BUILD_FLAGS=-buildvcs=true without changing other build flags.
 GO_BUILD_FLAGS ?=
+GO_LOCAL_BUILD_FLAGS ?= -buildvcs=false
 
 GO_TEST_TIMEOUT ?= 300s
 GO_COVERAGE_TIMEOUT ?= 10m
@@ -255,10 +258,10 @@ coverage-help:
 	$(info A build or typecheck alone does not replace either completed coverage run.)
 
 build:
-	$(GO) build $(GO_BUILD_FLAGS) -o $(BIN_DIR)/$(BINARY_NAME) $(CMD_PATH)
+	$(GO) build $(GO_BUILD_FLAGS) $(GO_LOCAL_BUILD_FLAGS) -o $(BIN_DIR)/$(BINARY_NAME) $(CMD_PATH)
 
 install:
-	$(GO) build $(GO_BUILD_FLAGS) -o $(INSTALL_DIR)/$(BINARY_NAME) $(CMD_PATH)
+	$(GO) build $(GO_BUILD_FLAGS) $(GO_LOCAL_BUILD_FLAGS) -o $(INSTALL_DIR)/$(BINARY_NAME) $(CMD_PATH)
 
 bundle-api:
 	$(NODE) scripts/run-quiet-api-command.js bundle:rest ./api/openapi-main.yaml ./api/openapi.yaml

--- a/docs/internal/development/development.md
+++ b/docs/internal/development/development.md
@@ -81,6 +81,24 @@ make ui-storybook
 make ui-test-storybook
 ```
 
+### Local build provenance
+
+`make build` and `make install` use `GO_LOCAL_BUILD_FLAGS`, which defaults to
+`-buildvcs=false`. This avoids Go's repository metadata probe on repeated local
+CLI builds because the maintained `cmd/` and `pkg/` code does not consume
+`vcs.revision`, `vcs.time`, or `vcs.modified`; the CLI's development version
+fallback only reads the main module version. The option is independent of
+`GO_BUILD_FLAGS`, and `GO_LOCAL_BUILD_FLAGS=-buildvcs=true` restores local VCS
+stamping when it is needed for a comparison.
+
+The local verification aggregators that call `make build`—including
+`make build-all`, `make backend-verification`, `make verify-build`, and
+`make release-surface-smoke`—inherit the unstamped local default. Shipped
+provenance remains unchanged: GoReleaser runs `.goreleaser.yml` directly,
+`make acp-baseline-self` performs its own direct `go build`, and the published
+`go install` smoke paths invoke `go install` directly. Those paths do not use
+`GO_LOCAL_BUILD_FLAGS` and remain stamped by their existing Go tooling.
+
 `make backend-dependency-graph` writes the direct production-import graph for
 repository packages under `cmd/` and `pkg/` to
 `.artifacts/backend-dependency-graph/backend-dependency-graph.dot`. When

--- a/docs/internal/development/development.md
+++ b/docs/internal/development/development.md
@@ -184,6 +184,12 @@ that contain Go tests and disables `go test`'s duplicate implicit vet pass;
 The normal `make test` loop retains Go's content-addressed test cache, so
 unchanged packages do not relink and rerun on every local invocation. Use
 `make test-unit-fresh` when uncached `-count=1` evidence is explicitly needed.
+
+On Windows, the Makefile selects arithmetic compatible with GNU Make's
+effective shell: POSIX arithmetic for `sh.exe`/`bash.exe` and native `cmd.exe`
+arithmetic otherwise. The raw result is validated as a positive decimal before
+it becomes `GO_LANE_BUDGET`; malformed output produces a visible warning and
+falls back to 2 so the default test and lint flags remain numeric.
 `make test` is the compatibility entrypoint for `make test-unit`; `make
 test-full` remains the broad unshortened aggregate across every Go package.
 

--- a/scripts/ci/lane-budget.test.mjs
+++ b/scripts/ci/lane-budget.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { env, platform } from "node:process";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const makeCommand = platform === "win32" ? "make.exe" : "make";
+
+function requireMake(t) {
+	const result = spawnSync(makeCommand, ["--version"], { encoding: "utf8" });
+	if (result.error) {
+		t.skip(`GNU Make is unavailable: ${result.error.message}`);
+		return false;
+	}
+	return true;
+}
+
+function runMake(variables, targets = ["print-go-parallelism"]) {
+	return spawnSync(
+		makeCommand,
+		["--no-print-directory", "-f", "Makefile", ...variables, ...targets],
+		{
+			cwd: repositoryRoot,
+			env,
+			encoding: "utf8",
+		},
+	);
+}
+
+function outputValue(stdout, name) {
+	const match = stdout.match(new RegExp(`(?:^|\\r?\\n)"?${name}=(\\d+)"?(?:\\r?\\n|$)`));
+	assert.ok(match, `${name} was not a positive integer in output:\n${stdout}`);
+	return Number(match[1]);
+}
+
+function assertBudgetOutput(result, expected) {
+	assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+	for (const name of ["GO_LANE_BUDGET", "FUNCTIONAL_DEFAULT_JOBS", "UNIT_DEFAULT_JOBS", "LINT_JOBS"]) {
+		assert.equal(outputValue(result.stdout, name), expected, `${name} output:\n${result.stdout}`);
+	}
+}
+
+function installedPosixShell() {
+	const candidates = [
+		env.SHELL,
+		env.ProgramFiles ? join(env.ProgramFiles, "Git", "bin", "sh.exe") : "",
+		env.ProgramFiles ? join(env.ProgramFiles, "Git", "usr", "bin", "sh.exe") : "",
+	];
+	return candidates.find((candidate) => candidate && existsSync(candidate));
+}
+
+test("production Make computation yields the bounded numeric budget", (t) => {
+	if (!requireMake(t)) return;
+
+	const result = runMake(["YOU_LOGICAL_CPUS=16", "YOU_EXPECTED_CONCURRENT_LANES=4"]);
+	assertBudgetOutput(result, 4);
+});
+
+test("corrupted production result warns, falls back, and reaches numeric job flags", (t) => {
+	if (!requireMake(t)) return;
+
+	for (const computedValue of ["0", "", "Windows banner text", "4x"]) {
+		const result = runMake(
+			[
+				"YOU_LOGICAL_CPUS=16",
+				"YOU_EXPECTED_CONCURRENT_LANES=4",
+				`GO_LANE_BUDGET_COMPUTED=${computedValue}`,
+			],
+			["-n", "test-unit", "test-functional", "lint"],
+		);
+		assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+		assert.ok(
+			result.stderr.includes(`GO_LANE_BUDGET received invalid computed value '${computedValue}'; using 2`),
+			`missing invalid-value warning for ${JSON.stringify(computedValue)}:\n${result.stderr}`,
+		);
+		assert.match(result.stdout, /unitlane -jobs 2/);
+		assert.match(result.stdout, /functionallane -jobs 2/);
+		assert.match(result.stdout, /lintlane -make .* -jobs "2"/);
+	}
+});
+
+test("Windows Make uses numeric arithmetic through sh-compatible and cmd shells", (t) => {
+	if (platform !== "win32") {
+		t.skip("Windows shell-family coverage runs on Windows CI");
+		return;
+	}
+	if (!requireMake(t)) return;
+
+	const common = ["OS=Windows_NT", "NUMBER_OF_PROCESSORS=16", "YOU_EXPECTED_CONCURRENT_LANES=4"];
+	const posixShell = installedPosixShell();
+	if (!posixShell) {
+		t.skip("a Git sh.exe installation is unavailable");
+		return;
+	}
+	const shells = [`SHELL=${posixShell}`, "SHELL=cmd.exe"];
+	for (const shell of shells) {
+		const result = runMake([...common, shell]);
+		assertBudgetOutput(result, 4);
+	}
+});

--- a/scripts/default-pipeline.test.mjs
+++ b/scripts/default-pipeline.test.mjs
@@ -60,7 +60,7 @@ async function createHarness(t, failMatch = "") {
 	return { harnessEnv, logPath, toolPaths };
 }
 
-function runMake(harness, extraArgs = []) {
+function runMakeTarget(harness, target, extraArgs = []) {
 	const args = [
 		"--no-print-directory",
 		"-f",
@@ -74,13 +74,17 @@ function runMake(harness, extraArgs = []) {
 		"YOU_EXPECTED_CONCURRENT_LANES=4",
 		"LINT_TARGETS=lint-sentinel",
 		...extraArgs,
-		"default",
+		target,
 	];
 	return spawnSync(platform === "win32" ? "make.exe" : "make", args, {
 		cwd: repositoryRoot,
 		env: harness.harnessEnv,
 		encoding: "utf8",
 	});
+}
+
+function runMake(harness, extraArgs = []) {
+	return runMakeTarget(harness, "default", extraArgs);
 }
 
 async function toolEvents(logPath) {
@@ -177,4 +181,31 @@ test("make -n default emits all phases without running tool or nested-make proce
 	]) {
 		assert.ok(result.stdout.includes(marker), `dry run omitted ${marker}`);
 	}
+});
+
+test("local build and install use an overridable VCS build flag", async (t) => {
+	if (!requireMake(t)) return;
+
+	const defaultHarness = await createHarness(t);
+	for (const target of ["build", "install"]) {
+		const result = runMakeTarget(defaultHarness, target, ["GO_BUILD_FLAGS=-a"]);
+		assert.equal(result.status, 0, `${target}: ${result.stdout}\n${result.stderr}`);
+		const buildEvents = (await toolEvents(defaultHarness.logPath)).filter((event) =>
+			event.startsWith("go|build "),
+		);
+		const buildEvent = buildEvents.at(-1) ?? "";
+		assert.match(buildEvent, /^go\|build -a -buildvcs=false -o .+ \.\/cmd\/factory\/$/);
+		if (target === "build") {
+			const binaryName = platform === "win32" ? "you.exe" : "you";
+			assert.match(buildEvent, new RegExp(` -o bin/${binaryName.replace(".", "\\.")} `));
+		}
+	}
+
+	const stampedHarness = await createHarness(t);
+	const stamped = runMakeTarget(stampedHarness, "build", ["GO_LOCAL_BUILD_FLAGS=-buildvcs=true"]);
+	assert.equal(stamped.status, 0, `${stamped.stdout}\n${stamped.stderr}`);
+	assert.match(
+		(await toolEvents(stampedHarness.logPath)).find((event) => event.startsWith("go|build ")) ?? "",
+		/-buildvcs=true/,
+	);
 });


### PR DESCRIPTION
{
  "project": "Fast Local Go Builds and Shell-Safe Lane Budgets",
  "branchName": "thr-build-vcs-stamp-and-lane-budget-shell-defect",
  "description": "Make repeated local Go builds materially faster by disabling unused VCS stamping only for local build/install commands, and make Windows lane-budget derivation shell-safe, numeric, warning-visible, and unable to pass malformed values into test or lint job flags, while retaining provenance on shipped release paths.",
  "context": {
    "customerAsk": "Fix both reproduced Makefile defects in one narrow PR: skip unused Go VCS stamping for local build/install without affecting shipped provenance, and compute plus validate positive numeric lane budgets under the shell GNU Make actually uses. Demonstrate interleaved build timings, both Windows shell families, corrupted-result warning/fallback behavior, release-path decisions, and the evidence-based relationship to the Windows exit status 0xffffffff failure; add a focused regression test that invokes production Make logic.",
    "problem": "Warm local builds spend most of their time in Go's fixed Git VCS probe even though repository code does not consume build metadata. Independently, Windows Make can execute a cmd.exe budget expression through sh.exe, receive non-empty banner text, and propagate that garbage through GO_LANE_BUDGET into functional, unit, and lint parallelism flags because the existing fallback checks emptiness rather than numeric validity.",
    "solution": "Add a dedicated overridable -buildvcs=false default used only by local build/install, leaving independent release and packaging paths stamped or otherwise unaffected. Select arithmetic compatible with GNU Make's effective shell, validate the computed result itself as a positive integer, warn with the received value and fall back to 2 on failure, and protect the real Make behavior with focused CI-script tests and direct shell/performance evidence in PR comments."
  },
  "acceptanceCriteria": [
    "Local make build and make install default to an overridable -buildvcs=false option kept separate from GO_BUILD_FLAGS, while -buildvcs=true remains available.",
    "A fresh ReadBuildInfo/vcs.revision/vcs.time/vcs.modified search under pkg/ and cmd/ confirms no consumer before stamping is disabled; all release/packaging build paths are documented, with GoReleaser shipped builds and direct ACP baseline capture remaining stamped, published go install unaffected, and local build-all/backend-verification/release-surface-smoke using the local unstamped build.",
    "Interleaved stamped and unstamped warm-cache make build timings demonstrate a measurable improvement and are posted with raw commands in a PR comment rather than committed.",
    "Under both sh-compatible and PowerShell Windows invocations, GO_LANE_BUDGET, FUNCTIONAL_DEFAULT_JOBS, UNIT_DEFAULT_JOBS, and LINT_JOBS print as positive integers for valid inputs.",
    "Corrupted production computation output emits a visible warning naming the received value, falls back to 2 before reaching derived job flags, is covered by a focused test that invokes real Make logic, and the PR comment gives an evidence-based conclusion about the exit status 0xffffffff link without expanding into full coverage runs.",
    "Typecheck and focused tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file reconciliation are resolved, and the PR is actually merged; CI-run evidence is posted only in PR comments and never committed."
  ],
  "userStories": [
    {
      "id": "thr-build-vcs-stamp-and-lane-budget-shell-defect-001",
      "title": "Make local Go builds skip unused VCS discovery",
      "description": "As a developer repeatedly building the CLI, I want local build and install commands to skip unused repository metadata discovery so warm builds complete substantially faster without removing provenance from shipped binaries.",
      "acceptanceCriteria": [
        "make build and make install pass an overridable local VCS-build option that defaults to -buildvcs=false, and setting it to -buildvcs=true restores stamping.",
        "The local VCS-build option remains separate from GO_BUILD_FLAGS and does not silently affect independent Go build or release tooling.",
        "A fresh search for ReadBuildInfo, vcs.revision, vcs.time, and vcs.modified under pkg/ and cmd/ confirms no consumer before the default changes; finding a consumer stops implementation for escalation.",
        "Release and packaging paths are documented: GoReleaser shipped paths remain stamped and unaffected, published go install remains unaffected, direct ACP baseline capture remains stamped, and local verification aggregators that call make build inherit the local unstamped default.",
        "Alternating stamped and unstamped warm-cache make build runs show a measurable reduction, with raw commands and timings placed in a PR comment rather than a commit.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented GO_LOCAL_BUILD_FLAGS=-buildvcs=false for make build/install with true override, documented local versus shipped paths, and added production Make behavior coverage. Focused CI-script tests, actual stamped/unstamped builds, and typecheck pass."
    },
    {
      "id": "thr-build-vcs-stamp-and-lane-budget-shell-defect-002",
      "title": "Derive safe lane budgets under the shell Make actually uses",
      "description": "As a Windows developer running test and lint commands, I want Make to derive and validate numeric job counts under its actual shell so malformed shell output cannot corrupt local verification arguments.",
      "acceptanceCriteria": [
        "Valid positive inputs use arithmetic compatible with GNU Make's effective shell and preserve max(2, logical CPUs / expected concurrent lanes).",
        "The computed output itself is validated as a positive integer before assignment to GO_LANE_BUDGET.",
        "Invalid, zero, empty, banner-text, or otherwise non-numeric computation output emits a visible Make warning naming the received value and assigns GO_LANE_BUDGET=2.",
        "FUNCTIONAL_DEFAULT_JOBS, UNIT_DEFAULT_JOBS, and LINT_JOBS inherit only the validated numeric budget unless explicitly overridden.",
        "Actual Windows invocations through both sh-compatible GNU Make and PowerShell print positive integers for the budget and all three derived job values.",
        "A focused scripts/ci test invokes production Make computation and guard behavior, including the corrupted-result warning and fallback, without duplicating the production validation algorithm, and is included in the normal CI-script test entry point.",
        "A PR comment records evidence that malformed output reaches current -jobs/-p arguments and states whether focused evidence proves the exact 0xffffffff mapping or supports only a strong plausible explanation.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented shell-aware GNU Make arithmetic with raw-result validation, visible warning/fallback to 2, numeric downstream job flags, and Windows sh/cmd coverage. Added production Make regression tests for valid and corrupted results; make test-ci-workflows, make test, and make typecheck pass."
    }
  ]
}
