### PR TITLE
cov-r1-functional-coverage-and-timing-report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,12 @@ jobs:
     # always-run summary and artifact-upload steps can preserve partial
     # diagnostics after a timeout.
     timeout-minutes: 80
+    # The functional lane upserts its own reporting comment on the pull
+    # request, mirroring Backend Lint. Every other permission stays at the
+    # workflow-level read-only default.
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
     strategy:
@@ -269,6 +275,64 @@ jobs:
           path: .artifacts/functional-test-viz/real-acpx-evidence.json
           if-no-files-found: error
           retention-days: 14
+      # Reporting only. Both steps below are fail-open: a missing or malformed
+      # artifact writes an explicit "unavailable" body and exits 0, so a
+      # renderer or API failure can never turn a passing suite red.
+      - name: Render functional coverage pull request comment
+        if: always() && matrix.suite == 'functional'
+        continue-on-error: true
+        run: bash scripts/ci/publish-functional-coverage-comment.sh
+        env:
+          FUNCTIONAL_TEST_VIZ_DIR: .artifacts/functional-test-viz
+          FUNCTIONAL_TEST_VIZ_TIMING: .artifacts/functional-test-viz/functional-timing-summary.json
+          FUNCTIONAL_TEST_VIZ_JSON: .artifacts/functional-test-viz/coverage-summary.json
+          FUNCTIONAL_COVERAGE_COMMENT_FILE: .artifacts/functional-test-viz/functional-coverage-comment.md
+          FUNCTIONAL_COVERAGE_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Publish functional coverage inventory to the pull request
+        if: always() && matrix.suite == 'functional' && github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          FUNCTIONAL_COVERAGE_COMMENT_FILE: .artifacts/functional-test-viz/functional-coverage-comment.md
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('node:fs');
+            const commentPath = `${process.env.GITHUB_WORKSPACE}/${process.env.FUNCTIONAL_COVERAGE_COMMENT_FILE}`;
+            let body = '';
+            try {
+              body = fs.readFileSync(commentPath, 'utf8');
+            } catch (error) {
+              core.info(`functional coverage comment body unavailable at ${commentPath}: ${error.message}`);
+              return;
+            }
+            if (!body.trim()) {
+              core.info('functional coverage comment body is empty; nothing to publish.');
+              return;
+            }
+            const { upsertFunctionalCoverageComment } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/ci/functional-coverage-comment.mjs`);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const publication = upsertFunctionalCoverageComment(comments, body);
+            if (publication.action === 'update') {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: publication.commentId,
+                body: publication.body,
+              });
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: publication.body,
+            });
 
   backend-lint:
     name: Backend Lint

--- a/Makefile
+++ b/Makefile
@@ -481,7 +481,7 @@ readme-check:
 test: test-unit test-ci-workflows
 
 test-ci-workflows:
-	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs scripts/ci/lane-budget.test.mjs scripts/ci/backend-lint-report.test.mjs scripts/ci/backend-lint-workflow.test.mjs
+	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs scripts/ci/lane-budget.test.mjs scripts/ci/backend-lint-report.test.mjs scripts/ci/backend-lint-workflow.test.mjs scripts/ci/functional-coverage-comment.test.mjs
 
 test-full:
 	$(GO) test ./... -timeout $(GO_TEST_TIMEOUT)

--- a/cmd/gocoveragecheck/coverage_verdict.go
+++ b/cmd/gocoveragecheck/coverage_verdict.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// functionalCoverageSuite is the lane whose log is rendered as a compact
+// ordered verdict block instead of one raw coverage line per measured package.
+const functionalCoverageSuite = "functional"
+
+// nearFloorCoverageReportLimit caps how many passing near-floor packages the
+// verdict block names. The block stays readable at a glance while the omitted
+// count keeps the report honest about what it did not print.
+const nearFloorCoverageReportLimit = 10
+
+// nearFloorCoverageHeadroomPoints is the headroom in percentage points below
+// which a passing gated package is reported as near its floor.
+const nearFloorCoverageHeadroomPoints = 2.0
+
+// packageCoverageVerdict is one gated package's measured distance to its floor.
+// Headroom is negative exactly when the measurement is below the floor.
+type packageCoverageVerdict struct {
+	importPath      string
+	floor           float64
+	actual          float64
+	headroom        float64
+	covered         int
+	measurable      int
+	uncoveredBlocks int
+}
+
+// writeCoverageLaneReport prints a lane's per-package coverage result.
+//
+// The functional lane replaces the raw "coverage: N% of statements" line per
+// measured package — 300+ consecutive lines that bury the one actionable
+// verdict — with a compact ordered block: floor violations first, then the
+// packages closest to their floor, then a single tally line. No per-package
+// data is lost: the complete set is still written to the -json-output
+// coverage-summary artifact that the CI job uploads and renders.
+//
+// Every other lane keeps the raw per-package listing unchanged.
+func writeCoverageLaneReport(cfg config, result coverageResult, failures []string) {
+	if cfg.suite != functionalCoverageSuite {
+		writePackageCoverageSummaries(result.packageSummaries)
+		return
+	}
+	writeFunctionalCoverageVerdict(result, failures)
+}
+
+// writeFunctionalCoverageVerdict renders the ordered functional verdict block.
+func writeFunctionalCoverageVerdict(result coverageResult, failures []string) {
+	verdicts := collectPackageCoverageVerdicts(result)
+	belowFloor, nearFloor := partitionPackageCoverageVerdicts(verdicts)
+
+	fmt.Fprintln(stdoutWriter, "Functional package coverage verdict:")
+	writeBelowFloorCoverageLines(belowFloor)
+	writeNearFloorCoverageLines(nearFloor)
+	fmt.Fprintf(
+		stdoutWriter,
+		"  tally: measured-packages=%d gated-packages=%d below-floor=%d near-floor=%d gate-failures=%d\n",
+		len(result.packageSummaries),
+		len(verdicts),
+		len(belowFloor),
+		len(nearFloor),
+		len(failures),
+	)
+}
+
+func writeBelowFloorCoverageLines(belowFloor []packageCoverageVerdict) {
+	if len(belowFloor) == 0 {
+		fmt.Fprintln(stdoutWriter, "  floor violations: none")
+		return
+	}
+	for _, verdict := range belowFloor {
+		fmt.Fprintf(
+			stdoutWriter,
+			"  floor violation: package=%s floor=%.4f%% actual=%.4f%% delta=%+.4f percentage-points covered=%d/%d statements uncovered-blocks=%d\n",
+			verdict.importPath,
+			verdict.floor,
+			verdict.actual,
+			verdict.headroom,
+			verdict.covered,
+			verdict.measurable,
+			verdict.uncoveredBlocks,
+		)
+	}
+}
+
+func writeNearFloorCoverageLines(nearFloor []packageCoverageVerdict) {
+	if len(nearFloor) == 0 {
+		fmt.Fprintf(
+			stdoutWriter,
+			"  near floor: none within %.4f percentage points\n",
+			nearFloorCoverageHeadroomPoints,
+		)
+		return
+	}
+	reported := min(len(nearFloor), nearFloorCoverageReportLimit)
+	for _, verdict := range nearFloor[:reported] {
+		fmt.Fprintf(
+			stdoutWriter,
+			"  near floor: package=%s floor=%.4f%% actual=%.4f%% headroom=%+.4f percentage-points\n",
+			verdict.importPath,
+			verdict.floor,
+			verdict.actual,
+			verdict.headroom,
+		)
+	}
+	if omitted := len(nearFloor) - reported; omitted > 0 {
+		fmt.Fprintf(
+			stdoutWriter,
+			"  near floor: %d more package(s) within %.4f percentage points not shown\n",
+			omitted,
+			nearFloorCoverageHeadroomPoints,
+		)
+	}
+}
+
+// collectPackageCoverageVerdicts reports one verdict per package that carries a
+// floor and has measurable statements. Packages without a floor, without a
+// measurable denominator (a vacuous pass), or covered by a measurement
+// exception have no distance to report and are excluded.
+func collectPackageCoverageVerdicts(result coverageResult) []packageCoverageVerdict {
+	uncovered := uncoveredCoverageBlockCounts(result.coverageBlocks)
+	verdicts := make([]packageCoverageVerdict, 0, len(result.packageSummaries))
+	for _, summary := range result.packageSummaries {
+		gate := result.packageGates[summary.importPath]
+		if gate.Floor == nil {
+			continue
+		}
+		totals := result.packageTotals[summary.importPath]
+		if totals.totalStatements <= 0 {
+			continue
+		}
+		actual := float64(totals.coveredStatements) * 100 / float64(totals.totalStatements)
+		verdicts = append(verdicts, packageCoverageVerdict{
+			importPath:      summary.importPath,
+			floor:           *gate.Floor,
+			actual:          actual,
+			headroom:        actual - *gate.Floor,
+			covered:         totals.coveredStatements,
+			measurable:      totals.totalStatements,
+			uncoveredBlocks: uncovered[summary.importPath],
+		})
+	}
+	return verdicts
+}
+
+// partitionPackageCoverageVerdicts splits verdicts into below-floor packages
+// and passing packages within the near-floor band. Both are ordered by
+// headroom ascending — the worst regression and the closest near-miss first —
+// with import path as the deterministic tiebreak.
+//
+// A zero floor is excluded from the near-floor band: coverage is never
+// negative, so a package sitting on a 0% floor cannot regress through it and
+// naming it would crowd out the packages that can.
+func partitionPackageCoverageVerdicts(verdicts []packageCoverageVerdict) (belowFloor, nearFloor []packageCoverageVerdict) {
+	belowFloor = make([]packageCoverageVerdict, 0)
+	nearFloor = make([]packageCoverageVerdict, 0)
+	for _, verdict := range verdicts {
+		switch {
+		case verdict.headroom < 0:
+			belowFloor = append(belowFloor, verdict)
+		case verdict.floor > 0 && verdict.headroom <= nearFloorCoverageHeadroomPoints:
+			nearFloor = append(nearFloor, verdict)
+		}
+	}
+	slices.SortStableFunc(belowFloor, comparePackageCoverageHeadroom)
+	slices.SortStableFunc(nearFloor, comparePackageCoverageHeadroom)
+	return belowFloor, nearFloor
+}
+
+func comparePackageCoverageHeadroom(left, right packageCoverageVerdict) int {
+	if left.headroom < right.headroom {
+		return -1
+	}
+	if left.headroom > right.headroom {
+		return 1
+	}
+	return strings.Compare(left.importPath, right.importPath)
+}
+
+// uncoveredCoverageBlockCounts counts zero-execution coverage blocks per
+// package in a single pass so the verdict block does not rescan every block
+// once per reported package.
+func uncoveredCoverageBlockCounts(blocks map[string]coverageBlock) map[string]int {
+	counts := make(map[string]int, len(blocks))
+	for _, block := range blocks {
+		if block.executionCount != 0 {
+			continue
+		}
+		counts[block.importPath]++
+	}
+	return counts
+}

--- a/cmd/gocoveragecheck/coverage_verdict.go
+++ b/cmd/gocoveragecheck/coverage_verdict.go
@@ -49,6 +49,15 @@ func writeCoverageLaneReport(cfg config, result coverageResult, failures []strin
 	writeFunctionalCoverageVerdict(result, failures)
 }
 
+// writePackageCoverageSummaries prints one raw coverage line per measured
+// package. It remains the report for every non-functional lane and for the
+// malformed-manifest abort path, which never reaches the JSON summary.
+func writePackageCoverageSummaries(summaries []packageCoverageSummary) {
+	for _, summary := range summaries {
+		fmt.Fprintf(stdoutWriter, "%s\tcoverage: %.1f%% of statements\n", summary.importPath, summary.coverage)
+	}
+}
+
 // writeFunctionalCoverageVerdict renders the ordered functional verdict block.
 func writeFunctionalCoverageVerdict(result coverageResult, failures []string) {
 	verdicts := collectPackageCoverageVerdicts(result)

--- a/cmd/gocoveragecheck/coverage_verdict_test.go
+++ b/cmd/gocoveragecheck/coverage_verdict_test.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var functionalVerdictCoverPackages = []string{
+	modulePath + "/pkg/config",
+	modulePath + "/pkg/service",
+	modulePath + "/pkg/wire",
+}
+
+// fakeFunctionalCoverageCommand writes a profile with one below-floor package,
+// one near-floor package, and one comfortably passing package so the ordered
+// verdict block has something to order.
+func fakeFunctionalCoverageCommand(invocation commandInvocation) (string, string, error) {
+	if invocation.name != "go" || len(invocation.args) == 0 || invocation.args[0] != "test" {
+		return "", "", fmt.Errorf("unexpected command %q %v", invocation.name, invocation.args)
+	}
+	profilePath := helperCoverProfilePath(invocation.args[1:])
+	if profilePath == "" {
+		return "", "", fmt.Errorf("missing -coverprofile")
+	}
+	if err := writeFakeCoverageProfile(profilePath, strings.Join([]string{
+		"mode: count",
+		modulePath + "/pkg/config/config.go:1.1,2.1 1 1",
+		modulePath + "/pkg/config/config.go:11.1,12.1 2 0",
+		modulePath + "/pkg/config/load.go:21.1,22.1 1 0",
+		modulePath + "/pkg/service/factory.go:1.1,2.1 9 1",
+		modulePath + "/pkg/service/factory.go:31.1,32.1 1 0",
+		modulePath + "/pkg/wire/wire.go:1.1,2.1 10 3",
+		"",
+	}, "\n")); err != nil {
+		return "", "", err
+	}
+	// go test reports the per-package coverage percentage on its own line. The
+	// functional lane must not forward it once per package.
+	return "coverage: 71.4% of statements in " + strings.Join(functionalVerdictCoverPackages, ", ") + "\n", "", nil
+}
+
+func functionalVerdictManifest(t *testing.T, configMinimum string) string {
+	t.Helper()
+	return writePackageMinimumManifestWithEntries(t, "functional", []manifestPackageSpec{
+		{importPath: modulePath + "/pkg/config", minimum: configMinimum},
+		{importPath: modulePath + "/pkg/service", minimum: "89.00"},
+		{importPath: modulePath + "/pkg/wire", minimum: "50.00"},
+	})
+}
+
+func functionalVerdictConfig(manifestPath string, jsonPath string) config {
+	return config{
+		min:             0,
+		suite:           "functional",
+		coverpkg:        strings.Join(functionalVerdictCoverPackages, ","),
+		packages:        "./tests/functional/...",
+		packageManifest: manifestPath,
+		jsonOutput:      jsonPath,
+	}
+}
+
+func captureFunctionalVerdictRun(t *testing.T, cfg config) (string, string, error) {
+	t.Helper()
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	t.Cleanup(func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeFunctionalCoverageCommand
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	err := execute(cfg)
+	return stdout.String(), stderr.String(), err
+}
+
+func TestFunctionalCoverageVerdictOrdersViolationsBeforeNearFloorAndTally(t *testing.T) {
+	jsonPath := filepath.Join(t.TempDir(), "coverage-summary.json")
+	// pkg/config measures 25.0% against an 80.00 floor: a floor violation.
+	cfg := functionalVerdictConfig(functionalVerdictManifest(t, "80.00"), jsonPath)
+
+	stdout, _, err := captureFunctionalVerdictRun(t, cfg)
+	if err == nil {
+		t.Fatalf("execute() error = nil, want a non-zero floor-violation outcome; stdout=%s", stdout)
+	}
+	if !strings.Contains(err.Error(), "package coverage regression: package="+modulePath+"/pkg/config") {
+		t.Fatalf("execute() error = %v, want the pkg/config floor regression", err)
+	}
+
+	violation := strings.Index(stdout, "  floor violation: package="+modulePath+"/pkg/config ")
+	nearFloor := strings.Index(stdout, "  near floor: package="+modulePath+"/pkg/service ")
+	tally := strings.Index(stdout, "  tally: ")
+	if violation < 0 || nearFloor < 0 || tally < 0 {
+		t.Fatalf("verdict block missing sections (violation=%d nearFloor=%d tally=%d):\n%s", violation, nearFloor, tally, stdout)
+	}
+	if !(violation < nearFloor && nearFloor < tally) {
+		t.Fatalf("verdict block order = violation@%d nearFloor@%d tally@%d, want violation first and tally last:\n%s", violation, nearFloor, tally, stdout)
+	}
+	if !strings.Contains(stdout, "delta=-55.0000 percentage-points covered=1/4 statements uncovered-blocks=2") {
+		t.Fatalf("floor violation line missing floor/actual/delta/blocks detail:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "  tally: measured-packages=3 gated-packages=3 below-floor=1 near-floor=1 gate-failures=1\n") {
+		t.Fatalf("verdict tally line missing or wrong:\n%s", stdout)
+	}
+	// A comfortably passing package is neither a violation nor near its floor.
+	if strings.Contains(stdout, modulePath+"/pkg/wire") {
+		t.Fatalf("verdict block named a package with ample headroom:\n%s", stdout)
+	}
+}
+
+func TestFunctionalCoverageRunSuppressesPerPackageCoverageLines(t *testing.T) {
+	jsonPath := filepath.Join(t.TempDir(), "coverage-summary.json")
+	cfg := functionalVerdictConfig(functionalVerdictManifest(t, "80.00"), jsonPath)
+
+	stdout, _, err := captureFunctionalVerdictRun(t, cfg)
+	if err == nil {
+		t.Fatalf("execute() error = nil, want a non-zero floor-violation outcome")
+	}
+	for _, coverPackage := range functionalVerdictCoverPackages {
+		if raw := coverPackage + "\tcoverage: "; strings.Contains(stdout, raw) {
+			t.Fatalf("functional stdout still streams the raw per-package line %q:\n%s", raw, stdout)
+		}
+	}
+	if strings.Contains(stdout, "coverage: 71.4% of statements") {
+		t.Fatalf("functional stdout still streams the go test per-package coverage line:\n%s", stdout)
+	}
+
+	// Suppression is log-only: every measured package still reaches the JSON
+	// artifact the CI job uploads and renders.
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("read coverage summary json: %v", err)
+	}
+	var summary coverageSummaryJSON
+	if err := json.Unmarshal(data, &summary); err != nil {
+		t.Fatalf("decode coverage summary json: %v\n%s", err, data)
+	}
+	if len(summary.Packages) != len(functionalVerdictCoverPackages) {
+		t.Fatalf("coverage summary packages = %d, want %d: %s", len(summary.Packages), len(functionalVerdictCoverPackages), data)
+	}
+	for _, coverPackage := range functionalVerdictCoverPackages {
+		found := false
+		for _, entry := range summary.Packages {
+			if entry.Package == coverPackage {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("coverage summary json dropped package %q: %s", coverPackage, data)
+		}
+	}
+}
+
+func TestFunctionalCoverageVerdictPassesWhenEveryPackageMeetsItsFloor(t *testing.T) {
+	jsonPath := filepath.Join(t.TempDir(), "coverage-summary.json")
+	// pkg/config measures 25.0%; a 20.00 floor clears it.
+	cfg := functionalVerdictConfig(functionalVerdictManifest(t, "20.00"), jsonPath)
+
+	stdout, _, err := captureFunctionalVerdictRun(t, cfg)
+	if err != nil {
+		t.Fatalf("execute() error = %v, want a zero-exit outcome; stdout=%s", err, stdout)
+	}
+	if !strings.Contains(stdout, "  floor violations: none\n") {
+		t.Fatalf("verdict block missing the explicit no-violation line:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "  tally: measured-packages=3 gated-packages=3 below-floor=0 near-floor=1 gate-failures=0\n") {
+		t.Fatalf("passing verdict tally line missing or wrong:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "Go coverage") || !strings.Contains(stdout, "meets minimum") {
+		t.Fatalf("passing run lost its success message:\n%s", stdout)
+	}
+}
+
+func TestUnitCoverageRunKeepsRawPerPackageCoverageLines(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	defer func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	}()
+
+	configPackage := modulePath + "/pkg/config"
+	manifestPath := writePackageMinimumManifest(t, "unit", configPackage, "100.00")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeGoCoverageCommandPassing
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	if err := execute(config{
+		min:             0,
+		suite:           "unit",
+		coverpkg:        configPackage,
+		packages:        "./pkg/config",
+		packageManifest: manifestPath,
+	}); err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+
+	got := stdout.String()
+	if !strings.Contains(got, configPackage+"\tcoverage: 100.0% of statements\n") {
+		t.Fatalf("unit lane lost its raw per-package coverage line:\n%s", got)
+	}
+	if strings.Contains(got, "Functional package coverage verdict:") {
+		t.Fatalf("unit lane rendered the functional verdict block:\n%s", got)
+	}
+}
+
+func TestNearFloorCoverageReportStatesOmittedPackages(t *testing.T) {
+	originalStdout := stdoutWriter
+	defer func() { stdoutWriter = originalStdout }()
+	var stdout bytes.Buffer
+	stdoutWriter = &stdout
+
+	floor := 50.0
+	result := coverageResult{
+		packageGates:  make(map[string]packageCoverageGate),
+		packageTotals: make(map[string]packageCoverageTotals),
+	}
+	for index := range nearFloorCoverageReportLimit + 3 {
+		importPath := fmt.Sprintf("%s/pkg/near%02d", modulePath, index)
+		result.packageSummaries = append(result.packageSummaries, packageCoverageSummary{importPath: importPath, coverage: 51})
+		result.packageGates[importPath] = packageCoverageGate{Floor: &floor}
+		result.packageTotals[importPath] = packageCoverageTotals{coveredStatements: 51, totalStatements: 100}
+	}
+
+	writeFunctionalCoverageVerdict(result, nil)
+
+	got := stdout.String()
+	if count := strings.Count(got, "  near floor: package="); count != nearFloorCoverageReportLimit {
+		t.Fatalf("near-floor lines = %d, want the %d-row cap:\n%s", count, nearFloorCoverageReportLimit, got)
+	}
+	if !strings.Contains(got, "  near floor: 3 more package(s) within 2.0000 percentage points not shown\n") {
+		t.Fatalf("near-floor report did not state its omitted rows:\n%s", got)
+	}
+	if !strings.Contains(got, "near-floor=13") {
+		t.Fatalf("tally did not count every near-floor package:\n%s", got)
+	}
+}
+
+func TestFunctionalStreamKeepsNonCoverageOutputLines(t *testing.T) {
+	var sink bytes.Buffer
+	reporter := newFunctionalStreamReporter(&sink)
+	writer := reporter.stdoutWriter()
+
+	streamed := []string{
+		"=== RUN   TestSomething\n",
+		"coverage: 42.7% of statements in " + modulePath + "/pkg/config\n",
+		"--- FAIL: TestSomething (0.12s)\n",
+		"panic: test timed out after 10m0s\n",
+		"ok  \t" + modulePath + "/tests/functional/alpha\t1.234s\tcoverage: 42.7% of statements\n",
+	}
+	for _, output := range streamed {
+		event, err := json.Marshal(goTestTimingEvent{
+			Action:  "output",
+			Package: modulePath + "/tests/functional/alpha",
+			Output:  output,
+		})
+		if err != nil {
+			t.Fatalf("marshal stream event: %v", err)
+		}
+		if _, err := writer.Write(append(event, '\n')); err != nil {
+			t.Fatalf("stream reporter write error = %v", err)
+		}
+	}
+
+	got := sink.String()
+	for _, want := range []string{
+		"=== RUN   TestSomething\n",
+		"--- FAIL: TestSomething (0.12s)\n",
+		"panic: test timed out after 10m0s\n",
+		"ok  \t" + modulePath + "/tests/functional/alpha\t1.234s\tcoverage: 42.7% of statements\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("functional stream dropped %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "coverage: 42.7% of statements in ") {
+		t.Fatalf("functional stream forwarded the standalone per-package coverage line:\n%s", got)
+	}
+}

--- a/cmd/gocoveragecheck/functional_stream.go
+++ b/cmd/gocoveragecheck/functional_stream.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 )
 
@@ -97,6 +98,12 @@ func (writer *functionalStreamWriter) writeLineLocked(line []byte) error {
 
 	switch event.Action {
 	case "output":
+		if isRedundantCoverageOutputLine(event.Output) {
+			// The per-package coverage percentage is reported authoritatively
+			// by the end-of-run verdict block and the coverage-summary JSON.
+			// Streaming it once per package buries the actionable verdict.
+			return nil
+		}
 		// Keep the child failure text readable in the job log while the
 		// command runner retains the original JSON bytes for timing parsing.
 		return writer.reporter.writeSink([]byte(event.Output))
@@ -125,6 +132,16 @@ func (writer *functionalStreamWriter) writeLineLocked(line []byte) error {
 		// understand yet.
 		return writer.reporter.writeSink(line)
 	}
+}
+
+// isRedundantCoverageOutputLine reports whether a go test output event is the
+// standalone per-package coverage percentage line. Only a line that is
+// entirely that report is suppressed: package result lines ("ok  pkg 1.2s
+// coverage: ..."), test failures, and panics keep their exact text so a hang
+// or crash stays diagnosable from the raw stream.
+func isRedundantCoverageOutputLine(output string) bool {
+	trimmed := strings.TrimSpace(output)
+	return strings.HasPrefix(trimmed, "coverage: ") && strings.Contains(trimmed, "% of statements")
 }
 
 func (writer *lockedFunctionalStreamWriter) Write(data []byte) (int, error) {

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -152,6 +152,9 @@ func execute(cfg config) error {
 		writeCoverageTestFailureWarning(err)
 		var validationErr *coverageManifestValidationError
 		if errors.As(err, &validationErr) {
+			// A malformed manifest aborts before the coverage-summary JSON is
+			// written, so this path keeps the complete per-package listing: it
+			// is the only surviving copy of the measurement.
 			writePackageCoverageSummaries(result.packageSummaries)
 		}
 		return err
@@ -166,7 +169,7 @@ func execute(cfg config) error {
 	}
 	failures = append(failures, result.packageMinimumFailures...)
 
-	writePackageCoverageSummaries(result.packageSummaries)
+	writeCoverageLaneReport(cfg, result, failures)
 	if cfg.generateManifest != "" {
 		if err := createCoverageManifest(cfg.generateManifest, cfg.suite, result.packageTotals, packageImportPaths(result.packageSummaries)); err != nil {
 			return err

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -408,12 +408,6 @@ func runCoverageProfile(cfg config, targetOS string, profilePath string) (covera
 	return result, nil
 }
 
-func writePackageCoverageSummaries(summaries []packageCoverageSummary) {
-	for _, summary := range summaries {
-		fmt.Fprintf(stdoutWriter, "%s\tcoverage: %.1f%% of statements\n", summary.importPath, summary.coverage)
-	}
-}
-
 func (cfg config) testJobs(targetOS string) int {
 	if cfg.jobs > 0 {
 		return cfg.jobs

--- a/internal/functionaltestviz/coverage_markdown.go
+++ b/internal/functionaltestviz/coverage_markdown.go
@@ -8,10 +8,12 @@ import (
 )
 
 // RenderPackageCoverageMarkdown renders overall statement totals and a
-// stable-ordered per-production-package table from coverage-summary JSON
-// fields only (no profile recomputation).
+// headroom-ordered per-production-package table from coverage-summary JSON
+// fields only (no profile recomputation). Ordering by headroom puts the
+// packages closest to failing at the top, so a regression among hundreds of
+// rows does not have to be found by scanning.
 func RenderPackageCoverageMarkdown(summary CoverageSummary) string {
-	packages := StableOrderedPackages(summary.Packages)
+	packages := HeadroomOrderedPackages(summary.Packages)
 
 	var b strings.Builder
 	b.WriteString("## Package coverage\n\n")
@@ -24,8 +26,8 @@ func RenderPackageCoverageMarkdown(summary CoverageSummary) string {
 		return b.String()
 	}
 
-	b.WriteString("| Package | Covered | Measurable | Coverage % | Floor | Measurement exception |\n")
-	b.WriteString("| --- | ---: | ---: | ---: | ---: | --- |\n")
+	b.WriteString("| Package | Covered | Measurable | Coverage % | Floor | Headroom | Measurement exception |\n")
+	b.WriteString("| --- | ---: | ---: | ---: | ---: | ---: | --- |\n")
 	for _, pkg := range packages {
 		b.WriteString("| `")
 		b.WriteString(pkg.Package)
