### PR TITLE
ux: preserve every work and attempt

### DIFF
--- a/ui/scripts/verify-bento-card-catalog-storybook-responsive.mjs
+++ b/ui/scripts/verify-bento-card-catalog-storybook-responsive.mjs
@@ -6,7 +6,7 @@ const BENTO_CARD_NAMES = [
   "Submit work",
   "Work outcome chart",
   "Trace drill-down",
-  "Completed and failed work",
+  "Terminal work outcomes",
   "Add widget",
 ];
 
@@ -114,10 +114,26 @@ export async function verifyBentoCardCatalogResponsive({
   );
   await expectVisible(page.getByText("trace-active-story"), "Trace ID value");
   await expectVisible(page.getByText("Transcript"), "Provider transcript tab");
-  await expectVisible(
-    page.getByRole("button", { name: "Failed Story" }),
-    "Terminal work failed item",
-  );
+  const terminalWork = page.getByRole("article", {
+    name: "Terminal work outcomes",
+  });
+  for (const status of ["Completed", "Failed", "Canceled", "Terminated", "Unknown"]) {
+    const statusRegion = terminalWork.getByRole("region", { name: status });
+    await expectVisible(statusRegion, `Terminal work ${status} region`);
+    await expectVisible(
+      statusRegion.getByRole("status", { name: status }),
+      `Terminal work ${status} status`,
+    );
+  }
+  const failedWorkButton = terminalWork.getByRole("button", {
+    name: "Failed Story",
+  });
+  await expectVisible(failedWorkButton, "Terminal work failed item");
+  await expectFocusable(failedWorkButton, "Terminal work failed item");
+  await failedWorkButton.press("Enter");
+  if ((await failedWorkButton.getAttribute("aria-pressed")) !== "true") {
+    throw new Error("Terminal work failed item did not retain keyboard selection.");
+  }
 
   const addWidgetButton = page
     .getByRole("article", { name: "Add widget" })

--- a/ui/scripts/verify-dashboard-widget-bento-layout.mjs
+++ b/ui/scripts/verify-dashboard-widget-bento-layout.mjs
@@ -29,6 +29,13 @@ const storyChecks = [
     viewports: [
       { height: 844, label: "mobile", width: 390 },
       { height: 900, label: "desktop", width: 1440 },
+      {
+        forcedColors: "active",
+        height: 900,
+        label: "forced-colors",
+        width: 1280,
+      },
+      { height: 900, label: "zoom-200", pageScaleFactor: 2, width: 1280 },
     ],
   },
 ];
