### PR TITLE
DCP-3: derived cross-service cycle ratchet lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ LINT_JOBS ?= $(GO_LANE_BUDGET)
 # during -n so recursive builds can receive the dry-run flag.
 LINT_MAKE ?= $(MAKE)
 LINT_REPORT_FILE ?=
-LINT_TARGETS ?= ui-lint ui-deadcode vet backend-size pkg-maint pkg-file-count pkg-boundary pkg-structure package-target-manifest-check packaged-factory-source-check packaged-factory-consumption-check packaged-factory-catalog-check provider-catalog-check model-provider-package-check durable-runtime-construction-check logging-boundary-check compatibility-alias-check retired-surface-check ownership-inventory-check deadcode
+LINT_TARGETS ?= ui-lint ui-deadcode vet backend-size pkg-maint pkg-file-count pkg-boundary pkg-structure service-cycle-check package-target-manifest-check packaged-factory-source-check packaged-factory-consumption-check packaged-factory-catalog-check provider-catalog-check model-provider-package-check durable-runtime-construction-check logging-boundary-check compatibility-alias-check retired-surface-check ownership-inventory-check deadcode
 
 define run_lint_checker
 $(if $(LINT_CHECKER_DRIVER),"$(LINT_CHECKER_DRIVER)",$(GO) run $(LINT_CHECKER_DRIVER_PACKAGE)) -cache-dir "$(LINT_CHECKER_CACHE_DIR)" -go "$(GO)" $(if $(filter 1 true yes,$(LINT_CHECKER_FALLBACK)),-fallback,) -package "$(1)" -- $(2)
@@ -240,7 +240,7 @@ endef
 .PHONY: docs-reference-check docs-reference-smoke
 
 .PHONY: script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke javascript-contract-smoke config-contract-smoke
-.PHONY: backend-size pkg-maint pkg-file-count pkg-boundary pkg-structure package-target-manifest-check packaged-factory-source-check packaged-factory-consumption-check packaged-factory-catalog-generate packaged-factory-catalog-check provider-catalog-generate provider-catalog-check model-provider-package-generate model-provider-package-check durable-runtime-construction-check logging-boundary-check ownership-inventory-check
+.PHONY: backend-size pkg-maint pkg-file-count pkg-boundary pkg-structure service-cycle-check package-target-manifest-check packaged-factory-source-check packaged-factory-consumption-check packaged-factory-catalog-generate packaged-factory-catalog-check provider-catalog-generate provider-catalog-check model-provider-package-generate model-provider-package-check durable-runtime-construction-check logging-boundary-check ownership-inventory-check
 .PHONY: response-stream-stress-smoke release-surface-smoke artifact-contract-closeout
 .PHONY: compatibility-alias-check retired-surface-check readme-check deadcode dashboard-verify
 
@@ -740,6 +740,9 @@ pkg-boundary:
 
 pkg-structure:
 	$(call run_lint_checker,./cmd/pkgstructurecheck,-root "$(PACKAGE_STRUCTURE_ROOT)")
+
+service-cycle-check:
+	$(call run_lint_checker,./cmd/servicecyclecheck,-root ".")
 
 package-target-manifest-check:
 	$(call run_lint_checker,./cmd/packagetargetmanifestcheck,-root ".")

--- a/cmd/servicecyclecheck/fixture_test.go
+++ b/cmd/servicecyclecheck/fixture_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fixtureFile describes one Go file in a synthetic pkg/services-shaped tree.
+// Imports are written as repository-relative package paths such as
+// "pkg/services/beta"; the fixture writer expands them to module paths.
+type fixtureFile struct {
+	path    string
+	imports []string
+}
+
+// writeFixtureRepo materializes a synthetic repository root containing the
+// named services and files, and returns its path. Fixtures are built under
+// t.TempDir() rather than committed testdata so that no synthetic import ever
+// reaches a repository-wide checker.
+func writeFixtureRepo(t *testing.T, services []string, files []fixtureFile) string {
+	t.Helper()
+
+	root := t.TempDir()
+	for _, service := range services {
+		if err := os.MkdirAll(filepath.Join(root, "pkg", "services", service), 0o755); err != nil {
+			t.Fatalf("create fixture service %s: %v", service, err)
+		}
+	}
+	for _, file := range files {
+		writeFixtureFile(t, root, file)
+	}
+	return root
+}
+
+func writeFixtureFile(t *testing.T, root string, file fixtureFile) {
+	t.Helper()
+
+	fullPath := filepath.Join(root, filepath.FromSlash(file.path))
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		t.Fatalf("create fixture directory for %s: %v", file.path, err)
+	}
+
+	var builder strings.Builder
+	builder.WriteString("package fixture\n")
+	for _, importPath := range file.imports {
+		fmt.Fprintf(&builder, "\nimport %q\n", repositoryImportPrefix+importPath)
+	}
+	if err := os.WriteFile(fullPath, []byte(builder.String()), 0o600); err != nil {
+		t.Fatalf("write fixture file %s: %v", file.path, err)
+	}
+}
+
+// writeFixtureCeiling writes a ceiling baseline next to a fixture root and
+// returns its path.
+func writeFixtureCeiling(t *testing.T, root string, ceiling int) string {
+	t.Helper()
+
+	path := filepath.Join(root, "ceiling.json")
+	content, err := json.Marshal(cycleCeiling{Description: "fixture ceiling", Ceiling: ceiling})
+	if err != nil {
+		t.Fatalf("encode fixture ceiling: %v", err)
+	}
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write fixture ceiling: %v", err)
+	}
+	return path
+}
+
+// ratchetFixtureServices is the service roster shared by the ratchet fixtures.
+var ratchetFixtureServices = []string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta"}
+
+// ratchetFixtureFiles is a hand-checkable synthetic graph with two arc-disjoint
+// cycles, alpha<->beta and gamma<->delta, plus the one-way arc epsilon->zeta.
+// Breaking each cycle needs one arc and neither arc can serve both, so the
+// minimum feedback arc weight is exactly 2.
+func ratchetFixtureFiles() []fixtureFile {
+	return []fixtureFile{
+		{path: "pkg/services/alpha/internal/client.go", imports: []string{"pkg/services/beta"}},
+		{path: "pkg/services/beta/transports/http/adapter.go", imports: []string{"pkg/services/alpha"}},
+		{path: "pkg/services/gamma/contract.go", imports: []string{"pkg/services/delta"}},
+		{path: "pkg/services/delta/wire/provider.go", imports: []string{"pkg/services/gamma"}},
+		{path: "pkg/services/epsilon/reader.go", imports: []string{"pkg/services/zeta"}},
+	}
+}
+
+// withAddedBackEdge returns the ratchet fixture plus zeta->epsilon, which
+// closes a third arc-disjoint cycle and raises the minimum weight to 3.
+func withAddedBackEdge() []fixtureFile {
+	return append(ratchetFixtureFiles(), fixtureFile{
+		path:    "pkg/services/zeta/internal/adapter/callback.go",
+		imports: []string{"pkg/services/epsilon"},
+	})
+}
+
+// withRemovedBackEdge returns the ratchet fixture minus delta->gamma, which
+// opens the gamma/delta cycle and lowers the minimum weight to 1.
+func withRemovedBackEdge() []fixtureFile {
+	var kept []fixtureFile
+	for _, file := range ratchetFixtureFiles() {
+		if file.path == "pkg/services/delta/wire/provider.go" {
+			continue
+		}
+		kept = append(kept, file)
+	}
+	return kept
+}

