### PR TITLE
thr-deflake-manual-move-reads-state-before-the-cascade-settles

### DIFF
--- a/tests/functional/work/recovery/manual_move_test.go
+++ b/tests/functional/work/recovery/manual_move_test.go
@@ -73,20 +73,26 @@ func TestFailedCascadeCanBeRecoveredByPublicWorkMove(t *testing.T) {
 	})
 
 	waitForWorkIDsAtState(t, server.URL(), []string{parentWorkID, childWorkID}, "failed", 15*time.Second)
+	support.WaitForTerminalStatus(t, server.URL(), 15*time.Second)
 
-	parentMoved := postMoveWork(t, server.URL(), parentWorkID, "processing")
-	if workStateName(parentMoved.State) != "processing" {
-		t.Fatalf("parent move response = %#v, want processing", parentMoved)
+	parentMoveStatus, parentMoveBody := postMoveWorkStatus(t, server.URL(), parentWorkID, "processing")
+	if parentMoveStatus != http.StatusOK {
+		t.Fatalf("parent move status = %d, want 200: %s", parentMoveStatus, parentMoveBody)
 	}
 
-	childMoved := postMoveWork(t, server.URL(), childWorkID, "init")
-	if workStateName(childMoved.State) != "init" {
-		t.Fatalf("child move response = %#v, want init", childMoved)
+	childMoveStatus, childMoveBody := postMoveWorkStatus(t, server.URL(), childWorkID, "init")
+	if childMoveStatus != http.StatusOK {
+		t.Fatalf("child move status = %d, want 200: %s", childMoveStatus, childMoveBody)
 	}
 
-	completed := waitForWorkIDsComplete(t, server.URL(), []string{childWorkID}, 15*time.Second)
-	if len(completed) != 1 || workStateName(completed[0].State) != "complete" {
-		t.Fatalf("child completion = %#v, want complete", completed)
+	completed := waitForWorkIDsComplete(t, server.URL(), []string{parentWorkID, childWorkID}, 15*time.Second)
+	if len(completed) != 2 {
+		t.Fatalf("completed Works = %#v, want parent and child", completed)
+	}
+	for _, item := range completed {
+		if workStateName(item.State) != "complete" {
+			t.Fatalf("completed Work = %#v, want complete", item)
+		}
 	}
 
 	listed := support.ListDefaultSessionWork(t, server.URL())

--- a/tests/functional/work/recovery/manual_move_test.go
+++ b/tests/functional/work/recovery/manual_move_test.go
@@ -29,6 +29,12 @@ func TestFailedCascadeCanBeRecoveredByPublicWorkMove(t *testing.T) {
 	)
 
 	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "cascading_failure"))
+	// In-scope construction exception: this cascade needs independent response
+	// sequences for starter and finisher. ProviderCommandRunner receives only the
+	// policy-free command, args, and identical fixture prompt, so it cannot target
+	// those per-worker attempts; a queued edge run leaves the recovered child
+	// failed. The provider service below is the narrowest way to preserve this
+	// public cascade/recovery behavior without changing the production path.
 	provider := testutil.NewMockWorkerMapProviderWithDefault(map[string][]testutil.WorkResponse{
 		"starter": {
 			{Content: "COMPLETE"},


### PR DESCRIPTION
## Summary

Make `TestFailedCascadeCanBeRecoveredByPublicWorkMove` deterministic under hosted contention without changing the recovery contract. The test now waits for the public terminal/idle stability window after the initial failed observations, treats the two public moves as accepted HTTP operations rather than trusting unstable synchronous state fields, and waits for public Work observations to show both parent and child complete before asserting both `task:complete` locations.

## Mechanism and ordered evidence

Selected mechanism: **(a) transient cascade/scheduler propagation**. The first observed `failed` state is not a sufficient stable boundary for a subsequent operator move when the runtime is contended; the synchronous move response can be overtaken by scheduler progress.

The ordered evidence is:

1. Hosted PR [#2016](https://github.com/portpowered/you-agent-factory/pull/2016) failed at the synchronous parent move assertion while 110 of 140 packages were in flight. The known isolated baselines passed 3/3 on main `1473e508e` and 3/3 on unrelated branch `59c08ee48` using `go test ./tests/functional/work/recovery/ -run TestFailedCascadeCanBeRecoveredByPublicWorkMove -count=3`.
2. The pre-change local command `go test ./tests/functional/work/recovery/ -run TestFailedCascadeCanBeRecoveredByPublicWorkMove -count=20` did not reproduce the target assertion; it failed during four shared packaged-factory server-start/install-contention failures.
3. Narrow local event/public diagnostics showed one starter success, one finisher failure, no retry/repeat failure, both Works at `failed`, and zero in-flight dispatches before the operator moves. The existing move implementation applies the mutation before reading the result.
4. The corrected test waits for the public terminal/idle stable window, posts parent `processing` and child `init`, checks only HTTP 200 acceptance, and then reads both Works publicly at `complete` and `task:complete`.

This rules out **(b) retry/repeat re-failure**: the ordered diagnostic run had one finisher failure and no repeated failure. It rules out **(c) a pre-mutation endpoint response**: the move path mutates before reading, and the later public read is the authoritative observation. The stable precondition and eventual public assertions target the remaining transient propagation/scheduler window.

## Functional-test construction exception

This scenario has a narrow in-scope exception to the command-runner preference. It needs independent response sequences for the `starter` and `finisher` workers. `ProviderCommandRunner` receives only the policy-free command, args, and the identical `Test workstation.` fixture prompt, so a global queued edge response cannot target those per-worker attempts; the direct edge conversion left the recovered child failed. The existing provider service is therefore retained only for this cascade cell, through the same canonical functional server and `edges.Edges` construction path used by the helper. The exception is documented in the test next to the provider setup.

## Verification

After the change:

- `go test ./tests/functional/work/recovery/ -run TestFailedCascadeCanBeRecoveredByPublicWorkMove -count=1` — PASS.
- `go test ./tests/functional/work/recovery/ -run TestFailedCascadeCanBeRecoveredByPublicWorkMove -count=20` — PASS on the rerun (48.855s); the first attempt failed only during packaged-factory installation contention.
- `wsl bash -lc 'cd /mnt/c/Users/andre/work/portos/infinite-you/.claude/worktrees/thr-deflake-manual-move-reads-state-before-the-cascade-settles && go test -race ./tests/functional/work/recovery/ -run TestFailedCascadeCanBeRecoveredByPublicWorkMove -count=20'` — PASS (60.570s).
- Concurrent WSL run: `go test ./tests/functional/work/recovery/ -run TestFailedCascadeCanBeRecoveredByPublicWorkMove -count=1` and `go test ./tests/functional/work/...` — both PASS.
- The Windows `-race` command could not start the package because ThreadSanitizer failed its allocation with Windows error 87; the WSL race run above is the successful hosted-like result.
- A Windows concurrent run failed before the target assertion during shared packaged-factory installation/startup (`context canceled` / server starter not invoked); the same target-plus-broad-slice run passed under WSL.
- The prior hosted CI run [31936996554](https://github.com/portpowered/you-agent-factory/actions/runs/31936996554) passed the required backend lint, unit coverage, functional coverage, UI backend integration, and verification-policy checks on the previous code head.

No sleep, timeout padding, skip, deletion, weakened completion claim, quarantine entry, providercompat change, or unrelated contract/inventory change was added. The tracked diff is limited to `tests/functional/work/recovery/manual_move_test.go`.
