### PR TITLE
fix(factory): keep local worktree state when reused lane branch diverged from upstream

### DIFF
--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -782,9 +782,11 @@ def confirm_worktree_upstream_head(worktree_path, branch, upstream_ref):
 def sync_reused_worktree_branch(repo_root, worktree_path, branch):
     """Checkout branch in a reused worktree and fast-forward when safe.
 
-    No-upstream and missing-remote-branch conditions are non-fatal. Unsafe
-    fast-forward failures raise RuntimeError for worktree-preparation reporting.
-    Returns a human-readable outcome string for logging.
+    No-upstream, missing-remote-branch, and diverged-from-upstream conditions
+    are all non-fatal skips: a diverged local branch keeps its worktree state
+    as-is (remote commits stay on origin and reconcile at push time), because
+    resetting would destroy unpushed local commits and raising would kill the
+    lane. Returns a human-readable outcome string for logging.
     """
     run_git("checkout", branch, cwd=worktree_path)
 
@@ -819,8 +821,15 @@ def sync_reused_worktree_branch(repo_root, worktree_path, branch):
         local_sha = run_git("rev-parse", f"refs/heads/{branch}", cwd=worktree_path).stdout.strip()
         upstream_sha = run_git("rev-parse", upstream_ref, cwd=worktree_path).stdout.strip()
         if not can_fast_forward_main(worktree_path, local_sha, upstream_sha):
