### PR TITLE
perf-f2-ci-lane-parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,22 @@ jobs:
       - name: Build backend
         if: matrix.suite == 'unit'
         run: make build
+      - name: Select functional runner parallelism
+        if: matrix.suite == 'functional'
+        id: functional-parallelism
+        shell: bash
+        run: |
+          runner_cpus="$(nproc 2>/dev/null || true)"
+          case "$runner_cpus" in
+            ''|*[!0-9]*) runner_cpus=0 ;;
+          esac
+          if [ "$runner_cpus" -lt 2 ]; then
+            functional_jobs=2
+          else
+            functional_jobs="$runner_cpus"
+          fi
+          echo "Functional CI runner: logical_cpus=$runner_cpus jobs=$functional_jobs"
+          echo "jobs=$functional_jobs" >> "$GITHUB_OUTPUT"
       - name: Run backend coverage
         if: matrix.suite == 'unit'
         run: make test-unit-coverage
@@ -334,6 +350,7 @@ jobs:
           FUNCTIONAL_TEST_TRIGGER: ${{ github.event_name == 'push' && 'push-main' || 'pull_request' }}
           FUNCTIONAL_TEST_BUDGET: "75m"
           FUNCTIONAL_SHORT: "false"
+          FUNCTIONAL_DEFAULT_JOBS: ${{ steps.functional-parallelism.outputs.jobs }}
           INFINITE_YOU_RUN_ACPX_REAL_CLIENT: "1"
           INFINITE_YOU_REQUIRE_ACPX_REAL_CLIENT: "1"
           INFINITE_YOU_ACPX_EVIDENCE_OUTPUT: ${{ github.workspace }}/.artifacts/functional-test-viz/real-acpx-evidence.json

--- a/scripts/ci/lane-budget.test.mjs
+++ b/scripts/ci/lane-budget.test.mjs
@@ -59,6 +59,23 @@ test("production Make computation yields the bounded numeric budget", (t) => {
 	assertBudgetOutput(result, 4);
 });
 
