### PR TITLE
obs-4-claude-usage-capture

### DIFF
--- a/pkg/services/providers/internal/services/execution/internal/adapters/claude/adapter.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/claude/adapter.go
@@ -85,7 +85,10 @@ func newContinuationAttempt(effect Effect) execution.ContinuationAttempt {
 		}
 		metadata := cloneMetadata(effectResult.Metadata)
 		if metadata == nil {
-			metadata = make(map[string]string, 1)
+			metadata = make(map[string]string, 3)
+		}
+		for key, value := range decoder.reportedUsage {
+			metadata[key] = value
 		}
 		metadata["completion_evidence"] = "agent_message"
 		return providers.ExecuteResult{

--- a/pkg/services/providers/internal/services/execution/internal/adapters/claude/adapter_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/claude/adapter_test.go
@@ -49,7 +49,10 @@ func TestClaudeRootPreservesRequestOrderedStreamFinalAndSession(t *testing.T) {
 		}
 		return claude.EffectResult{
 			DurationMillis: 19,
-			Metadata:       map[string]string{"transport": "stream-json"},
+			Metadata: map[string]string{
+				"transport": "stream-json",
+				"api-token": "secret-value",
+			},
 		}, nil
 	})
 	root := newClaudeRoot(t, effect)
@@ -224,7 +227,10 @@ func assertClaudeSuccessResult(
 	}
 	if result.Diagnostics == nil ||
 		result.Diagnostics.DurationMillis != 19 ||
-		result.Diagnostics.Metadata["transport"] != "stream-json" {
+		result.Diagnostics.Metadata["transport"] != "stream-json" ||
+		result.Diagnostics.Metadata["input_tokens"] != "123" ||
+		result.Diagnostics.Metadata["output_tokens"] != "45" ||
+		result.Diagnostics.Metadata["api-token"] != "<redacted>" {
 		t.Fatalf("Diagnostics = %#v", result.Diagnostics)
 	}
 	assertProgress(t, result.Diagnostics.Progress)
@@ -307,6 +313,11 @@ func TestClaudeDecoderMapsMixedTextAndToolProgress(t *testing.T) {
 	}
 	if got := countPhase(result.Diagnostics.Progress, "tool.completed"); got < 1 {
 		t.Fatalf("tool.completed facts = %d, want at least 1", got)
+	}
+	for _, key := range []string{"input_tokens", "output_tokens"} {
+		if _, exists := result.Diagnostics.Metadata[key]; exists {
+			t.Fatalf("Diagnostics.Metadata[%q] = %q, want usage omitted without terminal usage", key, result.Diagnostics.Metadata[key])
+		}
 	}
 }
 
@@ -409,6 +420,7 @@ func claudeSuccessStream() []byte {
 		map[string]any{
 			"type": "result", "subtype": "success", "is_error": false,
 			"result": "authoritative final answer", "session_id": "claude-session-42",
+			"usage": map[string]any{"input_tokens": 123, "output_tokens": 45},
 		},
 	}
 	return encodeRecords(records)

