### PR TITLE
Deflake desktop session-tab focus precondition

### DIFF
--- a/ui/scripts/verify-dashboard-session-reconciliation-browser.mjs
+++ b/ui/scripts/verify-dashboard-session-reconciliation-browser.mjs
@@ -76,6 +76,40 @@ async function waitForSelectedTab(tab, navigation, action, viewportLabel) {
   }
 }
 
+async function waitForRovingTabState(navigation, action, viewportLabel) {
+  try {
+    const tabs = navigation.getByRole("tab");
+    const tabCount = await tabs.count();
+    const selectedTabs = navigation.getByRole("tab", { selected: true });
+    const nonSelectedTabs = navigation.getByRole("tab", { selected: false });
+
+    await expect(selectedTabs).toHaveCount(1);
+    await expect(nonSelectedTabs).toHaveCount(tabCount - 1);
+    await expect(navigation.locator('[role="tab"][tabindex="0"]')).toHaveCount(
+      1,
+    );
+    await expect(navigation.locator('[role="tab"][tabindex="-1"]')).toHaveCount(
+      tabCount - 1,
+    );
+    await expect(selectedTabs.first()).toHaveAttribute("tabindex", "0");
+
+    for (let index = 0; index < tabCount; index += 1) {
+      const tab = tabs.nth(index);
+      if ((await tab.getAttribute("aria-selected")) === "true") {
+        await expect(tab).toHaveAttribute("tabindex", "0");
+      } else {
+        await expect(tab).toHaveAttribute("aria-selected", "false");
+        await expect(tab).toHaveAttribute("tabindex", "-1");
+      }
+    }
+  } catch (error) {
+    throw new Error(
+      `${action} key found an invalid selected/roving tab state at ${viewportLabel}. Playwright error: ${errorMessage(error)}`,
+      { cause: error },
+    );
+  }
+}
+
 async function verifyViewport(browser, viewport) {
   const context = await browser.newContext({ viewport });
   const page = await context.newPage();
@@ -123,16 +157,29 @@ async function verifyViewport(browser, viewport) {
       );
     }
 
+    const refreshButton = page.getByRole("button", {
+      name: "Refresh sessions",
+    });
+    const failRefreshButton = page.getByRole("button", {
+      name: "Fail refresh",
+    });
     const tabs = navigation.getByRole("tab");
     const firstTab = tabs.first();
     const lastTab = tabs.last();
-    await firstTab.focus();
+    await waitForSelectedTab(firstTab, navigation, "Initial", viewport.label);
+    await waitForRovingTabState(navigation, "Initial", viewport.label);
+    await expect(refreshButton).toBeFocused();
+    await page.keyboard.press("Tab");
+    await expect(failRefreshButton).toBeFocused();
+    await page.keyboard.press("Tab");
     await waitForFocusedTab(firstTab, "End", viewport.label);
     await page.keyboard.press("End");
     await waitForSelectedTab(lastTab, navigation, "End", viewport.label);
+    await waitForRovingTabState(navigation, "End", viewport.label);
     await waitForFocusedTab(lastTab, "Home", viewport.label);
     await page.keyboard.press("Home");
     await waitForSelectedTab(firstTab, navigation, "Home", viewport.label);
+    await waitForRovingTabState(navigation, "Home", viewport.label);
 
     await page.getByRole("button", { name: "Fail refresh" }).click();
     await page

--- a/ui/scripts/verify-dashboard-session-reconciliation-browser.mjs
+++ b/ui/scripts/verify-dashboard-session-reconciliation-browser.mjs
@@ -174,6 +174,7 @@ async function verifyViewport(browser, viewport) {
     await waitForSelectedTab(firstTab, navigation, "Initial", viewport.label);
     await waitForRovingTabState(navigation, "Initial", viewport.label);
     await enterTablistWithKeyboard(page, firstTab, viewport.label);
+    await waitForFocusedTab(firstTab, "End", viewport.label);
     await page.keyboard.press("End");
     await waitForSelectedTab(lastTab, navigation, "End", viewport.label);
     await waitForRovingTabState(navigation, "End", viewport.label);

--- a/ui/scripts/verify-dashboard-session-reconciliation-browser.mjs
+++ b/ui/scripts/verify-dashboard-session-reconciliation-browser.mjs
@@ -62,6 +62,17 @@ async function waitForFocusedTab(tab, action, viewportLabel) {
   }
 }
 
