### PR TITLE
obs-2b-metrics-cli-coded-errors

### DIFF
--- a/pkg/services/factory_visualization/transports/cli/metrics.go
+++ b/pkg/services/factory_visualization/transports/cli/metrics.go
@@ -82,17 +82,25 @@ func RunMetrics(ctx context.Context, config MetricsConfig) error {
 	sessionID := strings.TrimSpace(config.SessionID)
 	homeDir, err := config.HomeDir()
 	if err != nil {
-		return fmt.Errorf("resolve metrics home directory: %w", err)
+		return newMetricsError(
+			MetricsHomeDirectoryFailedCode,
+			"resolve metrics home directory: home directory could not be resolved; set HOME or USERPROFILE",
+			err,
+		)
 	}
 	if strings.TrimSpace(homeDir) == "" {
-		return fmt.Errorf("resolve metrics home directory: path is empty")
+		return newMetricsError(
+			MetricsHomeDirectoryFailedCode,
+			"resolve metrics home directory: resolver returned an empty path; set HOME or USERPROFILE",
+			nil,
+		)
 	}
 	result, err := config.Query.QueryRuntimeMetrics(ctx, factoryvisualization.RuntimeMetricsQueryRequest{
 		MetricsRoot: platformmetrics.RuntimeMetricsRoot(homeDir),
 		SessionID:   sessionID,
 	})
 	if err != nil {
-		return fmt.Errorf("query Factory Runtime metrics: %w", err)
+		return newMetricsQueryError(err)
 	}
 	output, err := renderMetricsOutput(groupBy, sessionID, config.JSON, result)
 	if err != nil {
@@ -112,10 +120,18 @@ func validateMetricsConfig(ctx context.Context, config MetricsConfig) error {
 		return fmt.Errorf("render metrics: output writer is required")
 	}
 	if config.Query == nil {
-		return fmt.Errorf("query Factory Runtime metrics: query operation is required")
+		return newMetricsError(
+			MetricsQueryFailedCode,
+			"query Factory Runtime metrics: query operation is required",
+			nil,
+		)
 	}
 	if config.HomeDir == nil {
-		return fmt.Errorf("resolve metrics home directory: resolver is required")
+		return newMetricsError(
+			MetricsHomeDirectoryFailedCode,
+			"resolve metrics home directory: resolver is required; set HOME or USERPROFILE",
+			nil,
+		)
 	}
 	return nil
 }
@@ -129,9 +145,13 @@ func normalizeMetricsGroupBy(value string) (string, error) {
 	case metricsGroupByWorkstation, metricsGroupByWorker, metricsGroupByProvider:
 		return groupBy, nil
 	default:
-		return "", fmt.Errorf(
-			"invalid --group-by %q: choose workstation, worker, or provider",
-			value,
+		return "", newMetricsError(
+			MetricsInvalidGroupByCode,
+			fmt.Sprintf(
+				"invalid --group-by %q: choose workstation, worker, or provider",
+				value,
+			),
+			nil,
 		)
 	}
 }

--- a/pkg/services/factory_visualization/transports/cli/metrics_errors.go
+++ b/pkg/services/factory_visualization/transports/cli/metrics_errors.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 )
 
 const (
@@ -74,6 +75,19 @@ func (err *MetricsError) CLIErrorMessage() string {
 		return "metrics command failed"
 	}
 	return strings.TrimSpace(err.Message)
+}
+
+// CLIErrorFamily supplies the public response family through the shared
+// FamilyCodedError seam. Invalid command input is a bad request; local
+// artifact and environment failures remain internal failures.
+func (err *MetricsError) CLIErrorFamily() factoryapi.ErrorFamily {
+	if err == nil {
+		return ""
+	}
+	if err.CLIErrorCode() == MetricsInvalidGroupByCode {
+		return factoryapi.ErrorFamilyBadRequest
+	}
+	return factoryapi.ErrorFamilyInternalServerError
 }
 
 func newMetricsError(code, message string, cause error) *MetricsError {

--- a/pkg/services/factory_visualization/transports/cli/metrics_errors.go
+++ b/pkg/services/factory_visualization/transports/cli/metrics_errors.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+)
+
+const (
+	// MetricsInvalidGroupByCode identifies a grouping value that the metrics
+	// command cannot interpret.
+	MetricsInvalidGroupByCode = "METRICS_INVALID_GROUP_BY"
+	// MetricsHomeDirectoryFailedCode identifies a failure resolving the
+	// operator home directory used to locate runtime metrics.
+	MetricsHomeDirectoryFailedCode = "METRICS_HOME_DIRECTORY_FAILED"
+	// MetricsQueryFailedCode identifies a failure reading the metrics query.
+	MetricsQueryFailedCode = "METRICS_QUERY_FAILED"
+)
+
+const (
+	metricsQueryCauseInvalidInput  = "invalid query input"
+	metricsQueryCauseReadArtifacts = "read artifacts"
+	metricsQueryCauseReadFailure   = "read failure"
+	metricsQueryCauseTimedOut      = "request timed out"
+)
+
+// MetricsError is the safe CLI failure contract for the metrics command. Its
+// message is suitable for central diagnostics; Cause remains available to
+// callers that need errors.Is/errors.As inspection.
+type MetricsError struct {
+	Code    string
+	Message string
+	Cause   error
+}
+
+func (err *MetricsError) Error() string {
+	if err == nil {
+		return ""
+	}
+	code := strings.TrimSpace(err.Code)
+	message := strings.TrimSpace(err.Message)
+	if code == "" {
+		code = MetricsQueryFailedCode
+	}
+	if message == "" {
+		message = "metrics command failed"
+	}
+	return fmt.Sprintf("%s: %s", code, message)
+}
+
+func (err *MetricsError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+	return err.Cause
+}
+
+// CLIErrorCode exposes the stable code to the central CLI diagnostics
+// boundary without coupling that boundary to the concrete metrics error.
+func (err *MetricsError) CLIErrorCode() string {
+	if err == nil || strings.TrimSpace(err.Code) == "" {
+		return MetricsQueryFailedCode
+	}
+	return strings.TrimSpace(err.Code)
+}
+
+// CLIErrorMessage exposes only the already-sanitized message to the central
+// CLI diagnostics boundary.
+func (err *MetricsError) CLIErrorMessage() string {
+	if err == nil || strings.TrimSpace(err.Message) == "" {
+		return "metrics command failed"
+	}
+	return strings.TrimSpace(err.Message)
+}
+
+func newMetricsError(code, message string, cause error) *MetricsError {
+	return &MetricsError{Code: code, Message: message, Cause: cause}
+}
+
+func newMetricsQueryError(err error) *MetricsError {
+	return newMetricsError(
+		MetricsQueryFailedCode,
+		"query Factory Runtime metrics: "+metricsQueryCause(err),
+		err,
+	)
+}
+
+func metricsQueryCause(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return metricsQueryCauseTimedOut
+	}
+	var queryErr *factoryvisualization.RuntimeMetricsQueryError
+	if errors.As(err, &queryErr) {
+		switch queryErr.Kind {
+		case factoryvisualization.RuntimeMetricsQueryInvalidInput:
+			return metricsQueryCauseInvalidInput
+		case factoryvisualization.RuntimeMetricsQueryReadFailed:
+			return metricsQueryCauseReadArtifacts
+		}
+	}
+	return metricsQueryCauseReadFailure
+}

