### PR TITLE
cov-r2-unit-coverage-and-timing-report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,9 +188,10 @@ jobs:
     # always-run summary and artifact-upload steps can preserve partial
     # diagnostics after a timeout.
     timeout-minutes: 80
-    # The functional lane upserts its own reporting comment on the pull
-    # request, mirroring Backend Lint. Every other permission stays at the
-    # workflow-level read-only default.
+    # Both lanes upsert their own reporting comment on the pull request,
+    # mirroring Backend Lint. Each uses a distinct HTML-comment marker, so the
+    # two reports never find, overwrite, or delete each other's comment. Every
+    # other permission stays at the workflow-level read-only default.
     permissions:
       contents: read
       pull-requests: write
@@ -226,6 +227,99 @@ jobs:
       - name: Run backend coverage
         if: matrix.suite == 'unit'
         run: make test-unit-coverage
+        env:
+          GO_UNIT_COVERAGE_PROFILE: .artifacts/unit-coverage/coverage.out
+          GO_UNIT_COVERAGE_JSON_OUTPUT: .artifacts/unit-coverage/coverage-summary.json
+          GO_UNIT_COVERAGE_TIMING_OUTPUT: .artifacts/unit-coverage/unit-timing-summary.json
+      # Reporting only. Every unit step below is additive and runs with
+      # if: always() so a failing or timed-out lane still publishes the partial
+      # diagnostics it did produce. Each is fail-open: a missing or malformed
+      # artifact writes an explicit "unavailable" body and exits 0, so a
+      # renderer or API failure can never turn a passing suite red. Node is set
+      # up here rather than beside the Go toolchain so the measured lane runs in
+      # exactly the environment it ran in before.
+      - name: Set up Node for unit coverage reporting
+        if: always() && matrix.suite == 'unit'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Publish unit coverage job summary
+        if: always() && matrix.suite == 'unit'
+        continue-on-error: true
+        run: bash scripts/ci/publish-unit-coverage-summary.sh
+        env:
+          UNIT_COVERAGE_DIR: .artifacts/unit-coverage
+          UNIT_COVERAGE_PROFILE: .artifacts/unit-coverage/coverage.out
+          UNIT_COVERAGE_JSON: .artifacts/unit-coverage/coverage-summary.json
+          UNIT_COVERAGE_TIMING: .artifacts/unit-coverage/unit-timing-summary.json
+          UNIT_COVERAGE_SUMMARY_FILE: .artifacts/unit-coverage/unit-coverage-summary.md
+      - name: Upload unit coverage diagnostics
+        if: always() && matrix.suite == 'unit'
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-coverage-diagnostics
+          path: |
+            .artifacts/unit-coverage/coverage.out
+            .artifacts/unit-coverage/coverage-summary.json
+            .artifacts/unit-coverage/unit-timing-summary.json
+            .artifacts/unit-coverage/unit-coverage-summary.md
+          if-no-files-found: ignore
+          retention-days: 14
+      - name: Render unit coverage pull request comment
+        if: always() && matrix.suite == 'unit'
+        continue-on-error: true
+        run: bash scripts/ci/publish-unit-coverage-comment.sh
+        env:
+          UNIT_COVERAGE_DIR: .artifacts/unit-coverage
+          UNIT_COVERAGE_JSON: .artifacts/unit-coverage/coverage-summary.json
+          UNIT_COVERAGE_TIMING: .artifacts/unit-coverage/unit-timing-summary.json
+          UNIT_COVERAGE_COMMENT_FILE: .artifacts/unit-coverage/unit-coverage-comment.md
+          UNIT_COVERAGE_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Publish unit coverage report to the pull request
+        if: always() && matrix.suite == 'unit' && github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          UNIT_COVERAGE_COMMENT_FILE: .artifacts/unit-coverage/unit-coverage-comment.md
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('node:fs');
+            const commentPath = `${process.env.GITHUB_WORKSPACE}/${process.env.UNIT_COVERAGE_COMMENT_FILE}`;
+            let body = '';
+            try {
+              body = fs.readFileSync(commentPath, 'utf8');
+            } catch (error) {
+              core.info(`unit coverage comment body unavailable at ${commentPath}: ${error.message}`);
+              return;
+            }
+            if (!body.trim()) {
+              core.info('unit coverage comment body is empty; nothing to publish.');
+              return;
+            }
+            const { upsertUnitCoverageComment } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/ci/unit-coverage-report.mjs`);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const publication = upsertUnitCoverageComment(comments, body);
+            if (publication.action === 'update') {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: publication.commentId,
+                body: publication.body,
+              });
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: publication.body,
+            });
       # This is the authoritative Linux functional run. Pull requests and
       # pushes to main use the same complete non-short tier. The run expands
       # ./tests/functional/... once, subtracts only the versioned quarantine,

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,8 @@ FUNCTIONAL_TEST_TRIGGER ?= local
 FUNCTIONAL_TEST_BUDGET ?= 35m
 FUNCTIONAL_SHORT ?= true
 GO_UNIT_COVERAGE_PROFILE ?=
+GO_UNIT_COVERAGE_JSON_OUTPUT ?=
+GO_UNIT_COVERAGE_TIMING_OUTPUT ?=
 GO_FUNCTIONAL_COVERAGE_PROFILE ?=
 GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT ?=
 GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT ?=
@@ -672,8 +674,13 @@ test-coverage-go:
 	$(info make test-coverage-go is a compatibility alias for unit coverage; use make test-functional-coverage for the independent functional report.)
 	$(MAKE) test-unit-coverage
 
+# The three GO_UNIT_COVERAGE_* output paths are optional and independent. Each
+# is forwarded only when it is set, so an invocation with none of them set runs
+# exactly the command it ran before reporting existed. Setting the JSON or
+# timing path never changes the gate: gocoveragecheck's exit code stays the sole
+# pass/fail signal.
 test-unit-coverage:
-	$(GO) run ./cmd/gocoveragecheck -suite unit -min $(GO_UNIT_COVERAGE_MIN) -package-manifest $(GO_UNIT_COVERAGE_MANIFEST) -timeout $(GO_COVERAGE_TIMEOUT) $(if $(GO_UNIT_COVERAGE_PROFILE),-profile $(GO_UNIT_COVERAGE_PROFILE),)
+	$(GO) run ./cmd/gocoveragecheck -suite unit -min $(GO_UNIT_COVERAGE_MIN) -package-manifest $(GO_UNIT_COVERAGE_MANIFEST) -timeout $(GO_COVERAGE_TIMEOUT) $(if $(GO_UNIT_COVERAGE_PROFILE),-profile $(GO_UNIT_COVERAGE_PROFILE),) $(if $(GO_UNIT_COVERAGE_JSON_OUTPUT),-json-output $(GO_UNIT_COVERAGE_JSON_OUTPUT),) $(if $(GO_UNIT_COVERAGE_TIMING_OUTPUT),-timing-output $(GO_UNIT_COVERAGE_TIMING_OUTPUT),)
 
 # test-functional-coverage always runs functional-boundary-check first so the
 # required CI Backend Functional Coverage lane (and any local/alias caller of

--- a/Makefile
+++ b/Makefile
@@ -483,7 +483,7 @@ readme-check:
 test: test-unit test-ci-workflows
 
 test-ci-workflows:
-	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs scripts/ci/lane-budget.test.mjs scripts/ci/backend-lint-report.test.mjs scripts/ci/backend-lint-workflow.test.mjs scripts/ci/functional-coverage-comment.test.mjs
+	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs scripts/ci/lane-budget.test.mjs scripts/ci/backend-lint-report.test.mjs scripts/ci/backend-lint-workflow.test.mjs scripts/ci/functional-coverage-comment.test.mjs scripts/ci/unit-coverage-report.test.mjs
 
 test-full:
 	$(GO) test ./... -timeout $(GO_TEST_TIMEOUT)

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -355,7 +357,7 @@ func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, test
 			failedTestCountKnown = failedTestCountKnown && known
 		}
 
-		detail := mergeGoTestFailureDetail(batchStderr, batchStdout)
+		detail := mergeGoTestFailureDetail(batchStderr, coverageFailureDetailStdout(cfg, batchStdout))
 		batchFailurePrefix := failurePrefix
 		if len(plan.invocations) > 1 {
 			batchFailurePrefix = fmt.Sprintf("%s (batch %d/%d)", failurePrefix, index+1, len(plan.invocations))
@@ -613,6 +615,54 @@ func configureCoverageInvocationObservation(plan *coverageInvocationPlan, observ
 		plan.invocations[index].stderrWriter = reporter.stderrWriter(io.Discard)
 	}
 	return reporter
+}
+
+// coverageFailureDetailStdout returns the child stdout a failing batch should
+// be attributed with.
+//
+// Asking for a timing summary switches the child go test to -json, so the
+// buffered stdout holds test2json events rather than the human text a reader
+// needs to see which test failed and why. A lane that captures timing without
+// streaming therefore renders the human output back out of those events, which
+// keeps a failing unit lane exactly as diagnosable as it is with timing capture
+// switched off.
+//
+// A streaming lane already forwarded the human text to its sink line by line,
+// so its buffer is returned unchanged.
+func coverageFailureDetailStdout(cfg config, stdout string) string {
+	if cfg.stream || strings.TrimSpace(cfg.timingOutput) == "" {
+		return stdout
+	}
+	return renderGoTestEventOutput(stdout)
+}
+
+// renderGoTestEventOutput reconstitutes the human-readable go test stream from
+// captured test2json events. go test wraps every byte the test binary and the
+// toolchain write in an "output" event, so replaying those events in order
+// reproduces the original stream. Lines that are not decodable events pass
+// through unchanged: a child that crashed before test2json framed its output
+// still contributes its raw fragment.
+func renderGoTestEventOutput(stdout string) string {
+	if strings.TrimSpace(stdout) == "" {
+		return stdout
+	}
+	var rendered strings.Builder
+	scanner := bufio.NewScanner(strings.NewReader(stdout))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		var event goTestTimingEvent
+		if err := json.Unmarshal(bytes.TrimSpace(line), &event); err != nil || event.Package == "" {
+			rendered.Write(line)
+			rendered.WriteString("\n")
+			continue
+		}
+		if event.Action != "output" {
+			continue
+		}
+		rendered.WriteString(event.Output)
+	}
+	return rendered.String()
 }
 
 func mergeGoTestFailureDetail(stderr string, stdout string) string {

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -429,7 +429,7 @@ func configureFunctionalTimingSnapshot(plan *coverageInvocationPlan, cfg config,
 			return writePartialCoverageSnapshot(cfg.jsonOutput, profilePath, repoRoot, coverPackages, partialCoverageReason(nil))
 		},
 	)
-	snapshotter.publish(false, "functional run started", false)
+	snapshotter.publish(false, coverageLaneNoun(cfg.suite)+" run started", false)
 	return snapshotter
 }
 
@@ -444,7 +444,7 @@ func finalizeFunctionalTiming(cfg config, snapshotter *functionalTimingSnapshott
 	summary := buildFunctionalTimingSummary(stdout, testPackages, wallSeconds)
 	timingReason := ""
 	if !summary.Complete {
-		timingReason = "functional timing capture ended before every package reported a terminal result"
+		timingReason = coverageLaneNoun(cfg.suite) + " timing capture ended before every package reported a terminal result"
 		if laneErr != nil {
 			timingReason += ": " + compactDiagnosticError(laneErr)
 		}

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -444,7 +444,7 @@ func finalizeFunctionalTiming(cfg config, snapshotter *functionalTimingSnapshott
 	summary := buildFunctionalTimingSummary(stdout, testPackages, wallSeconds)
 	timingReason := ""
 	if !summary.Complete {
-		timingReason = coverageLaneNoun(cfg.suite) + " timing capture ended before every package reported a terminal result"
+		timingReason = coverageLaneNoun(cfg.suite) + " " + incompleteTimingCaptureCause(summary)
 		if laneErr != nil {
 			timingReason += ": " + compactDiagnosticError(laneErr)
 		}
@@ -459,6 +459,20 @@ func finalizeFunctionalTiming(cfg config, snapshotter *functionalTimingSnapshott
 		writeFunctionalTimingInventorySummary(summary, cfg.short)
 	}
 	return err
+}
+
+// incompleteTimingCaptureCause names why a capture is partial. The two causes
+// are unrelated and a reader acts on them differently, so reporting the wrong
+// one is worse than reporting none: the unit lane's first hosted run recorded
+// every one of its 548 packages and still described itself as having ended
+// early, which sends a reader hunting a truncated run that never happened.
+// Failing to parse a fraction of the child's output is the ordinary case at
+// that size, where one unreadable line among hundreds of thousands is enough.
+func incompleteTimingCaptureCause(summary functionalTimingSummaryJSON) string {
+	if summary.PackageCount < summary.ExpectedPackageCount {
+		return "timing capture ended before every package reported a terminal result"
+	}
+	return "timing capture could not read every go test event, so some per-test rows may be missing"
 }
 
 func publishPartialCoverageIfNeeded(cfg config, profilePath string, repoRoot string, coverPackages []string, laneErr error, mergeErr error) error {

--- a/cmd/gocoveragecheck/coverage_json_test.go
+++ b/cmd/gocoveragecheck/coverage_json_test.go
@@ -323,9 +323,15 @@ func TestExecuteWritesJSONWhenOverallFloorFails(t *testing.T) {
 		t.Fatalf("packages len = %d, want 2", len(summary.Packages))
 	}
 
+	// The complete per-package set is asserted on the JSON summary above. With
+	// that artifact written, stdout carries the collapsed lane verdict rather
+	// than one raw coverage line per measured package.
 	got := stdout.String()
-	if !strings.Contains(got, modulePath+"/pkg/config\tcoverage: 100.0% of statements") {
-		t.Fatalf("execute() stdout = %q, want package summary retained on floor failure", got)
+	if !strings.Contains(got, "Unit package coverage verdict:") {
+		t.Fatalf("execute() stdout = %q, want the lane verdict retained on floor failure", got)
+	}
+	if !strings.Contains(got, "tally: measured-packages=2 gated-packages=2 below-floor=0 near-floor=0 gate-failures=1") {
+		t.Fatalf("execute() stdout = %q, want the verdict tally to count the gate failure", got)
 	}
 	if strings.Contains(got, "meets minimum") {
 		t.Fatalf("execute() stdout = %q, did not expect success message", got)

--- a/cmd/gocoveragecheck/coverage_verdict.go
+++ b/cmd/gocoveragecheck/coverage_verdict.go
@@ -6,9 +6,11 @@ import (
 	"strings"
 )
 
-// functionalCoverageSuite is the lane whose log is rendered as a compact
-// ordered verdict block instead of one raw coverage line per measured package.
+// functionalCoverageSuite and unitCoverageSuite name the two lanes whose logs
+// are rendered as a compact ordered verdict block instead of one raw coverage
+// line per measured package.
 const functionalCoverageSuite = "functional"
+const unitCoverageSuite = "unit"
 
 // nearFloorCoverageReportLimit caps how many passing near-floor packages the
 // verdict block names. The block stays readable at a glance while the omitted
@@ -33,20 +35,37 @@ type packageCoverageVerdict struct {
 
 // writeCoverageLaneReport prints a lane's per-package coverage result.
 //
-// The functional lane replaces the raw "coverage: N% of statements" line per
+// A reporting lane replaces the raw "coverage: N% of statements" line per
 // measured package — 300+ consecutive lines that bury the one actionable
 // verdict — with a compact ordered block: floor violations first, then the
-// packages closest to their floor, then a single tally line. No per-package
-// data is lost: the complete set is still written to the -json-output
-// coverage-summary artifact that the CI job uploads and renders.
+// packages closest to their floor, then a single tally line.
 //
-// Every other lane keeps the raw per-package listing unchanged.
+// Collapsing the listing is only safe when the complete per-package measurement
+// survives somewhere a reader can still reach. Two lanes qualify: the
+// functional lane, whose CI job always publishes the coverage-summary artifact,
+// and any lane invoked with -json-output, which is that artifact. An invocation
+// without one — an ordinary local `make test-unit-coverage`, or the
+// malformed-manifest abort path that returns before the JSON is written — has
+// the raw listing as the only copy of the measurement, so it keeps it.
 func writeCoverageLaneReport(cfg config, result coverageResult, failures []string) {
-	if cfg.suite != functionalCoverageSuite {
+	if cfg.suite != functionalCoverageSuite && strings.TrimSpace(cfg.jsonOutput) == "" {
 		writePackageCoverageSummaries(result.packageSummaries)
 		return
 	}
-	writeFunctionalCoverageVerdict(result, failures)
+	writeCoverageVerdict(coverageLaneLabel(cfg.suite), result, failures)
+}
+
+// coverageLaneLabel names the lane in its verdict block so a job log that
+// carries both reports stays attributable to the suite that produced it.
+func coverageLaneLabel(suite string) string {
+	switch strings.TrimSpace(suite) {
+	case functionalCoverageSuite:
+		return "Functional"
+	case unitCoverageSuite, "":
+		return "Unit"
+	default:
+		return strings.ToUpper(suite[:1]) + suite[1:]
+	}
 }
 
 // writePackageCoverageSummaries prints one raw coverage line per measured
@@ -58,12 +77,12 @@ func writePackageCoverageSummaries(summaries []packageCoverageSummary) {
 	}
 }
 
-// writeFunctionalCoverageVerdict renders the ordered functional verdict block.
-func writeFunctionalCoverageVerdict(result coverageResult, failures []string) {
+// writeCoverageVerdict renders one lane's ordered verdict block.
+func writeCoverageVerdict(label string, result coverageResult, failures []string) {
 	verdicts := collectPackageCoverageVerdicts(result)
 	belowFloor, nearFloor := partitionPackageCoverageVerdicts(verdicts)
 
-	fmt.Fprintln(stdoutWriter, "Functional package coverage verdict:")
+	fmt.Fprintf(stdoutWriter, "%s package coverage verdict:\n", label)
 	writeBelowFloorCoverageLines(belowFloor)
 	writeNearFloorCoverageLines(nearFloor)
 	fmt.Fprintf(

--- a/cmd/gocoveragecheck/coverage_verdict.go
+++ b/cmd/gocoveragecheck/coverage_verdict.go
@@ -68,6 +68,14 @@ func coverageLaneLabel(suite string) string {
 	}
 }
 
+// coverageLaneNoun names the lane in prose. The timing capture notes are
+// produced by code both suites share, so a hard-coded "functional" tells a
+// reader of the unit lane's timing artifact that some other suite was
+// interrupted.
+func coverageLaneNoun(suite string) string {
+	return strings.ToLower(coverageLaneLabel(suite))
+}
+
 // writePackageCoverageSummaries prints one raw coverage line per measured
 // package. It remains the report for every non-functional lane and for the
 // malformed-manifest abort path, which never reaches the JSON summary.

--- a/cmd/gocoveragecheck/coverage_verdict_test.go
+++ b/cmd/gocoveragecheck/coverage_verdict_test.go
@@ -183,6 +183,9 @@ func TestFunctionalCoverageVerdictPassesWhenEveryPackageMeetsItsFloor(t *testing
 	}
 }
 
+// TestUnitCoverageRunKeepsRawPerPackageCoverageLines pins the invocation that
+// publishes no coverage-summary artifact. Its stdout listing is the only copy
+// of the per-package measurement, so it is never collapsed.
 func TestUnitCoverageRunKeepsRawPerPackageCoverageLines(t *testing.T) {
 	originalCommandRunner := commandRunner
 	originalStdout := stdoutWriter
@@ -215,8 +218,8 @@ func TestUnitCoverageRunKeepsRawPerPackageCoverageLines(t *testing.T) {
 	if !strings.Contains(got, configPackage+"\tcoverage: 100.0% of statements\n") {
 		t.Fatalf("unit lane lost its raw per-package coverage line:\n%s", got)
 	}
-	if strings.Contains(got, "Functional package coverage verdict:") {
-		t.Fatalf("unit lane rendered the functional verdict block:\n%s", got)
+	if strings.Contains(got, "package coverage verdict:") {
+		t.Fatalf("unit lane collapsed its only copy of the measurement into a verdict block:\n%s", got)
 	}
 }
 
@@ -238,7 +241,7 @@ func TestNearFloorCoverageReportStatesOmittedPackages(t *testing.T) {
 		result.packageTotals[importPath] = packageCoverageTotals{coveredStatements: 51, totalStatements: 100}
 	}
 
-	writeFunctionalCoverageVerdict(result, nil)
+	writeCoverageVerdict("Functional", result, nil)
 
 	got := stdout.String()
 	if count := strings.Count(got, "  near floor: package="); count != nearFloorCoverageReportLimit {

--- a/cmd/gocoveragecheck/diagnostic_files.go
+++ b/cmd/gocoveragecheck/diagnostic_files.go
@@ -7,6 +7,38 @@ import (
 	"path/filepath"
 )
 
+// prepareCoverageProfile resolves the coverage profile a lane writes and
+// returns the cleanup its caller owns. A caller-named profile is kept; an
+// unnamed one becomes a temp file the caller removes.
+//
+// A caller-named profile routinely points into a CI artifact directory that
+// does not exist yet, and go test -coverprofile does not create it, so the
+// directory is created here. Without it the lane fails before measuring
+// anything.
+func prepareCoverageProfile(profilePath string) (string, func() error, error) {
+	if profilePath != "" {
+		if directory := filepath.Dir(profilePath); directory != "" && directory != "." {
+			if err := os.MkdirAll(directory, 0o755); err != nil {
+				return "", nil, fmt.Errorf("create coverage profile directory: %w", err)
+			}
+		}
+		return profilePath, func() error { return nil }, nil
+	}
+	file, err := os.CreateTemp("", "go-coverage-*.out")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temp coverage profile: %w", err)
+	}
+	profilePath = file.Name()
+	cleanup := func() error { return os.Remove(profilePath) }
+	if err := file.Close(); err != nil {
+		return "", nil, errors.Join(
+			fmt.Errorf("close temp coverage profile: %w", err),
+			cleanup(),
+		)
+	}
+	return profilePath, cleanup, nil
+}
+
 // writeAtomicDiagnosticFile makes a completed JSON document visible in one
 // rename. A timeout can interrupt the producer at any point, so readers must
 // never observe a half-written timing or coverage artifact.

--- a/cmd/gocoveragecheck/functional_diagnostics.go
+++ b/cmd/gocoveragecheck/functional_diagnostics.go
@@ -103,6 +103,11 @@ func (tracker *functionalTimingTracker) snapshot(complete bool, reason string, a
 
 	packages := make([]functionalPackageTimingJSON, 0, len(tracker.terminals))
 	states := make([]functionalPackageStateJSON, 0, len(tracker.expected))
+	// A snapshot records package progress, not per-test rows. Tests is still
+	// emitted as an empty array rather than left nil, because a nil slice
+	// marshals to JSON null and a consumer reading a documented array field
+	// cannot tell null apart from an unreadable document.
+	tests := make([]functionalTestTimingJSON, 0)
 	packageElapsed := 0.0
 	for _, packageName := range tracker.expected {
 		if terminal, ok := tracker.terminals[packageName]; ok {
@@ -147,6 +152,7 @@ func (tracker *functionalTimingTracker) snapshot(complete bool, reason string, a
 			PackageCount:             len(packages),
 			Packages:                 packages,
 			PackageStates:            states,
+			Tests:                    tests,
 		}
 	}
 	return functionalTimingSummaryJSON{
@@ -157,6 +163,7 @@ func (tracker *functionalTimingTracker) snapshot(complete bool, reason string, a
 		PackageCount:         len(packages),
 		Packages:             packages,
 		PackageStates:        states,
+		Tests:                tests,
 	}
 }
 

--- a/cmd/gocoveragecheck/functional_diagnostics.go
+++ b/cmd/gocoveragecheck/functional_diagnostics.go
@@ -16,13 +16,18 @@ const functionalCoverageSnapshotInterval = 5 * time.Second
 // the buffered go test JSON. This lets a timeout snapshot describe packages
 // that have started but never emitted a terminal event.
 type functionalTimingTracker struct {
-	mu         sync.Mutex
-	expected   []string
-	started    map[string]time.Time
-	terminals  map[string]functionalPackageTimingJSON
-	invalid    bool
-	now        func() time.Time
-	runStarted time.Time
+	mu sync.Mutex
+	// expected preserves the sorted package order used by every snapshot.
+	// expectedSet answers membership in constant time: the unit lane observes
+	// hundreds of packages, so a linear scan per event grows with the square of
+	// the lane size.
+	expected    []string
+	expectedSet map[string]struct{}
+	started     map[string]time.Time
+	terminals   map[string]functionalPackageTimingJSON
+	invalid     bool
+	now         func() time.Time
+	runStarted  time.Time
 }
 
 func newFunctionalTimingTracker(expected []string, started time.Time) *functionalTimingTracker {
@@ -41,11 +46,12 @@ func newFunctionalTimingTracker(expected []string, started time.Time) *functiona
 	}
 	slices.Sort(ordered)
 	return &functionalTimingTracker{
-		expected:   ordered,
-		started:    make(map[string]time.Time, len(ordered)),
-		terminals:  make(map[string]functionalPackageTimingJSON, len(ordered)),
-		now:        time.Now,
-		runStarted: started,
+		expected:    ordered,
+		expectedSet: unique,
+		started:     make(map[string]time.Time, len(ordered)),
+		terminals:   make(map[string]functionalPackageTimingJSON, len(ordered)),
+		now:         time.Now,
+		runStarted:  started,
 	}
 }
 
@@ -94,7 +100,8 @@ func (tracker *functionalTimingTracker) observe(event goTestTimingEvent) bool {
 }
 
 func (tracker *functionalTimingTracker) isExpectedLocked(packageName string) bool {
-	return slices.Contains(tracker.expected, packageName)
+	_, expected := tracker.expectedSet[packageName]
+	return expected
 }
 
 func (tracker *functionalTimingTracker) snapshot(complete bool, reason string, at time.Time) functionalTimingSummaryJSON {
@@ -221,8 +228,22 @@ func (snapshotter *functionalTimingSnapshotter) run() {
 	}
 }
 
+// observe records a package lifecycle event. The caller is the goroutine that
+// drains the child go test pipe, so this path must stay cheap: a publish here
+// serializes the whole run's snapshot and writes it to disk, and while that
+// happens the pipe is not being read and every test binary blocks behind it.
+//
+// A streaming lane still publishes per event, because its progress lines are
+// the live log a reader watches, and it observes a few dozen packages. A
+// non-streaming lane has no sink to emit to, so persistence is left entirely to
+// the one-second ticker in run(): the timeout snapshot it exists to protect is
+// still on disk, without paying a full document write per event. The unit lane
+// observes hundreds of packages, which is what makes the difference matter.
 func (snapshotter *functionalTimingSnapshotter) observe(event goTestTimingEvent) {
 	if !snapshotter.tracker.observe(event) {
+		return
+	}
+	if snapshotter.sink == nil {
 		return
 	}
 	snapshotter.publish(false, "functional run still active", true)

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -299,6 +299,14 @@ func runForOS(cfg config, targetOS string) (result coverageResult, runErr error)
 
 func prepareCoverageProfile(profilePath string) (string, func() error, error) {
 	if profilePath != "" {
+		// A caller-named profile routinely points into a CI artifact directory
+		// that does not exist yet. go test -coverprofile does not create it, so
+		// without this the lane would fail before measuring anything.
+		if directory := filepath.Dir(profilePath); directory != "" && directory != "." {
+			if err := os.MkdirAll(directory, 0o755); err != nil {
+				return "", nil, fmt.Errorf("create coverage profile directory: %w", err)
+			}
+		}
 		return profilePath, func() error { return nil }, nil
 	}
 	file, err := os.CreateTemp("", "go-coverage-*.out")

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -297,33 +297,6 @@ func runForOS(cfg config, targetOS string) (result coverageResult, runErr error)
 	return runCoverageProfile(cfg, targetOS, profilePath)
 }
 
-func prepareCoverageProfile(profilePath string) (string, func() error, error) {
-	if profilePath != "" {
-		// A caller-named profile routinely points into a CI artifact directory
-		// that does not exist yet. go test -coverprofile does not create it, so
-		// without this the lane would fail before measuring anything.
-		if directory := filepath.Dir(profilePath); directory != "" && directory != "." {
-			if err := os.MkdirAll(directory, 0o755); err != nil {
-				return "", nil, fmt.Errorf("create coverage profile directory: %w", err)
-			}
-		}
-		return profilePath, func() error { return nil }, nil
-	}
-	file, err := os.CreateTemp("", "go-coverage-*.out")
-	if err != nil {
-		return "", nil, fmt.Errorf("create temp coverage profile: %w", err)
-	}
-	profilePath = file.Name()
-	cleanup := func() error { return os.Remove(profilePath) }
-	if err := file.Close(); err != nil {
-		return "", nil, errors.Join(
-			fmt.Errorf("close temp coverage profile: %w", err),
-			cleanup(),
-		)
-	}
-	return profilePath, cleanup, nil
-}
-
 func runCoverageProfile(cfg config, targetOS string, profilePath string) (coverageResult, error) {
 	coverPackages, testPackages, err := resolveCoverageLane(cfg)
 	if err != nil {

--- a/cmd/gocoveragecheck/unit_report_test.go
+++ b/cmd/gocoveragecheck/unit_report_test.go
@@ -69,10 +69,14 @@ func unitReportTimingEvents(t *testing.T, outcome string) string {
 
 func unitReportManifest(t *testing.T) string {
 	t.Helper()
+	// Measured coverage is config 25.00, service 90.00, wire 100.00, so these
+	// floors put all three inside the near-floor band with headroom ordering
+	// (service 1.00, wire 1.00, config 1.50) deliberately unequal to import-path
+	// ordering (config, service, wire).
 	return writePackageMinimumManifestWithEntries(t, "unit", []manifestPackageSpec{
-		{importPath: modulePath + "/pkg/config", minimum: "10.00"},
+		{importPath: modulePath + "/pkg/config", minimum: "23.50"},
 		{importPath: modulePath + "/pkg/service", minimum: "89.00"},
-		{importPath: modulePath + "/pkg/wire", minimum: "50.00"},
+		{importPath: modulePath + "/pkg/wire", minimum: "99.00"},
 	})
 }
 
@@ -183,6 +187,65 @@ func TestUnitCoverageLaneWritesCoverageAndTimingJSON(t *testing.T) {
 	}
 	if got := slowest["TestFastUnit"]; got != 0.25 {
 		t.Fatalf("TestFastUnit elapsed = %v, want 0.25 (timing rows: %+v)", got, timing.Tests)
+	}
+}
+
+// TestUnitCoverageLaneCollapsesPerPackageLinesWhenTheArtifactIsWritten pins the
+// console half of the unit report: once -json-output preserves the complete
+// per-package measurement, stdout carries one ordered verdict block instead of
+// a raw coverage line per measured package.
+func TestUnitCoverageLaneCollapsesPerPackageLinesWhenTheArtifactIsWritten(t *testing.T) {
+	outputDir := t.TempDir()
+	coveragePath := filepath.Join(outputDir, "coverage-summary.json")
+
+	stdout, _, err := captureUnitReportRun(
+		t,
+		unitReportConfig(unitReportManifest(t), coveragePath, filepath.Join(outputDir, "unit-timing-summary.json")),
+		unitReportTimingEvents(t, timingOutcomePass),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("execute() error = %v\n%s", err, stdout)
+	}
+
+	if !strings.Contains(stdout, "Unit package coverage verdict:") {
+		t.Fatalf("unit lane did not render its own verdict block:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "Functional package coverage verdict:") {
+		t.Fatalf("unit lane mislabelled its verdict block as functional:\n%s", stdout)
+	}
+	for _, importPath := range unitReportCoverPackages {
+		if strings.Contains(stdout, importPath+"\tcoverage: ") {
+			t.Fatalf("unit lane still printed a raw per-package coverage line for %s:\n%s", importPath, stdout)
+		}
+	}
+
+	// All three packages sit inside the near-floor band with headroom service
+	// 1.00, wire 1.00, config 1.50. Ordering is headroom ascending with an
+	// import-path tiebreak, so the block must read service, wire, config —
+	// deliberately not the import-path order config, service, wire.
+	block := stdout[strings.Index(stdout, "Unit package coverage verdict:"):]
+	var reported []string
+	for _, line := range strings.Split(block, "\n") {
+		if _, importPath, found := strings.Cut(strings.TrimSpace(line), "near floor: package="); found {
+			reported = append(reported, strings.Fields(importPath)[0])
+		}
+	}
+	want := []string{modulePath + "/pkg/service", modulePath + "/pkg/wire", modulePath + "/pkg/config"}
+	if strings.Join(reported, ",") != strings.Join(want, ",") {
+		t.Fatalf("near-floor order = %v, want headroom ascending %v:\n%s", reported, want, stdout)
+	}
+
+	// The collapsed log is only safe because the complete set survives in the
+	// artifact the CI job uploads.
+	var coverage struct {
+		Packages []struct {
+			Package string `json:"package"`
+		} `json:"packages"`
+	}
+	readUnitReportJSON(t, coveragePath, &coverage)
+	if len(coverage.Packages) != len(unitReportCoverPackages) {
+		t.Fatalf("collapsed log lost packages: artifact carries %d, want %d", len(coverage.Packages), len(unitReportCoverPackages))
 	}
 }
 

--- a/cmd/gocoveragecheck/unit_report_test.go
+++ b/cmd/gocoveragecheck/unit_report_test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var unitReportCoverPackages = []string{
+	modulePath + "/pkg/config",
+	modulePath + "/pkg/service",
+	modulePath + "/pkg/wire",
+}
+
+// unitReportProfile has one below-floor package, one near-floor package, and
+// one comfortably passing package so the ordered verdict block and the JSON
+// coverage summary both have something to order.
+func unitReportProfile() string {
+	return strings.Join([]string{
+		"mode: count",
+		modulePath + "/pkg/config/config.go:1.1,2.1 1 1",
+		modulePath + "/pkg/config/config.go:11.1,12.1 2 0",
+		modulePath + "/pkg/config/load.go:21.1,22.1 1 0",
+		modulePath + "/pkg/service/factory.go:1.1,2.1 9 1",
+		modulePath + "/pkg/service/factory.go:31.1,32.1 1 0",
+		modulePath + "/pkg/wire/wire.go:1.1,2.1 10 3",
+		"",
+	}, "\n")
+}
+
+func unitReportTimingEvents(t *testing.T, outcome string) string {
+	t.Helper()
+	events := []goTestTimingEvent{
+		{Action: "run", Package: modulePath + "/pkg/config", Test: "TestFastUnit"},
+		{Action: "output", Package: modulePath + "/pkg/config", Test: "TestFastUnit", Output: "=== RUN   TestFastUnit\n"},
+		{Action: "pass", Package: modulePath + "/pkg/config", Test: "TestFastUnit", Elapsed: 0.25},
+		{Action: "run", Package: modulePath + "/pkg/service", Test: "TestSlowUnit"},
+	}
+	if outcome == timingOutcomeFail {
+		events = append(events,
+			goTestTimingEvent{Action: "output", Package: modulePath + "/pkg/service", Test: "TestSlowUnit", Output: "    factory_test.go:41: want 3 workstations, got 2\n"},
+			goTestTimingEvent{Action: "output", Package: modulePath + "/pkg/service", Test: "TestSlowUnit", Output: "--- FAIL: TestSlowUnit (12.50s)\n"},
+		)
+	}
+	events = append(events,
+		goTestTimingEvent{Action: outcome, Package: modulePath + "/pkg/service", Test: "TestSlowUnit", Elapsed: 12.5},
+		goTestTimingEvent{Action: "output", Package: modulePath + "/pkg/config", Output: "ok  \t" + modulePath + "/pkg/config\t0.310s\n"},
+		goTestTimingEvent{Action: "pass", Package: modulePath + "/pkg/config", Elapsed: 0.31},
+		goTestTimingEvent{Action: outcome, Package: modulePath + "/pkg/service", Elapsed: 12.62},
+		goTestTimingEvent{Action: "output", Package: modulePath + "/pkg/wire", Output: "ok  \t" + modulePath + "/pkg/wire\t0.040s\n"},
+		goTestTimingEvent{Action: "pass", Package: modulePath + "/pkg/wire", Elapsed: 0.04},
+	)
+
+	var stream strings.Builder
+	for _, event := range events {
+		encoded, err := json.Marshal(event)
+		if err != nil {
+			t.Fatalf("marshal timing event: %v", err)
+		}
+		stream.Write(encoded)
+		stream.WriteString("\n")
+	}
+	return stream.String()
+}
+
+func unitReportManifest(t *testing.T) string {
+	t.Helper()
+	return writePackageMinimumManifestWithEntries(t, "unit", []manifestPackageSpec{
+		{importPath: modulePath + "/pkg/config", minimum: "10.00"},
+		{importPath: modulePath + "/pkg/service", minimum: "89.00"},
+		{importPath: modulePath + "/pkg/wire", minimum: "50.00"},
+	})
+}
+
+func unitReportConfig(manifestPath string, jsonPath string, timingPath string) config {
+	return config{
+		min:             0,
+		suite:           "unit",
+		coverpkg:        strings.Join(unitReportCoverPackages, ","),
+		packages:        "./pkg/...",
+		packageManifest: manifestPath,
+		jsonOutput:      jsonPath,
+		timingOutput:    timingPath,
+	}
+}
+
+// captureUnitReportRun stubs the go test child with a fake that writes the
+// shared profile and replays a recorded go test -json event stream, so the unit
+// lane's JSON, timing, and console outputs are all observable.
+func captureUnitReportRun(t *testing.T, cfg config, stream string, commandErr error) (string, string, error) {
+	t.Helper()
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	t.Cleanup(func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	})
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+	commandRunner = func(invocation commandInvocation) (string, string, error) {
+		if invocation.name != "go" || len(invocation.args) == 0 || invocation.args[0] != "test" {
+			return "", "", fmt.Errorf("unexpected command %q %v", invocation.name, invocation.args)
+		}
+		profilePath := helperCoverProfilePath(invocation.args[1:])
+		if profilePath == "" {
+			return "", "", errors.New("missing -coverprofile")
+		}
+		if err := writeFakeCoverageProfile(profilePath, unitReportProfile()); err != nil {
+			return "", "", err
+		}
+		if invocation.stdoutWriter != nil {
+			if _, err := invocation.stdoutWriter.Write([]byte(stream)); err != nil {
+				return "", "", err
+			}
+		}
+		return stream, "", commandErr
+	}
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	err := execute(cfg)
+	return stdout.String(), stderr.String(), err
+}
+
+func TestUnitCoverageLaneWritesCoverageAndTimingJSON(t *testing.T) {
+	outputDir := t.TempDir()
+	coveragePath := filepath.Join(outputDir, "coverage-summary.json")
+	timingPath := filepath.Join(outputDir, "unit-timing-summary.json")
+
+	stdout, _, err := captureUnitReportRun(
+		t,
+		unitReportConfig(unitReportManifest(t), coveragePath, timingPath),
+		unitReportTimingEvents(t, timingOutcomePass),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("execute() error = %v\n%s", err, stdout)
+	}
+
+	var coverage struct {
+		Packages []struct {
+			Package         string   `json:"package"`
+			CoveragePercent float64  `json:"coveragePercent"`
+			PackageFloor    *float64 `json:"packageFloor"`
+		} `json:"packages"`
+	}
+	readUnitReportJSON(t, coveragePath, &coverage)
+	if len(coverage.Packages) != len(unitReportCoverPackages) {
+		t.Fatalf("coverage summary packages = %d, want %d", len(coverage.Packages), len(unitReportCoverPackages))
+	}
+	floors := 0
+	for _, entry := range coverage.Packages {
+		if entry.PackageFloor != nil {
+			floors++
+		}
+	}
+	if floors != len(unitReportCoverPackages) {
+		t.Fatalf("coverage summary carried %d package floors, want %d", floors, len(unitReportCoverPackages))
+	}
+
+	var timing struct {
+		Tests []struct {
+			Package string  `json:"package"`
+			Test    string  `json:"test"`
+			Seconds float64 `json:"seconds"`
+			Outcome string  `json:"outcome"`
+		} `json:"tests"`
+	}
+	readUnitReportJSON(t, timingPath, &timing)
+	slowest := map[string]float64{}
+	for _, entry := range timing.Tests {
+		slowest[entry.Test] = entry.Seconds
+	}
+	if got := slowest["TestSlowUnit"]; got != 12.5 {
+		t.Fatalf("TestSlowUnit elapsed = %v, want 12.5 (timing rows: %+v)", got, timing.Tests)
+	}
+	if got := slowest["TestFastUnit"]; got != 0.25 {
+		t.Fatalf("TestFastUnit elapsed = %v, want 0.25 (timing rows: %+v)", got, timing.Tests)
+	}
+}
+
+func TestUnitCoverageLaneKeepsFailureDetailReadableWithTimingCapture(t *testing.T) {
+	outputDir := t.TempDir()
+	_, _, err := captureUnitReportRun(
+		t,
+		unitReportConfig(
+			unitReportManifest(t),
+			filepath.Join(outputDir, "coverage-summary.json"),
+			filepath.Join(outputDir, "unit-timing-summary.json"),
+		),
+		unitReportTimingEvents(t, timingOutcomeFail),
+		errors.New("exit status 1"),
+	)
+	if err == nil {
+		t.Fatal("execute() error = nil, want the failing go test lane to fail the gate")
+	}
+
+	detail := err.Error()
+	for _, want := range []string{
+		"--- FAIL: TestSlowUnit (12.50s)",
+		"factory_test.go:41: want 3 workstations, got 2",
+	} {
+		if !strings.Contains(detail, want) {
+			t.Fatalf("failure detail dropped %q:\n%s", want, detail)
+		}
+	}
+	if strings.Contains(detail, "\"Action\":\"output\"") {
+		t.Fatalf("failure detail reported raw test2json events instead of the human go test stream:\n%s", detail)
+	}
+}
+
+func readUnitReportJSON(t *testing.T, path string, target any) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", filepath.Base(path), err)
+	}
+	if err := json.Unmarshal(data, target); err != nil {
+		t.Fatalf("decode %s: %v\n%s", filepath.Base(path), err, data)
+	}
+}

--- a/cmd/gocoveragecheck/unit_report_test.go
+++ b/cmd/gocoveragecheck/unit_report_test.go
@@ -389,3 +389,86 @@ func readUnitReportJSON(t *testing.T, path string, target any) {
 		t.Fatalf("decode %s: %v\n%s", filepath.Base(path), err, data)
 	}
 }
+
+// TestNonStreamingTimingObserverDoesNotWritePerEvent guards the unit lane's
+// measured runtime. The snapshotter's observe path runs on the goroutine that
+// drains the child go test pipe: when it published per event it serialized the
+// whole run's snapshot and wrote it to disk once per package start and once per
+// package terminal, and the child blocked on a full pipe for the duration.
+//
+// The functional lane hid this because it observes a few dozen packages. The
+// unit lane observes hundreds, and the CI job went from ~5 minutes to over an
+// hour without completing.
+//
+// The bound below is deliberately loose. Per-event publishing cost roughly
+// 3.5ms per event locally, so this many events took about four seconds; leaving
+// persistence to the ticker costs no I/O on this path at all and finishes in
+// milliseconds. Anything near the old cost fails.
+func TestNonStreamingTimingObserverDoesNotWritePerEvent(t *testing.T) {
+	const packageCount = 528
+
+	expected := make([]string, 0, packageCount)
+	for index := range packageCount {
+		expected = append(expected, fmt.Sprintf("%s/pkg/probe/pkg%04d", modulePath, index))
+	}
+
+	timingPath := filepath.Join(t.TempDir(), "unit-timing-summary.json")
+	tracker := newFunctionalTimingTracker(expected, time.Now())
+	// sink nil is the non-streaming unit lane: -timing-output without -stream.
+	snapshotter := newFunctionalTimingSnapshotter(tracker, timingPath, nil, nil)
+
+	started := time.Now()
+	for _, packageName := range expected {
+		snapshotter.observe(goTestTimingEvent{Action: "start", Package: packageName})
+	}
+	for _, packageName := range expected {
+		snapshotter.observe(goTestTimingEvent{Action: timingOutcomePass, Package: packageName, Elapsed: 1.5})
+	}
+	elapsed := time.Since(started)
+
+	if elapsed > 1500*time.Millisecond {
+		t.Fatalf("observing %d package events on the pipe-drain path took %s; it must not perform per-event I/O", packageCount*2, elapsed)
+	}
+
+	// The events still have to be recorded: this must be cheaper, not blinder.
+	// An incomplete summary is the case the tracker exists for, because that is
+	// when finish() falls back to tracker state to describe every package.
+	if err := snapshotter.finish(functionalTimingSummaryJSON{Complete: false}, "lane interrupted"); err != nil {
+		t.Fatalf("finish timing snapshot: %v", err)
+	}
+
+	data, err := os.ReadFile(timingPath)
+	if err != nil {
+		t.Fatalf("read timing summary: %v", err)
+	}
+	var document functionalTimingSummaryJSON
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatalf("decode timing summary: %v", err)
+	}
+	if len(document.PackageStates) != packageCount {
+		t.Fatalf("timing summary recorded %d package states, want %d", len(document.PackageStates), packageCount)
+	}
+	for _, state := range document.PackageStates {
+		if state.State != functionalPackageStateCompleted {
+			t.Fatalf("package %s state is %q, want %q", state.Package, state.State, functionalPackageStateCompleted)
+		}
+	}
+}
+
+// TestStreamingTimingObserverStillPublishesPerEvent pins the functional lane's
+// behaviour in place: its progress lines are the live log a reader watches, so
+// the per-event publish must survive for a lane that has a sink.
+func TestStreamingTimingObserverStillPublishesPerEvent(t *testing.T) {
+	packages := []string{modulePath + "/tests/functional/alpha", modulePath + "/tests/functional/beta"}
+	timingPath := filepath.Join(t.TempDir(), "functional-timing-summary.json")
+	tracker := newFunctionalTimingTracker(packages, time.Now())
+
+	var sink strings.Builder
+	snapshotter := newFunctionalTimingSnapshotter(tracker, timingPath, &sink, nil)
+	snapshotter.observe(goTestTimingEvent{Action: "start", Package: packages[0]})
+	snapshotter.stopAndWait()
+
+	if !strings.Contains(sink.String(), "Functional timing snapshot:") {
+		t.Fatalf("streaming lane emitted no progress line per event; got %q", sink.String())
+	}
+}

--- a/cmd/gocoveragecheck/unit_report_test.go
+++ b/cmd/gocoveragecheck/unit_report_test.go
@@ -249,6 +249,31 @@ func TestUnitCoverageLaneCollapsesPerPackageLinesWhenTheArtifactIsWritten(t *tes
 	}
 }
 
+// TestUnitCoverageLaneCreatesItsArtifactDirectory pins the CI shape: the three
+// output paths point into an artifact directory that does not exist yet, and
+// go test -coverprofile will not create it.
+func TestUnitCoverageLaneCreatesItsArtifactDirectory(t *testing.T) {
+	artifactRoot := filepath.Join(t.TempDir(), ".artifacts", "unit-coverage")
+
+	cfg := unitReportConfig(
+		unitReportManifest(t),
+		filepath.Join(artifactRoot, "coverage-summary.json"),
+		filepath.Join(artifactRoot, "unit-timing-summary.json"),
+	)
+	cfg.profile = filepath.Join(artifactRoot, "coverage.out")
+
+	stdout, _, err := captureUnitReportRun(t, cfg, unitReportTimingEvents(t, timingOutcomePass), nil)
+	if err != nil {
+		t.Fatalf("execute() error = %v\n%s", err, stdout)
+	}
+
+	for _, name := range []string{"coverage.out", "coverage-summary.json", "unit-timing-summary.json"} {
+		if _, statErr := os.Stat(filepath.Join(artifactRoot, name)); statErr != nil {
+			t.Fatalf("unit lane did not publish %s into a fresh artifact directory: %v", name, statErr)
+		}
+	}
+}
+
 func TestUnitCoverageLaneKeepsFailureDetailReadableWithTimingCapture(t *testing.T) {
 	outputDir := t.TempDir()
 	_, _, err := captureUnitReportRun(

--- a/cmd/gocoveragecheck/unit_report_test.go
+++ b/cmd/gocoveragecheck/unit_report_test.go
@@ -472,3 +472,26 @@ func TestStreamingTimingObserverStillPublishesPerEvent(t *testing.T) {
 		t.Fatalf("streaming lane emitted no progress line per event; got %q", sink.String())
 	}
 }
+
+// TestIncompleteTimingCaptureNamesTheCauseItObserved covers the report accuracy
+// this lane's first hosted run broke: the unit lane recorded terminal results
+// for all 548 of its packages and still published "ended before every package
+// reported a terminal result", because a single unparseable line marks the whole
+// capture incomplete. A reader acts differently on a truncated run than on a
+// lossy parse, so the message has to follow the counts rather than assume.
+func TestIncompleteTimingCaptureNamesTheCauseItObserved(t *testing.T) {
+	truncated := functionalTimingSummaryJSON{PackageCount: 12, ExpectedPackageCount: 548}
+	if got := incompleteTimingCaptureCause(truncated); !strings.Contains(got, "ended before every package") {
+		t.Fatalf("a lane missing packages must report truncation; got %q", got)
+	}
+
+	// Every expected package reported, so the capture cannot have ended early.
+	lossy := functionalTimingSummaryJSON{PackageCount: 548, ExpectedPackageCount: 548}
+	got := incompleteTimingCaptureCause(lossy)
+	if strings.Contains(got, "ended before every package") {
+		t.Fatalf("a lane that reported every package must not claim it ended early; got %q", got)
+	}
+	if !strings.Contains(got, "could not read every go test event") {
+		t.Fatalf("a lossy parse must say so; got %q", got)
+	}
+}

--- a/cmd/gocoveragecheck/unit_report_test.go
+++ b/cmd/gocoveragecheck/unit_report_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 var unitReportCoverPackages = []string{
@@ -271,6 +272,38 @@ func TestUnitCoverageLaneCreatesItsArtifactDirectory(t *testing.T) {
 		if _, statErr := os.Stat(filepath.Join(artifactRoot, name)); statErr != nil {
 			t.Fatalf("unit lane did not publish %s into a fresh artifact directory: %v", name, statErr)
 		}
+	}
+}
+
+// TestInterruptedTimingSnapshotEmitsAnEmptyTestArray pins the artifact an
+// if: always() upload preserves when a lane is cut short. A snapshot has no
+// per-test rows yet, and a nil slice marshals to JSON null, which a consumer
+// reading a documented array field cannot tell apart from an unreadable
+// document. Reporting an interrupted lane as unmeasurable is exactly the
+// failure the always-on artifact exists to prevent.
+func TestInterruptedTimingSnapshotEmitsAnEmptyTestArray(t *testing.T) {
+	tracker := newFunctionalTimingTracker([]string{modulePath + "/pkg/config"}, time.Now())
+	snapshot := tracker.snapshot(false, "lane budget expired", time.Now())
+
+	if snapshot.Tests == nil {
+		t.Fatal("snapshot Tests is nil; it marshals to JSON null and reads as an unavailable timing summary")
+	}
+	if len(snapshot.Tests) != 0 {
+		t.Fatalf("snapshot Tests = %+v, want an empty array", snapshot.Tests)
+	}
+
+	data, err := renderFunctionalTimingSummaryJSON(snapshot)
+	if err != nil {
+		t.Fatalf("render timing snapshot: %v", err)
+	}
+	var decoded struct {
+		Tests *[]functionalTestTimingJSON `json:"tests"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("decode timing snapshot: %v\n%s", err, data)
+	}
+	if decoded.Tests == nil {
+		t.Fatalf("timing snapshot encoded tests as null:\n%s", data)
 	}
 }
 

