### PR TITLE
automations-hosted-poller-retry-backoff

### DIFF
--- a/pkg/services/automations/internal/services/hosted_sources/internal/linear/contracts.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/linear/contracts.go
@@ -28,4 +28,5 @@ type SecretResolver func(
 // Clock schedules hosted Linear poller waits.
 type Clock interface {
 	After(time.Duration) <-chan time.Time
+	Now() time.Time
 }

--- a/pkg/services/automations/internal/services/hosted_sources/internal/linear/errors.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/linear/errors.go
@@ -1,6 +1,10 @@
 package linear
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"time"
+)
 
 var (
 	// ErrWorkAdmission reports that Work admission failed for a generated hosted-source
@@ -11,4 +15,35 @@ var (
 	// The wrapped error preserves the underlying resolution cause without performing
 	// Work admission or reporting successful observation convergence.
 	ErrSecretResolution = errors.New("hosted sources: secret resolution failed")
+	// ErrRateLimited classifies a provider response that asks the poller to
+	// reduce its request rate.
+	ErrRateLimited = errors.New("hosted linear: rate limited")
 )
+
+// RateLimitError carries only safe retry metadata from a Linear rate-limit
+// response. Provider response bodies and messages are intentionally omitted.
+type RateLimitError struct {
+	RetryAfter    time.Duration
+	HasRetryAfter bool
+}
+
+func (e *RateLimitError) Error() string {
+	if e == nil || !e.HasRetryAfter {
+		return ErrRateLimited.Error()
+	}
+	return fmt.Sprintf("%s: retry after %s", ErrRateLimited, e.RetryAfter)
+}
+
+func (e *RateLimitError) Unwrap() error {
+	return ErrRateLimited
+}
+
+// RetryDelay returns provider guidance only when it is safe to use as a
+// duration. A malformed or otherwise unusable value therefore falls back to
+// the supervisor's local retry policy.
+func (e *RateLimitError) RetryDelay() (time.Duration, bool) {
+	if e == nil || !e.HasRetryAfter || e.RetryAfter < 0 {
+		return 0, false
+	}
+	return e.RetryAfter, true
+}

--- a/pkg/services/automations/internal/services/hosted_sources/internal/linear/linear.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/linear/linear.go
@@ -648,10 +648,6 @@ func (c Client) fetchIssuesPage(ctx context.Context, apiKey, cursor string, filt
 	return decodeIssuesPageResponseWithHeaders(resp.StatusCode, resp.Header, data, clientNow(c))
 }
 
-func decodeIssuesPageResponse(statusCode int, data []byte) (linearIssuePage, error) {
-	return decodeIssuesPageResponseWithHeaders(statusCode, nil, data, time.Now())
-}
-
 func decodeIssuesPageResponseWithHeaders(
 	statusCode int,
 	headers http.Header,
@@ -703,7 +699,10 @@ func clientNow(client Client) time.Time {
 	if client.Clock != nil {
 		return client.Clock.Now()
 	}
-	return time.Now()
+	// A missing clock is retained for direct adapter callers that only need
+	// successful responses. Rate-limit date metadata treats this zero value as
+	// unusable instead of consulting ambient process time.
+	return time.Time{}
 }
 
 func isRateLimitCode(code string) bool {

--- a/pkg/services/automations/internal/services/hosted_sources/internal/linear/linear.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/linear/linear.go
@@ -106,6 +106,7 @@ type linearIssuePage struct {
 type Client struct {
 	Endpoint   string
 	HTTPClient HTTPDoer
+	Clock      Clock
 	Logger     *zap.Logger
 }
 
@@ -644,10 +645,23 @@ func (c Client) fetchIssuesPage(ctx context.Context, apiKey, cursor string, filt
 		return linearIssuePage{}, fmt.Errorf("read hosted linear graphql response: %w", err)
 	}
 
-	return decodeIssuesPageResponse(resp.StatusCode, data)
+	return decodeIssuesPageResponseWithHeaders(resp.StatusCode, resp.Header, data, clientNow(c))
 }
 
 func decodeIssuesPageResponse(statusCode int, data []byte) (linearIssuePage, error) {
+	return decodeIssuesPageResponseWithHeaders(statusCode, nil, data, time.Now())
+}
+
+func decodeIssuesPageResponseWithHeaders(
+	statusCode int,
+	headers http.Header,
+	data []byte,
+	now time.Time,
+) (linearIssuePage, error) {
+	if statusCode == http.StatusTooManyRequests {
+		return linearIssuePage{}, newRateLimitError(headers, rateLimitExtensions{}, now)
+	}
+
 	var decoded struct {
 		Data struct {
 			Issues struct {
@@ -659,20 +673,19 @@ func decodeIssuesPageResponse(statusCode int, data []byte) (linearIssuePage, err
 			} `json:"issues"`
 		} `json:"data"`
 		Errors []struct {
-			Message    string `json:"message"`
-			Extensions struct {
-				Code string `json:"code"`
-			} `json:"extensions"`
+			Message    string              `json:"message"`
+			Extensions rateLimitExtensions `json:"extensions"`
 		} `json:"errors"`
 	}
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		return linearIssuePage{}, fmt.Errorf("decode hosted linear graphql response: %w", err)
 	}
 	if len(decoded.Errors) > 0 {
-		code := decoded.Errors[0].Extensions.Code
+		graphqlError := decoded.Errors[0]
+		code := graphqlError.Extensions.Code
 		msg := decoded.Errors[0].Message
-		if code == "RATELIMITED" {
-			return linearIssuePage{}, fmt.Errorf("hosted linear graphql rate limited: %s", msg)
+		if isRateLimitCode(code) {
+			return linearIssuePage{}, newRateLimitError(headers, graphqlError.Extensions, now)
 		}
 		return linearIssuePage{}, fmt.Errorf("hosted linear graphql error: %s", msg)
 	}
@@ -684,4 +697,16 @@ func decodeIssuesPageResponse(statusCode int, data []byte) (linearIssuePage, err
 		Next:   decoded.Data.Issues.PageInfo.EndCursor,
 		More:   decoded.Data.Issues.PageInfo.HasNextPage,
 	}, nil
+}
+
+func clientNow(client Client) time.Time {
+	if client.Clock != nil {
+		return client.Clock.Now()
+	}
+	return time.Now()
+}
+
+func isRateLimitCode(code string) bool {
+	normalized := strings.ToUpper(strings.ReplaceAll(strings.TrimSpace(code), "_", ""))
+	return normalized == "RATELIMITED" || normalized == "RATELIMIT"
 }

--- a/pkg/services/automations/internal/services/hosted_sources/internal/linear/rate_limit.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/linear/rate_limit.go
@@ -1,0 +1,82 @@
+package linear
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const maxRetryAfterSeconds = int64((1<<63 - 1) / int64(time.Second))
+
+type rateLimitExtensions struct {
+	Code              string          `json:"code"`
+	RetryAfter        json.RawMessage `json:"retryAfter"`
+	RetryAfterSeconds json.RawMessage `json:"retryAfterSeconds"`
+}
+
+func newRateLimitError(headers http.Header, extensions rateLimitExtensions, now time.Time) error {
+	delay, ok := retryAfterFromHeaders(headers, now)
+	if !ok {
+		delay, ok = retryAfterFromExtensions(extensions, now)
+	}
+	return &RateLimitError{RetryAfter: delay, HasRetryAfter: ok}
+}
+
+func retryAfterFromHeaders(headers http.Header, now time.Time) (time.Duration, bool) {
+	if headers == nil {
+		return 0, false
+	}
+	return parseRetryAfterValue(headers.Get("Retry-After"), now)
+}
+
+func retryAfterFromExtensions(extensions rateLimitExtensions, now time.Time) (time.Duration, bool) {
+	for _, value := range []json.RawMessage{extensions.RetryAfter, extensions.RetryAfterSeconds} {
+		if len(value) == 0 {
+			continue
+		}
+		var raw string
+		if err := json.Unmarshal(value, &raw); err == nil {
+			if delay, ok := parseRetryAfterValue(raw, now); ok {
+				return delay, true
+			}
+			continue
+		}
+		var seconds int64
+		if err := json.Unmarshal(value, &seconds); err != nil || seconds < 0 || seconds > maxRetryAfterSeconds {
+			continue
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+	return 0, false
+}
+
+func parseRetryAfterValue(value string, now time.Time) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false
+	}
+	if isDecimalSeconds(value) {
+		seconds, err := strconv.ParseInt(value, 10, 64)
+		if err != nil || seconds < 0 || seconds > maxRetryAfterSeconds {
+			return 0, false
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+
+	retryAt, err := http.ParseTime(value)
+	if err != nil || retryAt.Before(now) {
+		return 0, false
+	}
+	return retryAt.Sub(now), true
+}
+
+func isDecimalSeconds(value string) bool {
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/services/automations/internal/services/hosted_sources/internal/linear/rate_limit.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/linear/rate_limit.go
@@ -66,7 +66,7 @@ func parseRetryAfterValue(value string, now time.Time) (time.Duration, bool) {
 	}
 
 	retryAt, err := http.ParseTime(value)
-	if err != nil || retryAt.Before(now) {
+	if err != nil || now.IsZero() || retryAt.Before(now) {
 		return 0, false
 	}
 	return retryAt.Sub(now), true

--- a/pkg/services/automations/internal/services/hosted_sources/internal/linear/rate_limit_test.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/linear/rate_limit_test.go
@@ -43,6 +43,25 @@ func TestClientFetchIssuesPage_PreservesSanitizedRetryAfter(t *testing.T) {
 	}
 }
 
+func TestClientFetchIssuesPage_WithoutClockRejectsHTTPDateGuidance(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "Wed, 21 Aug 2030 13:00:00 GMT")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	_, err := (Client{Endpoint: server.URL, HTTPClient: server.Client()}).fetchIssuesPage(
+		context.Background(), "secret", "", linearIssueFilter{},
+	)
+	var rateLimitErr *RateLimitError
+	if !errors.As(err, &rateLimitErr) {
+		t.Fatalf("fetchIssuesPage() error = %v, want RateLimitError", err)
+	}
+	if _, ok := rateLimitErr.RetryDelay(); ok {
+		t.Fatal("retry delay = usable, want missing clock to make HTTP-date guidance unusable")
+	}
+}
+
 func TestDecodeIssuesPageResponse_RetryAfterSemantics(t *testing.T) {
 	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
 	cases := []struct {

--- a/pkg/services/automations/internal/services/hosted_sources/internal/linear/rate_limit_test.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/linear/rate_limit_test.go
@@ -1,0 +1,112 @@
+package linear
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+)
+
+func TestClientFetchIssuesPage_PreservesSanitizedRetryAfter(t *testing.T) {
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	fakeClock := clockwork.NewFakeClockAt(now)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "7")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"private provider response"}]}`))
+	}))
+	defer server.Close()
+
+	_, err := (Client{Endpoint: server.URL, HTTPClient: server.Client(), Clock: fakeClock}).fetchIssuesPage(
+		context.Background(), "secret", "", linearIssueFilter{},
+	)
+	if err == nil {
+		t.Fatal("fetchIssuesPage() error = nil, want rate-limit error")
+	}
+	var rateLimitErr *RateLimitError
+	if !errors.As(err, &rateLimitErr) {
+		t.Fatalf("fetchIssuesPage() error = %v, want RateLimitError", err)
+	}
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("fetchIssuesPage() error = %v, want ErrRateLimited", err)
+	}
+	if delay, ok := rateLimitErr.RetryDelay(); !ok || delay != 7*time.Second {
+		t.Fatalf("retry delay = (%s, %t), want (7s, true)", delay, ok)
+	}
+	if strings.Contains(err.Error(), "private provider response") || strings.Contains(err.Error(), "secret") {
+		t.Fatalf("rate-limit error = %q, want sanitized provider metadata", err)
+	}
+}
+
+func TestDecodeIssuesPageResponse_RetryAfterSemantics(t *testing.T) {
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name       string
+		header     string
+		wantDelay  time.Duration
+		wantUsable bool
+	}{
+		{name: "seconds", header: "5", wantDelay: 5 * time.Second, wantUsable: true},
+		{name: "http date", header: now.Add(9 * time.Second).Format(http.TimeFormat), wantDelay: 9 * time.Second, wantUsable: true},
+		{name: "zero seconds", header: "0", wantUsable: true},
+		{name: "missing", wantUsable: false},
+		{name: "malformed", header: "later", wantUsable: false},
+		{name: "fractional", header: "1.5", wantUsable: false},
+		{name: "negative", header: "-1", wantUsable: false},
+		{name: "expired date", header: now.Add(-time.Second).Format(http.TimeFormat), wantUsable: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			headers := http.Header{}
+			if tc.header != "" {
+				headers.Set("Retry-After", tc.header)
+			}
+			_, err := decodeIssuesPageResponseWithHeaders(http.StatusTooManyRequests, headers, []byte("not logged"), now)
+			var rateLimitErr *RateLimitError
+			if !errors.As(err, &rateLimitErr) {
+				t.Fatalf("decode error = %v, want RateLimitError", err)
+			}
+			gotDelay, gotUsable := rateLimitErr.RetryDelay()
+			if gotUsable != tc.wantUsable || gotDelay != tc.wantDelay {
+				t.Fatalf("retry delay = (%s, %t), want (%s, %t)", gotDelay, gotUsable, tc.wantDelay, tc.wantUsable)
+			}
+		})
+	}
+}
+
+func TestDecodeIssuesPageResponse_GraphQLRateLimitUsesRetryAfter(t *testing.T) {
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	header := http.Header{"Retry-After": []string{"11"}}
+	data := []byte(`{"errors":[{"message":"private provider response","extensions":{"code":"RATELIMITED"}}]}`)
+
+	_, err := decodeIssuesPageResponseWithHeaders(http.StatusOK, header, data, now)
+	var rateLimitErr *RateLimitError
+	if !errors.As(err, &rateLimitErr) {
+		t.Fatalf("decode error = %v, want RateLimitError", err)
+	}
+	if delay, ok := rateLimitErr.RetryDelay(); !ok || delay != 11*time.Second {
+		t.Fatalf("retry delay = (%s, %t), want (11s, true)", delay, ok)
+	}
+	if strings.Contains(err.Error(), "private provider response") {
+		t.Fatalf("GraphQL rate-limit error = %q, want sanitized error", err)
+	}
+}
+
+func TestDecodeIssuesPageResponse_GraphQLRateLimitUsesExtensionGuidance(t *testing.T) {
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	data := []byte(`{"errors":[{"message":"private provider response","extensions":{"code":"RATE_LIMITED","retryAfter":4}}]}`)
+
+	_, err := decodeIssuesPageResponseWithHeaders(http.StatusOK, nil, data, now)
+	var rateLimitErr *RateLimitError
+	if !errors.As(err, &rateLimitErr) {
+		t.Fatalf("decode error = %v, want RateLimitError", err)
+	}
+	if delay, ok := rateLimitErr.RetryDelay(); !ok || delay != 4*time.Second {
+		t.Fatalf("retry delay = (%s, %t), want (4s, true)", delay, ok)
+	}
+}

--- a/pkg/services/automations/internal/services/hosted_sources/internal/service/linear_poller.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/service/linear_poller.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	hostedsources "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources"
 	hostedlinear "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources/internal/linear"
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"go.uber.org/zap"
 )
@@ -26,6 +26,7 @@ type LinearPoller struct {
 	runtimeConfig  interfaces.RuntimeConfigLookup
 	workstation    interfaces.FactoryWorkstationConfig
 	worker         *interfaces.FactoryWorkerConfig
+	jitter         retryJitter
 	submitter      Submitter
 }
 
@@ -41,6 +42,7 @@ func NewLinearPoller(
 	runtimeConfig interfaces.RuntimeConfigLookup,
 	workstation interfaces.FactoryWorkstationConfig,
 	worker *interfaces.FactoryWorkerConfig,
+	jitter retryJitter,
 	submitter Submitter,
 ) (*LinearPoller, error) {
 	switch {
@@ -77,6 +79,7 @@ func NewLinearPoller(
 		runtimeConfig:  runtimeConfig,
 		workstation:    workstation,
 		worker:         worker,
+		jitter:         jitter,
 		submitter:      submitter,
 	}, nil
 }

--- a/pkg/services/automations/internal/services/hosted_sources/internal/service/retry.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/service/retry.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"crypto/rand"
+	"errors"
+	"math/big"
+	"time"
+
+	hostedlinear "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources/internal/linear"
+)
+
+const (
+	restartBackoffMin = 25 * time.Millisecond
+	restartBackoffMax = 60 * time.Second
+	retryDelayFloor   = 1 * time.Millisecond
+	// Local retry jitter is bounded to +/-20% of the computed delay, then
+	// clamped to the positive floor and 60-second ceiling below.
+	retryJitterRatio = 20
+)
+
+// retryJitter is the replaceable randomness boundary for local retry delays.
+// It receives the bounded exponential delay and returns a jittered candidate;
+// jitteredRetryBackoff clamps that candidate before it reaches the clock.
+type retryJitter func(time.Duration) time.Duration
+
+func retryDelay(consecutiveFailures int, runErr error, jitter retryJitter) (time.Duration, string) {
+	var rateLimitErr *hostedlinear.RateLimitError
+	if errors.As(runErr, &rateLimitErr) {
+		if providerDelay, ok := rateLimitErr.RetryDelay(); ok {
+			return providerDelay, "provider"
+		}
+	}
+	return jitteredRetryBackoff(consecutiveFailures, jitter), "computed"
+}
+
+func restartBackoff(consecutiveFailures int) time.Duration {
+	if consecutiveFailures <= 1 {
+		return restartBackoffMin
+	}
+	backoff := restartBackoffMin
+	for failure := 1; failure < consecutiveFailures; failure++ {
+		if backoff >= restartBackoffMax/2 {
+			return restartBackoffMax
+		}
+		backoff *= 2
+	}
+	return backoff
+}
+
+func jitteredRetryBackoff(consecutiveFailures int, jitter retryJitter) time.Duration {
+	base := restartBackoff(consecutiveFailures)
+	if jitter == nil {
+		jitter = defaultRetryJitter
+	}
+	return clampRetryDelay(jitter(base))
+}
+
+func defaultRetryJitter(base time.Duration) time.Duration {
+	base = clampRetryDelay(base)
+	maxJitter := base * retryJitterRatio / 100
+	minimum := clampRetryDelay(base - maxJitter)
+	maximum := clampRetryDelay(base + maxJitter)
+	if maximum < minimum {
+		maximum = minimum
+	}
+
+	span := maximum - minimum
+	if span == 0 {
+		return minimum
+	}
+	sample, err := rand.Int(rand.Reader, big.NewInt(int64(span)+1))
+	if err != nil {
+		return base
+	}
+	return minimum + time.Duration(sample.Int64())
+}
+
+func clampRetryDelay(delay time.Duration) time.Duration {
+	switch {
+	case delay < retryDelayFloor:
+		return retryDelayFloor
+	case delay > restartBackoffMax:
+		return restartBackoffMax
+	default:
+		return delay
+	}
+}

--- a/pkg/services/automations/internal/services/hosted_sources/internal/service/retry.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/service/retry.go
@@ -1,9 +1,7 @@
 package service
 
 import (
-	"crypto/rand"
 	"errors"
-	"math/big"
 	"time"
 
 	hostedlinear "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources/internal/linear"
@@ -22,6 +20,12 @@ const (
 // It receives the bounded exponential delay and returns a jittered candidate;
 // jitteredRetryBackoff clamps that candidate before it reaches the clock.
 type retryJitter func(time.Duration) time.Duration
+
+// RetryRandomSource supplies bounded entropy to the hosted retry policy. Wire
+// selects the platform implementation; tests can replace it deterministically.
+type RetryRandomSource interface {
+	Int63n(upperBound int64) (int64, error)
+}
 
 func retryDelay(consecutiveFailures int, runErr error, jitter retryJitter) (time.Duration, string) {
 	var rateLimitErr *hostedlinear.RateLimitError
@@ -50,13 +54,25 @@ func restartBackoff(consecutiveFailures int) time.Duration {
 func jitteredRetryBackoff(consecutiveFailures int, jitter retryJitter) time.Duration {
 	base := restartBackoff(consecutiveFailures)
 	if jitter == nil {
-		jitter = defaultRetryJitter
+		return clampRetryDelay(base)
 	}
 	return clampRetryDelay(jitter(base))
 }
 
-func defaultRetryJitter(base time.Duration) time.Duration {
+func retryJitterFromRandomSource(source RetryRandomSource) retryJitter {
+	if source == nil {
+		return nil
+	}
+	return func(base time.Duration) time.Duration {
+		return defaultRetryJitter(source, base)
+	}
+}
+
+func defaultRetryJitter(source RetryRandomSource, base time.Duration) time.Duration {
 	base = clampRetryDelay(base)
+	if source == nil {
+		return base
+	}
 	maxJitter := base * retryJitterRatio / 100
 	minimum := clampRetryDelay(base - maxJitter)
 	maximum := clampRetryDelay(base + maxJitter)
@@ -68,11 +84,11 @@ func defaultRetryJitter(base time.Duration) time.Duration {
 	if span == 0 {
 		return minimum
 	}
-	sample, err := rand.Int(rand.Reader, big.NewInt(int64(span)+1))
-	if err != nil {
+	sample, err := source.Int63n(int64(span) + 1)
+	if err != nil || sample < 0 || sample > int64(span) {
 		return base
 	}
-	return minimum + time.Duration(sample.Int64())
+	return minimum + time.Duration(sample)
 }
 
 func clampRetryDelay(delay time.Duration) time.Duration {

--- a/pkg/services/automations/internal/services/hosted_sources/internal/service/retry_supervisor_test.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/service/retry_supervisor_test.go
@@ -1,0 +1,283 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestJitteredRetryBackoff_ClampsAndDesynchronizesControlledValues(t *testing.T) {
+	offsets := []time.Duration{-5 * time.Millisecond, 5 * time.Millisecond}
+	call := 0
+	jitter := func(base time.Duration) time.Duration {
+		value := base + offsets[call]
+		call++
+		return value
+	}
+
+	first := jitteredRetryBackoff(1, jitter)
+	second := jitteredRetryBackoff(1, jitter)
+	if first != restartBackoffMin-5*time.Millisecond {
+		t.Fatalf("first jittered delay = %s, want %s", first, restartBackoffMin-5*time.Millisecond)
+	}
+	if second != restartBackoffMin+5*time.Millisecond {
+		t.Fatalf("second jittered delay = %s, want %s", second, restartBackoffMin+5*time.Millisecond)
+	}
+	if first == second {
+		t.Fatalf("equivalent failures received lockstep delay %s", first)
+	}
+
+	if got := jitteredRetryBackoff(1, func(time.Duration) time.Duration { return -time.Hour }); got != retryDelayFloor {
+		t.Fatalf("negative jittered delay = %s, want floor %s", got, retryDelayFloor)
+	}
+	if got := jitteredRetryBackoff(1, func(time.Duration) time.Duration { return time.Hour }); got != restartBackoffMax {
+		t.Fatalf("unbounded jittered delay = %s, want ceiling %s", got, restartBackoffMax)
+	}
+}
+
+func TestDefaultRetryJitter_StaysWithinBoundedRange(t *testing.T) {
+	for _, failures := range []int{1, 5, 13, 20} {
+		base := restartBackoff(failures)
+		minimum := clampRetryDelay(base - base*retryJitterRatio/100)
+		maximum := clampRetryDelay(base + base*retryJitterRatio/100)
+		for sample := 0; sample < 100; sample++ {
+			got := defaultRetryJitter(base)
+			if got < minimum || got > maximum {
+				t.Fatalf("defaultRetryJitter(%s) = %s, want within [%s, %s]", base, got, minimum, maximum)
+			}
+		}
+	}
+}
+
+func TestStartLinearPoller_ResetsFailureBackoffAfterSuccessfulCycle(t *testing.T) {
+	fakeClock := clockwork.NewFakeClock()
+	var requestCount atomic.Int32
+	requestEvents := make(chan int, 4)
+	logCore, observedLogs := observer.New(zap.InfoLevel)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		call := requestCount.Add(1)
+		requestEvents <- int(call)
+		if call == 1 || call == 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"errors":[{"message":"temporary provider failure"}]}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockLinearIssuesGraphQLResponse()))
+	}))
+	defer server.Close()
+
+	factoryDir := t.TempDir()
+	writeHostedLinearSecretForTest(t, factoryDir)
+	pollerCfg, runtimeCfg, poller, worker := hostedLinearPollerFixtureForTest(t, factoryDir, server, nil)
+	pollerCfg.Logger = zap.New(logCore)
+	pollerCfg.Clock = fakeClock
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var sidecars sync.WaitGroup
+	if err := startLinearPollerWithConfig(ctx, &sidecars, pollerCfg, runtimeCfg, poller, worker, func(context.Context, work.WorkRequest) error {
+		return nil
+	}); err != nil {
+		t.Fatalf("StartLinearPoller() error = %v", err)
+	}
+
+	waitForObservedLogCount(t, observedLogs, "hosted linear poller restarting", 1, time.Second)
+	waitForProviderRequest(t, requestEvents, 1)
+	firstRestart := observedLogs.FilterMessage("hosted linear poller restarting").All()[0]
+	if got := intField(firstRestart.ContextMap()["consecutive_failures"]); got != 1 {
+		t.Fatalf("first consecutive failure count = %d, want 1", got)
+	}
+	if got := durationField(firstRestart.ContextMap()["selected_delay"]); got != restartBackoffMin {
+		t.Fatalf("first selected delay = %s, want %s", got, restartBackoffMin)
+	}
+
+	waitForFakeClockWaiters(t, fakeClock, 1)
+	fakeClock.Advance(restartBackoffMin)
+	waitForProviderRequest(t, requestEvents, 2)
+	waitForFakeClockWaiters(t, fakeClock, 1)
+	fakeClock.Advance(time.Hour)
+	waitForProviderRequest(t, requestEvents, 3)
+	waitForObservedLogCount(t, observedLogs, "hosted linear poller restarting", 2, time.Second)
+
+	secondRestart := observedLogs.FilterMessage("hosted linear poller restarting").All()[1]
+	if got := intField(secondRestart.ContextMap()["consecutive_failures"]); got != 1 {
+		t.Fatalf("post-recovery consecutive failure count = %d, want reset to 1", got)
+	}
+	if got := durationField(secondRestart.ContextMap()["selected_delay"]); got != restartBackoffMin {
+		t.Fatalf("post-recovery selected delay = %s, want %s", got, restartBackoffMin)
+	}
+
+	cancel()
+	sidecars.Wait()
+}
+
+func TestStartLinearPoller_PersistentFailureRateStaysBounded(t *testing.T) {
+	const failureWindow = time.Minute
+	fakeClock := clockwork.NewFakeClock()
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"persistent provider failure"}]}`))
+	}))
+	defer server.Close()
+
+	factoryDir := t.TempDir()
+	writeHostedLinearSecretForTest(t, factoryDir)
+	logCore, observedLogs := observer.New(zap.InfoLevel)
+	pollerCfg, runtimeCfg, poller, worker := hostedLinearPollerFixtureForTest(t, factoryDir, server, nil)
+	pollerCfg.Logger = zap.New(logCore)
+	pollerCfg.Clock = fakeClock
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var sidecars sync.WaitGroup
+	if err := startLinearPollerWithConfig(ctx, &sidecars, pollerCfg, runtimeCfg, poller, worker, func(context.Context, work.WorkRequest) error {
+		return nil
+	}); err != nil {
+		t.Fatalf("StartLinearPoller() error = %v", err)
+	}
+
+	waitForObservedLogCount(t, observedLogs, "hosted linear poller restarting", 1, time.Second)
+	elapsed := time.Duration(0)
+	for failure := 1; ; failure++ {
+		delay := restartBackoff(failure)
+		if elapsed+delay > failureWindow {
+			break
+		}
+		waitForFakeClockWaiters(t, fakeClock, 1)
+		fakeClock.Advance(delay)
+		elapsed += delay
+		waitForObservedLogCount(t, observedLogs, "hosted linear poller restarting", failure+1, time.Second)
+	}
+	waitForFakeClockWaiters(t, fakeClock, 1)
+	fakeClock.Advance(failureWindow - elapsed)
+
+	got := int(requestCount.Load())
+	before := persistentFailureRequestCount(failureWindow, legacyRestartBackoff)
+	after := persistentFailureRequestCount(failureWindow, restartBackoff)
+	if got != after {
+		t.Fatalf("persistent-failure requests = %d, want %d in %s", got, after, failureWindow)
+	}
+	if got > 20 {
+		t.Fatalf("persistent-failure requests = %d, want no more than 20 in %s", got, failureWindow)
+	}
+	t.Logf(
+		"persistent failure over %s: before=%d (%.2f requests/s), after=%d (%.2f requests/s)",
+		failureWindow,
+		before,
+		float64(before)/failureWindow.Seconds(),
+		got,
+		float64(got)/failureWindow.Seconds(),
+	)
+
+	cancel()
+	sidecars.Wait()
+}
+
+func TestStartLinearPoller_StopsOnContextCancellationDuringProviderBackoff(t *testing.T) {
+	fakeClock := clockwork.NewFakeClock()
+	var requestCount atomic.Int32
+	logCore, observedLogs := observer.New(zap.InfoLevel)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		w.Header().Set("Retry-After", "3600")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	factoryDir := t.TempDir()
+	writeHostedLinearSecretForTest(t, factoryDir)
+	pollerCfg, runtimeCfg, poller, worker := hostedLinearPollerFixtureForTest(t, factoryDir, server, nil)
+	pollerCfg.Logger = zap.New(logCore)
+	pollerCfg.Clock = fakeClock
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var sidecars sync.WaitGroup
+	if err := startLinearPollerWithConfig(ctx, &sidecars, pollerCfg, runtimeCfg, poller, worker, func(context.Context, work.WorkRequest) error {
+		return nil
+	}); err != nil {
+		t.Fatalf("StartLinearPoller() error = %v", err)
+	}
+
+	waitForObservedLogMessage(t, observedLogs, "hosted linear poller restarting", time.Second)
+	restartEntry := observedLogs.FilterMessage("hosted linear poller restarting").All()[0]
+	if got := durationField(restartEntry.ContextMap()["selected_delay"]); got != time.Hour {
+		t.Fatalf("provider selected delay = %s, want 1h", got)
+	}
+	if got := fieldString(restartEntry.ContextMap()["delay_source"]); got != "provider" {
+		t.Fatalf("provider delay source = %q, want provider", got)
+	}
+	waitForFakeClockWaiters(t, fakeClock, 1)
+	cancel()
+	sidecars.Wait()
+
+	if got := requestCount.Load(); got != 1 {
+		t.Fatalf("provider request count = %d, want no retry after provider-delay cancellation", got)
+	}
+	if got := observedLogs.FilterMessage("hosted linear poller restarting").Len(); got != 1 {
+		t.Fatalf("restart log count = %d, want 1", got)
+	}
+}
+
+func waitForProviderRequest(t *testing.T, requests <-chan int, want int) {
+	t.Helper()
+	// The handler channel synchronizes directly with the fake HTTP provider; the
+	// timeout only guards a broken poller without adding a scheduling delay.
+	timeout := time.NewTimer(time.Second)
+	defer timeout.Stop()
+	for {
+		select {
+		case got := <-requests:
+			if got == want {
+				return
+			}
+			if got > want {
+				t.Fatalf("provider request event = %d, want %d", got, want)
+			}
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for provider request %d", want)
+		}
+	}
+}
+
+func legacyRestartBackoff(consecutiveFailures int) time.Duration {
+	const (
+		legacyMinimum = 25 * time.Millisecond
+		legacyMaximum = 250 * time.Millisecond
+	)
+	if consecutiveFailures <= 1 {
+		return legacyMinimum
+	}
+	backoff := legacyMinimum
+	for failure := 1; failure < consecutiveFailures && backoff < legacyMaximum; failure++ {
+		backoff *= 2
+		if backoff > legacyMaximum {
+			return legacyMaximum
+		}
+	}
+	return backoff
+}
+
+func persistentFailureRequestCount(window time.Duration, delay func(int) time.Duration) int {
+	elapsed := time.Duration(0)
+	requests := 1
+	for failure := 1; ; failure++ {
+		nextDelay := delay(failure)
+		if elapsed+nextDelay > window {
+			return requests
+		}
+		elapsed += nextDelay
+		requests++
+	}
+}

