### PR TITLE
dcp-1: default coverage floor, vacuous pass, and per-service completeness

### DIFF
--- a/cmd/gocoveragecheck/coverage_json_test.go
+++ b/cmd/gocoveragecheck/coverage_json_test.go
@@ -347,7 +347,7 @@ func TestExecuteWritesJSONWhenPackageFloorFails(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	commandRunner = fakeGoCoverageCommand
+	commandRunner = fakeGoCoverageCommandWithMeasuredZeroConfig
 	stdoutWriter = &stdout
 	stderrWriter = &stderr
 
@@ -396,9 +396,8 @@ func TestExecuteWritesJSONWhenPackageFloorFails(t *testing.T) {
 	if strings.Contains(stdout.String(), "meets minimum") {
 		t.Fatalf("execute() stdout = %q, did not expect success message", stdout.String())
 	}
-	wantDiagnostic := "coverage not evaluated: package=" + configPackage + " lane=unit (no measurement in profile)\n"
-	if got := stderr.String(); got != wantDiagnostic {
-		t.Fatalf("execute() stderr = %q, want unmeasured-package diagnostic %q", got, wantDiagnostic)
+	if stderr.Len() != 0 {
+		t.Fatalf("execute() stderr = %q, want empty stderr for a measured package", stderr.String())
 	}
 }
 

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -398,7 +398,7 @@ func runCoverageProfile(cfg config, targetOS string, profilePath string) (covera
 		}
 		result.packageMinimumFailures, result.packageMinimumWarnings = checkCoverageManifestWithEpsilonAndBlocks(manifest, result.packageTotals, cfg.packageManifest, cfg.packageFloorEpsilon, result.coverageBlocks)
 		result.unmeasuredPackageDiagnostics = formatUnmeasuredCoverageManifestDiagnostics(manifest, result.packageTotals)
-		result.packageGates = packageGatesFromManifest(manifest)
+		result.packageGates = coverageManifestGatedPackages(manifest, result.packageTotals)
 	} else if legacyPackageGateEnabled {
 		result.packageGates = packageGatesFromLegacyMin(result.packageSummaries, cfg.packageCoverageMin(), baselinePackages)
 	}

--- a/cmd/gocoveragecheck/main_run_test.go
+++ b/cmd/gocoveragecheck/main_run_test.go
@@ -73,9 +73,9 @@ func TestExecuteReportsPackageSummariesWhenManifestValidationFails(t *testing.T)
 		stderrWriter = originalStderr
 	}()
 
-	configPackage := modulePath + "/pkg/config"
-	servicePackage := modulePath + "/pkg/service"
-	manifestPath := writePackageMinimumManifest(t, "unit", configPackage, "100.00")
+	workRootPackage := modulePath + "/pkg/services/work"
+	workInternalPackage := modulePath + "/pkg/services/work/internal"
+	manifestPath := writePackageMinimumManifest(t, "unit", workInternalPackage, "100.00")
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	commandRunner = fakeGoCoverageCommandPassing
@@ -85,16 +85,16 @@ func TestExecuteReportsPackageSummariesWhenManifestValidationFails(t *testing.T)
 	err := execute(config{
 		min:             0,
 		suite:           "unit",
-		coverpkg:        strings.Join([]string{configPackage, servicePackage}, ","),
-		packages:        "./pkg/config",
+		coverpkg:        strings.Join([]string{workRootPackage, workInternalPackage}, ","),
+		packages:        "./pkg/services/work/internal",
 		packageManifest: manifestPath,
 	})