+async function enterTablistWithKeyboard(page, tab, viewportLabel) {
+  for (let tabPress = 0; tabPress < 4; tabPress += 1) {
+    if (await tab.evaluate((element) => element === document.activeElement)) {
+      return;
+    }
+    await page.keyboard.press("Tab");
+  }
+
+  await waitForFocusedTab(tab, "Tab", viewportLabel);
+}
+
 async function waitForSelectedTab(tab, navigation, action, viewportLabel) {
   try {
     await expect(tab).toBeVisible();
@@ -157,22 +168,12 @@ async function verifyViewport(browser, viewport) {
       );
     }
 
-    const refreshButton = page.getByRole("button", {
-      name: "Refresh sessions",
-    });
-    const failRefreshButton = page.getByRole("button", {
-      name: "Fail refresh",
-    });
     const tabs = navigation.getByRole("tab");
     const firstTab = tabs.first();
     const lastTab = tabs.last();
     await waitForSelectedTab(firstTab, navigation, "Initial", viewport.label);
     await waitForRovingTabState(navigation, "Initial", viewport.label);
-    await expect(refreshButton).toBeFocused();
-    await page.keyboard.press("Tab");
-    await expect(failRefreshButton).toBeFocused();
-    await page.keyboard.press("Tab");
-    await waitForFocusedTab(firstTab, "End", viewport.label);
+    await enterTablistWithKeyboard(page, firstTab, viewport.label);
     await page.keyboard.press("End");
     await waitForSelectedTab(lastTab, navigation, "End", viewport.label);
     await waitForRovingTabState(navigation, "End", viewport.label);


### PR DESCRIPTION
{
  "AAAA00_THE_ONLY_CURRENT_OVERRIDE": "OPERATOR OVERRIDE v1, 2026-08-16, ISSUED BY THE FACTORY OPERATOR.\n\n**YOUR PREVIOUS SESSION DIED. YOUR DIAGNOSIS SURVIVED. THE FIX WAS NEVER WRITTEN.**\n\nI inspected your worktree directly. State of the world:\n\n    branch  thr-deflake-session-tab-desktop-focus-precondition\n    HEAD    2cdd3b37b   (STALE -- origin/main is now 64f9bee0c)\n    commits ahead of main: NONE\n    remote branch:         NONE\n    open PR:               NONE\n    working tree:          CLEAN -- no product files changed\n\nYour last session ended around 11:13Z after completing the investigation. **Nothing was lost, because\nnothing was written** -- you finished diagnosing and stopped before implementing. Your token then sat in\n`init/PROCESSING` for over five hours with no live worker behind it.\n\n**DO NOT REDO THE INVESTIGATION.** It is finished and it is good. Everything below is your own recorded\nevidence -- treat it as established fact and build on it.\n\n================================================================\nYOUR ESTABLISHED FINDINGS -- DO NOT RE-DERIVE THESE\n================================================================\n\n**ROOT CAUSE: the browser CHECK's precondition is invalid. This is NOT a product focus defect.**\n\n  - The failing check's locator had `aria-selected=\"true\"` and `tabindex=\"0\"` while\n    `document.activeElement` was NOT the tab. The responsible precondition is\n    **`ui/scripts/verify-dashboard-session-reconciliation-browser.mjs` lines 129-131.**\n  - A local DOM probe found exactly one visible navigation, one visible tablist and two visible tabs at\n    BOTH 390x844 and 1440x900. **This rejects the hidden-duplicate-responsive-tablist hypothesis** and\n    supports entering the tablist through a real user keyboard action in story 002.\n  - The component's focus hook focuses the committed active tab at\n    `ui/src/features/header/hooks/use-dashboard-session-tab-focus.ts` lines 42-44; tab semantics are at\n    `ui/src/features/header/components/dashboard-session-tab.tsx` lines 136 and 148.\n  - Baseline at `2cdd3b37b` (Windows, Node v22.12.0, Bun 1.3.12, Playwright 1.59.1, static Storybook):\n    **10/10 mobile and 10/10 desktop**, ordered pass x10 for each viewport.\n  - Archived PR run on SHA `aa73d38476aa1b06634087e91d31d9805158b104` failed once (mobile pass, then\n    desktop focus failure at `firstTab.focus()`); the same-SHA rerun **passed** both viewports\n    (Frontend Storybook job `95155325141`, run `31942633508` attempt 2).\n  - Focused Bun reconciliation tests passed (6 tests); `bun run typecheck` passed.\n\nAcceptance criteria 1, 2 and 3 are effectively already satisfied by the above. **What remains is the\nfix itself (criterion 4), the diff scope (criterion 5), and the AFTER measurements.**\n\n================================================================\nWHAT TO DO THIS ITERATION -- IMPLEMENT, THEN PUSH IMMEDIATELY\n================================================================\n\n**Step 1 -- rebase first. Your base is stale.**\n\n    git fetch origin main\n    git rebase origin/main          # 2cdd3b37b -> 64f9bee0c\n    # tree is clean, so this is trivial\n\n**Step 2 -- write the fix.** Your own recorded next step, which I endorse:\n\n> Revise ONLY the owned browser check to enter the tablist with supported keyboard interaction, assert\n> selected/roving state separately from DOM focus, then complete the repeated post-fix measurements.\n\nConcretely, at `verify-dashboard-session-reconciliation-browser.mjs` lines 129-131: stop treating\n`document.activeElement` as a precondition that a freshly-queried locator will satisfy. Enter the\ntablist through a supported keyboard interaction, **establish DOM focus BEFORE Home or End**, and assert\n`aria-selected` / roving `tabindex` as a SEPARATE claim from DOM focus. Keep exactly one selected tab at\n`tabindex=0` with all non-selected tabs at `tabindex=-1`.\n\n**PROHIBITED, per your acceptance criteria -- these will be rejected:** `force`, synthetic events,\nextending timeouts, skipping or quarantining coverage, and weakening truthiness assertions. Retain the\ncanonical reconciliation, error/retry and responsive-overflow coverage.\n\n**Step 3 -- COMMIT AND PUSH THE MOMENT THE FIX COMPILES. Then open the PR.**\n\nThis is the instruction that matters most. Your previous session produced five hours of correct\nanalysis and left **zero commits and no branch on the remote**, so none of it was visible to anyone and\nthe lane looked dead. An unpushed worktree is indistinguishable from a stranded lane.\n\n    git add -A && git commit && git push -u origin thr-deflake-session-tab-desktop-focus-precondition\n    gh pr create ...\n\n**Open the PR BEFORE running the 10-execution measurement sets, not after.** The measurements are the\nexpensive part and they are exactly where your last session ran out of road. With the PR open, your work\nsurvives; without it, it does not.\n\n**Step 4 -- the AFTER measurements.** Criterion 1 stands in full and is NOT waived: at least **10\nconsecutive executions per measurement set, for BOTH mobile and desktop**, reported as raw ordered pass\ncounts with the tested commit and environment named. **A single green execution is not proof** -- that\nis the entire point of this lane, so do not undercut it. Put the results in the PR description\nalongside the 10/10 + 10/10 baseline you already have.\n\n================================================================\nSCOPE AND HYGIENE\n================================================================\n\nCriterion 5: the diff stays within the owned reconciliation browser check and the dashboard session-tab\nfocus / roving-tabindex surface. **Do NOT touch the factory-graph or bento dashboard surfaces** -- those\nbelong to concurrent lanes and editing them will collide.\n\n`prd.json` and `progress.txt` are gitignored worktree scaffolding. They will not appear in your diff,\nand that is correct -- do not try to commit them.\n\nNEVER use `git stash` or `git stash pop`. The stash stack is shared repo-wide across roughly ten\nconcurrent worktrees and popping it destroys another lane's work. Use `cp` or `mv` to a path outside the\nworktree.\n\nIf you rebase again later, the plain push is REJECTED as non-fast-forward; use\n`git push --force-with-lease`. Never merge origin back into your branch.\n\n================================================================\nDELIVERY CONTRACT\n================================================================\n\nThis flake reddens unrelated pull requests and taxes every rebasing lane, so landing it compounds across\nthe whole board.\n\nYour finish line as the PROCESS stage is: fix committed AND PUSHED, PR open, CI started, review feedback\naddressed. **MERGED is owned by the REVIEW stage, NOT by you.** Do NOT poll CI in a loop. Do NOT commit\n\"CI evidence\" -- a new commit invalidates the run it records; evidence about a run belongs in a PR\ncomment.\n\nThe investigation is done. Rebase, write the check fix, push, open the PR, then measure.\n\nNOTHING ELSE IS WAIVED. Every other acceptance criterion remains in force.\n",
  "project": "Deflake the Desktop Session-Tab Focus Precondition",
  "branchName": "thr-deflake-session-tab-desktop-focus-precondition",
  "description": "Measure and eliminate the desktop-only dashboard session-tab focus-precondition failure that intermittently reddens unrelated pull requests, distinguish a production focus defect from an invalid browser-check assumption, apply only the evidence-supported correction, and prove stable accessible keyboard behavior at mobile and desktop.",
  "context": {
    "customerAsk": "Reproduce the required dashboard session-reconciliation Storybook check over at least 10 runs at both viewports, compare local/main-like and pull-request merge-commit conditions, rerun the failed job on an unchanged SHA, identify whether the component or check owns the DOM-focus defect, implement the corresponding correction, and publish before/after counts while preserving strict focus, roving-tabindex, reconciliation, and responsive assertions.",
    "problem": "Frontend Storybook can pass canonical session reconciliation at the 390x844 mobile viewport and then fail in the same process at the 1440x900 desktop viewport because the identified selected tab has aria-selected=true and tabindex=0 but is not document.activeElement before the End keypress. The flake appears on pull-request merge-commit runs despite six consecutive green main runs, so it blocks unrelated lanes without evidence that main itself is red. Selection, roving-tab-stop eligibility, and DOM focus are distinct states, and the current evidence does not yet establish whether desktop component behavior loses focus or the check assumes an invalid user-entry precondition.",
    "solution": "Collect ordered per-viewport results and active-element/accessibility diagnostics over repeated executions, obtain a same-head CI rerun sequence, test hidden duplicate tab-list and remount/locator hypotheses, and name the owning file and line. If production behavior is wrong, correct the existing session-tab focus operation and retain the focus assertion; if the check is wrong, enter the tab list through a real keyboard action and assert selected state, roving tabindex, and DOM focus separately. Re-run identical final measurements and preserve all reconciliation, error/retry, accessibility, and responsive checks without timing or assertion workarounds."
  },
  "acceptanceCriteria": [
    "The PR description reports raw before and after pass counts for mobile and desktop from at least 10 consecutive executions per measurement set, identifies the tested commits and environments, and does not use a single green execution as proof.",
    "A same-head rerun of failed Frontend Storybook job 95153958691, or the equivalent unchanged failing PR-head job if retention prevents that exact rerun, is recorded as an ordered result sequence; the PR explains relevant local/main-like versus pull-request merge-commit conditions and does not characterize main as red.",
    "The PR names either component focus behavior or browser-check precondition as the root cause, cites the responsible file and line, and provides viewport-specific evidence for tab-list visibility/count, locator identity, document.activeElement, aria-selected, and tabindex sufficient to reject the opposite diagnosis.",
    "The corrected flow uses supported keyboard interaction, keeps exactly one selected tab with tabindex=0 and all non-selected tabs at tabindex=-1, establishes DOM focus before Home or End, and retains canonical reconciliation, error/retry, and responsive overflow coverage without force, synthetic events, timeout extension, skipped/quarantined coverage, or weakened truthiness assertions.",
    "The diff stays within the owned reconciliation browser check and dashboard session-tab focus/roving-tabindex surface, excludes the factory-graph and bento dashboard surfaces owned by concurrent lanes, coordinates rather than blindly edits any component owned elsewhere, rebases onto origin/main before the final push, never uses git stash, and regenerates rather than hand-merges generated files.",
    "Quality gate: Typecheck, focused browser/component tests, and relevant tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. The review stage verifies required Frontend Storybook is terminal and passing on the final PR head.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "thr-deflake-session-tab-desktop-focus-precondition-001",
      "title": "Measure and locate the desktop focus failure",
      "description": "As a repository maintainer, I want repeatable viewport and CI evidence for the focus precondition so that the correction targets the actual owner instead of masking a flake.",
      "acceptanceCriteria": [
        "On an identified baseline commit, at least 10 consecutive executions of bun run storybook:dashboard-session-reconciliation-check produce separately reported mobile and desktop pass/fail counts and an ordered raw result sequence.",
        "The failed Frontend Storybook job is rerun on an unchanged SHA and its ordered result is recorded; the investigation also identifies the effective pull-request merge commit and compares relevant execution conditions with local/main-like runs.",
        "At the pre-End boundary for both viewports, evidence records the visible and total matching navigation/tab-list count, target locator identity, selected tab identity, aria-selected, tabindex, and document.activeElement before and after the attempted focus or user-entry action.",
        "The investigation explicitly concludes either that the component violates its keyboard-focus contract at desktop or that the check assumes an invalid precondition, names the responsible file and line, and rules in or out hidden duplicate responsive tab lists.",
        "Diagnostic instrumentation is narrowly scoped and removed from the final product change unless it provides durable failure output useful to maintainers; no timeout, retry, force, synthetic event, skip, or quarantine workaround is introduced.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Measured local main-like commit 2cdd3b37b in the static Storybook environment for 10 consecutive runs: mobile 10/10 and desktop 10/10, with ordered results recorded in progress.txt. Archived PR SHA aa73d38476aa1b06634087e91d31d9805158b104 reproduced mobile pass then desktop focus failure; same-head Frontend Storybook rerun job 95155325141 passed both viewports. Diagnostics found one navigation, one tablist, and two visible tabs at both viewports; the component preserved selected/roving semantics. Root cause is the browser check's direct focus precondition at lines 129-131, not component focus behavior. Focused Bun tests and typecheck pass."
    },
    {
      "id": "thr-deflake-session-tab-desktop-focus-precondition-002",
      "title": "Correct the owning focus path and prove stability",
      "description": "As a keyboard user and repository contributor, I want session-tab focus and its required browser check to follow the same accessible interaction contract at mobile and desktop so navigation works and unrelated pull requests are not failed by a false precondition.",
      "acceptanceCriteria": [
        "If story 001 proves a component defect, the selected session tab receives and retains DOM focus at the desktop breakpoint through the affected reconciliation path, the existing focus assertion remains, and a focused behavioral test fails without and passes with the correction.",
        "If story 001 proves a check defect, the check establishes focus through a real user keyboard action such as tabbing into the tab list, separately asserts the selected tab has aria-selected=true and tabindex=0 while other tabs have aria-selected=false and tabindex=-1, and only then asserts DOM focus and sends Home or End.",
        "At both 390x844 and 1440x900, End selects and focuses the last session tab and Home selects and focuses the first session tab after canonical-list refresh; retained tabs, refresh failure/retry, and responsive overflow behavior remain covered.",
        "At the final rebased head, at least 10 consecutive check executions pass 10/10 at mobile and 10/10 at desktop; before/after raw counts, commits, environments, and commands are placed in the PR description or a PR comment, never in a commit.",
        "Direct browser verification exercises the visible Storybook flow at both supported viewports, and focused component or browser regression coverage fails if selected/roving state is again conflated with active DOM focus.",
        "The check is not deleted, skipped, quarantined, timeout-extended, driven with force or synthetic keyboard events, or weakened to truthiness; unrelated factory-graph, bento layout, generated, and cleanup changes are absent.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Corrected only ui/scripts/verify-dashboard-session-reconciliation-browser.mjs on final head f81052d5f8c6a7f9c04768d0cac8d851a6a0f849. The check now enters the tablist with supported Tab keypresses, asserts DOM focus before End, and separately verifies exactly one selected/roving tab plus all non-selected tabs at tabindex=-1; canonical reconciliation, refresh failure/retry retention, and responsive overflow assertions remain. Final static Storybook command: cd ui && AGENT_FACTORY_STORYBOOK_URL=http://127.0.0.1:6018 node scripts/verify-dashboard-session-reconciliation-browser.mjs (PowerShell equivalent used). Environment: Windows, Node v22.12.0, Bun 1.3.12, Playwright 1.59.1. After final head f81052d5f8c6a7f9c04768d0cac8d851a6a0f849, the ordered results were mobile 390x844: pass, pass, pass, pass, pass, pass, pass, pass, pass, pass (10/10); desktop 1440x900: pass, pass, pass, pass, pass, pass, pass, pass, pass, pass (10/10). Before unmodified main-like 2cdd3b37b was mobile 10/10 and desktop 10/10 in the same environment; archived PR SHA aa73d38476aa1b06634087e91d31d9805158b104 failed once on desktop and its unchanged-SHA rerun passed (job 95155325141, run 31942633508 attempt 2). Focused reconciliation component tests passed 6/6 with 68 expectations, typecheck passed, targeted Biome and node syntax checks passed, static Storybook build passed, and required PR CI run 31960986696 passed on the final head. PR #2035 is open, all review feedback is addressed, and no product files beyond the owned browser check changed. Full local bun run check reports 185 unrelated pre-existing Biome diagnostics; no diagnostics occur in the owned file."
    }
  ]
}
