### PR TITLE
docs: assign JSON delivery criteria to stages

### DIFF
--- a/factory/workstations/plan/AGENTS.md
+++ b/factory/workstations/plan/AGENTS.md
@@ -92,15 +92,25 @@ The JSON file must be implementation-ready and contain:
 - `context.customerAsk`
 - `context.problem`
 - `context.solution`
-- `acceptanceCriteria` with 3-7 project-level criteria plus a final quality-gate
-  criterion for typecheck, lint, and tests and a delivery criterion requiring
-  the implementation/review loop to continue until the PR is actually merged.
-  Phrase the lint criterion as "no NEW lint violations relative to current
-  main, and the gates green on main (backend-size, pkg-maint, pkg-file-count,
-  pkg-structure, vet) stay green" — NOT as a blanket "make lint passes":
-  `make lint` cannot pass end-to-end on main while the pkg-boundary target
-  carries pre-existing packaged-service-structure migration debt (recorded
-  2026-08-08), and an unsatisfiable criterion stalls the review loop.
+- `acceptanceCriteria` with 3-7 project-level criteria, a final quality-gate
+  criterion for typecheck, lint, and tests, and a delivery criterion that keeps
+  the lane's implementation/review loop going until the PR is actually merged.
+  The delivery criterion must assign stage ownership explicitly: the
+  implementation stage finishes after its final head is pushed, the PR is open,
+  CI has started, and all blocking review feedback is addressed; the review
+  stage owns driving CI to terminal-and-passing, resolving merge conflicts, and
+  merging the PR. Terminal-and-passing CI, conflict resolution, and merge are
+  review-stage outcomes, not implementation-stage responsibilities, even though
+  merge remains the lane-wide completion boundary. After the implementation
+  finish line, implementation must not poll or re-check CI because every
+  redispatch consumes one of the 12 process visits. Put CI-run evidence in a PR
+  comment and never in a commit. Phrase the lint criterion as "no NEW lint
+  violations relative to current main, and the gates green on main
+  (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green" —
+  NOT as a blanket "make lint passes": `make lint` cannot pass end-to-end on
+  main while the pkg-boundary target carries pre-existing
+  packaged-service-structure migration debt (recorded 2026-08-08), and an
+  unsatisfiable criterion stalls the review loop.
 - `userStories` with sequential  ids, title, description,
   acceptanceCriteria, priority, `passes: false`, and empty `notes`
 - Ids for storeis should be shaped like {{ (index .Inputs 0).Name }}-001, 002, etc. 


### PR DESCRIPTION
{
  "project": "Attribute JSON Delivery Criteria to the Owning Stage",
  "branchName": "thr-plan-json-criterion-orders-lanes-to-loop-until-merged",
  "description": "Correct the plan-workstation instructions so generated JSON plans preserve merge as the lane-wide delivery boundary while assigning implementation completion and review-owned terminal CI and merge to the stages that control them. The change prevents process workers from exhausting their 12 visits by polling CI or waiting for a merge they cannot perform.",
  "context": {
    "customerAsk": "Amend only factory/workstations/plan/AGENTS.md so generated JSON delivery criteria use the same two-stage ownership already required for Markdown plans: implementation stops after final head push, PR open, CI started, and blocking review feedback addressed; review owns terminal CI, conflict resolution, and merge. Prohibit implementation-stage CI polling or re-checking, preserve the existing lint guidance, quote before and after text in the PR description, document alignment with lines 33-42, and state that activation requires a later daemon restart without requesting or performing one.",
    "problem": "The JSON acceptance-criteria instruction currently requires an unattributed implementation/review loop through actual merge. Process workers read prd.json literally but cannot merge, so they repeatedly re-check CI, consume the 12 available process visits, and can fail lanes that already have complete, green PRs. The Markdown guidance in the same prompt already contains the correct stage split, leaving the two output formats inconsistent.",
    "solution": "Replace the ambiguous JSON delivery instruction with explicit stage ownership that mirrors the existing Markdown guidance. Keep merge as the lane-wide completion boundary, make terminal CI and merge review-only outcomes, prohibit implementation-stage CI polling after its finish line, retain CI evidence in PR comments rather than commits, preserve the lint guidance, and align any other conflicting instruction in the same owned prompt without widening scope."
  },
  "acceptanceCriteria": [
    "The plan workstation no longer instructs planners to emit an unattributed JSON criterion that requires the implementation stage to continue until the PR is actually merged.",
    "The JSON delivery-criterion guidance states that implementation finishes when its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed; terminal-and-passing CI, conflict resolution, and merge belong to review and are explicitly not implementation-stage responsibilities, while merge remains the lane-wide completion boundary.",
    "The guidance prohibits implementation-stage polling or re-checking of CI after its finish line because every redispatch consumes one of the 12 process visits, and CI-run evidence is placed in a PR comment and never in a commit.",
    "A sweep of factory/workstations/plan/AGENTS.md leaves no other instruction assigning a review-only outcome to implementation, and the already-correct Markdown Delivery Loop guidance at lines 33-42 remains unchanged and aligned with the JSON guidance.",
    "The PR description quotes the before and after text of the changed bullet, points to lines 33-42 as the matching Markdown contract, and states that the prompt change takes effect only after a daemon restart; no restart is requested or performed because prompts are not hot-reloaded and restart wipes the in-memory board.",
    "The implementation changes only factory/workstations/plan/AGENTS.md; it does not modify factory/factory.json, maxVisits, another workstation prompt, any existing lane prd.json, or unrelated content, and it commits before any rebase without using bare git stash.",
    "Typecheck and relevant tests pass, with no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "The lane-level implementation/review loop continues through actual merge with stage ownership enforced: implementation is complete after final head push, PR open, CI started, and blocking review feedback addressed and must not poll or re-check CI; review owns terminal-and-passing CI, conflict and shared-file reconciliation, and the merge itself, so those outcomes are explicitly not implementation-stage acceptance conditions."
  ],
  "userStories": [
    {
      "id": "thr-plan-json-criterion-orders-lanes-to-loop-until-merged-001",
      "title": "Generate stage-owned JSON delivery criteria",
      "description": "As a process worker consuming a generated prd.json, I want its delivery criterion to stop my stage at the last outcome I control so that review can finish CI and merge without wasting the lane's remaining process visits.",
      "acceptanceCriteria": [
        "The plan-workstation JSON guidance requires generated delivery criteria to identify the implementation finish line as final head pushed, PR open, CI started, and all blocking review feedback addressed.",
        "The same guidance identifies terminal-and-passing CI, conflict resolution, and merge as review-stage responsibilities and explicitly not implementation-stage responsibilities, while preserving merge as the lane-wide completion boundary.",
        "The guidance explicitly prohibits implementation from polling or re-checking CI status after its finish line because every visit consumes one of the 12 process visits.",
        "CI-run evidence is required in a PR comment and is never committed as a progress note.",
        "The surrounding prompt contains no contradictory assignment of terminal CI or merge to implementation, and the existing Markdown Delivery Loop section at lines 33-42 is not rewritten.",
        "The PR description quotes the changed bullet before and after, explains its alignment with lines 33-42, and states that a later daemon restart is required for activation but is neither requested nor performed in this lane.",
        "Only factory/workstations/plan/AGENTS.md changes in the implementation PR; factory/factory.json, maxVisits, other workstation prompts, existing lane prd.json files, and unrelated content remain untouched.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented in factory/workstations/plan/AGENTS.md and committed as f8993ff69. make verify-fast and direct scope/contract checks passed. PR #2006 is open on the final head and required CI has started; review owns terminal CI, conflict resolution, and merge."
    }
  ]
}


## Changed bullet evidence

Before:
~~~text
- `acceptanceCriteria` with 3-7 project-level criteria plus a final quality-gate
  criterion for typecheck, lint, and tests and a delivery criterion requiring
  the implementation/review loop to continue until the PR is actually merged.
  Phrase the lint criterion as "no NEW lint violations relative to current
  main, and the gates green on main (backend-size, pkg-maint, pkg-file-count,
  pkg-structure, vet) stay green" — NOT as a blanket "make lint passes":
  `make lint` cannot pass end-to-end on main while the pkg-boundary target
  carries pre-existing packaged-service-structure migration debt (recorded
  2026-08-08), and an unsatisfiable criterion stalls the review loop.
~~~

After:
~~~text
- `acceptanceCriteria` with 3-7 project-level criteria, a final quality-gate
  criterion for typecheck, lint, and tests, and a delivery criterion that keeps
  the lane's implementation/review loop going until the PR is actually merged.
  The delivery criterion must assign stage ownership explicitly: the
  implementation stage finishes after its final head is pushed, the PR is open,
  CI has started, and all blocking review feedback is addressed; the review
  stage owns driving CI to terminal-and-passing, resolving merge conflicts, and
  merging the PR. Terminal-and-passing CI, conflict resolution, and merge are
  review-stage outcomes, not implementation-stage responsibilities, even though
  merge remains the lane-wide completion boundary. After the implementation
  finish line, implementation must not poll or re-check CI because every
  redispatch consumes one of the 12 process visits. Put CI-run evidence in a PR
  comment and never in a commit. Phrase the lint criterion as "no NEW lint
  violations relative to current main, and the gates green on main
  (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green" —
  NOT as a blanket "make lint passes": `make lint` cannot pass end-to-end on
  main while the pkg-boundary target carries pre-existing
  packaged-service-structure migration debt (recorded 2026-08-08), and an
  unsatisfiable criterion stalls the review loop.
~~~

The after text aligns with the existing Markdown Delivery Loop contract at
factory/workstations/plan/AGENTS.md lines 33-42, which was left unchanged.
Prompt activation requires a later daemon restart; no restart was requested or
performed because prompts are not hot-reloaded and restarting would wipe the
in-memory board.

Validation:
- make verify-fast: dashboard typecheck, MCP contract boundary, 363 UI files
  with 3,040 tests, and the short Go suite passed.
- Direct scope and line-preservation checks passed.