--- a/cmd/servicecyclecheck/graph.go
+++ b/cmd/servicecyclecheck/graph.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"fmt"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// repositoryImportPrefix matches the module path declared in go.mod. The
+// walking and parsing conventions in this file follow cmd/pkgboundarycheck:
+// filepath.WalkDir over the repository tree, parser.ImportsOnly parsing, and
+// the shared ignored-directory rules.
+const repositoryImportPrefix = "github.com/portpowered/infinite-you/"
+
+// servicesRelativeRoot is the tree whose immediate subdirectories define the
+// service list. The list is always derived from this tree at run time; the
+// checker never carries a hardcoded roster of service names.
+var servicesRelativeRoot = filepath.Join("pkg", "services")
+
+// ignoredWalkDirectoryNames mirrors cmd/pkgboundarycheck's ignored directory
+// names so generated, vendored, and fixture trees never contribute edges.
+var ignoredWalkDirectoryNames = map[string]struct{}{
+	".git":         {},
+	"node_modules": {},
+	"testdata":     {},
+	"vendor":       {},
+}
+
+// serviceEdge identifies one directed cross-service import relationship.
+type serviceEdge struct {
+	from string
+	to   string
+}
+
+// serviceGraph is the derived weighted directed cross-service import graph.
+// Weight is the number of non-test import statements in packages owned by
+// `from` that resolve into packages owned by `to`. Self-edges are excluded.
+type serviceGraph struct {
+	services []string
+	weights  map[serviceEdge]int
+	carriers map[serviceEdge][]string
+}
+
+// matrix renders the graph as a dense adjacency matrix indexed by the sorted
+// service list, which is the input form the exact MFAS solver consumes.
+func (graph *serviceGraph) matrix() [][]int {
+	index := make(map[string]int, len(graph.services))
+	for position, service := range graph.services {
+		index[service] = position
+	}
+	matrix := make([][]int, len(graph.services))
+	for position := range matrix {
+		matrix[position] = make([]int, len(graph.services))
+	}
+	for edge, weight := range graph.weights {
+		from, fromKnown := index[edge.from]
+		to, toKnown := index[edge.to]
+		if !fromKnown || !toKnown {
+			continue
+		}
+		matrix[from][to] = weight
+	}
+	return matrix
+}
+
+// buildServiceGraph derives the service list and the weighted cross-service
+// import graph rooted at repoRoot.
+func buildServiceGraph(repoRoot string) (*serviceGraph, error) {
+	absoluteRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repository root: %w", err)
+	}
+	servicesRoot := filepath.Join(absoluteRoot, servicesRelativeRoot)
+	services, err := discoverServices(servicesRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	graph := &serviceGraph{
+		services: services,
+		weights:  map[serviceEdge]int{},
+		carriers: map[serviceEdge][]string{},
+	}
+	known := make(map[string]struct{}, len(services))
+	for _, service := range services {
+		known[service] = struct{}{}
+	}
+	if err := graph.collectEdges(absoluteRoot, servicesRoot, known); err != nil {
+		return nil, err
+	}
+	graph.sortCarriers()
+	return graph, nil
+}
+
+// discoverServices lists the immediate subdirectories of pkg/services. Each
+// one is a service node, including services that import nothing.
+func discoverServices(servicesRoot string) ([]string, error) {
+	entries, err := os.ReadDir(servicesRoot)
+	if err != nil {
+		return nil, fmt.Errorf("read services root %s: %w", filepath.ToSlash(servicesRoot), err)
+	}
+	services := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, ignored := ignoredWalkDirectoryNames[entry.Name()]; ignored {
+			continue
+		}
+		services = append(services, entry.Name())
+	}
+	slices.Sort(services)
+	return services, nil
+}
+
+// collectEdges walks every non-test Go file under pkg/services and records one
+// unit of weight per import statement that crosses a service boundary.
+func (graph *serviceGraph) collectEdges(repoRoot string, servicesRoot string, known map[string]struct{}) error {
+	return filepath.WalkDir(servicesRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("walk %s: %w", filepath.ToSlash(path), walkErr)
+		}
+		if entry.IsDir() {
+			if _, ignored := ignoredWalkDirectoryNames[entry.Name()]; ignored {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(entry.Name()) != ".go" || strings.HasSuffix(entry.Name(), "_test.go") {
+			return nil
+		}
+		relativePath, err := filepath.Rel(repoRoot, path)
+		if err != nil {
+			return fmt.Errorf("resolve relative path for %s: %w", filepath.ToSlash(path), err)
+		}
+		return graph.collectFileEdges(path, filepath.ToSlash(relativePath), known)
+	})
+}
+
+// collectFileEdges records the cross-service imports of a single file.
+func (graph *serviceGraph) collectFileEdges(path string, relativePath string, known map[string]struct{}) error {
+	owner, ok := serviceOwnerOf(relativePath)
+	if !ok {
+		return nil
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", relativePath, err)
+	}
+	parsedFile, err := parser.ParseFile(token.NewFileSet(), path, content, parser.ImportsOnly)
+	if err != nil {
+		return fmt.Errorf("parse %s: %w", relativePath, err)
+	}
+
+	carrierPackage := pathDirectory(relativePath)
+	for _, importSpec := range parsedFile.Imports {
+		importPath, err := strconv.Unquote(importSpec.Path.Value)
+		if err != nil {
+			continue
+		}
+		target, ok := importedServiceOf(importPath)
+		if !ok || target == owner {
+			continue
+		}
+		if _, isService := known[target]; !isService {
+			continue
+		}
+		graph.recordImport(serviceEdge{from: owner, to: target}, carrierPackage)
+	}
+	return nil
+}
+
+// recordImport adds one import statement's worth of weight to an edge and
+// remembers the package that carries it.
+func (graph *serviceGraph) recordImport(edge serviceEdge, carrierPackage string) {
+	graph.weights[edge]++
+	if !slices.Contains(graph.carriers[edge], carrierPackage) {
+		graph.carriers[edge] = append(graph.carriers[edge], carrierPackage)
+	}
+}
+
+// sortCarriers makes carrier reporting deterministic across runs.
+func (graph *serviceGraph) sortCarriers() {
+	for edge := range graph.carriers {
+		slices.Sort(graph.carriers[edge])
+	}
+}
+
+// serviceOwnerOf reports which service owns a repository-relative file path.
+func serviceOwnerOf(relativePath string) (string, bool) {
+	parts := strings.Split(relativePath, "/")
+	if len(parts) < 4 || parts[0] != "pkg" || parts[1] != "services" {
+		return "", false
+	}
+	return parts[2], true
+}
+
+// importedServiceOf reports which service an import path resolves into. Both
+// the service root package and any nested package count as the same target.
+func importedServiceOf(importPath string) (string, bool) {
+	const servicesImportPrefix = repositoryImportPrefix + "pkg/services/"
+	suffix, ok := strings.CutPrefix(importPath, servicesImportPrefix)
+	if !ok || suffix == "" {
+		return "", false
+	}
+	service, _, _ := strings.Cut(suffix, "/")
+	if service == "" {
+		return "", false
+	}
+	return service, true
+}
+
+// pathDirectory returns the slash-separated parent directory of a path.
+func pathDirectory(relativePath string) string {
+	index := strings.LastIndex(relativePath, "/")
+	if index < 0 {
+		return "."
+	}
+	return relativePath[:index]
+}

