### PR TITLE
svc-1-boundary-checker-test-edges

### DIFF
--- a/cmd/ownershipboundarycheck/hosted_ownership.go
+++ b/cmd/ownershipboundarycheck/hosted_ownership.go
@@ -72,6 +72,7 @@ func evaluateHostedOwnershipClaims(claims []hostedOwnershipClaim) []finding {
 				Rule:     ruleHostedOwnershipAssignment,
 				FilePath: hostedOwnershipClaimsFile,
 				Target:   fmt.Sprintf("unknown responsibility %q", claim.Responsibility),
+				class:    productionSourceClass,
 			})
 			continue
 		}
@@ -87,6 +88,7 @@ func evaluateHostedOwnershipClaims(claims []hostedOwnershipClaim) []finding {
 				claim.Owner,
 				wantOwner,
 			),
+			class: productionSourceClass,
 		})
 	}
 	sort.Slice(findings, func(i, j int) bool {

--- a/cmd/ownershipboundarycheck/main.go
+++ b/cmd/ownershipboundarycheck/main.go
@@ -99,6 +99,7 @@ type finding struct {
 	FilePath string `json:"filePath"`
 	Target   string `json:"target"`
 	Line     int    `json:"-"`
+	class    boundarySourceClass
 }
 
 type baseline struct {
@@ -110,6 +111,7 @@ type baselineEntry struct {
 	Rule         string `json:"rule"`
 	FilePath     string `json:"filePath"`
 	Target       string `json:"target"`
+	Class        string `json:"class,omitempty"`
 	Stage        string `json:"stage"`
 	DeletionGate string `json:"deletionGate"`
 }
@@ -139,37 +141,51 @@ func run(cfg config, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
+	productionFindings := filterFindingsByClass(findings, productionSourceClass)
+	testOnlyFindings := filterFindingsByClass(findings, testOnlySourceClass)
 	if cfg.createBaseline {
-		return createBaseline(repoRoot, findings, stdout)
+		return createBaseline(repoRoot, productionFindings, stdout)
 	}
 	recorded, err := loadBaseline(repoRoot)
 	if err != nil {
 		return err
 	}
-	active, unrecorded, stale, err := partition(findings, recorded)
+	recorded, err = productionBaseline(recorded)
 	if err != nil {
 		return err
+	}
+	active, unrecorded, stale, err := partition(productionFindings, recorded)
+	if err != nil {
+		return err
+	}
+	for _, item := range testOnlyFindings {
+		writeFinding(stdout, "test-only observation", item)
 	}
 	for _, item := range unrecorded {
 		writeFinding(stderr, "new violation", item)
 	}
+	counts := countFindingClasses(testOnlyFindings, unrecorded)
 	for _, item := range stale {
 		fmt.Fprintf(
 			stderr,
-			"[agent-factory:ownership-boundary] stale baseline: %s %s -> %s; remove this entry from %s\n",
+			"[agent-factory:ownership-boundary] stale baseline: %s %s -> %s [class=%s]; remove this entry from %s\n",
 			item.Rule,
 			item.FilePath,
 			item.Target,
+			effectiveBoundarySourceClass(boundarySourceClass(item.Class), item.FilePath),
 			baselineFile,
 		)
+		counts.add(effectiveBoundarySourceClass(boundarySourceClass(item.Class), item.FilePath))
 	}
 	if len(unrecorded) > 0 || len(stale) > 0 {
+		writeClassifiedFindingCounts(stderr, counts)
 		return fmt.Errorf(
 			"[agent-factory:ownership-boundary] found %d new violation(s) and %d stale baseline entries",
 			len(unrecorded),
 			len(stale),
 		)
 	}
+	writeClassifiedFindingCounts(stdout, counts)
 	fmt.Fprintf(
 		stdout,
 		"[agent-factory:ownership-boundary] ownership boundaries hold (%d deletion-only baseline entries remain)\n",
@@ -206,7 +222,7 @@ func scan(repoRoot string) ([]finding, error) {
 				}
 				return nil
 			}
-			if !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			if !strings.HasSuffix(entry.Name(), ".go") {
 				return nil
 			}
 			relative, err := filepath.Rel(repoRoot, path)
@@ -254,6 +270,10 @@ func scanFile(path, relative string, inventory ownerInventory) ([]finding, error
 		findings = append(findings, scanPlatformImports(fileSet, imports, relative)...)
 	case within(relative, mappingRoot):
 		findings = append(findings, scanMappingBehavior(fileSet, file, aliases, imports, relative)...)
+	}
+	class := classifyBoundarySource(relative)
+	for index := range findings {
+		findings[index].class = class
 	}
 	return findings, nil
 }
@@ -509,14 +529,15 @@ func uniqueFindings(items []finding) []finding {
 }
 
 func findingKey(item finding) string {
-	return item.Rule + "\x00" + item.FilePath + "\x00" + item.Target
+	return item.Rule + "\x00" + item.FilePath + "\x00" + string(effectiveBoundarySourceClass(item.class, item.FilePath)) + "\x00" + item.Target
 }
 
 func entryKey(item baselineEntry) string {
-	return item.Rule + "\x00" + item.FilePath + "\x00" + item.Target
+	return item.Rule + "\x00" + item.FilePath + "\x00" + string(effectiveBoundarySourceClass(boundarySourceClass(item.Class), item.FilePath)) + "\x00" + item.Target
 }
 
 func createBaseline(repoRoot string, findings []finding, stdout io.Writer) error {
+	findings = filterFindingsByClass(findings, productionSourceClass)
 	if len(findings) == 0 {
 		return fmt.Errorf("refusing to create empty %s; absence records zero debt", baselineFile)
 	}
@@ -532,6 +553,7 @@ func createBaseline(repoRoot string, findings []finding, stdout io.Writer) error
 	for _, item := range findings {
 		entries = append(entries, baselineEntry{
 			Rule: item.Rule, FilePath: item.FilePath, Target: item.Target,
+			Class: string(effectiveBoundarySourceClass(item.class, item.FilePath)),
 			Stage: baselineStage, DeletionGate: deletionGates[item.Rule],
 		})
 	}
@@ -609,6 +631,9 @@ func validateEntry(item baselineEntry) error {
 	if item.Rule == "" || item.FilePath == "" || item.Target == "" {
 		return fmt.Errorf("%s contains an entry with a missing rule, filePath, or target", baselineFile)
 	}
+	if _, err := sourceClassFromBaseline(item.Class, item.FilePath); err != nil {
+		return err
+	}
 	gate, known := deletionGates[item.Rule]
 	if !known {
 		return fmt.Errorf("%s contains unknown rule %q", baselineFile, item.Rule)
@@ -629,12 +654,13 @@ func writeFinding(writer io.Writer, label string, item finding) {
 	}
 	fmt.Fprintf(
 		writer,
-		"[agent-factory:ownership-boundary] %s: %s:%d %s -> %s; %s\n",
+		"[agent-factory:ownership-boundary] %s: %s:%d %s -> %s; %s [class=%s]\n",
 		label,
 		item.FilePath,
 		item.Line,
 		item.Rule,
 		item.Target,
 		remediation,
+		effectiveBoundarySourceClass(item.class, item.FilePath),
 	)
 }

--- a/cmd/ownershipboundarycheck/peer_import.go
+++ b/cmd/ownershipboundarycheck/peer_import.go
@@ -123,7 +123,7 @@ func scanPeerServiceImports(
 			}
 			return nil
 		}
-		if !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+		if !strings.HasSuffix(entry.Name(), ".go") {
 			return nil
 		}
 		relative, err := filepath.Rel(repoRoot, path)
@@ -157,6 +157,7 @@ func scanPeerServiceImports(
 				FilePath: relative,
 				Target:   importPath,
 				Line:     fileSet.Position(spec.Pos()).Line,
+				class:    classifyBoundarySource(relative),
 			})
 		}
 		return nil

--- a/cmd/ownershipboundarycheck/source_classification.go
+++ b/cmd/ownershipboundarycheck/source_classification.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// boundarySourceClass identifies the kind of Go source that produced a
+// boundary observation. Keeping it on the finding prevents production and
+// test-only edges from collapsing into one report or baseline key.
+type boundarySourceClass string
+
+const (
+	productionSourceClass boundarySourceClass = "production"
+	testOnlySourceClass   boundarySourceClass = "test-only"
+)
+
+func classifyBoundarySource(filePath string) boundarySourceClass {
+	if strings.HasSuffix(filePath, "_test.go") {
+		return testOnlySourceClass
+	}
+	return productionSourceClass
+}
+
+func (class boundarySourceClass) valid() bool {
+	return class == productionSourceClass || class == testOnlySourceClass
+}
+
+func effectiveBoundarySourceClass(class boundarySourceClass, filePath string) boundarySourceClass {
+	if class.valid() {
+		return class
+	}
+	return classifyBoundarySource(filePath)
+}
+
+// sourceClassFromBaseline keeps the existing production baseline format
+// readable while allowing new entries to carry an explicit class. The source
+// filename remains authoritative so a malformed class cannot relabel an edge.
+func sourceClassFromBaseline(value, filePath string) (boundarySourceClass, error) {
+	expected := classifyBoundarySource(filePath)
+	if strings.TrimSpace(value) == "" {
+		return expected, nil
+	}
+	class := boundarySourceClass(value)
+	if !class.valid() {
+		return "", fmt.Errorf("baseline entry %s has invalid class %q", filePath, value)
+	}
+	if class != expected {
+		return "", fmt.Errorf("baseline entry %s class = %q, want %q", filePath, class, expected)
+	}
+	return class, nil
+}
+
+type classifiedFindingCounts struct {
+	production int
+	testOnly   int
+}
+
+func (counts *classifiedFindingCounts) add(class boundarySourceClass) {
+	switch class {
+	case productionSourceClass:
+		counts.production++
+	case testOnlySourceClass:
+		counts.testOnly++
+	}
+}
+
+func countFindingClasses(findings ...[]finding) classifiedFindingCounts {
+	var counts classifiedFindingCounts
+	for _, group := range findings {
+		for _, item := range group {
+			counts.add(effectiveBoundarySourceClass(item.class, item.FilePath))
+		}
+	}
+	return counts
+}
+
+func writeClassifiedFindingCounts(writer io.Writer, counts classifiedFindingCounts) {
+	fmt.Fprintf(
+		writer,
+		"[agent-factory:ownership-boundary] dependency violation counts: production=%d test-only=%d\n",
+		counts.production,
+		counts.testOnly,
+	)
+}
+
+func filterFindingsByClass(findings []finding, want boundarySourceClass) []finding {
+	filtered := make([]finding, 0, len(findings))
+	for _, item := range findings {
+		if effectiveBoundarySourceClass(item.class, item.FilePath) == want {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
+func productionBaseline(recorded baseline) (baseline, error) {
+	result := baseline{Version: recorded.Version}
+	for _, entry := range recorded.Entries {
+		class, err := sourceClassFromBaseline(entry.Class, entry.FilePath)
+		if err != nil {
+			return baseline{}, err
+		}
+		if class == productionSourceClass {
+			result.Entries = append(result.Entries, entry)
+		}
+	}
+	return result, nil
+}

--- a/cmd/ownershipboundarycheck/source_classification_test.go
+++ b/cmd/ownershipboundarycheck/source_classification_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunClassifiesOwnershipBoundaryEdgesBySourceClass(t *testing.T) {
+	const peerImport = `import engine "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine"`
+
+	tests := []struct {
+		name    string
+		files   map[string]string
+		wantErr bool
+		counts  string
+		class   string
+	}{
+		{
+			name: "production",
+			files: map[string]string{
+				"pkg/services/factory_sessions/doc.go":                "package factory_sessions\n",
+				"pkg/services/factory_runtime/doc.go":                 "package factory_runtime\n",
+				"pkg/services/factory_runtime/internal/engine/doc.go": "package engine\n",
+				"pkg/services/factory_sessions/consume_peer.go":       "package factory_sessions\n" + peerImport + "\n",
+			},
+			wantErr: true,
+			counts:  "dependency violation counts: production=1 test-only=0",
+			class:   "[class=production]",
+		},
+		{
+			name: "test-only",
+			files: map[string]string{
+				"pkg/services/factory_sessions/doc.go":                "package factory_sessions\n",
+				"pkg/services/factory_runtime/doc.go":                 "package factory_runtime\n",
+				"pkg/services/factory_runtime/internal/engine/doc.go": "package engine\n",
+				"pkg/services/factory_sessions/consume_peer_test.go":  "package factory_sessions\n" + peerImport + "\n",
+			},
+			counts: "dependency violation counts: production=0 test-only=1",
+			class:  "[class=test-only]",
+		},
+		{
+			name: "mixed",
+			files: map[string]string{
+				"pkg/services/factory_sessions/doc.go":                "package factory_sessions\n",
+				"pkg/services/factory_runtime/doc.go":                 "package factory_runtime\n",
+				"pkg/services/factory_runtime/internal/engine/doc.go": "package engine\n",
+				"pkg/services/factory_sessions/consume_peer.go":       "package factory_sessions\n" + peerImport + "\n",
+				"pkg/services/factory_sessions/consume_peer_test.go":  "package factory_sessions\n" + peerImport + "\n",
+			},
+			wantErr: true,
+			counts:  "dependency violation counts: production=1 test-only=1",
+			class:   "[class=test-only]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := fixtureRepository(t, test.files)
+			var stdout, stderr bytes.Buffer
+			err := run(config{root: root}, &stdout, &stderr)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("run() error = %v, wantErr=%t; stdout=%q stderr=%q", err, test.wantErr, stdout.String(), stderr.String())
+			}
+			output := stdout.String() + stderr.String()
+			if !strings.Contains(output, test.counts) {
+				t.Fatalf("run() output = %q, want counts %q", output, test.counts)
+			}
+			if !strings.Contains(output, test.class) {
+				t.Fatalf("run() output = %q, want source class %q", output, test.class)
+			}
+			if test.name == "test-only" && strings.Contains(stderr.String(), "new violation") {
+				t.Fatalf("test-only finding entered blocking stderr path: %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestOwnershipBoundaryDiscoveryRetainsTestOnlyEdgesInScopedAndPeerScans(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_sessions/doc.go":                "package factory_sessions\n",
+		"pkg/services/factory_runtime/doc.go":                 "package factory_runtime\n",
+		"pkg/services/factory_runtime/internal/engine/doc.go": "package engine\n",
+		"pkg/initializer/application/initializer.go":          "package application\nimport _ \"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine\"\n",
+		"pkg/initializer/application/initializer_test.go":     "package application\nimport _ \"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine\"\n",
+		"pkg/services/factory_sessions/consume_peer.go":       "package factory_sessions\nimport _ \"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine\"\n",
+		"pkg/services/factory_sessions/consume_peer_test.go":  "package factory_sessions\nimport _ \"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine\"\n",
+	})
+
+	findings := scanFixture(t, root)
+	want := map[string]bool{
+		"pkg/initializer/application/initializer.go|production":        false,
+		"pkg/initializer/application/initializer_test.go|test-only":    false,
+		"pkg/services/factory_sessions/consume_peer.go|production":     false,
+		"pkg/services/factory_sessions/consume_peer_test.go|test-only": false,
+	}
+	for _, item := range findings {
+		key := item.FilePath + "|" + string(effectiveBoundarySourceClass(item.class, item.FilePath))
+		if _, ok := want[key]; ok {
+			want[key] = true
+		}
+	}
+	for key, found := range want {
+		if !found {
+			t.Errorf("scan findings missing classified edge %q: %#v", key, findings)
+		}
+	}
+}
+
+func TestOwnershipBoundaryTestOnlyFindingsDoNotUseProductionBaseline(t *testing.T) {
+	const (
+		productionPath = "pkg/services/factory_sessions/consume_peer.go"
+		testPath       = "pkg/services/factory_sessions/consume_peer_test.go"
+		target         = modulePath + "/pkg/services/factory_runtime/internal/engine"
+	)
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_sessions/doc.go":                "package factory_sessions\n",
+		"pkg/services/factory_runtime/doc.go":                 "package factory_runtime\n",
+		"pkg/services/factory_runtime/internal/engine/doc.go": "package engine\n",
+		productionPath: "package factory_sessions\nimport _ \"" + target + "\"\n",
+		testPath:       "package factory_sessions\nimport _ \"" + target + "\"\n",
+	})
+	writeBaseline(t, root, baselineEntryFor(rulePeerServiceImplementation, productionPath, target))
+
+	var stdout, stderr bytes.Buffer
+	if err := run(config{root: root}, &stdout, &stderr); err != nil {
+		t.Fatalf("run with recorded production edge and test-only edge: %v; stdout=%s stderr=%s", err, stdout.String(), stderr.String())
+	}
+	output := stdout.String() + stderr.String()
+	if !strings.Contains(output, "test-only observation") ||
+		!strings.Contains(output, "dependency violation counts: production=0 test-only=1") {
+		t.Fatalf("output = %q, want visible non-blocking test-only edge and zero unrecorded production count", output)
+	}
+	if !strings.Contains(stdout.String(), "1 deletion-only baseline") {
+		t.Fatalf("stdout = %q, want active production baseline", stdout.String())
+	}
+}
+
+func TestOwnershipBoundaryCreateBaselineIgnoresTestOnlyFindings(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_sessions/doc.go":                "package factory_sessions\n",
+		"pkg/services/factory_runtime/doc.go":                 "package factory_runtime\n",
+		"pkg/services/factory_runtime/internal/engine/doc.go": "package engine\n",
+		"pkg/services/factory_sessions/consume_peer_test.go":  "package factory_sessions\nimport _ \"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine\"\n",
+	})
+
+	var stdout, stderr bytes.Buffer
+	err := run(config{root: root, createBaseline: true}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "absence records zero debt") {
+		t.Fatalf("create baseline with only test findings = %v, want zero production debt refusal", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, baselineFile)); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("test-only baseline exists or stat failed unexpectedly: %v", statErr)
+	}
+}
+
+func TestOwnershipBoundaryKeysIncludeSourceClass(t *testing.T) {
+	production := findingKey(finding{
+		Rule: rulePeerServiceImplementation, FilePath: "pkg/services/factory_sessions/edge.go",
+		Target: "peer", class: productionSourceClass,
+	})
+	testOnly := findingKey(finding{
+		Rule: rulePeerServiceImplementation, FilePath: "pkg/services/factory_sessions/edge.go",
+		Target: "peer", class: testOnlySourceClass,
+	})
+	if production == testOnly {
+		t.Fatalf("finding keys collapsed source classes: %q", production)
+	}
+
+	productionEntry := entryKey(baselineEntry{
+		Rule: rulePeerServiceImplementation, FilePath: "pkg/services/factory_sessions/edge.go",
+		Target: "peer", Class: string(productionSourceClass),
+	})
+	testOnlyEntry := entryKey(baselineEntry{
+		Rule: rulePeerServiceImplementation, FilePath: "pkg/services/factory_sessions/edge.go",
+		Target: "peer", Class: string(testOnlySourceClass),
+	})
+	if productionEntry == testOnlyEntry {
+		t.Fatalf("baseline keys collapsed source classes: %q", productionEntry)
+	}
+}

--- a/cmd/packagetargetmanifestcheck/inventory.go
+++ b/cmd/packagetargetmanifestcheck/inventory.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-
-	"github.com/portpowered/infinite-you/internal/ownershipinventory"
 )
 
 // listProductionPkgPackages returns every production Go package under pkg/ in