--- a/pkg/services/automations/internal/services/hosted_sources/internal/service/retry_supervisor_test.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/service/retry_supervisor_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
+	platformrandom "github.com/portpowered/infinite-you/pkg/platform/random"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -50,11 +51,26 @@ func TestDefaultRetryJitter_StaysWithinBoundedRange(t *testing.T) {
 		minimum := clampRetryDelay(base - base*retryJitterRatio/100)
 		maximum := clampRetryDelay(base + base*retryJitterRatio/100)
 		for sample := 0; sample < 100; sample++ {
-			got := defaultRetryJitter(base)
+			got := defaultRetryJitter(platformrandom.SourceFunc(func(bound int64) (int64, error) {
+				return bound / 2, nil
+			}), base)
 			if got < minimum || got > maximum {
 				t.Fatalf("defaultRetryJitter(%s) = %s, want within [%s, %s]", base, got, minimum, maximum)
 			}
 		}
+	}
+}
+
+func TestRetryJitterFromRandomSourceUsesInjectedEntropy(t *testing.T) {
+	base := restartBackoff(5)
+	source := platformrandom.SourceFunc(func(bound int64) (int64, error) {
+		return bound - 1, nil
+	})
+
+	got := retryJitterFromRandomSource(source)(base)
+	want := clampRetryDelay(base + base*retryJitterRatio/100)
+	if got != want {
+		t.Fatalf("injected jitter = %s, want upper bound %s", got, want)
 	}
 }
 

