### PR TITLE
thr-coverage-gate-silence-is-not-a-pass

### DIFF
--- a/cmd/gocoveragecheck/coverage_diagnostics.go
+++ b/cmd/gocoveragecheck/coverage_diagnostics.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+func writeCoverageTestFailureWarning(err error) {
+	var testFailureErr *coverageTestFailureError
+	if !errors.As(err, &testFailureErr) {
+		return
+	}
+	if testFailureErr.failedTestCountKnown {
+		fmt.Fprintf(stderrWriter, "coverage not evaluated: %d failed tests observed; package floors were NOT checked because the coverage test run failed\n", testFailureErr.failedTestCount)
+		return
+	}
+	fmt.Fprintln(stderrWriter, "coverage not evaluated: package floors were NOT checked because the coverage test run failed; failed-test count unavailable")
+}
+
+func writeCoverageDiagnostics(result coverageResult) {
+	for _, warning := range result.packageMinimumWarnings {
+		fmt.Fprintln(stderrWriter, warning)
+	}
+	for _, diagnostic := range result.unmeasuredPackageDiagnostics {
+		fmt.Fprintln(stderrWriter, diagnostic)
+	}
+}

--- a/cmd/gocoveragecheck/coverage_diagnostics.go
+++ b/cmd/gocoveragecheck/coverage_diagnostics.go
@@ -1,21 +1,6 @@
 package main
 