--- a/cmd/gocoveragecheck/unit_report_test.go
+++ b/cmd/gocoveragecheck/unit_report_test.go
@@ -275,6 +275,48 @@ func TestUnitCoverageLaneCreatesItsArtifactDirectory(t *testing.T) {
 	}
 }
 
+// TestUnitCoverageLaneNamesItsOwnLaneInItsCaptureNote pins the prose the unit
+// report renders when a capture ends early. The note is written by code both
+// suites share, and the rendered summary shows it to a reader who is looking
+// at the unit job, so naming the functional suite there reads as evidence that
+// the wrong lane was measured.
+func TestUnitCoverageLaneNamesItsOwnLaneInItsCaptureNote(t *testing.T) {
+	outputDir := t.TempDir()
+	timingPath := filepath.Join(outputDir, "unit-timing-summary.json")
+
+	stdout, _, err := captureUnitReportRun(
+		t,
+		unitReportConfig(
+			unitReportManifest(t),
+			filepath.Join(outputDir, "coverage-summary.json"),
+			timingPath,
+		),
+		unitReportTimingEvents(t, timingOutcomePass),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("execute() error = %v\n%s", err, stdout)
+	}
+
+	var timing struct {
+		Complete      bool   `json:"complete"`
+		CaptureReason string `json:"captureReason"`
+	}
+	readUnitReportJSON(t, timingPath, &timing)
+	if timing.Complete {
+		t.Fatal("timing capture reported complete; this fixture must end early or it stops covering the capture note")
+	}
+	if !strings.HasPrefix(timing.CaptureReason, "unit ") {
+		t.Fatalf("unit lane capture note = %q, want it to name the unit lane", timing.CaptureReason)
+	}
+
+	// The note is shared with the functional lane, whose wording this change
+	// must leave byte-identical.
+	if got := coverageLaneNoun(functionalCoverageSuite); got != "functional" {
+		t.Fatalf("functional lane noun = %q, want the wording its reports already carry", got)
+	}
+}
+
 // TestInterruptedTimingSnapshotEmitsAnEmptyTestArray pins the artifact an
 // if: always() upload preserves when a lane is cut short. A snapshot has no
 // per-test rows yet, and a nil slice marshals to JSON null, which a consumer

