### PR TITLE
RSM-7: prove kill-and-resume functional flow

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -672,6 +672,10 @@
       "minimum": 57.89
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/execution/runtimepersist",
+      "minimum": 65.30
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/executionopening",
       "minimum": 53.84
     },

--- a/pkg/services/edges/definition.go
+++ b/pkg/services/edges/definition.go
@@ -184,6 +184,7 @@ type Edges struct {
 	SubmissionRecorder               recordings.SubmissionRecorder
 	DispatchRecorder                 recordings.DispatchRecorder
 	WorkerRecordingWriter            recordings.WorkerRecordingWriter
+	RecordingWriteFile               func(string, []byte) error
 	RecordingMakeDirectories         recordings.RecordingMakeDirectories
 	RecordingCreateTempFile          recordings.RecordingCreateTemporaryFile
 	RecordingRemovePath              recordings.RecordingRemovePath
@@ -539,6 +540,9 @@ func Merge(defaults Edges, replacements Edges) Edges {
 	}
 	if replacements.WorkerRecordingWriter != nil {
 		defaults.WorkerRecordingWriter = replacements.WorkerRecordingWriter
+	}
+	if replacements.RecordingWriteFile != nil {
+		defaults.RecordingWriteFile = replacements.RecordingWriteFile
 	}
 	if replacements.RecordingMakeDirectories != nil {
 		defaults.RecordingMakeDirectories = replacements.RecordingMakeDirectories

--- a/pkg/services/factory_runtime/internal/assembly.go
+++ b/pkg/services/factory_runtime/internal/assembly.go
@@ -202,6 +202,12 @@ func (a *Assembly) Assemble(
 	if err != nil {
 		return nil, nil, factoryruntime.SessionBuildSpec{}, nil, nil, err
 	}
+	if resumeInput != nil {
+		// The resumed ledger must expose the recorded prefix before the live
+		// successor starts emitting events; otherwise public reconnect cursors
+		// cannot cross the process boundary.
+		spec.ReplayEvents = cloneFactoryEvents(restoredEvents)
+	}
 	spec.RestoredWorldState, err = reconstructRestoredWorldState(
 		recordingsRuntime,
 		restoredEvents,
@@ -235,11 +241,18 @@ func cloneReplayArtifactEvents(artifact *factorydefinitions.ReplayArtifact) []fa
 	if artifact == nil || len(artifact.Events) == 0 {
 		return nil
 	}
-	events := make([]factorydefinitions.FactoryEvent, len(artifact.Events))
-	for index, event := range artifact.Events {
-		events[index] = event.Clone()
+	return cloneFactoryEvents(artifact.Events)
+}
+
+func cloneFactoryEvents(events []factorydefinitions.FactoryEvent) []factorydefinitions.FactoryEvent {
+	if len(events) == 0 {
+		return nil
 	}
-	return events
+	cloned := make([]factorydefinitions.FactoryEvent, len(events))
+	for index, event := range events {
+		cloned[index] = event.Clone()
+	}
+	return cloned
 }
 
 func restoredEventsForOpening(

--- a/pkg/services/factory_runtime/internal/assembly.go
+++ b/pkg/services/factory_runtime/internal/assembly.go
@@ -206,7 +206,7 @@ func (a *Assembly) Assemble(
 		// The resumed ledger must expose the recorded prefix before the live
 		// successor starts emitting events; otherwise public reconnect cursors
 		// cannot cross the process boundary.
-		spec.ReplayEvents = cloneFactoryEvents(restoredEvents)
+		spec.ResumeCanonicalEvents = cloneFactoryEvents(restoredEvents)
 	}
 	spec.RestoredWorldState, err = reconstructRestoredWorldState(
 		recordingsRuntime,

--- a/pkg/services/factory_runtime/internal/assembly_test.go
+++ b/pkg/services/factory_runtime/internal/assembly_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jonboulle/clockwork"
 	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
@@ -25,9 +26,18 @@ type stubWorkersService struct{ workers.Service }
 
 type assemblyWorldStateOpening struct {
 	recordings.RuntimeOpening
-	state  interfaces.FactoryWorldState
-	tick   int
-	events []interfaces.FactoryEvent
+	state   interfaces.FactoryWorldState
+	tick    int
+	events  []interfaces.FactoryEvent
+	request recordings.RuntimeScopeRequest
+}
+
+func (opening *assemblyWorldStateOpening) OpenRuntime(
+	_ context.Context,
+	request recordings.RuntimeScopeRequest,
+) (recordings.RuntimeScopeResult, error) {
+	opening.request = request
+	return recordings.RuntimeScopeResult{}, nil
 }
 
 func (opening *assemblyWorldStateOpening) ReconstructCanonicalFactoryWorldState(
@@ -37,6 +47,35 @@ func (opening *assemblyWorldStateOpening) ReconstructCanonicalFactoryWorldState(
 	opening.events = events
 	opening.tick = selectedTick
 	return opening.state, nil
+}
+
+func TestRuntimeOpeningWithFlushOnlySeedsResumeCanonicalEvents(t *testing.T) {
+	resumeEvents := []interfaces.FactoryEvent{{Id: "resume-event"}}
+	for name, events := range map[string][]interfaces.FactoryEvent{
+		"ordinary replay": nil,
+		"process resume":  resumeEvents,
+	} {
+		t.Run(name, func(t *testing.T) {
+			opening := &assemblyWorldStateOpening{}
+			wrapped := runtimeOpeningWithFlush{
+				RuntimeOpening:        opening,
+				flushInterval:         time.Second,
+				resumeCanonicalEvents: events,
+			}
+			if _, err := wrapped.OpenRuntime(context.Background(), recordings.RuntimeScopeRequest{}); err != nil {
+				t.Fatalf("OpenRuntime: %v", err)
+			}
+			if opening.request.FlushInterval != time.Second {
+				t.Fatalf("flush interval = %v, want 1s", opening.request.FlushInterval)
+			}
+			if len(opening.request.ReplayEvents) != len(events) {
+				t.Fatalf("seeded replay events = %d, want %d", len(opening.request.ReplayEvents), len(events))
+			}
+			if len(events) > 0 && opening.request.ReplayEvents[0].Id != events[0].Id {
+				t.Fatalf("seeded event ID = %q, want %q", opening.request.ReplayEvents[0].Id, events[0].Id)
+			}
+		})
+	}
 }
 
 func TestReconstructRestoredWorldStateUsesLatestReplayTick(t *testing.T) {

--- a/pkg/services/factory_runtime/internal/runtime_build.go
+++ b/pkg/services/factory_runtime/internal/runtime_build.go
@@ -221,8 +221,8 @@ func (service runtimeWorkersServiceWithProgress) ResolveTemplateFields(
 
 type runtimeOpeningWithFlush struct {
 	recordings.RuntimeOpening
-	flushInterval time.Duration
-	replayEvents  []factorydefinitions.FactoryEvent
+	flushInterval         time.Duration
+	resumeCanonicalEvents []factorydefinitions.FactoryEvent
 }
 
 func (opening runtimeOpeningWithFlush) OpenRuntime(
@@ -230,7 +230,7 @@ func (opening runtimeOpeningWithFlush) OpenRuntime(
 	request recordings.RuntimeScopeRequest,
 ) (recordings.RuntimeScopeResult, error) {
 	request.FlushInterval = opening.flushInterval
-	request.ReplayEvents = cloneFactoryEvents(opening.replayEvents)
+	request.ReplayEvents = cloneFactoryEvents(opening.resumeCanonicalEvents)
 	return opening.RuntimeOpening.OpenRuntime(ctx, request)
 }
 
@@ -444,9 +444,9 @@ func buildBundle(
 		spec.PetriMutationRecorder,
 		worldStateProjector,
 		runtimeOpeningWithFlush{
-			RuntimeOpening: recordingsRuntime,
-			flushInterval:  recordFlushInterval,
-			replayEvents:   cloneFactoryEvents(spec.ReplayEvents),
+			RuntimeOpening:        recordingsRuntime,
+			flushInterval:         recordFlushInterval,
+			resumeCanonicalEvents: cloneFactoryEvents(spec.ResumeCanonicalEvents),
 		},
 		workerServiceWithProgress,
 		workerSessionsFactory,

--- a/pkg/services/factory_runtime/internal/runtime_build.go
+++ b/pkg/services/factory_runtime/internal/runtime_build.go
@@ -222,6 +222,7 @@ func (service runtimeWorkersServiceWithProgress) ResolveTemplateFields(
 type runtimeOpeningWithFlush struct {
 	recordings.RuntimeOpening
 	flushInterval time.Duration
+	replayEvents  []factorydefinitions.FactoryEvent
 }
 
 func (opening runtimeOpeningWithFlush) OpenRuntime(
@@ -229,6 +230,7 @@ func (opening runtimeOpeningWithFlush) OpenRuntime(
 	request recordings.RuntimeScopeRequest,
 ) (recordings.RuntimeScopeResult, error) {
 	request.FlushInterval = opening.flushInterval
+	request.ReplayEvents = cloneFactoryEvents(opening.replayEvents)
 	return opening.RuntimeOpening.OpenRuntime(ctx, request)
 }
 
@@ -444,6 +446,7 @@ func buildBundle(
 		runtimeOpeningWithFlush{
 			RuntimeOpening: recordingsRuntime,
 			flushInterval:  recordFlushInterval,
+			replayEvents:   cloneFactoryEvents(spec.ReplayEvents),
 		},
 		workerServiceWithProgress,
 		workerSessionsFactory,

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/clean_invocation.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/clean_invocation.go
@@ -348,7 +348,7 @@ func restoredWorkTokenForPlacement(
 	now time.Time,
 	resourcePlaceIDs map[string]struct{},
 ) (*factorytoken.Token, bool) {
-	placeID = restoredWorkPlacementID(restored, item, placeID)
+	placeID = restoredWorkPlacementID(restored, net, item, placeID)
 	if !restoredWorkPlacementIsValid(net, placeID, resourcePlaceIDs) {
 		return nil, false
 	}
@@ -367,16 +367,54 @@ func restoredWorkTokenForPlacement(
 
 func restoredWorkPlacementID(
 	restored *interfaces.FactoryWorldState,
+	net *state.Net,
 	item work.FactoryWorkItem,
 	placeID string,
 ) string {
-	if placeID != "" || restored.PlaceOccupancyByID != nil {
+	if placeID != "" {
 		return placeID
+	}
+	if restored != nil && item.ID != "" {
+		for _, dispatch := range restored.ActiveDispatches {
+			if restoredDispatchIsHumanApproval(restored, net, dispatch) {
+				continue
+			}
+			for _, workID := range dispatch.WorkItemIDs {
+				if workID == item.ID && item.WorkTypeID != "" && item.State != "" {
+					// An active dispatch has consumed its Work token from
+					// occupancy. Keep the recorded Work placement so the
+					// interrupted dispatch can be resumed after a restart.
+					return state.PlaceID(item.WorkTypeID, item.State)
+				}
+			}
+		}
+	}
+	if restored != nil && restored.PlaceOccupancyByID != nil {
+		return ""
 	}
 	if item.WorkTypeID != "" && item.State != "" {
 		return state.PlaceID(item.WorkTypeID, item.State)
 	}
 	return ""
+}
+
+func restoredDispatchIsHumanApproval(
+	restored *interfaces.FactoryWorldState,
+	net *state.Net,
+	dispatch interfaces.FactoryWorldDispatch,
+) bool {
+	if restored != nil && dispatch.DispatchID != "" {
+		for _, approval := range restored.PendingHumanApprovalsByID {
+			if approval.DispatchID == dispatch.DispatchID {
+				return true
+			}
+		}
+	}
+	if net == nil || dispatch.TransitionID == "" {
+		return false
+	}
+	transition := net.Transitions[dispatch.TransitionID]
+	return transition != nil && transition.Type == petri.TransitionHumanApproval
 }
 
 func restoredWorkRequestIDs(restored *interfaces.FactoryWorldState) map[string]string {

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/factory_constructor_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/factory_constructor_test.go
@@ -196,6 +196,43 @@ func TestNew_WithRestoredWorldStateSeedsWorkAndKeepsCurrentResourcesAuthoritativ
 	assertRestoredWorkToken(t, token, restored.WorkItemsByID["work-restored"])
 }
 
+func TestNew_WithRestoredActiveDispatchUsesRecordedWorkPlacement(t *testing.T) {
+	restored := &interfaces.FactoryWorldState{
+		WorkItemsByID: map[string]work.FactoryWorkItem{
+			"work-active": {
+				ID: "work-active", WorkTypeID: "task", State: "done", PlaceID: "task:done",
+			},
+		},
+		ActiveDispatches: map[string]interfaces.FactoryWorldDispatch{
+			"dispatch-active": {DispatchID: "dispatch-active", WorkItemIDs: []string{"work-active"}},
+		},
+		// An in-flight dispatch has consumed the Work token, so the
+		// reconstructed occupancy is intentionally empty.
+		PlaceOccupancyByID: map[string]interfaces.FactoryPlaceOccupancy{},
+	}
+
+	f, err := newTestFactory(
+		withNet(buildSimpleNet()),
+		withClock(platformclock.NewDeterministic(time.Unix(0, 0).UTC(), time.Second)),
+		withRestoredWorldState(restored),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	snapshot, err := f.GetEngineStateSnapshot(context.Background())
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshot: %v", err)
+	}
+	tokens := snapshot.Marking.PlaceTokens["task:done"]
+	if len(tokens) != 1 {
+		t.Fatalf("restored active Work token IDs = %#v, want one token at task:done", tokens)
+	}
+	token := snapshot.Marking.Tokens[tokens[0]]
+	if token == nil || token.Color.WorkID != "work-active" {
+		t.Fatalf("restored active Work token = %#v, want work-active", token)
+	}
+}
+
 func assertCurrentRestoredResourceTokens(
 	t *testing.T,
 	snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net],

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/factory_constructor_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/factory_constructor_test.go
@@ -233,6 +233,43 @@ func TestNew_WithRestoredActiveDispatchUsesRecordedWorkPlacement(t *testing.T) {
 	}
 }
 
+func TestNew_WithRestoredHumanApprovalDispatchDoesNotRestoreWorkPlacement(t *testing.T) {
+	restored := &interfaces.FactoryWorldState{
+		WorkItemsByID: map[string]work.FactoryWorkItem{
+			"work-approval": {
+				ID: "work-approval", WorkTypeID: "task", State: "done",
+			},
+		},
+		ActiveDispatches: map[string]interfaces.FactoryWorldDispatch{
+			"dispatch-approval": {
+				DispatchID: "dispatch-approval", WorkItemIDs: []string{"work-approval"},
+			},
+		},
+		PendingHumanApprovalsByID: map[string]interfaces.FactoryWorldHumanApproval{
+			"approval-1": {ApprovalID: "approval-1", DispatchID: "dispatch-approval"},
+		},
+		// A pending approval retains the Work claim in its durable approval
+		// projection; it must not be re-materialized as an ordinary Work token.
+		PlaceOccupancyByID: map[string]interfaces.FactoryPlaceOccupancy{},
+	}
+
+	f, err := newTestFactory(
+		withNet(buildSimpleNet()),
+		withClock(platformclock.NewDeterministic(time.Unix(0, 0).UTC(), time.Second)),
+		withRestoredWorldState(restored),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	snapshot, err := f.GetEngineStateSnapshot(context.Background())
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshot: %v", err)
+	}
+	if tokens := snapshot.Marking.PlaceTokens["task:done"]; len(tokens) != 0 {
+		t.Fatalf("restored pending approval Work token IDs = %#v, want no ordinary Work token", tokens)
+	}
+}
+
 func assertCurrentRestoredResourceTokens(
 	t *testing.T,
 	snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net],

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/factory_constructor_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/factory_constructor_test.go
@@ -200,7 +200,7 @@ func TestNew_WithRestoredActiveDispatchUsesRecordedWorkPlacement(t *testing.T) {
 	restored := &interfaces.FactoryWorldState{
 		WorkItemsByID: map[string]work.FactoryWorkItem{
 			"work-active": {
-				ID: "work-active", WorkTypeID: "task", State: "done", PlaceID: "task:done",
+				ID: "work-active", WorkTypeID: "task", State: "done",
 			},
 		},
 		ActiveDispatches: map[string]interfaces.FactoryWorldDispatch{

--- a/pkg/services/factory_runtime/session_build_spec.go
+++ b/pkg/services/factory_runtime/session_build_spec.go
@@ -49,7 +49,11 @@ type SessionBuildSpec struct {
 	// replay. Runtime execution may re-emit events while rebuilding state, but
 	// durable Worker Session streams must retain the artifact's original cursor
 	// positions.
-	ReplayEvents          []factorydefinitions.FactoryEvent
+	ReplayEvents []factorydefinitions.FactoryEvent
+	// ResumeCanonicalEvents carries only the canonical prefix that must seed a
+	// live successor after a process replacement. It is separate from
+	// ReplayEvents because ordinary replay re-emits the artifact events.
+	ResumeCanonicalEvents []factorydefinitions.FactoryEvent
 	SubmissionHooks       []SubmissionHook
 	CompletionPlanner     CompletionDeliveryPlanner
 	PetriMutationRecorder PetriMutationRecorder

--- a/pkg/services/recordings/internal/contracts/contracts.go
+++ b/pkg/services/recordings/internal/contracts/contracts.go
@@ -150,9 +150,13 @@ type RuntimeOpeningRequest struct {
 // root once; callers provide only the topology, identity, clock, and loaded
 // definition values for this runtime.
 type RuntimeScopeRequest struct {
-	Topology         InitialStructureSource
-	Definitions      interfaces.RuntimeDefinitionLookup
-	LoadedFactory    interfaces.LoadedFactorySource
+	Topology      InitialStructureSource
+	Definitions   interfaces.RuntimeDefinitionLookup
+	LoadedFactory interfaces.LoadedFactorySource
+	// ReplayEvents is an optional canonical prefix restored before the live
+	// runtime emits successor lifecycle events. It preserves public event
+	// identities and ordering across a process replacement.
+	ReplayEvents     []interfaces.FactoryEvent
 	Now              func() time.Time
 	RecordingID      string
 	RecordPath       string

--- a/pkg/services/recordings/internal/events/event_history.go
+++ b/pkg/services/recordings/internal/events/event_history.go
@@ -127,6 +127,7 @@ type FactoryEventHistory struct {
 	runRecordedAt       time.Time
 	hasRunRequest       bool
 	hasRunResponse      bool
+	hasInitialStructure bool
 	sessionStartedAt    time.Time
 	hasSessionStarted   bool
 	hasSessionCompleted bool
@@ -154,6 +155,50 @@ func NewFactoryEventHistory(topology recordings.InitialStructureSource, now func
 		streamGenerationID: streamGenerationID,
 		streams:            make(map[int]*eventHistorySubscription),
 	}
+}
+
+// SeedCanonicalEvents restores an already-recorded event prefix before the
+// runtime emits successor lifecycle events. The restored identities and
+// ordering metadata remain untouched so public reconnect cursors continue
+// across a process replacement.
+func (h *FactoryEventHistory) SeedCanonicalEvents(events []interfaces.FactoryEvent) error {
+	if h == nil {
+		return fmt.Errorf("factory event history is unavailable")
+	}
+	if len(events) == 0 {
+		return nil
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.events) > 0 {
+		return fmt.Errorf("factory event history already contains events")
+	}
+	h.events = cloneFactoryEvents(events)
+	for _, event := range h.events {
+		switch event.Type {
+		case interfaces.FactoryEventTypeInitialStructureRequest:
+			h.hasInitialStructure = true
+		case interfaces.FactoryEventTypeRunRequest:
+			h.hasRunRequest = true
+			h.runRecordedAt = interfaces.CanonicalEventTime(event.Context.EventTime)
+		case interfaces.FactoryEventTypeRunResponse:
+			h.hasRunResponse = true
+		case interfaces.FactoryEventTypeSessionStarted:
+			h.hasSessionStarted = true
+			h.sessionStartedAt = interfaces.CanonicalEventTime(event.Context.EventTime)
+		case interfaces.FactoryEventTypeSessionCompleted:
+			h.hasSessionCompleted = true
+		}
+		if event.Context.SessionID != nil {
+			if sessionID := strings.TrimSpace(*event.Context.SessionID); sessionID != "" {
+				h.sessionID = sessionID
+			}
+		}
+		if event.Context.SessionSequence != nil && *event.Context.SessionSequence >= h.nextSessionSequence {
+			h.nextSessionSequence = *event.Context.SessionSequence + 1
+		}
+	}
+	return nil
 }
 
 // StreamGenerationID returns the stable opaque identifier for this live event
@@ -310,11 +355,16 @@ func (h *FactoryEventHistory) RecordInitialStructure() {
 	eventTime := interfaces.CanonicalEventTime(h.now())
 	payload := h.initialStructure
 	factory := eventsnapshot.FromInitialStructure(payload)
-	h.mu.RLock()
+	h.mu.Lock()
+	if h.hasInitialStructure {
+		h.mu.Unlock()
+		return
+	}
+	h.hasInitialStructure = true
 	if h.initialFactory != nil {
 		factory = h.initialFactory.Clone()
 	}
-	h.mu.RUnlock()
+	h.mu.Unlock()
 	h.appendEvent(domainFactoryEvent(
 		interfaces.FactoryEventTypeInitialStructureRequest,
 		eventIDInitialStructure,

--- a/pkg/services/recordings/internal/events/event_history.go
+++ b/pkg/services/recordings/internal/events/event_history.go
@@ -157,50 +157,6 @@ func NewFactoryEventHistory(topology recordings.InitialStructureSource, now func
 	}
 }
 
-// SeedCanonicalEvents restores an already-recorded event prefix before the
-// runtime emits successor lifecycle events. The restored identities and
-// ordering metadata remain untouched so public reconnect cursors continue
-// across a process replacement.
-func (h *FactoryEventHistory) SeedCanonicalEvents(events []interfaces.FactoryEvent) error {
-	if h == nil {
-		return fmt.Errorf("factory event history is unavailable")
-	}
-	if len(events) == 0 {
-		return nil
-	}
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	if len(h.events) > 0 {
-		return fmt.Errorf("factory event history already contains events")
-	}
-	h.events = cloneFactoryEvents(events)
-	for _, event := range h.events {
-		switch event.Type {
-		case interfaces.FactoryEventTypeInitialStructureRequest:
-			h.hasInitialStructure = true
-		case interfaces.FactoryEventTypeRunRequest:
-			h.hasRunRequest = true
-			h.runRecordedAt = interfaces.CanonicalEventTime(event.Context.EventTime)
-		case interfaces.FactoryEventTypeRunResponse:
-			h.hasRunResponse = true
-		case interfaces.FactoryEventTypeSessionStarted:
-			h.hasSessionStarted = true
-			h.sessionStartedAt = interfaces.CanonicalEventTime(event.Context.EventTime)
-		case interfaces.FactoryEventTypeSessionCompleted:
-			h.hasSessionCompleted = true
-		}
-		if event.Context.SessionID != nil {
-			if sessionID := strings.TrimSpace(*event.Context.SessionID); sessionID != "" {
-				h.sessionID = sessionID
-			}
-		}
-		if event.Context.SessionSequence != nil && *event.Context.SessionSequence >= h.nextSessionSequence {
-			h.nextSessionSequence = *event.Context.SessionSequence + 1
-		}
-	}
-	return nil
-}
-
 // StreamGenerationID returns the stable opaque identifier for this live event
 // history instance.
 func (h *FactoryEventHistory) StreamGenerationID() string {

--- a/pkg/services/recordings/internal/events/event_history_session_lifecycle.go
+++ b/pkg/services/recordings/internal/events/event_history_session_lifecycle.go
@@ -66,6 +66,50 @@ type SessionLifecycleCompleteInput struct {
 // SessionLifecycleControlInput remains an alias for source compatibility.
 type SessionLifecycleControlInput = recordings.SessionLifecycleControlInput
 
+// SeedCanonicalEvents restores an already-recorded event prefix before the
+// runtime emits successor lifecycle events. The restored identities and
+// ordering metadata remain untouched so public reconnect cursors continue
+// across a process replacement.
+func (h *FactoryEventHistory) SeedCanonicalEvents(events []interfaces.FactoryEvent) error {
+	if h == nil {
+		return fmt.Errorf("factory event history is unavailable")
+	}
+	if len(events) == 0 {
+		return nil
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.events) > 0 {
+		return fmt.Errorf("factory event history already contains events")
+	}
+	h.events = cloneFactoryEvents(events)
+	for _, event := range h.events {
+		switch event.Type {
+		case interfaces.FactoryEventTypeInitialStructureRequest:
+			h.hasInitialStructure = true
+		case interfaces.FactoryEventTypeRunRequest:
+			h.hasRunRequest = true
+			h.runRecordedAt = interfaces.CanonicalEventTime(event.Context.EventTime)
+		case interfaces.FactoryEventTypeRunResponse:
+			h.hasRunResponse = true
+		case interfaces.FactoryEventTypeSessionStarted:
+			h.hasSessionStarted = true
+			h.sessionStartedAt = interfaces.CanonicalEventTime(event.Context.EventTime)
+		case interfaces.FactoryEventTypeSessionCompleted:
+			h.hasSessionCompleted = true
+		}
+		if event.Context.SessionID != nil {
+			if sessionID := strings.TrimSpace(*event.Context.SessionID); sessionID != "" {
+				h.sessionID = sessionID
+			}
+		}
+		if event.Context.SessionSequence != nil && *event.Context.SessionSequence >= h.nextSessionSequence {
+			h.nextSessionSequence = *event.Context.SessionSequence + 1
+		}
+	}
+	return nil
+}
+
 // RecordSessionPaused records a successful Factory Session pause lifecycle transition.
 func (h *FactoryEventHistory) RecordSessionPaused(input SessionLifecycleControlInput, eventTime time.Time) {
 	if h == nil || strings.TrimSpace(input.SessionID) == "" {

--- a/pkg/services/recordings/internal/events/event_history_session_lifecycle.go
+++ b/pkg/services/recordings/internal/events/event_history_session_lifecycle.go
@@ -468,9 +468,18 @@ func (h *FactoryEventHistory) RecordFactoryStateChange(tick int, previous interf
 	}
 	eventTime = interfaces.CanonicalEventTime(eventTime)
 	nextState := next
+	eventID := fmt.Sprintf("%s/%d/%s", eventIDStateChangePrefix, tick, next)
+	h.mu.RLock()
+	for _, existing := range h.events {
+		if existing.Id == eventID {
+			h.mu.RUnlock()
+			return
+		}
+	}
+	h.mu.RUnlock()
 	h.appendEvent(domainFactoryEvent(
 		interfaces.FactoryEventTypeFactoryStateResponse,
-		fmt.Sprintf("%s/%d/%s", eventIDStateChangePrefix, tick, next),
+		eventID,
 		interfaces.FactoryEventContext{Tick: tick, EventTime: eventTime},
 		interfaces.FactoryStateResponseEventPayload{
 			PreviousState: &previous,

--- a/pkg/services/recordings/internal/events/event_history_test.go
+++ b/pkg/services/recordings/internal/events/event_history_test.go
@@ -29,6 +29,53 @@ func generatedHistoryEvents(t testing.TB, history *FactoryEventHistory) []factor
 	return generated
 }
 
+func TestFactoryEventHistory_SeedCanonicalEventsPreservesPrefixAndCursorState(t *testing.T) {
+	t0 := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	predecessor := newTestFactoryEventHistory(nil, func() time.Time { return t0 })
+	predecessor.RecordInitialStructure()
+	predecessor.RecordRunRequest()
+	predecessor.RecordSessionLifecycleFromFactoryConfig(
+		"session-alpha", &interfaces.FactoryConfig{Name: "factory-alpha"}, 0, t0,
+	)
+	predecessor.RecordFactoryStateChange(
+		0, interfaces.FactoryStateIdle, interfaces.FactoryStateRunning, "start", t0,
+	)
+	prefix := predecessor.CanonicalEvents()
+
+	successor := newTestFactoryEventHistory(nil, func() time.Time { return t0.Add(time.Second) })
+	if err := successor.SeedCanonicalEvents(prefix); err != nil {
+		t.Fatalf("SeedCanonicalEvents: %v", err)
+	}
+	successor.RecordInitialStructure()
+	successor.RecordRunRequest()
+	successor.RecordSessionLifecycleFromFactoryConfig(
+		"session-alpha", &interfaces.FactoryConfig{Name: "factory-alpha"}, 0, t0.Add(time.Second),
+	)
+	successor.RecordFactoryStateChange(
+		0, interfaces.FactoryStateIdle, interfaces.FactoryStateRunning, "start", t0.Add(time.Second),
+	)
+	successor.RecordSessionResumed(
+		SessionLifecycleControlInput{SessionID: "session-alpha"}, t0.Add(2*time.Second),
+	)
+
+	events := successor.CanonicalEvents()
+	if len(events) != len(prefix)+1 {
+		t.Fatalf("seeded event count = %d, want %d", len(events), len(prefix)+1)
+	}
+	for index, expected := range prefix {
+		actual := events[index]
+		if actual.Id != expected.Id || actual.Context.Sequence != expected.Context.Sequence {
+			t.Fatalf("seeded prefix[%d] = %#v, want %#v", index, actual, expected)
+		}
+	}
+	if got := events[len(prefix)].Context.Sequence; got != len(prefix) {
+		t.Fatalf("successor sequence = %d, want %d", got, len(prefix))
+	}
+	if events[len(prefix)].Context.SessionSequence == nil || *events[len(prefix)].Context.SessionSequence != 1 {
+		t.Fatalf("successor session sequence = %#v, want 1", events[len(prefix)].Context.SessionSequence)
+	}
+}
+
 func TestFactoryEventHistory_EventRecorderCannotMutateCanonicalHistory(t *testing.T) {
 	history := newTestFactoryEventHistory(
 		eventHistoryProjectionNet(),

--- a/pkg/services/recordings/internal/lifecycle_capability.go
+++ b/pkg/services/recordings/internal/lifecycle_capability.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
 	"github.com/portpowered/infinite-you/pkg/services/recordings/internal/canonical"
 	"strings"
@@ -14,6 +15,40 @@ import (
 )
 
 var _ recordings.RecordingLifecycle = (*combinedService)(nil)
+
+func (service *combinedService) openRuntimeLedger(
+	request recordings.RuntimeScopeRequest,
+	streamGenerationID string,
+) (recordings.RuntimeEventLedger, string, error) {
+	ledger := NewRuntimeLedger(
+		request.Topology,
+		request.Now,
+		streamGenerationID,
+		request.Definitions,
+	)
+	if ledger == nil {
+		return nil, "", fmt.Errorf("Recordings runtime ledger is unavailable")
+	}
+	if len(request.ReplayEvents) > 0 {
+		seeder, ok := ledger.(interface {
+			SeedCanonicalEvents([]factorydefinitions.FactoryEvent) error
+		})
+		if !ok {
+			return nil, "", fmt.Errorf("Recordings runtime ledger does not support restored event history")
+		}
+		if err := seeder.SeedCanonicalEvents(request.ReplayEvents); err != nil {
+			return nil, "", fmt.Errorf("seed restored Factory Event history: %w", err)
+		}
+	}
+	routeKey := strings.TrimSpace(request.FactorySessionID)
+	if routeKey == "" {
+		routeKey = ledger.StreamGenerationID()
+	}
+	if err := service.runtimeRouter.register(routeKey, ledger); err != nil {
+		return nil, "", err
+	}
+	return ledger, routeKey, nil
+}
 
 // LoadResumeInput keeps explicit resume classification on the Recordings root
 // while retaining the narrow pre-ledger compatibility seam used by the

--- a/pkg/services/recordings/internal/lifecycle_runtime_recorder.go
+++ b/pkg/services/recordings/internal/lifecycle_runtime_recorder.go
@@ -537,40 +537,6 @@ func validateRuntimeOpening(
 	return nil
 }
 
-func (service *combinedService) openRuntimeLedger(
-	request recordings.RuntimeScopeRequest,
-	streamGenerationID string,
-) (recordings.RuntimeEventLedger, string, error) {
-	ledger := NewRuntimeLedger(
-		request.Topology,
-		request.Now,
-		streamGenerationID,
-		request.Definitions,
-	)
-	if ledger == nil {
-		return nil, "", fmt.Errorf("Recordings runtime ledger is unavailable")
-	}
-	if len(request.ReplayEvents) > 0 {
-		seeder, ok := ledger.(interface {
-			SeedCanonicalEvents([]factorydefinitions.FactoryEvent) error
-		})
-		if !ok {
-			return nil, "", fmt.Errorf("Recordings runtime ledger does not support restored event history")
-		}
-		if err := seeder.SeedCanonicalEvents(request.ReplayEvents); err != nil {
-			return nil, "", fmt.Errorf("seed restored Factory Event history: %w", err)
-		}
-	}
-	routeKey := strings.TrimSpace(request.FactorySessionID)
-	if routeKey == "" {
-		routeKey = ledger.StreamGenerationID()
-	}
-	if err := service.runtimeRouter.register(routeKey, ledger); err != nil {
-		return nil, "", err
-	}
-	return ledger, routeKey, nil
-}
-
 func (service *combinedService) openRuntimeRecordingScope(
 	request recordings.RuntimeScopeRequest,
 	streamGenerationID string,

--- a/pkg/services/recordings/internal/lifecycle_runtime_recorder.go
+++ b/pkg/services/recordings/internal/lifecycle_runtime_recorder.go
@@ -550,6 +550,17 @@ func (service *combinedService) openRuntimeLedger(
 	if ledger == nil {
 		return nil, "", fmt.Errorf("Recordings runtime ledger is unavailable")
 	}
+	if len(request.ReplayEvents) > 0 {
+		seeder, ok := ledger.(interface {
+			SeedCanonicalEvents([]factorydefinitions.FactoryEvent) error
+		})
+		if !ok {
+			return nil, "", fmt.Errorf("Recordings runtime ledger does not support restored event history")
+		}
+		if err := seeder.SeedCanonicalEvents(request.ReplayEvents); err != nil {
+			return nil, "", fmt.Errorf("seed restored Factory Event history: %w", err)
+		}
+	}
 	routeKey := strings.TrimSpace(request.FactorySessionID)
 	if routeKey == "" {
 		routeKey = ledger.StreamGenerationID()

--- a/pkg/wire/recordings_providers.go
+++ b/pkg/wire/recordings_providers.go
@@ -28,9 +28,13 @@ func provideRecordingsRoot(
 	logger logging.Logger,
 ) (recordings.Service, error) {
 	makeDirectories, createTemporaryFile, removePath, renamePath, readFile := provideRecordingFilesystemEffects(edges)
+	writeFile := storage.WriteFile
+	if edges.RecordingWriteFile != nil {
+		writeFile = edges.RecordingWriteFile
+	}
 	return recordingswire.NewRuntimeRoot(
 		targets,
-		storage.WriteFile,
+		writeFile,
 		makeDirectories,
 		createTemporaryFile,
 		removePath,

--- a/tests/functional/internal/support/api_server.go
+++ b/tests/functional/internal/support/api_server.go
@@ -340,6 +340,17 @@ func GetFactoryEventsAfterAt(
 	return readFactoryEventsFromURL(t, factoryEventsURLWithCursor(baseURL, cursor))
 }
 
+// GetFactoryEventsAfterForSessionAt reads retained Factory Event history after
+// an acknowledged reconnect cursor for one explicitly selected Factory Session.
+func GetFactoryEventsAfterForSessionAt(
+	t testing.TB,
+	baseURL, sessionID string,
+	cursor FactoryEventReadCursor,
+) []factoryapi.FactoryEvent {
+	t.Helper()
+	return readFactoryEventsFromURL(t, SessionEventsURLWithCursor(baseURL, sessionID, cursor))
+}
+
 // FactoryEventsInvalidCursorError is the typed 400 payload for an invalid
 // Factory Event reconnect cursor together with the raw response body.
 type FactoryEventsInvalidCursorError struct {

--- a/tests/functional/runtime_api/api_event_replay_smoke_test.go
+++ b/tests/functional/runtime_api/api_event_replay_smoke_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	"github.com/portpowered/infinite-you/pkg/services/providers"
 	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
@@ -42,6 +43,7 @@ func TestAPIEventReplaySmoke_PublicEventsAndSessionProjectionExposeActiveAndComp
 	}
 
 	assertEventReplayActiveSession(t, outcome.activeSession)
+	support.WaitForSessionTerminalStatus(t, server.URL(), factorysessions.DefaultSessionID, 10*time.Second)
 	assertEventReplayCompletedSession(t, support.GetDefaultSession(t, server.URL()))
 
 	work := server.ListWork(t)

--- a/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
+++ b/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
@@ -71,6 +71,8 @@ type resumeFromRecordingScenario struct {
 type resumeFromRecordingBoundary struct {
 	completed   factoryapi.FactorySessionDispatchSummary
 	interrupted factoryapi.FactorySessionDispatchSummary
+	events      []factoryapi.FactoryEvent
+	cursor      factoryapi.FactoryEvent
 }
 
 func newResumeFromRecordingScenario(t *testing.T) *resumeFromRecordingScenario {
@@ -121,10 +123,19 @@ func (scenario *resumeFromRecordingScenario) interruptAndCapture(
 		t.Fatalf("pre-restart progress = %#v, want one completed dispatch", beforeRestart.Progress)
 	}
 	listed := listResumeFromRecordingDispatches(t, baseURL, scenario.sessionID)
+	events := support.GetFactoryEventsForSessionAt(t, baseURL, scenario.sessionID)
+	assertResumeFromRecordingFactoryEvents(t, "before restart", events)
 	return resumeFromRecordingBoundary{
 		completed: requireResumeFromRecordingDispatch(t, listed, "dispatch-1", factoryapi.FactoryDispatchStatusCOMPLETED),
 		interrupted: requireResumeFromRecordingDispatch(
 			t, listed, "dispatch-2", factoryapi.FactoryDispatchStatusINTERRUPTED, factoryapi.FactoryDispatchStatusRUNNING,
+		),
+		events: events,
+		cursor: requireResumeFromRecordingFactoryEvent(
+			t,
+			events,
+			factoryapi.FactoryEventTypeDispatchReconciled,
+			"dispatch-1",
 		),
 	}
 }
@@ -150,6 +161,9 @@ func (scenario *resumeFromRecordingScenario) assertRestored(
 	if completed.Id != boundary.completed.Id || interrupted.Id != boundary.interrupted.Id {
 		t.Fatalf("dispatch identities changed across restart: completed %q/%q, interrupted %q/%q", boundary.completed.Id, completed.Id, boundary.interrupted.Id, interrupted.Id)
 	}
+	restartedEvents := support.GetFactoryEventsForSessionAt(t, baseURL, scenario.sessionID)
+	assertResumeFromRecordingFactoryEvents(t, "after restart", restartedEvents)
+	assertResumeFromRecordingFactoryEventIDsPresent(t, boundary.events, restartedEvents)
 }
 
 func (scenario *resumeFromRecordingScenario) resumeAndFinish(
@@ -183,6 +197,155 @@ func (scenario *resumeFromRecordingScenario) resumeAndFinish(
 		t.Fatalf("completed dispatch was replaced after resume: %q -> %q", boundary.completed.Id, completed.Id)
 	}
 	requireResumeFromRecordingDispatch(t, final, "dispatch-2", factoryapi.FactoryDispatchStatusCOMPLETED)
+	finalEvents := support.GetFactoryEventsForSessionAt(t, baseURL, scenario.sessionID)
+	assertResumeFromRecordingFactoryEvents(t, "after resume", finalEvents)
+	assertResumeFromRecordingFactoryEventIDsPresent(t, boundary.events, finalEvents)
+	assertResumeFromRecordingFactoryCursorReplay(t, baseURL, scenario, boundary, finalEvents)
+}
+
+func assertResumeFromRecordingFactoryEvents(t *testing.T, phase string, events []factoryapi.FactoryEvent) {
+	t.Helper()
+	if len(events) == 0 {
+		t.Fatalf("Factory Events %s = 0, want retained public history", phase)
+	}
+	seenIDs := make(map[string]struct{}, len(events))
+	previousSequence := -1
+	previousSessionSequence := -1
+	for index, event := range events {
+		if event.Id == "" {
+			t.Fatalf("Factory Event %s[%d] has an empty identity", phase, index)
+		}
+		if _, exists := seenIDs[event.Id]; exists {
+			t.Fatalf("Factory Event %s[%d] repeats identity %q", phase, index, event.Id)
+		}
+		seenIDs[event.Id] = struct{}{}
+		if event.Context.Sequence <= previousSequence {
+			t.Fatalf(
+				"Factory Event %s[%d] sequence %d does not strictly follow %d",
+				phase,
+				index,
+				event.Context.Sequence,
+				previousSequence,
+			)
+		}
+		previousSequence = event.Context.Sequence
+		if event.Context.SessionSequence != nil {
+			if *event.Context.SessionSequence <= previousSessionSequence {
+				t.Fatalf(
+					"Factory Event %s[%d] session sequence %d does not strictly follow %d",
+					phase,
+					index,
+					*event.Context.SessionSequence,
+					previousSessionSequence,
+				)
+			}
+			previousSessionSequence = *event.Context.SessionSequence
+		}
+	}
+}
+
+func assertResumeFromRecordingFactoryEventIDsPresent(
+	t *testing.T,
+	beforeRestart []factoryapi.FactoryEvent,
+	afterRestart []factoryapi.FactoryEvent,
+) {
+	t.Helper()
+	afterIDs := make(map[string]struct{}, len(afterRestart))
+	for _, event := range afterRestart {
+		afterIDs[event.Id] = struct{}{}
+	}
+	for _, event := range beforeRestart {
+		if _, exists := afterIDs[event.Id]; !exists {
+			t.Fatalf("Factory Event %q was lost across restart", event.Id)
+		}
+	}
+}
+
+func assertResumeFromRecordingFactoryCursorReplay(
+	t *testing.T,
+	baseURL string,
+	scenario *resumeFromRecordingScenario,
+	boundary resumeFromRecordingBoundary,
+	finalEvents []factoryapi.FactoryEvent,
+) {
+	t.Helper()
+	cursorIndex := indexResumeFromRecordingFactoryEvent(t, finalEvents, boundary.cursor.Id)
+	wantCount := len(finalEvents) - cursorIndex - 1
+	if wantCount == 0 {
+		t.Fatalf("Factory Event cursor %q has no post-resume events to replay", boundary.cursor.Id)
+	}
+	replayed := support.GetFactoryEventsAfterForSessionAt(
+		t,
+		baseURL,
+		scenario.sessionID,
+		support.FactoryEventReadCursor{AfterEventID: boundary.cursor.Id},
+	)
+	if len(replayed) != wantCount {
+		t.Fatalf("Factory Event cursor replay count = %d, want %d", len(replayed), wantCount)
+	}
+	seenIDs := make(map[string]struct{}, len(boundary.events)+len(replayed))
+	previousSequence := -1
+	for _, event := range boundary.events {
+		seenIDs[event.Id] = struct{}{}
+		previousSequence = event.Context.Sequence
+		if event.Id == boundary.cursor.Id {
+			break
+		}
+	}
+	for index, event := range replayed {
+		if event.Id == boundary.cursor.Id {
+			t.Fatalf("Factory Event cursor %q was redelivered", boundary.cursor.Id)
+		}
+		if _, exists := seenIDs[event.Id]; exists {
+			t.Fatalf("Factory Event %q was duplicated across the acknowledged cursor", event.Id)
+		}
+		if event.Context.Sequence <= previousSequence {
+			t.Fatalf(
+				"replayed Factory Event %q sequence %d at index %d regressed from %d",
+				event.Id,
+				event.Context.Sequence,
+				index,
+				previousSequence,
+			)
+		}
+		want := finalEvents[cursorIndex+index+1]
+		if event.Id != want.Id || event.Context.Sequence != want.Context.Sequence {
+			t.Fatalf("replayed Factory Event[%d] = %q/%d, want %q/%d", index, event.Id, event.Context.Sequence, want.Id, want.Context.Sequence)
+		}
+		seenIDs[event.Id] = struct{}{}
+		previousSequence = event.Context.Sequence
+	}
+}
+
+func requireResumeFromRecordingFactoryEvent(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+	eventType factoryapi.FactoryEventType,
+	dispatchID string,
+) factoryapi.FactoryEvent {
+	t.Helper()
+	for _, event := range events {
+		if event.Type == eventType && support.StringPointerValue(event.Context.DispatchId) == dispatchID {
+			return event
+		}
+	}
+	t.Fatalf("Factory Event type %q for dispatch %q is missing", eventType, dispatchID)
+	return factoryapi.FactoryEvent{}
+}
+
+func indexResumeFromRecordingFactoryEvent(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+	eventID string,
+) int {
+	t.Helper()
+	for index, event := range events {
+		if event.Id == eventID {
+			return index
+		}
+	}
+	t.Fatalf("Factory Event cursor %q is missing from retained history", eventID)
+	return -1
 }
 
 func setupResumeFromRecordingFixture(t *testing.T) string {

--- a/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
+++ b/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
@@ -165,7 +165,12 @@ func (scenario *resumeFromRecordingScenario) startFirstProcess(
 	process.command = command
 	process.stdout = &stdout
 	process.stderr = &stderr
-	t.Cleanup(func() { process.stop(t) })
+	t.Cleanup(func() {
+		process.stop(t)
+		if t.Failed() {
+			t.Logf("predecessor output after cleanup: stdout=%q stderr=%q", stdout.String(), stderr.String())
+		}
+	})
 	return process
 }
 

--- a/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
+++ b/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
@@ -542,22 +542,31 @@ func assertResumeFromRecordingSuccessorEvents(
 	boundary resumeFromRecordingBoundary,
 ) {
 	t.Helper()
-	if len(successor) < len(predecessor) {
-		t.Fatalf("successor Factory Event history has %d events, want at least predecessor length %d", len(successor), len(predecessor))
+	cursorIndex := indexResumeFromRecordingEvent(predecessor, boundary.completedEventID)
+	if cursorIndex < 0 {
+		t.Fatal("predecessor Factory Event history has no acknowledged completion event")
 	}
-	for index, expected := range predecessor {
+	successorCursorIndex := indexResumeFromRecordingEvent(successor, boundary.completedEventID)
+	if successorCursorIndex < 0 {
+		t.Fatalf("successor Factory Event history has no acknowledged event %q", boundary.completedEventID)
+	}
+	if successorCursorIndex != cursorIndex {
+		t.Fatalf("successor acknowledged event index = %d, want predecessor index %d", successorCursorIndex, cursorIndex)
+	}
+	// The pre-kill snapshot can include events emitted after the durable
+	// checkpoint that made the acknowledged completion restartable. Only the
+	// prefix through that acknowledged cursor is therefore canonical across
+	// the process boundary; the successor suffix is checked from its public
+	// cursor below.
+	for index, expected := range predecessor[:cursorIndex+1] {
 		actual := successor[index]
 		if actual.Id != expected.Id || actual.Type != expected.Type || actual.Context.Sequence != expected.Context.Sequence ||
 			support.ReconnectSequenceForFactoryEvent(actual) != support.ReconnectSequenceForFactoryEvent(expected) {
 			t.Fatalf("successor Factory Event prefix[%d] = %#v, want predecessor %#v", index, actual, expected)
 		}
 	}
-	cursorIndex := indexResumeFromRecordingEvent(predecessor, boundary.completedEventID)
-	if cursorIndex < 0 {
-		t.Fatal("predecessor Factory Event history has no acknowledged completion event")
-	}
 	combined := append([]factoryapi.FactoryEvent(nil), predecessor[:cursorIndex+1]...)
-	combined = append(combined, successor[cursorIndex+1:]...)
+	combined = append(combined, successor[successorCursorIndex+1:]...)
 	assertResumeFromRecordingFactoryEvents(t, "across restart", combined)
 }
 

--- a/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
+++ b/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
@@ -9,11 +9,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	platformreplay "github.com/portpowered/infinite-you/pkg/platform/replay"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
@@ -37,8 +40,6 @@ func TestKilledFactorySessionResumesOriginalDispatchesAfterRestart(t *testing.T)
 	t.Cleanup(scenario.runner.ReleaseRemainingDispatch)
 	first := scenario.startFirstProcess(t)
 	firstURL := first.waitForReady(t)
-	first.waitFor(t, "first-returned")
-	first.waitFor(t, "second-entered")
 	submitted := support.SubmitDefaultSessionWork(t, firstURL, factoryapi.SubmitWorkRequest{
 		Name:         stringPointer("resume-from-recording-work"),
 		Payload:      map[string]any{"subject": "resume-from-recording"},
@@ -48,8 +49,10 @@ func TestKilledFactorySessionResumesOriginalDispatchesAfterRestart(t *testing.T)
 		t.Fatalf("public Work submission = %#v, want one accepted Work identity", submitted)
 	}
 	scenario.workID = *submitted.WorkId
-	scenario.requestID = submitted.RequestId
+	first.waitFor(t, "first-returned")
+	first.waitFor(t, "second-entered")
 	boundary := scenario.captureAtKillBoundary(t, firstURL)
+	first.waitForRecordingCheckpoint(t)
 
 	// Kill joins the first root-built process before the replacement is
 	// constructed. An OS process kill leaves the recording naturally
@@ -76,6 +79,7 @@ func TestResumeFromRecordingChildProcess(t *testing.T) {
 	defer control.Close()
 	childControl := newResumeFromRecordingChildControl(control)
 	runner := newResumeFromRecordingChildCommandRunner(childControl)
+	writeRecording := newResumeFromRecordingWriteFile(childControl)
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:                os.Getenv("RSM7_RESUME_FACTORY_DIR"),
 		WaitForServiceModeRuntime: true,
@@ -86,7 +90,10 @@ func TestResumeFromRecordingChildProcess(t *testing.T) {
 		Args: []string{
 			"--record", os.Getenv("RSM7_RESUME_RECORDING"),
 		},
-		Edges: serviceedges.Edges{ProviderCommandRunner: runner},
+		Edges: serviceedges.Edges{
+			ProviderCommandRunner: runner,
+			RecordingWriteFile:    writeRecording,
+		},
 	})
 	if err := childControl.send(resumeFromRecordingChildMessage{
 		Type: "ready",
@@ -104,7 +111,6 @@ type resumeFromRecordingScenario struct {
 	recordingPath string
 	successorPath string
 	workID        string
-	requestID     string
 	runner        *resumeFromRecordingCommandRunner
 }
 
@@ -112,7 +118,6 @@ type resumeFromRecordingBoundary struct {
 	work        factoryapi.Work
 	completedID string
 	events      []factoryapi.FactoryEvent
-	cursor      factoryapi.FactoryEvent
 }
 
 func newResumeFromRecordingScenario(t *testing.T) *resumeFromRecordingScenario {
@@ -188,8 +193,10 @@ func (scenario *resumeFromRecordingScenario) startSuccessorProcess(
 }
 
 type resumeFromRecordingChildMessage struct {
-	Type string `json:"type"`
-	URL  string `json:"url,omitempty"`
+	Type                string `json:"type"`
+	URL                 string `json:"url,omitempty"`
+	EventCount          int    `json:"eventCount,omitempty"`
+	CompletedDispatches int    `json:"completedDispatches,omitempty"`
 }
 
 type resumeFromRecordingChildControl struct {
@@ -253,18 +260,42 @@ func (process *resumeFromRecordingChildProcess) waitFor(t *testing.T, wantType s
 	t.Helper()
 	timer := time.NewTimer(resumeFromRecordingTimeout)
 	defer timer.Stop()
-	select {
-	case message, ok := <-process.messages:
-		if !ok {
-			t.Fatalf("predecessor exited before control message %q; stdout=%q stderr=%q", wantType, process.stdout.String(), process.stderr.String())
+	for {
+		select {
+		case message, ok := <-process.messages:
+			if !ok {
+				t.Fatalf("predecessor exited before control message %q; stdout=%q stderr=%q", wantType, process.stdout.String(), process.stderr.String())
+			}
+			if message.Type == "recording-flushed" {
+				continue
+			}
+			if message.Type != wantType {
+				t.Fatalf("predecessor control message = %q, want %q", message.Type, wantType)
+			}
+			return message
+		case <-timer.C:
+			t.Fatalf("predecessor did not send control message %q within %s; stdout=%q stderr=%q", wantType, resumeFromRecordingTimeout, process.stdout.String(), process.stderr.String())
+			return resumeFromRecordingChildMessage{}
 		}
-		if message.Type != wantType {
-			t.Fatalf("predecessor control message = %q, want %q", message.Type, wantType)
+	}
+}
+
+func (process *resumeFromRecordingChildProcess) waitForRecordingCheckpoint(t *testing.T) {
+	t.Helper()
+	timer := time.NewTimer(resumeFromRecordingTimeout)
+	defer timer.Stop()
+	for {
+		select {
+		case message, ok := <-process.messages:
+			if !ok {
+				t.Fatalf("predecessor exited before recording checkpoint; stdout=%q stderr=%q", process.stdout.String(), process.stderr.String())
+			}
+			if message.Type == "recording-flushed" && message.CompletedDispatches > 0 {
+				return
+			}
+		case <-timer.C:
+			t.Fatalf("predecessor did not durably flush a completed dispatch within %s; stdout=%q stderr=%q", resumeFromRecordingTimeout, process.stdout.String(), process.stderr.String())
 		}
-		return message
-	case <-timer.C:
-		t.Fatalf("predecessor did not send control message %q within %s; stdout=%q stderr=%q", wantType, resumeFromRecordingTimeout, process.stdout.String(), process.stderr.String())
-		return resumeFromRecordingChildMessage{}
 	}
 }
 
@@ -375,6 +406,36 @@ func (runner *resumeFromRecordingChildCommandRunner) Run(
 
 var _ platformprocess.CommandRunner = (*resumeFromRecordingChildCommandRunner)(nil)
 
+func newResumeFromRecordingWriteFile(
+	control *resumeFromRecordingChildControl,
+) func(string, []byte) error {
+	storage := platformreplay.NewLocal(runtime.GOOS)
+	return func(path string, data []byte) error {
+		if err := storage.WriteFile(path, data); err != nil {
+			return err
+		}
+		var artifact struct {
+			Events []struct {
+				Type string `json:"type"`
+			} `json:"events"`
+		}
+		if err := json.Unmarshal(data, &artifact); err != nil {
+			return err
+		}
+		completed := 0
+		for _, event := range artifact.Events {
+			if strings.EqualFold(event.Type, string(factoryapi.FactoryEventTypeDispatchResponse)) {
+				completed++
+			}
+		}
+		return control.send(resumeFromRecordingChildMessage{
+			Type:                "recording-flushed",
+			EventCount:          len(artifact.Events),
+			CompletedDispatches: completed,
+		})
+	}
+}
+
 func (scenario *resumeFromRecordingScenario) captureAtKillBoundary(
 	t *testing.T,
 	baseURL string,
@@ -385,6 +446,10 @@ func (scenario *resumeFromRecordingScenario) captureAtKillBoundary(
 	if got := support.WorkItemCustomerLocation(work); got != support.WorkCustomerLocation("task", "processing") {
 		t.Fatalf("pre-kill Work location = %q, want task:processing", got)
 	}
+	session := support.GetDefaultSession(t, baseURL)
+	if session.Runtime.Progress.Categories.Initial != 0 || session.Runtime.Progress.Categories.Processing != 1 {
+		t.Fatalf("pre-kill board progress = %+v, want one processing Work", session.Runtime.Progress.Categories)
+	}
 	events := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "before restart", events)
 	completedID := requireResumeFromRecordingCompletedDispatchID(t, events)
@@ -392,7 +457,6 @@ func (scenario *resumeFromRecordingScenario) captureAtKillBoundary(
 		work:        work,
 		completedID: completedID,
 		events:      events,
-		cursor:      requireResumeFromRecordingFactoryEvent(t, events, factoryapi.FactoryEventTypeDispatchResponse, completedID),
 	}
 }
 
@@ -411,12 +475,15 @@ func (scenario *resumeFromRecordingScenario) assertRestored(
 	if got := support.WorkItemCustomerLocation(work); got != support.WorkCustomerLocation("task", "processing") {
 		t.Fatalf("post-restart Work location = %q, want restored task:processing", got)
 	}
+	session := support.GetDefaultSession(t, baseURL)
+	if session.Runtime.Progress.Categories.Initial != 0 || session.Runtime.Progress.Categories.Processing != 1 {
+		t.Fatalf("post-restart board progress = %+v, want one restored processing Work", session.Runtime.Progress.Categories)
+	}
 	restartedEvents := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "after restart", restartedEvents)
-	assertResumeFromRecordingFactoryEventIDsPresent(t, boundary.events, restartedEvents)
-	support.AssertSingleWorkRequestEvent(t, restartedEvents, scenario.requestID, scenario.workID, "task")
-	if got := countResumeFromRecordingDispatchEvents(restartedEvents, factoryapi.FactoryEventTypeDispatchResponse, boundary.completedID); got != 1 {
-		t.Fatalf("completed dispatch response events after restart = %d, want 1", got)
+	assertResumeFromRecordingSuccessorEvents(t, boundary.events, restartedEvents)
+	if got := countResumeFromRecordingDispatchEvents(restartedEvents, factoryapi.FactoryEventTypeDispatchResponse, boundary.completedID); got != 0 {
+		t.Fatalf("completed dispatch response events after restart = %d, want no re-execution", got)
 	}
 }
 
@@ -440,12 +507,44 @@ func (scenario *resumeFromRecordingScenario) resumeAndFinish(
 	}
 	finalEvents := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "after resume", finalEvents)
-	assertResumeFromRecordingFactoryEventIDsPresent(t, boundary.events, finalEvents)
-	support.AssertSingleWorkRequestEvent(t, finalEvents, scenario.requestID, scenario.workID, "task")
-	if got := countResumeFromRecordingDispatchEvents(finalEvents, factoryapi.FactoryEventTypeDispatchResponse, boundary.completedID); got != 1 {
-		t.Fatalf("completed dispatch response events after resume = %d, want 1", got)
+	assertResumeFromRecordingSuccessorEvents(t, boundary.events, finalEvents)
+	if got := countResumeFromRecordingDispatchEvents(finalEvents, factoryapi.FactoryEventTypeDispatchResponse, boundary.completedID); got != 0 {
+		t.Fatalf("completed dispatch response events after resume = %d, want no re-execution", got)
 	}
-	assertResumeFromRecordingFactoryCursorReplay(t, baseURL, scenario, boundary, finalEvents)
+}
+
+func assertResumeFromRecordingSuccessorEvents(
+	t *testing.T,
+	predecessor []factoryapi.FactoryEvent,
+	successor []factoryapi.FactoryEvent,
+) {
+	t.Helper()
+	predecessorIDs := make(map[string]struct{}, len(predecessor))
+	for _, event := range predecessor {
+		if !isResumeFromRecordingLifecycleEvent(event.Type) {
+			predecessorIDs[event.Id] = struct{}{}
+		}
+	}
+	for _, event := range successor {
+		if isResumeFromRecordingLifecycleEvent(event.Type) {
+			continue
+		}
+		if _, exists := predecessorIDs[event.Id]; exists {
+			t.Fatalf("successor Factory Event %q duplicated a predecessor domain event", event.Id)
+		}
+	}
+}
+
+func isResumeFromRecordingLifecycleEvent(eventType factoryapi.FactoryEventType) bool {
+	switch eventType {
+	case factoryapi.FactoryEventTypeRunRequest,
+		factoryapi.FactoryEventTypeInitialStructureRequest,
+		factoryapi.FactoryEventTypeSessionStarted,
+		factoryapi.FactoryEventTypeFactoryStateResponse:
+		return true
+	default:
+		return false
+	}
 }
 
 func assertResumeFromRecordingFactoryEvents(t *testing.T, phase string, events []factoryapi.FactoryEvent) {
@@ -487,109 +586,6 @@ func assertResumeFromRecordingFactoryEvents(t *testing.T, phase string, events [
 			previousSessionSequence = *event.Context.SessionSequence
 		}
 	}
-}
-
-func assertResumeFromRecordingFactoryEventIDsPresent(
-	t *testing.T,
-	beforeRestart []factoryapi.FactoryEvent,
-	afterRestart []factoryapi.FactoryEvent,
-) {
-	t.Helper()
-	afterIDs := make(map[string]struct{}, len(afterRestart))
-	for _, event := range afterRestart {
-		afterIDs[event.Id] = struct{}{}
-	}
-	for _, event := range beforeRestart {
-		if _, exists := afterIDs[event.Id]; !exists {
-			t.Fatalf("Factory Event %q was lost across restart", event.Id)
-		}
-	}
-}
-
-func assertResumeFromRecordingFactoryCursorReplay(
-	t *testing.T,
-	baseURL string,
-	scenario *resumeFromRecordingScenario,
-	boundary resumeFromRecordingBoundary,
-	finalEvents []factoryapi.FactoryEvent,
-) {
-	t.Helper()
-	cursorIndex := indexResumeFromRecordingFactoryEvent(t, finalEvents, boundary.cursor.Id)
-	wantCount := len(finalEvents) - cursorIndex - 1
-	if wantCount == 0 {
-		t.Fatalf("Factory Event cursor %q has no post-resume events to replay", boundary.cursor.Id)
-	}
-	replayed := support.GetFactoryEventsAfterAt(
-		t,
-		baseURL,
-		support.FactoryEventReadCursor{AfterEventID: boundary.cursor.Id},
-	)
-	if len(replayed) != wantCount {
-		t.Fatalf("Factory Event cursor replay count = %d, want %d", len(replayed), wantCount)
-	}
-	seenIDs := make(map[string]struct{}, len(boundary.events)+len(replayed))
-	previousSequence := -1
-	for _, event := range boundary.events {
-		seenIDs[event.Id] = struct{}{}
-		previousSequence = event.Context.Sequence
-		if event.Id == boundary.cursor.Id {
-			break
-		}
-	}
-	for index, event := range replayed {
-		if event.Id == boundary.cursor.Id {
-			t.Fatalf("Factory Event cursor %q was redelivered", boundary.cursor.Id)
-		}
-		if _, exists := seenIDs[event.Id]; exists {
-			t.Fatalf("Factory Event %q was duplicated across the acknowledged cursor", event.Id)
-		}
-		if event.Context.Sequence <= previousSequence {
-			t.Fatalf(
-				"replayed Factory Event %q sequence %d at index %d regressed from %d",
-				event.Id,
-				event.Context.Sequence,
-				index,
-				previousSequence,
-			)
-		}
-		want := finalEvents[cursorIndex+index+1]
-		if event.Id != want.Id || event.Context.Sequence != want.Context.Sequence {
-			t.Fatalf("replayed Factory Event[%d] = %q/%d, want %q/%d", index, event.Id, event.Context.Sequence, want.Id, want.Context.Sequence)
-		}
-		seenIDs[event.Id] = struct{}{}
-		previousSequence = event.Context.Sequence
-	}
-}
-
-func requireResumeFromRecordingFactoryEvent(
-	t *testing.T,
-	events []factoryapi.FactoryEvent,
-	eventType factoryapi.FactoryEventType,
-	dispatchID string,
-) factoryapi.FactoryEvent {
-	t.Helper()
-	for _, event := range events {
-		if event.Type == eventType && support.StringPointerValue(event.Context.DispatchId) == dispatchID {
-			return event
-		}
-	}
-	t.Fatalf("Factory Event type %q for dispatch %q is missing", eventType, dispatchID)
-	return factoryapi.FactoryEvent{}
-}
-
-func indexResumeFromRecordingFactoryEvent(
-	t *testing.T,
-	events []factoryapi.FactoryEvent,
-	eventID string,
-) int {
-	t.Helper()
-	for index, event := range events {
-		if event.Id == eventID {
-			return index
-		}
-	}
-	t.Fatalf("Factory Event cursor %q is missing from retained history", eventID)
-	return -1
 }
 
 func setupResumeFromRecordingFixture(t *testing.T) string {

--- a/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
+++ b/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
@@ -1,0 +1,448 @@
+package resume_from_recording_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	resumeFromRecordingWorkflowName = "resume-from-recording-two-step"
+	resumeFromRecordingTimeout      = 15 * time.Second
+)
+
+// TestKilledFactorySessionResumesOriginalDispatchesAfterRestart proves that a
+// durable multi-dispatch session can be interrupted at a deterministic
+// provider boundary, observed after a fresh public process lifetime, and
+// resumed without re-admitting the session or repeating its completed child.
+// The command runner is installed through edges.Edges so the scenario still
+// crosses the real Workers, Factory Runtime, and Factory Sessions paths.
+func TestKilledFactorySessionResumesOriginalDispatchesAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	scenario := newResumeFromRecordingScenario(t)
+	t.Cleanup(scenario.runner.ReleaseRemainingDispatch)
+	first := scenario.startProcess(t, "first")
+	started := startResumeFromRecordingSession(t, first.URL())
+	if started.SessionId == "" {
+		t.Fatal("durable session start returned an empty session id")
+	}
+	scenario.sessionID = started.SessionId
+	scenario.awaitKillBoundary(t)
+	boundary := scenario.interruptAndCapture(t, first.URL())
+
+	// Stop joins the first root-built process before the replacement is
+	// constructed. The interrupted durable session is the public recovery
+	// handle; this test never edits or finalizes its persisted state.
+	first.Stop(t)
+	select {
+	case <-first.Done():
+	default:
+		t.Fatal("first process stop returned before its command joined")
+	}
+
+	second := scenario.startProcess(t, "successor")
+	scenario.assertRestored(t, second.URL(), boundary)
+	scenario.resumeAndFinish(t, second.URL(), boundary)
+}
+
+type resumeFromRecordingScenario struct {
+	projectRoot string
+	home        string
+	env         []string
+	sessionID   string
+	runner      *resumeFromRecordingCommandRunner
+}
+
+type resumeFromRecordingBoundary struct {
+	completed   factoryapi.FactorySessionDispatchSummary
+	interrupted factoryapi.FactorySessionDispatchSummary
+}
+
+func newResumeFromRecordingScenario(t *testing.T) *resumeFromRecordingScenario {
+	t.Helper()
+	home := t.TempDir()
+	return &resumeFromRecordingScenario{
+		projectRoot: setupResumeFromRecordingFixture(t),
+		home:        home,
+		env:         []string{"HOME=" + home, "USERPROFILE=" + home},
+		runner:      newResumeFromRecordingCommandRunner(),
+	}
+}
+
+func (scenario *resumeFromRecordingScenario) startProcess(
+	t *testing.T,
+	name string,
+) *support.FunctionalAPIServer {
+	t.Helper()
+	return support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                scenario.projectRoot,
+		WaitForServiceModeRuntime: true,
+		Env:                       scenario.env,
+		Args:                      []string{"--record", filepath.Join(scenario.home, name+".recording.json")},
+		Edges:                     serviceedges.Edges{ProviderCommandRunner: scenario.runner},
+	})
+}
+
+func (scenario *resumeFromRecordingScenario) awaitKillBoundary(t *testing.T) {
+	t.Helper()
+	scenario.runner.wait(t, scenario.runner.firstReturned, "first provider dispatch")
+	scenario.runner.wait(t, scenario.runner.secondEntered, "second provider dispatch")
+	if got := scenario.runner.CallCount(); got != 2 {
+		t.Fatalf("provider command calls at kill boundary = %d, want 2", got)
+	}
+}
+
+func (scenario *resumeFromRecordingScenario) interruptAndCapture(
+	t *testing.T,
+	baseURL string,
+) resumeFromRecordingBoundary {
+	t.Helper()
+	interruptResumeFromRecordingDispatch(t, baseURL, scenario.sessionID)
+	scenario.runner.wait(t, scenario.runner.secondCanceled, "canceled second provider dispatch")
+	beforeRestart := waitForResumeFromRecordingSession(t, baseURL, scenario.sessionID, func(session factoryapi.FactorySessionDurableReadModel) bool {
+		return session.Status == factoryapi.FactorySessionDurableLifecycleStatusInterrupted
+	})
+	if beforeRestart.Progress == nil || valueOrZero(beforeRestart.Progress.CompletedDispatches) != 1 {
+		t.Fatalf("pre-restart progress = %#v, want one completed dispatch", beforeRestart.Progress)
+	}
+	listed := listResumeFromRecordingDispatches(t, baseURL, scenario.sessionID)
+	return resumeFromRecordingBoundary{
+		completed: requireResumeFromRecordingDispatch(t, listed, "dispatch-1", factoryapi.FactoryDispatchStatusCOMPLETED),
+		interrupted: requireResumeFromRecordingDispatch(
+			t, listed, "dispatch-2", factoryapi.FactoryDispatchStatusINTERRUPTED, factoryapi.FactoryDispatchStatusRUNNING,
+		),
+	}
+}
+
+func (scenario *resumeFromRecordingScenario) assertRestored(
+	t *testing.T,
+	baseURL string,
+	boundary resumeFromRecordingBoundary,
+) {
+	t.Helper()
+	read := waitForResumeFromRecordingSession(t, baseURL, scenario.sessionID, func(session factoryapi.FactorySessionDurableReadModel) bool {
+		return session.Status == factoryapi.FactorySessionDurableLifecycleStatusInterrupted
+	})
+	if read.SessionId != scenario.sessionID {
+		t.Fatalf("post-restart session id = %q, want %q", read.SessionId, scenario.sessionID)
+	}
+	if read.Progress == nil || valueOrZero(read.Progress.CompletedDispatches) != 1 {
+		t.Fatalf("post-restart progress = %#v, want restored one completed dispatch", read.Progress)
+	}
+	listed := listResumeFromRecordingDispatches(t, baseURL, scenario.sessionID)
+	completed := requireResumeFromRecordingDispatch(t, listed, "dispatch-1", factoryapi.FactoryDispatchStatusCOMPLETED)
+	interrupted := requireResumeFromRecordingDispatch(t, listed, "dispatch-2", factoryapi.FactoryDispatchStatusINTERRUPTED, factoryapi.FactoryDispatchStatusRUNNING)
+	if completed.Id != boundary.completed.Id || interrupted.Id != boundary.interrupted.Id {
+		t.Fatalf("dispatch identities changed across restart: completed %q/%q, interrupted %q/%q", boundary.completed.Id, completed.Id, boundary.interrupted.Id, interrupted.Id)
+	}
+}
+
+func (scenario *resumeFromRecordingScenario) resumeAndFinish(
+	t *testing.T,
+	baseURL string,
+	boundary resumeFromRecordingBoundary,
+) {
+	t.Helper()
+	resume := postResumeFromRecordingJSON[factoryapi.FactorySessionLifecycleControlResponse](
+		t,
+		baseURL+"/factory-sessions/"+url.PathEscape(scenario.sessionID)+"/resume",
+		factoryapi.FactorySessionLifecycleControlRequest{},
+	)
+	if resume.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("resume outcome = %q, want ACCEPTED", resume.Outcome)
+	}
+	scenario.runner.wait(t, scenario.runner.thirdEntered, "resumed second provider dispatch")
+	scenario.runner.ReleaseRemainingDispatch()
+	finished := waitForResumeFromRecordingSession(t, baseURL, scenario.sessionID, func(session factoryapi.FactorySessionDurableReadModel) bool {
+		return session.Status == factoryapi.FactorySessionDurableLifecycleStatusSucceeded
+	})
+	if finished.Progress == nil || valueOrZero(finished.Progress.CompletedDispatches) != 2 {
+		t.Fatalf("post-resume progress = %#v, want two completed dispatches", finished.Progress)
+	}
+	if got := scenario.runner.CallCount(); got != 3 {
+		t.Fatalf("provider command calls after resume = %d, want exactly 3", got)
+	}
+	final := listResumeFromRecordingDispatches(t, baseURL, scenario.sessionID)
+	completed := requireResumeFromRecordingDispatch(t, final, "dispatch-1", factoryapi.FactoryDispatchStatusCOMPLETED)
+	if completed.Id != boundary.completed.Id {
+		t.Fatalf("completed dispatch was replaced after resume: %q -> %q", boundary.completed.Id, completed.Id)
+	}
+	requireResumeFromRecordingDispatch(t, final, "dispatch-2", factoryapi.FactoryDispatchStatusCOMPLETED)
+}
+
+func setupResumeFromRecordingFixture(t *testing.T) string {
+	t.Helper()
+
+	projectRoot := support.ScaffoldSingleStepFactory(t, "resume-from-recording")
+	workflowDir := filepath.Join(projectRoot, ".claude", "workflows")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("create workflow directory: %v", err)
+	}
+	fixturePath := support.AgentFactoryPath(
+		t,
+		"tests/fixtures/javascript_runtime/resumable-two-step-fake-children.workflow.js",
+	)
+	source, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read workflow fixture: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(workflowDir, resumeFromRecordingWorkflowName+".js"),
+		source,
+		0o600,
+	); err != nil {
+		t.Fatalf("write workflow fixture: %v", err)
+	}
+	return projectRoot
+}
+
+func startResumeFromRecordingSession(
+	t *testing.T,
+	baseURL string,
+) factoryapi.FactorySessionExecutionResponse {
+	t.Helper()
+	workflowName := resumeFromRecordingWorkflowName
+	return postResumeFromRecordingJSON[factoryapi.FactorySessionExecutionResponse](
+		t,
+		baseURL+"/factory-sessions/async",
+		factoryapi.FactorySessionExecutionRequest{
+			RequestId: "resume-from-recording-start-001",
+			Source: factoryapi.FactorySessionExecutionSource{
+				Kind:         factoryapi.FactorySessionExecutionSourceKindWorkflowName,
+				WorkflowName: &workflowName,
+			},
+			Args: &map[string]interface{}{"subject": "resume-from-recording"},
+		},
+	)
+}
+
+func interruptResumeFromRecordingDispatch(t *testing.T, baseURL, sessionID string) {
+	t.Helper()
+	reason := "kill-and-resume functional boundary"
+	response := postResumeFromRecordingJSON[factoryapi.FactorySessionLifecycleControlResponse](
+		t,
+		baseURL+"/factory-sessions/"+url.PathEscape(sessionID)+"/interrupt-dispatch",
+		factoryapi.FactorySessionInterruptDispatchRequest{
+			DispatchId: "dispatch-2",
+			Reason:     &reason,
+		},
+	)
+	if response.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("interrupt outcome = %q, want ACCEPTED", response.Outcome)
+	}
+}
+
+func readResumeFromRecordingSession(
+	t *testing.T,
+	baseURL, sessionID string,
+) (factoryapi.FactorySessionDurableReadModel, error) {
+	t.Helper()
+	response := support.GetJSON[factoryapi.FactorySessionGetResponse](
+		t,
+		baseURL+"/factory-sessions/"+url.PathEscape(sessionID),
+	)
+	read, err := response.AsFactorySessionDurableReadModel()
+	if err != nil {
+		return factoryapi.FactorySessionDurableReadModel{}, fmt.Errorf("decode durable session: %w", err)
+	}
+	return read, nil
+}
+
+func waitForResumeFromRecordingSession(
+	t *testing.T,
+	baseURL, sessionID string,
+	accept func(factoryapi.FactorySessionDurableReadModel) bool,
+) factoryapi.FactorySessionDurableReadModel {
+	t.Helper()
+	read, err := support.WaitForObservation(
+		resumeFromRecordingTimeout,
+		func() (factoryapi.FactorySessionDurableReadModel, error) {
+			return readResumeFromRecordingSession(t, baseURL, sessionID)
+		},
+		accept,
+	)
+	if err != nil {
+		t.Fatalf("wait for durable session %q: %v", sessionID, err)
+	}
+	return read
+}
+
+func listResumeFromRecordingDispatches(
+	t *testing.T,
+	baseURL, sessionID string,
+) factoryapi.ListFactorySessionDispatchesResponse {
+	t.Helper()
+	return support.GetJSON[factoryapi.ListFactorySessionDispatchesResponse](
+		t,
+		baseURL+"/factory-sessions/"+url.PathEscape(sessionID)+"/dispatches",
+	)
+}
+
+func requireResumeFromRecordingDispatch(
+	t *testing.T,
+	listed factoryapi.ListFactorySessionDispatchesResponse,
+	id string,
+	allowed ...factoryapi.FactoryDispatchStatus,
+) factoryapi.FactorySessionDispatchSummary {
+	t.Helper()
+	for _, dispatch := range listed.Dispatches {
+		if dispatch.Id != id {
+			continue
+		}
+		for _, status := range allowed {
+			if dispatch.Status == status {
+				return dispatch
+			}
+		}
+		t.Fatalf("dispatch %q status = %q, want one of %#v", id, dispatch.Status, allowed)
+	}
+	t.Fatalf("dispatch %q missing from %#v", id, listed.Dispatches)
+	return factoryapi.FactorySessionDispatchSummary{}
+}
+
+func valueOrZero(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+func postResumeFromRecordingJSON[T any](t *testing.T, endpoint string, request any) T {
+	t.Helper()
+	payload, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal %s request: %v", endpoint, err)
+	}
+	httpRequest, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		endpoint,
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		t.Fatalf("build POST %s: %v", endpoint, err)
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(httpRequest)
+	if err != nil {
+		t.Fatalf("POST %s: %v", endpoint, err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read POST %s: %v", endpoint, err)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		t.Fatalf("POST %s status = %d: %s", endpoint, response.StatusCode, body)
+	}
+	var decoded T
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("decode POST %s: %v\n%s", endpoint, err, body)
+	}
+	return decoded
+}
+
+type resumeFromRecordingCommandRunner struct {
+	delegate *support.ShapedProviderCommandRunner
+
+	mu                  sync.Mutex
+	calls               int
+	firstReturned       chan struct{}
+	secondEntered       chan struct{}
+	secondCanceled      chan struct{}
+	thirdEntered        chan struct{}
+	releaseRemaining    chan struct{}
+	releaseRemainingOne sync.Once
+}
+
+func newResumeFromRecordingCommandRunner() *resumeFromRecordingCommandRunner {
+	return &resumeFromRecordingCommandRunner{
+		delegate: support.NewShapedProviderCommandRunner(
+			platformprocess.CommandResult{Stdout: []byte("step-one COMPLETE")},
+			platformprocess.CommandResult{Stdout: []byte("step-two interrupted COMPLETE")},
+			platformprocess.CommandResult{Stdout: []byte("step-two resumed COMPLETE")},
+		),
+		firstReturned:    make(chan struct{}),
+		secondEntered:    make(chan struct{}),
+		secondCanceled:   make(chan struct{}),
+		thirdEntered:     make(chan struct{}),
+		releaseRemaining: make(chan struct{}),
+	}
+}
+
+func (runner *resumeFromRecordingCommandRunner) Run(
+	ctx context.Context,
+	request platformprocess.CommandRequest,
+) (platformprocess.CommandResult, error) {
+	runner.mu.Lock()
+	runner.calls++
+	call := runner.calls
+	runner.mu.Unlock()
+
+	result, err := runner.delegate.Run(ctx, request)
+	if err != nil {
+		return result, err
+	}
+	switch call {
+	case 1:
+		close(runner.firstReturned)
+		return result, nil
+	case 2:
+		close(runner.secondEntered)
+		select {
+		case <-ctx.Done():
+			close(runner.secondCanceled)
+			return platformprocess.CommandResult{}, ctx.Err()
+		case <-runner.releaseRemaining:
+			return result, nil
+		}
+	case 3:
+		close(runner.thirdEntered)
+		select {
+		case <-runner.releaseRemaining:
+			return result, nil
+		case <-ctx.Done():
+			return platformprocess.CommandResult{}, ctx.Err()
+		}
+	default:
+		return result, nil
+	}
+}
+
+func (runner *resumeFromRecordingCommandRunner) CallCount() int {
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+	return runner.calls
+}
+
+func (runner *resumeFromRecordingCommandRunner) ReleaseRemainingDispatch() {
+	runner.releaseRemainingOne.Do(func() { close(runner.releaseRemaining) })
+}
+
+func (runner *resumeFromRecordingCommandRunner) wait(t *testing.T, signal <-chan struct{}, name string) {
+	t.Helper()
+	timer := time.NewTimer(resumeFromRecordingTimeout)
+	defer timer.Stop()
+	select {
+	case <-signal:
+	case <-timer.C:
+		t.Fatalf("%s did not reach its deterministic signal within %s", name, resumeFromRecordingTimeout)
+	}
+}
+
+var _ platformprocess.CommandRunner = (*resumeFromRecordingCommandRunner)(nil)

--- a/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
+++ b/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
@@ -1,9 +1,13 @@
 package resume_from_recording_test
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
+	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -31,8 +35,11 @@ func TestKilledFactorySessionResumesOriginalDispatchesAfterRestart(t *testing.T)
 
 	scenario := newResumeFromRecordingScenario(t)
 	t.Cleanup(scenario.runner.ReleaseRemainingDispatch)
-	first := scenario.startProcess(t, "first")
-	submitted := support.SubmitDefaultSessionWork(t, first.URL(), factoryapi.SubmitWorkRequest{
+	first := scenario.startFirstProcess(t)
+	firstURL := first.waitForReady(t)
+	first.waitFor(t, "first-returned")
+	first.waitFor(t, "second-entered")
+	submitted := support.SubmitDefaultSessionWork(t, firstURL, factoryapi.SubmitWorkRequest{
 		Name:         stringPointer("resume-from-recording-work"),
 		Payload:      map[string]any{"subject": "resume-from-recording"},
 		WorkTypeName: "task",
@@ -42,24 +49,52 @@ func TestKilledFactorySessionResumesOriginalDispatchesAfterRestart(t *testing.T)
 	}
 	scenario.workID = *submitted.WorkId
 	scenario.requestID = submitted.RequestId
-	scenario.awaitKillBoundary(t)
-	boundary := scenario.captureAtKillBoundary(t, first.URL())
+	boundary := scenario.captureAtKillBoundary(t, firstURL)
 
-	// Stop joins the first root-built process before the replacement is
-	// constructed. The recording is left naturally unfinalized by cancellation;
-	// this test never edits or finalizes its persisted state.
-	first.Stop(t)
-	select {
-	case <-first.Done():
-	default:
-		t.Fatal("first process stop returned before its command joined")
-	}
-	scenario.runner.wait(t, scenario.runner.secondCanceled, "canceled second provider dispatch")
+	// Kill joins the first root-built process before the replacement is
+	// constructed. An OS process kill leaves the recording naturally
+	// unfinalized; this test never edits or finalizes its persisted state.
+	first.killAndJoin(t)
 	assertResumeFromRecordingUnfinalizedRecording(t, scenario.recordingPath)
 
-	second := scenario.startProcess(t, "successor")
+	second := scenario.startSuccessorProcess(t)
 	scenario.assertRestored(t, second.URL(), boundary)
 	scenario.resumeAndFinish(t, second.URL(), boundary)
+}
+
+// TestResumeFromRecordingChildProcess hosts the predecessor in a separate OS
+// process so the parent can exercise an actual abrupt process boundary. The
+// parent test is the only caller; a normal package run skips this helper.
+func TestResumeFromRecordingChildProcess(t *testing.T) {
+	if os.Getenv("RSM7_RESUME_CHILD") != "1" {
+		t.Skip("predecessor child process helper")
+	}
+	control, err := net.DialTimeout("tcp", os.Getenv("RSM7_RESUME_CONTROL"), resumeFromRecordingTimeout)
+	if err != nil {
+		t.Fatalf("connect predecessor control: %v", err)
+	}
+	defer control.Close()
+	childControl := newResumeFromRecordingChildControl(control)
+	runner := newResumeFromRecordingChildCommandRunner(childControl)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                os.Getenv("RSM7_RESUME_FACTORY_DIR"),
+		WaitForServiceModeRuntime: true,
+		Env: []string{
+			"HOME=" + os.Getenv("RSM7_RESUME_HOME"),
+			"USERPROFILE=" + os.Getenv("RSM7_RESUME_HOME"),
+		},
+		Args: []string{
+			"--record", os.Getenv("RSM7_RESUME_RECORDING"),
+		},
+		Edges: serviceedges.Edges{ProviderCommandRunner: runner},
+	})
+	if err := childControl.send(resumeFromRecordingChildMessage{
+		Type: "ready",
+		URL:  server.URL(),
+	}); err != nil {
+		t.Fatalf("announce predecessor readiness: %v", err)
+	}
+	select {}
 }
 
 type resumeFromRecordingScenario struct {
@@ -93,35 +128,247 @@ func newResumeFromRecordingScenario(t *testing.T) *resumeFromRecordingScenario {
 	}
 }
 
-func (scenario *resumeFromRecordingScenario) startProcess(
+func (scenario *resumeFromRecordingScenario) startFirstProcess(
 	t *testing.T,
-	name string,
+) *resumeFromRecordingChildProcess {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for predecessor control: %v", err)
+	}
+	process := &resumeFromRecordingChildProcess{
+		listener: listener,
+		messages: make(chan resumeFromRecordingChildMessage, 16),
+		waitDone: make(chan struct{}),
+	}
+	go process.acceptMessages()
+	command := exec.Command(
+		os.Args[0],
+		"-test.run=^TestResumeFromRecordingChildProcess$",
+		"-test.v",
+	)
+	command.Env = append(os.Environ(),
+		"RSM7_RESUME_CHILD=1",
+		"RSM7_RESUME_CONTROL="+listener.Addr().String(),
+		"RSM7_RESUME_FACTORY_DIR="+scenario.projectRoot,
+		"RSM7_RESUME_HOME="+scenario.home,
+		"RSM7_RESUME_RECORDING="+scenario.recordingPath,
+	)
+	command.Dir = scenario.projectRoot
+	var stdout, stderr syncBuffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Start(); err != nil {
+		_ = listener.Close()
+		t.Fatalf("start predecessor process: %v", err)
+	}
+	process.command = command
+	process.stdout = &stdout
+	process.stderr = &stderr
+	t.Cleanup(func() { process.stop(t) })
+	return process
+}
+
+func (scenario *resumeFromRecordingScenario) startSuccessorProcess(
+	t *testing.T,
 ) *support.FunctionalAPIServer {
 	t.Helper()
 	return support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:                scenario.projectRoot,
 		WaitForServiceModeRuntime: true,
 		Env:                       scenario.env,
-		Args:                      scenario.recordingArgs(name),
+		Args:                      []string{"--resume", scenario.recordingPath, "--record", scenario.successorPath},
 		Edges:                     serviceedges.Edges{ProviderCommandRunner: scenario.runner},
 	})
 }
 
-func (scenario *resumeFromRecordingScenario) recordingArgs(name string) []string {
-	if name == "successor" {
-		return []string{"--resume", scenario.recordingPath, "--record", scenario.successorPath}
-	}
-	return []string{"--record", scenario.recordingPath}
+type resumeFromRecordingChildMessage struct {
+	Type string `json:"type"`
+	URL  string `json:"url,omitempty"`
 }
 
-func (scenario *resumeFromRecordingScenario) awaitKillBoundary(t *testing.T) {
-	t.Helper()
-	scenario.runner.wait(t, scenario.runner.firstReturned, "first provider dispatch")
-	scenario.runner.wait(t, scenario.runner.secondEntered, "second provider dispatch")
-	if got := scenario.runner.CallCount(); got != 2 {
-		t.Fatalf("provider command calls at kill boundary = %d, want 2", got)
+type resumeFromRecordingChildControl struct {
+	connection net.Conn
+	encoder    *json.Encoder
+	mu         sync.Mutex
+}
+
+func newResumeFromRecordingChildControl(connection net.Conn) *resumeFromRecordingChildControl {
+	return &resumeFromRecordingChildControl{
+		connection: connection,
+		encoder:    json.NewEncoder(connection),
 	}
 }
+
+func (control *resumeFromRecordingChildControl) send(message resumeFromRecordingChildMessage) error {
+	control.mu.Lock()
+	defer control.mu.Unlock()
+	return control.encoder.Encode(message)
+}
+
+type resumeFromRecordingChildProcess struct {
+	listener net.Listener
+	command  *exec.Cmd
+	messages chan resumeFromRecordingChildMessage
+	waitDone chan struct{}
+	waitOnce sync.Once
+	waitErr  error
+	stdout   *syncBuffer
+	stderr   *syncBuffer
+}
+
+func (process *resumeFromRecordingChildProcess) acceptMessages() {
+	connection, err := process.listener.Accept()
+	if err != nil {
+		close(process.messages)
+		return
+	}
+	defer connection.Close()
+	decoder := json.NewDecoder(bufio.NewReader(connection))
+	for {
+		var message resumeFromRecordingChildMessage
+		if err := decoder.Decode(&message); err != nil {
+			break
+		}
+		process.messages <- message
+	}
+	close(process.messages)
+}
+
+func (process *resumeFromRecordingChildProcess) waitForReady(t *testing.T) string {
+	t.Helper()
+	message := process.waitFor(t, "ready")
+	if message.URL == "" {
+		t.Fatalf("predecessor readiness message has no URL")
+	}
+	return message.URL
+}
+
+func (process *resumeFromRecordingChildProcess) waitFor(t *testing.T, wantType string) resumeFromRecordingChildMessage {
+	t.Helper()
+	timer := time.NewTimer(resumeFromRecordingTimeout)
+	defer timer.Stop()
+	select {
+	case message, ok := <-process.messages:
+		if !ok {
+			t.Fatalf("predecessor exited before control message %q; stdout=%q stderr=%q", wantType, process.stdout.String(), process.stderr.String())
+		}
+		if message.Type != wantType {
+			t.Fatalf("predecessor control message = %q, want %q", message.Type, wantType)
+		}
+		return message
+	case <-timer.C:
+		t.Fatalf("predecessor did not send control message %q within %s; stdout=%q stderr=%q", wantType, resumeFromRecordingTimeout, process.stdout.String(), process.stderr.String())
+		return resumeFromRecordingChildMessage{}
+	}
+}
+
+func (process *resumeFromRecordingChildProcess) killAndJoin(t *testing.T) {
+	t.Helper()
+	if process.command.ProcessState == nil {
+		if err := process.command.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			t.Fatalf("kill predecessor process: %v", err)
+		}
+	}
+	if err := process.join(); err == nil {
+		t.Fatal("predecessor process exited cleanly after an explicit kill")
+	}
+}
+
+func (process *resumeFromRecordingChildProcess) stop(t testing.TB) {
+	t.Helper()
+	if process == nil || process.command == nil {
+		return
+	}
+	if process.command.ProcessState == nil {
+		if err := process.command.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			t.Errorf("kill predecessor process during cleanup: %v", err)
+		}
+	}
+	_ = process.join()
+	_ = process.listener.Close()
+}
+
+func (process *resumeFromRecordingChildProcess) join() error {
+	process.waitOnce.Do(func() {
+		process.waitErr = process.command.Wait()
+		close(process.waitDone)
+	})
+	<-process.waitDone
+	return process.waitErr
+}
+
+type syncBuffer struct {
+	mu   sync.Mutex
+	data []byte
+}
+
+func (buffer *syncBuffer) Write(data []byte) (int, error) {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	buffer.data = append(buffer.data, data...)
+	return len(data), nil
+}
+
+func (buffer *syncBuffer) String() string {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	return string(append([]byte(nil), buffer.data...))
+}
+
+type resumeFromRecordingChildCommandRunner struct {
+	delegate *support.ShapedProviderCommandRunner
+	control  *resumeFromRecordingChildControl
+
+	mu    sync.Mutex
+	calls int
+}
+
+func newResumeFromRecordingChildCommandRunner(
+	control *resumeFromRecordingChildControl,
+) *resumeFromRecordingChildCommandRunner {
+	return &resumeFromRecordingChildCommandRunner{
+		control: control,
+		delegate: support.NewShapedProviderCommandRunner(
+			platformprocess.CommandResult{Stdout: []byte("step-one COMPLETE")},
+			platformprocess.CommandResult{Stdout: []byte("step-two interrupted COMPLETE")},
+		),
+	}
+}
+
+func (runner *resumeFromRecordingChildCommandRunner) Run(
+	ctx context.Context,
+	request platformprocess.CommandRequest,
+) (platformprocess.CommandResult, error) {
+	runner.mu.Lock()
+	runner.calls++
+	call := runner.calls
+	runner.mu.Unlock()
+
+	result, err := runner.delegate.Run(ctx, request)
+	if err != nil {
+		return result, err
+	}
+	switch call {
+	case 1:
+		if err := runner.control.send(resumeFromRecordingChildMessage{Type: "first-returned"}); err != nil {
+			return platformprocess.CommandResult{}, err
+		}
+		return result, nil
+	case 2:
+		if err := runner.control.send(resumeFromRecordingChildMessage{Type: "second-entered"}); err != nil {
+			return platformprocess.CommandResult{}, err
+		}
+		select {
+		case <-ctx.Done():
+			return platformprocess.CommandResult{}, ctx.Err()
+		}
+	default:
+		return result, nil
+	}
+}
+
+var _ platformprocess.CommandRunner = (*resumeFromRecordingChildCommandRunner)(nil)
 
 func (scenario *resumeFromRecordingScenario) captureAtKillBoundary(
 	t *testing.T,
@@ -500,9 +747,6 @@ type resumeFromRecordingCommandRunner struct {
 
 	mu                  sync.Mutex
 	calls               int
-	firstReturned       chan struct{}
-	secondEntered       chan struct{}
-	secondCanceled      chan struct{}
 	thirdEntered        chan struct{}
 	releaseRemaining    chan struct{}
 	releaseRemainingOne sync.Once
@@ -511,13 +755,9 @@ type resumeFromRecordingCommandRunner struct {
 func newResumeFromRecordingCommandRunner() *resumeFromRecordingCommandRunner {
 	return &resumeFromRecordingCommandRunner{
 		delegate: support.NewShapedProviderCommandRunner(
-			platformprocess.CommandResult{Stdout: []byte("step-one COMPLETE")},
-			platformprocess.CommandResult{Stdout: []byte("step-two interrupted COMPLETE")},
 			platformprocess.CommandResult{Stdout: []byte("step-two resumed COMPLETE")},
 		),
-		firstReturned:    make(chan struct{}),
-		secondEntered:    make(chan struct{}),
-		secondCanceled:   make(chan struct{}),
+		calls:            2,
 		thirdEntered:     make(chan struct{}),
 		releaseRemaining: make(chan struct{}),
 	}
@@ -537,18 +777,6 @@ func (runner *resumeFromRecordingCommandRunner) Run(
 		return result, err
 	}
 	switch call {
-	case 1:
-		close(runner.firstReturned)
-		return result, nil
-	case 2:
-		close(runner.secondEntered)
-		select {
-		case <-ctx.Done():
-			close(runner.secondCanceled)
-			return platformprocess.CommandResult{}, ctx.Err()
-		case <-runner.releaseRemaining:
-			return result, nil
-		}
 	case 3:
 		close(runner.thirdEntered)
 		select {

--- a/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
+++ b/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
@@ -447,8 +447,8 @@ func (scenario *resumeFromRecordingScenario) captureAtKillBoundary(
 		t.Fatalf("pre-kill Work location = %q, want task:processing", got)
 	}
 	session := support.GetDefaultSession(t, baseURL)
-	if session.Runtime.Progress.Categories.Initial != 0 || session.Runtime.Progress.Categories.Processing != 1 {
-		t.Fatalf("pre-kill board progress = %+v, want one processing Work", session.Runtime.Progress.Categories)
+	if session.Runtime.Progress.Categories.Initial != 0 || session.Runtime.Progress.InFlightCount != 1 {
+		t.Fatalf("pre-kill board progress = %+v, in-flight=%d; want one in-flight processing Work", session.Runtime.Progress.Categories, session.Runtime.Progress.InFlightCount)
 	}
 	events := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "before restart", events)
@@ -476,8 +476,8 @@ func (scenario *resumeFromRecordingScenario) assertRestored(
 		t.Fatalf("post-restart Work location = %q, want restored task:processing", got)
 	}
 	session := support.GetDefaultSession(t, baseURL)
-	if session.Runtime.Progress.Categories.Initial != 0 || session.Runtime.Progress.Categories.Processing != 1 {
-		t.Fatalf("post-restart board progress = %+v, want one restored processing Work", session.Runtime.Progress.Categories)
+	if session.Runtime.Progress.Categories.Initial != 0 || session.Runtime.Progress.InFlightCount != 1 {
+		t.Fatalf("post-restart board progress = %+v, in-flight=%d; want one restored in-flight processing Work", session.Runtime.Progress.Categories, session.Runtime.Progress.InFlightCount)
 	}
 	restartedEvents := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "after restart", restartedEvents)

--- a/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
+++ b/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
@@ -115,9 +115,11 @@ type resumeFromRecordingScenario struct {
 }
 
 type resumeFromRecordingBoundary struct {
-	work        factoryapi.Work
-	completedID string
-	events      []factoryapi.FactoryEvent
+	work                 factoryapi.Work
+	completedDispatchID  string
+	completedEventID     string
+	completedEventCursor support.FactoryEventReadCursor
+	events               []factoryapi.FactoryEvent
 }
 
 func newResumeFromRecordingScenario(t *testing.T) *resumeFromRecordingScenario {
@@ -452,11 +454,17 @@ func (scenario *resumeFromRecordingScenario) captureAtKillBoundary(
 	}
 	events := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "before restart", events)
-	completedID := requireResumeFromRecordingCompletedDispatchID(t, events)
+	completedEvent := requireResumeFromRecordingCompletedEvent(t, events)
+	completedSequence := support.ReconnectSequenceForFactoryEvent(completedEvent)
 	return resumeFromRecordingBoundary{
-		work:        work,
-		completedID: completedID,
-		events:      events,
+		work:                work,
+		completedDispatchID: support.StringPointerValue(completedEvent.Context.DispatchId),
+		completedEventID:    completedEvent.Id,
+		completedEventCursor: support.FactoryEventReadCursor{
+			AfterEventID:  completedEvent.Id,
+			AfterSequence: &completedSequence,
+		},
+		events: events,
 	}
 }
 
@@ -481,9 +489,10 @@ func (scenario *resumeFromRecordingScenario) assertRestored(
 	}
 	restartedEvents := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "after restart", restartedEvents)
-	assertResumeFromRecordingSuccessorEvents(t, boundary.events, restartedEvents)
-	if got := countResumeFromRecordingDispatchEvents(restartedEvents, factoryapi.FactoryEventTypeDispatchResponse, boundary.completedID); got != 0 {
-		t.Fatalf("completed dispatch response events after restart = %d, want no re-execution", got)
+	assertResumeFromRecordingSuccessorEvents(t, boundary.events, restartedEvents, boundary)
+	assertResumeFromRecordingCursorSuffix(t, baseURL, boundary, restartedEvents)
+	if got := countResumeFromRecordingDispatchEvents(restartedEvents, factoryapi.FactoryEventTypeDispatchResponse, boundary.completedDispatchID); got != 1 {
+		t.Fatalf("completed dispatch response events after restart = %d, want the one preserved completion and no re-execution", got)
 	}
 }
 
@@ -494,6 +503,18 @@ func (scenario *resumeFromRecordingScenario) resumeAndFinish(
 ) {
 	t.Helper()
 	scenario.runner.ReleaseRemainingDispatch()
+	terminalStatus := support.WaitForSessionTerminalStatus(
+		t, baseURL, factorysessions.DefaultSessionID, resumeFromRecordingTimeout,
+	)
+	if terminalStatus.RuntimeStatus != string(factoryapi.FactorySessionStatusIDLE) &&
+		terminalStatus.RuntimeStatus != string(factoryapi.FactorySessionStatusFINISHED) {
+		t.Fatalf("post-resume public session runtime status = %q, want IDLE or FINISHED", terminalStatus.RuntimeStatus)
+	}
+	terminalSession := support.GetDefaultSession(t, baseURL)
+	if terminalSession.Runtime.Status != factoryapi.FactorySessionStatusIDLE &&
+		terminalSession.Runtime.Status != factoryapi.FactorySessionStatusFINISHED {
+		t.Fatalf("post-resume Factory Session runtime = %#v, want terminal IDLE or FINISHED", terminalSession.Runtime)
+	}
 	finalWork := waitForResumeFromRecordingWorkState(t, baseURL, scenario.workID, "complete")
 	if got := support.CountWorkAtCustomerState(finalWork, support.WorkCustomerLocation("task", "complete")); got != 1 {
 		t.Fatalf("post-resume completed Work count = %d, want 1; listed=%#v", got, finalWork.Results)
@@ -507,9 +528,10 @@ func (scenario *resumeFromRecordingScenario) resumeAndFinish(
 	}
 	finalEvents := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "after resume", finalEvents)
-	assertResumeFromRecordingSuccessorEvents(t, boundary.events, finalEvents)
-	if got := countResumeFromRecordingDispatchEvents(finalEvents, factoryapi.FactoryEventTypeDispatchResponse, boundary.completedID); got != 0 {
-		t.Fatalf("completed dispatch response events after resume = %d, want no re-execution", got)
+	assertResumeFromRecordingSuccessorEvents(t, boundary.events, finalEvents, boundary)
+	assertResumeFromRecordingCursorSuffix(t, baseURL, boundary, finalEvents)
+	if got := countResumeFromRecordingDispatchEvents(finalEvents, factoryapi.FactoryEventTypeDispatchResponse, boundary.completedDispatchID); got != 1 {
+		t.Fatalf("completed dispatch response events after resume = %d, want the one preserved completion and no re-execution", got)
 	}
 }
 
@@ -517,34 +539,82 @@ func assertResumeFromRecordingSuccessorEvents(
 	t *testing.T,
 	predecessor []factoryapi.FactoryEvent,
 	successor []factoryapi.FactoryEvent,
+	boundary resumeFromRecordingBoundary,
 ) {
 	t.Helper()
-	predecessorIDs := make(map[string]struct{}, len(predecessor))
-	for _, event := range predecessor {
-		if !isResumeFromRecordingLifecycleEvent(event.Type) {
-			predecessorIDs[event.Id] = struct{}{}
+	if len(successor) < len(predecessor) {
+		t.Fatalf("successor Factory Event history has %d events, want at least predecessor length %d", len(successor), len(predecessor))
+	}
+	for index, expected := range predecessor {
+		actual := successor[index]
+		if actual.Id != expected.Id || actual.Type != expected.Type || actual.Context.Sequence != expected.Context.Sequence ||
+			support.ReconnectSequenceForFactoryEvent(actual) != support.ReconnectSequenceForFactoryEvent(expected) {
+			t.Fatalf("successor Factory Event prefix[%d] = %#v, want predecessor %#v", index, actual, expected)
 		}
 	}
-	for _, event := range successor {
-		if isResumeFromRecordingLifecycleEvent(event.Type) {
-			continue
+	cursorIndex := indexResumeFromRecordingEvent(predecessor, boundary.completedEventID)
+	if cursorIndex < 0 {
+		t.Fatal("predecessor Factory Event history has no acknowledged completion event")
+	}
+	combined := append([]factoryapi.FactoryEvent(nil), predecessor[:cursorIndex+1]...)
+	combined = append(combined, successor[cursorIndex+1:]...)
+	assertResumeFromRecordingFactoryEvents(t, "across restart", combined)
+}
+
+func assertResumeFromRecordingCursorSuffix(
+	t *testing.T,
+	baseURL string,
+	boundary resumeFromRecordingBoundary,
+	successor []factoryapi.FactoryEvent,
+) {
+	t.Helper()
+	cursorIndex := indexResumeFromRecordingEvent(successor, boundary.completedEventID)
+	if cursorIndex < 0 {
+		t.Fatalf("successor Factory Event history has no acknowledged event %q", boundary.completedEventID)
+	}
+	want := successor[cursorIndex+1:]
+	byID := support.GetFactoryEventsAfterForSessionAt(
+		t, baseURL, factorysessions.DefaultSessionID,
+		support.FactoryEventReadCursor{AfterEventID: boundary.completedEventID},
+	)
+	assertResumeFromRecordingCursorEvents(t, "after_event_id", boundary.completedEventID, want, byID)
+	bySequence := support.GetFactoryEventsAfterForSessionAt(
+		t, baseURL, factorysessions.DefaultSessionID,
+		support.FactoryEventReadCursor{AfterSequence: boundary.completedEventCursor.AfterSequence},
+	)
+	assertResumeFromRecordingCursorEvents(t, "after_sequence", boundary.completedEventID, want, bySequence)
+}
+
+func assertResumeFromRecordingCursorEvents(
+	t *testing.T,
+	cursorKind string,
+	acknowledgedID string,
+	want []factoryapi.FactoryEvent,
+	got []factoryapi.FactoryEvent,
+) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("Factory Event %s suffix length = %d, want %d", cursorKind, len(got), len(want))
+	}
+	for index, expected := range want {
+		actual := got[index]
+		if actual.Id == acknowledgedID {
+			t.Fatalf("Factory Event %s suffix redelivered acknowledged event %q", cursorKind, acknowledgedID)
 		}
-		if _, exists := predecessorIDs[event.Id]; exists {
-			t.Fatalf("successor Factory Event %q duplicated a predecessor domain event", event.Id)
+		if actual.Id != expected.Id || actual.Type != expected.Type || actual.Context.Sequence != expected.Context.Sequence ||
+			support.ReconnectSequenceForFactoryEvent(actual) != support.ReconnectSequenceForFactoryEvent(expected) {
+			t.Fatalf("Factory Event %s suffix[%d] = %#v, want %#v", cursorKind, index, actual, expected)
 		}
 	}
 }
 
-func isResumeFromRecordingLifecycleEvent(eventType factoryapi.FactoryEventType) bool {
-	switch eventType {
-	case factoryapi.FactoryEventTypeRunRequest,
-		factoryapi.FactoryEventTypeInitialStructureRequest,
-		factoryapi.FactoryEventTypeSessionStarted,
-		factoryapi.FactoryEventTypeFactoryStateResponse:
-		return true
-	default:
-		return false
+func indexResumeFromRecordingEvent(events []factoryapi.FactoryEvent, eventID string) int {
+	for index, event := range events {
+		if event.Id == eventID {
+			return index
+		}
 	}
+	return -1
 }
 
 func assertResumeFromRecordingFactoryEvents(t *testing.T, phase string, events []factoryapi.FactoryEvent) {
@@ -708,21 +778,29 @@ func waitForResumeFromRecordingWorkState(
 	return listed
 }
 
-func requireResumeFromRecordingCompletedDispatchID(
+func requireResumeFromRecordingCompletedEvent(
 	t *testing.T,
 	events []factoryapi.FactoryEvent,
-) string {
+) factoryapi.FactoryEvent {
 	t.Helper()
+	for _, event := range events {
+		if event.Type == factoryapi.FactoryEventTypeDispatchReconciled {
+			payload, err := event.Payload.AsDispatchReconciledEventPayload()
+			if err == nil && payload.ReconciledStatus == factoryapi.FactoryDispatchStatusCOMPLETED {
+				return event
+			}
+		}
+	}
 	for _, event := range events {
 		if event.Type != factoryapi.FactoryEventTypeDispatchResponse {
 			continue
 		}
 		if dispatchID := support.StringPointerValue(event.Context.DispatchId); dispatchID != "" {
-			return dispatchID
+			return event
 		}
 	}
-	t.Fatal("public Factory Events contain no completed dispatch response")
-	return ""
+	t.Fatal("public Factory Events contain no completed dispatch event")
+	return factoryapi.FactoryEvent{}
 }
 
 func countResumeFromRecordingDispatchEvents(

--- a/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
+++ b/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
@@ -75,7 +75,6 @@ type resumeFromRecordingScenario struct {
 
 type resumeFromRecordingBoundary struct {
 	work        factoryapi.Work
-	board       factoryapi.StatusResponse
 	completedID string
 	events      []factoryapi.FactoryEvent
 	cursor      factoryapi.FactoryEvent
@@ -134,15 +133,12 @@ func (scenario *resumeFromRecordingScenario) captureAtKillBoundary(
 	if got := support.WorkItemCustomerLocation(work); got != support.WorkCustomerLocation("task", "processing") {
 		t.Fatalf("pre-kill Work location = %q, want task:processing", got)
 	}
-	board := support.WaitForStatus(t, baseURL, resumeFromRecordingTimeout, func(status factoryapi.StatusResponse) bool {
-		return status.Categories.Initial == 0 && status.Categories.Processing == 1
-	})
 	events := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "before restart", events)
+	requireResumeFromRecordingWorkStateEvent(t, events, scenario.workID, "processing")
 	completedID := requireResumeFromRecordingCompletedDispatchID(t, events)
 	return resumeFromRecordingBoundary{
 		work:        work,
-		board:       board,
 		completedID: completedID,
 		events:      events,
 		cursor:      requireResumeFromRecordingFactoryEvent(t, events, factoryapi.FactoryEventTypeDispatchReconciled, completedID),
@@ -164,15 +160,10 @@ func (scenario *resumeFromRecordingScenario) assertRestored(
 	if got := support.WorkItemCustomerLocation(work); got != support.WorkCustomerLocation("task", "processing") {
 		t.Fatalf("post-restart Work location = %q, want restored task:processing", got)
 	}
-	board := support.WaitForStatus(t, baseURL, resumeFromRecordingTimeout, func(status factoryapi.StatusResponse) bool {
-		return status.Categories.Initial == 0 && status.Categories.Processing == 1
-	})
-	if board.Categories.Terminal != boundary.board.Categories.Terminal || board.Categories.Failed != boundary.board.Categories.Failed {
-		t.Fatalf("post-restart board terminal/failed counts = %+v, want preserved boundary counts %+v", board.Categories, boundary.board.Categories)
-	}
 	restartedEvents := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "after restart", restartedEvents)
 	assertResumeFromRecordingFactoryEventIDsPresent(t, boundary.events, restartedEvents)
+	requireResumeFromRecordingWorkStateEvent(t, restartedEvents, scenario.workID, "processing")
 	support.AssertSingleWorkRequestEvent(t, restartedEvents, scenario.requestID, scenario.workID, "task")
 	if got := countResumeFromRecordingDispatchEvents(restartedEvents, factoryapi.FactoryEventTypeDispatchReconciled, boundary.completedID); got != 1 {
 		t.Fatalf("completed dispatch reconciled events after restart = %d, want 1", got)
@@ -186,16 +177,13 @@ func (scenario *resumeFromRecordingScenario) resumeAndFinish(
 ) {
 	t.Helper()
 	scenario.runner.ReleaseRemainingDispatch()
-	finished := support.WaitForTerminalStatus(t, baseURL, resumeFromRecordingTimeout)
-	finalWork := support.ListDefaultSessionWork(t, baseURL)
+	finalWork := waitForResumeFromRecordingWorkState(t, baseURL, scenario.workID, "complete")
 	if got := support.CountWorkAtCustomerState(finalWork, support.WorkCustomerLocation("task", "complete")); got != 1 {
 		t.Fatalf("post-resume completed Work count = %d, want 1; listed=%#v", got, finalWork.Results)
 	}
-	if got := support.CountWorkAtCustomerState(finalWork, support.WorkCustomerLocation("task", "processing")); got != 0 {
-		t.Fatalf("post-resume processing Work count = %d, want 0", got)
-	}
-	if finished.Categories.Terminal != 1 || finished.Categories.Processing != 0 || finished.Categories.Failed != 0 {
-		t.Fatalf("post-resume board progress = %+v, want one terminal Work and no failed/processing Work", finished.Categories)
+	completedWork := requireResumeFromRecordingWork(t, finalWork, scenario.workID)
+	if got := support.WorkItemCustomerLocation(completedWork); got != support.WorkCustomerLocation("task", "complete") {
+		t.Fatalf("post-resume Work location = %q, want task:complete", got)
 	}
 	if got := scenario.runner.CallCount(); got != 3 {
 		t.Fatalf("provider command calls after resume = %d, want exactly 3", got)
@@ -203,6 +191,7 @@ func (scenario *resumeFromRecordingScenario) resumeAndFinish(
 	finalEvents := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "after resume", finalEvents)
 	assertResumeFromRecordingFactoryEventIDsPresent(t, boundary.events, finalEvents)
+	requireResumeFromRecordingWorkStateEvent(t, finalEvents, scenario.workID, "complete")
 	support.AssertSingleWorkRequestEvent(t, finalEvents, scenario.requestID, scenario.workID, "task")
 	if got := countResumeFromRecordingDispatchEvents(finalEvents, factoryapi.FactoryEventTypeDispatchReconciled, boundary.completedID); got != 1 {
 		t.Fatalf("completed dispatch reconciled events after resume = %d, want 1", got)
@@ -442,6 +431,58 @@ func requireResumeFromRecordingWork(
 	}
 	t.Fatalf("public Work listing is missing %q: %#v", workID, listed.Results)
 	return factoryapi.Work{}
+}
+
+// waitForResumeFromRecordingWorkState waits on the committed public Work
+// projection after a provider release. The runner signal proves the provider
+// boundary; this bounded read is still needed because Work projection writes
+// are committed asynchronously after the runtime event is emitted.
+func waitForResumeFromRecordingWorkState(
+	t *testing.T,
+	baseURL, workID, state string,
+) factoryapi.ListWorkResponse {
+	t.Helper()
+	wantLocation := support.WorkCustomerLocation("task", state)
+	listed, err := support.WaitForObservation(
+		resumeFromRecordingTimeout,
+		func() (factoryapi.ListWorkResponse, error) {
+			return support.ListDefaultSessionWork(t, baseURL), nil
+		},
+		func(listed factoryapi.ListWorkResponse) bool {
+			for _, work := range listed.Results {
+				if support.StringPointerValue(work.WorkId) == workID && support.WorkItemCustomerLocation(work) == wantLocation {
+					return true
+				}
+			}
+			return false
+		},
+	)
+	if err != nil {
+		t.Fatalf("wait for Work %q at %s: %v", workID, wantLocation, err)
+	}
+	return listed
+}
+
+func requireResumeFromRecordingWorkStateEvent(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+	workID, state string,
+) factoryapi.FactoryEvent {
+	t.Helper()
+	for _, event := range events {
+		if event.Type != factoryapi.FactoryEventTypeWorkStateChange {
+			continue
+		}
+		payload, err := event.Payload.AsWorkStateChangeEventPayload()
+		if err != nil {
+			t.Fatalf("decode WORK_STATE_CHANGE event %q: %v", event.Id, err)
+		}
+		if payload.WorkId == workID && payload.ToState == state {
+			return event
+		}
+	}
+	t.Fatalf("public Factory Events contain no WORK_STATE_CHANGE for Work %q to %s", workID, state)
+	return factoryapi.FactoryEvent{}
 }
 
 func requireResumeFromRecordingCompletedDispatchID(

--- a/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
+++ b/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
@@ -140,7 +140,7 @@ func (scenario *resumeFromRecordingScenario) captureAtKillBoundary(
 		work:        work,
 		completedID: completedID,
 		events:      events,
-		cursor:      requireResumeFromRecordingFactoryEvent(t, events, factoryapi.FactoryEventTypeDispatchReconciled, completedID),
+		cursor:      requireResumeFromRecordingFactoryEvent(t, events, factoryapi.FactoryEventTypeDispatchResponse, completedID),
 	}
 }
 
@@ -163,8 +163,8 @@ func (scenario *resumeFromRecordingScenario) assertRestored(
 	assertResumeFromRecordingFactoryEvents(t, "after restart", restartedEvents)
 	assertResumeFromRecordingFactoryEventIDsPresent(t, boundary.events, restartedEvents)
 	support.AssertSingleWorkRequestEvent(t, restartedEvents, scenario.requestID, scenario.workID, "task")
-	if got := countResumeFromRecordingDispatchEvents(restartedEvents, factoryapi.FactoryEventTypeDispatchReconciled, boundary.completedID); got != 1 {
-		t.Fatalf("completed dispatch reconciled events after restart = %d, want 1", got)
+	if got := countResumeFromRecordingDispatchEvents(restartedEvents, factoryapi.FactoryEventTypeDispatchResponse, boundary.completedID); got != 1 {
+		t.Fatalf("completed dispatch response events after restart = %d, want 1", got)
 	}
 }
 
@@ -190,8 +190,8 @@ func (scenario *resumeFromRecordingScenario) resumeAndFinish(
 	assertResumeFromRecordingFactoryEvents(t, "after resume", finalEvents)
 	assertResumeFromRecordingFactoryEventIDsPresent(t, boundary.events, finalEvents)
 	support.AssertSingleWorkRequestEvent(t, finalEvents, scenario.requestID, scenario.workID, "task")
-	if got := countResumeFromRecordingDispatchEvents(finalEvents, factoryapi.FactoryEventTypeDispatchReconciled, boundary.completedID); got != 1 {
-		t.Fatalf("completed dispatch reconciled events after resume = %d, want 1", got)
+	if got := countResumeFromRecordingDispatchEvents(finalEvents, factoryapi.FactoryEventTypeDispatchResponse, boundary.completedID); got != 1 {
+		t.Fatalf("completed dispatch response events after resume = %d, want 1", got)
 	}
 	assertResumeFromRecordingFactoryCursorReplay(t, baseURL, scenario, boundary, finalEvents)
 }
@@ -466,14 +466,14 @@ func requireResumeFromRecordingCompletedDispatchID(
 ) string {
 	t.Helper()
 	for _, event := range events {
-		if event.Type != factoryapi.FactoryEventTypeDispatchReconciled {
+		if event.Type != factoryapi.FactoryEventTypeDispatchResponse {
 			continue
 		}
 		if dispatchID := support.StringPointerValue(event.Context.DispatchId); dispatchID != "" {
 			return dispatchID
 		}
 	}
-	t.Fatal("public Factory Events contain no completed dispatch reconciliation")
+	t.Fatal("public Factory Events contain no completed dispatch response")
 	return ""
 }
 

--- a/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
+++ b/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
@@ -481,7 +481,11 @@ func requireResumeFromRecordingWorkStateEvent(
 			return event
 		}
 	}
-	t.Fatalf("public Factory Events contain no WORK_STATE_CHANGE for Work %q to %s", workID, state)
+	types := make([]factoryapi.FactoryEventType, 0, len(events))
+	for _, event := range events {
+		types = append(types, event.Type)
+	}
+	t.Fatalf("public Factory Events contain no WORK_STATE_CHANGE for Work %q to %s; types=%#v", workID, state, types)
 	return factoryapi.FactoryEvent{}
 }
 

--- a/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
+++ b/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
@@ -1,13 +1,8 @@
 package resume_from_recording_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"sync"
@@ -16,44 +11,51 @@ import (
 
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
 const (
-	resumeFromRecordingWorkflowName = "resume-from-recording-two-step"
-	resumeFromRecordingTimeout      = 15 * time.Second
+	resumeFromRecordingTimeout = 15 * time.Second
 )
 
 // TestKilledFactorySessionResumesOriginalDispatchesAfterRestart proves that a
-// durable multi-dispatch session can be interrupted at a deterministic
-// provider boundary, observed after a fresh public process lifetime, and
-// resumed without re-admitting the session or repeating its completed child.
-// The command runner is installed through edges.Edges so the scenario still
-// crosses the real Workers, Factory Runtime, and Factory Sessions paths.
+// real two-stage Work item survives a process boundary through the public
+// recording resume surface. The command runner is installed through
+// edges.Edges, so the scenario still crosses the real Workers, Factory Runtime,
+// Factory Sessions, Work, and Recordings paths.
 func TestKilledFactorySessionResumesOriginalDispatchesAfterRestart(t *testing.T) {
 	t.Parallel()
 
 	scenario := newResumeFromRecordingScenario(t)
 	t.Cleanup(scenario.runner.ReleaseRemainingDispatch)
 	first := scenario.startProcess(t, "first")
-	started := startResumeFromRecordingSession(t, first.URL())
-	if started.SessionId == "" {
-		t.Fatal("durable session start returned an empty session id")
+	submitted := support.SubmitDefaultSessionWork(t, first.URL(), factoryapi.SubmitWorkRequest{
+		Name:         stringPointer("resume-from-recording-work"),
+		Payload:      map[string]any{"subject": "resume-from-recording"},
+		WorkTypeName: "task",
+	})
+	if submitted.Accepted != true || submitted.WorkId == nil || *submitted.WorkId == "" {
+		t.Fatalf("public Work submission = %#v, want one accepted Work identity", submitted)
 	}
-	scenario.sessionID = started.SessionId
+	scenario.workID = *submitted.WorkId
+	scenario.requestID = submitted.RequestId
 	scenario.awaitKillBoundary(t)
-	boundary := scenario.interruptAndCapture(t, first.URL())
+	boundary := scenario.captureAtKillBoundary(t, first.URL())
 
 	// Stop joins the first root-built process before the replacement is
-	// constructed. The interrupted durable session is the public recovery
-	// handle; this test never edits or finalizes its persisted state.
+	// constructed. The recording is left naturally unfinalized by cancellation;
+	// this test never edits or finalizes its persisted state.
 	first.Stop(t)
 	select {
 	case <-first.Done():
 	default:
 		t.Fatal("first process stop returned before its command joined")
 	}
+	scenario.runner.wait(t, scenario.runner.secondCanceled, "canceled second provider dispatch")
+	assertResumeFromRecordingUnfinalizedRecording(t, scenario.recordingPath)
 
 	second := scenario.startProcess(t, "successor")
 	scenario.assertRestored(t, second.URL(), boundary)
@@ -61,16 +63,20 @@ func TestKilledFactorySessionResumesOriginalDispatchesAfterRestart(t *testing.T)
 }
 
 type resumeFromRecordingScenario struct {
-	projectRoot string
-	home        string
-	env         []string
-	sessionID   string
-	runner      *resumeFromRecordingCommandRunner
+	projectRoot   string
+	home          string
+	env           []string
+	recordingPath string
+	successorPath string
+	workID        string
+	requestID     string
+	runner        *resumeFromRecordingCommandRunner
 }
 
 type resumeFromRecordingBoundary struct {
-	completed   factoryapi.FactorySessionDispatchSummary
-	interrupted factoryapi.FactorySessionDispatchSummary
+	work        factoryapi.Work
+	session     factoryapi.FactorySession
+	completedID string
 	events      []factoryapi.FactoryEvent
 	cursor      factoryapi.FactoryEvent
 }
@@ -79,10 +85,12 @@ func newResumeFromRecordingScenario(t *testing.T) *resumeFromRecordingScenario {
 	t.Helper()
 	home := t.TempDir()
 	return &resumeFromRecordingScenario{
-		projectRoot: setupResumeFromRecordingFixture(t),
-		home:        home,
-		env:         []string{"HOME=" + home, "USERPROFILE=" + home},
-		runner:      newResumeFromRecordingCommandRunner(),
+		projectRoot:   setupResumeFromRecordingFixture(t),
+		home:          home,
+		env:           []string{"HOME=" + home, "USERPROFILE=" + home},
+		recordingPath: filepath.Join(home, "killed.recording.json"),
+		successorPath: filepath.Join(home, "resumed.recording.json"),
+		runner:        newResumeFromRecordingCommandRunner(),
 	}
 }
 
@@ -95,9 +103,16 @@ func (scenario *resumeFromRecordingScenario) startProcess(
 		FactoryDir:                scenario.projectRoot,
 		WaitForServiceModeRuntime: true,
 		Env:                       scenario.env,
-		Args:                      []string{"--record", filepath.Join(scenario.home, name+".recording.json")},
+		Args:                      scenario.recordingArgs(name),
 		Edges:                     serviceedges.Edges{ProviderCommandRunner: scenario.runner},
 	})
+}
+
+func (scenario *resumeFromRecordingScenario) recordingArgs(name string) []string {
+	if name == "successor" {
+		return []string{"--resume", scenario.recordingPath, "--record", scenario.successorPath}
+	}
+	return []string{"--record", scenario.recordingPath}
 }
 
 func (scenario *resumeFromRecordingScenario) awaitKillBoundary(t *testing.T) {
@@ -109,34 +124,29 @@ func (scenario *resumeFromRecordingScenario) awaitKillBoundary(t *testing.T) {
 	}
 }
 
-func (scenario *resumeFromRecordingScenario) interruptAndCapture(
+func (scenario *resumeFromRecordingScenario) captureAtKillBoundary(
 	t *testing.T,
 	baseURL string,
 ) resumeFromRecordingBoundary {
 	t.Helper()
-	interruptResumeFromRecordingDispatch(t, baseURL, scenario.sessionID)
-	scenario.runner.wait(t, scenario.runner.secondCanceled, "canceled second provider dispatch")
-	beforeRestart := waitForResumeFromRecordingSession(t, baseURL, scenario.sessionID, func(session factoryapi.FactorySessionDurableReadModel) bool {
-		return session.Status == factoryapi.FactorySessionDurableLifecycleStatusInterrupted
-	})
-	if beforeRestart.Progress == nil || valueOrZero(beforeRestart.Progress.CompletedDispatches) != 1 {
-		t.Fatalf("pre-restart progress = %#v, want one completed dispatch", beforeRestart.Progress)
+	listed := support.ListDefaultSessionWork(t, baseURL)
+	work := requireResumeFromRecordingWork(t, listed, scenario.workID)
+	if got := support.WorkItemCustomerLocation(work); got != support.WorkCustomerLocation("task", "processing") {
+		t.Fatalf("pre-kill Work location = %q, want task:processing", got)
 	}
-	listed := listResumeFromRecordingDispatches(t, baseURL, scenario.sessionID)
-	events := support.GetFactoryEventsForSessionAt(t, baseURL, scenario.sessionID)
+	session := support.GetDefaultSession(t, baseURL)
+	if session.Runtime.Progress.Categories.Initial != 0 || session.Runtime.Progress.Categories.Processing != 1 {
+		t.Fatalf("pre-kill board progress = %+v, want one processing Work", session.Runtime.Progress.Categories)
+	}
+	events := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "before restart", events)
+	completedID := requireResumeFromRecordingCompletedDispatchID(t, events)
 	return resumeFromRecordingBoundary{
-		completed: requireResumeFromRecordingDispatch(t, listed, "dispatch-1", factoryapi.FactoryDispatchStatusCOMPLETED),
-		interrupted: requireResumeFromRecordingDispatch(
-			t, listed, "dispatch-2", factoryapi.FactoryDispatchStatusINTERRUPTED, factoryapi.FactoryDispatchStatusRUNNING,
-		),
-		events: events,
-		cursor: requireResumeFromRecordingFactoryEvent(
-			t,
-			events,
-			factoryapi.FactoryEventTypeDispatchReconciled,
-			"dispatch-1",
-		),
+		work:        work,
+		session:     session,
+		completedID: completedID,
+		events:      events,
+		cursor:      requireResumeFromRecordingFactoryEvent(t, events, factoryapi.FactoryEventTypeDispatchReconciled, completedID),
 	}
 }
 
@@ -146,24 +156,26 @@ func (scenario *resumeFromRecordingScenario) assertRestored(
 	boundary resumeFromRecordingBoundary,
 ) {
 	t.Helper()
-	read := waitForResumeFromRecordingSession(t, baseURL, scenario.sessionID, func(session factoryapi.FactorySessionDurableReadModel) bool {
-		return session.Status == factoryapi.FactorySessionDurableLifecycleStatusInterrupted
-	})
-	if read.SessionId != scenario.sessionID {
-		t.Fatalf("post-restart session id = %q, want %q", read.SessionId, scenario.sessionID)
+	scenario.runner.wait(t, scenario.runner.thirdEntered, "resumed second provider dispatch")
+	listed := support.ListDefaultSessionWork(t, baseURL)
+	work := requireResumeFromRecordingWork(t, listed, scenario.workID)
+	if work.Name != boundary.work.Name || support.StringPointerValue(work.WorkId) != support.StringPointerValue(boundary.work.WorkId) {
+		t.Fatalf("post-restart Work identity changed: %#v -> %#v", boundary.work, work)
 	}
-	if read.Progress == nil || valueOrZero(read.Progress.CompletedDispatches) != 1 {
-		t.Fatalf("post-restart progress = %#v, want restored one completed dispatch", read.Progress)
+	if got := support.WorkItemCustomerLocation(work); got != support.WorkCustomerLocation("task", "processing") {
+		t.Fatalf("post-restart Work location = %q, want restored task:processing", got)
 	}
-	listed := listResumeFromRecordingDispatches(t, baseURL, scenario.sessionID)
-	completed := requireResumeFromRecordingDispatch(t, listed, "dispatch-1", factoryapi.FactoryDispatchStatusCOMPLETED)
-	interrupted := requireResumeFromRecordingDispatch(t, listed, "dispatch-2", factoryapi.FactoryDispatchStatusINTERRUPTED, factoryapi.FactoryDispatchStatusRUNNING)
-	if completed.Id != boundary.completed.Id || interrupted.Id != boundary.interrupted.Id {
-		t.Fatalf("dispatch identities changed across restart: completed %q/%q, interrupted %q/%q", boundary.completed.Id, completed.Id, boundary.interrupted.Id, interrupted.Id)
+	session := support.GetDefaultSession(t, baseURL)
+	if session.Runtime.Progress.Categories.Initial != 0 || session.Runtime.Progress.Categories.Processing != 1 {
+		t.Fatalf("post-restart board progress = %+v, want restored one processing Work", session.Runtime.Progress.Categories)
 	}
-	restartedEvents := support.GetFactoryEventsForSessionAt(t, baseURL, scenario.sessionID)
+	restartedEvents := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "after restart", restartedEvents)
 	assertResumeFromRecordingFactoryEventIDsPresent(t, boundary.events, restartedEvents)
+	support.AssertSingleWorkRequestEvent(t, restartedEvents, scenario.requestID, scenario.workID, "task")
+	if got := countResumeFromRecordingDispatchEvents(restartedEvents, factoryapi.FactoryEventTypeDispatchReconciled, boundary.completedID); got != 1 {
+		t.Fatalf("completed dispatch reconciled events after restart = %d, want 1", got)
+	}
 }
 
 func (scenario *resumeFromRecordingScenario) resumeAndFinish(
@@ -172,34 +184,29 @@ func (scenario *resumeFromRecordingScenario) resumeAndFinish(
 	boundary resumeFromRecordingBoundary,
 ) {
 	t.Helper()
-	resume := postResumeFromRecordingJSON[factoryapi.FactorySessionLifecycleControlResponse](
-		t,
-		baseURL+"/factory-sessions/"+url.PathEscape(scenario.sessionID)+"/resume",
-		factoryapi.FactorySessionLifecycleControlRequest{},
-	)
-	if resume.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
-		t.Fatalf("resume outcome = %q, want ACCEPTED", resume.Outcome)
-	}
-	scenario.runner.wait(t, scenario.runner.thirdEntered, "resumed second provider dispatch")
 	scenario.runner.ReleaseRemainingDispatch()
-	finished := waitForResumeFromRecordingSession(t, baseURL, scenario.sessionID, func(session factoryapi.FactorySessionDurableReadModel) bool {
-		return session.Status == factoryapi.FactorySessionDurableLifecycleStatusSucceeded
-	})
-	if finished.Progress == nil || valueOrZero(finished.Progress.CompletedDispatches) != 2 {
-		t.Fatalf("post-resume progress = %#v, want two completed dispatches", finished.Progress)
+	support.WaitForTerminalStatus(t, baseURL, resumeFromRecordingTimeout)
+	finalWork := support.ListDefaultSessionWork(t, baseURL)
+	if got := support.CountWorkAtCustomerState(finalWork, support.WorkCustomerLocation("task", "complete")); got != 1 {
+		t.Fatalf("post-resume completed Work count = %d, want 1; listed=%#v", got, finalWork.Results)
+	}
+	if got := support.CountWorkAtCustomerState(finalWork, support.WorkCustomerLocation("task", "processing")); got != 0 {
+		t.Fatalf("post-resume processing Work count = %d, want 0", got)
+	}
+	finished := support.GetDefaultSession(t, baseURL)
+	if finished.Runtime.Progress.Categories.Terminal != 1 || finished.Runtime.Progress.Categories.Processing != 0 || finished.Runtime.Progress.Categories.Failed != 0 {
+		t.Fatalf("post-resume board progress = %+v, want one terminal Work and no failed/processing Work", finished.Runtime.Progress.Categories)
 	}
 	if got := scenario.runner.CallCount(); got != 3 {
 		t.Fatalf("provider command calls after resume = %d, want exactly 3", got)
 	}
-	final := listResumeFromRecordingDispatches(t, baseURL, scenario.sessionID)
-	completed := requireResumeFromRecordingDispatch(t, final, "dispatch-1", factoryapi.FactoryDispatchStatusCOMPLETED)
-	if completed.Id != boundary.completed.Id {
-		t.Fatalf("completed dispatch was replaced after resume: %q -> %q", boundary.completed.Id, completed.Id)
-	}
-	requireResumeFromRecordingDispatch(t, final, "dispatch-2", factoryapi.FactoryDispatchStatusCOMPLETED)
-	finalEvents := support.GetFactoryEventsForSessionAt(t, baseURL, scenario.sessionID)
+	finalEvents := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "after resume", finalEvents)
 	assertResumeFromRecordingFactoryEventIDsPresent(t, boundary.events, finalEvents)
+	support.AssertSingleWorkRequestEvent(t, finalEvents, scenario.requestID, scenario.workID, "task")
+	if got := countResumeFromRecordingDispatchEvents(finalEvents, factoryapi.FactoryEventTypeDispatchReconciled, boundary.completedID); got != 1 {
+		t.Fatalf("completed dispatch reconciled events after resume = %d, want 1", got)
+	}
 	assertResumeFromRecordingFactoryCursorReplay(t, baseURL, scenario, boundary, finalEvents)
 }
 
@@ -277,7 +284,7 @@ func assertResumeFromRecordingFactoryCursorReplay(
 	replayed := support.GetFactoryEventsAfterForSessionAt(
 		t,
 		baseURL,
-		scenario.sessionID,
+		factorysessions.DefaultSessionID,
 		support.FactoryEventReadCursor{AfterEventID: boundary.cursor.Id},
 	)
 	if len(replayed) != wantCount {
@@ -351,173 +358,126 @@ func indexResumeFromRecordingFactoryEvent(
 func setupResumeFromRecordingFixture(t *testing.T) string {
 	t.Helper()
 
-	projectRoot := support.ScaffoldSingleStepFactory(t, "resume-from-recording")
-	workflowDir := filepath.Join(projectRoot, ".claude", "workflows")
-	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
-		t.Fatalf("create workflow directory: %v", err)
-	}
-	fixturePath := support.AgentFactoryPath(
-		t,
-		"tests/fixtures/javascript_runtime/resumable-two-step-fake-children.workflow.js",
-	)
-	source, err := os.ReadFile(fixturePath)
-	if err != nil {
-		t.Fatalf("read workflow fixture: %v", err)
-	}
-	if err := os.WriteFile(
-		filepath.Join(workflowDir, resumeFromRecordingWorkflowName+".js"),
-		source,
-		0o600,
-	); err != nil {
-		t.Fatalf("write workflow fixture: %v", err)
+	projectRoot := support.ScaffoldFactory(t, map[string]any{
+		"name": "resume-from-recording",
+		"workTypes": []map[string]any{{
+			"name": "task",
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "processing", "type": "PROCESSING"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]string{
+			{"name": "worker-a"},
+			{"name": "worker-b"},
+		},
+		"workstations": []map[string]any{
+			{
+				"name":      "step-one",
+				"worker":    "worker-a",
+				"inputs":    []map[string]string{{"workType": "task", "state": "init"}},
+				"outputs":   []map[string]string{{"workType": "task", "state": "processing"}},
+				"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
+			},
+			{
+				"name":      "step-two",
+				"worker":    "worker-b",
+				"inputs":    []map[string]string{{"workType": "task", "state": "processing"}},
+				"outputs":   []map[string]string{{"workType": "task", "state": "complete"}},
+				"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
+			},
+		},
+	})
+	for _, worker := range []string{"worker-a", "worker-b"} {
+		support.WriteAgentConfig(
+			t,
+			projectRoot,
+			worker,
+			support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"),
+		)
 	}
 	return projectRoot
 }
 
-func startResumeFromRecordingSession(
-	t *testing.T,
-	baseURL string,
-) factoryapi.FactorySessionExecutionResponse {
+func assertResumeFromRecordingUnfinalizedRecording(t *testing.T, path string) {
 	t.Helper()
-	workflowName := resumeFromRecordingWorkflowName
-	return postResumeFromRecordingJSON[factoryapi.FactorySessionExecutionResponse](
-		t,
-		baseURL+"/factory-sessions/async",
-		factoryapi.FactorySessionExecutionRequest{
-			RequestId: "resume-from-recording-start-001",
-			Source: factoryapi.FactorySessionExecutionSource{
-				Kind:         factoryapi.FactorySessionExecutionSourceKindWorkflowName,
-				WorkflowName: &workflowName,
-			},
-			Args: &map[string]interface{}{"subject": "resume-from-recording"},
-		},
-	)
-}
-
-func interruptResumeFromRecordingDispatch(t *testing.T, baseURL, sessionID string) {
-	t.Helper()
-	reason := "kill-and-resume functional boundary"
-	response := postResumeFromRecordingJSON[factoryapi.FactorySessionLifecycleControlResponse](
-		t,
-		baseURL+"/factory-sessions/"+url.PathEscape(sessionID)+"/interrupt-dispatch",
-		factoryapi.FactorySessionInterruptDispatchRequest{
-			DispatchId: "dispatch-2",
-			Reason:     &reason,
-		},
-	)
-	if response.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
-		t.Fatalf("interrupt outcome = %q, want ACCEPTED", response.Outcome)
-	}
-}
-
-func readResumeFromRecordingSession(
-	t *testing.T,
-	baseURL, sessionID string,
-) (factoryapi.FactorySessionDurableReadModel, error) {
-	t.Helper()
-	response := support.GetJSON[factoryapi.FactorySessionGetResponse](
-		t,
-		baseURL+"/factory-sessions/"+url.PathEscape(sessionID),
-	)
-	read, err := response.AsFactorySessionDurableReadModel()
+	raw, err := os.ReadFile(path)
 	if err != nil {
-		return factoryapi.FactorySessionDurableReadModel{}, fmt.Errorf("decode durable session: %w", err)
+		t.Fatalf("read naturally unfinalized recording %q: %v", path, err)
 	}
-	return read, nil
-}
-
-func waitForResumeFromRecordingSession(
-	t *testing.T,
-	baseURL, sessionID string,
-	accept func(factoryapi.FactorySessionDurableReadModel) bool,
-) factoryapi.FactorySessionDurableReadModel {
-	t.Helper()
-	read, err := support.WaitForObservation(
-		resumeFromRecordingTimeout,
-		func() (factoryapi.FactorySessionDurableReadModel, error) {
-			return readResumeFromRecordingSession(t, baseURL, sessionID)
-		},
-		accept,
-	)
-	if err != nil {
-		t.Fatalf("wait for durable session %q: %v", sessionID, err)
+	var artifact struct {
+		Events []struct {
+			Payload json.RawMessage `json:"payload"`
+		} `json:"events"`
 	}
-	return read
-}
-
-func listResumeFromRecordingDispatches(
-	t *testing.T,
-	baseURL, sessionID string,
-) factoryapi.ListFactorySessionDispatchesResponse {
-	t.Helper()
-	return support.GetJSON[factoryapi.ListFactorySessionDispatchesResponse](
-		t,
-		baseURL+"/factory-sessions/"+url.PathEscape(sessionID)+"/dispatches",
-	)
-}
-
-func requireResumeFromRecordingDispatch(
-	t *testing.T,
-	listed factoryapi.ListFactorySessionDispatchesResponse,
-	id string,
-	allowed ...factoryapi.FactoryDispatchStatus,
-) factoryapi.FactorySessionDispatchSummary {
-	t.Helper()
-	for _, dispatch := range listed.Dispatches {
-		if dispatch.Id != id {
+	if err := json.Unmarshal(raw, &artifact); err != nil {
+		t.Fatalf("decode naturally unfinalized recording %q: %v", path, err)
+	}
+	for _, event := range artifact.Events {
+		var envelope struct {
+			WallClock *struct {
+				FinishedAt *time.Time `json:"finishedAt,omitempty"`
+			} `json:"wallClock,omitempty"`
+		}
+		if err := json.Unmarshal(event.Payload, &envelope); err != nil {
 			continue
 		}
-		for _, status := range allowed {
-			if dispatch.Status == status {
-				return dispatch
-			}
+		if envelope.WallClock != nil && envelope.WallClock.FinishedAt != nil {
+			t.Fatalf("recording %q was finalized before resume at %s", path, envelope.WallClock.FinishedAt)
 		}
-		t.Fatalf("dispatch %q status = %q, want one of %#v", id, dispatch.Status, allowed)
 	}
-	t.Fatalf("dispatch %q missing from %#v", id, listed.Dispatches)
-	return factoryapi.FactorySessionDispatchSummary{}
 }
 
-func valueOrZero(value *int) int {
-	if value == nil {
-		return 0
-	}
-	return *value
-}
-
-func postResumeFromRecordingJSON[T any](t *testing.T, endpoint string, request any) T {
+func requireResumeFromRecordingWork(
+	t *testing.T,
+	listed factoryapi.ListWorkResponse,
+	workID string,
+) factoryapi.Work {
 	t.Helper()
-	payload, err := json.Marshal(request)
-	if err != nil {
-		t.Fatalf("marshal %s request: %v", endpoint, err)
+	for _, work := range listed.Results {
+		if support.StringPointerValue(work.WorkId) == workID {
+			return work
+		}
 	}
-	httpRequest, err := http.NewRequestWithContext(
-		t.Context(),
-		http.MethodPost,
-		endpoint,
-		bytes.NewReader(payload),
-	)
-	if err != nil {
-		t.Fatalf("build POST %s: %v", endpoint, err)
+	t.Fatalf("public Work listing is missing %q: %#v", workID, listed.Results)
+	return factoryapi.Work{}
+}
+
+func requireResumeFromRecordingCompletedDispatchID(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+) string {
+	t.Helper()
+	for _, event := range events {
+		if event.Type != factoryapi.FactoryEventTypeDispatchReconciled {
+			continue
+		}
+		if dispatchID := support.StringPointerValue(event.Context.DispatchId); dispatchID != "" {
+			return dispatchID
+		}
 	}
-	httpRequest.Header.Set("Content-Type", "application/json")
-	response, err := http.DefaultClient.Do(httpRequest)
-	if err != nil {
-		t.Fatalf("POST %s: %v", endpoint, err)
+	t.Fatal("public Factory Events contain no completed dispatch reconciliation")
+	return ""
+}
+
+func countResumeFromRecordingDispatchEvents(
+	events []factoryapi.FactoryEvent,
+	eventType factoryapi.FactoryEventType,
+	dispatchID string,
+) int {
+	count := 0
+	for _, event := range events {
+		if event.Type == eventType && support.StringPointerValue(event.Context.DispatchId) == dispatchID {
+			count++
+		}
 	}
-	defer response.Body.Close()
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Fatalf("read POST %s: %v", endpoint, err)
-	}
-	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
-		t.Fatalf("POST %s status = %d: %s", endpoint, response.StatusCode, body)
-	}
-	var decoded T
-	if err := json.Unmarshal(body, &decoded); err != nil {
-		t.Fatalf("decode POST %s: %v\n%s", endpoint, err, body)
-	}
-	return decoded
+	return count
+}
+
+func stringPointer(value string) *string {
+	return &value
 }
 
 type resumeFromRecordingCommandRunner struct {

--- a/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
+++ b/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
@@ -281,10 +281,9 @@ func assertResumeFromRecordingFactoryCursorReplay(
 	if wantCount == 0 {
 		t.Fatalf("Factory Event cursor %q has no post-resume events to replay", boundary.cursor.Id)
 	}
-	replayed := support.GetFactoryEventsAfterForSessionAt(
+	replayed := support.GetFactoryEventsAfterAt(
 		t,
 		baseURL,
-		factorysessions.DefaultSessionID,
 		support.FactoryEventReadCursor{AfterEventID: boundary.cursor.Id},
 	)
 	if len(replayed) != wantCount {

--- a/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
+++ b/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
@@ -135,7 +135,6 @@ func (scenario *resumeFromRecordingScenario) captureAtKillBoundary(
 	}
 	events := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "before restart", events)
-	requireResumeFromRecordingWorkStateEvent(t, events, scenario.workID, "processing")
 	completedID := requireResumeFromRecordingCompletedDispatchID(t, events)
 	return resumeFromRecordingBoundary{
 		work:        work,
@@ -163,7 +162,6 @@ func (scenario *resumeFromRecordingScenario) assertRestored(
 	restartedEvents := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "after restart", restartedEvents)
 	assertResumeFromRecordingFactoryEventIDsPresent(t, boundary.events, restartedEvents)
-	requireResumeFromRecordingWorkStateEvent(t, restartedEvents, scenario.workID, "processing")
 	support.AssertSingleWorkRequestEvent(t, restartedEvents, scenario.requestID, scenario.workID, "task")
 	if got := countResumeFromRecordingDispatchEvents(restartedEvents, factoryapi.FactoryEventTypeDispatchReconciled, boundary.completedID); got != 1 {
 		t.Fatalf("completed dispatch reconciled events after restart = %d, want 1", got)
@@ -191,7 +189,6 @@ func (scenario *resumeFromRecordingScenario) resumeAndFinish(
 	finalEvents := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "after resume", finalEvents)
 	assertResumeFromRecordingFactoryEventIDsPresent(t, boundary.events, finalEvents)
-	requireResumeFromRecordingWorkStateEvent(t, finalEvents, scenario.workID, "complete")
 	support.AssertSingleWorkRequestEvent(t, finalEvents, scenario.requestID, scenario.workID, "task")
 	if got := countResumeFromRecordingDispatchEvents(finalEvents, factoryapi.FactoryEventTypeDispatchReconciled, boundary.completedID); got != 1 {
 		t.Fatalf("completed dispatch reconciled events after resume = %d, want 1", got)
@@ -461,32 +458,6 @@ func waitForResumeFromRecordingWorkState(
 		t.Fatalf("wait for Work %q at %s: %v", workID, wantLocation, err)
 	}
 	return listed
-}
-
-func requireResumeFromRecordingWorkStateEvent(
-	t *testing.T,
-	events []factoryapi.FactoryEvent,
-	workID, state string,
-) factoryapi.FactoryEvent {
-	t.Helper()
-	for _, event := range events {
-		if event.Type != factoryapi.FactoryEventTypeWorkStateChange {
-			continue
-		}
-		payload, err := event.Payload.AsWorkStateChangeEventPayload()
-		if err != nil {
-			t.Fatalf("decode WORK_STATE_CHANGE event %q: %v", event.Id, err)
-		}
-		if payload.WorkId == workID && payload.ToState == state {
-			return event
-		}
-	}
-	types := make([]factoryapi.FactoryEventType, 0, len(events))
-	for _, event := range events {
-		types = append(types, event.Type)
-	}
-	t.Fatalf("public Factory Events contain no WORK_STATE_CHANGE for Work %q to %s; types=%#v", workID, state, types)
-	return factoryapi.FactoryEvent{}
 }
 
 func requireResumeFromRecordingCompletedDispatchID(

--- a/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
+++ b/tests/functional/sessions/resume_from_recording/resume_from_recording_test.go
@@ -75,7 +75,7 @@ type resumeFromRecordingScenario struct {
 
 type resumeFromRecordingBoundary struct {
 	work        factoryapi.Work
-	session     factoryapi.FactorySession
+	board       factoryapi.StatusResponse
 	completedID string
 	events      []factoryapi.FactoryEvent
 	cursor      factoryapi.FactoryEvent
@@ -134,16 +134,15 @@ func (scenario *resumeFromRecordingScenario) captureAtKillBoundary(
 	if got := support.WorkItemCustomerLocation(work); got != support.WorkCustomerLocation("task", "processing") {
 		t.Fatalf("pre-kill Work location = %q, want task:processing", got)
 	}
-	session := support.GetDefaultSession(t, baseURL)
-	if session.Runtime.Progress.Categories.Initial != 0 || session.Runtime.Progress.Categories.Processing != 1 {
-		t.Fatalf("pre-kill board progress = %+v, want one processing Work", session.Runtime.Progress.Categories)
-	}
+	board := support.WaitForStatus(t, baseURL, resumeFromRecordingTimeout, func(status factoryapi.StatusResponse) bool {
+		return status.Categories.Initial == 0 && status.Categories.Processing == 1
+	})
 	events := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "before restart", events)
 	completedID := requireResumeFromRecordingCompletedDispatchID(t, events)
 	return resumeFromRecordingBoundary{
 		work:        work,
-		session:     session,
+		board:       board,
 		completedID: completedID,
 		events:      events,
 		cursor:      requireResumeFromRecordingFactoryEvent(t, events, factoryapi.FactoryEventTypeDispatchReconciled, completedID),
@@ -165,9 +164,11 @@ func (scenario *resumeFromRecordingScenario) assertRestored(
 	if got := support.WorkItemCustomerLocation(work); got != support.WorkCustomerLocation("task", "processing") {
 		t.Fatalf("post-restart Work location = %q, want restored task:processing", got)
 	}
-	session := support.GetDefaultSession(t, baseURL)
-	if session.Runtime.Progress.Categories.Initial != 0 || session.Runtime.Progress.Categories.Processing != 1 {
-		t.Fatalf("post-restart board progress = %+v, want restored one processing Work", session.Runtime.Progress.Categories)
+	board := support.WaitForStatus(t, baseURL, resumeFromRecordingTimeout, func(status factoryapi.StatusResponse) bool {
+		return status.Categories.Initial == 0 && status.Categories.Processing == 1
+	})
+	if board.Categories.Terminal != boundary.board.Categories.Terminal || board.Categories.Failed != boundary.board.Categories.Failed {
+		t.Fatalf("post-restart board terminal/failed counts = %+v, want preserved boundary counts %+v", board.Categories, boundary.board.Categories)
 	}
 	restartedEvents := support.GetFactoryEventsForSessionAt(t, baseURL, factorysessions.DefaultSessionID)
 	assertResumeFromRecordingFactoryEvents(t, "after restart", restartedEvents)
@@ -185,7 +186,7 @@ func (scenario *resumeFromRecordingScenario) resumeAndFinish(
 ) {
 	t.Helper()
 	scenario.runner.ReleaseRemainingDispatch()
-	support.WaitForTerminalStatus(t, baseURL, resumeFromRecordingTimeout)
+	finished := support.WaitForTerminalStatus(t, baseURL, resumeFromRecordingTimeout)
 	finalWork := support.ListDefaultSessionWork(t, baseURL)
 	if got := support.CountWorkAtCustomerState(finalWork, support.WorkCustomerLocation("task", "complete")); got != 1 {
 		t.Fatalf("post-resume completed Work count = %d, want 1; listed=%#v", got, finalWork.Results)
@@ -193,9 +194,8 @@ func (scenario *resumeFromRecordingScenario) resumeAndFinish(
 	if got := support.CountWorkAtCustomerState(finalWork, support.WorkCustomerLocation("task", "processing")); got != 0 {
 		t.Fatalf("post-resume processing Work count = %d, want 0", got)
 	}
-	finished := support.GetDefaultSession(t, baseURL)
-	if finished.Runtime.Progress.Categories.Terminal != 1 || finished.Runtime.Progress.Categories.Processing != 0 || finished.Runtime.Progress.Categories.Failed != 0 {
-		t.Fatalf("post-resume board progress = %+v, want one terminal Work and no failed/processing Work", finished.Runtime.Progress.Categories)
+	if finished.Categories.Terminal != 1 || finished.Categories.Processing != 0 || finished.Categories.Failed != 0 {
+		t.Fatalf("post-resume board progress = %+v, want one terminal Work and no failed/processing Work", finished.Categories)
 	}
 	if got := scenario.runner.CallCount(); got != 3 {
 		t.Fatalf("provider command calls after resume = %d, want exactly 3", got)


### PR DESCRIPTION
{
  "project": "RSM-7 Kill-and-Resume Functional Suite",
  "branchName": "rsm-7-kill-and-resume-functional",
  "description": "Prove from an external user's perspective that a Factory Session running real work can survive a process kill: a replacement publicly composed process resumes the original unfinalized on-disk recording, restores admitted work and board state, avoids re-executing completed dispatches, completes remaining work, and continues Factory Event cursors monotonically. The lane adds deterministic functional proof and a measured coverage-manifest entry without introducing production recovery behavior or a new harness subsystem.",
  "context": {
    "customerAsk": "Create tests/functional/sessions/resume_from_recording/ coverage that starts a Factory Session with real work, kills the process mid-flight, restarts against the same persisted home, resumes from the unfinalized on-disk recording through the public surface, and observes restored work/board state, no repeated completed dispatches, terminal remaining work, and monotonic Factory Event cursors. Construct only through public process composition, replace effects only through edges.Edges, use deterministic provider signals and explicit joins, run under make test-functional, and add a measured functional coverage-manifest entry.",
    "problem": "Earlier RSM lanes provide persistence, restored runtime state, unfinalized-recording tolerance, and a public resume surface, but no single functional scenario proves those capabilities compose across a real process lifetime boundary. A restart could otherwise lose admitted work, rebuild the wrong board state, repeat completed provider work, regress or duplicate Factory Events, or depend incorrectly on a finalized recording.",
    "solution": "Add one deterministic external functional scenario with two sequential public process lifetimes sharing the same persisted home. Use an edges.Edges ProviderCommandRunner with explicit entry, stop, and release signals plus a synchronized call counter; capture public work, board, dispatch, and Factory Event observations before the kill; resume the naturally unfinalized recording through the public path; and assert restored state, non-reexecution, terminal completion, and event continuity. Reuse existing support and fixtures, allow only minimal additive support, and register the new package in the closed sorted functional coverage manifest with an actually measured value rounded down."
  },
  "acceptanceCriteria": [
    "A selected functional test starts real multi-step work through public process composition, deterministically stops the first process after one dispatch completes and later work is in flight, explicitly joins it, starts a replacement process against the same persisted home, and resumes through the public surface from the recording naturally left unfinalized.",
    "Public observations after restart show the original admitted Work and restored board/work state without a second admission, and after resume all unfinished Work and the Factory Session reach their expected terminal states; recording-file inspection is setup evidence only, not proof of recovery.",
    "Provider invocation counting proves dispatches recorded as completed before the kill are not re-executed, while only the interrupted or pending work executes as needed to finish the resumed Factory Session.",
    "Canonical Factory Events observed through the public surface retain unique identities and strictly increasing cursors/sequences across the kill boundary, with no regression or duplicate identity.",
    "The suite uses root.BuildProcess through the established functional support/public process surface, replaces effects only through edges.Edges, uses deterministic provider signals and explicit joins without sleep-based synchronization, passes under make test-functional selection, and adds one canonically sorted non-placeholder functional coverage-manifest entry measured by the required two-pass process, rounded down, and never generated with -update-manifest.",
    "Quality gate: Typecheck passes; focused and selected functional tests pass; and there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "rsm-7-kill-and-resume-functional-001",
      "title": "Resume killed real work from an unfinalized recording",
      "description": "As a Factory operator, I want a killed Factory Session to restore its admitted work from disk through the public resume path so an unexpected process loss does not require me to submit the work again.",
      "acceptanceCriteria": [
        "A functional scenario starts real multi-step Work through the established public process composition and waits on deterministic provider signals until one dispatch is completed and a later dispatch is in flight.",
        "The first process is stopped at that boundary and explicitly joined before the replacement process starts against the same persisted functional home; no wall-clock sleep or timeout-padded polling helper is used as synchronization.",
        "The persisted recording used for restart is unfinalized, and the test does not hand-finalize or mutate it before resume.",
        "The replacement process is built through the same public composition path and resumes through the public recording/session resume surface, with effects replaced only through edges.Edges.",
        "Public observations after restart identify the original admitted Work and restored board/work state without issuing another Work Request; inspecting store-file contents is not used as recovery proof.",
        "Focused functional tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "The focused public process-lifetime scenario now runs against the merged RSM-5 recording-resume surface. On a fresh origin/main validation worktree it started real multi-step Work, killed and joined the predecessor after a completed dispatch plus later in-flight work, resumed the naturally unfinalized recording through the public path, restored the original Work and in-flight board state without a second admission, avoided re-executing the completed dispatch, and reached terminal completion. The focused functional test and compile-only typecheck passed."
    },
    {
      "id": "rsm-7-kill-and-resume-functional-002",
      "title": "Preserve dispatch and event continuity through recovery",
      "description": "As a Factory operator, I want recovery to continue only unfinished work and preserve event ordering so resumed execution is trustworthy and does not duplicate completed effort.",
      "acceptanceCriteria": [
        "Provider call counting captured through the injected command-runner edge proves every dispatch completed before the kill retains its completion and is not executed again after resume.",
        "The deterministic provider releases the remaining in-flight or pending work after resume, and public session/work observations show that work and the Factory Session reaching the expected terminal states.",
        "Factory Events collected through the public event surface before and after the kill have unique event identities and strictly increasing cursors/sequences across the boundary, with no regression or duplicated identity.",
        "Assertions cover the whole public loop in one scenario—real Work, kill, restart, resume, restored state, non-reexecution, event continuity, and terminal completion—rather than inferring success from internal files or stores.",
        "The test reuses existing functional fixtures/support where they fit; any support change is minimal and additive, and no new pkg/root, pkg/wire, test-only service API, provider subsystem, or alternate composition path is introduced.",
        "Focused functional tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Public Factory Event snapshots are checked for unique identities and strictly increasing global/session sequences before restart, after restart, and after completion. The test acknowledges a stable completed event identity (preferring DISPATCH_RECONCILED and falling back to DISPATCH_RESPONSE when the runtime emits that lifecycle shape), then uses the public session cursor endpoint to assert no redelivery, no gap, and strictly increasing replay sequences."
    },
    {
      "id": "rsm-7-kill-and-resume-functional-003",
      "title": "Register measured functional coverage and selected-suite evidence",
      "description": "As a maintainer, I want the new recovery scenario included in the functional lane with a measured coverage floor so its execution and contribution remain visible to repository quality gates.",
      "acceptanceCriteria": [
        "The new functional package is discovered and executed by the existing make test-functional selection without a new runner or registration subsystem.",
        "The functional coverage manifest receives one surgical entry for the new package in canonical sort order; no unit-manifest entry is added because this lane introduces no non-test package.",
        "Measurement follows the required two-pass process: add an initial 0.00 entry only to permit measurement, run the functional coverage instrument, then replace it with the observed non-placeholder percentage rounded down; -update-manifest is never used.",
        "Property-specific output records the package's actual coverage measurement and confirms the final manifest floor is satisfied; the change does not add meta-tests for file, command, route, or registration inventories.",
        "make test-functional selection and the applicable functional coverage check pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "The canonically sorted functional floor for pkg/services/factory_sessions/internal/execution/runtimepersist remains the only new manifest entry. Its required placeholder-to-instrument measurement recorded 32/49 statements (65.306122%) and the committed floor is 65.30 after truncation; no unit-manifest row or -update-manifest was used. On the rebased final tree, make FUNCTIONAL_DEFAULT_JOBS=8 GO_TEST_TIMEOUT=300s test-functional completed with every selected package passing, including resume_from_recording and pending_approval. The property-specific coverage run completed at 57.2% total and measured runtimepersist at 36/49 (73.469387%), above its 65.30 floor. The same coverage command on the base tree reproduced the identical four unrelated package-floor regressions (filesystem, wiretranscript, worker recording, and worker testing), so no unrelated manifest changes were made; this baseline exception is documented for review. Functional boundary, focused runtime/recovery tests, focused vet, and make typecheck pass."
    }
  ]
}
