### PR TITLE
test: share the verified graph node drag helper with the parity browser check

### DIFF
--- a/ui/integration/browser-test-harness.drag.test.mjs
+++ b/ui/integration/browser-test-harness.drag.test.mjs
@@ -1,0 +1,95 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+
+import { dragNodeByOffset } from "./browser-test-harness.mjs";
+
+function createDragPage() {
+  return {
+    mouse: {
+      down: vi.fn().mockResolvedValue(undefined),
+      move: vi.fn().mockResolvedValue(undefined),
+      up: vi.fn().mockResolvedValue(undefined),
+    },
+    waitForTimeout: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("verified graph node drag helper", () => {
+  it("releases and retries a lost pointer grab before returning measurements", async () => {
+    const initialPosition = { x: 100, y: 200 };
+    const finalPosition = { x: 130, y: 220 };
+    const nodeLocator = {
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce(initialPosition)
+        .mockResolvedValueOnce({ x: 50, y: 60 })
+        .mockResolvedValueOnce(initialPosition)
+        .mockResolvedValueOnce(initialPosition)
+        .mockResolvedValueOnce({ x: 50, y: 60 })
+        .mockResolvedValueOnce(finalPosition)
+        .mockResolvedValueOnce(finalPosition),
+      waitFor: vi.fn().mockResolvedValue(undefined),
+    };
+    const page = createDragPage();
+
+    await expect(
+      dragNodeByOffset(page, nodeLocator, 28, 20, {
+        displacementTolerancePx: 8,
+        settleDelayMs: 0,
+      }),
+    ).resolves.toMatchObject({
+      initialFlowPosition: initialPosition,
+      midDragDistancePx: 30,
+      midDragFlowPosition: finalPosition,
+      postMouseUpDistancePx: 30,
+      postMouseUpFlowPosition: finalPosition,
+    });
+    expect(page.mouse.down).toHaveBeenCalledTimes(2);
+    expect(page.mouse.up).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails quickly with measured positions after bounded no-op attempts", async () => {
+    const initialPosition = { x: 100, y: 200 };
+    const nodeLocator = {
+      evaluate: vi
+        .fn()
+        .mockResolvedValueOnce(initialPosition)
+        .mockResolvedValueOnce({ x: 50, y: 60 })
+        .mockResolvedValueOnce(initialPosition)
+        .mockResolvedValueOnce(initialPosition)
+        .mockResolvedValueOnce({ x: 50, y: 60 })
+        .mockResolvedValueOnce(initialPosition)
+        .mockResolvedValueOnce(initialPosition),
+      waitFor: vi.fn().mockResolvedValue(undefined),
+    };
+    const page = createDragPage();
+
+    let thrownError;
+    try {
+      await dragNodeByOffset(page, nodeLocator, 28, 20, {
+        displacementTolerancePx: 8,
+        settleDelayMs: 0,
+      });
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError.message).toContain(
+      "Mouse drag did not produce the required flow displacement",
+    );
+    const diagnostic = JSON.parse(
+      thrownError.message.slice(thrownError.message.indexOf("{")),
+    );
+    expect(diagnostic).toMatchObject({
+      attempts: 2,
+      initialFlowPosition: initialPosition,
+      midDragDistancePx: 0,
+      midDragFlowPosition: initialPosition,
+      postMouseUpDistancePx: 0,
+      postMouseUpFlowPosition: initialPosition,
+    });
+    expect(page.mouse.up).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -317,6 +317,184 @@ export async function waitForStableFactoryGraphViewport(
   return stableTransform;
 }
 
+/** Read the React Flow position encoded by a graph node's DOM transform. */
+export async function readFactoryGraphNodeFlowPosition(nodeLocator) {
+  return nodeLocator
+    .evaluate((element) => {
+      const flowNode =
+        element.classList.contains("react-flow__node") === true
+          ? element
+          : element.closest(".react-flow__node");
+      if (!flowNode) {
+        return null;
+      }
+
+      const transform =
+        flowNode.style.transform || window.getComputedStyle(flowNode).transform;
+      if (!transform || transform === "none") {
+        return null;
+      }
+
+      const translateMatch =
+        /translate(?:3d)?\(([-\d.]+)px,\s*([-\d.]+)px/.exec(transform);
+      if (translateMatch) {
+        return {
+          x: Number(translateMatch[1]),
+          y: Number(translateMatch[2]),
+        };
+      }
+
+      const matrixMatch = /matrix\(([^)]+)\)/.exec(transform);
+      if (matrixMatch) {
+        const values = matrixMatch[1]
+          .split(",")
+          .map((value) => Number.parseFloat(value.trim()));
+        if (values.length >= 6) {
+          return { x: values[4], y: values[5] };
+        }
+      }
+
+      return null;
+    })
+    .catch(() => null);
+}
+
+export function flowPositionDistance(left, right) {
+  if (!left || !right) {
+    return null;
+  }
+
+  return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
+}
+
+async function draggableFactoryGraphNodeStartPoint(nodeLocator, nodeLabel) {
+  const point = await nodeLocator.evaluate((element) => {
+    const flowNode =
+      element.classList.contains("react-flow__node") === true
+        ? element
+        : element.closest(".react-flow__node");
+    if (!flowNode) {
+      return null;
+    }
+
+    const flowNodeBox = flowNode.getBoundingClientRect();
+    const elementBox = element.getBoundingClientRect();
+    const candidates = [
+      { x: flowNodeBox.right - 4, y: flowNodeBox.top + flowNodeBox.height / 2 },
+      { x: flowNodeBox.left + 4, y: flowNodeBox.top + flowNodeBox.height / 2 },
+      {
+        x: flowNodeBox.left + flowNodeBox.width / 2,
+        y: flowNodeBox.top + 4,
+      },
+      {
+        x: flowNodeBox.left + flowNodeBox.width / 2,
+        y: flowNodeBox.bottom - 4,
+      },
+      { x: elementBox.right - 4, y: elementBox.top + elementBox.height / 2 },
+    ];
+
+    for (const candidate of candidates) {
+      const hit = document.elementFromPoint(candidate.x, candidate.y);
+      if (hit && flowNode.contains(hit) && !hit.closest(".nodrag")) {
+        return candidate;
+      }
+    }
+
+    return null;
+  });
+
+  if (!point) {
+    throw new Error(
+      `Expected a draggable surface inside ${nodeLabel}; all candidate points were nodrag controls.`,
+    );
+  }
+
+  return point;
+}
+
+/**
+ * Drag a graph node and verify that React Flow moved it during and after the
+ * pointer gesture. The tolerance is caller-provided because browser checks
+ * intentionally use different movement contracts.
+ */
+export async function dragNodeByOffset(
+  page,
+  nodeLocator,
+  deltaX,
+  deltaY,
+  { displacementTolerancePx, nodeLabel = "graph node", steps = 16 } = {},
+) {
+  if (!Number.isFinite(displacementTolerancePx)) {
+    throw new TypeError(
+      `A finite displacement tolerance is required to drag ${nodeLabel}.`,
+    );
+  }
+
+  await nodeLocator.waitFor({
+    state: "visible",
+    timeout: uiInteractionTimeoutMs,
+  });
+  const initialFlowPosition =
+    await readFactoryGraphNodeFlowPosition(nodeLocator);
+  const startPoint = await draggableFactoryGraphNodeStartPoint(
+    nodeLocator,
+    nodeLabel,
+  );
+
+  let pointerIsDown = false;
+  let midDragFlowPosition = null;
+  try {
+    await page.mouse.move(startPoint.x, startPoint.y);
+    await page.mouse.down();
+    pointerIsDown = true;
+    await page.mouse.move(startPoint.x + deltaX, startPoint.y + deltaY, {
+      steps,
+    });
+    midDragFlowPosition = await readFactoryGraphNodeFlowPosition(nodeLocator);
+  } finally {
+    if (pointerIsDown) {
+      await page.mouse.up();
+    }
+  }
+
+  const postMouseUpFlowPosition =
+    await readFactoryGraphNodeFlowPosition(nodeLocator);
+  const midDragDistancePx = flowPositionDistance(
+    initialFlowPosition,
+    midDragFlowPosition,
+  );
+  const postMouseUpDistancePx = flowPositionDistance(
+    initialFlowPosition,
+    postMouseUpFlowPosition,
+  );
+  if (
+    midDragDistancePx === null ||
+    midDragDistancePx <= displacementTolerancePx ||
+    postMouseUpDistancePx === null ||
+    postMouseUpDistancePx <= displacementTolerancePx
+  ) {
+    throw new Error(
+      `Mouse drag did not produce the required flow displacement: ${JSON.stringify(
+        {
+          initialFlowPosition,
+          midDragFlowPosition,
+          midDragDistancePx,
+          postMouseUpFlowPosition,
+          postMouseUpDistancePx,
+        },
+      )}`,
+    );
+  }
+
+  return {
+    initialFlowPosition,
+    midDragFlowPosition,
+    midDragDistancePx,
+    postMouseUpDistancePx,
+    postMouseUpFlowPosition,
+  };
+}
+
 function graphNodePlacementSamplesEqual(left, right) {
   if (!left || !right) {
     return false;

--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -412,21 +412,81 @@ async function draggableFactoryGraphNodeStartPoint(nodeLocator, nodeLabel) {
   return point;
 }
 
+const defaultDragAttemptCount = 2;
+const defaultDragSettleDelayMs = 50;
+
+async function dragFactoryGraphNodeAttempt(
+  page,
+  nodeLocator,
+  deltaX,
+  deltaY,
+  nodeLabel,
+  steps,
+  settleDelayMs,
+) {
+  const startPoint = await draggableFactoryGraphNodeStartPoint(
+    nodeLocator,
+    nodeLabel,
+  );
+  let pointerGestureStarted = false;
+  let midDragFlowPosition = null;
+
+  try {
+    await page.waitForTimeout(settleDelayMs);
+    await page.mouse.move(startPoint.x, startPoint.y);
+    pointerGestureStarted = true;
+    await page.mouse.down();
+    await page.waitForTimeout(settleDelayMs);
+    await page.mouse.move(startPoint.x + deltaX, startPoint.y + deltaY, {
+      steps,
+    });
+    await page.waitForTimeout(settleDelayMs);
+    midDragFlowPosition = await readFactoryGraphNodeFlowPosition(nodeLocator);
+  } finally {
+    if (pointerGestureStarted) {
+      await page.mouse.up().catch(() => {});
+    }
+  }
+
+  await page.waitForTimeout(settleDelayMs);
+  const postMouseUpFlowPosition =
+    await readFactoryGraphNodeFlowPosition(nodeLocator);
+
+  return { midDragFlowPosition, postMouseUpFlowPosition };
+}
+
 /**
  * Drag a graph node and verify that React Flow moved it during and after the
  * pointer gesture. The tolerance is caller-provided because browser checks
- * intentionally use different movement contracts.
+ * intentionally use different movement contracts. A failed displacement gets
+ * one bounded settle/retry before the measured failure is reported.
  */
 export async function dragNodeByOffset(
   page,
   nodeLocator,
   deltaX,
   deltaY,
-  { displacementTolerancePx, nodeLabel = "graph node", steps = 16 } = {},
+  {
+    displacementTolerancePx,
+    maxAttempts = defaultDragAttemptCount,
+    nodeLabel = "graph node",
+    settleDelayMs = defaultDragSettleDelayMs,
+    steps = 16,
+  } = {},
 ) {
   if (!Number.isFinite(displacementTolerancePx)) {
     throw new TypeError(
       `A finite displacement tolerance is required to drag ${nodeLabel}.`,
+    );
+  }
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new TypeError(
+      `A positive integer attempt count is required to drag ${nodeLabel}.`,
+    );
+  }
+  if (!Number.isFinite(settleDelayMs) || settleDelayMs < 0) {
+    throw new TypeError(
+      `A non-negative settle delay is required to drag ${nodeLabel}.`,
     );
   }
 
@@ -434,65 +494,68 @@ export async function dragNodeByOffset(
     state: "visible",
     timeout: uiInteractionTimeoutMs,
   });
+  await page.waitForTimeout(settleDelayMs);
   const initialFlowPosition =
     await readFactoryGraphNodeFlowPosition(nodeLocator);
-  const startPoint = await draggableFactoryGraphNodeStartPoint(
-    nodeLocator,
-    nodeLabel,
-  );
 
-  let pointerIsDown = false;
-  let midDragFlowPosition = null;
-  try {
-    await page.mouse.move(startPoint.x, startPoint.y);
-    await page.mouse.down();
-    pointerIsDown = true;
-    await page.mouse.move(startPoint.x + deltaX, startPoint.y + deltaY, {
-      steps,
+  let latestObservation = {
+    midDragDistancePx: null,
+    midDragFlowPosition: null,
+    postMouseUpDistancePx: null,
+    postMouseUpFlowPosition: null,
+  };
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    await nodeLocator.waitFor({
+      state: "visible",
+      timeout: uiInteractionTimeoutMs,
     });
-    midDragFlowPosition = await readFactoryGraphNodeFlowPosition(nodeLocator);
-  } finally {
-    if (pointerIsDown) {
-      await page.mouse.up();
+    const { midDragFlowPosition, postMouseUpFlowPosition } =
+      await dragFactoryGraphNodeAttempt(
+        page,
+        nodeLocator,
+        deltaX,
+        deltaY,
+        nodeLabel,
+        steps,
+        settleDelayMs,
+      );
+    const midDragDistancePx = flowPositionDistance(
+      initialFlowPosition,
+      midDragFlowPosition,
+    );
+    const postMouseUpDistancePx = flowPositionDistance(
+      initialFlowPosition,
+      postMouseUpFlowPosition,
+    );
+    latestObservation = {
+      midDragDistancePx,
+      midDragFlowPosition,
+      postMouseUpDistancePx,
+      postMouseUpFlowPosition,
+    };
+
+    if (
+      midDragDistancePx !== null &&
+      midDragDistancePx > displacementTolerancePx &&
+      postMouseUpDistancePx !== null &&
+      postMouseUpDistancePx > displacementTolerancePx
+    ) {
+      return {
+        initialFlowPosition,
+        ...latestObservation,
+      };
     }
   }
 
-  const postMouseUpFlowPosition =
-    await readFactoryGraphNodeFlowPosition(nodeLocator);
-  const midDragDistancePx = flowPositionDistance(
-    initialFlowPosition,
-    midDragFlowPosition,
+  throw new Error(
+    `Mouse drag did not produce the required flow displacement: ${JSON.stringify(
+      {
+        attempts: maxAttempts,
+        initialFlowPosition,
+        ...latestObservation,
+      },
+    )}`,
   );
-  const postMouseUpDistancePx = flowPositionDistance(
-    initialFlowPosition,
-    postMouseUpFlowPosition,
-  );
-  if (
-    midDragDistancePx === null ||
-    midDragDistancePx <= displacementTolerancePx ||
-    postMouseUpDistancePx === null ||
-    postMouseUpDistancePx <= displacementTolerancePx
-  ) {
-    throw new Error(
-      `Mouse drag did not produce the required flow displacement: ${JSON.stringify(
-        {
-          initialFlowPosition,
-          midDragFlowPosition,
-          midDragDistancePx,
-          postMouseUpFlowPosition,
-          postMouseUpDistancePx,
-        },
-      )}`,
-    );
-  }
-
-  return {
-    initialFlowPosition,
-    midDragFlowPosition,
-    midDragDistancePx,
-    postMouseUpDistancePx,
-    postMouseUpFlowPosition,
-  };
 }
 
 function graphNodePlacementSamplesEqual(left, right) {

--- a/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
@@ -168,6 +168,9 @@ const editableGraphFactoryReplayLines = [
 
 const flowPositionTolerancePx = 8;
 const persistedFlowPositionTolerancePx = 80;
+// The 120x80 gesture has a 120px max-axis displacement, preserving the
+// greater-than-80px persistence contract while keeping tolerance caller-scoped.
+const persistedNodeDragDelta = { x: 120, y: 80 };
 
 function flowPositionsMatchWithinTolerance(
   left,
@@ -1066,8 +1069,8 @@ describe.concurrent("factory graph editor node placement browser integration", (
         const dragObservation = await dragNodeByOffset(
           browserPage.page,
           browserPage.page.getByTestId(resourceTestId),
-          120,
-          80,
+          persistedNodeDragDelta.x,
+          persistedNodeDragDelta.y,
           {
             displacementTolerancePx: persistedFlowPositionTolerancePx,
             nodeLabel: resourceTestId,

--- a/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
@@ -4,10 +4,13 @@ import { describe } from "vitest";
 
 import {
   browserScenarioTimeoutMs,
+  dragNodeByOffset,
   expectNoBrowserErrors,
   fillModelWorkerAddOperationDraft,
   fillWorkstationPromptBody,
+  flowPositionDistance,
   modelProviderOptionLabel,
+  readFactoryGraphNodeFlowPosition,
   resolvedDefaultFactorySessionID,
   selectLabeledComboboxOption,
   startFactoryApiServer,
@@ -179,14 +182,6 @@ function flowPositionsMatchWithinTolerance(
   return distance <= tolerance;
 }
 
-function flowPositionDistance(left, right) {
-  if (!left || !right) {
-    return null;
-  }
-
-  return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
-}
-
 function boundingBoxesOverlap(left, right) {
   return (
     left.x < right.x + right.width &&
@@ -330,93 +325,10 @@ async function addWorkstation(page, toolbar, { body, name }) {
   });
 }
 
-async function readNodeFlowPosition(page, nodeTestId) {
-  return page.evaluate((testId) => {
-    const element = document.querySelector(`[data-testid="${testId}"]`);
-    const reactFlowNode =
-      element?.classList.contains("react-flow__node") === true
-        ? element
-        : element?.closest(".react-flow__node");
-    if (!reactFlowNode) {
-      return null;
-    }
-
-    const transform =
-      reactFlowNode.style.transform ||
-      window.getComputedStyle(reactFlowNode).transform;
-    if (!transform || transform === "none") {
-      return null;
-    }
-
-    const translateMatch = /translate(?:3d)?\(([-\d.]+)px,\s*([-\d.]+)px/.exec(
-      transform,
-    );
-    if (translateMatch) {
-      return {
-        x: Number(translateMatch[1]),
-        y: Number(translateMatch[2]),
-      };
-    }
-
-    const matrixMatch = /matrix\(([^)]+)\)/.exec(transform);
-    if (matrixMatch) {
-      const values = matrixMatch[1]
-        .split(",")
-        .map((value) => Number.parseFloat(value.trim()));
-      if (values.length >= 6) {
-        return { x: values[4], y: values[5] };
-      }
-    }
-
-    return null;
-  }, nodeTestId);
-}
-
 function savedLayoutNodePosition(factory, nodeId) {
   return (
     factory?.layout?.nodes?.find((node) => node.id === nodeId)?.position ?? null
   );
-}
-
-async function draggableNodeStartPoint(page, nodeTestId, nodeBox) {
-  const point = await page.evaluate(
-    ({ box, testId }) => {
-      const target = [...document.querySelectorAll("[data-testid]")].find(
-        (element) => element.getAttribute("data-testid") === testId,
-      );
-      const flowNode = target?.closest(".react-flow__node");
-      if (!flowNode) {
-        throw new Error(`Expected React Flow node for ${testId}.`);
-      }
-
-      const rect = flowNode.getBoundingClientRect();
-      const candidates = [
-        { x: rect.right - 4, y: rect.top + rect.height / 2 },
-        { x: rect.left + 4, y: rect.top + rect.height / 2 },
-        { x: rect.left + rect.width / 2, y: rect.top + 4 },
-        { x: rect.left + rect.width / 2, y: rect.bottom - 4 },
-        { x: box.x + box.width - 4, y: box.y + box.height / 2 },
-      ];
-
-      for (const candidate of candidates) {
-        const hit = document.elementFromPoint(candidate.x, candidate.y);
-        if (hit && flowNode.contains(hit) && !hit.closest(".nodrag")) {
-          return candidate;
-        }
-      }
-
-      throw new Error(
-        `Expected a draggable surface inside ${testId}; all candidate points were nodrag controls.`,
-      );
-    },
-    { box: nodeBox, testId: nodeTestId },
-  );
-
-  if (!point) {
-    throw new Error(`Expected a draggable start point for ${nodeTestId}.`);
-  }
-
-  return point;
 }
 
 async function addResource(page, toolbar, { capacity = "1", name }) {
@@ -438,59 +350,6 @@ async function addResource(page, toolbar, { capacity = "1", name }) {
     state: "hidden",
     timeout: uiInteractionTimeoutMs,
   });
-}
-
-async function dragNodeByOffset(page, nodeTestId, deltaX, deltaY) {
-  const node = page.getByTestId(nodeTestId);
-  await node.waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
-  const initialFlowPosition = await readNodeFlowPosition(page, nodeTestId);
-  const nodeBox = await node.boundingBox();
-  if (!nodeBox) {
-    throw new Error(`Expected bounding boxes for ${nodeTestId} drag.`);
-  }
-
-  const startPoint = await draggableNodeStartPoint(page, nodeTestId, nodeBox);
-  await page.mouse.move(startPoint.x, startPoint.y);
-  await page.mouse.down();
-  await page.mouse.move(startPoint.x + deltaX, startPoint.y + deltaY, {
-    steps: 16,
-  });
-  const midDragFlowPosition = await readNodeFlowPosition(page, nodeTestId);
-  await page.mouse.up();
-
-  const postMouseUpFlowPosition = await readNodeFlowPosition(page, nodeTestId);
-  const midDragDistancePx = flowPositionDistance(
-    initialFlowPosition,
-    midDragFlowPosition,
-  );
-  const postMouseUpDistancePx = flowPositionDistance(
-    initialFlowPosition,
-    postMouseUpFlowPosition,
-  );
-  if (
-    midDragDistancePx === null ||
-    midDragDistancePx <= persistedFlowPositionTolerancePx ||
-    postMouseUpDistancePx === null ||
-    postMouseUpDistancePx <= persistedFlowPositionTolerancePx
-  ) {
-    throw new Error(
-      `Mouse drag did not produce the required flow displacement: ${JSON.stringify(
-        {
-          initialFlowPosition,
-          midDragFlowPosition,
-          midDragDistancePx,
-          postMouseUpFlowPosition,
-          postMouseUpDistancePx,
-        },
-      )}`,
-    );
-  }
-
-  return {
-    initialFlowPosition,
-    midDragFlowPosition,
-    postMouseUpFlowPosition,
-  };
 }
 
 async function beginSaveActivationTrace(page) {
@@ -1014,9 +873,8 @@ describe.concurrent("factory graph editor node placement browser integration", (
           isWithinViewportBounds(addedWorkstationCenter, viewportMetrics),
         ).toBe(true);
 
-        const flowPosition = await readNodeFlowPosition(
-          browserPage.page,
-          "rf__node-workstation:review",
+        const flowPosition = await readFactoryGraphNodeFlowPosition(
+          browserPage.page.getByTestId("rf__node-workstation:review"),
         );
         expect(flowPosition).not.toBeNull();
         expect(Number.isFinite(flowPosition.x)).toBe(true);
@@ -1130,9 +988,8 @@ describe.concurrent("factory graph editor node placement browser integration", (
           workstationTestId,
         );
 
-        const positionBeforeSave = await readNodeFlowPosition(
-          browserPage.page,
-          workstationTestId,
+        const positionBeforeSave = await readFactoryGraphNodeFlowPosition(
+          browserPage.page.getByTestId(workstationTestId),
         );
         expect(positionBeforeSave).not.toBeNull();
 
@@ -1208,9 +1065,13 @@ describe.concurrent("factory graph editor node placement browser integration", (
 
         const dragObservation = await dragNodeByOffset(
           browserPage.page,
-          resourceTestId,
+          browserPage.page.getByTestId(resourceTestId),
           120,
           80,
+          {
+            displacementTolerancePx: persistedFlowPositionTolerancePx,
+            nodeLabel: resourceTestId,
+          },
         );
         const {
           initialFlowPosition,
@@ -1276,9 +1137,8 @@ describe.concurrent("factory graph editor node placement browser integration", (
           { requireViewportVisibility: false },
         );
         await waitForFactoryGraphSelectionReady(browserPage.page);
-        const reloadedFlowPosition = await readNodeFlowPosition(
-          browserPage.page,
-          resourceTestId,
+        const reloadedFlowPosition = await readFactoryGraphNodeFlowPosition(
+          browserPage.page.getByTestId(resourceTestId),
         );
         expect(
           flowPositionsMatchWithinTolerance(

--- a/ui/scripts/run-factory-graph-large-parity-browser-check.mjs
+++ b/ui/scripts/run-factory-graph-large-parity-browser-check.mjs
@@ -1,5 +1,8 @@
 import { chromium } from "playwright";
-import { expectNoBrowserErrors } from "../integration/browser-test-harness.mjs";
+import {
+  dragNodeByOffset,
+  expectNoBrowserErrors,
+} from "../integration/browser-test-harness.mjs";
 import { ensureStorybookServer } from "./run-storybook-responsive-check.mjs";
 import {
   storyUrl,
@@ -13,6 +16,11 @@ const storybookUrl = `http://${host}:${port}`;
 const storyId =
   "factory-graph-editor-large-fixtures--large-factory-visual-parity-matrix";
 const browserCheckTimeoutMs = 60_000;
+// The parity gesture is intentionally smaller than the integration drag:
+// max(|28|, |20|) = 28px of requested flow displacement, so 8px rejects a
+// no-op while remaining below the movement this check is asserting.
+const parityDragDelta = { x: 28, y: 20 };
+const parityDragDisplacementTolerancePx = 8;
 const viewports = [
   { height: 844, label: "mobile", width: 390 },
   { height: 1024, label: "tablet", width: 768 },
@@ -164,7 +172,16 @@ try {
       await authoredNode.click();
       await assertNodeSelected(page, authoredNodeId, viewport.label);
       const initialNodeTransform = await readNodeTransform(authoredNode);
-      await dragNodeByOffset(page, authoredNode, 28, 20);
+      await dragNodeByOffset(
+        page,
+        authoredNode,
+        parityDragDelta.x,
+        parityDragDelta.y,
+        {
+          displacementTolerancePx: parityDragDisplacementTolerancePx,
+          nodeLabel: authoredNodeId,
+        },
+      );
       await page.waitForFunction(
         ({ id, initialTransform }) => {
           const node = document.querySelector(
@@ -269,42 +286,6 @@ async function assertNodeSelected(page, nodeId, viewportLabel) {
   if (!(await selected.isVisible())) {
     throw new Error(`Selected graph node was not visible at ${viewportLabel}.`);
   }
-}
-
-async function dragNodeByOffset(page, node, deltaX, deltaY) {
-  const box = await node.boundingBox();
-  if (!box) {
-    throw new Error("Expected an authored node bounding box for pointer drag.");
-  }
-  const point = await page.evaluate(
-    ({ box: nodeBox }) => {
-      const candidates = [
-        { x: nodeBox.x + nodeBox.width / 2, y: nodeBox.y + 4 },
-        { x: nodeBox.x + 4, y: nodeBox.y + nodeBox.height / 2 },
-        {
-          x: nodeBox.x + nodeBox.width - 4,
-          y: nodeBox.y + nodeBox.height / 2,
-        },
-      ];
-      for (const candidate of candidates) {
-        const hit = document.elementFromPoint(candidate.x, candidate.y);
-        if (hit && !hit.closest(".nodrag")) {
-          return candidate;
-        }
-      }
-      return null;
-    },
-    { box },
-  );
-  if (!point) {
-    throw new Error(
-      "Expected a draggable point outside nested graph controls.",
-    );
-  }
-  await page.mouse.move(point.x, point.y);
-  await page.mouse.down();
-  await page.mouse.move(point.x + deltaX, point.y + deltaY, { steps: 12 });
-  await page.mouse.up();
 }
 
 function assertNoBrowserErrors(pageErrors, consoleErrors, viewportLabel) {


### PR DESCRIPTION
{
  "project": "Harden the Shared Factory Graph Drag Check",
  "branchName": "thr-parity-drag-helper-unverified-twin",
  "description": "Replace the divergent Factory graph browser-test drag implementations with one verified operation that measures actual flow displacement, retries a lost pointer grab, preserves caller-specific movement contracts, and reports the cause with measured values in under 10 seconds instead of surfacing a later 60-second timeout.",
  "context": {
    "customerAsk": "Eliminate the unhardened dragNodeByOffset twin used by the large Factory graph parity browser check. Both the parity check and node-placement integration test must use one verified helper that observes actual flow displacement, retries a lost pointer grab, and fails quickly with measured diagnostic values when movement does not occur, without changing graph-editor product code or weakening the checks.",
    "problem": "The parity check performs a roughly 34-pixel pointer gesture and assumes it succeeded. A non-draggable hit or React Flow activation race can silently no-op, after which a transform-change wait consumes 60 seconds and reports only a timeout. The node-placement integration test has a hardened duplicate with before, mid-drag, and post-mouse-up measurements, but its fixed 80-pixel threshold does not match the parity check's smaller movement contract. Same-head fail/pass evidence and identical failures on unrelated UI lanes identify a shared intermittent.",
    "solution": "Provide one importable browser-test drag operation for ui/scripts and ui/integration. It will choose a valid drag point, capture flow positions before, during, and after the gesture, require both measured distances to exceed a caller-appropriate tolerance, safely settle and retry a lost grab, and throw a named JSON diagnostic within 10 seconds after bounded retry exhaustion. Both callers will use documented, mutually consistent delta and tolerance values while the integration path retains its 80-pixel persistence contract."
  },
  "acceptanceCriteria": [
    "Both the large parity browser check and node-placement integration test use one canonical drag operation that observes flow position before, during, and after the gesture and rejects inadequate mid-drag or post-mouse-up displacement.",
    "A lost pointer grab receives a bounded settle/retry; exhausted attempts throw 'Mouse drag did not produce the required flow displacement' with initial, mid-drag, and post-mouse-up positions plus both measured distances in under 10 seconds.",
    "The parity and integration callers document and use drag deltas and displacement tolerances that are mathematically consistent with their distinct assertions; a smaller parity movement uses a caller-provided tolerance while the integration path retains its 80-pixel persistence threshold.",
    "Exactly one async function dragNodeByOffset definition remains under ui/, and the parity path reaches the surviving verified tolerance and displacement behavior through its import.",
    "With the temporary no-op injection reverted, the large parity browser check passes five consecutive local runs, and the invocation, results, and before/after failure text are recorded in a PR comment rather than a commit.",
    "Quality gates pass: Typecheck passes, tests pass, no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "PROCESS-STAGE FINISH LINE (operator-corrected): this stage is complete when the final head is pushed, the PR is open, CI has STARTED, and all blocking review feedback is addressed. Terminal CI and MERGED are owned by the REVIEW workstation and are explicitly NOT this stage's responsibility. Do not wait for, poll, or re-check CI status - each such visit consumes one of only 12 process visits before executor-loop-breaker kills this lane. CI-run evidence goes in a PR comment, never a commit."
  ],
  "userStories": [
    {
      "id": "thr-parity-drag-helper-unverified-twin-001",
      "title": "Preserve verified node-placement drag behavior through one reusable operation",
      "description": "As a test maintainer, I want the existing verified node-placement drag behavior exposed through a reusable browser operation so other real-browser checks can rely on the same position observations and diagnostic contract.",
      "acceptanceCriteria": [
        "The reusable operation reads flow position before the pointer gesture, during the drag, and after mouse-up, and returns all three observations to callers that need persistence assertions.",
        "Both mid-drag and post-mouse-up distances must exceed an explicit tolerance; null or insufficient measurements throw 'Mouse drag did not produce the required flow displacement' with JSON containing all three positions and both measured distances.",
        "The node-placement integration scenarios retain their existing greater-than-80-pixel displacement and persisted-position behavior after adopting the reusable operation.",
        "The shared location follows an existing cross-tree test-utility convention if one is found; otherwise the PR explains that no convention existed and uses the location requiring the fewest new import paths.",
        "No Factory graph editor product file, Bun/Vitest component runner script, or functional quarantine entry changes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added the verified drag operation, flow-position reader, and shared distance helper to ui/integration/browser-test-harness.mjs; migrated node-placement integration coverage with its existing 120x80 gesture and >80px displacement contract. Focused browser integration (4/4), typecheck, and targeted Biome checks pass."
    },
    {
      "id": "thr-parity-drag-helper-unverified-twin-002",
      "title": "Make parity drags retry and fail at the cause",
      "description": "As a UI lane contributor, I want the parity check to retry a lost node grab and report measured drag failure promptly so an intermittent pointer no-op does not consume a full CI timeout or masquerade as a product regression.",
      "acceptanceCriteria": [
        "The large parity browser check uses the reusable verified drag operation, and the previous local duplicate is removed so exactly one async function dragNodeByOffset definition remains under ui/.",
        "A failed displacement triggers a bounded settle/retry of the pointer gesture; retry exhaustion completes in under 10 seconds and cannot fall through to the existing 60-second transform wait.",
        "The parity caller's chosen delta and tolerance are documented together in code, the requested displacement is achievable by that delta, and the tolerance is strict enough to distinguish its required transform change from a no-op.",
        "The integration caller retains its 80-pixel persistence tolerance; if parity needs less travel, tolerance is a helper parameter rather than a hard-coded global threshold applied to both callers.",
        "The drag uses a valid point outside nested .nodrag controls, allows React Flow's pointer handling to settle, and always releases the mouse before retrying or throwing.",
        "The existing 60-second timeout is not increased, and the parity check is neither skipped nor quarantined.",
        "Direct browser verification confirms a normal parity drag still changes the node transform and preserves the remainder of the parity scenario.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Migrated the large parity browser check to the shared verified drag operation, removed its local duplicate, and added a bounded two-attempt settle/retry with guaranteed pointer release and measured JSON failure diagnostics. The parity caller documents its 28x20 delta and 8px tolerance; the integration caller documents its 120x80 delta and existing 80px persistence tolerance. Focused drag tests, typecheck, Biome, node-placement integration (4/4), and the parity browser check at mobile/tablet/desktop pass."
    },
    {
      "id": "thr-parity-drag-helper-unverified-twin-003",
      "title": "Prove fast diagnostics and repeated parity stability",
      "description": "As a reviewer, I want direct success-path and forced-failure browser evidence so I can verify that the intermittent is hardened at its cause rather than hidden by a passing build or a longer wait.",
      "acceptanceCriteria": [
        "With the pointer sequence temporarily forced to no-op, the browser path throws 'Mouse drag did not produce the required flow displacement' in under 10 seconds and prints the initial, mid-drag, and post-mouse-up positions plus both measured pixel distances.",
        "The temporary no-op mechanism is reverted before the final push and does not appear in the final diff.",
        "The large Factory graph parity browser check passes five consecutive local runs on the final implementation.",
        "A PR comment records the exact five-run invocation and outcomes and the before/after failure text; CI-run evidence and transient proof are never committed.",
        "Direct browser verification confirms both owned call sites exercise the canonical drag behavior without browser or console errors attributable to the change.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Verified the real parity browser path on the rebased final implementation with a temporary local no-op injection: it failed after 2.379s with the named displacement error and JSON measurements (initial/mid/post positions and both zero distances); the injection was reverted and is absent from the final diff. The final parity command passed five consecutive runs (each mobile/tablet/desktop, strict page and console error checks); focused node-placement integration passed 4/4, shared drag tests passed 2/2, and typecheck passed. Evidence was posted to PR #2014."
    }
  ]
}