--- a/cmd/servicecyclecheck/graph_test.go
+++ b/cmd/servicecyclecheck/graph_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestBuildServiceGraphDerivesServicesFromTheDirectoryTree(t *testing.T) {
+	t.Parallel()
+
+	root := writeFixtureRepo(t,
+		[]string{"alpha", "beta", "lonely"},
+		[]fixtureFile{{path: "pkg/services/alpha/client.go", imports: []string{"pkg/services/beta"}}},
+	)
+	// A stray file and an ignored directory must not become services.
+	if err := os.WriteFile(filepath.Join(root, "pkg", "services", "README.md"), []byte("notes"), 0o600); err != nil {
+		t.Fatalf("write stray file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "pkg", "services", "testdata"), 0o755); err != nil {
+		t.Fatalf("create ignored directory: %v", err)
+	}
+
+	graph, err := buildServiceGraph(root)
+	if err != nil {
+		t.Fatalf("buildServiceGraph returned an error: %v", err)
+	}
+
+	want := []string{"alpha", "beta", "lonely"}
+	if !slices.Equal(graph.services, want) {
+		t.Fatalf("derived services = %v, want %v (services with no imports still count)", graph.services, want)
+	}
+}
+
+func TestBuildServiceGraphWeighsEachImportStatementAndSkipsSelfEdges(t *testing.T) {
+	t.Parallel()
+
+	root := writeFixtureRepo(t,
+		[]string{"alpha", "beta", "gamma"},
+		[]fixtureFile{
+			{path: "pkg/services/alpha/a.go", imports: []string{
+				"pkg/services/beta",
+				"pkg/services/beta/internal/store",
+				"pkg/services/alpha/internal/self",
+				"pkg/platform/logging",
+			}},
+			{path: "pkg/services/alpha/internal/b.go", imports: []string{"pkg/services/beta/wire"}},
+			{path: "pkg/services/gamma/c.go", imports: []string{"pkg/services/beta"}},
+		},
+	)
+
+	graph, err := buildServiceGraph(root)
+	if err != nil {
+		t.Fatalf("buildServiceGraph returned an error: %v", err)
+	}
+
+	if got := graph.weights[serviceEdge{from: "alpha", to: "beta"}]; got != 3 {
+		t.Fatalf("alpha -> beta weight = %d, want 3 (one per crossing import statement)", got)
+	}
+	if got := graph.weights[serviceEdge{from: "gamma", to: "beta"}]; got != 1 {
+		t.Fatalf("gamma -> beta weight = %d, want 1", got)
+	}
+	if got := graph.weights[serviceEdge{from: "alpha", to: "alpha"}]; got != 0 {
+		t.Fatalf("alpha -> alpha weight = %d, want 0 because self-edges are excluded", got)
+	}
+	if len(graph.weights) != 2 {
+		t.Fatalf("recorded %d edge(s), want 2; non-service imports must not create edges: %v", len(graph.weights), graph.weights)
+	}
+}
+
+func TestBuildServiceGraphRecordsCarrierPackagesAndIgnoresTestFiles(t *testing.T) {
+	t.Parallel()
+
+	root := writeFixtureRepo(t,
+		[]string{"alpha", "beta"},
+		[]fixtureFile{
+			{path: "pkg/services/alpha/transports/http/adapter.go", imports: []string{"pkg/services/beta"}},
+			{path: "pkg/services/alpha/internal/store.go", imports: []string{"pkg/services/beta/contract"}},
+			{path: "pkg/services/alpha/wire/provider_test.go", imports: []string{"pkg/services/beta"}},
+			{path: "pkg/services/alpha/testdata/sample/fake.go", imports: []string{"pkg/services/beta"}},
+		},
+	)
+
+	graph, err := buildServiceGraph(root)
+	if err != nil {
+		t.Fatalf("buildServiceGraph returned an error: %v", err)
+	}
+
+	edge := serviceEdge{from: "alpha", to: "beta"}
+	if got := graph.weights[edge]; got != 2 {
+		t.Fatalf("alpha -> beta weight = %d, want 2; _test.go and testdata imports must not count", got)
+	}
+	want := []string{"pkg/services/alpha/internal", "pkg/services/alpha/transports/http"}
+	if !slices.Equal(graph.carriers[edge], want) {
+		t.Fatalf("carrier packages = %v, want %v", graph.carriers[edge], want)
+	}
+}
+
+func TestServiceGraphMatrixIndexesBySortedServiceList(t *testing.T) {
+	t.Parallel()
+
+	root := writeFixtureRepo(t,
+		[]string{"alpha", "beta", "gamma"},
+		[]fixtureFile{
+			{path: "pkg/services/gamma/a.go", imports: []string{"pkg/services/alpha", "pkg/services/alpha/wire"}},
+			{path: "pkg/services/beta/b.go", imports: []string{"pkg/services/gamma"}},
+		},
+	)
+
+	graph, err := buildServiceGraph(root)
+	if err != nil {
+		t.Fatalf("buildServiceGraph returned an error: %v", err)
+	}
+
+	matrix := graph.matrix()
+	if len(matrix) != 3 {
+		t.Fatalf("matrix has %d row(s), want 3", len(matrix))
+	}
+	// services sort to [alpha beta gamma], so gamma -> alpha is (2,0).
+	if matrix[2][0] != 2 {
+		t.Fatalf("matrix[gamma][alpha] = %d, want 2", matrix[2][0])
+	}
+	if matrix[1][2] != 1 {
+		t.Fatalf("matrix[beta][gamma] = %d, want 1", matrix[1][2])
+	}
+	if matrix[0][1] != 0 {
+		t.Fatalf("matrix[alpha][beta] = %d, want 0", matrix[0][1])
+	}
+}
+
+func TestBuildServiceGraphReportsAMissingServicesRoot(t *testing.T) {
+	t.Parallel()
+
+	if _, err := buildServiceGraph(t.TempDir()); err == nil {
+		t.Fatal("expected an error when pkg/services is absent, got none")
+	}
+}
+
+func TestServiceGraphCutSetNamesBackEdgesWithCarriers(t *testing.T) {
+	t.Parallel()
+
+	root := writeFixtureRepo(t, ratchetFixtureServices, ratchetFixtureFiles())
+	graph, err := buildServiceGraph(root)
+	if err != nil {
+		t.Fatalf("buildServiceGraph returned an error: %v", err)
+	}
+	solution, err := minimumFeedbackArcSet(graph.matrix())
+	if err != nil {
+		t.Fatalf("minimumFeedbackArcSet returned an error: %v", err)
+	}
+
+	if solution.weight != 2 {
+		t.Fatalf("fixture minimum feedback arc weight = %d, want 2", solution.weight)
+	}
+	edges := graph.cutSet(solution.ordering)
+	if totalWeight(edges) != solution.weight {
+		t.Fatalf("cut set total weight %d does not match the solver weight %d", totalWeight(edges), solution.weight)
+	}
+	if len(edges) != 2 {
+		t.Fatalf("cut set has %d edge(s), want 2: %+v", len(edges), edges)
+	}
+	for _, edge := range edges {
+		if len(edge.carriers) == 0 {
+			t.Fatalf("cut edge %s -> %s reported no carrier package", edge.from, edge.to)
+		}
+	}
+}

--- a/cmd/servicecyclecheck/main.go
+++ b/cmd/servicecyclecheck/main.go
@@ -1,0 +1,102 @@
+// Command servicecyclecheck is the derived cross-service cycle ratchet.
+//
+// It derives the service list from the pkg/services directory tree, builds the
+// weighted directed graph of non-test cross-service imports, computes the
+// exact minimum feedback arc weight of that graph, and compares the weight
+// against a ceiling recorded in a small dedicated baseline file.
+//
+// The comparison is a ratchet in both directions. A weight above the ceiling
+// is a regression and fails. A weight below the ceiling is an unclaimed
+// improvement and also fails, with instructions to lower the ceiling, so that
+// untangling work is captured permanently instead of being silently undone by
+// a later change.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+var (
+	stdoutWriter io.Writer = os.Stdout
+	stderrWriter io.Writer = os.Stderr
+	exitFunc               = os.Exit
+)
+
+type config struct {
+	root        string
+	ceilingFile string
+}
+
+func main() {
+	cfg := parseConfig()
+	if err := run(cfg, stdoutWriter, stderrWriter); err != nil {
+		fmt.Fprintln(stderrWriter, err)
+		exitFunc(1)
+	}
+}
+
+func parseConfig() config {
+	cfg := config{}
+	flag.StringVar(&cfg.root, "root", ".", "repository root to scan")
+	flag.StringVar(&cfg.ceilingFile, "ceiling-file", "", "path to the cycle ceiling baseline (defaults to the repository baseline under the scanned root)")
+	flag.Parse()
+	return cfg
+}
+
+// ceilingPath resolves the baseline location, defaulting to the repository
+// baseline beneath the scanned root.
+func (cfg config) ceilingPath() string {
+	if cfg.ceilingFile != "" {
+		return cfg.ceilingFile
+	}
+	return filepath.Join(cfg.root, defaultCeilingRelativePath)
+}
+
+func run(cfg config, stdout io.Writer, stderr io.Writer) error {
+	graph, err := buildServiceGraph(cfg.root)
+	if err != nil {
+		return err
+	}
+	ceiling, err := loadCycleCeiling(cfg.ceilingPath())
+	if err != nil {
+		return err
+	}
+	solution, err := minimumFeedbackArcSet(graph.matrix())
+	if err != nil {
+		return err
+	}
+
+	edges := graph.cutSet(solution.ordering)
+	if solution.weight == ceiling.Ceiling {
+		writeSuccess(stdout, solution.weight, ceiling, edges, len(graph.services))
+		return nil
+	}
+	return reportRatchetFailure(stderr, solution.weight, ceiling, edges)
+}
+
+// reportRatchetFailure prints the failing diagnosis, emits the machine
+// readable violation count so the CI lint policy never classifies this target
+// as unmeasured, and returns the summarizing error.
+func reportRatchetFailure(stderr io.Writer, measured int, ceiling cycleCeiling, edges []backEdge) error {
+	drift := measured - ceiling.Ceiling
+	if drift < 0 {
+		drift = -drift
+	}
+	if measured > ceiling.Ceiling {
+		writeRegression(stderr, measured, ceiling, edges)
+	} else {
+		writeUnclaimedImprovement(stderr, measured, ceiling, edges)
+	}
+	fmt.Fprintf(stderr, "LINT_VIOLATION_COUNT: %d\n", drift)
+	return fmt.Errorf(
+		"%s minimum feedback arc weight %d does not match the recorded ceiling %d (drift %d)",
+		diagnosticPrefix,
+		measured,
+		ceiling.Ceiling,
+		drift,
+	)
+}

