### PR TITLE
perf(ui): make component Vitest workers CPU-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
       - name: Run browserless component tests
         env:
           UI_COMPONENT_MAX_DURATION_MS: "300000"
+          UI_COMPONENT_TEST_MAX_WORKERS: "4"
         run: make ui-component-test
 
   ui-coverage:

--- a/ui/scripts/component-test-workers.test.ts
+++ b/ui/scripts/component-test-workers.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  buildVitestComponentArgs,
+  componentTestMaxWorkersEnvironmentVariable,
+  getComponentTestMaxWorkers,
+  minimumComponentTestWorkers,
+} from "./component-test-workers";
+
+describe("component test worker selection", () => {
+  test("uses the detected logical CPU count when no override is set", () => {
+    expect(getComponentTestMaxWorkers({}, 6)).toBe(6);
+  });
+
+  test("floors detected CPU counts below two workers", () => {
+    expect(getComponentTestMaxWorkers({}, 1)).toBe(minimumComponentTestWorkers);
+    expect(getComponentTestMaxWorkers({}, 0)).toBe(minimumComponentTestWorkers);
+  });
+
+  test("uses a valid environment override before CPU detection", () => {
+    expect(
+      getComponentTestMaxWorkers(
+        { [componentTestMaxWorkersEnvironmentVariable]: "4" },
+        32,
+      ),
+    ).toBe(4);
+  });
+
+  test.each(["", "not-a-worker-count", "0", "-1", "1.5"])(
+    "rejects invalid environment override %j before Vitest starts",
+    (override) => {
+      expect(() =>
+        getComponentTestMaxWorkers({
+          [componentTestMaxWorkersEnvironmentVariable]: override,
+        }),
+      ).toThrow(/expected a positive integer/);
+    },
+  );
+
+  test("keeps Vitest selection, retry, forwarded args, and files stable", () => {
+    const args = buildVitestComponentArgs({
+      componentTests: ["src/example.component.test.ts"],
+      env: { [componentTestMaxWorkersEnvironmentVariable]: "4" },
+      forwardedArgs: ["--reporter=verbose"],
+    });
+
+    expect(args).toEqual([
+      "run",
+      "--config",
+      "vitest.lanes.config.ts",
+      "--project=dashboard-component",
+      "--maxWorkers=4",
+      "--retry=0",
+      "--reporter=verbose",
+      "src/example.component.test.ts",
+    ]);
+    expect(args.filter((arg) => arg.startsWith("--maxWorkers"))).toHaveLength(
+      1,
+    );
+  });
+});

--- a/ui/scripts/component-test-workers.ts
+++ b/ui/scripts/component-test-workers.ts
@@ -1,0 +1,61 @@
+import { cpus } from "node:os";
+
+export const componentTestMaxWorkersEnvironmentVariable =
+  "UI_COMPONENT_TEST_MAX_WORKERS";
+export const minimumComponentTestWorkers = 2;
+
+type ComponentTestEnvironment = Record<string, string | undefined>;
+
+export function detectLogicalCpuCount() {
+  return cpus().length;
+}
+
+export function getComponentTestMaxWorkers(
+  env: ComponentTestEnvironment = process.env,
+  logicalCpuCount = detectLogicalCpuCount(),
+) {
+  const rawOverride = env[componentTestMaxWorkersEnvironmentVariable];
+  if (rawOverride !== undefined) {
+    const trimmedOverride = rawOverride.trim();
+    const parsedOverride = Number(trimmedOverride);
+    if (
+      !/^\d+$/.test(trimmedOverride) ||
+      !Number.isSafeInteger(parsedOverride) ||
+      parsedOverride < 1
+    ) {
+      throw new Error(
+        `Invalid ${componentTestMaxWorkersEnvironmentVariable} "${rawOverride}"; expected a positive integer (for example, 4).`,
+      );
+    }
+
+    return parsedOverride;
+  }
+
+  const detectedWorkers = Number.isSafeInteger(logicalCpuCount)
+    ? logicalCpuCount
+    : 0;
+  return Math.max(minimumComponentTestWorkers, detectedWorkers);
+}
+
+export function buildVitestComponentArgs({
+  componentTests,
+  env = process.env,
+  forwardedArgs = [],
+  logicalCpuCount = detectLogicalCpuCount(),
+}: {
+  componentTests: readonly string[];
+  env?: ComponentTestEnvironment;
+  forwardedArgs?: readonly string[];
+  logicalCpuCount?: number;
+}) {
+  return [
+    "run",
+    "--config",
+    "vitest.lanes.config.ts",
+    "--project=dashboard-component",
+    `--maxWorkers=${getComponentTestMaxWorkers(env, logicalCpuCount)}`,
+    "--retry=0",
+    ...forwardedArgs,
+    ...componentTests,
+  ];
+}

