### PR TITLE
fix: skip oversized codex stream records and preserve typed provider errors (rsm-4 RC)

### DIFF
--- a/pkg/services/providers/internal/services/execution/internal/adapters/codex/adapter.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/codex/adapter.go
@@ -81,10 +81,18 @@ func newContinuationAttempt(effect Effect) execution.ContinuationAttempt {
 		}
 		content, session, finalErr := decoder.final()
 		if finalErr != nil {
-			return providers.ExecuteResult{}, execution.AttemptFailure{
+			failure := execution.AttemptFailure{
 				SessionRef:      decoder.sessionRef(),
 				FinalParseError: finalErr,
 			}
+			// A skipped oversized record only fails the execution when the
+			// stream ends without a recoverable final agent decision. Keep the
+			// pre-existing record-limit classification for that terminal case.
+			if skipped := decoder.skippedRecordFailure(); skipped != nil {
+				failure.Declared = skipped
+				failure.Diagnostics = decoder.diagnostics()
+			}
+			return providers.ExecuteResult{}, failure
 		}
 		metadata := cloneMetadata(effectResult.Metadata)
 		if metadata == nil {
@@ -135,7 +143,8 @@ func collectFailure(
 		failure.FlushError = flushErr
 		failed = true
 	}
-	if decoder.limit != nil || decoder.transcriptFull || decoder.diagnosticsFull || decoder.retainedTextFull {
+	if decoder.limit != nil || decoder.recordSkips > 0 ||
+		decoder.transcriptFull || decoder.diagnosticsFull || decoder.retainedTextFull {
 		failure.Diagnostics = decoder.diagnostics()
 	}
 	return failure, failed

--- a/pkg/services/providers/internal/services/execution/internal/adapters/codex/decoder.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/codex/decoder.go
@@ -29,6 +29,8 @@ type decoder struct {
 	diagnosticCount  int
 	retainedText     int64
 	limit            *streamLimit
+	skippedRecord    *streamLimit
+	recordSkips      int64
 	transcriptFull   bool
 	diagnosticsFull  bool
 	retainedTextFull bool
@@ -131,14 +133,14 @@ func (decoder *decoder) consume(chunk []byte) {
 				recordBytes := len(decoder.pending) + len(chunk)
 				decoder.pending = nil
 				decoder.discardLine = true
-				decoder.markResourceLimitAtLine("record", maxRecordBytes, int64(recordBytes), decoder.lineCount+1)
+				decoder.skipOversizedRecord(int64(recordBytes))
 				return
 			}
 			decoder.pending = append(decoder.pending, chunk...)
 			return
 		}
 		if len(decoder.pending)+newline > maxRecordBytes {
-			decoder.markResourceLimitAtLine("record", maxRecordBytes, int64(len(decoder.pending)+newline), decoder.lineCount+1)
+			decoder.skipOversizedRecord(int64(len(decoder.pending) + newline))
 		} else {
 			decoder.pending = append(decoder.pending, chunk[:newline]...)
 			if decoder.beginRecord() {
@@ -221,11 +223,14 @@ func (decoder *decoder) diagnostics() *providers.ExecuteDiagnostics {
 	if decoder.retainedTextFull {
 		metadata[inspectionRetainedTextTruncatedMetadata] = "true"
 	}
-	if decoder.limit != nil {
-		metadata[inspectionLimitCategoryMetadata] = decoder.limit.category
-		metadata[inspectionLimitConfiguredMetadata] = inspectionMetadataValue(decoder.limit.configured)
-		metadata[inspectionLimitObservedMetadata] = inspectionMetadataValue(decoder.limit.observed)
-		metadata[inspectionLimitLineMetadata] = inspectionMetadataValue(decoder.limit.line)
+	if limit := decoder.inspectionLimit(); limit != nil {
+		metadata[inspectionLimitCategoryMetadata] = limit.category
+		metadata[inspectionLimitConfiguredMetadata] = inspectionMetadataValue(limit.configured)
+		metadata[inspectionLimitObservedMetadata] = inspectionMetadataValue(limit.observed)
+		metadata[inspectionLimitLineMetadata] = inspectionMetadataValue(limit.line)
+	}
+	if decoder.recordSkips > 0 {
+		metadata[inspectionRecordsSkippedMetadata] = inspectionMetadataValue(decoder.recordSkips)
 	}
 	return &providers.ExecuteDiagnostics{
 		Progress: decoder.progressFacts(),
@@ -238,6 +243,25 @@ func (decoder *decoder) resourceFailure() *providers.ExecuteFailure {
 		return nil
 	}
 	return decoder.limit.failure(decoder.sessionRef(), decoder.diagnostics())
+}
+
+// inspectionLimit reports the fact that bounds stream inspection: a hard
+// stream limit when one tripped, otherwise the first skipped oversized record.
+func (decoder *decoder) inspectionLimit() *streamLimit {
+	if decoder.limit != nil {
+		return decoder.limit
+	}
+	return decoder.skippedRecord
+}
+
+// skippedRecordFailure classifies an execution whose final agent decision was
+// unrecoverable after one or more oversized records were skipped. It keeps the
+// pre-existing record-limit dependency classification for that terminal case.
+func (decoder *decoder) skippedRecordFailure() *providers.ExecuteFailure {
+	if decoder.skippedRecord == nil {
+		return nil
+	}
+	return decoder.skippedRecord.failure(decoder.sessionRef(), decoder.diagnostics())
 }
 
 func (decoder *decoder) beginRecord() bool {
@@ -396,6 +420,12 @@ func (decoder *decoder) addProgress(
 }
 
 func (decoder *decoder) addDiagnostic(code string) {
+	decoder.addDiagnosticEntry("Codex stream record was omitted", map[string]string{
+		"code": boundedDetail(code),
+	})
+}
+
+func (decoder *decoder) addDiagnosticEntry(detail string, metadata map[string]string) {
 	if decoder.diagnosticCount >= maxCodexDiagnosticFacts {
 		decoder.diagnosticsFull = true
 		return
@@ -406,13 +436,38 @@ func (decoder *decoder) addDiagnostic(code string) {
 		return
 	}
 	decoder.progress = append(decoder.progress, providers.ExecuteProgress{
-		Phase:  "diagnostic",
-		Detail: "Codex stream record was omitted",
-		Metadata: map[string]string{
-			"code": boundedDetail(code),
-		},
+		Phase:    "diagnostic",
+		Detail:   detail,
+		Metadata: metadata,
 	})
 	decoder.progressCount++
+}
+
+// skipOversizedRecord records that one over-limit JSONL record was discarded
+// without buffering it, then lets decoding continue with the next record. An
+// oversized mid-stream record (for example one tool result carrying a huge
+// aggregated command output) must not fail an otherwise-clean execution: the
+// stream's later final agent message remains authoritative. Nothing over
+// maxRecordBytes is ever retained, so the memory-safety bound is unchanged.
+func (decoder *decoder) skipOversizedRecord(observed int64) {
+	decoder.lineCount++
+	decoder.recordSkips++
+	if decoder.skippedRecord == nil {
+		decoder.skippedRecord = &streamLimit{
+			category:   "record",
+			configured: maxRecordBytes,
+			observed:   observed,
+			line:       decoder.lineCount,
+		}
+	}
+	decoder.addDiagnosticEntry(
+		"Codex stream record exceeded the record limit and was skipped",
+		map[string]string{
+			"code":         "record_skipped",
+			"record_bytes": inspectionMetadataValue(observed),
+			"line":         inspectionMetadataValue(decoder.lineCount),
+		},
+	)
 }
 
 func (decoder *decoder) markDecodeFailure(code string) {

--- a/pkg/services/providers/internal/services/execution/internal/adapters/codex/decoder_oversized_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/codex/decoder_oversized_test.go
@@ -1,0 +1,73 @@
+package codex
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDecoderSkipsOversizedRecordWithoutBuffering pins the memory-safety
+// property of the skip path directly on the decoder: while an over-limit line
+// streams through in small chunks, the decoder never retains more than
+// maxRecordBytes, and once the limit trips it holds nothing at all -- it
+// discards the rest of the line without buffering and keeps decoding.
+func TestDecoderSkipsOversizedRecordWithoutBuffering(t *testing.T) {
+	t.Parallel()
+
+	decoder := newDecoder(nil)
+	observe := func(chunk []byte) {
+		t.Helper()
+		if err := decoder.observe(chunk); err != nil {
+			t.Fatalf("observe() error = %v", err)
+		}
+		if len(decoder.pending) > maxRecordBytes {
+			t.Fatalf("decoder buffered %d bytes, want at most %d", len(decoder.pending), maxRecordBytes)
+		}
+	}
+
+	observe([]byte(`{"type":"thread.started","thread_id":"thread-bounded-skip"}` + "\n"))
+	oversized := []byte(
+		`{"type":"item.completed","item":{"id":"tool-1","type":"command_execution","aggregated_output":"` +
+			strings.Repeat("x", int(float64(maxRecordBytes)*1.5)) + `"}}` + "\n",
+	)
+	for len(oversized) > 0 {
+		size := 32 << 10
+		if size > len(oversized) {
+			size = len(oversized)
+		}
+		observe(oversized[:size])
+		oversized = oversized[size:]
+		if decoder.discardLine && len(decoder.pending) != 0 {
+			t.Fatalf("decoder retained %d bytes while discarding an oversized line", len(decoder.pending))
+		}
+	}
+	observe([]byte(`{"type":"item.completed","item":{"id":"message-final","type":"agent_message","text":"<CONTINUE>"}}` + "\n"))
+
+	if err := decoder.flush(); err != nil {
+		t.Fatalf("flush() error = %v", err)
+	}
+	assertRecoveredAfterSkip(t, decoder)
+}
+
+func assertRecoveredAfterSkip(t *testing.T, decoder *decoder) {
+	t.Helper()
+	content, session, err := decoder.final()
+	if err != nil {
+		t.Fatalf("final() error = %v, want recovered decision after skipped record", err)
+	}
+	if content != "<CONTINUE>" {
+		t.Fatalf("final() content = %q, want <CONTINUE>", content)
+	}
+	if session == nil || session.ID != "thread-bounded-skip" {
+		t.Fatalf("final() session = %#v, want observed thread", session)
+	}
+	if decoder.limit != nil {
+		t.Fatalf("decoder.limit = %#v, want no hard stream limit for a skipped record", decoder.limit)
+	}
+	if decoder.recordSkips != 1 || decoder.skippedRecord == nil || decoder.skippedRecord.line != 2 {
+		t.Fatalf("recordSkips = %d, skippedRecord = %#v, want one skip at line 2",
+			decoder.recordSkips, decoder.skippedRecord)
+	}
+	if decoder.resourceFailure() != nil {
+		t.Fatal("resourceFailure() != nil, want no whole-execution failure for a skipped record")
+	}
+}

--- a/pkg/services/providers/internal/services/execution/internal/adapters/codex/limits.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/codex/limits.go
@@ -30,6 +30,7 @@ const (
 	inspectionTranscriptTruncatedMetadata   = "inspection_transcript_truncated"
 	inspectionDiagnosticsTruncatedMetadata  = "inspection_diagnostics_truncated"
 	inspectionRetainedTextTruncatedMetadata = "inspection_retained_text_truncated"
+	inspectionRecordsSkippedMetadata        = "inspection_records_skipped"
 	usageInputTokensMetadata                = "input_tokens"
 	usageOutputTokensMetadata               = "output_tokens"
 )

--- a/pkg/services/providers/internal/services/execution/internal/adapters/codex/oversized_record_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/codex/oversized_record_test.go
@@ -1,0 +1,150 @@
+package codex_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	execution "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution"
+	codex "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/internal/adapters/codex"
+)
+
+// TestCodexRootSkipsOversizedMidStreamRecordAndRecoversFinalDecision pins the
+// root-cause fix for the rsm-4 review-lane kill: `codex exec --json` emits one
+// tool result as one JSONL record carrying the full aggregated command output,
+// so a single fetched CI log can exceed the 1 MiB record inspection limit
+// mid-stream. The oversized record must be skipped -- with a truncation
+// diagnostic -- while the later final agent decision is still recovered.
+func TestCodexRootSkipsOversizedMidStreamRecordAndRecoversFinalDecision(t *testing.T) {
+	t.Parallel()
+
+	finalDecision := "<CONTINUE>\n\nHold: CI is red-terminal; waiting on checks."
+	stream := []byte(
+		`{"type":"thread.started","thread_id":"thread-oversized-recovery"}` + "\n" +
+			`{"type":"item.completed","item":{"id":"tool-log-fetch","type":"command_execution",` +
+			`"command":"gh run view --log-failed","aggregated_output":"` +
+			strings.Repeat("x", (1<<20)+128) + `"}}` + "\n" +
+			`{"type":"item.completed","item":{"id":"reason-after","type":"reasoning","text":"post-skip reasoning"}}` + "\n" +
+			`{"type":"item.completed","item":{"id":"message-final","type":"agent_message","text":"` +
+			`<CONTINUE>\n\nHold: CI is red-terminal; waiting on checks.` + `"}}` + "\n",
+	)
+	effect := codex.EffectFunc(func(
+		_ context.Context,
+		_ execution.ContinuationRequest,
+		observe func([]byte) error,
+	) (codex.EffectResult, error) {
+		for _, chunk := range splitEvery(stream, 64<<10) {
+			if err := observe(chunk); err != nil {
+				return codex.EffectResult{}, err
+			}
+		}
+		return codex.EffectResult{}, nil
+	})
+
+	result, err := newCodexRoot(t, effect).Execute(t.Context(), providers.ExecuteRequest{
+		Provider:    providers.IDCodex,
+		AttemptID:   "attempt-oversized-recovery",
+		UserMessage: "review the pull request",
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v, want recovered final decision after skipped record", err)
+	}
+	if result.Content != finalDecision {
+		t.Fatalf("Execute() Content = %q, want the recovered final agent decision", result.Content)
+	}
+	if result.SessionRef == nil || result.SessionRef.ID != "thread-oversized-recovery" {
+		t.Fatalf("Execute() SessionRef = %#v, want the observed thread", result.SessionRef)
+	}
+	if result.Diagnostics == nil {
+		t.Fatal("Execute() Diagnostics = nil, want truncation diagnostics")
+	}
+	assertSkippedRecordMetadata(t, result.Diagnostics.Metadata)
+	assertSkippedRecordProgress(t, result.Diagnostics.Progress)
+}
+
+func assertSkippedRecordMetadata(t *testing.T, metadata map[string]string) {
+	t.Helper()
+	if metadata["inspection_records_skipped"] != "1" ||
+		metadata["inspection_limit_category"] != "record" ||
+		metadata["inspection_limit_configured"] != "1048576" ||
+		metadata["inspection_limit_observed"] == "" ||
+		metadata["inspection_limit_line"] != "2" {
+		t.Fatalf("skip metadata = %#v, want bounded skipped-record facts", metadata)
+	}
+	if metadata["completion_evidence"] != "agent_message" {
+		t.Fatalf("completion_evidence = %q, want agent_message", metadata["completion_evidence"])
+	}
+}
+
+func assertSkippedRecordProgress(t *testing.T, progress []providers.ExecuteProgress) {
+	t.Helper()
+	if got := countPhase(progress, "message.completed"); got != 1 {
+		t.Fatalf("completed message facts = %d, want the post-skip final message decoded", got)
+	}
+	if !hasSkippedRecordDiagnostic(progress) {
+		t.Fatalf("progress = %#v, want a record_skipped diagnostic fact", progress)
+	}
+	for _, fact := range progress {
+		if strings.Contains(fact.Detail, strings.Repeat("x", 128)) {
+			t.Fatalf("progress retained oversized record content: %q", fact.Detail[:200])
+		}
+	}
+}
+
+// TestCodexRootStillFailsWhenSkippedRecordHidesFinalDecision pins the terminal
+// half of the contract: skipping an oversized record is only safe because the
+// execution still fails -- with the pre-existing record-limit dependency
+// classification -- when the stream ends without a recoverable final decision.
+func TestCodexRootStillFailsWhenSkippedRecordHidesFinalDecision(t *testing.T) {
+	t.Parallel()
+
+	stream := []byte(
+		`{"type":"thread.started","thread_id":"thread-skip-terminal"}` + "\n" +
+			`{"type":"item.completed","item":{"id":"message-oversized","type":"agent_message","text":"` +
+			strings.Repeat("x", (1<<20)+64) + `"}}` + "\n",
+	)
+	effect := codex.EffectFunc(func(
+		_ context.Context,
+		_ execution.ContinuationRequest,
+		observe func([]byte) error,
+	) (codex.EffectResult, error) {
+		for _, chunk := range splitEvery(stream, 64<<10) {
+			if err := observe(chunk); err != nil {
+				return codex.EffectResult{}, err
+			}
+		}
+		return codex.EffectResult{}, nil
+	})
+
+	result, err := newCodexRoot(t, effect).Execute(t.Context(), providers.ExecuteRequest{
+		Provider:    providers.IDCodex,
+		AttemptID:   "attempt-skip-terminal",
+		UserMessage: "review the pull request",
+	})
+	assertCodexFailure(t, result, err, providers.ExecuteFailureKindDependency, "")
+	var failure providers.ExecuteFailure
+	if !errors.As(err, &failure) {
+		t.Fatalf("Execute() error = %#v, want ExecuteFailure", err)
+	}
+	if !strings.Contains(failure.Message, "record limit") ||
+		!strings.Contains(failure.Message, "thread-skip-terminal") {
+		t.Fatalf("failure message = %q, want safe record-limit context", failure.Message)
+	}
+	if failure.Diagnostics == nil ||
+		failure.Diagnostics.Metadata["inspection_records_skipped"] != "1" ||
+		failure.Diagnostics.Metadata["inspection_limit_category"] != "record" {
+		t.Fatalf("failure diagnostics = %#v, want skipped-record facts", failure.Diagnostics)
+	}
+}
+
+func hasSkippedRecordDiagnostic(progress []providers.ExecuteProgress) bool {
+	for _, fact := range progress {
+		if fact.Phase == "diagnostic" && fact.Metadata["code"] == "record_skipped" &&
+			fact.Metadata["record_bytes"] != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/services/workers/execution_contracts.go
+++ b/pkg/services/workers/execution_contracts.go
@@ -525,6 +525,7 @@ const (
 	ProviderResponseMetadataInspectionSourceBytes           = "inspection_source_bytes"
 	ProviderResponseMetadataInspectionLineCount             = "inspection_line_count"
 	ProviderResponseMetadataInspectionRecordCount           = "inspection_record_count"
+	ProviderResponseMetadataInspectionRecordsSkipped        = "inspection_records_skipped"
 	ProviderResponseMetadataInspectionTranscriptTruncated   = "inspection_transcript_truncated"
 	ProviderResponseMetadataInspectionDiagnosticsTruncated  = "inspection_diagnostics_truncated"
 	ProviderResponseMetadataInspectionRetainedTextTruncated = "inspection_retained_text_truncated"

--- a/pkg/services/workers/internal/diagnostics/codec.go
+++ b/pkg/services/workers/internal/diagnostics/codec.go
@@ -380,6 +380,7 @@ func isSafeProviderMetadataKey(key string) bool {
 		"inspection_limit_line",
 		"inspection_limit_observed",
 		"inspection_record_count",
+		"inspection_records_skipped",
 		"inspection_retained_text_truncated",
 		"inspection_source_bytes",
 		"inspection_transcript_truncated",

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/detached.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/detached.go
@@ -2,6 +2,7 @@ package agentrun
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -73,6 +74,16 @@ func ExecuteDetached(
 		result.Diagnostics,
 	)
 	if err != nil {
+		// The go-agent-loop engine flattens a failing turn into
+		// errors.New(message) before it reaches the harness result, which
+		// destroys the typed provider error's retryable/terminal
+		// classification. The last runner turn observed that typed error
+		// first-hand, so re-attach it -- unless the loop ended for a
+		// caller-owned cancellation or deadline, which must keep precedence.
+		if runnerErr := observed.lastError(); runnerErr != nil &&
+			!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			err = runnerErr
+		}
 		return result, err
 	}
 	publishAgentFinalMessage(
@@ -89,6 +100,7 @@ type lastRunnerResult struct {
 	runner   workerexecution.Runner
 	mu       sync.Mutex
 	result   workerexecution.RunnerExecutionResult
+	lastErr  error
 	executed bool
 }
 
@@ -99,6 +111,7 @@ func (observed *lastRunnerResult) Execute(
 	result, err := observed.runner.Execute(ctx, request)
 	observed.mu.Lock()
 	observed.result = result
+	observed.lastErr = err
 	observed.executed = true
 	observed.mu.Unlock()
 	return result, err
@@ -108,4 +121,13 @@ func (observed *lastRunnerResult) snapshot() (workerexecution.RunnerExecutionRes
 	observed.mu.Lock()
 	defer observed.mu.Unlock()
 	return observed.result, observed.executed
+}
+
+// lastError reports the typed error of the most recent runner turn, or nil when
+// that turn succeeded or no turn ran. A turn error terminates the agent loop,
+// so a non-nil value is always the root cause of a failed harness execution.
+func (observed *lastRunnerResult) lastError() error {
+	observed.mu.Lock()
+	defer observed.mu.Unlock()
+	return observed.lastErr
 }

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/detached_test.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/detached_test.go
@@ -412,6 +412,85 @@ func TestExecuteDetachedPropagatesRunnerFailure(t *testing.T) {
 	}
 }
 
+// TestExecuteDetachedPreservesTypedProviderErrorAcrossHarnessSeam pins the
+// second root-cause fix from the rsm-4 review-lane kill: the go-agent-loop
+// engine rebuilds a failing inference turn as errors.New(message), which
+// destroyed the typed *ProviderError -- worker-session ledgers recorded
+// `type: unknown, family: terminal` for a retryable provider failure. The
+// typed error the runner produced must survive ExecuteDetached, through the
+// REAL library harness, after the inferencer's bounded retries exhaust.
+func TestExecuteDetachedPreservesTypedProviderErrorAcrossHarnessSeam(t *testing.T) {
+	t.Parallel()
+
+	providerFailure := workerexecution.NewProviderError(
+		workerexecution.WorkFailureTypeInternalServerError,
+		`Codex rollout inspection reached record limit for provider session "01a02180"`,
+		nil,
+	)
+	runner := &detachedRunnerStub{err: providerFailure}
+
+	result, err := ExecuteDetached(
+		context.Background(),
+		NewLibraryHarnessAdapter(localToolFileSystem{}),
+		runner,
+		DetachedRequest{Attempt: detachedAttempt()},
+	)
+	if err == nil {
+		t.Fatal("ExecuteDetached() error = nil, want the exhausted provider failure")
+	}
+	var providerErr *workerexecution.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Type != workerexecution.WorkFailureTypeInternalServerError {
+		t.Fatalf("ExecuteDetached() error = %v, want the typed provider error preserved across the harness seam", err)
+	}
+	if decision := workerexecution.WorkFailureDecisionFromProviderError(providerErr); !decision.Retryable {
+		t.Fatalf("failure decision = %#v, want the retryable classification to survive", decision)
+	}
+	if metadata := failureMetadataForError(err); metadata == nil ||
+		metadata.Type != workerexecution.WorkFailureTypeInternalServerError ||
+		metadata.Family != workerexecution.WorkFailureFamilyRetryable {
+		t.Fatalf("failureMetadataForError() = %#v, want typed retryable metadata, not unknown/terminal", metadata)
+	}
+	if got := failureClassForError(err); got != FailureClassProvider {
+		t.Fatalf("failureClassForError() = %q, want %q", got, FailureClassProvider)
+	}
+	// The inferencer's own bounded retry budget still applies before the typed
+	// error surfaces: one initial call plus agentRunProviderMaxRetries.
+	if runner.callCount() != 1+agentRunProviderMaxRetries {
+		t.Fatalf("runner executed %d times, want %d bounded attempts", runner.callCount(), 1+agentRunProviderMaxRetries)
+	}
+	if result.Content != "" {
+		t.Fatalf("ExecuteDetached() Content = %q, want the failed runner turn result", result.Content)
+	}
+}
+
+// TestExecuteDetachedKeepsCancellationOverTypedRunnerError pins the precedence
+// guard on the re-attach: a caller-owned cancellation or deadline that ends the
+// loop must stay observable even when the last runner turn also failed.
+func TestExecuteDetachedKeepsCancellationOverTypedRunnerError(t *testing.T) {
+	t.Parallel()
+
+	providerFailure := workerexecution.NewProviderError(
+		workerexecution.WorkFailureTypePermanentBadRequest,
+		"invalid request",
+		nil,
+	)
+	canceled := fmt.Errorf("agent loop interrupted: %w", context.Canceled)
+
+	_, err := ExecuteDetached(
+		context.Background(),
+		&inferencingHarnessStub{err: canceled},
+		&detachedRunnerStub{err: providerFailure},
+		DetachedRequest{Attempt: detachedAttempt()},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ExecuteDetached() error = %v, want the cancellation to keep precedence", err)
+	}
+	var providerErr *workerexecution.ProviderError
+	if errors.As(err, &providerErr) {
+		t.Fatalf("ExecuteDetached() error = %v, want the runner error not to replace a cancellation", err)
+	}
+}
+
 // TestLastRunnerResultSnapshotIsConcurrencySafe exercises the request-scoped
 // observer under concurrent turns; the agent loop may drive parallel tool
 // turns, and a torn snapshot would return a mixed result.

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/inferencer.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/inferencer.go
@@ -70,9 +70,12 @@ func (i *runnerInferencer) InferStream(ctx context.Context, req messages.Inferen
 	go func() {
 		defer close(ch)
 		if err != nil {
+			// Carry the error object, not just its text: typed provider errors
+			// keep their retryable/terminal classification wherever the loop
+			// honors ErrorValue.Err instead of rebuilding errors.New(message).
 			ch <- messages.StreamMessage{
 				Type:  messages.StreamTypeError,
-				Value: messages.NewErrorValue(err.Error()),
+				Value: messages.NewErrorValueWithError(err),
 			}
 			return
 		}

--- a/pkg/services/workers/internal/services/workstations/executor/agentrun/inferencer_test.go
+++ b/pkg/services/workers/internal/services/workstations/executor/agentrun/inferencer_test.go
@@ -83,6 +83,38 @@ func TestRunnerInferencer_InferStreamEmitsDeltas(t *testing.T) {
 	}
 }
 
+// TestRunnerInferencer_InferStreamCarriesTypedError pins the harness-seam
+// contract: a failed inference must stream an ErrorValue that carries the
+// error OBJECT, not just its text, so consumers that honor ErrorValue.Err can
+// recover the typed provider classification.
+func TestRunnerInferencer_InferStreamCarriesTypedError(t *testing.T) {
+	t.Parallel()
+
+	failure := workerexecution.NewProviderError(
+		workerexecution.WorkFailureTypePermanentBadRequest,
+		"invalid request",
+		nil,
+	)
+	inferencer := newRunnerInferencer(&sequenceRunner{errors: []error{failure}}, workerexecution.ProviderInferenceRequest{})
+	ch, err := inferencer.InferStream(context.Background(), messages.InferenceRequest{})
+	if err != nil {
+		t.Fatalf("InferStream: %v", err)
+	}
+	var streamed *messages.ErrorValue
+	for msg := range ch {
+		if msg.Type == messages.StreamTypeError {
+			streamed, _ = msg.Value.(*messages.ErrorValue)
+		}
+	}
+	if streamed == nil || streamed.Err == nil {
+		t.Fatalf("stream error value = %#v, want the error object preserved", streamed)
+	}
+	var providerErr *workerexecution.ProviderError
+	if !errors.As(streamed.Err, &providerErr) || providerErr.Type != workerexecution.WorkFailureTypePermanentBadRequest {
+		t.Fatalf("stream error = %v, want the typed provider error", streamed.Err)
+	}
+}
+
 func TestRunnerInferencer_RetriesTransientProviderFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Incident

Review lane `rsm-4-accept-unfinalized-recordings` (attempt `d538840f`) was killed with `WORKERS_EXECUTION_FAILURE` although all three codex sessions in the attempt ended cleanly with a valid `<CONTINUE>` hold. The reviewer fetched a failed CI log in-session; `codex exec --json` emits each tool result as ONE JSONL record carrying the full untruncated `aggregated_output`, and that log produced a single 1,057,706-byte stdout record — over the codex adapter's 1,048,576-byte (`maxRecordBytes`) inspection limit.

Full RC analysis: `docs/temp/review-failure-rc-2026-08-20.md`. Latent defect since #1823; #2083's review/ci-wait hold loop multiplied the exposure. `obs-5-petri-dispatch-usage` was observed hitting the same limit on nearly every first invocation.

## Causal chain (brief)

1. Oversized mid-stream record trips `maxRecordBytes`; the decoder poisons `decoder.limit` and `consume()` discards the REST of the stream — including the later clean final `agent_message` with `<CONTINUE>`.
2. The adapter declares the whole exit-0 execution failed (`ExecuteFailureKindDependency`), classified `internal_server_error` (retryable).
3. The agent-run inferencer silently re-runs the identical prompt twice more (fresh sessions, 100/200 ms backoff); each re-fetches the same giant log and trips the same limit.
4. On exhaustion, the harness seam flattens the typed `*ProviderError` to a plain string (`messages.NewErrorValue(err.Error())`), and go-agent-loop rebuilds `errors.New(message)` — retryable typing destroyed, ledger records `type: unknown, family: terminal`.
5. `worker_sessions` classifies `WORKERS_EXECUTION_FAILURE`; the review workstation's `onFailure` routes a single FAILED outcome to `task->failed, review->fin`. Lane dead.

## Fix A — codex decoder skips oversized mid-stream records

`pkg/services/providers/.../adapters/codex/decoder.go`, `adapter.go`, `limits.go`

- An over-limit JSONL record no longer aborts decoding: both record-limit trip sites now call `skipOversizedRecord`, which discards the line via the existing non-buffering `discardLine` machinery and keeps decoding subsequent records. The later final agent decision is recovered.
- The 1 MiB memory-safety property is unchanged: nothing over `maxRecordBytes` is ever buffered (the limit itself was NOT raised), pinned by a white-box test asserting the pending buffer bound while streaming a >1.5 MiB line in chunks.
- Every skip records a truncation diagnostic: a `diagnostic` progress fact (`code=record_skipped`, `record_bytes`, `line`) plus `inspection_records_skipped` and the existing `inspection_limit_*` metadata (new key allowlisted through the workers safe-diagnostics codec).
- The execution fails only when the stream ends without a recoverable final decision; that terminal case keeps the pre-existing record-limit dependency classification and message (`Codex rollout inspection reached record limit ...`), now attached as the Declared failure on the final-parse path.

## Fix B — typed provider errors survive the agent-run harness seam

`pkg/services/workers/.../executor/agentrun/inferencer.go`, `detached.go`

- `InferStream` now emits `messages.NewErrorValueWithError(err)` so the error object (not just its text) rides the stream wherever the loop honors `ErrorValue.Err`.
- The go-agent-loop engine (external module) still rebuilds `errors.New(message)` on its non-streaming path, so `ExecuteDetached` re-attaches the typed error via the existing request-scoped `lastRunnerResult` observer: it now also records the last runner turn's error, and a failed harness execution returns that typed error — unless the loop ended for a caller-owned cancellation/deadline, which keeps precedence. A runner-turn error always terminates the loop, so a recorded error is always the root cause of the harness failure.
- Result: `retryable/terminal` classification and the informative provider message survive into `normalize.failureFromError`, worker-session classification, and the ledger — no more `unknown/terminal` for a retryable provider failure, and `invokeWorkerShouldRetry`'s `Retryable` gate works again.

Option C from the RC report (factory.json failure allowance) was deliberately NOT implemented — root-cause fixes only, no config palliatives.

## Test evidence

New/updated tests (all passing):

- `TestCodexRootSkipsOversizedMidStreamRecordAndRecoversFinalDecision` — stream of [normal, ONE >1MiB record, normal, final `<CONTINUE>`] fed in 64 KiB chunks decodes successfully, yields the CONTINUE decision, and carries the skip diagnostics; no oversized content retained.
- `TestCodexRootStillFailsWhenSkippedRecordHidesFinalDecision` — oversized FINAL record with no recoverable decision still fails `ExecuteFailureKindDependency` with the record-limit message and skip metadata.
- `TestDecoderSkipsOversizedRecordWithoutBuffering` (white-box) — pending buffer never exceeds `maxRecordBytes`, nothing retained while discarding, `decoder.limit` stays nil, decision recovered.
- `TestCodexRootCarriesBoundedRecordLimitThroughFailureDiagnostics` (pre-existing) — passes unchanged.
- `TestExecuteDetachedPreservesTypedProviderErrorAcrossHarnessSeam` — retryable `*ProviderError` through the REAL library harness surfaces typed (`internal_server_error`/retryable, `FailureClassProvider`) after the inferencer's 3 bounded attempts. Verified load-bearing: with Fix B reverted this test reproduces the incident's exact flattened `provider error: internal_server_error` string.
- `TestExecuteDetachedKeepsCancellationOverTypedRunnerError` — cancellation precedence guard.
- `TestRunnerInferencer_InferStreamCarriesTypedError` — the streamed `ErrorValue` carries the typed error object.

Verification: `go test` green for `providers/.../execution/...` (codex adapter ok), `workers/.../agentrun`, `workers/internal/diagnostics`, `workers`; `make test` (short Go suite) green — exit 0, 493 packages ok, 0 failures; `go vet` clean; lint gates `pkg-maint`, `pkg-file-count`, `pkg-boundary`, `backend-size` all pass. (Two unrelated single-occurrence environment flakes were observed under parallel load and each passed on same-head isolated re-run: `TestClaudeCommandEnvironmentPreventsGitMergeEditorPrompt` git-timeout, and the `factory_runtime` checkpoint-deletion compile-probe 60s deadline.)

## Rollout note

This fix activates only when the daemon binary is rebuilt and restarted. Until then, any review session on a red-terminal-CI lane that fetches a large failed-CI log remains exposed (see the RC report's live-exposure section: `obs-5-petri-dispatch-usage`, `rsm-1-durable-checkpoint-stores`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178zD5WHNqjQvwBeQ8eFyed