--- a/cmd/servicecyclecheck/main_test.go
+++ b/cmd/servicecyclecheck/main_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runFixture executes the checker against a synthetic repository root and
+// returns its stdout, stderr and error.
+func runFixture(t *testing.T, files []fixtureFile, ceiling int) (string, string, error) {
+	t.Helper()
+
+	root := writeFixtureRepo(t, ratchetFixtureServices, files)
+	var stdout, stderr bytes.Buffer
+	err := run(config{root: root, ceilingFile: writeFixtureCeiling(t, root, ceiling)}, &stdout, &stderr)
+	return stdout.String(), stderr.String(), err
+}
+
+func TestRunPassesWhenTheMeasuredWeightMatchesTheCeiling(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr, err := runFixture(t, ratchetFixtureFiles(), 2)
+	if err != nil {
+		t.Fatalf("run returned an error: %v\nstderr:\n%s", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("passing run wrote to stderr:\n%s", stderr)
+	}
+	for _, want := range []string{diagnosticPrefix, "minimum feedback arc weight 2", "matches ceiling 2", "6 service(s)"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout %q does not contain %q", stdout, want)
+		}
+	}
+	if strings.Contains(stdout, "LINT_VIOLATION_COUNT") {
+		t.Fatalf("a passing run must not emit a violation count, got:\n%s", stdout)
+	}
+}
+
+func TestRunFailsWhenAnAddedBackEdgeDeepensTheCycle(t *testing.T) {
+	t.Parallel()
+
+	_, stderr, err := runFixture(t, withAddedBackEdge(), 2)
+	if err == nil {
+		t.Fatalf("expected a regression failure, got success:\n%s", stderr)
+	}
+
+	for _, want := range []string{
+		"cross-service cycle regression",
+		"minimum feedback arc weight is 3",
+		"above the recorded ceiling of 2",
+		"zeta -> epsilon (weight 1)",
+		"carrier package: pkg/services/zeta/internal/adapter",
+		"LINT_VIOLATION_COUNT: 1",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("regression output does not contain %q:\n%s", want, stderr)
+		}
+	}
+	if strings.Contains(stderr, "Lower the ceiling") {
+		t.Fatalf("a regression must not tell the maintainer to lower the ceiling:\n%s", stderr)
+	}
+	if !strings.Contains(err.Error(), "does not match the recorded ceiling 2") {
+		t.Fatalf("summary error = %v", err)
+	}
+}
+
+func TestRunFailsWhenARemovedBackEdgeLeavesTheCeilingUnclaimed(t *testing.T) {
+	t.Parallel()
+
+	_, stderr, err := runFixture(t, withRemovedBackEdge(), 2)
+	if err == nil {
+		t.Fatalf("expected an unclaimed-improvement failure, got success:\n%s", stderr)
+	}
+
+	for _, want := range []string{
+		"cross-service cycle improved and the gain is not captured",
+		"minimum feedback arc weight is 1",
+		"below the recorded ceiling of 2",
+		"Lower the ceiling to 1",
+		"LINT_VIOLATION_COUNT: 1",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("unclaimed-improvement output does not contain %q:\n%s", want, stderr)
+		}
+	}
+	if !strings.Contains(stderr, "cut set (1 edge(s), total weight 1)") {
+		t.Fatalf("improvement output must still print the remaining cut set:\n%s", stderr)
+	}
+}
+
+func TestRunReportsTheDriftMagnitudeAsTheViolationCount(t *testing.T) {
+	t.Parallel()
+
+	_, stderr, err := runFixture(t, withAddedBackEdge(), 0)
+	if err == nil {
+		t.Fatal("expected a regression failure, got success")
+	}
+	if !strings.Contains(stderr, "LINT_VIOLATION_COUNT: 3") {
+		t.Fatalf("violation count must be the drift magnitude (3 - 0), got:\n%s", stderr)
+	}
+}
+
+func TestRunRejectsAnUnreadableOrInvalidCeilingBaseline(t *testing.T) {
+	t.Parallel()
+
+	root := writeFixtureRepo(t, ratchetFixtureServices, ratchetFixtureFiles())
+	var stdout, stderr bytes.Buffer
+
+	missing := filepath.Join(root, "absent.json")
+	if err := run(config{root: root, ceilingFile: missing}, &stdout, &stderr); err == nil {
+		t.Fatal("expected an error for a missing ceiling baseline, got none")
+	}
+
+	malformed := filepath.Join(root, "malformed.json")
+	if err := os.WriteFile(malformed, []byte("{"), 0o600); err != nil {
+		t.Fatalf("write malformed ceiling: %v", err)
+	}
+	if err := run(config{root: root, ceilingFile: malformed}, &stdout, &stderr); err == nil {
+		t.Fatal("expected an error for a malformed ceiling baseline, got none")
+	}
+
+	negative := filepath.Join(root, "negative.json")
+	if err := os.WriteFile(negative, []byte(`{"ceiling":-1}`), 0o600); err != nil {
+		t.Fatalf("write negative ceiling: %v", err)
+	}
+	if err := run(config{root: root, ceilingFile: negative}, &stdout, &stderr); err == nil {
+		t.Fatal("expected an error for a negative ceiling, got none")
+	}
+}
+
+func TestCeilingPathDefaultsToTheRepositoryBaseline(t *testing.T) {
+	t.Parallel()
+
+	got := config{root: "somewhere"}.ceilingPath()
+	want := filepath.Join("somewhere", "docs", "internal", "baselines", "service-cycle-ceiling.json")
+	if got != want {
+		t.Fatalf("default ceiling path = %q, want %q", got, want)
+	}
+	if override := (config{root: "somewhere", ceilingFile: "explicit.json"}).ceilingPath(); override != "explicit.json" {
+		t.Fatalf("explicit ceiling path = %q, want %q", override, "explicit.json")
+	}
+}
+
+// TestRunAgainstTheRepositoryMatchesTheRecordedCeiling is the live gate: it
+// runs the checker over this repository with the committed baseline, which is
+// exactly what `make service-cycle` does in CI.
+func TestRunAgainstTheRepositoryMatchesTheRecordedCeiling(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	if err := run(config{root: repositoryRoot(t)}, &stdout, &stderr); err != nil {
+		t.Fatalf("service cycle ratchet failed against the repository: %v\n%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "matches ceiling") {
+		t.Fatalf("repository run did not report the ceiling comparison:\n%s", stdout.String())
+	}
+}
+
+// repositoryRoot walks up from the test's working directory to the module root.
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+
+	directory, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("resolve working directory: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(directory, "go.mod")); err == nil {
+			return directory
+		}
+		parent := filepath.Dir(directory)
+		if parent == directory {
+			t.Fatal("could not locate the module root from the test working directory")
+		}
+		directory = parent
+	}
+}

--- a/cmd/servicecyclecheck/mfas.go
+++ b/cmd/servicecyclecheck/mfas.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"math/bits"
+)
+
+// maxSafeServiceCount bounds the subset dynamic program. The state space is
+// 2^N, so the exact solver stays cheap well past the current service count but
+// would become unreasonable if the tree grew without anyone noticing. Crossing
+// the bound is a deliberate maintainer decision, so the solver refuses to run
+// rather than silently degrading to a heuristic whose answer would not be
+// comparable against a recorded ceiling.
+const maxSafeServiceCount = 20
+
+// feedbackArcSolution is the exact minimum feedback arc set of a weighted
+// directed graph: the smallest total edge weight that has to be removed to
+// make the graph acyclic, plus one linear ordering that realizes it.
+type feedbackArcSolution struct {
+	weight   int
+	ordering []int
+}
+
+// minimumFeedbackArcSet computes the exact minimum feedback arc weight of a
+// weighted directed graph given as a dense adjacency matrix.
+//
+// Every acyclic subgraph corresponds to a linear ordering of the vertices, and
+// the arcs that must be removed for a given ordering are exactly the arcs
+// pointing backwards in it. The minimum feedback arc weight is therefore the
+// minimum, over all orderings, of the total backward arc weight.
+//
+// The minimum is found by dynamic programming over subsets: state S is the set
+// of vertices already placed in the ordering's prefix, and dp[S] is the least
+// backward weight induced inside that prefix. Placing vertex v immediately
+// after every vertex in S turns exactly the arcs v -> u (u in S) into backward
+// arcs, so dp[S|{v}] = min over v not in S of dp[S] + sum of weights(v, u) for
+// u in S. dp over the full set is the exact optimum. This is a true optimum
+// over all N! orderings at roughly 2^N * N cost -- not a greedy or
+// nearest-neighbor approximation, both of which can be arbitrarily worse.
+//
+// Ties are broken towards the lowest vertex index, so repeated runs on the
+// same input report the same ordering and therefore the same cut set.
+func minimumFeedbackArcSet(weights [][]int) (feedbackArcSolution, error) {
+	count := len(weights)
+	if count > maxSafeServiceCount {
+		return feedbackArcSolution{}, fmt.Errorf(
+			"exact minimum feedback arc set refuses to run on %d vertices: the subset dynamic program is bounded at %d; raise maxSafeServiceCount deliberately after confirming the 2^N state space is still affordable, and never substitute a heuristic, because a heuristic result is not comparable against the recorded ceiling",
+			count,
+			maxSafeServiceCount,
+		)
+	}
+	if err := validateSquareMatrix(weights); err != nil {
+		return feedbackArcSolution{}, err
+	}
+	if count == 0 {
+		return feedbackArcSolution{weight: 0, ordering: nil}, nil
+	}
+
+	best, predecessor := solveOrderingDP(weights)
+	full := (1 << count) - 1
+	return feedbackArcSolution{
+		weight:   best[full],
+		ordering: reconstructOrdering(predecessor, count),
+	}, nil
+}
+
+// validateSquareMatrix rejects malformed input before the dynamic program
+// indexes into it.
+func validateSquareMatrix(weights [][]int) error {
+	for row, columns := range weights {
+		if len(columns) != len(weights) {
+			return fmt.Errorf("weight matrix row %d has %d column(s), want %d", row, len(columns), len(weights))
+		}
+		for column, weight := range columns {
+			if weight < 0 {
+				return fmt.Errorf("weight matrix entry (%d,%d) is negative: %d", row, column, weight)
+			}
+		}
+	}
+	return nil
+}
+
+// solveOrderingDP fills the subset table and records, for each state, which
+// vertex was placed last on a cheapest path into that state.
+func solveOrderingDP(weights [][]int) ([]int, []int) {
+	count := len(weights)
+	states := 1 << count
+	best := make([]int, states)
+	predecessor := make([]int, states)
+	for state := range best {
+		best[state] = math.MaxInt
+		predecessor[state] = -1
+	}
+	best[0] = 0
+
+	for state := range states {
+		placed := best[state]
+		if placed == math.MaxInt {
+			continue
+		}
+		for vertex := range count {
+			bit := 1 << vertex
+			if state&bit != 0 {
+				continue
+			}
+			candidate := placed + backwardWeightInto(weights[vertex], state)
+			next := state | bit
+			if candidate < best[next] {
+				best[next] = candidate
+				predecessor[next] = vertex
+			}
+		}
+	}
+	return best, predecessor
+}
+
+// backwardWeightInto sums the arcs from the vertex owning row into every
+// already-placed vertex; those arcs become backward arcs when the vertex is
+// appended after the placed prefix.
+func backwardWeightInto(row []int, state int) int {
+	total := 0
+	for remaining := state; remaining != 0; remaining &= remaining - 1 {
+		total += row[bits.TrailingZeros(uint(remaining))]
+	}
+	return total
+}
+
+// reconstructOrdering walks the recorded predecessors back from the full state
+// to recover one optimal ordering.
+func reconstructOrdering(predecessor []int, count int) []int {
+	ordering := make([]int, count)
+	state := (1 << count) - 1
+	for position := count - 1; position >= 0; position-- {
+		vertex := predecessor[state]
+		ordering[position] = vertex
+		state &^= 1 << vertex
+	}
+	return ordering
+}
+
+// orderedPositions inverts an ordering into a vertex-indexed position lookup.
+func orderedPositions(ordering []int) []int {
+	positions := make([]int, len(ordering))
+	for position, vertex := range ordering {
+		positions[vertex] = position
+	}
+	return positions
+}