--- a/ui/scripts/run-bun-component-tests.ts
+++ b/ui/scripts/run-bun-component-tests.ts
@@ -2,6 +2,10 @@ import { listComponentTestFiles } from "./component-test-files";
 
 const ISOLATED_COMPONENT_TEST_MARKER = ".isolated.bun.component.test.tsx";
 const PRELOAD_PATH = "./src/testing/bun/component.setup.ts";
+// The Bun and Vitest component runners share the four-vCPU CI job. Keep Bun's
+// test scheduler from consuming the entire host while Vitest uses its four
+// configured workers.
+const MAX_COMPONENT_TEST_CONCURRENCY = "4";
 
 const componentTests = listComponentTestFiles()
   .filter((file) => file.runner === "bun")
@@ -30,6 +34,7 @@ function runComponentTests(files: string[]): void {
       PRELOAD_PATH,
       "--reporter=dots",
       "--timeout=10000",
+      `--max-concurrency=${MAX_COMPONENT_TEST_CONCURRENCY}`,
       ...files,
     ],
     cwd: process.cwd(),

--- a/ui/scripts/run-bun-component-tests.ts
+++ b/ui/scripts/run-bun-component-tests.ts
@@ -2,10 +2,6 @@ import { listComponentTestFiles } from "./component-test-files";
 
 const ISOLATED_COMPONENT_TEST_MARKER = ".isolated.bun.component.test.tsx";
 const PRELOAD_PATH = "./src/testing/bun/component.setup.ts";
-// The Bun and Vitest component runners share the four-vCPU CI job. Keep Bun's
-// test scheduler from consuming the entire host while Vitest uses its four
-// configured workers.
-const MAX_COMPONENT_TEST_CONCURRENCY = "4";
 
 const componentTests = listComponentTestFiles()
   .filter((file) => file.runner === "bun")
@@ -34,7 +30,6 @@ function runComponentTests(files: string[]): void {
       PRELOAD_PATH,
       "--reporter=dots",
       "--timeout=10000",
-      `--max-concurrency=${MAX_COMPONENT_TEST_CONCURRENCY}`,
       ...files,
     ],
     cwd: process.cwd(),

--- a/ui/scripts/run-vitest-component-tests.ts
+++ b/ui/scripts/run-vitest-component-tests.ts
@@ -1,4 +1,5 @@
 import { listComponentTestFiles } from "./component-test-files";
+import { buildVitestComponentArgs } from "./component-test-workers";
 
 const componentTests = listComponentTestFiles()
   .filter((file) => file.runner === "vitest")