@@ -37,6 +39,8 @@ func RenderPackageCoverageMarkdown(summary CoverageSummary) string {
 		b.WriteString(formatCoveragePercent(pkg.CoveragePercent))
 		b.WriteString(" | ")
 		b.WriteString(formatOptionalFloor(pkg.PackageFloor))
+		b.WriteString(" | ")
+		b.WriteString(formatPackageHeadroom(pkg))
 		b.WriteString(" | ")
 		b.WriteString(formatMeasurementException(pkg.MeasurementException))
 		b.WriteString(" |\n")
@@ -52,6 +56,45 @@ func StableOrderedPackages(packages []PackageCoverage) []PackageCoverage {
 		return ordered[i].Package < ordered[j].Package
 	})
 	return ordered
+}
+
+// HeadroomOrderedPackages returns a copy of packages ordered by headroom
+// ascending — the packages closest to their floor first — with import-path
+// order as the deterministic tiebreak. A package with no floor has no distance
+// to report, so it sorts after every gated package, in import-path order.
+func HeadroomOrderedPackages(packages []PackageCoverage) []PackageCoverage {
+	ordered := StableOrderedPackages(packages)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		left, leftGated := packageHeadroom(ordered[i])
+		right, rightGated := packageHeadroom(ordered[j])
+		if leftGated != rightGated {
+			return leftGated
+		}
+		if !leftGated {
+			return false
+		}
+		return left < right
+	})
+	return ordered
+}
+
+// packageHeadroom reports a package's percentage points above its floor and
+// whether a floor applied at all.
+func packageHeadroom(pkg PackageCoverage) (float64, bool) {
+	if pkg.PackageFloor == nil {
+		return 0, false
+	}
+	return pkg.CoveragePercent - *pkg.PackageFloor, true
+}
+
+// formatPackageHeadroom renders the signed distance to the floor, or an empty
+// cell when the package has no floor to be measured against.
+func formatPackageHeadroom(pkg PackageCoverage) string {
+	headroom, gated := packageHeadroom(pkg)
+	if !gated {
+		return ""
+	}
+	return strconv.FormatFloat(headroom, 'f', 2, 64)
 }
 
 func formatCoveragePercent(value float64) string {

--- a/internal/functionaltestviz/coverage_markdown_test.go
+++ b/internal/functionaltestviz/coverage_markdown_test.go
@@ -91,13 +91,16 @@ func TestRenderPackageCoverageMarkdownUsesSummaryFieldsOnly(t *testing.T) {
 	configIdx := strings.Index(first, "| `github.com/portpowered/infinite-you/pkg/config` |")
 	serviceIdx := strings.Index(first, "| `github.com/portpowered/infinite-you/pkg/service` |")
 	if configIdx < 0 || serviceIdx < 0 || configIdx >= serviceIdx {
-		t.Fatalf("packages must render in stable path order:\n%s", first)
+		t.Fatalf("a gated package must render before an ungated one:\n%s", first)
 	}
-	if !strings.Contains(first, "| `github.com/portpowered/infinite-you/pkg/config` | 3 | 3 | 100.0 | 66.66 | — |") {
-		t.Fatalf("config package row missing floor rendering:\n%s", first)
+	if !strings.Contains(first, "| Package | Covered | Measurable | Coverage % | Floor | Headroom | Measurement exception |\n") {
+		t.Fatalf("coverage table lost a column:\n%s", first)
 	}
-	if !strings.Contains(first, "| `github.com/portpowered/infinite-you/pkg/service` | 0 | 0 | 0.0 | — | measurement: no measurable statements (owner=backend-quality; deadline=2027-07-15; removalGate=profile reports measurable statements) |") {
-		t.Fatalf("service package row missing measurement exception:\n%s", first)
+	if !strings.Contains(first, "| `github.com/portpowered/infinite-you/pkg/config` | 3 | 3 | 100.0 | 66.66 | 33.34 | — |") {
+		t.Fatalf("config package row missing floor or headroom rendering:\n%s", first)
+	}
+	if !strings.Contains(first, "| `github.com/portpowered/infinite-you/pkg/service` | 0 | 0 | 0.0 | — |  | measurement: no measurable statements (owner=backend-quality; deadline=2027-07-15; removalGate=profile reports measurable statements) |") {
+		t.Fatalf("service package row missing measurement exception or blank headroom:\n%s", first)
 	}
 }
 
@@ -157,7 +160,55 @@ func TestRenderCatalogMarkdownAppendsPackageCoverageAfterDebt(t *testing.T) {
 	if !strings.Contains(catalog, "- Coverage percent: 50.0%\n") {
 		t.Fatalf("overall coverage percent missing from catalog:\n%s", catalog)
 	}
-	if !strings.Contains(catalog, "| `github.com/portpowered/infinite-you/pkg/example` | 1 | 2 | 50.0 | 40 | — |") {
+	if !strings.Contains(catalog, "| `github.com/portpowered/infinite-you/pkg/example` | 1 | 2 | 50.0 | 40 | 10.00 | — |") {
 		t.Fatalf("package coverage row missing from catalog:\n%s", catalog)
+	}
+}
+
+func TestRenderPackageCoverageMarkdownOrdersRowsByHeadroomAscending(t *testing.T) {
+	t.Parallel()
+
+	tightFloor := 90.0
+	violatedFloor := 80.0
+	looseFloor := 10.0
+	summary := functionaltestviz.CoverageSummary{
+		CoveredStatements:    10,
+		MeasurableStatements: 20,
+		CoveragePercent:      50.0,
+		Packages: []functionaltestviz.PackageCoverage{
+			{Package: "github.com/portpowered/infinite-you/pkg/alpha", CoveragePercent: 99.0, PackageFloor: &looseFloor},
+			{Package: "github.com/portpowered/infinite-you/pkg/bravo", CoveragePercent: 90.5, PackageFloor: &tightFloor},
+			{Package: "github.com/portpowered/infinite-you/pkg/charlie", CoveragePercent: 70.0, PackageFloor: &violatedFloor},
+			{Package: "github.com/portpowered/infinite-you/pkg/delta", CoveragePercent: 12.0},
+			{Package: "github.com/portpowered/infinite-you/pkg/echo", CoveragePercent: 90.5, PackageFloor: &tightFloor},
+		},
+	}
+
+	rendered := functionaltestviz.RenderPackageCoverageMarkdown(summary)
+	// Violated floor first, then the two 0.5pp near-misses in import-path
+	// order, then ample headroom, then the ungated package last.
+	want := []string{
+		"| `github.com/portpowered/infinite-you/pkg/charlie` |",
+		"| `github.com/portpowered/infinite-you/pkg/bravo` |",
+		"| `github.com/portpowered/infinite-you/pkg/echo` |",
+		"| `github.com/portpowered/infinite-you/pkg/alpha` |",
+		"| `github.com/portpowered/infinite-you/pkg/delta` |",
+	}
+	previous := -1
+	for _, row := range want {
+		index := strings.Index(rendered, row)
+		if index < 0 {
+			t.Fatalf("row %q missing:\n%s", row, rendered)
+		}
+		if index <= previous {
+			t.Fatalf("row %q is out of headroom order:\n%s", row, rendered)
+		}
+		previous = index
+	}
+	if !strings.Contains(rendered, "| `github.com/portpowered/infinite-you/pkg/charlie` | 0 | 0 | 70.0 | 80 | -10.00 | \u2014 |") {
+		t.Fatalf("a violated floor must render a negative headroom:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "| `github.com/portpowered/infinite-you/pkg/delta` | 0 | 0 | 12.0 | \u2014 |  | \u2014 |") {
+		t.Fatalf("an ungated package must render a blank headroom:\n%s", rendered)
 	}
 }

--- a/internal/functionaltestviz/testdata/full-report/functional-tests.md
+++ b/internal/functionaltestviz/testdata/full-report/functional-tests.md
@@ -171,10 +171,10 @@
 - Measurable statements: 10
 - Coverage percent: 80.0%
 
-| Package | Covered | Measurable | Coverage % | Floor | Measurement exception |
-| --- | ---: | ---: | ---: | ---: | --- |
-| `github.com/portpowered/infinite-you/pkg/config` | 3 | 3 | 100.0 | 66.66 | — |
-| `github.com/portpowered/infinite-you/pkg/service` | 0 | 0 | 0.0 | — | measurement: no measurable statements (owner=backend-quality; deadline=2027-07-15; removalGate=profile reports measurable statements) |
+| Package | Covered | Measurable | Coverage % | Floor | Headroom | Measurement exception |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| `github.com/portpowered/infinite-you/pkg/config` | 3 | 3 | 100.0 | 66.66 | 33.34 | — |
+| `github.com/portpowered/infinite-you/pkg/service` | 0 | 0 | 0.0 | — |  | measurement: no measurable statements (owner=backend-quality; deadline=2027-07-15; removalGate=profile reports measurable statements) |
 
 ## Functional test timings
 

--- a/internal/functionaltestviz/timing_markdown.go
+++ b/internal/functionaltestviz/timing_markdown.go
@@ -58,7 +58,57 @@ func RenderFunctionalTimingMarkdown(summary FunctionalTimingSummary) string {
 	}
 
 	renderFunctionalTestFailures(&b, summary.Tests)
+	renderSlowestFunctionalTests(&b, summary.Tests)
 	return b.String()
+}
+
+// slowestFunctionalTestReportLimit caps how many individual tests the slowest-
+// tests table names. The rendered text always states how many rows the cap
+// dropped so a truncated table is never mistaken for the whole suite.
+const slowestFunctionalTestReportLimit = 15
+
+// renderSlowestFunctionalTests renders the longest-running top-level tests
+// from the per-test rows already captured alongside the package timings.
+// Package totals answer "which package is slow"; this answers "which test".
+// Nothing is rendered when a run captured no per-test rows at all.
+func renderSlowestFunctionalTests(output *strings.Builder, tests []FunctionalTestTiming) {
+	if len(tests) == 0 {
+		return
+	}
+	slowest := make([]FunctionalTestTiming, len(tests))
+	copy(slowest, tests)
+	sort.SliceStable(slowest, func(i, j int) bool {
+		if slowest[i].Seconds != slowest[j].Seconds {
+			return slowest[i].Seconds > slowest[j].Seconds
+		}
+		if slowest[i].Package != slowest[j].Package {
+			return slowest[i].Package < slowest[j].Package
+		}
+		return slowest[i].Test < slowest[j].Test
+	})
+
+	shown := min(len(slowest), slowestFunctionalTestReportLimit)
+	output.WriteString("\n### Slowest top-level tests\n\n")
+	fmt.Fprintf(
+		output,
+		"- Showing the %d slowest of %d observed top-level tests by elapsed time; %d additional row(s) omitted.\n\n",
+		shown,
+		len(slowest),
+		len(slowest)-shown,
+	)
+	output.WriteString("| Test | Package | Elapsed (s) | Outcome |\n")
+	output.WriteString("| --- | --- | ---: | --- |\n")
+	for _, test := range slowest[:shown] {
+		output.WriteString("| `")
+		output.WriteString(test.Test)
+		output.WriteString("` | `")
+		output.WriteString(test.Package)
+		output.WriteString("` | ")
+		fmt.Fprintf(output, "%.3f", test.Seconds)
+		output.WriteString(" | ")
+		output.WriteString(test.Outcome)
+		output.WriteString(" |\n")
+	}
 }
 
 func renderFunctionalTestFailures(output *strings.Builder, tests []FunctionalTestTiming) {

--- a/internal/functionaltestviz/timing_markdown_test.go
+++ b/internal/functionaltestviz/timing_markdown_test.go
@@ -1,6 +1,7 @@
 package functionaltestviz_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -129,5 +130,116 @@ func TestRenderFunctionalTimingMarkdownZeroDurationPackagesNotHiddenAsMissing(t 
 	got := functionaltestviz.RenderFunctionalTimingMarkdown(summary)
 	if !strings.Contains(got, "| `github.com/portpowered/infinite-you/tests/functional/empty` | 0.000 | skip |") {
 		t.Fatalf("zero-duration package must still render, not be treated as missing:\n%s", got)
+	}
+}
+
+func TestRenderFunctionalTimingMarkdownRendersSlowestTopLevelTests(t *testing.T) {
+	t.Parallel()
+
+	summary := functionaltestviz.FunctionalTimingSummary{
+		Version:       functionaltestviz.FunctionalTimingSummaryVersion,
+		Complete:      true,
+		WallSeconds:   30.0,
+		PackageCount:  1,
+		TestCount:     3,
+		TestPassCount: 2,
+		TestFailCount: 1,
+		Packages: []functionaltestviz.FunctionalPackageTiming{
+			{Package: "github.com/portpowered/infinite-you/tests/functional/alpha", Seconds: 30.0, Outcome: "fail"},
+		},
+		Tests: []functionaltestviz.FunctionalTestTiming{
+			{Package: "github.com/portpowered/infinite-you/tests/functional/alpha", Test: "TestQuick", Seconds: 0.5, Outcome: "pass"},
+			{Package: "github.com/portpowered/infinite-you/tests/functional/alpha", Test: "TestSlowest", Seconds: 21.25, Outcome: "pass"},
+			{Package: "github.com/portpowered/infinite-you/tests/functional/alpha", Test: "TestMiddle", Seconds: 8.125, Outcome: "fail", Reason: "assertion failed"},
+		},
+	}
+
+	rendered := functionaltestviz.RenderFunctionalTimingMarkdown(summary)
+
+	if !strings.Contains(rendered, "### Slowest top-level tests\n") {
+		t.Fatalf("slowest top-level tests section missing:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "- Showing the 3 slowest of 3 observed top-level tests by elapsed time; 0 additional row(s) omitted.\n") {
+		t.Fatalf("slowest-tests section must state its cap and omitted count:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "| Test | Package | Elapsed (s) | Outcome |\n") {
+		t.Fatalf("slowest-tests table header missing:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "| `TestSlowest` | `github.com/portpowered/infinite-you/tests/functional/alpha` | 21.250 | pass |\n") {
+		t.Fatalf("slowest test row missing:\n%s", rendered)
+	}
+
+	// Scope the ordering assertion to the new section: the failed-tests table
+	// above it names the same tests in a different order by design.
+	section := rendered[strings.Index(rendered, "### Slowest top-level tests\n"):]
+	slowest := strings.Index(section, "| `TestSlowest` |")
+	middle := strings.Index(section, "| `TestMiddle` |")
+	quick := strings.Index(section, "| `TestQuick` |")
+	if slowest < 0 || middle < 0 || quick < 0 || slowest >= middle || middle >= quick {
+		t.Fatalf("slowest tests must render in elapsed-descending order:\n%s", rendered)
+	}
+
+	// The package table and its scalar counts stay exactly where they were.
+	packageTable := strings.Index(rendered, "| Package | Elapsed (s) | Outcome |\n")
+	if packageTable < 0 || packageTable >= strings.Index(rendered, "### Slowest top-level tests\n") {
+		t.Fatalf("the per-package timing table must be preserved above the slowest-tests section:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "- Top-level tests with observed outcomes: 3\n") {
+		t.Fatalf("scalar test counts must be preserved:\n%s", rendered)
+	}
+}
+
+func TestRenderFunctionalTimingMarkdownCapsSlowestTopLevelTests(t *testing.T) {
+	t.Parallel()
+
+	summary := functionaltestviz.FunctionalTimingSummary{
+		Version:      functionaltestviz.FunctionalTimingSummaryVersion,
+		Complete:     true,
+		WallSeconds:  100.0,
+		PackageCount: 1,
+		Packages: []functionaltestviz.FunctionalPackageTiming{
+			{Package: "github.com/portpowered/infinite-you/tests/functional/alpha", Seconds: 100.0, Outcome: "pass"},
+		},
+	}
+	const observed = 20
+	for index := range observed {
+		summary.Tests = append(summary.Tests, functionaltestviz.FunctionalTestTiming{
+			Package: "github.com/portpowered/infinite-you/tests/functional/alpha",
+			Test:    fmt.Sprintf("TestCase%02d", index),
+			Seconds: float64(index),
+			Outcome: "pass",
+		})
+	}
+
+	rendered := functionaltestviz.RenderFunctionalTimingMarkdown(summary)
+
+	if rows := strings.Count(rendered, "| `TestCase"); rows != 15 {
+		t.Fatalf("slowest-tests rows = %d, want the 15-row cap:\n%s", rows, rendered)
+	}
+	if !strings.Contains(rendered, "- Showing the 15 slowest of 20 observed top-level tests by elapsed time; 5 additional row(s) omitted.\n") {
+		t.Fatalf("capped slowest-tests section must state its omitted count:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "| `TestCase04` |") {
+		t.Fatalf("the five fastest tests must be the omitted rows:\n%s", rendered)
+	}
+}
+
+func TestRenderFunctionalTimingMarkdownOmitsSlowestSectionWithoutPerTestRows(t *testing.T) {
+	t.Parallel()
+
+	rendered := functionaltestviz.RenderFunctionalTimingMarkdown(functionaltestviz.FunctionalTimingSummary{
+		Version:      functionaltestviz.FunctionalTimingSummaryVersion,
+		Complete:     true,
+		WallSeconds:  1.0,
+		PackageCount: 1,
+		Packages: []functionaltestviz.FunctionalPackageTiming{
+			{Package: "github.com/portpowered/infinite-you/tests/functional/alpha", Seconds: 1.0, Outcome: "pass"},
+		},
+	})
+	if strings.Contains(rendered, "### Slowest top-level tests") {
+		t.Fatalf("a run with no per-test rows must not render an empty slowest-tests table:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "| Package | Elapsed (s) | Outcome |\n") {
+		t.Fatalf("the per-package timing table must still render:\n%s", rendered)
 	}
 }

--- a/scripts/ci/functional-coverage-comment.mjs
+++ b/scripts/ci/functional-coverage-comment.mjs
@@ -8,7 +8,9 @@ export const FUNCTIONAL_COVERAGE_COMMENT_MARKER =
 	"<!-- functional-coverage-report -->";
 
 // Row caps for the pull request comment. The rendered text always states how
-// many rows a cap dropped so a truncated table is never read as the whole set.
+// many rows a cap dropped so a truncated table is never read as the whole set,
+// and the body stays well inside GitHub's comment size limit.
+export const FUNCTIONAL_COVERAGE_VIOLATION_LIMIT = 25;
 export const FUNCTIONAL_COVERAGE_PACKAGE_LIMIT = 10;
 export const FUNCTIONAL_COVERAGE_SLOWEST_TEST_LIMIT = 10;
 
@@ -27,7 +29,15 @@ export function summarizeFunctionalCoverage(coverage, timing) {
 
 function summarizeCoverageArtifact(coverage) {
 	if (!coverage || typeof coverage !== "object" || !Array.isArray(coverage.packages)) {
-		return { available: false, violations: [], nearFloor: [], gatedCount: 0, omitted: 0 };
+		return {
+			available: false,
+			violations: [],
+			violationCount: 0,
+			omittedViolations: 0,
+			nearFloor: [],
+			gatedCount: 0,
+			omitted: 0,
+		};
 	}
 	const ranked = coverage.packages
 		.filter((entry) => entry && typeof entry.package === "string")
@@ -46,9 +56,14 @@ function summarizeCoverageArtifact(coverage) {
 				: left.headroom - right.headroom,
 		);
 
-	const violations = ranked.filter((entry) => entry.headroom < 0);
-	const passing = ranked.filter((entry) => entry.headroom >= 0);
-	const nearFloor = passing.slice(0, FUNCTIONAL_COVERAGE_PACKAGE_LIMIT);
+	const allViolations = ranked.filter((entry) => entry.headroom < 0);
+	// Coverage is never negative, so a package sitting on a 0% floor cannot
+	// regress through it. The functional lane holds every package without an
+	// explicit manifest entry to a 0.00 default floor, so including those would
+	// crowd every genuinely close package out of the table.
+	const contenders = ranked.filter((entry) => entry.headroom >= 0 && entry.floor > 0);
+	const violations = allViolations.slice(0, FUNCTIONAL_COVERAGE_VIOLATION_LIMIT);
+	const nearFloor = contenders.slice(0, FUNCTIONAL_COVERAGE_PACKAGE_LIMIT);
 	return {
 		available: true,
 		complete: coverage.complete !== false,
@@ -58,9 +73,11 @@ function summarizeCoverageArtifact(coverage) {
 		coveragePercent: finiteNumber(coverage.coveragePercent),
 		packageCount: coverage.packages.length,
 		gatedCount: ranked.length,
+		violationCount: allViolations.length,
 		violations,
+		omittedViolations: allViolations.length - violations.length,
 		nearFloor,
-		omitted: passing.length - nearFloor.length,
+		omitted: contenders.length - nearFloor.length,
 	};
 }
 
@@ -108,13 +125,14 @@ export function renderFunctionalCoverageComment(summary, metadata = {}) {
 	];
 	const violations = renderPackageTable(summary.coverage.violations);
 	if (violations) {
-		sections.push(`### Floor violations\n\n${violations}`);
+		sections.push(
+			`### Floor violations\n\n${violations}\n- ${summary.coverage.omittedViolations} additional violation(s) omitted.`,
+		);
 	}
 	const nearFloor = renderPackageTable(summary.coverage.nearFloor);
 	if (nearFloor) {
-		const omitted = summary.coverage.omitted;
 		sections.push(
-			`### Closest to their floor\n\n${nearFloor}\n- ${omitted} additional gated package(s) omitted.`,
+			`### Closest to their floor\n\n${nearFloor}\n- ${summary.coverage.omitted} additional gated package(s) omitted.`,
 		);
 	}
 	sections.push(renderTimingOverview(summary.timing));
@@ -138,7 +156,7 @@ function renderCoverageOverview(coverage) {
 	const lines = [
 		`- Coverage: ${coverage.coveragePercent.toFixed(1)}% (${coverage.coveredStatements}/${coverage.measurableStatements} statements) across ${coverage.packageCount} measured package(s)`,
 		`- Gated packages: ${coverage.gatedCount}`,
-		`- Floor violations: ${coverage.violations.length}`,
+		`- Floor violations: ${coverage.violationCount}`,
 	];
 	if (!coverage.complete) {
 		lines.push(

--- a/scripts/ci/functional-coverage-comment.mjs
+++ b/scripts/ci/functional-coverage-comment.mjs
@@ -1,0 +1,277 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Distinct from BACKEND_LINT_COMMENT_MARKER so the two reports never find,
+// overwrite, or delete each other's pull request comment.
+export const FUNCTIONAL_COVERAGE_COMMENT_MARKER =
+	"<!-- functional-coverage-report -->";
+
+// Row caps for the pull request comment. The rendered text always states how
+// many rows a cap dropped so a truncated table is never read as the whole set.
+export const FUNCTIONAL_COVERAGE_PACKAGE_LIMIT = 10;
+export const FUNCTIONAL_COVERAGE_SLOWEST_TEST_LIMIT = 10;
+
+/**
+ * summarizeFunctionalCoverage reduces the coverage-summary and
+ * functional-timing-summary artifacts to the ordered digest the pull request
+ * comment renders. Absent or malformed inputs produce an explicitly
+ * unavailable summary instead of throwing: reporting must never fail the job.
+ */
+export function summarizeFunctionalCoverage(coverage, timing) {
+	return {
+		coverage: summarizeCoverageArtifact(coverage),
+		timing: summarizeTimingArtifact(timing),
+	};
+}
+
+function summarizeCoverageArtifact(coverage) {
+	if (!coverage || typeof coverage !== "object" || !Array.isArray(coverage.packages)) {
+		return { available: false, violations: [], nearFloor: [], gatedCount: 0, omitted: 0 };
+	}
+	const ranked = coverage.packages
+		.filter((entry) => entry && typeof entry.package === "string")
+		.map((entry) => ({
+			package: entry.package,
+			coveragePercent: finiteNumber(entry.coveragePercent),
+			floor: typeof entry.packageFloor === "number" && Number.isFinite(entry.packageFloor)
+				? entry.packageFloor
+				: null,
+		}))
+		.filter((entry) => entry.floor !== null)
+		.map((entry) => ({ ...entry, headroom: entry.coveragePercent - entry.floor }))
+		.sort((left, right) =>
+			left.headroom === right.headroom
+				? left.package.localeCompare(right.package)
+				: left.headroom - right.headroom,
+		);
+
+	const violations = ranked.filter((entry) => entry.headroom < 0);
+	const passing = ranked.filter((entry) => entry.headroom >= 0);
+	const nearFloor = passing.slice(0, FUNCTIONAL_COVERAGE_PACKAGE_LIMIT);
+	return {
+		available: true,
+		complete: coverage.complete !== false,
+		measurementReason: textValue(coverage.measurementReason),
+		coveredStatements: finiteNumber(coverage.coveredStatements),
+		measurableStatements: finiteNumber(coverage.measurableStatements),
+		coveragePercent: finiteNumber(coverage.coveragePercent),
+		packageCount: coverage.packages.length,
+		gatedCount: ranked.length,
+		violations,
+		nearFloor,
+		omitted: passing.length - nearFloor.length,
+	};
+}
+
+function summarizeTimingArtifact(timing) {
+	if (!timing || typeof timing !== "object" || !Array.isArray(timing.tests)) {
+		return { available: false, slowest: [], observed: 0, omitted: 0 };
+	}
+	const slowest = timing.tests
+		.filter((entry) => entry && typeof entry.package === "string" && typeof entry.test === "string")
+		.map((entry) => ({
+			package: entry.package,
+			test: entry.test,
+			seconds: finiteNumber(entry.seconds),
+			outcome: textValue(entry.outcome) || "unknown",
+		}))
+		.sort((left, right) =>
+			left.seconds === right.seconds
+				? left.package.localeCompare(right.package) || left.test.localeCompare(right.test)
+				: right.seconds - left.seconds,
+		);
+	const shown = slowest.slice(0, FUNCTIONAL_COVERAGE_SLOWEST_TEST_LIMIT);
+	return {
+		available: true,
+		complete: timing.complete !== false,
+		captureReason: textValue(timing.captureReason),
+		wallSeconds: finiteNumber(timing.wallSeconds),
+		packageCount: finiteNumber(timing.packageCount),
+		expectedPackageCount: finiteNumber(timing.expectedPackageCount),
+		testFailCount: finiteNumber(timing.testFailCount),
+		slowest: shown,
+		observed: slowest.length,
+		omitted: slowest.length - shown.length,
+	};
+}
+
+/**
+ * renderFunctionalCoverageComment renders the marked pull request comment
+ * body. The marker is always the first line so the upsert can find it.
+ */
+export function renderFunctionalCoverageComment(summary, metadata = {}) {
+	const sections = [
+		FUNCTIONAL_COVERAGE_COMMENT_MARKER,
+		"## Backend Functional Coverage",
+		renderCoverageOverview(summary.coverage),
+	];
+	const violations = renderPackageTable(summary.coverage.violations);
+	if (violations) {
+		sections.push(`### Floor violations\n\n${violations}`);
+	}
+	const nearFloor = renderPackageTable(summary.coverage.nearFloor);
+	if (nearFloor) {
+		const omitted = summary.coverage.omitted;
+		sections.push(
+			`### Closest to their floor\n\n${nearFloor}\n- ${omitted} additional gated package(s) omitted.`,
+		);
+	}
+	sections.push(renderTimingOverview(summary.timing));
+	const slowest = renderSlowestTable(summary.timing.slowest);
+	if (slowest) {
+		sections.push(
+			`### Slowest top-level tests\n\n${slowest}\n- ${summary.timing.omitted} additional row(s) omitted.`,
+		);
+	}
+	const provenance = renderProvenance(metadata);
+	if (provenance) {
+		sections.push(provenance);
+	}
+	return `${sections.join("\n\n")}\n`;
+}
+
+function renderCoverageOverview(coverage) {
+	if (!coverage.available) {
+		return "- Coverage summary: unavailable — this run published no readable `coverage-summary.json`.";
+	}
+	const lines = [
+		`- Coverage: ${coverage.coveragePercent.toFixed(1)}% (${coverage.coveredStatements}/${coverage.measurableStatements} statements) across ${coverage.packageCount} measured package(s)`,
+		`- Gated packages: ${coverage.gatedCount}`,
+		`- Floor violations: ${coverage.violations.length}`,
+	];
+	if (!coverage.complete) {
+		lines.push(
+			`- Measurement status: incomplete — partial diagnostics only${coverage.measurementReason ? ` (${coverage.measurementReason})` : ""}`,
+		);
+	}
+	return lines.join("\n");
+}
+
+function renderTimingOverview(timing) {
+	if (!timing.available) {
+		return "- Timing summary: unavailable — this run published no readable `functional-timing-summary.json`.";
+	}
+	const lines = [
+		`- Wall-clock duration: ${timing.wallSeconds.toFixed(3)}s across ${timing.packageCount}/${timing.expectedPackageCount || timing.packageCount} package(s)`,
+		`- Observed top-level tests: ${timing.observed} (failed: ${timing.testFailCount})`,
+	];
+	if (!timing.complete) {
+		lines.push(
+			`- Capture status: incomplete — partial diagnostics only${timing.captureReason ? ` (${timing.captureReason})` : ""}`,
+		);
+	}
+	return lines.join("\n");
+}
+
+function renderPackageTable(rows) {
+	if (!rows || rows.length === 0) {
+		return "";
+	}
+	const lines = ["| Package | Coverage % | Floor | Headroom |", "| --- | ---: | ---: | ---: |"];
+	for (const row of rows) {
+		lines.push(
+			`| \`${row.package}\` | ${row.coveragePercent.toFixed(2)} | ${row.floor.toFixed(2)} | ${row.headroom.toFixed(2)} |`,
+		);
+	}
+	return lines.join("\n");
+}
+
+function renderSlowestTable(rows) {
+	if (!rows || rows.length === 0) {
+		return "";
+	}
+	const lines = ["| Test | Package | Elapsed (s) | Outcome |", "| --- | --- | ---: | --- |"];
+	for (const row of rows) {
+		lines.push(
+			`| \`${row.test}\` | \`${row.package}\` | ${row.seconds.toFixed(3)} | ${row.outcome} |`,
+		);
+	}
+	return lines.join("\n");
+}
+
+function renderProvenance(metadata) {
+	const lines = [];
+	if (textValue(metadata.headSha)) {
+		lines.push(`- Hosted head: \`${textValue(metadata.headSha)}\``);
+	}
+	if (textValue(metadata.runUrl)) {
+		lines.push(`- Hosted run: ${textValue(metadata.runUrl)}`);
+	}
+	return lines.join("\n");
+}
+
+/**
+ * upsertFunctionalCoverageComment finds this report's own marked bot comment
+ * and updates it, so a second run on the same pull request replaces the
+ * report instead of appending a duplicate.
+ */
+export function upsertFunctionalCoverageComment(comments, body, options = {}) {
+	const botLogin = options.botLogin || "github-actions[bot]";
+	const marker = options.marker || FUNCTIONAL_COVERAGE_COMMENT_MARKER;
+	const existing = (comments || []).find(
+		(comment) => comment.user?.login === botLogin && comment.body?.includes(marker),
+	);
+	if (existing) {
+		return { action: "update", commentId: existing.id, body };
+	}
+	return { action: "create", body };
+}
+
+function finiteNumber(value) {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function textValue(value) {
+	return typeof value === "string" ? value.trim() : "";
+}
+
+function readJson(path) {
+	if (!path) {
+		return null;
+	}
+	try {
+		return JSON.parse(readFileSync(path, "utf8"));
+	} catch {
+		return null;
+	}
+}
+
+function optionValue(args, name) {
+	const index = args.indexOf(name);
+	if (index === -1 || !args[index + 1]) {
+		return "";
+	}
+	return args[index + 1];
+}
+
+function runCli() {
+	const args = process.argv.slice(2);
+	const commentPath = optionValue(args, "--comment");
+	if (!commentPath) {
+		process.stderr.write("functional coverage comment: --comment path is required; skipping.\n");
+		return;
+	}
+	const summary = summarizeFunctionalCoverage(
+		readJson(optionValue(args, "--coverage")),
+		readJson(optionValue(args, "--timing")),
+	);
+	const body = renderFunctionalCoverageComment(summary, {
+		headSha: process.env.FUNCTIONAL_COVERAGE_HEAD_SHA || process.env.GITHUB_SHA,
+		runUrl:
+			process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
+				? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+				: "",
+	});
+	writeFileSync(commentPath, body);
+	process.stdout.write(`functional coverage comment written to ${commentPath}\n`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+	try {
+		runCli();
+	} catch (error) {
+		// Reporting is never allowed to fail the coverage job.
+		process.stderr.write(`functional coverage comment: ${error.message}\n`);
+	}
+}

--- a/scripts/ci/functional-coverage-comment.test.mjs
+++ b/scripts/ci/functional-coverage-comment.test.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { BACKEND_LINT_COMMENT_MARKER } from "./backend-lint-report.mjs";
+import {
+	FUNCTIONAL_COVERAGE_COMMENT_MARKER,
+	FUNCTIONAL_COVERAGE_PACKAGE_LIMIT,
+	FUNCTIONAL_COVERAGE_SLOWEST_TEST_LIMIT,
+	renderFunctionalCoverageComment,
+	summarizeFunctionalCoverage,
+	upsertFunctionalCoverageComment,
+} from "./functional-coverage-comment.mjs";
+
+function coverageArtifact() {
+	return {
+		complete: true,
+		coveredStatements: 30,
+		measurableStatements: 40,
+		coveragePercent: 75,
+		packages: [
+			{ package: "pkg/ample", coveragePercent: 99, packageFloor: 10 },
+			{ package: "pkg/near", coveragePercent: 80.5, packageFloor: 80 },
+			{ package: "pkg/regressed", coveragePercent: 40, packageFloor: 70 },
+			{ package: "pkg/ungated", coveragePercent: 12, packageFloor: null },
+		],
+	};
+}
+
+function timingArtifact() {
+	return {
+		version: 1,
+		complete: true,
+		wallSeconds: 61.5,
+		packageCount: 2,
+		expectedPackageCount: 2,
+		testCount: 3,
+		testFailCount: 1,
+		tests: [
+			{ package: "tests/functional/alpha", test: "TestQuick", seconds: 0.25, outcome: "pass" },
+			{ package: "tests/functional/alpha", test: "TestSlow", seconds: 40.125, outcome: "fail" },
+			{ package: "tests/functional/beta", test: "TestMiddle", seconds: 12.5, outcome: "pass" },
+		],
+	};
+}
+
+test("orders gated packages by headroom ascending with violations first", () => {
+	const summary = summarizeFunctionalCoverage(coverageArtifact(), timingArtifact());
+	assert.deepEqual(
+		summary.coverage.violations.map((entry) => entry.package),
+		["pkg/regressed"],
+	);
+	assert.deepEqual(
+		summary.coverage.nearFloor.map((entry) => entry.package),
+		["pkg/near", "pkg/ample"],
+	);
+	assert.equal(summary.coverage.gatedCount, 3);
+	assert.equal(summary.coverage.omitted, 0);
+});
+
+test("orders the slowest observed tests by elapsed descending", () => {
+	const summary = summarizeFunctionalCoverage(coverageArtifact(), timingArtifact());
+	assert.deepEqual(
+		summary.timing.slowest.map((entry) => entry.test),
+		["TestSlow", "TestMiddle", "TestQuick"],
+	);
+	assert.equal(summary.timing.observed, 3);
+	assert.equal(summary.timing.omitted, 0);
+});
+
+test("renders a marked body distinct from the backend lint comment", () => {
+	const body = renderFunctionalCoverageComment(
+		summarizeFunctionalCoverage(coverageArtifact(), timingArtifact()),
+		{ headSha: "abc123", runUrl: "https://example.test/run/1" },
+	);
+	assert.ok(body.startsWith(FUNCTIONAL_COVERAGE_COMMENT_MARKER));
+	assert.notEqual(FUNCTIONAL_COVERAGE_COMMENT_MARKER, BACKEND_LINT_COMMENT_MARKER);
+	assert.ok(!body.includes(BACKEND_LINT_COMMENT_MARKER));
+	assert.ok(body.includes("### Floor violations"));
+	assert.ok(body.includes("| `pkg/regressed` | 40.00 | 70.00 | -30.00 |"));
+	assert.ok(body.includes("### Slowest top-level tests"));
+	assert.ok(body.includes("| `TestSlow` | `tests/functional/alpha` | 40.125 | fail |"));
+	assert.ok(body.includes("- 0 additional row(s) omitted."));
+	assert.ok(body.includes("- Hosted head: `abc123`"));
+	assert.ok(body.includes("https://example.test/run/1"));
+	assert.ok(body.indexOf("### Floor violations") < body.indexOf("### Closest to their floor"));
+});
+
+test("caps both tables and states the omitted row counts", () => {
+	const packages = [];
+	for (let index = 0; index < FUNCTIONAL_COVERAGE_PACKAGE_LIMIT + 4; index += 1) {
+		packages.push({
+			package: `pkg/p${String(index).padStart(2, "0")}`,
+			coveragePercent: 50 + index,
+			packageFloor: 50,
+		});
+	}
+	const tests = [];
+	for (let index = 0; index < FUNCTIONAL_COVERAGE_SLOWEST_TEST_LIMIT + 7; index += 1) {
+		tests.push({
+			package: "tests/functional/alpha",
+			test: `TestCase${String(index).padStart(2, "0")}`,
+			seconds: index,
+			outcome: "pass",
+		});
+	}
+
+	const summary = summarizeFunctionalCoverage(
+		{ ...coverageArtifact(), packages },
+		{ ...timingArtifact(), tests },
+	);
+	assert.equal(summary.coverage.nearFloor.length, FUNCTIONAL_COVERAGE_PACKAGE_LIMIT);
+	assert.equal(summary.coverage.omitted, 4);
+	assert.equal(summary.timing.slowest.length, FUNCTIONAL_COVERAGE_SLOWEST_TEST_LIMIT);
+	assert.equal(summary.timing.omitted, 7);
+
+	const body = renderFunctionalCoverageComment(summary);
+	assert.ok(body.includes("- 4 additional gated package(s) omitted."));
+	assert.ok(body.includes("- 7 additional row(s) omitted."));
+	assert.ok(!body.includes("`TestCase00`"));
+});
+
+test("reports missing and malformed artifacts instead of throwing", () => {
+	for (const [coverage, timing] of [
+		[null, null],
+		[undefined, undefined],
+		["not json", 42],
+		[{ packages: "not an array" }, { tests: null }],
+	]) {
+		const summary = summarizeFunctionalCoverage(coverage, timing);
+		assert.equal(summary.coverage.available, false);
+		assert.equal(summary.timing.available, false);
+		const body = renderFunctionalCoverageComment(summary);
+		assert.ok(body.startsWith(FUNCTIONAL_COVERAGE_COMMENT_MARKER));
+		assert.ok(body.includes("Coverage summary: unavailable"));
+		assert.ok(body.includes("Timing summary: unavailable"));
+	}
+});
+
+test("updates its own marked comment and never the backend lint comment", () => {
+	const body = renderFunctionalCoverageComment(
+		summarizeFunctionalCoverage(coverageArtifact(), timingArtifact()),
+	);
+	const comments = [
+		{ id: 1, user: { login: "github-actions[bot]" }, body: `${BACKEND_LINT_COMMENT_MARKER}\nlint` },
+		{ id: 2, user: { login: "someone" }, body: `${FUNCTIONAL_COVERAGE_COMMENT_MARKER}\nimpostor` },
+	];
+
+	const created = upsertFunctionalCoverageComment(comments, body);
+	assert.equal(created.action, "create");
+	assert.equal(created.body, body);
+
+	const published = [
+		...comments,
+		{ id: 3, user: { login: "github-actions[bot]" }, body: created.body },
+	];
+	const updated = upsertFunctionalCoverageComment(published, `${body}second run`);
+	assert.equal(updated.action, "update");
+	assert.equal(updated.commentId, 3);
+	assert.equal(updated.body, `${body}second run`);
+
+	// A second upsert against the same thread still targets one comment.
+	assert.equal(
+		published.filter(
+			(comment) =>
+				comment.user.login === "github-actions[bot]" &&
+				comment.body.includes(FUNCTIONAL_COVERAGE_COMMENT_MARKER),
+		).length,
+		1,
+	);
+});

--- a/scripts/ci/functional-coverage-comment.test.mjs
+++ b/scripts/ci/functional-coverage-comment.test.mjs
@@ -6,6 +6,7 @@ import {
 	FUNCTIONAL_COVERAGE_COMMENT_MARKER,
 	FUNCTIONAL_COVERAGE_PACKAGE_LIMIT,
 	FUNCTIONAL_COVERAGE_SLOWEST_TEST_LIMIT,
+	FUNCTIONAL_COVERAGE_VIOLATION_LIMIT,
 	renderFunctionalCoverageComment,
 	summarizeFunctionalCoverage,
 	upsertFunctionalCoverageComment,
@@ -22,6 +23,9 @@ function coverageArtifact() {
 			{ package: "pkg/near", coveragePercent: 80.5, packageFloor: 80 },
 			{ package: "pkg/regressed", coveragePercent: 40, packageFloor: 70 },
 			{ package: "pkg/ungated", coveragePercent: 12, packageFloor: null },
+			// The functional lane holds unlisted packages to a 0.00 default
+			// floor. Those can never regress through it.
+			{ package: "pkg/lane-default", coveragePercent: 0, packageFloor: 0 },
 		],
 	};
 }
@@ -53,7 +57,9 @@ test("orders gated packages by headroom ascending with violations first", () => 
 		summary.coverage.nearFloor.map((entry) => entry.package),
 		["pkg/near", "pkg/ample"],
 	);
-	assert.equal(summary.coverage.gatedCount, 3);
+	assert.equal(summary.coverage.gatedCount, 4);
+	assert.equal(summary.coverage.violationCount, 1);
+	assert.equal(summary.coverage.omittedViolations, 0);
 	assert.equal(summary.coverage.omitted, 0);
 });
 
@@ -83,6 +89,8 @@ test("renders a marked body distinct from the backend lint comment", () => {
 	assert.ok(body.includes("- Hosted head: `abc123`"));
 	assert.ok(body.includes("https://example.test/run/1"));
 	assert.ok(body.indexOf("### Floor violations") < body.indexOf("### Closest to their floor"));
+	// A package held to the 0.00 lane-default floor cannot be close to failing.
+	assert.ok(!body.includes("`pkg/lane-default`"));
 });
 
 test("caps both tables and states the omitted row counts", () => {
@@ -117,6 +125,29 @@ test("caps both tables and states the omitted row counts", () => {
 	assert.ok(body.includes("- 4 additional gated package(s) omitted."));
 	assert.ok(body.includes("- 7 additional row(s) omitted."));
 	assert.ok(!body.includes("`TestCase00`"));
+});
+
+test("caps the violation table while reporting the true violation count", () => {
+	const packages = [];
+	for (let index = 0; index < FUNCTIONAL_COVERAGE_VIOLATION_LIMIT + 3; index += 1) {
+		packages.push({
+			package: `pkg/broken${String(index).padStart(2, "0")}`,
+			coveragePercent: index,
+			packageFloor: 90,
+		});
+	}
+
+	const summary = summarizeFunctionalCoverage({ ...coverageArtifact(), packages }, null);
+	assert.equal(summary.coverage.violations.length, FUNCTIONAL_COVERAGE_VIOLATION_LIMIT);
+	assert.equal(summary.coverage.violationCount, FUNCTIONAL_COVERAGE_VIOLATION_LIMIT + 3);
+	assert.equal(summary.coverage.omittedViolations, 3);
+
+	const body = renderFunctionalCoverageComment(summary);
+	assert.ok(body.includes(`- Floor violations: ${FUNCTIONAL_COVERAGE_VIOLATION_LIMIT + 3}`));
+	assert.ok(body.includes("- 3 additional violation(s) omitted."));
+	// The worst regression is always kept; the mildest ones are dropped.
+	assert.ok(body.includes("`pkg/broken00`"));
+	assert.ok(!body.includes("`pkg/broken27`"));
 });
 
 test("reports missing and malformed artifacts instead of throwing", () => {

--- a/scripts/ci/publish-functional-coverage-comment.sh
+++ b/scripts/ci/publish-functional-coverage-comment.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Renders the Backend Functional Coverage pull request comment body from the
+# coverage and timing artifacts the functional tier publishes. This is a
+# reporting-only sibling of publish-functional-test-summary.sh and is
+# deliberately fail-open: a missing artifact, a malformed document, or a
+# missing node runtime writes an explicit "unavailable" body (or nothing) and
+# exits 0. A reporting failure must never turn a passing suite red.
+
+set -uo pipefail
+
+artifact_root="${FUNCTIONAL_TEST_VIZ_DIR:-.artifacts/functional-test-viz}"
+timing_path="${FUNCTIONAL_TEST_VIZ_TIMING:-$artifact_root/functional-timing-summary.json}"
+coverage_path="${FUNCTIONAL_TEST_VIZ_JSON:-$artifact_root/coverage-summary.json}"
+comment_path="${FUNCTIONAL_COVERAGE_COMMENT_FILE:-$artifact_root/functional-coverage-comment.md}"
+node_bin="${NODE_BIN:-node}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+mkdir -p "$(dirname "$comment_path")" 2>/dev/null || true
+
+if ! command -v "$node_bin" >/dev/null 2>&1; then
+  echo "functional coverage comment: $node_bin is unavailable; skipping comment body." >&2
+  exit 0
+fi
+
+"$node_bin" "$script_dir/functional-coverage-comment.mjs" \
+  --coverage "$coverage_path" \
+  --timing "$timing_path" \
+  --comment "$comment_path"
+status=$?
+if [ "$status" -ne 0 ]; then
+  echo "functional coverage comment: renderer exited with $status; continuing without a comment body." >&2
+fi
+
+exit 0


### PR DESCRIPTION
## PRD

This PR implements `prd.json` for the `cov-r1-functional-coverage-and-timing-report` lane. All four user stories are `passes: true`.

```json
{
  "project": "you-agent-factory",
  "branchName": "cov-r1-functional-coverage-and-timing-report",
  "description": "Make the Backend Functional Coverage CI job legible: quiet the ~300-line raw per-package coverage log stream in favor of an ordered verdict block (floor violations first), add a Headroom column to the job-summary coverage table sorted ascending, render already-captured per-test timing data as a slowest-tests table, and post/upsert a PR comment mirroring the existing Backend Lint pattern. Reporting-only: no floor, threshold, manifest entry, or gate exit code changes.",
  "context": {
    "customerAsk": "The Backend Functional Coverage CI job log is unreadable (the one actionable regression line is buried under ~300 raw per-package coverage lines), the job summary table is sorted by import path instead of severity, per-test timing data is captured but never rendered, and nothing about a coverage failure ever reaches the PR conversation the way Backend Lint's comment does. Fix the reporting surface without changing what passes.",
    "problem": "internal/functionaltestviz/coverage_markdown.go:47 StableOrderedPackages sorts by import path with no headroom/distance-to-floor column, so a regression among 300+ rows is invisible. cmd/gocoveragecheck/timing.go:66 functionalTestTimingJSON already captures per-test {Package, Test, Seconds, Outcome, Reason} rows, but internal/functionaltestviz/timing_markdown.go renders only the package-level table, discarding per-test data. scripts/ci/publish-functional-test-summary.sh only writes to $GITHUB_STEP_SUMMARY; unlike Backend Lint (ci.yml:333, ci.yml:353, scripts/ci/backend-lint-workflow.mjs), functional coverage never posts a PR comment.",
    "solution": "S1: stop streaming per-package 'coverage: N% of statements' lines in cmd/gocoveragecheck; print a compact end-of-run block with floor violations first, then near-floor packages, then a tally, while writing full per-package data to existing JSON artifacts and leaving all other streamed lines untouched. S2: add a Headroom column (coverage % minus floor) to the coverage_markdown.go table and sort ascending by headroom with import-path tiebreak. S3: add a capped, elapsed-descending slowest-top-level-tests table to timing_markdown.go sourced from existing per-test timing JSON, stating the omitted-row count. S4: extend scripts/ci/publish-functional-test-summary.sh (or a sibling) to also produce a PR-comment body, and add an if: always() && github.event_name == 'pull_request' github-script step to the backend-coverage job that finds-by-marker and upserts, using a marker distinct from the Backend Lint comment."
  },
  "acceptanceCriteria": [
    "On a run with a floor violation, the CI job log no longer contains ~300 consecutive raw per-package 'coverage: N% of statements' lines; instead the log ends with a compact ordered verdict block where any floor violation appears before the near-floor summary and tally, and all other streamed output (test failures, panics, progress) is unchanged.",
    "The job summary's package coverage table includes a Headroom column (coverage % minus floor, blank when no floor applies) and is ordered by headroom ascending with import-path order as tiebreak; all existing columns are preserved.",
    "The job summary includes a slowest-top-level-tests table (Test | Package | Elapsed (s) | Outcome) populated from existing per-test timing data, ordered by elapsed descending, with a stated cap and an explicit count of omitted rows; the existing package timing table is preserved.",
    "A PR comment distinct from the Backend Lint comment (different marker string) is created on the lane's own PR containing the ordered coverage summary and timing highlights, and a second CI run on the same PR updates that comment in place instead of adding a second one.",
    "No floor, threshold, minimum, manifest entry (including docs/internal/baselines/go-*-coverage-package-minimums.json), or gate exit code changes; gocoveragecheck is never invoked with -update-manifest; no unit-lane (lane=unit) rendering, script, or CI step is modified.",
    "Every new or modified CI step in the backend-coverage job runs with if: always() and exits 0 when its expected inputs are missing, so a reporting failure cannot fail the job or any downstream job depending on ci.yml; no existing step's if:/always()/matrix/timeout/needs condition is altered.",
    "Quality gate: typecheck passes; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green; make test-functional-coverage exits non-zero on a floor violation and zero otherwise, both outcomes demonstrated.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts (including in .github/workflows/ci.yml against other concurrently open lanes), and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "cov-r1-functional-coverage-and-timing-report-001",
      "title": "Quiet the per-package log stream and print an ordered verdict block",
      "description": "As a CI reader, I want the functional coverage job log to stop repeating ~300 raw per-package coverage lines and instead show floor violations and near-floor packages up front, so I can diagnose a regression without scrolling past noise.",
      "acceptanceCriteria": [
        "cmd/gocoveragecheck no longer streams the raw 'coverage: N% of statements' line for every package to the log during a functional run",
        "At the end of a run, the log contains a single compact block: any floor violations first (package, floor, actual, delta, uncovered blocks), then the N packages closest to their floor, then a one-line tally (total/violations/near-floor counts)",
        "All non-coverage streamed output (test failures, panics, progress) is unchanged in content and ordering",
        "Full per-package data continues to be written to the existing JSON artifacts (no data loss, only log-line suppression)",
        "make test-functional-coverage still exits non-zero when a floor violation exists and zero when it does not (both demonstrated)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "cmd/gocoveragecheck/coverage_verdict.go renders the functional ordered verdict block (violations -> near-floor -> tally); functional_stream.go drops the standalone per-package \"coverage: N% of statements\" output event. Unit lane and the malformed-manifest abort path keep the raw listing. Verified by coverage_verdict_test.go (both exit outcomes, ordering, JSON artifact completeness, unit-lane regression guard)."
    },
    {
      "id": "cov-r1-functional-coverage-and-timing-report-002",
      "title": "Add headroom ranking to the coverage summary table",
      "description": "As a reviewer reading the job summary, I want the package coverage table sorted by how close each package is to its floor, so regressions and near-misses are visible without scanning every row.",
      "acceptanceCriteria": [
        "internal/functionaltestviz/coverage_markdown.go adds a Headroom column (coverage % minus floor; blank when the package has no floor)",
        "The rendered table is ordered by headroom ascending, with import-path order as the deterministic tiebreak",
        "All previously existing columns (Package, Covered, Measurable, Coverage %, Floor, Measurement exception) are preserved",
        "No floor value, threshold, or manifest entry is changed by this story",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "internal/functionaltestviz/coverage_markdown.go adds a Headroom column and HeadroomOrderedPackages (headroom ascending, import-path tiebreak, ungated packages last). Golden testdata/full-report/functional-tests.md regenerated."
    },
    {
      "id": "cov-r1-functional-coverage-and-timing-report-003",
      "title": "Render slowest top-level test durations",
      "description": "As a maintainer investigating a slow functional suite run, I want to see which individual tests took the longest, not just per-package totals, so I can find the actual slow test.",
      "acceptanceCriteria": [
        "internal/functionaltestviz/timing_markdown.go renders a new section listing the slowest top-level tests as '| Test | Package | Elapsed (s) | Outcome |', ordered by elapsed time descending, sourced from the existing per-test rows already captured by cmd/gocoveragecheck/timing.go",
        "The rendered list is capped at a stated number of rows, and the text explicitly states how many additional rows were omitted (0 when nothing was omitted)",
        "The existing per-package timing table and scalar counts are preserved unchanged",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "internal/functionaltestviz/timing_markdown.go renders \"### Slowest top-level tests\" (Test | Package | Elapsed (s) | Outcome), elapsed descending, capped at 15 rows with the omitted count always stated. Package table, scalar counts and failed-tests table unchanged."
    },
    {
      "id": "cov-r1-functional-coverage-and-timing-report-004",
      "title": "Post and upsert a functional coverage PR comment",
      "description": "As a PR author, I want the functional coverage report to appear as a PR comment (like Backend Lint already does), and I want a re-run to update that comment instead of adding a duplicate, so the PR conversation reflects only the latest state.",
      "acceptanceCriteria": [
        "scripts/ci/publish-functional-test-summary.sh (or a sibling script) additionally writes a PR-comment body file containing the ordered coverage summary and slowest-tests highlights",
        "A new backend-coverage job step runs with if: always() && github.event_name == 'pull_request' and upserts the comment via a find-by-marker-then-update approach (mirroring scripts/ci/backend-lint-workflow.mjs's upsert), using a marker string distinct from the Backend Lint comment marker",
        "Running CI twice on the same PR results in exactly one functional coverage comment that reflects the second run's content, not two comments",
        "The step exits 0 and does not fail the job when its expected input artifacts are missing or malformed (fail-open verified)",
        "No existing backend-coverage job step's if: condition, matrix, timeout, or needs is altered; no existing step's always() behavior is touched",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "scripts/ci/functional-coverage-comment.mjs (marker <!-- functional-coverage-report -->) + publish-functional-coverage-comment.sh render the body; two new fail-open backend-coverage steps (if: always(), continue-on-error) render and upsert it. Job gains pull-requests: write. Registered in make test-ci-workflows."
    }
  ]
}
```
