### PR TITLE
RSM-8: truth up record, replay, and resume docs

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -30,7 +30,7 @@ concept owners below when you need the complete customer-facing contract.
 | `factory-validation` | Required pre-run static gate, current validation checks, exact source commands, and validation limits | [Factory validation](factory-validation.md) |
 | `mock-workers` | `--with-mock-workers` and the `mockWorkers` JSON contract | [Mock workers](mock-workers.md) |
 | `record-replay` | Default recording, `--record`, `--replay`, `--resume`, and `--no-record` | [Record, replay, and resume](record-replay.md) |
-| `operations` | Real-pipeline lifetime, finite-drain classification, and same-name restart recovery | [Operations](operations.md) |
+| `operations` | Real-pipeline lifetime, finite-drain classification, and recorded-state restart recovery | [Operations](operations.md) |
 | `work` | Submitted work: session-scoped work routes, tags, and batch cross-links | [Submitted work](work.md) |
 | `sessions` | Session list, session show, pause and resume, factory query, status API, dashboard, and run modes | [Sessions](sessions.md) |
 | `metrics` | Factory Runtime metrics and exact operator-configured cost rollups with deterministic grouping, coverage, and Factory Session scope | [Metrics](metrics.md) |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -29,7 +29,7 @@ concept owners below when you need the complete customer-facing contract.
 | `config` | Operator initialization plus Factory validation, transformation, and minimum authoring contract | [Config](config.md) and [Author factories](authoring-factories.md) |
 | `factory-validation` | Required pre-run static gate, current validation checks, exact source commands, and validation limits | [Factory validation](factory-validation.md) |
 | `mock-workers` | `--with-mock-workers` and the `mockWorkers` JSON contract | [Mock workers](mock-workers.md) |
-| `record-replay` | Default recording, `--record`, `--replay`, and `--no-record` | [Record and replay](record-replay.md) |
+| `record-replay` | Default recording, `--record`, `--replay`, `--resume`, and `--no-record` | [Record, replay, and resume](record-replay.md) |
 | `operations` | Real-pipeline lifetime, finite-drain classification, and same-name restart recovery | [Operations](operations.md) |
 | `work` | Submitted work: session-scoped work routes, tags, and batch cross-links | [Submitted work](work.md) |
 | `sessions` | Session list, session show, pause and resume, factory query, status API, dashboard, and run modes | [Sessions](sessions.md) |
@@ -135,9 +135,9 @@ Use these canonical concept owners when you need the current contract.
   full variable inventory, and the JSON-versus-Markdown quoting rules.
 - [Mock workers](mock-workers.md) owns `--with-mock-workers`, the
   `mockWorkers` JSON contract, selection fields, and `runType` outcomes.
-- [Record and replay](record-replay.md) owns default recording, generated
-  artifact paths, `--record`, `--replay`, `--no-record`, and incompatible flag
-  combinations.
+- [Record, replay, and resume](record-replay.md) owns default recording,
+  generated artifact paths, `--record`, `--replay`, `--resume`, `--no-record`,
+  successor recordings, and incompatible flag combinations.
 - [Author factories](authoring-factories.md) keeps factory sequencing, quick-start
   run commands, reusable [`docs/examples/`](../examples/README.md) inputs, and
   links to the dedicated mock-worker and record/replay guides.

--- a/docs/reference/authoring-factories.md
+++ b/docs/reference/authoring-factories.md
@@ -394,7 +394,7 @@ listening server.
 Live runs record a replay-compatible artifact by default. Use `--no-record`,
 `--record <path>`, `--replay <path>`, or `--resume <recording>` when you need to
 override capture, playback, or continuation. Resume writes a successor
