### PR TITLE
ux-p4-trace-identity-and-relation-completeness

### DIFF
--- a/ui/scripts/feature-folder-file-count-allowlist.mjs
+++ b/ui/scripts/feature-folder-file-count-allowlist.mjs
@@ -50,7 +50,7 @@ export const allowlistedOversizedFeatureFolders = [
     relativeDirectoryPath: "src/features/trace-drilldown/components",
   },
   {
-    maxFileCount: 14,
+    maxFileCount: 17,
     relativeDirectoryPath: "src/features/trace-drilldown/lib",
   },
   {

--- a/ui/src/api/dashboard/types.ts
+++ b/ui/src/api/dashboard/types.ts
@@ -452,6 +452,7 @@ export interface DashboardTraceMutation {
 }
 
 export interface DashboardTraceDispatch {
+  attempt?: number;
   current_chaining_trace_id?: string;
   dispatch_id: string;
   transition_id: string;

--- a/ui/src/features/bento/components/dashboard-bento.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.tsx
@@ -88,6 +88,7 @@ export function DashboardBento({
     currentSelection.selectedWorkID,
     selectedTraceID,
     resolvedLocale,
+    workOutcomeStream?.identity,
   );
   const providerSessionState =
     useSelectedProviderSessionState(currentSelection);

--- a/ui/src/features/timeline/state/timeline/replayCompletion.ts
+++ b/ui/src/features/timeline/state/timeline/replayCompletion.ts
@@ -169,6 +169,7 @@ export function responseCompletion(
   ]);
 
   return {
+    attempt: latestAttempt?.attempt,
     consumedTokens: active?.consumedTokens ?? [],
     currentChainingTraceID:
       event.context.currentChainingTraceId ??
@@ -280,6 +281,7 @@ export function completionToTraceDispatch(
   completion: WorldCompletion,
 ): DashboardTraceDispatch {
   return {
+    attempt: completion.attempt,
     consumed_tokens: completion.consumedTokens,
     current_chaining_trace_id: completion.currentChainingTraceID,
     diagnostics: completion.diagnostics,

--- a/ui/src/features/timeline/state/timeline/replayWorldStateInference.test.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldStateInference.test.ts
@@ -63,10 +63,10 @@ const initialStructureRequest = factoryEvent(
 );
 
 describe("reconstructWorldState inference success", () => {
-  it("records inference attempts for an active dispatch", () => {
+  it("projects the recorded retry attempt into the completed trace dispatch", () => {
     const workID = "work-inference";
     const dispatchID = "dispatch-inference";
-    const inferenceRequestID = `${dispatchID}/inference-request/1`;
+    const inferenceRequestID = `${dispatchID}/inference-request/2`;
     const events: FactoryEvent[] = [
       initialStructureRequest,
       factoryEvent(
@@ -110,7 +110,7 @@ describe("reconstructWorldState inference success", () => {
         3,
         FACTORY_EVENT_TYPES.inferenceRequest,
         {
-          attempt: 1,
+          attempt: 2,
           inferenceRequestId: inferenceRequestID,
           prompt: "Review the story.",
           workingDirectory: "/work/project",
@@ -127,7 +127,7 @@ describe("reconstructWorldState inference success", () => {
         4,
         FACTORY_EVENT_TYPES.inferenceResponse,
         {
-          attempt: 1,
+          attempt: 2,
           durationMillis: 500,
           inferenceRequestId: inferenceRequestID,
           outcome: "SUCCEEDED",
@@ -139,13 +139,29 @@ describe("reconstructWorldState inference success", () => {
           workIds: [workID],
         },
       ),
+      factoryEvent(
+        "event-dispatch-response",
+        5,
+        FACTORY_EVENT_TYPES.dispatchResponse,
+        {
+          durationMillis: 500,
+          outcome: "SUCCEEDED",
+          transitionId: "review",
+        },
+        {
+          dispatchId: dispatchID,
+          traceIds: [`trace-${workID}`],
+          workIds: [workID],
+        },
+      ),
     ];
 
-    const state = reconstructFactoryReplayState(events, 4);
+    const state = reconstructFactoryReplayState(events, 5);
     const attempt =
       state.inferenceAttemptsByDispatchID[dispatchID]?.[inferenceRequestID];
     expect(attempt).toEqual(
       expect.objectContaining({
+        attempt: 2,
         dispatch_id: dispatchID,
         inference_request_id: inferenceRequestID,
         outcome: "SUCCEEDED",
@@ -162,6 +178,13 @@ describe("reconstructWorldState inference success", () => {
     expect(
       state.textBlobsByID[`inference:${inferenceRequestID}:response`],
     ).toBe("Looks good.");
+    expect(state.tracesByID[`trace-${workID}`]?.dispatches).toEqual([
+      expect.objectContaining({
+        attempt: 2,
+        dispatch_id: dispatchID,
+        work_ids: [workID],
+      }),
+    ]);
   });
 });
 

--- a/ui/src/features/timeline/state/timeline/replayWorldStateSupport.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldStateSupport.ts
@@ -94,6 +94,11 @@ export function syncCompletedDispatchAttempt(
     }
 
     completion.diagnostics = attempt.diagnostics ?? completion.diagnostics;
+    // Inference attempts are authoritative for retry identity. Keep the
+    // highest recorded attempt when responses arrive out of order; a legacy
+    // completion with no inference event remains undefined and uses the
+    // documented UI fallback for old recordings.
+    completion.attempt = Math.max(completion.attempt ?? 0, attempt.attempt);
     completion.providerSession =
       attempt.provider_session ?? completion.providerSession;
 

--- a/ui/src/features/timeline/state/timeline/types.ts
+++ b/ui/src/features/timeline/state/timeline/types.ts
@@ -50,6 +50,7 @@ export interface WorldDispatch {
 }
 
 export interface WorldCompletion extends WorldDispatch {
+  attempt?: number;
   diagnostics?: DashboardWorkDiagnostics;
   durationMillis: number;
   endTime: string;

--- a/ui/src/features/trace-drilldown/components/trace-drilldown-widget.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-drilldown-widget.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { TraceSelectionIdentity } from "../lib/trace-selection";
 import type { TraceGridState } from "./trace-grid-card";
 import { TraceGridBentoCard } from "./trace-grid-card";
 
@@ -6,6 +7,8 @@ export interface TraceDrilldownWidgetProps {
   headerAction?: ReactNode;
   locale?: string;
   onSelectWorkID?: (workID: string) => void;
+  onSelectTraceSelection?: (selection: TraceSelectionIdentity) => void;
+  selectedTraceSelection?: TraceSelectionIdentity | null;
   state: TraceGridState;
   widgetId?: string;
 }
@@ -14,6 +17,8 @@ export function TraceDrilldownWidget({
   headerAction,
   locale,
   onSelectWorkID,
+  onSelectTraceSelection,
+  selectedTraceSelection,
   state,
   widgetId = "trace",
 }: TraceDrilldownWidgetProps) {
@@ -24,6 +29,8 @@ export function TraceDrilldownWidget({
       headerAction={headerAction}
       locale={locale}
       onSelectWorkID={onSelectWorkID}
+      onSelectTraceSelection={onSelectTraceSelection}
+      selectedTraceSelection={selectedTraceSelection}
       state={state}
       widgetId={widgetId}
     />

--- a/ui/src/features/trace-drilldown/components/trace-graph-surfaces.stories.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-graph-surfaces.stories.tsx
@@ -1,6 +1,6 @@
 import "../../../styles.css";
 
-import { expect, within } from "storybook/test";
+import { expect, userEvent, within } from "storybook/test";
 import type {
   DashboardTraceDispatch,
   DashboardWorkItemRef,
@@ -116,11 +116,67 @@ export const UnresolvedLineage = {
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
 
-    await expect(canvas.getByRole("status")).toHaveTextContent(
+    const unresolvedStatus = canvas.getByText(
       "Lineage is unresolved: no recorded relationship connects one or more dispatches, so no predecessor was inferred.",
     );
+    await expect(unresolvedStatus).toBeVisible();
+    await expect(unresolvedStatus).toHaveAttribute("role", "status");
     await expect(
       canvas.getByRole("region", { name: "Dispatch relationship graph" }),
     ).toBeVisible();
+  },
+};
+
+export const TextualRelationFallback = {
+  tags: ["test"],
+  render: () => (
+    <div className="grid gap-4">
+      <TraceWorkstationPath
+        dispatches={TRACE_DISPATCHES}
+        onSelectTraceSelection={() => {}}
+        renderGraph={false}
+      />
+      <TraceRelationFlow
+        onSelectWorkID={() => {}}
+        relations={TRACE_RELATIONS}
+        renderGraph={false}
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const relationPaths = canvas.getAllByRole("region", {
+      name: "Textual relation path",
+    });
+
+    await expect(relationPaths).toHaveLength(2);
+    await expect(
+      canvas.queryByRole("region", { name: "Dispatch relationship graph" }),
+    ).toBeNull();
+    await expect(
+      canvas.queryByRole("region", { name: "Batch relation graph" }),
+    ).toBeNull();
+
+    const dispatchRelationButton = within(relationPaths[0]).getAllByRole(
+      "button",
+    )[0];
+    if (!dispatchRelationButton) {
+      throw new Error("Expected a keyboard-operable dispatch relation.");
+    }
+    dispatchRelationButton.focus();
+    await expect(dispatchRelationButton).toHaveFocus();
+    await userEvent.keyboard("{Enter}");
+
+    const firstBatchRelation = within(relationPaths[1]).getAllByRole(
+      "listitem",
+    )[0];
+    if (!firstBatchRelation) {
+      throw new Error("Expected a textual batch relation.");
+    }
+    const batchRelationButton = within(firstBatchRelation).getByRole("button", {
+      name: "Select work work-implement.",
+    });
+    await userEvent.click(batchRelationButton);
+    await expect(batchRelationButton).toHaveFocus();
   },
 };

--- a/ui/src/features/trace-drilldown/components/trace-graph-surfaces.stories.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-graph-surfaces.stories.tsx
@@ -1,5 +1,6 @@
 import "../../../styles.css";
 
+import { expect, within } from "storybook/test";
 import type {
   DashboardTraceDispatch,
   DashboardWorkItemRef,
@@ -80,6 +81,11 @@ const TRACE_RELATIONS: DashboardWorkRelation[] = [
   },
 ];
 
+const UNRESOLVED_TRACE_DISPATCHES: DashboardTraceDispatch[] = [
+  buildDispatch("dispatch-parallel-a", { workstation_name: "Parallel A" }),
+  buildDispatch("dispatch-parallel-b", { workstation_name: "Parallel B" }),
+];
+
 export default {
   title: "Agent Factory/Dashboard/Trace Graph Surfaces",
 };
@@ -100,4 +106,21 @@ export const LocalizedZhCN = {
       <TraceRelationFlow locale="zh-CN" relations={TRACE_RELATIONS} />
     </div>
   ),
+};
+
+export const UnresolvedLineage = {
+  tags: ["test"],
+  render: () => (
+    <TraceWorkstationPath dispatches={UNRESOLVED_TRACE_DISPATCHES} />
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole("status")).toHaveTextContent(
+      "Lineage is unresolved: no recorded relationship connects one or more dispatches, so no predecessor was inferred.",
+    );
+    await expect(
+      canvas.getByRole("region", { name: "Dispatch relationship graph" }),
+    ).toBeVisible();
+  },
 };

--- a/ui/src/features/trace-drilldown/components/trace-grid-card.replay.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-grid-card.replay.test.tsx
@@ -60,6 +60,7 @@ vi.mock("@xyflow/react", async () => ({
   ) => nodes,
 }));
 
+import type { DashboardTrace } from "../../../api/dashboard/types";
 import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
 import { parseReplayFixtureEvents } from "../../../testing/replay-fixtures";
 import { buildFactoryTimelineSnapshot } from "../../timeline/state/factoryTimelineStore";
@@ -79,6 +80,23 @@ const TRACE_WORKSTATION_PATH_REGRESSION_DISPATCH_IDS = [
   "74d8f3b3-d91b-4bcc-927d-b2643e71bc8a",
   "82d4be6a-68c3-4c94-ad3b-53fd53326015",
 ] as const;
+
+const RELATION_ONLY_TRACE: DashboardTrace = {
+  dispatches: [],
+  relations: [
+    {
+      source_work_id: "work-plan",
+      source_work_name: "Plan story",
+      target_work_id: "work-implement",
+      target_work_name: "Implement story",
+      type: "PARENT_CHILD",
+    },
+  ],
+  trace_id: "trace-relation-only",
+  transition_ids: [],
+  work_ids: ["work-plan", "work-implement"],
+  workstation_sequence: [],
+};
 
 function nodeIDsForFlow(flow: HTMLElement): string[] {
   return JSON.parse(flow.getAttribute("data-node-ids") ?? "[]") as string[];
@@ -140,5 +158,29 @@ describe("TraceGridBentoCard replayed world state", () => {
     expect(within(workstationFlow).getByText("plan")).toBeTruthy();
     expect(within(workstationFlow).getByText("setup-workspace")).toBeTruthy();
     expect(within(workstationFlow).getAllByText("process")).toHaveLength(5);
+  });
+
+  it("renders relation-only traces without the known-empty state", async () => {
+    render(
+      <TraceGridBentoCard
+        state={{ status: "ready", trace: RELATION_ONLY_TRACE }}
+      />,
+    );
+
+    const card = screen.getByRole("article", { name: "Trace drill-down" });
+    await waitFor(() => {
+      expect(
+        within(card).getByRole("region", { name: "Batch relation graph" }),
+      ).toBeTruthy();
+    });
+
+    expect(within(card).getByText("Plan story")).toBeTruthy();
+    expect(within(card).getByText("Implement story")).toBeTruthy();
+    expect(within(card).queryByText("Trace history unavailable")).toBeNull();
+    expect(
+      within(card).queryByText(
+        "No retained dispatch history is currently available for this work item.",
+      ),
+    ).toBeNull();
   });
 });

--- a/ui/src/features/trace-drilldown/components/trace-grid-card.replay.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-grid-card.replay.test.tsx
@@ -176,8 +176,11 @@ describe("TraceGridBentoCard replayed world state", () => {
       ).toBeTruthy();
     });
 
-    expect(within(card).getByText("Plan story")).toBeTruthy();
-    expect(within(card).getByText("Implement story")).toBeTruthy();
+    const relationGraph = within(card).getByRole("region", {
+      name: "Batch relation graph",
+    });
+    expect(within(relationGraph).getByText("Plan story")).toBeTruthy();
+    expect(within(relationGraph).getByText("Implement story")).toBeTruthy();
     expect(within(card).queryByText("Trace history unavailable")).toBeNull();
     expect(
       within(card).queryByText(
@@ -223,8 +226,14 @@ describe("TraceGridBentoCard replayed world state", () => {
       expect(button).toBeTruthy();
       return button;
     });
-    const graphSurface = card.querySelector<HTMLElement>(
-      '[data-trace-selection-surface="graph"]',
+    const graphSurface = [
+      ...card.querySelectorAll<HTMLElement>(
+        '[data-trace-selection-surface="graph"]',
+      ),
+    ].find((candidate) =>
+      candidate
+        .getAttribute("data-trace-selection-keys")
+        ?.includes("dispatch-retry|work-shared|2"),
     );
     if (!graphSurface) {
       throw new Error("Expected a trace graph selection surface.");
@@ -243,6 +252,93 @@ describe("TraceGridBentoCard replayed world state", () => {
     await waitFor(() => {
       expect(dispatchButton.getAttribute("aria-pressed")).toBe("true");
       expect(document.activeElement).toBe(dispatchButton);
+    });
+  });
+
+  it("returns textual relation selection to the matching dispatch graph item", async () => {
+    const trace: DashboardTrace = {
+      dispatches: [
+        {
+          attempt: 1,
+          current_chaining_trace_id: "trace-plan-chain",
+          dispatch_id: "dispatch-plan",
+          duration_millis: 1000,
+          end_time: "2026-05-27T14:15:24.172854+07:00",
+          output_items: [{ work_id: "work-shared" }],
+          outcome: "ACCEPTED",
+          start_time: "2026-05-27T14:13:35.734332+07:00",
+          transition_id: "plan",
+          workstation_name: "Plan",
+        },
+        {
+          attempt: 2,
+          dispatch_id: "dispatch-retry",
+          duration_millis: 1000,
+          end_time: "2026-05-27T14:15:25.614203+07:00",
+          input_items: [{ work_id: "work-shared" }],
+          outcome: "ACCEPTED",
+          start_time: "2026-05-27T14:15:24.183895+07:00",
+          transition_id: "retry",
+          workstation_name: "Retry",
+        },
+      ],
+      relations: [
+        {
+          source_work_id: "work-shared",
+          source_work_name: "Shared work",
+          target_work_id: "work-shared",
+          target_work_name: "Shared work",
+          type: "RETRY",
+        },
+      ],
+      trace_id: "trace-text-selection",
+      transition_ids: ["plan", "retry"],
+      work_ids: ["work-shared"],
+      workstation_sequence: ["Plan", "Retry"],
+    };
+
+    render(<TraceGridBentoCard state={{ status: "ready", trace }} />);
+
+    const card = screen.getByRole("article", { name: "Trace drill-down" });
+    const textPath = await waitFor(() => {
+      const path = within(card)
+        .getAllByRole("region", { name: "Textual relation path" })
+        .find((candidate) =>
+          candidate.querySelector(
+            '[data-trace-relation-id^="work-type-state|"]',
+          ),
+        );
+      expect(path).toBeTruthy();
+      return path;
+    });
+    const textSelectionButtons = within(textPath).getAllByRole("button", {
+      name: "dispatch-retry · Work work-shared · attempt 2",
+    });
+    expect(textSelectionButtons).toHaveLength(2);
+    const textSelectionButton = textSelectionButtons[1];
+    if (!textSelectionButton) {
+      throw new Error("Expected the target relation identity to render.");
+    }
+    const graphSurface = [
+      ...card.querySelectorAll<HTMLElement>(
+        '[data-trace-selection-surface="graph"]',
+      ),
+    ].find((candidate) =>
+      candidate
+        .getAttribute("data-trace-selection-keys")
+        ?.includes("dispatch-retry|work-shared|2"),
+    );
+    if (!graphSurface) {
+      throw new Error("Expected a dispatch graph selection surface.");
+    }
+    const retryGraphButton = within(graphSurface).getByRole("button", {
+      name: "Select Retry workstation",
+    });
+
+    fireEvent.click(textSelectionButton);
+    await waitFor(() => {
+      expect(retryGraphButton.getAttribute("aria-pressed")).toBe("true");
+      expect(document.activeElement).toBe(retryGraphButton);
     });
   });
 });

--- a/ui/src/features/trace-drilldown/components/trace-grid-card.replay.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-grid-card.replay.test.tsx
@@ -1,5 +1,6 @@
 import {
   cleanup,
+  fireEvent,
   render,
   screen,
   waitFor,
@@ -102,6 +103,7 @@ function nodeIDsForFlow(flow: HTMLElement): string[] {
   return JSON.parse(flow.getAttribute("data-node-ids") ?? "[]") as string[];
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Replay coverage keeps the captured trace and bidirectional selection scenario together.
 describe("TraceGridBentoCard replayed world state", () => {
   let restoreBrowserShims: (() => void) | undefined;
 
@@ -182,5 +184,65 @@ describe("TraceGridBentoCard replayed world state", () => {
         "No retained dispatch history is currently available for this work item.",
       ),
     ).toBeNull();
+  });
+
+  it("synchronizes table and graph selection by the full trace identity", async () => {
+    const trace: DashboardTrace = {
+      dispatches: [
+        {
+          attempt: 2,
+          dispatch_id: "dispatch-retry",
+          duration_millis: 1000,
+          end_time: "2026-05-27T14:15:24.172854+07:00",
+          input_items: [
+            {
+              display_name: "Shared work",
+              work_id: "work-shared",
+              work_type_id: "story",
+            },
+          ],
+          outcome: "ACCEPTED",
+          start_time: "2026-05-27T14:13:35.734332+07:00",
+          transition_id: "retry",
+          workstation_name: "Retry",
+          work_ids: ["work-shared"],
+        },
+      ],
+      trace_id: "trace-retry-selection",
+      transition_ids: ["retry"],
+      work_ids: ["work-shared"],
+    };
+
+    render(<TraceGridBentoCard state={{ status: "ready", trace }} />);
+
+    const card = screen.getByRole("article", { name: "Trace drill-down" });
+    const dispatchButton = await waitFor(() => {
+      const button = within(card).getByRole("button", {
+        name: "Select dispatch dispatch-retry, Work work-shared, attempt 2.",
+      });
+      expect(button).toBeTruthy();
+      return button;
+    });
+    const graphSurface = card.querySelector<HTMLElement>(
+      '[data-trace-selection-surface="graph"]',
+    );
+    if (!graphSurface) {
+      throw new Error("Expected a trace graph selection surface.");
+    }
+    const graphButton = within(graphSurface).getByRole("button", {
+      name: "Select Retry workstation",
+    });
+
+    fireEvent.click(dispatchButton);
+    await waitFor(() => {
+      expect(graphButton.getAttribute("aria-pressed")).toBe("true");
+      expect(document.activeElement).toBe(graphButton);
+    });
+
+    fireEvent.click(graphButton);
+    await waitFor(() => {
+      expect(dispatchButton.getAttribute("aria-pressed")).toBe("true");
+      expect(document.activeElement).toBe(dispatchButton);
+    });
   });
 });

--- a/ui/src/features/trace-drilldown/components/trace-grid-card.stories.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-grid-card.stories.tsx
@@ -1,4 +1,7 @@
+import { useState } from "react";
+import { expect, userEvent, within } from "storybook/test";
 import type { DashboardTrace } from "../../../api/dashboard/types";
+import type { TraceSelectionIdentity } from "../lib/trace-selection";
 import { TraceGridBentoCard } from "./trace-grid-card";
 
 const populatedTrace: DashboardTrace = {
@@ -148,5 +151,41 @@ export const LocalizedZhCN = {
     locale: "zh-CN",
     state: { status: "ready", trace: populatedTrace },
     widgetId: "trace-zh-cn-story",
+  },
+};
+
+function SelectionSynchronizationStory() {
+  const [selectedTraceSelection, setSelectedTraceSelection] =
+    useState<TraceSelectionIdentity | null>(null);
+
+  return (
+    <TraceGridBentoCard
+      onSelectTraceSelection={setSelectedTraceSelection}
+      selectedTraceSelection={selectedTraceSelection}
+      state={{ status: "ready", trace: populatedTrace }}
+      widgetId="trace-selection-synchronization-story"
+    />
+  );
+}
+
+export const SelectionSynchronization = {
+  tags: ["test"],
+  render: () => <SelectionSynchronizationStory />,
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const dispatchButton = await canvas.findByRole("button", {
+      name: "Select dispatch dispatch-review-active, Work work-active-story, attempt 1.",
+    });
+    const graphButton = await canvas.findByRole("button", {
+      name: "Select Plan workstation",
+    });
+
+    await userEvent.click(dispatchButton);
+    await expect(graphButton).toHaveAttribute("aria-pressed", "true");
+    await expect(graphButton).toHaveFocus();
+
+    await userEvent.click(graphButton);
+    await expect(dispatchButton).toHaveAttribute("aria-pressed", "true");
+    await expect(dispatchButton).toHaveFocus();
   },
 };

--- a/ui/src/features/trace-drilldown/components/trace-grid-card.stories.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-grid-card.stories.tsx
@@ -103,6 +103,22 @@ export const PopulatedTrace = {
   },
 };
 
+export const RelationOnlyTrace = {
+  args: {
+    state: {
+      status: "ready",
+      trace: {
+        ...populatedTrace,
+        dispatches: [],
+        trace_id: "trace-relation-only-story",
+        transition_ids: [],
+        workstation_sequence: [],
+      },
+    },
+    widgetId: "trace-relation-only-story",
+  },
+};
+
 export const EmptyTrace = {
   args: {
     state: { status: "empty", workID: "work-missing" },

--- a/ui/src/features/trace-drilldown/components/trace-grid-card.stories.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-grid-card.stories.tsx
@@ -184,7 +184,7 @@ export const SelectionSynchronization = {
     await expect(graphButton).toHaveAttribute("aria-pressed", "true");
     await expect(graphButton).toHaveFocus();
 
-    await userEvent.click(graphButton);
+    await userEvent.keyboard("{Enter}");
     await expect(dispatchButton).toHaveAttribute("aria-pressed", "true");
     await expect(dispatchButton).toHaveFocus();
   },

--- a/ui/src/features/trace-drilldown/components/trace-grid-card.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-grid-card.tsx
@@ -36,6 +36,7 @@ import { DashboardWidgetFrame } from "../../bento/components/dashboard-widget-fr
 import {
   type TraceSelectionIdentity,
   traceSelectionForDispatch,
+  traceSelectionIdentitiesByWorkID,
   traceSelectionIdentitiesForDispatch,
   traceSelectionKey,
   traceSelectionMatches,
@@ -166,13 +167,14 @@ interface TraceGridProps {
   trace: DashboardTrace;
 }
 
-type TraceSelectionSource = "graph" | "table";
+type TraceSelectionSource = "graph" | "table" | "text";
 
 interface PendingTraceFocus {
   selection: TraceSelectionIdentity;
   source: TraceSelectionSource;
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: trace card keeps the canonical metadata, relation, table, and graph surfaces in one selection-aware render path.
 function TraceGrid({
   locale,
   onSelectWorkID,
@@ -182,6 +184,14 @@ function TraceGrid({
 }: TraceGridProps) {
   const messages = getTraceDrilldownMessages(locale);
   const workItems = useMemo(() => resolveTraceWorkItems(trace), [trace]);
+  const workItemsByWorkId = useMemo(
+    () => new Map(workItems.map((workItem) => [workItem.work_id, workItem])),
+    [workItems],
+  );
+  const selectionIdentitiesByWorkID = useMemo(
+    () => traceSelectionIdentitiesByWorkID(trace.dispatches),
+    [trace.dispatches],
+  );
   const [workItemsExpanded, setWorkItemsExpanded] = useState(false);
   const [localSelection, setLocalSelection] =
     useState<TraceSelectionIdentity | null>(null);
@@ -210,19 +220,27 @@ function TraceGrid({
   );
 
   useEffect(() => {
-    if (!pendingFocus || !gridRef.current) {
+    const grid = gridRef.current;
+    if (!pendingFocus || !grid) {
       return;
     }
 
-    const targetSurface = pendingFocus.source === "table" ? "graph" : "table";
     const targetKey = traceSelectionKey(pendingFocus.selection);
-    const target = [
-      ...gridRef.current.querySelectorAll<HTMLElement>(
-        `[data-trace-selection-surface="${targetSurface}"]`,
-      ),
-    ].find((element) =>
-      traceSelectionKeysFromElement(element).includes(targetKey),
-    );
+    const targetSurfaces =
+      pendingFocus.source === "table"
+        ? ["graph", "text"]
+        : pendingFocus.source === "graph"
+          ? ["table", "text"]
+          : ["graph", "table"];
+    const target = targetSurfaces
+      .flatMap((surface) => [
+        ...grid.querySelectorAll<HTMLElement>(
+          `[data-trace-selection-surface="${surface}"]`,
+        ),
+      ])
+      .find((element) =>
+        traceSelectionKeysFromElement(element).includes(targetKey),
+      );
     const focusTarget = target?.matches("button")
       ? target
       : target?.querySelector<HTMLElement>("button");
@@ -319,7 +337,14 @@ function TraceGrid({
               <TraceRelationFlow
                 locale={locale}
                 onSelectWorkID={onSelectWorkID}
+                onSelectTraceSelection={(selection) =>
+                  selectTraceSelection(selection, "text")
+                }
                 relations={trace.relations}
+                selectedTraceSelection={selectedTraceSelection}
+                selectedWorkID={selectedTraceSelection?.work_id}
+                selectionIdentitiesByWorkID={selectionIdentitiesByWorkID}
+                workItemsByWorkId={workItemsByWorkId}
               />
             ) : (
               messages.noBatchRelations

--- a/ui/src/features/trace-drilldown/components/trace-grid-card.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-grid-card.tsx
@@ -1,4 +1,5 @@
 import {
+  DescriptionList,
   Table,
   TableBody,
   TableCaption,
@@ -7,7 +8,7 @@ import {
   TableHeader,
   TableRow,
 } from "@you-agent-factory/components/data-display";
-import { Button } from "@you-agent-factory/components/primitives";
+import { Button, Code, Label } from "@you-agent-factory/components/primitives";
 import {
   WidgetEmptyState,
   WidgetEmptyStateText,
@@ -19,13 +20,11 @@ import type {
   DashboardTrace,
   DashboardWorkItemRef,
 } from "../../../api/dashboard/types";
-import { DescriptionList } from "@you-agent-factory/components/data-display";
-import { Code, Label } from "@you-agent-factory/components/primitives";
-import { ExpandablePanelTrigger } from "../../../components/ui/expandable-panel-trigger";
 import {
   Collapsible,
   CollapsibleContent,
 } from "../../../components/ui/collapsible";
+import { ExpandablePanelTrigger } from "../../../components/ui/expandable-panel-trigger";
 import {
   formatDurationMillis,
   formatTraceOutcome,
@@ -307,7 +306,7 @@ function TraceGrid({ locale, onSelectWorkID, trace }: TraceGridProps) {
             ))}
           </TableBody>
         </Table>
-      ) : (
+      ) : trace.relations && trace.relations.length > 0 ? null : (
         <WidgetEmptyState compact>
           <WidgetEmptyStateTitle>
             {messages.noTraceHistoryTitle}

--- a/ui/src/features/trace-drilldown/components/trace-grid-card.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-grid-card.tsx
@@ -15,9 +15,10 @@ import {
   WidgetEmptyStateTitle,
 } from "@you-agent-factory/components/recipes";
 import type { HTMLAttributes, ReactNode } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   DashboardTrace,
+  DashboardTraceDispatch,
   DashboardWorkItemRef,
 } from "../../../api/dashboard/types";
 import {
@@ -32,6 +33,13 @@ import {
 } from "../../../components/ui/formatters";
 import { Skeleton } from "../../../components/ui/skeleton";
 import { DashboardWidgetFrame } from "../../bento/components/dashboard-widget-frame/dashboard-widget-frame";
+import {
+  type TraceSelectionIdentity,
+  traceSelectionForDispatch,
+  traceSelectionIdentitiesForDispatch,
+  traceSelectionKey,
+  traceSelectionMatches,
+} from "../lib/trace-selection";
 import { getTraceDrilldownMessages } from "../messages/trace-drilldown";
 import { TraceRelationFlow } from "./trace-relation-flow";
 import { TraceWorkstationPath } from "./trace-workstation-path";
@@ -48,6 +56,8 @@ export interface TraceGridBentoCardProps {
   headerAction?: ReactNode;
   locale?: string;
   onSelectWorkID?: (workID: string) => void;
+  onSelectTraceSelection?: (selection: TraceSelectionIdentity) => void;
+  selectedTraceSelection?: TraceSelectionIdentity | null;
   state: TraceGridState;
   title?: string;
   widgetId?: string;
@@ -58,6 +68,8 @@ export function TraceGridBentoCard({
   headerAction,
   locale,
   onSelectWorkID,
+  onSelectTraceSelection,
+  selectedTraceSelection,
   state,
   title,
   widgetId = "trace-drilldown",
@@ -76,7 +88,13 @@ export function TraceGridBentoCard({
       wide
       widgetId={widgetId}
     >
-      {renderTraceState(state, locale, onSelectWorkID)}
+      {renderTraceState(
+        state,
+        locale,
+        onSelectWorkID,
+        onSelectTraceSelection,
+        selectedTraceSelection,
+      )}
     </DashboardWidgetFrame>
   );
 }
@@ -85,6 +103,8 @@ function renderTraceState(
   state: TraceGridState,
   locale?: string,
   onSelectWorkID?: (workID: string) => void,
+  onSelectTraceSelection?: (selection: TraceSelectionIdentity) => void,
+  selectedTraceSelection?: TraceSelectionIdentity | null,
 ) {
   const messages = getTraceDrilldownMessages(locale);
 
@@ -130,6 +150,8 @@ function renderTraceState(
         <TraceGrid
           locale={locale}
           onSelectWorkID={onSelectWorkID}
+          onSelectTraceSelection={onSelectTraceSelection}
+          selectedTraceSelection={selectedTraceSelection}
           trace={state.trace}
         />
       );
@@ -139,21 +161,82 @@ function renderTraceState(
 interface TraceGridProps {
   locale?: string;
   onSelectWorkID?: (workID: string) => void;
+  onSelectTraceSelection?: (selection: TraceSelectionIdentity) => void;
+  selectedTraceSelection?: TraceSelectionIdentity | null;
   trace: DashboardTrace;
 }
 
-function TraceGrid({ locale, onSelectWorkID, trace }: TraceGridProps) {
+type TraceSelectionSource = "graph" | "table";
+
+interface PendingTraceFocus {
+  selection: TraceSelectionIdentity;
+  source: TraceSelectionSource;
+}
+
+function TraceGrid({
+  locale,
+  onSelectWorkID,
+  onSelectTraceSelection,
+  selectedTraceSelection: controlledSelection,
+  trace,
+}: TraceGridProps) {
   const messages = getTraceDrilldownMessages(locale);
   const workItems = useMemo(() => resolveTraceWorkItems(trace), [trace]);
   const [workItemsExpanded, setWorkItemsExpanded] = useState(false);
+  const [localSelection, setLocalSelection] =
+    useState<TraceSelectionIdentity | null>(null);
+  const [pendingFocus, setPendingFocus] = useState<PendingTraceFocus | null>(
+    null,
+  );
+  const gridRef = useRef<HTMLDivElement>(null);
+  const selectedTraceSelection =
+    controlledSelection === undefined ? localSelection : controlledSelection;
   const workItemsID = `trace-work-items-${trace.trace_id || "selected"}`;
 
   useEffect(() => {
     setWorkItemsExpanded(false);
   }, []);
 
+  const selectTraceSelection = useCallback(
+    (selection: TraceSelectionIdentity, source: TraceSelectionSource) => {
+      setLocalSelection(selection);
+      setPendingFocus({ selection, source });
+      onSelectTraceSelection?.(selection);
+      if (selection.work_id) {
+        onSelectWorkID?.(selection.work_id);
+      }
+    },
+    [onSelectTraceSelection, onSelectWorkID],
+  );
+
+  useEffect(() => {
+    if (!pendingFocus || !gridRef.current) {
+      return;
+    }
+
+    const targetSurface = pendingFocus.source === "table" ? "graph" : "table";
+    const targetKey = traceSelectionKey(pendingFocus.selection);
+    const target = [
+      ...gridRef.current.querySelectorAll<HTMLElement>(
+        `[data-trace-selection-surface="${targetSurface}"]`,
+      ),
+    ].find((element) =>
+      traceSelectionKeysFromElement(element).includes(targetKey),
+    );
+    const focusTarget = target?.matches("button")
+      ? target
+      : target?.querySelector<HTMLElement>("button");
+
+    if (focusTarget) {
+      focusTarget.focus();
+      focusTarget.scrollIntoView?.({ block: "nearest", inline: "nearest" });
+    }
+
+    setPendingFocus(null);
+  }, [pendingFocus]);
+
   return (
-    <div className="grid min-w-0 w-full gap-3">
+    <div className="grid min-w-0 w-full gap-3" ref={gridRef}>
       <DescriptionList className="gap-3 [&_div:first-child]:border-t-0 [&_div:first-child]:pt-0 [&_div]:border-t [&_div]:border-outline [&_div]:pt-3 [&_dt]:mb-1">
         <div>
           <Label as="dt">{messages.traceIdLabel}</Label>
@@ -167,6 +250,10 @@ function TraceGrid({ locale, onSelectWorkID, trace }: TraceGridProps) {
             <TraceWorkstationPath
               dispatches={trace.dispatches}
               locale={locale}
+              onSelectTraceSelection={(selection) =>
+                selectTraceSelection(selection, "graph")
+              }
+              selectedTraceSelection={selectedTraceSelection}
             />
           </dd>
         </div>
@@ -242,70 +329,14 @@ function TraceGrid({ locale, onSelectWorkID, trace }: TraceGridProps) {
       </DescriptionList>
 
       {trace.dispatches.length > 0 ? (
-        <Table
-          className="min-w-2xl"
-          containerClassName="min-w-0 overscroll-x-contain"
-          containerProps={
-            {
-              "data-trace-dispatch-table": "",
-            } as HTMLAttributes<HTMLDivElement>
+        <TraceDispatchTable
+          dispatches={trace.dispatches}
+          locale={locale}
+          onSelectTraceSelection={(selection) =>
+            selectTraceSelection(selection, "table")
           }
-        >
-          <TableCaption className="mb-2 text-left">
-            {messages.tableCaption}
-          </TableCaption>
-          <TableHeader>
-            <TableRow>
-              <TableHead scope="col">{messages.dispatchColumnLabel}</TableHead>
-              <TableHead scope="col">
-                {messages.workstationColumnLabel}
-              </TableHead>
-              <TableHead scope="col">{messages.outcomeColumnLabel}</TableHead>
-              <TableHead scope="col">
-                {messages.inputItemsColumnLabel}
-              </TableHead>
-              <TableHead scope="col">
-                {messages.outputItemsColumnLabel}
-              </TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {trace.dispatches.map((dispatch) => (
-              <TableRow key={dispatch.dispatch_id}>
-                <TableCell className="align-top" scope="row">
-                  {dispatch.dispatch_id}
-                </TableCell>
-                <TableCell className="align-top">
-                  {dispatch.workstation_name || dispatch.transition_id}
-                </TableCell>
-                <TableCell className="align-top">
-                  {formatTraceOutcome(dispatch.outcome)} ·{" "}
-                  {formatDurationMillis(dispatch.duration_millis)}
-                </TableCell>
-                <TableCell className="align-top">
-                  {dispatch.input_items && dispatch.input_items.length > 0 ? (
-                    <SelectableWorkList
-                      onSelectWorkID={onSelectWorkID}
-                      workItems={dispatch.input_items}
-                    />
-                  ) : (
-                    <span>{messages.noInputItems}</span>
-                  )}
-                </TableCell>
-                <TableCell className="align-top">
-                  {dispatch.output_items && dispatch.output_items.length > 0 ? (
-                    <SelectableWorkList
-                      onSelectWorkID={onSelectWorkID}
-                      workItems={dispatch.output_items}
-                    />
-                  ) : (
-                    <span>{messages.noOutputItems}</span>
-                  )}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+          selectedTraceSelection={selectedTraceSelection}
+        />
       ) : trace.relations && trace.relations.length > 0 ? null : (
         <WidgetEmptyState compact>
           <WidgetEmptyStateTitle>
@@ -320,34 +351,194 @@ function TraceGrid({ locale, onSelectWorkID, trace }: TraceGridProps) {
   );
 }
 
+function TraceDispatchTable({
+  dispatches,
+  locale,
+  onSelectTraceSelection,
+  selectedTraceSelection,
+}: {
+  dispatches: DashboardTraceDispatch[];
+  locale?: string;
+  onSelectTraceSelection: (selection: TraceSelectionIdentity) => void;
+  selectedTraceSelection: TraceSelectionIdentity | null;
+}) {
+  const messages = getTraceDrilldownMessages(locale);
+
+  return (
+    <Table
+      className="min-w-2xl"
+      containerClassName="min-w-0 overscroll-x-contain"
+      containerProps={
+        {
+          "data-trace-dispatch-table": "",
+        } as HTMLAttributes<HTMLDivElement>
+      }
+    >
+      <TableCaption className="mb-2 text-left">
+        {messages.tableCaption}
+      </TableCaption>
+      <TableHeader>
+        <TableRow>
+          <TableHead scope="col">{messages.dispatchColumnLabel}</TableHead>
+          <TableHead scope="col">{messages.workstationColumnLabel}</TableHead>
+          <TableHead scope="col">{messages.outcomeColumnLabel}</TableHead>
+          <TableHead scope="col">{messages.inputItemsColumnLabel}</TableHead>
+          <TableHead scope="col">{messages.outputItemsColumnLabel}</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {dispatches.map((dispatch) => {
+          const dispatchSelections =
+            traceSelectionIdentitiesForDispatch(dispatch);
+          const isSelected = dispatchSelections.some((selection) =>
+            traceSelectionMatches(selection, selectedTraceSelection),
+          );
+          const primarySelection = traceSelectionForDispatch(dispatch);
+          const primarySelectionKey = traceSelectionKey(primarySelection);
+          const selectLabel = messages.selectDispatchLabel(
+            dispatch.dispatch_id,
+            primarySelection.work_id,
+            primarySelection.attempt,
+          );
+
+          return (
+            <TableRow
+              aria-selected={isSelected}
+              data-trace-dispatch-row
+              data-trace-selection-key={primarySelectionKey}
+              key={primarySelectionKey}
+            >
+              <TableCell className="align-top" scope="row">
+                <Button
+                  aria-label={selectLabel}
+                  aria-pressed={isSelected}
+                  className="h-auto min-h-0 justify-start px-2.5 py-1.5 text-left"
+                  data-trace-selection-key={primarySelectionKey}
+                  data-trace-selection-surface="table"
+                  onClick={() => onSelectTraceSelection(primarySelection)}
+                  size="sm"
+                  title={selectLabel}
+                  tone="outline"
+                >
+                  {dispatch.dispatch_id}
+                </Button>
+              </TableCell>
+              <TableCell className="align-top">
+                {dispatch.workstation_name || dispatch.transition_id}
+              </TableCell>
+              <TableCell className="align-top">
+                {formatTraceOutcome(dispatch.outcome)} ·{" "}
+                {formatDurationMillis(dispatch.duration_millis)}
+              </TableCell>
+              <TableCell className="align-top">
+                {dispatch.input_items && dispatch.input_items.length > 0 ? (
+                  <SelectableWorkList
+                    dispatch={dispatch}
+                    onSelectTraceSelection={onSelectTraceSelection}
+                    selectedTraceSelection={selectedTraceSelection}
+                    workItems={dispatch.input_items}
+                  />
+                ) : (
+                  <span>{messages.noInputItems}</span>
+                )}
+              </TableCell>
+              <TableCell className="align-top">
+                {dispatch.output_items && dispatch.output_items.length > 0 ? (
+                  <SelectableWorkList
+                    dispatch={dispatch}
+                    onSelectTraceSelection={onSelectTraceSelection}
+                    selectedTraceSelection={selectedTraceSelection}
+                    workItems={dispatch.output_items}
+                  />
+                ) : (
+                  <span>{messages.noOutputItems}</span>
+                )}
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}
+
 function SelectableWorkList({
+  dispatch,
   onSelectWorkID,
+  onSelectTraceSelection,
+  selectedTraceSelection,
   workItems,
 }: {
+  dispatch?: DashboardTraceDispatch;
   onSelectWorkID?: (workID: string) => void;
+  onSelectTraceSelection?: (selection: TraceSelectionIdentity) => void;
+  selectedTraceSelection?: TraceSelectionIdentity | null;
   workItems: DashboardWorkItemRef[];
 }) {
   return (
     <ul className="m-0 grid gap-1.5 p-0">
-      {workItems.map((workItem) => (
-        <li className="list-none" key={workItem.work_id}>
-          {onSelectWorkID ? (
-            <Button
-              className="h-auto min-h-0 justify-start px-2.5 py-1.5 text-left"
-              onClick={() => onSelectWorkID(workItem.work_id)}
-              size="sm"
-              title={workItem.work_id}
-              tone="outline"
-            >
-              {formatTypedWorkItemLabel(workItem)}
-            </Button>
-          ) : (
-            <Code size="supporting">{formatTypedWorkItemLabel(workItem)}</Code>
-          )}
-        </li>
-      ))}
+      {workItems.map((workItem) => {
+        const selection = dispatch
+          ? traceSelectionForDispatch(dispatch, workItem.work_id)
+          : undefined;
+        const isSelected = traceSelectionMatches(
+          selection,
+          selectedTraceSelection,
+        );
+
+        return (
+          <li
+            className="list-none"
+            key={selection ? traceSelectionKey(selection) : workItem.work_id}
+          >
+            {onSelectWorkID || onSelectTraceSelection ? (
+              <Button
+                aria-pressed={selection ? isSelected : undefined}
+                className="h-auto min-h-0 justify-start px-2.5 py-1.5 text-left"
+                data-trace-selection-key={
+                  selection ? traceSelectionKey(selection) : undefined
+                }
+                data-trace-selection-surface={selection ? "table" : undefined}
+                onClick={() => {
+                  if (selection && onSelectTraceSelection) {
+                    onSelectTraceSelection(selection);
+                    return;
+                  }
+                  onSelectWorkID?.(workItem.work_id);
+                }}
+                size="sm"
+                title={workItem.work_id}
+                tone="outline"
+              >
+                {formatTypedWorkItemLabel(workItem)}
+              </Button>
+            ) : (
+              <Code size="supporting">
+                {formatTypedWorkItemLabel(workItem)}
+              </Code>
+            )}
+          </li>
+        );
+      })}
     </ul>
   );
+}
+
+function traceSelectionKeysFromElement(element: HTMLElement): string[] {
+  const serializedKeys = element.getAttribute("data-trace-selection-keys");
+  if (serializedKeys) {
+    try {
+      const keys = JSON.parse(serializedKeys) as unknown;
+      if (Array.isArray(keys)) {
+        return keys.filter((key): key is string => typeof key === "string");
+      }
+    } catch {
+      return [];
+    }
+  }
+
+  const key = element.getAttribute("data-trace-selection-key");
+  return key ? [key] : [];
 }
 
 function resolveTraceWorkItems(trace: DashboardTrace): DashboardWorkItemRef[] {

--- a/ui/src/features/trace-drilldown/components/trace-relation-flow.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-relation-flow.test.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/style/noExcessiveLinesPerFile: relation graph coverage keeps one mocked React Flow harness alongside the textual fallback and responsive surface assertions.
 import {
   cleanup,
   fireEvent,
@@ -299,8 +300,11 @@ describe("TraceRelationFlow", () => {
     expect(implementNode.className).toContain("border-info-border");
     expect(implementNode.className).toContain("bg-info-container");
     expect(within(implementButton).getByText("Implement story")).toBeTruthy();
-    expect(screen.queryByText("Parent-child")).toBeNull();
-    expect(screen.queryByText("Done")).toBeNull();
+    const textualPath = screen.getByRole("region", {
+      name: "Textual relation path",
+    });
+    expect(within(textualPath).getByText("Parent-child")).toBeTruthy();
+    expect(within(textualPath).getByText(/Required state:.*Done/)).toBeTruthy();
     expect(screen.queryByText("Work state")).toBeNull();
     expect(screen.queryByText("Failed")).toBeNull();
 
@@ -355,7 +359,11 @@ describe("TraceRelationFlow selected work", () => {
 
     expect(screen.queryByRole("button", { name: "Plan story" })).toBeNull();
 
-    const selectedShell = screen.getByText("Plan story").closest("article");
+    const selectedShell = within(
+      screen.getByTestId("trace-relation-react-flow"),
+    )
+      .getByText("Plan story")
+      .closest("article");
     if (!(selectedShell instanceof HTMLElement)) {
       throw new Error("Expected selected relation node shell to render.");
     }
@@ -367,6 +375,65 @@ describe("TraceRelationFlow selected work", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Implement story" }));
     expect(onSelectWorkID).toHaveBeenCalledWith("work-implement");
+  });
+});
+
+describe("TraceRelationFlow textual fallback", () => {
+  let restoreBrowserShims: (() => void) | undefined;
+
+  beforeEach(() => {
+    restoreBrowserShims = installDashboardBrowserTestShims();
+  });
+
+  afterEach(() => {
+    cleanup();
+    restoreBrowserShims?.();
+    restoreBrowserShims = undefined;
+  });
+
+  it("keeps the semantic relation path usable when graph rendering is disabled", () => {
+    const onSelectWorkID = vi.fn();
+
+    render(
+      <TraceRelationFlow
+        onSelectWorkID={onSelectWorkID}
+        relations={RELATIONS}
+        renderGraph={false}
+      />,
+    );
+
+    const textualPath = screen.getByRole("region", {
+      name: "Textual relation path",
+    });
+    expect(within(textualPath).getAllByRole("listitem")).toHaveLength(2);
+    expect(
+      screen.queryByRole("region", { name: "Batch relation graph" }),
+    ).toBeNull();
+
+    const firstRelation = within(textualPath).getAllByRole("listitem")[0];
+    if (!firstRelation) {
+      throw new Error("Expected the first textual relation to render.");
+    }
+    const target = within(firstRelation).getByRole("button", {
+      name: "Select work work-implement.",
+    });
+    target.focus();
+    fireEvent.keyDown(target, { key: "Enter" });
+    fireEvent.click(target);
+    expect(onSelectWorkID).toHaveBeenCalledWith("work-implement");
+    expect(target.className).toContain("focus-visible:ring-af-focus-ring");
+  });
+
+  it("keeps the zero-relation state named and accessible", () => {
+    render(<TraceRelationFlow relations={[]} renderGraph={false} />);
+
+    const textualPath = screen.getByRole("region", {
+      name: "Textual relation path",
+    });
+    expect(within(textualPath).getByRole("status").textContent).toBe(
+      "No recorded relations.",
+    );
+    expect(screen.getByText("None")).toBeTruthy();
   });
 });
 
@@ -448,10 +515,15 @@ describe("TraceRelationFlow localization", () => {
       expect(screen.getByRole("region", { name: "批次关系图" })).toBeTruthy();
     });
 
-    expect(screen.getByText("Review story")).toBeTruthy();
-    expect(screen.getByText("Fix story")).toBeTruthy();
-    expect(screen.queryByText("派生自")).toBeNull();
-    expect(screen.queryByText("未知状态：escalated_review")).toBeNull();
+    const textualPath = screen.getByRole("region", {
+      name: "文本关系路径",
+    });
+    expect(within(textualPath).getByText("Review story")).toBeTruthy();
+    expect(within(textualPath).getByText("Fix story")).toBeTruthy();
+    expect(within(textualPath).getByText("派生自")).toBeTruthy();
+    expect(
+      within(textualPath).getByText(/未知状态：escalated_review/),
+    ).toBeTruthy();
     expect(renderedEdges()[0]?.ariaLabel).toBe(
       "派生自关系：从 Review story 到 Fix story，要求 未知状态：escalated_review",
     );
@@ -482,7 +554,10 @@ describe("TraceRelationFlow localization", () => {
       expect(screen.getByRole("region", { name: "批次关系图" })).toBeTruthy();
     });
 
-    expect(screen.getByText("未知来源")).toBeTruthy();
-    expect(screen.getByText("work-target")).toBeTruthy();
+    const textualPath = screen.getByRole("region", {
+      name: "文本关系路径",
+    });
+    expect(within(textualPath).getByText("未知来源")).toBeTruthy();
+    expect(within(textualPath).getAllByText("work-target")).toHaveLength(2);
   });
 });

--- a/ui/src/features/trace-drilldown/components/trace-relation-flow.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-relation-flow.tsx
@@ -26,8 +26,10 @@ import { applyTraceFactoryGraphLayoutToNode } from "../lib/trace-factory-graph-l
 import { failOnTraceReactFlowError } from "../lib/trace-react-flow-error";
 import type { TraceRelationFlowNode } from "../lib/trace-relation-factory-graph-flow";
 import { buildTraceRelationFactoryGraphFlow } from "../lib/trace-relation-factory-graph-flow";
+import type { TraceSelectionIdentity } from "../lib/trace-selection";
 import { useMeasuredTraceGraphViewport } from "../lib/use-measured-trace-graph-viewport";
 import { getTraceDrilldownMessages } from "../messages/trace-drilldown";
+import { TraceRelationPath } from "./trace-relation-path";
 
 const GRAPH_SHELL_STYLE = { height: 352, minHeight: 288 };
 const GRAPH_VIEWPORT_STYLE = { height: "100%", width: "100%" };
@@ -36,16 +38,28 @@ const GRAPH_FIT_VIEW_OPTIONS = { maxZoom: 1.5, padding: 0.08 } as const;
 export interface TraceRelationFlowProps {
   locale?: string;
   onSelectWorkID?: (workID: string) => void;
+  onSelectTraceSelection?: (selection: TraceSelectionIdentity) => void;
+  renderGraph?: boolean;
   relations: DashboardWorkRelation[];
+  selectedTraceSelection?: TraceSelectionIdentity | null;
   selectedWorkID?: string | null;
+  selectionIdentitiesByWorkID?: ReadonlyMap<
+    string,
+    readonly TraceSelectionIdentity[]
+  >;
   workItemsByWorkId?: ReadonlyMap<string, DashboardWorkItemRef>;
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: graph layout, React Flow, textual fallback, and selection wiring share one projection-driven surface.
 export function TraceRelationFlow({
   locale,
   onSelectWorkID,
+  onSelectTraceSelection,
+  renderGraph = true,
   relations,
+  selectedTraceSelection,
   selectedWorkID,
+  selectionIdentitiesByWorkID,
   workItemsByWorkId,
 }: TraceRelationFlowProps) {
   const graph = useMemo(
@@ -53,10 +67,18 @@ export function TraceRelationFlow({
       buildTraceRelationFactoryGraphFlow(relations, {
         locale,
         onSelectWorkID,
+        selectionIdentitiesByWorkID,
         selectedWorkID,
         workItemsByWorkId,
       }),
-    [locale, onSelectWorkID, relations, selectedWorkID, workItemsByWorkId],
+    [
+      locale,
+      onSelectWorkID,
+      relations,
+      selectedWorkID,
+      selectionIdentitiesByWorkID,
+      workItemsByWorkId,
+    ],
   );
   const topologyKey = useMemo(
     () => traceRelationTopologyLayoutKey(graph.topology),
@@ -143,33 +165,42 @@ export function TraceRelationFlow({
   const { graphViewportReady, graphViewportRef } =
     useMeasuredTraceGraphViewport();
 
-  if (relations.length === 0) {
-    return <span>{getTraceDrilldownMessages(locale).noBatchRelations}</span>;
-  }
-
   return (
-    <DashboardGraphFrame
-      aria-label={getTraceDrilldownMessages(locale).batchRelationGraphLabel}
-      className="max-w-full min-w-80 resize overflow-hidden border-transparent bg-transparent"
-      data-trace-relation-flow
-      style={GRAPH_SHELL_STYLE}
-    >
-      <div
-        className="h-full min-w-0 w-full"
-        data-trace-graph-viewport
-        ref={graphViewportRef}
-        style={GRAPH_VIEWPORT_STYLE}
-      >
-        {graphViewportReady ? (
-          <TraceRelationReactFlow
-            edges={graph.edges}
-            fitViewKey={fitViewKey}
-            nodes={renderedNodes}
-            onNodesChange={handleNodesChange}
-          />
-        ) : null}
-      </div>
-    </DashboardGraphFrame>
+    <div className="grid min-w-0 gap-3">
+      <TraceRelationPath
+        entries={graph.relations}
+        locale={locale}
+        onSelectTraceSelection={onSelectTraceSelection}
+        onSelectWorkID={onSelectWorkID}
+        selectedTraceSelection={selectedTraceSelection}
+      />
+      {renderGraph && graph.relations.length > 0 ? (
+        <DashboardGraphFrame
+          aria-label={getTraceDrilldownMessages(locale).batchRelationGraphLabel}
+          className="max-w-full min-w-80 resize overflow-hidden border-transparent bg-transparent"
+          data-trace-relation-flow
+          style={GRAPH_SHELL_STYLE}
+        >
+          <div
+            className="h-full min-w-0 w-full"
+            data-trace-graph-viewport
+            ref={graphViewportRef}
+            style={GRAPH_VIEWPORT_STYLE}
+          >
+            {graphViewportReady ? (
+              <TraceRelationReactFlow
+                edges={graph.edges}
+                fitViewKey={fitViewKey}
+                nodes={renderedNodes}
+                onNodesChange={handleNodesChange}
+              />
+            ) : null}
+          </div>
+        </DashboardGraphFrame>
+      ) : relations.length === 0 ? (
+        <span>{getTraceDrilldownMessages(locale).noBatchRelations}</span>
+      ) : null}
+    </div>
   );
 }
 

--- a/ui/src/features/trace-drilldown/components/trace-relation-path.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-relation-path.test.tsx
@@ -1,3 +1,4 @@
+// @component-test-runner vitest: imports workspace graph packages that Bun resolves through declaration files.
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { DashboardTraceDispatch } from "../../../api/dashboard/types";

--- a/ui/src/features/trace-drilldown/components/trace-relation-path.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-relation-path.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { DashboardTraceDispatch } from "../../../api/dashboard/types";
+import { buildTraceDispatchFactoryGraphFlow } from "../lib/trace-dispatch-factory-graph-flow";
+import { traceSelectionKey } from "../lib/trace-selection";
+import { TraceRelationPath } from "./trace-relation-path";
+
+function buildDispatch(
+  dispatchID: string,
+  overrides: Partial<DashboardTraceDispatch> = {},
+): DashboardTraceDispatch {
+  return {
+    dispatch_id: dispatchID,
+    duration_millis: 1000,
+    end_time: "2026-04-22T18:00:01Z",
+    outcome: "ACCEPTED",
+    start_time: "2026-04-22T18:00:00Z",
+    transition_id: dispatchID,
+    workstation_name: dispatchID,
+    ...overrides,
+  };
+}
+
+describe("TraceRelationPath", () => {
+  it("renders the same canonical relation ids and complete endpoint identities as the dispatch graph", () => {
+    const flow = buildTraceDispatchFactoryGraphFlow([
+      buildDispatch("dispatch-plan", {
+        attempt: 1,
+        output_items: [{ work_id: "work-shared" }],
+      }),
+      buildDispatch("dispatch-retry", {
+        attempt: 2,
+        input_items: [{ work_id: "work-shared" }],
+      }),
+    ]);
+    const onSelectTraceSelection = vi.fn();
+
+    render(
+      <TraceRelationPath
+        entries={flow.relations}
+        onSelectTraceSelection={onSelectTraceSelection}
+      />,
+    );
+
+    const relationPath = screen.getByRole("region", {
+      name: "Textual relation path",
+    });
+    expect(
+      [
+        ...relationPath.querySelectorAll<HTMLElement>(
+          "[data-trace-relation-entry]",
+        ),
+      ].map((entry) => entry.getAttribute("data-trace-relation-id")),
+    ).toEqual(flow.relations.map((relation) => relation.id));
+
+    const targetSelection = flow.relations[0]?.target.selectionIdentities[0];
+    if (!targetSelection) {
+      throw new Error("Expected a target selection identity.");
+    }
+
+    const targetButton = within(relationPath).getByRole("button", {
+      name: "dispatch-retry · Work work-shared · attempt 2",
+    });
+    expect(targetButton.getAttribute("data-trace-selection-key")).toBe(
+      traceSelectionKey(targetSelection),
+    );
+    fireEvent.click(targetButton);
+    expect(onSelectTraceSelection).toHaveBeenCalledWith(targetSelection);
+  });
+
+  it("keeps an accessible empty fallback when no relation entries exist", () => {
+    render(<TraceRelationPath entries={[]} />);
+
+    const relationPath = screen.getByRole("region", {
+      name: "Textual relation path",
+    });
+    expect(within(relationPath).getByRole("status").textContent).toBe(
+      "No recorded relations.",
+    );
+  });
+});

--- a/ui/src/features/trace-drilldown/components/trace-relation-path.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-relation-path.tsx
@@ -1,0 +1,224 @@
+import { Button, Code } from "@you-agent-factory/components/primitives";
+import type {
+  TraceRelationPathEndpoint,
+  TraceRelationPathEntry,
+} from "../lib/trace-relation-path";
+import type { TraceSelectionIdentity } from "../lib/trace-selection";
+import {
+  traceSelectionKey,
+  traceSelectionMatches,
+} from "../lib/trace-selection";
+import { getTraceDrilldownMessages } from "../messages/trace-drilldown";
+
+export interface TraceRelationPathProps {
+  entries: readonly TraceRelationPathEntry[];
+  locale?: string;
+  onSelectTraceSelection?: (selection: TraceSelectionIdentity) => void;
+  onSelectWorkID?: (workID: string) => void;
+  selectedTraceSelection?: TraceSelectionIdentity | null;
+}
+
+export function TraceRelationPath({
+  entries,
+  locale,
+  onSelectTraceSelection,
+  onSelectWorkID,
+  selectedTraceSelection,
+}: TraceRelationPathProps) {
+  const messages = getTraceDrilldownMessages(locale);
+
+  return (
+    <section
+      aria-label={messages.relationPathLabel}
+      className="grid min-w-0 gap-2"
+      data-trace-relation-path
+    >
+      {entries.length === 0 ? (
+        <p
+          className="m-0 text-sm text-on-surface-variant"
+          data-trace-relation-path-empty
+          role="status"
+        >
+          {messages.relationPathEmpty}
+        </p>
+      ) : (
+        <ol className="m-0 grid min-w-0 gap-2 p-0">
+          {entries.map((entry) => (
+            <TraceRelationPathEntryView
+              entry={entry}
+              key={entry.id}
+              locale={locale}
+              messages={messages}
+              onSelectTraceSelection={onSelectTraceSelection}
+              onSelectWorkID={onSelectWorkID}
+              selectedTraceSelection={selectedTraceSelection}
+            />
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}
+
+function TraceRelationPathEntryView({
+  entry,
+  locale,
+  messages,
+  onSelectTraceSelection,
+  onSelectWorkID,
+  selectedTraceSelection,
+}: Omit<TraceRelationPathProps, "entries"> & {
+  entry: TraceRelationPathEntry;
+  messages: ReturnType<typeof getTraceDrilldownMessages>;
+}) {
+  const relationLabel =
+    entry.kind === "predecessor"
+      ? messages.predecessorRelationLabel
+      : messages.localizeRelationType(entry.relationType);
+  const sourceLabel =
+    entry.kind === "predecessor"
+      ? messages.predecessorSourceLabel
+      : messages.relationPathSourceLabel;
+  const targetLabel =
+    entry.kind === "predecessor"
+      ? messages.predecessorTargetLabel
+      : messages.relationPathTargetLabel;
+
+  return (
+    <li
+      className="grid min-w-0 gap-2 rounded-lg border border-outline bg-surface-container-high p-3"
+      data-trace-relation-entry
+      data-trace-relation-id={entry.id}
+    >
+      <div className="flex min-w-0 flex-wrap items-baseline gap-2">
+        <span className="font-semibold text-on-surface">{relationLabel}</span>
+        {entry.requiredState ? (
+          <span className="text-sm text-on-surface-variant">
+            {messages.relationPathRequiredStateLabel}:{" "}
+            {messages.localizeRelationState(entry.requiredState)}
+          </span>
+        ) : null}
+        {entry.requestID ? (
+          <span className="text-sm text-on-surface-variant">
+            {messages.relationPathRequestIDLabel}:{" "}
+            <Code size="supporting">{entry.requestID}</Code>
+          </span>
+        ) : null}
+      </div>
+
+      <div className="grid min-w-0 gap-2 sm:flex sm:items-start sm:gap-3">
+        <TraceRelationPathEndpointView
+          endpoint={entry.source}
+          endpointLabel={sourceLabel}
+          locale={locale}
+          messages={messages}
+          onSelectTraceSelection={onSelectTraceSelection}
+          onSelectWorkID={onSelectWorkID}
+          selectedTraceSelection={selectedTraceSelection}
+        />
+        <span
+          aria-hidden="true"
+          className="hidden shrink-0 self-center text-on-surface-variant sm:block"
+        >
+          →
+        </span>
+        <TraceRelationPathEndpointView
+          endpoint={entry.target}
+          endpointLabel={targetLabel}
+          locale={locale}
+          messages={messages}
+          onSelectTraceSelection={onSelectTraceSelection}
+          onSelectWorkID={onSelectWorkID}
+          selectedTraceSelection={selectedTraceSelection}
+        />
+      </div>
+    </li>
+  );
+}
+
+function TraceRelationPathEndpointView({
+  endpoint,
+  endpointLabel,
+  messages,
+  onSelectTraceSelection,
+  onSelectWorkID,
+  selectedTraceSelection,
+}: Omit<TraceRelationPathProps, "entries"> & {
+  endpoint: TraceRelationPathEndpoint;
+  endpointLabel: string;
+  messages: ReturnType<typeof getTraceDrilldownMessages>;
+}) {
+  return (
+    <div className="grid min-w-0 flex-1 gap-1">
+      <span className="text-xs font-semibold uppercase tracking-wide text-on-surface-variant">
+        {endpointLabel}
+      </span>
+      <span className="break-words font-semibold text-on-surface">
+        {endpoint.label}
+      </span>
+      {endpoint.dispatchID ? (
+        <Code className="max-w-full break-all" size="supporting">
+          {endpoint.dispatchID}
+        </Code>
+      ) : null}
+      {endpoint.selectionIdentities.length > 0 ? (
+        <ul className="m-0 grid min-w-0 gap-1 p-0">
+          {endpoint.selectionIdentities.map((selection) => (
+            <li className="list-none" key={traceSelectionKey(selection)}>
+              {onSelectTraceSelection || onSelectWorkID ? (
+                <Button
+                  aria-pressed={traceSelectionMatches(
+                    selection,
+                    selectedTraceSelection,
+                  )}
+                  className="h-auto min-h-11 max-w-full justify-start whitespace-normal px-2.5 py-2 text-left"
+                  data-trace-selection-key={traceSelectionKey(selection)}
+                  data-trace-selection-surface="text"
+                  onClick={() => {
+                    onSelectTraceSelection?.(selection);
+                    if (!onSelectTraceSelection && selection.work_id) {
+                      onSelectWorkID?.(selection.work_id);
+                    }
+                  }}
+                  title={messages.traceSelectionIdentityLabel(
+                    selection.dispatch_id,
+                    selection.work_id,
+                    selection.attempt,
+                  )}
+                  tone="outline"
+                >
+                  {messages.traceSelectionIdentityLabel(
+                    selection.dispatch_id,
+                    selection.work_id,
+                    selection.attempt,
+                  )}
+                </Button>
+              ) : (
+                <Code size="supporting">
+                  {messages.traceSelectionIdentityLabel(
+                    selection.dispatch_id,
+                    selection.work_id,
+                    selection.attempt,
+                  )}
+                </Code>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : endpoint.workID ? (
+        onSelectWorkID ? (
+          <Button
+            className="h-auto min-h-11 max-w-full justify-start whitespace-normal px-2.5 py-2 text-left"
+            onClick={() => onSelectWorkID(endpoint.workID ?? "")}
+            title={endpoint.workID}
+            tone="outline"
+          >
+            {messages.selectWorkLabel(endpoint.workID)}
+          </Button>
+        ) : (
+          <Code size="supporting">{endpoint.workID}</Code>
+        )
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/features/trace-drilldown/components/trace-workstation-path.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-workstation-path.test.tsx
@@ -1,5 +1,11 @@
 // biome-ignore lint/style/noExcessiveLinesPerFile: trace workstation path coverage shares one mocked React Flow harness for lineage, layout bounds, and semantics regressions.
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
@@ -373,7 +379,11 @@ describe("TraceWorkstationPath fallback lineage", () => {
       expect(renderedEdgePairs()).toEqual([]);
     });
 
-    expect(screen.getByRole("status").textContent).toBe(
+    expect(
+      document.querySelector<HTMLElement>(
+        '[data-trace-lineage-status="unresolved"]',
+      )?.textContent,
+    ).toBe(
       "Lineage is unresolved: no recorded relationship connects one or more dispatches, so no predecessor was inferred.",
     );
   });
@@ -416,8 +426,10 @@ describe("TraceWorkstationPath localization", () => {
       ).toBe("true");
     });
 
-    expect(screen.getByText("计划")).toBeTruthy();
-    expect(screen.getByText("实现")).toBeTruthy();
+    const graph = screen.getByRole("region", { name: "分派关系图" });
+    expect(graph.querySelector('[data-workstation-title="true"]')).toBeTruthy();
+    expect(within(graph).getByText("计划")).toBeTruthy();
+    expect(within(graph).getByText("实现")).toBeTruthy();
     expect(
       screen
         .getByTestId("trace-react-flow-controls")
@@ -565,17 +577,28 @@ describe("TraceWorkstationPath semantics", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("dispatch-plan")).toBeTruthy();
+      expect(
+        within(screen.getByTestId("trace-react-flow")).getByText(
+          "dispatch-plan",
+        ),
+      ).toBeTruthy();
     });
 
-    expect(screen.queryByText("Dispatch")).toBeNull();
+    expect(
+      within(
+        screen.getByRole("region", { name: "Textual relation path" }),
+      ).getByText("Dispatch"),
+    ).toBeTruthy();
     expect(screen.queryByText("Workstation")).toBeNull();
     expect(screen.queryByText("Accepted")).toBeNull();
     expect(screen.queryByText("Failed")).toBeNull();
     expect(screen.queryByText(/^In:/)).toBeNull();
     expect(screen.queryByText(/^Out:/)).toBeNull();
 
-    const acceptedNode = screen.getByText("dispatch-plan").closest("article");
+    const graph = screen.getByTestId("trace-react-flow");
+    const acceptedNode = within(graph)
+      .getByText("dispatch-plan")
+      .closest("article");
     if (!acceptedNode) {
       throw new Error("Expected accepted workstation node to render.");
     }
@@ -584,7 +607,9 @@ describe("TraceWorkstationPath semantics", () => {
     );
     expect(acceptedNode.className).toContain("border-info-border");
 
-    const failedNode = screen.getByText("dispatch-repair").closest("article");
+    const failedNode = within(graph)
+      .getByText("dispatch-repair")
+      .closest("article");
     if (!failedNode) {
       throw new Error("Expected failed workstation node to render.");
     }

--- a/ui/src/features/trace-drilldown/components/trace-workstation-path.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-workstation-path.test.tsx
@@ -359,23 +359,23 @@ describe("TraceWorkstationPath fallback lineage", () => {
     });
   });
 
-  it("falls back to sequential ordering when no explicit or work-item lineage is available", async () => {
+  it("shows unresolved lineage instead of inventing sequential edges", async () => {
     render(
       <TraceWorkstationPath
         dispatches={[
           buildDispatch("dispatch-plan"),
           buildDispatch("dispatch-review"),
-          buildDispatch("dispatch-implement"),
         ]}
       />,
     );
 
     await waitFor(() => {
-      expect(renderedEdgePairs()).toEqual([
-        "dispatch-plan->dispatch-review",
-        "dispatch-review->dispatch-implement",
-      ]);
+      expect(renderedEdgePairs()).toEqual([]);
     });
+
+    expect(screen.getByRole("status").textContent).toBe(
+      "Lineage is unresolved: no recorded relationship connects one or more dispatches, so no predecessor was inferred.",
+    );
   });
 });
 

--- a/ui/src/features/trace-drilldown/components/trace-workstation-path.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-workstation-path.tsx
@@ -21,6 +21,7 @@ import { failOnTraceReactFlowError } from "../lib/trace-react-flow-error";
 import type { TraceSelectionIdentity } from "../lib/trace-selection";
 import { useMeasuredTraceGraphViewport } from "../lib/use-measured-trace-graph-viewport";
 import { getTraceDrilldownMessages } from "../messages/trace-drilldown";
+import { TraceRelationPath } from "./trace-relation-path";
 
 const GRAPH_SHELL_STYLE = { height: 320, minHeight: 256 };
 const GRAPH_VIEWPORT_STYLE = { height: "100%", width: "100%" };
@@ -33,6 +34,7 @@ export interface TraceWorkstationPathProps {
   dispatches: DashboardTraceDispatch[];
   locale?: string;
   onSelectTraceSelection?: (selection: TraceSelectionIdentity) => void;
+  renderGraph?: boolean;
   selectedTraceSelection?: TraceSelectionIdentity | null;
 }
 
@@ -40,6 +42,7 @@ export function TraceWorkstationPath({
   dispatches,
   locale,
   onSelectTraceSelection,
+  renderGraph = true,
   selectedTraceSelection,
 }: TraceWorkstationPathProps) {
   const messages = getTraceDrilldownMessages(locale);
@@ -113,12 +116,14 @@ export function TraceWorkstationPath({
   const { graphViewportReady, graphViewportRef } =
     useMeasuredTraceGraphViewport();
 
-  if (graph.nodes.length === 0) {
-    return <span>{messages.dispatchPathEmpty}</span>;
-  }
-
   return (
     <div className="grid max-w-full min-w-80 gap-2">
+      <TraceRelationPath
+        entries={graph.relations}
+        locale={locale}
+        onSelectTraceSelection={onSelectTraceSelection}
+        selectedTraceSelection={selectedTraceSelection}
+      />
       {graph.lineageStatus === "unresolved" ? (
         <p
           aria-live="polite"
@@ -129,31 +134,35 @@ export function TraceWorkstationPath({
           {messages.unresolvedLineageMessage}
         </p>
       ) : null}
-      <div
-        className="relative max-w-full resize overflow-hidden"
-        style={GRAPH_SHELL_STYLE}
-      >
-        <GraphViewportSurface
-          aria-label={messages.dispatchPathGraphLabel}
-          className="h-full border-transparent"
-          data-trace-workstation-path
+      {renderGraph && graph.nodes.length > 0 ? (
+        <div
+          className="relative max-w-full resize overflow-hidden"
+          style={GRAPH_SHELL_STYLE}
         >
-          <div
-            className="h-full min-w-0 w-full"
-            data-trace-graph-viewport
-            ref={graphViewportRef}
-            style={GRAPH_VIEWPORT_STYLE}
+          <GraphViewportSurface
+            aria-label={messages.dispatchPathGraphLabel}
+            className="h-full border-transparent"
+            data-trace-workstation-path
           >
-            {graphViewportReady ? (
-              <TraceWorkstationReactFlow
-                edges={graph.edges}
-                nodes={nodes}
-                onNodesChange={handleNodesChange}
-              />
-            ) : null}
-          </div>
-        </GraphViewportSurface>
-      </div>
+            <div
+              className="h-full min-w-0 w-full"
+              data-trace-graph-viewport
+              ref={graphViewportRef}
+              style={GRAPH_VIEWPORT_STYLE}
+            >
+              {graphViewportReady ? (
+                <TraceWorkstationReactFlow
+                  edges={graph.edges}
+                  nodes={nodes}
+                  onNodesChange={handleNodesChange}
+                />
+              ) : null}
+            </div>
+          </GraphViewportSurface>
+        </div>
+      ) : graph.nodes.length === 0 ? (
+        <span>{messages.dispatchPathEmpty}</span>
+      ) : null}
     </div>
   );
 }

--- a/ui/src/features/trace-drilldown/components/trace-workstation-path.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-workstation-path.tsx
@@ -18,6 +18,7 @@ import type { TraceDispatchFlowNode } from "../lib/trace-dispatch-factory-graph-
 import { buildTraceDispatchFactoryGraphFlow } from "../lib/trace-dispatch-factory-graph-flow";
 import { applyTraceFactoryGraphLayoutToNode } from "../lib/trace-factory-graph-layout";
 import { failOnTraceReactFlowError } from "../lib/trace-react-flow-error";
+import type { TraceSelectionIdentity } from "../lib/trace-selection";
 import { useMeasuredTraceGraphViewport } from "../lib/use-measured-trace-graph-viewport";
 import { getTraceDrilldownMessages } from "../messages/trace-drilldown";
 
@@ -31,16 +32,25 @@ const TRACE_DISPATCH_FLOW_FIT_VIEW_OPTIONS = {
 export interface TraceWorkstationPathProps {
   dispatches: DashboardTraceDispatch[];
   locale?: string;
+  onSelectTraceSelection?: (selection: TraceSelectionIdentity) => void;
+  selectedTraceSelection?: TraceSelectionIdentity | null;
 }
 
 export function TraceWorkstationPath({
   dispatches,
   locale,
+  onSelectTraceSelection,
+  selectedTraceSelection,
 }: TraceWorkstationPathProps) {
   const messages = getTraceDrilldownMessages(locale);
   const graph = useMemo(
-    () => buildTraceDispatchFactoryGraphFlow(dispatches, locale),
-    [dispatches, locale],
+    () =>
+      buildTraceDispatchFactoryGraphFlow(dispatches, {
+        locale,
+        onSelectTraceSelection,
+        selectedTraceSelection,
+      }),
+    [dispatches, locale, onSelectTraceSelection, selectedTraceSelection],
   );
   const topologyKey = useMemo(
     () => traceDispatchTopologyLayoutKey(graph.topology),
@@ -167,7 +177,7 @@ function TraceWorkstationReactFlow({
       minZoom={0.35}
       nodes={nodes}
       nodesDraggable={true}
-      nodeTypes={FACTORY_GRAPH_NODE_TYPES}
+      nodeTypes={TRACE_DISPATCH_NODE_TYPES}
       onNodesChange={onNodesChange}
       onError={failOnTraceReactFlowError}
       panOnDrag
@@ -179,5 +189,27 @@ function TraceWorkstationReactFlow({
         fitViewOptions={TRACE_DISPATCH_FLOW_FIT_VIEW_OPTIONS}
       />
     </ReactFlow>
+  );
+}
+
+type FactoryWorkstationNodeProps = Parameters<
+  (typeof FACTORY_GRAPH_NODE_TYPES)["workstation"]
+>[0];
+
+const TRACE_DISPATCH_NODE_TYPES = {
+  ...FACTORY_GRAPH_NODE_TYPES,
+  workstation: TraceDispatchWorkstationNode,
+};
+
+function TraceDispatchWorkstationNode(props: FactoryWorkstationNodeProps) {
+  const data = props.data as TraceDispatchFlowNode["data"];
+
+  return (
+    <div
+      data-trace-selection-keys={JSON.stringify(data.traceSelectionKeys ?? [])}
+      data-trace-selection-surface="graph"
+    >
+      <FACTORY_GRAPH_NODE_TYPES.workstation {...props} />
+    </div>
   );
 }

--- a/ui/src/features/trace-drilldown/components/trace-workstation-path.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-workstation-path.tsx
@@ -108,30 +108,42 @@ export function TraceWorkstationPath({
   }
 
   return (
-    <div
-      className="relative max-w-full min-w-80 resize overflow-hidden"
-      style={GRAPH_SHELL_STYLE}
-    >
-      <GraphViewportSurface
-        aria-label={messages.dispatchPathGraphLabel}
-        className="h-full border-transparent"
-        data-trace-workstation-path
-      >
-        <div
-          className="h-full min-w-0 w-full"
-          data-trace-graph-viewport
-          ref={graphViewportRef}
-          style={GRAPH_VIEWPORT_STYLE}
+    <div className="grid max-w-full min-w-80 gap-2">
+      {graph.lineageStatus === "unresolved" ? (
+        <p
+          aria-live="polite"
+          className="m-0 rounded-md border border-af-warning-border bg-warning-container px-3 py-2 text-sm text-on-warning-container"
+          data-trace-lineage-status="unresolved"
+          role="status"
         >
-          {graphViewportReady ? (
-            <TraceWorkstationReactFlow
-              edges={graph.edges}
-              nodes={nodes}
-              onNodesChange={handleNodesChange}
-            />
-          ) : null}
-        </div>
-      </GraphViewportSurface>
+          {messages.unresolvedLineageMessage}
+        </p>
+      ) : null}
+      <div
+        className="relative max-w-full resize overflow-hidden"
+        style={GRAPH_SHELL_STYLE}
+      >
+        <GraphViewportSurface
+          aria-label={messages.dispatchPathGraphLabel}
+          className="h-full border-transparent"
+          data-trace-workstation-path
+        >
+          <div
+            className="h-full min-w-0 w-full"
+            data-trace-graph-viewport
+            ref={graphViewportRef}
+            style={GRAPH_VIEWPORT_STYLE}
+          >
+            {graphViewportReady ? (
+              <TraceWorkstationReactFlow
+                edges={graph.edges}
+                nodes={nodes}
+                onNodesChange={handleNodesChange}
+              />
+            ) : null}
+          </div>
+        </GraphViewportSurface>
+      </div>
     </div>
   );
 }

--- a/ui/src/features/trace-drilldown/hooks/useTrace.session-scope.stories.tsx
+++ b/ui/src/features/trace-drilldown/hooks/useTrace.session-scope.stories.tsx
@@ -1,0 +1,181 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useLayoutEffect, useState } from "react";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+import type { DashboardTrace } from "../../../api/dashboard/types";
+import {
+  factoryTimelineEntryKey,
+  useFactoryTimelineStore,
+} from "../../timeline/public/store";
+import type { StreamDerivedCacheIdentity } from "../../timeline/public/stream-identity";
+import { TraceGridBentoCard } from "../components/trace-grid-card";
+import { dashboardTraceQueryKey } from "./useTrace";
+import { useTraceDrilldown } from "./useTraceDrilldown";
+
+const STREAM_IDENTITY_A: StreamDerivedCacheIdentity = {
+  backendScopeID: "storybook-backend",
+  factorySessionID: "storybook-session-a",
+  logicalSessionKeyID: "storybook-logical-a",
+  streamGenerationID: "storybook-generation-a",
+};
+
+const STREAM_IDENTITY_B: StreamDerivedCacheIdentity = {
+  backendScopeID: "storybook-backend",
+  factorySessionID: "storybook-session-b",
+  logicalSessionKeyID: "storybook-logical-b",
+  streamGenerationID: "storybook-generation-b",
+};
+
+const SHARED_WORK_ID = "storybook-shared-work";
+
+function buildTrace(traceID: string): DashboardTrace {
+  return {
+    dispatches: [
+      {
+        dispatch_id: `${traceID}-dispatch`,
+        end_time: "2026-08-15T12:00:01Z",
+        outcome: "ACCEPTED",
+        start_time: "2026-08-15T12:00:00Z",
+        transition_id: "review",
+        workstation_name: "Review",
+      },
+    ],
+    relations: [],
+    request_ids: [],
+    trace_id: traceID,
+    transition_ids: [],
+    work_ids: [SHARED_WORK_ID],
+    work_items: [],
+    workstation_sequence: [],
+  };
+}
+
+function seedTrace(
+  streamIdentity: StreamDerivedCacheIdentity,
+  trace: DashboardTrace,
+): void {
+  const store = useFactoryTimelineStore.getState();
+  const entryKey = factoryTimelineEntryKey(streamIdentity);
+  if (!store.entriesByKey[entryKey]) {
+    store.activateEntry(streamIdentity);
+  }
+
+  useFactoryTimelineStore.setState((state) => {
+    const entry = state.entriesByKey[entryKey];
+    if (!entry) {
+      throw new Error("Expected the Storybook trace timeline entry.");
+    }
+    const snapshot = entry.worldViewCache[0];
+    if (!snapshot) {
+      throw new Error("Expected the Storybook trace timeline snapshot.");
+    }
+
+    const nextEntry = {
+      ...entry,
+      selectedTick: 0,
+      worldViewCache: {
+        0: {
+          ...snapshot,
+          tracesByWorkID: { [SHARED_WORK_ID]: trace },
+        },
+      },
+    };
+
+    return {
+      ...(state.activeEntryKey === entryKey ? nextEntry : {}),
+      entriesByKey: {
+        ...state.entriesByKey,
+        [entryKey]: nextEntry,
+      },
+    };
+  });
+}
+
+function TraceSessionScopeStory() {
+  const queryClient = useQueryClient();
+  const [selectedIdentity, setSelectedIdentity] = useState(STREAM_IDENTITY_A);
+  const { traceGridState } = useTraceDrilldown(
+    SHARED_WORK_ID,
+    null,
+    "en",
+    selectedIdentity,
+  );
+
+  useLayoutEffect(() => {
+    useFactoryTimelineStore.getState().reset();
+    seedTrace(STREAM_IDENTITY_A, buildTrace("trace-session-a"));
+    seedTrace(STREAM_IDENTITY_B, buildTrace("trace-session-b"));
+    useFactoryTimelineStore.getState().activateEntry(STREAM_IDENTITY_A);
+  }, []);
+
+  function deliverLateSessionAResult() {
+    const lateTrace = buildTrace("trace-session-a-late");
+    seedTrace(STREAM_IDENTITY_A, lateTrace);
+    queryClient.setQueryData(
+      dashboardTraceQueryKey(SHARED_WORK_ID, null, 0, STREAM_IDENTITY_A),
+      lateTrace,
+    );
+  }
+
+  return (
+    <main className="grid min-h-screen gap-4 bg-surface p-4 text-on-surface">
+      <div className="flex flex-wrap items-center gap-2">
+        <span aria-live="polite" role="status">
+          Selected stream: {selectedIdentity === STREAM_IDENTITY_A ? "A" : "B"}
+        </span>
+        <button
+          onClick={() => setSelectedIdentity(STREAM_IDENTITY_A)}
+          type="button"
+        >
+          Select session A
+        </button>
+        <button
+          onClick={() => setSelectedIdentity(STREAM_IDENTITY_B)}
+          type="button"
+        >
+          Select session B
+        </button>
+        <button onClick={deliverLateSessionAResult} type="button">
+          Deliver late session A result
+        </button>
+      </div>
+      <TraceGridBentoCard state={traceGridState} />
+    </main>
+  );
+}
+
+export default {
+  title: "you-agent-factory/Trace Drilldown/Session Scope",
+  component: TraceSessionScopeStory,
+  tags: ["test"],
+};
+
+export const LateResultDoesNotCrossSessions = {
+  render: () => <TraceSessionScopeStory />,
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const card = await canvas.findByRole("article", {
+      name: "Trace drill-down",
+    });
+
+    await expect(
+      await within(card).findByText("trace-session-a"),
+    ).toBeVisible();
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Select session B" }),
+    );
+    await waitFor(() => {
+      expect(within(card).getByText("trace-session-b")).toBeVisible();
+    });
+
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: "Deliver late session A result",
+      }),
+    );
+    await waitFor(() => {
+      expect(within(card).getByText("trace-session-b")).toBeVisible();
+      expect(within(card).queryByText("trace-session-a-late")).toBeNull();
+    });
+  },
+};

--- a/ui/src/features/trace-drilldown/hooks/useTrace.session-scope.test.tsx
+++ b/ui/src/features/trace-drilldown/hooks/useTrace.session-scope.test.tsx
@@ -1,0 +1,147 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { DashboardTrace } from "../../../api/dashboard/types";
+import {
+  factoryTimelineEntryKey,
+  useFactoryTimelineStore,
+} from "../../timeline/public/store";
+import type { StreamDerivedCacheIdentity } from "../../timeline/public/stream-identity";
+import { dashboardTraceQueryKey, useDashboardTrace } from "./useTrace";
+
+const streamIdentityA: StreamDerivedCacheIdentity = {
+  backendScopeID: "backend-scope",
+  factorySessionID: "session-a",
+  logicalSessionKeyID: "logical-a",
+  streamGenerationID: "generation-a",
+};
+
+const streamIdentityB: StreamDerivedCacheIdentity = {
+  backendScopeID: "backend-scope",
+  factorySessionID: "session-b",
+  logicalSessionKeyID: "logical-b",
+  streamGenerationID: "generation-b",
+};
+
+function buildTrace(traceID: string): DashboardTrace {
+  return {
+    dispatches: [],
+    relations: [],
+    request_ids: [],
+    trace_id: traceID,
+    transition_ids: [],
+    work_ids: ["work-shared"],
+    work_items: [],
+    workstation_sequence: [],
+  };
+}
+
+function seedTrace(
+  streamIdentity: StreamDerivedCacheIdentity,
+  trace: DashboardTrace,
+): void {
+  const entryKey = factoryTimelineEntryKey(streamIdentity);
+  const current = useFactoryTimelineStore.getState();
+  if (!current.entriesByKey[entryKey]) {
+    current.activateEntry(streamIdentity);
+  }
+
+  useFactoryTimelineStore.setState((state) => {
+    const entry = state.entriesByKey[entryKey];
+    if (!entry) {
+      throw new Error("Expected the trace test timeline entry to exist.");
+    }
+
+    const snapshot = entry.worldViewCache[0];
+    if (!snapshot) {
+      throw new Error("Expected the trace test timeline snapshot to exist.");
+    }
+    return {
+      entriesByKey: {
+        ...state.entriesByKey,
+        [entryKey]: {
+          ...entry,
+          selectedTick: 0,
+          worldViewCache: {
+            0: {
+              ...snapshot,
+              tracesByWorkID: { "work-shared": trace },
+            },
+          },
+        },
+      },
+    };
+  });
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useDashboardTrace session and stream identity", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    useFactoryTimelineStore.getState().reset();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { gcTime: 0, retry: false },
+      },
+    });
+  });
+
+  afterEach(() => {
+    useFactoryTimelineStore.getState().reset();
+    queryClient.clear();
+  });
+
+  it("keeps a late session A read out of the selected session B view", async () => {
+    const traceA = buildTrace("trace-session-a");
+    const traceB = buildTrace("trace-session-b");
+    seedTrace(streamIdentityA, traceA);
+    seedTrace(streamIdentityB, traceB);
+
+    const { result, rerender } = renderHook(
+      ({ streamIdentity }: { streamIdentity: StreamDerivedCacheIdentity }) =>
+        useDashboardTrace("work-shared", null, streamIdentity),
+      {
+        initialProps: { streamIdentity: streamIdentityA },
+        wrapper: createWrapper(queryClient),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data?.trace_id).toBe("trace-session-a");
+    });
+
+    act(() => {
+      rerender({ streamIdentity: streamIdentityB });
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.trace_id).toBe("trace-session-b");
+    });
+
+    const lateTraceA = buildTrace("trace-session-a-late");
+    act(() => {
+      seedTrace(streamIdentityA, lateTraceA);
+      queryClient.setQueryData(
+        dashboardTraceQueryKey("work-shared", null, 0, streamIdentityA),
+        lateTraceA,
+      );
+    });
+
+    expect(result.current.data?.trace_id).toBe("trace-session-b");
+    expect(
+      queryClient.getQueryData(
+        dashboardTraceQueryKey("work-shared", null, 0, streamIdentityB),
+      ),
+    ).toMatchObject({ trace_id: "trace-session-b" });
+  });
+});

--- a/ui/src/features/trace-drilldown/hooks/useTrace.ts
+++ b/ui/src/features/trace-drilldown/hooks/useTrace.ts
@@ -5,9 +5,38 @@ import type {
   DashboardTraceDispatch,
   DashboardWorkRelation,
 } from "../../../api/dashboard/types";
-import { useFactoryTimelineStore } from "../../timeline/state/factoryTimelineStore";
+import {
+  factoryTimelineEntryKey,
+  useFactoryTimelineStore,
+} from "../../timeline/public/store";
+import {
+  normalizeStreamDerivedCacheIdentity,
+  type StreamDerivedCacheIdentity,
+  streamDerivedCacheKeyPrefix,
+} from "../../timeline/public/stream-identity";
 
 const DASHBOARD_WORK_TRACE_QUERY_KEY = ["agent-factory-work-trace"] as const;
+const EMPTY_TRACES_BY_WORK_ID: Record<string, DashboardTrace> = {};
+
+export function dashboardTraceQueryKey(
+  workID: string | null,
+  traceID: string | null | undefined,
+  selectedTick: number,
+  streamIdentity?: StreamDerivedCacheIdentity | null,
+) {
+  const normalizedStreamIdentity =
+    normalizeStreamDerivedCacheIdentity(streamIdentity);
+
+  return [
+    ...DASHBOARD_WORK_TRACE_QUERY_KEY,
+    ...(normalizedStreamIdentity
+      ? streamDerivedCacheKeyPrefix(normalizedStreamIdentity)
+      : []),
+    workID,
+    traceID ?? "",
+    selectedTick,
+  ] as const;
+}
 
 export function expandTraceWithCausalPredecessors(
   trace: DashboardTrace | undefined,
@@ -94,24 +123,49 @@ export function expandTraceWithCausalPredecessors(
 export function useDashboardTrace(
   workID: string | null,
   traceID?: string | null,
+  streamIdentity?: StreamDerivedCacheIdentity | null,
 ) {
-  const selectedTick = useFactoryTimelineStore((state) => state.selectedTick);
-  const tracesByWorkID = useFactoryTimelineStore(
-    (state) => state.worldViewCache[state.selectedTick]?.tracesByWorkID ?? {},
+  const normalizedStreamIdentity = useMemo(
+    () => normalizeStreamDerivedCacheIdentity(streamIdentity),
+    [streamIdentity],
   );
-  const eventTrace = useFactoryTimelineStore(
-    (state) =>
-      state.worldViewCache[state.selectedTick]?.tracesByWorkID[workID ?? ""],
+  const scopedTimelineEntryKey = useMemo(
+    () =>
+      normalizedStreamIdentity
+        ? factoryTimelineEntryKey(normalizedStreamIdentity)
+        : null,
+    [normalizedStreamIdentity],
   );
-  const directTrace = useFactoryTimelineStore((state) => {
-    if (!traceID) {
-      return undefined;
+  const selectedTick = useFactoryTimelineStore((state) => {
+    if (scopedTimelineEntryKey === null) {
+      return state.selectedTick;
+    }
+    return state.entriesByKey[scopedTimelineEntryKey]?.selectedTick ?? 0;
+  });
+  const tracesByWorkID = useFactoryTimelineStore((state) => {
+    if (scopedTimelineEntryKey === null) {
+      return (
+        state.worldViewCache[state.selectedTick]?.tracesByWorkID ??
+        EMPTY_TRACES_BY_WORK_ID
+      );
     }
 
-    return Object.values(
-      state.worldViewCache[state.selectedTick]?.tracesByWorkID ?? {},
-    ).find((trace) => trace.trace_id === traceID);
-  });
+    const entry = state.entriesByKey[scopedTimelineEntryKey];
+    return (
+      entry?.worldViewCache[entry.selectedTick]?.tracesByWorkID ??
+      EMPTY_TRACES_BY_WORK_ID
+    );
+  }, Object.is);
+  const eventTrace = tracesByWorkID[workID ?? ""];
+  const directTrace = useMemo(
+    () =>
+      traceID
+        ? Object.values(tracesByWorkID).find(
+            (trace) => trace.trace_id === traceID,
+          )
+        : undefined,
+    [traceID, tracesByWorkID],
+  );
   const trace = useMemo(
     () =>
       expandTraceWithCausalPredecessors(
@@ -122,12 +176,12 @@ export function useDashboardTrace(
   );
 
   return useQuery({
-    queryKey: [
-      ...DASHBOARD_WORK_TRACE_QUERY_KEY,
+    queryKey: dashboardTraceQueryKey(
       workID,
-      traceID ?? "",
+      traceID,
       selectedTick,
-    ],
+      normalizedStreamIdentity,
+    ),
     queryFn: () => trace,
     enabled: trace !== undefined,
     initialData: trace,

--- a/ui/src/features/trace-drilldown/hooks/useTraceDrilldown.test.ts
+++ b/ui/src/features/trace-drilldown/hooks/useTraceDrilldown.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import type { DashboardTrace } from "../../../api/dashboard/types";
+import { resolveTraceGridState } from "./useTraceDrilldown";
+
+function buildTrace(overrides: Partial<DashboardTrace> = {}): DashboardTrace {
+  return {
+    dispatches: [],
+    relations: [],
+    trace_id: "trace-selected",
+    transition_ids: [],
+    work_ids: ["work-selected"],
+    workstation_sequence: [],
+    ...overrides,
+  };
+}
+
+function resolve(
+  overrides: Partial<Parameters<typeof resolveTraceGridState>[0]> = {},
+) {
+  return resolveTraceGridState({
+    error: null,
+    idleMessage: "Select work",
+    isLoading: false,
+    selectedTrace: buildTrace(),
+    selectedWorkID: "work-selected",
+    ...overrides,
+  });
+}
+
+describe("resolveTraceGridState", () => {
+  it("gives query errors precedence over known-empty classification", () => {
+    expect(resolve({ error: new Error("trace read failed") })).toEqual({
+      message: "trace read failed",
+      status: "error",
+    });
+  });
+
+  it("treats relation-only traces as successful content", () => {
+    const trace = buildTrace({
+      relations: [
+        {
+          source_work_id: "work-source",
+          target_work_id: "work-selected",
+          type: "DEPENDS_ON",
+        },
+      ],
+    });
+
+    expect(resolve({ selectedTrace: trace })).toEqual({
+      status: "ready",
+      trace,
+    });
+  });
+
+  it("keeps loading, known-empty, and dispatch-bearing success distinct", () => {
+    expect(resolve({ isLoading: true })).toEqual({
+      status: "loading",
+      workID: "work-selected",
+    });
+    expect(resolve()).toEqual({ status: "empty", workID: "work-selected" });
+
+    const trace = buildTrace({
+      dispatches: [
+        {
+          dispatch_id: "dispatch-selected",
+          end_time: "2026-08-15T12:00:01Z",
+          outcome: "ACCEPTED",
+          start_time: "2026-08-15T12:00:00Z",
+          transition_id: "process",
+        },
+      ],
+    });
+    expect(resolve({ selectedTrace: trace })).toEqual({
+      status: "ready",
+      trace,
+    });
+  });
+
+  it("keeps the unselected state explicit", () => {
+    expect(resolve({ selectedWorkID: null })).toEqual({
+      message: "Select work",
+      status: "idle",
+    });
+  });
+});

--- a/ui/src/features/trace-drilldown/hooks/useTraceDrilldown.ts
+++ b/ui/src/features/trace-drilldown/hooks/useTraceDrilldown.ts
@@ -1,3 +1,4 @@
+import type { StreamDerivedCacheIdentity } from "../../timeline/public/stream-identity";
 import type { TraceGridState } from "../components/trace-grid-card";
 import { getTraceDrilldownMessages } from "../messages/trace-drilldown";
 import { useDashboardTrace } from "./useTrace";
@@ -11,9 +12,14 @@ export function useTraceDrilldown(
   selectedWorkID: string | null,
   selectedTraceID?: string | null,
   locale?: string | null,
+  streamIdentity?: StreamDerivedCacheIdentity | null,
 ): UseTraceDrilldownResult {
   const messages = getTraceDrilldownMessages(locale);
-  const traceQuery = useDashboardTrace(selectedWorkID, selectedTraceID);
+  const traceQuery = useDashboardTrace(
+    selectedWorkID,
+    selectedTraceID,
+    streamIdentity,
+  );
   const selectedTrace = traceQuery.data;
   const traceUnavailable =
     selectedWorkID !== null &&

--- a/ui/src/features/trace-drilldown/hooks/useTraceDrilldown.ts
+++ b/ui/src/features/trace-drilldown/hooks/useTraceDrilldown.ts
@@ -1,3 +1,4 @@
+import type { DashboardTrace } from "../../../api/dashboard/types";
 import type { StreamDerivedCacheIdentity } from "../../timeline/public/stream-identity";
 import type { TraceGridState } from "../components/trace-grid-card";
 import { getTraceDrilldownMessages } from "../messages/trace-drilldown";
@@ -6,6 +7,47 @@ import { useDashboardTrace } from "./useTrace";
 export interface UseTraceDrilldownResult {
   selectedTrace: ReturnType<typeof useDashboardTrace>["data"];
   traceGridState: TraceGridState;
+}
+
+export interface ResolveTraceGridStateOptions {
+  error: unknown;
+  idleMessage: string;
+  isLoading: boolean;
+  selectedTrace: DashboardTrace | undefined;
+  selectedWorkID: string | null;
+}
+
+export function resolveTraceGridState({
+  error,
+  idleMessage,
+  isLoading,
+  selectedTrace,
+  selectedWorkID,
+}: ResolveTraceGridStateOptions): TraceGridState {
+  if (selectedWorkID === null) {
+    return { message: idleMessage, status: "idle" };
+  }
+
+  if (error) {
+    return {
+      message: error instanceof Error ? error.message : String(error),
+      status: "error",
+    };
+  }
+
+  if (isLoading) {
+    return { status: "loading", workID: selectedWorkID };
+  }
+
+  const hasTraceContent =
+    (selectedTrace?.dispatches.length ?? 0) > 0 ||
+    (selectedTrace?.relations?.length ?? 0) > 0;
+
+  if (selectedTrace && hasTraceContent) {
+    return { status: "ready", trace: selectedTrace };
+  }
+
+  return { status: "empty", workID: selectedWorkID };
 }
 
 export function useTraceDrilldown(
@@ -21,27 +63,13 @@ export function useTraceDrilldown(
     streamIdentity,
   );
   const selectedTrace = traceQuery.data;
-  const traceUnavailable =
-    selectedWorkID !== null &&
-    (selectedTrace === undefined || selectedTrace.dispatches.length === 0);
-  const traceGridState: TraceGridState =
-    selectedWorkID === null
-      ? {
-          status: "idle",
-          message: messages.idleMessage,
-        }
-      : traceQuery.isLoading
-        ? { status: "loading", workID: selectedWorkID }
-        : traceUnavailable
-          ? { status: "empty", workID: selectedWorkID }
-          : traceQuery.error instanceof Error
-            ? { status: "error", message: traceQuery.error.message }
-            : selectedTrace
-              ? { status: "ready", trace: selectedTrace }
-              : {
-                  status: "idle",
-                  message: messages.idleMessage,
-                };
+  const traceGridState = resolveTraceGridState({
+    error: traceQuery.error,
+    idleMessage: messages.idleMessage,
+    isLoading: traceQuery.isLoading,
+    selectedTrace,
+    selectedWorkID,
+  });
 
   return { selectedTrace, traceGridState };
 }

--- a/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph-flow.test.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph-flow.test.ts
@@ -83,6 +83,7 @@ function buildReplayWorkstationFlow() {
   });
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Flow coverage keeps shared-node parity and retry identity assertions together.
 describe("buildTraceDispatchFactoryGraphFlow", () => {
   it("projects dispatch history into shared workstation nodes and editor edges", () => {
     const flow = buildTraceDispatchFactoryGraphFlow([
@@ -151,6 +152,52 @@ describe("buildTraceDispatchFactoryGraphFlow", () => {
     );
 
     expect(flow.nodes[0]?.data.locale).toBe("zh");
+  });
+
+  it("keeps retry nodes distinct when dispatch and work identifiers repeat", () => {
+    const flow = buildTraceDispatchFactoryGraphFlow(
+      [
+        buildDispatch("dispatch-retry", {
+          attempt: 1,
+          work_ids: ["work-shared"],
+        }),
+        buildDispatch("dispatch-retry", {
+          attempt: 2,
+          work_ids: ["work-shared"],
+        }),
+      ],
+      {
+        selectedTraceSelection: {
+          attempt: 2,
+          dispatch_id: "dispatch-retry",
+          work_id: "work-shared",
+        },
+      },
+    );
+
+    expect(flow.nodes.map((node) => node.id)).toEqual([
+      "dispatch-retry#work-shared#attempt-1",
+      "dispatch-retry#work-shared#attempt-2",
+    ]);
+    expect(flow.nodes.map((node) => node.data.selectionIdentities)).toEqual([
+      [
+        {
+          attempt: 1,
+          dispatch_id: "dispatch-retry",
+          work_id: "work-shared",
+        },
+      ],
+      [
+        {
+          attempt: 2,
+          dispatch_id: "dispatch-retry",
+          work_id: "work-shared",
+        },
+      ],
+    ]);
+    expect(flow.nodes[0]?.data.selectedWorkstation).toBe(false);
+    expect(flow.nodes[1]?.data.selectedWorkstation).toBe(true);
+    expect(flow.nodes[1]?.data.selectedWorkID).toBe("work-shared");
   });
 
   it("registers only shared workstation graph React Flow node types", () => {

--- a/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph-flow.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph-flow.ts
@@ -28,6 +28,7 @@ export type TraceDispatchFlowNode = Node<
 export interface TraceDispatchFactoryGraphFlow {
   dispatchIdByNodeId: ReadonlyMap<string, string>;
   edges: FactoryGraphReactFlowEdge[];
+  lineageStatus: "resolved" | "unresolved";
   nodes: TraceDispatchFlowNode[];
   topology: FactoryGraphTopology;
 }
@@ -120,6 +121,7 @@ export function buildTraceDispatchFactoryGraphFlow(
   return {
     dispatchIdByNodeId: traceProjection.dispatchIdByNodeId,
     edges,
+    lineageStatus: traceProjection.lineageStatus,
     nodes,
     topology: traceProjection.topology,
   };

--- a/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph-flow.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph-flow.ts
@@ -14,6 +14,7 @@ import {
   type TraceDispatchFactoryGraphProjection,
   type TraceDispatchNodeOverlay,
 } from "./trace-dispatch-factory-graph";
+import type { TraceRelationPathEntry } from "./trace-relation-path";
 import {
   type TraceSelectionIdentity,
   traceSelectionKey,
@@ -39,6 +40,7 @@ export interface TraceDispatchFactoryGraphFlow {
   edges: FactoryGraphReactFlowEdge[];
   lineageStatus: "resolved" | "unresolved";
   nodes: TraceDispatchFlowNode[];
+  relations: readonly TraceRelationPathEntry[];
   selectionIdentitiesByNodeId: ReadonlyMap<
     string,
     readonly TraceSelectionIdentity[]
@@ -132,6 +134,7 @@ export function buildTraceDispatchFactoryGraphFlow(
     edges,
     lineageStatus: traceProjection.lineageStatus,
     nodes,
+    relations: traceProjection.relations,
     selectionIdentitiesByNodeId,
     topology: traceProjection.topology,
   };

--- a/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph-flow.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph-flow.ts
@@ -11,13 +11,22 @@ import {
 } from "../../factory-graph-editor/lib/projection/factory-graph-react-flow-projection";
 import {
   projectTraceDispatchesToFactoryGraph,
+  type TraceDispatchFactoryGraphProjection,
   type TraceDispatchNodeOverlay,
 } from "./trace-dispatch-factory-graph";
+import {
+  type TraceSelectionIdentity,
+  traceSelectionKey,
+  traceSelectionMatches,
+} from "./trace-selection";
 
 export type TraceDispatchFlowNodeData = FactoryGraphWorkstationNodeData &
   TraceDispatchNodeOverlay & {
     factoryNodeId: string;
     locale?: string;
+    onSelectTraceSelection?: (selection: TraceSelectionIdentity) => void;
+    selectionIdentities: readonly TraceSelectionIdentity[];
+    traceSelectionKeys: readonly string[];
   } & Record<string, unknown>;
 
 export type TraceDispatchFlowNode = Node<
@@ -30,13 +39,25 @@ export interface TraceDispatchFactoryGraphFlow {
   edges: FactoryGraphReactFlowEdge[];
   lineageStatus: "resolved" | "unresolved";
   nodes: TraceDispatchFlowNode[];
+  selectionIdentitiesByNodeId: ReadonlyMap<
+    string,
+    readonly TraceSelectionIdentity[]
+  >;
   topology: FactoryGraphTopology;
 }
 
 export function buildTraceDispatchFactoryGraphFlow(
   dispatches: DashboardTraceDispatch[],
-  locale?: string,
+  localeOrOptions:
+    | string
+    | {
+        locale?: string;
+        onSelectTraceSelection?: (selection: TraceSelectionIdentity) => void;
+        selectedTraceSelection?: TraceSelectionIdentity | null;
+      } = {},
 ): TraceDispatchFactoryGraphFlow {
+  const { locale, onSelectTraceSelection, selectedTraceSelection } =
+    normalizeTraceDispatchGraphOptions(localeOrOptions);
   const traceProjection = projectTraceDispatchesToFactoryGraph(
     dispatches,
     locale,
@@ -46,51 +67,25 @@ export function buildTraceDispatchFactoryGraphFlow(
     mode: "observer",
     topology: traceProjection.topology,
   });
-  const nodes = factoryProjection.nodes.map((node) => {
-    const overlay = traceProjection.overlaysByNodeId.get(node.id);
-    if (!overlay) {
-      throw new Error(`Missing trace overlay for factory node ${node.id}.`);
-    }
-
-    const dispatchId = overlay.dispatchId;
-    const handles = node.data.handles.map((handle) => ({
-      ...handle,
-      hidden: true,
-    }));
-    return {
-      ...node,
-      data: {
-        ...overlay,
-        active: false,
-        activeFlow: false,
-        executions: [],
-        factoryNodeId: node.id,
-        handles,
-        kind: "workstation",
-        locale,
-        muted: false,
-        now: 0,
-        runtimeStatus: overlay.outcome,
-        selectedWorkID: null,
-        selectedWorkstation: false,
-        summaryOnly: true,
-        workstation: traceDispatchWorkstationNode(overlay),
-        workstationSemantics: node.data.workstationSemantics,
-      },
-      id: dispatchId,
-      sourcePosition: Position.Right,
-      targetPosition: Position.Left,
-      type: "workstation",
-    } satisfies TraceDispatchFlowNode;
-  });
+  const nodes = factoryProjection.nodes.map((node) =>
+    buildTraceDispatchFlowNode(
+      node,
+      traceProjection,
+      locale,
+      onSelectTraceSelection,
+      selectedTraceSelection,
+    ),
+  );
 
   const nodesByID = new Map(nodes.map((node) => [node.id, node]));
 
   const edges = factoryProjection.edges.map((edge) => {
     const source =
-      traceProjection.dispatchIdByNodeId.get(edge.source) ?? edge.source;
+      traceProjection.traceNodeIdByFactoryNodeId.get(edge.source) ??
+      edge.source;
     const target =
-      traceProjection.dispatchIdByNodeId.get(edge.target) ?? edge.target;
+      traceProjection.traceNodeIdByFactoryNodeId.get(edge.target) ??
+      edge.target;
     const sourceNode = nodesByID.get(source);
     const targetNode = nodesByID.get(target);
 
@@ -118,13 +113,109 @@ export function buildTraceDispatchFactoryGraphFlow(
     };
   });
 
+  const selectionIdentitiesByNodeId = new Map(
+    factoryProjection.nodes.flatMap((node) => {
+      const flowNodeID = traceProjection.traceNodeIdByFactoryNodeId.get(
+        node.id,
+      );
+      const identities = traceProjection.selectionIdentitiesByNodeId.get(
+        node.id,
+      );
+      return flowNodeID && identities
+        ? [[flowNodeID, identities] as const]
+        : [];
+    }),
+  );
+
   return {
-    dispatchIdByNodeId: traceProjection.dispatchIdByNodeId,
+    dispatchIdByNodeId: traceProjection.traceNodeIdByFactoryNodeId,
     edges,
     lineageStatus: traceProjection.lineageStatus,
     nodes,
+    selectionIdentitiesByNodeId,
     topology: traceProjection.topology,
   };
+}
+
+function buildTraceDispatchFlowNode(
+  node: ReturnType<typeof projectFactoryGraphToReactFlow>["nodes"][number],
+  traceProjection: TraceDispatchFactoryGraphProjection,
+  locale: string | undefined,
+  onSelectTraceSelection:
+    | ((selection: TraceSelectionIdentity) => void)
+    | undefined,
+  selectedTraceSelection: TraceSelectionIdentity | null | undefined,
+): TraceDispatchFlowNode {
+  const overlay = traceProjection.overlaysByNodeId.get(node.id);
+  if (!overlay) {
+    throw new Error(`Missing trace overlay for factory node ${node.id}.`);
+  }
+
+  const flowNodeID =
+    traceProjection.traceNodeIdByFactoryNodeId.get(node.id) ??
+    overlay.dispatchId;
+  const selectionIdentities =
+    traceProjection.selectionIdentitiesByNodeId.get(node.id) ?? [];
+  const selectedSelection = selectionIdentities.find((selection) =>
+    traceSelectionMatches(selection, selectedTraceSelection),
+  );
+  const handles = node.data.handles.map((handle) => ({
+    ...handle,
+    hidden: true,
+  }));
+
+  return {
+    ...node,
+    data: {
+      ...overlay,
+      active: false,
+      activeFlow: false,
+      executions: [],
+      factoryNodeId: node.id,
+      handles,
+      kind: "workstation",
+      locale,
+      muted: false,
+      now: 0,
+      onSelectTraceSelection,
+      runtimeStatus: overlay.outcome,
+      selectedWorkID: selectedSelection?.work_id || null,
+      selectedWorkstation: Boolean(selectedSelection),
+      selectionIdentities,
+      traceSelectionKeys: selectionIdentities.map(traceSelectionKey),
+      summaryOnly: true,
+      workstation: traceDispatchWorkstationNode(overlay),
+      workstationSemantics: node.data.workstationSemantics,
+      ...(onSelectTraceSelection && selectionIdentities[0]
+        ? {
+            onSelectWorkstation: () =>
+              onSelectTraceSelection(selectionIdentities[0]),
+          }
+        : {}),
+    },
+    id: flowNodeID,
+    sourcePosition: Position.Right,
+    targetPosition: Position.Left,
+    type: "workstation",
+  } satisfies TraceDispatchFlowNode;
+}
+
+function normalizeTraceDispatchGraphOptions(
+  localeOrOptions:
+    | string
+    | {
+        locale?: string;
+        onSelectTraceSelection?: (selection: TraceSelectionIdentity) => void;
+        selectedTraceSelection?: TraceSelectionIdentity | null;
+      },
+): {
+  locale?: string;
+  onSelectTraceSelection?: (selection: TraceSelectionIdentity) => void;
+  selectedTraceSelection?: TraceSelectionIdentity | null;
+} {
+  return typeof localeOrOptions === "string"
+    ? { locale: localeOrOptions }
+    : localeOrOptions;
 }
 
 function resolveTraceEdgeHandle(

--- a/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph.test.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph.test.ts
@@ -102,6 +102,28 @@ describe("projectTraceDispatchesToFactoryGraph explicit lineage", () => {
         (edge) => edge.kind === "workstation-on-continue",
       ),
     ).toBe(true);
+    expect(projection.relations).toHaveLength(2);
+    expect(projection.relations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "predecessor",
+          relationType: "PREDECESSOR",
+          source: expect.objectContaining({
+            dispatchID: "dispatch-plan",
+            selectionIdentities: [
+              {
+                attempt: 1,
+                dispatch_id: "dispatch-plan",
+                work_id: "work-reviewed",
+              },
+            ],
+          }),
+          target: expect.objectContaining({
+            dispatchID: "dispatch-implement",
+          }),
+        }),
+      ]),
+    );
   });
 });
 
@@ -119,6 +141,9 @@ describe("projectTraceDispatchesToFactoryGraph recorded lineage", () => {
     expect(dispatchEdgePairs(projection)).toEqual([
       "dispatch-plan->dispatch-implement",
     ]);
+    expect(projection.relations.map((relation) => relation.kind)).toEqual([
+      "predecessor",
+    ]);
   });
 
   it("marks missing lineage unresolved instead of inventing sequential edges", () => {
@@ -133,6 +158,7 @@ describe("projectTraceDispatchesToFactoryGraph recorded lineage", () => {
 
       expect(projection.lineageStatus).toBe("unresolved");
       expect(dispatchEdgePairs(projection)).toEqual([]);
+      expect(projection.relations).toEqual([]);
     }
   });
 });

--- a/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph.test.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph.test.ts
@@ -105,7 +105,7 @@ describe("projectTraceDispatchesToFactoryGraph explicit lineage", () => {
   });
 });
 
-describe("projectTraceDispatchesToFactoryGraph fallback lineage", () => {
+describe("projectTraceDispatchesToFactoryGraph recorded lineage", () => {
   it("falls back to output-to-input work lineage when chaining metadata is absent", () => {
     const projection = projectTraceDispatchesToFactoryGraph([
       buildDispatch("dispatch-plan", {
@@ -121,17 +121,19 @@ describe("projectTraceDispatchesToFactoryGraph fallback lineage", () => {
     ]);
   });
 
-  it("falls back to sequential ordering when no explicit or work-item lineage is available", () => {
-    const projection = projectTraceDispatchesToFactoryGraph([
+  it("marks missing lineage unresolved instead of inventing sequential edges", () => {
+    const dispatches = [
       buildDispatch("dispatch-plan"),
       buildDispatch("dispatch-review"),
-      buildDispatch("dispatch-implement"),
-    ]);
+    ];
 
-    expect(dispatchEdgePairs(projection)).toEqual([
-      "dispatch-plan->dispatch-review",
-      "dispatch-review->dispatch-implement",
-    ]);
+    for (const orderedDispatches of [dispatches, [...dispatches].reverse()]) {
+      const projection =
+        projectTraceDispatchesToFactoryGraph(orderedDispatches);
+
+      expect(projection.lineageStatus).toBe("unresolved");
+      expect(dispatchEdgePairs(projection)).toEqual([]);
+    }
   });
 });
 

--- a/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph.ts
@@ -22,6 +22,7 @@ export interface TraceDispatchNodeOverlay {
 
 export interface TraceDispatchFactoryGraphProjection {
   dispatchIdByNodeId: ReadonlyMap<string, string>;
+  lineageStatus: "resolved" | "unresolved";
   nodeIdByDispatchId: ReadonlyMap<string, string>;
   overlaysByNodeId: ReadonlyMap<string, TraceDispatchNodeOverlay>;
   topology: FactoryGraphTopology;
@@ -70,6 +71,7 @@ export function projectTraceDispatchesToFactoryGraph(
   );
   const edgeKeys = new Set<string>();
   const latestDispatchIDByChainingTraceID = new Map<string, string>();
+  let hasUnresolvedLineage = false;
 
   for (
     let currentIndex = 0;
@@ -88,8 +90,11 @@ export function projectTraceDispatchesToFactoryGraph(
         latestDispatchIDByChainingTraceID,
       ) ??
       resolveWorkItemProducerDispatchIDs(dispatches, currentIndex) ??
-      resolveSequentialPredecessorDispatchIDs(dispatches, currentIndex) ??
       [];
+
+    if (currentIndex > 0 && predecessorDispatchIDs.length === 0) {
+      hasUnresolvedLineage = true;
+    }
 
     for (const producerDispatchID of predecessorDispatchIDs) {
       if (producerDispatchID === currentDispatch.dispatch_id) {
@@ -142,6 +147,7 @@ export function projectTraceDispatchesToFactoryGraph(
 
   return {
     dispatchIdByNodeId,
+    lineageStatus: hasUnresolvedLineage ? "unresolved" : "resolved",
     nodeIdByDispatchId,
     overlaysByNodeId,
     topology: {
@@ -213,13 +219,6 @@ function resolveWorkItemProducerDispatchIDs(
   }
 
   return producerDispatchIDs.size > 0 ? [...producerDispatchIDs] : null;
-}
-
-function resolveSequentialPredecessorDispatchIDs(
-  dispatches: DashboardTraceDispatch[],
-  currentIndex: number,
-): string[] | null {
-  return currentIndex > 0 ? [dispatches[currentIndex - 1].dispatch_id] : null;
 }
 
 function collectCurrentChainingTraceIDs(

--- a/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph.ts
@@ -7,10 +7,16 @@ import {
   buildEdge,
   buildNode,
   type FactoryGraphEdge,
+  type FactoryGraphNode,
   type FactoryGraphNodeReference,
   type FactoryGraphTopology,
 } from "../../factory-graph-editor/lib/draft/factory-graph-draft-types";
 import { getTraceDrilldownMessages } from "../messages/trace-drilldown";
+import {
+  type TraceSelectionIdentity,
+  traceSelectionAttempt,
+  traceSelectionIdentitiesForDispatch,
+} from "./trace-selection";
 
 export interface TraceDispatchNodeOverlay {
   dispatchId: string;
@@ -25,18 +31,85 @@ export interface TraceDispatchFactoryGraphProjection {
   lineageStatus: "resolved" | "unresolved";
   nodeIdByDispatchId: ReadonlyMap<string, string>;
   overlaysByNodeId: ReadonlyMap<string, TraceDispatchNodeOverlay>;
+  selectionIdentitiesByNodeId: ReadonlyMap<
+    string,
+    readonly TraceSelectionIdentity[]
+  >;
+  traceNodeIdByFactoryNodeId: ReadonlyMap<string, string>;
   topology: FactoryGraphTopology;
+}
+
+interface TraceDispatchProjectionNode {
+  dispatch: DashboardTraceDispatch;
+  node: FactoryGraphNode;
+  overlay: TraceDispatchNodeOverlay;
+  selectionIdentities: readonly TraceSelectionIdentity[];
+  traceNodeId: string;
 }
 
 export function projectTraceDispatchesToFactoryGraph(
   dispatches: DashboardTraceDispatch[],
   locale?: string,
 ): TraceDispatchFactoryGraphProjection {
+  const nodes = buildTraceDispatchProjectionNodes(dispatches, locale);
+  const nodeIdByDispatchId = new Map(
+    nodes.map(({ dispatch, node }) => [dispatch.dispatch_id, node.id]),
+  );
+  const dispatchIdByNodeId = new Map(
+    nodes.map(({ dispatch, node }) => [node.id, dispatch.dispatch_id]),
+  );
+  const overlaysByNodeId = new Map(
+    nodes.map(({ node, overlay }) => [node.id, overlay]),
+  );
+  const selectionIdentitiesByNodeId = new Map(
+    nodes.map(({ node, selectionIdentities }) => [
+      node.id,
+      selectionIdentities,
+    ]),
+  );
+  const traceNodeIdByFactoryNodeId = new Map(
+    nodes.map(({ node, traceNodeId }) => [node.id, traceNodeId]),
+  );
+  const { edges, lineageStatus } = buildTraceLineageEdges(
+    dispatches,
+    nodes,
+    dispatchIdByNodeId,
+  );
+
+  return {
+    dispatchIdByNodeId,
+    lineageStatus,
+    nodeIdByDispatchId,
+    overlaysByNodeId,
+    selectionIdentitiesByNodeId,
+    traceNodeIdByFactoryNodeId,
+    topology: {
+      edges,
+      nodes: nodes.map(({ node }) => node),
+    },
+  };
+}
+
+function buildTraceDispatchProjectionNodes(
+  dispatches: DashboardTraceDispatch[],
+  locale?: string,
+): TraceDispatchProjectionNode[] {
   const messages = getTraceDrilldownMessages(locale);
   const reservedWorkstationNames = new Set<string>();
-  const nodes = dispatches.map((dispatch) => {
+  const usedTraceNodeIDs = new Set<string>();
+  const dispatchCountsByID = new Map<string, number>();
+  for (const dispatch of dispatches) {
+    dispatchCountsByID.set(
+      dispatch.dispatch_id,
+      (dispatchCountsByID.get(dispatch.dispatch_id) ?? 0) + 1,
+    );
+  }
+
+  return dispatches.map((dispatch) => {
+    const selectionIdentities = traceSelectionIdentitiesForDispatch(dispatch);
     const workstationName = resolveTraceWorkstationNodeName(
       dispatch,
+      selectionIdentities[0],
       reservedWorkstationNames,
     );
     const workstationKey: FactoryGraphNodeReference = {
@@ -58,19 +131,28 @@ export function projectTraceDispatchesToFactoryGraph(
         outcome: dispatch.outcome,
         outputSummary: summarizeWorkItems(dispatch.output_items, locale),
       } satisfies TraceDispatchNodeOverlay,
+      selectionIdentities,
+      traceNodeId: resolveTraceNodeID(
+        dispatch,
+        selectionIdentities[0],
+        dispatchCountsByID,
+        usedTraceNodeIDs,
+      ),
     };
   });
-  const nodeIdByDispatchId = new Map(
-    nodes.map(({ dispatch, node }) => [dispatch.dispatch_id, node.id]),
-  );
-  const dispatchIdByNodeId = new Map(
-    nodes.map(({ dispatch, node }) => [node.id, dispatch.dispatch_id]),
-  );
-  const overlaysByNodeId = new Map(
-    nodes.map(({ node, overlay }) => [node.id, overlay]),
-  );
+}
+
+function buildTraceLineageEdges(
+  dispatches: DashboardTraceDispatch[],
+  nodes: TraceDispatchProjectionNode[],
+  dispatchIdByNodeId: ReadonlyMap<string, string>,
+): {
+  edges: FactoryGraphEdge[];
+  lineageStatus: "resolved" | "unresolved";
+} {
   const edgeKeys = new Set<string>();
-  const latestDispatchIDByChainingTraceID = new Map<string, string>();
+  const latestNodeIDByChainingTraceID = new Map<string, string>();
+  const nodeIDsByIndex = nodes.map(({ node }) => node.id);
   let hasUnresolvedLineage = false;
 
   for (
@@ -79,43 +161,40 @@ export function projectTraceDispatchesToFactoryGraph(
     currentIndex += 1
   ) {
     const currentDispatch = dispatches[currentIndex];
-    const currentNodeId = nodeIdByDispatchId.get(currentDispatch.dispatch_id);
+    const currentNodeId = nodeIDsByIndex[currentIndex];
     if (!currentNodeId) {
       continue;
     }
 
-    const predecessorDispatchIDs =
-      resolveExplicitPredecessorDispatchIDs(
+    const predecessorNodeIDs =
+      resolveExplicitPredecessorNodeIDs(
         currentDispatch,
-        latestDispatchIDByChainingTraceID,
+        latestNodeIDByChainingTraceID,
       ) ??
-      resolveWorkItemProducerDispatchIDs(dispatches, currentIndex) ??
+      resolveWorkItemProducerNodeIDs(
+        dispatches,
+        currentIndex,
+        nodeIDsByIndex,
+      ) ??
       [];
 
-    if (currentIndex > 0 && predecessorDispatchIDs.length === 0) {
+    if (currentIndex > 0 && predecessorNodeIDs.length === 0) {
       hasUnresolvedLineage = true;
     }
 
-    for (const producerDispatchID of predecessorDispatchIDs) {
-      if (producerDispatchID === currentDispatch.dispatch_id) {
-        continue;
+    for (const producerNodeID of predecessorNodeIDs) {
+      if (
+        producerNodeID !== currentNodeId &&
+        dispatchIdByNodeId.has(producerNodeID)
+      ) {
+        edgeKeys.add(`${producerNodeID}->${currentNodeId}`);
       }
-
-      const sourceNodeId = nodeIdByDispatchId.get(producerDispatchID);
-      if (!sourceNodeId) {
-        continue;
-      }
-
-      edgeKeys.add(`${sourceNodeId}->${currentNodeId}`);
     }
 
     for (const chainingTraceID of collectCurrentChainingTraceIDs(
       currentDispatch,
     )) {
-      latestDispatchIDByChainingTraceID.set(
-        chainingTraceID,
-        currentDispatch.dispatch_id,
-      );
+      latestNodeIDByChainingTraceID.set(chainingTraceID, currentNodeId);
     }
   }
 
@@ -125,11 +204,9 @@ export function projectTraceDispatchesToFactoryGraph(
       const [sourceNodeId, targetNodeId] = edgeKey.split("->");
       const sourceNode = nodeById.get(sourceNodeId);
       const targetNode = nodeById.get(targetNodeId);
-      if (!sourceNode || !targetNode) {
-        return null;
-      }
-
       if (
+        !sourceNode ||
+        !targetNode ||
         sourceNode.key.kind !== "workstation" ||
         targetNode.key.kind !== "workstation"
       ) {
@@ -146,19 +223,14 @@ export function projectTraceDispatchesToFactoryGraph(
     .sort((left, right) => left.id.localeCompare(right.id));
 
   return {
-    dispatchIdByNodeId,
+    edges,
     lineageStatus: hasUnresolvedLineage ? "unresolved" : "resolved",
-    nodeIdByDispatchId,
-    overlaysByNodeId,
-    topology: {
-      edges,
-      nodes: nodes.map(({ node }) => node),
-    },
   };
 }
 
 function resolveTraceWorkstationNodeName(
   dispatch: DashboardTraceDispatch,
+  selection: TraceSelectionIdentity | undefined,
   reservedWorkstationNames: Set<string>,
 ): string {
   const candidates = [
@@ -174,30 +246,62 @@ function resolveTraceWorkstationNodeName(
     }
   }
 
-  const fallback = dispatch.dispatch_id.trim();
+  const fallbackBase = `${dispatch.dispatch_id.trim()}#attempt-${selection?.attempt ?? traceSelectionAttempt(dispatch)}`;
+  let fallback = fallbackBase;
+  let suffix = 2;
+  while (reservedWorkstationNames.has(fallback)) {
+    fallback = `${fallbackBase}-${suffix}`;
+    suffix += 1;
+  }
   reservedWorkstationNames.add(fallback);
   return fallback;
 }
 
-function resolveExplicitPredecessorDispatchIDs(
+function resolveTraceNodeID(
   dispatch: DashboardTraceDispatch,
-  latestDispatchIDByChainingTraceID: Map<string, string>,
-): string[] | null {
-  const predecessorDispatchIDs = collectPreviousChainingTraceIDs(dispatch)
-    .map((traceID) => latestDispatchIDByChainingTraceID.get(traceID))
-    .filter((dispatchID): dispatchID is string => Boolean(dispatchID));
+  selection: TraceSelectionIdentity | undefined,
+  dispatchCountsByID: ReadonlyMap<string, number>,
+  usedTraceNodeIDs: Set<string>,
+): string {
+  const dispatchID = dispatch.dispatch_id.trim();
+  if ((dispatchCountsByID.get(dispatch.dispatch_id) ?? 0) === 1) {
+    usedTraceNodeIDs.add(dispatchID);
+    return dispatchID;
+  }
 
-  return predecessorDispatchIDs.length > 0
-    ? uniqueNonEmptyStrings(predecessorDispatchIDs)
+  const identityKey = selection
+    ? `${selection.dispatch_id}#${selection.work_id || "none"}#attempt-${selection.attempt}`
+    : `${dispatchID}#attempt-${traceSelectionAttempt(dispatch)}`;
+  let traceNodeID = identityKey;
+  let suffix = 2;
+  while (usedTraceNodeIDs.has(traceNodeID)) {
+    traceNodeID = `${identityKey}-${suffix}`;
+    suffix += 1;
+  }
+  usedTraceNodeIDs.add(traceNodeID);
+  return traceNodeID;
+}
+
+function resolveExplicitPredecessorNodeIDs(
+  dispatch: DashboardTraceDispatch,
+  latestNodeIDByChainingTraceID: Map<string, string>,
+): string[] | null {
+  const predecessorNodeIDs = collectPreviousChainingTraceIDs(dispatch)
+    .map((traceID) => latestNodeIDByChainingTraceID.get(traceID))
+    .filter((nodeID): nodeID is string => Boolean(nodeID));
+
+  return predecessorNodeIDs.length > 0
+    ? uniqueNonEmptyStrings(predecessorNodeIDs)
     : null;
 }
 
-function resolveWorkItemProducerDispatchIDs(
+function resolveWorkItemProducerNodeIDs(
   dispatches: DashboardTraceDispatch[],
   currentIndex: number,
+  nodeIDsByIndex: string[],
 ): string[] | null {
   const currentDispatch = dispatches[currentIndex];
-  const producerDispatchIDs = new Set<string>();
+  const producerNodeIDs = new Set<string>();
 
   for (const inputItem of currentDispatch.input_items ?? []) {
     for (
@@ -214,11 +318,14 @@ function resolveWorkItemProducerDispatchIDs(
         continue;
       }
 
-      producerDispatchIDs.add(producerDispatch.dispatch_id);
+      const producerNodeID = nodeIDsByIndex[producerIndex];
+      if (producerNodeID) {
+        producerNodeIDs.add(producerNodeID);
+      }
     }
   }
 
-  return producerDispatchIDs.size > 0 ? [...producerDispatchIDs] : null;
+  return producerNodeIDs.size > 0 ? [...producerNodeIDs] : null;
 }
 
 function collectCurrentChainingTraceIDs(

--- a/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph.ts
@@ -12,6 +12,10 @@ import {
   type FactoryGraphTopology,
 } from "../../factory-graph-editor/lib/draft/factory-graph-draft-types";
 import { getTraceDrilldownMessages } from "../messages/trace-drilldown";
+import type {
+  TraceRelationPathEndpoint,
+  TraceRelationPathEntry,
+} from "./trace-relation-path";
 import {
   type TraceSelectionIdentity,
   traceSelectionAttempt,
@@ -31,6 +35,7 @@ export interface TraceDispatchFactoryGraphProjection {
   lineageStatus: "resolved" | "unresolved";
   nodeIdByDispatchId: ReadonlyMap<string, string>;
   overlaysByNodeId: ReadonlyMap<string, TraceDispatchNodeOverlay>;
+  relations: readonly TraceRelationPathEntry[];
   selectionIdentitiesByNodeId: ReadonlyMap<
     string,
     readonly TraceSelectionIdentity[]
@@ -70,7 +75,7 @@ export function projectTraceDispatchesToFactoryGraph(
   const traceNodeIdByFactoryNodeId = new Map(
     nodes.map(({ node, traceNodeId }) => [node.id, traceNodeId]),
   );
-  const { edges, lineageStatus } = buildTraceLineageEdges(
+  const { edges, lineageStatus, relations } = buildTraceLineageEdges(
     dispatches,
     nodes,
     dispatchIdByNodeId,
@@ -81,6 +86,7 @@ export function projectTraceDispatchesToFactoryGraph(
     lineageStatus,
     nodeIdByDispatchId,
     overlaysByNodeId,
+    relations,
     selectionIdentitiesByNodeId,
     traceNodeIdByFactoryNodeId,
     topology: {
@@ -149,10 +155,13 @@ function buildTraceLineageEdges(
 ): {
   edges: FactoryGraphEdge[];
   lineageStatus: "resolved" | "unresolved";
+  relations: TraceRelationPathEntry[];
 } {
   const edgeKeys = new Set<string>();
   const latestNodeIDByChainingTraceID = new Map<string, string>();
   const nodeIDsByIndex = nodes.map(({ node }) => node.id);
+  const nodesByID = new Map(nodes.map(({ node, ...rest }) => [node.id, rest]));
+  const relations: TraceRelationPathEntry[] = [];
   let hasUnresolvedLineage = false;
 
   for (
@@ -188,6 +197,17 @@ function buildTraceLineageEdges(
         dispatchIdByNodeId.has(producerNodeID)
       ) {
         edgeKeys.add(`${producerNodeID}->${currentNodeId}`);
+        const sourceNode = nodesByID.get(producerNodeID);
+        const targetNode = nodesByID.get(currentNodeId);
+        if (sourceNode && targetNode) {
+          relations.push({
+            id: `predecessor|${sourceNode.traceNodeId}|${targetNode.traceNodeId}`,
+            kind: "predecessor",
+            relationType: "PREDECESSOR",
+            source: traceDispatchPathEndpoint(sourceNode),
+            target: traceDispatchPathEndpoint(targetNode),
+          });
+        }
       }
     }
 
@@ -225,6 +245,23 @@ function buildTraceLineageEdges(
   return {
     edges,
     lineageStatus: hasUnresolvedLineage ? "unresolved" : "resolved",
+    relations: relations.sort((left, right) => left.id.localeCompare(right.id)),
+  };
+}
+
+function traceDispatchPathEndpoint({
+  dispatch,
+  overlay,
+  selectionIdentities,
+}: Omit<
+  TraceDispatchProjectionNode,
+  "node" | "traceNodeId"
+>): TraceRelationPathEndpoint {
+  return {
+    dispatchID: dispatch.dispatch_id,
+    label: overlay.displayLabel,
+    selectionIdentities,
+    workID: selectionIdentities[0]?.work_id || undefined,
   };
 }
 

--- a/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts
@@ -76,6 +76,9 @@ describe("buildTraceRelationFactoryGraphFlow", () => {
         "trace-relation-source",
       ]),
     );
+    expect(flow.relations.map((relation) => relation.id)).toEqual(
+      flow.edges.map((edge) => edge.id),
+    );
   });
 
   it("registers only shared work graph React Flow node types", () => {

--- a/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.ts
@@ -12,6 +12,7 @@ import {
   projectTraceRelationsToFactoryGraph,
   type TraceRelationNodeOverlay,
 } from "./trace-relation-factory-graph";
+import type { TraceRelationPathEntry } from "./trace-relation-path";
 
 const TRACE_RELATION_SOURCE_HANDLE_ID = "trace-relation-source";
 const TRACE_RELATION_TARGET_HANDLE_ID = "trace-relation-target";
@@ -34,6 +35,7 @@ export interface TraceRelationFactoryGraphFlow {
   edges: FactoryGraphReactFlowEdge[];
   endpointKeyByNodeId: ReadonlyMap<string, string>;
   nodes: TraceRelationFlowNode[];
+  relations: readonly TraceRelationPathEntry[];
   topology: FactoryGraphTopology;
 }
 
@@ -44,9 +46,16 @@ export function buildTraceRelationFactoryGraphFlow(
     selectedWorkID?: string | null;
   } = {},
 ): TraceRelationFactoryGraphFlow {
-  const { locale, onSelectWorkID, selectedWorkID, workItemsByWorkId } = options;
+  const {
+    locale,
+    onSelectWorkID,
+    selectedWorkID,
+    selectionIdentitiesByWorkID,
+    workItemsByWorkId,
+  } = options;
   const traceProjection = projectTraceRelationsToFactoryGraph(relations, {
     locale,
+    selectionIdentitiesByWorkID,
     workItemsByWorkId,
   });
   const factoryProjection = projectFactoryGraphToReactFlow({
@@ -135,6 +144,7 @@ export function buildTraceRelationFactoryGraphFlow(
     edges,
     endpointKeyByNodeId: traceProjection.endpointKeyByNodeId,
     nodes,
+    relations: traceProjection.relations,
     topology: traceProjection.topology,
   };
 }

--- a/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph.bun.unit.test.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph.bun.unit.test.ts
@@ -159,6 +159,21 @@ describe("projectTraceRelationsToFactoryGraph edges and overlays", () => {
     ).toBe(
       "Retry relation from Implement story to Repair story, requiring Failed",
     );
+    expect(projection.relations.map((relation) => relation.id)).toEqual(
+      projection.topology.edges.map((edge) => edge.id),
+    );
+    expect(projection.relations[0]).toMatchObject({
+      kind: "relation",
+      relationType: "PARENT_CHILD",
+      source: {
+        label: "Plan story",
+        workID: "work-plan",
+      },
+      target: {
+        label: "Implement story",
+        workID: "work-implement",
+      },
+    });
   });
 
   it("aggregates relation metadata onto one node per endpoint", () => {

--- a/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph.ts
@@ -11,6 +11,8 @@ import {
   nodeKeyId,
 } from "../../factory-graph-editor/lib/draft/factory-graph-draft-types";
 import { getTraceDrilldownMessages } from "../messages/trace-drilldown";
+import type { TraceRelationPathEntry } from "./trace-relation-path";
+import type { TraceSelectionIdentity } from "./trace-selection";
 
 export interface TraceRelationNodeOverlay {
   displayLabel: string;
@@ -32,11 +34,16 @@ export interface TraceRelationFactoryGraphProjection {
   endpointKeyByNodeId: ReadonlyMap<string, string>;
   nodeIdByEndpointKey: ReadonlyMap<string, string>;
   overlaysByNodeId: ReadonlyMap<string, TraceRelationNodeOverlay>;
+  relations: readonly TraceRelationPathEntry[];
   topology: FactoryGraphTopology;
 }
 
 export interface ProjectTraceRelationsToFactoryGraphOptions {
   locale?: string;
+  selectionIdentitiesByWorkID?: ReadonlyMap<
+    string,
+    readonly TraceSelectionIdentity[]
+  >;
   workItemsByWorkId?: ReadonlyMap<string, DashboardWorkItemRef>;
 }
 
@@ -54,7 +61,7 @@ export function projectTraceRelationsToFactoryGraph(
   relations: DashboardWorkRelation[],
   options: ProjectTraceRelationsToFactoryGraphOptions = {},
 ): TraceRelationFactoryGraphProjection {
-  const { locale, workItemsByWorkId } = options;
+  const { locale, selectionIdentitiesByWorkID, workItemsByWorkId } = options;
   const messages = getTraceDrilldownMessages(locale);
   const endpointRecords = new Map<string, RelationEndpointRecord>();
 
@@ -106,6 +113,7 @@ export function projectTraceRelationsToFactoryGraph(
   }
 
   const edgeOverlaysByEdgeId = new Map<string, TraceRelationEdgeOverlay>();
+  const relationPathEntries: TraceRelationPathEntry[] = [];
   const edges: FactoryGraphEdge[] = [];
 
   relations.forEach((relation, index) => {
@@ -129,8 +137,9 @@ export function projectTraceRelationsToFactoryGraph(
     };
     const sourceOverlay = overlaysByNodeId.get(sourceNodeId);
     const targetOverlay = overlaysByNodeId.get(targetNodeId);
+    const relationID = relationEdgeId(relation, index);
 
-    edgeOverlaysByEdgeId.set(edge.id, {
+    edgeOverlaysByEdgeId.set(relationID, {
       ariaLabel: messages.relationEdgeLabel({
         relationState: relation.required_state,
         relationType: relation.type,
@@ -141,6 +150,25 @@ export function projectTraceRelationsToFactoryGraph(
       requiredState: relation.required_state,
       requestId: relation.request_id,
     });
+    relationPathEntries.push({
+      id: relationID,
+      kind: "relation",
+      relationType: relation.type,
+      requestID: relation.request_id,
+      requiredState: relation.required_state,
+      source: {
+        label: sourceOverlay?.displayLabel ?? source.displayLabel,
+        selectionIdentities:
+          selectionIdentitiesByWorkID?.get(source.workID ?? "") ?? [],
+        workID: source.workID,
+      },
+      target: {
+        label: targetOverlay?.displayLabel ?? target.displayLabel,
+        selectionIdentities:
+          selectionIdentitiesByWorkID?.get(target.workID ?? "") ?? [],
+        workID: target.workID,
+      },
+    });
     edges.push(edge);
   });
 
@@ -149,6 +177,7 @@ export function projectTraceRelationsToFactoryGraph(
     endpointKeyByNodeId,
     nodeIdByEndpointKey,
     overlaysByNodeId,
+    relations: relationPathEntries,
     topology: {
       edges: edges.sort((left, right) => left.id.localeCompare(right.id)),
       nodes,

--- a/ui/src/features/trace-drilldown/lib/trace-relation-path.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-relation-path.ts
@@ -1,0 +1,27 @@
+import type { TraceSelectionIdentity } from "./trace-selection";
+
+export type TraceRelationPathKind = "predecessor" | "relation";
+
+export interface TraceRelationPathEndpoint {
+  dispatchID?: string;
+  label: string;
+  selectionIdentities: readonly TraceSelectionIdentity[];
+  workID?: string;
+}
+
+/**
+ * One relationship shared by the graph projection and the textual fallback.
+ *
+ * Graph node ids are intentionally absent here. They are disposable React
+ * Flow projections; dispatch, Work, and attempt identities are the stable
+ * values that the table and textual path can use to move focus.
+ */
+export interface TraceRelationPathEntry {
+  id: string;
+  kind: TraceRelationPathKind;
+  relationType: string;
+  requestID?: string;
+  requiredState?: string;
+  source: TraceRelationPathEndpoint;
+  target: TraceRelationPathEndpoint;
+}

--- a/ui/src/features/trace-drilldown/lib/trace-selection.test.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-selection.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  traceSelectionIdentitiesForDispatch,
+  traceSelectionKey,
+  traceSelectionMatches,
+} from "./trace-selection";
+
+describe("trace selection identity", () => {
+  it("requires dispatch, work, and attempt to match", () => {
+    const selection = {
+      attempt: 2,
+      dispatch_id: "dispatch-retry",
+      work_id: "work-shared",
+    };
+
+    expect(traceSelectionMatches(selection, selection)).toBe(true);
+    expect(
+      traceSelectionMatches(selection, {
+        ...selection,
+        attempt: 1,
+      }),
+    ).toBe(false);
+    expect(
+      traceSelectionMatches(selection, {
+        ...selection,
+        dispatch_id: "dispatch-other",
+      }),
+    ).toBe(false);
+    expect(
+      traceSelectionMatches(selection, {
+        ...selection,
+        work_id: "work-other",
+      }),
+    ).toBe(false);
+    expect(traceSelectionMatches(selection, null)).toBe(false);
+  });
+
+  it("projects each dispatch work item into a stable tuple key", () => {
+    const identities = traceSelectionIdentitiesForDispatch({
+      attempt: 2,
+      dispatch_id: "dispatch-retry",
+      input_items: [{ work_id: "work-shared" }],
+      output_items: [{ work_id: "work-result" }],
+    });
+
+    expect(identities).toEqual([
+      {
+        attempt: 2,
+        dispatch_id: "dispatch-retry",
+        work_id: "work-shared",
+      },
+      {
+        attempt: 2,
+        dispatch_id: "dispatch-retry",
+        work_id: "work-result",
+      },
+    ]);
+    expect(new Set(identities.map(traceSelectionKey)).size).toBe(2);
+  });
+});

--- a/ui/src/features/trace-drilldown/lib/trace-selection.test.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-selection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  traceSelectionIdentitiesByWorkID,
   traceSelectionIdentitiesForDispatch,
   traceSelectionKey,
   traceSelectionMatches,
@@ -56,5 +57,33 @@ describe("trace selection identity", () => {
       },
     ]);
     expect(new Set(identities.map(traceSelectionKey)).size).toBe(2);
+  });
+
+  it("indexes every Work identity without collapsing attempts", () => {
+    const selectionsByWorkID = traceSelectionIdentitiesByWorkID([
+      {
+        attempt: 1,
+        dispatch_id: "dispatch-retry",
+        input_items: [{ work_id: "work-shared" }],
+      },
+      {
+        attempt: 2,
+        dispatch_id: "dispatch-retry",
+        input_items: [{ work_id: "work-shared" }],
+      },
+    ]);
+
+    expect(selectionsByWorkID.get("work-shared")).toEqual([
+      {
+        attempt: 1,
+        dispatch_id: "dispatch-retry",
+        work_id: "work-shared",
+      },
+      {
+        attempt: 2,
+        dispatch_id: "dispatch-retry",
+        work_id: "work-shared",
+      },
+    ]);
   });
 });

--- a/ui/src/features/trace-drilldown/lib/trace-selection.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-selection.ts
@@ -13,6 +13,11 @@ export interface TraceSelectionIdentity {
   work_id: string;
 }
 
+// Older recordings and non-provider dispatches do not carry an inference
+// attempt. Replay supplies the field for current provider-backed dispatches;
+// retain one only as the compatibility identity for those legacy records.
+const LEGACY_TRACE_SELECTION_ATTEMPT = 1;
+
 export function traceSelectionKey(identity: TraceSelectionIdentity): string {
   return [
     encodeURIComponent(identity.dispatch_id),
@@ -20,8 +25,6 @@ export function traceSelectionKey(identity: TraceSelectionIdentity): string {
     String(identity.attempt),
   ].join("|");
 }
-
-export const traceSelectionIdentityKey = traceSelectionKey;
 
 export function traceSelectionMatches(
   left: TraceSelectionIdentity | null | undefined,
@@ -38,15 +41,13 @@ export function traceSelectionMatches(
   );
 }
 
-export const traceSelectionsMatch = traceSelectionMatches;
-
 export function traceSelectionAttempt(
   dispatch: Pick<DashboardTraceDispatch, "attempt">,
 ): number {
   const attempt = dispatch.attempt;
   return typeof attempt === "number" && Number.isInteger(attempt) && attempt > 0
     ? attempt
-    : 1;
+    : LEGACY_TRACE_SELECTION_ATTEMPT;
 }
 
 export function traceDispatchWorkIDs(
@@ -94,12 +95,6 @@ export function traceSelectionIdentitiesForDispatch(
   return (workIDs.length > 0 ? workIDs : [""]).map((workID) =>
     traceSelectionForDispatch(dispatch, workID),
   );
-}
-
-export function traceSelectionKeysForDispatch(
-  dispatch: Parameters<typeof traceSelectionIdentitiesForDispatch>[0],
-): string[] {
-  return traceSelectionIdentitiesForDispatch(dispatch).map(traceSelectionKey);
 }
 
 export function traceSelectionIdentitiesByWorkID(

--- a/ui/src/features/trace-drilldown/lib/trace-selection.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-selection.ts
@@ -1,0 +1,110 @@
+import type { DashboardTraceDispatch } from "../../../api/dashboard/types";
+
+/**
+ * The smallest identity that can distinguish one trace execution from every
+ * other execution shown by the drilldown.
+ *
+ * React Flow node ids and table keys are projections of this value. They must
+ * not become a second source of trace data or drop the attempt dimension.
+ */
+export interface TraceSelectionIdentity {
+  attempt: number;
+  dispatch_id: string;
+  work_id: string;
+}
+
+export function traceSelectionKey(identity: TraceSelectionIdentity): string {
+  return [
+    encodeURIComponent(identity.dispatch_id),
+    encodeURIComponent(identity.work_id),
+    String(identity.attempt),
+  ].join("|");
+}
+
+export const traceSelectionIdentityKey = traceSelectionKey;
+
+export function traceSelectionMatches(
+  left: TraceSelectionIdentity | null | undefined,
+  right: TraceSelectionIdentity | null | undefined,
+): boolean {
+  return (
+    left !== null &&
+    left !== undefined &&
+    right !== null &&
+    right !== undefined &&
+    left.dispatch_id === right.dispatch_id &&
+    left.work_id === right.work_id &&
+    left.attempt === right.attempt
+  );
+}
+
+export const traceSelectionsMatch = traceSelectionMatches;
+
+export function traceSelectionAttempt(
+  dispatch: Pick<DashboardTraceDispatch, "attempt">,
+): number {
+  const attempt = dispatch.attempt;
+  return typeof attempt === "number" && Number.isInteger(attempt) && attempt > 0
+    ? attempt
+    : 1;
+}
+
+export function traceDispatchWorkIDs(
+  dispatch: Pick<
+    DashboardTraceDispatch,
+    "input_items" | "output_items" | "work_ids"
+  >,
+): string[] {
+  const workIDs = new Set<string>();
+
+  for (const workID of dispatch.work_ids ?? []) {
+    addWorkID(workIDs, workID);
+  }
+  for (const workItem of dispatch.input_items ?? []) {
+    addWorkID(workIDs, workItem.work_id);
+  }
+  for (const workItem of dispatch.output_items ?? []) {
+    addWorkID(workIDs, workItem.work_id);
+  }
+
+  return [...workIDs];
+}
+
+export function traceSelectionForDispatch(
+  dispatch: Pick<DashboardTraceDispatch, "attempt" | "dispatch_id"> &
+    Partial<
+      Pick<DashboardTraceDispatch, "input_items" | "output_items" | "work_ids">
+    >,
+  workID?: string,
+): TraceSelectionIdentity {
+  return {
+    attempt: traceSelectionAttempt(dispatch),
+    dispatch_id: dispatch.dispatch_id,
+    work_id: workID ?? traceDispatchWorkIDs(dispatch)[0] ?? "",
+  };
+}
+
+export function traceSelectionIdentitiesForDispatch(
+  dispatch: Pick<DashboardTraceDispatch, "attempt" | "dispatch_id"> &
+    Partial<
+      Pick<DashboardTraceDispatch, "input_items" | "output_items" | "work_ids">
+    >,
+): TraceSelectionIdentity[] {
+  const workIDs = traceDispatchWorkIDs(dispatch);
+  return (workIDs.length > 0 ? workIDs : [""]).map((workID) =>
+    traceSelectionForDispatch(dispatch, workID),
+  );
+}
+
+export function traceSelectionKeysForDispatch(
+  dispatch: Parameters<typeof traceSelectionIdentitiesForDispatch>[0],
+): string[] {
+  return traceSelectionIdentitiesForDispatch(dispatch).map(traceSelectionKey);
+}
+
+function addWorkID(workIDs: Set<string>, workID: string | undefined): void {
+  const normalized = workID?.trim();
+  if (normalized) {
+    workIDs.add(normalized);
+  }
+}

--- a/ui/src/features/trace-drilldown/lib/trace-selection.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-selection.ts
@@ -102,6 +102,32 @@ export function traceSelectionKeysForDispatch(
   return traceSelectionIdentitiesForDispatch(dispatch).map(traceSelectionKey);
 }
 
+export function traceSelectionIdentitiesByWorkID(
+  dispatches: readonly DashboardTraceDispatch[],
+): ReadonlyMap<string, readonly TraceSelectionIdentity[]> {
+  const selectionsByWorkID = new Map<string, TraceSelectionIdentity[]>();
+
+  for (const dispatch of dispatches) {
+    for (const selection of traceSelectionIdentitiesForDispatch(dispatch)) {
+      if (!selection.work_id) {
+        continue;
+      }
+
+      const selections = selectionsByWorkID.get(selection.work_id) ?? [];
+      if (
+        !selections.some((candidate) =>
+          traceSelectionMatches(candidate, selection),
+        )
+      ) {
+        selections.push(selection);
+        selectionsByWorkID.set(selection.work_id, selections);
+      }
+    }
+  }
+
+  return selectionsByWorkID;
+}
+
 function addWorkID(workIDs: Set<string>, workID: string | undefined): void {
   const normalized = workID?.trim();
   if (normalized) {

--- a/ui/src/features/trace-drilldown/messages/trace-drilldown.ts
+++ b/ui/src/features/trace-drilldown/messages/trace-drilldown.ts
@@ -31,6 +31,21 @@ export interface TraceDrilldownMessages {
   noBatchRelations: string;
   noInputItems: string;
   noOutputItems: string;
+  predecessorRelationLabel: string;
+  predecessorSourceLabel: string;
+  predecessorTargetLabel: string;
+  relationPathEmpty: string;
+  relationPathLabel: string;
+  relationPathRequestIDLabel: string;
+  relationPathRequiredStateLabel: string;
+  relationPathSourceLabel: string;
+  relationPathTargetLabel: string;
+  selectWorkLabel: (workID: string) => string;
+  traceSelectionIdentityLabel: (
+    dispatchID: string,
+    workID: string,
+    attempt: number,
+  ) => string;
   unresolvedLineageMessage: string;
   noTraceHistoryMessage: string;
   noTraceHistoryTitle: string;
@@ -84,6 +99,18 @@ const traceDrilldownMessagesByLocale = {
     noBatchRelations: "None",
     noInputItems: "No input items recorded.",
     noOutputItems: "No output items recorded.",
+    predecessorRelationLabel: "Predecessor",
+    predecessorSourceLabel: "Predecessor",
+    predecessorTargetLabel: "Dispatch",
+    relationPathEmpty: "No recorded relations.",
+    relationPathLabel: "Textual relation path",
+    relationPathRequestIDLabel: "Request ID",
+    relationPathRequiredStateLabel: "Required state",
+    relationPathSourceLabel: "Source",
+    relationPathTargetLabel: "Target",
+    selectWorkLabel: (workID) => `Select work ${workID}.`,
+    traceSelectionIdentityLabel: (dispatchID, workID, attempt) =>
+      `${dispatchID} · Work ${workID || "Unavailable"} · attempt ${attempt}`,
     unresolvedLineageMessage:
       "Lineage is unresolved: no recorded relationship connects one or more dispatches, so no predecessor was inferred.",
     noTraceHistoryMessage:
@@ -201,6 +228,18 @@ const traceDrilldownMessagesByLocale = {
     noBatchRelations: "无",
     noInputItems: "没有记录输入项。",
     noOutputItems: "没有记录输出项。",
+    predecessorRelationLabel: "前置分派",
+    predecessorSourceLabel: "前置分派",
+    predecessorTargetLabel: "分派",
+    relationPathEmpty: "没有记录的关系。",
+    relationPathLabel: "文本关系路径",
+    relationPathRequestIDLabel: "请求 ID",
+    relationPathRequiredStateLabel: "所需状态",
+    relationPathSourceLabel: "来源",
+    relationPathTargetLabel: "目标",
+    selectWorkLabel: (workID) => `选择工作 ${workID}。`,
+    traceSelectionIdentityLabel: (dispatchID, workID, attempt) =>
+      `${dispatchID} · 工作 ${workID || "不可用"} · 第 ${attempt} 次尝试`,
     unresolvedLineageMessage:
       "谱系未解析：一个或多个分派之间没有记录的关系，因此未推断前置分派。",
     noTraceHistoryMessage: "当前这个工作项暂时没有可保留的分派历史。",

--- a/ui/src/features/trace-drilldown/messages/trace-drilldown.ts
+++ b/ui/src/features/trace-drilldown/messages/trace-drilldown.ts
@@ -26,6 +26,7 @@ export interface TraceDrilldownMessages {
   noBatchRelations: string;
   noInputItems: string;
   noOutputItems: string;
+  unresolvedLineageMessage: string;
   noTraceHistoryMessage: string;
   noTraceHistoryTitle: string;
   unknownRelationSource: string;
@@ -76,6 +77,8 @@ const traceDrilldownMessagesByLocale = {
     noBatchRelations: "None",
     noInputItems: "No input items recorded.",
     noOutputItems: "No output items recorded.",
+    unresolvedLineageMessage:
+      "Lineage is unresolved: no recorded relationship connects one or more dispatches, so no predecessor was inferred.",
     noTraceHistoryMessage:
       "No retained dispatch history is currently available for this work item.",
     noTraceHistoryTitle: "Trace history unavailable",
@@ -189,6 +192,8 @@ const traceDrilldownMessagesByLocale = {
     noBatchRelations: "无",
     noInputItems: "没有记录输入项。",
     noOutputItems: "没有记录输出项。",
+    unresolvedLineageMessage:
+      "谱系未解析：一个或多个分派之间没有记录的关系，因此未推断前置分派。",
     noTraceHistoryMessage: "当前这个工作项暂时没有可保留的分派历史。",
     noTraceHistoryTitle: "追踪历史不可用",
     unknownRelationSource: "未知来源",

--- a/ui/src/features/trace-drilldown/messages/trace-drilldown.ts
+++ b/ui/src/features/trace-drilldown/messages/trace-drilldown.ts
@@ -15,6 +15,11 @@ export interface TraceDrilldownMessages {
   dispatchPathInputPrefix: string;
   dispatchPathOutputPrefix: string;
   dispatchPathPendingOutcome: string;
+  selectDispatchLabel: (
+    dispatchID: string,
+    workID: string,
+    attempt: number,
+  ) => string;
   emptyMessage: string;
   emptyTitle: string;
   errorTitle: string;
@@ -63,6 +68,8 @@ const traceDrilldownMessagesByLocale = {
     dispatchPathInputPrefix: "In",
     dispatchPathOutputPrefix: "Out",
     dispatchPathPendingOutcome: "Observed",
+    selectDispatchLabel: (dispatchID, workID, attempt) =>
+      `Select dispatch ${dispatchID}, Work ${workID || "Unavailable"}, attempt ${attempt}.`,
     emptyMessage:
       "No retained dispatch history is currently available for this work item.",
     emptyTitle: "Trace history unavailable",
@@ -181,6 +188,8 @@ const traceDrilldownMessagesByLocale = {
     dispatchPathInputPrefix: "输入",
     dispatchPathOutputPrefix: "输出",
     dispatchPathPendingOutcome: "已观测",
+    selectDispatchLabel: (dispatchID, workID, attempt) =>
+      `选择分派 ${dispatchID}，工作 ${workID || "不可用"}，第 ${attempt} 次尝试。`,
     emptyMessage: "当前这个工作项暂时没有可保留的分派历史。",
     emptyTitle: "追踪历史不可用",
     errorTitle: "追踪查询失败",


### PR DESCRIPTION
{
  "project": "Complete Trace Identity and Relation Behavior",
  "branchName": "ux-p4-trace-identity-and-relation-completeness",
  "description": "Correct the frontend trace drilldown so trace reads are scoped to Factory Session and stream generation, relation-only traces remain visible, absent lineage is represented as unresolved rather than fabricated, and graph, table, and textual relation views share stable selection identity and accessible behavior.",
  "context": {
    "customerAsk": "Make trace drilldown results session- and generation-safe, show relation-only traces, stop inventing sequential causality when lineage is absent, synchronize graph and table selection by dispatch, Work, and attempt identity, and provide a textual relation path when React Flow is unavailable.",
    "problem": "A late read from a previous Factory Session can populate the current trace cache; zero-dispatch traces are classified empty before errors and relations are considered; the no-lineage fallback synthesizes predecessor edges from display order; and relation data and selection are not consistently available across graph, table, and non-graph experiences.",
    "solution": "Include Factory Session and stream generation in trace request identity and reject superseded completions; classify loading, error, content, and known-empty states in safe precedence; project an explicit unresolved-lineage state without synthetic edges; use (dispatch_id, work_id, attempt) as canonical selection identity; and render graph and textual relation views from the same canonical relation model."
  },
  "acceptanceCriteria": [
    "A trace result is scoped by Factory Session and stream generation, and an integration test proves a late result from session A cannot overwrite the view after session B is selected.",
    "Query errors take precedence over empty classification, and a trace with at least one relation and zero dispatches shows its relations without showing the known-empty state while loading, error, empty, and success remain distinguishable.",
    "Two dispatches with neither explicit nor Work-item lineage produce an explicit unresolved-lineage state and no fabricated predecessor edge; the existing sequential-fallback assertion is inverted rather than deleted.",
    "Table-to-graph and graph-to-table selection focus the matching item using the complete (dispatch_id, work_id, attempt) identity, including ambiguous partial-identifier cases.",
    "An accessible textual relation/predecessor path represents the same canonical relations as the graph and remains usable when React Flow is not rendered on supported narrow and wide layouts.",
    "Typecheck and focused trace tests pass; the trace-test count before and after is reported in a PR comment; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "PROCESS-STAGE FINISH LINE (operator-corrected): this stage is complete when the final head is pushed, the PR is open, CI has STARTED, and all blocking review feedback is addressed. Terminal CI and MERGED are owned by the REVIEW workstation and are explicitly NOT this stage's responsibility. Do not wait for, poll, or re-check CI status - each such visit consumes one of only 12 process visits before executor-loop-breaker kills this lane. CI-run evidence goes in a PR comment, never a commit."
  ],
  "userStories": [
    {
      "id": "ux-p4-trace-identity-and-relation-completeness-001",
      "title": "Keep trace results bound to the selected session generation",
      "description": "As an operator switching between live Factory Sessions, I want trace results to remain bound to the session and stream generation that produced them so a late read cannot replace the trace I am currently inspecting.",
      "acceptanceCriteria": [
        "Trace request/cache identity includes trace inputs, selected Factory Session identity, and stream generation.",
        "A result from a superseded session or generation is aborted or discarded and cannot populate the current view or current cache entry.",
        "An integration test starts a read for session A, selects session B, resolves A late, and observes only session B data in the drilldown rather than relying solely on direct component props.",
        "Loading and success state transitions remain explicit while a current-generation read is pending and resolves.",
        "Verify the session-switch behavior directly in a browser or browser integration runner.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Trace query and timeline projection identity now include the selected stream identity; component and Storybook regressions prove a late session A result cannot replace session B. Typecheck, focused tests, test-lane audit, formatting, and the focused browser runner pass."
    },
    {
      "id": "ux-p4-trace-identity-and-relation-completeness-002",
      "title": "Show relation-only traces with correct state precedence",
      "description": "As an operator inspecting a trace, I want errors and relation data represented before emptiness is decided so valid relation-only traces are not hidden and an unloaded trace is not mistaken for an empty one.",
      "acceptanceCriteria": [
        "Query errors render the error state even when the selected trace has zero dispatches.",
        "A trace with at least one relation and zero dispatches renders its relations and does not render the known-empty state.",
        "Loading, known-empty, error, relation-only success, and dispatch-bearing success are distinct reviewer-verifiable states.",
        "A regression test records that the previous behavior showed the empty state for relation-only input and proves the corrected rendered outcome.",
        "Existing trace-grid loading, empty, error, and success coverage continues to pass.",
        "Verify relation-only, loading, empty, and error states directly in a browser or component browser harness at narrow and wide viewport sizes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Trace state resolution now gives query errors precedence, distinguishes loading/empty/success, and treats relation-only traces as content. The trace card no longer renders the dispatch-empty state when relations are present. Resolver matrix tests, replayed relation-only component coverage, existing trace-card component coverage, Storybook relation-only state, focused Biome, and TypeScript checks pass; the repository-wide ui check remains blocked by pre-existing diagnostics outside this story."
    },
    {
      "id": "ux-p4-trace-identity-and-relation-completeness-003",
      "title": "Represent missing lineage without invented causality",
      "description": "As an operator reasoning about parallel or out-of-order work, I want missing lineage shown as unresolved so the trace never claims one dispatch caused another merely because of display order.",
      "acceptanceCriteria": [
        "When neither explicit lineage nor Work-item lineage exists, the trace projection exposes an explicit unresolved-lineage state.",
        "For two such dispatches, no predecessor edge is synthesized between them in either ordering.",
        "Existing explicit-lineage and Work-item-lineage relationships continue to produce their recorded edges.",
        "The existing sequential-fallback test is retained and inverted to assert unresolved lineage and absence of a fabricated edge, and the PR description states that the old assertion encoded a defect.",
        "The unresolved state has a non-color-only textual treatment understandable by assistive technology.",
        "Verify the unresolved-lineage state directly in a browser or component browser harness.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Dispatch graph projection now preserves explicit and Work-item lineage only, exposes lineageStatus=unresolved when a predecessor cannot be proven, and renders an accessible textual warning instead of inventing sequential edges. The prior sequential-fallback assertions were inverted. Focused Vitest, the non-Bun trace suite, native Bun trace tests, TypeScript, Biome, semantic-color and spacing checks, and the tagged Chromium Storybook scenario pass."
    },
    {
      "id": "ux-p4-trace-identity-and-relation-completeness-004",
      "title": "Synchronize table and graph selection by stable trace identity",
      "description": "As an operator moving between tabular and graphical trace views, I want selection in either view to focus the identical dispatch attempt in the other so I do not lose context.",
      "acceptanceCriteria": [
        "Canonical selection includes dispatch_id, work_id, and attempt, and table and graph projections consume it without replacing canonical trace data with React Flow state.",
        "Selecting a table row focuses the matching graph node, and selecting a graph node focuses the matching table row.",
        "Tests cover records sharing a dispatch or Work identifier but differing by attempt and prove that only the complete tuple matches.",
        "Selection is keyboard-operable, visibly focused, and announced through appropriate row and node semantics without relying only on color.",
        "Selection remains coherent when the views stack or scroll on narrow layouts.",
        "If the affected @xyflow/react test render requires useStore, only trace-relation-flow.test.tsx uses importOriginal spreading; shared mock consolidation is excluded.",
        "Verify both selection directions directly in a real browser or browser integration runner.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Added the canonical (dispatch_id, work_id, attempt) selection contract and kept React Flow ids as projections. Table dispatch/work-item controls and graph workstation nodes now synchronize selected state and focus with row/node semantics, including duplicate dispatch/work identifiers across attempts. Review follow-up now propagates the authoritative recorded inference attempt through replay into DashboardTraceDispatch and proves a retry attempt through the real timeline projection. Focused Vitest, native Bun trace-card tests, TypeScript, focused Biome, UI copy/color/spacing/test-lane checks, and the targeted Chromium Storybook interaction pass; the broader tagged Storybook suite still reports unrelated baseline failures outside the trace surface."
    },
    {
      "id": "ux-p4-trace-identity-and-relation-completeness-005",
      "title": "Provide an accessible textual relation and predecessor path",
      "description": "As an operator who cannot use the graph, I want a textual relation and predecessor list so the same trace relationships remain inspectable with a keyboard, assistive technology, or a degraded graph environment.",
      "acceptanceCriteria": [
        "A semantic textual list or table renders relation type, source, target or predecessor, and stable Work and attempt identity from the same canonical relation model used by the graph.",
        "When React Flow is unavailable or intentionally not rendered, the textual path remains visible and usable rather than collapsing to only a no-relations message.",
        "A test proves the textual path and graph projection contain the same relation set and stable identities for the same trace.",
        "Textual entries participate in the shared selection contract and focus the corresponding available graph or table item.",
        "Zero-relation, loading, error, and successful relation-list states use accessible semantics and remain usable on mobile, tablet, and desktop widths.",
        "Verify keyboard navigation, focus visibility, graph-unavailable fallback, and responsive presentation directly in a real browser.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": "Added canonical textual predecessor/relation entries shared with graph projections, including stable Work/attempt identities and accessible keyboard selection/focus synchronization across text, graph, and table surfaces. The relation-path component regression is explicitly assigned to the Vitest compatibility lane because its workspace graph dependency is not Bun-native resolvable. React Flow-disabled fallback, empty state, responsive layout, focused Vitest/Bun tests, TypeScript, focused Biome, UI copy/color/spacing/lane checks, and the tagged Chromium Storybook fallback scenario pass."
    }
  ],
  "REVIEW_FOLLOW_UP_STATUS": "Resolved on head 69164ee40: replay now propagates authoritative inference attempt identity into DashboardTraceDispatch, the relation-path test is assigned to the passing Vitest compatibility lane, and the three branch-owned dead-code exports are removed. The historical AAAA00 review note describes the superseded head adaac7c91 and must not be re-applied."
}
