### PR TITLE
perf: move functionallong compile guard off unit critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,9 +218,6 @@ jobs:
         if: matrix.suite == 'functional'
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Compile functionallong test packages
-        if: matrix.suite == 'unit'
-        run: make test-functional-long-compile
       - name: Select functional runner parallelism
         if: matrix.suite == 'functional'
         id: functional-parallelism
@@ -532,6 +529,10 @@ jobs:
           }
           console.log(`Backend Lint selected at ${selection.headSha}`);
           NODE
+      - name: Compile functionallong test packages
+        id: compile-functionallong
+        continue-on-error: true
+        run: make test-functional-long-compile
       - name: Select Backend Lint runner parallelism
         id: backend-lint-parallelism
         shell: bash
@@ -615,6 +616,15 @@ jobs:
                 body: publication.body,
               });
             }
+      - name: Enforce functionallong compile guard
+        if: always()
+        env:
+          FUNCTIONALLONG_COMPILE_OUTCOME: ${{ steps.compile-functionallong.outcome }}
+        run: |
+          if [ "$FUNCTIONALLONG_COMPILE_OUTCOME" != "success" ]; then
+            echo "functionallong compile guard failed with outcome: ${FUNCTIONALLONG_COMPILE_OUTCOME:-unknown}"
+            exit 1
+          fi
 
   ui-backend-integration:
     name: UI Backend Integration

--- a/tests/functional/smoke/guarded_loop_breaker_long_test.go
+++ b/tests/functional/smoke/guarded_loop_breaker_long_test.go
@@ -80,3 +80,5 @@ func assertFactoryHasNoTopLevelExhaustionRules(t *testing.T, dir string) {
 		t.Fatalf("factory.json unexpectedly includes top-level exhaustion_rules: %#v", rules)
 	}
 }
+
+var _ = functionallongCompileProbeIntentionalError

--- a/tests/functional/smoke/guarded_loop_breaker_long_test.go
+++ b/tests/functional/smoke/guarded_loop_breaker_long_test.go
@@ -80,5 +80,3 @@ func assertFactoryHasNoTopLevelExhaustionRules(t *testing.T, dir string) {
 		t.Fatalf("factory.json unexpectedly includes top-level exhaustion_rules: %#v", rules)
 	}
 }
-
-var _ = functionallongCompileProbeIntentionalError