--- a/cmd/servicecyclecheck/mfas_test.go
+++ b/cmd/servicecyclecheck/mfas_test.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// feedbackWeightOfOrdering scores an ordering the way the definition does:
+// total weight of arcs whose source is placed after their target.
+func feedbackWeightOfOrdering(weights [][]int, ordering []int) int {
+	positions := orderedPositions(ordering)
+	total := 0
+	for from, row := range weights {
+		for to, weight := range row {
+			if positions[from] > positions[to] {
+				total += weight
+			}
+		}
+	}
+	return total
+}
+
+// bruteForceFeedbackArcWeight enumerates every ordering. It is exponentially
+// slower than the subset dynamic program but obviously correct, so it is the
+// independent oracle the solver is checked against.
+func bruteForceFeedbackArcWeight(weights [][]int) int {
+	count := len(weights)
+	ordering := make([]int, count)
+	for index := range ordering {
+		ordering[index] = index
+	}
+	best := -1
+	var permute func(depth int)
+	permute = func(depth int) {
+		if depth == count {
+			score := feedbackWeightOfOrdering(weights, ordering)
+			if best < 0 || score < best {
+				best = score
+			}
+			return
+		}
+		for index := depth; index < count; index++ {
+			ordering[depth], ordering[index] = ordering[index], ordering[depth]
+			permute(depth + 1)
+			ordering[depth], ordering[index] = ordering[index], ordering[depth]
+		}
+	}
+	permute(0)
+	if best < 0 {
+		return 0
+	}
+	return best
+}
+
+// greedyFeedbackArcWeight is the cheapest-next ("nearest neighbor") ordering
+// heuristic: repeatedly append whichever unplaced vertex adds the least
+// backward weight right now, breaking ties towards the lowest index. It is the
+// kind of heuristic this checker must not use, because it optimizes each step
+// in isolation and has no bound on how far off the optimum it can land.
+func greedyFeedbackArcWeight(weights [][]int) int {
+	count := len(weights)
+	placed := 0
+	total := 0
+	for range count {
+		bestVertex := -1
+		bestCost := 0
+		for vertex := range count {
+			if placed&(1<<vertex) != 0 {
+				continue
+			}
+			cost := backwardWeightInto(weights[vertex], placed)
+			if bestVertex < 0 || cost < bestCost {
+				bestVertex, bestCost = vertex, cost
+			}
+		}
+		placed |= 1 << bestVertex
+		total += bestCost
+	}
+	return total
+}
+
+// greedyTrapGraph is hand-checkable. Vertices 1, 2 and 3 each point at vertex 0
+// with weight 3, and the only other arcs are the light chain 0->1->2->3 with
+// weight 1 each. Placing 0 last costs just the single light arc 0->1, so the
+// optimum is 1. The cheapest-next heuristic starts from an empty prefix where
+// every vertex looks free, appends vertex 0 first, and then pays 3 for each of
+// the three heavy arcs it stranded behind it, for a total of 9.
+func greedyTrapGraph() [][]int {
+	weights := make([][]int, 4)
+	for index := range weights {
+		weights[index] = make([]int, 4)
+	}
+	weights[1][0] = 3
+	weights[2][0] = 3
+	weights[3][0] = 3
+	weights[0][1] = 1
+	weights[1][2] = 1
+	weights[2][3] = 1
+	return weights
+}
+
+// completeDigraph has every ordered pair of distinct vertices joined with unit
+// weight. Every ordering leaves exactly one arc of each unordered pair pointing
+// backwards, so the optimum is the closed form count * (count-1) / 2.
+func completeDigraph(count int) [][]int {
+	weights := make([][]int, count)
+	for from := range weights {
+		weights[from] = make([]int, count)
+		for to := range weights[from] {
+			if from != to {
+				weights[from][to] = 1
+			}
+		}
+	}
+	return weights
+}
+
+func TestMinimumFeedbackArcSetReturnsTrueOptimumWhereGreedyDoesNot(t *testing.T) {
+	t.Parallel()
+
+	weights := greedyTrapGraph()
+	solution, err := minimumFeedbackArcSet(weights)
+	if err != nil {
+		t.Fatalf("minimumFeedbackArcSet returned an error: %v", err)
+	}
+
+	if solution.weight != 1 {
+		t.Fatalf("exact minimum feedback arc weight = %d, want 1", solution.weight)
+	}
+	if greedy := greedyFeedbackArcWeight(weights); greedy != 9 {
+		t.Fatalf("cheapest-next greedy weight = %d, want 9 so the trap still discriminates", greedy)
+	}
+	if got := feedbackWeightOfOrdering(weights, solution.ordering); got != solution.weight {
+		t.Fatalf("reported ordering %v scores %d, but the reported weight is %d", solution.ordering, got, solution.weight)
+	}
+	if want := []int{1, 2, 3, 0}; !slices.Equal(solution.ordering, want) {
+		t.Fatalf("optimal ordering = %v, want %v", solution.ordering, want)
+	}
+}
+
+func TestMinimumFeedbackArcSetMatchesBruteForceOptimum(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		weights [][]int
+	}{
+		{
+			name:    "acyclic chain has no back edges",
+			weights: [][]int{{0, 4, 7}, {0, 0, 5}, {0, 0, 0}},
+		},
+		{
+			name:    "unit three cycle costs one arc",
+			weights: [][]int{{0, 1, 0}, {0, 0, 1}, {1, 0, 0}},
+		},
+		{
+			name:    "weighted three cycle cuts the cheapest arc",
+			weights: [][]int{{0, 9, 0}, {0, 0, 6}, {2, 0, 0}},
+		},
+		{
+			name:    "greedy trap",
+			weights: greedyTrapGraph(),
+		},
+		{
+			name: "two arc disjoint two cycles must both be cut",
+			weights: [][]int{
+				{0, 3, 0, 0},
+				{5, 0, 0, 0},
+				{0, 0, 0, 2},
+				{0, 0, 8, 0},
+			},
+		},
+		{
+			name:    "complete digraph on five vertices",
+			weights: completeDigraph(5),
+		},
+		{
+			name: "dense mixed weights on six vertices",
+			weights: [][]int{
+				{0, 2, 0, 1, 0, 4},
+				{3, 0, 5, 0, 0, 0},
+				{0, 1, 0, 7, 2, 0},
+				{6, 0, 0, 0, 3, 1},
+				{0, 4, 1, 0, 0, 2},
+				{1, 0, 3, 0, 5, 0},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			solution, err := minimumFeedbackArcSet(testCase.weights)
+			if err != nil {
+				t.Fatalf("minimumFeedbackArcSet returned an error: %v", err)
+			}
+			if want := bruteForceFeedbackArcWeight(testCase.weights); solution.weight != want {
+				t.Fatalf("minimum feedback arc weight = %d, brute-force optimum = %d", solution.weight, want)
+			}
+			if got := feedbackWeightOfOrdering(testCase.weights, solution.ordering); got != solution.weight {
+				t.Fatalf("reported ordering %v scores %d, but the reported weight is %d", solution.ordering, got, solution.weight)
+			}
+		})
+	}
+}
+
+func TestMinimumFeedbackArcSetOnAcyclicGraphIsZero(t *testing.T) {
+	t.Parallel()
+
+	weights := [][]int{
+		{0, 5, 3, 9},
+		{0, 0, 4, 2},
+		{0, 0, 0, 6},
+		{0, 0, 0, 0},
+	}
+	solution, err := minimumFeedbackArcSet(weights)
+	if err != nil {
+		t.Fatalf("minimumFeedbackArcSet returned an error: %v", err)
+	}
+	if solution.weight != 0 {
+		t.Fatalf("already-acyclic graph reported weight %d, want 0", solution.weight)
+	}
+}
+
+func TestMinimumFeedbackArcSetOnCompleteDigraphMatchesClosedForm(t *testing.T) {
+	t.Parallel()
+
+	for count := 2; count <= 7; count++ {
+		weights := completeDigraph(count)
+		solution, err := minimumFeedbackArcSet(weights)
+		if err != nil {
+			t.Fatalf("minimumFeedbackArcSet(%d vertices) returned an error: %v", count, err)
+		}
+		if want := count * (count - 1) / 2; solution.weight != want {
+			t.Fatalf("complete digraph on %d vertices reported weight %d, want %d", count, solution.weight, want)
+		}
+	}
+}
+
+func TestMinimumFeedbackArcSetIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	weights := completeDigraph(6)
+	first, err := minimumFeedbackArcSet(weights)
+	if err != nil {
+		t.Fatalf("first run returned an error: %v", err)
+	}
+	second, err := minimumFeedbackArcSet(weights)
+	if err != nil {
+		t.Fatalf("second run returned an error: %v", err)
+	}
+	if !slices.Equal(first.ordering, second.ordering) {
+		t.Fatalf("repeated runs reported different orderings: %v then %v", first.ordering, second.ordering)
+	}
+}
+
+func TestMinimumFeedbackArcSetRefusesGraphsAboveTheSafeBound(t *testing.T) {
+	t.Parallel()
+
+	oversized := completeDigraph(maxSafeServiceCount + 1)
+	if _, err := minimumFeedbackArcSet(oversized); err == nil {
+		t.Fatal("expected an explicit error above the safe bound, got none")
+	} else if !strings.Contains(err.Error(), "refuses to run") || !strings.Contains(err.Error(), "heuristic") {
+		t.Fatalf("error must tell a maintainer to raise the bound rather than accept a heuristic, got: %v", err)
+	}
+
+	atBound := completeDigraph(maxSafeServiceCount)
+	if _, err := minimumFeedbackArcSet(atBound); err != nil {
+		t.Fatalf("the safe bound itself must still be solvable, got: %v", err)
+	}
+}
+
+func TestMinimumFeedbackArcSetRejectsMalformedInput(t *testing.T) {
+	t.Parallel()
+
+	if _, err := minimumFeedbackArcSet([][]int{{0, 1}, {1}}); err == nil {
+		t.Fatal("expected an error for a non-square weight matrix, got none")
+	}
+	if _, err := minimumFeedbackArcSet([][]int{{0, -1}, {0, 0}}); err == nil {
+		t.Fatal("expected an error for a negative weight, got none")
+	}
+	solution, err := minimumFeedbackArcSet(nil)
+	if err != nil {
+		t.Fatalf("empty graph returned an error: %v", err)
+	}
+	if solution.weight != 0 || len(solution.ordering) != 0 {
+		t.Fatalf("empty graph reported %+v, want zero weight and an empty ordering", solution)
+	}
+}

