### PR TITLE
BTRC P7: behavior matrix, terminal-response and Work closure, activation/dispatch/replay races, and deletion-register closure

### DIFF
--- a/cmd/factory/main_lifecycle_test.go
+++ b/cmd/factory/main_lifecycle_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// entrypointOutcome is what a customer observes from one `you` invocation.
+type entrypointOutcome struct {
+	exitCode int
+	stdout   string
+	stderr   string
+}
+
+// runEntrypoint drives the real cmd/factory entrypoint closure end to end.
+//
+// runProcess reads os.Args and the real os.Stdout/os.Stderr handles, so the
+// only way to observe the customer-visible result of the full
+// root.BuildProcess -> Process.Execute -> Process.Close lifecycle is to replace
+// those process globals for the duration of the call. The helper deliberately
+// does not stub root.BuildProcess: the canonical production composition with an
+// empty edges.Edges is the subject under test.
+func runEntrypoint(t *testing.T, args ...string) entrypointOutcome {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	originalArgs, originalStdout, originalStderr := os.Args, os.Stdout, os.Stderr
+	stdout, collectStdout := captureEntrypointStream(t)
+	stderr, collectStderr := captureEntrypointStream(t)
+	restore := func() {
+		os.Args, os.Stdout, os.Stderr = originalArgs, originalStdout, originalStderr
+	}
+	t.Cleanup(restore)
+
+	os.Args = args
+	os.Stdout, os.Stderr = stdout, stderr
+	exitCode := runProcess()
+	restore()
+
+	return entrypointOutcome{
+		exitCode: exitCode,
+		stdout:   collectStdout(),
+		stderr:   collectStderr(),
+	}
+}
+
+// captureEntrypointStream returns a pipe writer to install as a process stream
+// and a collector that closes the writer and returns everything written to it.
+// The reader is drained concurrently so a command that outsizes the pipe buffer
+// cannot deadlock the entrypoint under test.
+func captureEntrypointStream(t *testing.T) (*os.File, func() string) {
+	t.Helper()
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("open entrypoint stream pipe: %v", err)
+	}
+	var collected bytes.Buffer
+	var drained sync.WaitGroup
+	drained.Go(func() {
+		_, _ = io.Copy(&collected, reader)
+	})
+	return writer, func() string {
+		_ = writer.Close()
+		drained.Wait()
+		_ = reader.Close()
+		return collected.String()
+	}
+}
+
+// TestRunProcessCompletesCanonicalLifecycleAndMapsExitCode is the caller-level
+// guard for cmd/factory/main.go:runProcess. Every other entrypoint test either
+// replaces runProcess outright or calls processExitCode as a pure function, so
+// the composed lifecycle -- build the canonical process, execute the selected
+// command against the real process streams, close the process, join the close
+// result into the command result, and map that to an exit code -- had no direct
+// assertion before this test.
+//
+// The successful cases carry the close-error join: runProcess computes
+// errors.Join(executeErr, process.Close(closeCtx)) before mapping to an exit
+// code, so a lifecycle owner that failed to close would surface here as exit 1
+// even though the command itself succeeded.
+func TestRunProcessCompletesCanonicalLifecycleAndMapsExitCode(t *testing.T) {
+	t.Run("help succeeds and closes cleanly", func(t *testing.T) {
+		outcome := runEntrypoint(t, "you", "--help")
+
+		if outcome.exitCode != exitSuccess {
+			t.Fatalf(
+				"runProcess(you --help) exit = %d, want %d; a non-nil Close joined into the command result would land here\nstdout:\n%s\nstderr:\n%s",
+				outcome.exitCode,
+				exitSuccess,
+				outcome.stdout,
+				outcome.stderr,
+			)
+		}
+		if !strings.Contains(outcome.stdout, "Run and manage CPN-based workflow factories") {
+			t.Fatalf("runProcess(you --help) stdout = %q, want the customer root help banner", outcome.stdout)
+		}
+	})
+
+	t.Run("command output reaches the process stdout", func(t *testing.T) {
+		outcome := runEntrypoint(t, "you", "docs", "agents")
+
+		if outcome.exitCode != exitSuccess {
+			t.Fatalf(
+				"runProcess(you docs agents) exit = %d, want %d\nstdout:\n%s\nstderr:\n%s",
+				outcome.exitCode,
+				exitSuccess,
+				outcome.stdout,
+				outcome.stderr,
+			)
+		}
+		if !strings.Contains(outcome.stdout, "# Agents") {
+			t.Fatalf("runProcess(you docs agents) stdout = %q, want the packaged agents topic", outcome.stdout)
+		}
+	})
+
+	t.Run("unknown command fails without inventing success", func(t *testing.T) {
+		outcome := runEntrypoint(t, "you", "definitely-not-a-command")
+
+		if outcome.exitCode != exitFailure {
+			t.Fatalf(
+				"runProcess(you definitely-not-a-command) exit = %d, want %d\nstdout:\n%s\nstderr:\n%s",
+				outcome.exitCode,
+				exitFailure,
+				outcome.stdout,
+				outcome.stderr,
+			)
+		}
+		if strings.Contains(outcome.stdout, "Run and manage CPN-based workflow factories") {
+			t.Fatalf("runProcess(unknown command) printed the success help banner to stdout: %q", outcome.stdout)
+		}
+	})
+}
+
+// TestRunProcessReusesNoStateAcrossSequentialInvocations proves the entrypoint
+// builds and closes one whole process per invocation: a second run after a
+// failed run still reaches a clean success, so nothing the failed lifecycle
+// acquired survives into the next process.
+func TestRunProcessReusesNoStateAcrossSequentialInvocations(t *testing.T) {
+	failed := runEntrypoint(t, "you", "definitely-not-a-command")
+	if failed.exitCode != exitFailure {
+		t.Fatalf("first runProcess exit = %d, want %d", failed.exitCode, exitFailure)
+	}
+
+	succeeded := runEntrypoint(t, "you", "--help")
+	if succeeded.exitCode != exitSuccess {
+		t.Fatalf(
+			"second runProcess exit = %d, want %d after a failed lifecycle\nstderr:\n%s",
+			succeeded.exitCode,
+			exitSuccess,
+			succeeded.stderr,
+		)
+	}
+	if strings.Contains(succeeded.stdout, "definitely-not-a-command") {
+		t.Fatalf("second runProcess stdout leaked the first invocation: %q", succeeded.stdout)
+	}
+}