-            raise RuntimeError(
-                f"worktree branch update failed for {branch}: {stderr}"
+            if snapshot_id is not None:
+                return (
+                    f"stashed local changes in snapshot {snapshot_id[:8]}, "
+                    "then skipped (local branch diverged from upstream; "
+                    "keeping local worktree state)"
+                )
+            return (
+                "skipped (local branch diverged from upstream; "
+                "keeping local worktree state)"
             )
 
         run_git("reset", "--hard", upstream_ref, cwd=worktree_path)

--- a/tests/factory/scripts/test_setup_workspace_failures.py
+++ b/tests/factory/scripts/test_setup_workspace_failures.py
@@ -192,7 +192,7 @@ class SetupWorkspaceFailureTest(unittest.TestCase):
         self.assertNotIn("Worktree preparation failed", result.stderr)
         self.assertNotIn("PRD copy failed", result.stderr)
 
-    def test_reports_worktree_preparation_failure_without_root_sync_label(self):
+    def test_diverged_branch_reuse_reports_no_failure_labels(self):
         bare_remote = self.repo_path / "remote.git"
         bare_remote.mkdir()
         subprocess.run(
@@ -260,9 +260,11 @@ class SetupWorkspaceFailureTest(unittest.TestCase):
         subprocess.run(["git", "fetch", "origin"], cwd=local_repo, check=True)
 
         second = run_setup_workspace(local_repo, prd_name)
-        self.assertEqual(second.returncode, 1, second.stdout)
-        self.assertIn("Worktree preparation failed:", second.stderr)
-        self.assertIn("worktree branch update failed", second.stderr.lower())
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertIn(
+            "skipped (local branch diverged from upstream", second.stderr,
+        )
+        self.assertNotIn("Worktree preparation failed", second.stderr)
         self.assertNotIn("Root sync failed", second.stderr)
         self.assertNotIn("PRD copy failed", second.stderr)
 

--- a/tests/factory/scripts/test_setup_workspace_worktree.py
+++ b/tests/factory/scripts/test_setup_workspace_worktree.py
@@ -419,7 +419,7 @@ class SetupWorkspaceWorktreeTest(unittest.TestCase):
         self.assertTrue(marker.exists())
         self.assertIn("no upstream", second.stderr.lower())
 
-    def test_reports_worktree_preparation_failure_when_branch_update_unsafe(self):
+    def test_keeps_local_worktree_state_when_branch_diverged_from_upstream(self):
         bare_remote = self.repo_path / "remote.git"
         bare_remote.mkdir()
         git(["init", "--bare", "-b", "main"], bare_remote)
@@ -458,11 +458,45 @@ class SetupWorkspaceWorktreeTest(unittest.TestCase):
         git(["push", "origin", prd_name], upstream)
         git(["fetch", "origin"], local_repo)
 
+        local_tip = git(["rev-parse", "HEAD"], worktree_path).stdout.strip()
+        dirty_file = worktree_path / "diverged-dirty.txt"
+        dirty_file.write_text("keep me dirty\n", encoding="utf-8")
+
         second = run_setup_workspace(local_repo, prd_name)
-        self.assertEqual(second.returncode, 1, second.stdout)
-        self.assertIn("Worktree preparation failed", second.stderr)
-        self.assertNotIn("Root sync failed", second.stderr)
-        self.assertIn("worktree branch update failed", second.stderr.lower())
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertIn(
+            "skipped (local branch diverged from upstream", second.stderr,
+        )
+        self.assertIn("stashed local changes", second.stderr.lower())
+        self.assertNotIn("worktree branch update failed", second.stderr.lower())
+        second_payload = json.loads(second.stdout)
+        self.assertTrue(second_payload["reused"])
+
+        # The unpushed local commits survive: HEAD still equals the pre-sync
+        # local tip, and the worktree was not reset to the remote history.
+        self.assertEqual(
+            git(["rev-parse", "HEAD"], worktree_path).stdout.strip(),
+            local_tip,
+        )
+        self.assertTrue((worktree_path / "local-only.txt").exists())
+        self.assertFalse((worktree_path / "remote-only.txt").exists())
+
+        # Stashed local changes are restored by the finally block.
+        self.assertEqual(
+            dirty_file.read_text(encoding="utf-8"),
+            "keep me dirty\n",
+        )
+        self.assertIn(
+            "?? diverged-dirty.txt",
+            git(["status", "--porcelain"], worktree_path).stdout,
+        )
+
+        # Nothing is lost remotely either: the diverged remote commits remain
+        # reachable on the fetched upstream ref for push-time reconciliation.
+        remote_tip = git(
+            ["rev-parse", f"origin/{prd_name}"], worktree_path,
+        ).stdout.strip()
+        self.assertNotEqual(remote_tip, local_tip)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Measured failure

On 2026-08-20 (after a daemon restart), lane `rsm-1-durable-checkpoint-stores` was resubmitted while its existing worktree `.claude/worktrees/rsm-1-durable-checkpoint-stores` held a branch that had diverged from `origin/rsm-1-durable-checkpoint-stores`: local 17 ahead / 3 behind (the worker had rebased and continued locally without pushing; open PR #2075 still points at the older remote history). `factory/scripts/setup-workspace.py` took the worktree reuse path, `git pull --ff-only` failed, `can_fast_forward_main` was false, and `sync_reused_worktree_branch()` raised `RuntimeError("worktree branch update failed for ...: Not possible to fast-forward")`. The script exited 1 and the factory marked the lane's plan token FAILED - the lane was dead on the board.

## Why raise and reset are both wrong

- Raising kills the lane while protecting nothing: the local worktree already holds the newest work, and the remote commits remain safely on origin. The worker reconciles the divergence at push time.
- `reset --hard` to upstream would be worse: it would destroy the 17 unpushed local commits.

Every other unsafe condition in this function family (no upstream configured, branch missing on origin, root main not fast-forwardable, fetch failure with a usable local main) is a non-fatal skip; lethality on divergence was the outlier.

## Fix

`sync_reused_worktree_branch()` now treats a diverged local branch as a non-fatal skip: it keeps the local worktree state as-is and returns `skipped (local branch diverged from upstream; keeping local worktree state)` (prefixed with the snapshot id when local changes were stashed). The fast-forward path, the strictly-behind fetch/reset path, the existing skip cases, and the stash/restore semantics (the `finally` restore still runs in the new path) are all preserved.

## Test changes

- `tests/factory/scripts/test_setup_workspace_worktree.py`: the diverged-branch test (`diverge locally` / `diverge on remote` fixture) now asserts the non-fatal keep-local contract: exit 0, the skipped-diverged outcome, worktree HEAD still equal to the pre-sync local tip, the local-only commit surviving, no remote-only file materialized, stashed dirty files restored, and the remote tip still reachable on the fetched upstream ref.
- `tests/factory/scripts/test_setup_workspace_failures.py`: the same fixture existed there as a failure-label categorization test; it now asserts exit 0 with the skipped-diverged outcome and no failure labels. (This third file had to change because it asserted the identical lethal behavior and would have failed the suite otherwise.)

## Verification

- `python -m unittest discover -s tests/factory/scripts -p "test_*.py" -v`: all tests pass.
- Manual repro from the repo root: `python factory/scripts/setup-workspace.py rsm-1-durable-checkpoint-stores` now exits 0, prints the skipped-diverged outcome, copies the fresh prd.json/prd.md into the worktree, and leaves the worktree HEAD unchanged at 17a8283c8d407cdee66e207b8e11a6f5015c610a (still 17 ahead / 3 behind).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178zD5WHNqjQvwBeQ8eFyed
