### PR TITLE
Deflake contract staging clean-repository verification

### DIFF
--- a/internal/contractstaging/check_test.go
+++ b/internal/contractstaging/check_test.go
@@ -24,6 +24,10 @@ func TestCheckPassesCleanStagingAndDoesNotChangeRepositoryBytes(t *testing.T) {
 	if !drift.Empty() {
 		t.Fatalf("Check() drift = %#v, want none", drift)
 	}
+	afterCheck := checkTree(t, root)
+	if !reflect.DeepEqual(before, afterCheck) {
+		t.Fatalf("Check() changed repository bytes on clean fixture: %v", changedCheckTreePaths(before, afterCheck))
+	}
 
 	if err := contractstaging.Generate(root); err != nil {
 		t.Fatalf("Generate() error = %v", err)

--- a/internal/contractstaging/check_test.go
+++ b/internal/contractstaging/check_test.go
@@ -2,9 +2,9 @@ package contractstaging_test
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -28,10 +28,37 @@ func TestCheckPassesCleanStagingAndDoesNotChangeRepositoryBytes(t *testing.T) {
 	if err := contractstaging.Generate(root); err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
-	after := checkTree(t, root)
-	if !reflect.DeepEqual(before, after) {
-		t.Fatal("Check() and Generate() changed repository bytes on clean fixture")
+	afterFirstGenerate := checkTree(t, root)
+	if !reflect.DeepEqual(before, afterFirstGenerate) {
+		t.Fatalf("Check() and first Generate() changed repository bytes on clean fixture: %v", changedCheckTreePaths(before, afterFirstGenerate))
 	}
+
+	if err := contractstaging.Generate(root); err != nil {
+		t.Fatalf("second Generate() error = %v", err)
+	}
+	afterSecondGenerate := checkTree(t, root)
+	if !reflect.DeepEqual(before, afterSecondGenerate) {
+		t.Fatalf("second Generate() changed repository bytes on clean fixture: %v", changedCheckTreePaths(before, afterSecondGenerate))
+	}
+}
+
+func changedCheckTreePaths(before, after map[string]string) []string {
+	paths := make(map[string]struct{}, len(before)+len(after))
+	for path := range before {
+		paths[path] = struct{}{}
+	}
+	for path := range after {
+		paths[path] = struct{}{}
+	}
+
+	changed := make([]string, 0)
+	for path := range paths {
+		if before[path] != after[path] {
+			changed = append(changed, path)
+		}
+	}
+	sort.Strings(changed)
+	return changed
 }
 
 func TestCheckRejectsUnexpectedNonPackageArtifactPathsWhenOrderedAndSorted(t *testing.T) {
@@ -55,13 +82,14 @@ func TestCheckRejectsUnexpectedNonPackageArtifactPathsWhenOrderedAndSorted(t *te
 func checkFixture(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
+	// The development manifest is commit-independent. Keep this a working-tree
+	// fixture so Git's mutable metadata cannot enter the byte-stability proof.
 	writeCheckFixture(t, root, "contracts/common/documentation.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json","$defs":{"itemId":{"type":"string"}}}`)
 	writeCheckFixture(t, root, "contracts/common/deprecations.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json","properties":{"itemId":{"$ref":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"}}}`)
 	writeCheckFixture(t, root, "contracts/manifest.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/manifest.schema.json","properties":{"packageId":{"$ref":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"}}}`)
 	for _, artifact := range contractstaging.RawArtifacts() {
 		writeCheckFixture(t, root, artifact.Source, canonicalFixture(artifact.Source))
 	}
-	initCheckGitRepo(t, root)
 	if err := contractstaging.Generate(root); err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
@@ -139,26 +167,3 @@ func canonicalFixture(path string) string {
 	}
 	return "canonical:" + path
 }
-
-func initCheckGitRepo(t *testing.T, root string) {
-	t.Helper()
-	commands := [][]string{
-		{"git", "-C", root, "init", "--initial-branch", "main"},
-		{"git", "-C", root, "config", "user.email", "contractstaging-check@test"},
-		{"git", "-C", root, "config", "user.name", "contractstaging-check"},
-		{"git", "-C", root, "add", "-A"},
-		{"git", "-C", root, "commit", "-m", "contract staging check fixture"},
-	}
-	for _, command := range commands {
-		if output, err := execCommand(command...); err != nil {
-			t.Fatalf("%v: %s", command, output)
-		}
-	}
-}
-
-func execCommand(command ...string) ([]byte, error) {
-	cmd := exec.Command(command[0], command[1:]...)
-	return cmd.CombinedOutput()
-}
-
-const checkFixtureDefaultBranch = "main"


### PR DESCRIPTION
{
  "project": "Deflake Contract-Staging Clean-Repository Verification",
  "branchName": "cleanup-deflake-contractstaging",
  "description": "Find and remove the root cause of nondeterministic byte changes in the internal/contractstaging clean synthetic-repository check so Check() and Generate() are repeatably byte-stable without retries, sleeps, skips, or weakened assertions.",
  "context": {
    "customerAsk": "Make TestCheckPassesCleanStagingAndDoesNotChangeRepositoryBytes reliably prove that clean contract staging is unchanged by Check() and Generate(). Name the root cause and failing mechanism in the PR body, demonstrate go test -count=20 stability for internal/contractstaging, and add a cheap targeted guard against the prior nondeterminism shape where feasible.",
    "problem": "Main run 32443921559 at head 07a82fa4d failed because Check() followed by Generate() changed bytes in a self-contained temporary repository, while an operator-triggered rerun of the identical job and head passed. This same-head fail/pass result proves nondeterminism and undermines confidence in the API contract and package gate.",
    "solution": "Reproduce and isolate the unstable fixture input, artifact computation, ordering, timestamp, mutable state, or file-write interaction; make that owned boundary deterministic; preserve strict clean-drift and complete-tree byte checks; and add focused regression plus 20-run package evidence without broad unrelated cleanup."
  },
  "acceptanceCriteria": [
    "On a clean synthetic repository, Check() reports no drift and neither Check() nor subsequent Generate() calls alter any repository file bytes; the result is stable across repeated executions.",
    "The implementation removes the named root cause without retries, sleeps, skips, weakened byte comparisons, or test-only masking, and the PR body explains the failing mechanism using evidence from run 32443921559 and the same-head passing rerun.",
    "Focused regression evidence exercises the prior nondeterminism shape where feasible, and go test ./internal/contractstaging -count=20 passes locally; any CI-run evidence is reported in a PR comment rather than committed.",
    "Scope remains within internal/contractstaging and necessary canonical generated output. Baseline or generated files are never hand-merged: after rebasing onto origin/main before the final push, the appropriate generator/checker is rerun and its output is committed. If an in-scope deletion reaches zero debt, its ratchet entry is removed, and deleted paths leave no stranded baseline-ledger rows.",
    "Typecheck and focused and relevant tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "cleanup-deflake-contractstaging-001",
      "title": "Keep clean contract staging byte-identical",
      "description": "As a maintainer relying on contract drift enforcement, I want checking and regenerating a clean synthetic repository to be deterministic so identical source contracts cannot produce intermittent CI failures.",
      "acceptanceCriteria": [
        "The nondeterministic fixture, artifact computation, or write interaction is isolated and corrected at the boundary that owns it.",
        "A clean synthetic repository produces empty drift from Check() and identical complete-tree bytes before and after Generate() across repeated executions.",
        "A focused test exercises the old failure mechanism where feasible and would fail if that nondeterministic behavior returned; existing behavior-named coverage is retained or replaced with equivalent direct proof.",
        "The fix contains no retries, sleeps, skips, timing padding, weakened assertions, or unrelated contract-staging cleanup.",
        "go test ./internal/contractstaging -count=20 passes.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
    "notes": "Root cause was stale Git fixture setup left over from the former commit-derived manifest: init/commit created mutable .git metadata that the complete-tree assertion included even though current development manifests are commit-independent. The synthetic fixture now stays a working tree, checks exact changed paths, and independently proves Check followed by two Generate calls preserve complete-tree bytes. go test ./internal/contractstaging -count=20 and make test both passed."
    }
  ]
}
