### PR TITLE
thr-deflake-cancellation-event-order-whitelist

### DIFF
--- a/tests/functional/factory/invocation/btrc_p0_cancellation_characterization_test.go
+++ b/tests/functional/factory/invocation/btrc_p0_cancellation_characterization_test.go
@@ -2,6 +2,7 @@ package oneshot_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -90,42 +91,113 @@ func TestBTRCP0OneShotCancellationCharacterization(t *testing.T) {
 	}
 }
 
-var btrcOneShotCanceledEventOrders = [][]interfaces.FactoryEventType{
-	{
-		interfaces.FactoryEventTypeRunRequest,
-		interfaces.FactoryEventTypeInitialStructureRequest,
-		interfaces.FactoryEventTypeSessionStarted,
-		interfaces.FactoryEventTypeFactoryStateResponse,
-		interfaces.FactoryEventTypeWorkRequest,
-		interfaces.FactoryEventTypeDispatchRequest,
-		interfaces.FactoryEventTypeDispatchWorkerSessionAssoc,
-		interfaces.FactoryEventTypeModelRequest,
-		interfaces.FactoryEventTypeModelResponse,
-		interfaces.FactoryEventTypeFactoryStateResponse,
-		interfaces.FactoryEventTypeRunResponse,
-		interfaces.FactoryEventTypeSessionResultUpdated,
-		interfaces.FactoryEventTypeSessionCompleted,
-	},
-	{
-		interfaces.FactoryEventTypeRunRequest,
-		interfaces.FactoryEventTypeInitialStructureRequest,
-		interfaces.FactoryEventTypeSessionStarted,
-		interfaces.FactoryEventTypeFactoryStateResponse,
-		interfaces.FactoryEventTypeWorkRequest,
-		interfaces.FactoryEventTypeDispatchRequest,
-		interfaces.FactoryEventTypeDispatchWorkerSessionAssoc,
-		interfaces.FactoryEventTypeModelRequest,
-		interfaces.FactoryEventTypeFactoryStateResponse,
-		interfaces.FactoryEventTypeModelResponse,
-		interfaces.FactoryEventTypeRunResponse,
-		interfaces.FactoryEventTypeSessionResultUpdated,
-		interfaces.FactoryEventTypeSessionCompleted,
-	},
+func TestBTRCOneShotCanceledEventOrderForcesModelResponseInterleavings(t *testing.T) {
+	cases := []struct {
+		name  string
+		types []interfaces.FactoryEventType
+	}{
+		{
+			name: "before-first-terminal-event",
+			types: []interfaces.FactoryEventType{
+				interfaces.FactoryEventTypeRunRequest,
+				interfaces.FactoryEventTypeInitialStructureRequest,
+				interfaces.FactoryEventTypeSessionStarted,
+				interfaces.FactoryEventTypeFactoryStateResponse,
+				interfaces.FactoryEventTypeWorkRequest,
+				interfaces.FactoryEventTypeDispatchRequest,
+				interfaces.FactoryEventTypeDispatchWorkerSessionAssoc,
+				interfaces.FactoryEventTypeModelRequest,
+				interfaces.FactoryEventTypeModelResponse,
+				interfaces.FactoryEventTypeAgentRunResponse,
+				interfaces.FactoryEventTypeFactoryStateResponse,
+				interfaces.FactoryEventTypeRunResponse,
+				interfaces.FactoryEventTypeSessionResultUpdated,
+				interfaces.FactoryEventTypeSessionCompleted,
+			},
+		},
+		{
+			name: "between-factory-state-and-run-response",
+			types: []interfaces.FactoryEventType{
+				interfaces.FactoryEventTypeRunRequest,
+				interfaces.FactoryEventTypeInitialStructureRequest,
+				interfaces.FactoryEventTypeSessionStarted,
+				interfaces.FactoryEventTypeFactoryStateResponse,
+				interfaces.FactoryEventTypeWorkRequest,
+				interfaces.FactoryEventTypeDispatchRequest,
+				interfaces.FactoryEventTypeDispatchWorkerSessionAssoc,
+				interfaces.FactoryEventTypeModelRequest,
+				interfaces.FactoryEventTypeFactoryStateResponse,
+				interfaces.FactoryEventTypeAgentRunResponse,
+				interfaces.FactoryEventTypeModelResponse,
+				interfaces.FactoryEventTypeRunResponse,
+				interfaces.FactoryEventTypeSessionResultUpdated,
+				interfaces.FactoryEventTypeSessionCompleted,
+			},
+		},
+		{
+			name: "after-session-completed",
+			types: []interfaces.FactoryEventType{
+				interfaces.FactoryEventTypeRunRequest,
+				interfaces.FactoryEventTypeInitialStructureRequest,
+				interfaces.FactoryEventTypeSessionStarted,
+				interfaces.FactoryEventTypeFactoryStateResponse,
+				interfaces.FactoryEventTypeWorkRequest,
+				interfaces.FactoryEventTypeDispatchRequest,
+				interfaces.FactoryEventTypeDispatchWorkerSessionAssoc,
+				interfaces.FactoryEventTypeModelRequest,
+				interfaces.FactoryEventTypeFactoryStateResponse,
+				interfaces.FactoryEventTypeRunResponse,
+				interfaces.FactoryEventTypeSessionResultUpdated,
+				interfaces.FactoryEventTypeSessionCompleted,
+				interfaces.FactoryEventTypeAgentRunResponse,
+				interfaces.FactoryEventTypeModelResponse,
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assertBTRCOneShotCanceledEventOrder(t, btrcOneShotCanceledEvents(testCase.types))
+		})
+	}
+}
+
+func btrcOneShotCanceledEvents(types []interfaces.FactoryEventType) []interfaces.FactoryEvent {
+	events := make([]interfaces.FactoryEvent, len(types))
+	for index, eventType := range types {
+		events[index] = interfaces.FactoryEvent{
+			Type: eventType,
+			Id:   fmt.Sprintf("canceled-event-%d", index),
+			Context: interfaces.FactoryEventContext{
+				Sequence: index,
+			},
+		}
+	}
+	return events
+}
+
+var btrcOneShotCanceledEventOrder = []interfaces.FactoryEventType{
+	interfaces.FactoryEventTypeRunRequest,
+	interfaces.FactoryEventTypeInitialStructureRequest,
+	interfaces.FactoryEventTypeSessionStarted,
+	interfaces.FactoryEventTypeFactoryStateResponse,
+	interfaces.FactoryEventTypeWorkRequest,
+	interfaces.FactoryEventTypeDispatchRequest,
+	interfaces.FactoryEventTypeDispatchWorkerSessionAssoc,
+	interfaces.FactoryEventTypeModelRequest,
+	interfaces.FactoryEventTypeFactoryStateResponse,
+	interfaces.FactoryEventTypeRunResponse,
+	interfaces.FactoryEventTypeSessionResultUpdated,
+	interfaces.FactoryEventTypeSessionCompleted,
 }
 
 func assertBTRCOneShotCanceledEventOrder(t *testing.T, events []interfaces.FactoryEvent) {
 	t.Helper()
 	types := make([]interfaces.FactoryEventType, 0, len(events))
+	modelRequestCount := 0
+	modelRequestIndex := -1
+	modelResponseCount := 0
+	modelResponseIndex := -1
 	for index, event := range events {
 		if event.Context.Sequence != index {
 			t.Fatalf("canceled event[%d] sequence = %d, want %d", index, event.Context.Sequence, index)
@@ -133,19 +205,35 @@ func assertBTRCOneShotCanceledEventOrder(t *testing.T, events []interfaces.Facto
 		if strings.TrimSpace(event.Id) == "" {
 			t.Fatalf("canceled event[%d] id is empty", index)
 		}
-		// Agent-run responses are emitted only if cancellation loses the race
-		// with the detached run. Exclude that optional observation so this
-		// characterization asserts the deterministic lifecycle ordering.
-		if event.Type != interfaces.FactoryEventTypeAgentRunResponse {
+		switch event.Type {
+		case interfaces.FactoryEventTypeModelRequest:
+			modelRequestCount++
+			modelRequestIndex = index
+			types = append(types, event.Type)
+		case interfaces.FactoryEventTypeModelResponse:
+			modelResponseCount++
+			modelResponseIndex = index
+		case interfaces.FactoryEventTypeAgentRunResponse:
+			// AGENT_RUN_RESPONSE is emitted by detached-run cleanup, while
+			// MODEL_RESPONSE is emitted while the provider unwinds cancellation.
+			// Both observations race the invocation terminal lifecycle, so
+			// neither belongs in its canonical order comparison.
+		default:
 			types = append(types, event.Type)
 		}
 	}
-	for _, want := range btrcOneShotCanceledEventOrders {
-		if reflect.DeepEqual(types, want) {
-			return
-		}
+	if modelRequestCount != 1 {
+		t.Fatalf("canceled MODEL_REQUEST count = %d, want exactly one", modelRequestCount)
 	}
-	t.Fatalf("canceled canonical event order = %v, want one of %v", types, btrcOneShotCanceledEventOrders)
+	if modelResponseCount != 1 {
+		t.Fatalf("canceled MODEL_RESPONSE count = %d, want exactly one", modelResponseCount)
+	}
+	if modelResponseIndex <= modelRequestIndex {
+		t.Fatalf("canceled MODEL_RESPONSE index = %d, want strictly after MODEL_REQUEST index %d", modelResponseIndex, modelRequestIndex)
+	}
+	if !reflect.DeepEqual(types, btrcOneShotCanceledEventOrder) {
+		t.Fatalf("canceled canonical event order = %v, want %v", types, btrcOneShotCanceledEventOrder)
+	}
 }
 
 type btrcBlockingProvider struct {


### PR DESCRIPTION
{
  "project": "Assert Cancellation Lifecycle Invariants Without Whitelisting a Race",
  "branchName": "thr-deflake-cancellation-event-order-whitelist",
  "description": "Deflake the one-shot cancellation characterization by replacing its incomplete full-event-order whitelist with one deterministic lifecycle assertion plus separate model-response count and happens-after checks, while preserving event integrity invariants, forcing all reachable interleavings, mutation-testing the gate, and sweeping sibling cancellation tests without changing production code.",
  "context": {
    "customerAsk": "Correct TestBTRCP0OneShotCancellationCharacterization so it accepts every valid MODEL_RESPONSE position created by cancellation, preserves sequence and event-ID integrity, deterministically proves all three reachable interleavings and a negative lifecycle mutation, sweeps cancellation and interruption order assertions for the same defect, and remains a strictly test-only PR.",
    "problem": "The cancellation helper compares a full event-type sequence against two hardcoded permutations even though MODEL_RESPONSE is emitted by provider unwind concurrently with the invocation terminal path. CI rejected the valid third ordering with MODEL_RESPONSE last, while same-head reruns and repeated main/PR measurements show a pre-existing 1.7-2.5% flake. The gate measures a race-dependent interleaving but reports a deterministic lifecycle-order failure.",
    "solution": "Exclude both AGENT_RUN_RESPONSE and MODEL_RESPONSE from one canonical lifecycle-order comparison, assert exactly one MODEL_REQUEST and MODEL_RESPONSE with request strictly before response, and retain complete sequence/index and ID checks. Use deterministic test coordination to force all three known interleavings, prove a deliberate lifecycle-order mutation still fails, inspect sibling cancellation/interrupt order assertions, and publish commands and outputs in PR comments rather than commits."
  },
  "acceptanceCriteria": [
    "The canceled event-order gate compares one canonical deterministic lifecycle order after excluding both AGENT_RUN_RESPONSE and MODEL_RESPONSE; the obsolete full-sequence whitelist is removed, and no relative ordering between MODEL_RESPONSE and RUN_RESPONSE, SESSION_RESULT_UPDATED, or SESSION_COMPLETED is asserted.",
    "The characterization requires exactly one MODEL_REQUEST, exactly one MODEL_RESPONSE, and places the response strictly after the request while retaining every existing event.Context.Sequence == index and non-empty event-ID check.",
    "Deterministic regression coverage explicitly forces all three reachable MODEL_RESPONSE interleavings: before the first terminal lifecycle event, between the intermediate Factory state response and RUN_RESPONSE, and after SESSION_COMPLETED; all three pass at the final head, while before-change evidence shows the last-position case failing with the exact canceled canonical event order diagnostic.",
    "A temporary, uncommitted production mutation that misorders SESSION_RESULT_UPDATED and SESSION_COMPLETED makes the reduced assertion fail; the mutation is reverted, and the before/after and mutation outputs are posted in a PR comment rather than committed.",
    "Every site selected by the required cancellation or interrupt whole-sequence sweep is listed in the PR with its verdict and rationale; only sites proven to pin a race-dependent post-cancellation event are changed, no success-only characterization is touched without that proof, and the final committed diff contains no production change under pkg or unrelated cleanup.",
    "Typecheck and tests pass, including go test ./tests/functional/factory/invocation/ -run 'TestBTRCP0' -count=50 without -race; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are reconciled, and the PR is actually merged; the implementation stage ends after its final head is pushed, the PR is open, CI has started, and blocking review feedback is addressed, while the review stage owns terminal-and-passing CI and the merge. CI-run evidence is posted in PR comments and never committed."
  ],
  "userStories": [
    {
      "id": "thr-deflake-cancellation-event-order-whitelist-001",
      "title": "Assert the deterministic cancellation contract",
      "description": "As a maintainer, I want the one-shot cancellation characterization to distinguish deterministic lifecycle order from race-dependent response timing so that valid cancellation runs do not fail unrelated backend PRs.",
      "acceptanceCriteria": [
        "Before changing the helper, deterministic test coordination reproduces the third ordering with MODEL_RESPONSE after SESSION_COMPLETED, and the current helper fails with the exact canceled canonical event order message; the command and verbatim output are recorded in a PR comment.",
        "The lifecycle comparison excludes both AGENT_RUN_RESPONSE and MODEL_RESPONSE and compares the remaining event types with one canonical order rather than a permutation whitelist.",
        "The helper asserts exactly one MODEL_REQUEST, exactly one MODEL_RESPONSE, and MODEL_REQUEST strictly before MODEL_RESPONSE, without constraining the response against terminal lifecycle events.",
        "The existing event sequence/index and non-empty event-ID checks remain active for every event, and the comment names both excluded race-dependent response types and explains their detached or unwinding cancellation race.",
        "Deterministic coverage forces each of the two previously accepted orderings and the previously rejected last-position ordering, and all three pass without sleeps, timeout padding, retries, quarantine, or reliance on chance.",
        "A temporary local swap of SESSION_RESULT_UPDATED and SESSION_COMPLETED in the production lifecycle makes the reduced assertion fail; the mutation is reverted before commit and the failing output is posted in a PR comment.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented the deterministic lifecycle assertion and exact model request/response properties in tests/functional/factory/invocation/btrc_p0_cancellation_characterization_test.go. Deterministic coverage forces MODEL_RESPONSE before terminal lifecycle events, between FACTORY_STATE_RESPONSE and RUN_RESPONSE, and after SESSION_COMPLETED while varying optional AGENT_RUN_RESPONSE placement. Before-change and temporary lifecycle-mutation failures were reproduced locally; focused BTRCP0 -count=50, focused vet, and make typecheck pass. The captured evidence will be posted in the PR conversation when story 002 is complete and the PR is opened."
    },
    {
      "id": "thr-deflake-cancellation-event-order-whitelist-002",
      "title": "Sweep sibling cancellation order assertions and prove repeat stability",
      "description": "As a repository maintainer, I want equivalent cancellation and interruption order assertions inspected and the corrected BTRC scenarios exercised repeatedly so that the same false gate does not remain elsewhere and the focused suite demonstrates stable behavior.",
      "acceptanceCriteria": [
        "rg -n 'EventOrders|assert.*EventOrder' tests/ is used to locate whole-sequence event-order assertions, and every matching scenario whose test name contains Cancel, Canceled, Cancellation, or Interrupt is inspected for a post-cancellation event emitted by an unwinding goroutine.",
        "The PR lists every inspected site, including unchanged sites, and states for each whether its asserted order is deterministic or race-dependent and why; any sibling with the same defect receives the same reduction and property-specific assertions in its owning sibling test file.",
        "The two BTRC success characterizations and all other non-defective sites remain unchanged unless the sweep supplies concrete evidence that they pin the same race-dependent behavior.",
        "At the final reconciled head, go test ./tests/functional/factory/invocation/ -run 'TestBTRCP0' -count=50 passes without -race, and the exact command plus ok/elapsed output line is posted in a PR comment rather than committed.",
        "The final diff is limited to tests/functional/factory/invocation/btrc_p0_cancellation_characterization_test.go and sibling test files proven by the sweep to carry the same defect; it contains no pkg changes, quarantine changes, or broad cleanup.",
        "If PR #1993 has not merged when the branch is prepared for final push, the branch is rebased onto origin/main rather than hand-merged; any generator output required by reconciliation is regenerated and committed, and focused evidence is rerun on the reconciled final head.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Inspected every whole-sequence event-order helper found by rg -n 'EventOrders|assert.*EventOrder' tests/. The only cancellation-named site is the corrected BTRC cancellation characterization; no sibling assertion pins a post-cancellation unwinding event, so the success/provider-failure, batch, hosted-poller, ACP, and unified replay helpers remain unchanged. The required go test ./tests/functional/factory/invocation/ -run 'TestBTRCP0' -count=50 passed (ok ... 174.646s) without -race, and make typecheck passed. Reproduced the pre-fix whitelist failure and temporary SESSION_RESULT_UPDATED/SESSION_COMPLETED lifecycle mutation failure locally, reverted both, and will post the verbatim evidence in the PR conversation."
    }
  ]
}
