### PR TITLE
fix(factory_definitions): publish a staging lease only after its owner is known

### DIFF
--- a/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/service.go
+++ b/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/service.go
@@ -378,45 +378,14 @@ func (service *Service) acquireStagingOwnership(
 			}
 			return nil, contention
 		}
-		if err := service.fileSystem.MkdirAll(rootDir, 0o755); err != nil {
-			return nil, service.installationFailure(backendScopeID, rootDir, name, "", ownerLivenessIndeterminate, err)
-		}
-		leasePath := stagingOwnershipPath(rootDir, name)
-		if err := service.directoryCreator(leasePath, 0o755); err != nil {
-			if errors.Is(err, fs.ErrExist) {
-				continue
-			}
-			return nil, service.installationFailure(backendScopeID, rootDir, name, leasePath, ownerLivenessIndeterminate, err)
-		}
-		owner, err := service.ownerProbe.Current()
+		lease, lost, err := service.publishOwnedStagingLease(backendScopeID, rootDir, name)
 		if err != nil {
-			_ = service.fileSystem.RemoveAll(leasePath)
-			return nil, service.installationFailure(backendScopeID, rootDir, name, leasePath, ownerLivenessIndeterminate, err)
+			return nil, err
 		}
-		if owner.PID <= 0 {
-			_ = service.fileSystem.RemoveAll(leasePath)
-			return nil, service.installationFailure(
-				backendScopeID,
-				rootDir,
-				name,
-				leasePath,
-				ownerLivenessIndeterminate,
-				fmt.Errorf("owner PID is invalid: %d", owner.PID),
-			)
+		if lost {
+			continue
 		}
-		if err := service.publishOwnerRecord(leasePath, owner); err != nil {
-			_ = service.fileSystem.RemoveAll(leasePath)
-			return nil, service.installationFailure(backendScopeID, rootDir, name, leasePath, ownerLivenessIndeterminate, err)
-		}
-		service.logOutcome(
-			backendScopeID,
-			name,
-			leasePath,
-			"acquired",
-			ownerLivenessActive,
-			owner.PID,
-		)
-		return &stagingLease{path: leasePath, root: rootDir, name: name, backendScopeID: backendScopeID, owner: owner}, nil
+		return lease, nil
 	}
 	return nil, service.installationContention(
 		backendScopeID,
@@ -582,7 +551,7 @@ func (service *Service) releaseStagingOwnership(lease *stagingLease) error {
 			fmt.Errorf("staging owner changed from PID %d to PID %d", lease.owner.PID, owner.PID),
 		)
 	}
