### PR TITLE
perf-f5-functional-test-window-overcommit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,15 +231,25 @@ jobs:
         run: |
           runner_cpus="$(nproc 2>/dev/null || true)"
           case "$runner_cpus" in
-            ''|*[!0-9]*) runner_cpus=0 ;;
+            ''|*[!0-9]*|0|0[0-9]*)
+              echo "Functional CI runner: nproc returned an unusable logical CPU count: '$runner_cpus'" >&2
+              exit 1
+              ;;
           esac
+          max_functional_logical_cpus=64
+          if [ "${#runner_cpus}" -gt 2 ] || [ "$runner_cpus" -gt "$max_functional_logical_cpus" ]; then
+            echo "Functional CI runner: logical CPU count '$runner_cpus' exceeds the bounded test-jobs limit of $max_functional_logical_cpus" >&2
+            exit 1
+          fi
           if [ "$runner_cpus" -lt 2 ]; then
             functional_jobs=2
           else
             functional_jobs="$runner_cpus"
           fi
-          echo "Functional CI runner: logical_cpus=$runner_cpus jobs=$functional_jobs"
+          functional_test_jobs=$((runner_cpus * 2))
+          echo "Functional CI runner: logical_cpus=$runner_cpus jobs=$functional_jobs test_jobs=$functional_test_jobs"
           echo "jobs=$functional_jobs" >> "$GITHUB_OUTPUT"
+          echo "test_jobs=$functional_test_jobs" >> "$GITHUB_OUTPUT"
       - name: Verify quarantined package inventory on Linux
         if: matrix.suite == 'functional'
         run: bash scripts/ci/verify-functional-quarantine-packages.sh
@@ -373,6 +383,7 @@ jobs:
           FUNCTIONAL_TEST_BUDGET: "75m"
           FUNCTIONAL_SHORT: "false"
           FUNCTIONAL_DEFAULT_JOBS: ${{ steps.functional-parallelism.outputs.jobs }}
+          FUNCTIONAL_TEST_JOBS: ${{ steps.functional-parallelism.outputs.test_jobs }}
           FUNCTIONAL_GOCOVERAGE_EXIT_FILE: .artifacts/functional-test-viz/gocoveragecheck-exit-code.txt
           FUNCTIONAL_COVERAGE_VERDICT_FILE: .artifacts/functional-test-viz/functional-coverage-verdict.txt
           INFINITE_YOU_RUN_ACPX_REAL_CLIENT: "1"

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,10 @@ endif
 endif
 
 FUNCTIONAL_DEFAULT_JOBS ?= $(GO_LANE_BUDGET)
+# CI may set this only for the instrumented functional coverage window. Leave
+# it empty by default so local invocations and discovery keep their existing
+# FUNCTIONAL_DEFAULT_JOBS behavior.
+FUNCTIONAL_TEST_JOBS ?=
 UNIT_DEFAULT_JOBS ?= $(GO_LANE_BUDGET)
 FUNCTIONAL_LONG_TAGS ?= functionallong
 FUNCTIONAL_LONG_PACKAGES := ./tests/functional/...
@@ -552,6 +556,7 @@ functional-test-viz:
 		GO_FUNCTIONAL_COVERAGE_PROFILE=$(FUNCTIONAL_TEST_VIZ_PROFILE) \
 		GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT=$(FUNCTIONAL_TEST_VIZ_JSON) \
 		GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT=$(FUNCTIONAL_TEST_VIZ_TIMING) \
+		$(if $(strip $(FUNCTIONAL_TEST_JOBS)),FUNCTIONAL_TEST_JOBS=$(FUNCTIONAL_TEST_JOBS),) \
 		FUNCTIONAL_GOCOVERAGE_EXIT_FILE=$(FUNCTIONAL_GOCOVERAGE_EXIT_FILE)
 	$(GO) run ./cmd/functionaltestviz \
 		-coverage-summary $(FUNCTIONAL_TEST_VIZ_JSON) \
@@ -697,9 +702,9 @@ test-unit-coverage:
 # non-zero before gocoveragecheck starts.
 test-functional-coverage:
 	$(MAKE) functional-boundary-check
-	@echo "Functional tier: name=$(FUNCTIONAL_TEST_TIER) trigger=$(FUNCTIONAL_TEST_TRIGGER) short=$(FUNCTIONAL_SHORT) budget=$(FUNCTIONAL_TEST_BUDGET) selection=subtractive quarantine=$(FUNCTIONAL_QUARANTINE)"
+	@echo "Functional tier: name=$(FUNCTIONAL_TEST_TIER) trigger=$(FUNCTIONAL_TEST_TRIGGER) short=$(FUNCTIONAL_SHORT) budget=$(FUNCTIONAL_TEST_BUDGET) selection=subtractive quarantine=$(FUNCTIONAL_QUARANTINE) jobs=$(FUNCTIONAL_DEFAULT_JOBS) test_jobs=$(if $(strip $(FUNCTIONAL_TEST_JOBS)),$(FUNCTIONAL_TEST_JOBS),default)"
 	@set +e; \