--- a/pkg/services/automations/internal/services/hosted_sources/internal/service/service.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/service/service.go
@@ -18,6 +18,7 @@ type Service struct {
 	secretResolver hostedlinear.SecretResolver
 	checkpoints    hostedlinear.CheckpointStore
 	linearEndpoint string
+	jitter         retryJitter
 }
 
 // New constructs hosted polling without starting its lifecycle.
@@ -36,6 +37,7 @@ func New(
 	return &Service{
 		logger: defaultLogger(logger), clock: clock, httpClient: httpClient,
 		secretResolver: secretResolver, checkpoints: checkpoints, linearEndpoint: defaultLinearEndpoint(linearEndpoint),
+		jitter: defaultRetryJitter,
 	}
 }
 
@@ -50,7 +52,7 @@ func (s *Service) StartLinearPoller(
 	return StartLinearPoller(
 		ctx, sidecars,
 		s.logger, s.clock, s.httpClient, s.secretResolver, s.checkpoints, s.linearEndpoint,
-		runtimeConfig, workstation, worker, submitter,
+		runtimeConfig, workstation, worker, s.jitter, submitter,
 	)
 }
 
@@ -62,7 +64,7 @@ func (s *Service) ValidateLinearPoller(
 ) error {
 	_, err := NewLinearPoller(
 		s.logger, s.clock, s.httpClient, s.secretResolver, s.checkpoints, s.linearEndpoint,
-		runtimeConfig, workstation, worker, submitter,
+		runtimeConfig, workstation, worker, s.jitter, submitter,
 	)
 	return err
 }