--- a/cmd/servicecyclecheck/report.go
+++ b/cmd/servicecyclecheck/report.go
@@ -12,7 +12,7 @@ import (
 
 // diagnosticPrefix labels this checker's output the way the other repository
 // lint checkers label theirs.
-const diagnosticPrefix = "[agent-factory:service-cycle]"
+const diagnosticPrefix = "[agent-factory:service-cycle-check]"
 
 // defaultCeilingRelativePath is the small dedicated baseline that stores the
 // ratchet ceiling. It is deliberately separate from ownership-inventory.json:

--- a/cmd/servicecyclecheck/report.go
+++ b/cmd/servicecyclecheck/report.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// diagnosticPrefix labels this checker's output the way the other repository
+// lint checkers label theirs.
+const diagnosticPrefix = "[agent-factory:service-cycle]"
+
+// defaultCeilingRelativePath is the small dedicated baseline that stores the
+// ratchet ceiling. It is deliberately separate from ownership-inventory.json:
+// the ceiling is a single derived integer, not a hand-maintained edge table.
+var defaultCeilingRelativePath = filepath.Join("docs", "internal", "baselines", "service-cycle-ceiling.json")
+
+// cycleCeiling is the parsed ceiling baseline.
+type cycleCeiling struct {
+	Description string `json:"description"`
+	Ceiling     int    `json:"ceiling"`
+}
+
+// loadCycleCeiling reads and validates the ceiling baseline file.
+func loadCycleCeiling(path string) (cycleCeiling, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return cycleCeiling{}, fmt.Errorf("read cycle ceiling baseline %s: %w", filepath.ToSlash(path), err)
+	}
+	var baseline cycleCeiling
+	if err := json.Unmarshal(content, &baseline); err != nil {
+		return cycleCeiling{}, fmt.Errorf("decode cycle ceiling baseline %s: %w", filepath.ToSlash(path), err)
+	}
+	if baseline.Ceiling < 0 {
+		return cycleCeiling{}, fmt.Errorf("cycle ceiling baseline %s has a negative ceiling: %d", filepath.ToSlash(path), baseline.Ceiling)
+	}
+	return baseline, nil
+}
+
+// backEdge is one arc of the cut set: an import direction that has to be
+// reversed or removed for the service graph to become acyclic.
+type backEdge struct {
+	from     string
+	to       string
+	weight   int
+	carriers []string
+}
+
+// cutSet returns the arcs that point backwards in the supplied ordering,
+// which is exactly the minimum feedback arc set the solver selected. The
+// result is ordered heaviest-first so the most valuable cut leads the report.
+func (graph *serviceGraph) cutSet(ordering []int) []backEdge {
+	positions := orderedPositions(ordering)
+	index := make(map[string]int, len(graph.services))
+	for position, service := range graph.services {
+		index[service] = position
+	}
+
+	var edges []backEdge
+	for edge, weight := range graph.weights {
+		from, fromKnown := index[edge.from]
+		to, toKnown := index[edge.to]
+		if !fromKnown || !toKnown || weight <= 0 {
+			continue
+		}
+		if positions[from] <= positions[to] {
+			continue
+		}
+		edges = append(edges, backEdge{
+			from:     edge.from,
+			to:       edge.to,
+			weight:   weight,
+			carriers: graph.carriers[edge],
+		})
+	}
+	slices.SortFunc(edges, func(left, right backEdge) int {
+		if left.weight != right.weight {
+			return right.weight - left.weight
+		}
+		if byFrom := strings.Compare(left.from, right.from); byFrom != 0 {
+			return byFrom
+		}
+		return strings.Compare(left.to, right.to)
+	})
+	return edges
+}
+
+// totalWeight sums a cut set's arc weights.
+func totalWeight(edges []backEdge) int {
+	total := 0
+	for _, edge := range edges {
+		total += edge.weight
+	}
+	return total
+}
+
+// writeCutSet prints the full cut set: every back-edge with its weight and the
+// packages that carry it, so a decoupling lane can act on the report directly
+// and later use the same report as proof that its cut landed.
+func writeCutSet(writer io.Writer, edges []backEdge) {
+	fmt.Fprintf(writer, "cut set (%d edge(s), total weight %d):\n", len(edges), totalWeight(edges))
+	for _, edge := range edges {
+		fmt.Fprintf(writer, "- %s -> %s (weight %d)\n", edge.from, edge.to, edge.weight)
+		for _, carrier := range edge.carriers {
+			fmt.Fprintf(writer, "    carrier package: %s\n", carrier)
+		}
+	}
+}
+
+// writeRegression reports a cycle that got deeper than the recorded ceiling.
+func writeRegression(writer io.Writer, measured int, ceiling cycleCeiling, edges []backEdge) {
+	fmt.Fprintf(
+		writer,
+		"cross-service cycle regression: minimum feedback arc weight is %d, above the recorded ceiling of %d.\n",
+		measured,
+		ceiling.Ceiling,
+	)
+	fmt.Fprintf(
+		writer,
+		"Remove or reverse cross-service imports until the weight is back at %d; do not raise the ceiling in %s.\n",
+		ceiling.Ceiling,
+		filepath.ToSlash(defaultCeilingRelativePath),
+	)
+	writeCutSet(writer, edges)
+}
+
+// writeUnclaimedImprovement reports a cycle that got shallower without the
+// ceiling being lowered, which is what makes this check a ratchet rather than
+// a one-directional cap.
+func writeUnclaimedImprovement(writer io.Writer, measured int, ceiling cycleCeiling, edges []backEdge) {
+	fmt.Fprintf(
+		writer,
+		"cross-service cycle improved and the gain is not captured: minimum feedback arc weight is %d, below the recorded ceiling of %d.\n",
+		measured,
+		ceiling.Ceiling,
+	)
+	fmt.Fprintf(
+		writer,
+		"Lower the ceiling to %d in %s so the improvement cannot silently regress later.\n",
+		measured,
+		filepath.ToSlash(defaultCeilingRelativePath),
+	)
+	writeCutSet(writer, edges)
+}
+
+// writeSuccess reports the measured weight against an equal ceiling.
+func writeSuccess(writer io.Writer, measured int, ceiling cycleCeiling, edges []backEdge, services int) {
+	fmt.Fprintf(
+		writer,
+		"%s minimum feedback arc weight %d across %d service(s) in %d cut edge(s) matches ceiling %d\n",
+		diagnosticPrefix,
+		measured,
+		services,
+		len(edges),
+		ceiling.Ceiling,
+	)
+}

--- a/docs/internal/baselines/service-cycle-ceiling.json
+++ b/docs/internal/baselines/service-cycle-ceiling.json
@@ -1,0 +1,4 @@
+{
+  "description": "Ceiling for the exact minimum feedback arc set weight of the pkg/services cross-service import graph, derived by cmd/servicecyclecheck (make service-cycle). Weight is the number of non-test import statements that must be removed or reversed to make the service graph acyclic. This is a two-directional ratchet: the check fails when the weight rises above the ceiling, and it also fails when the weight drops below the ceiling without the ceiling being lowered in the same change. Lower this number whenever the checker reports a lower measured weight; never raise it.",
+  "ceiling": 42
+}

--- a/scripts/ci/backend-lint-policy.mjs
+++ b/scripts/ci/backend-lint-policy.mjs
@@ -21,6 +21,18 @@ export const BACKEND_LINT_ALLOWANCES = Object.freeze({
 	},
 });
 
