### PR TITLE
thr-functional-gate-emits-nothing-when-it-times-out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,10 @@ jobs:
         run: bash scripts/ci/publish-functional-test-summary.sh
         env:
           FUNCTIONAL_TEST_VIZ_MARKDOWN: .artifacts/functional-test-viz/functional-tests.md
+          FUNCTIONAL_TEST_VIZ_DIR: .artifacts/functional-test-viz
+          FUNCTIONAL_TEST_VIZ_TIMING: .artifacts/functional-test-viz/functional-timing-summary.json
+          FUNCTIONAL_TEST_VIZ_JSON: .artifacts/functional-test-viz/coverage-summary.json
+          FUNCTIONAL_TEST_VIZ_PROFILE: .artifacts/functional-test-viz/coverage.out
       - name: Upload functional test diagnostics
         if: always() && matrix.suite == 'functional'
         uses: actions/upload-artifact@v4
@@ -253,6 +257,7 @@ jobs:
             .artifacts/functional-test-viz/coverage-summary.json
             .artifacts/functional-test-viz/coverage.out
             .artifacts/functional-test-viz/command.log
+            .artifacts/functional-test-viz/diagnostic-status.txt
             .artifacts/functional-test-viz/real-acpx-evidence.json
           if-no-files-found: ignore
           retention-days: 14

--- a/Makefile
+++ b/Makefile
@@ -684,7 +684,7 @@ test-unit-coverage:
 test-functional-coverage:
 	$(MAKE) functional-boundary-check
 	@echo "Functional tier: name=$(FUNCTIONAL_TEST_TIER) trigger=$(FUNCTIONAL_TEST_TRIGGER) short=$(FUNCTIONAL_SHORT) budget=$(FUNCTIONAL_TEST_BUDGET) selection=subtractive quarantine=$(FUNCTIONAL_QUARANTINE)"
-	$(GO) run ./cmd/gocoveragecheck -suite functional -jobs $(FUNCTIONAL_DEFAULT_JOBS) -min $(GO_FUNCTIONAL_COVERAGE_MIN) -package-manifest $(GO_FUNCTIONAL_COVERAGE_MANIFEST) -functional-quarantine $(FUNCTIONAL_QUARANTINE) -timeout $(GO_COVERAGE_TIMEOUT) $(if $(filter false 0 no,$(FUNCTIONAL_SHORT)),-short=false,) $(if $(GO_FUNCTIONAL_COVERAGE_PROFILE),-profile $(GO_FUNCTIONAL_COVERAGE_PROFILE),) $(if $(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT),-json-output $(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT),) $(if $(GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT),-timing-output $(GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT),)
+	$(GO) run ./cmd/gocoveragecheck -suite functional -stream -jobs $(FUNCTIONAL_DEFAULT_JOBS) -min $(GO_FUNCTIONAL_COVERAGE_MIN) -package-manifest $(GO_FUNCTIONAL_COVERAGE_MANIFEST) -functional-quarantine $(FUNCTIONAL_QUARANTINE) -timeout $(GO_COVERAGE_TIMEOUT) $(if $(filter false 0 no,$(FUNCTIONAL_SHORT)),-short=false,) $(if $(GO_FUNCTIONAL_COVERAGE_PROFILE),-profile $(GO_FUNCTIONAL_COVERAGE_PROFILE),) $(if $(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT),-json-output $(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT),) $(if $(GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT),-timing-output $(GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT),)
 
 script-timeout-companion-smoke-100:
 	$(GO) test -tags=$(FUNCTIONAL_LONG_TAGS) ./tests/functional/workers/inference -run $(SCRIPT_TIMEOUT_COMPANION_SMOKE_TEST) -count=$(SCRIPT_TIMEOUT_COMPANION_SMOKE_COUNT) -timeout $(SCRIPT_TIMEOUT_COMPANION_SMOKE_TIMEOUT)

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -51,10 +51,10 @@ func writeCoverageTestFailureWarning(err error) {
 	fmt.Fprintln(stderrWriter, "coverage not evaluated: package floors were NOT checked because the coverage test run failed; failed-test count unavailable")
 }
 
