### PR TITLE
thr-service-runner-test-never-starts-its-api-server

### DIFF
--- a/docs/internal/development/functional-latent-failure-inventory.md
+++ b/docs/internal/development/functional-latent-failure-inventory.md
@@ -85,20 +85,14 @@ The two historical passes had identical classifications: 21 failures at both
 commits, 14 passes at both commits, and one setup-incomparable skip at both
 commits. There was no test that failed at `ed502b781` and passed at
 `db7379d47`; no genuine tip-only regression was found. This lane repaired five
-alignment rows that had failed in that historical comparison, leaving 16
-same-machine failures as confirmed pre-existing candidates for the next
-quarantine story. The 14 CI failures that passed when isolated on both commits
-remain ambiguous/non-reproduced and must not be quarantined. The observability
-row is setup-incomparable because its Linux-only test files are not runnable on
-this Windows machine and must not be quarantined from this comparison.
-same-machine failures as confirmed pre-existing candidates for the next
-quarantine story. The service-command-runner parent and two nested rows are
-also repaired in this lane, leaving 13 same-machine failures as confirmed
-pre-existing candidates for the next quarantine story. The 14 CI failures that
-passed when isolated on both commits remain ambiguous/non-reproduced and must
-not be quarantined. The observability row is setup-incomparable because its
-Linux-only test files are not runnable on this Windows machine and must not be
-quarantined from this comparison.
+alignment rows that had failed in that historical comparison. The
+service-command-runner parent and two nested rows are also repaired in this
+lane, leaving 13 same-machine failures as confirmed pre-existing candidates
+for the next quarantine story. The 14 CI failures that passed when isolated on
+both commits remain ambiguous/non-reproduced and must not be quarantined. The
+observability row is setup-incomparable because its Linux-only test files are
+not runnable on this Windows machine and must not be quarantined from this
+comparison.
 
 | # | Package | Test identity | `ed502b781` | `db7379d47` | Verdict | Failure or comparison evidence |
 | ---: | --- | --- | --- | --- | --- | --- |

--- a/docs/internal/development/functional-latent-failure-inventory.md
+++ b/docs/internal/development/functional-latent-failure-inventory.md
@@ -20,13 +20,14 @@ later updates to this file.
 
 The raw structured reconciliation is 44 `fail` events: 36 named test events
 and 8 package-summary events. The named events initially produced 36 distinct
-package/test pairs across 8 packages. This lane's alignment selector has since
-passed; its parent and four nested rows were removed from the active inventory,
-leaving 31 distinct package/test pairs. Nested subtests remain separate rows;
-their slash-delimited identities are preserved exactly as emitted. The
-quarantine schema currently accepts only top-level test selectors, so later
-quarantine entries must use the corresponding top-level name while retaining
-these nested identities as evidence.
+package/test pairs across 8 packages. The alignment selector and the
+service-command-runner selector have since passed; their parent and nested
+rows were removed from the active inventory, leaving 28 distinct package/test
+pairs. Nested subtests remain separate rows; their slash-delimited identities
+are preserved exactly as emitted. The quarantine schema currently accepts only
+top-level test selectors, so later quarantine entries must use the
+corresponding top-level name while retaining these nested identities as
+evidence.
 
 ## Distinct authoritative package/test pairs
 
@@ -56,15 +57,12 @@ these nested identities as evidence.
 | `github.com/portpowered/infinite-you/tests/functional/observability/verification` | `TestFunctionalTestVizLaneScriptSmoke_TimesOutAndRetainsDiagnostics` |
 | `github.com/portpowered/infinite-you/tests/functional/product/packaged_factory_portability` | `TestPackagedFactoryInitMaterialization_InvokesOutsideRepositoryWithBootstrapParity` |
 | `github.com/portpowered/infinite-you/tests/functional/providers` | `TestMockWorkers_EndToEndSmokeRunsMixedOutcomesWithoutLiveProviderCredentials` |