-	$(GO) run ./cmd/gocoveragecheck -suite functional -stream -jobs $(FUNCTIONAL_DEFAULT_JOBS) -min $(GO_FUNCTIONAL_COVERAGE_MIN) -package-manifest $(GO_FUNCTIONAL_COVERAGE_MANIFEST) -functional-quarantine $(FUNCTIONAL_QUARANTINE) -timeout $(GO_COVERAGE_TIMEOUT) $(if $(filter false 0 no,$(FUNCTIONAL_SHORT)),-short=false,) $(if $(GO_FUNCTIONAL_COVERAGE_PROFILE),-profile $(GO_FUNCTIONAL_COVERAGE_PROFILE),) $(if $(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT),-json-output $(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT),) $(if $(GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT),-timing-output $(GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT),); \
+	$(GO) run ./cmd/gocoveragecheck -suite functional -stream -jobs $(FUNCTIONAL_DEFAULT_JOBS) $(if $(strip $(FUNCTIONAL_TEST_JOBS)),-test-jobs $(FUNCTIONAL_TEST_JOBS),) -min $(GO_FUNCTIONAL_COVERAGE_MIN) -package-manifest $(GO_FUNCTIONAL_COVERAGE_MANIFEST) -functional-quarantine $(FUNCTIONAL_QUARANTINE) -timeout $(GO_COVERAGE_TIMEOUT) $(if $(filter false 0 no,$(FUNCTIONAL_SHORT)),-short=false,) $(if $(GO_FUNCTIONAL_COVERAGE_PROFILE),-profile $(GO_FUNCTIONAL_COVERAGE_PROFILE),) $(if $(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT),-json-output $(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT),) $(if $(GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT),-timing-output $(GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT),); \
 	status=$$?; \
 	if [ -n "$(FUNCTIONAL_GOCOVERAGE_EXIT_FILE)" ]; then \
 		printf '%s\n' "$$status" > "$(FUNCTIONAL_GOCOVERAGE_EXIT_FILE)"; \

