### PR TITLE
perf-f4-log-bloat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,9 +357,21 @@ jobs:
           FUNCTIONAL_TEST_BUDGET: "75m"
           FUNCTIONAL_SHORT: "false"
           FUNCTIONAL_DEFAULT_JOBS: ${{ steps.functional-parallelism.outputs.jobs }}
+          FUNCTIONAL_GOCOVERAGE_EXIT_FILE: .artifacts/functional-test-viz/gocoveragecheck-exit-code.txt
+          FUNCTIONAL_COVERAGE_VERDICT_FILE: .artifacts/functional-test-viz/functional-coverage-verdict.txt
           INFINITE_YOU_RUN_ACPX_REAL_CLIENT: "1"
           INFINITE_YOU_REQUIRE_ACPX_REAL_CLIENT: "1"
           INFINITE_YOU_ACPX_EVIDENCE_OUTPUT: ${{ github.workspace }}/.artifacts/functional-test-viz/real-acpx-evidence.json
+      # Ordinary test and coverage-gate failures are deferred by the runner so
+      # this step is the only failing log for those outcomes. Timeout and
+      # infrastructure failures keep the full run step failed instead.
+      - name: Report functional coverage verdict
+        if: always() && matrix.suite == 'functional'
+        run: bash scripts/ci/publish-functional-coverage-verdict.sh
+        env:
+          FUNCTIONAL_TEST_VIZ_DIR: .artifacts/functional-test-viz
+          FUNCTIONAL_GOCOVERAGE_EXIT_FILE: .artifacts/functional-test-viz/gocoveragecheck-exit-code.txt
+          FUNCTIONAL_COVERAGE_VERDICT_FILE: .artifacts/functional-test-viz/functional-coverage-verdict.txt
       - name: Publish functional test job summary
         if: always() && matrix.suite == 'functional'
         run: bash scripts/ci/publish-functional-test-summary.sh
@@ -381,6 +393,8 @@ jobs:
             .artifacts/functional-test-viz/coverage.out
             .artifacts/functional-test-viz/command.log
             .artifacts/functional-test-viz/diagnostic-status.txt
+            .artifacts/functional-test-viz/gocoveragecheck-exit-code.txt
+            .artifacts/functional-test-viz/functional-coverage-verdict.txt
             .artifacts/functional-test-viz/real-acpx-evidence.json
           if-no-files-found: ignore
           retention-days: 14

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,10 @@ FUNCTIONAL_TEST_VIZ_PROFILE ?= $(FUNCTIONAL_TEST_VIZ_DIR)/coverage.out
 FUNCTIONAL_TEST_VIZ_JSON ?= $(FUNCTIONAL_TEST_VIZ_DIR)/coverage-summary.json
 FUNCTIONAL_TEST_VIZ_TIMING ?= $(FUNCTIONAL_TEST_VIZ_DIR)/functional-timing-summary.json
 FUNCTIONAL_TEST_VIZ_MARKDOWN ?= $(FUNCTIONAL_TEST_VIZ_DIR)/functional-tests.md
+# The Linux CI wrapper sets this optional handoff so an ordinary
+# gocoveragecheck failure can be reported by its compact terminal verdict step.
+# An unset path preserves the historical fail-fast target behavior.
+FUNCTIONAL_GOCOVERAGE_EXIT_FILE ?=
 BACKEND_SIZE_ROOT ?= .
 PACKAGE_MAINT_ROOT ?= .
 PACKAGE_FILE_COUNT_ROOT ?= .
@@ -483,7 +487,7 @@ readme-check:
 test: test-unit test-ci-workflows
 
 test-ci-workflows:
-	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs scripts/ci/lane-budget.test.mjs scripts/ci/backend-lint-report.test.mjs scripts/ci/backend-lint-workflow.test.mjs scripts/ci/functional-coverage-comment.test.mjs scripts/ci/unit-coverage-report.test.mjs
+	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs scripts/ci/lane-budget.test.mjs scripts/ci/backend-lint-report.test.mjs scripts/ci/backend-lint-workflow.test.mjs scripts/ci/functional-coverage-comment.test.mjs scripts/ci/functional-coverage-verdict.test.mjs scripts/ci/unit-coverage-report.test.mjs
 
 test-full:
 	$(GO) test ./... -timeout $(GO_TEST_TIMEOUT)
@@ -538,14 +542,17 @@ functional-boundary-check:
 # so already-written diagnostics (for example coverage.out / coverage-summary.json
 # after a floor fail, or those files before a render fail) remain inspectable.
 # gocoveragecheck writes -json-output after a completed measurement even when a
-# floor fails; Make then stops before Markdown so the failure stays non-zero.
+# floor fails. Without FUNCTIONAL_GOCOVERAGE_EXIT_FILE, Make stops before
+# Markdown so the failure stays non-zero; the Linux CI wrapper sets that path
+# to hand an ordinary exit-1 outcome to its compact verdict step.
 functional-test-viz:
 	$(MAKE) functional-boundary-check
 	$(call ensure_directory,$(FUNCTIONAL_TEST_VIZ_DIR))
 	$(MAKE) test-functional-coverage \
 		GO_FUNCTIONAL_COVERAGE_PROFILE=$(FUNCTIONAL_TEST_VIZ_PROFILE) \
 		GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT=$(FUNCTIONAL_TEST_VIZ_JSON) \
-		GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT=$(FUNCTIONAL_TEST_VIZ_TIMING)
+		GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT=$(FUNCTIONAL_TEST_VIZ_TIMING) \
+		FUNCTIONAL_GOCOVERAGE_EXIT_FILE=$(FUNCTIONAL_GOCOVERAGE_EXIT_FILE)
 	$(GO) run ./cmd/functionaltestviz \
 		-coverage-summary $(FUNCTIONAL_TEST_VIZ_JSON) \
 		-timing-summary $(FUNCTIONAL_TEST_VIZ_TIMING) \
@@ -691,7 +698,14 @@ test-unit-coverage:
 test-functional-coverage:
 	$(MAKE) functional-boundary-check
 	@echo "Functional tier: name=$(FUNCTIONAL_TEST_TIER) trigger=$(FUNCTIONAL_TEST_TRIGGER) short=$(FUNCTIONAL_SHORT) budget=$(FUNCTIONAL_TEST_BUDGET) selection=subtractive quarantine=$(FUNCTIONAL_QUARANTINE)"