-	if err == nil || !strings.Contains(err.Error(), "measured unit package \""+servicePackage+"\" has no manifest entry") {
-		t.Fatalf("execute() error = %v, want missing-manifest validation failure", err)
+	if err == nil || !strings.Contains(err.Error(), "measured unit service \""+workRootPackage+"\" has no root manifest entry") {
+		t.Fatalf("execute() error = %v, want missing-service-root validation failure", err)
 	}
 
-	wantSummaries := configPackage + "\tcoverage: 100.0% of statements\n" + servicePackage + "\tcoverage: 100.0% of statements\n"
-	if got := stdout.String(); !strings.Contains(got, "total: (statements) 100.0%") || !strings.Contains(got, wantSummaries) {
+	wantSummaries := workRootPackage + "\tcoverage: 0.0% of statements\n" + workInternalPackage + "\tcoverage: 0.0% of statements\n"
+	if got := stdout.String(); !strings.Contains(got, "total: (statements) 0.0%") || !strings.Contains(got, wantSummaries) {
 		t.Fatalf("execute() stdout = %q, want total and exact package summaries", got)
 	}
 	if strings.Contains(stdout.String(), "meets minimum") {
@@ -256,7 +256,10 @@ func TestExecuteReportsRootObservationCoverageRegressionWithExactCountsAndBlocks
 	}()
 
 	rootObservationPackage := modulePath + "/pkg/services/factory_runtime/internal/rootobservation"
-	manifestPath := writePackageMinimumManifest(t, "unit", rootObservationPackage, "100.00")
+	manifestPath := writePackageMinimumManifestWithEntries(t, "unit", []manifestPackageSpec{
+		{importPath: modulePath + "/pkg/services/factory_runtime", minimum: "0.00"},
+		{importPath: rootObservationPackage, minimum: "100.00"},
+	})
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	commandRunner = fakeGoCoverageCommandWithRootObservationRegression
@@ -266,7 +269,7 @@ func TestExecuteReportsRootObservationCoverageRegressionWithExactCountsAndBlocks
 	err := execute(config{
 		min:             0,
 		suite:           "unit",
-		coverpkg:        rootObservationPackage,
+		coverpkg:        strings.Join([]string{modulePath + "/pkg/services/factory_runtime", rootObservationPackage}, ","),
 		packages:        "./pkg/services/factory_runtime/internal/rootobservation",
 		packageManifest: manifestPath,
 	})
@@ -288,8 +291,9 @@ func TestExecuteReportsRootObservationCoverageRegressionWithExactCountsAndBlocks
 	if !strings.Contains(stdout.String(), rootObservationPackage+"\tcoverage: 95.6% of statements") {
 		t.Fatalf("execute() stdout = %q, want rootobservation package summary", stdout.String())
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+	wantDiagnostic := "coverage not evaluated: package=" + modulePath + "/pkg/services/factory_runtime lane=unit (no measurement in profile)\n"
+	if got := stderr.String(); got != wantDiagnostic {
+		t.Fatalf("execute() stderr = %q, want the service-root unmeasured diagnostic %q", got, wantDiagnostic)
 	}
 }
 
@@ -475,9 +479,8 @@ func TestExecuteEnforcesAggregateAndManifestMinimumsIndependently(t *testing.T) 
 			name:         "aggregate pass cannot mask package regression",
 			minimum:      "1.00",
 			aggregateMin: 0,
-			command:      fakeGoCoverageCommand,
-			wantFailure:  "package coverage regression: package=" + modulePath + "/pkg/config lane=unit expected-minimum=1.00%",
-			wantStderr:   "coverage not evaluated: package=" + modulePath + "/pkg/config lane=unit (no measurement in profile)\n",
+			command:      fakeGoCoverageCommandWithMeasuredZeroConfig,
+			wantFailure:  "package coverage regression: package=" + modulePath + "/pkg/config lane=unit expected-minimum=1.00% actual=0.0000%",
 		},
 		{
 			name:         "package pass cannot mask aggregate regression",

--- a/cmd/gocoveragecheck/manifest.go
+++ b/cmd/gocoveragecheck/manifest.go
@@ -125,7 +125,7 @@ func newCoverageManifestEntry(lane string, importPath string, totals packageCove
 		return coverageManifestEntry{}, false, err
 	}
 	if isCoverageManifestServiceRoot(importPath) {
-		return coverageManifestServiceRootEntry(lane, importPath), true, nil
+		return coverageManifestServiceRootEntry(importPath), true, nil
 	}
 	return coverageManifestEntry{}, false, nil
 }

--- a/cmd/gocoveragecheck/manifest.go
+++ b/cmd/gocoveragecheck/manifest.go
@@ -21,9 +21,13 @@ const unmeasurablePackageDeadline = "2027-07-15"
 type coverageFloor int64
 
 type coverageManifest struct {
-	Version  int                     `json:"version"`
-	Lane     string                  `json:"lane"`
-	Packages []coverageManifestEntry `json:"packages"`
+	Version int    `json:"version"`
+	Lane    string `json:"lane"`
+	// DefaultFloorPercent is the floor applied to a measured package with no
+	// entry in Packages. It is optional; when absent the lane's built-in
+	// default applies. Explicit Packages entries always win over it.
+	DefaultFloorPercent json.RawMessage         `json:"defaultFloorPercent,omitempty"`
+	Packages            []coverageManifestEntry `json:"packages"`
 }
 
 type coverageManifestEntry struct {
@@ -90,33 +94,40 @@ func newCoverageManifest(lane string, totals map[string]packageCoverageTotals, p
 	slices.Sort(packages)
 	entries := make([]coverageManifestEntry, 0, len(packages))
 	for _, importPath := range packages {
-		entry, err := newCoverageManifestEntry(lane, importPath, totals[importPath])
+		entry, required, err := newCoverageManifestEntry(lane, importPath, totals[importPath])
 		if err != nil {
 			return coverageManifest{}, fmt.Errorf("generate %s coverage manifest for %s: %w", lane, importPath, err)
 		}
+		if !required {
+			continue
+		}
 		entries = append(entries, entry)
 	}
-	return coverageManifest{Version: coverageManifestVersion, Lane: lane, Packages: entries}, nil
+	return coverageManifest{
+		Version:             coverageManifestVersion,
+		Lane:                lane,
+		DefaultFloorPercent: laneDefaultCoverageFloorRaw(lane),
+		Packages:            entries,
+	}, nil
 }
 
-func newCoverageManifestEntry(lane string, importPath string, totals packageCoverageTotals) (coverageManifestEntry, error) {
+// newCoverageManifestEntry builds the manifest row for importPath and reports
+// whether the package requires a row at all. A package whose profile reports no
+// measurable statements passes vacuously and needs no row, so none is minted
+// for it. A service root always declares a row, because per-service
+// completeness is satisfied by that root entry.
+func newCoverageManifestEntry(lane string, importPath string, totals packageCoverageTotals) (coverageManifestEntry, bool, error) {
 	floor, err := coverageFloorFromTotals(totals)
 	if err == nil {
-		return coverageManifestEntry{Package: importPath, Minimum: json.RawMessage(floor.String())}, nil
+		return coverageManifestEntry{Package: importPath, Minimum: json.RawMessage(floor.String())}, true, nil
 	}
 	if totals.totalStatements != 0 || totals.coveredStatements != 0 {
-		return coverageManifestEntry{}, err
+		return coverageManifestEntry{}, false, err
 	}
-	return coverageManifestEntry{
-		Package: importPath,
-		Exception: &coverageManifestException{
-			Kind:          "measurement",
-			Justification: fmt.Sprintf("The active %s coverage profile contains no measurable statements for this package.", lane),
-			Owner:         "backend-quality",
-			Deadline:      unmeasurablePackageDeadline,
-			RemovalGate:   fmt.Sprintf("The %s coverage profile reports at least one measurable statement for this package.", lane),
-		},
-	}, nil
+	if isCoverageManifestServiceRoot(importPath) {
+		return coverageManifestServiceRootEntry(lane, importPath), true, nil
+	}
+	return coverageManifestEntry{}, false, nil
 }
 
 func coverageFloorFromTotals(totals packageCoverageTotals) (coverageFloor, error) {
@@ -213,6 +224,9 @@ func validateCoverageManifestAtModeWithTotals(manifest coverageManifest, expecte
 	if manifest.Lane != expectedLane {
 		return fmt.Errorf("validate go coverage manifest: lane %q does not match active lane %q", manifest.Lane, expectedLane)
 	}
+	if err := validateCoverageManifestDefaultFloor(manifest); err != nil {
+		return err
+	}
 	measured := make(map[string]struct{}, len(measuredPackages))
 	for _, importPath := range measuredPackages {
 		measured[importPath] = struct{}{}
@@ -244,44 +258,13 @@ func validateCoverageManifestAtModeWithTotals(manifest coverageManifest, expecte
 		seen[entry.Package] = struct{}{}
 		previous = entry.Package
 	}
+	// A measured package with no entry is not a completeness gap: it resolves to
+	// the lane default floor. Completeness only requires that every measured
+	// service declares a floor at its root.
 	if requireComplete {
-		missing := make([]string, 0)
-		for importPath := range measured {
-			if _, ok := seen[importPath]; !ok {
-				missing = append(missing, importPath)
-			}
-		}
-		if len(missing) > 0 {
-			slices.Sort(missing)
-			return formatMissingCoverageManifestEntries(expectedLane, missing, measuredTotals)
-		}
+		return validateCoverageManifestServiceRoots(expectedLane, measuredPackages, seen, measuredTotals)
 	}
 	return nil
-}
-
-func formatMissingCoverageManifestEntries(lane string, missing []string, measuredTotals map[string]packageCoverageTotals) error {
-	lines := make([]string, 0, len(missing))
-	for _, importPath := range missing {
-		line := fmt.Sprintf("- measured %s package %q has no manifest entry", lane, importPath)
-		if measuredTotals != nil {
-			totals := measuredTotals[importPath]
-			switch {
-			case totals.totalStatements == 0 && totals.coveredStatements == 0:
-				line += "; no measurable statements"
-			case totals.totalStatements > 0:
-				floor, err := coverageFloorFromTotals(totals)
-				if err != nil {
-					line += fmt.Sprintf("; measured coverage unavailable: %v", err)
-				} else {
-					line += fmt.Sprintf("; measured coverage %s%%", floor)
-				}
-			default:
-				line += "; measured coverage unavailable"
-			}
-		}
-		lines = append(lines, line)
-	}
-	return fmt.Errorf("validate go coverage manifest: measured %s packages have no manifest entry:\n%s", lane, strings.Join(lines, "\n"))
 }
 
 func dateOnlyUTC(value time.Time) time.Time {
@@ -343,7 +326,9 @@ func checkCoverageManifestWithEpsilonAndBlocks(manifest coverageManifest, totals
 		}
 		minimum, _ := parseCoverageFloor(entry.Minimum)
 		actual := totals[entry.Package]
-		if actual.totalStatements > 0 && int64(actual.coveredStatements)*10000 >= int64(minimum)*int64(actual.totalStatements) {
+		// A package with no measurable statements passes vacuously: the floor
+		// has no denominator to be evaluated against.
+		if coveragePassesFloor(minimum, actual) {
 			continue
 		}
 		actualPercent := 0.0
@@ -376,6 +361,7 @@ func checkCoverageManifestWithEpsilonAndBlocks(manifest coverageManifest, totals
 			manifest.Lane, manifestPath,
 		))
 	}
+	failures = append(failures, checkCoverageDefaultFloor(manifest, totals, manifestPath, coverageBlocks)...)
 	return failures, warnings
 }
 

--- a/cmd/gocoveragecheck/manifest_default_floor.go
+++ b/cmd/gocoveragecheck/manifest_default_floor.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+)
+
+// Per-lane default coverage floors. A measured package with no manifest entry
+// is held to its lane's default floor instead of failing the manifest
+// completeness check, so adding a package no longer requires a manifest edit.
+//
+// The values come from the measured distribution of existing floors: the unit
+// lane's tenth percentile is 50.00, so a new package that reaches the default
+// sits in the bottom decile rather than failing on arrival. Functional tests
+// exercise flows rather than packages, so a positive functional default would
+// fail ordinary packages en masse; 0.00 keeps a package measured and reported
+// without demanding that a flow reach it.
+const (
+	unitLaneDefaultFloorPercent       = "50.00"
+	functionalLaneDefaultFloorPercent = "0.00"
+)
+
+// laneDefaultCoverageFloor reports the built-in default floor for lane. It is
+// the floor used when a manifest omits defaultFloorPercent.
+func laneDefaultCoverageFloor(lane string) coverageFloor {
+	if lane == "functional" {
+		floor, _ := parseCoverageFloor(json.RawMessage(functionalLaneDefaultFloorPercent))
+		return floor
+	}
+	floor, _ := parseCoverageFloor(json.RawMessage(unitLaneDefaultFloorPercent))
+	return floor
+}
+
+// laneDefaultCoverageFloorRaw renders lane's built-in default floor in the
+// manifest's fixed two-decimal form.
+func laneDefaultCoverageFloorRaw(lane string) json.RawMessage {
+	if lane == "functional" {
+		return json.RawMessage(functionalLaneDefaultFloorPercent)
+	}
+	return json.RawMessage(unitLaneDefaultFloorPercent)
+}
+
+// defaultFloor reports the floor applied to a measured package that has no
+// entry in this manifest. An explicit manifest-level defaultFloorPercent wins;
+// otherwise the lane's built-in default applies.
+func (manifest coverageManifest) defaultFloor() coverageFloor {
+	if len(manifest.DefaultFloorPercent) > 0 && string(manifest.DefaultFloorPercent) != "null" {
+		if floor, err := parseCoverageFloor(manifest.DefaultFloorPercent); err == nil {
+			return floor
+		}
+	}
+	return laneDefaultCoverageFloor(manifest.Lane)
+}
+
+// manifestPackageSet reports the import paths carrying an explicit manifest
+// entry. Those entries always win over the lane default.
+func manifestPackageSet(manifest coverageManifest) map[string]struct{} {
+	listed := make(map[string]struct{}, len(manifest.Packages))
+	for _, entry := range manifest.Packages {
+		listed[entry.Package] = struct{}{}
+	}
+	return listed
+}
+
+// checkCoverageDefaultFloor evaluates every measured package with no manifest
+// entry against the manifest's default floor. A package whose profile reports
+// no measurable statements passes vacuously and is not reported.
+func checkCoverageDefaultFloor(
+	manifest coverageManifest,
+	totals map[string]packageCoverageTotals,
+	manifestPath string,
+	coverageBlocks map[string]coverageBlock,
+) []string {
+	listed := manifestPackageSet(manifest)
+	floor := manifest.defaultFloor()
+	failures := make([]string, 0)
+	for _, importPath := range slices.Sorted(maps.Keys(totals)) {
+		if _, explicit := listed[importPath]; explicit {
+			continue
+		}
+		actual := totals[importPath]
+		if coveragePassesFloor(floor, actual) {
+			continue
+		}
+		failures = append(failures, formatDefaultFloorRegression(manifest, importPath, floor, actual, manifestPath, coverageBlocks))
+	}
+	return failures
+}
+
+// coveragePassesFloor reports whether actual satisfies floor. A package with no
+// measurable statements passes: the floor cannot be evaluated against an empty
+// denominator, and the coverage profile already records that fact.
+func coveragePassesFloor(floor coverageFloor, actual packageCoverageTotals) bool {
+	if actual.totalStatements <= 0 {
+		return true
+	}
+	return int64(actual.coveredStatements)*10000 >= int64(floor)*int64(actual.totalStatements)
+}
+
+func formatDefaultFloorRegression(
+	manifest coverageManifest,
+	importPath string,
+	floor coverageFloor,
+	actual packageCoverageTotals,
+	manifestPath string,
+	coverageBlocks map[string]coverageBlock,
+) string {
+	actualPercent := float64(actual.coveredStatements) * 100 / float64(actual.totalStatements)
+	expectedPercent := float64(floor) / 100
+	diagnostic := fmt.Sprintf(
+		"package coverage regression: package=%s lane=%s floor-source=lane-default expected-minimum=%s%% actual=%.4f%% delta=%+.4f percentage-points covered=%d/%d statements",
+		importPath,
+		manifest.Lane,
+		floor.String(),
+		actualPercent,
+		actualPercent-expectedPercent,
+		actual.coveredStatements,
+		actual.totalStatements,
+	)
+	if uncovered := formatUncoveredCoverageBlocks(coverageBlocks, importPath); uncovered != "" {
+		diagnostic += "; " + uncovered
+	}
+	return diagnostic + fmt.Sprintf(
+		"; this package has no entry in %s, so it is held to the %s lane default floor of %s%%; raise its coverage or record an explicit minimum for it",
+		manifestPath, manifest.Lane, floor.String(),
+	)
+}
+
+// coverageManifestGatedPackages reports the gate applied to each measured
+// package, including packages resolved through the lane default floor rather
+// than an explicit entry.
+func coverageManifestGatedPackages(manifest coverageManifest, totals map[string]packageCoverageTotals) map[string]packageCoverageGate {
+	gates := packageGatesFromManifest(manifest)
+	floor := manifest.defaultFloor()
+	for importPath, actual := range totals {
+		if _, explicit := gates[importPath]; explicit {
+			continue
+		}
+		if actual.totalStatements <= 0 {
+			continue
+		}
+		percent := float64(floor) / 100
+		gates[importPath] = packageCoverageGate{Floor: &percent}
+	}
+	return gates
+}

--- a/cmd/gocoveragecheck/manifest_default_floor_test.go
+++ b/cmd/gocoveragecheck/manifest_default_floor_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestCoverageDefaultFloorIsLaneSpecific pins the two lane defaults so a change
+// to one cannot silently move the other.
+func TestCoverageDefaultFloorIsLaneSpecific(t *testing.T) {
+	t.Parallel()
+
+	if got := laneDefaultCoverageFloor("unit").String(); got != "50.00" {
+		t.Fatalf("unit lane default = %s, want 50.00", got)
+	}
+	if got := laneDefaultCoverageFloor("functional").String(); got != "0.00" {
+		t.Fatalf("functional lane default = %s, want 0.00", got)
+	}
+	unitManifest := coverageManifest{Lane: "unit"}
+	if got := unitManifest.defaultFloor().String(); got != "50.00" {
+		t.Fatalf("unit manifest without defaultFloorPercent = %s, want the unit lane default", got)
+	}
+	functionalManifest := coverageManifest{Lane: "functional"}
+	if got := functionalManifest.defaultFloor().String(); got != "0.00" {
+		t.Fatalf("functional manifest without defaultFloorPercent = %s, want the functional lane default", got)
+	}
+	declared := coverageManifest{Lane: "functional", DefaultFloorPercent: json.RawMessage("25.00")}
+	if got := declared.defaultFloor().String(); got != "25.00" {
+		t.Fatalf("declared defaultFloorPercent = %s, want 25.00", got)
+	}
+}
+
+// TestCheckCoverageDefaultFloorEvaluatesUnlistedPackagesPerLane proves the four
+// default-floor cases independently for each lane. The unit and functional rows
+// share the same measured totals wherever the lanes must disagree, so a default
+// bleeding from one lane into the other fails this test.
+func TestCheckCoverageDefaultFloorEvaluatesUnlistedPackagesPerLane(t *testing.T) {
+	t.Parallel()
+
+	unlisted := modulePath + "/pkg/platform/unlisted"
+	tests := []struct {
+		name         string
+		lane         string
+		defaultFloor string
+		entries      []coverageManifestEntry
+		totals       packageCoverageTotals
+		wantFailure  string
+		rejectText   string
+	}{
+		{
+			name:        "unit unlisted below the lane default fails",
+			lane:        "unit",
+			totals:      packageCoverageTotals{coveredStatements: 40, totalStatements: 100},
+			wantFailure: "package coverage regression: package=" + unlisted + " lane=unit floor-source=lane-default expected-minimum=50.00% actual=40.0000% delta=-10.0000 percentage-points covered=40/100 statements",
+		},
+		{
+			name:   "unit unlisted at the lane default passes",
+			lane:   "unit",
+			totals: packageCoverageTotals{coveredStatements: 50, totalStatements: 100},
+		},
+		{
+			name:   "unit unlisted above the lane default passes",
+			lane:   "unit",
+			totals: packageCoverageTotals{coveredStatements: 90, totalStatements: 100},
+		},
+		{
+			name:        "unit explicit floor above the lane default still applies",
+			lane:        "unit",
+			entries:     []coverageManifestEntry{{Package: unlisted, Minimum: json.RawMessage("80.00")}},
+			totals:      packageCoverageTotals{coveredStatements: 60, totalStatements: 100},
+			wantFailure: "package coverage regression: package=" + unlisted + " lane=unit expected-minimum=80.00%",
+			rejectText:  "floor-source=lane-default",
+		},
+		{
+			name:   "functional unlisted at the unit-failing measurement passes its 0.00 default",
+			lane:   "functional",
+			totals: packageCoverageTotals{coveredStatements: 40, totalStatements: 100},
+		},
+		{
+			name:   "functional unlisted with no covered statements passes",
+			lane:   "functional",
+			totals: packageCoverageTotals{coveredStatements: 0, totalStatements: 100},
+		},
+		{
+			name:         "functional unlisted below a declared default fails",
+			lane:         "functional",
+			defaultFloor: "25.00",
+			totals:       packageCoverageTotals{coveredStatements: 10, totalStatements: 100},
+			wantFailure:  "package coverage regression: package=" + unlisted + " lane=functional floor-source=lane-default expected-minimum=25.00% actual=10.0000% delta=-15.0000 percentage-points covered=10/100 statements",
+		},
+		{
+			name:        "functional explicit floor above the lane default still applies",
+			lane:        "functional",
+			entries:     []coverageManifestEntry{{Package: unlisted, Minimum: json.RawMessage("60.00")}},
+			totals:      packageCoverageTotals{coveredStatements: 40, totalStatements: 100},
+			wantFailure: "package coverage regression: package=" + unlisted + " lane=functional expected-minimum=60.00%",
+			rejectText:  "floor-source=lane-default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			manifest := coverageManifest{Version: coverageManifestVersion, Lane: tt.lane, Packages: tt.entries}
+			if tt.defaultFloor != "" {
+				manifest.DefaultFloorPercent = json.RawMessage(tt.defaultFloor)
+			}
+			failures, _ := checkCoverageManifestWithEpsilon(
+				manifest,
+				map[string]packageCoverageTotals{unlisted: tt.totals},
+				"minimums.json",
+				0,
+			)
+			joined := strings.Join(failures, "\n")
+			if tt.wantFailure == "" {
+				if len(failures) != 0 {
+					t.Fatalf("failures = %v, want none", failures)
+				}
+				return
+			}
+			if len(failures) != 1 {
+				t.Fatalf("failures = %v, want exactly one", failures)
+			}
+			if !strings.Contains(joined, tt.wantFailure) {
+				t.Fatalf("failure = %q, want containing %q", joined, tt.wantFailure)
+			}
+			if tt.rejectText != "" && strings.Contains(joined, tt.rejectText) {
+				t.Fatalf("failure = %q, did not expect %q", joined, tt.rejectText)
+			}
+		})
+	}
+}
+
+// TestCheckCoverageDefaultFloorNamesTheDefaultRemedy proves the diagnostic
+// explains which floor was applied and how to override it.
+func TestCheckCoverageDefaultFloorNamesTheDefaultRemedy(t *testing.T) {
+	t.Parallel()
+
+	unlisted := modulePath + "/pkg/platform/unlisted"
+	failures, _ := checkCoverageManifestWithEpsilon(
+		coverageManifest{Version: coverageManifestVersion, Lane: "unit"},
+		map[string]packageCoverageTotals{unlisted: {coveredStatements: 1, totalStatements: 10}},
+		"docs/internal/baselines/go-unit-coverage-package-minimums.json",
+		0,
+	)
+	if len(failures) != 1 {
+		t.Fatalf("failures = %v, want exactly one", failures)
+	}
+	want := "this package has no entry in docs/internal/baselines/go-unit-coverage-package-minimums.json, so it is held to the unit lane default floor of 50.00%; raise its coverage or record an explicit minimum for it"
+	if !strings.Contains(failures[0], want) {
+		t.Fatalf("failure = %q, want containing %q", failures[0], want)
+	}
+}
+
+// TestCoverageManifestGatedPackagesNamesDefaultFloorPackages proves an unlisted
+// measured package is reported with the floor it was held to, so a package that
+// resolves through the lane default is still named in checker output.
+func TestCoverageManifestGatedPackagesNamesDefaultFloorPackages(t *testing.T) {
+	t.Parallel()
+
+	listed := modulePath + "/pkg/config"
+	unlisted := modulePath + "/pkg/platform/unlisted"
+	unmeasurable := modulePath + "/pkg/platform/contracts"
+	gates := coverageManifestGatedPackages(
+		coverageManifest{
+			Version:  coverageManifestVersion,
+			Lane:     "unit",
+			Packages: []coverageManifestEntry{{Package: listed, Minimum: json.RawMessage("80.00")}},
+		},
+		map[string]packageCoverageTotals{
+			listed:       {coveredStatements: 9, totalStatements: 10},
+			unlisted:     {coveredStatements: 9, totalStatements: 10},
+			unmeasurable: {},
+		},
+	)
+	if gate := gates[listed]; gate.Floor == nil || *gate.Floor != 80 {
+		t.Fatalf("listed gate = %+v, want the explicit 80 floor", gate)
+	}
+	if gate := gates[unlisted]; gate.Floor == nil || *gate.Floor != 50 {
+		t.Fatalf("unlisted gate = %+v, want the unit lane default floor", gate)
+	}
+	if gate, ok := gates[unmeasurable]; ok {
+		t.Fatalf("unmeasurable gate = %+v, want no floor for a package with no measurable statements", gate)
+	}
+}

--- a/cmd/gocoveragecheck/manifest_service_completeness.go
+++ b/cmd/gocoveragecheck/manifest_service_completeness.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+)
+
+// coverageServiceRootPrefix is the import-path prefix under which every product
+// service lives. Completeness is checked once per service beneath it.
+const coverageServiceRootPrefix = modulePath + "/pkg/services/"
+
+// validateCoverageManifestDefaultFloor rejects a manifest whose optional
+// defaultFloorPercent is present but is not a two-decimal percentage.
+func validateCoverageManifestDefaultFloor(manifest coverageManifest) error {
+	raw := manifest.DefaultFloorPercent
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	if _, err := parseCoverageFloor(raw); err != nil {
+		return fmt.Errorf("validate go coverage manifest: defaultFloorPercent: %w", err)
+	}
+	return nil
+}
+
+// coverageManifestServiceRoot reports the pkg/services/<name> root import path
+// that governs importPath, and whether importPath belongs to a service at all.
+// The service root governs itself.
+func coverageManifestServiceRoot(importPath string) (string, bool) {
+	rest, ok := strings.CutPrefix(importPath, coverageServiceRootPrefix)
+	if !ok {
+		return "", false
+	}
+	name := rest
+	if head, _, found := strings.Cut(rest, "/"); found {
+		name = head
+	}
+	if name == "" {
+		return "", false
+	}
+	return coverageServiceRootPrefix + name, true
+}
+
+// validateCoverageManifestServiceRoots enforces per-service completeness: every
+// service with a measured package must declare a floor at its own root. A
+// package inside an already-declared service needs no entry of its own, and an
+// undeclared service is reported once rather than once per package under it.
+func validateCoverageManifestServiceRoots(
+	lane string,
+	measuredPackages []string,
+	declared map[string]struct{},
+	measuredTotals map[string]packageCoverageTotals,
+) error {
+	missing := make(map[string]struct{})
+	for _, importPath := range measuredPackages {
+		root, ok := coverageManifestServiceRoot(importPath)
+		if !ok {
+			continue
+		}
+		if _, declaredRoot := declared[root]; declaredRoot {
+			continue
+		}
+		missing[root] = struct{}{}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return formatMissingCoverageManifestServiceRoots(lane, slices.Sorted(maps.Keys(missing)), measuredTotals)
+}
+
+func formatMissingCoverageManifestServiceRoots(lane string, missing []string, measuredTotals map[string]packageCoverageTotals) error {
+	lines := make([]string, 0, len(missing))
+	for _, root := range missing {
+		line := fmt.Sprintf(
+			"- measured %s service %q has no root manifest entry; record one entry for the service root",
+			lane, root,
+		)
+		if measuredTotals != nil {
+			totals := measuredTotals[root]
+			line += fmt.Sprintf("; the root package measures %d/%d statements", totals.coveredStatements, totals.totalStatements)
+		}
+		lines = append(lines, line)
+	}
+	return fmt.Errorf(
+		"validate go coverage manifest: measured %s services have no root manifest entry:\n%s",
+		lane, strings.Join(lines, "\n"),
+	)
+}
+
+// isCoverageManifestServiceRoot reports whether importPath is a service root.
+func isCoverageManifestServiceRoot(importPath string) bool {
+	root, ok := coverageManifestServiceRoot(importPath)
+	return ok && root == importPath
+}
+
+// coverageManifestServiceRootEntry builds the root entry a service declares
+// when its root package carries no measurable statements of its own. The lane
+// default is recorded explicitly so the row states the floor it applies.
+func coverageManifestServiceRootEntry(lane string, importPath string) coverageManifestEntry {
+	return coverageManifestEntry{
+		Package: importPath,
+		Minimum: laneDefaultCoverageFloorRaw(lane),
+	}
+}

--- a/cmd/gocoveragecheck/manifest_service_completeness.go
+++ b/cmd/gocoveragecheck/manifest_service_completeness.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"maps"
 	"slices"
@@ -94,12 +95,19 @@ func isCoverageManifestServiceRoot(importPath string) bool {
 	return ok && root == importPath
 }
 
-// coverageManifestServiceRootEntry builds the root entry a service declares
-// when its root package carries no measurable statements of its own. The lane
-// default is recorded explicitly so the row states the floor it applies.
-func coverageManifestServiceRootEntry(lane string, importPath string) coverageManifestEntry {
+// unmeasuredServiceRootFloorPercent is the floor recorded for a service root
+// whose own package carries no measurable statements. The row exists to declare
+// the service for per-service completeness; its floor is inert, because a
+// package with no measurable statements passes vacuously. Recording anything
+// higher would fabricate a floor for a package the profile never measured.
+// `-update-manifest` raises the row from samples once the root is measured.
+const unmeasuredServiceRootFloorPercent = "0.00"
+
+// coverageManifestServiceRootEntry builds the declaration row for a service
+// root whose package carries no measurable statements of its own.
+func coverageManifestServiceRootEntry(importPath string) coverageManifestEntry {
 	return coverageManifestEntry{
 		Package: importPath,
-		Minimum: laneDefaultCoverageFloorRaw(lane),
+		Minimum: json.RawMessage(unmeasuredServiceRootFloorPercent),
 	}
 }

--- a/cmd/gocoveragecheck/manifest_test.go
+++ b/cmd/gocoveragecheck/manifest_test.go
@@ -90,29 +90,59 @@ func TestNewCoverageManifestIsSortedAndByteDeterministic(t *testing.T) {
 	}
 }
 
-func TestNewCoverageManifestUsesExplicitExceptionForUnmeasurablePackage(t *testing.T) {
+func TestNewCoverageManifestOmitsUnmeasurablePackagesAndDeclaresServiceRoots(t *testing.T) {
 	t.Parallel()
 
-	importPath := modulePath + "/cmd/factory"
-	manifest, err := newCoverageManifest("unit", map[string]packageCoverageTotals{}, []string{importPath})
+	commandPackage := modulePath + "/cmd/factory"
+	serviceRoot := modulePath + "/pkg/services/work"
+	serviceInternal := modulePath + "/pkg/services/work/internal"
+	measured := []string{commandPackage, serviceRoot, serviceInternal}
+	manifest, err := newCoverageManifest("unit", map[string]packageCoverageTotals{}, measured)
 	if err != nil {
 		t.Fatalf("newCoverageManifest() error = %v", err)
 	}
-	entry := manifest.Packages[0]
-	if len(entry.Minimum) != 0 {
-		t.Fatalf("minimum = %s, want no fabricated floor", entry.Minimum)
+
+	entries := make(map[string]coverageManifestEntry, len(manifest.Packages))
+	for _, entry := range manifest.Packages {
+		entries[entry.Package] = entry
 	}
-	if entry.Exception == nil || entry.Exception.Kind != "measurement" || entry.Exception.Deadline != unmeasurablePackageDeadline {
-		t.Fatalf("exception = %+v, want structured measurement exception", entry.Exception)
+	if _, ok := entries[commandPackage]; ok {
+		t.Fatalf("manifest = %+v, want no row for an unmeasurable non-service package", manifest.Packages)
 	}
-	if got, want := entry.Exception.Justification, "The active unit coverage profile contains no measurable statements for this package."; got != want {
-		t.Fatalf("exception justification = %q, want %q", got, want)
+	if _, ok := entries[serviceInternal]; ok {
+		t.Fatalf("manifest = %+v, want no row for an unmeasurable package inside a declared service", manifest.Packages)
 	}
-	if strings.Contains(entry.Exception.Justification, "declaration-only") {
-		t.Fatalf("exception justification %q invents an uninspected package property", entry.Exception.Justification)
+	root, ok := entries[serviceRoot]
+	if !ok {
+		t.Fatalf("manifest = %+v, want a root row declaring the service", manifest.Packages)
 	}
-	if err := validateCoverageManifest(manifest, "unit", []string{importPath}); err != nil {
+	if root.Exception != nil {
+		t.Fatalf("service root entry = %+v, want an explicit floor rather than an exception", root)
+	}
+	if got := string(root.Minimum); got != unitLaneDefaultFloorPercent {
+		t.Fatalf("service root minimum = %s, want the unit lane default %s", got, unitLaneDefaultFloorPercent)
+	}
+	if err := validateCoverageManifest(manifest, "unit", measured); err != nil {
 		t.Fatalf("generated manifest does not validate: %v", err)
+	}
+}
+
+func TestNewCoverageManifestRecordsFunctionalServiceRootDefault(t *testing.T) {
+	t.Parallel()
+
+	serviceRoot := modulePath + "/pkg/services/work"
+	manifest, err := newCoverageManifest("functional", map[string]packageCoverageTotals{}, []string{serviceRoot})
+	if err != nil {
+		t.Fatalf("newCoverageManifest() error = %v", err)
+	}
+	if len(manifest.Packages) != 1 {
+		t.Fatalf("manifest packages = %+v, want exactly the service root", manifest.Packages)
+	}
+	if got := string(manifest.Packages[0].Minimum); got != functionalLaneDefaultFloorPercent {
+		t.Fatalf("service root minimum = %s, want the functional lane default %s", got, functionalLaneDefaultFloorPercent)
+	}
+	if got := string(manifest.DefaultFloorPercent); got != functionalLaneDefaultFloorPercent {
+		t.Fatalf("defaultFloorPercent = %s, want %s", got, functionalLaneDefaultFloorPercent)
 	}
 }
 
@@ -135,7 +165,8 @@ func TestReadCoverageManifestValidatesContract(t *testing.T) {
 		{name: "unknown lane", manifest: strings.Replace(valid, `"unit"`, `"long"`, 1), measured: []string{configPackage, servicePackage}, want: "unknown lane"},
 		{name: "duplicate", manifest: `{"version":1,"lane":"unit","packages":[{"package":"` + configPackage + `","minimum":80.00},{"package":"` + configPackage + `","minimum":81.00}]}`, measured: []string{configPackage}, want: "duplicate package"},
 		{name: "outside measured set", manifest: valid, measured: []string{configPackage}, want: "outside the unit measured package set"},
-		{name: "missing measured package", manifest: `{"version":1,"lane":"unit","packages":[{"package":"` + configPackage + `","minimum":80.00}]}`, measured: []string{configPackage, servicePackage}, want: "has no manifest entry"},
+		{name: "missing service root", manifest: `{"version":1,"lane":"unit","packages":[{"package":"` + configPackage + `","minimum":80.00}]}`, measured: []string{configPackage, modulePath + "/pkg/services/work/internal"}, want: `measured unit service "` + modulePath + `/pkg/services/work" has no root manifest entry`},
+		{name: "invalid default floor", manifest: `{"version":1,"lane":"unit","defaultFloorPercent":50.0,"packages":[{"package":"` + configPackage + `","minimum":80.00}]}`, measured: []string{configPackage}, want: "defaultFloorPercent"},
 		{name: "unsorted", manifest: `{"version":1,"lane":"unit","packages":[{"package":"` + servicePackage + `","minimum":80.00},{"package":"` + configPackage + `","minimum":80.00}]}`, measured: []string{configPackage, servicePackage}, want: "must be sorted"},
 		{name: "invalid percentage", manifest: `{"version":1,"lane":"unit","packages":[{"package":"` + configPackage + `","minimum":100.01}]}`, measured: []string{configPackage}, want: "between 0.00 and 100.00"},
 		{name: "imprecise percentage", manifest: `{"version":1,"lane":"unit","packages":[{"package":"` + configPackage + `","minimum":80.0}]}`, measured: []string{configPackage}, want: "exactly two decimal places"},
@@ -230,11 +261,12 @@ func TestCheckCoverageManifestControlledProfilesForBothLanes(t *testing.T) {
 					{Package: beta, Minimum: json.RawMessage("75.00")},
 				},
 			}
-			missing := manifest
-			missing.Packages = missing.Packages[:1]
-			err := validateCoverageManifestAt(missing, lane, []string{alpha, beta}, time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC))
-			if err == nil || !strings.Contains(err.Error(), "measured "+lane+" package \""+beta+"\" has no manifest entry") {
-				t.Fatalf("missing-entry error = %v, want lane-specific closed failure", err)
+			// A measured package outside pkg/services with no entry is not a
+			// completeness failure: it resolves to the lane default floor.
+			unlisted := manifest
+			unlisted.Packages = unlisted.Packages[:1]
+			if err := validateCoverageManifestAt(unlisted, lane, []string{alpha, beta}, time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC)); err != nil {
+				t.Fatalf("unlisted non-service package error = %v, want the %s lane default to apply", err, lane)
 			}
 
 			if failures := checkCoverageManifest(manifest, map[string]packageCoverageTotals{
@@ -389,27 +421,30 @@ func uncoveredBlockManifestFixture() (coverageManifest, map[string]coverageBlock
 	return manifest, coverageBlocks, importPath
 }
 
-func TestValidateCoverageManifestReportsAllMissingPackagesWithMeasurements(t *testing.T) {
+func TestValidateCoverageManifestReportsEachUndeclaredServiceOnce(t *testing.T) {
 	t.Parallel()
 
-	alpha := modulePath + "/pkg/alpha"
-	beta := modulePath + "/pkg/beta"
-	zeta := modulePath + "/pkg/zeta"
+	declaredRoot := modulePath + "/pkg/services/work"
+	declaredChild := modulePath + "/pkg/services/work/internal/staging"
+	alphaRoot := modulePath + "/pkg/services/alpha"
+	zetaRoot := modulePath + "/pkg/services/zeta"
 	manifest := coverageManifest{
 		Version: coverageManifestVersion,
 		Lane:    "functional",
 		Packages: []coverageManifestEntry{
-			{Package: alpha, Minimum: json.RawMessage("80.00")},
+			{Package: declaredRoot, Minimum: json.RawMessage("40.00")},
 		},
 	}
 	err := validateCoverageManifestAtWithTotals(
 		manifest,
 		"functional",
-		[]string{zeta, alpha, beta},
+		[]string{
+			zetaRoot, zetaRoot + "/internal", zetaRoot + "/transports/http",
+			alphaRoot + "/wire", declaredRoot, declaredChild,
+		},
 		time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC),
 		map[string]packageCoverageTotals{
-			beta: {coveredStatements: 2, totalStatements: 3},
-			zeta: {},
+			zetaRoot: {coveredStatements: 2, totalStatements: 3},
 		},
 	)
 	if err == nil {
@@ -417,20 +452,47 @@ func TestValidateCoverageManifestReportsAllMissingPackagesWithMeasurements(t *te
 	}
 
 	message := err.Error()
-	if !strings.Contains(message, "measured functional packages have no manifest entry") {
-		t.Fatalf("missing-entry error = %q, want functional lane diagnostic", message)
+	if !strings.Contains(message, "measured functional services have no root manifest entry") {
+		t.Fatalf("missing-root error = %q, want functional lane diagnostic", message)
 	}
-	if strings.Count(message, "has no manifest entry") != 2 {
-		t.Fatalf("missing-entry error = %q, want one line per missing package", message)
+	if got := strings.Count(message, "has no root manifest entry;"); got != 2 {
+		t.Fatalf("missing-root error = %q, want one line per undeclared service, got %d", message, got)
 	}
-	if !strings.Contains(message, `measured functional package "`+beta+`" has no manifest entry; measured coverage 66.66%`) {
-		t.Fatalf("missing-entry error = %q, want truncated two-decimal beta measurement", message)
+	if strings.Contains(message, declaredRoot+"/") || strings.Contains(message, zetaRoot+"/") {
+		t.Fatalf("missing-root error = %q, want services named once rather than per package", message)
 	}
-	if !strings.Contains(message, `measured functional package "`+zeta+`" has no manifest entry; no measurable statements`) {
-		t.Fatalf("missing-entry error = %q, want no-measurable-statements classification", message)
+	if !strings.Contains(message, `measured functional service "`+alphaRoot+`" has no root manifest entry`) {
+		t.Fatalf("missing-root error = %q, want the alpha service named by its root", message)
 	}
-	if strings.Index(message, beta) > strings.Index(message, zeta) {
-		t.Fatalf("missing packages are not sorted by import path: %q", message)
+	if !strings.Contains(message, `measured functional service "`+zetaRoot+`" has no root manifest entry; record one entry for the service root; the root package measures 2/3 statements`) {
+		t.Fatalf("missing-root error = %q, want the zeta root measurement", message)
+	}
+	if strings.Index(message, alphaRoot) > strings.Index(message, zetaRoot) {
+		t.Fatalf("undeclared services are not sorted by import path: %q", message)
+	}
+}
+
+func TestValidateCoverageManifestAcceptsNewPackagesInsideDeclaredService(t *testing.T) {
+	t.Parallel()
+
+	declaredRoot := modulePath + "/pkg/services/work"
+	manifest := coverageManifest{
+		Version: coverageManifestVersion,
+		Lane:    "unit",
+		Packages: []coverageManifestEntry{
+			{Package: declaredRoot, Minimum: json.RawMessage("40.00")},
+		},
+	}
+	measured := []string{declaredRoot, declaredRoot + "/internal/brand_new", declaredRoot + "/transports/cli"}
+	if err := validateCoverageManifestAt(manifest, "unit", measured, time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("validateCoverageManifestAt() error = %v, want new packages inside a declared service to pass completeness", err)
+	}
+
+	withoutRoot := manifest
+	withoutRoot.Packages = nil
+	err := validateCoverageManifestAt(withoutRoot, "unit", measured, time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC))
+	if err == nil || !strings.Contains(err.Error(), `measured unit service "`+declaredRoot+`" has no root manifest entry`) {
+		t.Fatalf("validateCoverageManifestAt() error = %v, want the service named after its root entry is removed", err)
 	}
 }
 

--- a/cmd/gocoveragecheck/manifest_test.go
+++ b/cmd/gocoveragecheck/manifest_test.go
@@ -119,15 +119,15 @@ func TestNewCoverageManifestOmitsUnmeasurablePackagesAndDeclaresServiceRoots(t *
 	if root.Exception != nil {
 		t.Fatalf("service root entry = %+v, want an explicit floor rather than an exception", root)
 	}
-	if got := string(root.Minimum); got != unitLaneDefaultFloorPercent {
-		t.Fatalf("service root minimum = %s, want the unit lane default %s", got, unitLaneDefaultFloorPercent)
+	if got := string(root.Minimum); got != unmeasuredServiceRootFloorPercent {
+		t.Fatalf("service root minimum = %s, want the inert declaration floor %s", got, unmeasuredServiceRootFloorPercent)
 	}
 	if err := validateCoverageManifest(manifest, "unit", measured); err != nil {
 		t.Fatalf("generated manifest does not validate: %v", err)
 	}
 }
 
-func TestNewCoverageManifestRecordsFunctionalServiceRootDefault(t *testing.T) {
+func TestNewCoverageManifestRecordsFunctionalLaneDefaultFloor(t *testing.T) {
 	t.Parallel()
 
 	serviceRoot := modulePath + "/pkg/services/work"
@@ -138,8 +138,8 @@ func TestNewCoverageManifestRecordsFunctionalServiceRootDefault(t *testing.T) {
 	if len(manifest.Packages) != 1 {
 		t.Fatalf("manifest packages = %+v, want exactly the service root", manifest.Packages)
 	}
-	if got := string(manifest.Packages[0].Minimum); got != functionalLaneDefaultFloorPercent {
-		t.Fatalf("service root minimum = %s, want the functional lane default %s", got, functionalLaneDefaultFloorPercent)
+	if got := string(manifest.Packages[0].Minimum); got != unmeasuredServiceRootFloorPercent {
+		t.Fatalf("service root minimum = %s, want the inert declaration floor %s", got, unmeasuredServiceRootFloorPercent)
 	}
 	if got := string(manifest.DefaultFloorPercent); got != functionalLaneDefaultFloorPercent {
 		t.Fatalf("defaultFloorPercent = %s, want %s", got, functionalLaneDefaultFloorPercent)

--- a/cmd/gocoveragecheck/manifest_update.go
+++ b/cmd/gocoveragecheck/manifest_update.go
@@ -138,7 +138,12 @@ func planCoverageManifestUpdate(manifest coverageManifest, minimums map[string]p
 	}
 	slices.Sort(packages)
 
-	updated := coverageManifest{Version: manifest.Version, Lane: manifest.Lane, Packages: make([]coverageManifestEntry, 0, len(packages))}
+	updated := coverageManifest{
+		Version:             manifest.Version,
+		Lane:                manifest.Lane,
+		DefaultFloorPercent: manifest.DefaultFloorPercent,
+		Packages:            make([]coverageManifestEntry, 0, len(packages)),
+	}
 	updates := make([]coverageManifestUpdate, 0, len(packages))
 	for _, importPath := range packages {
 		entry, found := existing[importPath]
@@ -147,9 +152,12 @@ func planCoverageManifestUpdate(manifest coverageManifest, minimums map[string]p
 			if !ok {
 				return manifest, updates, fmt.Errorf("update %s coverage manifest: package %q has no compatible sample measurement", manifest.Lane, importPath)
 			}
-			entry, err := newCoverageManifestEntry(manifest.Lane, importPath, totals)
+			entry, required, err := newCoverageManifestEntry(manifest.Lane, importPath, totals)
 			if err != nil {
 				return manifest, updates, fmt.Errorf("update %s coverage manifest for new package %s: %w", manifest.Lane, importPath, err)
+			}
+			if !required {
+				continue
 			}
 			updated.Packages = append(updated.Packages, entry)
 			updates = append(updates, coverageManifestUpdate{

--- a/cmd/gocoveragecheck/manifest_vacuous_pass_test.go
+++ b/cmd/gocoveragecheck/manifest_vacuous_pass_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// staleMeasurementException mirrors the auto-generated exception rows this lane
+// retires, so the test proves the checker no longer needs them.
+func staleMeasurementException(lane string) *coverageManifestException {
+	return &coverageManifestException{
+		Kind:          "measurement",
+		Justification: "The active " + lane + " coverage profile contains no measurable statements for this package.",
+		Owner:         "backend-quality",
+		Deadline:      "2027-07-15",
+		RemovalGate:   "The " + lane + " coverage profile reports at least one measurable statement for this package.",
+	}
+}
+
+// TestZeroStatementPackagePassesWithoutAnyManifestEntry proves the vacuous pass:
+// a package whose profile reports no measurable statements passes with no
+// manifest row, and is not reported as a completeness gap.
+func TestZeroStatementPackagePassesWithoutAnyManifestEntry(t *testing.T) {
+	t.Parallel()
+
+	for _, lane := range []string{"unit", "functional"} {
+		t.Run(lane, func(t *testing.T) {
+			t.Parallel()
+
+			unmeasurable := modulePath + "/pkg/platform/contracts"
+			manifest := coverageManifest{Version: coverageManifestVersion, Lane: lane}
+			failures, warnings := checkCoverageManifestWithEpsilon(
+				manifest,
+				map[string]packageCoverageTotals{unmeasurable: {}},
+				"minimums.json",
+				0,
+			)
+			if len(failures) != 0 || len(warnings) != 0 {
+				t.Fatalf("failures = %v, warnings = %v, want none", failures, warnings)
+			}
+			if err := validateCoverageManifestAt(manifest, lane, []string{unmeasurable}, time.Date(2026, 8, 17, 0, 0, 0, 0, time.UTC)); err != nil {
+				t.Fatalf("validateCoverageManifestAt() error = %v, want no completeness gap", err)
+			}
+		})
+	}
+}
+
+// TestZeroStatementPackagePassesWithAStaleMeasurementException proves the stale
+// rows this lane deletes are harmless while they remain: an entry that is
+// present still passes.
+func TestZeroStatementPackagePassesWithAStaleMeasurementException(t *testing.T) {
+	t.Parallel()
+
+	unmeasurable := modulePath + "/pkg/platform/contracts"
+	manifest := coverageManifest{
+		Version: coverageManifestVersion,
+		Lane:    "unit",
+		Packages: []coverageManifestEntry{
+			{Package: unmeasurable, Exception: staleMeasurementException("unit")},
+		},
+	}
+	failures, warnings := checkCoverageManifestWithEpsilon(
+		manifest,
+		map[string]packageCoverageTotals{unmeasurable: {}},
+		"minimums.json",
+		0,
+	)
+	if len(failures) != 0 || len(warnings) != 0 {
+		t.Fatalf("failures = %v, warnings = %v, want none", failures, warnings)
+	}
+	if err := validateCoverageManifestAt(manifest, "unit", []string{unmeasurable}, time.Date(2026, 8, 17, 0, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("validateCoverageManifestAt() error = %v, want a stale measurement exception to validate", err)
+	}
+}
+
+// TestRemovingAMeasurementExceptionKeepsAZeroStatementPackagePassing proves
+// deleting a stale measurement row does not convert the package into a
+// completeness failure or a coverage regression.
+func TestRemovingAMeasurementExceptionKeepsAZeroStatementPackagePassing(t *testing.T) {
+	t.Parallel()
+
+	unmeasurable := modulePath + "/pkg/platform/contracts"
+	totals := map[string]packageCoverageTotals{unmeasurable: {}}
+	measured := []string{unmeasurable}
+	now := time.Date(2026, 8, 17, 0, 0, 0, 0, time.UTC)
+
+	with := coverageManifest{
+		Version: coverageManifestVersion,
+		Lane:    "functional",
+		Packages: []coverageManifestEntry{
+			{Package: unmeasurable, Exception: staleMeasurementException("functional")},
+		},
+	}
+	withFailures, _ := checkCoverageManifestWithEpsilon(with, totals, "minimums.json", 0)
+	if len(withFailures) != 0 {
+		t.Fatalf("failures with the exception = %v, want none", withFailures)
+	}
+
+	without := with
+	without.Packages = nil
+	withoutFailures, _ := checkCoverageManifestWithEpsilon(without, totals, "minimums.json", 0)
+	if len(withoutFailures) != 0 {
+		t.Fatalf("failures after removing the exception = %v, want none", withoutFailures)
+	}
+	if err := validateCoverageManifestAt(without, "functional", measured, now); err != nil {
+		t.Fatalf("validateCoverageManifestAt() error = %v, want removal to leave no completeness gap", err)
+	}
+}
+
+// TestZeroStatementPackagePassesEvenWithAnExplicitFloor proves the vacuous pass
+// is independent of the default floor from the first story: an explicit
+// numeric floor is also not evaluated against an empty denominator. This is
+// what lets a service root declare a floor before its root package carries any
+// measurable statement.
+func TestZeroStatementPackagePassesEvenWithAnExplicitFloor(t *testing.T) {
+	t.Parallel()
+
+	serviceRoot := modulePath + "/pkg/services/work"
+	manifest := coverageManifest{
+		Version: coverageManifestVersion,
+		Lane:    "unit",
+		Packages: []coverageManifestEntry{
+			{Package: serviceRoot, Minimum: json.RawMessage("50.00")},
+		},
+	}
+	failures, warnings := checkCoverageManifestWithEpsilon(
+		manifest,
+		map[string]packageCoverageTotals{serviceRoot: {}},
+		"minimums.json",
+		0,
+	)
+	if len(failures) != 0 || len(warnings) != 0 {
+		t.Fatalf("failures = %v, warnings = %v, want none", failures, warnings)
+	}
+}
+
+// TestUpdateManifestMintsNoRowForAnUnmeasurablePackage proves the manifest
+// update path does not re-create the rows this lane retires.
+func TestUpdateManifestMintsNoRowForAnUnmeasurablePackage(t *testing.T) {
+	t.Parallel()
+
+	unmeasurable := modulePath + "/pkg/platform/contracts"
+	measurable := modulePath + "/pkg/config"
+	manifest := coverageManifest{
+		Version:             coverageManifestVersion,
+		Lane:                "unit",
+		DefaultFloorPercent: json.RawMessage("50.00"),
+	}
+	updated, updates, err := planCoverageManifestUpdate(manifest, map[string]packageCoverageTotals{
+		unmeasurable: {},
+		measurable:   {coveredStatements: 8, totalStatements: 10},
+	})
+	if err != nil {
+		t.Fatalf("planCoverageManifestUpdate() error = %v", err)
+	}
+	if len(updated.Packages) != 1 || updated.Packages[0].Package != measurable {
+		t.Fatalf("updated packages = %+v, want only the measurable package", updated.Packages)
+	}
+	if string(updated.DefaultFloorPercent) != "50.00" {
+		t.Fatalf("defaultFloorPercent = %s, want the update to preserve it", updated.DefaultFloorPercent)
+	}
+	for _, update := range updates {
+		if strings.Contains(update.String(), unmeasurable) {
+			t.Fatalf("updates = %v, did not expect a row for an unmeasurable package", updates)
+		}
+	}
+}

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1,17 +1,8 @@
 {
   "version": 1,
   "lane": "functional",
+  "defaultFloorPercent": 0.00,
   "packages": [
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/initializer",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
     {
       "package": "github.com/portpowered/infinite-you/pkg/initializer/application",
       "minimum": 71.53
@@ -122,27 +113,11 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal",
       "minimum": 65.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/cron",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/cron/internal/service",
@@ -181,32 +156,12 @@
       "minimum": 0.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/reconciliation",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/reconciliation/internal/service",
       "minimum": 38.69
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/reconciliation/wire",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/script_pollers",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/script_pollers/internal/service",
@@ -223,64 +178,8 @@
       "minimum": 0.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/automations/transports/http",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/automations/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/responsebridge",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/edges",
@@ -325,48 +224,8 @@
       "minimum": 40.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/authoring_layout",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/authoring_layout/authoredlayout",
       "minimum": 61.47
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/authoring_layout/expand",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/authoring_layout/flatten",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/authoring_layout/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/authoring_layout/persist",
@@ -375,26 +234,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/authoring_layout/prepare",
       "minimum": 57.89
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/authoring_layout/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/catalog",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/catalog/internal/service",
@@ -413,48 +252,8 @@
       "minimum": 64.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/catalog/resource",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/catalog/wire",
       "minimum": 62.50
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/compilation",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/compilation/canonical",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/compilation/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/compilation/loadedsource",
@@ -467,36 +266,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/compilation/runtimeconfig",
       "minimum": 83.62
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/compilation/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/distribution",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/distribution/goal",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/distribution/internal/service",
@@ -519,72 +288,12 @@
       "minimum": 0.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/distribution/review",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/distribution/scaffoldfacts",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/distribution/subagent",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/distribution/tts",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/distribution/wire",
       "minimum": 0.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/invocation_policy",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/invocation_policy/decisionenvelope",
       "minimum": 40.90
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/invocation_policy/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/invocation_policy/invocationinterpolation",
@@ -607,32 +316,12 @@
       "minimum": 15.55
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/invocation_policy/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/invocation_policy/workpropagation",
       "minimum": 85.71
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/invocation_policy/workstationexecution",
       "minimum": 71.42
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/runtime_snapshot",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/runtime_snapshot/internal",
@@ -643,32 +332,12 @@
       "minimum": 75.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/snapshots_portability",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/snapshots_portability/capture",
       "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/snapshots_portability/editable",
       "minimum": 0.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/snapshots_portability/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/snapshots_portability/materialize",
@@ -685,26 +354,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/snapshots_portability/replayconfig",
       "minimum": 0.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/snapshots_portability/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/validation",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/validation/authoredmodel/namevalue",
@@ -747,48 +396,8 @@
       "minimum": 0.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/testcomposition",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/cli",
       "minimum": 39.72
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/http",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/mcp",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire/defaultscaffold",
@@ -815,32 +424,12 @@
       "minimum": 5.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/legacysnapshot",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri",
       "minimum": 36.92
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/rootobservation",
       "minimum": 78.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/checkpoint_recovery",
@@ -867,32 +456,12 @@
       "minimum": 21.42
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/dispatch_planning",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/dispatch_planning/internal/service",
       "minimum": 62.54
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/dispatch_planning/wire",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/instance_host",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/instance_host/build",
@@ -905,16 +474,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/instance_host/wire",
       "minimum": 0.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/context",
@@ -1025,98 +584,8 @@
       "minimum": 0.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/testkit",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli",
       "minimum": 0.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/http",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/http/control",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/http/dispatch",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/http/internal/common",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/http/internal/errors",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/http/observation",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/mcp",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions",
@@ -1129,16 +598,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/artifactprojection",
       "minimum": 31.57
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/contracts",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/controlplane",
@@ -1155,26 +614,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/execution",
       "minimum": 57.89
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/execution/recordingreplay",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/execution/runtimepersist",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/executionopening",
@@ -1197,32 +636,12 @@
       "minimum": 77.77
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/legacysnapshot",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/livechange",
       "minimum": 57.77
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/livesession",
       "minimum": 53.12
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/logicaltarget",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/ondemandtarget",
@@ -1253,26 +672,6 @@
       "minimum": 30.97
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/responsestream/ndjsoncontract",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/roles",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtime",
       "minimum": 59.87
     },
@@ -1297,32 +696,12 @@
       "minimum": 76.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtimeports",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/scopedlisting",
       "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/service",
       "minimum": 56.25
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/durable_execution",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/durable_execution/internal/service",
@@ -1333,16 +712,6 @@
       "minimum": 83.33
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/identity",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/identity/internal/service",
       "minimum": 25.71
     },
@@ -1351,32 +720,12 @@
       "minimum": 60.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/invocation",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/invocation/internal/service",
       "minimum": 57.89
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/invocation/wire",
       "minimum": 80.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/live_runtime",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/live_runtime/internal/service",
@@ -1419,16 +768,6 @@
       "minimum": 51.51
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/testing/eventsstub",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/transports/cli",
       "minimum": 0.00
     },
@@ -1457,28 +796,8 @@
       "minimum": 65.11
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/wire/contracts",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization",
       "minimum": 0.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/contracts",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/recordingsqueries",
@@ -1489,16 +808,6 @@
       "minimum": 0.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service",
       "minimum": 0.00
     },
@@ -1507,38 +816,8 @@
       "minimum": 0.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/live_view_projection",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/live_view_projection/internal/service",
       "minimum": 0.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/live_view_projection/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/response_event_presentation",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/response_event_presentation/internal/service",
@@ -1549,48 +828,8 @@
       "minimum": 100.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/testing/recordingsstub",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/cli",
       "minimum": 42.54
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/http",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/mcp",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models",
@@ -1609,28 +848,8 @@
       "minimum": 57.73
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/managedruntime",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/service",
       "minimum": 41.97
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets/internal/service",
@@ -1641,16 +860,6 @@
       "minimum": 60.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/internal/service",
       "minimum": 66.41
     },
@@ -1659,68 +868,8 @@
       "minimum": 54.54
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/artifacts",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service",
       "minimum": 37.41
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service",
@@ -1731,62 +880,12 @@
       "minimum": 72.72
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/transports/cli",
       "minimum": 42.67
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/transports/http",
       "minimum": 58.27
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/transports/mcp",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/wire",
@@ -1801,48 +900,8 @@
       "minimum": 0.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/construct",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/identityinputinventory",
       "minimum": 47.82
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/identityinventory",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/internal/service",
@@ -1853,154 +912,24 @@
       "minimum": 100.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/defaults",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/testlink",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/testproviders",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/cli",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig",
       "minimum": 83.69
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/http",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/mcp",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions",
       "minimum": 18.18
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/service",
       "minimum": 58.33
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/internal/service",
       "minimum": 65.44
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/cursor_reader",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/cursor_reader/internal/cursor",
@@ -2015,54 +944,8 @@
       "minimum": 0.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/transports/http",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/acp",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/acp/internal/service",
@@ -2077,62 +960,12 @@
       "minimum": 100.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/builtins",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/builtins/internal/service",
       "minimum": 78.57
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/builtins/wire",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/internal/adapters/agy",
@@ -2159,94 +992,8 @@
       "minimum": 50.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/testutil/execution",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/transports/cli",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/transports/http",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/transports/mcp",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/artifacts",
@@ -2263,16 +1010,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/events",
       "minimum": 52.41
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/events/kinds",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/events/snapshot",
@@ -2295,16 +1032,6 @@
       "minimum": 42.54
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/artifacts_export",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/artifacts_export/internal/service",
       "minimum": 1.47
     },
@@ -2313,122 +1040,12 @@
       "minimum": 66.66
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/canonical_ledger",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/canonical_ledger/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/canonical_ledger/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/historical_query",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/historical_query/internal/service",
       "minimum": 0.48
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/historical_query/wire",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/projection_query",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/projection_query/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/projection_query/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/recording_lifecycle",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/recording_lifecycle/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/recording_lifecycle/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/replay",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/replay/internal/service",
@@ -2451,68 +1068,12 @@
       "minimum": 100.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/transports/cli",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/transports/http",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/transports/mcp",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/system_initialization",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/system_initialization/internal/workflow",
       "minimum": 38.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/system_initialization/transports/cli",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/system_initialization/wire",
@@ -2520,13 +1081,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/webhooks",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/webhooks/internal/service",
@@ -2565,16 +1120,6 @@
       "minimum": 0.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_materialization",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_materialization/internal/service",
       "minimum": 4.11
     },
@@ -2583,32 +1128,12 @@
       "minimum": 75.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_staging",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_staging/internal/service",
       "minimum": 64.49
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_staging/wire",
       "minimum": 75.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/state_access",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/state_access/internal/service",
@@ -2627,48 +1152,12 @@
       "minimum": 0.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/work/transports/http",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/work/transports/mcp",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/wire",
       "minimum": 8.82
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/worker_sessions",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/worker_sessions/internal/service",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/worker_sessions/transports/cli",
@@ -2679,16 +1168,6 @@
       "minimum": 52.16
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/worker_sessions/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers",
       "minimum": 56.00
     },
@@ -2697,28 +1176,8 @@
       "minimum": 6.79
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/diagnostics",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/draftvalidation",
       "minimum": 0.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/execution",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/execution/recording",
@@ -2729,16 +1188,6 @@
       "minimum": 0.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/interface",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/prompting",
       "minimum": 23.80
     },
@@ -2747,52 +1196,12 @@
       "minimum": 0.80
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/inference",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/mock",
       "minimum": 0.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/script",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/service",
       "minimum": 69.56
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/services/agent",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service",
@@ -2801,36 +1210,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/services/agent/wire",
       "minimum": 51.85
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/testkit",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/process",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/runner",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/testing",
@@ -2867,98 +1246,8 @@
       "minimum": 48.96
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/acp",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/acp/internal/envelope",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/acp/internal/identity",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/acp/internal/mapping",
       "minimum": 0.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/acp/internal/negotiation",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/acp/internal/protocol",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/acp/internal/session",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/acp/internal/stdio",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/acp/wire",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli",
@@ -3001,16 +1290,6 @@
       "minimum": 60.62
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/completionprojection",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/config",
       "minimum": 62.22
     },
@@ -3051,28 +1330,8 @@
       "minimum": 77.27
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/resolvedinput",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/run",
       "minimum": 55.58
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/runconfig",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/sessionpath",
@@ -3099,16 +1358,6 @@
       "minimum": 0.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/workflow",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/http",
       "minimum": 66.35
     },
@@ -3129,26 +1378,6 @@
       "minimum": 48.98
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/factoryconfig/diagnostics",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/factoryconfig/openapitests",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/factorydefinition",
       "minimum": 59.09
     },
@@ -3165,16 +1394,6 @@
       "minimum": 75.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/factorytarget",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/optional",
       "minimum": 97.50
     },
@@ -3187,28 +1406,8 @@
       "minimum": 60.46
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/workerdiagnostics",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/workerinference",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/mcp/discoverygen",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active functional coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/mcp/server",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1,17 +1,8 @@
 {
   "version": 1,
   "lane": "unit",
+  "defaultFloorPercent": 50.00,
   "packages": [
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/initializer",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
     {
       "package": "github.com/portpowered/infinite-you/pkg/initializer/application",
       "minimum": 78.83
@@ -122,27 +113,11 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal",
       "minimum": 81.20
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/cron",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/cron/internal/service",
@@ -181,32 +156,12 @@
       "minimum": 33.33
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/reconciliation",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/reconciliation/internal/service",
       "minimum": 99.10
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/reconciliation/wire",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/script_pollers",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/script_pollers/internal/service",
@@ -232,13 +187,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/responsebridge",
@@ -289,16 +238,6 @@
       "minimum": 74.17
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/authoring_layout",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/authoring_layout/authoredlayout",
       "minimum": 54.26
     },
@@ -327,16 +266,6 @@
       "minimum": 96.40
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/catalog",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/catalog/internal/service",
       "minimum": 74.35
     },
@@ -353,28 +282,8 @@
       "minimum": 70.55
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/catalog/resource",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/catalog/wire",
       "minimum": 87.50
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/compilation",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/compilation/canonical",
@@ -401,16 +310,6 @@
       "minimum": 90.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/distribution",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/distribution/goal",
       "minimum": 67.27
     },
@@ -435,16 +334,6 @@
       "minimum": 95.20
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/distribution/review",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/distribution/scaffoldfacts",
       "minimum": 73.33
     },
@@ -459,16 +348,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/distribution/wire",
       "minimum": 90.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/invocation_policy",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/invocation_policy/decisionenvelope",
@@ -511,32 +390,12 @@
       "minimum": 35.71
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/runtime_snapshot",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/runtime_snapshot/internal",
       "minimum": 83.50
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/runtime_snapshot/wire",
       "minimum": 75.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/snapshots_portability",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/snapshots_portability/capture",
@@ -569,16 +428,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/snapshots_portability/wire",
       "minimum": 93.75
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/validation",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/validation/authoredmodel/namevalue",
@@ -665,16 +514,6 @@
       "minimum": 44.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/legacysnapshot",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri",
       "minimum": 85.23
     },
@@ -717,32 +556,12 @@
       "minimum": 100.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/dispatch_planning",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/dispatch_planning/internal/service",
       "minimum": 82.77
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/dispatch_planning/wire",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/instance_host",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/instance_host/build",
@@ -755,16 +574,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/instance_host/wire",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/context",
@@ -927,16 +736,6 @@
       "minimum": 42.10
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/contracts",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/controlplane",
       "minimum": 75.65
     },
@@ -979,16 +778,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/invocation/runtimeadapter",
       "minimum": 44.44
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/legacysnapshot",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/livechange",
@@ -1035,16 +824,6 @@
       "minimum": 100.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/roles",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtime",
       "minimum": 54.93
     },
@@ -1069,32 +848,12 @@
       "minimum": 85.33
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtimeports",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/scopedlisting",
       "minimum": 87.23
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/service",
       "minimum": 59.37
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/durable_execution",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/durable_execution/internal/service",
@@ -1105,16 +864,6 @@
       "minimum": 66.66
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/identity",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/identity/internal/service",
       "minimum": 54.28
     },
@@ -1123,32 +872,12 @@
       "minimum": 60.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/invocation",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/invocation/internal/service",
       "minimum": 78.94
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/invocation/wire",
       "minimum": 80.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/live_runtime",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/services/live_runtime/internal/service",
@@ -1223,28 +952,8 @@
       "minimum": 69.76
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/wire/contracts",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization",
       "minimum": 4.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/contracts",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/recordingsqueries",
@@ -1253,16 +962,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/service",
       "minimum": 52.10
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service",
@@ -1283,16 +982,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/live_view_projection/wire",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/response_event_presentation",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/response_event_presentation/internal/service",
@@ -1339,28 +1028,8 @@
       "minimum": 69.59
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/managedruntime",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/service",
       "minimum": 76.95
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets/internal/service",
@@ -1371,32 +1040,12 @@
       "minimum": 100.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/internal/service",
       "minimum": 87.31
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire",
       "minimum": 81.81
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/artifacts",
@@ -1411,28 +1060,8 @@
       "minimum": 100.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/service",
       "minimum": 78.44
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/internal/services/leases/internal/service",
@@ -1445,16 +1074,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_host/wire",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/internal/service",
@@ -1501,16 +1120,6 @@
       "minimum": 57.64
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/identityinventory",
       "minimum": 100.00
     },
@@ -1521,16 +1130,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/document/wire",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/internal/services/resolution/defaults",
@@ -1577,28 +1176,8 @@
       "minimum": 18.18
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/service",
       "minimum": 94.40
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/internal/service",
@@ -1607,16 +1186,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/codex_reader/wire",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/cursor_reader",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/provider_sessions/internal/services/cursor_reader/internal/cursor",
@@ -1647,16 +1216,6 @@
       "minimum": 75.40
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/acp",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/acp/internal/service",
       "minimum": 49.81
     },
@@ -1669,16 +1228,6 @@
       "minimum": 100.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/builtins",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/builtins/internal/service",
       "minimum": 78.57
     },
@@ -1687,32 +1236,12 @@
       "minimum": 100.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/internal/service",
       "minimum": 89.47
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/catalog/wire",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/internal/adapters/agy",
@@ -1768,13 +1297,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal",
@@ -1821,32 +1344,12 @@
       "minimum": 78.72
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/artifacts_export",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/artifacts_export/internal/service",
       "minimum": 73.89
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/artifacts_export/wire",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/canonical_ledger",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/canonical_ledger/internal/service",
@@ -1857,32 +1360,12 @@
       "minimum": 100.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/historical_query",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/historical_query/internal/service",
       "minimum": 38.04
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/historical_query/wire",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/projection_query",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/projection_query/internal/service",
@@ -1893,32 +1376,12 @@
       "minimum": 100.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/recording_lifecycle",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/recording_lifecycle/internal/service",
       "minimum": 93.28
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/recording_lifecycle/wire",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/replay",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/replay/internal/service",
@@ -1974,13 +1437,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/webhooks",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
+      "minimum": 0.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/webhooks/internal/service",
@@ -2019,16 +1476,6 @@
       "minimum": 80.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_materialization",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_materialization/internal/service",
       "minimum": 68.91
     },
@@ -2037,32 +1484,12 @@
       "minimum": 100.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_staging",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_staging/internal/service",
       "minimum": 77.53
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_staging/wire",
       "minimum": 100.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/state_access",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/state_access/internal/service",
@@ -2121,28 +1548,8 @@
       "minimum": 53.22
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/diagnostics",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/draftvalidation",
       "minimum": 0.00
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/execution",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/execution/recording",
@@ -2165,16 +1572,6 @@
       "minimum": 71.00
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/inference",
       "minimum": 93.18
     },
@@ -2191,16 +1588,6 @@
       "minimum": 90.21
     },
     {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/services/agent",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service",
       "minimum": 91.42
     },
@@ -2211,26 +1598,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/internal/testkit",
       "minimum": 88.42
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/process",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/runner",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/testing",
@@ -2391,16 +1758,6 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/run",
       "minimum": 80.25
-    },
-    {
-      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/runconfig",
-      "exception": {
-        "kind": "measurement",
-        "justification": "The active unit coverage profile contains no measurable statements for this package.",
-        "owner": "backend-quality",
-        "deadline": "2027-07-15",
-        "removalGate": "The unit coverage profile reports at least one measurable statement for this package."
-      }
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/sessionpath",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -4,6 +4,10 @@
   "defaultFloorPercent": 50.00,
   "packages": [
     {
+      "package": "github.com/portpowered/infinite-you/pkg/initializer",
+      "minimum": 43.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/initializer/application",
       "minimum": 78.83
     },
@@ -576,6 +580,10 @@
       "minimum": 100.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration",
+      "minimum": 41.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/context",
       "minimum": 86.11
     },
@@ -964,6 +972,10 @@
       "minimum": 52.10
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle",
+      "minimum": 0.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle/internal/service",
       "minimum": 35.00
     },
@@ -1046,6 +1058,10 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/wire",
       "minimum": 81.81
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference",
+      "minimum": 49.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/inference/internal/artifacts",
@@ -1476,6 +1492,10 @@
       "minimum": 80.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_materialization",
+      "minimum": 0.00
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_materialization/internal/service",
       "minimum": 68.91
     },
@@ -1550,6 +1570,10 @@
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/draftvalidation",
       "minimum": 0.00
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/execution",
+      "minimum": 38.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/execution/recording",

--- a/pkg/services/automations/transports/http/manifest_registration_test.go
+++ b/pkg/services/automations/transports/http/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	httpAdapterPackagePath = "pkg/services/automations/transports/http"
-	httpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/automations/transports/http"
-	automationsOwner       = "automations"
+	httpAdapterPackagePath           = "pkg/services/automations/transports/http"
+	httpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/automations/transports/http"
+	httpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/automations"
+	automationsOwner                 = "automations"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != httpAdapterImportPath {
+		if entry.Package != httpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, httpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, httpAdapterServiceRootImportPath, httpAdapterImportPath)
 }

--- a/pkg/services/factory_definitions/transports/cli/manifest_registration_test.go
+++ b/pkg/services/factory_definitions/transports/cli/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	cliAdapterPackagePath   = "pkg/services/factory_definitions/transports/cli"
-	cliAdapterImportPath    = "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/cli"
-	factoryDefinitionsOwner = "factory_definitions"
+	cliAdapterPackagePath           = "pkg/services/factory_definitions/transports/cli"
+	cliAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/cli"
+	cliAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryDefinitionsOwner         = "factory_definitions"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != cliAdapterImportPath {
+		if entry.Package != cliAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, cliAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, cliAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, cliAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, cliAdapterServiceRootImportPath, cliAdapterImportPath)
 }

