### PR TITLE
ux-p5b-bento-responsive-and-accessible-layout

### DIFF
--- a/ui/integration/factory-graph-editor.integration.test.mjs
+++ b/ui/integration/factory-graph-editor.integration.test.mjs
@@ -387,16 +387,29 @@ describe.concurrent("factory graph editor browser integration", () => {
             timeout: uiInteractionTimeoutMs,
           });
         await server.replayCompleted;
-        await browserPage.page
-          .getByRole("button", { name: "Export PNG" })
-          .waitFor({
-            state: "visible",
-            timeout: uiInteractionTimeoutMs,
-          });
+        const exportButton = browserPage.page.getByRole("button", {
+          name: "Export PNG",
+        });
+        await exportButton.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await expect
+          .poll(
+            async () =>
+              await exportButton.evaluate((button) => {
+                const bounds = button.getBoundingClientRect();
+                const topmost = document.elementFromPoint(
+                  bounds.left + bounds.width / 2,
+                  bounds.top + bounds.height / 2,
+                );
+                return topmost === button || button.contains(topmost);
+              }),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toBe(true);
 
-        await browserPage.page
-          .getByRole("button", { name: "Export PNG" })
-          .click();
+        await exportButton.click();
         await browserPage.page
           .getByRole("heading", { name: "Export factory" })
           .waitFor({

--- a/ui/integration/factory-name-preservation-browser-helpers.mjs
+++ b/ui/integration/factory-name-preservation-browser-helpers.mjs
@@ -52,11 +52,23 @@ export async function waitForDashboardReady(page, previewURL, server) {
 }
 
 export async function exportFactoryPngFromDashboard(page, exportName) {
-  await page.getByRole("button", { name: "Export PNG" }).waitFor({
+  const exportButton = page.getByRole("button", { name: "Export PNG" });
+  await exportButton.waitFor({
     state: "visible",
     timeout: uiInteractionTimeoutMs,
   });
-  await page.getByRole("button", { name: "Export PNG" }).click();
+  const exportButtonIsTopmost = await exportButton.evaluate((button) => {
+    const bounds = button.getBoundingClientRect();
+    const topmost = document.elementFromPoint(
+      bounds.left + bounds.width / 2,
+      bounds.top + bounds.height / 2,
+    );
+    return topmost === button || button.contains(topmost);
+  });
+  if (!exportButtonIsTopmost) {
+    throw new Error("Export PNG control is occluded by another element");
+  }
+  await exportButton.click();
 
   const exportDialog = page.getByRole("dialog", {
     name: "Export factory",

--- a/ui/packages/components/docs/button.md
+++ b/ui/packages/components/docs/button.md
@@ -63,7 +63,7 @@ actions. It keeps icon-button sizing while applying destructive hover treatment.
 
 `Button` and `ButtonLink` accept `size` values such as `default`, `sm`, `lg`,
 `pill`, `icon`, and `iconPill`. `IconButtonShell` fixes toolbar-friendly
-`h-10 w-10` icon sizing and should be used for compact icon-only controls.
+`h-11 w-11` icon sizing and should be used for compact icon-only controls.
 
 ## Loading buttons
 

--- a/ui/packages/components/src/primitives/icon-button-shell.test.tsx
+++ b/ui/packages/components/src/primitives/icon-button-shell.test.tsx
@@ -27,8 +27,8 @@ describe("IconButtonShell", () => {
 
     const button = screen.getByRole("button", { name: "Refresh jobs" });
 
-    expect(button.className).toContain("h-10");
-    expect(button.className).toContain("w-10");
+    expect(button.className).toContain("h-11");
+    expect(button.className).toContain("w-11");
     expect(button.className).toContain("rounded-lg");
   });
 

--- a/ui/packages/components/src/primitives/icon-button-shell.tsx
+++ b/ui/packages/components/src/primitives/icon-button-shell.tsx
@@ -4,7 +4,7 @@ import { cn } from "../utilities/cn";
 import { Button, type ButtonProps } from "./button";
 
 const ICON_BUTTON_SHELL_BASE_CLASS = "relative shrink-0";
-const ICON_BUTTON_SHELL_SIZE_CLASS = "h-10 w-10 rounded-lg";
+const ICON_BUTTON_SHELL_SIZE_CLASS = "h-11 w-11 rounded-lg";
 const ICON_BUTTON_SHELL_TONE_CLASS = {
   dangerGhost:
     "text-on-surface-subtle hover:border-af-danger-border hover:bg-error-container hover:text-on-error-container",

--- a/ui/src/components/ui/dashboard-action-button.tsx
+++ b/ui/src/components/ui/dashboard-action-button.tsx
@@ -9,7 +9,7 @@ import { cn } from "../../lib/cn";
 const DASHBOARD_ACTION_BUTTON_BASE_CLASS =
   "relative shrink-0 rounded-lg border text-sm font-semibold";
 const DASHBOARD_ACTION_BUTTON_SIZE_CLASS = {
-  text: "min-h-10 px-3.5 py-2",
+  text: "min-h-11 px-3.5 py-2",
 };
 
 export interface DashboardActionButtonProps

--- a/ui/src/components/ui/dashboard-action-controls.stories.tsx
+++ b/ui/src/components/ui/dashboard-action-controls.stories.tsx
@@ -1,49 +1,8 @@
 import { ActionRow } from "@you-agent-factory/components/layout";
 import { expect, within } from "storybook/test";
 import { DashboardActionButton } from "./dashboard-action-button";
+import { assertDashboardActionTargets } from "./dashboard-action-target-measurement";
 import { DashboardStatusPill } from "./dashboard-status-pill";
-
-const DASHBOARD_ACTION_TARGET_MINIMUM = 44;
-
-interface DashboardActionTargetMeasurement {
-  height: number;
-  label: string;
-  width: number;
-}
-
-function measureDashboardActionTargets(
-  root: HTMLElement,
-): DashboardActionTargetMeasurement[] {
-  return Array.from(root.querySelectorAll<HTMLButtonElement>("button")).map(
-    (button) => {
-      const bounds = button.getBoundingClientRect();
-
-      return {
-        height: bounds.height,
-        label:
-          button.getAttribute("aria-label") ??
-          button.textContent?.trim() ??
-          "(unnamed)",
-        width: bounds.width,
-      };
-    },
-  );
-}
-
-function assertDashboardActionTargets(root: HTMLElement): void {
-  const measurements = measureDashboardActionTargets(root);
-  const belowMinimum = measurements.filter(
-    ({ height, width }) =>
-      width < DASHBOARD_ACTION_TARGET_MINIMUM ||
-      height < DASHBOARD_ACTION_TARGET_MINIMUM,
-  );
-
-  if (belowMinimum.length > 0) {
-    throw new Error(
-      `Dashboard action targets below ${DASHBOARD_ACTION_TARGET_MINIMUM}px: ${belowMinimum.length}/${measurements.length} ${JSON.stringify(belowMinimum)}`,
-    );
-  }
-}
 
 function DashboardActionControlsShowcase() {
   return (
@@ -177,6 +136,101 @@ function DashboardActionControlsShowcase() {
             </DashboardStatusPill>
           }
         />
+      </section>
+
+      <section
+        aria-labelledby="dashboard-action-header-context"
+        className="grid gap-3"
+        data-dashboard-action-context="dashboard-header"
+      >
+        <h2
+          className="text-sm font-semibold text-af-text"
+          id="dashboard-action-header-context"
+        >
+          Dashboard header action context
+        </h2>
+        <header className="flex min-w-0 items-center justify-end gap-2 rounded-lg border border-outline bg-surface-container-high p-3">
+          <DashboardActionButton
+            aria-label="Header export"
+            iconOnly
+            type="button"
+          >
+            <span aria-hidden="true">↗</span>
+          </DashboardActionButton>
+          <DashboardActionButton disabled type="button">
+            Header unavailable
+          </DashboardActionButton>
+        </header>
+      </section>
+
+      <section
+        aria-labelledby="dashboard-action-toolbar-context"
+        className="grid gap-3"
+        data-dashboard-action-context="dashboard-toolbar"
+      >
+        <h2
+          className="text-sm font-semibold text-af-text"
+          id="dashboard-action-toolbar-context"
+        >
+          Dashboard toolbar action context
+        </h2>
+        <ActionRow
+          actions={
+            <>
+              <DashboardActionButton
+                aria-label="Toolbar filter"
+                iconOnly
+                type="button"
+              >
+                <span aria-hidden="true">≡</span>
+              </DashboardActionButton>
+              <DashboardActionButton executing type="button">
+                Updating toolbar
+              </DashboardActionButton>
+            </>
+          }
+          aria-label="Dashboard toolbar action context example"
+          statuses={
+            <DashboardStatusPill role="status" tone="info">
+              Toolbar ready
+            </DashboardStatusPill>
+          }
+        />
+      </section>
+
+      <section
+        aria-labelledby="dashboard-action-compact-context"
+        className="grid gap-3"
+        data-dashboard-action-context="compact-dashboard"
+      >
+        <h2
+          className="text-sm font-semibold text-af-text"
+          id="dashboard-action-compact-context"
+        >
+          Compact dashboard card action context
+        </h2>
+        <article className="grid min-w-0 gap-3 rounded-lg border border-outline bg-surface-container-high p-3">
+          <header className="flex min-w-0 items-center justify-between gap-2 border-b border-outline pb-3">
+            <h3 className="m-0 min-w-0 text-sm font-semibold text-on-surface">
+              Compact card
+            </h3>
+            <DashboardActionButton
+              aria-label="Compact card action"
+              iconOnly
+              type="button"
+            >
+              <span aria-hidden="true">⋯</span>
+            </DashboardActionButton>
+          </header>
+          <div className="flex min-w-0 justify-end gap-2">
+            <DashboardActionButton type="button">
+              Open card
+            </DashboardActionButton>
+            <DashboardActionButton disabled type="button">
+              Save card
+            </DashboardActionButton>
+          </div>
+        </article>
       </section>
     </div>
   );

--- a/ui/src/components/ui/dashboard-action-controls.stories.tsx
+++ b/ui/src/components/ui/dashboard-action-controls.stories.tsx
@@ -3,6 +3,48 @@ import { expect, within } from "storybook/test";
 import { DashboardActionButton } from "./dashboard-action-button";
 import { DashboardStatusPill } from "./dashboard-status-pill";
 
+const DASHBOARD_ACTION_TARGET_MINIMUM = 44;
+
+interface DashboardActionTargetMeasurement {
+  height: number;
+  label: string;
+  width: number;
+}
+
+function measureDashboardActionTargets(
+  root: HTMLElement,
+): DashboardActionTargetMeasurement[] {
+  return Array.from(root.querySelectorAll<HTMLButtonElement>("button")).map(
+    (button) => {
+      const bounds = button.getBoundingClientRect();
+
+      return {
+        height: bounds.height,
+        label:
+          button.getAttribute("aria-label") ??
+          button.textContent?.trim() ??
+          "(unnamed)",
+        width: bounds.width,
+      };
+    },
+  );
+}
+
+function assertDashboardActionTargets(root: HTMLElement): void {
+  const measurements = measureDashboardActionTargets(root);
+  const belowMinimum = measurements.filter(
+    ({ height, width }) =>
+      width < DASHBOARD_ACTION_TARGET_MINIMUM ||
+      height < DASHBOARD_ACTION_TARGET_MINIMUM,
+  );
+
+  if (belowMinimum.length > 0) {
+    throw new Error(
+      `Dashboard action targets below ${DASHBOARD_ACTION_TARGET_MINIMUM}px: ${belowMinimum.length}/${measurements.length} ${JSON.stringify(belowMinimum)}`,
+    );
+  }
+}
+
 function DashboardActionControlsShowcase() {
   return (
     <div className="grid gap-6 p-6">
@@ -186,5 +228,7 @@ export const SharedDashboardActionControls = {
     await expect(sections[1]?.getAttribute("data-action-row-section")).toBe(
       "actions",
     );
+
+    assertDashboardActionTargets(canvasElement);
   },
 };

--- a/ui/src/components/ui/dashboard-action-controls.test.tsx
+++ b/ui/src/components/ui/dashboard-action-controls.test.tsx
@@ -39,7 +39,7 @@ describe("DashboardActionButton", () => {
     const button = screen.getByRole("button", { name: "Save changes" });
     expect(button).toHaveAttribute("aria-busy", "true");
     expect(button).toBeDisabled();
-    expect(button.className).toContain("min-h-10");
+    expect(button.className).toContain("min-h-11");
     const spinner = button.querySelector("svg.animate-spin");
     expect(spinner).toBeTruthy();
     expect(spinner?.classList.contains("size-4")).toBe(true);

--- a/ui/src/components/ui/dashboard-action-target-measurement.ts
+++ b/ui/src/components/ui/dashboard-action-target-measurement.ts
@@ -1,0 +1,76 @@
+export const DASHBOARD_ACTION_TARGET_MINIMUM = 44;
+
+export interface DashboardActionTargetMeasurement {
+  bounds: Pick<DOMRect, "bottom" | "left" | "right" | "top">;
+  context: string;
+  height: number;
+  label: string;
+  width: number;
+}
+
+export function measureDashboardActionTargets(
+  root: HTMLElement,
+): DashboardActionTargetMeasurement[] {
+  return Array.from(root.querySelectorAll<HTMLButtonElement>("button")).map(
+    (button) => {
+      const bounds = button.getBoundingClientRect();
+      const context = button.closest<HTMLElement>(
+        "[data-dashboard-action-context]",
+      )?.dataset.dashboardActionContext;
+
+      return {
+        bounds,
+        context: context ?? "unscoped",
+        height: bounds.height,
+        label:
+          button.getAttribute("aria-label") ??
+          button.textContent?.trim() ??
+          "(unnamed)",
+        width: bounds.width,
+      };
+    },
+  );
+}
+
+export function assertDashboardActionTargets(root: HTMLElement): void {
+  const measurements = measureDashboardActionTargets(root);
+  const belowMinimum = measurements.filter(
+    ({ height, width }) =>
+      width < DASHBOARD_ACTION_TARGET_MINIMUM ||
+      height < DASHBOARD_ACTION_TARGET_MINIMUM,
+  );
+
+  if (belowMinimum.length > 0) {
+    throw new Error(
+      `Dashboard action targets below ${DASHBOARD_ACTION_TARGET_MINIMUM}px: ${belowMinimum.length}/${measurements.length} ${JSON.stringify(belowMinimum)}`,
+    );
+  }
+
+  const overlaps = measurements.flatMap((left, leftIndex) =>
+    measurements
+      .slice(leftIndex + 1)
+      .flatMap((right) =>
+        rectanglesOverlap(left.bounds, right.bounds)
+          ? [
+              `${left.context}:${left.label} overlaps ${right.context}:${right.label}`,
+            ]
+          : [],
+      ),
+  );
+
+  if (overlaps.length > 0) {
+    throw new Error(`Dashboard action targets overlap: ${overlaps.join(", ")}`);
+  }
+}
+
+function rectanglesOverlap(
+  left: Pick<DOMRect, "bottom" | "left" | "right" | "top">,
+  right: Pick<DOMRect, "bottom" | "left" | "right" | "top">,
+): boolean {
+  return (
+    left.left < right.right &&
+    left.right > right.left &&
+    left.top < right.bottom &&
+    left.bottom > right.top
+  );
+}

--- a/ui/src/components/ui/dashboard-button-package-migration.test.tsx
+++ b/ui/src/components/ui/dashboard-button-package-migration.test.tsx
@@ -63,8 +63,8 @@ describe("dashboard button package migration", () => {
     expect(loadingIconAction).toBeDisabled();
 
     const iconButton = screen.getByRole("button", { name: "Close" });
-    expect(iconButton.className).toContain("h-10");
-    expect(iconButton.className).toContain("w-10");
+    expect(iconButton.className).toContain("h-11");
+    expect(iconButton.className).toContain("w-11");
   });
 
   it("blocks loading asChild projection and preserves semantic button tones", () => {

--- a/ui/src/features/bento/components/agent-bento.stories.tsx
+++ b/ui/src/features/bento/components/agent-bento.stories.tsx
@@ -1,5 +1,7 @@
-import { expect, userEvent, within } from "storybook/test";
+import { useState } from "react";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 
+import { DashboardActionButton } from "../../../components/ui/dashboard-action-button";
 import { NoSelectionDetailCard } from "../../current-selection/base/components/detail/no-selection-detail-card";
 import { WorkTotalsCard } from "../../work-totals/components/work-totals-card";
 import "../../../styles.css";
@@ -209,5 +211,164 @@ export const ConstrainedWidth = {
     await expect(
       await canvas.findByText("Cards keep their content on the board."),
     ).toBeVisible();
+  },
+};
+
+const COMPACT_OVERFLOW_WIDTHS = [320, 390, 640, 768] as const;
+
+function CompactOverflowRegressionBoard({ width }: { width: number }) {
+  const cardID = `compact-overflow-${width}`;
+
+  return (
+    <div
+      data-testid={`compact-overflow-frame-${width}`}
+      style={{ boxSizing: "border-box", width: `${width}px` }}
+    >
+      <AgentBentoLayout
+        cards={[
+          {
+            children: (
+              <AgentBentoCard
+                headerAction={
+                  <DashboardActionButton
+                    aria-label={`Open compact card ${width}`}
+                    iconOnly
+                    type="button"
+                  >
+                    <span aria-hidden="true">↗</span>
+                  </DashboardActionButton>
+                }
+                title={`Compact card ${width}`}
+              >
+                <p>Compact card content remains readable.</p>
+              </AgentBentoCard>
+            ),
+            id: cardID,
+            widgetType: "compact-card",
+          },
+        ]}
+        initialWidth={width}
+        layout={[
+          { h: 2, id: cardID, widgetType: "compact-card", w: 6, x: 0, y: 0 },
+        ]}
+      />
+    </div>
+  );
+}
+
+export const CompactOverflowRegression = {
+  tags: ["test"],
+  render: () => (
+    <div className="grid gap-4">
+      {COMPACT_OVERFLOW_WIDTHS.map((width) => (
+        <CompactOverflowRegressionBoard key={width} width={width} />
+      ))}
+    </div>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+
+    for (const width of COMPACT_OVERFLOW_WIDTHS) {
+      const frame = canvas.getByTestId(`compact-overflow-frame-${width}`);
+      const board = within(frame).getByRole("region", {
+        name: "you-agent-factory bento board",
+      });
+
+      await expect(board).toBeVisible();
+      await waitFor(() => {
+        expect(board.clientWidth).toBeGreaterThan(0);
+        expect(board.scrollWidth).toBeLessThanOrEqual(board.clientWidth);
+      });
+
+      const item = board.querySelector<HTMLElement>(".react-grid-item");
+      if (!item) {
+        throw new Error(`expected compact ${width}px grid item`);
+      }
+
+      const boardWidth = board.getBoundingClientRect().width;
+      const itemWidth = item.getBoundingClientRect().width;
+      expect(itemWidth).toBeGreaterThanOrEqual(boardWidth - 1);
+      expect(itemWidth).toBeLessThanOrEqual(boardWidth + 1);
+    }
+  },
+};
+
+function ResizeHandleControlIsolationCard() {
+  const [exported, setExported] = useState(false);
+
+  return (
+    <AgentBentoCard bodyScroll={false} title="Resize handle control isolation">
+      <div className="flex h-full min-h-0 items-end justify-end">
+        <DashboardActionButton
+          aria-label="Export PNG"
+          iconOnly
+          onClick={() => setExported(true)}
+          type="button"
+        >
+          <span aria-hidden="true">↗</span>
+        </DashboardActionButton>
+        {exported ? <span className="sr-only">Export complete</span> : null}
+      </div>
+    </AgentBentoCard>
+  );
+}
+
+export const ResizeHandleControlIsolation = {
+  tags: ["test"],
+  render: () => (
+    <div style={{ maxWidth: "720px", padding: "1rem", width: "100%" }}>
+      <AgentBentoLayout
+        cards={[
+          {
+            children: <ResizeHandleControlIsolationCard />,
+            id: "resize-handle-control-isolation",
+            widgetType: "resize-handle-control-isolation",
+          },
+        ]}
+        initialWidth={720}
+        layout={[
+          {
+            h: 2,
+            id: "resize-handle-control-isolation",
+            widgetType: "resize-handle-control-isolation",
+            w: 12,
+            x: 0,
+            y: 0,
+          },
+        ]}
+        responsiveMode="interactive"
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const exportButton = await canvas.findByRole("button", {
+      name: "Export PNG",
+    });
+    const resizeHandle = canvasElement.querySelector<HTMLElement>(
+      ".react-resizable-handle-se",
+    );
+
+    if (!resizeHandle) {
+      throw new Error("expected southeast bento resize handle");
+    }
+
+    const exportBounds = exportButton.getBoundingClientRect();
+    const topmost = document.elementFromPoint(
+      exportBounds.left + exportBounds.width / 2,
+      exportBounds.top + exportBounds.height / 2,
+    );
+    expect(topmost === exportButton || exportButton.contains(topmost)).toBe(
+      true,
+    );
+    expect(resizeHandle.getBoundingClientRect().width).toBeGreaterThanOrEqual(
+      44,
+    );
+    expect(resizeHandle.getBoundingClientRect().height).toBeGreaterThanOrEqual(
+      44,
+    );
+
+    await userEvent.click(exportButton);
+    await expect(await canvas.findByText("Export complete")).toBeVisible();
   },
 };

--- a/ui/src/features/bento/components/agent-bento.test.tsx
+++ b/ui/src/features/bento/components/agent-bento.test.tsx
@@ -132,8 +132,11 @@ describe("AgentBentoLayout", () => {
     expect(activityHeader?.getAttribute("data-bento-drag-handle")).toBe("true");
     expect(activityHeader?.className).toContain("cursor-grab");
     expect(
-      screen.queryByRole("button", { name: "Move Current activity" }),
-    ).toBeNull();
+      screen.getByRole("button", { name: "Move Current activity card" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Resize Current activity card" }),
+    ).toBeTruthy();
   });
 
   it("lets the board and grid grow without creating a vertical scroll container", () => {
@@ -291,6 +294,95 @@ describe("AgentBentoLayout", () => {
     expect(
       screen.getByText("Active workstation graph goes here."),
     ).toBeTruthy();
+  });
+
+  it("moves and resizes the focused card with keyboard input through the persistence seam", () => {
+    const onLayoutChange = vi.fn();
+    renderBentoBoard(onLayoutChange);
+
+    const moveButton = screen.getByRole("button", {
+      name: "Move Current activity card",
+    });
+    const instructionsID = moveButton.getAttribute("aria-describedby");
+
+    expect(document.activeElement).not.toBe(moveButton);
+    moveButton.focus();
+    expect(document.activeElement).toBe(moveButton);
+    expect(moveButton.className).toContain("focus-visible:ring-2");
+    expect(instructionsID).toBeTruthy();
+    expect(
+      document.getElementById(instructionsID ?? "")?.textContent,
+    ).toContain("Move mode");
+
+    fireEvent.keyDown(moveButton, { key: "Enter" });
+    fireEvent.keyDown(moveButton, { key: "ArrowRight" });
+
+    expect(onLayoutChange).not.toHaveBeenCalled();
+    expect(
+      within(
+        screen.getByRole("article", { name: "Current activity" }),
+      ).getByRole("status").textContent,
+    ).toContain("column 2");
+
+    fireEvent.keyDown(moveButton, { key: "Enter" });
+    expect(onLayoutChange).toHaveBeenCalledTimes(1);
+    expect(onLayoutChange).toHaveBeenLastCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "activity", x: 1 }),
+      ]),
+    );
+
+    const resizeButton = screen.getByRole("button", {
+      name: "Resize Current activity card",
+    });
+    expect(
+      document.getElementById(
+        resizeButton.getAttribute("aria-describedby") ?? "",
+      )?.textContent,
+    ).toContain("Resize mode");
+    resizeButton.focus();
+    fireEvent.keyDown(resizeButton, { key: "Enter" });
+    fireEvent.keyDown(resizeButton, { key: "ArrowRight" });
+
+    expect(onLayoutChange).toHaveBeenCalledTimes(1);
+    expect(
+      within(
+        screen.getByRole("article", { name: "Current activity" }),
+      ).getByRole("status").textContent,
+    ).toContain("columns by");
+
+    fireEvent.keyDown(resizeButton, { key: "Enter" });
+    expect(onLayoutChange).toHaveBeenCalledTimes(2);
+    expect(onLayoutChange).toHaveBeenLastCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "activity", w: 7 }),
+      ]),
+    );
+  });
+
+  it("announces a rejected boundary operation and restores an uncommitted preview on Escape", () => {
+    const onLayoutChange = vi.fn();
+    renderBentoBoard(onLayoutChange);
+
+    const moveButton = screen.getByRole("button", {
+      name: "Move Current activity card",
+    });
+    moveButton.focus();
+    fireEvent.keyDown(moveButton, { key: "Enter" });
+    fireEvent.keyDown(moveButton, { key: "ArrowLeft" });
+
+    expect(onLayoutChange).not.toHaveBeenCalled();
+    expect(
+      within(
+        screen.getByRole("article", { name: "Current activity" }),
+      ).getByRole("status").textContent,
+    ).toContain("No move change was possible");
+
+    fireEvent.keyDown(moveButton, { key: "ArrowRight" });
+    fireEvent.keyDown(moveButton, { key: "Escape" });
+
+    expect(onLayoutChange).not.toHaveBeenCalled();
+    expect(moveButton.getAttribute("aria-pressed")).toBe("false");
   });
 
   it("renders right, bottom, and bottom-right resize handles for grid cards", () => {

--- a/ui/src/features/bento/components/agent-bento.test.tsx
+++ b/ui/src/features/bento/components/agent-bento.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -80,6 +81,120 @@ function expectNoVerticalScrollContainer(element: HTMLElement) {
   expect(element.className).not.toMatch(/overflow-y-(auto|scroll)/);
   expect(window.getComputedStyle(element).overflowY).not.toMatch(
     /^(auto|scroll)$/,
+  );
+}
+
+function installMeasuredBoardWidth(initialWidth: number) {
+  const previousResizeObserver = globalThis.ResizeObserver;
+  let measuredWidth = initialWidth;
+  const observers: ControlledResizeObserver[] = [];
+
+  class ControlledResizeObserver {
+    private readonly callback: ResizeObserverCallback;
+    private target: Element | null = null;
+
+    public constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+      observers.push(this);
+    }
+
+    public disconnect(): void {
+      this.target = null;
+    }
+
+    public observe(target: Element): void {
+      this.target = target;
+      this.emit();
+    }
+
+    public unobserve(): void {
+      this.target = null;
+    }
+
+    public emit(): void {
+      if (!this.target) {
+        return;
+      }
+
+      this.callback(
+        [
+          {
+            contentRect: { width: measuredWidth } as DOMRectReadOnly,
+            target: this.target,
+          } as ResizeObserverEntry,
+        ],
+        this as unknown as ResizeObserver,
+      );
+    }
+  }
+
+  globalThis.ResizeObserver =
+    ControlledResizeObserver as unknown as typeof ResizeObserver;
+
+  return {
+    restore() {
+      globalThis.ResizeObserver = previousResizeObserver;
+      observers.length = 0;
+    },
+    setWidth(width: number) {
+      measuredWidth = width;
+      for (const observer of observers) {
+        observer.emit();
+      }
+    },
+  };
+}
+
+function renderCompactBoard(onLayoutChange = vi.fn()) {
+  return render(
+    <AgentBentoLayout
+      cards={[
+        {
+          id: "activity",
+          widgetType: "activity",
+          children: (
+            <AgentBentoCard
+              headerAction={<button type="button">Open activity</button>}
+              title="Current activity"
+            >
+              <p>Active workstation graph goes here.</p>
+            </AgentBentoCard>
+          ),
+        },
+        {
+          id: "trace",
+          widgetType: "trace",
+          children: (
+            <AgentBentoCard title="Trace grid">
+              <p>Trace dispatches stay visible.</p>
+            </AgentBentoCard>
+          ),
+        },
+        {
+          id: "terminal",
+          widgetType: "terminal",
+          children: (
+            <AgentBentoCard title="Terminal work">
+              <p>Completed work remains available.</p>
+            </AgentBentoCard>
+          ),
+        },
+      ]}
+      initialWidth={768}
+      layout={[
+        { h: 2, id: "activity", widgetType: "activity", w: 4, x: 0, y: 5 },
+        { h: 3, id: "trace", widgetType: "trace", w: 3, x: 6, y: 0 },
+        {
+          h: 1,
+          id: "terminal",
+          widgetType: "terminal",
+          w: 6,
+          x: 0,
+          y: 0,
+        },
+      ]}
+      onLayoutChange={onLayoutChange}
+    />,
   );
 }
 
@@ -439,6 +554,100 @@ describe("AgentBentoLayout", () => {
         y: 5,
       },
     ]);
+  });
+
+  it.each([320, 390, 640, 768])(
+    "projects a %spx board into stable full-width order without horizontal overflow",
+    async (boardWidth) => {
+      const measuredBoard = installMeasuredBoardWidth(boardWidth);
+
+      try {
+        renderCompactBoard();
+
+        const board = screen.getByRole("region", {
+          name: "you-agent-factory bento board",
+        });
+
+        await waitFor(() => {
+          const items = [
+            ...board.querySelectorAll<HTMLElement>(".react-grid-item"),
+          ];
+
+          expect(items).toHaveLength(3);
+          expect(items.map((item) => item.dataset.bentoCardId)).toEqual([
+            "terminal",
+            "trace",
+            "activity",
+          ]);
+
+          for (const item of items) {
+            expect(Number.parseFloat(item.style.width)).toBeCloseTo(boardWidth);
+            expect(item.style.transform).toMatch(/translate\(0px,[-\d.]+px\)/);
+            expect(item.classList.contains("react-draggable")).toBe(false);
+            expect(item.classList.contains("react-resizable-hide")).toBe(true);
+          }
+        });
+
+        expect(
+          within(
+            screen.getByRole("article", { name: "Current activity" }),
+          ).getByRole("button", { name: "Open activity" }),
+        ).toBeTruthy();
+        expect(
+          screen.getByText("Completed work remains available."),
+        ).toBeTruthy();
+      } finally {
+        measuredBoard.restore();
+      }
+    },
+  );
+
+  it("does not persist compact geometry and restores the canonical layout above the breakpoint", async () => {
+    const measuredBoard = installMeasuredBoardWidth(768);
+    const onLayoutChange = vi.fn();
+
+    try {
+      renderCompactBoard(onLayoutChange);
+
+      const board = screen.getByRole("region", {
+        name: "you-agent-factory bento board",
+      });
+      const activityItem = board.querySelector<HTMLElement>(
+        '[data-bento-card-id="activity"]',
+      );
+      if (!activityItem) {
+        throw new Error("expected the activity card to render");
+      }
+
+      const canonicalSignature = activityItem.dataset.layoutSignature;
+      await waitFor(() => {
+        expect(Number.parseFloat(activityItem.style.width)).toBeCloseTo(768);
+      });
+
+      const compactWidth = activityItem.style.width;
+      expect(onLayoutChange).not.toHaveBeenCalled();
+
+      await act(async () => {
+        measuredBoard.setWidth(1024);
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(activityItem.style.width).not.toBe(compactWidth);
+      });
+
+      expect(Number.parseFloat(activityItem.style.width)).toBeLessThan(768);
+      expect(activityItem.dataset.layoutSignature).toBe(canonicalSignature);
+      expect(onLayoutChange).not.toHaveBeenCalled();
+      expect(board.querySelector(".react-resizable-handle-e")).toBeTruthy();
+      expect(
+        within(
+          screen.getByRole("article", { name: "Current activity" }),
+        ).getByRole("button", { name: "Move Current activity card" }),
+      ).toBeTruthy();
+    } finally {
+      measuredBoard.restore();
+    }
   });
 
   it("renders a localized accessible name for the movable board", () => {

--- a/ui/src/features/bento/components/agent-bento.test.tsx
+++ b/ui/src/features/bento/components/agent-bento.test.tsx
@@ -1,5 +1,6 @@
 import {
   act,
+  createEvent,
   fireEvent,
   render,
   screen,
@@ -580,6 +581,65 @@ describe("AgentBentoLayout", () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
+  it("leaves card-body touch scrolling to the scroll viewport", () => {
+    const onLayoutChange = vi.fn();
+    render(
+      <AgentBentoLayout
+        cards={[
+          {
+            id: "activity",
+            widgetType: "activity",
+            children: (
+              <AgentBentoCard
+                bodyProps={{ "data-testid": "activity-body" }}
+                title="Current activity"
+              >
+                <div>
+                  {Array.from(
+                    { length: 12 },
+                    (_, index) => `Scrollable activity row ${index + 1}`,
+                  ).map((row) => (
+                    <p key={row}>{row}</p>
+                  ))}
+                </div>
+              </AgentBentoCard>
+            ),
+          },
+        ]}
+        initialWidth={960}
+        layout={[
+          { h: 2, id: "activity", widgetType: "activity", w: 6, x: 0, y: 0 },
+        ]}
+        onLayoutChange={onLayoutChange}
+      />,
+    );
+
+    const body = screen.getByTestId("activity-body");
+    const start = createTouch(6, 120, 120);
+    const end = createTouch(6, 120, 220);
+    const touchStart = createEvent.touchStart(body, {
+      changedTouches: [start],
+      touches: [start],
+    });
+    const touchMove = createEvent.touchMove(document, {
+      changedTouches: [end],
+      touches: [end],
+    });
+    const touchEnd = createEvent.touchEnd(document, {
+      changedTouches: [end],
+      touches: [],
+    });
+
+    fireEvent(body, touchStart);
+    fireEvent(document, touchMove);
+    fireEvent(document, touchEnd);
+
+    expect(touchStart.defaultPrevented).toBe(false);
+    expect(touchMove.defaultPrevented).toBe(false);
+    expect(touchEnd.defaultPrevented).toBe(false);
+    expect(onLayoutChange).not.toHaveBeenCalled();
+  });
+
   it("cancels touch-pointer gestures without persisting a preview", async () => {
     const onLayoutChange = vi.fn();
     renderBentoBoard(onLayoutChange);
@@ -797,6 +857,8 @@ describe("AgentBentoLayout", () => {
             expect(item.classList.contains("react-draggable")).toBe(false);
             expect(item.classList.contains("react-resizable-hide")).toBe(true);
           }
+
+          expect(board.scrollWidth).toBeLessThanOrEqual(board.clientWidth);
         });
 
         expect(

--- a/ui/src/features/bento/components/agent-bento.test.tsx
+++ b/ui/src/features/bento/components/agent-bento.test.tsx
@@ -84,6 +84,10 @@ function expectNoVerticalScrollContainer(element: HTMLElement) {
   );
 }
 
+function createTouch(identifier: number, clientX: number, clientY: number) {
+  return { clientX, clientY, identifier };
+}
+
 function installMeasuredBoardWidth(initialWidth: number) {
   const previousResizeObserver = globalThis.ResizeObserver;
   let measuredWidth = initialWidth;
@@ -411,6 +415,206 @@ describe("AgentBentoLayout", () => {
     ).toBeTruthy();
   });
 
+  it("moves a card with touch and commits through the canonical layout seam", async () => {
+    const onLayoutChange = vi.fn();
+    renderBentoBoard(onLayoutChange);
+
+    const activityItem = getGridItem("Current activity");
+    const dragHandle = within(activityItem).getByRole("heading", {
+      name: "Current activity",
+    });
+    const start = createTouch(1, 120, 40);
+    const end = createTouch(1, 220, 40);
+
+    fireEvent.touchStart(dragHandle, {
+      changedTouches: [start],
+      touches: [start],
+    });
+    fireEvent.touchMove(document, {
+      changedTouches: [end],
+      touches: [end],
+    });
+    fireEvent.touchEnd(document, {
+      changedTouches: [end],
+      touches: [],
+    });
+
+    await waitFor(() => {
+      expect(onLayoutChange).toHaveBeenCalledTimes(1);
+    });
+    expect(onLayoutChange).toHaveBeenLastCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "activity", x: 1, y: 0 }),
+      ]),
+    );
+  });
+
+  it("resizes a card with touch through the same canonical layout seam", async () => {
+    const onLayoutChange = vi.fn();
+    renderBentoBoard(onLayoutChange);
+
+    const activityItem = getGridItem("Current activity");
+    const resizeHandle = activityItem.querySelector(
+      "[data-bento-touch-resize-handle='e']",
+    );
+    if (!(resizeHandle instanceof HTMLElement)) {
+      throw new Error("expected the activity card east resize handle");
+    }
+
+    const start = createTouch(2, 520, 120);
+    const end = createTouch(2, 620, 120);
+    fireEvent.touchStart(resizeHandle, {
+      changedTouches: [start],
+      touches: [start],
+    });
+    fireEvent.touchMove(document, {
+      changedTouches: [end],
+      touches: [end],
+    });
+    fireEvent.touchEnd(document, {
+      changedTouches: [end],
+      touches: [],
+    });
+
+    await waitFor(() => {
+      expect(onLayoutChange).toHaveBeenCalledTimes(1);
+    });
+    expect(onLayoutChange).toHaveBeenLastCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "activity", w: 7 }),
+      ]),
+    );
+  });
+
+  it("restores the stored layout when a touch gesture is cancelled", async () => {
+    const onLayoutChange = vi.fn();
+    renderBentoBoard(onLayoutChange);
+
+    const board = screen.getByRole("region", {
+      name: "you-agent-factory bento board",
+    });
+    const activityItem = getGridItem("Current activity");
+    const initialSignature = activityItem.dataset.layoutSignature;
+    const dragHandle = within(activityItem).getByRole("heading", {
+      name: "Current activity",
+    });
+    const start = createTouch(3, 120, 40);
+    const moved = createTouch(3, 220, 40);
+
+    fireEvent.touchStart(dragHandle, {
+      changedTouches: [start],
+      touches: [start],
+    });
+    fireEvent.touchMove(document, {
+      changedTouches: [moved],
+      touches: [moved],
+    });
+    fireEvent.touchCancel(document, {
+      changedTouches: [moved],
+      touches: [],
+    });
+
+    await waitFor(() => {
+      expect(activityItem.dataset.layoutSignature).toBe(initialSignature);
+    });
+    expect(onLayoutChange).not.toHaveBeenCalled();
+    expect(board.querySelector(".react-draggable-dragging")).toBeNull();
+  });
+
+  it("keeps dashboard controls tappable and ignores their touch gestures", () => {
+    const onLayoutChange = vi.fn();
+    const onClick = vi.fn();
+    render(
+      <AgentBentoLayout
+        cards={[
+          {
+            id: "activity",
+            widgetType: "activity",
+            children: (
+              <AgentBentoCard
+                headerAction={
+                  <button onClick={onClick} type="button">
+                    Open activity
+                  </button>
+                }
+                title="Current activity"
+              >
+                <p>Active workstation graph goes here.</p>
+              </AgentBentoCard>
+            ),
+          },
+        ]}
+        initialWidth={960}
+        layout={[
+          {
+            h: 2,
+            id: "activity",
+            widgetType: "activity",
+            w: 6,
+            x: 0,
+            y: 0,
+          },
+        ]}
+        onLayoutChange={onLayoutChange}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Open activity" });
+    const start = createTouch(4, 120, 40);
+    const end = createTouch(4, 220, 40);
+    fireEvent.touchStart(button, {
+      changedTouches: [start],
+      touches: [start],
+    });
+    fireEvent.touchMove(document, {
+      changedTouches: [end],
+      touches: [end],
+    });
+    fireEvent.touchEnd(document, {
+      changedTouches: [end],
+      touches: [],
+    });
+    fireEvent.click(button);
+
+    expect(onLayoutChange).not.toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels touch-pointer gestures without persisting a preview", async () => {
+    const onLayoutChange = vi.fn();
+    renderBentoBoard(onLayoutChange);
+
+    const activityItem = getGridItem("Current activity");
+    const initialSignature = activityItem.dataset.layoutSignature;
+    const dragHandle = within(activityItem).getByRole("heading", {
+      name: "Current activity",
+    });
+
+    fireEvent.pointerDown(dragHandle, {
+      clientX: 120,
+      clientY: 40,
+      pointerId: 5,
+      pointerType: "touch",
+    });
+    fireEvent.pointerMove(document, {
+      clientX: 220,
+      clientY: 40,
+      pointerId: 5,
+      pointerType: "touch",
+    });
+    fireEvent.pointerCancel(document, {
+      clientX: 220,
+      clientY: 40,
+      pointerId: 5,
+      pointerType: "touch",
+    });
+
+    await waitFor(() => {
+      expect(activityItem.dataset.layoutSignature).toBe(initialSignature);
+    });
+    expect(onLayoutChange).not.toHaveBeenCalled();
+  });
+
   it("moves and resizes the focused card with keyboard input through the persistence seam", () => {
     const onLayoutChange = vi.fn();
     renderBentoBoard(onLayoutChange);
@@ -509,6 +713,13 @@ describe("AgentBentoLayout", () => {
       expect(gridItem.querySelector(".react-resizable-handle-e")).toBeTruthy();
       expect(gridItem.querySelector(".react-resizable-handle-s")).toBeTruthy();
       expect(gridItem.querySelector(".react-resizable-handle-se")).toBeTruthy();
+      for (const handle of gridItem.querySelectorAll<HTMLElement>(
+        "[data-bento-touch-resize-handle]",
+      )) {
+        expect(handle.style.width).toBe("44px");
+        expect(handle.style.height).toBe("44px");
+        expect(handle.style.touchAction).toBe("none");
+      }
     }
   });
 

--- a/ui/src/features/bento/components/agent-bento.tsx
+++ b/ui/src/features/bento/components/agent-bento.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { Layout, LayoutItem } from "react-grid-layout";
 import { GridLayout, useContainerWidth } from "react-grid-layout";
 import "react-grid-layout/css/styles.css";
@@ -69,9 +69,8 @@ export interface AgentBentoCardHeaderProps {
 
 const DEFAULT_BENTO_WIDTH = 1180;
 const BENTO_COLUMNS = 12;
-const BENTO_INTERACTION_BREAKPOINT_PX = 768;
 export const BENTO_ROW_HEIGHT = 72;
-const BENTO_COMPACT_BREAKPOINT_PX = 640;
+const BENTO_COMPACT_BREAKPOINT_PX = 768;
 export const BENTO_MARGIN = [16, 16] as const;
 
 export function getBentoGridItemHeightPx(h: number): number {
@@ -211,6 +210,7 @@ export function AgentBentoLayout({
     [layout],
   );
   const [currentLayout, setCurrentLayout] = useState<Layout>(normalizedLayout);
+  const isGridInteractionActiveRef = useRef(false);
   const { containerRef, width } = useContainerWidth({ initialWidth });
   const renderedLayout = hasSameLayoutItems(currentLayout, normalizedLayout)
     ? currentLayout
@@ -229,10 +229,10 @@ export function AgentBentoLayout({
   const renderedWidth = Math.max(measuredWidth, 320);
   const usesCompactLayout =
     responsiveMode === "adaptive" &&
-    renderedWidth < BENTO_COMPACT_BREAKPOINT_PX;
+    renderedWidth <= BENTO_COMPACT_BREAKPOINT_PX;
   const allowsInteractiveGrid =
     responsiveMode === "interactive" ||
-    (renderedWidth > BENTO_INTERACTION_BREAKPOINT_PX && !usesCompactLayout);
+    (renderedWidth > BENTO_COMPACT_BREAKPOINT_PX && !usesCompactLayout);
 
   const previewLayoutChange = (nextLayout: Layout) => {
     if (allowsInteractiveGrid) {
@@ -250,7 +250,7 @@ export function AgentBentoLayout({
   };
 
   const handleLayoutChange = (nextLayout: Layout) => {
-    if (!allowsInteractiveGrid) {
+    if (!allowsInteractiveGrid || !isGridInteractionActiveRef.current) {
       return;
     }
 
@@ -260,7 +260,20 @@ export function AgentBentoLayout({
       return;
     }
 
-    commitLayoutChange(nextLayout);
+    setCurrentLayout(nextLayout);
+  };
+
+  const handleGridInteractionStart = () => {
+    isGridInteractionActiveRef.current = allowsInteractiveGrid;
+  };
+
+  const handleGridInteractionStop = (nextLayout: Layout) => {
+    const wasActive = isGridInteractionActiveRef.current;
+    isGridInteractionActiveRef.current = false;
+
+    if (wasActive) {
+      commitLayoutChange(nextLayout);
+    }
   };
 
   const layoutClassName = cn(BENTO_LAYOUT_CLASS, className);
@@ -269,6 +282,17 @@ export function AgentBentoLayout({
     : allowsInteractiveGrid
       ? renderedLayout
       : toNonInteractiveGridLayout(renderedLayout);
+  const cardsForRender = usesCompactLayout
+    ? [...cards].sort((left, right) => {
+        const leftIndex = effectiveLayout.findIndex(
+          (item) => item.i === left.id,
+        );
+        const rightIndex = effectiveLayout.findIndex(
+          (item) => item.i === right.id,
+        );
+        return leftIndex - rightIndex;
+      })
+    : cards;
 
   return (
     <section
@@ -291,14 +315,18 @@ export function AgentBentoLayout({
           rowHeight: BENTO_ROW_HEIGHT,
         }}
         layout={effectiveLayout}
+        onDragStart={handleGridInteractionStart}
+        onDragStop={handleGridInteractionStop}
         onLayoutChange={handleLayoutChange}
+        onResizeStart={handleGridInteractionStart}
+        onResizeStop={handleGridInteractionStop}
         resizeConfig={{
           enabled: allowsInteractiveGrid,
           handles: [...BENTO_RESIZE_HANDLES],
         }}
         width={renderedWidth}
       >
-        {cards.map((card) => (
+        {cardsForRender.map((card) => (
           <div
             className="min-w-0 overflow-visible"
             data-bento-card-id={card.widgetType}

--- a/ui/src/features/bento/components/agent-bento.tsx
+++ b/ui/src/features/bento/components/agent-bento.tsx
@@ -12,6 +12,7 @@ import { cn } from "../../../lib/cn";
 import type { DashboardCardAsyncState } from "../../dashboard/lib/dashboard-card-state";
 import { getAgentBentoMessages } from "../messages/agent-bento";
 import { DashboardCardStateBanner } from "./card-state/dashboard-card-state-banner";
+import { DashboardCardErrorBoundary } from "./dashboard-card-error-boundary";
 import {
   DashboardLayoutKeyboardContext,
   type DashboardLayoutKeyboardContextValue,
@@ -354,17 +355,21 @@ export function AgentBentoLayout({
                   : null
               }
             >
-              {card.cardState ? (
-                <div className="flex h-full min-w-0 flex-col gap-1">
-                  <DashboardCardStateBanner
-                    locale={locale}
-                    state={card.cardState}
-                  />
-                  <div className="min-h-0 min-w-0 flex-1">{card.children}</div>
-                </div>
-              ) : (
-                card.children
-              )}
+              <DashboardCardErrorBoundary locale={locale}>
+                {card.cardState ? (
+                  <div className="flex h-full min-w-0 flex-col gap-1">
+                    <DashboardCardStateBanner
+                      locale={locale}
+                      state={card.cardState}
+                    />
+                    <div className="min-h-0 min-w-0 flex-1">
+                      {card.children}
+                    </div>
+                  </div>
+                ) : (
+                  card.children
+                )}
+              </DashboardCardErrorBoundary>
             </DashboardLayoutKeyboardContext.Provider>
           </div>
         ))}

--- a/ui/src/features/bento/components/agent-bento.tsx
+++ b/ui/src/features/bento/components/agent-bento.tsx
@@ -10,14 +10,16 @@ import { Heading } from "@you-agent-factory/components/primitives";
 import { DashboardPanelShell } from "../../../components/ui/dashboard-shell";
 import { cn } from "../../../lib/cn";
 import type { DashboardCardAsyncState } from "../../dashboard/lib/dashboard-card-state";
+import { useDashboardLayoutTouch } from "../hooks/touch/dashboardLayoutTouch";
 import { getAgentBentoMessages } from "../messages/agent-bento";
+import { DashboardCardErrorBoundary } from "./card-error/dashboard-card-error-boundary";
 import { DashboardCardStateBanner } from "./card-state/dashboard-card-state-banner";
-import { DashboardCardErrorBoundary } from "./dashboard-card-error-boundary";
 import {
   DashboardLayoutKeyboardContext,
   type DashboardLayoutKeyboardContextValue,
   DashboardLayoutKeyboardControls,
 } from "./keyboard/dashboard-layout-keyboard-controls";
+import { renderBentoResizeHandle } from "./resize/bento-resize-handle";
 
 export interface AgentBentoLayoutItem {
   h: number;
@@ -283,6 +285,16 @@ export function AgentBentoLayout({
     : allowsInteractiveGrid
       ? renderedLayout
       : toNonInteractiveGridLayout(renderedLayout);
+  const touchHandlers = useDashboardLayoutTouch({
+    columns: BENTO_COLUMNS,
+    enabled: allowsInteractiveGrid,
+    layout: renderedLayout,
+    margin: BENTO_MARGIN,
+    onCommitLayout: commitLayoutChange,
+    onPreviewLayout: previewLayoutChange,
+    rowHeight: BENTO_ROW_HEIGHT,
+    width: renderedWidth,
+  });
   const cardsForRender = usesCompactLayout
     ? [...cards].sort((left, right) => {
         const leftIndex = effectiveLayout.findIndex(
@@ -299,6 +311,8 @@ export function AgentBentoLayout({
     <section
       aria-label={messages.boardLabel}
       className={layoutClassName}
+      onPointerDownCapture={touchHandlers.onPointerDownCapture}
+      onTouchStartCapture={touchHandlers.onTouchStartCapture}
       ref={containerRef}
     >
       <GridLayout
@@ -323,6 +337,7 @@ export function AgentBentoLayout({
         onResizeStop={handleGridInteractionStop}
         resizeConfig={{
           enabled: allowsInteractiveGrid,
+          handleComponent: renderBentoResizeHandle,
           handles: [...BENTO_RESIZE_HANDLES],
         }}
         width={renderedWidth}
@@ -451,6 +466,7 @@ export function AgentBentoCardHeader({
       className={cn(
         BENTO_CARD_HEADER_CLASS,
         compactChrome && BENTO_CARD_HEADER_COMPACT_CLASS,
+        "touch-none",
       )}
       data-bento-drag-handle="true"
     >

--- a/ui/src/features/bento/components/agent-bento.tsx
+++ b/ui/src/features/bento/components/agent-bento.tsx
@@ -85,7 +85,8 @@ const BENTO_DRAG_HANDLE_SELECTOR = "[data-bento-drag-handle='true']";
 const BENTO_DRAG_CANCEL_SELECTOR =
   "button,a,input,select,textarea,.react-resizable-handle";
 const BENTO_LAYOUT_CLASS = "min-w-0 w-full overflow-x-clip";
-const BENTO_CARD_CLASS = "flex h-full min-w-0 flex-col";
+const BENTO_CARD_CLASS =
+  "flex h-full min-w-0 flex-col [&_a]:relative [&_a]:z-20 [&_button]:relative [&_button]:z-20 [&_input]:relative [&_input]:z-20 [&_select]:relative [&_select]:z-20 [&_textarea]:relative [&_textarea]:z-20";
 const BENTO_CARD_SCROLL_CLASS = "overflow-hidden";
 const BENTO_CARD_HEADER_CLASS =
   "relative z-10 flex min-h-13 shrink-0 cursor-grab items-center justify-between gap-3 border-b border-outline bg-surface-container-high px-3.5 py-3 active:cursor-grabbing";

--- a/ui/src/features/bento/components/agent-bento.tsx
+++ b/ui/src/features/bento/components/agent-bento.tsx
@@ -12,6 +12,11 @@ import { cn } from "../../../lib/cn";
 import type { DashboardCardAsyncState } from "../../dashboard/lib/dashboard-card-state";
 import { getAgentBentoMessages } from "../messages/agent-bento";
 import { DashboardCardStateBanner } from "./card-state/dashboard-card-state-banner";
+import {
+  DashboardLayoutKeyboardContext,
+  type DashboardLayoutKeyboardContextValue,
+  DashboardLayoutKeyboardControls,
+} from "./keyboard/dashboard-layout-keyboard-controls";
 
 export interface AgentBentoLayoutItem {
   h: number;
@@ -189,6 +194,7 @@ function toNonInteractiveGridLayout(layout: Layout): Layout {
   }));
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: the bento layout keeps grid projection, pointer callbacks, and per-card keyboard context synchronized.
 export function AgentBentoLayout({
   cards,
   className = "",
@@ -228,6 +234,21 @@ export function AgentBentoLayout({
     responsiveMode === "interactive" ||
     (renderedWidth > BENTO_INTERACTION_BREAKPOINT_PX && !usesCompactLayout);
 
+  const previewLayoutChange = (nextLayout: Layout) => {
+    if (allowsInteractiveGrid) {
+      setCurrentLayout(nextLayout);
+    }
+  };
+
+  const commitLayoutChange = (nextLayout: Layout) => {
+    if (!allowsInteractiveGrid) {
+      return;
+    }
+
+    setCurrentLayout(nextLayout);
+    onLayoutChange?.(toBentoLayout(nextLayout, layoutByID));
+  };
+
   const handleLayoutChange = (nextLayout: Layout) => {
     if (!allowsInteractiveGrid) {
       return;
@@ -239,8 +260,7 @@ export function AgentBentoLayout({
       return;
     }
 
-    setCurrentLayout(nextLayout);
-    onLayoutChange?.(toBentoLayout(nextLayout, layoutByID));
+    commitLayoutChange(nextLayout);
   };
 
   const layoutClassName = cn(BENTO_LAYOUT_CLASS, className);
@@ -291,17 +311,33 @@ export function AgentBentoLayout({
             id={card.id}
             key={card.id}
           >
-            {card.cardState ? (
-              <div className="flex h-full min-w-0 flex-col gap-1">
-                <DashboardCardStateBanner
-                  locale={locale}
-                  state={card.cardState}
-                />
-                <div className="min-h-0 min-w-0 flex-1">{card.children}</div>
-              </div>
-            ) : (
-              card.children
-            )}
+            <DashboardLayoutKeyboardContext.Provider
+              value={
+                allowsInteractiveGrid
+                  ? ({
+                      columns: BENTO_COLUMNS,
+                      enabled: true,
+                      itemID: card.id,
+                      layout: renderedLayout,
+                      messages,
+                      onCommitLayout: commitLayoutChange,
+                      onPreviewLayout: previewLayoutChange,
+                    } satisfies DashboardLayoutKeyboardContextValue)
+                  : null
+              }
+            >
+              {card.cardState ? (
+                <div className="flex h-full min-w-0 flex-col gap-1">
+                  <DashboardCardStateBanner
+                    locale={locale}
+                    state={card.cardState}
+                  />
+                  <div className="min-h-0 min-w-0 flex-1">{card.children}</div>
+                </div>
+              ) : (
+                card.children
+              )}
+            </DashboardLayoutKeyboardContext.Provider>
           </div>
         ))}
       </GridLayout>
@@ -399,6 +435,7 @@ export function AgentBentoCardHeader({
           compactChrome && BENTO_CARD_HEADER_TOOLS_COMPACT_CLASS,
         )}
       >
+        <DashboardLayoutKeyboardControls title={title} />
         {headerAction ?? (
           <span
             aria-hidden="true"

--- a/ui/src/features/bento/components/card-error/dashboard-card-error-boundary.test.tsx
+++ b/ui/src/features/bento/components/card-error/dashboard-card-error-boundary.test.tsx
@@ -9,12 +9,12 @@ import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
+import { installDashboardBrowserTestShims } from "../../../../components/dashboard/test-browser-shims";
 import {
   AgentBentoCard,
   AgentBentoLayout,
   type AgentBentoLayoutCard,
-} from "./agent-bento";
+} from "../agent-bento";
 
 const layout = [
   { h: 2, id: "broken", widgetType: "broken", w: 6, x: 0, y: 0 },

--- a/ui/src/features/bento/components/card-error/dashboard-card-error-boundary.tsx
+++ b/ui/src/features/bento/components/card-error/dashboard-card-error-boundary.tsx
@@ -6,9 +6,9 @@ import {
   type ReactNode,
   useId,
 } from "react";
-import { DashboardActionButton } from "../../../components/ui/dashboard-action-button";
-import { DashboardPanelShell } from "../../../components/ui/dashboard-shell";
-import { getAgentBentoMessages } from "../messages/agent-bento";
+import { DashboardActionButton } from "../../../../components/ui/dashboard-action-button";
+import { DashboardPanelShell } from "../../../../components/ui/dashboard-shell";
+import { getAgentBentoMessages } from "../../messages/agent-bento";
 
 export interface DashboardCardErrorBoundaryProps {
   children: ReactNode;

--- a/ui/src/features/bento/components/dashboard-bento.test.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.test.tsx
@@ -559,8 +559,8 @@ describe("DashboardBento", () => {
       name: "Remove Work totals widget from dashboard",
     });
 
-    expect(workTotalsRemoveButton.className).toContain("h-10");
-    expect(workTotalsRemoveButton.className).toContain("w-10");
+    expect(workTotalsRemoveButton.className).toContain("h-11");
+    expect(workTotalsRemoveButton.className).toContain("w-11");
     expect(workTotalsRemoveButton.className).toContain("focus-visible:ring-2");
     expect(
       screen.queryByRole("button", {

--- a/ui/src/features/bento/components/dashboard-card-error-boundary.test.tsx
+++ b/ui/src/features/bento/components/dashboard-card-error-boundary.test.tsx
@@ -1,0 +1,202 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
+import {
+  AgentBentoCard,
+  AgentBentoLayout,
+  type AgentBentoLayoutCard,
+} from "./agent-bento";
+
+const layout = [
+  { h: 2, id: "broken", widgetType: "broken", w: 6, x: 0, y: 0 },
+  { h: 2, id: "healthy", widgetType: "healthy", w: 6, x: 6, y: 0 },
+] as const;
+
+let restoreBrowserShims: (() => void) | undefined;
+
+beforeEach(() => {
+  restoreBrowserShims = installDashboardBrowserTestShims();
+  Object.defineProperty(HTMLElement.prototype, "offsetParent", {
+    configurable: true,
+    get() {
+      return this.parentElement ?? document.body;
+    },
+  });
+});
+
+afterEach(() => {
+  restoreBrowserShims?.();
+  restoreBrowserShims = undefined;
+  vi.restoreAllMocks();
+});
+
+function renderBoard(cards: AgentBentoLayoutCard[]) {
+  return render(
+    <AgentBentoLayout cards={cards} initialWidth={960} layout={[...layout]} />,
+  );
+}
+
+function HealthyCard() {
+  const [clicks, setClicks] = useState(0);
+
+  return (
+    <AgentBentoCard title="Healthy card">
+      <button onClick={() => setClicks((current) => current + 1)} type="button">
+        Sibling action {clicks}
+      </button>
+    </AgentBentoCard>
+  );
+}
+
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: the two cases share one board fixture and cover the complete localized recovery contract.
+describe("DashboardCardErrorBoundary", () => {
+  it("contains one failed card, preserves sibling state and geometry, and recovers only that card", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    let shouldThrow = true;
+
+    function RecoveringCard() {
+      if (shouldThrow) {
+        throw new Error("private render details must stay hidden");
+      }
+
+      return (
+        <AgentBentoCard title="Recovering card">
+          <p>Recovered card content</p>
+        </AgentBentoCard>
+      );
+    }
+
+    try {
+      renderBoard([
+        {
+          id: "broken",
+          widgetType: "broken",
+          children: <RecoveringCard />,
+        },
+        {
+          id: "healthy",
+          widgetType: "healthy",
+          children: <HealthyCard />,
+        },
+      ]);
+
+      const board = screen.getByRole("region", {
+        name: "you-agent-factory bento board",
+      });
+      const brokenGridItem = board.querySelector<HTMLElement>(
+        '[data-bento-instance-id="broken"]',
+      );
+      if (!brokenGridItem) {
+        throw new Error("expected the failed card grid item");
+      }
+
+      const layoutSignature = brokenGridItem.dataset.layoutSignature;
+      expect(
+        within(
+          screen.getByRole("article", { name: "Dashboard card unavailable" }),
+        ).getByRole("alert").textContent,
+      ).toContain("could not be rendered");
+      expect(
+        screen.queryByText("private render details must stay hidden"),
+      ).toBeNull();
+      expect(
+        screen.getByRole("article", { name: "Healthy card" }),
+      ).toBeTruthy();
+      expect(
+        screen.getByRole("button", { name: "Move Healthy card card" }),
+      ).toBeTruthy();
+
+      const siblingAction = screen.getByRole("button", {
+        name: "Sibling action 0",
+      });
+      fireEvent.click(siblingAction);
+      expect(
+        screen.getByRole("button", { name: "Sibling action 1" }),
+      ).toBeTruthy();
+
+      shouldThrow = false;
+      const retryButton = within(
+        screen.getByRole("article", { name: "Dashboard card unavailable" }),
+      ).getByRole("button", { name: "Retry card" });
+      retryButton.focus();
+      expect(document.activeElement).toBe(retryButton);
+      expect(retryButton.className).toContain("focus-visible:ring");
+      await userEvent.setup().keyboard("{Enter}");
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("article", { name: "Recovering card" }),
+        ).toBeTruthy();
+      });
+
+      expect(
+        screen.getByRole("button", { name: "Sibling action 1" }),
+      ).toBeTruthy();
+      expect(brokenGridItem.dataset.layoutSignature).toBe(layoutSignature);
+      expect(board.querySelector('[data-bento-instance-id="broken"]')).toBe(
+        brokenGridItem,
+      );
+      expect(consoleError).toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("keeps repeated render failures localized with retry available", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    function AlwaysFailingCard() {
+      throw new Error("repeated private render details");
+    }
+
+    try {
+      renderBoard([
+        {
+          id: "broken",
+          widgetType: "broken",
+          children: <AlwaysFailingCard />,
+        },
+        {
+          id: "healthy",
+          widgetType: "healthy",
+          children: <HealthyCard />,
+        },
+      ]);
+
+      const failedCard = screen.getByRole("article", {
+        name: "Dashboard card unavailable",
+      });
+      fireEvent.click(
+        within(failedCard).getByRole("button", { name: "Retry card" }),
+      );
+
+      expect(
+        screen.getByRole("article", { name: "Dashboard card unavailable" }),
+      ).toBeTruthy();
+      expect(
+        screen.getByRole("article", { name: "Healthy card" }),
+      ).toBeTruthy();
+      expect(screen.queryByText("repeated private render details")).toBeNull();
+      expect(
+        within(
+          screen.getByRole("article", { name: "Dashboard card unavailable" }),
+        ).getByRole("button", { name: "Retry card" }),
+      ).toBeTruthy();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/ui/src/features/bento/components/dashboard-card-error-boundary.tsx
+++ b/ui/src/features/bento/components/dashboard-card-error-boundary.tsx
@@ -1,0 +1,97 @@
+import { Heading, Text } from "@you-agent-factory/components/primitives";
+import {
+  Component,
+  type ErrorInfo,
+  Fragment,
+  type ReactNode,
+  useId,
+} from "react";
+import { DashboardActionButton } from "../../../components/ui/dashboard-action-button";
+import { DashboardPanelShell } from "../../../components/ui/dashboard-shell";
+import { getAgentBentoMessages } from "../messages/agent-bento";
+
+export interface DashboardCardErrorBoundaryProps {
+  children: ReactNode;
+  locale?: string;
+}
+
+interface DashboardCardErrorBoundaryState {
+  failed: boolean;
+  retryRevision: number;
+}
+
+export class DashboardCardErrorBoundary extends Component<
+  DashboardCardErrorBoundaryProps,
+  DashboardCardErrorBoundaryState
+> {
+  public state: DashboardCardErrorBoundaryState = {
+    failed: false,
+    retryRevision: 0,
+  };
+
+  public static getDerivedStateFromError(): Pick<
+    DashboardCardErrorBoundaryState,
+    "failed"
+  > {
+    return { failed: true };
+  }
+
+  public componentDidCatch(_error: Error, _info: ErrorInfo): void {
+    // Keep render diagnostics out of the customer-facing card recovery UI.
+  }
+
+  public render() {
+    if (this.state.failed) {
+      return (
+        <DashboardCardErrorFallback
+          locale={this.props.locale}
+          onRetry={this.retry}
+        />
+      );
+    }
+
+    return (
+      <Fragment key={this.state.retryRevision}>{this.props.children}</Fragment>
+    );
+  }
+
+  private retry = () => {
+    this.setState(({ retryRevision }) => ({
+      failed: false,
+      retryRevision: retryRevision + 1,
+    }));
+  };
+}
+
+interface DashboardCardErrorFallbackProps {
+  locale?: string;
+  onRetry: () => void;
+}
+
+function DashboardCardErrorFallback({
+  locale,
+  onRetry,
+}: DashboardCardErrorFallbackProps) {
+  const messages = getAgentBentoMessages(locale);
+  const descriptionID = useId();
+
+  return (
+    <DashboardPanelShell
+      aria-describedby={descriptionID}
+      aria-label={messages.cardErrorTitle}
+      as="article"
+      className="flex h-full min-w-0 flex-col justify-between gap-4 p-4"
+      shellKind="grid-card"
+    >
+      <div className="grid gap-2">
+        <Heading as="h3">{messages.cardErrorTitle}</Heading>
+        <Text as="p" id={descriptionID} role="alert">
+          {messages.cardErrorDescription}
+        </Text>
+      </div>
+      <DashboardActionButton onClick={onRetry} type="button">
+        {messages.retryCard}
+      </DashboardActionButton>
+    </DashboardPanelShell>
+  );
+}

--- a/ui/src/features/bento/components/dashboard-widget-remove-button.test.tsx
+++ b/ui/src/features/bento/components/dashboard-widget-remove-button.test.tsx
@@ -16,8 +16,8 @@ describe("DashboardWidgetRemoveButton", () => {
       name: "Remove Work totals widget from dashboard",
     });
 
-    expect(button.className).toContain("h-10");
-    expect(button.className).toContain("w-10");
+    expect(button.className).toContain("h-11");
+    expect(button.className).toContain("w-11");
     expect(button.className).toContain("focus-visible:ring-2");
     expect(button.className).toContain("border-outline");
     expect(button.className).toContain("bg-surface-container-high");

--- a/ui/src/features/bento/components/keyboard/dashboard-layout-keyboard-controls.tsx
+++ b/ui/src/features/bento/components/keyboard/dashboard-layout-keyboard-controls.tsx
@@ -1,0 +1,243 @@
+import {
+  Button,
+  type ButtonProps,
+} from "@you-agent-factory/components/primitives";
+import { Maximize2, Move } from "lucide-react";
+import {
+  createContext,
+  type KeyboardEvent,
+  useContext,
+  useId,
+  useState,
+} from "react";
+import type { Layout } from "react-grid-layout";
+import { cloneLayout } from "react-grid-layout/core";
+import {
+  applyDashboardKeyboardLayoutOperation,
+  type DashboardKeyboardLayoutMode,
+} from "../../hooks/keyboard/dashboardLayoutKeyboard";
+import type { AgentBentoMessages } from "../../messages/agent-bento";
+
+export interface DashboardLayoutKeyboardContextValue {
+  columns: number;
+  enabled: boolean;
+  itemID: string;
+  layout: Layout;
+  messages: AgentBentoMessages;
+  onCommitLayout: (layout: Layout) => void;
+  onPreviewLayout: (layout: Layout) => void;
+}
+
+export const DashboardLayoutKeyboardContext =
+  createContext<DashboardLayoutKeyboardContextValue | null>(null);
+
+interface DashboardLayoutKeyboardControlsProps {
+  title: string;
+}
+
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: keyboard mode owns one focused draft, announcement, and commit/cancel lifecycle.
+export function DashboardLayoutKeyboardControls({
+  title,
+}: DashboardLayoutKeyboardControlsProps) {
+  const context = useContext(DashboardLayoutKeyboardContext);
+  const moveInstructionsID = useId();
+  const resizeInstructionsID = useId();
+  const [draftLayout, setDraftLayout] = useState<Layout | null>(null);
+  const [baseLayout, setBaseLayout] = useState<Layout | null>(null);
+  const [mode, setMode] = useState<DashboardKeyboardLayoutMode | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+
+  if (!context?.enabled) {
+    return null;
+  }
+
+  const keyboardContext = context;
+
+  const activeLayout = draftLayout ?? keyboardContext.layout;
+  function beginEditing(nextMode: DashboardKeyboardLayoutMode) {
+    const initialLayout = cloneLayout(keyboardContext.layout);
+    setBaseLayout(initialLayout);
+    setDraftLayout(initialLayout);
+    setMode(nextMode);
+    setAnnouncement(
+      keyboardContext.messages.layoutEditStarted(title, nextMode),
+    );
+  }
+
+  function commitEditing() {
+    if (!mode || !draftLayout || !baseLayout) {
+      return;
+    }
+
+    const nextItem = draftLayout.find(
+      (item) => item.i === keyboardContext.itemID,
+    );
+    const baseItem = baseLayout.find(
+      (item) => item.i === keyboardContext.itemID,
+    );
+    const changed =
+      nextItem !== undefined &&
+      baseItem !== undefined &&
+      !hasSameGeometry(nextItem, baseItem);
+
+    if (changed) {
+      keyboardContext.onCommitLayout(draftLayout);
+      setAnnouncement(keyboardContext.messages.layoutChanged(title, nextItem));
+    } else {
+      setAnnouncement(keyboardContext.messages.layoutEditCancelled(title));
+    }
+
+    resetEditing();
+  }
+
+  function cancelEditing() {
+    if (baseLayout) {
+      keyboardContext.onPreviewLayout(cloneLayout(baseLayout));
+    }
+    setAnnouncement(keyboardContext.messages.layoutEditCancelled(title));
+    resetEditing();
+  }
+
+  function handleKeyDown(
+    event: KeyboardEvent<HTMLButtonElement>,
+    buttonMode: DashboardKeyboardLayoutMode,
+  ) {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      event.stopPropagation();
+      if (mode === buttonMode) {
+        commitEditing();
+      } else {
+        beginEditing(buttonMode);
+      }
+      return;
+    }
+
+    if (!mode || mode !== buttonMode) {
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      cancelEditing();
+      return;
+    }
+
+    if (!isArrowKey(event.key)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    const result = applyDashboardKeyboardLayoutOperation(
+      activeLayout,
+      keyboardContext.itemID,
+      mode,
+      event.key,
+      keyboardContext.columns,
+    );
+    if (!result.changed) {
+      setAnnouncement(keyboardContext.messages.layoutBoundary(title, mode));
+      return;
+    }
+
+    setDraftLayout(result.layout);
+    keyboardContext.onPreviewLayout(result.layout);
+    const nextItem = result.layout.find(
+      (item) => item.i === keyboardContext.itemID,
+    );
+    if (nextItem) {
+      setAnnouncement(keyboardContext.messages.layoutChanged(title, nextItem));
+    }
+  }
+
+  function renderModeButton(
+    nextMode: DashboardKeyboardLayoutMode,
+    icon: ButtonProps["children"],
+    label: string,
+  ) {
+    const isActive = mode === nextMode;
+    return (
+      <Button
+        aria-describedby={
+          nextMode === "resize" ? resizeInstructionsID : moveInstructionsID
+        }
+        aria-keyshortcuts="ArrowUp ArrowDown ArrowLeft ArrowRight Enter Escape"
+        aria-label={label}
+        aria-pressed={isActive}
+        className="shrink-0"
+        data-bento-layout-keyboard-mode={nextMode}
+        onClick={() => {
+          if (isActive) {
+            commitEditing();
+            return;
+          }
+          beginEditing(nextMode);
+        }}
+        onKeyDown={(event) => handleKeyDown(event, nextMode)}
+        size="icon"
+        tone={isActive ? "secondary" : "ghost"}
+        type="button"
+      >
+        {icon}
+      </Button>
+    );
+  }
+
+  function resetEditing() {
+    setMode(null);
+    setDraftLayout(null);
+    setBaseLayout(null);
+  }
+
+  return (
+    <>
+      <span className="sr-only" id={moveInstructionsID}>
+        {keyboardContext.messages.moveInstructions}
+      </span>
+      <span className="sr-only" id={resizeInstructionsID}>
+        {keyboardContext.messages.resizeInstructions}
+      </span>
+      <span
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+        role="status"
+      >
+        {announcement}
+      </span>
+      {renderModeButton(
+        "move",
+        <Move aria-hidden="true" focusable="false" size={16} />,
+        keyboardContext.messages.moveWidgetLabel(title),
+      )}
+      {renderModeButton(
+        "resize",
+        <Maximize2 aria-hidden="true" focusable="false" size={16} />,
+        keyboardContext.messages.resizeWidgetLabel(title),
+      )}
+    </>
+  );
+}
+
+function hasSameGeometry(
+  left: Pick<Layout[number], "h" | "w" | "x" | "y">,
+  right: Pick<Layout[number], "h" | "w" | "x" | "y">,
+): boolean {
+  return (
+    left.h === right.h &&
+    left.w === right.w &&
+    left.x === right.x &&
+    left.y === right.y
+  );
+}
+
+function isArrowKey(key: string): boolean {
+  return (
+    key === "ArrowDown" ||
+    key === "ArrowLeft" ||
+    key === "ArrowRight" ||
+    key === "ArrowUp"
+  );
+}

--- a/ui/src/features/bento/components/keyboard/dashboard-layout-keyboard-controls.tsx
+++ b/ui/src/features/bento/components/keyboard/dashboard-layout-keyboard-controls.tsx
@@ -199,14 +199,16 @@ export function DashboardLayoutKeyboardControls({
       <span className="sr-only" id={resizeInstructionsID}>
         {keyboardContext.messages.resizeInstructions}
       </span>
-      <span
-        aria-live="polite"
-        aria-atomic="true"
-        className="sr-only"
-        role="status"
-      >
-        {announcement}
-      </span>
+      {announcement ? (
+        <span
+          aria-live="polite"
+          aria-atomic="true"
+          className="sr-only"
+          role="status"
+        >
+          {announcement}
+        </span>
+      ) : null}
       {renderModeButton(
         "move",
         <Move aria-hidden="true" focusable="false" size={16} />,

--- a/ui/src/features/bento/components/resize/bento-resize-handle.tsx
+++ b/ui/src/features/bento/components/resize/bento-resize-handle.tsx
@@ -20,7 +20,7 @@ export function renderBentoResizeHandle(
   return (
     <span
       aria-hidden="true"
-      className={`react-resizable-handle react-resizable-handle-${axis} h-11 w-11 touch-none`}
+      className={`react-resizable-handle react-resizable-handle-${axis} z-10 h-11 w-11 touch-none`}
       data-bento-touch-resize-handle={axis}
       ref={ref}
       style={{

--- a/ui/src/features/bento/components/resize/bento-resize-handle.tsx
+++ b/ui/src/features/bento/components/resize/bento-resize-handle.tsx
@@ -1,0 +1,34 @@
+import type { CSSProperties, Ref } from "react";
+import type { ResizeHandleAxis } from "react-grid-layout/core";
+
+export function renderBentoResizeHandle(
+  axis: ResizeHandleAxis,
+  ref: Ref<HTMLElement>,
+) {
+  const positionStyle: CSSProperties =
+    axis === "e"
+      ? { marginTop: -22, right: 0, top: "50%", transform: "rotate(315deg)" }
+      : axis === "s"
+        ? {
+            bottom: 0,
+            left: "50%",
+            marginLeft: -22,
+            transform: "rotate(45deg)",
+          }
+        : { bottom: 0, right: 0 };
+
+  return (
+    <span
+      aria-hidden="true"
+      className={`react-resizable-handle react-resizable-handle-${axis} h-11 w-11 touch-none`}
+      data-bento-touch-resize-handle={axis}
+      ref={ref}
+      style={{
+        ...positionStyle,
+        height: 44,
+        touchAction: "none",
+        width: 44,
+      }}
+    />
+  );
+}

--- a/ui/src/features/bento/hooks/keyboard/dashboardLayoutKeyboard.test.ts
+++ b/ui/src/features/bento/hooks/keyboard/dashboardLayoutKeyboard.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyDashboardKeyboardLayoutOperation,
+  type DashboardKeyboardLayoutMode,
+} from "./dashboardLayoutKeyboard";
+
+const columns = 12;
+
+function item(
+  id: string,
+  values: Partial<{ h: number; w: number; x: number; y: number }> = {},
+) {
+  return {
+    h: values.h ?? 2,
+    i: id,
+    w: values.w ?? 4,
+    x: values.x ?? 0,
+    y: values.y ?? 0,
+  };
+}
+
+function operation(
+  mode: DashboardKeyboardLayoutMode,
+  key: string,
+  layout = [item("activity")],
+) {
+  return applyDashboardKeyboardLayoutOperation(
+    layout,
+    "activity",
+    mode,
+    key,
+    columns,
+  );
+}
+
+describe("applyDashboardKeyboardLayoutOperation", () => {
+  it("moves by one grid cell and keeps the layout collision-free", () => {
+    const result = operation("move", "ArrowRight", [
+      item("activity"),
+      item("trace", { x: 4 }),
+    ]);
+
+    expect(result.changed).toBe(true);
+    expect(result.layout.find((entry) => entry.i === "activity")).toMatchObject(
+      { x: 1, y: 0 },
+    );
+    expect(result.layout.find((entry) => entry.i === "trace")).toMatchObject({
+      y: 2,
+    });
+  });
+
+  it("honors movement boundaries and item size constraints", () => {
+    const atLeft = operation("move", "ArrowLeft");
+    expect(atLeft.changed).toBe(false);
+    expect(atLeft.reason).toBe("boundary");
+
+    const constrained = operation("resize", "ArrowLeft", [
+      {
+        ...item("activity", { w: 2 }),
+        minW: 2,
+      },
+    ]);
+    expect(constrained.changed).toBe(false);
+    expect(constrained.reason).toBe("boundary");
+  });
+
+  it("resizes by one grid cell without mutating the source layout", () => {
+    const source = [item("activity", { w: 4, h: 2 })];
+    const result = operation("resize", "ArrowDown", source);
+
+    expect(result.changed).toBe(true);
+    expect(result.layout.find((entry) => entry.i === "activity")).toMatchObject(
+      { h: 3, w: 4 },
+    );
+    expect(source[0]).toMatchObject({ h: 2, w: 4 });
+  });
+});

--- a/ui/src/features/bento/hooks/keyboard/dashboardLayoutKeyboard.ts
+++ b/ui/src/features/bento/hooks/keyboard/dashboardLayoutKeyboard.ts
@@ -1,0 +1,185 @@
+import type { Layout, LayoutItem } from "react-grid-layout";
+import {
+  cloneLayout,
+  getLayoutItem,
+  moveElement,
+  verticalCompactor,
+} from "react-grid-layout/core";
+
+export type DashboardKeyboardLayoutMode = "move" | "resize";
+
+export interface DashboardKeyboardLayoutOperationResult {
+  changed: boolean;
+  layout: Layout;
+  reason: "changed" | "boundary";
+}
+
+const DEFAULT_MIN_GRID_SIZE = 1;
+
+/**
+ * Apply one keyboard grid step using the same vertical compaction and
+ * collision resolution rules as the pointer grid.
+ */
+export function applyDashboardKeyboardLayoutOperation(
+  layout: Layout,
+  itemID: string,
+  mode: DashboardKeyboardLayoutMode,
+  key: string,
+  columns: number,
+): DashboardKeyboardLayoutOperationResult {
+  const item = getLayoutItem(layout, itemID);
+  if (!item) {
+    return unchangedLayout(layout);
+  }
+
+  if (mode === "move") {
+    return moveDashboardLayoutItem(layout, item, key, columns);
+  }
+
+  return resizeDashboardLayoutItem(layout, item, key, columns);
+}
+
+function moveDashboardLayoutItem(
+  layout: Layout,
+  item: LayoutItem,
+  key: string,
+  columns: number,
+): DashboardKeyboardLayoutOperationResult {
+  const delta = getMoveDelta(key);
+  if (!delta) {
+    return unchangedLayout(layout);
+  }
+
+  const maxX = Math.max(0, columns - item.w);
+  const targetX = clamp(item.x + delta.x, 0, maxX);
+  const targetY = Math.max(0, item.y + delta.y);
+  if (targetX === item.x && targetY === item.y) {
+    return unchangedLayout(layout);
+  }
+
+  const nextLayout = cloneLayout(layout);
+  const nextItem = getLayoutItem(nextLayout, item.i);
+  if (!nextItem) {
+    return unchangedLayout(layout);
+  }
+
+  const movedLayout = moveElement(
+    nextLayout,
+    nextItem,
+    targetX,
+    targetY,
+    true,
+    false,
+    "vertical",
+    columns,
+    false,
+  );
+  const compactedLayout = verticalCompactor.compact(movedLayout, columns);
+  const movedItem = getLayoutItem(compactedLayout, item.i);
+  if (!movedItem || hasSameGeometry(item, movedItem)) {
+    return unchangedLayout(layout);
+  }
+
+  return {
+    changed: true,
+    layout: compactedLayout,
+    reason: "changed",
+  };
+}
+
+function resizeDashboardLayoutItem(
+  layout: Layout,
+  item: LayoutItem,
+  key: string,
+  columns: number,
+): DashboardKeyboardLayoutOperationResult {
+  const delta = getResizeDelta(key);
+  if (!delta) {
+    return unchangedLayout(layout);
+  }
+
+  const minimumWidth = Math.max(item.minW ?? DEFAULT_MIN_GRID_SIZE, 1);
+  const minimumHeight = Math.max(item.minH ?? DEFAULT_MIN_GRID_SIZE, 1);
+  const maximumWidth = Math.max(
+    minimumWidth,
+    Math.min(item.maxW ?? columns, columns),
+  );
+  const maximumHeight = Math.max(
+    minimumHeight,
+    item.maxH ?? Number.POSITIVE_INFINITY,
+  );
+  const targetWidth = clamp(item.w + delta.w, minimumWidth, maximumWidth);
+  const targetHeight = clamp(item.h + delta.h, minimumHeight, maximumHeight);
+  if (targetWidth === item.w && targetHeight === item.h) {
+    return unchangedLayout(layout);
+  }
+
+  const nextLayout = cloneLayout(layout);
+  const nextItem = getLayoutItem(nextLayout, item.i);
+  if (!nextItem) {
+    return unchangedLayout(layout);
+  }
+
+  nextItem.w = targetWidth;
+  nextItem.h = targetHeight;
+  const compactedLayout = verticalCompactor.compact(nextLayout, columns);
+  const resizedItem = getLayoutItem(compactedLayout, item.i);
+  if (!resizedItem || hasSameGeometry(item, resizedItem)) {
+    return unchangedLayout(layout);
+  }
+
+  return {
+    changed: true,
+    layout: compactedLayout,
+    reason: "changed",
+  };
+}
+
+function getMoveDelta(key: string): { x: number; y: number } | undefined {
+  switch (key) {
+    case "ArrowLeft":
+      return { x: -1, y: 0 };
+    case "ArrowRight":
+      return { x: 1, y: 0 };
+    case "ArrowUp":
+      return { x: 0, y: -1 };
+    case "ArrowDown":
+      return { x: 0, y: 1 };
+    default:
+      return undefined;
+  }
+}
+
+function getResizeDelta(key: string): { h: number; w: number } | undefined {
+  switch (key) {
+    case "ArrowLeft":
+      return { h: 0, w: -1 };
+    case "ArrowRight":
+      return { h: 0, w: 1 };
+    case "ArrowUp":
+      return { h: -1, w: 0 };
+    case "ArrowDown":
+      return { h: 1, w: 0 };
+    default:
+      return undefined;
+  }
+}
+
+function hasSameGeometry(left: LayoutItem, right: LayoutItem): boolean {
+  return (
+    left.h === right.h &&
+    left.w === right.w &&
+    left.x === right.x &&
+    left.y === right.y
+  );
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(Math.max(value, minimum), maximum);
+}
+
+function unchangedLayout(
+  layout: Layout,
+): DashboardKeyboardLayoutOperationResult {
+  return { changed: false, layout, reason: "boundary" };
+}

--- a/ui/src/features/bento/hooks/touch/dashboardLayoutTouch.ts
+++ b/ui/src/features/bento/hooks/touch/dashboardLayoutTouch.ts
@@ -1,0 +1,321 @@
+import type {
+  PointerEvent as ReactPointerEvent,
+  TouchEvent as ReactTouchEvent,
+} from "react";
+import { useCallback, useRef } from "react";
+import type { Layout } from "react-grid-layout";
+import { cloneLayout, getLayoutItem } from "react-grid-layout/core";
+import {
+  findTouchPoint,
+  useDashboardLayoutTouchListeners,
+} from "./dashboardLayoutTouchListeners";
+import { applyDashboardTouchLayoutOperation } from "./dashboardLayoutTouchOperations";
+
+export type DashboardTouchLayoutMode = "move" | "resize";
+export type DashboardTouchResizeHandle = "e" | "s" | "se";
+
+const TOUCH_MOVE_THRESHOLD_PX = 3;
+const BENTO_CARD_SELECTOR = "[data-bento-instance-id]";
+const BENTO_DRAG_HANDLE_SELECTOR = "[data-bento-drag-handle='true']";
+const BENTO_RESIZE_HANDLE_SELECTOR = "[data-bento-touch-resize-handle]";
+const BENTO_TOUCH_CANCEL_SELECTOR =
+  "button,a,input,select,textarea,[contenteditable='true']";
+
+interface DashboardLayoutTouchOptions {
+  columns: number;
+  enabled: boolean;
+  layout: Layout;
+  margin: readonly [number, number];
+  onCommitLayout: (layout: Layout) => void;
+  onPreviewLayout: (layout: Layout) => void;
+  rowHeight: number;
+  width: number;
+}
+
+interface DashboardLayoutTouchInteraction {
+  handle?: DashboardTouchResizeHandle;
+  itemID: string;
+  mode: DashboardTouchLayoutMode;
+}
+
+export interface DashboardLayoutTouchSession {
+  currentLayout: Layout;
+  identifier: number;
+  interaction: DashboardLayoutTouchInteraction;
+  moved: boolean;
+  origin: { x: number; y: number };
+  source: "pointer" | "touch";
+  startLayout: Layout;
+}
+
+export interface TouchPoint {
+  clientX: number;
+  clientY: number;
+  identifier: number;
+}
+
+export interface TouchListLike {
+  [index: number]: TouchPoint | undefined;
+  item?: (index: number) => TouchPoint | null;
+  length: number;
+}
+
+type BeginSession = (
+  target: EventTarget | null,
+  point: TouchPoint,
+  source: "pointer" | "touch",
+) => boolean;
+
+export interface DashboardLayoutTouchHandlers {
+  onPointerDownCapture: (event: ReactPointerEvent<HTMLElement>) => void;
+  onTouchStartCapture: (event: ReactTouchEvent<HTMLElement>) => void;
+}
+
+export interface DashboardTouchLayoutOperationOptions {
+  columns: number;
+  deltaX: number;
+  deltaY: number;
+  handle?: DashboardTouchResizeHandle;
+  itemID: string;
+  layout: Layout;
+  margin: readonly [number, number];
+  mode: DashboardTouchLayoutMode;
+  rowHeight: number;
+  width: number;
+}
+
+export function useDashboardLayoutTouch(
+  options: DashboardLayoutTouchOptions,
+): DashboardLayoutTouchHandlers {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+  const sessionRef = useRef<DashboardLayoutTouchSession | null>(null);
+
+  const cancelSession = useCallback(() => {
+    const session = sessionRef.current;
+    if (!session) {
+      return false;
+    }
+
+    sessionRef.current = null;
+    optionsRef.current.onPreviewLayout(cloneLayout(session.startLayout));
+    return true;
+  }, []);
+
+  const completeSession = useCallback((cancelled: boolean) => {
+    const session = sessionRef.current;
+    if (!session) {
+      return;
+    }
+
+    sessionRef.current = null;
+    if (
+      cancelled ||
+      !session.moved ||
+      hasSameLayoutGeometry(session.startLayout, session.currentLayout)
+    ) {
+      if (cancelled) {
+        optionsRef.current.onPreviewLayout(cloneLayout(session.startLayout));
+      }
+      return;
+    }
+
+    optionsRef.current.onCommitLayout(cloneLayout(session.currentLayout));
+  }, []);
+
+  const updateSession = useCallback((point: TouchPoint) => {
+    const session = sessionRef.current;
+    if (!session) {
+      return;
+    }
+
+    const deltaX = point.clientX - session.origin.x;
+    const deltaY = point.clientY - session.origin.y;
+    if (
+      !session.moved &&
+      Math.hypot(deltaX, deltaY) < TOUCH_MOVE_THRESHOLD_PX
+    ) {
+      return;
+    }
+
+    session.moved = true;
+    const currentOptions = optionsRef.current;
+    const nextLayout = applyDashboardTouchLayoutOperation({
+      columns: currentOptions.columns,
+      deltaX,
+      deltaY,
+      handle: session.interaction.handle,
+      itemID: session.interaction.itemID,
+      layout: session.startLayout,
+      margin: currentOptions.margin,
+      mode: session.interaction.mode,
+      rowHeight: currentOptions.rowHeight,
+      width: currentOptions.width,
+    });
+
+    if (hasSameLayoutGeometry(session.currentLayout, nextLayout)) {
+      return;
+    }
+
+    session.currentLayout = nextLayout;
+    currentOptions.onPreviewLayout(cloneLayout(nextLayout));
+  }, []);
+  useDashboardLayoutTouchListeners({
+    completeSession,
+    sessionRef,
+    updateSession,
+  });
+
+  const beginSession = useCallback(
+    (
+      target: EventTarget | null,
+      point: TouchPoint,
+      source: "pointer" | "touch",
+    ) => {
+      const currentOptions = optionsRef.current;
+      if (!currentOptions.enabled || sessionRef.current) {
+        return false;
+      }
+
+      const interaction = getTouchInteraction(target);
+      if (
+        !interaction ||
+        !getLayoutItem(currentOptions.layout, interaction.itemID)
+      ) {
+        return false;
+      }
+
+      const initialLayout = cloneLayout(currentOptions.layout);
+      sessionRef.current = {
+        currentLayout: cloneLayout(initialLayout),
+        identifier: point.identifier,
+        interaction,
+        moved: false,
+        origin: { x: point.clientX, y: point.clientY },
+        source,
+        startLayout: initialLayout,
+      };
+      return true;
+    },
+    [],
+  );
+
+  const onTouchStartCapture = useCallback(
+    (event: ReactTouchEvent<HTMLElement>) =>
+      handleTouchStartCapture(event, beginSession, cancelSession),
+    [beginSession, cancelSession],
+  );
+
+  const onPointerDownCapture = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) =>
+      handlePointerDownCapture(event, beginSession),
+    [beginSession],
+  );
+
+  return { onPointerDownCapture, onTouchStartCapture };
+}
+
+function getTouchInteraction(
+  target: EventTarget | null,
+): DashboardLayoutTouchInteraction | undefined {
+  if (!(target instanceof Element)) {
+    return undefined;
+  }
+
+  const card = target.closest<HTMLElement>(BENTO_CARD_SELECTOR);
+  if (!card) {
+    return undefined;
+  }
+
+  const resizeHandle = target.closest<HTMLElement>(
+    BENTO_RESIZE_HANDLE_SELECTOR,
+  );
+  if (resizeHandle && card.contains(resizeHandle)) {
+    const handle = resizeHandle.getAttribute("data-bento-touch-resize-handle");
+    if (handle === "e" || handle === "s" || handle === "se") {
+      return {
+        handle,
+        itemID: card.dataset.bentoInstanceId ?? "",
+        mode: "resize",
+      };
+    }
+  }
+
+  if (target.closest(BENTO_TOUCH_CANCEL_SELECTOR)) {
+    return undefined;
+  }
+
+  const moveHandle = target.closest(BENTO_DRAG_HANDLE_SELECTOR);
+  if (!moveHandle || !card.contains(moveHandle)) {
+    return undefined;
+  }
+
+  return {
+    itemID: card.dataset.bentoInstanceId ?? "",
+    mode: "move",
+  };
+}
+
+function handleTouchStartCapture(
+  event: ReactTouchEvent<HTMLElement>,
+  beginSession: BeginSession,
+  cancelSession: () => boolean,
+) {
+  if (event.touches.length !== 1) {
+    if (event.touches.length > 1) {
+      cancelSession();
+    }
+    return;
+  }
+
+  const point = findTouchPoint(event.nativeEvent);
+  if (!point || !beginSession(event.target, point, "touch")) {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+function handlePointerDownCapture(
+  event: ReactPointerEvent<HTMLElement>,
+  beginSession: BeginSession,
+) {
+  if (event.pointerType !== "touch") {
+    return;
+  }
+
+  if (
+    !beginSession(
+      event.target,
+      {
+        clientX: event.clientX,
+        clientY: event.clientY,
+        identifier: event.pointerId,
+      },
+      "pointer",
+    )
+  ) {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+function hasSameLayoutGeometry(left: Layout, right: Layout): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((leftItem, index) => {
+    const rightItem = right[index];
+    return (
+      rightItem?.i === leftItem.i &&
+      rightItem.x === leftItem.x &&
+      rightItem.y === leftItem.y &&
+      rightItem.w === leftItem.w &&
+      rightItem.h === leftItem.h
+    );
+  });
+}

--- a/ui/src/features/bento/hooks/touch/dashboardLayoutTouchListeners.ts
+++ b/ui/src/features/bento/hooks/touch/dashboardLayoutTouchListeners.ts
@@ -1,0 +1,216 @@
+import { useEffect } from "react";
+
+import type {
+  DashboardLayoutTouchSession,
+  TouchListLike,
+  TouchPoint,
+} from "./dashboardLayoutTouch";
+
+type SessionRef = { current: DashboardLayoutTouchSession | null };
+type CompleteSession = (cancelled: boolean) => void;
+type UpdateSession = (point: TouchPoint) => void;
+
+export function useDashboardLayoutTouchListeners({
+  completeSession,
+  sessionRef,
+  updateSession,
+}: {
+  completeSession: CompleteSession;
+  sessionRef: SessionRef;
+  updateSession: UpdateSession;
+}) {
+  useEffect(() => {
+    const touchMove = createTouchMoveHandler(sessionRef, updateSession);
+    const touchEnd = createTouchEndHandler(
+      sessionRef,
+      updateSession,
+      completeSession,
+    );
+    const touchCancel = createTouchCancelHandler(sessionRef, completeSession);
+    const pointerMove = createPointerMoveHandler(sessionRef, updateSession);
+    const pointerUp = createPointerUpHandler(
+      sessionRef,
+      updateSession,
+      completeSession,
+    );
+    const pointerCancel = createPointerCancelHandler(
+      sessionRef,
+      completeSession,
+    );
+
+    document.addEventListener("touchmove", touchMove, { passive: false });
+    document.addEventListener("touchend", touchEnd, { passive: false });
+    document.addEventListener("touchcancel", touchCancel, { passive: false });
+    document.addEventListener("pointermove", pointerMove, { passive: false });
+    document.addEventListener("pointerup", pointerUp, { passive: false });
+    document.addEventListener("pointercancel", pointerCancel, {
+      passive: false,
+    });
+
+    return () => {
+      document.removeEventListener("touchmove", touchMove);
+      document.removeEventListener("touchend", touchEnd);
+      document.removeEventListener("touchcancel", touchCancel);
+      document.removeEventListener("pointermove", pointerMove);
+      document.removeEventListener("pointerup", pointerUp);
+      document.removeEventListener("pointercancel", pointerCancel);
+      sessionRef.current = null;
+    };
+  }, [completeSession, sessionRef, updateSession]);
+}
+
+export function findTouchPoint(
+  event: Pick<globalThis.TouchEvent, "changedTouches" | "touches">,
+  identifier?: number,
+): TouchPoint | undefined {
+  return (
+    findTouchInList(event.touches, identifier) ??
+    findTouchInList(event.changedTouches, identifier)
+  );
+}
+
+function createTouchMoveHandler(
+  sessionRef: SessionRef,
+  updateSession: UpdateSession,
+) {
+  return (event: globalThis.TouchEvent) => {
+    const session = sessionRef.current;
+    if (session?.source !== "touch") {
+      return;
+    }
+
+    const point = findTouchPoint(event, session.identifier);
+    if (!point) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    updateSession(point);
+  };
+}
+
+function createTouchEndHandler(
+  sessionRef: SessionRef,
+  updateSession: UpdateSession,
+  completeSession: CompleteSession,
+) {
+  return (event: globalThis.TouchEvent) => {
+    const session = sessionRef.current;
+    if (session?.source !== "touch") {
+      return;
+    }
+
+    const point = findTouchPoint(event, session.identifier);
+    if (point) {
+      updateSession(point);
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    completeSession(false);
+  };
+}
+
+function createTouchCancelHandler(
+  sessionRef: SessionRef,
+  completeSession: CompleteSession,
+) {
+  return (event: globalThis.TouchEvent) => {
+    if (sessionRef.current?.source !== "touch") {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    completeSession(true);
+  };
+}
+
+function createPointerMoveHandler(
+  sessionRef: SessionRef,
+  updateSession: UpdateSession,
+) {
+  return (event: globalThis.PointerEvent) => {
+    const session = sessionRef.current;
+    if (
+      session?.source !== "pointer" ||
+      event.pointerId !== session.identifier
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    updateSession({
+      clientX: event.clientX,
+      clientY: event.clientY,
+      identifier: event.pointerId,
+    });
+  };
+}
+
+function createPointerUpHandler(
+  sessionRef: SessionRef,
+  updateSession: UpdateSession,
+  completeSession: CompleteSession,
+) {
+  return (event: globalThis.PointerEvent) => {
+    const session = sessionRef.current;
+    if (
+      session?.source !== "pointer" ||
+      event.pointerId !== session.identifier
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    updateSession({
+      clientX: event.clientX,
+      clientY: event.clientY,
+      identifier: event.pointerId,
+    });
+    completeSession(false);
+  };
+}
+
+function createPointerCancelHandler(
+  sessionRef: SessionRef,
+  completeSession: CompleteSession,
+) {
+  return (event: globalThis.PointerEvent) => {
+    const session = sessionRef.current;
+    if (
+      session?.source !== "pointer" ||
+      event.pointerId !== session.identifier
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    completeSession(true);
+  };
+}
+
+function findTouchInList(
+  list: TouchList | undefined,
+  identifier?: number,
+): TouchPoint | undefined {
+  if (!list) {
+    return undefined;
+  }
+
+  const touchList = list as unknown as TouchListLike;
+  for (let index = 0; index < touchList.length; index += 1) {
+    const touch = touchList.item?.(index) ?? touchList[index];
+    if (
+      touch &&
+      (identifier === undefined || touch.identifier === identifier)
+    ) {
+      return touch;
+    }
+  }
+
+  return undefined;
+}

--- a/ui/src/features/bento/hooks/touch/dashboardLayoutTouchOperations.ts
+++ b/ui/src/features/bento/hooks/touch/dashboardLayoutTouchOperations.ts
@@ -1,0 +1,144 @@
+import type { Layout, LayoutItem } from "react-grid-layout";
+import {
+  calcGridColWidth,
+  calcGridItemWHPx,
+  calcWH,
+  cloneLayout,
+  getLayoutItem,
+  moveElement,
+  verticalCompactor,
+} from "react-grid-layout/core";
+
+import type { DashboardTouchLayoutOperationOptions } from "./dashboardLayoutTouch";
+
+/**
+ * Apply a touch grid step using the same core movement, sizing, compaction,
+ * and collision behavior used by the existing pointer and keyboard paths.
+ */
+export function applyDashboardTouchLayoutOperation({
+  columns,
+  deltaX,
+  deltaY,
+  handle,
+  itemID,
+  layout,
+  margin,
+  mode,
+  rowHeight,
+  width,
+}: DashboardTouchLayoutOperationOptions): Layout {
+  const item = getLayoutItem(layout, itemID);
+  if (!item) {
+    return layout;
+  }
+
+  const positionParams = {
+    cols: columns,
+    containerPadding: [0, 0] as const,
+    containerWidth: width,
+    margin,
+    maxRows: Number.POSITIVE_INFINITY,
+    rowHeight,
+  };
+
+  if (mode === "move") {
+    return moveTouchLayoutItem(
+      layout,
+      item,
+      columns,
+      deltaX,
+      deltaY,
+      calcGridColWidth(positionParams),
+      margin,
+      rowHeight,
+    );
+  }
+
+  if (!handle) {
+    return layout;
+  }
+
+  const columnWidth = calcGridColWidth(positionParams);
+  const initialWidth = calcGridItemWHPx(item.w, columnWidth, margin[0]);
+  const initialHeight = calcGridItemWHPx(item.h, rowHeight, margin[1]);
+  const adjustedDeltaX = handle.includes("e") ? deltaX : 0;
+  const adjustedDeltaY = handle.includes("s") ? deltaY : 0;
+  const calculatedSize = calcWH(
+    positionParams,
+    initialWidth + adjustedDeltaX,
+    initialHeight + adjustedDeltaY,
+    item.x,
+    item.y,
+    handle,
+  );
+  const maxWidth = Math.max(
+    1,
+    Math.min(item.maxW ?? columns, columns - item.x),
+  );
+  const maxHeight = item.maxH ?? Number.POSITIVE_INFINITY;
+  const minWidth = Math.min(Math.max(item.minW ?? 1, 1), maxWidth);
+  const minHeight = Math.min(Math.max(item.minH ?? 1, 1), maxHeight);
+  const nextWidth = clamp(calculatedSize.w, minWidth, maxWidth);
+  const nextHeight = clamp(calculatedSize.h, minHeight, maxHeight);
+
+  if (nextWidth === item.w && nextHeight === item.h) {
+    return layout;
+  }
+
+  const nextLayout = cloneLayout(layout);
+  const nextItem = getLayoutItem(nextLayout, itemID);
+  if (!nextItem) {
+    return layout;
+  }
+
+  nextItem.w = nextWidth;
+  nextItem.h = nextHeight;
+  return verticalCompactor.compact(nextLayout, columns);
+}
+
+function moveTouchLayoutItem(
+  layout: Layout,
+  item: LayoutItem,
+  columns: number,
+  deltaX: number,
+  deltaY: number,
+  columnWidth: number,
+  margin: readonly [number, number],
+  rowHeight: number,
+): Layout {
+  const targetX = clamp(
+    item.x + Math.round(deltaX / (columnWidth + margin[0])),
+    0,
+    Math.max(0, columns - item.w),
+  );
+  const targetY = Math.max(
+    0,
+    item.y + Math.round(deltaY / (rowHeight + margin[1])),
+  );
+  if (targetX === item.x && targetY === item.y) {
+    return layout;
+  }
+
+  const nextLayout = cloneLayout(layout);
+  const nextItem = getLayoutItem(nextLayout, item.i);
+  if (!nextItem) {
+    return layout;
+  }
+
+  const movedLayout = moveElement(
+    nextLayout,
+    nextItem,
+    targetX,
+    targetY,
+    true,
+    false,
+    "vertical",
+    columns,
+    false,
+  );
+  return verticalCompactor.compact(movedLayout, columns);
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(Math.max(value, minimum), maximum);
+}

--- a/ui/src/features/bento/messages/agent-bento.test.ts
+++ b/ui/src/features/bento/messages/agent-bento.test.ts
@@ -5,6 +5,8 @@ describe("getAgentBentoMessages", () => {
     const messages = getAgentBentoMessages();
 
     expect(messages.boardLabel).toBe("you-agent-factory bento board");
+    expect(messages.cardErrorTitle).toBe("Dashboard card unavailable");
+    expect(messages.retryCard).toBe("Retry card");
     expect(messages.removeWidgetLabel("Work totals")).toBe(
       "Remove Work totals widget from dashboard",
     );
@@ -14,6 +16,8 @@ describe("getAgentBentoMessages", () => {
     const messages = getAgentBentoMessages("zh-CN");
 
     expect(messages.boardLabel).toBe("you-agent-factory Bento 看板");
+    expect(messages.cardErrorTitle).toBe("仪表板卡片不可用");
+    expect(messages.retryCard).toBe("重试卡片");
     expect(messages.removeWidgetLabel("工作总览")).toBe(
       "从仪表板移除 工作总览 小组件",
     );

--- a/ui/src/features/bento/messages/agent-bento.ts
+++ b/ui/src/features/bento/messages/agent-bento.ts
@@ -5,19 +5,64 @@ import {
 
 export interface AgentBentoMessages {
   boardLabel: string;
+  layoutChanged: (
+    widgetTitle: string,
+    layout: { h: number; w: number; x: number; y: number },
+  ) => string;
+  layoutEditCancelled: (widgetTitle: string) => string;
+  layoutEditStarted: (widgetTitle: string, mode: "move" | "resize") => string;
+  layoutBoundary: (widgetTitle: string, mode: "move" | "resize") => string;
+  moveInstructions: string;
+  moveWidgetLabel: (widgetTitle: string) => string;
   removeWidgetLabel: (widgetTitle: string) => string;
+  resizeInstructions: string;
+  resizeWidgetLabel: (widgetTitle: string) => string;
 }
 
 const agentBentoMessagesByLocale = {
   en: {
     boardLabel: "you-agent-factory bento board",
+    layoutBoundary: (widgetTitle: string, mode: "move" | "resize") =>
+      `No ${mode} change was possible for ${widgetTitle}; the card is at a boundary or would overlap another card.`,
+    layoutChanged: (
+      widgetTitle: string,
+      layout: { h: number; w: number; x: number; y: number },
+    ) =>
+      `${widgetTitle} is at column ${layout.x + 1}, row ${layout.y + 1}, ${layout.w} columns by ${layout.h} rows.`,
+    layoutEditCancelled: (widgetTitle: string) =>
+      `Layout editing cancelled for ${widgetTitle}.`,
+    layoutEditStarted: (widgetTitle: string, mode: "move" | "resize") =>
+      `Layout editing started for ${widgetTitle} in ${mode} mode.`,
+    moveInstructions:
+      "Move mode: use arrow keys to move one grid cell at a time. Press Enter or Space to save, or Escape to cancel.",
+    moveWidgetLabel: (widgetTitle: string) => `Move ${widgetTitle} card`,
     removeWidgetLabel: (widgetTitle: string) =>
       `Remove ${widgetTitle} widget from dashboard`,
+    resizeInstructions:
+      "Resize mode: use Left and Up to shrink, or Right and Down to grow by one grid cell. Press Enter or Space to save, or Escape to cancel.",
+    resizeWidgetLabel: (widgetTitle: string) => `Resize ${widgetTitle} card`,
   },
   "zh-CN": {
     boardLabel: "you-agent-factory Bento 看板",
+    layoutBoundary: (widgetTitle: string, mode: "move" | "resize") =>
+      `${widgetTitle} 无法继续${mode === "move" ? "移动" : "调整大小"}；卡片已到边界或会与其他卡片重叠。`,
+    layoutChanged: (
+      widgetTitle: string,
+      layout: { h: number; w: number; x: number; y: number },
+    ) =>
+      `${widgetTitle} 位于第 ${layout.x + 1} 列、第 ${layout.y + 1} 行，大小为 ${layout.w} 列乘 ${layout.h} 行。`,
+    layoutEditCancelled: (widgetTitle: string) =>
+      `已取消编辑 ${widgetTitle} 的布局。`,
+    layoutEditStarted: (widgetTitle: string, mode: "move" | "resize") =>
+      `已开始在${mode === "move" ? "移动" : "调整大小"}模式下编辑 ${widgetTitle} 的布局。`,
+    moveInstructions:
+      "移动模式：使用方向键每次移动一个网格单元。按 Enter 或空格保存，按 Escape 取消。",
+    moveWidgetLabel: (widgetTitle: string) => `移动 ${widgetTitle} 卡片`,
     removeWidgetLabel: (widgetTitle: string) =>
       `从仪表板移除 ${widgetTitle} 小组件`,
+    resizeInstructions:
+      "调整大小模式：使用左键和上键缩小，或使用右键和下键按一个网格单元放大。按 Enter 或空格保存，按 Escape 取消。",
+    resizeWidgetLabel: (widgetTitle: string) => `调整 ${widgetTitle} 卡片大小`,
   },
 } satisfies LocalizedMessageCatalog<AgentBentoMessages>;
 

--- a/ui/src/features/bento/messages/agent-bento.ts
+++ b/ui/src/features/bento/messages/agent-bento.ts
@@ -5,6 +5,8 @@ import {
 
 export interface AgentBentoMessages {
   boardLabel: string;
+  cardErrorDescription: string;
+  cardErrorTitle: string;
   layoutChanged: (
     widgetTitle: string,
     layout: { h: number; w: number; x: number; y: number },
@@ -15,6 +17,7 @@ export interface AgentBentoMessages {
   moveInstructions: string;
   moveWidgetLabel: (widgetTitle: string) => string;
   removeWidgetLabel: (widgetTitle: string) => string;
+  retryCard: string;
   resizeInstructions: string;
   resizeWidgetLabel: (widgetTitle: string) => string;
 }
@@ -22,6 +25,9 @@ export interface AgentBentoMessages {
 const agentBentoMessagesByLocale = {
   en: {
     boardLabel: "you-agent-factory bento board",
+    cardErrorDescription:
+      "This dashboard card could not be rendered. Retry it without affecting the rest of your dashboard.",
+    cardErrorTitle: "Dashboard card unavailable",
     layoutBoundary: (widgetTitle: string, mode: "move" | "resize") =>
       `No ${mode} change was possible for ${widgetTitle}; the card is at a boundary or would overlap another card.`,
     layoutChanged: (
@@ -38,12 +44,16 @@ const agentBentoMessagesByLocale = {
     moveWidgetLabel: (widgetTitle: string) => `Move ${widgetTitle} card`,
     removeWidgetLabel: (widgetTitle: string) =>
       `Remove ${widgetTitle} widget from dashboard`,
+    retryCard: "Retry card",
     resizeInstructions:
       "Resize mode: use Left and Up to shrink, or Right and Down to grow by one grid cell. Press Enter or Space to save, or Escape to cancel.",
     resizeWidgetLabel: (widgetTitle: string) => `Resize ${widgetTitle} card`,
   },
   "zh-CN": {
     boardLabel: "you-agent-factory Bento 看板",
+    cardErrorDescription:
+      "此仪表板卡片无法渲染。重试此卡片不会影响仪表板的其余部分。",
+    cardErrorTitle: "仪表板卡片不可用",
     layoutBoundary: (widgetTitle: string, mode: "move" | "resize") =>
       `${widgetTitle} 无法继续${mode === "move" ? "移动" : "调整大小"}；卡片已到边界或会与其他卡片重叠。`,
     layoutChanged: (
@@ -60,6 +70,7 @@ const agentBentoMessagesByLocale = {
     moveWidgetLabel: (widgetTitle: string) => `移动 ${widgetTitle} 卡片`,
     removeWidgetLabel: (widgetTitle: string) =>
       `从仪表板移除 ${widgetTitle} 小组件`,
+    retryCard: "重试卡片",
     resizeInstructions:
       "调整大小模式：使用左键和上键缩小，或使用右键和下键按一个网格单元放大。按 Enter 或空格保存，按 Escape 取消。",
     resizeWidgetLabel: (widgetTitle: string) => `调整 ${widgetTitle} 卡片大小`,


### PR DESCRIPTION
{
  "AAAA00_THE_ONLY_CURRENT_OVERRIDE": "OPERATOR OVERRIDE v2, 2026-08-16 09:55, ISSUED BY THE FACTORY OPERATOR. THIS REPLACES OVERRIDE v1 IN FULL. READ THE 'WHAT CHANGED' SECTION FIRST.\n\nWHAT CHANGED, AND WHICH PART OF v1 WAS WRONG.\nOverride v1 ended by telling you the only work remaining was to rebase, push, and OPEN THE PULL REQUEST, and that all stories were set to passes:true and you should not re-open them. You did that correctly: PR #2024 IS OPEN. That instruction is now SPENT and is HEREBY SUPERSEDED. It was accurate when written and is WRONG NOW, because three BLOCKING reviews have landed since, on your unchanged head ad38e26b1. Any sentence in v1 implying that nothing is left to implement no longer applies. There IS work left to implement, it is listed below, and it is real product work in real product files.\n\nTHIS IS URGENT. You have re-handed the SAME head ad38e26b1 three times. The review circuit breaker kills this lane at three consecutive rejections. Every visit that ends without a NEW COMMIT PUSHED is a visit that feeds the breaker. Push a real code change this visit.\n\nWHAT REMAINS WAIVED, AND WHAT IS NOT.\nSTILL WAIVED: direct human-eye / in-app browser observation. This host has no reachable browser backend. Do not retry it. Do not hold a story open on it.\nEXPLICITLY NOT WAIVED, AND NEVER WAS: the required Frontend Browser CI check, and the Verification Policy check derived from it. Those run on the hosted runner, not on this host, and they are currently RED because of a genuine defect in your change. The reviewer said this in as many words: 'the direct/in-app browser observation remains operator-waived; automated required browser CI is not waived.' Fixing that red is your job and it is the top of your list.\n\nTHE FOUR BLOCKERS, TRANSCRIBED VERBATIM FROM THE REVIEWER. Fix all four.\n\n1. Frontend Browser remains red: the 44px southeast resize handle intercepts visible `Export PNG` controls, and the always-mounted keyboard live region creates duplicate generic `role=\"status\"` elements. Constrain the resize target/stacking without dropping below 44px, add a browser regression proving affected controls remain clickable, and make the live-region semantics non-ambiguous (or intentionally update behavioral locators). Make Frontend Browser and downstream Verification Policy green.\n\n2. Add rendered `scrollWidth <= clientWidth` board measurements at exactly 320, 390, 640, and 768px.\n\n3. Extend the same 44px `getBoundingClientRect()` instrument beyond the isolated nine-button showcase to representative header, toolbar, compact-dashboard, disabled/loading, and icon-only contexts; assert no target overlaps another control; report the same-instrument baseline and final below-44px counts in a PR conversation comment.\n\n4. Add behavioral coverage proving a card-body touch scroll gesture is not captured or persisted as layout editing.\n\nNOTE ON BLOCKER 1: this is a REAL DEFECT, not a test-harness artifact. An enlarged 44x44 southeast resize overlay that sits on top of a visible `Export PNG` button makes that button unclickable for every real user. Enlarging a touch target so it swallows a neighbouring control is a regression, and the browser CI caught it correctly. Constrain the overlay's geometry or stacking so it keeps a 44px target WITHOUT covering sibling controls; do not shrink it below 44px and do not delete the assertion that caught it.\n\nSTORY STATE. Stories 002, 004 and 005 are re-opened to passes:false by the operator, because the reviewer has confirmed them failing on source inspection and on terminal CI. Stories 001 and 003 remain passes:true and the reviewer agrees. Set 002/004/005 back to passes:true ONLY when their listed blocker is actually fixed in code.\n\nDELIVERY CONTRACT FOR THIS LANE.\n- Your finish line is: blockers 1-4 fixed, final head PUSHED, PR #2024 updated, required CI green.\n- MERGED is owned by the review stage, not by you. Do not wait for merge, do not poll CI in a loop, and do not commit CI evidence. Evidence about a CI run goes in a PR comment, never in a commit.\n- Do not open a second PR. #2024 is yours; push to its branch.\n- NEVER use `git stash`. The stash stack is shared repo-wide across roughly ten concurrent worktrees and popping it destroys another lane's work. Isolate a diff with `cp`/`mv` instead.\n- Rebase onto origin/main before your final push. Resolve any generated-file conflict by rerunning the generator, never by hand-editing generated output.\n",
  "project": "Dashboard Bento Responsive and Accessible Layout Editing",
  "branchName": "ux-p5b-bento-responsive-and-accessible-layout",
  "description": "Make the dashboard bento board keyboard- and touch-operable, intentionally compact and overflow-free from 320 through 768px, resilient to individual card render failures, and compliant with a tested 44px minimum dashboard action target while preserving the canonical scoped persistence path delivered by ux-p5a.",
  "context": {
    "customerAsk": "Deliver the responsive layout and accessible-input follow-up identified by dashboard UX item 5 and probes 28 and 30. This lane owns bento grid configuration, responsive geometry, keyboard/touch behavior, the dashboard per-card rendering boundary, and the shared dashboard action-button size contract. It depends on ux-p5a, must start from main after that lane merges, and must use ux-p5a's canonical persistence operation without editing ui/src/features/bento/lib/** or adding a second write path.",
    "problem": "Bento layout editing is pointer-only; widths from 640 through 768px are non-interactive but retain desktop geometry; one card render exception can take down the board; dashboard text actions currently have a 40px minimum and icon-only controls lack proof of a 44px target; and touch move/resize behavior is unproven.",
    "solution": "Add focus-visible keyboard move/resize with announced geometry, define 320-768px inclusive as an overflow-free single-column compact projection that never overwrites the canonical wider layout, contain render failures behind localized per-card retry, enforce and measure a 44-by-44px minimum dashboard action target, and add cancellable touch move/resize. Route every completed input modality through the same ux-p5a layout mutation and persistence operation used by pointer editing."
  },
  "acceptanceCriteria": [
    "A focused test moves and resizes a card using only keyboard events, observes visible focus and announced position/size changes, and proves the resulting layout reaches the same canonical ux-p5a persistence operation used by pointer drag or resize.",
    "At measured board widths of 320, 390, 640, and 768px, cards use the defined compact single-column projection, readable content stays within the board, no horizontal board overflow occurs, and compact projection geometry does not overwrite the persisted wider layout.",
    "When one card throws during render, all other cards and board actions remain usable; only the failed card shows localized recovery UI, and retry can recover it without resetting siblings.",
    "Every rendered dashboard action control, including icon-only and applicable disabled/loading variants, measures at least 44px wide and 44px high; the exact number below 44px before the change is measured with the same instrument and reported in a PR comment.",
    "Touch-only move and resize interactions persist position/size changes through the same canonical operation as pointer and keyboard editing, while cancellation leaves the stored layout unchanged.",
    "Typecheck, focused bento component/browser tests, and applicable UI tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. [OPERATOR-WAIVED 2026-08-16: the browser-verification clause of this criterion ONLY is waived; every other clause still stands.]",
    "The implementation stage is FINISHED when all four of these are true: its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. At that point the implementation stage MUST STOP and end its session. It must NOT poll CI, re-check checks, wait for green, or re-dispatch itself to look again, because each redispatch consumes one of the 12 process visits and the lane dies at 12. It must NOT commit CI evidence or status updates: a new commit creates a new head, invalidates the run it just recorded, and starts another. MERGED is the lane-wide completion boundary but it is owned by the REVIEW stage, NOT by the implementation stage. Review owns driving CI to terminal-and-passing, resolving merge conflicts and shared-file churn, and merging the PR. CI-run evidence and measured before/after numbers go in PR comments, never in commits."
  ],
  "userStories": [
    {
      "id": "ux-p5b-bento-responsive-and-accessible-layout-001",
      "title": "Move and resize cards with a keyboard",
      "description": "As a keyboard-only dashboard user, I want to move and resize the focused card so I can arrange my dashboard without a pointer.",
      "acceptanceCriteria": [
        "Each editable card exposes a keyboard-reachable layout affordance with a visible focus indicator and accessible instructions that distinguish moving from resizing.",
        "Keyboard commands move and resize by deterministic grid increments within existing minimum, bound, and collision rules without triggering unrelated card actions.",
        "Accepted changes announce the card and resulting position or size; rejected boundary operations provide understandable feedback without losing focus.",
        "Keyboard changes call the same feature-owned ux-p5a canonical layout mutation/persistence operation as pointer layout changes, with no second durable write path.",
        "Focused tests use only keyboard events to move and resize, assert the persisted result, compare the invoked persistence seam with pointer editing, and preserve existing pointer regression coverage.",
        "Direct browser verification covers keyboard reachability, focus visibility, move, resize, announcements, and boundary behavior on a wider editable board. [OPERATOR-WAIVED 2026-08-16: this host has no reachable browser backend; the automated rendered/Storybook evidence already recorded in this story's notes is the substitute. Treat as SATISFIED.]",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Keyboard move/resize implementation and focused automated verification are complete. The keyboard controls use the same onLayoutChange seam as pointer editing. OPERATOR 2026-08-16: direct in-app browser observation is waived because this host has no reachable browser backend; the rendered and operation tests are the substitute evidence. This story is passing."
    },
    {
      "id": "ux-p5b-bento-responsive-and-accessible-layout-002",
      "title": "Use a defined compact layout through 768px",
      "description": "As a dashboard user on a phone or tablet-width viewport, I want cards to use a readable compact arrangement so the board never presents clipped desktop geometry.",
      "acceptanceCriteria": [
        "Measured board widths from 320 through 768px inclusive use a deterministic single-column compact projection; wider measured boards use the editable desktop grid.",
        "Tests at exactly 320, 390, 640, and 768px assert full-width compact cards in stable order and prove board scroll width does not exceed available width.",
        "Headers, actions, card-owned loading/empty/error/success content, focus treatment, and intentionally scrollable inner content remain reachable without board-level clipping or overlap.",
        "Entering, rendering, or leaving compact mode never persists projected full-width geometry and restores the canonical wider layout unchanged above 768px.",
        "Direct browser verification covers 320, 390, 640, 768, and one width above 768px, including overflow and compact-round-trip persistence behavior. [OPERATOR-WAIVED 2026-08-16: this host has no reachable browser backend; the automated rendered/Storybook evidence already recorded in this story's notes is the substitute. Treat as SATISFIED.]",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented an inclusive compact projection through 768px, stable visual/DOM order, no projection persistence across breakpoint transitions, and focused measurements at exactly 320, 390, 640, and 768px. Component and Storybook Chromium checks now assert board scrollWidth <= clientWidth and full-width compact cards. Direct in-app browser verification is waived by the operator; automated evidence satisfies this story."
    },
    {
      "id": "ux-p5b-bento-responsive-and-accessible-layout-003",
      "title": "Recover one failed card locally",
      "description": "As a dashboard user, I want a broken card to fail independently and offer retry so I can continue using the rest of my dashboard.",
      "acceptanceCriteria": [
        "One card's render exception is contained locally while sibling cards, board layout, actions, and persisted layout remain mounted and usable.",
        "The failed card shows localized error and retry content with appropriate semantics, keyboard operation, visible focus, and no raw exception details.",
        "Retry remounts only the failed card, preserves its stable identity and geometry, and restores normal content without resetting sibling state.",
        "A repeated render failure stays localized and leaves retry available rather than escalating to a board-wide failure.",
        "Focused tests prove healthy-card continuity, successful recovery, and repeated-failure behavior.",
        "Direct browser verification covers localized failure, keyboard retry, recovered success, and sibling continuity at wide and compact widths. [OPERATOR-WAIVED 2026-08-16: this host has no reachable browser backend; the automated rendered/Storybook evidence already recorded in this story's notes is the substitute. Treat as SATISFIED.]",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented per-card render containment, localized error/retry UI, keyboard retry semantics, subtree-only recovery remount, and focused sibling/repeated-failure tests. OPERATOR 2026-08-16: direct in-app browser observation is waived because this host has no reachable browser backend; the focused rendered tests are the substitute evidence. This story is passing."
    },
    {
      "id": "ux-p5b-bento-responsive-and-accessible-layout-004",
      "title": "Guarantee 44px dashboard action targets",
      "description": "As a dashboard user using touch or limited-precision input, I want every action to have a sufficiently large target so controls are reliable to activate.",
      "acceptanceCriteria": [
        "Shared dashboard text and icon-only actions render an interactive box at least 44px wide and 44px high without counting neighboring whitespace.",
        "The size contract holds for representative enabled, disabled, loading/executing, toolbar, header, and compact states while preserving accessible names, tooltips, focus, and hierarchy.",
        "Behavioral tests measure rendered controls, including icon-only controls, and fail when either interactive dimension is below 44px.",
        "The exact baseline count below 44px is measured with the same instrument and reported in a PR comment; the after-change count is zero and evidence is never committed.",
        "Direct browser verification proves target dimensions and no overlap, clipping, or horizontal board overflow at 320, 390, 640, and 768px. [OPERATOR-WAIVED 2026-08-16: this host has no reachable browser backend; the automated rendered/Storybook evidence already recorded in this story's notes is the substitute. Treat as SATISFIED.]",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Implemented explicit 44px shared dashboard action contracts, protected bento card controls from the 44px southeast resize target, and expanded the same getBoundingClientRect instrument from the original 9-button showcase to 16 representative header, toolbar, compact, disabled, executing, and icon-only controls. Baseline: 0/9 below 44px; final: 0/16 below 44px, with overlap assertions. Storybook Chromium and integration regressions prove affected Export PNG controls remain topmost and clickable. Direct in-app browser verification is waived by the operator."
    },
    {
      "id": "ux-p5b-bento-responsive-and-accessible-layout-005",
      "title": "Move and resize cards with touch",
      "description": "As a touch dashboard user, I want clear move and resize operation so I can arrange cards without a mouse or keyboard.",
      "acceptanceCriteria": [
        "Editable wider-layout cards expose touch move and resize targets meeting the 44px contract without stealing card control taps or scrolling.",
        "Touch-only gestures move and resize within the same grid bounds, minimums, collision rules, and deterministic outcomes as keyboard and pointer input.",
        "Completed touch operations reach the same feature-owned ux-p5a mutation/persistence operation and canonical result as pointer and keyboard editing.",
        "Touch or pointer cancellation leaves the persisted layout unchanged and clears transient gesture state without stranding focus or interaction state.",
        "Compact presentation through 768px remains readable and overflow-free, and projected geometry is not persisted as a touch side effect.",
        "Focused tests prove touch move, resize, cancellation, control-tap isolation, and canonical persistence calls.",
        "Direct browser verification with touch emulation covers move, resize, cancellation, card scrolling/control activation, and persistence after reload. [OPERATOR-WAIVED 2026-08-16: this host has no reachable browser backend; the automated rendered/Storybook evidence already recorded in this story's notes is the substitute. Treat as SATISFIED.]",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": "Implemented touch and touch-pointer move/resize through the canonical layout preview/commit seam, cancellation rollback, control-tap isolation, card-body scroll preservation, and 44px resize handles. Focused component tests now include a behavioral card-body touch scroll assertion, while Storybook Chromium proves the southeast handle remains 44px and does not intercept Export PNG. Typecheck, UI lint, changed-file Biome, and focused component/unit suites pass. Direct in-app browser verification is waived by the operator."
    }
  ]
}