--- a/scripts/ci/coverage-report.mjs
+++ b/scripts/ci/coverage-report.mjs
@@ -1,0 +1,297 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * Shared renderer for the two halves of the backend-coverage matrix.
+ *
+ * The functional half shipped first and owned this logic outright. The unit
+ * half renders the same three things — a headroom-ordered package table, a
+ * capped slowest-tests table that always states what it dropped, and a marked
+ * pull request comment that updates in place — so the ordering, capping, and
+ * fail-open rules live here once and both lanes pass their own labels, markers,
+ * and row caps in.
+ *
+ * Every function here is reporting-only and total: a missing, truncated, or
+ * malformed artifact produces an explicitly unavailable summary rather than
+ * throwing. Reporting must never turn a passing suite red.
+ */
+
+export const DEFAULT_COVERAGE_REPORT_LIMITS = Object.freeze({
+	violations: 25,
+	packages: 10,
+	slowestTests: 10,
+});
+
+/**
+ * summarizeCoverageReport reduces a coverage-summary artifact and a timing
+ * artifact to the ordered digest a report renders.
+ */
+export function summarizeCoverageReport(coverage, timing, limits = {}) {
+	const resolved = { ...DEFAULT_COVERAGE_REPORT_LIMITS, ...limits };
+	return {
+		coverage: summarizeCoverageArtifact(coverage, resolved),
+		timing: summarizeTimingArtifact(timing, resolved),
+	};
+}
+
+function summarizeCoverageArtifact(coverage, limits) {
+	if (!coverage || typeof coverage !== "object" || !Array.isArray(coverage.packages)) {
+		return {
+			available: false,
+			violations: [],
+			violationCount: 0,
+			omittedViolations: 0,
+			nearFloor: [],
+			gatedCount: 0,
+			omitted: 0,
+		};
+	}
+	const ranked = coverage.packages
+		.filter((entry) => entry && typeof entry.package === "string")
+		.map((entry) => ({
+			package: entry.package,
+			coveragePercent: finiteNumber(entry.coveragePercent),
+			floor:
+				typeof entry.packageFloor === "number" && Number.isFinite(entry.packageFloor)
+					? entry.packageFloor
+					: null,
+		}))
+		.filter((entry) => entry.floor !== null)
+		.map((entry) => ({ ...entry, headroom: entry.coveragePercent - entry.floor }))
+		.sort((left, right) =>
+			left.headroom === right.headroom
+				? left.package.localeCompare(right.package)
+				: left.headroom - right.headroom,
+		);
+
+	const allViolations = ranked.filter((entry) => entry.headroom < 0);
+	// Coverage is never negative, so a package sitting on a 0% floor cannot
+	// regress through it. Both lanes hold packages without an explicit manifest
+	// entry to a 0.00 default floor, so including those would crowd every
+	// genuinely close package out of the table.
+	const contenders = ranked.filter((entry) => entry.headroom >= 0 && entry.floor > 0);
+	const violations = allViolations.slice(0, limits.violations);
+	const nearFloor = contenders.slice(0, limits.packages);
+	return {
+		available: true,
+		complete: coverage.complete !== false,
+		measurementReason: textValue(coverage.measurementReason),
+		coveredStatements: finiteNumber(coverage.coveredStatements),
+		measurableStatements: finiteNumber(coverage.measurableStatements),
+		coveragePercent: finiteNumber(coverage.coveragePercent),
+		packageCount: coverage.packages.length,
+		gatedCount: ranked.length,
+		violationCount: allViolations.length,
+		violations,
+		omittedViolations: allViolations.length - violations.length,
+		nearFloor,
+		omitted: contenders.length - nearFloor.length,
+	};
+}
+
+function summarizeTimingArtifact(timing, limits) {
+	if (!timing || typeof timing !== "object" || !Array.isArray(timing.tests)) {
+		return { available: false, slowest: [], observed: 0, omitted: 0 };
+	}
+	const slowest = timing.tests
+		.filter((entry) => entry && typeof entry.package === "string" && typeof entry.test === "string")
+		.map((entry) => ({
+			package: entry.package,
+			test: entry.test,
+			seconds: finiteNumber(entry.seconds),
+			outcome: textValue(entry.outcome) || "unknown",
+		}))
+		.sort((left, right) =>
+			left.seconds === right.seconds
+				? left.package.localeCompare(right.package) || left.test.localeCompare(right.test)
+				: right.seconds - left.seconds,
+		);
+	const shown = slowest.slice(0, limits.slowestTests);
+	return {
+		available: true,
+		complete: timing.complete !== false,
+		captureReason: textValue(timing.captureReason),
+		wallSeconds: finiteNumber(timing.wallSeconds),
+		packageCount: finiteNumber(timing.packageCount),
+		expectedPackageCount: finiteNumber(timing.expectedPackageCount),
+		testFailCount: finiteNumber(timing.testFailCount),
+		slowest: shown,
+		observed: slowest.length,
+		omitted: slowest.length - shown.length,
+	};
+}
+
+/**
+ * renderCoverageReportBody renders one lane's Markdown report. When a marker is
+ * supplied it is always the first line so an upsert can find the report again;
+ * a job summary omits it.
+ */
+export function renderCoverageReportBody(summary, options = {}) {
+	const heading = options.heading || "Backend Coverage";
+	const coverageArtifactName = options.coverageArtifactName || "coverage-summary.json";
+	const timingArtifactName = options.timingArtifactName || "timing-summary.json";
+	const slowestHeading = options.slowestHeading || "Slowest top-level tests";
+	const sections = [];
+	if (options.marker) {
+		sections.push(options.marker);
+	}
+	sections.push(`## ${heading}`, renderCoverageOverview(summary.coverage, coverageArtifactName));
+
+	const violations = renderPackageTable(summary.coverage.violations);
+	if (violations) {
+		sections.push(
+			`### Floor violations\n\n${violations}\n- ${summary.coverage.omittedViolations} additional violation(s) omitted.`,
+		);
+	}
+	const nearFloor = renderPackageTable(summary.coverage.nearFloor);
+	if (nearFloor) {
+		sections.push(
+			`### Closest to their floor\n\n${nearFloor}\n- ${summary.coverage.omitted} additional gated package(s) omitted.`,
+		);
+	}
+	sections.push(renderTimingOverview(summary.timing, timingArtifactName));
+	const slowest = renderSlowestTable(summary.timing.slowest);
+	if (slowest) {
+		sections.push(
+			`### ${slowestHeading}\n\n${slowest}\n- ${summary.timing.omitted} additional row(s) omitted.`,
+		);
+	}
+	const provenance = renderProvenance(options.metadata || {});
+	if (provenance) {
+		sections.push(provenance);
+	}
+	return `${sections.join("\n\n")}\n`;
+}
+
+function renderCoverageOverview(coverage, artifactName) {
+	if (!coverage.available) {
+		return `- Coverage summary: unavailable — this run published no readable \`${artifactName}\`.`;
+	}
+	const lines = [
+		`- Coverage: ${coverage.coveragePercent.toFixed(1)}% (${coverage.coveredStatements}/${coverage.measurableStatements} statements) across ${coverage.packageCount} measured package(s)`,
+		`- Gated packages: ${coverage.gatedCount}`,
+		`- Floor violations: ${coverage.violationCount}`,
+	];
+	if (!coverage.complete) {
+		lines.push(
+			`- Measurement status: incomplete — partial diagnostics only${coverage.measurementReason ? ` (${coverage.measurementReason})` : ""}`,
+		);
+	}
+	return lines.join("\n");
+}
+
+function renderTimingOverview(timing, artifactName) {
+	if (!timing.available) {
+		return `- Timing summary: unavailable — this run published no readable \`${artifactName}\`.`;
+	}
+	const lines = [
+		`- Wall-clock duration: ${timing.wallSeconds.toFixed(3)}s across ${timing.packageCount}/${timing.expectedPackageCount || timing.packageCount} package(s)`,
+		`- Observed top-level tests: ${timing.observed} (failed: ${timing.testFailCount})`,
+	];
+	if (!timing.complete) {
+		lines.push(
+			`- Capture status: incomplete — partial diagnostics only${timing.captureReason ? ` (${timing.captureReason})` : ""}`,
+		);
+	}
+	return lines.join("\n");
+}
+
+function renderPackageTable(rows) {
+	if (!rows || rows.length === 0) {
+		return "";
+	}
+	const lines = ["| Package | Coverage % | Floor | Headroom |", "| --- | ---: | ---: | ---: |"];
+	for (const row of rows) {
+		lines.push(
+			`| \`${row.package}\` | ${row.coveragePercent.toFixed(2)} | ${row.floor.toFixed(2)} | ${row.headroom.toFixed(2)} |`,
+		);
+	}
+	return lines.join("\n");
+}
+
+function renderSlowestTable(rows) {
+	if (!rows || rows.length === 0) {
+		return "";
+	}
+	const lines = ["| Test | Package | Elapsed (s) | Outcome |", "| --- | --- | ---: | --- |"];
+	for (const row of rows) {
+		lines.push(
+			`| \`${row.test}\` | \`${row.package}\` | ${row.seconds.toFixed(3)} | ${row.outcome} |`,
+		);
+	}
+	return lines.join("\n");
+}
+
+function renderProvenance(metadata) {
+	const lines = [];
+	if (textValue(metadata.headSha)) {
+		lines.push(`- Hosted head: \`${textValue(metadata.headSha)}\``);
+	}
+	if (textValue(metadata.runUrl)) {
+		lines.push(`- Hosted run: ${textValue(metadata.runUrl)}`);
+	}
+	return lines.join("\n");
+}
+
+/**
+ * upsertMarkedComment finds a report's own marked bot comment and updates it,
+ * so a second run on the same pull request replaces the report instead of
+ * appending a duplicate. Each report passes its own marker, so two reports on
+ * one thread never find, overwrite, or delete each other's comment.
+ */
+export function upsertMarkedComment(comments, body, options = {}) {
+	const botLogin = options.botLogin || "github-actions[bot]";
+	const marker = options.marker;
+	if (!marker) {
+		throw new Error("upsertMarkedComment requires the report's own comment marker");
+	}
+	const existing = (comments || []).find(
+		(comment) => comment.user?.login === botLogin && comment.body?.includes(marker),
+	);
+	if (existing) {
+		return { action: "update", commentId: existing.id, body };
+	}
+	return { action: "create", body };
+}
+
+/** readCoverageReportJson returns null for an absent or malformed document. */
+export function readCoverageReportJson(path) {
+	if (!path) {
+		return null;
+	}
+	try {
+		return JSON.parse(readFileSync(path, "utf8"));
+	} catch {
+		return null;
+	}
+}
+
+/** coverageReportOptionValue reads a `--name value` pair out of argv. */
+export function coverageReportOptionValue(args, name) {
+	const index = args.indexOf(name);
+	if (index === -1 || !args[index + 1]) {
+		return "";
+	}
+	return args[index + 1];
+}
+
+/**
+ * coverageReportProvenance derives the hosted head and run URL from the
+ * workflow environment. Missing variables simply drop their line.
+ */
+export function coverageReportProvenance(env, headShaVariable) {
+	return {
+		headSha: (headShaVariable ? env[headShaVariable] : "") || env.GITHUB_SHA || "",
+		runUrl:
+			env.GITHUB_SERVER_URL && env.GITHUB_REPOSITORY && env.GITHUB_RUN_ID
+				? `${env.GITHUB_SERVER_URL}/${env.GITHUB_REPOSITORY}/actions/runs/${env.GITHUB_RUN_ID}`
+				: "",
+	};
+}
+
+function finiteNumber(value) {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function textValue(value) {
+	return typeof value === "string" ? value.trim() : "";
+}

--- a/scripts/ci/coverage-report.mjs
+++ b/scripts/ci/coverage-report.mjs
@@ -21,6 +21,11 @@ export const DEFAULT_COVERAGE_REPORT_LIMITS = Object.freeze({
 	slowestTests: 10,
 });
 
+// Absorbs IEEE754 representation error in a headroom subtraction and nothing
+// else: floors are authored to two decimals, so this is seven orders of
+// magnitude below the smallest shortfall that can actually exist.
+const HEADROOM_EPSILON = 1e-9;
+
 /**
  * summarizeCoverageReport reduces a coverage-summary artifact and a timing
  * artifact to the ordered digest a report renders.
@@ -49,7 +54,7 @@ function summarizeCoverageArtifact(coverage, limits) {
 		.filter((entry) => entry && typeof entry.package === "string")
 		.map((entry) => ({
 			package: entry.package,
-			coveragePercent: finiteNumber(entry.coveragePercent),
+			coveragePercent: measuredCoveragePercent(entry),
 			floor:
 				typeof entry.packageFloor === "number" && Number.isFinite(entry.packageFloor)
 					? entry.packageFloor
@@ -63,12 +68,20 @@ function summarizeCoverageArtifact(coverage, limits) {
 				: left.headroom - right.headroom,
 		);
 
-	const allViolations = ranked.filter((entry) => entry.headroom < 0);
+	// A package that lands exactly on its floor meets it. Recomputing coverage
+	// as a ratio means that case arrives as a value like -1.4e-14 rather than a
+	// clean zero, so a bare `< 0` would report a package as failing purely
+	// because 63.75 is not representable in binary. The tolerance is far below
+	// the two decimals a floor is authored with, so it can only absorb
+	// representation error, never a real shortfall.
+	const allViolations = ranked.filter((entry) => entry.headroom < -HEADROOM_EPSILON);
 	// Coverage is never negative, so a package sitting on a 0% floor cannot
 	// regress through it. Both lanes hold packages without an explicit manifest
 	// entry to a 0.00 default floor, so including those would crowd every
 	// genuinely close package out of the table.
-	const contenders = ranked.filter((entry) => entry.headroom >= 0 && entry.floor > 0);
+	const contenders = ranked.filter(
+		(entry) => entry.headroom >= -HEADROOM_EPSILON && entry.floor > 0,
+	);
 	const violations = allViolations.slice(0, limits.violations);
 	const nearFloor = contenders.slice(0, limits.packages);
 	return {
@@ -290,6 +303,31 @@ export function coverageReportProvenance(env, headShaVariable) {
 
 function finiteNumber(value) {
 	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+// Headroom is a subtraction between two numbers the producer records at
+// different precisions: coveragePercent is rounded to one decimal, while a
+// package floor carries two (it is authored in basis points and divided by
+// 100). Subtracting them directly manufactures violations that do not exist --
+// a package measured at 73.3333% against a 73.33 floor is comfortably above it,
+// but rounds to 73.3 and reads as 0.03 below. Recomputing from the statement
+// counts the same document already carries makes the comparison exact, so the
+// table agrees with the gate instead of contradicting it. Falls back to the
+// rounded percent when the counts are absent or unusable, because a slightly
+// imprecise row is still better than dropping the package from the report.
+function measuredCoveragePercent(entry) {
+	const covered = entry.coveredStatements;
+	const measurable = entry.measurableStatements;
+	if (
+		typeof covered === "number" &&
+		Number.isFinite(covered) &&
+		typeof measurable === "number" &&
+		Number.isFinite(measurable) &&
+		measurable > 0
+	) {
+		return (covered / measurable) * 100;
+	}
+	return finiteNumber(entry.coveragePercent);
 }
 
 function textValue(value) {

--- a/scripts/ci/functional-coverage-comment.mjs
+++ b/scripts/ci/functional-coverage-comment.mjs
@@ -1,9 +1,19 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// Distinct from BACKEND_LINT_COMMENT_MARKER so the two reports never find,
-// overwrite, or delete each other's pull request comment.
+import {
+	coverageReportOptionValue,
+	coverageReportProvenance,
+	readCoverageReportJson,
+	renderCoverageReportBody,
+	summarizeCoverageReport,
+	upsertMarkedComment,
+} from "./coverage-report.mjs";
+
+// Distinct from BACKEND_LINT_COMMENT_MARKER and from
+// UNIT_COVERAGE_COMMENT_MARKER so no two reports ever find, overwrite, or
+// delete each other's pull request comment.
 export const FUNCTIONAL_COVERAGE_COMMENT_MARKER =
 	"<!-- functional-coverage-report -->";
 
@@ -14,6 +24,20 @@ export const FUNCTIONAL_COVERAGE_VIOLATION_LIMIT = 25;
 export const FUNCTIONAL_COVERAGE_PACKAGE_LIMIT = 10;
 export const FUNCTIONAL_COVERAGE_SLOWEST_TEST_LIMIT = 10;
 
+const FUNCTIONAL_COVERAGE_LIMITS = {
+	violations: FUNCTIONAL_COVERAGE_VIOLATION_LIMIT,
+	packages: FUNCTIONAL_COVERAGE_PACKAGE_LIMIT,
+	slowestTests: FUNCTIONAL_COVERAGE_SLOWEST_TEST_LIMIT,
+};
+
+const FUNCTIONAL_COVERAGE_RENDER_OPTIONS = {
+	marker: FUNCTIONAL_COVERAGE_COMMENT_MARKER,
+	heading: "Backend Functional Coverage",
+	coverageArtifactName: "coverage-summary.json",
+	timingArtifactName: "functional-timing-summary.json",
+	slowestHeading: "Slowest top-level tests",
+};
+
 /**
  * summarizeFunctionalCoverage reduces the coverage-summary and
  * functional-timing-summary artifacts to the ordered digest the pull request
@@ -21,96 +45,7 @@ export const FUNCTIONAL_COVERAGE_SLOWEST_TEST_LIMIT = 10;
  * unavailable summary instead of throwing: reporting must never fail the job.
  */
 export function summarizeFunctionalCoverage(coverage, timing) {
-	return {
-		coverage: summarizeCoverageArtifact(coverage),
-		timing: summarizeTimingArtifact(timing),
-	};
-}
-
-function summarizeCoverageArtifact(coverage) {
-	if (!coverage || typeof coverage !== "object" || !Array.isArray(coverage.packages)) {
-		return {
-			available: false,
-			violations: [],
-			violationCount: 0,
-			omittedViolations: 0,
-			nearFloor: [],
-			gatedCount: 0,
-			omitted: 0,
-		};
-	}
-	const ranked = coverage.packages
-		.filter((entry) => entry && typeof entry.package === "string")
-		.map((entry) => ({
-			package: entry.package,
-			coveragePercent: finiteNumber(entry.coveragePercent),
-			floor: typeof entry.packageFloor === "number" && Number.isFinite(entry.packageFloor)
-				? entry.packageFloor
-				: null,
-		}))
-		.filter((entry) => entry.floor !== null)
-		.map((entry) => ({ ...entry, headroom: entry.coveragePercent - entry.floor }))
-		.sort((left, right) =>
-			left.headroom === right.headroom
-				? left.package.localeCompare(right.package)
-				: left.headroom - right.headroom,
-		);
-
-	const allViolations = ranked.filter((entry) => entry.headroom < 0);
-	// Coverage is never negative, so a package sitting on a 0% floor cannot
-	// regress through it. The functional lane holds every package without an
-	// explicit manifest entry to a 0.00 default floor, so including those would
-	// crowd every genuinely close package out of the table.
-	const contenders = ranked.filter((entry) => entry.headroom >= 0 && entry.floor > 0);
-	const violations = allViolations.slice(0, FUNCTIONAL_COVERAGE_VIOLATION_LIMIT);
-	const nearFloor = contenders.slice(0, FUNCTIONAL_COVERAGE_PACKAGE_LIMIT);
-	return {
-		available: true,
-		complete: coverage.complete !== false,
-		measurementReason: textValue(coverage.measurementReason),
-		coveredStatements: finiteNumber(coverage.coveredStatements),
-		measurableStatements: finiteNumber(coverage.measurableStatements),
-		coveragePercent: finiteNumber(coverage.coveragePercent),
-		packageCount: coverage.packages.length,
-		gatedCount: ranked.length,
-		violationCount: allViolations.length,
-		violations,
-		omittedViolations: allViolations.length - violations.length,
-		nearFloor,
-		omitted: contenders.length - nearFloor.length,
-	};
-}
-
-function summarizeTimingArtifact(timing) {
-	if (!timing || typeof timing !== "object" || !Array.isArray(timing.tests)) {
-		return { available: false, slowest: [], observed: 0, omitted: 0 };
-	}
-	const slowest = timing.tests
-		.filter((entry) => entry && typeof entry.package === "string" && typeof entry.test === "string")
-		.map((entry) => ({
-			package: entry.package,
-			test: entry.test,
-			seconds: finiteNumber(entry.seconds),
-			outcome: textValue(entry.outcome) || "unknown",
-		}))
-		.sort((left, right) =>
-			left.seconds === right.seconds
-				? left.package.localeCompare(right.package) || left.test.localeCompare(right.test)
-				: right.seconds - left.seconds,
-		);
-	const shown = slowest.slice(0, FUNCTIONAL_COVERAGE_SLOWEST_TEST_LIMIT);
-	return {
-		available: true,
-		complete: timing.complete !== false,
-		captureReason: textValue(timing.captureReason),
-		wallSeconds: finiteNumber(timing.wallSeconds),
-		packageCount: finiteNumber(timing.packageCount),
-		expectedPackageCount: finiteNumber(timing.expectedPackageCount),
-		testFailCount: finiteNumber(timing.testFailCount),
-		slowest: shown,
-		observed: slowest.length,
-		omitted: slowest.length - shown.length,
-	};
+	return summarizeCoverageReport(coverage, timing, FUNCTIONAL_COVERAGE_LIMITS);
 }
 
 /**
@@ -118,105 +53,7 @@ function summarizeTimingArtifact(timing) {
  * body. The marker is always the first line so the upsert can find it.
  */
 export function renderFunctionalCoverageComment(summary, metadata = {}) {
-	const sections = [
-		FUNCTIONAL_COVERAGE_COMMENT_MARKER,
-		"## Backend Functional Coverage",
-		renderCoverageOverview(summary.coverage),
-	];
-	const violations = renderPackageTable(summary.coverage.violations);
-	if (violations) {
-		sections.push(
-			`### Floor violations\n\n${violations}\n- ${summary.coverage.omittedViolations} additional violation(s) omitted.`,
-		);
-	}
-	const nearFloor = renderPackageTable(summary.coverage.nearFloor);
-	if (nearFloor) {
-		sections.push(
-			`### Closest to their floor\n\n${nearFloor}\n- ${summary.coverage.omitted} additional gated package(s) omitted.`,
-		);
-	}
-	sections.push(renderTimingOverview(summary.timing));
-	const slowest = renderSlowestTable(summary.timing.slowest);
-	if (slowest) {
-		sections.push(
-			`### Slowest top-level tests\n\n${slowest}\n- ${summary.timing.omitted} additional row(s) omitted.`,
-		);
-	}
-	const provenance = renderProvenance(metadata);
-	if (provenance) {
-		sections.push(provenance);
-	}
-	return `${sections.join("\n\n")}\n`;
-}
-
-function renderCoverageOverview(coverage) {
-	if (!coverage.available) {
-		return "- Coverage summary: unavailable — this run published no readable `coverage-summary.json`.";
-	}
-	const lines = [
-		`- Coverage: ${coverage.coveragePercent.toFixed(1)}% (${coverage.coveredStatements}/${coverage.measurableStatements} statements) across ${coverage.packageCount} measured package(s)`,
-		`- Gated packages: ${coverage.gatedCount}`,
-		`- Floor violations: ${coverage.violationCount}`,
-	];
-	if (!coverage.complete) {
-		lines.push(
-			`- Measurement status: incomplete — partial diagnostics only${coverage.measurementReason ? ` (${coverage.measurementReason})` : ""}`,
-		);
-	}
-	return lines.join("\n");
-}
-
-function renderTimingOverview(timing) {
-	if (!timing.available) {
-		return "- Timing summary: unavailable — this run published no readable `functional-timing-summary.json`.";
-	}
-	const lines = [
-		`- Wall-clock duration: ${timing.wallSeconds.toFixed(3)}s across ${timing.packageCount}/${timing.expectedPackageCount || timing.packageCount} package(s)`,
-		`- Observed top-level tests: ${timing.observed} (failed: ${timing.testFailCount})`,
-	];
-	if (!timing.complete) {
-		lines.push(
-			`- Capture status: incomplete — partial diagnostics only${timing.captureReason ? ` (${timing.captureReason})` : ""}`,
-		);
-	}
-	return lines.join("\n");
-}
-
-function renderPackageTable(rows) {
-	if (!rows || rows.length === 0) {
-		return "";
-	}
-	const lines = ["| Package | Coverage % | Floor | Headroom |", "| --- | ---: | ---: | ---: |"];
-	for (const row of rows) {
-		lines.push(
-			`| \`${row.package}\` | ${row.coveragePercent.toFixed(2)} | ${row.floor.toFixed(2)} | ${row.headroom.toFixed(2)} |`,
-		);
-	}
-	return lines.join("\n");
-}
-
-function renderSlowestTable(rows) {
-	if (!rows || rows.length === 0) {
-		return "";
-	}
-	const lines = ["| Test | Package | Elapsed (s) | Outcome |", "| --- | --- | ---: | --- |"];
-	for (const row of rows) {
-		lines.push(
-			`| \`${row.test}\` | \`${row.package}\` | ${row.seconds.toFixed(3)} | ${row.outcome} |`,
-		);
-	}
-	return lines.join("\n");
-}
-
-function renderProvenance(metadata) {
-	const lines = [];
-	if (textValue(metadata.headSha)) {
-		lines.push(`- Hosted head: \`${textValue(metadata.headSha)}\``);
-	}
-	if (textValue(metadata.runUrl)) {
-		lines.push(`- Hosted run: ${textValue(metadata.runUrl)}`);
-	}
-	return lines.join("\n");
+	return renderCoverageReportBody(summary, { ...FUNCTIONAL_COVERAGE_RENDER_OPTIONS, metadata });
 }
 
 /**
@@ -225,62 +62,27 @@ function renderProvenance(metadata) {
  * report instead of appending a duplicate.
  */
 export function upsertFunctionalCoverageComment(comments, body, options = {}) {
-	const botLogin = options.botLogin || "github-actions[bot]";
-	const marker = options.marker || FUNCTIONAL_COVERAGE_COMMENT_MARKER;
-	const existing = (comments || []).find(
-		(comment) => comment.user?.login === botLogin && comment.body?.includes(marker),
-	);
-	if (existing) {
-		return { action: "update", commentId: existing.id, body };
-	}
-	return { action: "create", body };
-}
-
-function finiteNumber(value) {
-	return typeof value === "number" && Number.isFinite(value) ? value : 0;
-}
-
-function textValue(value) {
-	return typeof value === "string" ? value.trim() : "";
-}
-
-function readJson(path) {
-	if (!path) {
-		return null;
-	}
-	try {
-		return JSON.parse(readFileSync(path, "utf8"));
-	} catch {
-		return null;
-	}
-}
-
-function optionValue(args, name) {
-	const index = args.indexOf(name);
-	if (index === -1 || !args[index + 1]) {
-		return "";
-	}
-	return args[index + 1];
+	return upsertMarkedComment(comments, body, {
+		marker: FUNCTIONAL_COVERAGE_COMMENT_MARKER,
+		...options,
+	});
 }
 
 function runCli() {
 	const args = process.argv.slice(2);
-	const commentPath = optionValue(args, "--comment");
+	const commentPath = coverageReportOptionValue(args, "--comment");
 	if (!commentPath) {
 		process.stderr.write("functional coverage comment: --comment path is required; skipping.\n");
 		return;
 	}
 	const summary = summarizeFunctionalCoverage(
-		readJson(optionValue(args, "--coverage")),
-		readJson(optionValue(args, "--timing")),
+		readCoverageReportJson(coverageReportOptionValue(args, "--coverage")),
+		readCoverageReportJson(coverageReportOptionValue(args, "--timing")),
 	);
-	const body = renderFunctionalCoverageComment(summary, {
-		headSha: process.env.FUNCTIONAL_COVERAGE_HEAD_SHA || process.env.GITHUB_SHA,
-		runUrl:
-			process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
-				? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
-				: "",
-	});
+	const body = renderFunctionalCoverageComment(
+		summary,
+		coverageReportProvenance(process.env, "FUNCTIONAL_COVERAGE_HEAD_SHA"),
+	);
 	writeFileSync(commentPath, body);
 	process.stdout.write(`functional coverage comment written to ${commentPath}\n`);
 }

--- a/scripts/ci/publish-unit-coverage-comment.sh
+++ b/scripts/ci/publish-unit-coverage-comment.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Renders the Backend Unit Coverage pull request comment body from the coverage
+# and timing artifacts the unit lane publishes. This is a reporting-only sibling
+# of publish-unit-coverage-summary.sh and is deliberately fail-open: a missing
+# artifact, a malformed document, or a missing node runtime writes a
+# degraded-but-present body (or nothing) and exits 0. A reporting failure must
+# never turn a passing suite red.
+
+set -uo pipefail
+
+artifact_root="${UNIT_COVERAGE_DIR:-.artifacts/unit-coverage}"
+coverage_path="${UNIT_COVERAGE_JSON:-$artifact_root/coverage-summary.json}"
+timing_path="${UNIT_COVERAGE_TIMING:-$artifact_root/unit-timing-summary.json}"
+comment_path="${UNIT_COVERAGE_COMMENT_FILE:-$artifact_root/unit-coverage-comment.md}"
+node_bin="${NODE_BIN:-node}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+mkdir -p "$(dirname "$comment_path")" 2>/dev/null || true
+
+if ! command -v "$node_bin" >/dev/null 2>&1; then
+  echo "unit coverage comment: $node_bin is unavailable; skipping comment body." >&2
+  exit 0
+fi
+
+"$node_bin" "$script_dir/unit-coverage-report.mjs" \
+  --coverage "$coverage_path" \
+  --timing "$timing_path" \
+  --comment "$comment_path"
+status=$?
+if [ "$status" -ne 0 ]; then
+  echo "unit coverage comment: renderer exited with $status; continuing without a comment body." >&2
+fi
+
+exit 0

--- a/scripts/ci/publish-unit-coverage-summary.sh
+++ b/scripts/ci/publish-unit-coverage-summary.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# Publishes the Backend Unit Coverage job summary from the coverage and timing
+# artifacts the unit lane writes. This is a reporting-only sibling of
+# publish-functional-test-summary.sh and is deliberately fail-open: a missing
+# artifact, a malformed document, or a missing node runtime writes an explicit
+# "unavailable" section and exits 0. A reporting failure must never turn a
+# passing suite red.
+
+set -uo pipefail
+
+artifact_root="${UNIT_COVERAGE_DIR:-.artifacts/unit-coverage}"
+coverage_path="${UNIT_COVERAGE_JSON:-$artifact_root/coverage-summary.json}"
+timing_path="${UNIT_COVERAGE_TIMING:-$artifact_root/unit-timing-summary.json}"
+profile_path="${UNIT_COVERAGE_PROFILE:-$artifact_root/coverage.out}"
+summary_path="${UNIT_COVERAGE_SUMMARY_FILE:-$artifact_root/unit-coverage-summary.md}"
+node_bin="${NODE_BIN:-node}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -z "${GITHUB_STEP_SUMMARY:-}" ]; then
+  echo "GITHUB_STEP_SUMMARY not set; skipping the unit coverage job summary."
+  exit 0
+fi
+
+mkdir -p "$(dirname "$summary_path")" 2>/dev/null || true
+
+# The renderer owns the report and its diagnostics-availability section: it is
+# the only party that knows whether an artifact that exists on disk actually
+# parsed, so it reports readability rather than mere presence.
+if command -v "$node_bin" >/dev/null 2>&1; then
+  "$node_bin" "$script_dir/unit-coverage-report.mjs" \
+    --coverage "$coverage_path" \
+    --timing "$timing_path" \
+    --profile "$profile_path" \
+    --summary "$summary_path"
+  render_status=$?
+  if [ "$render_status" -ne 0 ]; then
+    echo "unit coverage summary: renderer exited with $render_status; falling back to a presence-only section." >&2
+  fi
+else
+  echo "unit coverage summary: $node_bin is unavailable; falling back to a presence-only section." >&2
+fi
+
+if [ -s "$summary_path" ]; then
+  cat "$summary_path" >> "$GITHUB_STEP_SUMMARY" || echo "warning: failed to append the unit coverage report to the job summary" >&2
+  exit 0
+fi
+
+# The renderer produced no body at all, so all this step can still report is
+# which inputs are present on disk.
+{
+  printf '%s\n\n' "## Backend Unit Coverage"
+  printf '%s\n\n' "The report is unavailable because the lane ended before the renderer produced a body."
+  printf '%s\n\n' "### Unit coverage diagnostics availability"
+  for input in "coverage-summary:$coverage_path" "timing:$timing_path" "coverage-profile:$profile_path"; do
+    name="${input%%:*}"
+    path="${input#*:}"
+    if [ -f "$path" ]; then
+      printf '%s\n' "present: name=$name path=$path status=unverified — the renderer never read it"
+    else
+      printf '%s\n' "unavailable: name=$name path=$path reason=the lane published no such file before it ended"
+    fi
+  done
+} >> "$GITHUB_STEP_SUMMARY" || echo "warning: failed to append the unit coverage availability section" >&2
+
+exit 0

--- a/scripts/ci/unit-coverage-report.mjs
+++ b/scripts/ci/unit-coverage-report.mjs
@@ -1,0 +1,180 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+	coverageReportOptionValue,
+	coverageReportProvenance,
+	readCoverageReportJson,
+	renderCoverageReportBody,
+	summarizeCoverageReport,
+	upsertMarkedComment,
+} from "./coverage-report.mjs";
+
+// Distinct from BACKEND_LINT_COMMENT_MARKER and from
+// FUNCTIONAL_COVERAGE_COMMENT_MARKER so no two reports ever find, overwrite, or
+// delete each other's pull request comment.
+export const UNIT_COVERAGE_COMMENT_MARKER = "<!-- unit-coverage-report -->";
+
+// Row caps for the pull request comment. The rendered text always states how
+// many rows a cap dropped so a truncated table is never read as the whole set,
+// and the body stays well inside GitHub's comment size limit.
+export const UNIT_COVERAGE_VIOLATION_LIMIT = 25;
+export const UNIT_COVERAGE_PACKAGE_LIMIT = 10;
+export const UNIT_COVERAGE_SLOWEST_TEST_LIMIT = 10;
+
+// The job summary has no comment size limit to respect and is the place a
+// contributor goes for detail, so it carries more rows than the comment. It
+// states its own omitted counts for exactly the same reason.
+export const UNIT_COVERAGE_SUMMARY_PACKAGE_LIMIT = 25;
+export const UNIT_COVERAGE_SUMMARY_SLOWEST_TEST_LIMIT = 20;
+
+const UNIT_COVERAGE_COMMENT_LIMITS = {
+	violations: UNIT_COVERAGE_VIOLATION_LIMIT,
+	packages: UNIT_COVERAGE_PACKAGE_LIMIT,
+	slowestTests: UNIT_COVERAGE_SLOWEST_TEST_LIMIT,
+};
+
+const UNIT_COVERAGE_SUMMARY_LIMITS = {
+	violations: UNIT_COVERAGE_VIOLATION_LIMIT,
+	packages: UNIT_COVERAGE_SUMMARY_PACKAGE_LIMIT,
+	slowestTests: UNIT_COVERAGE_SUMMARY_SLOWEST_TEST_LIMIT,
+};
+
+const UNIT_COVERAGE_RENDER_OPTIONS = {
+	heading: "Backend Unit Coverage",
+	coverageArtifactName: "coverage-summary.json",
+	timingArtifactName: "unit-timing-summary.json",
+	slowestHeading: "Slowest unit tests",
+};
+
+/**
+ * summarizeUnitCoverage reduces the unit lane's coverage-summary and
+ * unit-timing-summary artifacts to the ordered digest the report renders.
+ * Absent or malformed inputs produce an explicitly unavailable summary instead
+ * of throwing: reporting must never fail the coverage job.
+ */
+export function summarizeUnitCoverage(coverage, timing, limits = UNIT_COVERAGE_COMMENT_LIMITS) {
+	return summarizeCoverageReport(coverage, timing, limits);
+}
+
+/**
+ * renderUnitCoverageComment renders the marked pull request comment body. The
+ * marker is always the first line so the upsert can find it again.
+ */
+export function renderUnitCoverageComment(summary, metadata = {}) {
+	return renderCoverageReportBody(summary, {
+		...UNIT_COVERAGE_RENDER_OPTIONS,
+		marker: UNIT_COVERAGE_COMMENT_MARKER,
+		metadata,
+	});
+}
+
+/**
+ * renderUnitCoverageJobSummary renders the $GITHUB_STEP_SUMMARY body. It omits
+ * the comment marker, which is only meaningful on a pull request thread.
+ */
+export function renderUnitCoverageJobSummary(summary, metadata = {}) {
+	return renderCoverageReportBody(summary, { ...UNIT_COVERAGE_RENDER_OPTIONS, metadata });
+}
+
+/**
+ * upsertUnitCoverageComment finds this report's own marked bot comment and
+ * updates it, so a second run on the same pull request replaces the report
+ * instead of appending a duplicate.
+ */
+export function upsertUnitCoverageComment(comments, body, options = {}) {
+	return upsertMarkedComment(comments, body, { marker: UNIT_COVERAGE_COMMENT_MARKER, ...options });
+}
+
+/**
+ * renderUnitCoverageAvailability names each input the report depends on when
+ * any of them is degraded, so a partial job summary is never read as a complete
+ * measurement. It reports readability, not mere presence: a file that exists but
+ * does not parse is reported unreadable, which is what the report above it says.
+ *
+ * A run with every input intact renders nothing, keeping a healthy summary to
+ * the report itself.
+ */
+export function renderUnitCoverageAvailability(summary, inputs = {}) {
+	const rows = [
+		{
+			name: "coverage-summary",
+			path: inputs.coverage,
+			available: summary.coverage.available,
+			reason: "the lane published no readable coverage summary before it ended",
+		},
+		{
+			name: "timing",
+			path: inputs.timing,
+			available: summary.timing.available,
+			reason: "the lane published no readable timing summary before it ended",
+		},
+		{
+			name: "coverage-profile",
+			path: inputs.profile,
+			available: Boolean(inputs.profile) && existsSync(inputs.profile),
+			reason: "go test did not flush a coverage profile",
+		},
+	].filter((row) => Boolean(row.path));
+
+	if (rows.every((row) => row.available)) {
+		return "";
+	}
+	const lines = ["### Unit coverage diagnostics availability", ""];
+	for (const row of rows) {
+		lines.push(
+			row.available
+				? `available: name=${row.name} path=${row.path}`
+				: `unavailable: name=${row.name} path=${row.path} reason=${row.reason}`,
+		);
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+function writeReport(path, body) {
+	mkdirSync(dirname(resolve(path)), { recursive: true });
+	writeFileSync(path, body);
+	process.stdout.write(`unit coverage report written to ${path}\n`);
+}
+
+function runCli() {
+	const args = process.argv.slice(2);
+	const commentPath = coverageReportOptionValue(args, "--comment");
+	const summaryPath = coverageReportOptionValue(args, "--summary");
+	if (!commentPath && !summaryPath) {
+		process.stderr.write("unit coverage report: --comment or --summary path is required; skipping.\n");
+		return;
+	}
+	const inputs = {
+		coverage: coverageReportOptionValue(args, "--coverage"),
+		timing: coverageReportOptionValue(args, "--timing"),
+		profile: coverageReportOptionValue(args, "--profile"),
+	};
+	const coverage = readCoverageReportJson(inputs.coverage);
+	const timing = readCoverageReportJson(inputs.timing);
+	const metadata = coverageReportProvenance(process.env, "UNIT_COVERAGE_HEAD_SHA");
+	if (summaryPath) {
+		const summary = summarizeCoverageReport(coverage, timing, UNIT_COVERAGE_SUMMARY_LIMITS);
+		const availability = renderUnitCoverageAvailability(summary, inputs);
+		writeReport(
+			summaryPath,
+			renderUnitCoverageJobSummary(summary, metadata) + (availability ? `\n${availability}` : ""),
+		);
+	}
+	if (commentPath) {
+		writeReport(
+			commentPath,
+			renderUnitCoverageComment(summarizeUnitCoverage(coverage, timing), metadata),
+		);
+	}
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+	try {
+		runCli();
+	} catch (error) {
+		// Reporting is never allowed to fail the coverage job.
+		process.stderr.write(`unit coverage report: ${error.message}\n`);
+	}
+}

--- a/scripts/ci/unit-coverage-report.test.mjs
+++ b/scripts/ci/unit-coverage-report.test.mjs
@@ -66,6 +66,73 @@ test("orders gated packages by headroom ascending with violations first", () => 
 	assert.equal(summary.coverage.violationCount, 1);
 });
 
+// Regression: the first real CI run of this report accused 33 passing packages
+// of breaking their floor. The producer rounds coveragePercent to one decimal
+// but authors floors in basis points, so a package measured at 73.3333% against
+// a 73.33 floor arrived as 73.3 and subtracted to 0.03 below. The gate passed
+// while the report it publishes named those packages as violations, which is
+// the one thing this report must never do.
+test("judges a floor by the measured statements, not the rounded percent", () => {
+	const artifact = {
+		complete: true,
+		coveredStatements: 11,
+		measurableStatements: 15,
+		coveragePercent: 73.3,
+		packages: [
+			// Exactly 73.3333%, which clears its floor but rounds below it.
+			{
+				package: "pkg/rounds-below",
+				coveredStatements: 11,
+				measurableStatements: 15,
+				coveragePercent: 73.3,
+				packageFloor: 73.33,
+			},
+			// Genuinely under its floor: it must stay reported.
+			{
+				package: "pkg/truly-under",
+				coveredStatements: 7,
+				measurableStatements: 10,
+				coveragePercent: 70,
+				packageFloor: 73.33,
+			},
+		],
+	};
+	const summary = summarizeUnitCoverage(artifact, timingArtifact());
+	assert.deepEqual(
+		summary.coverage.violations.map((entry) => entry.package),
+		["pkg/truly-under"],
+	);
+	assert.equal(summary.coverage.violationCount, 1);
+	assert.ok(summary.coverage.nearFloor.some((entry) => entry.package === "pkg/rounds-below"));
+});
+
+test("falls back to the reported percent when statement counts are unusable", () => {
+	const artifact = {
+		complete: true,
+		coveredStatements: 0,
+		measurableStatements: 0,
+		coveragePercent: 0,
+		packages: [
+			// No counts at all, so the rounded percent is the only signal left.
+			{ package: "pkg/countless", coveragePercent: 40, packageFloor: 70 },
+			// A zero denominator must not become a division by zero.
+			{
+				package: "pkg/empty",
+				coveredStatements: 0,
+				measurableStatements: 0,
+				coveragePercent: 90,
+				packageFloor: 80,
+			},
+		],
+	};
+	const summary = summarizeUnitCoverage(artifact, timingArtifact());
+	assert.deepEqual(
+		summary.coverage.violations.map((entry) => entry.package),
+		["pkg/countless"],
+	);
+	assert.ok(summary.coverage.nearFloor.some((entry) => entry.package === "pkg/empty"));
+});
+
 test("renders a package table ordered by headroom, not by import path", () => {
 	const body = renderUnitCoverageComment(
 		summarizeUnitCoverage(coverageArtifact(), timingArtifact()),

--- a/scripts/ci/unit-coverage-report.test.mjs
+++ b/scripts/ci/unit-coverage-report.test.mjs
@@ -1,0 +1,281 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { BACKEND_LINT_COMMENT_MARKER } from "./backend-lint-report.mjs";
+import { FUNCTIONAL_COVERAGE_COMMENT_MARKER } from "./functional-coverage-comment.mjs";
+import {
+	UNIT_COVERAGE_COMMENT_MARKER,
+	UNIT_COVERAGE_PACKAGE_LIMIT,
+	UNIT_COVERAGE_SLOWEST_TEST_LIMIT,
+	UNIT_COVERAGE_SUMMARY_PACKAGE_LIMIT,
+	UNIT_COVERAGE_SUMMARY_SLOWEST_TEST_LIMIT,
+	UNIT_COVERAGE_VIOLATION_LIMIT,
+	renderUnitCoverageAvailability,
+	renderUnitCoverageComment,
+	renderUnitCoverageJobSummary,
+	summarizeUnitCoverage,
+	upsertUnitCoverageComment,
+} from "./unit-coverage-report.mjs";
+
+function coverageArtifact() {
+	return {
+		complete: true,
+		coveredStatements: 30,
+		measurableStatements: 40,
+		coveragePercent: 75,
+		packages: [
+			{ package: "pkg/ample", coveragePercent: 99, packageFloor: 10 },
+			{ package: "pkg/near", coveragePercent: 80.5, packageFloor: 80 },
+			{ package: "pkg/regressed", coveragePercent: 40, packageFloor: 70 },
+			{ package: "pkg/ungated", coveragePercent: 12, packageFloor: null },
+			// The unit lane holds unlisted packages to a 0.00 default floor.
+			// Those can never regress through it.
+			{ package: "pkg/lane-default", coveragePercent: 0, packageFloor: 0 },
+		],
+	};
+}
+
+function timingArtifact() {
+	return {
+		version: 1,
+		complete: true,
+		wallSeconds: 184.25,
+		packageCount: 2,
+		expectedPackageCount: 2,
+		testCount: 3,
+		testFailCount: 1,
+		tests: [
+			{ package: "pkg/alpha", test: "TestQuick", seconds: 0.25, outcome: "pass" },
+			{ package: "pkg/alpha", test: "TestSlow", seconds: 40.125, outcome: "fail" },
+			{ package: "pkg/beta", test: "TestMiddle", seconds: 12.5, outcome: "pass" },
+		],
+	};
+}
+
+test("orders gated packages by headroom ascending with violations first", () => {
+	const summary = summarizeUnitCoverage(coverageArtifact(), timingArtifact());
+	assert.deepEqual(
+		summary.coverage.violations.map((entry) => entry.package),
+		["pkg/regressed"],
+	);
+	assert.deepEqual(
+		summary.coverage.nearFloor.map((entry) => entry.package),
+		["pkg/near", "pkg/ample"],
+	);
+	assert.equal(summary.coverage.gatedCount, 4);
+	assert.equal(summary.coverage.violationCount, 1);
+});
+
+test("renders a package table ordered by headroom, not by import path", () => {
+	const body = renderUnitCoverageComment(
+		summarizeUnitCoverage(coverageArtifact(), timingArtifact()),
+	);
+	assert.ok(body.includes("## Backend Unit Coverage"));
+	assert.ok(body.includes("| `pkg/regressed` | 40.00 | 70.00 | -30.00 |"));
+	assert.ok(body.indexOf("### Floor violations") < body.indexOf("### Closest to their floor"));
+	// pkg/near has 0.50 headroom and pkg/ample has 89.00, so headroom ordering
+	// puts pkg/near first even though pkg/ample sorts first by import path.
+	assert.ok(body.indexOf("`pkg/near`") < body.indexOf("`pkg/ample`"));
+	// A package held to the 0.00 lane-default floor cannot be close to failing.
+	assert.ok(!body.includes("`pkg/lane-default`"));
+});
+
+test("renders the slowest unit tests with real durations, ordered descending", () => {
+	const summary = summarizeUnitCoverage(coverageArtifact(), timingArtifact());
+	assert.deepEqual(
+		summary.timing.slowest.map((entry) => entry.test),
+		["TestSlow", "TestMiddle", "TestQuick"],
+	);
+
+	const body = renderUnitCoverageComment(summary);
+	assert.ok(body.includes("### Slowest unit tests"));
+	assert.ok(body.includes("| `TestSlow` | `pkg/alpha` | 40.125 | fail |"));
+	assert.ok(body.includes("| `TestQuick` | `pkg/alpha` | 0.250 | pass |"));
+	assert.ok(body.includes("- Wall-clock duration: 184.250s across 2/2 package(s)"));
+});
+
+test("states the omitted counts for every capped table instead of truncating silently", () => {
+	const packages = [];
+	for (let index = 0; index < UNIT_COVERAGE_PACKAGE_LIMIT + 4; index += 1) {
+		packages.push({
+			package: `pkg/p${String(index).padStart(2, "0")}`,
+			coveragePercent: 50 + index,
+			packageFloor: 50,
+		});
+	}
+	const tests = [];
+	for (let index = 0; index < UNIT_COVERAGE_SLOWEST_TEST_LIMIT + 7; index += 1) {
+		tests.push({
+			package: "pkg/alpha",
+			test: `TestCase${String(index).padStart(2, "0")}`,
+			seconds: index,
+			outcome: "pass",
+		});
+	}
+
+	const summary = summarizeUnitCoverage(
+		{ ...coverageArtifact(), packages },
+		{ ...timingArtifact(), tests },
+	);
+	assert.equal(summary.coverage.nearFloor.length, UNIT_COVERAGE_PACKAGE_LIMIT);
+	assert.equal(summary.coverage.omitted, 4);
+	assert.equal(summary.timing.slowest.length, UNIT_COVERAGE_SLOWEST_TEST_LIMIT);
+	assert.equal(summary.timing.omitted, 7);
+
+	const body = renderUnitCoverageComment(summary);
+	assert.ok(body.includes("- 4 additional gated package(s) omitted."));
+	assert.ok(body.includes("- 7 additional row(s) omitted."));
+	assert.ok(!body.includes("`TestCase00`"));
+});
+
+test("caps the violation table while reporting the true violation count", () => {
+	const packages = [];
+	for (let index = 0; index < UNIT_COVERAGE_VIOLATION_LIMIT + 3; index += 1) {
+		packages.push({
+			package: `pkg/broken${String(index).padStart(2, "0")}`,
+			coveragePercent: index,
+			packageFloor: 90,
+		});
+	}
+
+	const summary = summarizeUnitCoverage({ ...coverageArtifact(), packages }, null);
+	assert.equal(summary.coverage.violations.length, UNIT_COVERAGE_VIOLATION_LIMIT);
+	assert.equal(summary.coverage.violationCount, UNIT_COVERAGE_VIOLATION_LIMIT + 3);
+
+	const body = renderUnitCoverageComment(summary);
+	assert.ok(body.includes(`- Floor violations: ${UNIT_COVERAGE_VIOLATION_LIMIT + 3}`));
+	assert.ok(body.includes("- 3 additional violation(s) omitted."));
+	// The worst regression is always kept; the mildest ones are dropped.
+	assert.ok(body.includes("`pkg/broken00`"));
+	assert.ok(!body.includes("`pkg/broken27`"));
+});
+
+test("the job summary carries more rows than the comment and omits the marker", () => {
+	const packages = [];
+	for (let index = 0; index < UNIT_COVERAGE_SUMMARY_PACKAGE_LIMIT + 2; index += 1) {
+		packages.push({
+			package: `pkg/p${String(index).padStart(2, "0")}`,
+			coveragePercent: 50 + index,
+			packageFloor: 50,
+		});
+	}
+	const tests = [];
+	for (let index = 0; index < UNIT_COVERAGE_SUMMARY_SLOWEST_TEST_LIMIT + 2; index += 1) {
+		tests.push({
+			package: "pkg/alpha",
+			test: `TestCase${String(index).padStart(2, "0")}`,
+			seconds: index,
+			outcome: "pass",
+		});
+	}
+
+	const artifacts = [{ ...coverageArtifact(), packages }, { ...timingArtifact(), tests }];
+	const jobSummary = renderUnitCoverageJobSummary(
+		summarizeUnitCoverage(artifacts[0], artifacts[1], {
+			violations: UNIT_COVERAGE_VIOLATION_LIMIT,
+			packages: UNIT_COVERAGE_SUMMARY_PACKAGE_LIMIT,
+			slowestTests: UNIT_COVERAGE_SUMMARY_SLOWEST_TEST_LIMIT,
+		}),
+	);
+
+	assert.ok(!jobSummary.includes(UNIT_COVERAGE_COMMENT_MARKER));
+	assert.ok(jobSummary.startsWith("## Backend Unit Coverage"));
+	assert.ok(jobSummary.includes("- 2 additional gated package(s) omitted."));
+	assert.ok(jobSummary.includes("- 2 additional row(s) omitted."));
+	assert.equal(
+		jobSummary.split("\n").filter((line) => line.startsWith("| `pkg/p")).length,
+		UNIT_COVERAGE_SUMMARY_PACKAGE_LIMIT,
+	);
+});
+
+test("degrades to a present body when an artifact is missing or malformed", () => {
+	for (const [coverage, timing] of [
+		[null, null],
+		[undefined, undefined],
+		["not json", 42],
+		[{ packages: "not an array" }, { tests: null }],
+		[coverageArtifact(), null],
+	]) {
+		const summary = summarizeUnitCoverage(coverage, timing);
+		const body = renderUnitCoverageComment(summary);
+		assert.ok(body.startsWith(UNIT_COVERAGE_COMMENT_MARKER));
+		assert.ok(body.includes("## Backend Unit Coverage"));
+		assert.ok(body.includes("Timing summary: unavailable"));
+		assert.ok(body.includes("unit-timing-summary.json"));
+	}
+});
+
+test("reports an incomplete measurement rather than presenting it as whole", () => {
+	const summary = summarizeUnitCoverage(
+		{ ...coverageArtifact(), complete: false, measurementReason: "lane budget expired" },
+		{ ...timingArtifact(), complete: false, captureReason: "package never reported" },
+	);
+	const body = renderUnitCoverageComment(summary);
+	assert.ok(body.includes("- Measurement status: incomplete — partial diagnostics only (lane budget expired)"));
+	assert.ok(body.includes("- Capture status: incomplete — partial diagnostics only (package never reported)"));
+});
+
+test("the availability section reports readability, not mere presence", () => {
+	const inputs = {
+		coverage: "artifacts/coverage-summary.json",
+		timing: "artifacts/unit-timing-summary.json",
+		profile: "artifacts/coverage.out",
+	};
+
+	// A run with both documents parsed renders no availability section at all;
+	// a healthy summary is just the report.
+	const intact = renderUnitCoverageAvailability(
+		summarizeUnitCoverage(coverageArtifact(), timingArtifact()),
+		{ coverage: inputs.coverage, timing: inputs.timing },
+	);
+	assert.equal(intact, "");
+
+	// A coverage-summary that exists on disk but does not parse is reported
+	// unavailable, matching what the report above it says.
+	const degraded = renderUnitCoverageAvailability(
+		summarizeUnitCoverage("not json", timingArtifact()),
+		inputs,
+	);
+	assert.ok(degraded.includes("unavailable: name=coverage-summary path=artifacts/coverage-summary.json"));
+	assert.ok(degraded.includes("available: name=timing path=artifacts/unit-timing-summary.json"));
+	// The profile is never opened by the renderer, so an absent one is reported
+	// as absent rather than claimed present.
+	assert.ok(degraded.includes("unavailable: name=coverage-profile path=artifacts/coverage.out"));
+});
+
+test("updates its own marked comment and never another report's", () => {
+	const body = renderUnitCoverageComment(
+		summarizeUnitCoverage(coverageArtifact(), timingArtifact()),
+	);
+	assert.notEqual(UNIT_COVERAGE_COMMENT_MARKER, BACKEND_LINT_COMMENT_MARKER);
+	assert.notEqual(UNIT_COVERAGE_COMMENT_MARKER, FUNCTIONAL_COVERAGE_COMMENT_MARKER);
+	assert.ok(!body.includes(BACKEND_LINT_COMMENT_MARKER));
+	assert.ok(!body.includes(FUNCTIONAL_COVERAGE_COMMENT_MARKER));
+
+	const comments = [
+		{ id: 1, user: { login: "github-actions[bot]" }, body: `${BACKEND_LINT_COMMENT_MARKER}\nlint` },
+		{
+			id: 2,
+			user: { login: "github-actions[bot]" },
+			body: `${FUNCTIONAL_COVERAGE_COMMENT_MARKER}\nfunctional`,
+		},
+		{ id: 3, user: { login: "someone" }, body: `${UNIT_COVERAGE_COMMENT_MARKER}\nimpostor` },
+	];
+
+	const created = upsertUnitCoverageComment(comments, body);
+	assert.equal(created.action, "create");
+
+	const published = [
+		...comments,
+		{ id: 4, user: { login: "github-actions[bot]" }, body: created.body },
+	];
+	const updated = upsertUnitCoverageComment(published, `${body}second run`);
+	assert.equal(updated.action, "update");
+	assert.equal(updated.commentId, 4);
+	assert.equal(updated.body, `${body}second run`);
+
+	// A third run still targets the same single comment.
+	const third = upsertUnitCoverageComment(published, `${body}third run`);
+	assert.equal(third.action, "update");
+	assert.equal(third.commentId, 4);
+});


### PR DESCRIPTION
Brings the unit half of the `backend-coverage` matrix to reporting parity with
the functional half: coverage/timing JSON capture, a headroom-ordered package
table, a slowest-tests table with an explicit omitted count, an `if: always()`
job summary and diagnostics artifact scoped to `matrix.suite == 'unit'`, and a
distinctly-marked unit-coverage PR comment.

Reporting only. No floor, threshold, manifest, or gate exit-code change.

## Reuse decision (story 002)

The PRD recorded that no functional-side renderer existed on `origin/main` and
told the implementation to re-verify. **That claim was stale**: `cov-r1` (#2061)
merged before this lane started and delivered exactly the renderer the PRD
described. So this takes the reuse branch, not the fork branch.

## Shared-code changes (acceptance criterion 6)

Five shared changes, each called out with exactly what changed and why:

1. **`scripts/ci/coverage-report.mjs` (new, extracted).** The summarize / render
   / marked-comment-upsert core from `functional-coverage-comment.mjs`, moved
   verbatim behind lane options (marker, heading, artifact names, slowest-table
   heading, table limits). `functional-coverage-comment.mjs` is now a thin lane
   profile over it and keeps every public export and its CLI. **The proof this
   is behaviour-preserving is that its 7 pre-existing tests pass untouched** —
   not one assertion was edited.

2. **`cmd/gocoveragecheck` timing snapshot emits `tests: []` instead of `null`.**
   A nil Go slice marshals to JSON `null`, and a consumer reading a documented
   array field cannot tell `null` apart from an unreadable document — so an
   interrupted lane reported itself as *unmeasurable* rather than *partial*.
   This is the producer both lanes share, so **it also fixes the functional
   lane's degraded path**, which had the same defect. It cannot affect a
   complete run: the field was already populated there.

3. **Timing capture notes are attributed to their own lane.** The same shared
   producer hard-coded `"functional timing capture ended before every package
   reported a terminal result"` and `"functional run started"`. The unit job
   summary renders those notes verbatim, where naming the functional suite reads
   as evidence the wrong lane was measured. The noun is now derived from
   `cfg.suite`; **the functional wording stays byte-identical** (asserted).

4. **`cmd/gocoveragecheck` publishes timing snapshots off the pipe-drain
   goroutine (non-streaming lanes only).** `observe()` serialized the whole
   run's snapshot and performed an atomic file write on *every* package event,
   while running on the goroutine that drains the child `go test` stdout pipe —
   so each write applied backpressure to every test binary. Invisible at the
   functional lane's few dozen packages; fatal at the unit lane's 528, where the
   required check ran 60min+ and never once completed. Non-streaming lanes now
   leave persistence to the 1s ticker `run()` already owns; **streaming lanes
   (functional, which passes `-stream`) keep the per-event publish, so the
   functional path is byte-identical.** A membership scan on the same hot path
   went from `slices.Contains` to a set lookup. Guarded by a wall-clock
   regression test, proven non-tautological at 3.295s reverted vs 0.01s fixed.

5. **Headroom is computed from statement counts, not the rounded percent.**
   Found in the first real hosted output: the report headlined *40 floor
   violations* while the gate exited 0. Not a gate disagreement — the producer
   rounds `coveragePercent` to 1dp while floors are authored in basis points and
   carry 2dp, so `pkg/platform/inboxgitkeep` measured 73.3333% against a 73.33
   floor, arrived as 73.3, and subtracted to −0.03. 33 of the 40 were that
   artifact, i.e. the report named 33 passing packages as failing. Headroom now
   derives from the `coveredStatements` / `measurableStatements` counts the same
   document already carries, falls back to the rounded percent when those are
   unusable, and carries a 1e-9 tolerance so a package exactly on its floor is
   not flagged by IEEE754 error. Validated against the real artifact from run
   `32104579745`: **40 → 6**, matching an independent exact-ratio computation.
   This lives in the shared renderer, so **it corrects the functional lane's
   violation accounting the same way**; the functional lane's 7 tests still pass
   untouched.

No existing step in the `backend-coverage` job had its `run`, `if`, `timeout`,
`matrix`, or `needs` changed. The entire `ci.yml` diff is additive except for
three stale comment lines above `permissions:` that said only the functional
lane comments on the PR — now true of both lanes. Every removed line in that
file, in full:

    -    # The functional lane upserts its own reporting comment on the pull
    -    # request, mirroring Backend Lint. Every other permission stays at the
    -    # workflow-level read-only default.

## `-timing-output` is not gated on `-suite functional` (story 001)

Traced `configureFunctionalTimingSnapshot` and `finalizeFunctionalTiming` in
`cmd/gocoveragecheck/coverage_invocation.go`. Both are suite-agnostic; the only
`cfg.suite == "functional"` gate in that path guards
`writeFunctionalTimingInventorySummary`, which is a functional-only console
inventory, not the artifact. **Nothing needed ungating** — confirmed empirically
by running the unit lane at base `3d46e3fc2` with `-json-output`/`-timing-output`
set and seeing both files written. Story 001 was therefore pure Makefile wiring.

One consequence did need handling: `-timing-output` flips the child to
`go test -json`, so a non-streaming lane's buffered stdout holds test2json
events rather than human text. `coverageFailureDetailStdout` replays those
events back to human text so a unit failure stays diagnosable. It is scoped to
non-streaming lanes, so the functional streaming path is provably untouched.

## Gate behaviour: before / after (acceptance criterion 1)

The same scoped unit-lane invocation was run at base `3d46e3fc2` (in a
disposable detached worktree) and at this branch's head. **Console output
changed; exit codes did not.**

| Scenario | base `3d46e3fc2` | head |
| --- | :---: | :---: |
| Clean run, within floors | `0` | `0` |
| Induced per-package floor violation | `1` | `1` |
| Induced overall floor violation (`-min 100.1`) | `1` | `1` |

**BEFORE** — base `3d46e3fc2`, clean run, reporting flags set:

    total: (statements) 100.0%
    github.com/portpowered/infinite-you/pkg/platform/taskgroup   coverage: 100.0% of statements
    Go coverage 100.0% meets minimum 0.0%.
    BASE_CLEAN_EXIT=0

**AFTER** — head, same invocation:

    total: (statements) 100.0%
    Unit package coverage verdict:
      floor violations: none
      near floor: none within 2.0000 percentage points
      tally: measured-packages=1 gated-packages=1 below-floor=0 near-floor=0 gate-failures=0
    Go coverage 100.0% meets minimum 0.0%.
    HEAD_CLEAN_EXIT=0

**AFTER** — head, induced per-package floor violation (`jsonvalue` floored at
50.00% with no tests):

    total: (statements) 27.9%
    Unit package coverage verdict:
      floor violation: package=.../pkg/platform/jsonvalue floor=50.0000% actual=0.0000% delta=-50.0000 percentage-points covered=0/49 statements uncovered-blocks=36
      near floor: none within 2.0000 percentage points
      tally: measured-packages=2 gated-packages=2 below-floor=1 near-floor=0 gate-failures=1
    package coverage regression: package=.../pkg/platform/jsonvalue lane=unit expected-minimum=50.00% actual=0.0000% ...
    VIOLATION EXIT=1

The base printed one raw `coverage:` line per measured package in each of these
runs. The real unit lane measures ~547 packages, which is the log spam story 002
targets.

The collapse is deliberately gated: the verdict block replaces the raw
per-package lines **only when `-json-output` is set**, so the complete
measurement always survives in the uploaded artifact first. With reporting off,
the raw listing is preserved byte-for-byte — which is why the pre-existing
`TestExecuteFloorFailureWithoutJSONOptionKeepsHumanDiagnostics` still passes
unedited.

## Rendered job summary (story 003)

Produced by `scripts/ci/unit-coverage-report.mjs` from the artifacts of the
induced-violation run above (import paths shortened here for width):

    ## Backend Unit Coverage

    - Coverage: 27.9% (19/68 statements) across 2 measured package(s)
    - Gated packages: 2
    - Floor violations: 1

    ### Floor violations

    | Package | Coverage % | Floor | Headroom |
    | --- | ---: | ---: | ---: |
    | `.../pkg/platform/jsonvalue` | 0.00 | 50.00 | -50.00 |
    - 0 additional violation(s) omitted.

    ### Closest to their floor

    | Package | Coverage % | Floor | Headroom |
    | --- | ---: | ---: | ---: |
    | `.../pkg/platform/taskgroup` | 100.00 | 10.00 | 90.00 |
    - 0 additional gated package(s) omitted.

    - Wall-clock duration: 3.379s across 0/2 package(s)
    - Observed top-level tests: 10 (failed: 0)
    - Capture status: incomplete — partial diagnostics only (unit timing capture
      ended before every package reported a terminal result)

    ### Slowest unit tests

    | Test | Package | Elapsed (s) | Outcome |
    | --- | --- | ---: | --- |
    | `TestGroupDoneClosesAfterEveryTaskReturnsRegardlessOfOutcome` | `.../taskgroup` | 0.000 | pass |
    | ... 9 more rows ... |
    - 0 additional row(s) omitted.

Package rows are ordered by headroom (coverage minus that package's floor)
ascending, with an import-path tiebreak. Omitted counts are always printed,
including at zero — a silent truncation is exactly what these tables exist to
prevent.

(That capture note reads `incomplete` because this demo passes `-packages` with
relative spellings, while `go test -json` reports import paths, so the timing
tracker never matches its expected keys. CI never hits this: with `-packages`
unset, `resolveTestPackages` resolves through `go list -f {{.ImportPath}}`. It is
kept here because it is also what makes the lane-attribution fix visible.)

## PR comment (story 004)

Marker `<!-- unit-coverage-report -->`, distinct from the backend-lint marker in
`scripts/ci/backend-lint-workflow.mjs` and from the functional coverage marker.
The paginate-then-match-then-create-or-update plumbing is the shared
`upsertMarkedComment` helper (extraction decision: extracted, see above), which
throws rather than guessing when a marker is absent. Both publish scripts are
`set -uo pipefail` + `exit 0`, and the renderer degrades to a present-but-partial
body when an input is missing or unparseable, so reporting can never turn a
passing suite red. The in-place-update evidence (two run IDs, one comment) is
posted as a comment on this PR rather than committed.

## Verification

- `go vet ./...` — clean
- `go test ./cmd/gocoveragecheck/` — ok
- `make test-ci-workflows` — 64/64
- `make backend-size`, `make pkg-maint`, `make pkg-file-count`,
  `make pkg-structure`, `make pkg-boundary`, `make ownership-boundary` — pass

---

## PRD

<details>
<summary><code>prd.json</code></summary>

```json
{
  "project": "you-agent-factory",
  "branchName": "cov-r2-unit-coverage-and-timing-report",
  "description": "Bring the unit half of the CI backend-coverage matrix to reporting parity with the functional half: capture unit coverage/timing JSON outputs, render a headroom-ordered package table and a slowest-tests table with an explicit omitted count, publish an if:always() job summary and diagnostics artifact scoped to matrix.suite == 'unit', and upsert a distinctly-marked unit-coverage PR comment. Reporting-only: no floor, threshold, manifest, or gate exit-code changes, and the functional path stays untouched except for an explicitly-called-out shared-helper extraction.",
  "context": {
    "customerAsk": "Give the unit half of the backend-coverage CI matrix the same reporting surface the functional half already has (job summary, artifact, PR comment, slow-test visibility, near-floor package visibility) without changing gate behavior or touching the functional path beyond extracting a shared helper.",
    "problem": "The unit path of the backend-coverage job in .github/workflows/ci.yml is three bare steps ending in `run: make test-unit-coverage` (ci.yml:222): no profile, no JSON coverage summary, no timing capture, no $GITHUB_STEP_SUMMARY render, no artifact upload, no PR comment. Failures render as a raw make error; passes reveal nothing about near-floor packages or slow tests. Note: the seeding payload described a merged 'cov-r1' functional-side renderer (headroom ordering, slowest-tests table, collapsed verdict log, PR comment) as the thing to reuse, but a direct check of origin/main at PRD-authoring time found no such renderer or PR-comment step anywhere in the repository for the functional path either -- only a raw Markdown catalog dump and an artifact upload exist today. Implementation must re-verify this at start and build the unit-side reporting fresh unless something has since merged.",
    "solution": "Wire -json-output and -timing-output through make test-unit-coverage using the same conditional-forwarding style the functional target already uses; build a small unit-scoped renderer that turns the resulting JSON into a headroom-ascending package coverage table, a capped slowest-unit-tests table with an explicit omitted count, and a collapsed console verdict block; wire that renderer into the unit path of the backend-coverage job as additive, if: always() && matrix.suite == 'unit' steps (job summary render + diagnostics artifact upload); and add a PR-comment upsert with a marker distinct from the lint comment and any functional coverage comment, reusing the existing paginate/match/create-or-update pattern already used for the lint comment."
  },
  "acceptanceCriteria": [
    "make test-unit-coverage still exits non-zero on a per-package or overall floor violation and zero when the unit suite is within its floors, demonstrated before and after this change with a deliberately induced violation and a clean run.",
    "Running the unit coverage target locally with reporting enabled writes a deterministic JSON coverage summary and a deterministic JSON timing summary to disk, in addition to the existing coverage profile.",
    "The unit path of the backend-coverage CI job publishes a $GITHUB_STEP_SUMMARY section with a package-coverage table ordered by headroom (coverage minus floor) ascending and a slowest-unit-tests table with real durations and an explicit omitted-test count.",
    "The unit path uploads an if: always() diagnostics artifact containing the coverage profile, coverage summary JSON, and timing JSON.",
    "A PR against this lane's branch carries a unit-coverage PR comment with a marker distinct from the lint comment and any functional coverage comment, and a second CI run on the same PR updates that comment in place rather than duplicating it (evidenced by run IDs in a PR comment).",
    "The functional path of the backend-coverage job is unaffected -- its steps, if: conditions, timeouts, and matrix are untouched, or any unavoidable shared-code change is called out explicitly in the PR body with exactly what changed and why.",
    "Quality gate: go vet ./... is clean, make pkg-boundary and make pkg-file-count pass for the new Go command/package, no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green -- make lint end-to-end is not required to pass because pkg-boundary carries pre-existing packaged-service-structure migration debt (recorded 2026-08-08). Tests pass for all touched packages.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "cov-r2-unit-coverage-and-timing-report-001",
      "title": "Unit coverage JSON and timing outputs are capturable",
      "description": "As a maintainer running the unit coverage target, I want machine-readable coverage and timing output written to disk so downstream reporting can consume them, the same way the functional target already supports GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT / GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT.",
      "acceptanceCriteria": [
        "make test-unit-coverage forwards -json-output when GO_UNIT_COVERAGE_JSON_OUTPUT is set and -timing-output when GO_UNIT_COVERAGE_TIMING_OUTPUT is set, using the same conditional-forwarding style already used for GO_UNIT_COVERAGE_PROFILE / -profile and for the functional target's JSON/timing variables.",
        "Running make test-unit-coverage with all three env vars set produces a coverage profile, a coverage summary JSON file, and a timing summary JSON file with real per-top-level-test durations for the unit suite; confirm in the PR body whether cmd/gocoveragecheck's -timing-output path is gated on -suite functional (trace configureFunctionalTimingSnapshot/finalizeFunctionalTiming in cmd/gocoveragecheck/coverage_invocation.go), and if it is gated, ungate it or explain why not.",
        "With none of the three env vars set, make test-unit-coverage behaves exactly as it does on main today.",
        "make test-unit-coverage still exits non-zero on a floor violation and zero otherwise; demonstrate both.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Makefile forwards -json-output/-timing-output for GO_UNIT_COVERAGE_JSON_OUTPUT / GO_UNIT_COVERAGE_TIMING_OUTPUT with the same $(if $(VAR),-flag $(VAR),) idiom the profile already used, so an invocation with none set runs main's exact command. Traced configureFunctionalTimingSnapshot/finalizeFunctionalTiming: -timing-output is NOT gated on -suite functional (only writeFunctionalTimingInventorySummary is), so no ungating was needed. Setting -timing-output does flip the child to go test -json, so coverageFailureDetailStdout replays test2json events back to human text to keep unit failures readable. Exit codes verified at base 3d46e3fc2 and at head: clean=0, per-package violation=1, overall floor violation=1. REGRESSION FOUND AND FIXED (2026-08-18): enabling -timing-output on the 528-package unit lane made the required Backend Unit Coverage step run 60min+ without completing on two heads, vs 4.3-5.3min on main and on four other PRs (528 packages measured in both, so not selection skew). Cause: the timing snapshotter's observe() published a full serialized snapshot plus an atomic file write on EVERY package event, while running on the goroutine draining the child go test stdout pipe, so each write blocked every test binary. Fixed by leaving persistence to the existing 1s ticker for non-streaming lanes (the functional lane streams, so its behaviour is byte-identical) and by replacing an O(N) slices.Contains membership scan with a set lookup. Symmetric A/B: timing capture cost +39% before (23.1s->32.2s), nothing measurable after; the new guard fails at 3.295s and passes at 0.01s. NOT the profile: prepareCoverageProfile(\"\") always created a temp profile, so main already wrote one and GO_UNIT_COVERAGE_PROFILE only changes its destination. Gate re-verified: clean=0, per-package violation=1, overall violation=1. CONFIRMED IN CI (2026-08-18): run 32104579745 is the first run on this branch where Backend Unit Coverage completed -- step 7 took 7m48s (05:55:40Z -> 06:03:28Z) and the job concluded success, versus 61min+ and never completing on the two pre-fix heads. The perf regression is closed. Also fixed there: the timing capture reported \"ended before every package reported a terminal result\" while its own counts recorded terminal results for all 548/548 packages; the reason now follows the counts, since a single unparseable line is enough to mark a large lane lossy."
    },
    {
      "id": "cov-r2-unit-coverage-and-timing-report-002",
      "title": "Unit coverage report renderer",
      "description": "As a maintainer reading CI output, I want a rendered report built from the unit suite's coverage/timing JSON that shows which packages are closest to their floor and which tests are slowest, instead of raw per-package coverage: log spam.",
      "acceptanceCriteria": [
        "A renderer (new command or extracted-and-reused shared code) consumes the unit coverage summary JSON and unit timing JSON from story 001 and emits a package-coverage table ordered by headroom (measured coverage minus that package's floor) ascending, showing measured coverage, floor, and delta per package.",
        "The same renderer emits a slowest-unit-tests table with real durations, capped at a stated size, with an explicit 'N tests omitted' line when the full set exceeds that cap -- never a silent truncation.",
        "The renderer's console/log output is a single collapsed ordered pass/fail verdict block, replacing the raw per-package coverage: line spam a plain go test -cover run currently produces for the unit suite.",
        "Before writing new code, check git log origin/main for any lane that already delivered an equivalent functional-side renderer; if one exists, reuse it and extract only the minimal shared helper needed instead of forking a parallel implementation, and say so in the PR body. If none exists, build the unit renderer standalone and say so in the PR body.",
        "The renderer makes no gate/exit-code decisions itself -- gocoveragecheck's own exit code remains the sole pass/fail signal.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Re-checked git log origin/main at start: the PRD's claim that no functional renderer existed was stale -- cov-r1 (#2061) had merged. Took the reuse branch: extracted scripts/ci/coverage-report.mjs as the shared helper and reduced functional-coverage-comment.mjs to a lane profile over it (its 7 pre-existing tests pass untouched, which is the behaviour-preservation proof). scripts/ci/unit-coverage-report.mjs is the unit lane profile, with 10 new tests. Console side: the Go verdict block now covers the unit lane, gated on -json-output so the complete measurement always survives in the artifact before the raw lines are collapsed. The renderer makes no exit-code decisions. ACCURACY FIX (2026-08-18, after the first hosted run of this report ever completed): the report named 40 floor violations while the gate exited 0. Cause was a precision mismatch, not a gate disagreement -- the producer rounds coveragePercent to 1 decimal while floors are authored in basis points and carry 2, so e.g. pkg/platform/inboxgitkeep measured 73.3333% against a 73.33 floor, arrived as 73.3, and subtracted to -0.03. 33 of the 40 were that artifact. Headroom is now computed from the coveredStatements/measurableStatements counts the same document already carries, falling back to the rounded percent when counts are unusable, plus a 1e-9 tolerance so a package exactly on its floor is not flagged by IEEE754 error. Verified against the REAL artifact from run 32104579745: 40 -> 6 named violations, matching an independent exact-ratio computation; the remaining 6 are truly below floor and inside the drift the gate tolerates. Guard proven non-tautological (fails with the fix reverted, passes restored). Functional lane behaviour preserved: its 7 tests pass untouched."
    },
    {
      "id": "cov-r2-unit-coverage-and-timing-report-003",
      "title": "Unit path publishes a CI job summary and diagnostics artifact",
      "description": "As a contributor whose PR touches backend packages, I want the unit coverage job's summary and artifacts to show the same kind of report the functional job already shows, so I can see near-floor packages and slow tests without downloading raw logs.",
      "acceptanceCriteria": [
        "The unit path of the backend-coverage job in .github/workflows/ci.yml sets the artifact directory and the three output paths (profile, JSON coverage summary, timing JSON) for make test-unit-coverage.",
        "A new step, scoped with if: always() && matrix.suite == 'unit', runs the story-002 renderer and appends its Markdown output to $GITHUB_STEP_SUMMARY, failing open when inputs are partial or absent, mirroring scripts/ci/publish-functional-test-summary.sh's availability-fallback pattern.",
        "A new actions/upload-artifact@v4 step, also if: always() && matrix.suite == 'unit', uploads the unit diagnostics (coverage profile, coverage summary JSON, timing JSON) with if-no-files-found: ignore, mirroring the functional upload step.",
        "No existing step in the backend-coverage job (functional or unit) has its run, if, timeout, matrix, or needs changed; any unavoidable shared-helper extraction is called out explicitly in the PR body.",
        "Typecheck passes",
        "Tests pass, with before/after job-log tails (raw make error or bare success vs. the rendered summary) pasted in the PR body"
      ],
      "priority": 3,
      "passes": true,
      "notes": "ci.yml unit path sets the artifact dir and the three output paths, then adds if: always() && matrix.suite == 'unit' steps for the job-summary render and the upload-artifact@v4 upload with if-no-files-found: ignore. Additivity verified: git diff origin/main -- .github/workflows/ci.yml shows the only removed lines are three stale permissions comment lines; no existing run/if/timeout/matrix/needs changed. OBSERVED IN CI (2026-08-18, run 32104579745): steps 8-12 all ran and succeeded for the first time. The diagnostics artifact downloaded clean with all four files (coverage.out 10.4MB, coverage-summary.json, unit-timing-summary.json 3.7MB, unit-coverage-summary.md)."
    },
    {
      "id": "cov-r2-unit-coverage-and-timing-report-004",
      "title": "Unit coverage PR comment",
      "description": "As a PR author, I want a unit coverage comment on my PR that updates in place across reruns, distinct from the lint comment and any functional coverage comment, so I can see unit coverage/timing status without opening the job summary.",
      "acceptanceCriteria": [
        "A new if: always() && matrix.suite == 'unit' step (or equivalently-gated job-level step) upserts a PR comment built from the story-002 renderer's output, using an HTML-comment marker distinct from the existing lint comment marker in scripts/ci/backend-lint-workflow.mjs and from any functional coverage comment marker.",
        "The step reuses the existing paginate-then-match-then-create-or-update comment pattern already used for the lint comment (the upsertBackendLintComment call in .github/workflows/ci.yml), extracted into a small shared helper if that avoids duplicating the GitHub API plumbing, with the extraction decision stated in the PR body.",
        "The step fails open: a missing or partial JSON/timing input produces a degraded-but-present comment body rather than a failed step.",
        "Two CI runs on the same PR head-range result in exactly one unit coverage comment that was updated, not duplicated, verified by run IDs posted in a PR comment.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "scripts/ci/publish-unit-coverage-comment.sh upserts a comment marked <!-- unit-coverage-report -->, distinct from the backend-lint marker and from the functional coverage marker, reusing the shared paginate/match/create-or-update helper in coverage-report.mjs (upsertMarkedComment, which throws on a missing marker). Fails open: the script is set -uo pipefail with exit 0, and renderUnitCoverageAvailability degrades to a present-but-partial body when an input is missing or unparseable. Two-run in-place update is evidenced by run IDs posted in a PR comment. OBSERVED IN CI (2026-08-18, run 32104579745): the bot posted comment 5324267811 carrying the <!-- unit-coverage-report --> marker. Author-filtered count with two green controls (functional-coverage-report=1, backend-lint-report=1) gives unit marker=1, so the count is trustworthy rather than a broken filter. The rendered body carries the headroom tables AND the Slowest unit tests table with real durations (top 26.590s) and an explicit \"10411 additional row(s) omitted\" line."
    }
  ]
}
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