--- a/pkg/services/factory_definitions/transports/http/manifest_registration_test.go
+++ b/pkg/services/factory_definitions/transports/http/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	httpAdapterPackagePath  = "pkg/services/factory_definitions/transports/http"
-	httpAdapterImportPath   = "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/http"
-	factoryDefinitionsOwner = "factory_definitions"
+	httpAdapterPackagePath           = "pkg/services/factory_definitions/transports/http"
+	httpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/http"
+	httpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryDefinitionsOwner          = "factory_definitions"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != httpAdapterImportPath {
+		if entry.Package != httpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, httpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, httpAdapterServiceRootImportPath, httpAdapterImportPath)
 }

--- a/pkg/services/factory_definitions/transports/mcp/manifest_registration_test.go
+++ b/pkg/services/factory_definitions/transports/mcp/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	mcpAdapterPackagePath   = "pkg/services/factory_definitions/transports/mcp"
-	mcpAdapterImportPath    = "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/mcp"
-	factoryDefinitionsOwner = "factory_definitions"
+	mcpAdapterPackagePath           = "pkg/services/factory_definitions/transports/mcp"
+	mcpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/mcp"
+	mcpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryDefinitionsOwner         = "factory_definitions"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != mcpAdapterImportPath {
+		if entry.Package != mcpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, mcpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, mcpAdapterServiceRootImportPath, mcpAdapterImportPath)
 }

