### PR TITLE
perf-u1-unit-coverage-parallelism

### DIFF
--- a/cmd/gocoveragecheck/functional_quarantine.go
+++ b/cmd/gocoveragecheck/functional_quarantine.go
@@ -90,7 +90,7 @@ func resolveFunctionalCoverageSelection(path string, packages []string, timeout 
 	return selection, manifest, nil
 }
 
-func prepareFunctionalCoverageRun(cfg config, packages []string, targetOS string, repoRoot string) (functionalCoverageSelection, []string, error) {
+func prepareFunctionalCoverageRun(cfg config, packages []string, targetOS string, logicalCPUs int, repoRoot string) (functionalCoverageSelection, []string, error) {
 	quarantinePath := cfg.functionalQuarantine
 	if !filepath.IsAbs(quarantinePath) {
 		quarantinePath = filepath.Join(repoRoot, quarantinePath)
@@ -100,7 +100,7 @@ func prepareFunctionalCoverageRun(cfg config, packages []string, targetOS string
 		packages,
 		cfg.timeout,
 		cfg.short,
-		cfg.testJobs(targetOS),
+		cfg.testJobs(targetOS, logicalCPUs),
 		repoRoot,
 	)
 	if err != nil {

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -193,7 +193,7 @@ func parseConfig() config {
 	flag.StringVar(&cfg.covermode, "covermode", "count", "go test -covermode value")
 	flag.StringVar(&cfg.coverpkg, "coverpkg", "", "comma-separated import paths to measure; defaults to backend-owned packages")
 	flag.StringVar(&cfg.functionalQuarantine, "functional-quarantine", "", "strict functional quarantine JSON manifest; discovers and subtracts its package/test selectors")
-	flag.IntVar(&cfg.jobs, "jobs", 0, "maximum concurrent go test packages; defaults to 2")
+	flag.IntVar(&cfg.jobs, "jobs", 0, "maximum concurrent go test packages; defaults to runtime CPU count for non-Windows unit coverage, 1 for Windows unit coverage, and 2 for functional coverage")
 	flag.StringVar(&cfg.generateManifest, "generate-manifest", "", "create a deterministic package-minimum manifest from this lane's coverage profile")
 	flag.StringVar(&cfg.updateManifest, "update-manifest", "", "update an existing package-minimum manifest from a complete compatible profile sample set")
 	flag.StringVar(&cfg.updateProfiles, "update-profiles", "", "comma-separated complete coverage profiles for -update-manifest; requires at least five compatible profiles")
@@ -285,6 +285,10 @@ func run(cfg config) (coverageResult, error) {
 }
 
 func runForOS(cfg config, targetOS string) (result coverageResult, runErr error) {
+	return runForOSWithCPU(cfg, targetOS, runtime.NumCPU())
+}
+
+func runForOSWithCPU(cfg config, targetOS string, logicalCPUs int) (result coverageResult, runErr error) {
 	profilePath, cleanup, err := prepareCoverageProfile(cfg.profile)
 	if err != nil {
 		return coverageResult{}, err
@@ -294,10 +298,10 @@ func runForOS(cfg config, targetOS string) (result coverageResult, runErr error)
 			runErr = errors.Join(runErr, fmt.Errorf("remove temporary coverage profile: %w", cleanupErr))
 		}
 	}()
-	return runCoverageProfile(cfg, targetOS, profilePath)
+	return runCoverageProfile(cfg, targetOS, logicalCPUs, profilePath)
 }
 
-func runCoverageProfile(cfg config, targetOS string, profilePath string) (coverageResult, error) {
+func runCoverageProfile(cfg config, targetOS string, logicalCPUs int, profilePath string) (coverageResult, error) {
 	coverPackages, testPackages, err := resolveCoverageLane(cfg)
 	if err != nil {
 		return coverageResult{}, err
@@ -308,7 +312,7 @@ func runCoverageProfile(cfg config, targetOS string, profilePath string) (covera
 	}
 	var functionalSelection *functionalCoverageSelection
 	if strings.TrimSpace(cfg.functionalQuarantine) != "" {
-		selection, selectedPackages, selectionErr := prepareFunctionalCoverageRun(cfg, testPackages, targetOS, repoRoot)
+		selection, selectedPackages, selectionErr := prepareFunctionalCoverageRun(cfg, testPackages, targetOS, logicalCPUs, repoRoot)
 		if selectionErr != nil {
 			return coverageResult{}, selectionErr
 		}
@@ -326,7 +330,7 @@ func runCoverageProfile(cfg config, targetOS string, profilePath string) (covera
 	coverageTestArgs := []string{
 		"test",
 		fmt.Sprintf("-coverpkg=%s", coverPackageArgument),
-		fmt.Sprintf("-p=%d", cfg.testJobs(targetOS)),
+		fmt.Sprintf("-p=%d", cfg.testJobs(targetOS, logicalCPUs)),
 		// Coverage is an authoritative measurement, so every package must run
 		// even when a prior non-instrumented invocation is cached.
 		"-count=1",
@@ -389,7 +393,7 @@ func runCoverageProfile(cfg config, targetOS string, profilePath string) (covera
 	return result, nil
 }
 
-func (cfg config) testJobs(targetOS string) int {
+func (cfg config) testJobs(targetOS string, logicalCPUs int) int {
 	if cfg.jobs > 0 {
 		return cfg.jobs
 	}
@@ -397,6 +401,15 @@ func (cfg config) testJobs(targetOS string) int {
 		// Full unit coverage instrumentation exceeds the Windows host's stable
 		// memory boundary when go test builds two instrumented packages at once.
 		return 1
+	}
+	if cfg.suite == "" || cfg.suite == "unit" {
+		// Unit coverage is one instrumented go test, so non-Windows hosts can
+		// use their full logical CPU budget without changing functional coverage.
+		if logicalCPUs > 0 {
+			return logicalCPUs
+		}
+		// Keep the historical shared default if the runtime cannot provide a
+		// usable count. runtime.NumCPU normally guarantees a positive value.
 	}
 	return defaultCoverageJobs
 }

--- a/cmd/gocoveragecheck/main_test.go
+++ b/cmd/gocoveragecheck/main_test.go
@@ -81,24 +81,71 @@ func TestCoverageTestJobs(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name     string
-		cfg      config
-		targetOS string
-		want     int
+		name        string
+		cfg         config
+		targetOS    string
+		logicalCPUs int
+		want        int
 	}{
-		{name: "unit defaults to one Windows coverage builder", cfg: config{suite: "unit"}, targetOS: "windows", want: 1},
-		{name: "empty suite defaults to one Windows unit builder", cfg: config{}, targetOS: "windows", want: 1},
-		{name: "functional keeps the shared Windows default", cfg: config{suite: "functional"}, targetOS: "windows", want: defaultCoverageJobs},
-		{name: "non-Windows keeps the shared unit default", cfg: config{suite: "unit"}, targetOS: "linux", want: defaultCoverageJobs},
-		{name: "explicit override", cfg: config{suite: "unit", jobs: 2}, targetOS: "windows", want: 2},
+		{name: "unit uses the non-Windows runner CPU count", cfg: config{suite: "unit"}, targetOS: "linux", logicalCPUs: 4, want: 4},
+		{name: "unit follows another positive non-Windows CPU count", cfg: config{suite: "unit"}, targetOS: "linux", logicalCPUs: 8, want: 8},
+		{name: "unit defaults to one Windows coverage builder", cfg: config{suite: "unit"}, targetOS: "windows", logicalCPUs: 64, want: 1},
+		{name: "empty suite defaults to one Windows unit builder", cfg: config{}, targetOS: "windows", logicalCPUs: 64, want: 1},
+		{name: "functional keeps the shared Windows default", cfg: config{suite: "functional"}, targetOS: "windows", logicalCPUs: 64, want: defaultCoverageJobs},
+		{name: "functional keeps the shared non-Windows default", cfg: config{suite: "functional"}, targetOS: "linux", logicalCPUs: 64, want: defaultCoverageJobs},
+		{name: "invalid CPU input uses the shared fallback", cfg: config{suite: "unit"}, targetOS: "linux", logicalCPUs: 0, want: defaultCoverageJobs},
+		{name: "explicit override wins on Windows", cfg: config{suite: "unit", jobs: 9}, targetOS: "windows", logicalCPUs: 64, want: 9},
+		{name: "explicit override wins on non-Windows", cfg: config{suite: "unit", jobs: 7}, targetOS: "linux", logicalCPUs: 4, want: 7},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := tc.cfg.testJobs(tc.targetOS); got != tc.want {
-				t.Fatalf("config.testJobs(%q) = %d, want %d", tc.targetOS, got, tc.want)
+			if got := tc.cfg.testJobs(tc.targetOS, tc.logicalCPUs); got != tc.want {
+				t.Fatalf("config.testJobs(%q, %d) = %d, want %d", tc.targetOS, tc.logicalCPUs, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestRunForOSWithCPUUsesDerivedUnitJobs(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	t.Cleanup(func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	})
+
+	var invocations []commandInvocation
+	var stdout strings.Builder
+	var stderr strings.Builder
+	commandRunner = func(invocation commandInvocation) (string, string, error) {
+		invocations = append(invocations, invocation)
+		return fakeGoCoverageCommandPassing(invocation)
+	}
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	_, err := runForOSWithCPU(config{
+		min:       0,
+		suite:     "unit",
+		totalOnly: true,
+		coverpkg:  strings.Join([]string{modulePath + "/pkg/config", modulePath + "/pkg/service"}, ","),
+		packages:  "./pkg/config",
+		profile:   filepath.Join(t.TempDir(), "coverage.out"),
+	}, "linux", 4)
+	if err != nil {
+		t.Fatalf("runForOSWithCPU() error = %v", err)
+	}
+	if len(invocations) != 1 {
+		t.Fatalf("coverage invocations = %d, want one", len(invocations))
+	}
+	if !slices.Contains(invocations[0].args, "-p=4") {
+		t.Fatalf("go test args = %v, want CPU-derived -p=4", invocations[0].args)
+	}
+	if stdout.Len() == 0 || stderr.Len() != 0 {
+		t.Fatalf("coverage output = stdout %q, stderr %q; want stdout only", stdout.String(), stderr.String())
 	}
 }
 


### PR DESCRIPTION
{   "project": "PERF-U1 — Scale Backend Unit Coverage Parallelism to Runner CPUs",   "branchName": "perf-u1-unit-coverage-parallelism",   "description": "Make the Backend Unit Coverage lane use the Linux runner's available CPU budget for its single instrumented go test, reducing required CI latency while preserving the Windows jobs=1 memory guard, authoritative -jobs overrides, functional-lane behavior, package selection, coverage semantics, and coverage gates.",   "context": {     "customerAsk": "Make the Backend Unit Coverage lane use the full Linux runner CPU budget for its instrumented go test, preserve the Windows memory guard and explicit override behavior, and verify that the repeated post-merge CI median meets the requested wall-time and step-time targets without coverage drift.",     "problem": "Backend Unit Coverage runs one instrumented go test across 549 packages with -p=2 on a public four-vCPU ubuntu-latest runner. The 2026-08-20 median timing artifact reported 319.3 seconds of wall time versus 212.0 seconds summed package time, and five main runs had a 6m48 coverage-step median with a 4m26-8m28 range, showing that instrumented compile/link work is CPU-throttled and that one run is insufficient performance evidence.",     "solution": "Derive the non-Windows unit default from a deterministic runtime CPU-count input, targeting four jobs on the current runner, while retaining explicit -jobs precedence and the Windows unit default of one. Keep functional jobs and every coverage semantic unchanged, prove selection with focused owner-local tests, and have review record three consecutive post-merge main run IDs, step durations, timing-artifact values, coverage outcomes, and memory observations in a PR comment rather than a commit."   },   "acceptanceCriteria": [     "On Linux, a Backend Unit Coverage invocation without -jobs selects the CPU-derived unit default and emits go test -p equal to the detected runner CPU count or an explicitly documented safe cap; on the current public four-vCPU runner the intended value is four. A positive -jobs value remains authoritative, and the Windows unit default remains one.",     "Backend Unit Coverage retains the same package selection, -coverpkg set, -count=1, -short, cover mode, timeout, manifest evaluation, total threshold, and package floors. Backend Unit Coverage total remains within normal drift of the 80.7% baseline and the same packages pass their floors. The functional coverage lane and FUNCTIONAL_DEFAULT_JOBS behavior are unchanged.",     "Across three consecutive post-merge main Backend Unit Coverage runs, the median unit-timing-summary.json wallSeconds is at most 240 seconds and the median Run backend coverage step is at most 5m30. A PR comment, never a commit, records all three run IDs, step durations, wallSeconds, selected jobs values, coverage totals, package-floor outcomes, and any observed memory ceiling; no single run is accepted as proof.",     "The change stays within cmd/gocoveragecheck/** and, only if needed for an explicit CI-side value, the test-unit-coverage target and its variables in Makefile or the backend-coverage unit matrix environment in .github/workflows/ci.yml. It does not add packages, coverage-manifest entries, generated files, functional-lane changes, or unrelated cleanup; the PR body states that cmd/gocoveragecheck is outside ./pkg/... and therefore needs no coverage-manifest entry.",     "Quality gate: Typecheck passes; focused cmd/gocoveragecheck tests and applicable broader tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",     "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The implementation/review cycle continues through required CI, explicit resolution of blocking PR conversation feedback, shared-file reconciliation, conflict resolution, and actual merge."   ],   "userStories": [     {       "id": "perf-u1-unit-coverage-parallelism-001",       "title": "Select safe runner-scale unit coverage jobs",       "description": "As a maintainer waiting on Backend Unit Coverage, I want Linux unit coverage to use the runner's available CPU budget so instrumented compilation finishes sooner without changing Windows safety, explicit overrides, functional coverage, or coverage policy.",       "acceptanceCriteria": [         "With a fake non-Windows host and CPU count of four, unit job selection returns four and the printed or captured go test command or timing evidence uses -p=4; other positive fake CPU counts produce the corresponding documented CPU-derived value or documented cap.",         "A positive explicit -jobs value wins over the CPU-derived default and the Windows guard, so callers retain authoritative control of concurrency.",         "With a fake Windows unit host and no explicit override, job selection remains one regardless of the fake CPU count, preserving local make test-unit-coverage memory safety.",         "The functional suite continues to use its explicitly supplied jobs value, and package selection, -coverpkg, -count=1, -short, cover mode, timeout, timing artifacts, manifest gating, total coverage policy, and package floors remain unchanged.",         "CPU-count and host inputs used by job selection are controllable in focused table-driven tests so expectations are deterministic on Linux and Windows development hosts; tests extend the existing cmd/gocoveragecheck test files without adding a test scaffolding package.",         "If four concurrent instrumented package builds show OOM or memory-pressure failure on the 16 GB runner, the implementation uses a measured cap of four or GOMAXPROCS-1 and explains the observed ceiling in the PR body; it does not lower coverage scope or alter the functional lane.",         "Typecheck passes",         "Tests pass"       ],       "priority": 1,       "passes": true,       "notes": "Implemented runtime CPU-derived non-Windows unit coverage jobs with deterministic CPU/OS inputs in focused tests. Explicit -jobs remains authoritative, Windows unit coverage remains at 1 by default, and functional coverage remains on the shared default. Owner-local go test and go vet pass."     }   ] }  
## Implementation scope and coverage-floor evidence

cmd/gocoveragecheck is outside ./pkg/... and therefore needs no coverage-manifest entry.

The five floor rows in the Backend Unit Coverage report are unchanged tolerated baseline diagnostics, not regressions introduced by this change. Their exact statement counts are 204/285 (pkg/services/edges), 101/121 (factory_definitions/internal/services/runtime_snapshot/internal), 739/740 (worker_sessions), 3045/3085 (worker_sessions/internal/service), and 251/268 (workers/internal/services/runners/internal/script). Each is within the existing 0.25 percentage-point manifest epsilon, so the package-floor gate passes; the report lists raw headroom diagnostics. The same five rows and counts are present in main runs 32439741480 and 32438244777. This change does not alter coverage scope, the package manifest, or floor policy.