### PR TITLE
perf-u4-unit-leg-drop-redundant-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,9 +221,6 @@ jobs:
       - name: Compile functionallong test packages
         if: matrix.suite == 'unit'
         run: make test-functional-long-compile
-      - name: Build backend
-        if: matrix.suite == 'unit'
-        run: make build
       - name: Select functional runner parallelism
         if: matrix.suite == 'functional'
         id: functional-parallelism


### PR DESCRIPTION
{
  "project": "Settle and Remove a Redundant Unit-Coverage Build",
  "branchName": "perf-u4-unit-leg-drop-redundant-build",
  "description": "Determine whether the Backend Unit Coverage CI job consumes the you executable produced by make build, then remove or narrowly condition that roughly 62-second pre-test build only if it is proven unnecessary while preserving the functionallong compile guard, unit suite, and coverage package set. A proven load-bearing dependency is a successful negative result and must not be forced into a workflow change.",
  "context": {
    "customerAsk": "Own only the unit leg's pre-test build behavior: inspect the ./pkg/... unit lane for direct or indirect use of bin/you, you.exe, BIN_DIR, BINARY_NAME, process execution, or other make build artifacts; report the result either way; remove or condition make build only when no consumer exists; and keep the functionallong compile guard unless it is positively proven redundant.",
    "problem": "Backend Unit Coverage currently spends about 5 seconds compiling functionallong-tagged packages and about 62 seconds building the backend before tests begin. The build costs roughly 11-17% of a typical 411-second job, but its necessity is inferred rather than established, so either blindly removing it or retaining it without investigation risks correctness or recurring waste.",
    "solution": "Follow the actual make test-unit-coverage package selection, classify plausible executable and artifact dependencies, and make the smallest evidence-supported decision. If the built binary is unused, remove or narrowly gate the unit-only build and prove the tagged compile guard, full unit suite, and unchanged coverage evaluation. If it is load-bearing, retain it and document the exact consumer. Compare at least three before and three after/current CI observations without cherry-picking, with CI evidence only in a PR comment."
  },
  "acceptanceCriteria": [
    "The PR reports a reproducible classification of all plausible ./pkg/... unit-test dependencies on BIN_DIR, BINARY_NAME, bin/you, you.exe, process execution, and other artifacts produced by make build, and states plainly whether the build is unused or load-bearing.",
    "If no unit-lane consumer exists, Backend Unit Coverage no longer performs the unconsumed make build work or performs it only under a demonstrated consuming condition; if a consumer exists, the build remains and the documented evidence explains why no forced optimization was made.",
    "The functionallong compile guard remains active; if make build is removed or narrowed, a temporary deliberate functionallong compile break makes the guard fail, the break is reverted, and no deliberate-break commit remains in final history.",
    "The full unit suite passes and the unit coverage gate evaluates the same package set and floors as before; the unit and functional coverage manifests are unchanged.",
    "A PR comment reports all sampled wall-clock values for at least three before and three after/current Backend Unit Coverage runs, identifies commit/run URLs and workflow shape, summarizes median and range without treating one lucky run as proof, and places no CI-run evidence in a commit.",
    "Typecheck and relevant tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "perf-u4-unit-leg-drop-redundant-build-001",
      "title": "Establish whether the unit lane consumes the built executable",
      "description": "As a CI maintainer, I want a reproducible dependency finding for the unit-coverage lane so that the workflow decision is based on actual test behavior rather than inference.",
      "acceptanceCriteria": [
        "The investigation covers the tests selected beneath ./pkg/..., including exec.Command and exec.CommandContext call sites and references to BIN_DIR, BINARY_NAME, bin/you, you.exe, or other outputs created by make build.",
        "Each plausible subprocess call is classified as using the current test executable, a system or tool executable, a test-created executable, or the repository-built you binary, and any indirect setup dependency is included.",
        "The PR states one unambiguous conclusion: no selected unit test needs the build artifact, or the exact consumer and required artifact make the build load-bearing.",
        "The evidence is reported without adding a source-inventory or command-registration meta-test.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "2026-08-21 investigation: make test-unit-coverage runs go run ./cmd/gocoveragecheck with ./pkg/... filtered by testlanes.IsUnitPackage. The Linux-selected unit surface contains 56 subprocess/executable references, all classified as the current Go test executable, host tools (git/sleep/browser), injected provider/model/required-tool commands, or test-created scripts. No selected code references BIN_DIR, BINARY_NAME, bin/you, you.exe, or another make build output. Focused Go verification passed. Conclusion: the unit-lane make build artifact is unused; story 002 can remove only that pre-test step while retaining the functionallong compile guard."
    },
    {
      "id": "perf-u4-unit-leg-drop-redundant-build-002",
      "title": "Apply the evidence-supported unit pre-test behavior",
      "description": "As a contributor waiting on CI, I want the unit-coverage job to perform only required pre-test work so that avoidable compilation time is removed without weakening regression protection.",
      "acceptanceCriteria": [
        "When story 001 finds no consumer, the unit leg omits make build or gates it only to a positively identified consuming condition; when story 001 finds a consumer, the build remains unchanged and the load-bearing finding completes this story without a forced workflow edit.",
        "make test-functional-long-compile remains before the unit coverage run unless separate positive evidence proves that guard redundant; this lane does not remove it merely because it is another pre-test step.",
        "If make build is removed or narrowed, a deliberate temporary functionallong compile error causes the retained guard to fail, the error is reverted, and the clean guard succeeds.",
        "The complete unit coverage command passes and reports the same evaluated package set and package-floor behavior as the baseline.",
        "The change does not modify gocoveragecheck orchestration, functional discovery, test job counts, Vitest behavior, lint parallelism, or either coverage manifest.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "2026-08-21 implementation: removed only the unit-matrix Build backend step from .github/workflows/ci.yml; retained make test-functional-long-compile immediately before make test-unit-coverage. A temporary undefined functionallong symbol made the guard fail (exit 2), the probe was removed, and the clean guard passed. make test-ci-workflows passed all 80 checks. The complete local unit-coverage command executed the same package set and reached 80.9% overall, but its unchanged baseline gate failed on pkg/platform/filesystem (71.74% vs 75.00%); the only implementation diff is the workflow file, so this is a base/environment blocker to report for CI review rather than a change-caused failure."
    },
    {
      "id": "perf-u4-unit-leg-drop-redundant-build-003",
      "title": "Validate performance and deliver through review",
      "description": "As a maintainer, I want variance-aware CI evidence and a completed review loop so that the optimization or negative result is trustworthy and actually delivered.",
      "acceptanceCriteria": [
        "A PR comment lists at least three comparable before and three after/current Backend Unit Coverage wall-clock observations, with run links, commit identity, workflow shape, median, range, and any outliers retained.",
        "The report distinguishes measured results from inference and does not claim success from a single run; if the build remains load-bearing, it reports that negative result without manufacturing a timing improvement.",
        "CI-run evidence is posted in a PR comment and is never committed to the branch.",
        "The branch is rebased onto current origin/main before the final push, preserving already-merged perf-u3 behavior and resolving any shared-workflow conflict without re-litigating gocoveragecheck orchestration.",
        "The PR is opened ready for review, never as a draft, early enough that pushed work survives the visit cap; environment-blocked checks are listed under Not verified in this environment rather than silently claimed or used to withhold delivery.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": false,
      "notes": "2026-08-21 delivery handoff: PR #2142 remains open, ready for review, clean, and green on final head eb4ffc116, rebased onto origin/main 9263e2ad29f, with no authoritative review threads or blocking feedback. Backend Unit Coverage job 96925194871 in run 32531688552 completed successfully in 466s and evaluated the unchanged 535 measured / 483 gated package shape with 80.9% coverage and the same five floor diagnostics. The evidence comment records this one terminal post-removal observation alongside the three pre-change samples (421s, 423s, 601s; median 423s; range 421-601s, including the outlier). Two additional comparable post-removal observations are still absent, so the after median/range remains provisional and story 003 stays false; the implementation-stage delivery criterion is satisfied and review-stage measurement follow-up remains outstanding."
    }
  ]
}