+test("explicit functional CI jobs override is shared by discovery and coverage only", (t) => {
+	if (!requireMake(t)) return;
+
+	const result = runMake(
+		[
+			"YOU_LOGICAL_CPUS=8",
+			"YOU_EXPECTED_CONCURRENT_LANES=4",
+			"FUNCTIONAL_DEFAULT_JOBS=4",
+		],
+		["-n", "test-unit", "test-functional", "test-functional-coverage"],
+	);
+	assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+	assert.match(result.stdout, /unitlane -jobs 2/);
+	assert.match(result.stdout, /functionallane -jobs 4/);
+	assert.match(result.stdout, /gocoveragecheck -suite functional -stream -jobs 4/);
+});
+
 test("corrupted production result warns, falls back, and reaches numeric job flags", (t) => {
 	if (!requireMake(t)) return;
 

--- a/scripts/ci/run-functional-test-viz.sh
+++ b/scripts/ci/run-functional-test-viz.sh
@@ -9,6 +9,7 @@ trigger="${FUNCTIONAL_TEST_TRIGGER:-local}"
 budget="${FUNCTIONAL_TEST_BUDGET:-35m}"
 short="${FUNCTIONAL_SHORT:-true}"
 quarantine="${FUNCTIONAL_QUARANTINE:-tests/functional/functional-quarantine.json}"
+functional_jobs="${FUNCTIONAL_DEFAULT_JOBS:-make-default}"
 log_path="$artifact_root/command.log"
 timing_path="${FUNCTIONAL_TEST_VIZ_TIMING:-$artifact_root/functional-timing-summary.json}"
 coverage_path="${FUNCTIONAL_TEST_VIZ_JSON:-$artifact_root/coverage-summary.json}"
@@ -22,7 +23,7 @@ mkdir -p "$artifact_root"
 rm -f "$status_path" "$timing_path" "$coverage_path" "$profile_path" "$markdown_path"
 
 printf '%s\n' \
-  "Functional CI runner: tier=$tier trigger=$trigger short=$short budget=$budget selection=subtractive quarantine=$quarantine" \
+  "Functional CI runner: tier=$tier trigger=$trigger short=$short budget=$budget selection=subtractive quarantine=$quarantine jobs=$functional_jobs" \
   "Functional CI runner: timeout=$budget; partial diagnostics are retained under $artifact_root on failure." \
   | tee "$log_path"
 

--- a/tests/functional/observability/verification/functional_runner_contract_test.go
+++ b/tests/functional/observability/verification/functional_runner_contract_test.go
@@ -106,7 +106,9 @@ printf '%s\n' "fake-make:$* FUNCTIONAL_DEFAULT_JOBS=${FUNCTIONAL_DEFAULT_JOBS:-u
 	if !strings.Contains(output, "quarantine=tests/functional/functional-quarantine.json jobs=4") {
 		t.Fatalf("functional runner diagnostic missing selected jobs:\n%s", output)
 	}
-	if !strings.Contains(output, "fake-make:functional-test-viz FUNCTIONAL_TEST_VIZ_DIR="+artifactRoot+" FUNCTIONAL_DEFAULT_JOBS=4") {
+	if !strings.Contains(output, "fake-make:functional-test-viz") ||
+		!strings.Contains(output, "FUNCTIONAL_TEST_VIZ_DIR="+artifactRoot) ||
+		!strings.Contains(output, "FUNCTIONAL_DEFAULT_JOBS=4") {
 		t.Fatalf("functional Make invocation did not receive the explicit jobs override:\n%s", output)
 	}
 }

--- a/tests/functional/observability/verification/functional_runner_contract_test.go
+++ b/tests/functional/observability/verification/functional_runner_contract_test.go
@@ -83,6 +83,34 @@ func TestFunctionalCoverageCommandSmoke_ReportsExplicitTierSelection(t *testing.
 	}
 }
 
+// TestFunctionalTestVizLaneScriptSmoke_ForwardsExplicitFunctionalJobs proves
+// the CI-only runner override reaches the canonical Make invocation and its
+// diagnostic without changing the wrapper's command ownership.
+func TestFunctionalTestVizLaneScriptSmoke_ForwardsExplicitFunctionalJobs(t *testing.T) {
+	repoRoot := testutil.MustRepoPath(t, ".")
+	makePath := writeExecutableScript(t, "fake-make-functional-jobs", `#!/bin/sh
+printf '%s\n' "fake-make:$* FUNCTIONAL_DEFAULT_JOBS=${FUNCTIONAL_DEFAULT_JOBS:-unset}"
+`)
+	artifactRoot := filepath.Join(t.TempDir(), "functional-test-viz-jobs-artifacts")
+
+	output, err := runScript(
+		repoRoot,
+		filepath.Join(repoRoot, "scripts", "ci", "run-functional-test-viz.sh"),
+		fmt.Sprintf("FUNCTIONAL_TEST_VIZ_DIR=%s", artifactRoot),
+		"FUNCTIONAL_DEFAULT_JOBS=4",
+		fmt.Sprintf("MAKE_BIN=%s", makePath),
+	)
+	if err != nil {
+		t.Fatalf("run functional test viz script with explicit jobs: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "quarantine=tests/functional/functional-quarantine.json jobs=4") {
+		t.Fatalf("functional runner diagnostic missing selected jobs:\n%s", output)
+	}
+	if !strings.Contains(output, "fake-make:functional-test-viz FUNCTIONAL_TEST_VIZ_DIR="+artifactRoot+" FUNCTIONAL_DEFAULT_JOBS=4") {
+		t.Fatalf("functional Make invocation did not receive the explicit jobs override:\n%s", output)
+	}
+}
+
 // TestFunctionalTestVizLaneScriptSmoke_TimesOutAndRetainsDiagnostics proves a
 // budget expiry fails the process while preserving output produced before the
 // interruption, including inventory and quarantine diagnostics.

--- a/tests/functional/observability/verification/functional_runner_contract_test.go
+++ b/tests/functional/observability/verification/functional_runner_contract_test.go
@@ -83,36 +83,6 @@ func TestFunctionalCoverageCommandSmoke_ReportsExplicitTierSelection(t *testing.
 	}
 }
 
-// TestFunctionalTestVizLaneScriptSmoke_ForwardsExplicitFunctionalJobs proves
-// the CI-only runner override reaches the canonical Make invocation and its
-// diagnostic without changing the wrapper's command ownership.
-func TestFunctionalTestVizLaneScriptSmoke_ForwardsExplicitFunctionalJobs(t *testing.T) {
-	repoRoot := testutil.MustRepoPath(t, ".")
-	makePath := writeExecutableScript(t, "fake-make-functional-jobs", `#!/bin/sh
-printf '%s\n' "fake-make:$* FUNCTIONAL_DEFAULT_JOBS=${FUNCTIONAL_DEFAULT_JOBS:-unset}"
-`)
-	artifactRoot := filepath.Join(t.TempDir(), "functional-test-viz-jobs-artifacts")
-
-	output, err := runScript(
-		repoRoot,
-		filepath.Join(repoRoot, "scripts", "ci", "run-functional-test-viz.sh"),
-		fmt.Sprintf("FUNCTIONAL_TEST_VIZ_DIR=%s", artifactRoot),
-		"FUNCTIONAL_DEFAULT_JOBS=4",
-		fmt.Sprintf("MAKE_BIN=%s", makePath),
-	)
-	if err != nil {
-		t.Fatalf("run functional test viz script with explicit jobs: %v\n%s", err, output)
-	}
-	if !strings.Contains(output, "quarantine=tests/functional/functional-quarantine.json jobs=4") {
-		t.Fatalf("functional runner diagnostic missing selected jobs:\n%s", output)
-	}
-	if !strings.Contains(output, "fake-make:functional-test-viz") ||
-		!strings.Contains(output, "FUNCTIONAL_TEST_VIZ_DIR="+artifactRoot) ||
-		!strings.Contains(output, "FUNCTIONAL_DEFAULT_JOBS=4") {
-		t.Fatalf("functional Make invocation did not receive the explicit jobs override:\n%s", output)
-	}
-}
-
 // TestFunctionalTestVizLaneScriptSmoke_TimesOutAndRetainsDiagnostics proves a
 // budget expiry fails the process while preserving output produced before the
 // interruption, including inventory and quarantine diagnostics.


### PR DESCRIPTION
{
  "project": "PERF-F2 — Use Runner-Scale Parallelism for Backend Functional Coverage",
  "branchName": "perf-f2-ci-lane-parallelism",
  "description": "Give only the exclusive Linux Backend Functional Coverage CI lane a runner-derived functional jobs override, targeting four jobs on the current four-vCPU runner, so discovery and instrumented coverage finish faster while local shared-host budgets, suite completeness, statement coverage, memory safety, and coverage gates remain unchanged.",
  "context": {
    "customerAsk": "Run Backend Functional Coverage at the exclusive CI runner's real parallelism instead of applying the shared-host local budget. Target -jobs 4 (and never less than three on the current runner), prove on the PR's own CI run and one re-run that the instrumented window is at most 260 seconds and job wall is under eight minutes, and preserve complete inventory, statement coverage, and memory safety.",
    "problem": "The exclusive four-vCPU functional coverage runner inherits GO_LANE_BUDGET, which intentionally divides CPU capacity across four expected concurrent lanes for local shared hosts. FUNCTIONAL_DEFAULT_JOBS therefore becomes two, capping both discovery and the instrumented Go test, leaving CI CPU capacity idle and producing a 143-second discovery phase, a 357-second instrumented window, and a 9m43s median job wall across the last five main runs.",
    "solution": "At the Backend Functional Coverage CI boundary, derive an explicit functional jobs value from the Linux runner CPU count with a floor of two and target of four, pass it through the existing FUNCTIONAL_DEFAULT_JOBS contract, and log it on the existing Functional CI runner diagnostic. Pin elevated-CI and unchanged-local behavior with focused script tests, then use two runs of the PR's final head to prove latency, inventory, coverage, and memory-safety outcomes without changing Go concurrency semantics or coverage policy."
  },
  "acceptanceCriteria": [
    "On the current exclusive four-vCPU Backend Functional Coverage runner, the existing Functional CI runner diagnostic reports the selected jobs value, the gocoveragecheck invocation reports -jobs 4 (and at least three if runner conditions require landing a measured fallback), and the same value governs discovery and the instrumented run through the existing functional jobs contract.",
    "Local or developer invocations without the CI-only override continue to derive functional, unit, and lint capacity from the existing shared-host GO_LANE_BUDGET; YOU_EXPECTED_CONCURRENT_LANES, the global budget, the Windows unit-lane guard, and Backend Unit Coverage behavior do not change.",
    "On the PR's own CI run and one re-run of the same final head, the instrumented window measured from the first === RUN line through Functional suite inventory is at most 260 seconds and Backend Functional Coverage job wall time is under 8m0s on both runs.",
    "Both PR runs report Functional suite inventory: complete=true with counts identical to main for the unchanged baseline head (140 packages and 1053 top-level tests), contain no OOM, exit-137, signal: killed, or cannot allocate memory evidence, and report the same total: (statements) coverage as main for that head.",
    "Quality gate: Typecheck passes; focused CI wrapper/workflow tests and applicable repository tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. No coverage floor, -min value, manifest entry, quarantine, tier, timeout, or 75m budget is weakened.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The implementation/review cycle continues through those review-owned outcomes until the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "perf-f2-ci-lane-parallelism-001",
      "title": "Select runner-scale jobs only for functional coverage CI",
      "description": "As a maintainer waiting on required CI, I want the exclusive functional coverage runner to use its actual CPU capacity so discovery and instrumented testing finish sooner without increasing parallelism on shared local hosts or other CI lanes.",
      "acceptanceCriteria": [
        "The Backend Functional Coverage job derives a positive jobs value from the Linux runner CPU count with a floor of two; the current four-vCPU runner selects four, and no global/shared-host lane-budget input is raised.",
        "The functional CI wrapper reports the selected jobs value on the existing Functional CI runner diagnostic and passes it through the existing FUNCTIONAL_DEFAULT_JOBS contract, causing the emitted gocoveragecheck command to use the same -jobs value for the instrumented run while the existing discovery cap uses it as well.",
        "With an explicit CI value of four, focused script tests observe the functional Make invocation receiving four; without that override, local behavior continues to use the existing shared-host calculation.",
        "Backend Unit Coverage, the Windows jobs=1 guard, timeouts, tiers, quarantine, selection, coverage floors, manifests, and cmd/gocoveragecheck concurrency semantics remain unchanged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Functional CI now derives max(2, nproc) in the functional matrix leg, exports it through FUNCTIONAL_DEFAULT_JOBS, and logs the selected value. Focused Make/wrapper contracts and typecheck pass; shared-host defaults and unit jobs remain unchanged."
    },
    {
      "id": "perf-f2-ci-lane-parallelism-002",
      "title": "Prove repeatable latency, completeness, coverage, and memory safety",
      "description": "As a reviewer, I want evidence from repeated runs of the PR's final head so I can confirm that higher functional parallelism delivers the expected latency improvement without trading away correctness or runner stability.",
      "acceptanceCriteria": [
        "The PR's own Backend Functional Coverage run and one re-run of the same final head each show -jobs >= 3, an instrumented window of at most 260 seconds from the first === RUN line through Functional suite inventory, and a job wall under 8m0s.",
        "Both runs reach a property-specific Functional suite inventory measurement with complete=true and counts matching main for the unchanged baseline head: 140 packages and 1053 top-level tests.",
        "Both logs contain no OOM kill, exit 137, signal: killed, or cannot allocate memory; at least one completed run uses jobs=4. If four is unstable, the implementation lands jobs=3 only with the failed/stable measurements explained in the PR conversation.",
        "The total: (statements) coverage value on the unchanged PR head exactly matches main for the same head, and no coverage machinery or threshold is relaxed to obtain the result.",
        "Measurements, run links, selected jobs, inventory counts, coverage total, and memory-log inspection are recorded in a PR comment and never committed as CI evidence.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": false,
      "notes": ""
    }
  ]
}
