### PR TITLE
fix(lint): keep the pkg-boundary baseline stable across code motion

### DIFF
--- a/cmd/pkgboundarycheck/recorded_baseline.go
+++ b/cmd/pkgboundarycheck/recorded_baseline.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 )
 
@@ -321,8 +322,38 @@ func clearVisibleRecordedFindings(visible *scanResult) {
 	visible.recordedPetriPublicSurfaceFindings = nil
 }
 
+// volatileBoundaryFindingFields names finding fields that move when unrelated
+// code moves. A recorded baseline identifies a known finding across two trees,
+// so it must survive code motion: splitting a file, extracting a helper, or
+// adding an import above a pre-existing violation all shift its line number
+// without changing what the violation is. Including the line made every such
+// edit re-surface the whole file's recorded findings as new, which failed
+// Backend Lint for lanes that introduced no violation at all.
+//
+// Occurrence counts stay in the fingerprint on purpose: a second construction
+// added to a file raises count, and that is genuine growth the ratchet must
+// still catch.
+var volatileBoundaryFindingFields = map[string]struct{}{"line": {}}
+
 func boundaryFindingFingerprint(category string, finding any) string {
-	return fmt.Sprintf("%s:%T:%#v", category, finding, finding)
+	value := reflect.ValueOf(finding)
+	if value.Kind() != reflect.Struct {
+		return fmt.Sprintf("%s:%T:%#v", category, finding, finding)
+	}
+
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "%s:%T:", category, finding)
+	fields := value.Type()
+	for index := range value.NumField() {
+		name := fields.Field(index).Name
+		if _, volatile := volatileBoundaryFindingFields[strings.ToLower(name)]; volatile {
+			continue
+		}
+		// Format the reflect.Value itself: these finding structs keep their
+		// fields unexported, so Interface() would panic here.
+		fmt.Fprintf(&builder, "%s=%v;", name, value.Field(index))
+	}
+	return builder.String()
 }
 
 func boundaryFindingFingerprints(result scanResult) map[string]struct{} {

--- a/cmd/pkgboundarycheck/recorded_baseline_test.go
+++ b/cmd/pkgboundarycheck/recorded_baseline_test.go
@@ -209,3 +209,54 @@ func runPackageBoundaryProcess(t *testing.T, fixtureRoot string, args ...string)
 	command.Env = append(os.Environ(), packageBoundaryBaseRefEnvironment+"=")
 	return command.CombinedOutput()
 }
