### PR TITLE
thr-deflake-filewatcher-duplicate-stale-signal

### DIFF
--- a/pkg/services/automations/internal/services/filesystem_watchers/internal/service/debounce_test.go
+++ b/pkg/services/automations/internal/services/filesystem_watchers/internal/service/debounce_test.go
@@ -249,7 +249,14 @@ func writeLocalFile(path string, content []byte) error {
 func waitForSubmitCount(t *testing.T, submitter *recordingSubmitter, want int) {
 	t.Helper()
 	deadline := time.After(time.Second)
-	for submitter.submitCallCount() < want {
+	for {
+		if submitter.submitCallCount() >= want {
+			// The count is authoritative. Clear notifications for submissions
+			// already included in the count so callers cannot mistake an old
+			// edge-triggered signal for new work.
+			submitter.drainSubmitted()
+			return
+		}
 		select {
 		case <-submitter.submitted:
 		case <-time.After(10 * time.Millisecond):

--- a/pkg/services/automations/internal/services/filesystem_watchers/internal/service/duplicate_test.go
+++ b/pkg/services/automations/internal/services/filesystem_watchers/internal/service/duplicate_test.go
@@ -151,7 +151,7 @@ func TestFileWatcher_DuplicateLiveObservationSubmitsOnce(t *testing.T) {
 		}
 		select {
 		case <-submitter.submitted:
-			t.Fatal("unexpected second submission for duplicate observation")
+			// Notifications only wake the loop; the count check is authoritative.
 		case <-deadline:
 			cancel()
 			waitForWatchDone(t, done)

--- a/pkg/services/automations/internal/services/filesystem_watchers/internal/service/test_helpers.go
+++ b/pkg/services/automations/internal/services/filesystem_watchers/internal/service/test_helpers.go
@@ -43,6 +43,19 @@ func (m *recordingSubmitter) submitCallCount() int {
 	return len(m.workRequests)
 }
 
+func (m *recordingSubmitter) drainSubmitted() {
+	if m.submitted == nil {
+		return
+	}
+	for {
+		select {
+		case <-m.submitted:
+		default:
+			return
+		}
+	}
+}
+
 func cloneWorkRequest(request work.WorkRequest) work.WorkRequest {
 	out := request
 	out.Works = make([]work.Work, len(request.Works))


### PR DESCRIPTION
{
  "project": "Deflake the file-watcher duplicate-observation regression test",
  "branchName": "thr-deflake-filewatcher-duplicate-stale-signal",
  "description": "Restore reliable Backend Unit Coverage with a test-only correction that prevents a stale buffered notification from masquerading as a second filesystem-watcher submission while preserving proof that duplicate live observations submit exactly once.",
  "context": {
    "customerAsk": "Deflake TestFileWatcher_DuplicateLiveObservationSubmitsOnce, preserve its duplicate-suppression regression coverage, change only the allowlisted filesystem-watcher test files, rebase onto origin/main before the final push, and deliver through the implementation/review PR loop.",
    "problem": "The shared wait helper can return after observing the monotonic submission count without consuming the buffered notification for that same submission. The duplicate test's later channel receive can mistake this stale first-submission signal for a second submission, intermittently failing required Backend Unit Coverage even though Submit ran only once.",
    "solution": "Treat the mutex-protected submission count as authoritative, make successful wait synchronization leave already-counted notification state defined, and assert over the existing 200 ms settle window that the count never exceeds one. Verify all current recordingSubmitter users in the owned test files, run 50 repeated package-test executions, and use a fully reverted uncommitted double-submit negative control to prove the regression guard remains sensitive."
  },
  "acceptanceCriteria": [
    "TestFileWatcher_DuplicateLiveObservationSubmitsOnce retains its 200 ms settle window, uses the monotonic submission count to detect a real second submission, and never treats a buffered notification alone as proof that Submit ran again.",
    "waitForSubmitCount returns with notification state for already-counted submissions drained or otherwise defined, and all current recordingSubmitter users in duplicate_test.go, debounce_test.go, watcher_loop_test.go, and test_helpers.go preserve their intended observable behavior without sleep-based synchronization.",
    "go test ./pkg/services/automations/internal/services/filesystem_watchers/... -count=50 passes with zero failures, and the PR comment states the exact command and observed 50 successful repetitions.",
    "A temporary uncommitted mutation that makes duplicate handling submit twice causes the regression test to fail with the count-based message; the mutation is fully reverted before commit or push, and both failing and restored passing outputs are pasted in a PR comment.",
    "The final branch diff changes only the smallest necessary subset of duplicate_test.go, debounce_test.go, watcher_loop_test.go, and test_helpers.go under pkg/services/automations/internal/services/filesystem_watchers/internal/service/; no production code, generated contract, frontend, or other service file is modified.",
    "Typecheck passes; tests pass; Backend Unit Coverage is green on the PR; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "thr-deflake-filewatcher-duplicate-stale-signal-001",
      "title": "Reliably detect duplicate submissions by recorded state",
      "description": "As a maintainer, I want the duplicate-live-observation test to distinguish a real second submission from a stale wake-up signal so that required backend coverage is stable without weakening the regression guard.",
      "acceptanceCriteria": [
        "After the first submission is observed, the shared wait behavior leaves no already-accounted notification that a later assertion can mistake for new work.",
        "During the existing 200 ms duplicate-observation settle window, the test continuously treats a submission count greater than one as failure and does not fail solely because a buffered signal exists.",
        "All current recordingSubmitter call sites in the four owned test files retain their intended behavior, and any stale-signal assumption found there is corrected without sleep, skip, quarantine, production changes, or weakened assertions.",
        "go test ./pkg/services/automations/internal/services/filesystem_watchers/... -count=50 passes with zero failures, with the exact command and 50-pass result recorded in the PR.",
        "A temporary uncommitted double-submit negative control makes the test fail with the count-based diagnostic; the mutation is reverted, the restored test passes, and both outputs are recorded in a PR comment.",
        "Only the allowlisted filesystem-watcher test files are changed in the final diff.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented count-authoritative notification draining in the allowlisted watcher tests. The exact go test ./pkg/services/automations/internal/services/filesystem_watchers/... -count=50 command passed all 50 repetitions; the temporary duplicate-guard bypass failed with the count-based diagnostic and the restored test passed. make typecheck, go vet ./..., and the focused repository gates pass. Broad make lint still reports three unrelated baseline failures in packaged-factory consumption, ownership inventory, and deadcode."
    }
  ]
}