-recording by default; `--record <path>` selects its path. Run `you docs
+recording by default. Use `--record <path>` to select its path. Run `you docs
 record-replay` for generated paths, incompatible flag combinations, sensitivity
 warnings, and copy-pasteable record, replay, and resume examples.
 

--- a/docs/reference/authoring-factories.md
+++ b/docs/reference/authoring-factories.md
@@ -1,6 +1,6 @@
 ---
 author: Agent Factory Team
-last-modified: 2026-08-09
+last-modified: 2026-08-21
 doc-id: agent-factory/authoring-factories
 ---
 
@@ -392,10 +392,11 @@ The command loads the selected JSON or YAML definition, resolves the split
 listening server.
 
 Live runs record a replay-compatible artifact by default. Use `--no-record`,
-`--record <path>`, or `--replay <path>` when you need to override capture or
-playback. Run `you docs record-replay` for generated paths, incompatible flag
-combinations, sensitivity warnings, and copy-pasteable record and replay
-examples.
+`--record <path>`, `--replay <path>`, or `--resume <recording>` when you need to
+override capture, playback, or continuation. Resume writes a successor
+recording by default; `--record <path>` selects its path. Run `you docs
+record-replay` for generated paths, incompatible flag combinations, sensitivity
+warnings, and copy-pasteable record, replay, and resume examples.
 
 Run `you docs mock-workers` for the `--with-mock-workers` JSON contract,
 selection fields, and deterministic outcome examples beyond this quick start.

--- a/docs/reference/javascript-workflows.md
+++ b/docs/reference/javascript-workflows.md
@@ -1,6 +1,6 @@
 ---
 author: Agent Factory Team
-last-modified: 2026-07-30
+last-modified: 2026-08-21
 doc-id: agent-factory/guides/javascript-workflows
 ---
 
@@ -297,7 +297,7 @@ VM internals part of the inspection contract.
 | Non-JSON checkpoint, artifact, log fields, or final value | Execution fails with a bounded `must be JSON-compatible` diagnostic. | The session, earlier dispatches/artifacts/events, and any approved checkpoint references remain inspectable; the rejected value is not promised as an artifact. | Convert the value to JSON data without functions, cycles, or host objects. |
 | Result not ready | Result reads return `resultStatus: NOT_READY` with availability reason `RESULT_NOT_READY`; this is retryable while the session is running. | Status, partial result when present, dispatches, artifacts, and events remain inspectable. | Poll status/events and retry the result read after progress or a terminal transition. |
 | Factory Session not found | CLI reports `SESSION_NOT_FOUND`; REST uses `NOT_FOUND`; MCP returns its Factory Session not-found error envelope. | Nothing is inspectable for that identifier. | Reuse the exact `sessionId` returned by start and confirm the same runtime/storage scope. |
-| Recording flag conflict | `--record` with `--replay`, or `--no-record` with `--record`, is rejected before execution. | No new session or session-owned facts. | Choose one recording mode; see `you docs record-replay`. |
+| Recording flag conflict | `--record` with `--replay`, `--no-record` with `--record`, `--resume` with `--replay`, or `--resume` with `--no-record` is rejected before execution. | No new session or session-owned facts. | Choose one recording mode; see `you docs record-replay`. |
 | Missing, malformed, or incompatible replay | Replay load fails before reconstruction; unsupported artifacts report `unsupported replay artifact schemaVersion`. | No reconstructed session is created from the rejected file; the file itself remains unchanged. | Use an artifact with the supported schema, regenerate it with a compatible `you` version, or run live to create a new recording. |
 
 A successful final result has `resultStatus: FINAL`. A running session can be
@@ -312,4 +312,4 @@ Use the session lifecycle status together with result status and availability.
 - `you docs sessions` — session discovery and inspection
 - `you docs mcp` — fixture-backed and runtime-backed MCP host setup
 - `you docs config` — worker preset and operator-default configuration
-- `you docs record-replay` — recording and replay modes
+- `you docs record-replay` — recording, replay, and resume modes

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -427,9 +427,9 @@ hot-reload check.
 
 The live Factory Session queue is process-local and in memory, but its admitted
 Work and dispatch lifecycle are represented in the Factory Event recording.
-Restarting the process loses the running queue and provider process; it does
-not make recorded Work unrecoverable. A retained recording can reconstruct the
-recorded Factory state in a new live Factory Session with
+Restarting the process loses the running queue and provider process.
+It does not make recorded Work unrecoverable. A retained recording can
+reconstruct the recorded Factory state in a new live Factory Session with
 `you run --resume <recording>`. Resume reads the source without overwriting it
 and writes a successor recording by default. Use `--record <successor-path>` to
 choose that path.
@@ -438,13 +438,13 @@ Resume re-admits recorded non-terminal Work, including Work that was queued or
 in flight at the stop boundary. Terminal Work represented by the recording is
 not dispatched again, and a completed dispatch remains one completed dispatch
 in the successor. A dispatch without a recorded completion can run again after
-resume. This is not an exactly-once provider-effect guarantee: a provider may
-have performed an effect before the process stopped, so make provider-side
-operations idempotent when duplicate attempts matter.
+resume. This is not an exactly-once provider-effect guarantee.
+A provider may have performed an effect before the process stopped.
+Make provider-side operations idempotent when duplicate attempts matter.
 
 Work that never reached a durable Factory Event is not recoverable from that
 recording. Portable JavaScript recordings remain replay and inspection
-artifacts; they do not contain a JavaScript VM or provider process and cannot be
+artifacts. They do not contain a JavaScript VM or provider process and cannot be
 passed to `--resume`. Unfinalized recordings with a valid complete event prefix
 are supported. A truncated final event-stream block can be skipped after
 earlier complete events. Mid-stream corruption and recordings without a valid
@@ -458,23 +458,21 @@ Use this recovery sequence:
    `you run --resume <recording> --record <successor-path>` and inspect both
    recording paths. Confirm that recorded terminal Work was not dispatched
    again and that recorded non-terminal Work was re-admitted.
-3. If the intended Work was never admitted into the recording, start a new
-   Factory Session with the continuous server shape above and resubmit it
-   through the normal Work ingress, preserving its authored `name`. Do not
-   invent a new name just because the old process stopped.
-   This same-name resubmit fallback applies only to Work absent from the
-   recoverable recording.
-4. For resubmitted Work, let the workstation's worktree template render from
-   that same name. For a template such as
-   `.claude/worktrees/{{ (index .Inputs 0).Name }}`, the new dispatch targets
-   the existing named artifact directory when the runtime's worktree rules
-   allow it.
+3. If Work was never admitted into the recording, start a new Factory Session.
+   Use the continuous server shape above.
+   Resubmit the Work through the normal Work ingress with its authored `name`.
+   Do not invent a new name because the old process stopped.
+   This is the same-name resubmit fallback. It applies only to Work absent from
+   the recoverable recording.
+4. Use the same name in the Workstation worktree template.
+   For `.claude/worktrees/{{ (index .Inputs 0).Name }}`, runtime rules can
+   target the existing named artifact directory.
 5. Verify resumed or resubmitted Work reaches an explicit terminal or failed
    state. A successful recovery proves only that this recovery worked for that
-   Work; provider-side exactly-once effects still require idempotency.
+   Work. Provider-side exactly-once effects still require idempotency.
 
 The six production recoveries recorded on 2026-08-08/09 remain historical
-operational evidence for the same-name fallback; they are not a durability
+operational evidence for the same-name fallback. They are not a durability
 guarantee or a substitute for inspecting the source and successor recordings.
 
 For a copyable record → kill → resume journey with a fresh binary and isolated

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -425,16 +425,17 @@ reload behavior is covered by the functional prompt hot-reload check.
 ## Recover after a process restart
 
 The live Factory Session queue is process-local and in memory. Restarting the
-process loses the live queue, but a retained Factory Event recording can seed a
-new live Factory Session with `you run --resume <recording>`. Resume reads the
-source without overwriting it and writes a successor recording by default. Use
-`--record <successor-path>` to choose that path.
+process loses the live queue. A retained Factory Event recording can reconstruct
+the recorded Factory state in a new live Factory Session with
+`you run --resume <recording>`. Resume reads the source without overwriting it
+and writes a successor recording by default. Use `--record <successor-path>` to
+choose that path.
 
-Resume restores the last valid Factory world state. Terminal Work is not
-dispatched again. Queued Work can become eligible, and nonterminal Work can
-receive a new live attempt. A provider effect may run again when its completion
-event was not recorded before the process stopped, so provider-side operations
-that matter should be idempotent.
+Resume does not make the lost queue durable. Terminal Work represented by the
+recording is not dispatched again. Work that was queued or in flight when the
+process stopped is not guaranteed to be re-admitted by `--resume`. A provider
+effect can run again if you resubmit interrupted Work, so provider-side
+operations that matter should be idempotent.
 
 Portable JavaScript recordings remain replay and inspection artifacts. They do
 not contain a JavaScript VM or provider process and cannot be passed to
@@ -448,30 +449,29 @@ Use this recovery sequence:
 1. Inspect any durable artifacts first: the existing worktree, generated
    outputs, runtime logs, and any recording that was explicitly retained.
 2. If the recording contains recoverable Factory Event history, run
-   `you run --resume <recording>` and inspect the successor recording path.
-   Continue at step 6.
-3. If resume is unavailable, start a new Factory Session with the continuous
-   server shape above.
-4. For that new session, resubmit the intended Work through the normal Work
-   ingress, preserving each
+   `you run --resume <recording> --record <successor-path>` and inspect both
+   recording paths. Successor creation reconstructs recorded state. It does not
+   prove that interrupted Work was dispatched.
+3. Start a new Factory Session with the continuous server shape above.
+4. Resubmit the intended Work through the normal Work ingress, preserving each
    Work's authored `name`. Do not invent a new name just because the old
    process stopped.
 5. For that new session, let the workstation's worktree template render from
-   that same name. For a
-   template such as
-   `.claude/worktrees/{{ (index .Inputs 0).Name }}`, the resumed dispatch
-   targets the existing named artifact directory; valid existing worktrees are
-   reusable when the runtime's worktree rules allow it.
-6. Verify the resumed Work reaches an explicit terminal or failed state. A
-   successful recovery proves only that this recovery worked for that Work; it
+   that same name. For a template such as
+   `.claude/worktrees/{{ (index .Inputs 0).Name }}`, the new dispatch targets
+   the existing named artifact directory when the runtime's worktree rules
+   allow it.
+6. Verify the resubmitted Work reaches an explicit terminal or failed state. A
+   successful recovery proves only that this recovery worked for that Work. It
    does not make the original in-memory queue durable.
 
 The six production recoveries recorded on 2026-08-08/09 are operational
 evidence that this inspect → restart → same-name resubmit procedure worked in
 those cases. They are not a durability guarantee, restart replay contract, or
-promise that every provider dispatch can be resumed automatically. Prefer
-`--resume` when the retained recording has the Factory Event history required
-for live continuation.
+promise that every provider dispatch can be resumed automatically. Use
+`--resume` to reconstruct recorded state and write a successor. Use the
+same-name resubmit procedure for Work that the stopped process had not recorded
+as terminal.
 
 ## Related topics
 

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -418,31 +418,37 @@ This includes the worker and workstation `AGENTS.md` files in the split
 layout, plus a workstation `promptFile` when one is configured. Save an edit
 before the next dispatch and that next dispatch uses the new prompt. An
 already-running dispatch keeps the prompt snapshot it already received;
-editing a file does not mutate an in-flight dispatch, restore lost Work, or
-restore the in-memory Factory Session queue after a restart. The dispatch-time
-reload behavior is covered by the functional prompt hot-reload check.
+editing a file does not mutate an in-flight dispatch or by itself restore a
+stopped session. Use the record/replay/resume path for recorded Work after a
+restart. The dispatch-time reload behavior is covered by the functional prompt
+hot-reload check.
 
 ## Recover after a process restart
 
-The live Factory Session queue is process-local and in memory. Restarting the
-process loses the live queue. A retained Factory Event recording can reconstruct
-the recorded Factory state in a new live Factory Session with
+The live Factory Session queue is process-local and in memory, but its admitted
+Work and dispatch lifecycle are represented in the Factory Event recording.
+Restarting the process loses the running queue and provider process; it does
+not make recorded Work unrecoverable. A retained recording can reconstruct the
+recorded Factory state in a new live Factory Session with
 `you run --resume <recording>`. Resume reads the source without overwriting it
 and writes a successor recording by default. Use `--record <successor-path>` to
 choose that path.
 
-Resume does not make the lost queue durable. Terminal Work represented by the
-recording is not dispatched again. Work that was queued or in flight when the
-process stopped is not guaranteed to be re-admitted by `--resume`. A provider
-effect can run again if you resubmit interrupted Work, so provider-side
-operations that matter should be idempotent.
+Resume re-admits recorded non-terminal Work, including Work that was queued or
+in flight at the stop boundary. Terminal Work represented by the recording is
+not dispatched again, and a completed dispatch remains one completed dispatch
+in the successor. A dispatch without a recorded completion can run again after
+resume. This is not an exactly-once provider-effect guarantee: a provider may
+have performed an effect before the process stopped, so make provider-side
+operations idempotent when duplicate attempts matter.
 
-Portable JavaScript recordings remain replay and inspection artifacts. They do
-not contain a JavaScript VM or provider process and cannot be passed to
-`--resume`. Unfinalized recordings with a valid complete event prefix are
-supported. A truncated final event-stream block can be skipped after earlier
-complete events. Mid-stream corruption and recordings without a valid complete
-event are rejected.
+Work that never reached a durable Factory Event is not recoverable from that
+recording. Portable JavaScript recordings remain replay and inspection
+artifacts; they do not contain a JavaScript VM or provider process and cannot be
+passed to `--resume`. Unfinalized recordings with a valid complete event prefix
+are supported. A truncated final event-stream block can be skipped after
+earlier complete events. Mid-stream corruption and recordings without a valid
+complete event are rejected.
 
 Use this recovery sequence:
 
@@ -450,28 +456,29 @@ Use this recovery sequence:
    outputs, runtime logs, and any recording that was explicitly retained.
 2. If the recording contains recoverable Factory Event history, run
    `you run --resume <recording> --record <successor-path>` and inspect both
-   recording paths. Successor creation reconstructs recorded state. It does not
-   prove that interrupted Work was dispatched.
-3. Start a new Factory Session with the continuous server shape above.
-4. Resubmit the intended Work through the normal Work ingress, preserving each
-   Work's authored `name`. Do not invent a new name just because the old
-   process stopped.
-5. For that new session, let the workstation's worktree template render from
+   recording paths. Confirm that recorded terminal Work was not dispatched
+   again and that recorded non-terminal Work was re-admitted.
+3. If the intended Work was never admitted into the recording, start a new
+   Factory Session with the continuous server shape above and resubmit it
+   through the normal Work ingress, preserving its authored `name`. Do not
+   invent a new name just because the old process stopped.
+   This same-name resubmit fallback applies only to Work absent from the
+   recoverable recording.
+4. For resubmitted Work, let the workstation's worktree template render from
    that same name. For a template such as
    `.claude/worktrees/{{ (index .Inputs 0).Name }}`, the new dispatch targets
    the existing named artifact directory when the runtime's worktree rules
    allow it.
-6. Verify the resubmitted Work reaches an explicit terminal or failed state. A
-   successful recovery proves only that this recovery worked for that Work. It
-   does not make the original in-memory queue durable.
+5. Verify resumed or resubmitted Work reaches an explicit terminal or failed
+   state. A successful recovery proves only that this recovery worked for that
+   Work; provider-side exactly-once effects still require idempotency.
 
-The six production recoveries recorded on 2026-08-08/09 are operational
-evidence that this inspect → restart → same-name resubmit procedure worked in
-those cases. They are not a durability guarantee, restart replay contract, or
-promise that every provider dispatch can be resumed automatically. Use
-`--resume` to reconstruct recorded state and write a successor. Use the
-same-name resubmit procedure for Work that the stopped process had not recorded
-as terminal.
+The six production recoveries recorded on 2026-08-08/09 remain historical
+operational evidence for the same-name fallback; they are not a durability
+guarantee or a substitute for inspecting the source and successor recordings.
+
+For a copyable record → kill → resume journey with a fresh binary and isolated
+temporary directory, use the procedure in `you docs record-replay`.
 
 ## Related topics
 

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -1,6 +1,6 @@
 ---
 author: Agent Factory Team
-last-modified: 2026-08-12
+last-modified: 2026-08-21
 doc-id: agent-factory/guides/operations
 ---
 
@@ -425,33 +425,53 @@ reload behavior is covered by the functional prompt hot-reload check.
 ## Recover after a process restart
 
 The live Factory Session queue is process-local and in memory. Restarting the
-process loses queued and in-flight live session state; there is no storage
-engine available that reconstructs that queue. Recordings, runtime logs,
-artifacts, and files already written to a worktree can still be useful for
-inspection, but they are evidence for recovery, not a durable session queue or
-automatic replay guarantee.
+process loses the live queue, but a retained Factory Event recording can seed a
+new live Factory Session with `you run --resume <recording>`. Resume reads the
+source without overwriting it and writes a successor recording by default. Use
+`--record <successor-path>` to choose that path.
+
+Resume restores the last valid Factory world state. Terminal Work is not
+dispatched again. Queued Work can become eligible, and nonterminal Work can
+receive a new live attempt. A provider effect may run again when its completion
+event was not recorded before the process stopped, so provider-side operations
+that matter should be idempotent.
+
+Portable JavaScript recordings remain replay and inspection artifacts. They do
+not contain a JavaScript VM or provider process and cannot be passed to
+`--resume`. Unfinalized recordings with a valid complete event prefix are
+supported. A truncated final event-stream block can be skipped after earlier
+complete events. Mid-stream corruption and recordings without a valid complete
+event are rejected.
 
 Use this recovery sequence:
 
 1. Inspect any durable artifacts first: the existing worktree, generated
    outputs, runtime logs, and any recording that was explicitly retained.
-2. Start a new Factory Session with the continuous server shape above.
-3. Resubmit the intended Work through the normal Work ingress, preserving each
+2. If the recording contains recoverable Factory Event history, run
+   `you run --resume <recording>` and inspect the successor recording path.
+   Continue at step 6.
+3. If resume is unavailable, start a new Factory Session with the continuous
+   server shape above.
+4. For that new session, resubmit the intended Work through the normal Work
+   ingress, preserving each
    Work's authored `name`. Do not invent a new name just because the old
    process stopped.
-4. Let the workstation's worktree template render from that same name. For a
+5. For that new session, let the workstation's worktree template render from
+   that same name. For a
    template such as
    `.claude/worktrees/{{ (index .Inputs 0).Name }}`, the resumed dispatch
    targets the existing named artifact directory; valid existing worktrees are
    reusable when the runtime's worktree rules allow it.
-5. Verify the resumed Work reaches an explicit terminal or failed state. A
-   successful resubmission proves only that this recovery worked for that
-   Work; it does not make the original in-memory queue durable.
+6. Verify the resumed Work reaches an explicit terminal or failed state. A
+   successful recovery proves only that this recovery worked for that Work; it
+   does not make the original in-memory queue durable.
 
 The six production recoveries recorded on 2026-08-08/09 are operational
 evidence that this inspect → restart → same-name resubmit procedure worked in
 those cases. They are not a durability guarantee, restart replay contract, or
-promise that every provider dispatch can be resumed automatically.
+promise that every provider dispatch can be resumed automatically. Prefer
+`--resume` when the retained recording has the Factory Event history required
+for live continuation.
 
 ## Related topics
 

--- a/docs/reference/orchestrators.md
+++ b/docs/reference/orchestrators.md
@@ -163,9 +163,10 @@ The current canonical operator story is intentionally bounded:
 - Durable JavaScript execution inspection belongs to `FactorySession`,
   `Dispatch`, `FactoryArtifact`, and `FactoryEvent` reads across CLI, API,
   dashboard, and MCP-compatible docs.
-- Replay-resume expansion, broader live-provider bridge parity, and broader MCP
-  host parity remain explicit follow-up scope, not implied capabilities of the
-  current shipped session model.
+- Portable JavaScript recording resume is not supported. See `you docs
+  record-replay` for the supported Factory Event resume path and portable
+  recording limits. Broader live-provider bridge parity and broader MCP host
+  parity remain follow-up scope for the current shipped session model.
 
 ## Related Topics
 

--- a/docs/reference/record-replay.md
+++ b/docs/reference/record-replay.md
@@ -53,8 +53,8 @@ recording.
 
 **Resume mode** reads a recoverable Factory Event recording, reconstructs its
 last valid Factory world state, and opens a new live Factory Session from that
-state. Pass `--resume <path>`. Resume can dispatch eligible Work again and
-writes a successor recording.
+state. Pass `--resume <path>`. Resume writes a successor recording, but it does
+not make the original live Factory Session queue durable.
 
 ## Run Controls
 
@@ -97,19 +97,28 @@ you run --resume ./recordings/source.json \
   --record ./recordings/successor.json
 ```
 
