### PR TITLE
thr-deflake-run-cancellation-unroutable-failed-outcome

### DIFF
--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
@@ -567,17 +567,7 @@ func (e *FactoryEngine) tick(ctx context.Context) (bool, bool, error) {
 	completedDispatches := make(map[string]interfaces.CompletedDispatch)
 	e.logger.Info("engine: [START] running engine tick", "tick", e.runtimeState.TickCount)
 	for _, sub := range e.subsystems {
-		// Cancellation can arrive after beginTick admitted a late Worker
-		// result but before the transitioner observes it. Stop at this
-		// subsystem boundary so a cancellation-induced result is not routed
-		// through the ordinary FAILED arc set.
-		if err := ctx.Err(); err != nil {
-			return false, false, err
-		}
 		rtSnapshot = e.refreshSnapshotBeforeSubsystem(sub, rtSnapshot)
-		if err := ctx.Err(); err != nil {
-			return false, false, err
-		}
 		result, err := e.executeSubsystem(ctx, sub, &rtSnapshot)
 		if err != nil {
 			return false, false, fmt.Errorf("subsystem tick-group %d: %w", sub.TickGroup(), err)

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
@@ -567,7 +567,17 @@ func (e *FactoryEngine) tick(ctx context.Context) (bool, bool, error) {
 	completedDispatches := make(map[string]interfaces.CompletedDispatch)
 	e.logger.Info("engine: [START] running engine tick", "tick", e.runtimeState.TickCount)
 	for _, sub := range e.subsystems {
+		// Cancellation can arrive after beginTick admitted a late Worker
+		// result but before the transitioner observes it. Stop at this
+		// subsystem boundary so a cancellation-induced result is not routed
+		// through the ordinary FAILED arc set.
+		if err := ctx.Err(); err != nil {
+			return false, false, err
+		}
 		rtSnapshot = e.refreshSnapshotBeforeSubsystem(sub, rtSnapshot)
+		if err := ctx.Err(); err != nil {
+			return false, false, err
+		}
 		result, err := e.executeSubsystem(ctx, sub, &rtSnapshot)
 		if err != nil {
 			return false, false, fmt.Errorf("subsystem tick-group %d: %w", sub.TickGroup(), err)

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/root_contract_service_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/root_contract_service_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,6 +29,42 @@ type controlledWorkstationBoundary struct {
 type countingWorkerExecutor struct {
 	calls atomic.Int32
 }
+
+type gatedRuntimeLogger struct {
+	armed       atomic.Bool
+	entered     chan struct{}
+	release     chan struct{}
+	releaseOnce sync.Once
+}
+
+func newGatedRuntimeLogger() *gatedRuntimeLogger {
+	return &gatedRuntimeLogger{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (l *gatedRuntimeLogger) arm() {
+	l.armed.Store(true)
+}
+
+func (l *gatedRuntimeLogger) releaseTick() {
+	l.releaseOnce.Do(func() { close(l.release) })
+}
+
+func (l *gatedRuntimeLogger) Debug(string, ...any) {}
+
+func (l *gatedRuntimeLogger) Info(message string, _ ...any) {
+	if message != "engine: [START] running engine tick" || !l.armed.CompareAndSwap(true, false) {
+		return
+	}
+	close(l.entered)
+	<-l.release
+}
+
+func (l *gatedRuntimeLogger) Warn(string, ...any)    {}
+func (l *gatedRuntimeLogger) Error(string, ...any)   {}
+func (l *gatedRuntimeLogger) Verbose(string, ...any) {}
 
 func (e *countingWorkerExecutor) Execute(
 	context.Context,
@@ -413,6 +450,59 @@ func TestFactoryImpl_RunCancellationPropagatesThroughWorkersBoundary(t *testing.
 	}
 	if state := impl.dispatchPlan.State(); state.Mode != "STOPPED" || state.StopReason != "CANCELLED" {
 		t.Fatalf("cancelled Runtime outbox state = %#v", state)
+	}
+}
+
+// TestFactoryImpl_RunCancellationAbsorbsLateCanceledResult fixes the ordering
+// that previously routed a cancellation-induced result through the ordinary
+// FAILED transition path: the result is admitted, the engine tick is gated,
+// cancellation happens, and the result arrives before the transitioner runs.
+func TestFactoryImpl_RunCancellationAbsorbsLateCanceledResult(t *testing.T) {
+	boundary := newControlledWorkstationBoundary()
+	logger := newGatedRuntimeLogger()
+	runtime, err := newTestFactory(
+		withNet(buildSimpleNet()), withServiceMode(), withWorkerService(boundary),
+		withWorkerExecutor("mock", &passExecutor{}), withLogger(logger),
+	)
+	requireNoRootErr(t, err, "New")
+	impl := runtime.(*factoryImpl)
+	if _, err := submitWorkRequests(t.Context(), runtime, []work.SubmitRequest{{
+		WorkID: "work-cancel-gated", WorkTypeID: "task", TraceID: "trace-cancel-gated",
+	}}); err != nil {
+		t.Fatalf("SubmitWorkRequest: %v", err)
+	}
+	defer logger.releaseTick()
+	runCtx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	runDone := make(chan error, 1)
+	go func() { runDone <- runtime.Run(runCtx) }()
+	request := awaitCanonicalWorkersRequest(t, boundary.requests)
+	if request.Execution.Dispatch.TransitionID != "t-process" {
+		t.Fatalf("gated dispatch transition = %q, want t-process", request.Execution.Dispatch.TransitionID)
+	}
+	written := observeNextBufferedResult(t, runtime)
+	logger.arm()
+	impl.engine.NotifyResult()
+	select {
+	case <-logger.entered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the gated cancellation tick")
+	}
+	cancel()
+	waitForBufferedResult(t, written)
+	logger.releaseTick()
+
+	err = <-runDone
+	if err != nil {
+		t.Fatalf("Run after deterministic late cancellation result = %v, want nil", err)
+	}
+	state := impl.dispatchPlan.State()
+	if state.Mode != "STOPPED" || state.StopReason != "CANCELLED" {
+		t.Fatalf("cancelled Runtime outbox state = %#v, want STOPPED/CANCELLED", state)
+	}
+	late, ok := impl.resultBuffer.Read()
+	if !ok || late.Outcome != workers.OutcomeFailed || late.Error == "" {
+		t.Fatalf("absorbed late cancellation result = (%#v, %t), want retained FAILED cancellation result", late, ok)
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/root_contract_service_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/root_contract_service_test.go
@@ -52,15 +52,15 @@ func (l *gatedRuntimeLogger) releaseTick() {
 	l.releaseOnce.Do(func() { close(l.release) })
 }
 
-func (l *gatedRuntimeLogger) Debug(string, ...any) {}
-
-func (l *gatedRuntimeLogger) Info(message string, _ ...any) {
-	if message != "engine: [START] running engine tick" || !l.armed.CompareAndSwap(true, false) {
+func (l *gatedRuntimeLogger) Debug(message string, _ ...any) {
+	if message != "transitioner: processing results" || !l.armed.CompareAndSwap(true, false) {
 		return
 	}
 	close(l.entered)
 	<-l.release
 }
+
+func (l *gatedRuntimeLogger) Info(string, ...any) {}
 
 func (l *gatedRuntimeLogger) Warn(string, ...any)    {}
 func (l *gatedRuntimeLogger) Error(string, ...any)   {}
@@ -455,8 +455,8 @@ func TestFactoryImpl_RunCancellationPropagatesThroughWorkersBoundary(t *testing.
 
 // TestFactoryImpl_RunCancellationAbsorbsLateCanceledResult fixes the ordering
 // that previously routed a cancellation-induced result through the ordinary
-// FAILED transition path: the result is admitted, the engine tick is gated,
-// cancellation happens, and the result arrives before the transitioner runs.
+// FAILED transition path: the result is admitted, the transitioner starts,
+// cancellation happens inside Execute, and routing then observes cancellation.
 func TestFactoryImpl_RunCancellationAbsorbsLateCanceledResult(t *testing.T) {
 	boundary := newControlledWorkstationBoundary()
 	logger := newGatedRuntimeLogger()
@@ -482,14 +482,15 @@ func TestFactoryImpl_RunCancellationAbsorbsLateCanceledResult(t *testing.T) {
 	}
 	written := observeNextBufferedResult(t, runtime)
 	logger.arm()
+	boundary.results <- canceledWorkersResult(request)
+	waitForBufferedResult(t, written)
 	impl.engine.NotifyResult()
 	select {
 	case <-logger.entered:
 	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for the gated cancellation tick")
+		t.Fatal("timed out waiting for the gated transitioner")
 	}
 	cancel()
-	waitForBufferedResult(t, written)
 	logger.releaseTick()
 
 	err = <-runDone
@@ -500,9 +501,10 @@ func TestFactoryImpl_RunCancellationAbsorbsLateCanceledResult(t *testing.T) {
 	if state.Mode != "STOPPED" || state.StopReason != "CANCELLED" {
 		t.Fatalf("cancelled Runtime outbox state = %#v, want STOPPED/CANCELLED", state)
 	}
-	late, ok := impl.resultBuffer.Read()
-	if !ok || late.Outcome != workers.OutcomeFailed || late.Error == "" {
-		t.Fatalf("absorbed late cancellation result = (%#v, %t), want retained FAILED cancellation result", late, ok)
+	snapshot := impl.engine.GetRuntimeStateSnapshot()
+	if len(snapshot.Results) != 1 || snapshot.Results[0].Outcome != workers.OutcomeFailed ||
+		snapshot.Results[0].Error != workers.ErrWorkstationDispatchCanceled.Error() {
+		t.Fatalf("absorbed late cancellation results = %#v, want retained FAILED cancellation result", snapshot.Results)
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_transitioner.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_transitioner.go
@@ -118,7 +118,7 @@ func (t *TransitionerSubsystem) TickGroup() TickGroup {
 // TODO: this thing needs more tests.
 // Execute reads results and raw dispatch snapshots from the RuntimeStateSnapshot
 // and produces marking mutations for token routing.
-func (t *TransitionerSubsystem) Execute(_ context.Context, snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) (*interfaces.TickResult, error) {
+func (t *TransitionerSubsystem) Execute(ctx context.Context, snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) (*interfaces.TickResult, error) {
 	if len(snapshot.Results) == 0 {
 		return nil, nil
 	}
@@ -130,7 +130,7 @@ func (t *TransitionerSubsystem) Execute(_ context.Context, snapshot *interfaces.
 	var generatedBatches []work.GeneratedSubmissionBatch
 	var completedDispatches []interfaces.CompletedDispatch
 	for i := range results {
-		muts, completedDispatch, batchRecords, err := t.mapToCorrespondingTokenMutations(snapshot, &results[i])
+		muts, completedDispatch, batchRecords, err := t.mapToCorrespondingTokenMutations(ctx, snapshot, &results[i])
 		if err != nil {
 			t.logger.Error("transitioner: error processing result", "error", err, "transition", results[i].TransitionID)
 			return nil, fmt.Errorf("processing result for transition %s: %w", results[i].TransitionID, err)
@@ -155,7 +155,7 @@ func (t *TransitionerSubsystem) Execute(_ context.Context, snapshot *interfaces.
 // arc set and creates new tokens with embedded history.
 // TODO: we should break out the logic here to be referentially transparent and testable independent of the subsystem. Right now its too reliant on internal state.
 // Break out dependency on ID generation as well as the logger/mocker.
-func (t *TransitionerSubsystem) mapToCorrespondingTokenMutations(snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], result *workerexecution.WorkResult) ([]interfaces.MarkingMutation, interfaces.CompletedDispatch, []work.GeneratedSubmissionBatch, error) {
+func (t *TransitionerSubsystem) mapToCorrespondingTokenMutations(ctx context.Context, snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], result *workerexecution.WorkResult) ([]interfaces.MarkingMutation, interfaces.CompletedDispatch, []work.GeneratedSubmissionBatch, error) {
 	currentTransition, ok := t.netDefinition.Transitions[result.TransitionID]
 	if !ok {
 		t.logger.Error("transitioner: unknown transition in result", "transitionID", result.TransitionID)
@@ -210,7 +210,7 @@ func (t *TransitionerSubsystem) mapToCorrespondingTokenMutations(snapshot *inter
 	}
 	t.logArcSelection(result.TransitionID, resolved.outcome)
 	if len(arcs) == 0 {
-		return nil, interfaces.CompletedDispatch{}, nil, fmt.Errorf("transition %s has no arcs for outcome %s", result.TransitionID, resolved.outcome)
+		return nil, interfaces.CompletedDispatch{}, nil, transitionRoutingError(ctx, result.TransitionID, resolved.outcome)
 	}
 
 	var workstationDef *interfaces.FactoryWorkstationConfig
@@ -251,6 +251,13 @@ func (t *TransitionerSubsystem) mapToCorrespondingTokenMutations(snapshot *inter
 
 	t.logger.Info("releasing tokens", "transition", result.TransitionID, "outcome", resolved.outcome, "mutation_count", len(mutations))
 	return mutations, t.buildCompletedDispatch(snapshot, result, resolved, consumedTokens, mutations, now), generatedBatches, nil
+}
+
+func transitionRoutingError(ctx context.Context, transitionID string, outcome workerexecution.WorkOutcome) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return fmt.Errorf("transition %s has no arcs for outcome %s", transitionID, outcome)
 }
 
 func effectiveGeneratedWorkItemLimit(limits interfaces.WorkstationLimits, inputColors []factorytoken.Color) int {

--- a/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_transitioner_failure_resource_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_transitioner_failure_resource_test.go
@@ -2,6 +2,7 @@ package subsystems
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +14,26 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
 )
+
+func TestTransitionerPreservesNoArcDiagnosticWhileContextIsActive(t *testing.T) {
+	net := workerBatchTestNet()
+	net.Transitions["t1"].FailureArcs = nil
+	snapshot := workerBatchSnapshot("")
+	snapshot.Results[0].Outcome = workerexecution.OutcomeFailed
+	snapshot.Results[0].Error = "ordinary failure"
+	transitioner := NewTransitioner(
+		net, nil, testSubsystemNow, testTokenTransformer(net), nil, nil, nil,
+		testWorkPropagationPolicy(),
+	)
+
+	result, err := transitioner.Execute(context.Background(), snapshot)
+	if err == nil || !strings.Contains(err.Error(), "transition t1 has no arcs for outcome FAILED") {
+		t.Fatalf("Execute() = (%#v, %v), want the existing no-arc diagnostic", result, err)
+	}
+	if result != nil {
+		t.Fatalf("Execute() result = %#v, want nil on an unroutable live failure", result)
+	}
+}
 
 func TestTransitioner_ExpectedArtifactFailureUsesFailureDestination(t *testing.T) {
 	now := time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
{
  "project": "Deflake Run Cancellation with an Unroutable Late Failed Outcome",
  "branchName": "thr-deflake-run-cancellation-unroutable-failed-outcome",
  "description": "Make Factory Runtime cancellation deterministic when an in-flight Worker result arrives after Run cancellation. Reproduce the losing interleaving, settle whether cancellation absorbs the late result or failure-capable Factory definitions must declare failure routes, implement only the evidence-selected contract, and prove the race is eliminated without changing verification wiring or neighboring owned services.",
  "context": {
    "customerAsk": "Restore reliable required verification by fixing the nondeterministic cancellation race behind TestFactoryImpl_RunCancellationPropagatesThroughWorkersBoundary. Prove the pre-fix failure at the parent commit, determine whether cancellation should absorb the late result or Factory validation should require failure routing, implement only the evidence-supported behavior, and prove zero failures with repeated race-enabled execution.",
    "problem": "Main CI observed one failure among 1,027 top-level tests when a cancelled Run processed a late cancellation-induced Worker result as FAILED and the transition had no FAILED arcs. Run returned 'transition t-process has no arcs for outcome FAILED' instead of completing in STOPPED/CANCELLED state. The failure is nondeterministic and causes the functional coverage job to exit before measuring any package floor, making unrelated changes red.",
    "solution": "Force the late-result-versus-shutdown ordering with deterministic synchronization, use sibling contracts and authored plus compiled Factory-definition evidence to select Reading A or Reading B, and correct the owning Runtime/subsystem behavior or, only if required, Factory Definitions validation/compilation. Preserve ordinary failure behavior and verify identical parent/head race commands, focused neighboring packages, and the short Go suite without sleeps, retries, skips, timeout changes, coverage changes, or CI-lane rewiring."
  },
  "acceptanceCriteria": [
    "The PR states the exact interleaving that produces 'transition t-process has no arcs for outcome FAILED', names Reading A or Reading B, and cites sibling-contract plus authored-and-compiled-definition evidence that distinguishes failure-capable transitions from non-executing transition types.",
    "Before the production fix, the failure is reproduced on demand at the parent commit using a documented deterministic harness and exact go test -race command with an observed failures-over-N count; after the fix, the identical harness, command, and N produce zero failures at the final head.",
    "The evidence-selected contract is enforced: Reading A makes a cancellation-induced late result complete Run with STOPPED/CANCELLED state, while Reading B rejects a failure-capable Factory definition without a required failure route during validation/compilation with a clear actionable message.",
    "Ordinary non-cancellation FAILED, accepted, rejected, and termination result paths retain their established routing, completion, mutation, and diagnostic behavior with focused behavioral regression tests.",
    "The change remains within the owned Runtime/subsystem packages and Factory Definitions validation/compilation only if Reading B requires it; Workers, worker functional tests, Wire, Recordings, Providers, verification smoke tests, unit-lane wiring, coverage floors, and generated manifests are unchanged.",
    "Typecheck passes; make test and focused race/package tests pass with zero failing tests; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, shared-file changes and merge conflicts are reconciled against current main, and the PR is actually merged; an opened, green, approved, or ready-to-merge PR is not complete."
  ],
  "userStories": [
    {
      "id": "thr-deflake-run-cancellation-unroutable-failed-outcome-001",
      "title": "Establish the deterministic cancellation contract",
      "description": "As a Factory Runtime maintainer, I want a deterministic reproduction and an evidence-backed contract decision so that the fix targets the incorrect behavior instead of merely changing the flaky fixture.",
      "acceptanceCriteria": [
        "A synchronization seam or equivalent harness forces an in-flight dispatch, Run cancellation and Worker cancellation propagation, delivery of a cancellation-induced result, and result handling before shutdown completion without relying on timing luck.",
        "The harness uses no sleep, retry, eventually loop, timeout bump, test skip, quarantine, or relaxed Run assertion, and temporary instrumentation is removed unless it remains as a focused deterministic behavioral regression test.",
        "Applying the same test-only harness to the parent commit reproduces 'transition t-process has no arcs for outcome FAILED' under go test -race; the PR records the exact command, parent SHA, N, and observed failure count.",
        "The audit covers factory/factory.json, examples, and packaged factories at authored and compiled behavior boundaries, distinguishes Worker-result-capable transitions from non-executing transition types, and remains PR evidence rather than a file-inventory or asset-topology test.",
        "The PR records one decision paragraph naming Reading A or Reading B and explains how sibling cancellation, termination, ordinary failure, validation, and compilation contracts support it.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Reading A selected. A gated runtime logger forces dispatch admission, engine tick entry, Run cancellation, cancellation-induced Worker result delivery, and tick resumption before transition handling. On parent 82096af01a22220542899cd2c2b10c8e17aa5d2b, the temporary harness reproduced the exact no-FAILED-arc error 100/100 times with go test -race ./pkg/services/factory_runtime/internal/services/orchestration/runtime -run '^TestFactoryImpl_RunCancellationLateCanceledResultReproducesParentFailure$' -count=100 -v. The authored and compiled factory audit shows failure routes on AGENT_RUN, SCRIPT_RUN, INFERENCE_RUN, and CLASSIFIER_WORKSTATION, while non-executing LOGICAL_MOVE transitions have none."
    },
    {
      "id": "thr-deflake-run-cancellation-unroutable-failed-outcome-002",
      "title": "Enforce the selected cancellation or validation behavior",
      "description": "As an operator cancelling a Factory Session, I want cancellation to complete according to the established Factory contract so that a late in-flight result cannot nondeterministically fail the entire Run or bypass required definition validation.",
      "acceptanceCriteria": [
        "If Reading A is selected, explicit Runtime/subsystem lifecycle state identifies and absorbs cancellation-induced late results without ordinary failure-arc routing; Run returns nil and observable state reaches STOPPED with stop reason CANCELLED.",
        "If Reading B is selected, Factory Definitions validation/compilation rejects every failure-capable transition lacking a required failure route before Run starts, returns an actionable customer-facing message, and the cancellation fixture remains strict but contract-valid.",
        "Exactly one reading is implemented; no speculative dual policy, fallback routing, synthetic failure arc, hidden retry, or silent coercion is introduced.",
        "A focused test fails without the production change and proves the selected observable behavior, while sibling tests prove ordinary non-cancellation Worker failures retain established routing and explicit termination remains successful.",
        "Runtime state ownership, cancellation propagation, result ingress, arc selection, and any validation side effects remain explicit and within their owning package boundaries, with no global state, secondary injection, or unrelated refactor.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "The Transitioner no-arc routing boundary now returns context.Canceled when a late cancellation-induced result is being handled, so Run shutdown absorbs it without ordinary FAILED arc routing. The deterministic regression gates inside TransitionerSubsystem.Execute after result admission and requires Run nil plus observable STOPPED/CANCELLED state; existing cancellation, termination, ordinary failure, result materialization, and terminal-outcome tests remain green."
    },
    {
      "id": "thr-deflake-run-cancellation-unroutable-failed-outcome-003",
      "title": "Prove the race and neighboring behavior are stable",
      "description": "As a reviewer of a concurrency fix, I want repeatable before-and-after and neighboring-package evidence so that the result demonstrates elimination of the race rather than another majority-green sample.",
      "acceptanceCriteria": [
        "At the final head, the same deterministic harness, exact go test -race command, and N used for the parent reproduction report zero failures, and a PR comment compares parent and head failure counts directly.",
        "The affected Runtime and subsystem packages and relevant neighboring orchestration packages pass focused tests, with evidence comparing failure identities or failure sets rather than relying only on total counts.",
        "make test completes with zero failing tests at the final head; compilation alone is not treated as acceptance.",
        "No verification smoke test, unit-lane wiring, coverage floor, coverage manifest, skip, retry, sleep, eventually loop, or timeout is changed to obtain the result.",
        "Any CI evidence later recorded by the review stage comes only from this PR's current head, confirms the cited gate measured the claimed property, and is posted in a PR comment rather than committed to the branch; the implementation iteration finishes once its final head is pushed, the PR is open, CI has started, and blocking feedback is addressed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "The identical final-head harness command with -race and -count=100 passed with zero failures after the routing-site fix; focused runtime, subsystem, and engine race tests, make pkg-maint, make test, and isolated make typecheck passed. The rebased final head is 1bf6c2c3b on current main 700eca34e; PR #1993 is open, the required CI run has started, and the implementation handoff is ready for review. The diff remains limited to Factory Runtime engine, transitioner, and focused Runtime/subsystem contract tests; no verification wiring or neighboring owned service changed."
    }
  ],
  "operatorOverride": {
    "issuedBy": "factory operator",
    "issuedAt": "2026-08-15T15:20:00Z",
    "AAAA00_THE_ONLY_CURRENT_OVERRIDE": "=== PR #1993 REVIEW: KEEP THE TEST, MOVE THE FIX. TWO GATES AGREE. ===\n\nTHIS REPLACES EVERY EARLIER OVERRIDE.\n\nYour reproduction is right and valuable. Your production change is in the wrong\nplace, and Backend Lint independently says so. Both points below are measured, not\nopinion. Full detail is in PR comments 5302653482 and 5302657520.\n\n=== WHAT IS GOOD - DO NOT DELETE IT ===\n\nTestFactoryImpl_RunCancellationAbsorbsLateCanceledResult is a genuine\nDETERMINISTIC reproduction. Gating on the \"engine: [START] running engine tick\"\nlog line to pin the interleaving - admit result, enter tick, cancel, then release -\nis exactly the right instrument. KEEP the gatedRuntimeLogger harness and this test.\n\n=== PROBLEM 1: THE FIX NARROWS THE WINDOW, IT DOES NOT CLOSE IT ===\n\nbeginTick(ctx) admits the buffered result at engine.go:561, BEFORE the subsystem\nloop. Your two guards are inside the loop, both BEFORE executeSubsystem:\n\n    for _, sub := range e.subsystems {\n        if err := ctx.Err(); err != nil { return ... }      guard A\n        rtSnapshot = e.refreshSnapshotBeforeSubsystem(...)\n        if err := ctx.Err(); err != nil { return ... }      guard B\n        result, err := e.executeSubsystem(ctx, sub, &rtSnapshot)   <- ROUTING IS IN HERE\n\nThree orderings:\n  cancel observed before guard A or B  -> absorbed. Your test covers this.\n  CANCEL LANDS AFTER GUARD B, DURING executeSubsystem -> the result is ALREADY\n    ADMITTED and still routes to the ordinary FAILED arc set ->\n    \"transition t-process has no arcs for outcome FAILED\". STILL BROKEN.\n\nYour gated logger fires at the [START] line, which is UPSTREAM of guard A, so the\ntest enters through the one path your guards cover and CANNOT exercise the third\nordering. That is why it passes deterministically while the original race survives.\n\nThis matters especially for a deflake lane: a narrowed window yields a long run of\ngreen - green is the majority outcome for a race even UNFIXED - and then it returns\nweeks later and someone re-derives everything you already know today.\n\n=== PROBLEM 2: BACKEND LINT IS RED, FROM THE SAME CAUSE ===\n\nRun 31889627647, job 95023871085: 7 failing lint targets vs main's baseline of 6.\nThe one NEW failure is yours, and the two guards caused it:\n\n    [agent-factory:pkg-maint]\n    pkg/services/factory_runtime/internal/services/orchestration/engine\n      rule=cyclomatic-complexity target=FactoryEngine.tick\n      actual=17 limit=15\n\nTwo added branches took tick from 15 to 17.\n\n=== THE DIRECTION THAT SOLVES BOTH ===\n\nPut the decision at the ROUTING SITE, not upstream of it:\n\n    pkg/services/factory_runtime/internal/services/orchestration/subsystems/\n      subsystem_transitioner.go:213\n    return nil, ..., fmt.Errorf(\"transition %s has no arcs for outcome %s\", ...)\n    guarded by `if len(arcs) == 0` right after calculateArcsForResolvedResult\n\nA cancellation-induced result reaching that point is EXPECTED, not a defect.\nAbsorbing it there - or refusing to admit results in beginTick once the context is\ndone, so the situation cannot arise - holds NO MATTER WHERE cancellation lands,\nbecause it does not depend on observing cancellation at a particular instant. It\nalso adds ZERO branches to tick, so pkg-maint clears at the same time.\n\nTHE TEST TO WRITE: the same gated interleaving, but with the gate placed so\ncancellation lands INSIDE executeSubsystem. If that passes without the loop guards,\nthe guards are redundant. If it fails with them, the window is proven open.\n\n=== DO NOT FIX THE INHERITED LINT FAILURES ===\n\nBackend Lint is a COUNTED ALLOWANCE RATCHET, not pass/fail. Six targets fail inside\na GREEN job on main: ui-deadcode 4, backend-size 2, package-target-manifest-check 5,\npackaged-factory-consumption-check 1, ownership-inventory-check 16, deadcode 580.\nOnly an EXCEEDED count or a NEW failing target blocks.\n\nSo the backend-size lines naming TestFunctionalQuarantineValidationFailsClosed and\nfunctionalExecutionCatalogRequest, and the package-target-manifest line about\nruntime_snapshot, are INHERITED FROM MAIN. NOT YOURS. Fixing them is scope creep and\nreview will block you for it. pkg-maint is the ONLY one you introduced and the ONLY\none you must clear.\n\nNever read job.conclusion for this gate - read the per-target verdict table or the\nbackend-lint-diagnostics artifact.\n\n=== IF YOU EXTRACT A HELPER TO CUT COMPLEXITY ===\n\nWatch the ping-pong: a helper is new production lines and the touched package's\ncoverage floor moves with it. Keep the split AND cover the helper, and verify BOTH\npkg-maint and the coverage floors before pushing.\n\n=== EVIDENCE STANDARD ===\n\nA single green run is NOT proof for a race. Prove the pre-fix failure reproduces at\nthe PARENT commit, and that your head produces ZERO failures over the same N runs\nunder -race. Record the reproduction command in the PR. Compare FAILURE SETS, not\ncounts, when checking neighbours.\n\nNo skip, no quarantine, no sleep/retry, no timeout bump, no weakened assertion, no\nfloor changes, no -update-manifest.\n\nBefore believing ANY coverage number, check the run's inventory line. If fail is\nnon-zero the gate printed \"coverage not evaluated\" and measured NOTHING - silence is\nnot a pass. If Backend Functional Coverage reddens inside\nTestVerifyFastCommandSmoke_UsesOnlyShortOwnedSuites, that is the amplifier owned by\nlane thr-verifyfast-smoke-executes-the-real-unit-suite - NOT YOURS. Ask for a job\nre-run; change no code.\n\nCOMMIT AND PUSH EVERY SESSION even if incomplete. Never `git stash` in this repo -\nthe stash stack is shared repo-wide across ~10 worktrees. CI evidence goes in a PR\ncomment, never a commit. MERGED is owned by review, not by you.\n\n"
  }
}