--- a/pkg/services/automations/internal/services/hosted_sources/internal/service/service.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/service/service.go
@@ -28,6 +28,7 @@ func New(
 	httpClient hostedlinear.HTTPDoer,
 	secretResolver hostedlinear.SecretResolver,
 	linearEndpoint string,
+	random RetryRandomSource,
 	checkpointStores ...hostedlinear.CheckpointStore,
 ) *Service {
 	var checkpoints hostedlinear.CheckpointStore
@@ -37,7 +38,7 @@ func New(
 	return &Service{
 		logger: defaultLogger(logger), clock: clock, httpClient: httpClient,
 		secretResolver: secretResolver, checkpoints: checkpoints, linearEndpoint: defaultLinearEndpoint(linearEndpoint),
-		jitter: defaultRetryJitter,
+		jitter: retryJitterFromRandomSource(random),
 	}
 }
 

--- a/pkg/services/automations/internal/services/hosted_sources/internal/service/service_test.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/service/service_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/jonboulle/clockwork"
 	factorydefinitioncomposition "github.com/portpowered/infinite-you/internal/testutil/factorydefinitionfixtures"
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
-	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	hostedlinear "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources/internal/linear"
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 )
 
@@ -102,49 +102,49 @@ func TestNewLinearPollerRejectsMissingDependencies(t *testing.T) {
 		{
 			name: "clock",
 			run: func() error {
-				_, err := NewLinearPoller(nil, nil, httpClient, secretResolver, checkpoints, "", runtimeCfg, workstation, worker, submitter)
+				_, err := NewLinearPoller(nil, nil, httpClient, secretResolver, checkpoints, "", runtimeCfg, workstation, worker, nil, submitter)
 				return err
 			},
 		},
 		{
 			name: "http client",
 			run: func() error {
-				_, err := NewLinearPoller(nil, clock, nil, secretResolver, checkpoints, "", runtimeCfg, workstation, worker, submitter)
+				_, err := NewLinearPoller(nil, clock, nil, secretResolver, checkpoints, "", runtimeCfg, workstation, worker, nil, submitter)
 				return err
 			},
 		},
 		{
 			name: "secret resolver",
 			run: func() error {
-				_, err := NewLinearPoller(nil, clock, httpClient, nil, checkpoints, "", runtimeCfg, workstation, worker, submitter)
+				_, err := NewLinearPoller(nil, clock, httpClient, nil, checkpoints, "", runtimeCfg, workstation, worker, nil, submitter)
 				return err
 			},
 		},
 		{
 			name: "checkpoint store",
 			run: func() error {
-				_, err := NewLinearPoller(nil, clock, httpClient, secretResolver, nil, "", runtimeCfg, workstation, worker, submitter)
+				_, err := NewLinearPoller(nil, clock, httpClient, secretResolver, nil, "", runtimeCfg, workstation, worker, nil, submitter)
 				return err
 			},
 		},
 		{
 			name: "runtime config",
 			run: func() error {
-				_, err := NewLinearPoller(nil, clock, httpClient, secretResolver, checkpoints, "", nil, workstation, worker, submitter)
+				_, err := NewLinearPoller(nil, clock, httpClient, secretResolver, checkpoints, "", nil, workstation, worker, nil, submitter)
 				return err
 			},
 		},
 		{
 			name: "worker",
 			run: func() error {
-				_, err := NewLinearPoller(nil, clock, httpClient, secretResolver, checkpoints, "", runtimeCfg, workstation, nil, submitter)
+				_, err := NewLinearPoller(nil, clock, httpClient, secretResolver, checkpoints, "", runtimeCfg, workstation, nil, nil, submitter)
 				return err
 			},
 		},
 		{
 			name: "submitter",
 			run: func() error {
-				_, err := NewLinearPoller(nil, clock, httpClient, secretResolver, checkpoints, "", runtimeCfg, workstation, worker, nil)
+				_, err := NewLinearPoller(nil, clock, httpClient, secretResolver, checkpoints, "", runtimeCfg, workstation, worker, nil, nil)
 				return err
 			},
 		},

--- a/pkg/services/automations/internal/services/hosted_sources/internal/service/service_test.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/service/service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	factorydefinitioncomposition "github.com/portpowered/infinite-you/internal/testutil/factorydefinitionfixtures"
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+	platformrandom "github.com/portpowered/infinite-you/pkg/platform/random"
 	hostedlinear "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources/internal/linear"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/work"
@@ -28,6 +29,7 @@ func TestNewConstructsHostedSourcesServiceWithDefaults(t *testing.T) {
 		&http.Client{Timeout: hostedlinear.DefaultRequestTimeout},
 		hostedlinear.NewSecretResolver(func(string) string { return "" }, nil),
 		"",
+		platformrandom.CryptoSource{},
 		checkpoints,
 	)
 	if service == nil {
@@ -171,6 +173,7 @@ func TestServiceValidateLinearPollerDelegates(t *testing.T) {
 		&http.Client{Timeout: hostedlinear.DefaultRequestTimeout},
 		hostedlinear.NewSecretResolver(func(string) string { return "" }, nil),
 		"https://linear.example/graphql",
+		platformrandom.CryptoSource{},
 		checkpoints,
 	)
 
@@ -195,6 +198,7 @@ func TestServiceStartLinearPollerRejectsMissingAuth(t *testing.T) {
 		&http.Client{Timeout: hostedlinear.DefaultRequestTimeout},
 		hostedlinear.NewSecretResolver(func(string) string { return "" }, nil),
 		"",
+		platformrandom.CryptoSource{},
 		checkpoints,
 	)
 

--- a/pkg/services/automations/internal/services/hosted_sources/internal/service/supervisor.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/service/supervisor.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
-	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	hostedsources "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources"
 	hostedlinear "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources/internal/linear"
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"go.uber.org/zap"
 )
 
@@ -76,10 +76,13 @@ func (p *LinearPoller) supervise(ctx context.Context) {
 			return
 		}
 
-		backoff := restartBackoff(attempt)
+		backoff, delaySource := retryDelay(attempt, runErr)
 		logger.Warn("hosted linear poller restarting",
 			zap.Int("attempt", attempt),
+			zap.Int("consecutive_failures", attempt),
 			zap.Duration("backoff", backoff),
+			zap.Duration("selected_delay", backoff),
+			zap.String("delay_source", delaySource),
 			zap.Error(runErr),
 		)
 
@@ -110,6 +113,7 @@ func (p *LinearPoller) run(ctx context.Context, logger *zap.Logger) error {
 	pollerClient := hostedlinear.Client{
 		Endpoint:   p.linearEndpoint,
 		HTTPClient: p.httpClient,
+		Clock:      p.clock,
 		Logger:     logger,
 	}
 	checkpointPath := hostedlinear.CheckpointPath(p.runtimeConfig, p.workstation, p.worker)
@@ -164,6 +168,17 @@ func restartBackoff(attempt int) time.Duration {
 		}
 	}
 	return backoff
+}
+
+func retryDelay(attempt int, runErr error) (time.Duration, string) {
+	backoff := restartBackoff(attempt)
+	var rateLimitErr *hostedlinear.RateLimitError
+	if errors.As(runErr, &rateLimitErr) {
+		if providerDelay, ok := rateLimitErr.RetryDelay(); ok {
+			return providerDelay, "provider"
+		}
+	}
+	return backoff, "computed"
 }
 
 func stopReason(err error) string {

--- a/pkg/services/automations/internal/services/hosted_sources/internal/service/supervisor.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/service/supervisor.go
@@ -6,17 +6,11 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"time"
 
 	hostedsources "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources"
 	hostedlinear "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources/internal/linear"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"go.uber.org/zap"
-)
-
-const (
-	restartBackoffMin = 25 * time.Millisecond
-	restartBackoffMax = 250 * time.Millisecond
 )
 
 // StartLinearPoller supervises a hosted Linear poller for one poller workstation.
