### PR TITLE
Give review a non-failing bounded hold route

### DIFF
--- a/factory/factory.json
+++ b/factory/factory.json
@@ -769,6 +769,7 @@
       "workingDirectory": ".claude/worktrees/{{ (index .Inputs 0).Name }}"
     },
     {
+      "behavior": "REPEATER",
       "id": "review",
       "inputs": [
         {
@@ -781,6 +782,16 @@
         }
       ],
       "name": "review",
+      "onContinue": [
+        {
+          "state": "in-review",
+          "workType": "task"
+        },
+        {
+          "state": "init",
+          "workType": "review"
+        }
+      ],
       "onFailure": [
         {
           "state": "failed",

--- a/factory/workstations/review/AGENTS.md
+++ b/factory/workstations/review/AGENTS.md
@@ -75,7 +75,11 @@ If the change involves modification to the website, you should use the playwrigh
   started — that routes the work back to the processor, which has nothing to
   do, and burns a process/review round trip.
 - Only if checks are STILL non-terminal after the bounded wait: end with
-  `<REJECTED>` without posting a comment, so the loop re-enters review later.
+  `<CONTINUE>` and post no comment. That is a HOLD, not a verdict: it returns
+  this work item to review so the loop re-enters review later once CI has
+  moved, without a failed worker session and without a rejection strike.
+  Waiting on CI is never executor rework, so it must never take the rejection
+  route.
 - Known-baseline flake policy: if a required check fails ONLY on a test in a
   package the PR diff does not touch, and that test is a known baseline flake
   (see the deflake lane list in docs/temp/scale-program-rules.md in the root
@@ -83,8 +87,10 @@ If the change involves modification to the website, you should use the playwrigh
   (`gh run rerun <id> --failed`) and watch again. If it greens, proceed. If
   the same untouched-package flake fails twice, post ONE comment naming the
   test and the owning deflake lane, state explicitly "NO EXECUTOR ACTION
-  REQUIRED — waiting on baseline deflake", and end `<REJECTED>`. Never demand
-  code changes for a baseline flake in a package the diff does not touch.
+  REQUIRED — waiting on baseline deflake", and end `<CONTINUE>`. That is a wait
+  on another lane, not executor rework, so it takes the hold route; post that
+  comment at most once and stay silent on later holds for the same flake. Never
+  demand code changes for a baseline flake in a package the diff does not touch.
 
 ### Step 3 — Verify project acceptance criteria
 
@@ -121,6 +127,18 @@ operator to file separately. From the third review pass onward the decision
 bar is: MERGE unless an unfixed previously-flagged blocker or red required CI
 remains.
 
+Route a converged repeat review as a HOLD. If the head has not moved since
+your last pass and you have no NEW independent finding — including the case
+where you are only re-confirming a blocker set the executor was already told
+about — end with `<CONTINUE>` and post no new PR comment. Re-sending an
+unchanged blocker set is a no-op that hands the processor nothing to act on,
+and taking the rejection route for it counts a consecutive-failure strike that
+can kill a healthy lane. `<REJECTED>` is for delivering concrete executor work
+the executor does not already have: the first time you raise a blocker set, or
+a new blocker on a head pushed since your last pass. Holds are bounded by the
+review visit cap, so a genuinely stuck lane still surfaces without you forcing
+a rejection.
+
 ### Step 5 - handle feedback
 
 - Post a PR comment with your review summary, including the acceptance criteria checklist results, only after the required CI state is terminal for the current head or you have concrete independent review findings to report.
@@ -128,6 +146,7 @@ remains.
 - If you would have requested changes in a normal review, describe the required fixes plainly in the comment so the executor can act on them.
 - If earlier blocking feedback is no longer applicable, say so explicitly in a newer PR conversation comment so the processor has clear resolution evidence.
 - Do not post a PR comment whose only content is that required CI is still pending or in progress.
+- A hold (`<CONTINUE>`) is silent by definition: when you hold for non-terminal CI or for an unchanged head with no new findings, post no PR comment at all.
 
 Use `gh pr comment` for the comment post. Do not use `gh pr review --approve` or `gh pr review --request-changes`.
 
@@ -139,22 +158,31 @@ If the PR has merge conflicts, please tell the processor to fix the merge confli
 
 ### Step 7 - respond back
 
-End your final response with exactly one review routing marker:
+End your final response with exactly one review routing marker, alone on the
+final line:
 
 - `<COMPLETE>` when the PR is complete, approved, and merged.
-- `<REJECTED>` when concrete executor work remains, required CI is still
-  running, or the change is otherwise not ready to approve.
+- `<CONTINUE>` to HOLD, because required CI is still non-terminal after the
+  bounded watcher, or because this is a repeat pass on an unchanged head with
+  no new independent findings. A hold posts no PR comment and re-enters review
+  with no failed worker session and no consecutive-failure strike. Holds are
+  bounded by the review visit cap, so holding cannot loop forever.
+- `<REJECTED>` when concrete executor rework remains that the executor has not
+  already been given — a blocker set you are raising for the first time, or a
+  new blocker on a head pushed since your last pass. Rejection routes the work
+  back to the processor, so use it only when the processor has something to do.
+  Never use it as a way to wait.
 
 Write the review summary and acceptance-criteria checklist before the marker.
-Do not return a JSON decision envelope. The runtime derives the review outcome
-from the worker's `<COMPLETE>` stop token; a response without that stop token
-follows the review rejection route. Do not use `<CONTINUE>` from this
-workstation because review rework belongs on the rejection route.
+Do not return a JSON decision envelope.
 
-If CI is still pending or in progress and you have no concrete independent
-review findings to report yet, end with `<REJECTED>` without posting a new PR
-comment so the workflow waits silently instead of creating premature review
-noise.
+The runtime scans your whole response for these markers, so emit exactly one of
+them and put it alone on the final line. Do not quote or mention the other
+markers anywhere in your summary text: a stray `<COMPLETE>` inside a checklist
+line can be read as approval-and-merge even when you meant to hold. `<COMPLETE>`
+takes precedence over `<CONTINUE>`, and a response carrying neither marker
+follows the rejection route — which is why `<REJECTED>` is a marker you write
+for the human reader rather than a separate runtime token.
 
 ## addenda
 

--- a/factory/workstations/review/AGENTS.md
+++ b/factory/workstations/review/AGENTS.md
@@ -177,12 +177,18 @@ Write the review summary and acceptance-criteria checklist before the marker.
 Do not return a JSON decision envelope.
 
 The runtime scans your whole response for these markers, so emit exactly one of
-them and put it alone on the final line. Do not quote or mention the other
-markers anywhere in your summary text: a stray `<COMPLETE>` inside a checklist
-line can be read as approval-and-merge even when you meant to hold. `<COMPLETE>`
-takes precedence over `<CONTINUE>`, and a response carrying neither marker
-follows the rejection route — which is why `<REJECTED>` is a marker you write
-for the human reader rather than a separate runtime token.
+them and put it alone on the final line. `<COMPLETE>` takes precedence over
+`<CONTINUE>`, and a response carrying neither marker follows the rejection
+route — which is why `<REJECTED>` is a marker you write for the human reader
+rather than a separate runtime token.
+
+Because the scan is a plain substring match over the entire response, never
+write a routing marker anywhere except that final line. This matters most when
+you are reviewing a PR that is itself about routing markers: when a PRD
+criterion or a quoted diff contains one, paraphrase it by name — "the COMPLETE
+marker", "the CONTINUE marker" — instead of pasting the literal token into your
+summary or acceptance-criteria checklist. A stray literal `<COMPLETE>` in a
+checklist line is read as approval-and-merge even when you meant to hold.
 
 ## addenda
 

--- a/pkg/services/factory_definitions/internal/services/validation/impl/topology_guards_test.go
+++ b/pkg/services/factory_definitions/internal/services/validation/impl/topology_guards_test.go
@@ -107,6 +107,70 @@ func TestRuleGuards_VisitCountZeroMaxVisits(t *testing.T) {
 	assertFindingExists(t, findings, "guard-visit-count-max-visits")
 }
 
+func TestValidate_ReviewRepeaterContinueTopologyWithBoundedLoopBreaker(t *testing.T) {
+	cfg := &factorydefinitions.FactoryConfig{
+		WorkTypes: []factorydefinitions.WorkTypeConfig{
+			{
+				Name: "task",
+				States: []factorydefinitions.StateConfig{
+					{Name: "init", Type: factorydefinitions.StateTypeInitial},
+					{Name: "in-review", Type: factorydefinitions.StateTypeProcessing},
+					{Name: "to-complete", Type: factorydefinitions.StateTypeProcessing},
+					{Name: "complete", Type: factorydefinitions.StateTypeTerminal},
+					{Name: "failed", Type: factorydefinitions.StateTypeFailed},
+				},
+			},
+			{
+				Name: "review",
+				States: []factorydefinitions.StateConfig{
+					{Name: "init", Type: factorydefinitions.StateTypeInitial},
+					{Name: "complete", Type: factorydefinitions.StateTypeTerminal},
+					{Name: "fin", Type: factorydefinitions.StateTypeFailed},
+				},
+			},
+		},
+		Workstations: []factorydefinitions.FactoryWorkstationConfig{
+			{
+				Name: "review",
+				Kind: factorydefinitions.WorkstationKindRepeater,
+				Inputs: []factorydefinitions.IOConfig{
+					{WorkTypeName: "task", StateName: "in-review"},
+					{WorkTypeName: "review", StateName: "init"},
+				},
+				Outputs: []factorydefinitions.IOConfig{
+					{WorkTypeName: "task", StateName: "to-complete"},
+					{WorkTypeName: "review", StateName: "complete"},
+				},
+				OnContinue: []factorydefinitions.IOConfig{
+					{WorkTypeName: "task", StateName: "in-review"},
+					{WorkTypeName: "review", StateName: "init"},
+				},
+				OnRejection: []factorydefinitions.IOConfig{{WorkTypeName: "task", StateName: "init"}},
+				OnFailure: []factorydefinitions.IOConfig{
+					{WorkTypeName: "task", StateName: "failed"},
+					{WorkTypeName: "review", StateName: "fin"},
+				},
+			},
+			{
+				Name:    "review-loop-breaker",
+				Type:    factorydefinitions.WorkstationTypeLogical,
+				Inputs:  []factorydefinitions.IOConfig{{WorkTypeName: "task", StateName: "in-review"}},
+				Outputs: []factorydefinitions.IOConfig{{WorkTypeName: "task", StateName: "failed"}},
+				Guards: []factorydefinitions.GuardConfig{{
+					Type:        factorydefinitions.GuardTypeVisitCount,
+					Workstation: "review",
+					MaxVisits:   10,
+				}},
+			},
+		},
+	}
+
+	result := Validate(cfg)
+	if len(result.Targets) != 0 {
+		t.Fatalf("review hold topology produced validation targets: %#v", result.Targets)
+	}
+}
+
 func TestRuleInvocationBoundLimitsAcceptsNumberStringParameters(t *testing.T) {
 	cfg := testBaseConfig()
 	cfg.InvocationSignature = &factorydefinitions.InvocationSignatureConfig{Parameters: []factorydefinitions.InvocationParameterConfig{

--- a/pkg/services/factory_runtime/internal/services/orchestration/definitionmapping/maptests/config_mapper_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/definitionmapping/maptests/config_mapper_test.go
@@ -180,6 +180,97 @@ func TestConfigMapping_RejectionLoopWithGuardedLoopBreaker(t *testing.T) {
 	testutil.AssertGuardedLoopBreakerTransition(t, outputNet.Transitions["reviewer-loop-breaker"], "task:init", "task:failed", "reviewer", 3)
 }
 
+func TestConfigMapping_ReviewRepeaterContinuePreservesRejectionFailureAndVisitBound(t *testing.T) {
+	mapper := testConfigMapper{}
+	outputNet, err := mapper.Map(context.Background(), reviewHoldFactoryConfig())
+	if err != nil {
+		t.Fatalf("failed to map review hold config: %v", err)
+	}
+
+	review := outputNet.Transitions["review"]
+	if review == nil {
+		t.Fatal("expected review transition")
+	}
+	assertTransitionArcPlaces(t, review.OutputArcs, "task:to-complete", "review:complete")
+	assertTransitionArcPlaces(t, review.ContinueArcs, "task:in-review", "review:init")
+	assertTransitionArcPlaces(t, review.RejectionArcs, "task:init")
+	assertTransitionArcPlaces(t, review.FailureArcs, "task:failed", "review:fin")
+
+	breaker := outputNet.Transitions["review-loop-breaker"]
+	if breaker == nil {
+		t.Fatal("expected review-loop-breaker transition")
+	}
+	if len(breaker.InputArcs) != 1 {
+		t.Fatalf("review-loop-breaker input arcs = %d, want 1", len(breaker.InputArcs))
+	}
+	guard, ok := breaker.InputArcs[0].Guard.(*factoryruntime.PetriVisitCountGuard)
+	if !ok {
+		t.Fatalf("review-loop-breaker input guard = %T, want VisitCountGuard", breaker.InputArcs[0].Guard)
+	}
+	if guard.TransitionID != "review" || guard.MaxVisits != 10 {
+		t.Fatalf("review loop guard = (%q, %d), want (review, 10)", guard.TransitionID, guard.MaxVisits)
+	}
+}
+
+func reviewHoldFactoryConfig() *interfaces.FactoryConfig {
+	return &interfaces.FactoryConfig{
+		WorkTypes: []interfaces.WorkTypeConfig{
+			{
+				Name: "task",
+				States: []interfaces.StateConfig{
+					{Name: "init", Type: interfaces.StateTypeInitial},
+					{Name: "in-review", Type: interfaces.StateTypeProcessing},
+					{Name: "to-complete", Type: interfaces.StateTypeProcessing},
+					{Name: "complete", Type: interfaces.StateTypeTerminal},
+					{Name: "failed", Type: interfaces.StateTypeFailed},
+				},
+			},
+			{
+				Name: "review",
+				States: []interfaces.StateConfig{
+					{Name: "init", Type: interfaces.StateTypeInitial},
+					{Name: "complete", Type: interfaces.StateTypeTerminal},
+					{Name: "fin", Type: interfaces.StateTypeFailed},
+				},
+			},
+		},
+		Workstations: []interfaces.FactoryWorkstationConfig{
+			{
+				Name: "review",
+				Kind: interfaces.WorkstationKindRepeater,
+				Inputs: []interfaces.IOConfig{
+					{WorkTypeName: "task", StateName: "in-review"},
+					{WorkTypeName: "review", StateName: "init"},
+				},
+				Outputs: []interfaces.IOConfig{
+					{WorkTypeName: "task", StateName: "to-complete"},
+					{WorkTypeName: "review", StateName: "complete"},
+				},
+				OnContinue: []interfaces.IOConfig{
+					{WorkTypeName: "task", StateName: "in-review"},
+					{WorkTypeName: "review", StateName: "init"},
+				},
+				OnRejection: []interfaces.IOConfig{{WorkTypeName: "task", StateName: "init"}},
+				OnFailure: []interfaces.IOConfig{
+					{WorkTypeName: "task", StateName: "failed"},
+					{WorkTypeName: "review", StateName: "fin"},
+				},
+			},
+			{
+				Name:    "review-loop-breaker",
+				Type:    interfaces.WorkstationTypeLogical,
+				Inputs:  []interfaces.IOConfig{{WorkTypeName: "task", StateName: "in-review"}},
+				Outputs: []interfaces.IOConfig{{WorkTypeName: "task", StateName: "failed"}},
+				Guards: []interfaces.GuardConfig{{
+					Type:        interfaces.GuardTypeVisitCount,
+					Workstation: "review",
+					MaxVisits:   10,
+				}},
+			},
+		},
+	}
+}
+
 func rejectionLoopWithGuardedLoopBreakerFactoryConfig() *interfaces.FactoryConfig {
 	return &interfaces.FactoryConfig{
 		WorkTypes: []interfaces.WorkTypeConfig{{

--- a/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_history_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_history_test.go
@@ -120,6 +120,28 @@ func TestBuildHistory_MergesSharedLineageVisitCountsWithMaxNotSum(t *testing.T) 
 	}
 }
 
+func TestBuildHistory_ContinueResetsConsecutiveFailureStrike(t *testing.T) {
+	consumed := []factorytoken.Token{{
+		Color: factorytoken.Color{WorkID: "task-1", WorkTypeID: "task"},
+		History: factorytoken.History{
+			TotalVisits:         map[string]int{"review": 4},
+			ConsecutiveFailures: map[string]int{"review": 2},
+		},
+	}}
+
+	history := buildHistory(consumed, &workerexecution.WorkResult{
+		TransitionID: "review",
+		Outcome:      workerexecution.OutcomeContinue,
+	}, "task-1")
+
+	if got := history.TotalVisits["review"]; got != 5 {
+		t.Fatalf("TotalVisits[review] = %d, want 5 for the continued visit", got)
+	}
+	if got := history.ConsecutiveFailures["review"]; got != 0 {
+		t.Fatalf("ConsecutiveFailures[review] = %d, want 0 for a non-failing continue", got)
+	}
+}
+
 func TestBuildHistory_IncompleteOutputRemainsConsecutiveFailure(t *testing.T) {
 	consumed := []factorytoken.Token{{
 		Color: factorytoken.Color{WorkID: "review-1", WorkTypeID: "review"},


### PR DESCRIPTION
## Summary

Gives the `review` workstation a bounded, non-failing HOLD route so waiting on
non-terminal CI, or re-reading an unchanged head with no new findings, no longer
burns a consecutive-failure strike and kills a healthy lane.

Three parts, matching the PRD:

1. `factory/factory.json` — `review` gains `behavior: REPEATER` and an `onContinue`
   route targeting its own inputs (task `in-review`, review `init`).
2. `factory/workstations/review/AGENTS.md` — the routing tokens are split so each
   outcome has exactly one meaning (details below).
3. The hold stays BOUNDED by the existing `review-loop-breaker`, a LOGICAL_MOVE
   with a `VISIT_COUNT` guard of `maxVisits: 10` naming workstation `review`.

### Why this case proves the fix

btrc-p5b (#2042) died on head `d6fd68c336cde581405b95137f941677e6740f1a` from
three review rejections against that one UNCHANGED head (11:26:56Z, 11:42:55Z,
and a third shortly after) with no push between them. Task token
`batch-operator-p5b-token-restore-20260817-btrc-p5b-http-mcp-acp-cutover` went to
failed/FAILED and review token `work-review-206` to fin/FAILED; a hand-written
operator restoration was required.

The damning detail: that third rejection comment says in its own words that it is
a "repeat review on unchanged head" and that it "does not add new blockers". So
PR #1898's Step 4.2 convergence rule DETECTED the no-op correctly, said so, and
then still emitted a FAILING verdict that counted as a strike.

**Detection already existed; only the ROUTING was wrong.** This PR does not try to
detect convergence better — it gives the already-detected no-op a non-failing
route. p5b was two coverage statements from green with Backend Lint fully passing
when it died, which is the shape of the defect: it kills healthy lanes at the very
end, when the head naturally stops moving because the remaining work is small.

### Token semantics after this change

| Marker | Meaning | Routes to |
| --- | --- | --- |
| COMPLETE | PR complete, approved, merged | `task:to-complete`, `review:complete` |
| CONTINUE | HOLD: CI non-terminal after the bounded watcher, or unchanged head with no new findings. Posts no PR comment. | `task:in-review`, `review:init` |
| REJECTED | Concrete executor rework the executor does not already have | `task:init` |

A hold produces no failed worker-session outcome and does not increment the
review transition's consecutive-failure tally, because only FAILED outcomes
append to failure history.

### Preserved

The `process` workstation is untouched. The circuit-breaker threshold, merge
ownership, the 45-minute single bounded CI watcher, the Step 4.2 convergence rule,
the third-pass merge bar, blocking-review rules, and the acceptance-criteria check
are all intact. Rejection still routes only `task:init`; failure still routes
`task:failed` + `review:fin`; success outputs are unchanged.

### Verification (no daemon restart)

These files are not hot-reloaded and a restart would wipe in-memory board state,
so every criterion is proven by routing/mapping behavior and config validation:

- `pkg/services/factory_runtime/.../definitionmapping/maptests/config_mapper_test.go`
  — continue arcs map to the review inputs; rejection/failure/success arcs unchanged.
- `pkg/services/factory_runtime/.../subsystems/subsystem_history_test.go` — a
  CONTINUE outcome leaves the consecutive-failure tally unmoved.
- `pkg/services/factory_definitions/internal/services/validation/impl/topology_guards_test.go`
  — topology validation accepts the review self-owned continue route and fails if
  the visit bound goes absent or above 10.
- `you factory config validate factory/factory.json` passes with the positional argument.
- Gates run in the required order before the final push: `make vet`,
  `make pkg-boundary`, `make pkg-file-count` — all green.

### Non-blocking follow-up for the operator to file separately

While tracing the routing contract I found an adjacent pre-existing defect that is
OUT OF SCOPE here but worth a work item. The live outcome decision is
`evaluateAgentOutcome`
(`pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner.go:304-312`),
which uses a plain `strings.Contains` over the whole response. The stricter
"stop token must be the final non-empty line" rule in `workers.ContainsStopToken`
(`pkg/services/workers/failure.go:326-341`) — which has its own test asserting
that continue wins — is only reachable via `normalizeProviderOverrideResult`,
i.e. behind a non-nil provider override that only functional-test harnesses set.
So the two disagree in production: a response whose final line is the CONTINUE
marker but which mentions the COMPLETE marker in prose resolves to Accepted, not
Continue.

I did not change that here because it is outside the three-part scope and would
alter outcome handling for every AGENT_RUN workstation, not just review. It is
mitigated prompt-side in this PR: the instructions now tell review to emit exactly
one marker alone on the final line, and to paraphrase markers by name when quoting
a PRD criterion or diff that contains one.

> **Reviewer note:** this PR is itself about routing markers, and the PRD criteria
> below contain them as literals. Please paraphrase them by name in your
> acceptance-criteria checklist rather than pasting the literal tokens, or an
> intended hold will be read as approval-and-merge.

## PRD

```json
{
  "AAAA00_THE_ONLY_CURRENT_OVERRIDE": "OPERATOR OVERRIDE v1 -- ADDITIONAL MEASURED EVIDENCE. Your scope is UNCHANGED;\nthis only strengthens the problem statement and adds one fact you should cite.\n\nA THIRD lane has now been killed by the defect you are fixing, and it is the most\ndamning case yet because it happened WITH the convergence rule already in place.\n\nbtrc-p5b (PR #2042) died at 2026-08-17 on head\nd6fd68c336cde581405b95137f941677e6740f1a. Three review rejections against that\none UNCHANGED head -- 11:26:56Z, 11:42:55Z and a third shortly after -- with no\npush in between. Board result: task token\nbatch-operator-p5b-token-restore-20260817-btrc-p5b-http-mcp-acp-cutover ->\nfailed/FAILED and its review token work-review-206 -> fin/FAILED. It required a\nhand-written operator restoration.\n\nWHY THIS CASE MATTERS MORE THAN p5c AND p5a. The third rejection comment says, in\nits own words, that it is a \"repeat review on unchanged head\" and that \"this\ncomment confirms the existing blocker set; it does not add new blockers.\"\n\nSo PR #1898's Step 4.2 convergence rule WORKED. Review correctly detected that it\nwas re-reading an unchanged head, correctly determined it had nothing new to say,\ncorrectly said so in the comment -- and then still emitted a FAILING verdict that\ncounted as a circuit-breaker strike and killed the lane.\n\nThat is the cleanest possible statement of the defect: **detection already exists;\nonly the ROUTING is wrong.** A review pass that has itself concluded \"no new\nfindings, unchanged head\" is definitionally a HOLD, not a rejection, and there is\ncurrently no token that expresses it. Please cite this case in your PR\ndescription, because it proves the fix is not \"detect convergence better\" -- it is\n\"give the detected no-op a non-failing route.\"\n\nNote also that p5b was two coverage statements from green when it died, with\nBackend Lint passing its full ratchet. The defect kills healthy lanes at the very\nend, when the head naturally stops moving because the remaining work is small.\n\nNOTHING ELSE CHANGES. Same three-part solution: (1) add `behavior: REPEATER` plus\nan `onContinue` route to the `review` workstation in factory/factory.json,\ntargeting review's own inputs (task in-review, review init); (2) split the prompt\ntokens in factory/workstations/review/AGENTS.md so `<CONTINUE>` means HOLD,\n`<REJECTED>` means genuine rework and `<COMPLETE>` is unchanged; (3) keep the hold\nBOUNDED with an explicit maxVisits on the review transition. Same non-goals: do\nnot touch the `process` workstation, do not change the circuit-breaker threshold,\ndo not change who owns merging, do not weaken any rule, do not restart the daemon.\n\nAcceptance must remain provable WITHOUT a daemon restart -- prompts and\nfactory.json are not hot-reloaded and a restart wipes all in-memory board state.\nProve it with routing/mapping tests and config validation, and word every\ncriterion that way.\n\nDELIVERY: your finish line as the processor is a rebased final head PUSHED with\nthe PR open and CI started. MERGED is owned by the review stage, not by you. Do\nnot babysit CI in a polling loop and never commit CI evidence. Open the PR early\nso progress survives a visit-cap reset.\n",
  "project": "Give Review a Non-Failing Hold Route",
  "branchName": "thr-review-hold-route-is-counted-as-a-failure",
  "description": "Add a bounded review-owned hold outcome so waiting for non-terminal CI or finding nothing new on an unchanged pull-request head re-enters review without a failed worker session, a consecutive-failure strike, or an unnecessary processor visit. Configure review as a repeater with a self-owned continue route, document <CONTINUE> for hold while preserving <REJECTED> for concrete rework and <COMPLETE> for merged work, and prove the changed and preserved behavior through focused validation and definition-mapping tests without restarting the live factory.",
  "context": {
    "customerAsk": "Give the review workstation a non-failing, bounded hold route that mirrors the generic repeater capability already used by process, and distinguish review completion, hold, and genuine rejection with <COMPLETE>, <CONTINUE>, and <REJECTED> respectively. Keep the lane limited to the review workstation entry, its instructions, and focused routing/validation tests.",
    "problem": "Review sometimes must wait for required CI or revisit an unchanged head with no new findings, but its current configuration has no continue route and its instructions emit <REJECTED> for those wait-only states. Rejection sends work back to an idle processor, while failure sends task to failed and review to fin and counts toward the three-consecutive-failure circuit breaker. PRs #2040 and #2041 demonstrate repeated unchanged-head reviews consuming strikes and, for #2041, killing a healthy lane.",
    "solution": "Configure review as a REPEATER whose onContinue route restores task to in-review and review to init, with an explicit visit cap no greater than 10. Update the review instructions so <CONTINUE> silently holds for non-terminal CI or an unchanged head with no new findings, <REJECTED> remains concrete executor rework, and <COMPLETE> remains merged completion. Extend focused routing/mapping and topology-validation coverage for continue, rejection, failure, validation, and bounded visits; do not restart the daemon because these files are not hot-reloaded and restart would erase in-memory board state."
  },
  "acceptanceCriteria": [
    "A review <CONTINUE> outcome routes task back to in-review and review back to init, produces no failed worker-session outcome, and does not increment the review transition's consecutive-failure tally; focused routing/mapping behavior proves this rather than merely inspecting JSON.",
    "A review <REJECTED> outcome still routes only the task to task:init, and a review failure still routes to task:failed plus review:fin; completion behavior remains unchanged.",
    "Review has repeater behavior and an explicit visit-count bound no greater than 10, and focused validation/mapping coverage proves the continue topology is accepted and the bound is present.",
    "you factory config validate factory/factory.json succeeds with the positional configuration argument, and structural/topology validation accepts review's self-owned continue route.",
    "The review instructions define <COMPLETE> for a merged PR, <CONTINUE> for non-terminal CI or an unchanged head with no new findings, and <REJECTED> only for concrete executor rework; a hold posts no PR comment, and no remaining instruction tells review to use <REJECTED> for a pending-CI wait.",
    "Quality gate: focused validation and definition-mapping tests, typecheck, and applicable tests pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Before the final push, make vet, make pkg-boundary, and make pkg-file-count run in that order.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "thr-review-hold-route-is-counted-as-a-failure-001",
      "title": "Route review holds without failure",
      "description": "As an operator, I want a wait-only review outcome to re-enter review without a failure strike so slow CI or an unchanged head cannot kill an otherwise healthy lane.",
      "acceptanceCriteria": [
        "<CONTINUE> returns task to in-review and review to init, and does not route either input through rejection or failure outputs.",
        "Routing/mapping behavior shows that <CONTINUE> produces no failed worker-session outcome and does not increment the review transition's consecutive-failure tally.",
        "<REJECTED> still sends only task to init; failure still sends task to failed and review to fin; success outputs are unchanged.",
        "Review is a repeater and its continue route is accepted by structural/topology validation.",
        "Review repeats are protected by an explicit visit-count cap no greater than 10, and focused test evidence fails if the bound becomes absent or unbounded.",
        "you factory config validate factory/factory.json passes using the positional argument.",
        "The process workstation and its behavior, routes, and instructions remain unchanged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Configured review as a bounded repeater with self-owned continue routing; added mapper, topology-validation, and history assertions; focused Go suites and positional factory validation pass."
    },
    {
      "id": "thr-review-hold-route-is-counted-as-a-failure-002",
      "title": "Classify review completion, hold, and rework distinctly",
      "description": "As a reviewer, I want one unambiguous routing token for each review outcome so I can wait silently, request real rework, or finish the lane without misclassifying its health.",
      "acceptanceCriteria": [
        "The review instructions use <COMPLETE> only when the PR is complete, approved, and merged.",
        "When required CI remains non-terminal after the existing bounded watcher, review ends with <CONTINUE> and posts no PR comment solely to report the wait.",
        "When an unchanged head has no new independent findings, review ends with <CONTINUE> and posts no new PR comment.",
        "<REJECTED> is reserved for concrete executor work and continues to route rework to the processor.",
        "No instruction forbids <CONTINUE> or tells review to emit <REJECTED> merely because CI is pending or a repeat review has no new findings.",
        "Existing bounded-CI-watch limits, repeat-review convergence rules, the third-pass merge bar, blocking-review rules, acceptance-criteria checks, and review ownership of merge remain intact.",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Split the review routing tokens in factory/workstations/review/AGENTS.md: <COMPLETE> merged-only, <CONTINUE> a silent bounded hold for non-terminal CI or an unchanged head with no new findings, <REJECTED> only for concrete executor rework not already handed over. Removed the sentence forbidding <CONTINUE> and both instructions that routed a wait through rejection. Bounded-watch limits, convergence rule, third-pass merge bar, blocking rules, acceptance-criteria checks, and merge ownership left intact; positional factory validation and focused Go suites pass."
    }
  ]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
