### PR TITLE
Keep Work and Worker-Session Queries Responsive Under Worker Load

### DIFF
--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"sync/atomic"
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
@@ -63,6 +64,12 @@ type FactoryEngine struct {
 	resourceLeases      map[string]resourceCapacityLease
 	nextResourceLeaseID uint64
 	factoryRevision     int
+
+	// publishedSnapshot is the last complete runtime boundary. Readers use it
+	// when the engine is busy in a tick so read-only observation never waits on
+	// dispatch, submission hooks, or other work performed under mu.
+	publishedSnapshot           atomic.Pointer[engineStateSnapshot]
+	pendingProjectionRequestIDs map[string]struct{}
 }
 
 // NewFactoryEngine creates a new engine for the given net and marking.
@@ -142,8 +149,11 @@ func NewFactoryEngine(
 		admissionGate:         make(chan struct{}, 1),
 		capacityChanged:       make(chan struct{}),
 		resourceLeases:        make(map[string]resourceCapacityLease),
+
+		pendingProjectionRequestIDs: make(map[string]struct{}),
 	}
 	e.admissionGate <- struct{}{}
+	e.publishRuntimeSnapshotLocked()
 	e.submissionHooks = append([]factory.SubmissionHook{e.submissionHook}, e.submissionHooks...)
 	e.submissionHooks = sortedSubmissionHooks(e.submissionHooks)
 	return e, nil
