### PR TITLE
thr-session-tab-selection-assert-cannot-identify-the-tab

### DIFF
--- a/ui/scripts/verify-dashboard-session-reconciliation-browser.mjs
+++ b/ui/scripts/verify-dashboard-session-reconciliation-browser.mjs
@@ -1,4 +1,5 @@
 import { chromium } from "playwright";
+import { expect } from "playwright/test";
 
 const storybookURL =
   process.env.AGENT_FACTORY_STORYBOOK_URL ?? "http://127.0.0.1:6008";
@@ -9,14 +10,69 @@ const viewports = [
   { height: 900, label: "desktop", width: 1440 },
 ];
 
-async function waitForSelectedTab(tab, failureMessage) {
+function errorMessage(error) {
+  return error instanceof Error && error.message
+    ? error.message
+    : String(error);
+}
+
+async function accessibleTabName(tab) {
   try {
-    await tab
-      .locator("xpath=..")
-      .getByRole("tab", { selected: true })
-      .waitFor({ state: "visible" });
+    return await tab.evaluate((element) => {
+      const ariaLabel = element.getAttribute("aria-label")?.trim();
+      if (ariaLabel) {
+        return ariaLabel;
+      }
+
+      const textContent = element.textContent?.replace(/\s+/g, " ").trim();
+      return textContent || "(unnamed tab)";
+    });
   } catch {
-    throw new Error(failureMessage);
+    return "(tab name unavailable)";
+  }
+}
+
+async function selectedTabNames(navigation) {
+  try {
+    const selectedTabs = navigation.getByRole("tab", { selected: true });
+    const selectedTabCount = await selectedTabs.count();
+    if (selectedTabCount === 0) {
+      return "(none could be identified)";
+    }
+
+    const names = [];
+    for (let index = 0; index < selectedTabCount; index += 1) {
+      names.push(await accessibleTabName(selectedTabs.nth(index)));
+    }
+    return names.join(", ");
+  } catch {
+    return "(none could be identified)";
+  }
+}
+
+async function waitForFocusedTab(tab, action, viewportLabel) {
+  try {
+    await expect(tab).toBeFocused();
+  } catch (error) {
+    const expectedTabName = await accessibleTabName(tab);
+    throw new Error(
+      `${action} key expected the ${expectedTabName} session tab to be focused before the keypress at ${viewportLabel}. Playwright error: ${errorMessage(error)}`,
+      { cause: error },
+    );
+  }
+}
+
+async function waitForSelectedTab(tab, navigation, action, viewportLabel) {
+  try {
+    await expect(tab).toBeVisible();
+    await expect(tab).toHaveAttribute("aria-selected", "true");
+  } catch (error) {
+    const expectedTabName = await accessibleTabName(tab);
+    const actualSelectedTabNames = await selectedTabNames(navigation);
+    throw new Error(
+      `${action} key did not select the expected ${expectedTabName} session tab at ${viewportLabel}. Actually selected tab: ${actualSelectedTabNames}. Playwright error: ${errorMessage(error)}`,
+      { cause: error },
+    );
   }
 }
 
@@ -68,17 +124,15 @@ async function verifyViewport(browser, viewport) {
     }
 
     const tabs = navigation.getByRole("tab");
-    await tabs.first().focus();
+    const firstTab = tabs.first();
+    const lastTab = tabs.last();
+    await firstTab.focus();
+    await waitForFocusedTab(firstTab, "End", viewport.label);
     await page.keyboard.press("End");
-    await waitForSelectedTab(
-      tabs.last(),
-      `End key did not select the last session at ${viewport.label}.`,
-    );
+    await waitForSelectedTab(lastTab, navigation, "End", viewport.label);
+    await waitForFocusedTab(lastTab, "Home", viewport.label);
     await page.keyboard.press("Home");
-    await waitForSelectedTab(
-      tabs.first(),
-      `Home key did not restore the first session at ${viewport.label}.`,
-    );
+    await waitForSelectedTab(firstTab, navigation, "Home", viewport.label);
 
     await page.getByRole("button", { name: "Fail refresh" }).click();
     await page


### PR DESCRIPTION
{
  "project": "Make the session-tab End/Home browser assertion discriminating and diagnosable",
  "branchName": "thr-session-tab-selection-assert-cannot-identify-the-tab",
  "description": "Correct the intermittent Frontend Storybook dashboard-session reconciliation browser check so End and Home prove the specific expected session tab is selected, focus is confirmed before each keypress, and failures preserve the underlying Playwright error while naming the tab actually selected. Keep the lane confined to ui/scripts/verify-dashboard-session-reconciliation-browser.mjs and prove correctness and stability with intentional negative experiments, mobile and desktop browser verification, wall times, and at least 10 consecutive passing runs.",
  "context": {
    "customerAsk": "Make the existing session reconciliation Storybook browser check stricter and reliable: prove that End selects the last session tab and Home selects the first, confirm focus before dispatching each keyboard command, and retain enough Playwright and selected-tab context to diagnose a future failure. Demonstrate that the corrected assertion discriminates between tabs, run the check at mobile and desktop viewports, and measure at least 10 consecutive successful runs. Change only ui/scripts/verify-dashboard-session-reconciliation-browser.mjs.",
    "problem": "Frontend Storybook failed intermittently on unrelated PR #2006 with 'End key did not select the last session at mobile' even though main passed the same check eight minutes earlier. The helper scopes both first-tab and last-tab assertions to their common parent and accepts any selected sibling, so End and Home cannot identify which tab is selected. It then discards the original Playwright error, and the flow sends keypresses without proving focus survived a refresh-driven tablist re-render.",
    "solution": "Assert aria-selected on the specific expected first or last tab, await that the intended starting tab is the browser's active element before pressing End or Home, and preserve the caught Playwright error while reporting the accessible name of the tab selected at failure time. Demonstrate discrimination with a temporary wrong-tab swap, demonstrate actionable diagnostics with a temporary broken run, revert both experiments, then verify mobile and desktop wall times and at least 10 consecutive complete passes without weakening or quarantining the check."
  },
  "acceptanceCriteria": [
    "End and Home await aria-selected=true on their respective specific expected tabs; the two checks are observably distinguishable and neither can pass merely because some sibling tab is selected.",
    "Before each End or Home keypress, the script awaits proof that the intended starting tab is the browser's focused element; focus loss fails precisely rather than routing the key silently to document.body.",
    "A failed selection assertion retains the underlying Playwright error text or cause and reports the accessible name of the tab actually selected at failure time, including a safe explicit representation when no selected tab can be identified.",
    "PR evidence records that an intentional corrected End-expectation swap to the first tab fails while the pre-fix parent-scoped equivalent passes, and a deliberately broken run reports both the actually selected tab and underlying Playwright error; all temporary breakage is reverted before the final head.",
    "The dashboard session reconciliation check passes at mobile and desktop viewports with wall times reported and then passes at least 10 consecutive complete runs with the pass count reported; the final diff changes only ui/scripts/verify-dashboard-session-reconciliation-browser.mjs and uses no skip, quarantine, allowlist, baseline bump, deleted check, weakened assertion, application change, parity-drag change, shared @xyflow/react test-double change, or other verification-script change.",
    "Quality gate: Typecheck passes, Tests pass, and there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "PROCESS-STAGE FINISH LINE (operator-corrected): this stage is complete when the final head is pushed, the PR is open, CI has STARTED, and all blocking review feedback is addressed. Terminal CI and MERGED are owned by the REVIEW workstation and are explicitly NOT this stage's responsibility. Do not wait for, poll, or re-check CI status - each such visit consumes one of only 12 process visits before executor-loop-breaker kills this lane. CI-run evidence goes in a PR comment, never a commit."
  ],
  "userStories": [
    {
      "id": "thr-session-tab-selection-assert-cannot-identify-the-tab-001",
      "title": "Reliably verify session-tab keyboard selection",
      "description": "As a dashboard maintainer, I want the Storybook browser check to prove the exact tab selected by End and Home and explain failures with focus and selection context so intermittent failures block only for a real, diagnosable regression.",
      "acceptanceCriteria": [
        "After the refreshed session tablist stabilizes, the script awaits that the intended starting tab is the active element before pressing End or Home; a failure identifies which focus expectation was not met.",
        "Pressing End is successful only when the specific last session tab has aria-selected=true, and pressing Home is successful only when the specific first session tab has aria-selected=true.",
        "The selection failure preserves the caught Playwright error through its message and/or cause and includes the accessible name of the currently selected tab, or explicitly states that none could be identified.",
        "An intentional temporary swap of the End expectation from the last tab to the first makes the corrected check fail; PR evidence contrasts this with the pre-fix parent-scoped assertion passing the equivalent swap, and the swap is reverted before the final head.",
        "A deliberately broken temporary run produces an error containing both the actually selected tab's accessible name and the underlying Playwright error text; the breakage is reverted before the final head.",
        "The unchanged keyboard interaction is verified directly in a real browser at mobile and desktop viewports, including End-to-last and Home-to-first behavior and the absence of a skipped, quarantined, or weakened path.",
        "bun run storybook:dashboard-session-reconciliation-check passes at both viewports with wall times recorded, followed by at least 10 consecutive complete passing runs with the pass count recorded in the PR.",
        "Only ui/scripts/verify-dashboard-session-reconciliation-browser.mjs changes; no dashboard application source, parity-drag helper, shared @xyflow/react test double, or other verification script changes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented and verified the one-file browser-check fix. Evidence: corrected End-target swap failed while the described common-parent equivalent passed; a deliberately broken assertion reported the actual selected tab and underlying Playwright matcher error/cause; final mobile and desktop check passed in 1.629s, followed by 10/10 complete passes in 15.994s. Typecheck, 3,048 UI unit tests, 214 Bun unit tests, and full UI lint passed. Temporary experiments were reverted. PR delivery remains subject to review CI and merge."
    }
  ]
}