-func buildCoverageTestArgs(commonArgs []string, profilePath string, timingEnabled bool, testPackages []string) []string {
+func buildCoverageTestArgs(commonArgs []string, profilePath string, jsonEventsEnabled bool, testPackages []string) []string {
 	args := append([]string(nil), commonArgs...)
 	args = append(args, fmt.Sprintf("-coverprofile=%s", profilePath))
-	if timingEnabled {
+	if jsonEventsEnabled {
 		args = append(args, "-json")
 	}
 	return append(args, testPackages...)
@@ -67,12 +67,12 @@ func buildCoverageTestArgs(commonArgs []string, profilePath string, timingEnable
 // resolved test package exactly once. Each batch writes an isolated profile
 // that the caller merges with mergeCoverageProfiles after execution, including
 // profiles from failed subprocesses when they were produced.
-func buildCoverageInvocationPlan(commonArgs []string, testPackages []string, profilePath string, timingEnabled bool, targetOS string, compactPackageArgs ...[]string) (coverageInvocationPlan, error) {
+func buildCoverageInvocationPlan(commonArgs []string, testPackages []string, profilePath string, jsonEventsEnabled bool, targetOS string, compactPackageArgs ...[]string) (coverageInvocationPlan, error) {
 	directPackageArgs := testPackages
 	if len(compactPackageArgs) > 0 && len(compactPackageArgs[0]) > 0 {
 		directPackageArgs = compactPackageArgs[0]
 	}
-	directArgs := buildCoverageTestArgs(commonArgs, profilePath, timingEnabled, directPackageArgs)
+	directArgs := buildCoverageTestArgs(commonArgs, profilePath, jsonEventsEnabled, directPackageArgs)
 	if targetOS != "windows" || coverageCommandFitsWindowsLimit(directArgs) {
 		return coverageInvocationPlan{
 			invocations: []commandInvocation{{
@@ -105,7 +105,7 @@ func buildCoverageInvocationPlan(commonArgs []string, testPackages []string, pro
 	for _, testPackage := range testPackages {
 		candidateBatch := append(append([]string(nil), currentBatch...), testPackage)
 		candidateProfile := batchProfilePath(batchDir, len(plan.invocations))
-		candidateArgs := buildCoverageTestArgs(commonArgs, candidateProfile, timingEnabled, candidateBatch)
+		candidateArgs := buildCoverageTestArgs(commonArgs, candidateProfile, jsonEventsEnabled, candidateBatch)
 		if coverageCommandFitsWindowsLimit(candidateArgs) {
 			currentBatch = candidateBatch
 			continue
@@ -118,10 +118,10 @@ func buildCoverageInvocationPlan(commonArgs []string, testPackages []string, pro
 			)
 		}
 
-		appendCoverageInvocation(&plan, commonArgs, candidateProfile, timingEnabled, currentBatch)
+		appendCoverageInvocation(&plan, commonArgs, candidateProfile, jsonEventsEnabled, currentBatch)
 		currentBatch = []string{testPackage}
 		candidateProfile = batchProfilePath(batchDir, len(plan.invocations))
-		candidateArgs = buildCoverageTestArgs(commonArgs, candidateProfile, timingEnabled, currentBatch)
+		candidateArgs = buildCoverageTestArgs(commonArgs, candidateProfile, jsonEventsEnabled, currentBatch)
 		if !coverageCommandFitsWindowsLimit(candidateArgs) {
 			return coverageInvocationPlan{}, errors.Join(
 				coverageCommandTooLongError(testPackage, candidateArgs),
@@ -131,16 +131,16 @@ func buildCoverageInvocationPlan(commonArgs []string, testPackages []string, pro
 	}
 
 	if len(currentBatch) > 0 {
-		appendCoverageInvocation(&plan, commonArgs, batchProfilePath(batchDir, len(plan.invocations)), timingEnabled, currentBatch)
+		appendCoverageInvocation(&plan, commonArgs, batchProfilePath(batchDir, len(plan.invocations)), jsonEventsEnabled, currentBatch)
 	}
 	return plan, nil
 }
 
-func appendCoverageInvocation(plan *coverageInvocationPlan, commonArgs []string, profilePath string, timingEnabled bool, testPackages []string) {
+func appendCoverageInvocation(plan *coverageInvocationPlan, commonArgs []string, profilePath string, jsonEventsEnabled bool, testPackages []string) {
 	plan.profilePaths = append(plan.profilePaths, profilePath)
 	plan.invocations = append(plan.invocations, commandInvocation{
 		name: "go",
-		args: buildCoverageTestArgs(commonArgs, profilePath, timingEnabled, testPackages),
+		args: buildCoverageTestArgs(commonArgs, profilePath, jsonEventsEnabled, testPackages),
 		env:  os.Environ(),
 	})
 }
@@ -304,12 +304,12 @@ func windowsCommandLineArgLength(arg string) int {
 
 // runGoTestCoverageLane runs the coverage invocation once on short command
 // lines, or in deterministic test-package batches when Windows needs it. When
-// cfg.timingOutput is set, it combines every batch's -json stdout before
-// writing the timing summary, so a failed or crashed lane still leaves
-// trustworthy (possibly incomplete) diagnostics on disk.
+// timing capture or streaming is enabled, it combines every batch's -json
+// stdout before writing the timing summary, so a failed or crashed lane still
+// leaves trustworthy (possibly incomplete) diagnostics on disk.
 func runGoTestCoverageLane(cfg config, commonArgs []string, testPackages []string, profilePath string, repoRoot string, coverPackages []string, targetOS string, failurePrefix string, compactPackageArgs ...[]string) error {
-	timingEnabled := strings.TrimSpace(cfg.timingOutput) != ""
-	plan, err := buildCoverageInvocationPlan(commonArgs, testPackages, profilePath, timingEnabled, targetOS, compactPackageArgs...)
+	jsonEventsEnabled := strings.TrimSpace(cfg.timingOutput) != "" || cfg.stream
+	plan, err := buildCoverageInvocationPlan(commonArgs, testPackages, profilePath, jsonEventsEnabled, targetOS, compactPackageArgs...)
 	if err != nil {
 		return err
 	}
@@ -317,8 +317,8 @@ func runGoTestCoverageLane(cfg config, commonArgs []string, testPackages []strin
 }
 
 func runGoTestCoverageLaneWithSelection(cfg config, commonArgs []string, testPackages []string, profilePath string, repoRoot string, coverPackages []string, targetOS string, failurePrefix string, selection functionalCoverageSelection) error {
-	timingEnabled := strings.TrimSpace(cfg.timingOutput) != ""
-	plan, err := buildFunctionalCoverageInvocationPlan(commonArgs, selection.Groups, profilePath, timingEnabled, targetOS)
+	jsonEventsEnabled := strings.TrimSpace(cfg.timingOutput) != "" || cfg.stream
+	plan, err := buildFunctionalCoverageInvocationPlan(commonArgs, selection.Groups, profilePath, jsonEventsEnabled, targetOS)
 	if err != nil {
 		return err
 	}
@@ -339,6 +339,7 @@ func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, test
 	failedTestCountKnown := true
 	for index, invocation := range plan.invocations {
 		batchStdout, batchStderr, commandErr := runCommand(invocation)
+		commandErr = errors.Join(commandErr, flushFunctionalStreamWriter(invocation.stdoutWriter))
 		appendCoverageOutput(&stdout, batchStdout)
 		appendCoverageOutput(&stderr, batchStderr)
 		if commandErr == nil {
@@ -431,13 +432,13 @@ func countObservedGoTestFailures(stdout string, stderr string) int {
 	return count
 }
 
-func buildFunctionalCoverageInvocationPlan(commonArgs []string, groups []coverageRunGroup, profilePath string, timingEnabled bool, targetOS string) (coverageInvocationPlan, error) {
+func buildFunctionalCoverageInvocationPlan(commonArgs []string, groups []coverageRunGroup, profilePath string, jsonEventsEnabled bool, targetOS string) (coverageInvocationPlan, error) {
 	if len(groups) == 0 {
 		return coverageInvocationPlan{}, errors.New("prepare functional coverage lane: no selected run groups")
 	}
 	if len(groups) == 1 {
 		args := appendCoverageRunPattern(commonArgs, groups[0].RunPattern)
-		return buildCoverageInvocationPlan(args, groups[0].Packages, profilePath, timingEnabled, targetOS)
+		return buildCoverageInvocationPlan(args, groups[0].Packages, profilePath, jsonEventsEnabled, targetOS)
 	}
 
 	groupDir, err := os.MkdirTemp("", "gocoveragecheck-functional-groups-*")
@@ -449,7 +450,7 @@ func buildFunctionalCoverageInvocationPlan(commonArgs []string, groups []coverag
 	for index, group := range groups {
 		groupProfile := filepath.Join(groupDir, fmt.Sprintf("coverage-%06d.out", index))
 		args := appendCoverageRunPattern(commonArgs, group.RunPattern)
-		groupPlan, groupErr := buildCoverageInvocationPlan(args, group.Packages, groupProfile, timingEnabled, targetOS)
+		groupPlan, groupErr := buildCoverageInvocationPlan(args, group.Packages, groupProfile, jsonEventsEnabled, targetOS)
 		if groupErr != nil {
 			for _, cleanup := range cleanups {
 				groupErr = errors.Join(groupErr, cleanup())
@@ -515,9 +516,10 @@ func configureCoverageInvocationStreaming(plan *coverageInvocationPlan, enabled 
 	if !enabled {
 		return
 	}
+	reporter := newFunctionalStreamReporter(stdoutWriter)
 	for index := range plan.invocations {
-		plan.invocations[index].stdoutWriter = stdoutWriter
-		plan.invocations[index].stderrWriter = stderrWriter
+		plan.invocations[index].stdoutWriter = reporter.stdoutWriter()
+		plan.invocations[index].stderrWriter = reporter.stderrWriter(stderrWriter)
 	}
 }
 

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -327,9 +329,47 @@ func runGoTestCoverageLaneWithSelection(cfg config, commonArgs []string, testPac
 
 func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, testPackages []string, profilePath string, repoRoot string, coverPackages []string, failurePrefix string) error {
 	timingEnabled := strings.TrimSpace(cfg.timingOutput) != ""
-	configureCoverageInvocationStreaming(&plan, cfg.stream)
-
 	started := time.Now()
+	var snapshotter *functionalTimingSnapshotter
+	if cfg.stream || timingEnabled {
+		tracker := newFunctionalTimingTracker(testPackages, started)
+		observer := func(event goTestTimingEvent) {
+			if snapshotter != nil {
+				snapshotter.observe(event)
+				return
+			}
+			tracker.observe(event)
+		}
+		var reporter *functionalStreamReporter
+		if cfg.stream {
+			reporter = configureCoverageInvocationStreaming(&plan, true, observer)
+		} else {
+			reporter = configureCoverageInvocationObservation(&plan, observer)
+		}
+		sink := io.Writer(nil)
+		var sinkMu *sync.Mutex
+		if cfg.stream {
+			sink = stdoutWriter
+			sinkMu = &reporter.sinkMu
+		}
+		snapshotter = newFunctionalTimingSnapshotter(
+			tracker,
+			cfg.timingOutput,
+			sink,
+			sinkMu,
+			func() error {
+				return writePartialCoverageSnapshot(
+					cfg.jsonOutput,
+					profilePath,
+					repoRoot,
+					coverPackages,
+					partialCoverageReason(nil),
+				)
+			},
+		)
+		snapshotter.publish(false, "functional run started", false)
+		defer snapshotter.stopAndWait()
+	}
 	var stdout strings.Builder
 	var stderr strings.Builder
 	var laneErr error
@@ -368,10 +408,23 @@ func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, test
 	var timingWriteErr error
 	if timingEnabled {
 		summary := buildFunctionalTimingSummary(stdout.String(), testPackages, wallSeconds)
-		timingWriteErr = writeFunctionalTimingSummaryJSON(cfg.timingOutput, summary)
+		timingReason := ""
+		if !summary.Complete {
+			timingReason = "functional timing capture ended before every package reported a terminal result"
+			if laneErr != nil {
+				timingReason += ": " + compactDiagnosticError(laneErr)
+			}
+		}
+		if snapshotter != nil {
+			timingWriteErr = snapshotter.finish(summary, timingReason)
+		} else {
+			timingWriteErr = writeFunctionalTimingSummaryJSON(cfg.timingOutput, summary)
+		}
 		if timingWriteErr == nil && cfg.suite == "functional" {
 			writeFunctionalTimingInventorySummary(summary, cfg.short)
 		}
+	} else if snapshotter != nil {
+		snapshotter.stopAndWait()
 	}
 
 	var mergeErr error
@@ -383,7 +436,17 @@ func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, test
 		}
 	}
 
-	runErr := errors.Join(laneErr, timingWriteErr, mergeErr, plan.cleanup())
+	partialCoverageErr := error(nil)
+	if laneErr != nil || mergeErr != nil {
+		partialCoverageErr = writePartialCoverageSnapshot(
+			cfg.jsonOutput,
+			profilePath,
+			repoRoot,
+			coverPackages,
+			partialCoverageReason(errors.Join(laneErr, mergeErr)),
+		)
+	}
+	runErr := errors.Join(laneErr, timingWriteErr, mergeErr, partialCoverageErr, plan.cleanup())
 	if !testFailureObserved {
 		return runErr
 	}
@@ -512,15 +575,29 @@ func runCommand(invocation commandInvocation) (string, string, error) {
 	return commandRunner(invocation)
 }
 
-func configureCoverageInvocationStreaming(plan *coverageInvocationPlan, enabled bool) {
+func configureCoverageInvocationStreaming(plan *coverageInvocationPlan, enabled bool, observers ...func(goTestTimingEvent)) *functionalStreamReporter {
 	if !enabled {
-		return
+		return nil
 	}
-	reporter := newFunctionalStreamReporter(stdoutWriter)
+	var observer func(goTestTimingEvent)
+	if len(observers) > 0 {
+		observer = observers[0]
+	}
+	reporter := newFunctionalStreamReporterWithObserver(stdoutWriter, observer)
 	for index := range plan.invocations {
 		plan.invocations[index].stdoutWriter = reporter.stdoutWriter()
 		plan.invocations[index].stderrWriter = reporter.stderrWriter(stderrWriter)
 	}
+	return reporter
+}
+
+func configureCoverageInvocationObservation(plan *coverageInvocationPlan, observer func(goTestTimingEvent)) *functionalStreamReporter {
+	reporter := newFunctionalStreamReporterWithObserver(io.Discard, observer)
+	for index := range plan.invocations {
+		plan.invocations[index].stdoutWriter = reporter.stdoutWriter()
+		plan.invocations[index].stderrWriter = reporter.stderrWriter(io.Discard)
+	}
+	return reporter
 }
 
 func mergeGoTestFailureDetail(stderr string, stdout string) string {

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -328,46 +328,9 @@ func runGoTestCoverageLaneWithSelection(cfg config, commonArgs []string, testPac
 }
 
 func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, testPackages []string, profilePath string, repoRoot string, coverPackages []string, failurePrefix string) error {
-	timingEnabled := strings.TrimSpace(cfg.timingOutput) != ""
 	started := time.Now()
-	var snapshotter *functionalTimingSnapshotter
-	if cfg.stream || timingEnabled {
-		tracker := newFunctionalTimingTracker(testPackages, started)
-		observer := func(event goTestTimingEvent) {
-			if snapshotter != nil {
-				snapshotter.observe(event)
-				return
-			}
-			tracker.observe(event)
-		}
-		var reporter *functionalStreamReporter
-		if cfg.stream {
-			reporter = configureCoverageInvocationStreaming(&plan, true, observer)
-		} else {
-			reporter = configureCoverageInvocationObservation(&plan, observer)
-		}
-		sink := io.Writer(nil)
-		var sinkMu *sync.Mutex
-		if cfg.stream {
-			sink = stdoutWriter
-			sinkMu = &reporter.sinkMu
-		}
-		snapshotter = newFunctionalTimingSnapshotter(
-			tracker,
-			cfg.timingOutput,
-			sink,
-			sinkMu,
-			func() error {
-				return writePartialCoverageSnapshot(
-					cfg.jsonOutput,
-					profilePath,
-					repoRoot,
-					coverPackages,
-					partialCoverageReason(nil),
-				)
-			},
-		)
-		snapshotter.publish(false, "functional run started", false)
+	snapshotter := configureFunctionalTimingSnapshot(&plan, cfg, testPackages, started, profilePath, repoRoot, coverPackages)
+	if snapshotter != nil {
 		defer snapshotter.stopAndWait()
 	}
 	var stdout strings.Builder
@@ -405,27 +368,7 @@ func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, test
 	}
 	wallSeconds := time.Since(started).Seconds()
 
-	var timingWriteErr error
-	if timingEnabled {
-		summary := buildFunctionalTimingSummary(stdout.String(), testPackages, wallSeconds)
-		timingReason := ""
-		if !summary.Complete {
-			timingReason = "functional timing capture ended before every package reported a terminal result"
-			if laneErr != nil {
-				timingReason += ": " + compactDiagnosticError(laneErr)
-			}
-		}
-		if snapshotter != nil {
-			timingWriteErr = snapshotter.finish(summary, timingReason)
-		} else {
-			timingWriteErr = writeFunctionalTimingSummaryJSON(cfg.timingOutput, summary)
-		}
-		if timingWriteErr == nil && cfg.suite == "functional" {
-			writeFunctionalTimingInventorySummary(summary, cfg.short)
-		}
-	} else if snapshotter != nil {
-		snapshotter.stopAndWait()
-	}
+	timingWriteErr := finalizeFunctionalTiming(cfg, snapshotter, stdout.String(), testPackages, wallSeconds, laneErr)
 
 	var mergeErr error
 	if len(plan.profilePaths) > 1 {
@@ -436,16 +379,7 @@ func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, test
 		}
 	}
 
-	partialCoverageErr := error(nil)
-	if laneErr != nil || mergeErr != nil {
-		partialCoverageErr = writePartialCoverageSnapshot(
-			cfg.jsonOutput,
-			profilePath,
-			repoRoot,
-			coverPackages,
-			partialCoverageReason(errors.Join(laneErr, mergeErr)),
-		)
-	}
+	partialCoverageErr := publishPartialCoverageIfNeeded(cfg, profilePath, repoRoot, coverPackages, laneErr, mergeErr)
 	runErr := errors.Join(laneErr, timingWriteErr, mergeErr, partialCoverageErr, plan.cleanup())
 	if !testFailureObserved {
 		return runErr
@@ -455,6 +389,87 @@ func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, test
 		failedTestCount:      failedTestCount,
 		failedTestCountKnown: failedTestCountKnown && failedTestCount > 0,
 	}
+}
+
+func configureFunctionalTimingSnapshot(plan *coverageInvocationPlan, cfg config, testPackages []string, started time.Time, profilePath string, repoRoot string, coverPackages []string) *functionalTimingSnapshotter {
+	timingEnabled := strings.TrimSpace(cfg.timingOutput) != ""
+	if !cfg.stream && !timingEnabled {
+		return nil
+	}
+
+	tracker := newFunctionalTimingTracker(testPackages, started)
+	var snapshotter *functionalTimingSnapshotter
+	observer := func(event goTestTimingEvent) {
+		if snapshotter != nil {
+			snapshotter.observe(event)
+			return
+		}
+		tracker.observe(event)
+	}
+	var reporter *functionalStreamReporter
+	if cfg.stream {
+		reporter = configureCoverageInvocationStreaming(plan, true, observer)
+	} else {
+		reporter = configureCoverageInvocationObservation(plan, observer)
+	}
+	sink := io.Writer(nil)
+	var sinkMu *sync.Mutex
+	if cfg.stream {
+		sink = stdoutWriter
+		sinkMu = &reporter.sinkMu
+	}
+	snapshotter = newFunctionalTimingSnapshotter(
+		tracker,
+		cfg.timingOutput,
+		sink,
+		sinkMu,
+		func() error {
+			return writePartialCoverageSnapshot(cfg.jsonOutput, profilePath, repoRoot, coverPackages, partialCoverageReason(nil))
+		},
+	)
+	snapshotter.publish(false, "functional run started", false)
+	return snapshotter
+}
+
+func finalizeFunctionalTiming(cfg config, snapshotter *functionalTimingSnapshotter, stdout string, testPackages []string, wallSeconds float64, laneErr error) error {
+	if strings.TrimSpace(cfg.timingOutput) == "" {
+		if snapshotter != nil {
+			snapshotter.stopAndWait()
+		}
+		return nil
+	}
+
+	summary := buildFunctionalTimingSummary(stdout, testPackages, wallSeconds)
+	timingReason := ""
+	if !summary.Complete {
+		timingReason = "functional timing capture ended before every package reported a terminal result"
+		if laneErr != nil {
+			timingReason += ": " + compactDiagnosticError(laneErr)
+		}
+	}
+	var err error
+	if snapshotter != nil {
+		err = snapshotter.finish(summary, timingReason)
+	} else {
+		err = writeFunctionalTimingSummaryJSON(cfg.timingOutput, summary)
+	}
+	if err == nil && cfg.suite == "functional" {
+		writeFunctionalTimingInventorySummary(summary, cfg.short)
+	}
+	return err
+}
+
+func publishPartialCoverageIfNeeded(cfg config, profilePath string, repoRoot string, coverPackages []string, laneErr error, mergeErr error) error {
+	if laneErr == nil && mergeErr == nil {
+		return nil
+	}
+	return writePartialCoverageSnapshot(
+		cfg.jsonOutput,
+		profilePath,
+		repoRoot,
+		coverPackages,
+		partialCoverageReason(errors.Join(laneErr, mergeErr)),
+	)
 }
 
 func coverageTestFailureDetails(commandErr error, stdout string, stderr string) (int, bool, bool) {

--- a/cmd/gocoveragecheck/coverage_json.go
+++ b/cmd/gocoveragecheck/coverage_json.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"os"
 	"strings"
 )
 
@@ -12,6 +11,8 @@ import (
 // gocoveragecheck. Downstream visualizers consume this artifact instead of
 // re-parsing coverage profiles.
 type coverageSummaryJSON struct {
+	Complete             bool                  `json:"complete"`
+	MeasurementReason    string                `json:"measurementReason,omitempty"`
 	CoveredStatements    int                   `json:"coveredStatements"`
 	MeasurableStatements int                   `json:"measurableStatements"`
 	CoveragePercent      float64               `json:"coveragePercent"`
@@ -40,6 +41,7 @@ type packageCoverageGate struct {
 func buildCoverageSummaryJSON(result coverageResult) coverageSummaryJSON {
 	covered, measurable := overallStatementTotals(result)
 	return coverageSummaryJSON{
+		Complete:             true,
 		CoveredStatements:    covered,
 		MeasurableStatements: measurable,
 		CoveragePercent:      roundCoveragePercent(result.actual),
@@ -128,15 +130,22 @@ func renderCoverageSummaryJSON(summary coverageSummaryJSON) ([]byte, error) {
 }
 
 func writeCoverageSummaryJSON(path string, result coverageResult) error {
+	return writeCoverageSummaryJSONWithStatus(path, result, true, "")
+}
+
+func writeCoverageSummaryJSONWithStatus(path string, result coverageResult, complete bool, reason string) error {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return nil
 	}
-	data, err := renderCoverageSummaryJSON(buildCoverageSummaryJSON(result))
+	summary := buildCoverageSummaryJSON(result)
+	summary.Complete = complete
+	summary.MeasurementReason = strings.TrimSpace(reason)
+	data, err := renderCoverageSummaryJSON(summary)
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := writeAtomicDiagnosticFile(path, data); err != nil {
 		return fmt.Errorf("write go coverage summary json: %w", err)
 	}
 	return nil

--- a/cmd/gocoveragecheck/coverage_json_test.go
+++ b/cmd/gocoveragecheck/coverage_json_test.go
@@ -402,7 +402,7 @@ func TestExecuteWritesJSONWhenPackageFloorFails(t *testing.T) {
 	}
 }
 
-func TestExecuteDoesNotWriteJSONWhenMeasurementIncomplete(t *testing.T) {
+func TestExecuteWritesIncompleteJSONWhenMeasurementFailsWithProfile(t *testing.T) {
 	originalCommandRunner := commandRunner
 	originalStdout := stdoutWriter
 	originalStderr := stderrWriter
@@ -435,8 +435,22 @@ func TestExecuteDoesNotWriteJSONWhenMeasurementIncomplete(t *testing.T) {
 	if !strings.Contains(err.Error(), "run go test coverage lane") {
 		t.Fatalf("execute() error = %q, want incomplete measurement failure", err.Error())
 	}
-	if _, statErr := os.Stat(jsonPath); !os.IsNotExist(statErr) {
-		t.Fatalf("unexpected json file at %s after incomplete measurement (stat err=%v)", jsonPath, statErr)
+	data, readErr := os.ReadFile(jsonPath)
+	if readErr != nil {
+		t.Fatalf("read incomplete coverage summary json: %v", readErr)
+	}
+	var summary coverageSummaryJSON
+	if decodeErr := json.Unmarshal(data, &summary); decodeErr != nil {
+		t.Fatalf("decode incomplete coverage summary json: %v\n%s", decodeErr, data)
+	}
+	if summary.Complete {
+		t.Fatal("incomplete coverage summary marked complete")
+	}
+	if len(summary.Packages) == 0 {
+		t.Fatalf("incomplete coverage summary packages = %+v, want retained partial package totals", summary.Packages)
+	}
+	if !strings.Contains(summary.MeasurementReason, "did not complete") {
+		t.Fatalf("measurement reason = %q, want incomplete-measurement explanation", summary.MeasurementReason)
 	}
 }
 

--- a/cmd/gocoveragecheck/coverage_partial.go
+++ b/cmd/gocoveragecheck/coverage_partial.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func writePartialCoverageSnapshot(path, profilePath, repoRoot string, coverPackages []string, reason string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	result, err := readPartialCoverageResult(profilePath, repoRoot, coverPackages)
+	if err != nil {
+		// A profile that has not reached a complete line yet is not a
+		// trustworthy partial measurement. The timing artifact and runner
+		// inventory name this coverage item as unavailable instead.
+		return nil
+	}
+	return writeCoverageSummaryJSONWithStatus(path, result, false, reason)
+}
+
+func readPartialCoverageResult(profilePath, repoRoot string, coverPackages []string) (coverageResult, error) {
+	blocks, err := readCoverageProfileBlocks(profilePath, repoRoot)
+	if err != nil {
+		return coverageResult{}, err
+	}
+	if len(blocks) == 0 {
+		return coverageResult{}, errors.New("partial go coverage profile contains no complete source blocks")
+	}
+	totals := coverageTotals(blocks)
+	actual, _ := calculateTotalCoverage(totals, coverPackages)
+	return coverageResult{
+		actual:           actual,
+		coverageBlocks:   blocks,
+		packageTotals:    totals,
+		packageSummaries: summarizePackageCoverageFromTotals(totals, coverPackages),
+	}, nil
+}
+
+func partialCoverageReason(commandErr error) string {
+	if commandErr == nil {
+		return "go test coverage is still running; partial statements are diagnostic only"
+	}
+	return fmt.Sprintf("go test coverage did not complete: %s; partial statements are diagnostic only", compactDiagnosticError(commandErr))
+}
+
+func compactDiagnosticError(err error) string {
+	if err == nil {
+		return "unknown interruption"
+	}
+	reason := strings.Join(strings.Fields(err.Error()), " ")
+	if len(reason) > 240 {
+		return reason[:240] + "..."
+	}
+	return reason
+}

--- a/cmd/gocoveragecheck/diagnostic_files.go
+++ b/cmd/gocoveragecheck/diagnostic_files.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// writeAtomicDiagnosticFile makes a completed JSON document visible in one
+// rename. A timeout can interrupt the producer at any point, so readers must
+// never observe a half-written timing or coverage artifact.
+func writeAtomicDiagnosticFile(path string, data []byte) (err error) {
+	directory := filepath.Dir(path)
+	if directory != "" && directory != "." {
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			return fmt.Errorf("create diagnostic output directory: %w", err)
+		}
+	}
+
+	temporary, err := os.CreateTemp(directory, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temporary diagnostic file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		removeErr := os.Remove(temporaryPath)
+		if err == nil && removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			err = fmt.Errorf("remove temporary diagnostic file: %w", removeErr)
+		}
+	}()
+
+	if _, err := temporary.Write(data); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("write temporary diagnostic file: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("sync temporary diagnostic file: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary diagnostic file: %w", err)
+	}
+	if err := replaceDiagnosticFile(temporaryPath, path); err != nil {
+		return err
+	}
+	return nil
+}
+
+func replaceDiagnosticFile(temporaryPath, path string) error {
+	if err := os.Rename(temporaryPath, path); err == nil {
+		return nil
+	} else if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		return fmt.Errorf("replace diagnostic file: rename: %w; remove existing: %v", err, removeErr)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("replace diagnostic file: %w", err)
+	}
+	return nil
+}

--- a/cmd/gocoveragecheck/functional_diagnostics.go
+++ b/cmd/gocoveragecheck/functional_diagnostics.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+)
+
+const functionalTimingSnapshotInterval = time.Second
+const functionalCoverageSnapshotInterval = 5 * time.Second
+
+// functionalTimingTracker records package lifecycle events independently from
+// the buffered go test JSON. This lets a timeout snapshot describe packages
+// that have started but never emitted a terminal event.
+type functionalTimingTracker struct {
+	mu         sync.Mutex
+	expected   []string
+	started    map[string]time.Time
+	terminals  map[string]functionalPackageTimingJSON
+	invalid    bool
+	now        func() time.Time
+	runStarted time.Time
+}
+
+func newFunctionalTimingTracker(expected []string, started time.Time) *functionalTimingTracker {
+	unique := make(map[string]struct{}, len(expected))
+	ordered := make([]string, 0, len(expected))
+	for _, packageName := range expected {
+		packageName = strings.TrimSpace(packageName)
+		if packageName == "" {
+			continue
+		}
+		if _, exists := unique[packageName]; exists {
+			continue
+		}
+		unique[packageName] = struct{}{}
+		ordered = append(ordered, packageName)
+	}
+	slices.Sort(ordered)
+	return &functionalTimingTracker{
+		expected:   ordered,
+		started:    make(map[string]time.Time, len(ordered)),
+		terminals:  make(map[string]functionalPackageTimingJSON, len(ordered)),
+		now:        time.Now,
+		runStarted: started,
+	}
+}
+
+func (tracker *functionalTimingTracker) observe(event goTestTimingEvent) bool {
+	packageName := strings.TrimSpace(event.Package)
+	if packageName == "" || event.Test != "" {
+		return false
+	}
+
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	if !tracker.isExpectedLocked(packageName) {
+		tracker.invalid = true
+		return false
+	}
+
+	switch event.Action {
+	case "start":
+		if _, alreadyStarted := tracker.started[packageName]; alreadyStarted {
+			return false
+		}
+		tracker.started[packageName] = tracker.now()
+		return true
+	case timingOutcomePass, timingOutcomeFail, timingOutcomeSkip:
+		if !validTimingElapsed(event.Elapsed) {
+			tracker.invalid = true
+			return false
+		}
+		if _, alreadyTerminal := tracker.terminals[packageName]; alreadyTerminal {
+			tracker.invalid = true
+			return false
+		}
+		entry := functionalPackageTimingJSON{
+			Package: packageName,
+			Seconds: event.Elapsed,
+			Outcome: event.Action,
+		}
+		if event.Output != "" {
+			entry.Reason = firstTimingFailureReason(event.Output)
+		}
+		tracker.terminals[packageName] = entry
+		return true
+	default:
+		return false
+	}
+}
+
+func (tracker *functionalTimingTracker) isExpectedLocked(packageName string) bool {
+	return slices.Contains(tracker.expected, packageName)
+}
+
+func (tracker *functionalTimingTracker) snapshot(complete bool, reason string, at time.Time) functionalTimingSummaryJSON {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+
+	packages := make([]functionalPackageTimingJSON, 0, len(tracker.terminals))
+	states := make([]functionalPackageStateJSON, 0, len(tracker.expected))
+	packageElapsed := 0.0
+	for _, packageName := range tracker.expected {
+		if terminal, ok := tracker.terminals[packageName]; ok {
+			packages = append(packages, terminal)
+			states = append(states, functionalPackageStateJSON{
+				Package: packageName,
+				Seconds: terminal.Seconds,
+				State:   functionalPackageStateCompleted,
+				Outcome: terminal.Outcome,
+				Reason:  terminal.Reason,
+			})
+			packageElapsed += terminal.Seconds
+			continue
+		}
+
+		seconds := 0.0
+		state := functionalPackageStateUnobserved
+		if packageStarted, ok := tracker.started[packageName]; ok {
+			state = functionalPackageStateInFlight
+			seconds = at.Sub(packageStarted).Seconds()
+			if seconds < 0 {
+				seconds = 0
+			}
+		}
+		states = append(states, functionalPackageStateJSON{
+			Package: packageName,
+			Seconds: roundTimingSeconds(seconds),
+			State:   state,
+		})
+		packageElapsed += seconds
+	}
+
+	allTerminal := len(tracker.terminals) == len(tracker.expected) && !tracker.invalid
+	if wallSeconds := at.Sub(tracker.runStarted).Seconds(); wallSeconds >= 0 {
+		return functionalTimingSummaryJSON{
+			Version:                  functionalTimingSummaryVersion,
+			Complete:                 complete && allTerminal,
+			CaptureReason:            strings.TrimSpace(reason),
+			WallSeconds:              roundTimingSeconds(wallSeconds),
+			PackageElapsedSecondsSum: roundTimingSeconds(packageElapsed),
+			ExpectedPackageCount:     len(tracker.expected),
+			PackageCount:             len(packages),
+			Packages:                 packages,
+			PackageStates:            states,
+		}
+	}
+	return functionalTimingSummaryJSON{
+		Version:              functionalTimingSummaryVersion,
+		Complete:             false,
+		CaptureReason:        strings.TrimSpace(reason),
+		ExpectedPackageCount: len(tracker.expected),
+		PackageCount:         len(packages),
+		Packages:             packages,
+		PackageStates:        states,
+	}
+}
+
+func validTimingElapsed(seconds float64) bool {
+	return seconds >= 0 && seconds < 1e12
+}
+
+// functionalTimingSnapshotter persists an incomplete document while the child
+// is running and replaces it with the final buffered summary after completion.
+// The ticker is deliberately short-lived and only writes the small structured
+// timing document; it does not poll the child or extend the tier budget.
+type functionalTimingSnapshotter struct {
+	tracker               *functionalTimingTracker
+	path                  string
+	sink                  io.Writer
+	sinkMu                *sync.Mutex
+	onPublish             func() error
+	writeMu               sync.Mutex
+	writeErr              error
+	lastCoveragePublishAt time.Time
+	stop                  chan struct{}
+	done                  chan struct{}
+	stopOnce              sync.Once
+}
+
+func newFunctionalTimingSnapshotter(tracker *functionalTimingTracker, path string, sink io.Writer, sinkMu *sync.Mutex, callbacks ...func() error) *functionalTimingSnapshotter {
+	var onPublish func() error
+	if len(callbacks) > 0 {
+		onPublish = callbacks[0]
+	}
+	snapshotter := &functionalTimingSnapshotter{
+		tracker:   tracker,
+		path:      strings.TrimSpace(path),
+		sink:      sink,
+		sinkMu:    sinkMu,
+		onPublish: onPublish,
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+	go snapshotter.run()
+	return snapshotter
+}
+
+func (snapshotter *functionalTimingSnapshotter) run() {
+	defer close(snapshotter.done)
+	ticker := time.NewTicker(functionalTimingSnapshotInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			snapshotter.publish(false, "functional run still active", false)
+		case <-snapshotter.stop:
+			return
+		}
+	}
+}
+
+func (snapshotter *functionalTimingSnapshotter) observe(event goTestTimingEvent) {
+	if !snapshotter.tracker.observe(event) {
+		return
+	}
+	snapshotter.publish(false, "functional run still active", true)
+}
+
+func (snapshotter *functionalTimingSnapshotter) finish(summary functionalTimingSummaryJSON, reason string) error {
+	snapshotter.stopAndWait()
+	snapshotter.writeMu.Lock()
+	defer snapshotter.writeMu.Unlock()
+	if !summary.Complete {
+		partial := snapshotter.tracker.snapshot(false, reason, time.Now())
+		partial.Tests = summary.Tests
+		partial.TestCount = summary.TestCount
+		partial.TestPassCount = summary.TestPassCount
+		partial.TestFailCount = summary.TestFailCount
+		partial.TestSkipCount = summary.TestSkipCount
+		partial.Packages = summary.Packages
+		partial.PackageCount = summary.PackageCount
+		partial.PackageElapsedSecondsSum = summary.PackageElapsedSecondsSum
+		partial.WallSeconds = summary.WallSeconds
+		summary = partial
+	}
+	if snapshotter.path != "" {
+		if err := writeFunctionalTimingSummaryJSON(snapshotter.path, summary); err != nil {
+			snapshotter.rememberWriteErrorLocked(err)
+		}
+	}
+	snapshotter.publishCoverageSnapshotLocked(true)
+	if !summary.Complete || strings.TrimSpace(reason) != "" {
+		snapshotter.emitSummary(summary, reason)
+	}
+	return snapshotter.writeErr
+}
+
+func (snapshotter *functionalTimingSnapshotter) stopAndWait() {
+	snapshotter.stopOnce.Do(func() { close(snapshotter.stop) })
+	<-snapshotter.done
+}
+
+func (snapshotter *functionalTimingSnapshotter) publish(complete bool, reason string, emit bool) {
+	snapshotter.writeMu.Lock()
+	defer snapshotter.writeMu.Unlock()
+	summary := snapshotter.tracker.snapshot(complete, reason, time.Now())
+	if snapshotter.path != "" {
+		if err := writeFunctionalTimingSummaryJSON(snapshotter.path, summary); err != nil {
+			snapshotter.rememberWriteErrorLocked(err)
+		}
+	}
+	snapshotter.publishCoverageSnapshotLocked(false)
+	if emit {
+		snapshotter.emitSummary(summary, reason)
+	}
+}
+
+func (snapshotter *functionalTimingSnapshotter) publishCoverageSnapshotLocked(force bool) {
+	if snapshotter.onPublish == nil {
+		return
+	}
+	now := time.Now()
+	if !force && !snapshotter.lastCoveragePublishAt.IsZero() && now.Sub(snapshotter.lastCoveragePublishAt) < functionalCoverageSnapshotInterval {
+		return
+	}
+	snapshotter.lastCoveragePublishAt = now
+	if err := snapshotter.onPublish(); err != nil {
+		snapshotter.rememberWriteErrorLocked(err)
+	}
+}
+
+func (snapshotter *functionalTimingSnapshotter) emitSummary(summary functionalTimingSummaryJSON, reason string) {
+	if snapshotter.sink == nil {
+		return
+	}
+	write := func() {
+		fmt.Fprintf(snapshotter.sink, "Functional timing snapshot: complete=%t packages=%d/%d wall=%.3fs reason=%s\n", summary.Complete, summary.PackageCount, summary.ExpectedPackageCount, summary.WallSeconds, reason)
+		for _, state := range summary.PackageStates {
+			if state.State == functionalPackageStateCompleted {
+				continue
+			}
+			fmt.Fprintf(snapshotter.sink, "Functional package state: package=%s state=%s elapsed=%.3fs\n", state.Package, state.State, state.Seconds)
+		}
+	}
+	if snapshotter.sinkMu == nil {
+		write()
+		return
+	}
+	snapshotter.sinkMu.Lock()
+	defer snapshotter.sinkMu.Unlock()
+	write()
+}
+
+func (snapshotter *functionalTimingSnapshotter) rememberWriteErrorLocked(err error) {
+	if snapshotter.writeErr == nil {
+		snapshotter.writeErr = err
+	}
+}
+
+func (snapshotter *functionalTimingSnapshotter) writeError() error {
+	snapshotter.writeMu.Lock()
+	defer snapshotter.writeMu.Unlock()
+	return snapshotter.writeErr
+}

--- a/cmd/gocoveragecheck/functional_diagnostics_test.go
+++ b/cmd/gocoveragecheck/functional_diagnostics_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFunctionalTimingTrackerSnapshotNamesActiveAndUnobservedPackages(t *testing.T) {
+	started := time.Unix(100, 0)
+	tracker := newFunctionalTimingTracker([]string{"pkg/alpha", "pkg/beta", "pkg/gamma"}, started)
+	tracker.now = func() time.Time { return started }
+
+	if !tracker.observe(goTestTimingEvent{Action: "start", Package: "pkg/alpha"}) {
+		t.Fatal("start event was not observed")
+	}
+	tracker.now = func() time.Time { return started.Add(4 * time.Second) }
+	if !tracker.observe(goTestTimingEvent{Action: timingOutcomePass, Package: "pkg/beta", Elapsed: 1.25}) {
+		t.Fatal("terminal event was not observed")
+	}
+
+	summary := tracker.snapshot(false, "tier budget expired", started.Add(4*time.Second))
+	if summary.Complete {
+		t.Fatal("snapshot marked complete after an interrupted run")
+	}
+	if len(summary.PackageStates) != 3 {
+		t.Fatalf("package states = %+v, want all expected packages", summary.PackageStates)
+	}
+	assertPackageState(t, summary.PackageStates[0], "pkg/alpha", functionalPackageStateInFlight, 4)
+	assertPackageState(t, summary.PackageStates[1], "pkg/beta", functionalPackageStateCompleted, 1.25)
+	assertPackageState(t, summary.PackageStates[2], "pkg/gamma", functionalPackageStateUnobserved, 0)
+}
+
+func TestFunctionalTimingSnapshotWritesMachineReadablePartialArtifact(t *testing.T) {
+	started := time.Unix(200, 0)
+	tracker := newFunctionalTimingTracker([]string{"pkg/hung"}, started)
+	tracker.now = func() time.Time { return started.Add(3 * time.Second) }
+	path := filepath.Join(t.TempDir(), "functional-timing-summary.json")
+	snapshotter := newFunctionalTimingSnapshotter(tracker, path, nil, nil)
+	snapshotter.publish(false, "tier budget expired", false)
+	snapshotter.stopAndWait()
+	if err := snapshotter.writeError(); err != nil {
+		t.Fatalf("snapshot write error = %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read timing snapshot: %v", err)
+	}
+	var summary functionalTimingSummaryJSON
+	if err := json.Unmarshal(data, &summary); err != nil {
+		t.Fatalf("decode timing snapshot: %v\n%s", err, data)
+	}
+	if summary.Complete || summary.CaptureReason != "tier budget expired" {
+		t.Fatalf("partial timing summary = %+v, want incomplete timeout state", summary)
+	}
+	if len(summary.PackageStates) != 1 || summary.PackageStates[0].State != functionalPackageStateUnobserved {
+		t.Fatalf("partial package states = %+v, want unobserved package", summary.PackageStates)
+	}
+}
+
+func TestWritePartialCoverageSnapshotSkipsUntrustworthyProfile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coverage-summary.json")
+	err := writePartialCoverageSnapshot(
+		path,
+		filepath.Join(t.TempDir(), "missing-coverage.out"),
+		".",
+		[]string{modulePath + "/pkg/config"},
+		"tier budget expired",
+	)
+	if err != nil {
+		t.Fatalf("writePartialCoverageSnapshot() error = %v, want no error for unavailable profile", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("unexpected partial coverage artifact, stat err=%v", err)
+	}
+}
+
+func TestWriteFunctionalTimingSummaryAtomicFailureNamesOutputDirectory(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(parent, []byte("file"), 0o600); err != nil {
+		t.Fatalf("write parent fixture: %v", err)
+	}
+	err := writeFunctionalTimingSummaryJSON(filepath.Join(parent, "timing.json"), functionalTimingSummaryJSON{Version: functionalTimingSummaryVersion})
+	if err == nil || !strings.Contains(err.Error(), "create diagnostic output directory") {
+		t.Fatalf("writeFunctionalTimingSummaryJSON() error = %v, want actionable directory failure", err)
+	}
+}
+
+func assertPackageState(t *testing.T, got functionalPackageStateJSON, packageName, state string, seconds float64) {
+	t.Helper()
+	if got.Package != packageName || got.State != state || got.Seconds != seconds {
+		t.Fatalf("package state = %+v, want package=%s state=%s seconds=%v", got, packageName, state, seconds)
+	}
+}

--- a/cmd/gocoveragecheck/functional_stream.go
+++ b/cmd/gocoveragecheck/functional_stream.go
@@ -16,7 +16,9 @@ import (
 type functionalStreamReporter struct {
 	sink              io.Writer
 	mu                sync.Mutex
+	sinkMu            sync.Mutex
 	completedPackages map[string]struct{}
+	onEvent           func(goTestTimingEvent)
 }
 
 type functionalStreamWriter struct {
@@ -34,6 +36,12 @@ func newFunctionalStreamReporter(sink io.Writer) *functionalStreamReporter {
 		sink:              sink,
 		completedPackages: make(map[string]struct{}),
 	}
+}
+
+func newFunctionalStreamReporterWithObserver(sink io.Writer, observer func(goTestTimingEvent)) *functionalStreamReporter {
+	reporter := newFunctionalStreamReporter(sink)
+	reporter.onEvent = observer
+	return reporter
 }
 
 func (reporter *functionalStreamReporter) stdoutWriter() *functionalStreamWriter {
@@ -81,14 +89,17 @@ func (writer *functionalStreamWriter) Flush() error {
 func (writer *functionalStreamWriter) writeLineLocked(line []byte) error {
 	var event goTestTimingEvent
 	if err := json.Unmarshal(bytes.TrimSpace(line), &event); err != nil || event.Package == "" {
-		return writeFunctionalStreamBytes(writer.reporter.sink, line)
+		return writer.reporter.writeSink(line)
+	}
+	if writer.reporter.onEvent != nil {
+		writer.reporter.onEvent(event)
 	}
 
 	switch event.Action {
 	case "output":
 		// Keep the child failure text readable in the job log while the
 		// command runner retains the original JSON bytes for timing parsing.
-		return writeFunctionalStreamBytes(writer.reporter.sink, []byte(event.Output))
+		return writer.reporter.writeSink([]byte(event.Output))
 	case timingOutcomePass, timingOutcomeFail, timingOutcomeSkip:
 		if event.Test != "" {
 			return nil
@@ -97,26 +108,45 @@ func (writer *functionalStreamWriter) writeLineLocked(line []byte) error {
 			return nil
 		}
 		writer.reporter.completedPackages[event.Package] = struct{}{}
-		_, err := fmt.Fprintf(
-			writer.reporter.sink,
-			"Functional package result: package=%s outcome=%s elapsed=%.3fs\n",
-			event.Package,
-			event.Action,
-			event.Elapsed,
-		)
+		var err error
+		writer.reporter.withSink(func(sink io.Writer) {
+			_, err = fmt.Fprintf(
+				sink,
+				"Functional package result: package=%s outcome=%s elapsed=%.3fs\n",
+				event.Package,
+				event.Action,
+				event.Elapsed,
+			)
+		})
 		return err
 	default:
 		// Unknown JSON lines remain visible rather than being silently
 		// discarded if go test adds an event action this reporter does not
 		// understand yet.
-		return writeFunctionalStreamBytes(writer.reporter.sink, line)
+		return writer.reporter.writeSink(line)
 	}
 }
 
 func (writer *lockedFunctionalStreamWriter) Write(data []byte) (int, error) {
 	writer.reporter.mu.Lock()
 	defer writer.reporter.mu.Unlock()
-	return len(data), writeFunctionalStreamBytes(writer.sink, data)
+	return len(data), writer.reporter.writeSinkTo(writer.sink, data)
+}
+
+func (reporter *functionalStreamReporter) writeSink(data []byte) error {
+	return reporter.writeSinkTo(reporter.sink, data)
+}
+
+func (reporter *functionalStreamReporter) writeSinkTo(sink io.Writer, data []byte) error {
+	reporter.sinkMu.Lock()
+	defer reporter.sinkMu.Unlock()
+	return writeFunctionalStreamBytes(sink, data)
+}
+
+func (reporter *functionalStreamReporter) withSink(fn func(io.Writer)) {
+	reporter.sinkMu.Lock()
+	defer reporter.sinkMu.Unlock()
+	fn(reporter.sink)
 }
 
 func writeFunctionalStreamBytes(sink io.Writer, data []byte) error {

--- a/cmd/gocoveragecheck/functional_stream.go
+++ b/cmd/gocoveragecheck/functional_stream.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// functionalStreamReporter serializes the two child output streams so a
+// decoded test event and its human-readable package result reach the same
+// diagnostic sink as complete writes. Package completion is tracked across
+// invocation batches because a functional selection can be split into more
+// than one go test process on Windows.
+type functionalStreamReporter struct {
+	sink              io.Writer
+	mu                sync.Mutex
+	completedPackages map[string]struct{}
+}
+
+type functionalStreamWriter struct {
+	reporter *functionalStreamReporter
+	pending  []byte
+}
+
+type lockedFunctionalStreamWriter struct {
+	reporter *functionalStreamReporter
+	sink     io.Writer
+}
+
+func newFunctionalStreamReporter(sink io.Writer) *functionalStreamReporter {
+	return &functionalStreamReporter{
+		sink:              sink,
+		completedPackages: make(map[string]struct{}),
+	}
+}
+
+func (reporter *functionalStreamReporter) stdoutWriter() *functionalStreamWriter {
+	return &functionalStreamWriter{reporter: reporter}
+}
+
+func (reporter *functionalStreamReporter) stderrWriter(sink io.Writer) io.Writer {
+	return &lockedFunctionalStreamWriter{reporter: reporter, sink: sink}
+}
+
+func (writer *functionalStreamWriter) Write(data []byte) (int, error) {
+	writer.reporter.mu.Lock()
+	defer writer.reporter.mu.Unlock()
+
+	writer.pending = append(writer.pending, data...)
+	for {
+		lineEnd := bytes.IndexByte(writer.pending, '\n')
+		if lineEnd < 0 {
+			break
+		}
+		line := append([]byte(nil), writer.pending[:lineEnd+1]...)
+		writer.pending = writer.pending[lineEnd+1:]
+		if err := writer.writeLineLocked(line); err != nil {
+			return len(data), err
+		}
+	}
+	return len(data), nil
+}
+
+// Flush preserves a final child-output fragment when a subprocess exits
+// without a trailing newline. Normal go test JSON events are newline-delimited,
+// but timeout and signal paths should not lose the last diagnostic fragment.
+func (writer *functionalStreamWriter) Flush() error {
+	writer.reporter.mu.Lock()
+	defer writer.reporter.mu.Unlock()
+
+	if len(writer.pending) == 0 {
+		return nil
+	}
+	line := append([]byte(nil), writer.pending...)
+	writer.pending = nil
+	return writer.writeLineLocked(line)
+}
+
+func (writer *functionalStreamWriter) writeLineLocked(line []byte) error {
+	var event goTestTimingEvent
+	if err := json.Unmarshal(bytes.TrimSpace(line), &event); err != nil || event.Package == "" {
+		return writeFunctionalStreamBytes(writer.reporter.sink, line)
+	}
+
+	switch event.Action {
+	case "output":
+		// Keep the child failure text readable in the job log while the
+		// command runner retains the original JSON bytes for timing parsing.
+		return writeFunctionalStreamBytes(writer.reporter.sink, []byte(event.Output))
+	case timingOutcomePass, timingOutcomeFail, timingOutcomeSkip:
+		if event.Test != "" {
+			return nil
+		}
+		if _, alreadyReported := writer.reporter.completedPackages[event.Package]; alreadyReported {
+			return nil
+		}
+		writer.reporter.completedPackages[event.Package] = struct{}{}
+		_, err := fmt.Fprintf(
+			writer.reporter.sink,
+			"Functional package result: package=%s outcome=%s elapsed=%.3fs\n",
+			event.Package,
+			event.Action,
+			event.Elapsed,
+		)
+		return err
+	default:
+		// Unknown JSON lines remain visible rather than being silently
+		// discarded if go test adds an event action this reporter does not
+		// understand yet.
+		return writeFunctionalStreamBytes(writer.reporter.sink, line)
+	}
+}
+
+func (writer *lockedFunctionalStreamWriter) Write(data []byte) (int, error) {
+	writer.reporter.mu.Lock()
+	defer writer.reporter.mu.Unlock()
+	return len(data), writeFunctionalStreamBytes(writer.sink, data)
+}
+
+func writeFunctionalStreamBytes(sink io.Writer, data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	written, err := sink.Write(data)
+	if err != nil {
+		return err
+	}
+	if written != len(data) {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
+func flushFunctionalStreamWriter(writer io.Writer) error {
+	flusher, ok := writer.(*functionalStreamWriter)
+	if !ok {
+		return nil
+	}
+	return flusher.Flush()
+}

--- a/cmd/gocoveragecheck/functional_stream_test.go
+++ b/cmd/gocoveragecheck/functional_stream_test.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	functionalStreamChildEnv    = "GOCOVERAGECHECK_FUNCTIONAL_STREAM_CHILD"
+	functionalStreamChildMode   = "GOCOVERAGECHECK_FUNCTIONAL_STREAM_MODE"
+	functionalStreamChildPkg    = modulePath + "/tests/functional/streaming"
+	functionalStreamPassMode    = "pass"
+	functionalStreamTimeoutMode = "timeout"
+)
+
+func TestFunctionalStreamReportsPackageBeforeChildCompletes(t *testing.T) {
+	liveOutput, resultCh, releaseWriter, rawOutput := startFunctionalStreamChild(t, functionalStreamPassMode)
+	waitForFunctionalStreamMarker(t, liveOutput, "Functional package result: package="+functionalStreamChildPkg)
+
+	if got := liveOutput.String(); !strings.Contains(got, "outcome=pass") || !strings.Contains(got, "elapsed=0.125s") {
+		t.Fatalf("live functional output = %q, want package outcome and elapsed duration", got)
+	}
+	select {
+	case result := <-resultCh:
+		t.Fatalf("functional child completed before release: %+v", result)
+	default:
+	}
+
+	releaseFunctionalStreamChild(t, releaseWriter)
+	result := waitForStreamChild(t, resultCh)
+	if result.err != nil {
+		t.Fatalf("functional child error = %v, want nil", result.err)
+	}
+	if result.stdout != rawOutput {
+		t.Fatalf("captured functional JSON = %q, want unchanged %q", result.stdout, rawOutput)
+	}
+}
+
+func TestFunctionalStreamPreservesTimeoutOutputBeforeChildCompletes(t *testing.T) {
+	liveOutput, resultCh, releaseWriter, rawOutput := startFunctionalStreamChild(t, functionalStreamTimeoutMode)
+	waitForFunctionalStreamMarker(t, liveOutput, "goroutine 123 [running]")
+
+	got := liveOutput.String()
+	for _, want := range []string{"panic: test timed out", "goroutine 123 [running]"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("live timeout output = %q, want %q", got, want)
+		}
+	}
+	select {
+	case result := <-resultCh:
+		t.Fatalf("functional timeout child completed before release: %+v", result)
+	default:
+	}
+
+	releaseFunctionalStreamChild(t, releaseWriter)
+	result := waitForStreamChild(t, resultCh)
+	if result.err != nil {
+		t.Fatalf("functional timeout child error = %v, want nil", result.err)
+	}
+	if result.stdout != rawOutput {
+		t.Fatalf("captured timeout JSON = %q, want unchanged %q", result.stdout, rawOutput)
+	}
+}
+
+func TestFunctionalStreamReporterSerializesUniquePackageResults(t *testing.T) {
+	var sink bytes.Buffer
+	reporter := newFunctionalStreamReporter(&sink)
+	writer := reporter.stdoutWriter()
+	packages := []string{
+		modulePath + "/tests/functional/streaming/alpha",
+		modulePath + "/tests/functional/streaming/beta",
+		modulePath + "/tests/functional/streaming/gamma",
+	}
+	events := make([][]byte, 0, len(packages)+1)
+	for index, packageName := range packages {
+		events = append(events, marshalFunctionalStreamEvent(goTestTimingEvent{
+			Action:  timingOutcomePass,
+			Elapsed: float64(index+1) / 10,
+			Package: packageName,
+		}))
+	}
+	// A duplicate terminal event must not create a second completion line.
+	events = append(events, events[0])
+
+	var writes sync.WaitGroup
+	errCh := make(chan error, len(events))
+	for _, event := range events {
+		event := event
+		writes.Add(1)
+		go func() {
+			defer writes.Done()
+			_, err := writer.Write(event)
+			errCh <- err
+		}()
+	}
+	writes.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("stream reporter write error = %v", err)
+		}
+	}
+
+	output := sink.String()
+	for _, packageName := range packages {
+		if got := strings.Count(output, "package="+packageName+" "); got != 1 {
+			t.Fatalf("package %q appears in %d result lines, want 1; output=%q", packageName, got, output)
+		}
+	}
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if !strings.HasPrefix(line, "Functional package result: ") {
+			t.Fatalf("stream output line = %q, want one complete package result line", line)
+		}
+	}
+}
+
+func startFunctionalStreamChild(t *testing.T, mode string) (*functionalStreamCapture, <-chan streamCommandResult, *io.PipeWriter, string) {
+	t.Helper()
+	originalCommandRunner := commandRunner
+	originalExecCommand := execCommand
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	t.Cleanup(func() {
+		commandRunner = originalCommandRunner
+		execCommand = originalExecCommand
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	})
+
+	releaseReader, releaseWriter := io.Pipe()
+	t.Cleanup(func() { _ = releaseWriter.Close() })
+	execCommand = func(string, ...string) *exec.Cmd {
+		cmd := exec.Command(os.Args[0], "-test.run=TestGocoveragecheckFunctionalStreamChildProcess", "--")
+		cmd.Stdin = releaseReader
+		return cmd
+	}
+	commandRunner = originalCommandRunner
+
+	rawOutput := functionalStreamChildOutput(t, mode)
+	liveOutput := newFunctionalStreamCapture(functionalStreamMarker(mode))
+	stdoutWriter = liveOutput
+	stderrWriter = liveOutput
+	plan := coverageInvocationPlan{invocations: []commandInvocation{{
+		name: "go",
+		env: append(os.Environ(),
+			functionalStreamChildEnv+"=1",
+			functionalStreamChildMode+"="+mode,
+		),
+	}}}
+	configureCoverageInvocationStreaming(&plan, true)
+
+	resultCh := make(chan streamCommandResult, 1)
+	go func() {
+		stdout, stderr, err := runCommand(plan.invocations[0])
+		resultCh <- streamCommandResult{stdout: stdout, stderr: stderr, err: err}
+	}()
+	return liveOutput, resultCh, releaseWriter, rawOutput
+}
+
+func releaseFunctionalStreamChild(t *testing.T, releaseWriter *io.PipeWriter) {
+	t.Helper()
+	if _, err := releaseWriter.Write([]byte{1}); err != nil {
+		t.Fatalf("release functional stream child: %v", err)
+	}
+	if err := releaseWriter.Close(); err != nil {
+		t.Fatalf("close functional stream child release: %v", err)
+	}
+}
+
+func waitForFunctionalStreamMarker(t *testing.T, output *functionalStreamCapture, marker string) {
+	t.Helper()
+	select {
+	case <-output.seen:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for functional stream marker %q; output=%q", marker, output.String())
+	}
+}
+
+func functionalStreamMarker(mode string) string {
+	if mode == functionalStreamTimeoutMode {
+		return "goroutine 123 [running]"
+	}
+	return "Functional package result: package=" + functionalStreamChildPkg
+}
+
+func functionalStreamChildOutput(t *testing.T, mode string) string {
+	t.Helper()
+	var output strings.Builder
+	for _, event := range functionalStreamChildEvents(mode) {
+		data := marshalFunctionalStreamEvent(event)
+		output.Write(data)
+	}
+	return output.String()
+}
+
+func functionalStreamChildEvents(mode string) []goTestTimingEvent {
+	if mode == functionalStreamTimeoutMode {
+		return []goTestTimingEvent{{
+			Action:  "output",
+			Package: functionalStreamChildPkg,
+			Output:  "panic: test timed out\ngoroutine 123 [running]:\n\tcreated by TestHung in goroutine 1\n",
+		}}
+	}
+	return []goTestTimingEvent{{
+		Action:  timingOutcomePass,
+		Elapsed: 0.125,
+		Package: functionalStreamChildPkg,
+	}}
+}
+
+func marshalFunctionalStreamEvent(event goTestTimingEvent) []byte {
+	data, err := json.Marshal(event)
+	if err != nil {
+		panic(err)
+	}
+	return append(data, '\n')
+}
+
+func TestGocoveragecheckFunctionalStreamChildProcess(t *testing.T) {
+	if os.Getenv(functionalStreamChildEnv) != "1" {
+		return
+	}
+	mode := os.Getenv(functionalStreamChildMode)
+	for _, event := range functionalStreamChildEvents(mode) {
+		_, _ = os.Stdout.Write(marshalFunctionalStreamEvent(event))
+	}
+	var release [1]byte
+	if _, err := io.ReadFull(os.Stdin, release[:]); err != nil {
+		os.Exit(8)
+	}
+	os.Exit(0)
+}
+
+type functionalStreamCapture struct {
+	mu     sync.Mutex
+	data   bytes.Buffer
+	marker string
+	seen   chan struct{}
+	once   sync.Once
+}
+
+func newFunctionalStreamCapture(marker string) *functionalStreamCapture {
+	return &functionalStreamCapture{
+		marker: marker,
+		seen:   make(chan struct{}),
+	}
+}
+
+func (capture *functionalStreamCapture) Write(data []byte) (int, error) {
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	n, err := capture.data.Write(data)
+	if strings.Contains(capture.data.String(), capture.marker) {
+		capture.once.Do(func() { close(capture.seen) })
+	}
+	return n, err
+}
+
+func (capture *functionalStreamCapture) String() string {
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	return capture.data.String()
+}

--- a/cmd/gocoveragecheck/timing.go
+++ b/cmd/gocoveragecheck/timing.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 )
@@ -19,6 +17,12 @@ const (
 	timingOutcomePass = "pass"
 	timingOutcomeFail = "fail"
 	timingOutcomeSkip = "skip"
+)
+
+const (
+	functionalPackageStateCompleted  = "completed"
+	functionalPackageStateInFlight   = "in_flight"
+	functionalPackageStateUnobserved = "unobserved"
 )
 
 const maxTimingFailureReasonLength = 240
@@ -40,6 +44,18 @@ type functionalPackageTimingJSON struct {
 	Package string  `json:"package"`
 	Seconds float64 `json:"seconds"`
 	Outcome string  `json:"outcome"`
+	Reason  string  `json:"reason,omitempty"`
+}
+
+// functionalPackageStateJSON keeps the package-level state visible while a
+// functional run is still active. Packages with a terminal go test event also
+// appear in Packages; in-flight and unobserved packages are retained here so a
+// timeout snapshot names the work that did not finish.
+type functionalPackageStateJSON struct {
+	Package string  `json:"package"`
+	Seconds float64 `json:"seconds"`
+	State   string  `json:"state"`
+	Outcome string  `json:"outcome,omitempty"`
 	Reason  string  `json:"reason,omitempty"`
 }
 
@@ -65,6 +81,7 @@ type functionalTestTimingJSON struct {
 type functionalTimingSummaryJSON struct {
 	Version                  int                           `json:"version"`
 	Complete                 bool                          `json:"complete"`
+	CaptureReason            string                        `json:"captureReason,omitempty"`
 	WallSeconds              float64                       `json:"wallSeconds"`
 	PackageElapsedSecondsSum float64                       `json:"packageElapsedSecondsSum"`
 	ExpectedPackageCount     int                           `json:"expectedPackageCount"`
@@ -74,6 +91,7 @@ type functionalTimingSummaryJSON struct {
 	TestFailCount            int                           `json:"testFailCount"`
 	TestSkipCount            int                           `json:"testSkipCount"`
 	Packages                 []functionalPackageTimingJSON `json:"packages"`
+	PackageStates            []functionalPackageStateJSON  `json:"packageStates,omitempty"`
 	Tests                    []functionalTestTimingJSON    `json:"tests"`
 }
 
@@ -235,16 +253,11 @@ func writeFunctionalTimingSummaryJSON(path string, summary functionalTimingSumma
 	if path == "" {
 		return nil
 	}
-	if directory := filepath.Dir(path); directory != "" && directory != "." {
-		if err := os.MkdirAll(directory, 0o755); err != nil {
-			return fmt.Errorf("create go functional timing summary directory: %w", err)
-		}
-	}
 	data, err := renderFunctionalTimingSummaryJSON(summary)
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := writeAtomicDiagnosticFile(path, data); err != nil {
 		return fmt.Errorf("write go functional timing summary json: %w", err)
 	}
 	return nil

--- a/internal/functionaltestviz/runner_contract_test.go
+++ b/internal/functionaltestviz/runner_contract_test.go
@@ -1,0 +1,115 @@
+package functionaltestviz_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+// TestFunctionalTestVizRunnerClearsStaleArtifactsBeforeTimeout proves a later
+// timeout cannot advertise complete diagnostics from an earlier run.
+func TestFunctionalTestVizRunnerClearsStaleArtifactsBeforeTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("functional test viz runner contract requires a POSIX shell")
+	}
+	repoRoot := testutil.MustRepoPath(t, ".")
+	artifactRoot := filepath.Join(t.TempDir(), "functional-test-viz-stale-artifacts")
+	if err := os.MkdirAll(artifactRoot, 0o755); err != nil {
+		t.Fatalf("create stale artifact directory: %v", err)
+	}
+	staleArtifacts := map[string]string{
+		"functional-timing-summary.json": `{"complete":true,"captureReason":"stale timing"}`,
+		"coverage-summary.json":          `{"complete":true,"coverage":99,"marker":"stale coverage"}`,
+		"coverage.out":                   "mode: set\nstale coverage profile\n",
+		"functional-tests.md":            "# stale Markdown\n",
+		"diagnostic-status.txt":          "stale status\n",
+	}
+	for name, contents := range staleArtifacts {
+		if err := os.WriteFile(filepath.Join(artifactRoot, name), []byte(contents), 0o644); err != nil {
+			t.Fatalf("seed stale artifact %s: %v", name, err)
+		}
+	}
+
+	makePath := writeShellExecutable(t, "fake-make-functional-viz-no-profile", "#!/bin/sh\nprintf '%s\\n' 'fake-make:functional-test-viz'\n")
+	timeoutPath := writeShellExecutable(t, "timeout", "#!/bin/sh\n[ \"$1\" = \"--signal=TERM\" ] && shift\n[ \"$1\" = \"--kill-after=30s\" ] && shift\nshift\n\"$@\" >/dev/null 2>&1\nexit 124\n")
+	pathEnv, ok := os.LookupEnv("PATH")
+	if !ok {
+		t.Skip("functional test viz runner requires PATH")
+	}
+
+	output, err := runShellScript(
+		repoRoot,
+		filepath.Join(repoRoot, "scripts", "ci", "run-functional-test-viz.sh"),
+		fmt.Sprintf("FUNCTIONAL_TEST_VIZ_DIR=%s", artifactRoot),
+		fmt.Sprintf("FUNCTIONAL_TEST_BUDGET=%s", "0.1s"),
+		fmt.Sprintf("MAKE_BIN=%s", makePath),
+		fmt.Sprintf("PATH=%s%c%s", filepath.Dir(timeoutPath), os.PathListSeparator, pathEnv),
+	)
+	if err == nil {
+		t.Fatalf("functional runner unexpectedly succeeded after simulated budget expiry:\n%s", output)
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok || exitErr.ExitCode() != 124 {
+		t.Fatalf("functional runner exit = %v, want timeout exit code 124\n%s", err, output)
+	}
+
+	statusPath := filepath.Join(artifactRoot, "diagnostic-status.txt")
+	statusBody, readErr := os.ReadFile(statusPath)
+	if readErr != nil {
+		t.Fatalf("read current timeout diagnostic status: %v", readErr)
+	}
+	status := string(statusBody)
+	for _, expected := range []string{
+		"missing: name=timing",
+		"missing: name=coverage-summary",
+		"missing: name=coverage-profile",
+		"missing: name=markdown",
+		"reason=no trustworthy partial coverage summary was available before interruption",
+	} {
+		if !strings.Contains(status, expected) {
+			t.Fatalf("timeout diagnostic status missing %q:\n%s", expected, status)
+		}
+	}
+	for _, staleMarker := range []string{"stale timing", "stale coverage", "stale coverage profile", "stale Markdown", "stale status", "complete=true"} {
+		if strings.Contains(status, staleMarker) || strings.Contains(output, staleMarker) {
+			t.Fatalf("stale marker %q leaked into current timeout diagnostics:\nstatus=%s\noutput=%s", staleMarker, status, output)
+		}
+	}
+
+	for name := range staleArtifacts {
+		if name == "diagnostic-status.txt" {
+			continue
+		}
+		if _, statErr := os.Stat(filepath.Join(artifactRoot, name)); !os.IsNotExist(statErr) {
+			t.Fatalf("stale run-owned artifact %s survived timeout cleanup; stat error = %v", name, statErr)
+		}
+	}
+}
+
+func writeShellExecutable(t *testing.T, name string, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write shell executable %s: %v", name, err)
+	}
+	return path
+}
+
+func runShellScript(repoRoot string, scriptPath string, env ...string) (string, error) {
+	cmd := exec.Command(scriptPath)
+	cmd.Dir = repoRoot
+	pathEnv, _ := os.LookupEnv("PATH")
+	cmd.Env = append([]string{"PATH=" + pathEnv}, env...)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	err := cmd.Run()
+	return output.String(), err
+}

--- a/scripts/ci/publish-functional-test-summary.sh
+++ b/scripts/ci/publish-functional-test-summary.sh
@@ -3,6 +3,11 @@
 set -euo pipefail
 
 markdown_path="${FUNCTIONAL_TEST_VIZ_MARKDOWN:-.artifacts/functional-test-viz/functional-tests.md}"
+artifact_root="${FUNCTIONAL_TEST_VIZ_DIR:-.artifacts/functional-test-viz}"
+timing_path="${FUNCTIONAL_TEST_VIZ_TIMING:-$artifact_root/functional-timing-summary.json}"
+coverage_path="${FUNCTIONAL_TEST_VIZ_JSON:-$artifact_root/coverage-summary.json}"
+profile_path="${FUNCTIONAL_TEST_VIZ_PROFILE:-$artifact_root/coverage.out}"
+status_path="$artifact_root/diagnostic-status.txt"
 
 if [ -z "${GITHUB_STEP_SUMMARY:-}" ]; then
   echo "GITHUB_STEP_SUMMARY not set; skipping functional test job summary."
@@ -10,8 +15,45 @@ if [ -z "${GITHUB_STEP_SUMMARY:-}" ]; then
 fi
 
 if [ ! -f "$markdown_path" ]; then
-  echo "functional-test-viz markdown not found at $markdown_path; skipping job summary (diagnostics unavailable)."
-  exit 0
+  if [ -z "${FUNCTIONAL_TEST_VIZ_DIR:-}" ] && [ ! -f "$status_path" ] && [ ! -f "$timing_path" ] && [ ! -f "$coverage_path" ] && [ ! -f "$profile_path" ]; then
+    echo "functional-test-viz markdown not found at $markdown_path; skipping job summary (diagnostics unavailable)."
+    exit 0
+  fi
 fi
 
-cat "$markdown_path" >> "$GITHUB_STEP_SUMMARY" || echo "warning: failed to append functional test markdown to job summary" >&2
+if [ -f "$markdown_path" ]; then
+  cat "$markdown_path" >> "$GITHUB_STEP_SUMMARY" || echo "warning: failed to append functional test markdown to job summary" >&2
+else
+  printf '%s\n' "## Functional test diagnostics" >> "$GITHUB_STEP_SUMMARY"
+  printf '%s\n\n' "The Markdown catalog is unavailable because the tier ended before complete coverage and timing inputs were rendered." >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [ -f "$status_path" ] || [ ! -f "$markdown_path" ]; then
+  {
+    printf '%s\n\n' "## Functional diagnostics availability"
+    if [ -f "$status_path" ]; then
+      cat "$status_path"
+    else
+      if [ -f "$timing_path" ]; then
+        printf '%s\n' "available: name=timing path=$timing_path status=incomplete-or-partial"
+      else
+        printf '%s\n' "missing: name=timing path=$timing_path reason=no timing snapshot was published before the lane ended"
+      fi
+      if [ -f "$coverage_path" ]; then
+        printf '%s\n' "available: name=coverage-summary path=$coverage_path status=incomplete-or-partial"
+      else
+        printf '%s\n' "missing: name=coverage-summary path=$coverage_path reason=no trustworthy complete or partial coverage measurement was published"
+      fi
+      if [ -f "$profile_path" ]; then
+        printf '%s\n' "available: name=coverage-profile path=$profile_path status=raw-profile"
+      else
+        printf '%s\n' "missing: name=coverage-profile path=$profile_path reason=go test did not flush a coverage profile"
+      fi
+      if [ -f "$markdown_path" ]; then
+        printf '%s\n' "available: name=markdown path=$markdown_path"
+      else
+        printf '%s\n' "missing: name=markdown path=$markdown_path reason=the catalog renderer did not receive complete inputs"
+      fi
+    fi
+  } >> "$GITHUB_STEP_SUMMARY" || echo "warning: failed to append functional diagnostics availability" >&2
+fi

--- a/scripts/ci/publish-functional-test-summary.sh
+++ b/scripts/ci/publish-functional-test-summary.sh
@@ -15,7 +15,7 @@ if [ -z "${GITHUB_STEP_SUMMARY:-}" ]; then
 fi
 
 if [ ! -f "$markdown_path" ]; then
-  if [ -z "${FUNCTIONAL_TEST_VIZ_DIR:-}" ] && [ ! -f "$status_path" ] && [ ! -f "$timing_path" ] && [ ! -f "$coverage_path" ] && [ ! -f "$profile_path" ]; then
+  if [ ! -f "$status_path" ] && [ ! -f "$timing_path" ] && [ ! -f "$coverage_path" ] && [ ! -f "$profile_path" ]; then
     echo "functional-test-viz markdown not found at $markdown_path; skipping job summary (diagnostics unavailable)."
     exit 0
   fi

--- a/scripts/ci/run-functional-test-viz.sh
+++ b/scripts/ci/run-functional-test-viz.sh
@@ -10,8 +10,14 @@ budget="${FUNCTIONAL_TEST_BUDGET:-35m}"
 short="${FUNCTIONAL_SHORT:-true}"
 quarantine="${FUNCTIONAL_QUARANTINE:-tests/functional/functional-quarantine.json}"
 log_path="$artifact_root/command.log"
+timing_path="${FUNCTIONAL_TEST_VIZ_TIMING:-$artifact_root/functional-timing-summary.json}"
+coverage_path="${FUNCTIONAL_TEST_VIZ_JSON:-$artifact_root/coverage-summary.json}"
+profile_path="${FUNCTIONAL_TEST_VIZ_PROFILE:-$artifact_root/coverage.out}"
+markdown_path="${FUNCTIONAL_TEST_VIZ_MARKDOWN:-$artifact_root/functional-tests.md}"
+status_path="$artifact_root/diagnostic-status.txt"
 
 mkdir -p "$artifact_root"
+rm -f "$status_path"
 
 printf '%s\n' \
   "Functional CI runner: tier=$tier trigger=$trigger short=$short budget=$budget selection=subtractive quarantine=$quarantine" \
@@ -56,6 +62,81 @@ if [ "$tee_status" -ne 0 ]; then
 fi
 
 if [ "$command_status" -eq 124 ]; then
+  if [ -f "$timing_path" ]; then
+    if command -v python3 >/dev/null 2>&1; then
+      timeout 5s python3 - "$timing_path" <<'PY' | tee -a "$log_path" || true
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    with open(path, encoding="utf-8") as stream:
+        summary = json.load(stream)
+    wall_seconds = float(summary.get("wallSeconds", 0) or 0)
+    states = summary.get("packageStates", []) or []
+    if not isinstance(states, list):
+        raise ValueError("packageStates is not an array")
+except Exception as error:
+    print(f"Functional timing snapshot unavailable: path={path} reason={error}")
+    raise SystemExit(0)
+
+print(
+    "Functional timing snapshot: "
+    f"complete={summary.get('complete', False)} "
+    f"packages={summary.get('packageCount', 0)}/{summary.get('expectedPackageCount', 0)} "
+    f"wall={wall_seconds:.3f}s reason={summary.get('captureReason', 'tier budget expired')}"
+)
+for state in states:
+    if not isinstance(state, dict):
+        continue
+    if state.get("state") == "completed":
+        continue
+    try:
+        elapsed = float(state.get("seconds", 0) or 0)
+    except (TypeError, ValueError):
+        elapsed = 0
+    print(
+        "Functional package state: "
+        f"package={state.get('package', '<unknown>')} "
+        f"state={state.get('state', 'unobserved')} "
+        f"elapsed={elapsed:.3f}s"
+    )
+PY
+    else
+      printf '%s\n' "Functional timing snapshot could not be rendered: python3 is unavailable; timing artifact remains at $timing_path." | tee -a "$log_path" >&2
+    fi
+  else
+    printf '%s\n' "Functional timing summary missing: path=$timing_path reason=no incremental timing snapshot was written before the tier budget expired." | tee -a "$log_path" >&2
+  fi
+
+  {
+    printf '%s\n' "Functional diagnostics availability: outcome=tier-timeout budget=$budget"
+    if [ -f "$timing_path" ]; then
+      printf '%s\n' "available: name=timing path=$timing_path status=incomplete-or-partial"
+    else
+      printf '%s\n' "missing: name=timing path=$timing_path reason=no incremental timing snapshot was written before interruption"
+    fi
+    if [ -f "$coverage_path" ]; then
+      printf '%s\n' "available: name=coverage-summary path=$coverage_path status=incomplete-or-partial"
+    else
+      printf '%s\n' "missing: name=coverage-summary path=$coverage_path reason=no trustworthy partial coverage summary was available before interruption"
+    fi
+    if [ -f "$profile_path" ]; then
+      printf '%s\n' "available: name=coverage-profile path=$profile_path status=raw-profile"
+    else
+      printf '%s\n' "missing: name=coverage-profile path=$profile_path reason=go test did not flush a coverage profile before interruption"
+    fi
+    if [ -f "$markdown_path" ]; then
+      printf '%s\n' "available: name=markdown path=$markdown_path"
+    else
+      printf '%s\n' "missing: name=markdown path=$markdown_path reason=catalog rendering did not run because the tier stopped before complete inputs were available"
+    fi
+  } > "$status_path" || true
+  if [ -f "$status_path" ]; then
+    tee -a "$log_path" < "$status_path"
+  else
+    printf '%s\n' "Functional diagnostics status unavailable: path=$status_path reason=status file could not be written." | tee -a "$log_path" >&2
+  fi
   printf '%s\n' "Functional CI runner: tier timed out after budget=$budget; partial diagnostics retained under $artifact_root." \
     | tee -a "$log_path" >&2
   exit 124

--- a/scripts/ci/run-functional-test-viz.sh
+++ b/scripts/ci/run-functional-test-viz.sh
@@ -17,7 +17,9 @@ markdown_path="${FUNCTIONAL_TEST_VIZ_MARKDOWN:-$artifact_root/functional-tests.m
 status_path="$artifact_root/diagnostic-status.txt"
 
 mkdir -p "$artifact_root"
-rm -f "$status_path"
+# Each invocation owns these outputs. Remove them before starting so a later
+# timeout cannot publish a complete artifact produced by an earlier run.
+rm -f "$status_path" "$timing_path" "$coverage_path" "$profile_path" "$markdown_path"
 
 printf '%s\n' \
   "Functional CI runner: tier=$tier trigger=$trigger short=$short budget=$budget selection=subtractive quarantine=$quarantine" \

--- a/tests/functional/observability/verification/verify_tier_contract_test.go
+++ b/tests/functional/observability/verification/verify_tier_contract_test.go
@@ -733,6 +733,7 @@ func TestFunctionalTestSummaryPublishScriptSmoke_AppendsMarkdownWhenPresent(t *t
 		repoRoot,
 		filepath.Join(repoRoot, "scripts", "ci", "publish-functional-test-summary.sh"),
 		fmt.Sprintf("FUNCTIONAL_TEST_VIZ_MARKDOWN=%s", markdownPath),
+		fmt.Sprintf("FUNCTIONAL_TEST_VIZ_DIR=%s", tempDir),
 		fmt.Sprintf("GITHUB_STEP_SUMMARY=%s", summaryPath),
 	)
 	if err != nil {
@@ -759,6 +760,7 @@ func TestFunctionalTestSummaryPublishScriptSmoke_SkipsWhenMarkdownMissing(t *tes
 		repoRoot,
 		filepath.Join(repoRoot, "scripts", "ci", "publish-functional-test-summary.sh"),
 		fmt.Sprintf("FUNCTIONAL_TEST_VIZ_MARKDOWN=%s", missingMarkdownPath),
+		fmt.Sprintf("FUNCTIONAL_TEST_VIZ_DIR=%s", tempDir),
 		fmt.Sprintf("GITHUB_STEP_SUMMARY=%s", summaryPath),
 	)
 	if err != nil {
@@ -791,6 +793,7 @@ func TestFunctionalTestSummaryPublishScriptSmoke_NoopWhenGithubStepSummaryUnset(
 		repoRoot,
 		filepath.Join(repoRoot, "scripts", "ci", "publish-functional-test-summary.sh"),
 		fmt.Sprintf("FUNCTIONAL_TEST_VIZ_MARKDOWN=%s", markdownPath),
+		fmt.Sprintf("FUNCTIONAL_TEST_VIZ_DIR=%s", tempDir),
 		"GITHUB_STEP_SUMMARY=",
 	)
 	if err != nil {


### PR DESCRIPTION
{
  "project": "Preserve Functional Gate Diagnostics on Timeout",
  "branchName": "thr-functional-gate-emits-nothing-when-it-times-out",
  "description": "Make the Backend Functional Coverage gate stream readable per-package progress, preserve child timeout goroutine dumps, report packages still in flight when the tier budget expires, and publish honest partial timing and coverage diagnostics without changing test or coverage policy.",
  "context": {
    "customerAsk": "When the functional tier times out, stream per-package completion, preserve panic: test timed out goroutine dumps, report every package still running with its elapsed time, and upload whatever partial timing and coverage diagnostics are trustworthy. Demonstrate the same deliberately induced hang before and after the change, and show that a normal green run retains its existing summary without a material wall-time regression.",
    "problem": "PR #1997 run 31916812367, job 95089964170, emitted no useful output for roughly 72 minutes before exit 124 and uploaded a 1,394-byte artifact containing only command.log and real-acpx-evidence.json. The existing default-off gocoveragecheck streaming option is not enabled by the functional Make target, and timing artifacts are still built only after the coverage child returns, so the outer 75-minute timeout can kill the process before package events, active state, timeout dumps, or partial summaries are flushed.",
    "solution": "Consume functional go test events incrementally, emit readable package results and child failure output, track package start and terminal state explicitly, and persist atomic incomplete timing snapshots. On interruption, perform a bounded flush that names active packages and retains trustworthy partial timing or coverage outputs, while the CI runner and publisher report exactly what exists or why an artifact is missing. Preserve completed summaries, exit codes, selection, concurrency, timeouts, and coverage policy."
  },
  "acceptanceCriteria": [
    "During the functional gate, each package terminal result is emitted promptly with its package name and outcome; a deliberately induced per-package timeout leaves the hung package name and its panic: test timed out goroutine dump in both live output and command.log before non-zero exit.",
    "When the tier budget interrupts the gate, final diagnostics name every package still in flight and report each elapsed runtime, while streamed results continue to identify already completed packages.",
    "A timed-out run uploads at least one structured partial per-package diagnostic artifact in addition to command.log; timing and coverage outputs identify themselves as incomplete and never present partial data as a successful coverage measurement, and any unavailable requested artifact is named with a concrete reason.",
    "A normal completed run retains the existing Functional suite inventory, coverage summary, timing summary, Markdown summary, exit semantics, and coverage verdict, with no material wall-time increase attributable to streaming under a comparable measurement.",
    "Scope remains confined to cmd/gocoveragecheck output/reporting behavior and focused tests plus functional CI runner, publisher scripts, and owned Makefile targets; test selection, quarantine contents, coverage floors, budgets, timeouts, jobs/concurrency, tests/functional, and pkg/services/recordings remain unchanged.",
    "Quality gate: Typecheck passes; focused cmd/gocoveragecheck and functional runner/publisher tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "PROCESS-STAGE FINISH LINE (operator-corrected): this stage is complete when the final head is pushed, the PR is open, CI has STARTED, and all blocking review feedback is addressed. Terminal CI and MERGED are owned by the REVIEW workstation and are explicitly NOT this stage's responsibility. Do not wait for, poll, or re-check CI status - each such visit consumes one of only 12 process visits before executor-loop-breaker kills this lane. CI-run evidence goes in a PR comment, never a commit."
  ],
  "userStories": [
    {
      "id": "thr-functional-gate-emits-nothing-when-it-times-out-001",
      "title": "Stream readable functional package diagnostics",
      "description": "As a CI operator, I want functional package outcomes and failure output while the run is active so I can identify progress and a timed-out package without waiting for the whole suite to return.",
      "acceptanceCriteria": [
        "The functional coverage target enables live diagnostics for the functional suite while the existing default behavior for unrelated gocoveragecheck callers remains unchanged.",
        "Every functional package terminal event promptly produces a readable line containing the package name, outcome, and elapsed duration before the overall child process exits.",
        "Child failure output is not discarded or reduced to a terminal aggregate: panic: test timed out and the associated goroutine dump reach both live job output and command.log.",
        "Concurrent package events do not corrupt lines, duplicate terminal outcomes, change buffered evaluation data, or change the lane exit status.",
        "Focused deterministic tests prove output is observable before child completion and prove package completion and timeout dump behavior without adding or modifying a test under tests/functional.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Functional coverage now opts into synchronized incremental go test event reporting: readable package outcome/elapsed lines and decoded child failure output stream before process completion while captured JSON remains unchanged. Focused cmd/gocoveragecheck tests, go vet, and make typecheck pass. make lint still reports pre-existing UI/deadcode, backend-size, and packaged-factory baseline violations."
    },
    {
      "id": "thr-functional-gate-emits-nothing-when-it-times-out-002",
      "title": "Finalize partial timeout diagnostics",
      "description": "As a CI operator, I want the timeout path to summarize active work and retain partial artifacts so a failed tier explains what finished, what remained active, and what data is trustworthy.",
      "acceptanceCriteria": [
        "On tier timeout, explicit package start and terminal state produces a final snapshot naming every in-flight package and its elapsed runtime.",
        "Completed-package timing progress is persisted before whole-lane completion, and timeout leaves a machine-readable timing artifact marked complete=false that distinguishes completed packages from in-flight or unobserved packages.",
        "Any valid partial coverage output available at interruption is retained and clearly marked incomplete; coverage floors and the overall coverage verdict are not evaluated from an incomplete measurement.",
        "The functional runner preserves exit 124 for a tier-budget timeout and existing non-timeout failure codes while allowing a bounded diagnostic flush that does not extend or redefine the configured tier budget.",
        "Artifact and job-summary publication surfaces publish available partial diagnostics and explicitly name each missing timing, coverage, or Markdown item with its reason rather than referring generically to a nonexistent path.",
        "Focused tests cover normal completion, child test timeout, tier-budget interruption, partial-write failure, and no-trustworthy-coverage behavior without changing functional selection or adding a sleep-based repository functional test.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Functional timing now persists atomic incremental snapshots with completed, in-flight, and unobserved package states; coverage writes trustworthy partial summaries as complete=false without evaluating floors; the bounded CI timeout flush and publisher enumerate available and missing diagnostics with concrete reasons. Focused Go tests, vet, typecheck, and shell syntax checks pass. The full go test ./... attempt exceeded the local five-minute bound without a reported failure; the Windows race detector could not allocate ThreadSanitizer memory."
    },
    {
      "id": "thr-functional-gate-emits-nothing-when-it-times-out-003",
      "title": "Prove timeout diagnostics and completed-run parity",
      "description": "As a maintainer, I want reproducible before/after and green-run evidence so I can verify diagnosability improved without changing the functional gate's policy or performance.",
      "acceptanceCriteria": [
        "Using the same temporary uncommitted test package that exceeds the existing per-package timeout, a PR comment quotes before-change silence and after-change output naming the hung package, showing panic: test timed out, and including representative goroutine-dump lines.",
        "The timeout evidence lists artifact contents and quotes structured partial package progress proving the artifact contains more than command.log; the temporary test and generated probes are absent from the final diff.",
        "A comparable normal green run on the final head quotes the existing Functional suite inventory, confirms timing, coverage, and Markdown artifacts, and compares wall time with a before measurement using the same command, machine, and selected workload.",
        "The comparison shows no material wall-time increase attributable to reporting; environmental noise is reported without changing budgets, concurrency, selection, quarantine, or coverage floors.",
        "Final diff review confirms no changes under tests/functional or pkg/services/recordings and no skip, quarantine, allowlist, manifest update, baseline bump, timeout increase, or coverage-floor reduction escape hatch.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Evidence collected on Windows 2026-08-15 with the same temporary uncommitted timeout probe, then removed. Base 4e4a537ce buffered binary was interrupted at an outer 1s budget while the probe had -timeout=20s: stdout/stderr were both 0 bytes at exit, reproducing silence. Final ee6b040dd streamed the probe at -timeout=2s: live output and command.log contained the probe package, `panic: test timed out after 2s`, `goroutine 18 [running]`, `goroutine 7 [select (no cases)]`, and `Functional package result ... outcome=fail elapsed=2.024s`, with exit 1. The tier wrapper at a 0.5s budget exited 124 and retained command.log (3853 bytes), functional-timing-summary.json (807 bytes, complete=false, package state=unobserved), coverage.out (12 bytes, raw profile), and diagnostic-status.txt with concrete missing coverage-summary/Markdown reasons. Warm comparable green runs of tests/functional/cli/factory_run/output measured base 4.282s vs final 4.177s (final 2.5% faster); final reported 2/2 top-level tests pass, pkg/root coverage 13.2% (5/38 statements), complete timing JSON, coverage JSON, and functional-tests.md (497578 bytes). Focused Go tests, vet, typecheck, and shell syntax checks pass; no temporary probe or generated evidence is in the final diff."
    }
  ]
}
