### PR TITLE
thr-deflake-worker-sessions-controlled-boundary-deadlock

### DIFF
--- a/pkg/services/worker_sessions/internal/service/control_test.go
+++ b/pkg/services/worker_sessions/internal/service/control_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	"github.com/portpowered/infinite-you/pkg/services/events"
@@ -14,6 +17,30 @@ import (
 	workersessions "github.com/portpowered/infinite-you/pkg/services/worker_sessions"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 )
+
+const controlledBoundaryWaitTimeout = 2 * time.Second
+
+var errControlledBoundaryCompletionTimeout = errors.New("controlled boundary completion signal not received")
+
+type controlledDispatch struct {
+	prepared      chan struct{}
+	preparedOnce  sync.Once
+	completed     chan struct{}
+	completedOnce sync.Once
+	returned      chan struct{}
+	returnedOnce  sync.Once
+	request       workers.WorkstationDispatchRequest
+	result        workers.WorkstationDispatchResult
+	err           error
+}
+
+func newControlledDispatch() *controlledDispatch {
+	return &controlledDispatch{
+		prepared:  make(chan struct{}),
+		completed: make(chan struct{}),
+		returned:  make(chan struct{}),
+	}
+}
 
 // controlledBoundary records the exact Workers execution controls Worker
 // Sessions performs and exposes completion as deterministic test input. It
@@ -28,23 +55,30 @@ type controlledBoundary struct {
 	request            workers.WorkstationDispatchRequest
 	publishCalls       int
 	publishError       func(int, workers.WorkstationDispatchRequest) error
-	completed          chan struct{}
-	completedOnce      sync.Once
-	returned           chan struct{}
-	returnedOnce       sync.Once
+	dispatches         map[string]*controlledDispatch
+	dispatchesChanged  chan struct{}
 	cancelled          []workers.WorkstationDispatchCancelRequest
 	cancelObserved     chan struct{}
 	cancelObservedOnce sync.Once
 	ignoreCancellation bool
-	result             workers.WorkstationDispatchResult
-	resultErr          error
+	waitTimeout        time.Duration
 }
 
 func newControlledBoundary() *controlledBoundary {
+	return newControlledBoundaryWithTimeout(controlledBoundaryWaitTimeout)
+}
+
+func newControlledBoundaryWithTimeout(timeout time.Duration) *controlledBoundary {
+	if timeout <= 0 {
+		timeout = controlledBoundaryWaitTimeout
+	}
 	return &controlledBoundary{
-		started:        make(chan struct{}),
-		admitted:       make(chan struct{}),
-		cancelObserved: make(chan struct{}),
+		started:           make(chan struct{}),
+		admitted:          make(chan struct{}),
+		cancelObserved:    make(chan struct{}),
+		dispatches:        make(map[string]*controlledDispatch),
+		dispatchesChanged: make(chan struct{}),
+		waitTimeout:       timeout,
 	}
 }
 
@@ -53,7 +87,7 @@ func (b *controlledBoundary) DispatchWorkstation(ctx context.Context, request wo
 }
 
 func (b *controlledBoundary) DispatchWorkstationWithAdmission(ctx context.Context, request workers.WorkstationDispatchRequest, admitted workers.WorkstationDispatchAdmissionFunc) (workers.WorkstationDispatchResult, error) {
-	completed, err := b.prepare(request)
+	dispatch, err := b.prepare(request)
 	if err != nil {
 		return workers.WorkstationDispatchResult{}, err
 	}
@@ -61,29 +95,36 @@ func (b *controlledBoundary) DispatchWorkstationWithAdmission(ctx context.Contex
 		admitted()
 		b.admittedOnce.Do(func() { close(b.admitted) })
 	}
-	return b.await(ctx, completed, request.Execution.Dispatch.DispatchID)
+	return b.await(ctx, dispatch, request.Execution.Dispatch.DispatchID)
 }
 