@@ -16,14 +17,10 @@ const result = Bun.spawnSync({
   cmd: [
     "bunx",
     "vitest",
-    "run",
-    "--config",
-    "vitest.lanes.config.ts",
-    "--project=dashboard-component",
-    "--maxWorkers=2",
-    "--retry=0",
-    ...process.argv.slice(2),
-    ...componentTests,
+    ...buildVitestComponentArgs({
+      componentTests,
+      forwardedArgs: process.argv.slice(2),
+    }),
   ],
   cwd: process.cwd(),
   stderr: "inherit",


### PR DESCRIPTION
{
  "project": "CPU-Aware Vitest Component Worker Count",
  "branchName": "perf-c1-vitest-component-worker-count",
  "description": "Reduce Frontend Component CI latency by replacing the Vitest component runner's unconditional two-worker limit with CPU-derived, environment-overrideable concurrency, explicitly using the four-vCPU CI capacity when memory permits, and proving performance and isolation on two consecutive green runs without changing component tests or unmeasured runners.",
  "context": {
    "customerAsk": "Replace the Vitest component runner's unconditional two-worker limit with CPU-aware, overrideable concurrency, use the four-vCPU CI runner effectively, and prove on two consecutive green runs that the component lane becomes materially faster without cross-file state leakage, test-count changes, or memory failures.",
    "problem": "Green CI run 32509668745, Frontend Component job 96858752107, took 209 seconds wall-clock; make ui-component-test consumed 199.4 seconds and Vitest reported 198.07 seconds over 166 files and 1,018 tests. The runner always passes --maxWorkers=2 on a four-vCPU host even though import and jsdom environment phases dominate the duration.",
    "solution": "Resolve UI_COMPONENT_TEST_MAX_WORKERS as a validated positive-integer override, otherwise use the detected logical CPU count with a floor of two; configure only the Frontend Component job for four workers, preserve existing test selection and process behavior, cover worker selection directly, and require two consecutive final-head CI runs to prove unchanged counts, stability, and the latency target, with a measured fallback to three workers if four is memory-bound."
  },
  "acceptanceCriteria": [
    "With no override, the Vitest component runner passes a CPU-derived --maxWorkers value with a floor of two; a valid positive-integer UI_COMPONENT_TEST_MAX_WORKERS value takes precedence, and invalid values stop with an actionable error rather than launching Vitest ambiguously.",
    "The Frontend Component job configures UI_COMPONENT_TEST_MAX_WORKERS to 4, or to 3 only when final-head CI evidence shows four-way execution is memory-bound; no other CI job block or UI runner is changed without comparable measurement.",
    "On two consecutive green runs of the same final PR head, the Vitest component lane reports 166 passed (166) files and 1018 passed (1018) tests with zero new failures, demonstrating no observable cross-file state leakage.",
    "On both consecutive green runs, Vitest's Duration and the make ui-component-test step are each no more than 150 seconds, and the Frontend Component job wall-clock is no more than 165 seconds; the PR comment identifies the exact CI runs, job, command or step, and reported values, and local Windows timings are not accepted as comparative evidence.",
    "Typecheck and focused tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "perf-c1-vitest-component-worker-count-001",
      "title": "Select component-test concurrency from the host or an override",
      "description": "As a frontend maintainer, I want the Vitest component runner to choose an explicit, configurable worker count so that it can use available CPU capacity while remaining predictable on constrained or shared hosts.",
      "acceptanceCriteria": [
        "When UI_COMPONENT_TEST_MAX_WORKERS is absent, an invocation on a detected host uses its logical CPU count for --maxWorkers, with any detected count below two raised to two.",
        "A valid positive-integer UI_COMPONENT_TEST_MAX_WORKERS value overrides CPU detection and is passed to Vitest exactly once.",
        "An empty, non-integer, zero, or negative override fails before Vitest starts and explains the accepted value shape.",
        "Existing component-file selection, --retry=0, forwarded arguments, exit status, and output streaming remain unchanged.",
        "Focused runner tests directly exercise default, floor, valid-override, and invalid-override behavior without changing tests under ui/src.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented CPU-derived worker selection with a two-worker floor, validated UI_COMPONENT_TEST_MAX_WORKERS override, preserved Vitest arguments, and added focused script-level tests."
    },
    {
      "id": "perf-c1-vitest-component-worker-count-002",
      "title": "Run and verify the Frontend Component lane at higher concurrency",
      "description": "As a contributor waiting on CI, I want the Frontend Component job to use the measured runner capacity so that feedback arrives faster without reducing test reliability.",
      "acceptanceCriteria": [
        "Only the Frontend Component job sets UI_COMPONENT_TEST_MAX_WORKERS, initially to 4; edits from perf-l1-ci-lint-parallelism in its separate job block are preserved during rebase and conflict resolution.",
        "Before final push, the branch is rebased onto current origin/main; sibling runner findings are reported in the PR, but ui-unit-runner.mjs, ui-integration-runner.mjs, and ui-coverage-runner.mjs remain unchanged because this lane has no comparable measurements for them.",
        "Neither run shows OOM, exit 137, or another memory-pressure failure; if four workers is memory-bound, the job uses three workers instead and the PR comment records the failed four-worker evidence and measured fallback rationale.",
        "CI measurements are recorded in a PR comment with exact run and job identifiers and are never committed to the repository.",
        "Typecheck passes",
        "Tests pass",
        "OPERATOR-REVISED 2026-08-22: push your final head, ensure the PR is open, READY (not draft) and has CI started.",
        "OPERATOR-REVISED: post ONE PR comment containing the evidence you have ALREADY gathered - exact run and job IDs, the measured wall-clock numbers, and the selected jobs/worker settings. Report the numbers you actually observed; do not round toward the target and do not describe an unmeasured value as passing.",
        "OPERATOR-REVISED: under a heading 'Operator-owned verification', state plainly which measurements still require repeated runs to confirm, and that the operator owns them. Naming the gap honestly SATISFIES this criterion; claiming a result you did not measure does NOT.",
        "OPERATOR-REVISED: if any run you already have shows OOM, exit 137, 'signal: killed', or an allocation failure, say so explicitly - that is a blocking safety finding and must not be omitted.",
        "OPERATOR-REVISED: then STOP and hand off to review. Do NOT trigger further CI runs to accumulate repeat measurements, and do NOT push a new commit merely to re-measure."
      ],
      "priority": 2,
      "passes": true,
      "latestReviewCheck": "2026-08-22 handoff: PR #2133 remains open, non-draft, mergeable, and fully green at pushed head 8ff0f94f33983c052574d3b5b32c494cf1e99a56; the worktree HEAD and remote head match. The prior blocking comment (#5376695291) was addressed against the operator-revised story criteria, and operator waiver #5379215041 explicitly withdraws the unsatisfiable exact-count criterion without requiring a new commit or CI run. The final-head evidence and operator-owned verification gap remain recorded in PR comment #5376620117. No code or CI refresh was needed.",
      "latestHostedEvidence": "Run 32533935895 / Frontend Component job 96931312510 on final head 8ff0f94f33983c052574d3b5b32c494cf1e99a56: 167/167 files and 1022/1022 tests, no OOM/exit-137/memory-pressure failure, Vitest 162.83s, component step 164.26s, and job wall-clock about 188s. This green workflow result misses the PRD's 166/166, 1018/1018, 150s, 150s, and 165s limits; evidence is in PR comment https://github.com/portpowered/you-agent-factory/pull/2133#issuecomment-5376476953. The prior 166/166 qualifying component candidate was on old head b0595fba0 and its workflow was non-terminal, so it cannot count toward the required final-head pair.",
      "notes": "Configured only the Frontend Component job with UI_COMPONENT_TEST_MAX_WORKERS=4; sibling runners and component test selection remain unchanged. Rebased the implementation cleanly onto current origin/main and force-with-lease pushed final head 8ff0f94f33983c052574d3b5b32c494cf1e99a56. Focused worker-selection tests (9/9), UI typecheck, Biome, and diff checks pass locally. Posted the required evidence summary in PR comment https://github.com/portpowered/you-agent-factory/pull/2133#issuecomment-5376620117. The final hosted workflow 32533935895 is green, but its component job reports 167/167 files, 1022/1022 tests, Vitest 162.83s, component step 164.26s, and about 188s job wall-clock. These measurements remain honestly recorded; the operator-owned verification and criterion-3 waiver are documented in PR comment https://github.com/portpowered/you-agent-factory/pull/2133#issuecomment-5379215041.",
      "operatorRevisedFrom": [
        "Only the Frontend Component job sets UI_COMPONENT_TEST_MAX_WORKERS, initially to 4; edits from perf-l1-ci-lint-parallelism in its separate job block are preserved during rebase and conflict resolution.",
        "Before final push, the branch is rebased onto current origin/main; sibling runner findings are reported in the PR, but ui-unit-runner.mjs, ui-integration-runner.mjs, and ui-coverage-runner.mjs remain unchanged because this lane has no comparable measurements for them.",
        "Two consecutive green runs of the same final PR head each report 166 passed (166) files, 1018 passed (1018) tests, and zero new failures.",
        "In each qualifying run, Vitest's Duration and the make ui-component-test step are no more than 150 seconds, and the Frontend Component job wall-clock is no more than 165 seconds.",
        "Neither run shows OOM, exit 137, or another memory-pressure failure; if four workers is memory-bound, the job uses three workers instead and the PR comment records the failed four-worker evidence and measured fallback rationale.",
        "CI measurements are recorded in a PR comment with exact run and job identifiers and are never committed to the repository.",
        "Typecheck passes",
        "Tests pass"
      ],
      "operatorNote": "Revised 2026-08-22 by the operator. Criteria requiring repeated same-head confirmation runs were removed because satisfying them consumed a visit per check and was about to trip the visit breaker on an already-green PR. The repeated-run verification is now OPERATOR-OWNED. Originals preserved in operatorRevisedFrom. No unmet numeric target has been marked as passing."
    }
  ]
}