@@ -33,6 +27,7 @@ func StartLinearPoller(
 	runtimeCfg interfaces.RuntimeConfigLookup,
 	workstation interfaces.FactoryWorkstationConfig,
 	workerDef *interfaces.FactoryWorkerConfig,
+	jitter retryJitter,
 	submitter Submitter,
 ) error {
 	if ctx == nil {
@@ -43,7 +38,7 @@ func StartLinearPoller(
 	}
 	poller, err := NewLinearPoller(
 		logger, clock, httpClient, secretResolver, checkpoints, linearEndpoint,
-		runtimeCfg, workstation, workerDef, submitter,
+		runtimeCfg, workstation, workerDef, jitter, submitter,
 	)
 	if err != nil {
 		return err
@@ -59,7 +54,7 @@ func StartLinearPoller(
 func (p *LinearPoller) supervise(ctx context.Context) {
 	logger := pollerLogger(p.logger, p.workstation, p.worker).With(zap.String("provider", interfaces.HostedWorkerProviderLinear))
 	backoffClock := p.clock
-	attempt := 0
+	consecutiveFailures := 0
 	logger.Info("hosted linear poller started")
 	defer func() {
 		logger.Info("hosted linear poller stopped", zap.String("reason", stopReason(ctx.Err())))
@@ -70,16 +65,19 @@ func (p *LinearPoller) supervise(ctx context.Context) {
 			return
 		}
 
-		attempt++
-		runErr := p.run(ctx, logger)
+		runErr, completedCycle := p.run(ctx, logger)
 		if ctx.Err() != nil {
 			return
 		}
 
-		backoff, delaySource := retryDelay(attempt, runErr)
+		if completedCycle {
+			consecutiveFailures = 0
+		}
+		consecutiveFailures++
+		backoff, delaySource := retryDelay(consecutiveFailures, runErr, p.jitter)
 		logger.Warn("hosted linear poller restarting",
-			zap.Int("attempt", attempt),
-			zap.Int("consecutive_failures", attempt),
+			zap.Int("attempt", consecutiveFailures),
+			zap.Int("consecutive_failures", consecutiveFailures),
 			zap.Duration("backoff", backoff),
 			zap.Duration("selected_delay", backoff),
 			zap.String("delay_source", delaySource),
@@ -94,10 +92,10 @@ func (p *LinearPoller) supervise(ctx context.Context) {
 	}
 }
 
-func (p *LinearPoller) run(ctx context.Context, logger *zap.Logger) error {
+func (p *LinearPoller) run(ctx context.Context, logger *zap.Logger) (error, bool) {
 	interval, err := hostedlinear.PollInterval(p.worker.Linear)
 	if err != nil {
-		return err
+		return err, false
 	}
 
 	apiKey, err := p.secretResolver(ctx, p.runtimeConfig, p.worker.Auth.SecretRef)
@@ -107,7 +105,7 @@ func (p *LinearPoller) run(ctx context.Context, logger *zap.Logger) error {
 			p.worker.Auth.SecretRef,
 			hostedlinear.ErrSecretResolution,
 			err,
-		)
+		), false
 	}
 
 	pollerClient := hostedlinear.Client{
@@ -117,15 +115,17 @@ func (p *LinearPoller) run(ctx context.Context, logger *zap.Logger) error {
 		Logger:     logger,
 	}
 	checkpointPath := hostedlinear.CheckpointPath(p.runtimeConfig, p.workstation, p.worker)
+	completedCycle := false
 
 	for {
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return ctx.Err(), completedCycle
 		}
 		result, err := hostedlinear.RunPollCycle(ctx, pollerClient, p.runtimeConfig, p.workstation, p.worker, hostedlinear.Submitter(p.submitter), p.checkpoints, checkpointPath, apiKey, logger)
 		if err != nil {
-			return redactResolvedSecret(err, apiKey)
+			return redactResolvedSecret(err, apiKey), completedCycle
 		}
+		completedCycle = true
 		if result.FoundNewer {
 			logger.Info("hosted linear poller cycle completed",
 				zap.Int("submissions", len(result.Submissions)),
@@ -136,7 +136,7 @@ func (p *LinearPoller) run(ctx context.Context, logger *zap.Logger) error {
 
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return ctx.Err(), completedCycle
 		case <-p.clock.After(interval):
 		}
 	}
@@ -154,31 +154,6 @@ func pollerLogger(logger *zap.Logger, workstation interfaces.FactoryWorkstationC
 		zap.String("workstation", workstation.Name),
 		zap.String("worker", workerDef.Name),
 	)
-}
-
-func restartBackoff(attempt int) time.Duration {
-	if attempt <= 1 {
-		return restartBackoffMin
-	}
-	backoff := restartBackoffMin
-	for i := 1; i < attempt && backoff < restartBackoffMax; i++ {
-		backoff *= 2
-		if backoff >= restartBackoffMax {
-			return restartBackoffMax
-		}
-	}
-	return backoff
-}
-
-func retryDelay(attempt int, runErr error) (time.Duration, string) {
-	backoff := restartBackoff(attempt)
-	var rateLimitErr *hostedlinear.RateLimitError
-	if errors.As(runErr, &rateLimitErr) {
-		if providerDelay, ok := rateLimitErr.RetryDelay(); ok {
-			return providerDelay, "provider"
-		}
-	}
-	return backoff, "computed"
 }
 
 func stopReason(err error) string {

--- a/pkg/services/automations/internal/services/hosted_sources/internal/service/supervisor_test.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/service/supervisor_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/jonboulle/clockwork"
 	factorydefinitioncomposition "github.com/portpowered/infinite-you/internal/testutil/factorydefinitionfixtures"
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
-	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	hostedlinear "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources/internal/linear"
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -665,6 +665,116 @@ func TestStartLinearPoller_RestartsOnProviderHTTPFailure(t *testing.T) {
 	waitForFakeClockWaiters(t, fakeClock, 1)
 	fakeClock.Advance(restartBackoffMin)
 	waitForSubmitCalls(t, &submitCalls, 1, time.Second)
+
+	cancel()
+	sidecars.Wait()
+}
+
+func TestStartLinearPoller_UsesProviderRetryAfter(t *testing.T) {
+	fakeClock := clockwork.NewFakeClock()
+	var requestCount atomic.Int32
+	logCore, observedLogs := observer.New(zap.InfoLevel)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		call := requestCount.Add(1)
+		if call == 1 {
+			w.Header().Set("Retry-After", "10")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"errors":[{"message":"private provider response"}]}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockLinearIssuesGraphQLResponse()))
+	}))
+	defer server.Close()
+
+	factoryDir := t.TempDir()
+	writeHostedLinearSecretForTest(t, factoryDir)
+	pollerCfg, runtimeCfg, poller, worker := hostedLinearPollerFixtureForTest(t, factoryDir, server, nil)
+	pollerCfg.Logger = zap.New(logCore)
+	pollerCfg.Clock = fakeClock
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var sidecars sync.WaitGroup
+	if err := startLinearPollerWithConfig(ctx, &sidecars, pollerCfg, runtimeCfg, poller, worker, func(context.Context, work.WorkRequest) error {
+		return nil
+	}); err != nil {
+		t.Fatalf("StartLinearPoller() error = %v", err)
+	}
+
+	waitForObservedLogMessage(t, observedLogs, "hosted linear poller restarting", time.Second)
+	restartEntry := observedLogs.FilterMessage("hosted linear poller restarting").All()[0]
+	if got := durationField(restartEntry.ContextMap()["selected_delay"]); got != 10*time.Second {
+		t.Fatalf("selected retry delay = %s, want 10s", got)
+	}
+	if got := fieldString(restartEntry.ContextMap()["delay_source"]); got != "provider" {
+		t.Fatalf("retry delay source = %q, want provider", got)
+	}
+	if got := fieldString(restartEntry.ContextMap()["error"]); strings.Contains(got, "private provider response") {
+		t.Fatalf("restart error = %q, want sanitized provider failure", got)
+	}
+
+	waitForFakeClockWaiters(t, fakeClock, 1)
+	fakeClock.Advance(9 * time.Second)
+	if got := requestCount.Load(); got != 1 {
+		t.Fatalf("provider requests before provider delay elapsed = %d, want 1", got)
+	}
+	fakeClock.Advance(time.Second)
+	waitForFakeClockWaiters(t, fakeClock, 1)
+	if got := requestCount.Load(); got != 2 {
+		t.Fatalf("provider requests after provider delay elapsed = %d, want 2", got)
+	}
+
+	cancel()
+	sidecars.Wait()
+}
+
+func TestStartLinearPoller_InvalidRetryAfterFallsBackToComputedDelay(t *testing.T) {
+	fakeClock := clockwork.NewFakeClock()
+	var requestCount atomic.Int32
+	logCore, observedLogs := observer.New(zap.InfoLevel)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		call := requestCount.Add(1)
+		if call == 1 {
+			w.Header().Set("Retry-After", "not-a-delay")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockLinearIssuesGraphQLResponse()))
+	}))
+	defer server.Close()
+
+	factoryDir := t.TempDir()
+	writeHostedLinearSecretForTest(t, factoryDir)
+	pollerCfg, runtimeCfg, poller, worker := hostedLinearPollerFixtureForTest(t, factoryDir, server, nil)
+	pollerCfg.Logger = zap.New(logCore)
+	pollerCfg.Clock = fakeClock
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var sidecars sync.WaitGroup
+	if err := startLinearPollerWithConfig(ctx, &sidecars, pollerCfg, runtimeCfg, poller, worker, func(context.Context, work.WorkRequest) error {
+		return nil
+	}); err != nil {
+		t.Fatalf("StartLinearPoller() error = %v", err)
+	}
+
+	waitForObservedLogMessage(t, observedLogs, "hosted linear poller restarting", time.Second)
+	restartEntry := observedLogs.FilterMessage("hosted linear poller restarting").All()[0]
+	if got := durationField(restartEntry.ContextMap()["selected_delay"]); got != restartBackoffMin {
+		t.Fatalf("selected retry delay = %s, want %s", got, restartBackoffMin)
+	}
+	if got := fieldString(restartEntry.ContextMap()["delay_source"]); got != "computed" {
+		t.Fatalf("retry delay source = %q, want computed", got)
+	}
+
+	waitForFakeClockWaiters(t, fakeClock, 1)
+	fakeClock.Advance(restartBackoffMin)
+	waitForFakeClockWaiters(t, fakeClock, 1)
+	if got := requestCount.Load(); got != 2 {
+		t.Fatalf("provider requests after computed delay elapsed = %d, want 2", got)
+	}
 
 	cancel()
 	sidecars.Wait()

