### PR TITLE
obs-6-dispatches-render-and-label

### DIFF
--- a/pkg/services/factory_sessions/transports/cli/session/dispatches.go
+++ b/pkg/services/factory_sessions/transports/cli/session/dispatches.go
@@ -148,8 +148,14 @@ func renderDispatchHuman(output io.Writer, dispatch factoryapi.FactorySessionDis
 	if dispatch.Attempt != nil {
 		attempt = fmt.Sprint(*dispatch.Attempt)
 	}
+	inputTokens, outputTokens, totalTokens := "unavailable", "unavailable", "unavailable"
 	if dispatch.Usage != nil && dispatch.Usage.DurationMillis != nil {
 		duration = fmt.Sprintf("%dms", *dispatch.Usage.DurationMillis)
+	}
+	if dispatch.Usage != nil {
+		inputTokens = formatOptionalInt64(dispatch.Usage.InputTokens)
+		outputTokens = formatOptionalInt64(dispatch.Usage.OutputTokens)
+		totalTokens = formatOptionalInt64(dispatch.Usage.TotalTokens)
 	}
 	artifacts, failure := "none", "none"
 	if dispatch.OutputArtifactIds != nil && len(*dispatch.OutputArtifactIds) > 0 {
@@ -162,6 +168,7 @@ func renderDispatchHuman(output io.Writer, dispatch factoryapi.FactorySessionDis
 		{"Phase", formatOptionalString(dispatch.Phase)}, {"Label", formatOptionalString(dispatch.Label)},
 		{"Runner", formatOptionalString(dispatch.RunnerId)}, {"Model", formatOptionalString(dispatch.Model)},
 		{"Provider sessions", providerSessions}, {"Attempt", attempt}, {"Duration", duration},
+		{"Input tokens", inputTokens}, {"Output tokens", outputTokens}, {"Total tokens", totalTokens},
 		{"Artifacts", artifacts}, {"Failure", failure},
 	}
 	for _, row := range rows {
@@ -170,4 +177,11 @@ func renderDispatchHuman(output io.Writer, dispatch factoryapi.FactorySessionDis
 		}
 	}
 	return nil
+}
+
+func formatOptionalInt64(value *int64) string {
+	if value == nil {
+		return "unavailable"
+	}
+	return fmt.Sprintf("%d", *value)
 }

--- a/pkg/services/factory_sessions/transports/cli/session/show.go
+++ b/pkg/services/factory_sessions/transports/cli/session/show.go
@@ -187,7 +187,7 @@ func renderShowResult(
 		{label: "Orchestrator kind", value: string(session.Runtime.OrchestratorKind)},
 		{label: "Runtime status", value: string(session.Runtime.Status)},
 		{label: "Factory state", value: session.Runtime.Progress.FactoryState},
-		{label: "Total tokens", value: fmt.Sprintf("%d", session.Runtime.Progress.TotalTokens)},
+		{label: "Work tokens (marking)", value: fmt.Sprintf("%d", session.Runtime.Progress.TotalTokens)},
 		{label: "In-flight dispatches", value: fmt.Sprintf("%d", session.Runtime.Progress.InFlightCount)},
 	}
 	if session.Runtime.Dialect != nil {

--- a/pkg/services/factory_sessions/transports/cli/session/show_test.go
+++ b/pkg/services/factory_sessions/transports/cli/session/show_test.go
@@ -95,6 +95,7 @@ func TestShow_HumanOutputRendersPetriFactorySession(t *testing.T) {
 	output := out.String()
 	for _, want := range []string{
 		"Orchestrator kind:\tPETRI",
+		"Work tokens (marking):\t1",
 		"Petri marking tokens:\t1",
 		"Enabled transition:\ttr-process (worker-a)",
 	} {
@@ -104,6 +105,12 @@ func TestShow_HumanOutputRendersPetriFactorySession(t *testing.T) {
 	}
 	if strings.Contains(output, "Dynamic workflow:") {
 		t.Fatalf("Petri output should not include dynamic workflow shorthand: %s", output)
+	}
+	if strings.Contains(output, "Total tokens:") {
+		t.Fatalf("Petri output retained ambiguous total-token label: %s", output)
+	}
+	if strings.Contains(strings.ToLower(output), "cost") {
+		t.Fatalf("human output unexpectedly contains cost text: %s", output)
 	}
 }
 
@@ -128,6 +135,32 @@ func TestShow_JSONModeEmitsFactorySession(t *testing.T) {
 	}
 	if got.Id != "session-beta" || got.Runtime.OrchestratorKind != factoryapi.JAVASCRIPT {
 		t.Fatalf("session = %#v, want JavaScript session-beta", got)
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("decode raw JSON: %v\n%s", err, out.String())
+	}
+	var runtime map[string]json.RawMessage
+	if err := json.Unmarshal(payload["runtime"], &runtime); err != nil {
+		t.Fatalf("decode runtime JSON: %v\n%s", err, out.String())
+	}
+	var progress map[string]json.RawMessage
+	if err := json.Unmarshal(runtime["progress"], &progress); err != nil {
+		t.Fatalf("decode progress JSON: %v\n%s", err, out.String())
+	}
+	totalTokens, ok := progress["totalTokens"]
+	if !ok {
+		t.Fatalf("JSON missing runtime.progress.totalTokens: %s", out.String())
+	}
+	var gotTotalTokens int
+	if err := json.Unmarshal(totalTokens, &gotTotalTokens); err != nil {
+		t.Fatalf("decode totalTokens: %v", err)
+	}
+	if gotTotalTokens != 0 {
+		t.Fatalf("totalTokens = %d, want 0", gotTotalTokens)
+	}
+	if strings.Contains(strings.ToLower(out.String()), "cost") {
+		t.Fatalf("JSON output unexpectedly contains cost text: %s", out.String())
 	}
 }
 

--- a/pkg/services/factory_sessions/transports/cli/session/show_test.go
+++ b/pkg/services/factory_sessions/transports/cli/session/show_test.go
@@ -398,6 +398,7 @@ func TestShow_DurableSessionHumanOutputRendersLifecycleContinuity(t *testing.T) 
 
 func TestDispatches_DurableSessionJSONUsesListFactorySessionDispatchesResponse(t *testing.T) {
 	label := "step-one"
+	inputTokens, outputTokens, totalTokens := int64(12), int64(8), int64(20)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got, want := r.URL.Path, "/factory-sessions/dur-sess-js-interrupted-001/dispatches"; got != want {
 			t.Fatalf("path = %q, want %q", got, want)
@@ -411,6 +412,11 @@ func TestDispatches_DurableSessionJSONUsesListFactorySessionDispatchesResponse(t
 					Status:       factoryapi.FactoryDispatchStatusCOMPLETED,
 					DispatchKind: factoryapi.FactoryDispatchKindJAVASCRIPTAGENT,
 					Label:        &label,
+					Usage: &factoryapi.FactoryDispatchUsage{
+						InputTokens:  &inputTokens,
+						OutputTokens: &outputTokens,
+						TotalTokens:  &totalTokens,
+					},
 				},
 			},
 		}); err != nil {
@@ -438,6 +444,15 @@ func TestDispatches_DurableSessionJSONUsesListFactorySessionDispatchesResponse(t
 	}
 	if len(listed.Dispatches) != 1 {
 		t.Fatalf("dispatches = %#v, want one dispatch", listed.Dispatches)
+	}
+	usage := listed.Dispatches[0].Usage
+	if usage == nil || usage.InputTokens == nil || *usage.InputTokens != inputTokens ||
+		usage.OutputTokens == nil || *usage.OutputTokens != outputTokens ||
+		usage.TotalTokens == nil || *usage.TotalTokens != totalTokens {
+		t.Fatalf("usage = %#v, want input=%d output=%d total=%d", usage, inputTokens, outputTokens, totalTokens)
+	}
+	if strings.Contains(strings.ToLower(out.String()), "cost") {
+		t.Fatalf("JSON output unexpectedly contains cost text: %s", out.String())
 	}
 }
 
@@ -494,12 +509,64 @@ func TestDispatches_DurableSessionHumanOutputRendersDispatchSummaries(t *testing
 		"  Provider sessions:\tprovider-session-1",
 		"  Attempt:\t2",
 		"  Duration:\t1250ms",
+		"  Input tokens:\tunavailable",
+		"  Output tokens:\tunavailable",
+		"  Total tokens:\tunavailable",
 		"  Artifacts:\tartifact-1",
 		"  Failure:\tprovider unavailable",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output missing %q:\n%s", want, output)
 		}
+	}
+	for _, label := range []string{"Input tokens", "Output tokens", "Total tokens"} {
+		if strings.Contains(output, "  "+label+":\t0") {
+			t.Fatalf("nil usage value rendered as zero for %s:\n%s", label, output)
+		}
+	}
+}
+
+func TestDispatches_DurableSessionHumanOutputRendersPopulatedTokenUsage(t *testing.T) {
+	inputTokens, outputTokens, totalTokens := int64(17), int64(0), int64(17)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(factoryapi.ListFactorySessionDispatchesResponse{
+			SessionId: "dur-sess-usage-001",
+			Dispatches: []factoryapi.FactorySessionDispatchSummary{{
+				Id:           "dispatch-usage-1",
+				Status:       factoryapi.FactoryDispatchStatusCOMPLETED,
+				DispatchKind: factoryapi.FactoryDispatchKindJAVASCRIPTAGENT,
+				Usage: &factoryapi.FactoryDispatchUsage{
+					InputTokens:  &inputTokens,
+					OutputTokens: &outputTokens,
+					TotalTokens:  &totalTokens,
+				},
+			}},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	if err := NewDispatches(testHTTPProtocol(t))(DispatchesConfig{
+		Context: context.Background(), Server: srv.URL, SessionID: "dur-sess-usage-001", Output: &out,
+	}); err != nil {
+		t.Fatalf("Dispatches durable human: %v", err)
+	}
+
+	output := out.String()
+	for _, want := range []string{
+		"  Input tokens:\t17",
+		"  Output tokens:\t0",
+		"  Total tokens:\t17",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(strings.ToLower(output), "cost") {
+		t.Fatalf("human output unexpectedly contains cost text: %s", output)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "OBS-6 Dispatch Token Rendering and Work-Token Label",
  "branchName": "obs-6-dispatches-render-and-label",
  "description": "Make Factory Session CLI output distinguish LLM usage from Factory Runtime marking state. Render the input, output, and total token values already present in each `you session dispatches <id>` response, use `unavailable` for absent values, and relabel the Petri progress value in `you session show` as work/marking tokens while preserving JSON contracts and rendering no cost values.",
  "context": {
    "customerAsk": "Render the dispatch token fields already supplied by the merged OBS-5 usage surface, using `unavailable` when token data is absent. Replace the human `Total tokens` label in `you session show` with an unambiguous work/marking-token label without changing machine contracts or adding cost output.",
    "problem": "`you session dispatches <id>` currently renders only duration from `FactoryDispatchUsage`, dropping available input, output, and total token counts. `you session show` labels Petri marking state as `Total tokens`, so agents can miss real LLM usage and mistake unrelated work tokens for usage tokens.",
    "solution": "Change only the Factory Sessions CLI human presenters: add three independently nil-aware dispatch token rows and label session progress as `Work tokens (marking)`. Continue serializing the existing generated response types in JSON mode, add focused behavioral regression tests, and make no API, mapping, recordings, generated, pricing, or UI changes."
  },
  "acceptanceCriteria": [
    "`you session dispatches <id>` human output shows `Input tokens`, `Output tokens`, and `Total tokens` for every dispatch, using the exact supplied values when the corresponding usage fields are present and `unavailable` when they are nil.",
    "A nil token field is never rendered as `0`; an explicitly supplied zero remains distinguishable as the measured value `0`.",
    "`you session show` human output labels `session.Runtime.Progress.TotalTokens` as `Work tokens (marking)` (or an equivalently explicit work/marking-token label) and no longer emits the bare `Total tokens` row for that value.",
    "JSON output for both commands retains the existing generated contract field names and structure, including dispatch usage token fields and the session runtime progress `totalTokens` field; no API, OpenAPI, mapping, or generated artifact changes are made.",
    "Neither human nor JSON output from either command adds or computes a cost value, price, or cost row.",
    "Quality gates pass: Typecheck passes; Tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The worker/reviewer cycle continues through review-owned outcomes until the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "obs-6-dispatches-render-and-label-001",
      "title": "Render dispatch token usage",
      "description": "As a CLI user, I want each dispatch to show its available LLM token usage so I can inspect consumption without parsing JSON or mistaking missing data for zero.",
      "acceptanceCriteria": [
        "Human output for each dispatch includes `Input tokens`, `Output tokens`, and `Total tokens` alongside the existing duration and dispatch details.",
        "When all three usage token fields are present, their exact integer values are rendered, including an explicitly supplied zero.",
        "When usage has duration but token fields are nil, every token row renders `unavailable`; token rows also render `unavailable` when the usage object itself is absent.",
        "No cost label, value, computed price, or zero-value placeholder appears in human or JSON output.",
        "JSON mode continues to serialize the canonical dispatch response with its existing field names and nesting; a parsed-output test asserts the established usage keys rather than human labels.",
        "Focused CLI behavioral tests cover populated token usage, duration-only usage, absent usage, and contract-stable JSON output.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented nil-aware human token rows and JSON-preserving regression coverage; focused dispatch tests pass."
    },
    {
      "id": "obs-6-dispatches-render-and-label-002",
      "title": "Disambiguate Factory work tokens",
      "description": "As a CLI user, I want session progress to identify Petri work/marking tokens explicitly so I do not interpret them as LLM token usage.",
      "acceptanceCriteria": [
        "Human `you session show` output renders `session.Runtime.Progress.TotalTokens` under `Work tokens (marking)` or an equivalently explicit label that names both work and marking semantics.",
        "The session progress output no longer contains a bare `Total tokens` label for the marking value.",
        "JSON mode retains the existing runtime progress field name `totalTokens` and value; a parsed-output regression test proves the human relabel does not rename the machine contract.",
        "Neither human nor JSON session-show output adds a cost label or cost value.",
        "Focused CLI behavioral tests cover the relabeled human row, absence of the ambiguous row, unchanged JSON output, and absence of cost output.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Relabeled live session human output as Work tokens (marking) and added regression coverage proving the JSON runtime.progress.totalTokens contract and cost-free output remain unchanged."
    }
  ]
}