--- a/cmd/gocoveragecheck/coverage_phases.go
+++ b/cmd/gocoveragecheck/coverage_phases.go
@@ -40,7 +40,7 @@ func prepareCoverageRun(cfg config, targetOS string, logicalCPUs int, profilePat
 	coverageTestArgs := []string{
 		"test",
 		fmt.Sprintf("-coverpkg=%s", coverPackageArgument),
-		fmt.Sprintf("-p=%d", cfg.testJobs(targetOS, logicalCPUs)),
+		fmt.Sprintf("-p=%d", cfg.instrumentedTestJobs(targetOS, logicalCPUs)),
 		// Coverage is authoritative, so every package must run even when a prior
 		// non-instrumented invocation is cached.
 		"-count=1",

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -83,6 +83,8 @@ type config struct {
 	coverpkg             string
 	functionalQuarantine string
 	jobs                 int
+	testJobsOverride     int
+	testJobsOverrideSet  bool
 	generateManifest     string
 	updateManifest       string
 	updateProfiles       string
@@ -202,6 +204,7 @@ func parseConfig() config {
 	flag.StringVar(&cfg.coverpkg, "coverpkg", "", "comma-separated import paths to measure; defaults to backend-owned packages")
 	flag.StringVar(&cfg.functionalQuarantine, "functional-quarantine", "", "strict functional quarantine JSON manifest; discovers and subtracts its package/test selectors")
 	flag.IntVar(&cfg.jobs, "jobs", 0, "maximum concurrent go test packages; defaults to runtime CPU count for non-Windows unit coverage, 1 for Windows unit coverage, and 2 for functional coverage")
+	flag.IntVar(&cfg.testJobsOverride, "test-jobs", 0, "positive instrumented go test -p override; omitted uses -jobs (functional subprocess I/O wait can benefit from controlled oversubscription)")
 	flag.StringVar(&cfg.generateManifest, "generate-manifest", "", "create a deterministic package-minimum manifest from this lane's coverage profile")
 	flag.StringVar(&cfg.updateManifest, "update-manifest", "", "update an existing package-minimum manifest from a complete compatible profile sample set")
 	flag.StringVar(&cfg.updateProfiles, "update-profiles", "", "comma-separated complete coverage profiles for -update-manifest; requires at least five compatible profiles")
@@ -225,10 +228,18 @@ func parseConfig() config {
 	flag.DurationVar(&cfg.timeout, "timeout", 5*time.Minute, "go test timeout")
 	flag.BoolVar(&cfg.totalOnly, "total-only", false, "disable package-local coverage gates while retaining per-package reporting")
 	flag.Parse()
+	flag.Visit(func(visited *flag.Flag) {
+		if visited.Name == "test-jobs" {
+			cfg.testJobsOverrideSet = true
+		}
+	})
 	return cfg
 }
 
 func validateConfig(cfg config) error {
+	if cfg.testJobsOverride < 0 || (cfg.testJobsOverride == 0 && cfg.testJobsOverrideSet) {
+		return fmt.Errorf("configure go coverage: -test-jobs must be a positive integer (got %d)", cfg.testJobsOverride)
+	}
 	manifestOperations := 0
 	for _, value := range []string{cfg.generateManifest, cfg.updateManifest, cfg.packageManifest} {
 		if strings.TrimSpace(value) != "" {
@@ -321,7 +332,6 @@ func runCoverageProfile(cfg config, targetOS string, logicalCPUs int, profilePat
 	}); err != nil {
 		return coverageResult{}, err
 	}
-
 	var prepared preparedCoverageRun
 	if err := cfg.measureCoveragePhase(coveragePhasePlan, func() error {
 		var err error
@@ -383,6 +393,16 @@ func (cfg config) testJobs(targetOS string, logicalCPUs int) int {
 		// usable count. runtime.NumCPU normally guarantees a positive value.
 	}
 	return defaultCoverageJobs
+}
+
+// instrumentedTestJobs keeps the instrumented test window independently
+// tunable: functional subprocesses spend time waiting on I/O, so controlled
+// oversubscription can reduce wall time without changing discovery's jobs.
+func (cfg config) instrumentedTestJobs(targetOS string, logicalCPUs int) int {
+	if cfg.testJobsOverride > 0 {
+		return cfg.testJobsOverride
+	}
+	return cfg.testJobs(targetOS, logicalCPUs)
 }
 
 func packageCoverageBaselinePackages(cfg config, repoRoot string) (map[string]struct{}, error) {

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -204,7 +204,7 @@ func parseConfig() config {
 	flag.StringVar(&cfg.coverpkg, "coverpkg", "", "comma-separated import paths to measure; defaults to backend-owned packages")
 	flag.StringVar(&cfg.functionalQuarantine, "functional-quarantine", "", "strict functional quarantine JSON manifest; discovers and subtracts its package/test selectors")
 	flag.IntVar(&cfg.jobs, "jobs", 0, "maximum concurrent go test packages; defaults to runtime CPU count for non-Windows unit coverage, 1 for Windows unit coverage, and 2 for functional coverage")
-	flag.IntVar(&cfg.testJobsOverride, "test-jobs", 0, "positive instrumented go test -p override; omitted uses -jobs (functional subprocess I/O wait can benefit from controlled oversubscription)")
+	registerTestJobsFlag(&cfg)
 	flag.StringVar(&cfg.generateManifest, "generate-manifest", "", "create a deterministic package-minimum manifest from this lane's coverage profile")
 	flag.StringVar(&cfg.updateManifest, "update-manifest", "", "update an existing package-minimum manifest from a complete compatible profile sample set")
 	flag.StringVar(&cfg.updateProfiles, "update-profiles", "", "comma-separated complete coverage profiles for -update-manifest; requires at least five compatible profiles")
@@ -228,17 +228,13 @@ func parseConfig() config {
 	flag.DurationVar(&cfg.timeout, "timeout", 5*time.Minute, "go test timeout")
 	flag.BoolVar(&cfg.totalOnly, "total-only", false, "disable package-local coverage gates while retaining per-package reporting")
 	flag.Parse()
-	flag.Visit(func(visited *flag.Flag) {
-		if visited.Name == "test-jobs" {
-			cfg.testJobsOverrideSet = true
-		}
-	})
+	markTestJobsOverrideSet(&cfg)
 	return cfg
 }
 
 func validateConfig(cfg config) error {
-	if cfg.testJobsOverride < 0 || (cfg.testJobsOverride == 0 && cfg.testJobsOverrideSet) {
-		return fmt.Errorf("configure go coverage: -test-jobs must be a positive integer (got %d)", cfg.testJobsOverride)
+	if err := validateTestJobsOverride(cfg); err != nil {
+		return err
 	}
 	manifestOperations := 0
 	for _, value := range []string{cfg.generateManifest, cfg.updateManifest, cfg.packageManifest} {
@@ -393,16 +389,6 @@ func (cfg config) testJobs(targetOS string, logicalCPUs int) int {
 		// usable count. runtime.NumCPU normally guarantees a positive value.
 	}
 	return defaultCoverageJobs
-}
-
-// instrumentedTestJobs keeps the instrumented test window independently
-// tunable: functional subprocesses spend time waiting on I/O, so controlled
-// oversubscription can reduce wall time without changing discovery's jobs.
-func (cfg config) instrumentedTestJobs(targetOS string, logicalCPUs int) int {
-	if cfg.testJobsOverride > 0 {
-		return cfg.testJobsOverride
-	}
-	return cfg.testJobs(targetOS, logicalCPUs)
 }
 
 func packageCoverageBaselinePackages(cfg config, repoRoot string) (map[string]struct{}, error) {

--- a/cmd/gocoveragecheck/main_test.go
+++ b/cmd/gocoveragecheck/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"os"
 	"path/filepath"
 	"slices"
@@ -107,6 +108,62 @@ func TestCoverageTestJobs(t *testing.T) {
 	}
 }
 
+func TestInstrumentedTestJobsOverrideIsIndependentFromDiscoveryJobs(t *testing.T) {
+	t.Parallel()
+
+	cfg := config{
+		suite:            "functional",
+		jobs:             4,
+		testJobsOverride: 8,
+	}
+	if got := cfg.instrumentedTestJobs("linux", 4); got != 8 {
+		t.Fatalf("config.instrumentedTestJobs() = %d, want override 8", got)
+	}
+	if got := cfg.testJobs("linux", 4); got != 4 {
+		t.Fatalf("config.testJobs() = %d, want discovery jobs 4", got)
+	}
+}
+
+func TestInstrumentedTestJobsFallsBackToExistingJobs(t *testing.T) {
+	t.Parallel()
+
+	cfg := config{suite: "functional", jobs: 6}
+	if got := cfg.instrumentedTestJobs("linux", 4); got != 6 {
+		t.Fatalf("config.instrumentedTestJobs() = %d, want existing jobs 6", got)
+	}
+}
+
+func TestParseConfigTracksExplicitTestJobsOverride(t *testing.T) {
+	originalArgs := os.Args
+	originalFlagSet := flag.CommandLine
+	t.Cleanup(func() {
+		os.Args = originalArgs
+		flag.CommandLine = originalFlagSet
+	})
+
+	flag.CommandLine = flag.NewFlagSet("gocoveragecheck", flag.ContinueOnError)
+	os.Args = []string{"gocoveragecheck", "-test-jobs=8"}
+
+	cfg := parseConfig()
+	if cfg.testJobsOverride != 8 || !cfg.testJobsOverrideSet {
+		t.Fatalf("parseConfig() test-jobs = (%d, %t), want (8, true)", cfg.testJobsOverride, cfg.testJobsOverrideSet)
+	}
+}
+
+func TestValidateConfigRejectsNonPositiveTestJobsOverride(t *testing.T) {
+	t.Parallel()
+
+	cases := []config{
+		{testJobsOverride: -1},
+		{testJobsOverrideSet: true},
+	}
+	for _, cfg := range cases {
+		if err := validateConfig(cfg); err == nil || !strings.Contains(err.Error(), "-test-jobs must be a positive integer") {
+			t.Fatalf("validateConfig(%+v) error = %v, want positive test-jobs diagnostic", cfg, err)
+		}
+	}
+}
+
 func TestRunForOSWithCPUUsesDerivedUnitJobs(t *testing.T) {
 	originalCommandRunner := commandRunner
 	originalStdout := stdoutWriter
@@ -146,6 +203,27 @@ func TestRunForOSWithCPUUsesDerivedUnitJobs(t *testing.T) {
 	}
 	if stdout.Len() == 0 || stderr.Len() != 0 {
 		t.Fatalf("coverage output = stdout %q, stderr %q; want stdout only", stdout.String(), stderr.String())
+	}
+
+	invocations = nil
+	_, err = runForOSWithCPU(config{
+		min:              0,
+		suite:            "functional",
+		jobs:             4,
+		testJobsOverride: 8,
+		totalOnly:        true,
+		coverpkg:         strings.Join([]string{modulePath + "/pkg/config", modulePath + "/pkg/service"}, ","),
+		packages:         "./pkg/config",
+		profile:          filepath.Join(t.TempDir(), "coverage.out"),
+	}, "linux", 4)
+	if err != nil {
+		t.Fatalf("runForOSWithCPU() with test-jobs override error = %v", err)
+	}
+	if len(invocations) != 1 {
+		t.Fatalf("coverage invocations with test-jobs override = %d, want one", len(invocations))
+	}
+	if !slices.Contains(invocations[0].args, "-p=8") {
+		t.Fatalf("go test args with test-jobs override = %v, want -p=8", invocations[0].args)
 	}
 }
 

--- a/cmd/gocoveragecheck/test_jobs.go
+++ b/cmd/gocoveragecheck/test_jobs.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+const testJobsFlagUsage = "positive instrumented go test -p override; omitted uses -jobs (functional subprocess I/O wait can benefit from controlled oversubscription)"
+
+func registerTestJobsFlag(cfg *config) {
+	flag.IntVar(&cfg.testJobsOverride, "test-jobs", 0, testJobsFlagUsage)
+}
+
+func markTestJobsOverrideSet(cfg *config) {
+	flag.Visit(func(visited *flag.Flag) {
+		if visited.Name == "test-jobs" {
+			cfg.testJobsOverrideSet = true
+		}
+	})
+}
+
+func validateTestJobsOverride(cfg config) error {
+	if cfg.testJobsOverride < 0 || (cfg.testJobsOverride == 0 && cfg.testJobsOverrideSet) {
+		return fmt.Errorf("configure go coverage: -test-jobs must be a positive integer (got %d)", cfg.testJobsOverride)
+	}
+	return nil
+}
+
+// instrumentedTestJobs keeps the instrumented test window independently
+// tunable: functional subprocesses spend time waiting on I/O, so controlled
+// oversubscription can reduce wall time without changing discovery's jobs.
+func (cfg config) instrumentedTestJobs(targetOS string, logicalCPUs int) int {
+	if cfg.testJobsOverride > 0 {
+		return cfg.testJobsOverride
+	}
+	return cfg.testJobs(targetOS, logicalCPUs)
+}

--- a/scripts/ci/lane-budget.test.mjs
+++ b/scripts/ci/lane-budget.test.mjs
@@ -59,7 +59,26 @@ test("production Make computation yields the bounded numeric budget", (t) => {
 	assertBudgetOutput(result, 4);
 });
 
-test("explicit functional CI jobs override is shared by discovery and coverage only", (t) => {
+test("explicit functional CI jobs keep discovery and instrumented coverage separate", (t) => {
+	if (!requireMake(t)) return;
+
+	const result = runMake(
+		[
+			"YOU_LOGICAL_CPUS=8",
+			"YOU_EXPECTED_CONCURRENT_LANES=4",
+			"FUNCTIONAL_DEFAULT_JOBS=4",
+			"FUNCTIONAL_TEST_JOBS=8",
+		],
+		["-n", "test-unit", "test-functional", "test-functional-coverage"],
+	);
+	assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+	assert.match(result.stdout, /unitlane -jobs 2/);
+	assert.match(result.stdout, /functionallane -jobs 4/);
+	assert.match(result.stdout, /gocoveragecheck -suite functional -stream -jobs 4 -test-jobs 8/);
+	assert.doesNotMatch(result.stdout, /functionallane -jobs 4 .*test-jobs/);
+});
+
+test("functional coverage without the CI test-window override keeps the existing command", (t) => {
 	if (!requireMake(t)) return;
 
 	const result = runMake(
@@ -68,12 +87,11 @@ test("explicit functional CI jobs override is shared by discovery and coverage o
 			"YOU_EXPECTED_CONCURRENT_LANES=4",
 			"FUNCTIONAL_DEFAULT_JOBS=4",
 		],
-		["-n", "test-unit", "test-functional", "test-functional-coverage"],
+		["-n", "test-functional-coverage"],
 	);
-	assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
-	assert.match(result.stdout, /unitlane -jobs 2/);
-	assert.match(result.stdout, /functionallane -jobs 4/);
-	assert.match(result.stdout, /gocoveragecheck -suite functional -stream -jobs 4/);
+	assert.equal(result.status, 0);
+	assert.match(result.stdout, /gocoveragecheck -suite functional -stream -jobs 4(?! -test-jobs)/);
+	assert.doesNotMatch(result.stdout, /-test-jobs/);
 });
 
 test("corrupted production result warns, falls back, and reaches numeric job flags", (t) => {

--- a/scripts/ci/run-functional-test-viz.sh
+++ b/scripts/ci/run-functional-test-viz.sh
@@ -11,6 +11,7 @@ budget="${FUNCTIONAL_TEST_BUDGET:-35m}"
 short="${FUNCTIONAL_SHORT:-true}"
 quarantine="${FUNCTIONAL_QUARANTINE:-tests/functional/functional-quarantine.json}"
 functional_jobs="${FUNCTIONAL_DEFAULT_JOBS:-make-default}"
+functional_test_jobs="${FUNCTIONAL_TEST_JOBS:-make-default}"
 log_path="$artifact_root/command.log"
 timing_path="${FUNCTIONAL_TEST_VIZ_TIMING:-$artifact_root/functional-timing-summary.json}"
 coverage_path="${FUNCTIONAL_TEST_VIZ_JSON:-$artifact_root/coverage-summary.json}"
@@ -26,7 +27,7 @@ mkdir -p "$artifact_root"
 rm -f "$status_path" "$timing_path" "$coverage_path" "$profile_path" "$markdown_path" "$gocoverage_exit_path" "$verdict_path"
 
 printf '%s\n' \
-  "Functional CI runner: tier=$tier trigger=$trigger short=$short budget=$budget selection=subtractive quarantine=$quarantine jobs=$functional_jobs" \
+  "Functional CI runner: tier=$tier trigger=$trigger short=$short budget=$budget selection=subtractive quarantine=$quarantine jobs=$functional_jobs test_jobs=$functional_test_jobs" \
   "Functional CI runner: timeout=$budget; partial diagnostics are retained under $artifact_root on failure." \
   | tee "$log_path"
 

--- a/tests/functional/observability/coverage/functional_test_viz_contract_test.go
+++ b/tests/functional/observability/coverage/functional_test_viz_contract_test.go
@@ -67,7 +67,8 @@ func TestFunctionalTestVizContract_WiresBoundarySingleCoverageThenMarkdown(t *te
 		"functional-boundary-check": "@printf '%s\\n' 'stub:boundary-ok'\n",
 		"test-functional-coverage": "@printf '%s\\n' 'stub:coverage-once'\n" +
 			"\t@printf '%s\\n' 'profile=$(GO_FUNCTIONAL_COVERAGE_PROFILE)'\n" +
-			"\t@printf '%s\\n' 'json=$(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT)'\n",
+			"\t@printf '%s\\n' 'json=$(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT)'\n" +
+			"\t@printf '%s\\n' 'test-jobs=$(FUNCTIONAL_TEST_JOBS)'\n",
 	})
 	goStub := writeMakeEchoScript(t, "stub-go")
 
@@ -76,6 +77,7 @@ func TestFunctionalTestVizContract_WiresBoundarySingleCoverageThenMarkdown(t *te
 		makefilePath,
 		"functional-test-viz",
 		"GO="+goStub,
+		"FUNCTIONAL_TEST_JOBS=8",
 	)
 	if err != nil {
 		t.Fatalf("run functional-test-viz wiring contract: %v\n%s", err, output)
@@ -100,6 +102,9 @@ func TestFunctionalTestVizContract_WiresBoundarySingleCoverageThenMarkdown(t *te
 	}
 	if !strings.Contains(output, "json="+functionalTestVizDefaultJSON) {
 		t.Fatalf("coverage invocation missing default JSON path:\n%s", output)
+	}
+	if !strings.Contains(output, "test-jobs=8") {
+		t.Fatalf("coverage invocation did not preserve the CI test-jobs override:\n%s", output)
 	}
 	if !strings.Contains(output, "-coverage-summary "+functionalTestVizDefaultJSON) {
 		t.Fatalf("Markdown generator missing default coverage-summary path:\n%s", output)

--- a/tests/functional/observability/verification/functional_runner_contract_test.go
+++ b/tests/functional/observability/verification/functional_runner_contract_test.go
@@ -110,10 +110,11 @@ func TestFunctionalCoverageCommandSmoke_SeparatesDiscoveryAndInstrumentedJobs(t 
 			})
 			args := []string{
 				"FUNCTIONAL_DEFAULT_JOBS=4",
+				// Make exports command-line variables through MAKEFLAGS. Passing an
+				// explicit empty value keeps this local-default case isolated when
+				// the functional suite itself runs under the CI override.
+				"FUNCTIONAL_TEST_JOBS=" + tc.testJobs,
 				"GO=" + goStub,
-			}
-			if tc.testJobs != "" {
-				args = append(args, "FUNCTIONAL_TEST_JOBS="+tc.testJobs)
 			}
 			output, err := runMakefileTargetWithArgs(repoRoot, makefilePath, "test-functional-coverage", args...)
 			if err != nil {

--- a/tests/functional/observability/verification/functional_runner_contract_test.go
+++ b/tests/functional/observability/verification/functional_runner_contract_test.go
@@ -83,6 +83,59 @@ func TestFunctionalCoverageCommandSmoke_ReportsExplicitTierSelection(t *testing.
 	}
 }
 
+// TestFunctionalCoverageCommandSmoke_SeparatesDiscoveryAndInstrumentedJobs
+// proves the CI-only override reaches the instrumented coverage invocation
+// while omission leaves the existing -jobs-only command unchanged.
+func TestFunctionalCoverageCommandSmoke_SeparatesDiscoveryAndInstrumentedJobs(t *testing.T) {
+	repoRoot := testutil.MustRepoPath(t, ".")
+	goStub := writeMakeEchoScript(t, "stub-go-functional-jobs")
+
+	for _, tc := range []struct {
+		name       string
+		testJobs   string
+		wantHeader string
+		wantFlag   string
+	}{{
+		name:       "functional CI override",
+		testJobs:   "8",
+		wantHeader: "jobs=4 test_jobs=8",
+		wantFlag:   "-test-jobs 8",
+	}, {
+		name:       "local default",
+		wantHeader: "jobs=4 test_jobs=default",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			makefilePath := writeVerifyFastWrapperMakefile(t, repoRoot, map[string]string{
+				"functional-boundary-check": "@printf '%s\\n' 'stub:boundary-ok'\n",
+			})
+			args := []string{
+				"FUNCTIONAL_DEFAULT_JOBS=4",
+				"GO=" + goStub,
+			}
+			if tc.testJobs != "" {
+				args = append(args, "FUNCTIONAL_TEST_JOBS="+tc.testJobs)
+			}
+			output, err := runMakefileTargetWithArgs(repoRoot, makefilePath, "test-functional-coverage", args...)
+			if err != nil {
+				t.Fatalf("run %s: %v\n%s", tc.name, err, output)
+			}
+			if !strings.Contains(output, tc.wantHeader) {
+				t.Fatalf("%s diagnostic missing %q:\n%s", tc.name, tc.wantHeader, output)
+			}
+			if !strings.Contains(output, "-jobs 4") {
+				t.Fatalf("%s did not preserve discovery jobs:\n%s", tc.name, output)
+			}
+			if tc.wantFlag != "" {
+				if !strings.Contains(output, tc.wantFlag) {
+					t.Fatalf("%s did not forward instrumented test jobs %q:\n%s", tc.name, tc.wantFlag, output)
+				}
+			} else if strings.Contains(output, "-test-jobs") {
+				t.Fatalf("%s unexpectedly changed the default command:\n%s", tc.name, output)
+			}
+		})
+	}
+}
+
 // TestFunctionalCoverageCommandSmoke_DefersOrdinaryGocoverageFailure proves
 // the CI-only handoff preserves gocoveragecheck's exact exit code while
 // allowing the compact verdict step to own an ordinary exit-1 outcome.
@@ -130,6 +183,7 @@ func TestFunctionalTestVizLaneScriptSmoke_TimesOutAndRetainsDiagnostics(t *testi
 
 	repoRoot := testutil.MustRepoPath(t, ".")
 	makePath := writeExecutableScript(t, "fake-make-functional-viz-timeout", `#!/bin/sh
+printf '%s\n' "fake-make: default_jobs=$FUNCTIONAL_DEFAULT_JOBS test_jobs=$FUNCTIONAL_TEST_JOBS"
 printf '%s\n' 'inventory: discovered-packages=147 observed-packages=12'
 printf '%s\n' 'quarantine: selector=./tests/functional/example bucket=ENVIRONMENT-DEPENDENT observed=skip'
 trap 'exit 143' TERM INT
@@ -145,6 +199,8 @@ sleep 2
 		"FUNCTIONAL_TEST_TIER=pr-short",
 		"FUNCTIONAL_TEST_TRIGGER=pull_request",
 		"FUNCTIONAL_SHORT=true",
+		"FUNCTIONAL_DEFAULT_JOBS=4",
+		"FUNCTIONAL_TEST_JOBS=8",
 		fmt.Sprintf("MAKE_BIN=%s", makePath),
 	)
 	if err == nil {
@@ -161,7 +217,8 @@ sleep 2
 	}
 	log := string(logBody)
 	for _, expected := range []string{
-		"tier=pr-short trigger=pull_request short=true budget=0.1s selection=subtractive",
+		"tier=pr-short trigger=pull_request short=true budget=0.1s selection=subtractive quarantine=tests/functional/functional-quarantine.json jobs=4 test_jobs=8",
+		"fake-make: default_jobs=4 test_jobs=8",
 		"inventory: discovered-packages=147 observed-packages=12",
 		"quarantine: selector=./tests/functional/example bucket=ENVIRONMENT-DEPENDENT observed=skip",
 		"tier timed out after budget=0.1s",

--- a/tests/functional/observability/verification/makefile_helpers_test.go
+++ b/tests/functional/observability/verification/makefile_helpers_test.go
@@ -90,6 +90,7 @@ var functionalCoverageMakeOverrideVars = []string{
 	"FUNCTIONAL_TEST_VIZ_MARKDOWN",
 	"GO_FUNCTIONAL_COVERAGE_PROFILE",
 	"GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT",
+	"FUNCTIONAL_TEST_JOBS",
 }
 
 func scrubMakeOverrideEnv(environ []string, dropNames ...string) []string {


### PR DESCRIPTION
{
  "project": "PERF-F5 \u2014 Oversubscribe the I/O-Bound Functional Test Window",
  "branchName": "perf-f5-functional-test-window-overcommit",
  "description": "Separate Backend Functional Coverage discovery concurrency from instrumented-test concurrency, keep discovery at four jobs, and test the I/O-bound coverage window at eight processes so its measured 300.383-second wall time can fall to at most 240 seconds on two consecutive green runs without losing any of 141 packages or causing memory pressure. This lane targets only the test window and does not claim to make the full 488-second job a sub-three-minute job.",
  "currentStatus": "2026-08-21 17:02 -07:00 handoff: PR #2138 remains open and unmerged at head 753681e93, non-draft, mergeable, clean, and ready for review, with all required checks terminal-success or intentionally skipped. The full base-repository conversation has zero submitted reviews, zero review threads, and no reviewer-authored requests. The revised Story 003 handoff is satisfied: one evidence comment records the existing run/job IDs, exact settings, inventory, wall times, and safety inspection, and its Operator-owned verification heading states that repeated <=240.000s confirmation remains operator-owned. The measured final-head inventory is 274.310s, above the strict 240.000s target, and is not claimed as a performance pass.",
  "context": {
    "customerAsk": "Add a distinct -test-jobs override to gocoveragecheck that applies only to the instrumented go test -p call, configure Backend Functional Coverage to use roughly logicalCPUs*2 test jobs while ordinary discovery jobs remains unchanged, and require two consecutive green same-head CI runs with Functional suite inventory wall at or below 240 seconds, all 141 packages passing, and no OOM or exit 137 before merging.",
    "problem": "Green CI run 32509668745 took 488 seconds. Its instrumented test window took 300.383 seconds even though -jobs 4 was correctly selected: 141 package durations summed to 735.1 seconds, yielding only 2.45 effective workers, while the slowest packages launch real subprocesses and wait on I/O. Raising the existing shared knob would also change the separate 130.4-second discovery/build phase and collide with concurrent owners.",
    "solution": "Add an optional positive instrumented-test concurrency override whose absent/default behavior is exactly today's jobs resolution. Keep functional discovery at the runner-derived four jobs, derive a bounded test-jobs value of logicalCPUs*2 at the functional CI boundary, forward and diagnose both values, and use focused tests plus two consecutive final-head CI runs to prove latency, inventory completeness, coverage success, and memory safety. If the same-method measurement is neutral or harmful, report the negative result and do not merge the hypothesis as an improvement."
  },
  "acceptanceCriteria": [
    "gocoveragecheck accepts a distinct positive instrumented-test jobs override; when absent, the instrumented go test -p value remains the value selected by existing -jobs behavior, and the unit-suite cfg.jobs <= 0 default path remains behaviorally and textually unchanged.",
    "Backend Functional Coverage reports and uses separate values: ordinary jobs remains runner-derived (4 on the measured runner) for discovery, while test jobs is initially logicalCPUs*2 (8 on that runner) and affects only the instrumented test call. Local/default invocations and other CI lanes are unchanged.",
    "On the PR's final head, two consecutive green Backend Functional Coverage runs each emit a completed Functional suite inventory with wall <= 240.000s, all 141 packages passing, and no OOM, exit 137, signal: killed, or equivalent allocation failure. Both measurements use the same CI command and artifact as the 300.383-second baseline and are recorded in a PR comment.",
    "The optimization ships only with measured proof. If oversubscription is neutral, slower, incomplete, or unstable, do not merge the hypothesis as a performance improvement; report the negative same-method measurements honestly in the PR conversation and close the experimental lane rather than weakening the threshold, inventory, or safety requirements.",
    "Quality gate: Typecheck passes; focused cmd/gocoveragecheck unit tests, functional-wrapper tests, and applicable repository tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. No coverage floor, quarantine, timeout, test selection, inventory gate, or verdict behavior is weakened.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The implementation/review cycle continues through those review-owned outcomes until the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "perf-f5-functional-test-window-overcommit-001",
      "title": "Separate instrumented-test concurrency from discovery concurrency",
      "description": "As a maintainer invoking gocoveragecheck, I want an optional instrumented-test concurrency override so I can test an I/O-bound workload at higher process concurrency without changing discovery or established defaults.",
      "acceptanceCriteria": [
        "A positive -test-jobs N makes the final instrumented go test command use -p=N, while discovery and quarantine selection continue to use the existing -jobs selection.",
        "Omitting -test-jobs, including with an explicit -jobs N, produces the same instrumented concurrency as before; focused tests cover override, fallback, and invalid/non-positive input behavior.",
        "The existing unit-suite default branch for cfg.jobs <= 0 stays byte-identical, and focused regression tests continue to prove its Windows, non-Windows, and invalid-CPU outcomes.",
        "The separate knob has a concise rationale explaining that functional subprocess I/O wait\u2014not additional CPU capacity\u2014justifies controlled oversubscription and that the knobs must not be collapsed.",
        "functional_quarantine.go, functional discovery/build behavior, output streaming/diagnostics, and generated files are not changed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added and validated -test-jobs; instrumented coverage uses the override while discovery and existing defaults remain on -jobs. Focused gocoveragecheck tests and vet pass."
    },
    {
      "id": "perf-f5-functional-test-window-overcommit-002",
      "title": "Oversubscribe only the functional CI test window",
      "description": "As a maintainer waiting on CI, I want the functional wrapper to pass separate runner-derived discovery and test-window limits so only the I/O-bound phase can use more processes than CPUs.",
      "acceptanceCriteria": [
        "On a four-logical-CPU functional runner, the lane keeps ordinary jobs at four and derives test jobs as eight; the values are passed separately to the coverage command and are both visible in the existing Functional CI runner diagnostic.",
        "Focused wrapper tests observe the two separate values reaching the real Make/coverage invocation boundary and prove that an invocation without the new CI override retains the existing default behavior.",
        "The new setting exists only in the Backend Functional Coverage lane; unit coverage, local lane budgeting, discovery selection, timeouts, quarantine, coverage floors, inventory, and verdict handling remain unchanged.",
        "The derivation rejects or fails closed on malformed/unusable values and does not create unbounded process concurrency.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Functional CI now derives bounded test jobs as logical CPUs*2, keeps discovery on runner jobs, forwards the values separately through the Make/viz wrapper, reports both diagnostics, and passes focused Make, runner, coverage, shell, workflow, and vet checks."
    },
    {
      "id": "perf-f5-functional-test-window-overcommit-003",
      "title": "Prove repeatable speed and safety before shipping",
      "description": "As a reviewer, I want repeated measurements from the exact PR head so I can distinguish a real improvement from noise and reject harmful oversubscription.",
      "acceptanceCriteria": [
        "Typecheck passes",
        "Tests pass",
        "OPERATOR-REVISED 2026-08-22: push your final head, ensure the PR is open, READY (not draft) and has CI started.",
        "OPERATOR-REVISED: post ONE PR comment containing the evidence you have ALREADY gathered - exact run and job IDs, the measured wall-clock numbers, and the selected jobs/worker settings. Report the numbers you actually observed; do not round toward the target and do not describe an unmeasured value as passing.",
        "OPERATOR-REVISED: under a heading 'Operator-owned verification', state plainly which measurements still require repeated runs to confirm, and that the operator owns them. Naming the gap honestly SATISFIES this criterion; claiming a result you did not measure does NOT.",
        "OPERATOR-REVISED: if any run you already have shows OOM, exit 137, 'signal: killed', or an allocation failure, say so explicitly - that is a blocking safety finding and must not be omitted.",
        "OPERATOR-REVISED: then STOP and hand off to review. Do NOT trigger further CI runs to accumulate repeat measurements, and do NOT push a new commit merely to re-measure."
      ],
      "priority": 3,
      "passes": true,
      "notes": "Operator-revised Story 003 handoff is complete: final head 753681e93 is pushed to open, ready PR #2138 with CI started and all required checks green; comment https://github.com/portpowered/you-agent-factory/pull/2138#issuecomment-5376626889 records exact run/job IDs, commands/artifacts, settings, inventory, wall times, and the safety inspection, with an 'Operator-owned verification' heading. The final-head run (32527242147, job 96912618596) used jobs=4 and test_jobs=8 and recorded 142/142 selected packages passing with complete=true, but its exact inventory wall was 274.310s, above the strict 240.000s threshold. The numeric performance target remains unmet and is not claimed as passing; repeated <=240.000s confirmation is explicitly operator-owned. No reviewer-authored feedback or unresolved review thread exists, so stop and hand off without a new CI run or commit.",
      "operatorRevisedFrom": [
        "Two consecutive green Backend Functional Coverage runs on the same final head each report Functional suite inventory wall at or below 240.000 seconds using the same CI instrument that produced the 300.383-second baseline.",
        "Each proof run reports the complete 141-package inventory with every package passing and reaches the existing successful coverage verdict.",
        "Each proof-run log is inspected for OOM, exit 137, signal: killed, and allocation failures; none is present.",
        "The PR comment links both runs and quotes the exact command/artifact, selected jobs/test-jobs values, inventory result, and wall time. No local Windows timing is presented as comparable evidence, and CI evidence is never committed.",
        "If either run misses the latency, completeness, green, or memory-safety condition, the candidate is not merged on hypothesis; any further bounded tuning is re-measured twice, otherwise the negative result is reported and the lane is closed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "operatorNote": "Revised 2026-08-22 by the operator. Criteria requiring repeated same-head confirmation runs were removed because satisfying them consumed a visit per check and was about to trip the visit breaker on an already-green PR. The repeated-run verification is now OPERATOR-OWNED. Originals preserved in operatorRevisedFrom. No unmet numeric target has been marked as passing."
    }
  ]
}