-	$(GO) run ./cmd/gocoveragecheck -suite functional -stream -jobs $(FUNCTIONAL_DEFAULT_JOBS) -min $(GO_FUNCTIONAL_COVERAGE_MIN) -package-manifest $(GO_FUNCTIONAL_COVERAGE_MANIFEST) -functional-quarantine $(FUNCTIONAL_QUARANTINE) -timeout $(GO_COVERAGE_TIMEOUT) $(if $(filter false 0 no,$(FUNCTIONAL_SHORT)),-short=false,) $(if $(GO_FUNCTIONAL_COVERAGE_PROFILE),-profile $(GO_FUNCTIONAL_COVERAGE_PROFILE),) $(if $(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT),-json-output $(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT),) $(if $(GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT),-timing-output $(GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT),)
+	@set +e; \
+	$(GO) run ./cmd/gocoveragecheck -suite functional -stream -jobs $(FUNCTIONAL_DEFAULT_JOBS) -min $(GO_FUNCTIONAL_COVERAGE_MIN) -package-manifest $(GO_FUNCTIONAL_COVERAGE_MANIFEST) -functional-quarantine $(FUNCTIONAL_QUARANTINE) -timeout $(GO_COVERAGE_TIMEOUT) $(if $(filter false 0 no,$(FUNCTIONAL_SHORT)),-short=false,) $(if $(GO_FUNCTIONAL_COVERAGE_PROFILE),-profile $(GO_FUNCTIONAL_COVERAGE_PROFILE),) $(if $(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT),-json-output $(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT),) $(if $(GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT),-timing-output $(GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT),); \
+	status=$$?; \
+	if [ -n "$(FUNCTIONAL_GOCOVERAGE_EXIT_FILE)" ]; then \
+		printf '%s\n' "$$status" > "$(FUNCTIONAL_GOCOVERAGE_EXIT_FILE)"; \
+		if [ "$$status" -eq 1 ]; then exit 0; fi; \
+	fi; \
+	exit "$$status"
 
 script-timeout-companion-smoke-100:
 	$(GO) test -tags=$(FUNCTIONAL_LONG_TAGS) ./tests/functional/workers/inference -run $(SCRIPT_TIMEOUT_COMPANION_SMOKE_TEST) -count=$(SCRIPT_TIMEOUT_COMPANION_SMOKE_COUNT) -timeout $(SCRIPT_TIMEOUT_COMPANION_SMOKE_TIMEOUT)

--- a/cmd/gocoveragecheck/functional_diagnostics.go
+++ b/cmd/gocoveragecheck/functional_diagnostics.go
@@ -273,7 +273,7 @@ func (snapshotter *functionalTimingSnapshotter) finish(summary functionalTimingS
 	}
 	snapshotter.publishCoverageSnapshotLocked(true)
 	if !summary.Complete || strings.TrimSpace(reason) != "" {
-		snapshotter.emitSummary(summary, reason)
+		snapshotter.emitSummary(summary, reason, true)
 	}
 	return snapshotter.writeErr
 }
@@ -294,7 +294,7 @@ func (snapshotter *functionalTimingSnapshotter) publish(complete bool, reason st
 	}
 	snapshotter.publishCoverageSnapshotLocked(false)
 	if emit {
-		snapshotter.emitSummary(summary, reason)
+		snapshotter.emitSummary(summary, reason, false)
 	}
 }
 
@@ -312,12 +312,15 @@ func (snapshotter *functionalTimingSnapshotter) publishCoverageSnapshotLocked(fo
 	}
 }
 
