### PR TITLE
thr-backend-lint-allowances-carry-34-violations-of-slack

### DIFF
--- a/scripts/ci/backend-lint-policy.mjs
+++ b/scripts/ci/backend-lint-policy.mjs
@@ -1,17 +1,10 @@
 export const BACKEND_LINT_BASELINE_SOURCE =
-	"Hosted Backend Lint run 31873961077 on 2026-08-15 (semantic baseline observed on rebased head 3e625b9a10f3edc9550786d26798cce165d7adc6)";
+	"Hosted Backend Lint run 31974329925 on 2026-08-16 (semantic baseline observed on rebased head a4b25a57198454083670ae632d0111502e073244)";
 
 // These are measured current-main failures, not extra capacity. A failing
 // checker is allowed only while its observed count remains at or below the
 // recorded count; a clean checker and any unlisted failure remain gated.
 export const BACKEND_LINT_ALLOWANCES = Object.freeze({
-	"package-target-manifest-check": {
-		baselineViolationCount: 5,
-		reason: "The current package inventory omits five production package entries from the live tree, including the factory_definitions runtime_snapshot migration paths.",
-		ownerOrLane: "Factory Definitions package inventory remediation lane",
-		deadline: "2026-10-15",
-		removalCondition: "Reconcile the package inventory with the production tree, then delete this allowance when hosted package-target-manifest-check passes.",
-	},
 	"packaged-factory-consumption-check": {
 		baselineViolationCount: 1,
 		reason: "The migration-ledger matrix has one direct packaged-factories import instead of using the catalog boundary.",
@@ -20,15 +13,15 @@ export const BACKEND_LINT_ALLOWANCES = Object.freeze({
 		removalCondition: "Route the matrix through the Factory Definitions catalog boundary, then delete this allowance when hosted packaged-factory-consumption-check passes.",
 	},
 	"ownership-inventory-check": {
-		baselineViolationCount: 16,
-		reason: "The 2026-08-08 packaged-service-structure migration debt has 9 missing package entries, 5 missing cross-service edges, and 2 unexpected edges.",
+		baselineViolationCount: 5,
+		reason: "The 2026-08-16 hosted baseline reports 5 existing ownership-inventory violations from packaged-service-structure migration debt.",
 		ownerOrLane: "Packaged-service structure migration / ownership inventory lane",
 		deadline: "2026-10-31",
 		removalCondition: "Reconcile the migrated package and edge inventory, then delete this allowance when hosted ownership-inventory-check passes.",
 	},
 	deadcode: {
-		baselineViolationCount: 580,
-		reason: "The hosted baseline reports 580 existing dead-code findings against the repository baseline.",
+		baselineViolationCount: 562,
+		reason: "The 2026-08-16 hosted baseline reports 562 existing dead-code findings against the repository baseline.",
 		ownerOrLane: "Repository dead-code cleanup lane",
 		deadline: "2026-12-31",
 		removalCondition: "Remove or review the existing findings and update the source baseline intentionally, then delete this allowance when hosted deadcode reports zero drift.",

--- a/scripts/ci/backend-lint-report.test.mjs
+++ b/scripts/ci/backend-lint-report.test.mjs
@@ -111,7 +111,7 @@ test("all clean current-main checkers pass the baseline policy", () => {
 
 	assert.equal(summary.ok, true);
 	assert.equal(summary.failures.length, 0);
-	assert.equal(summary.targets.filter((target) => target.policyStatus === "clean").length, 4);
+	assert.equal(summary.targets.filter((target) => target.policyStatus === "clean").length, 3);
 });
 
 test("a measured baseline failure is reported but allowed at its recorded count", () => {
@@ -119,7 +119,7 @@ test("a measured baseline failure is reported but allowed at its recorded count"
 		targets: baselineTargets({
 			deadcode: {
 				status: "fail",
-				output: "Repository dead-code baseline drift detected\nLINT_VIOLATION_COUNT: 580\ncurrent findings: 580",
+				output: "Repository dead-code baseline drift detected\nLINT_VIOLATION_COUNT: 562\ncurrent findings: 562",
 			},
 		}),
 	}));
@@ -128,7 +128,7 @@ test("a measured baseline failure is reported but allowed at its recorded count"
 	assert.equal(summary.ok, true);
 	assert.equal(summary.targets.find((target) => target.name === "deadcode").policyStatus, "allowed");
 	assert.match(markdown, /Allowed baseline debt: `1` checker\(s\) within measured limits/);
-	assert.match(markdown, /\| deadcode \| 580 \| 580 \| \+0 \| allowed \|/);
+	assert.match(markdown, /\| deadcode \| 562 \| 562 \| \+0 \| allowed \|/);
 });
 
 test("a measured failure below its baseline remains tolerated with a negative delta", () => {
@@ -136,7 +136,7 @@ test("a measured failure below its baseline remains tolerated with a negative de
 		targets: baselineTargets({
 			deadcode: {
 				status: "fail",
-				output: "LINT_VIOLATION_COUNT: 579",
+				output: "LINT_VIOLATION_COUNT: 561",
 			},
 		}),
 	}));
@@ -144,7 +144,7 @@ test("a measured failure below its baseline remains tolerated with a negative de
 	assert.equal(summary.ok, true);
 	assert.match(
 		renderBackendLintVerdict(summary),
-		/deadcode: baseline 580 -> current 579 \(delta -1; allowed\)/,
+		/deadcode: baseline 562 -> current 561 \(delta -1; allowed\)/,
 	);
 });
 
@@ -243,7 +243,7 @@ test("a no-rise ratchet pass states the baseline rule and tolerated debt", () =>
 		targets: baselineTargets({
 			deadcode: {
 				status: "fail",
-				output: "LINT_VIOLATION_COUNT: 580",
+				output: "LINT_VIOLATION_COUNT: 562",
 			},
 		}),
 	}));
@@ -252,7 +252,7 @@ test("a no-rise ratchet pass states the baseline rule and tolerated debt", () =>
 	assert.equal(summary.ok, true);
 	assert.match(verdict, /BACKEND LINT RATCHET PASSED/);
 	assert.match(verdict, /every observed target is at or below baseline/);
-	assert.match(verdict, /deadcode: baseline 580 -> current 580 \(delta \+0; allowed\)/);
+	assert.match(verdict, /deadcode: baseline 562 -> current 562 \(delta \+0; allowed\)/);
 });
 
 test("the reporter CLI logs the authoritative verdict and exits with that decision", (t) => {
@@ -321,7 +321,7 @@ test("a failed checker without a machine-readable count fails closed", () => {
 	assert.equal(summary.ok, false);
 	assert.equal(summary.targets.find((target) => target.name === "ownership-inventory-check").violationCount, null);
 	assert.match(summary.failures.join("\n"), /without a reliable machine-readable violation count/);
-	assert.match(renderBackendLintVerdict(summary), /ownership-inventory-check: baseline 16 -> current unknown \(delta unknown; unmeasured\)/);
+	assert.match(renderBackendLintVerdict(summary), /ownership-inventory-check: baseline 5 -> current unknown \(delta unknown; unmeasured\)/);
 });
 
 test("a missing allowed target is an explicit failed ratchet condition", () => {
@@ -337,7 +337,7 @@ test("a missing allowed target is an explicit failed ratchet condition", () => {
 	assert.equal(incomplete.ok, false);
 	assert.match(
 		renderBackendLintVerdict(incomplete),
-		/deadcode: baseline 580 -> current unknown \(delta unknown; not observed\)/,
+		/deadcode: baseline 562 -> current unknown \(delta unknown; not observed\)/,
 	);
 });
 
@@ -347,15 +347,15 @@ test("structured finding growth exceeds the ownership allowance even on one diag
 		output: `inventory report: Report{MissingPackages:[]string{${Array.from({ length: count }, (_, index) => `\"finding-${index}\"`).join(", ")}}}\nLINT_VIOLATION_COUNT: ${count}`,
 	});
 	const baseline = summarizeBackendLintReport(report({
-		targets: baselineTargets({ "ownership-inventory-check": ownershipTarget(16) }),
+		targets: baselineTargets({ "ownership-inventory-check": ownershipTarget(5) }),
 	}));
 	const grown = summarizeBackendLintReport(report({
-		targets: baselineTargets({ "ownership-inventory-check": ownershipTarget(17) }),
+		targets: baselineTargets({ "ownership-inventory-check": ownershipTarget(6) }),
 	}));
 
 	assert.equal(baseline.ok, true);
 	assert.equal(grown.ok, false);
-	assert.match(grown.failures.join("\n"), /ownership-inventory-check reported 17 violation\(s\), exceeding its baseline allowance of 16/);
+	assert.match(grown.failures.join("\n"), /ownership-inventory-check reported 6 violation\(s\), exceeding its baseline allowance of 5/);
 });
 
 test("missing or malformed hosted reports fail closed", () => {


### PR DESCRIPTION
{
  "AAAA00_THE_ONLY_CURRENT_OVERRIDE": "OPERATOR OVERRIDE v1, 2026-08-16, ISSUED BY THE FACTORY OPERATOR.\n\n**MY PAYLOAD WAS WRONG AND IT IS BLOCKING YOU. YOU MUST ALSO EDIT THE POLICY'S TEST FILE.**\n\nThe original payload said \"This lane OWNS `scripts/ci/backend-lint-policy.mjs` and nothing else.\" That\ninstruction was incorrect and it makes your task impossible as written. The allowance table has a test\nfile that is coupled to it **by design**, and changing the allowances necessarily changes that file.\nThe mistake is mine, not yours.\n\n**You now also own `scripts/ci/backend-lint-report.test.mjs`.** Those two files, and still nothing else.\n\n================================================================\nWHAT IS ACTUALLY FAILING\n================================================================\n\nYour allowance edit is CORRECT and I am not asking you to revise it. `Verification Policy` is red\nbecause `make test-ci-workflows` (Makefile:484) runs the policy's own tests and 7 subtests fail:\n\n     2 - all clean current-main checkers pass the baseline policy\n     3 - a measured baseline failure is reported but allowed at its recorded count\n     4 - a measured failure below its baseline remains tolerated with a negative delta\n    10 - a no-rise ratchet pass states the baseline rule and tolerated debt\n    15 - a failed checker without a machine-readable count fails closed\n    16 - a missing allowed target is an explicit failed ratchet condition\n    17 - structured finding growth exceeds the ownership allowance even on one diagnostic line\n\nTwo distinct reasons, both expected consequences of a correct change:\n\n1. `scripts/ci/backend-lint-report.test.mjs:8` imports `BACKEND_LINT_ALLOWANCES`, and line 49 builds\n   its fixture targets by mapping over that object's entries. You deleted an entry, so the derived\n   fixture set changed shape. That is why the majority of these fail.\n2. The `deadcode` count `580` is HARDCODED in fixtures and regex assertions in at least three places\n   (around lines 120-131, 137-147, and 244-255), e.g.\n   `assert.match(markdown, /\\| deadcode \\| 580 \\| 580 \\| \\+0 \\| allowed \\|/)`.\n   Those literals must become the count you actually set.\n\n================================================================\nTHE RULE FOR EDITING THESE TESTS\n================================================================\n\nUpdate FIXTURE VALUES and derived expectations. **Do not weaken, loosen, or delete any assertion.**\n\nEach of these tests encodes a ratchet guarantee that must survive your change:\n  - a failed checker with no machine-readable count **fails closed** (never passes as \"allowed\")\n  - a target that has an allowance but is **not observed** is an explicit failure\n  - finding growth beyond the allowance is a failure even on a single diagnostic line\n  - a clean checker and any unlisted failure remain gated\n\nIf a test can only be made to pass by removing what it checks, **STOP and report it in the PR\ndescription instead of changing it**. That would mean the policy change altered behaviour rather than\njust the numbers, and I need to know. Deleting a test to green a build is the failure mode that has\ncost this repository real coverage before: a guard that is removed looks identical to a guard that\npasses.\n\nWhere a test name describes a behaviour, that behaviour must still be exercised after your edit.\n\n================================================================\nVERIFY LOCALLY BEFORE PUSHING\n================================================================\n\n    node --test scripts/ci/backend-lint-report.test.mjs      # fast, this is the failing suite\n    make test-ci-workflows                                   # the exact target CI runs (Makefile:484)\n\nRead the OUTPUT, not just the exit code. Expect `pass 38 / fail 0` style output with zero `not ok`\nlines. Do NOT run a full `make test` or `make ci` -- this host is saturated with ~24 concurrent\nworkers and a duplicate full suite helps nobody.\n\n================================================================\nSTOP CONDITION -- evaluate against YOUR OWN TREE\n================================================================\n\n    1.  git status --porcelain              -> clean?\n    2.  git rev-list --count @{u}..HEAD     -> 0 (nothing unpushed)?\n    3.  gh pr checks 2039                   -> any line reporting FAILURE?\n\n    All three satisfied -> YOU ARE FINISHED. Do not commit, do not push, end your turn.\n    PENDING / IN_PROGRESS is NOT failing; waiting is not your job.\n    Otherwise -> fix precisely what is failing, push once, re-evaluate.\n\nThis override contains no commit hash, so it cannot go stale when you push.\n\n================================================================\nUNCHANGED FROM THE ORIGINAL PAYLOAD\n================================================================\n\n- Do NOT fix the underlying violations (dead code, ownership inventory, package inventory). Each has\n  its own named remediation lane and deadline in the allowance table. This lane only makes the ratchet\n  describe reality.\n- If an observed count comes back HIGHER than a recorded allowance, do NOT raise the allowance -- stop\n  and report it as someone else's regression.\n- MERGED is owned by the REVIEW stage. Do not poll CI in a loop. Never commit CI evidence -- a new\n  commit invalidates the run it records; evidence belongs in a PR comment.\n- NEVER use `git stash` -- the stack is shared repo-wide across ~10 concurrent worktrees. Use `cp`/`mv`.\n\nNOTHING ELSE IS WAIVED. Every other acceptance criterion remains in force.\n",
  "project": "Re-ratchet Backend Lint Allowances to Observed Counts",
  "branchName": "thr-backend-lint-allowances-carry-34-violations-of-slack",
  "description": "Tighten the Backend Lint counted ratchet and its coupled report-test fixtures in one pull request so its allowances match fresh hosted observations rather than retaining 34 violations of silent regression capacity. Remove the clean package-target manifest allowance, lower the ownership-inventory and dead-code baselines without raising any allowance, preserve the accurate packaged-factory allowance, and record auditable run provenance and review evidence. Before/after allowance slack: 602 -> 568 (34 fewer slots).",
  "context": {
    "customerAsk": "Update scripts/ci/backend-lint-policy.mjs and its coupled scripts/ci/backend-lint-report.test.mjs fixtures. Rebase on origin/main, measure current counts from this pull request's hosted Backend Lint job, remove package-target-manifest-check, lower ownership-inventory-check and deadcode without ever raising them, leave packaged-factory-consumption-check unchanged, update the edited reasons and provenance, document before/after slack, and complete the implementation/review delivery loop through merge.",
    "problem": "Backend Lint currently records stale baselines that can admit 5 package-target manifest, 11 ownership-inventory, and 18 dead-code violations after those violations have disappeared. Because a currently passing target is labeled clean before its allowance is consulted, the stale allowance becomes active again on a future failure. The policy can therefore report its authoritative ratchet verdict as passed while absorbing up to 34 reintroduced violations.",
    "solution": "Use the pull request's hosted Backend Lint Baseline allowances table as the authoritative measurement instrument. Delete the clean package-target allowance, set ownership-inventory and deadcode to their non-increasing observed counts, preserve packaged-factory-consumption at 1, update count/date/run provenance and coupled report-test fixtures without weakening assertions, rebase before the final push with main authoritative on conflicts, and provide commit-specific evidence in a pull request comment."
  },
  "acceptanceCriteria": [
    "The policy contains exactly three allowance entries: package-target-manifest-check is absent, ownership-inventory-check and deadcode use freshly measured counts, and packaged-factory-consumption-check remains untouched at 1.",
    "Each edited baselineViolationCount equals the corresponding observed count from the Backend Lint allowances table on this pull request; a count above its current recorded allowance is not adopted and is reported as a regression requiring separate remediation.",
    "Each edited reason states its new count and measurement date, and the baseline provenance names the hosted run used for measurement in the existing format; ownerOrLane, deadline, and removalCondition remain unchanged.",
    "The branch is rebased onto current origin/main before the final push; if the allowance table conflicts, main's entries are kept and counts are re-derived from a fresh hosted run rather than restoring prior branch values.",
    "On the final head, hosted Backend Lint emits the authoritative ratchet verdict PASSED, with every remaining allowance at delta +0 or its target clean; the pull request body states the before/after slack total, and a pull request comment quotes the run's Baseline allowances table as evidence.",
    "Quality gates pass: Typecheck passes; Tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. The pre-existing packaged-service-structure migration debt recorded on 2026-08-08 does not make blanket end-to-end make lint success a criterion.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "thr-backend-lint-allowances-carry-34-violations-of-slack-001",
      "title": "Tighten the Backend Lint ratchet to fresh hosted measurements",
      "description": "As a repository maintainer, I want every Backend Lint allowance to match current observed debt so resolved violations cannot silently return while known remediation lanes remain unblocked.",
      "acceptanceCriteria": [
        "A clean package-target-manifest-check has no allowance, so any future failure is evaluated as a new failure rather than admitted under the former baseline of 5.",
        "ownership-inventory-check and deadcode each allow no more than the count observed by the pull request's hosted Backend Lint measurement, and a subsequent count above the recorded value evaluates as exceeded.",
        "If either fresh observed count is greater than its current allowance, implementation does not raise the baseline and reports the regression for a separate lane.",
        "packaged-factory-consumption-check remains unchanged at 1, including its reason, owner or lane, deadline, and removal condition.",
        "Edited reasons contain the fresh count and date, the provenance names the measurement run, and outstanding entries retain their existing ownership, deadline, and removal condition.",
        "The final diff changes only scripts/ci/backend-lint-policy.mjs and its coupled scripts/ci/backend-lint-report.test.mjs fixtures; no pkg file, lint implementation, coverage manifest, quarantine file, underlying violation, or update-manifest output changes.",
        "Focused policy/report verification confirms the ratchet verdict and allowance-table output remain correct after the table change.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
    "notes": "Policy committed as 0e466ec26 and coupled report-test fixtures as 51da67f3a. PR #2039 is open on final head 51da67f3a, rebased onto current origin/main, with required Backend Lint and Classify Verification checks started and no review or inline comments. Hosted measurement evidence remains posted from Backend Lint run 31974329925; local node --test scripts/ci/backend-lint-report.test.mjs passes all 19 tests and make test-ci-workflows passes all 41 tests."
    }
  ]
}