-func (b *controlledBoundary) await(ctx context.Context, completed chan struct{}, dispatchID string) (workers.WorkstationDispatchResult, error) {
-	defer b.returnedOnce.Do(func() { close(b.returned) })
+func (b *controlledBoundary) await(ctx context.Context, dispatch *controlledDispatch, dispatchID string) (workers.WorkstationDispatchResult, error) {
+	defer dispatch.returnedOnce.Do(func() { close(dispatch.returned) })
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	timer := time.NewTimer(b.waitTimeout)
+	defer timer.Stop()
 	select {
-	case <-completed:
+	case <-dispatch.completed:
 	case <-ctx.Done():
 		b.recordCancellation(dispatchID)
 		b.mu.Lock()
 		ignoreCancellation := b.ignoreCancellation
 		b.mu.Unlock()
 		if ignoreCancellation {
-			<-completed
-			b.mu.Lock()
-			defer b.mu.Unlock()
-			return b.result, b.resultErr
+			select {
+			case <-dispatch.completed:
+			case <-timer.C:
+				return controlledBoundaryTimeoutResult(dispatchID), controlledBoundaryTimeoutError(dispatchID)
+			}
+			return b.dispatchResult(dispatch)
 		}
 		return canceledDispatchResult(dispatchID), ctx.Err()
+	case <-timer.C:
+		return controlledBoundaryTimeoutResult(dispatchID), controlledBoundaryTimeoutError(dispatchID)
 	}
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.result, b.resultErr
+	return b.dispatchResult(dispatch)
 }
 
 func (b *controlledBoundary) recordCancellation(dispatchID string) {
@@ -109,38 +150,129 @@ func (b *controlledBoundary) setIgnoreCancellation(ignore bool) {
 	b.mu.Unlock()
 }
 
-func (b *controlledBoundary) prepare(request workers.WorkstationDispatchRequest) (chan struct{}, error) {
+func (b *controlledBoundary) prepare(request workers.WorkstationDispatchRequest) (*controlledDispatch, error) {
+	dispatchID := request.Execution.Dispatch.DispatchID
 	b.mu.Lock()
-	defer b.mu.Unlock()
+	dispatch := b.dispatches[dispatchID]
+	if dispatch == nil {
+		dispatch = newControlledDispatch()
+		b.dispatches[dispatchID] = dispatch
+		close(b.dispatchesChanged)
+		b.dispatchesChanged = make(chan struct{})
+	}
+	select {
+	case <-dispatch.prepared:
+		b.mu.Unlock()
+		return nil, fmt.Errorf("controlled boundary duplicate preparation for dispatch %q", dispatchID)
+	default:
+	}
 	b.request = request
 	b.publishCalls++
 	publishCall := b.publishCalls
 	publishError := b.publishError
-	b.completed = make(chan struct{})
-	b.completedOnce = sync.Once{}
-	completed := b.completed
-	b.returned = make(chan struct{})
-	b.returnedOnce = sync.Once{}
+	dispatch.request = request
 	b.startedOnce.Do(func() { close(b.started) })
+	dispatch.preparedOnce.Do(func() { close(dispatch.prepared) })
+	b.mu.Unlock()
 	if publishError != nil {
 		if err := publishError(publishCall, request); err != nil {
-			return nil, err
+			return dispatch, err
 		}
 	}
-	return completed, nil
+	return dispatch, nil
 }
 
 func (b *controlledBoundary) complete(result workers.WorkstationDispatchResult, err error) {
-	b.mu.Lock()
-	completed := b.completed
-	b.result, b.resultErr = result, err
-	b.mu.Unlock()
-	if completed == nil {
-		panic("complete before Publish")
+	dispatchID := result.DispatchID
+	if dispatchID == "" {
+		dispatchID = result.Result.DispatchID
 	}
-	b.completedOnce.Do(func() { close(completed) })
-	if returned := b.returned; returned != nil {
-		<-returned
+	if dispatchID == "" {
+		panic("controlled boundary complete: dispatch ID is required")
+	}
+	b.mu.Lock()
+	dispatch := b.dispatches[dispatchID]
+	if dispatch == nil {
+		dispatch = newControlledDispatch()
+		b.dispatches[dispatchID] = dispatch
+		close(b.dispatchesChanged)
+		b.dispatchesChanged = make(chan struct{})
+	}
+	dispatch.result, dispatch.err = result, err
+	b.mu.Unlock()
+	dispatch.completedOnce.Do(func() { close(dispatch.completed) })
+	if err := waitControlledSignal(dispatch.returned, b.waitTimeout); err != nil {
+		panic(fmt.Sprintf("controlled boundary complete(%q): %v", dispatchID, err))
+	}
+}
+
+func (b *controlledBoundary) dispatchResult(dispatch *controlledDispatch) (workers.WorkstationDispatchResult, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return dispatch.result, dispatch.err
+}
+
+func controlledBoundaryTimeoutError(dispatchID string) error {
+	return fmt.Errorf("%w: dispatch %q", errControlledBoundaryCompletionTimeout, dispatchID)
+}
+
+func controlledBoundaryTimeoutResult(dispatchID string) workers.WorkstationDispatchResult {
+	err := controlledBoundaryTimeoutError(dispatchID)
+	return workers.WorkstationDispatchResult{
+		DispatchID:      dispatchID,
+		TerminalOutcome: workers.WorkstationDispatchTerminalOutcomeFailed,
+		Result: workers.WorkResult{
+			DispatchID: dispatchID,
+			Outcome:    workers.OutcomeFailed,
+			Error:      err.Error(),
+		},
+	}
+}
+
+func waitControlledSignal(signal <-chan struct{}, timeout time.Duration) error {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-signal:
+		return nil
+	case <-timer.C:
+		return fmt.Errorf("%w after %s", errControlledBoundaryCompletionTimeout, timeout)
+	}
+}
+
+func (b *controlledBoundary) requestFor(t *testing.T, dispatchID string) workers.WorkstationDispatchRequest {
+	t.Helper()
+	dispatch, err := b.dispatchFor(dispatchID)
+	if err != nil {
+		t.Fatalf("controlled boundary dispatch %q was not prepared: %v", dispatchID, err)
+	}
+	if err := waitControlledSignal(dispatch.prepared, b.waitTimeout); err != nil {
+		t.Fatalf("controlled boundary dispatch %q readiness: %v", dispatchID, err)
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return workers.WorkstationDispatchRequest{
+		WorkstationName: dispatch.request.WorkstationName,
+		Execution:       workers.CloneWorkstationExecutionRequest(dispatch.request.Execution),
+	}
+}
+
+func (b *controlledBoundary) dispatchFor(dispatchID string) (*controlledDispatch, error) {
+	timer := time.NewTimer(b.waitTimeout)
+	defer timer.Stop()
+	for {
+		b.mu.Lock()
+		dispatch := b.dispatches[dispatchID]
+		changed := b.dispatchesChanged
+		b.mu.Unlock()
+		if dispatch != nil {
+			return dispatch, nil
+		}
+		select {
+		case <-changed:
+		case <-timer.C:
+			return nil, controlledBoundaryTimeoutError(dispatchID)
+		}
 	}
 }
 
@@ -197,15 +329,39 @@ func completedDispatchResult(dispatchID string) workers.WorkstationDispatchResul
 func startControlledSession(t *testing.T, registry workersessions.Service, boundary *controlledBoundary, id, dispatchID string) <-chan workersessions.InvokeSessionResult {
 	t.Helper()
 	result := make(chan workersessions.InvokeSessionResult, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
 	go func() {
-		started, err := registry.InvokeSession(context.Background(), validStartRequest(id, dispatchID))
+		defer close(done)
+		started, err := registry.InvokeSession(ctx, validStartRequest(id, dispatchID))
 		if err != nil {
 			t.Errorf("Start() error = %v", err)
 		}
 		result <- started
 	}()
-	<-boundary.admitted
+	t.Cleanup(func() {
+		cancel()
+		if err := waitControlledSignal(done, boundary.waitTimeout); err != nil {
+			t.Errorf("controlled Start() goroutine did not join: %v", err)
+		}
+	})
+	if err := waitControlledSignal(boundary.admitted, boundary.waitTimeout); err != nil {
+		t.Fatalf("controlled Start() admission: %v", err)
+	}
 	return result
+}
+
+func TestControlledBoundary_MissingCompletionFailsWithDispatchDiagnostic(t *testing.T) {
+	boundary := newControlledBoundaryWithTimeout(10 * time.Millisecond)
+	dispatch, err := boundary.prepare(validStartRequest("worker-1", "dispatch-missing").Execution)
+	if err != nil {
+		t.Fatalf("prepare() error = %v", err)
+	}
+	_, err = boundary.await(context.Background(), dispatch, "dispatch-missing")
+	if !errors.Is(err, errControlledBoundaryCompletionTimeout) ||
+		!strings.Contains(err.Error(), `dispatch "dispatch-missing"`) {
+		t.Fatalf("await() error = %v, want named dispatch completion timeout", err)
+	}
 }
 
 func TestCancel_UsesServerOwnedAttemptContextDespiteCanceledCallerContextAndIsIdempotent(t *testing.T) {
@@ -300,7 +456,7 @@ func TestPauseResume_ContinuesExactProviderReferenceWithSameWorkerSessionCorrela
 	if err != nil || resumed.Outcome != workersessions.ControlOutcomeApplied || resumed.Session.State != workersessions.StateRunning {
 		t.Fatalf("Resume() = %#v, %v, want applied RUNNING", resumed, err)
 	}
-	continuation := boundary.currentRequest()
+	continuation := boundary.requestFor(t, resumed.DispatchID)
 	wantContinuation := reference.ContinuationRef()
 	if continuation.Execution.Continuation == nil || *continuation.Execution.Continuation != wantContinuation {
 		t.Fatalf("continuation Continuation = %#v, want exact %#v", continuation.Execution.Continuation, wantContinuation)

--- a/pkg/services/worker_sessions/internal/service/fakes_test.go
+++ b/pkg/services/worker_sessions/internal/service/fakes_test.go
@@ -472,7 +472,7 @@ func TestContinue_CreatesDistinctSuccessorWithExactReferenceAndLineage(t *testin
 	}
 	assertContinuationAdmission(t, continued, request)
 
-	handoff := boundary.currentRequest()
+	handoff := boundary.requestFor(t, continued.Session.ProviderSessionAssociation.DispatchID)
 	assertContinuationHandoff(t, handoff, request, reference, source)
 
 	sourceAfter, err := registry.Get(context.Background(), workersessions.GetRequest{ID: request.SourceWorkerSessionID})
@@ -698,7 +698,7 @@ func (b *continuationAdmissionBoundary) DispatchWorkstationWithAdmission(
 	request workers.WorkstationDispatchRequest,
 	admitted workers.WorkstationDispatchAdmissionFunc,
 ) (workers.WorkstationDispatchResult, error) {
-	completed, err := b.controlledBoundary.prepare(request)
+	dispatch, err := b.controlledBoundary.prepare(request)
 	if err != nil {
 		return workers.WorkstationDispatchResult{}, err
 	}
@@ -714,7 +714,7 @@ func (b *continuationAdmissionBoundary) DispatchWorkstationWithAdmission(
 		admitted()
 		b.controlledBoundary.admittedOnce.Do(func() { close(b.controlledBoundary.admitted) })
 	}
-	return b.controlledBoundary.await(ctx, completed, request.Execution.Dispatch.DispatchID)
+	return b.controlledBoundary.await(ctx, dispatch, request.Execution.Dispatch.DispatchID)
 }
 
 func TestContinue_ProviderFailureLeavesSuccessorFailedWithExactAssociation(t *testing.T) {

--- a/pkg/services/worker_sessions/internal/service/publish_test.go
+++ b/pkg/services/worker_sessions/internal/service/publish_test.go
@@ -665,7 +665,7 @@ func TestContinue_PersistsExactAttemptAndPortableContinuationLineage(t *testing.
 	assertSourceContinuationLineage(t, sourceRecords, request, reference)
 	successorRecords := readWorkerSessionRecords(t, eventsSvc, request.SuccessorWorkerSessionID)
 	assertSuccessorContinuationOpening(t, successorRecords, request, reference)
-	successorHandoff := boundary.currentRequest()
+	successorHandoff := boundary.requestFor(t, continued.Session.ProviderSessionAssociation.DispatchID)
 	boundary.complete(completedDispatchWithProviderSession(successorHandoff.Execution.Dispatch.DispatchID, reference), nil)
 	successorRecords = readWorkerSessionRecordsUntil(t, eventsSvc, request.SuccessorWorkerSessionID, 2)
 	if len(successorRecords) != 2 {

--- a/pkg/services/worker_sessions/internal/service/service_test.go
+++ b/pkg/services/worker_sessions/internal/service/service_test.go
@@ -645,7 +645,7 @@ func TestInterrupt_CancelsExactSourceBeforeAdmittingExactSessionSuccessor(t *tes
 		t.Fatalf("cancellations = %#v, want one exact source dispatch", cancellations)
 	}
 
-	handoff := boundary.currentRequest()
+	handoff := boundary.requestFor(t, result.Successor.ProviderSessionAssociation.DispatchID)
 	assertInterruptHandoff(t, handoff, request, reference)
 	if sourceResult := <-sourceResult; sourceResult.Session.State != workersessions.StateCanceled {
 		t.Fatalf("source InvokeSession() = %#v, want CANCELED", sourceResult.Session)
@@ -781,7 +781,7 @@ func TestInterrupt_IdempotencyAndRequestConflictAvoidDuplicateEffects(t *testing
 	if boundary.publishCount() != firstPublishCount || len(boundary.cancellations()) != firstCancellationCount {
 		t.Fatalf("conflict effects changed: publishes=%d cancels=%d", boundary.publishCount(), len(boundary.cancellations()))
 	}
-	handoff := boundary.currentRequest()
+	handoff := boundary.requestFor(t, first.Successor.ProviderSessionAssociation.DispatchID)
 	boundary.complete(completedDispatchWithProviderSession(handoff.Execution.Dispatch.DispatchID, reference), nil)
 	if got := <-sourceResult; got.Session.State != workersessions.StateCanceled {
 		t.Fatalf("source InvokeSession() = %#v, want CANCELED", got.Session)
@@ -852,9 +852,13 @@ func TestInterrupt_ConcurrentIdenticalRequestsReplayOneOperation(t *testing.T) {
 	}
 	group.Wait()
 	close(outcomes)
+	var successorDispatchID string
 	for result := range outcomes {
 		if result.err != nil || !result.result.Accepted {
 			t.Fatalf("concurrent Interrupt() = %#v, %v, want accepted replay", result.result, result.err)
+		}
+		if result.result.Successor.ProviderSessionAssociation != nil {
+			successorDispatchID = result.result.Successor.ProviderSessionAssociation.DispatchID
 		}
 	}
 	if got := len(boundary.cancellations()); got != 1 {
@@ -863,7 +867,7 @@ func TestInterrupt_ConcurrentIdenticalRequestsReplayOneOperation(t *testing.T) {
 	if got := boundary.publishCount(); got != 2 {
 		t.Fatalf("concurrent interrupt publishes = %d, want source plus one successor", got)
 	}
-	handoff := boundary.currentRequest()
+	handoff := boundary.requestFor(t, successorDispatchID)
 	boundary.complete(completedDispatchWithProviderSession(handoff.Execution.Dispatch.DispatchID, reference), nil)
 	if got := <-sourceResult; got.Session.State != workersessions.StateCanceled {
 		t.Fatalf("source cleanup InvokeSession() = %#v, want CANCELED", got.Session)

--- a/pkg/services/worker_sessions/internal/service/start_side_effects_test.go
+++ b/pkg/services/worker_sessions/internal/service/start_side_effects_test.go
@@ -618,7 +618,6 @@ func TestReplayOnly_DoesNotClaimCompletenessBeforeTerminalRecordIsRetained(t *te
 		terminalAppendStarted: make(chan struct{}),
 		releaseTerminalAppend: make(chan struct{}),
 	}
-	defer appender.release()
 	boundary := newControlledBoundary()
 	registry, err := newService(boundary, appender, nil)
 	if err != nil {
@@ -646,7 +645,17 @@ func TestReplayOnly_DoesNotClaimCompletenessBeforeTerminalRecordIsRetained(t *te
 	}); err != nil {
 		t.Fatalf("AssociateProviderSession() error = %v, want nil", err)
 	}
-	go boundary.complete(completedDispatchResult("dispatch-1"), nil)
+	completionDone := make(chan struct{})
+	go func() {
+		defer close(completionDone)
+		boundary.complete(completedDispatchResult("dispatch-1"), nil)
+	}()
+	t.Cleanup(func() {
+		appender.release()
+		if err := waitControlledSignal(completionDone, controlledBoundaryWaitTimeout); err != nil {
+			t.Errorf("controlled dispatch completion goroutine did not join: %v", err)
+		}
+	})
 	waitForReplayRaceSignal(t, appender.terminalAppendStarted, "blocked terminal append")
 
 	replay, err := registry.StreamObservations(ctx, workersessions.StreamObservationsRequest{
@@ -661,6 +670,7 @@ func TestReplayOnly_DoesNotClaimCompletenessBeforeTerminalRecordIsRetained(t *te
 
 	appender.release()
 	assertReplayRaceStartCompleted(t, <-startDone)
+	waitForReplayRaceSignal(t, completionDone, "controlled dispatch completion")
 }
 
 func waitForReplayRaceSignal(t *testing.T, signal <-chan struct{}, name string) {

--- a/pkg/services/worker_sessions/internal/service/start_test.go
+++ b/pkg/services/worker_sessions/internal/service/start_test.go
@@ -986,7 +986,7 @@ func TestStart_ProviderProgressCommitsAssociationBeforeOutputAndEnablesResume(t 
 	if err != nil || resumed.Outcome != workersessions.ControlOutcomeApplied {
 		t.Fatalf("Resume() = %#v, %v, want applied exact continuation", resumed, err)
 	}
-	continuation := boundary.currentRequest()
+	continuation := boundary.requestFor(t, resumed.DispatchID)
 	wantContinuation := reference.ContinuationRef()
 	if continuation.Execution.Continuation == nil || *continuation.Execution.Continuation != wantContinuation {
 		t.Fatalf("continuation Continuation = %#v, want exact %#v", continuation.Execution.Continuation, wantContinuation)


### PR DESCRIPTION
{
  "project": "Deflake the Worker Sessions Controlled-Boundary Deadlock",
  "branchName": "thr-deflake-worker-sessions-controlled-boundary-deadlock",
  "description": "Eliminate the intermittent channel deadlock in the Worker Sessions internal service unit package by measuring the pre-fix failure rate, identifying the exact unmatched synchronization operation, bounding controlled test waits, cleaning up every test-started goroutine, and proving zero hangs at the same focused and whole-package stress counts while preserving invalid-continuation failure and association retention behavior.",
  "context": {
    "customerAsk": "Stop pkg/services/worker_sessions/internal/service from intermittently consuming the full 10-minute test timeout. Reproduce and quantify the deadlock, identify the unmatched channel operation, fix the cause without sleeps, retries, quarantine, timeout increases, or weakened assertions, and report matched before/after stress evidence while staying inside the owned Worker Sessions internal service package.",
    "problem": "PR #2042 head 42b65718e, run 32016370609, job 95347765965 failed after exactly 600.315 seconds in TestPauseResume_InvalidContinuationResultFailsAndRetainsAssociation/missing_reference. The goroutine dump shows controlledBoundary waiting during dispatch, publishRegisteredAttempt waiting for publication, and goroutines from other tests still blocked on channel sends or receives. This indicates an unmatched signal or an early receiver exit that can leak across tests and fail unrelated pull requests. The recent coverage-guard commits are hypotheses to investigate, not established attribution.",
    "solution": "Run the focused invalid-continuation test 200 times and the whole package 50 times before editing, or cite equivalent CI stress if local runs do not reproduce. Trace channel ownership and lifecycle ordering to the exact unmatched operation, then apply the narrowest correction within Worker Sessions: bound waits with a test-owned context or deadline, make missing signals fail with named diagnostics, and cancel or join every test-started goroutine. Preserve all invalid-continuation and association-retention assertions, repeat both stress workloads at the same counts with zero hangs, and leave adjacent BTRC surfaces and coverage manifests untouched."
  },
  "acceptanceCriteria": [
    "Before modification, the focused command go test ./pkg/services/worker_sessions/internal/service/ -run 'TestPauseResume_InvalidContinuationResultFailsAndRetainsAssociation' -count=200 -timeout=15m and a whole-package -count=50 stress run report completed runs, hang counts, and failure rates. If the defect does not reproduce locally, equivalent CI stress is reported with a run ID; the unchanged-head rerun outcome for job 95347765965 is recorded but one green rerun is not treated as proof.",
    "The investigation identifies the exact unmatched send, receive, close, cancellation, or early return and reports evidence for the cause, explicitly confirming or rejecting attribution to commits 26e43e49c and cf60883ad rather than presenting the hypothesis as fact.",
    "Every affected test wait is bounded by its owning test context or deadline, every test-started goroutine is canceled or joined before return, and deliberately withholding the relevant signal fails promptly with a named diagnostic instead of consuming the suite timeout.",
    "TestPauseResume_InvalidContinuationResultFailsAndRetainsAssociation continues to prove that missing, malformed, and foreign continuation references fail the Worker Session as an invalid continuation while retaining the original provider-session association.",
    "After the fix, the same focused -count=200 and whole-package -count=50 stress commands complete with zero hangs; before/after counts and rates are reported, and the change's own Backend Unit Coverage job measures the package without either coverage manifest being edited.",
    "The diff remains under pkg/services/worker_sessions/internal/service/** and is rebased onto origin/main immediately before the final push; it does not touch pkg/services/factory_sessions/**, pkg/transports/**, pkg/wire, either coverage manifest, or unrelated cleanup. Typecheck passes and Tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "thr-deflake-worker-sessions-controlled-boundary-deadlock-001",
      "title": "Reproduce and locate the unmatched synchronization",
      "description": "As a maintainer, I want quantified reproduction and an exact synchronization trace so the correction addresses the deadlock mechanism rather than masking an intermittent symptom.",
      "acceptanceCriteria": [
        "Before any fix, the focused invalid-continuation test runs 200 times with a 15-minute command timeout and the whole package runs 50 times; evidence reports completed runs, hang count, and failure rate for each workload.",
        "If neither workload reproduces locally, equivalent stress runs in CI are cited by run ID, and the original failure plus the unchanged-head rerun outcome are recorded without treating one green rerun as proof of stability.",
        "The investigation names the exact channel send, receive, close, cancellation, or early return that lacks its counterpart and explains how the missing_reference path or cross-test goroutine leakage reaches that state.",
        "History for 26e43e49c and cf60883ad is compared with the identified mechanism; attribution is stated only when supported, otherwise the PR plainly rejects or leaves the hypothesis unproven.",
        "No sleeps, retries, longer suite timeouts, quarantine entries, deleted assertions, coverage-manifest edits, or out-of-scope package changes are introduced during diagnosis.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Baseline on unchanged 118ebd666: the exact focused -count=200 workload completed 200/200 runs with 0 hangs and 0 failures (0% failure rate) in 0.344s. The exact whole-package -count=50 workload completed 0/50 package iterations, hung once, and timed out at 900.081s (1/1 invocation hung; 100% command-level hang rate); three assertion failures were emitted before the deadlock. The timeout dump names control_test.go:69 (resumed controlledBoundary.await), control_test.go:501 (test waiting for Start), and invoke_session.go:244 (driver waiting on attemptDone). The cause is the test adapter's shared completion channel: publishExecution returns after the service admission callback, before the legacy execution adapter enters controlledBoundary.prepare for the resumed dispatch, so complete can close the prior attempt's channel while the resumed await waits on a new one. History rejects 26e43e49c and cf60883ad as causal: both only add/split coverage tests or manifests; the admission ordering entered with a629a83137's direct execution migration."
    },
    {
      "id": "thr-deflake-worker-sessions-controlled-boundary-deadlock-002",
      "title": "Bound the controlled boundary and prove clean termination",
      "description": "As a contributor, I want Worker Sessions concurrency tests to complete or fail with an attributable bounded error so an unmatched signal cannot consume the suite timeout or leak into another test.",
      "acceptanceCriteria": [
        "The exact unmatched synchronization cause is corrected at its owning boundary; the change does not merely increase a timeout, retry an operation, add a sleep, or suppress the affected test.",
        "Every affected wait observes a deadline or cancellation owned by the test, and a regression scenario that deliberately withholds the relevant signal fails promptly with a diagnostic naming the awaited event or operation.",
        "Every goroutine started by the affected controlled boundary or coverage guard is joined or canceled before its test returns, including early-error paths, so later tests cannot inherit blocked senders or receivers.",
        "Missing, malformed, and foreign continuation results still produce a failed Worker Session with invalid-continuation classification and the original provider-session association retained.",
        "The focused invalid-continuation stress command completes 200 runs with zero hangs, and the whole-package stress command completes 50 runs with zero hangs; evidence reports the before/after failure rates using the same counts.",
        "The focused package tests and the PR's Backend Unit Coverage job pass without modifying either coverage manifest, and the final diff stays within pkg/services/worker_sessions/internal/service/**.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented per-dispatch controlled-boundary completion/readiness state keyed by dispatch ID, bounded missing-completion diagnostics, and test goroutine cleanup/join paths. Missing, malformed, and foreign continuation assertions remain unchanged and pass. Focused exact -count=200 completed 200/200 with 0 hangs and 0 failures; whole-package exact -count=50 completed 50/50 with 0 hangs, with five unrelated TestContinue_CreatesDistinctSuccessorWithExactReferenceAndLineage assertion flakes reproduced against unchanged 118ebd666. Count-1 package tests, targeted repeats, go vet, formatting, and diff checks pass; no coverage manifests or out-of-scope packages changed. Implementation delivery still requires final push, open PR, CI started, and blocking feedback addressed."
    }
  ]
}
