### PR TITLE
test(worker-sessions): read the concurrent dispatch count after terminal delivery

### DIFF
--- a/pkg/services/worker_sessions/internal/service/start_test.go
+++ b/pkg/services/worker_sessions/internal/service/start_test.go
@@ -657,10 +657,13 @@ func TestStart_ConcurrentSameRequestIDConvergesOnOneExecution(t *testing.T) {
 	if accepted.ID != req.ID {
 		t.Fatalf("concurrent accepted session ID = %q, want %q", accepted.ID, req.ID)
 	}
+	// Start is async: it returns once admission converges, while the winning
+	// caller dispatches on its own goroutine. Read the dispatch count only after
+	// the terminal event proves that goroutine ran, or the count races to 0.
+	assertTerminalDelivery(t, terminalSubscription)
 	if execution.callCount() != 1 {
 		t.Fatalf("concurrent Workers dispatch count = %d, want exactly one", execution.callCount())
 	}
-	assertTerminalDelivery(t, terminalSubscription)
 	read, err := eventsSvc.Read(context.Background(), events.ReadRequest{
 		Topic: workersessions.Topic(req.ID),
 		From:  events.Cursor{Topic: workersessions.Topic(req.ID)},


### PR DESCRIPTION
## Problem

`Backend Unit Coverage` went red on main at `3e3e75a40` ([run 32091670708](https://github.com/portpowered/you-agent-factory/actions/runs/32091670708)):

```
--- FAIL: TestStart_ConcurrentSameRequestIDConvergesOnOneExecution (0.00s)
    start_test.go:661: concurrent Workers dispatch count = 0, want exactly one
coverage not evaluated: 1 failed tests observed; package floors were NOT checked
```

The failing test is in `worker_sessions`, unrelated to the `dcp-t3` mapping move that head carried. Note the second line: a single failing test blanks the package floor check for the whole suite, so this flake costs far more than one test.

## Cause

The test asserts `execution.callCount() == 1` *before* `assertTerminalDelivery`. `Start` is async — it returns once admission converges, while the winning caller dispatches on its own goroutine. The count was read before that goroutine ran and observed `0`.

Every assertion above the failing line passed: all 8 callers returned nil error, converged on one session, and matched `req.ID`. Only the dispatch count raced.

## Fix

Read the dispatch count after the terminal event, which proves the dispatch goroutine ran. Four lines, test-only.

## Evidence

Stressed on `3e3e75a40` in a detached worktree:

| | runs | failures |
|---|---|---|
| before | 500 | 17 (3.4%) |
| after | 1500 | 0 |

## Sibling sweep

Checked every other `execution.callCount()` assertion in the package (`service_test.go:465,490,520,585`, `start_side_effects_test.go`, `start_test.go:51,79`). All use synchronous `InvokeSession` or wait on a channel first. This was the only instance of the shape.

## Non-goals

No production change, no floor/manifest/threshold change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)