### PR TITLE
perf: reduce gocoveragecheck orchestration overhead

### DIFF
--- a/cmd/gocoveragecheck/coverage_discovery.go
+++ b/cmd/gocoveragecheck/coverage_discovery.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+)
+
+// coveragePackageListing is the small portion of go list metadata needed to
+// derive both coverage package sets. The listing is intentionally scoped to
+// one invocation; it is never persisted between checker runs.
+type coveragePackageListing struct {
+	importPath string
+	goFiles    int
+	hasGoFiles bool
+}
+
+type coveragePackageDiscovery struct {
+	allPackages []string
+}
+
+func resolveCoverageLaneWithDiscovery(cfg config) (coveragePackageDiscovery, []string, []string, error) {
+	coverConfigured := strings.TrimSpace(cfg.coverpkg) != ""
+	testConfigured := strings.TrimSpace(cfg.packages) != ""
+	patterns := make([]string, 0, 2)
+	if !coverConfigured {
+		patterns = appendUniqueCoveragePatterns(patterns, defaultCoveragePatterns...)
+	}
+	if !testConfigured {
+		switch cfg.suite {
+		case "", unitCoverageSuite:
+			patterns = appendUniqueCoveragePatterns(patterns, unitTestPatterns...)
+		case functionalCoverageSuite:
+			patterns = appendUniqueCoveragePatterns(patterns, functionalTestPatterns...)
+		default:
+			return coveragePackageDiscovery{}, nil, nil, fmt.Errorf("resolve go coverage lane: unsupported suite %q", cfg.suite)
+		}
+	}
+
+	var listings []coveragePackageListing
+	var err error
+	if len(patterns) > 0 {
+		listings, err = listGoPackageListings(patterns)
+		if err != nil {
+			return coveragePackageDiscovery{}, nil, nil, err
+		}
+	}
+
+	var coverPackages []string
+	if coverConfigured {
+		coverPackages = splitList(cfg.coverpkg, ",", false)
+	} else {
+		coverPackages, err = filterCoveragePackageListings(listings, isBackendCoveragePackage, true)
+		if err != nil {
+			return coveragePackageDiscovery{}, nil, nil, err
+		}
+	}
+
+	var testPackages []string
+	if testConfigured {
+		testPackages = splitList(cfg.packages, " ", true)
+	} else {
+		include := isBackendCoveragePackage
+		if cfg.suite == functionalCoverageSuite {
+			include = isFunctionalTestPackage
+		}
+		testPackages, err = filterCoveragePackageListings(listings, include, false)
+		if err != nil {
+			return coveragePackageDiscovery{}, nil, nil, err
+		}
+	}
+
+	discovery := coveragePackageDiscovery{}
+	if !testConfigured && (cfg.suite == "" || cfg.suite == unitCoverageSuite) {
+		discovery.allPackages = allListedPackagePaths(listings)
+	}
+	return discovery, coverPackages, testPackages, nil
+}
+
+func appendUniqueCoveragePatterns(patterns []string, additions ...string) []string {
+	for _, addition := range additions {
+		if slices.Contains(patterns, addition) {
+			continue
+		}
+		patterns = append(patterns, addition)
+	}
+	return patterns
+}
+
+func listGoPackageListings(patterns []string) ([]coveragePackageListing, error) {
+	args := append([]string{"list", "-f", "{{.ImportPath}}\t{{len .GoFiles}}"}, patterns...)
+	rootDir, err := repoRootDir()
+	if err != nil {
+		return nil, err
+	}
+	stdout, stderr, err := runCommand(commandInvocation{
+		name: "go",
+		args: args,
+		env:  os.Environ(),
+		dir:  rootDir,
+	})
+	if err != nil {
+		detail := strings.TrimSpace(stderr)
+		if detail == "" {
+			detail = strings.TrimSpace(stdout)
+		}
+		if detail != "" {
+			return nil, fmt.Errorf("list go packages: %w\n%s", err, detail)
+		}
+		return nil, fmt.Errorf("list go packages: %w", err)
+	}
+
+	listings := make([]coveragePackageListing, 0)
+	for _, line := range strings.Split(stdout, "\n") {
+		importPath, goFiles, hasGoFiles := parseGoListPackageLine(line)
+		if strings.TrimSpace(importPath) == "" {
+			continue
+		}
+		listings = append(listings, coveragePackageListing{
+			importPath: importPath,
+			goFiles:    goFiles,
+			hasGoFiles: hasGoFiles,
+		})
+	}
+	return listings, nil
+}
+
+func filterCoveragePackageListings(listings []coveragePackageListing, include func(string) bool, requireNonTestGoFiles bool) ([]string, error) {
+	seen := make(map[string]struct{}, len(listings))
+	packages := make([]string, 0, len(listings))
+	for _, listing := range listings {
+		if !include(listing.importPath) {
+			continue
+		}
+		if requireNonTestGoFiles && listing.hasGoFiles && listing.goFiles == 0 {
+			continue
+		}
+		if _, ok := seen[listing.importPath]; ok {
+			continue
+		}
+		seen[listing.importPath] = struct{}{}
+		packages = append(packages, listing.importPath)
+	}
+	slices.Sort(packages)
+	if len(packages) == 0 {
+		return nil, errors.New("resolve go coverage lane: no packages matched")
+	}
+	return packages, nil
+}
+
+func allListedPackagePaths(listings []coveragePackageListing) []string {
+	seen := make(map[string]struct{}, len(listings))
+	packages := make([]string, 0, len(listings))
+	for _, listing := range listings {
+		if _, ok := seen[listing.importPath]; ok {
+			continue
+		}
+		seen[listing.importPath] = struct{}{}
+		packages = append(packages, listing.importPath)
+	}
+	slices.Sort(packages)
+	return packages
+}