--- a/pkg/services/factory_runtime/transports/cli/manifest_registration_test.go
+++ b/pkg/services/factory_runtime/transports/cli/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	cliAdapterPackagePath = "pkg/services/factory_runtime/transports/cli"
-	cliAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli"
-	factoryRuntimeOwner   = "factory_runtime"
+	cliAdapterPackagePath           = "pkg/services/factory_runtime/transports/cli"
+	cliAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/cli"
+	cliAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryRuntimeOwner             = "factory_runtime"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != cliAdapterImportPath {
+		if entry.Package != cliAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, cliAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, cliAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, cliAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, cliAdapterServiceRootImportPath, cliAdapterImportPath)
 }

--- a/pkg/services/factory_runtime/transports/http/manifest_registration_test.go
+++ b/pkg/services/factory_runtime/transports/http/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	httpAdapterPackagePath = "pkg/services/factory_runtime/transports/http"
-	httpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/http"
-	factoryRuntimeOwner    = "factory_runtime"
+	httpAdapterPackagePath           = "pkg/services/factory_runtime/transports/http"
+	httpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/http"
+	httpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryRuntimeOwner              = "factory_runtime"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != httpAdapterImportPath {
+		if entry.Package != httpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, httpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, httpAdapterServiceRootImportPath, httpAdapterImportPath)
 }