--- a/pkg/services/automations/internal/services/hosted_sources/internal/service/supervisor_test.go
+++ b/pkg/services/automations/internal/services/hosted_sources/internal/service/supervisor_test.go
@@ -31,6 +31,7 @@ type Config struct {
 	SecretResolver hostedlinear.SecretResolver
 	Checkpoints    hostedlinear.CheckpointStore
 	LinearEndpoint string
+	Jitter         retryJitter
 }
 
 func startLinearPollerWithConfig(
@@ -61,10 +62,13 @@ func startLinearPollerWithConfig(
 			return err
 		}
 	}
+	if cfg.Jitter == nil {
+		cfg.Jitter = func(base time.Duration) time.Duration { return base }
+	}
 	return StartLinearPoller(
 		ctx, sidecars, cfg.Logger, cfg.Clock, cfg.HTTPClient,
 		cfg.SecretResolver, cfg.Checkpoints, cfg.LinearEndpoint,
-		runtimeConfig, workstation, worker, submitter,
+		runtimeConfig, workstation, worker, cfg.Jitter, submitter,
 	)
 }
 
@@ -317,7 +321,7 @@ func TestNewLinearPoller_RequiresExternalEffects(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := NewLinearPoller(
 				zap.NewNop(), tc.clock, tc.client, tc.resolver, tc.checkpoints, "", runtimeCfg,
-				interfaces.FactoryWorkstationConfig{}, worker,
+				interfaces.FactoryWorkstationConfig{}, worker, nil,
 				func(context.Context, work.WorkRequest) error { return nil },
 			)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
@@ -492,9 +496,12 @@ func TestRestartBackoff_ProgressesWithinBounds(t *testing.T) {
 		{attempt: 2, want: 2 * restartBackoffMin},
 		{attempt: 3, want: 4 * restartBackoffMin},
 		{attempt: 4, want: 8 * restartBackoffMin},
-		{attempt: 5, want: restartBackoffMax},
-		{attempt: 6, want: restartBackoffMax},
-		{attempt: 10, want: restartBackoffMax},
+		{attempt: 5, want: 16 * restartBackoffMin},
+		{attempt: 6, want: 32 * restartBackoffMin},
+		{attempt: 10, want: 512 * restartBackoffMin},
+		{attempt: 12, want: 2048 * restartBackoffMin},
+		{attempt: 13, want: restartBackoffMax},
+		{attempt: 14, want: restartBackoffMax},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -594,7 +601,8 @@ func TestStartLinearPoller_BackoffProgressesAfterRepeatedFailures(t *testing.T) 
 		2 * restartBackoffMin,
 		4 * restartBackoffMin,
 		8 * restartBackoffMin,
-		restartBackoffMax,
+		16 * restartBackoffMin,
+		32 * restartBackoffMin,
 	}
 	for attempt, wantBackoff := range wantBackoffs {
 		waitForObservedLogCount(t, observedLogs, "hosted linear poller restarting", attempt+1, time.Second)

--- a/pkg/services/automations/internal/services/hosted_sources/wire/wire.go
+++ b/pkg/services/automations/internal/services/hosted_sources/wire/wire.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"sync"
 
+	platformrandom "github.com/portpowered/infinite-you/pkg/platform/random"
 	hostedsources "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources"
 	hostedservice "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources/internal/service"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
@@ -50,6 +51,7 @@ func NewHostedPollers(
 		httpClient,
 		secretResolver,
 		linearEndpoint,
+		platformrandom.CryptoSource{},
 		checkpointStores...,
 	)}
 }


