### PR TITLE
thr-verifyfast-smoke-executes-the-real-unit-suite

### DIFF
--- a/tests/functional/observability/verification/makefile_helpers_test.go
+++ b/tests/functional/observability/verification/makefile_helpers_test.go
@@ -45,6 +45,18 @@ func runMakefileTargetDryRun(repoRoot, makefilePath, target string) (string, err
 	return runMakefileTargetWithArgs(repoRoot, makefilePath, "-n", target)
 }
 
+// runMakefileTargetWithPrerequisitesMarkedOld keeps wrapper execution focused
+// on the target recipe. GNU Make merges prerequisites from the included rule
+// and appended stub, so -o is the test-local seam for neutralizing inherited
+// prerequisites during an invocation that must execute the stub.
+func runMakefileTargetWithPrerequisitesMarkedOld(repoRoot, makefilePath, target string, prerequisites ...string) (string, error) {
+	args := make([]string, 0, len(prerequisites)*2)
+	for _, prerequisite := range prerequisites {
+		args = append(args, "-o", prerequisite)
+	}
+	return runMakefileTargetWithArgs(repoRoot, makefilePath, target, args...)
+}
+
 func runMakefileTargetWithArgs(repoRoot, makefilePath, target string, args ...string) (string, error) {
 	makePath, err := exec.LookPath("make")
 	if err != nil {

--- a/tests/functional/observability/verification/makefile_helpers_test.go
+++ b/tests/functional/observability/verification/makefile_helpers_test.go
@@ -41,6 +41,10 @@ func runMakefileTarget(repoRoot, makefilePath, target string) (string, error) {
 	return runMakefileTargetWithArgs(repoRoot, makefilePath, target)
 }
 
+func runMakefileTargetDryRun(repoRoot, makefilePath, target string) (string, error) {
+	return runMakefileTargetWithArgs(repoRoot, makefilePath, "-n", target)
+}
+
 func runMakefileTargetWithArgs(repoRoot, makefilePath, target string, args ...string) (string, error) {
 	makePath, err := exec.LookPath("make")
 	if err != nil {

--- a/tests/functional/observability/verification/verify_tier_contract_test.go
+++ b/tests/functional/observability/verification/verify_tier_contract_test.go
@@ -191,7 +191,13 @@ func TestVerifyFastCommandSmoke_FailureReportsOwnedSuiteAndRerunCommand(t *testi
 		"test":               "@printf '%s\\n' 'stub:test'\n",
 	})
 
-	output, err := runMakefileTarget(repoRoot, makefilePath, "verify-fast")
+	output, err := runMakefileTargetWithPrerequisitesMarkedOld(
+		repoRoot,
+		makefilePath,
+		"verify-fast",
+		"test-unit",
+		"test-ci-workflows",
+	)
 	if err == nil {
 		t.Fatalf("verify-fast unexpectedly succeeded:\n%s", output)
 	}
@@ -213,7 +219,13 @@ func TestVerifyFastCommandSmoke_ContractFailureStopsLaterSuites(t *testing.T) {
 		"test":               "@printf '%s\\n' 'stub:test'\n",
 	})
 
-	output, err := runMakefileTarget(repoRoot, makefilePath, "verify-fast")
+	output, err := runMakefileTargetWithPrerequisitesMarkedOld(
+		repoRoot,
+		makefilePath,
+		"verify-fast",
+		"test-unit",
+		"test-ci-workflows",
+	)
 	if err == nil {
 		t.Fatalf("verify-fast unexpectedly succeeded:\n%s", output)
 	}

--- a/tests/functional/observability/verification/verify_tier_contract_test.go
+++ b/tests/functional/observability/verification/verify_tier_contract_test.go
@@ -133,45 +133,50 @@ fi
 	}
 }
 