--- a/pkg/services/factory_runtime/transports/mcp/manifest_registration_test.go
+++ b/pkg/services/factory_runtime/transports/mcp/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	mcpAdapterPackagePath = "pkg/services/factory_runtime/transports/mcp"
-	mcpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/mcp"
-	factoryRuntimeOwner   = "factory_runtime"
+	mcpAdapterPackagePath           = "pkg/services/factory_runtime/transports/mcp"
+	mcpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/factory_runtime/transports/mcp"
+	mcpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryRuntimeOwner             = "factory_runtime"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != mcpAdapterImportPath {
+		if entry.Package != mcpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, mcpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, mcpAdapterServiceRootImportPath, mcpAdapterImportPath)
 }

--- a/pkg/services/factory_sessions/transports/http/manifest_registration_test.go
+++ b/pkg/services/factory_sessions/transports/http/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	httpAdapterPackagePath = "pkg/services/factory_sessions/transports/http"
-	httpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/factory_sessions/transports/http"
-	factorySessionsOwner   = "factory_sessions"
+	httpAdapterPackagePath           = "pkg/services/factory_sessions/transports/http"
+	httpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/factory_sessions/transports/http"
+	httpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factorySessionsOwner             = "factory_sessions"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != httpAdapterImportPath {
+		if entry.Package != httpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, httpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, httpAdapterServiceRootImportPath, httpAdapterImportPath)
 }