-| `github.com/portpowered/infinite-you/tests/functional/providers` | `TestMockWorkers_ServiceCommandRunnerCompletesModelAndScriptWorkers` |
-| `github.com/portpowered/infinite-you/tests/functional/providers` | `TestMockWorkers_ServiceCommandRunnerCompletesModelAndScriptWorkers/model_worker` |
-| `github.com/portpowered/infinite-you/tests/functional/providers` | `TestMockWorkers_ServiceCommandRunnerCompletesModelAndScriptWorkers/script_worker` |
 | `github.com/portpowered/infinite-you/tests/functional/providers/acp` | `TestPackagedTournamentRunsCompetitorsAndJudgeThroughPersistentACPStdio` |
 | `github.com/portpowered/infinite-you/tests/functional/runtime_api` | `TestAPIUnifiedEventLogSmoke_LiveRecordReplayProjectionAndDivergenceUseSameTimeline` |
 | `github.com/portpowered/infinite-you/tests/functional/runtime_api` | `TestDashboard_EngineStateSnapshot_EndToEnd` |
 | `github.com/portpowered/infinite-you/tests/functional/runtime_api` | `TestInferenceEvents_ModelProviderAttemptsRecordInCanonicalHistoryAndArtifact` |
 
-**Active inventory count: 31 distinct package/test pairs.**
+**Active inventory count: 28 distinct package/test pairs.**
 
 ## Parent-versus-tip comparison
 
@@ -93,6 +91,14 @@ quarantine story. The 14 CI failures that passed when isolated on both commits
 remain ambiguous/non-reproduced and must not be quarantined. The observability
 row is setup-incomparable because its Linux-only test files are not runnable on
 this Windows machine and must not be quarantined from this comparison.
+same-machine failures as confirmed pre-existing candidates for the next
+quarantine story. The service-command-runner parent and two nested rows are
+also repaired in this lane, leaving 13 same-machine failures as confirmed
+pre-existing candidates for the next quarantine story. The 14 CI failures that
+passed when isolated on both commits remain ambiguous/non-reproduced and must
+not be quarantined. The observability row is setup-incomparable because its
+Linux-only test files are not runnable on this Windows machine and must not be
+quarantined from this comparison.
 
 | # | Package | Test identity | `ed502b781` | `db7379d47` | Verdict | Failure or comparison evidence |
 | ---: | --- | --- | --- | --- | --- | --- |
@@ -120,13 +126,10 @@ this Windows machine and must not be quarantined from this comparison.
 | 22 | `tests/functional/observability/verification` | `TestFunctionalTestVizLaneScriptSmoke_TimesOutAndRetainsDiagnostics` | SETUP-SKIP (0.57s) | SETUP-SKIP (0.49s) | SETUP-INCOMPARABLE | The Linux test files are absent under Windows build constraints (`[no test files]`); the authoritative Linux assertion was not comparable. |
 | 23 | `tests/functional/product/packaged_factory_portability` | `TestPackagedFactoryInitMaterialization_InvokesOutsideRepositoryWithBootstrapParity` | FAIL (20.40s) | FAIL (18.68s) | CONFIRMED PRE-EXISTING | Both replays timed out waiting for the process API server and reported missing invocation input during shutdown. |
 | 24 | `tests/functional/providers` | `TestMockWorkers_EndToEndSmokeRunsMixedOutcomesWithoutLiveProviderCredentials` | FAIL (6.97s) | FAIL (4.31s) | CONFIRMED PRE-EXISTING | Same-machine rejection/process failure reproduced at both commits; authoritative CI also failed the worker-session start path. |
