### PR TITLE
thr-main-red-deadcode-plus-one-blocks-every-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,7 @@ jobs:
             .artifacts/backend-lint/report.json
             .artifacts/backend-lint/lint.log
             .artifacts/backend-lint/comment.md
+            bin/deadcode-current.txt
           if-no-files-found: warn
           retention-days: 14
       - name: Publish Backend Lint inventory to the pull request

--- a/pkg/transports/cli/run/factory_invocation_input.go
+++ b/pkg/transports/cli/run/factory_invocation_input.go
@@ -984,13 +984,6 @@ func remoteDurableFailureReason(result factoryapi.FactorySessionResult) string {
 	return string(result.FailureDetail.Reason)
 }
 
-// ResolveFactoryInvocationRequest exposes the same request projection used by
-// the local run operation. Callers must prepare the RunConfig through the
-// shared Work input preparation boundary before invoking this helper.
-func ResolveFactoryInvocationRequest(cfg RunConfig) (*factoryapi.InvocationRequest, bool, error) {
-	return resolveFactoryInvocationRequest(cfg)
-}
-
 // RunRemoteInvocation starts one server-owned durable Factory Session through
 // the selected remote adapter. It does not open local runtime state or use the
 // live-session compatibility invocation route.


### PR DESCRIPTION
{
  "project": "Restore Mergeability After the #2040 Deadcode Regression",
  "branchName": "thr-main-red-deadcode-plus-one-blocks-every-merge",
  "description": "Restore repository mergeability after #2040 made main exceed the hosted Backend Lint deadcode ratchet by one finding. Identify the exact newly unreachable symbol through a before/after finding-list diff, remove only that dead code, and include bin/deadcode-current.txt in the existing Backend Lint diagnostics artifact so future drift names the attributable symbol without changing baselines, checker logic, tests, or concurrent backend-lane surfaces.",
  "context": {
    "customerAsk": "Use an A/B deadcode-output diff across d6b783661 and 01f9be754 to identify and remove the single symbol made unreachable by #2040, then add bin/deadcode-current.txt to backend-lint-diagnostics in .github/workflows/ci.yml. Keep the critical-path pull request fast and narrow, preserve warning-only artifact upload behavior, and do not touch lint baselines, deadcode comparison logic, tests, or the surfaces owned by btrc-p5b, btrc-p5c, and wse-j.",
    "problem": "Main commit 01f9be754 deterministically raises the hosted deadcode count from baseline 562 to current 563, the only policy failure among 20 Backend Lint checkers. Verification Policy is the sole required check and rolls up Backend Lint, so every descendant branch inherits a red required check and cannot merge. The generated finding list is not uploaded, making the one-symbol regression expensive to identify.",
    "solution": "Compare complete sorted deadcode finding lists from the known-good pre-#2040 commit and the failing merge commit, use the single added line as the removal target, and delete only the unreachable function and any code made unreachable with it. Add the existing generated finding list to backend-lint-diagnostics with if-no-files-found set to warn, then use the pull request's own counted-ratchet verdict, required check, existing suites, and downloaded artifact as evidence."
  },
  "acceptanceCriteria": [
    "The pull request names the exact A/B-added finding as <path>.go: unreachable func: <Name>, attributes it to 01f9be754 / #2040, and removes that unreachable symbol and only code that becomes unreachable with it; if an exported contract requires it, a legitimate reachable caller is restored and the evidence is explained instead.",
    "On the pull request's own run, Backend Lint measures deadcode at 562 or lower against the hosted baseline of 562, reports delta 0 or negative, and has an empty Policy failures list; the before verdict baseline 562 -> current 563 (delta +1; exceeded) and measured after verdict are recorded for reviewers.",
    "The pull request's Verification Policy becomes terminal and passing in the review stage, restoring the required merge gate that the inherited deadcode regression blocked.",
    "A pull request CI run's backend-lint-diagnostics artifact contains bin/deadcode-current.txt; its downloaded line count is recorded in a pull request comment, never in a commit, and if-no-files-found: warn preserves artifact-upload behavior when the file is absent.",
    "The final diff does not modify docs/internal/baselines/deadcode-baseline.txt, any other lint baseline, cmd/deadcodecheck comparison logic, any test, or the surfaces owned by btrc-p5b, btrc-p5c, and wse-j. If pkg/wire proves unavoidable, the branch is rebased onto origin/main immediately before the final push and any wire_gen.go conflict is resolved by rerunning its generator, never by hand-merging generated output.",
    "Quality gates pass: Typecheck passes; Tests pass, including the existing unit and full functional tiers; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. The pre-existing packaged-service-structure migration debt recorded on 2026-08-08 does not make blanket end-to-end make lint success a criterion.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "thr-main-red-deadcode-plus-one-blocks-every-merge-001",
      "title": "Remove the exact deadcode regression introduced by #2040",
      "description": "As a repository maintainer, I want the one newly unreachable symbol identified by measured before/after output and removed so Backend Lint no longer blocks every branch descended from main.",
      "acceptanceCriteria": [
        "Deadcode outputs from d6b783661 and 01f9be754 are compared, and the single added finding is recorded in the pull request as <path>.go: unreachable func: <Name>; absolute platform-specific count differences are not used to replace the finding-list delta.",
        "The identified function and only code made unreachable with it are deleted. If it is required by an exported contract, it is instead connected to a legitimate reachable caller and that exception is documented with the A/B evidence.",
        "The pull request's Backend Lint run measures 562 deadcode findings or fewer against the hosted baseline of 562, with delta 0 or negative and no deadcode entry in the authoritative Policy failures list.",
        "The stale 346-entry local deadcode baseline, every other lint baseline, deadcode comparison logic, tests, and btrc-p5b, btrc-p5c, and wse-j-owned surfaces remain unchanged.",
        "Existing unit and full functional tiers remain green; a failure attributable to the deletion invalidates the dead-code diagnosis and is corrected without weakening or deleting tests.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": false,
      "notes": "Implementation complete locally: exact WSL A/B checker output measured d6b783661 at 562 and 01f9be754 at 563; removed only pkg/transports/cli/run/factory_invocation_input.go: unreachable func: ResolveFactoryInvocationRequest. Modified checker output is 562, focused resolver tests pass in native WSL, and make typecheck passes. Hosted PR Backend Lint/Verification Policy evidence remains pending."
    },
    {
      "id": "thr-main-red-deadcode-plus-one-blocks-every-merge-002",
      "title": "Publish attributable deadcode diagnostics",
      "description": "As a maintainer diagnosing a future deadcode drift, I want the complete generated finding list in the Backend Lint diagnostics artifact so I can identify the offending symbol without rebuilding two revisions.",
      "acceptanceCriteria": [
        "After the pull request's Backend Lint job runs, downloading backend-lint-diagnostics yields bin/deadcode-current.txt alongside the existing report, log, and comment artifacts.",
        "The artifact upload retains warning-only missing-file handling, so an execution path that does not produce the finding list does not fail solely during artifact upload.",
        "A pull request comment records the run identifier and downloaded finding-list line count as evidence from the change's own head; the evidence is never committed because a new commit would invalidate the cited run.",
        "No checker output, comparison policy, baseline, test, public contract, runtime package behavior, or unrelated workflow behavior changes as part of the artifact addition.",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": false,
      "notes": "Implementation complete locally: .github/workflows/ci.yml now includes bin/deadcode-current.txt in backend-lint-diagnostics and preserves if-no-files-found: warn. Hosted PR artifact contents and the required downloaded line-count comment remain pending."
    }
  ]
}