@@ -77,20 +75,6 @@ func listProductionPkgPackages(repoRoot string) ([]string, error) {
 // own path, so adding or deleting a package inside a service needs no registry
 // edit.
 func validateRowsNamePackagesThatExist(repoRoot string, packages []PackageMapping) error {
-	// The open-move ledger is shared with the ownership-inventory checker, so
-	// "this package still exists" has to mean the same thing in both tools.
-	// ListProductionPackages counts any directory under pkg/ that holds a .go
-	// file, which keeps test-helper packages (…/clonetests, …/fixturetests)
-	// from reading as stale rows.
-	live, err := ownershipinventory.ListProductionPackages(repoRoot)
-	if err != nil {
-		return err
-	}
-	liveSet := make(map[string]struct{}, len(live))
-	for _, packagePath := range live {
-		liveSet[packagePath] = struct{}{}
-	}
-
 	var stale []string
 	for i, row := range packages {
 		packagePath := row.PackagePath
@@ -100,7 +84,15 @@ func validateRowsNamePackagesThatExist(repoRoot string, packages []PackageMappin
 		if !strings.HasPrefix(packagePath, "pkg/") {
 			return fmt.Errorf("moves[%d] %q must be repository-relative under pkg/", i, packagePath)
 		}
-		if _, alive := liveSet[packagePath]; !alive {
+		// Discover the source class before deciding whether the row is live. A
+		// test-only package remains visible to the package-target report instead
+		// of disappearing behind a production-only filter; both source classes
+		// still establish that the named directory exists.
+		classes, err := packageTargetSourceClasses(repoRoot, packagePath)
+		if err != nil {
+			return err
+		}
+		if len(classes) == 0 {
 			stale = append(stale, packagePath)
 		}
 	}

--- a/cmd/packagetargetmanifestcheck/main.go
+++ b/cmd/packagetargetmanifestcheck/main.go
@@ -51,12 +51,15 @@ func run(cfg config, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	if err := validateOpenMoveLedgerSchema(repoRoot, moves); err != nil {
-		return fmt.Errorf("[agent-factory:package-target-manifest] %w", err)
-	}
 	findings, err := scanPackageTargetFindings(repoRoot, moves.Moves)
 	if err != nil {
 		return err
+	}
+	if err := validateOpenMoveLedgerSchema(repoRoot, moves); err != nil {
+		writePackageTargetObservationCounts(stderr, findings)
+		writePackageTargetTestOnlyObservations(stderr, findings)
+		writePackageTargetViolationCountsForFindings(stderr, packageTargetProductionRows(findings), findings)
+		return fmt.Errorf("[agent-factory:package-target-manifest] %w", err)
 	}
 	productionStale := packageTargetProductionStaleRows(moves.Moves, findings)
 	if len(productionStale) > 0 {

--- a/cmd/packagetargetmanifestcheck/main.go
+++ b/cmd/packagetargetmanifestcheck/main.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type config struct {
@@ -36,19 +37,45 @@ func main() {
 	}
 }
 
-func run(cfg config, stdout, _ io.Writer) error {
+func run(cfg config, stdout, stderr io.Writer) error {
 	repoRoot, err := filepath.Abs(cfg.root)
 	if err != nil {
 		return fmt.Errorf("resolve repository root: %w", err)
 	}
-	movesFile := resolveRepoPath(repoRoot, cfg.movesPath)
+	movesPath := cfg.movesPath
+	if movesPath == "" {
+		movesPath = unfinishedMovesRelativePath
+	}
+	movesFile := resolveRepoPath(repoRoot, movesPath)
 	moves, err := loadUnfinishedMoves(movesFile)
 	if err != nil {
 		return err
 	}
-	if err := validateOpenMoveLedger(repoRoot, moves); err != nil {
+	if err := validateOpenMoveLedgerSchema(repoRoot, moves); err != nil {
 		return fmt.Errorf("[agent-factory:package-target-manifest] %w", err)
 	}
+	findings, err := scanPackageTargetFindings(repoRoot, moves.Moves)
+	if err != nil {
+		return err
+	}
+	productionStale := packageTargetProductionStaleRows(moves.Moves, findings)
+	if len(productionStale) > 0 {
+		writePackageTargetObservationCounts(stderr, findings)
+		writePackageTargetTestOnlyObservations(stderr, findings)
+		writePackageTargetViolationCountsForFindings(stderr, productionStale, findings)
+		for _, row := range productionStale {
+			writeStaleProductionPackageTargetRow(stderr, row)
+		}
+		return fmt.Errorf(
+			"[agent-factory:package-target-manifest] found %d stale production row(s) [%s]\nLINT_VIOLATION_COUNT: %d",
+			len(productionStale),
+			strings.Join(packageTargetStaleRowPaths(productionStale), ", "),
+			len(productionStale),
+		)
+	}
+	writePackageTargetObservationCounts(stdout, findings)
+	writePackageTargetTestOnlyObservations(stdout, findings)
+	writePackageTargetViolationCountsForFindings(stdout, productionStale, findings)
 	fmt.Fprintf(
 		stdout,
 		"[agent-factory:package-target-manifest] all %d open migration row(s) hold the closed destination vocabulary and name live packages (%s)\n",

--- a/cmd/packagetargetmanifestcheck/manifest.go
+++ b/cmd/packagetargetmanifestcheck/manifest.go
@@ -100,6 +100,16 @@ func loadUnfinishedMoves(path string) (UnfinishedMoves, error) {
 // validateOpenMoveLedger checks the consolidated open-move ledger's schema and
 // that every remaining row still names a package that exists on disk.
 func validateOpenMoveLedger(repoRoot string, moves UnfinishedMoves) error {
+	if err := validateOpenMoveLedgerSchema(repoRoot, moves); err != nil {
+		return err
+	}
+	return validateRowsNamePackagesThatExist(repoRoot, moves.Moves)
+}
+
+// validateOpenMoveLedgerSchema keeps schema and destination validation separate
+// from source liveness. The package-target command needs to report classified
+// source observations before it applies the existing production failure path.
+func validateOpenMoveLedgerSchema(repoRoot string, moves UnfinishedMoves) error {
 	vocabulary, err := derivedDestinationVocabulary(repoRoot)
 	if err != nil {
 		return err
@@ -107,7 +117,7 @@ func validateOpenMoveLedger(repoRoot string, moves UnfinishedMoves) error {
 	if err := validateUnfinishedMovesSchema(moves, vocabulary); err != nil {
 		return err
 	}
-	return validateRowsNamePackagesThatExist(repoRoot, moves.Moves)
+	return nil
 }
 
 func validateUnfinishedMovesSchema(moves UnfinishedMoves, vocabulary DestinationVocabulary) error {

--- a/cmd/packagetargetmanifestcheck/source_classification.go
+++ b/cmd/packagetargetmanifestcheck/source_classification.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// packageTargetSourceClass identifies the kind of Go source that makes an
+// unfinished package-target row observable. Keeping the class on the finding
+// prevents test-only evidence from being folded into production counts.
+type packageTargetSourceClass string
+
+const (
+	packageTargetProductionSourceClass packageTargetSourceClass = "production"
+	packageTargetTestOnlySourceClass   packageTargetSourceClass = "test-only"
+)
+
+type packageTargetFinding struct {
+	PackagePath string
+	Destination string
+	Successor   string
+	Class       packageTargetSourceClass
+}
+
+// packageTargetSourceClasses examines direct Go files in one package
+// directory. Nested directories are separate packages and remain represented
+// by their own move rows. Classification happens while the directory is being
+// discovered, before any production-only view can discard _test.go files.
+func packageTargetSourceClasses(repoRoot, packagePath string) (map[packageTargetSourceClass]struct{}, error) {
+	if strings.Contains(packagePath, "\\") {
+		return nil, fmt.Errorf("package path %q must use slash separators", packagePath)
+	}
+	if !strings.HasPrefix(packagePath, "pkg/") {
+		return nil, fmt.Errorf("package path %q must be repository-relative under pkg/", packagePath)
+	}
+
+	classes := map[packageTargetSourceClass]struct{}{}
+	directory := filepath.Join(repoRoot, filepath.FromSlash(packagePath))
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return classes, nil
+		}
+		return nil, fmt.Errorf("read package-target source directory %s: %w", packagePath, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") {
+			continue
+		}
+		if strings.HasSuffix(entry.Name(), "_test.go") {
+			classes[packageTargetTestOnlySourceClass] = struct{}{}
+			continue
+		}
+		classes[packageTargetProductionSourceClass] = struct{}{}
+	}
+	return classes, nil
+}
+
+// scanPackageTargetFindings observes only package paths named by the
+// unfinished-move ledger. This preserves the ledger's deletion-only role while
+// making both source classes visible for each relevant package-target edge.
+func scanPackageTargetFindings(repoRoot string, moves []PackageMapping) ([]packageTargetFinding, error) {
+	findings := make([]packageTargetFinding, 0, len(moves)*2)
+	for _, row := range moves {
+		classes, err := packageTargetSourceClasses(repoRoot, row.PackagePath)
+		if err != nil {
+			return nil, err
+		}
+		for class := range classes {
+			findings = append(findings, packageTargetFinding{
+				PackagePath: row.PackagePath,
+				Destination: row.Destination,
+				Successor:   row.Successor,
+				Class:       class,
+			})
+		}
+	}
+	slices.SortFunc(findings, comparePackageTargetFindings)
+	return findings, nil
+}
+
+func comparePackageTargetFindings(left, right packageTargetFinding) int {
+	if comparison := strings.Compare(left.PackagePath, right.PackagePath); comparison != 0 {
+		return comparison
+	}
+	if comparison := strings.Compare(left.Destination, right.Destination); comparison != 0 {
+		return comparison
+	}
+	if comparison := strings.Compare(left.Successor, right.Successor); comparison != 0 {
+		return comparison
+	}
+	return strings.Compare(string(left.Class), string(right.Class))
+}
+
+func packageTargetFindingKey(finding packageTargetFinding) string {
+	return strings.Join([]string{
+		filepath.ToSlash(finding.PackagePath),
+		finding.Destination,
+		finding.Successor,
+		string(finding.Class),
+	}, "\x00")
+}
+
+func hasPackageTargetClass(findings []packageTargetFinding, packagePath string, class packageTargetSourceClass) bool {
+	for _, finding := range findings {
+		if finding.PackagePath == packagePath && finding.Class == class {
+			return true
+		}
+	}
+	return false
+}
+
+// packageTargetProductionStaleRows retains the existing blocking path for a
+// move row whose package directory has disappeared. A visible test-only source
+// is reported separately and is intentionally non-blocking; it does not turn
+// into a production finding or a baseline entry.
+func packageTargetProductionStaleRows(moves []PackageMapping, findings []packageTargetFinding) []PackageMapping {
+	stale := make([]PackageMapping, 0)
+	for _, row := range moves {
+		if hasPackageTargetClass(findings, row.PackagePath, packageTargetProductionSourceClass) ||
+			hasPackageTargetClass(findings, row.PackagePath, packageTargetTestOnlySourceClass) {
+			continue
+		}
+		stale = append(stale, row)
+	}
+	slices.SortFunc(stale, func(left, right PackageMapping) int {
+		return strings.Compare(packageTargetRowKey(left), packageTargetRowKey(right))
+	})
+	return stale
+}
+
+func packageTargetRowKey(row PackageMapping) string {
+	return strings.Join([]string{row.PackagePath, row.Destination, row.Successor}, "\x00")
+}
+
+func packageTargetStaleRowPaths(rows []PackageMapping) []string {
+	paths := make([]string, 0, len(rows))
+	for _, row := range rows {
+		paths = append(paths, row.PackagePath)
+	}
+	return paths
+}
+
+func writePackageTargetObservationCounts(writer io.Writer, findings []packageTargetFinding) {
+	production, testOnly := 0, 0
+	for _, finding := range findings {
+		switch finding.Class {
+		case packageTargetProductionSourceClass:
+			production++
+		case packageTargetTestOnlySourceClass:
+			testOnly++
+		}
+	}
+	fmt.Fprintf(writer, "[agent-factory:package-target-manifest] package-target observations: production=%d test-only=%d\n", production, testOnly)
+}
+
+func writePackageTargetViolationCountsForFindings(writer io.Writer, productionStale []PackageMapping, findings []packageTargetFinding) {
+	testOnly := 0
+	for _, finding := range findings {
+		if finding.Class == packageTargetTestOnlySourceClass {
+			testOnly++
+		}
+	}
+	fmt.Fprintf(
+		writer,
+		"[agent-factory:package-target-manifest] dependency violation counts: production=%d test-only=%d\n",
+		len(productionStale),
+		testOnly,
+	)
+}
+
+func writePackageTargetTestOnlyObservations(writer io.Writer, findings []packageTargetFinding) {
+	for _, finding := range findings {
+		if finding.Class != packageTargetTestOnlySourceClass {
+			continue
+		}
+		fmt.Fprintf(
+			writer,
+			"[agent-factory:package-target-manifest] test-only observation: %s -> %s (successor %s) [class=%s]\n",
+			finding.PackagePath,
+			finding.Destination,
+			finding.Successor,
+			finding.Class,
+		)
+	}
+}
+
+func writeStaleProductionPackageTargetRow(writer io.Writer, row PackageMapping) {
+	fmt.Fprintf(
+		writer,
+		"[agent-factory:package-target-manifest] stale production package-target row: %s -> %s (successor %s) [class=production]\n",
+		row.PackagePath,
+		row.Destination,
+		row.Successor,
+	)
+}

--- a/cmd/packagetargetmanifestcheck/source_classification.go
+++ b/cmd/packagetargetmanifestcheck/source_classification.go
@@ -133,6 +133,21 @@ func packageTargetProductionStaleRows(moves []PackageMapping, findings []package
 	return stale
 }
 
+func packageTargetProductionRows(findings []packageTargetFinding) []PackageMapping {
+	rows := make([]PackageMapping, 0, len(findings))
+	for _, finding := range findings {
+		if finding.Class != packageTargetProductionSourceClass {
+			continue
+		}
+		rows = append(rows, PackageMapping{
+			PackagePath: finding.PackagePath,
+			Destination: finding.Destination,
+			Successor:   finding.Successor,
+		})
+	}
+	return rows
+}
+
 func packageTargetRowKey(row PackageMapping) string {
 	return strings.Join([]string{row.PackagePath, row.Destination, row.Successor}, "\x00")
 }

--- a/cmd/packagetargetmanifestcheck/source_classification_test.go
+++ b/cmd/packagetargetmanifestcheck/source_classification_test.go
@@ -23,8 +23,9 @@ func TestRunClassifiesPackageTargetEdgesBySourceClass(t *testing.T) {
 		{
 			name:       "production-only",
 			production: true,
+			wantErr:    true,
 			counts:     "package-target observations: production=1 test-only=0",
-			violations: "dependency violation counts: production=0 test-only=0",
+			violations: "dependency violation counts: production=1 test-only=0",
 		},
 		{
 			name:       "test-only",
@@ -37,8 +38,9 @@ func TestRunClassifiesPackageTargetEdgesBySourceClass(t *testing.T) {
 			name:       "mixed",
 			production: true,
 			testOnly:   true,
+			wantErr:    true,
 			counts:     "package-target observations: production=1 test-only=1",
-			violations: "dependency violation counts: production=0 test-only=1",
+			violations: "dependency violation counts: production=1 test-only=1",
 		},
 	}
 
@@ -51,18 +53,32 @@ func TestRunClassifiesPackageTargetEdgesBySourceClass(t *testing.T) {
 				writeGoPackage(t, root, "pkg/services/work/edge", "package edge\n")
 			}
 			if test.testOnly {
-				writeGoPackage(t, root, "pkg/services/work/edge", "package edge_test\n", "edge_test.go")
+				writeGoPackage(t, root, "pkg/services/work/testedge", "package testedge_test\n", "testedge_test.go")
 			}
-			writeFixtureMoveLedger(t, root, []PackageMapping{{
-				PackagePath: "pkg/services/work/edge",
-				Destination: "work/internal",
-				Successor:   "pkg/services/work/internal",
-			}})
+			rows := make([]PackageMapping, 0, 2)
+			if test.production {
+				rows = append(rows, PackageMapping{
+					PackagePath: "pkg/services/work/edge",
+					Destination: "work/not-a-closed-destination",
+					Successor:   "pkg/services/work/not-a-closed-destination",
+				})
+			}
+			if test.testOnly {
+				rows = append(rows, PackageMapping{
+					PackagePath: "pkg/services/work/testedge",
+					Destination: "work/internal",
+					Successor:   "pkg/services/work/internal",
+				})
+			}
+			writeFixtureMoveLedger(t, root, rows)
 
 			var stdout, stderr bytes.Buffer
 			err := run(config{root: root}, &stdout, &stderr)
 			if (err != nil) != test.wantErr {
 				t.Fatalf("run() error = %v, wantErr=%t; stdout=%q stderr=%q", err, test.wantErr, stdout.String(), stderr.String())
+			}
+			if test.wantErr && (err == nil || !strings.Contains(err.Error(), "not-a-closed-destination")) {
+				t.Fatalf("run() error = %v, want the production migration gate to reject the closed-destination violation", err)
 			}
 			output := stdout.String() + stderr.String()
 			for _, want := range []string{test.counts, test.violations} {

--- a/cmd/packagetargetmanifestcheck/source_classification_test.go
+++ b/cmd/packagetargetmanifestcheck/source_classification_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunClassifiesPackageTargetEdgesBySourceClass(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		production bool
+		testOnly   bool
+		wantErr    bool
+		counts     string
+		violations string
+		classes    []string
+	}{
+		{
+			name:       "production-only",
+			production: true,
+			counts:     "package-target observations: production=1 test-only=0",
+			violations: "dependency violation counts: production=0 test-only=0",
+		},
+		{
+			name:       "test-only",
+			testOnly:   true,
+			counts:     "package-target observations: production=0 test-only=1",
+			violations: "dependency violation counts: production=0 test-only=1",
+			classes:    []string{"[class=test-only]"},
+		},
+		{
+			name:       "mixed",
+			production: true,
+			testOnly:   true,
+			counts:     "package-target observations: production=1 test-only=1",
+			violations: "dependency violation counts: production=0 test-only=1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeGoPackage(t, root, "pkg/services/work", "package work\n")
+			if test.production {
+				writeGoPackage(t, root, "pkg/services/work/edge", "package edge\n")
+			}
+			if test.testOnly {
+				writeGoPackage(t, root, "pkg/services/work/edge", "package edge_test\n", "edge_test.go")
+			}
+			writeFixtureMoveLedger(t, root, []PackageMapping{{
+				PackagePath: "pkg/services/work/edge",
+				Destination: "work/internal",
+				Successor:   "pkg/services/work/internal",
+			}})
+
+			var stdout, stderr bytes.Buffer
+			err := run(config{root: root}, &stdout, &stderr)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("run() error = %v, wantErr=%t; stdout=%q stderr=%q", err, test.wantErr, stdout.String(), stderr.String())
+			}
+			output := stdout.String() + stderr.String()
+			for _, want := range []string{test.counts, test.violations} {
+				if !strings.Contains(output, want) {
+					t.Fatalf("run() output = %q, want %q", output, want)
+				}
+			}
+			for _, class := range test.classes {
+				if !strings.Contains(output, class) {
+					t.Fatalf("run() output = %q, want class %q", output, class)
+				}
+			}
+			if test.name == "test-only" && err != nil {
+				t.Fatalf("test-only observation entered the blocking path: %v; stderr=%q", err, stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunBlocksStaleProductionRowsWithoutBlockingTestOnlyObservations(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeGoPackage(t, root, "pkg/services/work", "package work\n")
+	writeGoPackage(t, root, "pkg/services/work/onlytest", "package onlytest_test\n", "onlytest_test.go")
+	writeFixtureMoveLedger(t, root, []PackageMapping{
+		{
+			PackagePath: "pkg/services/work/missing",
+			Destination: "work/internal",
+			Successor:   "pkg/services/work/internal",
+		},
+		{
+			PackagePath: "pkg/services/work/onlytest",
+			Destination: "work/internal",
+			Successor:   "pkg/services/work/internal",
+		},
+	})
+
+	var stdout, stderr bytes.Buffer
+	err := run(config{root: root}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("run() error = nil, want stale production row failure")
+	}
+	output := stdout.String() + stderr.String()
+	for _, want := range []string{
+		"package-target observations: production=0 test-only=1",
+		"dependency violation counts: production=1 test-only=1",
+		"test-only observation: pkg/services/work/onlytest -> work/internal (successor pkg/services/work/internal) [class=test-only]",
+		"stale production package-target row: pkg/services/work/missing -> work/internal (successor pkg/services/work/internal) [class=production]",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("run() output = %q, want %q", output, want)
+		}
+	}
+	if !strings.Contains(err.Error(), "LINT_VIOLATION_COUNT: 1") {
+		t.Fatalf("run() error = %v, want one production violation", err)
+	}
+	if strings.Contains(output, "test-only package-target baseline") {
+		t.Fatalf("run() output = %q, must not mention a test-only baseline", output)
+	}
+}
+
+func TestPackageTargetSourceClassDiscoveryRetainsBothClasses(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeGoPackage(t, root, "pkg/services/work/edge", "package edge\n")
+	writeGoPackage(t, root, "pkg/services/work/edge", "package edge_test\n", "edge_test.go")
+
+	classes, err := packageTargetSourceClasses(root, "pkg/services/work/edge")
+	if err != nil {
+		t.Fatalf("packageTargetSourceClasses() error = %v", err)
+	}
+	if _, ok := classes[packageTargetProductionSourceClass]; !ok {
+		t.Fatalf("classes = %#v, missing production", classes)
+	}
+	if _, ok := classes[packageTargetTestOnlySourceClass]; !ok {
+		t.Fatalf("classes = %#v, missing test-only", classes)
+	}
+}
+
+func TestPackageTargetFindingKeyIncludesSourceClass(t *testing.T) {
+	production := packageTargetFinding{
+		PackagePath: "pkg/services/work/edge",
+		Destination: "work/internal",
+		Successor:   "pkg/services/work/internal",
+		Class:       packageTargetProductionSourceClass,
+	}
+	testOnly := production
+	testOnly.Class = packageTargetTestOnlySourceClass
+	if packageTargetFindingKey(production) == packageTargetFindingKey(testOnly) {
+		t.Fatalf("package-target finding keys collapsed source classes: %q", packageTargetFindingKey(production))
+	}
+}
+
+func TestPackageTargetDoesNotCreateTestOnlyBaseline(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeGoPackage(t, root, "pkg/services/work", "package work\n")
+	writeGoPackage(t, root, "pkg/services/work/edge", "package edge_test\n", "edge_test.go")
+	writeFixtureMoveLedger(t, root, []PackageMapping{{
+		PackagePath: "pkg/services/work/edge",
+		Destination: "work/internal",
+		Successor:   "pkg/services/work/internal",
+	}})
+
+	var stdout, stderr bytes.Buffer
+	if err := run(config{root: root}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v; stderr=%s", err, stderr.String())
+	}
+	entries, err := os.ReadDir(filepath.Join(root, "docs", "internal", "baselines"))
+	if err != nil {
+		t.Fatalf("read baseline directory: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.Contains(entry.Name(), "test-only") {
+			t.Fatalf("run() created test-only baseline %q", entry.Name())
+		}
+	}
+}

--- a/cmd/pkgboundarycheck/converged_boundaries_test.go
+++ b/cmd/pkgboundarycheck/converged_boundaries_test.go
@@ -220,18 +220,20 @@ func TestRunRejectsUnrecordedCrossOwnerTestServiceInternal(t *testing.T) {
 	)
 
 	stdout := &bytes.Buffer{}
-	err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, stdout, &bytes.Buffer{})
-	if err != nil {
-		t.Fatalf("run() error = %v, want test-only service import to remain non-blocking", err)
+	stderr := &bytes.Buffer{}
+	err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, stdout, stderr)
+	if err == nil {
+		t.Fatal("run() error = nil, want unrecorded test-only service import to remain blocking")
 	}
+	output := stdout.String() + stderr.String()
 	for _, want := range []string{
 		"prohibited test import of service internals",
 		"pkg/services/factory_sessions/internal/execution/runtimepersist",
 		"[class=test-only]",
 		"dependency violation counts: production=0 test-only=2",
 	} {
-		if !strings.Contains(stdout.String(), want) {
-			t.Fatalf("run() stdout = %q, want %q", stdout.String(), want)
+		if !strings.Contains(output, want) {
+			t.Fatalf("run() output = %q, want %q", output, want)
 		}
 	}
 }
@@ -293,10 +295,10 @@ func TestRunAllowsRecordedTestServiceInternalAndRejectsStaleEntry(t *testing.T) 
 		}
 		writeTestServiceImportBaseline(t, repoRoot, filePath, importPath, "factory_sessions")
 
-		stdout := &bytes.Buffer{}
-		err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, stdout, &bytes.Buffer{})
-		if err != nil || !strings.Contains(stdout.String(), "stale test service import baseline entry") {
-			t.Fatalf("run() = %v stdout=%q, want visible non-blocking stale test baseline", err, stdout.String())
+		stderr := &bytes.Buffer{}
+		err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, &bytes.Buffer{}, stderr)
+		if err == nil || !strings.Contains(stderr.String(), "stale test service import baseline entry") {
+			t.Fatalf("run() = %v stderr=%q, want blocking stale test baseline", err, stderr.String())
 		}
 	})
 }

--- a/cmd/pkgboundarycheck/converged_boundaries_test.go
+++ b/cmd/pkgboundarycheck/converged_boundaries_test.go
@@ -219,18 +219,19 @@ func TestRunRejectsUnrecordedCrossOwnerTestServiceInternal(t *testing.T) {
 		"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/execution/runtimepersist",
 	)
 
-	stderr := &bytes.Buffer{}
-	err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, &bytes.Buffer{}, stderr)
-	if err == nil {
-		t.Fatal("run() error = nil, want cross-owner test service import rejected")
+	stdout := &bytes.Buffer{}
+	err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, stdout, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("run() error = %v, want test-only service import to remain non-blocking", err)
 	}
 	for _, want := range []string{
 		"prohibited test import of service internals",
 		"pkg/services/factory_sessions/internal/execution/runtimepersist",
-		"use the service root contract",
+		"[class=test-only]",
+		"dependency violation counts: production=0 test-only=2",
 	} {
-		if !strings.Contains(stderr.String(), want) {
-			t.Fatalf("run() stderr = %q, want %q", stderr.String(), want)
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("run() stdout = %q, want %q", stdout.String(), want)
 		}
 	}
 }
@@ -292,10 +293,10 @@ func TestRunAllowsRecordedTestServiceInternalAndRejectsStaleEntry(t *testing.T) 
 		}
 		writeTestServiceImportBaseline(t, repoRoot, filePath, importPath, "factory_sessions")
 
-		stderr := &bytes.Buffer{}
-		err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, &bytes.Buffer{}, stderr)
-		if err == nil || !strings.Contains(stderr.String(), "stale test service import baseline entry") {
-			t.Fatalf("run() = %v stderr=%q, want stale test baseline failure", err, stderr.String())
+		stdout := &bytes.Buffer{}
+		err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, stdout, &bytes.Buffer{})
+		if err != nil || !strings.Contains(stdout.String(), "stale test service import baseline entry") {
+			t.Fatalf("run() = %v stdout=%q, want visible non-blocking stale test baseline", err, stdout.String())
 		}
 	})
 }
@@ -341,10 +342,10 @@ func TestRunRejectsRetiredExecutionTestHarnessPackageAndImport(t *testing.T) {
 		repoRoot := t.TempDir()
 		writeGoImportFile(t, repoRoot, "pkg/wire/session_test.go", "wire", importPath)
 
-		stderr := &bytes.Buffer{}
-		err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, &bytes.Buffer{}, stderr)
-		if err == nil || !strings.Contains(stderr.String(), "prohibited retired package import: "+importPath) {
-			t.Fatalf("run() = %v stderr=%q, want retired package import rejected", err, stderr.String())
+		stdout := &bytes.Buffer{}
+		err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, stdout, &bytes.Buffer{})
+		if err != nil || !strings.Contains(stdout.String(), "prohibited retired package import: "+importPath) || !strings.Contains(stdout.String(), "[class=test-only]") {
+			t.Fatalf("run() = %v stdout=%q, want visible non-blocking test-only retired import", err, stdout.String())
 		}
 	})
 }