-| 25 | `tests/functional/providers` | `TestMockWorkers_ServiceCommandRunnerCompletesModelAndScriptWorkers` | FAIL (35.84s) | FAIL (35.71s) | CONFIRMED PRE-EXISTING | Parent failure reproduced at both commits; model and script variants time out waiting for the process API server. |
-| 26 | `tests/functional/providers` | `TestMockWorkers_ServiceCommandRunnerCompletesModelAndScriptWorkers/model_worker` | FAIL (20.84s) | FAIL (20.21s) | CONFIRMED PRE-EXISTING | Timed out waiting for the process API server at both commits. |
-| 27 | `tests/functional/providers` | `TestMockWorkers_ServiceCommandRunnerCompletesModelAndScriptWorkers/script_worker` | FAIL (18.95s) | FAIL (40.86s) | CONFIRMED PRE-EXISTING | Timed out waiting for the process API server at both commits. |
-| 28 | `tests/functional/providers/acp` | `TestPackagedTournamentRunsCompetitorsAndJudgeThroughPersistentACPStdio` | PASS (10.71s) | PASS (5.47s) | AMBIGUOUS | Authoritative CI emitted a failure with only progress-publication warnings; isolated replays passed at both commits. |
-| 29 | `tests/functional/runtime_api` | `TestAPIUnifiedEventLogSmoke_LiveRecordReplayProjectionAndDivergenceUseSameTimeline` | FAIL (22.50s) | FAIL (4.33s) | CONFIRMED PRE-EXISTING | `/events` replay failed with `unexpected EOF` at both commits. |
-| 30 | `tests/functional/runtime_api` | `TestDashboard_EngineStateSnapshot_EndToEnd` | FAIL (7.01s) | FAIL (3.99s) | CONFIRMED PRE-EXISTING | Provider sessions were absent from events; `sess-world-view-success` was missing at both commits. |
-| 31 | `tests/functional/runtime_api` | `TestInferenceEvents_ModelProviderAttemptsRecordInCanonicalHistoryAndArtifact` | FAIL (5.34s) | FAIL (4.61s) | CONFIRMED PRE-EXISTING | Event order stopped before the expected dispatch-created/inference-request/inference-response/dispatch-completed sequence at both commits. |
+| 25 | `tests/functional/providers/acp` | `TestPackagedTournamentRunsCompetitorsAndJudgeThroughPersistentACPStdio` | PASS (10.71s) | PASS (5.47s) | AMBIGUOUS | Authoritative CI emitted a failure with only progress-publication warnings; isolated replays passed at both commits. |
+| 26 | `tests/functional/runtime_api` | `TestAPIUnifiedEventLogSmoke_LiveRecordReplayProjectionAndDivergenceUseSameTimeline` | FAIL (22.50s) | FAIL (4.33s) | CONFIRMED PRE-EXISTING | `/events` replay failed with `unexpected EOF` at both commits. |
+| 27 | `tests/functional/runtime_api` | `TestDashboard_EngineStateSnapshot_EndToEnd` | FAIL (7.01s) | FAIL (3.99s) | CONFIRMED PRE-EXISTING | Provider sessions were absent from events; `sess-world-view-success` was missing at both commits. |
+| 28 | `tests/functional/runtime_api` | `TestInferenceEvents_ModelProviderAttemptsRecordInCanonicalHistoryAndArtifact` | FAIL (5.34s) | FAIL (4.61s) | CONFIRMED PRE-EXISTING | Event order stopped before the expected dispatch-created/inference-request/inference-response/dispatch-completed sequence at both commits. |
 
 The exact command for each row is the per-row command pattern above with the
 row's full test identity and package substituted verbatim. The authoritative
@@ -135,7 +138,7 @@ parent-versus-tip behavior and do not replace that source failure set.
 
 ## Quarantine mapping
 
-The remaining 16 confirmed pre-existing failure rows map to 11 top-level selectors
+The remaining 13 confirmed pre-existing failure rows map to 10 top-level selectors
 because the quarantine schema intentionally matches top-level Go tests. A
 parent selector covers its independently recorded nested subtests; no broader
 package selector is used. Every entry below is `GENUINELY FAILING`, names the
@@ -151,16 +154,18 @@ observed failure, and records reproduction at both `ed502b781` and
 | `tests/functional/cli/named_invocation` | `TestRun_NamedAndExplicitNoSignatureFactoriesPreserveCompatibilityInputs` | 19–20 | `INVOCATION_ARGUMENT_UNKNOWN_ARGUMENT`: `mode` is unknown for `@you/goal` | CLI named invocation / compatibility inputs |
 | `tests/functional/product/packaged_factory_portability` | `TestPackagedFactoryInitMaterialization_InvokesOutsideRepositoryWithBootstrapParity` | 23 | Process API server readiness timeout and missing invocation input during shutdown | Packaged factory portability / bootstrap |
 | `tests/functional/providers` | `TestMockWorkers_EndToEndSmokeRunsMixedOutcomesWithoutLiveProviderCredentials` | 24 | Same-machine rejection/process failure and worker-session start failure | Providers / mock-worker startup |