### PR DESCRIPTION
{
  "project": "Move the Functionallong Compile Guard off the Unit Critical Path",
  "branchName": "perf-u5-vet-compile-off-unit-critical-path",
  "description": "Move the unchanged go vet -tags=functionallong ./tests/functional/... compile-only guard from Backend Unit Coverage into the concurrently running Backend Lint job so unit coverage no longer waits 53-66 seconds for unrelated functional-package compilation, while preserving every-PR and push execution, fail-closed protection, and honest variance-aware timing evidence.",
  "context": {
    "customerAsk": "Remove make test-functional-long-compile from the Backend Unit Coverage critical path without deleting or weakening it; keep the guard active on every pull request, demonstrate in hosted CI that a deliberate functionallong compile break is caught in its new location, report exact before/after unit and destination-job timings with run IDs, and keep CI observations in a PR comment rather than commits.",
    "problem": "Backend Unit Coverage currently spends 53-66 seconds, or 13-16% of four observed green runs, compiling ./tests/functional/... before any unit test runs. The work does not contribute to unit testing or coverage, but deleting it would reopen a previously observed failure class in which build-tagged code reaches main without compiling. The earlier inference that make build costs about 62 seconds was incorrect; measured build time is only 1-2 seconds.",
    "solution": "Keep the existing compile-only Make target and exact tag/package scope, remove its unit-matrix invocation, and run it as a fail-closed step in Backend Lint, which already runs concurrently on pull requests and pushes and measured 198-209 seconds versus unit's 396-601 seconds. Prove the new job catches a temporary deliberate tagged compile failure, revert that failure, report all actually observed hosted timings without treating one sample as proof, and assign outstanding repeats explicitly to Operator-owned verification."
  },
  "acceptanceCriteria": [
    "Backend Unit Coverage no longer runs Compile functionallong test packages, while Backend Lint runs the unchanged make test-functional-long-compile guard for every pull-request and push execution before the lane can be considered successful.",
    "A temporary deliberate source error compiled only with -tags=functionallong makes the PR's Backend Lint job fail at the relocated guard with attributable output; the error is reverted, the clean guard succeeds, and no deliberate-break code remains in the final head.",
    "One PR comment reports baseline run IDs 32519009912, 32506376854, 32478717440, and 32509668745 with exact unit, compile-step, and lint timings; reports every comparable post-change observation actually available with run/job IDs; never presents one run as proof; records missing repeats under Operator-owned verification; and never commits CI-run evidence.",
    "The timing report states whether relocated Backend Lint remains below the corresponding Backend Unit Coverage wall-clock and safely within its configured timeout budget; contrary measurements are reported as unmet and resolved rather than described as passing.",
    "The change does not modify make build, gocoveragecheck internals, functional discovery, the functional test window, Vitest, either coverage manifest, or the set of lint rules, and includes no broad unrelated cleanup or meta-test inventory enforcement.",
    "Typecheck and relevant tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "perf-u5-vet-compile-off-unit-critical-path-001",
      "title": "Relocate the tagged compile guard without weakening it",
      "description": "As a contributor waiting on unit results, I want the unrelated tagged functional compile guard to run concurrently in its new CI home so that unit coverage starts sooner while tagged compile failures still block the pull request.",
      "acceptanceCriteria": [
        "Backend Unit Coverage reaches its owned backend build and unit coverage work without invoking make test-functional-long-compile.",
        "Backend Lint invokes the existing make test-functional-long-compile target on both pull-request and push events, retaining the exact functionallong tag and ./tests/functional/... scope.",
        "A nonzero exit from the relocated guard makes Backend Lint fail even if later always-run lint diagnostics, artifacts, or PR-comment publication execute.",
        "The existing valid tagged fixture passes compile-only verification, the existing invalid tagged fixture fails with the attributable compile error, and the compile-only guard does not execute long tests.",
        "The implementation changes CI ownership only and does not change Make target semantics or which lint rules run.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Moved the unchanged compile-only guard to Backend Lint with continue-on-error plus a final always-run fail-closed gate. actionlint, CI workflow tests, the unchanged compile target, and typecheck pass locally. Hosted deliberate-break/timing evidence remains in story 002."
    },
    {
      "id": "perf-u5-vet-compile-off-unit-critical-path-002",
      "title": "Prove hosted failure behavior, timing, and delivery",
      "description": "As a CI maintainer, I want hosted failure proof and variance-aware timing evidence so that the guard move is demonstrably safe, useful, and carried through the full review cycle.",
      "acceptanceCriteria": [
        "On the ready pull request, a temporary functionallong-only compile error is pushed, the resulting run/job ID and failing Backend Lint guard output are recorded, and a subsequent push removes the error before the final head.",
        "One PR comment records baseline runs 32519009912, 32506376854, 32478717440, and 32509668745 with unit totals 601s/411s/414s/396s, compile-step times 66s/62s/59s/53s, and lint totals 205s/209s/198s/201s, plus every comparable post-change unit and lint wall-clock actually observed with run/job IDs.",
        "The report distinguishes measurements from inference, does not use a single post-change run as proof, does not round toward a target, and lists unobserved repeat-run evidence under Operator-owned verification for the review/operator stage.",
        "The PR body justifies choosing Backend Lint by its every-PR/push selection, concurrent execution, and measured slack, and reports honestly if the moved work makes lint the slower job or threatens its timeout budget.",
        "The branch is rebased onto current origin/main before the final push, shared .github/workflows/ci.yml changes are reconciled without overwriting other performance lanes, and generated files are regenerated rather than hand-merged if an unexpected generated conflict occurs.",
        "The PR is opened ready for review, never draft, by the second or third implementation iteration; the live factory daemon on port 7437 is never restarted, killed, or reconfigured.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Opened ready PR #2147 with prd.json as the body, rebased the final clean head bd6247a0b onto current origin/main, and posted one evidence comment. Hosted deliberate-break run 32541246413 / Backend Lint job 96953004333 failed at the relocated fail-closed guard with the attributable undefined functionallongCompileProbeIntentionalError output; the probe was reverted and the clean guard passed locally. Available post-change timings and missing repeated clean destination timings are reported honestly with run/job IDs; final clean CI run 32542068156 was started and terminal CI remains Operator-owned per the implementation-stage criterion."
    }
  ]
}