-Resume restores Work from the recovered world state with these boundaries:
+Resume restores the recorded Work state with these boundaries:
 
 - Work in a terminal state is not dispatched again.
-- Queued Work is restored and can become eligible for dispatch.
-- Nonterminal Work that was in flight can receive a new live attempt after
-  resume.
-- A provider effect that completed before its completion event was recorded can
-  run again. Use idempotent provider-side operations when duplicate attempts
-  would matter.
+- Only Work state represented by recorded Factory Events is reconstructed.
+- The live queue is process-local. Work that was queued or in flight when the
+  source process stopped is not guaranteed to be re-admitted by `--resume`.
 
-This is not an exactly-once provider-effect guarantee. The recorded terminal
-state prevents duplicate dispatch of completed Work, while an incomplete
-provider attempt can be retried after recovery.
+This is not an exactly-once provider-effect guarantee. If you resubmit Work
+after a process stop, a provider-side effect may run again. Make provider-side
+operations idempotent when duplicate attempts would matter.
+
+### Process-kill recovery boundary
+
+The live Factory Session queue and provider process are not stored in a
+recording. A process-kill can leave a valid, unfinalized recording while Work
+was queued or in flight. `--resume` can read the valid prefix and write a
+successor, but successor creation does not prove that interrupted Work was
+continued.
+
+For interrupted Work, start a new live Factory Session and resubmit the Work
+with its original authored `name`. Inspect the source and successor recordings
+separately. See `you docs operations` for the complete restart procedure.
 
 The runtime accepts an unfinalized recording when it has a valid complete event
 prefix. It can also skip a truncated final event-stream block after earlier

