### PR TITLE
rsm-2-enable-session-persistence

### DIFF
--- a/pkg/services/factory_sessions/internal/execution/service.go
+++ b/pkg/services/factory_sessions/internal/execution/service.go
@@ -268,10 +268,9 @@ const (
 
 // PersistenceChoiceForPolicy resolves application policy into the closed
 // persistence choice consumed by durable execution composition.
-// Ordinary runtime opening uses the zero value / disabled policy so live
-// you run and packaged-factory invocations do not create project-local
-// .you-agent-factory/durable-sessions. Explicit enabled policy preserves
-// restart/resume snapshot persistence for callers and tests that opt in.
+// Public runtime opening selects PersistencePolicyEnabled explicitly before it
+// reaches this selector. The zero value and explicit disabled policy remain
+// memory-only choices for callers and tests that need deterministic isolation.
 func PersistenceChoiceForPolicy(
 	policy PersistencePolicy,
 	projectRoot string,

--- a/pkg/services/factory_sessions/internal/services/durable_execution/internal/service/construction_test.go
+++ b/pkg/services/factory_sessions/internal/services/durable_execution/internal/service/construction_test.go
@@ -52,6 +52,51 @@ func TestNewDurable_DefaultPolicyDoesNotCreateProjectDurableSessions(t *testing.
 	}
 }
 
+func TestNewDurable_DisabledPolicyDoesNotCreateProjectDurableSessions(t *testing.T) {
+	t.Parallel()
+
+	projectRoot := t.TempDir()
+	startedOwner, err := NewDurable(
+		projectRoot,
+		factorysessions.PersistencePolicyDisabled,
+		projectPersistenceStoreFactory(),
+		factorysessions.ChildExecutorModeFake,
+		restartClock{now: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+		restartSyncWaitScheduler{},
+		checkpointfixtures.CheckpointSummariesFixture{},
+		factoryruntimefixtures.ScriptedJavaScriptWorkflows{},
+		factoryruntimefixtures.ScriptedJavaScriptWorkflows{},
+		factoryruntimefixtures.ScriptedJavaScriptWorkflows{},
+		nil,
+		factoryruntime.JavaScriptWorkerSettings{},
+		restartRecordingWriter{},
+		func() string { return "dddddddddddddddddddddddddddddddd" },
+		nil,
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewDurable(disabled policy): %v", err)
+	}
+
+	_, err = startedOwner.StartSync(context.Background(), factorysessions.DurableStartRequest{
+		RequestID: "req-construction-disabled-persistence-001",
+		Source: factorysessions.Source{
+			Kind: factoryruntime.WorkflowSourceKindInlineWorkflow,
+			InlineWorkflow: &factorysessions.InlineWorkflowSource{
+				Dialect:      "you-workflow-v1",
+				InlineSource: `return { ok: true };`,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartSync: %v", err)
+	}
+	if _, err := os.Stat(runtimepersist.DirForProjectRoot(projectRoot)); !os.IsNotExist(err) {
+		t.Fatalf("disabled persistence path stat error = %v, want not exist", err)
+	}
+}
+
 func TestNewDurable_EnabledPolicyPersistsProjectDurableSessions(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/wire/runtime_inputs.go
+++ b/pkg/wire/runtime_inputs.go
@@ -237,8 +237,12 @@ func provideRuntimeOpeningRequestFactory() runcli.RuntimeOpeningRequestFactory {
 				},
 			},
 			FactorySession: factorysessions.SessionRuntimeOpeningRequest{
-				SystemConfigHome: cfg.HomeDir,
-				WorkFile:         cfg.WorkFile,
+				// Public run and service openings use the existing durable
+				// snapshot path explicitly. Empty and disabled remain
+				// memory-only choices for callers that opt into them.
+				PersistencePolicy: factorysessions.PersistencePolicyEnabled,
+				SystemConfigHome:  cfg.HomeDir,
+				WorkFile:          cfg.WorkFile,
 				Host: factorysessions.RuntimeHostRequest{
 					Directory:   cfg.Dir,
 					RuntimeMode: mode,

--- a/pkg/wire/runtime_inputs_test.go
+++ b/pkg/wire/runtime_inputs_test.go
@@ -450,6 +450,9 @@ func TestRuntimeOpeningRequestFactoryMapsSelectionsIntoOwnerRequests(t *testing.
 		!request.FactorySession.Host.AutoPort {
 		t.Fatalf("Factory Session request = %#v", request.FactorySession)
 	}
+	if request.FactorySession.PersistencePolicy != factorysessions.PersistencePolicyEnabled {
+		t.Fatalf("Factory Session persistence policy = %q, want %q", request.FactorySession.PersistencePolicy, factorysessions.PersistencePolicyEnabled)
+	}
 	if request.Workers.RunnerID != "runner" || request.Workers.Worktree != "feature-login" ||
 		request.Workers.WorkerReasoningEffort != "xhigh" ||
 		request.Workers.MockWorkers != mocks || request.Workers.InvocationSkipPermissionsOverride != &skip {
@@ -460,6 +463,31 @@ func TestRuntimeOpeningRequestFactoryMapsSelectionsIntoOwnerRequests(t *testing.
 	}
 	if request.ModelCacheDirectory != "models" {
 		t.Fatalf("Model cache directory = %#v", request.ModelCacheDirectory)
+	}
+}
+
+func TestRuntimeOpeningRequestFactorySelectsEnabledPersistenceForBatchAndService(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name         string
+		continuously bool
+		mode         factorydefinitions.RuntimeMode
+	}{
+		{name: "batch", mode: factorydefinitions.RuntimeModeBatch},
+		{name: "service", continuously: true, mode: factorydefinitions.RuntimeModeService},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := provideRuntimeOpeningRequestFactory()(runcli.RunConfig{
+				Dir:          "factory",
+				Continuously: test.continuously,
+			}, nil)
+			if request.FactoryRuntime.Mode != test.mode {
+				t.Fatalf("runtime mode = %q, want %q", request.FactoryRuntime.Mode, test.mode)
+			}
+			if request.FactorySession.PersistencePolicy != factorysessions.PersistencePolicyEnabled {
+				t.Fatalf("persistence policy = %q, want %q", request.FactorySession.PersistencePolicy, factorysessions.PersistencePolicyEnabled)
+			}
+		})
 	}
 }
 

--- a/tests/functional/orchestration/javascript/durability/resume_test.go
+++ b/tests/functional/orchestration/javascript/durability/resume_test.go
@@ -192,10 +192,10 @@ func TestJavaScriptResumeRestoresCheckpointAndFinalResult(t *testing.T) {
 	assertResumableTwoStepFinalPrimaryResult(t, result, workflowName)
 }
 
-// TestJavaScriptDurabilityDoesNotPersistSnapshotsByDefault proves the public
-// process keeps interrupted JavaScript sessions inspectable in memory without
-// recreating the retired project-local durable-sessions directory.
-func TestJavaScriptDurabilityDoesNotPersistSnapshotsByDefault(t *testing.T) {
+// TestJavaScriptDurabilityPersistsSnapshotsByDefault proves the public process
+// writes an interrupted JavaScript Factory Session to the project-local
+// durable-sessions directory during orderly shutdown.
+func TestJavaScriptDurabilityPersistsSnapshotsByDefault(t *testing.T) {
 	const workflowName = "resumable-two-step-fake-children"
 	projectRoot := setupJavaScriptDurabilityResumeWorkflowFixture(t, workflowName)
 	provider := newJavaScriptDurabilityResumeBlockingCommandRunner(workflowName)
@@ -215,10 +215,10 @@ func TestJavaScriptDurabilityDoesNotPersistSnapshotsByDefault(t *testing.T) {
 	}
 	// The public interrupted projection is published before the canceled
 	// provider command necessarily returns. Join the root-built process before
-	// inspecting project-local persistence so the negative assertion runs after
-	// all runtime work and cleanup associated with the canceled edge is done.
+	// inspecting project-local persistence so the assertion runs after all
+	// runtime work and cleanup associated with the canceled edge is done.
 	server.Stop(t)
-	assertNoJavaScriptDurableSessionPersistence(t, projectRoot, sessionID)
+	assertJavaScriptDurableSessionPersistence(t, projectRoot, sessionID)
 }
 
 func setupJavaScriptDurabilityResumeWorkflowFixture(t *testing.T, workflowName string) string {
@@ -392,16 +392,19 @@ func javaScriptDurableSessionPersistencePath(projectRoot, sessionID string) stri
 	return filepath.Join(projectRoot, ".you-agent-factory", "durable-sessions", sessionID+".json")
 }
 
-func assertNoJavaScriptDurableSessionPersistence(t *testing.T, projectRoot, sessionID string) {
+func assertJavaScriptDurableSessionPersistence(t *testing.T, projectRoot, sessionID string) {
 	t.Helper()
 
 	persistencePath := javaScriptDurableSessionPersistencePath(projectRoot, sessionID)
-	if _, err := os.Stat(persistencePath); !os.IsNotExist(err) {
-		t.Fatalf("project-local durable session snapshot stat error = %v, want not exist", err)
+	info, err := os.Stat(persistencePath)
+	if err != nil {
+		t.Fatalf("project-local durable session snapshot stat error = %v, want exist", err)
 	}
-	persistenceDir := filepath.Dir(persistencePath)
-	if _, err := os.Stat(persistenceDir); !os.IsNotExist(err) {
-		t.Fatalf("project-local durable session directory stat error = %v, want not exist", err)
+	if info.IsDir() {
+		t.Fatalf("project-local durable session snapshot %s is a directory, want a file", persistencePath)
+	}
+	if info.Size() == 0 {
+		t.Fatalf("project-local durable session snapshot %s is empty, want persisted session state", persistencePath)
 	}
 }
 

--- a/tests/functional/sessions/restart/logical_identity_test.go
+++ b/tests/functional/sessions/restart/logical_identity_test.go
@@ -213,10 +213,10 @@ func TestFactorySessionResumeDoesNotRepeatCompletedDispatch(t *testing.T) {
 	}
 }
 
-// TestFactorySessionHistoryIsNotPersistedByDefault proves an interrupted
-// Factory Session remains inspectable for its process lifetime but is absent
-// after restart while durable snapshot recording is disabled by default.
-func TestFactorySessionHistoryIsNotPersistedByDefault(t *testing.T) {
+// TestFactorySessionHistoryIsPersistedAcrossRestart proves an interrupted
+// Factory Session remains inspectable after the public process is restarted
+// with the same project-local durable session store.
+func TestFactorySessionHistoryIsPersistedAcrossRestart(t *testing.T) {
 	const workflowName = "resumable-two-step-fake-children"
 	factoryDir := setupResumableTwoStepWorkflowFixture(t, workflowName)
 	home := t.TempDir()
@@ -242,13 +242,13 @@ func TestFactorySessionHistoryIsNotPersistedByDefault(t *testing.T) {
 	}
 
 	beforeDispatches := listFactorySessionDispatches(t, beforeURL, sessionID)
-	requireDispatchSummary(
+	dispatchOneBefore := requireDispatchSummary(
 		t,
 		beforeDispatches,
 		"dispatch-1",
 		factoryapi.FactoryDispatchStatusCOMPLETED,
 	)
-	requireDispatchSummary(
+	dispatchTwoBefore := requireDispatchSummary(
 		t,
 		beforeDispatches,
 		"dispatch-2",
@@ -284,21 +284,60 @@ func TestFactorySessionHistoryIsNotPersistedByDefault(t *testing.T) {
 		t.Fatalf("sync-preflight reasonCode = %q, want %q", preflight.ReasonCode, factoryapi.LogicalSessionRemap)
 	}
 
-	endpoint := afterURL + "/factory-sessions/" + url.PathEscape(sessionID)
-	response, err := http.Get(endpoint)
-	if err != nil {
-		t.Fatalf("GET %s: %v", endpoint, err)
+	afterShow := readDurableFactorySession(t, afterURL, sessionID)
+	if afterShow.SessionId != sessionID {
+		t.Fatalf("post-restart sessionId = %q, want %q", afterShow.SessionId, sessionID)
 	}
-	defer response.Body.Close()
-	if response.StatusCode != http.StatusNotFound {
-		body, _ := io.ReadAll(response.Body)
+	assertDurableProgressCounts(t, afterShow.Progress, 1, 2, 0)
+	if afterShow.Status != factoryapi.FactorySessionDurableLifecycleStatusInterrupted {
+		t.Fatalf("post-restart status = %q, want INTERRUPTED", afterShow.Status)
+	}
+	if afterShow.Lifecycle == nil || afterShow.Lifecycle.InterruptedAt == nil {
+		t.Fatalf("post-restart lifecycle = %#v, want interruptedAt", afterShow.Lifecycle)
+	}
+	if beforeShow.Lifecycle == nil || beforeShow.Lifecycle.InterruptedAt == nil {
+		t.Fatal("pre-restart lifecycle missing interruptedAt")
+	}
+	if !afterShow.Lifecycle.InterruptedAt.Equal(*beforeShow.Lifecycle.InterruptedAt) {
 		t.Fatalf(
-			"GET %s status = %d body = %s, want 404 while persistence is disabled",
-			endpoint,
-			response.StatusCode,
-			body,
+			"interruptedAt changed across restart: before=%s after=%s",
+			beforeShow.Lifecycle.InterruptedAt,
+			afterShow.Lifecycle.InterruptedAt,
 		)
 	}
+
+	afterDispatches := listFactorySessionDispatches(t, afterURL, sessionID)
+	afterDispatchOne := requireDispatchSummary(
+		t,
+		afterDispatches,
+		"dispatch-1",
+		factoryapi.FactoryDispatchStatusCOMPLETED,
+	)
+	afterDispatchTwo := requireDispatchSummary(
+		t,
+		afterDispatches,
+		"dispatch-2",
+		factoryapi.FactoryDispatchStatusINTERRUPTED,
+		factoryapi.FactoryDispatchStatusRUNNING,
+	)
+	if len(afterDispatches.Dispatches) != 2 {
+		t.Fatalf("post-restart dispatch count = %d, want 2", len(afterDispatches.Dispatches))
+	}
+	assertDispatchSummaryParity(t, dispatchOneBefore, afterDispatchOne)
+	assertDispatchSummaryParity(t, dispatchTwoBefore, afterDispatchTwo)
+	if dispatchTwoBefore.Status != afterDispatchTwo.Status {
+		t.Fatalf(
+			"dispatch-2 status changed across restart: before=%q after=%q",
+			dispatchTwoBefore.Status,
+			afterDispatchTwo.Status,
+		)
+	}
+
+	afterEvents := listFactorySessionEvents(t, afterURL, sessionID)
+	if len(afterEvents) == 0 {
+		t.Fatal("post-restart factory events unexpectedly empty")
+	}
+	assertFactoryEventHistoryContinuity(t, beforeEvents, afterEvents)
 }
 
 func startLogicalIdentityRestartServer(

--- a/tests/functional/sessions/restart/logical_identity_test.go
+++ b/tests/functional/sessions/restart/logical_identity_test.go
@@ -284,7 +284,29 @@ func TestFactorySessionHistoryIsPersistedAcrossRestart(t *testing.T) {
 		t.Fatalf("sync-preflight reasonCode = %q, want %q", preflight.ReasonCode, factoryapi.LogicalSessionRemap)
 	}
 
-	afterShow := readDurableFactorySession(t, afterURL, sessionID)
+	assertRestartedFactorySession(
+		t,
+		afterURL,
+		sessionID,
+		beforeShow,
+		dispatchOneBefore,
+		dispatchTwoBefore,
+		beforeEvents,
+	)
+}
+
+func assertRestartedFactorySession(
+	t *testing.T,
+	baseURL string,
+	sessionID string,
+	beforeShow factoryapi.FactorySessionDurableReadModel,
+	beforeDispatchOne factoryapi.FactorySessionDispatchSummary,
+	beforeDispatchTwo factoryapi.FactorySessionDispatchSummary,
+	beforeEvents []factoryapi.FactoryEvent,
+) {
+	t.Helper()
+
+	afterShow := readDurableFactorySession(t, baseURL, sessionID)
 	if afterShow.SessionId != sessionID {
 		t.Fatalf("post-restart sessionId = %q, want %q", afterShow.SessionId, sessionID)
 	}
@@ -306,13 +328,8 @@ func TestFactorySessionHistoryIsPersistedAcrossRestart(t *testing.T) {
 		)
 	}
 
-	afterDispatches := listFactorySessionDispatches(t, afterURL, sessionID)
-	afterDispatchOne := requireDispatchSummary(
-		t,
-		afterDispatches,
-		"dispatch-1",
-		factoryapi.FactoryDispatchStatusCOMPLETED,
-	)
+	afterDispatches := listFactorySessionDispatches(t, baseURL, sessionID)
+	afterDispatchOne := requireDispatchSummary(t, afterDispatches, "dispatch-1", factoryapi.FactoryDispatchStatusCOMPLETED)
 	afterDispatchTwo := requireDispatchSummary(
 		t,
 		afterDispatches,
@@ -323,17 +340,17 @@ func TestFactorySessionHistoryIsPersistedAcrossRestart(t *testing.T) {
 	if len(afterDispatches.Dispatches) != 2 {
 		t.Fatalf("post-restart dispatch count = %d, want 2", len(afterDispatches.Dispatches))
 	}
-	assertDispatchSummaryParity(t, dispatchOneBefore, afterDispatchOne)
-	assertDispatchSummaryParity(t, dispatchTwoBefore, afterDispatchTwo)
-	if dispatchTwoBefore.Status != afterDispatchTwo.Status {
+	assertDispatchSummaryParity(t, beforeDispatchOne, afterDispatchOne)
+	assertDispatchSummaryParity(t, beforeDispatchTwo, afterDispatchTwo)
+	if beforeDispatchTwo.Status != afterDispatchTwo.Status {
 		t.Fatalf(
 			"dispatch-2 status changed across restart: before=%q after=%q",
-			dispatchTwoBefore.Status,
+			beforeDispatchTwo.Status,
 			afterDispatchTwo.Status,
 		)
 	}
 
-	afterEvents := listFactorySessionEvents(t, afterURL, sessionID)
+	afterEvents := listFactorySessionEvents(t, baseURL, sessionID)
 	if len(afterEvents) == 0 {
 		t.Fatal("post-restart factory events unexpectedly empty")
 	}


### PR DESCRIPTION
{
  "project": "Enable Durable Factory Session Persistence for you run and you serve",
  "branchName": "rsm-2-enable-session-persistence",
  "description": "Make durable Factory Session persistence explicitly default-on for the public process used by you run and you serve, route the existing PersistencePolicyEnabled selection into existing durable execution, prove project-local JavaScript snapshots and interrupted-session inspection across restart, and preserve explicit-disabled memory-only behavior without changing the policy zero value or adding another persistence mechanism.",
  "context": {
    "customerAsk": "Make PersistencePolicyEnabled reachable from you run and you serve through the existing public process composition, invert the two functional tests that currently assert memory-only behavior into positive snapshot and restart proofs, retain explicit-disabled coverage, and avoid changes to Recordings, checkpoint recovery, Models, and generated files.",
    "problem": "Durable JavaScript session snapshot and resume behavior is implemented but unreachable because no production path selects PersistencePolicyEnabled. Public Runtime Opening requests therefore carry the empty policy, which intentionally selects memory-only execution: real runs create no .you-agent-factory/durable-sessions artifacts, and interrupted Factory Sessions return 404 after a process restart. Existing functional tests assert this undesired behavior rather than the intended durable outcome.",
    "solution": "Choose default-on persistence at the shared public Runtime Opening composition for batch and service modes, explicitly carry PersistencePolicyEnabled through root.BuildProcess and pkg/wire into the existing Factory Sessions durable execution constructor, and preserve empty and PersistencePolicyDisabled as memory-only choices. Reuse existing functional fixtures and process support to prove snapshots on disk and public session inspection after restart, with focused disabled-policy regression coverage.",
    "operatorNote": "OPERATOR NOTE: the original work payload with measured file:line baselines is at docs/temp/operator-measured-baselines.md in this worktree. Read it before implementing; it contains the exact code anchors this prd summarizes."
  },
  "acceptanceCriteria": [
    "A production path reached by both you run and you serve explicitly selects PersistencePolicyEnabled before Factory Session durable execution is constructed; the zero value and PersistencePolicyDisabled continue to mean memory-only, and no deep environment lookup or second persistence mechanism is introduced.",
    "During a real root-built JavaScript run, an interrupted Factory Session writes durable snapshot artifacts beneath <project-root>/.you-agent-factory/durable-sessions, proven through public-process functional behavior and filesystem observation after orderly process shutdown.",
    "After stopping and reconstructing the public process with the same project-local inputs, the interrupted Factory Session remains inspectable through its public Factory Session endpoints with its interrupted lifecycle, progress, dispatch, and event history preserved instead of returning 404.",
    "Explicit-disabled persistence remains covered and produces deterministic memory-only behavior without project-local durable snapshot artifacts, while existing enabled, disabled, empty, and invalid policy behavior remains compatible.",
    "Scope stays within Factory Sessions, minimal pkg/root and pkg/wire policy threading, run/serve transport plumbing only if necessary, and the two named functional areas; no changes land in Recordings, checkpoint recovery, Models or model commands, or generated files.",
    "Quality gates pass: focused Factory Sessions and restart/JavaScript durability tests, typecheck, and tests; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "rsm-2-enable-session-persistence-001",
      "title": "Select persistence for public Factory Sessions",
      "description": "As a customer running or serving a Factory, I want the public process to select durable persistence automatically so restart-capable execution is used without a hidden configuration step.",
      "acceptanceCriteria": [
        "Runtime Opening requests created by the production you run path explicitly carry PersistencePolicyEnabled; service mode used by you serve receives the same policy rather than relying on the zero value.",
        "The selected policy flows through the canonical root.BuildProcess and pkg/wire composition into the existing Factory Sessions durable execution construction without a second injector, global mutable state, or environment read inside Factory Sessions.",
        "The zero value is not redefined: empty policy and explicit PersistencePolicyDisabled continue selecting memory-only execution, while PersistencePolicyEnabled continues selecting the existing durable store.",
        "Focused tests prove the public Runtime Opening mapping selects enabled for both batch and service modes and prove explicit disabled still selects memory-only behavior.",
        "The implementation does not introduce a persistence CLI flag or HTTP contract change; you run and you serve remain behaviorally equivalent through their shared opening contract.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Public run/server Runtime Opening composition now explicitly selects PersistencePolicyEnabled; batch and service mapping tests pass, and existing zero/disabled selector coverage remains unchanged."
    },
    {
      "id": "rsm-2-enable-session-persistence-002",
      "title": "Write project-local JavaScript snapshots during real runs",
      "description": "As a customer running a JavaScript workflow, I want interrupted session snapshots written inside my project so durable state exists for later restart and inspection.",
      "acceptanceCriteria": [
        "The existing negative JavaScript durability functional scenario is inverted or replaced with a positive scenario using the resumable-two-step-fake-children fixture and a process constructed through root.BuildProcess.",
        "After the scenario reaches the public INTERRUPTED lifecycle state and the process is stopped cleanly, durable snapshot artifacts for that Factory Session exist beneath <project-root>/.you-agent-factory/durable-sessions.",
        "The proof observes the documented public-process and filesystem outcomes; it does not inspect internal engine state, add a parallel test harness, or use timing sleeps as its synchronization contract.",
        "A focused disabled-policy regression proves memory-only execution does not write that project-local durable session state, preserving deterministic isolated test paths.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "The root-built JavaScript durability functional test now observes a non-empty project-local durable session snapshot after orderly shutdown; an explicit PersistencePolicyDisabled construction test proves a real inline run leaves the durable-sessions path absent."
    },
    {
      "id": "rsm-2-enable-session-persistence-003",
      "title": "Inspect interrupted sessions after public-process restart",
      "description": "As a customer recovering from an interrupted run, I want the restarted public process to expose the same Factory Session history so I can inspect its state and continue later recovery workflows.",
      "acceptanceCriteria": [
        "TestFactorySessionHistoryIsNotPersistedByDefault is inverted or replaced using the existing resumable-two-step-fake-children fixture and StartFunctionalAPIServer flow to prove enabled persistence across two root-built process instances.",
        "Before restart, the scenario observes the interrupted lifecycle, one completed unit of progress, the completed and interrupted or running dispatch summaries, and non-empty Factory Event history through public Factory Session APIs.",
        "After restart with the same project and home inputs, reading the original Factory Session succeeds rather than returning 404 and preserves its interrupted lifecycle facts, progress counts, dispatch identities and statuses, and non-empty event history.",
        "Logical-session remap behavior remains compatible across restart; the durability proof does not implement marking seeding, a --resume CLI, or portable replay behavior owned by later lanes.",
        "The test uses deterministic provider-edge observation and existing readiness mechanisms, with no new sleeps, timeout-padded polling helpers, or internal state exposure.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "The restart functional test now reconstructs two root-built public processes and verifies the original interrupted session remains readable with stable lifecycle, progress, dispatch, and event history facts; logical-session remap remains asserted."
    }
  ]
}