--- a/pkg/services/providers/internal/services/execution/internal/adapters/claude/decoder.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/claude/decoder.go
@@ -36,6 +36,7 @@ type decoder struct {
 	finalContent   string
 	finalSessionID string
 	hasResult      bool
+	reportedUsage  map[string]string
 
 	progress        []providers.ExecuteProgress
 	declaredFailure *providers.ExecuteFailure
@@ -67,6 +68,7 @@ type nativeEnvelope struct {
 	SessionID       string          `json:"session_id"`
 	IsError         bool            `json:"is_error"`
 	Result          string          `json:"result"`
+	Usage           json.RawMessage `json:"usage"`
 	ParentToolUseID json.RawMessage `json:"parent_tool_use_id"`
 	Event           json.RawMessage `json:"event"`
 	Message         *nativeMessage  `json:"message"`
@@ -254,7 +256,39 @@ func (decoder *decoder) decodeResultRecord(envelope nativeEnvelope) {
 	}
 	decoder.finalContent = strings.TrimSpace(envelope.Result)
 	decoder.finalSessionID = strings.TrimSpace(envelope.SessionID)
+	decoder.reportedUsage = decodeUsageMetadata(envelope.Usage)
 	decoder.hasResult = true
+}
+
+type nativeUsage struct {
+	InputTokens  json.RawMessage `json:"input_tokens"`
+	OutputTokens json.RawMessage `json:"output_tokens"`
+}
+
+func decodeUsageMetadata(raw json.RawMessage) map[string]string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return nil
+	}
+	var usage nativeUsage
+	if json.Unmarshal(raw, &usage) != nil {
+		return nil
+	}
+	metadata := make(map[string]string, 2)
+	addUsageMetadata(metadata, "input_tokens", usage.InputTokens)
+	addUsageMetadata(metadata, "output_tokens", usage.OutputTokens)
+	if len(metadata) == 0 {
+		return nil
+	}
+	return metadata
+}
+
+func addUsageMetadata(metadata map[string]string, key string, raw json.RawMessage) {
+	value, err := strconv.ParseInt(string(bytes.TrimSpace(raw)), 10, 64)
+	if err != nil || value < 0 {
+		return
+	}
+	metadata[key] = strconv.FormatInt(value, 10)
 }
 
 func (decoder *decoder) decodeStreamEvent(raw json.RawMessage, parentItemID string) {


### PR DESCRIPTION
{
  "project": "OBS-4 Claude Usage Capture",
  "branchName": "obs-4-claude-usage-capture",
  "description": "Make token use from Claude workers observable by decoding input and output counts from the authoritative structured usage object on Claude Code's terminal stream result and preserving them through provider diagnostics into Diagnostics.Provider.ResponseMetadata, while omitting unavailable usage, preserving secret scrubbing, and documenting Claude/ACP flow coverage.",
  "context": {
    "customerAsk": "Decode Claude/ACP token usage into provider response metadata so Claude worker executions can feed the runtime metrics host through the same input_tokens and output_tokens vocabulary already used by other providers, without fabricated zeros, weakened scrubbing, or changes to downstream metrics consumers.",
    "problem": "The Claude decoder has no usage decoding. Although the Claude command requests verbose stream-json with partial messages, the adapter currently returns only its existing completion metadata. Consequently, a Claude execution whose terminal result reports usage loses those facts before the Workers diagnostic mapping, and runtime token metrics never fire. Treating absent usage as zero would falsely claim measurement, while parsing token-like text from progress would make correctness depend on human-readable output.",
    "solution": "Extend the existing Claude stream model and decoder to retain numeric input/output usage from the authoritative terminal success result, merge only present values into the adapter's existing diagnostics metadata, and rely on the existing provider result normalization and Workers mapping to preserve those values as Diagnostics.Provider.ResponseMetadata. Extend the existing Claude adapter fixtures to prove usage-present, usage-absent, and secret-scrubbing behavior. Do not modify the public provider or Workers contracts, the metrics host, the ACP protocol contract, or the Codex adapter."
  },
  "acceptanceCriteria": [
    "A Claude execution over a fixture stream whose terminal success result carries usage returns the stream's input and output counts in provider diagnostics metadata; after the existing Workers mapping, the same values are available at Diagnostics.Provider.ResponseMetadata[\"input_tokens\"] and [\"output_tokens\"].",
    "A successful Claude stream without usage returns neither usage key; it does not fabricate 0, infer counts from content, or scrape human-readable progress.",
    "Usage is decoded only from an authoritative structured Claude stream field, uses the established input_tokens and output_tokens strings, and does not add or change public provider, Workers, runtime-metrics, generated, or ACP protocol contracts.",
    "Existing result normalization preserves the numeric usage values while secret-like non-usage metadata remains redacted exactly as before; the allowlist is not broadened or the scrubber weakened.",
    "The PR body states which investigated flows carry usage and which do not: configured Claude Code print-mode stream-json terminal results carry the in-scope aggregate when supplied, partial events are not scraped, and current ACP-only prompt/turn flows lack a standardized implemented usage field and therefore remain without usage metadata in this lane.",
    "Quality gates: focused Claude adapter and provider result-normalization tests, typecheck, and tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "obs-4-claude-usage-capture-001",
      "title": "Preserve Authoritative Claude Usage",
      "description": "As an operator running Claude workers, I want token counts reported by Claude's authoritative terminal stream result preserved in provider diagnostics so existing runtime observability can measure the execution without estimating usage.",
      "acceptanceCriteria": [
        "An existing Claude adapter fixture with a successful terminal result usage object produces diagnostics metadata containing input_tokens and output_tokens as base-10 strings equal to the structured stream values.",
        "The returned provider execution result passes those values through the existing Workers mapping as Diagnostics.Provider.ResponseMetadata without a Workers or Factory Runtime change.",
        "A successful fixture with no terminal usage object produces neither input_tokens nor output_tokens; missing values are not converted to zero and token counts are not regex-scraped from progress text.",
        "Existing completion, content, progress, Provider Session, and duration behavior remains unchanged for both new and resumed Claude execution paths.",
        "A focused normalization regression proves an allowed numeric usage key survives while a non-usage sensitive key remains redacted, with no scrubber weakening or allowlist expansion.",
        "The implementation stays within the Claude adapter and, only if existing normalization fails to forward adapter metadata, the leased provider execution result-normalization area; it does not touch Codex, Workers, Factory Runtime, Recordings, generated artifacts, or ACP protocol contracts.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ],
  "goals": [
    "Preserve Claude-reported aggregate input and output token counts through the provider execution result.",
    "Use exactly the established input_tokens and output_tokens metadata keys consumed by Workers and Factory Runtime.",
    "Distinguish measured usage from unavailable usage by omitting keys when the authoritative record lacks them.",
    "Preserve existing sensitive-metadata scrubbing for every non-allowlisted key.",
    "Document exact Claude and ACP flow coverage in the delivery PR."
  ],
  "functionalRequirements": [
    "Decode non-negative input_tokens and output_tokens from the structured usage object on a successful Claude terminal result.",
    "Emit each established metadata key only when the corresponding structured field is present; do not fabricate missing values.",
    "Serialize captured counts as base-10 metadata strings compatible with the existing runtime numeric parser.",
    "Merge captured usage with existing Claude diagnostic metadata and completion evidence without discarding unrelated values.",
    "Preserve success, failure, continuation, progress, content, session, and duration semantics when usage is present or absent.",
    "Preserve the current secret-scrubbing policy for every non-usage sensitive metadata key.",
    "Extend existing Claude adapter tests rather than adding parallel fixtures or test scaffolding.",
    "State investigated Claude/ACP usage coverage and non-coverage in the PR body."
  ],
  "nonGoals": [
    "Codex usage capture, which belongs to OBS-3.",
    "Cost calculation, pricing, cache-token accounting, aggregation, new metrics, or user-facing metric readers.",
    "Changes to Workers, Factory Runtime, Recordings, generated contracts, or the ACP protocol.",
    "Regex or free-text extraction of usage from progress, logs, assistant content, or rate-limit messages.",
    "Emitting zero-valued metadata as a substitute for an absent usage report.",
    "Broad decoder refactoring or unrelated metadata cleanup."
  ],
  "supportingConsiderations": [
    "Keep state attempt-scoped inside the existing decoder; do not introduce global mutable state or a second normalization path.",
    "Use the exact established key strings and existing metadata merge/clone behavior. Do not introduce provider-prefixed or Claude-specific aliases.",
    "Treat field presence separately from numeric value so a reported zero remains distinguishable from an omitted field.",
    "Prefer terminal aggregate usage over partial-event accumulation to avoid double counting across model turns, tool calls, retries, or resumed sessions.",
    "Extend current adapter test helpers and fixture construction. Direct assertions on returned execution diagnostics are the narrowest behavioral evidence; a broad functional metrics test is unnecessary because downstream mapping and consumption already have their own coverage and are out of lease.",
    "If investigation of a pinned Claude stream fixture contradicts the assumed terminal location, capture from the actual structured authoritative record within the Claude adapter and update the PR-body coverage statement; never fall back to free text."
  ],
  "successMetrics": [
    "Every usage-bearing Claude fixture reports exact input/output counts through provider response metadata.",
    "Every no-usage Claude fixture omits both usage keys with no fabricated measurements.",
    "Focused regression coverage confirms unchanged secret scrubbing and existing Claude execution behavior.",
    "No downstream contract or consumer changes are required for Factory Runtime to observe the captured counts."
  ],
  "deliveryLoop": "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The worker/reviewer cycle continues until required CI is terminal and passing, every blocking PR conversation item is explicitly addressed, merge conflicts and shared-file contention are reconciled, and the PR is merged. A PR that is merely opened, green, approved, or ready to merge is not complete."
}
