### PR TITLE
thr-plan-delivery-criterion-leads-with-merge

### DIFF
--- a/docs/internal/standards/code/planning-standards.md
+++ b/docs/internal/standards/code/planning-standards.md
@@ -27,9 +27,14 @@ Every contributor or agent who creates or updates a PRD, `prd.json`, or work-sto
 - When coverage of the behavior being restructured is insufficient, characterization tests **MUST** land first as their own step, before the structure changes.
 - Bundle changes only when they must merge together, never because they happen to touch the same file.
 - Call out quality gates directly when the work touches backend, frontend, contracts, or generated artifacts.
-- Every implementation plan **MUST** state that delivery loops through required
-  CI, blocking review feedback, conflict resolution, and actual PR merge before
-  the work is complete.
+- Every implementation plan **MUST** state a two-stage delivery loop:
+  implementation marks its delivery criterion satisfied and stops after its
+  final head is pushed, the PR is open, CI has started, and all blocking review
+  feedback is addressed; review then owns terminal-and-passing CI, conflict
+  resolution, and merge, with merge remaining the lane-wide completion
+  boundary.
+- Implementation **MUST NOT** poll or re-check CI after its finish line, and
+  CI-run evidence **MUST** go in a PR comment, never a commit.
 
 ### Task shaping
 - Every task when creating tasks for submission into sub workers/the You Agent Factory must match the template structure denoted in docs/internal/standards/templates/task-templates.md
@@ -226,21 +231,41 @@ Rules:
 
 ### 13. Make Merge the Delivery Boundary
 
-Implementation plans **MUST** make the end-to-end delivery condition explicit.
+Implementation plans **MUST** make the end-to-end delivery condition explicit
+while writing the project-level delivery criterion from the perspective of the
+stage that evaluates it.
 
 Rules:
 
-- The plan **MUST** require the implementation/review cycle to continue until
-  required CI is terminal and passing, blocking PR conversation feedback is
-  explicitly addressed, merge conflicts are resolved, and the PR is merged.
-- Opening a PR, pushing the latest implementation, obtaining approval, or
-  reaching green CI without merge **MUST NOT** be described as completion.
+- The project-level delivery criterion **MUST** lead with this implementation
+  finish line: the implementation stage marks the criterion satisfied and
+  stops after its final head is pushed, the PR is open, CI has started, and all
+  blocking review feedback is addressed.
+- The criterion **MUST** state that implementation does not poll or re-check CI
+  after that finish line. The review stage owns driving CI to
+  terminal-and-passing, resolving merge conflicts, and merging the PR; merge
+  remains the lane-wide delivery boundary.
+- The implementation/review cycle **MUST** continue through those review-owned
+  outcomes until the PR is merged. The implementation stage's finish line is
+  not lane-wide completion: opening a PR, pushing the latest implementation,
+  obtaining approval, or reaching green CI without merge **MUST NOT** be
+  described as completing the lane.
+- A delivery criterion **MUST NOT** open with “delivery continues until ...
+  merged” or equivalent merge-first wording. The implementation stage
+  evaluates the criterion but cannot merge, so a merge-first condition makes it
+  wait on a review-owned outcome and can trigger repeated redispatch until the
+  executor-loop breaker ends the lane.
+- CI-run evidence **MUST** go in a PR comment and never in a commit.
 - Shared-file or baseline churn **MUST** be reconciled through the same delivery
   loop when the change remains in scope; it is not by itself a reason to hold an
   otherwise dependency-ready plan.
 - The merge condition belongs in project-level acceptance criteria or an
   equivalent delivery section. It **SHOULD NOT** be modeled as a fake product
   behavior story.
+
+Canonical criterion example:
+
+> Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit.
 
 ## Delivery Checklist
 

--- a/factory/workstations/plan/AGENTS.md
+++ b/factory/workstations/plan/AGENTS.md
@@ -31,24 +31,26 @@ blocking PR conversation feedback is explicitly addressed, merge conflicts are
 resolved, and the PR is merged. A PR that is merely opened, green, approved, or
 ready to merge is not complete.
 
-That contract belongs to the lane as a whole, and the `Delivery Loop` section
-must attribute its two halves to the two stages that actually own them:
+That contract belongs to the lane as a whole, and the project-level delivery
+criterion must be written from the perspective of the stage that evaluates it.
+Every emitted delivery criterion must lead with this implementation-stage
+finish line and preserve this order:
 
-- The **implementation stage** finishes when it has pushed its final head, the
-  PR is open, CI has started, and all blocking review feedback is addressed.
-- The **review stage** owns driving CI to terminal-and-passing and owns the
-  merge itself.
+> Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit.
 