--- a/cmd/gocoveragecheck/coverage_discovery_test.go
+++ b/cmd/gocoveragecheck/coverage_discovery_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestResolveCoverageLaneUsesOneFreshSweepForDefaultUnitSets(t *testing.T) {
+	originalCommandRunner := commandRunner
+	t.Cleanup(func() { commandRunner = originalCommandRunner })
+
+	var listCalls []commandInvocation
+	commandRunner = func(invocation commandInvocation) (string, string, error) {
+		if len(invocation.args) == 0 || invocation.args[0] != "list" {
+			return fakeGoCoverageCommandPassing(invocation)
+		}
+		listCalls = append(listCalls, invocation)
+		return strings.Join([]string{
+			modulePath + "/pkg/covered\t2",
+			modulePath + "/pkg/testless\t0",
+			modulePath + "/pkg/transports/http/client\t4",
+			modulePath + "/internal/testutil/runtimefixtures\t1",
+			modulePath + "/cmd/factory\t1",
+			modulePath + "/pkg/covered\t2",
+		}, "\n"), "", nil
+	}
+
+	discovery, coverPackages, testPackages, err := resolveCoverageLaneWithDiscovery(config{suite: unitCoverageSuite})
+	if err != nil {
+		t.Fatalf("resolveCoverageLaneWithDiscovery() error = %v", err)
+	}
+	wantCover := []string{modulePath + "/pkg/covered"}
+	wantTest := []string{modulePath + "/pkg/covered", modulePath + "/pkg/testless"}
+	if !reflect.DeepEqual(coverPackages, wantCover) {
+		t.Fatalf("cover packages = %v, want %v", coverPackages, wantCover)
+	}
+	if !reflect.DeepEqual(testPackages, wantTest) {
+		t.Fatalf("test packages = %v, want %v", testPackages, wantTest)
+	}
+	wantUniverse := []string{
+		modulePath + "/cmd/factory",
+		modulePath + "/internal/testutil/runtimefixtures",
+		modulePath + "/pkg/covered",
+		modulePath + "/pkg/testless",
+		modulePath + "/pkg/transports/http/client",
+	}
+	if !reflect.DeepEqual(discovery.allPackages, wantUniverse) {
+		t.Fatalf("discovered package universe = %v, want %v", discovery.allPackages, wantUniverse)
+	}
+	if len(listCalls) != 1 {
+		t.Fatalf("go list calls = %d, want one fresh sweep: %#v", len(listCalls), listCalls)
+	}
+	if got := listCalls[0].args[3:]; !reflect.DeepEqual(got, []string{"./pkg/..."}) {
+		t.Fatalf("go list patterns = %v, want one default unit pattern", got)
+	}
+
+	_, _, _, err = resolveCoverageLaneWithDiscovery(config{suite: unitCoverageSuite})
+	if err != nil {
+		t.Fatalf("second resolveCoverageLaneWithDiscovery() error = %v", err)
+	}
+	if len(listCalls) != 2 {
+		t.Fatalf("go list calls after second invocation = %d, want fresh discovery per invocation", len(listCalls))
+	}
+}
+
+func TestCompactUnitTestPackageArgsUsesProvidedUniverse(t *testing.T) {
+	originalCommandRunner := commandRunner
+	t.Cleanup(func() { commandRunner = originalCommandRunner })
+	commandRunner = func(invocation commandInvocation) (string, string, error) {
+		t.Fatalf("unexpected package-list sweep while planning from provided universe: %#v", invocation.args)
+		return "", "", nil
+	}
+
+	root := modulePath + "/pkg"
+	allPackages := []string{
+		root + "/alpha",
+		root + "/alpha/one",
+		root + "/alpha/two",
+		root + "/beta",
+		root + "/beta/excluded",
+	}
+	selectedPackages := []string{root + "/alpha", root + "/alpha/one", root + "/alpha/two", root + "/beta"}
+	want := []string{root + "/alpha/...", root + "/beta"}
+
+	got := compactUnitTestPackageArgs(config{}, selectedPackages, "windows", allPackages)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("compactUnitTestPackageArgs() = %v, want %v", got, want)
+	}
+}
+
+func TestResolveCoverageLaneUsesOneSweepForFunctionalCoverAndTestSets(t *testing.T) {
+	originalCommandRunner := commandRunner
+	t.Cleanup(func() { commandRunner = originalCommandRunner })
+
+	var listCalls []commandInvocation
+	commandRunner = func(invocation commandInvocation) (string, string, error) {
+		if len(invocation.args) == 0 || invocation.args[0] != "list" {
+			return fakeGoCoverageCommandPassing(invocation)
+		}
+		listCalls = append(listCalls, invocation)
+		return strings.Join([]string{
+			modulePath + "/pkg/covered\t2",
+			modulePath + "/tests/functional/runtime_api\t1",
+			modulePath + "/tests/functional/internal/support\t1",
+		}, "\n"), "", nil
+	}
+
+	_, coverPackages, testPackages, err := resolveCoverageLaneWithDiscovery(config{suite: functionalCoverageSuite})
+	if err != nil {
+		t.Fatalf("resolveCoverageLaneWithDiscovery() error = %v", err)
+	}
+	if !reflect.DeepEqual(coverPackages, []string{modulePath + "/pkg/covered"}) {
+		t.Fatalf("functional cover packages = %v", coverPackages)
+	}
+	if !reflect.DeepEqual(testPackages, []string{modulePath + "/tests/functional/runtime_api"}) {
+		t.Fatalf("functional test packages = %v", testPackages)
+	}
+	if len(listCalls) != 1 {
+		t.Fatalf("go list calls = %d, want one combined sweep", len(listCalls))
+	}
+	if got := listCalls[0].args[3:]; !reflect.DeepEqual(got, []string{"./pkg/...", "./tests/functional/..."}) {
+		t.Fatalf("functional go list patterns = %v", got)
+	}
+}
+
+func TestCanonicalizeBlocksCanBeReusedWithoutChangingEvaluation(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := filepath.Clean(t.TempDir())
+	profilePath := writeCoverageProfile(t, strings.Join([]string{
+		"mode: count",
+		modulePath + "/pkg/service/factory.go:3.1,4.1 2 0",
+		modulePath + "/pkg/config/config.go:1.1,2.1 3 1",
+		modulePath + "/pkg/service/factory.go:3.1,4.1 2 4",
+		"",
+	}, "\n"))
+	coverPackages := []string{modulePath + "/pkg/config", modulePath + "/pkg/service"}
+
+	canonicalBlocks, err := canonicalizeCoverageProfileWithBlocks(profilePath, repoRoot, coverPackages)
+	if err != nil {
+		t.Fatalf("canonicalizeCoverageProfileWithBlocks() error = %v", err)
+	}
+	readBlocks, err := readCoverageProfileBlocks(profilePath, repoRoot)
+	if err != nil {
+		t.Fatalf("readCoverageProfileBlocks() error = %v", err)
+	}
+	if !reflect.DeepEqual(canonicalBlocks, readBlocks) {
+		t.Fatalf("reused canonical blocks = %#v, reread blocks = %#v", canonicalBlocks, readBlocks)
+	}
+
+	baseline := map[string]struct{}{}
+	fromProfile, fromProfileLine, err := evaluateCoverage("", "", profilePath, repoRoot, coverPackages, 80, baseline)
+	if err != nil {
+		t.Fatalf("evaluateCoverage() error = %v", err)
+	}
+	fromBlocks, fromBlocksLine, err := evaluateCoverageBlocks(canonicalBlocks, coverPackages, 80, baseline)
+	if err != nil {
+		t.Fatalf("evaluateCoverageBlocks() error = %v", err)
+	}
+	if !reflect.DeepEqual(fromBlocks, fromProfile) || fromBlocksLine != fromProfileLine {
+		t.Fatalf("reused evaluation = %#v/%q, reread evaluation = %#v/%q", fromBlocks, fromBlocksLine, fromProfile, fromProfileLine)
+	}
+}

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -306,14 +306,25 @@ func windowsCommandLineArgLength(arg string) int {
 	return 2 + len(arg) + strings.Count(arg, `\`) + 2*strings.Count(arg, `"`)
 }
 
+// planGoTestCoverageLane builds the coverage invocation once on short command
+// lines, or in deterministic test-package batches when Windows needs it.
+func planGoTestCoverageLane(commonArgs []string, testPackages []string, profilePath string, cfg config, targetOS string, compactPackageArgs ...[]string) (coverageInvocationPlan, error) {
+	jsonEventsEnabled := strings.TrimSpace(cfg.timingOutput) != "" || cfg.stream
+	return buildCoverageInvocationPlan(commonArgs, testPackages, profilePath, jsonEventsEnabled, targetOS, compactPackageArgs...)
+}
+
+func planGoTestCoverageLaneWithSelection(commonArgs []string, profilePath string, cfg config, targetOS string, selection functionalCoverageSelection) (coverageInvocationPlan, error) {
+	jsonEventsEnabled := strings.TrimSpace(cfg.timingOutput) != "" || cfg.stream
+	return buildFunctionalCoverageInvocationPlan(commonArgs, selection.Groups, profilePath, jsonEventsEnabled, targetOS)
+}
+
 // runGoTestCoverageLane runs the coverage invocation once on short command
 // lines, or in deterministic test-package batches when Windows needs it. When
 // timing capture or streaming is enabled, it combines every batch's -json
 // stdout before writing the timing summary, so a failed or crashed lane still
 // leaves trustworthy (possibly incomplete) diagnostics on disk.
 func runGoTestCoverageLane(cfg config, commonArgs []string, testPackages []string, profilePath string, repoRoot string, coverPackages []string, targetOS string, failurePrefix string, compactPackageArgs ...[]string) error {
-	jsonEventsEnabled := strings.TrimSpace(cfg.timingOutput) != "" || cfg.stream
-	plan, err := buildCoverageInvocationPlan(commonArgs, testPackages, profilePath, jsonEventsEnabled, targetOS, compactPackageArgs...)
+	plan, err := planGoTestCoverageLane(commonArgs, testPackages, profilePath, cfg, targetOS, compactPackageArgs...)
 	if err != nil {
 		return err
 	}
@@ -321,8 +332,7 @@ func runGoTestCoverageLane(cfg config, commonArgs []string, testPackages []strin
 }
 
 func runGoTestCoverageLaneWithSelection(cfg config, commonArgs []string, testPackages []string, profilePath string, repoRoot string, coverPackages []string, targetOS string, failurePrefix string, selection functionalCoverageSelection) error {
-	jsonEventsEnabled := strings.TrimSpace(cfg.timingOutput) != "" || cfg.stream
-	plan, err := buildFunctionalCoverageInvocationPlan(commonArgs, selection.Groups, profilePath, jsonEventsEnabled, targetOS)
+	plan, err := planGoTestCoverageLaneWithSelection(commonArgs, profilePath, cfg, targetOS, selection)
 	if err != nil {
 		return err
 	}

--- a/cmd/gocoveragecheck/coverage_phases.go
+++ b/cmd/gocoveragecheck/coverage_phases.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+type preparedCoverageRun struct {
+	plan         coverageInvocationPlan
+	repoRoot     string
+	testPackages []string
+}
+
+func prepareCoverageRun(cfg config, targetOS string, logicalCPUs int, profilePath string, coverPackages []string, testPackages []string) (preparedCoverageRun, error) {
+	repoRoot, err := repoRootDir()
+	if err != nil {
+		return preparedCoverageRun{}, err
+	}
+
+	var functionalSelection *functionalCoverageSelection
+	if strings.TrimSpace(cfg.functionalQuarantine) != "" {
+		selection, selectedPackages, selectionErr := prepareFunctionalCoverageRun(cfg, testPackages, targetOS, logicalCPUs, repoRoot)
+		if selectionErr != nil {
+			return preparedCoverageRun{}, selectionErr
+		}
+		functionalSelection = &selection
+		testPackages = selectedPackages
+	}
+
+	coverPackageArgument := strings.Join(coverPackages, ",")
+	if targetOS == "windows" && strings.TrimSpace(cfg.coverpkg) == "" {
+		// A fully expanded backend package list exceeds Windows' command-line
+		// limit. A package pattern keeps the invocation to one logical coverage
+		// pass; the resolved list remains authoritative for filtering, reporting,
+		// and package gates.
+		coverPackageArgument = modulePath + "/pkg/..."
+	}
+	coverageTestArgs := []string{
+		"test",
+		fmt.Sprintf("-coverpkg=%s", coverPackageArgument),
+		fmt.Sprintf("-p=%d", cfg.testJobs(targetOS, logicalCPUs)),
+		// Coverage is authoritative, so every package must run even when a prior
+		// non-instrumented invocation is cached.
+		"-count=1",
+	}
+	if cfg.short {
+		coverageTestArgs = append(coverageTestArgs, "-short")
+	}
+	coverageTestArgs = append(coverageTestArgs,
+		fmt.Sprintf("-covermode=%s", cfg.covermode),
+		fmt.Sprintf("-timeout=%s", cfg.timeout),
+	)
+	testPackageArgs := compactUnitTestPackageArgs(cfg, testPackages, targetOS)
+
+	var plan coverageInvocationPlan
+	if functionalSelection == nil {
+		plan, err = planGoTestCoverageLane(coverageTestArgs, testPackages, profilePath, cfg, targetOS, testPackageArgs)
+	} else {
+		plan, err = planGoTestCoverageLaneWithSelection(coverageTestArgs, profilePath, cfg, targetOS, *functionalSelection)
+	}
+	if err != nil {
+		return preparedCoverageRun{}, err
+	}
+	return preparedCoverageRun{plan: plan, repoRoot: repoRoot, testPackages: testPackages}, nil
+}
+
+type evaluatedCoverageRun struct {
+	result           coverageResult
+	baselinePackages map[string]struct{}
+}
+
+func evaluateCoverageRun(cfg config, profilePath string, repoRoot string, coverPackages []string) (evaluatedCoverageRun, error) {
+	baselinePackages := map[string]struct{}{}
+	if legacyPackageGateEnabled(cfg) {
+		var err error
+		baselinePackages, err = packageCoverageBaselinePackages(cfg, repoRoot)
+		if err != nil {
+			return evaluatedCoverageRun{}, err
+		}
+	}
+
+	result, totalLine, err := evaluateCoverage("", "", profilePath, repoRoot, coverPackages, cfg.packageCoverageMin(), baselinePackages, legacyPackageGateEnabled(cfg))
+	if err != nil {
+		return evaluatedCoverageRun{}, err
+	}
+	fmt.Fprintln(stdoutWriter, totalLine)
+	return evaluatedCoverageRun{result: result, baselinePackages: baselinePackages}, nil
+}
+
+func legacyPackageGateEnabled(cfg config) bool {
+	return !cfg.totalOnly && cfg.generateManifest == "" && cfg.updateManifest == "" && strings.TrimSpace(cfg.packageManifest) == ""
+}
+
+func applyCoverageManifestGate(cfg config, result coverageResult, repoRoot string, baselinePackages map[string]struct{}) (coverageResult, error) {
+	if !cfg.totalOnly && strings.TrimSpace(cfg.packageManifest) != "" {
+		manifestPath := cfg.packageManifest
+		if !filepath.IsAbs(manifestPath) {
+			manifestPath = filepath.Join(repoRoot, manifestPath)
+		}
+		manifest, err := readCoverageManifestFileWithTotals(manifestPath, cfg.suite, packageImportPaths(result.packageSummaries), result.packageTotals)
+		if err != nil {
+			var validationErr *coverageManifestValidationError
+			if errors.As(err, &validationErr) {
+				return result, err
+			}
+			return coverageResult{}, err
+		}
+		result.packageMinimumFailures, result.packageMinimumWarnings = checkCoverageManifestWithEpsilonAndBlocks(manifest, result.packageTotals, cfg.packageManifest, cfg.packageFloorEpsilon, result.coverageBlocks)
+		result.unmeasuredPackageDiagnostics = formatUnmeasuredCoverageManifestDiagnostics(manifest, result.packageTotals)
+		result.packageGates = coverageManifestGatedPackages(manifest, result.packageTotals)
+	} else if legacyPackageGateEnabled(cfg) {
+		result.packageGates = packageGatesFromLegacyMin(result.packageSummaries, cfg.packageCoverageMin(), baselinePackages)
+	}
+	return result, nil
+}

--- a/cmd/gocoveragecheck/coverage_phases.go
+++ b/cmd/gocoveragecheck/coverage_phases.go
@@ -13,7 +13,7 @@ type preparedCoverageRun struct {
 	testPackages []string
 }
 
-func prepareCoverageRun(cfg config, targetOS string, logicalCPUs int, profilePath string, coverPackages []string, testPackages []string) (preparedCoverageRun, error) {
+func prepareCoverageRun(cfg config, targetOS string, logicalCPUs int, profilePath string, coverPackages []string, testPackages []string, packageUniverse []string) (preparedCoverageRun, error) {
 	repoRoot, err := repoRootDir()
 	if err != nil {
 		return preparedCoverageRun{}, err
@@ -52,7 +52,7 @@ func prepareCoverageRun(cfg config, targetOS string, logicalCPUs int, profilePat
 		fmt.Sprintf("-covermode=%s", cfg.covermode),
 		fmt.Sprintf("-timeout=%s", cfg.timeout),
 	)
-	testPackageArgs := compactUnitTestPackageArgs(cfg, testPackages, targetOS)
+	testPackageArgs := compactUnitTestPackageArgs(cfg, testPackages, targetOS, packageUniverse)
 
 	var plan coverageInvocationPlan
 	if functionalSelection == nil {
@@ -71,7 +71,7 @@ type evaluatedCoverageRun struct {
 	baselinePackages map[string]struct{}
 }
 
-func evaluateCoverageRun(cfg config, profilePath string, repoRoot string, coverPackages []string) (evaluatedCoverageRun, error) {
+func evaluateCoverageRun(cfg config, profilePath string, repoRoot string, coverPackages []string, canonicalBlocks map[string]coverageBlock) (evaluatedCoverageRun, error) {
 	baselinePackages := map[string]struct{}{}
 	if legacyPackageGateEnabled(cfg) {
 		var err error
@@ -81,7 +81,14 @@ func evaluateCoverageRun(cfg config, profilePath string, repoRoot string, coverP
 		}
 	}
 
-	result, totalLine, err := evaluateCoverage("", "", profilePath, repoRoot, coverPackages, cfg.packageCoverageMin(), baselinePackages, legacyPackageGateEnabled(cfg))
+	var result coverageResult
+	var totalLine string
+	var err error
+	if canonicalBlocks == nil {
+		result, totalLine, err = evaluateCoverage("", "", profilePath, repoRoot, coverPackages, cfg.packageCoverageMin(), baselinePackages, legacyPackageGateEnabled(cfg))
+	} else {
+		result, totalLine, err = evaluateCoverageBlocks(canonicalBlocks, coverPackages, cfg.packageCoverageMin(), baselinePackages, legacyPackageGateEnabled(cfg))
+	}
 	if err != nil {
 		return evaluatedCoverageRun{}, err
 	}

--- a/cmd/gocoveragecheck/functional_diagnostics.go
+++ b/cmd/gocoveragecheck/functional_diagnostics.go
@@ -9,7 +9,11 @@ import (
 	"time"
 )
 
-const functionalTimingSnapshotInterval = time.Second
+// Keep partial timing diagnostics fresh without rewriting the full package
+// state document for every second of a long non-streaming unit run. Streaming
+// lanes still publish on each observed package event; the interval only
+// controls the background persistence path.
+const functionalTimingSnapshotInterval = 5 * time.Second
 const functionalCoverageSnapshotInterval = 5 * time.Second
 
 // functionalTimingTracker records package lifecycle events independently from
@@ -236,7 +240,7 @@ func (snapshotter *functionalTimingSnapshotter) run() {
 // A streaming lane still publishes per event, because its progress lines are
 // the live log a reader watches, and it observes a few dozen packages. A
 // non-streaming lane has no sink to emit to, so persistence is left entirely to
-// the one-second ticker in run(): the timeout snapshot it exists to protect is
+// the periodic ticker in run(): the timeout snapshot it exists to protect is
 // still on disk, without paying a full document write per event. The unit lane
 // observes hundreds of packages, which is what makes the difference matter.
 func (snapshotter *functionalTimingSnapshotter) observe(event goTestTimingEvent) {

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -105,6 +105,7 @@ type config struct {
 	stream               bool
 	timeout              time.Duration
 	totalOnly            bool
+	phaseTiming          *coveragePhaseTimer
 }
 
 type coverageResult struct {
@@ -147,6 +148,10 @@ func execute(cfg config) error {
 	if strings.TrimSpace(cfg.updateProfiles) != "" {
 		return executeSampledManifestUpdate(cfg)
 	}
+	if cfg.phaseTiming == nil && unitCoveragePhaseTimingEnabled(cfg) {
+		cfg.phaseTiming = newCoveragePhaseTimer(stdoutWriter)
+		defer cfg.phaseTiming.emit()
+	}
 	result, err := run(cfg)
 	if err != nil {
 		writeCoverageTestFailureWarning(err)
@@ -172,14 +177,17 @@ func execute(cfg config) error {
 	writeCoverageLaneReport(cfg, result, failures)
 	if cfg.generateManifest != "" {
 		if err := createCoverageManifest(cfg.generateManifest, cfg.suite, result.packageTotals, packageImportPaths(result.packageSummaries)); err != nil {
+			cfg.finishCoveragePhase(coveragePhaseManifest, coveragePhaseStatusError)
 			return err
 		}
 		fmt.Fprintf(stdoutWriter, "Created %s coverage manifest at %s.\n", cfg.suite, cfg.generateManifest)
 	}
 	if err := writeCoverageSummaryJSON(cfg.jsonOutput, result); err != nil {
+		cfg.finishCoveragePhase(coveragePhaseManifest, coveragePhaseStatusError)
 		return err
 	}
 	writeCoverageDiagnostics(result)
+	cfg.finishCoveragePhase(coveragePhaseManifest, coveragePhaseStatusComplete)
 
 	if len(failures) > 0 {
 		return errors.New(strings.Join(failures, "\n"))
@@ -302,93 +310,52 @@ func runForOSWithCPU(cfg config, targetOS string, logicalCPUs int) (result cover
 }
 
 func runCoverageProfile(cfg config, targetOS string, logicalCPUs int, profilePath string) (coverageResult, error) {
-	coverPackages, testPackages, err := resolveCoverageLane(cfg)
-	if err != nil {
+	var coverPackages []string
+	var testPackages []string
+	if err := cfg.measureCoveragePhase(coveragePhaseList, func() error {
+		var err error
+		coverPackages, testPackages, err = resolveCoverageLane(cfg)
+		return err
+	}); err != nil {
 		return coverageResult{}, err
 	}
-	repoRoot, err := repoRootDir()
-	if err != nil {
-		return coverageResult{}, err
-	}
-	var functionalSelection *functionalCoverageSelection
-	if strings.TrimSpace(cfg.functionalQuarantine) != "" {
-		selection, selectedPackages, selectionErr := prepareFunctionalCoverageRun(cfg, testPackages, targetOS, logicalCPUs, repoRoot)
-		if selectionErr != nil {
-			return coverageResult{}, selectionErr
-		}
-		functionalSelection = &selection
-		testPackages = selectedPackages
-	}
-	coverPackageArgument := strings.Join(coverPackages, ",")
-	if targetOS == "windows" && strings.TrimSpace(cfg.coverpkg) == "" {
-		// A fully expanded backend package list exceeds Windows' command-line
-		// limit. A package pattern keeps the invocation to one logical coverage
-		// pass; the resolved list above remains authoritative for profile
-		// filtering, reporting, and package gates.
-		coverPackageArgument = modulePath + "/pkg/..."
-	}
-	coverageTestArgs := []string{
-		"test",
-		fmt.Sprintf("-coverpkg=%s", coverPackageArgument),
-		fmt.Sprintf("-p=%d", cfg.testJobs(targetOS, logicalCPUs)),
-		// Coverage is an authoritative measurement, so every package must run
-		// even when a prior non-instrumented invocation is cached.
-		"-count=1",
-	}
-	if cfg.short {
-		coverageTestArgs = append(coverageTestArgs, "-short")
-	}
-	coverageTestArgs = append(coverageTestArgs,
-		fmt.Sprintf("-covermode=%s", cfg.covermode),
-		fmt.Sprintf("-timeout=%s", cfg.timeout),
-	)
 
-	testPackageArgs := compactUnitTestPackageArgs(cfg, testPackages, targetOS)
-	var runErr error
-	if functionalSelection == nil {
-		runErr = runGoTestCoverageLane(cfg, coverageTestArgs, testPackages, profilePath, repoRoot, coverPackages, targetOS, "run go test coverage lane", testPackageArgs)
-	} else {
-		runErr = runGoTestCoverageLaneWithSelection(cfg, coverageTestArgs, testPackages, profilePath, repoRoot, coverPackages, targetOS, "run go test coverage lane", *functionalSelection)
+	var prepared preparedCoverageRun
+	if err := cfg.measureCoveragePhase(coveragePhasePlan, func() error {
+		var err error
+		prepared, err = prepareCoverageRun(cfg, targetOS, logicalCPUs, profilePath, coverPackages, testPackages)
+		return err
+	}); err != nil {
+		return coverageResult{}, err
 	}
+
+	var runErr error
+	runErr = cfg.measureCoveragePhase(coveragePhaseTest, func() error {
+		return executeCoverageInvocationPlan(cfg, prepared.plan, prepared.testPackages, profilePath, prepared.repoRoot, coverPackages, "run go test coverage lane")
+	})
 	if runErr != nil {
 		return coverageResult{}, runErr
 	}
-	if err := canonicalizeCoverageProfile(profilePath, repoRoot, coverPackages); err != nil {
+	if err := cfg.measureCoveragePhase(coveragePhaseCanonicalize, func() error {
+		return canonicalizeCoverageProfile(profilePath, prepared.repoRoot, coverPackages)
+	}); err != nil {
 		return coverageResult{}, err
 	}
 
-	legacyPackageGateEnabled := !cfg.totalOnly && cfg.generateManifest == "" && cfg.updateManifest == "" && strings.TrimSpace(cfg.packageManifest) == ""
-	baselinePackages := map[string]struct{}{}
-	if legacyPackageGateEnabled {
-		baselinePackages, err = packageCoverageBaselinePackages(cfg, repoRoot)
-		if err != nil {
-			return coverageResult{}, err
-		}
+	var evaluated evaluatedCoverageRun
+	if err := cfg.measureCoveragePhase(coveragePhaseEvaluate, func() error {
+		var err error
+		evaluated, err = evaluateCoverageRun(cfg, profilePath, prepared.repoRoot, coverPackages)
+		return err
+	}); err != nil {
+		return coverageResult{}, err
 	}
 
-	result, totalLine, err := evaluateCoverage("", "", profilePath, repoRoot, coverPackages, cfg.packageCoverageMin(), baselinePackages, legacyPackageGateEnabled)
+	cfg.beginCoveragePhase(coveragePhaseManifest)
+	result, err := applyCoverageManifestGate(cfg, evaluated.result, prepared.repoRoot, evaluated.baselinePackages)
 	if err != nil {
-		return coverageResult{}, err
-	}
-	fmt.Fprintln(stdoutWriter, totalLine)
-	if !cfg.totalOnly && strings.TrimSpace(cfg.packageManifest) != "" {
-		manifestPath := cfg.packageManifest
-		if !filepath.IsAbs(manifestPath) {
-			manifestPath = filepath.Join(repoRoot, manifestPath)
-		}
-		manifest, err := readCoverageManifestFileWithTotals(manifestPath, cfg.suite, packageImportPaths(result.packageSummaries), result.packageTotals)
-		if err != nil {
-			var validationErr *coverageManifestValidationError
-			if errors.As(err, &validationErr) {
-				return result, err
-			}
-			return coverageResult{}, err
-		}
-		result.packageMinimumFailures, result.packageMinimumWarnings = checkCoverageManifestWithEpsilonAndBlocks(manifest, result.packageTotals, cfg.packageManifest, cfg.packageFloorEpsilon, result.coverageBlocks)
-		result.unmeasuredPackageDiagnostics = formatUnmeasuredCoverageManifestDiagnostics(manifest, result.packageTotals)
-		result.packageGates = coverageManifestGatedPackages(manifest, result.packageTotals)
-	} else if legacyPackageGateEnabled {
-		result.packageGates = packageGatesFromLegacyMin(result.packageSummaries, cfg.packageCoverageMin(), baselinePackages)
+		cfg.finishCoveragePhase(coveragePhaseManifest, coveragePhaseStatusError)
+		return result, err
 	}
 	return result, nil
 }

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -312,9 +312,11 @@ func runForOSWithCPU(cfg config, targetOS string, logicalCPUs int) (result cover
 func runCoverageProfile(cfg config, targetOS string, logicalCPUs int, profilePath string) (coverageResult, error) {
 	var coverPackages []string
 	var testPackages []string
+	var packageDiscovery coveragePackageDiscovery
+	var canonicalBlocks map[string]coverageBlock
 	if err := cfg.measureCoveragePhase(coveragePhaseList, func() error {
 		var err error
-		coverPackages, testPackages, err = resolveCoverageLane(cfg)
+		packageDiscovery, coverPackages, testPackages, err = resolveCoverageLaneWithDiscovery(cfg)
 		return err
 	}); err != nil {
 		return coverageResult{}, err
@@ -323,7 +325,7 @@ func runCoverageProfile(cfg config, targetOS string, logicalCPUs int, profilePat
 	var prepared preparedCoverageRun
 	if err := cfg.measureCoveragePhase(coveragePhasePlan, func() error {
 		var err error
-		prepared, err = prepareCoverageRun(cfg, targetOS, logicalCPUs, profilePath, coverPackages, testPackages)
+		prepared, err = prepareCoverageRun(cfg, targetOS, logicalCPUs, profilePath, coverPackages, testPackages, packageDiscovery.allPackages)
 		return err
 	}); err != nil {
 		return coverageResult{}, err
@@ -337,7 +339,9 @@ func runCoverageProfile(cfg config, targetOS string, logicalCPUs int, profilePat
 		return coverageResult{}, runErr
 	}
 	if err := cfg.measureCoveragePhase(coveragePhaseCanonicalize, func() error {
-		return canonicalizeCoverageProfile(profilePath, prepared.repoRoot, coverPackages)
+		var err error
+		canonicalBlocks, err = canonicalizeCoverageProfileWithBlocks(profilePath, prepared.repoRoot, coverPackages)
+		return err
 	}); err != nil {
 		return coverageResult{}, err
 	}
@@ -345,7 +349,7 @@ func runCoverageProfile(cfg config, targetOS string, logicalCPUs int, profilePat
 	var evaluated evaluatedCoverageRun
 	if err := cfg.measureCoveragePhase(coveragePhaseEvaluate, func() error {
 		var err error
-		evaluated, err = evaluateCoverageRun(cfg, profilePath, prepared.repoRoot, coverPackages)
+		evaluated, err = evaluateCoverageRun(cfg, profilePath, prepared.repoRoot, coverPackages, canonicalBlocks)
 		return err
 	}); err != nil {
 		return coverageResult{}, err
@@ -390,93 +394,36 @@ func packageCoverageBaselinePackages(cfg config, repoRoot string) (map[string]st
 }
 
 func resolveCoverageLane(cfg config) ([]string, []string, error) {
-	coverPackages, err := resolveCoverPackages(cfg)
-	if err != nil {
-		return nil, nil, err
-	}
-	testPackages, err := resolveTestPackages(cfg)
+	_, coverPackages, testPackages, err := resolveCoverageLaneWithDiscovery(cfg)
 	if err != nil {
 		return nil, nil, err
 	}
 	return coverPackages, testPackages, nil
 }
 
-func resolveCoverPackages(cfg config) ([]string, error) {
-	if strings.TrimSpace(cfg.coverpkg) != "" {
-		return splitList(cfg.coverpkg, ",", false), nil
-	}
-	return listGoPackages(defaultCoveragePatterns, isBackendCoveragePackage, true)
-}
-
-func resolveTestPackages(cfg config) ([]string, error) {
-	if strings.TrimSpace(cfg.packages) != "" {
-		return splitList(cfg.packages, " ", true), nil
-	}
-	switch cfg.suite {
-	case "", "unit":
-		return listGoPackages(unitTestPatterns, isBackendCoveragePackage, false)
-	case "functional":
-		return listGoPackages(functionalTestPatterns, isFunctionalTestPackage, false)
-	default:
-		return nil, fmt.Errorf("resolve go coverage lane: unsupported suite %q", cfg.suite)
-	}
-}
-
 func listGoPackages(patterns []string, include func(string) bool, requireNonTestGoFiles bool) ([]string, error) {
-	args := append([]string{"list", "-f", "{{.ImportPath}}	{{len .GoFiles}}"}, patterns...)
-	rootDir, err := repoRootDir()
+	listings, err := listGoPackageListings(patterns)
 	if err != nil {
 		return nil, err
 	}
-	stdout, stderr, err := runCommand(commandInvocation{
-		name: "go",
-		args: args,
-		env:  os.Environ(),
-		dir:  rootDir,
-	})
-	if err != nil {
-		detail := strings.TrimSpace(stderr)
-		if detail == "" {
-			detail = strings.TrimSpace(stdout)
-		}
-		if detail != "" {
-			return nil, fmt.Errorf("list go packages: %w\n%s", err, detail)
-		}
-		return nil, fmt.Errorf("list go packages: %w", err)
-	}
-
-	seen := make(map[string]struct{})
-	var packages []string
-	for _, line := range strings.Split(stdout, "\n") {
-		importPath, goFiles, hasGoFiles := parseGoListPackageLine(line)
-		if importPath == "" || !include(importPath) {
-			continue
-		}
-		if requireNonTestGoFiles && hasGoFiles && goFiles == 0 {
-			continue
-		}
-		if _, ok := seen[importPath]; ok {
-			continue
-		}
-		seen[importPath] = struct{}{}
-		packages = append(packages, importPath)
-	}
-	slices.Sort(packages)
-	if len(packages) == 0 {
-		return nil, errors.New("resolve go coverage lane: no packages matched")
-	}
-	return packages, nil
+	return filterCoveragePackageListings(listings, include, requireNonTestGoFiles)
 }
 
-func compactUnitTestPackageArgs(cfg config, testPackages []string, targetOS string) []string {
+func compactUnitTestPackageArgs(cfg config, testPackages []string, targetOS string, packageUniverse ...[]string) []string {
 	// The compact patterns are safe only for the default unit package universe:
 	// custom package lists and functional packages retain their existing args.
 	if targetOS != "windows" || (cfg.suite != "" && cfg.suite != "unit") || strings.TrimSpace(cfg.packages) != "" {
 		return nil
 	}
-	allPackages, err := listGoPackages([]string{"./pkg/..."}, func(string) bool { return true }, false)
-	if err != nil {
-		return nil
+	var allPackages []string
+	if len(packageUniverse) > 0 && len(packageUniverse[0]) > 0 {
+		allPackages = append([]string(nil), packageUniverse[0]...)
+	} else {
+		var err error
+		allPackages, err = listGoPackages([]string{"./pkg/..."}, func(string) bool { return true }, false)
+		if err != nil {
+			return nil
+		}
 	}
 	patterns, err := compactGoPackagePatterns(allPackages, testPackages, modulePath+"/pkg")
 	if err != nil {
@@ -571,6 +518,10 @@ func evaluateCoverage(_ string, _ string, profilePath string, repoRoot string, c
 	if err != nil {
 		return coverageResult{}, "", err
 	}
+	return evaluateCoverageBlocks(coverageBlocks, coverPackages, minCoverage, baselinePackages, packageGate...)
+}
+
+func evaluateCoverageBlocks(coverageBlocks map[string]coverageBlock, coverPackages []string, minCoverage float64, baselinePackages map[string]struct{}, packageGate ...bool) (coverageResult, string, error) {
 	packageTotals := coverageTotals(coverageBlocks)
 	actual, totalLine := calculateTotalCoverage(packageTotals, coverPackages)
 	packageGateEnabled := len(packageGate) == 0 || packageGate[0]
@@ -811,34 +762,44 @@ func coverageTotals(coverageBlocks map[string]coverageBlock) map[string]packageC
 }
 
 func canonicalizeCoverageProfile(profilePath string, repoRoot string, coverPackages []string) error {
-	return mergeCoverageProfiles([]string{profilePath}, profilePath, repoRoot, coverPackages)
+	_, err := canonicalizeCoverageProfileWithBlocks(profilePath, repoRoot, coverPackages)
+	return err
 }
 
 func mergeCoverageProfiles(profilePaths []string, outputPath string, repoRoot string, coverPackages []string) error {
+	_, err := mergeCoverageProfilesWithBlocks(profilePaths, outputPath, repoRoot, coverPackages)
+	return err
+}
+
+func canonicalizeCoverageProfileWithBlocks(profilePath string, repoRoot string, coverPackages []string) (map[string]coverageBlock, error) {
+	return mergeCoverageProfilesWithBlocks([]string{profilePath}, profilePath, repoRoot, coverPackages)
+}
+
+func mergeCoverageProfilesWithBlocks(profilePaths []string, outputPath string, repoRoot string, coverPackages []string) (map[string]coverageBlock, error) {
 	coverageBlocks := make(map[string]coverageBlock)
 	header := ""
 	for _, profilePath := range profilePaths {
 		profile, err := os.Open(profilePath)
 		if err != nil {
-			return fmt.Errorf("read go coverage profile: %w", err)
+			return nil, fmt.Errorf("read go coverage profile: %w", err)
 		}
 		profileHeader, profileBlocks, scanErr := scanCoverageProfile(profile, repoRoot)
 		closeErr := profile.Close()
 		if scanErr != nil {
-			return scanErr
+			return nil, scanErr
 		}
 		if closeErr != nil {
-			return fmt.Errorf("close go coverage profile: %w", closeErr)
+			return nil, fmt.Errorf("close go coverage profile: %w", closeErr)
 		}
 		if header == "" {
 			header = profileHeader
 		} else if header != profileHeader {
-			return fmt.Errorf("merge go coverage profiles: mode headers differ: %q and %q", header, profileHeader)
+			return nil, fmt.Errorf("merge go coverage profiles: mode headers differ: %q and %q", header, profileHeader)
 		}
 		for key, block := range profileBlocks {
 			merged := coverageBlocks[key]
 			if merged.statementCount != 0 && merged.statementCount != block.statementCount {
-				return fmt.Errorf("merge go coverage profiles: source block %s has inconsistent statement counts %d and %d", key, merged.statementCount, block.statementCount)
+				return nil, fmt.Errorf("merge go coverage profiles: source block %s has inconsistent statement counts %d and %d", key, merged.statementCount, block.statementCount)
 			}
 			if block.executionCount > merged.executionCount {
 				merged.executionCount = block.executionCount
@@ -865,15 +826,17 @@ func mergeCoverageProfiles(profilePaths []string, outputPath string, repoRoot st
 
 	output, err := os.Create(outputPath)
 	if err != nil {
-		return fmt.Errorf("rewrite canonical go coverage profile: %w", err)
+		return nil, fmt.Errorf("rewrite canonical go coverage profile: %w", err)
 	}
 	writer := bufio.NewWriter(output)
 	_, writeErr := fmt.Fprintln(writer, header)
+	selectedBlocks := make(map[string]coverageBlock, len(keys))
 	for _, key := range keys {
 		if writeErr != nil {
 			break
 		}
 		block := coverageBlocks[key]
+		selectedBlocks[key] = block
 		_, writeErr = fmt.Fprintf(writer, "%s:%s %d %d\n", block.canonicalPath, block.rangeSpec, block.statementCount, block.executionCount)
 	}
 	if writeErr == nil {
@@ -881,12 +844,12 @@ func mergeCoverageProfiles(profilePaths []string, outputPath string, repoRoot st
 	}
 	closeErr := output.Close()
 	if writeErr != nil {
-		return fmt.Errorf("rewrite canonical go coverage profile: %w", writeErr)
+		return nil, fmt.Errorf("rewrite canonical go coverage profile: %w", writeErr)
 	}
 	if closeErr != nil {
-		return fmt.Errorf("close canonical go coverage profile: %w", closeErr)
+		return nil, fmt.Errorf("close canonical go coverage profile: %w", closeErr)
 	}
-	return nil
+	return selectedBlocks, nil
 }
 
 func coverageCanonicalFilePath(filePath string, repoRoot string) (string, error) {

--- a/cmd/gocoveragecheck/main_entrypoint_test.go
+++ b/cmd/gocoveragecheck/main_entrypoint_test.go
@@ -217,7 +217,7 @@ func TestMainReportsSkippedPackageFloorsWhenCoverageTestsFail(t *testing.T) {
 	if exitCode != 1 {
 		t.Fatalf("main() exit code = %d, want 1", exitCode)
 	}
-	if stdout != "" {
+	if strings.Contains(stdout, "\tcoverage:") || strings.Contains(stdout, "total: (statements)") {
 		t.Fatalf("main() stdout = %q, want no coverage summaries without a valid measurement", stdout)
 	}
 	for _, want := range []string{

--- a/cmd/gocoveragecheck/main_run_test.go
+++ b/cmd/gocoveragecheck/main_run_test.go
@@ -321,7 +321,7 @@ func TestExecuteDoesNotReportPackageSummariesWhenMeasurementFails(t *testing.T) 
 	if err == nil {
 		t.Fatal("execute() unexpectedly succeeded")
 	}
-	if stdout.Len() != 0 {
+	if strings.Contains(stdout.String(), "\tcoverage:") || strings.Contains(stdout.String(), "total: (statements)") {
 		t.Fatalf("execute() stdout = %q, want no package summaries without a valid measurement", stdout.String())
 	}
 	if got := stderr.String(); !strings.Contains(got, "coverage not evaluated") || !strings.Contains(got, "package floors were NOT checked") {

--- a/cmd/gocoveragecheck/phase_timing.go
+++ b/cmd/gocoveragecheck/phase_timing.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+type coveragePhaseName string
+
+const (
+	coveragePhaseList         coveragePhaseName = "list"
+	coveragePhasePlan         coveragePhaseName = "plan"
+	coveragePhaseTest         coveragePhaseName = "test"
+	coveragePhaseCanonicalize coveragePhaseName = "canonicalize"
+	coveragePhaseEvaluate     coveragePhaseName = "evaluate"
+	coveragePhaseManifest     coveragePhaseName = "manifest"
+)
+
+var coveragePhaseOrder = []coveragePhaseName{
+	coveragePhaseList,
+	coveragePhasePlan,
+	coveragePhaseTest,
+	coveragePhaseCanonicalize,
+	coveragePhaseEvaluate,
+	coveragePhaseManifest,
+}
+
+const (
+	coveragePhaseStatusComplete = "complete"
+	coveragePhaseStatusError    = "error"
+	coveragePhaseStatusSkipped  = "skipped"
+)
+
+type coveragePhaseTiming struct {
+	duration time.Duration
+	started  time.Time
+	active   bool
+	recorded bool
+	status   string
+}
+
+// coveragePhaseTimer emits one deterministic observation for each checker
+// phase. The timer owns only measurement state; the caller still owns the
+// phase boundaries and all coverage behavior.
+type coveragePhaseTimer struct {
+	now     func() time.Time
+	sink    io.Writer
+	phases  map[coveragePhaseName]*coveragePhaseTiming
+	emitted bool
+}
+
+func newCoveragePhaseTimer(sink io.Writer) *coveragePhaseTimer {
+	if sink == nil {
+		sink = io.Discard
+	}
+	phases := make(map[coveragePhaseName]*coveragePhaseTiming, len(coveragePhaseOrder))
+	for _, name := range coveragePhaseOrder {
+		phases[name] = &coveragePhaseTiming{}
+	}
+	return &coveragePhaseTimer{
+		now:    time.Now,
+		sink:   sink,
+		phases: phases,
+	}
+}
+
+func (timer *coveragePhaseTimer) measure(name coveragePhaseName, action func() error) error {
+	timer.begin(name)
+	err := action()
+	status := coveragePhaseStatusComplete
+	if err != nil {
+		status = coveragePhaseStatusError
+	}
+	timer.finish(name, status)
+	return err
+}
+
+func (timer *coveragePhaseTimer) begin(name coveragePhaseName) {
+	phase, ok := timer.phases[name]
+	if !ok || phase.recorded || phase.active {
+		return
+	}
+	phase.started = timer.now()
+	phase.active = true
+}
+
+func (timer *coveragePhaseTimer) finish(name coveragePhaseName, status string) {
+	phase, ok := timer.phases[name]
+	if !ok || phase.recorded {
+		return
+	}
+	if phase.active {
+		phase.duration = timer.now().Sub(phase.started)
+		phase.active = false
+	}
+	if phase.duration < 0 {
+		phase.duration = 0
+	}
+	phase.status = status
+	phase.recorded = true
+}
+
+func (timer *coveragePhaseTimer) finishRemaining(status string) {
+	for _, name := range coveragePhaseOrder {
+		phase := timer.phases[name]
+		if phase.active {
+			timer.finish(name, status)
+			continue
+		}
+		if !phase.recorded {
+			timer.finish(name, coveragePhaseStatusSkipped)
+		}
+	}
+}
+
+func (timer *coveragePhaseTimer) emit() {
+	if timer == nil || timer.emitted {
+		return
+	}
+	timer.finishRemaining(coveragePhaseStatusError)
+	for _, name := range coveragePhaseOrder {
+		phase := timer.phases[name]
+		fmt.Fprintf(timer.sink, "gocoveragecheck phase timing: phase=%s duration=%.3fs status=%s\n", name, phase.duration.Seconds(), phase.status)
+	}
+	timer.emitted = true
+}
+
+func (cfg config) measureCoveragePhase(name coveragePhaseName, action func() error) error {
+	if cfg.phaseTiming == nil {
+		return action()
+	}
+	return cfg.phaseTiming.measure(name, action)
+}
+
+func (cfg config) beginCoveragePhase(name coveragePhaseName) {
+	if cfg.phaseTiming != nil {
+		cfg.phaseTiming.begin(name)
+	}
+}
+
+func (cfg config) finishCoveragePhase(name coveragePhaseName, status string) {
+	if cfg.phaseTiming != nil {
+		cfg.phaseTiming.finish(name, status)
+	}
+}
+
+func unitCoveragePhaseTimingEnabled(cfg config) bool {
+	return cfg.suite == "" || cfg.suite == unitCoverageSuite
+}

--- a/cmd/gocoveragecheck/phase_timing_test.go
+++ b/cmd/gocoveragecheck/phase_timing_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCoveragePhaseTimerEmitsStableLines(t *testing.T) {
+	var output bytes.Buffer
+	timer := newCoveragePhaseTimer(&output)
+	start := time.Unix(100, 0)
+	now := []time.Time{
+		start,
+		start.Add(1250 * time.Millisecond),
+		start.Add(1250 * time.Millisecond),
+		start.Add(3250 * time.Millisecond),
+	}
+	timer.now = func() time.Time {
+		if len(now) == 0 {
+			return start
+		}
+		value := now[0]
+		now = now[1:]
+		return value
+	}
+
+	if err := timer.measure(coveragePhaseList, func() error { return nil }); err != nil {
+		t.Fatalf("list phase error = %v", err)
+	}
+	wantPlanError := errors.New("plan failed")
+	if err := timer.measure(coveragePhasePlan, func() error { return wantPlanError }); !errors.Is(err, wantPlanError) {
+		t.Fatalf("plan phase error = %v, want %v", err, wantPlanError)
+	}
+	timer.emit()
+
+	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
+	if len(lines) != len(coveragePhaseOrder) {
+		t.Fatalf("timing lines = %d, want %d:\n%s", len(lines), len(coveragePhaseOrder), output.String())
+	}
+	wantLines := []string{
+		"gocoveragecheck phase timing: phase=list duration=1.250s status=complete",
+		"gocoveragecheck phase timing: phase=plan duration=2.000s status=error",
+		"gocoveragecheck phase timing: phase=test duration=0.000s status=skipped",
+		"gocoveragecheck phase timing: phase=canonicalize duration=0.000s status=skipped",
+		"gocoveragecheck phase timing: phase=evaluate duration=0.000s status=skipped",
+		"gocoveragecheck phase timing: phase=manifest duration=0.000s status=skipped",
+	}
+	if got := strings.Join(lines, "\n"); got != strings.Join(wantLines, "\n") {
+		t.Fatalf("timing output =\n%s\nwant=\n%s", got, strings.Join(wantLines, "\n"))
+	}
+
+	timer.emit()
+	if got := strings.Count(output.String(), "gocoveragecheck phase timing:"); got != len(coveragePhaseOrder) {
+		t.Fatalf("emitting twice produced %d lines, want %d", got, len(coveragePhaseOrder))
+	}
+}
+
+func TestExecuteEmitsCoveragePhasesWhenTestFails(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	t.Cleanup(func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeGoCoverageCommandTestFailsWithoutDetail
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	err := execute(config{
+		suite:    unitCoverageSuite,
+		coverpkg: modulePath + "/pkg/config",
+		packages: "./pkg/config",
+	})
+	if err == nil {
+		t.Fatal("execute() unexpectedly succeeded")
+	}
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) != len(coveragePhaseOrder) {
+		t.Fatalf("timing lines = %d, want %d:\n%s", len(lines), len(coveragePhaseOrder), stdout.String())
+	}
+	for _, name := range coveragePhaseOrder {
+		marker := "phase=" + string(name) + " "
+		count := 0
+		for _, line := range lines {
+			if strings.Contains(line, marker) {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Fatalf("phase %q occurred %d times in timing output:\n%s", name, count, stdout.String())
+		}
+	}
+	testLine := ""
+	for _, line := range lines {
+		if strings.Contains(line, "phase=test ") {
+			testLine = line
+			break
+		}
+	}
+	if !strings.Contains(testLine, "phase=test duration=") || !strings.Contains(testLine, "status=error") {
+		t.Fatalf("test error phase was not emitted as an error:\n%s", stdout.String())
+	}
+}


### PR DESCRIPTION
{
  "project": "Attribute and Reduce Backend Unit Coverage Orchestration Overhead",
  "branchName": "perf-u3-gocoveragecheck-orchestration-overhead",
  "description": "Instrument the Backend Unit Coverage checker with named phase timings, then remove only measurement-proven orchestration waste so the 47-89 second non-test window falls to a three-run median of at most 30 seconds without changing coverage verdicts, package-gate freshness, existing timing-summary consumers, or Backend Functional Coverage behavior.",
  "context": {
    "customerAsk": "Make the Backend Unit Coverage step attributable with list, plan, test, canonicalize, evaluate, and manifest timing lines that explain the full step wall within approximately five seconds, then reduce median step-wall-minus-wallSeconds overhead from the measured 47-89 second range to no more than 30 seconds over three consecutive post-merge main runs while preserving coverage and functional-lane behavior.",
    "problem": "The current step wall exceeds the reported go test wall by 47-89 seconds, but that aggregate window combines checker compilation, two full package-list sweeps, 10.4 MB profile processing, and the 549-package manifest gate. Without phase evidence, optimization can target the wrong work or silently weaken fresh package discovery, timing-summary consumers, coverage enforcement, or the functional suite that shares the checker.",
    "solution": "Add stable invocation-scoped timing observations for all six checker phases while preserving existing summary fields, use those measurements to select narrow optimizations such as a shared fresh package-discovery sweep, a prebuilt checker binary, or cheaper canonicalization, and prove same-tree verdict parity plus functional-lane compatibility before reporting three consecutive post-merge run measurements in a PR comment."
  },
  "acceptanceCriteria": [
    "The Backend Unit Coverage step log emits one timing line for each named phase—list, plan, test, canonicalize, evaluate, and manifest—and the reported phase durations attribute the full step wall within approximately five seconds of slack.",
    "Across three consecutive post-merge main runs, the median of Backend Unit Coverage step wall minus unit-timing-summary.json wallSeconds is no more than 30 seconds, improved from the measured 47-89 second baseline; a PR comment records each run ID, step wall, wallSeconds, derived overhead, and the median.",
    "For the same source tree, coverage totals, floor violations, failure sets, manifest diagnostics, and gated-package counts are unchanged from pre-change behavior, including the 2026-08-20 main reference of 80.7% total coverage, 529 measured packages, and 477 gated packages.",
    "Backend Functional Coverage remains green with no change attributable to this lane in package selection, quarantine, streaming, artifacts, or verdict behavior.",
    "Quality gates pass: typecheck and focused checker/reporter tests pass; make test-functional-coverage passes when the shared functional path is affected; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "perf-u3-gocoveragecheck-orchestration-overhead-001",
      "title": "Attribute the complete coverage workflow to named phases",
      "description": "As a maintainer diagnosing Backend Unit Coverage latency, I want stable phase timings in the step output so I can identify where time is spent before choosing an optimization.",
      "acceptanceCriteria": [
        "A unit coverage invocation prints exactly one unambiguous duration line for each list, plan, test, canonicalize, evaluate, and manifest phase, including when a phase terminates with an error.",
        "Timing boundaries cover checker-controlled work without double-counting, and the sum can be compared with the CI step wall to within approximately five seconds of unattributed slack.",
        "Existing unit-timing-summary.json fields and unit-coverage-summary.md behavior remain compatible; any phase data added to the JSON is additive, and the existing reporter consumes both old and new summaries.",
        "Focused tests verify the phase timing line format, required phase names, duration values, error-path emission, and backward compatibility of additive summary fields.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added fixed-format list/plan/test/canonicalize/evaluate/manifest timing lines for unit invocations, including error and skipped phases; preserved existing timing JSON and functional output. Focused and full checker tests pass with serialized package execution."
    },
    {
      "id": "perf-u3-gocoveragecheck-orchestration-overhead-002",
      "title": "Remove only measured orchestration waste",
      "description": "As a maintainer running backend coverage, I want package discovery, checker startup, and profile processing to avoid measured duplicate work so the authoritative verdict arrives faster without stale inputs or policy changes.",
      "acceptanceCriteria": [
        "Measurements from story 001 identify the phase or phases selected for optimization, and the PR explains before/after phase costs rather than claiming improvement from aggregate timing alone.",
        "Each invocation discovers packages fresh from the current source tree; no go list result is cached across CI runs.",
        "If package discovery is consolidated, the resulting cover-package and test-package lists are byte-identical to the two-sweep baseline for representative fixture modules, including excluded and testless packages.",
        "If checker startup is optimized, test-unit-coverage builds and invokes a checker binary without changing existing flags, environment compatibility, output locations, exit behavior, or the perf-u1-owned testJobs/defaultCoverageJobs policy.",
        "If profile processing is optimized, canonical coverage totals, package attribution, floor failures, manifest failures, diagnostic ordering, and output artifacts remain identical for the same profile and source tree.",
        "The optimized code keeps phase state explicit, isolates process and file side effects at the existing command boundary, and introduces no broad cleanup or generated-file changes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Consolidated fresh go list discovery into one invocation-scoped listing for discovered cover/test sets, reused the package universe for Windows compaction, and returned canonicalized coverage blocks for evaluation to avoid reparsing. Preserved custom inputs and compatibility wrappers. Focused parity/call-count tests, full cmd/gocoveragecheck tests, and targeted vet pass. Story 003 remains responsible for same-tree/functional parity and post-merge performance evidence."
    },
    {
      "id": "perf-u3-gocoveragecheck-orchestration-overhead-003",
      "title": "Prove performance, verdict parity, and functional-lane compatibility",
      "description": "As a reviewer, I want direct same-tree and CI evidence that the faster checker preserves every coverage decision and the shared functional workflow so latency savings cannot silently weaken the gate.",
      "acceptanceCriteria": [
        "A same-tree comparison records identical total coverage, measured-package count, gated-package count, floor-violation set, manifest diagnostics, and final exit verdict before and after the optimization; the 2026-08-20 reference values are 80.7%, 529 measured, and 477 gated.",
        "Backend Functional Coverage passes with unchanged observable selection, quarantine, streaming, artifact, and verdict behavior, or the PR body demonstrates that the changed path cannot affect those behaviors and identifies the focused evidence used instead.",
        "Three consecutive post-merge main Backend Unit Coverage runs yield a median (step wall - wallSeconds) of no more than 30 seconds, and a PR comment lists each run ID, both source numbers, each derived overhead, and the median.",
        "CI-run evidence is posted only as a PR comment and is not added to commits, task files, generated files, or repository progress artifacts.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented the measured non-streaming timing snapshot optimization and rebased the three commits onto current origin/main at 69511bdff, preserving final snapshots, streaming progress, coverage snapshots, and functional behavior. Same-tree direct/batched and canonical-block parity tests pass; focused checker tests, workflow tests, vet, and the mandated local make test pass on the rebased tree. The Windows Make wrapper cannot execute the POSIX functional recipe, and the direct substitute did not produce a valid terminal verdict; hosted functional CI and the remaining three post-merge overhead measurements remain review-stage evidence under the delivery criterion."
    }
  ]
}
