### PR TITLE
perf-f1-coverage-output-per-package

### DIFF
--- a/cmd/gocoveragecheck/coverage_verdict.go
+++ b/cmd/gocoveragecheck/coverage_verdict.go
@@ -12,19 +12,16 @@ import (
 const functionalCoverageSuite = "functional"
 const unitCoverageSuite = "unit"
 
-// nearFloorCoverageReportLimit caps how many passing near-floor packages the
-// verdict block names. The block stays readable at a glance while the omitted
-// count keeps the report honest about what it did not print.
-const nearFloorCoverageReportLimit = 10
-
 // nearFloorCoverageHeadroomPoints is the headroom in percentage points below
 // which a passing gated package is reported as near its floor.
 const nearFloorCoverageHeadroomPoints = 2.0
 
-// packageCoverageVerdict is one gated package's measured distance to its floor.
-// Headroom is negative exactly when the measurement is below the floor.
+// packageCoverageVerdict is one measured package's coverage and, when present,
+// its distance to the package floor. Headroom is negative when a measurable
+// package is below its floor. A package without a numeric floor is report-only.
 type packageCoverageVerdict struct {
 	importPath      string
+	hasFloor        bool
 	floor           float64
 	actual          float64
 	headroom        float64
@@ -37,8 +34,8 @@ type packageCoverageVerdict struct {
 //
 // A reporting lane replaces the raw "coverage: N% of statements" line per
 // measured package — 300+ consecutive lines that bury the one actionable
-// verdict — with a compact ordered block: floor violations first, then the
-// packages closest to their floor, then a single tally line.
+// verdict — with a compact ordered block: the existing floor diagnostics, one
+// complete package line per measured package, then a single tally line.
 //
 // Collapsing the listing is only safe when the complete per-package measurement
 // survives somewhere a reader can still reach. Two lanes qualify: the
@@ -89,15 +86,18 @@ func writePackageCoverageSummaries(summaries []packageCoverageSummary) {
 func writeCoverageVerdict(label string, result coverageResult, failures []string) {
 	verdicts := collectPackageCoverageVerdicts(result)
 	belowFloor, nearFloor := partitionPackageCoverageVerdicts(verdicts)
+	slices.SortStableFunc(verdicts, comparePackageCoverageVerdicts)
 
 	fmt.Fprintf(stdoutWriter, "%s package coverage verdict:\n", label)
 	writeBelowFloorCoverageLines(belowFloor)
-	writeNearFloorCoverageLines(nearFloor)
+	for _, verdict := range verdicts {
+		writePackageCoverageVerdictLine(verdict, coverageLaneNoun(label))
+	}
 	fmt.Fprintf(
 		stdoutWriter,
 		"  tally: measured-packages=%d gated-packages=%d below-floor=%d near-floor=%d gate-failures=%d\n",
 		len(result.packageSummaries),
-		len(verdicts),
+		countGatedPackageCoverageVerdicts(verdicts),
 		len(belowFloor),
 		len(nearFloor),
 		len(failures),
@@ -124,70 +124,65 @@ func writeBelowFloorCoverageLines(belowFloor []packageCoverageVerdict) {
 	}
 }
 
-func writeNearFloorCoverageLines(nearFloor []packageCoverageVerdict) {
-	if len(nearFloor) == 0 {
+func writePackageCoverageVerdictLine(verdict packageCoverageVerdict, lane string) {
+	if !verdict.hasFloor {
 		fmt.Fprintf(
 			stdoutWriter,
-			"  near floor: none within %.4f percentage points\n",
-			nearFloorCoverageHeadroomPoints,
+			"  package=%s coverage=%.1f%% floor=none delta=n/a gate=report-only lane=%s\n",
+			verdict.importPath,
+			verdict.actual,
+			lane,
 		)
 		return
 	}
-	reported := min(len(nearFloor), nearFloorCoverageReportLimit)
-	for _, verdict := range nearFloor[:reported] {
-		fmt.Fprintf(
-			stdoutWriter,
-			"  near floor: package=%s floor=%.4f%% actual=%.4f%% headroom=%+.4f percentage-points\n",
-			verdict.importPath,
-			verdict.floor,
-			verdict.actual,
-			verdict.headroom,
-		)
+
+	gate := "pass"
+	if verdict.measurable > 0 && verdict.headroom < 0 {
+		gate = "fail"
 	}
-	if omitted := len(nearFloor) - reported; omitted > 0 {
-		fmt.Fprintf(
-			stdoutWriter,
-			"  near floor: %d more package(s) within %.4f percentage points not shown\n",
-			omitted,
-			nearFloorCoverageHeadroomPoints,
-		)
-	}
+	fmt.Fprintf(
+		stdoutWriter,
+		"  package=%s coverage=%.1f%% floor=%.1f%% delta=%+.1fpp gate=%s lane=%s\n",
+		verdict.importPath,
+		verdict.actual,
+		verdict.floor,
+		verdict.headroom,
+		gate,
+		lane,
+	)
 }
 
-// collectPackageCoverageVerdicts reports one verdict per package that carries a
-// floor and has measurable statements. Packages without a floor, without a
-// measurable denominator (a vacuous pass), or covered by a measurement
-// exception have no distance to report and are excluded.
+// collectPackageCoverageVerdicts reports one verdict per measured package.
+// Numeric floors produce gate headroom; packages with no floor, including
+// measurement exceptions, remain visible as report-only rows.
 func collectPackageCoverageVerdicts(result coverageResult) []packageCoverageVerdict {
 	uncovered := uncoveredCoverageBlockCounts(result.coverageBlocks)
 	verdicts := make([]packageCoverageVerdict, 0, len(result.packageSummaries))
 	for _, summary := range result.packageSummaries {
 		gate := result.packageGates[summary.importPath]
-		if gate.Floor == nil {
-			continue
-		}
 		totals := result.packageTotals[summary.importPath]
-		if totals.totalStatements <= 0 {
-			continue
-		}
-		actual := float64(totals.coveredStatements) * 100 / float64(totals.totalStatements)
-		verdicts = append(verdicts, packageCoverageVerdict{
+		verdict := packageCoverageVerdict{
 			importPath:      summary.importPath,
-			floor:           *gate.Floor,
-			actual:          actual,
-			headroom:        actual - *gate.Floor,
+			actual:          summary.coverage,
 			covered:         totals.coveredStatements,
 			measurable:      totals.totalStatements,
 			uncoveredBlocks: uncovered[summary.importPath],
-		})
+		}
+		if gate.Floor != nil {
+			verdict.hasFloor = true
+			verdict.floor = *gate.Floor
+			verdict.headroom = verdict.actual - verdict.floor
+		}
+		verdicts = append(verdicts, verdict)
 	}
 	return verdicts
 }
 
 // partitionPackageCoverageVerdicts splits verdicts into below-floor packages
-// and passing packages within the near-floor band. Both are ordered by
-// headroom ascending — the worst regression and the closest near-miss first —
-// with import path as the deterministic tiebreak.
+// and passing packages within the near-floor band for the established
+// diagnostics and tally. Report-only and vacuously passing packages do not
+// participate in either count. Both returned groups are ordered by headroom
+// ascending with import path as the deterministic tiebreak.
 //
 // A zero floor is excluded from the near-floor band: coverage is never
 // negative, so a package sitting on a 0% floor cannot regress through it and
@@ -196,6 +191,9 @@ func partitionPackageCoverageVerdicts(verdicts []packageCoverageVerdict) (belowF
 	belowFloor = make([]packageCoverageVerdict, 0)
 	nearFloor = make([]packageCoverageVerdict, 0)
 	for _, verdict := range verdicts {
+		if !verdict.hasFloor || verdict.measurable <= 0 {
+			continue
+		}
 		switch {
 		case verdict.headroom < 0:
 			belowFloor = append(belowFloor, verdict)
@@ -208,6 +206,21 @@ func partitionPackageCoverageVerdicts(verdicts []packageCoverageVerdict) (belowF
 	return belowFloor, nearFloor
 }
 
+func comparePackageCoverageVerdicts(left packageCoverageVerdict, right packageCoverageVerdict) int {
+	if left.hasFloor != right.hasFloor {
+		if left.hasFloor {
+			return -1
+		}
+		return 1
+	}
+	if left.hasFloor {
+		if comparison := comparePackageCoverageHeadroom(left, right); comparison != 0 {
+			return comparison
+		}
+	}
+	return strings.Compare(left.importPath, right.importPath)
+}
+
 func comparePackageCoverageHeadroom(left, right packageCoverageVerdict) int {
 	if left.headroom < right.headroom {
 		return -1
@@ -216,6 +229,16 @@ func comparePackageCoverageHeadroom(left, right packageCoverageVerdict) int {
 		return 1
 	}
 	return strings.Compare(left.importPath, right.importPath)
+}
+
+func countGatedPackageCoverageVerdicts(verdicts []packageCoverageVerdict) int {
+	count := 0
+	for _, verdict := range verdicts {
+		if verdict.hasFloor {
+			count++
+		}
+	}
+	return count
 }
 
 // uncoveredCoverageBlockCounts counts zero-execution coverage blocks per

--- a/cmd/gocoveragecheck/coverage_verdict_test.go
+++ b/cmd/gocoveragecheck/coverage_verdict_test.go
@@ -265,7 +265,7 @@ func TestFunctionalStreamKeepsNonCoverageOutputLines(t *testing.T) {
 		"coverage: 42.7% of statements in " + modulePath + "/pkg/config\n",
 		"--- FAIL: TestSomething (0.12s)\n",
 		"panic: test timed out after 10m0s\n",
-		"ok  \t" + modulePath + "/tests/functional/alpha\t1.234s\tcoverage: 42.7% of statements\n",
+		"FAIL\t" + modulePath + "/tests/functional/alpha\tcoverage: 42.7% of statements in " + modulePath + "/pkg/config\n",
 	}
 	for _, output := range streamed {
 		event, err := json.Marshal(goTestTimingEvent{
@@ -286,13 +286,15 @@ func TestFunctionalStreamKeepsNonCoverageOutputLines(t *testing.T) {
 		"=== RUN   TestSomething\n",
 		"--- FAIL: TestSomething (0.12s)\n",
 		"panic: test timed out after 10m0s\n",
-		"ok  \t" + modulePath + "/tests/functional/alpha\t1.234s\tcoverage: 42.7% of statements\n",
+		"FAIL\t" + modulePath + "/tests/functional/alpha\tcoverage: 42.7% of statements in " + modulePath + "/pkg/config\n",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("functional stream dropped %q:\n%s", want, got)
 		}
 	}
-	if strings.Contains(got, "coverage: 42.7% of statements in ") {
-		t.Fatalf("functional stream forwarded the standalone per-package coverage line:\n%s", got)
+	for _, line := range strings.Split(got, "\n") {
+		if strings.HasPrefix(line, "coverage: 42.7% of statements in ") {
+			t.Fatalf("functional stream forwarded the standalone per-package coverage line:\n%s", got)
+		}
 	}
 }

--- a/cmd/gocoveragecheck/coverage_verdict_test.go
+++ b/cmd/gocoveragecheck/coverage_verdict_test.go
@@ -17,8 +17,8 @@ var functionalVerdictCoverPackages = []string{
 }
 
 // fakeFunctionalCoverageCommand writes a profile with one below-floor package,
-// one near-floor package, and one comfortably passing package so the ordered
-// verdict block has something to order.
+// one near-floor package, and one comfortably passing package so the complete
+// ordered verdict block has something to order.
 func fakeFunctionalCoverageCommand(invocation commandInvocation) (string, string, error) {
 	if invocation.name != "go" || len(invocation.args) == 0 || invocation.args[0] != "test" {
 		return "", "", fmt.Errorf("unexpected command %q %v", invocation.name, invocation.args)
@@ -99,13 +99,15 @@ func TestFunctionalCoverageVerdictOrdersViolationsBeforeNearFloorAndTally(t *tes
 	}
 
 	violation := strings.Index(stdout, "  floor violation: package="+modulePath+"/pkg/config ")
-	nearFloor := strings.Index(stdout, "  near floor: package="+modulePath+"/pkg/service ")
+	configLine := strings.Index(stdout, "  package="+modulePath+"/pkg/config coverage=25.0% floor=80.0% delta=-55.0pp gate=fail lane=functional\n")
+	serviceLine := strings.Index(stdout, "  package="+modulePath+"/pkg/service coverage=90.0% floor=89.0% delta=+1.0pp gate=pass lane=functional\n")
+	wireLine := strings.Index(stdout, "  package="+modulePath+"/pkg/wire coverage=100.0% floor=50.0% delta=+50.0pp gate=pass lane=functional\n")
 	tally := strings.Index(stdout, "  tally: ")
-	if violation < 0 || nearFloor < 0 || tally < 0 {
-		t.Fatalf("verdict block missing sections (violation=%d nearFloor=%d tally=%d):\n%s", violation, nearFloor, tally, stdout)
+	if violation < 0 || configLine < 0 || serviceLine < 0 || wireLine < 0 || tally < 0 {
+		t.Fatalf("verdict block missing sections (violation=%d config=%d service=%d wire=%d tally=%d):\n%s", violation, configLine, serviceLine, wireLine, tally, stdout)
 	}
-	if !(violation < nearFloor && nearFloor < tally) {
-		t.Fatalf("verdict block order = violation@%d nearFloor@%d tally@%d, want violation first and tally last:\n%s", violation, nearFloor, tally, stdout)
+	if !(violation < configLine && configLine < serviceLine && serviceLine < wireLine && wireLine < tally) {
+		t.Fatalf("verdict block order = violation@%d config@%d service@%d wire@%d tally@%d, want headroom order and tally last:\n%s", violation, configLine, serviceLine, wireLine, tally, stdout)
 	}
 	if !strings.Contains(stdout, "delta=-55.0000 percentage-points covered=1/4 statements uncovered-blocks=2") {
 		t.Fatalf("floor violation line missing floor/actual/delta/blocks detail:\n%s", stdout)
@@ -113,9 +115,8 @@ func TestFunctionalCoverageVerdictOrdersViolationsBeforeNearFloorAndTally(t *tes
 	if !strings.Contains(stdout, "  tally: measured-packages=3 gated-packages=3 below-floor=1 near-floor=1 gate-failures=1\n") {
 		t.Fatalf("verdict tally line missing or wrong:\n%s", stdout)
 	}
-	// A comfortably passing package is neither a violation nor near its floor.
-	if strings.Contains(stdout, modulePath+"/pkg/wire") {
-		t.Fatalf("verdict block named a package with ample headroom:\n%s", stdout)
+	if strings.Contains(stdout, "  near floor: package=") || strings.Contains(stdout, "not shown") {
+		t.Fatalf("verdict block retained the elided near-floor format:\n%s", stdout)
 	}
 }
 
@@ -175,8 +176,20 @@ func TestFunctionalCoverageVerdictPassesWhenEveryPackageMeetsItsFloor(t *testing
 	if !strings.Contains(stdout, "  floor violations: none\n") {
 		t.Fatalf("verdict block missing the explicit no-violation line:\n%s", stdout)
 	}
+	for _, want := range []string{
+		"  package=" + modulePath + "/pkg/config coverage=25.0% floor=20.0% delta=+5.0pp gate=pass lane=functional\n",
+		"  package=" + modulePath + "/pkg/service coverage=90.0% floor=89.0% delta=+1.0pp gate=pass lane=functional\n",
+		"  package=" + modulePath + "/pkg/wire coverage=100.0% floor=50.0% delta=+50.0pp gate=pass lane=functional\n",
+	} {
+		if strings.Count(stdout, want) != 1 {
+			t.Fatalf("verdict line count for %q = %d, want one:\n%s", want, strings.Count(stdout, want), stdout)
+		}
+	}
 	if !strings.Contains(stdout, "  tally: measured-packages=3 gated-packages=3 below-floor=0 near-floor=1 gate-failures=0\n") {
 		t.Fatalf("passing verdict tally line missing or wrong:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "  near floor: package=") || strings.Contains(stdout, "not shown") {
+		t.Fatalf("passing verdict retained the elided near-floor format:\n%s", stdout)
 	}
 	if !strings.Contains(stdout, "Go coverage") || !strings.Contains(stdout, "meets minimum") {
 		t.Fatalf("passing run lost its success message:\n%s", stdout)
@@ -223,7 +236,7 @@ func TestUnitCoverageRunKeepsRawPerPackageCoverageLines(t *testing.T) {
 	}
 }
 
-func TestNearFloorCoverageReportStatesOmittedPackages(t *testing.T) {
+func TestCoverageVerdictReportsEveryGatedPackage(t *testing.T) {
 	originalStdout := stdoutWriter
 	defer func() { stdoutWriter = originalStdout }()
 	var stdout bytes.Buffer
@@ -234,7 +247,8 @@ func TestNearFloorCoverageReportStatesOmittedPackages(t *testing.T) {
 		packageGates:  make(map[string]packageCoverageGate),
 		packageTotals: make(map[string]packageCoverageTotals),
 	}
-	for index := range nearFloorCoverageReportLimit + 3 {
+	const packageCount = 13
+	for index := range packageCount {
 		importPath := fmt.Sprintf("%s/pkg/near%02d", modulePath, index)
 		result.packageSummaries = append(result.packageSummaries, packageCoverageSummary{importPath: importPath, coverage: 51})
 		result.packageGates[importPath] = packageCoverageGate{Floor: &floor}
@@ -244,14 +258,51 @@ func TestNearFloorCoverageReportStatesOmittedPackages(t *testing.T) {
 	writeCoverageVerdict("Functional", result, nil)
 
 	got := stdout.String()
-	if count := strings.Count(got, "  near floor: package="); count != nearFloorCoverageReportLimit {
-		t.Fatalf("near-floor lines = %d, want the %d-row cap:\n%s", count, nearFloorCoverageReportLimit, got)
+	if count := strings.Count(got, "  package="); count != packageCount {
+		t.Fatalf("package verdict lines = %d, want all %d rows:\n%s", count, packageCount, got)
 	}
-	if !strings.Contains(got, "  near floor: 3 more package(s) within 2.0000 percentage points not shown\n") {
-		t.Fatalf("near-floor report did not state its omitted rows:\n%s", got)
+	if strings.Contains(got, "  near floor: package=") || strings.Contains(got, "not shown") {
+		t.Fatalf("complete verdict retained the elided near-floor format:\n%s", got)
 	}
 	if !strings.Contains(got, "near-floor=13") {
 		t.Fatalf("tally did not count every near-floor package:\n%s", got)
+	}
+}
+
+func TestCoverageVerdictReportsUngatedPackagesAfterGatedRows(t *testing.T) {
+	originalStdout := stdoutWriter
+	defer func() { stdoutWriter = originalStdout }()
+	var stdout bytes.Buffer
+	stdoutWriter = &stdout
+
+	floor := 80.0
+	gated := modulePath + "/pkg/gated"
+	ungated := modulePath + "/pkg/report-only"
+	result := coverageResult{
+		packageSummaries: []packageCoverageSummary{
+			{importPath: ungated, coverage: 5},
+			{importPath: gated, coverage: 25},
+		},
+		packageTotals: map[string]packageCoverageTotals{
+			gated: {coveredStatements: 25, totalStatements: 100},
+		},
+		packageGates: map[string]packageCoverageGate{
+			gated: {Floor: &floor},
+		},
+	}
+
+	writeCoverageVerdict("Functional", result, nil)
+
+	got := stdout.String()
+	wantGated := "  package=" + gated + " coverage=25.0% floor=80.0% delta=-55.0pp gate=fail lane=functional\n"
+	wantUngated := "  package=" + ungated + " coverage=5.0% floor=none delta=n/a gate=report-only lane=functional\n"
+	gatedIndex := strings.Index(got, wantGated)
+	ungatedIndex := strings.Index(got, wantUngated)
+	if gatedIndex < 0 || ungatedIndex < 0 || gatedIndex > ungatedIndex {
+		t.Fatalf("verdict rows = gated@%d report-only@%d, want gated first:\n%s", gatedIndex, ungatedIndex, got)
+	}
+	if !strings.Contains(got, "measured-packages=2 gated-packages=1 below-floor=1 near-floor=0 gate-failures=0") {
+		t.Fatalf("verdict tally did not distinguish report-only package:\n%s", got)
 	}
 }
 

--- a/cmd/gocoveragecheck/functional_stream.go
+++ b/cmd/gocoveragecheck/functional_stream.go
@@ -23,9 +23,18 @@ type functionalStreamReporter struct {
 }
 
 type functionalStreamWriter struct {
-	reporter *functionalStreamReporter
-	pending  []byte
+	reporter           *functionalStreamReporter
+	pending            []byte
+	coverageOutputMode functionalCoverageOutputMode
 }
+
+type functionalCoverageOutputMode uint8
+
+const (
+	functionalCoverageOutputNormal functionalCoverageOutputMode = iota
+	functionalCoverageOutputSuppress
+	functionalCoverageOutputCompact
+)
 
 type lockedFunctionalStreamWriter struct {
 	reporter *functionalStreamReporter
@@ -98,13 +107,19 @@ func (writer *functionalStreamWriter) writeLineLocked(line []byte) error {
 
 	switch event.Action {
 	case "output":
-		if isRedundantCoverageOutputLine(event.Output) {
+		output := writer.filterCoverageOutput(event.Output)
+		if output == "" {
 			// The per-package coverage percentage is reported authoritatively
 			// by the end-of-run verdict block and the coverage-summary JSON.
-			// Streaming it once per package buries the actionable verdict.
+			// Streaming it once per package, including wrapped fragments, buries
+			// the actionable verdict.
 			return nil
 		}
-		output := compactSuccessfulCoverageOutputLine(event.Output)
+		compactContinuation := writer.coverageOutputMode == functionalCoverageOutputCompact
+		output = compactSuccessfulCoverageOutputLine(output)
+		if compactContinuation && !strings.Contains(output, "\n") {
+			output += "\n"
+		}
 		// Keep the child failure text readable in the job log while the
 		// command runner retains the original JSON bytes for timing parsing.
 		return writer.reporter.writeSink([]byte(output))
@@ -135,13 +150,72 @@ func (writer *functionalStreamWriter) writeLineLocked(line []byte) error {
 	}
 }
 
+// filterCoverageOutput suppresses the standalone per-package coverage line,
+// including a long line split across multiple test2json output events. It also
+// records a split successful package result so its coverpkg continuation can be
+// dropped after the compact prefix is rendered. Once a recognizable line
+// prefix has been seen without a newline, following bytes belong to that same
+// line until its newline; the next human diagnostic is then passed through.
+func (writer *functionalStreamWriter) filterCoverageOutput(output string) string {
+	var filtered strings.Builder
+	for {
+		if writer.coverageOutputMode != functionalCoverageOutputNormal {
+			newline := strings.IndexByte(output, '\n')
+			if newline < 0 {
+				return filtered.String()
+			}
+			writer.coverageOutputMode = functionalCoverageOutputNormal
+			output = output[newline+1:]
+			if output == "" {
+				return filtered.String()
+			}
+			continue
+		}
+
+		newline := strings.IndexByte(output, '\n')
+		if newline < 0 {
+			if isRedundantCoverageOutputLine(output) {
+				writer.coverageOutputMode = functionalCoverageOutputSuppress
+				return filtered.String()
+			}
+			if isSuccessfulCoverageOutputFragment(output) {
+				writer.coverageOutputMode = functionalCoverageOutputCompact
+			}
+			filtered.WriteString(output)
+			return filtered.String()
+		}
+
+		lineEnd := newline + 1
+		line := output[:lineEnd]
+		if !isRedundantCoverageOutputLine(line) {
+			filtered.WriteString(line)
+		}
+		output = output[lineEnd:]
+		if output == "" {
+			return filtered.String()
+		}
+	}
+}
+
+func isSuccessfulCoverageOutputFragment(output string) bool {
+	line, _, ok := singleFunctionalOutputLine(output)
+	if !ok || (!strings.HasPrefix(line, "ok ") && !strings.HasPrefix(line, "ok\t")) {
+		return false
+	}
+	return strings.Contains(line, "coverage: ") && strings.Contains(line, "% of statements in ")
+}
+
 // isRedundantCoverageOutputLine reports whether a go test output event is the
 // standalone per-package coverage percentage line. Only a line that is
 // entirely that report is suppressed: package result lines ("ok  pkg 1.2s
 // coverage: ..."), test failures, and panics keep their exact text so a hang
 // or crash stays diagnosable from the raw stream.
 func isRedundantCoverageOutputLine(output string) bool {
-	trimmed := strings.TrimSpace(output)
+	line, _, ok := singleFunctionalOutputLine(output)
+	if !ok {
+		return false
+	}
+	trimmed := strings.TrimSpace(line)
 	return strings.HasPrefix(trimmed, "coverage: ") && strings.Contains(trimmed, "% of statements")
 }
 

--- a/cmd/gocoveragecheck/functional_stream.go
+++ b/cmd/gocoveragecheck/functional_stream.go
@@ -34,6 +34,8 @@ const (
 	functionalCoverageOutputNormal functionalCoverageOutputMode = iota
 	functionalCoverageOutputSuppress
 	functionalCoverageOutputCompact
+	functionalCoverageOutputSuppressPending
+	functionalCoverageOutputCompactPending
 )
 
 type lockedFunctionalStreamWriter struct {
@@ -159,6 +161,19 @@ func (writer *functionalStreamWriter) writeLineLocked(line []byte) error {
 func (writer *functionalStreamWriter) filterCoverageOutput(output string) string {
 	var filtered strings.Builder
 	for {
+		if writer.coverageOutputMode == functionalCoverageOutputSuppressPending || writer.coverageOutputMode == functionalCoverageOutputCompactPending {
+			if isCoveragePackageListContinuation(output) {
+				if writer.coverageOutputMode == functionalCoverageOutputCompactPending {
+					writer.coverageOutputMode = functionalCoverageOutputCompact
+				} else {
+					writer.coverageOutputMode = functionalCoverageOutputSuppress
+				}
+				continue
+			}
+			writer.coverageOutputMode = functionalCoverageOutputNormal
+			continue
+		}
+
 		if writer.coverageOutputMode != functionalCoverageOutputNormal {
 			newline := strings.IndexByte(output, '\n')
 			if newline < 0 {
@@ -187,8 +202,13 @@ func (writer *functionalStreamWriter) filterCoverageOutput(output string) string
 
 		lineEnd := newline + 1
 		line := output[:lineEnd]
-		if !isRedundantCoverageOutputLine(line) {
+		if isRedundantCoverageOutputLine(line) {
+			writer.coverageOutputMode = functionalCoverageOutputSuppressPending
+		} else {
 			filtered.WriteString(line)
+			if isSuccessfulCoverageOutputLine(line) {
+				writer.coverageOutputMode = functionalCoverageOutputCompactPending
+			}
 		}
 		output = output[lineEnd:]
 		if output == "" {
@@ -197,12 +217,48 @@ func (writer *functionalStreamWriter) filterCoverageOutput(output string) string
 	}
 }
 
+func isSuccessfulCoverageOutputLine(output string) bool {
+	line, _, ok := singleFunctionalOutputLine(output)
+	if !ok || (!strings.HasPrefix(line, "ok ") && !strings.HasPrefix(line, "ok\t")) {
+		return false
+	}
+	return strings.Contains(line, "coverage: ") && strings.Contains(line, "% of statements")
+}
+
 func isSuccessfulCoverageOutputFragment(output string) bool {
 	line, _, ok := singleFunctionalOutputLine(output)
 	if !ok || (!strings.HasPrefix(line, "ok ") && !strings.HasPrefix(line, "ok\t")) {
 		return false
 	}
 	return strings.Contains(line, "coverage: ") && strings.Contains(line, "% of statements in ")
+}
+
+func isCoveragePackageListContinuation(output string) bool {
+	line := output
+	if newline := strings.IndexByte(line, '\n'); newline >= 0 {
+		line = line[:newline]
+	}
+	line = strings.TrimSuffix(line, "\r")
+	if strings.TrimSpace(line) == "" {
+		return false
+	}
+	trimmed := strings.TrimSpace(line)
+	for _, diagnosticPrefix := range []string{
+		"=== ",
+		"--- ",
+		"FAIL",
+		"PASS",
+		"panic:",
+		"goroutine ",
+		"coverage: ",
+		"ok ",
+		"ok\t",
+	} {
+		if strings.HasPrefix(trimmed, diagnosticPrefix) {
+			return false
+		}
+	}
+	return strings.Contains(line, modulePath+"/")
 }
 
 // isRedundantCoverageOutputLine reports whether a go test output event is the

--- a/cmd/gocoveragecheck/functional_stream.go
+++ b/cmd/gocoveragecheck/functional_stream.go
@@ -23,9 +23,10 @@ type functionalStreamReporter struct {
 }
 
 type functionalStreamWriter struct {
-	reporter           *functionalStreamReporter
-	pending            []byte
-	coverageOutputMode functionalCoverageOutputMode
+	reporter                   *functionalStreamReporter
+	pending                    []byte
+	coverageOutputMode         functionalCoverageOutputMode
+	coverageContinuationBuffer []byte
 }
 
 type functionalCoverageOutputMode uint8
@@ -90,12 +91,14 @@ func (writer *functionalStreamWriter) Flush() error {
 	writer.reporter.mu.Lock()
 	defer writer.reporter.mu.Unlock()
 
-	if len(writer.pending) == 0 {
-		return nil
+	if len(writer.pending) > 0 {
+		line := append([]byte(nil), writer.pending...)
+		writer.pending = nil
+		if err := writer.writeLineLocked(line); err != nil {
+			return err
+		}
 	}
-	line := append([]byte(nil), writer.pending...)
-	writer.pending = nil
-	return writer.writeLineLocked(line)
+	return writer.flushCoverageContinuationLocked()
 }
 
 func (writer *functionalStreamWriter) writeLineLocked(line []byte) error {
@@ -105,6 +108,11 @@ func (writer *functionalStreamWriter) writeLineLocked(line []byte) error {
 	}
 	if writer.reporter.onEvent != nil {
 		writer.reporter.onEvent(event)
+	}
+	if event.Action != "output" {
+		if err := writer.flushCoverageContinuationLocked(); err != nil {
+			return err
+		}
 	}
 
 	switch event.Action {
@@ -154,36 +162,32 @@ func (writer *functionalStreamWriter) writeLineLocked(line []byte) error {
 
 // filterCoverageOutput suppresses the standalone per-package coverage line,
 // including a long line split across multiple test2json output events. It also
-// records a split successful package result so its coverpkg continuation can be
-// dropped after the compact prefix is rendered. Once a recognizable line
-// prefix has been seen without a newline, following bytes belong to that same
-// line until its newline; the next human diagnostic is then passed through.
+// records a split successful package result so its coverpkg continuation can
+// be dropped after the compact prefix is rendered. Candidate continuation
+// bytes are buffered until their line is complete, because a diagnostic can
+// begin with the same module path as a coverpkg entry. The complete line is
+// then parsed rather than classified by a broad substring match.
 func (writer *functionalStreamWriter) filterCoverageOutput(output string) string {
 	var filtered strings.Builder
 	for {
-		if writer.coverageOutputMode == functionalCoverageOutputSuppressPending || writer.coverageOutputMode == functionalCoverageOutputCompactPending {
-			if isCoveragePackageListContinuation(output) {
-				if writer.coverageOutputMode == functionalCoverageOutputCompactPending {
-					writer.coverageOutputMode = functionalCoverageOutputCompact
-				} else {
-					writer.coverageOutputMode = functionalCoverageOutputSuppress
-				}
-				continue
-			}
-			writer.coverageOutputMode = functionalCoverageOutputNormal
-			continue
-		}
-
 		if writer.coverageOutputMode != functionalCoverageOutputNormal {
 			newline := strings.IndexByte(output, '\n')
 			if newline < 0 {
+				writer.coverageContinuationBuffer = append(writer.coverageContinuationBuffer, output...)
 				return filtered.String()
 			}
+
+			candidate := append(writer.coverageContinuationBuffer, output[:newline+1]...)
+			writer.coverageContinuationBuffer = nil
 			writer.coverageOutputMode = functionalCoverageOutputNormal
-			output = output[newline+1:]
-			if output == "" {
-				return filtered.String()
+			if isCoveragePackageListLine(string(candidate)) {
+				output = output[newline+1:]
+				if output == "" {
+					return filtered.String()
+				}
+				continue
 			}
+			output = string(candidate) + output[newline+1:]
 			continue
 		}
 
@@ -191,10 +195,12 @@ func (writer *functionalStreamWriter) filterCoverageOutput(output string) string
 		if newline < 0 {
 			if isRedundantCoverageOutputLine(output) {
 				writer.coverageOutputMode = functionalCoverageOutputSuppress
+				writer.coverageContinuationBuffer = append(writer.coverageContinuationBuffer, coveragePackageListFragment(output)...)
 				return filtered.String()
 			}
 			if isSuccessfulCoverageOutputFragment(output) {
 				writer.coverageOutputMode = functionalCoverageOutputCompact
+				writer.coverageContinuationBuffer = append(writer.coverageContinuationBuffer, coveragePackageListFragment(output)...)
 			}
 			filtered.WriteString(output)
 			return filtered.String()
@@ -203,10 +209,14 @@ func (writer *functionalStreamWriter) filterCoverageOutput(output string) string
 		lineEnd := newline + 1
 		line := output[:lineEnd]
 		if isRedundantCoverageOutputLine(line) {
-			writer.coverageOutputMode = functionalCoverageOutputSuppressPending
+			if hasCoveragePackageList(line) {
+				writer.coverageOutputMode = functionalCoverageOutputNormal
+			} else {
+				writer.coverageOutputMode = functionalCoverageOutputSuppressPending
+			}
 		} else {
 			filtered.WriteString(line)
-			if isSuccessfulCoverageOutputLine(line) {
+			if isSuccessfulCoverageOutputLine(line) && !strings.Contains(line, "% of statements in ") {
 				writer.coverageOutputMode = functionalCoverageOutputCompactPending
 			}
 		}
@@ -233,32 +243,54 @@ func isSuccessfulCoverageOutputFragment(output string) bool {
 	return strings.Contains(line, "coverage: ") && strings.Contains(line, "% of statements in ")
 }
 
-func isCoveragePackageListContinuation(output string) bool {
-	line := output
-	if newline := strings.IndexByte(line, '\n'); newline >= 0 {
-		line = line[:newline]
+func hasCoveragePackageList(output string) bool {
+	return strings.Contains(output, "% of statements in ")
+}
+
+func coveragePackageListFragment(output string) string {
+	const coveragePackageListSuffix = "% of statements in "
+	start := strings.Index(output, coveragePackageListSuffix)
+	if start < 0 {
+		return ""
 	}
-	line = strings.TrimSuffix(line, "\r")
-	if strings.TrimSpace(line) == "" {
+	return output[start+len(coveragePackageListSuffix):]
+}
+
+func isCoveragePackageListLine(output string) bool {
+	line, _, ok := singleFunctionalOutputLine(output)
+	if !ok || line == "" {
 		return false
 	}
-	trimmed := strings.TrimSpace(line)
-	for _, diagnosticPrefix := range []string{
-		"=== ",
-		"--- ",
-		"FAIL",
-		"PASS",
-		"panic:",
-		"goroutine ",
-		"coverage: ",
-		"ok ",
-		"ok\t",
-	} {
-		if strings.HasPrefix(trimmed, diagnosticPrefix) {
+	for _, packagePath := range strings.Split(line, ", ") {
+		if !isCoveragePackagePath(packagePath) {
 			return false
 		}
 	}
-	return strings.Contains(line, modulePath+"/")
+	return true
+}
+
+func isCoveragePackagePath(packagePath string) bool {
+	if packagePath == modulePath {
+		return true
+	}
+	if !strings.HasPrefix(packagePath, modulePath+"/") {
+		return false
+	}
+	suffix := strings.TrimPrefix(packagePath, modulePath+"/")
+	if suffix == "" || strings.HasPrefix(suffix, "/") || strings.HasSuffix(suffix, "/") || strings.Contains(suffix, "//") {
+		return false
+	}
+	for index := 0; index < len(suffix); index++ {
+		character := suffix[index]
+		if (character >= 'a' && character <= 'z') ||
+			(character >= 'A' && character <= 'Z') ||
+			(character >= '0' && character <= '9') ||
+			character == '.' || character == '_' || character == '-' || character == '~' || character == '/' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // isRedundantCoverageOutputLine reports whether a go test output event is the
@@ -318,6 +350,20 @@ func singleFunctionalOutputLine(output string) (line, lineEnding string, ok bool
 		lineEnding = "\r" + lineEnding
 	}
 	return line, lineEnding, true
+}
+
+func (writer *functionalStreamWriter) flushCoverageContinuationLocked() error {
+	if len(writer.coverageContinuationBuffer) == 0 {
+		writer.coverageOutputMode = functionalCoverageOutputNormal
+		return nil
+	}
+	candidate := writer.coverageContinuationBuffer
+	writer.coverageContinuationBuffer = nil
+	writer.coverageOutputMode = functionalCoverageOutputNormal
+	if isCoveragePackageListLine(string(candidate)) {
+		return nil
+	}
+	return writer.reporter.writeSink(candidate)
 }
 
 func (writer *lockedFunctionalStreamWriter) Write(data []byte) (int, error) {

--- a/cmd/gocoveragecheck/functional_stream.go
+++ b/cmd/gocoveragecheck/functional_stream.go
@@ -104,9 +104,10 @@ func (writer *functionalStreamWriter) writeLineLocked(line []byte) error {
 			// Streaming it once per package buries the actionable verdict.
 			return nil
 		}
+		output := compactSuccessfulCoverageOutputLine(event.Output)
 		// Keep the child failure text readable in the job log while the
 		// command runner retains the original JSON bytes for timing parsing.
-		return writer.reporter.writeSink([]byte(event.Output))
+		return writer.reporter.writeSink([]byte(output))
 	case timingOutcomePass, timingOutcomeFail, timingOutcomeSkip:
 		if event.Test != "" {
 			return nil
@@ -142,6 +143,51 @@ func (writer *functionalStreamWriter) writeLineLocked(line []byte) error {
 func isRedundantCoverageOutputLine(output string) bool {
 	trimmed := strings.TrimSpace(output)
 	return strings.HasPrefix(trimmed, "coverage: ") && strings.Contains(trimmed, "% of statements")
+}
+
+// compactSuccessfulCoverageOutputLine removes the repeated -coverpkg import
+// list from one successful go test package-result line. It deliberately
+// accepts only a single line beginning with "ok": a failing package, panic,
+// or test-produced diagnostic keeps its original bytes even when its text
+// mentions coverage.
+func compactSuccessfulCoverageOutputLine(output string) string {
+	line, lineEnding, ok := singleFunctionalOutputLine(output)
+	if !ok || (!strings.HasPrefix(line, "ok ") && !strings.HasPrefix(line, "ok\t")) {
+		return output
+	}
+
+	const coveragePrefix = "coverage: "
+	const coveragePackageListSuffix = "% of statements in "
+	coverageStart := strings.Index(line, coveragePrefix)
+	if coverageStart < 0 {
+		return output
+	}
+	suffixStart := strings.Index(line[coverageStart+len(coveragePrefix):], coveragePackageListSuffix)
+	if suffixStart < 0 {
+		return output
+	}
+	suffixStart += coverageStart + len(coveragePrefix)
+	return line[:suffixStart+len("% of statements")] + lineEnding
+}
+
+// singleFunctionalOutputLine separates a complete output line from its line
+// ending. Multi-line events are left alone because their later bytes may be a
+// failure or diagnostic that the stream must preserve exactly.
+func singleFunctionalOutputLine(output string) (line, lineEnding string, ok bool) {
+	newline := strings.IndexByte(output, '\n')
+	if newline < 0 {
+		return output, "", true
+	}
+	if newline != len(output)-1 {
+		return "", "", false
+	}
+	line = output[:newline]
+	lineEnding = output[newline:]
+	if strings.HasSuffix(line, "\r") {
+		line = strings.TrimSuffix(line, "\r")
+		lineEnding = "\r" + lineEnding
+	}
+	return line, lineEnding, true
 }
 
 func (writer *lockedFunctionalStreamWriter) Write(data []byte) (int, error) {

--- a/cmd/gocoveragecheck/functional_stream_test.go
+++ b/cmd/gocoveragecheck/functional_stream_test.go
@@ -144,6 +144,78 @@ func TestFunctionalStreamSuppressesWrappedStandaloneCoverageOutput(t *testing.T)
 	}
 }
 
+func TestFunctionalStreamSuppressesBareCoverageContinuationAfterCompleteOutput(t *testing.T) {
+	var sink bytes.Buffer
+	reporter := newFunctionalStreamReporter(&sink)
+	writer := reporter.stdoutWriter()
+	packageName := modulePath + "/tests/functional/streaming"
+	coverPackages := make([]string, 530)
+	for index := range coverPackages {
+		coverPackages[index] = fmt.Sprintf("%s/pkg/cover%03d", modulePath, index)
+	}
+	coverList := strings.Join(coverPackages, ", ")
+	events := []string{
+		"ok  " + packageName + "\t1.234s\tcoverage: 42.7% of statements\n",
+		coverList[:len(coverList)/2],
+		coverList[len(coverList)/2:] + "\n",
+		"--- FAIL: TestSomething (0.12s)\n",
+	}
+	for _, output := range events {
+		event, err := json.Marshal(goTestTimingEvent{
+			Action:  "output",
+			Package: packageName,
+			Output:  output,
+		})
+		if err != nil {
+			t.Fatalf("marshal stream event: %v", err)
+		}
+		if _, err := writer.Write(append(event, '\n')); err != nil {
+			t.Fatalf("stream reporter write error = %v", err)
+		}
+	}
+
+	want := "ok  " + packageName + "\t1.234s\tcoverage: 42.7% of statements\n--- FAIL: TestSomething (0.12s)\n"
+	if got := sink.String(); got != want {
+		t.Fatalf("bare coverage continuation = %q, want %q", got, want)
+	}
+}
+
+func TestFunctionalStreamSuppressesBareStandaloneCoverageContinuationAfterCompleteOutput(t *testing.T) {
+	var sink bytes.Buffer
+	reporter := newFunctionalStreamReporter(&sink)
+	writer := reporter.stdoutWriter()
+	packageName := modulePath + "/tests/functional/streaming"
+	coverPackages := make([]string, 530)
+	for index := range coverPackages {
+		coverPackages[index] = fmt.Sprintf("%s/pkg/cover%03d", modulePath, index)
+	}
+	coverList := strings.Join(coverPackages, ", ")
+	events := []string{
+		"coverage: 42.7% of statements\n",
+		coverList[:len(coverList)/2],
+		coverList[len(coverList)/2:] + "\n",
+		"--- FAIL: TestSomething (0.12s)\n",
+	}
+	for _, output := range events {
+		event, err := json.Marshal(goTestTimingEvent{
+			Action:  "output",
+			Package: packageName,
+			Output:  output,
+		})
+		if err != nil {
+			t.Fatalf("marshal stream event: %v", err)
+		}
+		if _, err := writer.Write(append(event, '\n')); err != nil {
+			t.Fatalf("stream reporter write error: %v", err)
+		}
+	}
+
+	want := "--- FAIL: TestSomething (0.12s)\n"
+	if got := sink.String(); got != want {
+		t.Fatalf("bare standalone coverage continuation = %q, want %q", got, want)
+	}
+}
+
 func TestFunctionalStreamPreservesTimeoutOutputBeforeChildCompletes(t *testing.T) {
 	liveOutput, resultCh, releaseWriter, rawOutput := startFunctionalStreamChild(t, functionalStreamTimeoutMode)
 	waitForFunctionalStreamMarker(t, liveOutput, "goroutine 123 [running]")

--- a/cmd/gocoveragecheck/functional_stream_test.go
+++ b/cmd/gocoveragecheck/functional_stream_test.go
@@ -216,6 +216,106 @@ func TestFunctionalStreamSuppressesBareStandaloneCoverageContinuationAfterComple
 	}
 }
 
+func TestFunctionalStreamPreservesModulePathDiagnosticsAfterCoverageRecords(t *testing.T) {
+	packageName := modulePath + "/tests/functional/streaming"
+	tests := []struct {
+		name         string
+		coverage     string
+		wantCoverage string
+		diagnostic   string
+	}{
+		{
+			name:         "successful result build diagnostic",
+			coverage:     "ok  " + packageName + "\t1.234s\tcoverage: 42.7% of statements\n",
+			wantCoverage: "ok  " + packageName + "\t1.234s\tcoverage: 42.7% of statements\n",
+			diagnostic:   "# " + modulePath + "/pkg/diagnostic: build failed\n",
+		},
+		{
+			name:         "successful result stack frame",
+			coverage:     "ok  " + packageName + "\t1.234s\tcoverage: 42.7% of statements\n",
+			wantCoverage: "ok  " + packageName + "\t1.234s\tcoverage: 42.7% of statements\n",
+			diagnostic:   modulePath + "/pkg/diagnostic.TestSomething(0x123)\n",
+		},
+		{
+			name:       "standalone coverage build diagnostic",
+			coverage:   "coverage: 42.7% of statements\n",
+			diagnostic: "# " + modulePath + "/pkg/diagnostic: build failed\n",
+		},
+		{
+			name:       "standalone coverage stack frame",
+			coverage:   "coverage: 42.7% of statements\n",
+			diagnostic: modulePath + "/pkg/diagnostic.TestSomething(0x123)\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var sink bytes.Buffer
+			reporter := newFunctionalStreamReporter(&sink)
+			writer := reporter.stdoutWriter()
+			for _, output := range []string{test.coverage, test.diagnostic} {
+				if _, err := writer.Write(marshalFunctionalStreamEvent(goTestTimingEvent{
+					Action:  "output",
+					Package: packageName,
+					Output:  output,
+				})); err != nil {
+					t.Fatalf("stream reporter write error: %v", err)
+				}
+			}
+
+			if got, want := sink.String(), test.wantCoverage+test.diagnostic; got != want {
+				t.Fatalf("coverage diagnostic output = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestFunctionalStreamSuppressesPackageListSplitBeforeNextModulePath(t *testing.T) {
+	packageName := modulePath + "/tests/functional/streaming"
+	tests := []struct {
+		name         string
+		coverage     string
+		wantCoverage string
+	}{
+		{
+			name:         "successful result",
+			coverage:     "ok  " + packageName + "\t1.234s\tcoverage: 42.7% of statements\n",
+			wantCoverage: "ok  " + packageName + "\t1.234s\tcoverage: 42.7% of statements\n",
+		},
+		{
+			name:     "standalone coverage",
+			coverage: "coverage: 42.7% of statements\n",
+		},
+	}
+	diagnostic := "# " + modulePath + "/pkg/diagnostic: build failed\n"
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var sink bytes.Buffer
+			reporter := newFunctionalStreamReporter(&sink)
+			writer := reporter.stdoutWriter()
+			for _, output := range []string{
+				test.coverage,
+				modulePath + "/pkg/cover-first, ",
+				modulePath + "/pkg/cover-second\n",
+				diagnostic,
+			} {
+				if _, err := writer.Write(marshalFunctionalStreamEvent(goTestTimingEvent{
+					Action:  "output",
+					Package: packageName,
+					Output:  output,
+				})); err != nil {
+					t.Fatalf("stream reporter write error: %v", err)
+				}
+			}
+
+			if got, want := sink.String(), test.wantCoverage+diagnostic; got != want {
+				t.Fatalf("package-list continuation output = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
 func TestFunctionalStreamPreservesTimeoutOutputBeforeChildCompletes(t *testing.T) {
 	liveOutput, resultCh, releaseWriter, rawOutput := startFunctionalStreamChild(t, functionalStreamTimeoutMode)
 	waitForFunctionalStreamMarker(t, liveOutput, "goroutine 123 [running]")

--- a/cmd/gocoveragecheck/functional_stream_test.go
+++ b/cmd/gocoveragecheck/functional_stream_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -24,8 +25,17 @@ func TestFunctionalStreamReportsPackageBeforeChildCompletes(t *testing.T) {
 	liveOutput, resultCh, releaseWriter, rawOutput := startFunctionalStreamChild(t, functionalStreamPassMode)
 	waitForFunctionalStreamMarker(t, liveOutput, "Functional package result: package="+functionalStreamChildPkg)
 
-	if got := liveOutput.String(); !strings.Contains(got, "outcome=pass") || !strings.Contains(got, "elapsed=0.125s") {
+	got := liveOutput.String()
+	if !strings.Contains(got, "outcome=pass") || !strings.Contains(got, "elapsed=0.125s") {
 		t.Fatalf("live functional output = %q, want package outcome and elapsed duration", got)
+	}
+	if strings.Contains(got, " of statements in ") {
+		t.Fatalf("live functional output retained the repeated coverpkg suffix: %q", got)
+	}
+	for _, line := range strings.Split(strings.TrimSuffix(got, "\n"), "\n") {
+		if len(line) > 1024 {
+			t.Fatalf("live functional output line length = %d, want <= 1024: %q", len(line), line)
+		}
 	}
 	select {
 	case result := <-resultCh:
@@ -40,6 +50,30 @@ func TestFunctionalStreamReportsPackageBeforeChildCompletes(t *testing.T) {
 	}
 	if result.stdout != rawOutput {
 		t.Fatalf("captured functional JSON = %q, want unchanged %q", result.stdout, rawOutput)
+	}
+}
+
+func TestFunctionalStreamCompactsSuccessfulPackageCoverageList(t *testing.T) {
+	var sink bytes.Buffer
+	reporter := newFunctionalStreamReporter(&sink)
+	writer := reporter.stdoutWriter()
+	packageName := modulePath + "/tests/functional/streaming"
+	input := "ok  " + packageName + "\t1.234s\tcoverage: 42.7% of statements in a, b, c\n"
+	event, err := json.Marshal(goTestTimingEvent{
+		Action:  "output",
+		Package: packageName,
+		Output:  input,
+	})
+	if err != nil {
+		t.Fatalf("marshal stream event: %v", err)
+	}
+	if _, err := writer.Write(append(event, '\n')); err != nil {
+		t.Fatalf("stream reporter write error = %v", err)
+	}
+
+	want := "ok  " + packageName + "\t1.234s\tcoverage: 42.7% of statements\n"
+	if got := sink.String(); got != want {
+		t.Fatalf("compacted successful coverage output = %q, want %q", got, want)
 	}
 }
 
@@ -208,11 +242,26 @@ func functionalStreamChildEvents(mode string) []goTestTimingEvent {
 			Output:  "panic: test timed out\ngoroutine 123 [running]:\n\tcreated by TestHung in goroutine 1\n",
 		}}
 	}
-	return []goTestTimingEvent{{
-		Action:  timingOutcomePass,
-		Elapsed: 0.125,
-		Package: functionalStreamChildPkg,
-	}}
+	return []goTestTimingEvent{
+		{
+			Action:  "output",
+			Package: functionalStreamChildPkg,
+			Output:  functionalStreamCoverageResultOutput(),
+		},
+		{
+			Action:  timingOutcomePass,
+			Elapsed: 0.125,
+			Package: functionalStreamChildPkg,
+		},
+	}
+}
+
+func functionalStreamCoverageResultOutput() string {
+	coverPackages := make([]string, 530)
+	for index := range coverPackages {
+		coverPackages[index] = fmt.Sprintf("%s/pkg/cover%03d", modulePath, index)
+	}
+	return "ok  " + functionalStreamChildPkg + "\t0.125s\tcoverage: 71.4% of statements in " + strings.Join(coverPackages, ", ") + "\n"
 }
 
 func marshalFunctionalStreamEvent(event goTestTimingEvent) []byte {

--- a/cmd/gocoveragecheck/functional_stream_test.go
+++ b/cmd/gocoveragecheck/functional_stream_test.go
@@ -77,6 +77,73 @@ func TestFunctionalStreamCompactsSuccessfulPackageCoverageList(t *testing.T) {
 	}
 }
 
+func TestFunctionalStreamCompactsWrappedSuccessfulCoverageOutput(t *testing.T) {
+	var sink bytes.Buffer
+	reporter := newFunctionalStreamReporter(&sink)
+	writer := reporter.stdoutWriter()
+	packageName := modulePath + "/tests/functional/streaming"
+	coverPackages := make([]string, 530)
+	for index := range coverPackages {
+		coverPackages[index] = fmt.Sprintf("%s/pkg/cover%03d", modulePath, index)
+	}
+	coverList := strings.Join(coverPackages, ", ")
+	outputs := []string{
+		"ok  " + packageName + "\t1.234s\tcoverage: 42.7% of statements in " + coverList[:len(coverList)/2],
+		coverList[len(coverList)/2:] + "\n",
+	}
+	for _, output := range outputs {
+		event, err := json.Marshal(goTestTimingEvent{
+			Action:  "output",
+			Package: packageName,
+			Output:  output,
+		})
+		if err != nil {
+			t.Fatalf("marshal stream event: %v", err)
+		}
+		if _, err := writer.Write(append(event, '\n')); err != nil {
+			t.Fatalf("stream reporter write error = %v", err)
+		}
+	}
+
+	want := "ok  " + packageName + "\t1.234s\tcoverage: 42.7% of statements\n"
+	if got := sink.String(); got != want {
+		t.Fatalf("wrapped successful coverage output = %q, want %q", got, want)
+	}
+}
+
+func TestFunctionalStreamSuppressesWrappedStandaloneCoverageOutput(t *testing.T) {
+	var sink bytes.Buffer
+	reporter := newFunctionalStreamReporter(&sink)
+	writer := reporter.stdoutWriter()
+	packageName := modulePath + "/tests/functional/streaming"
+	coverPackages := make([]string, 530)
+	for index := range coverPackages {
+		coverPackages[index] = fmt.Sprintf("%s/pkg/cover%03d", modulePath, index)
+	}
+	events := []string{
+		"coverage: 71.4% of statements in ",
+		strings.Join(coverPackages, ", ") + "\n",
+		"--- FAIL: TestSomething (0.12s)\n",
+	}
+	for _, output := range events {
+		event, err := json.Marshal(goTestTimingEvent{
+			Action:  "output",
+			Package: packageName,
+			Output:  output,
+		})
+		if err != nil {
+			t.Fatalf("marshal stream event: %v", err)
+		}
+		if _, err := writer.Write(append(event, '\n')); err != nil {
+			t.Fatalf("stream reporter write error = %v", err)
+		}
+	}
+
+	if got := sink.String(); got != "--- FAIL: TestSomething (0.12s)\n" {
+		t.Fatalf("wrapped standalone coverage output = %q, want only the failure line", got)
+	}
+}
+
 func TestFunctionalStreamPreservesTimeoutOutputBeforeChildCompletes(t *testing.T) {
 	liveOutput, resultCh, releaseWriter, rawOutput := startFunctionalStreamChild(t, functionalStreamTimeoutMode)
 	waitForFunctionalStreamMarker(t, liveOutput, "goroutine 123 [running]")

--- a/cmd/gocoveragecheck/unit_report_test.go
+++ b/cmd/gocoveragecheck/unit_report_test.go
@@ -18,8 +18,8 @@ var unitReportCoverPackages = []string{
 }
 
 // unitReportProfile has one below-floor package, one near-floor package, and
-// one comfortably passing package so the ordered verdict block and the JSON
-// coverage summary both have something to order.
+// one comfortably passing package so the complete ordered verdict block and
+// the JSON coverage summary both have something to order.
 func unitReportProfile() string {
 	return strings.Join([]string{
 		"mode: count",
@@ -228,7 +228,7 @@ func TestUnitCoverageLaneCollapsesPerPackageLinesWhenTheArtifactIsWritten(t *tes
 	block := stdout[strings.Index(stdout, "Unit package coverage verdict:"):]
 	var reported []string
 	for _, line := range strings.Split(block, "\n") {
-		if _, importPath, found := strings.Cut(strings.TrimSpace(line), "near floor: package="); found {
+		if _, importPath, found := strings.Cut(strings.TrimSpace(line), "package="); found {
 			reported = append(reported, strings.Fields(importPath)[0])
 		}
 	}


### PR DESCRIPTION
{
  "project": "PERF-F1 Functional Coverage Output per Package",
  "branchName": "perf-f1-coverage-output-per-package",
  "description": "Reform gocoveragecheck's functional-lane human output so streamed successful package results omit repeated cover-package lists and the final verdict reports every measured package deterministically, while preserving coverage gates, failure behavior, unit-lane semantics, and JSON artifacts.",
  "context": {
    "customerAsk": "Make the functional coverage log readable by removing the roughly 48 KB coverpkg tail from streamed successful package result lines and printing one deterministic coverage, floor, delta, and gate line for every gated package.",
    "problem": "A measured green CI run emitted 140 successful package lines totaling 6.7 MB because each repeated about 530 coverpkg import paths, while the verdict displayed only about 10 of 438 gated packages. Maintainers cannot efficiently read progress or inspect all package gates, and the shared command's exit, failure, unit-lane, and JSON contracts must not drift.",
    "solution": "Compact only the repeated coverpkg-list suffix on streamed functional output and replace the near-floor elision with a complete per-package verdict sorted by headroom and import path. Render ungated measured packages as report-only, retain the tally and established diagnostics, and leave all policy evaluation and machine-readable output unchanged."
  },
  "acceptanceCriteria": [
    "On the same representative green functional run, no human-output line from the coverage lane exceeds 1 KB, and the string ' of statements in ' occurs zero times.",
    "The final functional verdict contains exactly one line per gated package in the form 'package=<import path> coverage=NN.N% floor=NN.N% delta=+N.Npp gate=pass|fail lane=functional', with a negative sign when delta is below zero; measured ungated packages appear once with 'floor=none delta=n/a gate=report-only', and lines are ordered by headroom ascending and then import path.",
    "A below-minimum total, a below-floor package, and a malformed manifest retain the same exit codes and failure strings as current main; functional failure and panic output remains byte-identical, and shared unit-lane pass/fail behavior is unchanged.",
    "For an identical coverage profile and timing input, coverage-summary.json and functional-timing-summary.json are byte-identical to current main, including field names, values, ordering, and schema.",
    "Typecheck and focused tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "perf-f1-coverage-output-per-package-001",
      "title": "Compact streamed functional package results",
      "description": "As a maintainer reading a functional coverage run, I want successful package result lines to omit the repeated cover-package list so that progress remains readable without hiding failures.",
      "acceptanceCriteria": [
        "A streamed functional 'ok ... coverage: N% of statements in a, b, c' output event renders as 'ok ... coverage: N% of statements', retaining the rest of the line's bytes and spacing.",
        "A failing-package output line, panic line, and non-coverage output line pass through byte-identically.",
        "A green functional-run regression proves no emitted human-output line contains ' of statements in ' and no coverage-lane human-output line exceeds 1 KB.",
        "Existing standalone redundant-coverage suppression and all Functional package result, Functional suite inventory, and timing output formats remain unchanged.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "perf-f1-coverage-output-per-package-002",
      "title": "Report every measured package deterministically",
      "description": "As a maintainer evaluating coverage health, I want a stable verdict line for every measured package so that every gate is visible and actionable without consulting a separate artifact.",
      "acceptanceCriteria": [
        "Every gated package appears exactly once as 'package=<import path> coverage=NN.N% floor=NN.N% delta=<signed N.N>pp gate=pass|fail lane=functional', with coverage, floor, and delta rounded to one decimal place for display only.",
        "Measured ungated packages appear exactly once as 'package=<import path> coverage=NN.N% floor=none delta=n/a gate=report-only lane=functional'.",
        "Verdict lines are sorted by headroom ascending and then import path, and the existing tally line remains in its current format after the complete listing; the near-floor top-10 elision and 'not shown' line are absent.",
        "A below-floor package renders gate=fail, exits non-zero, and retains the existing below-floor failure string; below-minimum-total and malformed-manifest cases retain their current exit codes and failure strings.",
        "The total coverage, minimum-success, coverage-not-evaluated, functional result/inventory, failure-detail, and panic output formats remain unchanged.",
        "For identical inputs, coverage-summary.json and functional-timing-summary.json are byte-identical to current main, and unit-lane pass/fail behavior remains unchanged.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