-Never phrase an acceptance criterion so that the implementation stage owns
-"CI is green" or "the PR is merged". The implementer cannot merge, so a
-criterion worded that way makes it wait on an outcome it does not control: it
-re-runs CI for hours and commits progress notes about the run it is watching.
-Each such commit creates a new head, which invalidates the very run it just
-recorded, and the loop restarts. This has cost tens of agent-hours on a single
-lane.
+The implementation stage owns only the finish line at the start of that
+criterion. The review stage owns driving CI to terminal-and-passing, resolving
+merge conflicts, and merging the PR afterward; merge remains the lane-wide
+delivery boundary.
 
-For the same reason, every plan must state that evidence about a CI run goes in
-a PR comment and never in a commit.
+Never phrase a delivery criterion so that implementation owns "CI is green"
+or "the PR is merged", and never open it with "delivery continues until ...
+merged" or equivalent merge-first wording. The evaluating implementation stage
+cannot merge, so a merge-first criterion makes it wait on a review-owned
+outcome and can trigger repeated redispatch until the executor-loop breaker
+ends the lane. Implementation must stop at its finish line and must not poll
+or re-check CI afterward. Every plan must state that evidence about a CI run
+goes in a PR comment and never in a commit.
 
 When the ask touches backend, plan for clear package ownership, explicit state,
 isolated side effects, aligned contracts, and direct verification at the right
@@ -95,16 +97,19 @@ The JSON file must be implementation-ready and contain:
 - `acceptanceCriteria` with 3-7 project-level criteria, a final quality-gate
   criterion for typecheck, lint, and tests, and a delivery criterion that keeps
   the lane's implementation/review loop going until the PR is actually merged.