+
+func TestRecordedBaselineFingerprintSurvivesLineMotion(t *testing.T) {
+	before := serviceConstructionFinding{
+		owner:      "pkg/services/factory_definitions",
+		importPath: "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire",
+		symbol:     "NewService",
+		filePath:   "tests/functional/factory/definitions/execution_catalog_test.go",
+		line:       348,
+		count:      1,
+	}
+	moved := before
+	moved.line = 386
+
+	if got, want := boundaryFindingFingerprint("service-construction", moved), boundaryFindingFingerprint("service-construction", before); got != want {
+		t.Fatalf("moving a recorded finding to a new line changed its fingerprint:\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestRecordedBaselineFingerprintStillSeparatesRealGrowth(t *testing.T) {
+	base := serviceConstructionFinding{
+		owner:      "pkg/services/work",
+		importPath: "github.com/portpowered/infinite-you/pkg/services/work/wire",
+		symbol:     "NewRuntimeService",
+		filePath:   "pkg/services/factory_runtime/internal/runtime/helpers_test.go",
+		line:       105,
+		count:      1,
+	}
+	baseFingerprint := boundaryFindingFingerprint("service-construction", base)
+
+	extraSelection := base
+	extraSelection.count = 2
+	if boundaryFindingFingerprint("service-construction", extraSelection) == baseFingerprint {
+		t.Fatal("an additional construction selection must not reuse the recorded fingerprint")
+	}
+
+	otherFile := base
+	otherFile.filePath = "pkg/services/factory_runtime/internal/runtime/other_test.go"
+	if boundaryFindingFingerprint("service-construction", otherFile) == baseFingerprint {
+		t.Fatal("the same construction in a different file must not reuse the recorded fingerprint")
+	}
+
+	otherSymbol := base
+	otherSymbol.symbol = "NewProjectionService"
+	if boundaryFindingFingerprint("service-construction", otherSymbol) == baseFingerprint {
+		t.Fatal("a different constructed symbol must not reuse the recorded fingerprint")
+	}
+
+	if boundaryFindingFingerprint("test-service-import", base) == baseFingerprint {
+		t.Fatal("a different finding category must not reuse the recorded fingerprint")
+	}
+}


### PR DESCRIPTION
## Problem

The recorded package-boundary baseline identifies a known finding with

```go
fmt.Sprintf("%s:%T:%#v", category, finding, finding)
```

`%#v` serializes the whole finding struct, and every finding struct carries a `line int`. So the baseline key changes whenever a line moves. Splitting a file, extracting a helper, or adding an import above a pre-existing violation all produce a fingerprint the baseline cannot match, and the unchanged violation is re-reported as new.

The consequence is that **Backend Lint fails for lanes that introduced no violation at all** — precisely the file-split and refactor lanes this program is made of.

Two compounding effects made it hard to read:

- `cmd/pkgboundarycheck` emits no `LINT_VIOLATION_COUNT:` marker, so the ratchet cannot grade the target at all and records it as `unmeasured`. An unmeasured target fails the gate regardless of its count, so the report never showed a number to argue with.
- `Verification Policy` is derived from Backend Lint, so it goes red too and looks like a second, independent defect.

## Evidence

PR #2023 moved a pre-existing `factory_definitions` construction in `tests/functional/factory/definitions/execution_catalog_test.go` from **line 348 to line 386**. The construction is byte-identical to the one on `main`, where `pkg-boundary` reports `pass | 0 | 0 | +0 | clean`. #2023's Backend Lint reported:

```
- pkg-boundary: baseline 0 -> current unknown (delta unknown; unmeasured)
| pkg-boundary | `fail` | 0 | unknown | unknown | 55.66s | unmeasured |
```

with exactly one diagnostic, the moved construction. The lane had two BLOCKING rejections on it.

## Fix

Fingerprint findings on their stable identity, excluding the line number.

Occurrence `count` stays in the fingerprint on purpose: a second construction added to the same file raises count, and that is genuine growth the ratchet must still catch. File path, symbol, owner, import path and category all remain part of the key, so a violation that moves to a different file, or a different symbol in the same file, is still reported as new.

## Verification

A/B on PR #2023's actual head `a624edc85` with two builds of the checker, same command both arms:

| checker | findings | exit |
| --- | ---: | --- |
| `main` | 13 | 1 |
| this branch | 12 | 1 |

The single cleared finding is exactly the one CI reported:

```
- [agent-factory:pkg-boundary] prohibited product-service construction:
    .../factory_definitions/wire.NewService
    (tests/functional/factory/definitions/execution_catalog_test.go:386, 1 selection(s))
```

Nothing else changed. (The head is un-rebased, which is why its absolute count is 13 rather than CI's 1 — CI grades a rebased head. The delta is the point.)

Two regression tests added:

- `TestRecordedBaselineFingerprintSurvivesLineMotion` — the same finding at line 348 and line 386 keeps one fingerprint.
- `TestRecordedBaselineFingerprintStillSeparatesRealGrowth` — a raised occurrence count, a different file, a different symbol, and a different category each produce a **different** fingerprint, so the ratchet still catches real growth.

`go vet ./cmd/pkgboundarycheck/` is clean.

Note: `TestRunBlocksWorkerFailurePolicyInMapping` fails identically on unmodified `main` on this host and is unrelated to this change; `main`'s hosted Backend job is green.

## Follow-up, not in this PR

`cmd/pkgboundarycheck` should emit a `LINT_VIOLATION_COUNT:` line like its sibling checkers, so a pkg-boundary failure reports a gradeable count instead of `unmeasured`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)