-func (snapshotter *functionalTimingSnapshotter) emitSummary(summary functionalTimingSummaryJSON, reason string) {
+func (snapshotter *functionalTimingSnapshotter) emitSummary(summary functionalTimingSummaryJSON, reason string, includePackageStates bool) {
 	if snapshotter.sink == nil {
 		return
 	}
 	write := func() {
 		fmt.Fprintf(snapshotter.sink, "Functional timing snapshot: complete=%t packages=%d/%d wall=%.3fs reason=%s\n", summary.Complete, summary.PackageCount, summary.ExpectedPackageCount, summary.WallSeconds, reason)
+		if !includePackageStates {
+			return
+		}
 		for _, state := range summary.PackageStates {
 			if state.State == functionalPackageStateCompleted {
 				continue

--- a/cmd/gocoveragecheck/functional_diagnostics_test.go
+++ b/cmd/gocoveragecheck/functional_diagnostics_test.go
@@ -62,6 +62,51 @@ func TestFunctionalTimingSnapshotWritesMachineReadablePartialArtifact(t *testing
 	}
 }
 
+func TestFunctionalTimingSnapshotDoesNotRepeatPackageStatesDuringCompleteRun(t *testing.T) {
+	packages := []string{"pkg/alpha", "pkg/beta"}
+	tracker := newFunctionalTimingTracker(packages, time.Unix(300, 0))
+	var sink strings.Builder
+	snapshotter := newFunctionalTimingSnapshotter(tracker, "", &sink, nil)
+
+	snapshotter.observe(goTestTimingEvent{Action: "start", Package: packages[0]})
+	snapshotter.observe(goTestTimingEvent{Action: timingOutcomePass, Package: packages[0], Elapsed: 1})
+	snapshotter.observe(goTestTimingEvent{Action: "start", Package: packages[1]})
+	snapshotter.observe(goTestTimingEvent{Action: timingOutcomePass, Package: packages[1], Elapsed: 2})
+	if err := snapshotter.finish(functionalTimingSummaryJSON{Complete: true}, ""); err != nil {
+		t.Fatalf("finish complete timing snapshot: %v", err)
+	}
+
+	if got := strings.Count(sink.String(), "Functional package state:"); got != 0 {
+		t.Fatalf("complete run emitted %d package-state lines, want none; output=%q", got, sink.String())
+	}
+}
+
+func TestFunctionalTimingSnapshotEmitsIncompletePackageStatesOnceAtFinish(t *testing.T) {
+	packages := []string{"pkg/alpha", "pkg/beta", "pkg/gamma"}
+	tracker := newFunctionalTimingTracker(packages, time.Unix(400, 0))
+	var sink strings.Builder
+	snapshotter := newFunctionalTimingSnapshotter(tracker, "", &sink, nil)
+
+	snapshotter.observe(goTestTimingEvent{Action: "start", Package: packages[0]})
+	snapshotter.observe(goTestTimingEvent{Action: timingOutcomePass, Package: packages[1], Elapsed: 1})
+	if err := snapshotter.finish(functionalTimingSummaryJSON{Complete: false}, "tier budget expired"); err != nil {
+		t.Fatalf("finish incomplete timing snapshot: %v", err)
+	}
+
+	output := sink.String()
+	if got := strings.Count(output, "Functional package state:"); got != 2 {
+		t.Fatalf("incomplete run emitted %d package-state lines, want two; output=%q", got, output)
+	}
+	for _, packageName := range []string{packages[0], packages[2]} {
+		if got := strings.Count(output, "Functional package state: package="+packageName+" "); got != 1 {
+			t.Fatalf("package %q appeared in %d final state lines, want one; output=%q", packageName, got, output)
+		}
+	}
+	if strings.Contains(output, "Functional package state: package="+packages[1]+" ") {
+		t.Fatalf("completed package appeared in final state listing: %q", output)
+	}
+}
+
 func TestWritePartialCoverageSnapshotSkipsUntrustworthyProfile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "coverage-summary.json")
 	err := writePartialCoverageSnapshot(

--- a/cmd/gocoveragecheck/functional_stream.go
+++ b/cmd/gocoveragecheck/functional_stream.go
@@ -114,6 +114,9 @@ func (writer *functionalStreamWriter) writeLineLocked(line []byte) error {
 			return err
 		}
 	}
+	if isKnownFunctionalLifecycleAction(event.Action) {
+		return nil
+	}
 
 	switch event.Action {
 	case "output":
@@ -157,6 +160,18 @@ func (writer *functionalStreamWriter) writeLineLocked(line []byte) error {
 		// discarded if go test adds an event action this reporter does not
 		// understand yet.
 		return writer.reporter.writeSink(line)
+	}
+}
+
+// isKnownFunctionalLifecycleAction identifies test2json events that carry
+// timing state but no human-readable diagnostics. The observer above still
+// receives each event so timing snapshots and coverage tracking stay current.
+func isKnownFunctionalLifecycleAction(action string) bool {
+	switch action {
+	case "start", "run", "pause", "cont":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/cmd/gocoveragecheck/functional_stream_test.go
+++ b/cmd/gocoveragecheck/functional_stream_test.go
@@ -53,6 +53,67 @@ func TestFunctionalStreamReportsPackageBeforeChildCompletes(t *testing.T) {
 	}
 }
 
+func TestFunctionalStreamSuppressesKnownLifecycleActionsButNotObserverUpdates(t *testing.T) {
+	var sink bytes.Buffer
+	observed := make([]goTestTimingEvent, 0, 4)
+	reporter := newFunctionalStreamReporterWithObserver(&sink, func(event goTestTimingEvent) {
+		observed = append(observed, event)
+	})
+	writer := reporter.stdoutWriter()
+	packageName := modulePath + "/tests/functional/streaming"
+	for _, action := range []string{"start", "run", "pause", "cont"} {
+		if _, err := writer.Write(marshalFunctionalStreamEvent(goTestTimingEvent{
+			Action:  action,
+			Package: packageName,
+		})); err != nil {
+			t.Fatalf("write %s event: %v", action, err)
+		}
+	}
+
+	if got := sink.String(); got != "" {
+		t.Fatalf("known lifecycle events reached the human stream: %q", got)
+	}
+	if len(observed) != 4 {
+		t.Fatalf("observer saw %d lifecycle events, want 4", len(observed))
+	}
+	for index, action := range []string{"start", "run", "pause", "cont"} {
+		if observed[index].Action != action || observed[index].Package != packageName {
+			t.Fatalf("observer event %d = %+v, want action=%s package=%s", index, observed[index], action, packageName)
+		}
+	}
+}
+
+func TestFunctionalStreamPreservesUnknownActionAndNormalOutputAndResult(t *testing.T) {
+	var sink bytes.Buffer
+	reporter := newFunctionalStreamReporter(&sink)
+	writer := reporter.stdoutWriter()
+	packageName := modulePath + "/tests/functional/streaming"
+	unknown := []byte(`{"Time":"2026-08-20T12:00:00Z","Action":"future","Package":"` + packageName + `","Test":"TestFuture"}` + "\n")
+	if _, err := writer.Write(unknown); err != nil {
+		t.Fatalf("write unknown action: %v", err)
+	}
+	if _, err := writer.Write(marshalFunctionalStreamEvent(goTestTimingEvent{
+		Action:  "output",
+		Package: packageName,
+		Output:  "--- FAIL: TestVisible (0.01s)\n",
+	})); err != nil {
+		t.Fatalf("write output event: %v", err)
+	}
+	if _, err := writer.Write(marshalFunctionalStreamEvent(goTestTimingEvent{
+		Action:  timingOutcomeFail,
+		Package: packageName,
+		Elapsed: 0.01,
+	})); err != nil {
+		t.Fatalf("write package result event: %v", err)
+	}
+
+	want := string(unknown) + "--- FAIL: TestVisible (0.01s)\n" +
+		"Functional package result: package=" + packageName + " outcome=fail elapsed=0.010s\n"
+	if got := sink.String(); got != want {
+		t.Fatalf("functional stream = %q, want unknown action, output, and result %q", got, want)
+	}
+}
+
 func TestFunctionalStreamCompactsSuccessfulPackageCoverageList(t *testing.T) {
 	var sink bytes.Buffer
 	reporter := newFunctionalStreamReporter(&sink)

--- a/cmd/gocoveragecheck/unit_report_test.go
+++ b/cmd/gocoveragecheck/unit_report_test.go
@@ -455,10 +455,10 @@ func TestNonStreamingTimingObserverDoesNotWritePerEvent(t *testing.T) {
 	}
 }
 
-// TestStreamingTimingObserverStillPublishesPerEvent pins the functional lane's
-// behaviour in place: its progress lines are the live log a reader watches, so
-// the per-event publish must survive for a lane that has a sink.
-func TestStreamingTimingObserverStillPublishesPerEvent(t *testing.T) {
+// TestStreamingTimingObserverStillPublishesProgressSnapshot pins the
+// functional lane's one-line progress output while ensuring package states
+// remain reserved for the final incomplete snapshot.
+func TestStreamingTimingObserverStillPublishesProgressSnapshot(t *testing.T) {
 	packages := []string{modulePath + "/tests/functional/alpha", modulePath + "/tests/functional/beta"}
 	timingPath := filepath.Join(t.TempDir(), "functional-timing-summary.json")
 	tracker := newFunctionalTimingTracker(packages, time.Now())
@@ -469,7 +469,10 @@ func TestStreamingTimingObserverStillPublishesPerEvent(t *testing.T) {
 	snapshotter.stopAndWait()
 
 	if !strings.Contains(sink.String(), "Functional timing snapshot:") {
-		t.Fatalf("streaming lane emitted no progress line per event; got %q", sink.String())
+		t.Fatalf("streaming lane emitted no progress line; got %q", sink.String())
+	}
+	if strings.Contains(sink.String(), "Functional package state:") {
+		t.Fatalf("streaming progress emitted package state before final snapshot; got %q", sink.String())
 	}
 }
 

--- a/scripts/ci/functional-coverage-verdict.mjs
+++ b/scripts/ci/functional-coverage-verdict.mjs
@@ -36,7 +36,7 @@ function isCompactVerdictLine(line) {
 		line.startsWith("  tally:") ||
 		line.startsWith("package coverage regression:") ||
 		line.startsWith("coverage not evaluated:") ||
-		/^go coverage (?:found |.* below minimum |.* meets minimum )/.test(line)
+		/^(?:go|Go) coverage (?:found |.* below minimum |.* meets minimum )/.test(line)
 	);
 }
 

--- a/scripts/ci/functional-coverage-verdict.mjs
+++ b/scripts/ci/functional-coverage-verdict.mjs
@@ -1,0 +1,222 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const inventoryPrefix = "Functional suite inventory:";
+const ordinaryGocoverageExitCode = 1;
+
+export function parseRecordedExitCode(value, source = "recorded exit code") {
+	const normalized = String(value).trim();
+	if (!/^\d+$/.test(normalized)) {
+		throw new Error(`${source} must contain one non-negative integer (got ${JSON.stringify(normalized)})`);
+	}
+	const exitCode = Number(normalized);
+	if (!Number.isSafeInteger(exitCode) || exitCode > 255) {
+		throw new Error(`${source} is outside the supported process exit-code range (got ${normalized})`);
+	}
+	return exitCode;
+}
+
+export function readRecordedExitCode(path) {
+	return parseRecordedExitCode(readFileSync(path, "utf8"), path);
+}
+
+function normalizedLines(log) {
+	return String(log).replace(/\r\n?/g, "\n").split("\n");
+}
+
+function isCompactVerdictLine(line) {
+	return (
+		line.startsWith(inventoryPrefix) ||
+		line.startsWith("total: (statements)") ||
+		line.startsWith("Functional package coverage verdict:") ||
+		line.startsWith("  floor violation:") ||
+		line === "  floor violations: none" ||
+		line.startsWith("  package=") ||
+		line.startsWith("  tally:") ||
+		line.startsWith("package coverage regression:") ||
+		line.startsWith("coverage not evaluated:") ||
+		/^go coverage (?:found |.* below minimum |.* meets minimum )/.test(line)
+	);
+}
+
+function hasCoverageGateFailure(lines) {
+	return lines.some(
+		(line) =>
+			line.startsWith("package coverage regression:") ||
+			line.startsWith("go coverage found ") ||
+			/^go coverage .* below minimum /.test(line) ||
+			/\bgate-failures=[1-9]\d*/.test(line),
+	);
+}
+
+function hasOrdinaryTestFailure(lines) {
+	return lines.some((line) => line.startsWith("coverage not evaluated:"));
+}
+
+function hasGreenGate(lines) {
+	return lines.some((line) => /^Go coverage .* meets minimum /.test(line));
+}
+
+export function extractFunctionalCoverageVerdict(log) {
+	const lines = normalizedLines(log);
+	// Use the terminal inventory when a test itself happens to print the same
+	// prefix earlier in the full stream.
+	const inventoryIndex = lines.findLastIndex((line) => line.startsWith(inventoryPrefix));
+	if (inventoryIndex < 0) {
+		return {
+			foundInventory: false,
+			text: "",
+			lines: [],
+			hasCoverageGateFailure: false,
+			hasOrdinaryTestFailure: false,
+			hasGreenGate: false,
+		};
+	}
+
+	const tail = lines.slice(inventoryIndex);
+	const verdictLines = tail.filter(isCompactVerdictLine);
+	const text = verdictLines.length > 0 ? `${verdictLines.join("\n")}\n` : "";
+	return {
+		foundInventory: true,
+		text,
+		lines: verdictLines,
+		hasCoverageGateFailure: hasCoverageGateFailure(tail),
+		hasOrdinaryTestFailure: hasOrdinaryTestFailure(tail),
+		hasGreenGate: hasGreenGate(tail),
+	};
+}
+
+export function classifyFunctionalCoverageRun({ commandExitCode = 0, gocoverageExitCode, log }) {
+	const extraction = extractFunctionalCoverageVerdict(log);
+	if (commandExitCode === 124 || commandExitCode === 125) {
+		return {
+			outcome: "timeout",
+			shouldDeferFailure: false,
+			exitCode: commandExitCode,
+			extraction,
+			reason: `functional runner exited with timeout status ${commandExitCode}`,
+		};
+	}
+	if (commandExitCode !== 0) {
+		return {
+			outcome: "infrastructure-failure",
+			shouldDeferFailure: false,
+			exitCode: commandExitCode,
+			extraction,
+			reason: `functional runner exited with infrastructure status ${commandExitCode}`,
+		};
+	}
+	if (!Number.isInteger(gocoverageExitCode)) {
+		return {
+			outcome: "infrastructure-failure",
+			shouldDeferFailure: false,
+			exitCode: 1,
+			extraction,
+			reason: "gocoveragecheck did not record an exit code",
+		};
+	}
+	if (gocoverageExitCode === 0 && extraction.foundInventory && extraction.hasGreenGate) {
+		return {
+			outcome: "green",
+			shouldDeferFailure: false,
+			exitCode: 0,
+			extraction,
+			reason: "functional coverage and test gates passed",
+		};
+	}
+	if (
+		gocoverageExitCode === ordinaryGocoverageExitCode &&
+		extraction.foundInventory &&
+		extraction.hasCoverageGateFailure
+	) {
+		return {
+			outcome: "coverage-gate-failure",
+			shouldDeferFailure: true,
+			exitCode: gocoverageExitCode,
+			extraction,
+			reason: "gocoveragecheck recorded a coverage-gate failure",
+		};
+	}
+	if (
+		gocoverageExitCode === ordinaryGocoverageExitCode &&
+		extraction.foundInventory &&
+		extraction.hasOrdinaryTestFailure
+	) {
+		return {
+			outcome: "test-failure",
+			shouldDeferFailure: true,
+			exitCode: gocoverageExitCode,
+			extraction,
+			reason: "gocoveragecheck recorded an ordinary test failure",
+		};
+	}
+	return {
+		outcome: "infrastructure-failure",
+		shouldDeferFailure: false,
+		exitCode: gocoverageExitCode || 1,
+		extraction,
+		reason: `gocoveragecheck exit ${gocoverageExitCode} had no recognized complete verdict`,
+	};
+}
+
+function parseArguments(argv) {
+	const values = {};
+	for (let index = 0; index < argv.length; index += 1) {
+		const argument = argv[index];
+		if (!argument.startsWith("--") || index + 1 >= argv.length) {
+			throw new Error(`expected a value after ${argument}`);
+		}
+		values[argument.slice(2)] = argv[index + 1];
+		index += 1;
+	}
+	for (const name of ["log", "exit-code-file", "output"]) {
+		if (!values[name]) {
+			throw new Error(`--${name} is required`);
+		}
+	}
+	return values;
+}
+
+export function writeFunctionalCoverageVerdict({ logPath, exitCodePath, outputPath }) {
+	const log = readFileSync(logPath, "utf8");
+	const gocoverageExitCode = readRecordedExitCode(exitCodePath);
+	const classification = classifyFunctionalCoverageRun({
+		commandExitCode: 0,
+		gocoverageExitCode,
+		log,
+	});
+	if (classification.outcome === "infrastructure-failure") {
+		throw new Error(classification.reason);
+	}
+	if (!classification.extraction.text) {
+		throw new Error("functional coverage verdict extract is empty");
+	}
+	mkdirSync(dirname(resolve(outputPath)), { recursive: true });
+	writeFileSync(outputPath, classification.extraction.text, "utf8");
+	return classification;
+}
+
+function runCli(argv) {
+	const args = parseArguments(argv);
+	const classification = writeFunctionalCoverageVerdict({
+		logPath: args.log,
+		exitCodePath: args["exit-code-file"],
+		outputPath: args.output,
+	});
+	console.log(
+		`Functional coverage capture: outcome=${classification.outcome} ` +
+		`gocoveragecheck-exit-code=${classification.exitCode} ` +
+		`verdict-bytes=${Buffer.byteLength(classification.extraction.text, "utf8")}`,
+	);
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : "";
+if (invokedPath === import.meta.url) {
+	try {
+		runCli(process.argv.slice(2));
+	} catch (error) {
+		console.error(`Functional coverage verdict unavailable: ${error.message}`);
+		process.exitCode = 1;
+	}
+}

--- a/scripts/ci/functional-coverage-verdict.test.mjs
+++ b/scripts/ci/functional-coverage-verdict.test.mjs
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+import {
+	classifyFunctionalCoverageRun,
+	extractFunctionalCoverageVerdict,
+	parseRecordedExitCode,
+} from "./functional-coverage-verdict.mjs";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const runnerPath = "scripts/ci/run-functional-test-viz.sh";
+const publishPath = "scripts/ci/publish-functional-coverage-verdict.sh";
+
+function requireBash(t) {
+	if (process.platform === "win32") {
+		t.skip("POSIX workflow smoke test runs on the Linux CI runner");
+		return false;
+	}
+	const result = spawnSync("bash", ["-c", "exit 0"], { encoding: "utf8" });
+	if (result.error) {
+		t.skip(`Bash workflow smoke test requires bash: ${result.error.message}`);
+		return false;
+	}
+	return true;
+}
+
+function writeFakeMake(t, outcome) {
+	const path = join(mkdtempSync(join(tmpdir(), "functional-verdict-")), "fake-make.sh");
+	const body = `#!/bin/sh
+exit_file=""
+for argument in "$@"; do
+  case "$argument" in
+    FUNCTIONAL_GOCOVERAGE_EXIT_FILE=*) exit_file="\${argument#*=}" ;;
+  esac
+done
+case "${outcome}" in
+  green)
+    printf '%s\\n' 'Functional suite inventory: discovered-packages=2 observed-packages=2 (pass=2 fail=0 skip=0) top-level-tests=2 (pass=2 fail=0 skip=0) deferred-short-tests=0 wall=1.000s complete=true'
+    printf '%s\\n' 'total: (statements) 80.0%'
+    printf '%s\\n' 'Functional package coverage verdict:'
+    printf '%s\\n' '  floor violations: none'
+    printf '%s\\n' '  package=github.com/portpowered/infinite-you/pkg/alpha coverage=80.0% floor=75.0% delta=+5.0pp gate=pass lane=functional'
+    printf '%s\\n' '  tally: measured-packages=1 gated-packages=1 below-floor=0 near-floor=0 gate-failures=0'
+    printf '%s\\n' 'Go coverage 80.0% meets minimum 33.1%.'
+    printf '%s\\n' 'full functional stream remains in command.log'
+    printf '%s\\n' '0' > "$exit_file"
+    ;;
+  gate)
+    printf '%s\\n' 'full functional stream remains in command.log'
+    printf '%s\\n' 'Functional suite inventory: discovered-packages=2 observed-packages=2 (pass=2 fail=0 skip=0) top-level-tests=2 (pass=2 fail=0 skip=0) deferred-short-tests=0 wall=1.000s complete=true'
+    printf '%s\\n' 'total: (statements) 70.0%'
+    printf '%s\\n' 'Functional package coverage verdict:'
+    printf '%s\\n' '  floor violation: package=github.com/portpowered/infinite-you/pkg/alpha floor=75.0000% actual=70.0000% delta=-5.0000 percentage-points covered=7/10 statements uncovered-blocks=3'
+    printf '%s\\n' '  package=github.com/portpowered/infinite-you/pkg/alpha coverage=70.0% floor=75.0% delta=-5.0pp gate=fail lane=functional'
+    printf '%s\\n' '  tally: measured-packages=1 gated-packages=1 below-floor=1 near-floor=0 gate-failures=1'
+    printf '%s\\n' 'package coverage regression: package=github.com/portpowered/infinite-you/pkg/alpha lane=functional expected-minimum=75.00% actual=70.0000% delta=-5.0000 percentage-points covered=7/10 statements'
+    printf '%s\\n' 'package coverage regression: package=github.com/portpowered/infinite-you/pkg/beta lane=functional expected-minimum=75.00% actual=60.0000% delta=-15.0000 percentage-points covered=6/10 statements'
+    printf '%s\\n' '1' > "$exit_file"
+    ;;
+  test)
+    printf '%s\\n' 'full functional stream remains in command.log'
+    printf '%s\\n' 'Functional suite inventory: discovered-packages=2 observed-packages=2 (pass=1 fail=1 skip=0) top-level-tests=2 (pass=1 fail=1 skip=0) deferred-short-tests=0 wall=1.000s complete=true'
+    printf '%s\\n' 'coverage not evaluated: 1 failed tests observed; package floors were NOT checked because the coverage test run failed'
+    printf '%s\\n' '1' > "$exit_file"
+    ;;
+  infra)
+    printf '%s\\n' 'missing tool: go was not found'
+    printf '%s\\n' '1' > "$exit_file"
+    ;;
+esac
+`;
+	writeFileSync(path, body, "utf8");
+	chmodSync(path, 0o755);
+	return path;
+}
+
+function runFunctionalRunner(t, outcome) {
+	const artifactRoot = mkdtempSync(join(tmpdir(), `functional-verdict-${outcome}-`));
+	const makePath = writeFakeMake(t, outcome);
+	return {
+		artifactRoot,
+		result: spawnSync("bash", [runnerPath], {
+			cwd: repositoryRoot,
+			env: {
+				...process.env,
+				FUNCTIONAL_TEST_VIZ_DIR: artifactRoot,
+				FUNCTIONAL_TEST_BUDGET: "5s",
+				FUNCTIONAL_TEST_TIER: "test",
+				FUNCTIONAL_TEST_TRIGGER: "node-test",
+				MAKE_BIN: makePath.replaceAll("\\", "/"),
+				NODE_BIN: process.execPath,
+			},
+			encoding: "utf8",
+		}),
+	};
+}
+
+test("extracts the compact verdict and every package regression without raw stream noise", () => {
+	const rawLine = `{"Time":"2026-08-20T00:00:00Z","Action":"run","Package":"github.com/portpowered/infinite-you/tests/functional"}`;
+	const log = [
+		rawLine,
+		"Functional suite inventory: discovered-packages=3 observed-packages=3 (pass=1 fail=0 skip=0) top-level-tests=1 (pass=1 fail=0 skip=0) deferred-short-tests=0 wall=1.000s complete=true",
+		"total: (statements) 70.0%",
+		"Functional package coverage verdict:",
+		"  floor violation: package=github.com/portpowered/infinite-you/pkg/alpha floor=75.0000% actual=70.0000% delta=-5.0000 percentage-points covered=7/10 statements uncovered-blocks=3",
+		"  package=github.com/portpowered/infinite-you/pkg/alpha coverage=70.0% floor=75.0% delta=-5.0pp gate=fail lane=functional",
+		"  tally: measured-packages=2 gated-packages=2 below-floor=1 near-floor=0 gate-failures=1",
+		"package coverage regression: package=github.com/portpowered/infinite-you/pkg/alpha lane=functional expected-minimum=75.00% actual=70.0000% delta=-5.0000 percentage-points covered=7/10 statements",
+		"package coverage regression: package=github.com/portpowered/infinite-you/pkg/beta lane=functional expected-minimum=75.00% actual=60.0000% delta=-15.0000 percentage-points covered=6/10 statements",
+		"make: *** [functional-test-viz] Error 1",
+	].join("\n");
+
+	const extracted = extractFunctionalCoverageVerdict(log);
+	assert.equal(extracted.foundInventory, true);
+	assert.equal(extracted.hasCoverageGateFailure, true);
+	assert.equal(extracted.lines.filter((line) => line.startsWith("package coverage regression:")).length, 2);
+	assert.equal(extracted.text.includes(rawLine), false);
+	assert.equal(extracted.text.includes("make: ***"), false);
+	assert.match(extracted.text, /Functional suite inventory:/);
+});
+
+test("captures the exact recorded gocoveragecheck exit code", () => {
+	assert.equal(parseRecordedExitCode("17\n", "test exit file"), 17);
+	assert.throws(() => parseRecordedExitCode("17 18", "test exit file"), /one non-negative integer/);
+	assert.throws(() => parseRecordedExitCode("256", "test exit file"), /outside the supported/);
+});
+
+test("defers ordinary test and coverage-gate failures but propagates timeout and infrastructure outcomes", () => {
+	const testFailure = classifyFunctionalCoverageRun({
+		commandExitCode: 0,
+		gocoverageExitCode: 1,
+		log: "Functional suite inventory: discovered-packages=1 observed-packages=1 (pass=0 fail=1 skip=0)\ncoverage not evaluated: test failed",
+	});
+	assert.equal(testFailure.outcome, "test-failure");
+	assert.equal(testFailure.shouldDeferFailure, true);
+
+	const gateFailure = classifyFunctionalCoverageRun({
+		commandExitCode: 0,
+		gocoverageExitCode: 1,
+		log: "Functional suite inventory: discovered-packages=1 observed-packages=1 (pass=1 fail=0 skip=0)\nFunctional package coverage verdict:\n  tally: gate-failures=1\npackage coverage regression: package=p",
+	});
+	assert.equal(gateFailure.outcome, "coverage-gate-failure");
+	assert.equal(gateFailure.shouldDeferFailure, true);
+
+	const timeout = classifyFunctionalCoverageRun({ commandExitCode: 124, gocoverageExitCode: 1, log: "" });
+	assert.equal(timeout.outcome, "timeout");
+	assert.equal(timeout.shouldDeferFailure, false);
+	assert.equal(timeout.exitCode, 124);
+
+	const infrastructure = classifyFunctionalCoverageRun({
+		commandExitCode: 0,
+		gocoverageExitCode: 1,
+		log: "missing tool: go was not found",
+	});
+	assert.equal(infrastructure.outcome, "infrastructure-failure");
+	assert.equal(infrastructure.shouldDeferFailure, false);
+});
+
+test("green runner remains successful and records its compact verdict", (t) => {
+	if (!requireBash(t)) return;
+	const { artifactRoot, result } = runFunctionalRunner(t, "green");
+	assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+	const verdictPath = join(artifactRoot, "functional-coverage-verdict.txt");
+	assert.ok(existsSync(verdictPath));
+	assert.match(readFileSync(verdictPath, "utf8"), /Go coverage 80\.0% meets minimum/);
+	assert.equal(readFileSync(join(artifactRoot, "gocoveragecheck-exit-code.txt"), "utf8").trim(), "0");
+});
+
+test("recorded nonzero verdict fails only in the final verdict step", (t) => {
+	if (!requireBash(t)) return;
+	const { artifactRoot, result } = runFunctionalRunner(t, "gate");
+	assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+	const summaryPath = join(artifactRoot, "summary.md");
+	const verdict = readFileSync(join(artifactRoot, "functional-coverage-verdict.txt"), "utf8");
+	const publish = spawnSync("bash", [publishPath], {
+		cwd: repositoryRoot,
+		env: {
+			...process.env,
+			FUNCTIONAL_TEST_VIZ_DIR: artifactRoot,
+			GITHUB_STEP_SUMMARY: summaryPath,
+		},
+		encoding: "utf8",
+	});
+	assert.equal(publish.status, 1, `${publish.stdout}\n${publish.stderr}`);
+	assert.equal(publish.stdout.includes(verdict), true);
+	assert.equal(readFileSync(summaryPath, "utf8").includes(verdict), true);
+});
+
+test("infrastructure failure keeps the full runner step red", (t) => {
+	if (!requireBash(t)) return;
+	const { artifactRoot, result } = runFunctionalRunner(t, "infra");
+	assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
+	assert.equal(existsSync(join(artifactRoot, "functional-coverage-verdict.txt")), false);
+});

--- a/scripts/ci/functional-coverage-verdict.test.mjs
+++ b/scripts/ci/functional-coverage-verdict.test.mjs
@@ -130,6 +130,19 @@ test("captures the exact recorded gocoveragecheck exit code", () => {
 	assert.throws(() => parseRecordedExitCode("256", "test exit file"), /outside the supported/);
 });
 
+test("retains the uppercase final green coverage gate in the compact extract", () => {
+	const extracted = extractFunctionalCoverageVerdict(
+		[
+			"Functional suite inventory: discovered-packages=1 observed-packages=1 complete=true",
+			"Functional package coverage verdict:",
+			"  tally: measured-packages=1 gated-packages=1 below-floor=0 near-floor=0 gate-failures=0",
+			"Go coverage 80.0% meets minimum 33.1%.",
+		].join("\n"),
+	);
+	assert.equal(extracted.hasGreenGate, true);
+	assert.match(extracted.text, /Go coverage 80\.0% meets minimum 33\.1%\./);
+});
+
 test("defers ordinary test and coverage-gate failures but propagates timeout and infrastructure outcomes", () => {
 	const testFailure = classifyFunctionalCoverageRun({
 		commandExitCode: 0,

--- a/scripts/ci/publish-functional-coverage-verdict.sh
+++ b/scripts/ci/publish-functional-coverage-verdict.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+artifact_root="${FUNCTIONAL_TEST_VIZ_DIR:-.artifacts/functional-test-viz}"
+verdict_path="${FUNCTIONAL_COVERAGE_VERDICT_FILE:-$artifact_root/functional-coverage-verdict.txt}"
+exit_path="${FUNCTIONAL_GOCOVERAGE_EXIT_FILE:-$artifact_root/gocoveragecheck-exit-code.txt}"
+
+# A timeout, missing tool, or other infrastructure failure already makes the
+# full-stream run step red and has no compact gocoverage verdict to replay.
+# Keep this always-run reporting step successful so it cannot hide that
+# original diagnostic outcome.
+if [ ! -f "$verdict_path" ] || [ ! -f "$exit_path" ]; then
+	printf '%s\n' "Functional coverage verdict unavailable: run step did not produce a classified verdict."
+	exit 0
+fi
+
+exit_code="$(tr -d '[:space:]' < "$exit_path")"
+if ! [[ "$exit_code" =~ ^[0-9]+$ ]] || [ "$exit_code" -gt 255 ]; then
+	printf '%s\n' "Functional coverage verdict unavailable: recorded gocoveragecheck exit code is invalid: $exit_code" >&2
+	exit 1
+fi
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+	{
+		printf '%s\n\n' "## Functional coverage verdict"
+		cat "$verdict_path"
+	} | tee -a "$GITHUB_STEP_SUMMARY"
+else
+	cat "$verdict_path"
+fi
+
+exit "$exit_code"

--- a/scripts/ci/run-functional-test-viz.sh
+++ b/scripts/ci/run-functional-test-viz.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 artifact_root="${FUNCTIONAL_TEST_VIZ_DIR:-.artifacts/functional-test-viz}"
 make_bin="${MAKE_BIN:-make}"
+node_bin="${NODE_BIN:-node}"
 tier="${FUNCTIONAL_TEST_TIER:-pr-short}"
 trigger="${FUNCTIONAL_TEST_TRIGGER:-local}"
 budget="${FUNCTIONAL_TEST_BUDGET:-35m}"
@@ -16,11 +17,13 @@ coverage_path="${FUNCTIONAL_TEST_VIZ_JSON:-$artifact_root/coverage-summary.json}
 profile_path="${FUNCTIONAL_TEST_VIZ_PROFILE:-$artifact_root/coverage.out}"
 markdown_path="${FUNCTIONAL_TEST_VIZ_MARKDOWN:-$artifact_root/functional-tests.md}"
 status_path="$artifact_root/diagnostic-status.txt"
+gocoverage_exit_path="${FUNCTIONAL_GOCOVERAGE_EXIT_FILE:-$artifact_root/gocoveragecheck-exit-code.txt}"
+verdict_path="${FUNCTIONAL_COVERAGE_VERDICT_FILE:-$artifact_root/functional-coverage-verdict.txt}"
 
 mkdir -p "$artifact_root"
 # Each invocation owns these outputs. Remove them before starting so a later
 # timeout cannot publish a complete artifact produced by an earlier run.
-rm -f "$status_path" "$timing_path" "$coverage_path" "$profile_path" "$markdown_path"
+rm -f "$status_path" "$timing_path" "$coverage_path" "$profile_path" "$markdown_path" "$gocoverage_exit_path" "$verdict_path"
 
 printf '%s\n' \
   "Functional CI runner: tier=$tier trigger=$trigger short=$short budget=$budget selection=subtractive quarantine=$quarantine jobs=$functional_jobs" \
@@ -52,6 +55,7 @@ timeout --signal=TERM --kill-after=30s "$budget" \
     FUNCTIONAL_TEST_BUDGET="$budget" \
     FUNCTIONAL_SHORT="$short" \
     FUNCTIONAL_QUARANTINE="$quarantine" \
+    FUNCTIONAL_GOCOVERAGE_EXIT_FILE="$gocoverage_exit_path" \
     2>&1 | tee -a "$log_path"
 pipeline_status=("${PIPESTATUS[@]}")
 set -e
@@ -155,6 +159,33 @@ if [ "$command_status" -ne 0 ]; then
   printf '%s\n' "Functional CI runner: tier failed with exit=$command_status; diagnostics retained under $artifact_root." \
     | tee -a "$log_path" >&2
   exit "$command_status"
+fi
+
+# The Make target deliberately records only gocoveragecheck's ordinary exit 1
+# so its complete stream can remain in this successful run step. Classify that
+# handoff from the compact terminal markers and write the extract consumed by
+# the final failing verdict step. Any unrecognized or missing handoff is an
+# infrastructure failure and keeps this full-stream step red.
+set +e
+"$node_bin" scripts/ci/functional-coverage-verdict.mjs \
+  --log "$log_path" \
+  --exit-code-file "$gocoverage_exit_path" \
+  --output "$verdict_path" \
+  2>&1 | tee -a "$log_path"
+verdict_pipeline_status=("${PIPESTATUS[@]}")
+set -e
+
+verdict_status="${verdict_pipeline_status[0]}"
+verdict_tee_status="${verdict_pipeline_status[1]}"
+if [ "$verdict_tee_status" -ne 0 ]; then
+  printf '%s\n' "Functional CI runner: verdict log writer failed with exit=$verdict_tee_status; tier failed closed." \
+    | tee -a "$log_path" >&2
+  exit "$verdict_tee_status"
+fi
+if [ "$verdict_status" -ne 0 ]; then
+  printf '%s\n' "Functional CI runner: compact verdict could not classify the recorded coverage outcome; diagnostics retained under $artifact_root." \
+    | tee -a "$log_path" >&2
+  exit "$verdict_status"
 fi
 
 printf '%s\n' "Functional CI runner: tier completed within budget=$budget; diagnostics written under $artifact_root." \

--- a/tests/functional/observability/verification/functional_runner_contract_test.go
+++ b/tests/functional/observability/verification/functional_runner_contract_test.go
@@ -83,6 +83,43 @@ func TestFunctionalCoverageCommandSmoke_ReportsExplicitTierSelection(t *testing.
 	}
 }
 
+// TestFunctionalCoverageCommandSmoke_DefersOrdinaryGocoverageFailure proves
+// the CI-only handoff preserves gocoveragecheck's exact exit code while
+// allowing the compact verdict step to own an ordinary exit-1 outcome.
+func TestFunctionalCoverageCommandSmoke_DefersOrdinaryGocoverageFailure(t *testing.T) {
+	repoRoot := testutil.MustRepoPath(t, ".")
+	goStub := writeExecutableScript(t, "stub-go-functional-failure", `#!/bin/sh
+printf '%s\n' 'Functional suite inventory: discovered-packages=1 observed-packages=1 (pass=0 fail=1 skip=0) top-level-tests=1 (pass=0 fail=1 skip=0)'
+printf '%s\n' 'coverage not evaluated: 1 failed tests observed; package floors were NOT checked because the coverage test run failed' >&2
+exit 1
+`)
+	exitPath := filepath.Join(t.TempDir(), "gocoveragecheck-exit-code.txt")
+	makefilePath := writeVerifyFastWrapperMakefile(t, repoRoot, map[string]string{
+		"functional-boundary-check": "@printf '%s\\n' 'stub:boundary-ok'\n",
+	})
+
+	output, err := runMakefileTargetWithArgs(
+		repoRoot,
+		makefilePath,
+		fmt.Sprintf("GO=%s", goStub),
+		fmt.Sprintf("FUNCTIONAL_GOCOVERAGE_EXIT_FILE=%s", filepath.ToSlash(exitPath)),
+		"test-functional-coverage",
+	)
+	if err != nil {
+		t.Fatalf("ordinary gocoveragecheck failure was not deferred: %v\n%s", err, output)
+	}
+	gotExit, readErr := os.ReadFile(exitPath)
+	if readErr != nil {
+		t.Fatalf("read recorded gocoveragecheck exit code: %v", readErr)
+	}
+	if strings.TrimSpace(string(gotExit)) != "1" {
+		t.Fatalf("recorded gocoveragecheck exit code = %q, want 1", gotExit)
+	}
+	if !strings.Contains(output, "coverage not evaluated:") {
+		t.Fatalf("deferred gocoveragecheck diagnostics were not preserved:\n%s", output)
+	}
+}
+
 // TestFunctionalTestVizLaneScriptSmoke_TimesOutAndRetainsDiagnostics proves a
 // budget expiry fails the process while preserving output produced before the
 // interruption, including inventory and quarantine diagnostics.

--- a/tests/functional/observability/verification/verify_tier_contract_test.go
+++ b/tests/functional/observability/verification/verify_tier_contract_test.go
@@ -673,6 +673,13 @@ for argument in "$@"; do
       ;;
   esac
 done
+printf '%s\n' 'Functional suite inventory: discovered-packages=1 observed-packages=1 (pass=1 fail=0 skip=0) top-level-tests=1 (pass=1 fail=0 skip=0) deferred-short-tests=0 wall=0.001s complete=true'
+printf '%s\n' 'total: (statements) 80.0%'
+printf '%s\n' 'Functional package coverage verdict:'
+printf '%s\n' '  floor violations: none'
+printf '%s\n' '  package=github.com/portpowered/infinite-you/pkg/alpha coverage=80.0% floor=75.0% delta=+5.0pp gate=pass lane=functional'
+printf '%s\n' '  tally: measured-packages=1 gated-packages=1 below-floor=0 near-floor=0 gate-failures=0'
+printf '%s\n' 'Go coverage 80.0% meets minimum 33.1%.'
 printf '%s\n' "fake-make:$*"
 `)
 	artifactRoot := filepath.Join(t.TempDir(), "functional-test-viz-artifacts")

--- a/tests/functional/observability/verification/verify_tier_contract_test.go
+++ b/tests/functional/observability/verification/verify_tier_contract_test.go
@@ -665,7 +665,16 @@ func TestBackendVerificationLaneScriptSmoke_PreservesFailureExitAndLog(t *testin
 // TestFunctionalTestVizLaneScriptSmoke_UsesCanonicalOwnedCommandAndCapturesLog prove run-functional-test-viz.sh invokes the canonical make target with the shared artifact directory and captures command.log.
 func TestFunctionalTestVizLaneScriptSmoke_UsesCanonicalOwnedCommandAndCapturesLog(t *testing.T) {
 	repoRoot := testutil.MustRepoPath(t, ".")
-	makePath := writeExecutableScript(t, "fake-make-functional-viz", "#!/bin/sh\nprintf '%s\\n' \"fake-make:$*\"\n")
+	makePath := writeExecutableScript(t, "fake-make-functional-viz", `#!/bin/sh
+for argument in "$@"; do
+  case "$argument" in
+    FUNCTIONAL_GOCOVERAGE_EXIT_FILE=*)
+      printf '%s\n' '0' > "${argument#*=}"
+      ;;
+  esac
+done
+printf '%s\n' "fake-make:$*"
+`)
 	artifactRoot := filepath.Join(t.TempDir(), "functional-test-viz-artifacts")
 
 	output, err := runScript(


### PR DESCRIPTION
{
  "project": "perf-f4: Bound Failed Backend Functional Coverage Log Fetches",
  "branchName": "perf-f4-log-bloat",
  "description": "Reduce a Backend Functional Coverage job's reviewer-facing failed-log fetch from the measured 20,617,189-byte baseline to under 200KB by bounding package-state diagnostics, suppressing known non-output test2json actions, and failing ordinary test or coverage-gate outcomes in a compact verdict step while preserving the full stream and every existing red/green semantic.",
  "context": {
    "customerAsk": "Make a Backend Functional Coverage job red only on an ordinary test or coverage-gate failure return a complete verdict under 200KB from gh run view <run> --log-failed. Emit package states only for an incomplete final or timeout snapshot, drop known non-output test2json actions, split the coverage verdict into its own small failing workflow step, and preserve the full test stream, timeout diagnostics, job outcomes, artifacts, summaries, and Verification Policy behavior.",
    "problem": "The job currently combines the functional test stream and coverage verdict in one workflow step. Even after perf-f1, the projected failed fetch is about 7.5MB because package observation repeatedly prints every outstanding package, known lifecycle-only test2json actions pass through as raw JSON, and an ordinary gate failure marks the whole stream step failed. The measured 20.6MB response has already overflowed a Codex record and repeatedly consumes costly reviewer context.",
    "solution": "Keep package timing state and persisted snapshots current without per-event state listings; print one outstanding-package listing only when final state is incomplete. Consume start, run, pause, and cont test2json actions silently while preserving observer updates and unknown-action passthrough. Capture the exact tool exit code and complete verdict extract in the run step, fail that step directly only for infrastructure errors, and replay ordinary test or coverage-gate failure from a compact final verdict step while retaining the full run-step job log.",
    "originalDocument": "C:/Users/andre/work/portos/infinite-you/docs/temp/ci-log-bloat-analysis-2026-08-21.md"
  },
  "acceptanceCriteria": [
    "Before/after evidence shows the measured 20,617,189-byte baseline for run 32426615245 and a change-PR Backend Functional Coverage job red only on an ordinary test or coverage-gate failure whose gh run view <run> --log-failed output is under 200KB and contains the complete verdict block, including every floor violation and package coverage regression: line.",
    "A green job log contains zero Functional package state lines and zero raw {\"Time\": test2json lines for known start, run, pause, or cont actions; an incomplete final or timeout path prints exactly one final package-state listing containing only non-completed packages.",
    "The full functional stream remains fetchable with gh run view --job <run-step-job-id> --log; timeout exit 124/125 and missing-tool failures still fail the run step itself with existing diagnostics, while output, failure text, panics, runtime error/warn diagnostics, and per-test progress remain available.",
    "Workflow tests demonstrate unchanged red/green outcomes for coverage-gate failure, ordinary test failure, timeout, and green execution, and one red plus one green change-PR CI demonstration is linked in a PR comment; Verification Policy, artifact uploads, the PR coverage comment, both summary JSONs, floors, manifests, -min, quarantine, and gate meanings remain unchanged.",
    "Quality gate: Typecheck passes; focused Go and Node workflow tests and broader required tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "perf-f4-log-bloat-001",
      "title": "Bound package-state diagnostics to incomplete final snapshots",
      "description": "As a CI reviewer, I want package progress to remain available when a run times out without repeating the outstanding-package list throughout healthy execution, so normal and failed logs stay compact while timeout diagnosis remains useful.",
      "acceptanceCriteria": [
        "Observing any number of package lifecycle events continues to update the timing tracker, timing JSON, and coverage snapshots without emitting a Functional package state line per event.",
        "A complete green run emits zero Functional package state lines.",
        "An incomplete final or timeout snapshot emits exactly one final package-state listing, with exactly one state line for each non-completed package and no completed packages.",
        "The bounded one-line Functional timing snapshot cadence may remain, and timing document contents, final capture reason, and timeout diagnostics retain their existing meaning.",
        "Focused cmd/gocoveragecheck diagnostics tests prove complete and incomplete behavior without adding new test scaffolding packages.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "perf-f4-log-bloat-002",
      "title": "Suppress known non-output test2json lifecycle actions",
      "description": "As a CI reviewer, I want the functional stream to omit machine-only lifecycle events that carry no useful output, so the readable log contains diagnostics and results rather than raw test2json noise.",
      "acceptanceCriteria": [
        "test2json events with known actions start, run, pause, and cont produce no raw log output while still reaching any timing observer that requires them.",
        "A genuinely unknown future test2json action remains visible as its original raw line so new upstream behavior is not silently discarded.",
        "Output processing, package-level pass/fail/skip results, failure text, panics, per-test progress, and perf-f1 coverage-output compaction remain behaviorally unchanged.",
        "A representative green stream contains zero raw {\"Time\": lines attributable to the known non-output actions.",
        "Focused stream tests cover every suppressed known action, an unknown action, and unchanged output and terminal-result handling.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Known start/run/pause/cont events are observer-visible but omitted from the human stream; unknown actions and output/results remain visible. Focused and full cmd/gocoveragecheck tests pass; make typecheck passes after installing the locked UI dependencies."
    },
    {
      "id": "perf-f4-log-bloat-003",
      "title": "Isolate the compact functional coverage verdict",
      "description": "As a CI reviewer, I want an ordinary test or coverage-gate failure to fail in a compact verdict step while retaining the full run stream separately, so --log-failed is actionable and deep diagnostics remain available on demand.",
      "acceptanceCriteria": [
        "The functional run records the exact gocoveragecheck exit code and writes a compact end-of-run verdict extract spanning the inventory line through the final gate line and including every package coverage regression: line.",
        "The run step succeeds after recording an ordinary test or coverage-gate nonzero code so the compact verdict step owns that failure; timeout exit 124/125 and missing-tool or equivalent infrastructure failures still fail the run step itself with existing diagnostics.",
        "A final Functional coverage verdict step prints the complete extract into its own log, appends the same verdict to GITHUB_STEP_SUMMARY, and exits with the recorded nonzero code rather than passing a recorded failure.",
        "A coverage-gate or ordinary test failure yields under 200KB from gh run view <run> --log-failed, while gh run view --job <run-step-job-id> --log still returns the full functional stream.",
        "Green, test-failure, gate-failure, and timeout conclusions remain unchanged, as do Verification Policy, artifact uploads, the PR coverage comment, and both summary JSONs.",
        "Focused Node workflow tests pin verdict extraction, exit-code capture, infrastructure-failure propagation, verdict-step failure on a recorded nonzero code, and unchanged green behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "The functional runner records the exact gocoveragecheck status, defers recognized ordinary test/coverage-gate exit 1 outcomes, extracts a compact inventory-to-gate verdict, and replays it through an always-run failing summary step. Timeout and infrastructure paths remain runner failures. Focused Go diagnostics/stream/verdict tests, Node workflow tests, workflow YAML parsing, Make dry-run, typecheck, and make test-ci-workflows pass; POSIX shell integration is exercised on Linux CI and skipped on Windows."
    }
  ]
}