--- a/pkg/services/factory_visualization/transports/cli/metrics_output.go
+++ b/pkg/services/factory_visualization/transports/cli/metrics_output.go
@@ -23,7 +23,7 @@ func renderHumanMetrics(
 		fmt.Fprintf(&output, "Scope: Factory Session %s\n", sessionID)
 	}
 	fmt.Fprintf(&output, "Group by: %s\n", groupBy)
-	fmt.Fprintln(&output, "Cost: unavailable")
+	fmt.Fprintf(&output, "Cost: %s\n", normalizeMetricsCostAvailability(result.Cost.Availability))
 	fmt.Fprintln(&output)
 	fmt.Fprintln(&output, "Totals:")
 	renderMetricsAggregate(&output, "  ", result.Totals)
@@ -100,7 +100,7 @@ func renderMetricsOutput(
 			Counts:  "count",
 			Latency: "milliseconds",
 		},
-		Cost:   metricsJSONCost{Availability: "unavailable"},
+		Cost:   metricsJSONCost{Availability: normalizeMetricsCostAvailability(result.Cost.Availability)},
 		Totals: toJSONAggregate(result.Totals),
 		Groups: toJSONGroups(metricsBreakdowns(groupBy, result)),
 	}
@@ -109,6 +109,14 @@ func renderMetricsOutput(
 		return "", fmt.Errorf("encode metrics JSON: %w", err)
 	}
 	return string(append(encoded, '\n')), nil
+}
+
+func normalizeMetricsCostAvailability(availability factoryvisualization.RuntimeMetricsCostAvailability) string {
+	normalized := strings.ToLower(strings.TrimSpace(string(availability)))
+	if normalized == "" {
+		return "unavailable"
+	}
+	return normalized
 }
 
 func metricsJSONScopeForSession(sessionID string) metricsJSONScope {

--- a/pkg/services/factory_visualization/transports/cli/metrics_test.go
+++ b/pkg/services/factory_visualization/transports/cli/metrics_test.go
@@ -189,6 +189,46 @@ func TestMetricsCommand_JSONIsDeterministicAndPreservesMissingLatency(t *testing
 	}
 }
 
