### PR TITLE
report every functional test's elapsed time in the job summary

### DIFF
--- a/internal/functionaltestviz/timing_markdown.go
+++ b/internal/functionaltestviz/timing_markdown.go
@@ -58,20 +58,18 @@ func RenderFunctionalTimingMarkdown(summary FunctionalTimingSummary) string {
 	}
 
 	renderFunctionalTestFailures(&b, summary.Tests)
-	renderSlowestFunctionalTests(&b, summary.Tests)
+	renderFunctionalTestsByElapsed(&b, summary.Tests)
 	return b.String()
 }
 
-// slowestFunctionalTestReportLimit caps how many individual tests the slowest-
-// tests table names. The rendered text always states how many rows the cap
-// dropped so a truncated table is never mistaken for the whole suite.
-const slowestFunctionalTestReportLimit = 15
-
-// renderSlowestFunctionalTests renders the longest-running top-level tests
-// from the per-test rows already captured alongside the package timings.
-// Package totals answer "which package is slow"; this answers "which test".
-// Nothing is rendered when a run captured no per-test rows at all.
-func renderSlowestFunctionalTests(output *strings.Builder, tests []FunctionalTestTiming) {
+// renderFunctionalTestsByElapsed renders every top-level test the run observed,
+// slowest first, from the per-test rows already captured alongside the package
+// timings. Package totals answer "which package is slow"; this answers "how
+// long did each test take". The job summary is the one surface with room for
+// the complete list, so it is not truncated here -- the pull request comment
+// renderer caps its own excerpt separately. Nothing is rendered when a run
+// captured no per-test rows at all.
+func renderFunctionalTestsByElapsed(output *strings.Builder, tests []FunctionalTestTiming) {
 	if len(tests) == 0 {
 		return
 	}
@@ -87,18 +85,15 @@ func renderSlowestFunctionalTests(output *strings.Builder, tests []FunctionalTes
 		return slowest[i].Test < slowest[j].Test
 	})
 
-	shown := min(len(slowest), slowestFunctionalTestReportLimit)
-	output.WriteString("\n### Slowest top-level tests\n\n")
+	output.WriteString("\n### Top-level tests by elapsed time\n\n")
 	fmt.Fprintf(
 		output,
-		"- Showing the %d slowest of %d observed top-level tests by elapsed time; %d additional row(s) omitted.\n\n",
-		shown,
+		"- Showing all %d observed top-level tests by elapsed time, slowest first.\n\n",
 		len(slowest),
-		len(slowest)-shown,
 	)
 	output.WriteString("| Test | Package | Elapsed (s) | Outcome |\n")
 	output.WriteString("| --- | --- | ---: | --- |\n")
-	for _, test := range slowest[:shown] {
+	for _, test := range slowest {
 		output.WriteString("| `")
 		output.WriteString(test.Test)
 		output.WriteString("` | `")

--- a/internal/functionaltestviz/timing_markdown_test.go
+++ b/internal/functionaltestviz/timing_markdown_test.go
@@ -156,11 +156,11 @@ func TestRenderFunctionalTimingMarkdownRendersSlowestTopLevelTests(t *testing.T)
 
 	rendered := functionaltestviz.RenderFunctionalTimingMarkdown(summary)
 
-	if !strings.Contains(rendered, "### Slowest top-level tests\n") {
+	if !strings.Contains(rendered, "### Top-level tests by elapsed time\n") {
 		t.Fatalf("slowest top-level tests section missing:\n%s", rendered)
 	}
-	if !strings.Contains(rendered, "- Showing the 3 slowest of 3 observed top-level tests by elapsed time; 0 additional row(s) omitted.\n") {
-		t.Fatalf("slowest-tests section must state its cap and omitted count:\n%s", rendered)
+	if !strings.Contains(rendered, "- Showing all 3 observed top-level tests by elapsed time, slowest first.\n") {
+		t.Fatalf("per-test section must state the full observed count:\n%s", rendered)
 	}
 	if !strings.Contains(rendered, "| Test | Package | Elapsed (s) | Outcome |\n") {
 		t.Fatalf("slowest-tests table header missing:\n%s", rendered)
@@ -171,7 +171,7 @@ func TestRenderFunctionalTimingMarkdownRendersSlowestTopLevelTests(t *testing.T)
 
 	// Scope the ordering assertion to the new section: the failed-tests table
 	// above it names the same tests in a different order by design.
-	section := rendered[strings.Index(rendered, "### Slowest top-level tests\n"):]
+	section := rendered[strings.Index(rendered, "### Top-level tests by elapsed time\n"):]
 	slowest := strings.Index(section, "| `TestSlowest` |")
 	middle := strings.Index(section, "| `TestMiddle` |")
 	quick := strings.Index(section, "| `TestQuick` |")
@@ -181,7 +181,7 @@ func TestRenderFunctionalTimingMarkdownRendersSlowestTopLevelTests(t *testing.T)
 
 	// The package table and its scalar counts stay exactly where they were.
 	packageTable := strings.Index(rendered, "| Package | Elapsed (s) | Outcome |\n")
-	if packageTable < 0 || packageTable >= strings.Index(rendered, "### Slowest top-level tests\n") {
+	if packageTable < 0 || packageTable >= strings.Index(rendered, "### Top-level tests by elapsed time\n") {
 		t.Fatalf("the per-package timing table must be preserved above the slowest-tests section:\n%s", rendered)
 	}
 	if !strings.Contains(rendered, "- Top-level tests with observed outcomes: 3\n") {
@@ -189,7 +189,7 @@ func TestRenderFunctionalTimingMarkdownRendersSlowestTopLevelTests(t *testing.T)
 	}
 }
 
-func TestRenderFunctionalTimingMarkdownCapsSlowestTopLevelTests(t *testing.T) {
+func TestRenderFunctionalTimingMarkdownReportsEveryObservedTest(t *testing.T) {
 	t.Parallel()
 
 	summary := functionaltestviz.FunctionalTimingSummary{
@@ -213,14 +213,17 @@ func TestRenderFunctionalTimingMarkdownCapsSlowestTopLevelTests(t *testing.T) {
 
 	rendered := functionaltestviz.RenderFunctionalTimingMarkdown(summary)
 
-	if rows := strings.Count(rendered, "| `TestCase"); rows != 15 {
-		t.Fatalf("slowest-tests rows = %d, want the 15-row cap:\n%s", rows, rendered)
+	if rows := strings.Count(rendered, "| `TestCase"); rows != observed {
+		t.Fatalf("per-test rows = %d, want every one of the %d observed tests:\n%s", rows, observed, rendered)
 	}
-	if !strings.Contains(rendered, "- Showing the 15 slowest of 20 observed top-level tests by elapsed time; 5 additional row(s) omitted.\n") {
-		t.Fatalf("capped slowest-tests section must state its omitted count:\n%s", rendered)
+	if !strings.Contains(rendered, "- Showing all 20 observed top-level tests by elapsed time, slowest first.\n") {
+		t.Fatalf("per-test section must state the full observed count:\n%s", rendered)
 	}
-	if strings.Contains(rendered, "| `TestCase04` |") {
-		t.Fatalf("the five fastest tests must be the omitted rows:\n%s", rendered)
+	// The job summary is the surface with room for the whole list, so the
+	// fastest tests must survive too -- truncation belongs to the pull
+	// request comment renderer alone.
+	if !strings.Contains(rendered, "| `TestCase00` |") {
+		t.Fatalf("the fastest test must still be reported:\n%s", rendered)
 	}
 }
 
@@ -236,7 +239,7 @@ func TestRenderFunctionalTimingMarkdownOmitsSlowestSectionWithoutPerTestRows(t *
 			{Package: "github.com/portpowered/infinite-you/tests/functional/alpha", Seconds: 1.0, Outcome: "pass"},
 		},
 	})
-	if strings.Contains(rendered, "### Slowest top-level tests") {
+	if strings.Contains(rendered, "### Top-level tests by elapsed time") {
 		t.Fatalf("a run with no per-test rows must not render an empty slowest-tests table:\n%s", rendered)
 	}
 	if !strings.Contains(rendered, "| Package | Elapsed (s) | Outcome |\n") {


### PR DESCRIPTION
Follow-up to #2061, closing the last gap against the request that prompted it: *"for the tests i want to see how long each took."*

## Problem

#2061 added a per-test timing table, but capped it at the 15 slowest:

```
### Slowest top-level tests

- Showing the 15 slowest of N observed top-level tests by elapsed time; M additional row(s) omitted.
```

That cap applied to **both** output surfaces, because `RenderFunctionalTimingMarkdown` feeds the job summary and the PR comment renderer independently reads the same JSON. So "how long did each test take" could not be answered from any human-readable output — everything below the top 15 existed only inside the uploaded `functional-timing-summary.json`.

## Fix

The job summary now renders every observed top-level test, slowest first:

```
### Top-level tests by elapsed time

- Showing all N observed top-level tests by elapsed time, slowest first.
```

The PR comment renderer (`scripts/ci/functional-coverage-comment.mjs`) is deliberately **unchanged** and keeps its 10-row excerpt. Comment bodies have a hard size limit; job summaries have a 1 MB budget that a few hundred table rows does not approach. Splitting the two is the point — the comment stays skimmable, the summary stays complete.

## Scope

Test-reporting only. Two files, both under `internal/functionaltestviz`. No floor, threshold, manifest entry, or gate exit code changes; no production code touched.

## Verification

- `go test ./internal/functionaltestviz/` passes.
- `TestRenderFunctionalTimingMarkdownCapsSlowestTopLevelTests` became `TestRenderFunctionalTimingMarkdownReportsEveryObservedTest` and now asserts all 20 rows render, including the fastest.
- Repo-wide sweep for the removed identifiers found no stale references; the only remaining `Slowest top-level tests` strings are the PR-comment renderer's own, which is intended.
- Control run: `internal/functionaltestmetadata` and `internal/migrationledgercheck` fail identically with and without this change on this host (gitignored `docs/temp/` paths absent from a fresh worktree), so they are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)