-	if err := service.fileSystem.RemoveAll(lease.path); err != nil {
+	if err := service.retractStagingLease(lease.root, lease.path); err != nil {
 		return service.installationFailure(
 			lease.backendScopeID,
 			lease.root,

--- a/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/staging_lease.go
+++ b/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/staging_lease.go
@@ -1,0 +1,155 @@
+package packagedinstallation
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+)
+
+const (
+	// stagingLeasePendingPrefix and stagingLeaseRetractedPrefix name the private
+	// directories that hold a staging lease before it is published and after it
+	// is withdrawn.
+	//
+	// Neither prefix can be discovered by findPreExistingStaging. A staging
+	// directory prefix is always "." + <factory name> + ".staging-", which
+	// contains at least two "." characters, while these names contain exactly
+	// one. A private lease directory therefore cannot be mistaken for a lease no
+	// matter which Factory name is being installed.
+	stagingLeasePendingPrefix   = ".you-packaged-lease-pending-"
+	stagingLeaseRetractedPrefix = ".you-packaged-lease-retracted-"
+)
+
+var stagingLeaseSequence uint64
+
+// privateStagingLeasePath returns a unique path inside rootDir that no staging
+// lookup can discover. Keeping it inside rootDir keeps publication a
+// same-filesystem rename, which is the atomicity the lease depends on.
+func privateStagingLeasePath(rootDir, prefix string) string {
+	sequence := atomic.AddUint64(&stagingLeaseSequence, 1)
+	return filepath.Join(rootDir, fmt.Sprintf("%s%d-%d", prefix, os.Getpid(), sequence))
+}
+
+// identifyStagingOwner resolves the owning process before any directory exists,
+// so a failed or invalid probe leaves no residue behind.
+func (service *Service) identifyStagingOwner() (ownerRecord, error) {
+	owner, err := service.ownerProbe.Current()
+	if err != nil {
+		return ownerRecord{}, err
+	}
+	if owner.PID <= 0 {
+		return ownerRecord{}, fmt.Errorf("owner PID is invalid: %d", owner.PID)
+	}
+	return owner, nil
+}
+
+// stageStagingLease builds the complete lease - directory plus owner record - at
+// a private path. Nothing observable is created here, so the lease can never be
+// seen while it is still half built.
+func (service *Service) stageStagingLease(rootDir string, owner ownerRecord) (string, error) {
+	pendingPath := privateStagingLeasePath(rootDir, stagingLeasePendingPrefix)
+	if err := service.directoryCreator(pendingPath, 0o755); err != nil {
+		return "", err
+	}
+	if err := service.publishOwnerRecord(pendingPath, owner); err != nil {
+		_ = service.fileSystem.RemoveAll(pendingPath)
+		return "", err
+	}
+	return pendingPath, nil
+}
+
+// publishStagingLease moves the fully identified private lease onto the
+// canonical staging ownership path. This rename is the single step that makes
+// the lease externally observable, so any observer that can see the lease
+// directory can also read its owner record.
+//
+// It reports whether another process published first. That lost race keeps the
+// behavior the exclusive directory reservation had: the loser discards its own
+// private lease and falls through to the existing staging contention inspection
+// and retry. A published lease is a non-empty directory, so a losing rename
+// surfaces as fs.ErrExist on some platforms and as a directory-not-empty or
+// access error on others; the presence of the destination is the portable
+// lost-race signal.
+func (service *Service) publishStagingLease(pendingPath, leasePath string) (bool, error) {
+	err := service.fileSystem.Rename(pendingPath, leasePath)
+	if err == nil {
+		return false, nil
+	}
+	_ = service.fileSystem.RemoveAll(pendingPath)
+	if errors.Is(err, fs.ErrExist) || service.stagingLeaseIsPublished(leasePath) {
+		return true, nil
+	}
+	return false, fmt.Errorf("publish staging owner lease: %w", err)
+}
+
+func (service *Service) stagingLeaseIsPublished(leasePath string) bool {
+	_, err := service.fileSystem.Stat(leasePath)
+	return err == nil
+}
+
+// retractStagingLease withdraws a published lease. The lease is renamed out of
+// the observable path first because a recursive delete unlinks the owner record
+// before the directory that holds it, which would expose exactly the
+// published-but-unidentified lease that publication is careful never to create.
+// When the platform refuses the rename the recursive delete still runs against
+// the lease directly, so a release that would otherwise succeed is never turned
+// into a failure.
+func (service *Service) retractStagingLease(rootDir, leasePath string) error {
+	retractedPath := privateStagingLeasePath(rootDir, stagingLeaseRetractedPrefix)
+	if err := service.fileSystem.Rename(leasePath, retractedPath); err != nil {
+		return service.fileSystem.RemoveAll(leasePath)
+	}
+	return service.fileSystem.RemoveAll(retractedPath)
+}
+
+// publishOwnedStagingLease identifies the owning process first, then builds the
+// lease privately and publishes it with one atomic rename. Ordering the owner
+// record ahead of publication is what guarantees that a lease visible at the
+// canonical staging path always reports a concrete owner PID instead of the
+// unattributable owner_pid=unavailable diagnostic a half-built lease produced.
+//
+// It reports lost=true when another process published first, which routes the
+// caller back through the existing staging contention inspection and retry.
+func (service *Service) publishOwnedStagingLease(
+	backendScopeID string,
+	rootDir string,
+	name string,
+) (*stagingLease, bool, error) {
+	if err := service.fileSystem.MkdirAll(rootDir, 0o755); err != nil {
+		return nil, false, service.installationFailure(backendScopeID, rootDir, name, "", ownerLivenessIndeterminate, err)
+	}
+	leasePath := stagingOwnershipPath(rootDir, name)
+	owner, err := service.identifyStagingOwner()
+	if err != nil {
+		return nil, false, service.installationFailure(backendScopeID, rootDir, name, leasePath, ownerLivenessIndeterminate, err)
+	}
+	pendingPath, err := service.stageStagingLease(rootDir, owner)
+	if err != nil {
+		return nil, false, service.installationFailure(backendScopeID, rootDir, name, leasePath, ownerLivenessIndeterminate, err)
+	}
+	lost, err := service.publishStagingLease(pendingPath, leasePath)
+	if err != nil {
+		return nil, false, service.installationFailure(backendScopeID, rootDir, name, leasePath, ownerLivenessIndeterminate, err)
+	}
+	if lost {
+		return nil, true, nil
+	}
+	service.logOutcome(
+		backendScopeID,
+		name,
+		leasePath,
+		"acquired",
+		ownerLivenessActive,
+		owner.PID,
+	)
+	return &stagingLease{
+		path:           leasePath,
+		root:           rootDir,
+		name:           name,
+		backendScopeID: backendScopeID,
+		owner:          owner,
+	}, false, nil
+}

--- a/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/staging_lease_test.go
+++ b/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/staging_lease_test.go
@@ -1,0 +1,305 @@
+package packagedinstallation
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+)
+
+const stagingLeaseObservationTimeout = 30 * time.Second
+
+// TestInstallPackagedFactory_PublishedStagingLeaseAlwaysNamesItsOwner parks the
+// installer at the two moments a staging lease could become visible without an
+// owner record - directory creation during acquisition, and the recursive
+// delete during release - and proves a concurrent observer either sees no
+// staging resource at all or sees one that reports a concrete owner PID.
+//
+// The observation is repeated across a release-then-reacquire cycle by the same
+// owner, which is the sequence the CLI successor path exercises and the one
+// that produced the unattributable owner_pid=unavailable diagnostic.
+func TestInstallPackagedFactory_PublishedStagingLeaseAlwaysNamesItsOwner(t *testing.T) {
+	root := t.TempDir()
+	name := "@test/lease-identity"
+	gate := newStagingLeaseGate()
+	seam := &yieldingPackagedInstallationFileSystem{gate: gate}
+	installer := New(&successfulPackagedInstallationPersistence{}, seam, seam.Mkdir)
+	observer := New(&successfulPackagedInstallationPersistence{}, platformfilesystem.Local{}, os.Mkdir)
+	params := factorydefinitions.PackagedFactoryInstallParams{
+		NamedFactoriesRoot: root,
+		BackendScopeID:     "lease-identity-scope",
+		Definition: factorydefinitions.PackagedDefinition{
+			Name: name,
+			JSON: []byte(`{}`),
+		},
+		Format: factorydefinitions.PackagedFactoryFormatJSON,
+	}
+
+	installDone := make(chan error, 1)
+	go func() {
+		// Two installations in sequence acquire, release, then reacquire the
+		// same canonical lease path with the same owning process.
+		for attempt := 0; attempt < 2; attempt++ {
+			if _, err := installer.InstallPackagedFactory(t.Context(), params); err != nil {
+				installDone <- fmt.Errorf("install attempt %d: %w", attempt+1, err)
+				return
+			}
+		}
+		installDone <- nil
+	}()
+
+	acquisitionYields, releaseYields := 0, 0
+	for done := false; !done; {
+		select {
+		case parked := <-gate.reached:
+			if strings.HasPrefix(parked, "mkdir:") {
+				acquisitionYields++
+			} else {
+				releaseYields++
+			}
+			observeStagingLeaseIdentity(t, observer, root, name, parked)
+			gate.release <- struct{}{}
+		case err := <-installDone:
+			if err != nil {
+				t.Fatalf("InstallPackagedFactory() error = %v", err)
+			}
+			done = true
+		case <-time.After(stagingLeaseObservationTimeout):
+			t.Fatalf("timed out waiting for staging lease observation; acquisitions=%d releases=%d", acquisitionYields, releaseYields)
+		}
+	}
+
+	if acquisitionYields < 2 {
+		t.Errorf("observed %d lease acquisition windows, want the acquire and reacquire of a release-then-reacquire cycle", acquisitionYields)
+	}
+	if releaseYields < 2 {
+		t.Errorf("observed %d lease release windows, want one per installation", releaseYields)
+	}
+	if _, err := os.Stat(stagingOwnershipPath(root, name)); !os.IsNotExist(err) {
+		t.Errorf("staging lease stat error = %v, want the lease released", err)
+	}
+	assertNoStagingLeaseResidue(t, root)
+}
+
+// observeStagingLeaseIdentity is the concurrent observer. It runs the package's
+// own staging inspection path while the installer is parked, and holds the
+// invariant the diagnostic depends on: a discoverable staging resource always
+// reports an owner PID a remediation can act on.
+func observeStagingLeaseIdentity(t *testing.T, observer *Service, root, name, parked string) {
+	t.Helper()
+	stagingPath, err := findPreExistingStaging(platformfilesystem.Local{}, root, name)
+	if err != nil {
+		t.Errorf("findPreExistingStaging() while parked at %s error = %v", parked, err)
+		return
+	}
+	if stagingPath == "" {
+		// No lease is observable at all, which is the other legal outcome.
+		return
+	}
+	if stagingPath != stagingOwnershipPath(root, name) {
+		t.Errorf(
+			"staging lookup while parked at %s discovered %q, want only the canonical lease path %q; a private lease path must never be discoverable",
+			parked,
+			stagingPath,
+			stagingOwnershipPath(root, name),
+		)
+		return
+	}
+	contention, retry, recovered, inspectErr := observer.inspectStagingContention(
+		"observer-scope",
+		root,
+		name,
+		stagingPath,
+	)
+	if inspectErr != nil {
+		t.Errorf("inspectStagingContention() while parked at %s error = %v", parked, inspectErr)
+		return
+	}
+	if recovered != nil {
+		t.Errorf("observer reclaimed the live lease at %s while parked at %s", recovered.path, parked)
+		return
+	}
+	if retry {
+		// The lease was released between lookup and inspection, so nothing was
+		// observable by the time the owner record was read.
+		return
+	}
+	if contention == nil {
+		t.Errorf("inspectStagingContention() while parked at %s returned no diagnostic for a visible lease", parked)
+		return
+	}
+	message := contention.Error()
+	if strings.Contains(message, "owner_pid=unavailable") {
+		t.Errorf("observer saw a published lease with no readable owner while parked at %s: %s", parked, message)
+		return
+	}
+	if want := fmt.Sprintf("owner_pid=%d", os.Getpid()); !strings.Contains(message, want) {
+		t.Errorf("staging diagnostic while parked at %s = %q, want %q", parked, message, want)
+	}
+}
+
+// assertNoStagingLeaseResidue proves the private paths used to build and
+// withdraw a lease are always cleaned up, so a completed installation leaves
+// the Factory root exactly as it found it.
+func assertNoStagingLeaseResidue(t *testing.T, root string) {
+	t.Helper()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read Factory root: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), stagingLeasePendingPrefix) ||
+			strings.HasPrefix(entry.Name(), stagingLeaseRetractedPrefix) {
+			t.Errorf("private staging lease residue %q was left behind", entry.Name())
+		}
+	}
+}
+
+// TestPrivateStagingLeasePathsAreNotDiscoverableStagingResources proves the
+// private build and withdraw paths cannot be mistaken for a lease. They live in
+// the same directory the staging lookup scans, so a name that matched the
+// staging prefix would reintroduce the unidentified-lease diagnostic through a
+// different door.
+func TestPrivateStagingLeasePathsAreNotDiscoverableStagingResources(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{
+		"@test/private-paths",
+		"you-packaged-lease-pending",
+		"you-packaged-lease-retracted",
+		"",
+	} {
+		for _, prefix := range []string{stagingLeasePendingPrefix, stagingLeaseRetractedPrefix} {
+			privatePath := privateStagingLeasePath(root, prefix)
+			if err := os.Mkdir(privatePath, 0o755); err != nil {
+				t.Fatalf("create private lease path: %v", err)
+			}
+			discovered, err := findPreExistingStaging(platformfilesystem.Local{}, root, name)
+			if err != nil {
+				t.Fatalf("findPreExistingStaging(%q) error = %v", name, err)
+			}
+			if discovered != "" {
+				t.Errorf(
+					"findPreExistingStaging(%q) = %q with private path %q present, want no staging resource",
+					name,
+					discovered,
+					filepath.Base(privatePath),
+				)
+			}
+			if err := os.RemoveAll(privatePath); err != nil {
+				t.Fatalf("remove private lease path: %v", err)
+			}
+		}
+	}
+}
+
+// TestPublishStagingLeaseTreatsAnOccupiedDestinationAsALostRace proves the
+// lost-race signal does not depend on one platform's rename error. A published
+// lease is a non-empty directory, so the losing rename reports fs.ErrExist on
+// some platforms and a directory-not-empty or access error on others.
+func TestPublishStagingLeaseTreatsAnOccupiedDestinationAsALostRace(t *testing.T) {
+	root := t.TempDir()
+	service := New(&successfulPackagedInstallationPersistence{}, platformfilesystem.Local{}, os.Mkdir)
+	leasePath := stagingOwnershipPath(root, "@test/occupied")
+	if err := os.MkdirAll(leasePath, 0o755); err != nil {
+		t.Fatalf("create winner lease: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(leasePath, stagingOwnerMetadataName), []byte(`{"pid":4242}`), 0o600); err != nil {
+		t.Fatalf("write winner owner metadata: %v", err)
+	}
+	pendingPath, err := service.stageStagingLease(root, ownerRecord{PID: os.Getpid()})
+	if err != nil {
+		t.Fatalf("stageStagingLease() error = %v", err)
+	}
+
+	lost, err := service.publishStagingLease(pendingPath, leasePath)
+	if err != nil {
+		t.Fatalf("publishStagingLease() error = %v, want a clean lost race", err)
+	}
+	if !lost {
+		t.Fatal("publishStagingLease() lost = false, want the occupied destination reported as a lost race")
+	}
+	if _, statErr := os.Stat(pendingPath); !os.IsNotExist(statErr) {
+		t.Errorf("pending lease stat error = %v, want the loser's private lease removed", statErr)
+	}
+	owner, _, readErr := service.readOwnerRecord(leasePath)
+	if readErr != nil {
+		t.Fatalf("readOwnerRecord() error = %v, want the winner lease preserved", readErr)
+	}
+	if owner.PID != 4242 {
+		t.Errorf("winner owner PID = %d, want 4242", owner.PID)
+	}
+}
+
+// TestPublishStagingLeaseReportsAFailureWhenTheDestinationIsAbsent proves a
+// rename failure that is not a lost race still surfaces as a bounded failure
+// rather than being retried forever.
+func TestPublishStagingLeaseReportsAFailureWhenTheDestinationIsAbsent(t *testing.T) {
+	root := t.TempDir()
+	fileSystem := &failingPackagedInstallationFileSystem{}
+	service := New(&successfulPackagedInstallationPersistence{}, fileSystem, fileSystem.Mkdir)
+	pendingPath := filepath.Join(root, "pending-lease")
+	if err := os.MkdirAll(pendingPath, 0o755); err != nil {
+		t.Fatalf("create pending lease: %v", err)
+	}
+	fileSystem.renameErr = fmt.Errorf("rename refused")
+
+	lost, err := service.publishStagingLease(pendingPath, stagingOwnershipPath(root, "@test/absent"))
+	if lost {
+		t.Fatal("publishStagingLease() lost = true, want a bounded failure when nothing occupies the destination")
+	}
+	if err == nil || !strings.Contains(err.Error(), "rename refused") {
+		t.Fatalf("publishStagingLease() error = %v, want the rename failure reported", err)
+	}
+}
+
+type stagingLeaseGate struct {
+	reached chan string
+	release chan struct{}
+}
+
+func newStagingLeaseGate() *stagingLeaseGate {
+	return &stagingLeaseGate{reached: make(chan string), release: make(chan struct{})}
+}
+
+func (gate *stagingLeaseGate) yield(parked string) {
+	gate.reached <- parked
+	<-gate.release
+}
+
+// yieldingPackagedInstallationFileSystem parks the installer at each moment a
+// staging lease could become observable without its owner record.
+type yieldingPackagedInstallationFileSystem struct {
+	platformfilesystem.Local
+	gate *stagingLeaseGate
+}
+
+// Mkdir yields after the directory exists, which is the exact window in which a
+// lease published before its owner record would be visible to an observer.
+func (fileSystem *yieldingPackagedInstallationFileSystem) Mkdir(path string, mode fs.FileMode) error {
+	if err := os.Mkdir(path, mode); err != nil {
+		return err
+	}
+	fileSystem.gate.yield("mkdir:" + path)
+	return nil
+}
+
+// RemoveAll reproduces what a real recursive delete does to a lease directory:
+// the owner record is unlinked before the directory that holds it. Yielding in
+// between exposes any lease that is removed in place instead of being renamed
+// out of the observable path first.
+func (fileSystem *yieldingPackagedInstallationFileSystem) RemoveAll(path string) error {
+	metadataPath := filepath.Join(path, stagingOwnerMetadataName)
+	if _, err := os.Stat(metadataPath); err == nil {
+		if err := os.Remove(metadataPath); err != nil {
+			return err
+		}
+		fileSystem.gate.yield("removeall:" + path)
+	}
+	return fileSystem.Local.RemoveAll(path)
+}


### PR DESCRIPTION
## Summary

Fixes packaged-Factory staging lease acquisition so the lease directory at `stagingOwnershipPath` is published **only after** its owner record is written, closing the window where a visible lease has no readable owner and installation-contention diagnostics report `owner_pid=unavailable owner_identity=unverified`.

The lease is now built privately (create directory, probe owner, write `.owner.json`) and published into `stagingOwnershipPath` via a single atomic directory rename. Release is symmetric: the lease is renamed **out** of the observable path before the recursive delete, because `RemoveAll` unlinks `.owner.json` before the directory that holds it — a second published-but-unidentified window on the release side.

Existing `fs.ErrExist` race handling and the active / orphaned / indeterminate contention classifications are preserved.

## PRD

```json
{
  "project": "you-agent-factory",
  "branchName": "thr-staging-lease-published-before-owner-identity",
  "description": "Fix packaged-Factory staging lease acquisition so the lease directory at stagingOwnershipPath is published only after its owner record is written, closing the window where a visible lease has no readable owner and installation-contention diagnostics report owner_pid=unavailable owner_identity=unverified. Build the lease privately (create directory, probe owner, write .owner.json), then publish it into stagingOwnershipPath via a single atomic directory rename, preserving existing fs.ErrExist race handling and existing active/orphaned/indeterminate contention classifications.",
  "context": {
    "customerAsk": "Fix the staging-lease publish ordering so packaged-Factory installation contention diagnostics can always identify the owning process for a visible lease, without touching tests/functional/transport/cli/process/hard_kill_successor_test.go and without touching pkg/services/workers, pkg/services/factory_runtime, or pkg/services/factory_sessions/internal/runtimeopening (owned by a concurrently active lane).",
    "problem": "acquireStagingOwnership in pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/service.go calls directoryCreator to publish the lease directory at stagingOwnershipPath (line 385) before it probes the owning process's PID (line 391) and writes .owner.json (publishOwnerRecord, lines 524-539). An observer that sees the lease directory during that window cannot attribute it to an owner: inspectStagingContention's zero-PID branch (readOwnerRecord returns fs.ErrNotExist while the directory still exists) emits owner_pid=unavailable owner_identity=unverified, making the diagnostic's own remediation guidance (verify no you process is still installing, remove only <path>) non-actionable. This is measured as a proven-nondeterministic CI failure of TestCLISuccessorAfterHardKillReportsPreRuntimeStagingContention (same commit 469c3bbcb: one run failed, the re-run passed) reachable via a release-then-reacquire cycle, and it has survived four prior test-side hardening attempts that never touched production publish ordering.",
    "solution": "Restructure acquireStagingOwnership to build the lease (directory + owner record) at a private, not-yet-discoverable path, then publish it into the canonical stagingOwnershipPath via a single atomic directory rename (reusing the already-present service.fileSystem.Rename edge) as the one step that makes the lease externally observable. Preserve existing fs.ErrExist handling on the publish step so a genuine acquisition race still loses correctly and still reaches inspectStagingContention, and preserve all existing active/orphaned/indeterminate classification behavior. If this pushes service.go over the package size gate, extract the lease publish/identify helpers into a new sibling file in the same package rather than weakening any check."
  },
  "acceptanceCriteria": [
    "A package-level test in packagedinstallation proves that an observer can never see a lease directory at stagingOwnershipPath without also being able to read a concrete owner PID, using an injected directoryCreator/owner-probe seam that yields between publish and identity write, including across a release-then-reacquire sequence by the same owning process",
    "tests/functional/transport/cli/process/hard_kill_successor_test.go passes UNCHANGED (zero diff to that file), including its owner_pid=<predecessor pid> assertion at line 99",
    "TestCLISuccessorAfterHardKillReportsPreRuntimeStagingContention is run locally with -count=5 (and -race if supported) and passes every iteration; the exact command and its output are pasted into a PR comment, never committed to a file",
    "Existing tests in diagnostics_test.go and service_test.go in the packagedinstallation package continue to pass unmodified in behavior",
    "Existing staging-contention classifications are unchanged for active-owner contention (real PID reported), orphaned-owner reclaim (still routes through reclaimOrphanedStaging), and metadata unreadable for reasons other than not-yet-published (still classified indeterminate)",
    "Quality gate: typecheck/build passes, no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green; if service.go is at risk of exceeding the package size gate, the lease publish/identify logic is extracted into a new sibling file in the same package rather than any check being weakened or removed",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "thr-staging-lease-published-before-owner-identity-001",
      "title": "Publish the staging lease directory only after its owner record is written",
      "description": "As a maintainer of packaged-Factory installation, I want acquireStagingOwnership to build the lease directory and its owner record privately and then publish both atomically, so that no other process can ever observe a lease directory without being able to read who owns it.",
      "acceptanceCriteria": [
        "acquireStagingOwnership no longer calls service.directoryCreator on the final stagingOwnershipPath before the owner is known; it builds the lease (directory + owner record) at a private, not-yet-discoverable location, then publishes it into stagingOwnershipPath via service.fileSystem.Rename (or an equivalent already-available atomic filesystem primitive) as the single step that makes the lease externally visible",
        "The existing fs.ErrExist handling on the publish step is preserved: when another process wins the race to publish first, this process's attempt loses cleanly, cleans up its private temporary directory, and falls through to the existing inspectStagingContention/retry path exactly as before",
        "owner.PID <= 0 and owner-probe-failure handling are preserved: the private lease build is discarded (no residue left behind) and the existing installationFailure path is returned unchanged",
        "If this change pushes service.go over the package size gate, the lease publish/identify helpers are moved to a new sibling file in the same packagedinstallation package (not a new package, not a relaxed size check)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": false,
      "notes": ""
    },
    {
      "id": "thr-staging-lease-published-before-owner-identity-002",
      "title": "Prove the no-unidentified-lease invariant at package level, including release-then-reacquire",
      "description": "As a maintainer, I want a package-level test that forces the publish/identify race window open and asserts an observer always reads a concrete owner PID, so the fix is verified directly rather than only through an infrequently-triggered functional test.",
      "acceptanceCriteria": [
        "A new or extended test in the packagedinstallation package injects a directoryCreator and/or owner-probe seam that yields control between lease publication and owner identity write, and asserts that any concurrent observer calling the package's staging-inspection path during that yield either sees no lease at all or sees a lease with a fully readable owner record, never a published-but-unidentified lease",
        "The test drives at least one release-then-reacquire sequence (release the lease, have the same simulated owner immediately reacquire) and asserts the invariant holds across that sequence too",
        "The test fails against the pre-fix ordering and passes against the fixed ordering (verified during development)",
        "Existing tests in diagnostics_test.go and service_test.go continue to pass unmodified in behavior",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": false,
      "notes": ""
    },
    {
      "id": "thr-staging-lease-published-before-owner-identity-003",
      "title": "Verify the functional hard-kill-successor test is fixed, unchanged, and stable",
      "description": "As a maintainer, I need direct evidence that the previously flaky/failing functional test now passes reliably against the real CLI successor path, without any edits to the test itself.",
      "acceptanceCriteria": [
        "git diff shows zero changes to tests/functional/transport/cli/process/hard_kill_successor_test.go",
        "TestCLISuccessorAfterHardKillReportsPreRuntimeStagingContention is run locally with -count=5 (and -race if supported by the test/build tags) and passes on every iteration",
        "The exact command used and its full pass output (or a summary showing 5/5 passes) is posted as a PR comment, not committed to any file",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": false,
      "notes": ""
    }
  ]
}
```