### PR DESCRIPTION
{
  "project": "Resilient Hosted-Source Poller Retry Backoff",
  "branchName": "automations-hosted-poller-retry-backoff",
  "description": "Make hosted Linear source retries production-safe by growing exponential backoff from the existing 25-millisecond floor to a 60-second ceiling, applying bounded jitter, honoring valid provider Retry-After guidance, resetting failure state after recovery, and proving a bounded persistent-failure request rate with injected time.",
  "context": {
    "customerAsk": "Prevent the hosted-source supervisor from hammering a failing or rate-limiting Linear provider. Add realistic exponential backoff, jitter, Retry-After handling, and recovery reset behavior; prove the behavior with an injected clock; bound the request rate during a persistent 60-second failure; and state the measured before/after rate in the pull request body.",
    "problem": "The hosted-source supervisor restarts failed Linear polls with a 25-250 millisecond schedule and no jitter, while the Linear response boundary discards Retry-After guidance. Prolonged outages can therefore create sustained avoidable traffic, concurrent sources can retry in lockstep, provider-directed delays are ignored, and accumulated failure state has no explicit successful-cycle reset transition.",
    "solution": "Keep retry policy and explicit per-poller state in the Automations-owned hosted-source supervisor; grow local delay exponentially to 60 seconds with bounded controllable jitter; carry sanitized structured rate-limit guidance from the Linear adapter; give valid provider delay precedence; reset consecutive failures after a successful cycle; preserve cancellation; and verify all behavior with fake HTTP responses, injected time, and controlled jitter rather than wall-clock sleeps."
  },
  "acceptanceCriteria": [
    "Consecutive hosted Linear poll failures use exponential retry delay from the existing 25-millisecond floor toward a 60-second ceiling, with bounded jitter that desynchronizes equivalent failures and never produces a negative or unbounded delay.",
    "A valid Retry-After on an HTTP 429 or equivalent Linear rate-limit response overrides the locally computed retry delay; missing, malformed, or unusable metadata falls back safely to normal jittered backoff without exposing credentials or private response content.",
    "One successful poll cycle resets consecutive-failure state, so the next later failure uses the initial backoff range rather than the previously accumulated delay, while context cancellation still stops pending retry promptly.",
    "Injected-clock and controlled-jitter tests show delay progression beyond 250 milliseconds toward the ceiling, non-lockstep jitter, provider-delay precedence, recovery reset, and no more than 20 provider requests during 60 seconds of virtual persistent failure; the PR body reports the measured before/after request counts and average rates for the same 60-second scenario.",
    "Changes remain owned by pkg/services/automations/internal/services/hosted_sources/; the Linear client changes only as needed to carry rate-limit metadata, no sibling automation family, public API contract, generated artifact, or unrelated cleanup is changed, and the live Factory daemon on port 7437 is not restarted, killed, or reconfigured.",
    "Final quality gate: Typecheck passes; Tests pass for the focused hosted-source package and required repository verification; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. Before reaching its finish line, implementation rebases the final head onto current origin/main and opens the PR ready, never as a draft."
  ],
  "userStories": [
    {
      "id": "automations-hosted-poller-retry-backoff-001",
      "title": "Preserve Linear rate-limit retry guidance",
      "description": "As an operator, I want the hosted Linear integration to preserve provider retry guidance so rate-limited polling waits for the provider-directed duration instead of worsening the limit.",
      "acceptanceCriteria": [
        "A Linear HTTP 429 response with a valid Retry-After produces a typed or otherwise reliably classifiable failure that carries the sanitized retry duration to the hosted-source supervisor.",
        "The supervisor selects the provider-directed duration instead of its locally computed exponential delay when valid retry guidance is present.",
        "Supported Retry-After forms are interpreted consistently with HTTP semantics; missing, expired, malformed, negative, or otherwise unusable values fall back to normal retry policy without panicking.",
        "GraphQL-equivalent rate-limit failures retain their existing safe error behavior and use provider guidance when the response supplies usable metadata.",
        "Structured retry logging distinguishes provider-directed and computed delay decisions and records the selected duration without logging API keys, authorization values, or private response bodies.",
        "Deterministic tests use injected time and a fake Linear HTTP server to prove provider-delay precedence and fallback behavior without wall-clock sleeps or intentionally triggering a live provider limit.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented sanitized typed Linear rate-limit failures, Retry-After seconds/date parsing with injected time, GraphQL rate-limit metadata, supervisor provider-delay precedence, safe delay logging, and focused deterministic tests."
    },
    {
      "id": "automations-hosted-poller-retry-backoff-002",
      "title": "Bound and reset hosted-source retry traffic",
      "description": "As an operator, I want failed hosted sources to retry with production-safe, desynchronized delays and recover quickly after success so an upstream outage does not become a retry storm.",
      "acceptanceCriteria": [
        "Consecutive failures grow exponentially from a 25-millisecond base beyond the old 250-millisecond ceiling and approach a 60-second maximum before bounded jitter is applied.",
        "Jitter is supplied through a controllable side-effect boundary, remains within a documented safe range, and causes equivalent concurrently failing sources or successive scheduled retries to receive non-lockstep delays without exceeding the maximum or dropping below a safe positive delay.",
        "After at least one accumulated failure, a successful poll cycle resets consecutive-failure state; a later failure schedules from the initial-delay range.",
        "Cancellation while awaiting any computed or provider-directed retry exits promptly and causes no additional provider request.",
        "An injected-clock persistent-failure test advances 60 seconds of virtual time with no wall-clock sleep, observes no more than 20 provider requests, and captures the comparable pre-change and post-change request counts and average rates for the PR body.",
        "Retry logs expose consecutive-failure count, selected delay, delay source, and safe hosted-source identity so operators can diagnose progression and recovery without sensitive data.",
        "Focused tests cover exponential progression, ceiling behavior, deterministic jitter bounds and desynchronization, recovery reset, persistent-failure request rate, and cancellation.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented 60-second exponential backoff, bounded +/-20% jitter through an injected retry boundary, success reset, cancellation coverage for computed and provider delays, structured retry logging, and fake-clock persistent-failure coverage. Measured over the same virtual 60-second failure window: pre-change 243 requests (4.05 requests/s), post-change 12 requests (0.20 requests/s). Focused hosted-source and Automations tests, race, affected-family vet, backend-size, pkg-maint, pkg-file-count, and pkg-structure pass. Local verify-fast is blocked by missing Bun type definitions and the unconstrained full Go suite exceeded its local timeout; CI remains the authoritative repository-wide gate."
    }
  ]
}