-// TestVerifyFastCommandSmoke_UsesOnlyShortOwnedSuites prove verify-fast invokes only short owned suites in order.
+// TestVerifyFastCommandSmoke_UsesOnlyShortOwnedSuites prove verify-fast selects only short owned suites in order.
 func TestVerifyFastCommandSmoke_UsesOnlyShortOwnedSuites(t *testing.T) {
 	repoRoot := testutil.MustRepoPath(t, ".")
+	executionSentinel := filepath.Join(t.TempDir(), "verify-fast-suite-executed")
 	makefilePath := writeVerifyFastWrapperMakefile(t, repoRoot, map[string]string{
 		"typecheck":             "@printf '%s\\n' 'stub:typecheck'\n",
 		"mcp-contract-check":    "@printf '%s\\n' 'stub:mcp-contract-check'\n",
 		"ui-test":               "@printf '%s\\n' 'stub:ui-test'\n",
-		"test":                  "@printf '%s\\n' 'stub:test'\n",
+		"test":                  fmt.Sprintf("@printf '%%s\\n' 'stub:test'\n@printf '%%s\\n' 'selected-suite-executed' > %q\n", executionSentinel),
+		"test-unit":             fmt.Sprintf("@printf '%%s\\n' 'simulated-unit-failure'\n@printf '%%s\\n' 'unit-suite-executed' > %q\n@exit 73\n", executionSentinel),
 		"ui-install-playwright": "@printf '%s\\n' 'unexpected:ui-install-playwright'\n\t@exit 99\n",
 		"ui-integration-test":   "@printf '%s\\n' 'unexpected:ui-integration-test'\n\t@exit 99\n",
 		"test-functional-long":  "@printf '%s\\n' 'unexpected:test-functional-long'\n\t@exit 99\n",
 		"long-tests":            "@printf '%s\\n' 'unexpected:long-tests'\n\t@exit 99\n",
 	})
 
-	output, err := runMakefileTarget(repoRoot, makefilePath, "verify-fast")
+	output, err := runMakefileTargetDryRun(repoRoot, makefilePath, "verify-fast")
 	if err != nil {
-		t.Fatalf("run verify-fast wrapper: %v\n%s", err, output)
+		t.Fatalf("dry-run verify-fast wrapper: %v\n%s", err, output)
+	}
+	if _, err := os.Stat(executionSentinel); !os.IsNotExist(err) {
+		t.Fatalf("dry-run verify-fast executed a suite recipe; sentinel error = %v\n%s", err, output)
 	}
 
 	assertOutputOrder(t, output,
 		"Running fast verification tier: typecheck + MCP contract boundary + short UI/unit suite + short Go suite",
 		"==> dashboard typecheck [make typecheck]",
-		"stub:typecheck",
+		"typecheck ||",
 		"==> MCP contract boundary [make mcp-contract-check]",
-		"stub:mcp-contract-check",
+		"mcp-contract-check ||",
 		"==> short UI/unit suite [make ui-test]",
-		"stub:ui-test",
+		"ui-test ||",
 		"==> short Go suite [make test]",
-		"stub:test",
+		"test ||",
 	)
 
 	for _, unwanted := range []string{
-		"unexpected:ui-install-playwright",
-		"unexpected:ui-integration-test",
-		"unexpected:test-functional-long",
-		"unexpected:long-tests",
+		"[make ui-install-playwright]",
+		"[make ui-integration-test]",
+		"[make test-functional-long]",
+		"[make long-tests]",
 	} {
 		if strings.Contains(output, unwanted) {
-			t.Fatalf("verify-fast unexpectedly ran %q:\n%s", unwanted, output)
+			t.Fatalf("verify-fast unexpectedly selected %q:\n%s", unwanted, output)
 		}
 	}
 }