-import (
-	"errors"
-	"fmt"
-)
-
-func writeCoverageTestFailureWarning(err error) {
-	var testFailureErr *coverageTestFailureError
-	if !errors.As(err, &testFailureErr) {
-		return
-	}
-	if testFailureErr.failedTestCountKnown {
-		fmt.Fprintf(stderrWriter, "coverage not evaluated: %d failed tests observed; package floors were NOT checked because the coverage test run failed\n", testFailureErr.failedTestCount)
-		return
-	}
-	fmt.Fprintln(stderrWriter, "coverage not evaluated: package floors were NOT checked because the coverage test run failed; failed-test count unavailable")
-}
+import "fmt"
 
 func writeCoverageDiagnostics(result coverageResult) {
 	for _, warning := range result.packageMinimumWarnings {

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -39,6 +39,18 @@ func (err *coverageTestFailureError) Unwrap() error {
 	return err.err
 }
 
+func writeCoverageTestFailureWarning(err error) {
+	var testFailureErr *coverageTestFailureError
+	if !errors.As(err, &testFailureErr) {
+		return
+	}
+	if testFailureErr.failedTestCountKnown {
+		fmt.Fprintf(stderrWriter, "coverage not evaluated: %d failed tests observed; package floors were NOT checked because the coverage test run failed\n", testFailureErr.failedTestCount)
+		return
+	}
+	fmt.Fprintln(stderrWriter, "coverage not evaluated: package floors were NOT checked because the coverage test run failed; failed-test count unavailable")
+}
+
 func buildCoverageTestArgs(commonArgs []string, profilePath string, timingEnabled bool, testPackages []string) []string {
 	args := append([]string(nil), commonArgs...)
 	args = append(args, fmt.Sprintf("-coverprofile=%s", profilePath))

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -22,6 +23,20 @@ type coverageInvocationPlan struct {
 	invocations  []commandInvocation
 	profilePaths []string
 	cleanup      func() error
+}
+
+type coverageTestFailureError struct {
+	err                  error
+	failedTestCount      int
+	failedTestCountKnown bool
+}
+
+func (err *coverageTestFailureError) Error() string {
+	return err.err.Error()
+}
+
+func (err *coverageTestFailureError) Unwrap() error {
+	return err.err
 }
 
 func buildCoverageTestArgs(commonArgs []string, profilePath string, timingEnabled bool, testPackages []string) []string {
@@ -307,6 +322,9 @@ func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, test
 	var stderr strings.Builder
 	var laneErr error
 	succeeded := make([]bool, len(plan.invocations))
+	testFailureObserved := false
+	failedTestCount := 0
+	failedTestCountKnown := true
 	for index, invocation := range plan.invocations {
 		batchStdout, batchStderr, commandErr := runCommand(invocation)
 		appendCoverageOutput(&stdout, batchStdout)
@@ -314,6 +332,11 @@ func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, test
 		if commandErr == nil {
 			succeeded[index] = true
 			continue
+		}
+		if count, known, observed := coverageTestFailureDetails(commandErr, batchStdout, batchStderr); observed {
+			testFailureObserved = true
+			failedTestCount += count
+			failedTestCountKnown = failedTestCountKnown && known
 		}
 
 		detail := mergeGoTestFailureDetail(batchStderr, batchStdout)
@@ -347,7 +370,53 @@ func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, test
 		}
 	}
 
-	return errors.Join(laneErr, timingWriteErr, mergeErr, plan.cleanup())
+	runErr := errors.Join(laneErr, timingWriteErr, mergeErr, plan.cleanup())
+	if !testFailureObserved {
+		return runErr
+	}
+	return &coverageTestFailureError{
+		err:                  runErr,
+		failedTestCount:      failedTestCount,
+		failedTestCountKnown: failedTestCountKnown && failedTestCount > 0,
+	}
+}
+
+func coverageTestFailureDetails(commandErr error, stdout string, stderr string) (int, bool, bool) {
+	if !isCoverageTestProcessFailure(commandErr) {
+		return 0, false, false
+	}
+	count := countObservedGoTestFailures(stdout, stderr)
+	return count, count > 0, true
+}
+
+func isCoverageTestProcessFailure(commandErr error) bool {
+	var exitErr *exec.ExitError
+	if errors.As(commandErr, &exitErr) {
+		return true
+	}
+	return strings.HasPrefix(commandErr.Error(), "exit status ")
+}
+
+func countObservedGoTestFailures(stdout string, stderr string) int {
+	count := 0
+	for _, output := range []string{stdout, stderr} {
+		for _, line := range strings.Split(output, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "--- FAIL:") {
+				count++
+				continue
+			}
+			if !strings.HasPrefix(trimmed, "{") {
+				continue
+			}
+
+			var event goTestTimingEvent
+			if err := json.Unmarshal([]byte(trimmed), &event); err == nil && event.Action == timingOutcomeFail && event.Test != "" {
+				count++
+			}
+		}
+	}
+	return count
 }
 
 func buildFunctionalCoverageInvocationPlan(commonArgs []string, groups []coverageRunGroup, profilePath string, timingEnabled bool, targetOS string) (coverageInvocationPlan, error) {

--- a/cmd/gocoveragecheck/coverage_json_test.go
+++ b/cmd/gocoveragecheck/coverage_json_test.go
@@ -264,8 +264,9 @@ func TestExecuteJSONReportsMeasurementExceptionFromManifest(t *testing.T) {
 	if summary.Packages[0].PackageFloor == nil || *summary.Packages[0].PackageFloor != 100.0 {
 		t.Fatalf("pkg/config packageFloor = %v, want 100", summary.Packages[0].PackageFloor)
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+	wantDiagnostic := "coverage not evaluated: package=" + initializerPackage + " lane=unit (no measurement in profile)\n"
+	if got := stderr.String(); got != wantDiagnostic {
+		t.Fatalf("execute() stderr = %q, want unmeasured-package diagnostic %q", got, wantDiagnostic)
 	}
 }
 
@@ -395,8 +396,9 @@ func TestExecuteWritesJSONWhenPackageFloorFails(t *testing.T) {
 	if strings.Contains(stdout.String(), "meets minimum") {
 		t.Fatalf("execute() stdout = %q, did not expect success message", stdout.String())
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+	wantDiagnostic := "coverage not evaluated: package=" + configPackage + " lane=unit (no measurement in profile)\n"
+	if got := stderr.String(); got != wantDiagnostic {
+		t.Fatalf("execute() stderr = %q, want unmeasured-package diagnostic %q", got, wantDiagnostic)
 	}
 }
 

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -148,6 +148,7 @@ func execute(cfg config) error {
 	}
 	result, err := run(cfg)
 	if err != nil {
+		writeCoverageTestFailureWarning(err)
 		var validationErr *coverageManifestValidationError
 		if errors.As(err, &validationErr) {
 			writePackageCoverageSummaries(result.packageSummaries)
@@ -183,6 +184,18 @@ func execute(cfg config) error {
 	}
 	fmt.Fprintf(stdoutWriter, "Go coverage %.1f%% meets minimum %.1f%%.\n", result.actual, cfg.min)
 	return nil
+}
+
+func writeCoverageTestFailureWarning(err error) {
+	var testFailureErr *coverageTestFailureError
+	if !errors.As(err, &testFailureErr) {
+		return
+	}
+	if testFailureErr.failedTestCountKnown {
+		fmt.Fprintf(stderrWriter, "coverage not evaluated: %d failed tests observed; package floors were NOT checked because the coverage test run failed\n", testFailureErr.failedTestCount)
+		return
+	}
+	fmt.Fprintln(stderrWriter, "coverage not evaluated: package floors were NOT checked because the coverage test run failed; failed-test count unavailable")
 }
 
 func parseConfig() config {

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -117,6 +117,7 @@ type coverageResult struct {
 	zeroCoveragePackages         []string
 	packageMinimumFailures       []string
 	packageMinimumWarnings       []string
+	unmeasuredPackageDiagnostics []string
 }
 
 type packageCoverageTotals struct {
@@ -177,6 +178,9 @@ func execute(cfg config) error {
 	}
 	for _, warning := range result.packageMinimumWarnings {
 		fmt.Fprintln(stderrWriter, warning)
+	}
+	for _, diagnostic := range result.unmeasuredPackageDiagnostics {
+		fmt.Fprintln(stderrWriter, diagnostic)
 	}
 
 	if len(failures) > 0 {
@@ -410,6 +414,7 @@ func runCoverageProfile(cfg config, targetOS string, profilePath string) (covera
 			return coverageResult{}, err
 		}
 		result.packageMinimumFailures, result.packageMinimumWarnings = checkCoverageManifestWithEpsilonAndBlocks(manifest, result.packageTotals, cfg.packageManifest, cfg.packageFloorEpsilon, result.coverageBlocks)
+		result.unmeasuredPackageDiagnostics = formatUnmeasuredCoverageManifestDiagnostics(manifest, result.packageTotals)
 		result.packageGates = packageGatesFromManifest(manifest)
 	} else if legacyPackageGateEnabled {
 		result.packageGates = packageGatesFromLegacyMin(result.packageSummaries, cfg.packageCoverageMin(), baselinePackages)

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -176,30 +176,13 @@ func execute(cfg config) error {
 	if err := writeCoverageSummaryJSON(cfg.jsonOutput, result); err != nil {
 		return err
 	}
-	for _, warning := range result.packageMinimumWarnings {
-		fmt.Fprintln(stderrWriter, warning)
-	}
-	for _, diagnostic := range result.unmeasuredPackageDiagnostics {
-		fmt.Fprintln(stderrWriter, diagnostic)
-	}
+	writeCoverageDiagnostics(result)
 
 	if len(failures) > 0 {
 		return errors.New(strings.Join(failures, "\n"))
 	}
 	fmt.Fprintf(stdoutWriter, "Go coverage %.1f%% meets minimum %.1f%%.\n", result.actual, cfg.min)
 	return nil
-}
-
-func writeCoverageTestFailureWarning(err error) {
-	var testFailureErr *coverageTestFailureError
-	if !errors.As(err, &testFailureErr) {
-		return
-	}
-	if testFailureErr.failedTestCountKnown {
-		fmt.Fprintf(stderrWriter, "coverage not evaluated: %d failed tests observed; package floors were NOT checked because the coverage test run failed\n", testFailureErr.failedTestCount)
-		return
-	}
-	fmt.Fprintln(stderrWriter, "coverage not evaluated: package floors were NOT checked because the coverage test run failed; failed-test count unavailable")
 }
 
 func parseConfig() config {

--- a/cmd/gocoveragecheck/main_entrypoint_test.go
+++ b/cmd/gocoveragecheck/main_entrypoint_test.go
@@ -203,6 +203,33 @@ func TestMainRejectsNegativePackageFloorEpsilonBeforeCoverageWork(t *testing.T) 
 	if !strings.Contains(stderr, "finite non-negative percentage-point value") || !strings.Contains(stderr, "set it to 0 or greater") {
 		t.Fatalf("main() stderr = %q, want actionable epsilon diagnostic", stderr)
 	}
+	if strings.Contains(stderr, "coverage not evaluated") {
+		t.Fatalf("main() stderr = %q, did not expect test-failure-only warning", stderr)
+	}
+}
+
+func TestMainReportsSkippedPackageFloorsWhenCoverageTestsFail(t *testing.T) {
+	stdout, stderr, exitCode := runMainForTest(t, []string{
+		"-coverpkg=" + modulePath + "/pkg/config",
+		"-packages=./pkg/config",
+	}, fakeGoCoverageCommandTestFailsWithObservedFailures)
+
+	if exitCode != 1 {
+		t.Fatalf("main() exit code = %d, want 1", exitCode)
+	}
+	if stdout != "" {
+		t.Fatalf("main() stdout = %q, want no coverage summaries without a valid measurement", stdout)
+	}
+	for _, want := range []string{
+		"coverage not evaluated",
+		"2 failed tests observed",
+		"package floors were NOT checked",
+		"raw failure output from go test",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("main() stderr = %q, want diagnostic containing %q", stderr, want)
+		}
+	}
 }
 
 func TestMainRejectsSingleProfileManifestUpdateBeforeCoverage(t *testing.T) {

--- a/cmd/gocoveragecheck/main_fake_process_test.go
+++ b/cmd/gocoveragecheck/main_fake_process_test.go
@@ -42,6 +42,10 @@ func fakeGoCoverageCommandTestFailsWithoutDetail(invocation commandInvocation) (
 	return fakeGoCommandByScenario("coverage-test-fails-without-detail", invocation.name, invocation.args...)
 }
 
+func fakeGoCoverageCommandTestFailsWithObservedFailures(invocation commandInvocation) (string, string, error) {
+	return fakeGoCommandByScenario("coverage-test-fails-with-observed-failures", invocation.name, invocation.args...)
+}
+
 func fakeGoListCommandFailsWithStderr(invocation commandInvocation) (string, string, error) {
 	return fakeGoCommandByScenario("go-list-fails-with-stderr", invocation.name, invocation.args...)
 }
@@ -101,7 +105,7 @@ func fakeGoTestScenario(scenario string, args []string) (string, string, error) 
 			return "", "", fmt.Errorf("missing -coverprofile")
 		}
 		switch scenario {
-		case "coverage-passing", "coverage-cover-fails-with-stderr", "coverage-cover-fails-with-stdout", "coverage-cover-fails-without-detail", "coverage-measured-zero-config", "coverage-temp-profile", "coverage-test-fails-without-detail":
+		case "coverage-passing", "coverage-cover-fails-with-stderr", "coverage-cover-fails-with-stdout", "coverage-cover-fails-without-detail", "coverage-measured-zero-config", "coverage-temp-profile", "coverage-test-fails-without-detail", "coverage-test-fails-with-observed-failures":
 			if err := writeFakeCoverageProfile(profilePath, strings.Join([]string{
 				"mode: count",
 				modulePath + "/pkg/config/config.go:1.1,2.1 3 1",
@@ -157,6 +161,8 @@ func fakeGoTestScenario(scenario string, args []string) (string, string, error) 
 				modulePath + "/pkg/transports/http/client\t\tcoverage: 0.0% of statements\n", "", nil
 		case "coverage-test-fails-without-detail":
 			return "", "raw failure output from go test", fmt.Errorf("exit status 7")
+		case "coverage-test-fails-with-observed-failures":
+			return "--- FAIL: TestObservedFirstFailure (0.01s)\n--- FAIL: TestObservedSecondFailure (0.01s)\nFAIL\n", "raw failure output from go test", fmt.Errorf("exit status 7")
 		default:
 			return "", "", fmt.Errorf("unexpected cover scenario: %s", scenario)
 		}
@@ -171,6 +177,8 @@ func fakeGoTestScenario(scenario string, args []string) (string, string, error) 
 			modulePath + "/pkg/service\t\tcoverage: 100.0% of statements\n", "", nil
 	case "coverage-test-fails-without-detail":
 		return "", "raw failure output from go test", fmt.Errorf("exit status 7")
+	case "coverage-test-fails-with-observed-failures":
+		return "--- FAIL: TestObservedFirstFailure (0.01s)\n--- FAIL: TestObservedSecondFailure (0.01s)\nFAIL\n", "raw failure output from go test", fmt.Errorf("exit status 7")
 	}
 
 	switch scenario {

--- a/cmd/gocoveragecheck/main_run_test.go
+++ b/cmd/gocoveragecheck/main_run_test.go
@@ -268,8 +268,11 @@ func TestExecuteDoesNotReportPackageSummariesWhenMeasurementFails(t *testing.T) 
 	if stdout.Len() != 0 {
 		t.Fatalf("execute() stdout = %q, want no package summaries without a valid measurement", stdout.String())
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+	if got := stderr.String(); !strings.Contains(got, "coverage not evaluated") || !strings.Contains(got, "package floors were NOT checked") {
+		t.Fatalf("execute() stderr = %q, want skipped-floor diagnostic", got)
+	}
+	if strings.Contains(stderr.String(), "failed tests observed") {
+		t.Fatalf("execute() stderr = %q, did not expect an invented failure count", stderr.String())
 	}
 }
 

--- a/cmd/gocoveragecheck/main_run_test.go
+++ b/cmd/gocoveragecheck/main_run_test.go
@@ -147,6 +147,58 @@ func TestExecuteReportsPackageSummariesForCompleteManifest(t *testing.T) {
 	}
 }
 
+func TestExecuteReportsManifestPackagesWithoutProfileMeasurement(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	defer func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	}()
+
+	configPackage := modulePath + "/pkg/config"
+	initializerPackage := modulePath + "/pkg/initializer"
+	servicePackage := modulePath + "/pkg/service"
+	manifestPath := writePackageMinimumManifestWithEntries(t, "unit", []manifestPackageSpec{
+		{importPath: configPackage, minimum: "0.00"},
+		{importPath: initializerPackage, exception: unitUnmeasurableMeasurementException()},
+		{importPath: servicePackage, exception: unitUnmeasurableMeasurementException()},
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeGoCoverageCommandWithMeasuredZeroConfig
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	err := execute(config{
+		min:             0,
+		suite:           "unit",
+		coverpkg:        strings.Join([]string{configPackage, initializerPackage, servicePackage}, ","),
+		packages:        "./pkg/config",
+		packageManifest: manifestPath,
+	})
+	if err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+
+	wantStderr := strings.Join([]string{
+		"coverage not evaluated: package=" + initializerPackage + " lane=unit (no measurement in profile)",
+		"coverage not evaluated: package=" + servicePackage + " lane=unit (no measurement in profile)",
+		"",
+	}, "\n")
+	if got := stderr.String(); got != wantStderr {
+		t.Fatalf("execute() stderr = %q, want deterministic unmeasured diagnostics %q", got, wantStderr)
+	}
+	if strings.Contains(stderr.String(), "package="+configPackage) {
+		t.Fatalf("execute() stderr = %q, did not report measured package as unmeasured", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Go coverage 0.0% meets minimum 0.0%.") {
+		t.Fatalf("execute() stdout = %q, want unchanged successful gate result", stdout.String())
+	}
+}
+
 func TestExecuteReportsUncoveredBlocksForManifestRegression(t *testing.T) {
 	originalCommandRunner := commandRunner
 	originalStdout := stdoutWriter
@@ -417,6 +469,7 @@ func TestExecuteEnforcesAggregateAndManifestMinimumsIndependently(t *testing.T) 
 		command      commandRunnerFunc
 		wantFailure  string
 		rejectText   string
+		wantStderr   string
 	}{
 		{
 			name:         "aggregate pass cannot mask package regression",
@@ -424,6 +477,7 @@ func TestExecuteEnforcesAggregateAndManifestMinimumsIndependently(t *testing.T) 
 			aggregateMin: 0,
 			command:      fakeGoCoverageCommand,
 			wantFailure:  "package coverage regression: package=" + modulePath + "/pkg/config lane=unit expected-minimum=1.00%",
+			wantStderr:   "coverage not evaluated: package=" + modulePath + "/pkg/config lane=unit (no measurement in profile)\n",
 		},
 		{
 			name:         "package pass cannot mask aggregate regression",
@@ -457,8 +511,8 @@ func TestExecuteEnforcesAggregateAndManifestMinimumsIndependently(t *testing.T) 
 			if tc.rejectText != "" && strings.Contains(err.Error(), tc.rejectText) {
 				t.Fatalf("execute() error = %q, did not expect %q", err.Error(), tc.rejectText)
 			}
-			if stderr.Len() != 0 {
-				t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+			if got := stderr.String(); got != tc.wantStderr {
+				t.Fatalf("execute() stderr = %q, want %q", got, tc.wantStderr)
 			}
 		})
 	}

--- a/cmd/gocoveragecheck/manifest.go
+++ b/cmd/gocoveragecheck/manifest.go
@@ -315,6 +315,21 @@ func checkCoverageManifest(manifest coverageManifest, totals map[string]packageC
 	return failures
 }
 
+func formatUnmeasuredCoverageManifestDiagnostics(manifest coverageManifest, measuredTotals map[string]packageCoverageTotals) []string {
+	diagnostics := make([]string, 0)
+	for _, entry := range manifest.Packages {
+		if _, measured := measuredTotals[entry.Package]; measured {
+			continue
+		}
+		diagnostics = append(diagnostics, fmt.Sprintf(
+			"coverage not evaluated: package=%s lane=%s (no measurement in profile)",
+			entry.Package,
+			manifest.Lane,
+		))
+	}
+	return diagnostics
+}
+
 func checkCoverageManifestWithEpsilon(manifest coverageManifest, totals map[string]packageCoverageTotals, manifestPath string, epsilon float64) ([]string, []string) {
 	return checkCoverageManifestWithEpsilonAndBlocks(manifest, totals, manifestPath, epsilon, nil)
 }


### PR DESCRIPTION
{
  "project": "Coverage Gate Silence Is Not a Pass",
  "branchName": "thr-coverage-gate-silence-is-not-a-pass",
  "description": "Make gocoveragecheck explicitly report when package coverage floors were not evaluated because the underlying test suite failed and when a package required by the active coverage manifest has no measurement in a completed profile. The change is diagnostic only: it preserves every existing pass/fail decision, threshold, manifest, baseline, and merged block-level report while preventing operators from interpreting silence as a clean coverage result.",
  "context": {
    "customerAsk": "Remove two forms of coverage-gate silence inside cmd/gocoveragecheck/: report that package floors were not checked when the underlying test suite fails, including a substantiated failure count when available, and report each manifest package missing from a completed coverage profile as unmeasured. Preserve existing pass/fail outcomes, build on PR #1980's block-level reporting, and prove the behavior with the established fake process test plumbing.",
    "problem": "execute() returns as soon as run(cfg) reports a failed test execution, before package floor evaluation or floor output, and it does not say that coverage was skipped. Operators have therefore read zero coverage-regression lines as a clean result even though coverage was never evaluated. Separately, a package named by the active manifest can be absent from an otherwise completed profile and report, making an unmeasured package look as though it passed.",
    "solution": "At the existing command boundary, distinguish failed-test execution from configuration, validation, parsing, and IO failures. Emit a greppable skipped-floor diagnostic before returning the original test failure, using the observed failing-test count only when trustworthy. For completed profiles, compare manifest expectations with measured package totals and emit a deterministic unmeasured diagnostic for every absent package. Keep the implementation and tests local to cmd/gocoveragecheck/ and leave all gate decisions and block-level reporting unchanged."
  },
  "acceptanceCriteria": [
    "When the underlying coverage test run observes at least one test failure, stderr contains 'coverage not evaluated' and 'package floors were NOT checked'; it includes the actual observed failure count when available and never invents a count.",
    "A test-failing run retains its existing non-zero outcome, while configuration, validation, and IO errors retain their existing diagnostics and do not receive the test-failure-only warning.",
    "Every package listed in the active coverage manifest but absent from a completed profile is reported as 'coverage not evaluated: package=<import path> lane=<lane> (no measurement in profile)' rather than being silently omitted.",
    "Existing total floors, package floors, manifest and baseline values, block-level regression reporting, and all pass/fail decisions remain unchanged; implementation stays within cmd/gocoveragecheck/ and does not touch pkg/services/workers, coverage_blocks.go, or any coverage manifest or baseline file.",
    "Before/after command output in a PR comment demonstrates the previously silent failing-test case and the new diagnostic on the changed binary, including the non-zero result; evidence about a CI run is recorded in a PR comment and never in a commit.",
    "Typecheck and focused tests pass, including go test ./cmd/gocoveragecheck/...; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts are resolved, and the PR is actually merged; the implementation stage ends after its final rebased head is pushed, the PR is open, CI has started, and blocking feedback is addressed, while the review stage owns terminal passing CI and the merge."
  ],
  "userStories": [
    {
      "id": "thr-coverage-gate-silence-is-not-a-pass-001",
      "title": "Explain skipped floors when tests fail",
      "description": "As an operator reading a failed coverage job, I want the command to state that coverage floors were not evaluated so I cannot mistake missing regression lines for a clean coverage result.",
      "acceptanceCriteria": [
        "A run whose underlying go test output establishes one or more failed tests writes a stderr line containing 'coverage not evaluated', the substantiated failure count, and 'package floors were NOT checked' before returning its error.",
        "If the error is known to represent test failure but no trustworthy count is available, the command emits the skipped-floor warning without a count rather than remaining silent or inventing a count.",
        "The same test-failing scenario still produces a non-zero process exit and retains the underlying test-failure diagnostic.",
        "A configuration error returns the same diagnostic and non-zero behavior as before and does not emit the test-failure-only 'coverage not evaluated' warning.",
        "Focused tests exercise the real command boundary through the established fake process plumbing and assert the emitted stderr strings and process exit outcome.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented typed coverage-test failure diagnostics at the command boundary. Explicit failed-test markers report their observed count; failures without a trustworthy count report the warning without inventing one. Focused fake-process tests cover stderr, preserved failure outcome, and configuration-error silence."
    },
    {
      "id": "thr-coverage-gate-silence-is-not-a-pass-002",
      "title": "Report manifest packages with no measurement",
      "description": "As an operator reviewing a completed coverage report, I want every manifest package missing from the profile identified as unmeasured so absence cannot be interpreted as passing its floor.",
      "acceptanceCriteria": [
        "For a completed coverage profile, each package expected by the active manifest but missing from measured package totals emits exactly one diagnostic shaped as 'coverage not evaluated: package=<import path> lane=<lane> (no measurement in profile)'.",
        "The diagnostic uses the manifest package import path and lane, is deterministic for multiple absent packages, and does not label measured packages as unmeasured.",
        "Existing behavior for measured packages, including package-floor and merged block-level regression output, remains unchanged.",
        "Reporting an absent measurement does not alter any existing gate success or failure decision.",
        "Focused tests create a manifest/profile mismatch through established test fixtures and assert the observable unmeasured diagnostic rather than source structure or registration inventory.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented deterministic command-boundary diagnostics for every active-manifest package absent from completed profile totals. Added fake-process coverage for multiple missing packages, measured-package silence, preserved successful gates, and retained existing package-floor failures with the new diagnostic."
    }
  ]
}
