### PR TITLE
Refresh stale materialized packaged Factories safely

### DIFF
--- a/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/diagnostics_test.go
+++ b/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/diagnostics_test.go
@@ -122,6 +122,31 @@ func TestInstallPackagedFactory_LogsStructuredScopeAndSuccess(t *testing.T) {
 	}
 }
 
+func TestManagedInstallationFailureUsesErrorDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	logger := &packagedInstallationLogger{}
+	service := New(
+		packagedInstallationTestPersistence(),
+		platformfilesystem.Local{},
+		os.Mkdir,
+		logger,
+	)
+	service.logInstallationOutcome(
+		"managed-failure-scope",
+		factorydefinitions.PackagedFactoryInstallResult{
+			Name:    "@you/goal",
+			Outcome: factorydefinitions.PackagedFactoryInstallFailed,
+		},
+		&stagingLease{path: "managed-lease", owner: ownerRecord{PID: 42}},
+	)
+
+	entries := logger.snapshot()
+	if len(entries) == 0 || entries[len(entries)-1].level != "error" {
+		t.Fatalf("managed failure diagnostics = %#v, want final error entry", entries)
+	}
+}
+
 func TestInstallPackagedFactory_ReclaimsOnlyRevalidatedOrphan(t *testing.T) {
 	root := t.TempDir()
 	name := "@test/orphan-recovery"

--- a/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/managed_reconciliation.go
+++ b/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/managed_reconciliation.go
@@ -1,0 +1,564 @@
+package packagedinstallation
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+)
+
+const (
+	managedStampVersion  = 1
+	managedStampName     = ".you-packaged-installation.json"
+	managedStampTemp     = managedStampName + ".tmp"
+	managedBackupRoot    = ".you-packaged-backups"
+	managedScratchRoot   = ".you-packaged-managed"
+	managedPathAttempts  = 100
+	managedEnsureRetries = 7
+	managedRetryDelay    = 10 * time.Millisecond
+)
+
+type managedInstallationStamp struct {
+	Version            int    `json:"version"`
+	FactoryName        string `json:"factoryName"`
+	PublishedContentID string `json:"publishedContentId"`
+	InstalledContentID string `json:"installedContentId"`
+}
+
+func (service *Service) ensureManagedPackagedFactory(
+	ctx context.Context,
+	rootDir string,
+	backendScopeID string,
+	definition factorydefinitions.PackagedDefinition,
+) (factorydefinitions.PackagedFactoryInstallResult, error) {
+	params := factorydefinitions.PackagedFactoryInstallParams{
+		NamedFactoriesRoot: rootDir,
+		BackendScopeID:     backendScopeID,
+		Definition:         definition,
+		Format:             factorydefinitions.PackagedFactoryFormatJSON,
+		ManagedRefresh:     true,
+	}
+	for attempt := 0; ; attempt++ {
+		result, err := service.InstallPackagedFactory(ctx, params)
+		if err == nil || !errors.Is(err, factorydefinitions.ErrFactoryInstallationContention) || attempt >= managedEnsureRetries {
+			return result, err
+		}
+		delay := managedRetryDelay << attempt
+		if err := waitForManagedRetry(ctx, delay); err != nil {
+			return result, err
+		}
+	}
+}
+
+func waitForManagedRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (service *Service) logInstallationOutcome(
+	backendScopeID string,
+	result factorydefinitions.PackagedFactoryInstallResult,
+	lease *stagingLease,
+) {
+	outcome := string(result.Outcome)
+	if outcome == "" {
+		outcome = "success"
+	}
+	logOutcome := outcome
+	if result.Outcome == factorydefinitions.PackagedFactoryInstallCreated ||
+		result.Outcome == factorydefinitions.PackagedFactoryInstallReplaced ||
+		result.Outcome == factorydefinitions.PackagedFactoryInstallSkipped {
+		logOutcome = "success"
+	}
+	fields := []any{
+		"backend_scope_id", normalizedBackendScopeID(backendScopeID),
+		"factory_name", result.Name,
+		"resource", lease.path,
+		"outcome", logOutcome,
+		"install_outcome", outcome,
+		"owner_liveness", ownerLivenessActive,
+		"owner_pid", lease.owner.PID,
+		"owner_identity", "unverified",
+	}
+	if result.BackupDir != "" {
+		fields = append(fields, "backup_dir", result.BackupDir)
+	}
+	switch result.Outcome {
+	case factorydefinitions.PackagedFactoryInstallCustomerModified:
+		service.logger.Warn("factory_definitions.packaged_installation", fields...)
+	case factorydefinitions.PackagedFactoryInstallFailed:
+		service.logger.Error("factory_definitions.packaged_installation", fields...)
+	default:
+		service.logger.Info("factory_definitions.packaged_installation", fields...)
+	}
+}
+
+func (service *Service) createManagedPackagedFactory(
+	ctx context.Context,
+	rootDir string,
+	name string,
+	payload []byte,
+	rootFileName string,
+	result factorydefinitions.PackagedFactoryInstallResult,
+) (factorydefinitions.PackagedFactoryInstallResult, error) {
+	prepared, err := service.prepareManagedLayout(ctx, name, payload, rootFileName)
+	if err != nil {
+		return managedInstallFailure(result, name, rootDir, err)
+	}
+	factoryDir, err := service.persistence.CreateNamedFactory(rootDir, name, prepared)
+	if err != nil {
+		return managedInstallFailure(result, name, rootDir, err)
+	}
+	result.FactoryDir = factoryDir
+	installedID, err := service.contentIdentity(factoryDir)
+	if err != nil {
+		return managedInstallFailure(result, name, rootDir, err)
+	}
+	if err := service.writeManagedStamp(ctx, factoryDir, name, installedID, installedID); err != nil {
+		return managedInstallFailure(result, name, rootDir, err)
+	}
+	result.Outcome = factorydefinitions.PackagedFactoryInstallCreated
+	result.PublishedContentID = installedID
+	result.InstalledContentID = installedID
+	return result, nil
+}
+
+func (service *Service) reconcileManagedPackagedFactory(
+	ctx context.Context,
+	rootDir string,
+	name string,
+	normalizedFormat factorydefinitions.PackagedFactoryFormat,
+	targetDir string,
+	payload []byte,
+	rootFileName string,
+	result factorydefinitions.PackagedFactoryInstallResult,
+) (factorydefinitions.PackagedFactoryInstallResult, error) {
+	if err := service.persistence.ValidateFactoryLayout(targetDir); err != nil {
+		return managedInstallFailure(result, name, rootDir, fmt.Errorf("existing target %s is invalid: %w", targetDir, err))
+	}
+	existingFormat, err := authoredRootFormat(targetDir, service.fileSystem)
+	if err != nil {
+		return managedInstallFailure(result, name, rootDir, err)
+	}
+	if existingFormat != normalizedFormat {
+		return managedInstallFailure(
+			result,
+			name,
+			rootDir,
+			fmt.Errorf("%w: factory %q already exists", factorydefinitions.ErrNamedFactoryAlreadyExists, name),
+		)
+	}
+	prepared, err := service.prepareManagedLayout(ctx, name, payload, rootFileName)
+	if err != nil {
+		return managedInstallFailure(result, name, rootDir, err)
+	}
+	publishedID, err := service.expectedManagedContentID(ctx, rootDir, name, prepared)
+	if err != nil {
+		return managedInstallFailure(result, name, rootDir, err)
+	}
+	installedID, err := service.contentIdentity(targetDir)
+	if err != nil {
+		return managedInstallFailure(result, name, rootDir, err)
+	}
+	stamp, stamped, err := service.readManagedStamp(targetDir, name)
+	if err != nil {
+		return managedInstallFailure(result, name, rootDir, err)
+	}
+	result.PublishedContentID = publishedID
+	result.InstalledContentID = installedID
+	if installedID == publishedID {
+		if !stamped || stamp.PublishedContentID != publishedID || stamp.InstalledContentID != installedID {
+			if err := service.writeManagedStamp(ctx, targetDir, name, publishedID, installedID); err != nil {
+				return managedInstallFailure(result, name, rootDir, err)
+			}
+		}
+		result.Outcome = factorydefinitions.PackagedFactoryInstallCurrent
+		return result, nil
+	}
+	outcome := factorydefinitions.PackagedFactoryInstallRefreshed
+	if stamped && stamp.InstalledContentID != installedID {
+		outcome = factorydefinitions.PackagedFactoryInstallCustomerModified
+	}
+	return service.refreshManagedPackagedFactory(
+		ctx,
+		rootDir,
+		name,
+		targetDir,
+		prepared,
+		publishedID,
+		outcome,
+		result,
+	)
+}
+
+func (service *Service) refreshManagedPackagedFactory(
+	ctx context.Context,
+	rootDir string,
+	name string,
+	targetDir string,
+	prepared *factorydefinitions.PreparedFactoryLayoutPayload,
+	publishedID string,
+	outcome factorydefinitions.PackagedFactoryInstallOutcome,
+	result factorydefinitions.PackagedFactoryInstallResult,
+) (factorydefinitions.PackagedFactoryInstallResult, error) {
+	backupDir, err := service.snapshotManagedFactory(ctx, rootDir, name, targetDir)
+	if err != nil {
+		return managedInstallFailure(result, name, rootDir, err)
+	}
+	result.BackupDir = backupDir
+	if err := ctx.Err(); err != nil {
+		return service.cleanupManagedReplacementFailure(result, name, rootDir, backupDir, err)
+	}
+	replacement, err := service.persistence.ReplaceFactoryLayout(targetDir, prepared)
+	if err != nil {
+		return service.cleanupManagedReplacementFailure(result, name, rootDir, backupDir, err)
+	}
+	if replacement == nil {
+		return service.cleanupManagedReplacementFailure(
+			result,
+			name,
+			rootDir,
+			backupDir,
+			fmt.Errorf("Factory Definitions replacement result is required"),
+		)
+	}
+	installedID, err := service.contentIdentity(targetDir)
+	if err != nil {
+		service.discardReplacementBackup(replacement)
+		return managedInstallFailure(result, name, rootDir, err)
+	}
+	if err := service.writeManagedStamp(ctx, targetDir, name, publishedID, installedID); err != nil {
+		service.discardReplacementBackup(replacement)
+		return managedInstallFailure(result, name, rootDir, err)
+	}
+	service.discardReplacementBackup(replacement)
+	result.Outcome = outcome
+	result.PublishedContentID = publishedID
+	result.InstalledContentID = installedID
+	return result, nil
+}
+
+func (service *Service) prepareManagedLayout(
+	ctx context.Context,
+	name string,
+	payload []byte,
+	rootFileName string,
+) (*factorydefinitions.PreparedFactoryLayoutPayload, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	prepared, err := service.persistence.PreparePackagedFactoryLayout(ctx, name, payload)
+	if err != nil {
+		return nil, err
+	}
+	if prepared == nil {
+		return nil, fmt.Errorf("prepared Factory layout is required")
+	}
+	prepared.RootFileName = rootFileName
+	return prepared, nil
+}
+
+func (service *Service) expectedManagedContentID(
+	ctx context.Context,
+	rootDir string,
+	name string,
+	prepared *factorydefinitions.PreparedFactoryLayoutPayload,
+) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if err := service.fileSystem.MkdirAll(rootDir, 0o755); err != nil {
+		return "", fmt.Errorf("create packaged Factory staging parent %s: %w", rootDir, err)
+	}
+	scratchDir, err := service.createManagedDirectory(rootDir, managedScratchRoot, name, 0o755)
+	if err != nil {
+		return "", fmt.Errorf("create packaged Factory comparison staging: %w", err)
+	}
+	factoryDir, createErr := service.persistence.CreateNamedFactory(scratchDir, name, prepared)
+	identity, identityErr := "", error(nil)
+	if createErr == nil {
+		identity, identityErr = service.contentIdentity(factoryDir)
+	}
+	cleanupErr := service.fileSystem.RemoveAll(scratchDir)
+	if createErr != nil {
+		return "", fmt.Errorf("materialize packaged Factory comparison layout: %w", createErr)
+	}
+	if identityErr != nil {
+		return "", identityErr
+	}
+	if cleanupErr != nil {
+		return "", fmt.Errorf("remove packaged Factory comparison staging %s: %w", scratchDir, cleanupErr)
+	}
+	return identity, nil
+}
+
+func (service *Service) readManagedStamp(
+	targetDir string,
+	name string,
+) (managedInstallationStamp, bool, error) {
+	data, err := service.fileSystem.ReadFile(filepath.Join(targetDir, managedStampName))
+	if errors.Is(err, fs.ErrNotExist) {
+		return managedInstallationStamp{}, false, nil
+	}
+	if err != nil {
+		return managedInstallationStamp{}, false, fmt.Errorf("read packaged Factory management evidence %s: %w", targetDir, err)
+	}
+	var stamp managedInstallationStamp
+	if err := json.Unmarshal(data, &stamp); err != nil {
+		return managedInstallationStamp{}, false, nil
+	}
+	if stamp.Version != managedStampVersion ||
+		stamp.FactoryName != name ||
+		strings.TrimSpace(stamp.PublishedContentID) == "" ||
+		strings.TrimSpace(stamp.InstalledContentID) == "" {
+		return managedInstallationStamp{}, false, nil
+	}
+	return stamp, true, nil
+}
+
+func (service *Service) writeManagedStamp(
+	ctx context.Context,
+	targetDir string,
+	name string,
+	publishedID string,
+	installedID string,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	data, err := json.Marshal(managedInstallationStamp{
+		Version:            managedStampVersion,
+		FactoryName:        name,
+		PublishedContentID: publishedID,
+		InstalledContentID: installedID,
+	})
+	if err != nil {
+		return fmt.Errorf("encode packaged Factory management evidence: %w", err)
+	}
+	temporary := filepath.Join(targetDir, managedStampTemp)
+	metadata := filepath.Join(targetDir, managedStampName)
+	if err := service.fileSystem.WriteFile(temporary, data, 0o600); err != nil {
+		_ = service.fileSystem.RemoveAll(temporary)
+		return fmt.Errorf("write packaged Factory management evidence: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		_ = service.fileSystem.RemoveAll(temporary)
+		return err
+	}
+	if err := service.fileSystem.Rename(temporary, metadata); err != nil {
+		_ = service.fileSystem.RemoveAll(temporary)
+		return fmt.Errorf("publish packaged Factory management evidence: %w", err)
+	}
+	return nil
+}
+
+func (service *Service) contentIdentity(root string) (string, error) {
+	if _, err := service.fileSystem.Stat(root); err != nil {
+		return "", fmt.Errorf("inspect packaged Factory content %s: %w", root, err)
+	}
+	hasher := sha256.New()
+	if err := service.hashManagedDirectory(hasher, root, ""); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func (service *Service) hashManagedDirectory(hasher interface{ Write([]byte) (int, error) }, root string, relative string) error {
+	entries, err := service.fileSystem.ReadDir(root)
+	if err != nil {
+		return fmt.Errorf("read packaged Factory content %s: %w", root, err)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	for _, entry := range entries {
+		childRelative := entry.Name()
+		if relative != "" {
+			childRelative = filepath.Join(relative, entry.Name())
+		}
+		if childRelative == managedStampName || childRelative == managedStampTemp {
+			continue
+		}
+		childPath := filepath.Join(root, entry.Name())
+		if entry.IsDir() {
+			if _, err := fmt.Fprintf(hasher, "d:%d:%s\n", len(childRelative), filepath.ToSlash(childRelative)); err != nil {
+				return err
+			}
+			if err := service.hashManagedDirectory(hasher, childPath, childRelative); err != nil {
+				return err
+			}
+			continue
+		}
+		data, err := service.fileSystem.ReadFile(childPath)
+		if err != nil {
+			return fmt.Errorf("read packaged Factory content %s: %w", childPath, err)
+		}
+		if _, err := fmt.Fprintf(
+			hasher,
+			"f:%d:%s:%d:",
+			len(childRelative),
+			filepath.ToSlash(childRelative),
+			len(data),
+		); err != nil {
+			return err
+		}
+		if _, err := hasher.Write(data); err != nil {
+			return err
+		}
+		if _, err := hasher.Write([]byte{'\n'}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (service *Service) snapshotManagedFactory(
+	ctx context.Context,
+	rootDir string,
+	name string,
+	targetDir string,
+) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	before, err := service.contentIdentity(targetDir)
+	if err != nil {
+		return "", err
+	}
+	backupDir, err := service.createManagedDirectory(
+		rootDir,
+		managedBackupRoot,
+		name,
+		0o700,
+	)
+	if err != nil {
+		return "", fmt.Errorf("reserve packaged Factory backup: %w", err)
+	}
+	if err := service.copyManagedDirectory(ctx, targetDir, backupDir); err != nil {
+		cleanupErr := service.fileSystem.RemoveAll(backupDir)
+		if cleanupErr != nil {
+			err = errors.Join(err, fmt.Errorf("remove incomplete packaged Factory backup %s: %w", backupDir, cleanupErr))
+		}
+		return "", fmt.Errorf("preserve packaged Factory %q at %s: %w", name, backupDir, err)
+	}
+	after, err := service.contentIdentity(targetDir)
+	if err != nil {
+		cleanupErr := service.fileSystem.RemoveAll(backupDir)
+		if cleanupErr != nil {
+			err = errors.Join(err, fmt.Errorf("remove packaged Factory backup %s: %w", backupDir, cleanupErr))
+		}
+		return "", fmt.Errorf("verify packaged Factory backup %s: %w", backupDir, err)
+	}
+	if before != after {
+		if cleanupErr := service.fileSystem.RemoveAll(backupDir); cleanupErr != nil {
+			return "", fmt.Errorf("packaged Factory %q changed while preserving backup %s and cleanup failed: %w", name, backupDir, cleanupErr)
+		}
+		return "", fmt.Errorf("packaged Factory %q changed while preserving backup %s; retry initialization", name, backupDir)
+	}
+	return backupDir, nil
+}
+
+func (service *Service) copyManagedDirectory(ctx context.Context, sourceDir, targetDir string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	entries, err := service.fileSystem.ReadDir(sourceDir)
+	if err != nil {
+		return err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		sourcePath := filepath.Join(sourceDir, entry.Name())
+		targetPath := filepath.Join(targetDir, entry.Name())
+		if entry.IsDir() {
+			if err := service.fileSystem.MkdirAll(targetPath, 0o755); err != nil {
+				return err
+			}
+			if err := service.copyManagedDirectory(ctx, sourcePath, targetPath); err != nil {
+				return err
+			}
+			continue
+		}
+		data, err := service.fileSystem.ReadFile(sourcePath)
+		if err != nil {
+			return err
+		}
+		if err := service.fileSystem.WriteFile(targetPath, data, 0o600); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (service *Service) createManagedDirectory(
+	rootDir string,
+	parentName string,
+	name string,
+	mode fs.FileMode,
+) (string, error) {
+	parentDir := filepath.Join(rootDir, parentName)
+	if err := service.fileSystem.MkdirAll(parentDir, 0o700); err != nil {
+		return "", err
+	}
+	safeName := strings.NewReplacer("/", "--", "\\", "--", "@", "").Replace(name)
+	for attempt := 0; attempt < managedPathAttempts; attempt++ {
+		candidate := filepath.Join(
+			parentDir,
+			fmt.Sprintf("%s-%s-%d-%d", parentName, safeName, os.Getpid(), attempt),
+		)
+		if err := service.directoryCreator(candidate, mode); err == nil {
+			return candidate, nil
+		} else if !errors.Is(err, fs.ErrExist) && !os.IsExist(err) {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("could not reserve a unique packaged Factory path below %s", parentDir)
+}
+
+func (service *Service) cleanupManagedReplacementFailure(
+	result factorydefinitions.PackagedFactoryInstallResult,
+	name string,
+	rootDir string,
+	backupDir string,
+	cause error,
+) (factorydefinitions.PackagedFactoryInstallResult, error) {
+	if cleanupErr := service.fileSystem.RemoveAll(backupDir); cleanupErr != nil {
+		cause = errors.Join(cause, fmt.Errorf("remove packaged Factory backup %s: %w", backupDir, cleanupErr))
+	} else {
+		result.BackupDir = ""
+	}
+	return managedInstallFailure(result, name, rootDir, cause)
+}
+
+func (service *Service) discardReplacementBackup(replacement *factorydefinitions.FactorySplitLayoutReplaceResult) {
+	if replacement != nil && replacement.DiscardBackup != nil {
+		replacement.DiscardBackup()
+	}
+}
+
+func managedInstallFailure(
+	result factorydefinitions.PackagedFactoryInstallResult,
+	name string,
+	rootDir string,
+	cause error,
+) (factorydefinitions.PackagedFactoryInstallResult, error) {
+	result.Outcome = factorydefinitions.PackagedFactoryInstallFailed
+	return result, installError(name, rootDir, cause)
+}

--- a/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/managed_reconciliation.go
+++ b/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/managed_reconciliation.go
@@ -485,10 +485,14 @@ func (service *Service) copyManagedDirectory(ctx context.Context, sourceDir, tar
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
 		sourcePath := filepath.Join(sourceDir, entry.Name())
 		targetPath := filepath.Join(targetDir, entry.Name())
 		if entry.IsDir() {
-			if err := service.fileSystem.MkdirAll(targetPath, 0o755); err != nil {
+			if err := service.fileSystem.MkdirAll(targetPath, info.Mode().Perm()); err != nil {
 				return err
 			}
 			if err := service.copyManagedDirectory(ctx, sourcePath, targetPath); err != nil {
@@ -500,7 +504,7 @@ func (service *Service) copyManagedDirectory(ctx context.Context, sourceDir, tar
 		if err != nil {
 			return err
 		}
-		if err := service.fileSystem.WriteFile(targetPath, data, 0o600); err != nil {
+		if err := service.fileSystem.WriteFile(targetPath, data, info.Mode().Perm()); err != nil {
 			return err
 		}
 	}

--- a/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/managed_reconciliation_test.go
+++ b/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/managed_reconciliation_test.go
@@ -2,7 +2,9 @@ package packagedinstallation
 
 import (
 	"bytes"
+	"context"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -57,6 +59,46 @@ func TestEnsurePackagedFactories_ManagedInstallIsCurrentAndAdoptsEquivalentLegac
 		t.Fatalf("repeat ensure outcome = %q, want current", current[0].Outcome)
 	}
 	assertDirectorySnapshotUnchanged(t, legacy.FactoryDir, beforeCurrent)
+}
+
+func TestEnsurePackagedFactories_ManagedInstallReplacesInvalidEvidenceWithoutReplacingContent(t *testing.T) {
+	t.Parallel()
+
+	definition := publishedManagedTestDefinition(t)
+	root := t.TempDir()
+	installer := New(packagedInstallationTestPersistence(), platformfilesystem.Local{}, os.Mkdir)
+	created, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{definition})
+	if err != nil {
+		t.Fatalf("initial ensure: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(created[0].FactoryDir, managedStampName), []byte("not-json"), 0o600); err != nil {
+		t.Fatalf("write invalid management evidence: %v", err)
+	}
+
+	current, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{definition})
+	if err != nil {
+		t.Fatalf("ensure with invalid management evidence: %v", err)
+	}
+	if len(current) != 1 || current[0].Outcome != factorydefinitions.PackagedFactoryInstallCurrent {
+		t.Fatalf("invalid evidence outcome = %#v, want one current result", current)
+	}
+	if current[0].BackupDir != "" {
+		t.Fatalf("invalid evidence backup = %q, want no replacement backup", current[0].BackupDir)
+	}
+	if _, err := os.Stat(filepath.Join(created[0].FactoryDir, managedStampName)); err != nil {
+		t.Fatalf("rewritten management evidence: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(created[0].FactoryDir, managedStampName),
+		[]byte(`{"version":0,"factoryName":"@you/goal","publishedContentId":"published","installedContentId":"installed"}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write obsolete management evidence: %v", err)
+	}
+	current, err = installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{definition})
+	if err != nil || len(current) != 1 || current[0].Outcome != factorydefinitions.PackagedFactoryInstallCurrent {
+		t.Fatalf("obsolete evidence outcome = %#v, %v, want one current result", current, err)
+	}
 }
 
 func TestEnsurePackagedFactories_ManagedRefreshPreservesStaleActiveDirectory(t *testing.T) {
@@ -183,6 +225,189 @@ func TestEnsurePackagedFactories_ManagedReplacementFailurePreservesActiveAndClea
 	}
 }
 
+func TestEnsurePackagedFactories_ManagedNilReplacementPreservesActiveAndCleansBackup(t *testing.T) {
+	t.Parallel()
+
+	definition := publishedManagedTestDefinition(t)
+	root := t.TempDir()
+	basePersistence := packagedInstallationTestPersistence()
+	installer := New(basePersistence, platformfilesystem.Local{}, os.Mkdir)
+	created, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{definition})
+	if err != nil {
+		t.Fatalf("initial ensure: %v", err)
+	}
+	before := snapshotDirectoryContents(t, created[0].FactoryDir)
+	updated := definition
+	updated.JSON = bytes.Replace(updated.JSON, []byte("Persists goal progress"), []byte("nil replacement content"), 1)
+
+	failed, err := New(
+		&nilManagedReplacementPersistence{PackagedFactoryPersistence: basePersistence},
+		platformfilesystem.Local{},
+		os.Mkdir,
+	).EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{updated})
+	if err == nil || !strings.Contains(err.Error(), "replacement result is required") {
+		t.Fatalf("nil replacement error = %v, want required-result error", err)
+	}
+	if len(failed) != 1 || failed[0].Outcome != factorydefinitions.PackagedFactoryInstallFailed {
+		t.Fatalf("nil replacement result = %#v, want one failed result", failed)
+	}
+	assertDirectorySnapshotUnchanged(t, created[0].FactoryDir, before)
+	backupEntries, readErr := os.ReadDir(filepath.Join(root, managedBackupRoot))
+	if readErr == nil && len(backupEntries) != 0 {
+		t.Fatalf("backup entries after nil replacement = %v, want none", backupEntries)
+	}
+}
+
+func TestEnsurePackagedFactories_ManagedStampPublicationFailureReportsFailedOutcome(t *testing.T) {
+	t.Parallel()
+
+	definition := publishedManagedTestDefinition(t)
+	root := t.TempDir()
+	fileSystem := &managedStampFailureFileSystem{Local: platformfilesystem.Local{}}
+	installer := New(packagedInstallationTestPersistence(), fileSystem, os.Mkdir)
+	created, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{definition})
+	if err != nil {
+		t.Fatalf("initial ensure: %v", err)
+	}
+	fileSystem.failStampRename = true
+	updated := definition
+	updated.JSON = bytes.Replace(updated.JSON, []byte("Persists goal progress"), []byte("stamp publication failure content"), 1)
+
+	failed, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{updated})
+	if err == nil || !strings.Contains(err.Error(), "publish packaged Factory management evidence") {
+		t.Fatalf("stamp publication error = %v, want management-evidence error", err)
+	}
+	if len(failed) != 1 || failed[0].Outcome != factorydefinitions.PackagedFactoryInstallFailed {
+		t.Fatalf("stamp publication result = %#v, want one failed result", failed)
+	}
+	active, readErr := os.ReadFile(filepath.Join(created[0].FactoryDir, factorydefinitions.FactoryConfigFile))
+	if readErr != nil || !bytes.Contains(active, []byte("stamp publication failure content")) {
+		t.Fatalf("active Factory after stamp failure = %q, %v, want current payload", active, readErr)
+	}
+}
+
+func TestWaitForManagedRetryHonorsCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := waitForManagedRetry(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForManagedRetry() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestWriteManagedStampFailureCleansTemporaryEvidence(t *testing.T) {
+	t.Parallel()
+
+	targetDir := t.TempDir()
+	fileSystem := &failingPackagedInstallationFileSystem{
+		Local:        platformfilesystem.Local{},
+		writeFileErr: errors.New("management evidence write unavailable"),
+	}
+	service := New(packagedInstallationTestPersistence(), fileSystem, os.Mkdir)
+	if err := service.writeManagedStamp(t.Context(), targetDir, "@you/goal", "published", "installed"); err == nil {
+		t.Fatal("writeManagedStamp() error = nil, want write failure")
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, managedStampTemp)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("temporary management evidence stat = %v, want absent", err)
+	}
+}
+
+func TestWriteManagedStampCancellationCleansTemporaryEvidence(t *testing.T) {
+	t.Parallel()
+
+	targetDir := t.TempDir()
+	ctx, cancel := context.WithCancel(t.Context())
+	fileSystem := &cancelAfterManagedWriteFileSystem{
+		Local:  platformfilesystem.Local{},
+		cancel: cancel,
+	}
+	service := New(packagedInstallationTestPersistence(), fileSystem, os.Mkdir)
+	err := service.writeManagedStamp(ctx, targetDir, "@you/goal", "published", "installed")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("writeManagedStamp() error = %v, want context.Canceled", err)
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, managedStampTemp)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("temporary management evidence stat = %v, want absent", err)
+	}
+}
+
+func TestContentIdentityReportsFilesystemInspectionFailures(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	statFailure := errors.New("content stat unavailable")
+	fileSystem := &failingPackagedInstallationFileSystem{
+		Local:    platformfilesystem.Local{},
+		statPath: root,
+		statErr:  statFailure,
+	}
+	service := New(packagedInstallationTestPersistence(), fileSystem, os.Mkdir)
+	if _, err := service.contentIdentity(root); !errors.Is(err, statFailure) {
+		t.Fatalf("contentIdentity() stat error = %v, want %v", err, statFailure)
+	}
+}
+
+func TestEnsurePackagedFactories_ManagedStampReadFailureIsActionable(t *testing.T) {
+	t.Parallel()
+
+	definition := publishedManagedTestDefinition(t)
+	root := t.TempDir()
+	fileSystem := &managedStampReadFailureFileSystem{Local: platformfilesystem.Local{}}
+	installer := New(packagedInstallationTestPersistence(), fileSystem, os.Mkdir)
+	if _, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{definition}); err != nil {
+		t.Fatalf("initial ensure: %v", err)
+	}
+	fileSystem.failStampRead = true
+	_, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{definition})
+	if err == nil || !strings.Contains(err.Error(), "read packaged Factory management evidence") {
+		t.Fatalf("management evidence read error = %v, want actionable read error", err)
+	}
+}
+
+func TestEnsurePackagedFactories_ManagedPreparationRequiresPreparedLayout(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	definition := publishedManagedTestDefinition(t)
+	installer := New(
+		&nilManagedPreparationPersistence{PackagedFactoryPersistence: packagedInstallationTestPersistence()},
+		platformfilesystem.Local{},
+		os.Mkdir,
+	)
+	_, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{definition})
+	if err == nil || !strings.Contains(err.Error(), "prepared Factory layout is required") {
+		t.Fatalf("nil prepared layout error = %v, want required-layout error", err)
+	}
+}
+
+func TestEnsurePackagedFactories_ManagedBackupReservationFailureIsActionable(t *testing.T) {
+	t.Parallel()
+
+	definition := publishedManagedTestDefinition(t)
+	root := t.TempDir()
+	directoryCreator := func(path string, mode fs.FileMode) error {
+		if strings.Contains(path, managedBackupRoot) {
+			return errors.New("backup reservation unavailable")
+		}
+		return os.Mkdir(path, mode)
+	}
+	installer := New(packagedInstallationTestPersistence(), platformfilesystem.Local{}, directoryCreator)
+	created, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{definition})
+	if err != nil {
+		t.Fatalf("initial ensure: %v", err)
+	}
+	updated := definition
+	updated.JSON = bytes.Replace(updated.JSON, []byte("Persists goal progress"), []byte("backup reservation failure content"), 1)
+	_, err = installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{updated})
+	if err == nil || !strings.Contains(err.Error(), "reserve packaged Factory backup") {
+		t.Fatalf("backup reservation error = %v, want actionable reservation error", err)
+	}
+	if _, statErr := os.Stat(created[0].FactoryDir); statErr != nil {
+		t.Fatalf("active Factory after backup reservation failure: %v", statErr)
+	}
+}
+
 func TestEnsurePackagedFactories_ConcurrentManagedRefreshesConverge(t *testing.T) {
 	t.Parallel()
 
@@ -251,6 +476,66 @@ func TestEnsurePackagedFactories_ConcurrentManagedRefreshesConverge(t *testing.T
 type failingManagedReplacementPersistence struct {
 	factorydefinitions.PackagedFactoryPersistence
 	replaceErr error
+}
+
+type nilManagedReplacementPersistence struct {
+	factorydefinitions.PackagedFactoryPersistence
+}
+
+func (persistence *nilManagedReplacementPersistence) ReplaceFactoryLayout(
+	string,
+	*factorydefinitions.PreparedFactoryLayoutPayload,
+) (*factorydefinitions.FactorySplitLayoutReplaceResult, error) {
+	return nil, nil
+}
+
+type nilManagedPreparationPersistence struct {
+	factorydefinitions.PackagedFactoryPersistence
+}
+
+func (persistence *nilManagedPreparationPersistence) PreparePackagedFactoryLayout(
+	context.Context,
+	string,
+	[]byte,
+) (*factorydefinitions.PreparedFactoryLayoutPayload, error) {
+	return nil, nil
+}
+
+type managedStampReadFailureFileSystem struct {
+	platformfilesystem.Local
+	failStampRead bool
+}
+
+func (fileSystem *managedStampReadFailureFileSystem) ReadFile(path string) ([]byte, error) {
+	if fileSystem.failStampRead && filepath.Base(path) == managedStampName {
+		return nil, errors.New("management evidence read unavailable")
+	}
+	return fileSystem.Local.ReadFile(path)
+}
+
+type managedStampFailureFileSystem struct {
+	platformfilesystem.Local
+	failStampRename bool
+}
+
+type cancelAfterManagedWriteFileSystem struct {
+	platformfilesystem.Local
+	cancel context.CancelFunc
+}
+
+func (fileSystem *cancelAfterManagedWriteFileSystem) WriteFile(path string, data []byte, mode fs.FileMode) error {
+	if err := fileSystem.Local.WriteFile(path, data, mode); err != nil {
+		return err
+	}
+	fileSystem.cancel()
+	return nil
+}
+
+func (fileSystem *managedStampFailureFileSystem) Rename(oldPath, newPath string) error {
+	if fileSystem.failStampRename && filepath.Base(newPath) == managedStampName {
+		return errors.New("management evidence rename unavailable")
+	}
+	return fileSystem.Local.Rename(oldPath, newPath)
 }
 
 type blockingManagedReplacementPersistence struct {

--- a/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/managed_reconciliation_test.go
+++ b/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/managed_reconciliation_test.go
@@ -1,0 +1,290 @@
+package packagedinstallation
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/packagedfactorycatalog"
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+)
+
+func TestEnsurePackagedFactories_ManagedInstallIsCurrentAndAdoptsEquivalentLegacyContent(t *testing.T) {
+	t.Parallel()
+
+	definition := publishedManagedTestDefinition(t)
+	root := t.TempDir()
+	installer := New(packagedInstallationTestPersistence(), platformfilesystem.Local{}, os.Mkdir)
+	legacy, err := installer.InstallPackagedFactory(t.Context(), factorydefinitions.PackagedFactoryInstallParams{
+		NamedFactoriesRoot: root,
+		Definition:         definition,
+		Format:             factorydefinitions.PackagedFactoryFormatJSON,
+	})
+	if err != nil {
+		t.Fatalf("legacy installation: %v", err)
+	}
+	legacySnapshot := snapshotDirectoryContents(t, legacy.FactoryDir)
+
+	adopted, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{definition})
+	if err != nil {
+		t.Fatalf("adopt legacy installation: %v", err)
+	}
+	if len(adopted) != 1 || adopted[0].Outcome != factorydefinitions.PackagedFactoryInstallCurrent {
+		t.Fatalf("legacy adoption = %#v, want one current result", adopted)
+	}
+	if adopted[0].BackupDir != "" {
+		t.Fatalf("legacy adoption backup = %q, want no replacement backup", adopted[0].BackupDir)
+	}
+	if _, err := os.Stat(filepath.Join(legacy.FactoryDir, managedStampName)); err != nil {
+		t.Fatalf("managed stamp after legacy adoption: %v", err)
+	}
+	if got := snapshotDirectoryContents(t, legacy.FactoryDir); len(got) != len(legacySnapshot)+1 {
+		t.Fatalf("legacy adoption changed %d content entries, want only management evidence added", len(got)-len(legacySnapshot))
+	}
+
+	beforeCurrent := snapshotDirectoryContents(t, legacy.FactoryDir)
+	current, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{definition})
+	if err != nil {
+		t.Fatalf("repeat ensure: %v", err)
+	}
+	if current[0].Outcome != factorydefinitions.PackagedFactoryInstallCurrent {
+		t.Fatalf("repeat ensure outcome = %q, want current", current[0].Outcome)
+	}
+	assertDirectorySnapshotUnchanged(t, legacy.FactoryDir, beforeCurrent)
+}
+
+func TestEnsurePackagedFactories_ManagedRefreshPreservesStaleActiveDirectory(t *testing.T) {
+	t.Parallel()
+
+	definition := publishedManagedTestDefinition(t)
+	root := t.TempDir()
+	installer := New(packagedInstallationTestPersistence(), platformfilesystem.Local{}, os.Mkdir)
+	created, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{definition})
+	if err != nil {
+		t.Fatalf("initial ensure: %v", err)
+	}
+	if created[0].Outcome != factorydefinitions.PackagedFactoryInstallCreated {
+		t.Fatalf("initial outcome = %q, want created", created[0].Outcome)
+	}
+	oldFactory, err := os.ReadFile(filepath.Join(created[0].FactoryDir, factorydefinitions.FactoryConfigFile))
+	if err != nil {
+		t.Fatalf("read initial Factory: %v", err)
+	}
+
+	updated := definition
+	updated.JSON = bytes.Replace(
+		updated.JSON,
+		[]byte("Persists goal progress"),
+		[]byte("Updated packaged goal progress"),
+		1,
+	)
+	if bytes.Equal(updated.JSON, definition.JSON) {
+		t.Fatal("test definition did not change")
+	}
+	refreshed, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{updated})
+	if err != nil {
+		t.Fatalf("stale refresh: %v", err)
+	}
+	if refreshed[0].Outcome != factorydefinitions.PackagedFactoryInstallRefreshed {
+		t.Fatalf("refresh outcome = %q, want refreshed", refreshed[0].Outcome)
+	}
+	if refreshed[0].BackupDir == "" {
+		t.Fatal("refresh backup path is empty")
+	}
+	backupFactory, err := os.ReadFile(filepath.Join(refreshed[0].BackupDir, factorydefinitions.FactoryConfigFile))
+	if err != nil {
+		t.Fatalf("read stale backup: %v", err)
+	}
+	if !bytes.Equal(backupFactory, oldFactory) {
+		t.Fatal("stale backup does not preserve the complete prior Factory root file")
+	}
+	activeFactory, err := os.ReadFile(filepath.Join(refreshed[0].FactoryDir, factorydefinitions.FactoryConfigFile))
+	if err != nil {
+		t.Fatalf("read refreshed Factory: %v", err)
+	}
+	if !bytes.Contains(activeFactory, []byte("Updated packaged goal progress")) {
+		t.Fatal("active Factory does not contain the current packaged definition")
+	}
+	if _, err := os.Stat(refreshed[0].BackupDir); err != nil {
+		t.Fatalf("preserved backup stat: %v", err)
+	}
+}
+
+func TestEnsurePackagedFactories_ManagedCustomerModificationIsReportedAndPreserved(t *testing.T) {
+	t.Parallel()
+
+	definition := publishedManagedTestDefinition(t)
+	root := t.TempDir()
+	installer := New(packagedInstallationTestPersistence(), platformfilesystem.Local{}, os.Mkdir)
+	created, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{definition})
+	if err != nil {
+		t.Fatalf("initial ensure: %v", err)
+	}
+	marker := filepath.Join(created[0].FactoryDir, "customer-owned.txt")
+	if err := os.WriteFile(marker, []byte("keep this edit"), 0o600); err != nil {
+		t.Fatalf("write customer edit: %v", err)
+	}
+
+	refreshed, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{definition})
+	if err != nil {
+		t.Fatalf("customer-modified refresh: %v", err)
+	}
+	if refreshed[0].Outcome != factorydefinitions.PackagedFactoryInstallCustomerModified {
+		t.Fatalf("customer-modified outcome = %q, want customer-modified", refreshed[0].Outcome)
+	}
+	if refreshed[0].BackupDir == "" {
+		t.Fatal("customer-modified backup path is empty")
+	}
+	backupMarker, err := os.ReadFile(filepath.Join(refreshed[0].BackupDir, "customer-owned.txt"))
+	if err != nil || string(backupMarker) != "keep this edit" {
+		t.Fatalf("preserved customer edit = %q, %v", backupMarker, err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("active customer edit stat = %v, want removed from refreshed active directory", err)
+	}
+}
+
+func TestEnsurePackagedFactories_ManagedReplacementFailurePreservesActiveAndCleansBackup(t *testing.T) {
+	t.Parallel()
+
+	definition := publishedManagedTestDefinition(t)
+	root := t.TempDir()
+	persistence := &failingManagedReplacementPersistence{
+		PackagedFactoryPersistence: packagedInstallationTestPersistence(),
+		replaceErr:                 errors.New("replacement unavailable"),
+	}
+	installer := New(persistence, platformfilesystem.Local{}, os.Mkdir)
+	created, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{definition})
+	if err != nil {
+		t.Fatalf("initial ensure: %v", err)
+	}
+	before := snapshotDirectoryContents(t, created[0].FactoryDir)
+	updated := definition
+	updated.JSON = bytes.Replace(updated.JSON, []byte("Persists goal progress"), []byte("Replacement failure content"), 1)
+
+	failed, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{updated})
+	if err == nil || !strings.Contains(err.Error(), "replacement unavailable") {
+		t.Fatalf("failed refresh error = %v, want replacement failure", err)
+	}
+	if len(failed) != 1 || failed[0].Outcome != factorydefinitions.PackagedFactoryInstallFailed {
+		t.Fatalf("failed refresh result = %#v, want one failed result", failed)
+	}
+	assertDirectorySnapshotUnchanged(t, created[0].FactoryDir, before)
+	backupRoot := filepath.Join(root, managedBackupRoot)
+	entries, readErr := os.ReadDir(backupRoot)
+	if readErr == nil && len(entries) != 0 {
+		t.Fatalf("backup entries after failed replacement = %v, want none", entries)
+	}
+}
+
+func TestEnsurePackagedFactories_ConcurrentManagedRefreshesConverge(t *testing.T) {
+	t.Parallel()
+
+	definition := publishedManagedTestDefinition(t)
+	root := t.TempDir()
+	persistence := &blockingManagedReplacementPersistence{
+		PackagedFactoryPersistence: packagedInstallationTestPersistence(),
+		replacementStarted:         make(chan struct{}),
+		allowReplacement:           make(chan struct{}),
+	}
+	installer := New(persistence, platformfilesystem.Local{}, os.Mkdir)
+	if _, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{definition}); err != nil {
+		t.Fatalf("initial ensure: %v", err)
+	}
+	updated := definition
+	updated.JSON = bytes.Replace(updated.JSON, []byte("Persists goal progress"), []byte("Concurrent refresh content"), 1)
+
+	type ensureResult struct {
+		results []factorydefinitions.PackagedFactoryInstallResult
+		err     error
+	}
+	firstDone := make(chan ensureResult, 1)
+	go func() {
+		results, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{updated})
+		firstDone <- ensureResult{results: results, err: err}
+	}()
+	select {
+	case <-persistence.replacementStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for first managed replacement")
+	}
+	secondDone := make(chan ensureResult, 1)
+	go func() {
+		results, err := installer.EnsurePackagedFactories(t.Context(), root, "managed-test", []factorydefinitions.PackagedDefinition{updated})
+		secondDone <- ensureResult{results: results, err: err}
+	}()
+	close(persistence.allowReplacement)
+
+	var completed []ensureResult
+	for range 2 {
+		select {
+		case result := <-firstDone:
+			completed = append(completed, result)
+			firstDone = nil
+		case result := <-secondDone:
+			completed = append(completed, result)
+			secondDone = nil
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for concurrent managed refreshes")
+		}
+	}
+	for _, result := range completed {
+		if result.err != nil {
+			t.Fatalf("concurrent ensure error: %v", result.err)
+		}
+		if len(result.results) != 1 {
+			t.Fatalf("concurrent ensure results = %#v, want one result", result.results)
+		}
+		if result.results[0].Outcome != factorydefinitions.PackagedFactoryInstallRefreshed &&
+			result.results[0].Outcome != factorydefinitions.PackagedFactoryInstallCurrent {
+			t.Fatalf("concurrent ensure outcome = %q, want refreshed or current", result.results[0].Outcome)
+		}
+	}
+}
+
+type failingManagedReplacementPersistence struct {
+	factorydefinitions.PackagedFactoryPersistence
+	replaceErr error
+}
+
+type blockingManagedReplacementPersistence struct {
+	factorydefinitions.PackagedFactoryPersistence
+	replacementStarted chan struct{}
+	allowReplacement   chan struct{}
+	replacementOnce    sync.Once
+}
+
+func (persistence *blockingManagedReplacementPersistence) ReplaceFactoryLayout(
+	targetDir string,
+	prepared *factorydefinitions.PreparedFactoryLayoutPayload,
+) (*factorydefinitions.FactorySplitLayoutReplaceResult, error) {
+	persistence.replacementOnce.Do(func() { close(persistence.replacementStarted) })
+	<-persistence.allowReplacement
+	return persistence.PackagedFactoryPersistence.ReplaceFactoryLayout(targetDir, prepared)
+}
+
+func (persistence *failingManagedReplacementPersistence) ReplaceFactoryLayout(
+	string,
+	*factorydefinitions.PreparedFactoryLayoutPayload,
+) (*factorydefinitions.FactorySplitLayoutReplaceResult, error) {
+	return nil, persistence.replaceErr
+}
+
+func publishedManagedTestDefinition(t *testing.T) factorydefinitions.PackagedDefinition {
+	t.Helper()
+	catalog, err := packagedfactorycatalog.LoadPublishedDefinitionCatalog()
+	if err != nil {
+		t.Fatalf("load packaged catalog: %v", err)
+	}
+	definition, ok := catalog.Lookup("@you/goal")
+	if !ok {
+		t.Fatal("packaged catalog is missing @you/goal")
+	}
+	return definition
+}

--- a/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/service.go
+++ b/pkg/services/factory_definitions/internal/services/distribution/packagedinstallation/service.go
@@ -100,17 +100,15 @@ func (service *Service) EnsurePackagedFactories(
 ) ([]factorydefinitions.PackagedFactoryInstallResult, error) {
 	results := make([]factorydefinitions.PackagedFactoryInstallResult, 0, len(definitions))
 	for _, definition := range definitions {
-		result, err := service.InstallPackagedFactory(
+		result, err := service.ensureManagedPackagedFactory(
 			ctx,
-			factorydefinitions.PackagedFactoryInstallParams{
-				NamedFactoriesRoot: namedFactoriesRoot,
-				BackendScopeID:     backendScopeID,
-				Definition:         definition,
-				Format:             factorydefinitions.PackagedFactoryFormatJSON,
-			},
+			namedFactoriesRoot,
+			backendScopeID,
+			definition,
 		)
 		if err != nil {
-			return nil, err
+			results = append(results, result)
+			return results, err
 		}
 		results = append(results, result)
 	}
@@ -120,15 +118,20 @@ func (service *Service) EnsurePackagedFactories(
 func (service *Service) InstallPackagedFactory(
 	ctx context.Context,
 	params factorydefinitions.PackagedFactoryInstallParams,
-) (factorydefinitions.PackagedFactoryInstallResult, error) {
+) (result factorydefinitions.PackagedFactoryInstallResult, installErr error) {
 	definition := params.Definition
 	format := params.Format
 	namedFactoriesRoot := params.NamedFactoriesRoot
 	backendScopeID := normalizedBackendScopeID(params.BackendScopeID)
-	result := factorydefinitions.PackagedFactoryInstallResult{
+	result = factorydefinitions.PackagedFactoryInstallResult{
 		Name:   definition.Name,
 		Format: format,
 	}
+	defer func() {
+		if installErr != nil && params.ManagedRefresh {
+			result.Outcome = factorydefinitions.PackagedFactoryInstallFailed
+		}
+	}()
 	if err := ctx.Err(); err != nil {
 		return result, service.installationError(backendScopeID, namedFactoriesRoot, definition.Name, "", ownerLivenessIndeterminate, err)
 	}
@@ -178,6 +181,16 @@ func (service *Service) InstallPackagedFactory(
 		result,
 		recoveredLease,
 		func() (factorydefinitions.PackagedFactoryInstallResult, error) {
+			if params.ManagedRefresh {
+				return service.createManagedPackagedFactory(
+					ctx,
+					namedFactoriesRoot,
+					definition.Name,
+					payload,
+					rootFileName,
+					result,
+				)
+			}
 			return service.createPackagedFactory(
 				ctx,
 				namedFactoriesRoot,
@@ -204,6 +217,28 @@ func (service *Service) installExistingPackagedFactory(
 ) (factorydefinitions.PackagedFactoryInstallResult, error) {
 	name := params.Definition.Name
 	rootDir := params.NamedFactoriesRoot
+	if params.ManagedRefresh {
+		return service.withStagingOwnership(
+			ctx,
+			rootDir,
+			name,
+			backendScopeID,
+			result,
+			recoveredLease,
+			func() (factorydefinitions.PackagedFactoryInstallResult, error) {
+				return service.reconcileManagedPackagedFactory(
+					ctx,
+					rootDir,
+					name,
+					normalizedFormat,
+					targetDir,
+					payload,
+					rootFileName,
+					result,
+				)
+			},
+		)
+	}
 	if err := service.persistence.ValidateFactoryLayout(targetDir); err != nil {
 		if releaseErr := service.releaseStagingOwnership(recoveredLease); releaseErr != nil {
 			err = errors.Join(err, releaseErr)
@@ -317,14 +352,7 @@ func (service *Service) withStagingOwnership(
 	}()
 	installResult, installErr = operation()
 	if installErr == nil {
-		service.logOutcome(
-			backendScopeID,
-			name,
-			lease.path,
-			"success",
-			ownerLivenessActive,
-			lease.owner.PID,
-		)
+		service.logInstallationOutcome(backendScopeID, installResult, lease)
 	} else {
 		service.logOutcome(
 			backendScopeID,

--- a/pkg/services/factory_definitions/packaged_installation.go
+++ b/pkg/services/factory_definitions/packaged_installation.go
@@ -5,9 +5,13 @@ import "context"
 type PackagedFactoryInstallOutcome string
 
 const (
-	PackagedFactoryInstallCreated  PackagedFactoryInstallOutcome = "created"
-	PackagedFactoryInstallSkipped  PackagedFactoryInstallOutcome = "skipped"
-	PackagedFactoryInstallReplaced PackagedFactoryInstallOutcome = "replaced"
+	PackagedFactoryInstallCreated          PackagedFactoryInstallOutcome = "created"
+	PackagedFactoryInstallSkipped          PackagedFactoryInstallOutcome = "skipped"
+	PackagedFactoryInstallReplaced         PackagedFactoryInstallOutcome = "replaced"
+	PackagedFactoryInstallCurrent          PackagedFactoryInstallOutcome = "current"
+	PackagedFactoryInstallRefreshed        PackagedFactoryInstallOutcome = "refreshed"
+	PackagedFactoryInstallCustomerModified PackagedFactoryInstallOutcome = "customer-modified"
+	PackagedFactoryInstallFailed           PackagedFactoryInstallOutcome = "failed"
 )
 
 // PackagedFactoryInstallParams carries one Definitions-owned packaged
@@ -19,13 +23,20 @@ type PackagedFactoryInstallParams struct {
 	Definition         PackagedDefinition
 	Format             PackagedFactoryFormat
 	Replace            bool
+	// ManagedRefresh is set only by the system-initialization ensure route.
+	// Direct installation retains its historical create/skip/replace behavior;
+	// managed installation may reconcile stale materialized content.
+	ManagedRefresh bool
 }
 
 type PackagedFactoryInstallResult struct {
-	Name       string
-	FactoryDir string
-	Outcome    PackagedFactoryInstallOutcome
-	Format     PackagedFactoryFormat
+	Name               string
+	FactoryDir         string
+	Outcome            PackagedFactoryInstallOutcome
+	Format             PackagedFactoryFormat
+	BackupDir          string
+	PublishedContentID string
+	InstalledContentID string
 }
 
 // PackagedFactoryInstaller owns validation and persistence of the packaged

--- a/pkg/services/factory_definitions/systeminitializationtests/packaged_scripts_test.go
+++ b/pkg/services/factory_definitions/systeminitializationtests/packaged_scripts_test.go
@@ -172,8 +172,8 @@ func TestEnsurePackagedFactories_InstallsAssembledScriptsThinExecutableAndBacksU
 	}
 
 	factoryDir := created[0].FactoryDir
-	assertInstalledPackagedScript(t, factoryDir, "scripts/setup.sh", "#!/bin/sh\nprintf 'packaged setup\\n'\n")
-	assertInstalledPackagedScript(t, factoryDir, "scripts/nested/check.py", "print('nested packaged script')\n")
+	assertInstalledPackagedScript(t, factoryDir, "scripts/setup.sh", "#!/bin/sh\nprintf 'packaged setup\\n'\n", 0o755)
+	assertInstalledPackagedScript(t, factoryDir, "scripts/nested/check.py", "print('nested packaged script')\n", 0o755)
 	assertThinPackagedScriptManifest(t, factoryDir)
 	assertInstalledPackagedScriptRuntimeConfig(t, factoryDir)
 
@@ -205,12 +205,14 @@ func TestEnsurePackagedFactories_InstallsAssembledScriptsThinExecutableAndBacksU
 		refreshed[0].BackupDir,
 		"scripts/nested/check.py",
 		"print('operator edit')\n",
+		0o600,
 	)
 	assertInstalledPackagedScript(
 		t,
 		factoryDir,
 		"scripts/nested/check.py",
 		"print('nested packaged script')\n",
+		0o755,
 	)
 }
 
@@ -236,7 +238,7 @@ func assembledScriptPackageDefinition(t *testing.T) factorydefinitions.PackagedD
 	return factorydefinitions.PackagedDefinition{Name: "@test/scripts", Project: "packaged-script-fixture", JSON: payload}
 }
 
-func assertInstalledPackagedScript(t *testing.T, factoryDir, relativePath, wantContent string) {
+func assertInstalledPackagedScript(t *testing.T, factoryDir, relativePath, wantContent string, wantMode fs.FileMode) {
 	t.Helper()
 
 	path := filepath.Join(factoryDir, filepath.FromSlash(relativePath))
@@ -251,8 +253,8 @@ func assertInstalledPackagedScript(t *testing.T, factoryDir, relativePath, wantC
 	if err != nil {
 		t.Fatalf("Stat(%s): %v", relativePath, err)
 	}
-	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o755 {
-		t.Fatalf("%s mode = %04o, want 0755", relativePath, info.Mode().Perm())
+	if runtime.GOOS != "windows" && info.Mode().Perm() != wantMode.Perm() {
+		t.Fatalf("%s mode = %04o, want %04o", relativePath, info.Mode().Perm(), wantMode.Perm())
 	}
 }
 

--- a/pkg/services/factory_definitions/systeminitializationtests/packaged_scripts_test.go
+++ b/pkg/services/factory_definitions/systeminitializationtests/packaged_scripts_test.go
@@ -152,7 +152,7 @@ func assertDirectorySnapshotUnchanged(t *testing.T, root string, before map[stri
 	}
 }
 
-func TestEnsurePackagedFactories_InstallsAssembledScriptsThinExecutableAndPreservesEdits(t *testing.T) {
+func TestEnsurePackagedFactories_InstallsAssembledScriptsThinExecutableAndBacksUpEdits(t *testing.T) {
 	t.Parallel()
 
 	definition := assembledScriptPackageDefinition(t)
@@ -184,9 +184,7 @@ func TestEnsurePackagedFactories_InstallsAssembledScriptsThinExecutableAndPreser
 	if err := os.Chmod(editedPath, 0o600); err != nil {
 		t.Fatalf("Chmod(operator-edited script): %v", err)
 	}
-	beforeRerun := snapshotDirectoryContents(t, factoryDir)
-
-	skipped, err := packagedinstallation.New(packagedScriptsTestPersistence(), platformfilesystem.Local{}, os.Mkdir).
+	refreshed, err := packagedinstallation.New(packagedScriptsTestPersistence(), platformfilesystem.Local{}, os.Mkdir).
 		EnsurePackagedFactories(
 			t.Context(),
 			factorydefinitions.NamedFactoriesRoot(homeDir),
@@ -196,10 +194,24 @@ func TestEnsurePackagedFactories_InstallsAssembledScriptsThinExecutableAndPreser
 	if err != nil {
 		t.Fatalf("Initialize(rerun): %v", err)
 	}
-	if len(skipped) != 1 || skipped[0].Outcome != factorydefinitions.PackagedFactoryInstallSkipped {
-		t.Fatalf("rerun results = %#v, want one skipped package", skipped)
+	if len(refreshed) != 1 || refreshed[0].Outcome != factorydefinitions.PackagedFactoryInstallCustomerModified {
+		t.Fatalf("rerun results = %#v, want one customer-modified refresh", refreshed)
 	}
-	assertDirectorySnapshotUnchanged(t, factoryDir, beforeRerun)
+	if refreshed[0].BackupDir == "" {
+		t.Fatal("rerun backup path is empty")
+	}
+	assertInstalledPackagedScript(
+		t,
+		refreshed[0].BackupDir,
+		"scripts/nested/check.py",
+		"print('operator edit')\n",
+	)
+	assertInstalledPackagedScript(
+		t,
+		factoryDir,
+		"scripts/nested/check.py",
+		"print('nested packaged script')\n",
+	)
 }
 
 func assembledScriptPackageDefinition(t *testing.T) factorydefinitions.PackagedDefinition {

--- a/pkg/services/factory_definitions/systeminitializationtests/packaged_scripts_test.go
+++ b/pkg/services/factory_definitions/systeminitializationtests/packaged_scripts_test.go
@@ -6,7 +6,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -27,12 +26,6 @@ import (
 	factorymapping "github.com/portpowered/infinite-you/pkg/transports/mapping/factoryconfig"
 	authoredmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/factoryconfig/authored"
 )
-
-type directoryEntrySnapshot struct {
-	Contents []byte
-	Mode     fs.FileMode
-	IsDir    bool
-}
 
 func packagedScriptsTestPersistence() factorydefinitions.PackagedFactoryPersistence {
 	validator := factoryvalidation.New(nil)
@@ -100,56 +93,6 @@ func packagedScriptsTestPersistence() factorydefinitions.PackagedFactoryPersiste
 		panic(err)
 	}
 	return persistence
-}
-
-func snapshotDirectoryContents(t *testing.T, root string) map[string]directoryEntrySnapshot {
-	t.Helper()
-	snapshot := map[string]directoryEntrySnapshot{}
-	if err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		info, err := entry.Info()
-		if err != nil {
-			return err
-		}
-		relative, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		value := directoryEntrySnapshot{Mode: info.Mode(), IsDir: entry.IsDir()}
-		if info.Mode().IsRegular() {
-			value.Contents, err = os.ReadFile(path)
-			if err != nil {
-				return err
-			}
-		}
-		snapshot[filepath.ToSlash(relative)] = value
-		return nil
-	}); err != nil {
-		t.Fatalf("snapshot directory: %v", err)
-	}
-	return snapshot
-}
-
-func assertDirectorySnapshotUnchanged(t *testing.T, root string, before map[string]directoryEntrySnapshot) {
-	t.Helper()
-	after := snapshotDirectoryContents(t, root)
-	if reflect.DeepEqual(before, after) {
-		return
-	}
-	for path, want := range before {
-		if got, ok := after[path]; !ok {
-			t.Errorf("directory entry %q was removed", path)
-		} else if !reflect.DeepEqual(want, got) {
-			t.Errorf("directory entry %q changed: before=%#v after=%#v", path, want, got)
-		}
-	}
-	for path := range after {
-		if _, ok := before[path]; !ok {
-			t.Errorf("directory entry %q was added", path)
-		}
-	}
 }
 
 func TestEnsurePackagedFactories_InstallsAssembledScriptsThinExecutableAndBacksUpEdits(t *testing.T) {

--- a/pkg/services/system_initialization/internal/workflow/workflow.go
+++ b/pkg/services/system_initialization/internal/workflow/workflow.go
@@ -224,7 +224,10 @@ func projectPackagedFactoryResults(installed []factorydefinitions.PackagedFactor
 	results := make([]systeminitialization.PackagedFactoryResult, 0, len(installed))
 	for _, result := range installed {
 		results = append(results, systeminitialization.PackagedFactoryResult{
-			Name: result.Name, FactoryDir: result.FactoryDir, Outcome: systeminitialization.PackagedFactoryOutcome(result.Outcome),
+			Name:       result.Name,
+			FactoryDir: result.FactoryDir,
+			Outcome:    systeminitialization.PackagedFactoryOutcome(result.Outcome),
+			BackupDir:  result.BackupDir,
 		})
 	}
 	return results

--- a/pkg/services/system_initialization/service.go
+++ b/pkg/services/system_initialization/service.go
@@ -31,8 +31,12 @@ const (
 type PackagedFactoryOutcome string
 
 const (
-	PackagedFactoryCreated PackagedFactoryOutcome = "created"
-	PackagedFactorySkipped PackagedFactoryOutcome = "skipped"
+	PackagedFactoryCreated          PackagedFactoryOutcome = "created"
+	PackagedFactorySkipped          PackagedFactoryOutcome = "skipped"
+	PackagedFactoryCurrent          PackagedFactoryOutcome = "current"
+	PackagedFactoryRefreshed        PackagedFactoryOutcome = "refreshed"
+	PackagedFactoryCustomerModified PackagedFactoryOutcome = "customer-modified"
+	PackagedFactoryFailed           PackagedFactoryOutcome = "failed"
 )
 
 // PackagedFactoryResult summarizes one packaged Factory installation.
@@ -40,6 +44,7 @@ type PackagedFactoryResult struct {
 	Name       string
 	FactoryDir string
 	Outcome    PackagedFactoryOutcome
+	BackupDir  string
 }
 
 // Request contains the caller-controlled inputs for one initialization.

--- a/pkg/services/system_initialization/transports/cli/initialize.go
+++ b/pkg/services/system_initialization/transports/cli/initialize.go
@@ -38,6 +38,7 @@ type InitializePackagedFactory struct {
 	Name       string `json:"name"`
 	FactoryDir string `json:"factoryDir"`
 	Outcome    string `json:"outcome"`
+	BackupDir  string `json:"backupDir,omitempty"`
 }
 
 // Initialize delegates home-directory intent to the Bootstrap root and surfaces
@@ -145,6 +146,25 @@ func renderInitializeSuccess(
 			); err != nil {
 				return err
 			}
+		case string(systeminitialization.PackagedFactoryCurrent):
+			if _, err := fmt.Fprintf(
+				cfg.Output,
+				"Packaged factory %s is current at %s\n",
+				factory.Name,
+				factory.FactoryDir,
+			); err != nil {
+				return err
+			}
+		case string(systeminitialization.PackagedFactoryRefreshed), string(systeminitialization.PackagedFactoryCustomerModified):
+			if _, err := fmt.Fprintf(
+				cfg.Output,
+				"Refreshed packaged factory %s\nDirectory: %s\nPrevious content backup: %s\n",
+				factory.Name,
+				factory.FactoryDir,
+				factory.BackupDir,
+			); err != nil {
+				return err
+			}
 		default:
 			if _, err := fmt.Fprintf(
 				cfg.Output,
@@ -182,6 +202,7 @@ func initializeResultPayload(result systeminitialization.Result) InitializeResul
 			Name:       factory.Name,
 			FactoryDir: factory.FactoryDir,
 			Outcome:    string(factory.Outcome),
+			BackupDir:  factory.BackupDir,
 		})
 	}
 	return InitializeResult{

--- a/pkg/services/system_initialization/transports/cli/service_parity_test.go
+++ b/pkg/services/system_initialization/transports/cli/service_parity_test.go
@@ -36,6 +36,7 @@ func TestConstructedService_InitializeHumanOutcomesMatchPackageCommand(t *testin
 		name                string
 		systemConfigOutcome systeminitialization.SystemConfigOutcome
 		factoryOutcome      systeminitialization.PackagedFactoryOutcome
+		backupDir           string
 		wantContains        []string
 	}{
 		{
@@ -58,6 +59,26 @@ func TestConstructedService_InitializeHumanOutcomesMatchPackageCommand(t *testin
 				"Packaged factory @you/goal is already installed at " + factoryDir,
 			},
 		},
+		{
+			name:                "current",
+			systemConfigOutcome: systeminitialization.SystemConfigSkipped,
+			factoryOutcome:      systeminitialization.PackagedFactoryCurrent,
+			wantContains: []string{
+				"Operator config already present at " + configPath,
+				"Packaged factory @you/goal is current at " + factoryDir,
+			},
+		},
+		{
+			name:                "refreshed",
+			systemConfigOutcome: systeminitialization.SystemConfigSkipped,
+			factoryOutcome:      systeminitialization.PackagedFactoryRefreshed,
+			backupDir:           "/home/operator/.you-agent-factory/factories/.you-packaged-backups/goal",
+			wantContains: []string{
+				"Operator config already present at " + configPath,
+				"Refreshed packaged factory @you/goal",
+				"Previous content backup: /home/operator/.you-agent-factory/factories/.you-packaged-backups/goal",
+			},
+		},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -75,6 +96,7 @@ func TestConstructedService_InitializeHumanOutcomesMatchPackageCommand(t *testin
 							Name:       "@you/goal",
 							FactoryDir: factoryDir,
 							Outcome:    tc.factoryOutcome,
+							BackupDir:  tc.backupDir,
 						},
 					},
 				},
@@ -111,6 +133,7 @@ func TestConstructedService_InitializeJSONOutcomesMatchPackageCommand(t *testing
 		name                string
 		systemConfigOutcome systeminitialization.SystemConfigOutcome
 		factoryOutcome      systeminitialization.PackagedFactoryOutcome
+		backupDir           string
 	}{
 		{
 			name:                "created",
@@ -121,6 +144,17 @@ func TestConstructedService_InitializeJSONOutcomesMatchPackageCommand(t *testing
 			name:                "skipped",
 			systemConfigOutcome: systeminitialization.SystemConfigSkipped,
 			factoryOutcome:      systeminitialization.PackagedFactorySkipped,
+		},
+		{
+			name:                "current",
+			systemConfigOutcome: systeminitialization.SystemConfigSkipped,
+			factoryOutcome:      systeminitialization.PackagedFactoryCurrent,
+		},
+		{
+			name:                "refreshed",
+			systemConfigOutcome: systeminitialization.SystemConfigSkipped,
+			factoryOutcome:      systeminitialization.PackagedFactoryRefreshed,
+			backupDir:           "/home/operator/.you-agent-factory/factories/.you-packaged-backups/goal",
 		},
 	}
 	for _, tc := range cases {
@@ -139,6 +173,7 @@ func TestConstructedService_InitializeJSONOutcomesMatchPackageCommand(t *testing
 							Name:       "@you/goal",
 							FactoryDir: factoryDir,
 							Outcome:    tc.factoryOutcome,
+							BackupDir:  tc.backupDir,
 						},
 					},
 				},
@@ -169,7 +204,8 @@ func TestConstructedService_InitializeJSONOutcomesMatchPackageCommand(t *testing
 			if len(payload.PackagedFactories) != 1 ||
 				payload.PackagedFactories[0].Name != "@you/goal" ||
 				payload.PackagedFactories[0].FactoryDir != factoryDir ||
-				payload.PackagedFactories[0].Outcome != string(tc.factoryOutcome) {
+				payload.PackagedFactories[0].Outcome != string(tc.factoryOutcome) ||
+				payload.PackagedFactories[0].BackupDir != tc.backupDir {
 				t.Fatalf("packaged factories = %#v, want retained JSON fields", payload.PackagedFactories)
 			}
 		})

--- a/pkg/services/system_initialization/transports/cli/service_test.go
+++ b/pkg/services/system_initialization/transports/cli/service_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	systeminitialization "github.com/portpowered/infinite-you/pkg/services/system_initialization"
@@ -235,6 +236,49 @@ func TestInitializeSystemFacadePreservesExitErrors(t *testing.T) {
 	if !errors.Is(err, systeminitialization.ErrMissingHomeDir) {
 		t.Fatalf("InitializeSystem() error = %v, want ErrMissingHomeDir", err)
 	}
+}
+
+func TestInitializeHumanRenderingPreservesOutputErrorsForEachFactoryOutcome(t *testing.T) {
+	t.Parallel()
+
+	for _, outcome := range []systeminitialization.PackagedFactoryOutcome{
+		systeminitialization.PackagedFactoryCreated,
+		systeminitialization.PackagedFactorySkipped,
+		systeminitialization.PackagedFactoryCurrent,
+		systeminitialization.PackagedFactoryRefreshed,
+	} {
+		outcome := outcome
+		t.Run(string(outcome), func(t *testing.T) {
+			t.Parallel()
+			root := &fakeBootstrapRoot{
+				result: systeminitialization.Result{
+					ConfigPath:          "/home/operator/.you-agent-factory/config.json",
+					NamedFactoriesRoot:  "/home/operator/.you-agent-factory/factories",
+					SystemConfigOutcome: systeminitialization.SystemConfigCreated,
+					PackagedFactories: []systeminitialization.PackagedFactoryResult{{
+						Name:       "@you/goal",
+						FactoryDir: "/home/operator/.you-agent-factory/factories/@you/goal",
+						Outcome:    outcome,
+						BackupDir:  "/home/operator/.you-agent-factory/factories/.you-packaged-backups/goal",
+					}},
+				},
+			}
+			_, err := systeminitializationcli.Initialize(systeminitializationcli.InitializeConfig{
+				Context: context.Background(),
+				HomeDir: "/home/operator",
+				Output:  initializeErrorWriter{},
+			}, root)
+			if err == nil || !strings.Contains(err.Error(), "initialize output unavailable") {
+				t.Fatalf("Initialize(%s) error = %v, want output error", outcome, err)
+			}
+		})
+	}
+}
+
+type initializeErrorWriter struct{}
+
+func (initializeErrorWriter) Write([]byte) (int, error) {
+	return 0, errors.New("initialize output unavailable")
 }
 
 type fakeBootstrapRoot struct {

--- a/pkg/wire/system_initialization_composition_test.go
+++ b/pkg/wire/system_initialization_composition_test.go
@@ -101,7 +101,7 @@ func bootstrapCompositionGoalCatalog(t *testing.T) factorydefinitions.PackagedFa
 	return packagedCatalog
 }
 
-func TestProvideSystemInitializationServiceComposedInitializeCreatesThenSkipsPackagedFactories(t *testing.T) {
+func TestProvideSystemInitializationServiceComposedInitializeCreatesThenReportsCurrentPackagedFactories(t *testing.T) {
 	t.Parallel()
 
 	edges := serviceedges.Edges{}
@@ -167,7 +167,7 @@ func TestProvideSystemInitializationServiceComposedInitializeCreatesThenSkipsPac
 	}
 	if len(second.PackagedFactories) != 1 ||
 		second.PackagedFactories[0].Name != "@you/goal" ||
-		second.PackagedFactories[0].Outcome != systeminitialization.PackagedFactorySkipped {
-		t.Fatalf("second packaged factories = %#v, want one skipped @you/goal", second.PackagedFactories)
+		second.PackagedFactories[0].Outcome != systeminitialization.PackagedFactoryCurrent {
+		t.Fatalf("second packaged factories = %#v, want one current @you/goal", second.PackagedFactories)
 	}
 }

--- a/tests/functional/cli/named_invocation/named_invocation_test.go
+++ b/tests/functional/cli/named_invocation/named_invocation_test.go
@@ -33,6 +33,7 @@ const (
 	packagedSubagentWorkerName          = "subagent-worker"
 	packagedSubagentRunWorkstationName  = "run-subagent"
 	packagedFactoryBuilderName          = "@you/factory-builder"
+	customizedNamedGoalFactoryName      = "@test/goal"
 	wantHermeticInvocationPrimaryResult = "mock worker accepted"
 )
 
@@ -174,6 +175,8 @@ func TestRun_NamedAndExplicitNoSignatureFactoriesPreserveCompatibilityInputs(t *
 	)
 	factoryPath := filepath.Join(factoryDir, "factory.json")
 	support.RemoveInvocationSignatureFixture(t, factoryPath)
+	factoryDir = support.CopyFactoryAsNamed(t, factoryDir, homeDir, customizedNamedGoalFactoryName)
+	factoryPath = filepath.Join(factoryDir, "factory.json")
 	mockWorkersPath := writeMockWorkersConfig(t, workers.MockWorkersConfig{
 		UnmatchedDispatchPolicy: workers.MockWorkerUnmatchedDispatchPolicyPassthrough,
 		MockWorkers: []workers.MockWorkerConfig{{
@@ -199,7 +202,7 @@ func TestRun_NamedAndExplicitNoSignatureFactoriesPreserveCompatibilityInputs(t *
 		t.Run(test.name, func(t *testing.T) {
 			namedStdout, namedStderr := executeCustomerCommandWithStdin(
 				t, process, environment, workingDirectory,
-				append(append([]string{"you", "run", "--named", packagedGoalFactoryName}, base...), test.input...),
+				append(append([]string{"you", "run", "--named", customizedNamedGoalFactoryName}, base...), test.input...),
 				test.stdin,
 			)
 			fileStdout, fileStderr := executeCustomerCommandWithStdin(
@@ -244,6 +247,8 @@ func TestRun_NamedAndExplicitFactorySelectionsExecuteEquivalentEffectiveSignatur
 	factoryPath := filepath.Join(factoryDir, "factory.json")
 	addEffectiveSignatureFixture(t, factoryPath)
 	support.ReplaceGoalWorkstationPrompt(t, factoryPath, "input=${input}|format=${format}|count=${count}|document=${document}|stdin=${body}")
+	factoryDir = support.CopyFactoryAsNamed(t, factoryDir, homeDir, customizedNamedGoalFactoryName)
+	factoryPath = filepath.Join(factoryDir, "factory.json")
 	documentPath := filepath.Join(workingDirectory, "story.md")
 	if err := os.WriteFile(documentPath, []byte("factory invocation document"), 0o600); err != nil {
 		t.Fatalf("write FILE_CONTENTS fixture: %v", err)
@@ -258,7 +263,7 @@ func TestRun_NamedAndExplicitFactorySelectionsExecuteEquivalentEffectiveSignatur
 	}
 	namedStdout, namedStderr := executeCustomerCommandWithStdin(
 		t, process, environment, workingDirectory,
-		append([]string{"you", "run", "--named", packagedGoalFactoryName}, common...),
+		append([]string{"you", "run", "--named", customizedNamedGoalFactoryName}, common...),
 		"canonical stdin body",
 	)
 	fileStdout, fileStderr := executeCustomerCommandWithStdin(
@@ -439,13 +444,15 @@ func runEmptyDefaultInvocationCase(t *testing.T, selection string) {
 	})
 	support.ReplaceGoalWorkerInstructions(t, factoryPath, "mode=${mode}")
 	support.ReplaceGoalWorkstationPrompt(t, factoryPath, "mode=${mode}")
+	factoryDir = support.CopyFactoryAsNamed(t, factoryDir, homeDir, customizedNamedGoalFactoryName)
+	factoryPath = filepath.Join(factoryDir, "factory.json")
 
 	stdout, stderr := executeCustomerCommand(
 		t,
 		process,
 		environment,
 		workingDirectory,
-		emptyInvocationArguments(selection, factoryPath),
+		emptyInvocationArguments(selection, factoryPath, customizedNamedGoalFactoryName),
 	)
 	if stdout == "" {
 		t.Fatalf("default-only invocation output: stdout=%q stderr=%q", stdout, stderr)
@@ -501,13 +508,15 @@ func runEmptyPreparationFailureCase(
 	)
 	factoryPath := filepath.Join(factoryDir, "factory.json")
 	replaceInvocationSignatureFixture(t, factoryPath, signature)
+	factoryDir = support.CopyFactoryAsNamed(t, factoryDir, homeDir, customizedNamedGoalFactoryName)
+	factoryPath = filepath.Join(factoryDir, "factory.json")
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	stdinIsTTY := true
 	stdoutIsTTY := false
 	err = process.Execute(root.Input{
-		Args:             emptyInvocationArguments(selection, factoryPath),
+		Args:             emptyInvocationArguments(selection, factoryPath, customizedNamedGoalFactoryName),
 		Env:              environment,
 		Stdin:            strings.NewReader(""),
 		Stdout:           &stdout,
@@ -523,9 +532,9 @@ func runEmptyPreparationFailureCase(
 	observation.assertNoExecution(t, provider.CallCount())
 }
 
-func emptyInvocationArguments(selection, factoryPath string) []string {
+func emptyInvocationArguments(selection, factoryPath, factoryName string) []string {
 	if selection == "named" {
-		return []string{"you", "run", "--named", packagedGoalFactoryName, "--no-record"}
+		return []string{"you", "run", "--named", factoryName, "--no-record"}
 	}
 	return []string{"you", "run", "--factory", factoryPath, "--no-record"}
 }

--- a/tests/functional/factory/packaged/deep_research/invocation_test.go
+++ b/tests/functional/factory/packaged/deep_research/invocation_test.go
@@ -28,6 +28,112 @@ import (
 // definition is deliberately written after the first initialization, so the
 // second Process.Execute must reconcile it before named-command composition.
 func TestPackagedDeepResearchStaleNamedInvocationRefreshesThroughCustomerProcess(t *testing.T) {
+	fixture := prepareStaleDeepResearchFixture(t)
+	assertDeepResearchExternalNames(t, fixture.stalePayload, "model-provider", "model", "researchDepth", "maxSubagents")
+
+	commandArgs := []string{
+		"you", "run", "--named", factorydefinitions.PackagedDeepResearchFactoryName,
+		"--maxSubagents", "0", "What is a Petri net?",
+	}
+	inputs := support.FakeInputs(t.Context(), commandArgs)
+	inputs.Input.Env = fixture.environment
+	inputs.Input.WorkingDirectory = fixture.workingDirectory
+	invocationErr := fixture.process.Execute(inputs.Input)
+	if invocationErr != nil && strings.Contains(invocationErr.Error(), "cli.composition.long-name-collision") {
+		t.Fatalf(
+			"refreshed named deep-research invocation still returned the stale composition collision: %v\nstdout:\n%s\nstderr:\n%s",
+			invocationErr,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+
+	activePayload, err := os.ReadFile(fixture.factoryPath)
+	if err != nil {
+		t.Fatalf("read refreshed deep-research materialization: %v", err)
+	}
+	assertDeepResearchExternalNames(t, activePayload, "research-model-provider", "research-model", "research-depth", "max-subagents")
+	assertDeepResearchExternalNamesAbsent(t, activePayload, "model-provider", "model", "researchDepth", "maxSubagents")
+
+	backupRoot := filepath.Join(filepath.Dir(filepath.Dir(fixture.factoryDir)), ".you-packaged-backups")
+	backupEntries, err := os.ReadDir(backupRoot)
+	if err != nil {
+		t.Fatalf("read packaged Factory backup root %s: %v", backupRoot, err)
+	}
+	var backupDirs []string
+	for _, entry := range backupEntries {
+		if entry.IsDir() {
+			backupDirs = append(backupDirs, filepath.Join(backupRoot, entry.Name()))
+		}
+	}
+	if len(backupDirs) != 1 {
+		t.Fatalf("packaged Factory backup directories = %v, want exactly one preserved prior copy", backupDirs)
+	}
+	backupPayload, err := os.ReadFile(filepath.Join(backupDirs[0], factorydefinitions.FactoryConfigFile))
+	if err != nil {
+		t.Fatalf("read preserved stale deep-research backup: %v", err)
+	}
+	if !bytes.Equal(backupPayload, fixture.stalePayload) {
+		t.Fatalf("preserved stale backup differs from the complete pre-refresh factory.json")
+	}
+	if filepath.Clean(backupDirs[0]) == filepath.Clean(fixture.factoryDir) {
+		t.Fatalf("backup path %s is still the active Factory path", backupDirs[0])
+	}
+	structuredArgs := []string{
+		"you", "--json", "run", "--named", factorydefinitions.PackagedDeepResearchFactoryName,
+		"--maxSubagents", "0", "What is a Petri net?",
+	}
+	structuredInputs := support.FakeInputs(t.Context(), structuredArgs)
+	structuredInputs.Input.Env = fixture.environment
+	structuredInputs.Input.WorkingDirectory = fixture.workingDirectory
+	if err := fixture.process.Execute(structuredInputs.Input); err != nil {
+		t.Fatalf(
+			"structured refreshed named deep-research invocation error = %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			structuredInputs.Stdout(),
+			structuredInputs.Stderr(),
+		)
+	}
+	structuredResponse := support.DecodeInvocationResponseJSON(t, structuredInputs.Stdout())
+	if structuredResponse.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("structured refreshed invocation status = %q, want COMPLETED", structuredResponse.Status)
+	}
+	if fixture.provider.CallCount() != 2 {
+		t.Fatalf("provider calls = %d, want one lead synthesis for each command after --maxSubagents 0", fixture.provider.CallCount())
+	}
+	request := fixture.provider.LastRequest()
+	if request.Command != "codex" {
+		t.Fatalf("provider command = %q, want codex", request.Command)
+	}
+	if !strings.Contains(string(request.Stdin), "What is a Petri net?") {
+		t.Fatalf("provider prompt = %q, want the exact customer topic", string(request.Stdin))
+	}
+	t.Logf(
+		"customer command %q refreshed %s and reached provider; backup=%s; invocation_error=%v; stdout=%q; stderr=%q; structured_command=%q; structured_status=%q; structured_provider_result=%t",
+		strings.Join(commandArgs, " "),
+		fixture.factoryPath,
+		backupDirs[0],
+		invocationErr,
+		inputs.Stdout(),
+		inputs.Stderr(),
+		strings.Join(structuredArgs, " "),
+		structuredResponse.Status,
+		strings.Contains(structuredInputs.Stdout(), "deep research provider reached"),
+	)
+}
+
+type staleDeepResearchFixture struct {
+	process          support.Process
+	provider         *testutil.ProviderCommandRunner
+	environment      []string
+	workingDirectory string
+	factoryDir       string
+	factoryPath      string
+	stalePayload     []byte
+}
+
+func prepareStaleDeepResearchFixture(t *testing.T) staleDeepResearchFixture {
+	t.Helper()
 	homeDir := t.TempDir()
 	workingDirectory := t.TempDir()
 	providerResult := platformprocess.CommandResult{
@@ -58,97 +164,15 @@ func TestPackagedDeepResearchStaleNamedInvocationRefreshesThroughCustomerProcess
 	if err := os.WriteFile(factoryPath, stalePayload, 0o600); err != nil {
 		t.Fatalf("write stale deep-research materialization: %v", err)
 	}
-	assertDeepResearchExternalNames(t, stalePayload, "model-provider", "model", "researchDepth", "maxSubagents")
-
-	commandArgs := []string{
-		"you", "run", "--named", factorydefinitions.PackagedDeepResearchFactoryName,
-		"--maxSubagents", "0", "What is a Petri net?",
+	return staleDeepResearchFixture{
+		process:          process,
+		provider:         provider,
+		environment:      environment,
+		workingDirectory: workingDirectory,
+		factoryDir:       factoryDir,
+		factoryPath:      factoryPath,
+		stalePayload:     stalePayload,
 	}
-	inputs := support.FakeInputs(t.Context(), commandArgs)
-	inputs.Input.Env = environment
-	inputs.Input.WorkingDirectory = workingDirectory
-	invocationErr := process.Execute(inputs.Input)
-	if invocationErr != nil && strings.Contains(invocationErr.Error(), "cli.composition.long-name-collision") {
-		t.Fatalf(
-			"refreshed named deep-research invocation still returned the stale composition collision: %v\nstdout:\n%s\nstderr:\n%s",
-			invocationErr,
-			inputs.Stdout(),
-			inputs.Stderr(),
-		)
-	}
-
-	activePayload, err := os.ReadFile(factoryPath)
-	if err != nil {
-		t.Fatalf("read refreshed deep-research materialization: %v", err)
-	}
-	assertDeepResearchExternalNames(t, activePayload, "research-model-provider", "research-model", "research-depth", "max-subagents")
-	assertDeepResearchExternalNamesAbsent(t, activePayload, "model-provider", "model", "researchDepth", "maxSubagents")
-
-	backupRoot := filepath.Join(filepath.Dir(filepath.Dir(factoryDir)), ".you-packaged-backups")
-	backupEntries, err := os.ReadDir(backupRoot)
-	if err != nil {
-		t.Fatalf("read packaged Factory backup root %s: %v", backupRoot, err)
-	}
-	var backupDirs []string
-	for _, entry := range backupEntries {
-		if entry.IsDir() {
-			backupDirs = append(backupDirs, filepath.Join(backupRoot, entry.Name()))
-		}
-	}
-	if len(backupDirs) != 1 {
-		t.Fatalf("packaged Factory backup directories = %v, want exactly one preserved prior copy", backupDirs)
-	}
-	backupPayload, err := os.ReadFile(filepath.Join(backupDirs[0], factorydefinitions.FactoryConfigFile))
-	if err != nil {
-		t.Fatalf("read preserved stale deep-research backup: %v", err)
-	}
-	if !bytes.Equal(backupPayload, stalePayload) {
-		t.Fatalf("preserved stale backup differs from the complete pre-refresh factory.json")
-	}
-	if filepath.Clean(backupDirs[0]) == filepath.Clean(factoryDir) {
-		t.Fatalf("backup path %s is still the active Factory path", backupDirs[0])
-	}
-	structuredArgs := []string{
-		"you", "--json", "run", "--named", factorydefinitions.PackagedDeepResearchFactoryName,
-		"--maxSubagents", "0", "What is a Petri net?",
-	}
-	structuredInputs := support.FakeInputs(t.Context(), structuredArgs)
-	structuredInputs.Input.Env = environment
-	structuredInputs.Input.WorkingDirectory = workingDirectory
-	if err := process.Execute(structuredInputs.Input); err != nil {
-		t.Fatalf(
-			"structured refreshed named deep-research invocation error = %v\nstdout:\n%s\nstderr:\n%s",
-			err,
-			structuredInputs.Stdout(),
-			structuredInputs.Stderr(),
-		)
-	}
-	structuredResponse := support.DecodeInvocationResponseJSON(t, structuredInputs.Stdout())
-	if structuredResponse.Status != factoryapi.InvocationTerminalStatusCompleted {
-		t.Fatalf("structured refreshed invocation status = %q, want COMPLETED", structuredResponse.Status)
-	}
-	if provider.CallCount() != 2 {
-		t.Fatalf("provider calls = %d, want one lead synthesis for each command after --maxSubagents 0", provider.CallCount())
-	}
-	request := provider.LastRequest()
-	if request.Command != "codex" {
-		t.Fatalf("provider command = %q, want codex", request.Command)
-	}
-	if !strings.Contains(string(request.Stdin), "What is a Petri net?") {
-		t.Fatalf("provider prompt = %q, want the exact customer topic", string(request.Stdin))
-	}
-	t.Logf(
-		"customer command %q refreshed %s and reached provider; backup=%s; invocation_error=%v; stdout=%q; stderr=%q; structured_command=%q; structured_status=%q; structured_provider_result=%t",
-		strings.Join(commandArgs, " "),
-		factoryPath,
-		backupDirs[0],
-		invocationErr,
-		inputs.Stdout(),
-		inputs.Stderr(),
-		strings.Join(structuredArgs, " "),
-		structuredResponse.Status,
-		strings.Contains(structuredInputs.Stdout(), "deep research provider reached"),
-	)
 }
 
 func deepResearchCustomerEnvironment(homeDir string) []string {

--- a/tests/functional/factory/packaged/deep_research/invocation_test.go
+++ b/tests/functional/factory/packaged/deep_research/invocation_test.go
@@ -7,17 +7,203 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/portpowered/infinite-you/internal/testutil"
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	"github.com/portpowered/infinite-you/pkg/root"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
+
+// TestPackagedDeepResearchStaleNamedInvocationRefreshesThroughCustomerProcess
+// proves the automatic upgrade route at the customer boundary. The stale
+// definition is deliberately written after the first initialization, so the
+// second Process.Execute must reconcile it before named-command composition.
+func TestPackagedDeepResearchStaleNamedInvocationRefreshesThroughCustomerProcess(t *testing.T) {
+	homeDir := t.TempDir()
+	workingDirectory := t.TempDir()
+	providerResult := platformprocess.CommandResult{
+		Stdout: support.CodexSuccessStdout("deep research provider reached"),
+	}
+	provider := testutil.NewProviderCommandRunner(providerResult, providerResult)
+	process, err := root.BuildProcess(t.Context(), serviceedges.Edges{
+		ProviderCommandRunner: provider,
+	})
+	if err != nil {
+		t.Fatalf("root.BuildProcess() error = %v", err)
+	}
+	support.CleanupProcess(t, process)
+	environment := deepResearchCustomerEnvironment(homeDir)
+	factoryDir := support.InstallPackagedFactoryWithProcess(
+		t,
+		process,
+		environment,
+		workingDirectory,
+		factorydefinitions.PackagedDeepResearchFactoryName,
+	)
+	factoryPath := filepath.Join(factoryDir, factorydefinitions.FactoryConfigFile)
+	currentPayload, err := os.ReadFile(factoryPath)
+	if err != nil {
+		t.Fatalf("read current deep-research materialization: %v", err)
+	}
+	stalePayload := staleDeepResearchPayload(currentPayload)
+	if err := os.WriteFile(factoryPath, stalePayload, 0o600); err != nil {
+		t.Fatalf("write stale deep-research materialization: %v", err)
+	}
+	assertDeepResearchExternalNames(t, stalePayload, "model-provider", "model", "researchDepth", "maxSubagents")
+
+	commandArgs := []string{
+		"you", "run", "--named", factorydefinitions.PackagedDeepResearchFactoryName,
+		"--maxSubagents", "0", "What is a Petri net?",
+	}
+	inputs := support.FakeInputs(t.Context(), commandArgs)
+	inputs.Input.Env = environment
+	inputs.Input.WorkingDirectory = workingDirectory
+	invocationErr := process.Execute(inputs.Input)
+	if invocationErr != nil && strings.Contains(invocationErr.Error(), "cli.composition.long-name-collision") {
+		t.Fatalf(
+			"refreshed named deep-research invocation still returned the stale composition collision: %v\nstdout:\n%s\nstderr:\n%s",
+			invocationErr,
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+
+	activePayload, err := os.ReadFile(factoryPath)
+	if err != nil {
+		t.Fatalf("read refreshed deep-research materialization: %v", err)
+	}
+	assertDeepResearchExternalNames(t, activePayload, "research-model-provider", "research-model", "research-depth", "max-subagents")
+	assertDeepResearchExternalNamesAbsent(t, activePayload, "model-provider", "model", "researchDepth", "maxSubagents")
+
+	backupRoot := filepath.Join(filepath.Dir(filepath.Dir(factoryDir)), ".you-packaged-backups")
+	backupEntries, err := os.ReadDir(backupRoot)
+	if err != nil {
+		t.Fatalf("read packaged Factory backup root %s: %v", backupRoot, err)
+	}
+	var backupDirs []string
+	for _, entry := range backupEntries {
+		if entry.IsDir() {
+			backupDirs = append(backupDirs, filepath.Join(backupRoot, entry.Name()))
+		}
+	}
+	if len(backupDirs) != 1 {
+		t.Fatalf("packaged Factory backup directories = %v, want exactly one preserved prior copy", backupDirs)
+	}
+	backupPayload, err := os.ReadFile(filepath.Join(backupDirs[0], factorydefinitions.FactoryConfigFile))
+	if err != nil {
+		t.Fatalf("read preserved stale deep-research backup: %v", err)
+	}
+	if !bytes.Equal(backupPayload, stalePayload) {
+		t.Fatalf("preserved stale backup differs from the complete pre-refresh factory.json")
+	}
+	if filepath.Clean(backupDirs[0]) == filepath.Clean(factoryDir) {
+		t.Fatalf("backup path %s is still the active Factory path", backupDirs[0])
+	}
+	structuredArgs := []string{
+		"you", "--json", "run", "--named", factorydefinitions.PackagedDeepResearchFactoryName,
+		"--maxSubagents", "0", "What is a Petri net?",
+	}
+	structuredInputs := support.FakeInputs(t.Context(), structuredArgs)
+	structuredInputs.Input.Env = environment
+	structuredInputs.Input.WorkingDirectory = workingDirectory
+	if err := process.Execute(structuredInputs.Input); err != nil {
+		t.Fatalf(
+			"structured refreshed named deep-research invocation error = %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			structuredInputs.Stdout(),
+			structuredInputs.Stderr(),
+		)
+	}
+	structuredResponse := support.DecodeInvocationResponseJSON(t, structuredInputs.Stdout())
+	if structuredResponse.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("structured refreshed invocation status = %q, want COMPLETED", structuredResponse.Status)
+	}
+	if provider.CallCount() != 2 {
+		t.Fatalf("provider calls = %d, want one lead synthesis for each command after --maxSubagents 0", provider.CallCount())
+	}
+	request := provider.LastRequest()
+	if request.Command != "codex" {
+		t.Fatalf("provider command = %q, want codex", request.Command)
+	}
+	if !strings.Contains(string(request.Stdin), "What is a Petri net?") {
+		t.Fatalf("provider prompt = %q, want the exact customer topic", string(request.Stdin))
+	}
+	t.Logf(
+		"customer command %q refreshed %s and reached provider; backup=%s; invocation_error=%v; stdout=%q; stderr=%q; structured_command=%q; structured_status=%q; structured_provider_result=%t",
+		strings.Join(commandArgs, " "),
+		factoryPath,
+		backupDirs[0],
+		invocationErr,
+		inputs.Stdout(),
+		inputs.Stderr(),
+		strings.Join(structuredArgs, " "),
+		structuredResponse.Status,
+		strings.Contains(structuredInputs.Stdout(), "deep research provider reached"),
+	)
+}
+
+func deepResearchCustomerEnvironment(homeDir string) []string {
+	environment := make([]string, 0, len(os.Environ())+4)
+	for _, entry := range os.Environ() {
+		name := strings.SplitN(entry, "=", 2)[0]
+		switch {
+		case strings.EqualFold(name, "HOME"), strings.EqualFold(name, "USERPROFILE"),
+			strings.EqualFold(name, "YOU_DEFAULT_WORKER_MODEL_PROVIDER"), strings.EqualFold(name, "YOU_DEFAULT_WORKER_MODEL"):
+			continue
+		default:
+			environment = append(environment, entry)
+		}
+	}
+	return append(
+		environment,
+		"HOME="+homeDir,
+		"USERPROFILE="+homeDir,
+		"YOU_DEFAULT_WORKER_MODEL_PROVIDER=CODEX",
+		"YOU_DEFAULT_WORKER_MODEL=gpt-5",
+	)
+}
+
+func staleDeepResearchPayload(currentPayload []byte) []byte {
+	stalePayload := append([]byte(nil), currentPayload...)
+	for _, replacement := range []struct{ current, stale string }{
+		{current: "research-model-provider", stale: "model-provider"},
+		{current: "research-model", stale: "model"},
+		{current: "research-depth", stale: "researchDepth"},
+		{current: "max-subagents", stale: "maxSubagents"},
+	} {
+		stalePayload = bytes.ReplaceAll(stalePayload, []byte(replacement.current), []byte(replacement.stale))
+	}
+	return stalePayload
+}
+
+func assertDeepResearchExternalNames(t testing.TB, payload []byte, names ...string) {
+	t.Helper()
+	content := string(payload)
+	for _, name := range names {
+		if !strings.Contains(content, `"externalName": "`+name+`"`) {
+			t.Fatalf("definition is missing externalName %q", name)
+		}
+	}
+}
+
+func assertDeepResearchExternalNamesAbsent(t testing.TB, payload []byte, names ...string) {
+	t.Helper()
+	content := string(payload)
+	for _, name := range names {
+		if strings.Contains(content, `"externalName": "`+name+`"`) {
+			t.Fatalf("definition still contains stale externalName %q", name)
+		}
+	}
+}
 
 // TestPackagedDeepResearchRequiredInputCompletes proves that invoking the
 // packaged @you/deep-research Factory with only the required research topic

--- a/tests/functional/factory/packaged/fix/invocation_test.go
+++ b/tests/functional/factory/packaged/fix/invocation_test.go
@@ -20,7 +20,10 @@ import (
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
-const packagedFixFactoryName = "@you/fix"
+const (
+	packagedFixFactoryName           = "@you/fix"
+	configuredPackagedFixFactoryName = "@test/fix"
+)
 
 var packagedFixPlanFile = regexp.MustCompile(`tasks/todo/([A-Za-z0-9._-]+)\.json`)
 
@@ -377,11 +380,14 @@ func runPackagedFixCLIWithFactorySetup(
 	t.Helper()
 	home := t.TempDir()
 	factoryDir := support.InstallPackagedFactory(t, home, packagedFixFactoryName)
+	factoryName := packagedFixFactoryName
 	if configure != nil {
 		configure(t, factoryDir)
+		factoryDir = support.CopyFactoryAsNamed(t, factoryDir, home, configuredPackagedFixFactoryName)
+		factoryName = configuredPackagedFixFactoryName
 	}
 	inputArgs := []string{
-		"you", "--json", "run", "--named", packagedFixFactoryName, "--no-record",
+		"you", "--json", "run", "--named", factoryName, "--no-record",
 	}
 	inputArgs = append(inputArgs, args...)
 	inputs := support.FakeInputs(t.Context(), inputArgs)

--- a/tests/functional/factory/packaged/goal/invocation_interpolation_test.go
+++ b/tests/functional/factory/packaged/goal/invocation_interpolation_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
+const customizedPackagedGoalFactoryName = "@test/goal"
+
 // TestPackagedGoalInterpolationFailureStopsBeforeProviderExecution proves an
 // omitted definition variable fails in Factory Definitions before provider
 // selection for both named and explicit-file packaged goal invocation.
@@ -31,13 +33,15 @@ func TestPackagedGoalInterpolationFailureStopsBeforeProviderExecution(t *testing
 	)
 	factoryPath := filepath.Join(factoryDir, "factory.json")
 	configureMissingInterpolationFactory(t, factoryPath)
+	factoryDir = support.CopyFactoryAsNamed(t, factoryDir, homeDir, customizedPackagedGoalFactoryName)
+	factoryPath = filepath.Join(factoryDir, "factory.json")
 
 	for _, selection := range []string{"named", "file"} {
 		var stdout, stderr bytes.Buffer
 		stdinIsTTY := true
 		stdoutIsTTY := false
 		err := process.Execute(root.Input{
-			Args:             packagedGoalInterpolationFailureArguments(selection, factoryPath),
+			Args:             packagedGoalInterpolationFailureArguments(selection, factoryPath, customizedPackagedGoalFactoryName),
 			Env:              environment,
 			Stdin:            strings.NewReader(""),
 			Stdout:           &stdout,
@@ -98,10 +102,10 @@ func configureMissingInterpolationFactory(t *testing.T, factoryPath string) {
 	support.ReplaceGoalWorkerInstructions(t, factoryPath, "input=${input}|missing=${missing}")
 }
 
-func packagedGoalInterpolationFailureArguments(selection, factoryPath string) []string {
+func packagedGoalInterpolationFailureArguments(selection, factoryPath, factoryName string) []string {
 	if selection == "named" {
 		return []string{
-			"you", "run", "--named", packagedGoalFactoryName,
+			"you", "run", "--named", factoryName,
 			"--no-record", "provided interpolation input",
 		}
 	}

--- a/tests/functional/factory/packaged/ralph/invocation_test.go
+++ b/tests/functional/factory/packaged/ralph/invocation_test.go
@@ -19,7 +19,10 @@ import (
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
-const packagedRalphFactoryName = "@you/ralph"
+const (
+	packagedRalphFactoryName           = "@you/ralph"
+	configuredPackagedRalphFactoryName = "@test/ralph"
+)
 
 var packagedRalphPlanFile = regexp.MustCompile(`tasks/todo/([A-Za-z0-9._-]+)\.json`)
 
@@ -162,16 +165,20 @@ func TestPackagedRalphUsesConfiguredAndRoleOverrideModels(t *testing.T) {
 			home := t.TempDir()
 			workspace := t.TempDir()
 			factoryDir := support.InstallPackagedFactory(t, home, packagedRalphFactoryName)
+			factoryName := packagedRalphFactoryName
 			if test.configure != nil {
 				test.configure(t, factoryDir)
+				factoryDir = support.CopyFactoryAsNamed(t, factoryDir, home, configuredPackagedRalphFactoryName)
+				factoryName = configuredPackagedRalphFactoryName
 			}
 			runner := &packagedRalphCommandRunner{workspace: workspace}
 
-			response, stderr, err := runPackagedRalphCLI(
+			response, stderr, err := runPackagedRalphCLIAs(
 				t,
 				runner,
 				home,
 				workspace,
+				factoryName,
 				append(test.args, "--to", "complete a configured Ralph request")...,
 			)
 			if err != nil {
@@ -360,8 +367,17 @@ func runPackagedRalphCLI(
 	home, workspace string,
 	args ...string,
 ) (factoryapi.InvocationResponse, string, error) {
+	return runPackagedRalphCLIAs(t, runner, home, workspace, packagedRalphFactoryName, args...)
+}
+
+func runPackagedRalphCLIAs(
+	t *testing.T,
+	runner platformprocess.CommandRunner,
+	home, workspace, factoryName string,
+	args ...string,
+) (factoryapi.InvocationResponse, string, error) {
 	t.Helper()
-	inputArgs := []string{"you", "--json", "run", "--named", packagedRalphFactoryName, "--no-record"}
+	inputArgs := []string{"you", "--json", "run", "--named", factoryName, "--no-record"}
 	inputArgs = append(inputArgs, args...)
 	inputs := support.FakeInputs(t.Context(), inputArgs)
 	inputs.Input.Env = append(os.Environ(), "HOME="+home, "USERPROFILE="+home)

--- a/tests/functional/factory/packaged/review/helpers_test.go
+++ b/tests/functional/factory/packaged/review/helpers_test.go
@@ -68,13 +68,16 @@ func runPackagedReviewCLIJSONInvocationWithFactorySetup(
 
 	homeDir := t.TempDir()
 	factoryDir := support.InstallPackagedFactory(t, homeDir, factorydefinitions.PackagedReviewFactoryName)
+	factoryName := factorydefinitions.PackagedReviewFactoryName
 	if configure != nil {
 		configure(t, factoryDir)
+		factoryDir = support.CopyFactoryAsNamed(t, factoryDir, homeDir, "@test/review")
+		factoryName = "@test/review"
 	}
 
 	args := []string{
 		"you", "--json", "run",
-		"--named", factorydefinitions.PackagedReviewFactoryName,
+		"--named", factoryName,
 		"--no-record",
 	}
 	args = append(args, extraArgs...)

--- a/tests/functional/factory/packaged/tts/invocation_test.go
+++ b/tests/functional/factory/packaged/tts/invocation_test.go
@@ -33,7 +33,9 @@ func TestPackagedTTSNoServerPromptUsesCanonicalInputContract(t *testing.T) {
 		homeDir,
 		factorydefinitions.PackagedTTSFactoryName,
 	)
+	factoryDir = support.CopyFactoryAsNamed(t, factoryDir, homeDir, "@test/tts")
 	overwritePackagedTTSFactoryWithCommandRunnerTopology(t, factoryDir)
+	factoryName := "@test/tts"
 	audioPath := filepath.Join(t.TempDir(), "packaged-tts-command-runner.wav")
 	if err := os.WriteFile(audioPath, []byte(packagedTTSFakeAudioFixture), 0o644); err != nil {
 		t.Fatalf("write command-runner audio fixture: %v", err)
@@ -50,7 +52,7 @@ func TestPackagedTTSNoServerPromptUsesCanonicalInputContract(t *testing.T) {
 	runner := support.NewShapedProviderCommandRunner(platformprocess.CommandResult{Stdout: audioContent})
 	inputs := support.FakeInputs(t.Context(), []string{
 		"you", "--json", "run",
-		"--named", factorydefinitions.PackagedTTSFactoryName,
+		"--named", factoryName,
 		"--no-record",
 		"--output", "primary",
 		"--to", text,

--- a/tests/functional/factory/packaged/tts/invocation_test.go
+++ b/tests/functional/factory/packaged/tts/invocation_test.go
@@ -109,6 +109,7 @@ func TestPackagedTTSRequiredInputProducesAudioArtifactMetadata(t *testing.T) {
 		homeDir,
 		factorydefinitions.PackagedTTSFactoryName,
 	)
+	factoryDir = support.CopyFactoryAsNamed(t, factoryDir, homeDir, "@test/tts")
 	overwritePackagedTTSFactoryWithProviderFakeTopology(t, factoryDir)
 
 	fakeProvider := newPackagedTTSFakeProvider([]byte(packagedTTSFakeAudioFixture))
@@ -724,6 +725,7 @@ func TestPackagedTTSOptionalVoiceAndFormatReachModel(t *testing.T) {
 		homeDir,
 		factorydefinitions.PackagedTTSFactoryName,
 	)
+	factoryDir = support.CopyFactoryAsNamed(t, factoryDir, homeDir, "@test/tts")
 	overwritePackagedTTSFactoryWithOptionalVoiceAndFormatTopology(t, factoryDir)
 
 	fakeProvider := newPackagedTTSFakeProvider([]byte(packagedTTSFakeAudioFixture))
@@ -780,6 +782,7 @@ func TestPackagedTTSModelFailureReturnsNoFalseArtifact(t *testing.T) {
 		homeDir,
 		factorydefinitions.PackagedTTSFactoryName,
 	)
+	factoryDir = support.CopyFactoryAsNamed(t, factoryDir, homeDir, "@test/tts")
 	overwritePackagedTTSFactoryWithProviderFakeTopology(t, factoryDir)
 
 	fakeProvider := newPackagedTTSFailingFakeProvider("omnivoice invoke failed: exit status 1")

--- a/tests/functional/internal/support/process.go
+++ b/tests/functional/internal/support/process.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -106,6 +107,48 @@ func InstallPackagedFactory(t testing.TB, homeDir, name string) string {
 		t.Fatalf("initializer omitted packaged Factory %q at %s: %v", name, factoryDir, err)
 	}
 	return factoryDir
+}
+
+// CopyFactoryAsNamed copies a customized fixture to a customer-owned named
+// Factory. Bundled @you directories are refreshed during every initialization,
+// so tests that intentionally edit a packaged payload must invoke the copy.
+func CopyFactoryAsNamed(t testing.TB, sourceDir, homeDir, name string) string {
+	t.Helper()
+	targetDir := filepath.Join(
+		append([]string{homeDir, ".you-agent-factory", "factories"}, strings.Split(name, "/")...)...,
+	)
+	if err := copyFactoryDirectory(sourceDir, targetDir); err != nil {
+		t.Fatalf("copy Factory fixture %q to %q: %v", sourceDir, targetDir, err)
+	}
+	return targetDir
+}
+
+func copyFactoryDirectory(sourceDir, targetDir string) error {
+	return filepath.WalkDir(sourceDir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return err
+		}
+		if relative == "." {
+			return os.MkdirAll(targetDir, 0o755)
+		}
+		targetPath := filepath.Join(targetDir, relative)
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return os.MkdirAll(targetPath, info.Mode().Perm())
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(targetPath, data, info.Mode().Perm())
+	})
 }
 
 // InstallPackagedFactoryWithProcess materializes a packaged Factory through a


### PR DESCRIPTION
{
  "project": "Refresh Stale Materialized Packaged Factories Safely",
  "branchName": "pkgf-materialized-factory-staleness",
  "description": "Make the Factory Definitions-owned packaged-installation lifecycle detect stale materialized @you Factories during the existing system-initialization ensure route, preserve every prior or customer-edited directory in a reported non-active backup, atomically activate the definition bundled with the running binary, and restore @you/deep-research invocation without changing authored Factories or CLI collision validation.",
  "context": {
    "customerAsk": "Repair packaged-Factory materialization so upgrading the binary automatically makes the bundled definition current without silently destroying editable user content. Measure the current blast radius across all 17 operator-materialized Factories, reproduce and record the @you/deep-research failure before changing behavior, prove the stale-file upgrade and successful invocation afterward, and add a regression test that fails without the fix.",
    "problem": "System initialization calls Factory Definitions EnsurePackagedFactories, but an existing valid same-format target is unconditionally skipped unless explicit replacement is requested. There is no published-content identity or installed-content evidence, so runtime resolution can indefinitely execute a weeks-old global materialization. The reported stale @you/deep-research copy exposes a bare --model input that collides with you run's static --model flag and makes every invocation fail with cli.composition.long-name-collision even though the authored and generated definitions are already correct.",
    "solution": "Add deterministic managed-installation evidence and reconciliation to the existing Definitions-owned ensure path. Equivalent content is left in place and stamped when needed. Stale, legacy-divergent, or customer-modified content is classified explicitly, completely preserved at a discoverable non-active backup path, and replaced atomically at the canonical @you name with the current binary payload. Clear customer/operator diagnostics and structured safe outcomes report what happened. This activates the upgraded definition automatically while keeping every prior editable copy recoverable."
  },
  "acceptanceCriteria": [
    "On the existing system-initialization/ensure route, every bundled @you Factory is compared with managed installation evidence; a stale or legacy-unstamped materialized copy is detected and the current definition from the running binary becomes active without a manual replace command.",
    "Before replacing any non-current active directory, the complete prior copy is preserved at a clearly reported, non-active backup path. A customer-modified stamped copy is explicitly identified, preserved, and replaced rather than silently discarded; an interrupted or failed refresh leaves a valid recoverable active or prior copy.",
    "With an isolated customer home and without restarting, killing, or reconfiguring the daemon on port 7437, the exact @you/deep-research command is recorded failing before the change and is recorded composing and running after the change; the PR also includes real output and before/after definition evidence showing the stale names replaced by the current invocation contract.",
    "The PR body reports a deterministic comparison of all 17 materialized Factories against the generated packaged counterparts, including the exact number that differ and enough per-Factory result detail to review the measured blast radius; it also explains the selected stamp/backup policy and why it preserves user edits.",
    "Factory Definitions remains the lifecycle owner; refresh uses its existing explicit filesystem/persistence effects and concurrency-safe staged publication, preserves system-initialization rollback/error behavior, and does not modify authored Factory definitions, the collision check, generated packaged-factory build policy, or the concurrently owned ralph and fix Factory directories.",
    "Quality gate: focused Factory Definitions unit/integration tests and a customer-route functional regression pass; typecheck and applicable verification pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. The test must fail against the pre-fix lifecycle, and no broad unrelated cleanup is included.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "pkgf-materialized-factory-staleness-001",
      "title": "Establish the customer failure and staleness blast radius",
      "description": "As an operator, I need a reproducible baseline of the stale materialization behavior so the implementation fixes the actual upgrade path and reviewers can see whether other packaged Factories are affected.",
      "acceptanceCriteria": [
        "In an isolated customer home that reproduces the reported stale @you/deep-research materialization, run the exact customer command and capture the pre-fix cli.composition.long-name-collision output for the PR body without contacting or altering the live daemon on port 7437.",
        "Compare each of the 17 existing operator-materialized @you Factory directories with the corresponding generated packaged Factory payload using a deterministic content comparison that accounts for the materialized layout, and report the exact differing count plus each Factory's current/different result in the PR body.",
        "Record the currently observed lifecycle trigger and skip behavior in the PR body: system initialization invokes the Definitions-owned ensure operation, and an existing valid same-format target is skipped without published-content staleness evidence.",
        "Any measurement that cannot be run in the implementation environment is labeled Not verified in this environment with the precise blocker and human reproduction command; it is not claimed as passing and does not justify altering the live daemon.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Baseline measured on 2026-08-21 in isolated temporary homes using the current source binary, without server flags or any contact with port 7437. Exact command returned exit 1 with cli.composition.long-name-collision: Factory input \"model\" collides with reserved static owner \"you.run.flag.model\" on \"model\". The existing operator catalog contained all 17 generated names; each was compared against a fresh production-layout materialization of its generated packaged counterpart (recursive relative-path/length/SHA-256 comparison): 17 DIFFERENT, 0 CURRENT. Results: agy-clip-qa DIFFERENT (1 differing file), agy-cold-watch DIFFERENT (3), classify DIFFERENT (9), deep-research DIFFERENT (2), factory-builder DIFFERENT (9), full-flow DIFFERENT (19), fusion DIFFERENT (5), goal DIFFERENT (4), loop DIFFERENT (4), plan-execute DIFFERENT (25), plan-parallel DIFFERENT (7), quorum DIFFERENT (8), review DIFFERENT (8), spawn DIFFERENT (2), subagent DIFFERENT (4), tournament DIFFERENT (2), tts DIFFERENT (3). Source characterization confirms system initialization invokes Definitions-owned EnsurePackagedFactories and the existing valid same-format target returns skipped without content-staleness evidence. Focused Go tests/typecheck passed: go test ./pkg/services/factory_definitions/... ./pkg/services/system_initialization/...."
    },
    {
      "id": "pkgf-materialized-factory-staleness-002",
      "title": "Reconcile packaged installations while preserving prior content",
      "description": "As a user upgrading you, I want my managed packaged Factories refreshed to the binary's current definitions while any prior or edited copy remains recoverable.",
      "acceptanceCriteria": [
        "A newly materialized packaged Factory records deterministic published-content and installed-content identity sufficient to distinguish current, stale, legacy-unstamped, and customer-modified installations on a later ensure.",
        "Re-running ensure with equivalent published and active content leaves the active directory unchanged, returns or reports a current outcome, and may add missing management metadata without rewriting equivalent Factory content.",
        "When the published definition changes, the same initialization/ensure route preserves the complete previous active directory in a unique non-active backup and atomically publishes the current payload at the canonical named-Factory path without requiring --replace or another manual action.",
        "When active content differs from its recorded installed identity, the lifecycle classifies it as customer-modified, emits a clear warning containing the Factory name and backup location, preserves the edited directory, and activates the current published payload.",
        "A legacy installation with no stamp is handled safely: equivalent content is adopted without destructive replacement, while differing content is backed up and refreshed with a clear diagnostic.",
        "Cancellation, validation, backup, staging, or publication failure returns an actionable Definitions-owned error, cleans up only operation-owned staging artifacts, and never leaves the canonical path partially written or loses the prior materialized copy.",
        "Concurrent ensures retain the existing ownership and lease guarantees and converge on one current active definition without overwriting another process's staging resource or backup.",
        "Structured operation records distinguish created, current, refreshed, customer-modified, and failed outcomes with safe Factory identity and backup facts, without logging definition bodies or sensitive user content.",
        "Focused tests cover all decision states, idempotency, preservation, atomic failure, and concurrent ensure behavior and fail against the pre-fix skip lifecycle.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "reviewFollowUp": "2026-08-21 review follow-up: managed backups now preserve source permissions, the composed initialization contract reports current on an equivalent second ensure, customized functional fixtures use customer-owned @test/* copies so the bundled refresh contract remains exercised, and the packaged-script regression distinguishes active 0755 permissions from a preserved customer-edited 0600 backup. The final rebased head was pushed and required CI started.",
      "notes": "Implemented on 2026-08-21. System-initialization EnsurePackagedFactories now uses Definitions-owned managed reconciliation while direct InstallPackagedFactory retains create/skip/replace behavior. Materialized layouts receive deterministic recursive SHA-256 evidence in .you-packaged-installation.json; legacy-equivalent installs are stamped without replacement; stale and stamped customer-modified layouts are classified, copied completely to unique non-active .you-packaged-backups paths, and atomically refreshed through ReplaceFactoryLayout. Failed snapshot, cancellation, validation, publication, and replacement paths preserve a valid active/prior copy and clean operation-owned artifacts; bounded context-aware retries let concurrent ensures converge. Structured result/CLI outcomes expose current, refreshed, customer-modified, failed, backup, and content identity facts. Focused, system-initialization, race, vet, backend-size, pkg-maint, pkg-file-count, and pkg-structure checks pass. Full lint has only environment/baseline blockers: missing UI node_modules binaries, an existing internal/migrationledgercheck packaged-factory direct import, and deadcode baseline drift; no touched-file lint violation was reported."
    },
    {
      "id": "pkgf-materialized-factory-staleness-003",
      "title": "Restore deep-research invocation through the upgrade route",
      "description": "As a @you/deep-research user, I want an upgraded binary to refresh my stale packaged Factory before resolution so the documented named invocation composes and runs.",
      "acceptanceCriteria": [
        "A functional regression starts from a stale materialized @you/deep-research copy containing the old model, model-provider, researchDepth, and maxSubagents external names, enters through root.BuildProcess and Process.Execute, and proves initialization refreshes the canonical global materialization before named invocation composition.",
        "After refresh, the active materialized definition contains the current invocation names, including research-model, and the preserved backup contains the original stale bytes; the test observes these outcomes through the customer filesystem and CLI route rather than a private helper seam.",
        "you run --named @you/deep-research --maxSubagents 0 \"What is a Petri net?\" no longer returns cli.composition.long-name-collision, composes successfully, and reaches a deterministic mocked provider or worker boundary suitable for repeatable functional verification.",
        "The PR body includes the real post-fix command output and the before and after relevant definition excerpts. If real provider execution is unavailable, that unmeasured portion is listed under Not verified in this environment while the executable customer-route regression remains required.",
        "The test uses an isolated temporary home and existing edge mocks, does not use the running daemon or port 7437, does not add sleeps as synchronization, and does not edit any authored or generated packaged Factory definition.",
        "Existing explicit you init --package replace and skip behavior remains compatible outside automatic managed refresh unless a clear customer diagnostic necessarily changes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented on 2026-08-21. Added a customer-route regression under tests/functional/factory/packaged/deep_research that builds the canonical root process, materializes @you/deep-research, rewrites its current invocation names to the observed stale model/model-provider/researchDepth/maxSubagents spellings, and reuses the same Process.Execute path for the exact named command. Before excerpt: externalName values were model-provider, model, researchDepth, and maxSubagents. After excerpt: externalName values are research-model-provider, research-model, research-depth, and max-subagents, with the stale values absent. The ensure route refreshed the active definition before composition and preserved the complete stale factory.json at a unique non-active .you-packaged-backups path. Captured post-fix output for `you run --named @you/deep-research --maxSubagents 0 What is a Petri net?`: stdout ended with [8] factory completed: SUCCEEDED; stderr was {\"code\":\"RUN_INVOCATION_FAILED\",\"family\":\"INTERNAL_SERVER_ERROR\",\"message\":\"invocation primary result is not plain text; use --json\"}. This is the existing structured-primary presentation diagnostic, not cli.composition.long-name-collision; the mocked Codex request was reached with the exact topic. The same process then ran `you --json run --named @you/deep-research --maxSubagents 0 What is a Petri net?` and returned invocation_result status COMPLETED with the deterministic provider result. Real provider execution is Not verified in this environment; the executable customer route uses the injected command-runner edge. Review follow-up preserved source permissions in backups, moved customized fixture copies to customer-owned @test names, and split the regression setup so backend-size is clean. Focused package tests, race test, vet, make backend-size, and make test pass. No authored or generated Factory definition changed."
    }
  ]
}