--- a/docs/reference/record-replay.md
+++ b/docs/reference/record-replay.md
@@ -53,8 +53,11 @@ recording.
 
 **Resume mode** reads a recoverable Factory Event recording, reconstructs its
 last valid Factory world state, and opens a new live Factory Session from that
-state. Pass `--resume <path>`. Resume writes a successor recording, but it does
-not make the original live Factory Session queue durable.
+state. Pass `--resume <path>`. Recorded non-terminal Work is seeded back into
+the live scheduler, including Work that was queued or in flight when the
+source process stopped. Resume writes a separate successor recording; it does
+not preserve the original process-local queue or provider process as a live
+object.
 
 ## Run Controls
 
@@ -100,25 +103,35 @@ you run --resume ./recordings/source.json \
 Resume restores the recorded Work state with these boundaries:
 
 - Work in a terminal state is not dispatched again.
-- Only Work state represented by recorded Factory Events is reconstructed.
-- The live queue is process-local. Work that was queued or in flight when the
-  source process stopped is not guaranteed to be re-admitted by `--resume`.
+- Recorded non-terminal Work is re-admitted to the successor's live scheduler.
+  This includes a Work item whose dispatch was active when the source stopped.
+- Only Work and dispatch state represented by recorded Factory Events is
+  reconstructed. Work that was submitted but never reached the recording is
+  not recoverable from that recording.
+- A completed dispatch remains completed in the successor. A dispatch without
+  a recorded completion is reconciled as interrupted and may run again in the
+  successor.
 
-This is not an exactly-once provider-effect guarantee. If you resubmit Work
-after a process stop, a provider-side effect may run again. Make provider-side
-operations idempotent when duplicate attempts would matter.
+The completed-dispatch rule is an exactly-once expectation for the recorded
+Factory dispatch lineage, not an exactly-once provider-effect guarantee. A
+provider may have performed a side effect before the process stopped without
+publishing a completion event; resuming the interrupted dispatch can therefore
+repeat that provider attempt. Make provider-side operations idempotent when
+duplicate attempts would matter.
 
 ### Process-kill recovery boundary
 
-The live Factory Session queue and provider process are not stored in a
-recording. A process-kill can leave a valid, unfinalized recording while Work
-was queued or in flight. `--resume` can read the valid prefix and write a
-successor, but successor creation does not prove that interrupted Work was
-continued.
+The live queue and provider process are not stored as running processes in a
+recording. A process kill can nevertheless leave a valid, unfinalized
+recording with the admitted Work and dispatch facts needed for recovery.
+`--resume` reads that valid prefix, restores the recorded Work placement, marks
+an incomplete dispatch as interrupted, and writes a successor. A completed
+dispatch in the prefix is preserved rather than executed again.
 
-For interrupted Work, start a new live Factory Session and resubmit the Work
-with its original authored `name`. Inspect the source and successor recordings
-separately. See `you docs operations` for the complete restart procedure.
+Do not resubmit Work merely because the source process stopped. First resume
+the recording and inspect the source and successor separately. Resubmit only
+Work that was never admitted into the recording, or when the recording is not
+recoverable. See `you docs operations` for the operational recovery sequence.
 
 The runtime accepts an unfinalized recording when it has a valid complete event
 prefix. It can also skip a truncated final event-stream block after earlier
@@ -132,6 +145,248 @@ replay artifact. It does not contain the JavaScript VM stack, closures, timers,
 module state, or provider process, so `--resume` cannot continue that VM. Use
 the live Factory Session resume controls and checkpoint state for a supported
 JavaScript continuation.