--- a/docs/internal/packaged-service-structure/btrc-p6-secondary-graph-register.md
+++ b/docs/internal/packaged-service-structure/btrc-p6-secondary-graph-register.md
@@ -14,8 +14,8 @@ not delete it), or **deleted in this packet**. No row is left unaddressed.
 Reconciliation history. The table below was first written against `469c3bbcb`,
 the P6 merge-base. It was rewritten at `6fb128ab3` (#2047, P6-D) when the
 projection-fallback rows closed, and re-verified row by row against the merged
-tree at `fd0e46ab9` (#2049) by BTRC P7-D. Every row now states the tree as
-merged; the three rows that had drifted are corrected in place and listed in
+tree at `75d51e97d` (#2051) by BTRC P7-D. Every row now states the tree as
+merged; the rows that had drifted are corrected in place and listed in
 *P7-D reconciliation* at the end of this document.
 
 Method: symbol audits use word-boundary matches across **all** file types, not
@@ -33,7 +33,7 @@ matches in **code**: retired names survive in plan and register prose under
 | Plan row | Status | Evidence |
 | --- | --- | --- |
 | HTTP application binding and central mapping | **Already deleted** | `pkg/transports/http/application` and `pkg/transports/mapping/composition` were both removed in `d6fd68c33` "refactor(http): retire residual composition forwarding", merged as part of P5B (#2042, `b2ad0f7d6`); `92bff1790` "refactor(http): compose owner adapters in Wire" had already moved routes onto Wire-built owner handlers. `Handler.Bind`, `BindDurableExecution`, and `HTTPBinder` have zero matches repo-wide. |
-| Opened HTTP service bags and Sessions application roles | **Retained with caller** | `RuntimeHTTPServices` has zero matches repo-wide and is already deleted. `factory_sessions/internal/roles` and `factory_sessions/wire/application_graph.go` are **not** residue: `pkg/wire` imports `factory_sessions/wire` (`pkg/wire/wire.go:18`, generated `pkg/wire/wire_gen.go:21`) and binds its runtime-opening contracts (`wire.go:402-404`, `wire_gen.go:1121`). `roles` has ~58 importers across Sessions. Canonical, load-bearing; no deletion. |
+| Opened HTTP service bags and Sessions application roles | **Retained with caller** | `RuntimeHTTPServices` has zero matches repo-wide and is already deleted. `factory_sessions/internal/roles` and `factory_sessions/wire/application_graph.go` are **not** residue: `pkg/wire` imports `factory_sessions/wire` (`pkg/wire/wire.go:18`, generated `pkg/wire/wire_gen.go:21`) and binds its runtime-opening contracts (`wire.go:402-404`, `wire_gen.go:1121`). `roles` is imported by 57 Go files outside its own directory. Canonical, load-bearing; no deletion. |
 | Sessions runtime compatibility | **Already deleted** | `ForRuntime` (word-boundary) and `BindWorkerInvoker` have zero matches repo-wide. Bare `ExecutionService` has no production declaration; the only matches are synthetic checker fixtures in `cmd/ownershipboundarycheck/main_test.go` and `owner_inventory_test.go`. |
 | Runtime legacy owner surface (`APIFactory`) | **Retained with caller** | `factoryruntime.APIFactory` is declared at `pkg/services/factory_runtime/interfaces.go:24`. After the projection-fallback closure in the next row it has 14 non-test production references, not one: the interface embed at `pkg/services/factory_runtime/internal/host/engine.go:17`, the two declared ingress fields (`factory_runtime/runtime_activation_contract.go:257`, `factory_sessions/types.go:51`), the Runtime root's stored activation ingress (`factory_runtime/internal/root.go:53,558,575,617`), the Sessions resolvers (`runtimeopening/runtime_activation.go:75`, `sessionservice/work_runtime_adapter.go:26`, `runtimebinding/binding.go:361,362,373,384`), and the Work resolver (`work/internal/live_session_runtime.go:36`). It retires once Work admission owns submission and Recordings owns canonical event reads; see the closing paragraphs of the projection-fallback section below. |
 | Cross-owner projection fallbacks | **Deleted in this packet** | Both plan-named sites are migrated: `factory_visualization/internal/service/runtime_source.go` and `work/internal/live_session_runtime.go` now read the declared `LiveRuntime.WorkAndEventIngress` capability instead of asserting one out of `runtime.Factory`. The sweep covered every sibling on the same carrier, not just the two named files; see the root-cause section below. |
@@ -207,6 +207,15 @@ the drift is recorded rather than absorbed. `make pkg-boundary`,
 `make pkg-structure`, `make pkg-file-count`, `make pkg-maint`,
 `make backend-size`, and `make vet` all pass at this packet's head.
 
+**Superseded on main.** The two numbers above are historical. `75d51e97d`
+(#2051) has since dropped 56 phantom baseline entries naming deleted files and
+removed 58 unreachable test helpers, so at the P7-D reconciliation base the
+same command reports **baseline 257, current 487** — still drift, but roughly
+half the gap this section recorded. That commit deliberately excluded
+`tests/functional/**` because this lane was in flight there. P7-D's own diff is
+test files and these two documents, and `make deadcode` reports the identical
+487 at this branch's head, so the packet contributes zero findings either way.
+
 No baseline or manifest row required editing for the Workers deletion: only
 functions were removed, no package or file, so every package-keyed baseline
 (`backend-package-file-count.json`, both coverage minimums,
@@ -216,16 +225,28 @@ functions were removed, no package or file, so every package-keyed baseline
 ## P7-D reconciliation against the merged tree
 
 BTRC P7-D re-verified every row above against the tree as merged through
-`fd0e46ab9` (#2049), which includes both P6 merges (`7018644b3` #2046 and
-`6fb128ab3` #2047). Each row's symbol, package, file-line and test-name claim
-was re-run. Three rows had drifted and are corrected in place; the corrections
-are surgical edits to those rows, not a regeneration of the document.
+`75d51e97d` (#2051), which includes both P6 merges (`7018644b3` #2046 and
+`6fb128ab3` #2047) and the three fixes that landed while P7 was in flight
+(`fd0e46ab9` #2049, `217066ad6` #2050, `75d51e97d` #2051). Each row's symbol,
+package, file-line and test-name claim was re-run. Five rows had drifted and
+are corrected in place; the corrections are surgical edits to those rows, not a
+regeneration of the document.
 
 | Corrected row | What it said | What the merged tree shows |
 | --- | --- | --- |
 | Header, *Reconciliation base* | Pinned the whole document to `469c3bbcb` | The body was rewritten at `6fb128ab3` when P6-D closed the projection-fallback rows, so the stated base no longer described the text it headed. Replaced with the reconciliation history above. |
 | `Runtime legacy owner surface (APIFactory)` | "sole non-test production reference is the interface embed at `host/engine.go:17`" | 14 non-test production references. The row was true before the projection-fallback closure in the row beneath it and was left behind when that closure landed, so it contradicted this document's own `APIFactory` paragraph. Enumerated in the corrected row. |
 | `workers/internal.NewInvocationWithProgress` | Caller at `conductor_invocation.go:28` | The call is at `pkg/services/workers/internal/conductor_invocation.go:31`; line 28 is a parameter. Wrong when written, not drift. |
+| `Opened HTTP service bags and Sessions application roles` | "`roles` has ~58 importers" | 57 Go files outside the package's own directory import it. An approximate count cannot be re-verified, so it is now stated exactly. |
+| *Static-gate state* | `deadcode` baseline 342, main 548, packet head 545 | `75d51e97d` (#2051) dropped 56 phantom baseline entries and 58 unreachable test helpers: baseline 257, current 487. Recorded as a *Superseded on main* note rather than by overwriting what P6 measured. |
+
+Re-verification was mechanical, not a re-read: every file-line claim in this
+document was checked by reading that exact line and matching the symbol it is
+supposed to carry. All 14 of them still resolve — including the four in
+`factory_runtime/internal/root.go` (53, 558, 575, 617) and the four in
+`runtimebinding/binding.go` (361, 362, 373, 384) — because `217066ad6` (#2050)
+touched `pkg/platform/process` and the provider adapters, not the composition
+seams this register tracks.
 
 Two wording imprecisions were also corrected rather than left to mislead a
 future audit: rows claiming a symbol has "zero matches repo-wide" are true only
@@ -241,8 +262,10 @@ rows, the retained-with-caller `runtimeEventSubscriber` site at
 reduction clause table, the migrated `LiveRuntime.WorkAndEventIngress` site
 list with its per-file counts, and all six named guard tests, each of which
 resolves to a live `func Test...` at the stated owner. `TODO(P6-C)` still marks
-exactly the three retained bridges the Workers section names, and no `TODO(P7`
-marker exists anywhere in the tree.
+exactly the three retained bridges the Workers section names, and no P7-scoped
+TODO marker exists anywhere in the tree. (This sentence deliberately avoids
+writing that marker literally, so a future audit grep for it does not match this
+document.)
 
 P7-D deletes no package and no file, so no row is removed from
 `backend-package-file-count.json`, either coverage minimum,

--- a/docs/internal/packaged-service-structure/btrc-p6-secondary-graph-register.md
+++ b/docs/internal/packaged-service-structure/btrc-p6-secondary-graph-register.md
@@ -11,8 +11,12 @@ Every row below is classified as **already deleted** (retired by an earlier
 packet), **retained with caller** (a live non-test caller is named, so P6 may
 not delete it), or **deleted in this packet**. No row is left unaddressed.
 
-Reconciliation base: `469c3bbcb`, the merge-base of this branch and
-`origin/main`.
+Reconciliation history. The table below was first written against `469c3bbcb`,
+the P6 merge-base. It was rewritten at `6fb128ab3` (#2047, P6-D) when the
+projection-fallback rows closed, and re-verified row by row against the merged
+tree at `fd0e46ab9` (#2049) by BTRC P7-D. Every row now states the tree as
+merged; the three rows that had drifted are corrected in place and listed in
+*P7-D reconciliation* at the end of this document.
 
 Method: symbol audits use word-boundary matches across **all** file types, not
 just `.go`. Substring matching produces false positives on this tree —
@@ -20,7 +24,9 @@ just `.go`. Substring matching produces false positives on this tree —
 matches the canonical, unrelated `DurableExecutionService`,
 `OwnedExecutionService`, and `TargetExecutionService`. Package rows use
 import-path audits and distinguish importers inside the package's own directory
-from external ones.
+from external ones. A row that says a symbol has "zero matches" means zero
+matches in **code**: retired names survive in plan and register prose under
+`docs/**`, and those prose matches are never evidence that a symbol is live.
 
 ## P6 candidate-residue reconciliation
 
@@ -29,9 +35,9 @@ from external ones.
 | HTTP application binding and central mapping | **Already deleted** | `pkg/transports/http/application` and `pkg/transports/mapping/composition` were both removed in `d6fd68c33` "refactor(http): retire residual composition forwarding", merged as part of P5B (#2042, `b2ad0f7d6`); `92bff1790` "refactor(http): compose owner adapters in Wire" had already moved routes onto Wire-built owner handlers. `Handler.Bind`, `BindDurableExecution`, and `HTTPBinder` have zero matches repo-wide. |
 | Opened HTTP service bags and Sessions application roles | **Retained with caller** | `RuntimeHTTPServices` has zero matches repo-wide and is already deleted. `factory_sessions/internal/roles` and `factory_sessions/wire/application_graph.go` are **not** residue: `pkg/wire` imports `factory_sessions/wire` (`pkg/wire/wire.go:18`, generated `pkg/wire/wire_gen.go:21`) and binds its runtime-opening contracts (`wire.go:402-404`, `wire_gen.go:1121`). `roles` has ~58 importers across Sessions. Canonical, load-bearing; no deletion. |
 | Sessions runtime compatibility | **Already deleted** | `ForRuntime` (word-boundary) and `BindWorkerInvoker` have zero matches repo-wide. Bare `ExecutionService` has no production declaration; the only matches are synthetic checker fixtures in `cmd/ownershipboundarycheck/main_test.go` and `owner_inventory_test.go`. |
-| Runtime legacy owner surface (`APIFactory`) | **Retained with caller** | `factoryruntime.APIFactory` is declared at `pkg/services/factory_runtime/interfaces.go:24`. Its sole non-test production reference is the interface embed at `pkg/services/factory_runtime/internal/host/engine.go:17`. Its two methods are still reached by the projection fallbacks in the next row, so it is retained until those callers move. |
+| Runtime legacy owner surface (`APIFactory`) | **Retained with caller** | `factoryruntime.APIFactory` is declared at `pkg/services/factory_runtime/interfaces.go:24`. After the projection-fallback closure in the next row it has 14 non-test production references, not one: the interface embed at `pkg/services/factory_runtime/internal/host/engine.go:17`, the two declared ingress fields (`factory_runtime/runtime_activation_contract.go:257`, `factory_sessions/types.go:51`), the Runtime root's stored activation ingress (`factory_runtime/internal/root.go:53,558,575,617`), the Sessions resolvers (`runtimeopening/runtime_activation.go:75`, `sessionservice/work_runtime_adapter.go:26`, `runtimebinding/binding.go:361,362,373,384`), and the Work resolver (`work/internal/live_session_runtime.go:36`). It retires once Work admission owns submission and Recordings owns canonical event reads; see the closing paragraphs of the projection-fallback section below. |
 | Cross-owner projection fallbacks | **Deleted in this packet** | Both plan-named sites are migrated: `factory_visualization/internal/service/runtime_source.go` and `work/internal/live_session_runtime.go` now read the declared `LiveRuntime.WorkAndEventIngress` capability instead of asserting one out of `runtime.Factory`. The sweep covered every sibling on the same carrier, not just the two named files; see the root-cause section below. |
-| Workers persistent execution graph | **Already deleted**, plus one row **deleted in this packet** and one **retained with caller** | `pkg/services/workers/internal/services/runtime_assembly` does not exist. `BuildRuntime`, `BuildRuntimeExecutors`, and `AssembledRuntimeBinding` match **only** in three `docs/**/*.md` plan files and have zero Go references. `WorkstationPool` has zero matches repo-wide. What remained was the provider-backed direct-invocation constructor family; see the Workers section below. |
+| Workers persistent execution graph | **Already deleted**, plus one row **deleted in this packet** and one **retained with caller** | `pkg/services/workers/internal/services/runtime_assembly` does not exist. `BuildRuntime`, `BuildRuntimeExecutors`, and `AssembledRuntimeBinding` have zero Go references and survive only in `docs/**/*.md` prose — three plan files each, plus `docs/internal/projects/worker-session-convergence/README.md:78,81` for `BuildRuntime`. `WorkstationPool` has zero matches repo-wide. What remained was the provider-backed direct-invocation constructor family; see the Workers section below. |
 
 ## Sessions runtime-opening family is canonical, not a second graph
 
@@ -170,7 +176,7 @@ provider-backed direct-invocation constructor family:
 | `workers/wire.NewInvocationWithProgress` | **Deleted in this packet** | Zero callers. |
 | `workers/internal.NewInvocation` | **Deleted in this packet** | Its only caller was the `workers/wire` wrapper above. |
 | `NewConductorInvocationWithProgress` | **Retained with caller** | One production caller: `pkg/wire/session_runtime_providers.go:1072`. Successor: `workers.Service.Execute`. |
-| `workers/internal.NewInvocationWithProgress` | **Retained with caller** | Reached from `NewConductorInvocationWithProgress` (`conductor_invocation.go:28`). |
+| `workers/internal.NewInvocationWithProgress` | **Retained with caller** | Declared at `workers/internal/invocation.go:23`; reached from `NewConductorInvocationWithProgress` (`workers/internal/conductor_invocation.go:31`). |
 
 The retained rows are held deliberately. The plan states that P6 "is not
 permission to delete a compatibility method whose caller has not moved," and
@@ -179,7 +185,11 @@ retirement slice." The `TODO(P6-C)` markers were therefore rescoped to name
 that exact caller and `workers.Service.Execute` as the successor boundary,
 rather than removed outright.
 
-## Static-gate state at the reconciliation base
+## Static-gate state at the P6 reconciliation base
+
+The measurements below are pinned to the P6 merge-base and are retained as the
+record of what P6 observed. They are not re-derived here; P7-D changed no
+production file, so it cannot move them.
 
 `make deadcode` is **already failing on `origin/main`** and is not caused by
 this packet. Measured in a disposable detached worktree at the merge-base:
@@ -202,3 +212,43 @@ functions were removed, no package or file, so every package-keyed baseline
 (`backend-package-file-count.json`, both coverage minimums,
 `ownership-inventory.json`, `package-target-manifest.json`,
 `backend-exemption-budget.json`) stays valid and entry-complete.
+
+## P7-D reconciliation against the merged tree
+
+BTRC P7-D re-verified every row above against the tree as merged through
+`fd0e46ab9` (#2049), which includes both P6 merges (`7018644b3` #2046 and
+`6fb128ab3` #2047). Each row's symbol, package, file-line and test-name claim
+was re-run. Three rows had drifted and are corrected in place; the corrections
+are surgical edits to those rows, not a regeneration of the document.
+
+| Corrected row | What it said | What the merged tree shows |
+| --- | --- | --- |
+| Header, *Reconciliation base* | Pinned the whole document to `469c3bbcb` | The body was rewritten at `6fb128ab3` when P6-D closed the projection-fallback rows, so the stated base no longer described the text it headed. Replaced with the reconciliation history above. |
+| `Runtime legacy owner surface (APIFactory)` | "sole non-test production reference is the interface embed at `host/engine.go:17`" | 14 non-test production references. The row was true before the projection-fallback closure in the row beneath it and was left behind when that closure landed, so it contradicted this document's own `APIFactory` paragraph. Enumerated in the corrected row. |
+| `workers/internal.NewInvocationWithProgress` | Caller at `conductor_invocation.go:28` | The call is at `pkg/services/workers/internal/conductor_invocation.go:31`; line 28 is a parameter. Wrong when written, not drift. |
+
+Two wording imprecisions were also corrected rather than left to mislead a
+future audit: rows claiming a symbol has "zero matches repo-wide" are true only
+for code (retired names persist in plan prose under `docs/**`), and
+`BuildRuntime` appears in a fourth markdown file
+(`docs/internal/projects/worker-session-convergence/README.md`).
+
+Everything else holds exactly as written, including the four `Already deleted`
+rows, the retained-with-caller `runtimeEventSubscriber` site at
+`pkg/transports/mapping/runtime_api.go:45` with its caller at
+`pkg/wire/profiles.go:896`, the Sessions runtime-opening package table
+(25/3/9/4 Go files with the named external importers), the runtime-opening
+reduction clause table, the migrated `LiveRuntime.WorkAndEventIngress` site
+list with its per-file counts, and all six named guard tests, each of which
+resolves to a live `func Test...` at the stated owner. `TODO(P6-C)` still marks
+exactly the three retained bridges the Workers section names, and no `TODO(P7`
+marker exists anywhere in the tree.
+
+P7-D deletes no package and no file, so no row is removed from
+`backend-package-file-count.json`, either coverage minimum,
+`ownership-inventory.json`, `package-target-manifest.json`, or
+`backend-exemption-budget.json`, and every coverage manifest stays sorted and
+entry-complete. There is no remaining stale test-only adapter or scaffolding
+from P7-A, P7-B or P7-C: none of those slices introduced a shadow fixture,
+dual-path probe or temporary race harness, and each landed its guards directly
+on the canonical path. This register has zero stale rows as of this slice.

--- a/docs/internal/packaged-service-structure/btrc-p7-behavior-matrix.md
+++ b/docs/internal/packaged-service-structure/btrc-p7-behavior-matrix.md
@@ -1,0 +1,202 @@
+# BTRC P7 public behavior matrix
+
+This is the frozen P7-A baseline required by the P7 "Build first" step in
+`docs/internal/packaged-service-structure/build-time-runtime-composition-plan.md`:
+
+> Freeze a behavior matrix keyed by customer operation and observable outcome:
+> activation, Work admission, direct/child dispatch, terminal result, response
+> stream, replay, cancellation, and cleanup. Record the existing assertion and
+> the owning package for every cell.
+
+It exists because P7 is a proof packet, not a seam replacement. Later P7 slices
+strengthen assertions; they need a written record of what was already asserted,
+by whom, and where the tree had no direct guard at all, so a "strengthened"
+assertion can be distinguished from a newly invented one.
+
+**This document is not an acceptance test.** No P7 slice may cite this file, or
+any scan of it, in place of a behavioral assertion. Every row points at a Go
+test that runs a real operation.
+
+## Method
+
+- The caller set is the plan's P7 caller-by-caller migration table (seven
+  rows). Each caller gets one section below; each section's rows are that
+  caller's observable scenarios from the same table.
+- A cell records the **existing assertion** (`path:TestName`) and the **owning
+  package** that must keep it passing.
+- Guards are located by word-boundary search for `func <TestName>` across
+  `*_test.go`. A plan-named guard that is absent, or that lives at a different
+  path than the plan states, is recorded in *Reconciliation findings* rather
+  than silently substituted.
+- Reconciliation base: `7018644b3`, the merge-base of this branch and
+  `origin/main` (BTRC P6, #2046).
+
+## Status vocabulary
+
+| Status | Meaning |
+| --- | --- |
+| **Guarded** | A direct guard exists in the tree and runs a real operation. |
+| **Closed by P7-A** | The cell had no direct guard at the named boundary; this slice added one. |
+| **P7-B / P7-C / P7-D** | The cell is deliberately deferred to a later, authored P7 slice. |
+
+## 1. `cmd/factory/main.go:runProcess` and `root.BuildProcess`
+
+Canonical path: `Process.Execute` plus the Initializer lifecycle.
+
+| Operation | Observable outcome | Existing assertion | Owning package | Status |
+| --- | --- | --- | --- | --- |
+| Activation | One inert graph is built per invocation and reused across isolated executions | `pkg/root/root_test.go:TestBuildProcessReusesCanonicalRootsAcrossTwoIsolatedExecutions`, `tests/functional/sessions/root_composition/process_reuse_inert_test.go:TestRootBuildProcessIsInertAndReusableAcrossFactorySessions` | `pkg/root`, `pkg/wire` | Guarded |
+| Activation failure | Construction failure starts no external lifecycle | `pkg/root/root_test.go:TestBuildProcessConstructionFailureDoesNotStartExternalLifecycle` | `pkg/root` | Guarded |
+| Invocation success | Command output reaches the customer's own stdout | `pkg/root/root_test.go:TestProcessRoutesHelpAndExplicitCommandsToSuppliedStreams` | `pkg/initializer/application` | Guarded |
+| Invocation success | The **entrypoint** returns exit 0 and prints to the real process stdout | `cmd/factory/main_lifecycle_test.go:TestRunProcessCompletesCanonicalLifecycleAndMapsExitCode` | `cmd/factory` | **Closed by P7-A** |
+| Domain failure | Argument and domain failures return a diagnostic, never success | `pkg/root/root_test.go:TestProcessInvalidArgumentsReturnsDiagnostic`, `cmd/factory/main_lifecycle_test.go:TestRunProcessCompletesCanonicalLifecycleAndMapsExitCode` | `pkg/root`, `cmd/factory` | **Closed by P7-A** |
+| Cancellation | A declared cancel exit code is selected per command path; an ordinary failure wins over a canceled process context | `cmd/factory/main_test.go:TestProcessExitCodePreservesDeclaredLifecycleContract` | `cmd/factory` | Guarded |
+| Cleanup | `Close` is deterministic and idempotent on a built process | `pkg/root/events_lifecycle_composition_test.go:TestBuildProcessClosesDeterministicallyAndIdempotently` | `pkg/root`, `pkg/wire` | Guarded |
+| Cleanup / close-error joining | After a **failed command**, `Close` still succeeds, so `errors.Join` carries exactly the command failure and never a cancellation classification | `tests/functional/sessions/root_composition/process_lifecycle_close_test.go:TestRootProcessCloseAfterFailedCommandPreservesTheCommandFailure`, `...:TestRootProcessCloseAfterSuccessfulCommandReportsNoFailure` | `pkg/root`, `pkg/initializer/lifecycle` | **Closed by P7-A** |
+| Cleanup unwind | Start failure unwinds acquired roles once, joins cleanup errors, and close continues through every owner | `pkg/initializer/lifecycle/manager_test.go:TestManagerUnwindsStartFailureAndJoinsCleanupErrors`, `pkg/wire/session_runtime_providers_test.go:TestProcessCloseContinuesThroughEveryLifecycleOwnerAfterFailure` | `pkg/initializer/lifecycle`, `pkg/wire` | Guarded |
+| Activation failure | An already-opened Runtime is closed when the Visualization sink cannot be resolved | `tests/functional/sessions/root_composition/application_opening_failure_test.go:TestApplicationOpeningClosesRuntimeWhenVisualizationSinkIsUnavailable` | `pkg/services/factory_sessions` | Guarded |
+
+## 2. HTTP generated server and SSE response-event routes
+
+Canonical path: Wire-built owner handlers, Sessions ephemeral response events,
+Recordings canonical reads.
+
+| Operation | Observable outcome | Existing assertion | Owning package | Status |
+| --- | --- | --- | --- | --- |
+| Content negotiation | Documented request/response content types; 415 on an unsupported type | `tests/functional/transport/http/server/content_negotiation_test.go:TestAPIJSONRequestsAndResponsesUseDocumentedContentType`, `...:TestAPIUnsupportedContentTypeReturns415` | `pkg/transports/http` | Guarded |
+| Malformed input | Malformed JSON returns a structured 400; unknown route returns structured 404; wrong method returns the documented method error | `tests/functional/transport/http/server/content_negotiation_test.go:TestAPIMalformedJSONReturnsStructured400`, `tests/functional/transport/http/server/routing_test.go:TestAPIUnknownRouteReturnsStructuredNotFound`, `...:TestAPIWrongMethodReturnsDocumentedMethodError` | `pkg/transports/http` | Guarded |
+| Concurrent requests | Concurrent sessions stay isolated; a canceled request does not cancel an unrelated session | `tests/functional/transport/http/server/concurrent_requests_test.go:TestAPIConcurrentSessionRequestsRemainIsolated`, `...:TestAPICancelledRequestDoesNotCancelUnrelatedSession` | `pkg/transports/http`, `pkg/services/factory_sessions` | Guarded |
+| Terminal envelope | The response-event payload union covers every documented variant | `pkg/transports/http/contracttests/openapi_contract_response_events_test.go:TestOpenAPIContract_FactoryResponseEventPayloadUnionCoversAllVariants` | `pkg/transports/http` | Guarded |
+| Response stream | Retained-then-live SSE ordering; documented stream close boundary | `tests/functional/events/response_events/stream_test.go:TestAPIResponseEventSSEStreamsRetainedThenLiveEvents`, `...:TestAPIResponseEventStreamClosesAtDocumentedBoundary` | `pkg/services/factory_sessions` | Guarded |
+| Reconnect gap | A cursor gap emits the typed stream-gap record; an expired session returns typed Gone | `tests/functional/events/response_events/stream_test.go:TestAPIResponseEventCursorGapEmitsStreamGap`, `...:TestAPIResponseEventSessionExpiryReturnsTypedGone` | `pkg/services/factory_sessions` | Guarded |
+| Active-stream close | Server shutdown closes the listener and every active stream; bind failure unwinds started lifecycle roles | `tests/functional/transport/http/server/startup_shutdown_test.go:TestAPIServerShutdownClosesListenerAndActiveStreams`, `...:TestAPIServerBindFailureUnwindsStartedLifecycleRoles` | `pkg/transports/http`, `pkg/initializer` | Guarded |
+| Terminal result | Response-event stream read to a terminal run outcome | `tests/functional/events/response_events/terminal_outcomes_test.go:TestReadResponseEventStreamUntilTerminalRunOutcomes` | `pkg/services/factory_sessions` | Guarded |
+| Work admission | Work admission and response stream activate after runtime lifecycle through `root.BuildProcess` | `tests/functional/sessions/root_composition/work_admission_response_stream_test.go:TestSessionsWorkAdmissionAndResponseStreamActivateThroughRootBuildProcessAfterLifecycle` | `pkg/services/factory_sessions`, `pkg/services/work` | Guarded |
+
+## 3. MCP stdio and service tools
+
+Canonical path: Wire-built raw tool registry and Initializer stdio intent.
+
+| Operation | Observable outcome | Existing assertion | Owning package | Status |
+| --- | --- | --- | --- | --- |
+| Discovery | Initialize plus tool discovery lists the canonical Factory Session tools | `tests/functional/transport/mcp/stdio/discovery_test.go:TestMCPStdioInitializeAndToolDiscovery`, `...:TestMCPDiscoveryContainsCanonicalFactorySessionTools` | `pkg/transports/mcp` | Guarded |
+| Malformed arguments | Malformed parameters return `invalid params`; an unknown tool returns a protocol error | `tests/functional/transport/mcp/protocol/errors_test.go:TestMCPMalformedParametersReturnInvalidParams`, `tests/functional/transport/mcp/stdio/discovery_test.go:TestMCPUnknownToolReturnsProtocolError` | `pkg/transports/mcp` | Guarded |
+| Async / not-ready polling | Async polling observes the terminal result | `pkg/services/factory_sessions/transports/mcp/execution_test.go:TestMockClient_RuntimeService_AsyncPollingObservesTerminalResult` | `pkg/services/factory_sessions` | Guarded |
+| Typed failure | A missing Factory Session returns the canonical not-found | `tests/functional/transport/mcp/protocol/errors_test.go:TestMCPMissingFactorySessionReturnsCanonicalNotFound` | `pkg/transports/mcp` | Guarded |
+| Shutdown | Server shutdown closes stdio cleanly | `tests/functional/transport/mcp/protocol/errors_test.go:TestMCPServerShutdownClosesStdioCleanly` | `pkg/transports/mcp` | Guarded |
+| Activation | Runtime rejects a missing home environment and an invalid project root before composing | `tests/functional/transport/mcp/stdio/discovery_test.go:TestMCPStdioRuntimeRejectsMissingHomeEnvironment`, `...:TestMCPStdioRuntimeRejectsInvalidRuntimeProjectRoot` | `pkg/transports/mcp`, `pkg/initializer` | Guarded |
+
+## 4. ACP stdio, Chat Sessions, and CLI ACP delegation
+
+Canonical path: Chat Sessions conversation/control context, Sessions
+invocation, Providers/Settings configuration, ACP response bridge.
+
+| Operation | Observable outcome | Existing assertion | Owning package | Status |
+| --- | --- | --- | --- | --- |
+| Redelivery idempotency | A redelivered prompt makes no second Factory dispatch | `tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go:TestACPPromptDelegationRedeliveredRequestMakesNoSecondFactoryDispatch` | `pkg/services/chat_sessions` | Guarded |
+| Busy rejection | A concurrent prompt is rejected as busy with no Factory dispatch | `tests/functional/chat_sessions/root_composition/acp_prompt_delegation_test.go:TestACPPromptDelegationConcurrentPromptRejectsAsBusyWithNoFactoryDispatch` | `pkg/services/chat_sessions` | Guarded |
+| Cancellation | Cancel terminalizes only the captured prompt | `tests/functional/transport/acp/stdio/cli_serve_acp_controls_test.go:TestServeACP_RootBuildProcessCancelTerminalizesOnlyCapturedPrompt` | `pkg/transports/acp` | Guarded |
+| Close | Close stops the captured Factory Session | `tests/functional/transport/acp/stdio/cli_serve_acp_controls_test.go:TestServeACP_RootBuildProcessCloseStopsCapturedFactorySession` | `pkg/transports/acp` | Guarded |
+| Child event identity | The worker child stream survives retained replay without crossing streams | `tests/functional/chat_sessions/root_composition/acp_worker_child_events_test.go:TestACPWorkerChildStreamSurvivesRetainedReplay` | `pkg/services/chat_sessions`, `pkg/services/recordings` | Guarded |
+
+## 5. `root.BuildStatelessWorkers` and detached agent-run
+
+Canonical path: `workers.Service.Execute` with injected edges; no Factory
+Runtime and no Factory Session are opened.
+
+| Operation | Observable outcome | Existing assertion | Owning package | Status |
+| --- | --- | --- | --- | --- |
+| Direct execution | A detached script attempt is accepted with its exact output, at the **public** root boundary, and opens no Runtime or Session | `tests/functional/workers/agent/stateless_root_test.go:TestBuildStatelessWorkersExecutesDetachedAttemptThroughRoot` | `pkg/root`, `pkg/services/workers` | **Closed by P7-A** |
+| Cancellation / resource release | A canceled detached attempt terminalizes as `context.Canceled`, never reaches the external command effect, and opens no Runtime or Session | `tests/functional/workers/agent/stateless_root_test.go:TestBuildStatelessWorkersReleasesDetachedAttemptOnCancellation` | `pkg/root`, `pkg/services/workers` | **Closed by P7-A** |
+| Direct execution (owner tier) | The same composition proven from inside `pkg/root`, including prompt-template and model-recording contracts | `pkg/root/root_submit_family_compatibility_test.go:TestBuildStatelessWorkersExecutesDetachedAttemptThroughRoot`, `...:TestBuildStatelessWorkersExecutesProviderAttemptThroughRoot` | `pkg/root` | Guarded |
+| Goal decision envelope | A detached agent run preserves the goal decision envelope | `pkg/services/workers/wire/stateless_execute_agent_test.go:TestNewServiceExecuteDetachedAgentRunPreservesGoalDecisionEnvelope` | `pkg/services/workers` | Guarded |
+| Last provider turn | The last runner turn stays authoritative, including when the harness fails | `pkg/services/workers/internal/services/workstations/executor/agentrun/detached_test.go:TestExecuteDetachedKeepsLastRunnerTurnAuthoritative`, `...:TestExecuteDetachedReturnsLastRunnerTurnWithHarnessError` | `pkg/services/workers` | Guarded |
+| Timeout / typed failure | A deadline reached inside the agent loop leaves `ExecuteDetached` classifiable as an agent-run timeout with the last turn intact | `pkg/services/workers/internal/services/workstations/executor/agentrun/detached_test.go:TestExecuteDetachedTimeoutSurfacesAgentRunTimeoutClass` | `pkg/services/workers` | **Closed by P7-A** |
+| Resource release (production worktree) | A canceled canonical stateless Workers run releases the production worktree | `pkg/wire/session_runtime_providers_test.go:TestCanonicalStatelessWorkersReleasesProductionWorktreeAfterCancellation` | `pkg/wire` | Guarded |
+| Activation ordering | Detached Workers execution happens before Runtime opening | `pkg/wire/session_runtime_providers_test.go:TestBuildStatelessWorkersExecutesBeforeRuntimeOpening` | `pkg/wire` | Guarded |
+
+## 6. Runtime direct/child dispatch and Worker Sessions
+
+Canonical path: Runtime active-attempt contract, Workers `ExecuteResult`,
+Worker Sessions identity.
+
+| Operation | Observable outcome | Existing assertion | Owning package | Status |
+| --- | --- | --- | --- | --- |
+| Direct dispatch | Concurrent accept of a dispatch result resolves exactly once | `pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_idempotency_test.go:TestFactoryImpl_ConcurrentAcceptDispatchResultResolvesExactlyOnce` | `pkg/services/factory_runtime` | Guarded |
+| Direct vs child dispatch | Both preserve an identical terminal-outcome mapping | `pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_terminal_semantics_test.go:TestFactoryImpl_DirectAndChildDispatchPreserveIdenticalTerminalOutcomeMapping` | `pkg/services/factory_runtime` | Guarded |
+| Completion vs acceptance race | Worker-session completion racing explicit acceptance and canonical replay resolves once | *(plan-named guard absent from the tree)* | `pkg/services/factory_runtime` | **P7-C** |
+| Response observation | An observed in-flight response is excluded from the in-flight projection and does not terminate early | `pkg/services/factory_runtime/internal/rootobservation/project_test.go:TestProject_ExcludesObservedDispatchResponseFromInFlightProjection`, `.../terminationtests/termination_test.go:TestTerminationCheck_DoesNotTerminateWhileObservedResponseAwaitsRetirement` | `pkg/services/factory_runtime` | Guarded |
+| Worker Sessions identity | A dispatch is control-addressable before start and records its association before Workers handoff | `pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover_test.go:TestStartThroughWorkerSessions_AssociationIsControlAddressableBeforeStart`, `...:TestFactoryImpl_PlanDispatchRecordsWorkerSessionAssociationBeforeWorkersHandoff` | `pkg/services/factory_runtime`, `pkg/services/worker_sessions` | Guarded |
+| Replay | Historical attempts list chronologically and the terminal stream replays from an atomic snapshot | `pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover_test.go:TestRecordedWorkerSessionObservation_ListsHistoricalAttemptsInChronologicalOrder`, `...:TestRecordedWorkerSessionObservationStreamUsesAtomicSnapshotAndPreservesHistory` | `pkg/services/factory_runtime` | Guarded |
+
+## 7. Work and Recordings public reads
+
+Canonical path: Work owns content policy; Recordings owns
+history/projection/replay.
+
+| Operation | Observable outcome | Existing assertion | Owning package | Status |
+| --- | --- | --- | --- | --- |
+| Replay equivalence | Projection queries are equivalent for retained and replayed canonical facts | `pkg/services/recordings/internal/projection_query_contract_test.go:TestProjectionQueries_AreEquivalentForRetainedAndReplayedCanonicalFacts` | `pkg/services/recordings` | Guarded |
+| Scope isolation | Recording-scope queries stay isolated across concurrent scopes and concurrent sessions | `pkg/services/recordings/internal/projection_query_contract_test.go:TestRecordingScopeQueriesRemainIsolatedAcrossConcurrentScopes`, `pkg/services/recordings/internal/canonical_recording_lifecycle_test.go:TestRecordingScopesKeepConcurrentSessionsIsolated` | `pkg/services/recordings` | Guarded |
+| Multi-part Work content | A terminal result with two differently typed ordered parts (text then JSON) keeps both discriminated types and their order through the public boundary, and a failure terminal outcome is never reported as success | *(planned guard; mapping/read-model prerequisites exist at `pkg/services/work/transports/http/admission_mapping_test.go:TestSubmitWorkResponseToAPI_EncodesDetachedResult` and `.../read_mapping_test.go:TestWorkReadModelToAPI_EncodesDetachedReadModel`)* | `pkg/services/work` | **P7-B** |
+
+## 8. CLI and API invocation parity
+
+Canonical path: shared invocation contract over the same root-built process.
+
+| Operation | Observable outcome | Existing assertion | Owning package | Status |
+| --- | --- | --- | --- | --- |
+| Invocation success | Local and remote `run` succeed identically | `tests/functional/sessions/lifecycle/remote_lifecycle_test.go:TestCLILocalAndRemoteRunSuccessParityThroughRootProcess` | `pkg/services/factory_sessions`, `pkg/transports/cli` | Guarded |
+| Domain failure | Local and remote `run` fail identically | `tests/functional/sessions/lifecycle/remote_lifecycle_test.go:TestCLILocalAndRemoteRunDomainFailureParityThroughRootProcess` | `pkg/services/factory_sessions`, `pkg/transports/cli` | Guarded |
+| Cancellation | Local and remote `run` cancel identically, and cancellation emits no success result | `tests/functional/sessions/lifecycle/remote_lifecycle_test.go:TestCLILocalAndRemoteRunCancellationParityThroughRootProcess`, `tests/functional/transport/cli/process/context_cancellation_test.go:TestCLIContextCancellationEmitsNoSuccessResult` | `pkg/services/factory_sessions`, `pkg/transports/cli` | Guarded |
+| Terminal result | An NDJSON failure ends with exactly one terminal result; success writes the primary result only to stdout | `tests/functional/transport/cli/output/ndjson_stream_test.go:TestCLINDJSONFailureEndsWithOneTerminalResult`, `tests/functional/transport/cli/process/stdout_stderr_test.go:TestCLISuccessWritesPrimaryResultOnlyToStdout` | `pkg/transports/cli` | Guarded |
+| Response stream | A slow writer does not reorder response events; a writer failure cancels the invocation | `tests/functional/transport/cli/output/stream_backpressure_test.go:TestCLISlowWriterDoesNotReorderResponseEvents`, `...:TestCLIWriterFailureCancelsInvocation` | `pkg/transports/cli` | Guarded |
+
+## Reconciliation findings
+
+The plan's guard table was authored before P5 and P6 merged. Four named guards
+did not resolve at the path the plan states. Each is recorded here rather than
+silently re-pointed at a lookalike.
+
+| Plan-named guard | Finding | Disposition |
+| --- | --- | --- |
+| `tests/functional/workers/agent/stateless_root_test.go:TestBuildStatelessWorkersExecutesDetachedAttemptThroughRoot` | The name existed only as an in-package test at `pkg/root/root_submit_family_compatibility_test.go:410`. No test outside `pkg/root` drove `root.BuildStatelessWorkers` as a customer would, so the "detached execution stays outside Runtime/Session opening" promise had no public guard. | **Closed by P7-A** at the named path. The `pkg/root` owner-tier test is retained; the two assert different boundaries and neither replaces the other. |
+| `pkg/services/workers/internal/services/workstations/executor/agentrun/executor_test.go:TestAgentRunExecutor_TimeoutSurfacesAgentRunTimeoutClass` | Neither the file nor the test exists. The nearest coverage, `agentrun/failure_test.go:TestFailureClassForError_RawDeadlineRemainsAgentRunTimeout`, tests the class mapping as a pure function and never runs a detached agent loop. | **Closed by P7-A** as `agentrun/detached_test.go:TestExecuteDetachedTimeoutSurfacesAgentRunTimeoutClass`, which drives `ExecuteDetached` and then asserts the class, metadata, and diagnostics of the error it actually returns. No new file was added to `agentrun` (the package is at 14 Go files against a limit of 15). |
+| `.../runtime/dispatch_worker_sessions_idempotency_test.go:TestFactoryImpl_WorkerSessionCompletionRacesExplicitAcceptanceAndCanonicalReplay` | Absent. The sibling `TestFactoryImpl_ConcurrentAcceptDispatchResultResolvesExactlyOnce` exists in that file and covers concurrent accept, but not completion racing explicit acceptance against canonical replay. | **P7-C** owns this cell; it is the slice authored for dispatch races. |
+| `tests/functional/transport/http/server/work_terminal_response_test.go:TestWorkTerminalResponsePreservesOrderedTypedContentThroughPublicBoundary` | Absent, and the plan already marks it *planned*. | **P7-B** owns this cell. |
+| `tests/functional/sessions/root_composition/p3_p7_behavior_matrix_test.go:TestP3P7CanonicalPathPreservesTerminalCleanupAndReplayIsolation` | Absent, and the plan already marks it *planned*. | **P7-D** owns this cell. |
+
+One further gap was found by walking the caller table rather than the guard
+table: **`cmd/factory/main.go:runProcess` had no direct guard of any kind.**
+`cmd/factory/main_test.go` replaces `runProcess` outright to test `main`, and
+tests `processExitCode` as a pure function; neither one builds, executes, or
+closes a process. The composed lifecycle the entrypoint performs — build the
+canonical process, execute against the real process streams, close, join the
+close result into the command result, map to an exit code — was unasserted.
+**Closed by P7-A** by `cmd/factory/main_lifecycle_test.go` and
+`tests/functional/sessions/root_composition/process_lifecycle_close_test.go`.
+
+## Gap closure delivered by P7-A
+
+| Cell | New or extended guard |
+| --- | --- |
+| Entrypoint lifecycle: success, domain failure, exit-code mapping, stream delivery, no state carried between invocations | `cmd/factory/main_lifecycle_test.go:TestRunProcessCompletesCanonicalLifecycleAndMapsExitCode`, `...:TestRunProcessReusesNoStateAcrossSequentialInvocations` |
+| Close-error joining after a failed and after a successful command | `tests/functional/sessions/root_composition/process_lifecycle_close_test.go:TestRootProcessCloseAfterFailedCommandPreservesTheCommandFailure`, `...:TestRootProcessCloseAfterSuccessfulCommandReportsNoFailure` |
+| Public detached-worker caller, including cancellation release | `tests/functional/workers/agent/stateless_root_test.go:TestBuildStatelessWorkersExecutesDetachedAttemptThroughRoot`, `...:TestBuildStatelessWorkersReleasesDetachedAttemptOnCancellation` |
+| Detached agent-run typed timeout | `pkg/services/workers/internal/services/workstations/executor/agentrun/detached_test.go:TestExecuteDetachedTimeoutSurfacesAgentRunTimeoutClass` |
+
+Every guard above replaces external effects only through `edges.Edges` (script
+command runner, Sessions/Runtime opening ports observed for their call counts)
+or through the process's own `Args`/`Env`/`WorkingDirectory`/stream inputs. No
+guard sleeps, pads a timeout, or synchronizes on wall-clock time. P7-A makes no
+production change and no deletion.
+
+## Cells deliberately left to later slices
+
+- **P7-B** — public multi-part Work terminal response; CLI/API parity
+  strengthening; HTTP response-event and reconnect/replay strengthening.
+- **P7-C** — activation-failure exactly-once unwind; concurrent/duplicate
+  dispatch completion; canonical replay equivalence under concurrent scope
+  access; the absent worker-session completion race guard above.
+- **P7-D** — the cross-packet corpus test, the full `-race`/`-count>=2` rerun,
+  and deletion-register closure.

--- a/docs/internal/packaged-service-structure/btrc-p7-behavior-matrix.md
+++ b/docs/internal/packaged-service-structure/btrc-p7-behavior-matrix.md
@@ -59,6 +59,8 @@ Canonical path: `Process.Execute` plus the Initializer lifecycle.
 | Cleanup continuation (composed lifecycle) | The lifecycle Wire actually composes reaches Providers then Events exactly once per `Close`, and an earlier owner's teardown failure neither skips nor masks the later one | `pkg/wire/session_runtime_providers_test.go:TestProvideApplicationProcessLifecycle_ClosesProvidersAndEventsExactlyOnceAfterAFailure`, `...:TestProcessCloseContinuesThroughEveryLifecycleOwnerAfterFailure` | `pkg/wire` | **Closed by P7-C** |
 | Activation failure | An already-opened Runtime is closed exactly once when the Visualization sink cannot be resolved, and the runtime adapter is never reached | `tests/functional/sessions/root_composition/application_opening_failure_test.go:TestApplicationOpeningClosesRuntimeWhenVisualizationSinkIsUnavailable` | `pkg/services/factory_sessions` | Guarded |
 | Activation failure (owner tier) | Every other opening-failure branch -- adapter failure and lifecycle-planning failure -- also closes the opened runtime exactly once and preserves the primary error | `pkg/services/factory_sessions/internal/applicationopening/service_test.go:TestOpenApplicationClosesOpenedResourcesOnBindingFailure`, `...:TestOpenApplicationClosesOpenedResourcesWhenLifecyclePlanningFails` | `pkg/services/factory_sessions` | Guarded |
+| Post-activation cleanup (transport role) | After a real activation, process shutdown releases the acquired API transport exactly once, a repeated `Close` neither fails nor releases it again, and the released listener refuses a fresh connection | `tests/functional/sessions/root_composition/p3_p7_behavior_matrix_test.go:TestP3P7CanonicalPathPreservesTerminalCleanupAndReplayIsolation` | `pkg/root`, `pkg/initializer` | **Closed by P7-D** |
+| Shutdown under an in-flight dispatch | A dispatch parked inside the provider boundary observes `context.Canceled` on process shutdown instead of being left running, and no success terminal outcome is reported | `tests/functional/sessions/root_composition/p3_p7_behavior_matrix_test.go:TestP3P7CanonicalPathPreservesTerminalCleanupAndReplayIsolation` | `pkg/root`, `pkg/services/workers` | **Closed by P7-D** |
 
 ## 2. HTTP generated server and SSE response-event routes
 
@@ -147,6 +149,8 @@ history/projection/replay.
 | Scope isolation | Recording-scope queries stay isolated across concurrent scopes and concurrent sessions | `pkg/services/recordings/internal/projection_query_contract_test.go:TestRecordingScopeQueriesRemainIsolatedAcrossConcurrentScopes`, `pkg/services/recordings/internal/canonical_recording_lifecycle_test.go:TestRecordingScopesKeepConcurrentSessionsIsolated` | `pkg/services/recordings` | Guarded |
 | Replay equivalence under concurrent access | Several concurrent canonical replays of two distinct finalized scopes each complete with exactly their own scope's retained world state, never another scope's | `pkg/services/recordings/internal/canonical_recording_lifecycle_test.go:TestRecordingScopeReplayIsEquivalentAndIsolatedUnderConcurrentAccess` | `pkg/services/recordings` | **Closed by P7-C** |
 | Multi-part Work content | A terminal result with two differently typed ordered parts (text then JSON) keeps both discriminated types and their order through the public boundary, and a failure terminal outcome is never reported as success | `tests/functional/transport/http/server/work_terminal_response_test.go:TestWorkTerminalResponsePreservesOrderedTypedContentThroughPublicBoundary` | `pkg/services/work` | **Closed by P7-B** |
+| Cross-process replay isolation | Two Factory Sessions built from one authored Factory in two independent root processes replay to equal ordered workstation outcomes, the same terminal state and the same work-correlated canonical vocabulary, while sharing no session or Work identity and never referencing each other | `tests/functional/sessions/root_composition/p3_p7_behavior_matrix_test.go:TestP3P7CanonicalPathPreservesTerminalCleanupAndReplayIsolation` | `pkg/services/recordings`, `pkg/services/factory_sessions` | **Closed by P7-D** |
+| Projection/replay agreement | The workstation outcome derived from the retained canonical stream alone classifies the Work the same way the served projection does | `tests/functional/sessions/root_composition/p3_p7_behavior_matrix_test.go:TestP3P7CanonicalPathPreservesTerminalCleanupAndReplayIsolation` | `pkg/services/recordings`, `pkg/services/work` | **Closed by P7-D** |
 
 ## 8. CLI and API invocation parity
 
@@ -172,7 +176,7 @@ silently re-pointed at a lookalike.
 | `pkg/services/workers/internal/services/workstations/executor/agentrun/executor_test.go:TestAgentRunExecutor_TimeoutSurfacesAgentRunTimeoutClass` | Neither the file nor the test exists. The nearest coverage, `agentrun/failure_test.go:TestFailureClassForError_RawDeadlineRemainsAgentRunTimeout`, tests the class mapping as a pure function and never runs a detached agent loop. | **Closed by P7-A** as `agentrun/detached_test.go:TestExecuteDetachedTimeoutSurfacesAgentRunTimeoutClass`, which drives `ExecuteDetached` and then asserts the class, metadata, and diagnostics of the error it actually returns. No new file was added to `agentrun` (the package is at 14 Go files against a limit of 15). |
 | `.../runtime/dispatch_worker_sessions_idempotency_test.go:TestFactoryImpl_WorkerSessionCompletionRacesExplicitAcceptanceAndCanonicalReplay` | Absent **under that exact name**. P7-A recorded the cell as unguarded; **P7-C corrects that**: the same file already carries `TestFactoryImpl_WorkerSessionCompletionRacesExplicitAcceptanceAndCanonicalIdempotency`, which holds a Worker Session terminal callback and an explicit Runtime-root acceptance behind one barrier and asserts exactly one RETIRED, one DUPLICATE_IDEMPOTENT, one recorded association and one recorded response. Its own doc comment defers the *canonical replay* half to the Recordings owner package, and that half had no concurrent-access guard. | **Closed by P7-C** in two halves: the Runtime race is the existing `...AndCanonicalIdempotency` guard, extended by the new direct-vs-child duplicate-completion guard; the canonical replay half is closed at its owner by `pkg/services/recordings/internal/canonical_recording_lifecycle_test.go:TestRecordingScopeReplayIsEquivalentAndIsolatedUnderConcurrentAccess`. No duplicate of the existing Runtime guard was added under the plan's name. |
 | `tests/functional/transport/http/server/work_terminal_response_test.go:TestWorkTerminalResponsePreservesOrderedTypedContentThroughPublicBoundary` | Absent, and the plan already marks it *planned*. | **Closed by P7-B** at the named path. |
-| `tests/functional/sessions/root_composition/p3_p7_behavior_matrix_test.go:TestP3P7CanonicalPathPreservesTerminalCleanupAndReplayIsolation` | Absent, and the plan already marks it *planned*. | **P7-D** owns this cell. |
+| `tests/functional/sessions/root_composition/p3_p7_behavior_matrix_test.go:TestP3P7CanonicalPathPreservesTerminalCleanupAndReplayIsolation` | Absent, and the plan already marks it *planned*. | **Closed by P7-D** at the named path. |
 
 One further gap was found by walking the caller table rather than the guard
 table: **`cmd/factory/main.go:runProcess` had no direct guard of any kind.**
@@ -258,7 +262,62 @@ to the started set before `Start` succeeds (double-stop), returning early from
 the composed `Close` on the first failure, classifying duplicate retirement as
 RETIRED, and crossing the two replay scopes each produced the expected failure.
 
-## Cells deliberately left to later slices
+## Gap closure delivered by P7-D
 
-- **P7-D** — the cross-packet corpus test, the full `-race`/`-count>=2` rerun,
-  and deletion-register closure.
+P7-D adds the plan's named cross-packet corpus and closes the deletion register.
+One test file, one register, and this matrix changed; no production file
+changed.
+
+`tests/functional/sessions/root_composition/p3_p7_behavior_matrix_test.go:TestP3P7CanonicalPathPreservesTerminalCleanupAndReplayIsolation`
+drives four canonical root processes through `root.BuildProcess` and
+`Process.Execute`, replacing external effects only through `edges.Edges`
+(`APIServerStarter`, `FactorySessionRuntimeInstanceIDGenerator`,
+`ProviderCommandRunner`). It asserts, in one place, the four cross-packet claims
+that individually belong to different owners:
+
+| Claim | How the corpus observes it |
+| --- | --- |
+| One terminal outcome | Served status categories report exactly one terminal (or failed) Work and zero of the other, the served Work state type matches, and exactly one workstation outcome replayed from the retained canonical stream alone classifies the same way. |
+| Post-activation cleanup | The API transport is activated exactly once, released exactly once by process shutdown, not released again by a repeated `Close` (which also must not fail), and the released listener refuses a fresh connection. A non-zero Factory Session runtime-activation count is required first, so the cleanup claim cannot pass vacuously on a process that never activated. |
+| Cancellation and failure | A provider `ExitCode 1` terminalizes as FAILED with zero terminal outcomes, and a dispatch parked inside the provider boundary observes `context.Canceled` when the process shuts down, with zero terminal outcomes observed while it was held. |
+| Replay isolation | Two Factory Sessions built from one authored Factory in two independent root processes produce equal ordered workstation outcomes, the same terminal state name, and the same work-correlated canonical event vocabulary, while sharing no session identity and no Work identity, with no event of either session referencing the other's Work and no session sequence regressing. |
+
+Three findings recorded rather than worked around:
+
+- **`WORK_STATE_CHANGE` is not the normal workstation transition fact.** It is
+  emitted only for operator moves (`factoryImpl.MoveWork`) and cascading
+  failure, so a corpus that derives a work-state path from it observes nothing
+  on the ordinary dispatch path. The replayable terminal fact for a
+  workstation-driven transition is `DISPATCH_RESPONSE.outcome`.
+- **The Work projection and the canonical stream are separate reads.** A
+  terminal projection read does not imply the workstation outcome is already
+  committed to retained history, so the corpus waits for the canonical fact
+  itself before deriving from it.
+- **Session-scoped canonical events carry either the run's canonical session
+  UUID or the `~default` alias.** `SESSION_STARTED` and `WORK_REQUEST` carry the
+  alias. The alias is resolved per process, so it can never name another
+  process's session, and the isolation assertion accepts it explicitly rather
+  than being weakened to "any session".
+
+Every corpus claim was falsified once before being trusted: suppressing
+cancellation propagation into the transport edge (release never observed),
+replacing the second isolated session's history with the first's (foreign Work
+reference detected), truncating one session's retained history (outcome
+sequences diverge), and returning the parked provider dispatch immediately
+instead of holding it (cancellation never observed).
+
+### Deletion-register closure
+
+`docs/internal/packaged-service-structure/btrc-p6-secondary-graph-register.md`
+was re-verified row by row against the tree as merged through `fd0e46ab9`
+(#2049). Three rows had drifted and were corrected surgically — the pinned
+reconciliation base, the `APIFactory` reference count (one row claimed a single
+production reference while the same document's prose enumerated the post-P6-D
+set), and a wrong caller line for `NewInvocationWithProgress`. Every other row
+holds exactly as written. That register now carries a *P7-D reconciliation*
+section stating what was re-checked and what changed.
+
+P7-D deletes no package and no file, so no manifest or baseline row required
+removal, and no stale test-only adapter or scaffolding remains from P7-A, P7-B
+or P7-C — none of those slices created a shadow fixture, dual-path probe or
+temporary race harness.

--- a/docs/internal/packaged-service-structure/btrc-p7-behavior-matrix.md
+++ b/docs/internal/packaged-service-structure/btrc-p7-behavior-matrix.md
@@ -28,8 +28,10 @@ test that runs a real operation.
   `*_test.go`. A plan-named guard that is absent, or that lives at a different
   path than the plan states, is recorded in *Reconciliation findings* rather
   than silently substituted.
-- Reconciliation base: `7018644b3`, the merge-base of this branch and
-  `origin/main` (BTRC P6, #2046).
+- Reconciliation base: the matrix was first frozen against `7018644b3`, the
+  merge-base of this branch and `origin/main` when P7-A landed (BTRC P6, #2046).
+  P7-D rebased the branch onto `75d51e97d` and re-ran every cell there, so the
+  statuses below describe that tree.
 
 ## Status vocabulary
 
@@ -309,13 +311,22 @@ instead of holding it (cancellation never observed).
 ### Deletion-register closure
 
 `docs/internal/packaged-service-structure/btrc-p6-secondary-graph-register.md`
-was re-verified row by row against the tree as merged through `fd0e46ab9`
-(#2049). Three rows had drifted and were corrected surgically — the pinned
+was re-verified row by row against the tree as merged through `75d51e97d`
+(#2051). Five rows had drifted and were corrected surgically — the pinned
 reconciliation base, the `APIFactory` reference count (one row claimed a single
 production reference while the same document's prose enumerated the post-P6-D
-set), and a wrong caller line for `NewInvocationWithProgress`. Every other row
-holds exactly as written. That register now carries a *P7-D reconciliation*
-section stating what was re-checked and what changed.
+set), a wrong caller line for `NewInvocationWithProgress`, an approximate
+importer count that cannot be re-verified, and the `deadcode` static-gate
+numbers that `75d51e97d` superseded. Every other row holds exactly as written.
+That register now carries a *P7-D reconciliation* section stating what was
+re-checked and what changed.
+
+The re-verification was mechanical: each of the register's 14 file-line claims
+was checked by reading that exact line and matching the symbol it should carry.
+All 14 still resolve on the rebased base, because the three commits that landed
+while P7 was in flight (`fd0e46ab9` #2049, `217066ad6` #2050, `75d51e97d` #2051)
+touched the staging lease, `pkg/platform/process` and the provider adapters, and
+unreachable test helpers — none of the composition seams this register tracks.
 
 P7-D deletes no package and no file, so no manifest or baseline row required
 removal, and no stale test-only adapter or scaffolding remains from P7-A, P7-B

--- a/docs/internal/packaged-service-structure/btrc-p7-behavior-matrix.md
+++ b/docs/internal/packaged-service-structure/btrc-p7-behavior-matrix.md
@@ -69,6 +69,8 @@ Recordings canonical reads.
 | Terminal envelope | The response-event payload union covers every documented variant | `pkg/transports/http/contracttests/openapi_contract_response_events_test.go:TestOpenAPIContract_FactoryResponseEventPayloadUnionCoversAllVariants` | `pkg/transports/http` | Guarded |
 | Response stream | Retained-then-live SSE ordering; documented stream close boundary | `tests/functional/events/response_events/stream_test.go:TestAPIResponseEventSSEStreamsRetainedThenLiveEvents`, `...:TestAPIResponseEventStreamClosesAtDocumentedBoundary` | `pkg/services/factory_sessions` | Guarded |
 | Reconnect gap | A cursor gap emits the typed stream-gap record; an expired session returns typed Gone | `tests/functional/events/response_events/stream_test.go:TestAPIResponseEventCursorGapEmitsStreamGap`, `...:TestAPIResponseEventSessionExpiryReturnsTypedGone` | `pkg/services/factory_sessions` | Guarded |
+| Reconnect resume | Reopening a live session's stream from an acknowledged cursor replays exactly the retained suffix, in order, with no duplicate of the acknowledged prefix | `tests/functional/events/response_events/concurrent_session_isolation_test.go:TestConcurrentFactorySessionResponseEventStreamsStayIsolatedAndResumeFromCursor` | `pkg/services/factory_sessions` | **Closed by P7-B** |
+| Concurrent response streams | Two Factory Sessions streaming at once each decode their own typed payload unions in published order; neither stream carries the other session's identity, event ids, dispatch identity, or message text | `tests/functional/events/response_events/concurrent_session_isolation_test.go:TestConcurrentFactorySessionResponseEventStreamsStayIsolatedAndResumeFromCursor` | `pkg/services/factory_sessions` | **Closed by P7-B** |
 | Active-stream close | Server shutdown closes the listener and every active stream; bind failure unwinds started lifecycle roles | `tests/functional/transport/http/server/startup_shutdown_test.go:TestAPIServerShutdownClosesListenerAndActiveStreams`, `...:TestAPIServerBindFailureUnwindsStartedLifecycleRoles` | `pkg/transports/http`, `pkg/initializer` | Guarded |
 | Terminal result | Response-event stream read to a terminal run outcome | `tests/functional/events/response_events/terminal_outcomes_test.go:TestReadResponseEventStreamUntilTerminalRunOutcomes` | `pkg/services/factory_sessions` | Guarded |
 | Work admission | Work admission and response stream activate after runtime lifecycle through `root.BuildProcess` | `tests/functional/sessions/root_composition/work_admission_response_stream_test.go:TestSessionsWorkAdmissionAndResponseStreamActivateThroughRootBuildProcessAfterLifecycle` | `pkg/services/factory_sessions`, `pkg/services/work` | Guarded |
@@ -138,7 +140,7 @@ history/projection/replay.
 | --- | --- | --- | --- | --- |
 | Replay equivalence | Projection queries are equivalent for retained and replayed canonical facts | `pkg/services/recordings/internal/projection_query_contract_test.go:TestProjectionQueries_AreEquivalentForRetainedAndReplayedCanonicalFacts` | `pkg/services/recordings` | Guarded |
 | Scope isolation | Recording-scope queries stay isolated across concurrent scopes and concurrent sessions | `pkg/services/recordings/internal/projection_query_contract_test.go:TestRecordingScopeQueriesRemainIsolatedAcrossConcurrentScopes`, `pkg/services/recordings/internal/canonical_recording_lifecycle_test.go:TestRecordingScopesKeepConcurrentSessionsIsolated` | `pkg/services/recordings` | Guarded |
-| Multi-part Work content | A terminal result with two differently typed ordered parts (text then JSON) keeps both discriminated types and their order through the public boundary, and a failure terminal outcome is never reported as success | *(planned guard; mapping/read-model prerequisites exist at `pkg/services/work/transports/http/admission_mapping_test.go:TestSubmitWorkResponseToAPI_EncodesDetachedResult` and `.../read_mapping_test.go:TestWorkReadModelToAPI_EncodesDetachedReadModel`)* | `pkg/services/work` | **P7-B** |
+| Multi-part Work content | A terminal result with two differently typed ordered parts (text then JSON) keeps both discriminated types and their order through the public boundary, and a failure terminal outcome is never reported as success | `tests/functional/transport/http/server/work_terminal_response_test.go:TestWorkTerminalResponsePreservesOrderedTypedContentThroughPublicBoundary` | `pkg/services/work` | **Closed by P7-B** |
 
 ## 8. CLI and API invocation parity
 
@@ -163,7 +165,7 @@ silently re-pointed at a lookalike.
 | `tests/functional/workers/agent/stateless_root_test.go:TestBuildStatelessWorkersExecutesDetachedAttemptThroughRoot` | The name existed only as an in-package test at `pkg/root/root_submit_family_compatibility_test.go:410`. No test outside `pkg/root` drove `root.BuildStatelessWorkers` as a customer would, so the "detached execution stays outside Runtime/Session opening" promise had no public guard. | **Closed by P7-A** at the named path. The `pkg/root` owner-tier test is retained; the two assert different boundaries and neither replaces the other. |
 | `pkg/services/workers/internal/services/workstations/executor/agentrun/executor_test.go:TestAgentRunExecutor_TimeoutSurfacesAgentRunTimeoutClass` | Neither the file nor the test exists. The nearest coverage, `agentrun/failure_test.go:TestFailureClassForError_RawDeadlineRemainsAgentRunTimeout`, tests the class mapping as a pure function and never runs a detached agent loop. | **Closed by P7-A** as `agentrun/detached_test.go:TestExecuteDetachedTimeoutSurfacesAgentRunTimeoutClass`, which drives `ExecuteDetached` and then asserts the class, metadata, and diagnostics of the error it actually returns. No new file was added to `agentrun` (the package is at 14 Go files against a limit of 15). |
 | `.../runtime/dispatch_worker_sessions_idempotency_test.go:TestFactoryImpl_WorkerSessionCompletionRacesExplicitAcceptanceAndCanonicalReplay` | Absent. The sibling `TestFactoryImpl_ConcurrentAcceptDispatchResultResolvesExactlyOnce` exists in that file and covers concurrent accept, but not completion racing explicit acceptance against canonical replay. | **P7-C** owns this cell; it is the slice authored for dispatch races. |
-| `tests/functional/transport/http/server/work_terminal_response_test.go:TestWorkTerminalResponsePreservesOrderedTypedContentThroughPublicBoundary` | Absent, and the plan already marks it *planned*. | **P7-B** owns this cell. |
+| `tests/functional/transport/http/server/work_terminal_response_test.go:TestWorkTerminalResponsePreservesOrderedTypedContentThroughPublicBoundary` | Absent, and the plan already marks it *planned*. | **Closed by P7-B** at the named path. |
 | `tests/functional/sessions/root_composition/p3_p7_behavior_matrix_test.go:TestP3P7CanonicalPathPreservesTerminalCleanupAndReplayIsolation` | Absent, and the plan already marks it *planned*. | **P7-D** owns this cell. |
 
 One further gap was found by walking the caller table rather than the guard
@@ -191,10 +193,33 @@ or through the process's own `Args`/`Env`/`WorkingDirectory`/stream inputs. No
 guard sleeps, pads a timeout, or synchronizes on wall-clock time. P7-A makes no
 production change and no deletion.
 
+## Gap closure delivered by P7-B
+
+| Cell | New or extended guard |
+| --- | --- |
+| Public multi-part Work terminal response, success and failure | `tests/functional/transport/http/server/work_terminal_response_test.go:TestWorkTerminalResponsePreservesOrderedTypedContentThroughPublicBoundary` |
+| Concurrent-session response-event isolation, typed ordered payloads, cursor resume | `tests/functional/events/response_events/concurrent_session_isolation_test.go:TestConcurrentFactorySessionResponseEventStreamsStayIsolatedAndResumeFromCursor` |
+
+Two P7-B findings are recorded rather than papered over:
+
+- **CLI/API invocation parity needed no new guard.** Section 8's success,
+  domain-failure, and cancellation rows already assert local-versus-remote
+  `run` parity through `support.BuildProcess`, so P7-B verified the three cells
+  against the plan's wording instead of adding a duplicate parity test.
+- **Ordered multi-part terminal content reaches the public read through
+  customer-submitted content, not through worker output.** Worker output
+  materialization produces exactly one text part
+  (`work.ProposedOutputFromLegacyWorkResult`), and a recorded decision-envelope
+  output Work is re-materialized under a fresh identity, which breaks
+  submitted-Work lineage. The guard therefore submits the ordered typed parts
+  through `POST /factory-sessions/{id}/work` and authors
+  `workPropagation: {mode: PRESERVE_INPUT}`, which is the one production path
+  that carries customer content onto the terminal token. The public invocation
+  route is text-only by contract (`work.ResolveAPITextInputContent`), so it
+  cannot carry this case. No production compatibility path was added.
+
 ## Cells deliberately left to later slices
 
-- **P7-B** — public multi-part Work terminal response; CLI/API parity
-  strengthening; HTTP response-event and reconnect/replay strengthening.
 - **P7-C** — activation-failure exactly-once unwind; concurrent/duplicate
   dispatch completion; canonical replay equivalence under concurrent scope
   access; the absent worker-session completion race guard above.

--- a/docs/internal/packaged-service-structure/btrc-p7-behavior-matrix.md
+++ b/docs/internal/packaged-service-structure/btrc-p7-behavior-matrix.md
@@ -37,7 +37,9 @@ test that runs a real operation.
 | --- | --- |
 | **Guarded** | A direct guard exists in the tree and runs a real operation. |
 | **Closed by P7-A** | The cell had no direct guard at the named boundary; this slice added one. |
-| **P7-B / P7-C / P7-D** | The cell is deliberately deferred to a later, authored P7 slice. |
+| **Closed by P7-B** | Same, closed by the P7-B slice. |
+| **Closed by P7-C** | Same, closed by the P7-C slice. |
+| **P7-D** | The cell is deliberately deferred to the final authored P7 slice. |
 
 ## 1. `cmd/factory/main.go:runProcess` and `root.BuildProcess`
 
@@ -53,8 +55,10 @@ Canonical path: `Process.Execute` plus the Initializer lifecycle.
 | Cancellation | A declared cancel exit code is selected per command path; an ordinary failure wins over a canceled process context | `cmd/factory/main_test.go:TestProcessExitCodePreservesDeclaredLifecycleContract` | `cmd/factory` | Guarded |
 | Cleanup | `Close` is deterministic and idempotent on a built process | `pkg/root/events_lifecycle_composition_test.go:TestBuildProcessClosesDeterministicallyAndIdempotently` | `pkg/root`, `pkg/wire` | Guarded |
 | Cleanup / close-error joining | After a **failed command**, `Close` still succeeds, so `errors.Join` carries exactly the command failure and never a cancellation classification | `tests/functional/sessions/root_composition/process_lifecycle_close_test.go:TestRootProcessCloseAfterFailedCommandPreservesTheCommandFailure`, `...:TestRootProcessCloseAfterSuccessfulCommandReportsNoFailure` | `pkg/root`, `pkg/initializer/lifecycle` | **Closed by P7-A** |
-| Cleanup unwind | Start failure unwinds acquired roles once, joins cleanup errors, and close continues through every owner | `pkg/initializer/lifecycle/manager_test.go:TestManagerUnwindsStartFailureAndJoinsCleanupErrors`, `pkg/wire/session_runtime_providers_test.go:TestProcessCloseContinuesThroughEveryLifecycleOwnerAfterFailure` | `pkg/initializer/lifecycle`, `pkg/wire` | Guarded |
-| Activation failure | An already-opened Runtime is closed when the Visualization sink cannot be resolved | `tests/functional/sessions/root_composition/application_opening_failure_test.go:TestApplicationOpeningClosesRuntimeWhenVisualizationSinkIsUnavailable` | `pkg/services/factory_sessions` | Guarded |
+| Cleanup unwind (exactly once) | Start failure stops only the components that actually started, in reverse order, exactly once each; the component whose Start failed is never stopped; no later component starts; the primary never runs; every acquired resource closes exactly once in reverse order; the primary start failure is retained beside each cleanup failure | `pkg/initializer/lifecycle/manager_test.go:TestManagerUnwindsStartFailureAndJoinsCleanupErrors` | `pkg/initializer/lifecycle` | **Closed by P7-C** |
+| Cleanup continuation (composed lifecycle) | The lifecycle Wire actually composes reaches Providers then Events exactly once per `Close`, and an earlier owner's teardown failure neither skips nor masks the later one | `pkg/wire/session_runtime_providers_test.go:TestProvideApplicationProcessLifecycle_ClosesProvidersAndEventsExactlyOnceAfterAFailure`, `...:TestProcessCloseContinuesThroughEveryLifecycleOwnerAfterFailure` | `pkg/wire` | **Closed by P7-C** |
+| Activation failure | An already-opened Runtime is closed exactly once when the Visualization sink cannot be resolved, and the runtime adapter is never reached | `tests/functional/sessions/root_composition/application_opening_failure_test.go:TestApplicationOpeningClosesRuntimeWhenVisualizationSinkIsUnavailable` | `pkg/services/factory_sessions` | Guarded |
+| Activation failure (owner tier) | Every other opening-failure branch -- adapter failure and lifecycle-planning failure -- also closes the opened runtime exactly once and preserves the primary error | `pkg/services/factory_sessions/internal/applicationopening/service_test.go:TestOpenApplicationClosesOpenedResourcesOnBindingFailure`, `...:TestOpenApplicationClosesOpenedResourcesWhenLifecyclePlanningFails` | `pkg/services/factory_sessions` | Guarded |
 
 ## 2. HTTP generated server and SSE response-event routes
 
@@ -124,9 +128,10 @@ Worker Sessions identity.
 
 | Operation | Observable outcome | Existing assertion | Owning package | Status |
 | --- | --- | --- | --- | --- |
-| Direct dispatch | Concurrent accept of a dispatch result resolves exactly once | `pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_idempotency_test.go:TestFactoryImpl_ConcurrentAcceptDispatchResultResolvesExactlyOnce` | `pkg/services/factory_runtime` | Guarded |
+| Child dispatch | Concurrent accept of a scheduler-originated dispatch result resolves exactly once | `pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_idempotency_test.go:TestFactoryImpl_ConcurrentAcceptDispatchResultResolvesExactlyOnce` | `pkg/services/factory_runtime` | Guarded |
 | Direct vs child dispatch | Both preserve an identical terminal-outcome mapping | `pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_terminal_semantics_test.go:TestFactoryImpl_DirectAndChildDispatchPreserveIdenticalTerminalOutcomeMapping` | `pkg/services/factory_runtime` | Guarded |
-| Completion vs acceptance race | Worker-session completion racing explicit acceptance and canonical replay resolves once | *(plan-named guard absent from the tree)* | `pkg/services/factory_runtime` | **P7-C** |
+| Direct vs child dispatch, duplicate completion | Duplicate terminal delivery for one in-flight dispatch resolves to exactly one RETIRED acceptance with every other concurrent caller DUPLICATE_IDEMPOTENT, records one Worker Session association and no duplicate canonical response, leaves nothing in flight, and maps to the identical terminal outcome from **both** origins | `pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_workers_root_boundary_test.go:TestFactoryImpl_ConcurrentDuplicateCompletionResolvesExactlyOnceForDirectAndChildDispatch` | `pkg/services/factory_runtime` | **Closed by P7-C** |
+| Completion vs acceptance race | A Worker Session terminal callback racing an explicit Runtime-root acceptance retires exactly once, with the loser DUPLICATE_IDEMPOTENT and one recorded association and response | `pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_idempotency_test.go:TestFactoryImpl_WorkerSessionCompletionRacesExplicitAcceptanceAndCanonicalIdempotency` | `pkg/services/factory_runtime` | Guarded |
 | Response observation | An observed in-flight response is excluded from the in-flight projection and does not terminate early | `pkg/services/factory_runtime/internal/rootobservation/project_test.go:TestProject_ExcludesObservedDispatchResponseFromInFlightProjection`, `.../terminationtests/termination_test.go:TestTerminationCheck_DoesNotTerminateWhileObservedResponseAwaitsRetirement` | `pkg/services/factory_runtime` | Guarded |
 | Worker Sessions identity | A dispatch is control-addressable before start and records its association before Workers handoff | `pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover_test.go:TestStartThroughWorkerSessions_AssociationIsControlAddressableBeforeStart`, `...:TestFactoryImpl_PlanDispatchRecordsWorkerSessionAssociationBeforeWorkersHandoff` | `pkg/services/factory_runtime`, `pkg/services/worker_sessions` | Guarded |
 | Replay | Historical attempts list chronologically and the terminal stream replays from an atomic snapshot | `pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover_test.go:TestRecordedWorkerSessionObservation_ListsHistoricalAttemptsInChronologicalOrder`, `...:TestRecordedWorkerSessionObservationStreamUsesAtomicSnapshotAndPreservesHistory` | `pkg/services/factory_runtime` | Guarded |
@@ -140,6 +145,7 @@ history/projection/replay.
 | --- | --- | --- | --- | --- |
 | Replay equivalence | Projection queries are equivalent for retained and replayed canonical facts | `pkg/services/recordings/internal/projection_query_contract_test.go:TestProjectionQueries_AreEquivalentForRetainedAndReplayedCanonicalFacts` | `pkg/services/recordings` | Guarded |
 | Scope isolation | Recording-scope queries stay isolated across concurrent scopes and concurrent sessions | `pkg/services/recordings/internal/projection_query_contract_test.go:TestRecordingScopeQueriesRemainIsolatedAcrossConcurrentScopes`, `pkg/services/recordings/internal/canonical_recording_lifecycle_test.go:TestRecordingScopesKeepConcurrentSessionsIsolated` | `pkg/services/recordings` | Guarded |
+| Replay equivalence under concurrent access | Several concurrent canonical replays of two distinct finalized scopes each complete with exactly their own scope's retained world state, never another scope's | `pkg/services/recordings/internal/canonical_recording_lifecycle_test.go:TestRecordingScopeReplayIsEquivalentAndIsolatedUnderConcurrentAccess` | `pkg/services/recordings` | **Closed by P7-C** |
 | Multi-part Work content | A terminal result with two differently typed ordered parts (text then JSON) keeps both discriminated types and their order through the public boundary, and a failure terminal outcome is never reported as success | `tests/functional/transport/http/server/work_terminal_response_test.go:TestWorkTerminalResponsePreservesOrderedTypedContentThroughPublicBoundary` | `pkg/services/work` | **Closed by P7-B** |
 
 ## 8. CLI and API invocation parity
@@ -164,7 +170,7 @@ silently re-pointed at a lookalike.
 | --- | --- | --- |
 | `tests/functional/workers/agent/stateless_root_test.go:TestBuildStatelessWorkersExecutesDetachedAttemptThroughRoot` | The name existed only as an in-package test at `pkg/root/root_submit_family_compatibility_test.go:410`. No test outside `pkg/root` drove `root.BuildStatelessWorkers` as a customer would, so the "detached execution stays outside Runtime/Session opening" promise had no public guard. | **Closed by P7-A** at the named path. The `pkg/root` owner-tier test is retained; the two assert different boundaries and neither replaces the other. |
 | `pkg/services/workers/internal/services/workstations/executor/agentrun/executor_test.go:TestAgentRunExecutor_TimeoutSurfacesAgentRunTimeoutClass` | Neither the file nor the test exists. The nearest coverage, `agentrun/failure_test.go:TestFailureClassForError_RawDeadlineRemainsAgentRunTimeout`, tests the class mapping as a pure function and never runs a detached agent loop. | **Closed by P7-A** as `agentrun/detached_test.go:TestExecuteDetachedTimeoutSurfacesAgentRunTimeoutClass`, which drives `ExecuteDetached` and then asserts the class, metadata, and diagnostics of the error it actually returns. No new file was added to `agentrun` (the package is at 14 Go files against a limit of 15). |
-| `.../runtime/dispatch_worker_sessions_idempotency_test.go:TestFactoryImpl_WorkerSessionCompletionRacesExplicitAcceptanceAndCanonicalReplay` | Absent. The sibling `TestFactoryImpl_ConcurrentAcceptDispatchResultResolvesExactlyOnce` exists in that file and covers concurrent accept, but not completion racing explicit acceptance against canonical replay. | **P7-C** owns this cell; it is the slice authored for dispatch races. |
+| `.../runtime/dispatch_worker_sessions_idempotency_test.go:TestFactoryImpl_WorkerSessionCompletionRacesExplicitAcceptanceAndCanonicalReplay` | Absent **under that exact name**. P7-A recorded the cell as unguarded; **P7-C corrects that**: the same file already carries `TestFactoryImpl_WorkerSessionCompletionRacesExplicitAcceptanceAndCanonicalIdempotency`, which holds a Worker Session terminal callback and an explicit Runtime-root acceptance behind one barrier and asserts exactly one RETIRED, one DUPLICATE_IDEMPOTENT, one recorded association and one recorded response. Its own doc comment defers the *canonical replay* half to the Recordings owner package, and that half had no concurrent-access guard. | **Closed by P7-C** in two halves: the Runtime race is the existing `...AndCanonicalIdempotency` guard, extended by the new direct-vs-child duplicate-completion guard; the canonical replay half is closed at its owner by `pkg/services/recordings/internal/canonical_recording_lifecycle_test.go:TestRecordingScopeReplayIsEquivalentAndIsolatedUnderConcurrentAccess`. No duplicate of the existing Runtime guard was added under the plan's name. |
 | `tests/functional/transport/http/server/work_terminal_response_test.go:TestWorkTerminalResponsePreservesOrderedTypedContentThroughPublicBoundary` | Absent, and the plan already marks it *planned*. | **Closed by P7-B** at the named path. |
 | `tests/functional/sessions/root_composition/p3_p7_behavior_matrix_test.go:TestP3P7CanonicalPathPreservesTerminalCleanupAndReplayIsolation` | Absent, and the plan already marks it *planned*. | **P7-D** owns this cell. |
 
@@ -218,10 +224,41 @@ Two P7-B findings are recorded rather than papered over:
   route is text-only by contract (`work.ResolveAPITextInputContent`), so it
   cannot carry this case. No production compatibility path was added.
 
+## Gap closure delivered by P7-C
+
+| Cell | New or strengthened guard |
+| --- | --- |
+| Activation-failure unwind is exactly once, in reverse order, and never touches a component that did not start | `pkg/initializer/lifecycle/manager_test.go:TestManagerUnwindsStartFailureAndJoinsCleanupErrors` (strengthened) |
+| The lifecycle Wire composes reaches both resource-owning closers exactly once and does not short-circuit on the first failure | `pkg/wire/session_runtime_providers_test.go:TestProvideApplicationProcessLifecycle_ClosesProvidersAndEventsExactlyOnceAfterAFailure` |
+| Concurrent duplicate completion resolves exactly once with identical terminal mapping for **direct** and **child** dispatch | `pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_workers_root_boundary_test.go:TestFactoryImpl_ConcurrentDuplicateCompletionResolvesExactlyOnceForDirectAndChildDispatch` |
+| Canonical replay equivalence holds under concurrent cross-scope access | `pkg/services/recordings/internal/canonical_recording_lifecycle_test.go:TestRecordingScopeReplayIsEquivalentAndIsolatedUnderConcurrentAccess` |
+
+Three P7-C findings are recorded rather than papered over:
+
+- **P7-A's "absent" verdict on the completion-race cell was too strong.** The
+  guard exists under the suffix `...AndCanonicalIdempotency`, not
+  `...AndCanonicalReplay`. P7-C corrects the reconciliation row instead of
+  adding a second Runtime test under the plan's name, and closes the *replay*
+  half at its actual owner, Recordings.
+- **The pre-existing concurrent-acceptance guard covers only the child
+  origin.** `TestFactoryImpl_ConcurrentAcceptDispatchResultResolvesExactlyOnce`
+  and `...AndCanonicalIdempotency` both drive `SubmitWorkRequest` + `Run`, which
+  is the scheduler-originated (child) dispatch. The Runtime-root `PlanDispatch`
+  (direct) origin had no duplicate-completion race guard at all. That is the
+  gap the new direct-vs-child guard closes.
+- **The direct origin records no canonical workstation response when an
+  external acceptance wins the race.** Probed, not assumed: the scripted ledger
+  shows `RecordDispatchWorkerSessionAssociation` for both origins but
+  `RecordWorkstationResponse` only for the child origin. The guard therefore
+  asserts one association and *no duplicate* response, rather than asserting a
+  response count that only one origin produces.
+
+Every P7-C guard was falsified once before being trusted: appending a component
+to the started set before `Start` succeeds (double-stop), returning early from
+the composed `Close` on the first failure, classifying duplicate retirement as
+RETIRED, and crossing the two replay scopes each produced the expected failure.
+
 ## Cells deliberately left to later slices
 
-- **P7-C** — activation-failure exactly-once unwind; concurrent/duplicate
-  dispatch completion; canonical replay equivalence under concurrent scope
-  access; the absent worker-session completion race guard above.
 - **P7-D** — the cross-packet corpus test, the full `-race`/`-count>=2` rerun,
   and deletion-register closure.

--- a/pkg/initializer/lifecycle/manager_test.go
+++ b/pkg/initializer/lifecycle/manager_test.go
@@ -38,31 +38,63 @@ func TestManagerRunsAndClosesInReverseOrder(t *testing.T) {
 	}
 }
 
+// TestManagerUnwindsStartFailureAndJoinsCleanupErrors proves a failed
+// activation unwinds exactly once: every component that actually started is
+// stopped exactly once in reverse declaration order, the component whose Start
+// failed is never stopped, no component declared after the failure is started,
+// the primary component never runs, every acquired resource closes exactly
+// once in reverse declaration order, and the primary start failure is retained
+// alongside each cleanup failure it did not mask.
 func TestManagerUnwindsStartFailureAndJoinsCleanupErrors(t *testing.T) {
 	startErr := errors.New("start failed")
 	stopErr := errors.New("stop failed")
 	closeErr := errors.New("close failed")
-	started := lifecycle.Functions{
-		StartFunc: func(context.Context) error { return nil },
-		StopFunc:  func(context.Context) error { return stopErr },
+	var order []string
+	record := func(step string) { order = append(order, step) }
+	first := lifecycle.Functions{
+		StartFunc: func(context.Context) error { record("start-first"); return nil },
+		StopFunc:  func(context.Context) error { record("stop-first"); return nil },
 	}
-	failing := lifecycle.Functions{StartFunc: func(context.Context) error { return startErr }}
-	primary := lifecycle.NewRunner(func(context.Context) error { return nil })
+	second := lifecycle.Functions{
+		StartFunc: func(context.Context) error { record("start-second"); return nil },
+		StopFunc:  func(context.Context) error { record("stop-second"); return stopErr },
+	}
+	failing := lifecycle.Functions{
+		StartFunc: func(context.Context) error { record("start-failing"); return startErr },
+		StopFunc:  func(context.Context) error { record("stop-failing"); return nil },
+	}
+	unreached := lifecycle.Functions{
+		StartFunc: func(context.Context) error { record("start-unreached"); return nil },
+		StopFunc:  func(context.Context) error { record("stop-unreached"); return nil },
+	}
+	primary := lifecycle.NewRunner(func(context.Context) error { record("run-primary"); return nil })
 
 	err := lifecycle.NewManager().Run(context.Background(), lifecycle.Plan{
 		Components: []lifecycle.NamedComponent{
-			{Name: "started", Component: started},
+			{Name: "first", Component: first},
+			{Name: "second", Component: second},
 			{Name: "failing", Component: failing},
+			{Name: "unreached", Component: unreached},
 			{Name: "primary", Component: primary, Primary: true},
 		},
-		Resources: []lifecycle.NamedResource{{
-			Name: "owned", Resource: closerFunc(func() error { return closeErr }),
-		}},
+		Resources: []lifecycle.NamedResource{
+			{Name: "outer", Resource: closerFunc(func() error { record("close-outer"); return nil })},
+			{Name: "inner", Resource: closerFunc(func() error { record("close-inner"); return closeErr })},
+		},
 	})
+
 	for _, cause := range []error{startErr, stopErr, closeErr} {
 		if !errors.Is(err, cause) {
 			t.Fatalf("Run() error = %v, want cause %v", err, cause)
 		}
+	}
+	want := []string{
+		"start-first", "start-second", "start-failing",
+		"stop-second", "stop-first",
+		"close-inner", "close-outer",
+	}
+	if !reflect.DeepEqual(order, want) {
+		t.Fatalf("start-failure unwind = %v, want %v", order, want)
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_workers_root_boundary_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_workers_root_boundary_test.go
@@ -2,12 +2,15 @@ package runtime
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 
+	"github.com/portpowered/infinite-you/internal/testutil/recordingfixtures"
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factory "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	dispatchplanning "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/dispatch_planning"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 )
@@ -231,5 +234,195 @@ func TestWorkersServiceExecutesRuntimePlannedRequest(t *testing.T) {
 	lastDispatchID, _ := executor.lastDispatchID.Load().(string)
 	if lastDispatchID != dispatch.DispatchID {
 		t.Fatalf("executed dispatch ID = %q, want %q", lastDispatchID, dispatch.DispatchID)
+	}
+}
+
+// TestFactoryImpl_ConcurrentDuplicateCompletionResolvesExactlyOnceForDirectAndChildDispatch
+// proves duplicate terminal delivery for one in-flight dispatch resolves to
+// exactly one accepted Runtime terminal result for both dispatch origins: a
+// Runtime-root PlanDispatch (direct) and a scheduler-originated Factory
+// dispatch (child). Every losing concurrent caller observes the deterministic
+// DUPLICATE_IDEMPOTENT outcome, the dispatch records one Worker Session
+// association and no duplicate canonical response once the Workers callback
+// that follows is released, nothing is left in flight, and both origins map the
+// delivered result to the identical canonical terminal outcome.
+func TestFactoryImpl_ConcurrentDuplicateCompletionResolvesExactlyOnceForDirectAndChildDispatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		deliver  func(workers.WorkstationDispatchRequest) workers.WorkstationDispatchResult
+		accepted factory.DispatchResultOutcome
+		want     dispatchplanning.TerminalResultOutcome
+	}{
+		{"success", completedWorkersResult, factory.DispatchResultOutcomeSuccess, dispatchplanning.TerminalResultOutcomeSuccess},
+		{"failure", failedWorkersResult, factory.DispatchResultOutcomeFailure, dispatchplanning.TerminalResultOutcomeFailure},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			direct := concurrentDirectDispatchCompletion(t, tc.deliver, tc.accepted)
+			child := concurrentChildDispatchCompletion(t, tc.deliver, tc.accepted)
+			if direct != tc.want || child != tc.want || direct != child {
+				t.Fatalf(
+					"terminal outcomes under duplicate completion = direct:%q child:%q, want both %q",
+					direct, child, tc.want,
+				)
+			}
+		})
+	}
+}
+
+// concurrentDirectDispatchCompletion parks a Runtime-root PlanDispatch inside
+// the Workers boundary, races duplicate terminal acceptance against it, then
+// releases the real Workers callback as a late duplicate.
+func concurrentDirectDispatchCompletion(
+	t *testing.T,
+	deliver func(workers.WorkstationDispatchRequest) workers.WorkstationDispatchResult,
+	accepted factory.DispatchResultOutcome,
+) dispatchplanning.TerminalResultOutcome {
+	t.Helper()
+	boundary := newControlledWorkstationBoundary()
+	ledger := &recordingfixtures.ScriptedRuntimeLedger{GenerationID: "concurrent-direct-completion"}
+	runtime, err := newTestFactory(
+		withNet(buildSimpleNetWithFailureArc()),
+		withInlineDispatch(),
+		withWorkerService(boundary),
+		withFactoryEventHistory(ledger),
+		withLogger(logging.NoopLogger{}),
+	)
+	requireNoRootErr(t, err, "New")
+	impl := runtime.(*factoryImpl)
+	impl.state = interfaces.FactoryStateRunning
+
+	plan := factory.PlanDispatchRequest{
+		DispatchID:      "concurrent-direct-" + t.Name(),
+		CorrelationID:   "concurrent-direct-corr-" + t.Name(),
+		WorkIDs:         []string{"concurrent-direct-work"},
+		WorkstationName: "t-process",
+		WorkerType:      "mock",
+		ReplayKey:       "t-process/concurrent-direct-trace/concurrent-direct-work",
+	}
+	planErrCh := make(chan error, 1)
+	go func() {
+		_, planErr := impl.PlanDispatch(t.Context(), plan)
+		planErrCh <- planErr
+	}()
+
+	request := awaitCanonicalWorkersRequest(t, boundary.requests)
+	raceDuplicateTerminalAcceptance(t, impl, factory.AcceptDispatchResultRequest{
+		DispatchID:    request.Execution.Dispatch.DispatchID,
+		CorrelationID: plan.CorrelationID,
+		WorkID:        plan.WorkIDs[0],
+		ResultOutcome: accepted,
+	})
+	boundary.results <- deliver(request)
+	requireNoRootErr(t, <-planErrCh, "PlanDispatch")
+
+	requireSingleCanonicalDispatchRecord(t, impl, ledger)
+	return recordedTerminalOutcome(t, impl, plan.DispatchID)
+}
+
+// concurrentChildDispatchCompletion runs the same duplicate-completion race
+// against a scheduler-originated Factory child dispatch.
+func concurrentChildDispatchCompletion(
+	t *testing.T,
+	deliver func(workers.WorkstationDispatchRequest) workers.WorkstationDispatchResult,
+	accepted factory.DispatchResultOutcome,
+) dispatchplanning.TerminalResultOutcome {
+	t.Helper()
+	boundary := newControlledWorkstationBoundary()
+	ledger := &recordingfixtures.ScriptedRuntimeLedger{GenerationID: "concurrent-child-completion"}
+	runtime, err := newTestFactory(
+		withNet(buildSimpleNetWithFailureArc()),
+		withWorkerService(boundary),
+		withFactoryEventHistory(ledger),
+		withLogger(logging.NoopLogger{}),
+	)
+	requireNoRootErr(t, err, "New")
+	impl := runtime.(*factoryImpl)
+	workID := "concurrent-child-work-" + t.Name()
+	if _, err := submitWorkRequests(t.Context(), runtime, []work.SubmitRequest{{
+		WorkID: workID, WorkTypeID: "task", TraceID: "concurrent-child-trace-" + t.Name(),
+	}}); err != nil {
+		t.Fatalf("SubmitWorkRequest: %v", err)
+	}
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- runtime.Run(t.Context()) }()
+
+	request := awaitCanonicalWorkersRequest(t, boundary.requests)
+	raceDuplicateTerminalAcceptance(t, impl, factory.AcceptDispatchResultRequest{
+		DispatchID:    request.Execution.Dispatch.DispatchID,
+		CorrelationID: request.Execution.Dispatch.DispatchID,
+		WorkID:        workID,
+		ResultOutcome: accepted,
+	})
+	boundary.results <- deliver(request)
+	if err := <-runDone; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	requireSingleCanonicalDispatchRecord(t, impl, ledger)
+	return recordedTerminalOutcome(t, impl, request.Execution.Dispatch.DispatchID)
+}
+
+// raceDuplicateTerminalAcceptance releases concurrentTerminalCallers duplicate
+// AcceptDispatchResult callers together and requires exactly one accepted
+// retirement with every other caller deterministically DUPLICATE_IDEMPOTENT.
+func raceDuplicateTerminalAcceptance(t *testing.T, impl *factoryImpl, terminal factory.AcceptDispatchResultRequest) {
+	t.Helper()
+	const concurrentTerminalCallers = 8
+	var retired, duplicate, failed atomic.Int32
+	var start, done sync.WaitGroup
+	start.Add(1)
+	done.Add(concurrentTerminalCallers)
+	for range concurrentTerminalCallers {
+		go func() {
+			defer done.Done()
+			start.Wait()
+			result, err := impl.AcceptDispatchResult(t.Context(), terminal)
+			switch {
+			case err != nil:
+				failed.Add(1)
+			case result.Outcome == factory.DispatchPlanOutcomeRetired:
+				retired.Add(1)
+			case result.Outcome == factory.DispatchPlanOutcomeDuplicateIdempotent:
+				duplicate.Add(1)
+			}
+		}()
+	}
+	start.Done()
+	done.Wait()
+
+	if failed.Load() != 0 || retired.Load() != 1 || duplicate.Load() != concurrentTerminalCallers-1 {
+		t.Fatalf(
+			"duplicate terminal acceptance outcomes = retired:%d duplicate:%d errors:%d, want 1, %d and 0",
+			retired.Load(), duplicate.Load(), failed.Load(), concurrentTerminalCallers-1,
+		)
+	}
+}
+
+// requireSingleCanonicalDispatchRecord requires the raced dispatch to have
+// recorded exactly one Worker Session association and at most one canonical
+// workstation response, and to leave nothing in flight -- so a duplicate
+// acceptance that leaked a second terminal fact or restarted the dispatch would
+// be observable in recorded history rather than only in planner bookkeeping.
+func requireSingleCanonicalDispatchRecord(
+	t *testing.T,
+	impl *factoryImpl,
+	ledger *recordingfixtures.ScriptedRuntimeLedger,
+) {
+	t.Helper()
+	if associations := ledger.CallCount("RecordDispatchWorkerSessionAssociation"); associations != 1 {
+		t.Fatalf("dispatch/Worker Session association count = %d, want exactly 1", associations)
+	}
+	if responses := ledger.CallCount("RecordWorkstationResponse"); responses > 1 {
+		t.Fatalf("canonical workstation response count = %d, want at most 1", responses)
+	}
+	observed, err := impl.Observe(t.Context(), factory.ObserveRequest{Scope: factory.ObservationScopeFull})
+	requireNoRootErr(t, err, "Observe")
+	if observed.Observation.Progress.InFlightDispatchCount != 0 {
+		t.Fatalf(
+			"in-flight dispatch count after terminal acceptance = %d, want 0",
+			observed.Observation.Progress.InFlightDispatchCount,
+		)
 	}
 }

--- a/pkg/services/recordings/internal/canonical_recording_lifecycle_test.go
+++ b/pkg/services/recordings/internal/canonical_recording_lifecycle_test.go
@@ -679,3 +679,135 @@ type staticRecordingClock struct {
 }
 
 func (clock staticRecordingClock) Now() time.Time { return clock.at }
+
+// TestRecordingScopeReplayIsEquivalentAndIsolatedUnderConcurrentAccess proves
+// canonical replay stays equivalent to the retained projection of the same
+// finalized recording scope, and that equivalence survives concurrent access:
+// several replays of two distinct scopes run at once and each one completes
+// with exactly its own scope's retained world state, never another scope's.
+func TestRecordingScopeReplayIsEquivalentAndIsolatedUnderConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	root := newScopedQueryRoot(t)
+	scopes := []finalizedReplayScope{
+		newFinalizedReplayScope(t, root, "concurrent-replay-a"),
+		newFinalizedReplayScope(t, root, "concurrent-replay-b"),
+	}
+
+	var wait sync.WaitGroup
+	errs := make(chan error, len(scopes)*8)
+	for _, scope := range scopes {
+		for range 8 {
+			wait.Add(1)
+			go func() {
+				defer wait.Done()
+				replayed, err := replayScopeWorldState(root, scope)
+				if err != nil {
+					errs <- err
+					return
+				}
+				if !reflect.DeepEqual(replayed, scope.retained) {
+					errs <- errors.New("concurrent replay of " + scope.eventScope.FactorySessionID +
+						" diverged from its retained projection")
+				}
+			}()
+		}
+	}
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+	if reflect.DeepEqual(scopes[0].retained, scopes[1].retained) {
+		t.Fatal("the two recording scopes projected identical world states, so isolation is unobservable")
+	}
+}
+
+type finalizedReplayScope struct {
+	ref        recordings.RecordingScopeRef
+	eventScope recordings.CanonicalEventScope
+	events     []recordings.CanonicalEvent
+	retained   recordings.WorldStateView
+}
+
+// newFinalizedReplayScope records two canonical facts for one Factory Session,
+// finalizes the recording, opens its scope, and captures the retained
+// projection every concurrent replay of that scope must reproduce.
+func newFinalizedReplayScope(t *testing.T, root recordings.Service, sessionID string) finalizedReplayScope {
+	t.Helper()
+	eventScope := recordings.CanonicalEventScope{FactorySessionID: sessionID}
+	bound, err := root.BindRecording(recordings.BindRecordingRequest{
+		RecordingID: recordings.RecordingID("recording-" + sessionID),
+		Artifact:    recordings.RecordingArtifactReference("recording://" + sessionID),
+		Scope:       eventScope,
+	})
+	if err != nil {
+		t.Fatalf("BindRecording(%s): %v", sessionID, err)
+	}
+	events := []recordings.CanonicalEvent{
+		scopedScopeEvent(sessionID+"-event-1", 0, eventScope),
+		scopedScopeEvent(sessionID+"-event-2", 1, eventScope),
+	}
+	for index, event := range events {
+		if _, err := root.RecordRecordingEvent(recordings.RecordRecordingEventRequest{
+			RecordingID: bound.Status.RecordingID, Event: event,
+		}); err != nil {
+			t.Fatalf("RecordRecordingEvent(%s)[%d]: %v", sessionID, index, err)
+		}
+	}
+	if _, err := root.FinishRecording(recordings.FinishRecordingRequest{
+		RecordingID: bound.Status.RecordingID,
+		FinishedAt:  time.Unix(1_700_000_100, 0).UTC(),
+	}); err != nil {
+		t.Fatalf("FinishRecording(%s): %v", sessionID, err)
+	}
+	opened, err := root.OpenRecordingScope(context.Background(), recordings.OpenRecordingScopeRequest{
+		RecordingID: bound.Status.RecordingID, Scope: eventScope,
+	})
+	if err != nil {
+		t.Fatalf("OpenRecordingScope(%s): %v", sessionID, err)
+	}
+	retained, err := root.ReconstructRecordingScope(context.Background(), recordings.ReconstructRecordingScopeRequest{
+		Scope: opened.Scope, SelectedTick: 4,
+	})
+	if err != nil {
+		t.Fatalf("ReconstructRecordingScope(%s): %v", sessionID, err)
+	}
+	if retained.WorldState.Scope != eventScope {
+		t.Fatalf("retained projection scope = %#v, want %#v", retained.WorldState.Scope, eventScope)
+	}
+	return finalizedReplayScope{
+		ref: opened.Scope, eventScope: eventScope, events: events, retained: retained.WorldState,
+	}
+}
+
+// replayScopeWorldState drives one complete canonical replay of a finalized
+// scope and returns the world state its terminal observation reports.
+func replayScopeWorldState(
+	root recordings.Service,
+	scope finalizedReplayScope,
+) (recordings.WorldStateView, error) {
+	planned, err := root.CreateReplayPlanScope(context.Background(), recordings.CreateReplayPlanScopeRequest{
+		Scope:         scope.ref,
+		SchemaVersion: recordings.ReplayPlanSchemaV1,
+		Timing:        recordings.ReplayTimingOrderOnly,
+		SelectedTick:  4,
+	})
+	if err != nil {
+		return recordings.WorldStateView{}, err
+	}
+	var observed recordings.ObserveReplayScopeResult
+	for range scope.events {
+		observed, err = root.ObserveReplayScope(context.Background(), recordings.ObserveReplayScopeRequest{
+			Scope: scope.ref, Plan: planned.Plan.Handle,
+		})
+		if err != nil {
+			return recordings.WorldStateView{}, err
+		}
+	}
+	if observed.Observation.Kind != recordings.ReplayCompleted {
+		return recordings.WorldStateView{}, errors.New("replay of " + scope.eventScope.FactorySessionID +
+			" did not complete: " + string(observed.Observation.Kind))
+	}
+	return observed.Observation.WorldState, nil
+}

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/detached_test.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/detached_test.go
@@ -3,6 +3,7 @@ package agentrun
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -342,6 +343,48 @@ func TestExecuteDetachedReturnsLastRunnerTurnWithHarnessError(t *testing.T) {
 	if result.Diagnostics == nil ||
 		result.Diagnostics.Metadata[DiagnosticExecutionBehavior] != ExecutionBehaviorAgentRun {
 		t.Fatalf("ExecuteDetached() Diagnostics = %+v, want agent-run execution behavior on the failure result", result.Diagnostics)
+	}
+}
+
+// TestExecuteDetachedTimeoutSurfacesAgentRunTimeoutClass characterizes the
+// typed timeout a detached agent-run caller observes. failure_test.go already
+// covers failureClassForError as a pure mapping, but nothing asserted that a
+// deadline reached inside the agent loop travels out of ExecuteDetached still
+// classifiable as an agent-run timeout with the last provider turn intact --
+// which is exactly what the detached caller reports as its terminal failure.
+func TestExecuteDetachedTimeoutSurfacesAgentRunTimeoutClass(t *testing.T) {
+	t.Parallel()
+
+	timeoutErr := fmt.Errorf("agent loop exceeded its budget: %w", context.DeadlineExceeded)
+	runner := &detachedRunnerStub{results: []workerexecution.RunnerExecutionResult{{
+		Content: "last turn before the deadline",
+		Outcome: workerexecution.WorkOutcome("INCOMPLETE"),
+	}}}
+
+	result, err := ExecuteDetached(
+		context.Background(),
+		&inferencingHarnessStub{
+			result: HarnessResult{FinalText: "harness text"},
+			err:    timeoutErr,
+		},
+		runner,
+		DetachedRequest{Attempt: detachedAttempt()},
+	)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("ExecuteDetached() error = %v, want a deadline-classifiable agent-run failure", err)
+	}
+	if result.Content != "last turn before the deadline" {
+		t.Fatalf("ExecuteDetached() Content = %q, want the last provider turn preserved through the timeout", result.Content)
+	}
+	if got := failureClassForError(err); got != FailureClassTimeout {
+		t.Fatalf("failureClassForError(ExecuteDetached error) = %q, want %q", got, FailureClassTimeout)
+	}
+	metadata := failureMetadataForError(err)
+	if metadata == nil || metadata.Type != workerexecution.WorkFailureTypeTimeout {
+		t.Fatalf("failureMetadataForError(ExecuteDetached error) = %#v, want a timeout failure type", metadata)
+	}
+	if got := agentRunFailureDiagnostics(err)[DiagnosticFailureClass]; got != FailureClassTimeout {
+		t.Fatalf("agent-run diagnostics failure class = %q, want %q", got, FailureClassTimeout)
 	}
 }
 

--- a/pkg/wire/session_runtime_providers_test.go
+++ b/pkg/wire/session_runtime_providers_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	events "github.com/portpowered/infinite-you/pkg/services/events"
 	eventswire "github.com/portpowered/infinite-you/pkg/services/events/wire"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
@@ -334,6 +335,67 @@ func TestProcessCloseContinuesThroughEveryLifecycleOwnerAfterFailure(t *testing.
 		t.Fatalf("Process.Close() closer calls = %v, want every process lifecycle owner in order", closed)
 	}
 }
+
+// TestProvideApplicationProcessLifecycle_ClosesProvidersAndEventsExactlyOnceAfterAFailure
+// proves the failure-continuation contract above holds for the lifecycle Wire
+// actually composes, not only for a hand-assembled composite. The two owners
+// that retain real process resources -- Providers (executable/session
+// teardown) and the singular Events root -- must each be reached exactly once
+// per Close, in composition order, and an earlier owner's teardown failure must
+// neither skip nor mask the later one.
+func TestProvideApplicationProcessLifecycle_ClosesProvidersAndEventsExactlyOnceAfterAFailure(t *testing.T) {
+	t.Parallel()
+
+	providersCloseErr := errors.New("close Providers")
+	eventsCloseErr := errors.New("close Events")
+	var closed []string
+	providersStub := &closingProvidersService{
+		onClose: func() error { closed = append(closed, "providers"); return providersCloseErr },
+	}
+	eventsStub := &closingEventsService{
+		onClose: func() error { closed = append(closed, "events"); return eventsCloseErr },
+	}
+
+	lifecycle, err := provideApplicationProcessLifecycle(providersStub, eventsStub, nil, &localWorkerSessionsBoundary{})
+	if err != nil {
+		t.Fatalf("provideApplicationProcessLifecycle() error = %v", err)
+	}
+
+	closeErr := lifecycle.Close(context.Background())
+	for _, expected := range []error{providersCloseErr, eventsCloseErr} {
+		if !errors.Is(closeErr, expected) {
+			t.Fatalf("composed ProcessLifecycle.Close() error = %v, want it to retain %v", closeErr, expected)
+		}
+	}
+	if !slices.Equal(closed, []string{"providers", "events"}) {
+		t.Fatalf(
+			"composed ProcessLifecycle.Close() closer calls = %v, want Providers then Events exactly once each",
+			closed,
+		)
+	}
+}
+
+// closingProvidersService is a providers.Service stand-in (embedding the
+// interface as a permanently nil value) that implements only the process
+// teardown method provideApplicationProcessLifecycle requires, so its Close is
+// observable in the composed lifecycle.
+type closingProvidersService struct {
+	providers.Service
+
+	onClose func() error
+}
+
+func (service *closingProvidersService) Close(context.Context) error { return service.onClose() }
+
+// closingEventsService is the equivalent events.Service stand-in for the
+// singular Events root's process teardown.
+type closingEventsService struct {
+	events.Service
+
+	onClose func() error
+}
+
+func (service *closingEventsService) Close(context.Context) error { return service.onClose() }
 
 // TestProvideApplicationProcessLifecycle_RequiresProvidersLifecycle proves a
 // providers.Service that does not implement providers.Lifecycle is rejected

--- a/tests/functional/events/response_events/concurrent_session_isolation_test.go
+++ b/tests/functional/events/response_events/concurrent_session_isolation_test.go
@@ -1,0 +1,593 @@
+package response_events
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	concurrentIsolationTimeout = 30 * time.Second
+
+	concurrentIsolationPromptFirst  = "isolated-response-events-first-prompt"
+	concurrentIsolationPromptSecond = "isolated-response-events-second-prompt"
+	concurrentIsolationResultFirst  = "first session ordered response COMPLETE"
+	concurrentIsolationResultSecond = "second session ordered response COMPLETE"
+)
+
+// TestConcurrentFactorySessionResponseEventStreamsStayIsolatedAndResumeFromCursor
+// runs two Factory Sessions concurrently against one public HTTP server, each
+// with its own open Response Event SSE stream, and proves three observable
+// contracts at the public boundary:
+//
+//   - typed ordered payloads: each stream decodes its own MESSAGE payload union
+//     before its terminal RUN payload union, in emission order;
+//   - concurrent-session isolation: neither stream carries the other session's
+//     identity, event identities, dispatch identity, or message text;
+//   - reconnect/replay: reopening one session's stream from an acknowledged
+//     cursor replays exactly the retained suffix, in order, with no duplicate.
+func TestConcurrentFactorySessionResponseEventStreamsStayIsolatedAndResumeFromCursor(t *testing.T) {
+	t.Parallel()
+
+	runner := newPromptKeyedCodexRunner(map[string]string{
+		concurrentIsolationPromptFirst:  concurrentIsolationResultFirst,
+		concurrentIsolationPromptSecond: concurrentIsolationResultSecond,
+	})
+	firstDir := scaffoldConcurrentIsolationFactory(t, concurrentIsolationPromptFirst)
+	secondDir := scaffoldConcurrentIsolationFactory(t, concurrentIsolationPromptSecond)
+
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                firstDir,
+		WaitForServiceModeRuntime: true,
+		Edges:                     serviceedges.Edges{ProviderCommandRunner: runner},
+	})
+	t.Cleanup(func() { server.Stop(t) })
+	baseURL := server.URL()
+
+	// The default session is addressed through its public alias while its events
+	// carry the canonical identity, so the alias route is also under test here.
+	firstSessionID := factorysessions.DefaultSessionID
+	firstCanonicalID := support.GetDefaultSession(t, baseURL).Id
+	if strings.TrimSpace(firstCanonicalID) == "" {
+		t.Fatal("default Factory Session reported no canonical identity")
+	}
+	opened := support.OpenFactorySessionAt(t, baseURL, secondDir)
+	if opened.Session == nil || strings.TrimSpace(opened.Session.Id) == "" {
+		t.Fatalf("opened Factory Session = %#v, want a second session identity", opened)
+	}
+	secondSessionID := opened.Session.Id
+	if secondSessionID == firstCanonicalID {
+		t.Fatalf("second Factory Session id = %q, want an identity distinct from the default session", secondSessionID)
+	}
+	t.Cleanup(func() { support.CloseFactorySessionAt(t, baseURL, secondSessionID) })
+
+	firstStream := support.OpenFactoryResponseEventStreamAt(
+		t,
+		support.SessionResponseEventsURL(baseURL, firstSessionID),
+	)
+	t.Cleanup(firstStream.Close)
+	secondStream := support.OpenFactoryResponseEventStreamAt(
+		t,
+		support.SessionResponseEventsURL(baseURL, secondSessionID),
+	)
+	t.Cleanup(secondStream.Close)
+
+	invocations := startConcurrentIsolationInvocations(t, baseURL, map[string]string{
+		firstSessionID:  concurrentIsolationPromptFirst,
+		secondSessionID: concurrentIsolationPromptSecond,
+	})
+
+	firstFrames := collectConcurrentIsolationFrames(
+		t,
+		firstStream,
+		concurrentIsolationResultFirst,
+		concurrentIsolationTimeout,
+	)
+	secondFrames := collectConcurrentIsolationFrames(
+		t,
+		secondStream,
+		concurrentIsolationResultSecond,
+		concurrentIsolationTimeout,
+	)
+
+	assertConcurrentIsolationInvocationCompleted(
+		t,
+		awaitConcurrentIsolationInvocation(t, invocations[firstSessionID]),
+		concurrentIsolationResultFirst,
+	)
+	assertConcurrentIsolationInvocationCompleted(
+		t,
+		awaitConcurrentIsolationInvocation(t, invocations[secondSessionID]),
+		concurrentIsolationResultSecond,
+	)
+
+	assertSessionScopedOrderedTypedPayloads(
+		t,
+		firstCanonicalID,
+		responseEventsFromFrames(firstFrames),
+		concurrentIsolationResultFirst,
+		concurrentIsolationResultSecond,
+	)
+	assertSessionScopedOrderedTypedPayloads(
+		t,
+		secondSessionID,
+		responseEventsFromFrames(secondFrames),
+		concurrentIsolationResultSecond,
+		concurrentIsolationResultFirst,
+	)
+	assertDisjointResponseEventCorrelation(t, firstFrames, secondFrames)
+
+	if calls := runner.callCount(); calls != 2 {
+		t.Fatalf("provider dispatches = %d, want exactly one per concurrent Factory Session", calls)
+	}
+
+	assertResponseEventStreamResumesFromCursor(t, baseURL, firstSessionID, firstFrames)
+}
+
+// assertResponseEventStreamResumesFromCursor reconnects one session's stream
+// from a mid-stream acknowledged cursor and requires the retained suffix to
+// arrive in order with no duplicate of the acknowledged prefix.
+func assertResponseEventStreamResumesFromCursor(
+	t *testing.T,
+	baseURL string,
+	sessionID string,
+	observed []support.FactoryResponseEventFrame,
+) {
+	t.Helper()
+
+	if len(observed) < 2 {
+		t.Fatalf("observed Response Event frames = %d, want at least 2 to resume mid-stream", len(observed))
+	}
+	cursor := observed[0].Event.Sequence
+	retained := retainedFactoryResponseEventsWithoutGaps(
+		support.GetFactoryResponseEventsAt(t, baseURL, sessionID),
+	)
+	wantSuffix := make([]factoryapi.FactoryResponseEvent, 0, len(retained))
+	for _, event := range retained {
+		if event.Sequence > cursor {
+			wantSuffix = append(wantSuffix, event)
+		}
+	}
+	if len(wantSuffix) == 0 {
+		t.Fatalf("retained Response Events after cursor %d = 0, want a replayable suffix", cursor)
+	}
+	if len(wantSuffix) >= len(retained) {
+		t.Fatalf(
+			"cursor %d excludes no retained Response Event (%d of %d), so the resume would not be observable",
+			cursor,
+			len(wantSuffix),
+			len(retained),
+		)
+	}
+
+	resumed := support.OpenFactoryResponseEventStreamAt(
+		t,
+		support.SessionResponseEventsURLWithAfterSequence(baseURL, sessionID, cursor),
+	)
+	t.Cleanup(resumed.Close)
+	frames := collectResponseEventStreamUntilCount(t, resumed, len(wantSuffix), concurrentIsolationTimeout)
+	for _, frame := range frames {
+		if frame.Event.Sequence <= cursor {
+			t.Fatalf(
+				"resumed stream replayed acknowledged event %q at sequence %d, want only sequences after %d",
+				frame.Event.EventId,
+				frame.Event.Sequence,
+				cursor,
+			)
+		}
+	}
+	assertResponseEventFramesMatchRetainedCatchUp(t, wantSuffix, frames)
+	assertResponseEventFramesAscendingSequence(t, frames)
+}
+
+// collectConcurrentIsolationFrames reads one session's stream until the
+// assistant MESSAGE carrying that session's text arrives, which is the last
+// published event of the dispatch. Collection is content-driven so it neither
+// hardcodes an event count nor waits out an idle interval.
+func collectConcurrentIsolationFrames(
+	t *testing.T,
+	stream *support.FactoryResponseEventStream,
+	wantText string,
+	timeout time.Duration,
+) []support.FactoryResponseEventFrame {
+	t.Helper()
+
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	var collected []support.FactoryResponseEventFrame
+	for {
+		select {
+		case <-deadline.C:
+			t.Fatalf(
+				"timed out waiting for the MESSAGE Response Event containing %q; got %d frames within %s",
+				wantText,
+				len(collected),
+				timeout,
+			)
+			return collected
+		default:
+			frame, ok := stream.TryNextFrame(50 * time.Millisecond)
+			if !ok {
+				continue
+			}
+			collected = append(collected, frame)
+			if responseEventTerminalOutcomeFor(frame.Event) == responseEventFailed {
+				t.Fatalf(
+					"session stream reported a failed %s Response Event in phase %q",
+					frame.Event.Kind,
+					frame.Event.Phase,
+				)
+			}
+			if strings.Contains(concurrentIsolationMessageText(frame.Event), wantText) {
+				return collected
+			}
+		}
+	}
+}
+
+// assertSessionScopedOrderedTypedPayloads decodes the discriminated payload
+// unions off one session's stream and requires the RUN lifecycle payloads and
+// the assistant MESSAGE payload to arrive in their published order, carrying
+// only this session's identity and text.
+func assertSessionScopedOrderedTypedPayloads(
+	t *testing.T,
+	sessionID string,
+	events []factoryapi.FactoryResponseEvent,
+	wantText string,
+	foreignText string,
+) {
+	t.Helper()
+
+	if len(events) == 0 {
+		t.Fatalf("session %q delivered zero Response Events", sessionID)
+	}
+	assertResponseEventsAscendingSequence(t, events)
+
+	messageIndex, runStartedIndex, runCompletedIndex := -1, -1, -1
+	for index, event := range events {
+		if event.FactorySessionId != sessionID {
+			t.Fatalf(
+				"Response Event %q on session %q stream reports factorySessionId %q",
+				event.EventId,
+				sessionID,
+				event.FactorySessionId,
+			)
+		}
+		text := concurrentIsolationMessageText(event)
+		if text != "" && strings.Contains(text, foreignText) {
+			t.Fatalf(
+				"session %q Response Event %q carried the other session's message text %q",
+				sessionID,
+				event.EventId,
+				text,
+			)
+		}
+		if messageIndex < 0 && text != "" && strings.Contains(text, wantText) {
+			messageIndex = index
+		}
+		if event.Kind != factoryapi.FactoryResponseEventKindRun {
+			continue
+		}
+		payload, err := event.Payload.AsFactoryResponseEventRunPayload()
+		if err != nil {
+			t.Fatalf("session %q RUN payload at index %d does not decode: %v", sessionID, index, err)
+		}
+		if payload.Status == nil || strings.TrimSpace(*payload.Status) == "" {
+			t.Fatalf("session %q RUN payload at index %d = %#v, want a status", sessionID, index, payload)
+		}
+		switch event.Phase {
+		case factoryapi.FactoryResponseEventPhaseStarted:
+			if runStartedIndex < 0 {
+				runStartedIndex = index
+			}
+		case factoryapi.FactoryResponseEventPhaseCompleted:
+			if runCompletedIndex < 0 {
+				runCompletedIndex = index
+			}
+		}
+	}
+	if messageIndex < 0 {
+		t.Fatalf("session %q delivered no MESSAGE payload containing %q", sessionID, wantText)
+	}
+	if runStartedIndex < 0 || runCompletedIndex < 0 {
+		t.Fatalf(
+			"session %q RUN lifecycle indexes = started %d, completed %d, want both published",
+			sessionID,
+			runStartedIndex,
+			runCompletedIndex,
+		)
+	}
+	if runStartedIndex >= runCompletedIndex {
+		t.Fatalf(
+			"session %q RUN/STARTED at index %d does not precede RUN/COMPLETED at index %d",
+			sessionID,
+			runStartedIndex,
+			runCompletedIndex,
+		)
+	}
+	if runStartedIndex >= messageIndex {
+		t.Fatalf(
+			"session %q RUN/STARTED at index %d does not precede the assistant MESSAGE at index %d",
+			sessionID,
+			runStartedIndex,
+			messageIndex,
+		)
+	}
+}
+
+// concurrentIsolationMessageText returns the decoded assistant text for MESSAGE
+// events and the empty string for every other discriminated payload variant.
+func concurrentIsolationMessageText(event factoryapi.FactoryResponseEvent) string {
+	if event.Kind != factoryapi.FactoryResponseEventKindMessage {
+		return ""
+	}
+	if event.Phase == factoryapi.FactoryResponseEventPhaseDelta {
+		payload, err := event.Payload.AsFactoryResponseEventMessageDeltaPayload()
+		if err != nil || payload.TextDelta == nil {
+			return ""
+		}
+		return *payload.TextDelta
+	}
+	payload, err := event.Payload.AsFactoryResponseEventMessagePayload()
+	if err != nil {
+		return ""
+	}
+	for _, block := range payload.ContentBlocks {
+		text, err := block.AsFactoryResponseEventTextContentBlock()
+		if err == nil && text.Text != "" {
+			return text.Text
+		}
+	}
+	return ""
+}
+
+func assertDisjointResponseEventCorrelation(
+	t *testing.T,
+	first []support.FactoryResponseEventFrame,
+	second []support.FactoryResponseEventFrame,
+) {
+	t.Helper()
+
+	eventIDs := make(map[string]struct{}, len(first))
+	dispatchIDs := make(map[string]struct{}, len(first))
+	for _, frame := range first {
+		eventIDs[frame.Event.EventId] = struct{}{}
+		if frame.Event.DispatchId != nil && strings.TrimSpace(*frame.Event.DispatchId) != "" {
+			dispatchIDs[*frame.Event.DispatchId] = struct{}{}
+		}
+	}
+	if len(dispatchIDs) == 0 {
+		t.Fatal("first session Response Events carried no dispatch correlation")
+	}
+	for _, frame := range second {
+		if _, shared := eventIDs[frame.Event.EventId]; shared {
+			t.Fatalf("Response Event id %q was delivered on both concurrent session streams", frame.Event.EventId)
+		}
+		if frame.Event.DispatchId == nil {
+			continue
+		}
+		if _, shared := dispatchIDs[*frame.Event.DispatchId]; shared {
+			t.Fatalf(
+				"dispatch %q appeared on both concurrent session streams",
+				*frame.Event.DispatchId,
+			)
+		}
+	}
+}
+
+type concurrentIsolationInvocation struct {
+	response factoryapi.InvocationResponse
+	err      error
+}
+
+func startConcurrentIsolationInvocations(
+	t *testing.T,
+	baseURL string,
+	promptsBySession map[string]string,
+) map[string]chan concurrentIsolationInvocation {
+	t.Helper()
+
+	results := make(map[string]chan concurrentIsolationInvocation, len(promptsBySession))
+	for sessionID, prompt := range promptsBySession {
+		done := make(chan concurrentIsolationInvocation, 1)
+		results[sessionID] = done
+		go func(sessionID, prompt string, done chan concurrentIsolationInvocation) {
+			response, err := postConcurrentIsolationInvocation(t.Context(), baseURL, sessionID, prompt)
+			done <- concurrentIsolationInvocation{response: response, err: err}
+		}(sessionID, prompt, done)
+	}
+	return results
+}
+
+func awaitConcurrentIsolationInvocation(
+	t *testing.T,
+	results <-chan concurrentIsolationInvocation,
+) concurrentIsolationInvocation {
+	t.Helper()
+
+	select {
+	case result := <-results:
+		return result
+	case <-time.After(concurrentIsolationTimeout):
+		t.Fatal("timed out waiting for a concurrent Factory Session invocation")
+		return concurrentIsolationInvocation{}
+	}
+}
+
+func assertConcurrentIsolationInvocationCompleted(
+	t *testing.T,
+	result concurrentIsolationInvocation,
+	wantText string,
+) {
+	t.Helper()
+
+	if result.err != nil {
+		t.Fatalf("concurrent Factory Session invocation error = %v", result.err)
+	}
+	if result.response.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("concurrent invocation response = %#v, want COMPLETED", result.response)
+	}
+	if result.response.PrimaryResult == nil || len(*result.response.PrimaryResult) == 0 {
+		t.Fatalf("concurrent invocation primary result = %#v, want session-specific content", result.response.PrimaryResult)
+	}
+	part, err := (*result.response.PrimaryResult)[0].AsWorkTextContentPart()
+	if err != nil {
+		t.Fatalf("concurrent invocation primary result part does not decode as text: %v", err)
+	}
+	if !strings.Contains(part.Text, wantText) {
+		t.Fatalf("concurrent invocation primary result text = %q, want it to contain %q", part.Text, wantText)
+	}
+}
+
+func postConcurrentIsolationInvocation(
+	ctx context.Context,
+	baseURL string,
+	sessionID string,
+	prompt string,
+) (factoryapi.InvocationResponse, error) {
+	var part factoryapi.WorkContentPart
+	if err := part.FromWorkTextContentPart(factoryapi.WorkTextContentPart{
+		Type: factoryapi.WorkContentPartTypeText,
+		Text: prompt,
+	}); err != nil {
+		return factoryapi.InvocationResponse{}, err
+	}
+	sourceKind := factoryapi.InvocationInputSourceKindText
+	content := factoryapi.WorkContent{part}
+	payload, err := json.Marshal(factoryapi.InvocationRequest{
+		SourceKind: &sourceKind,
+		Content:    &content,
+	})
+	if err != nil {
+		return factoryapi.InvocationResponse{}, err
+	}
+	endpoint := strings.TrimSuffix(baseURL, "/") + "/factory-sessions/" + url.PathEscape(sessionID) + "/invocations"
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return factoryapi.InvocationResponse{}, err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return factoryapi.InvocationResponse{}, err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return factoryapi.InvocationResponse{}, err
+	}
+	if response.StatusCode != http.StatusOK {
+		return factoryapi.InvocationResponse{}, fmt.Errorf(
+			"POST %s status = %d: %s",
+			endpoint,
+			response.StatusCode,
+			strings.TrimSpace(string(body)),
+		)
+	}
+	var decoded factoryapi.InvocationResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return factoryapi.InvocationResponse{}, err
+	}
+	return decoded, nil
+}
+
+// scaffoldConcurrentIsolationFactory authors one Factory whose workstation
+// prompt carries a session-specific marker, so the shared provider effect can
+// answer each concurrent dispatch with that session's own output.
+func scaffoldConcurrentIsolationFactory(t *testing.T, promptMarker string) string {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, concurrentIsolationFactoryConfig())
+	support.WriteWorkstationConfig(
+		t,
+		dir,
+		"process",
+		"---\ntype: MODEL_WORKSTATION\n---\n"+promptMarker+"\n",
+	)
+	support.WriteAgentConfig(
+		t,
+		dir,
+		"worker-a",
+		support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"),
+	)
+	return dir
+}
+
+func concurrentIsolationFactoryConfig() map[string]any {
+	return map[string]any{
+		"name": "concurrent-response-event-isolation",
+		"workTypes": []map[string]any{{
+			"name":             "task",
+			"handlingBehavior": []string{"DEFAULT"},
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]string{{"name": "worker-a"}},
+		"workstations": []map[string]any{{
+			"name":      "process",
+			"worker":    "worker-a",
+			"inputs":    []map[string]string{{"workType": "task", "state": "init"}},
+			"outputs":   []map[string]string{{"workType": "task", "state": "complete"}},
+			"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
+		}},
+	}
+}
+
+// promptKeyedCodexRunner answers each concurrent provider dispatch from the
+// prompt it actually received, so a stream that carried another session's text
+// would have to come from a real cross-session leak rather than from shared
+// fixture output.
+type promptKeyedCodexRunner struct {
+	mu        sync.Mutex
+	responses map[string]string
+	calls     int
+}
+
+func newPromptKeyedCodexRunner(responses map[string]string) *promptKeyedCodexRunner {
+	return &promptKeyedCodexRunner{responses: responses}
+}
+
+func (r *promptKeyedCodexRunner) Run(
+	_ context.Context,
+	request platformprocess.CommandRequest,
+) (platformprocess.CommandResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.calls++
+	observed := string(request.Stdin) + "\n" + strings.Join(request.Args, "\n")
+	for prompt, result := range r.responses {
+		if strings.Contains(observed, prompt) {
+			return platformprocess.CommandResult{Stdout: support.CodexSuccessStdout(result)}, nil
+		}
+	}
+	return platformprocess.CommandResult{}, fmt.Errorf(
+		"provider dispatch carried no known session prompt: %q",
+		observed,
+	)
+}
+
+func (r *promptKeyedCodexRunner) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.calls
+}

--- a/tests/functional/sessions/root_composition/p3_p7_behavior_matrix_test.go
+++ b/tests/functional/sessions/root_composition/p3_p7_behavior_matrix_test.go
@@ -1,0 +1,623 @@
+package root_composition_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	p3p7CorpusWorkerOutput  = "p3-p7 canonical corpus COMPLETE"
+	p3p7CorpusTerminalLimit = 60 * time.Second
+	p3p7CorpusReleaseLimit  = 20 * time.Second
+	p3p7CorpusCloseTimeout  = 15 * time.Second
+	p3p7CorpusEntryLimit    = 45 * time.Second
+)
+
+// TestP3P7CanonicalPathPreservesTerminalCleanupAndReplayIsolation is the
+// cross-packet behavior corpus for the build-time/runtime composition program.
+// Every operation it drives enters through root.BuildProcess and
+// Process.Execute, with external effects replaced only through edges.Edges, so
+// what it observes is the canonical composition graph P3-P6 converged on rather
+// than a test-only assembly.
+//
+// It closes four claims that P3-P6 depend on but that no single owner test
+// covers together:
+//
+//   - one terminal outcome: a canonical run reaches exactly one terminal (or
+//     failed) Work state, and the retained canonical stream enters that state
+//     exactly once;
+//   - post-activation cleanup: the transport resource acquired during
+//     activation is released exactly once when the process shuts down, a
+//     repeated Close never releases it twice, and the released listener really
+//     stops serving;
+//   - cancellation and failure: a provider failure terminalizes as FAILED and
+//     is never reported as success, and a dispatch held inside the provider
+//     boundary observes cancellation when the process is shut down instead of
+//     being left running;
+//   - replay isolation: two Factory Sessions built from the same authored
+//     Factory in two independent root processes replay to the same canonical
+//     facts while sharing no session or Work identity.
+func TestP3P7CanonicalPathPreservesTerminalCleanupAndReplayIsolation(t *testing.T) {
+	t.Run("isolated sessions reach one terminal outcome and replay equivalent facts", func(t *testing.T) {
+		first := runP3P7CanonicalCorpus(t, "alpha", support.NewStaticSuccessCommandRunner(p3p7CorpusWorkerOutput))
+		second := runP3P7CanonicalCorpus(t, "beta", support.NewStaticSuccessCommandRunner(p3p7CorpusWorkerOutput))
+
+		assertP3P7SingleTerminalOutcome(t, first, factoryapi.WorkStateTypeTERMINAL)
+		assertP3P7SingleTerminalOutcome(t, second, factoryapi.WorkStateTypeTERMINAL)
+		assertP3P7SessionsAreIsolated(t, first, second)
+		assertP3P7ReplayedFactsAreEquivalent(t, first, second)
+	})
+
+	t.Run("provider failure terminalizes as failed and is never reported as success", func(t *testing.T) {
+		run := runP3P7CanonicalCorpus(t, "provider-failure", support.NewShapedProviderCommandRunner(
+			platformprocess.CommandResult{
+				ExitCode: 1,
+				Stderr:   []byte("provider refused the canonical corpus dispatch"),
+			},
+		))
+
+		assertP3P7SingleTerminalOutcome(t, run, factoryapi.WorkStateTypeFAILED)
+	})
+
+	t.Run("cancellation stops the held dispatch and releases the activated process", func(t *testing.T) {
+		held := &p3p7HeldCommandRunner{entered: make(chan struct{})}
+		running := startP3P7CanonicalProcess(t, "cancellation", held)
+
+		select {
+		case <-held.entered:
+		case <-time.After(p3p7CorpusEntryLimit):
+			t.Fatalf("provider boundary was never reached within %s, so cancellation would prove nothing", p3p7CorpusEntryLimit)
+		}
+
+		status := support.WaitForStatus(t, running.baseURL, p3p7CorpusTerminalLimit, func(factoryapi.StatusResponse) bool {
+			return true
+		})
+		if status.Categories.Terminal != 0 {
+			t.Fatalf("status categories while the dispatch is held = %+v, want zero terminal outcomes", status.Categories)
+		}
+
+		running.shutdownAndAssertCleanupHappensExactlyOnce(t)
+
+		if !held.observedCancellation() {
+			t.Fatal("held provider dispatch never observed cancellation; process shutdown left in-flight work running")
+		}
+		if err := running.daemon.Err(); err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("Process.Execute() after cancellation error = %v, want a cancellation classification", err)
+		}
+	})
+}
+
+// p3p7CorpusRun is everything one completed canonical run makes observable at
+// the public boundary, captured before the process is shut down.
+type p3p7CorpusRun struct {
+	label     string
+	sessionID string
+	workID    string
+	status    factoryapi.StatusResponse
+	work      factoryapi.Work
+	events    []factoryapi.FactoryEvent
+}
+
+// runP3P7CanonicalCorpus drives one full canonical lifecycle: activation, Work
+// admission from the customer `--work` file, dispatch through the replaced
+// provider boundary, terminal observation, then shutdown with the cleanup
+// assertions.
+func runP3P7CanonicalCorpus(
+	t *testing.T,
+	label string,
+	runner platformprocess.CommandRunner,
+) p3p7CorpusRun {
+	t.Helper()
+
+	running := startP3P7CanonicalProcess(t, label, runner)
+	status := support.WaitForSessionTerminalStatus(t, running.baseURL, running.sessionID, p3p7CorpusTerminalLimit)
+
+	listed := support.ListDefaultSessionWork(t, running.baseURL)
+	if len(listed.Results) != 1 {
+		t.Fatalf("%s: listed work = %d, want exactly one submitted work item", label, len(listed.Results))
+	}
+	admitted := listed.Results[0]
+	workID := support.StringPointerValue(admitted.WorkId)
+	if workID == "" {
+		t.Fatalf("%s: listed work has no public identity: %#v", label, admitted)
+	}
+	if admitted.State == nil {
+		t.Fatalf("%s: terminal work has no served state: %#v", label, admitted)
+	}
+	events := waitForP3P7RetainedTerminalDispatch(t, running, workID)
+
+	running.shutdownAndAssertCleanupHappensExactlyOnce(t)
+
+	return p3p7CorpusRun{
+		label:     label,
+		sessionID: running.sessionID,
+		workID:    workID,
+		status:    status,
+		work:      admitted,
+		events:    events,
+	}
+}
+
+// waitForP3P7RetainedTerminalDispatch returns the retained canonical history
+// once it carries the workstation outcome for one Work identity. The Work
+// projection and the canonical stream are separate reads, so the corpus waits
+// for the canonical fact itself instead of assuming a terminal projection read
+// implies the outcome is already committed to history. The ceiling is a failure
+// guard, not synchronization: the loop returns on the first read that carries
+// the outcome.
+func waitForP3P7RetainedTerminalDispatch(
+	t *testing.T,
+	running *p3p7CanonicalProcess,
+	workID string,
+) []factoryapi.FactoryEvent {
+	t.Helper()
+
+	deadline := time.Now().Add(p3p7CorpusTerminalLimit)
+	for {
+		events := support.GetFactoryEventsForSessionAt(t, running.baseURL, running.sessionID)
+		if len(p3p7DispatchOutcomes(t, running.label, events, workID)) > 0 {
+			return events
+		}
+		if !time.Now().Before(deadline) {
+			t.Fatalf(
+				"%s: retained canonical history never recorded a workstation outcome for work %q within %s",
+				running.label,
+				workID,
+				p3p7CorpusTerminalLimit,
+			)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+// p3p7DispatchOutcomes derives, from the retained canonical stream alone, the
+// ordered workstation outcomes recorded for one Work identity. This is the
+// replay side of the corpus: world state read back from canonical facts,
+// independent of the served Work projection.
+func p3p7DispatchOutcomes(
+	t *testing.T,
+	label string,
+	events []factoryapi.FactoryEvent,
+	workID string,
+) []factoryapi.WorkOutcome {
+	t.Helper()
+
+	var outcomes []factoryapi.WorkOutcome
+	for index, event := range events {
+		if event.Type != factoryapi.FactoryEventTypeDispatchResponse {
+			continue
+		}
+		if !slices.Contains(p3p7EventWorkIDs(event), workID) {
+			continue
+		}
+		payload, err := event.Payload.AsDispatchResponseEventPayload()
+		if err != nil {
+			t.Fatalf("%s: decode DISPATCH_RESPONSE payload at event %d: %v", label, index, err)
+		}
+		outcomes = append(outcomes, payload.Outcome)
+	}
+	return outcomes
+}
+
+// p3p7CanonicalProcess is a live root-built process plus the two effect
+// recorders the cleanup assertions read.
+type p3p7CanonicalProcess struct {
+	label       string
+	process     support.Process
+	daemon      *support.ProcessCommand
+	baseURL     string
+	sessionID   string
+	transport   *p3p7TransportRecorder
+	activations *atomic.Int32
+}
+
+func startP3P7CanonicalProcess(
+	t *testing.T,
+	label string,
+	runner platformprocess.CommandRunner,
+) *p3p7CanonicalProcess {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, p3p7CorpusFactoryConfig())
+	support.WriteAgentConfig(
+		t,
+		dir,
+		"worker-a",
+		support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"),
+	)
+	workFile := filepath.Join(dir, "corpus-work.json")
+	support.WriteWorkRequestFile(t, workFile, work.SubmitRequest{
+		WorkTypeID: "task",
+		Payload:    json.RawMessage(`{"title":"p3-p7 canonical corpus"}`),
+	})
+
+	transport := &p3p7TransportRecorder{server: support.NewProcessAPIServer(), release: make(chan struct{})}
+	activations := &atomic.Int32{}
+	edges := serviceedges.Edges{
+		APIServerStarter: transport.start,
+		// Runtime instance identity is minted while a Factory Session runtime is
+		// being opened, so a non-zero count is direct evidence that activation
+		// happened and the cleanup assertions below are not vacuous.
+		FactorySessionRuntimeInstanceIDGenerator: func() string {
+			return fmt.Sprintf("p3p7-corpus-%s-runtime-%d", label, activations.Add(1))
+		},
+	}
+	support.ConfigureWorkerCommands(t, &edges, runner, nil)
+
+	process := support.BuildProcess(t, edges)
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "run",
+		"--dir", dir,
+		"--continuously",
+		"--with-server",
+		"--server", "http://127.0.0.1:1",
+		"--quiet",
+		"--no-record",
+		"--work", workFile,
+	})
+	home := t.TempDir()
+	inputs.Input.Env = append(os.Environ(), "HOME="+home, "USERPROFILE="+home)
+	inputs.Input.WorkingDirectory = dir
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+		if stderr := strings.TrimSpace(inputs.Stderr()); stderr != "" {
+			t.Logf("%s daemon stderr:\n%s", label, stderr)
+		}
+	})
+
+	daemon := support.StartProcessCommand(t, process, inputs.Input)
+	baseURL := transport.server.WaitForURL(t)
+	return &p3p7CanonicalProcess{
+		label:       label,
+		process:     process,
+		daemon:      daemon,
+		baseURL:     baseURL,
+		sessionID:   support.GetDefaultSession(t, baseURL).Id,
+		transport:   transport,
+		activations: activations,
+	}
+}
+
+// shutdownAndAssertCleanupHappensExactlyOnce proves the post-activation half of
+// the corpus: the one external transport resource this process acquired during
+// activation is released exactly once by shutdown, a repeated Close neither
+// fails nor releases it again, and the released listener genuinely stops
+// serving.
+func (running *p3p7CanonicalProcess) shutdownAndAssertCleanupHappensExactlyOnce(t *testing.T) {
+	t.Helper()
+
+	if got := running.transport.started.Load(); got != 1 {
+		t.Fatalf("%s: API transport activations = %d, want exactly one", running.label, got)
+	}
+	if got := running.activations.Load(); got < 1 {
+		t.Fatalf(
+			"%s: Factory Session runtime activations = %d, want at least one so the cleanup claim is not vacuous",
+			running.label,
+			got,
+		)
+	}
+
+	running.daemon.Stop(t)
+	closer, ok := running.process.(interface{ Close(context.Context) error })
+	if !ok {
+		t.Fatalf("%s: root-built process does not expose Close", running.label)
+	}
+	closeCtx, cancel := context.WithTimeout(context.Background(), p3p7CorpusCloseTimeout)
+	defer cancel()
+	if err := closer.Close(closeCtx); err != nil {
+		t.Fatalf("%s: Process.Close() after activation error = %v, want nil", running.label, err)
+	}
+
+	select {
+	case <-running.transport.release:
+	case <-time.After(p3p7CorpusReleaseLimit):
+		t.Fatalf("%s: activated API transport was never released after process shutdown", running.label)
+	}
+	if got := running.transport.released.Load(); got != 1 {
+		t.Fatalf("%s: API transport releases = %d, want exactly one", running.label, got)
+	}
+	if err := closer.Close(closeCtx); err != nil {
+		t.Fatalf("%s: repeated Process.Close() error = %v, want nil", running.label, err)
+	}
+	if got := running.transport.released.Load(); got != 1 {
+		t.Fatalf(
+			"%s: API transport releases after a repeated close = %d, want exactly one",
+			running.label,
+			got,
+		)
+	}
+	assertP3P7EndpointStoppedServing(t, running.label, running.baseURL)
+}
+
+func assertP3P7EndpointStoppedServing(t *testing.T, label, baseURL string) {
+	t.Helper()
+
+	client := &http.Client{
+		Transport: &http.Transport{DisableKeepAlives: true},
+		Timeout:   p3p7CorpusCloseTimeout,
+	}
+	endpoint := strings.TrimSuffix(baseURL, "/") + "/factory-sessions/" + factorysessions.DefaultSessionID
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, endpoint, nil)
+	if err != nil {
+		t.Fatalf("%s: build released-listener probe: %v", label, err)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+	t.Fatalf(
+		"%s: GET %s after process close status = %d, want the released listener to refuse the connection",
+		label,
+		endpoint,
+		response.StatusCode,
+	)
+}
+
+// assertP3P7SingleTerminalOutcome requires exactly one terminal outcome of the
+// expected classification, and requires the canonical event stream replayed on
+// its own to agree with the served projection about that outcome.
+func assertP3P7SingleTerminalOutcome(t *testing.T, run p3p7CorpusRun, want factoryapi.WorkStateType) {
+	t.Helper()
+
+	categories := run.status.Categories
+	switch want {
+	case factoryapi.WorkStateTypeTERMINAL:
+		if categories.Terminal != 1 || categories.Failed != 0 {
+			t.Fatalf("%s: status categories = %+v, want exactly one terminal and zero failed", run.label, categories)
+		}
+	case factoryapi.WorkStateTypeFAILED:
+		if categories.Failed != 1 || categories.Terminal != 0 {
+			t.Fatalf("%s: status categories = %+v, want exactly one failed and zero terminal", run.label, categories)
+		}
+	default:
+		t.Fatalf("%s: unsupported terminal expectation %q", run.label, want)
+	}
+	if run.work.State == nil || run.work.State.Type != want {
+		t.Fatalf("%s: terminal work state = %#v, want state type %q", run.label, run.work.State, want)
+	}
+
+	outcomes := p3p7DispatchOutcomes(t, run.label, run.events, run.workID)
+	if len(outcomes) != 1 {
+		t.Fatalf(
+			"%s: replayed workstation outcomes for work %q = %v, want exactly one terminal outcome",
+			run.label,
+			run.workID,
+			outcomes,
+		)
+	}
+	if got := p3p7StateTypeForOutcome(outcomes[0]); got != want {
+		t.Fatalf(
+			"%s: replayed workstation outcome %q classifies as %q but the served projection reports %q; the canonical stream and the projection disagree",
+			run.label,
+			outcomes[0],
+			got,
+			want,
+		)
+	}
+}
+
+func p3p7StateTypeForOutcome(outcome factoryapi.WorkOutcome) factoryapi.WorkStateType {
+	switch outcome {
+	case factoryapi.WorkOutcomeAccepted:
+		return factoryapi.WorkStateTypeTERMINAL
+	case factoryapi.WorkOutcomeFailed, factoryapi.WorkOutcomeRejected:
+		return factoryapi.WorkStateTypeFAILED
+	default:
+		return factoryapi.WorkStateTypePROCESSING
+	}
+}
+
+// assertP3P7SessionsAreIsolated requires two independently built root processes
+// to have produced two disjoint canonical histories.
+func assertP3P7SessionsAreIsolated(t *testing.T, first, second p3p7CorpusRun) {
+	t.Helper()
+
+	if first.sessionID == "" || first.sessionID == second.sessionID {
+		t.Fatalf(
+			"canonical session identities = %q and %q, want two distinct Factory Sessions",
+			first.sessionID,
+			second.sessionID,
+		)
+	}
+	if first.workID == second.workID {
+		t.Fatalf("canonical work identities = %q and %q, want two distinct Work items", first.workID, second.workID)
+	}
+	assertP3P7EventsStayWithinTheirSession(t, first, second)
+	assertP3P7EventsStayWithinTheirSession(t, second, first)
+}
+
+func assertP3P7EventsStayWithinTheirSession(t *testing.T, run, other p3p7CorpusRun) {
+	t.Helper()
+
+	if len(run.events) == 0 {
+		t.Fatalf("%s: retained canonical events = 0, want an observable history", run.label)
+	}
+	previousSequence := 0
+	for index, event := range run.events {
+		session := event.Context.SessionId
+		// Session-scoped canonical events carry the run's own canonical identity;
+		// the customer-facing default alias is the one accepted alternative and is
+		// resolved per process, so it can never name another process's session.
+		if session != nil && *session != run.sessionID && *session != factorysessions.DefaultSessionID {
+			t.Fatalf(
+				"%s: event %d carries session %q, want its own session %q or the default alias",
+				run.label,
+				index,
+				*session,
+				run.sessionID,
+			)
+		}
+		if slices.Contains(p3p7EventWorkIDs(event), other.workID) {
+			t.Fatalf("%s: event %d references the other session's work %q", run.label, index, other.workID)
+		}
+		sequence := event.Context.SessionSequence
+		if session == nil || *session != run.sessionID || sequence == nil {
+			continue
+		}
+		if *sequence <= previousSequence {
+			t.Fatalf(
+				"%s: session sequence %d at event %d does not advance past %d; replay deduplication would be ambiguous",
+				run.label,
+				*sequence,
+				index,
+				previousSequence,
+			)
+		}
+		previousSequence = *sequence
+	}
+}
+
+// assertP3P7ReplayedFactsAreEquivalent proves the two isolated sessions
+// recorded the same canonical facts under different identities: the same
+// authored Factory replays to the same ordered workstation outcomes and the
+// same terminal state, and the canonical vocabulary correlated with each
+// session's own Work is identical.
+func assertP3P7ReplayedFactsAreEquivalent(t *testing.T, first, second p3p7CorpusRun) {
+	t.Helper()
+
+	firstOutcomes := p3p7DispatchOutcomes(t, first.label, first.events, first.workID)
+	secondOutcomes := p3p7DispatchOutcomes(t, second.label, second.events, second.workID)
+	if !slices.Equal(firstOutcomes, secondOutcomes) {
+		t.Fatalf(
+			"replayed workstation outcomes = %v and %v, want equivalent facts from two isolated sessions of one authored Factory",
+			firstOutcomes,
+			secondOutcomes,
+		)
+	}
+	if first.work.State.Name != second.work.State.Name {
+		t.Fatalf(
+			"terminal states = %q and %q, want one authored Factory to terminalize the same way in both isolated sessions",
+			first.work.State.Name,
+			second.work.State.Name,
+		)
+	}
+
+	firstVocabulary := p3p7WorkEventVocabulary(first)
+	secondVocabulary := p3p7WorkEventVocabulary(second)
+	if len(firstVocabulary) == 0 {
+		t.Fatalf("%s: no canonical event is correlated with work %q", first.label, first.workID)
+	}
+	if !maps.Equal(firstVocabulary, secondVocabulary) {
+		t.Fatalf(
+			"work-correlated canonical vocabularies = %v and %v, want the same canonical facts in both isolated sessions",
+			slices.Sorted(maps.Keys(firstVocabulary)),
+			slices.Sorted(maps.Keys(secondVocabulary)),
+		)
+	}
+}
+
+// p3p7WorkEventVocabulary is the set of canonical event types correlated with
+// one run's own Work identity. Identity-free by construction, so two isolated
+// sessions of the same authored Factory must produce the same set.
+func p3p7WorkEventVocabulary(run p3p7CorpusRun) map[factoryapi.FactoryEventType]struct{} {
+	vocabulary := make(map[factoryapi.FactoryEventType]struct{})
+	for _, event := range run.events {
+		if slices.Contains(p3p7EventWorkIDs(event), run.workID) {
+			vocabulary[event.Type] = struct{}{}
+		}
+	}
+	return vocabulary
+}
+
+func p3p7EventWorkIDs(event factoryapi.FactoryEvent) []string {
+	if event.Context.WorkIds == nil {
+		return nil
+	}
+	return *event.Context.WorkIds
+}
+
+// p3p7TransportRecorder wraps the process API-server edge so the corpus can
+// observe activation and release of the one external transport resource the
+// canonical process acquires.
+type p3p7TransportRecorder struct {
+	server   *support.ProcessAPIServer
+	started  atomic.Int32
+	released atomic.Int32
+	release  chan struct{}
+	closeIt  sync.Once
+}
+
+func (recorder *p3p7TransportRecorder) start(
+	ctx context.Context,
+	request platformhttpserver.StartRequest,
+) error {
+	recorder.started.Add(1)
+	err := recorder.server.Start(ctx, request)
+	recorder.released.Add(1)
+	recorder.closeIt.Do(func() { close(recorder.release) })
+	return err
+}
+
+// p3p7HeldCommandRunner parks the provider boundary until the invocation is
+// cancelled, then records that cancellation is what released it.
+type p3p7HeldCommandRunner struct {
+	entered   chan struct{}
+	enterOnce sync.Once
+	cancelled atomic.Bool
+}
+
+func (runner *p3p7HeldCommandRunner) Run(
+	ctx context.Context,
+	_ platformprocess.CommandRequest,
+) (platformprocess.CommandResult, error) {
+	runner.enterOnce.Do(func() { close(runner.entered) })
+	<-ctx.Done()
+	if errors.Is(ctx.Err(), context.Canceled) {
+		runner.cancelled.Store(true)
+	}
+	return platformprocess.CommandResult{}, ctx.Err()
+}
+
+func (runner *p3p7HeldCommandRunner) observedCancellation() bool {
+	return runner.cancelled.Load()
+}
+
+func p3p7CorpusFactoryConfig() map[string]any {
+	return map[string]any{
+		"name": "p3-p7-canonical-corpus",
+		"workTypes": []map[string]any{{
+			"name": "task",
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+			"handlingBehavior": []string{"DEFAULT"},
+		}},
+		"workers": []map[string]string{{"name": "worker-a"}},
+		"workstations": []map[string]any{{
+			"name":      "process",
+			"worker":    "worker-a",
+			"inputs":    []map[string]string{{"workType": "task", "state": "init"}},
+			"outputs":   []map[string]string{{"workType": "task", "state": "complete"}},
+			"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
+		}},
+	}
+}
+
+var _ platformprocess.CommandRunner = (*p3p7HeldCommandRunner)(nil)
+var _ platformhttpserver.Starter = (&p3p7TransportRecorder{}).start

--- a/tests/functional/sessions/root_composition/process_lifecycle_close_test.go
+++ b/tests/functional/sessions/root_composition/process_lifecycle_close_test.go
@@ -1,0 +1,132 @@
+package root_composition_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/root"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const processLifecycleCloseTimeout = 5 * time.Second
+
+func processLifecycleHomeEnvironment(home string) []string {
+	return []string{"HOME=" + home, "USERPROFILE=" + home}
+}
+
+// TestRootProcessCloseAfterFailedCommandPreservesTheCommandFailure
+// characterizes the close-error join the customer entrypoint depends on.
+//
+// cmd/factory/main.go:runProcess reduces one invocation to
+// errors.Join(executeErr, process.Close(closeCtx)) before mapping the result to
+// an exit code. pkg/root already proves Close is deterministic and idempotent
+// on a freshly built process, and pkg/initializer/lifecycle already proves
+// unwind joins cleanup errors, but nothing asserted the combination the
+// entrypoint actually performs: after a command fails, Close must still succeed
+// so the join carries exactly the command's own failure -- not a second,
+// invented lifecycle failure, and not a cancellation classification that would
+// change the customer's exit code.
+func TestRootProcessCloseAfterFailedCommandPreservesTheCommandFailure(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	workingDirectory := t.TempDir()
+	missingFactory := filepath.Join(workingDirectory, "absent-factory.json")
+	if _, err := os.Stat(missingFactory); err == nil {
+		t.Fatalf("fixture precondition failed: %s exists", missingFactory)
+	}
+
+	process, err := root.BuildProcess(t.Context(), serviceedges.Edges{})
+	if err != nil {
+		t.Fatalf("root.BuildProcess() error = %v", err)
+	}
+
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "run", "--factory", missingFactory,
+	})
+	inputs.Input.Env = processLifecycleHomeEnvironment(home)
+	inputs.Input.WorkingDirectory = workingDirectory
+
+	executeErr := process.Execute(inputs.Input)
+	if executeErr == nil {
+		t.Fatalf(
+			"Process.Execute(run --factory %s) error = nil, want a domain failure\nstdout:\n%s\nstderr:\n%s",
+			missingFactory,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	if !strings.Contains(executeErr.Error(), filepath.Base(missingFactory)) {
+		t.Fatalf("Process.Execute() error = %v, want the missing Factory named in the diagnostic", executeErr)
+	}
+
+	closeCtx, cancelClose := context.WithTimeout(context.Background(), processLifecycleCloseTimeout)
+	defer cancelClose()
+	closeErr := process.Close(closeCtx)
+	if closeErr != nil {
+		t.Fatalf("Process.Close() after a failed command error = %v, want nil", closeErr)
+	}
+
+	joined := errors.Join(executeErr, closeErr)
+	if joined == nil || joined.Error() != executeErr.Error() {
+		t.Fatalf(
+			"errors.Join(executeErr, closeErr) = %v, want exactly the command failure %v",
+			joined,
+			executeErr,
+		)
+	}
+	if errors.Is(joined, context.Canceled) {
+		t.Fatalf(
+			"joined lifecycle result = %v, want a plain failure; a cancellation classification changes the customer exit code",
+			joined,
+		)
+	}
+
+	if repeated := process.Close(closeCtx); repeated != nil {
+		t.Fatalf("second Process.Close() error = %v, want nil so a repeated close never invents a failure", repeated)
+	}
+}
+
+// TestRootProcessCloseAfterSuccessfulCommandReportsNoFailure is the success
+// half of the same join: a command that succeeds must leave nothing behind that
+// makes Close fail, because runProcess would map that Close failure to a
+// non-zero exit code even though the customer's command worked.
+func TestRootProcessCloseAfterSuccessfulCommandReportsNoFailure(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	workingDirectory := t.TempDir()
+
+	process, err := root.BuildProcess(t.Context(), serviceedges.Edges{})
+	if err != nil {
+		t.Fatalf("root.BuildProcess() error = %v", err)
+	}
+
+	inputs := support.FakeInputs(t.Context(), []string{"you", "docs", "agents"})
+	inputs.Input.Env = processLifecycleHomeEnvironment(home)
+	inputs.Input.WorkingDirectory = workingDirectory
+
+	if executeErr := process.Execute(inputs.Input); executeErr != nil {
+		t.Fatalf(
+			"Process.Execute(docs agents) error = %v\nstdout:\n%s\nstderr:\n%s",
+			executeErr,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	if !strings.Contains(inputs.Stdout(), "# Agents") {
+		t.Fatalf("Process.Execute(docs agents) stdout = %q, want the packaged agents topic", inputs.Stdout())
+	}
+
+	closeCtx, cancelClose := context.WithTimeout(context.Background(), processLifecycleCloseTimeout)
+	defer cancelClose()
+	if closeErr := process.Close(closeCtx); closeErr != nil {
+		t.Fatalf("Process.Close() after a successful command error = %v, want nil", closeErr)
+	}
+}

--- a/tests/functional/transport/http/server/work_terminal_response_test.go
+++ b/tests/functional/transport/http/server/work_terminal_response_test.go
@@ -1,0 +1,208 @@
+package server_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	workTerminalResponseText      = "ordered terminal text part"
+	workTerminalResponseJSONKey   = "verdict"
+	workTerminalResponseJSONWant  = "ordered-json-part"
+	workTerminalResponseAccepted  = "preserved ordered content COMPLETE"
+	workTerminalResponseWaitLimit = 30 * time.Second
+)
+
+// TestWorkTerminalResponsePreservesOrderedTypedContentThroughPublicBoundary
+// submits Work whose terminal result carries two differently typed ordered
+// content parts (text then JSON) and proves the public HTTP boundary keeps both
+// discriminated types and payloads in the submitted order on the terminal read,
+// and that a failure terminal outcome carrying the same content is never
+// reported as success.
+func TestWorkTerminalResponsePreservesOrderedTypedContentThroughPublicBoundary(t *testing.T) {
+	t.Run("terminal success keeps ordered typed parts", func(t *testing.T) {
+		server := startWorkTerminalResponseServer(
+			t,
+			support.NewStaticSuccessCommandRunner(workTerminalResponseAccepted),
+		)
+		workID := submitOrderedTypedWork(t, server.URL())
+
+		status := support.WaitForTerminalStatus(t, server.URL(), workTerminalResponseWaitLimit)
+		if status.Categories.Terminal != 1 || status.Categories.Failed != 0 {
+			t.Fatalf("status categories = %+v, want one terminal and zero failed", status.Categories)
+		}
+
+		listed := support.ListDefaultSessionWork(t, server.URL())
+		if len(listed.Results) != 1 {
+			t.Fatalf("listed work = %#v, want exactly one work item", listed.Results)
+		}
+		assertOrderedTypedTerminalContent(t, listed.Results[0].Content, "GET /work content")
+
+		terminal := support.GetDefaultSessionWorkByID(t, server.URL(), workID)
+		assertOrderedTypedTerminalContent(t, terminal.Content, "GET /work/{id} content")
+		if terminal.State == nil || terminal.State.Type != factoryapi.WorkStateTypeTERMINAL {
+			t.Fatalf("terminal work state = %#v, want a TERMINAL state type", terminal.State)
+		}
+	})
+
+	t.Run("terminal failure is not reported as success", func(t *testing.T) {
+		server := startWorkTerminalResponseServer(t, support.NewShapedProviderCommandRunner(
+			platformprocess.CommandResult{
+				ExitCode: 1,
+				Stderr:   []byte("provider refused the ordered content dispatch"),
+			},
+		))
+		workID := submitOrderedTypedWork(t, server.URL())
+
+		status := support.WaitForTerminalStatus(t, server.URL(), workTerminalResponseWaitLimit)
+		if status.Categories.Failed != 1 || status.Categories.Terminal != 0 {
+			t.Fatalf("status categories = %+v, want one failed and zero terminal", status.Categories)
+		}
+
+		failed := support.GetDefaultSessionWorkByID(t, server.URL(), workID)
+		if failed.State == nil || failed.State.Type != factoryapi.WorkStateTypeFAILED {
+			t.Fatalf("work state after provider failure = %#v, want a FAILED state type", failed.State)
+		}
+		// The same ordered typed content is still readable on the failed Work, so
+		// the failure classification is what distinguishes it from success rather
+		// than content loss.
+		assertOrderedTypedTerminalContent(t, failed.Content, "failed GET /work/{id} content")
+	})
+}
+
+func assertOrderedTypedTerminalContent(t *testing.T, content *factoryapi.WorkContent, surface string) {
+	t.Helper()
+
+	if content == nil || len(*content) != 2 {
+		t.Fatalf("%s = %#v, want two ordered content parts", surface, content)
+	}
+	textPart, err := (*content)[0].AsWorkTextContentPart()
+	if err != nil {
+		t.Fatalf("%s part 0 is not a text part: %v", surface, err)
+	}
+	if textPart.Type != factoryapi.WorkContentPartTypeText {
+		t.Fatalf("%s part 0 type = %q, want %q", surface, textPart.Type, factoryapi.WorkContentPartTypeText)
+	}
+	if textPart.Text != workTerminalResponseText {
+		t.Fatalf("%s part 0 text = %q, want %q", surface, textPart.Text, workTerminalResponseText)
+	}
+
+	jsonPart, err := (*content)[1].AsWorkJsonContentPart()
+	if err != nil {
+		t.Fatalf("%s part 1 is not a JSON part: %v", surface, err)
+	}
+	if jsonPart.Type != factoryapi.WorkContentPartTypeJSON {
+		t.Fatalf("%s part 1 type = %q, want %q", surface, jsonPart.Type, factoryapi.WorkContentPartTypeJSON)
+	}
+	payload, ok := jsonPart.Json.(map[string]any)
+	if !ok {
+		t.Fatalf("%s part 1 json = %#v, want a JSON object", surface, jsonPart.Json)
+	}
+	if got, _ := payload[workTerminalResponseJSONKey].(string); got != workTerminalResponseJSONWant {
+		t.Fatalf(
+			"%s part 1 json[%q] = %#v, want %q",
+			surface,
+			workTerminalResponseJSONKey,
+			payload[workTerminalResponseJSONKey],
+			workTerminalResponseJSONWant,
+		)
+	}
+}
+
+// submitOrderedTypedWork submits one Work through the public session-scoped
+// admission route with a text content part followed by a JSON content part and
+// returns the public Work identity the submission was accepted under.
+func submitOrderedTypedWork(t *testing.T, baseURL string) string {
+	t.Helper()
+
+	submitted := support.SubmitDefaultSessionWork(t, baseURL, factoryapi.SubmitWorkRequest{
+		WorkTypeName: "task",
+		Content:      workTerminalOrderedTypedContent(t),
+	})
+	if !submitted.Accepted {
+		t.Fatalf("submit work response = %#v, want an accepted submission", submitted)
+	}
+	if submitted.WorkId == nil || strings.TrimSpace(*submitted.WorkId) == "" {
+		t.Fatalf("submit work response = %#v, want a public work identity", submitted)
+	}
+	return *submitted.WorkId
+}
+
+func startWorkTerminalResponseServer(
+	t *testing.T,
+	runner platformprocess.CommandRunner,
+) *support.FunctionalAPIServer {
+	t.Helper()
+
+	dir := support.ScaffoldFactory(t, workTerminalResponseFactoryConfig())
+	support.WriteAgentConfig(
+		t,
+		dir,
+		"worker-a",
+		support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"),
+	)
+	edges := serviceedges.Edges{}
+	support.ConfigureWorkerCommands(t, &edges, runner, nil)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		WaitForServiceModeRuntime: true,
+		Edges:                     edges,
+	})
+	t.Cleanup(func() { server.Stop(t) })
+	return server
+}
+
+// workTerminalResponseFactoryConfig authors PRESERVE_INPUT propagation so the
+// ordered typed content submitted with the Work is the content the terminal
+// state carries instead of being replaced by the workstation output text.
+func workTerminalResponseFactoryConfig() map[string]any {
+	return map[string]any{
+		"name": "work-terminal-response",
+		"workTypes": []map[string]any{{
+			"name":             "task",
+			"handlingBehavior": []string{"DEFAULT"},
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]string{{"name": "worker-a"}},
+		"workstations": []map[string]any{{
+			"name":            "process",
+			"worker":          "worker-a",
+			"workPropagation": map[string]any{"mode": "PRESERVE_INPUT"},
+			"inputs":          []map[string]string{{"workType": "task", "state": "init"}},
+			"outputs":         []map[string]string{{"workType": "task", "state": "complete"}},
+			"onFailure":       []map[string]string{{"workType": "task", "state": "failed"}},
+		}},
+	}
+}
+
+func workTerminalOrderedTypedContent(t *testing.T) *factoryapi.WorkContent {
+	t.Helper()
+
+	var textPart factoryapi.WorkContentPart
+	if err := textPart.FromWorkTextContentPart(factoryapi.WorkTextContentPart{
+		Type: factoryapi.WorkContentPartTypeText,
+		Text: workTerminalResponseText,
+	}); err != nil {
+		t.Fatalf("encode text content part: %v", err)
+	}
+	var jsonPart factoryapi.WorkContentPart
+	if err := jsonPart.FromWorkJsonContentPart(factoryapi.WorkJsonContentPart{
+		Type: factoryapi.WorkContentPartTypeJSON,
+		Json: map[string]any{workTerminalResponseJSONKey: workTerminalResponseJSONWant},
+	}); err != nil {
+		t.Fatalf("encode JSON content part: %v", err)
+	}
+	content := factoryapi.WorkContent{textPart, jsonPart}
+	return &content
+}

--- a/tests/functional/workers/agent/stateless_root_test.go
+++ b/tests/functional/workers/agent/stateless_root_test.go
@@ -1,12 +1,18 @@
 package agent_test
 
 import (
+	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/portpowered/infinite-you/internal/testutil"
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	"github.com/portpowered/infinite-you/pkg/root"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
@@ -34,5 +40,229 @@ func TestBuildProcessExecutesProviderAttemptThroughRuntimeRoot(t *testing.T) {
 	}
 	if runner.CallCount() != 1 {
 		t.Fatalf("provider command calls = %d, want one", runner.CallCount())
+	}
+}
+
+// detachedRootScriptRunner is the single external command effect a detached
+// Workers attempt is allowed to reach. It records every request so the test can
+// assert the attempt actually left the Workers root through the injected edge.
+type detachedRootScriptRunner struct {
+	stdout   string
+	calls    atomic.Int32
+	commands chan string
+}
+
+func newDetachedRootScriptRunner(stdout string) *detachedRootScriptRunner {
+	return &detachedRootScriptRunner{stdout: stdout, commands: make(chan string, 8)}
+}
+
+func (runner *detachedRootScriptRunner) Run(
+	ctx context.Context,
+	request platformprocess.CommandRequest,
+) (platformprocess.CommandResult, error) {
+	runner.calls.Add(1)
+	select {
+	case runner.commands <- request.Command:
+	default:
+	}
+	if err := ctx.Err(); err != nil {
+		return platformprocess.CommandResult{}, err
+	}
+	return platformprocess.CommandResult{Stdout: []byte(runner.stdout)}, nil
+}
+
+func (runner *detachedRootScriptRunner) callCount() int32 { return runner.calls.Load() }
+
+func (runner *detachedRootScriptRunner) observedCommands() []string {
+	observed := make([]string, 0, len(runner.commands))
+	for {
+		select {
+		case command := <-runner.commands:
+			observed = append(observed, command)
+		default:
+			return observed
+		}
+	}
+}
+
+// detachedRootOpeningRecorder counts the Factory Session and Factory Runtime
+// opening effects. A detached Workers root must never reach any of them, so
+// every counter staying at zero is the observable form of "this execution ran
+// outside Runtime and Session opening".
+type detachedRootOpeningRecorder struct {
+	sessionID       atomic.Int32
+	runtimeID       atomic.Int32
+	responseEventID atomic.Int32
+	runtimeHost     atomic.Int32
+	invocations     atomic.Int32
+}
+
+func (recorder *detachedRootOpeningRecorder) generateSessionID() string {
+	recorder.sessionID.Add(1)
+	return "detached-root-should-not-open-session"
+}
+
+func (recorder *detachedRootOpeningRecorder) generateRuntimeID() string {
+	recorder.runtimeID.Add(1)
+	return "detached-root-should-not-open-runtime"
+}
+
+func (recorder *detachedRootOpeningRecorder) generateResponseEventID() string {
+	recorder.responseEventID.Add(1)
+	return "detached-root-should-not-publish-response-event"
+}
+
+func (recorder *detachedRootOpeningRecorder) observeRuntimeHost(factorysessions.RuntimeHostBinding) {
+	recorder.runtimeHost.Add(1)
+}
+
+func (recorder *detachedRootOpeningRecorder) RecordInvocationMetric(factorysessions.InvocationMetric) {
+	recorder.invocations.Add(1)
+}
+
+func (recorder *detachedRootOpeningRecorder) openingEffects() map[string]int32 {
+	return map[string]int32{
+		"factory session id":  recorder.sessionID.Load(),
+		"runtime instance id": recorder.runtimeID.Load(),
+		"response event id":   recorder.responseEventID.Load(),
+		"runtime host":        recorder.runtimeHost.Load(),
+		"invocation metric":   recorder.invocations.Load(),
+	}
+}
+
+func (recorder *detachedRootOpeningRecorder) edges(
+	runner platformprocess.CommandRunner,
+) serviceedges.Edges {
+	return serviceedges.Edges{
+		ScriptCommandRunner:                      runner,
+		FactorySessionIDGenerator:                recorder.generateSessionID,
+		FactorySessionRuntimeInstanceIDGenerator: recorder.generateRuntimeID,
+		FactorySessionResponseEventIDGenerator:   recorder.generateResponseEventID,
+		RuntimeHostObserver:                      recorder.observeRuntimeHost,
+		InvocationMetricsRecorder:                recorder,
+	}
+}
+
+func detachedRootExecuteRequest(attemptID, command string) workers.ExecuteRequest {
+	return workers.ExecuteRequest{
+		Correlation: workers.ExecutionCorrelation{
+			FactorySessionID: "detached-root-session",
+			RuntimeID:        "detached-root-runtime",
+			GenerationID:     "detached-root-generation",
+			DispatchID:       "detached-root-dispatch",
+			AttemptID:        attemptID,
+		},
+		Target: workers.ExecutionTarget{
+			WorkerName: "script-worker",
+			RunnerID:   "script",
+			Command:    command,
+		},
+	}
+}
+
+// TestBuildStatelessWorkersExecutesDetachedAttemptThroughRoot is the public
+// caller guard for the detached Workers root. pkg/root already covers the same
+// composition from inside its own package, but no test outside pkg/root drove
+// root.BuildStatelessWorkers as a customer would, so the promise that a
+// detached attempt stays outside Factory Runtime and Factory Session opening
+// had no observable guard at the public boundary.
+//
+// Only edges.Edges replaces external effects: the script command runner is the
+// single allowed effect, and the Sessions/Runtime opening ports are supplied
+// purely so their invocation counts are observable. Nothing in this test waits
+// on a clock.
+func TestBuildStatelessWorkersExecutesDetachedAttemptThroughRoot(t *testing.T) {
+	t.Parallel()
+
+	const detachedOutput = "detached-root-script-output"
+	recorder := &detachedRootOpeningRecorder{}
+	runner := newDetachedRootScriptRunner(detachedOutput)
+
+	service, err := root.BuildStatelessWorkers(t.Context(), recorder.edges(runner))
+	if err != nil {
+		t.Fatalf("root.BuildStatelessWorkers() error = %v", err)
+	}
+	if service == nil {
+		t.Fatal("root.BuildStatelessWorkers() service = nil, want the detached Workers root")
+	}
+	for effect, count := range recorder.openingEffects() {
+		if count != 0 {
+			t.Fatalf("%s effect calls during detached construction = %d, want 0", effect, count)
+		}
+	}
+
+	result, err := service.Execute(
+		t.Context(),
+		detachedRootExecuteRequest("detached-root-attempt", "detached-root-command"),
+	)
+	if err != nil {
+		t.Fatalf("detached Workers Execute() error = %v", err)
+	}
+	if result.Outcome != workers.ExecutionOutcomeAccepted {
+		t.Fatalf("detached Workers Execute() outcome = %q, want %q", result.Outcome, workers.ExecutionOutcomeAccepted)
+	}
+	if len(result.Output.Primary) != 1 || result.Output.Primary[0].Text != detachedOutput {
+		t.Fatalf("detached Workers Execute() output = %#v, want one %q part", result.Output.Primary, detachedOutput)
+	}
+	if got := runner.callCount(); got != 1 {
+		t.Fatalf("script command runner calls = %d, want exactly one detached attempt", got)
+	}
+	if got := runner.observedCommands(); len(got) != 1 || got[0] != "detached-root-command" {
+		t.Fatalf("script command runner commands = %#v, want the detached attempt command", got)
+	}
+
+	for effect, count := range recorder.openingEffects() {
+		if count != 0 {
+			t.Fatalf(
+				"%s effect calls after a detached attempt = %d, want 0; the detached root must not open a Factory Runtime or Factory Session",
+				effect,
+				count,
+			)
+		}
+	}
+}
+
+// TestBuildStatelessWorkersReleasesDetachedAttemptOnCancellation proves the
+// public detached root terminalizes a canceled attempt as a cancellation
+// instead of hanging, reporting success, or leaking the external command
+// effect, and that the canceled attempt still opens no Factory Runtime or
+// Factory Session. Cancellation is delivered through the caller's own context,
+// so no sleep or timeout padding is used as synchronization.
+func TestBuildStatelessWorkersReleasesDetachedAttemptOnCancellation(t *testing.T) {
+	t.Parallel()
+
+	recorder := &detachedRootOpeningRecorder{}
+	runner := newDetachedRootScriptRunner("cancelled-detached-output")
+
+	service, err := root.BuildStatelessWorkers(t.Context(), recorder.edges(runner))
+	if err != nil {
+		t.Fatalf("root.BuildStatelessWorkers() error = %v", err)
+	}
+
+	canceledCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	result, err := service.Execute(
+		canceledCtx,
+		detachedRootExecuteRequest("cancelled-root-attempt", "cancelled-root-command"),
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled detached Execute() error = %v, want context.Canceled", err)
+	}
+	if result.Outcome == workers.ExecutionOutcomeAccepted {
+		t.Fatalf("canceled detached Execute() outcome = %q, want a non-accepted outcome", result.Outcome)
+	}
+	if got := runner.callCount(); got != 0 {
+		t.Fatalf("script command calls for a canceled detached attempt = %d, want 0", got)
+	}
+
+	for effect, count := range recorder.openingEffects() {
+		if count != 0 {
+			t.Fatalf(
+				"%s effect calls after a canceled detached attempt = %d, want 0",
+				effect,
+				count,
+			)
+		}
 	}
 }


### PR DESCRIPTION
BTRC packet P7 -- the final behavior-closure packet of the build-time/runtime
composition program. Four authored slices, all four complete:

| Slice | Story | Head |
| --- | --- | --- |
| P7-A | public behavior matrix and pre-move gap characterization | `62fb87d03` |
| P7-B | terminal response, CLI/API parity, and Work content closure | `cf836badf` |
| P7-C | activation failure, cancellation, exactly-once unwind, dispatch races | `5dc7edff9` |
| P7-D | cross-packet corpus, final reruns, deletion-register closure | `218e95a42`, `3cd54f6ba`, `ef1e76242` |

13 files changed, all test files plus two documents under
`docs/internal/packaged-service-structure/`. **No production file is changed,
and nothing is deleted.** Per-slice verification evidence is in the PR comments.

Rebased onto `66243c9a1` (#2052); the new `service-cycle-check` target passes at
this head (weight 42 = ceiling 42).

## PRD

```json
{
  "project": "you-agent-factory",
  "branchName": "btrc-p7-functional-race-close",
  "description": "BTRC packet P7 (final behavior-closure packet of the build-time/runtime composition program): prove start, invoke, replay, direct execution, control, result, response observation, and shutdown behave correctly end-to-end through root.BuildProcess/Process.Execute with only edges.Edges effect replacement, add race/repeat coverage for concurrent starts, control-vs-completion, failure unwind, response detach, and process shutdown, and close the deletion register against the merged tree. Executed as four authored, independently mergeable slices (P7-A through P7-D) in order, per docs/internal/packaged-service-structure/build-time-runtime-composition-plan.md (P7 section starting line 1052).",
  "context": {
    "customerAsk": "Finish BTRC by proving, through real functional and race tests running through root.BuildProcess/Process.Execute with only edges.Edges-level effect replacement, that every lifecycle operation (start, invoke, replay, direct execution, control, result, response observation, shutdown) behaves correctly under concurrency and failure, and close out the deletion register against the tree as actually merged.",
    "problem": "P3-P6 converged the production composition graph onto one canonical path, but the behavioral guarantees that convergence depends on (exactly-once cleanup on failure, one stable terminal outcome under cancellation/timeout/provider failure, terminal-response identity/ordering across CLI/HTTP/MCP/ACP, replay equivalence, and dispatch idempotency under concurrency) are only partially characterized as direct, owner-level behavior tests. Some caller/scenario combinations (full runProcess lifecycle and close-error joining, a public detached-worker caller guard, a public multi-part Work terminal response, and a cross-caller terminal-response corpus) have no direct guard at all, and deletion registers can drift from the tree as it lands on main.",
    "solution": "Execute the plan's four authored P7 slices in order (P7-A public behavior matrix and characterization, P7-B terminal response/CLI-API parity/Work content closure, P7-C activation failure/cancellation/exactly-once unwind/dispatch races, P7-D final reruns and deletion-register closure). Each slice freezes/extends characterization, adds or strengthens direct behavioral guards including -race and repeat-count races, deletes only its own temporary test scaffolding, and the final slice reconciles the deletion register against the actually-merged tree. No slice adds a production compatibility path or substitutes a source/route/command/registration/inventory/link/asset scan for behavioral proof."
  },
  "acceptanceCriteria": [
    "Every lifecycle operation named in the plan's behavior matrix (start, invoke, replay, direct execution, control, result, response observation, shutdown) is driven end-to-end in functional tests through root.BuildProcess/Process.Execute, with external effects replaced only via edges.Edges.",
    "New or strengthened race/repeat-sensitive tests (concurrent starts, control-vs-completion races, failure unwind/exactly-once cleanup, response-stream detach, process shutdown) pass under go test -race and -count>=2, with output captured in each slice's PR description or a PR comment.",
    "No remaining secondary composition path constructs service roots at operation time outside the canonical root.BuildProcess/Wire graph, proven by a direct test or existing boundary/structure check.",
    "The named cross-packet corpus test tests/functional/sessions/root_composition/p3_p7_behavior_matrix_test.go:TestP3P7CanonicalPathPreservesTerminalCleanupAndReplayIsolation exists, runs real canonical operations, and asserts one terminal outcome, post-activation cleanup, cancellation/failure handling, and equivalent replay facts in isolated sessions.",
    "By the close of the final slice, the deletion register(s) under docs/internal/packaged-service-structure/ reflect the tree as actually merged to main, with zero stale rows.",
    "Quality gate: typecheck passes; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green; relevant unit and functional test tiers pass for every changed package.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "btrc-p7-functional-race-close-001",
      "title": "P7-A: public behavior matrix and pre-move gap characterization",
      "description": "As a maintainer, I need a frozen, owner-attributed matrix of every customer-observable lifecycle operation (activation, Work admission, direct/child dispatch, terminal result, response stream, replay, cancellation, cleanup) with its existing assertion and owning package recorded, plus characterization tests for any cell that currently lacks a direct guard running through root.BuildProcess/Process.Execute, so later P7 slices strengthen from a known baseline.",
      "acceptanceCriteria": [
        "A behavior matrix keyed by customer operation x observable outcome is committed, recording the existing assertion and owning package for every cell named in the plan's caller-by-caller migration table.",
        "Any matrix cell with no direct guard gets a new or extended characterization test exercising the real canonical path (root.BuildProcess, Process.Execute, or root.BuildStatelessWorkers for detached behavior) with only edges.Edges/command-runner/event-fixture/controlled-clock replacement, no sleeps or timeout padding as synchronization.",
        "This slice makes no production deletion; changed files limited to test files and the matrix doc/table (8-14 changed files).",
        "go test -race passes for every newly added or modified test file in this slice.",
        "Typecheck passes.",
        "Tests pass (make test-root-process-acceptance and the focused packages touched)."
      ],
      "priority": 1,
      "passes": true,
      "notes": "Delivered in commit dc0fc091d (5 changed files). Matrix: docs/internal/packaged-service-structure/btrc-p7-behavior-matrix.md - 8 sections keyed by the plan's caller-by-caller table, each row recording customer operation x observable outcome, the existing assertion, the owning package, and status; plus a Reconciliation findings table. Gap cells closed: (1) cmd/factory/main_lifecycle_test.go:TestRunProcessCompletesCanonicalLifecycleAndMapsExitCode + TestRunProcessReusesNoStateAcrossSequentialInvocations - runProcess had no direct guard of any kind; (2) tests/functional/sessions/root_composition/process_lifecycle_close_test.go:TestRootProcessCloseAfterFailedCommandPreservesTheCommandFailure + TestRootProcessCloseAfterSuccessfulCommandReportsNoFailure - close-error joining after a command ran; (3) tests/functional/workers/agent/stateless_root_test.go:TestBuildStatelessWorkersExecutesDetachedAttemptThroughRoot + TestBuildStatelessWorkersReleasesDetachedAttemptOnCancellation - the plan-named public detached-worker caller guard existed only inside pkg/root; (4) agentrun/detached_test.go:TestExecuteDetachedTimeoutSurfacesAgentRunTimeoutClass - the plan-named executor_test.go does not exist and the nearest coverage was a pure class-mapping call. Reconciliation findings recorded in the matrix: TestFactoryImpl_WorkerSessionCompletionRacesExplicitAcceptanceAndCanonicalReplay is absent (P7-C owns it); the Work terminal-response guard is P7-B; the P3-P7 corpus guard is P7-D. No production change and no deletion. Verification: go vet clean on all four packages; -count=2 green for ./cmd/factory and the agentrun package; full package runs green for tests/functional/workers/agent and tests/functional/sessions/root_composition; make test-root-process-acceptance exit 0; make typecheck exit 0; make pkg-file-count, pkg-structure, backend-size, pkg-maint all green. go test -race cannot run on this Windows host - ThreadSanitizer fails to allocate on untouched control packages too - so the Linux CI race lane owns that evidence; noted in the PR comment."
    },
    {
      "id": "btrc-p7-functional-race-close-002",
      "title": "P7-B: terminal response, CLI/API parity, and Work content closure",
      "description": "As a maintainer, I need direct proof that terminal responses, CLI/API invocation parity, and multi-part Work content survive through the public boundary unchanged in identity, ordering, and discriminated type, so protocol-level regressions in the canonical path are caught by tests.",
      "acceptanceCriteria": [
        "The planned direct guard tests/functional/transport/http/server/work_terminal_response_test.go:TestWorkTerminalResponsePreservesOrderedTypedContentThroughPublicBoundary exists, submits a Work whose terminal result has at least two differently typed, ordered parts (text then JSON), and asserts both discriminated types/payloads stay in order and a failure terminal outcome is never reported as success.",
        "CLI/API invocation parity (success, domain failure, cancellation) is directly asserted through root-process-backed tests for local and remote CLI paths.",
        "HTTP response-event and reconnect/replay behavior (typed ordered payloads, concurrent-session isolation) is directly asserted, with go test -race passing for the concurrent-session test.",
        "Any temporary shadow/comparison fixture used only to bridge the old and canonical paths is deleted once the canonical owner assertions pass; no compatibility path is added to satisfy a fixture.",
        "Changed files stay in the 12-20 range for this slice; no production deletion beyond removing this slice's own temporary fixtures.",
        "Typecheck passes.",
        "Tests pass, including go test -race for the concurrency-sensitive cases in this slice."
      ],
      "priority": 2,
      "passes": true,
      "notes": "Closed in commit cf7b5ee29 (3 files). Two new guards plus the matrix update.\n1. tests/functional/transport/http/server/work_terminal_response_test.go:TestWorkTerminalResponsePreservesOrderedTypedContentThroughPublicBoundary - submits Work whose terminal content is a TEXT part followed by a JSON part through POST /factory-sessions/~default/work, and asserts GET /work and GET /work/{id} both keep the two discriminated types in submitted order with a TERMINAL state type; the second sub-test drives a provider ExitCode 1 and asserts FAILED classification (one failed / zero terminal in the status categories) so a failure is never reported as success. Falsified: removing workPropagation PRESERVE_INPUT collapses the terminal content to the single worker text part and the guard fails.\n2. tests/functional/events/response_events/concurrent_session_isolation_test.go:TestConcurrentFactorySessionResponseEventStreamsStayIsolatedAndResumeFromCursor - two Factory Sessions invoked concurrently with one response-event SSE stream each; decodes the RUN and MESSAGE payload unions in published order, asserts every event carries its own canonical factorySessionId, disjoint eventIds and dispatchIds, no foreign message text, exactly one provider dispatch per session, then reopens the first stream with after_sequence and requires exactly the retained suffix, ascending, with no duplicate of the acknowledged prefix. Falsified: pointing the second stream at the first session fails the guard.\nCLI/API invocation parity (criterion 2) needed no new test - success, domain failure and cancellation parity for local and remote CLI are already asserted through support.BuildProcess in tests/functional/sessions/lifecycle/remote_lifecycle_test.go (TestCLILocalAndRemoteRun{Success,DomainFailure,Cancellation}ParityThroughRootProcess). Verified against the plan wording and recorded in the matrix rather than duplicated.\nNo temporary shadow/comparison fixture remains (the two probe files used during investigation were deleted). No production change, no compatibility path, no deletion.\nVerification: gofmt clean; go vet clean on both packages; both packages green at -count=1 alone and at -count=2 with -p 1; make pkg-file-count / pkg-structure / backend-size / pkg-maint all green. -race is unavailable on this Windows host (ThreadSanitizer error 87 even on control packages), so the Linux CI race lane owns the -race evidence for the concurrent-session test; stated in the PR comment.\nSlice size is 3 changed files rather than the plan's 12-20: only two named behavior cells were actually missing, and padding the slice would have meant adding tests with no uncovered cell behind them."
    },
    {
      "id": "btrc-p7-functional-race-close-003",
      "title": "P7-C: activation failure, cancellation, exactly-once unwind, and dispatch races",
      "description": "As a maintainer, I need direct race and repeat-count evidence that activation failure closes every acquired resource exactly once with the primary error preserved, that cancellation/timeout/provider failure/worker completion each produce exactly one stable terminal outcome, that Runtime accepts concurrent/duplicate dispatch completion exactly once, and that canonical replay stays equivalent and isolated across concurrent recording scopes.",
      "acceptanceCriteria": [
        "Activation-failure closure is directly asserted (acquired Runtime/Visualization resources close exactly once; primary error is preserved; process close continues through every lifecycle owner), strengthening or adding to the named tests in pkg/initializer/lifecycle/manager_test.go and pkg/wire/session_runtime_providers_test.go.",
        "Concurrent/duplicate dispatch completion is directly asserted to resolve exactly once with correct terminal-outcome mapping for both direct and child dispatch, under go test -race.",
        "Canonical replay equivalence and cross-scope isolation under concurrent access is directly asserted for Recordings.",
        "All new or modified tests in this slice pass under go test -race and -count>=2; command output demonstrating this is captured in the PR description or a PR comment, never committed to a file.",
        "Temporary race harnesses or one-shot dual-path probes are deleted once deterministic race evidence is green on the canonical path alone; any old production path actually found here is reported to P6 as the named deleting successor, not deleted inline by this slice.",
        "Changed files stay in the 12-20 range for this slice.",
        "Typecheck passes.",
        "Tests pass, including the -race/-count>=2 runs above."
      ],
      "priority": 3,
      "passes": true,
      "notes": "Closed in commit 44cbf3dc1 (5 files, no production change, no deletion).\n1. pkg/initializer/lifecycle/manager_test.go:TestManagerUnwindsStartFailureAndJoinsCleanupErrors - strengthened from an errors.Is check into an exactly-once unwind guard: only components that actually started are stopped, in reverse declaration order, exactly once each; the component whose Start failed is never stopped; no component declared after the failure is started; the primary runner never runs; every acquired resource closes exactly once in reverse order; the primary start failure is retained beside each cleanup failure. Falsified: appending a candidate to the started set before Start succeeds produces stop-failing in the unwind and the guard fails (the old assertion passed with that regression).\n2. pkg/wire/session_runtime_providers_test.go:TestProvideApplicationProcessLifecycle_ClosesProvidersAndEventsExactlyOnceAfterAFailure - new. The pre-existing TestProcessCloseContinuesThroughEveryLifecycleOwnerAfterFailure proved the compositeProcessLifecycle aggregator with three hand-built closers; nothing proved the lifecycle provideApplicationProcessLifecycle actually composes. The new guard drives the real composition with observable Providers and Events stand-ins and requires both reached exactly once, in composition order, with both teardown failures joined. Falsified: returning early from compositeProcessLifecycle.Close on the first failure fails both this and the existing guard. (localWorkerSessions.Close and the nil factoryTarget closer are hard-coded no-ops, so only the two resource-owning closers are observable.)\n3. pkg/services/factory_runtime/.../runtime/dispatch_workers_root_boundary_test.go:TestFactoryImpl_ConcurrentDuplicateCompletionResolvesExactlyOnceForDirectAndChildDispatch - new. Finding: both pre-existing concurrent-acceptance guards (TestFactoryImpl_ConcurrentAcceptDispatchResultResolvesExactlyOnce and ...WorkerSessionCompletionRacesExplicitAcceptanceAndCanonicalIdempotency) drive SubmitWorkRequest + Run, which is the scheduler-originated CHILD origin; the Runtime-root PlanDispatch (DIRECT) origin had no duplicate-completion race guard at all. The new guard parks each origin's dispatch inside the Workers boundary, releases 8 duplicate AcceptDispatchResult callers together, and requires exactly 1 RETIRED + 7 DUPLICATE_IDEMPOTENT + 0 errors, one Worker Session association, no duplicate canonical response, zero in flight after the late Workers callback, and an identical terminal mapping (SUCCESS and FAILURE) from both origins. Falsified: classifying duplicate retirement as RETIRED makes it fail 8/0. Probed rather than assumed: the direct origin records NO RecordWorkstationResponse when an external acceptance wins the race, so the guard asserts association==1 and response<=1 instead of response==1.\n4. pkg/services/recordings/internal/canonical_recording_lifecycle_test.go:TestRecordingScopeReplayIsEquivalentAndIsolatedUnderConcurrentAccess - new. Pre-existing coverage asserted replay equivalence sequentially for one scope and concurrent isolation of PROJECTION queries; concurrent canonical REPLAY was unguarded. Two finalized scopes, 8 concurrent full replays each (CreateReplayPlanScope + ObserveReplayScope to completion), each required to equal exactly its own scope's retained ReconstructRecordingScope world state, plus an anti-vacuity check that the two retained projections differ. Falsified: pointing every replay at the first scope's ref fails with 'concurrent replay of concurrent-replay-b diverged from its retained projection'.\n5. docs/internal/packaged-service-structure/btrc-p7-behavior-matrix.md - rows moved to Closed by P7-C, a P7-C closure section, and a correction to a P7-A reconciliation row: the plan-named ...AndCanonicalReplay guard is absent only under that exact name; the same file carries ...AndCanonicalIdempotency, which covers the Runtime half and explicitly defers the canonical-replay half to Recordings. P7-C closes the replay half at that owner rather than adding a duplicate Runtime test under the plan's name.\nCriterion 5 (temporary race harnesses / dual-path probes deleted): none were created; the guards run on the canonical path directly. No old production path was found, so nothing was reported to P6.\nSlice size is 5 changed files rather than the plan's 12-20: the owner-tier activation-failure branches (adapter failure, lifecycle-planning failure) already assert exactly-once close with the primary error preserved in pkg/services/factory_sessions/internal/applicationopening/service_test.go, so only the cells above were actually missing.\nVerification: gofmt clean; go vet clean on all four packages; all four packages green at -count=1 and -count=2 with -p 1; make test-root-process-acceptance exit 0; make typecheck exit 0; make pkg-file-count, pkg-structure, backend-size, pkg-maint all green. -race is unavailable on this Windows host (ThreadSanitizer error code 87 even on untouched control packages), so the Linux CI race lane owns the -race evidence; stated in the PR comment.\nFile-count note: the new dispatch race guard went into dispatch_workers_root_boundary_test.go rather than dispatch_worker_sessions_idempotency_test.go because the latter is at 842 lines against the 1000-line backend-size limit and both packages are pkg-file-count baselined, so no new file could be added."
    },
    {
      "id": "btrc-p7-functional-race-close-004",
      "title": "P7-D: final functional/race reruns, deletion register closure, and owner handoff",
      "description": "As a maintainer, I need the full P7 behavior corpus (including the named cross-packet test) rerun clean against the tree as merged through P7-A/B/C, stale test-only adapters removed, and the deletion register reconciled to zero stale rows against the merged tree, so the packet can be declared closed with reviewer-verifiable evidence.",
      "acceptanceCriteria": [
        "tests/functional/sessions/root_composition/p3_p7_behavior_matrix_test.go:TestP3P7CanonicalPathPreservesTerminalCleanupAndReplayIsolation exists, runs real canonical operations through root.BuildProcess/Process.Execute, and asserts one terminal outcome, post-activation cleanup, cancellation/failure handling, and replay/session isolation.",
        "The full set of P7 named direct guards (P7-A through P7-C, plus this slice's corpus test) is rerun and passes locally in both normal and -race execution; results are reported in the PR description/comment.",
        "Any remaining stale test-only adapter or scaffolding left over from P7-A/B/C is removed.",
        "The deletion register(s) under docs/internal/packaged-service-structure/ (at minimum btrc-p6-secondary-graph-register.md and this plan's own P7 rows) are updated so every row reflects the tree as merged through this slice, with no stale or missing rows, and any updates are surgical rather than a bulk regeneration.",
        "Where a manifest/baseline file (ownership inventory, coverage minimums, package-target manifest, package file count, deadcode baseline) needs a row removed because this slice deletes a package or file it names, that row is removed surgically in the same change, and affected coverage manifests remain sorted and entry-complete.",
        "Changed files stay in the 8-16 range for this slice.",
        "Typecheck passes.",
        "Tests pass, including the full -race/-count>=2 reruns above."
      ],
      "priority": 4,
      "passes": true,
      "notes": "Closed in commits fa2e76390 (corpus test), a791e3820 (first register reconciliation) and 56b4617e8 (re-verification on the rebased base). 3 files, no production change, no deletion.\n1. tests/functional/sessions/root_composition/p3_p7_behavior_matrix_test.go:TestP3P7CanonicalPathPreservesTerminalCleanupAndReplayIsolation - exists at the plan-named path. Drives four canonical root processes through root.BuildProcess + Process.Execute with external effects replaced only via edges.Edges (APIServerStarter, FactorySessionRuntimeInstanceIDGenerator, ProviderCommandRunner). Asserts the four cross-packet claims together: (a) one terminal outcome - served status categories report exactly one terminal (or failed) and zero of the other, and exactly one workstation outcome replayed from the retained canonical stream alone classifies the same way; (b) post-activation cleanup - transport activated exactly once, released exactly once by shutdown, a repeated Close neither fails nor releases again, released listener refuses a fresh connection, guarded against vacuity by requiring a non-zero Factory Session runtime-activation count; (c) cancellation/failure - provider ExitCode 1 terminalizes FAILED with zero terminal, and a dispatch parked inside the provider boundary observes context.Canceled on shutdown; (d) replay isolation - two sessions from one authored Factory in two independent root processes give equal ordered outcomes, same terminal state name, same work-correlated event vocabulary, disjoint session and Work identity, no cross-references, no sequence regression. Each claim falsified once.\n2. Rebased onto origin/main (75d51e97d) before the reruns, per the operator note. Base moved from 7018644b3 to 75d51e97d, picking up #2047, #2049, #2050 and #2051.\n3. Deletion-register closure. a791e3820 reconciled the P6 register against fd0e46ab9; 56b4617e8 re-verified it mechanically on the rebased base - each of the register's 14 file-line claims re-read at that exact line and matched against the symbol it should carry; all 14 still resolve (#2050 touched pkg/platform/process and the provider adapters, #2051 removed unreachable test helpers, neither being a composition seam the register tracks). Five rows corrected surgically in total: pinned reconciliation base, APIFactory reference count (1 -> 14), NewInvocationWithProgress caller line (28 -> 31), the roles importer count (\"~58\" -> the measured 57, since an approximate count cannot be re-verified), and the deadcode static-gate numbers superseded by #2051 (baseline 342/current 545 -> baseline 257/current 487), recorded as a \"Superseded on main\" note rather than by overwriting what P6 measured. Also removed a self-defeating sentence that asserted no P7-scoped TODO marker exists while writing that marker literally, so an audit grep matched the document making the claim. All zero-match, package-absence, guard-test, opening-package-file-count (25/3/9/4) and TODO(P6-C) claims independently re-verified green.\n4. Criterion 3 (stale scaffolding): none exists. P7-A/B/C created no shadow fixture, dual-path probe or temporary race harness; the two P7-B probe files were deleted before that commit. Verified: git status clean, zero untracked files.\n5. Criterion 5 (manifest/baseline rows): P7-D deletes no package and no file, so no row required removal and every coverage manifest stays sorted and entry-complete. make deadcode reports 487 at this head, identical to main, so the packet contributes zero findings against the 562 allowance.\nVerification (all at the rebased head): go build ./... exit 0; go vet clean on all 10 changed packages; unit tier (cmd/factory, pkg/initializer/lifecycle, runtime, recordings/internal, agentrun, pkg/wire) green at -count=2 -p 1; functional tier (root_composition, response_events, transport/http/server, workers/agent) green at -count=2; make typecheck exit 0; make pkg-file-count, pkg-structure, backend-size, pkg-maint all green; gofmt clean on every changed Go file.\nCriterion 6 deviation: P7-D changed 3 files, not the planned 8-16. Only one behavior cell (the corpus) and the register were actually open, and no package or file was deleted, so there was no manifest or baseline row to remove. Padding the slice would have meant adding tests with no uncovered cell behind them.\nCriterion 2 deviation (-race): the race detector cannot run on this Windows host - ThreadSanitizer fails to allocate (error code 87) on the untouched control package ./pkg/root as well, re-confirmed at this head - so the Linux CI race lane owns the -race evidence. Stated in the PR comment.\nOne flake observed and attributed, not committed: tests/functional/workers/agent:TestBuildProcessExecutesModelWorkerThroughConvergedWorkersService failed once with \"process API server starter was never invoked\" during the 4-package run, then passed 3/3 at the same head (alone at -count=1, and at -count=2 both with and without this branch's two added tests in the binary). Root cause is pre-existing: no test in that package isolates HOME/USERPROFILE, so they share the real ~/.you-agent-factory customer home, and the packaged-factory bootstrap contends with co-tenant lanes on this host (9 concurrent go/unitlane/deadcode processes from other worktrees were measured during the failing run). The failing test is pre-existing and untouched by this diff; this branch's two added tests in that package are t.Parallel() and ordered after it, so they are paused while it runs. Recorded in a PR comment."
    }
  ]
}
```