+func TestMetricsCommand_PresentsQueryCostAvailabilityInHumanAndJSON(t *testing.T) {
+	tests := []struct {
+		name         string
+		availability factoryvisualization.RuntimeMetricsCostAvailability
+		want         string
+	}{
+		{name: "unavailable", availability: factoryvisualization.RuntimeMetricsCostUnavailable, want: "unavailable"},
+		{name: "query-provided state", availability: "ESTIMATED", want: "estimated"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			query := metricsQueryStub(func(context.Context, factoryvisualization.RuntimeMetricsQueryRequest) (factoryvisualization.RuntimeMetricsQueryResult, error) {
+				result := metricsResult()
+				result.Cost.Availability = test.availability
+				return result, nil
+			})
+
+			human, err := executeMetricsCommand(t, query, nil)
+			if err != nil {
+				t.Fatalf("execute human metrics: %v", err)
+			}
+			if !strings.Contains(human, "Cost: "+test.want+"\n") {
+				t.Fatalf("human cost = %q, want %q", human, "Cost: "+test.want)
+			}
+
+			jsonOutput, err := executeMetricsCommandWithJSON(t, query, nil, true)
+			if err != nil {
+				t.Fatalf("execute JSON metrics: %v", err)
+			}
+			var document metricsJSONDocument
+			if err := json.Unmarshal([]byte(jsonOutput), &document); err != nil {
+				t.Fatalf("decode JSON output: %v\n%s", err, jsonOutput)
+			}
+			if document.Cost.Availability != test.want {
+				t.Fatalf("JSON cost availability = %q, want %q", document.Cost.Availability, test.want)
+			}
+		})
+	}
+}
+
 func TestMetricsCommand_EmptyResultShowsZeroCountsAndNoSamples(t *testing.T) {
 	output, err := executeMetricsCommand(t, metricsQueryStub(func(context.Context, factoryvisualization.RuntimeMetricsQueryRequest) (factoryvisualization.RuntimeMetricsQueryResult, error) {
 		return factoryvisualization.RuntimeMetricsQueryResult{

--- a/pkg/services/factory_visualization/transports/cli/metrics_test.go
+++ b/pkg/services/factory_visualization/transports/cli/metrics_test.go
@@ -222,6 +222,11 @@ func TestMetricsCommand_RejectsUnsupportedGroupingBeforeQuery(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), `invalid --group-by "region"`) || !strings.Contains(err.Error(), "workstation, worker, or provider") {
 		t.Fatalf("error = %v, want actionable group validation error", err)
 	}
+	var metricsErr *visualizationcli.MetricsError
+	if !errors.As(err, &metricsErr) || metricsErr.CLIErrorCode() != visualizationcli.MetricsInvalidGroupByCode ||
+		metricsErr.CLIErrorMessage() != `invalid --group-by "region": choose workstation, worker, or provider` {
+		t.Fatalf("error = %#v, want coded invalid-group failure", err)
+	}
 	if called {
 		t.Fatal("invalid grouping invoked the metrics query")
 	}
@@ -233,15 +238,69 @@ func TestMetricsCommand_RejectsUnsupportedGroupingBeforeQuery(t *testing.T) {
 func TestMetricsCommand_QueryFailureDoesNotWritePartialOutput(t *testing.T) {
 	for _, jsonOutput := range []bool{false, true} {
 		t.Run(fmt.Sprintf("json=%t", jsonOutput), func(t *testing.T) {
-			wantErr := errors.New("metrics artifact unavailable")
+			wantErr := errors.New("metrics artifact unavailable: credential=do-not-leak")
 			output, err := executeMetricsCommandWithJSON(t, metricsQueryStub(func(context.Context, factoryvisualization.RuntimeMetricsQueryRequest) (factoryvisualization.RuntimeMetricsQueryResult, error) {
 				return factoryvisualization.RuntimeMetricsQueryResult{}, wantErr
 			}), nil, jsonOutput)
-			if err == nil || !strings.Contains(err.Error(), wantErr.Error()) {
-				t.Fatalf("error = %v, want query failure", err)
+			if err == nil || !errors.Is(err, wantErr) || !strings.HasPrefix(err.Error(), "METRICS_QUERY_FAILED: query Factory Runtime metrics:") {
+				t.Fatalf("error = %v, want safe coded query failure", err)
+			}
+			if strings.Contains(err.Error(), "credential=do-not-leak") {
+				t.Fatalf("query failure exposed its underlying payload: %v", err)
 			}
 			if output != "" {
 				t.Fatalf("query failure wrote partial output %q", output)
+			}
+		})
+	}
+}
+
+func TestMetricsCommand_HomeResolutionFailuresAreCodedAndPrecedeQuery(t *testing.T) {
+	resolverErr := errors.New("home lookup credential=do-not-leak")
+	tests := []struct {
+		name      string
+		home      func() (string, error)
+		wantCause error
+	}{
+		{
+			name: "resolver failure",
+			home: func() (string, error) { return "", resolverErr }, wantCause: resolverErr,
+		},
+		{
+			name: "empty path",
+			home: func() (string, error) { return "  ", nil },
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			queryCalled := false
+			var output bytes.Buffer
+			err := visualizationcli.RunMetrics(context.Background(), visualizationcli.MetricsConfig{
+				GroupBy: "workstation", Output: &output, HomeDir: test.home,
+				Query: metricsQueryStub(func(context.Context, factoryvisualization.RuntimeMetricsQueryRequest) (factoryvisualization.RuntimeMetricsQueryResult, error) {
+					queryCalled = true
+					return factoryvisualization.RuntimeMetricsQueryResult{}, nil
+				}),
+			})
+			if err == nil {
+				t.Fatal("RunMetrics() error = nil, want home-resolution failure")
+			}
+			var metricsErr *visualizationcli.MetricsError
+			if !errors.As(err, &metricsErr) || metricsErr.CLIErrorCode() != visualizationcli.MetricsHomeDirectoryFailedCode ||
+				!strings.Contains(metricsErr.CLIErrorMessage(), "resolve metrics home directory") {
+				t.Fatalf("error = %#v, want coded home-resolution failure", err)
+			}
+			if test.wantCause != nil && !errors.Is(err, test.wantCause) {
+				t.Fatalf("error = %v, want resolver cause", err)
+			}
+			if strings.Contains(err.Error(), "credential=do-not-leak") {
+				t.Fatalf("home failure exposed its underlying payload: %v", err)
+			}
+			if queryCalled {
+				t.Fatal("home-resolution failure invoked the metrics query")
+			}
+			if output.Len() != 0 {
+				t.Fatalf("home-resolution failure wrote output %q", output.String())
 			}
 		})
 	}

--- a/pkg/transports/cli/command_factory_injection_test.go
+++ b/pkg/transports/cli/command_factory_injection_test.go
@@ -512,7 +512,19 @@ func TestProductionMetricsCommandResolvesGlobalJSONAndSessionScope(t *testing.T)
 	}
 }
 
+type productionMetricsFailureCase struct {
+	name        string
+	args        []string
+	home        func() (string, error)
+	queryError  error
+	wantCode    string
+	wantMessage string
+	wantCalls   int
+	wantCause   error
+}
+
 func TestProductionMetricsCommandExecuteCommandPreservesCodedFailures(t *testing.T) {
+	t.Parallel()
 	queryCause := errors.New("metrics path=/private/credential=do-not-leak")
 	queryError := &factoryvisualization.RuntimeMetricsQueryError{
 		Kind:    factoryvisualization.RuntimeMetricsQueryReadFailed,
@@ -520,16 +532,7 @@ func TestProductionMetricsCommandExecuteCommandPreservesCodedFailures(t *testing
 		Cause:   queryCause,
 	}
 	resolverCause := errors.New("home resolver credential=do-not-leak")
-	tests := []struct {
-		name        string
-		args        []string
-		home        func() (string, error)
-		queryError  error
-		wantCode    string
-		wantMessage string
-		wantCalls   int
-		wantCause   error
-	}{
+	tests := []productionMetricsFailureCase{
 		{
 			name:        "invalid group",
 			args:        []string{"metrics", "--group-by", "region"},
@@ -573,46 +576,51 @@ func TestProductionMetricsCommandExecuteCommandPreservesCodedFailures(t *testing
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			queryCalls := 0
-			factory := withTestInjectedPlatformRoles(CommandFactory{
-				runtimeMetricsQuery: func(context.Context, factoryvisualization.RuntimeMetricsQueryRequest) (factoryvisualization.RuntimeMetricsQueryResult, error) {
-					queryCalls++
-					return factoryvisualization.RuntimeMetricsQueryResult{}, test.queryError
-				},
-			})
-			var stdout, stderr bytes.Buffer
-			err := factory.ExecuteCommand(startupcli.CommandInvocation{
-				Arguments: test.args,
-				Stdin:     strings.NewReader(""),
-				Stdout:    &stdout,
-				Stderr:    &stderr,
-				Context:   context.Background(),
-				HomeDir:   test.home,
-				LookupEnv: func(string) (string, bool) { return "", false },
-			})
-			if err == nil {
-				t.Fatal("ExecuteCommand() error = nil, want metrics failure")
-			}
-			if stdout.Len() != 0 {
-				t.Fatalf("stdout = %q, want empty failure output", stdout.String())
-			}
-			assertSingleMetricsDiagnostic(t, stderr.String(), test.wantCode, test.wantMessage)
-			if queryCalls != test.wantCalls {
-				t.Fatalf("metrics query calls = %d, want %d", queryCalls, test.wantCalls)
-			}
-			if test.wantCause != nil && !errors.Is(err, test.wantCause) {
-				t.Fatalf("ExecuteCommand() error = %v, want to preserve cause", err)
-			}
-			if test.queryError != nil {
-				var gotQueryError *factoryvisualization.RuntimeMetricsQueryError
-				if !errors.As(err, &gotQueryError) {
-					t.Fatalf("ExecuteCommand() error = %v, want query error classification preserved", err)
-				}
-			}
-			if strings.Contains(stderr.String(), "do-not-leak") {
-				t.Fatalf("central diagnostic exposed an underlying payload: %q", stderr.String())
-			}
+			runProductionMetricsFailureCase(t, test)
 		})
+	}
+}
+
+func runProductionMetricsFailureCase(t *testing.T, test productionMetricsFailureCase) {
+	t.Helper()
+	queryCalls := 0
+	factory := withTestInjectedPlatformRoles(CommandFactory{
+		runtimeMetricsQuery: func(context.Context, factoryvisualization.RuntimeMetricsQueryRequest) (factoryvisualization.RuntimeMetricsQueryResult, error) {
+			queryCalls++
+			return factoryvisualization.RuntimeMetricsQueryResult{}, test.queryError
+		},
+	})
+	var stdout, stderr bytes.Buffer
+	err := factory.ExecuteCommand(startupcli.CommandInvocation{
+		Arguments: test.args,
+		Stdin:     strings.NewReader(""),
+		Stdout:    &stdout,
+		Stderr:    &stderr,
+		Context:   context.Background(),
+		HomeDir:   test.home,
+		LookupEnv: func(string) (string, bool) { return "", false },
+	})
+	if err == nil {
+		t.Fatal("ExecuteCommand() error = nil, want metrics failure")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty failure output", stdout.String())
+	}
+	assertSingleMetricsDiagnostic(t, stderr.String(), test.wantCode, test.wantMessage)
+	if queryCalls != test.wantCalls {
+		t.Fatalf("metrics query calls = %d, want %d", queryCalls, test.wantCalls)
+	}
+	if test.wantCause != nil && !errors.Is(err, test.wantCause) {
+		t.Fatalf("ExecuteCommand() error = %v, want to preserve cause", err)
+	}
+	if test.queryError != nil {
+		var gotQueryError *factoryvisualization.RuntimeMetricsQueryError
+		if !errors.As(err, &gotQueryError) {
+			t.Fatalf("ExecuteCommand() error = %v, want query error classification preserved", err)
+		}
+	}
+	if strings.Contains(stderr.String(), "do-not-leak") {
+		t.Fatalf("central diagnostic exposed an underlying payload: %q", stderr.String())
 	}
 }
 

--- a/pkg/transports/cli/command_factory_injection_test.go
+++ b/pkg/transports/cli/command_factory_injection_test.go
@@ -512,6 +512,129 @@ func TestProductionMetricsCommandResolvesGlobalJSONAndSessionScope(t *testing.T)
 	}
 }
 
+func TestProductionMetricsCommandExecuteCommandPreservesCodedFailures(t *testing.T) {
+	queryCause := errors.New("metrics path=/private/credential=do-not-leak")
+	queryError := &factoryvisualization.RuntimeMetricsQueryError{
+		Kind:    factoryvisualization.RuntimeMetricsQueryReadFailed,
+		Message: "query Factory Runtime metrics: read artifacts",
+		Cause:   queryCause,
+	}
+	resolverCause := errors.New("home resolver credential=do-not-leak")
+	tests := []struct {
+		name        string
+		args        []string
+		home        func() (string, error)
+		queryError  error
+		wantCode    string
+		wantMessage string
+		wantCalls   int
+		wantCause   error
+	}{
+		{
+			name:        "invalid group",
+			args:        []string{"metrics", "--group-by", "region"},
+			home:        func() (string, error) { return "operator-home", nil },
+			wantCode:    "METRICS_INVALID_GROUP_BY",
+			wantMessage: `invalid --group-by "region": choose workstation, worker, or provider`,
+		},
+		{
+			name:        "invalid group in JSON mode",
+			args:        []string{"--json", "metrics", "--group-by", "region"},
+			home:        func() (string, error) { return "operator-home", nil },
+			wantCode:    "METRICS_INVALID_GROUP_BY",
+			wantMessage: `invalid --group-by "region": choose workstation, worker, or provider`,
+		},
+		{
+			name:        "home resolver failure",
+			args:        []string{"metrics"},
+			home:        func() (string, error) { return "", resolverCause },
+			wantCode:    "METRICS_HOME_DIRECTORY_FAILED",
+			wantMessage: "resolve metrics home directory: home directory could not be resolved; set HOME or USERPROFILE",
+			wantCause:   resolverCause,
+		},
+		{
+			name:        "empty home path",
+			args:        []string{"metrics"},
+			home:        func() (string, error) { return "  ", nil },
+			wantCode:    "METRICS_HOME_DIRECTORY_FAILED",
+			wantMessage: "resolve metrics home directory: resolver returned an empty path; set HOME or USERPROFILE",
+		},
+		{
+			name:        "query read failure",
+			args:        []string{"--json", "metrics"},
+			home:        func() (string, error) { return "operator-home", nil },
+			queryError:  queryError,
+			wantCode:    "METRICS_QUERY_FAILED",
+			wantMessage: "query Factory Runtime metrics: read artifacts",
+			wantCalls:   1,
+			wantCause:   queryCause,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			queryCalls := 0
+			factory := withTestInjectedPlatformRoles(CommandFactory{
+				runtimeMetricsQuery: func(context.Context, factoryvisualization.RuntimeMetricsQueryRequest) (factoryvisualization.RuntimeMetricsQueryResult, error) {
+					queryCalls++
+					return factoryvisualization.RuntimeMetricsQueryResult{}, test.queryError
+				},
+			})
+			var stdout, stderr bytes.Buffer
+			err := factory.ExecuteCommand(startupcli.CommandInvocation{
+				Arguments: test.args,
+				Stdin:     strings.NewReader(""),
+				Stdout:    &stdout,
+				Stderr:    &stderr,
+				Context:   context.Background(),
+				HomeDir:   test.home,
+				LookupEnv: func(string) (string, bool) { return "", false },
+			})
+			if err == nil {
+				t.Fatal("ExecuteCommand() error = nil, want metrics failure")
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout = %q, want empty failure output", stdout.String())
+			}
+			assertSingleMetricsDiagnostic(t, stderr.String(), test.wantCode, test.wantMessage)
+			if queryCalls != test.wantCalls {
+				t.Fatalf("metrics query calls = %d, want %d", queryCalls, test.wantCalls)
+			}
+			if test.wantCause != nil && !errors.Is(err, test.wantCause) {
+				t.Fatalf("ExecuteCommand() error = %v, want to preserve cause", err)
+			}
+			if test.queryError != nil {
+				var gotQueryError *factoryvisualization.RuntimeMetricsQueryError
+				if !errors.As(err, &gotQueryError) {
+					t.Fatalf("ExecuteCommand() error = %v, want query error classification preserved", err)
+				}
+			}
+			if strings.Contains(stderr.String(), "do-not-leak") {
+				t.Fatalf("central diagnostic exposed an underlying payload: %q", stderr.String())
+			}
+		})
+	}
+}
+
+func assertSingleMetricsDiagnostic(t *testing.T, output, wantCode, wantMessage string) {
+	t.Helper()
+	trimmed := strings.TrimSpace(output)
+	lines := strings.Split(trimmed, "\n")
+	if trimmed == "" || len(lines) != 1 {
+		t.Fatalf("diagnostic output = %q, want exactly one JSON line", output)
+	}
+	var diagnostic struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &diagnostic); err != nil {
+		t.Fatalf("decode central diagnostic: %v; output=%q", err, output)
+	}
+	if diagnostic.Code != wantCode || diagnostic.Message != wantMessage {
+		t.Fatalf("diagnostic = %#v, want code %q and message %q", diagnostic, wantCode, wantMessage)
+	}
+}
+
 type injectedModelsCLIService struct {
 	list func(modelscli.ListConfig) error
 }

--- a/pkg/transports/cli/command_factory_injection_test.go
+++ b/pkg/transports/cli/command_factory_injection_test.go
@@ -518,6 +518,7 @@ type productionMetricsFailureCase struct {
 	home        func() (string, error)
 	queryError  error
 	wantCode    string
+	wantFamily  string
 	wantMessage string
 	wantCalls   int
 	wantCause   error
@@ -538,6 +539,7 @@ func TestProductionMetricsCommandExecuteCommandPreservesCodedFailures(t *testing
 			args:        []string{"metrics", "--group-by", "region"},
 			home:        func() (string, error) { return "operator-home", nil },
 			wantCode:    "METRICS_INVALID_GROUP_BY",
+			wantFamily:  "BAD_REQUEST",
 			wantMessage: `invalid --group-by "region": choose workstation, worker, or provider`,
 		},
 		{
@@ -545,6 +547,7 @@ func TestProductionMetricsCommandExecuteCommandPreservesCodedFailures(t *testing
 			args:        []string{"--json", "metrics", "--group-by", "region"},
 			home:        func() (string, error) { return "operator-home", nil },
 			wantCode:    "METRICS_INVALID_GROUP_BY",
+			wantFamily:  "BAD_REQUEST",
 			wantMessage: `invalid --group-by "region": choose workstation, worker, or provider`,
 		},
 		{
@@ -552,6 +555,7 @@ func TestProductionMetricsCommandExecuteCommandPreservesCodedFailures(t *testing
 			args:        []string{"metrics"},
 			home:        func() (string, error) { return "", resolverCause },
 			wantCode:    "METRICS_HOME_DIRECTORY_FAILED",
+			wantFamily:  "INTERNAL_SERVER_ERROR",
 			wantMessage: "resolve metrics home directory: home directory could not be resolved; set HOME or USERPROFILE",
 			wantCause:   resolverCause,
 		},
@@ -560,6 +564,7 @@ func TestProductionMetricsCommandExecuteCommandPreservesCodedFailures(t *testing
 			args:        []string{"metrics"},
 			home:        func() (string, error) { return "  ", nil },
 			wantCode:    "METRICS_HOME_DIRECTORY_FAILED",
+			wantFamily:  "INTERNAL_SERVER_ERROR",
 			wantMessage: "resolve metrics home directory: resolver returned an empty path; set HOME or USERPROFILE",
 		},
 		{
@@ -568,6 +573,7 @@ func TestProductionMetricsCommandExecuteCommandPreservesCodedFailures(t *testing
 			home:        func() (string, error) { return "operator-home", nil },
 			queryError:  queryError,
 			wantCode:    "METRICS_QUERY_FAILED",
+			wantFamily:  "INTERNAL_SERVER_ERROR",
 			wantMessage: "query Factory Runtime metrics: read artifacts",
 			wantCalls:   1,
 			wantCause:   queryCause,
@@ -606,7 +612,7 @@ func runProductionMetricsFailureCase(t *testing.T, test productionMetricsFailure
 	if stdout.Len() != 0 {
 		t.Fatalf("stdout = %q, want empty failure output", stdout.String())
 	}
-	assertSingleMetricsDiagnostic(t, stderr.String(), test.wantCode, test.wantMessage)
+	assertSingleMetricsDiagnostic(t, stderr.String(), test.wantCode, test.wantFamily, test.wantMessage)
 	if queryCalls != test.wantCalls {
 		t.Fatalf("metrics query calls = %d, want %d", queryCalls, test.wantCalls)
 	}
@@ -624,7 +630,7 @@ func runProductionMetricsFailureCase(t *testing.T, test productionMetricsFailure
 	}
 }
 
-func assertSingleMetricsDiagnostic(t *testing.T, output, wantCode, wantMessage string) {
+func assertSingleMetricsDiagnostic(t *testing.T, output, wantCode, wantFamily, wantMessage string) {
 	t.Helper()
 	trimmed := strings.TrimSpace(output)
 	lines := strings.Split(trimmed, "\n")
@@ -633,13 +639,14 @@ func assertSingleMetricsDiagnostic(t *testing.T, output, wantCode, wantMessage s
 	}
 	var diagnostic struct {
 		Code    string `json:"code"`
+		Family  string `json:"family"`
 		Message string `json:"message"`
 	}
 	if err := json.Unmarshal([]byte(trimmed), &diagnostic); err != nil {
 		t.Fatalf("decode central diagnostic: %v; output=%q", err, output)
 	}
-	if diagnostic.Code != wantCode || diagnostic.Message != wantMessage {
-		t.Fatalf("diagnostic = %#v, want code %q and message %q", diagnostic, wantCode, wantMessage)
+	if diagnostic.Code != wantCode || diagnostic.Family != wantFamily || diagnostic.Message != wantMessage {
+		t.Fatalf("diagnostic = %#v, want code %q, family %q, and message %q", diagnostic, wantCode, wantFamily, wantMessage)
 	}
 }
 

--- a/tests/functional/factory/visualization/runtime_metrics/metrics_cli_test.go
+++ b/tests/functional/factory/visualization/runtime_metrics/metrics_cli_test.go
@@ -1,0 +1,92 @@
+package runtime_metrics_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestMetricsInvalidGroupThroughRootProcessPreservesCodedDiagnostic proves
+// the customer CLI process keeps the metrics-owned code and safe message at
+// the production central-diagnostics boundary.
+func TestMetricsInvalidGroupThroughRootProcessPreservesCodedDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "--json", "metrics", "--group-by", "region",
+	})
+	inputs.Input.Env = []string{"HOME=" + t.TempDir(), "USERPROFILE=" + t.TempDir()}
+
+	err := process.Execute(inputs.Input)
+	if err == nil {
+		t.Fatal("Process.Execute(metrics invalid group) error = nil, want coded failure")
+	}
+	if inputs.Stdout() != "" {
+		t.Fatalf("metrics stdout = %q, want empty", inputs.Stdout())
+	}
+	assertMetricsDiagnostic(t, inputs.Stderr(), "METRICS_INVALID_GROUP_BY", `invalid --group-by "region": choose workstation, worker, or provider`)
+}
+
+// TestMetricsSuccessThroughRootProcessRendersQueryCostAvailability proves
+// both public presenters consume the query result returned by the canonical
+// process rather than relying on a presenter-local cost constant.
+func TestMetricsSuccessThroughRootProcessRendersQueryCostAvailability(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(homeDir, ".you-agent-factory", "metrics"), 0o755); err != nil {
+		t.Fatalf("create metrics root: %v", err)
+	}
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	env := []string{"HOME=" + homeDir, "USERPROFILE=" + homeDir}
+
+	human := support.FakeInputs(t.Context(), []string{"you", "metrics"})
+	human.Input.Env = env
+	if err := process.Execute(human.Input); err != nil {
+		t.Fatalf("Process.Execute(metrics human) error = %v\nstdout:\n%s\nstderr:\n%s", err, human.Stdout(), human.Stderr())
+	}
+	if !strings.Contains(human.Stdout(), "Cost: unavailable\n") || human.Stderr() != "" {
+		t.Fatalf("human metrics output = %q, stderr = %q", human.Stdout(), human.Stderr())
+	}
+
+	machine := support.FakeInputs(t.Context(), []string{"you", "--json", "metrics"})
+	machine.Input.Env = env
+	if err := process.Execute(machine.Input); err != nil {
+		t.Fatalf("Process.Execute(metrics JSON) error = %v\nstdout:\n%s\nstderr:\n%s", err, machine.Stdout(), machine.Stderr())
+	}
+	var document struct {
+		Cost struct {
+			Availability string `json:"availability"`
+		} `json:"cost"`
+	}
+	if err := json.Unmarshal([]byte(machine.Stdout()), &document); err != nil {
+		t.Fatalf("decode metrics JSON: %v\n%s", err, machine.Stdout())
+	}
+	if document.Cost.Availability != "unavailable" || machine.Stderr() != "" {
+		t.Fatalf("JSON metrics cost = %#v, stderr = %q", document.Cost, machine.Stderr())
+	}
+}
+
+func assertMetricsDiagnostic(t *testing.T, output, wantCode, wantMessage string) {
+	t.Helper()
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" || strings.Contains(trimmed, "\n") {
+		t.Fatalf("metrics diagnostic = %q, want one JSON line", output)
+	}
+	var response factoryapi.ErrorResponse
+	if err := json.Unmarshal([]byte(trimmed), &response); err != nil {
+		t.Fatalf("decode metrics diagnostic: %v\n%s", err, output)
+	}
+	if response.Code != factoryapi.ErrorResponseCode(wantCode) || response.Message != wantMessage {
+		t.Fatalf("metrics diagnostic = %#v, want code %q and message %q", response, wantCode, wantMessage)
+	}
+}


### PR DESCRIPTION
{
  "project": "OBS-2B Metrics CLI Coded Errors",
  "branchName": "obs-2b-metrics-cli-coded-errors",
  "description": "Make `you metrics` failures actionable for blind CLI-only agents by preserving safe metrics-specific codes and messages through the production central-diagnostics boundary. Cover invalid grouping, home-directory resolution, and metrics query failures; keep stdout clean; and derive human and JSON cost availability from the Factory Visualization query result without adding pricing or changing metrics computation.",
  "context": {
    "customerAsk": "Correct the probe-verified OBS-2 regression so `you metrics --group-by region` and metrics read failures produce actionable coded diagnostics through the production `ExecuteCommand` path, with clean stdout in JSON mode. Within the leased metrics CLI surface, map the query result's cost availability through both presenters.",
    "problem": "The metrics command returns plain errors for invalid grouping, home-directory resolution, and query failures. Bare Cobra tests see their text, but production central normalization replaces uncoded errors with `CLI_COMMAND_FAILED: command failed`, leaving blind CLI consumers unable to correct input or classify a read failure. The presenters also hardcode today's unavailable cost state instead of reflecting the query result.",
    "solution": "Return Factory Visualization metrics errors that implement the established `clidiag.CodedError` contract with stable metrics-specific codes, safe actionable messages, and wrapped causes where applicable. Prove them through `CommandFactory.ExecuteCommand`, assert one stderr JSON diagnostic and empty stdout, and map the typed query cost-availability state consistently into human and JSON output without adding numeric pricing."
  },
  "acceptanceCriteria": [
    "Through the production `ExecuteCommand`/central-diagnostics path, `you metrics --group-by region` emits one JSON diagnostic with code `METRICS_INVALID_GROUP_BY` and the actionable message `invalid --group-by \"region\": choose workstation, worker, or provider`; it does not invoke the metrics query or write success output to stdout.",
    "Home-directory resolution failures and injected metrics query read failures survive central normalization as stable metrics-specific coded diagnostics with safe, actionable context; a query failure message starts with `query Factory Runtime metrics:` and exposes only the approved cause classification, not arbitrary sensitive cause text.",
    "Human and JSON success output derive cost availability from the Factory Visualization query result, preserving today's `unavailable` presentation without adding prices or metrics computation.",
    "Quality gates pass: Typecheck passes; Tests pass, including focused Factory Visualization metrics CLI tests and `make test`; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The worker/reviewer cycle continues through review-owned outcomes until the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "obs-2b-metrics-cli-coded-errors-001",
      "title": "Receive actionable metrics failures through production diagnostics",
      "description": "As a blind CLI-only agent, I want metrics command failures to retain safe codes and actionable messages so I can correct my input or classify an operational read failure without source access.",
      "acceptanceCriteria": [
        "Running the command through `CommandFactory.ExecuteCommand` with `metrics --group-by region` writes exactly one central diagnostic to stderr with code `METRICS_INVALID_GROUP_BY` and message `invalid --group-by \"region\": choose workstation, worker, or provider`.",
        "Invalid grouping is rejected before the metrics query is called, returns a non-nil command error, and leaves stdout empty in both ordinary and JSON output modes.",
        "An injected query read failure writes exactly one central diagnostic with code `METRICS_QUERY_FAILED` and a message beginning `query Factory Runtime metrics:` followed by an approved safe cause classification; arbitrary underlying payloads, paths, credentials, or implementation details are not exposed.",
        "Home-directory resolver failure and empty-path failure use a stable metrics-specific coded diagnostic with actionable home-resolution context and do not call the metrics query.",
        "Covered failures retain their underlying cause for `errors.Is`/`errors.As` inspection where a cause exists, without weakening the customer-facing sanitization boundary.",
        "Focused regression tests exercise the production `ExecuteCommand`/central-diagnostics route used by `cmd/factory`; bare Cobra `Execute` is not accepted as the proof for this regression.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented metrics-owned coded failures and production ExecuteCommand regression coverage; focused tests pass."
    },
    {
      "id": "obs-2b-metrics-cli-coded-errors-002",
      "title": "Present the query's cost availability state",
      "description": "As a CLI consumer, I want metrics output to report the availability state supplied by the metrics query so the human and machine-readable views cannot silently disagree with the service contract.",
      "acceptanceCriteria": [
        "Human metrics output derives its cost-availability label from `result.Cost.Availability` and continues to render the current `UNAVAILABLE` contract state as `Cost: unavailable`.",
        "JSON metrics output derives `cost.availability` from the same query result and continues to render the current `UNAVAILABLE` contract state as `\"unavailable\"`.",
        "Human and JSON presenters use one consistent normalization policy for availability values and do not invent a numeric cost or price.",
        "Focused presenter tests prove the current unavailable state and at least one non-hardcoded availability value without changing the Factory Visualization query contract.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Human and JSON metrics presenters now derive normalized cost availability from the query result; focused tests cover UNAVAILABLE and a query-provided state."
    }
  ]
}