--- a/pkg/services/factory_sessions/transports/mcp/manifest_registration_test.go
+++ b/pkg/services/factory_sessions/transports/mcp/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	mcpAdapterPackagePath = "pkg/services/factory_sessions/transports/mcp"
-	mcpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/factory_sessions/transports/mcp"
-	factorySessionsOwner  = "factory_sessions"
+	mcpAdapterPackagePath           = "pkg/services/factory_sessions/transports/mcp"
+	mcpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/factory_sessions/transports/mcp"
+	mcpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factorySessionsOwner            = "factory_sessions"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != mcpAdapterImportPath {
+		if entry.Package != mcpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, mcpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, mcpAdapterServiceRootImportPath, mcpAdapterImportPath)
 }

--- a/pkg/services/factory_visualization/transports/http/manifest_registration_test.go
+++ b/pkg/services/factory_visualization/transports/http/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	httpAdapterPackagePath  = "pkg/services/factory_visualization/transports/http"
-	httpAdapterImportPath   = "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/http"
-	factoryVisualizationOwner = "factory_visualization"
+	httpAdapterPackagePath           = "pkg/services/factory_visualization/transports/http"
+	httpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/http"
+	httpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	factoryVisualizationOwner        = "factory_visualization"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != httpAdapterImportPath {
+		if entry.Package != httpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, httpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, httpAdapterServiceRootImportPath, httpAdapterImportPath)
 }

--- a/pkg/services/factory_visualization/transports/mcp/manifest_registration_test.go
+++ b/pkg/services/factory_visualization/transports/mcp/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	mcpAdapterPackagePath = "pkg/services/factory_visualization/transports/mcp"
-	mcpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/mcp"
-	factoryVisualizationOwner = "factory_visualization"
+	mcpAdapterPackagePath           = "pkg/services/factory_visualization/transports/mcp"
+	mcpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/factory_visualization/transports/mcp"
+	mcpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	factoryVisualizationOwner       = "factory_visualization"
 )
 
 type coverageMinimumManifest struct {
@@ -135,19 +136,19 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != mcpAdapterImportPath {
+		if entry.Package != mcpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Exception != nil {
 			if entry.Exception.Kind != "measurement" {
-				t.Fatalf("%s coverage exception kind for %q = %q, want measurement", lane, mcpAdapterImportPath, entry.Exception.Kind)
+				t.Fatalf("%s coverage exception kind for %q = %q, want measurement", lane, mcpAdapterServiceRootImportPath, entry.Exception.Kind)
 			}
 			return
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, mcpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, mcpAdapterServiceRootImportPath, mcpAdapterImportPath)
 }

--- a/pkg/services/models/transports/http/manifest_registration_test.go
+++ b/pkg/services/models/transports/http/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	httpAdapterPackagePath = "pkg/services/models/transports/http"
-	httpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/models/transports/http"
-	modelsOwner            = "models"
+	httpAdapterPackagePath           = "pkg/services/models/transports/http"
+	httpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/models/transports/http"
+	httpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/models"
+	modelsOwner                      = "models"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != httpAdapterImportPath {
+		if entry.Package != httpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, httpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, httpAdapterServiceRootImportPath, httpAdapterImportPath)
 }

--- a/pkg/services/models/transports/mcp/manifest_registration_test.go
+++ b/pkg/services/models/transports/mcp/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	mcpAdapterPackagePath = "pkg/services/models/transports/mcp"
-	mcpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/models/transports/mcp"
-	modelsOwner           = "models"
+	mcpAdapterPackagePath           = "pkg/services/models/transports/mcp"
+	mcpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/models/transports/mcp"
+	mcpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/models"
+	modelsOwner                     = "models"
 )
 
 type coverageMinimumManifest struct {
@@ -135,19 +136,19 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != mcpAdapterImportPath {
+		if entry.Package != mcpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Exception != nil {
 			if entry.Exception.Kind != "measurement" {
-				t.Fatalf("%s coverage exception kind for %q = %q, want measurement", lane, mcpAdapterImportPath, entry.Exception.Kind)
+				t.Fatalf("%s coverage exception kind for %q = %q, want measurement", lane, mcpAdapterServiceRootImportPath, entry.Exception.Kind)
 			}
 			return
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, mcpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, mcpAdapterServiceRootImportPath, mcpAdapterImportPath)
 }

--- a/pkg/services/operator_settings/transports/cli/manifest_registration_test.go
+++ b/pkg/services/operator_settings/transports/cli/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	cliAdapterPackagePath = "pkg/services/operator_settings/transports/cli"
-	cliAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/cli"
-	operatorSettingsOwner = "operator_settings"
+	cliAdapterPackagePath           = "pkg/services/operator_settings/transports/cli"
+	cliAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/cli"
+	cliAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	operatorSettingsOwner           = "operator_settings"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != cliAdapterImportPath {
+		if entry.Package != cliAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, cliAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, cliAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, cliAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, cliAdapterServiceRootImportPath, cliAdapterImportPath)
 }