-| `tests/functional/providers` | `TestMockWorkers_ServiceCommandRunnerCompletesModelAndScriptWorkers` | 25–27 | Process API server readiness timeout in model and script worker variants | Providers / command-runner worker readiness |
-| `tests/functional/runtime_api` | `TestAPIUnifiedEventLogSmoke_LiveRecordReplayProjectionAndDivergenceUseSameTimeline` | 29 | `/events` replay failed with `unexpected EOF` | Runtime API / event replay framing |
-| `tests/functional/runtime_api` | `TestDashboard_EngineStateSnapshot_EndToEnd` | 30 | Provider sessions were absent from events; `sess-world-view-success` was missing | Runtime API / provider-session projection |
-| `tests/functional/runtime_api` | `TestInferenceEvents_ModelProviderAttemptsRecordInCanonicalHistoryAndArtifact` | 31 | Canonical event order stopped before the expected dispatch/inference sequence | Runtime API / inference event emission |
+| `tests/functional/runtime_api` | `TestAPIUnifiedEventLogSmoke_LiveRecordReplayProjectionAndDivergenceUseSameTimeline` | 26 | `/events` replay failed with `unexpected EOF` | Runtime API / event replay framing |
+| `tests/functional/runtime_api` | `TestDashboard_EngineStateSnapshot_EndToEnd` | 27 | Provider sessions were absent from events; `sess-world-view-success` was missing | Runtime API / provider-session projection |
+| `tests/functional/runtime_api` | `TestInferenceEvents_ModelProviderAttemptsRecordInCanonicalHistoryAndArtifact` | 28 | Canonical event order stopped before the expected dispatch/inference sequence | Runtime API / inference event emission |
 
-The 14 ambiguous/non-reproduced rows (1–3, 5–13, 21, and 28) and the one
+The 14 ambiguous/non-reproduced rows (1–3, 5–13, 21, and 25) and the one
 setup-incomparable Windows row (22) remain unquarantined. No failure that
 passed at `ed502b781` and failed at `db7379d47`, or otherwise indicated a
 tip-only regression, was found.
 
 The runtime-config alignment selector changed from observed-fail to
 observed-pass. Its quarantine entry and the five corresponding inventory rows
-were removed after the exact selector passed.
+were removed after the exact selector passed. The service-command-runner
+selector also changed from observed-fail to observed-pass; its quarantine entry
+and three corresponding inventory rows were removed after the exact selector
+passed.

