### PR TITLE
obs-3-codex-usage-capture

### DIFF
--- a/pkg/services/providers/internal/services/execution/internal/adapters/codex/adapter_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/codex/adapter_test.go
@@ -50,7 +50,10 @@ func TestCodexRootPreservesRequestOrderedStreamFinalAndSession(t *testing.T) {
 		}
 		return codex.EffectResult{
 			DurationMillis: 23,
-			Metadata:       map[string]string{"transport": "jsonl"},
+			Metadata: map[string]string{
+				"transport": "jsonl",
+				"api_token": "provider-secret",
+			},
 		}, nil
 	})
 	root := newCodexRoot(t, effect)
@@ -149,6 +152,13 @@ func assertCodexSuccessResult(
 		result.Diagnostics.DurationMillis != 23 ||
 		result.Diagnostics.Metadata["transport"] != "jsonl" {
 		t.Fatalf("Diagnostics = %#v", result.Diagnostics)
+	}
+	if result.Diagnostics.Metadata["input_tokens"] != "10" ||
+		result.Diagnostics.Metadata["output_tokens"] != "5" {
+		t.Fatalf("usage metadata = %#v, want decimal input/output counters", result.Diagnostics.Metadata)
+	}
+	if result.Diagnostics.Metadata["api_token"] != "<redacted>" {
+		t.Fatalf("api_token = %q, want redacted", result.Diagnostics.Metadata["api_token"])
 	}
 	assertProgress(t, result.Diagnostics.Progress)
 }