--- a/cmd/pkgboundarycheck/main.go
+++ b/cmd/pkgboundarycheck/main.go
@@ -676,7 +676,16 @@ func runWithPolicy(cfg config, policy boundaryPolicy, stdout io.Writer, stderr i
 }
 
 func countBlockingViolations(findings scanResult) int {
-	count := len(findings.rootPackageFindings) +
+	return countAlwaysBlockingViolations(findings) +
+		countProductionBoundaryViolations(findings) +
+		// Test-service imports are an intentional test-specific policy. They
+		// remain blocking even though their source class is test-only.
+		len(findings.testServiceImportFindings) +
+		len(findings.staleTestServiceBaselineEntries)
+}
+
+func countAlwaysBlockingViolations(findings scanResult) int {
+	return len(findings.rootPackageFindings) +
 		len(findings.retiredPackageRootFindings) +
 		len(findings.migrationShimFindings) +
 		len(findings.handwrittenGeneratedFindings) +
@@ -688,10 +697,20 @@ func countBlockingViolations(findings scanResult) int {
 		len(findings.productionDefaultFindings) +
 		len(findings.staleProductionDefaultEntries) +
 		len(findings.initializerBehaviorFindings) +
-		len(findings.staleInitializerBehaviorEntries)
-	count += len(findings.testBehaviorFindings) + len(findings.staleTestBehaviorEntries)
-	count += len(findings.petriPublicSurfaceFindings) + len(findings.stalePetriPublicSurfaceEntries)
-	count += len(findings.providerEffectOwnershipFindings)
+		len(findings.staleInitializerBehaviorEntries) +
+		len(findings.testBehaviorFindings) +
+		len(findings.staleTestBehaviorEntries) +
+		len(findings.petriPublicSurfaceFindings) +
+		len(findings.stalePetriPublicSurfaceEntries) +
+		len(findings.providerEffectOwnershipFindings)
+}
+
+func countProductionBoundaryViolations(findings scanResult) int {
+	return countProductionBoundaryImports(findings) + countProductionBoundaryBaselines(findings)
+}
+
+func countProductionBoundaryImports(findings scanResult) int {
+	count := 0
 	count += countProductionBoundaryFindings(
 		findings.retiredPackageImportFindings,
 		func(finding retiredPackageImportFinding) boundarySourceClass { return finding.class },
@@ -713,11 +732,6 @@ func countBlockingViolations(findings scanResult) int {
 		func(finding peerServiceImportFinding) string { return finding.filePath },
 	)
 	count += countProductionBoundaryFindings(
-		findings.testServiceImportFindings,
-		func(finding testServiceImportFinding) boundarySourceClass { return finding.class },
-		func(finding testServiceImportFinding) string { return finding.filePath },
-	)
-	count += countProductionBoundaryFindings(
 		findings.supportServiceImportFindings,
 		func(finding supportServiceImportFinding) boundarySourceClass { return finding.class },
 		func(finding supportServiceImportFinding) string { return finding.filePath },
@@ -737,6 +751,11 @@ func countBlockingViolations(findings scanResult) int {
 		func(finding transportServiceImplementationFinding) boundarySourceClass { return finding.class },
 		func(finding transportServiceImplementationFinding) string { return finding.filePath },
 	)
+	return count
+}
+
+func countProductionBoundaryBaselines(findings scanResult) int {
+	count := 0
 	count += countProductionBoundaryFindings(
 		findings.stalePeerServiceBaselineEntries,
 		func(entry peerServiceImportBaselineEntry) boundarySourceClass {
@@ -744,14 +763,6 @@ func countBlockingViolations(findings scanResult) int {
 			return class
 		},
 		func(entry peerServiceImportBaselineEntry) string { return entry.FilePath },
-	)
-	count += countProductionBoundaryFindings(
-		findings.staleTestServiceBaselineEntries,
-		func(entry testServiceImportBaselineEntry) boundarySourceClass {
-			class, _ := sourceClassFromBaseline(entry.Class, entry.FilePath)
-			return class
-		},
-		func(entry testServiceImportBaselineEntry) string { return entry.FilePath },
 	)
 	count += countProductionBoundaryFindings(
 		findings.staleSupportServiceBaselineEntries,

--- a/cmd/pkgboundarycheck/main.go
+++ b/cmd/pkgboundarycheck/main.go
@@ -419,6 +419,7 @@ type retiredPackageImportFinding struct {
 	retiredPackageRoot
 	importPath string
 	filePath   string
+	class      boundarySourceClass
 }
 
 type handwrittenGeneratedFinding struct {
@@ -439,12 +440,14 @@ type migrationShimFinding struct {
 type applicationGraphImportFinding struct {
 	packagePath string
 	filePath    string
+	class       boundarySourceClass
 }
 
 type domainTransportImportFinding struct {
 	packagePath string
 	importPath  string
 	filePath    string
+	class       boundarySourceClass
 }
 
 type peerServiceImportFinding struct {
@@ -452,6 +455,7 @@ type peerServiceImportFinding struct {
 	peer       string
 	importPath string
 	filePath   string
+	class      boundarySourceClass
 }
 
 type peerServiceImportBaseline struct {
@@ -465,6 +469,7 @@ type peerServiceImportBaselineEntry struct {
 	ImportPath   string `json:"importPath"`
 	FilePath     string `json:"filePath"`
 	TargetRoot   string `json:"targetRoot"`
+	Class        string `json:"class,omitempty"`
 	Stage        string `json:"stage"`
 	DeletionGate string `json:"deletionGate"`
 }
@@ -472,12 +477,14 @@ type peerServiceImportBaselineEntry struct {
 type transportServiceImplementationFinding struct {
 	importPath string
 	filePath   string
+	class      boundarySourceClass
 }
 
 type testServiceImportFinding struct {
 	owner      string
 	importPath string
 	filePath   string
+	class      boundarySourceClass
 }
 
 type testServiceImportBaseline struct {
@@ -490,6 +497,7 @@ type testServiceImportBaselineEntry struct {
 	ImportPath   string `json:"importPath"`
 	FilePath     string `json:"filePath"`
 	TargetRoot   string `json:"targetRoot"`
+	Class        string `json:"class,omitempty"`
 	Stage        string `json:"stage"`
 	DeletionGate string `json:"deletionGate"`
 }
@@ -501,6 +509,7 @@ type serviceConstructionFinding struct {
 	filePath   string
 	line       int
 	count      int
+	class      boundarySourceClass
 }
 
 type serviceConstructionBaseline struct {
@@ -514,6 +523,7 @@ type serviceConstructionBaselineEntry struct {
 	Symbol       string `json:"symbol"`
 	FilePath     string `json:"filePath"`
 	Count        int    `json:"count"`
+	Class        string `json:"class,omitempty"`
 	Stage        string `json:"stage"`
 	DeletionGate string `json:"deletionGate"`
 }
@@ -637,11 +647,16 @@ func runWithPolicy(cfg config, policy boundaryPolicy, stdout io.Writer, stderr i
 	}
 	visibleFindings, _ := filterRecordedScanResult(findings, baseline)
 	blockingViolationCount := countBlockingViolations(visibleFindings)
+	classifiedDependencyCounts := countClassifiedDependencyViolations(visibleFindings)
+	testOnlyFindings := testOnlyDependencyFindings(visibleFindings)
 	if blockingViolationCount == 0 {
 		if cfg.all {
 			writeBoundaryFindings(stdout, findings)
 			writeBaselineSummaries(stdout, findings)
+		} else {
+			writeBoundaryFindings(stdout, testOnlyFindings)
 		}
+		writeClassifiedDependencyViolationCounts(stdout, classifiedDependencyCounts)
 		fmt.Fprintln(stdout, "[agent-factory:pkg-boundary] package boundary passed (no blocking package-boundary violations)")
 		writeGeneratedCodeExceptionSummary(stdout, policy)
 		return nil
@@ -655,6 +670,7 @@ func runWithPolicy(cfg config, policy boundaryPolicy, stdout io.Writer, stderr i
 	if cfg.all {
 		writeBaselineSummaries(stderr, findings)
 	}
+	writeClassifiedDependencyViolationCounts(stderr, classifiedDependencyCounts)
 	writeGeneratedCodeExceptionSummary(stderr, policy)
 	return fmt.Errorf("[agent-factory:pkg-boundary] found %d package-boundary violation(s)", blockingViolationCount)
 }
@@ -662,21 +678,8 @@ func runWithPolicy(cfg config, policy boundaryPolicy, stdout io.Writer, stderr i
 func countBlockingViolations(findings scanResult) int {
 	count := len(findings.rootPackageFindings) +
 		len(findings.retiredPackageRootFindings) +
-		len(findings.retiredPackageImportFindings) +
 		len(findings.migrationShimFindings) +
-		len(findings.applicationGraphImportFindings) +
 		len(findings.handwrittenGeneratedFindings) +
-		len(findings.domainTransportFindings) +
-		len(findings.peerServiceImportFindings) +
-		len(findings.stalePeerServiceBaselineEntries) +
-		len(findings.testServiceImportFindings) +
-		len(findings.staleTestServiceBaselineEntries) +
-		len(findings.supportServiceImportFindings) +
-		len(findings.staleSupportServiceBaselineEntries) +
-		len(findings.serviceConstructionFindings) +
-		len(findings.staleServiceConstructionEntries) +
-		len(findings.transportImplementationFindings) +
-		len(findings.externalImplementationFindings) +
 		len(findings.transportBehaviorFindings) +
 		len(findings.staleTransportBehaviorEntries) +
 		len(findings.functionalProcessEdgeFindings) +
@@ -688,7 +691,85 @@ func countBlockingViolations(findings scanResult) int {
 		len(findings.staleInitializerBehaviorEntries)
 	count += len(findings.testBehaviorFindings) + len(findings.staleTestBehaviorEntries)
 	count += len(findings.petriPublicSurfaceFindings) + len(findings.stalePetriPublicSurfaceEntries)
-	return count + len(findings.providerEffectOwnershipFindings)
+	count += len(findings.providerEffectOwnershipFindings)
+	count += countProductionBoundaryFindings(
+		findings.retiredPackageImportFindings,
+		func(finding retiredPackageImportFinding) boundarySourceClass { return finding.class },
+		func(finding retiredPackageImportFinding) string { return finding.filePath },
+	)
+	count += countProductionBoundaryFindings(
+		findings.applicationGraphImportFindings,
+		func(finding applicationGraphImportFinding) boundarySourceClass { return finding.class },
+		func(finding applicationGraphImportFinding) string { return finding.filePath },
+	)
+	count += countProductionBoundaryFindings(
+		findings.domainTransportFindings,
+		func(finding domainTransportImportFinding) boundarySourceClass { return finding.class },
+		func(finding domainTransportImportFinding) string { return finding.filePath },
+	)
+	count += countProductionBoundaryFindings(
+		findings.peerServiceImportFindings,
+		func(finding peerServiceImportFinding) boundarySourceClass { return finding.class },
+		func(finding peerServiceImportFinding) string { return finding.filePath },
+	)
+	count += countProductionBoundaryFindings(
+		findings.testServiceImportFindings,
+		func(finding testServiceImportFinding) boundarySourceClass { return finding.class },
+		func(finding testServiceImportFinding) string { return finding.filePath },
+	)
+	count += countProductionBoundaryFindings(
+		findings.supportServiceImportFindings,
+		func(finding supportServiceImportFinding) boundarySourceClass { return finding.class },
+		func(finding supportServiceImportFinding) string { return finding.filePath },
+	)
+	count += countProductionBoundaryFindings(
+		findings.serviceConstructionFindings,
+		func(finding serviceConstructionFinding) boundarySourceClass { return finding.class },
+		func(finding serviceConstructionFinding) string { return finding.filePath },
+	)
+	count += countProductionBoundaryFindings(
+		findings.transportImplementationFindings,
+		func(finding transportServiceImplementationFinding) boundarySourceClass { return finding.class },
+		func(finding transportServiceImplementationFinding) string { return finding.filePath },
+	)
+	count += countProductionBoundaryFindings(
+		findings.externalImplementationFindings,
+		func(finding transportServiceImplementationFinding) boundarySourceClass { return finding.class },
+		func(finding transportServiceImplementationFinding) string { return finding.filePath },
+	)
+	count += countProductionBoundaryFindings(
+		findings.stalePeerServiceBaselineEntries,
+		func(entry peerServiceImportBaselineEntry) boundarySourceClass {
+			class, _ := sourceClassFromBaseline(entry.Class, entry.FilePath)
+			return class
+		},
+		func(entry peerServiceImportBaselineEntry) string { return entry.FilePath },
+	)
+	count += countProductionBoundaryFindings(
+		findings.staleTestServiceBaselineEntries,
+		func(entry testServiceImportBaselineEntry) boundarySourceClass {
+			class, _ := sourceClassFromBaseline(entry.Class, entry.FilePath)
+			return class
+		},
+		func(entry testServiceImportBaselineEntry) string { return entry.FilePath },
+	)
+	count += countProductionBoundaryFindings(
+		findings.staleSupportServiceBaselineEntries,
+		func(entry supportServiceImportBaselineEntry) boundarySourceClass {
+			class, _ := sourceClassFromBaseline(entry.Class, entry.FilePath)
+			return class
+		},
+		func(entry supportServiceImportBaselineEntry) string { return entry.FilePath },
+	)
+	count += countProductionBoundaryFindings(
+		findings.staleServiceConstructionEntries,
+		func(entry serviceConstructionBaselineEntry) boundarySourceClass {
+			class, _ := sourceClassFromBaseline(entry.Class, entry.FilePath)
+			return class
+		},
+		func(entry serviceConstructionBaselineEntry) string { return entry.FilePath },
+	)
+	return count
 }
 
 func writeBoundaryFindings(writer io.Writer, findings scanResult) {
@@ -857,7 +938,7 @@ func scanRepo(cfg config, policy boundaryPolicy) (scanResult, error) {
 		peerServiceFindings,
 		result.peerServiceImportFindings,
 		func(finding peerServiceImportFinding) string {
-			return peerServiceImportKey(finding.filePath, finding.importPath)
+			return peerServiceImportKey(finding.filePath, finding.importPath, finding.class)
 		},
 	)
 	result.peerServiceBaselineCount = len(peerServiceBaseline.Entries)
@@ -878,7 +959,7 @@ func scanRepo(cfg config, policy boundaryPolicy) (scanResult, error) {
 		testServiceFindings,
 		result.testServiceImportFindings,
 		func(finding testServiceImportFinding) string {
-			return testServiceImportKey(finding.filePath, finding.importPath)
+			return testServiceImportKey(finding.filePath, finding.importPath, finding.class)
 		},
 	)
 	result.testServiceBaselineCount = len(testServiceBaseline.Entries)
@@ -899,7 +980,7 @@ func scanRepo(cfg config, policy boundaryPolicy) (scanResult, error) {
 		supportServiceFindings,
 		result.supportServiceImportFindings,
 		func(finding supportServiceImportFinding) string {
-			return supportServiceImportKey(finding.filePath, finding.importPath)
+			return supportServiceImportKey(finding.filePath, finding.importPath, finding.class)
 		},
 	)
 	result.supportServiceBaselineCount = len(supportServiceBaseline.Entries)
@@ -920,7 +1001,7 @@ func scanRepo(cfg config, policy boundaryPolicy) (scanResult, error) {
 		serviceConstructionFindings,
 		result.serviceConstructionFindings,
 		func(finding serviceConstructionFinding) string {
-			return serviceConstructionKey(finding.filePath, finding.importPath, finding.symbol)
+			return serviceConstructionKey(finding.filePath, finding.importPath, finding.symbol, finding.class)
 		},
 	)
 	result.serviceConstructionBaselineCount = len(serviceConstructionBaseline.Entries)
@@ -1079,7 +1160,7 @@ func scanConvergedServiceSubpackageImports(repoRoot string) ([]transportServiceI
 		if shouldSkipRepositoryWalkDirectory(repoRoot, path, entry) {
 			return filepath.SkipDir
 		}
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" || strings.HasSuffix(entry.Name(), "_test.go") {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" {
 			return nil
 		}
 		filePath, err := filepath.Rel(repoRoot, path)
@@ -1090,6 +1171,9 @@ func scanConvergedServiceSubpackageImports(repoRoot string) ([]transportServiceI
 		content, err := os.ReadFile(path)
 		if err != nil {
 			return err
+		}
+		if bytesContainGeneratedMarker(content) {
+			return nil
 		}
 		parsedFile, err := parser.ParseFile(token.NewFileSet(), path, content, parser.ImportsOnly)
 		if err != nil {
@@ -1135,6 +1219,7 @@ func scanConvergedServiceSubpackageImports(repoRoot string) ([]transportServiceI
 				findings = append(findings, transportServiceImplementationFinding{
 					importPath: importPath,
 					filePath:   filePath,
+					class:      classifyBoundarySource(filePath),
 				})
 				break
 			}
@@ -1149,6 +1234,7 @@ func scanConvergedServiceSubpackageImports(repoRoot string) ([]transportServiceI
 			findings = append(findings, transportServiceImplementationFinding{
 				importPath: importPath,
 				filePath:   filePath,
+				class:      classifyBoundarySource(filePath),
 			})
 		}
 		return nil
@@ -1195,6 +1281,9 @@ func scanTestServiceSubpackageImports(repoRoot string) ([]testServiceImportFindi
 		if err != nil {
 			return err
 		}
+		if bytesContainGeneratedMarker(content) {
+			return nil
+		}
 		parsedFile, err := parser.ParseFile(token.NewFileSet(), path, content, parser.ImportsOnly)
 		if err != nil {
 			return err
@@ -1226,6 +1315,7 @@ func scanTestServiceSubpackageImports(repoRoot string) ([]testServiceImportFindi
 				owner:      importedOwner,
 				importPath: importPath,
 				filePath:   filePath,
+				class:      classifyBoundarySource(filePath),
 			}
 			findingsByKey[testServiceImportKey(filePath, importPath)] = finding
 		}
@@ -1281,7 +1371,14 @@ func partitionTestServiceImportFindings(
 		if err := validateTestServiceImportBaselineEntry(entry); err != nil {
 			return nil, nil, err
 		}
-		key := testServiceImportKey(entry.FilePath, entry.ImportPath)
+		class, err := sourceClassFromBaseline(entry.Class, entry.FilePath)
+		if err != nil || class != testOnlySourceClass {
+			if err != nil {
+				return nil, nil, err
+			}
+			return nil, nil, fmt.Errorf("test service import baseline entry %s -> %s class = %q, want %q", entry.FilePath, entry.ImportPath, class, testOnlySourceClass)
+		}
+		key := testServiceImportKey(entry.FilePath, entry.ImportPath, class)
 		if _, duplicate := baselineByKey[key]; duplicate {
 			return nil, nil, fmt.Errorf(
 				"duplicate test service import baseline entry: %s -> %s",
@@ -1295,7 +1392,7 @@ func partitionTestServiceImportFindings(
 	var blocking []testServiceImportFinding
 	seen := make(map[string]struct{}, len(findings))
 	for _, finding := range findings {
-		key := testServiceImportKey(finding.filePath, finding.importPath)
+		key := testServiceImportKey(finding.filePath, finding.importPath, finding.class)
 		seen[key] = struct{}{}
 		entry, recorded := baselineByKey[key]
 		if !recorded {
@@ -1340,6 +1437,13 @@ func validateTestServiceImportBaselineEntry(entry testServiceImportBaselineEntry
 		if strings.ContainsAny(value, "*?[]") {
 			return fmt.Errorf("test service import baseline entry must be exact and cannot contain wildcards: %#v", entry)
 		}
+	}
+	class, err := sourceClassFromBaseline(entry.Class, entry.FilePath)
+	if err != nil || class != testOnlySourceClass {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("test service import baseline entry %s -> %s class = %q, want %q", entry.FilePath, entry.ImportPath, class, testOnlySourceClass)
 	}
 	if entry.Stage != testServiceImportBaselineStage {
 		return fmt.Errorf(
@@ -1398,6 +1502,7 @@ func createTestServiceImportBaseline(cfg config) error {
 			ImportPath:   finding.importPath,
 			FilePath:     finding.filePath,
 			TargetRoot:   "pkg/services/" + finding.owner,
+			Class:        string(finding.class),
 			Stage:        testServiceImportBaselineStage,
 			DeletionGate: testServiceImportDeletionGate,
 		})
@@ -1427,8 +1532,12 @@ func createTestServiceImportBaseline(cfg config) error {
 	return nil
 }
 
-func testServiceImportKey(filePath, importPath string) string {
-	return filepath.ToSlash(filePath) + "\x00" + importPath
+func testServiceImportKey(filePath, importPath string, classes ...boundarySourceClass) string {
+	class := classifyBoundarySource(filePath)
+	if len(classes) > 0 {
+		class = effectiveBoundarySourceClass(classes[0], filePath)
+	}
+	return filepath.ToSlash(filePath) + "\x00" + string(class) + "\x00" + importPath
 }
 
 var repositoryBoundaryIgnoredDirectoryNames = map[string]struct{}{
@@ -1514,6 +1623,9 @@ func scanProductServiceConstruction(repoRoot string) ([]serviceConstructionFindi
 		if err != nil {
 			return err
 		}
+		if bytesContainGeneratedMarker(content) {
+			return nil
+		}
 		fset := token.NewFileSet()
 		parsedFile, err := parser.ParseFile(fset, path, content, 0)
 		if err != nil {
@@ -1565,7 +1677,8 @@ func scanProductServiceConstruction(repoRoot string) ([]serviceConstructionFindi
 			importsByName[name] = root
 		}
 		record := func(root importedServiceRoot, symbol string, position token.Pos) {
-			key := serviceConstructionKey(filePath, root.importPath, symbol)
+			class := classifyBoundarySource(filePath)
+			key := serviceConstructionKey(filePath, root.importPath, symbol, class)
 			finding := findingsByKey[key]
 			if finding.count == 0 {
 				finding = serviceConstructionFinding{
@@ -1574,6 +1687,7 @@ func scanProductServiceConstruction(repoRoot string) ([]serviceConstructionFindi
 					symbol:     symbol,
 					filePath:   filePath,
 					line:       fset.Position(position).Line,
+					class:      class,
 				}
 			}
 			finding.count++
@@ -1717,7 +1831,11 @@ func partitionServiceConstructionFindings(
 		if err := validateServiceConstructionBaselineEntry(entry); err != nil {
 			return nil, nil, err
 		}
-		key := serviceConstructionKey(entry.FilePath, entry.ImportPath, entry.Symbol)
+		class, err := sourceClassFromBaseline(entry.Class, entry.FilePath)
+		if err != nil {
+			return nil, nil, err
+		}
+		key := serviceConstructionKey(entry.FilePath, entry.ImportPath, entry.Symbol, class)
 		if _, duplicate := baselineByKey[key]; duplicate {
 			return nil, nil, fmt.Errorf("duplicate service construction baseline entry: %s -> %s.%s", entry.FilePath, entry.ImportPath, entry.Symbol)
 		}
@@ -1726,7 +1844,7 @@ func partitionServiceConstructionFindings(
 	var blocking []serviceConstructionFinding
 	seen := make(map[string]struct{}, len(findings))
 	for _, finding := range findings {
-		key := serviceConstructionKey(finding.filePath, finding.importPath, finding.symbol)
+		key := serviceConstructionKey(finding.filePath, finding.importPath, finding.symbol, finding.class)
 		seen[key] = struct{}{}
 		entry, recorded := baselineByKey[key]
 		if !recorded || entry.Count != finding.count {
@@ -1770,6 +1888,9 @@ func validateServiceConstructionBaselineEntry(entry serviceConstructionBaselineE
 			return fmt.Errorf("service construction baseline entry must be exact and cannot contain wildcards: %#v", entry)
 		}
 	}
+	if _, err := sourceClassFromBaseline(entry.Class, entry.FilePath); err != nil {
+		return err
+	}
 	wantOwner, servicePackage := serviceRootOwner(entry.ImportPath)
 	if !servicePackage {
 		repositoryPath := strings.TrimPrefix(entry.ImportPath, repositoryImportPrefix)
@@ -1790,8 +1911,12 @@ func validateServiceConstructionBaselineEntry(entry serviceConstructionBaselineE
 	return nil
 }
 
-func serviceConstructionKey(filePath, importPath, symbol string) string {
-	return filepath.ToSlash(filePath) + "\x00" + importPath + "\x00" + symbol
+func serviceConstructionKey(filePath, importPath, symbol string, classes ...boundarySourceClass) string {
+	class := classifyBoundarySource(filePath)
+	if len(classes) > 0 {
+		class = effectiveBoundarySourceClass(classes[0], filePath)
+	}
+	return filepath.ToSlash(filePath) + "\x00" + string(class) + "\x00" + importPath + "\x00" + symbol
 }
 
 func serviceRootOwner(importPath string) (string, bool) {
@@ -1896,14 +2021,17 @@ func scanTransportServiceImplementationImports(repoRoot string) ([]transportServ
 		if shouldSkipRepositoryWalkDirectory(repoRoot, path, entry) {
 			return filepath.SkipDir
 		}
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" || strings.HasSuffix(entry.Name(), "_test.go") {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" {
 			return nil
 		}
 		content, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
-		parsedFile, err := parser.ParseFile(token.NewFileSet(), path, content, parser.ImportsOnly)
+		if bytesContainGeneratedMarker(content) {
+			return nil
+		}
+		parsedFile, err := parser.ParseFile(token.NewFileSet(), path, content, parser.ImportsOnly|parser.ParseComments)
 		if err != nil {
 			return err
 		}
@@ -1923,6 +2051,7 @@ func scanTransportServiceImplementationImports(repoRoot string) ([]transportServ
 					findings = append(findings, transportServiceImplementationFinding{
 						importPath: importPath,
 						filePath:   filePath,
+						class:      classifyBoundarySource(filePath),
 					})
 					break
 				}
@@ -1955,7 +2084,7 @@ func scanPeerServiceImports(repoRoot string) ([]peerServiceImportFinding, error)
 		if shouldSkipRepositoryWalkDirectory(repoRoot, path, entry) {
 			return filepath.SkipDir
 		}
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" || strings.HasSuffix(entry.Name(), "_test.go") {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" {
 			return nil
 		}
 		filePath, err := filepath.Rel(repoRoot, path)
@@ -1972,7 +2101,10 @@ func scanPeerServiceImports(repoRoot string) ([]peerServiceImportFinding, error)
 		if err != nil {
 			return err
 		}
-		parsedFile, err := parser.ParseFile(token.NewFileSet(), path, content, parser.ImportsOnly)
+		if bytesContainGeneratedMarker(content) {
+			return nil
+		}
+		parsedFile, err := parser.ParseFile(token.NewFileSet(), path, content, parser.ImportsOnly|parser.ParseComments)
 		if err != nil {
 			return err
 		}
@@ -1995,6 +2127,7 @@ func scanPeerServiceImports(repoRoot string) ([]peerServiceImportFinding, error)
 			}
 			findings = append(findings, peerServiceImportFinding{
 				owner: owner, peer: serviceParts[0], importPath: importPath, filePath: filePath,
+				class: classifyBoundarySource(filePath),
 			})
 		}
 		return nil
@@ -2060,7 +2193,11 @@ func partitionPeerServiceImportFindings(
 		if err := validatePeerServiceImportBaselineEntry(entry); err != nil {
 			return nil, nil, fmt.Errorf("peer service import baseline entry %d: %w", index, err)
 		}
-		key := peerServiceImportKey(entry.FilePath, entry.ImportPath)
+		class, err := sourceClassFromBaseline(entry.Class, entry.FilePath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("peer service import baseline entry %d: %w", index, err)
+		}
+		key := peerServiceImportKey(entry.FilePath, entry.ImportPath, class)
 		if _, exists := baselineByKey[key]; exists {
 			return nil, nil, fmt.Errorf(
 				"peer service import baseline entry %d: duplicate file/import edge %s -> %s",
@@ -2075,7 +2212,7 @@ func partitionPeerServiceImportFindings(
 	remaining := make(map[string]struct{}, len(findings))
 	var violations []peerServiceImportFinding
 	for _, finding := range findings {
-		key := peerServiceImportKey(finding.filePath, finding.importPath)
+		key := peerServiceImportKey(finding.filePath, finding.importPath, finding.class)
 		entry, approved := baselineByKey[key]
 		if !approved {
 			violations = append(violations, finding)
@@ -2123,6 +2260,9 @@ func validatePeerServiceImportBaselineEntry(entry peerServiceImportBaselineEntry
 			return fmt.Errorf("%s must be exact and cannot contain wildcards", field)
 		}
 	}
+	if _, err := sourceClassFromBaseline(entry.Class, entry.FilePath); err != nil {
+		return err
+	}
 	if entry.Stage != peerServiceImportBaselineStage || entry.DeletionGate != peerServiceImportDeletionGate {
 		return fmt.Errorf("stage or deletionGate is not the recognized peer-service migration contract")
 	}
@@ -2144,8 +2284,12 @@ func validatePeerServiceImportBaselineEntry(entry peerServiceImportBaselineEntry
 	return nil
 }
 
-func peerServiceImportKey(filePath, importPath string) string {
-	return filepath.ToSlash(filePath) + "\x00" + importPath
+func peerServiceImportKey(filePath, importPath string, classes ...boundarySourceClass) string {
+	class := classifyBoundarySource(filePath)
+	if len(classes) > 0 {
+		class = effectiveBoundarySourceClass(classes[0], filePath)
+	}
+	return filepath.ToSlash(filePath) + "\x00" + string(class) + "\x00" + importPath
 }
 
 func scanDomainTransportImports(repoRoot string, exceptions []string) ([]domainTransportImportFinding, error) {
@@ -2166,7 +2310,7 @@ func scanDomainTransportImports(repoRoot string, exceptions []string) ([]domainT
 			if shouldSkipRepositoryWalkDirectory(repoRoot, path, entry) {
 				return filepath.SkipDir
 			}
-			if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" || strings.HasSuffix(entry.Name(), "_test.go") {
+			if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" {
 				return nil
 			}
 			filePath, err := filepath.Rel(repoRoot, path)
@@ -2184,6 +2328,9 @@ func scanDomainTransportImports(repoRoot string, exceptions []string) ([]domainT
 			if err != nil {
 				return err
 			}
+			if bytesContainGeneratedMarker(content) {
+				return nil
+			}
 			parsedFile, err := parser.ParseFile(token.NewFileSet(), path, content, parser.ImportsOnly)
 			if err != nil {
 				return fmt.Errorf("parse Factory package imports %s: %w", filePath, err)
@@ -2196,6 +2343,7 @@ func scanDomainTransportImports(repoRoot string, exceptions []string) ([]domainT
 						packagePath: packagePath,
 						importPath:  importPath,
 						filePath:    filePath,
+						class:       classifyBoundarySource(filePath),
 					})
 				}
 			}
@@ -2303,6 +2451,9 @@ func scanRetiredPackageImports(repoRoot string, scanRoot string, packageRoot str
 		if err != nil {
 			return fmt.Errorf("read package import file %s: %w", filepath.ToSlash(path), err)
 		}
+		if bytesContainGeneratedMarker(content) {
+			return nil
+		}
 		parsedFile, err := parser.ParseFile(token.NewFileSet(), path, content, parser.ImportsOnly)
 		if err != nil {
 			return fmt.Errorf("parse package imports %s: %w", filepath.ToSlash(path), err)
@@ -2326,6 +2477,7 @@ func scanRetiredPackageImports(repoRoot string, scanRoot string, packageRoot str
 					retiredPackageRoot: retiredRoot,
 					importPath:         importPath,
 					filePath:           filepath.ToSlash(filePath),
+					class:              classifyBoundarySource(filepath.ToSlash(filePath)),
 				})
 			}
 		}
@@ -2365,6 +2517,9 @@ func scanApplicationGraphImports(repoRoot string, scanRoot string, packageRoot s
 		if err != nil {
 			return fmt.Errorf("read package import file %s: %w", filepath.ToSlash(path), err)
 		}
+		if bytesContainGeneratedMarker(content) {
+			return nil
+		}
 		if !strings.Contains(string(content), applicationGraphImportPath) {
 			return nil
 		}
@@ -2393,6 +2548,7 @@ func scanApplicationGraphImports(repoRoot string, scanRoot string, packageRoot s
 		findings = append(findings, applicationGraphImportFinding{
 			packagePath: packagePath,
 			filePath:    filepath.ToSlash(filePath),
+			class:       classifyBoundarySource(filepath.ToSlash(filePath)),
 		})
 		return nil
 	})
@@ -2584,7 +2740,7 @@ func writeRetiredPackageRootFindings(writer io.Writer, findings []retiredPackage
 
 func writeRetiredPackageImportFindings(writer io.Writer, findings []retiredPackageImportFinding) {
 	for _, finding := range findings {
-		fmt.Fprintf(writer, "[agent-factory:pkg-boundary] prohibited retired package import: %s (%s)\n", finding.importPath, finding.filePath)
+		fmt.Fprintf(writer, "[agent-factory:pkg-boundary] prohibited retired package import: %s (%s) [class=%s]\n", finding.importPath, finding.filePath, effectiveBoundarySourceClass(finding.class, finding.filePath))
 		fmt.Fprintf(writer, "  canonical owner: %s\n", finding.canonicalOwner)
 		fmt.Fprintf(writer, "  remediation: import %s directly; do not recreate or depend on %s.\n", finding.canonicalOwner, finding.packagePath)
 	}
@@ -2617,7 +2773,7 @@ func writeMigrationShimBlockingFindings(writer io.Writer, findings []migrationSh
 
 func writeApplicationGraphImportFindings(writer io.Writer, findings []applicationGraphImportFinding) {
 	for _, finding := range findings {
-		fmt.Fprintf(writer, "[agent-factory:pkg-boundary] prohibited application composition import: %s (%s)\n", finding.packagePath, finding.filePath)
+		fmt.Fprintf(writer, "[agent-factory:pkg-boundary] prohibited application composition import: %s (%s) [class=%s]\n", finding.packagePath, finding.filePath, effectiveBoundarySourceClass(finding.class, finding.filePath))
 		fmt.Fprintln(writer, "  reason: pkg/wire is the outward application composition root and must not be imported by domain or transport packages.")
 		fmt.Fprintln(writer, "  remediation: depend on a narrow domain-owned contract and inject the collaborator through pkg/root or pkg/initializer.")
 	}
@@ -2625,7 +2781,7 @@ func writeApplicationGraphImportFindings(writer io.Writer, findings []applicatio
 
 func writeDomainTransportImportFindings(writer io.Writer, findings []domainTransportImportFinding) {
 	for _, finding := range findings {
-		fmt.Fprintf(writer, "[agent-factory:pkg-boundary] prohibited domain transport import: %s (%s)\n", finding.importPath, finding.filePath)
+		fmt.Fprintf(writer, "[agent-factory:pkg-boundary] prohibited domain transport import: %s (%s) [class=%s]\n", finding.importPath, finding.filePath, effectiveBoundarySourceClass(finding.class, finding.filePath))
 		fmt.Fprintf(writer, "  domain owner: %s\n", finding.packagePath)
 		fmt.Fprintln(writer, "  reason: protected domain packages must not consume transport contracts or adapters.")
 		fmt.Fprintln(writer, "  remediation: define the input at its domain owner and map generated values under pkg/transports/mapping.")
@@ -2634,7 +2790,7 @@ func writeDomainTransportImportFindings(writer io.Writer, findings []domainTrans
 
 func writePeerServiceImportFindings(writer io.Writer, findings []peerServiceImportFinding) {
 	for _, finding := range findings {
-		fmt.Fprintf(writer, "[agent-factory:pkg-boundary] prohibited peer service subpackage import: %s (%s)\n", finding.importPath, finding.filePath)
+		fmt.Fprintf(writer, "[agent-factory:pkg-boundary] prohibited peer service subpackage import: %s (%s) [class=%s]\n", finding.importPath, finding.filePath, effectiveBoundarySourceClass(finding.class, finding.filePath))
 		fmt.Fprintf(writer, "  service owner: pkg/services/%s; peer owner: pkg/services/%s\n", finding.owner, finding.peer)
 		fmt.Fprintf(writer, "  remediation: publish the required value or capability at pkg/services/%s and import only that peer root.\n", finding.peer)
 	}
@@ -2644,9 +2800,13 @@ func writeStalePeerServiceBaselineEntries(writer io.Writer, entries []peerServic
 	for _, entry := range entries {
 		fmt.Fprintf(
 			writer,
-			"[agent-factory:pkg-boundary] stale peer service import baseline entry: %s -> %s\n",
+			"[agent-factory:pkg-boundary] stale peer service import baseline entry: %s -> %s [class=%s]\n",
 			entry.FilePath,
 			entry.ImportPath,
+			func() boundarySourceClass {
+				class, _ := sourceClassFromBaseline(entry.Class, entry.FilePath)
+				return class
+			}(),
 		)
 		fmt.Fprintln(writer, "  reason: the recorded bypass edge no longer exists.")
 		fmt.Fprintln(writer, "  remediation: remove this entry from service-cross-import-baseline.json in the same change.")
@@ -2669,9 +2829,10 @@ func writeTestServiceImportFindings(writer io.Writer, findings []testServiceImpo
 	for _, finding := range findings {
 		fmt.Fprintf(
 			writer,
-			"[agent-factory:pkg-boundary] prohibited test import of service internals: %s (%s)\n",
+			"[agent-factory:pkg-boundary] prohibited test import of service internals: %s (%s) [class=%s]\n",
 			finding.importPath,
 			finding.filePath,
+			effectiveBoundarySourceClass(finding.class, finding.filePath),
 		)
 		fmt.Fprintf(writer, "  service owner: pkg/services/%s\n", finding.owner)
 		fmt.Fprintln(writer, "  remediation: use the service root contract, move the invariant to the owning service, or exercise cross-service behavior through root.BuildProcess.")
@@ -2682,9 +2843,13 @@ func writeStaleTestServiceBaselineEntries(writer io.Writer, entries []testServic
 	for _, entry := range entries {
 		fmt.Fprintf(
 			writer,
-			"[agent-factory:pkg-boundary] stale test service import baseline entry: %s -> %s\n",
+			"[agent-factory:pkg-boundary] stale test service import baseline entry: %s -> %s [class=%s]\n",
 			entry.FilePath,
 			entry.ImportPath,
+			func() boundarySourceClass {
+				class, _ := sourceClassFromBaseline(entry.Class, entry.FilePath)
+				return class
+			}(),
 		)
 		fmt.Fprintln(writer, "  reason: the concrete cross-owner test import no longer exists.")
 		fmt.Fprintf(writer, "  remediation: remove this entry from %s in the same change.\n", testServiceImportBaselinePath)
@@ -2707,12 +2872,13 @@ func writeServiceConstructionFindings(writer io.Writer, findings []serviceConstr
 	for _, finding := range findings {
 		fmt.Fprintf(
 			writer,
-			"[agent-factory:pkg-boundary] prohibited product-service construction: %s.%s (%s:%d, %d selection(s))\n",
+			"[agent-factory:pkg-boundary] prohibited product-service construction: %s.%s (%s:%d, %d selection(s), class=%s)\n",
 			finding.importPath,
 			finding.symbol,
 			finding.filePath,
 			finding.line,
 			finding.count,
+			effectiveBoundarySourceClass(finding.class, finding.filePath),
 		)
 		fmt.Fprintf(writer, "  service owner: pkg/services/%s\n", finding.owner)
 		fmt.Fprintln(writer, "  remediation: construct the collaborator in pkg/wire and inject its service-root role; owner-local invariants may construct it inside the owning service.")
@@ -2723,10 +2889,14 @@ func writeStaleServiceConstructionBaselineEntries(writer io.Writer, entries []se
 	for _, entry := range entries {
 		fmt.Fprintf(
 			writer,
-			"[agent-factory:pkg-boundary] stale service construction baseline entry: %s -> %s.%s\n",
+			"[agent-factory:pkg-boundary] stale service construction baseline entry: %s -> %s.%s [class=%s]\n",
 			entry.FilePath,
 			entry.ImportPath,
 			entry.Symbol,
+			func() boundarySourceClass {
+				class, _ := sourceClassFromBaseline(entry.Class, entry.FilePath)
+				return class
+			}(),
 		)
 		fmt.Fprintln(writer, "  reason: the recorded construction selection no longer exists.")
 		fmt.Fprintf(writer, "  remediation: remove this entry from %s in the same change.\n", serviceConstructionBaselinePath)
@@ -2747,7 +2917,7 @@ func writeServiceConstructionBaselineSummary(writer io.Writer, count int) {
 
 func writeTransportServiceImplementationFindings(writer io.Writer, findings []transportServiceImplementationFinding) {
 	for _, finding := range findings {
-		fmt.Fprintf(writer, "[agent-factory:pkg-boundary] prohibited transport service implementation import: %s (%s)\n", finding.importPath, finding.filePath)
+		fmt.Fprintf(writer, "[agent-factory:pkg-boundary] prohibited transport service implementation import: %s (%s) [class=%s]\n", finding.importPath, finding.filePath, effectiveBoundarySourceClass(finding.class, finding.filePath))
 		fmt.Fprintln(writer, "  reason: transports may consume only service root contracts or explicitly public service subservices.")
 		fmt.Fprintln(writer, "  remediation: publish the required capability at its service boundary and keep representation mapping in the transport.")
 	}
@@ -2755,7 +2925,7 @@ func writeTransportServiceImplementationFindings(writer io.Writer, findings []tr
 
 func writeExternalServiceImplementationFindings(writer io.Writer, findings []transportServiceImplementationFinding) {
 	for _, finding := range findings {
-		fmt.Fprintf(writer, "[agent-factory:pkg-boundary] prohibited external service subpackage import: %s (%s)\n", finding.importPath, finding.filePath)
+		fmt.Fprintf(writer, "[agent-factory:pkg-boundary] prohibited external service subpackage import: %s (%s) [class=%s]\n", finding.importPath, finding.filePath, effectiveBoundarySourceClass(finding.class, finding.filePath))
 		fmt.Fprintln(writer, "  reason: service subpackages are owner-internal for ordinary consumers; pkg/wire is the unrestricted composition-root exception.")
 		fmt.Fprintln(writer, "  remediation: import the exact pkg/services/<service-name> root and use its published contract.")
 	}

--- a/cmd/pkgboundarycheck/main_test.go
+++ b/cmd/pkgboundarycheck/main_test.go
@@ -299,18 +299,21 @@ func directImplementation() { hostedsources.New() }
 `)
 
 	stdout := &bytes.Buffer{}
-	err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, stdout, &bytes.Buffer{})
-	if err != nil {
-		t.Fatalf("run() error = %v, want test-only external-effect construction to remain non-blocking", err)
+	stderr := &bytes.Buffer{}
+	err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, stdout, stderr)
+	if err == nil {
+		t.Fatal("run() error = nil, want the unrecorded dedicated test-service import to remain blocking")
 	}
+	output := stdout.String() + stderr.String()
 	for _, want := range []string{
 		"prohibited product-service construction: github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources.New",
+		"prohibited test import of service internals: github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources",
 		"[class=test-only]",
 		"dependency violation counts: production=0 test-only=2",
 		"construct the collaborator in pkg/wire and inject its service-root role",
 	} {
-		if got := stdout.String(); !strings.Contains(got, want) {
-			t.Fatalf("run() stdout = %q, want substring %q", got, want)
+		if !strings.Contains(output, want) {
+			t.Fatalf("run() output = %q, want substring %q", output, want)
 		}
 	}
 }

--- a/cmd/pkgboundarycheck/main_test.go
+++ b/cmd/pkgboundarycheck/main_test.go
@@ -88,18 +88,19 @@ func TestRunRejectsApplicationGraphImportsFromTestsOutsidePackageRoot(t *testing
 	writeGoSourceFile(t, repoRoot, "pkg/root/root.go", "package root\n")
 	writeGoImportFile(t, repoRoot, "tests/stress/alternate_graph_test.go", "stress", applicationGraphImportPath)
 
-	stderr := &bytes.Buffer{}
-	err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, &bytes.Buffer{}, stderr)
-	if err == nil {
-		t.Fatal("run() error = nil, want alternate test injector rejected")
+	stdout := &bytes.Buffer{}
+	err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, stdout, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("run() error = %v, want test-only alternate injector to remain non-blocking", err)
 	}
 	for _, want := range []string{
 		"prohibited application composition import",
 		"tests/stress/alternate_graph_test.go",
-		"inject the collaborator through pkg/root",
+		"[class=test-only]",
+		"dependency violation counts: production=0 test-only=1",
 	} {
-		if !strings.Contains(stderr.String(), want) {
-			t.Fatalf("run() stderr = %q, want %q", stderr.String(), want)
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("run() stdout = %q, want %q", stdout.String(), want)
 		}
 	}
 }
@@ -246,8 +247,8 @@ func directSession() { _ = sessions.NewLiveSession("", "", nil, nil) }
 			t.Fatalf("run() stderr = %q, want substring %q", got, want)
 		}
 	}
-	if got := err.Error(); got != "[agent-factory:pkg-boundary] found 4 package-boundary violation(s)" {
-		t.Fatalf("run() error = %q, want four violations", got)
+	if got := err.Error(); got != "[agent-factory:pkg-boundary] found 3 package-boundary violation(s)" {
+		t.Fatalf("run() error = %q, want three production violations", got)
 	}
 }
 
@@ -297,17 +298,19 @@ import hostedsources "github.com/portpowered/infinite-you/pkg/services/automatio
 func directImplementation() { hostedsources.New() }
 `)
 
-	stderr := &bytes.Buffer{}
-	err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, &bytes.Buffer{}, stderr)
-	if err == nil {
-		t.Fatal("run() error = nil, want external-effect implementation construction rejected")
+	stdout := &bytes.Buffer{}
+	err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, stdout, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("run() error = %v, want test-only external-effect construction to remain non-blocking", err)
 	}
 	for _, want := range []string{
 		"prohibited product-service construction: github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources.New",
+		"[class=test-only]",
+		"dependency violation counts: production=0 test-only=2",
 		"construct the collaborator in pkg/wire and inject its service-root role",
 	} {
-		if got := stderr.String(); !strings.Contains(got, want) {
-			t.Fatalf("run() stderr = %q, want substring %q", got, want)
+		if got := stdout.String(); !strings.Contains(got, want) {
+			t.Fatalf("run() stdout = %q, want substring %q", got, want)
 		}
 	}
 }
@@ -1276,6 +1279,7 @@ func TestRunFailsForUnapprovedRootPackageFamily(t *testing.T) {
 		"[agent-factory:pkg-boundary] unapproved root package family: pkg/experimental",
 		"  reason: pkg/experimental is outside the approved package-family allowlist.",
 		"  remediation: move the code under an approved owner or deliberately update the allowlist with ownership rationale.",
+		"[agent-factory:pkg-boundary] dependency violation counts: production=0 test-only=0",
 		"[agent-factory:pkg-boundary] active generated-code exceptions: pkg/transports/http/client (root), pkg/transports/http/generated (root)",
 		"",
 	}, "\n")

--- a/cmd/pkgboundarycheck/source_classification.go
+++ b/cmd/pkgboundarycheck/source_classification.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// boundarySourceClass identifies the kind of Go source that produced a
+// dependency observation. Keep it on the finding so production and test-only
+// edges remain distinct even when they have the same target.
+type boundarySourceClass string
+
+const (
+	productionSourceClass boundarySourceClass = "production"
+	testOnlySourceClass   boundarySourceClass = "test-only"
+)
+
+func classifyBoundarySource(filePath string) boundarySourceClass {
+	if strings.HasSuffix(filePath, "_test.go") {
+		return testOnlySourceClass
+	}
+	return productionSourceClass
+}
+
+func (class boundarySourceClass) valid() bool {
+	return class == productionSourceClass || class == testOnlySourceClass
+}
+
+func effectiveBoundarySourceClass(class boundarySourceClass, filePath string) boundarySourceClass {
+	if class.valid() {
+		return class
+	}
+	return classifyBoundarySource(filePath)
+}
+
+// sourceClassFromBaseline keeps old exact production entries readable while
+// allowing new class-bearing entries to distinguish otherwise identical edges.
+// The source filename remains authoritative when a class is present.
+func sourceClassFromBaseline(value string, filePath string) (boundarySourceClass, error) {
+	expected := classifyBoundarySource(filePath)
+	if strings.TrimSpace(value) == "" {
+		return expected, nil
+	}
+	class := boundarySourceClass(value)
+	if !class.valid() {
+		return "", fmt.Errorf("baseline entry %s has invalid class %q", filePath, value)
+	}
+	if class != expected {
+		return "", fmt.Errorf("baseline entry %s class = %q, want %q", filePath, class, expected)
+	}
+	return class, nil
+}
+
+type classifiedDependencyViolationCounts struct {
+	production int
+	testOnly   int
+}
+
+func (counts *classifiedDependencyViolationCounts) add(class boundarySourceClass) {
+	switch class {
+	case productionSourceClass:
+		counts.production++
+	case testOnlySourceClass:
+		counts.testOnly++
+	}
+}
+
+func countClassifiedDependencyViolations(findings scanResult) classifiedDependencyViolationCounts {
+	var counts classifiedDependencyViolationCounts
+	for _, finding := range findings.retiredPackageImportFindings {
+		counts.add(effectiveBoundarySourceClass(finding.class, finding.filePath))
+	}
+	for _, finding := range findings.applicationGraphImportFindings {
+		counts.add(effectiveBoundarySourceClass(finding.class, finding.filePath))
+	}
+	for _, finding := range findings.domainTransportFindings {
+		counts.add(effectiveBoundarySourceClass(finding.class, finding.filePath))
+	}
+	for _, finding := range findings.peerServiceImportFindings {
+		counts.add(effectiveBoundarySourceClass(finding.class, finding.filePath))
+	}
+	for _, finding := range findings.testServiceImportFindings {
+		counts.add(effectiveBoundarySourceClass(finding.class, finding.filePath))
+	}
+	for _, finding := range findings.supportServiceImportFindings {
+		counts.add(effectiveBoundarySourceClass(finding.class, finding.filePath))
+	}
+	for _, finding := range findings.serviceConstructionFindings {
+		counts.add(effectiveBoundarySourceClass(finding.class, finding.filePath))
+	}
+	for _, finding := range findings.transportImplementationFindings {
+		counts.add(effectiveBoundarySourceClass(finding.class, finding.filePath))
+	}
+	for _, finding := range findings.externalImplementationFindings {
+		counts.add(effectiveBoundarySourceClass(finding.class, finding.filePath))
+	}
+	for _, entry := range findings.stalePeerServiceBaselineEntries {
+		class, err := sourceClassFromBaseline(entry.Class, entry.FilePath)
+		if err == nil {
+			counts.add(class)
+		}
+	}
+	for _, entry := range findings.staleTestServiceBaselineEntries {
+		class, err := sourceClassFromBaseline(entry.Class, entry.FilePath)
+		if err == nil {
+			counts.add(class)
+		}
+	}
+	for _, entry := range findings.staleSupportServiceBaselineEntries {
+		class, err := sourceClassFromBaseline(entry.Class, entry.FilePath)
+		if err == nil {
+			counts.add(class)
+		}
+	}
+	for _, entry := range findings.staleServiceConstructionEntries {
+		class, err := sourceClassFromBaseline(entry.Class, entry.FilePath)
+		if err == nil {
+			counts.add(class)
+		}
+	}
+	return counts
+}
+
+func writeClassifiedDependencyViolationCounts(writer io.Writer, counts classifiedDependencyViolationCounts) {
+	fmt.Fprintf(
+		writer,
+		"[agent-factory:pkg-boundary] dependency violation counts: production=%d test-only=%d\n",
+		counts.production,
+		counts.testOnly,
+	)
+}
+
+func countProductionBoundaryFindings[T any](findings []T, class func(T) boundarySourceClass, path func(T) string) int {
+	count := 0
+	for _, finding := range findings {
+		if effectiveBoundarySourceClass(class(finding), path(finding)) == productionSourceClass {
+			count++
+		}
+	}
+	return count
+}
+
+func testOnlyDependencyFindings(findings scanResult) scanResult {
+	result := scanResult{}
+	result.retiredPackageImportFindings = filterRetiredPackageImportsByClass(findings.retiredPackageImportFindings, testOnlySourceClass)
+	result.applicationGraphImportFindings = filterApplicationGraphImportsByClass(findings.applicationGraphImportFindings, testOnlySourceClass)
+	result.domainTransportFindings = filterDomainTransportFindingsByClass(findings.domainTransportFindings, testOnlySourceClass)
+	result.peerServiceImportFindings = filterPeerServiceImportsByClass(findings.peerServiceImportFindings, testOnlySourceClass)
+	result.testServiceImportFindings = filterTestServiceImportsByClass(findings.testServiceImportFindings, testOnlySourceClass)
+	result.supportServiceImportFindings = filterSupportServiceImportsByClass(findings.supportServiceImportFindings, testOnlySourceClass)
+	result.serviceConstructionFindings = filterServiceConstructionFindingsByClass(findings.serviceConstructionFindings, testOnlySourceClass)
+	result.transportImplementationFindings = filterTransportImplementationFindingsByClass(findings.transportImplementationFindings, testOnlySourceClass)
+	result.externalImplementationFindings = filterTransportImplementationFindingsByClass(findings.externalImplementationFindings, testOnlySourceClass)
+	result.stalePeerServiceBaselineEntries = filterPeerServiceBaselineEntriesByClass(findings.stalePeerServiceBaselineEntries, testOnlySourceClass)
+	result.staleTestServiceBaselineEntries = filterTestServiceBaselineEntriesByClass(findings.staleTestServiceBaselineEntries, testOnlySourceClass)
+	result.staleSupportServiceBaselineEntries = filterSupportServiceBaselineEntriesByClass(findings.staleSupportServiceBaselineEntries, testOnlySourceClass)
+	result.staleServiceConstructionEntries = filterServiceConstructionBaselineEntriesByClass(findings.staleServiceConstructionEntries, testOnlySourceClass)
+	return result
+}
+
+func filterRetiredPackageImportsByClass(findings []retiredPackageImportFinding, want boundarySourceClass) []retiredPackageImportFinding {
+	return filterByClass(findings, want, func(finding retiredPackageImportFinding) boundarySourceClass { return finding.class }, func(finding retiredPackageImportFinding) string { return finding.filePath })
+}
+
+func filterApplicationGraphImportsByClass(findings []applicationGraphImportFinding, want boundarySourceClass) []applicationGraphImportFinding {
+	return filterByClass(findings, want, func(finding applicationGraphImportFinding) boundarySourceClass { return finding.class }, func(finding applicationGraphImportFinding) string { return finding.filePath })
+}
+
+func filterDomainTransportFindingsByClass(findings []domainTransportImportFinding, want boundarySourceClass) []domainTransportImportFinding {
+	return filterByClass(findings, want, func(finding domainTransportImportFinding) boundarySourceClass { return finding.class }, func(finding domainTransportImportFinding) string { return finding.filePath })
+}
+
+func filterPeerServiceImportsByClass(findings []peerServiceImportFinding, want boundarySourceClass) []peerServiceImportFinding {
+	return filterByClass(findings, want, func(finding peerServiceImportFinding) boundarySourceClass { return finding.class }, func(finding peerServiceImportFinding) string { return finding.filePath })
+}
+
+func filterTestServiceImportsByClass(findings []testServiceImportFinding, want boundarySourceClass) []testServiceImportFinding {
+	return filterByClass(findings, want, func(finding testServiceImportFinding) boundarySourceClass { return finding.class }, func(finding testServiceImportFinding) string { return finding.filePath })
+}
+
+func filterSupportServiceImportsByClass(findings []supportServiceImportFinding, want boundarySourceClass) []supportServiceImportFinding {
+	return filterByClass(findings, want, func(finding supportServiceImportFinding) boundarySourceClass { return finding.class }, func(finding supportServiceImportFinding) string { return finding.filePath })
+}
+
+func filterServiceConstructionFindingsByClass(findings []serviceConstructionFinding, want boundarySourceClass) []serviceConstructionFinding {
+	return filterByClass(findings, want, func(finding serviceConstructionFinding) boundarySourceClass { return finding.class }, func(finding serviceConstructionFinding) string { return finding.filePath })
+}
+
+func filterTransportImplementationFindingsByClass(findings []transportServiceImplementationFinding, want boundarySourceClass) []transportServiceImplementationFinding {
+	return filterByClass(findings, want, func(finding transportServiceImplementationFinding) boundarySourceClass { return finding.class }, func(finding transportServiceImplementationFinding) string { return finding.filePath })
+}
+
+func filterPeerServiceBaselineEntriesByClass(findings []peerServiceImportBaselineEntry, want boundarySourceClass) []peerServiceImportBaselineEntry {
+	return filterByClass(findings, want, func(finding peerServiceImportBaselineEntry) boundarySourceClass {
+		class, _ := sourceClassFromBaseline(finding.Class, finding.FilePath)
+		return class
+	}, func(finding peerServiceImportBaselineEntry) string { return finding.FilePath })
+}
+
+func filterTestServiceBaselineEntriesByClass(findings []testServiceImportBaselineEntry, want boundarySourceClass) []testServiceImportBaselineEntry {
+	return filterByClass(findings, want, func(finding testServiceImportBaselineEntry) boundarySourceClass {
+		class, _ := sourceClassFromBaseline(finding.Class, finding.FilePath)
+		return class
+	}, func(finding testServiceImportBaselineEntry) string { return finding.FilePath })
+}
+
+func filterSupportServiceBaselineEntriesByClass(findings []supportServiceImportBaselineEntry, want boundarySourceClass) []supportServiceImportBaselineEntry {
+	return filterByClass(findings, want, func(finding supportServiceImportBaselineEntry) boundarySourceClass {
+		class, _ := sourceClassFromBaseline(finding.Class, finding.FilePath)
+		return class
+	}, func(finding supportServiceImportBaselineEntry) string { return finding.FilePath })
+}
+
+func filterServiceConstructionBaselineEntriesByClass(findings []serviceConstructionBaselineEntry, want boundarySourceClass) []serviceConstructionBaselineEntry {
+	return filterByClass(findings, want, func(finding serviceConstructionBaselineEntry) boundarySourceClass {
+		class, _ := sourceClassFromBaseline(finding.Class, finding.FilePath)
+		return class
+	}, func(finding serviceConstructionBaselineEntry) string { return finding.FilePath })
+}
+
+func filterByClass[T any](findings []T, want boundarySourceClass, class func(T) boundarySourceClass, path func(T) string) []T {
+	filtered := make([]T, 0, len(findings))
+	for _, finding := range findings {
+		if effectiveBoundarySourceClass(class(finding), path(finding)) == want {
+			filtered = append(filtered, finding)
+		}
+	}
+	return filtered
+}

--- a/cmd/pkgboundarycheck/source_classification_test.go
+++ b/cmd/pkgboundarycheck/source_classification_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestRunClassifiesPackageBoundaryEdgesBySourceClass(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		files         map[string]string
+		wantErr       bool
+		wantError     string
+		wantErrorText string
+		wantCounts    string
+	}{
+		{
+			name: "production",
+			files: map[string]string{
+				"pkg/services/work/composition.go": "package work\nimport _ \"github.com/portpowered/infinite-you/pkg/wire\"\n",
+			},
+			wantErr:       true,
+			wantError:     "found 1 package-boundary violation(s)",
+			wantErrorText: "prohibited application composition import: pkg/services/work (pkg/services/work/composition.go) [class=production]",
+			wantCounts:    "dependency violation counts: production=1 test-only=0",
+		},
+		{
+			name: "test-only",
+			files: map[string]string{
+				"pkg/services/work/composition_test.go": "package work_test\nimport _ \"github.com/portpowered/infinite-you/pkg/wire\"\n",
+			},
+			wantErrorText: "prohibited application composition import: pkg/services/work (pkg/services/work/composition_test.go) [class=test-only]",
+			wantCounts:    "dependency violation counts: production=0 test-only=1",
+		},
+		{
+			name: "mixed",
+			files: map[string]string{
+				"pkg/services/work/composition.go":      "package work\nimport _ \"github.com/portpowered/infinite-you/pkg/wire\"\n",
+				"pkg/services/work/composition_test.go": "package work_test\nimport _ \"github.com/portpowered/infinite-you/pkg/wire\"\n",
+			},
+			wantErr:       true,
+			wantError:     "found 1 package-boundary violation(s)",
+			wantErrorText: "dependency violation counts: production=1 test-only=1",
+			wantCounts:    "dependency violation counts: production=1 test-only=1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			repoRoot := t.TempDir()
+			for filePath, source := range test.files {
+				writeGoSourceFile(t, repoRoot, filePath, source)
+			}
+			var stdout, stderr bytes.Buffer
+			err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, &stdout, &stderr)
+			if test.wantErr != (err != nil) {
+				t.Fatalf("run() error = %v, wantErr=%t; stdout=%q stderr=%q", err, test.wantErr, stdout.String(), stderr.String())
+			}
+			if test.wantError != "" && (err == nil || !strings.Contains(err.Error(), test.wantError)) {
+				t.Fatalf("run() error = %v, want substring %q", err, test.wantError)
+			}
+			output := stdout.String() + stderr.String()
+			if !strings.Contains(output, test.wantErrorText) {
+				t.Fatalf("run() output = %q, want %q", output, test.wantErrorText)
+			}
+			if !strings.Contains(output, test.wantCounts) {
+				t.Fatalf("run() output = %q, want counts %q", output, test.wantCounts)
+			}
+		})
+	}
+}
+
+func TestPackageBoundaryImportScansRetainTestOnlyEdges(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	writeGoImportFile(t, repoRoot, "pkg/transports/work.go", "work", "github.com/portpowered/infinite-you/pkg/services/work/internal/engine")
+	writeGoImportFile(t, repoRoot, "pkg/transports/work_test.go", "work_test", "github.com/portpowered/infinite-you/pkg/services/work/internal/engine")
+	writeGoImportFile(t, repoRoot, "pkg/services/work/peer.go", "work", "github.com/portpowered/infinite-you/pkg/services/models/internal/catalog")
+	writeGoImportFile(t, repoRoot, "pkg/services/work/peer_test.go", "work_test", "github.com/portpowered/infinite-you/pkg/services/models/internal/catalog")
+
+	converged, err := scanConvergedServiceSubpackageImports(repoRoot)
+	if err != nil {
+		t.Fatalf("scanConvergedServiceSubpackageImports() error = %v", err)
+	}
+	if got := countSourceClasses(converged, func(finding transportServiceImplementationFinding) boundarySourceClass { return finding.class }, func(finding transportServiceImplementationFinding) string { return finding.filePath }); got != "production=1 test-only=1" {
+		t.Fatalf("converged classes = %s, want production=1 test-only=1", got)
+	}
+
+	peer, err := scanPeerServiceImports(repoRoot)
+	if err != nil {
+		t.Fatalf("scanPeerServiceImports() error = %v", err)
+	}
+	if got := countSourceClasses(peer, func(finding peerServiceImportFinding) boundarySourceClass { return finding.class }, func(finding peerServiceImportFinding) string { return finding.filePath }); got != "production=1 test-only=1" {
+		t.Fatalf("peer classes = %s, want production=1 test-only=1", got)
+	}
+}
+
+func TestPackageBoundaryDependencyKeysIncludeSourceClass(t *testing.T) {
+	t.Parallel()
+
+	production := peerServiceImportKey("pkg/services/work/import.go", "github.com/portpowered/infinite-you/pkg/services/models/internal", productionSourceClass)
+	testOnly := peerServiceImportKey("pkg/services/work/import.go", "github.com/portpowered/infinite-you/pkg/services/models/internal", testOnlySourceClass)
+	if production == testOnly {
+		t.Fatalf("peer-service keys collapsed source classes: %q", production)
+	}
+
+	production = serviceConstructionKey("pkg/services/work/import.go", "github.com/portpowered/infinite-you/pkg/services/models", "NewService", productionSourceClass)
+	testOnly = serviceConstructionKey("pkg/services/work/import.go", "github.com/portpowered/infinite-you/pkg/services/models", "NewService", testOnlySourceClass)
+	if production == testOnly {
+		t.Fatalf("service-construction keys collapsed source classes: %q", production)
+	}
+}
+
+func countSourceClasses[T any](findings []T, class func(T) boundarySourceClass, path func(T) string) string {
+	production, testOnly := 0, 0
+	for _, finding := range findings {
+		switch effectiveBoundarySourceClass(class(finding), path(finding)) {
+		case productionSourceClass:
+			production++
+		case testOnlySourceClass:
+			testOnly++
+		}
+	}
+	return "production=" + strconv.Itoa(production) + " test-only=" + strconv.Itoa(testOnly)
+}

--- a/cmd/pkgboundarycheck/support_service_imports.go
+++ b/cmd/pkgboundarycheck/support_service_imports.go
@@ -17,6 +17,7 @@ type supportServiceImportFinding struct {
 	owner      string
 	importPath string
 	filePath   string
+	class      boundarySourceClass
 }
 
 type supportServiceImportBaseline struct {
@@ -29,6 +30,7 @@ type supportServiceImportBaselineEntry struct {
 	ImportPath   string `json:"importPath"`
 	FilePath     string `json:"filePath"`
 	TargetRoot   string `json:"targetRoot"`
+	Class        string `json:"class,omitempty"`
 	Stage        string `json:"stage"`
 	DeletionGate string `json:"deletionGate"`
 }
@@ -78,7 +80,7 @@ func scanSupportRootServiceSubpackageImports(
 		if entry.IsDir() {
 			return nil
 		}
-		if filepath.Ext(entry.Name()) != ".go" || strings.HasSuffix(entry.Name(), "_test.go") {
+		if filepath.Ext(entry.Name()) != ".go" {
 			return nil
 		}
 		filePath, err := filepath.Rel(repoRoot, path)
@@ -86,7 +88,14 @@ func scanSupportRootServiceSubpackageImports(
 			return err
 		}
 		filePath = filepath.ToSlash(filePath)
-		parsedFile, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if bytesContainGeneratedMarker(content) {
+			return nil
+		}
+		parsedFile, err := parser.ParseFile(token.NewFileSet(), path, content, parser.ImportsOnly|parser.ParseComments)
 		if err != nil {
 			return err
 		}
@@ -110,8 +119,9 @@ func scanSupportRootServiceSubpackageImports(
 				owner:      importedOwner,
 				importPath: importPath,
 				filePath:   filePath,
+				class:      classifyBoundarySource(filePath),
 			}
-			findingsByKey[supportServiceImportKey(filePath, importPath)] = finding
+			findingsByKey[supportServiceImportKey(filePath, importPath, finding.class)] = finding
 		}
 		return nil
 	})
@@ -157,7 +167,11 @@ func partitionSupportServiceImportFindings(
 		if err := validateSupportServiceImportBaselineEntry(entry); err != nil {
 			return nil, nil, err
 		}
-		key := supportServiceImportKey(entry.FilePath, entry.ImportPath)
+		class, err := sourceClassFromBaseline(entry.Class, entry.FilePath)
+		if err != nil {
+			return nil, nil, err
+		}
+		key := supportServiceImportKey(entry.FilePath, entry.ImportPath, class)
 		if _, duplicate := baselineByKey[key]; duplicate {
 			return nil, nil, fmt.Errorf(
 				"duplicate reusable support service import baseline entry: %s -> %s",
@@ -171,7 +185,7 @@ func partitionSupportServiceImportFindings(
 	var blocking []supportServiceImportFinding
 	seen := make(map[string]struct{}, len(findings))
 	for _, finding := range findings {
-		key := supportServiceImportKey(finding.filePath, finding.importPath)
+		key := supportServiceImportKey(finding.filePath, finding.importPath, finding.class)
 		seen[key] = struct{}{}
 		entry, recorded := baselineByKey[key]
 		if !recorded {
@@ -213,6 +227,9 @@ func validateSupportServiceImportBaselineEntry(entry supportServiceImportBaselin
 		if strings.ContainsAny(value, "*?[]") {
 			return fmt.Errorf("reusable support service import baseline entry must be exact and cannot contain wildcards: %#v", entry)
 		}
+	}
+	if _, err := sourceClassFromBaseline(entry.Class, entry.FilePath); err != nil {
+		return err
 	}
 	wantTargetRoot := "pkg/services/" + entry.Owner
 	if entry.Owner == "wire" {
@@ -273,6 +290,7 @@ func createSupportServiceImportBaseline(cfg config) error {
 			Owner:      finding.owner,
 			ImportPath: finding.importPath,
 			FilePath:   finding.filePath,
+			Class:      string(finding.class),
 			TargetRoot: func() string {
 				if finding.owner == "wire" {
 					return "pkg/wire"
@@ -295,17 +313,22 @@ func createSupportServiceImportBaseline(cfg config) error {
 	return nil
 }
 
-func supportServiceImportKey(filePath, importPath string) string {
-	return filePath + "\x00" + importPath
+func supportServiceImportKey(filePath, importPath string, classes ...boundarySourceClass) string {
+	class := classifyBoundarySource(filePath)
+	if len(classes) > 0 {
+		class = effectiveBoundarySourceClass(classes[0], filePath)
+	}
+	return filepath.ToSlash(filePath) + "\x00" + string(class) + "\x00" + importPath
 }
 
 func writeSupportServiceImportFindings(writer io.Writer, findings []supportServiceImportFinding) {
 	for _, finding := range findings {
 		fmt.Fprintf(
 			writer,
-			"[agent-factory:pkg-boundary] prohibited reusable support service implementation import: %s (%s)\n",
+			"[agent-factory:pkg-boundary] prohibited reusable support service implementation import: %s (%s) [class=%s]\n",
 			finding.importPath,
 			finding.filePath,
+			effectiveBoundarySourceClass(finding.class, finding.filePath),
 		)
 		fmt.Fprintln(writer, "  reason: repository-wide reusable test support is not an application composition root.")
 		fmt.Fprintln(writer, "  remediation: use the owning service root contract, a typed edge fake, package-local owner coverage, or root.BuildProcess.")
@@ -316,9 +339,13 @@ func writeStaleSupportServiceBaselineEntries(writer io.Writer, entries []support
 	for _, entry := range entries {
 		fmt.Fprintf(
 			writer,
-			"[agent-factory:pkg-boundary] stale reusable support service import baseline entry: %s -> %s\n",
+			"[agent-factory:pkg-boundary] stale reusable support service import baseline entry: %s -> %s [class=%s]\n",
 			entry.FilePath,
 			entry.ImportPath,
+			func() boundarySourceClass {
+				class, _ := sourceClassFromBaseline(entry.Class, entry.FilePath)
+				return class
+			}(),
 		)
 		fmt.Fprintln(writer, "  reason: the concrete reusable-support import no longer exists.")
 		fmt.Fprintf(writer, "  remediation: remove this entry from %s in the same change.\n", supportServiceImportBaselinePath)

--- a/cmd/pkgboundarycheck/support_service_imports.go
+++ b/cmd/pkgboundarycheck/support_service_imports.go
@@ -171,6 +171,15 @@ func partitionSupportServiceImportFindings(
 		if err != nil {
 			return nil, nil, err
 		}
+		if class != productionSourceClass {
+			return nil, nil, fmt.Errorf(
+				"reusable support service import baseline entry %s -> %s class = %q, want %q",
+				entry.FilePath,
+				entry.ImportPath,
+				class,
+				productionSourceClass,
+			)
+		}
 		key := supportServiceImportKey(entry.FilePath, entry.ImportPath, class)
 		if _, duplicate := baselineByKey[key]; duplicate {
 			return nil, nil, fmt.Errorf(
@@ -182,14 +191,20 @@ func partitionSupportServiceImportFindings(
 		baselineByKey[key] = entry
 	}
 
-	var blocking []supportServiceImportFinding
+	var visible []supportServiceImportFinding
 	seen := make(map[string]struct{}, len(findings))
 	for _, finding := range findings {
+		if effectiveBoundarySourceClass(finding.class, finding.filePath) != productionSourceClass {
+			// Test-only support imports remain visible to the report, but this
+			// general dependency baseline is production-only.
+			visible = append(visible, finding)
+			continue
+		}
 		key := supportServiceImportKey(finding.filePath, finding.importPath, finding.class)
 		seen[key] = struct{}{}
 		entry, recorded := baselineByKey[key]
 		if !recorded {
-			blocking = append(blocking, finding)
+			visible = append(visible, finding)
 			continue
 		}
 		if entry.Owner != finding.owner {
@@ -214,7 +229,7 @@ func partitionSupportServiceImportFindings(
 		}
 		return strings.Compare(left.ImportPath, right.ImportPath)
 	})
-	return blocking, stale, nil
+	return visible, stale, nil
 }
 
 func validateSupportServiceImportBaselineEntry(entry supportServiceImportBaselineEntry) error {
@@ -278,8 +293,9 @@ func createSupportServiceImportBaseline(cfg config) error {
 	if err != nil {
 		return err
 	}
+	findings = filterSupportServiceImportsByClass(findings, productionSourceClass)
 	if len(findings) == 0 {
-		return fmt.Errorf("refusing to create empty reusable support service import baseline: no migration debt exists")
+		return fmt.Errorf("refusing to create empty reusable support service import baseline: no production migration debt exists")
 	}
 	baseline := supportServiceImportBaseline{
 		Version: 1,

--- a/cmd/pkgboundarycheck/support_service_imports_test.go
+++ b/cmd/pkgboundarycheck/support_service_imports_test.go
@@ -207,6 +207,54 @@ func TestCreateReusableSupportBaselineRefusesOverwrite(t *testing.T) {
 	}
 }
 
+func TestCreateReusableSupportBaselineIgnoresTestOnlyFindings(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	writeGoImportFile(
+		t,
+		repoRoot,
+		"internal/testutil/runtime_test.go",
+		"testutil",
+		"github.com/portpowered/infinite-you/pkg/services/factory_definitions/service",
+	)
+	err := createSupportServiceImportBaseline(config{root: repoRoot})
+	if err == nil || !strings.Contains(err.Error(), "no production migration debt") {
+		t.Fatalf("createSupportServiceImportBaseline() error = %v, want production-only empty-baseline rejection", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(repoRoot, supportServiceImportBaselinePath)); !os.IsNotExist(statErr) {
+		t.Fatalf("support baseline stat error = %v, want no test-only baseline written", statErr)
+	}
+}
+
+func TestRunRejectsTestOnlyReusableSupportBaseline(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	makeDir(t, repoRoot, "pkg/root")
+	const (
+		filePath   = "internal/testutil/runtime_test.go"
+		importPath = "github.com/portpowered/infinite-you/pkg/services/factory_definitions/service"
+	)
+	writeGoImportFile(t, repoRoot, filePath, "testutil", importPath)
+	writeSupportServiceBaseline(t, repoRoot, supportServiceImportBaseline{
+		Version: 1,
+		Entries: []supportServiceImportBaselineEntry{{
+			Owner:        "factory_definitions",
+			ImportPath:   importPath,
+			FilePath:     filePath,
+			TargetRoot:   "pkg/services/factory_definitions",
+			Stage:        supportServiceImportBaselineStage,
+			DeletionGate: supportServiceImportDeletionGate,
+		}},
+	})
+
+	err := run(config{root: repoRoot, packageRoot: defaultScanRoot}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "class = \"test-only\", want \"production\"") {
+		t.Fatalf("run() error = %v, want test-only support baseline rejected", err)
+	}
+}
+
 func TestReusableSupportBaselineRejectsWildcardAndEmptyCreation(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/pkgboundarycheck/support_service_imports_test.go
+++ b/cmd/pkgboundarycheck/support_service_imports_test.go
@@ -157,7 +157,7 @@ func TestRunRequiresExactDeletionOnlyBaselineForReusableSupportWireImport(t *tes
 	}
 }
 
-func TestReusableSupportScanDoesNotConflateTestFiles(t *testing.T) {
+func TestReusableSupportScanClassifiesTestFiles(t *testing.T) {
 	t.Parallel()
 
 	repoRoot := t.TempDir()
@@ -172,8 +172,11 @@ func TestReusableSupportScanDoesNotConflateTestFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("scanSupportServiceSubpackageImports() error = %v", err)
 	}
-	if len(findings) != 0 {
-		t.Fatalf("reusable support findings = %#v, want _test.go handled only by test baseline", findings)
+	if len(findings) != 1 {
+		t.Fatalf("reusable support findings = %#v, want one test-only edge", findings)
+	}
+	if findings[0].class != testOnlySourceClass {
+		t.Fatalf("reusable support finding class = %q, want %q", findings[0].class, testOnlySourceClass)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "Boundary Checkers Classify Production and Test-Only Edges",
  "branchName": "svc-1-boundary-checker-test-edges",
  "description": "Update pkgboundarycheck, ownershipboundarycheck, and packagetargetmanifestcheck in place so they observe and separately report production and test-only dependency edges, preserve existing production blocking behavior, keep test-only edges non-blocking without a baseline, and prove the distinction with checker fixtures and a corrected current-tree providers-to-workers measurement.",
  "context": {
    "customerAsk": "Make all three boundary checkers classify every relevant dependency edge as production or test-only, report both classes, keep production edges blocking exactly as today, keep test-only edges separately visible and initially non-blocking, add no baseline, prove both outcomes in each checker's own tests, and report the current providers-to-workers direction as production zero after re-measurement.",
    "problem": "Relevant graph scans discard _test.go files before classification, making test-only dependencies invisible and allowing hand-grep results to be mistaken for production architecture. This produced a false providers-to-workers blocker where the cited files were tests and the production count was zero.",
    "solution": "Carry source class from file discovery through edge aggregation and reporting in each existing checker. Emit explicit production and test-only counts, route only production findings through the unchanged blocking and baseline paths, keep test-only findings reporting-only, reuse each checker's fixture pattern for production-only, test-only, and mixed proofs, and re-measure the current tree after rebasing onto origin/main."
  },
  "acceptanceCriteria": [
    "Running all three checkers on the rebased current tree emits explicit production and test-only counts, reports providers -> workers as production=0 with the separately measured test-only count (10 only if still current), and exits successfully when no other unapproved production finding exists.",
    "Each checker has direct production-only, test-only, and mixed fixtures proving that a test-only edge is reported and non-blocking while the equivalent unapproved production edge still reaches the existing blocking path and fails the run.",
    "Every relevant graph-discovery path classifies observed source files before any filtering can hide test-only dependency edges; both labels are emitted even for zero counts, while intentional test-specific policies preserve their established semantics.",
    "Production baselines, diagnostics, thresholds, and exit behavior remain unchanged; test-only edges do not create or consume a baseline, no new checker binary or shared graph subsystem is introduced, no file appears under docs/internal/baselines/, and no pkg/services/** production code changes.",
    "Typecheck and focused checker tests pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "svc-1-boundary-checker-test-edges-001",
      "title": "Report both edge classes in the package boundary checker",
      "description": "As a maintainer, I want the package boundary checker to distinguish production and test-only dependency edges so its output describes the full graph without weakening production enforcement.",
      "acceptanceCriteria": [
        "A production-only fixture emits a production count and a separately labeled zero test-only count, and preserves the existing failing result for an unapproved production peer edge.",
        "A test-only fixture emits a separately labeled test-only count and production=0 for that direction, and exits successfully because the test-only edge is non-blocking.",
        "A mixed fixture reports both classes accurately and fails only because its production edge reaches the existing blocking path.",
        "Relevant discovery paths observe _test.go imports before classification while existing rules that deliberately govern test behavior remain distinct.",
        "Existing production baseline matching, stale-baseline detection, diagnostics, and exit behavior remain unchanged, and no test-edge baseline or new checker executable is added.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented source-class discovery/reporting, class-aware dependency keys and legacy baseline compatibility, zero-inclusive production/test-only counts, non-blocking test-only findings, and production/test/mixed fixtures. Focused tests and checker gates pass."
    },
    {
      "id": "svc-1-boundary-checker-test-edges-002",
      "title": "Report both edge classes in the ownership boundary checker",
      "description": "As a maintainer, I want the ownership boundary checker to expose test-only peer imports separately so I can see test architecture without turning existing test dependencies into blockers.",
      "acceptanceCriteria": [
        "A production-only peer-import fixture reports its production edge and retains the existing non-zero failure result for an unapproved production ownership edge.",
        "A test-only peer-import fixture reports its edge under a separately labeled test-only counter, reports production=0 for that direction, and exits successfully.",
        "A mixed fixture reports both classes and fails only on the production finding.",
        "Production owner, peer, target, remediation, deletion-only baseline, and stale-entry behavior remain compatible, and test-only reporting cannot consume or stale the production baseline.",
        "Discovery assigns source class before any _test.go exclusion and preserves deterministic output using the existing fixture approach without a test-edge baseline.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented source-class discovery/reporting across scoped and peer scans, class-aware production-baseline compatibility, non-blocking test-only observations, zero-inclusive counts, and production/test/mixed plus baseline-isolation fixtures. Focused tests, ownership checker, structural gates, and go vet pass."
    },
    {
      "id": "svc-1-boundary-checker-test-edges-003",
      "title": "Report both edge classes in the package target manifest checker",
      "description": "As a maintainer, I want the package target manifest checker to classify the dependency evidence it observes so test-only edges are visible without changing its production migration gate.",
      "acceptanceCriteria": [
        "A production-only fixture reports a production edge and preserves the current blocking result when that edge violates the migration contract.",
        "A test-only fixture reports a separate test-only count, reports production=0 for that direction, and remains non-blocking.",
        "A mixed fixture reports both classes and demonstrates that only production evidence can fail the current gate.",
        "Package discovery stays deterministic, test-only evidence is classified rather than silently discarded, and established closed-destination and live-production-package behavior remains intact.",
        "Test-only evidence neither requires nor modifies the unfinished-move ledger, creates a baseline or parallel manifest, nor introduces a shared graph library or new test subsystem.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented source-class discovery before liveness filtering, deterministic production/test-only observations and counts, non-blocking test-only reporting without a test baseline, and production stale-row blocking. Added production-only, test-only, mixed, stale-production-plus-test-only, class-key, discovery, and no-baseline fixtures. Focused checker tests, package-target-manifest-check, go vet, backend-size, pkg-maint, pkg-file-count, and pkg-structure pass; the full package-target suite still has four unrelated current-tree root-inventory mismatches in Models, Recordings, and Work."
    },
    {
      "id": "svc-1-boundary-checker-test-edges-004",
      "title": "Prove the corrected current-tree measurement and preserve delivery gates",
      "description": "As an architecture reviewer, I want a direct current-tree measurement and focused regression evidence so later boundary decisions rely on an instrument that distinguishes shipped and test-only dependencies.",
      "acceptanceCriteria": [
        "After rebasing onto origin/main, current-tree checker output reports providers -> workers as production=0 and reports the separately measured test-only count, using 10 only if re-measurement still produces 10.",
        "The current-tree run exits successfully for this direction, while focused fixture output demonstrates that the same prohibited direction in production exits non-zero.",
        "All three reports contain explicit production and test-only labels even when either count is zero; absent output is not accepted as a zero measurement.",
        "No new file appears under docs/internal/baselines/, the diff contains no pkg/services/** production changes, and no unrelated violation remediation is bundled.",
        "Focused unit suites for all three checker commands demonstrate production-only, test-only, and mixed behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Rebased onto origin/main and re-measured the current tree. The three checker reports emit explicit class counts and exit successfully: package boundary production=0/test-only=0, ownership production=0/test-only=28, and package-target production=38/test-only=37. The direct providers -> workers measurement is production=0/test-only=10, with all ten matches in _test.go. Focused production-only, test-only, and mixed suites pass for all three commands; backend-size, pkg-maint, pkg-file-count, pkg-structure, vet, pkg-boundary, and package-target-manifest-check pass. No pkg/services production change or baseline file was added."
    }
  ]
}
