### PR TITLE
ux-p1-truthful-session-and-async-state

### DIFF
--- a/ui/integration/dashboard-session-tabs.integration.test.mjs
+++ b/ui/integration/dashboard-session-tabs.integration.test.mjs
@@ -5,6 +5,7 @@ import { describe, expect } from "vitest";
 import {
   browserScenarioTimeoutMs,
   expectNoBrowserErrors,
+  loadReplayLines,
   startFactoryApiServer,
   uiInteractionTimeoutMs,
 } from "./browser-test-harness.mjs";
@@ -383,6 +384,40 @@ describe.concurrent("dashboard session tabs browser integration", () => {
           .getByRole("status", { name: "Timeline mode: Live" })
           .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
 
+        const workTotalsCard = browserPage.page.locator(
+          '[data-bento-card-id="work-totals"]',
+        );
+        const workTotalsState = workTotalsCard.getByRole("status");
+        await workTotalsState.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await expect
+          .poll(
+            () =>
+              workTotalsState.getAttribute("data-dashboard-card-content-state"),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toBe("known-empty");
+        await expect
+          .poll(
+            () =>
+              workTotalsState.getAttribute(
+                "data-dashboard-card-freshness-state",
+              ),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toBe("fresh");
+        await expect
+          .poll(
+            () =>
+              workTotalsState.getAttribute(
+                "data-dashboard-card-temporal-state",
+              ),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toBe("live");
+
         const pauseButton = sessionControls.getByRole("button", {
           name: "Pause live dashboard updates for root",
         });
@@ -405,6 +440,15 @@ describe.concurrent("dashboard session tabs browser integration", () => {
         await sessionControls
           .getByRole("status", { name: "Timeline mode: Historical" })
           .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+        await expect
+          .poll(
+            () =>
+              workTotalsState.getAttribute(
+                "data-dashboard-card-temporal-state",
+              ),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toBe("historical");
         expect(
           await sessionControls
             .getByText("Factory Session paused", { exact: true })
@@ -415,6 +459,10 @@ describe.concurrent("dashboard session tabs browser integration", () => {
         await sessionControls
           .getByRole("status", { name: "Timeline mode: Historical" })
           .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+        await workTotalsState.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
         await browserPage.page.setViewportSize({ width: 1280, height: 900 });
 
         const resumeButton = sessionControls.getByRole("button", {
@@ -431,6 +479,15 @@ describe.concurrent("dashboard session tabs browser integration", () => {
         await sessionControls
           .getByRole("status", { name: "Timeline mode: Live" })
           .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+        await expect
+          .poll(
+            () =>
+              workTotalsState.getAttribute(
+                "data-dashboard-card-temporal-state",
+              ),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toBe("live");
 
         expectSubtleActiveSessionTabShell(
           await readSessionTabShellClassName(rootTab),
@@ -483,6 +540,109 @@ describe.concurrent("dashboard session tabs browser integration", () => {
           await readSessionTabShellClassName(rootTab),
         );
 
+        expectNoBrowserErrors(
+          browserPage.pageErrors,
+          browserPage.consoleErrors,
+          expect,
+        );
+      } finally {
+        await server.stop();
+        await browserPage.close();
+      }
+    },
+    browserScenarioTimeoutMs,
+  );
+
+  it(
+    "keeps retained card data visible as its live stream goes stale at desktop and narrow widths",
+    async ({ expect, openBrowserPage, preview }) => {
+      const replayLines = await loadReplayLines("event-stream-replay.jsonl");
+      const server = await startFactoryApiServer({
+        apiPort: preview.apiPort,
+        currentFactory: defaultFactoryDefinition,
+        eventLines: [],
+      });
+      const browserPage = await openBrowserPage({
+        artifactLabel: "dashboard-card-reconnecting",
+      });
+      let eventStreamAttempts = 0;
+
+      try {
+        await browserPage.page.route("**/events**", async (route) => {
+          const acceptHeader = route.request().headers().accept ?? "";
+          if (!acceptHeader.includes("text/event-stream")) {
+            await route.continue();
+            return;
+          }
+
+          eventStreamAttempts += 1;
+          if (eventStreamAttempts === 1) {
+            const body = replayLines
+              .map((line) => `data: ${line}\n\n`)
+              .join("");
+            await route.fulfill({
+              body,
+              contentType: "text/event-stream",
+              status: 200,
+            });
+            return;
+          }
+
+          await route.abort("failed");
+        });
+
+        await browserPage.page.goto(preview.previewURL, {
+          waitUntil: "domcontentloaded",
+        });
+        await browserPage.page
+          .getByRole("heading", { level: 1, name: "U", exact: true })
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+
+        const workTotalsState = browserPage.page
+          .locator('[data-bento-card-id="work-totals"]')
+          .getByRole("status");
+        await workTotalsState.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await expect
+          .poll(
+            () =>
+              workTotalsState.getAttribute("data-dashboard-card-content-state"),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toBe("populated");
+        await expect
+          .poll(
+            () =>
+              workTotalsState.getAttribute(
+                "data-dashboard-card-freshness-state",
+              ),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toBe("stale");
+        expect(eventStreamAttempts).toBeGreaterThanOrEqual(1);
+
+        await browserPage.page.setViewportSize({ width: 360, height: 800 });
+        await workTotalsState.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await expect
+          .poll(
+            () =>
+              workTotalsState.getAttribute(
+                "data-dashboard-card-freshness-state",
+              ),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toBe("stale");
+
+        await browserPage.page.setViewportSize({ width: 1280, height: 900 });
+        await workTotalsState.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
         expectNoBrowserErrors(
           browserPage.pageErrors,
           browserPage.consoleErrors,

--- a/ui/integration/dashboard-session-tabs.integration.test.mjs
+++ b/ui/integration/dashboard-session-tabs.integration.test.mjs
@@ -6,6 +6,7 @@ import {
   browserScenarioTimeoutMs,
   expectNoBrowserErrors,
   loadReplayLines,
+  resolvedDefaultFactorySessionID,
   startFactoryApiServer,
   uiInteractionTimeoutMs,
 } from "./browser-test-harness.mjs";
@@ -101,6 +102,11 @@ const openedFactoryDefinition = {
       worker: "review-writer",
     },
   ],
+};
+
+const betaFactoryDefinition = {
+  ...defaultFactoryDefinition,
+  name: "Beta Browser Session Harness Factory",
 };
 
 const betaSessionID = "session-beta";
@@ -643,6 +649,187 @@ describe.concurrent("dashboard session tabs browser integration", () => {
           state: "visible",
           timeout: uiInteractionTimeoutMs,
         });
+        expectNoBrowserErrors(
+          browserPage.pageErrors,
+          browserPage.consoleErrors,
+          expect,
+        );
+      } finally {
+        await server.stop();
+        await browserPage.close();
+      }
+    },
+    browserScenarioTimeoutMs,
+  );
+
+  it(
+    "keeps the selected beta session stable when alpha stream data arrives late",
+    async ({ expect, openBrowserPage, preview }) => {
+      const alphaLines = buildReplayLines(defaultFactoryDefinition);
+      const betaLines = buildReplayLines(betaFactoryDefinition);
+      const server = await startFactoryApiServer({
+        apiPort: preview.apiPort,
+        currentFactory: defaultFactoryDefinition,
+        eventLines: alphaLines,
+        eventLinesBySessionID: {
+          [betaSessionID]: betaLines,
+        },
+        currentFactoryBySessionID: {
+          [betaSessionID]: betaFactoryDefinition,
+        },
+        sessions: [defaultSession, betaSession],
+      });
+      const browserPage = await openBrowserPage({
+        artifactLabel: "dashboard-late-session-result",
+      });
+      const delayedAlphaRoutes = [];
+      let alphaStreamAttempts = 0;
+
+      try {
+        await browserPage.page.route("**/events**", async (route) => {
+          const acceptHeader = route.request().headers().accept ?? "";
+          if (!acceptHeader.includes("text/event-stream")) {
+            await route.continue();
+            return;
+          }
+
+          const pathname = new URL(route.request().url()).pathname;
+          const alphaEventsPath = `/factory-sessions/${resolvedDefaultFactorySessionID}/events`;
+          if (pathname !== alphaEventsPath) {
+            await route.continue();
+            return;
+          }
+
+          alphaStreamAttempts += 1;
+          if (alphaStreamAttempts === 1) {
+            await route.fulfill({
+              body: alphaLines
+                .slice(0, 2)
+                .map((line) => `data: ${line}\n\n`)
+                .join(""),
+              contentType: "text/event-stream",
+              status: 200,
+            });
+            return;
+          }
+
+          delayedAlphaRoutes.push(route);
+        });
+
+        await browserPage.page.goto(preview.previewURL, {
+          waitUntil: "domcontentloaded",
+        });
+        await browserPage.page
+          .getByRole("heading", { level: 1, name: "U", exact: true })
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+
+        const rootTab = browserPage.page.getByRole("tab", { name: "root" });
+        const betaTab = browserPage.page.getByRole("tab", { name: "beta" });
+        await rootTab.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await betaTab.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await expect
+          .poll(() => delayedAlphaRoutes.length, {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBeGreaterThan(0);
+
+        await betaTab.click();
+        await expect
+          .poll(() => betaTab.getAttribute("aria-selected"), {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBe("true");
+        await expect
+          .poll(() => readSessionTabStatusLabel(betaTab), {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBe("Factory event stream connected.");
+
+        const sessionControls = browserPage.page.getByRole("article", {
+          name: "Session controls",
+        });
+        await sessionControls
+          .getByRole("status", { name: "Timeline mode: Live" })
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+
+        const workTotalsState = browserPage.page
+          .locator('[data-bento-card-id="work-totals"]')
+          .getByRole("status");
+        await expect
+          .poll(
+            () =>
+              workTotalsState.getAttribute("data-dashboard-card-content-state"),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toBe("known-empty");
+        const betaCardText = await workTotalsState.textContent();
+        const betaCardFreshness = await workTotalsState.getAttribute(
+          "data-dashboard-card-freshness-state",
+        );
+
+        const timelineSlider = sessionControls.getByRole("slider", {
+          name: "Timeline tick",
+        });
+        await timelineSlider.focus();
+        await timelineSlider.press("ArrowLeft");
+        await sessionControls
+          .getByRole("status", { name: "Timeline mode: Historical" })
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+        await timelineSlider.press("ArrowRight");
+        await sessionControls
+          .getByRole("status", { name: "Timeline mode: Live" })
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+
+        const delayedAlphaRoute = delayedAlphaRoutes.at(-1);
+        if (!delayedAlphaRoute) {
+          throw new Error("Expected a delayed alpha event-stream request.");
+        }
+        await delayedAlphaRoute.fulfill({
+          body: alphaLines
+            .slice(2)
+            .map((line) => `data: ${line}\n\n`)
+            .join(""),
+          contentType: "text/event-stream",
+          status: 200,
+        });
+
+        await expect
+          .poll(() => betaTab.getAttribute("aria-selected"), {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBe("true");
+        await expect
+          .poll(() => readSessionTabStatusLabel(betaTab), {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBe("Factory event stream connected.");
+        await expect
+          .poll(
+            () =>
+              workTotalsState.getAttribute("data-dashboard-card-content-state"),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toBe("known-empty");
+        await expect
+          .poll(
+            () =>
+              workTotalsState.getAttribute(
+                "data-dashboard-card-freshness-state",
+              ),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toBe(betaCardFreshness);
+        expect(await workTotalsState.textContent()).toBe(betaCardText);
+        await sessionControls
+          .getByRole("status", { name: "Timeline mode: Live" })
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+
         expectNoBrowserErrors(
           browserPage.pageErrors,
           browserPage.consoleErrors,

--- a/ui/integration/dashboard-session-tabs.integration.test.mjs
+++ b/ui/integration/dashboard-session-tabs.integration.test.mjs
@@ -372,6 +372,66 @@ describe.concurrent("dashboard session tabs browser integration", () => {
           })
           .toBe("Loading factory events...");
 
+        const sessionControls = browserPage.page.getByRole("article", {
+          name: "Session controls",
+        });
+        await sessionControls.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await sessionControls
+          .getByRole("status", { name: "Timeline mode: Live" })
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+
+        const pauseButton = sessionControls.getByRole("button", {
+          name: "Pause live dashboard updates for root",
+        });
+        await pauseButton.focus();
+        await pauseButton.press("Enter");
+        await sessionControls
+          .getByRole("status", { name: "Live dashboard updates paused" })
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+        await sessionControls
+          .getByRole("button", {
+            name: "Resume live dashboard updates for root",
+          })
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+
+        const timelineSlider = sessionControls.getByRole("slider", {
+          name: "Timeline tick",
+        });
+        await timelineSlider.focus();
+        await timelineSlider.press("ArrowLeft");
+        await sessionControls
+          .getByRole("status", { name: "Timeline mode: Historical" })
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+        expect(
+          await sessionControls
+            .getByText("Factory Session paused", { exact: true })
+            .count(),
+        ).toBe(0);
+
+        await browserPage.page.setViewportSize({ width: 360, height: 800 });
+        await sessionControls
+          .getByRole("status", { name: "Timeline mode: Historical" })
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+        await browserPage.page.setViewportSize({ width: 1280, height: 900 });
+
+        const resumeButton = sessionControls.getByRole("button", {
+          name: "Resume live dashboard updates for root",
+        });
+        await resumeButton.focus();
+        await resumeButton.press("Enter");
+        await sessionControls
+          .getByRole("button", {
+            name: "Pause live dashboard updates for root",
+          })
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+        await timelineSlider.press("ArrowRight");
+        await sessionControls
+          .getByRole("status", { name: "Timeline mode: Live" })
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+
         expectSubtleActiveSessionTabShell(
           await readSessionTabShellClassName(rootTab),
         );

--- a/ui/integration/dashboard-session-tabs.integration.test.mjs
+++ b/ui/integration/dashboard-session-tabs.integration.test.mjs
@@ -361,6 +361,16 @@ describe.concurrent("dashboard session tabs browser integration", () => {
             timeout: uiInteractionTimeoutMs,
           })
           .toBe("true");
+        await expect
+          .poll(() => readSessionTabStatusLabel(rootTab), {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBe("Factory event stream connected.");
+        await expect
+          .poll(() => readSessionTabStatusLabel(betaTab), {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBe("Loading factory events...");
 
         expectSubtleActiveSessionTabShell(
           await readSessionTabShellClassName(rootTab),
@@ -380,6 +390,31 @@ describe.concurrent("dashboard session tabs browser integration", () => {
             timeout: uiInteractionTimeoutMs,
           })
           .toBe("false");
+        await expect
+          .poll(() => readSessionTabStatusLabel(betaTab), {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toMatch(/\S+/);
+        await expect
+          .poll(() => readSessionTabStatusLabel(rootTab), {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toMatch(/\S+/);
+
+        await browserPage.page.setViewportSize({ width: 360, height: 800 });
+        await expect
+          .poll(
+            () =>
+              browserPage.page
+                .getByRole("navigation", { name: "factory sessions" })
+                .getAttribute("class"),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toMatch(/overflow-x-auto/);
+        await betaTab.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
 
         expectSubtleActiveSessionTabShell(
           await readSessionTabShellClassName(betaTab),
@@ -410,6 +445,10 @@ async function readSessionTabShellClassName(tabLocator) {
     }
     return shell.className;
   });
+}
+
+async function readSessionTabStatusLabel(tabLocator) {
+  return tabLocator.getByRole("img").getAttribute("aria-label");
 }
 
 function expectSubtleActiveSessionTabShell(className) {

--- a/ui/src/features/bento/components/agent-bento.tsx
+++ b/ui/src/features/bento/components/agent-bento.tsx
@@ -9,7 +9,9 @@ import { ScrollArea } from "@you-agent-factory/components/overlays";
 import { Heading } from "@you-agent-factory/components/primitives";
 import { DashboardPanelShell } from "../../../components/ui/dashboard-shell";
 import { cn } from "../../../lib/cn";
+import type { DashboardCardAsyncState } from "../../dashboard/lib/dashboard-card-state";
 import { getAgentBentoMessages } from "../messages/agent-bento";
+import { DashboardCardStateBanner } from "./card-state/dashboard-card-state-banner";
 
 export interface AgentBentoLayoutItem {
   h: number;
@@ -26,6 +28,7 @@ export interface AgentBentoLayoutItem {
 }
 
 export interface AgentBentoLayoutCard {
+  cardState?: DashboardCardAsyncState;
   children: ReactNode;
   id: string;
   widgetType: string;
@@ -288,7 +291,17 @@ export function AgentBentoLayout({
             id={card.id}
             key={card.id}
           >
-            {card.children}
+            {card.cardState ? (
+              <div className="flex h-full min-w-0 flex-col gap-1">
+                <DashboardCardStateBanner
+                  locale={locale}
+                  state={card.cardState}
+                />
+                <div className="min-h-0 min-w-0 flex-1">{card.children}</div>
+              </div>
+            ) : (
+              card.children
+            )}
           </div>
         ))}
       </GridLayout>

--- a/ui/src/features/bento/components/card-state/dashboard-card-state-banner.bun.component.test.tsx
+++ b/ui/src/features/bento/components/card-state/dashboard-card-state-banner.bun.component.test.tsx
@@ -1,0 +1,64 @@
+import "../../../../testing/vitest-dom-capabilities.setup";
+
+import { describe, expect, it } from "bun:test";
+import { render, screen } from "@testing-library/react";
+
+import { DashboardCardStateBanner } from "./dashboard-card-state-banner";
+
+describe("DashboardCardStateBanner", () => {
+  it("renders known-empty, reconnecting, stale, recovering, historical, and live vocabulary", () => {
+    const { rerender } = render(
+      <DashboardCardStateBanner
+        state={{
+          content: "known-empty",
+          freshness: "fresh",
+          temporal: "live",
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("status", {
+        name: "Card state: No data yet. Live.",
+      }),
+    ).toBeTruthy();
+    expect(screen.getByText("No data yet")).toBeTruthy();
+    expect(screen.getByText("Live")).toBeTruthy();
+
+    rerender(
+      <DashboardCardStateBanner
+        state={{
+          content: "populated",
+          freshness: "reconnecting",
+          temporal: "live",
+        }}
+      />,
+    );
+    expect(screen.getByText("Reconnecting")).toBeTruthy();
+    expect(screen.getByText("Live")).toBeTruthy();
+
+    rerender(
+      <DashboardCardStateBanner
+        state={{
+          content: "populated",
+          freshness: "stale",
+          temporal: "historical",
+        }}
+      />,
+    );
+    expect(screen.getByText("Stale data")).toBeTruthy();
+    expect(screen.getByText("Historical")).toBeTruthy();
+
+    rerender(
+      <DashboardCardStateBanner
+        state={{
+          content: "loading",
+          freshness: "recovering",
+          temporal: "historical",
+        }}
+      />,
+    );
+    expect(screen.getByText("Recovering")).toBeTruthy();
+    expect(screen.getByText("Historical")).toBeTruthy();
+  });
+});

--- a/ui/src/features/bento/components/card-state/dashboard-card-state-banner.tsx
+++ b/ui/src/features/bento/components/card-state/dashboard-card-state-banner.tsx
@@ -1,0 +1,98 @@
+import {
+  DashboardStatusPill,
+  type DashboardStatusPillTone,
+} from "../../../../components/ui/dashboard-status-pill";
+import type { DashboardCardAsyncState } from "../../../dashboard/lib/dashboard-card-state";
+import { getDashboardCardStateMessages } from "../../../dashboard/messages/dashboard-card-state";
+
+export interface DashboardCardStateBannerProps {
+  locale?: string;
+  state: DashboardCardAsyncState;
+}
+
+export function DashboardCardStateBanner({
+  locale,
+  state,
+}: DashboardCardStateBannerProps) {
+  const messages = getDashboardCardStateMessages(locale);
+  const stateLabel = dashboardCardStateLabel(state, messages);
+  const temporalLabel =
+    state.temporal === "historical"
+      ? messages.historicalLabel
+      : messages.liveLabel;
+
+  return (
+    <div
+      aria-label={messages.statusAriaLabel(stateLabel, temporalLabel)}
+      aria-live="polite"
+      className="flex min-h-7 min-w-0 items-center gap-1.5 overflow-x-auto px-1"
+      data-dashboard-card-content-state={state.content}
+      data-dashboard-card-freshness-state={state.freshness}
+      data-dashboard-card-temporal-state={state.temporal}
+      role="status"
+    >
+      <DashboardStatusPill
+        className="shrink-0"
+        size="compact"
+        tone={dashboardCardStateTone(state)}
+      >
+        {stateLabel}
+      </DashboardStatusPill>
+      {stateLabel === temporalLabel ? null : (
+        <span className="shrink-0 text-xs font-semibold text-on-surface-variant">
+          {temporalLabel}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function dashboardCardStateLabel(
+  state: DashboardCardAsyncState,
+  messages: ReturnType<typeof getDashboardCardStateMessages>,
+): string {
+  switch (state.freshness) {
+    case "failed":
+      return messages.unavailableLabel;
+    case "reconnecting":
+      return messages.reconnectingLabel;
+    case "recovering":
+      return messages.recoveringLabel;
+    case "stale":
+      return messages.staleLabel;
+    case "fresh":
+      switch (state.content) {
+        case "error":
+          return messages.unavailableLabel;
+        case "known-empty":
+          return messages.knownEmptyLabel;
+        case "loading":
+          return messages.loadingLabel;
+        case "populated":
+          return state.temporal === "historical"
+            ? messages.historicalLabel
+            : messages.liveLabel;
+      }
+  }
+}
+
+function dashboardCardStateTone(
+  state: DashboardCardAsyncState,
+): DashboardStatusPillTone {
+  switch (state.freshness) {
+    case "failed":
+      return "danger";
+    case "reconnecting":
+    case "stale":
+      return "warning";
+    case "recovering":
+      return "info";
+    case "fresh":
+      if (state.content === "loading") {
+        return "info";
+      }
+      return state.content === "known-empty" || state.temporal === "historical"
+        ? "neutral"
+        : "success";
+  }
+}

--- a/ui/src/features/bento/components/dashboard-bento-cards.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-cards.tsx
@@ -455,6 +455,9 @@ function buildSingletonWidgetCard({
         widgetType: layoutItem.widgetType,
         children: (
           <SessionControlsWidget
+            factoryLifecycleStatus={
+              snapshot.runtime.session.bracket?.lifecycle_control_status
+            }
             headerAction={headerAction}
             locale={locale}
             widgetId={layoutItem.id}

--- a/ui/src/features/bento/components/dashboard-bento-cards.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-cards.tsx
@@ -7,6 +7,14 @@ import { CurrentSelectionWidget } from "../../current-selection/components/widge
 import type { useCurrentSelection } from "../../current-selection/hooks/core/useCurrentSelection";
 import type { useCurrentSelectionDetails } from "../../current-selection/hooks/core/useCurrentSelectionDetails";
 import type { useSelectedProviderSessionState } from "../../current-selection/work-selection/hooks/useSelectedProviderSessionState";
+import {
+  type DashboardCardAsyncState,
+  type DashboardCardContentState,
+  type DashboardCardStateContext,
+  dashboardSnapshotHasRecords,
+  resolveDashboardCardAsyncState,
+  resolveDashboardCardContentState,
+} from "../../dashboard/lib/dashboard-card-state";
 import { InlineAddWidgetCard } from "../../dashboard-add-card/components/inline-add-widget-card";
 import { FactorySessionWidget } from "../../factory-session-detail/components/factory-session-widget";
 import { getFactorySessionWidgetMessages } from "../../factory-session-detail/messages/factory-session-widget";
@@ -41,6 +49,7 @@ import { SessionControlsWidget } from "./session-controls-widget";
 
 export interface DashboardCardBuilderArgs {
   currentSelection: ReturnType<typeof useCurrentSelection>;
+  dashboardCardStateContext: DashboardCardStateContext;
   dashboardLayout: AgentBentoLayoutItem[];
   importController: ReturnType<typeof useCurrentActivityImportController>;
   isCurrent: boolean;
@@ -61,11 +70,13 @@ export interface DashboardCardBuilderArgs {
   setSelectedTraceID: (traceID: string | null) => void;
   snapshot: DashboardSnapshot;
   traceGridState: ReturnType<typeof useTraceDrilldown>["traceGridState"];
+  workOutcomeHydrationStatus: "loading" | "ready";
   workChartModel: ReturnType<typeof useWorkOutcomeChart>;
 }
 
 interface DashboardWidgetCardBuilderArgs {
   currentSelection: ReturnType<typeof useCurrentSelection>;
+  dashboardCardStateContext: DashboardCardStateContext;
   importController: ReturnType<typeof useCurrentActivityImportController>;
   isCurrent: boolean;
   layoutItem: AgentBentoLayoutItem;
@@ -85,11 +96,13 @@ interface DashboardWidgetCardBuilderArgs {
   setSelectedTraceID: (traceID: string | null) => void;
   snapshot: DashboardSnapshot;
   traceGridState: ReturnType<typeof useTraceDrilldown>["traceGridState"];
+  workOutcomeHydrationStatus: "loading" | "ready";
   workChartModel: ReturnType<typeof useWorkOutcomeChart>;
 }
 
 export function buildDashboardCards({
   currentSelection,
+  dashboardCardStateContext,
   dashboardLayout,
   importController,
   isCurrent,
@@ -106,12 +119,13 @@ export function buildDashboardCards({
   setSelectedTraceID,
   snapshot,
   traceGridState,
+  workOutcomeHydrationStatus,
   workChartModel,
 }: DashboardCardBuilderArgs): AgentBentoLayoutCard[] {
   const pickerAvailability =
     getDashboardWidgetPickerAvailability(dashboardLayout);
 
-  return dashboardLayout.flatMap((layoutItem) => {
+  return dashboardLayout.flatMap((layoutItem): AgentBentoLayoutCard[] => {
     if (layoutItem.hidden) {
       return [];
     }
@@ -132,28 +146,174 @@ export function buildDashboardCards({
       ];
     }
 
+    const card = buildWidgetCard({
+      currentSelection,
+      dashboardCardStateContext,
+      importController,
+      isCurrent,
+      layoutItem,
+      locale,
+      now,
+      onRemoveDashboardWidget,
+      providerSessionState,
+      selectedSessionID,
+      selectedTrace,
+      selectedTraceID,
+      selectedWorkExecutionDetails,
+      selectedWorkRelationshipGraph,
+      setSelectedTraceID,
+      snapshot,
+      traceGridState,
+      workOutcomeHydrationStatus,
+      workChartModel,
+    });
+
     return [
-      buildWidgetCard({
-        currentSelection,
-        importController,
-        isCurrent,
-        layoutItem,
-        locale,
-        now,
-        onRemoveDashboardWidget,
-        providerSessionState,
-        selectedSessionID,
-        selectedTrace,
-        selectedTraceID,
-        selectedWorkExecutionDetails,
-        selectedWorkRelationshipGraph,
-        setSelectedTraceID,
-        snapshot,
-        traceGridState,
-        workChartModel,
-      }),
+      {
+        ...card,
+        cardState: resolveDashboardCardState({
+          currentSelection,
+          dashboardCardStateContext,
+          layoutItem,
+          providerSessionState,
+          selectedSessionID,
+          snapshot,
+          traceGridState,
+          workOutcomeHydrationStatus,
+          workChartModel,
+        }),
+      },
     ];
   });
+}
+
+function resolveDashboardCardState({
+  currentSelection,
+  dashboardCardStateContext,
+  layoutItem,
+  providerSessionState,
+  selectedSessionID,
+  snapshot,
+  traceGridState,
+  workOutcomeHydrationStatus,
+  workChartModel,
+}: Pick<
+  DashboardCardBuilderArgs,
+  | "currentSelection"
+  | "dashboardCardStateContext"
+  | "providerSessionState"
+  | "selectedSessionID"
+  | "snapshot"
+  | "traceGridState"
+  | "workOutcomeHydrationStatus"
+  | "workChartModel"
+> & {
+  layoutItem: AgentBentoLayoutItem;
+}): DashboardCardAsyncState {
+  const content = resolveDashboardCardContentStateForWidget({
+    currentSelection,
+    dashboardCardStateContext,
+    layoutItem,
+    providerSessionState,
+    selectedSessionID,
+    snapshot,
+    traceGridState,
+    workOutcomeHydrationStatus,
+    workChartModel,
+  });
+
+  return resolveDashboardCardAsyncState({
+    ...dashboardCardStateContext,
+    content,
+    hasRetainedData: content === "populated",
+  });
+}
+
+function resolveDashboardCardContentStateForWidget({
+  currentSelection,
+  dashboardCardStateContext,
+  layoutItem,
+  providerSessionState,
+  selectedSessionID,
+  snapshot,
+  traceGridState,
+  workOutcomeHydrationStatus,
+  workChartModel,
+}: Pick<
+  DashboardCardBuilderArgs,
+  | "currentSelection"
+  | "dashboardCardStateContext"
+  | "providerSessionState"
+  | "selectedSessionID"
+  | "snapshot"
+  | "traceGridState"
+  | "workOutcomeHydrationStatus"
+  | "workChartModel"
+> & {
+  layoutItem: AgentBentoLayoutItem;
+}): DashboardCardContentState {
+  const authoritative = dashboardCardStateContext.hasAuthoritativeSnapshot;
+  const snapshotContent = (hasRecords: boolean) =>
+    resolveDashboardCardContentState({
+      authoritative,
+      hasRecords,
+    });
+
+  switch (layoutItem.widgetType) {
+    case DASHBOARD_WIDGET_IDS.workTotals:
+      return snapshotContent(dashboardSnapshotHasRecords(snapshot));
+    case DASHBOARD_WIDGET_IDS.workGraph:
+      return snapshotContent(
+        snapshot.topology.edges.length > 0 ||
+          snapshot.topology.workstation_node_ids.length > 0,
+      );
+    case DASHBOARD_WIDGET_IDS.terminalWork:
+      return snapshotContent(
+        currentSelection.completedWorkItems.length > 0 ||
+          currentSelection.failedWorkItems.length > 0,
+      );
+    case DASHBOARD_WIDGET_IDS.workOutcomeChart:
+      return resolveDashboardCardContentState({
+        authoritative,
+        error: workChartModel.chartState?.status === "error",
+        hasRecords: workChartModel.samples.length > 0,
+        loading:
+          workOutcomeHydrationStatus === "loading" ||
+          workChartModel.chartState?.status === "loading",
+      });
+    case DASHBOARD_WIDGET_IDS.currentSelection:
+      return snapshotContent(currentSelection.selection != null);
+    case DASHBOARD_WIDGET_IDS.factorySession:
+      return snapshotContent((selectedSessionID?.trim().length ?? 0) > 0);
+    case DASHBOARD_WIDGET_IDS.sessionControls:
+      return snapshotContent(true);
+    case DASHBOARD_WIDGET_IDS.providerSession:
+      return snapshotContent(
+        providerSessionState.selectedProviderSession != null,
+      );
+    case DASHBOARD_WIDGET_IDS.submitWork:
+      return snapshotContent(
+        (snapshot.topology.submit_work_types?.length ?? 0) > 0,
+      );
+    case DASHBOARD_WIDGET_IDS.trace:
+      switch (traceGridState.status) {
+        case "error":
+          return "error";
+        case "loading":
+          return "loading";
+        case "ready":
+          return "populated";
+        case "empty":
+        case "idle":
+          return snapshotContent(false);
+        default:
+          return snapshotContent(false);
+      }
+    case DASHBOARD_WIDGET_IDS.workerSessionTimeline:
+      return snapshotContent(currentSelection.selectedWorkID != null);
+    default:
+      return snapshotContent(true);
+  }
 }
 
 function buildWidgetCard({

--- a/ui/src/features/bento/components/dashboard-bento.test.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.test.tsx
@@ -215,6 +215,7 @@ vi.mock("../../trace-drilldown/components/trace-drilldown-widget", () => ({
 vi.mock("../../work-outcome/hooks/useWorkOutcomeChart", () => ({
   useWorkOutcomeChart: () => ({
     chartState: { status: "ready" },
+    samples: [],
     status: "empty",
   }),
 }));

--- a/ui/src/features/bento/components/dashboard-bento.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.tsx
@@ -4,8 +4,8 @@ import { useAppLocale } from "../../../i18n";
 import { useCurrentSelectionDetails } from "../../current-selection/hooks/core/useCurrentSelectionDetails";
 import { useSelectedProviderSessionState } from "../../current-selection/work-selection/hooks/useSelectedProviderSessionState";
 import { useDashboardSession } from "../../dashboard/session/dashboard-session-provider";
-import type { FactoryImportConfirmInput } from "../../import/lib/factory-import-save-choice";
 import { DashboardImportPreviewDialog } from "../../import/components/dashboard-import-preview-dialog";
+import type { FactoryImportConfirmInput } from "../../import/lib/factory-import-save-choice";
 import { useTraceDrilldown } from "../../trace-drilldown/hooks/useTraceDrilldown";
 import { useWorkOutcomeChart } from "../../work-outcome/hooks/useWorkOutcomeChart";
 import { useCurrentActivityImportController } from "../../workflow-activity/hooks/current-activity-import-controller";
@@ -66,6 +66,7 @@ export function DashboardBento({
   const { rawSessionID, sessionID } = useDashboardSession();
   const {
     currentSelection,
+    dashboardCardStateContext,
     materializedWorkOutcomeState,
     selectedSnapshot,
     selectedTimelineTick,
@@ -107,6 +108,7 @@ export function DashboardBento({
   const cards = buildDashboardCardLayouts({
     addDashboardWidget,
     currentSelection,
+    dashboardCardStateContext,
     dashboardLayout,
     importController,
     isCurrent: selectedTimelineTick === snapshot.tick_count,
@@ -122,6 +124,7 @@ export function DashboardBento({
     setSelectedTraceID,
     snapshot,
     traceGridState,
+    workOutcomeHydrationStatus,
     workChartModel,
   });
   const renderableLayout = getRenderableDashboardLayout(
@@ -156,6 +159,7 @@ export function DashboardBento({
 function buildDashboardCardLayouts({
   addDashboardWidget,
   currentSelection,
+  dashboardCardStateContext,
   dashboardLayout,
   importController,
   isCurrent,
@@ -171,6 +175,7 @@ function buildDashboardCardLayouts({
   setSelectedTraceID,
   snapshot,
   traceGridState,
+  workOutcomeHydrationStatus,
   workChartModel,
 }: Omit<DashboardCardBuilderArgs, "onSelectInlineWidget"> & {
   addDashboardWidget: ReturnType<
@@ -179,6 +184,7 @@ function buildDashboardCardLayouts({
 }) {
   return buildDashboardCards({
     currentSelection,
+    dashboardCardStateContext,
     dashboardLayout,
     importController,
     isCurrent,
@@ -197,6 +203,7 @@ function buildDashboardCardLayouts({
     setSelectedTraceID,
     snapshot,
     traceGridState,
+    workOutcomeHydrationStatus,
     workChartModel,
   });
 }

--- a/ui/src/features/bento/components/session-controls-widget.test.tsx
+++ b/ui/src/features/bento/components/session-controls-widget.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SessionControlsWidget } from "./session-controls-widget";
+
+let sessionStreamPaused = false;
 
 const sessionTabsState = {
   activeSession: {
@@ -12,7 +14,7 @@ const sessionTabsState = {
     project: "factory",
     target: { kind: "default" as const },
   },
-  isSessionStreamPaused: () => false,
+  isSessionStreamPaused: () => sessionStreamPaused,
   toggleSessionStreamPaused: vi.fn(),
 };
 
@@ -38,6 +40,10 @@ vi.mock("../../header/components/tick-slider-control", () => ({
 }));
 
 describe("SessionControlsWidget", () => {
+  beforeEach(() => {
+    sessionStreamPaused = false;
+  });
+
   it("renders timeline actions in portable bento card chrome with body inset", () => {
     render(<SessionControlsWidget locale="en" />);
 
@@ -51,8 +57,31 @@ describe("SessionControlsWidget", () => {
     expect(cardBody?.className).toContain("pb-4");
     expect(screen.getByRole("slider", { name: "Timeline tick" })).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: "Pause factory updates" }),
+      screen.getByRole("button", {
+        name: "Pause live dashboard updates for factory",
+      }),
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: "Export PNG" })).toBeTruthy();
+  });
+
+  it("keeps client update pause separate from a running Factory Session", () => {
+    sessionStreamPaused = true;
+
+    render(
+      <SessionControlsWidget factoryLifecycleStatus="RUNNING" locale="en" />,
+    );
+
+    expect(
+      screen.getByRole("status", { name: "Factory Session running" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("status", { name: "Live dashboard updates paused" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: "Resume live dashboard updates for factory",
+      }),
+    ).toBeTruthy();
+    expect(screen.queryByText("Factory Session paused")).toBeNull();
   });
 });

--- a/ui/src/features/bento/components/session-controls-widget.tsx
+++ b/ui/src/features/bento/components/session-controls-widget.tsx
@@ -8,12 +8,14 @@ import { getHeaderControlsMessages } from "../../header/messages/header-controls
 import { DashboardWidgetFrame } from "./dashboard-widget-frame/dashboard-widget-frame";
 
 export interface SessionControlsWidgetProps {
+  factoryLifecycleStatus?: string | null;
   headerAction?: ReactNode;
   locale?: string;
   widgetId?: string;
 }
 
 export function SessionControlsWidget({
+  factoryLifecycleStatus,
   headerAction,
   locale,
   widgetId = "session-controls",
@@ -38,6 +40,7 @@ export function SessionControlsWidget({
       <div className="flex min-w-0 w-full items-center gap-1.5">
         <TickSliderControl locale={locale} />
         <DashboardSessionControls
+          factoryLifecycleStatus={factoryLifecycleStatus}
           isExportDialogOpen={isExportDialogOpen}
           locale={locale ?? "en"}
           onOpenExportDialog={openExportDialog}

--- a/ui/src/features/bento/hooks/use-dashboard-bento-snapshot.ts
+++ b/ui/src/features/bento/hooks/use-dashboard-bento-snapshot.ts
@@ -1,6 +1,8 @@
 import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import { DEFAULT_FACTORY_SESSION_ID } from "../../../api/session-routing";
 import { useCurrentSelection } from "../../current-selection/hooks/core/useCurrentSelection";
+import type { DashboardCardStateContext } from "../../dashboard/lib/dashboard-card-state";
+import { useDashboardStreamStore } from "../../dashboard/state/dashboardStreamStore";
 import {
   factoryTimelineEntryKey,
   useFactoryTimelineStore,
@@ -10,6 +12,11 @@ import type { StreamDerivedCacheIdentity } from "../../timeline/public/stream-id
 export interface DashboardWorkOutcomeStream {
   identity: StreamDerivedCacheIdentity | null;
   status: "loading" | "ready";
+}
+
+export interface DashboardBentoCardStateContext
+  extends DashboardCardStateContext {
+  workOutcomeHydrationStatus: DashboardWorkOutcomeStream["status"];
 }
 
 interface WorkOutcomeTimelineSelectionState {
@@ -91,12 +98,24 @@ export function useDashboardBentoSnapshot(
     (state) =>
       selectDashboardWorkOutcomeInput(state, workOutcomeStream).hydrationStatus,
   );
+  const hasRestoredCheckpoint = useFactoryTimelineStore(
+    (state) => state.currentReplayCheckpoint != null,
+  );
+  const timelineMode = useFactoryTimelineStore(
+    (state) => state.mode ?? "current",
+  );
+  const streamStatus = useDashboardStreamStore((state) => state.streamState);
   const workstationRequestsByDispatchID = useFactoryTimelineStore(
     (state) =>
       state.worldViewCache[state.selectedTick]?.workstationRequestsByDispatchID,
   );
   const selectedSnapshot = useFactoryTimelineStore(
     (state) => state.worldViewCache[state.selectedTick],
+  );
+  const hasAuthoritativeSnapshot = useFactoryTimelineStore(
+    (state) =>
+      state.worldViewCache[state.selectedTick] != null &&
+      (state.events.length > 0 || state.currentReplayCheckpoint != null),
   );
   const snapshot = selectedSnapshot ?? EMPTY_DASHBOARD_SNAPSHOT;
   const currentSelection = useCurrentSelection({
@@ -110,6 +129,14 @@ export function useDashboardBentoSnapshot(
     selectedSnapshot,
     selectedTimelineTick,
     snapshot,
+    dashboardCardStateContext: {
+      hasAuthoritativeSnapshot,
+      recoveryPending:
+        hasRestoredCheckpoint || workOutcomeHydrationStatus === "loading",
+      streamStatus: streamStatus.status,
+      timelineMode,
+      workOutcomeHydrationStatus,
+    } satisfies DashboardBentoCardStateContext,
     workOutcomeHydrationStatus,
   };
 }

--- a/ui/src/features/dashboard/components/dashboard-screen.single-scroll.test.tsx
+++ b/ui/src/features/dashboard/components/dashboard-screen.single-scroll.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach } from "vitest";
 import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import { dashboardSemanticSnapshotFixtures } from "../../../components/dashboard/fixtures";
 import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
+import type { useDashboardBentoSnapshot } from "../../bento/hooks/use-dashboard-bento-snapshot";
 import { createMaterializedWorkOutcomeState } from "../../work-outcome/public/materializer";
 import { DashboardScreen } from "./dashboard-screen";
 
@@ -56,52 +57,62 @@ vi.mock("../session/dashboard-session-provider", () => ({
 }));
 
 vi.mock("../../bento/hooks/use-dashboard-bento-snapshot", () => ({
-  useDashboardBentoSnapshot: vi.fn(() => {
-    const snapshot = dashboardSnapshotState.value.snapshot;
+  useDashboardBentoSnapshot: vi.fn(
+    (): ReturnType<typeof useDashboardBentoSnapshot> => {
+      const snapshot = dashboardSnapshotState.value.snapshot;
 
-    if (!snapshot) {
-      throw new Error("Expected a dashboard snapshot fixture for bento tests.");
-    }
+      if (!snapshot) {
+        throw new Error("Expected a dashboard snapshot fixture for bento tests.");
+      }
 
-    return {
-      currentSelection: {
-        canRedoSelection: false,
-        canUndoSelection: false,
-        clearSelectedWorkerIfMatching: vi.fn(),
-        completedWorkItems: [],
-        failedWorkItems: [],
-        openTerminalWorkDetail: vi.fn(),
-        redoSelection: vi.fn(),
-        selectedNode: null,
-        selectedNodeActiveExecutions: [],
-        selectedNodeProviderSessions: [],
-        selectedNodeWorkstationRequests: [],
-        selectedStateCurrentWorkItems: [],
-        selectedStatePlace: null,
-        selectedStateTerminalHistoryWorkItems: [],
-        selectedStateTokenCount: 0,
-        selectedWorkDispatchAttempts: [],
-        selectedWorkID: null,
-        selectedWorkProviderSessions: [],
-        selectedWorkRequestHistory: [],
-        selectedWorkWorkstationRequests: [],
-        selectedWorkstationRequest: null,
-        selection: null,
-        selectStateNode: vi.fn(),
-        selectStateWorkItem: vi.fn(),
-        selectWorkByID: vi.fn(),
-        selectWorkItem: vi.fn(),
-        selectWorkstation: vi.fn(),
-        selectWorkstationRequest: vi.fn(),
-        terminalWorkDetail: null,
-        undoSelection: vi.fn(),
-      },
-      materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
-      selectedSnapshot: snapshot,
-      selectedTimelineTick: snapshot.tick_count,
-      snapshot,
-    };
-  }),
+      return {
+        currentSelection: {
+          canRedoSelection: false,
+          canUndoSelection: false,
+          clearSelectedWorkerIfMatching: vi.fn(),
+          completedWorkItems: [],
+          failedWorkItems: [],
+          openTerminalWorkDetail: vi.fn(),
+          redoSelection: vi.fn(),
+          selectedNode: null,
+          selectedNodeActiveExecutions: [],
+          selectedNodeProviderSessions: [],
+          selectedNodeWorkstationRequests: [],
+          selectedStateCurrentWorkItems: [],
+          selectedStatePlace: null,
+          selectedStateTerminalHistoryWorkItems: [],
+          selectedStateTokenCount: 0,
+          selectedWorkDispatchAttempts: [],
+          selectedWorkID: null,
+          selectedWorkProviderSessions: [],
+          selectedWorkRequestHistory: [],
+          selectedWorkWorkstationRequests: [],
+          selectedWorkstationRequest: null,
+          selection: null,
+          selectStateNode: vi.fn(),
+          selectStateWorkItem: vi.fn(),
+          selectWorkByID: vi.fn(),
+          selectWorkItem: vi.fn(),
+          selectWorkstation: vi.fn(),
+          selectWorkstationRequest: vi.fn(),
+          terminalWorkDetail: null,
+          undoSelection: vi.fn(),
+        },
+        dashboardCardStateContext: {
+          hasAuthoritativeSnapshot: true,
+          recoveryPending: false,
+          streamStatus: dashboardSnapshotState.value.streamState.status,
+          timelineMode: "current" as const,
+          workOutcomeHydrationStatus: "ready" as const,
+        },
+        materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
+        selectedSnapshot: snapshot,
+        selectedTimelineTick: snapshot.tick_count,
+        snapshot,
+        workOutcomeHydrationStatus: "ready" as const,
+      };
+    },
+  ),
 }));
 
 vi.mock("../../bento/hooks/useDashboardLayout", async () => {
@@ -153,7 +164,16 @@ vi.mock("../../trace-drilldown/hooks/useTraceDrilldown", () => ({
 }));
 
 vi.mock("../../work-outcome/hooks/useWorkOutcomeChart", () => ({
-  useWorkOutcomeChart: () => ({ status: "empty" as const }),
+  useWorkOutcomeChart: () => ({
+    chartState: { status: "ready" as const },
+    delta: { completed: 0, failed: 0, inFlight: 0, queued: 0 },
+    failureGroups: [],
+    points: [],
+    rangeID: "session" as const,
+    rangeLabel: "Session",
+    samples: [],
+    series: [],
+  }),
 }));
 
 vi.mock(

--- a/ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.test.tsx
+++ b/ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.test.tsx
@@ -6,7 +6,10 @@ import {
   CURRENT_FACTORY_DEFINITION_QUERY_KEY,
   CURRENT_FACTORY_DOCUMENT_QUERY_KEY,
 } from "../../../current-factory-definition/hooks/useCurrentFactoryDefinition";
-import { useDashboardStreamStore } from "../../state/dashboardStreamStore";
+import {
+  getDashboardStreamStateForSession,
+  useDashboardStreamStore,
+} from "../../state/dashboardStreamStore";
 import { useFactoryEventStream } from "./useFactoryEventStream";
 import {
   CANONICAL_SELECTED_TICK_EVENTS,
@@ -246,6 +249,80 @@ describe("useFactoryEventStream transport", () => {
     await waitFor(() => {
       expect(replayHarness.getStreams()).toHaveLength(2);
     });
+  });
+
+  it("rejects late events and status callbacks from a previous session target", async () => {
+    const receivedEvents: string[] = [];
+    const { rerender } = renderHook(
+      ({ sessionID }: { sessionID: string }) =>
+        useFactoryEventStream({
+          enabled: true,
+          onEvents: (events) => {
+            receivedEvents.push(...events.map((event) => event.id));
+          },
+          onEvent: () => {},
+          sessionID,
+        }),
+      {
+        initialProps: { sessionID: "session-a" },
+        wrapper: createFactoryEventStreamTestWrapper(queryClient),
+      },
+    );
+
+    await waitFor(() => {
+      expect(replayHarness.getStreams()).toHaveLength(1);
+    });
+    const sessionAStream = replayHarness.getStreams()[0];
+    if (!sessionAStream) {
+      throw new Error("expected session A stream to be opened");
+    }
+
+    act(() => {
+      sessionAStream.emit("message", {
+        ...CANONICAL_SELECTED_TICK_EVENTS[0],
+        id: "session-a-queued-before-switch",
+      });
+      rerender({ sessionID: "session-b" });
+    });
+
+    await waitFor(() => {
+      expect(replayHarness.getStreams()).toHaveLength(2);
+    });
+    const sessionBStream = replayHarness.getStreams()[1];
+    if (!sessionBStream) {
+      throw new Error("expected session B stream to be opened");
+    }
+
+    act(() => {
+      sessionAStream.emit("message", {
+        ...CANONICAL_SELECTED_TICK_EVENTS[0],
+        id: "session-a-late",
+      });
+      sessionAStream.onerror?.(new Event("late-session-a-error"));
+      sessionBStream.emitOpen();
+    });
+
+    const stateBeforeSessionBEvent = useDashboardStreamStore.getState();
+    expect(
+      getDashboardStreamStateForSession(
+        "session-b",
+        stateBeforeSessionBEvent.sessionStreamStates,
+        stateBeforeSessionBEvent.sessionStreamStateKeysBySessionID,
+      ),
+    ).toMatchObject({ status: "live" });
+    expect(receivedEvents).toEqual([]);
+
+    await act(async () => {
+      sessionBStream.emit("message", {
+        ...CANONICAL_SELECTED_TICK_EVENTS[0],
+        id: "session-b-current",
+      });
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, 20);
+      });
+    });
+
+    expect(receivedEvents).toEqual(["session-b-current"]);
   });
 
   it("does not open a stream when sessionID is null", () => {

--- a/ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.test.tsx
+++ b/ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.test.tsx
@@ -312,17 +312,16 @@ describe("useFactoryEventStream transport", () => {
     ).toMatchObject({ status: "live" });
     expect(receivedEvents).toEqual([]);
 
-    await act(async () => {
+    act(() => {
       sessionBStream.emit("message", {
         ...CANONICAL_SELECTED_TICK_EVENTS[0],
         id: "session-b-current",
       });
-      await new Promise<void>((resolve) => {
-        window.setTimeout(resolve, 20);
-      });
     });
 
-    expect(receivedEvents).toEqual(["session-b-current"]);
+    await waitFor(() => {
+      expect(receivedEvents).toEqual(["session-b-current"]);
+    });
   });
 
   it("does not open a stream when sessionID is null", () => {

--- a/ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.ts
+++ b/ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.ts
@@ -61,10 +61,11 @@ export interface UseFactoryEventStreamOptions {
 }
 
 interface DashboardStreamConnectionOptions {
+  isCurrentStreamTarget: (targetKey: string) => boolean;
   debugOptions: ReturnType<typeof readFactoryTimelineDebugOptions>;
   enabled: boolean;
   flushHandleRef: RefObject<number | null>;
-  flushQueuedEvents: () => void;
+  flushQueuedEvents: (expectedTargetKey?: string) => void;
   initialReconnectCursor?: FactoryEventReconnectCursor;
   initialCursorFreeReplayCorrelationToken?: string | null;
   locale?: string | null;
@@ -75,7 +76,7 @@ interface DashboardStreamConnectionOptions {
   queuedEventsRef: RefObject<FactoryEvent[]>;
   refreshToken: number;
   resetTimeline: () => void;
-  scheduleQueuedFlush: () => void;
+  scheduleQueuedFlush: (targetKey: string) => void;
   sessionID: string | null;
   setStreamState: (
     streamState: ReturnType<
@@ -84,6 +85,7 @@ interface DashboardStreamConnectionOptions {
   ) => void;
   streamIdentity: StreamDerivedCacheIdentity | null;
   streamSessionID: string;
+  streamTargetKey: string;
   validateReconnectCursor: (
     sessionID?: string | null,
     reconnect?: FactoryEventReconnectCursor,
@@ -192,6 +194,7 @@ function useDashboardStreamConnection({
   flushQueuedEvents,
   initialReconnectCursor,
   initialCursorFreeReplayCorrelationToken,
+  isCurrentStreamTarget,
   locale,
   onInvalidReconnectCursor,
   openStream,
@@ -205,6 +208,7 @@ function useDashboardStreamConnection({
   setStreamState,
   streamIdentity,
   streamSessionID,
+  streamTargetKey,
   validateReconnectCursor,
 }: DashboardStreamConnectionOptions) {
   const refs = useDashboardStreamConnectionRefs();
@@ -212,6 +216,19 @@ function useDashboardStreamConnection({
 
   // biome-ignore lint/complexity/noExcessiveLinesPerFunction: the effect owns one stream lifecycle with coordinated reconnect paths.
   useEffect(() => {
+    const capturedStreamTargetKey = streamTargetKey;
+    const disposed = { current: false };
+    const isActive = () =>
+      !disposed.current && isCurrentStreamTarget(capturedStreamTargetKey);
+    const applyStreamState = (
+      streamState: Parameters<
+        DashboardStreamConnectionOptions["setStreamState"]
+      >[0],
+    ) => {
+      if (isActive()) {
+        setStreamState(streamState);
+      }
+    };
     const sessionKey = dashboardSessionKey(sessionID, refreshToken);
     const previousSessionKey = refs.lastSessionKeyRef.current;
     const sessionSelectionChanged = sessionKey !== previousSessionKey;
@@ -225,14 +242,16 @@ function useDashboardStreamConnection({
         queuedEventsRef,
         refreshToken,
         sessionID,
-        setStreamState,
+        setStreamState: applyStreamState,
       })
     ) {
       return;
     }
 
-    const disposed = { current: false };
     const handleStreamEvent = (event: FactoryEvent) => {
+      if (!isActive()) {
+        return;
+      }
       refs.cursorFreeReplayPendingRef.current = false;
       refs.staleCursorRecoveryAttemptedRef.current = false;
       invalidReconnectRecoveryUsedRef.current = false;
@@ -246,10 +265,13 @@ function useDashboardStreamConnection({
       queuedEventsRef.current.push(
         compactFactoryEventForTimeline(event, debugOptions),
       );
-      scheduleQueuedFlush();
+      scheduleQueuedFlush(capturedStreamTargetKey);
     };
 
     const openDashboardStream = (reconnect?: FactoryEventReconnectCursor) => {
+      if (!isActive()) {
+        return;
+      }
       const validationAttempt = ++refs.reconnectValidationAttemptRef.current;
       void (async () => {
         if (reconnect != null) {
@@ -258,6 +280,7 @@ function useDashboardStreamConnection({
             reconnect,
           );
           if (
+            !isActive() ||
             validationAttempt !== refs.reconnectValidationAttemptRef.current
           ) {
             return;
@@ -281,7 +304,7 @@ function useDashboardStreamConnection({
               openDashboardStream(undefined);
               return;
             }
-            setStreamState({
+            applyStreamState({
               message: validation.message,
               status: "offline",
             });
@@ -289,13 +312,13 @@ function useDashboardStreamConnection({
           }
         }
 
-        if (disposed.current) {
+        if (!isActive()) {
           return;
         }
         refs.streamRef.current?.close();
         const stream = openStream(
           handleStreamEvent,
-          (status, message) => setStreamState({ status, message }),
+          (status, message) => applyStreamState({ status, message }),
           streamSessionID,
           reconnect,
         );
@@ -313,16 +336,22 @@ function useDashboardStreamConnection({
         }
         const previousOnOpen = stream.onopen;
         stream.onopen = (openEvent) => {
+          if (!isActive()) {
+            return;
+          }
           refs.cursorFreeReplayPendingRef.current = false;
           previousOnOpen?.call(stream, openEvent);
         };
         const previousOnError = stream.onerror;
         stream.onerror = (errorEvent) => {
+          if (!isActive()) {
+            return;
+          }
           previousOnError?.call(stream, errorEvent);
           if (refs.cursorFreeReplayPendingRef.current) {
             refs.cursorFreeReplayPendingRef.current = false;
             refs.recoveringRef.current = false;
-            setStreamState(recoveryFailedStreamState(locale));
+            applyStreamState(recoveryFailedStreamState(locale));
             return;
           }
           const cursor = refs.reconnectCursorRef.current;
@@ -344,7 +373,7 @@ function useDashboardStreamConnection({
             queuedEventsRef,
             refs,
             resetTimeline,
-            setStreamState,
+            setStreamState: applyStreamState,
             streamIdentity,
             streamSessionID,
           });
@@ -363,11 +392,18 @@ function useDashboardStreamConnection({
     invalidReconnectRecoveryUsedRef.current = false;
     openDashboardStream(initialReconnectCursor);
     return () => {
+      const targetRemainsCurrent = isCurrentStreamTarget(
+        capturedStreamTargetKey,
+      );
       disposed.current = true;
       refs.reconnectValidationAttemptRef.current += 1;
       clearReconnectTimeout(refs.reconnectTimeoutRef);
       clearQueuedFlush(flushHandleRef);
-      flushQueuedEvents();
+      if (targetRemainsCurrent) {
+        flushQueuedEvents(capturedStreamTargetKey);
+      } else {
+        queuedEventsRef.current = [];
+      }
       refs.streamRef.current?.close();
       refs.streamRef.current = null;
     };
@@ -378,6 +414,7 @@ function useDashboardStreamConnection({
     flushQueuedEvents,
     initialReconnectCursor,
     initialCursorFreeReplayCorrelationToken,
+    isCurrentStreamTarget,
     locale,
     onInvalidReconnectCursor,
     openStream,
@@ -392,10 +429,12 @@ function useDashboardStreamConnection({
     setStreamState,
     streamIdentity,
     streamSessionID,
+    streamTargetKey,
     validateReconnectCursor,
   ]);
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: stream target identity and queued delivery wiring stay together at the hook boundary.
 export function useFactoryEventStream({
   enabled,
   initialReconnectCursor,
@@ -434,6 +473,29 @@ export function useFactoryEventStream({
     () => resolveStreamSessionID(sessionID, streamIdentity),
     [sessionID, streamIdentity],
   );
+  const streamTargetKey = useMemo(
+    () =>
+      JSON.stringify([
+        sessionAliasID?.trim() ?? "",
+        streamSessionID,
+        refreshToken,
+        streamIdentity
+          ? [
+              streamIdentity.backendScopeID,
+              streamIdentity.factorySessionID,
+              streamIdentity.logicalSessionKeyID,
+              streamIdentity.streamGenerationID,
+            ]
+          : null,
+      ]),
+    [refreshToken, sessionAliasID, streamIdentity, streamSessionID],
+  );
+  const streamTargetKeyRef = useRef(streamTargetKey);
+  streamTargetKeyRef.current = streamTargetKey;
+  const isCurrentStreamTarget = useCallback(
+    (targetKey: string) => streamTargetKeyRef.current === targetKey,
+    [],
+  );
   const setStreamState = useCallback(
     (
       streamState: ReturnType<
@@ -460,36 +522,51 @@ export function useFactoryEventStream({
     [sessionAliasID, setSessionStreamState, streamIdentity, streamSessionID],
   );
 
-  const flushQueuedEvents = useCallback(() => {
-    flushHandleRef.current = null;
-    if (queuedEventsRef.current.length === 0) {
-      return;
-    }
-    const events = queuedEventsRef.current;
-    queuedEventsRef.current = [];
-    if (onEvents) {
-      onEvents(events);
-      return;
-    }
-    for (const event of events) {
-      onEvent(event);
-    }
-  }, [onEvent, onEvents]);
+  const flushQueuedEvents = useCallback(
+    (expectedTargetKey?: string) => {
+      if (
+        expectedTargetKey != null &&
+        !isCurrentStreamTarget(expectedTargetKey)
+      ) {
+        return;
+      }
+      flushHandleRef.current = null;
+      if (queuedEventsRef.current.length === 0) {
+        return;
+      }
+      const events = queuedEventsRef.current;
+      queuedEventsRef.current = [];
+      if (onEvents) {
+        onEvents(events);
+        return;
+      }
+      for (const event of events) {
+        onEvent(event);
+      }
+    },
+    [isCurrentStreamTarget, onEvent, onEvents],
+  );
 
-  const scheduleQueuedFlush = useCallback(() => {
-    if (flushHandleRef.current !== null) {
-      return;
-    }
-    if (typeof window.requestAnimationFrame === "function") {
-      flushHandleRef.current = window.requestAnimationFrame(() => {
-        flushQueuedEvents();
-      });
-      return;
-    }
-    flushHandleRef.current = window.setTimeout(() => {
-      flushQueuedEvents();
-    }, 16);
-  }, [flushQueuedEvents]);
+  const scheduleQueuedFlush = useCallback(
+    (expectedTargetKey: string) => {
+      if (!isCurrentStreamTarget(expectedTargetKey)) {
+        return;
+      }
+      if (flushHandleRef.current !== null) {
+        return;
+      }
+      if (typeof window.requestAnimationFrame === "function") {
+        flushHandleRef.current = window.requestAnimationFrame(() => {
+          flushQueuedEvents(expectedTargetKey);
+        });
+        return;
+      }
+      flushHandleRef.current = window.setTimeout(() => {
+        flushQueuedEvents(expectedTargetKey);
+      }, 16);
+    },
+    [flushQueuedEvents, isCurrentStreamTarget],
+  );
 
   useEffect(() => {
     return () => {
@@ -504,6 +581,7 @@ export function useFactoryEventStream({
     flushQueuedEvents,
     initialReconnectCursor,
     initialCursorFreeReplayCorrelationToken,
+    isCurrentStreamTarget,
     locale,
     onInvalidReconnectCursor,
     openStream,
@@ -517,6 +595,7 @@ export function useFactoryEventStream({
     setStreamState,
     streamIdentity,
     streamSessionID,
+    streamTargetKey,
     validateReconnectCursor,
   });
 }

--- a/ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.ts
+++ b/ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.ts
@@ -51,6 +51,7 @@ export interface UseFactoryEventStreamOptions {
   openStream?: typeof openFactoryEventStream;
   probeRecovery?: typeof probeFactoryEventStreamRecovery;
   refreshToken?: number;
+  sessionAliasID?: string | null;
   sessionID: string | null;
   streamIdentity?: StreamDerivedCacheIdentity | null;
   validateReconnectCursor?: (
@@ -103,6 +104,22 @@ function resolveStreamSessionID(
   return isDefaultFactorySessionID(sessionID)
     ? DEFAULT_FACTORY_SESSION_ID
     : sessionID;
+}
+
+function streamIdentityBelongsToSession(
+  streamIdentity: StreamDerivedCacheIdentity | null,
+  streamSessionID: string,
+  sessionAliasID: string | null,
+): boolean {
+  if (!streamIdentity || streamIdentity.factorySessionID !== streamSessionID) {
+    return streamIdentity == null;
+  }
+  const normalizedAlias = sessionAliasID?.trim() ?? "";
+  return (
+    normalizedAlias.length === 0 ||
+    normalizedAlias === streamSessionID ||
+    isDefaultFactorySessionID(normalizedAlias)
+  );
 }
 
 function reconnectCursorFromEvent(
@@ -390,6 +407,7 @@ export function useFactoryEventStream({
   openStream = openFactoryEventStream,
   probeRecovery = probeFactoryEventStreamRecovery,
   refreshToken = 0,
+  sessionAliasID,
   sessionID,
   streamIdentity = null,
   validateReconnectCursor = validateFactoryEventReconnectCursor,
@@ -406,8 +424,8 @@ export function useFactoryEventStream({
     }
     resetAllTimelines();
   }, [resetAllTimelines, resetTimelineEntry, streamIdentity]);
-  const setStreamState = useDashboardStreamStore(
-    (state) => state.setStreamState,
+  const setSessionStreamState = useDashboardStreamStore(
+    (state) => state.setSessionStreamState,
   );
   const queuedEventsRef = useRef<FactoryEvent[]>([]);
   const flushHandleRef = useRef<number | null>(null);
@@ -415,6 +433,31 @@ export function useFactoryEventStream({
   const streamSessionID = useMemo(
     () => resolveStreamSessionID(sessionID, streamIdentity),
     [sessionID, streamIdentity],
+  );
+  const setStreamState = useCallback(
+    (
+      streamState: ReturnType<
+        typeof useDashboardStreamStore.getState
+      >["streamState"],
+    ) => {
+      const streamStateSessionID = sessionAliasID ?? streamSessionID;
+      const ownedStreamIdentity = streamIdentityBelongsToSession(
+        streamIdentity,
+        streamSessionID,
+        sessionAliasID ?? null,
+      )
+        ? streamIdentity
+        : null;
+      setSessionStreamState(
+        streamStateSessionID,
+        ownedStreamIdentity,
+        streamState,
+        sessionAliasID && sessionAliasID !== streamStateSessionID
+          ? [sessionAliasID]
+          : undefined,
+      );
+    },
+    [sessionAliasID, setSessionStreamState, streamIdentity, streamSessionID],
   );
 
   const flushQueuedEvents = useCallback(() => {

--- a/ui/src/features/dashboard/hooks/preflight/use-dashboard-checkpoint-preflight.ts
+++ b/ui/src/features/dashboard/hooks/preflight/use-dashboard-checkpoint-preflight.ts
@@ -3,12 +3,12 @@ import { useEffect, useRef, useState } from "react";
 
 import type { DashboardStreamState } from "../../../../api/dashboard/types";
 import type { FactoryEventReconnectCursor } from "../../../../api/events";
+import { deletePersistedTimelineCheckpoint } from "../../../timeline/state/checkpoint-persistence/deletePersistedTimelineCheckpoint";
+import type { FactoryTimelineCheckpoint } from "../../../timeline/state/timeline/storeState";
 import {
   clearTimelineCheckpointsForSession,
   type TimelineCheckpointStreamIdentity,
 } from "../../../timeline/state/timelineCheckpointPersistence";
-import { deletePersistedTimelineCheckpoint } from "../../../timeline/state/checkpoint-persistence/deletePersistedTimelineCheckpoint";
-import type { FactoryTimelineCheckpoint } from "../../../timeline/state/timeline/storeState";
 import {
   isDefaultToRuntimeSessionAliasRemap,
   recoverDashboardSessionScopedState,
@@ -72,6 +72,11 @@ interface DashboardCheckpointPreflightCoreOptions
   effects?: DashboardCheckpointPreflightEffects;
   queryClient: QueryClient;
   remapSelectedSessionID: (sessionID: string) => void;
+  setSessionStreamState?: (
+    sessionID: string,
+    streamIdentity: TimelineCheckpointStreamIdentity | null,
+    streamState: DashboardStreamState,
+  ) => void;
   setStreamState: (streamState: DashboardStreamState) => void;
 }
 
@@ -162,10 +167,14 @@ export function useDashboardCheckpointPreflight(
   const setStreamState = useDashboardStreamStore(
     (state) => state.setStreamState,
   );
+  const setSessionStreamState = useDashboardStreamStore(
+    (state) => state.setSessionStreamState,
+  );
   return useDashboardCheckpointPreflightCore({
     ...options,
     queryClient,
     remapSelectedSessionID,
+    setSessionStreamState,
     setStreamState,
   });
 }
@@ -179,6 +188,7 @@ export function useDashboardCheckpointPreflightCore({
   rawSessionID,
   remapSelectedSessionID,
   restoreCheckpoint,
+  setSessionStreamState,
   setStreamState,
 }: DashboardCheckpointPreflightCoreOptions): UseDashboardCheckpointPreflightResult {
   const [checkpointHydratedKey, setCheckpointHydratedKey] = useState<
@@ -296,10 +306,16 @@ export function useDashboardCheckpointPreflightCore({
 
       if (resolution.kind === "error") {
         setPreflightError(resolution.error);
-        setStreamState({
+        const streamState = {
           message: resolution.error.message,
           status: "offline",
-        });
+        } as const;
+        setStreamState(streamState);
+        setSessionStreamState?.(
+          resolution.requestedSessionId,
+          null,
+          streamState,
+        );
         return;
       }
       if (resolution.kind === "recovery") {
@@ -360,6 +376,7 @@ export function useDashboardCheckpointPreflightCore({
     rawSessionID,
     remapSelectedSessionID,
     restoreCheckpoint,
+    setSessionStreamState,
     setStreamState,
   ]);
 

--- a/ui/src/features/dashboard/hooks/useDashboardSessionLifecycle.ts
+++ b/ui/src/features/dashboard/hooks/useDashboardSessionLifecycle.ts
@@ -24,8 +24,8 @@ export function useDashboardSessionLifecycle({
 }: UseDashboardSessionLifecycleOptions) {
   const queryClient = useQueryClient();
   const resetTimeline = useFactoryTimelineStore((state) => state.reset);
-  const resetStreamState = useDashboardStreamStore(
-    (state) => state.resetStreamState,
+  const resetSessionStreamState = useDashboardStreamStore(
+    (state) => state.resetSessionStreamState,
   );
   const backendRuntimeCacheScope = useDashboardStreamStore(
     (state) => state.backendRuntimeCacheScope,
@@ -42,13 +42,15 @@ export function useDashboardSessionLifecycle({
     (factoryDefinitionQueryResetMode: FactoryDefinitionQueryResetMode) => {
       resetDashboardSessionScopedState(
         queryClient,
-        resetStreamState,
+        (nextLocale) => {
+          resetSessionStreamState(sessionID, nextLocale);
+        },
         resetTimeline,
         locale,
         factoryDefinitionQueryResetMode,
       );
     },
-    [locale, queryClient, resetStreamState, resetTimeline],
+    [locale, queryClient, resetSessionStreamState, resetTimeline, sessionID],
   );
 
   useEffect(() => {

--- a/ui/src/features/dashboard/hooks/useDashboardSnapshot.isolated.bun.component.test.tsx
+++ b/ui/src/features/dashboard/hooks/useDashboardSnapshot.isolated.bun.component.test.tsx
@@ -1,14 +1,8 @@
 import "../../../testing/vitest-dom-capabilities.setup";
 
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-} from "bun:test";
 import type { PropsWithChildren } from "react";
 
 import type { DashboardSnapshot } from "../../../api/dashboard/types";
@@ -61,6 +55,36 @@ const RESOLVED_DEFAULT_SESSION_UUID = DEFAULT_RUNTIME_FACTORY_SESSION_ID;
 const STALE_FACTORY_SESSION_UUID = "66666666-6666-4666-8666-666666666666";
 const BETA_FACTORY_SESSION_UUID = "77777777-7777-4777-8777-777777777777";
 const REMAPPED_FACTORY_SESSION_UUID = "88888888-8888-4888-8888-888888888888";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function factoryStateEvent(id: string, state: string, tick: number) {
+  return {
+    context: {
+      eventTime: `2026-07-01T12:00:0${tick}Z`,
+      sequence: tick,
+      tick,
+    },
+    id,
+    payload: {
+      previousState: "IDLE",
+      reason: "session isolation test",
+      state,
+    },
+    type: FACTORY_EVENT_TYPES.factoryStateResponse,
+  };
+}
 
 function defaultStreamIdentity(
   factorySessionID = RESOLVED_DEFAULT_SESSION_UUID,
@@ -425,6 +449,108 @@ describe("useDashboardSnapshot composer", () => {
         defaultStreamIdentity("session-beta"),
       );
     });
+  });
+
+  it("keeps a selected session stable when its predecessor resolves late", async () => {
+    const sessionA =
+      createDeferred<factorySessionsAPI.FactorySessionSyncPreflightResponse>();
+    const sessionB =
+      createDeferred<factorySessionsAPI.FactorySessionSyncPreflightResponse>();
+    useDashboardSessionStore.setState({
+      pausedSessionIDs: [],
+      selectedSessionID: "session-a",
+    });
+    getFactorySessionSyncPreflightSpy.mockImplementation((sessionID) => {
+      if (sessionID === "session-a") {
+        return sessionA.promise;
+      }
+      return sessionB.promise;
+    });
+
+    const { result } = renderHook(() => useDashboardSnapshot(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(getFactorySessionSyncPreflightSpy).toHaveBeenCalledWith(
+        "session-a",
+        undefined,
+        { signal: expect.any(AbortSignal) },
+      );
+    });
+
+    act(() => {
+      useDashboardSessionStore.getState().setSelectedSessionID("session-b");
+    });
+    await waitFor(() => {
+      expect(getFactorySessionSyncPreflightSpy).toHaveBeenCalledWith(
+        "session-b",
+        undefined,
+        { signal: expect.any(AbortSignal) },
+      );
+    });
+
+    await act(async () => {
+      sessionB.resolve(
+        buildSyncPreflightResponse({
+          factorySessionId: "session-b",
+          logicalSessionKeyId: "logical-session-b",
+          requestedSessionId: "session-b",
+          streamGenerationId: "generation-session-b",
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(result.current.workOutcomeStreamIdentity).toEqual({
+        backendScopeID: DEFAULT_BACKEND_SCOPE_ID,
+        factorySessionID: "session-b",
+        logicalSessionKeyID: "logical-session-b",
+        streamGenerationID: "generation-session-b",
+      });
+      expect(replayHarness.getStreams()).toHaveLength(1);
+    });
+
+    const sessionBStream = replayHarness.getStreams()[0];
+    if (!sessionBStream) {
+      throw new Error("expected session B stream to be opened");
+    }
+    act(() => {
+      sessionBStream.emitOpen();
+      sessionBStream.emit(
+        "message",
+        factoryStateEvent("session-b-live", "RUNNING", 1),
+      );
+    });
+    await waitFor(() => {
+      expect(result.current.snapshot?.factory_state).toBe("RUNNING");
+    });
+    const sessionBEventIDs = useFactoryTimelineStore
+      .getState()
+      .events.map((event) => event.id);
+
+    await act(async () => {
+      sessionA.resolve(
+        buildSyncPreflightResponse({
+          factorySessionId: "session-a",
+          logicalSessionKeyId: "logical-session-a",
+          requestedSessionId: "session-a",
+          streamGenerationId: "generation-session-a",
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(result.current.workOutcomeStreamIdentity).toEqual({
+      backendScopeID: DEFAULT_BACKEND_SCOPE_ID,
+      factorySessionID: "session-b",
+      logicalSessionKeyID: "logical-session-b",
+      streamGenerationID: "generation-session-b",
+    });
+    expect(result.current.snapshot?.factory_state).toBe("RUNNING");
+    expect(
+      useFactoryTimelineStore.getState().events.map((event) => event.id),
+    ).toEqual(sessionBEventIDs);
+    expect(replayHarness.getStreams()).toHaveLength(1);
   });
 
   it("routes streamed events through the composer into timeline state", async () => {

--- a/ui/src/features/dashboard/hooks/useDashboardSnapshot.ts
+++ b/ui/src/features/dashboard/hooks/useDashboardSnapshot.ts
@@ -40,6 +40,32 @@ export interface DashboardSnapshotResult {
 
 type DashboardPreflightStatus = "loading" | "non-recoverable" | "success";
 
+function dashboardSnapshotTargetKey({
+  effectiveSessionID,
+  rawSessionID,
+  refreshToken,
+  streamIdentity,
+}: {
+  effectiveSessionID: string | null;
+  rawSessionID: string | null;
+  refreshToken: number;
+  streamIdentity: TimelineCheckpointStreamIdentity | null;
+}): string {
+  return JSON.stringify([
+    rawSessionID?.trim() ?? "",
+    effectiveSessionID?.trim() ?? "",
+    refreshToken,
+    streamIdentity
+      ? [
+          streamIdentity.backendScopeID,
+          streamIdentity.factorySessionID,
+          streamIdentity.logicalSessionKeyID,
+          streamIdentity.streamGenerationID,
+        ]
+      : null,
+  ]);
+}
+
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: snapshot composition keeps preflight, checkpoint hydration, and stream wiring in one hook.
 export function useDashboardSnapshot({
   locale,
@@ -115,6 +141,18 @@ export function useDashboardSnapshot({
   }, [activateTimelineEntry, streamIdentity]);
 
   const effectiveSessionID = resolvedSessionID ?? rawSessionID;
+  const snapshotTargetKey = useMemo(
+    () =>
+      dashboardSnapshotTargetKey({
+        effectiveSessionID,
+        rawSessionID,
+        refreshToken,
+        streamIdentity,
+      }),
+    [effectiveSessionID, rawSessionID, refreshToken, streamIdentity],
+  );
+  const snapshotTargetKeyRef = useRef(snapshotTargetKey);
+  snapshotTargetKeyRef.current = snapshotTargetKey;
 
   if (
     resolvedSessionID != null &&
@@ -162,12 +200,15 @@ export function useDashboardSnapshot({
   );
 
   const handleInvalidReconnectCursor = useCallback(() => {
+    if (snapshotTargetKeyRef.current !== snapshotTargetKey) {
+      return;
+    }
     reconnectCursorInvalidatedRef.current = true;
     if (streamIdentity) {
       resetTimelineEntry(streamIdentity);
     }
     void clearTimelineCheckpoint(window.indexedDB, streamIdentity);
-  }, [resetTimelineEntry, streamIdentity]);
+  }, [resetTimelineEntry, snapshotTargetKey, streamIdentity]);
 
   const checkpointSyncIdentity = useMemo(() => {
     if (
@@ -199,6 +240,9 @@ export function useDashboardSnapshot({
 
   const appendStreamEvents = useCallback(
     (events: FactoryEvent[]) => {
+      if (snapshotTargetKeyRef.current !== snapshotTargetKey) {
+        return;
+      }
       if (streamIdentity) {
         appendEventsForEntry(streamIdentity, events);
         return;
@@ -211,6 +255,7 @@ export function useDashboardSnapshot({
       appendEvents,
       appendEventsForEntry,
       debugOptions.disableTimelineCheckpoint,
+      snapshotTargetKey,
       streamIdentity,
     ],
   );

--- a/ui/src/features/dashboard/hooks/useDashboardSnapshot.ts
+++ b/ui/src/features/dashboard/hooks/useDashboardSnapshot.ts
@@ -2,11 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { FactoryEvent } from "../../../api/events";
 import { DEFAULT_FACTORY_SESSION_ID } from "../../../api/session-routing";
+import { readFactoryTimelineDebugOptions } from "../../timeline/state/factoryTimelineDebug";
 import {
   type FactoryTimelineCheckpoint,
   useFactoryTimelineStore,
 } from "../../timeline/state/factoryTimelineStore";
-import { readFactoryTimelineDebugOptions } from "../../timeline/state/factoryTimelineDebug";
 import {
   clearTimelineCheckpoint,
   type TimelineCheckpointStreamIdentity,
@@ -236,6 +236,7 @@ export function useDashboardSnapshot({
     onEvents: appendStreamEvents,
     onInvalidReconnectCursor: handleInvalidReconnectCursor,
     refreshToken,
+    sessionAliasID: rawSessionID,
     sessionID: effectiveSessionID,
     streamIdentity,
   });

--- a/ui/src/features/dashboard/lib/dashboard-card-state.bun.unit.test.ts
+++ b/ui/src/features/dashboard/lib/dashboard-card-state.bun.unit.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "bun:test";
+
+import type { DashboardCardStateContext } from "./dashboard-card-state";
+import {
+  dashboardSnapshotHasRecords,
+  resolveDashboardCardAsyncState,
+  resolveDashboardCardContentState,
+} from "./dashboard-card-state";
+
+const liveContext: DashboardCardStateContext = {
+  hasAuthoritativeSnapshot: true,
+  recoveryPending: false,
+  streamStatus: "live",
+  timelineMode: "current",
+};
+
+describe("dashboard card async projection", () => {
+  it("keeps loading separate from an authoritative known-empty input", () => {
+    expect(
+      resolveDashboardCardContentState({
+        authoritative: false,
+        hasRecords: false,
+      }),
+    ).toBe("loading");
+    expect(
+      resolveDashboardCardContentState({
+        authoritative: true,
+        hasRecords: false,
+      }),
+    ).toBe("known-empty");
+    expect(
+      resolveDashboardCardContentState({
+        authoritative: true,
+        hasRecords: true,
+      }),
+    ).toBe("populated");
+  });
+
+  it("distinguishes known-empty, reconnecting, and stale card states", () => {
+    expect(
+      resolveDashboardCardAsyncState({
+        ...liveContext,
+        content: "known-empty",
+      }),
+    ).toEqual({
+      content: "known-empty",
+      freshness: "fresh",
+      temporal: "live",
+    });
+
+    expect(
+      resolveDashboardCardAsyncState({
+        ...liveContext,
+        content: "populated",
+        streamStatus: "reconnecting",
+      }).freshness,
+    ).toBe("reconnecting");
+
+    expect(
+      resolveDashboardCardAsyncState({
+        ...liveContext,
+        content: "known-empty",
+        streamStatus: "reconnecting",
+      }),
+    ).toMatchObject({ content: "loading", freshness: "reconnecting" });
+
+    expect(
+      resolveDashboardCardAsyncState({
+        ...liveContext,
+        content: "populated",
+        streamStatus: "offline",
+      }).freshness,
+    ).toBe("stale");
+
+    expect(
+      resolveDashboardCardAsyncState({
+        ...liveContext,
+        content: "known-empty",
+        streamStatus: "offline",
+      }),
+    ).toMatchObject({ content: "error", freshness: "failed" });
+  });
+
+  it("reports checkpoint recovery and historical temporal mode separately", () => {
+    expect(
+      resolveDashboardCardAsyncState({
+        ...liveContext,
+        content: "populated",
+        recoveryPending: true,
+        streamStatus: "connecting",
+      }).freshness,
+    ).toBe("recovering");
+
+    expect(
+      resolveDashboardCardAsyncState({
+        ...liveContext,
+        content: "populated",
+        timelineMode: "fixed",
+      }).temporal,
+    ).toBe("historical");
+  });
+
+  it("uses session runtime data as the work totals authority", () => {
+    expect(
+      dashboardSnapshotHasRecords({
+        factory_state: "IDLE",
+        runtime: {
+          in_flight_dispatch_count: 0,
+          session: {
+            completed_count: 0,
+            dispatched_count: 0,
+            failed_count: 0,
+            has_data: false,
+          },
+        },
+        tick_count: 0,
+        topology: {
+          edges: [],
+          submit_work_types: [],
+          workstation_node_ids: [],
+          workstation_nodes_by_id: {},
+        },
+        uptime_seconds: 0,
+      }),
+    ).toBe(false);
+  });
+});

--- a/ui/src/features/dashboard/lib/dashboard-card-state.ts
+++ b/ui/src/features/dashboard/lib/dashboard-card-state.ts
@@ -1,0 +1,148 @@
+import type {
+  DashboardSnapshot,
+  DashboardStreamState,
+} from "../../../api/dashboard/types";
+import type { FactoryTimelineMode } from "../../timeline/state/timeline/storeState";
+
+export type DashboardCardContentState =
+  | "error"
+  | "known-empty"
+  | "loading"
+  | "populated";
+
+export type DashboardCardFreshnessState =
+  | "failed"
+  | "fresh"
+  | "reconnecting"
+  | "recovering"
+  | "stale";
+
+export type DashboardCardTemporalState = "historical" | "live";
+
+export interface DashboardCardAsyncState {
+  content: DashboardCardContentState;
+  freshness: DashboardCardFreshnessState;
+  temporal: DashboardCardTemporalState;
+}
+
+export interface DashboardCardStateContext {
+  hasAuthoritativeSnapshot: boolean;
+  recoveryPending: boolean;
+  streamStatus: DashboardStreamState["status"];
+  timelineMode: FactoryTimelineMode;
+}
+
+export interface DashboardCardContentInput {
+  authoritative: boolean;
+  error?: boolean;
+  hasRecords: boolean;
+  loading?: boolean;
+}
+
+export interface DashboardCardAsyncStateInput
+  extends DashboardCardStateContext {
+  content: DashboardCardContentState;
+  hasRetainedData?: boolean;
+}
+
+/**
+ * A card can report known-empty only after its own authoritative input has
+ * completed. This keeps an empty replay or chart from masquerading as a
+ * loaded zero while session or generation hydration is still pending.
+ */
+export function resolveDashboardCardContentState({
+  authoritative,
+  error = false,
+  hasRecords,
+  loading = false,
+}: DashboardCardContentInput): DashboardCardContentState {
+  if (error) {
+    return "error";
+  }
+  if (!authoritative || loading) {
+    return "loading";
+  }
+  return hasRecords ? "populated" : "known-empty";
+}
+
+export function resolveDashboardCardAsyncState({
+  content,
+  hasRetainedData = content === "populated",
+  recoveryPending,
+  streamStatus,
+  timelineMode,
+}: DashboardCardAsyncStateInput): DashboardCardAsyncState {
+  const freshness = resolveDashboardCardFreshness({
+    content,
+    hasRetainedData,
+    recoveryPending,
+    streamStatus,
+  });
+
+  return {
+    content: normalizeDashboardCardContentForFreshness({
+      content,
+      freshness,
+    }),
+    freshness,
+    temporal: timelineMode === "fixed" ? "historical" : "live",
+  };
+}
+
+function normalizeDashboardCardContentForFreshness({
+  content,
+  freshness,
+}: {
+  content: DashboardCardContentState;
+  freshness: DashboardCardFreshnessState;
+}): DashboardCardContentState {
+  if (content !== "known-empty") {
+    return content;
+  }
+  if (freshness === "failed") {
+    return "error";
+  }
+  if (freshness === "reconnecting" || freshness === "recovering") {
+    return "loading";
+  }
+  return content;
+}
+
+function resolveDashboardCardFreshness({
+  content,
+  hasRetainedData,
+  recoveryPending,
+  streamStatus,
+}: {
+  content: DashboardCardContentState;
+  hasRetainedData: boolean;
+  recoveryPending: boolean;
+  streamStatus: DashboardStreamState["status"];
+}): DashboardCardFreshnessState {
+  if (streamStatus === "recovery_failed" || content === "error") {
+    return "failed";
+  }
+  if (streamStatus === "reconnecting") {
+    return "reconnecting";
+  }
+  if (streamStatus === "offline") {
+    return hasRetainedData ? "stale" : "failed";
+  }
+  if (streamStatus === "connecting") {
+    if (recoveryPending) {
+      return "recovering";
+    }
+    return "reconnecting";
+  }
+  return "fresh";
+}
+
+export function dashboardSnapshotHasRecords(
+  snapshot: DashboardSnapshot,
+): boolean {
+  return (
+    snapshot.runtime.session.has_data ||
+    snapshot.runtime.in_flight_dispatch_count > 0 ||
+    (snapshot.runtime.active_dispatch_ids?.length ?? 0) > 0
+  );
+}

--- a/ui/src/features/dashboard/messages/dashboard-card-state.ts
+++ b/ui/src/features/dashboard/messages/dashboard-card-state.ts
@@ -1,0 +1,47 @@
+import {
+  type LocalizedMessageCatalog,
+  resolveLocalizedMessages,
+} from "../../../i18n";
+
+export interface DashboardCardStateMessages {
+  historicalLabel: string;
+  knownEmptyLabel: string;
+  liveLabel: string;
+  loadingLabel: string;
+  recoveringLabel: string;
+  reconnectingLabel: string;
+  staleLabel: string;
+  unavailableLabel: string;
+  statusAriaLabel: (state: string, temporal: string) => string;
+}
+
+const dashboardCardStateMessagesByLocale = {
+  en: {
+    historicalLabel: "Historical",
+    knownEmptyLabel: "No data yet",
+    liveLabel: "Live",
+    loadingLabel: "Loading",
+    recoveringLabel: "Recovering",
+    reconnectingLabel: "Reconnecting",
+    staleLabel: "Stale data",
+    unavailableLabel: "Data unavailable",
+    statusAriaLabel: (state, temporal) => `Card state: ${state}. ${temporal}.`,
+  },
+  "zh-CN": {
+    historicalLabel: "历史",
+    knownEmptyLabel: "暂无数据",
+    liveLabel: "实时",
+    loadingLabel: "加载中",
+    recoveringLabel: "恢复中",
+    reconnectingLabel: "重新连接中",
+    staleLabel: "数据已过期",
+    unavailableLabel: "数据不可用",
+    statusAriaLabel: (state, temporal) => `卡片状态：${state}。${temporal}。`,
+  },
+} satisfies LocalizedMessageCatalog<DashboardCardStateMessages>;
+
+export function getDashboardCardStateMessages(
+  locale?: string | null,
+): DashboardCardStateMessages {
+  return resolveLocalizedMessages(dashboardCardStateMessagesByLocale, locale);
+}

--- a/ui/src/features/dashboard/state/dashboardStreamStore.test.ts
+++ b/ui/src/features/dashboard/state/dashboardStreamStore.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  dashboardStreamStateKey,
+  getDashboardStreamStateForSession,
+  useDashboardStreamStore,
+} from "./dashboardStreamStore";
+
+const sessionAIdentity = {
+  backendScopeID: "backend-a",
+  factorySessionID: "session-a",
+  logicalSessionKeyID: "logical-a",
+  streamGenerationID: "generation-a",
+};
+
+const sessionBIdentity = {
+  backendScopeID: "backend-a",
+  factorySessionID: "session-b",
+  logicalSessionKeyID: "logical-b",
+  streamGenerationID: "generation-b",
+};
+
+describe("useDashboardStreamStore session projections", () => {
+  beforeEach(() => {
+    useDashboardStreamStore.getState().resetStreamState();
+  });
+
+  it("keeps connection state isolated by canonical session and generation", () => {
+    useDashboardStreamStore.getState().setSessionStreamState(
+      "session-a",
+      sessionAIdentity,
+      {
+        message: "Session A is live",
+        status: "live",
+      },
+      ["session-a-alias"],
+    );
+    useDashboardStreamStore
+      .getState()
+      .setSessionStreamState("session-b", sessionBIdentity, {
+        message: "Session B is offline",
+        status: "offline",
+      });
+
+    const state = useDashboardStreamStore.getState();
+    expect(dashboardStreamStateKey("session-a", sessionAIdentity)).toBe(
+      "session-a::generation-a",
+    );
+    expect(
+      getDashboardStreamStateForSession(
+        "session-a-alias",
+        state.sessionStreamStates,
+        state.sessionStreamStateKeysBySessionID,
+      ),
+    ).toMatchObject({ status: "live" });
+    expect(
+      getDashboardStreamStateForSession(
+        "session-b",
+        state.sessionStreamStates,
+        state.sessionStreamStateKeysBySessionID,
+      ),
+    ).toMatchObject({ status: "offline" });
+    expect(
+      state.sessionStreamStates["session-a::generation-a"]?.streamIdentity,
+    ).toEqual(sessionAIdentity);
+  });
+
+  it("advances one session to a new generation without changing its sibling", () => {
+    useDashboardStreamStore
+      .getState()
+      .setSessionStreamState("session-a", sessionAIdentity, {
+        message: "Session A is connecting",
+        status: "connecting",
+      });
+    useDashboardStreamStore
+      .getState()
+      .setSessionStreamState("session-b", sessionBIdentity, {
+        message: "Session B is live",
+        status: "live",
+      });
+
+    const nextSessionAIdentity = {
+      ...sessionAIdentity,
+      streamGenerationID: "generation-a-2",
+    };
+    useDashboardStreamStore
+      .getState()
+      .setSessionStreamState("session-a", nextSessionAIdentity, {
+        message: "Session A is live again",
+        status: "live",
+      });
+
+    const state = useDashboardStreamStore.getState();
+    expect(
+      getDashboardStreamStateForSession(
+        "session-a",
+        state.sessionStreamStates,
+        state.sessionStreamStateKeysBySessionID,
+      ),
+    ).toMatchObject({ status: "live" });
+    expect(
+      getDashboardStreamStateForSession(
+        "session-b",
+        state.sessionStreamStates,
+        state.sessionStreamStateKeysBySessionID,
+      ),
+    ).toMatchObject({ status: "live", message: "Session B is live" });
+    expect(
+      state.sessionStreamStates["session-a::generation-a"]?.streamState.status,
+    ).toBe("connecting");
+  });
+});

--- a/ui/src/features/dashboard/state/dashboardStreamStore.ts
+++ b/ui/src/features/dashboard/state/dashboardStreamStore.ts
@@ -1,20 +1,44 @@
 import { create } from "zustand";
 
 import type { DashboardStreamState } from "../../../api/dashboard/types";
-import type { StreamDerivedCacheIdentity } from "../../timeline/public/stream-identity";
+import {
+  normalizeStreamDerivedCacheIdentity,
+  type StreamDerivedCacheIdentity,
+} from "../../timeline/public/stream-identity";
 import { getDashboardStreamMessages } from "../messages/dashboard-stream";
+
+export interface DashboardSessionStreamProjection {
+  streamIdentity: StreamDerivedCacheIdentity | null;
+  streamState: DashboardStreamState;
+}
+
+export type DashboardSessionStreamProjectionMap = Readonly<
+  Record<string, DashboardSessionStreamProjection>
+>;
 
 interface DashboardStreamStoreState {
   backendRuntimeCacheScope: string | null;
+  resetSessionStreamState: (
+    sessionID: string | null,
+    locale?: string | null,
+  ) => void;
   resetStreamState: (locale?: string | null) => void;
   resolvedStreamIdentity: StreamDerivedCacheIdentity | null;
   setBackendRuntimeCacheScope: (
     backendRuntimeCacheScope: string | null,
   ) => void;
+  setSessionStreamState: (
+    sessionID: string,
+    streamIdentity: StreamDerivedCacheIdentity | null,
+    streamState: DashboardStreamState,
+    sessionAliases?: readonly string[],
+  ) => void;
   setResolvedStreamIdentity: (
     streamIdentity: StreamDerivedCacheIdentity | null,
   ) => void;
   setStreamState: (streamState: DashboardStreamState) => void;
+  sessionStreamStateKeysBySessionID: Readonly<Record<string, string>>;
+  sessionStreamStates: DashboardSessionStreamProjectionMap;
   streamState: DashboardStreamState;
 }
 
@@ -27,13 +51,92 @@ export function createDefaultDashboardStreamState(
   };
 }
 
+export function dashboardStreamStateKey(
+  sessionID: string,
+  streamIdentity?: StreamDerivedCacheIdentity | null,
+): string | null {
+  const normalizedSessionID = sessionID.trim();
+  const normalizedIdentity =
+    normalizeStreamDerivedCacheIdentity(streamIdentity);
+  const canonicalSessionID =
+    normalizedIdentity?.factorySessionID ?? normalizedSessionID;
+  if (canonicalSessionID.length === 0) {
+    return null;
+  }
+  if (!normalizedIdentity) {
+    return canonicalSessionID;
+  }
+  return `${canonicalSessionID}::${normalizedIdentity.streamGenerationID}`;
+}
+
+export function getDashboardStreamStateForSession(
+  sessionID: string,
+  sessionStreamStates: DashboardSessionStreamProjectionMap,
+  sessionStreamStateKeysBySessionID: Readonly<Record<string, string>>,
+  locale?: string | null,
+): DashboardStreamState {
+  const normalizedSessionID = sessionID.trim();
+  const key =
+    sessionStreamStateKeysBySessionID[normalizedSessionID] ??
+    dashboardStreamStateKey(normalizedSessionID);
+  return (
+    (key ? sessionStreamStates[key]?.streamState : undefined) ??
+    createDefaultDashboardStreamState(locale)
+  );
+}
+
 export const useDashboardStreamStore = create<DashboardStreamStoreState>(
   (set) => ({
     backendRuntimeCacheScope: null,
+    resetSessionStreamState: (sessionID, locale) => {
+      const normalizedSessionID = sessionID?.trim() ?? "";
+      set((current) => {
+        if (normalizedSessionID.length === 0) {
+          return {
+            backendRuntimeCacheScope: null,
+            resolvedStreamIdentity: null,
+            streamState: createDefaultDashboardStreamState(locale),
+          };
+        }
+
+        const stateKey =
+          current.sessionStreamStateKeysBySessionID[normalizedSessionID];
+        if (!stateKey) {
+          return {
+            backendRuntimeCacheScope: null,
+            resolvedStreamIdentity: null,
+            streamState: createDefaultDashboardStreamState(locale),
+          };
+        }
+
+        const sessionStreamStates = { ...current.sessionStreamStates };
+        delete sessionStreamStates[stateKey];
+        const sessionStreamStateKeysBySessionID = {
+          ...current.sessionStreamStateKeysBySessionID,
+        };
+        for (const [alias, key] of Object.entries(
+          sessionStreamStateKeysBySessionID,
+        )) {
+          if (key === stateKey) {
+            delete sessionStreamStateKeysBySessionID[alias];
+          }
+        }
+
+        return {
+          backendRuntimeCacheScope: null,
+          resolvedStreamIdentity: null,
+          sessionStreamStateKeysBySessionID,
+          sessionStreamStates,
+          streamState: createDefaultDashboardStreamState(locale),
+        };
+      });
+    },
     resetStreamState: (locale) => {
       set({
         backendRuntimeCacheScope: null,
         resolvedStreamIdentity: null,
+        sessionStreamStateKeysBySessionID: {},
+        sessionStreamStates: {},
         streamState: createDefaultDashboardStreamState(locale),
       });
     },
@@ -41,12 +144,62 @@ export const useDashboardStreamStore = create<DashboardStreamStoreState>(
     setBackendRuntimeCacheScope: (backendRuntimeCacheScope) => {
       set({ backendRuntimeCacheScope });
     },
+    setSessionStreamState: (
+      sessionID,
+      streamIdentity,
+      streamState,
+      sessionAliases = [],
+    ) => {
+      const normalizedSessionID = sessionID.trim();
+      const normalizedIdentity =
+        normalizeStreamDerivedCacheIdentity(streamIdentity);
+      const stateKey = dashboardStreamStateKey(
+        normalizedSessionID,
+        normalizedIdentity,
+      );
+      if (!stateKey) {
+        return;
+      }
+
+      const aliases = new Set(
+        [
+          normalizedSessionID,
+          normalizedIdentity?.factorySessionID,
+          ...sessionAliases.map((alias) => alias.trim()),
+        ].filter((alias): alias is string =>
+          Boolean(alias && alias.length > 0),
+        ),
+      );
+      set((current) => {
+        const sessionStreamStates = {
+          ...current.sessionStreamStates,
+          [stateKey]: {
+            streamIdentity: normalizedIdentity,
+            streamState,
+          },
+        };
+        const sessionStreamStateKeysBySessionID = {
+          ...current.sessionStreamStateKeysBySessionID,
+        };
+        for (const alias of aliases) {
+          sessionStreamStateKeysBySessionID[alias] = stateKey;
+        }
+
+        return {
+          sessionStreamStateKeysBySessionID,
+          sessionStreamStates,
+          streamState,
+        };
+      });
+    },
     setResolvedStreamIdentity: (streamIdentity) => {
       set({ resolvedStreamIdentity: streamIdentity });
     },
     setStreamState: (streamState) => {
       set({ streamState });
     },
+    sessionStreamStateKeysBySessionID: {},
+    sessionStreamStates: {},
     streamState: createDefaultDashboardStreamState(),
   }),
 );

--- a/ui/src/features/header/components/dashboard-session-controls.tsx
+++ b/ui/src/features/header/components/dashboard-session-controls.tsx
@@ -1,10 +1,15 @@
 import { DashboardActionButton } from "../../../components/ui/dashboard-action-button";
+import {
+  DashboardStatusPill,
+  type DashboardStatusPillTone,
+} from "../../../components/ui/dashboard-status-pill";
 import { getExportDialogMessages } from "../../export/messages/export-dialog";
 import type { DashboardSessionTabsState } from "../hooks/use-dashboard-session-tabs-state";
 import { sessionStreamToggleLabel } from "../lib/dashboard-session-tabs-utils";
-import { getHeaderControlsMessages } from "../messages/header-controls";
+import { getDashboardSessionControlsMessages } from "../messages/dashboard-session-controls";
 
 interface DashboardSessionControlsProps {
+  factoryLifecycleStatus?: string | null;
   isExportDialogOpen: boolean;
   locale: string;
   onOpenExportDialog: () => void;
@@ -12,6 +17,7 @@ interface DashboardSessionControlsProps {
 }
 
 export function DashboardSessionControls({
+  factoryLifecycleStatus,
   isExportDialogOpen,
   locale,
   onOpenExportDialog,
@@ -19,29 +25,56 @@ export function DashboardSessionControls({
 }: DashboardSessionControlsProps) {
   const activeSession = sessionTabsState.activeSession;
   const exportMessages = getExportDialogMessages(locale);
-  const headerMessages = getHeaderControlsMessages(locale);
+  const sessionControlMessages = getDashboardSessionControlsMessages(locale);
+  const isSessionStreamPaused = activeSession
+    ? sessionTabsState.isSessionStreamPaused(activeSession.id)
+    : false;
+  const streamToggleLabel = activeSession
+    ? sessionStreamToggleLabel(
+        activeSession,
+        isSessionStreamPaused,
+        sessionControlMessages,
+      )
+    : null;
+  const lifecycleStatus = factoryLifecycleStatusLabel(
+    factoryLifecycleStatus,
+    sessionControlMessages,
+  );
 
   return (
     <div className="ml-auto flex shrink-0 items-center gap-1.5">
+      {lifecycleStatus ? (
+        <DashboardStatusPill
+          aria-label={lifecycleStatus.label}
+          role="status"
+          size="compact"
+          tone={lifecycleStatus.tone}
+        >
+          {lifecycleStatus.label}
+        </DashboardStatusPill>
+      ) : null}
+      {isSessionStreamPaused ? (
+        <DashboardStatusPill
+          aria-label={sessionControlMessages.liveDashboardUpdatesPausedLabel}
+          role="status"
+          size="compact"
+          tone="warning"
+        >
+          {sessionControlMessages.liveDashboardUpdatesPausedLabel}
+        </DashboardStatusPill>
+      ) : null}
       {activeSession ? (
         <DashboardActionButton
-          aria-label={sessionStreamToggleLabel(
-            activeSession,
-            sessionTabsState.isSessionStreamPaused(activeSession.id),
-            headerMessages,
-          )}
-          aria-pressed={sessionTabsState.isSessionStreamPaused(
-            activeSession.id,
-          )}
+          aria-label={streamToggleLabel ?? undefined}
+          aria-pressed={isSessionStreamPaused}
           iconOnly
           onClick={() => {
             sessionTabsState.toggleSessionStreamPaused(activeSession.id);
           }}
+          title={streamToggleLabel ?? undefined}
           tone="outline"
         >
-          <SessionStreamToggleIcon
-            paused={sessionTabsState.isSessionStreamPaused(activeSession.id)}
-          />
+          <SessionStreamToggleIcon paused={isSessionStreamPaused} />
         </DashboardActionButton>
       ) : null}
       <DashboardActionButton
@@ -56,6 +89,26 @@ export function DashboardSessionControls({
       </DashboardActionButton>
     </div>
   );
+}
+
+function factoryLifecycleStatusLabel(
+  status: string | null | undefined,
+  messages: ReturnType<typeof getDashboardSessionControlsMessages>,
+): { label: string; tone: DashboardStatusPillTone } | null {
+  switch (status?.trim().toUpperCase()) {
+    case "PAUSED":
+      return {
+        label: messages.factoryLifecyclePausedLabel,
+        tone: "warning",
+      };
+    case "RUNNING":
+      return {
+        label: messages.factoryLifecycleRunningLabel,
+        tone: "success",
+      };
+    default:
+      return null;
+  }
 }
 
 function ExportButtonIcon() {

--- a/ui/src/features/header/components/dashboard-session-tab.test.tsx
+++ b/ui/src/features/header/components/dashboard-session-tab.test.tsx
@@ -29,6 +29,10 @@ describe("DashboardSessionTab controls", () => {
         onClose={() => undefined}
         onKeyDown={() => undefined}
         session={session()}
+        streamState={{
+          message: "Factory event stream is live",
+          status: "live",
+        }}
         streamStatus="live"
         tabID="tab-root"
       />,
@@ -65,6 +69,10 @@ describe("DashboardSessionTab controls", () => {
           project: "beta",
           target: { kind: "named", name: "beta" },
         })}
+        streamState={{
+          message: "Factory event stream is offline",
+          status: "offline",
+        }}
         streamStatus="offline"
         tabID="tab-beta"
       />,

--- a/ui/src/features/header/components/dashboard-session-tab.tsx
+++ b/ui/src/features/header/components/dashboard-session-tab.tsx
@@ -85,7 +85,7 @@ export function SessionTabButton({
   onDrop,
   onKeyDown,
   session,
-  streamStatus,
+  streamState,
   tabID,
 }: {
   active: boolean;
@@ -104,11 +104,12 @@ export function SessionTabButton({
   onDrop: (event: ReactDragEvent<HTMLDivElement>) => void;
   onKeyDown: (event: ReactKeyboardEvent<HTMLButtonElement>) => void;
   session: FactorySessionSummary;
-  streamStatus: DashboardStreamState["status"];
+  streamState: DashboardStreamState;
   tabID: string;
 }) {
   const label = sessionTabLabel(session);
   const secondaryPath = sessionTabSecondaryPath(session.folderPath);
+  const streamStatusID = `${tabID}-stream-status`;
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop is attached to the tab shell while the semantic tab control remains the inner button.
     <div
@@ -130,6 +131,7 @@ export function SessionTabButton({
     >
       <button
         aria-controls={controlsID}
+        aria-describedby={streamStatusID}
         aria-label={label}
         aria-selected={active}
         className={cn(
@@ -147,7 +149,11 @@ export function SessionTabButton({
         type="button"
       >
         <span className="flex min-w-0 items-center gap-2">
-          <SessionTabStatusIndicator status={streamStatus} />
+          <SessionTabStatusIndicator
+            id={streamStatusID}
+            message={streamState.message}
+            status={streamState.status}
+          />
           <span className="truncate text-sm font-semibold">{label}</span>
         </span>
         <span
@@ -176,30 +182,41 @@ export function SessionTabButton({
 }
 
 function SessionTabStatusIndicator({
+  id,
+  message,
   status,
 }: {
+  id: string;
+  message: string;
   status: DashboardStreamState["status"];
 }) {
   return (
-    <span aria-hidden="true" className="relative inline-flex size-2.5 shrink-0">
-      {status === "live" ? (
+    <>
+      <span
+        aria-hidden="true"
+        className="relative inline-flex size-2.5 shrink-0"
+      >
+        {status === "live" ? (
+          <span
+            className={cn(
+              "absolute -inset-1 animate-ping rounded-full",
+              "bg-[var(--color-af-session-live-ping)]",
+            )}
+            data-testid="dashboard-session-live-ping"
+          />
+        ) : null}
         <span
           className={cn(
-            "absolute -inset-1 animate-ping rounded-full",
-            "bg-[var(--color-af-session-live-ping)]",
+            "absolute inset-0 rounded-full",
+            status === "live" && "bg-success",
+            (status === "connecting" || status === "reconnecting") &&
+              "bg-primary",
+            (status === "offline" || status === "recovery_failed") &&
+              "bg-error",
           )}
-          data-testid="dashboard-session-live-ping"
         />
-      ) : null}
-      <span
-        className={cn(
-          "absolute inset-0 rounded-full",
-          status === "live" && "bg-success",
-          (status === "connecting" || status === "reconnecting") &&
-            "bg-primary",
-          (status === "offline" || status === "recovery_failed") && "bg-error",
-        )}
-      />
-    </span>
+      </span>
+      <span aria-label={message} className="sr-only" id={id} role="img" />
+    </>
   );
 }

--- a/ui/src/features/header/components/dashboard-session-tabs.isolated.bun.component.test.tsx
+++ b/ui/src/features/header/components/dashboard-session-tabs.isolated.bun.component.test.tsx
@@ -3,7 +3,13 @@
 
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 
 import { FactorySessionsAPIError } from "../../../api/factory-sessions";
 import { DEFAULT_FACTORY_SESSION_ID } from "../../../api/session-routing";
@@ -13,6 +19,7 @@ import {
   factorySessionTargetTarget,
 } from "../../../testing/factory-validation-target-fixtures";
 import { useDashboardSessionStore } from "../../dashboard/state/dashboardSessionStore";
+import { useDashboardStreamStore } from "../../dashboard/state/dashboardStreamStore";
 import {
   SESSION_TAB_PATH_MAX_LENGTH,
   sessionCloseLabel,
@@ -63,6 +70,7 @@ describe("DashboardSessionTabs", () => {
     openFactorySession.mockReset();
     closeFactorySession.mockReset();
     vi.unstubAllGlobals();
+    useDashboardStreamStore.getState().resetStreamState("en");
     useDashboardSessionStore.setState({
       pausedSessionIDs: [],
       selectedSessionID: DEFAULT_FACTORY_SESSION_ID,
@@ -166,6 +174,76 @@ describe("DashboardSessionTabs", () => {
 
     expectSubtleActiveSessionTabShell(sessionTabShell(betaTab));
     expectMutedInactiveSessionTabShell(sessionTabShell(rootTab));
+  });
+
+  it("renders each session tab's own connection projection", async () => {
+    listFactorySessions.mockResolvedValue([
+      {
+        factoryDir: "/workspace/root",
+        folderPath: "/workspace/root",
+        id: "session-root",
+        isDefault: true,
+        project: "root",
+        target: {
+          kind: "default",
+        },
+      },
+      {
+        factoryDir: "/workspace/root/beta",
+        folderPath: "/workspace/root",
+        id: "session-beta",
+        isDefault: false,
+        project: "beta",
+        target: {
+          kind: "named",
+          name: "beta",
+        },
+      },
+    ]);
+    useDashboardStreamStore
+      .getState()
+      .setSessionStreamState("session-root", null, {
+        message: "Root event stream is live",
+        status: "live",
+      });
+    useDashboardStreamStore
+      .getState()
+      .setSessionStreamState("session-beta", null, {
+        message: "Beta event stream is offline",
+        status: "offline",
+      });
+
+    renderWithQueryClient(<DashboardSessionTabs locale="en" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "root" })).toBeTruthy();
+      expect(screen.getByRole("tab", { name: "beta" })).toBeTruthy();
+    });
+
+    expect(
+      screen.getByRole("img", { name: "Root event stream is live" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("img", { name: "Beta event stream is offline" }),
+    ).toBeTruthy();
+
+    act(() => {
+      useDashboardStreamStore
+        .getState()
+        .setSessionStreamState("session-beta", null, {
+          message: "Beta event stream is reconnecting",
+          status: "reconnecting",
+        });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("img", { name: "Beta event stream is reconnecting" }),
+      ).toBeTruthy();
+    });
+    expect(
+      screen.getByRole("img", { name: "Root event stream is live" }),
+    ).toBeTruthy();
   });
 
   it("supports keyboard navigation across session tabs with roving tab focus", async () => {

--- a/ui/src/features/header/components/dashboard-session-tabs.isolated.bun.component.test.tsx
+++ b/ui/src/features/header/components/dashboard-session-tabs.isolated.bun.component.test.tsx
@@ -12,13 +12,15 @@ import {
 } from "@testing-library/react";
 
 import { FactorySessionsAPIError } from "../../../api/factory-sessions";
-import { DEFAULT_FACTORY_SESSION_ID } from "../../../api/session-routing";
 import { bunVi as vi } from "../../../testing/bun/vi-compat";
 import {
   factorySessionFieldTarget,
   factorySessionTargetTarget,
 } from "../../../testing/factory-validation-target-fixtures";
-import { useDashboardSessionStore } from "../../dashboard/state/dashboardSessionStore";
+import {
+  resetDashboardSessionStore,
+  useDashboardSessionStore,
+} from "../../dashboard/state/dashboardSessionStore";
 import { useDashboardStreamStore } from "../../dashboard/state/dashboardStreamStore";
 import {
   SESSION_TAB_PATH_MAX_LENGTH,
@@ -71,10 +73,7 @@ describe("DashboardSessionTabs", () => {
     closeFactorySession.mockReset();
     vi.unstubAllGlobals();
     useDashboardStreamStore.getState().resetStreamState("en");
-    useDashboardSessionStore.setState({
-      pausedSessionIDs: [],
-      selectedSessionID: DEFAULT_FACTORY_SESSION_ID,
-    });
+    resetDashboardSessionStore();
   });
 
   it("renders loading and then the active session tabs", async () => {

--- a/ui/src/features/header/components/dashboard-session-tabs.tsx
+++ b/ui/src/features/header/components/dashboard-session-tabs.tsx
@@ -2,6 +2,7 @@ import { Dialog } from "@you-agent-factory/components/overlays";
 import { Button, Text } from "@you-agent-factory/components/primitives";
 import {
   type DragEvent as ReactDragEvent,
+  useCallback,
   useId,
   useRef,
   useState,
@@ -9,7 +10,10 @@ import {
 import type { DashboardStreamState } from "../../../api/dashboard/types";
 import type { FactorySessionSummary } from "../../../api/factory-sessions";
 import { AlertPanel } from "../../../components/ui/alert-panel";
-import { useDashboardStreamStore } from "../../dashboard/state/dashboardStreamStore";
+import {
+  getDashboardStreamStateForSession,
+  useDashboardStreamStore,
+} from "../../dashboard/state/dashboardStreamStore";
 import { useDashboardSessionTabFocus } from "../hooks/use-dashboard-session-tab-focus";
 import {
   type DashboardSessionTabsState,
@@ -41,6 +45,26 @@ export function DashboardSessionTabs({
   return <DashboardSessionTabsView locale={locale} state={sessionTabsState} />;
 }
 
+function useDashboardStreamStateForSession(locale: string) {
+  const sessionStreamStates = useDashboardStreamStore(
+    (storeState) => storeState.sessionStreamStates,
+  );
+  const sessionStreamStateKeysBySessionID = useDashboardStreamStore(
+    (storeState) => storeState.sessionStreamStateKeysBySessionID,
+  );
+
+  return useCallback(
+    (sessionID: string) =>
+      getDashboardStreamStateForSession(
+        sessionID,
+        sessionStreamStates,
+        sessionStreamStateKeysBySessionID,
+        locale,
+      ),
+    [locale, sessionStreamStateKeysBySessionID, sessionStreamStates],
+  );
+}
+
 function DashboardSessionTabsView({
   locale,
   state,
@@ -50,9 +74,7 @@ function DashboardSessionTabsView({
 }) {
   const messages = getHeaderControlsMessages(locale);
   const dialogTriggerRef = useRef<HTMLButtonElement | null>(null);
-  const streamStatus = useDashboardStreamStore(
-    (storeState) => storeState.streamState.status,
-  );
+  const streamStateForSession = useDashboardStreamStateForSession(locale);
   const {
     activeSession,
     closeError,
@@ -115,7 +137,7 @@ function DashboardSessionTabsView({
             onReorderSession={moveSessionTab}
             onSelectSession={setActiveSessionID}
             sessions={sessions}
-            streamStatus={streamStatus}
+            streamStateForSession={streamStateForSession}
           />
         </div>
         {completedJourney ? (
@@ -184,7 +206,7 @@ function SessionTabsContent({
   onRetry,
   onSelectSession,
   sessions,
-  streamStatus,
+  streamStateForSession,
 }: {
   activeSession: FactorySessionSummary | null;
   closingSessionID: string | null;
@@ -199,7 +221,7 @@ function SessionTabsContent({
   onRetry: () => void;
   onSelectSession: (sessionID: string) => void;
   sessions: FactorySessionSummary[];
-  streamStatus: DashboardStreamState["status"];
+  streamStateForSession: (sessionID: string) => DashboardStreamState;
 }) {
   const sessionTabsID = useId();
   const [draggedSessionID, setDraggedSessionID] = useState<string | null>(null);
@@ -384,7 +406,7 @@ function SessionTabsContent({
                 onCloseSession(session.id);
               }}
               session={session}
-              streamStatus={streamStatus}
+              streamState={streamStateForSession(session.id)}
               tabID={sessionTabID(sessionTabsID, session.id)}
             />
           ))}

--- a/ui/src/features/header/components/tick-slider-control.test.tsx
+++ b/ui/src/features/header/components/tick-slider-control.test.tsx
@@ -127,6 +127,9 @@ describe("TickSliderControl", () => {
 
     expect(slider.value).toBe("9");
     expect(statusText).toBeTruthy();
+    expect(
+      screen.getByRole("status", { name: "Timeline mode: Live" }),
+    ).toBeTruthy();
     expect(slider.getAttribute("aria-describedby")).toBe(statusText.id);
     expect(slider.getAttribute("aria-valuetext")).toBe("9/9");
     expect(sliderShell?.className).toContain("gap-1.5");
@@ -150,6 +153,9 @@ describe("TickSliderControl", () => {
 
     await waitFor(() => {
       expect(screen.getByText("2/9")).toBeTruthy();
+      expect(
+        screen.getByRole("status", { name: "Timeline mode: Historical" }),
+      ).toBeTruthy();
     });
     expect(slider.getAttribute("aria-valuetext")).toBe("2/9");
     expect(useFactoryTimelineStore.getState().mode).toBe("fixed");
@@ -159,6 +165,9 @@ describe("TickSliderControl", () => {
 
     await waitFor(() => {
       expect(screen.getByText("9/9")).toBeTruthy();
+      expect(
+        screen.getByRole("status", { name: "Timeline mode: Live" }),
+      ).toBeTruthy();
     });
     expect(useFactoryTimelineStore.getState().mode).toBe("current");
     expect(useFactoryTimelineStore.getState().selectedTick).toBe(9);

--- a/ui/src/features/header/components/tick-slider-control.tsx
+++ b/ui/src/features/header/components/tick-slider-control.tsx
@@ -1,6 +1,8 @@
 import { type ChangeEvent, useId, useMemo } from "react";
+import { DashboardStatusPill } from "../../../components/ui/dashboard-status-pill";
 import { cn } from "../../../lib/cn";
 import { useFactoryTimelineStore } from "../../timeline/state/factoryTimelineStore";
+import { getDashboardSessionControlsMessages } from "../messages/dashboard-session-controls";
 import {
   getHeaderControlsMessages,
   HEADER_CURRENT_TICK_TOKEN,
@@ -68,6 +70,7 @@ export function TickSliderControl({ locale }: TickSliderControlProps) {
     Object.keys(state.worldViewCache),
   );
   const latestTick = useFactoryTimelineStore((state) => state.latestTick);
+  const mode = useFactoryTimelineStore((state) => state.mode);
   const selectTick = useFactoryTimelineStore((state) => state.selectTick);
   const selectedTick = useFactoryTimelineStore((state) => state.selectedTick);
   const setCurrentMode = useFactoryTimelineStore(
@@ -85,6 +88,11 @@ export function TickSliderControl({ locale }: TickSliderControlProps) {
     bounds.maxTick,
   );
   const messages = getHeaderControlsMessages(locale);
+  const sessionControlMessages = getDashboardSessionControlsMessages(locale);
+  const isLive = mode === "current";
+  const timelineModeLabel = isLive
+    ? sessionControlMessages.timelineModeLiveLabel
+    : sessionControlMessages.timelineModeHistoricalLabel;
   const sliderValueText = isDisabled
     ? messages.waitingForMoreTicks
     : formatCurrentTickStatus(
@@ -143,7 +151,15 @@ export function TickSliderControl({ locale }: TickSliderControlProps) {
         />
       </label>
 
-      <div className="ml-auto flex items-center">
+      <div className="ml-auto flex items-center gap-2">
+        <DashboardStatusPill
+          aria-label={`${sessionControlMessages.timelineModeLabel}: ${timelineModeLabel}`}
+          role="status"
+          size="compact"
+          tone={isLive ? "success" : "neutral"}
+        >
+          {timelineModeLabel}
+        </DashboardStatusPill>
         <output
           className="whitespace-nowrap text-xs font-medium tabular-nums text-on-surface-variant"
           id={tickStatusID}

--- a/ui/src/features/header/lib/dashboard-session-tabs-utils.ts
+++ b/ui/src/features/header/lib/dashboard-session-tabs-utils.ts
@@ -4,6 +4,7 @@ import {
   type FactorySessionsAPIErrorTarget,
   type FactorySessionTarget,
 } from "../../../api/factory-sessions";
+import type { getDashboardSessionControlsMessages } from "../messages/dashboard-session-controls";
 import type { getHeaderControlsMessages } from "../messages/header-controls";
 
 export const SESSION_TAB_PATH_MAX_LENGTH = 48;
@@ -99,12 +100,12 @@ export function sessionCloseLabel(
 export function sessionStreamToggleLabel(
   session: FactorySessionSummary,
   paused: boolean,
-  messages: ReturnType<typeof getHeaderControlsMessages>,
+  messages: ReturnType<typeof getDashboardSessionControlsMessages>,
 ): string {
   return replaceSessionLabelToken(
     paused
-      ? messages.resumeSessionStreamLabelTemplate
-      : messages.pauseSessionStreamLabelTemplate,
+      ? messages.resumeLiveUpdatesLabelTemplate
+      : messages.pauseLiveUpdatesLabelTemplate,
     session,
   );
 }

--- a/ui/src/features/header/messages/dashboard-session-controls.test.ts
+++ b/ui/src/features/header/messages/dashboard-session-controls.test.ts
@@ -1,0 +1,44 @@
+import { SUPPORTED_LOCALES } from "../../../i18n";
+import {
+  dashboardSessionControlsMessagesByLocale,
+  getDashboardSessionControlsMessages,
+} from "./dashboard-session-controls";
+
+describe("getDashboardSessionControlsMessages", () => {
+  it("supports every dashboard locale", () => {
+    expect(
+      Object.keys(dashboardSessionControlsMessagesByLocale).sort(),
+    ).toEqual([...SUPPORTED_LOCALES].sort());
+  });
+
+  it.each(["en", "ja", "ko", "zh-CN"] as const)(
+    "keeps session state copy and labels available for %s",
+    (locale) => {
+      const messages = getDashboardSessionControlsMessages(locale);
+
+      expect(messages.factoryLifecyclePausedLabel).toBeTruthy();
+      expect(messages.factoryLifecycleRunningLabel).toBeTruthy();
+      expect(messages.liveDashboardUpdatesPausedLabel).toBeTruthy();
+      expect(messages.pauseLiveUpdatesLabelTemplate).toContain(
+        "{{sessionLabel}}",
+      );
+      expect(messages.resumeLiveUpdatesLabelTemplate).toContain(
+        "{{sessionLabel}}",
+      );
+      expect(messages.timelineModeHistoricalLabel).toBeTruthy();
+      expect(messages.timelineModeLabel).toBeTruthy();
+      expect(messages.timelineModeLiveLabel).toBeTruthy();
+    },
+  );
+
+  it("falls back to English for missing or unsupported locales", () => {
+    const defaultMessages = getDashboardSessionControlsMessages("en");
+
+    expect(
+      getDashboardSessionControlsMessages(undefined).timelineModeLabel,
+    ).toBe(defaultMessages.timelineModeLabel);
+    expect(getDashboardSessionControlsMessages("fr").timelineModeLabel).toBe(
+      defaultMessages.timelineModeLabel,
+    );
+  });
+});

--- a/ui/src/features/header/messages/dashboard-session-controls.ts
+++ b/ui/src/features/header/messages/dashboard-session-controls.ts
@@ -1,0 +1,75 @@
+import {
+  type LocalizedMessageCatalog,
+  resolveLocalizedMessages,
+} from "../../../i18n";
+
+export interface DashboardSessionControlsMessages {
+  factoryLifecyclePausedLabel: string;
+  factoryLifecycleRunningLabel: string;
+  liveDashboardUpdatesPausedLabel: string;
+  pauseLiveUpdatesLabelTemplate: string;
+  resumeLiveUpdatesLabelTemplate: string;
+  timelineModeHistoricalLabel: string;
+  timelineModeLabel: string;
+  timelineModeLiveLabel: string;
+}
+
+const dashboardSessionControlsMessagesByLocale = {
+  en: {
+    factoryLifecyclePausedLabel: "Factory Session paused",
+    factoryLifecycleRunningLabel: "Factory Session running",
+    liveDashboardUpdatesPausedLabel: "Live dashboard updates paused",
+    pauseLiveUpdatesLabelTemplate:
+      "Pause live dashboard updates for {{sessionLabel}}",
+    resumeLiveUpdatesLabelTemplate:
+      "Resume live dashboard updates for {{sessionLabel}}",
+    timelineModeHistoricalLabel: "Historical",
+    timelineModeLabel: "Timeline mode",
+    timelineModeLiveLabel: "Live",
+  },
+  ja: {
+    factoryLifecyclePausedLabel: "ファクトリーセッションは一時停止中",
+    factoryLifecycleRunningLabel: "ファクトリーセッションは実行中",
+    liveDashboardUpdatesPausedLabel: "ライブダッシュボード更新を一時停止中",
+    pauseLiveUpdatesLabelTemplate:
+      "{{sessionLabel}} のライブダッシュボード更新を一時停止",
+    resumeLiveUpdatesLabelTemplate:
+      "{{sessionLabel}} のライブダッシュボード更新を再開",
+    timelineModeHistoricalLabel: "履歴",
+    timelineModeLabel: "タイムラインモード",
+    timelineModeLiveLabel: "ライブ",
+  },
+  ko: {
+    factoryLifecyclePausedLabel: "팩토리 세션 일시중지",
+    factoryLifecycleRunningLabel: "팩토리 세션 실행 중",
+    liveDashboardUpdatesPausedLabel: "라이브 대시보드 업데이트 일시중지",
+    pauseLiveUpdatesLabelTemplate:
+      "{{sessionLabel}} 라이브 대시보드 업데이트 일시중지",
+    resumeLiveUpdatesLabelTemplate:
+      "{{sessionLabel}} 라이브 대시보드 업데이트 다시 시작",
+    timelineModeHistoricalLabel: "기록",
+    timelineModeLabel: "타임라인 모드",
+    timelineModeLiveLabel: "라이브",
+  },
+  "zh-CN": {
+    factoryLifecyclePausedLabel: "工厂会话已暂停",
+    factoryLifecycleRunningLabel: "工厂会话运行中",
+    liveDashboardUpdatesPausedLabel: "实时仪表板更新已暂停",
+    pauseLiveUpdatesLabelTemplate: "暂停 {{sessionLabel}} 的实时仪表板更新",
+    resumeLiveUpdatesLabelTemplate: "恢复 {{sessionLabel}} 的实时仪表板更新",
+    timelineModeHistoricalLabel: "历史",
+    timelineModeLabel: "时间线模式",
+    timelineModeLiveLabel: "实时",
+  },
+} satisfies LocalizedMessageCatalog<DashboardSessionControlsMessages>;
+
+export function getDashboardSessionControlsMessages(
+  locale?: string | null,
+): DashboardSessionControlsMessages {
+  return resolveLocalizedMessages(
+    dashboardSessionControlsMessagesByLocale,
+    locale,
+  );
+}
+
+export { dashboardSessionControlsMessagesByLocale };


### PR DESCRIPTION
{
  "project": "Truthful Dashboard Session and Async State",
  "branchName": "ux-p1-truthful-session-and-async-state",
  "description": "Make the dashboard truthfully associate connection state with each Factory Session, distinguish client live-update pause from backend-owned Factory lifecycle pause, label Live versus Historical views, expose card-level known-empty/stale/reconnecting/recovering/historical/live state, and prevent late callbacks from a previously selected session from contaminating the current session without changing backend contracts, graph surfaces, or bento layout persistence.",
  "context": {
    "customerAsk": "Resolve audit probes 1, 3, 24, and 29 by making stream status session-specific, separating client stream pause from Factory lifecycle pause, labeling Live versus Historical views, widening card-level async state to distinguish known-empty, stale, reconnecting, recovering, historical, and live, and proving that a late callback from session A cannot contaminate session B after a switch. Preserve graph/editor surfaces, bento layout persistence, and backend contracts, and rebase onto origin/main before the final implementation push.",
    "problem": "The dashboard projects one active stream status onto every open session tab, presents a client-side live-update pause as though Factory execution may have paused, and collapses materially different async conditions into loading or ready. Customers can therefore mistake another session's connection health, disconnected or stale data, recovery, or historical data for the current live Factory state, and an out-of-order callback can risk crossing a session-selection boundary.",
    "solution": "Use canonical Factory Session identity and stream generation as explicit ownership keys for dashboard async results; maintain per-session connection projections; expose client update pause, backend lifecycle pause, and Live/Historical temporal mode as separate facts; derive content, freshness/transport, and temporal state per card; and reject callback commits whose identity no longer matches their target. Introduce the keyed projection alongside the singleton path, migrate owned consumers, and remove the old path only when deletion is small and mechanical."
  },
  "acceptanceCriteria": [
    "An executed rendered-behavior test opens two sessions with different real connection projections and proves each tab shows only its owning session's status, with no cross-session leakage.",
    "Client stream pause is labeled as pausing or resuming live dashboard updates and never as pausing the Factory; backend-derived Factory lifecycle pause, when available, remains a separate fact or control.",
    "Live and Historical are visibly and accessibly labeled, and rendered tests prove the label follows timeline selection rather than client pause state.",
    "Card projection and rendering distinguish known-empty, stale, reconnecting, recovering, historical, and live, with an executed test distinguishing at least known-empty, reconnecting, and stale on one representative card.",
    "An executed integration test switches session A to B, resolves A's in-flight callback afterward, and proves B's snapshot, connection label, temporal mode, and representative card state remain uncontaminated; the PR description cites file:line and executed test name for each claim and names unexecuted suites as unproven.",
    "Typecheck and focused frontend unit, component, and integration tests pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The implementation/review loop continues until required CI is terminal and passing, every blocking PR conversation is explicitly addressed, merge conflicts and shared-file churn are reconciled, and the PR is actually merged; CI-run evidence is recorded in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "ux-p1-truthful-session-and-async-state-001",
      "title": "Render connection status per session tab",
      "description": "As a customer with multiple Factory Sessions open, I want each tab to show the connection state belonging to that session so I do not mistake one session's health for another's.",
      "acceptanceCriteria": [
        "Session A and session B can hold different connection projections keyed by canonical session identity and stream generation where applicable, and a status update for one does not overwrite the other.",
        "A rendered two-session test gives the sessions different connection states and asserts the correct accessible text or status on each owning tab with no cross-session leakage.",
        "Status meaning is available through text or an accessible name and does not rely on color alone; existing keyboard tab selection, focus, close, and reorder behavior remains intact.",
        "The keyed path is introduced and consumers migrate to it before the shared singleton presentation path is removed; removal occurs in this PR only when small and mechanical.",
        "Direct browser verification covers two open tabs at supported narrow and desktop widths and confirms status remains attached to the owning tab through selection and horizontal overflow.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented keyed canonical-session/generation stream projections and alias lookup in ui/src/features/dashboard/state/dashboardStreamStore.ts:10-187; migrated the dashboard stream hook, preflight error writes, session lifecycle reset, and tab rendering. Rendered coverage is ui/src/features/header/components/dashboard-session-tabs.isolated.bun.component.test.tsx:179-239 (renders each session tab's own connection projection); browser coverage is ui/integration/dashboard-session-tabs.integration.test.mjs:341-430 (two tabs, selection, accessible status, desktop/narrow overflow). Focused typecheck, Biome, store, stream-hook, keyboard-navigation, component, and browser checks pass. Singleton streamState remains as a compatibility mirror while tabs consume keyed projections."
    },
    {
      "id": "ux-p1-truthful-session-and-async-state-002",
      "title": "Separate dashboard update pause from Factory lifecycle and label temporal mode",
      "description": "As a customer inspecting a running Factory, I want pause controls and temporal labels to state exactly what they affect so I never infer that pausing dashboard updates stopped Factory work or that historical data is live.",
      "acceptanceCriteria": [
        "The existing client-side action is named and described as pausing or resuming live dashboard updates for the owning session; its paused state never uses copy or semantics that claim the Factory is paused.",
        "Factory lifecycle pause is displayed or controlled only from existing backend-derived lifecycle facts and operations, remains distinct from client stream pause, and is never inferred from the client pause flag.",
        "Selecting the latest current snapshot renders an accessible Live label, while selecting an earlier timeline tick renders an accessible Historical label; the distinction does not rely on color alone.",
        "Component tests prove client update pause can coexist with a non-paused Factory lifecycle and that Live or Historical labels follow timeline selection rather than the client pause flag.",
        "Pause and resume controls remain semantic, keyboard operable, visibly focused, and use feature-owned localizable copy.",
        "Direct browser verification exercises pause or resume and Live or Historical transitions at narrow and desktop widths without implying Factory execution stopped.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Separated client update pause from backend lifecycle presentation in ui/src/features/header/components/dashboard-session-controls.tsx:19-114; the client action is localized as live dashboard updates and only selected replay snapshot lifecycle_control_status is rendered as Factory Session running/paused via ui/src/features/bento/components/dashboard-bento-cards.tsx:454-460. Live/Historical status is derived from timeline mode in ui/src/features/header/components/tick-slider-control.tsx:88-162, with component assertions in ui/src/features/bento/components/session-controls-widget.test.tsx:67-86 and ui/src/features/header/components/tick-slider-control.test.tsx:127-172. Browser coverage is ui/integration/dashboard-session-tabs.integration.test.mjs:324-432, including keyboard pause/resume and narrow/desktop viewport checks. Passing evidence: bun run tsc; targeted Biome lint; focused dashboard component/unit Vitest runs (11 and 32 tests); focused browser integration (2 tests); and hosted Frontend, Frontend Component, Frontend Browser, Frontend Coverage, and Frontend Storybook checks on PR #2002 head 68100fd7e."
    },
    {
      "id": "ux-p1-truthful-session-and-async-state-003",
      "title": "Expose truthful async state per dashboard card",
      "description": "As a customer reading dashboard cards, I want each card to explain whether its data is empty, stale, reconnecting, recovering, historical, or live so I can judge the state correctly instead of treating every populated or blank card as ready.",
      "acceptanceCriteria": [
        "The dashboard projection carries explicit typed card-level content, freshness or transport, and temporal facts sufficient to represent at least known-empty, stale, reconnecting, recovering, historical, and live without collapsing them to loading or ready.",
        "Known-empty is emitted only after the relevant card input is authoritatively hydrated with no records; it is not used while data is loading, reconnecting, recovering, failed, or awaiting the selected session and generation.",
        "A card with retained last-known data after connection loss renders stale, an active reconnect attempt renders reconnecting, replay or checkpoint restoration renders recovering, an earlier selected tick renders historical, and a current healthy source renders live.",
        "Async state is derived for each card from that card's data dependencies rather than copied from one global dashboard status; explicit loading, empty, recoverable error, and success handling remains available.",
        "Focused projection and rendered component tests distinguish known-empty, reconnecting, and stale for at least one representative card and cover recovering, historical, and live vocabulary.",
        "Status announcements are concise and accessible, do not rely on color alone, and do not obscure the last trustworthy data when stale or reconnecting.",
        "Direct browser verification covers representative empty, degraded, recovery, historical, and live card states at narrow and desktop widths.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented typed card content/freshness/temporal projection in ui/src/features/dashboard/lib/dashboard-card-state.ts:5-142, per-widget dependency resolution in ui/src/features/bento/components/dashboard-bento-cards.tsx:181-326, and accessible localized card banners in ui/src/features/bento/components/card-state/dashboard-card-state-banner.tsx:1-97. Known-empty is gated on authoritative selected-session/generation hydration; reconnecting/recovering normalize empty content to loading; offline retained data is stale; current/fixed timeline mode is live/historical. Projection coverage is ui/src/features/dashboard/lib/dashboard-card-state.bun.unit.test.ts:15-125 (4 Bun tests), rendered vocabulary coverage is ui/src/features/bento/components/card-state/dashboard-card-state-banner.bun.component.test.tsx:7-71 (1 Bun component test), existing DashboardBento coverage is ui/src/features/bento/components/dashboard-bento.test.tsx (8 Vitest tests), and browser coverage is ui/integration/dashboard-session-tabs.integration.test.mjs (3 tests: known-empty/live/historical, retained stale desktop/narrow) plus ui/integration/dashboard-session-recovery.integration.test.mjs (2 recovery viewport tests). Passing evidence: bun run tsc, targeted Biome lint, focused projection/component/DashboardBento tests, focused browser suites, and hosted Frontend, Frontend Component, Frontend Browser, Frontend Coverage, and Frontend Storybook checks on PR #2002 head 68100fd7e. The local complete component execution ran all 152 files and 908 tests without failures but exceeded the Windows wrapper's 150-second budget at 168.62 seconds; the wrapper result is therefore unproven locally."
    },
    {
      "id": "ux-p1-truthful-session-and-async-state-004",
      "title": "Reject late async results from a previously selected session",
      "description": "As a customer switching between Factory Sessions, I want late work from the old session ignored so the newly selected session never displays another session's snapshot or status.",
      "acceptanceCriteria": [
        "Async checkpoint, replay, stream, and materialization callbacks commit results only when their captured session and stream-generation identity still match the target projection they update.",
        "An integration test starts session A with an intentionally unresolved callback, switches to session B, renders B, then resolves A and proves B's snapshot or content, tab connection status, Live or Historical label, and representative card async state do not change to A's values.",
        "The same test proves B can still accept a matching callback after A's late result is rejected, so isolation does not freeze valid updates.",
        "Cancellation or teardown and identity guards are deterministic and do not depend on sleeps or timing padding.",
        "Direct browser verification repeats the A-to-B switch under delayed A data and confirms B remains stable and keyboard navigation remains usable.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Implemented identity-scoped callback commit guards across checkpoint preflight (ui/src/features/dashboard/hooks/preflight/use-dashboard-checkpoint-preflight.ts:224-317), persisted checkpoint scheduling (ui/src/features/dashboard/hooks/checkpoint-lifecycle/usePersistedTimelineCheckpoint.ts:37-142), stream open/reconnect/status/queued delivery and teardown (ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.ts:219-405,476-568), and materialized timeline append/reconnect recovery (ui/src/features/dashboard/hooks/useDashboardSnapshot.ts:144-281). Deterministic component coverage: 'rejects late events and status callbacks from a previous session target' in ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.test.tsx:254; 'keeps a selected session stable when its predecessor resolves late' in ui/src/features/dashboard/hooks/useDashboardSnapshot.isolated.bun.component.test.tsx:454; existing checkpoint cancellation coverage is in ui/src/features/dashboard/hooks/preflight/use-dashboard-checkpoint-preflight-core.bun.component.test.tsx:353. The matching B stream callback remains accepted in the stream test. Browser coverage: 'keeps the selected beta session stable when alpha stream data arrives late' in ui/integration/dashboard-session-tabs.integration.test.mjs:666, including beta tab status, Live/Historical keyboard navigation, representative card state, and delayed alpha SSE release. Review follow-up also fixed the stale DashboardBento hook double in ui/src/features/dashboard/components/dashboard-screen.single-scroll.test.tsx:60-112 by supplying a typed complete ReturnType<typeof useDashboardBentoSnapshot> result, including dashboardCardStateContext and workOutcomeHydrationStatus; its regression test passes. Passing evidence: bun run tsc; targeted Biome lint; 27 focused stream/snapshot component tests; 17 preflight/checkpoint component tests; 4 focused dashboard-session browser tests; complete component execution with 152 files and 908 passing tests before the local 150-second wrapper budget; and hosted required checks (run 31912575541) all pass on head 68100fd7e. Unexecuted locally: the full repository test suite; merge remains owned by review."
    }
  ],
  "AAAA00_THE_ONLY_CURRENT_OVERRIDE": "OPERATOR OVERRIDE (supersedes any conflicting statement in your payload or this prd).\n\nPUSH YOUR BRANCH AND OPEN YOUR PR NOW, BEFORE YOU WRITE ANY MORE CODE.\n\nOPERATOR-MEASURED, just now, in your worktree:\n\n    commits on your branch ahead of main : 3\n    first commit made                    : 64 minutes ago\n    remote branch (git ls-remote origin) : 0\n    pull request                          : none, in any state\n\nSo 3 commits of finished work exist ONLY on this machine, in this worktree, and have for over an\nhour. Nothing has been pushed. CI has never run on any of it. Review has never seen any of it.\n\nWHY THIS IS URGENT AND NOT A STYLE PREFERENCE.\n\n1. UNPUSHED WORK READS AS NO WORK. The review stage and the operator both judge progress by your pushed\n   head. A lane with local-only commits is indistinguishable from a lane that has done nothing. This\n   repo has already burned a lane on exactly that: 351 lines of real work sat unpushed while review\n   rejected the head twice for being \"unchanged\", and the review circuit breaker counts unchanged-head\n   re-hands - not rejections. Three at identical bytes kills the task token.\n\n2. YOU HAVE NO OPERATOR CHANNEL UNTIL YOU HAVE A PR. PR comments are the ONLY channel that reaches a\n   running session. Without a PR, the operator can only write into this prd.json, which you will not see\n   until your NEXT session. If you get stuck right now, nobody can reach you in time to help.\n\n3. YOU ARE ACCUMULATING UNMEASURED RISK. main moved to 48fd1c7c2 when PR #1978 merged and replaced the\n   provider execution engine. Your 3 commits were written against an older main and have never\n   been compiled, linted, or tested against the current one. The longer you go, the larger the eventual\n   conflict and the less any of your local verification means.\n\n4. IF YOUR SESSION IS KILLED, UNPUSHED WORK IS STRANDED. Sessions end on timeout, on a transient crash,\n   and on the visit breaker. A pushed branch survives all three. A worktree-only commit survives none of\n   them cleanly.\n\nDO THIS NOW, IN THIS ORDER.\n\n    git -C <your worktree> add -A && git -C <your worktree> commit -m \"<message>\"   # if anything is uncommitted\n    git -C <your worktree> fetch origin main\n    git -C <your worktree> rebase origin/main                                       # commit FIRST, never stash\n    git -C <your worktree> push -u origin HEAD\n    gh pr create --fill                                                             # then let CI start\n\nCOMMIT BEFORE YOU REBASE. Never use `git stash` in this repository under any circumstances - the stash\nstack is shared across roughly ten concurrent worktrees and popping it will silently take another lane's\nchanges. If you need to set work aside, move the files with `mv`.\n\nAFTER THE PR IS OPEN: keep pushing as you go, at least once per completed story. Do not batch. Your\nfinish line is \"final head pushed, PR open, CI started, blocking review feedback addressed\" - you do NOT\nown merging, the review stage does. Never commit \"CI evidence\": a new commit changes the head and\ninvalidates the exact run you were trying to record. Put CI evidence in a PR comment.\n\nEXPECT ONE FRONTEND BROWSER FAILURE THAT IS NOT YOURS, AND DO NOT CHASE IT. main itself is currently red\non the Frontend Browser job. The failing spec is\n\n    integration/factory-graph-editor-node-placement.integration.test.mjs\n      > \"persists a manually dragged node position in the saved shared layout\"\n      Error: Timed out waiting for durable checkpoint: save confirmation dialog activation;\n             unsatisfied conditions: dialogPresent (returned false), dialogVisible (returned false)\n\nThe operator has already measured this and it is NOT a flake: a same-head re-run of main at 48fd1c7c2\nfailed a second time on identical bytes. It is also NOT caused by the provider-engine merge - PR #1978\nchanged 432 files and ZERO of them are under ui/, so the dashboard build input is byte-identical to\n9bb9258c8, where this same spec PASSED. It is being tracked as its own lane.\n\nIf that spec is the ONLY browser failure you see, it is inherited - state that explicitly in your PR,\nwith the run ID, rather than letting it read as yours. If ANY OTHER browser spec fails, that one IS\nworth investigating and is probably yours.\n\nDO NOT \"fix\" it, do not skip it, and do not touch\nui/src/features/factory-graph-editor/** save-confirmation code to make your run green. Another lane owns\nit and you would collide.\n\nNOTHING ELSE IN YOUR MISSION CHANGES. Your defect, root cause, non-goals, and evidence rules all still\nstand.\n"
}
