### PR TITLE
perf-u2-checkpoint-proof-cold-cache-build

### DIFF
--- a/pkg/services/factory_runtime/checkpoint_deletion_proof_test.go
+++ b/pkg/services/factory_runtime/checkpoint_deletion_proof_test.go
@@ -2,20 +2,20 @@ package factory_test
 
 import (
 	"context"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
 	"os"
-	"os/exec"
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	factory "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 )
 
-const (
-	externalConsumerProofBuildMaxDuration = 60 * time.Second
-	externalConsumerProofBuildCleanupTime = 5 * time.Second
-)
+const externalConsumerProofFactoryImportPath = "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 
 // DEL-RUN-CKPT proof: CaptureCheckpoint, LoadCheckpoint, and RestoreCheckpoint
 // are gone from the published Factory Runtime root, and every external
@@ -33,69 +33,236 @@ func TestServiceDoesNotExposeDeletedCheckpointMethods(t *testing.T) {
 }
 
 // TestExternalConsumerCannotCallDeletedCheckpointMethods is the required
-// external-consumer negative-compilation proof: it invokes the Go compiler
-// against testdata/checkpointdeletionproof, an external-consumer fixture that
-// calls svc.CaptureCheckpoint/LoadCheckpoint/RestoreCheckpoint on a
-// factory.Service, and asserts the build fails with an undefined-method
-// diagnostic naming each removed selector. The fixture lives under a
-// directory named "testdata" specifically so `go build ./...`, `go vet
-// ./...`, and normal package discovery never compile it as part of this
-// module; only this test compiles it, on purpose, expecting failure.
+// external-consumer negative-compilation proof. It type-checks the fixture in
+// testdata/checkpointdeletionproof against the Service declaration parsed from
+// the published package source and requires an undefined-selector diagnostic
+// for every removed method. The fixture stays under testdata so normal package
+// discovery never compiles it; this test is its intentional type-checking
+// entrypoint.
 func TestExternalConsumerCannotCallDeletedCheckpointMethods(t *testing.T) {
-	// Keep the compiler proof serial with the package's other tests. The nested
-	// Go build can contend with the package test binary for the Windows build
-	// cache, so parallel scheduling turns a slow compile into an unbounded wait.
-	buildContext, cancel := externalConsumerProofBuildContext(t)
-	defer cancel()
-
-	cmd := exec.CommandContext(buildContext, "go", "build", "./testdata/checkpointdeletionproof")
-	// Give the nested build private cache and temporary-build directories. The
-	// external proof may run beside other package builds, and sharing those
-	// directories was the observed source of Windows lock contention.
-	cmd.Env = append(os.Environ(), "GOCACHE="+t.TempDir(), "GOTMPDIR="+t.TempDir())
-	// CommandContext kills the go process when the proof deadline expires.
-	// WaitDelay bounds the reap and pipe cleanup so orphaned compiler output
-	// cannot keep CombinedOutput blocked after cancellation.
-	cmd.WaitDelay = externalConsumerProofBuildCleanupTime
-	output, err := cmd.CombinedOutput()
-	if contextErr := buildContext.Err(); contextErr != nil {
-		childDeadline, _ := buildContext.Deadline()
-		t.Fatalf("external-consumer checkpoint deletion proof build ended with %v; child was killed and reaped at its %s deadline: %v\nbuild output:\n%s", contextErr, childDeadline.Format(time.RFC3339Nano), err, output)
-	}
-	if err == nil {
-		t.Fatalf("expected compilation of testdata/checkpointdeletionproof to fail because CaptureCheckpoint/LoadCheckpoint/RestoreCheckpoint no longer exist on factory.Service, but the build succeeded")
-	}
-
-	got := string(output)
-	for _, forbidden := range []string{"CaptureCheckpoint", "LoadCheckpoint", "RestoreCheckpoint"} {
-		if !strings.Contains(got, forbidden) {
-			t.Errorf("expected compiler diagnostic naming removed method %s, got build output:\n%s", forbidden, got)
+	factoryProof := checkpointProofFactoryPackage(t)
+	fixtureDiagnostics := checkpointProofTypeCheckFixture(t, factoryProof, "main.go")
+	deletedMethods := []string{"CaptureCheckpoint", "LoadCheckpoint", "RestoreCheckpoint"}
+	for _, forbidden := range deletedMethods {
+		if !checkpointProofHasUndefinedDiagnostic(fixtureDiagnostics, forbidden) {
+			t.Errorf("expected compiler diagnostic naming removed method %s as undefined, got diagnostics:\n%s", forbidden, checkpointProofDiagnosticsText(fixtureDiagnostics))
 		}
 	}
-	if !strings.Contains(got, "undefined") {
-		t.Errorf("expected an undefined-method compiler diagnostic, got build output:\n%s", got)
+	if len(fixtureDiagnostics) != len(deletedMethods) {
+		t.Errorf("expected exactly one diagnostic per deleted method, got %d:\n%s", len(fixtureDiagnostics), checkpointProofDiagnosticsText(fixtureDiagnostics))
+	}
+
+	positiveDiagnostics := checkpointProofTypeCheckFixture(t, factoryProof, "positive.go")
+	if len(positiveDiagnostics) != 0 {
+		t.Fatalf("expected valid external-consumer ControlPause call to type-check, got diagnostics:\n%s", checkpointProofDiagnosticsText(positiveDiagnostics))
 	}
 }
 
-func externalConsumerProofBuildContext(t *testing.T) (context.Context, context.CancelFunc) {
+type checkpointProofFactory struct {
+	pkg            *types.Package
+	contextPackage *types.Package
+}
+
+func checkpointProofFactoryPackage(t *testing.T) checkpointProofFactory {
 	t.Helper()
 
-	testDeadline, hasTestDeadline := t.Deadline()
-	if !hasTestDeadline {
-		return context.WithTimeout(context.Background(), externalConsumerProofBuildMaxDuration)
+	source, err := os.ReadFile("interfaces.go")
+	if err != nil {
+		t.Fatalf("read Factory Runtime Service source: %v", err)
+	}
+	return checkpointProofFactoryFromSource(t, source)
+}
+
+func checkpointProofFactoryFromSource(t *testing.T, source []byte) checkpointProofFactory {
+	t.Helper()
+
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, "interfaces.go", source, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse Factory Runtime Service source: %v", err)
+	}
+	serviceSpec := checkpointProofServiceSpec(file)
+	if serviceSpec == nil {
+		t.Fatal("Factory Runtime Service source does not declare Service")
 	}
 
-	now := time.Now()
-	childDeadline := testDeadline.Add(-externalConsumerProofBuildCleanupTime)
-	maxChildDeadline := now.Add(externalConsumerProofBuildMaxDuration)
-	if childDeadline.After(maxChildDeadline) {
-		childDeadline = maxChildDeadline
+	serviceFile := &ast.File{
+		Name: ast.NewIdent("factory"),
+		Decls: []ast.Decl{
+			&ast.GenDecl{Tok: token.IMPORT, Specs: []ast.Spec{checkpointProofContextImport()}},
+			&ast.GenDecl{Tok: token.TYPE, Specs: []ast.Spec{serviceSpec}},
+		},
 	}
-	if !childDeadline.After(now) {
-		t.Fatalf("external-consumer checkpoint deletion proof has no time left for a bounded child build and cleanup before the test deadline")
+	serviceFile.Imports = []*ast.ImportSpec{serviceFile.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ImportSpec)}
+	serviceFile.Decls = append(serviceFile.Decls, checkpointProofServiceStubTypes(serviceSpec)...)
+
+	contextPackage := checkpointProofContextPackage(t)
+	config := types.Config{Importer: checkpointProofImporter{contextPackage: contextPackage}}
+	factoryPackage, err := config.Check(externalConsumerProofFactoryImportPath, fileSet, []*ast.File{serviceFile}, nil)
+	if err != nil {
+		t.Fatalf("type-check Factory Runtime Service source: %v", err)
+	}
+	service := factoryPackage.Scope().Lookup("Service")
+	if service == nil {
+		t.Fatal("type-checker did not publish Factory Runtime Service")
+	}
+	serviceType, ok := service.Type().(*types.Named)
+	if !ok {
+		t.Fatalf("type-checker published Service as %T, want named interface", service.Type())
+	}
+	serviceInterface, ok := serviceType.Underlying().(*types.Interface)
+	if !ok {
+		t.Fatalf("type-checker published Service underlying type as %T, want interface", serviceType.Underlying())
+	}
+	serviceInterface.Complete()
+	if types.NewMethodSet(serviceType).Lookup(nil, "ControlPause") == nil {
+		t.Fatal("type-checker did not retain surviving ControlPause method")
+	}
+	return checkpointProofFactory{pkg: factoryPackage, contextPackage: contextPackage}
+}
+
+func checkpointProofServiceSpec(file *ast.File) *ast.TypeSpec {
+	for _, declaration := range file.Decls {
+		group, ok := declaration.(*ast.GenDecl)
+		if !ok || group.Tok != token.TYPE {
+			continue
+		}
+		for _, specification := range group.Specs {
+			typeSpec, ok := specification.(*ast.TypeSpec)
+			if ok && typeSpec.Name.Name == "Service" {
+				return typeSpec
+			}
+		}
+	}
+	return nil
+}
+
+func checkpointProofContextImport() *ast.ImportSpec {
+	return &ast.ImportSpec{Path: &ast.BasicLit{Kind: token.STRING, Value: `"context"`}}
+}
+
+func checkpointProofContextPackage(t *testing.T) *types.Package {
+	t.Helper()
+
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, "context.go", []byte("package context\ntype Context interface{}\n"), 0)
+	if err != nil {
+		t.Fatalf("parse checkpoint proof context package: %v", err)
+	}
+	contextPackage, err := (&types.Config{}).Check("context", fileSet, []*ast.File{file}, nil)
+	if err != nil {
+		t.Fatalf("type-check checkpoint proof context package: %v", err)
+	}
+	return contextPackage
+}
+
+func checkpointProofServiceStubTypes(serviceSpec *ast.TypeSpec) []ast.Decl {
+	selectorIdentifiers := make(map[*ast.Ident]struct{})
+	methodIdentifiers := make(map[*ast.Ident]struct{})
+	ast.Inspect(serviceSpec.Type, func(node ast.Node) bool {
+		switch current := node.(type) {
+		case *ast.SelectorExpr:
+			if qualifier, ok := current.X.(*ast.Ident); ok {
+				selectorIdentifiers[qualifier] = struct{}{}
+			}
+			selectorIdentifiers[current.Sel] = struct{}{}
+		case *ast.Field:
+			for _, name := range current.Names {
+				methodIdentifiers[name] = struct{}{}
+			}
+		}
+		return true
+	})
+
+	stubNames := make(map[string]struct{})
+	ast.Inspect(serviceSpec.Type, func(node ast.Node) bool {
+		identifier, ok := node.(*ast.Ident)
+		if !ok || identifier.Name == "Service" {
+			return true
+		}
+		if _, ok := selectorIdentifiers[identifier]; ok {
+			return true
+		}
+		if _, ok := methodIdentifiers[identifier]; ok {
+			return true
+		}
+		if types.Universe.Lookup(identifier.Name) != nil {
+			return true
+		}
+		stubNames[identifier.Name] = struct{}{}
+		return true
+	})
+
+	declarations := make([]ast.Decl, 0, len(stubNames))
+	for name := range stubNames {
+		declarations = append(declarations, &ast.GenDecl{
+			Tok: token.TYPE,
+			Specs: []ast.Spec{&ast.TypeSpec{
+				Name: ast.NewIdent(name),
+				Type: &ast.StructType{Fields: &ast.FieldList{}},
+			}},
+		})
+	}
+	return declarations
+}
+
+func checkpointProofTypeCheckFixture(t *testing.T, factoryProof checkpointProofFactory, filename string) []error {
+	t.Helper()
+
+	fileSet := token.NewFileSet()
+	source, err := os.ReadFile("testdata/checkpointdeletionproof/" + filename)
+	if err != nil {
+		t.Fatalf("read checkpoint deletion proof fixture %s: %v", filename, err)
+	}
+	file, err := parser.ParseFile(fileSet, filename, source, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse checkpoint deletion proof fixture %s: %v", filename, err)
 	}
 
-	return context.WithDeadline(context.Background(), childDeadline)
+	diagnostics := make([]error, 0)
+	config := types.Config{
+		Importer: checkpointProofImporter{
+			factoryPackage: factoryProof.pkg,
+			contextPackage: factoryProof.contextPackage,
+		},
+		Error: func(err error) { diagnostics = append(diagnostics, err) },
+	}
+	_, _ = config.Check("checkpointdeletionproof", fileSet, []*ast.File{file}, nil)
+	return diagnostics
+}
+
+type checkpointProofImporter struct {
+	factoryPackage *types.Package
+	contextPackage *types.Package
+}
+
+func (i checkpointProofImporter) Import(path string) (*types.Package, error) {
+	switch path {
+	case externalConsumerProofFactoryImportPath:
+		return i.factoryPackage, nil
+	case "context":
+		return i.contextPackage, nil
+	default:
+		return nil, fmt.Errorf("checkpoint proof importer cannot load %q", path)
+	}
+}
+
+func checkpointProofHasUndefinedDiagnostic(diagnostics []error, method string) bool {
+	for _, diagnostic := range diagnostics {
+		message := diagnostic.Error()
+		if strings.Contains(message, "svc."+method+" undefined") && strings.Contains(message, "factory.Service") {
+			return true
+		}
+	}
+	return false
+}
+
+func checkpointProofDiagnosticsText(diagnostics []error) string {
+	messages := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		messages = append(messages, diagnostic.Error())
+	}
+	return strings.Join(messages, "\n")
 }
 
 // externalConsumerPeer implements factory.Service using only the surviving

--- a/pkg/services/factory_runtime/testdata/checkpointdeletionproof/positive.go
+++ b/pkg/services/factory_runtime/testdata/checkpointdeletionproof/positive.go
@@ -1,0 +1,11 @@
+package checkpointdeletionproof
+
+import (
+	"context"
+
+	factory "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+func callExistingServiceMethod(ctx context.Context, svc factory.Service) {
+	_, _ = svc.ControlPause(ctx, factory.PauseRequest{})
+}


### PR DESCRIPTION
{
  "project": "Make the Checkpoint Deletion Proof Fast and Host-Robust",
  "branchName": "perf-u2-checkpoint-proof-cold-cache-build",
  "description": "Replace the Factory Runtime checkpoint deletion guard's forced cold-cache full dependency build with a cheap, host-robust compiler/type-checker proof while preserving the guarantee that external consumers cannot call CaptureCheckpoint, LoadCheckpoint, or RestoreCheckpoint on factory.Service.",
  "context": {
    "customerAsk": "Keep the negative-compilation guarantee that an external consumer cannot call the deleted checkpoint methods on factory.Service, while reducing the proof's CI cost to at most five seconds and making it pass in under ten seconds on the measured slow Windows host.",
    "problem": "TestExternalConsumerCannotCallDeletedCheckpointMethods launches a nested go build with a new empty GOCACHE and GOTMPDIR, serially recompiling the Factory Runtime dependency closure. The test consumed 25.8 seconds in CI and made pkg/services/factory_runtime an 18-26 second package outlier; on the measured Windows host it ran for 61.0 seconds and failed at its hard-coded deadline.",
    "solution": "Prefer an in-process types-only external-consumer proof that requires undefined-selector diagnostics naming all three deleted methods and includes a positive control using an existing service method. If that is infeasible, use the documented reviewer-approved fallback with host-cache reuse on non-Windows, Windows-scoped cache isolation, and host-aware deadline behavior. Preserve the fixture and existing guards, and record mutation and timing evidence only in PR conversation."
  },
  "acceptanceCriteria": [
    "TestExternalConsumerCannotCallDeletedCheckpointMethods, or an equivalent behavior-named replacement, uses a compiler/type-checker-backed external-consumer proof and fails unless diagnostics identify CaptureCheckpoint, LoadCheckpoint, and RestoreCheckpoint as undefined on factory.Service; source-text grep and reflection-only substitutes do not satisfy this criterion.",
    "The proof includes a positive self-check using an existing factory.Service method, demonstrating that valid external-consumer code type-checks and that missing-loader or vacuous-failure behavior cannot masquerade as success. TestServiceDoesNotExposeDeletedCheckpointMethods and TestExternalConsumerSatisfiesServiceWithoutCheckpointVocabulary remain behaviorally unchanged, and the fixture stays under testdata/checkpointdeletionproof.",
    "On the measured slow Windows host, a focused -count=1 run that previously took 61.0 seconds and failed at its deadline completes successfully in under ten seconds; the exact after-change command and measured duration are posted in a PR comment.",
    "The pkg/services/factory_runtime elapsed value in unit-timing-summary is at most five seconds for three consecutive post-merge main runs, with run identifiers and measured values posted in a PR comment. The PR body also records an uncommitted mutation check in which temporarily reintroducing each checkpoint method on factory.Service causes the proof to fail and name that method.",
    "The preferred types-only shape leaves no subprocess spawn on the default non-Windows path. If the reviewer-approved fallback is used, the PR body explains why the preferred shape was infeasible, the non-Windows path reuses the host Go cache, Windows-only isolation prevents the observed lock contention, and deadline behavior scales with available host/test time. No production Factory Runtime file, public contract, generated artifact, unrelated nested-build test, CI workflow, command, or Make target changes.",
    "Typecheck and focused Factory Runtime tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Broader required tests pass, and any new dependency remains justified and synchronized in go.mod/go.sum without adding a new package or coverage-manifest entry.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "perf-u2-checkpoint-proof-cold-cache-build-001",
      "title": "Preserve the deleted-method guard without cold-compiling the dependency closure",
      "description": "As a Factory Runtime maintainer, I want the external-consumer checkpoint deletion proof to use a cheap, host-robust compilation mechanism so the test continues protecting the public service boundary without dominating CI or failing on slow hosts.",
      "acceptanceCriteria": [
        "External-consumer code that calls CaptureCheckpoint, LoadCheckpoint, or RestoreCheckpoint on factory.Service is rejected by the proof, and the diagnostic asserted for each call names the corresponding undefined method.",
        "A positive control that calls an existing factory.Service method succeeds through the same proof mechanism, preventing vacuous success from loader or configuration failure.",
        "The behavior-named negative-compilation guard survives; the two existing reflection/interface-satisfaction guards retain their behavior; and testdata/checkpointdeletionproof remains under testdata so ordinary go build ./... and go vet ./... discovery do not compile it.",
        "The preferred implementation performs the proof in process and creates no child process or private GOCACHE; if the fallback is necessary, non-Windows uses the host cache, cache isolation is Windows-scoped, and the deadline respects the enclosing test's available time rather than relying only on a fixed 60-second cap.",
        "A focused -count=1 run completes successfully in under ten seconds on the measured Windows host, and focused package tests pass.",
        "A temporary, uncommitted mutation that reintroduces the checkpoint methods makes the proof fail with their names; the result is recorded in the PR body, and the mutation is removed before commit.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implementation complete and ready for review at PR #2091, head 7675929bf. The exact focused command `go test ./pkg/services/factory_runtime -run '^TestExternalConsumerCannotCallDeletedCheckpointMethods$' -count=1` completed successfully in 5.285s on the measured Windows host. Full factory_runtime tests, go vet, and diff checks pass. An uncommitted source-copy mutation reintroduced CaptureCheckpoint, LoadCheckpoint, and RestoreCheckpoint one at a time; each mutation removed that method's undefined diagnostic and the proof rejected it. Required CI started on the final head; post-merge unit-timing evidence and terminal CI remain review-owned."
    }
  ]
}