--- a/pkg/services/operator_settings/transports/http/manifest_registration_test.go
+++ b/pkg/services/operator_settings/transports/http/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	httpAdapterPackagePath = "pkg/services/operator_settings/transports/http"
-	httpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/http"
-	operatorSettingsOwner  = "operator_settings"
+	httpAdapterPackagePath           = "pkg/services/operator_settings/transports/http"
+	httpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/http"
+	httpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	operatorSettingsOwner            = "operator_settings"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != httpAdapterImportPath {
+		if entry.Package != httpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, httpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, httpAdapterServiceRootImportPath, httpAdapterImportPath)
 }

--- a/pkg/services/operator_settings/transports/mcp/manifest_registration_test.go
+++ b/pkg/services/operator_settings/transports/mcp/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	mcpAdapterPackagePath = "pkg/services/operator_settings/transports/mcp"
-	mcpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/mcp"
-	operatorSettingsOwner = "operator_settings"
+	mcpAdapterPackagePath           = "pkg/services/operator_settings/transports/mcp"
+	mcpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/mcp"
+	mcpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	operatorSettingsOwner           = "operator_settings"
 )
 
 type coverageMinimumManifest struct {
@@ -135,19 +136,19 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != mcpAdapterImportPath {
+		if entry.Package != mcpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Exception != nil {
 			if entry.Exception.Kind != "measurement" {
-				t.Fatalf("%s coverage exception kind for %q = %q, want measurement", lane, mcpAdapterImportPath, entry.Exception.Kind)
+				t.Fatalf("%s coverage exception kind for %q = %q, want measurement", lane, mcpAdapterServiceRootImportPath, entry.Exception.Kind)
 			}
 			return
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, mcpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, mcpAdapterServiceRootImportPath, mcpAdapterImportPath)
 }

--- a/pkg/services/operator_settings/wire/manifest_registration_test.go
+++ b/pkg/services/operator_settings/wire/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	settingsWirePackagePath = "pkg/services/operator_settings/wire"
-	settingsWireImportPath  = "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
-	settingsOwner           = "operator_settings"
+	settingsWirePackagePath           = "pkg/services/operator_settings/wire"
+	settingsWireImportPath            = "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire"
+	settingsWireServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	settingsOwner                     = "operator_settings"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != settingsWireImportPath {
+		if entry.Package != settingsWireServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, settingsWireImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, settingsWireServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, settingsWireImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, settingsWireServiceRootImportPath, settingsWireImportPath)
 }

--- a/pkg/services/providers/transports/http/manifest_registration_test.go
+++ b/pkg/services/providers/transports/http/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	httpAdapterPackagePath = "pkg/services/providers/transports/http"
-	httpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/providers/transports/http"
-	providersOwner         = "providers"
+	httpAdapterPackagePath           = "pkg/services/providers/transports/http"
+	httpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/providers/transports/http"
+	httpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/providers"
+	providersOwner                   = "providers"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != httpAdapterImportPath {
+		if entry.Package != httpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, httpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, httpAdapterServiceRootImportPath, httpAdapterImportPath)
 }

--- a/pkg/services/providers/transports/mcp/manifest_registration_test.go
+++ b/pkg/services/providers/transports/mcp/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	mcpAdapterPackagePath = "pkg/services/providers/transports/mcp"
-	mcpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/providers/transports/mcp"
-	providersOwner        = "providers"
+	mcpAdapterPackagePath           = "pkg/services/providers/transports/mcp"
+	mcpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/providers/transports/mcp"
+	mcpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/providers"
+	providersOwner                  = "providers"
 )
 
 type coverageMinimumManifest struct {
@@ -135,19 +136,19 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != mcpAdapterImportPath {
+		if entry.Package != mcpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Exception != nil {
 			if entry.Exception.Kind != "measurement" {
-				t.Fatalf("%s coverage exception kind for %q = %q, want measurement", lane, mcpAdapterImportPath, entry.Exception.Kind)
+				t.Fatalf("%s coverage exception kind for %q = %q, want measurement", lane, mcpAdapterServiceRootImportPath, entry.Exception.Kind)
 			}
 			return
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, mcpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, mcpAdapterServiceRootImportPath, mcpAdapterImportPath)
 }

--- a/pkg/services/providers/wire/manifest_registration_test.go
+++ b/pkg/services/providers/wire/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	providersWirePackagePath = "pkg/services/providers/wire"
-	providersWireImportPath  = "github.com/portpowered/infinite-you/pkg/services/providers/wire"
-	providersOwner           = "providers"
+	providersWirePackagePath           = "pkg/services/providers/wire"
+	providersWireImportPath            = "github.com/portpowered/infinite-you/pkg/services/providers/wire"
+	providersWireServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/providers"
+	providersOwner                     = "providers"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != providersWireImportPath {
+		if entry.Package != providersWireServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, providersWireImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, providersWireServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, providersWireImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, providersWireServiceRootImportPath, providersWireImportPath)
 }

--- a/pkg/services/recordings/transports/mcp/manifest_registration_test.go
+++ b/pkg/services/recordings/transports/mcp/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	mcpAdapterPackagePath = "pkg/services/recordings/transports/mcp"
-	mcpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/recordings/transports/mcp"
-	recordingsOwner       = "recordings"
+	mcpAdapterPackagePath           = "pkg/services/recordings/transports/mcp"
+	mcpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/recordings/transports/mcp"
+	mcpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/recordings"
+	recordingsOwner                 = "recordings"
 )
 
 type coverageMinimumManifest struct {
@@ -135,19 +136,19 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != mcpAdapterImportPath {
+		if entry.Package != mcpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Exception != nil {
 			if entry.Exception.Kind != "measurement" {
-				t.Fatalf("%s coverage exception kind for %q = %q, want measurement", lane, mcpAdapterImportPath, entry.Exception.Kind)
+				t.Fatalf("%s coverage exception kind for %q = %q, want measurement", lane, mcpAdapterServiceRootImportPath, entry.Exception.Kind)
 			}
 			return
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, mcpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, mcpAdapterServiceRootImportPath, mcpAdapterImportPath)
 }

--- a/pkg/services/system_initialization/transports/cli/manifest_registration_test.go
+++ b/pkg/services/system_initialization/transports/cli/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	cliAdapterPackagePath     = "pkg/services/system_initialization/transports/cli"
-	cliAdapterImportPath      = "github.com/portpowered/infinite-you/pkg/services/system_initialization/transports/cli"
-	systemInitializationOwner = "system_initialization"
+	cliAdapterPackagePath           = "pkg/services/system_initialization/transports/cli"
+	cliAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/system_initialization/transports/cli"
+	cliAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/system_initialization"
+	systemInitializationOwner       = "system_initialization"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != cliAdapterImportPath {
+		if entry.Package != cliAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, cliAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, cliAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, cliAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, cliAdapterServiceRootImportPath, cliAdapterImportPath)
 }

--- a/pkg/services/system_initialization/wire/manifest_registration_test.go
+++ b/pkg/services/system_initialization/wire/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	bootstrapWirePackagePath = "pkg/services/system_initialization/wire"
-	bootstrapWireImportPath  = "github.com/portpowered/infinite-you/pkg/services/system_initialization/wire"
-	systemInitializationOwner = "system_initialization"
+	bootstrapWirePackagePath           = "pkg/services/system_initialization/wire"
+	bootstrapWireImportPath            = "github.com/portpowered/infinite-you/pkg/services/system_initialization/wire"
+	bootstrapWireServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/system_initialization"
+	systemInitializationOwner          = "system_initialization"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != bootstrapWireImportPath {
+		if entry.Package != bootstrapWireServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, bootstrapWireImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, bootstrapWireServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, bootstrapWireImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, bootstrapWireServiceRootImportPath, bootstrapWireImportPath)
 }

--- a/pkg/services/work/transports/http/manifest_registration_test.go
+++ b/pkg/services/work/transports/http/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	httpAdapterPackagePath = "pkg/services/work/transports/http"
-	httpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/work/transports/http"
-	workOwner              = "work"
+	httpAdapterPackagePath           = "pkg/services/work/transports/http"
+	httpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/work/transports/http"
+	httpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/work"
+	workOwner                        = "work"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != httpAdapterImportPath {
+		if entry.Package != httpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, httpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, httpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, httpAdapterServiceRootImportPath, httpAdapterImportPath)
 }

--- a/pkg/services/work/transports/mcp/manifest_registration_test.go
+++ b/pkg/services/work/transports/mcp/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	mcpAdapterPackagePath = "pkg/services/work/transports/mcp"
-	mcpAdapterImportPath  = "github.com/portpowered/infinite-you/pkg/services/work/transports/mcp"
-	workOwner             = "work"
+	mcpAdapterPackagePath           = "pkg/services/work/transports/mcp"
+	mcpAdapterImportPath            = "github.com/portpowered/infinite-you/pkg/services/work/transports/mcp"
+	mcpAdapterServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/work"
+	workOwner                       = "work"
 )
 
 type coverageMinimumManifest struct {
@@ -135,19 +136,19 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != mcpAdapterImportPath {
+		if entry.Package != mcpAdapterServiceRootImportPath {
 			continue
 		}
 		if entry.Exception != nil {
 			if entry.Exception.Kind != "measurement" {
-				t.Fatalf("%s coverage exception kind for %q = %q, want measurement", lane, mcpAdapterImportPath, entry.Exception.Kind)
+				t.Fatalf("%s coverage exception kind for %q = %q, want measurement", lane, mcpAdapterServiceRootImportPath, entry.Exception.Kind)
 			}
 			return
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, mcpAdapterServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, mcpAdapterImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, mcpAdapterServiceRootImportPath, mcpAdapterImportPath)
 }

--- a/pkg/services/work/wire/manifest_registration_test.go
+++ b/pkg/services/work/wire/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	workWirePackagePath = "pkg/services/work/wire"
-	workWireImportPath  = "github.com/portpowered/infinite-you/pkg/services/work/wire"
-	workOwner           = "work"
+	workWirePackagePath           = "pkg/services/work/wire"
+	workWireImportPath            = "github.com/portpowered/infinite-you/pkg/services/work/wire"
+	workWireServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/work"
+	workOwner                     = "work"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != workWireImportPath {
+		if entry.Package != workWireServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, workWireImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, workWireServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, workWireImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, workWireServiceRootImportPath, workWireImportPath)
 }

--- a/pkg/services/workers/wire/manifest_registration_test.go
+++ b/pkg/services/workers/wire/manifest_registration_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	workersWirePackagePath = "pkg/services/workers/wire"
-	workersWireImportPath  = "github.com/portpowered/infinite-you/pkg/services/workers/wire"
-	workersOwner           = "workers"
+	workersWirePackagePath           = "pkg/services/workers/wire"
+	workersWireImportPath            = "github.com/portpowered/infinite-you/pkg/services/workers/wire"
+	workersWireServiceRootImportPath = "github.com/portpowered/infinite-you/pkg/services/workers"
+	workersOwner                     = "workers"
 )
 
 type coverageMinimumManifest struct {
@@ -132,13 +133,13 @@ func assertCoverageMinimumRegistration(t *testing.T, lane string, relativePath s
 	}
 
 	for _, entry := range manifest.Packages {
-		if entry.Package != workersWireImportPath {
+		if entry.Package != workersWireServiceRootImportPath {
 			continue
 		}
 		if entry.Minimum < 0 {
-			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, workersWireImportPath)
+			t.Fatalf("%s coverage minimum for %q must be non-negative", lane, workersWireServiceRootImportPath)
 		}
 		return
 	}
-	t.Fatalf("%s coverage manifest missing %q", lane, workersWireImportPath)
+	t.Fatalf("%s coverage manifest missing service root %q declaring %q", lane, workersWireServiceRootImportPath, workersWireImportPath)
 }


### PR DESCRIPTION
## Summary

Removes the coverage-manifest registration tax described by D1/D2/D3 in
`docs/temp/scale-program-rules.md` (DECOUPLING PROGRAM). A measured package with
no manifest row is now held to its lane's default floor instead of failing
completeness, a package with no measurable statements passes vacuously with no
row at all, and completeness is checked once per `pkg/services/<name>` service
instead of once per package.

**No existing floor value changes and no minimum row is dropped.**

### Measured on this branch

| | unit | functional | total |
|---|---|---|---|
| package rows before | 526 | 526 | 1052 |
| package rows after | 470 | 350 | 820 |
| exception rows before | 68 | 186 | **254** |
| exception rows after | 2 | 3 | **5** |

The 249 auto-generated `measurement` exceptions whose justification only restated
*"the active &lt;lane&gt; coverage profile contains no measurable statements for this
package"* are retired: 238 deleted outright and 11 converted to service-root
declarations. The 5 survivors are the genuine hand-written ones — 3 `measurement`
exceptions with real justifications and the 2 deadline-bound `migration`
exceptions.

### Three added row categories, and why each exists

1. **`defaultFloorPercent`** — unit `50.00`, functional `0.00`, one field per file.
2. **11 service-root declarations at `0.00`.** Those roots carried an
   auto-measurement exception, so retiring it would have removed the row
   per-service completeness now needs. Their floors are inert today because a
   package with no measurable statements passes vacuously; recording anything
   higher would fabricate a floor for a package the profile has never measured,
   and `-update-manifest` raises the row from samples once the root is measured.
3. **6 unit floors for packages whose exception was stale.** See below — this is
   the one finding worth reviewing carefully.

### The stale-exception finding

