### PR TITLE
p3-boundary-edge-classification

### DIFF
--- a/cmd/ownershipboundarycheck/hosted_ownership.go
+++ b/cmd/ownershipboundarycheck/hosted_ownership.go
@@ -72,7 +72,7 @@ func evaluateHostedOwnershipClaims(claims []hostedOwnershipClaim) []finding {
 				Rule:     ruleHostedOwnershipAssignment,
 				FilePath: hostedOwnershipClaimsFile,
 				Target:   fmt.Sprintf("unknown responsibility %q", claim.Responsibility),
-				class:    productionSourceClass,
+				Class:    productionSourceClass,
 			})
 			continue
 		}
@@ -82,13 +82,13 @@ func evaluateHostedOwnershipClaims(claims []hostedOwnershipClaim) []finding {
 		findings = append(findings, finding{
 			Rule:     ruleHostedOwnershipAssignment,
 			FilePath: hostedOwnershipClaimsFile,
+			Class:    productionSourceClass,
 			Target: fmt.Sprintf(
 				"responsibility %q claimed by %q; durable owner is %s",
 				claim.Responsibility,
 				claim.Owner,
 				wantOwner,
 			),
-			class: productionSourceClass,
 		})
 	}
 	sort.Slice(findings, func(i, j int) bool {

--- a/cmd/ownershipboundarycheck/main.go
+++ b/cmd/ownershipboundarycheck/main.go
@@ -95,11 +95,11 @@ type config struct {
 }
 
 type finding struct {
-	Rule     string `json:"rule"`
-	FilePath string `json:"filePath"`
-	Target   string `json:"target"`
-	Line     int    `json:"-"`
-	class    boundarySourceClass
+	Rule     string              `json:"rule"`
+	FilePath string              `json:"filePath"`
+	Target   string              `json:"target"`
+	Class    boundarySourceClass `json:"class"`
+	Line     int                 `json:"-"`
 }
 
 type baseline struct {
@@ -141,30 +141,20 @@ func run(cfg config, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	productionFindings := filterFindingsByClass(findings, productionSourceClass)
-	testOnlyFindings := filterFindingsByClass(findings, testOnlySourceClass)
 	if cfg.createBaseline {
-		return createBaseline(repoRoot, productionFindings, stdout)
+		return createBaseline(repoRoot, findings, stdout)
 	}
 	recorded, err := loadBaseline(repoRoot)
 	if err != nil {
 		return err
 	}
-	recorded, err = productionBaseline(recorded)
+	active, unrecorded, stale, err := partition(findings, recorded)
 	if err != nil {
 		return err
-	}
-	active, unrecorded, stale, err := partition(productionFindings, recorded)
-	if err != nil {
-		return err
-	}
-	for _, item := range testOnlyFindings {
-		writeFinding(stdout, "test-only observation", item)
 	}
 	for _, item := range unrecorded {
 		writeFinding(stderr, "new violation", item)
 	}
-	counts := countFindingClasses(testOnlyFindings, unrecorded)
 	for _, item := range stale {
 		fmt.Fprintf(
 			stderr,
@@ -172,25 +162,25 @@ func run(cfg config, stdout, stderr io.Writer) error {
 			item.Rule,
 			item.FilePath,
 			item.Target,
-			effectiveBoundarySourceClass(boundarySourceClass(item.Class), item.FilePath),
+			item.Class,
 			baselineFile,
 		)
-		counts.add(effectiveBoundarySourceClass(boundarySourceClass(item.Class), item.FilePath))
 	}
+	counts := countClassifiedViolations(unrecorded, stale)
 	if len(unrecorded) > 0 || len(stale) > 0 {
-		writeClassifiedFindingCounts(stderr, counts)
+		writeClassifiedViolationCounts(stderr, counts)
 		return fmt.Errorf(
 			"[agent-factory:ownership-boundary] found %d new violation(s) and %d stale baseline entries",
 			len(unrecorded),
 			len(stale),
 		)
 	}
-	writeClassifiedFindingCounts(stdout, counts)
 	fmt.Fprintf(
 		stdout,
 		"[agent-factory:ownership-boundary] ownership boundaries hold (%d deletion-only baseline entries remain)\n",
 		len(active),
 	)
+	writeClassifiedViolationCounts(stdout, counts)
 	return nil
 }
 
@@ -260,20 +250,17 @@ func scanFile(path, relative string, inventory ownerInventory) ([]finding, error
 	if ast.IsGenerated(file) {
 		return nil, nil
 	}
+	class := classifyBoundarySource(relative)
 	aliases, imports := importInventory(file)
 	var findings []finding
 	switch {
 	case within(relative, initializerRoot):
-		findings = append(findings, scanInitializerImports(fileSet, imports, relative, inventory)...)
-		findings = append(findings, scanInitializerCalls(fileSet, file, aliases, relative)...)
+		findings = append(findings, scanInitializerImports(fileSet, imports, relative, inventory, class)...)
+		findings = append(findings, scanInitializerCalls(fileSet, file, aliases, relative, class)...)
 	case within(relative, platformRoot):
-		findings = append(findings, scanPlatformImports(fileSet, imports, relative)...)
+		findings = append(findings, scanPlatformImports(fileSet, imports, relative, class)...)
 	case within(relative, mappingRoot):
-		findings = append(findings, scanMappingBehavior(fileSet, file, aliases, imports, relative)...)
-	}
-	class := classifyBoundarySource(relative)
-	for index := range findings {
-		findings[index].class = class
+		findings = append(findings, scanMappingBehavior(fileSet, file, aliases, imports, relative, class)...)
 	}
 	return findings, nil
 }
@@ -309,6 +296,7 @@ func scanInitializerImports(
 	imports []importedPackage,
 	relative string,
 	inventory ownerInventory,
+	class boundarySourceClass,
 ) []finding {
 	var findings []finding
 	for _, imported := range imports {
@@ -321,7 +309,7 @@ func scanInitializerImports(
 		}
 		if rule != "" {
 			findings = append(findings, finding{
-				Rule: rule, FilePath: relative, Target: imported.Path,
+				Rule: rule, FilePath: relative, Target: imported.Path, Class: class,
 				Line: fileSet.Position(imported.Pos).Line,
 			})
 		}
@@ -330,8 +318,8 @@ func scanInitializerImports(
 				strings.HasPrefix(imported.Path, transportsImport)) {
 			findings = append(findings, finding{
 				Rule: ruleInitializerConstruction, FilePath: relative,
-				Target: imported.Path + ".*",
-				Line:   fileSet.Position(imported.Pos).Line,
+				Target: imported.Path + ".*", Class: class,
+				Line: fileSet.Position(imported.Pos).Line,
 			})
 		}
 	}
@@ -362,6 +350,7 @@ func scanInitializerCalls(
 	file *ast.File,
 	aliases map[string]string,
 	relative string,
+	class boundarySourceClass,
 ) []finding {
 	var findings []finding
 	ast.Inspect(file, func(node ast.Node) bool {
@@ -387,8 +376,8 @@ func scanInitializerCalls(
 		}
 		findings = append(findings, finding{
 			Rule: ruleInitializerConstruction, FilePath: relative,
-			Target: importPath + "." + selector.Sel.Name,
-			Line:   fileSet.Position(call.Pos()).Line,
+			Target: importPath + "." + selector.Sel.Name, Class: class,
+			Line: fileSet.Position(call.Pos()).Line,
 		})
 		return true
 	})
@@ -404,7 +393,7 @@ func constructionName(name string) bool {
 	return false
 }
 
-func scanPlatformImports(fileSet *token.FileSet, imports []importedPackage, relative string) []finding {
+func scanPlatformImports(fileSet *token.FileSet, imports []importedPackage, relative string, class boundarySourceClass) []finding {
 	var findings []finding
 	for _, imported := range imports {
 		if !strings.HasPrefix(imported.Path, servicesImport) {
@@ -420,7 +409,7 @@ func scanPlatformImports(fileSet *token.FileSet, imports []importedPackage, rela
 			}
 		}
 		findings = append(findings, finding{
-			Rule: rulePlatformDomainImport, FilePath: relative, Target: imported.Path,
+			Rule: rulePlatformDomainImport, FilePath: relative, Target: imported.Path, Class: class,
 			Line: fileSet.Position(imported.Pos).Line,
 		})
 	}
@@ -433,12 +422,13 @@ func scanMappingBehavior(
 	aliases map[string]string,
 	imports []importedPackage,
 	relative string,
+	class boundarySourceClass,
 ) []finding {
 	var findings []finding
 	for _, imported := range imports {
 		if imported.Path == "os/exec" {
 			findings = append(findings, finding{
-				Rule: ruleMappingProcess, FilePath: relative, Target: "os/exec",
+				Rule: ruleMappingProcess, FilePath: relative, Target: "os/exec", Class: class,
 				Line: fileSet.Position(imported.Pos).Line,
 			})
 		}
@@ -454,7 +444,7 @@ func scanMappingBehavior(
 		}
 		if rule != "" {
 			findings = append(findings, finding{
-				Rule: rule, FilePath: relative, Target: imported.Path + ".*",
+				Rule: rule, FilePath: relative, Target: imported.Path + ".*", Class: class,
 				Line: fileSet.Position(imported.Pos).Line,
 			})
 		}
@@ -462,7 +452,7 @@ func scanMappingBehavior(
 	ast.Inspect(file, func(node ast.Node) bool {
 		if statement, ok := node.(*ast.GoStmt); ok {
 			findings = append(findings, finding{
-				Rule: ruleMappingGoroutine, FilePath: relative, Target: "go statement",
+				Rule: ruleMappingGoroutine, FilePath: relative, Target: "go statement", Class: class,
 				Line: fileSet.Position(statement.Pos()).Line,
 			})
 			return true
@@ -499,8 +489,8 @@ func scanMappingBehavior(
 		if rule != "" {
 			findings = append(findings, finding{
 				Rule: rule, FilePath: relative,
-				Target: importPath + "." + selector.Sel.Name,
-				Line:   fileSet.Position(call.Pos()).Line,
+				Target: importPath + "." + selector.Sel.Name, Class: class,
+				Line: fileSet.Position(call.Pos()).Line,
 			})
 		}
 		return true
@@ -529,15 +519,18 @@ func uniqueFindings(items []finding) []finding {
 }
 
 func findingKey(item finding) string {
-	return item.Rule + "\x00" + item.FilePath + "\x00" + string(effectiveBoundarySourceClass(item.class, item.FilePath)) + "\x00" + item.Target
+	return item.Rule + "\x00" + item.FilePath + "\x00" + string(item.Class) + "\x00" + item.Target
 }
 
 func entryKey(item baselineEntry) string {
-	return item.Rule + "\x00" + item.FilePath + "\x00" + string(effectiveBoundarySourceClass(boundarySourceClass(item.Class), item.FilePath)) + "\x00" + item.Target
+	class := item.Class
+	if strings.TrimSpace(class) == "" {
+		class = string(classifyBoundarySource(item.FilePath))
+	}
+	return item.Rule + "\x00" + item.FilePath + "\x00" + class + "\x00" + item.Target
 }
 
 func createBaseline(repoRoot string, findings []finding, stdout io.Writer) error {
-	findings = filterFindingsByClass(findings, productionSourceClass)
 	if len(findings) == 0 {
 		return fmt.Errorf("refusing to create empty %s; absence records zero debt", baselineFile)
 	}
@@ -553,7 +546,7 @@ func createBaseline(repoRoot string, findings []finding, stdout io.Writer) error
 	for _, item := range findings {
 		entries = append(entries, baselineEntry{
 			Rule: item.Rule, FilePath: item.FilePath, Target: item.Target,
-			Class: string(effectiveBoundarySourceClass(item.class, item.FilePath)),
+			Class: string(item.Class),
 			Stage: baselineStage, DeletionGate: deletionGates[item.Rule],
 		})
 	}
@@ -602,6 +595,11 @@ func partition(
 		if err := validateEntry(item); err != nil {
 			return nil, nil, nil, err
 		}
+		class, err := baselineSourceClass(item)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		item.Class = string(class)
 		key := entryKey(item)
 		if _, duplicate := entries[key]; duplicate {
 			return nil, nil, nil, fmt.Errorf("%s contains duplicate entry for %s", baselineFile, item.Target)
@@ -631,9 +629,6 @@ func validateEntry(item baselineEntry) error {
 	if item.Rule == "" || item.FilePath == "" || item.Target == "" {
 		return fmt.Errorf("%s contains an entry with a missing rule, filePath, or target", baselineFile)
 	}
-	if _, err := sourceClassFromBaseline(item.Class, item.FilePath); err != nil {
-		return err
-	}
 	gate, known := deletionGates[item.Rule]
 	if !known {
 		return fmt.Errorf("%s contains unknown rule %q", baselineFile, item.Rule)
@@ -643,6 +638,19 @@ func validateEntry(item baselineEntry) error {
 	}
 	if item.DeletionGate != gate {
 		return fmt.Errorf("%s entry %s has an invalid deletion gate", baselineFile, item.Target)
+	}
+	class, err := baselineSourceClass(item)
+	if err != nil {
+		return err
+	}
+	if class == testOnlySourceClass {
+		for field, value := range map[string]string{
+			"rule": item.Rule, "filePath": item.FilePath, "target": item.Target,
+		} {
+			if strings.ContainsAny(value, "*?[]") {
+				return fmt.Errorf("%s entry %s %s must be exact and cannot contain wildcards", baselineFile, item.Target, field)
+			}
+		}
 	}
 	return nil
 }
@@ -654,13 +662,13 @@ func writeFinding(writer io.Writer, label string, item finding) {
 	}
 	fmt.Fprintf(
 		writer,
-		"[agent-factory:ownership-boundary] %s: %s:%d %s -> %s; %s [class=%s]\n",
+		"[agent-factory:ownership-boundary] %s: %s:%d %s -> %s [class=%s]; %s\n",
 		label,
 		item.FilePath,
 		item.Line,
 		item.Rule,
 		item.Target,
+		item.Class,
 		remediation,
-		effectiveBoundarySourceClass(item.class, item.FilePath),
 	)
 }

--- a/cmd/ownershipboundarycheck/peer_import.go
+++ b/cmd/ownershipboundarycheck/peer_import.go
@@ -167,7 +167,6 @@ func scanPeerServiceImports(
 				Target:   importPath,
 				Class:    class,
 				Line:     fileSet.Position(spec.Pos()).Line,
-				class:    classifyBoundarySource(relative),
 			})
 		}
 		return nil

--- a/cmd/ownershipboundarycheck/peer_import.go
+++ b/cmd/ownershipboundarycheck/peer_import.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"
@@ -135,11 +136,19 @@ func scanPeerServiceImports(
 		if owner == "" || !inventory.hasOwner(owner) {
 			return nil
 		}
-		fileSet := token.NewFileSet()
-		file, err := parser.ParseFile(fileSet, path, nil, parser.ImportsOnly)
+		content, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
+		fileSet := token.NewFileSet()
+		file, err := parser.ParseFile(fileSet, path, content, parser.ImportsOnly|parser.ParseComments)
+		if err != nil {
+			return err
+		}
+		if ast.IsGenerated(file) {
+			return nil
+		}
+		class := classifyBoundarySource(relative)
 		packagePath := filepath.ToSlash(filepath.Dir(relative))
 		for _, spec := range file.Imports {
 			importPath, err := strconv.Unquote(spec.Path.Value)
@@ -156,6 +165,7 @@ func scanPeerServiceImports(
 				Rule:     rulePeerServiceImplementation,
 				FilePath: relative,
 				Target:   importPath,
+				Class:    class,
 				Line:     fileSet.Position(spec.Pos()).Line,
 				class:    classifyBoundarySource(relative),
 			})

--- a/cmd/ownershipboundarycheck/source_classification.go
+++ b/cmd/ownershipboundarycheck/source_classification.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 )
 
-// boundarySourceClass identifies the kind of Go source that produced a
-// boundary observation. Keeping it on the finding prevents production and
-// test-only edges from collapsing into one report or baseline key.
+// boundarySourceClass identifies whether a Go dependency observation came
+// from production code or from a test-only source file. The class is part of
+// the finding identity so the same boundary relationship can be ratcheted
+// independently in each source class.
 type boundarySourceClass string
 
 const (
@@ -27,37 +28,49 @@ func (class boundarySourceClass) valid() bool {
 	return class == productionSourceClass || class == testOnlySourceClass
 }
 
-func effectiveBoundarySourceClass(class boundarySourceClass, filePath string) boundarySourceClass {
-	if class.valid() {
-		return class
+func baselineSourceClass(entry baselineEntry) (boundarySourceClass, error) {
+	expected := classifyBoundarySource(entry.FilePath)
+	if strings.TrimSpace(entry.Class) == "" {
+		if expected == testOnlySourceClass {
+			return "", fmt.Errorf(
+				"%s entry %s requires an explicit class=%q",
+				baselineFile,
+				entry.Target,
+				testOnlySourceClass,
+			)
+		}
+		return productionSourceClass, nil
 	}
-	return classifyBoundarySource(filePath)
-}
-
-// sourceClassFromBaseline keeps the existing production baseline format
-// readable while allowing new entries to carry an explicit class. The source
-// filename remains authoritative so a malformed class cannot relabel an edge.
-func sourceClassFromBaseline(value, filePath string) (boundarySourceClass, error) {
-	expected := classifyBoundarySource(filePath)
-	if strings.TrimSpace(value) == "" {
-		return expected, nil
-	}
-	class := boundarySourceClass(value)
+	class := boundarySourceClass(entry.Class)
 	if !class.valid() {
-		return "", fmt.Errorf("baseline entry %s has invalid class %q", filePath, value)
+		return "", fmt.Errorf(
+			"%s entry %s has invalid class %q; want %q or %q",
+			baselineFile,
+			entry.Target,
+			entry.Class,
+			productionSourceClass,
+			testOnlySourceClass,
+		)
 	}
 	if class != expected {
-		return "", fmt.Errorf("baseline entry %s class = %q, want %q", filePath, class, expected)
+		return "", fmt.Errorf(
+			"%s entry %s class = %q does not match source file %s (%q)",
+			baselineFile,
+			entry.Target,
+			entry.Class,
+			entry.FilePath,
+			expected,
+		)
 	}
 	return class, nil
 }
 
-type classifiedFindingCounts struct {
+type classifiedViolationCounts struct {
 	production int
 	testOnly   int
 }
 
-func (counts *classifiedFindingCounts) add(class boundarySourceClass) {
+func (counts *classifiedViolationCounts) add(class boundarySourceClass) {
 	switch class {
 	case productionSourceClass:
 		counts.production++
@@ -66,45 +79,25 @@ func (counts *classifiedFindingCounts) add(class boundarySourceClass) {
 	}
 }
 
-func countFindingClasses(findings ...[]finding) classifiedFindingCounts {
-	var counts classifiedFindingCounts
-	for _, group := range findings {
-		for _, item := range group {
-			counts.add(effectiveBoundarySourceClass(item.class, item.FilePath))
+func countClassifiedViolations(unrecorded []finding, stale []baselineEntry) classifiedViolationCounts {
+	var counts classifiedViolationCounts
+	for _, item := range unrecorded {
+		counts.add(item.Class)
+	}
+	for _, item := range stale {
+		class, err := baselineSourceClass(item)
+		if err == nil {
+			counts.add(class)
 		}
 	}
 	return counts
 }
 
-func writeClassifiedFindingCounts(writer io.Writer, counts classifiedFindingCounts) {
+func writeClassifiedViolationCounts(writer io.Writer, counts classifiedViolationCounts) {
 	fmt.Fprintf(
 		writer,
-		"[agent-factory:ownership-boundary] dependency violation counts: production=%d test-only=%d\n",
+		"[agent-factory:ownership-boundary] violation counts: production=%d test-only=%d\n",
 		counts.production,
 		counts.testOnly,
 	)
-}
-
-func filterFindingsByClass(findings []finding, want boundarySourceClass) []finding {
-	filtered := make([]finding, 0, len(findings))
-	for _, item := range findings {
-		if effectiveBoundarySourceClass(item.class, item.FilePath) == want {
-			filtered = append(filtered, item)
-		}
-	}
-	return filtered
-}
-
-func productionBaseline(recorded baseline) (baseline, error) {
-	result := baseline{Version: recorded.Version}
-	for _, entry := range recorded.Entries {
-		class, err := sourceClassFromBaseline(entry.Class, entry.FilePath)
-		if err != nil {
-			return baseline{}, err
-		}
-		if class == productionSourceClass {
-			result.Entries = append(result.Entries, entry)
-		}
-	}
-	return result, nil
 }

--- a/cmd/ownershipboundarycheck/source_classification_test.go
+++ b/cmd/ownershipboundarycheck/source_classification_test.go
@@ -2,183 +2,264 @@ package main
 
 import (
 	"bytes"
-	"errors"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestRunClassifiesOwnershipBoundaryEdgesBySourceClass(t *testing.T) {
-	const peerImport = `import engine "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine"`
+func TestRunClassifiesEquivalentOwnershipEdgesBySourceClass(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_runtime/doc.go": "package factory_runtime\n",
+		"pkg/platform/runtimeinput/config.go": `package runtimeinput
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+var _ runtime.Service
+`,
+		"pkg/platform/runtimeinput/config_test.go": `package runtimeinput
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+var _ runtime.Service
+`,
+	})
 
-	tests := []struct {
-		name    string
-		files   map[string]string
-		wantErr bool
-		counts  string
-		class   string
-	}{
-		{
-			name: "production",
-			files: map[string]string{
-				"pkg/services/factory_sessions/doc.go":                "package factory_sessions\n",
-				"pkg/services/factory_runtime/doc.go":                 "package factory_runtime\n",
-				"pkg/services/factory_runtime/internal/engine/doc.go": "package engine\n",
-				"pkg/services/factory_sessions/consume_peer.go":       "package factory_sessions\n" + peerImport + "\n",
-			},
-			wantErr: true,
-			counts:  "dependency violation counts: production=1 test-only=0",
-			class:   "[class=production]",
-		},
-		{
-			name: "test-only",
-			files: map[string]string{
-				"pkg/services/factory_sessions/doc.go":                "package factory_sessions\n",
-				"pkg/services/factory_runtime/doc.go":                 "package factory_runtime\n",
-				"pkg/services/factory_runtime/internal/engine/doc.go": "package engine\n",
-				"pkg/services/factory_sessions/consume_peer_test.go":  "package factory_sessions\n" + peerImport + "\n",
-			},
-			counts: "dependency violation counts: production=0 test-only=1",
-			class:  "[class=test-only]",
-		},
-		{
-			name: "mixed",
-			files: map[string]string{
-				"pkg/services/factory_sessions/doc.go":                "package factory_sessions\n",
-				"pkg/services/factory_runtime/doc.go":                 "package factory_runtime\n",
-				"pkg/services/factory_runtime/internal/engine/doc.go": "package engine\n",
-				"pkg/services/factory_sessions/consume_peer.go":       "package factory_sessions\n" + peerImport + "\n",
-				"pkg/services/factory_sessions/consume_peer_test.go":  "package factory_sessions\n" + peerImport + "\n",
-			},
-			wantErr: true,
-			counts:  "dependency violation counts: production=1 test-only=1",
-			class:   "[class=test-only]",
-		},
+	var stdout, stderr bytes.Buffer
+	err := run(config{root: root}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("run() error = nil, want production and test-only violations")
 	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			root := fixtureRepository(t, test.files)
-			var stdout, stderr bytes.Buffer
-			err := run(config{root: root}, &stdout, &stderr)
-			if (err != nil) != test.wantErr {
-				t.Fatalf("run() error = %v, wantErr=%t; stdout=%q stderr=%q", err, test.wantErr, stdout.String(), stderr.String())
-			}
-			output := stdout.String() + stderr.String()
-			if !strings.Contains(output, test.counts) {
-				t.Fatalf("run() output = %q, want counts %q", output, test.counts)
-			}
-			if !strings.Contains(output, test.class) {
-				t.Fatalf("run() output = %q, want source class %q", output, test.class)
-			}
-			if test.name == "test-only" && strings.Contains(stderr.String(), "new violation") {
-				t.Fatalf("test-only finding entered blocking stderr path: %q", stderr.String())
-			}
-		})
+	out := stderr.String()
+	for _, want := range []string{
+		"pkg/platform/runtimeinput/config.go",
+		"pkg/platform/runtimeinput/config_test.go",
+		"[class=production]",
+		"[class=test-only]",
+		"violation counts: production=1 test-only=1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("run() stderr = %q, want %q", out, want)
+		}
+	}
+	if got, want := err.Error(), "[agent-factory:ownership-boundary] found 2 new violation(s) and 0 stale baseline entries"; got != want {
+		t.Fatalf("run() error = %q, want %q", got, want)
 	}
 }
 
-func TestOwnershipBoundaryDiscoveryRetainsTestOnlyEdgesInScopedAndPeerScans(t *testing.T) {
+func TestScanClassifiesInitializerMappingAndPeerEdgesBySourceClass(t *testing.T) {
 	root := fixtureRepository(t, map[string]string{
-		"pkg/services/factory_sessions/doc.go":                "package factory_sessions\n",
 		"pkg/services/factory_runtime/doc.go":                 "package factory_runtime\n",
+		"pkg/services/factory_sessions/doc.go":                "package factory_sessions\n",
 		"pkg/services/factory_runtime/internal/engine/doc.go": "package engine\n",
-		"pkg/initializer/application/initializer.go":          "package application\nimport _ \"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine\"\n",
-		"pkg/initializer/application/initializer_test.go":     "package application\nimport _ \"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine\"\n",
-		"pkg/services/factory_sessions/consume_peer.go":       "package factory_sessions\nimport _ \"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine\"\n",
-		"pkg/services/factory_sessions/consume_peer_test.go":  "package factory_sessions\nimport _ \"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine\"\n",
+		"pkg/initializer/coordinate.go": `package initializer
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine"
+var _ runtime.Service
+`,
+		"pkg/initializer/coordinate_test.go": `package initializer
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine"
+var _ runtime.Service
+`,
+		"pkg/transports/mapping/process.go": `package mapping
+import "os/exec"
+var _ = exec.Command
+`,
+		"pkg/transports/mapping/process_test.go": `package mapping
+import "os/exec"
+var _ = exec.Command
+`,
+		"pkg/services/factory_sessions/consume.go": `package factory_sessions
+import engine "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine"
+var _ engine.Service
+`,
+		"pkg/services/factory_sessions/consume_test.go": `package factory_sessions
+import engine "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine"
+var _ engine.Service
+`,
 	})
 
 	findings := scanFixture(t, root)
-	want := map[string]bool{
-		"pkg/initializer/application/initializer.go|production":        false,
-		"pkg/initializer/application/initializer_test.go|test-only":    false,
-		"pkg/services/factory_sessions/consume_peer.go|production":     false,
-		"pkg/services/factory_sessions/consume_peer_test.go|test-only": false,
-	}
+	assertClassifiedFindingPair(t, findings, ruleInitializerServiceImplementation)
+	assertClassifiedFindingPair(t, findings, ruleMappingProcess)
+	assertClassifiedFindingPair(t, findings, rulePeerServiceImplementation)
+}
+
+func TestScanIgnoresGeneratedOwnershipSources(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_runtime/doc.go":                 "package factory_runtime\n",
+		"pkg/services/factory_sessions/doc.go":                "package factory_sessions\n",
+		"pkg/services/factory_runtime/internal/engine/doc.go": "package engine\n",
+		"pkg/platform/runtimeinput/generated_test.go": `// Code generated by ownership test. DO NOT EDIT.
+
+package runtimeinput
+import _ "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+`,
+		"pkg/services/factory_sessions/generated_test.go": `// Code generated by ownership test. DO NOT EDIT.
+
+package factory_sessions
+import _ "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine"
+`,
+	})
+
+	findings := scanFixture(t, root)
 	for _, item := range findings {
-		key := item.FilePath + "|" + string(effectiveBoundarySourceClass(item.class, item.FilePath))
-		if _, ok := want[key]; ok {
-			want[key] = true
-		}
-	}
-	for key, found := range want {
-		if !found {
-			t.Errorf("scan findings missing classified edge %q: %#v", key, findings)
+		if strings.Contains(item.FilePath, "generated_test.go") {
+			t.Fatalf("generated source produced ownership finding: %#v", item)
 		}
 	}
 }
 
-func TestOwnershipBoundaryTestOnlyFindingsDoNotUseProductionBaseline(t *testing.T) {
+func TestTestOnlyBaselineIsExactClassBearingAndStale(t *testing.T) {
 	const (
-		productionPath = "pkg/services/factory_sessions/consume_peer.go"
-		testPath       = "pkg/services/factory_sessions/consume_peer_test.go"
-		target         = modulePath + "/pkg/services/factory_runtime/internal/engine"
+		sourcePath = "pkg/platform/runtimeinput/config_test.go"
+		target     = modulePath + "/pkg/services/factory_runtime"
+		source     = `package runtimeinput
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+var _ runtime.Service
+`
 	)
-	root := fixtureRepository(t, map[string]string{
-		"pkg/services/factory_sessions/doc.go":                "package factory_sessions\n",
-		"pkg/services/factory_runtime/doc.go":                 "package factory_runtime\n",
-		"pkg/services/factory_runtime/internal/engine/doc.go": "package engine\n",
-		productionPath: "package factory_sessions\nimport _ \"" + target + "\"\n",
-		testPath:       "package factory_sessions\nimport _ \"" + target + "\"\n",
-	})
-	writeBaseline(t, root, baselineEntryFor(rulePeerServiceImplementation, productionPath, target))
 
+	t.Run("active exact test-only entry passes", func(t *testing.T) {
+		root := fixtureRepository(t, map[string]string{
+			"pkg/services/factory_runtime/doc.go": "package factory_runtime\n",
+			sourcePath:                            source,
+		})
+		writeBaseline(t, root, baselineEntryForClass(rulePlatformDomainImport, sourcePath, target, testOnlySourceClass))
+		var stdout, stderr bytes.Buffer
+		if err := run(config{root: root}, &stdout, &stderr); err != nil {
+			t.Fatalf("run active test-only baseline: %v; stderr=%s", err, stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "1 deletion-only baseline") {
+			t.Fatalf("stdout = %q, want active baseline summary", stdout.String())
+		}
+		if !strings.Contains(stdout.String(), "violation counts: production=0 test-only=0") {
+			t.Fatalf("stdout = %q, want zero class-separated violation counts", stdout.String())
+		}
+	})
+
+	t.Run("stale test-only entry is labeled and blocking", func(t *testing.T) {
+		root := fixtureRepository(t, map[string]string{
+			"pkg/services/factory_runtime/doc.go": "package factory_runtime\n",
+		})
+		writeBaseline(t, root, baselineEntryForClass(rulePlatformDomainImport, sourcePath, target, testOnlySourceClass))
+		var stdout, stderr bytes.Buffer
+		err := run(config{root: root}, &stdout, &stderr)
+		if err == nil || !strings.Contains(stderr.String(), "stale baseline") {
+			t.Fatalf("run stale test-only baseline err=%v stderr=%q", err, stderr.String())
+		}
+		for _, want := range []string{
+			"[class=test-only]",
+			"violation counts: production=0 test-only=1",
+		} {
+			if !strings.Contains(stderr.String(), want) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+			}
+		}
+	})
+
+	t.Run("test-only entry must declare its class", func(t *testing.T) {
+		root := fixtureRepository(t, map[string]string{
+			"pkg/services/factory_runtime/doc.go": "package factory_runtime\n",
+			sourcePath:                            source,
+		})
+		writeBaseline(t, root, baselineEntryFor(rulePlatformDomainImport, sourcePath, target))
+		var stdout, stderr bytes.Buffer
+		err := run(config{root: root}, &stdout, &stderr)
+		if err == nil || !strings.Contains(err.Error(), "requires an explicit class") {
+			t.Fatalf("run missing test-only class err=%v, want explicit-class diagnostic", err)
+		}
+	})
+
+	t.Run("wildcard and duplicate entries are rejected", func(t *testing.T) {
+		root := fixtureRepository(t, map[string]string{
+			"pkg/services/factory_runtime/doc.go": "package factory_runtime\n",
+			sourcePath:                            source,
+		})
+		wildcard := baselineEntryForClass(rulePlatformDomainImport, sourcePath, target+"/*", testOnlySourceClass)
+		writeBaseline(t, root, wildcard)
+		var stdout, stderr bytes.Buffer
+		err := run(config{root: root}, &stdout, &stderr)
+		if err == nil || !strings.Contains(err.Error(), "cannot contain wildcards") {
+			t.Fatalf("run wildcard baseline err=%v, want exact-identity diagnostic", err)
+		}
+
+		root = fixtureRepository(t, map[string]string{
+			"pkg/services/factory_runtime/doc.go": "package factory_runtime\n",
+			sourcePath:                            source,
+		})
+		entry := baselineEntryForClass(rulePlatformDomainImport, sourcePath, target, testOnlySourceClass)
+		writeBaseline(t, root, entry, entry)
+		err = run(config{root: root}, &stdout, &stderr)
+		if err == nil || !strings.Contains(err.Error(), "duplicate entry") {
+			t.Fatalf("run duplicate baseline err=%v, want duplicate diagnostic", err)
+		}
+	})
+}
+
+func TestCreateBaselineRecordsSourceClass(t *testing.T) {
+	const sourcePath = "pkg/platform/runtimeinput/config_test.go"
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_runtime/doc.go": "package factory_runtime\n",
+		sourcePath: `package runtimeinput
+import runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+var _ runtime.Service
+`,
+	})
 	var stdout, stderr bytes.Buffer
-	if err := run(config{root: root}, &stdout, &stderr); err != nil {
-		t.Fatalf("run with recorded production edge and test-only edge: %v; stdout=%s stderr=%s", err, stdout.String(), stderr.String())
+	if err := run(config{root: root, createBaseline: true}, &stdout, &stderr); err != nil {
+		t.Fatalf("create test-only baseline: %v; stderr=%s", err, stderr.String())
 	}
-	output := stdout.String() + stderr.String()
-	if !strings.Contains(output, "test-only observation") ||
-		!strings.Contains(output, "dependency violation counts: production=0 test-only=1") {
-		t.Fatalf("output = %q, want visible non-blocking test-only edge and zero unrecorded production count", output)
+
+	data, err := os.ReadFile(filepath.Join(root, baselineFile))
+	if err != nil {
+		t.Fatalf("read created baseline: %v", err)
 	}
-	if !strings.Contains(stdout.String(), "1 deletion-only baseline") {
-		t.Fatalf("stdout = %q, want active production baseline", stdout.String())
+	var recorded baseline
+	if err := json.Unmarshal(data, &recorded); err != nil {
+		t.Fatalf("decode created baseline: %v", err)
+	}
+	if len(recorded.Entries) != 1 || recorded.Entries[0].Class != string(testOnlySourceClass) {
+		t.Fatalf("created baseline entries = %#v, want one explicit test-only entry", recorded.Entries)
 	}
 }
 
-func TestOwnershipBoundaryCreateBaselineIgnoresTestOnlyFindings(t *testing.T) {
-	root := fixtureRepository(t, map[string]string{
-		"pkg/services/factory_sessions/doc.go":                "package factory_sessions\n",
-		"pkg/services/factory_runtime/doc.go":                 "package factory_runtime\n",
-		"pkg/services/factory_runtime/internal/engine/doc.go": "package engine\n",
-		"pkg/services/factory_sessions/consume_peer_test.go":  "package factory_sessions\nimport _ \"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine\"\n",
-	})
-
-	var stdout, stderr bytes.Buffer
-	err := run(config{root: root, createBaseline: true}, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), "absence records zero debt") {
-		t.Fatalf("create baseline with only test findings = %v, want zero production debt refusal", err)
+func TestOwnershipFindingKeysIncludeSourceClass(t *testing.T) {
+	production := finding{Rule: rulePlatformDomainImport, FilePath: "pkg/platform/runtimeinput/config.go", Target: "target", Class: productionSourceClass}
+	testOnly := production
+	testOnly.Class = testOnlySourceClass
+	if findingKey(production) == findingKey(testOnly) {
+		t.Fatalf("finding keys collapsed source classes: %q", findingKey(production))
 	}
-	if _, statErr := os.Stat(filepath.Join(root, baselineFile)); !errors.Is(statErr, os.ErrNotExist) {
-		t.Fatalf("test-only baseline exists or stat failed unexpectedly: %v", statErr)
+
+	productionEntry := baselineEntry{Rule: production.Rule, FilePath: production.FilePath, Target: production.Target, Class: string(production.Class)}
+	testOnlyEntry := productionEntry
+	testOnlyEntry.Class = string(testOnly.Class)
+	if entryKey(productionEntry) == entryKey(testOnlyEntry) {
+		t.Fatalf("baseline keys collapsed source classes: %q", entryKey(productionEntry))
 	}
 }
 
-func TestOwnershipBoundaryKeysIncludeSourceClass(t *testing.T) {
-	production := findingKey(finding{
-		Rule: rulePeerServiceImplementation, FilePath: "pkg/services/factory_sessions/edge.go",
-		Target: "peer", class: productionSourceClass,
-	})
-	testOnly := findingKey(finding{
-		Rule: rulePeerServiceImplementation, FilePath: "pkg/services/factory_sessions/edge.go",
-		Target: "peer", class: testOnlySourceClass,
-	})
-	if production == testOnly {
-		t.Fatalf("finding keys collapsed source classes: %q", production)
+func assertClassifiedFindingPair(t *testing.T, findings []finding, rule string) {
+	t.Helper()
+	var production, testOnly int
+	for _, item := range findings {
+		if item.Rule != rule {
+			continue
+		}
+		switch item.Class {
+		case productionSourceClass:
+			production++
+		case testOnlySourceClass:
+			testOnly++
+		default:
+			t.Fatalf("rule %q has invalid source class: %#v", rule, item)
+		}
 	}
+	if production != 1 || testOnly != 1 {
+		t.Fatalf("rule %q class counts = production:%d test-only:%d; findings=%#v", rule, production, testOnly, findings)
+	}
+}
 
-	productionEntry := entryKey(baselineEntry{
-		Rule: rulePeerServiceImplementation, FilePath: "pkg/services/factory_sessions/edge.go",
-		Target: "peer", Class: string(productionSourceClass),
-	})
-	testOnlyEntry := entryKey(baselineEntry{
-		Rule: rulePeerServiceImplementation, FilePath: "pkg/services/factory_sessions/edge.go",
-		Target: "peer", Class: string(testOnlySourceClass),
-	})
-	if productionEntry == testOnlyEntry {
-		t.Fatalf("baseline keys collapsed source classes: %q", productionEntry)
+func baselineEntryForClass(rule, filePath, target string, class boundarySourceClass) baselineEntry {
+	return baselineEntry{
+		Rule: rule, FilePath: filePath, Target: target, Class: string(class),
+		Stage: baselineStage, DeletionGate: deletionGates[rule],
 	}
 }

--- a/cmd/packagetargetmanifestcheck/main.go
+++ b/cmd/packagetargetmanifestcheck/main.go
@@ -22,14 +22,18 @@ import (
 )
 
 type config struct {
-	root      string
-	movesPath string
+	root                   string
+	movesPath              string
+	testOnlyBaselinePath   string
+	createTestOnlyBaseline bool
 }
 
 func main() {
 	cfg := config{}
 	flag.StringVar(&cfg.root, "root", ".", "repository root containing the open-move ledger")
 	flag.StringVar(&cfg.movesPath, "moves", unfinishedMovesRelativePath, "repository-relative path to the consolidated unfinished-package-move ledger")
+	flag.StringVar(&cfg.testOnlyBaselinePath, "test-only-baseline", packageTargetTestOnlyBaselineRelativePath, "repository-relative path to the exact test-only package-target baseline")
+	flag.BoolVar(&cfg.createTestOnlyBaseline, "create-test-only-baseline", false, "create the deletion-only test-only package-target baseline; fails if the file already exists")
 	flag.Parse()
 	if err := run(cfg, os.Stdout, os.Stderr); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -51,39 +55,64 @@ func run(cfg config, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
+	if err := validateOpenMoveLedgerSchema(repoRoot, moves); err != nil {
+		return fmt.Errorf("[agent-factory:package-target-manifest] %w", err)
+	}
+	testOnlyBaselinePath := cfg.testOnlyBaselinePath
+	if testOnlyBaselinePath == "" {
+		testOnlyBaselinePath = packageTargetTestOnlyBaselineRelativePath
+	}
+
 	findings, err := scanPackageTargetFindings(repoRoot, moves.Moves)
 	if err != nil {
 		return err
 	}
-	if err := validateOpenMoveLedgerSchema(repoRoot, moves); err != nil {
-		writePackageTargetObservationCounts(stderr, findings)
-		writePackageTargetTestOnlyObservations(stderr, findings)
-		writePackageTargetViolationCountsForFindings(stderr, packageTargetProductionRows(findings), findings)
-		return fmt.Errorf("[agent-factory:package-target-manifest] %w", err)
+	if cfg.createTestOnlyBaseline {
+		return createPackageTargetTestOnlyBaseline(
+			resolveRepoPath(repoRoot, testOnlyBaselinePath),
+			findings,
+			stdout,
+		)
 	}
-	productionStale := packageTargetProductionStaleRows(moves.Moves, findings)
-	if len(productionStale) > 0 {
+	baselinePath := resolveRepoPath(repoRoot, testOnlyBaselinePath)
+	baseline, err := loadPackageTargetTestOnlyBaseline(baselinePath)
+	if err != nil {
+		return err
+	}
+	productionStale, testOnlyUnrecorded, testOnlyStale, err := partitionPackageTargetFindings(findings, moves.Moves, baseline)
+	if err != nil {
+		return err
+	}
+	if len(productionStale) > 0 || len(testOnlyUnrecorded) > 0 || len(testOnlyStale) > 0 {
 		writePackageTargetObservationCounts(stderr, findings)
-		writePackageTargetTestOnlyObservations(stderr, findings)
-		writePackageTargetViolationCountsForFindings(stderr, productionStale, findings)
+		writePackageTargetViolationCounts(stderr, productionStale, testOnlyUnrecorded, testOnlyStale)
 		for _, row := range productionStale {
 			writeStaleProductionPackageTargetRow(stderr, row)
 		}
+		for _, finding := range testOnlyUnrecorded {
+			writePackageTargetFinding(stderr, "new test-only package-target observation", finding)
+		}
+		for _, entry := range testOnlyStale {
+			writeStalePackageTargetTestOnlyBaselineEntry(stderr, entry, filepath.ToSlash(testOnlyBaselinePath))
+		}
 		return fmt.Errorf(
-			"[agent-factory:package-target-manifest] found %d stale production row(s) [%s]\nLINT_VIOLATION_COUNT: %d",
+			"[agent-factory:package-target-manifest] found %d stale production row(s) [%s], %d new test-only observation(s), and %d stale test-only baseline entry/entries\nLINT_VIOLATION_COUNT: %d",
 			len(productionStale),
 			strings.Join(packageTargetStaleRowPaths(productionStale), ", "),
-			len(productionStale),
+			len(testOnlyUnrecorded),
+			len(testOnlyStale),
+			len(productionStale)+len(testOnlyUnrecorded)+len(testOnlyStale),
 		)
 	}
 	writePackageTargetObservationCounts(stdout, findings)
-	writePackageTargetTestOnlyObservations(stdout, findings)
-	writePackageTargetViolationCountsForFindings(stdout, productionStale, findings)
+	writePackageTargetViolationCounts(stdout, productionStale, testOnlyUnrecorded, testOnlyStale)
 	fmt.Fprintf(
 		stdout,
-		"[agent-factory:package-target-manifest] all %d open migration row(s) hold the closed destination vocabulary and name live packages (%s)\n",
+		"[agent-factory:package-target-manifest] all %d open migration row(s) hold the closed destination vocabulary and name live packages (%s); test-only baseline=%d exact deletion-only edge(s) (%s)\n",
 		len(moves.Moves),
 		filepath.ToSlash(movesFile),
+		len(baseline.Entries),
+		filepath.ToSlash(baselinePath),
 	)
 	return nil
 }

--- a/cmd/packagetargetmanifestcheck/manifest.go
+++ b/cmd/packagetargetmanifestcheck/manifest.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	unfinishedMovesStage        = "pss-unfinished-package-moves"
-	unfinishedMovesRelativePath = "docs/internal/baselines/unfinished-package-moves.json"
+	unfinishedMovesStage                      = "pss-unfinished-package-moves"
+	unfinishedMovesRelativePath               = "docs/internal/baselines/unfinished-package-moves.json"
+	packageTargetTestOnlyBaselineRelativePath = "docs/internal/baselines/package-target-test-only-baseline.json"
 )
 
 // DestinationVocabulary is the closed set of destinations move rows may claim.
@@ -106,9 +107,6 @@ func validateOpenMoveLedger(repoRoot string, moves UnfinishedMoves) error {
 	return validateRowsNamePackagesThatExist(repoRoot, moves.Moves)
 }
 
-// validateOpenMoveLedgerSchema keeps schema and destination validation separate
-// from source liveness. The package-target command needs to report classified
-// source observations before it applies the existing production failure path.
 func validateOpenMoveLedgerSchema(repoRoot string, moves UnfinishedMoves) error {
 	vocabulary, err := derivedDestinationVocabulary(repoRoot)
 	if err != nil {
@@ -116,6 +114,19 @@ func validateOpenMoveLedgerSchema(repoRoot string, moves UnfinishedMoves) error 
 	}
 	if err := validateUnfinishedMovesSchema(moves, vocabulary); err != nil {
 		return err
+	}
+	return validateMovePackagePaths(moves.Moves)
+}
+
+func validateMovePackagePaths(packages []PackageMapping) error {
+	for i, row := range packages {
+		packagePath := row.PackagePath
+		if strings.Contains(packagePath, "\\") {
+			return fmt.Errorf("moves[%d] %q must use slash separators", i, packagePath)
+		}
+		if !strings.HasPrefix(packagePath, "pkg/") {
+			return fmt.Errorf("moves[%d] %q must be repository-relative under pkg/", i, packagePath)
+		}
 	}
 	return nil
 }

--- a/cmd/packagetargetmanifestcheck/source_classification.go
+++ b/cmd/packagetargetmanifestcheck/source_classification.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -9,14 +10,21 @@ import (
 	"strings"
 )
 
-// packageTargetSourceClass identifies the kind of Go source that makes an
-// unfinished package-target row observable. Keeping the class on the finding
-// prevents test-only evidence from being folded into production counts.
+// packageTargetSourceClass identifies the source class that makes an open
+// package-target edge observable. The class is part of the finding identity so
+// a test-only observation cannot become production liveness by being counted
+// in the same bucket.
 type packageTargetSourceClass string
 
 const (
 	packageTargetProductionSourceClass packageTargetSourceClass = "production"
 	packageTargetTestOnlySourceClass   packageTargetSourceClass = "test-only"
+)
+
+const (
+	packageTargetTestOnlyBaselineVersion = 1
+	packageTargetTestOnlyBaselineStage   = "pss-package-target-test-only"
+	packageTargetTestOnlyDeletionGate    = "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
 )
 
 type packageTargetFinding struct {
@@ -26,18 +34,47 @@ type packageTargetFinding struct {
 	Class       packageTargetSourceClass
 }
 
-// packageTargetSourceClasses examines direct Go files in one package
-// directory. Nested directories are separate packages and remain represented
-// by their own move rows. Classification happens while the directory is being
-// discovered, before any production-only view can discard _test.go files.
-func packageTargetSourceClasses(repoRoot, packagePath string) (map[packageTargetSourceClass]struct{}, error) {
-	if strings.Contains(packagePath, "\\") {
-		return nil, fmt.Errorf("package path %q must use slash separators", packagePath)
-	}
-	if !strings.HasPrefix(packagePath, "pkg/") {
-		return nil, fmt.Errorf("package path %q must be repository-relative under pkg/", packagePath)
-	}
+type packageTargetTestOnlyBaseline struct {
+	Version int                                  `json:"version"`
+	Entries []packageTargetTestOnlyBaselineEntry `json:"entries"`
+}
 
+type packageTargetTestOnlyBaselineEntry struct {
+	PackagePath  string `json:"packagePath"`
+	Destination  string `json:"destination"`
+	Successor    string `json:"successor"`
+	Class        string `json:"class"`
+	Stage        string `json:"stage"`
+	DeletionGate string `json:"deletionGate"`
+}
+
+// scanPackageTargetFindings observes only the package paths named by the open
+// move ledger. This keeps the ledger deletion-only and avoids reintroducing a
+// row for every live package merely because test files are visible now.
+func scanPackageTargetFindings(repoRoot string, moves []PackageMapping) ([]packageTargetFinding, error) {
+	findings := make([]packageTargetFinding, 0, len(moves))
+	for _, row := range moves {
+		classes, err := packageTargetSourceClasses(repoRoot, row.PackagePath)
+		if err != nil {
+			return nil, err
+		}
+		for class := range classes {
+			findings = append(findings, packageTargetFinding{
+				PackagePath: row.PackagePath,
+				Destination: row.Destination,
+				Successor:   row.Successor,
+				Class:       class,
+			})
+		}
+	}
+	slices.SortFunc(findings, comparePackageTargetFindings)
+	return findings, nil
+}
+
+// packageTargetSourceClasses examines only direct files in one package
+// directory. Nested directories are separate Go packages and are represented
+// by their own open-move rows when migration intent exists for them.
+func packageTargetSourceClasses(repoRoot, packagePath string) (map[packageTargetSourceClass]struct{}, error) {
 	classes := map[packageTargetSourceClass]struct{}{}
 	directory := filepath.Join(repoRoot, filepath.FromSlash(packagePath))
 	entries, err := os.ReadDir(directory)
@@ -58,29 +95,6 @@ func packageTargetSourceClasses(repoRoot, packagePath string) (map[packageTarget
 		classes[packageTargetProductionSourceClass] = struct{}{}
 	}
 	return classes, nil
-}
-
-// scanPackageTargetFindings observes only package paths named by the
-// unfinished-move ledger. This preserves the ledger's deletion-only role while
-// making both source classes visible for each relevant package-target edge.
-func scanPackageTargetFindings(repoRoot string, moves []PackageMapping) ([]packageTargetFinding, error) {
-	findings := make([]packageTargetFinding, 0, len(moves)*2)
-	for _, row := range moves {
-		classes, err := packageTargetSourceClasses(repoRoot, row.PackagePath)
-		if err != nil {
-			return nil, err
-		}
-		for class := range classes {
-			findings = append(findings, packageTargetFinding{
-				PackagePath: row.PackagePath,
-				Destination: row.Destination,
-				Successor:   row.Successor,
-				Class:       class,
-			})
-		}
-	}
-	slices.SortFunc(findings, comparePackageTargetFindings)
-	return findings, nil
 }
 
 func comparePackageTargetFindings(left, right packageTargetFinding) int {
@@ -105,47 +119,116 @@ func packageTargetFindingKey(finding packageTargetFinding) string {
 	}, "\x00")
 }
 
-func hasPackageTargetClass(findings []packageTargetFinding, packagePath string, class packageTargetSourceClass) bool {
-	for _, finding := range findings {
-		if finding.PackagePath == packagePath && finding.Class == class {
-			return true
-		}
-	}
-	return false
+func packageTargetBaselineEntryKey(entry packageTargetTestOnlyBaselineEntry) string {
+	return strings.Join([]string{
+		filepath.ToSlash(entry.PackagePath),
+		entry.Destination,
+		entry.Successor,
+		entry.Class,
+	}, "\x00")
 }
 
-// packageTargetProductionStaleRows retains the existing blocking path for a
-// move row whose package directory has disappeared. A visible test-only source
-// is reported separately and is intentionally non-blocking; it does not turn
-// into a production finding or a baseline entry.
-func packageTargetProductionStaleRows(moves []PackageMapping, findings []packageTargetFinding) []PackageMapping {
-	stale := make([]PackageMapping, 0)
+func loadPackageTargetTestOnlyBaseline(path string) (packageTargetTestOnlyBaseline, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return packageTargetTestOnlyBaseline{}, nil
+		}
+		return packageTargetTestOnlyBaseline{}, fmt.Errorf("read test-only package-target baseline %s: %w", path, err)
+	}
+	var baseline packageTargetTestOnlyBaseline
+	if err := json.Unmarshal(payload, &baseline); err != nil {
+		return packageTargetTestOnlyBaseline{}, fmt.Errorf("decode test-only package-target baseline %s: %w", path, err)
+	}
+	if baseline.Version != packageTargetTestOnlyBaselineVersion {
+		return packageTargetTestOnlyBaseline{}, fmt.Errorf(
+			"test-only package-target baseline version = %d, want %d",
+			baseline.Version,
+			packageTargetTestOnlyBaselineVersion,
+		)
+	}
+	if len(baseline.Entries) == 0 {
+		return packageTargetTestOnlyBaseline{}, fmt.Errorf(
+			"test-only package-target baseline %s is empty; delete the file to record zero debt",
+			path,
+		)
+	}
+	return baseline, nil
+}
+
+func partitionPackageTargetFindings(
+	findings []packageTargetFinding,
+	moves []PackageMapping,
+	baseline packageTargetTestOnlyBaseline,
+) (productionStale []PackageMapping, testOnlyUnrecorded []packageTargetFinding, testOnlyStale []packageTargetTestOnlyBaselineEntry, err error) {
+	baselineByKey := make(map[string]packageTargetTestOnlyBaselineEntry, len(baseline.Entries))
+	for index, entry := range baseline.Entries {
+		if validationErr := validatePackageTargetTestOnlyBaselineEntry(index, entry); validationErr != nil {
+			return nil, nil, nil, validationErr
+		}
+		key := packageTargetBaselineEntryKey(entry)
+		if _, duplicate := baselineByKey[key]; duplicate {
+			return nil, nil, nil, fmt.Errorf(
+				"test-only package-target baseline contains duplicate entry for %s -> %s",
+				entry.PackagePath,
+				entry.Destination,
+			)
+		}
+		baselineByKey[key] = entry
+	}
+	if !slices.IsSortedFunc(baseline.Entries, func(left, right packageTargetTestOnlyBaselineEntry) int {
+		return strings.Compare(packageTargetBaselineEntryKey(left), packageTargetBaselineEntryKey(right))
+	}) {
+		return nil, nil, nil, fmt.Errorf("test-only package-target baseline entries must be stable-sorted by exact identity")
+	}
+
+	seenTestOnly := make(map[string]struct{}, len(findings))
+	productionRows := make(map[string]PackageMapping, len(findings))
+	for _, finding := range findings {
+		switch finding.Class {
+		case packageTargetProductionSourceClass:
+			productionRows[finding.PackagePath] = PackageMapping{
+				PackagePath: finding.PackagePath,
+				Destination: finding.Destination,
+				Successor:   finding.Successor,
+			}
+		case packageTargetTestOnlySourceClass:
+			key := packageTargetFindingKey(finding)
+			seenTestOnly[key] = struct{}{}
+			if _, recorded := baselineByKey[key]; !recorded {
+				testOnlyUnrecorded = append(testOnlyUnrecorded, finding)
+			}
+		}
+	}
+
+	for key, entry := range baselineByKey {
+		if _, observed := seenTestOnly[key]; !observed {
+			testOnlyStale = append(testOnlyStale, entry)
+		}
+	}
+
+	// A row with no source class at all is stale production migration intent.
+	// A test-only row is deliberately not added here: it is visible only through
+	// the independent test-only baseline and must not make production liveness
+	// appear true.
 	for _, row := range moves {
-		if hasPackageTargetClass(findings, row.PackagePath, packageTargetProductionSourceClass) ||
-			hasPackageTargetClass(findings, row.PackagePath, packageTargetTestOnlySourceClass) {
+		if _, production := productionRows[row.PackagePath]; production {
 			continue
 		}
-		stale = append(stale, row)
+		if hasPackageTargetClass(findings, row.PackagePath, packageTargetTestOnlySourceClass) {
+			continue
+		}
+		productionStale = append(productionStale, row)
 	}
-	slices.SortFunc(stale, func(left, right PackageMapping) int {
+
+	slices.SortFunc(productionStale, func(left, right PackageMapping) int {
 		return strings.Compare(packageTargetRowKey(left), packageTargetRowKey(right))
 	})
-	return stale
-}
-
-func packageTargetProductionRows(findings []packageTargetFinding) []PackageMapping {
-	rows := make([]PackageMapping, 0, len(findings))
-	for _, finding := range findings {
-		if finding.Class != packageTargetProductionSourceClass {
-			continue
-		}
-		rows = append(rows, PackageMapping{
-			PackagePath: finding.PackagePath,
-			Destination: finding.Destination,
-			Successor:   finding.Successor,
-		})
-	}
-	return rows
+	slices.SortFunc(testOnlyUnrecorded, comparePackageTargetFindings)
+	slices.SortFunc(testOnlyStale, func(left, right packageTargetTestOnlyBaselineEntry) int {
+		return strings.Compare(packageTargetBaselineEntryKey(left), packageTargetBaselineEntryKey(right))
+	})
+	return productionStale, testOnlyUnrecorded, testOnlyStale, nil
 }
 
 func packageTargetRowKey(row PackageMapping) string {
@@ -158,6 +241,95 @@ func packageTargetStaleRowPaths(rows []PackageMapping) []string {
 		paths = append(paths, row.PackagePath)
 	}
 	return paths
+}
+
+func hasPackageTargetClass(findings []packageTargetFinding, packagePath string, class packageTargetSourceClass) bool {
+	for _, finding := range findings {
+		if finding.PackagePath == packagePath && finding.Class == class {
+			return true
+		}
+	}
+	return false
+}
+
+func validatePackageTargetTestOnlyBaselineEntry(index int, entry packageTargetTestOnlyBaselineEntry) error {
+	prefix := fmt.Sprintf("test-only package-target baseline entries[%d]", index)
+	if strings.TrimSpace(entry.PackagePath) == "" ||
+		strings.TrimSpace(entry.Destination) == "" ||
+		strings.TrimSpace(entry.Successor) == "" {
+		return fmt.Errorf("%s requires packagePath, destination, and successor", prefix)
+	}
+	if entry.PackagePath != strings.TrimSpace(entry.PackagePath) ||
+		entry.Destination != strings.TrimSpace(entry.Destination) ||
+		entry.Successor != strings.TrimSpace(entry.Successor) {
+		return fmt.Errorf("%s identities must not contain leading or trailing whitespace", prefix)
+	}
+	if !strings.HasPrefix(entry.PackagePath, "pkg/") || strings.Contains(entry.PackagePath, "\\") {
+		return fmt.Errorf("%s packagePath must be an exact slash-separated repository-relative pkg/ path", prefix)
+	}
+	if entry.Class != string(packageTargetTestOnlySourceClass) {
+		return fmt.Errorf("%s class = %q, want explicit %q", prefix, entry.Class, packageTargetTestOnlySourceClass)
+	}
+	for field, value := range map[string]string{
+		"packagePath": entry.PackagePath,
+		"destination": entry.Destination,
+		"successor":   entry.Successor,
+	} {
+		if strings.ContainsAny(value, "*?[]") {
+			return fmt.Errorf("%s %s must be exact and cannot contain wildcards", prefix, field)
+		}
+	}
+	if entry.Stage != packageTargetTestOnlyBaselineStage {
+		return fmt.Errorf("%s stage = %q, want %q", prefix, entry.Stage, packageTargetTestOnlyBaselineStage)
+	}
+	if entry.DeletionGate != packageTargetTestOnlyDeletionGate {
+		return fmt.Errorf("%s has an invalid deletion gate", prefix)
+	}
+	return nil
+}
+
+func createPackageTargetTestOnlyBaseline(
+	path string,
+	findings []packageTargetFinding,
+	stdout io.Writer,
+) error {
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("refusing to overwrite existing test-only package-target baseline: %s", filepath.ToSlash(path))
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat test-only package-target baseline: %w", err)
+	}
+	entries := make([]packageTargetTestOnlyBaselineEntry, 0)
+	for _, finding := range findings {
+		if finding.Class != packageTargetTestOnlySourceClass {
+			continue
+		}
+		entries = append(entries, packageTargetTestOnlyBaselineEntry{
+			PackagePath:  finding.PackagePath,
+			Destination:  finding.Destination,
+			Successor:    finding.Successor,
+			Class:        string(packageTargetTestOnlySourceClass),
+			Stage:        packageTargetTestOnlyBaselineStage,
+			DeletionGate: packageTargetTestOnlyDeletionGate,
+		})
+	}
+	if len(entries) == 0 {
+		return fmt.Errorf("refusing to create empty test-only package-target baseline: no test-only package-target debt exists")
+	}
+	slices.SortFunc(entries, func(left, right packageTargetTestOnlyBaselineEntry) int {
+		return strings.Compare(packageTargetBaselineEntryKey(left), packageTargetBaselineEntryKey(right))
+	})
+	payload, err := json.MarshalIndent(packageTargetTestOnlyBaseline{Version: packageTargetTestOnlyBaselineVersion, Entries: entries}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode test-only package-target baseline: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create test-only package-target baseline directory: %w", err)
+	}
+	if err := os.WriteFile(path, append(payload, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write test-only package-target baseline: %w", err)
+	}
+	fmt.Fprintf(stdout, "[agent-factory:package-target-manifest] created %s with %d exact deletion-only test-only edge(s)\n", filepath.ToSlash(path), len(entries))
+	return nil
 }
 
 func writePackageTargetObservationCounts(writer io.Writer, findings []packageTargetFinding) {
@@ -173,35 +345,13 @@ func writePackageTargetObservationCounts(writer io.Writer, findings []packageTar
 	fmt.Fprintf(writer, "[agent-factory:package-target-manifest] package-target observations: production=%d test-only=%d\n", production, testOnly)
 }
 
-func writePackageTargetViolationCountsForFindings(writer io.Writer, productionStale []PackageMapping, findings []packageTargetFinding) {
-	testOnly := 0
-	for _, finding := range findings {
-		if finding.Class == packageTargetTestOnlySourceClass {
-			testOnly++
-		}
-	}
+func writePackageTargetViolationCounts(writer io.Writer, productionStale []PackageMapping, testOnlyUnrecorded []packageTargetFinding, testOnlyStale []packageTargetTestOnlyBaselineEntry) {
 	fmt.Fprintf(
 		writer,
 		"[agent-factory:package-target-manifest] dependency violation counts: production=%d test-only=%d\n",
 		len(productionStale),
-		testOnly,
+		len(testOnlyUnrecorded)+len(testOnlyStale),
 	)
-}
-
-func writePackageTargetTestOnlyObservations(writer io.Writer, findings []packageTargetFinding) {
-	for _, finding := range findings {
-		if finding.Class != packageTargetTestOnlySourceClass {
-			continue
-		}
-		fmt.Fprintf(
-			writer,
-			"[agent-factory:package-target-manifest] test-only observation: %s -> %s (successor %s) [class=%s]\n",
-			finding.PackagePath,
-			finding.Destination,
-			finding.Successor,
-			finding.Class,
-		)
-	}
 }
 
 func writeStaleProductionPackageTargetRow(writer io.Writer, row PackageMapping) {
@@ -211,5 +361,29 @@ func writeStaleProductionPackageTargetRow(writer io.Writer, row PackageMapping) 
 		row.PackagePath,
 		row.Destination,
 		row.Successor,
+	)
+}
+
+func writePackageTargetFinding(writer io.Writer, label string, finding packageTargetFinding) {
+	fmt.Fprintf(
+		writer,
+		"[agent-factory:package-target-manifest] %s: %s -> %s (successor %s) [class=%s]\n",
+		label,
+		finding.PackagePath,
+		finding.Destination,
+		finding.Successor,
+		finding.Class,
+	)
+}
+
+func writeStalePackageTargetTestOnlyBaselineEntry(writer io.Writer, entry packageTargetTestOnlyBaselineEntry, path string) {
+	fmt.Fprintf(
+		writer,
+		"[agent-factory:package-target-manifest] stale test-only package-target baseline entry: %s -> %s (successor %s) [class=%s]; remove this exact entry from %s\n",
+		entry.PackagePath,
+		entry.Destination,
+		entry.Successor,
+		entry.Class,
+		path,
 	)
 }

--- a/cmd/packagetargetmanifestcheck/source_classification.go
+++ b/cmd/packagetargetmanifestcheck/source_classification.go
@@ -207,15 +207,11 @@ func partitionPackageTargetFindings(
 		}
 	}
 
-	// A row with no source class at all is stale production migration intent.
-	// A test-only row is deliberately not added here: it is visible only through
-	// the independent test-only baseline and must not make production liveness
-	// appear true.
+	// A row without a production source is stale production migration intent.
+	// Test-only evidence remains independently ratcheted above, but it cannot
+	// make an open move row satisfy the production liveness requirement.
 	for _, row := range moves {
 		if _, production := productionRows[row.PackagePath]; production {
-			continue
-		}
-		if hasPackageTargetClass(findings, row.PackagePath, packageTargetTestOnlySourceClass) {
 			continue
 		}
 		productionStale = append(productionStale, row)
@@ -241,15 +237,6 @@ func packageTargetStaleRowPaths(rows []PackageMapping) []string {
 		paths = append(paths, row.PackagePath)
 	}
 	return paths
-}
-
-func hasPackageTargetClass(findings []packageTargetFinding, packagePath string, class packageTargetSourceClass) bool {
-	for _, finding := range findings {
-		if finding.PackagePath == packagePath && finding.Class == class {
-			return true
-		}
-	}
-	return false
 }
 
 func validatePackageTargetTestOnlyBaselineEntry(index int, entry packageTargetTestOnlyBaselineEntry) error {

--- a/cmd/packagetargetmanifestcheck/source_classification_test.go
+++ b/cmd/packagetargetmanifestcheck/source_classification_test.go
@@ -72,15 +72,13 @@ func TestTestOnlyPackageDoesNotSatisfyProductionLiveness(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run(config{root: root}, &stdout, &stderr)
 	if err == nil {
-		t.Fatal("run() error = nil, want an unrecorded test-only edge")
-	}
-	if strings.Contains(stderr.String(), "stale production package-target row") {
-		t.Fatalf("run() stderr = %q, test-only source must not be counted as production liveness", stderr.String())
+		t.Fatal("run() error = nil, want test-only debt and production-liveness failure")
 	}
 	for _, want := range []string{
 		"package-target observations: production=0 test-only=1",
-		"dependency violation counts: production=0 test-only=1",
+		"dependency violation counts: production=1 test-only=1",
 		"[class=test-only]",
+		"stale production package-target row: pkg/services/work/testonly -> work/internal (successor pkg/services/work/internal) [class=production]",
 	} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("run() stderr = %q, want %q", stderr.String(), want)
@@ -97,11 +95,18 @@ func TestTestOnlyPackageDoesNotSatisfyProductionLiveness(t *testing.T) {
 	})
 	stdout.Reset()
 	stderr.Reset()
-	if err := run(config{root: root}, &stdout, &stderr); err != nil {
-		t.Fatalf("run() with accepted test-only edge error = %v; stderr=%s", err, stderr.String())
+	err = run(config{root: root}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("run() with accepted test-only edge error = nil, want production-liveness failure")
 	}
-	if !strings.Contains(stdout.String(), "package-target observations: production=0 test-only=1") {
-		t.Fatalf("run() stdout = %q, want production-liveness isolation", stdout.String())
+	for _, want := range []string{
+		"package-target observations: production=0 test-only=1",
+		"dependency violation counts: production=1 test-only=0",
+		"stale production package-target row: pkg/services/work/testonly -> work/internal (successor pkg/services/work/internal) [class=production]",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("run() stderr = %q, want production-liveness diagnostic %q", stderr.String(), want)
+		}
 	}
 }
 

--- a/cmd/packagetargetmanifestcheck/source_classification_test.go
+++ b/cmd/packagetargetmanifestcheck/source_classification_test.go
@@ -2,162 +2,180 @@ package main
 
 import (
 	"bytes"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestRunClassifiesPackageTargetEdgesBySourceClass(t *testing.T) {
+func TestPackageTargetFindingsSeparateProductionAndTestOnlyClasses(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name       string
-		production bool
-		testOnly   bool
-		wantErr    bool
-		counts     string
-		violations string
-		classes    []string
-	}{
-		{
-			name:       "production-only",
-			production: true,
-			wantErr:    true,
-			counts:     "package-target observations: production=1 test-only=0",
-			violations: "dependency violation counts: production=1 test-only=0",
-		},
-		{
-			name:       "test-only",
-			testOnly:   true,
-			counts:     "package-target observations: production=0 test-only=1",
-			violations: "dependency violation counts: production=0 test-only=1",
-			classes:    []string{"[class=test-only]"},
-		},
-		{
-			name:       "mixed",
-			production: true,
-			testOnly:   true,
-			wantErr:    true,
-			counts:     "package-target observations: production=1 test-only=1",
-			violations: "dependency violation counts: production=1 test-only=1",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			root := t.TempDir()
-			writeGoPackage(t, root, "pkg/services/work", "package work\n")
-			if test.production {
-				writeGoPackage(t, root, "pkg/services/work/edge", "package edge\n")
-			}
-			if test.testOnly {
-				writeGoPackage(t, root, "pkg/services/work/testedge", "package testedge_test\n", "testedge_test.go")
-			}
-			rows := make([]PackageMapping, 0, 2)
-			if test.production {
-				rows = append(rows, PackageMapping{
-					PackagePath: "pkg/services/work/edge",
-					Destination: "work/not-a-closed-destination",
-					Successor:   "pkg/services/work/not-a-closed-destination",
-				})
-			}
-			if test.testOnly {
-				rows = append(rows, PackageMapping{
-					PackagePath: "pkg/services/work/testedge",
-					Destination: "work/internal",
-					Successor:   "pkg/services/work/internal",
-				})
-			}
-			writeFixtureMoveLedger(t, root, rows)
-
-			var stdout, stderr bytes.Buffer
-			err := run(config{root: root}, &stdout, &stderr)
-			if (err != nil) != test.wantErr {
-				t.Fatalf("run() error = %v, wantErr=%t; stdout=%q stderr=%q", err, test.wantErr, stdout.String(), stderr.String())
-			}
-			if test.wantErr && (err == nil || !strings.Contains(err.Error(), "not-a-closed-destination")) {
-				t.Fatalf("run() error = %v, want the production migration gate to reject the closed-destination violation", err)
-			}
-			output := stdout.String() + stderr.String()
-			for _, want := range []string{test.counts, test.violations} {
-				if !strings.Contains(output, want) {
-					t.Fatalf("run() output = %q, want %q", output, want)
-				}
-			}
-			for _, class := range test.classes {
-				if !strings.Contains(output, class) {
-					t.Fatalf("run() output = %q, want class %q", output, class)
-				}
-			}
-			if test.name == "test-only" && err != nil {
-				t.Fatalf("test-only observation entered the blocking path: %v; stderr=%q", err, stderr.String())
-			}
-		})
-	}
-}
-
-func TestRunBlocksStaleProductionRowsWithoutBlockingTestOnlyObservations(t *testing.T) {
-	t.Parallel()
-
+	const packagePath = "pkg/services/work/dual"
 	root := t.TempDir()
 	writeGoPackage(t, root, "pkg/services/work", "package work\n")
-	writeGoPackage(t, root, "pkg/services/work/onlytest", "package onlytest_test\n", "onlytest_test.go")
-	writeFixtureMoveLedger(t, root, []PackageMapping{
-		{
-			PackagePath: "pkg/services/work/missing",
-			Destination: "work/internal",
-			Successor:   "pkg/services/work/internal",
-		},
-		{
-			PackagePath: "pkg/services/work/onlytest",
-			Destination: "work/internal",
-			Successor:   "pkg/services/work/internal",
-		},
-	})
+	writeGoPackage(t, root, packagePath, "package dual\n")
+	writeGoPackage(t, root, packagePath, "package dual\n", "dual_test.go")
+	writeFixtureMoveLedger(t, root, []PackageMapping{{
+		PackagePath: packagePath,
+		Destination: "work/internal",
+		Successor:   "pkg/services/work/internal",
+	}})
 
 	var stdout, stderr bytes.Buffer
 	err := run(config{root: root}, &stdout, &stderr)
 	if err == nil {
-		t.Fatal("run() error = nil, want stale production row failure")
+		t.Fatal("run() error = nil, want an unrecorded test-only observation")
 	}
-	output := stdout.String() + stderr.String()
 	for _, want := range []string{
-		"package-target observations: production=0 test-only=1",
-		"dependency violation counts: production=1 test-only=1",
-		"test-only observation: pkg/services/work/onlytest -> work/internal (successor pkg/services/work/internal) [class=test-only]",
-		"stale production package-target row: pkg/services/work/missing -> work/internal (successor pkg/services/work/internal) [class=production]",
+		"package-target observations: production=1 test-only=1",
+		"dependency violation counts: production=0 test-only=1",
+		"[class=test-only]",
 	} {
-		if !strings.Contains(output, want) {
-			t.Fatalf("run() output = %q, want %q", output, want)
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("run() stderr = %q, want %q", stderr.String(), want)
 		}
 	}
-	if !strings.Contains(err.Error(), "LINT_VIOLATION_COUNT: 1") {
-		t.Fatalf("run() error = %v, want one production violation", err)
+	if strings.Contains(stderr.String(), "stale production package-target row") {
+		t.Fatalf("run() stderr = %q, a production-live package must not be stale", stderr.String())
 	}
-	if strings.Contains(output, "test-only package-target baseline") {
-		t.Fatalf("run() output = %q, must not mention a test-only baseline", output)
+
+	writePackageTargetTestOnlyBaseline(t, root, packageTargetTestOnlyBaselineEntry{
+		PackagePath:  packagePath,
+		Destination:  "work/internal",
+		Successor:    "pkg/services/work/internal",
+		Class:        string(packageTargetTestOnlySourceClass),
+		Stage:        packageTargetTestOnlyBaselineStage,
+		DeletionGate: packageTargetTestOnlyDeletionGate,
+	})
+	stdout.Reset()
+	stderr.Reset()
+	if err := run(config{root: root}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() with exact test-only baseline error = %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "dependency violation counts: production=0 test-only=0") {
+		t.Fatalf("run() stdout = %q, want zero class-separated violations", stdout.String())
 	}
 }
 
-func TestPackageTargetSourceClassDiscoveryRetainsBothClasses(t *testing.T) {
+func TestTestOnlyPackageDoesNotSatisfyProductionLiveness(t *testing.T) {
 	t.Parallel()
 
+	const packagePath = "pkg/services/work/testonly"
 	root := t.TempDir()
-	writeGoPackage(t, root, "pkg/services/work/edge", "package edge\n")
-	writeGoPackage(t, root, "pkg/services/work/edge", "package edge_test\n", "edge_test.go")
+	writeGoPackage(t, root, "pkg/services/work", "package work\n")
+	writeGoPackage(t, root, packagePath, "package testonly\n", "testonly_test.go")
+	writeFixtureMoveLedger(t, root, []PackageMapping{{
+		PackagePath: packagePath,
+		Destination: "work/internal",
+		Successor:   "pkg/services/work/internal",
+	}})
 
-	classes, err := packageTargetSourceClasses(root, "pkg/services/work/edge")
-	if err != nil {
-		t.Fatalf("packageTargetSourceClasses() error = %v", err)
+	var stdout, stderr bytes.Buffer
+	err := run(config{root: root}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("run() error = nil, want an unrecorded test-only edge")
 	}
-	if _, ok := classes[packageTargetProductionSourceClass]; !ok {
-		t.Fatalf("classes = %#v, missing production", classes)
+	if strings.Contains(stderr.String(), "stale production package-target row") {
+		t.Fatalf("run() stderr = %q, test-only source must not be counted as production liveness", stderr.String())
 	}
-	if _, ok := classes[packageTargetTestOnlySourceClass]; !ok {
-		t.Fatalf("classes = %#v, missing test-only", classes)
+	for _, want := range []string{
+		"package-target observations: production=0 test-only=1",
+		"dependency violation counts: production=0 test-only=1",
+		"[class=test-only]",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("run() stderr = %q, want %q", stderr.String(), want)
+		}
 	}
+
+	writePackageTargetTestOnlyBaseline(t, root, packageTargetTestOnlyBaselineEntry{
+		PackagePath:  packagePath,
+		Destination:  "work/internal",
+		Successor:    "pkg/services/work/internal",
+		Class:        string(packageTargetTestOnlySourceClass),
+		Stage:        packageTargetTestOnlyBaselineStage,
+		DeletionGate: packageTargetTestOnlyDeletionGate,
+	})
+	stdout.Reset()
+	stderr.Reset()
+	if err := run(config{root: root}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() with accepted test-only edge error = %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "package-target observations: production=0 test-only=1") {
+		t.Fatalf("run() stdout = %q, want production-liveness isolation", stdout.String())
+	}
+}
+
+func TestPackageTargetTestOnlyBaselineRejectsMalformedAndStaleEntries(t *testing.T) {
+	t.Parallel()
+
+	const (
+		packagePath = "pkg/services/work/testonly"
+		destination = "work/internal"
+		successor   = "pkg/services/work/internal"
+	)
+	entry := packageTargetTestOnlyBaselineEntry{
+		PackagePath:  packagePath,
+		Destination:  destination,
+		Successor:    successor,
+		Class:        string(packageTargetTestOnlySourceClass),
+		Stage:        packageTargetTestOnlyBaselineStage,
+		DeletionGate: packageTargetTestOnlyDeletionGate,
+	}
+
+	t.Run("wildcard is rejected", func(t *testing.T) {
+		root := packageTargetTestOnlyFixture(t, packagePath, false)
+		wildcard := entry
+		wildcard.Destination = "work/*"
+		writePackageTargetTestOnlyBaseline(t, root, wildcard)
+		var stdout, stderr bytes.Buffer
+		err := run(config{root: root}, &stdout, &stderr)
+		if err == nil || !strings.Contains(err.Error(), "cannot contain wildcards") {
+			t.Fatalf("run() error = %v, want wildcard rejection", err)
+		}
+	})
+
+	t.Run("duplicate is rejected", func(t *testing.T) {
+		root := packageTargetTestOnlyFixture(t, packagePath, true)
+		writePackageTargetTestOnlyBaseline(t, root, entry, entry)
+		var stdout, stderr bytes.Buffer
+		err := run(config{root: root}, &stdout, &stderr)
+		if err == nil || !strings.Contains(err.Error(), "duplicate entry") {
+			t.Fatalf("run() error = %v, want duplicate rejection", err)
+		}
+	})
+
+	t.Run("class is required and must be test-only", func(t *testing.T) {
+		root := packageTargetTestOnlyFixture(t, packagePath, true)
+		malformed := entry
+		malformed.Class = ""
+		writePackageTargetTestOnlyBaseline(t, root, malformed)
+		var stdout, stderr bytes.Buffer
+		err := run(config{root: root}, &stdout, &stderr)
+		if err == nil || !strings.Contains(err.Error(), "want explicit") {
+			t.Fatalf("run() error = %v, want explicit class rejection", err)
+		}
+	})
+
+	t.Run("stale entry is class-labeled and blocking", func(t *testing.T) {
+		root := t.TempDir()
+		writeGoPackage(t, root, "pkg/services/work", "package work\n")
+		writeFixtureMoveLedger(t, root, nil)
+		writePackageTargetTestOnlyBaseline(t, root, entry)
+		var stdout, stderr bytes.Buffer
+		err := run(config{root: root}, &stdout, &stderr)
+		if err == nil {
+			t.Fatal("run() error = nil, want stale baseline failure")
+		}
+		for _, want := range []string{
+			"stale test-only package-target baseline entry",
+			"[class=test-only]",
+			"dependency violation counts: production=0 test-only=1",
+		} {
+			if !strings.Contains(stderr.String(), want) {
+				t.Fatalf("run() stderr = %q, want %q", stderr.String(), want)
+			}
+		}
+	})
 }
 
 func TestPackageTargetFindingKeyIncludesSourceClass(t *testing.T) {
@@ -174,29 +192,26 @@ func TestPackageTargetFindingKeyIncludesSourceClass(t *testing.T) {
 	}
 }
 
-func TestPackageTargetDoesNotCreateTestOnlyBaseline(t *testing.T) {
-	t.Parallel()
-
+func packageTargetTestOnlyFixture(t *testing.T, packagePath string, production bool) string {
+	t.Helper()
 	root := t.TempDir()
 	writeGoPackage(t, root, "pkg/services/work", "package work\n")
-	writeGoPackage(t, root, "pkg/services/work/edge", "package edge_test\n", "edge_test.go")
+	if production {
+		writeGoPackage(t, root, packagePath, "package testonly\n")
+	}
+	writeGoPackage(t, root, packagePath, "package testonly\n", "testonly_test.go")
 	writeFixtureMoveLedger(t, root, []PackageMapping{{
-		PackagePath: "pkg/services/work/edge",
+		PackagePath: packagePath,
 		Destination: "work/internal",
 		Successor:   "pkg/services/work/internal",
 	}})
+	return root
+}
 
-	var stdout, stderr bytes.Buffer
-	if err := run(config{root: root}, &stdout, &stderr); err != nil {
-		t.Fatalf("run() error = %v; stderr=%s", err, stderr.String())
-	}
-	entries, err := os.ReadDir(filepath.Join(root, "docs", "internal", "baselines"))
-	if err != nil {
-		t.Fatalf("read baseline directory: %v", err)
-	}
-	for _, entry := range entries {
-		if strings.Contains(entry.Name(), "test-only") {
-			t.Fatalf("run() created test-only baseline %q", entry.Name())
-		}
-	}
+func writePackageTargetTestOnlyBaseline(t *testing.T, repoRoot string, entries ...packageTargetTestOnlyBaselineEntry) {
+	t.Helper()
+	writeFixtureJSON(t, repoRoot, packageTargetTestOnlyBaselineRelativePath, packageTargetTestOnlyBaseline{
+		Version: packageTargetTestOnlyBaselineVersion,
+		Entries: entries,
+	})
 }

--- a/cmd/pkgboundarycheck/source_classification_test.go
+++ b/cmd/pkgboundarycheck/source_classification_test.go
@@ -101,6 +101,56 @@ func TestPackageBoundaryImportScansRetainTestOnlyEdges(t *testing.T) {
 	}
 }
 
+func TestPackageBoundaryDependencyScansRetainTestOnlyEdges(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	writeGoImportFile(t, repoRoot, "pkg/services/work/domain.go", "work", "github.com/portpowered/infinite-you/pkg/transports/mapping")
+	writeGoImportFile(t, repoRoot, "pkg/services/work/domain_test.go", "work_test", "github.com/portpowered/infinite-you/pkg/transports/mapping")
+	writeGoImportFile(t, repoRoot, "pkg/transports/runtime.go", "runtime", "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/runtime")
+	writeGoImportFile(t, repoRoot, "pkg/transports/runtime_test.go", "runtime_test", "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/runtime")
+	writeGoImportFile(t, repoRoot, "internal/testutil/support.go", "testutil", "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/service")
+	writeGoImportFile(t, repoRoot, "internal/testutil/support_test.go", "testutil", "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/service")
+
+	domain, err := scanDomainTransportImports(repoRoot, nil)
+	if err != nil {
+		t.Fatalf("scanDomainTransportImports() error = %v", err)
+	}
+	if got := countSourceClasses(domain, func(finding domainTransportImportFinding) boundarySourceClass { return finding.class }, func(finding domainTransportImportFinding) string { return finding.filePath }); got != "production=1 test-only=1" {
+		t.Fatalf("domain transport classes = %s, want production=1 test-only=1", got)
+	}
+
+	transport, err := scanTransportServiceImplementationImports(repoRoot)
+	if err != nil {
+		t.Fatalf("scanTransportServiceImplementationImports() error = %v", err)
+	}
+	if got := countSourceClasses(transport, func(finding transportServiceImplementationFinding) boundarySourceClass { return finding.class }, func(finding transportServiceImplementationFinding) string { return finding.filePath }); got != "production=1 test-only=1" {
+		t.Fatalf("transport implementation classes = %s, want production=1 test-only=1", got)
+	}
+
+	support, err := scanSupportServiceSubpackageImports(repoRoot)
+	if err != nil {
+		t.Fatalf("scanSupportServiceSubpackageImports() error = %v", err)
+	}
+	if got := countSourceClasses(support, func(finding supportServiceImportFinding) boundarySourceClass { return finding.class }, func(finding supportServiceImportFinding) string { return finding.filePath }); got != "production=1 test-only=1" {
+		t.Fatalf("support service classes = %s, want production=1 test-only=1", got)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, &stdout, &stderr); err == nil {
+		t.Fatal("run() error = nil, want all three dependency rules enforced")
+	}
+	for _, path := range []string{
+		"pkg/services/work/domain_test.go",
+		"pkg/transports/runtime_test.go",
+		"internal/testutil/support_test.go",
+	} {
+		if !strings.Contains(stderr.String(), path+") [class=test-only]") {
+			t.Fatalf("run() stderr = %q, want class-labeled test-only diagnostic for %s", stderr.String(), path)
+		}
+	}
+}
+
 func TestPackageBoundaryDependencyKeysIncludeSourceClass(t *testing.T) {
 	t.Parallel()
 

--- a/docs/internal/baselines/README.md
+++ b/docs/internal/baselines/README.md
@@ -34,6 +34,12 @@ row, and when `moves` is empty the file is deleted together with its loaders and
 checks. Both `ownership-inventory-check` and `package-target-manifest-check`
 read this one file, so there is no second destination catalog to keep in sync.
 
+`package-target-test-only-baseline.json` is the exact deletion-only companion
+for the package-target checker. It records only test-only source observations
+for open move rows, with the source class included in each identity. A
+test-only source never establishes production package liveness; new observations
+and stale accepted entries both fail until the exact edge is reviewed.
+
 `ownership-inventory.json` is the PSS-F01 frozen ownership inventory. It no
 longer enumerates packages — that moved to `unfinished-package-moves.json`
 above. It freezes the closed destination vocabulary, the Process Edges

--- a/docs/internal/baselines/package-target-test-only-baseline.json
+++ b/docs/internal/baselines/package-target-test-only-baseline.json
@@ -1,0 +1,301 @@
+{
+  "version": 1,
+  "entries": [
+    {
+      "packagePath": "pkg/services/factory_definitions/clonetests",
+      "destination": "factory_definitions/internal",
+      "successor": "pkg/services/factory_definitions/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/factory_definitions/definition",
+      "destination": "factory_definitions/internal",
+      "successor": "pkg/services/factory_definitions/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/factory_definitions/internal/services/runtime_snapshot",
+      "destination": "factory_definitions/internal",
+      "successor": "pkg/services/factory_definitions/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/factory_definitions/systeminitializationtests",
+      "destination": "factory_definitions/internal",
+      "successor": "pkg/services/factory_definitions/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/factory_runtime/internal/factorystatus",
+      "destination": "factory_runtime/internal",
+      "successor": "pkg/services/factory_runtime/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/factory_runtime/internal/orchestrators/petri",
+      "destination": "factory_runtime/internal/services/orchestration",
+      "successor": "pkg/services/factory_runtime/internal/services/orchestration",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/factory_runtime/internal/rootobservation",
+      "destination": "factory_runtime/internal",
+      "successor": "pkg/services/factory_runtime/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/factory_sessions/internal/runtimeopening",
+      "destination": "factory_sessions/internal/services/runtime_opening",
+      "successor": "pkg/services/factory_sessions/internal/services/runtime_opening",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/factory_sessions/internal/runtimeopening/invocation",
+      "destination": "factory_sessions/internal/services/runtime_opening",
+      "successor": "pkg/services/factory_sessions/internal/services/runtime_opening",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/factory_sessions/internal/runtimeopening/operatordefaults",
+      "destination": "factory_sessions/internal/services/runtime_opening",
+      "successor": "pkg/services/factory_sessions/internal/services/runtime_opening",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/internal",
+      "destination": "operator_settings/internal",
+      "successor": "pkg/services/operator_settings/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/internal/construct",
+      "destination": "operator_settings/internal",
+      "successor": "pkg/services/operator_settings/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/internal/identityinputinventory",
+      "destination": "operator_settings/internal",
+      "successor": "pkg/services/operator_settings/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/internal/service",
+      "destination": "operator_settings/internal",
+      "successor": "pkg/services/operator_settings/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/operator_settings/internal/testproviders",
+      "destination": "operator_settings/internal",
+      "successor": "pkg/services/operator_settings/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/providers/internal/services/execution/internal/adapters/agy/agypty",
+      "destination": "providers/internal/services/execution",
+      "successor": "pkg/services/providers",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/artifacts",
+      "destination": "recordings/internal/services/artifacts_export",
+      "successor": "pkg/services/recordings/internal/services/artifacts_export",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/events",
+      "destination": "recordings/internal/services/canonical_ledger",
+      "successor": "pkg/services/recordings/internal/services/canonical_ledger",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/events/kinds",
+      "destination": "recordings/internal/services/canonical_ledger",
+      "successor": "pkg/services/recordings/internal/services/canonical_ledger",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/events/snapshot",
+      "destination": "recordings/internal/services/canonical_ledger",
+      "successor": "pkg/services/recordings/internal/services/canonical_ledger",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/projections",
+      "destination": "recordings/internal/services/projection_query",
+      "successor": "pkg/services/recordings/internal/services/projection_query",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/projections/dashboard",
+      "destination": "recordings/internal/services/projection_query",
+      "successor": "pkg/services/recordings/internal/services/projection_query",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/projections/projectiontests",
+      "destination": "recordings/internal/services/projection_query",
+      "successor": "pkg/services/recordings/internal/services/projection_query",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/projections/workstation",
+      "destination": "recordings/internal/services/projection_query",
+      "successor": "pkg/services/recordings/internal/services/projection_query",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/replay",
+      "destination": "recordings/internal/services/replay",
+      "successor": "pkg/services/recordings/internal/services/replay",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/replay/clocktests",
+      "destination": "recordings/internal/services/replay",
+      "successor": "pkg/services/recordings/internal/services/replay",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/replay/configtests",
+      "destination": "recordings/internal/services/replay",
+      "successor": "pkg/services/recordings/internal/services/replay",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/recordings/internal/replay/fixturetests",
+      "destination": "recordings/internal/services/replay",
+      "successor": "pkg/services/recordings/internal/services/replay",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/work/internal/invocationreturnpolicy",
+      "destination": "work/internal",
+      "successor": "pkg/services/work/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/work/internal/lineagegraph",
+      "destination": "work/internal",
+      "successor": "pkg/services/work/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/work/internal/proposalmaterialization",
+      "destination": "work/internal",
+      "successor": "pkg/services/work/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/work/internal/requestadmission",
+      "destination": "work/internal",
+      "successor": "pkg/services/work/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/work/internal/stateaccessquery",
+      "destination": "work/internal",
+      "successor": "pkg/services/work/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/workers/internal",
+      "destination": "workers/internal",
+      "successor": "pkg/services/workers/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/workers/internal/diagnostics",
+      "destination": "workers/internal",
+      "successor": "pkg/services/workers/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/workers/internal/interface",
+      "destination": "workers/internal",
+      "successor": "pkg/services/workers/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    },
+    {
+      "packagePath": "pkg/services/workers/internal/service",
+      "destination": "workers/internal",
+      "successor": "pkg/services/workers/internal",
+      "class": "test-only",
+      "stage": "pss-package-target-test-only",
+      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
+    }
+  ]
+}

--- a/docs/internal/baselines/package-target-test-only-baseline.json
+++ b/docs/internal/baselines/package-target-test-only-baseline.json
@@ -2,14 +2,6 @@
   "version": 1,
   "entries": [
     {
-      "packagePath": "pkg/services/factory_definitions/clonetests",
-      "destination": "factory_definitions/internal",
-      "successor": "pkg/services/factory_definitions/internal",
-      "class": "test-only",
-      "stage": "pss-package-target-test-only",
-      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
-    },
-    {
       "packagePath": "pkg/services/factory_definitions/definition",
       "destination": "factory_definitions/internal",
       "successor": "pkg/services/factory_definitions/internal",
@@ -19,14 +11,6 @@
     },
     {
       "packagePath": "pkg/services/factory_definitions/internal/services/runtime_snapshot",
-      "destination": "factory_definitions/internal",
-      "successor": "pkg/services/factory_definitions/internal",
-      "class": "test-only",
-      "stage": "pss-package-target-test-only",
-      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
-    },
-    {
-      "packagePath": "pkg/services/factory_definitions/systeminitializationtests",
       "destination": "factory_definitions/internal",
       "successor": "pkg/services/factory_definitions/internal",
       "class": "test-only",
@@ -178,14 +162,6 @@
       "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
     },
     {
-      "packagePath": "pkg/services/recordings/internal/projections/projectiontests",
-      "destination": "recordings/internal/services/projection_query",
-      "successor": "pkg/services/recordings/internal/services/projection_query",
-      "class": "test-only",
-      "stage": "pss-package-target-test-only",
-      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
-    },
-    {
       "packagePath": "pkg/services/recordings/internal/projections/workstation",
       "destination": "recordings/internal/services/projection_query",
       "successor": "pkg/services/recordings/internal/services/projection_query",
@@ -195,30 +171,6 @@
     },
     {
       "packagePath": "pkg/services/recordings/internal/replay",
-      "destination": "recordings/internal/services/replay",
-      "successor": "pkg/services/recordings/internal/services/replay",
-      "class": "test-only",
-      "stage": "pss-package-target-test-only",
-      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
-    },
-    {
-      "packagePath": "pkg/services/recordings/internal/replay/clocktests",
-      "destination": "recordings/internal/services/replay",
-      "successor": "pkg/services/recordings/internal/services/replay",
-      "class": "test-only",
-      "stage": "pss-package-target-test-only",
-      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
-    },
-    {
-      "packagePath": "pkg/services/recordings/internal/replay/configtests",
-      "destination": "recordings/internal/services/replay",
-      "successor": "pkg/services/recordings/internal/services/replay",
-      "class": "test-only",
-      "stage": "pss-package-target-test-only",
-      "deletionGate": "delete the exact test-only package-target edge after its owning migration lands, then remove this baseline entry"
-    },
-    {
-      "packagePath": "pkg/services/recordings/internal/replay/fixturetests",
       "destination": "recordings/internal/services/replay",
       "successor": "pkg/services/recordings/internal/services/replay",
       "class": "test-only",

--- a/docs/internal/baselines/unfinished-package-moves.json
+++ b/docs/internal/baselines/unfinished-package-moves.json
@@ -11,12 +11,6 @@
   },
   "moves": [
     {
-      "packagePath": "pkg/services/factory_definitions/clonetests",
-      "destination": "factory_definitions/internal",
-      "successor": "pkg/services/factory_definitions/internal",
-      "deletionCondition": "delete transitional top-level package after CLN-DEF-FOLD-TOPLEVEL cutover proof"
-    },
-    {
       "packagePath": "pkg/services/factory_definitions/definition",
       "destination": "factory_definitions/internal",
       "successor": "pkg/services/factory_definitions/internal",
@@ -42,12 +36,6 @@
     },
     {
       "packagePath": "pkg/services/factory_definitions/internal/testcomposition",
-      "destination": "factory_definitions/internal",
-      "successor": "pkg/services/factory_definitions/internal",
-      "deletionCondition": "delete transitional top-level package after CLN-DEF-FOLD-TOPLEVEL cutover proof"
-    },
-    {
-      "packagePath": "pkg/services/factory_definitions/systeminitializationtests",
       "destination": "factory_definitions/internal",
       "successor": "pkg/services/factory_definitions/internal",
       "deletionCondition": "delete transitional top-level package after CLN-DEF-FOLD-TOPLEVEL cutover proof"
@@ -176,12 +164,6 @@
       "deletionCondition": "delete public package after IMP-REC-projection_query private subservice cutover proof"
     },
     {
-      "packagePath": "pkg/services/recordings/internal/projections/projectiontests",
-      "destination": "recordings/internal/services/projection_query",
-      "successor": "pkg/services/recordings/internal/services/projection_query",
-      "deletionCondition": "delete public package after IMP-REC-projection_query private subservice cutover proof"
-    },
-    {
       "packagePath": "pkg/services/recordings/internal/projections/workstation",
       "destination": "recordings/internal/services/projection_query",
       "successor": "pkg/services/recordings/internal/services/projection_query",
@@ -189,24 +171,6 @@
     },
     {
       "packagePath": "pkg/services/recordings/internal/replay",
-      "destination": "recordings/internal/services/replay",
-      "successor": "pkg/services/recordings/internal/services/replay",
-      "deletionCondition": "delete public package after IMP-REC-replay private subservice cutover proof"
-    },
-    {
-      "packagePath": "pkg/services/recordings/internal/replay/clocktests",
-      "destination": "recordings/internal/services/replay",
-      "successor": "pkg/services/recordings/internal/services/replay",
-      "deletionCondition": "delete public package after IMP-REC-replay private subservice cutover proof"
-    },
-    {
-      "packagePath": "pkg/services/recordings/internal/replay/configtests",
-      "destination": "recordings/internal/services/replay",
-      "successor": "pkg/services/recordings/internal/services/replay",
-      "deletionCondition": "delete public package after IMP-REC-replay private subservice cutover proof"
-    },
-    {
-      "packagePath": "pkg/services/recordings/internal/replay/fixturetests",
       "destination": "recordings/internal/services/replay",
       "successor": "pkg/services/recordings/internal/services/replay",
       "deletionCondition": "delete public package after IMP-REC-replay private subservice cutover proof"

--- a/ownership-boundary-baseline.json
+++ b/ownership-boundary-baseline.json
@@ -1,0 +1,229 @@
+{
+  "version": 1,
+  "entries": [
+    {
+      "rule": "mapping-filesystem-behavior",
+      "filePath": "pkg/transports/mapping/factoryconfig/authored/agents_config_test.go",
+      "target": "os.WriteFile",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "move filesystem behavior behind an injected service or exact external-effect port"
+    },
+    {
+      "rule": "mapping-filesystem-behavior",
+      "filePath": "pkg/transports/mapping/factoryconfig/authored/agents_config_test_helpers_test.go",
+      "target": "os.ReadFile",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "move filesystem behavior behind an injected service or exact external-effect port"
+    },
+    {
+      "rule": "mapping-filesystem-behavior",
+      "filePath": "pkg/transports/mapping/factoryconfig/openapitests/parity_inventory_test.go",
+      "target": "os.ReadFile",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "move filesystem behavior behind an injected service or exact external-effect port"
+    },
+    {
+      "rule": "mapping-filesystem-behavior",
+      "filePath": "pkg/transports/mapping/factorysession/factory_session_execution_test.go",
+      "target": "os.ReadFile",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "move filesystem behavior behind an injected service or exact external-effect port"
+    },
+    {
+      "rule": "mapping-filesystem-behavior",
+      "filePath": "pkg/transports/mapping/factorysession/factory_session_lifecycle_test.go",
+      "target": "os.ReadFile",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "move filesystem behavior behind an injected service or exact external-effect port"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/factory_definitions/transports/cli/cobracompletion/selected_factory_signature_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/work/transports/cli/climanifest",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/factory_runtime/internal/services/orchestration/runtime/captured_turn_terminate_integration_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/events/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/factory_runtime/internal/services/orchestration/runtime/captured_turn_terminate_integration_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/factory_runtime/internal/services/orchestration/runtime/captured_turn_terminate_integration_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/worker_sessions/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/events/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/worker_sessions/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/factory_sessions/internal/runtimeopening/runtime_load_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/factory_sessions/internal/runtimeopening/testmain_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/factory_visualization/wire/recordings_peer_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/recordings/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/factory_visualization/wire/wire_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/recordings/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/operator_settings/transports/cli/initsetup/init_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/providers/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/providers/transports/cli/contract_preservation_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/work/transports/cli/climanifest",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/providers/transports/cli/execute_adjacent_validation_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/work/transports/cli/climanifest",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/recordings/internal/replay/configtests/factory_snapshot_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/mapping/factorysnapshot",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/recordings/internal/replay/javascript_recording_contract_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/transports/mapping/factorysnapshot",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/system_initialization/internal/workflow/testmain_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/system_initialization/testmain_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/system_initialization/wire/testmain_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/operator_settings/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/worker_sessions/internal/service/fakes_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/events/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/worker_sessions/wire/wire_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/events/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/live_provider_session_integration_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/events/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/live_provider_session_integration_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/providers/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    },
+    {
+      "rule": "peer-service-implementation-import",
+      "filePath": "pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/live_provider_session_integration_test.go",
+      "target": "github.com/portpowered/infinite-you/pkg/services/worker_sessions/wire",
+      "class": "test-only",
+      "stage": "wire-injection-full-blow",
+      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
+    }
+  ]
+}

--- a/ownership-boundary-baseline.json
+++ b/ownership-boundary-baseline.json
@@ -75,22 +75,6 @@
     },
     {
       "rule": "peer-service-implementation-import",
-      "filePath": "pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover_test.go",
-      "target": "github.com/portpowered/infinite-you/pkg/services/events/wire",
-      "class": "test-only",
-      "stage": "wire-injection-full-blow",
-      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
-    },
-    {
-      "rule": "peer-service-implementation-import",
-      "filePath": "pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover_test.go",
-      "target": "github.com/portpowered/infinite-you/pkg/services/worker_sessions/wire",
-      "class": "test-only",
-      "stage": "wire-injection-full-blow",
-      "deletionGate": "import only the peer service root contract (pkg/services/\u003cpeer\u003e) instead of a peer implementation or nested subservice"
-    },
-    {
-      "rule": "peer-service-implementation-import",
       "filePath": "pkg/services/factory_sessions/internal/runtimeopening/runtime_load_test.go",
       "target": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire",
       "class": "test-only",


### PR DESCRIPTION
{
  "project": "P3-1 — Classify Production and Test-Only Boundary Edges",
  "branchName": "p3-boundary-edge-classification",
  "description": "Extend the repository's existing pkgboundarycheck, ownershipboundarycheck, and packagetargetmanifestcheck commands so every relevant Go dependency observation is explicitly classified as production or test-only. Report, count, enforce, and ratchet the classes independently while preserving strict production policy and production package-liveness semantics. The intent is to give maintainers a complete, correctly labeled graph before later service-cleanup migrations are planned, without performing those migrations in this lane.",
  "context": {
    "customerAsk": "Update cmd/pkgboundarycheck, cmd/ownershipboundarycheck, and cmd/packagetargetmanifestcheck so maintainers can distinguish production dependency edges from test-only edges and make architectural decisions from a complete, correctly labeled graph. Report and ratchet the classes separately, preserve strict production enforcement, prove the behavior through focused command tests and repository boundary gates, and complete the lane only after the PR is merged.",
    "problem": "The three checker families explicitly skip _test.go during relevant repository walks. Test-only imports are therefore absent from dependency observations and diagnostics, which has already supported a wrong architectural conclusion about a production blocker. Simply adding test files to existing undifferentiated counts would create the opposite failure by inflating production debt and weakening reliable production ratchets.",
    "solution": "Preserve each checker's existing ownership and policy while making source class explicit from observation through reporting and baseline comparison. Non-test .go dependencies remain production; _test.go dependencies are test-only. Findings, counts, diagnostics, and exact baseline keys retain that class. Production and test-only findings are partitioned and ratcheted independently, production package liveness remains based on production sources, and accepted test-only debt is recorded only as exact, reviewable, deletion-only entries with stale-entry detection."
  },
  "acceptanceCriteria": [
    "A maintainer running each of the existing pkgboundarycheck, ownershipboundarycheck, and packagetargetmanifestcheck commands receives dependency observations and diagnostics explicitly labeled production or test-only; relevant _test.go dependencies are no longer silently omitted.",
    "Production and test-only findings use separate counts and independently enforced ratchets. The same importer/target relationship observed in both classes remains two class-specific observations, and a test-only observation cannot change the production count or satisfy production package-liveness checks.",
    "Existing production violations and baselines remain blocking under their current production policy, no production allowlist or gate is weakened, and a repository area with a clean production graph does not become production-noncompliant merely because test files are now visible.",
    "Any required test-only baseline contains only exact, reviewable finding identities with their class, rejects wildcards and duplicate identities, blocks unrecorded growth, and fails when an entry becomes stale so accepted test debt can only shrink.",
    "Focused tests for all three commands prove equivalent production and _test.go inputs are classified and enforced separately, prove stale test-only baseline diagnostics, and prove stable class-labeled counts; repository package-boundary, package-structure, and package-target-manifest verification observes the intended behavior.",
    "Quality gate: focused Go tests for all three checker commands and the proportional fast verification tier pass; Typecheck passes; Tests pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. The pre-existing packaged-service-structure debt in the pkg-boundary target is compared against current main rather than converted into an unsatisfiable blanket make lint passes requirement.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "p3-boundary-edge-classification-001",
      "title": "Show class-separated package-boundary edges",
      "description": "As a maintainer, I want the package-boundary checker to label production and test-only dependency findings separately so its output cannot hide a test import or misstate it as a production violation.",
      "acceptanceCriteria": [
        "Relevant package-boundary scans observe both non-test .go imports and _test.go imports while retaining existing exclusions for generated sources and ignored fixture/vendor directories.",
        "Every observed dependency finding carries a stable production or test-only class from scanning through sorting, deduplication, counting, reporting, and baseline comparison.",
        "A prohibited import in a production source is reported as production and blocked by the existing production policy; the equivalent import in _test.go is reported as test-only and handled only by the test-only counter and ratchet.",
        "When the same importer/target relationship exists in both source classes, the command reports two class-specific observations and the test-only observation does not increase or discharge the production count.",
        "Existing package-boundary production baselines and deletion gates retain their meaning and strictness; any test-only baseline entries are exact, independently ratchetable, and reject wildcard identities.",
        "Focused command tests cover class separation, independent counts, new production failure, new test-only failure or baseline handling, and stable class-labeled diagnostics.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Package-boundary observations now carry production/test-only classes through keys, ratchets, diagnostics, counts, and focused tests."
    },
    {
      "id": "p3-boundary-edge-classification-002",
      "title": "Show class-separated ownership-boundary edges",
      "description": "As a maintainer, I want ownership-boundary results to distinguish production imports from test-only imports so ownership policy remains strict while test architecture debt is visible and independently reviewable.",
      "acceptanceCriteria": [
        "Ownership scans for Initializer, Platform, transport mapping, and cross-owner peer imports observe applicable production and _test.go dependencies and label each finding production or test-only.",
        "An equivalent prohibited ownership edge in production and test sources produces separate class-labeled outcomes; the production case remains immediately blocking under existing policy, while the test-only case uses only its separate exact ratchet.",
        "Production and test-only findings have independent machine-readable violation counts, deterministic ordering, and diagnostics that identify rule, source path, target, and class.",
        "Existing production ownership baseline entries remain production entries without broadened allowlists, reduced enforcement, or count inflation from test files.",
        "New, duplicate, wildcard, malformed, and stale test-only baseline entries are rejected with stable actionable diagnostics; removal of a test-only edge requires its exact baseline entry to be removed.",
        "Focused command tests cover production/test equivalence, independent enforcement, stable labeled output, and stale test-only baseline detection.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Ownership scans now include non-generated _test.go inputs across Initializer, Platform, mapping, and peer-service paths; findings, counts, diagnostics, and exact deletion-only baselines carry production/test-only classes with stale, duplicate, wildcard, and malformed-entry validation."
    },
    {
      "id": "p3-boundary-edge-classification-003",
      "title": "Preserve production liveness while exposing test-only package-target edges",
      "description": "As a maintainer, I want package-target manifest verification to expose test-only dependency evidence without allowing test sources to make a package or migration target appear production-live.",
      "acceptanceCriteria": [
        "Package-target manifest observations derived from Go sources distinguish production dependencies from test-only dependencies and report both classes explicitly where boundary evidence is emitted.",
        "A directory containing only _test.go remains test-only and cannot satisfy an open move row's production package-liveness requirement; a non-test .go file continues to establish production liveness under the existing rule.",
        "Equivalent production and _test.go dependency inputs are counted and ratcheted separately, and newly visible test-only evidence cannot increase or mask the production violation count.",
        "Existing closed destination vocabulary, unfinished-move ledger semantics, stale production-row checks, and production failure behavior remain unchanged.",
        "Any accepted test-only debt uses exact class-bearing identities, deterministic order, deletion-only behavior, and stale-entry failure rather than a wildcard or aggregate-only baseline.",
        "Focused command tests prove class-labeled dependency evidence, production-liveness isolation, independent counts, and stable stale-baseline diagnostics.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Package-target observations now classify production and test-only source classes, keep production liveness separate, and enforce a 31-entry exact deletion-only test-only baseline with stale and malformed-entry diagnostics. Test-only-only directories no longer remain as stale production move rows."
    },
    {
      "id": "p3-boundary-edge-classification-004",
      "title": "Run the repository boundary gates with stable class evidence",
      "description": "As a reviewer, I want the existing repository verification entry points to exercise all three class-aware checkers so the distinction is continuously enforced after this instrumentation lands.",
      "acceptanceCriteria": [
        "Running the focused Go test packages for cmd/pkgboundarycheck, cmd/ownershipboundarycheck, and cmd/packagetargetmanifestcheck proves both source classes are measured before each result is cited.",
        "The existing pkg-boundary, pkg-structure, and package-target-manifest-check verification paths invoke the updated checkers and preserve their established command behavior; Makefile changes, if any, are limited to narrow wiring needed for those existing checkers.",
        "Diagnostics remain deterministic and class-labeled across focused tests and repository verification, including separate observed production and test-only counts against their respective baselines.",
        "Current production debt does not grow, current clean production graphs remain clean, and any newly recorded test-only baseline is limited to exact findings actually observed by the changed checker.",
        "make verify-fast or the proportional fast verification tier passes, and CI evidence is recorded in the PR conversation rather than committed to the repository.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Focused class-aware tests for all three checkers pass; package-boundary, ownership, package-target, package-structure, backend-size, pkg-maint, pkg-file-count, targeted vet, typecheck, MCP contract, and UI unit gates pass. The clean-base branch preserves strict production liveness and the proportional boundary verification tier is green; the broad fast lane is being checked for unrelated current-main failures."
    }
  ]
}