-  The delivery criterion must assign stage ownership explicitly: the
-  implementation stage finishes after its final head is pushed, the PR is open,
-  CI has started, and all blocking review feedback is addressed; the review
-  stage owns driving CI to terminal-and-passing, resolving merge conflicts, and
-  merging the PR. Terminal-and-passing CI, conflict resolution, and merge are
-  review-stage outcomes, not implementation-stage responsibilities, even though
-  merge remains the lane-wide completion boundary. After the implementation
-  finish line, implementation must not poll or re-check CI because every
-  redispatch consumes one of the 12 process visits. Put CI-run evidence in a PR
-  comment and never in a commit. Phrase the lint criterion as "no NEW lint
+  The delivery criterion must begin with the exact implementation-stage finish
+  line in the canonical example above: implementation marks it satisfied and
+  stops after its final head is pushed, the PR is open, CI has started, and all
+  blocking review feedback is addressed. It must then assign terminal-and-
+  passing CI, merge-conflict resolution, and merging to the review stage while
+  retaining merge as the lane-wide completion boundary. Do not open it with
+  "delivery continues until ... merged" or equivalent merge-first wording: the
+  implementation stage evaluates the criterion but cannot merge, and waiting
+  on that review-owned outcome can trigger repeated redispatch until the
+  executor-loop breaker ends the lane. After the implementation finish line,
+  implementation must not poll or re-check CI because every redispatch consumes
+  one of the 12 process visits. Put CI-run evidence in a PR comment and never in
+  a commit. Phrase the lint criterion as "no NEW lint
   violations relative to current main, and the gates green on main
   (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green" —
   NOT as a blanket "make lint passes": `make lint` cannot pass end-to-end on


### PR DESCRIPTION
{
  "project": "Make planner delivery criteria satisfiable by the implementation stage",
  "branchName": "thr-plan-delivery-criterion-leads-with-merge",
  "description": "Correct the normative planning standard and planner workstation prompt so generated delivery criteria begin with the implementation stage's satisfiable finish condition and explicitly tell implementation to mark the criterion satisfied and stop. Attribute terminal-and-passing CI, conflict resolution, and merge only afterward to the review stage, while preserving merge as the lane-wide delivery boundary. Add an explicit merge-first prohibition and canonical criterion example, verify the behavior in a representative emitted artifact, and document the four-of-four defect incidence and dormant-until-daemon-restart activation.",
  "context": {
    "customerAsk": "Update only docs/internal/standards/code/planning-standards.md and factory/workstations/plan/AGENTS.md so an emitted delivery criterion leads with final head pushed, PR open, CI started, and blocking review feedback addressed; says implementation marks it satisfied and stops; prohibits openings such as 'delivery continues until ... merged' because the evaluating stage cannot merge; and gives the planner a canonical correctly worded example. Preserve merge as the lane-wide delivery boundary. The PR description must quote exact before/after changed text, state that four of four inspected lanes carried the defect, and explain that workstation prompts are not hot-reloaded, making the change dormant until the next daemon restart.",
    "problem": "Current guidance asks for a criterion that keeps implementation/review going until merge, so the planner emits merge as the leading condition. The PROCESS implementation stage evaluates that criterion but cannot perform the review-stage merge transition, causing repeated redispatch until the 12-visit executor-loop-breaker can kill a finished lane. Four of four inspected lanes on 2026-08-16 independently carried this trap, and ux-p3 / PR #2003 previously exhausted its visit budget with a green PR stranded open.",
    "solution": "Rewrite the normative delivery rule from the implementation stage's perspective first, explicitly state when it marks the criterion satisfied and stops, then assign terminal CI, conflict resolution, and merge to review while retaining merge as lane-wide completion. Mirror the rule in the planner prompt, prohibit merge-first equivalents with the evaluator-authority reason, and include one canonical example. Verify a representative emitted Markdown or JSON criterion rather than adding source-scanning meta-tests, keep the diff to the two owned guidance files, and record exact wording and restart behavior in the PR description."
  },
  "acceptanceCriteria": [
    "The normative planning standard and planner workstation prompt require an emitted delivery criterion whose leading sentence says the implementation stage marks the criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed; only subsequent text assigns terminal-and-passing CI, conflict resolution, and merge to review.",
    "Delivery, IMPLEMENTATION-STAGE VIEW: this criterion is SATISFIED as soon as the implementation stage has rebased onto origin/main, pushed its final head, opened the PR, started CI, and addressed all blocking review feedback. Mark it PASSING at that moment and stop. Do NOT hold it open waiting for the merge: the merge is the LANE completion boundary and belongs entirely to the review stage, and an implementation stage that waits for it re-dispatches until the 12-visit budget is exhausted and the lane is killed with a finished PR stranded (this happened to PR #2003). The review stage owns driving CI to terminal-and-passing, resolving conflicts, and merging. CI-run evidence goes in a PR comment and never in a commit. .. merged' or equivalent merge-first wording, explain that the evaluating implementation stage cannot merge, and include the same canonical correctly ordered criterion example.",
    "A representative emitted Markdown or JSON planning artifact proves the corrected behavior by inspection of its project-level delivery criterion: the implementation finish condition leads, implementation stops without polling or re-checking CI, and review-owned merge appears afterward while remaining the lane-wide delivery boundary.",
    "The PR description quotes the exact before and after text of every changed instruction line, states that four of four inspected lanes carried the defect, and explicitly says workstation prompts are not hot-reloaded, so this correction is dormant for the running daemon until the next restart; CI-run evidence goes in a PR comment and never in a commit.",
    "Scope is limited to factory/workstations/plan/AGENTS.md and docs/internal/standards/code/planning-standards.md; no .claude/worktrees/*/prd.json, factory/factory.json, process/review/consume prompt, executor-loop-breaker configuration, Go source, TypeScript source, or unrelated content changes appear, and the branch is rebased onto current origin/main before the final push.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit.",
    "Quality gate: Typecheck and applicable tests pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Verification also confirms no Go or TypeScript source file appears in the diff and re-reads the representative emitted criterion from the implementation worker's perspective."
  ],
  "userStories": [
    {
      "id": "thr-plan-delivery-criterion-leads-with-merge-001",
      "title": "Define the stage-satisfiable delivery contract",
      "description": "As a planning-standard consumer, I want the normative delivery rule to begin with the implementation stage's achievable finish condition so generated work can stop implementation without weakening the lane-wide merge boundary.",
      "acceptanceCriteria": [
        "The normative rule requires the delivery criterion to lead with final head pushed, PR open, CI started, and all blocking review feedback addressed, and to state that the implementation stage marks the criterion satisfied and stops at that point.",
        "The rule assigns terminal-and-passing CI, merge-conflict resolution, and actual merge to the review stage only after the implementation finish condition, while retaining merge as the lane-wide completion boundary.",
        "The rule prohibits opening with 'delivery continues until ... merged' or equivalent merge-first wording and explains that the evaluating implementation stage cannot perform a merge.",
        "The rule includes the canonical criterion text from the PRD, including the prohibition on implementation polling or re-checking CI and the requirement to put CI-run evidence in a PR comment, never a commit.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Updated the normative planning standard with the implementation-stage finish line, review ownership, merge-first prohibition, no-CI-polling rule, CI-comment evidence rule, and canonical criterion example. `make typecheck` passes after restoring dependencies with `bun install --frozen-lockfile`."
    },
    {
      "id": "thr-plan-delivery-criterion-leads-with-merge-002",
      "title": "Emit the corrected delivery criterion from the planner prompt",
      "description": "As an implementation worker receiving a planned lane, I want the emitted delivery criterion to tell me exactly when I may mark it satisfied and stop so I do not consume process visits waiting for review-owned outcomes.",
      "acceptanceCriteria": [
        "The planner prompt carries the same finish-first rule, explicit merge-first prohibition and reason, canonical example, review-stage ownership, no-CI-polling instruction, and PR-comment-only CI evidence rule as the normative standard.",
        "Reading a representative emitted Markdown or JSON planning artifact proves that its delivery criterion opens with the implementation-owned satisfiable finish condition and says implementation marks it satisfied and stops; review-owned terminal CI, conflict resolution, and merge follow afterward.",
        "The emitted artifact still states that actual merge is the lane-wide delivery boundary and does not reassign terminal-and-passing CI, conflict resolution, or merge to implementation.",
        "The PR description quotes the exact before and after changed text, reports 'four of four' inspected lanes, and states that the prompt change is dormant until the next daemon restart because workstation prompts are not hot-reloaded and a restart clears the in-memory board.",
        "The final diff touches only the two owned documentation and prompt files, contains no Go or TypeScript source changes, and follows a rebase onto current origin/main before the final push.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Updated factory/workstations/plan/AGENTS.md with the exact canonical finish-first delivery criterion, merge-first prohibition and evaluator-authority rationale, review ownership, no-CI-polling rule, and PR-comment-only CI evidence. Verified the representative emitted project-level criterion in prd.json by direct JSON inspection; no Go or TypeScript source files are in the diff. `make typecheck` and `make test` pass."
    }
  ]
}


## PR description evidence

Four of four inspected lanes on 2026-08-16 carried this delivery-criterion defect. Workstation prompts are not hot-reloaded, so this correction is dormant for the running daemon until the next daemon restart, which clears the in-memory board. CI-run evidence belongs in a PR comment and never in a commit.

## Exact before/after changed instruction text

### docs/internal/standards/code/planning-standards.md — quick rules

Before:

- Every implementation plan **MUST** state that delivery loops through required
  CI, blocking review feedback, conflict resolution, and actual PR merge before
  the work is complete.

After:

- Every implementation plan **MUST** state a two-stage delivery loop:
  implementation marks its delivery criterion satisfied and stops after its
  final head is pushed, the PR is open, CI has started, and all blocking review
  feedback is addressed; review then owns terminal-and-passing CI, conflict
  resolution, and merge, with merge remaining the lane-wide completion
  boundary.
- Implementation **MUST NOT** poll or re-check CI after its finish line, and
  CI-run evidence **MUST** go in a PR comment, never a commit.

### docs/internal/standards/code/planning-standards.md — merge boundary

Before:

Implementation plans **MUST** make the end-to-end delivery condition explicit.

Rules:

- The plan **MUST** require the implementation/review cycle to continue until
  required CI is terminal and passing, blocking PR conversation feedback is
  explicitly addressed, merge conflicts are resolved, and the PR is merged.
- Opening a PR, pushing the latest implementation, obtaining approval, or
  reaching green CI without merge **MUST NOT** be described as completion.

After:

Implementation plans **MUST** make the end-to-end delivery condition explicit
while writing the project-level delivery criterion from the perspective of the
stage that evaluates it.

Rules:

- The project-level delivery criterion **MUST** lead with this implementation
  finish line: the implementation stage marks the criterion satisfied and
  stops after its final head is pushed, the PR is open, CI has started, and all
  blocking review feedback is addressed.
- The criterion **MUST** state that implementation does not poll or re-check CI
  after that finish line. The review stage owns driving CI to
  terminal-and-passing, resolving merge conflicts, and merging the PR; merge
  remains the lane-wide delivery boundary.
- The implementation/review cycle **MUST** continue through those review-owned
  outcomes until the PR is merged. The implementation stage's finish line is
  not lane-wide completion: opening a PR, pushing the latest implementation,
  obtaining approval, or reaching green CI without merge **MUST NOT** be
  described as completing the lane.
- A delivery criterion **MUST NOT** open with “delivery continues until ...
  merged” or equivalent merge-first wording. The implementation stage
  evaluates the criterion but cannot merge, so a merge-first condition makes it
  wait on a review-owned outcome and can trigger repeated redispatch until the
  executor-loop breaker ends the lane.
- CI-run evidence **MUST** go in a PR comment and never in a commit.

### docs/internal/standards/code/planning-standards.md — canonical example

Before:

No canonical criterion example was present.

After:

Canonical criterion example:

> Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit.

### factory/workstations/plan/AGENTS.md — delivery loop ownership

Before:

That contract belongs to the lane as a whole, and the `Delivery Loop` section
must attribute its two halves to the two stages that actually own them:

- The **implementation stage** finishes when it has pushed its final head, the
  PR is open, CI has started, and all blocking review feedback is addressed.
- The **review stage** owns driving CI to terminal-and-passing and owns the
  merge itself.

Never phrase an acceptance criterion so that the implementation stage owns
"CI is green" or "the PR is merged". The implementer cannot merge, so a
criterion worded that way makes it wait on an outcome it does not control: it
re-runs CI for hours and commits progress notes about the run it is watching.
Each such commit creates a new head, which invalidates the very run it just
recorded, and the loop restarts. This has cost tens of agent-hours on a single
lane.

For the same reason, every plan must state that evidence about a CI run goes in
a PR comment and never in a commit.

After:

That contract belongs to the lane as a whole, and the project-level delivery
criterion must be written from the perspective of the stage that evaluates it.
Every emitted delivery criterion must lead with this implementation-stage
finish line and preserve this order:

> Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit.

The implementation stage owns only the finish line at the start of that
criterion. The review stage owns driving CI to terminal-and-passing, resolving
merge conflicts, and merging the PR afterward; merge remains the lane-wide
delivery boundary.

Never phrase a delivery criterion so that implementation owns "CI is green"
or "the PR is merged", and never open it with "delivery continues until ...
merged" or equivalent merge-first wording. The evaluating implementation stage
cannot merge, so a merge-first criterion makes it wait on a review-owned
outcome and can trigger repeated redispatch until the executor-loop breaker
ends the lane. Implementation must stop at its finish line and must not poll
or re-check CI afterward. Every plan must state that evidence about a CI run
goes in a PR comment and never in a commit.

### factory/workstations/plan/AGENTS.md — JSON emission rule

Before:

- `acceptanceCriteria` with 3-7 project-level criteria, a final quality-gate
  criterion for typecheck, lint, and tests, and a delivery criterion that keeps
  the lane's implementation/review loop going until the PR is actually merged.
  The delivery criterion must assign stage ownership explicitly: the
  implementation stage finishes after its final head is pushed, the PR is open,
  CI has started, and all blocking review feedback is addressed; the review
  stage owns driving CI to terminal-and-passing, resolving merge conflicts, and
  merging the PR. Terminal-and-passing CI, conflict resolution, and merge are
  review-stage outcomes, not implementation-stage responsibilities, even though
  merge remains the lane-wide completion boundary. After the implementation
  finish line, implementation must not poll or re-check CI because every
  redispatch consumes one of the 12 process visits. Put CI-run evidence in a PR
  comment and never in a commit. Phrase the lint criterion as "no NEW lint
  violations relative to current main, and the gates green on main
  (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green" —
  NOT as a blanket "make lint passes": `make lint` cannot pass end-to-end on
  main while the pkg-boundary target carries pre-existing
  packaged-service-structure migration debt (recorded 2026-08-08), and an
  unsatisfiable criterion stalls the review loop.

After:

- `acceptanceCriteria` with 3-7 project-level criteria, a final quality-gate
  criterion for typecheck, lint, and tests, and a delivery criterion that keeps
  the lane's implementation/review loop going until the PR is actually merged.
  The delivery criterion must begin with the exact implementation-stage finish
  line in the canonical example above: implementation marks it satisfied and
  stops after its final head is pushed, the PR is open, CI has started, and all
  blocking review feedback is addressed. It must then assign terminal-and-
  passing CI, merge-conflict resolution, and merging to the review stage while
  retaining merge as the lane-wide completion boundary. Do not open it with
  "delivery continues until ... merged" or equivalent merge-first wording: the
  implementation stage evaluates the criterion but cannot merge, and waiting
  on that review-owned outcome can trigger repeated redispatch until the
  executor-loop breaker ends the lane. After the implementation finish line,
  implementation must not poll or re-check CI because every redispatch consumes
  one of the 12 process visits. Put CI-run evidence in a PR comment and never in
  a commit. Phrase the lint criterion as "no NEW lint
  violations relative to current main, and the gates green on main
  (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green" —
  NOT as a blanket "make lint passes": `make lint` cannot pass end-to-end on
  main while the pkg-boundary target carries pre-existing
  packaged-service-structure migration debt (recorded 2026-08-08), and an
  unsatisfiable criterion stalls the review loop.