+// Targets recorded here are gated with no allowance at all: any failure is a
+// policy failure on its first run, and the target must appear in every Backend
+// Lint report. Requiring observation matters for ratchet checkers, because
+// dropping a target from LINT_TARGETS would otherwise be a silent way to turn
+// a red ratchet green without doing the decoupling work it is measuring.
+export const BACKEND_LINT_REQUIRED_TARGETS = Object.freeze({
+	"service-cycle-check": {
+		reason: "Derived cross-service cycle ratchet: fails when the pkg/services minimum feedback arc weight rises above the recorded ceiling, and equally when it drops below the ceiling without the ceiling being lowered.",
+		ownerOrLane: "Service decoupling program",
+	},
+});
+
 function allowanceStatus(target, allowance) {
 	if (target.status === "pass") {
 		return "clean";
@@ -69,6 +81,22 @@ export function evaluateBackendLintPolicy(targets) {
 		}
 	}
 
+	const requiredTargets = Object.entries(BACKEND_LINT_REQUIRED_TARGETS).map(([name, requirement]) => {
+		const target = evaluatedTargets.find((item) => item.name === name);
+		if (BACKEND_LINT_ALLOWANCES[name]) {
+			failures.push(`${name} is gated with no allowance but a baseline allowance was recorded for it; remove one of the two entries.`);
+		}
+		if (!target) {
+			failures.push(`${name} is gated with no allowance and must run in every lint report, but it was not observed.`);
+		}
+		return {
+			name,
+			...requirement,
+			observedViolationCount: target?.violationCount ?? null,
+			status: target ? target.policyStatus : "not observed",
+		};
+	});
+
 	const allowances = Object.entries(BACKEND_LINT_ALLOWANCES).map(([name, allowance]) => {
 		const target = evaluatedTargets.find((item) => item.name === name);
 		return {
@@ -84,5 +112,6 @@ export function evaluateBackendLintPolicy(targets) {
 		failures,
 		targets: evaluatedTargets,
 		allowances,
+		requiredTargets,
 	};
 }

--- a/scripts/ci/backend-lint-report.mjs
+++ b/scripts/ci/backend-lint-report.mjs
@@ -122,6 +122,7 @@ export function summarizeBackendLintReport(report, options = {}) {
 			jobs: null,
 			baselineSource: BACKEND_LINT_BASELINE_SOURCE,
 			allowances: [],
+			requiredTargets: [],
 		};
 	}
 
@@ -147,6 +148,7 @@ export function summarizeBackendLintReport(report, options = {}) {
 		failures: policy.failures,
 		baselineSource: BACKEND_LINT_BASELINE_SOURCE,
 		allowances: policy.allowances,
+		requiredTargets: policy.requiredTargets,
 		totalDurationMillis: numericValue(report.totalDurationMillis),
 		jobs: Number.isInteger(report.jobs) ? report.jobs : null,
 	};
@@ -305,6 +307,24 @@ export function renderBackendLintSummary(summary) {
 	}
 	if (!(summary.allowances || []).length) {
 		lines.push("| (none) | — | — | — | — | No baseline allowances loaded. | — | — | — |");
+	}
+
+	lines.push(
+		"",
+		"### No-allowance targets",
+		"",
+		"These targets carry no allowance and must appear in every report; any failure fails the policy on its first run.",
+		"",
+		"| Checker | Observed | Status | Reason | Owner/lane |",
+		"| --- | ---: | --- | --- | --- |",
+	);
+	for (const required of summary.requiredTargets || []) {
+		lines.push(
+			`| ${required.name} | ${required.observedViolationCount ?? "not observed"} | ${required.status} | ${formatMarkdownCell(required.reason)} | ${formatMarkdownCell(required.ownerOrLane)} |`,
+		);
+	}
+	if (!(summary.requiredTargets || []).length) {
+		lines.push("| (none) | — | — | No no-allowance targets loaded. | — |");
 	}
 
 	const failedTargets = summary.targets.filter((target) => target.status !== "pass");

--- a/scripts/ci/backend-lint-report.test.mjs
+++ b/scripts/ci/backend-lint-report.test.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import { BACKEND_LINT_ALLOWANCES } from "./backend-lint-policy.mjs";
+import { BACKEND_LINT_ALLOWANCES, BACKEND_LINT_REQUIRED_TARGETS } from "./backend-lint-policy.mjs";
 import {
 	BACKEND_LINT_COMMENT_MARKER,
 	countViolations,
@@ -46,7 +46,11 @@ function report(overrides = {}) {
 }
 
 function baselineTargets(overrides = {}) {
-	return Object.entries(BACKEND_LINT_ALLOWANCES).map(([name]) => ({
+	const names = [
+		...Object.keys(BACKEND_LINT_ALLOWANCES),
+		...Object.keys(BACKEND_LINT_REQUIRED_TARGETS),
+	];
+	return names.map((name) => ({
 		name,
 		status: "pass",
 		durationMillis: 100,
@@ -111,7 +115,10 @@ test("all clean current-main checkers pass the baseline policy", () => {
 
 	assert.equal(summary.ok, true);
 	assert.equal(summary.failures.length, 0);
-	assert.equal(summary.targets.filter((target) => target.policyStatus === "clean").length, 2);
+	assert.equal(
+		summary.targets.filter((target) => target.policyStatus === "clean").length,
+		baselineTargets().length,
+	);
 });
 
 test("a measured baseline failure is reported but allowed at its recorded count", () => {
@@ -399,4 +406,49 @@ test("PR publication includes a stable marker and hosted identity", () => {
 	assert.match(comment, new RegExp(BACKEND_LINT_COMMENT_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 	assert.match(comment, /Hosted head: `abc123`/);
 	assert.match(comment, /actions\/runs\/42/);
+});
+
+test("a no-allowance target is gated from its first failing run", () => {
+	const targets = baselineTargets({
+		"service-cycle-check": {
+			status: "fail",
+			output: [
+				"cross-service cycle regression: minimum feedback arc weight is 43, above the recorded ceiling of 42.",
+				"LINT_VIOLATION_COUNT: 1",
+			].join("\n"),
+		},
+	});
+	const summary = summarizeBackendLintReport(report({ targets }));
+	const verdict = renderBackendLintVerdict(summary);
+
+	assert.equal(BACKEND_LINT_ALLOWANCES["service-cycle-check"], undefined);
+	assert.equal(summary.ok, false);
+	assert.equal(summary.targets.find((target) => target.name === "service-cycle-check").violationCount, 1);
+	assert.match(verdict, /service-cycle-check: baseline 0 -> current 1 \(delta \+1; new failure\)/);
+	assert.match(
+		summary.failures.join("\n"),
+		/service-cycle-check failed with 1 reported violation\(s\); no baseline allowance exists/,
+	);
+});
+
+test("a passing no-allowance target is measured, not classified unmeasured", () => {
+	const summary = summarizeBackendLintReport(report({ targets: baselineTargets() }));
+	const target = summary.targets.find((item) => item.name === "service-cycle-check");
+
+	assert.equal(summary.ok, true);
+	assert.equal(target.violationCount, 0);
+	assert.equal(target.policyStatus, "clean");
+	assert.match(renderBackendLintSummary(summary), /\| service-cycle-check \| `pass` \| 0 \| 0 \| \+0 \|/);
+});
+
+test("dropping a no-allowance target from the lint suite fails the policy", () => {
+	const targets = baselineTargets().filter((target) => target.name !== "service-cycle-check");
+	const summary = summarizeBackendLintReport(report({ targets }));
+
+	assert.equal(summary.ok, false);
+	assert.match(
+		summary.failures.join("\n"),
+		/service-cycle-check is gated with no allowance and must run in every lint report, but it was not observed/,
+	);
+	assert.match(renderBackendLintSummary(summary), /### No-allowance targets/);
 });


### PR DESCRIPTION
PRD used for this lane (`prd.json`):

```json
{
  "project": "you-agent-factory",
  "branchName": "dcp-3-derived-service-cycle-ratchet",
  "description": "Add a derived cross-service cycle ratchet lint target that replaces the hand-maintained, never-failing crossServiceEdges registry. The tool derives the weighted service import graph from pkg/services/, computes the exact minimum feedback arc set weight via subset DP, and fails CI both when the cycle cost regresses above a stored ceiling and when it improves below the ceiling without the ceiling being lowered (a true ratchet). On failure it prints the exact back-edge cut set with carrier packages so downstream cut lanes (dcp-4 through dcp-7) can use it as proof-of-cut. This lane is a pure addition: it changes zero imports and does not touch ownership-inventory.json (owned by concurrent lane dcp-2).",
  "context": {
    "customerAsk": "Add a lint target that derives the service import graph and asserts the cycle cost is at or below a recorded ceiling, seeded at the measured current minimum feedback arc weight (22, 12 edges), computed exactly via subset-DP (not greedy), printing the exact cut set (back-edges + carrier packages) on failure, wired into the Makefile lint suite and scripts/ci/backend-lint-policy.mjs emitting LINT_VIOLATION_COUNT with no allowance.",
    "problem": "14 of 18 pkg/services services form one strongly-connected component in the import graph, and nothing in CI fails when a new back-edge deepens this cycle. The existing governance mechanism, crossServiceEdges in docs/internal/baselines/ownership-inventory.json (167 hand-maintained rows, 48 flagged unresolved+bidirectional), documents the cycle instead of failing on it and never turns red.",
    "solution": "Build a standalone checker (cmd/servicecyclecheck, following cmd/pkgboundarycheck's walking/parsing conventions) that derives the service list from the directory tree, builds a weighted directed cross-service import graph, computes the exact minimum feedback arc set weight via dynamic programming over subsets (with a safe-size guard that fails loudly rather than degrading to a heuristic above ~20 services), compares the weight against a ceiling stored in a small dedicated baseline file (failing on regression above the ceiling AND on unclaimed improvement below the ceiling), prints the exact cut set with carrier packages on any failure, and registers the target in the Makefile lint suite and scripts/ci/backend-lint-policy.mjs with no allowance."
  },
  "acceptanceCriteria": [
    "Running the new checker against unmodified main passes, reporting the measured minimum feedback arc weight against an equal ceiling; if the lane's own measured value differs from the operator-supplied reference (22, 12 edges), the ceiling is seeded at the lane's own measured value and the discrepancy is reported in a PR comment rather than forced to match.",
    "Introducing one additional back-edge into a synthetic test graph fixture makes the checker fail, naming that edge and at least one carrier package, proven by a unit test (no real back-edge is committed to production code).",
    "Removing a back-edge from a synthetic test graph fixture makes the checker fail with a 'lower the ceiling to N' message naming the new value, proven by a unit test.",
    "The exact MFAS computation is unit-tested against small hand-checkable graphs, including one where a greedy/nearest-neighbor ordering yields a worse result than the true optimum, and the implementation returns the true optimum -- a greedy implementation is not acceptable.",
    "The new target is registered in the Makefile lint suite and in scripts/ci/backend-lint-policy.mjs, emits LINT_VIOLATION_COUNT so it is never classified 'unmeasured', and carries no allowance.",
    "No import statement anywhere in pkg/ is changed by this lane, and docs/internal/baselines/ownership-inventory.json content (crossServiceEdges, owned by concurrent lane dcp-2) is left untouched.",
    "Quality gate: typecheck/build and go vet pass, make test passes for new and touched packages, no NEW lint violations relative to current main, and the gates green on main today (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. make lint end-to-end is not required to pass because pkg-boundary carries pre-existing packaged-service-structure migration debt (recorded 2026-08-08) that is out of scope here.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "dcp-3-derived-service-cycle-ratchet-001",
      "title": "Derive the weighted service import graph",
      "description": "As a maintainer, I want a tool that walks pkg/services/ and derives a weighted directed graph of cross-service imports (service list from the directory tree, edge weight = import-statement count, self-edges ignored), so that the cycle ratchet has a ground-truth graph to compute over.",
      "acceptanceCriteria": [
        "The service list is derived purely from the pkg/services/<service> directory tree at run time -- never a hardcoded list of service names",
        "For every package under pkg/services/<service>/..., non-test imports resolving to pkg/services/<other>/... are counted, edge weight equals the number of distinct import statements observed, and self-edges are excluded",
        "Running the graph builder against current main reports edge weights that reconcile with a manually spot-checked sample of at least 3 known cross-service imports",
        "Package walking/parsing reuses the approach already established in cmd/pkgboundarycheck rather than introducing a new parallel mechanism",
        "Tests pass: unit tests cover graph construction on a small synthetic pkg/services-shaped fixture tree, verifying edge weights and self-edge exclusion",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented in cmd/servicecyclecheck/graph.go. Service list derived at run time from the pkg/services/<service> directory tree (no hardcoded roster); non-test .go files parsed with parser.ImportsOnly following cmd/pkgboundarycheck conventions (same ignored-directory set, same WalkDir shape). Edge weight = one per crossing import statement; self-edges excluded; carrier packages recorded per edge. Measured on the rebased head: 18 services, weight 42, 12-edge cut. Spot-checked against real imports: work->workers=1, recordings->factory_runtime=1, factory_definitions->automations=1, models->workers=5 (5 statements across transports/cli and transports/http) -- all reconcile exactly. Unit tests cover service derivation, per-statement weighting, self-edge exclusion, _test.go and testdata exclusion, carrier recording and matrix indexing on synthetic pkg/services-shaped trees built in t.TempDir(). go vet ./... exit 0."
    },
    {
      "id": "dcp-3-derived-service-cycle-ratchet-002",
      "title": "Compute the exact minimum feedback arc set",
      "description": "As a maintainer, I want the exact minimum feedback arc weight of the service graph computed via dynamic programming over subsets (not a greedy heuristic), so that the ratchet's pass/fail decision and reported cut set are provably optimal and stable.",
      "acceptanceCriteria": [
        "Given a weighted directed graph, the algorithm computes the minimum total back-edge weight over all linear orderings via subset DP (state = placed-service-set), at roughly 2^N * N complexity",
        "The algorithm returns the minimum weight and one optimal ordering with deterministic tie-breaking so repeated runs on the same input produce the same reported cut set",
        "If the service count exceeds a fixed safe bound (~20), the function returns an explicit error instructing a maintainer to deliberately raise the bound rather than silently falling back to a heuristic",
        "Unit tests include a hand-checkable small graph where a greedy/nearest-neighbor ordering yields a worse feedback arc weight than the true optimum, and the implementation is asserted to return the true optimum on that graph",
        "Unit tests cover an already-acyclic graph (expected weight 0) and a fully-connected small cyclic graph with a known closed-form optimum",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented in cmd/servicecyclecheck/mfas.go. Exact subset DP: dp[S|{v}] = min over v not in S of dp[S] + sum of w(v,u) for u in S, at ~2^N*N. Returns the optimal weight plus one optimal ordering with lowest-index tie-breaking, so repeated runs report an identical cut set (asserted by a determinism test). Above 20 vertices it returns an explicit error telling the maintainer to raise the bound deliberately and never substitute a heuristic; the bound itself (20) is asserted still solvable. Optimality is proven two ways: (a) cross-validated against brute-force enumeration of all N! orderings on 7 graphs, and (b) a hand-checkable trap graph where the documented cheapest-next greedy scores 9 against the true optimum of 1. Also covers an acyclic graph (0), complete digraphs n=2..7 against the closed form n(n-1)/2, and malformed input rejection."
    },
    {
      "id": "dcp-3-derived-service-cycle-ratchet-003",
      "title": "Ceiling comparison, ratchet failure messages, and cut-set reporting",
      "description": "As a maintainer, I want the computed minimum feedback arc weight compared against a stored ceiling, with the check failing and printing an actionable diagnosis whenever the weight is above or below the ceiling, so that regressions are blocked and improvements are captured permanently.",
      "acceptanceCriteria": [
        "A small dedicated baseline file (separate from ownership-inventory.json) stores the current ceiling as an integer",
        "The check fails when computed weight exceeds the ceiling, with output stating both numbers",
        "The check fails when computed weight is below the ceiling, with output instructing the maintainer to lower the ceiling to the new measured value, stating that value",
        "On any failure, the tool prints the full cut set: each back-edge as '<source service> -> <target service>' with its weight, and the carrier package path(s) contributing to that edge's weight",
        "A synthetic-fixture test with one added back-edge relative to a passing baseline proves the checker fails, naming the added edge and a specific carrier package in the output",
        "A synthetic-fixture test with a back-edge removed relative to a passing baseline proves the checker fails with a 'lower the ceiling' message naming the new lower value",
        "Running the full checker against unmodified main passes with the ceiling seeded at the lane's own freshly measured weight (cross-checked against 22/12 edges from the standing-rules doc; any discrepancy is reported in a PR comment, not force-matched in code)",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented in cmd/servicecyclecheck/report.go + main.go. Ceiling stored as a single integer in the dedicated docs/internal/baselines/service-cycle-ceiling.json, separate from ownership-inventory.json. Two-directional ratchet: above the ceiling reports a regression stating both numbers; below the ceiling reports an unclaimed improvement instructing the maintainer to lower the ceiling to the new measured value, naming it. Both paths print the full cut set: each back-edge as '<source service> -> <target service>' with its weight and every carrier package path beneath it. Fixture tests prove both directions -- adding zeta->epsilon fails naming 'zeta -> epsilon (weight 1)' and carrier 'pkg/services/zeta/internal/adapter'; removing delta->gamma fails with 'Lower the ceiling to 1'. A live test runs the checker against this repository with the committed baseline. Ceiling seeded at this lane's own freshly measured value, 42; the operator reference of 22 is reconciled in a PR comment, not force-matched."
    },
    {
      "id": "dcp-3-derived-service-cycle-ratchet-004",
      "title": "Wire the target into the Makefile and CI lint policy",
      "description": "As a CI maintainer, I want the new cycle-ratchet checker registered as a Makefile lint target and in scripts/ci/backend-lint-policy.mjs emitting LINT_VIOLATION_COUNT, so that it runs as part of the standard lint suite and is correctly classified (never 'unmeasured') with no allowance.",
      "acceptanceCriteria": [
        "A new Makefile target builds and runs the checker as part of the existing lint suite composition, consistent with how other backend checkers are included",
        "scripts/ci/backend-lint-policy.mjs includes an entry for the new target reading its emitted LINT_VIOLATION_COUNT and applying no allowance (any nonzero/failing count fails the policy check outright)",
        "Running the new Makefile target locally against unmodified main exits 0 and prints a line showing the measured weight and ceiling, to be quoted verbatim in the PR description/comment",
        "Running scripts/ci/backend-lint-policy.mjs's classification logic against the new target's real output on unmodified main classifies it as passing, not 'unmeasured'",
        "No import statement in pkg/ is changed by this story or any prior story in this lane, and ownership-inventory.json is untouched",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Makefile gains a service-cycle-check target using the standard run_lint_checker call form, added to LINT_TARGETS and .PHONY. scripts/ci/backend-lint-policy.mjs gains BACKEND_LINT_REQUIRED_TARGETS with a service-cycle-check entry carrying no allowance; the policy already fails any un-allowanced target that reports violations, and the new registry adds the missing half -- a no-allowance target must also be observed in every report, so dropping it from LINT_TARGETS cannot silently turn the ratchet green. Verified end to end: 'make service-cycle-check' exits 0 printing the measured-weight line; a lintlane run records violationCount 0 with violationCountSource successful-check; classifying the checker's real failing bytes yields violationCount 1 from checker-marker with policyStatus 'new failure'. Never 'unmeasured' in either direction. Zero pkg/ files and zero ownership-inventory.json changes in the diff."
    }
  ]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