--- a/tests/functional/functional-quarantine.json
+++ b/tests/functional/functional-quarantine.json
@@ -20,13 +20,6 @@
       "followUp": "Repair bootstrap portability readiness and remove this entry after the exact selector passes"
     },
     {
-      "package": "github.com/portpowered/infinite-you/tests/functional/providers",
-      "test": "TestMockWorkers_ServiceCommandRunnerCompletesModelAndScriptWorkers",
-      "bucket": "GENUINELY FAILING",
-      "reason": "Timed out waiting for the process API server in the model and script worker variants; reproduced on the same machine at ed502b781 and db7379d47",
-      "followUp": "Repair command-runner worker readiness and remove this entry after the exact selector passes"
-    },
-    {
       "package": "github.com/portpowered/infinite-you/tests/functional/providers/agy",
       "test": "TestAgyLiveSmoke",
       "bucket": "ENVIRONMENT-DEPENDENT",

--- a/tests/functional/internal/support/process_api_server.go
+++ b/tests/functional/internal/support/process_api_server.go
@@ -19,8 +19,9 @@ const processAPIServerReadyTimeout = 15 * time.Second
 
 // A missing server activation request should be diagnosed before the full
 // readiness ceiling, while still allowing the asynchronously started process
-// enough time to enter the injected starter under normal scheduler variance.
-const processAPIServerStartTimeout = time.Second
+// enough time to enter the injected starter while several functional
+// applications are being initialized concurrently.
+const processAPIServerStartGracePeriod = 5 * time.Second
 
 // ProcessAPIServer is an HTTP transport edge for a root-built process. It owns
 // only the external server boundary and never constructs application services.
@@ -151,8 +152,8 @@ func (server *ProcessAPIServer) waitForURL(timeout time.Duration) (string, error
 	readyTimer := time.NewTimer(timeout)
 	defer readyTimer.Stop()
 	startWait := timeout
-	if startWait > processAPIServerStartTimeout {
-		startWait = processAPIServerStartTimeout
+	if startWait > processAPIServerStartGracePeriod {
+		startWait = processAPIServerStartGracePeriod
 	}
 	startTimer := time.NewTimer(startWait)
 	defer startTimer.Stop()

--- a/tests/functional/internal/support/process_api_server.go
+++ b/tests/functional/internal/support/process_api_server.go
@@ -17,10 +17,16 @@ import (
 // this as a ceiling only: readiness still returns immediately on success.
 const processAPIServerReadyTimeout = 15 * time.Second
 
+// A missing server activation request should be diagnosed before the full
+// readiness ceiling, while still allowing the asynchronously started process
+// enough time to enter the injected starter under normal scheduler variance.
+const processAPIServerStartTimeout = time.Second
+
 // ProcessAPIServer is an HTTP transport edge for a root-built process. It owns
 // only the external server boundary and never constructs application services.
 type ProcessAPIServer struct {
-	ready chan struct{}
+	startedSignal chan struct{}
+	ready         chan struct{}
 
 	mu           sync.Mutex
 	started      bool
@@ -29,7 +35,10 @@ type ProcessAPIServer struct {
 }
 
 func NewProcessAPIServer() *ProcessAPIServer {
-	return &ProcessAPIServer{ready: make(chan struct{})}
+	return &ProcessAPIServer{
+		startedSignal: make(chan struct{}),
+		ready:         make(chan struct{}),
+	}
 }
 
 // HoldShutdownUntilSignaled defers listener teardown, once the owning
@@ -69,6 +78,7 @@ func (server *ProcessAPIServer) Start(
 		return fmt.Errorf("process API server already started")
 	}
 	server.started = true
+	close(server.startedSignal)
 	httpServer := httptest.NewServer(request.Handler)
 	server.url = httpServer.URL
 	if request.OnBound != nil {
@@ -120,35 +130,60 @@ func (server *ProcessAPIServer) Ready() <-chan struct{} {
 // httptest URL.
 func (server *ProcessAPIServer) WaitForURL(t testing.TB) string {
 	t.Helper()
-	if server == nil {
-		t.Fatal("process API server is required")
+	baseURL, err := server.waitForURL(processAPIServerReadyTimeout)
+	if err != nil {
+		t.Fatal(err)
 	}
-	select {
-	case <-server.ready:
-	case <-time.After(processAPIServerReadyTimeout):
-		t.Fatal("timed out waiting for process API server")
-	}
-	server.mu.Lock()
-	defer server.mu.Unlock()
-	if server.url == "" {
-		t.Fatal("process API server became ready without a URL")
-	}
-	return server.url
+	return baseURL
 }
 
 // WaitForBaseURL waits for the injected transport to start and returns its URL
 // or an error. It is safe to call from background goroutines.
 func (server *ProcessAPIServer) WaitForBaseURL(timeout time.Duration) (string, error) {
+	return server.waitForURL(timeout)
+}
+
+func (server *ProcessAPIServer) waitForURL(timeout time.Duration) (string, error) {
 	if server == nil {
 		return "", fmt.Errorf("process API server is required")
 	}
+
+	readyTimer := time.NewTimer(timeout)
+	defer readyTimer.Stop()
+	startWait := timeout
+	if startWait > processAPIServerStartTimeout {
+		startWait = processAPIServerStartTimeout
+	}
+	startTimer := time.NewTimer(startWait)
+	defer startTimer.Stop()
+
 	select {
 	case <-server.ready:
-	case <-time.After(timeout):
-		return "", fmt.Errorf("timed out waiting for process API server")
+	case <-server.startedSignal:
+		select {
+		case <-server.ready:
+		case <-readyTimer.C:
+			return "", fmt.Errorf("timed out waiting for process API server after starter was invoked")
+		}
+	case <-startTimer.C:
+		if server.wasStarted() {
+			select {
+			case <-server.ready:
+			case <-readyTimer.C:
+				return "", fmt.Errorf("timed out waiting for process API server after starter was invoked")
+			}
+		} else {
+			return "", fmt.Errorf("process API server starter was never invoked; --with-server was probably omitted")
+		}
 	}
 	if baseURL, ok := server.BaseURL(); ok {
 		return baseURL, nil
 	}
 	return "", fmt.Errorf("process API server became ready without a URL")
+}
+
+func (server *ProcessAPIServer) wasStarted() bool {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	return server.started
 }

--- a/tests/functional/internal/support/process_api_server_test.go
+++ b/tests/functional/internal/support/process_api_server_test.go
@@ -68,6 +68,36 @@ func TestProcessAPIServerWaitForURLClassifiesInvokedButNotReady(t *testing.T) {
 	}
 }
 
+func TestProcessAPIServerWaitForURLAllowsDelayedStarterAfterInitialProbe(t *testing.T) {
+	server := NewProcessAPIServer()
+	ctx, cancel := context.WithCancel(t.Context())
+	startDone := make(chan error, 1)
+	defer func() {
+		cancel()
+		if err := <-startDone; err != nil {
+			t.Errorf("ProcessAPIServer.Start() error = %v, want nil", err)
+		}
+	}()
+
+	// This deliberately exceeds the former one-second classification window.
+	// The timer models delayed application startup; using it here proves that
+	// package-load variance does not turn a legitimate starter into a missing
+	// activation diagnosis.
+	time.AfterFunc(time.Second+50*time.Millisecond, func() {
+		startDone <- server.Start(ctx, platformhttpserver.StartRequest{
+			Handler: http.NotFoundHandler(),
+		})
+	})
+
+	baseURL, err := server.WaitForBaseURL(processAPIServerReadyTimeout)
+	if err != nil {
+		t.Fatalf("WaitForBaseURL() error = %v, want delayed starter URL", err)
+	}
+	if !strings.HasPrefix(baseURL, "http://") {
+		t.Fatalf("WaitForBaseURL() = %q, want httptest HTTP URL", baseURL)
+	}
+}
+
 func TestProcessAPIServerWaitForURLReturnsDynamicURLAfterStart(t *testing.T) {
 	server := NewProcessAPIServer()
 	ctx, cancel := context.WithCancel(t.Context())

--- a/tests/functional/internal/support/process_api_server_test.go
+++ b/tests/functional/internal/support/process_api_server_test.go
@@ -1,0 +1,93 @@
+package support
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
+)
+
+func TestProcessAPIServerWaitForURLReportsNeverInvokedStarter(t *testing.T) {
+	server := NewProcessAPIServer()
+
+	startedAt := time.Now()
+	_, err := server.WaitForBaseURL(processAPIServerReadyTimeout)
+	if err == nil {
+		t.Fatal("WaitForBaseURL error = nil, want never-invoked diagnostic")
+	}
+	if !strings.Contains(err.Error(), "process API server starter was never invoked") {
+		t.Fatalf("WaitForBaseURL error = %q, want never-invoked diagnostic", err)
+	}
+	if !strings.Contains(err.Error(), "--with-server was probably omitted") {
+		t.Fatalf("WaitForBaseURL error = %q, want --with-server guidance", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed >= processAPIServerReadyTimeout {
+		t.Fatalf("WaitForBaseURL elapsed = %s, want fast failure before readiness ceiling", elapsed)
+	}
+}
+
+func TestProcessAPIServerWaitForURLClassifiesInvokedButNotReady(t *testing.T) {
+	server := NewProcessAPIServer()
+	ctx, cancel := context.WithCancel(t.Context())
+	releaseBound := make(chan struct{})
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- server.Start(ctx, platformhttpserver.StartRequest{
+			Handler: http.NotFoundHandler(),
+			OnBound: func(platformhttpserver.Binding) {
+				<-releaseBound
+			},
+		})
+	}()
+	defer func() {
+		close(releaseBound)
+		cancel()
+		if err := <-startDone; err != nil {
+			t.Errorf("ProcessAPIServer.Start() error = %v, want nil", err)
+		}
+	}()
+
+	select {
+	case <-server.startedSignal:
+	case <-time.After(time.Second):
+		t.Fatal("ProcessAPIServer.Start() did not enter the starter")
+	}
+
+	_, err := server.WaitForBaseURL(50 * time.Millisecond)
+	if err == nil {
+		t.Fatal("WaitForBaseURL error = nil, want invoked-but-not-ready timeout")
+	}
+	if !strings.Contains(err.Error(), "after starter was invoked") {
+		t.Fatalf("WaitForBaseURL error = %q, want invoked-but-not-ready diagnostic", err)
+	}
+	if strings.Contains(err.Error(), "--with-server") {
+		t.Fatalf("WaitForBaseURL error = %q, want no missing-activation diagnosis", err)
+	}
+}
+
+func TestProcessAPIServerWaitForURLReturnsDynamicURLAfterStart(t *testing.T) {
+	server := NewProcessAPIServer()
+	ctx, cancel := context.WithCancel(t.Context())
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- server.Start(ctx, platformhttpserver.StartRequest{
+			Handler: http.NotFoundHandler(),
+		})
+	}()
+
+	baseURL, err := server.WaitForBaseURL(time.Second)
+	if err != nil {
+		t.Fatalf("WaitForBaseURL() error = %v, want dynamic URL", err)
+	}
+	if !strings.HasPrefix(baseURL, "http://") {
+		t.Fatalf("WaitForBaseURL() = %q, want httptest HTTP URL", baseURL)
+	}
+
+	cancel()
+	if err := <-startDone; err != nil {
+		t.Fatalf("ProcessAPIServer.Start() error = %v, want nil", err)
+	}
+}

--- a/tests/functional/providers/mock_workers_service_runner_test.go
+++ b/tests/functional/providers/mock_workers_service_runner_test.go
@@ -36,6 +36,7 @@ func TestMockWorkers_ServiceCommandRunnerCompletesModelAndScriptWorkers(t *testi
 				"--dir", dir,
 				"--continuously",
 				"--server", "http://127.0.0.1:1",
+				"--with-server",
 				"--with-mock-workers",
 				"--runtime-log-dir", logDir,
 				"--quiet",


### PR DESCRIPTION
{
  "project": "Make the Service-Runner API-Server Test Start and Fail Diagnostically",
  "branchName": "thr-service-runner-test-never-starts-its-api-server",
  "description": "Correct the quarantined service-command-runner functional scenario so it explicitly starts the process API server, remove only its repaired quarantine and latent-failure inventory records, and make the test harness fail promptly with an actionable missing --with-server diagnostic when its injected starter was never invoked.",
  "context": {
    "customerAsk": "Add --with-server to TestMockWorkers_ServiceCommandRunnerCompletesModelAndScriptWorkers, remove exactly that selector from functional quarantine and the matching latent-failure inventory, and add a fast-fail ProcessAPIServer harness guard that detects a never-invoked starter without inspecting argv. Keep provider ACP tests, production Providers and wiring, unrelated mock-worker smoke failures, generated files, and other lanes' quarantine entries untouched.",
    "problem": "The functional scenario injects an API-server starter and waits for its URL but never requests CLI server activation. Its model-worker and script-worker subtests therefore each time out after about 15 seconds. The symptom-only harness error hides the settled cause, and leaving the selector registered as expected failure after fixing it would make the two-way quarantine ratchet reject the observed pass.",
    "solution": "Track synchronized starter invocation separately from URL readiness in the test harness, report a prompt actionable failure when the starter was never invoked, explicitly enable the server in the affected CLI invocation, and retire only the repaired selector's quarantine and latent-failure records while proving both worker variants run and pass."
  },
  "acceptanceCriteria": [
    "The exact verbose functional selector passes in well under the former two-timeout duration and shows both model_worker and script_worker ran and passed rather than skipped.",
    "Waiting for a ProcessAPIServer whose starter was never invoked fails promptly and states both that the starter was never invoked and that --with-server was probably omitted.",
    "The harness classifies failure from explicit synchronized invocation/readiness state without scanning argv, while invoked servers retain dynamic-URL readiness and bounded timeout behavior.",
    "Only TestMockWorkers_ServiceCommandRunnerCompletesModelAndScriptWorkers is removed from functional quarantine and its matching latent-failure inventory records; every unrelated selector remains unchanged.",
    "The Providers functional package has no new failure relative to current main, and any pre-existing TestMockWorkers_EndToEndSmoke* failure is explicitly identified as unrelated and left unchanged.",
    "Typecheck and focused tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, shared-file and merge conflicts are resolved against current origin/main, and the PR is actually merged; the implementation stage ends after its final rebased head is pushed, the PR is open, CI has started, and blocking feedback is addressed, while the review stage owns terminal passing CI and merge, and CI evidence is posted in a PR comment and never committed."
  ],
  "userStories": [
    {
      "id": "thr-service-runner-test-never-starts-its-api-server-001",
      "title": "Diagnose a process API server that was never requested",
      "description": "As a functional-test maintainer, I want waiting on a never-invoked process API-server starter to fail promptly with the likely corrective action so a missing activation request is obvious instead of appearing as a slow readiness problem.",
      "acceptanceCriteria": [
        "WaitForURL distinguishes a never-invoked injected starter from an invoked starter that did not become ready, using explicit synchronized harness state rather than scanning argv.",
        "The never-invoked case fails promptly without waiting for the 15-second readiness ceiling and reports both that the starter was never invoked and that the caller probably omitted --with-server.",
        "A direct harness regression test proves the fast failure and actionable message, and deliberate before/after evidence from temporarily omitting the flag records the old symptom-only timeout and new causal message in the PR conversation.",
        "Existing callers that invoke the starter can still obtain the bound dynamic URL, and genuine invoked-but-not-ready behavior retains a bounded readiness failure rather than being mislabeled.",
        "The change does not lengthen, weaken, skip, or broadly restructure the functional support harness.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added synchronized starter-entry tracking, actionable missing --with-server diagnostics, and focused harness tests for never-invoked, invoked-but-not-ready, and dynamic-URL readiness paths."
    },
    {
      "id": "thr-service-runner-test-never-starts-its-api-server-002",
      "title": "Run both service-command-runner workers with an inspectable API server",
      "description": "As a maintainer, I want the service-command-runner functional scenario to request the server it inspects so both worker variants execute quickly and the repaired selector can leave quarantine.",
      "acceptanceCriteria": [
        "The CLI invocation for TestMockWorkers_ServiceCommandRunnerCompletesModelAndScriptWorkers explicitly requests server activation while preserving its existing mocked model-worker and script-worker behavior and API assertions.",
        "go test ./tests/functional/providers/ -run TestMockWorkers_ServiceCommandRunnerCompletesModelAndScriptWorkers -count=1 -v passes in well under the former approximately 30-second duration, with verbose output proving model_worker and script_worker both ran and passed rather than skipped.",
        "Exactly this selector's GENUINELY FAILING quarantine entry is deleted so the ratchet can observe fail to pass without an expected-fail mismatch; no other lane's entry is changed.",
        "The matching selector, subtest, evidence, and ownership references in the latent-failure inventory are reconciled consistently without rewriting unrelated historical or current failures.",
        "go test ./tests/functional/providers/ -count=1 introduces no new failure relative to current main; any existing TestMockWorkers_EndToEndSmoke* failure is called out explicitly and remains unchanged.",
        "The implementation touches no provider ACP test, production Providers service, production wiring, timeout value, or generated file.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added --with-server to the service-command-runner scenario; the exact selector passes in 0.27s with both model_worker and script_worker running and passing. The full providers package retains only the unrelated pre-existing TestMockWorkers_EndToEndSmokeRunsMixedOutcomesWithoutLiveProviderCredentials failure (recorded dispatch count = 5, want 3), unchanged."
    }
  ]
}