@@ -88,11 +95,18 @@ async function waitForHttpOk(url, timeoutMs = 30_000) {
 
 async function verifyStory(browser, storyCheck, viewport) {
   const context = await browser.newContext({
+    forcedColors: viewport.forcedColors,
     viewport: { height: viewport.height, width: viewport.width },
   });
   const page = await context.newPage();
 
   try {
+    if (viewport.pageScaleFactor) {
+      const client = await context.newCDPSession(page);
+      await client.send("Emulation.setPageScaleFactor", {
+        pageScaleFactor: viewport.pageScaleFactor,
+      });
+    }
     await page.goto(storyUrl(baseUrl, storyCheck.id), {
       timeout: STORY_RENDER_TIMEOUT_MS,
       waitUntil: "domcontentloaded",

--- a/ui/src/features/bento/components/dashboard-bento-cards.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-cards.tsx
@@ -338,12 +338,15 @@ function buildDuplicateCapableWidgetCard({
         widgetType: layoutItem.widgetType,
         children: (
           <TerminalWorkWidget
+            canceledItems={currentSelection.canceledWorkItems ?? []}
             completedItems={currentSelection.completedWorkItems}
             failedItems={currentSelection.failedWorkItems}
             headerAction={headerAction}
             locale={locale}
             onSelectItem={currentSelection.openTerminalWorkDetail}
             selectedItem={currentSelection.terminalWorkDetail}
+            terminatedItems={currentSelection.terminatedWorkItems ?? []}
+            unknownItems={currentSelection.unknownWorkItems ?? []}
             widgetId={layoutItem.id}
           />
         ),

--- a/ui/src/features/bento/components/dashboard-bento-story-shared.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-story-shared.tsx
@@ -1849,6 +1849,12 @@ function responsiveCatalogDetailCards({
     {
       children: (
         <TerminalWorkWidget
+          canceledItems={[
+            {
+              label: "Canceled Story",
+              traceWorkID: "work-canceled-story",
+            },
+          ]}
           completedItems={[
             {
               attempts: [completedAttempt],
@@ -1864,7 +1870,22 @@ function responsiveCatalogDetailCards({
             },
           ]}
           onSelectItem={() => undefined}
-          selectedItem={{ label: "Failed Story", status: "failed" }}
+          selectedItem={{
+            status: "failed",
+            traceWorkID: "work-failed-story",
+          }}
+          terminatedItems={[
+            {
+              label: "Terminated Story",
+              traceWorkID: "work-terminated-story",
+            },
+          ]}
+          unknownItems={[
+            {
+              label: "Unknown Story",
+              traceWorkID: "work-unknown-story",
+            },
+          ]}
           widgetId="terminal-work::responsive"
         />
       ),

--- a/ui/src/features/bento/components/dashboard-bento-terminal-work-catalog.stories.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-terminal-work-catalog.stories.tsx
@@ -1,8 +1,8 @@
 import { expect, userEvent, within } from "storybook/test";
 
 import "../../../styles.css";
-import { getTerminalWorkMessages } from "../../terminal-work/messages/terminal-work";
 import { TerminalWorkWidget } from "../../terminal-work/components/terminal-work-widget";
+import { getTerminalWorkMessages } from "../../terminal-work/messages/terminal-work";
 import { DASHBOARD_WIDGET_IDS } from "../hooks/dashboardLayoutSchema";
 import {
   completedAttempt,
@@ -37,7 +37,10 @@ export const TerminalWork = {
             },
           ]}
           onSelectItem={() => undefined}
-          selectedItem={{ label: "Failed Story", status: "failed" }}
+          selectedItem={{
+            status: "failed",
+            traceWorkID: "work-failed-story",
+          }}
           widgetId="terminal-work::story"
         />
       ),
@@ -49,14 +52,16 @@ export const TerminalWork = {
     }),
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
-    const card = await canvas.findByRole("article", {
-      name: "Completed and failed work",
-    });
     const messages = getTerminalWorkMessages("en");
+    const card = await canvas.findByRole("article", {
+      name: messages.cardTitle,
+    });
     const terminalScope = within(card);
 
     await expect(
-      terminalScope.getByRole("button", { name: "Failed Story" }),
+      terminalScope.getByRole("button", {
+        name: messages.selectWorkItemLabel("Failed Story"),
+      }),
     ).toBeVisible();
 
     const completedToggle = (
@@ -68,14 +73,18 @@ export const TerminalWork = {
     await userEvent.click(completedToggle);
     await expect(completedToggle).toHaveAttribute("aria-expanded", "false");
     expect(
-      terminalScope.queryByRole("button", { name: "Done Story" }),
+      terminalScope.queryByRole("button", {
+        name: messages.selectWorkItemLabel("Done Story"),
+      }),
     ).toBeNull();
     await userEvent.click(completedToggle);
     await expect(completedToggle).toHaveAttribute("aria-expanded", "true");
     await expect(
-      terminalScope.getByRole("button", { name: "Done Story" }),
+      terminalScope.getByRole("button", {
+        name: messages.selectWorkItemLabel("Done Story"),
+      }),
     ).toBeVisible();
-    expectBentoHeaderDragSurface(card, "Completed and failed work");
+    expectBentoHeaderDragSurface(card, messages.cardTitle);
   },
 };
 
@@ -99,15 +108,16 @@ export const TerminalWorkEmpty = {
     }),
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
+    const messages = getTerminalWorkMessages("en");
     const card = await canvas.findByRole("article", {
-      name: "Completed and failed work",
+      name: messages.cardTitle,
     });
 
     await expect(
-      within(card).getByText("No completed work recorded yet."),
+      within(card).getByText(messages.emptyState("completed")),
     ).toBeVisible();
     await expect(
-      within(card).getByText("No failed work recorded yet."),
+      within(card).getByText(messages.emptyState("failed")),
     ).toBeVisible();
   },
 };

--- a/ui/src/features/bento/components/dashboard-bento-verification-catalog.stories.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-verification-catalog.stories.tsx
@@ -1,6 +1,7 @@
 import { expect, within } from "storybook/test";
 
 import "../../../styles.css";
+import { getTerminalWorkMessages } from "../../terminal-work/messages/terminal-work";
 import {
   DashboardBentoResponsiveStory,
   expectBentoHeaderDragSurface,
@@ -80,7 +81,7 @@ export const ResponsiveVerification = {
     ).toBeVisible();
     await expect(
       await canvas.findByRole("article", {
-        name: "Completed and failed work",
+        name: getTerminalWorkMessages("en").cardTitle,
       }),
     ).toBeVisible();
     await expect(

--- a/ui/src/features/current-selection/base/messages/operational/current-selection-message-catalogs.coverage.test.ts
+++ b/ui/src/features/current-selection/base/messages/operational/current-selection-message-catalogs.coverage.test.ts
@@ -267,6 +267,7 @@ const invokeWorkstationDetailSecondaryFormatters = (
       return [formatter("Gemini" as never, "Factory" as never)];
     case "historyRequestCountLabel":
     case "historyRunCountLabel":
+    case "showMoreHistoryAction":
       return [formatter(1 as never), formatter(3 as never)];
     case "editableConfigurationPromptAutocompleteSummary":
       return [
@@ -367,6 +368,8 @@ const invokeWorkstationDetail = (
         formatter("LOGICAL_MOVE" as never),
         formatter("FUTURE_TYPE" as never),
       ];
+    case "historyProgressLabel":
+      return [formatter(10 as never, 12 as never, 2 as never)];
     case "editableConfigurationModelInvokeBindingDuplicate":
     case "editableConfigurationModelInvokeBindingRequired":
       return [formatter("prompt" as never)];

--- a/ui/src/features/current-selection/base/state/selectionHistoryStore.ts
+++ b/ui/src/features/current-selection/base/state/selectionHistoryStore.ts
@@ -72,8 +72,8 @@ function selectionHistoryTerminalDetailKey(
 
   return [
     terminalWorkDetail.status,
-    terminalWorkDetail.traceWorkID,
-    terminalWorkDetail.label,
+    terminalWorkDetail.dispatchID ?? "",
+    terminalWorkDetail.workItem?.work_id ?? terminalWorkDetail.traceWorkID,
     terminalWorkDetail.failureReason ?? "",
     terminalWorkDetail.failureMessage ?? "",
   ].join(":");

--- a/ui/src/features/current-selection/hooks/core/useCurrentSelection.derived.ts
+++ b/ui/src/features/current-selection/hooks/core/useCurrentSelection.derived.ts
@@ -7,6 +7,10 @@ import type {
   DashboardWorkstationRequest,
 } from "../../../../api/dashboard/types";
 import {
+  type TerminalWorkItem,
+  terminalWorkIdentity,
+} from "../../../terminal-work/lib/types";
+import {
   type FactoryBundledDocFile,
   findFactoryBundledDocFile,
 } from "../../../workflow-activity/lib/factory-bundled-docs";
@@ -26,6 +30,7 @@ import {
 } from "../helpers/selected-work-operation-history";
 import {
   activeExecutionsForSelectedWorkstation,
+  buildNonStandardTerminalWorkItems,
   buildSelectedWorkDispatchAttempts,
   buildTerminalWorkItems,
   currentWorkItemsForPlace,
@@ -364,13 +369,20 @@ export function deriveCurrentSelectionState({
     snapshot?.runtime.session.failed_work_details_by_work_id,
     projectedWorkstationRequestsByDispatchID,
   );
+  const nonStandardTerminalWorkItems = buildNonStandardTerminalWorkItems(
+    projectedWorkstationRequestsByDispatchID,
+    snapshot?.runtime.session.provider_sessions,
+  );
 
   return {
+    canceledWorkItems: nonStandardTerminalWorkItems.canceled,
     completedWorkItems,
     completedWorkLabels,
     currentFactoryDefinition,
     failedWorkItems,
     failedWorkLabels,
+    terminatedWorkItems: nonStandardTerminalWorkItems.terminated,
+    unknownWorkItems: nonStandardTerminalWorkItems.unknown,
     selectedNode,
     selectedNodeActiveExecutions,
     selectedNodeProviderSessions,
@@ -402,37 +414,32 @@ export function deriveCurrentSelectionState({
 }
 
 export function useTerminalWorkDetailCleanup({
-  completedWorkLabels,
-  failedWorkLabels,
   replacePresent,
   selection,
+  terminalWorkItems,
   terminalWorkDetail,
 }: {
-  completedWorkLabels: string[];
-  failedWorkLabels: string[];
   replacePresent: (state: {
     selection: DashboardSelection | null;
     terminalWorkDetail: TerminalWorkDetail | null;
   }) => void;
   selection: DashboardSelection | null;
+  terminalWorkItems: TerminalWorkItem[];
   terminalWorkDetail: TerminalWorkDetail | null;
 }) {
   useEffect(() => {
     if (
       terminalWorkDetail &&
-      !completedWorkLabels.includes(terminalWorkDetail.label) &&
-      !failedWorkLabels.includes(terminalWorkDetail.label)
+      !terminalWorkItems.some(
+        (item) =>
+          terminalWorkIdentity(item) ===
+          terminalWorkIdentity(terminalWorkDetail),
+      )
     ) {
       replacePresent({
         selection,
         terminalWorkDetail: null,
       });
     }
-  }, [
-    completedWorkLabels,
-    failedWorkLabels,
-    replacePresent,
-    selection,
-    terminalWorkDetail,
-  ]);
+  }, [replacePresent, selection, terminalWorkItems, terminalWorkDetail]);
 }

--- a/ui/src/features/current-selection/hooks/core/useCurrentSelection.ts
+++ b/ui/src/features/current-selection/hooks/core/useCurrentSelection.ts
@@ -41,9 +41,12 @@ import {
 export interface CurrentSelectionState {
   canRedoSelection: boolean;
   canUndoSelection: boolean;
+  canceledWorkItems?: TerminalWorkItem[];
   completedWorkItems: TerminalWorkItem[];
   currentFactoryDefinition?: CurrentFactoryDocument | null;
   failedWorkItems: TerminalWorkItem[];
+  terminatedWorkItems?: TerminalWorkItem[];
+  unknownWorkItems?: TerminalWorkItem[];
   openTerminalWorkDetail: (
     status: TerminalWorkStatus,
     item: TerminalWorkItem,
@@ -174,10 +177,9 @@ export function useCurrentSelection({
   });
 
   useTerminalWorkDetailCleanup({
-    completedWorkLabels: derived.completedWorkLabels,
-    failedWorkLabels: derived.failedWorkLabels,
     replacePresent: store.replacePresent,
     selection,
+    terminalWorkItems: terminalWorkItemsForCleanup(derived),
     terminalWorkDetail,
   });
 
@@ -194,9 +196,12 @@ export function useCurrentSelection({
   return {
     canRedoSelection: store.canRedoSelection,
     canUndoSelection: store.canUndoSelection,
+    canceledWorkItems: derived.canceledWorkItems,
     completedWorkItems: derived.completedWorkItems,
     currentFactoryDefinition: derived.currentFactoryDefinition,
     failedWorkItems: derived.failedWorkItems,
+    terminatedWorkItems: derived.terminatedWorkItems,
+    unknownWorkItems: derived.unknownWorkItems,
     openTerminalWorkDetail: actions.openTerminalWorkDetail,
     redoSelection: store.redoSelection,
     selectedNode: derived.selectedNode,
@@ -246,4 +251,16 @@ export function useCurrentSelection({
     terminalWorkDetail,
     undoSelection: store.undoSelection,
   };
+}
+
+function terminalWorkItemsForCleanup(
+  derived: ReturnType<typeof useCurrentSelectionDerivedState>,
+): TerminalWorkItem[] {
+  return [
+    ...(derived.canceledWorkItems ?? []),
+    ...derived.completedWorkItems,
+    ...derived.failedWorkItems,
+    ...(derived.terminatedWorkItems ?? []),
+    ...(derived.unknownWorkItems ?? []),
+  ];
 }

--- a/ui/src/features/current-selection/hooks/helpers/useCurrentSelection.selection-helpers.test.ts
+++ b/ui/src/features/current-selection/hooks/helpers/useCurrentSelection.selection-helpers.test.ts
@@ -13,6 +13,7 @@ import type {
 import { buildEmptyDashboardRuntimeFixture } from "../../../../components/dashboard/fixtures/runtime";
 import {
   activeExecutionsForSelectedWorkstation,
+  buildNonStandardTerminalWorkItems,
   buildTerminalWorkItems,
   currentWorkItemsForPlace,
   findStatePlace,
@@ -483,7 +484,7 @@ describe("useCurrentSelection.selection-helpers", () => {
     ).toBeNull();
   });
 
-  it("finds terminal work items by trace id, work item id, or label", () => {
+  it("finds terminal work items by canonical Work ID and optional dispatch ID", () => {
     const terminalItem = {
       attempts: [],
       label: "Alpha Story",
@@ -492,16 +493,81 @@ describe("useCurrentSelection.selection-helpers", () => {
     };
 
     expect(findTerminalWorkItem([terminalItem], workAlpha)).toBe(terminalItem);
+    const secondAttempt = {
+      ...terminalItem,
+      dispatchID: "dispatch-second",
+    };
+    const firstAttempt = { ...terminalItem, dispatchID: "dispatch-first" };
+    expect(
+      findTerminalWorkItem(
+        [firstAttempt, secondAttempt],
+        workAlpha,
+        "dispatch-second",
+      ),
+    ).toBe(secondAttempt);
     expect(
       findTerminalWorkItem(
         [{ ...terminalItem, traceWorkID: "other-work", workItem: undefined }],
         workAlpha,
       ),
-    ).toEqual({
-      ...terminalItem,
-      traceWorkID: "other-work",
-      workItem: undefined,
+    ).toBeUndefined();
+  });
+
+  it("keeps canceled, terminated, and future terminal outcomes distinct", () => {
+    const makeRequest = (
+      dispatchID: string,
+      outcome: string,
+      workItem: DashboardWorkItemRef,
+    ): DashboardWorkstationRequest => ({
+      dispatch_id: dispatchID,
+      dispatched_request_count: 1,
+      errored_request_count: 0,
+      inference_attempts: [],
+      outcome,
+      responded_request_count: 1,
+      transition_id: "review",
+      work_items: [workItem],
+      workstation_name: "Review",
+      workstation_node_id: "review",
     });
+
+    const result = buildNonStandardTerminalWorkItems(
+      {
+        canceled: makeRequest("dispatch-canceled", "CANCELED", workAlpha),
+        completed: makeRequest("dispatch-completed", "COMPLETED", workBeta),
+        future: makeRequest("dispatch-future", "FUTURE_TERMINAL", {
+          ...workBeta,
+          work_id: "work-future",
+        }),
+        terminated: makeRequest("dispatch-terminated", "TERMINATED", {
+          ...workAlpha,
+          work_id: "work-terminated",
+        }),
+      },
+      [],
+    );
+
+    expect(result.canceled).toEqual([
+      expect.objectContaining({
+        dispatchID: "dispatch-canceled",
+        label: "Alpha Story",
+        traceWorkID: "work-alpha",
+      }),
+    ]);
+    expect(result.terminated).toEqual([
+      expect.objectContaining({
+        dispatchID: "dispatch-terminated",
+        label: "Alpha Story",
+        traceWorkID: "work-terminated",
+      }),
+    ]);
+    expect(result.unknown).toEqual([
+      expect.objectContaining({
+        dispatchID: "dispatch-future",
+        label: "Beta Story",
+        traceWorkID: "work-future",
+      }),
+    ]);
   });
 
   it("prefers request-history terminal context over latest provider attempt context", () => {

--- a/ui/src/features/current-selection/hooks/helpers/useCurrentSelection.selection-helpers.ts
+++ b/ui/src/features/current-selection/hooks/helpers/useCurrentSelection.selection-helpers.ts
@@ -96,9 +96,13 @@ export function buildTerminalWorkItems(
             latestAttempt?.dispatch_id,
           failureMessage:
             matchedFailureDetail?.failure_message ??
+            (latestRequest
+              ? requestFailureMessage(latestRequest)
+              : undefined) ??
             latestAttempt?.failure_message,
           failureReason:
             matchedFailureDetail?.failure_reason ??
+            (latestRequest ? requestFailureReason(latestRequest) : undefined) ??
             latestAttempt?.failure_reason,
           label: matchedWorkItem?.display_name?.trim() || label,
           traceWorkID:
@@ -132,16 +136,16 @@ function uniqueTerminalWorkItemsForLabel(
       byWorkID.set(workItem.work_id, workItem);
     }
   };
-  for (const attempt of attempts ?? []) {
-    for (const workItem of attempt.work_items ?? []) {
-      addIfMatching(workItem);
-    }
-  }
   for (const detail of failureDetails) {
     addIfMatching(detail.work_item);
   }
   for (const request of requests) {
     for (const workItem of requestWorkItems(request)) {
+      addIfMatching(workItem);
+    }
+  }
+  for (const attempt of attempts ?? []) {
+    for (const workItem of attempt.work_items ?? []) {
       addIfMatching(workItem);
     }
   }

--- a/ui/src/features/current-selection/hooks/helpers/useCurrentSelection.selection-helpers.ts
+++ b/ui/src/features/current-selection/hooks/helpers/useCurrentSelection.selection-helpers.ts
@@ -10,9 +10,10 @@ import type {
   DashboardWorkstationNode,
   DashboardWorkstationRequest,
 } from "../../../../api/dashboard/types";
-import type {
-  TerminalWorkItem,
-  TerminalWorkStatus,
+import {
+  type TerminalWorkItem,
+  type TerminalWorkStatus,
+  terminalWorkStatusFromOutcome,
 } from "../../../terminal-work/lib/types";
 import {
   findWorkItemReference,
@@ -46,60 +47,185 @@ export function buildTerminalWorkItems(
     Object.values(workstationRequestsByDispatchID ?? {}),
   );
 
-  return labels.map((label) => {
-    const matchingAttempts =
+  return labels.flatMap((label) => {
+    const canonicalItems = uniqueTerminalWorkItemsForLabel(
+      label,
+      attempts,
+      failureDetails,
+      requests,
+    );
+    return (canonicalItems.length > 1 ? canonicalItems : [undefined]).map(
+      (canonicalItem) => {
+        const matchingAttempts =
+          attempts?.filter((attempt) =>
+            attempt.work_items?.some((workItem) =>
+              canonicalItem
+                ? workItem.work_id === canonicalItem.work_id
+                : workItem.display_name === label || workItem.work_id === label,
+            ),
+          ) ?? [];
+        const latestAttempt = matchingAttempts[matchingAttempts.length - 1];
+        const matchedWorkItem =
+          canonicalItem ??
+          matchingAttempts
+            .flatMap((attempt) => attempt.work_items ?? [])
+            .find(
+              (workItem) =>
+                workItem.display_name === label || workItem.work_id === label,
+            );
+        const matchingRequests = requests.filter((request) =>
+          requestWorkItems(request).some((workItem) =>
+            matchedWorkItem
+              ? workItem.work_id === matchedWorkItem.work_id
+              : workItem.display_name === label || workItem.work_id === label,
+          ),
+        );
+        const latestRequest = matchingRequests[0];
+        const matchedFailureDetail = failureDetails.find((detail) =>
+          matchedWorkItem
+            ? detail.work_item.work_id === matchedWorkItem.work_id
+            : detail.work_item.display_name === label ||
+              detail.work_item.work_id === label,
+        );
+
+        return {
+          attempts: matchingAttempts,
+          dispatchID:
+            matchedFailureDetail?.dispatch_id ??
+            (latestRequest ? requestDispatchID(latestRequest) : undefined) ??
+            latestAttempt?.dispatch_id,
+          failureMessage:
+            matchedFailureDetail?.failure_message ??
+            latestAttempt?.failure_message,
+          failureReason:
+            matchedFailureDetail?.failure_reason ??
+            latestAttempt?.failure_reason,
+          label: matchedWorkItem?.display_name?.trim() || label,
+          traceWorkID:
+            matchedWorkItem?.work_id ??
+            matchedFailureDetail?.work_item.work_id ??
+            label,
+          workItem: matchedWorkItem ?? matchedFailureDetail?.work_item,
+          workstationName: terminalWorkstationName(
+            matchedFailureDetail,
+            latestAttempt,
+            latestRequest,
+          ),
+        };
+      },
+    );
+  });
+}
+
+function uniqueTerminalWorkItemsForLabel(
+  label: string,
+  attempts: DashboardProviderSessionAttempt[] | undefined,
+  failureDetails: DashboardFailedWorkDetail[],
+  requests: DispatchWorkstationRequest[],
+): DashboardWorkItemRef[] {
+  const byWorkID = new Map<string, DashboardWorkItemRef>();
+  const addIfMatching = (workItem: DashboardWorkItemRef) => {
+    if (
+      (workItem.display_name === label || workItem.work_id === label) &&
+      !byWorkID.has(workItem.work_id)
+    ) {
+      byWorkID.set(workItem.work_id, workItem);
+    }
+  };
+  for (const attempt of attempts ?? []) {
+    for (const workItem of attempt.work_items ?? []) {
+      addIfMatching(workItem);
+    }
+  }
+  for (const detail of failureDetails) {
+    addIfMatching(detail.work_item);
+  }
+  for (const request of requests) {
+    for (const workItem of requestWorkItems(request)) {
+      addIfMatching(workItem);
+    }
+  }
+  return [...byWorkID.values()];
+}
+
+export function buildNonStandardTerminalWorkItems(
+  workstationRequestsByDispatchID:
+    | Record<string, DispatchWorkstationRequest>
+    | undefined,
+  attempts: DashboardProviderSessionAttempt[] | undefined,
+): Record<"canceled" | "terminated" | "unknown", TerminalWorkItem[]> {
+  const itemsByStatus: Record<
+    "canceled" | "terminated" | "unknown",
+    TerminalWorkItem[]
+  > = {
+    canceled: [],
+    terminated: [],
+    unknown: [],
+  };
+  const seen = new Set<string>();
+
+  for (const request of sortWorkstationRequests(
+    Object.values(workstationRequestsByDispatchID ?? {}),
+  )) {
+    const status = terminalWorkStatusFromOutcome(requestOutcome(request));
+    if (!status || status === "completed" || status === "failed") {
+      continue;
+    }
+
+    const requestID = requestDispatchID(request);
+    const requestAttempts =
       attempts?.filter((attempt) =>
         attempt.work_items?.some(
           (workItem) =>
-            workItem.display_name === label || workItem.work_id === label,
+            requestWorkItems(request).some(
+              (requestWorkItem) => requestWorkItem.work_id === workItem.work_id,
+            ) && attempt.dispatch_id === requestID,
         ),
       ) ?? [];
-    const latestAttempt = matchingAttempts[matchingAttempts.length - 1];
-    const matchedWorkItem = matchingAttempts
-      .flatMap((attempt) => attempt.work_items ?? [])
-      .find(
-        (workItem) =>
-          workItem.display_name === label || workItem.work_id === label,
-      );
-    const matchingRequests = requests.filter((request) =>
-      requestWorkItems(request).some(
-        (workItem) =>
-          workItem.display_name === label || workItem.work_id === label,
-      ),
-    );
-    const latestRequest = matchingRequests[0];
-    const matchedFailureDetail = failureDetails.find(
-      (detail) =>
-        detail.work_item.display_name === label ||
-        detail.work_item.work_id === label ||
-        (matchedWorkItem
-          ? detail.work_item.work_id === matchedWorkItem.work_id
-          : false),
-    );
+    for (const workItem of requestWorkItems(request)) {
+      const identity = `${requestID}:${workItem.work_id}`;
+      if (seen.has(identity)) {
+        continue;
+      }
+      seen.add(identity);
+      itemsByStatus[status].push({
+        attempts: requestAttempts,
+        dispatchID: requestID,
+        failureMessage: requestFailureMessage(request),
+        failureReason: requestFailureReason(request),
+        label: workItem.display_name?.trim() || workItem.work_id,
+        traceWorkID: workItem.work_id,
+        workItem,
+        workstationName: requestWorkstationName(request),
+      });
+    }
+  }
 
-    return {
-      attempts: matchingAttempts,
-      dispatchID:
-        matchedFailureDetail?.dispatch_id ??
-        (latestRequest ? requestDispatchID(latestRequest) : undefined) ??
-        latestAttempt?.dispatch_id,
-      failureMessage:
-        matchedFailureDetail?.failure_message ?? latestAttempt?.failure_message,
-      failureReason:
-        matchedFailureDetail?.failure_reason ?? latestAttempt?.failure_reason,
-      label,
-      traceWorkID:
-        matchedWorkItem?.work_id ??
-        matchedFailureDetail?.work_item.work_id ??
-        label,
-      workItem: matchedWorkItem ?? matchedFailureDetail?.work_item,
-      workstationName: terminalWorkstationName(
-        matchedFailureDetail,
-        latestAttempt,
-        latestRequest,
-      ),
-    };
-  });
+  return itemsByStatus;
+}
+
+function requestFailureMessage(
+  request: DispatchWorkstationRequest,
+): string | undefined {
+  return "workstation_node_id" in request
+    ? request.failure_message
+    : request.response?.failureDetail?.message;
+}
+
+function requestFailureReason(
+  request: DispatchWorkstationRequest,
+): string | undefined {
+  return "workstation_node_id" in request
+    ? request.failure_reason
+    : request.response?.failureDetail?.reason;
+}
+
+function requestOutcome(
+  request: DispatchWorkstationRequest,
+): string | undefined {
+  return "workstation_node_id" in request
+    ? request.outcome
+    : request.response?.outcome;
 }
 
 function terminalWorkstationName(
@@ -508,13 +634,19 @@ export function inferStateWorkTerminalStatus(
 export function findTerminalWorkItem(
   items: TerminalWorkItem[],
   workItem: DashboardWorkItemRef,
+  dispatchID?: string,
 ): TerminalWorkItem | undefined {
-  const workLabel = workItem.display_name?.trim() || workItem.work_id;
-  return items.find(
+  const matchingItems = items.filter(
     (item) =>
       item.traceWorkID === workItem.work_id ||
-      item.workItem?.work_id === workItem.work_id ||
-      item.label === workLabel,
+      item.workItem?.work_id === workItem.work_id,
+  );
+  if (!dispatchID) {
+    return matchingItems[0];
+  }
+  return (
+    matchingItems.find((item) => item.dispatchID === dispatchID) ??
+    matchingItems[0]
   );
 }
 

--- a/ui/src/features/current-selection/workstation-selection/components/detail-card/history/workstation-request-attempts.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/detail-card/history/workstation-request-attempts.tsx
@@ -1,0 +1,267 @@
+import { Code } from "@you-agent-factory/components/primitives";
+import type {
+  DashboardInferenceAttempt,
+  DashboardWorkstationRequest,
+} from "../../../../../../api/dashboard/types";
+import {
+  formatDurationMillis,
+  getLocalDateTimeDisplay,
+} from "../../../../../../components/ui/formatters";
+import { CurrentSelectionSupportingText } from "../../../../base/components/presentation/current-selection-supporting-text";
+import { getCurrentSelectionOperationalEnumMessages } from "../../../../base/messages/operational/current-selection-operational-enums";
+import { getCurrentSelectionDetailMessages } from "../../../../base/messages/shell/current-selection-detail";
+import {
+  CurrentSelectionHistoryCard,
+  CurrentSelectionHistoryCardHeader,
+} from "../../../../history/components/current-selection-history-card";
+import type { getWorkstationDetailMessages } from "../../../messages/workstation-detail";
+
+export function WorkstationRequestAttempts({
+  locale,
+  messages,
+  request,
+}: {
+  locale?: string;
+  messages: ReturnType<typeof getWorkstationDetailMessages>;
+  request: DashboardWorkstationRequest;
+}) {
+  const inferenceAttempts = request.inference_attempts
+    .map((attempt, index) => ({ attempt, index }))
+    .sort(
+      (left, right) =>
+        left.attempt.attempt - right.attempt.attempt ||
+        left.index - right.index,
+    );
+  const hasScriptAttempt = Boolean(
+    request.script_request || request.script_response,
+  );
+
+  if (inferenceAttempts.length === 0 && !hasScriptAttempt) {
+    return null;
+  }
+
+  return (
+    <div className="grid gap-2">
+      {inferenceAttempts.map(({ attempt }) => (
+        <WorkstationInferenceAttemptCard
+          attempt={attempt}
+          key={`${request.dispatch_id}:inference:${attempt.inference_request_id}:${attempt.attempt}`}
+          locale={locale}
+          messages={messages}
+        />
+      ))}
+      {hasScriptAttempt ? (
+        <WorkstationScriptAttemptCard
+          key={`${request.dispatch_id}:script:${getScriptRequestID(request) ?? "dispatch"}`}
+          locale={locale}
+          messages={messages}
+          request={request}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function WorkstationInferenceAttemptCard({
+  attempt,
+  locale,
+  messages,
+}: {
+  attempt: DashboardInferenceAttempt;
+  locale?: string;
+  messages: ReturnType<typeof getWorkstationDetailMessages>;
+}) {
+  const detailMessages = getCurrentSelectionDetailMessages(locale);
+  const enumMessages = getCurrentSelectionOperationalEnumMessages(locale);
+  const provider =
+    attempt.diagnostics?.provider?.provider ??
+    attempt.provider_session?.provider;
+  const model = attempt.diagnostics?.provider?.model;
+  const providerSummary = provider
+    ? messages.providerSummary(provider, model)
+    : model;
+  const requestTime = getLocalDateTimeDisplay(
+    attempt.request_time,
+    detailMessages.timestampUnavailable,
+    locale,
+  );
+  const responseTime = getLocalDateTimeDisplay(
+    attempt.response_time,
+    detailMessages.timestampUnavailable,
+    locale,
+  );
+  const outcome = enumMessages.localizeOutcome(
+    attempt.outcome ?? detailMessages.pendingOutcome,
+  );
+
+  return (
+    <CurrentSelectionHistoryCard className="p-3">
+      <CurrentSelectionHistoryCardHeader
+        identifier={attempt.inference_request_id}
+        subtitle={outcome}
+        title={detailMessages.attemptTitle(attempt.attempt)}
+      />
+      <div className="grid gap-1">
+        <WorkstationRequestAttemptDetail
+          label={detailMessages.providerLabel}
+          value={providerSummary}
+        />
+        <WorkstationRequestAttemptDetail
+          label={detailMessages.providerSessionLabel}
+          value={attempt.provider_session?.id}
+        />
+        <WorkstationRequestAttemptTimeDetail
+          label={detailMessages.requestTimeLabel}
+          timestamp={requestTime}
+        />
+        <WorkstationRequestAttemptDetail
+          label={detailMessages.elapsedTimeLabel}
+          value={
+            attempt.duration_millis !== undefined
+              ? formatDurationMillis(attempt.duration_millis, locale)
+              : undefined
+          }
+        />
+        <WorkstationRequestAttemptTimeDetail
+          label={detailMessages.responseTimeLabel}
+          timestamp={responseTime}
+          visible={Boolean(attempt.response_time)}
+        />
+      </div>
+    </CurrentSelectionHistoryCard>
+  );
+}
+
+function WorkstationScriptAttemptCard({
+  locale,
+  messages,
+  request,
+}: {
+  locale?: string;
+  messages: ReturnType<typeof getWorkstationDetailMessages>;
+  request: DashboardWorkstationRequest;
+}) {
+  const detailMessages = getCurrentSelectionDetailMessages(locale);
+  const enumMessages = getCurrentSelectionOperationalEnumMessages(locale);
+  const scriptRequestID = getScriptRequestID(request);
+  const scriptIdentifier = scriptRequestID ?? request.dispatch_id;
+  const scriptResponse = request.script_response;
+  const outcome = enumMessages.localizeOutcome(
+    scriptResponse?.outcome ?? request.outcome ?? detailMessages.pendingOutcome,
+  );
+  const provider = request.provider ?? request.provider_session?.provider;
+  const providerSummary = provider
+    ? messages.providerSummary(provider, request.model)
+    : request.model;
+  const requestTime = getLocalDateTimeDisplay(
+    request.started_at ?? request.request_view?.started_at,
+    detailMessages.timestampUnavailable,
+    locale,
+  );
+  const responseTime = getLocalDateTimeDisplay(
+    request.response_view?.end_time,
+    detailMessages.timestampUnavailable,
+    locale,
+  );
+  const durationMillis =
+    scriptResponse?.duration_millis ?? scriptResponse?.durationMillis;
+
+  return (
+    <CurrentSelectionHistoryCard className="p-3">
+      <CurrentSelectionHistoryCardHeader
+        identifier={scriptIdentifier}
+        subtitle={outcome}
+        title={detailMessages.scriptAttemptLabel}
+      />
+      <div className="grid gap-1">
+        <WorkstationRequestAttemptDetail
+          label={
+            scriptRequestID
+              ? detailMessages.scriptRequestIdLabel
+              : detailMessages.dispatchIdLabel
+          }
+          value={scriptIdentifier}
+        />
+        <WorkstationRequestAttemptDetail
+          label={detailMessages.commandLabel}
+          value={request.script_request?.command}
+        />
+        <WorkstationRequestAttemptDetail
+          label={detailMessages.providerLabel}
+          value={providerSummary}
+        />
+        <WorkstationRequestAttemptTimeDetail
+          label={detailMessages.requestTimeLabel}
+          timestamp={requestTime}
+        />
+        <WorkstationRequestAttemptDetail
+          label={detailMessages.elapsedTimeLabel}
+          value={
+            durationMillis !== undefined
+              ? formatDurationMillis(durationMillis, locale)
+              : undefined
+          }
+        />
+        <WorkstationRequestAttemptTimeDetail
+          label={detailMessages.responseTimeLabel}
+          timestamp={responseTime}
+          visible={Boolean(request.response_view?.end_time)}
+        />
+      </div>
+    </CurrentSelectionHistoryCard>
+  );
+}
+
+function WorkstationRequestAttemptDetail({
+  label,
+  value,
+}: {
+  label: string;
+  value?: string;
+}) {
+  if (!value) {
+    return null;
+  }
+
+  return (
+    <CurrentSelectionSupportingText>
+      {label}: <Code>{value}</Code>
+    </CurrentSelectionSupportingText>
+  );
+}
+
+function WorkstationRequestAttemptTimeDetail({
+  label,
+  timestamp,
+  visible = true,
+}: {
+  label: string;
+  timestamp: ReturnType<typeof getLocalDateTimeDisplay>;
+  visible?: boolean;
+}) {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <CurrentSelectionSupportingText>
+      {label}:{" "}
+      {timestamp.rawTimestamp ? (
+        <time dateTime={timestamp.rawTimestamp}>{timestamp.label}</time>
+      ) : (
+        timestamp.label
+      )}
+    </CurrentSelectionSupportingText>
+  );
+}
+
+function getScriptRequestID(
+  request: DashboardWorkstationRequest,
+): string | undefined {
+  return (
+    request.script_request?.script_request_id ??
+    request.script_request?.scriptRequestId ??
+    request.script_response?.script_request_id ??
+    request.script_response?.scriptRequestId
+  );
+}

--- a/ui/src/features/current-selection/workstation-selection/components/detail-card/history/workstation-request-history-section.pagination.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/detail-card/history/workstation-request-history-section.pagination.test.tsx
@@ -1,0 +1,108 @@
+import "../../../../../../testing/vitest-dom-capabilities.setup";
+
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { buildDashboardWorkstationRequestFixture } from "../../../../../../components/dashboard/fixtures";
+import { getWorkstationDetailMessages } from "../../../messages/workstation-detail";
+import { WorkstationRequestHistorySection } from "../workstation-request-history-section";
+
+const DETAIL_CARD_NOW = Date.parse("2026-04-08T12:00:04Z");
+
+describe("WorkstationRequestHistorySection bounded history", () => {
+  it("reveals bounded request history without skipping or duplicating rows", () => {
+    const requestHistory = Array.from({ length: 12 }, (_, index) => {
+      const requestNumber = index + 1;
+      return buildDashboardWorkstationRequestFixture(
+        `dispatch-review-history-${requestNumber}`,
+        {
+          request_id: `request-review-history-${requestNumber}`,
+          work_items: [
+            {
+              display_name: `History Story ${requestNumber}`,
+              trace_id: `trace-history-story-${requestNumber}`,
+              work_id: `work-history-story-${requestNumber}`,
+              work_type_id: "story",
+            },
+          ],
+        },
+      );
+    });
+
+    render(
+      <WorkstationRequestHistorySection
+        messages={getWorkstationDetailMessages("en")}
+        now={DETAIL_CARD_NOW}
+        onSelectWorkstationRequest={() => {}}
+        requests={requestHistory}
+        resetKey="review"
+        selectedRequest={requestHistory[0]}
+      />,
+    );
+
+    const requestHistorySection = screen
+      .getByRole("heading", { name: "Request history" })
+      .closest("section");
+    if (!requestHistorySection) {
+      throw new Error("expected request history section");
+    }
+    fireEvent.click(
+      within(requestHistorySection).getByRole("button", { name: "Expand" }),
+    );
+
+    const requestHistoryList = within(requestHistorySection).getByRole("list");
+    expect(within(requestHistoryList).getAllByRole("listitem")).toHaveLength(
+      10,
+    );
+    expect(
+      within(requestHistorySection).getByText(
+        "Showing 10 of 12 requests. 2 remaining.",
+      ),
+    ).toBeTruthy();
+    expect(
+      within(requestHistorySection).getByText("request-review-history-10"),
+    ).toBeTruthy();
+    expect(
+      within(requestHistorySection)
+        .getByRole("button", {
+          name: "Select workstation request dispatch-review-history-1",
+        })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      within(requestHistorySection).queryByText("request-review-history-11"),
+    ).toBeNull();
+
+    const revealAction = within(requestHistorySection).getByRole("button", {
+      name: "Show 2 more requests",
+    });
+    revealAction.focus();
+    fireEvent.click(revealAction);
+
+    expect(within(requestHistoryList).getAllByRole("listitem")).toHaveLength(
+      12,
+    );
+    expect(
+      within(requestHistorySection).getByText("request-review-history-11"),
+    ).toBeTruthy();
+    expect(
+      within(requestHistorySection).getByText("request-review-history-12"),
+    ).toBeTruthy();
+    expect(
+      within(requestHistorySection)
+        .getByRole("button", {
+          name: "Select workstation request dispatch-review-history-1",
+        })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      within(requestHistorySection).queryByText(
+        "Showing 10 of 12 requests. 2 remaining.",
+      ),
+    ).toBeNull();
+    expect(
+      within(requestHistorySection).queryByRole("button", {
+        name: "Show 2 more requests",
+      }),
+    ).toBeNull();
+    expect(document.activeElement).toBe(requestHistoryList);
+  });
+});

--- a/ui/src/features/current-selection/workstation-selection/components/detail-card/history/workstation-request-history-section.stories.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/detail-card/history/workstation-request-history-section.stories.tsx
@@ -1,0 +1,84 @@
+import { expect, userEvent, within } from "storybook/test";
+
+import { buildDashboardWorkstationRequestFixture } from "../../../../../../components/dashboard/fixtures";
+import { getWorkstationDetailMessages } from "../../../messages/workstation-detail";
+import { WorkstationRequestHistorySection } from "../workstation-request-history-section";
+
+const boundedRequestHistory = Array.from({ length: 12 }, (_, index) => {
+  const requestNumber = index + 1;
+  return buildDashboardWorkstationRequestFixture(
+    `dispatch-review-history-${requestNumber}`,
+    {
+      request_id: `request-review-history-${requestNumber}`,
+      work_items: [
+        {
+          display_name: `History Story ${requestNumber}`,
+          trace_id: `trace-history-story-${requestNumber}`,
+          work_id: `work-history-story-${requestNumber}`,
+          work_type_id: "story",
+        },
+      ],
+    },
+  );
+});
+
+export default {
+  title: "Agent Factory/Dashboard/Workstation Request History",
+  component: WorkstationRequestHistorySection,
+};
+
+export const BoundedHistory = {
+  tags: ["test"],
+  render: () => (
+    <div style={{ maxWidth: "960px" }}>
+      <WorkstationRequestHistorySection
+        messages={getWorkstationDetailMessages("en")}
+        now={Date.parse("2026-04-08T12:00:04Z")}
+        requests={boundedRequestHistory}
+        resetKey="review"
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const requestHistorySection = (
+      await canvas.findByRole("heading", { name: "Request history" })
+    ).closest("section");
+    if (!(requestHistorySection instanceof HTMLElement)) {
+      throw new Error("expected request history section");
+    }
+
+    await userEvent.click(
+      within(requestHistorySection).getByRole("button", { name: "Expand" }),
+    );
+
+    const requestHistoryList = within(requestHistorySection).getByRole("list");
+    await expect(
+      within(requestHistoryList).getAllByRole("listitem"),
+    ).toHaveLength(10);
+    await expect(
+      within(requestHistorySection).getByText(
+        "Showing 10 of 12 requests. 2 remaining.",
+      ),
+    ).toBeVisible();
+
+    const revealAction = within(requestHistorySection).getByRole("button", {
+      name: "Show 2 more requests",
+    });
+    revealAction.focus();
+    await userEvent.keyboard("{Enter}");
+
+    await expect(
+      within(requestHistoryList).getAllByRole("listitem"),
+    ).toHaveLength(12);
+    await expect(
+      within(requestHistorySection).getByText("request-review-history-12"),
+    ).toBeVisible();
+    expect(
+      within(requestHistorySection).queryByRole("button", {
+        name: "Show 2 more requests",
+      }),
+    ).toBeNull();
+    expect(document.activeElement).toBe(requestHistoryList);
+  },
+};

--- a/ui/src/features/current-selection/workstation-selection/components/detail-card/workstation-detail-card.history.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/detail-card/workstation-detail-card.history.test.tsx
@@ -3,6 +3,7 @@ import "../../../../../testing/vitest-dom-capabilities.setup";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { vi } from "vitest";
 import {
+  buildDashboardInferenceAttemptFixture,
   buildDashboardWorkstationRequestFixture,
   dashboardWorkstationRequestFixtures,
 } from "../../../../../components/dashboard/fixtures";
@@ -16,6 +17,46 @@ function requireValue<T>(value: T | null | undefined, message: string): T {
   }
 
   return value;
+}
+
+function buildMultiWorkstationRequest(dispatchID: string) {
+  const workItems = [
+    ["First Story", "work-first-story"],
+    ["Second Story", "work-second-story"],
+    ["Third Story", "work-third-story"],
+  ].map(([displayName, workID]) => ({
+    display_name: displayName,
+    trace_id: `trace-${workID}`,
+    work_id: workID,
+    work_type_id: "story",
+  }));
+
+  return buildDashboardWorkstationRequestFixture(dispatchID, {
+    inference_attempts: [
+      buildDashboardInferenceAttemptFixture(dispatchID, {
+        attempt: 2,
+        inference_request_id: `${dispatchID}/inference-request/2`,
+        outcome: "SUCCEEDED",
+      }),
+      buildDashboardInferenceAttemptFixture(dispatchID, {
+        attempt: 1,
+        inference_request_id: `${dispatchID}/inference-request/1`,
+        outcome: "FAILED",
+      }),
+    ],
+    request_id: "request-review-multi-work",
+    script_request: {
+      attempt: 1,
+      command: "review-script",
+      script_request_id: `${dispatchID}/script-request/1`,
+    },
+    script_response: {
+      duration_millis: 125,
+      outcome: "SUCCEEDED",
+      script_request_id: `${dispatchID}/script-request/1`,
+    },
+    work_items: workItems,
+  });
 }
 
 describe("WorkstationDetailCard run history", () => {
@@ -130,6 +171,127 @@ describe("WorkstationDetailCard run history", () => {
   });
 });
 
+describe("WorkstationDetailCard preserves every request Work and attempt", () => {
+  it("renders every work item and recorded inference or script attempt", () => {
+    const snapshot = semanticWorkflowDashboardSnapshot;
+    const selectedNode = snapshot.topology.workstation_nodes_by_id.review;
+    const onSelectWorkID = vi.fn();
+    const dispatchID = "dispatch-review-multi-work";
+    const workstationRequest = buildMultiWorkstationRequest(dispatchID);
+
+    render(
+      <WorkstationDetailCard
+        activeExecutions={[]}
+        now={DETAIL_CARD_NOW}
+        onSelectWorkID={onSelectWorkID}
+        providerSessions={[]}
+        selectedNode={selectedNode}
+        workstationRequests={[workstationRequest]}
+      />,
+    );
+
+    const requestHistorySection = requireValue(
+      screen
+        .getByRole("heading", { name: "Request history" })
+        .closest("section"),
+      "expected request history section",
+    );
+    fireEvent.click(
+      within(requestHistorySection).getByRole("button", { name: "Expand" }),
+    );
+
+    expect(
+      within(requestHistorySection).getByText("Work ID: work-first-story"),
+    ).toBeTruthy();
+    expect(
+      within(requestHistorySection).getByText("Work ID: work-second-story"),
+    ).toBeTruthy();
+    expect(
+      within(requestHistorySection).getByText("Work ID: work-third-story"),
+    ).toBeTruthy();
+    expect(
+      within(requestHistorySection).getByText(
+        `${dispatchID}/inference-request/1`,
+      ),
+    ).toBeTruthy();
+    expect(
+      within(requestHistorySection).getByText(
+        `${dispatchID}/inference-request/2`,
+      ),
+    ).toBeTruthy();
+    expect(
+      within(requestHistorySection).getAllByText(
+        `${dispatchID}/script-request/1`,
+      ).length,
+    ).toBeGreaterThan(1);
+
+    const historyText = requestHistorySection.textContent ?? "";
+    expect(
+      historyText.indexOf(`${dispatchID}/inference-request/1`),
+    ).toBeLessThan(historyText.indexOf(`${dispatchID}/inference-request/2`));
+
+    for (const work of [
+      ["First Story", "work-first-story"],
+      ["Second Story", "work-second-story"],
+      ["Third Story", "work-third-story"],
+    ]) {
+      fireEvent.click(
+        within(requestHistorySection).getByRole("button", {
+          name: `Select work item ${work[0]}`,
+        }),
+      );
+    }
+
+    expect(onSelectWorkID.mock.calls.map(([workID]) => workID)).toEqual([
+      "work-first-story",
+      "work-second-story",
+      "work-third-story",
+    ]);
+  });
+});
+
+describe("WorkstationDetailCard request history empty work", () => {
+  it("renders an explicit unknown work state when a request has no work items", () => {
+    const snapshot = semanticWorkflowDashboardSnapshot;
+    const selectedNode = snapshot.topology.workstation_nodes_by_id.review;
+
+    render(
+      <WorkstationDetailCard
+        activeExecutions={[]}
+        now={DETAIL_CARD_NOW}
+        onSelectWorkID={vi.fn()}
+        providerSessions={[]}
+        selectedNode={selectedNode}
+        workstationRequests={[
+          buildDashboardWorkstationRequestFixture("dispatch-review-empty", {
+            request_id: "request-review-empty",
+            work_items: [],
+          }),
+        ]}
+      />,
+    );
+
+    const requestHistorySection = requireValue(
+      screen
+        .getByRole("heading", { name: "Request history" })
+        .closest("section"),
+      "expected request history section",
+    );
+    fireEvent.click(
+      within(requestHistorySection).getByRole("button", { name: "Expand" }),
+    );
+
+    expect(
+      within(requestHistorySection).getByText("Unknown work"),
+    ).toBeTruthy();
+    expect(
+      within(requestHistorySection).queryByRole("button", {
+        name: /Select work item/,
+      }),
+    ).toBeNull();
+  });
+});
+
 describe("WorkstationDetailCard request history", () => {
   it("renders dispatch-keyed request history as the primary historical surface when projections exist", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
@@ -194,8 +356,8 @@ describe("WorkstationDetailCard request history", () => {
       within(requestHistorySection).getAllByText("Active Story").length,
     ).toBeGreaterThan(0);
     expect(
-      within(requestHistorySection).queryByText("request-script-success-story"),
-    ).toBeNull();
+      within(requestHistorySection).getByText("request-script-success-story"),
+    ).toBeTruthy();
     const successfulRuntimePill = within(requestHistorySection).getByText(
       "Total runtime: 222ms",
     );

--- a/ui/src/features/current-selection/workstation-selection/components/detail-card/workstation-detail-card.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/detail-card/workstation-detail-card.tsx
@@ -73,6 +73,7 @@ export function WorkstationDetailCard({
         <WorkstationHistorySection
           collapseActionLabel={messages.collapseAction}
           expandActionLabel={messages.expandAction}
+          locale={locale}
           messages={messages}
           now={now}
           onSelectProviderSession={onSelectProviderSession}

--- a/ui/src/features/current-selection/workstation-selection/components/detail-card/workstation-history-section.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/detail-card/workstation-history-section.tsx
@@ -6,6 +6,7 @@ import { WorkstationRequestHistorySection } from "./workstation-request-history-
 export function WorkstationHistorySection({
   collapseActionLabel,
   expandActionLabel,
+  locale,
   messages,
   now,
   onSelectProviderSession,
@@ -24,6 +25,7 @@ export function WorkstationHistorySection({
     return (
       <WorkstationRequestHistorySection
         key={`workstation-request-history:${selectedNodeID}`}
+        locale={locale}
         messages={messages}
         now={now}
         onSelectWorkID={onSelectWorkID}

--- a/ui/src/features/current-selection/workstation-selection/components/detail-card/workstation-request-history-section.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/detail-card/workstation-request-history-section.tsx
@@ -1,28 +1,24 @@
 import { Code } from "@you-agent-factory/components/primitives";
 import { WidgetDetailCopy } from "@you-agent-factory/components/recipes";
-import type {
-  DashboardInferenceAttempt,
-  DashboardWorkstationRequest,
-} from "../../../../../api/dashboard/types";
+import { useEffect, useRef, useState } from "react";
+import type { DashboardWorkstationRequest } from "../../../../../api/dashboard/types";
 import { DashboardActionButton } from "../../../../../components/ui/dashboard-action-button";
 import {
   formatDurationFromISO,
   formatDurationMillis,
   formatWorkItemLabel,
-  getLocalDateTimeDisplay,
 } from "../../../../../components/ui/formatters";
 import { CurrentSelectionExpandableSection } from "../../../base/components/detail/current-selection-expandable-section";
 import { CurrentSelectionExecutionPill } from "../../../base/components/presentation/current-selection-pill";
 import { CurrentSelectionSupportingText } from "../../../base/components/presentation/current-selection-supporting-text";
-import { getCurrentSelectionOperationalEnumMessages } from "../../../base/messages/operational/current-selection-operational-enums";
-import { getCurrentSelectionDetailMessages } from "../../../base/messages/shell/current-selection-detail";
-import {
-  CurrentSelectionHistoryCard,
-  CurrentSelectionHistoryCardHeader,
-} from "../../../history/components/current-selection-history-card";
+import { CurrentSelectionHistoryCard } from "../../../history/components/current-selection-history-card";
 import type { WorkstationRequestHistorySectionProps } from "../../lib/keys/detail-card-types";
 import type { getWorkstationDetailMessages } from "../../messages/workstation-detail";
+import { WorkstationRequestAttempts } from "./history/workstation-request-attempts";
 import { WorkstationDispatchRow } from "./workstation-dispatch-row";
+
+// Keep the workstation history compact while making every retained request reachable.
+const WORKSTATION_HISTORY_PAGE_SIZE = 10;
 
 export function WorkstationRequestHistorySection({
   locale,
@@ -36,6 +32,36 @@ export function WorkstationRequestHistorySection({
   selectedWorkID,
 }: WorkstationRequestHistorySectionProps) {
   const historyID = `workstation-request-history-${resetKey}`;
+  const [visibleRequestCount, setVisibleRequestCount] = useState(
+    WORKSTATION_HISTORY_PAGE_SIZE,
+  );
+  const [focusHistoryListAfterReveal, setFocusHistoryListAfterReveal] =
+    useState(false);
+  const historyListRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    if (!focusHistoryListAfterReveal) {
+      return;
+    }
+
+    historyListRef.current?.focus();
+    setFocusHistoryListAfterReveal(false);
+  }, [focusHistoryListAfterReveal]);
+
+  const visibleRequests = requests.slice(0, visibleRequestCount);
+  const remainingRequestCount = requests.length - visibleRequests.length;
+  const revealMoreRequests = () => {
+    if (remainingRequestCount <= 0) {
+      return;
+    }
+
+    if (remainingRequestCount <= WORKSTATION_HISTORY_PAGE_SIZE) {
+      setFocusHistoryListAfterReveal(true);
+    }
+    setVisibleRequestCount((currentCount) =>
+      Math.min(currentCount + WORKSTATION_HISTORY_PAGE_SIZE, requests.length),
+    );
+  };
 
   return (
     <CurrentSelectionExpandableSection
@@ -49,21 +75,46 @@ export function WorkstationRequestHistorySection({
       }
     >
       {requests.length > 0 ? (
-        <ul className="m-0 grid list-none gap-2.5 p-0">
-          {requests.map((request) => (
-            <WorkstationRequestHistoryRow
-              key={request.dispatch_id}
-              locale={locale}
-              messages={messages}
-              now={now}
-              onSelectWorkID={onSelectWorkID}
-              onSelectWorkstationRequest={onSelectWorkstationRequest}
-              request={request}
-              selectedRequest={selectedRequest}
-              selectedWorkID={selectedWorkID}
-            />
-          ))}
-        </ul>
+        <>
+          <ul
+            className="m-0 grid list-none gap-2.5 p-0"
+            id={`${historyID}-items`}
+            ref={historyListRef}
+            tabIndex={-1}
+          >
+            {visibleRequests.map((request) => (
+              <WorkstationRequestHistoryRow
+                key={request.dispatch_id}
+                locale={locale}
+                messages={messages}
+                now={now}
+                onSelectWorkID={onSelectWorkID}
+                onSelectWorkstationRequest={onSelectWorkstationRequest}
+                request={request}
+                selectedRequest={selectedRequest}
+                selectedWorkID={selectedWorkID}
+              />
+            ))}
+          </ul>
+          {remainingRequestCount > 0 ? (
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <CurrentSelectionSupportingText tone="status">
+                {messages.historyProgressLabel(
+                  visibleRequests.length,
+                  requests.length,
+                  remainingRequestCount,
+                )}
+              </CurrentSelectionSupportingText>
+              <DashboardActionButton
+                aria-controls={`${historyID}-items`}
+                onClick={revealMoreRequests}
+                type="button"
+              >
+                {messages.showMoreHistoryAction(remainingRequestCount)}
+              </DashboardActionButton>
+            </div>
+          ) : null}
+        </>
       ) : (
         <WidgetDetailCopy>{messages.noWorkstationRequests}</WidgetDetailCopy>
       )}
@@ -207,256 +258,6 @@ function WorkstationRequestWorkItems({
         );
       })}
     </div>
-  );
-}
-
-function WorkstationRequestAttempts({
-  locale,
-  messages,
-  request,
-}: {
-  locale?: string;
-  messages: ReturnType<typeof getWorkstationDetailMessages>;
-  request: DashboardWorkstationRequest;
-}) {
-  const inferenceAttempts = request.inference_attempts
-    .map((attempt, index) => ({ attempt, index }))
-    .sort(
-      (left, right) =>
-        left.attempt.attempt - right.attempt.attempt ||
-        left.index - right.index,
-    );
-  const hasScriptAttempt = Boolean(
-    request.script_request || request.script_response,
-  );
-
-  if (inferenceAttempts.length === 0 && !hasScriptAttempt) {
-    return null;
-  }
-
-  return (
-    <div className="grid gap-2">
-      {inferenceAttempts.map(({ attempt }) => (
-        <WorkstationInferenceAttemptCard
-          attempt={attempt}
-          key={`${request.dispatch_id}:inference:${attempt.inference_request_id}:${attempt.attempt}`}
-          locale={locale}
-          messages={messages}
-        />
-      ))}
-      {hasScriptAttempt ? (
-        <WorkstationScriptAttemptCard
-          key={`${request.dispatch_id}:script:${getScriptRequestID(request) ?? "dispatch"}`}
-          locale={locale}
-          messages={messages}
-          request={request}
-        />
-      ) : null}
-    </div>
-  );
-}
-
-function WorkstationInferenceAttemptCard({
-  attempt,
-  locale,
-  messages,
-}: {
-  attempt: DashboardInferenceAttempt;
-  locale?: string;
-  messages: ReturnType<typeof getWorkstationDetailMessages>;
-}) {
-  const detailMessages = getCurrentSelectionDetailMessages(locale);
-  const enumMessages = getCurrentSelectionOperationalEnumMessages(locale);
-  const provider =
-    attempt.diagnostics?.provider?.provider ??
-    attempt.provider_session?.provider;
-  const model = attempt.diagnostics?.provider?.model;
-  const providerSummary = provider
-    ? messages.providerSummary(provider, model)
-    : model;
-  const requestTime = getLocalDateTimeDisplay(
-    attempt.request_time,
-    detailMessages.timestampUnavailable,
-    locale,
-  );
-  const responseTime = getLocalDateTimeDisplay(
-    attempt.response_time,
-    detailMessages.timestampUnavailable,
-    locale,
-  );
-  const outcome = enumMessages.localizeOutcome(
-    attempt.outcome ?? detailMessages.pendingOutcome,
-  );
-
-  return (
-    <CurrentSelectionHistoryCard className="p-3">
-      <CurrentSelectionHistoryCardHeader
-        identifier={attempt.inference_request_id}
-        subtitle={outcome}
-        title={detailMessages.attemptTitle(attempt.attempt)}
-      />
-      <div className="grid gap-1">
-        <WorkstationRequestAttemptDetail
-          label={detailMessages.providerLabel}
-          value={providerSummary}
-        />
-        <WorkstationRequestAttemptDetail
-          label={detailMessages.providerSessionLabel}
-          value={attempt.provider_session?.id}
-        />
-        <WorkstationRequestAttemptTimeDetail
-          label={detailMessages.requestTimeLabel}
-          timestamp={requestTime}
-        />
-        <WorkstationRequestAttemptDetail
-          label={detailMessages.elapsedTimeLabel}
-          value={
-            attempt.duration_millis !== undefined
-              ? formatDurationMillis(attempt.duration_millis, locale)
-              : undefined
-          }
-        />
-        <WorkstationRequestAttemptTimeDetail
-          label={detailMessages.responseTimeLabel}
-          timestamp={responseTime}
-          visible={Boolean(attempt.response_time)}
-        />
-      </div>
-    </CurrentSelectionHistoryCard>
-  );
-}
-
-function WorkstationScriptAttemptCard({
-  locale,
-  messages,
-  request,
-}: {
-  locale?: string;
-  messages: ReturnType<typeof getWorkstationDetailMessages>;
-  request: DashboardWorkstationRequest;
-}) {
-  const detailMessages = getCurrentSelectionDetailMessages(locale);
-  const enumMessages = getCurrentSelectionOperationalEnumMessages(locale);
-  const scriptRequestID = getScriptRequestID(request);
-  const scriptIdentifier = scriptRequestID ?? request.dispatch_id;
-  const scriptResponse = request.script_response;
-  const outcome = enumMessages.localizeOutcome(
-    scriptResponse?.outcome ?? request.outcome ?? detailMessages.pendingOutcome,
-  );
-  const provider = request.provider ?? request.provider_session?.provider;
-  const providerSummary = provider
-    ? messages.providerSummary(provider, request.model)
-    : request.model;
-  const requestTime = getLocalDateTimeDisplay(
-    request.started_at ?? request.request_view?.started_at,
-    detailMessages.timestampUnavailable,
-    locale,
-  );
-  const responseTime = getLocalDateTimeDisplay(
-    request.response_view?.end_time,
-    detailMessages.timestampUnavailable,
-    locale,
-  );
-  const durationMillis =
-    scriptResponse?.duration_millis ?? scriptResponse?.durationMillis;
-
-  return (
-    <CurrentSelectionHistoryCard className="p-3">
-      <CurrentSelectionHistoryCardHeader
-        identifier={scriptIdentifier}
-        subtitle={outcome}
-        title={detailMessages.scriptAttemptLabel}
-      />
-      <div className="grid gap-1">
-        <WorkstationRequestAttemptDetail
-          label={
-            scriptRequestID
-              ? detailMessages.scriptRequestIdLabel
-              : detailMessages.dispatchIdLabel
-          }
-          value={scriptIdentifier}
-        />
-        <WorkstationRequestAttemptDetail
-          label={detailMessages.commandLabel}
-          value={request.script_request?.command}
-        />
-        <WorkstationRequestAttemptDetail
-          label={detailMessages.providerLabel}
-          value={providerSummary}
-        />
-        <WorkstationRequestAttemptTimeDetail
-          label={detailMessages.requestTimeLabel}
-          timestamp={requestTime}
-        />
-        <WorkstationRequestAttemptDetail
-          label={detailMessages.elapsedTimeLabel}
-          value={
-            durationMillis !== undefined
-              ? formatDurationMillis(durationMillis, locale)
-              : undefined
-          }
-        />
-        <WorkstationRequestAttemptTimeDetail
-          label={detailMessages.responseTimeLabel}
-          timestamp={responseTime}
-          visible={Boolean(request.response_view?.end_time)}
-        />
-      </div>
-    </CurrentSelectionHistoryCard>
-  );
-}
-
-function WorkstationRequestAttemptDetail({
-  label,
-  value,
-}: {
-  label: string;
-  value?: string;
-}) {
-  if (!value) {
-    return null;
-  }
-
-  return (
-    <CurrentSelectionSupportingText>
-      {label}: <Code>{value}</Code>
-    </CurrentSelectionSupportingText>
-  );
-}
-
-function WorkstationRequestAttemptTimeDetail({
-  label,
-  timestamp,
-  visible = true,
-}: {
-  label: string;
-  timestamp: ReturnType<typeof getLocalDateTimeDisplay>;
-  visible?: boolean;
-}) {
-  if (!visible) {
-    return null;
-  }
-
-  return (
-    <CurrentSelectionSupportingText>
-      {label}:{" "}
-      {timestamp.rawTimestamp ? (
-        <time dateTime={timestamp.rawTimestamp}>{timestamp.label}</time>
-      ) : (
-        timestamp.label
-      )}
-    </CurrentSelectionSupportingText>
-  );
-}
-
-function getScriptRequestID(
-  request: DashboardWorkstationRequest,
-): string | undefined {
-  return (
-    request.script_request?.script_request_id ??
-    request.script_request?.scriptRequestId ??
-    request.script_response?.script_request_id ??
-    request.script_response?.scriptRequestId
   );
 }
 

--- a/ui/src/features/current-selection/workstation-selection/components/detail-card/workstation-request-history-section.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/detail-card/workstation-request-history-section.tsx
@@ -1,19 +1,31 @@
+import { Code } from "@you-agent-factory/components/primitives";
 import { WidgetDetailCopy } from "@you-agent-factory/components/recipes";
-import type { DashboardWorkstationRequest } from "../../../../../api/dashboard/types";
+import type {
+  DashboardInferenceAttempt,
+  DashboardWorkstationRequest,
+} from "../../../../../api/dashboard/types";
 import { DashboardActionButton } from "../../../../../components/ui/dashboard-action-button";
 import {
   formatDurationFromISO,
   formatDurationMillis,
   formatWorkItemLabel,
+  getLocalDateTimeDisplay,
 } from "../../../../../components/ui/formatters";
 import { CurrentSelectionExpandableSection } from "../../../base/components/detail/current-selection-expandable-section";
 import { CurrentSelectionExecutionPill } from "../../../base/components/presentation/current-selection-pill";
 import { CurrentSelectionSupportingText } from "../../../base/components/presentation/current-selection-supporting-text";
+import { getCurrentSelectionOperationalEnumMessages } from "../../../base/messages/operational/current-selection-operational-enums";
+import { getCurrentSelectionDetailMessages } from "../../../base/messages/shell/current-selection-detail";
+import {
+  CurrentSelectionHistoryCard,
+  CurrentSelectionHistoryCardHeader,
+} from "../../../history/components/current-selection-history-card";
 import type { WorkstationRequestHistorySectionProps } from "../../lib/keys/detail-card-types";
 import type { getWorkstationDetailMessages } from "../../messages/workstation-detail";
 import { WorkstationDispatchRow } from "./workstation-dispatch-row";
 
 export function WorkstationRequestHistorySection({
+  locale,
   messages,
   now,
   onSelectWorkID,
@@ -41,6 +53,7 @@ export function WorkstationRequestHistorySection({
           {requests.map((request) => (
             <WorkstationRequestHistoryRow
               key={request.dispatch_id}
+              locale={locale}
               messages={messages}
               now={now}
               onSelectWorkID={onSelectWorkID}
@@ -59,6 +72,7 @@ export function WorkstationRequestHistorySection({
 }
 
 function WorkstationRequestHistoryRow({
+  locale,
   messages,
   now,
   onSelectWorkID,
@@ -67,6 +81,7 @@ function WorkstationRequestHistoryRow({
   selectedRequest,
   selectedWorkID,
 }: {
+  locale?: string;
   messages: ReturnType<typeof getWorkstationDetailMessages>;
   now: number;
   onSelectWorkID?: WorkstationRequestHistorySectionProps["onSelectWorkID"];
@@ -75,11 +90,7 @@ function WorkstationRequestHistoryRow({
   selectedRequest?: WorkstationRequestHistorySectionProps["selectedRequest"];
   selectedWorkID?: WorkstationRequestHistorySectionProps["selectedWorkID"];
 }) {
-  const primaryWorkItem = request.work_items[0];
   const requestSelected = selectedRequest?.dispatch_id === request.dispatch_id;
-  const workLabel = primaryWorkItem
-    ? formatWorkItemLabel(primaryWorkItem)
-    : messages.unknownActiveWorkLabel;
   const totalDurationMillis =
     request.total_duration_millis ?? request.script_response?.duration_millis;
   const normalizedOutcome = (
@@ -99,13 +110,9 @@ function WorkstationRequestHistoryRow({
     <WorkstationDispatchRow
       actions={renderWorkstationRequestActions({
         messages,
-        onSelectWorkID,
         onSelectWorkstationRequest,
-        primaryWorkItem,
         request,
         requestSelected,
-        selectedWorkID,
-        workLabel,
       })}
       status={renderWorkstationRequestStatusPill({
         hasFailedOutcome,
@@ -115,52 +122,360 @@ function WorkstationRequestHistoryRow({
         totalDurationMillis,
       })}
       supportingContent={
-        requestSelected ? (
-          <CurrentSelectionSupportingText tone="status">
-            {messages.selectedRequestLabel(request.dispatch_id)}
-          </CurrentSelectionSupportingText>
-        ) : null
+        <div className="grid gap-3">
+          <WorkstationRequestWorkItems
+            messages={messages}
+            onSelectWorkID={onSelectWorkID}
+            request={request}
+            selectedWorkID={selectedWorkID}
+          />
+          <WorkstationRequestAttempts
+            locale={locale}
+            messages={messages}
+            request={request}
+          />
+          {requestSelected ? (
+            <CurrentSelectionSupportingText tone="status">
+              {messages.selectedRequestLabel(request.dispatch_id)}
+            </CurrentSelectionSupportingText>
+          ) : null}
+        </div>
       }
-      title={workLabel}
+      title={
+        <>
+          <span>{messages.projectedWorkstationRequestSummary}</span>{" "}
+          <Code>{request.request_id ?? request.dispatch_id}</Code>
+        </>
+      }
     />
+  );
+}
+
+function WorkstationRequestWorkItems({
+  messages,
+  onSelectWorkID,
+  request,
+  selectedWorkID,
+}: {
+  messages: ReturnType<typeof getWorkstationDetailMessages>;
+  onSelectWorkID?: WorkstationRequestHistorySectionProps["onSelectWorkID"];
+  request: DashboardWorkstationRequest;
+  selectedWorkID?: WorkstationRequestHistorySectionProps["selectedWorkID"];
+}) {
+  if (request.work_items.length === 0) {
+    return (
+      <CurrentSelectionSupportingText tone="status">
+        {messages.unknownWorkLabel}
+      </CurrentSelectionSupportingText>
+    );
+  }
+
+  return (
+    <div className="grid gap-2">
+      {request.work_items.map((workItem) => {
+        const workLabel = formatWorkItemLabel(workItem);
+        const selected = selectedWorkID === workItem.work_id;
+
+        return (
+          <CurrentSelectionHistoryCard
+            className="p-3"
+            key={`${request.dispatch_id}:${workItem.work_id}`}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="grid min-w-0 gap-1">
+                <strong className="min-w-0 [overflow-wrap:anywhere]">
+                  {workLabel}
+                </strong>
+                <Code>
+                  {messages.workIdLabel}: {workItem.work_id}
+                </Code>
+              </div>
+              {onSelectWorkID ? (
+                <DashboardActionButton
+                  aria-label={messages.selectWorkItemLabel(workLabel)}
+                  aria-pressed={selected}
+                  onClick={() => onSelectWorkID(workItem.work_id)}
+                  type="button"
+                >
+                  {selected
+                    ? messages.workSelectedAction
+                    : messages.openWorkItemAction}
+                </DashboardActionButton>
+              ) : null}
+            </div>
+          </CurrentSelectionHistoryCard>
+        );
+      })}
+    </div>
+  );
+}
+
+function WorkstationRequestAttempts({
+  locale,
+  messages,
+  request,
+}: {
+  locale?: string;
+  messages: ReturnType<typeof getWorkstationDetailMessages>;
+  request: DashboardWorkstationRequest;
+}) {
+  const inferenceAttempts = request.inference_attempts
+    .map((attempt, index) => ({ attempt, index }))
+    .sort(
+      (left, right) =>
+        left.attempt.attempt - right.attempt.attempt ||
+        left.index - right.index,
+    );
+  const hasScriptAttempt = Boolean(
+    request.script_request || request.script_response,
+  );
+
+  if (inferenceAttempts.length === 0 && !hasScriptAttempt) {
+    return null;
+  }
+
+  return (
+    <div className="grid gap-2">
+      {inferenceAttempts.map(({ attempt }) => (
+        <WorkstationInferenceAttemptCard
+          attempt={attempt}
+          key={`${request.dispatch_id}:inference:${attempt.inference_request_id}:${attempt.attempt}`}
+          locale={locale}
+          messages={messages}
+        />
+      ))}
+      {hasScriptAttempt ? (
+        <WorkstationScriptAttemptCard
+          key={`${request.dispatch_id}:script:${getScriptRequestID(request) ?? "dispatch"}`}
+          locale={locale}
+          messages={messages}
+          request={request}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function WorkstationInferenceAttemptCard({
+  attempt,
+  locale,
+  messages,
+}: {
+  attempt: DashboardInferenceAttempt;
+  locale?: string;
+  messages: ReturnType<typeof getWorkstationDetailMessages>;
+}) {
+  const detailMessages = getCurrentSelectionDetailMessages(locale);
+  const enumMessages = getCurrentSelectionOperationalEnumMessages(locale);
+  const provider =
+    attempt.diagnostics?.provider?.provider ??
+    attempt.provider_session?.provider;
+  const model = attempt.diagnostics?.provider?.model;
+  const providerSummary = provider
+    ? messages.providerSummary(provider, model)
+    : model;
+  const requestTime = getLocalDateTimeDisplay(
+    attempt.request_time,
+    detailMessages.timestampUnavailable,
+    locale,
+  );
+  const responseTime = getLocalDateTimeDisplay(
+    attempt.response_time,
+    detailMessages.timestampUnavailable,
+    locale,
+  );
+  const outcome = enumMessages.localizeOutcome(
+    attempt.outcome ?? detailMessages.pendingOutcome,
+  );
+
+  return (
+    <CurrentSelectionHistoryCard className="p-3">
+      <CurrentSelectionHistoryCardHeader
+        identifier={attempt.inference_request_id}
+        subtitle={outcome}
+        title={detailMessages.attemptTitle(attempt.attempt)}
+      />
+      <div className="grid gap-1">
+        <WorkstationRequestAttemptDetail
+          label={detailMessages.providerLabel}
+          value={providerSummary}
+        />
+        <WorkstationRequestAttemptDetail
+          label={detailMessages.providerSessionLabel}
+          value={attempt.provider_session?.id}
+        />
+        <WorkstationRequestAttemptTimeDetail
+          label={detailMessages.requestTimeLabel}
+          timestamp={requestTime}
+        />
+        <WorkstationRequestAttemptDetail
+          label={detailMessages.elapsedTimeLabel}
+          value={
+            attempt.duration_millis !== undefined
+              ? formatDurationMillis(attempt.duration_millis, locale)
+              : undefined
+          }
+        />
+        <WorkstationRequestAttemptTimeDetail
+          label={detailMessages.responseTimeLabel}
+          timestamp={responseTime}
+          visible={Boolean(attempt.response_time)}
+        />
+      </div>
+    </CurrentSelectionHistoryCard>
+  );
+}
+
+function WorkstationScriptAttemptCard({
+  locale,
+  messages,
+  request,
+}: {
+  locale?: string;
+  messages: ReturnType<typeof getWorkstationDetailMessages>;
+  request: DashboardWorkstationRequest;
+}) {
+  const detailMessages = getCurrentSelectionDetailMessages(locale);
+  const enumMessages = getCurrentSelectionOperationalEnumMessages(locale);
+  const scriptRequestID = getScriptRequestID(request);
+  const scriptIdentifier = scriptRequestID ?? request.dispatch_id;
+  const scriptResponse = request.script_response;
+  const outcome = enumMessages.localizeOutcome(
+    scriptResponse?.outcome ?? request.outcome ?? detailMessages.pendingOutcome,
+  );
+  const provider = request.provider ?? request.provider_session?.provider;
+  const providerSummary = provider
+    ? messages.providerSummary(provider, request.model)
+    : request.model;
+  const requestTime = getLocalDateTimeDisplay(
+    request.started_at ?? request.request_view?.started_at,
+    detailMessages.timestampUnavailable,
+    locale,
+  );
+  const responseTime = getLocalDateTimeDisplay(
+    request.response_view?.end_time,
+    detailMessages.timestampUnavailable,
+    locale,
+  );
+  const durationMillis =
+    scriptResponse?.duration_millis ?? scriptResponse?.durationMillis;
+
+  return (
+    <CurrentSelectionHistoryCard className="p-3">
+      <CurrentSelectionHistoryCardHeader
+        identifier={scriptIdentifier}
+        subtitle={outcome}
+        title={detailMessages.scriptAttemptLabel}
+      />
+      <div className="grid gap-1">
+        <WorkstationRequestAttemptDetail
+          label={
+            scriptRequestID
+              ? detailMessages.scriptRequestIdLabel
+              : detailMessages.dispatchIdLabel
+          }
+          value={scriptIdentifier}
+        />
+        <WorkstationRequestAttemptDetail
+          label={detailMessages.commandLabel}
+          value={request.script_request?.command}
+        />
+        <WorkstationRequestAttemptDetail
+          label={detailMessages.providerLabel}
+          value={providerSummary}
+        />
+        <WorkstationRequestAttemptTimeDetail
+          label={detailMessages.requestTimeLabel}
+          timestamp={requestTime}
+        />
+        <WorkstationRequestAttemptDetail
+          label={detailMessages.elapsedTimeLabel}
+          value={
+            durationMillis !== undefined
+              ? formatDurationMillis(durationMillis, locale)
+              : undefined
+          }
+        />
+        <WorkstationRequestAttemptTimeDetail
+          label={detailMessages.responseTimeLabel}
+          timestamp={responseTime}
+          visible={Boolean(request.response_view?.end_time)}
+        />
+      </div>
+    </CurrentSelectionHistoryCard>
+  );
+}
+
+function WorkstationRequestAttemptDetail({
+  label,
+  value,
+}: {
+  label: string;
+  value?: string;
+}) {
+  if (!value) {
+    return null;
+  }
+
+  return (
+    <CurrentSelectionSupportingText>
+      {label}: <Code>{value}</Code>
+    </CurrentSelectionSupportingText>
+  );
+}
+
+function WorkstationRequestAttemptTimeDetail({
+  label,
+  timestamp,
+  visible = true,
+}: {
+  label: string;
+  timestamp: ReturnType<typeof getLocalDateTimeDisplay>;
+  visible?: boolean;
+}) {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <CurrentSelectionSupportingText>
+      {label}:{" "}
+      {timestamp.rawTimestamp ? (
+        <time dateTime={timestamp.rawTimestamp}>{timestamp.label}</time>
+      ) : (
+        timestamp.label
+      )}
+    </CurrentSelectionSupportingText>
+  );
+}
+
+function getScriptRequestID(
+  request: DashboardWorkstationRequest,
+): string | undefined {
+  return (
+    request.script_request?.script_request_id ??
+    request.script_request?.scriptRequestId ??
+    request.script_response?.script_request_id ??
+    request.script_response?.scriptRequestId
   );
 }
 
 function renderWorkstationRequestActions({
   messages,
-  onSelectWorkID,
   onSelectWorkstationRequest,
-  primaryWorkItem,
   request,
   requestSelected,
-  selectedWorkID,
-  workLabel,
 }: {
   messages: ReturnType<typeof getWorkstationDetailMessages>;
-  onSelectWorkID?: WorkstationRequestHistorySectionProps["onSelectWorkID"];
   onSelectWorkstationRequest?: WorkstationRequestHistorySectionProps["onSelectWorkstationRequest"];
-  primaryWorkItem:
-    | DashboardWorkstationRequest["work_items"][number]
-    | undefined;
   request: DashboardWorkstationRequest;
   requestSelected: boolean;
-  selectedWorkID?: WorkstationRequestHistorySectionProps["selectedWorkID"];
-  workLabel: string;
 }) {
-  const workAction =
-    primaryWorkItem && onSelectWorkID ? (
-      <DashboardActionButton
-        aria-label={messages.selectWorkItemLabel(workLabel)}
-        aria-pressed={selectedWorkID === primaryWorkItem.work_id}
-        onClick={() => onSelectWorkID(primaryWorkItem.work_id)}
-        type="button"
-      >
-        {selectedWorkID === primaryWorkItem.work_id
-          ? messages.workSelectedAction
-          : messages.openWorkItemAction}
-      </DashboardActionButton>
-    ) : null;
-  const requestAction = onSelectWorkstationRequest ? (
+  if (!onSelectWorkstationRequest) {
+    return undefined;
+  }
+
+  return (
     <DashboardActionButton
       aria-label={messages.selectWorkstationRequestLabel(request.dispatch_id)}
       aria-pressed={requestSelected}
@@ -171,17 +486,6 @@ function renderWorkstationRequestActions({
         ? messages.requestSelectedAction
         : messages.openRequestDetailsAction}
     </DashboardActionButton>
-  ) : null;
-
-  if (!workAction && !requestAction) {
-    return undefined;
-  }
-
-  return (
-    <>
-      {workAction}
-      {requestAction}
-    </>
   );
 }
 

--- a/ui/src/features/current-selection/workstation-selection/lib/keys/detail-card-types.ts
+++ b/ui/src/features/current-selection/workstation-selection/lib/keys/detail-card-types.ts
@@ -189,6 +189,7 @@ export interface WorkstationActiveWorkListProps {
 }
 
 export interface WorkstationRequestHistorySectionProps {
+  locale?: string;
   messages: WorkstationDetailMessages;
   now: number;
   onSelectWorkID?: (workID: string) => void;
@@ -202,6 +203,7 @@ export interface WorkstationRequestHistorySectionProps {
 export interface WorkstationHistorySectionProps {
   collapseActionLabel: string;
   expandActionLabel: string;
+  locale?: string;
   messages: WorkstationDetailMessages;
   now: number;
   onSelectProviderSession?: (session: LoadableProviderSessionRef) => void;

--- a/ui/src/features/current-selection/workstation-selection/messages/workstation-detail-types.ts
+++ b/ui/src/features/current-selection/workstation-selection/messages/workstation-detail-types.ts
@@ -144,6 +144,11 @@ export interface WorkstationDetailMessages {
   elapsedLabel: string;
   totalRuntimeLabel: string;
   expandAction: string;
+  historyProgressLabel: (
+    shownCount: number,
+    totalCount: number,
+    remainingCount: number,
+  ) => string;
   historyRequestCountLabel: (count: number) => string;
   historyRunCountLabel: (count: number) => string;
   historicalRequestsLabel: string;
@@ -162,6 +167,7 @@ export interface WorkstationDetailMessages {
   providerSummary: (provider: string, model?: string | null) => string;
   requestDetailsUnavailable: (dispatchId: string) => string;
   requestHistoryHeading: string;
+  showMoreHistoryAction: (remainingCount: number) => string;
   requestSelectedAction: string;
   requestStatusStartedAgo: (elapsed: string) => string;
   runnerFieldHelp: (runnerName: string, sourceLabel: string) => string;

--- a/ui/src/features/current-selection/workstation-selection/messages/workstation-detail.ts
+++ b/ui/src/features/current-selection/workstation-selection/messages/workstation-detail.ts
@@ -220,6 +220,8 @@ const workstationDetailMessagesByLocale = {
     elapsedLabel: "Elapsed",
     totalRuntimeLabel: "Total runtime",
     expandAction: "Expand",
+    historyProgressLabel: (shownCount, totalCount, remainingCount) =>
+      `Showing ${shownCount} of ${totalCount} requests. ${remainingCount} remaining.`,
     historyRequestCountLabel: (count) =>
       singularPlural(count, "request", "requests"),
     historyRunCountLabel: (count) => singularPlural(count, "run", "runs"),
@@ -243,6 +245,8 @@ const workstationDetailMessagesByLocale = {
     requestDetailsUnavailable: (dispatchId) =>
       `Request details unavailable for dispatch ${dispatchId}.`,
     requestHistoryHeading: "Request history",
+    showMoreHistoryAction: (remainingCount) =>
+      `Show ${remainingCount} more request${remainingCount === 1 ? "" : "s"}`,
     requestSelectedAction: "Request selected",
     requestStatusStartedAgo: (elapsed) => `Started ${elapsed}`,
     runnerFieldHelp: (runnerName, sourceLabel) =>
@@ -508,6 +512,8 @@ const workstationDetailMessagesByLocale = {
     elapsedLabel: "経過時間",
     totalRuntimeLabel: "合計実行時間",
     expandAction: "展開",
+    historyProgressLabel: (shownCount, totalCount, remainingCount) =>
+      `${totalCount}件中${shownCount}件を表示しています。残り${remainingCount}件。`,
     historyRequestCountLabel: (count) => `${count} 件のリクエスト`,
     historyRunCountLabel: (count) => `${count} 件のラン`,
     historicalRequestsLabel: "過去のリクエスト",
@@ -531,6 +537,7 @@ const workstationDetailMessagesByLocale = {
     requestDetailsUnavailable: (dispatchId) =>
       `ディスパッチ ${dispatchId} のリクエスト詳細は利用できません。`,
     requestHistoryHeading: "リクエスト履歴",
+    showMoreHistoryAction: (remainingCount) => `残り${remainingCount}件を表示`,
     requestSelectedAction: "リクエストを選択済み",
     requestStatusStartedAgo: (elapsed) => `${elapsed} に開始`,
     runnerFieldHelp: (runnerName, sourceLabel) =>
@@ -792,6 +799,8 @@ const workstationDetailMessagesByLocale = {
     elapsedLabel: "경과 시간",
     totalRuntimeLabel: "총 실행 시간",
     expandAction: "펼치기",
+    historyProgressLabel: (shownCount, totalCount, remainingCount) =>
+      `${totalCount}개 요청 중 ${shownCount}개를 표시합니다. ${remainingCount}개 남았습니다.`,
     historyRequestCountLabel: (count) => `${count}개 요청`,
     historyRunCountLabel: (count) => `${count}개 실행`,
     historicalRequestsLabel: "이전 요청",
@@ -814,6 +823,8 @@ const workstationDetailMessagesByLocale = {
     requestDetailsUnavailable: (dispatchId) =>
       `디스패치 ${dispatchId}의 요청 세부정보를 사용할 수 없습니다.`,
     requestHistoryHeading: "요청 기록",
+    showMoreHistoryAction: (remainingCount) =>
+      `요청 ${remainingCount}개 더 표시`,
     requestSelectedAction: "요청 선택됨",
     requestStatusStartedAgo: (elapsed) => `${elapsed} 시작`,
     runnerFieldHelp: (runnerName, sourceLabel) =>
@@ -1058,6 +1069,8 @@ const workstationDetailMessagesByLocale = {
     elapsedLabel: "已用时间",
     totalRuntimeLabel: "总运行时间",
     expandAction: "展开",
+    historyProgressLabel: (shownCount, totalCount, remainingCount) =>
+      `显示 ${totalCount} 个请求中的 ${shownCount} 个。剩余 ${remainingCount} 个。`,
     historyRequestCountLabel: (count) => `${count} 个请求`,
     historyRunCountLabel: (count) => `${count} 次运行`,
     historicalRequestsLabel: "历史请求",
@@ -1078,6 +1091,8 @@ const workstationDetailMessagesByLocale = {
     requestDetailsUnavailable: (dispatchId) =>
       `无法提供分派 ${dispatchId} 的请求详情。`,
     requestHistoryHeading: "请求历史",
+    showMoreHistoryAction: (remainingCount) =>
+      `再显示 ${remainingCount} 个请求`,
     requestSelectedAction: "请求已选中",
     requestStatusStartedAgo: (elapsed) => `开始于 ${elapsed}`,
     runnerFieldHelp: (runnerName, sourceLabel) =>

--- a/ui/src/features/terminal-work/components/terminal-work-card.stories.tsx
+++ b/ui/src/features/terminal-work/components/terminal-work-card.stories.tsx
@@ -51,6 +51,17 @@ const failedItems: TerminalWorkItem[] = [
   },
 ];
 
+const boundedCompletedItems: TerminalWorkItem[] = Array.from(
+  { length: 12 },
+  (_, index) => {
+    const itemNumber = index + 1;
+    return {
+      label: `Completed Story ${itemNumber}`,
+      traceWorkID: `work-completed-story-${itemNumber}`,
+    };
+  },
+);
+
 const ACCENT_SELECTED_TOKENS = [
   "bg-primary",
   "bg-primary-container",
@@ -194,6 +205,60 @@ export const LocalizedJapanese = {
         name: messages.disclosureLabel(false),
       }),
     ).toHaveAttribute("aria-expanded", "false");
+  },
+};
+
+export const BoundedHistory = {
+  tags: ["test"],
+  render: () => (
+    <CompletedFailedWorkstationCard
+      completedItems={boundedCompletedItems}
+      failedItems={[]}
+      onSelectItem={() => {}}
+      widgetId="terminal-work-bounded-history-story"
+    />
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const messages = getTerminalWorkMessages("en");
+    const terminalWork = await canvas.findByLabelText(messages.cardTitle);
+    const completedRow = (
+      await within(terminalWork).findByRole("heading", {
+        name: messages.rowTitle("completed"),
+      })
+    ).closest("section");
+    if (!(completedRow instanceof HTMLElement)) {
+      throw new Error("expected completed terminal-work row");
+    }
+
+    const completedList = within(completedRow).getByRole("list");
+    await expect(within(completedList).getAllByRole("listitem")).toHaveLength(
+      10,
+    );
+    await expect(
+      within(completedRow).getByText("Showing 10 of 12 items. 2 remaining."),
+    ).toBeVisible();
+
+    const revealAction = within(completedRow).getByRole("button", {
+      name: "Show 2 more items",
+    });
+    revealAction.focus();
+    await userEvent.keyboard("{Enter}");
+
+    await expect(within(completedList).getAllByRole("listitem")).toHaveLength(
+      12,
+    );
+    await expect(
+      within(completedRow).getByRole("button", {
+        name: messages.selectWorkItemLabel("Completed Story 12"),
+      }),
+    ).toBeVisible();
+    expect(
+      within(completedRow).queryByRole("button", {
+        name: "Show 2 more items",
+      }),
+    ).toBeNull();
+    expect(document.activeElement).toBe(completedList);
   },
 };
 

--- a/ui/src/features/terminal-work/components/terminal-work-card.stories.tsx
+++ b/ui/src/features/terminal-work/components/terminal-work-card.stories.tsx
@@ -4,14 +4,9 @@ import type { DashboardProviderSessionAttempt } from "../../../api/dashboard/typ
 import { getTerminalWorkMessages } from "../messages/terminal-work";
 import type {
   TerminalWorkItem,
-  TerminalWorkStatus,
+  TerminalWorkSelection,
 } from "./terminal-work-card";
 import { CompletedFailedWorkstationCard } from "./terminal-work-card";
-
-const STANDARD_LIST_SELECTION_ROW_DANGER_CLASS =
-  "border-af-danger-border bg-error-container text-on-error";
-const STANDARD_LIST_SELECTION_ROW_SELECTED_CLASS =
-  "border-outline-variant bg-surface-container-low text-on-surface";
 
 const failedAttempt: DashboardProviderSessionAttempt = {
   dispatch_id: "dispatch-repair-failed",
@@ -70,17 +65,23 @@ function expectNoAccentSelectedTreatment(className: string) {
 }
 
 function SelectableTerminalWorkStory() {
-  const [selectedItem, setSelectedItem] = useState<{
-    label: string;
-    status: TerminalWorkStatus;
-  } | null>({ label: "Failed Story", status: "failed" });
+  const [selectedItem, setSelectedItem] =
+    useState<TerminalWorkSelection | null>({
+      status: "failed",
+      traceWorkID: "work-failed-story",
+    });
 
   return (
     <CompletedFailedWorkstationCard
       completedItems={completedItems}
       failedItems={failedItems}
       onSelectItem={(status, item) =>
-        setSelectedItem({ label: item.label, status })
+        setSelectedItem({
+          dispatchID: item.dispatchID,
+          status,
+          traceWorkID: item.traceWorkID,
+          workItem: item.workItem,
+        })
       }
       selectedItem={selectedItem}
       widgetId="terminal-work-story"
@@ -118,7 +119,9 @@ export const MixedOutcomes = {
     const terminalScope = within(terminalWork);
 
     await expect(
-      await terminalScope.findByRole("button", { name: "Failed Story" }),
+      await terminalScope.findByRole("button", {
+        name: messages.selectWorkItemLabel("Failed Story"),
+      }),
     ).toBeVisible();
 
     const completedToggle = (
@@ -129,28 +132,25 @@ export const MixedOutcomes = {
     await userEvent.click(completedToggle);
     await expect(completedToggle).toHaveAttribute("aria-expanded", "false");
     expect(
-      terminalScope.queryByRole("button", { name: "Done Story" }),
+      terminalScope.queryByRole("button", {
+        name: messages.selectWorkItemLabel("Done Story"),
+      }),
     ).toBeNull();
 
     await userEvent.click(completedToggle);
     const doneStory = await terminalScope.findByRole("button", {
-      name: "Done Story",
+      name: messages.selectWorkItemLabel("Done Story"),
     });
     await expect(doneStory).toBeVisible();
-    await userEvent.click(doneStory);
-    await expect(doneStory).toHaveAttribute("data-selected", "true");
+    doneStory.focus();
+    await userEvent.keyboard("{Enter}");
     await expect(doneStory).toHaveAttribute("aria-pressed", "true");
-    expect(doneStory.className).toContain(
-      STANDARD_LIST_SELECTION_ROW_SELECTED_CLASS,
-    );
+    await expect(doneStory).toHaveTextContent(messages.selectedWorkItemAction);
     expectNoAccentSelectedTreatment(doneStory.className);
 
     const failedStory = await terminalScope.findByRole("button", {
-      name: "Failed Story",
+      name: messages.selectWorkItemLabel("Failed Story"),
     });
-    expect(failedStory.className).toContain(
-      STANDARD_LIST_SELECTION_ROW_DANGER_CLASS,
-    );
     await expect(failedStory).toHaveAttribute("aria-pressed", "false");
     expectNoAccentSelectedTreatment(failedStory.className);
   },

--- a/ui/src/features/terminal-work/components/terminal-work-card.test.tsx
+++ b/ui/src/features/terminal-work/components/terminal-work-card.test.tsx
@@ -1,6 +1,7 @@
 import "../../../testing/vitest-dom-capabilities.setup";
 
 import { fireEvent, render, screen, within } from "@testing-library/react";
+import { useState } from "react";
 import type { DashboardProviderSessionAttempt } from "../../../api/dashboard/types";
 import { getTerminalWorkMessages } from "../messages/terminal-work";
 import { CompletedFailedWorkstationCard } from "./terminal-work-card";
@@ -19,7 +20,7 @@ const failedAttempt: DashboardProviderSessionAttempt = {
 };
 
 describe("CompletedFailedWorkstationCard", () => {
-  it("renders exactly two expandable outcome rows with completed and failed items", () => {
+  it("renders distinct expandable outcome rows with canonical work identity", () => {
     const onSelectItem = vi.fn();
     const messages = getTerminalWorkMessages("en");
 
@@ -41,7 +42,7 @@ describe("CompletedFailedWorkstationCard", () => {
     );
 
     const rows = document.querySelectorAll("[data-terminal-work-status]");
-    expect(rows).toHaveLength(2);
+    expect(rows).toHaveLength(5);
     const completedHeading = screen.getByRole("heading", {
       name: messages.rowTitle("completed"),
     });
@@ -78,7 +79,7 @@ describe("CompletedFailedWorkstationCard", () => {
           name: messages.iconLabel("completed"),
         })
         .getAttribute("class"),
-    ).toContain("text-on-info");
+    ).toContain("text-on-success-container");
     expect(
       within(failedTitle as HTMLElement)
         .getByRole("img", { name: messages.iconLabel("failed") })
@@ -156,6 +157,124 @@ describe("CompletedFailedWorkstationCard", () => {
     expect(screen.getByText("Failed at Repair")).toBeTruthy();
     expect(screen.queryByText(/session_id/i)).toBeNull();
     expect(screen.queryByText(/codex/i)).toBeNull();
+  });
+
+  it("keeps duplicate display labels independently selectable by canonical Work ID", () => {
+    const messages = getTerminalWorkMessages("en");
+    const items = [
+      {
+        dispatchID: "dispatch-duplicate-one",
+        label: "Duplicate Story",
+        traceWorkID: "work-duplicate-one",
+      },
+      {
+        dispatchID: "dispatch-duplicate-two",
+        label: "Duplicate Story",
+        traceWorkID: "work-duplicate-two",
+      },
+    ];
+
+    function DuplicateLabelSelection() {
+      const [selectedItem, setSelectedItem] = useState<{
+        dispatchID?: string;
+        status: "completed";
+        traceWorkID: string;
+      } | null>(null);
+
+      return (
+        <CompletedFailedWorkstationCard
+          completedItems={items}
+          failedItems={[]}
+          onSelectItem={(status, item) =>
+            setSelectedItem({
+              dispatchID: item.dispatchID,
+              status,
+              traceWorkID: item.traceWorkID,
+            })
+          }
+          selectedItem={selectedItem}
+        />
+      );
+    }
+
+    render(<DuplicateLabelSelection />);
+
+    const duplicateActions = screen.getAllByRole("button", {
+      name: messages.selectWorkItemLabel("Duplicate Story"),
+    });
+    expect(duplicateActions).toHaveLength(2);
+    expect(screen.getByText("Work ID: work-duplicate-one")).toBeTruthy();
+    expect(screen.getByText("Work ID: work-duplicate-two")).toBeTruthy();
+
+    fireEvent.click(duplicateActions[1] as HTMLElement);
+
+    expect(
+      (duplicateActions[0] as HTMLElement).getAttribute("aria-pressed"),
+    ).toBe("false");
+    expect(
+      screen
+        .getAllByRole("button", {
+          name: messages.selectWorkItemLabel("Duplicate Story"),
+        })[1]
+        ?.getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+
+  it("renders canceled, terminated, and unknown outcomes as distinct statuses", () => {
+    const messages = getTerminalWorkMessages("en");
+
+    render(
+      <CompletedFailedWorkstationCard
+        canceledItems={[
+          { label: "Canceled Story", traceWorkID: "work-canceled" },
+        ]}
+        completedItems={[]}
+        failedItems={[{ label: "Failed Story", traceWorkID: "work-failed" }]}
+        onSelectItem={vi.fn()}
+        terminatedItems={[
+          { label: "Terminated Story", traceWorkID: "work-terminated" },
+        ]}
+        unknownItems={[{ label: "Unknown Story", traceWorkID: "work-unknown" }]}
+      />,
+    );
+
+    for (const status of [
+      "failed",
+      "canceled",
+      "terminated",
+      "unknown",
+    ] as const) {
+      const row = document.querySelector(
+        `[data-terminal-work-status="${status}"]`,
+      );
+      expect(row).toBeTruthy();
+      expect(
+        within(row as HTMLElement).getByRole("heading", {
+          name: messages.rowTitle(status),
+        }),
+      ).toBeTruthy();
+      expect(
+        within(row as HTMLElement).getByRole("status", {
+          name: messages.rowTitle(status),
+        }),
+      ).toBeTruthy();
+    }
+
+    expect(
+      document.querySelector(
+        '[data-terminal-work-status="canceled"] [data-graph-semantic-icon="processing"]',
+      ),
+    ).toBeTruthy();
+    expect(
+      document.querySelector(
+        '[data-terminal-work-status="terminated"] [data-graph-semantic-icon="limit"]',
+      ),
+    ).toBeTruthy();
+    expect(
+      document.querySelector(
+        '[data-terminal-work-status="unknown"] [data-graph-semantic-icon="queue"]',
+      ),
+    ).toBeTruthy();
   });
 
   it("collapses each row independently without hiding the other row heading", () => {
@@ -264,12 +383,12 @@ describe("CompletedFailedWorkstationCard", () => {
     const completedToggles = screen.getAllByRole("button", {
       name: messages.disclosureLabel(true),
     });
-    expect(completedToggles).toHaveLength(4);
+    expect(completedToggles).toHaveLength(10);
 
     expect(completedToggles[0]?.getAttribute("aria-controls")).toBe(
       "terminal-work::one-completed-items",
     );
-    expect(completedToggles[2]?.getAttribute("aria-controls")).toBe(
+    expect(completedToggles[5]?.getAttribute("aria-controls")).toBe(
       "terminal-work::two-completed-items",
     );
 
@@ -312,7 +431,10 @@ describe("CompletedFailedWorkstationCard", () => {
           { label: "Failed Story", traceWorkID: "work-failed-story" },
         ]}
         onSelectItem={vi.fn()}
-        selectedItem={{ label: "Failed Story", status: "failed" }}
+        selectedItem={{
+          status: "failed",
+          traceWorkID: "work-failed-story",
+        }}
       />,
     );
 
@@ -329,7 +451,7 @@ describe("CompletedFailedWorkstationCard", () => {
       { selected: false, text: messages.openWorkItemAction },
     );
     expect(
-      screen.getByText(messages.selectedWorkItemLabel("Failed Story")),
+      screen.getByText(messages.selectedWorkItemLabel("work-failed-story")),
     ).toBeTruthy();
   });
 
@@ -344,7 +466,10 @@ describe("CompletedFailedWorkstationCard", () => {
           { label: "Failed Story", traceWorkID: "work-failed-story" },
         ]}
         onSelectItem={vi.fn()}
-        selectedItem={{ label: "Done Story", status: "completed" }}
+        selectedItem={{
+          status: "completed",
+          traceWorkID: "work-done-story",
+        }}
       />,
     );
 
@@ -364,7 +489,10 @@ describe("CompletedFailedWorkstationCard", () => {
           { label: "Failed Story", traceWorkID: "work-failed-story" },
         ]}
         onSelectItem={vi.fn()}
-        selectedItem={{ label: "Failed Story", status: "failed" }}
+        selectedItem={{
+          status: "failed",
+          traceWorkID: "work-failed-story",
+        }}
       />,
     );
 

--- a/ui/src/features/terminal-work/components/terminal-work-card.test.tsx
+++ b/ui/src/features/terminal-work/components/terminal-work-card.test.tsx
@@ -20,6 +20,87 @@ const failedAttempt: DashboardProviderSessionAttempt = {
 };
 
 describe("CompletedFailedWorkstationCard", () => {
+  it("reveals bounded terminal history without skipping or duplicating rows", () => {
+    const completedItems = Array.from({ length: 12 }, (_, index) => {
+      const itemNumber = index + 1;
+      return {
+        label: `Completed Story ${itemNumber}`,
+        traceWorkID: `work-completed-story-${itemNumber}`,
+      };
+    });
+
+    render(
+      <CompletedFailedWorkstationCard
+        completedItems={completedItems}
+        failedItems={[]}
+        onSelectItem={vi.fn()}
+        selectedItem={{
+          status: "completed",
+          traceWorkID: "work-completed-story-1",
+        }}
+      />,
+    );
+
+    const completedRow = screen
+      .getByRole("heading", { name: "Completed" })
+      .closest("section");
+    if (!completedRow) {
+      throw new Error("expected completed row");
+    }
+    const completedList = within(completedRow).getByRole("list");
+
+    expect(within(completedList).getAllByRole("listitem")).toHaveLength(10);
+    expect(
+      within(completedRow)
+        .getByRole("button", {
+          name: "Select work item Completed Story 1",
+        })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      within(completedRow).getByText("Showing 10 of 12 items. 2 remaining."),
+    ).toBeTruthy();
+    expect(
+      within(completedRow).queryByRole("button", {
+        name: "Show 2 more items",
+      }),
+    ).toBeTruthy();
+    expect(
+      within(completedRow).queryByRole("button", {
+        name: "Select work item Completed Story 11",
+      }),
+    ).toBeNull();
+
+    const revealAction = within(completedRow).getByRole("button", {
+      name: "Show 2 more items",
+    });
+    revealAction.focus();
+    fireEvent.click(revealAction);
+
+    expect(within(completedList).getAllByRole("listitem")).toHaveLength(12);
+    expect(
+      within(completedRow).getByRole("button", {
+        name: "Select work item Completed Story 11",
+      }),
+    ).toBeTruthy();
+    expect(
+      within(completedRow)
+        .getByRole("button", {
+          name: "Select work item Completed Story 1",
+        })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      within(completedRow).queryByText("Showing 10 of 12 items. 2 remaining."),
+    ).toBeNull();
+    expect(
+      within(completedRow).queryByRole("button", {
+        name: "Show 2 more items",
+      }),
+    ).toBeNull();
+    expect(document.activeElement).toBe(completedList);
+  });
+
   it("renders distinct expandable outcome rows with canonical work identity", () => {
     const onSelectItem = vi.fn();
     const messages = getTerminalWorkMessages("en");

--- a/ui/src/features/terminal-work/components/terminal-work-card.tsx
+++ b/ui/src/features/terminal-work/components/terminal-work-card.tsx
@@ -1,6 +1,6 @@
+import { surfacePanelVariants } from "@you-agent-factory/components/layout";
 import { WidgetDetailCopy } from "@you-agent-factory/components/recipes";
 import type { ReactNode } from "react";
-import { surfacePanelVariants } from "@you-agent-factory/components/layout";
 import { DashboardActionButton } from "../../../components/ui/dashboard-action-button";
 import { cn } from "../../../lib/cn";
 import { DashboardWidgetFrame } from "../../bento/components/dashboard-widget-frame/dashboard-widget-frame";
@@ -12,12 +12,24 @@ import {
   type GraphSemanticIconKind,
 } from "../../flowchart/components/graph-semantic-icon";
 import { StandardExpandableSection } from "../../standard-card-components/components/standard-expandable-section";
-import type { TerminalWorkItem, TerminalWorkStatus } from "../lib/types";
+import {
+  TERMINAL_WORK_STATUSES,
+  type TerminalWorkItem,
+  type TerminalWorkSelection,
+  type TerminalWorkStatus,
+  terminalWorkIdentity,
+  terminalWorkSelectionMatches,
+} from "../lib/types";
 import { getTerminalWorkMessages } from "../messages/terminal-work";
 
-export type { TerminalWorkItem, TerminalWorkStatus } from "../lib/types";
+export type {
+  TerminalWorkItem,
+  TerminalWorkSelection,
+  TerminalWorkStatus,
+} from "../lib/types";
 
 export interface CompletedFailedWorkstationCardProps {
+  canceledItems?: TerminalWorkItem[];
   className?: string;
   completedItems: TerminalWorkItem[];
   failedItems: TerminalWorkItem[];
@@ -26,8 +38,10 @@ export interface CompletedFailedWorkstationCardProps {
   onMove?: (widgetId: "terminal-work", direction: "left" | "right") => void;
   onSelectItem: (status: TerminalWorkStatus, item: TerminalWorkItem) => void;
   order?: number;
-  selectedItem?: { label: string; status: TerminalWorkStatus } | null;
+  selectedItem?: TerminalWorkSelection | null;
+  terminatedItems?: TerminalWorkItem[];
   title?: string;
+  unknownItems?: TerminalWorkItem[];
   widgetId?: string;
 }
 
@@ -39,7 +53,7 @@ interface TerminalWorkRowProps {
   items: TerminalWorkItem[];
   messages: ReturnType<typeof getTerminalWorkMessages>;
   onSelectItem: (item: TerminalWorkItem) => void;
-  selectedLabel?: string;
+  selectedItem?: TerminalWorkSelection | null;
   status: TerminalWorkStatus;
   summary: (status: TerminalWorkStatus, workstation: string) => string;
   title: string;
@@ -53,14 +67,53 @@ const TERMINAL_BUTTON_META_CLASS = "leading-snug text-current";
 function terminalStatusIconKind(
   status: TerminalWorkStatus,
 ): GraphSemanticIconKind {
-  return status === "failed" ? "failed" : "terminal";
+  switch (status) {
+    case "completed":
+      return "terminal";
+    case "failed":
+      return "failed";
+    case "canceled":
+      return "processing";
+    case "terminated":
+      return "limit";
+    case "unknown":
+      return "queue";
+  }
 }
 
 function terminalStatusIconClassName(status: TerminalWorkStatus): string {
-  return status === "failed" ? "text-on-error" : "text-on-info";
+  switch (status) {
+    case "completed":
+      return "text-on-success-container";
+    case "failed":
+      return "text-on-error";
+    case "canceled":
+      return "text-on-warning-container";
+    case "terminated":
+      return "text-on-surface-variant";
+    case "unknown":
+      return "text-on-info-container";
+  }
+}
+
+function terminalStatusTone(
+  status: TerminalWorkStatus,
+): "danger" | "info" | "neutral" | "success" | "warning" {
+  switch (status) {
+    case "completed":
+      return "success";
+    case "failed":
+      return "danger";
+    case "canceled":
+      return "warning";
+    case "terminated":
+    case "unknown":
+      return "neutral";
+  }
 }
 
 export function CompletedFailedWorkstationCard({
+  canceledItems = [],
   className = "",
   completedItems,
   failedItems,
@@ -68,11 +121,20 @@ export function CompletedFailedWorkstationCard({
   locale,
   onSelectItem,
   selectedItem = null,
+  terminatedItems = [],
   title,
+  unknownItems = [],
   widgetId = "terminal-work",
 }: CompletedFailedWorkstationCardProps) {
   const messages = getTerminalWorkMessages(locale);
   const resolvedTitle = title ?? messages.cardTitle;
+  const itemsByStatus: Record<TerminalWorkStatus, TerminalWorkItem[]> = {
+    canceled: canceledItems,
+    completed: completedItems,
+    failed: failedItems,
+    terminated: terminatedItems,
+    unknown: unknownItems,
+  };
 
   return (
     <DashboardWidgetFrame
@@ -83,42 +145,26 @@ export function CompletedFailedWorkstationCard({
     >
       <fieldset className="grid gap-3">
         <legend className="sr-only">{messages.legendLabel}</legend>
-        <TerminalWorkRow
-          emptyMessage={messages.emptyState("completed")}
-          fallbackMessage={messages.sessionSummaryFallback("completed")}
-          iconLabel={messages.iconLabel("completed")}
-          itemCountLabel={messages.itemCountLabel(completedItems.length)}
-          items={completedItems}
-          messages={messages}
-          onSelectItem={(item) => onSelectItem("completed", item)}
-          selectedLabel={
-            selectedItem?.status === "completed"
-              ? selectedItem.label
-              : undefined
-          }
-          toggleLabel={messages.disclosureLabel}
-          status="completed"
-          summary={messages.summary}
-          title={messages.rowTitle("completed")}
-          widgetId={widgetId}
-        />
-        <TerminalWorkRow
-          emptyMessage={messages.emptyState("failed")}
-          fallbackMessage={messages.sessionSummaryFallback("failed")}
-          iconLabel={messages.iconLabel("failed")}
-          itemCountLabel={messages.itemCountLabel(failedItems.length)}
-          items={failedItems}
-          messages={messages}
-          onSelectItem={(item) => onSelectItem("failed", item)}
-          selectedLabel={
-            selectedItem?.status === "failed" ? selectedItem.label : undefined
-          }
-          toggleLabel={messages.disclosureLabel}
-          status="failed"
-          summary={messages.summary}
-          title={messages.rowTitle("failed")}
-          widgetId={widgetId}
-        />
+        {TERMINAL_WORK_STATUSES.map((status) => (
+          <TerminalWorkRow
+            emptyMessage={messages.emptyState(status)}
+            fallbackMessage={messages.sessionSummaryFallback(status)}
+            iconLabel={messages.iconLabel(status)}
+            itemCountLabel={messages.itemCountLabel(
+              itemsByStatus[status].length,
+            )}
+            items={itemsByStatus[status]}
+            key={status}
+            messages={messages}
+            onSelectItem={(item) => onSelectItem(status, item)}
+            selectedItem={selectedItem}
+            status={status}
+            summary={messages.summary}
+            title={messages.rowTitle(status)}
+            toggleLabel={messages.disclosureLabel}
+            widgetId={widgetId}
+          />
+        ))}
       </fieldset>
     </DashboardWidgetFrame>
   );
@@ -132,7 +178,7 @@ function TerminalWorkRow({
   items,
   messages,
   onSelectItem,
-  selectedLabel,
+  selectedItem,
   status,
   summary,
   title,
@@ -174,10 +220,14 @@ function TerminalWorkRow({
             <TerminalWorkListItem
               fallbackMessage={fallbackMessage}
               item={item}
-              key={`${status}-${item.label}`}
+              key={terminalWorkIdentity(item)}
               messages={messages}
               onClick={() => onSelectItem(item)}
-              selected={selectedLabel === item.label}
+              selected={terminalWorkSelectionMatches(
+                item,
+                selectedItem,
+                status,
+              )}
               selectionActionLabel={messages.selectWorkItemLabel(item.label)}
               status={status}
               summary={summary}
@@ -212,6 +262,8 @@ function TerminalWorkListItem({
   status,
   summary,
 }: TerminalWorkListItemProps) {
+  const workID = item.workItem?.work_id ?? item.traceWorkID;
+
   return (
     <WorkstationDispatchRow
       actions={
@@ -228,17 +280,25 @@ function TerminalWorkListItem({
       }
       status={
         <CurrentSelectionExecutionPill
-          tone={status === "failed" ? "danger" : "success"}
+          aria-label={messages.rowTitle(status)}
+          role="status"
+          tone={terminalStatusTone(status)}
         >
           {messages.rowTitle(status)}
         </CurrentSelectionExecutionPill>
       }
       supportingContent={
         <div className="grid gap-1">
+          <CurrentSelectionSupportingText
+            className={TERMINAL_BUTTON_META_CLASS}
+            tone="status"
+          >
+            {messages.workIDLabel(workID)}
+          </CurrentSelectionSupportingText>
           {renderTerminalWorkContext(item, fallbackMessage, summary, status)}
           {selected ? (
             <CurrentSelectionSupportingText tone="status">
-              {messages.selectedWorkItemLabel(item.label)}
+              {messages.selectedWorkItemLabel(workID)}
             </CurrentSelectionSupportingText>
           ) : null}
         </div>

--- a/ui/src/features/terminal-work/components/terminal-work-card.tsx
+++ b/ui/src/features/terminal-work/components/terminal-work-card.tsx
@@ -1,6 +1,6 @@
 import { surfacePanelVariants } from "@you-agent-factory/components/layout";
 import { WidgetDetailCopy } from "@you-agent-factory/components/recipes";
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { DashboardActionButton } from "../../../components/ui/dashboard-action-button";
 import { cn } from "../../../lib/cn";
 import { DashboardWidgetFrame } from "../../bento/components/dashboard-widget-frame/dashboard-widget-frame";
@@ -48,6 +48,11 @@ export interface CompletedFailedWorkstationCardProps {
 interface TerminalWorkRowProps {
   emptyMessage: string;
   fallbackMessage: string;
+  historyProgressLabel: (
+    shownCount: number,
+    totalCount: number,
+    remainingCount: number,
+  ) => string;
   iconLabel: string;
   itemCountLabel: string;
   items: TerminalWorkItem[];
@@ -55,6 +60,7 @@ interface TerminalWorkRowProps {
   onSelectItem: (item: TerminalWorkItem) => void;
   selectedItem?: TerminalWorkSelection | null;
   status: TerminalWorkStatus;
+  showMoreHistoryAction: (remainingCount: number) => string;
   summary: (status: TerminalWorkStatus, workstation: string) => string;
   title: string;
   toggleLabel: (expanded: boolean) => string;
@@ -63,6 +69,8 @@ interface TerminalWorkRowProps {
 
 const TERMINAL_ROW_TITLE_ICON_CLASS = "h-4 w-4 shrink-0";
 const TERMINAL_BUTTON_META_CLASS = "leading-snug text-current";
+// Keep each terminal status group compact while making every retained Work reachable.
+const TERMINAL_WORK_HISTORY_PAGE_SIZE = 10;
 
 function terminalStatusIconKind(
   status: TerminalWorkStatus,
@@ -149,16 +157,18 @@ export function CompletedFailedWorkstationCard({
           <TerminalWorkRow
             emptyMessage={messages.emptyState(status)}
             fallbackMessage={messages.sessionSummaryFallback(status)}
+            historyProgressLabel={messages.historyProgressLabel}
             iconLabel={messages.iconLabel(status)}
             itemCountLabel={messages.itemCountLabel(
               itemsByStatus[status].length,
             )}
             items={itemsByStatus[status]}
-            key={status}
+            key={`${widgetId}:${status}`}
             messages={messages}
             onSelectItem={(item) => onSelectItem(status, item)}
             selectedItem={selectedItem}
             status={status}
+            showMoreHistoryAction={messages.showMoreHistoryAction}
             summary={messages.summary}
             title={messages.rowTitle(status)}
             toggleLabel={messages.disclosureLabel}
@@ -173,6 +183,7 @@ export function CompletedFailedWorkstationCard({
 function TerminalWorkRow({
   emptyMessage,
   fallbackMessage,
+  historyProgressLabel,
   iconLabel,
   itemCountLabel,
   items,
@@ -180,6 +191,7 @@ function TerminalWorkRow({
   onSelectItem,
   selectedItem,
   status,
+  showMoreHistoryAction,
   summary,
   title,
   toggleLabel,
@@ -187,6 +199,36 @@ function TerminalWorkRow({
 }: TerminalWorkRowProps) {
   const rowId = `${widgetId}-${status}-items`;
   const headingId = `${rowId}-heading`;
+  const [visibleItemCount, setVisibleItemCount] = useState(
+    TERMINAL_WORK_HISTORY_PAGE_SIZE,
+  );
+  const [focusHistoryListAfterReveal, setFocusHistoryListAfterReveal] =
+    useState(false);
+  const historyListRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    if (!focusHistoryListAfterReveal) {
+      return;
+    }
+
+    historyListRef.current?.focus();
+    setFocusHistoryListAfterReveal(false);
+  }, [focusHistoryListAfterReveal]);
+
+  const visibleItems = items.slice(0, visibleItemCount);
+  const remainingItemCount = items.length - visibleItems.length;
+  const revealMoreItems = () => {
+    if (remainingItemCount <= 0) {
+      return;
+    }
+
+    if (remainingItemCount <= TERMINAL_WORK_HISTORY_PAGE_SIZE) {
+      setFocusHistoryListAfterReveal(true);
+    }
+    setVisibleItemCount((currentCount) =>
+      Math.min(currentCount + TERMINAL_WORK_HISTORY_PAGE_SIZE, items.length),
+    );
+  };
 
   return (
     <StandardExpandableSection
@@ -215,25 +257,53 @@ function TerminalWorkRow({
       toggleLabel={({ expanded }) => toggleLabel(expanded)}
     >
       {items.length > 0 ? (
-        <ul className="m-0 grid list-none gap-2.5 p-0">
-          {items.map((item) => (
-            <TerminalWorkListItem
-              fallbackMessage={fallbackMessage}
-              item={item}
-              key={terminalWorkIdentity(item)}
-              messages={messages}
-              onClick={() => onSelectItem(item)}
-              selected={terminalWorkSelectionMatches(
-                item,
-                selectedItem,
-                status,
-              )}
-              selectionActionLabel={messages.selectWorkItemLabel(item.label)}
-              status={status}
-              summary={summary}
-            />
-          ))}
-        </ul>
+        <>
+          <ul
+            className="m-0 grid list-none gap-2.5 p-0"
+            id={`${rowId}-list`}
+            ref={historyListRef}
+            tabIndex={-1}
+          >
+            {visibleItems.map((item) => (
+              <TerminalWorkListItem
+                fallbackMessage={fallbackMessage}
+                item={item}
+                key={terminalWorkIdentity(item)}
+                messages={messages}
+                onClick={() => onSelectItem(item)}
+                selected={terminalWorkSelectionMatches(
+                  item,
+                  selectedItem,
+                  status,
+                )}
+                selectionActionLabel={messages.selectWorkItemLabel(item.label)}
+                status={status}
+                summary={summary}
+              />
+            ))}
+          </ul>
+          {remainingItemCount > 0 ? (
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <CurrentSelectionSupportingText
+                className={TERMINAL_BUTTON_META_CLASS}
+                tone="status"
+              >
+                {historyProgressLabel(
+                  visibleItems.length,
+                  items.length,
+                  remainingItemCount,
+                )}
+              </CurrentSelectionSupportingText>
+              <DashboardActionButton
+                aria-controls={`${rowId}-list`}
+                onClick={revealMoreItems}
+                type="button"
+              >
+                {showMoreHistoryAction(remainingItemCount)}
+              </DashboardActionButton>
+            </div>
+          ) : null}
+        </>
       ) : (
         <WidgetDetailCopy>{emptyMessage}</WidgetDetailCopy>
       )}

--- a/ui/src/features/terminal-work/components/terminal-work-widget.test.tsx
+++ b/ui/src/features/terminal-work/components/terminal-work-widget.test.tsx
@@ -68,7 +68,10 @@ describe("TerminalWorkWidget", () => {
           { label: "Failed Story", traceWorkID: "work-failed-story" },
         ]}
         onSelectItem={onSelectItem}
-        selectedItem={{ label: "Done Story", status: "completed" }}
+        selectedItem={{
+          status: "completed",
+          traceWorkID: "work-done-story",
+        }}
       />,
     );
 

--- a/ui/src/features/terminal-work/components/terminal-work-widget.tsx
+++ b/ui/src/features/terminal-work/components/terminal-work-widget.tsx
@@ -9,33 +9,42 @@ import type {
 import { CompletedFailedWorkstationCard } from "./terminal-work-card";
 
 export interface TerminalWorkWidgetProps {
+  canceledItems?: TerminalWorkItem[];
   completedItems: TerminalWorkItem[];
   failedItems: TerminalWorkItem[];
   headerAction?: ReactNode;
   locale?: string;
   onSelectItem: (status: TerminalWorkStatus, item: TerminalWorkItem) => void;
   selectedItem: TerminalWorkDetail | null;
+  terminatedItems?: TerminalWorkItem[];
+  unknownItems?: TerminalWorkItem[];
   widgetId?: string;
 }
 
 export function TerminalWorkWidget({
+  canceledItems = [],
   completedItems,
   failedItems,
   headerAction,
   locale,
   onSelectItem,
   selectedItem,
+  terminatedItems = [],
+  unknownItems = [],
   widgetId = "terminal-work",
 }: TerminalWorkWidgetProps) {
   const resolvedLocale = resolveTerminalWorkLocale(locale);
 
   return (
     <CompletedFailedWorkstationCard
+      canceledItems={canceledItems}
       completedItems={completedItems}
       failedItems={failedItems}
       headerAction={headerAction}
       locale={resolvedLocale}
       selectedItem={selectedItem}
+      terminatedItems={terminatedItems}
+      unknownItems={unknownItems}
       widgetId={widgetId}
       onSelectItem={onSelectItem}
     />

--- a/ui/src/features/terminal-work/lib/types.test.ts
+++ b/ui/src/features/terminal-work/lib/types.test.ts
@@ -1,0 +1,27 @@
+import { terminalWorkIdentity, terminalWorkStatusFromOutcome } from "./types";
+
+describe("terminal work identity and status normalization", () => {
+  it("qualifies canonical Work identity with dispatch identity", () => {
+    expect(
+      terminalWorkIdentity({
+        dispatchID: "dispatch-two",
+        traceWorkID: "work-two",
+      }),
+    ).toBe("dispatch-two:work-two");
+  });
+
+  it.each([
+    ["ACCEPTED", "completed"],
+    ["FAILED", "failed"],
+    ["CANCELLED", "canceled"],
+    ["CANCELED", "canceled"],
+    ["TERMINATED", "terminated"],
+    ["future-terminal-value", "unknown"],
+  ] as const)("maps %s to the truthful terminal status", (outcome, status) => {
+    expect(terminalWorkStatusFromOutcome(outcome)).toBe(status);
+  });
+
+  it("does not invent a status when an outcome is absent", () => {
+    expect(terminalWorkStatusFromOutcome(undefined)).toBeUndefined();
+  });
+});

--- a/ui/src/features/terminal-work/lib/types.ts
+++ b/ui/src/features/terminal-work/lib/types.ts
@@ -3,7 +3,15 @@ import type {
   DashboardWorkItemRef,
 } from "../../../api/dashboard/types";
 
-export type TerminalWorkStatus = "completed" | "failed";
+export const TERMINAL_WORK_STATUSES = [
+  "completed",
+  "failed",
+  "canceled",
+  "terminated",
+  "unknown",
+] as const;
+
+export type TerminalWorkStatus = (typeof TERMINAL_WORK_STATUSES)[number];
 
 export interface TerminalWorkItem {
   attempts?: DashboardProviderSessionAttempt[];
@@ -25,4 +33,63 @@ export interface TerminalWorkDetail {
   status: TerminalWorkStatus;
   traceWorkID: string;
   workItem?: DashboardWorkItemRef;
+}
+
+export type TerminalWorkSelection = Pick<
+  TerminalWorkDetail,
+  "dispatchID" | "status" | "traceWorkID" | "workItem"
+>;
+
+/** Return the canonical Work ID represented by a terminal row. */
+export function terminalWorkID(
+  item: Pick<TerminalWorkItem, "traceWorkID" | "workItem">,
+): string {
+  return item.workItem?.work_id ?? item.traceWorkID;
+}
+
+/** Qualify a Work ID with dispatch identity when the row has it. */
+export function terminalWorkIdentity(
+  item: Pick<TerminalWorkItem, "dispatchID" | "traceWorkID" | "workItem">,
+): string {
+  const workID = terminalWorkID(item);
+  return item.dispatchID ? `${item.dispatchID}:${workID}` : workID;
+}
+
+export function terminalWorkSelectionMatches(
+  item: TerminalWorkItem,
+  selection: TerminalWorkSelection | null | undefined,
+  status: TerminalWorkStatus,
+): boolean {
+  return (
+    selection?.status === status &&
+    terminalWorkIdentity(item) === terminalWorkIdentity(selection)
+  );
+}
+
+export function terminalWorkStatusFromOutcome(
+  outcome: string | undefined,
+): TerminalWorkStatus | undefined {
+  const normalizedOutcome = outcome?.trim().toUpperCase();
+  if (!normalizedOutcome) {
+    return undefined;
+  }
+
+  switch (normalizedOutcome) {
+    case "ACCEPTED":
+    case "COMPLETED":
+    case "SUCCEEDED":
+    case "SUCCESS":
+    case "TERMINAL":
+      return "completed";
+    case "FAILED":
+      return "failed";
+    case "CANCELED":
+    case "CANCELLED":
+    case "INVOCATION_CANCELED":
+      return "canceled";
+    case "TERMINATED":
+      return "terminated";
+    default:
+      return "unknown";
+  }
 }

--- a/ui/src/features/terminal-work/messages/terminal-work.test.ts
+++ b/ui/src/features/terminal-work/messages/terminal-work.test.ts
@@ -12,10 +12,10 @@ describe("getTerminalWorkMessages", () => {
   });
 
   it.each([
-    ["en", "Completed and failed work"],
-    ["zh-CN", "已完成和失败的工作"],
-    ["ko", "완료 및 실패한 작업"],
-    ["ja", "完了済みおよび失敗した作業"],
+    ["en", "Terminal work outcomes"],
+    ["zh-CN", "终端工作结果"],
+    ["ko", "터미널 작업 결과"],
+    ["ja", "ターミナル作業の結果"],
   ] as const)("resolves %s catalog copy", (locale, expectedTitle) => {
     expect(getTerminalWorkMessages(locale).cardTitle).toBe(expectedTitle);
   });
@@ -34,11 +34,14 @@ describe("getTerminalWorkMessages", () => {
   it("keeps status-aware labels and fallback copy available through the resolved locale catalog", () => {
     const messages = getTerminalWorkMessages("ja");
 
-    expect(messages.legendLabel).toBe("ターミナル作業の結果");
+    expect(messages.legendLabel).toBe("ターミナル作業のステータスグループ");
     expect(messages.rowTitle("completed")).toBe("完了");
     expect(messages.rowTitle("failed")).toBe("失敗");
     expect(messages.iconLabel("completed")).toBe("完了した作業");
     expect(messages.iconLabel("failed")).toBe("失敗した作業");
+    expect(messages.rowTitle("canceled")).toBe("キャンセル済み");
+    expect(messages.rowTitle("terminated")).toBe("終了");
+    expect(messages.rowTitle("unknown")).toBe("不明");
     expect(messages.disclosureLabel(true)).toBe("折りたたむ");
     expect(messages.disclosureLabel(false)).toBe("展開");
     expect(messages.emptyState("completed")).toBe(

--- a/ui/src/features/terminal-work/messages/terminal-work.ts
+++ b/ui/src/features/terminal-work/messages/terminal-work.ts
@@ -2,8 +2,9 @@ import {
   type LocalizedMessages,
   resolveLocalizedMessages,
 } from "../../../i18n";
+import type { TerminalWorkStatus } from "../lib/types";
 
-export type TerminalWorkMessageStatus = "completed" | "failed";
+export type TerminalWorkMessageStatus = TerminalWorkStatus;
 
 export interface TerminalWorkMessages {
   cardTitle: string;
@@ -17,100 +18,114 @@ export interface TerminalWorkMessages {
   selectWorkItemLabel: (label: string) => string;
   sessionSummaryFallback: (status: TerminalWorkMessageStatus) => string;
   selectedWorkItemAction: string;
-  selectedWorkItemLabel: (label: string) => string;
+  selectedWorkItemLabel: (workID: string) => string;
   summary: (status: TerminalWorkMessageStatus, workstation: string) => string;
+  workIDLabel: (workID: string) => string;
 }
 
 const terminalWorkMessagesByLocale: LocalizedMessages<TerminalWorkMessages> = {
   en: {
-    cardTitle: "Completed and failed work",
+    cardTitle: "Terminal work outcomes",
     disclosureLabel: (expanded) => (expanded ? "Collapse" : "Expand"),
     emptyState: (status) =>
-      status === "failed"
-        ? "No failed work recorded yet."
-        : "No completed work recorded yet.",
-    iconLabel: (status) =>
-      status === "failed" ? "Failed work" : "Completed work",
+      `No ${englishTerminalStatusLabel(status).toLowerCase()} work recorded yet.`,
+    iconLabel: (status) => `${englishTerminalStatusLabel(status)} work`,
     itemCountLabel: (count) => `${count} ${count === 1 ? "item" : "items"}`,
-    legendLabel: "Terminal work outcomes",
+    legendLabel: "Terminal work status groups",
     openWorkItemAction: "Open work item",
-    rowTitle: (status) => (status === "failed" ? "Failed" : "Completed"),
+    rowTitle: englishTerminalStatusLabel,
     selectWorkItemLabel: (label) => `Select work item ${label}`,
     sessionSummaryFallback: (status) =>
-      status === "failed"
-        ? "Failed status recorded by session summary."
-        : "Completed by session summary.",
+      `${englishTerminalStatusLabel(status)} status recorded by session summary.`,
     selectedWorkItemAction: "Work selected",
-    selectedWorkItemLabel: (label) => `Selected work item ${label}`,
+    selectedWorkItemLabel: (workID) => `Selected Work ID ${workID}`,
     summary: (status, workstation) =>
-      `${status === "failed" ? "Failed" : "Completed"} at ${workstation}`,
+      `${englishTerminalStatusLabel(status)} at ${workstation}`,
+    workIDLabel: (workID) => `Work ID: ${workID}`,
   },
   ja: {
-    cardTitle: "完了済みおよび失敗した作業",
+    cardTitle: "ターミナル作業の結果",
     disclosureLabel: (expanded) => (expanded ? "折りたたむ" : "展開"),
     emptyState: (status) =>
-      status === "failed"
-        ? "失敗した作業はまだ記録されていません。"
-        : "完了した作業はまだ記録されていません。",
+      status === "completed"
+        ? "完了した作業はまだ記録されていません。"
+        : status === "failed"
+          ? "失敗した作業はまだ記録されていません。"
+          : `${japaneseTerminalStatusLabel(status)}の作業はまだ記録されていません。`,
     iconLabel: (status) =>
-      status === "failed" ? "失敗した作業" : "完了した作業",
+      status === "completed"
+        ? "完了した作業"
+        : status === "failed"
+          ? "失敗した作業"
+          : `${japaneseTerminalStatusLabel(status)}の作業`,
     itemCountLabel: (count) => `${count} 件`,
-    legendLabel: "ターミナル作業の結果",
+    legendLabel: "ターミナル作業のステータスグループ",
     openWorkItemAction: "作業を開く",
-    rowTitle: (status) => (status === "failed" ? "失敗" : "完了"),
+    rowTitle: japaneseTerminalStatusLabel,
     selectWorkItemLabel: (label) => `作業項目 ${label} を選択`,
     sessionSummaryFallback: (status) =>
-      status === "failed"
-        ? "セッション概要で失敗ステータスが記録されました。"
-        : "セッション概要で完了として記録されました。",
+      `セッション概要で${japaneseTerminalStatusLabel(status)}ステータスが記録されました。`,
     selectedWorkItemAction: "作業を選択済み",
-    selectedWorkItemLabel: (label) => `選択中の作業項目 ${label}`,
+    selectedWorkItemLabel: (workID) => `選択中の Work ID ${workID}`,
     summary: (status, workstation) =>
-      `${status === "failed" ? "失敗" : "完了"}: ${workstation}`,
+      `${japaneseTerminalStatusLabel(status)}: ${workstation}`,
+    workIDLabel: (workID) => `Work ID: ${workID}`,
   },
   ko: {
-    cardTitle: "완료 및 실패한 작업",
+    cardTitle: "터미널 작업 결과",
     disclosureLabel: (expanded) => (expanded ? "접기" : "펼치기"),
     emptyState: (status) =>
-      status === "failed"
-        ? "실패한 작업이 아직 기록되지 않았습니다."
-        : "완료된 작업이 아직 기록되지 않았습니다.",
+      status === "completed"
+        ? "완료된 작업이 아직 기록되지 않았습니다."
+        : status === "failed"
+          ? "실패한 작업이 아직 기록되지 않았습니다."
+          : `${koreanTerminalStatusLabel(status)} 작업이 아직 기록되지 않았습니다.`,
     iconLabel: (status) =>
-      status === "failed" ? "실패한 작업" : "완료된 작업",
+      status === "completed"
+        ? "완료된 작업"
+        : status === "failed"
+          ? "실패한 작업"
+          : `${koreanTerminalStatusLabel(status)} 작업`,
     itemCountLabel: (count) => `${count}개 항목`,
-    legendLabel: "터미널 작업 결과",
+    legendLabel: "터미널 작업 상태 그룹",
     openWorkItemAction: "작업 열기",
-    rowTitle: (status) => (status === "failed" ? "실패" : "완료"),
+    rowTitle: koreanTerminalStatusLabel,
     selectWorkItemLabel: (label) => `작업 항목 ${label} 선택`,
     sessionSummaryFallback: (status) =>
-      status === "failed"
-        ? "세션 요약에서 실패 상태가 기록되었습니다."
-        : "세션 요약에서 완료 상태로 기록되었습니다.",
+      `세션 요약에서 ${koreanTerminalStatusLabel(status)} 상태가 기록되었습니다.`,
     selectedWorkItemAction: "작업 선택됨",
-    selectedWorkItemLabel: (label) => `선택된 작업 항목 ${label}`,
+    selectedWorkItemLabel: (workID) => `선택된 Work ID ${workID}`,
     summary: (status, workstation) =>
-      `${status === "failed" ? "실패" : "완료"}: ${workstation}`,
+      `${koreanTerminalStatusLabel(status)}: ${workstation}`,
+    workIDLabel: (workID) => `Work ID: ${workID}`,
   },
   "zh-CN": {
-    cardTitle: "已完成和失败的工作",
+    cardTitle: "终端工作结果",
     disclosureLabel: (expanded) => (expanded ? "折叠" : "展开"),
     emptyState: (status) =>
-      status === "failed" ? "尚未记录失败的工作。" : "尚未记录已完成的工作。",
+      status === "completed"
+        ? "尚未记录已完成的工作。"
+        : status === "failed"
+          ? "尚未记录失败的工作。"
+          : `尚未记录${chineseTerminalStatusLabel(status)}工作。`,
     iconLabel: (status) =>
-      status === "failed" ? "失败的工作" : "已完成的工作",
+      status === "completed"
+        ? "已完成的工作"
+        : status === "failed"
+          ? "失败的工作"
+          : `${chineseTerminalStatusLabel(status)}工作`,
     itemCountLabel: (count) => `${count} 个项目`,
-    legendLabel: "终端工作结果",
+    legendLabel: "终端工作状态分组",
     openWorkItemAction: "打开工作项",
-    rowTitle: (status) => (status === "failed" ? "失败" : "已完成"),
+    rowTitle: chineseTerminalStatusLabel,
     selectWorkItemLabel: (label) => `选择工作项 ${label}`,
     sessionSummaryFallback: (status) =>
-      status === "failed"
-        ? "会话摘要已记录失败状态。"
-        : "会话摘要已记录完成状态。",
+      `会话摘要已记录${chineseTerminalStatusLabel(status)}状态。`,
     selectedWorkItemAction: "工作项已选中",
-    selectedWorkItemLabel: (label) => `已选中的工作项 ${label}`,
+    selectedWorkItemLabel: (workID) => `已选中的 Work ID ${workID}`,
     summary: (status, workstation) =>
-      `${status === "failed" ? "失败" : "已完成"}：${workstation}`,
+      `${chineseTerminalStatusLabel(status)}：${workstation}`,
+    workIDLabel: (workID) => `Work ID：${workID}`,
   },
 };
 
@@ -121,3 +136,65 @@ export function getTerminalWorkMessages(
 }
 
 export { terminalWorkMessagesByLocale };
+
+function englishTerminalStatusLabel(status: TerminalWorkMessageStatus): string {
+  switch (status) {
+    case "completed":
+      return "Completed";
+    case "failed":
+      return "Failed";
+    case "canceled":
+      return "Canceled";
+    case "terminated":
+      return "Terminated";
+    case "unknown":
+      return "Unknown";
+  }
+}
+
+function japaneseTerminalStatusLabel(
+  status: TerminalWorkMessageStatus,
+): string {
+  switch (status) {
+    case "completed":
+      return "完了";
+    case "failed":
+      return "失敗";
+    case "canceled":
+      return "キャンセル済み";
+    case "terminated":
+      return "終了";
+    case "unknown":
+      return "不明";
+  }
+}
+
+function koreanTerminalStatusLabel(status: TerminalWorkMessageStatus): string {
+  switch (status) {
+    case "completed":
+      return "완료";
+    case "failed":
+      return "실패";
+    case "canceled":
+      return "취소됨";
+    case "terminated":
+      return "종료됨";
+    case "unknown":
+      return "알 수 없음";
+  }
+}
+
+function chineseTerminalStatusLabel(status: TerminalWorkMessageStatus): string {
+  switch (status) {
+    case "completed":
+      return "已完成";
+    case "failed":
+      return "失败";
+    case "canceled":
+      return "已取消";
+    case "terminated":
+      return "已终止";
+    case "unknown":
+      return "未知";
+  }
+}

--- a/ui/src/features/terminal-work/messages/terminal-work.ts
+++ b/ui/src/features/terminal-work/messages/terminal-work.ts
@@ -10,11 +10,17 @@ export interface TerminalWorkMessages {
   cardTitle: string;
   disclosureLabel: (expanded: boolean) => string;
   emptyState: (status: TerminalWorkMessageStatus) => string;
+  historyProgressLabel: (
+    shownCount: number,
+    totalCount: number,
+    remainingCount: number,
+  ) => string;
   iconLabel: (status: TerminalWorkMessageStatus) => string;
   itemCountLabel: (count: number) => string;
   legendLabel: string;
   openWorkItemAction: string;
   rowTitle: (status: TerminalWorkMessageStatus) => string;
+  showMoreHistoryAction: (remainingCount: number) => string;
   selectWorkItemLabel: (label: string) => string;
   sessionSummaryFallback: (status: TerminalWorkMessageStatus) => string;
   selectedWorkItemAction: string;
@@ -29,11 +35,15 @@ const terminalWorkMessagesByLocale: LocalizedMessages<TerminalWorkMessages> = {
     disclosureLabel: (expanded) => (expanded ? "Collapse" : "Expand"),
     emptyState: (status) =>
       `No ${englishTerminalStatusLabel(status).toLowerCase()} work recorded yet.`,
+    historyProgressLabel: (shownCount, totalCount, remainingCount) =>
+      `Showing ${shownCount} of ${totalCount} items. ${remainingCount} remaining.`,
     iconLabel: (status) => `${englishTerminalStatusLabel(status)} work`,
     itemCountLabel: (count) => `${count} ${count === 1 ? "item" : "items"}`,
     legendLabel: "Terminal work status groups",
     openWorkItemAction: "Open work item",
     rowTitle: englishTerminalStatusLabel,
+    showMoreHistoryAction: (remainingCount) =>
+      `Show ${remainingCount} more item${remainingCount === 1 ? "" : "s"}`,
     selectWorkItemLabel: (label) => `Select work item ${label}`,
     sessionSummaryFallback: (status) =>
       `${englishTerminalStatusLabel(status)} status recorded by session summary.`,
@@ -52,6 +62,8 @@ const terminalWorkMessagesByLocale: LocalizedMessages<TerminalWorkMessages> = {
         : status === "failed"
           ? "失敗した作業はまだ記録されていません。"
           : `${japaneseTerminalStatusLabel(status)}の作業はまだ記録されていません。`,
+    historyProgressLabel: (shownCount, totalCount, remainingCount) =>
+      `${totalCount}件中${shownCount}件を表示しています。残り${remainingCount}件。`,
     iconLabel: (status) =>
       status === "completed"
         ? "完了した作業"
@@ -62,6 +74,7 @@ const terminalWorkMessagesByLocale: LocalizedMessages<TerminalWorkMessages> = {
     legendLabel: "ターミナル作業のステータスグループ",
     openWorkItemAction: "作業を開く",
     rowTitle: japaneseTerminalStatusLabel,
+    showMoreHistoryAction: (remainingCount) => `残り${remainingCount}件を表示`,
     selectWorkItemLabel: (label) => `作業項目 ${label} を選択`,
     sessionSummaryFallback: (status) =>
       `セッション概要で${japaneseTerminalStatusLabel(status)}ステータスが記録されました。`,
@@ -80,6 +93,8 @@ const terminalWorkMessagesByLocale: LocalizedMessages<TerminalWorkMessages> = {
         : status === "failed"
           ? "실패한 작업이 아직 기록되지 않았습니다."
           : `${koreanTerminalStatusLabel(status)} 작업이 아직 기록되지 않았습니다.`,
+    historyProgressLabel: (shownCount, totalCount, remainingCount) =>
+      `${totalCount}개 중 ${shownCount}개를 표시하고 있습니다. ${remainingCount}개 남았습니다.`,
     iconLabel: (status) =>
       status === "completed"
         ? "완료된 작업"
@@ -90,6 +105,7 @@ const terminalWorkMessagesByLocale: LocalizedMessages<TerminalWorkMessages> = {
     legendLabel: "터미널 작업 상태 그룹",
     openWorkItemAction: "작업 열기",
     rowTitle: koreanTerminalStatusLabel,
+    showMoreHistoryAction: (remainingCount) => `${remainingCount}개 더 표시`,
     selectWorkItemLabel: (label) => `작업 항목 ${label} 선택`,
     sessionSummaryFallback: (status) =>
       `세션 요약에서 ${koreanTerminalStatusLabel(status)} 상태가 기록되었습니다.`,
@@ -108,6 +124,8 @@ const terminalWorkMessagesByLocale: LocalizedMessages<TerminalWorkMessages> = {
         : status === "failed"
           ? "尚未记录失败的工作。"
           : `尚未记录${chineseTerminalStatusLabel(status)}工作。`,
+    historyProgressLabel: (shownCount, totalCount, remainingCount) =>
+      `显示 ${totalCount} 个项目中的 ${shownCount} 个。剩余 ${remainingCount} 个。`,
     iconLabel: (status) =>
       status === "completed"
         ? "已完成的工作"
@@ -118,6 +136,8 @@ const terminalWorkMessagesByLocale: LocalizedMessages<TerminalWorkMessages> = {
     legendLabel: "终端工作状态分组",
     openWorkItemAction: "打开工作项",
     rowTitle: chineseTerminalStatusLabel,
+    showMoreHistoryAction: (remainingCount) =>
+      `再显示 ${remainingCount} 个项目`,
     selectWorkItemLabel: (label) => `选择工作项 ${label}`,
     sessionSummaryFallback: (status) =>
       `会话摘要已记录${chineseTerminalStatusLabel(status)}状态。`,

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline-target.stories.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline-target.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { expect, userEvent, within } from "storybook/test";
+
+import type { WorkerSessionObservation } from "../../../api/worker-sessions";
+import type { UseWorkerSessionTimelineResult } from "../hooks/useWorkerSessionTimeline";
+import { getWorkerSessionTimelineMessages } from "../messages/worker-session-timeline";
+import { WorkerSessionTimelineWidget } from "./worker-session-timeline-widget";
+
+const meta = {
+  title: "Worker Session Timeline/Target origins",
+  component: WorkerSessionTimelineWidget,
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<typeof WorkerSessionTimelineWidget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+const observations: WorkerSessionObservation[] = [
+  observation("worker-session-story-1", "attempt-story-1", {
+    providerSession: {
+      id: "provider-story-1",
+      kind: "session_id",
+      provider: "codex",
+    },
+    providerSessionAvailable: true,
+    state: "COMPLETED",
+  }),
+  observation("worker-session-story-2", "attempt-story-2", {
+    state: "FAILED",
+  }),
+];
+
+export const MultipleObservations: Story = {
+  args: {
+    enabled: false,
+    factorySessionID: "factory-session-story",
+    loadWorkerSessionTargets: async () => observations,
+    stateOverride: readyEmptyTimelineState(),
+    workID: "work-terminal-story",
+    workerSessionID: null,
+  },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const messages = getWorkerSessionTimelineMessages("en");
+    const secondTarget = await canvas.findByRole("button", {
+      name: messages.openWorkerSessionTargetLabel(
+        "worker-session-story-2",
+        "work-terminal-story",
+      ),
+    });
+
+    await userEvent.click(secondTarget);
+    await expect(secondTarget).toHaveAttribute("aria-pressed", "true");
+    await expect(
+      canvasElement.querySelector(
+        '[data-worker-session-timeline-worker-session-id="worker-session-story-2"]',
+      ),
+    ).not.toBeNull();
+  },
+};
+
+function observation(
+  workerSessionId: string,
+  attemptId: string,
+  overrides: Partial<WorkerSessionObservation> = {},
+): WorkerSessionObservation {
+  return {
+    attemptId,
+    direct: false,
+    durationBasis: "UNAVAILABLE",
+    durationMillis: null,
+    endedAt: null,
+    parse: { errors: [], ignored: 0 },
+    providerSessionAvailable: false,
+    startedAt: null,
+    state: "RUNNING",
+    transcript: "AVAILABLE",
+    turnId: null,
+    workIds: ["work-terminal-story"],
+    workerSessionId,
+    ...overrides,
+  } as WorkerSessionObservation;
+}
+
+function readyEmptyTimelineState(): UseWorkerSessionTimelineResult {
+  return {
+    acknowledgedCursor: null,
+    entries: [],
+    isFollowing: false,
+    records: [],
+    recordingHealth: null,
+    recordingHealthReason: null,
+    reconnectCursor: null,
+    replaySummary: null,
+    retry: () => undefined,
+    sourceError: null,
+    status: "ready-empty",
+    streamGenerationId: null,
+    terminalDelivery: null,
+  };
+}

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline-target.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline-target.tsx
@@ -1,4 +1,4 @@
-import { EnumSelect } from "@you-agent-factory/components/forms";
+import { Label, Text } from "@you-agent-factory/components/primitives";
 import { WidgetDetailCopy } from "@you-agent-factory/components/recipes";
 import type { WorkerSessionObservation } from "../../../api/worker-sessions";
 import { AlertPanel } from "../../../components/ui/alert-panel";
@@ -56,26 +56,82 @@ export function WorkerSessionTimelineTarget({
     state.selectedWorkerSessionID ?? state.observations[0]?.workerSessionId;
 
   return (
-    <EnumSelect
-      aria-label={messages.sessionTargetSelectLabel}
-      id="worker-session-timeline-target"
-      onValueChange={state.setSelectedWorkerSessionID}
-      options={state.observations.map((observation) => ({
-        label: sessionTargetOption(messages, observation),
-        value: observation.workerSessionId,
-      }))}
-      value={selectedWorkerSessionID}
-    />
+    <ul
+      aria-label={messages.sessionTargetListLabel}
+      className="m-0 grid list-none gap-3 p-0"
+    >
+      {state.observations.map((observation) => {
+        const selected =
+          observation.workerSessionId === selectedWorkerSessionID;
+        return (
+          <li
+            className="grid min-w-0 gap-3 rounded-lg border border-outline bg-surface-container-low p-3"
+            key={observation.workerSessionId}
+          >
+            <dl className="grid min-w-0 gap-2 sm:grid-cols-2">
+              <TargetDetail
+                label={messages.workerSessionIDLabel}
+                value={observation.workerSessionId}
+              />
+              <TargetDetail
+                label={messages.attemptIDLabel}
+                value={observation.attemptId}
+              />
+              <TargetDetail
+                label={messages.sessionLifecycleLabel}
+                value={messages.sessionLifecycleStateLabel(observation.state)}
+              />
+              <TargetDetail
+                label={messages.providerSessionLabel}
+                value={providerSessionOrigin(messages, observation)}
+              />
+            </dl>
+            <DashboardActionButton
+              aria-label={messages.openWorkerSessionTargetLabel(
+                observation.workerSessionId,
+                workID,
+              )}
+              aria-pressed={selected}
+              className="w-fit"
+              onClick={() =>
+                state.setSelectedWorkerSessionID(observation.workerSessionId)
+              }
+              type="button"
+            >
+              {selected
+                ? messages.selectedWorkerSessionAction
+                : messages.openWorkerSessionAction}
+            </DashboardActionButton>
+          </li>
+        );
+      })}
+    </ul>
   );
 }
 
-function sessionTargetOption(
+function TargetDetail({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid min-w-0 gap-1">
+      <Label as="dt">{label}</Label>
+      <Text as="dd" className="m-0 min-w-0 [overflow-wrap:anywhere]">
+        {value}
+      </Text>
+    </div>
+  );
+}
+
+function providerSessionOrigin(
   messages: WorkerSessionTimelineMessages,
   observation: WorkerSessionObservation,
 ): string {
-  return messages.sessionTargetOption(
-    observation.workerSessionId,
-    observation.attemptId,
-    observation.state,
-  );
+  const providerSession = observation.providerSession;
+  if (
+    !providerSession?.provider ||
+    !providerSession.kind ||
+    !providerSession.id
+  ) {
+    return messages.providerSessionUnavailable;
+  }
+
+  return `${providerSession.provider} / ${providerSession.kind} / ${providerSession.id}`;
 }

--- a/ui/src/features/worker-session-timeline/components/worker-session-timeline.bun.component.test.tsx
+++ b/ui/src/features/worker-session-timeline/components/worker-session-timeline.bun.component.test.tsx
@@ -16,6 +16,7 @@ import type {
   WorkerSessionObservation,
 } from "../../../api/worker-sessions";
 import type { UseWorkerSessionTimelineResult } from "../hooks/useWorkerSessionTimeline";
+import type { UseWorkerSessionTimelineTargetResult } from "../hooks/useWorkerSessionTimelineTarget";
 import {
   projectWorkerSessionTimeline,
   type WorkerSessionTimelineEntry,
@@ -23,6 +24,7 @@ import {
 import { getWorkerSessionTimelineMessages } from "../messages/worker-session-timeline";
 import { WorkerSessionTimelineContent } from "./worker-session-timeline";
 import { BoundedCode } from "./worker-session-timeline-detail-primitives";
+import { WorkerSessionTimelineTarget } from "./worker-session-timeline-target";
 import { WorkerSessionTimelineWidget } from "./worker-session-timeline-widget";
 
 const WORKER_SESSION_ID = "worker-session-ui-1";
@@ -423,8 +425,19 @@ describe("WorkerSessionTimelineContent large details", () => {
 });
 
 describe("WorkerSessionTimelineWidget target selection", () => {
-  it("selects a Worker Session target from the selected Work before rendering its timeline", async () => {
-    const loadWorkerSessionTargets = async () => [observation("worker-1")];
+  it("renders every observation and opens the exact selected Worker Session timeline", async () => {
+    const loadWorkerSessionTargets = async () => [
+      observation("worker-1", "attempt-1", {
+        providerSession: {
+          id: "provider-session-1",
+          kind: "session_id",
+          provider: "codex",
+        },
+        providerSessionAvailable: true,
+        state: "COMPLETED",
+      }),
+      observation("worker-2", "attempt-2", { state: "FAILED" }),
+    ];
 
     render(
       <WorkerSessionTimelineWidget
@@ -441,11 +454,35 @@ describe("WorkerSessionTimelineWidget target selection", () => {
     const messages = getWorkerSessionTimelineMessages("en");
     await waitFor(() => {
       expect(
-        screen.getByRole("combobox", {
-          name: messages.sessionTargetSelectLabel,
+        screen.getByRole("list", {
+          name: messages.sessionTargetListLabel,
         }),
       ).toBeTruthy();
     });
+    expect(screen.getByText("worker-1")).toBeTruthy();
+    expect(screen.getByText("attempt-1")).toBeTruthy();
+    expect(
+      screen.getByText(messages.sessionLifecycleStateLabel("COMPLETED")),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(messages.sessionLifecycleStateLabel("FAILED")),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("codex / session_id / provider-session-1"),
+    ).toBeTruthy();
+    expect(screen.getByText(messages.providerSessionUnavailable)).toBeTruthy();
+
+    const secondTargetButton = screen.getByRole("button", {
+      name: messages.openWorkerSessionTargetLabel("worker-2", "work-1"),
+    });
+    fireEvent.click(secondTargetButton);
+
+    expect(secondTargetButton).toHaveAttribute("aria-pressed", "true");
+    expect(
+      document.querySelector(
+        '[data-worker-session-timeline-worker-session-id="worker-2"]',
+      ),
+    ).toBeTruthy();
     expect(screen.getByText(messages.timelineTitle)).toBeTruthy();
   });
 
@@ -467,6 +504,48 @@ describe("WorkerSessionTimelineWidget target selection", () => {
   });
 });
 
+describe("WorkerSessionTimelineTarget states", () => {
+  it("keeps loading, empty, error, and retry states explicit", () => {
+    const messages = getWorkerSessionTimelineMessages("en");
+    const retry = mock(() => {});
+    const { rerender } = render(
+      <WorkerSessionTimelineTarget
+        messages={messages}
+        state={targetState({ status: "loading" })}
+        workID="work-1"
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      messages.sessionTargetLoading,
+    );
+
+    rerender(
+      <WorkerSessionTimelineTarget
+        messages={messages}
+        state={targetState({ refetch: retry, status: "error" })}
+        workID="work-1"
+      />,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      messages.sessionTargetError,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: messages.sessionTargetRetry }),
+    );
+    expect(retry).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <WorkerSessionTimelineTarget
+        messages={messages}
+        state={targetState({ status: "ready" })}
+        workID="work-1"
+      />,
+    );
+    expect(screen.getByText(messages.sessionTargetEmpty)).toBeTruthy();
+  });
+});
+
 function createQueryWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -478,9 +557,13 @@ function createQueryWrapper() {
   };
 }
 
-function observation(workerSessionId: string): WorkerSessionObservation {
+function observation(
+  workerSessionId: string,
+  attemptId = "attempt-1",
+  overrides: Partial<WorkerSessionObservation> = {},
+): WorkerSessionObservation {
   return {
-    attemptId: "attempt-1",
+    attemptId,
     direct: false,
     durationBasis: "UNAVAILABLE",
     durationMillis: null,
@@ -493,7 +576,22 @@ function observation(workerSessionId: string): WorkerSessionObservation {
     turnId: null,
     workIds: ["work-1"],
     workerSessionId,
+    ...overrides,
   } as WorkerSessionObservation;
+}
+
+function targetState(
+  overrides: Partial<UseWorkerSessionTimelineTargetResult> = {},
+): UseWorkerSessionTimelineTargetResult {
+  return {
+    error: null,
+    observations: [],
+    refetch: mock(() => {}),
+    selectedWorkerSessionID: null,
+    setSelectedWorkerSessionID: mock(() => {}),
+    status: "idle",
+    ...overrides,
+  };
 }
 
 function timelineState(

--- a/ui/src/features/worker-session-timeline/messages/worker-session-timeline.ts
+++ b/ui/src/features/worker-session-timeline/messages/worker-session-timeline.ts
@@ -71,19 +71,24 @@ export interface WorkerSessionTimelineMessages {
   ) => string;
   retryAction: string;
   retryReasonLabel: string;
+  openWorkerSessionAction: string;
+  openWorkerSessionTargetLabel: (
+    workerSessionID: string,
+    workID: string | null,
+  ) => string;
+  providerSessionUnavailable: string;
+  selectedWorkerSessionAction: string;
+  sessionLifecycleLabel: string;
+  sessionLifecycleStateLabel: (state: string) => string;
+  workerSessionIDLabel: string;
   sourceErrorHeading: string;
   sourceLabel: string;
   sourceSequenceLabel: (sequence: number) => string;
   sessionTargetEmpty: string;
   sessionTargetError: string;
   sessionTargetLoading: string;
-  sessionTargetOption: (
-    workerSessionID: string,
-    attemptID: string,
-    state: string,
-  ) => string;
+  sessionTargetListLabel: string;
   sessionTargetRetry: string;
-  sessionTargetSelectLabel: string;
   successorLabel: string;
   terminalOutcomeLabel: (outcome: WorkerTimelineTerminalOutcome) => string;
   terminalOutcomeHeading: string;
@@ -151,10 +156,16 @@ const workerSessionTimelineMessagesByLocale: LocalizedMessageCatalog<WorkerSessi
         "This canonical event has no additional displayable detail.",
       openWorkerSessionLabel: (workerSessionID) =>
         `Open Worker Session ${workerSessionID}`,
+      openWorkerSessionAction: "Open Worker Session",
+      openWorkerSessionTargetLabel: (workerSessionID, workID) =>
+        workID
+          ? `Open Worker Session ${workerSessionID} for Work ${workID}`
+          : `Open Worker Session ${workerSessionID}`,
       outputTokensLabel: "Output tokens",
       predecessorLabel: "Predecessor Worker Session",
       providerLabel: "Provider",
       providerSessionLabel: "Provider Session",
+      providerSessionUnavailable: "Provider Session unavailable",
       reasoningDeltaLabel: "Reasoning delta",
       reasoningLabel: "Reasoning",
       reasoningSnapshotLabel: "Reasoning snapshot",
@@ -173,6 +184,26 @@ const workerSessionTimelineMessagesByLocale: LocalizedMessageCatalog<WorkerSessi
               : "Recording is incomplete; some history may be missing.",
       retryAction: "Retry",
       retryReasonLabel: "Retry reason",
+      selectedWorkerSessionAction: "Worker Session selected",
+      sessionLifecycleLabel: "Lifecycle outcome",
+      sessionLifecycleStateLabel: (state) => {
+        switch (state.trim().toUpperCase()) {
+          case "CANCELED":
+          case "CANCELLED":
+            return "Canceled";
+          case "COMPLETED":
+            return "Completed";
+          case "FAILED":
+            return "Failed";
+          case "RUNNING":
+            return "Running";
+          case "STARTING":
+            return "Starting";
+          default:
+            return state || "Unknown";
+        }
+      },
+      workerSessionIDLabel: "Worker Session ID",
       sourceErrorHeading: "Worker Session records could not be loaded",
       sourceLabel: "Source",
       sourceSequenceLabel: (sequence) => `Source sequence ${sequence}`,
@@ -180,10 +211,8 @@ const workerSessionTimelineMessagesByLocale: LocalizedMessageCatalog<WorkerSessi
         "No Worker Session attempts are correlated with this Work.",
       sessionTargetError: "Worker Session attempts could not be loaded.",
       sessionTargetLoading: "Loading Worker Session attempts…",
-      sessionTargetOption: (workerSessionID, attemptID, state) =>
-        `${workerSessionID} · ${attemptID} · ${state}`,
+      sessionTargetListLabel: "Worker Session attempts",
       sessionTargetRetry: "Retry Worker Session lookup",
-      sessionTargetSelectLabel: "Worker Session attempt",
       successorLabel: "Successor Worker Session",
       terminalOutcomeLabel: (outcome) =>
         outcome === "SUCCESS"
@@ -267,10 +296,16 @@ const workerSessionTimelineMessagesByLocale: LocalizedMessageCatalog<WorkerSessi
       noDetailState: "此规范事件没有可显示的其他详情。",
       openWorkerSessionLabel: (workerSessionID) =>
         `打开 Worker 会话 ${workerSessionID}`,
+      openWorkerSessionAction: "打开 Worker 会话",
+      openWorkerSessionTargetLabel: (workerSessionID, workID) =>
+        workID
+          ? `打开工作 ${workID} 的 Worker 会话 ${workerSessionID}`
+          : `打开 Worker 会话 ${workerSessionID}`,
       outputTokensLabel: "输出令牌",
       predecessorLabel: "前置 Worker 会话",
       providerLabel: "提供方",
       providerSessionLabel: "提供方会话",
+      providerSessionUnavailable: "提供方会话不可用",
       reasoningDeltaLabel: "推理增量",
       reasoningLabel: "推理",
       reasoningSnapshotLabel: "推理快照",
@@ -289,16 +324,34 @@ const workerSessionTimelineMessagesByLocale: LocalizedMessageCatalog<WorkerSessi
               : "记录不完整，部分历史可能缺失。",
       retryAction: "重试",
       retryReasonLabel: "重试原因",
+      selectedWorkerSessionAction: "Worker 会话已选择",
+      sessionLifecycleLabel: "生命周期结果",
+      sessionLifecycleStateLabel: (state) => {
+        switch (state.trim().toUpperCase()) {
+          case "CANCELED":
+          case "CANCELLED":
+            return "已取消";
+          case "COMPLETED":
+            return "已完成";
+          case "FAILED":
+            return "失败";
+          case "RUNNING":
+            return "运行中";
+          case "STARTING":
+            return "正在启动";
+          default:
+            return state || "未知";
+        }
+      },
+      workerSessionIDLabel: "Worker 会话 ID",
       sourceErrorHeading: "无法加载 Worker 会话记录",
       sourceLabel: "来源",
       sourceSequenceLabel: (sequence) => `来源序列 ${sequence}`,
       sessionTargetEmpty: "没有与此工作关联的 Worker 会话尝试。",
       sessionTargetError: "无法加载 Worker 会话尝试。",
       sessionTargetLoading: "正在加载 Worker 会话尝试…",
-      sessionTargetOption: (workerSessionID, attemptID, state) =>
-        `${workerSessionID} · ${attemptID} · ${state}`,
+      sessionTargetListLabel: "Worker 会话尝试",
       sessionTargetRetry: "重试 Worker 会话查找",
-      sessionTargetSelectLabel: "Worker 会话尝试",
       successorLabel: "后继 Worker 会话",
       terminalOutcomeLabel: (outcome) =>
         outcome === "SUCCESS"


### PR DESCRIPTION
{
  "project": "Preserve Every Work and Attempt in Request and Terminal History",
  "branchName": "ux-p2-preserve-every-work-and-attempt",
  "description": "Change request and terminal history so every Work and attempt remains visible and selectable by canonical identity, canceled and terminated outcomes are truthful and distinct, retained rows are bounded without silent loss, and terminal entries link to their authoritative Worker Session and available Provider Session context without changing backend contracts or redesigning inspection.",
  "context": {
    "customerAsk": "Preserve every Work and attempt in Workstation request history and terminal Work presentation. Use canonical dispatch, Work, attempt, and Worker Session identities rather than labels; show canceled and remaining terminal outcomes distinctly; make any history bound explicit; link terminal Work to its Worker Session while exposing available Worker/Provider origin; and rebase onto origin/main before the final push.",
    "problem": "The dashboard projects only work_items[0] for a Workstation request, so Works 2 through N disappear. Terminal rows and selection use display labels, causing canonical Works with duplicate labels to collide. Terminal presentation omits canceled and terminated outcomes, history has no explicit bound, and terminal Work does not link to the authoritative Worker Sessions and Provider Session context that executed it.",
    "solution": "Project request and terminal history from canonical dispatch, Work, attempt, and Worker Session identities; render every Work and attempt; map completed, failed, canceled, terminated, and unknown outcomes truthfully; progressively disclose bounded history with explicit remaining counts; and use the existing typed Work-scoped Worker Sessions API for exact navigation and available Provider origin. Do not infer missing Worker metadata or change backend/OpenAPI contracts."
  },
  "acceptanceCriteria": [
    "A rendered request containing at least three Works shows all three, exposes their distinct canonical Work identities, and preserves all recorded attempts for that request.",
    "Two Works with the same display label render and select independently because row keys, lookup, and selection use canonical dispatch/Work/attempt identity rather than label.",
    "Completed, failed, canceled, and terminated terminal outcomes are textually and visually distinguishable, with canceled never presented as failed or completed.",
    "Request and terminal history are bounded through paging or progressive disclosure, and the UI always states when more rows exist and how the customer can reveal or load them.",
    "Each terminal Work exposes links for every authoritative Worker Session observation returned for its canonical Work ID, displays canonical Worker Session/attempt identity and available Provider Session origin, and never fabricates missing Worker metadata.",
    "Typecheck and focused UI tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts and shared-file changes are resolved, and the PR is actually merged; CI-run evidence is posted in a PR comment and never committed."
  ],
  "userStories": [
    {
      "id": "ux-p2-preserve-every-work-and-attempt-001",
      "title": "Show every Work and request attempt",
      "description": "As a customer inspecting a Workstation request, I want every Work and attempt in that request to be visible so I can account for the complete execution rather than only its first item.",
      "acceptanceCriteria": [
        "Each request remains a coherent group and renders one independently selectable entry for every item in its work_items collection; an empty collection uses an explicit unknown or empty presentation without inventing an identity.",
        "Each Work entry displays its canonical Work ID alongside its localized display label, and all selection callbacks receive the exact Work ID represented by the activated entry.",
        "Every recorded inference or script attempt available on the request is shown in stable execution order with its canonical attempt or request identity, outcome, and available timing/provider context; repeated outcomes or labels do not collapse attempts.",
        "An executed component test renders one request with at least three Works and multiple attempts, asserts all canonical Work and attempt identities appear, and activates each Work independently.",
        "Loading, empty, error, and success behavior inherited from the owning detail surface remains truthful; this story does not alter session tabs, stream state, or pause semantics.",
        "Direct browser verification covers keyboard activation, visible focus, semantic list/group structure, mobile width, desktop width, and 200% zoom.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented grouped request history rendering for every canonical Work ID and every available inference/script attempt, including localized outcome/timing/provider context and explicit unknown-work empty state. Added focused multi-Work/multi-attempt component coverage with exact Work-ID callback assertions. Focused UI tests, typecheck, localized-copy check, changed-file Biome, Tailwind token, feature-root guard, and Playwright Storybook smoke (desktop/mobile/200% zoom) pass; full ui check remains blocked by unrelated baseline diagnostics and the full component lane timed out."
    },
    {
      "id": "ux-p2-preserve-every-work-and-attempt-002",
      "title": "Keep terminal identity and outcomes truthful",
      "description": "As a customer reviewing terminal Work, I want duplicate labels and all terminal outcomes represented accurately so I can distinguish the exact Work and understand how it ended.",
      "acceptanceCriteria": [
        "Terminal row keys, selected state, and callbacks use canonical Work identity, qualified by dispatch or attempt identity where required, and never use a display label as identity.",
        "An executed component test renders two terminal Works with the same display label but different canonical Work IDs, asserts both remain present, and proves selecting one does not select or replace the other.",
        "Completed, failed, canceled, and terminated are separate terminal statuses with localized visible text, accessible status semantics, and distinct non-color-only icon/tone treatment.",
        "An executed component test asserts canceled is visibly and accessibly distinguishable from failed and completed; terminated is also represented as its own terminal outcome.",
        "Unknown future terminal values use an explicit localized unknown terminal outcome rather than being silently classified as completed or failed.",
        "Existing completed and failed navigation behavior remains available after migration, and deletion of the label-keyed path occurs only after the canonical path is exercised by all in-scope callers.",
        "Direct browser verification covers keyboard activation, focus, mobile and desktop layout, forced-colors readability, and 200% zoom.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Terminal row keys, selection, callbacks, and selection-history keys now use canonical Work IDs qualified by dispatch identity; duplicate display labels remain independently selectable. Completed, failed, canceled, terminated, and unknown outcomes have localized visible labels, accessible status semantics, and distinct icon/tone treatments, with nonstandard request outcomes projected from canonical workstation requests. Added focused duplicate-label, outcome-projection, unknown-normalization, component, and Storybook interaction coverage. Typecheck, changed-file Biome, localized-copy, semantic-color, spacing, feature-boundary/root/lane guards, focused component/unit suites (76 tests), and direct Storybook browser verification at mobile, desktop, forced-colors, and 200% page scale pass; the in-app browser target was unavailable."
    },
    {
      "id": "ux-p2-preserve-every-work-and-attempt-003",
      "title": "Bound history without silent loss",
      "description": "As a customer with a long-running Factory Session, I want request and terminal histories to stay usable while clearly disclosing retained rows so no Work appears to vanish silently.",
      "acceptanceCriteria": [
        "Request and terminal lists initially render a documented bounded number of rows or pages while preserving deterministic ordering and canonical identity across reveal or load operations.",
        "Whenever rows remain undisplayed, the UI states the shown and remaining or total counts and provides a semantic, keyboard-operable action to reveal or load the next bounded set.",
        "Activating the continuation preserves already visible rows, selection, and focus context and never duplicates or skips a Work or attempt.",
        "Empty and fully displayed histories do not show a misleading truncation control; a failed page or load has an inline localized error and retry when network paging is used.",
        "An executed component test supplies more entries than the initial bound, proves the truncation notice is present before continuation, and proves all entries become reachable without silent loss.",
        "Direct browser verification covers the bounded presentation at mobile and desktop widths, keyboard-only operation, and 200% zoom.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented 10-row progressive disclosure for workstation request history and each terminal status group with deterministic slice ordering, explicit shown/total/remaining copy, semantic keyboard-operable reveal actions, selected-state preservation, and focus recovery to the retained list after the final reveal. Empty and fully displayed histories omit the continuation control. Extracted request-attempt rendering under detail-card/history to keep the feature folder guard green. Added focused 12-entry component coverage and tagged Storybook interaction stories. Focused component suites (40 tests), typecheck, full UI lint, localized-copy, semantic-color, spacing, feature-root/folder/boundary/lane guards, and targeted Chromium Storybook bounded-history stories (2) pass; the connected in-app browser target was unavailable for an additional responsive session."
    },
    {
      "id": "ux-p2-preserve-every-work-and-attempt-004",
      "title": "Link terminal Work to authoritative Worker Sessions",
      "description": "As a customer investigating terminal Work, I want to open the Worker Session that ran each attempt and see its Provider origin so I can continue inspection from authoritative execution identity.",
      "acceptanceCriteria": [
        "Terminal Work resolution queries the existing typed Worker Sessions operation using the selected Factory Session and canonical Work ID; it does not join by label, array position, Provider Session, or trace identity.",
        "Every returned observation is presented with canonical Worker Session ID, attempt ID, lifecycle outcome, and available Provider Session provider/kind/id, with a semantic link or button that opens the exact Worker Session target.",
        "Multiple Worker Sessions or attempts for one Work remain independently visible and navigable; the UI does not reduce the list to the latest attempt.",
        "Worker Session origin has explicit loading, known-empty, error-with-retry, and success states. A missing Provider Session is labeled unavailable and does not hide the Worker Session.",
        "No separate Worker name or identity is inferred when the generated contract does not provide one; the PR description calls out that exact absent field and treats richer Worker metadata as follow-up rather than changing backend or OpenAPI contracts in this lane.",
        "Executed typed API or hook and component tests cover multiple observations, Provider Session present and absent, exact navigation target, loading, empty, recoverable error, and retry behavior.",
        "Direct browser verification covers keyboard-operable links and retry controls, visible focus, accessible names containing canonical context, mobile and desktop widths, and 200% zoom.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "The existing typed Worker Sessions lookup remains scoped by selected Factory Session and canonical Work ID, and the Worker Session timeline target now renders every observation with canonical Worker Session ID, attempt ID, localized lifecycle outcome, Provider Session provider/kind/id when available, and an exact context-rich keyboard-operable selection action. Multiple observations remain independently selectable; missing Provider Session data is explicitly unavailable. Loading, known-empty, recoverable error, and retry states are covered in component tests. The generated observation contract has no Worker name field, so this lane does not infer one; richer Worker metadata is a follow-up and no backend or OpenAPI changes were made. Focused component tests (12), typecheck, changed-file Biome, localized-copy, semantic-color, spacing, feature guards, and targeted Storybook Chromium checks at mobile, desktop, keyboard activation, visible focus, and 200% page scale pass; the connected in-app browser target was unavailable."
    }
  ],
  "AAAA00_THE_ONLY_CURRENT_OVERRIDE": "OPERATOR OVERRIDE (supersedes any conflicting statement in your payload or this prd).\n\nPUSH YOUR BRANCH AND OPEN YOUR PR NOW, BEFORE YOU WRITE ANY MORE CODE.\n\nOPERATOR-MEASURED, just now, in your worktree:\n\n    commits on your branch ahead of main : 2\n    first commit made                    : 67 minutes ago\n    remote branch (git ls-remote origin) : 0\n    pull request                          : none, in any state\n\nSo 2 commits of finished work exist ONLY on this machine, in this worktree, and have for over an\nhour. Nothing has been pushed. CI has never run on any of it. Review has never seen any of it.\n\nWHY THIS IS URGENT AND NOT A STYLE PREFERENCE.\n\n1. UNPUSHED WORK READS AS NO WORK. The review stage and the operator both judge progress by your pushed\n   head. A lane with local-only commits is indistinguishable from a lane that has done nothing. This\n   repo has already burned a lane on exactly that: 351 lines of real work sat unpushed while review\n   rejected the head twice for being \"unchanged\", and the review circuit breaker counts unchanged-head\n   re-hands - not rejections. Three at identical bytes kills the task token.\n\n2. YOU HAVE NO OPERATOR CHANNEL UNTIL YOU HAVE A PR. PR comments are the ONLY channel that reaches a\n   running session. Without a PR, the operator can only write into this prd.json, which you will not see\n   until your NEXT session. If you get stuck right now, nobody can reach you in time to help.\n\n3. YOU ARE ACCUMULATING UNMEASURED RISK. main moved to 48fd1c7c2 when PR #1978 merged and replaced the\n   provider execution engine. Your 2 commits were written against an older main and have never\n   been compiled, linted, or tested against the current one. The longer you go, the larger the eventual\n   conflict and the less any of your local verification means.\n\n4. IF YOUR SESSION IS KILLED, UNPUSHED WORK IS STRANDED. Sessions end on timeout, on a transient crash,\n   and on the visit breaker. A pushed branch survives all three. A worktree-only commit survives none of\n   them cleanly.\n\nDO THIS NOW, IN THIS ORDER.\n\n    git -C <your worktree> add -A && git -C <your worktree> commit -m \"<message>\"   # if anything is uncommitted\n    git -C <your worktree> fetch origin main\n    git -C <your worktree> rebase origin/main                                       # commit FIRST, never stash\n    git -C <your worktree> push -u origin HEAD\n    gh pr create --fill                                                             # then let CI start\n\nCOMMIT BEFORE YOU REBASE. Never use `git stash` in this repository under any circumstances - the stash\nstack is shared across roughly ten concurrent worktrees and popping it will silently take another lane's\nchanges. If you need to set work aside, move the files with `mv`.\n\nAFTER THE PR IS OPEN: keep pushing as you go, at least once per completed story. Do not batch. Your\nfinish line is \"final head pushed, PR open, CI started, blocking review feedback addressed\" - you do NOT\nown merging, the review stage does. Never commit \"CI evidence\": a new commit changes the head and\ninvalidates the exact run you were trying to record. Put CI evidence in a PR comment.\n\nEXPECT ONE FRONTEND BROWSER FAILURE THAT IS NOT YOURS, AND DO NOT CHASE IT. main itself is currently red\non the Frontend Browser job. The failing spec is\n\n    integration/factory-graph-editor-node-placement.integration.test.mjs\n      > \"persists a manually dragged node position in the saved shared layout\"\n      Error: Timed out waiting for durable checkpoint: save confirmation dialog activation;\n             unsatisfied conditions: dialogPresent (returned false), dialogVisible (returned false)\n\nThe operator has already measured this and it is NOT a flake: a same-head re-run of main at 48fd1c7c2\nfailed a second time on identical bytes. It is also NOT caused by the provider-engine merge - PR #1978\nchanged 432 files and ZERO of them are under ui/, so the dashboard build input is byte-identical to\n9bb9258c8, where this same spec PASSED. It is being tracked as its own lane.\n\nIf that spec is the ONLY browser failure you see, it is inherited - state that explicitly in your PR,\nwith the run ID, rather than letting it read as yours. If ANY OTHER browser spec fails, that one IS\nworth investigating and is probably yours.\n\nDO NOT \"fix\" it, do not skip it, and do not touch\nui/src/features/factory-graph-editor/** save-confirmation code to make your run green. Another lane owns\nit and you would collide.\n\nNOTHING ELSE IN YOUR MISSION CHANGES. Your defect, root cause, non-goals, and evidence rules all still\nstand.\n"
}