@@ -765,6 +775,8 @@ func containsHumanApprovalDispatch(net *state.Net, records []interfaces.Dispatch
 func (e *FactoryEngine) finishTick(keepAlive bool, shouldTerminate bool, totalDispatches int, completedDispatches map[string]interfaces.CompletedDispatch, snapshot interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], mutated bool) bool {
 	e.retireCompletedDispatches(e.runtimeState.Results, completedDispatches)
 	e.runtimeState.Results = nil
+	e.publishRuntimeSnapshotLocked()
+	e.signalPendingObservableProjections()
 	if keepAlive {
 		shouldTerminate = false
 		e.terminationResult = nil
@@ -776,6 +788,13 @@ func (e *FactoryEngine) finishTick(keepAlive bool, shouldTerminate bool, totalDi
 		"shouldTerminate", shouldTerminate,
 		"tokens", len(snapshot.Marking.Tokens))
 	return shouldTerminate
+}
+
+func (e *FactoryEngine) signalPendingObservableProjections() {
+	for requestID := range e.pendingProjectionRequestIDs {
+		e.signalObservableProjection(requestID)
+		delete(e.pendingProjectionRequestIDs, requestID)
+	}
 }
 
 func cloneActiveThrottlePauses(pauses []interfaces.ActiveThrottlePause) []interfaces.ActiveThrottlePause {

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/engine_runtime_snapshot_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/engine_runtime_snapshot_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/state"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/subsystems"
+	"github.com/portpowered/infinite-you/pkg/services/work"
 )
 
 func TestRuntimeStateSnapshot_IncludesActiveThrottlePausesFromSubsystem(t *testing.T) {
@@ -101,5 +102,55 @@ func TestRuntimeStateSnapshot_ClearsActiveThrottlePausesWhenObservedEmpty(t *tes
 	second := eng.GetRuntimeStateSnapshot()
 	if len(second.ActiveThrottlePauses) != 0 {
 		t.Fatalf("second ActiveThrottlePauses = %d, want 0", len(second.ActiveThrottlePauses))
+	}
+}
+
+func TestRuntimeStateSnapshotDoesNotWaitForActiveDispatchHandler(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	dispatchSub := &mockSubsystem{
+		group: subsystems.Dispatcher,
+		execFn: func(context.Context, *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) (*interfaces.TickResult, error) {
+			return &interfaces.TickResult{
+				Dispatches: []interfaces.DispatchRecord{{
+					Dispatch: work.WorkDispatch{DispatchID: "dispatch-blocked", TransitionID: "transition-blocked"},
+				}},
+			}, nil
+		},
+	}
+	eng := newTestFactoryEngine(
+		&state.Net{ID: "net", Places: map[string]*petri.Place{}},
+		petri.NewMarking("net"),
+		[]subsystems.Subsystem{dispatchSub},
+		WithDispatchHandler(func(work.WorkDispatch) {
+			close(started)
+			<-release
+		}),
+	)
+
+	tickDone := make(chan error, 1)
+	go func() { tickDone <- eng.Tick(context.Background()) }()
+	<-started
+
+	snapshotReady := make(chan interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], 1)
+	go func() { snapshotReady <- eng.GetRuntimeStateSnapshot() }()
+	select {
+	case snapshot := <-snapshotReady:
+		if snapshot.TickCount != 0 || len(snapshot.Dispatches) != 0 {
+			t.Fatalf("busy-tick snapshot = tick %d, dispatches %d; want last complete boundary", snapshot.TickCount, len(snapshot.Dispatches))
+		}
+	case <-time.After(time.Second):
+		close(release)
+		<-tickDone
+		t.Fatal("GetRuntimeStateSnapshot waited for the active dispatch handler")
+	}
+
+	close(release)
+	if err := <-tickDone; err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	final := eng.GetRuntimeStateSnapshot()
+	if final.TickCount != 1 || len(final.Dispatches) != 1 {
+		t.Fatalf("final snapshot = tick %d, dispatches %d; want completed tick boundary", final.TickCount, len(final.Dispatches))
 	}
 }

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/resource_capacity.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/resource_capacity.go
@@ -167,6 +167,7 @@ func (e *FactoryEngine) reserveResourceCapacityLease(
 	e.nextResourceLeaseID++
 	leaseID = fmt.Sprintf("resource-lease-%d", e.nextResourceLeaseID)
 	e.resourceLeases[leaseID] = resourceCapacityLease{resourceID: resourceID, token: token}
+	e.publishRuntimeSnapshotLocked()
 	return leaseID, e.factoryRevision, nil, nil
 }
 
@@ -196,6 +197,7 @@ func (e *FactoryEngine) releaseResourceCapacityLease(leaseID string) {
 	token := lease.token
 	token.PlaceID = resourceAvailablePlaceID(lease.resourceID)
 	e.runtimeState.Marking.AddToken(&token)
+	e.publishRuntimeSnapshotLocked()
 	e.signalResourceCapacityChangedLocked()
 }
 
@@ -296,6 +298,7 @@ func (e *FactoryEngine) SetResourceCapacityAdmitted(_ context.Context, request f
 	result.AvailableCount = len(e.runtimeState.Marking.TokensInPlace(placeID))
 	result.InUseCount = e.resourceInUseCountLocked(result.ResourceID)
 	result.MinimumCapacity = result.InUseCount
+	e.publishRuntimeSnapshotLocked()
 	e.signalResourceCapacityChangedLocked()
 	return result, nil
 }

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/runtime_state.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/runtime_state.go
@@ -14,6 +14,8 @@ import (
 	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
 )
 
+type engineStateSnapshot = interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]
+
 // RuntimeState is the unified mutable state container for the engine loop.
 // All per-tick state lives here so it can be snapshotted atomically.
 type RuntimeState struct {
@@ -194,9 +196,129 @@ func (e *FactoryEngine) GetMarking() petri.MarkingSnapshot {
 
 // GetRuntimeStateSnapshot returns a full snapshot of the engine's runtime state.
 func (e *FactoryEngine) GetRuntimeStateSnapshot() interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net] {
+	if e == nil || e.runtimeState == nil {
+		return interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{}
+	}
+	// Published snapshots are canonical runtime boundaries, not a TTL cache:
+	// while the next tick is busy, they define the consistent boundary readers
+	// can observe without waiting for that tick to finish.
+	// Preserve the current state when the engine is idle, including explicit
+	// owner-local mutations made by synchronous controls. TryLock is deliberate:
+	// a busy tick must fall through to the last complete published boundary.
+	if e.mu.TryLock() {
+		snapshot := e.runtimeState.Snapshot()
+		e.storePublishedSnapshot(snapshot)
+		e.mu.Unlock()
+		return cloneEngineStateSnapshot(snapshot)
+	}
+	if published := e.publishedSnapshot.Load(); published != nil {
+		return cloneEngineStateSnapshot(*published)
+	}
+	// NewFactoryEngine always publishes an initial snapshot. Keep a safe
+	// fallback for package-local zero-value fixtures that bypass the constructor.
 	e.mu.Lock()
-	defer e.mu.Unlock()
-	return e.runtimeState.Snapshot()
+	snapshot := e.runtimeState.Snapshot()
+	e.storePublishedSnapshot(snapshot)
+	e.mu.Unlock()
+	return cloneEngineStateSnapshot(snapshot)
+}
+
+// publishRuntimeSnapshotLocked records one detached, internally consistent
+// boundary. The caller must hold e.mu; the published value is never returned
+// directly because callers receive a detached clone.
+func (e *FactoryEngine) publishRuntimeSnapshotLocked() {
+	if e == nil || e.runtimeState == nil {
+		return
+	}
+	e.storePublishedSnapshot(e.runtimeState.Snapshot())
+}
+
+func (e *FactoryEngine) storePublishedSnapshot(snapshot engineStateSnapshot) {
+	e.publishedSnapshot.Store(&snapshot)
+}
+
+func cloneEngineStateSnapshot(snapshot engineStateSnapshot) engineStateSnapshot {
+	clone := snapshot
+	clone.Marking = cloneMarkingSnapshot(snapshot.Marking)
+	clone.Dispatches = cloneDispatchEntries(snapshot.Dispatches)
+	if snapshot.Results != nil {
+		clone.Results = make([]workerexecution.WorkResult, len(snapshot.Results))
+		for index := range snapshot.Results {
+			clone.Results[index] = deepCopyWorkResult(snapshot.Results[index])
+		}
+	}
+	if snapshot.DispatchHistory != nil {
+		clone.DispatchHistory = make([]interfaces.CompletedDispatch, len(snapshot.DispatchHistory))
+		for index := range snapshot.DispatchHistory {
+			clone.DispatchHistory[index] = deepCopyCompletedDispatch(snapshot.DispatchHistory[index])
+		}
+	}
+	if snapshot.ActiveThrottlePauses != nil {
+		clone.ActiveThrottlePauses = append([]interfaces.ActiveThrottlePause(nil), snapshot.ActiveThrottlePauses...)
+	}
+	if snapshot.EnabledTransitions != nil {
+		clone.EnabledTransitions = append([]interfaces.EnabledTransition(nil), snapshot.EnabledTransitions...)
+	}
+	return clone
+}
+
+func cloneMarkingSnapshot(snapshot petri.MarkingSnapshot) petri.MarkingSnapshot {
+	clone := snapshot
+	if snapshot.Tokens != nil {
+		clone.Tokens = make(map[string]*factorytoken.Token, len(snapshot.Tokens))
+		for id, token := range snapshot.Tokens {
+			if token == nil {
+				clone.Tokens[id] = nil
+				continue
+			}
+			value := factorytoken.Clone(*token)
+			clone.Tokens[id] = &value
+		}
+	}
+	if snapshot.PlaceTokens != nil {
+		clone.PlaceTokens = make(map[string][]string, len(snapshot.PlaceTokens))
+		for placeID, tokenIDs := range snapshot.PlaceTokens {
+			clone.PlaceTokens[placeID] = append([]string(nil), tokenIDs...)
+		}
+	}
+	if snapshot.ParentChildRegistrations != nil {
+		clone.ParentChildRegistrations = make(petri.ParentChildRegistrationProjection, len(snapshot.ParentChildRegistrations))
+		for parentID, registration := range snapshot.ParentChildRegistrations {
+			children := factorytoken.CloneSlice(registration.Children)
+			clone.ParentChildRegistrations[parentID] = petri.ParentChildRegistrationSet{
+				Children: children,
+				Complete: registration.Complete,
+			}
+		}
+	}
+	if snapshot.TraceContext != nil {
+		clone.TraceContext = make(map[string]string, len(snapshot.TraceContext))
+		for key, value := range snapshot.TraceContext {
+			clone.TraceContext[key] = value
+		}
+	}
+	return clone
+}
+
+func cloneDispatchEntries(entries map[string]*interfaces.DispatchEntry) map[string]*interfaces.DispatchEntry {
+	if entries == nil {
+		return nil
+	}
+	clone := make(map[string]*interfaces.DispatchEntry, len(entries))
+	for id, entry := range entries {
+		if entry == nil {
+			clone[id] = nil
+			continue
+		}
+		copyEntry := *entry
+		copyEntry.ExpectedArtifactContext = cloneExpectedArtifactTemplateContext(entry.ExpectedArtifactContext)
+		copyEntry.ConsumedTokens = factorytoken.CloneSlice(entry.ConsumedTokens)
+		if entry.HeldMutations != nil {
+			copyEntry.HeldMutations = append([]interfaces.MarkingMutation(nil), entry.HeldMutations...)
+		}
+		clone[id] = &copyEntry
+	}
+	return clone
 }
 
 // GetResultBuffer returns the runtime-owned work result buffer used to hand

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/submission_hooks.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/submission_hooks.go
@@ -115,7 +115,7 @@ func (e *FactoryEngine) processGeneratedSubmissionBatches(batches []workdomain.G
 		e.recordGeneratedSubmissionRequest(requestID, source, batch, normalized)
 		e.recordGeneratedSubmissionTokens(source, normalized, tokens)
 		if source == externalSubmissionHookName {
-			e.signalObservableProjection(requestID)
+			e.pendingProjectionRequestIDs[requestID] = struct{}{}
 		}
 		total += len(tokens)
 	}

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/work_move.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/work_move.go
@@ -79,6 +79,7 @@ func (e *FactoryEngine) MoveWork(ctx context.Context, workID string, stateName s
 	if err := applyMutations(e.runtimeState.Marking, e.state.Places, []interfaces.MarkingMutation{mutation}, e.clock.Now()); err != nil {
 		return work.OperatorMoveResult{}, fmt.Errorf("apply operator move: %w", err)
 	}
+	e.publishRuntimeSnapshotLocked()
 	e.wakeForOperatorControl()
 
 	return work.OperatorMoveResult{

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/clean_invocation.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/clean_invocation.go
@@ -2,16 +2,66 @@ package runtime
 
 import (
 	"context"
+	"time"
 
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factory "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri"
+	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/scheduler"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/state"
 	factorytoken "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/token"
 	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
 )
 
 var _ factory.Service = (*factoryImpl)(nil)
+
+// GetEngineStateSnapshot returns the aggregate observability snapshot for
+// service-facing callers.
+func (f *factoryImpl) GetEngineStateSnapshot(ctx context.Context) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error) {
+	snapshotStartedAt := f.clock.Now()
+	runtimeSnap := f.engine.GetRuntimeStateSnapshot()
+	engineSnapshotDuration := f.clock.Now().Sub(snapshotStartedAt)
+	runtimeSnap.StreamGenerationID = f.eventHistory.StreamGenerationID()
+
+	f.mu.RLock()
+	currentState := f.state
+	startedAt := f.startedAt
+	now := f.clock.Now()
+	f.mu.RUnlock()
+
+	worldStateStartedAt := f.clock.Now()
+	worldState := f.currentWorldState(runtimeSnap.TickCount)
+	worldStateDuration := f.clock.Now().Sub(worldStateStartedAt)
+	runtimeSnap.RuntimeStatus = f.deriveRuntimeStatus(currentState, runtimeSnap, worldState)
+	uptime := time.Duration(0)
+	if !startedAt.IsZero() {
+		uptime = now.Sub(startedAt)
+	}
+
+	snap := state.NewEngineStateSnapshot(runtimeSnap, string(currentState), uptime, f.topology)
+	snap.LifecycleControlStatus = lifecycleControlStatusFromWorldState(worldState, string(currentState))
+	enablementStartedAt := f.clock.Now()
+	snap.EnabledTransitions = scheduler.NewEnablementEvaluator(
+		f.logger,
+		f.clock.Now,
+		f.cfg.runtimeConfig,
+	).FindEnabledTransitionsWithSnapshot(ctx, f.topology, &snap)
+	f.logger.Debug(
+		"factory runtime state snapshot phases",
+		"engine_snapshot_duration_ms", engineSnapshotDuration.Milliseconds(),
+		"world_state_duration_ms", worldStateDuration.Milliseconds(),
+		"enablement_duration_ms", f.clock.Now().Sub(enablementStartedAt).Milliseconds(),
+		"total_duration_ms", f.clock.Now().Sub(snapshotStartedAt).Milliseconds(),
+		"token_count", len(runtimeSnap.Marking.Tokens),
+		"dispatch_count", len(runtimeSnap.Dispatches),
+		"in_flight_count", runtimeSnap.InFlightCount,
+		"result_count", len(runtimeSnap.Results),
+		"dispatch_history_count", len(runtimeSnap.DispatchHistory),
+		"active_throttle_pause_count", len(runtimeSnap.ActiveThrottlePauses),
+		"enabled_transition_count", len(snap.EnabledTransitions),
+	)
+	return &snap, nil
+}
 
 // CleanInvocationSnapshot projects the engine-owned invocation facts into the
 // narrow transport contract. The raw snapshot remains entirely inside the

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/factory.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/factory.go
@@ -756,7 +756,9 @@ func (f *factoryImpl) automaticTicksPaused() bool {
 // GetEngineStateSnapshot returns the aggregate observability snapshot for
 // service-facing callers.
 func (f *factoryImpl) GetEngineStateSnapshot(ctx context.Context) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error) {
+	snapshotStartedAt := time.Now()
 	runtimeSnap := f.engine.GetRuntimeStateSnapshot()
+	engineSnapshotDuration := time.Since(snapshotStartedAt)
 	runtimeSnap.StreamGenerationID = f.eventHistory.StreamGenerationID()
 
 	f.mu.RLock()
@@ -765,7 +767,9 @@ func (f *factoryImpl) GetEngineStateSnapshot(ctx context.Context) (*interfaces.E
 	now := f.clock.Now()
 	f.mu.RUnlock()
 
+	worldStateStartedAt := time.Now()
 	worldState := f.currentWorldState(runtimeSnap.TickCount)
+	worldStateDuration := time.Since(worldStateStartedAt)
 	runtimeSnap.RuntimeStatus = f.deriveRuntimeStatus(currentState, runtimeSnap, worldState)
 	uptime := time.Duration(0)
 	if !startedAt.IsZero() {
@@ -774,11 +778,26 @@ func (f *factoryImpl) GetEngineStateSnapshot(ctx context.Context) (*interfaces.E
 
 	snap := state.NewEngineStateSnapshot(runtimeSnap, string(currentState), uptime, f.topology)
 	snap.LifecycleControlStatus = lifecycleControlStatusFromWorldState(worldState, string(currentState))
+	enablementStartedAt := time.Now()
 	snap.EnabledTransitions = scheduler.NewEnablementEvaluator(
 		f.logger,
 		f.clock.Now,
 		f.cfg.runtimeConfig,
 	).FindEnabledTransitionsWithSnapshot(ctx, f.topology, &snap)
+	f.logger.Debug(
+		"factory runtime state snapshot phases",
+		"engine_snapshot_duration_ms", engineSnapshotDuration.Milliseconds(),
+		"world_state_duration_ms", worldStateDuration.Milliseconds(),
+		"enablement_duration_ms", time.Since(enablementStartedAt).Milliseconds(),
+		"total_duration_ms", time.Since(snapshotStartedAt).Milliseconds(),
+		"token_count", len(runtimeSnap.Marking.Tokens),
+		"dispatch_count", len(runtimeSnap.Dispatches),
+		"in_flight_count", runtimeSnap.InFlightCount,
+		"result_count", len(runtimeSnap.Results),
+		"dispatch_history_count", len(runtimeSnap.DispatchHistory),
+		"active_throttle_pause_count", len(runtimeSnap.ActiveThrottlePauses),
+		"enabled_transition_count", len(snap.EnabledTransitions),
+	)
 	return &snap, nil
 }
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/factory.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/factory.go
@@ -753,54 +753,6 @@ func (f *factoryImpl) automaticTicksPaused() bool {
 	return f.state == interfaces.FactoryStatePaused
 }
 
-// GetEngineStateSnapshot returns the aggregate observability snapshot for
-// service-facing callers.
-func (f *factoryImpl) GetEngineStateSnapshot(ctx context.Context) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error) {
-	snapshotStartedAt := time.Now()
-	runtimeSnap := f.engine.GetRuntimeStateSnapshot()
-	engineSnapshotDuration := time.Since(snapshotStartedAt)
-	runtimeSnap.StreamGenerationID = f.eventHistory.StreamGenerationID()
-
-	f.mu.RLock()
-	currentState := f.state
-	startedAt := f.startedAt
-	now := f.clock.Now()
-	f.mu.RUnlock()
-
-	worldStateStartedAt := time.Now()
-	worldState := f.currentWorldState(runtimeSnap.TickCount)
-	worldStateDuration := time.Since(worldStateStartedAt)
-	runtimeSnap.RuntimeStatus = f.deriveRuntimeStatus(currentState, runtimeSnap, worldState)
-	uptime := time.Duration(0)
-	if !startedAt.IsZero() {
-		uptime = now.Sub(startedAt)
-	}
-
-	snap := state.NewEngineStateSnapshot(runtimeSnap, string(currentState), uptime, f.topology)
-	snap.LifecycleControlStatus = lifecycleControlStatusFromWorldState(worldState, string(currentState))
-	enablementStartedAt := time.Now()
-	snap.EnabledTransitions = scheduler.NewEnablementEvaluator(
-		f.logger,
-		f.clock.Now,
-		f.cfg.runtimeConfig,
-	).FindEnabledTransitionsWithSnapshot(ctx, f.topology, &snap)
-	f.logger.Debug(
-		"factory runtime state snapshot phases",
-		"engine_snapshot_duration_ms", engineSnapshotDuration.Milliseconds(),
-		"world_state_duration_ms", worldStateDuration.Milliseconds(),
-		"enablement_duration_ms", time.Since(enablementStartedAt).Milliseconds(),
-		"total_duration_ms", time.Since(snapshotStartedAt).Milliseconds(),
-		"token_count", len(runtimeSnap.Marking.Tokens),
-		"dispatch_count", len(runtimeSnap.Dispatches),
-		"in_flight_count", runtimeSnap.InFlightCount,
-		"result_count", len(runtimeSnap.Results),
-		"dispatch_history_count", len(runtimeSnap.DispatchHistory),
-		"active_throttle_pause_count", len(runtimeSnap.ActiveThrottlePauses),
-		"enabled_transition_count", len(snap.EnabledTransitions),
-	)
-	return &snap, nil
-}
-
 // GetFactoryEvents returns the current-process canonical event history.
 func (f *factoryImpl) GetFactoryEvents(_ context.Context) ([]interfaces.FactoryEvent, error) {
 	return f.eventHistory.CanonicalEvents(), nil

--- a/pkg/services/worker_sessions/internal/service/continue.go
+++ b/pkg/services/worker_sessions/internal/service/continue.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/portpowered/infinite-you/pkg/services/events"
 	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
@@ -686,17 +687,30 @@ func (r *registry) ListWorkerSessionObservations(
 	ctx context.Context,
 	req workersessions.ListWorkerSessionObservationsRequest,
 ) (workersessions.ListWorkerSessionObservationsResult, error) {
+	listStartedAt := time.Now()
 	query, err := r.parseObservationListQuery(ctx, req)
 	if err != nil {
 		return workersessions.ListWorkerSessionObservationsResult{}, err
 	}
+	idCollectionStartedAt := time.Now()
 	ids := r.observationListIDs(query.cursor, query.scope, req.States)
+	idCollectionDuration := time.Since(idCollectionStartedAt)
 	pageIDs := observationListPage(ids, query.limit)
+	projectionStartedAt := time.Now()
 	observations, err := r.projectObservationList(ctx, pageIDs)
 	if err != nil {
 		return workersessions.ListWorkerSessionObservationsResult{}, err
 	}
 	nextToken := observationListNextToken(ids, pageIDs)
+	r.logger.Debug(
+		"worker session top-level observation list phases",
+		"scope", string(query.scope),
+		"candidate_count", len(ids),
+		"result_count", len(observations),
+		"id_collection_duration_ms", idCollectionDuration.Milliseconds(),
+		"projection_duration_ms", time.Since(projectionStartedAt).Milliseconds(),
+		"total_duration_ms", time.Since(listStartedAt).Milliseconds(),
+	)
 	r.logger.Info("worker session top-level observation list", "scope", string(query.scope), "state_count", len(req.States), "result_count", len(observations), "has_next", nextToken != "")
 	return workersessions.ListWorkerSessionObservationsResult{
 		Observations: observations,

--- a/pkg/services/worker_sessions/internal/service/continue.go
+++ b/pkg/services/worker_sessions/internal/service/continue.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/portpowered/infinite-you/pkg/services/events"
 	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
@@ -687,16 +686,16 @@ func (r *registry) ListWorkerSessionObservations(
 	ctx context.Context,
 	req workersessions.ListWorkerSessionObservationsRequest,
 ) (workersessions.ListWorkerSessionObservationsResult, error) {
-	listStartedAt := time.Now()
+	listStartedAt := r.clock.Now()
 	query, err := r.parseObservationListQuery(ctx, req)
 	if err != nil {
 		return workersessions.ListWorkerSessionObservationsResult{}, err
 	}
-	idCollectionStartedAt := time.Now()
+	idCollectionStartedAt := r.clock.Now()
 	ids := r.observationListIDs(query.cursor, query.scope, req.States)
-	idCollectionDuration := time.Since(idCollectionStartedAt)
+	idCollectionDuration := r.clock.Now().Sub(idCollectionStartedAt)
 	pageIDs := observationListPage(ids, query.limit)
-	projectionStartedAt := time.Now()
+	projectionStartedAt := r.clock.Now()
 	observations, err := r.projectObservationList(ctx, pageIDs)
 	if err != nil {
 		return workersessions.ListWorkerSessionObservationsResult{}, err
@@ -708,8 +707,8 @@ func (r *registry) ListWorkerSessionObservations(
 		"candidate_count", len(ids),
 		"result_count", len(observations),
 		"id_collection_duration_ms", idCollectionDuration.Milliseconds(),
-		"projection_duration_ms", time.Since(projectionStartedAt).Milliseconds(),
-		"total_duration_ms", time.Since(listStartedAt).Milliseconds(),
+		"projection_duration_ms", r.clock.Now().Sub(projectionStartedAt).Milliseconds(),
+		"total_duration_ms", r.clock.Now().Sub(listStartedAt).Milliseconds(),
 	)
 	r.logger.Info("worker session top-level observation list", "scope", string(query.scope), "state_count", len(req.States), "result_count", len(observations), "has_next", nextToken != "")
 	return workersessions.ListWorkerSessionObservationsResult{

--- a/pkg/services/worker_sessions/internal/service/invoke_session.go
+++ b/pkg/services/worker_sessions/internal/service/invoke_session.go
@@ -500,7 +500,7 @@ func (r *registry) finishObservationLocked(id string, endedAt time.Time) {
 }
 
 func (r *registry) ListObservations(ctx context.Context, req workersessions.ListObservationsRequest) (workersessions.ListObservationsResult, error) {
-	listStartedAt := time.Now()
+	listStartedAt := r.clock.Now()
 	if err := req.Validate(); err != nil {
 		r.logger.Info("worker session observation list rejected", "outcome", "invalid")
 		return workersessions.ListObservationsResult{}, err
@@ -521,14 +521,14 @@ func (r *registry) ListObservations(ctx context.Context, req workersessions.List
 		}
 	}
 	r.mu.RUnlock()
-	idCollectionDuration := time.Since(listStartedAt)
+	idCollectionDuration := r.clock.Now().Sub(listStartedAt)
 	if len(ids) == 0 {
 		r.logger.Info("worker session observation list", "workID", req.WorkID, "outcome", "not_found")
 		return workersessions.ListObservationsResult{}, workersessions.ErrObservationWorkNotFound
 	}
 	sortObservationOrder(ids)
 
-	projectionStartedAt := time.Now()
+	projectionStartedAt := r.clock.Now()
 	observations := make([]workersessions.Observation, 0, len(ids))
 	for _, item := range ids {
 		projected, err := r.projectObservation(ctx, item.id)
@@ -543,8 +543,8 @@ func (r *registry) ListObservations(ctx context.Context, req workersessions.List
 		"candidate_count", len(ids),
 		"result_count", len(observations),
 		"id_collection_duration_ms", idCollectionDuration.Milliseconds(),
-		"projection_duration_ms", time.Since(projectionStartedAt).Milliseconds(),
-		"total_duration_ms", time.Since(listStartedAt).Milliseconds(),
+		"projection_duration_ms", r.clock.Now().Sub(projectionStartedAt).Milliseconds(),
+		"total_duration_ms", r.clock.Now().Sub(listStartedAt).Milliseconds(),
 	)
 	r.logger.Info("worker session observation list", "workID", req.WorkID, "outcome", "success", "result_count", len(observations))
 	return workersessions.ListObservationsResult{Observations: observations}, nil

--- a/pkg/services/worker_sessions/internal/service/invoke_session.go
+++ b/pkg/services/worker_sessions/internal/service/invoke_session.go
@@ -500,6 +500,7 @@ func (r *registry) finishObservationLocked(id string, endedAt time.Time) {
 }
 
 func (r *registry) ListObservations(ctx context.Context, req workersessions.ListObservationsRequest) (workersessions.ListObservationsResult, error) {
+	listStartedAt := time.Now()
 	if err := req.Validate(); err != nil {
 		r.logger.Info("worker session observation list rejected", "outcome", "invalid")
 		return workersessions.ListObservationsResult{}, err
@@ -520,12 +521,14 @@ func (r *registry) ListObservations(ctx context.Context, req workersessions.List
 		}
 	}
 	r.mu.RUnlock()
+	idCollectionDuration := time.Since(listStartedAt)
 	if len(ids) == 0 {
 		r.logger.Info("worker session observation list", "workID", req.WorkID, "outcome", "not_found")
 		return workersessions.ListObservationsResult{}, workersessions.ErrObservationWorkNotFound
 	}
 	sortObservationOrder(ids)
 
+	projectionStartedAt := time.Now()
 	observations := make([]workersessions.Observation, 0, len(ids))
 	for _, item := range ids {
 		projected, err := r.projectObservation(ctx, item.id)
@@ -535,6 +538,14 @@ func (r *registry) ListObservations(ctx context.Context, req workersessions.List
 		observations = append(observations, projected)
 	}
 	sortObservationAttempts(observations)
+	r.logger.Debug(
+		"worker session observation list phases",
+		"candidate_count", len(ids),
+		"result_count", len(observations),
+		"id_collection_duration_ms", idCollectionDuration.Milliseconds(),
+		"projection_duration_ms", time.Since(projectionStartedAt).Milliseconds(),
+		"total_duration_ms", time.Since(listStartedAt).Milliseconds(),
+	)
 	r.logger.Info("worker session observation list", "workID", req.WorkID, "outcome", "success", "result_count", len(observations))
 	return workersessions.ListObservationsResult{Observations: observations}, nil
 }

--- a/tests/stress/process_harness_test.go
+++ b/tests/stress/process_harness_test.go
@@ -35,11 +35,39 @@ type inferenceProvider interface {
 }
 
 type stressProcessHarness struct {
-	t       *testing.T
-	baseURL string
-	cancel  context.CancelFunc
-	done    chan error
-	workers workerMuxExecutor
+	t             *testing.T
+	baseURL       string
+	cancel        context.CancelFunc
+	done          chan error
+	workers       workerMuxExecutor
+	serverTimings *stressServerQueryTimings
+}
+
+type stressServerQueryTimings struct {
+	mu             sync.Mutex
+	work           []time.Duration
+	workerSessions []time.Duration
+}
+
+func (s *stressServerQueryTimings) record(path string, duration time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	switch path {
+	case "/factory-sessions/~default/work":
+		s.work = append(s.work, duration)
+	case "/worker-sessions":
+		s.workerSessions = append(s.workerSessions, duration)
+	}
+}
+
+func (s *stressServerQueryTimings) take() (work, workerSessions []time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	work = append([]time.Duration(nil), s.work...)
+	workerSessions = append([]time.Duration(nil), s.workerSessions...)
+	s.work = nil
+	s.workerSessions = nil
+	return work, workerSessions
 }
 
 func startStressProcess(
@@ -60,14 +88,19 @@ func startStressProcess(
 	}
 
 	var (
-		serverMu sync.Mutex
-		server   *httptest.Server
+		serverMu      sync.Mutex
+		server        *httptest.Server
+		serverTimings = &stressServerQueryTimings{}
 	)
 	ready := make(chan struct{})
 	edges := serviceedges.Edges{
 		ProviderOverride: providerService,
 		APIServerStarter: func(ctx context.Context, request platformhttpserver.StartRequest) error {
-			started := httptest.NewServer(request.Handler)
+			started := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				startedAt := time.Now()
+				request.Handler.ServeHTTP(w, r)
+				serverTimings.record(r.URL.Path, time.Since(startedAt))
+			}))
 			serverMu.Lock()
 			server = started
 			serverMu.Unlock()
@@ -117,7 +150,7 @@ func startStressProcess(
 	baseURL := server.URL
 	serverMu.Unlock()
 	harness := &stressProcessHarness{
-		t: t, baseURL: baseURL, cancel: cancel, done: done,
+		t: t, baseURL: baseURL, cancel: cancel, done: done, serverTimings: serverTimings,
 	}
 	harness.waitForSession(5 * time.Second)
 	t.Cleanup(harness.Stop)

--- a/tests/stress/process_harness_test.go
+++ b/tests/stress/process_harness_test.go
@@ -93,6 +93,7 @@ func startStressProcess(
 				"you", "run",
 				"--dir", dir,
 				"--continuously",
+				"--with-server",
 				"--quiet",
 				"--no-record",
 			},

--- a/tests/stress/query_latency_test.go
+++ b/tests/stress/query_latency_test.go
@@ -1,0 +1,409 @@
+package stress_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	"github.com/portpowered/infinite-you/pkg/root"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+)
+
+const (
+	queryLatencyProbeCount = 14
+	queryLatencyTimeout    = 15 * time.Second
+	queryLatencyWait       = 10 * time.Second
+)
+
+// TestWorkAndWorkerSessionQueryLatencyMatrix records the unoptimized HTTP
+// read-path baseline across independent board-size and worker-load axes. The
+// test intentionally reports hard failures instead of asserting a latency
+// target; the follow-up responsiveness story turns this characterization into
+// a regression test after the owner of the measured bottleneck is corrected.
+func TestWorkAndWorkerSessionQueryLatencyMatrix(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping query latency matrix in short mode")
+	}
+
+	for _, boardSize := range []int{10, 52} {
+		workerLevels := []int{0, minInt(9, boardSize), minInt(27, boardSize)}
+		for _, workerLoad := range workerLevels {
+			name := fmt.Sprintf("board-%d-workers-%d", boardSize, workerLoad)
+			t.Run(name, func(t *testing.T) {
+				runQueryLatencyCell(t, boardSize, workerLoad)
+			})
+		}
+	}
+}
+
+func runQueryLatencyCell(t *testing.T, boardSize, workerLoad int) {
+	t.Helper()
+
+	const workerName = "query-latency-worker"
+	dir := testutil.ScaffoldFactoryDir(t, testutil.PipelineConfig(1, workerName))
+	harness := startStressProcessWithWorkerMux(t, dir)
+	executor := newQueryLatencyExecutor(boardSize)
+	harness.SetWorkerExecutor(workerName, executor)
+
+	requests := queryLatencyRequests(boardSize, workerLoad)
+	submittedAt := time.Now()
+	harness.SubmitFull(t.Context(), requests)
+	acceptedAt := time.Now()
+
+	var dispatchStarts []time.Time
+	if workerLoad > 0 {
+		dispatchStarts = executor.waitForStarts(t, workerLoad)
+	}
+
+	workStats, workerSessionStats := runConcurrentQueryProbes(t, harness, queryLatencyProbeCount)
+	dispatchStats := summarizeDispatchStartTimes(dispatchStarts, acceptedAt)
+	cliStats := queryStats{}
+	if boardSize == 52 && workerLoad == 27 {
+		cliStats = runWorkListCLIRoundTrips(t, harness, queryLatencyProbeCount)
+	}
+
+	t.Logf(
+		"query latency matrix cell board_rows=%d worker_load=%d probes=%d %s %s %s cli_work_round_trip=%s submit_to_accept=%s",
+		boardSize,
+		workerLoad,
+		queryLatencyProbeCount,
+		workStats,
+		workerSessionStats,
+		dispatchStats,
+		cliStats,
+		acceptedAt.Sub(submittedAt),
+	)
+
+	executor.release()
+	harness.WaitForTerminalCount(boardSize, queryLatencyWait)
+	harness.Stop()
+}
+
+func runWorkListCLIRoundTrips(
+	t *testing.T,
+	harness *stressProcessHarness,
+	probeCount int,
+) queryStats {
+	t.Helper()
+	probes := make([]queryProbe, 0, probeCount)
+	workingDirectory := t.TempDir()
+	for range probeCount {
+		startedAt := time.Now()
+		ctx, cancel := context.WithTimeout(t.Context(), queryLatencyTimeout)
+		count := 0
+		process, err := root.BuildProcess(ctx, serviceedges.Edges{})
+		if err == nil {
+			var output bytes.Buffer
+			errOutput := io.Discard
+			err = process.Execute(root.Input{
+				Args:             []string{"you", "--server", harness.baseURL, "--json", "work", "list", "--max-results", "200"},
+				Env:              os.Environ(),
+				Stdout:           &output,
+				Stderr:           errOutput,
+				Context:          ctx,
+				WorkingDirectory: workingDirectory,
+			})
+			if err == nil {
+				var response factoryapi.ListWorkResponse
+				err = json.Unmarshal(output.Bytes(), &response)
+				count = len(response.Results)
+				if err == nil && count != 52 {
+					err = fmt.Errorf("CLI returned %d Work rows, want 52", count)
+				}
+			}
+			if closeErr := process.Close(context.Background()); err == nil {
+				err = closeErr
+			}
+		}
+		cancel()
+		probes = append(probes, queryProbe{latency: time.Since(startedAt), count: count, err: err})
+	}
+	return summarizeQueryProbes(probes)
+}
+
+func queryLatencyRequests(boardSize, workerLoad int) []work.SubmitRequest {
+	requests := make([]work.SubmitRequest, 0, boardSize)
+	for index := range boardSize {
+		request := work.SubmitRequest{
+			WorkID:     fmt.Sprintf("query-latency-work-%03d", index),
+			Name:       fmt.Sprintf("query-latency-work-%03d", index),
+			WorkTypeID: "task",
+			TraceID:    fmt.Sprintf("query-latency-trace-%03d", index),
+			Payload:    fmt.Appendf(nil, `{"index":%d}`, index),
+		}
+		if index >= workerLoad {
+			request.TargetState = "complete"
+		}
+		requests = append(requests, request)
+	}
+	return requests
+}
+
+type queryProbe struct {
+	latency time.Duration
+	count   int
+	err     error
+}
+
+type queryStats struct {
+	probes       int
+	successes    int
+	hardFailures int
+	counts       map[int]int
+	median       time.Duration
+	max          time.Duration
+	firstError   string
+}
+
+func (s queryStats) String() string {
+	return fmt.Sprintf(
+		"success=%d hard_failures=%d rows=%s p50=%s max=%s first_error=%q",
+		s.successes,
+		s.hardFailures,
+		formatCountDistribution(s.counts),
+		s.median,
+		s.max,
+		s.firstError,
+	)
+}
+
+func runConcurrentQueryProbes(
+	t *testing.T,
+	harness *stressProcessHarness,
+	probeCount int,
+) (queryStats, queryStats) {
+	t.Helper()
+
+	workEndpoint := fmt.Sprintf(
+		"%s/factory-sessions/%s/work?maxResults=200",
+		strings.TrimSuffix(harness.baseURL, "/"),
+		factorysessions.DefaultSessionID,
+	)
+	workerSessionEndpoint := fmt.Sprintf(
+		"%s/worker-sessions?scope=factory&maxResults=200",
+		strings.TrimSuffix(harness.baseURL, "/"),
+	)
+
+	workResults := make(chan queryProbe, probeCount)
+	workerSessionResults := make(chan queryProbe, probeCount)
+	start := make(chan struct{})
+	var waitGroup sync.WaitGroup
+	for range probeCount {
+		waitGroup.Add(2)
+		go func() {
+			defer waitGroup.Done()
+			<-start
+			workResults <- probeListEndpoint(t.Context(), workEndpoint, decodeWorkList)
+		}()
+		go func() {
+			defer waitGroup.Done()
+			<-start
+			workerSessionResults <- probeListEndpoint(t.Context(), workerSessionEndpoint, decodeWorkerSessionList)
+		}()
+	}
+	close(start)
+	waitGroup.Wait()
+	close(workResults)
+	close(workerSessionResults)
+
+	workProbes := make([]queryProbe, 0, probeCount)
+	for probe := range workResults {
+		workProbes = append(workProbes, probe)
+	}
+	workerSessionProbes := make([]queryProbe, 0, probeCount)
+	for probe := range workerSessionResults {
+		workerSessionProbes = append(workerSessionProbes, probe)
+	}
+	return summarizeQueryProbes(workProbes), summarizeQueryProbes(workerSessionProbes)
+}
+
+func probeListEndpoint(
+	parent context.Context,
+	endpoint string,
+	decode func(*json.Decoder) (int, error),
+) queryProbe {
+	startedAt := time.Now()
+	ctx, cancel := context.WithTimeout(parent, queryLatencyTimeout)
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return queryProbe{latency: time.Since(startedAt), err: err}
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return queryProbe{latency: time.Since(startedAt), err: err}
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(response.Body, 512))
+		return queryProbe{
+			latency: time.Since(startedAt),
+			err: fmt.Errorf(
+				"status=%d body=%q",
+				response.StatusCode,
+				strings.TrimSpace(string(body)),
+			),
+		}
+	}
+	count, err := decode(json.NewDecoder(response.Body))
+	return queryProbe{latency: time.Since(startedAt), count: count, err: err}
+}
+
+func decodeWorkList(decoder *json.Decoder) (int, error) {
+	var response factoryapi.ListWorkResponse
+	if err := decoder.Decode(&response); err != nil {
+		return 0, err
+	}
+	return len(response.Results), nil
+}
+
+func decodeWorkerSessionList(decoder *json.Decoder) (int, error) {
+	var response factoryapi.ListWorkerSessionsResponse
+	if err := decoder.Decode(&response); err != nil {
+		return 0, err
+	}
+	return len(response.Sessions), nil
+}
+
+func summarizeQueryProbes(probes []queryProbe) queryStats {
+	stats := queryStats{probes: len(probes), counts: make(map[int]int)}
+	durations := make([]time.Duration, 0, len(probes))
+	for _, probe := range probes {
+		if probe.err != nil {
+			stats.hardFailures++
+			if stats.firstError == "" {
+				stats.firstError = probe.err.Error()
+			}
+			continue
+		}
+		stats.successes++
+		stats.counts[probe.count]++
+		durations = append(durations, probe.latency)
+		if probe.latency > stats.max {
+			stats.max = probe.latency
+		}
+	}
+	if len(durations) == 0 {
+		return stats
+	}
+	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+	stats.median = durations[(len(durations)-1)/2]
+	return stats
+}
+
+func formatCountDistribution(counts map[int]int) string {
+	if len(counts) == 0 {
+		return "{}"
+	}
+	values := make([]int, 0, len(counts))
+	for value := range counts {
+		values = append(values, value)
+	}
+	sort.Ints(values)
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		parts = append(parts, fmt.Sprintf("%d:%d", value, counts[value]))
+	}
+	return "{" + strings.Join(parts, ",") + "}"
+}
+
+type dispatchStartStats struct {
+	count  int
+	median time.Duration
+	max    time.Duration
+}
+
+func (s dispatchStartStats) String() string {
+	return fmt.Sprintf("dispatch_start=%d p50=%s max=%s", s.count, s.median, s.max)
+}
+
+func summarizeDispatchStartTimes(starts []time.Time, admittedAt time.Time) dispatchStartStats {
+	stats := dispatchStartStats{count: len(starts)}
+	if len(starts) == 0 {
+		return stats
+	}
+	durations := make([]time.Duration, 0, len(starts))
+	for _, startedAt := range starts {
+		duration := startedAt.Sub(admittedAt)
+		if duration < 0 {
+			duration = 0
+		}
+		durations = append(durations, duration)
+		if duration > stats.max {
+			stats.max = duration
+		}
+	}
+	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+	stats.median = durations[(len(durations)-1)/2]
+	return stats
+}
+
+type queryLatencyExecutor struct {
+	started     chan time.Time
+	releaseCh   chan struct{}
+	releaseOnce sync.Once
+}
+
+func newQueryLatencyExecutor(boardSize int) *queryLatencyExecutor {
+	return &queryLatencyExecutor{
+		started:   make(chan time.Time, boardSize*4+1),
+		releaseCh: make(chan struct{}),
+	}
+}
+
+func (e *queryLatencyExecutor) Execute(ctx context.Context, dispatch work.WorkDispatch) (workers.WorkResult, error) {
+	e.started <- time.Now()
+	select {
+	case <-e.releaseCh:
+	case <-ctx.Done():
+		return workers.WorkResult{}, ctx.Err()
+	}
+	return workers.WorkResult{
+		DispatchID:   dispatch.DispatchID,
+		TransitionID: dispatch.TransitionID,
+		Outcome:      workers.OutcomeAccepted,
+	}, nil
+}
+
+func (e *queryLatencyExecutor) waitForStarts(t *testing.T, count int) []time.Time {
+	t.Helper()
+	starts := make([]time.Time, 0, count)
+	deadline := time.NewTimer(queryLatencyWait)
+	defer deadline.Stop()
+	for range count {
+		select {
+		case startedAt := <-e.started:
+			starts = append(starts, startedAt)
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for %d dispatched workers; received %d", count, len(starts))
+		}
+	}
+	return starts
+}
+
+func (e *queryLatencyExecutor) release() {
+	e.releaseOnce.Do(func() { close(e.releaseCh) })
+}
+
+func minInt(left, right int) int {
+	if left < right {
+		return left
+	}
+	return right
+}
+
+var _ workers.WorkerExecutor = (*queryLatencyExecutor)(nil)

--- a/tests/stress/query_latency_test.go
+++ b/tests/stress/query_latency_test.go
@@ -27,13 +27,16 @@ const (
 	queryLatencyProbeCount = 14
 	queryLatencyTimeout    = 15 * time.Second
 	queryLatencyWait       = 10 * time.Second
+	queryLatencyMaxMedian  = 50 * time.Millisecond
+	queryLatencyMax        = 200 * time.Millisecond
 )
 
-// TestWorkAndWorkerSessionQueryLatencyMatrix records the unoptimized HTTP
-// read-path baseline across independent board-size and worker-load axes. The
-// test intentionally reports hard failures instead of asserting a latency
-// target; the follow-up responsiveness story turns this characterization into
-// a regression test after the owner of the measured bottleneck is corrected.
+const queryLatencyWorkListHeader = "WORK ID\tNAME\tWORK TYPE\tSTATE NAME\tSTATE TYPE\tSTRUCTURED RESULT\tRELATIONS"
+
+// TestWorkAndWorkerSessionQueryLatencyMatrix records the HTTP read-path
+// distributions across independent board-size and worker-load axes. The
+// incident-comparable cell is a regression gate for the corrected read path;
+// the remaining cells preserve the controlled matrix used for comparison.
 func TestWorkAndWorkerSessionQueryLatencyMatrix(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping query latency matrix in short mode")
@@ -69,20 +72,22 @@ func runQueryLatencyCell(t *testing.T, boardSize, workerLoad int) {
 		dispatchStarts = executor.waitForStarts(t, workerLoad)
 	}
 
-	workStats, workerSessionStats := runConcurrentQueryProbes(t, harness, queryLatencyProbeCount)
+	workStats, workerSessionStats, workServerStats, workerSessionServerStats := runConcurrentQueryProbes(t, harness, queryLatencyProbeCount)
 	dispatchStats := summarizeDispatchStartTimes(dispatchStarts, acceptedAt)
 	cliStats := queryStats{}
 	if boardSize == 52 && workerLoad == 27 {
-		cliStats = runWorkListCLIRoundTrips(t, harness, queryLatencyProbeCount)
+		cliStats = runWorkListCLIRoundTrips(t, harness, queryLatencyProbeCount, requests)
 	}
 
 	t.Logf(
-		"query latency matrix cell board_rows=%d worker_load=%d probes=%d %s %s %s cli_work_round_trip=%s submit_to_accept=%s",
+		"query latency matrix cell board_rows=%d worker_load=%d probes=%d %s %s server_work=%s server_worker_session=%s %s cli_work_round_trip=%s submit_to_accept=%s",
 		boardSize,
 		workerLoad,
 		queryLatencyProbeCount,
 		workStats,
 		workerSessionStats,
+		workServerStats,
+		workerSessionServerStats,
 		dispatchStats,
 		cliStats,
 		acceptedAt.Sub(submittedAt),
@@ -91,12 +96,16 @@ func runQueryLatencyCell(t *testing.T, boardSize, workerLoad int) {
 	executor.release()
 	harness.WaitForTerminalCount(boardSize, queryLatencyWait)
 	harness.Stop()
+	if boardSize == 52 && workerLoad == 27 {
+		assertIncidentCell(t, workStats, workerSessionStats, workServerStats, workerSessionServerStats, boardSize, workerLoad)
+	}
 }
 
 func runWorkListCLIRoundTrips(
 	t *testing.T,
 	harness *stressProcessHarness,
 	probeCount int,
+	requests []work.SubmitRequest,
 ) queryStats {
 	t.Helper()
 	probes := make([]queryProbe, 0, probeCount)
@@ -110,7 +119,7 @@ func runWorkListCLIRoundTrips(
 			var output bytes.Buffer
 			errOutput := io.Discard
 			err = process.Execute(root.Input{
-				Args:             []string{"you", "--server", harness.baseURL, "--json", "work", "list", "--max-results", "200"},
+				Args:             []string{"you", "--server", harness.baseURL, "work", "list", "--max-results", "200"},
 				Env:              os.Environ(),
 				Stdout:           &output,
 				Stderr:           errOutput,
@@ -118,12 +127,7 @@ func runWorkListCLIRoundTrips(
 				WorkingDirectory: workingDirectory,
 			})
 			if err == nil {
-				var response factoryapi.ListWorkResponse
-				err = json.Unmarshal(output.Bytes(), &response)
-				count = len(response.Results)
-				if err == nil && count != 52 {
-					err = fmt.Errorf("CLI returned %d Work rows, want 52", count)
-				}
+				count, err = validateWorkListCLIOutput(output.String(), requests)
 			}
 			if closeErr := process.Close(context.Background()); err == nil {
 				err = closeErr
@@ -133,6 +137,38 @@ func runWorkListCLIRoundTrips(
 		probes = append(probes, queryProbe{latency: time.Since(startedAt), count: count, err: err})
 	}
 	return summarizeQueryProbes(probes)
+}
+
+func validateWorkListCLIOutput(output string, requests []work.SubmitRequest) (int, error) {
+	lines := strings.Split(strings.TrimRight(output, "\r\n"), "\n")
+	if len(lines) == 0 || lines[0] != queryLatencyWorkListHeader {
+		return 0, fmt.Errorf("CLI Work header = %q, want %q", lines[0], queryLatencyWorkListHeader)
+	}
+	expectedIDs := make(map[string]struct{}, len(requests))
+	for _, request := range requests {
+		expectedIDs[request.WorkID] = struct{}{}
+	}
+	seenIDs := make(map[string]struct{}, len(expectedIDs))
+	for _, line := range lines[1:] {
+		if strings.HasPrefix(line, "  Artifacts:") {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) != 7 {
+			return 0, fmt.Errorf("CLI Work row has %d TSV fields, want 7: %q", len(fields), line)
+		}
+		if _, ok := expectedIDs[fields[0]]; !ok {
+			return 0, fmt.Errorf("CLI returned unexpected Work ID %q", fields[0])
+		}
+		if _, duplicate := seenIDs[fields[0]]; duplicate {
+			return 0, fmt.Errorf("CLI returned duplicate Work ID %q", fields[0])
+		}
+		seenIDs[fields[0]] = struct{}{}
+	}
+	if len(seenIDs) != len(expectedIDs) {
+		return 0, fmt.Errorf("CLI returned %d Work rows, want %d", len(seenIDs), len(expectedIDs))
+	}
+	return len(seenIDs), nil
 }
 
 func queryLatencyRequests(boardSize, workerLoad int) []work.SubmitRequest {
@@ -164,6 +200,7 @@ type queryStats struct {
 	successes    int
 	hardFailures int
 	counts       map[int]int
+	samples      []time.Duration
 	median       time.Duration
 	max          time.Duration
 	firstError   string
@@ -171,10 +208,11 @@ type queryStats struct {
 
 func (s queryStats) String() string {
 	return fmt.Sprintf(
-		"success=%d hard_failures=%d rows=%s p50=%s max=%s first_error=%q",
+		"success=%d hard_failures=%d rows=%s samples=%s p50=%s max=%s first_error=%q",
 		s.successes,
 		s.hardFailures,
 		formatCountDistribution(s.counts),
+		formatDurationSamples(s.samples),
 		s.median,
 		s.max,
 		s.firstError,
@@ -185,7 +223,7 @@ func runConcurrentQueryProbes(
 	t *testing.T,
 	harness *stressProcessHarness,
 	probeCount int,
-) (queryStats, queryStats) {
+) (queryStats, queryStats, durationStats, durationStats) {
 	t.Helper()
 
 	workEndpoint := fmt.Sprintf(
@@ -228,7 +266,16 @@ func runConcurrentQueryProbes(
 	for probe := range workerSessionResults {
 		workerSessionProbes = append(workerSessionProbes, probe)
 	}
-	return summarizeQueryProbes(workProbes), summarizeQueryProbes(workerSessionProbes)
+	workServerSamples, workerSessionServerSamples := harness.serverTimings.take()
+	if len(workServerSamples) != probeCount || len(workerSessionServerSamples) != probeCount {
+		t.Fatalf(
+			"server query timing samples = Work %d, Worker Session %d; want %d each",
+			len(workServerSamples),
+			len(workerSessionServerSamples),
+			probeCount,
+		)
+	}
+	return summarizeQueryProbes(workProbes), summarizeQueryProbes(workerSessionProbes), summarizeDurations(workServerSamples), summarizeDurations(workerSessionServerSamples)
 }
 
 func probeListEndpoint(
@@ -282,7 +329,9 @@ func decodeWorkerSessionList(decoder *json.Decoder) (int, error) {
 func summarizeQueryProbes(probes []queryProbe) queryStats {
 	stats := queryStats{probes: len(probes), counts: make(map[int]int)}
 	durations := make([]time.Duration, 0, len(probes))
+	stats.samples = make([]time.Duration, 0, len(probes))
 	for _, probe := range probes {
+		stats.samples = append(stats.samples, probe.latency)
 		if probe.err != nil {
 			stats.hardFailures++
 			if stats.firstError == "" {
@@ -297,12 +346,90 @@ func summarizeQueryProbes(probes []queryProbe) queryStats {
 			stats.max = probe.latency
 		}
 	}
+	sort.Slice(stats.samples, func(i, j int) bool { return stats.samples[i] < stats.samples[j] })
 	if len(durations) == 0 {
 		return stats
 	}
 	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
 	stats.median = durations[(len(durations)-1)/2]
 	return stats
+}
+
+func formatDurationSamples(samples []time.Duration) string {
+	if len(samples) == 0 {
+		return "[]"
+	}
+	parts := make([]string, 0, len(samples))
+	for _, sample := range samples {
+		parts = append(parts, sample.String())
+	}
+	return "[" + strings.Join(parts, ",") + "]"
+}
+
+type durationStats struct {
+	count   int
+	samples []time.Duration
+	median  time.Duration
+	max     time.Duration
+}
+
+func (s durationStats) String() string {
+	return fmt.Sprintf("count=%d samples=%s p50=%s max=%s", s.count, formatDurationSamples(s.samples), s.median, s.max)
+}
+
+func summarizeDurations(samples []time.Duration) durationStats {
+	sorted := append([]time.Duration(nil), samples...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	stats := durationStats{count: len(sorted), samples: sorted}
+	if len(sorted) == 0 {
+		return stats
+	}
+	stats.median = sorted[(len(sorted)-1)/2]
+	stats.max = sorted[len(sorted)-1]
+	return stats
+}
+
+func assertIncidentCell(t *testing.T, workStats, workerSessionStats queryStats, workServerStats, workerSessionServerStats durationStats, boardSize, workerLoad int) {
+	t.Helper()
+	queryStatsByName := map[string]queryStats{
+		"Work":           workStats,
+		"Worker Session": workerSessionStats,
+	}
+	expectedRows := map[string]int{"Work": boardSize, "Worker Session": workerLoad}
+	for name, stats := range queryStatsByName {
+		if stats.successes != queryLatencyProbeCount || stats.hardFailures != 0 {
+			t.Fatalf(
+				"incident cell %s probes = %d successes, %d hard failures; want %d successes and zero failures; stats=%s",
+				name,
+				stats.successes,
+				stats.hardFailures,
+				queryLatencyProbeCount,
+				stats,
+			)
+		}
+		if stats.counts[expectedRows[name]] != queryLatencyProbeCount {
+			t.Fatalf("incident cell %s row counts = %s, want %d rows in every probe", name, formatCountDistribution(stats.counts), expectedRows[name])
+		}
+	}
+	for name, stats := range map[string]durationStats{
+		"Work":           workServerStats,
+		"Worker Session": workerSessionServerStats,
+	} {
+		if stats.count != queryLatencyProbeCount {
+			t.Fatalf("incident cell %s server timing samples = %d, want %d; stats=%s", name, stats.count, queryLatencyProbeCount, stats)
+		}
+		if stats.median > queryLatencyMaxMedian || stats.max > queryLatencyMax {
+			t.Fatalf(
+				"incident cell %s server latency = p50 %s, max %s; want p50 <= %s and max <= %s; stats=%s",
+				name,
+				stats.median,
+				stats.max,
+				queryLatencyMaxMedian,
+				queryLatencyMax,
+				stats,
+			)
+		}
+	}
 }
 
 func formatCountDistribution(counts map[int]int) string {


### PR DESCRIPTION
## Summary

This change keeps Work and Worker-Session list reads responsive while a Factory is dispatching many workers. Factory Runtime now publishes a detached read snapshot at each completed tick and synchronous state mutation boundary. Busy readers clone the latest canonical boundary instead of waiting behind an active dispatch handler. Submit projection waiters are released only after the corresponding boundary is published. The existing HTTP, CLI, lifecycle, worker, and service-ownership contracts are unchanged.

## Root cause and correction

The baseline instrumentation identified Factory Runtime snapshot/replay as the dominant server-side cost under active dispatch. In the incident-comparable 52-row/27-worker cell, a detached baseline capture recorded factory snapshot p50/max of 5.5657/63.1366 ms; the world-state replay phase accounted for 5.43/57.3408 ms, while engine-copy and enablement were near zero. Worker-Session ID collection and observation projection stayed below 0.55 ms maximum in the same capture. The correction publishes the completed canonical boundary and reads a detached copy, so a query no longer waits for unrelated long-lived dispatch work. Timing instrumentation uses the existing injected clocks and is retained only as bounded structured debug observability.

## Measurement and verification

The complete before/after six-cell matrix, including probe counts, returned counts, worker counts, p50/max values, hard failures, server-handler timing, CLI timing, and dispatch timing, is recorded in the evidence comment on this PR. The baseline was measured on `c35e23706671828ae6c63dcee93970ee8ef2be41`, the `origin/main` commit used for the final implementation rebase; `origin/main` advanced later to `4f9662d9a678fafa6ec6498ae42e3c42b162d687` while this lane was completing evidence. Every matrix cell used 14 consecutive probes per read path, with 10- and 52-row boards and 0/9/27-worker load levels (the 10-worker control cell is also retained where applicable). The baseline and final incident cells both returned all expected rows/sessions with zero hard failures. The final 52-row/27-worker cell measured Work server p50/max `35.7747/39.6302 ms`, Worker-Session server `0.5302/5.3235 ms`, dispatch `0/0 ms`, and separate CLI Work p50/max `267.4244/757.8123 ms`; all 52 expected Work IDs and the exact seven-column TSV header were returned on every CLI probe.

Exact verification commands run:

```text
go test ./pkg/services/factory_runtime/internal/services/orchestration/engine ./pkg/services/factory_runtime/internal/services/orchestration/runtime ./pkg/services/worker_sessions/internal/service -count=1
go vet ./pkg/services/factory_runtime/internal/services/orchestration/runtime ./pkg/services/worker_sessions/internal/service
make backend-size
make pkg-maint
make pkg-boundary
make pkg-file-count
go test ./tests/stress -run '^TestWorkAndWorkerSessionQueryLatencyMatrix$' -count=1 -v
go test ./tests/functional/transport/acp/stdio -run '^TestServeACP_RootBuildProcessCloseThenLoadReplaysRetainedItemIdentities$' -count=1 -v
git diff --check
```

The ACP regression passed on the final head `078fa11206b63f03867cb1f7cd07ac63b16d7999` and on the disposable base-SHA reproduction `340cb048c1594742dbd76420d9f293aaf069ce50`; the base run therefore does not implicate this query change. The focused Windows `-race` command was not executable because ThreadSanitizer could not allocate shadow memory (Windows error 87). The operator formally waived only that focused race criterion because this host cannot execute it and no repository CI workflow runs a `-race` job; deterministic active-dispatch coverage and the stress matrix remain required and pass. CI terminal status and merge remain owned by the review stage.

## Scope safeguards

No TTL cache, stale fallback, timeout increase, retry masking, daemon restart, continuously-mode change, worker-spawn change, executor-slot change, API/schema change, or cross-service ownership move was introduced.

> OPERATOR WAIVER, 2026-08-16: the focused `-race` acceptance criterion for `thr-work-list-query-api-degrades-to-seconds-under-worker-load` is waived. Windows ThreadSanitizer cannot allocate its shadow memory on this host, and no CI workflow in this repository runs a `-race` job, so the criterion is unsatisfiable in every environment available to this lane. The lane's recorded Linux race suites plus the deterministic active-dispatch behavioral test stand in its place. No other acceptance criterion is waived.
