### PR TITLE
Use full exclusive-runner capacity for Backend Lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,6 +504,12 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+          # Give the complete lint inventory a lane-specific key so its module
+          # and build data are saved and reused by later measurements.
+          cache-dependency-path: |
+            go.mod
+            go.sum
+            .github/workflows/ci.yml
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,6 +527,19 @@ jobs:
           }
           console.log(`Backend Lint selected at ${selection.headSha}`);
           NODE
+      - name: Select Backend Lint runner parallelism
+        id: backend-lint-parallelism
+        shell: bash
+        run: |
+          runner_cpus="$(nproc 2>/dev/null || true)"
+          RUNNER_LOGICAL_CPUS="$runner_cpus" node --input-type=module <<'NODE'
+          import { appendFileSync } from 'node:fs';
+          import { resolveRunnerParallelism } from './scripts/ci/runner-parallelism.mjs';
+
+          const { logicalCPUs, jobs } = resolveRunnerParallelism(process.env.RUNNER_LOGICAL_CPUS);
+          console.log(`Backend Lint CI runner: logical_cpus=${logicalCPUs} jobs=${jobs}`);
+          appendFileSync(process.env.GITHUB_OUTPUT, `jobs=${jobs}\n`);
+          NODE
       - name: Install UI dependencies for canonical UI lint targets
         if: always()
         run: make ui-deps
@@ -542,6 +555,8 @@ jobs:
           status=${PIPESTATUS[0]}
           printf 'exit_code=%s\n' "$status" >> "$GITHUB_OUTPUT"
           exit "$status"
+        env:
+          LINT_JOBS: ${{ steps.backend-lint-parallelism.outputs.jobs }}
       - name: Render Backend Lint summary and gate
         if: always()
         run: >-

--- a/scripts/ci/backend-lint-workflow.test.mjs
+++ b/scripts/ci/backend-lint-workflow.test.mjs
@@ -6,6 +6,7 @@ import {
 	selectBackendLint,
 	upsertBackendLintComment,
 } from "./backend-lint-workflow.mjs";