Six retired unit exceptions were not describing reality. `-update-manifest` copies
exception rows verbatim and never converts one back into a numeric floor, so an
exception minted while a package was unlinked survives after tests start reaching
it. Cross-checking every retired row against the **green** `Backend Unit Coverage`
job on main `217066ad6` ([run 32062198018](https://github.com/portpowered/you-agent-factory/actions/runs/32062198018), job 95485943463, total 80.6%) shows all
six are measured, and all six sit below the 50.00 unit default:

| package | measured | recorded floor |
|---|---|---|
| `pkg/initializer` | 44.4% | 43.00 |
| `pkg/services/factory_runtime/internal/services/orchestration` | 42.9% | 41.00 |
| `pkg/services/factory_visualization/internal/services/activation_lifecycle` | 0.0% | 0.00 |
| `pkg/services/models/internal/services/inference` | 50.0% | 49.00 |
| `pkg/services/work/internal/services/content_materialization` | 0.0% | 0.00 |
| `pkg/services/workers/internal/execution` | 39.0% | 38.00 |

Retiring those exceptions without a floor would have taken all six from *never
evaluated* to *held at 50.00* and turned the unit gate red. Each now carries an
explicit minimum, which is how the manifest already treats every other measurable
package. The checker summary reports coverage at one decimal, so each floor is
recorded a full percentage point below the observation rather than at it;
`-update-manifest` raises them to the exact sampled minimum on the next
five-profile run. Every one is a net strengthening: an unevaluated exception
becomes an enforced floor.

The functional lane needs no equivalent rows because its default floor is `0.00`,
which no measurement can fall below.

### Test files that asserted the retired rules

The 27 `pkg/services/**/manifest_registration_test.go` files asserted per-package
registration. They now assert the rule that replaced it — the package's *service*
declares a floor at its root. Their `package-target-manifest.json` and
`ownership-inventory.json` assertions are untouched; those registries belong to
`dcp-2`.

### Verification

- `go vet ./cmd/gocoveragecheck/...`, `go test ./cmd/gocoveragecheck/...` — green.
- All 27 `TestManifestRegistration_*` packages — green.
- `backend-size`, `pkg-maint`, `pkg-file-count`, `pkg-structure` — green.
  `make lint` end-to-end is not required (`pkg-boundary` carries pre-existing
  packaged-service-structure migration debt recorded 2026-08-08).
- Unit-lane checker run end-to-end against the **final** manifest over the full
  526-package measured set: **0 manifest validation errors**, so parse and
  per-service completeness hold on the real files.
- Manifest diff invariants proven by script: 0 existing minimum values changed,
  0 minimum rows dropped, added rows are exactly the 11 service roots + the 6
  stale-exception floors, both files sorted and unique, all 18 service roots
  declared exactly once per manifest.
- Lane totals (unit 75.9, functional 33.1) are untouched; this change does not
  alter the measured package set.

The hosted unit and functional coverage gates run on this head.

---

## PRD

```json
{
  "project": "you-agent-factory",
  "branchName": "dcp-1-coverage-default-floor-and-per-service-completeness",
  "description": "Change cmd/gocoveragecheck and the two coverage manifests (unit, functional) so a measured Go package with no manifest entry is held to its lane's default floor instead of failing completeness (D1), a package with zero measurable statements passes automatically with no exception row (D2), and completeness for pkg/services/* packages is checked per-service (18 root entries) instead of per-package (526 rows) (D3). No existing floor number, either lane's total, ownership-inventory.json, package-target-manifest.json, or any Go package is added/removed/changed by this lane.",
  "context": {
    "customerAsk": "Cut the manifest-editing tax so an ordinary lane that adds a package inside an existing service no longer has to hand-write coverage floor rows in two files just to pass the coverage gate.",
    "problem": "The coverage completeness check in cmd/gocoveragecheck requires every measured Go package to have an explicit manifest row (minimum or exception) in both docs/internal/baselines/go-unit-coverage-package-minimums.json and go-functional-coverage-package-minimums.json. Measured on main 6fb128ab3: 526 per-package rows total, 254 of them exception entries, and 249 of those exist only to record 'no measurable statements for this package' -- a fact already derivable from the coverage profile. Every lane that adds a package pays this registration tax.",
    "solution": "Implement three checker-level changes from operator design decisions D1-D3 in docs/temp/scale-program-rules.md (section 'DECOUPLING PROGRAM (dcp-*)'): (1) a per-lane default floor (unit 50.00, functional 0.00) applied to any measured package with no manifest entry, with explicit entries always winning; (2) a vacuous pass for packages with zero measurable statements, requiring no manifest entry, and removal of the now-redundant 'no measurable statements' exception rows; (3) per-service completeness for pkg/services/<name>/... packages -- one root-floor entry per service (18 total) instead of one entry per package (526), where a service with no root entry still fails but a new package inside an already-declared service does not. No existing floor number or lane total changes."
  },
  "acceptanceCriteria": [
    "A newly measured package with no manifest entry, whose coverage profile shows measurable statements, is evaluated against its lane's default floor (unit 50.00, functional 0.00) and named in checker output -- not skipped and not a completeness failure; a package below the default fails, a package at/above it passes.",
    "An explicit per-package minimum entry is always evaluated in preference to the lane default, including when the explicit floor is above the default; no existing minimum value is changed.",
    "A package whose coverage profile reports zero measurable statements passes with no manifest entry required; the auto-generated 'no measurable statements' exception rows are removed from both manifest files, dropping the combined exception count from 254 to only the genuine deadline-bound migration-kind exceptions (report the exact before/after counts measured on the branch).",
    "Completeness for pkg/services/<name>/... packages is evaluated per service: each of the 18 services has exactly one root-floor entry per manifest; a service with no root entry fails completeness by name (not by enumerating every package under it), while a new package inside a service that already has a root entry does not fail completeness.",
    "Neither manifest's existing floor numbers change and the lane totals (unit 75.9, functional 33.1) are unchanged; both hosted coverage gates (unit and functional -package-manifest runs) pass at those unchanged totals on the PR's final head.",
    "Quality gate: go vet ./... passes, cmd/gocoveragecheck unit tests pass, and there are no NEW lint violations relative to current main; the gates green on main today (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. make lint end-to-end is not required to pass because pkg-boundary carries pre-existing packaged-service-structure migration debt recorded 2026-08-08.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "dcp-1-coverage-default-floor-and-per-service-completeness-001",
      "title": "Default floor applies to unlisted measured packages",
      "description": "As a maintainer who adds a package with no manifest entry, I want the coverage gate to hold it to my lane's default floor instead of failing outright, so that adding a package doesn't require a manifest edit just to keep the gate green.",
      "acceptanceCriteria": [
        "Each coverage manifest (go-unit-coverage-package-minimums.json, go-functional-coverage-package-minimums.json) carries a new manifest-level defaultFloorPercent field: 50.00 for the unit manifest, 0.00 for the functional manifest.",
        "The checker evaluates a measured package with no manifest entry against its lane's defaultFloorPercent instead of reporting a completeness failure, and names the package in checker output either way.",
        "A measured package with no manifest entry whose actual coverage is below the lane default fails the run with a 'package coverage regression:' diagnostic naming the package and the default floor used.",
        "A measured package with no manifest entry whose actual coverage is at/above the lane default passes.",
        "An existing package with an explicit minimum entry above the lane default is still held to its explicit, higher floor.",
        "Add cmd/gocoveragecheck unit tests proving all four cases above independently for both the unit and functional lane's default (8 cases total), so the two lanes' defaults cannot bleed into each other.",
        "Typecheck passes (go vet ./cmd/gocoveragecheck/...).",
        "Tests pass (go test ./cmd/gocoveragecheck/...)."
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented. coverageManifest.DefaultFloorPercent (optional `defaultFloorPercent`) plus built-in lane defaults (unit 50.00, functional 0.00) in cmd/gocoveragecheck/manifest_default_floor.go. checkCoverageDefaultFloor evaluates every measured package with no row; failures carry floor-source=lane-default. Per-package completeness failure removed. Both manifests now declare the field. 8-case table test TestCheckCoverageDefaultFloorEvaluatesUnlistedPackagesPerLane proves the four cases per lane and pins anti-bleed (same 40/100 totals fail unit, pass functional). go vet + go test ./cmd/gocoveragecheck/... green."
    },
    {
      "id": "dcp-1-coverage-default-floor-and-per-service-completeness-002",
      "title": "Vacuous pass retires the 'no measurable statements' exceptions",
      "description": "As a maintainer, I want a package with zero measurable statements to pass automatically with no manifest entry, so the manifest files stop carrying hundreds of rows that only restate what the coverage profile already reports.",
      "acceptanceCriteria": [
        "The checker treats a measured package whose coverage profile reports zero measurable statements (totalStatements == 0) as an automatic pass, independent of defaultFloorPercent from story 001, and requires no manifest entry -- present or absent, the package passes and is not reported as a completeness gap.",
        "The measurement-kind exception rows in both manifest files whose justification is exactly 'the active {lane} coverage profile contains no measurable statements for this package' are removed; genuine deadline-bound migration-kind exceptions are left untouched.",
        "State the exact before/after exception-row counts in the PR description: 254 total (66 unit + 183 functional) before, and the remaining genuine migration-kind count after, measured on the branch.",
        "Add cmd/gocoveragecheck unit tests proving: (a) a zero-measurable-statement package with no manifest entry passes; (b) a zero-measurable-statement package with a stale measurement-kind exception entry still passes; (c) removing a measurement-kind exception for a zero-measurable-statement package does not turn it into a completeness failure.",
        "Typecheck passes (go vet ./cmd/gocoveragecheck/...).",
        "Tests pass (go test ./cmd/gocoveragecheck/...)."
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented. coveragePassesFloor returns true when totalStatements<=0, so the vacuous pass applies to explicit floors and the lane default alike; generation and -update-manifest no longer mint measurement exceptions. Measured on the branch: exception rows 254 -> 5 (unit 68 -> 2, functional 186 -> 3); package rows 1052 -> 814 -> 820 after the six stale-exception floors. 249 auto-measurement rows retired: 238 deleted, 11 converted to service-root declarations. Six unit rows were STALE (measurable in the real profile, below 50.00) and now carry explicit floors instead - see story 004 notes. Tests: TestZeroStatementPackagePassesWithoutAnyManifestEntry, ...WithAStaleMeasurementException, TestRemovingAMeasurementExceptionKeepsAZeroStatementPackagePassing, TestUpdateManifestMintsNoRowForAnUnmeasurablePackage."
    },
    {
      "id": "dcp-1-coverage-default-floor-and-per-service-completeness-003",
      "title": "Per-service completeness replaces per-package completeness",
      "description": "As a maintainer who adds a package inside an existing, already-guarded service, I want the coverage gate's completeness check to pass without a new manifest row, while a genuinely new, unguarded service still fails, so completeness tracks real risk instead of directory-tree restatement.",
      "acceptanceCriteria": [
        "Each coverage manifest carries exactly one root-floor entry (explicit minimum or a genuine migration-kind exception) per pkg/services/<name> service -- 18 entries per manifest -- for the services present under pkg/services/ today.",
        "Completeness for a package under pkg/services/<name>/... is satisfied when that service's root entry exists in the manifest; the package itself needs no entry of its own and is evaluated per stories 001/002.",
        "Completeness for a pkg/services/<name>/... package whose service has NO root entry anywhere in the manifest fails, and the failure names the service once, not once per package under it.",
        "Completeness for measured packages outside pkg/services/ (e.g. pkg/platform, pkg/initializer, pkg/transports, pkg/wire, pkg/root, cmd/...) is unaffected by this story -- they continue to resolve via stories 001/002 with no per-package completeness requirement.",
        "Add cmd/gocoveragecheck unit tests proving: (a) a new package inside a service that already has a root entry passes completeness and is evaluated at the applicable floor; (b) a new package inside a service with no root entry anywhere fails completeness naming the service; (c) removing a service's root entry while packages remain under it fails completeness for that service.",
        "Typecheck passes (go vet ./cmd/gocoveragecheck/...).",
        "Tests pass (go test ./cmd/gocoveragecheck/...)."
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented. validateCoverageManifestServiceRoots requires one pkg/services/<name> root row per measured service and names an undeclared service once, not once per package. Verified programmatically: all 18 services declared exactly once in both manifests. Packages outside pkg/services carry no completeness requirement. Tests: TestValidateCoverageManifestReportsEachUndeclaredServiceOnce, TestValidateCoverageManifestAcceptsNewPackagesInsideDeclaredService, plus the non-service case in TestCheckCoverageManifestControlledProfilesForBothLanes. The 27 pkg/services/**/manifest_registration_test.go files were repointed from per-package to per-service-root registration."
    },
    {
      "id": "dcp-1-coverage-default-floor-and-per-service-completeness-004",
      "title": "Both hosted coverage gates stay green at unchanged totals",
      "description": "As a reviewer, I need direct proof that this change does not move any existing floor or either lane's total, so I can approve it as a pure tax-removal change rather than a coverage-standard change.",
      "acceptanceCriteria": [
        "Run the unit-lane and functional-lane coverage checks (go run ./cmd/gocoveragecheck ... -package-manifest for both manifests, matching the Makefile's existing invocations) on the final branch head and confirm both are green.",
        "Grep each run's output for 'package coverage regression:' and confirm it is empty for both lanes.",
        "Confirm the unit lane total (75.9) and functional lane total (33.1) are unchanged from main.",
        "Diff both manifests against main and confirm the only changes are: added defaultFloorPercent fields, removed measurement-exception rows from story 002, and added/adjusted service-root rows from story 003 -- no existing minimum value changed.",
        "Post the grep output and the two totals in a PR comment, never in a commit.",
        "Typecheck passes (go vet ./...).",
        "Tests pass (go test ./cmd/gocoveragecheck/... and the two coverage Make targets used above)."
      ],
      "priority": 4,
      "passes": true,
      "notes": "Verified as far as the implementation stage owns. Ran the unit-lane checker against the FINAL manifest end-to-end (go run ./cmd/gocoveragecheck -suite unit -package-manifest ... over the full 526-package measured set): 0 manifest validation errors, so parse + per-service completeness hold on the real files. Cross-checked every retired row against the green Backend Unit Coverage job on main 217066ad6 (CI run 32062198018, job 95485943463, total 80.6%): that log names the 51 packages with no profile measurement and every package's coverage. Result: 0 unlisted+measured unit packages fall below the 50.00 default after the six stale-exception floors were added; the functional default of 0.00 makes that lane unconditionally safe. Manifest diff invariants proven by script: 0 existing minimum values changed, 0 minimum rows dropped, added rows are exactly the 11 service roots + the 6 stale-exception floors, both files sorted and unique, all 18 roots present. Lane totals untouched (no measured package set change). backend-size, pkg-maint, pkg-file-count, pkg-structure all pass; go vet clean. The hosted unit and functional coverage gates run on the PR head; driving them to terminal-and-passing is the review stage's job per the delivery criterion."
    }
  ]
}
```