+
+## Verify record, kill, and resume from a fresh binary
+
+The following PowerShell procedure is a self-contained smoke journey for the
+Factory Event resume path. It builds a fresh binary, creates an isolated
+temporary Factory and recording directory, and uses no `--with-server` or
+`--listen` flag, so it does not bind port `7437` (or any other port). It needs
+Go and Python 3 on `PATH`. The script mock emits the Codex JSON protocol because
+the authored workers use the Codex provider parser; plain text from a script
+would not be a provider completion.
+
+Run these setup commands from the repository root:
+
+```powershell
+$proofBinary = Join-Path ([System.IO.Path]::GetTempPath()) ("you-rsm8-" + [guid]::NewGuid().ToString("N") + ".exe")
+go build -o $proofBinary .\cmd\factory
+
+$proofRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("you-rsm8-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $proofRoot | Out-Null
+Set-Location $proofRoot
+New-Item -ItemType Directory -Force -Path .\factory\workers\first, .\factory\workers\second | Out-Null
+$proofHome = Join-Path $proofRoot "home"
+New-Item -ItemType Directory -Force -Path $proofHome | Out-Null
+$originalHome = $env:HOME
+$originalUserProfile = $env:USERPROFILE
+$env:HOME = $proofHome
+$env:USERPROFILE = $proofHome
+```
+
+Create the minimal two-stage Factory, one Work item, and deterministic worker
+helper:
+
+```powershell
+@'
+{
+  "name": "rsm8-resume",
+  "workTypes": [
+    {
+      "name": "task",
+      "states": [
+        {"name": "init", "type": "INITIAL"},
+        {"name": "processing", "type": "PROCESSING"},
+        {"name": "complete", "type": "TERMINAL"},
+        {"name": "failed", "type": "FAILED"}
+      ]
+    }
+  ],
+  "workers": [
+    {"name": "first"},
+    {"name": "second"}
+  ],
+  "workstations": [
+    {
+      "name": "step-one",
+      "behavior": "STANDARD",
+      "worker": "first",
+      "inputs": [{"workType": "task", "state": "init"}],
+      "outputs": [{"workType": "task", "state": "processing"}],
+      "onFailure": [{"workType": "task", "state": "failed"}]
+    },
+    {
+      "name": "step-two",
+      "behavior": "STANDARD",
+      "worker": "second",
+      "inputs": [{"workType": "task", "state": "processing"}],
+      "outputs": [{"workType": "task", "state": "complete"}],
+      "onFailure": [{"workType": "task", "state": "failed"}]
+    }
+  ]
+}
+'@ | Set-Content -Encoding utf8 .\factory\factory.json
+
+@'
+---
+type: MODEL_WORKER
+model: gpt-5-codex
+modelProvider: CODEX
+stopToken: COMPLETE
+---
+Execute the task.
+'@ | Set-Content -Encoding utf8 .\factory\workers\first\AGENTS.md
+Copy-Item .\factory\workers\first\AGENTS.md .\factory\workers\second\AGENTS.md
+
+@'
+{
+  "requestId": "rsm8-cli-proof",
+  "type": "FACTORY_REQUEST_BATCH",
+  "works": [
+    {
+      "name": "resume-me-once",
+      "workTypeName": "task",
+      "state": "init",
+      "payload": {"subject": "record kill resume"}
+    }
+  ]
+}
+'@ | Set-Content -Encoding utf8 .\work.json
+
+@'
+import json
+from pathlib import Path
+import time
+
+count_file = Path("worker-count")
+started = Path("worker-started")
+release = Path("worker-release")
+count = int(count_file.read_text() or "0") + 1 if count_file.exists() else 1
+count_file.write_text(str(count))
+
+def complete():
+    messages = [
+        {"type": "turn.started"},
+        {
+            "type": "item.completed",
+            "item": {
+                "id": "message-final",
+                "type": "agent_message",
+                "text": "mock worker accepted\nCOMPLETE",
+            },
+        },
+        {"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}},
+    ]
+    for message in messages:
+        print(json.dumps(message))
+
+if count == 1:
+    complete()
+elif not release.exists():
+    started.touch()
+    time.sleep(300)
+else:
+    complete()
+'@ | Set-Content -Encoding utf8 .\worker.py
+
+@'
+{
+  "mockWorkers": [
+    {
+      "runType": "script",
+      "scriptConfig": {
+        "command": "python",
+        "args": ["worker.py"],
+        "workingDirectory": ".",
+        "timeout": "10m"
+      }
+    }
+  ]
+}
+'@ | Set-Content -Encoding utf8 .\mock-workers.json
+```
+
+Start the source run and wait until the first dispatch is durably recorded and
+the second dispatch has entered the helper. The source process remains alive
+while the helper sleeps:
+
+```powershell
+$source = Start-Process -FilePath $proofBinary -ArgumentList @(
+  "run", "--dir", "./factory", "--with-mock-workers", "./mock-workers.json",
+  "--work", "./work.json", "--record", "./source-recording.json"
+) -WorkingDirectory $proofRoot -RedirectStandardOutput .\source.stdout.log `
+  -RedirectStandardError .\source.stderr.log -WindowStyle Hidden -PassThru
+$sourcePid = $source.Id
+
+$ready = $false
+$deadline = (Get-Date).AddSeconds(60)
+while (-not $ready -and (Get-Date) -lt $deadline) {
+    if ((Test-Path .\source-recording.json) -and (Test-Path .\worker-started)) {
+        try {
+            $sourceEnvelope = Get-Content -Raw .\source-recording.json | ConvertFrom-Json
+            $sourceEvents = @($sourceEnvelope.events)
+            $requests = @($sourceEvents | Where-Object { $_.type -eq "DISPATCH_REQUEST" })
+            $responses = @($sourceEvents | Where-Object { $_.type -eq "DISPATCH_RESPONSE" })
+            $ready = $requests.Count -eq 2 -and $responses.Count -eq 1
+        } catch {
+            $ready = $false
+        }
+    }
+    if (-not $ready) { Start-Sleep -Milliseconds 500 }
+}
+if (-not $ready) { throw "source recording did not reach the kill boundary" }
+Get-Content .\worker-count
+```
+
+Kill the source process tree, then inspect the source prefix and replay it as
+historical data:
+
+```powershell
+taskkill /PID $sourcePid /T /F
+
+function Show-RecordingFacts([string] $path) {
+    $envelope = Get-Content -Raw $path | ConvertFrom-Json
+    $events = @($envelope.events)
+    $requests = @($events | Where-Object { $_.type -eq "DISPATCH_REQUEST" })
+    $responses = @($events | Where-Object { $_.type -eq "DISPATCH_RESPONSE" })
+    $completed = @($events | Where-Object { $_.type -eq "SESSION_COMPLETED" })
+    $transitions = @($responses | ForEach-Object { $_.payload.transitionId })
+    $states = @($responses | ForEach-Object { $_.payload.outputWork[0].state.name })
+    Write-Output ("{0} events={1} dispatchRequests={2} dispatchResponses={3} responseTransitions={4} workStates={5} sessionCompleted={6}" -f `
+        $path, $events.Count, $requests.Count, $responses.Count, ($transitions -join ","), ($states -join ","), $completed.Count)
+}
+
+Show-RecordingFacts .\source-recording.json
+& $proofBinary run --dir ./factory --replay ./source-recording.json
+Write-Output ("source replay exit=" + $LASTEXITCODE)
+if ($LASTEXITCODE -ne 0) { throw "source replay failed" }
+```
+
+Release the helper and resume into a new recording. The existing
+`worker-count` is `2`, so a successful successor invokes only the interrupted
+dispatch as invocation `3`:
+
+```powershell
+New-Item -ItemType File -Force .\worker-release | Out-Null
+& $proofBinary run --dir ./factory --with-mock-workers ./mock-workers.json `
+  --resume ./source-recording.json --record ./successor-recording.json
+if ($LASTEXITCODE -ne 0) { throw "resume failed" }
+
+Show-RecordingFacts .\source-recording.json
+Show-RecordingFacts .\successor-recording.json
+Write-Output ("worker-count=" + (Get-Content -Raw .\worker-count))
+& $proofBinary run --dir ./factory --replay ./successor-recording.json
+Write-Output ("successor replay exit=" + $LASTEXITCODE)
+if ($LASTEXITCODE -ne 0) { throw "successor replay failed" }
+$env:HOME = $originalHome
+$env:USERPROFILE = $originalUserProfile
+```
+
+The observed facts from the fresh binary were:
+
+```text
+source-recording.json events=14 dispatchRequests=2 dispatchResponses=1 responseTransitions=step-one workStates=processing sessionCompleted=0
+successor-recording.json events=24 dispatchRequests=3 dispatchResponses=2 responseTransitions=step-one,step-two workStates=processing,complete sessionCompleted=1
+worker-count=3
+source replay exit=0
+successor replay exit=0
+```
+
+The source is an unfinalized but valid prefix. The successor carries the
+completed `step-one` response forward, adds one resumed `step-two` dispatch,
+and reaches terminal `complete` Work. A portable JavaScript recording is a
+different artifact class; confirm its `--resume` rejection rather than using it
+for this journey.
 
 ## JavaScript Recording Overview
 

--- a/docs/reference/record-replay.md
+++ b/docs/reference/record-replay.md
@@ -55,9 +55,9 @@ recording.
 last valid Factory world state, and opens a new live Factory Session from that
 state. Pass `--resume <path>`. Recorded non-terminal Work is seeded back into
 the live scheduler, including Work that was queued or in flight when the
-source process stopped. Resume writes a separate successor recording; it does
-not preserve the original process-local queue or provider process as a live
-object.
+source process stopped. Resume writes a separate successor recording.
+It does not preserve the original process-local queue or provider process as a
+live object.
 
 ## Run Controls
 
@@ -79,7 +79,7 @@ These flag pairs are rejected for the same invocation:
 - `--resume` with `--no-record`
 
 `--resume` and `--replay` are mutually exclusive. Replay is historical and
-read-only; resume opens live Factory execution.
+read-only. Resume opens live Factory execution.
 
 `--resume` with `--record` is allowed. The explicit path names the new
 successor recording. A flag validation failure happens before a new Factory
@@ -112,12 +112,11 @@ Resume restores the recorded Work state with these boundaries:
   a recorded completion is reconciled as interrupted and may run again in the
   successor.
 
-The completed-dispatch rule is an exactly-once expectation for the recorded
-Factory dispatch lineage, not an exactly-once provider-effect guarantee. A
-provider may have performed a side effect before the process stopped without
-publishing a completion event; resuming the interrupted dispatch can therefore
-repeat that provider attempt. Make provider-side operations idempotent when
-duplicate attempts would matter.
+The completed-dispatch rule is an exactly-once expectation for recorded Factory
+dispatch lineage. It is not an exactly-once provider-effect guarantee.
+A provider may perform a side effect before the process stops without
+publishing a completion event. Resume may repeat that provider attempt.
+Make provider-side operations idempotent when duplicate attempts matter.
 
 ### Process-kill recovery boundary
 
@@ -149,12 +148,13 @@ JavaScript continuation.
 ## Verify record, kill, and resume from a fresh binary
 
 The following PowerShell procedure is a self-contained smoke journey for the
-Factory Event resume path. It builds a fresh binary, creates an isolated
-temporary Factory and recording directory, and uses no `--with-server` or
-`--listen` flag, so it does not bind port `7437` (or any other port). It needs
-Go and Python 3 on `PATH`. The script mock emits the Codex JSON protocol because
-the authored workers use the Codex provider parser; plain text from a script
-would not be a provider completion.
+Factory Event resume path. It builds a fresh binary and creates an isolated
+temporary Factory and recording directory. It uses no `--with-server` or
+`--listen` flag, so it does not bind port `7437` or any other port.
+It requires Go and Python 3 on `PATH`. The script mock emits the Codex JSON
+protocol. The authored workers use the Codex provider parser.
+
+Plain text from a script does not create a provider completion.
 
 Run these setup commands from the repository root:
 
@@ -172,13 +172,21 @@ $originalHome = $env:HOME
 $originalUserProfile = $env:USERPROFILE
 $env:HOME = $proofHome
 $env:USERPROFILE = $proofHome
+
+function Write-Utf8NoBom([string] $path, [string] $content) {
+    [System.IO.File]::WriteAllText(
+        (Join-Path $proofRoot $path),
+        $content,
+        [System.Text.UTF8Encoding]::new($false)
+    )
+}
 ```
 
 Create the minimal two-stage Factory, one Work item, and deterministic worker
 helper:
 
 ```powershell
-@'
+Write-Utf8NoBom .\factory\factory.json @'
 {
   "name": "rsm8-resume",
   "workTypes": [
@@ -215,9 +223,9 @@ helper:
     }
   ]
 }
-'@ | Set-Content -Encoding utf8 .\factory\factory.json
+'@
 
-@'
+Write-Utf8NoBom .\factory\workers\first\AGENTS.md @'
 ---
 type: MODEL_WORKER
 model: gpt-5-codex
@@ -225,10 +233,10 @@ modelProvider: CODEX
 stopToken: COMPLETE
 ---
 Execute the task.
-'@ | Set-Content -Encoding utf8 .\factory\workers\first\AGENTS.md
+'@
 Copy-Item .\factory\workers\first\AGENTS.md .\factory\workers\second\AGENTS.md
 
-@'
+Write-Utf8NoBom .\work.json @'
 {
   "requestId": "rsm8-cli-proof",
   "type": "FACTORY_REQUEST_BATCH",
@@ -241,9 +249,9 @@ Copy-Item .\factory\workers\first\AGENTS.md .\factory\workers\second\AGENTS.md
     }
   ]
 }
-'@ | Set-Content -Encoding utf8 .\work.json
+'@
 
-@'
+Write-Utf8NoBom .\worker.py @'
 import json
 from pathlib import Path
 import time
@@ -277,9 +285,9 @@ elif not release.exists():
     time.sleep(300)
 else:
     complete()
-'@ | Set-Content -Encoding utf8 .\worker.py
+'@
 
-@'
+Write-Utf8NoBom .\mock-workers.json @'
 {
   "mockWorkers": [
     {
@@ -293,7 +301,7 @@ else:
     }
   ]
 }
-'@ | Set-Content -Encoding utf8 .\mock-workers.json
+'@
 ```
 
 Start the source run and wait until the first dispatch is durably recorded and
@@ -383,10 +391,10 @@ successor replay exit=0
 ```
 
 The source is an unfinalized but valid prefix. The successor carries the
-completed `step-one` response forward, adds one resumed `step-two` dispatch,
-and reaches terminal `complete` Work. A portable JavaScript recording is a
-different artifact class; confirm its `--resume` rejection rather than using it
-for this journey.
+completed `step-one` response forward. It adds one resumed `step-two` dispatch
+and reaches terminal `complete` Work. A portable JavaScript recording has a
+different artifact class. Confirm its `--resume` rejection before using this
+journey.
 
 ## JavaScript Recording Overview
 

--- a/docs/reference/record-replay.md
+++ b/docs/reference/record-replay.md
@@ -1,18 +1,19 @@
 # Record and Replay
 
-Use record and replay when you want to capture a live factory run as a
-replay-compatible artifact, locate the saved file after shutdown, or re-run
-from a saved history without dispatching live workers again.
+Use recording when you need a durable Factory Event history. Use replay for
+historical inspection. Use resume to continue live Factory execution from a
+recoverable recording and write a new successor recording.
 
-`you docs record-replay` is the canonical guide for `--record`, `--replay`, and
-`--no-record`, including JavaScript-orchestrated Factory Sessions. See `you docs
+`you docs record-replay` is the canonical guide for `--record`, `--replay`,
+`--resume`, and `--no-record`, including their flag conflicts. See `you docs
 javascript-workflows` for the supported JavaScript authoring contract and `you
 docs authoring-factories` for the full factory setup workflow.
 
 ## Default Recording On Live Runs
 
 Normal live `you run` invocations record a replay-compatible artifact by default
-when you do not pass `--record` or `--replay`.
+when you do not pass `--no-record` or `--replay`. A resume invocation uses a
+generated path for its new successor recording unless you pass `--record`.
 
 The generated artifact root is:
 
@@ -39,14 +40,21 @@ Recording saved: <path>
 That message makes the artifact easy to find after a failure or an unexpected
 run.
 
-## Record Mode vs Replay Mode
+## Record, Replay, and Resume Modes
 
 **Record mode** starts a live run and writes the observed runtime history to a
 replay artifact. Use the default generated path, `--record <path>`, or rely on
 default recording without extra flags.
 
 **Replay mode** reads an existing artifact and uses the recorded runtime history
-instead of dispatching live workers again. Pass `--replay <path>`.
+instead of dispatching live workers again. Pass `--replay <path>`. Replay is
+historical and read-only: it does not continue Work or write a successor
+recording.
+
+**Resume mode** reads a recoverable Factory Event recording, reconstructs its
+last valid Factory world state, and opens a new live Factory Session from that
+state. Pass `--resume <path>`. Resume can dispatch eligible Work again and
+writes a successor recording.
 
 ## Run Controls
 
@@ -56,6 +64,7 @@ instead of dispatching live workers again. Pass `--replay <path>`.
 | `--no-record` | Skip the default recording for one invocation |
 | `--record <path>` | Write the replay artifact to an explicit path you own |
 | `--replay <path>` | Replay an existing artifact instead of starting a live run |
+| `--resume <path>` | Continue live Factory execution from a recoverable recording |
 
 ### Incompatible Combinations
 
@@ -63,9 +72,57 @@ These flag pairs are rejected for the same invocation:
 
 - `--record` with `--replay`
 - `--no-record` with `--record`
+- `--resume` with `--replay`
+- `--resume` with `--no-record`
 
-A flag validation failure happens before a new Factory Session starts, so there
-is no new session, Dispatch, FactoryArtifact, or FactoryEvent to inspect.
+`--resume` and `--replay` are mutually exclusive. Replay is historical and
+read-only; resume opens live Factory execution.
+
+`--resume` with `--record` is allowed. The explicit path names the new
+successor recording. A flag validation failure happens before a new Factory
+Session starts, so there is no new session, Dispatch, FactoryArtifact, or
+FactoryEvent to inspect.
+
+## Resume Semantics
+
+Resume reads the source recording without modifying it. It reconstructs the
+last valid Factory world state, then opens a new live Factory Session. The
+source and successor are separate recordings.
+
+When `--record` is omitted, resume writes the successor to the generated
+recording directory described above. Choose the successor path explicitly:
+
+```bash
+you run --resume ./recordings/source.json \
+  --record ./recordings/successor.json
+```
+
+Resume restores Work from the recovered world state with these boundaries:
+
+- Work in a terminal state is not dispatched again.
+- Queued Work is restored and can become eligible for dispatch.
+- Nonterminal Work that was in flight can receive a new live attempt after
+  resume.
+- A provider effect that completed before its completion event was recorded can
+  run again. Use idempotent provider-side operations when duplicate attempts
+  would matter.
+
+This is not an exactly-once provider-effect guarantee. The recorded terminal
+state prevents duplicate dispatch of completed Work, while an incomplete
+provider attempt can be retried after recovery.
+
+The runtime accepts an unfinalized recording when it has a valid complete event
+prefix. It can also skip a truncated final event-stream block after earlier
+complete events. Corruption in the middle of the stream, or a source with no
+valid complete event, is rejected. Resume does not recover arbitrary damaged
+JSON or reconstruct an in-memory provider process.
+
+Resume requires a Factory Event recording with the Factory Definition needed to
+open the live runtime. A portable JavaScript recording is an inspection and
+replay artifact. It does not contain the JavaScript VM stack, closures, timers,
+module state, or provider process, so `--resume` cannot continue that VM. Use
+the live Factory Session resume controls and checkpoint state for a supported
+JavaScript continuation.
 
 ## JavaScript Recording Overview
 
@@ -118,10 +175,9 @@ their events actually contain.
 
 Replay never dispatches live child work and the portable envelope does not
 contain a child-dispatch list. Replay therefore does not contact model
-providers, rerun script workers, or resume a JavaScript VM. A replayed paused
-session is historical and cannot be resumed. To continue from checkpoint
-application state, use the original live Factory Session while it is available;
-to reproduce fresh live work, start a new Factory Session.
+providers, rerun script workers, or resume a JavaScript VM. A portable replay
+recording cannot be passed to `--resume`; use the live Factory Session resume
+controls when a supported checkpoint continuation is available.
 
 ## Example Commands
 
@@ -199,9 +255,9 @@ curl http://localhost:7437/factory-sessions/<session-id>/results?mode=final
 
 These reads expose the recorded public status, ordered `FactoryEvent`
 summaries, `FactoryArtifact` summaries, and partial or final result
-availability. A paused recording remains historical: it cannot be resumed or
-treated as a live Factory Session. Use live durable-session inspection when you
-need child-dispatch details or resumable checkpoint state.
+availability. A portable recording remains historical and cannot be passed to
+`--resume` or treated as a live Factory Session. Use live durable-session
+inspection when you need child-dispatch details or resumable checkpoint state.
 
 ## JavaScript Recording Contract
 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1,6 +1,6 @@
 ---
 author: Agent Factory Team
-last-modified: 2026-08-10
+last-modified: 2026-08-21
 doc-id: agent-factory/guides/run
 ---
 
@@ -29,6 +29,7 @@ sources.
 | Keep a local Factory Session alive while idle | Add `--continuously` |
 | Replace live worker dispatch with deterministic outcomes | Add `--with-mock-workers [config.json]` |
 | Run worker dispatches in an isolated Git checkout | Add `--worktree <name>` |
+| Continue recoverable recorded Factory execution | `you run --resume <recording>` |
 | Serve an API only for the run lifetime | Add `--with-server` |
 | Serve the embedded dashboard and open it once | Add `--with-site` |
 | Select an exact local listener | Add `--listen <host:port>` to `--with-server` or `--with-site` |

--- a/docs/reference/sessions.md
+++ b/docs/reference/sessions.md
@@ -162,9 +162,11 @@ or control the same durable `FactorySession`.
 - Keep the matrix narrow. It is meant to revalidate one already supported
   durable JavaScript session path, not to inventory every route or dashboard
   widget.
-- Do not treat replay-resume, broader live-provider bridge parity, or broader
-  MCP host parity as required outcomes for this proof. Those remain explicit
-  follow-up scope outside the shipped operator slice.
+- Do not treat portable JavaScript recording resume, broader live-provider
+  bridge parity, or broader MCP host parity as required outcomes for this
+  proof. See `you docs record-replay` for the supported Factory Event resume
+  path and portable recording limits. This matrix covers durable JavaScript
+  session reads and controls.
 - If the chosen session is already terminal, start another supported durable
   JavaScript session before attempting lifecycle-control confirmation so the
   control outcome remains observable on the same session path.
@@ -197,8 +199,8 @@ you use this proof for closeout review.
 
 ### Explicitly out of scope for this slice
 
-- Replay-resume or persistence-semantics expansion beyond the already shipped
-  durable session reads
+- Portable JavaScript recording resume and persistence-semantics expansion
+  beyond the already shipped durable session reads
 - Broader live-provider bridge parity than the current bounded dispatch,
   artifact, and result inspection path
 - Broader MCP host parity follow-up beyond the currently documented


### PR DESCRIPTION
{
  "project": "RSM-8 Record, Replay, and Resume Documentation Truth-Up",
  "branchName": "rsm-8-record-replay-resume-docs-truth-up",
  "description": "Truth up the canonical packaged record/replay reference so it accurately documents the shipped `you run --resume <recording>` behavior, distinguishes resume from replay, explains successor and crash-recovery semantics, and provides a verified record-kill-resume journey that customers can execute verbatim from a blank working directory. This project changes documentation only.",
  "context": {
    "customerAsk": "Correct every packaged reference claim that contradicts `you run --resume <recording>`, document the exact shipped semantics, and add a verbatim journey that records a live run, interrupts it, resumes its artifact, and observes continued Work.",
    "problem": "The canonical `you docs record-replay` source still says replayed or paused recordings cannot be resumed even though the CLI resume flag shipped in PR #2085. Customers can incorrectly conclude that recovery is unavailable, and no packaged topic explains successor recordings, crash-left recording tolerance, or what happens to Work that was in flight when the original process stopped.",
    "solution": "Revise only canonical sources under `docs/reference/`, align every resume claim with the final merged CLI and runtime behavior, distinguish `--resume` from `--replay`, disclose supported recovery and remaining limitations, and add a self-contained procedure verified with a freshly built binary in an isolated scratch directory away from the live daemon on port 7437."
  },
  "acceptanceCriteria": [
    "`you docs record-replay` and every sibling topic that discusses recording continuation contain no claim that contradicts the shipped `--resume` CLI or the final merged resume behavior; the implementation reviews all matching customer-facing claims, not only the two originally cited sentences.",
    "The reference clearly distinguishes live continuation with `--resume <recording>` from inspection-only `--replay <recording>`, states that they are mutually exclusive, and explains that resume writes a successor recording by default while `--record <path>` selects its path.",
    "The reference states the verified behavior for unfinalized recordings, a truncated final recording block, and Work that was in flight when the source process stopped, and it identifies any remaining partial behavior or unsupported recovery case honestly.",
    "The packaged topic contains a self-contained journey that a reader can execute from a blank working directory using only that topic, including exact setup, build/run, mid-run interruption, resume, and inspection commands plus the observable result after each important step.",
    "The author executes the published journey with a freshly built binary in an isolated scratch directory, never against the live daemon on port `7437`, and adds the real commands and observed output to the PR body or a PR comment; repository changes do not include generated scratch recordings or captured customer data.",
    "Quality gate: Typecheck passes; `make docs-reference-smoke` passes; relevant tests pass; `make readme-check` passes if README links change; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "rsm-8-record-replay-resume-docs-truth-up-001",
      "title": "Publish accurate resume semantics",
      "description": "As a Factory operator, I want the packaged reference to distinguish replay from resume and describe recovery precisely so that I can choose the correct mode and understand what state will continue.",
      "acceptanceCriteria": [
        "`you docs record-replay` defines `--replay <recording>` as non-live historical reconstruction or inspection and `--resume <recording>` as live continuation from recovered recording state.",
        "The run-controls and incompatible-combinations guidance states that `--resume` and `--replay` are mutually exclusive and preserves the other shipped recording conflicts.",
        "The reference states that resume writes a new successor recording by default and that `--record <path>` chooses the successor path; it does not imply that the source recording is overwritten.",
        "The reference explains the verified tolerance for unfinalized recordings and a truncated final block without implying that arbitrary mid-stream corruption is recoverable.",
        "The reference explains, according to final merged behavior, how queued and in-flight Work are restored or continued, including exactly-once expectations and any provider-attempt limitation that remains.",
        "Every resume-related claim in sibling `docs/reference/` topics is consistent with the canonical topic, and changes remain limited to claims that must be corrected or linked for this behavior.",
        "Before the final documentation push, the branch includes merged PR #2102 and is rebased over PR #2097 if it has merged; any RSM-7 proof or other dependency is treated as shipped evidence only after merge.",
        "Statements that cannot be verified as complete at the final merged dependency state are labeled as limitations rather than promises.",
        "Customer prose follows the repository technical-writing standard, including canonical product terms, short procedural steps, exact command literals, and observable results.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Updated canonical and direct sibling packaged docs to distinguish replay from live --resume, document successor recording and recovery limits, and align recording flag conflicts. Addressed PR #2137 feedback by qualifying portable JavaScript recording scope and fixing new customer-prose violations. Verified with docs-reference-smoke, readme-check, typecheck, focused CLI/replay tests, and assembled resume tests. PR #2102 and PR #2097 are merged."
    },
    {
      "id": "rsm-8-record-replay-resume-docs-truth-up-002",
      "title": "Provide and prove a verbatim recovery journey",
      "description": "As a Factory operator, I want a complete record-kill-resume example with expected results so that I can recover interrupted Work without relying on undocumented repository knowledge.",
      "acceptanceCriteria": [
        "The packaged topic gives all commands and authored input needed to start from a blank scratch directory, create or initialize the example Factory, and start a sufficiently long live run with `--record <source-path>`.",
        "The procedure tells the reader how to identify that Work is active, interrupt the owning CLI process mid-run, and confirm that the source recording exists without depending on the daemon at port `7437`.",
        "The procedure resumes with `you run --resume <source-path>` and either shows the default successor path or uses an explicit `--record <successor-path>` while explaining the default.",
        "Each important command is followed by the observable output or state that proves recording, interruption, live continuation, completion, and successor recording creation.",
        "The author runs the exact published commands with a freshly built binary in a new scratch directory and uses an isolated non-`7437` port if a server is necessary.",
        "The PR body or a PR comment contains the real observed command output, including evidence that the original run stopped mid-work, the resumed run continued that Work exactly once, and a successor recording was written; CI-run evidence is also kept in PR comments and never committed.",
        "The example does not require an existing repository checkout after the binary is built, an already-running daemon, hidden files, undeclared environment state, or live customer credentials when a repository-supported deterministic provider path can demonstrate the behavior.",
        "No generated recording, scratch Factory, copied build output, or live customer data is committed with the documentation.",
        "`make docs-reference-smoke` passes, and `make readme-check` passes if README links change.",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Built a fresh binary from merged main after PR #2129 merged and ran the published isolated PowerShell journey away from port 7437. After the exact CLI process tree was killed, source-recording.json contained 14 events with DISPATCH_REQUEST step-one/step-two and one accepted step-one response, leaving Work in processing. --resume wrote successor-recording.json with 24 events, three dispatch requests, accepted step-one and step-two responses, terminal complete Work, and SESSION_COMPLETED; the deterministic helper count was 3, proving the completed dispatch was not re-run. Source and successor replay both exited 0. A valid portable schema-v3 recording still exits 1 with CLI_COMMAND_FAILED under --resume. The revised journey uses BOM-free UTF-8 writes for Windows PowerShell 5.1. Updated record-replay.md, operations.md, authoring-factories.md, sessions.md, and orchestrators.md; docs-reference-smoke, readme-check, typecheck, diff check, and the published command shape pass."
    }
  ]
}
