### PR TITLE
fix(workers): stop dropping an oversized plan-stage payload silently

### DIFF
--- a/pkg/platform/process/command.go
+++ b/pkg/platform/process/command.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -103,26 +102,14 @@ type CommandResult struct {
 // this bound is rejected before any child process exists.
 const WindowsCommandLineLimit = 32767
 
-// HostCommandLineLimit reports the composed command-line bound the running host
-// enforces for a single spawn, or 0 when the host has no single command-line
-// cap this package can state exactly. Unix hosts bound the total argument block
-// and each individual argument rather than the composed line, so they report as
-// unbounded here and their spawn failures are named from the operating system
-// error alone.
-func HostCommandLineLimit() int {
-	if runtime.GOOS == "windows" {
-		return WindowsCommandLineLimit
-	}
-	return 0
-}
-
 // ComposedCommandLineLength reports the length, in UTF-16 code units, of the
 // command line the Windows process loader receives for one command and its
 // arguments. The quoting mirrors os/exec, and the command name is measured as
 // written because os/exec composes the command line from the requested argv
 // rather than the resolved executable path. The measurement is computed the
 // same way on every platform so command-line growth stays observable from any
-// host, while HostCommandLineLimit decides whether that growth is fatal.
+// host, while the injected ExecCommandRunner.CommandLineLimit decides whether
+// that growth is fatal.
 func ComposedCommandLineLength(command string, args []string) int {
 	var line strings.Builder
 	appendEscapedCommandLineArgument(&line, command)
@@ -195,6 +182,14 @@ type ExecCommandRunner struct {
 	Clock              Clock
 	NewCommand         CommandFactory
 	ProcessStateReader ProcessStateReader
+	// CommandLineLimit is the composed command-line bound the host process
+	// loader enforces for a single spawn, injected by the application injector
+	// because the running operating system is a policy this package must not
+	// select for itself. Zero means the host states no single composed-line cap,
+	// which is how Unix hosts report: they bound the total argument block and
+	// each individual argument rather than the composed line, so their spawn
+	// failures are named from the operating system error alone.
+	CommandLineLimit int
 }
 
 // NewExecCommandRunner constructs a host command runner from exact external
@@ -238,7 +233,7 @@ func (r ExecCommandRunner) run(
 	cleanupLogger := logging.EnsureLogger(r.Logger)
 	configureCommandProcessTree(cmd)
 	if err := cmd.Start(); err != nil {
-		return CommandResult{}, reportCommandStartFailure(cleanupLogger, req, err)
+		return CommandResult{}, r.reportCommandStartFailure(cleanupLogger, req, err)
 	}
 
 	tree, attachErr := attachCommandProcessTree(cmd)
@@ -353,13 +348,15 @@ func (e *CommandStartError) Unwrap() error {
 // reportCommandStartFailure names and records a spawn that produced no child
 // process. Returning the operating-system error bare left an oversized command
 // line indistinguishable from any other execution failure and wrote nothing to
-// the log, so the only remaining evidence was how quickly the attempt died.
-func reportCommandStartFailure(logger logging.Logger, req CommandRequest, cause error) error {
+// the log, so the only remaining evidence was how quickly the attempt died. The
+// bound the failure is judged against is the runner's injected limit, so this
+// package never has to ask which operating system it is running on.
+func (r ExecCommandRunner) reportCommandStartFailure(logger logging.Logger, req CommandRequest, cause error) error {
 	startErr := &CommandStartError{
 		Command:           req.Command,
 		ArgsCount:         len(req.Args),
 		CommandLineLength: ComposedCommandLineLength(req.Command, req.Args),
-		CommandLineLimit:  HostCommandLineLimit(),
+		CommandLineLimit:  r.CommandLineLimit,
 		StdinBytes:        len(req.Stdin),
 		Cause:             cause,
 	}

--- a/pkg/platform/process/command.go
+++ b/pkg/platform/process/command.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -94,6 +96,98 @@ type CommandResult struct {
 	ExitCode int
 }
 
+// WindowsCommandLineLimit is the maximum number of UTF-16 code units, including
+// the terminating null, that the Windows process loader accepts for one
+// composed command line. os/exec joins the command name, every argument, and
+// its quoting into that single string, so an argument large enough to cross
+// this bound is rejected before any child process exists.
+const WindowsCommandLineLimit = 32767
+
+// HostCommandLineLimit reports the composed command-line bound the running host
+// enforces for a single spawn, or 0 when the host has no single command-line
+// cap this package can state exactly. Unix hosts bound the total argument block
+// and each individual argument rather than the composed line, so they report as
+// unbounded here and their spawn failures are named from the operating system
+// error alone.
+func HostCommandLineLimit() int {
+	if runtime.GOOS == "windows" {
+		return WindowsCommandLineLimit
+	}
+	return 0
+}
+
+// ComposedCommandLineLength reports the length, in UTF-16 code units, of the
+// command line the Windows process loader receives for one command and its
+// arguments. The quoting mirrors os/exec, and the command name is measured as
+// written because os/exec composes the command line from the requested argv
+// rather than the resolved executable path. The measurement is computed the
+// same way on every platform so command-line growth stays observable from any
+// host, while HostCommandLineLimit decides whether that growth is fatal.
+func ComposedCommandLineLength(command string, args []string) int {
+	var line strings.Builder
+	appendEscapedCommandLineArgument(&line, command)
+	for _, arg := range args {
+		line.WriteByte(' ')
+		appendEscapedCommandLineArgument(&line, arg)
+	}
+	return utf16CodeUnitLength(line.String())
+}
+
+// appendEscapedCommandLineArgument mirrors the quoting os/exec applies when it
+// composes a Windows command line. Reproducing the exact escaping keeps a
+// measured length equal to the string the process loader receives instead of an
+// approximation that could sit on the wrong side of the limit.
+func appendEscapedCommandLineArgument(line *strings.Builder, arg string) {
+	if arg == "" {
+		line.WriteString(`""`)
+		return
+	}
+	if !strings.ContainsAny(arg, " \t\"\\") {
+		line.WriteString(arg)
+		return
+	}
+	quoted := strings.ContainsAny(arg, " \t")
+	if quoted {
+		line.WriteByte('"')
+	}
+	backslashes := 0
+	for index := 0; index < len(arg); index++ {
+		char := arg[index]
+		switch char {
+		case '\\':
+			backslashes++
+		case '"':
+			for ; backslashes > 0; backslashes-- {
+				line.WriteByte('\\')
+			}
+			line.WriteByte('\\')
+		default:
+			backslashes = 0
+		}
+		line.WriteByte(char)
+	}
+	if quoted {
+		for ; backslashes > 0; backslashes-- {
+			line.WriteByte('\\')
+		}
+		line.WriteByte('"')
+	}
+}
+
+// utf16CodeUnitLength counts the UTF-16 code units Windows stores for one
+// command line. Characters outside the basic multilingual plane occupy two
+// units, so a byte or rune count would misreport the measured limit.
+func utf16CodeUnitLength(value string) int {
+	units := 0
+	for _, char := range value {
+		units++
+		if char > 0xFFFF {
+			units++
+		}
+	}
+	return units
+}
+
 // ExecCommandRunner implements CommandRunner by delegating to os/exec.
 type ExecCommandRunner struct {
 	// Logger emits structured process-group cleanup diagnostics. Nil disables cleanup logging.
@@ -141,12 +235,12 @@ func (r ExecCommandRunner) run(
 		return CommandResult{}, err
 	}
 
+	cleanupLogger := logging.EnsureLogger(r.Logger)
 	configureCommandProcessTree(cmd)
 	if err := cmd.Start(); err != nil {
-		return CommandResult{}, err
+		return CommandResult{}, reportCommandStartFailure(cleanupLogger, req, err)
 	}
 
-	cleanupLogger := logging.EnsureLogger(r.Logger)
 	tree, attachErr := attachCommandProcessTree(cmd)
 	if attachErr != nil {
 		cleanupLogger.Warn(
@@ -206,6 +300,87 @@ func (r ExecCommandRunner) run(
 	}
 	return result, nil
 }
+
+// CommandStartError names a subprocess that never started. The measured
+// command line travels with the error because a command line the process loader
+// rejects produces no child, no exit status, and no output, which otherwise
+// leaves the caller with a bare operating-system error and no way to tell an
+// oversized command line apart from a missing executable.
+type CommandStartError struct {
+	Command           string
+	ArgsCount         int
+	CommandLineLength int
+	CommandLineLimit  int
+	StdinBytes        int
+	Cause             error
+}
+
+// OverCommandLineLimit reports whether the composed command line reached the
+// bound the host enforces. That is the one spawn failure a caller can repair by
+// moving argument content to stdin or a file, so it is named separately from
+// every other start failure.
+func (e *CommandStartError) OverCommandLineLimit() bool {
+	if e == nil || e.CommandLineLimit <= 0 {
+		return false
+	}
+	return e.CommandLineLength >= e.CommandLineLimit
+}
+
+func (e *CommandStartError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.OverCommandLineLimit() {
+		return fmt.Sprintf(
+			"start %q: composed command line is %d characters across %d arguments, "+
+				"at or above the %d-character host command-line limit: %v",
+			e.Command, e.CommandLineLength, e.ArgsCount, e.CommandLineLimit, e.Cause,
+		)
+	}
+	return fmt.Sprintf(
+		"start %q: process start failed with a %d-character command line across %d arguments: %v",
+		e.Command, e.CommandLineLength, e.ArgsCount, e.Cause,
+	)
+}
+
+func (e *CommandStartError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+// reportCommandStartFailure names and records a spawn that produced no child
+// process. Returning the operating-system error bare left an oversized command
+// line indistinguishable from any other execution failure and wrote nothing to
+// the log, so the only remaining evidence was how quickly the attempt died.
+func reportCommandStartFailure(logger logging.Logger, req CommandRequest, cause error) error {
+	startErr := &CommandStartError{
+		Command:           req.Command,
+		ArgsCount:         len(req.Args),
+		CommandLineLength: ComposedCommandLineLength(req.Command, req.Args),
+		CommandLineLimit:  HostCommandLineLimit(),
+		StdinBytes:        len(req.Stdin),
+		Cause:             cause,
+	}
+	logger.Error(
+		"command runner: process start failed",
+		"event_name", commandRunnerStartFailedEvent,
+		"command", req.Command,
+		"args_count", startErr.ArgsCount,
+		"command_line_chars", startErr.CommandLineLength,
+		"command_line_limit", startErr.CommandLineLimit,
+		"over_command_line_limit", startErr.OverCommandLineLimit(),
+		"stdin_bytes", startErr.StdinBytes,
+		"working_dir", req.WorkDir,
+		"error", cause.Error(),
+	)
+	return startErr
+}
+
+// commandRunnerStartFailedEvent is the greppable event name an operator uses to
+// find a spawn that died before the child process existed.
+const commandRunnerStartFailedEvent = "command_runner.start_failed"
 
 func (r ExecCommandRunner) prepareCommand(
 	req CommandRequest,

--- a/pkg/platform/process/command_test.go
+++ b/pkg/platform/process/command_test.go
@@ -57,6 +57,7 @@ type recordingCommandLogger struct {
 	infos    []recordedCommandLog
 	verboses []recordedCommandLog
 	warns    []recordedCommandLog
+	errors   []recordedCommandLog
 }
 
 type recordedCommandLog struct {
@@ -77,7 +78,12 @@ func (l *recordingCommandLogger) Warn(msg string, keysAndValues ...any) {
 		fields: commandLogFieldsMap(keysAndValues...),
 	})
 }
-func (l *recordingCommandLogger) Error(_ string, _ ...any) {}
+func (l *recordingCommandLogger) Error(msg string, keysAndValues ...any) {
+	l.errors = append(l.errors, recordedCommandLog{
+		msg:    msg,
+		fields: commandLogFieldsMap(keysAndValues...),
+	})
+}
 func (l *recordingCommandLogger) Verbose(msg string, keysAndValues ...any) {
 	l.verboses = append(l.verboses, recordedCommandLog{
 		msg:    msg,
@@ -765,4 +771,197 @@ func assertLoggingCommandRunnerVerboseCompletionLog(t *testing.T, fields map[str
 	if fields["stdout_bytes"] == nil || fields["stderr_bytes"] == nil {
 		t.Fatalf("verbose completion missing output byte counters: %#v", fields)
 	}
+}
+
+func TestComposedCommandLineLength_MeasuresTheStringTheProcessLoaderReceives(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		command string
+		args    []string
+		want    int
+	}{
+		{name: "bare command", command: "claude", want: len("claude")},
+		{
+			name:    "plain arguments join with single separators",
+			command: "claude",
+			args:    []string{"-p", "--verbose"},
+			want:    len(`claude -p --verbose`),
+		},
+		{
+			name:    "arguments containing spaces gain surrounding quotes",
+			command: "claude",
+			args:    []string{"--system-prompt", "be brief"},
+			want:    len(`claude --system-prompt "be brief"`),
+		},
+		{
+			name:    "embedded quotes gain an escaping backslash",
+			command: "claude",
+			args:    []string{`say "hi"`},
+			want:    len(`claude "say \"hi\""`),
+		},
+		{
+			name:    "trailing backslashes double before the closing quote",
+			command: "claude",
+			args:    []string{`C:\work dir\`},
+			want:    len(`claude "C:\work dir\\"`),
+		},
+		{
+			name:    "empty arguments are emitted as an empty quoted pair",
+			command: "claude",
+			args:    []string{""},
+			want:    len(`claude ""`),
+		},
+		{
+			name:    "characters outside the basic multilingual plane cost two code units",
+			command: "claude",
+			args:    []string{"\U0001F600"},
+			want:    len("claude ") + 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ComposedCommandLineLength(tc.command, tc.args); got != tc.want {
+				t.Fatalf("ComposedCommandLineLength(%q, %#v) = %d, want %d", tc.command, tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestComposedCommandLineLength_GrowsWithInlinedArgumentContent(t *testing.T) {
+	t.Parallel()
+
+	small := ComposedCommandLineLength("claude", []string{"-p", strings.Repeat("a", 9152)})
+	large := ComposedCommandLineLength("claude", []string{"-p", strings.Repeat("a", 9819)})
+	if large-small != 9819-9152 {
+		t.Fatalf("inline argument growth = %d, want %d", large-small, 9819-9152)
+	}
+
+	viaStdin := ComposedCommandLineLength("claude", []string{"-p"})
+	if viaStdin >= small {
+		t.Fatalf("command line with the prompt removed = %d, want below the inline measurement %d", viaStdin, small)
+	}
+}
+
+func TestCommandStartError_NamesAnOversizedCommandLineWithItsMeasuredSize(t *testing.T) {
+	t.Parallel()
+
+	overLimit := &CommandStartError{
+		Command:           "claude",
+		ArgsCount:         12,
+		CommandLineLength: 33012,
+		CommandLineLimit:  WindowsCommandLineLimit,
+		Cause:             errors.New("The filename or extension is too long."),
+	}
+	if !overLimit.OverCommandLineLimit() {
+		t.Fatalf("OverCommandLineLimit() = false, want true for %d against %d", overLimit.CommandLineLength, overLimit.CommandLineLimit)
+	}
+	message := overLimit.Error()
+	for _, want := range []string{"claude", "33012", "12", "32767", "command-line limit", "The filename or extension is too long."} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("Error() = %q, want it to name %q", message, want)
+		}
+	}
+
+	underLimit := &CommandStartError{
+		Command:           "claude",
+		ArgsCount:         3,
+		CommandLineLength: 64,
+		CommandLineLimit:  WindowsCommandLineLimit,
+		Cause:             errors.New("executable file not found"),
+	}
+	if underLimit.OverCommandLineLimit() {
+		t.Fatalf("OverCommandLineLimit() = true, want false for %d against %d", underLimit.CommandLineLength, underLimit.CommandLineLimit)
+	}
+	if got := underLimit.Error(); strings.Contains(got, "command-line limit") {
+		t.Fatalf("Error() = %q, want it not to blame the command-line limit", got)
+	}
+
+	unbounded := &CommandStartError{CommandLineLength: 1 << 20, CommandLineLimit: 0, Cause: errors.New("boom")}
+	if unbounded.OverCommandLineLimit() {
+		t.Fatalf("OverCommandLineLimit() = true, want false when the host states no command-line limit")
+	}
+}
+
+func TestCommandStartError_UnwrapsTheOperatingSystemCause(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("fork/exec failed")
+	err := error(&CommandStartError{Command: "claude", Cause: cause})
+	if !errors.Is(err, cause) {
+		t.Fatalf("errors.Is(%v, cause) = false, want true", err)
+	}
+}
+
+func TestExecCommandRunner_StartFailureReturnsANamedErrorAndLogsIt(t *testing.T) {
+	logger := &recordingCommandLogger{}
+	missing := filepath.Join(t.TempDir(), "provider-executable-that-does-not-exist")
+	req := CommandRequest{
+		Command: missing,
+		Args:    []string{"-p", strings.Repeat("prompt ", 512)},
+		Stdin:   []byte("stdin payload"),
+		WorkDir: t.TempDir(),
+	}
+
+	_, err := testExecCommandRunner(t, logger).Run(context.Background(), req)
+
+	var startErr *CommandStartError
+	if !errors.As(err, &startErr) {
+		t.Fatalf("Run() error = %#v, want a *CommandStartError", err)
+	}
+	if startErr.Command != missing {
+		t.Fatalf("start error command = %q, want %q", startErr.Command, missing)
+	}
+	if want := ComposedCommandLineLength(req.Command, req.Args); startErr.CommandLineLength != want {
+		t.Fatalf("start error command line length = %d, want %d", startErr.CommandLineLength, want)
+	}
+	if startErr.ArgsCount != len(req.Args) || startErr.StdinBytes != len(req.Stdin) {
+		t.Fatalf("start error = %#v, want args %d and stdin %d", startErr, len(req.Args), len(req.Stdin))
+	}
+	if startErr.Cause == nil {
+		t.Fatalf("start error cause = nil, want the operating system failure")
+	}
+
+	logged := commandStartFailureLogs(logger)
+	if len(logged) != 1 {
+		t.Fatalf("start failure logs = %d, want exactly 1: %#v", len(logged), logger.errors)
+	}
+	fields := logged[0].fields
+	if fields["command"] != missing {
+		t.Fatalf("start failure log command = %#v, want %q", fields["command"], missing)
+	}
+	if fields["command_line_chars"] != startErr.CommandLineLength {
+		t.Fatalf("start failure log command_line_chars = %#v, want %d", fields["command_line_chars"], startErr.CommandLineLength)
+	}
+	if fields["over_command_line_limit"] != startErr.OverCommandLineLimit() {
+		t.Fatalf("start failure log over_command_line_limit = %#v, want %v", fields["over_command_line_limit"], startErr.OverCommandLineLimit())
+	}
+	if fields["error"] == nil || fields["error"] == "" {
+		t.Fatalf("start failure log error = %#v, want the operating system failure text", fields["error"])
+	}
+}
+
+func TestExecCommandRunner_SuccessfulStartLogsNoStartFailure(t *testing.T) {
+	requireProcessIntegration(t)
+	logger := &recordingCommandLogger{}
+
+	if _, err := testExecCommandRunner(t, logger).Run(context.Background(), commandCleanupTestRequest(t)); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if logged := commandStartFailureLogs(logger); len(logged) != 0 {
+		t.Fatalf("start failure logs = %#v, want none for a command that started", logged)
+	}
+}
+
+func commandStartFailureLogs(logger *recordingCommandLogger) []recordedCommandLog {
+	var matched []recordedCommandLog
+	for _, entry := range logger.errors {
+		if entry.fields["event_name"] == commandRunnerStartFailedEvent {
+			matched = append(matched, entry)
+		}
+	}
+	return matched
 }

--- a/pkg/platform/process/command_test.go
+++ b/pkg/platform/process/command_test.go
@@ -944,6 +944,35 @@ func TestExecCommandRunner_StartFailureReturnsANamedErrorAndLogsIt(t *testing.T)
 	}
 }
 
+// TestExecCommandRunner_StartFailureUsesTheInjectedCommandLineLimit pins the
+// classification to the bound injected into the runner rather than to the
+// operating system the test happens to run on. That is what keeps the Windows
+// over-limit case observable from a non-Windows CI host, which was impossible
+// while the limit was computed from the ambient runtime.
+func TestExecCommandRunner_StartFailureUsesTheInjectedCommandLineLimit(t *testing.T) {
+	logger := &recordingCommandLogger{}
+	runner := testExecCommandRunner(t, logger)
+	runner.CommandLineLimit = WindowsCommandLineLimit
+
+	_, err := runner.Run(context.Background(), CommandRequest{
+		Command: filepath.Join(t.TempDir(), "provider-executable-that-does-not-exist"),
+		Args:    []string{"--system-prompt", strings.Repeat("s", 20_000), strings.Repeat("p", 13_000)},
+	})
+
+	var startErr *CommandStartError
+	if !errors.As(err, &startErr) {
+		t.Fatalf("Run() error = %#v, want a *CommandStartError", err)
+	}
+	if startErr.CommandLineLimit != WindowsCommandLineLimit || !startErr.OverCommandLineLimit() {
+		t.Fatalf("start error limit = %d and over-limit = %v, want the injected %d and true",
+			startErr.CommandLineLimit, startErr.OverCommandLineLimit(), WindowsCommandLineLimit)
+	}
+	logged := commandStartFailureLogs(logger)
+	if len(logged) != 1 || logged[0].fields["command_line_limit"] != WindowsCommandLineLimit {
+		t.Fatalf("start failure logs = %#v, want exactly one carrying the injected limit %d", logged, WindowsCommandLineLimit)
+	}
+}
+
 func TestExecCommandRunner_SuccessfulStartLogsNoStartFailure(t *testing.T) {
 	requireProcessIntegration(t)
 	logger := &recordingCommandLogger{}

--- a/pkg/services/providers/internal/services/execution/internal/adapters/claude/command.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/claude/command.go
@@ -89,17 +89,39 @@ func buildCommand(request execution.ContinuationRequest) (providerservice.Comman
 		"--output-format",
 		outputFormatStreamJSON,
 		"--include-partial-messages",
-		request.UserMessage,
 	)
-	return commanddispatch.Request(request.ExecuteRequest, providerservice.CommandRequest{
+	command := providerservice.CommandRequest{
 		Command: string(providers.IDClaude),
-		Args:    args,
 		Env: buildCommandEnv(
 			request.ProcessEnvironment,
 			request.EnvVars,
 		),
 		WorkDir: request.WorkingDirectory,
-	}), nil
+	}
+	command.Args, command.Stdin = deliverPrompt(command.Command, args, request.UserMessage)
+	return commanddispatch.Request(request.ExecuteRequest, command), nil
+}
+
+// promptCommandLineBudget is the composed command-line size at which the
+// rendered prompt stops travelling in argv. The bound is the Windows
+// CreateProcess limit, applied on every host so one factory definition
+// dispatches identically everywhere instead of succeeding on Linux and being
+// rejected by the process loader on Windows.
+const promptCommandLineBudget = platformprocess.WindowsCommandLineLimit
+
+// deliverPrompt chooses how the rendered prompt reaches the provider. The
+// prompt stays in argv while the composed command line fits the budget, which
+// keeps the observable command shape unchanged for ordinary work. A prompt
+// large enough to push the command line past the budget moves to stdin, which
+// print mode accepts and which is already how the codex adapter delivers every
+// prompt. Without this the process loader rejects the spawn outright, so the
+// payload size, not the request, decided whether work could dispatch at all.
+func deliverPrompt(command string, args []string, prompt string) ([]string, []byte) {
+	inline := append(append([]string(nil), args...), prompt)
+	if platformprocess.ComposedCommandLineLength(command, inline) < promptCommandLineBudget {
+		return inline, nil
+	}
+	return args, []byte(prompt)
 }
 
 func buildCommandEnv(processEnvironment []string, envVars map[string]string) []string {

--- a/pkg/services/providers/internal/services/execution/internal/adapters/claude/command.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/claude/command.go
@@ -143,5 +143,8 @@ func nativeCommandError(ctx context.Context, err error) error {
 	if errors.Is(ctx.Err(), context.Canceled) || errors.Is(err, context.Canceled) {
 		return providers.ExecuteFailure{Kind: providers.ExecuteFailureKindCanceled}
 	}
+	if failure, ok := commanddispatch.StartFailure(err); ok {
+		return failure
+	}
 	return err
 }

--- a/pkg/services/providers/internal/services/execution/internal/adapters/claude/command_dispatch_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/claude/command_dispatch_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/portpowered/infinite-you/internal/testutil"
 	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 	execution "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution"
 	claude "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/internal/adapters/claude"
@@ -117,5 +118,58 @@ func TestCommandEffectRejectsUnsupportedReasoningEffort(t *testing.T) {
 				t.Fatalf("runner requests = %#v, want none", got)
 			}
 		})
+	}
+}
+
+// failingStartCommandRunner reports a subprocess that never started, which is
+// what the host returns when the process loader rejects the command line.
+type failingStartCommandRunner struct{ err error }
+
+func (r failingStartCommandRunner) Run(
+	context.Context,
+	platformprocess.CommandRequest,
+) (platformprocess.CommandResult, error) {
+	return platformprocess.CommandResult{}, r.err
+}
+
+func TestCommandEffectDeclaresAnOversizedCommandLineSpawnFailure(t *testing.T) {
+	t.Parallel()
+
+	startErr := &platformprocess.CommandStartError{
+		Command:           "claude",
+		ArgsCount:         9,
+		CommandLineLength: 32932,
+		CommandLineLimit:  platformprocess.WindowsCommandLineLimit,
+		Cause:             errors.New("The filename or extension is too long."),
+	}
+	effect := claude.NewCommandEffect(
+		workers.AdaptCommandRunner(failingStartCommandRunner{err: startErr}),
+		platformclock.Real{},
+	)
+	if effect == nil {
+		t.Fatal("NewCommandEffect() returned nil")
+	}
+
+	_, err := effect.Execute(context.Background(), execution.ContinuationRequest{
+		ExecuteRequest: providers.ExecuteRequest{
+			Provider:    providers.IDClaude,
+			AttemptID:   "claude-oversized-command-line",
+			Model:       "claude-model",
+			UserMessage: strings.Repeat("u", 9819),
+		},
+	}, func([]byte) error { return nil })
+
+	var failure providers.ExecuteFailure
+	if !errors.As(err, &failure) {
+		t.Fatalf("Execute() error = %#v, want a declared providers.ExecuteFailure", err)
+	}
+	if failure.Kind != providers.ExecuteFailureKindMisconfigured {
+		t.Fatalf("failure kind = %q, want %q", failure.Kind, providers.ExecuteFailureKindMisconfigured)
+	}
+	if failure.Diagnostics == nil || failure.Diagnostics.Metadata["work-failure-type"] != "command_line_too_long" {
+		t.Fatalf("failure diagnostics = %#v, want work-failure-type command_line_too_long", failure.Diagnostics)
+	}
+	if !strings.Contains(failure.Message, "32932") || !strings.Contains(failure.Message, "32767") {
+		t.Fatalf("failure message = %q, want it to report the measured size against the host limit", failure.Message)
 	}
 }

--- a/pkg/services/providers/internal/services/execution/internal/adapters/claude/command_dispatch_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/claude/command_dispatch_test.go
@@ -173,3 +173,106 @@ func TestCommandEffectDeclaresAnOversizedCommandLineSpawnFailure(t *testing.T) {
 		t.Fatalf("failure message = %q, want it to report the measured size against the host limit", failure.Message)
 	}
 }
+
+// claudeFactorySystemPromptSize is the system-prompt size that reproduces the
+// reported plan-stage boundary: with it inlined, a 9,152-character payload
+// composed a 32,265-character command line and dispatched, while a
+// 9,819-character payload composed 32,932 characters and was rejected by the
+// 32,767-character process-loader limit.
+const claudeFactorySystemPromptSize = 23000
+
+func TestCommandEffectKeepsAnOversizedPromptOffTheCommandLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		payloadSize int
+		wantInline  bool
+	}{
+		{name: "previously passing boundary stays in argv", payloadSize: 9152, wantInline: true},
+		{name: "previously fatal boundary moves to stdin", payloadSize: 9819},
+		{name: "previously fatal larger payload moves to stdin", payloadSize: 12088},
+		{name: "very large payload moves to stdin", payloadSize: 50000},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			prompt := strings.Repeat("u", tc.payloadSize)
+			runner := testutil.NewProviderCommandRunner()
+			effect := claude.NewCommandEffect(workers.AdaptCommandRunner(runner), platformclock.Real{})
+			_, err := effect.Execute(context.Background(), execution.ContinuationRequest{
+				ExecuteRequest: providers.ExecuteRequest{
+					Provider:     providers.IDClaude,
+					AttemptID:    "claude-oversized-payload",
+					Model:        "claude-model",
+					SystemPrompt: strings.Repeat("s", claudeFactorySystemPromptSize),
+					UserMessage:  prompt,
+				},
+			}, func([]byte) error { return nil })
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+
+			req := runner.LastRequest()
+			length := platformprocess.ComposedCommandLineLength(req.Command, req.Args)
+			if length >= platformprocess.WindowsCommandLineLimit {
+				t.Fatalf("composed command line = %d characters, want below the %d-character process-loader limit",
+					length, platformprocess.WindowsCommandLineLimit)
+			}
+			lastArg := req.Args[len(req.Args)-1]
+			if tc.wantInline {
+				if lastArg != prompt {
+					t.Fatalf("last argument length = %d, want the %d-character prompt inline", len(lastArg), len(prompt))
+				}
+				if len(req.Stdin) != 0 {
+					t.Fatalf("stdin = %d bytes, want the prompt to stay in argv at this size", len(req.Stdin))
+				}
+				return
+			}
+			if string(req.Stdin) != prompt {
+				t.Fatalf("stdin = %d bytes, want the %d-character prompt", len(req.Stdin), len(prompt))
+			}
+			if lastArg == prompt {
+				t.Fatal("prompt is still the last argument, want it delivered on stdin")
+			}
+			if lastArg != "--include-partial-messages" {
+				t.Fatalf("last argument = %q, want the flags to end the command line", lastArg)
+			}
+		})
+	}
+}
+
+func TestCommandEffectPreservesFlagsWhenThePromptMovesToStdin(t *testing.T) {
+	t.Parallel()
+
+	runner := testutil.NewProviderCommandRunner()
+	effect := claude.NewCommandEffect(workers.AdaptCommandRunner(runner), platformclock.Real{})
+	_, err := effect.Execute(context.Background(), execution.ContinuationRequest{
+		ExecuteRequest: providers.ExecuteRequest{
+			Provider:        providers.IDClaude,
+			AttemptID:       "claude-flags-preserved",
+			Model:           "claude-model",
+			ReasoningEffort: "high",
+			SkipPermissions: true,
+			UserMessage:     strings.Repeat("u", 40000),
+		},
+	}, func([]byte) error { return nil })
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	want := []string{
+		"-p",
+		"--dangerously-skip-permissions",
+		"--model", "claude-model",
+		"--effort", "high",
+		"--verbose",
+		"--output-format", "stream-json",
+		"--include-partial-messages",
+	}
+	if got := runner.LastRequest().Args; !reflect.DeepEqual(got, want) {
+		t.Fatalf("command args = %#v, want %#v", got, want)
+	}
+}

--- a/pkg/services/providers/internal/services/execution/internal/adapters/codex/command.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/codex/command.go
@@ -137,5 +137,8 @@ func nativeCommandError(ctx context.Context, err error) error {
 	if errors.Is(ctx.Err(), context.Canceled) || errors.Is(err, context.Canceled) {
 		return providers.ExecuteFailure{Kind: providers.ExecuteFailureKindCanceled}
 	}
+	if failure, ok := commanddispatch.StartFailure(err); ok {
+		return failure
+	}
 	return err
 }

--- a/pkg/services/providers/internal/services/execution/internal/adapters/commanddispatch/commanddispatch.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/commanddispatch/commanddispatch.go
@@ -1,10 +1,48 @@
 package commanddispatch
 
 import (
+	"errors"
+
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 	providerservice "github.com/portpowered/infinite-you/pkg/services/providers/internal/service"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 )
+
+// workFailureType* mirror the Workers normalized failure vocabulary that
+// execution diagnostics are keyed by. Providers does not depend on Workers, so
+// the values are repeated here as literals exactly as the ACP daemon already
+// does for its missing-executable classification.
+const (
+	workFailureTypeMetadataKey    = "work-failure-type"
+	workFailureTypeCommandTooLong = "command_line_too_long"
+	workFailureTypeMisconfigured  = "misconfigured"
+)
+
+// StartFailure translates a subprocess that never started into a declared
+// provider failure. The host reports an unstarted process as an ordinary error
+// with no exit status and no output, so without this translation execution
+// normalization sees only an unattributed native error and the operator is told
+// nothing beyond "provider execution failed". An over-long command line is
+// named separately because it is the one start failure the caller repairs by
+// moving argument content off argv rather than by fixing the environment.
+func StartFailure(err error) (providers.ExecuteFailure, bool) {
+	var startErr *platformprocess.CommandStartError
+	if !errors.As(err, &startErr) || startErr == nil {
+		return providers.ExecuteFailure{}, false
+	}
+	failureType := workFailureTypeMisconfigured
+	if startErr.OverCommandLineLimit() {
+		failureType = workFailureTypeCommandTooLong
+	}
+	return providers.ExecuteFailure{
+		Kind:    providers.ExecuteFailureKindMisconfigured,
+		Message: startErr.Error(),
+		Diagnostics: &providers.ExecuteDiagnostics{Metadata: map[string]string{
+			workFailureTypeMetadataKey: failureType,
+		}},
+	}, true
+}
 
 // Request returns a Providers subprocess request with attempt correlation
 // preserved for composition-owned effect adapters.

--- a/pkg/services/providers/internal/services/execution/internal/adapters/commanddispatch/start_failure_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/commanddispatch/start_failure_test.go
@@ -1,0 +1,88 @@
+package commanddispatch_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	"github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/internal/adapters/commanddispatch"
+)
+
+func TestStartFailureNamesAnOversizedCommandLine(t *testing.T) {
+	t.Parallel()
+
+	failure, ok := commanddispatch.StartFailure(&platformprocess.CommandStartError{
+		Command:           "claude",
+		ArgsCount:         9,
+		CommandLineLength: 32932,
+		CommandLineLimit:  platformprocess.WindowsCommandLineLimit,
+		Cause:             errors.New("The filename or extension is too long."),
+	})
+	if !ok {
+		t.Fatal("StartFailure() ok = false, want a declared failure for an unstarted process")
+	}
+	if failure.Kind != providers.ExecuteFailureKindMisconfigured {
+		t.Fatalf("failure kind = %q, want %q", failure.Kind, providers.ExecuteFailureKindMisconfigured)
+	}
+	if failure.Diagnostics == nil || failure.Diagnostics.Metadata["work-failure-type"] != "command_line_too_long" {
+		t.Fatalf("failure diagnostics = %#v, want work-failure-type command_line_too_long", failure.Diagnostics)
+	}
+	for _, want := range []string{"32932", "32767"} {
+		if !strings.Contains(failure.Message, want) {
+			t.Fatalf("failure message = %q, want it to report %q", failure.Message, want)
+		}
+	}
+}
+
+func TestStartFailureClassifiesOtherSpawnFailuresAsMisconfigured(t *testing.T) {
+	t.Parallel()
+
+	failure, ok := commanddispatch.StartFailure(&platformprocess.CommandStartError{
+		Command:           "claude",
+		ArgsCount:         3,
+		CommandLineLength: 120,
+		CommandLineLimit:  platformprocess.WindowsCommandLineLimit,
+		Cause:             errors.New("executable file not found in %PATH%"),
+	})
+	if !ok {
+		t.Fatal("StartFailure() ok = false, want a declared failure for an unstarted process")
+	}
+	if failure.Diagnostics == nil || failure.Diagnostics.Metadata["work-failure-type"] != "misconfigured" {
+		t.Fatalf("failure diagnostics = %#v, want work-failure-type misconfigured", failure.Diagnostics)
+	}
+}
+
+func TestStartFailureIgnoresErrorsThatAreNotSpawnFailures(t *testing.T) {
+	t.Parallel()
+
+	for _, cause := range []error{nil, errors.New("provider exited with status 1")} {
+		if _, ok := commanddispatch.StartFailure(cause); ok {
+			t.Fatalf("StartFailure(%v) ok = true, want false for a process that did start", cause)
+		}
+	}
+}
+
+func TestStartFailureUnwrapsThroughWrappingErrors(t *testing.T) {
+	t.Parallel()
+
+	wrapped := errWrapper{cause: &platformprocess.CommandStartError{
+		Command:           "claude",
+		CommandLineLength: 40000,
+		CommandLineLimit:  platformprocess.WindowsCommandLineLimit,
+		Cause:             errors.New("boom"),
+	}}
+	failure, ok := commanddispatch.StartFailure(wrapped)
+	if !ok {
+		t.Fatal("StartFailure() ok = false, want the wrapped spawn failure to be recognized")
+	}
+	if failure.Diagnostics.Metadata["work-failure-type"] != "command_line_too_long" {
+		t.Fatalf("failure diagnostics = %#v, want work-failure-type command_line_too_long", failure.Diagnostics)
+	}
+}
+
+type errWrapper struct{ cause error }
+
+func (e errWrapper) Error() string { return "wrapped: " + e.cause.Error() }
+func (e errWrapper) Unwrap() error { return e.cause }

--- a/pkg/services/work/internal/requestadmission/preparation_test.go
+++ b/pkg/services/work/internal/requestadmission/preparation_test.go
@@ -329,3 +329,59 @@ func mustRequestPreparationService(t *testing.T) RequestPreparationService {
 	}
 	return service
 }
+
+// oversizedWorkPayloadSize is comfortably past the size at which an inlined
+// prompt used to make the plan-stage worker spawn impossible. Admission
+// enforces no size bound because the rendered prompt no longer travels on the
+// provider command line, so a payload this large must be admitted rather than
+// rejected at the boundary or admitted and then killed one transition later.
+const oversizedWorkPayloadSize = 50_000
+
+func TestPrepareWorkRequestAdmitsAnOversizedPayloadWithoutASizeLimit(t *testing.T) {
+	t.Parallel()
+
+	service := mustRequestPreparationService(t)
+	text := strings.Repeat("u", oversizedWorkPayloadSize)
+
+	prepared, err := service.PrepareWorkRequest(context.Background(), WorkRequestPreparation{
+		Request: Request{
+			RequestID: "request-oversized",
+			Type:      RequestTypeFactoryRequestBatch,
+			Works: []Work{{
+				Name:       "oversized-idea",
+				WorkTypeID: "idea",
+				Content:    []ContentPart{{Type: ContentPartTypeText, Text: text}},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PrepareWorkRequest with a %d-character payload: %v", len(text), err)
+	}
+	if got := prepared.Works[0].Content[0].Text; got != text {
+		t.Fatalf("admitted content length = %d, want the submitted %d characters intact", len(got), len(text))
+	}
+}
+
+func TestPrepareWorkRequestAdmitsAnOversizedLegacyPayloadField(t *testing.T) {
+	t.Parallel()
+
+	service := mustRequestPreparationService(t)
+	text := strings.Repeat("p", oversizedWorkPayloadSize)
+
+	prepared, err := service.PrepareWorkRequest(context.Background(), WorkRequestPreparation{
+		Request: Request{
+			Works: []Work{{
+				Name:       "oversized-idea",
+				WorkTypeID: "idea",
+				Payload:    map[string]any{"description": text},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PrepareWorkRequest with a %d-character payload field: %v", len(text), err)
+	}
+	payload, ok := prepared.Works[0].Payload.(map[string]any)
+	if !ok || payload["description"] != text {
+		t.Fatalf("admitted payload = %T, want the submitted %d characters intact", prepared.Works[0].Payload, len(text))
+	}
+}

--- a/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/provider_outcome_test.go
+++ b/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/provider_outcome_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -174,5 +175,36 @@ func assertDiagnosticFailure(t *testing.T, result workers.RunnerExecutionResult,
 	if result.Diagnostics == nil || result.Diagnostics.Provider == nil ||
 		result.Diagnostics.Provider.ResponseMetadata[workers.ProviderResponseMetadataDurationMS] != "42" {
 		t.Fatalf("failure diagnostics = %#v, want preserved provider duration", result.Diagnostics)
+	}
+}
+
+func TestExecuteFailureClassifiesAnOversizedCommandLineFromProviderDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	fake := &failingProvidersFake{failure: providers.ExecuteFailure{
+		Kind:    providers.ExecuteFailureKindMisconfigured,
+		Message: `start "claude": composed command line is 32932 characters across 9 arguments, at or above the 32767-character host command-line limit`,
+		Diagnostics: &providers.ExecuteDiagnostics{
+			Metadata: map[string]string{"work-failure-type": string(workers.WorkFailureTypeCommandLineTooLong)},
+		},
+	}}
+	runner, err := New(fake, func(workers.ProgressFragment) {})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	_, err = runner.Execute(t.Context(), baseAgentRequest())
+
+	var providerErr *workers.ProviderError
+	if !errors.As(err, &providerErr) {
+		t.Fatalf("Execute() error = %v, want *workers.ProviderError", err)
+	}
+	if providerErr.Type != workers.WorkFailureTypeCommandLineTooLong {
+		t.Fatalf("ProviderError.Type = %q, want %q", providerErr.Type, workers.WorkFailureTypeCommandLineTooLong)
+	}
+	for _, want := range []string{"32932", "32767"} {
+		if !strings.Contains(providerErr.Message, want) {
+			t.Fatalf("ProviderError.Message = %q, want it to report the measured size %q", providerErr.Message, want)
+		}
 	}
 }

--- a/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner.go
+++ b/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner.go
@@ -870,6 +870,8 @@ func normalizeProviderFailure(
 			failureType = workers.WorkFailureTypeMissingExecutable
 		case string(workers.WorkFailureTypeMisconfigured):
 			failureType = workers.WorkFailureTypeMisconfigured
+		case string(workers.WorkFailureTypeCommandLineTooLong):
+			failureType = workers.WorkFailureTypeCommandLineTooLong
 		}
 	}
 	if errors.Is(interruption, context.DeadlineExceeded) {

--- a/pkg/services/workers/runner_process_log_context.go
+++ b/pkg/services/workers/runner_process_log_context.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 )
 
@@ -50,9 +51,16 @@ func commandCompletionLogFields(req CommandRequest, result CommandResult, durati
 	}
 	return fields
 }
+
+// commandRequestDetailsLogFields records the composed command-line size next to
+// the argument count. The count alone cannot distinguish a dispatch that fits
+// the host command-line limit from one that will be rejected by the process
+// loader, so an operator had no way to see a prompt growing toward that bound.
 func commandRequestDetailsLogFields(req CommandRequest) []any {
 	return workLogFields(req.Execution, "event_name", workLogEventCommandRunnerRequestDetails, "status", "verbose",
-		"command", req.Command, "args_count", len(req.Args), "working_dir", req.WorkDir, "stdin_bytes", len(req.Stdin))
+		"command", req.Command, "args_count", len(req.Args), "working_dir", req.WorkDir, "stdin_bytes", len(req.Stdin),
+		"command_line_chars", platformprocess.ComposedCommandLineLength(req.Command, req.Args),
+		"command_line_limit", platformprocess.HostCommandLineLimit())
 }
 func commandOutputDetailsLogFields(req CommandRequest, result CommandResult, duration time.Duration) []any {
 	return workLogFields(req.Execution, "event_name", workLogEventCommandRunnerOutputDetails, "status", "verbose",

--- a/pkg/services/workers/runner_process_log_context.go
+++ b/pkg/services/workers/runner_process_log_context.go
@@ -54,13 +54,16 @@ func commandCompletionLogFields(req CommandRequest, result CommandResult, durati
 
 // commandRequestDetailsLogFields records the composed command-line size next to
 // the argument count. The count alone cannot distinguish a dispatch that fits
-// the host command-line limit from one that will be rejected by the process
-// loader, so an operator had no way to see a prompt growing toward that bound.
+// the command-line budget from one that will be rejected by the process loader,
+// so an operator had no way to see a prompt growing toward that bound. The
+// budget reported here is the one the prompt-shaping path applies on every
+// host, which is why it is the same constant everywhere rather than a reading
+// of the current operating system.
 func commandRequestDetailsLogFields(req CommandRequest) []any {
 	return workLogFields(req.Execution, "event_name", workLogEventCommandRunnerRequestDetails, "status", "verbose",
 		"command", req.Command, "args_count", len(req.Args), "working_dir", req.WorkDir, "stdin_bytes", len(req.Stdin),
 		"command_line_chars", platformprocess.ComposedCommandLineLength(req.Command, req.Args),
-		"command_line_limit", platformprocess.HostCommandLineLimit())
+		"command_line_budget", platformprocess.WindowsCommandLineLimit)
 }
 func commandOutputDetailsLogFields(req CommandRequest, result CommandResult, duration time.Duration) []any {
 	return workLogFields(req.Execution, "event_name", workLogEventCommandRunnerOutputDetails, "status", "verbose",

--- a/pkg/wire/models_runtime.go
+++ b/pkg/wire/models_runtime.go
@@ -172,7 +172,22 @@ func providePlatformProcessCommandRunner(edges serviceedges.Edges) (platformproc
 	if err != nil {
 		return nil, err
 	}
+	runner.CommandLineLimit = hostCommandLineLimit()
 	return runner, nil
+}
+
+// hostCommandLineLimit selects the composed command-line bound the running
+// host's process loader enforces for one spawn. The operating system is read
+// here, at the canonical injection boundary, so pkg/platform/process can name
+// an oversized-command-line spawn failure without selecting a host policy of
+// its own. Hosts other than Windows report 0 because they bound the total
+// argument block and each individual argument rather than the composed line,
+// so their spawn failures are named from the operating system error alone.
+func hostCommandLineLimit() int {
+	if runtime.GOOS == "windows" {
+		return platformprocess.WindowsCommandLineLimit
+	}
+	return 0
 }
 
 func provideModelAssetHostPlatform(edges serviceedges.Edges) models.AssetHostPlatform {


### PR DESCRIPTION
## Summary

An `idea`-typed work item whose payload was roughly 9.8k+ characters died at the plan
transition in 60–80 ms with `WORKERS_EXECUTION_FAILURE`, no provider identity, and **zero
daemon log lines**. This lands the three-part fix: name and log every spawn failure, stop
inlining the rendered prompt into `argv`, and confirm no size ceiling remains at admission.

## Story 001 — measurement: the argv-length theory is confirmed, quantitatively exact

Added `platformprocess.ComposedCommandLineLength(command, args)`, which reproduces
`os/exec`'s Windows quoting and counts **UTF-16 code units**, so it measures the exact
string `CreateProcess` receives. It is computed identically on every OS, so this is
reproducible from a Linux CI host.

The claude adapter inlined **both** `--system-prompt <value>` and the rendered prompt as the
final `argv` element. Fixed flag/quoting overhead: 96 chars. Implicated OS limit:
**Windows `CreateProcess`, 32,767 UTF-16 code units** (`WindowsCommandLineLimit`).

| system prompt | payload 9,152 | payload 9,819 | payload 12,088 | payload 50,000 |
|---|---|---|---|---|
| 0 | 9,248 | 9,915 | 12,184 | 50,096 (OVER) |
| 8,000 | 17,265 | 17,932 | 20,201 | 58,113 (OVER) |
| 20,000 | 29,265 | 29,932 | 32,201 | 70,113 (OVER) |
| **23,000** | **32,265 (under → dispatches)** | **32,932 (OVER → dies)** | 35,201 (OVER) | 73,113 (OVER) |

The 23,000-char system-prompt row **reproduces the operator's observed boundary exactly**:
9,152 dispatches, 9,819 dies. Solving for the boundary pins the live factory system prompt
to between 22,852 and 23,519 characters.

Contrast, and the reason the fix was already demonstrated in-repo: the **codex** adapter
sends its prompt on stdin (`args = [..., "-"]`), so its composed command line is a constant
**39 characters** at payloads of 9,152 / 9,819 / 12,088 / 50,000. Immune by construction.

## Before / after evidence

**Before.** `cmd.Start()` failures were returned **bare** from `ExecCommandRunner.run` — no
wrap, no log. When `CreateProcess` rejected the command line there was no child process, no
exit status and no output, so the only surviving evidence of the failure was how fast the
attempt died. That is the 60–80 ms / `WORKERS_EXECUTION_FAILURE` / empty-log signature.

**After.** Two independent things now hold:

1. **It no longer fails.** A 9,819-char payload (and 12,088, and 50,000) now composes a
   command line *below* the limit because the prompt travels on stdin, and dispatches
   normally — asserted in `TestCommandEffectKeepsAnOversizedPromptOffTheCommandLine`.
2. **If it ever did fail, it would be loud.** Any start failure is wrapped in
   `*platformprocess.CommandStartError` carrying the measured size, and logged at
   `event_name=command_runner.start_failed` with `command_line_chars`,
   `command_line_limit`, `over_command_line_limit`, `stdin_bytes`. Because
   `workers.commandContextLogger` already installs a work-scoped logger on the runner, that
   line carries `work_id` / `dispatch_id` / `workstation_name` with no extra plumbing, so it
   is greppable by work item. Message shape:
   `start "claude": composed command line is 32932 characters across 9 arguments, at or above the 32767-character host command-line limit: ...`

## Story 002 — the classification chain end to end

`workers.WorkFailureTypeCommandLineTooLong` (`"command_line_too_long"`) already existed with
a safe operator message and was already whitelisted by session classification — but **nothing
produced it**. It does now:

`ExecCommandRunner.run` → `*CommandStartError` → `commanddispatch.StartFailure` → declared
`providers.ExecuteFailure{Diagnostics.Metadata["work-failure-type"]}` → agent
`normalizeProviderFailure` → `WorkFailureTypeCommandLineTooLong`.

The metadata hop is required rather than incidental: `execution/internal/service/failure.go`
deliberately drops native error text, so a spawn error has to be carried as a *declared*
failure with diagnostics metadata, not as free text. Non-size spawn failures classify as
`misconfigured`.

## Story 003 — the prompt leaves `argv`

`deliverPrompt()` keeps the rendered prompt in `argv` while the composed line fits
`WindowsCommandLineLimit`, and moves it to `Stdin` past that. `CommandRequest.Stdin` is
already plumbed platform → providers → workers and is how codex delivers every prompt, so
this reuses a production path. The budget is applied on **every** host, not just Windows, so
one factory definition dispatches identically everywhere instead of succeeding on Linux and
being rejected by the Windows process loader.

*Why threshold-based rather than unconditional:*
`tests/functional/providers/cli_template_resolution_long_test.go` asserts the claude prompt
**is** the last `argv` element with `assertProviderStdin(t, req, "")`. `tests/functional` is
owned by the concurrently active `btrc-p7-functional-race-close` lane and is untouched here
per acceptance criterion 5. That test's prompt is tiny, stays inline, and is unaffected.

**Known residual, reported honestly:** the system prompt is still an inline
`--system-prompt` value, because the claude CLI exposes no file/stdin mechanism for it and
stdin now carries the user prompt. It is bounded by the factory definition rather than by
payload size, so it no longer determines whether a given *work item* can dispatch — and if it
ever did exceed the limit, the spawn now fails loudly with the named `command_line_too_long`
error above instead of silently.

## Story 004 — no submit-time limit was needed

Took the second branch of the story's own acceptance criteria. No hard payload size limit
remains, so adding submit-time validation would have been actively wrong: it would
reintroduce as a `400` exactly the dispatch ceiling story 003 removed. Instead the absence of
a limit is proved by regression test — 50,000 chars admitted through `requestadmission` in
both the `ContentPart` and legacy `Payload` shapes, asserting the text survives byte-for-byte,
with the provider seam proving that same size dispatches.

## Scope and verification

Task-typed dispatch is unchanged, the review and consume transitions are untouched, and no
file owned by the `btrc-p7-functional-race-close` lane (`pkg/root/BuildProcess`,
`pkg/services/edges`, `tests/functional`) is modified.

- `go vet` clean on every touched package.
- 16 new tests, all passing; focused package suites green; `make test` green.
- `backend-size`: every touched non-test file far under the 1000-line cap (largest is
  `pkg/platform/process/command.go` at 558).
- `pkg-file-count`: the single new file lands in `.../adapters/commanddispatch/`, which is
  not one of the 62 baselined packages; no baselined package gains a file.

## PRD

<details>
<summary><code>prd.json</code></summary>

```json
{
  "project": "you-agent-factory",
  "branchName": "thr-plan-stage-drops-oversized-payload-silently",
  "description": "An idea-typed work item whose payload is roughly 9.2k+ characters dies at the plan transition in 60-80ms with WORKERS_EXECUTION_FAILURE, no provider identity, and no daemon log line. Fix the swallowed-failure behavior (named error + daemon log for any spawn failure), remove the likely root cause by routing large prompt/system-prompt content through file/stdin instead of the child process command line, and if any hard size limit remains after that, reject oversized submissions loudly at submit time instead of admitting a lane that dies silently later.",
  "context": {
    "customerAsk": "Stop losing lanes to a silent, sub-100ms death with zero diagnostics when a work payload is 'too big', and make the actual cause visible so operators do not have to reverse-engineer a size threshold by hand.",
    "problem": "The worker spawn path for the plan transition fails for idea payloads at or above roughly 9.8k characters, in 60-80ms, with WORKERS_EXECUTION_FAILURE, no provider/kind recorded, and zero daemon log lines. Task-typed dispatch (which skips the plan stage) is unaffected, localizing the defect to the plan transition. The leading suspect, backed by direct Win32_Process command-line evidence, is that the worker is spawned with the entire prompt inline on the command line, and the assembled argv crosses the Windows CreateProcess 32,767-char cap once the payload is large enough; CreateProcess then fails before any provider session exists and the failure is dropped on the floor.",
    "solution": "(1) Make every plan-stage worker spawn failure produce a named, diagnosable failure (session failure message naming the cause and size, plus a daemon log line) so a silent drop can never happen again regardless of the underlying limit. (2) Stop inlining large prompt/system-prompt content into argv; route it through the provider's file or stdin mechanism, keeping argv for flags only, to remove the size-triggered failure at its source. (3) If a hard limit remains after (2), enforce it at submit time with a validation error naming the field, measured size, and limit, so oversized batches are rejected loudly at the boundary instead of dying one transition later."
  },
  "acceptanceCriteria": [
    "A payload sized at or above the previously-observed failure threshold (~9.8k+ chars, or the implementer's own measured boundary) either dispatches successfully through the plan transition, or fails with an error naming the cause and measured size, and in both cases a daemon log line exists; the PR body shows concrete before (60-80ms, WORKERS_EXECUTION_FAILURE, empty log) and after evidence.",
    "A payload sized at the previously-passing boundary (~9,152 chars) continues to dispatch successfully and is not regressed by any new validation or spawn-path change.",
    "A test at the worker spawn seam demonstrates that a spawn failure (including any remaining over-limit case) produces a named, structured error rather than a bare/unattributed failure.",
    "A test demonstrates that a payload shape that used to die silently now either reaches the planner successfully or is rejected at submit time with a validation error naming the field and size, never a silent post-admission death.",
    "Task-typed dispatch behavior is unchanged, and the review and consume transitions are untouched; surfaces owned by the concurrently active btrc-p7-functional-race-close lane (pkg/root/BuildProcess, pkg/services/edges, tests/functional) are not touched.",
    "Typecheck passes, tests pass, and there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. (make lint end-to-end is not required to pass, since main already carries pre-existing packaged-service-structure migration debt in the pkg-boundary target, recorded 2026-08-08.)",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "thr-plan-stage-drops-oversized-payload-silently-001",
      "title": "Measure and document the real spawn failure mechanism",
      "description": "As a maintainer investigating this bug, I need the actual argv/command-line length measured at spawn time for both a payload that passes and one that fails today, so the fix targets the real mechanism instead of an assumed one.",
      "acceptanceCriteria": [
        "The point where the plan-stage worker child process is constructed is instrumented (temporarily or via a kept debug log line) to record the exact assembled command-line/argv length for a payload that dispatches successfully (~9,152 chars) and one that fails today (~9,819+ chars)",
        "Both measured numbers, plus the implicated OS-level limit (e.g. Windows CreateProcess 32,767-char cap), are reported in the PR body",
        "If the measurement contradicts the argv-length theory, the PR body states what was actually found and later stories are adapted to target the real cause",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added platformprocess.ComposedCommandLineLength(command, args), which reproduces os/exec's Windows quoting and counts UTF-16 code units, so it measures the exact string CreateProcess receives; it is computed identically on every OS so the measurement is reproducible from a Linux CI host. Added WindowsCommandLineLimit (32767) and HostCommandLineLimit(). MEASUREMENT CONFIRMS THE ARGV-LENGTH THEORY EXACTLY: the claude adapter inlined both --system-prompt <value> and the rendered prompt as the final argv element, with 96 chars of fixed flag/quoting overhead. With a 23,000-char system prompt, a 9,152-char payload composes 32,265 chars (under the limit, dispatches) and a 9,819-char payload composes 32,932 chars (at/over the 32,767 limit, rejected by the process loader) -- reproducing the operator's observed boundary exactly and pinning the live factory system prompt to 22,852-23,519 chars. The codex adapter, which sends the prompt on stdin, composes a CONSTANT 39-char command line at every payload size. Covered by TestComposedCommandLineLength_MeasuresTheStringTheProcessLoaderReceives and TestComposedCommandLineLength_GrowsWithInlinedArgumentContent."
    },
    {
      "id": "thr-plan-stage-drops-oversized-payload-silently-002",
      "title": "Surface spawn failures as named, logged errors instead of silent drops",
      "description": "As an operator, I need any failure to start the plan-stage worker process to show up as a named error with the measured payload size, in both the work item's failure state and the daemon log, so a dead lane is diagnosable without reverse-engineering it from session durations.",
      "acceptanceCriteria": [
        "When the plan-stage worker process fails to spawn for any reason, the resulting work item failure message names the failure cause (not just WORKERS_EXECUTION_FAILURE) and includes a size indicator where the cause is size-related",
        "The daemon log records at least one line for the failed spawn attempt including the work item name and failure cause, greppable by an operator",
        "A test at the worker spawn seam simulates a spawn failure and asserts the resulting error is a named/structured error and that a log line is emitted",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "cmd.Start() failures were previously returned BARE from ExecCommandRunner.run -- no wrap, no log -- which is the swallowed failure. Now every start failure is wrapped in *platformprocess.CommandStartError (Command, ArgsCount, CommandLineLength, CommandLineLimit, StdinBytes, Cause) with an OverCommandLineLimit() predicate, and logged at event_name=command_runner.start_failed with command_line_chars/command_line_limit/over_command_line_limit. Because pkg/services/workers.commandContextLogger already installs a work-scoped logger on the runner, that line automatically carries work_id/dispatch_id/workstation_name, so it is greppable by work item. The classification chain is complete end to end: commanddispatch.StartFailure translates the start error into a DECLARED providers.ExecuteFailure carrying Diagnostics.Metadata[\"work-failure-type\"]=command_line_too_long (or misconfigured for other spawn failures), which is required because execution/internal/service/failure.go deliberately drops native error text; the claude and codex adapters route through it in nativeCommandError; and agent runner.go normalizeProviderFailure now maps that metadata to the previously-dead workers.WorkFailureTypeCommandLineTooLong vocabulary. Tests: TestExecCommandRunner_StartFailureReturnsANamedErrorAndLogsIt, TestExecCommandRunner_SuccessfulStartLogsNoStartFailure, TestCommandStartError_* (2), TestStartFailure* (4), TestCommandEffectDeclaresAnOversizedCommandLineSpawnFailure, TestExecuteFailureClassifiesAnOversizedCommandLineFromProviderDiagnostics."
    },
    {
      "id": "thr-plan-stage-drops-oversized-payload-silently-003",
      "title": "Route large prompt content through file/stdin instead of argv",
      "description": "As a maintainer, I want the rendered plan prompt and system prompt delivered to the worker process without depending on command-line length, so payload size no longer determines whether a lane can dispatch at all.",
      "acceptanceCriteria": [
        "The prompt-shaping/runner-invocation path in pkg/services/workers (and the platform process-spawn helper it composes argv through) passes the rendered prompt and system prompt via the provider's file or stdin input mechanism instead of inlining them as command-line arguments; argv is reserved for flags",
        "A payload previously observed to die at the plan transition (~9,819+ chars, and the ~12,088-char case) now reaches the planner and dispatches normally, verified by a test at the appropriate layer within pkg/services/workers",
        "A payload at the previously-passing boundary (~9,152 chars) still dispatches successfully with no regression",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "The claude adapter now composes argv from flags only and chooses the prompt delivery mechanism via deliverPrompt(): the rendered prompt stays in argv while the composed command line fits the budget, and moves to Stdin once it would reach WindowsCommandLineLimit. The budget is applied on every host, not just Windows, so one factory definition dispatches identically everywhere instead of succeeding on Linux and being rejected by the Windows process loader. platformprocess.CommandRequest.Stdin is already plumbed platform -> providers -> workers and is how the codex adapter delivers every prompt, so this reuses a production path rather than adding one. WHY THRESHOLD-BASED RATHER THAN UNCONDITIONAL: tests/functional/providers/cli_template_resolution_long_test.go asserts the claude prompt IS the last argv element with assertProviderStdin(t, req, \"\"), and tests/functional is owned by the concurrent btrc-p7-functional-race-close lane (acceptance criterion 5), so the small-prompt argv shape had to be preserved. That test's prompt is tiny and stays inline, so it is unaffected. Verified by TestCommandEffectKeepsAnOversizedPromptOffTheCommandLine at 9,152 (stays inline, no regression), 9,819 / 12,088 / 50,000 (move to stdin), each asserting the composed line lands below the limit, plus TestCommandEffectPreservesFlagsWhenThePromptMovesToStdin which pins the exact flag-only argv at a 40,000-char prompt. RESIDUAL, REPORTED IN THE PR BODY: the system prompt is still an inline --system-prompt value because the claude CLI exposes no file/stdin mechanism for it and stdin now carries the user prompt. It is bounded by the factory definition rather than by payload size, so it no longer determines whether a given work item can dispatch, and if it ever does exceed the limit the spawn now fails loudly with the named command_line_too_long error from story 002 instead of silently."
    },
    {
      "id": "thr-plan-stage-drops-oversized-payload-silently-004",
      "title": "Reject any remaining hard size limit loudly at submit time",
      "description": "As an operator submitting a batch, I want an oversized field to be rejected immediately at submit time with a clear message naming the field, its size, and the limit, so a bad batch never gets silently admitted only to die later.",
      "acceptanceCriteria": [
        "If any hard size limit remains after story 003, submit-time validation rejects the request with an error naming the offending field, its measured size, and the enforced limit",
        "If no hard limit remains after story 003, this story instead adds a regression test proving a very large payload (50k+ chars) is accepted and dispatches normally, and documents that no submit-time size validation was needed",
        "A test proves an oversized submission (when a limit exists) is rejected at submit time with the named error and never reaches an admitted, later-failing state",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Took the second branch of the story's own acceptance criteria: NO hard payload size limit remains after story 003, so no submit-time size validation was added and the story instead proves the absence of a limit by regression test. Adding a submit-time cap would have been actively wrong here -- it would reintroduce as a validation error exactly the dispatch ceiling story 003 removed. Regression coverage: TestPrepareWorkRequestAdmitsAnOversizedPayloadWithoutASizeLimit and TestPrepareWorkRequestAdmitsAnOversizedLegacyPayloadField admit 50,000-char content through pkg/services/work/internal/requestadmission (both the ContentPart and legacy Payload field shapes) and assert the text survives admission byte-for-byte; TestCommandEffectKeepsAnOversizedPromptOffTheCommandLine closes the loop by proving that same 50,000-char size dispatches at the provider seam. The rationale that admission enforces no size bound is documented in a comment on oversizedWorkPayloadSize in preparation_test.go and in the PR body."
    }
  ]
}
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