### PR DESCRIPTION
{
  "project": "Make the verify-fast Smoke Test Observe Selection Without Running the Unit Suite",
  "branchName": "thr-verifyfast-smoke-executes-the-real-unit-suite",
  "description": "Correct the functional verification contract tests so the verify-fast smoke continues to prove required short-suite selection, ordering, exclusions, failure reporting, and short-circuiting without executing the selected suites or their inherited prerequisites. Audit every shared wrapper caller, isolate the functional tier from unrelated unit flakes, preserve production verify-fast behavior, and complete delivery through actual PR merge.",
  "context": {
    "customerAsk": "Make TestVerifyFastCommandSmoke_UsesOnlyShortOwnedSuites assert the verify-fast selection contract without executing the real unit suite, audit all callers of writeVerifyFastWrapperMakefile for the same prerequisite-merging defect, preserve the original assertions, prove isolation and regression sensitivity, and keep production verification behavior unchanged.",
    "problem": "The wrapper Makefile includes the real Makefile and appends stubs, but GNU Make merges prerequisites across repeated rules. Stubbing the prerequisite-only test target therefore retains test-unit and test-ci-workflows, silently executing the repository unit lane. Any nondeterministic unit failure can redden Backend Functional Coverage before coverage is measured, while adding roughly 144–155 seconds of duplicate work.",
    "solution": "Observe Make target selection without executing selected suites, preferring a dry-run or equivalent non-executing plan and falling back to test-local prerequisite neutralization. Use a root Makefile prerequisite seam only if both test-local options are evidenced as unworkable. Preserve all positive, ordering, exclusion, short-circuit, and rerun assertions; prove isolation with deterministic sentinels and a simulated unit failure; and audit and correct all 15 shared-helper call sites."
  },
  "acceptanceCriteria": [
    "Before-change evidence demonstrates that stubbing test still executes test-unit, including command/output and wall time; after-change evidence shows that the focused smoke does not execute the unit lane and has a materially reduced wall time.",
    "The verify-fast smoke observes typecheck, mcp-contract-check, ui-test, and test in their required order without executing selected suites, and it still rejects ui-install-playwright, ui-integration-test, test-functional-long, and long-tests.",
    "A simulated unit failure cannot fail the selection smoke, while temporary intentional omissions, reordering, or long-lane inclusion still make the smoke fail; all intentional mutations are absent from the final head.",
    "All 15 current writeVerifyFastWrapperMakefile calls have a PR-recorded safe/unsafe verdict, and every caller vulnerable to inherited prerequisite execution is corrected without changing the production verification-tier contract.",
    "Changes remain in tests/functional/observability/verification unless both test-local approaches are evidenced as unworkable; the root Makefile is touched only for justified approach (c), and no excluded ownership area, coverage floor, manifest, generated contract, or unrelated test changes.",
    "Quality gates: Typecheck passes; make test passes with zero failing tests; focused verification functional tests pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are reconciled, and the PR is actually merged; CI evidence is recorded in PR comments and never in commits."
  ],
  "userStories": [
    {
      "id": "thr-verifyfast-smoke-executes-the-real-unit-suite-001",
      "title": "Observe verify-fast selection without executing selected suites",
      "description": "As a maintainer, I want the verify-fast smoke test to inspect the selected short verification lanes without running them so that unrelated unit flakes cannot fail the functional coverage tier.",
      "acceptanceCriteria": [
        "A before-change reproduction shows that the wrapper's test stub retains and executes the real test-unit prerequisite, with command/output and elapsed time captured for the PR.",
        "The corrected smoke completes without invoking the real unit lane or any other selected suite, and a deterministic sentinel or fake command proves that selected-suite execution would be detected.",
        "A simulated failing unit target does not fail TestVerifyFastCommandSmoke_UsesOnlyShortOwnedSuites because that target is not executed.",
        "Output observation still proves the required order: typecheck, mcp-contract-check, ui-test, then test.",
        "Output observation still fails for a temporary missing or reordered required lane and for a temporarily included long lane; the final head contains none of those intentional mutations.",
        "The after-change focused-test wall time is recorded and is a small fraction of the prior roughly 144–155 seconds.",
        "The production behavior of make verify-fast is unchanged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Selection smoke now uses GNU Make dry-run observation with a temporary sentinel and simulated failing test-unit recipe. Linux focused smoke: 0.297s in-test / 8.16s including startup; verification package passes. Temporary omission, reorder, and long-lane mutations each failed as expected; production Makefile unchanged."
    },
    {
      "id": "thr-verifyfast-smoke-executes-the-real-unit-suite-002",
      "title": "Make every shared wrapper caller prerequisite-safe",
      "description": "As a maintainer, I want every verification test using the shared wrapper to have an explicit prerequisite-execution boundary so that no sibling selection or failure-contract test silently runs a real suite it intended to stub.",
      "acceptanceCriteria": [
        "The PR enumerates all 15 current helper calls—14 in the verification-tier contract suite and one in the functional-runner contract suite—and gives each a reviewer-verifiable safe/unsafe verdict based on its target prerequisites and observation mode.",
        "Every caller that stubs a prerequisite-only or prerequisite-bearing target is changed so inherited prerequisites cannot execute outside the behavior that caller intentionally measures.",
        "Existing tests continue to prove their runtime contracts, including required lane selection, ordering, failure short-circuiting, exact rerun guidance, aliases, and explicit long-tier selection where applicable.",
        "Focused regression coverage fails if a stubbed target unexpectedly executes a real prerequisite, without relying on repository-wide source, route, command, or registration inventories.",
        "Temporary Makefiles, sentinels, and fake commands are isolated to test-owned temporary paths and leave no persistent repository or environment state.",
        "The root Makefile remains unchanged unless test-local dry-run and prerequisite-neutralization approaches are both evidenced as unworkable; any root change is limited to an overridable prerequisite seam and preserves default behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Audited all 15 helper call sites. The three verify-fast callers that stub prerequisite-bearing test are safe: selection uses make -n, and runtime failure-contract callers mark test-unit and test-ci-workflows old with a test-local -o seam. The other 12 callers stub targets with no declared prerequisites or intentionally execute their recipes. Linux verification package and native make test/typecheck pass; make lint reports six existing baseline violations outside this diff."
    }
  ],
  "operatorOverride": {
    "issuedBy": "factory operator",
    "issuedAt": "2026-08-15T15:35:00Z",
    "AAAA00_THE_ONLY_CURRENT_OVERRIDE": "=== OPERATOR-MEASURED SPECIFICS. DO NOT RE-DERIVE THESE. NOW WITH A THIRD OCCURRENCE. ===\n\nTHIS REPLACES EVERY EARLIER OVERRIDE AND ADDS NEW EVIDENCE MEASURED SINCE.\n\n=== THE EXACT LINE NUMBERS ===\n\n    Makefile:484      test: test-unit test-ci-workflows      <- PREREQUISITE-ONLY, no recipe\n    Makefile:493      test-unit:  $(GO) run ./cmd/unitlane -jobs $(UNIT_DEFAULT_JOBS) ...\n    Makefile:577      verify-fast:  $(call run_verification_step,test,short Go suite)\n\n    tests/functional/observability/verification/makefile_helpers_test.go:16\n        writeVerifyFastWrapperMakefile - writes \"include <repoRoot>/Makefile\"\n        and then APPENDS \"<target>:\" override rules.\n    tests/functional/observability/verification/verify_tier_contract_test.go:137\n        the test; its assertion fires at :152 (\"run verify-fast wrapper: exit status 2\").\n\nBecause the real `test` rule has NO RECIPE, GNU Make merges prerequisites from every\nrule for a target and only REPLACES the recipe - so test-unit still builds - and it\nemits NO \"overriding recipe for target\" warning. The stub looks like it worked. That\nsilence is why this survived so long; do not expect a warning to point at it.\n\n=== MY LEADING FIX SUGGESTION ===\n\nASSERT AGAINST A DRY RUN: `make -n verify-fast`, or a dedicated plan/print target.\nIt makes the measured property and the failure condition IDENTICAL BY CONSTRUCTION -\nyou observe which steps WOULD run and nothing executes. Stubbing harder keeps you in\nthe same trap, because you cannot remove prerequisites from a rule once declared.\nFallbacks in order if a dry run proves unworkable:\n  (b) pass make `--old-file`/`-o` for each prerequisite of a stubbed target;\n  (c) make the prerequisite list overridable (`test: $(TEST_PREREQS)` with\n      `TEST_PREREQS ?= test-unit test-ci-workflows`). (c) is LAST RESORT - it changes\n      a production build file to suit a test.\n\n=== THE GOVERNING PRINCIPLE (normative, merged PR #1991) ===\n\ndocs/internal/standards/code/planning-standards.md section 11:\nA GATE'S MEASUREMENT CONDITION MUST EQUAL ITS FAILURE CONDITION.\n\nHere the measured property is a SELECTION property - \"verify-fast invokes only the\nshort owned suites, in order\" - but the failure condition is \"ANY unit test anywhere\nin the repository fails\". Your fix must close THAT gap. Making the current failures go\naway without closing it is not a fix, and review will say so.\n\n=== THREE MEASURED OCCURRENCES, THREE DIFFERENT INNER TESTS, ALL 2026-08-15 ===\n\n  1. main 82096af01, CI run 31887063216, job 95017869012. Smoke failed at 144.01s;\n     inventory pass=138 fail=1 of 139, 1027 tests. Inner:\n     TestFactoryImpl_RunCancellationPropagatesThroughWorkersBoundary\n     (root_contract_service_test.go:412, orchestration/runtime).\n     A SAME-HEAD RE-RUN of that job then PASSED with zero changes.\n\n  2. PR #1979 head 13342ec4e, CI run 31887874231. Smoke failed at 155.15s;\n     inventory pass=138 fail=1 of 139, 1031 tests. Inner:\n     TestProtocolFailuresMapToStableExecuteFailureKinds/server-failure\n     (protocol_failure_classification_test.go:72, ACP):\n     ExecuteFailure.Kind = \"unknown\", want \"dependency\".\n\n  3. NEW - PR #1978 head b12d78bb0, CI run 31889282673, job 95023114528.\n     Smoke failed at 146.30s; inventory pass=138 fail=1 of 139, 1032 tests,\n     wall=452.326s. Inner:\n     --- FAIL: TestACPExecuteObservesProviderSessionWhileAttemptIsLive (0.00s)\n         run unit lane: exit status 1\n         make[3]: *** [Makefile:493: test-unit] Error 1\n         make[2]: *** [Makefile:577: verify-fast] Error 2\n         verify_tier_contract_test.go:152: run verify-fast wrapper: exit status 2\n\nTHREE DIFFERENT INNER TESTS ON THREE DIFFERENT HEADS is the amplifier signature and\nis your single strongest piece of evidence. Put all three in the PR.\n\n=== THE FREE SAME-HEAD PROOF (use this in your PR, it is very strong) ===\n\nOn occurrence 3, `Backend Unit Coverage` PASSED at b12d78bb0 while the NESTED copy of\nthat same unit suite FAILED. Same commit, same tests, two executions, opposite\nresults. The amplifier runs the unit suite TWICE per CI run, so it hands you a\nsame-head green/red pair for free - nondeterminism OBSERVED, not inferred.\n\n=== WHY IT IS URGENT (the multiplier) ===\n\nA failing test makes the coverage gate report NOTHING:\n\n    coverage not evaluated: 1 failed tests observed; package floors were NOT\n    checked because the coverage test run failed\n\nSo one unrelated unit flake BLANKS the entire functional coverage measurement for main\nand for EVERY PR. Measured cost today: it blanked PR #1979's measurement (which had\nrebased specifically to obtain per-statement diagnostics and received none), and it\nreddened PR #1978, forcing an operator job re-run. Both are on the critical path.\n\n=== DO NOT ===\n\nDo NOT fix the three inner unit tests. The cancellation one belongs to lane\nthr-deflake-run-cancellation-unroutable-failed-outcome; the two ACP ones are separate\nfindings. Do NOT skip or delete this smoke test - its selection property is worth\nkeeping. Do NOT change what verify-fast actually runs; its behavior is correct, only\nthe test's method of observing it is wrong.\n\nAUDIT EVERY writeVerifyFastWrapperMakefile CALLER and report a verdict per caller,\neven the safe ones. Any caller stubbing a prerequisite-only target has the same silent\nhole.\n\n=== BACKEND LINT IS A COUNTED ALLOWANCE RATCHET ===\n\nSix targets fail inside a GREEN job on main: ui-deadcode 4, backend-size 2,\npackage-target-manifest-check 5, packaged-factory-consumption-check 1,\nownership-inventory-check 16, deadcode 580. Only an EXCEEDED count or a NEW failing\ntarget blocks. Do NOT fix the inherited ones - that is scope creep and review will\nblock you for it. Never read job.conclusion for this gate; read the per-target verdict\ntable or the backend-lint-diagnostics artifact.\n\n=== EVIDENCE CAVEAT ===\n\nThe three runs above are on OTHER heads. Per planning-standards, CI evidence you CITE\nAS PASSING must come from a run on YOUR OWN pull request. Use these three as PROBLEM\nevidence and your own PR's runs as FIX evidence.\n\nCOMMIT AND PUSH EVERY SESSION even if incomplete. Never `git stash` in this repo - the\nstash stack is shared repo-wide across ~10 worktrees. CI evidence goes in a PR comment,\nnever a commit. MERGED is owned by review, not by you.\n\n"
  }
}