+import { resolveRunnerParallelism } from "./runner-parallelism.mjs";
 import {
 	BACKEND_LINT_COMMENT_MARKER,
 	renderBackendLintComment,
@@ -34,6 +35,22 @@ test("selects pull requests and pushes to main at the tested head", () => {
 		selectBackendLint({ eventName: "push", ref: "refs/heads/feature", sha: "feature-head" }).selected,
 		false,
 	);
+});
+
+test("uses all valid logical CPUs for the exclusive CI runner", () => {
+	assert.deepEqual(resolveRunnerParallelism("4"), { logicalCPUs: 4, jobs: 4 });
+	assert.deepEqual(resolveRunnerParallelism(" 8\n"), { logicalCPUs: 8, jobs: 8 });
+});
+
+test("uses the safe minimum when logical CPU discovery is invalid or unavailable", () => {
+	for (const rawLogicalCPUs of ["", "not-a-number", "0", "4x"]) {
+		assert.deepEqual(
+			resolveRunnerParallelism(rawLogicalCPUs),
+			{ logicalCPUs: 0, jobs: 2 },
+			`raw logical CPU value ${JSON.stringify(rawLogicalCPUs)}`,
+		);
+	}
+	assert.deepEqual(resolveRunnerParallelism("1"), { logicalCPUs: 1, jobs: 2 });
 });
 
 test("publishes a complete report by creating or updating the marked bot comment", () => {

--- a/scripts/ci/runner-parallelism.mjs
+++ b/scripts/ci/runner-parallelism.mjs
@@ -1,0 +1,19 @@
+const MINIMUM_RUNNER_JOBS = 2;
+
+function parseLogicalCPUs(rawValue) {
+	const value = String(rawValue ?? "").trim();
+	if (!/^\d+$/.test(value)) {
+		return 0;
+	}
+
+	const logicalCPUs = Number(value);
+	return Number.isSafeInteger(logicalCPUs) && logicalCPUs > 0 ? logicalCPUs : 0;
+}
+
+export function resolveRunnerParallelism(rawLogicalCPUs) {
+	const logicalCPUs = parseLogicalCPUs(rawLogicalCPUs);
+	return {
+		logicalCPUs,
+		jobs: Math.max(MINIMUM_RUNNER_JOBS, logicalCPUs),
+	};
+}


### PR DESCRIPTION
{
  "project": "Use full exclusive-runner capacity for Backend Lint",
  "branchName": "perf-l1-ci-lint-parallelism",
  "description": "Make the Backend Lint CI job select and use all four logical CPUs on its exclusive hosted runner, reducing its measured duration while preserving the local co-tenant discount, the exact 21-target inventory, and byte-identical pass/fail results for every target.",
  "context": {
    "customerAsk": "Apply the co-tenant discount fix already used by the functional and unit lanes to Backend Lint. The hosted Backend Lint job must use all four logical CPUs, while local development retains the shared-host discount. Preserve the exact 21-target lint inventory and each target's result, and provide comparable before/after evidence from the job's own diagnostics artifact and hosted timing.",
    "problem": "In green CI run 32509668745, job 96858518753, Backend Lint took 201 seconds. Its backend-lint-diagnostics/report.json recorded jobs=2 and totalDurationMillis=159618; the 21 checker durations totaled 295.1 seconds, for measured parallelism of 1.85 workers. The job inherits LINT_JOBS from the deliberate shared-host GO_LANE_BUDGET discount, which is correct locally but leaves half of an exclusive four-vCPU CI runner unused.",
    "solution": "Within the Backend Lint job only, resolve logical CPU capacity by mirroring the existing Select functional runner parallelism behavior, including its safe minimum or fallback, and apply the resolved value as LINT_JOBS or an equivalent lint runner jobs override to the existing canonical lint invocation. Keep the Makefile default and lint checker implementation untouched, and use the PR head's backend-lint-diagnostics/report.json plus hosted job timing to prove concurrency, exact target parity, and performance."
  },
  "acceptanceCriteria": [
    "On a green run of the PR head, backend-lint-diagnostics/report.json reports jobs=4; the selected value is applied only to the Backend Lint job's canonical lint invocation, and local invocations still inherit the unchanged Makefile GO_LANE_BUDGET discount.",
    "On that hosted run, backend-lint-diagnostics/report.json reports totalDurationMillis <= 130000, and the Backend Lint job wall-clock is <= 165s; no lower target is promised because the baseline's longest checker, vet, measured 116.5 seconds.",
    "The before and after reports contain the same 21 targets in the same inventory, with byte-identical pass/fail per target. In particular, the allowed baseline outcomes packaged-factory-consumption-check: FAIL and deadcode: fail remain unchanged; any previously failing target that passes or previously passing target that fails is a defect.",
    "The final change remains within the Backend Lint job block and, only if needed for a reusable selector and its focused tests, scripts/ci. It does not modify cmd/lintlane internals, cmd/gocoveragecheck, the Makefile's shared GO_LANE_BUDGET default formula, lint targets or baselines, generated files, the Verification Policy aggregator, or the separate perf-c1-vitest-component-worker-count job block. The branch is rebased onto current origin/main before the final push, and concurrent changes to the separate CI job block are preserved rather than reverted.",
    "The PR body quotes the complete before/after 21-target lists and identifies the exact evidence method: baseline run 32509668745, job 96858518753, and its downloaded backend-lint-diagnostics/report.json, compared with the PR-head Backend Lint run's job timing and downloaded artifact. CI-run observations, including the PR run and job identifiers, jobs, totalDurationMillis, wall-clock, and target parity, are posted in a PR comment and never committed.",
    "Quality gates pass: Typecheck passes; Tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. The pre-existing packaged-service-structure migration debt recorded on 2026-08-08 does not make blanket end-to-end make lint success a criterion.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "reviewEvidence": {
    "method": "Downloaded backend-lint-diagnostics/report.json artifacts and compared ordered name/status pairs; compared the Backend Lint job start and completion timestamps from the Actions API.",
    "baseline": {
      "run": 32509668745,
      "job": 96858518753,
      "jobs": 2,
      "totalDurationMillis": 159618,
      "wallClockSeconds": 201,
      "targets": [
        "ui-lint: pass",
        "ui-deadcode: pass",
        "vet: pass",
        "backend-size: pass",
        "pkg-maint: pass",
        "pkg-file-count: pass",
        "pkg-boundary: pass",
        "pkg-structure: pass",
        "service-cycle-check: pass",
        "package-target-manifest-check: pass",
        "packaged-factory-source-check: pass",
        "packaged-factory-consumption-check: fail",
        "packaged-factory-catalog-check: pass",
        "provider-catalog-check: pass",
        "model-provider-package-check: pass",
        "durable-runtime-construction-check: pass",
        "logging-boundary-check: pass",
        "compatibility-alias-check: pass",
        "retired-surface-check: pass",
        "ownership-inventory-check: pass",
        "deadcode: fail"
      ]
    },
    "head": {
      "run": 32526444203,
      "job": 96916004826,
      "head": "3e7737e0fff7eda72e7425e3e5861bdd8ed63cd2",
      "jobs": 4,
      "totalDurationMillis": 81687,
      "wallClockSeconds": 134,
      "targets": [
        "ui-lint: pass",
        "ui-deadcode: pass",
        "vet: pass",
        "backend-size: pass",
        "pkg-maint: pass",
        "pkg-file-count: pass",
        "pkg-boundary: pass",
        "pkg-structure: pass",
        "service-cycle-check: pass",
        "package-target-manifest-check: pass",
        "packaged-factory-source-check: pass",
        "packaged-factory-consumption-check: fail",
        "packaged-factory-catalog-check: pass",
        "provider-catalog-check: pass",
        "model-provider-package-check: pass",
        "durable-runtime-construction-check: pass",
        "logging-boundary-check: pass",
        "compatibility-alias-check: pass",
        "retired-surface-check: pass",
        "ownership-inventory-check: pass",
        "deadcode: fail"
      ],
      "performance": "PASS: the warmed same-head rerun is below the 130000ms report and 165s job budgets."
    }
  },
  "userStories": [
    {
      "id": "perf-l1-ci-lint-parallelism-001",
      "title": "Use exclusive runner capacity without changing lint semantics",
      "description": "As a repository maintainer, I want Backend Lint to use all four logical CPUs available on its exclusive hosted runner so the canonical inventory completes within its performance budget without weakening or changing verification.",
      "acceptanceCriteria": [
        "The Backend Lint job resolves hosted logical CPU capacity using the existing functional-runner selection behavior, including a safe fallback of at least two jobs when CPU discovery is unavailable or invalid.",
        "The resolved value overrides lint parallelism only for the Backend Lint job's canonical lint invocation; the Makefile's local GO_LANE_BUDGET formula and default LINT_JOBS behavior remain unchanged.",
        "On the PR head's green Backend Lint run, the downloaded backend-lint-diagnostics/report.json records jobs=4 and totalDurationMillis <= 130000, and the hosted job wall-clock is <= 165s.",
        "The baseline and PR-head reports list the same 21 targets and have byte-identical pass/fail per target, including unchanged packaged-factory-consumption-check: FAIL and deadcode: fail outcomes; the complete before/after lists are quoted in the PR body.",
        "Focused CI selection tests cover valid logical-CPU discovery and invalid or unavailable discovery when selector logic is introduced or changed; existing Backend Lint reporting and workflow-policy tests remain passing.",
        "The change does not alter lint target registration, checker execution semantics, result policy, reporting, diagnostics upload, or unrelated CI jobs.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implementation is committed as 8899be23e plus the Backend Lint cache-key review fix 3e7737e0f. PR #2131 is open on head 3e7737e0f; warm Backend Lint rerun 32526444203/job 96916004826 records jobs=4, totalDurationMillis=81687, 134s wall-clock, and exact 21-target result parity."
    }
  ]
}
