### PR TITLE
feat(factory): move reviews to dedicated luna/max reviewer worker

### DIFF
--- a/factory/docs/overview.md
+++ b/factory/docs/overview.md
@@ -91,6 +91,27 @@ Executor and review workstations run in worktrees under
 `.claude/worktrees/<work-item-name>/`, created by
 `factory/scripts/setup-workspace.py`.
 
+The **review** workstation runs the dedicated `reviewer` worker
+(codex `gpt-5.6-luna`, reasoning effort `max`). Planning (`plan`) stays on the
+`planner` worker (codex `gpt-5.6-sol`).
+
+### Review quality probes
+
+Reviews run on luna at max reasoning effort for cost reasons: sol review
+sessions were the factory's largest spend bucket, and luna runs at roughly
+1/25th of sol's token rates. Because review-evaluation quality on luna is a
+known risk, the operator dispatches an independent "review quality probe"
+subagent on luna-reviewed PRs. The probe re-reviews the same PR head at high
+capability and grades the factory review as one of:
+
+* `CONCUR` — the probe agrees with the factory review's verdict
+* `MISSED_BLOCKER` — the factory review approved despite a real blocker
+  (false approve)
+* `FALSE_REJECTION` — the factory review rejected without a real blocker
+
+A `MISSED_BLOCKER` on a merged PR, or a low concur rate over the first ~10
+luna reviews, reverts the review worker to sol.
+
 ## Batch Submission
 
 Use the canonical `FACTORY_REQUEST_BATCH` shape from `you docs batch-inputs`.

--- a/factory/factory.json
+++ b/factory/factory.json
@@ -585,6 +585,16 @@
       "type": "AGENT_WORKER"
     },
     {
+      "executorProvider": "SCRIPT_WRAP",
+      "modelProvider": "codex",
+      "model": "gpt-5.6-luna",
+      "reasoningEffort": "max",
+      "name": "reviewer",
+      "skipPermissions": true,
+      "stopToken": "<COMPLETE>",
+      "type": "AGENT_WORKER"
+    },
+    {
       "args": [
         "factory/scripts/setup-workspace.py",
         "{{ (index .Inputs 0).Name }}"
@@ -892,7 +902,7 @@
         }
       ],
       "type": "AGENT_RUN",
-      "worker": "planner",
+      "worker": "reviewer",
       "workingDirectory": ".claude/worktrees/{{ (index .Inputs 0).Name }}"
     },
     {


### PR DESCRIPTION
## Summary

Move the review workstation off the sol-backed `planner` worker onto a new dedicated `reviewer` worker running codex `gpt-5.6-luna` at reasoning effort `max`. Planning (`plan` workstation) and ideafy stay on sol. Document the operator's review quality probe protocol as part of the factory shape.

## Cost evidence

From `docs/temp/cost-analysis-2026-08-20.md` (week of 2026-08-14 → 2026-08-20):

- The review bucket was the single largest spend bucket: **$5,620 at full basis / $881 at discounted basis for 517 sol review sessions in one week** (42% / 38% of host spend).
- **9 of the top 10 most expensive sessions were sol reviews** in this factory's worktrees ($49–$153 each at full basis).
- The review worker was `planner` = `gpt-5.6-sol` ($5/M input, $30/M output), 25x the rates of `gpt-5.6-luna` ($0.20/$1.20).

## Changes

- `factory/factory.json`: new `AGENT_WORKER` `reviewer` (codex, `gpt-5.6-luna`, reasoning effort `max`, same shape as `processor`); the `review` workstation's worker changed from `planner` to `reviewer`. No other workstation, loop-breaker, guard, or output routing touched.
- `factory/docs/overview.md`: documents the review/plan model split and adds a "Review quality probes" subsection — reviews run on luna/max for cost reasons; because review-evaluation quality is a known risk, the operator dispatches an independent probe subagent on luna-reviewed PRs that re-reviews the same head at high capability and grades the factory review CONCUR / MISSED_BLOCKER (false approve) / FALSE_REJECTION; a MISSED_BLOCKER on a merged PR or a low concur rate over the first ~10 luna reviews reverts the review worker to sol.
- `factory/workers/reviewer/AGENTS.md`: new empty file matching the sibling worker-directory convention (all existing worker AGENTS.md files are empty).

`factory/workstations/review/AGENTS.md` was checked for self-references to the planner worker or sol: none exist, so it is untouched.

## Validation

`./bin/you.exe factory config validate factory/factory.json` prints `Factory validation passed.` and the runtime taxonomy lists:

```
worker reviewer: AGENT_WORKER
workstation review: AGENT_RUN (worker=reviewer)
```

All other workers/workstations are unchanged in the taxonomy (plan still `worker=planner`, process still `worker=processor`, ideafy still `worker=ideafier`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178zD5WHNqjQvwBeQ8eFyed