@@ -289,6 +299,9 @@ func assertProgress(t *testing.T, progress []providers.ExecuteProgress) {
 	}
 	if !reflect.DeepEqual(gotPhases, wantPhases) {
 		t.Fatalf("progress phases = %#v, want %#v", gotPhases, wantPhases)
+	}
+	if got := progress[12].Detail; got != `{"input_tokens":10,"cached_input_tokens":2,"output_tokens":5,"reasoning_output_tokens":1}` {
+		t.Fatalf("usage detail = %q, want existing serialized usage record", got)
 	}
 	for _, index := range []int{2, 3, 4} {
 		if progress[index].Metadata["item_id"] != "message-1" {

--- a/pkg/services/providers/internal/services/execution/internal/adapters/codex/decoder.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/codex/decoder.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
 
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
@@ -15,6 +16,7 @@ type decoder struct {
 	flushed          bool
 	sessionID        string
 	finalContent     string
+	usage            *usageRecord
 	progress         []providers.ExecuteProgress
 	declaredFailure  *providers.ExecuteFailure
 	declaredKnown    bool
@@ -206,6 +208,10 @@ func (decoder *decoder) diagnostics() *providers.ExecuteDiagnostics {
 		inspectionLineCountMetadata:   inspectionMetadataValue(decoder.lineCount),
 		inspectionRecordCountMetadata: inspectionMetadataValue(decoder.recordCount),
 	}
+	if decoder.usage != nil {
+		metadata[usageInputTokensMetadata] = strconv.FormatInt(decoder.usage.InputTokens, 10)
+		metadata[usageOutputTokensMetadata] = strconv.FormatInt(decoder.usage.OutputTokens, 10)
+	}
 	if decoder.transcriptFull {
 		metadata[inspectionTranscriptTruncatedMetadata] = "true"
 	}
@@ -271,6 +277,8 @@ func (decoder *decoder) decodeRecord(raw []byte) {
 			decoder.markDecodeFailure("malformed_usage")
 			return
 		}
+		usage := *record.Usage
+		decoder.usage = &usage
 		detail, _ := json.Marshal(record.Usage)
 		decoder.addProgress("usage.updated", string(detail), nil)
 		decoder.addProgress("turn.completed", "completed", nil)

--- a/pkg/services/providers/internal/services/execution/internal/adapters/codex/limits.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/codex/limits.go
@@ -30,6 +30,8 @@ const (
 	inspectionTranscriptTruncatedMetadata   = "inspection_transcript_truncated"
 	inspectionDiagnosticsTruncatedMetadata  = "inspection_diagnostics_truncated"
 	inspectionRetainedTextTruncatedMetadata = "inspection_retained_text_truncated"
+	usageInputTokensMetadata                = "input_tokens"
+	usageOutputTokensMetadata               = "output_tokens"
 )
 
 type streamLimit struct {


### PR DESCRIPTION
{
  "project": "OBS-3 — Capture Codex usage for provider token metrics",
  "branchName": "obs-3-codex-usage-capture",
  "description": "Make Codex token usage observable by projecting decoded turn.completed input and output counts into the successful execute result's provider response metadata under the established input_tokens and output_tokens keys. Preserve the existing usage.updated detail and secret scrubbing so the current runtime metrics host emits provider token samples without changes to Workers, Factory Runtime, or public contracts.",
  "context": {
    "customerAsk": "Write the Codex adapter's decoded usageRecord input and output token counts into execute diagnostics that become Diagnostics.Provider.ResponseMetadata under the established input_tokens and output_tokens keys, allowing the existing runtime metrics host to emit provider.input_tokens and provider.output_tokens for Codex worker dispatches. Keep the usage.updated detail string and non-usage secret scrubbing unchanged, and stay inside the Providers Codex adapter path lease.",
    "problem": "The Codex adapter currently serializes turn.completed usage only into a usage.updated progress Detail string. The runtime metrics host does not parse that string; it reads numeric input_tokens and output_tokens from provider response metadata, so Codex dispatches produce no provider token samples. Reparsing progress downstream, inventing key names, or weakening the scrubber would duplicate protocol knowledge or increase sensitive-data risk.",
    "solution": "Retain decoded usage as bounded Codex adapter state and add its input and output counts as base-10 strings to successful execute diagnostic metadata using the exact established input_tokens and output_tokens vocabulary. Let the existing adapter-to-worker projection expose those values as provider ResponseMetadata and the existing sanitizer preserve only its already-allowlisted usage keys. Keep the current usage.updated progress detail unchanged and prove metadata, metric compatibility, progress, and redaction through the existing Codex adapter fixture test and established host consumption behavior."
  },
  "acceptanceCriteria": [
    "Given the existing Codex success fixture stream containing a turn.completed usage record, the normalized successful execute result carries decimal string values matching the stream under the exact input_tokens and output_tokens provider response metadata keys.",
    "The metadata shape consumed by the existing runtime metrics host is present for a Codex worker result, so its existing parsing path can emit provider.input_tokens and provider.output_tokens samples with the fixture values; no Factory Runtime or Workers behavior or contract is changed.",
    "The same execution still emits one usage.updated progress event whose detail is the existing serialized usage record, including the fixture's input, cached-input, output, and reasoning-output token values.",
    "Normal result sanitization preserves the already-allowlisted usage counters while continuing to redact a representative non-usage sensitive metadata key; the scrubber allowlist is not widened and scrubbing is not bypassed.",
    "The implementation remains within pkg/services/providers/internal/services/execution/internal/adapters/codex/**, plus pkg/services/providers/internal/services/execution/internal/service/** only if normalization must be adjusted to forward the adapter metadata; it does not touch Claude/ACP, Workers, Factory Runtime, Recordings, public API contracts, or generated artifacts.",
    "Quality gate: Typecheck passes; focused Codex adapter and Providers Execution normalization tests pass; required tests pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The worker/reviewer cycle continues after that implementation finish line until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, conflicts and shared-file changes are reconciled, and the PR is actually merged; an opened, green, approved, or merge-ready PR is not lane completion."
  ],
  "userStories": [
    {
      "id": "obs-3-codex-usage-capture-001",
      "title": "Expose Codex token usage to existing metrics consumers",
      "description": "As an operator, I want a successful Codex worker execution to expose its decoded token counts through provider response metadata so the existing runtime metrics host records input and output token samples while existing progress and security behavior remain intact.",
      "acceptanceCriteria": [
        "Executing the existing fixture Codex JSONL stream with a turn.completed usage record returns diagnostics whose provider response metadata contains input_tokens equal to 10 and output_tokens equal to 5, matching the fixture values as metric-parseable decimal strings.",
        "The adapter emits the exact established input_tokens and output_tokens vocabulary consumed by the runtime metrics host; it does not introduce alternate usage key names or require downstream parsing of progress detail.",
        "The existing host consumption contract can read the returned values and produce provider.input_tokens and provider.output_tokens samples for a Codex worker dispatch; existing host evidence plus the adapter result assertions is sufficient unless a focused in-lease emission seam already exists.",
        "The execution still includes one usage.updated progress event with the same JSON detail representing input_tokens 10, cached_input_tokens 2, output_tokens 5, and reasoning_output_tokens 1.",
        "Through normal execution-result sanitization, usage metadata remains visible while a representative non-usage sensitive metadata key remains <redacted>; no scrubber allowlist entry is added or broadened.",
        "Focused coverage extends the existing Codex adapter test file and exercises the fixture through the normal execute-result path rather than adding parallel scaffolding.",
        "No Claude/ACP adapter, Workers, Factory Runtime, Recordings, public contract, generated artifact, cost calculation, pricing, aggregation, or CLI behavior changes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Codex adapter now preserves turn.completed usage in bounded attempt state, exposes input_tokens/output_tokens through normalized diagnostics, and extends existing adapter coverage for progress detail and scrubbing."
    }
  ]
}
