### PR TITLE
Make coverage floors advisory during the test rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,11 @@ jobs:
       pull-requests: write
     env:
       PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+      # Keep both coverage matrix lanes report-only for package-floor and
+      # manifest-completeness findings while the test corpus is rebuilt. The
+      # Makefile default remains blocking, so removing this one setting
+      # restores enforcement for local and hosted coverage runs.
+      GO_COVERAGE_FLOOR_POLICY: advisory
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ GO_LOCAL_BUILD_FLAGS ?= -buildvcs=false
 GO_TEST_TIMEOUT ?= 300s
 GO_COVERAGE_TIMEOUT ?= 10m
 GO_COVERAGE_MIN ?= 75.9
+GO_COVERAGE_FLOOR_POLICY ?= blocking
 GO_UNIT_COVERAGE_MIN ?= $(GO_COVERAGE_MIN)
 GO_FUNCTIONAL_COVERAGE_MIN ?= 33.1
 GO_UNIT_COVERAGE_MANIFEST ?= docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -549,6 +550,7 @@ functional-test-viz:
 	$(MAKE) functional-boundary-check
 	$(call ensure_directory,$(FUNCTIONAL_TEST_VIZ_DIR))
 	$(MAKE) test-functional-coverage \
+		GO_COVERAGE_FLOOR_POLICY=$(GO_COVERAGE_FLOOR_POLICY) \
 		GO_FUNCTIONAL_COVERAGE_PROFILE=$(FUNCTIONAL_TEST_VIZ_PROFILE) \
 		GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT=$(FUNCTIONAL_TEST_VIZ_JSON) \
 		GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT=$(FUNCTIONAL_TEST_VIZ_TIMING) \
@@ -685,9 +687,10 @@ test-coverage-go:
 # is forwarded only when it is set, so an invocation with none of them set runs
 # exactly the command it ran before reporting existed. Setting the JSON or
 # timing path never changes the gate: gocoveragecheck's exit code stays the sole
-# pass/fail signal.
+# pass/fail signal. Floor policy defaults to blocking for local callers; hosted
+# CI sets GO_COVERAGE_FLOOR_POLICY=advisory for both coverage lanes.
 test-unit-coverage:
-	$(GO) run ./cmd/gocoveragecheck -suite unit -min $(GO_UNIT_COVERAGE_MIN) -package-manifest $(GO_UNIT_COVERAGE_MANIFEST) -timeout $(GO_COVERAGE_TIMEOUT) $(if $(GO_UNIT_COVERAGE_PROFILE),-profile $(GO_UNIT_COVERAGE_PROFILE),) $(if $(GO_UNIT_COVERAGE_JSON_OUTPUT),-json-output $(GO_UNIT_COVERAGE_JSON_OUTPUT),) $(if $(GO_UNIT_COVERAGE_TIMING_OUTPUT),-timing-output $(GO_UNIT_COVERAGE_TIMING_OUTPUT),)
+	$(GO) run ./cmd/gocoveragecheck -suite unit -min $(GO_UNIT_COVERAGE_MIN) -package-manifest $(GO_UNIT_COVERAGE_MANIFEST) -package-floor-policy $(GO_COVERAGE_FLOOR_POLICY) -timeout $(GO_COVERAGE_TIMEOUT) $(if $(GO_UNIT_COVERAGE_PROFILE),-profile $(GO_UNIT_COVERAGE_PROFILE),) $(if $(GO_UNIT_COVERAGE_JSON_OUTPUT),-json-output $(GO_UNIT_COVERAGE_JSON_OUTPUT),) $(if $(GO_UNIT_COVERAGE_TIMING_OUTPUT),-timing-output $(GO_UNIT_COVERAGE_TIMING_OUTPUT),)
 
 # test-functional-coverage always runs functional-boundary-check first so the
 # required CI Backend Functional Coverage lane (and any local/alias caller of
@@ -699,7 +702,7 @@ test-functional-coverage:
 	$(MAKE) functional-boundary-check
 	@echo "Functional tier: name=$(FUNCTIONAL_TEST_TIER) trigger=$(FUNCTIONAL_TEST_TRIGGER) short=$(FUNCTIONAL_SHORT) budget=$(FUNCTIONAL_TEST_BUDGET) selection=subtractive quarantine=$(FUNCTIONAL_QUARANTINE)"
 	@set +e; \
-	$(GO) run ./cmd/gocoveragecheck -suite functional -stream -jobs $(FUNCTIONAL_DEFAULT_JOBS) -min $(GO_FUNCTIONAL_COVERAGE_MIN) -package-manifest $(GO_FUNCTIONAL_COVERAGE_MANIFEST) -functional-quarantine $(FUNCTIONAL_QUARANTINE) -timeout $(GO_COVERAGE_TIMEOUT) $(if $(filter false 0 no,$(FUNCTIONAL_SHORT)),-short=false,) $(if $(GO_FUNCTIONAL_COVERAGE_PROFILE),-profile $(GO_FUNCTIONAL_COVERAGE_PROFILE),) $(if $(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT),-json-output $(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT),) $(if $(GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT),-timing-output $(GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT),); \
+	$(GO) run ./cmd/gocoveragecheck -suite functional -stream -jobs $(FUNCTIONAL_DEFAULT_JOBS) -min $(GO_FUNCTIONAL_COVERAGE_MIN) -package-manifest $(GO_FUNCTIONAL_COVERAGE_MANIFEST) -package-floor-policy $(GO_COVERAGE_FLOOR_POLICY) -functional-quarantine $(FUNCTIONAL_QUARANTINE) -timeout $(GO_COVERAGE_TIMEOUT) $(if $(filter false 0 no,$(FUNCTIONAL_SHORT)),-short=false,) $(if $(GO_FUNCTIONAL_COVERAGE_PROFILE),-profile $(GO_FUNCTIONAL_COVERAGE_PROFILE),) $(if $(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT),-json-output $(GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT),) $(if $(GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT),-timing-output $(GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT),); \
 	status=$$?; \
 	if [ -n "$(FUNCTIONAL_GOCOVERAGE_EXIT_FILE)" ]; then \
 		printf '%s\n' "$$status" > "$(FUNCTIONAL_GOCOVERAGE_EXIT_FILE)"; \

--- a/cmd/gocoveragecheck/coverage_diagnostics.go
+++ b/cmd/gocoveragecheck/coverage_diagnostics.go
@@ -6,6 +6,9 @@ func writeCoverageDiagnostics(result coverageResult) {
 	for _, warning := range result.packageMinimumWarnings {
 		fmt.Fprintln(stderrWriter, warning)
 	}
+	for _, warning := range result.manifestCompletenessWarnings {
+		fmt.Fprintln(stderrWriter, warning)
+	}
 	for _, diagnostic := range result.unmeasuredPackageDiagnostics {
 		fmt.Fprintln(stderrWriter, diagnostic)
 	}

--- a/cmd/gocoveragecheck/coverage_json.go
+++ b/cmd/gocoveragecheck/coverage_json.go
@@ -13,6 +13,9 @@ import (
 type coverageSummaryJSON struct {
 	Complete             bool                  `json:"complete"`
 	MeasurementReason    string                `json:"measurementReason,omitempty"`
+	PackageFloorPolicy   string                `json:"packageFloorPolicy"`
+	PackageFloorFindings []string              `json:"packageFloorFindings,omitempty"`
+	ManifestDiagnostics  []string              `json:"manifestDiagnostics,omitempty"`
 	CoveredStatements    int                   `json:"coveredStatements"`
 	MeasurableStatements int                   `json:"measurableStatements"`
 	CoveragePercent      float64               `json:"coveragePercent"`
@@ -40,13 +43,36 @@ type packageCoverageGate struct {
 
 func buildCoverageSummaryJSON(result coverageResult) coverageSummaryJSON {
 	covered, measurable := overallStatementTotals(result)
+	policy := strings.TrimSpace(result.packageFloorPolicy)
+	if policy == "" {
+		policy = coverageFloorPolicyBlocking
+	}
 	return coverageSummaryJSON{
 		Complete:             true,
 		CoveredStatements:    covered,
 		MeasurableStatements: measurable,
 		CoveragePercent:      roundCoveragePercent(result.actual),
+		PackageFloorPolicy:   policy,
+		PackageFloorFindings: appendCoverageDiagnostics(result.packageMinimumWarnings, result.packageMinimumFailures),
+		ManifestDiagnostics:  appendCoverageDiagnostics(result.manifestCompletenessWarnings, result.unmeasuredPackageDiagnostics),
 		Packages:             buildPackageCoverageJSON(result),
 	}
+}
+
+func appendCoverageDiagnostics(groups ...[]string) []string {
+	count := 0
+	for _, group := range groups {
+		count += len(group)
+	}
+	if count == 0 {
+		return nil
+	}
+
+	diagnostics := make([]string, 0, count)
+	for _, group := range groups {
+		diagnostics = append(diagnostics, group...)
+	}
+	return diagnostics
 }
 
 func buildPackageCoverageJSON(result coverageResult) []packageCoverageJSON {

--- a/cmd/gocoveragecheck/coverage_json_test.go
+++ b/cmd/gocoveragecheck/coverage_json_test.go
@@ -85,6 +85,31 @@ func TestExecuteWritesDeterministicJSONCoverageTotals(t *testing.T) {
 	}
 }
 
+func TestCoverageSummaryRetainsFloorPolicyAndDiagnostics(t *testing.T) {
+	summary := buildCoverageSummaryJSON(coverageResult{
+		packageFloorPolicy: coverageFloorPolicyAdvisory,
+		packageMinimumWarnings: []string{
+			"package coverage regression: package=pkg/example lane=unit expected-minimum=80.00% actual=40.0000% delta=-40.0000 percentage-points",
+		},
+		manifestCompletenessWarnings: []string{
+			"coverage manifest missing entry: package=pkg/services/example lane=unit",
+		},
+		unmeasuredPackageDiagnostics: []string{
+			"coverage not evaluated: package=pkg/unmeasured lane=unit (no measurement in profile)",
+		},
+	})
+
+	if summary.PackageFloorPolicy != coverageFloorPolicyAdvisory {
+		t.Fatalf("packageFloorPolicy = %q, want %q", summary.PackageFloorPolicy, coverageFloorPolicyAdvisory)
+	}
+	if len(summary.PackageFloorFindings) != 1 || !strings.Contains(summary.PackageFloorFindings[0], "package=pkg/example") {
+		t.Fatalf("packageFloorFindings = %v, want retained floor diagnostic", summary.PackageFloorFindings)
+	}
+	if len(summary.ManifestDiagnostics) != 2 || !strings.Contains(summary.ManifestDiagnostics[0], "missing entry") || !strings.Contains(summary.ManifestDiagnostics[1], "no measurement") {
+		t.Fatalf("manifestDiagnostics = %v, want retained manifest diagnostics", summary.ManifestDiagnostics)
+	}
+}
+
 func TestExecuteOmitsJSONFileWhenJSONOutputOptionAbsent(t *testing.T) {
 	originalCommandRunner := commandRunner
 	originalStdout := stdoutWriter

--- a/cmd/gocoveragecheck/coverage_phases.go
+++ b/cmd/gocoveragecheck/coverage_phases.go
@@ -106,7 +106,14 @@ func applyCoverageManifestGate(cfg config, result coverageResult, repoRoot strin
 		if !filepath.IsAbs(manifestPath) {
 			manifestPath = filepath.Join(repoRoot, manifestPath)
 		}
-		manifest, err := readCoverageManifestFileWithTotals(manifestPath, cfg.suite, packageImportPaths(result.packageSummaries), result.packageTotals)
+		measuredPackages := packageImportPaths(result.packageSummaries)
+		manifest, err := readCoverageManifestFileWithTotalsAtMode(
+			manifestPath,
+			cfg.suite,
+			measuredPackages,
+			result.packageTotals,
+			!cfg.packageFloorPolicyIsAdvisory(),
+		)
 		if err != nil {
 			var validationErr *coverageManifestValidationError
 			if errors.As(err, &validationErr) {
@@ -115,6 +122,16 @@ func applyCoverageManifestGate(cfg config, result coverageResult, repoRoot strin
 			return coverageResult{}, err
 		}
 		result.packageMinimumFailures, result.packageMinimumWarnings = checkCoverageManifestWithEpsilonAndBlocks(manifest, result.packageTotals, cfg.packageManifest, cfg.packageFloorEpsilon, result.coverageBlocks)
+		if cfg.packageFloorPolicyIsAdvisory() {
+			result.packageMinimumWarnings = append(result.packageMinimumWarnings, result.packageMinimumFailures...)
+			result.packageMinimumFailures = nil
+			result.manifestCompletenessWarnings = formatMissingCoverageManifestServiceRootDiagnostics(
+				cfg.suite,
+				measuredPackages,
+				manifestPackageSet(manifest),
+				result.packageTotals,
+			)
+		}
 		result.unmeasuredPackageDiagnostics = formatUnmeasuredCoverageManifestDiagnostics(manifest, result.packageTotals)
 		result.packageGates = coverageManifestGatedPackages(manifest, result.packageTotals)
 	} else if legacyPackageGateEnabled(cfg) {

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -45,6 +45,11 @@ const defaultPackageCoverageMin = 80.0
 const defaultPackageFloorEpsilon = 0.25
 const defaultCoverageJobs = 2
 
+const (
+	coverageFloorPolicyBlocking = "blocking"
+	coverageFloorPolicyAdvisory = "advisory"
+)
+
 var (
 	defaultCoveragePatterns                   = []string{"./pkg/..."}
 	unitTestPatterns                          = []string{"./pkg/..."}
@@ -98,6 +103,7 @@ type config struct {
 	packageBaseline      string
 	packageMin           float64
 	packageFloorEpsilon  float64
+	packageFloorPolicy   string
 	packages             string
 	profile              string
 	short                bool
@@ -118,6 +124,7 @@ type coverageResult struct {
 	zeroCoveragePackages         []string
 	packageMinimumFailures       []string
 	packageMinimumWarnings       []string
+	manifestCompletenessWarnings []string
 	unmeasuredPackageDiagnostics []string
 }
 
@@ -148,6 +155,9 @@ func execute(cfg config) error {
 	if strings.TrimSpace(cfg.updateProfiles) != "" {
 		return executeSampledManifestUpdate(cfg)
 	}
+	if cfg.packageFloorPolicyIsAdvisory() {
+		writeAdvisoryFloorPolicyBanner()
+	}
 	if cfg.phaseTiming == nil && unitCoveragePhaseTimingEnabled(cfg) {
 		cfg.phaseTiming = newCoveragePhaseTimer(stdoutWriter)
 		defer cfg.phaseTiming.emit()
@@ -170,7 +180,12 @@ func execute(cfg config) error {
 		failures = append(failures, fmt.Sprintf("go coverage %.1f%% is below minimum %.1f%%", result.actual, cfg.min))
 	}
 	if len(result.insufficientCoveragePackages) > 0 {
-		failures = append(failures, formatInsufficientCoverageFailure(result.insufficientCoveragePackages, cfg.packageCoverageMin()))
+		insufficientFailure := formatInsufficientCoverageFailure(result.insufficientCoveragePackages, cfg.packageCoverageMin())
+		if cfg.packageFloorPolicyIsAdvisory() {
+			result.packageMinimumWarnings = append(result.packageMinimumWarnings, insufficientFailure)
+		} else {
+			failures = append(failures, insufficientFailure)
+		}
 	}
 	failures = append(failures, result.packageMinimumFailures...)
 
@@ -217,6 +232,7 @@ func parseConfig() config {
 	flag.StringVar(&cfg.packageBaseline, "package-baseline", "", "newline-delimited list of backend packages temporarily exempt from the per-package minimum coverage gate; defaults by suite")
 	flag.Float64Var(&cfg.packageMin, "package-min", defaultPackageCoverageMin, "minimum statement coverage required for each non-baselined backend package")
 	flag.Float64Var(&cfg.packageFloorEpsilon, "package-floor-epsilon", defaultPackageFloorEpsilon, "allowed manifest package-floor drift in percentage points; only applies with -package-manifest")
+	flag.StringVar(&cfg.packageFloorPolicy, "package-floor-policy", coverageFloorPolicyBlocking, "package-floor enforcement policy: blocking or advisory")
 	flag.StringVar(&cfg.packages, "packages", "", "space-separated go test package patterns; overrides -suite package discovery")
 	flag.StringVar(&cfg.profile, "profile", "", "coverage profile output path; defaults to a temp file")
 	flag.BoolVar(&cfg.short, "short", true, "run with go test -short")
@@ -229,6 +245,9 @@ func parseConfig() config {
 }
 
 func validateConfig(cfg config) error {
+	if policy := cfg.packageFloorPolicyValue(); policy != coverageFloorPolicyBlocking && policy != coverageFloorPolicyAdvisory {
+		return fmt.Errorf("configure go coverage: -package-floor-policy must be %q or %q (got %q)", coverageFloorPolicyBlocking, coverageFloorPolicyAdvisory, cfg.packageFloorPolicy)
+	}
 	manifestOperations := 0
 	for _, value := range []string{cfg.generateManifest, cfg.updateManifest, cfg.packageManifest} {
 		if strings.TrimSpace(value) != "" {
@@ -269,6 +288,24 @@ func validateConfig(cfg config) error {
 		}
 	}
 	return nil
+}
+
+func (cfg config) packageFloorPolicyValue() string {
+	policy := strings.ToLower(strings.TrimSpace(cfg.packageFloorPolicy))
+	if policy == "" {
+		return coverageFloorPolicyBlocking
+	}
+	return policy
+}
+
+func (cfg config) packageFloorPolicyIsAdvisory() bool {
+	return cfg.packageFloorPolicyValue() == coverageFloorPolicyAdvisory
+}
+
+func writeAdvisoryFloorPolicyBanner() {
+	fmt.Fprintln(stderrWriter, "!!! COVERAGE FLOOR POLICY: advisory !!!")
+	fmt.Fprintln(stderrWriter, "Package floors and missing-manifest findings are report-only during the test-corpus rebuild.")
+	fmt.Fprintln(stderrWriter, "Set -package-floor-policy=blocking to restore blocking enforcement.")
 }
 
 func (cfg config) packageCoverageBaselinePath() string {

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -126,6 +126,7 @@ type coverageResult struct {
 	packageMinimumWarnings       []string
 	manifestCompletenessWarnings []string
 	unmeasuredPackageDiagnostics []string
+	packageFloorPolicy           string
 }
 
 type packageCoverageTotals struct {
@@ -174,6 +175,7 @@ func execute(cfg config) error {
 		}
 		return err
 	}
+	result.packageFloorPolicy = cfg.packageFloorPolicyValue()
 
 	var failures []string
 	if result.actual < cfg.min {

--- a/cmd/gocoveragecheck/main_entrypoint_test.go
+++ b/cmd/gocoveragecheck/main_entrypoint_test.go
@@ -187,6 +187,178 @@ func TestMainPackageManifestEpsilonCases(t *testing.T) {
 	}
 }
 
+func TestMainPackageFloorPolicyAdvisoryReportsRegressionAndBlockingRestoresEnforcement(t *testing.T) {
+	configPackage := modulePath + "/pkg/config"
+	manifestPath := writePackageMinimumManifest(t, "unit", configPackage, "80.00")
+
+	for _, tc := range []struct {
+		name           string
+		policy         string
+		wantExit       int
+		wantBanner     bool
+		wantSuccess    bool
+		wantDiagnostic string
+	}{
+		{
+			name:           "advisory",
+			policy:         coverageFloorPolicyAdvisory,
+			wantBanner:     true,
+			wantSuccess:    true,
+			wantDiagnostic: "package coverage regression: package=" + configPackage + " lane=unit expected-minimum=80.00% actual=0.0000% delta=-80.0000 percentage-points covered=0/3 statements",
+		},
+		{
+			name:           "blocking",
+			policy:         coverageFloorPolicyBlocking,
+			wantExit:       1,
+			wantDiagnostic: "package coverage regression: package=" + configPackage + " lane=unit expected-minimum=80.00% actual=0.0000% delta=-80.0000 percentage-points covered=0/3 statements",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			args := []string{
+				"-min=0",
+				"-suite=unit",
+				"-package-floor-policy=" + tc.policy,
+				"-package-manifest=" + manifestPath,
+				"-coverpkg=" + configPackage,
+				"-packages=./pkg/config",
+			}
+			stdout, stderr, exitCode := runMainForTest(t, args, fakeGoCoverageCommandWithMeasuredZeroConfig)
+
+			if exitCode != tc.wantExit {
+				t.Fatalf("main() exit code = %d, want %d; stdout=%q stderr=%q", exitCode, tc.wantExit, stdout, stderr)
+			}
+			if tc.wantBanner {
+				for _, want := range []string{
+					"!!! COVERAGE FLOOR POLICY: advisory !!!",
+					"Package floors and missing-manifest findings are report-only",
+					"Set -package-floor-policy=blocking to restore blocking enforcement.",
+				} {
+					if !strings.Contains(stderr, want) {
+						t.Fatalf("main() stderr = %q, want advisory banner containing %q", stderr, want)
+					}
+				}
+			} else if strings.Contains(stderr, "COVERAGE FLOOR POLICY") {
+				t.Fatalf("main() stderr = %q, did not expect advisory banner in blocking mode", stderr)
+			}
+			if !strings.Contains(stderr, tc.wantDiagnostic) {
+				t.Fatalf("main() stderr = %q, want regression diagnostic containing %q", stderr, tc.wantDiagnostic)
+			}
+			if tc.wantSuccess {
+				if !strings.Contains(stdout, "Go coverage 0.0% meets minimum 0.0%.") {
+					t.Fatalf("main() stdout = %q, want successful aggregate message", stdout)
+				}
+			} else if strings.Contains(stdout, "meets minimum") {
+				t.Fatalf("main() stdout = %q, did not expect success message", stdout)
+			}
+		})
+	}
+}
+
+func TestMainPackageFloorPolicyAdvisoryReportsMissingManifestEntryAndBlockingRestoresEnforcement(t *testing.T) {
+	rootObservationPackage := modulePath + "/pkg/services/factory_runtime/internal/rootobservation"
+	manifestPath := writePackageMinimumManifest(t, "unit", rootObservationPackage, "0.00")
+
+	for _, tc := range []struct {
+		name       string
+		policy     string
+		wantExit   int
+		wantBanner bool
+	}{
+		{name: "advisory", policy: coverageFloorPolicyAdvisory, wantBanner: true},
+		{name: "blocking", policy: coverageFloorPolicyBlocking, wantExit: 1},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			args := []string{
+				"-min=0",
+				"-suite=unit",
+				"-package-floor-policy=" + tc.policy,
+				"-package-manifest=" + manifestPath,
+				"-coverpkg=" + rootObservationPackage,
+				"-packages=./pkg/services/factory_runtime/internal/rootobservation",
+			}
+			stdout, stderr, exitCode := runMainForTest(t, args, fakeGoCoverageCommandWithRootObservationRegression)
+
+			if exitCode != tc.wantExit {
+				t.Fatalf("main() exit code = %d, want %d; stdout=%q stderr=%q", exitCode, tc.wantExit, stdout, stderr)
+			}
+			wantDiagnostic := "coverage manifest missing entry: package=" + modulePath + "/pkg/services/factory_runtime lane=unit"
+			if !tc.wantBanner {
+				wantDiagnostic = "measured unit services have no root manifest entry"
+			}
+			if !strings.Contains(stderr, wantDiagnostic) {
+				t.Fatalf("main() stderr = %q, want missing-manifest diagnostic containing %q", stderr, wantDiagnostic)
+			}
+			if tc.wantBanner && !strings.Contains(stderr, "COVERAGE FLOOR POLICY: advisory") {
+				t.Fatalf("main() stderr = %q, want advisory banner", stderr)
+			}
+			if tc.wantBanner {
+				if !strings.Contains(stdout, "Go coverage 95.6% meets minimum 0.0%.") {
+					t.Fatalf("main() stdout = %q, want successful aggregate message", stdout)
+				}
+			} else if strings.Contains(stdout, "meets minimum") {
+				t.Fatalf("main() stdout = %q, did not expect success message", stdout)
+			}
+		})
+	}
+}
+
+func TestMainPackageFloorPolicyAdvisoryDoesNotMaskFailedTests(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		policy     string
+		wantBanner bool
+	}{
+		{name: "advisory", policy: coverageFloorPolicyAdvisory, wantBanner: true},
+		{name: "blocking", policy: coverageFloorPolicyBlocking},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, exitCode := runMainForTest(t, []string{
+				"-package-floor-policy=" + tc.policy,
+				"-coverpkg=" + modulePath + "/pkg/config",
+				"-packages=./pkg/config",
+			}, fakeGoCoverageCommandTestFailsWithObservedFailures)
+
+			if exitCode != 1 {
+				t.Fatalf("main() exit code = %d, want 1; stdout=%q stderr=%q", exitCode, stdout, stderr)
+			}
+			want := "coverage not evaluated: 2 failed tests observed; package floors were NOT checked because the coverage test run failed"
+			if !strings.Contains(stderr, want) {
+				t.Fatalf("main() stderr = %q, want exact failed-test diagnostic containing %q", stderr, want)
+			}
+			if strings.Contains(stderr, "package coverage regression") || strings.Contains(stdout, "meets minimum") {
+				t.Fatalf("failed-test run was reclassified: stdout=%q stderr=%q", stdout, stderr)
+			}
+			if tc.wantBanner && !strings.Contains(stderr, "COVERAGE FLOOR POLICY: advisory") {
+				t.Fatalf("main() stderr = %q, want advisory banner", stderr)
+			}
+			if !tc.wantBanner && strings.Contains(stderr, "COVERAGE FLOOR POLICY") {
+				t.Fatalf("main() stderr = %q, did not expect advisory banner in blocking mode", stderr)
+			}
+		})
+	}
+}
+
+func TestMainRejectsUnknownPackageFloorPolicyBeforeCoverageWork(t *testing.T) {
+	called := false
+	_, stderr, exitCode := runMainForTest(t, []string{"-package-floor-policy=unknown"}, func(commandInvocation) (string, string, error) {
+		called = true
+		return "", "", nil
+	})
+
+	if called {
+		t.Fatal("main() started coverage work for invalid package floor policy")
+	}
+	if exitCode != 1 {
+		t.Fatalf("main() exit code = %d, want 1", exitCode)
+	}
+	if !strings.Contains(stderr, "-package-floor-policy must be") {
+		t.Fatalf("main() stderr = %q, want actionable policy diagnostic", stderr)
+	}
+}
+
 func TestMainRejectsNegativePackageFloorEpsilonBeforeCoverageWork(t *testing.T) {
 	called := false
 	_, stderr, exitCode := runMainForTest(t, []string{"-package-floor-epsilon=-0.01"}, func(commandInvocation) (string, string, error) {

--- a/cmd/gocoveragecheck/manifest.go
+++ b/cmd/gocoveragecheck/manifest.go
@@ -277,15 +277,19 @@ func readCoverageManifestFile(filename string, lane string, measuredPackages []s
 }
 
 func readCoverageManifestFileWithTotals(filename string, lane string, measuredPackages []string, measuredTotals map[string]packageCoverageTotals) (coverageManifest, error) {
+	return readCoverageManifestFileWithTotalsAtMode(filename, lane, measuredPackages, measuredTotals, true)
+}
+
+func readCoverageManifestFileWithTotalsAtMode(filename string, lane string, measuredPackages []string, measuredTotals map[string]packageCoverageTotals, requireComplete bool) (coverageManifest, error) {
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		return coverageManifest{}, fmt.Errorf("read %s go coverage manifest: %w", lane, err)
 	}
 	var manifest coverageManifest
 	if measuredTotals == nil {
-		manifest, err = readCoverageManifest(data, lane, measuredPackages)
+		manifest, err = readCoverageManifestAtMode(data, lane, measuredPackages, time.Now().UTC(), requireComplete)
 	} else {
-		manifest, err = readCoverageManifestWithTotals(data, lane, measuredPackages, measuredTotals)
+		manifest, err = readCoverageManifestAtModeWithTotals(data, lane, measuredPackages, time.Now().UTC(), requireComplete, measuredTotals)
 	}
 	if err != nil {
 		return coverageManifest{}, err

--- a/cmd/gocoveragecheck/manifest_service_completeness.go
+++ b/cmd/gocoveragecheck/manifest_service_completeness.go
@@ -53,7 +53,15 @@ func validateCoverageManifestServiceRoots(
 	declared map[string]struct{},
 	measuredTotals map[string]packageCoverageTotals,
 ) error {
-	missing := make(map[string]struct{})
+	missing := missingCoverageManifestServiceRoots(measuredPackages, declared)
+	if len(missing) == 0 {
+		return nil
+	}
+	return formatMissingCoverageManifestServiceRoots(lane, missing, measuredTotals)
+}
+
+func missingCoverageManifestServiceRoots(measuredPackages []string, declared map[string]struct{}) []string {
+	missingSet := make(map[string]struct{})
 	for _, importPath := range measuredPackages {
 		root, ok := coverageManifestServiceRoot(importPath)
 		if !ok {
@@ -62,12 +70,9 @@ func validateCoverageManifestServiceRoots(
 		if _, declaredRoot := declared[root]; declaredRoot {
 			continue
 		}
-		missing[root] = struct{}{}
+		missingSet[root] = struct{}{}
 	}
-	if len(missing) == 0 {
-		return nil
-	}
-	return formatMissingCoverageManifestServiceRoots(lane, slices.Sorted(maps.Keys(missing)), measuredTotals)
+	return slices.Sorted(maps.Keys(missingSet))
 }
 
 func formatMissingCoverageManifestServiceRoots(lane string, missing []string, measuredTotals map[string]packageCoverageTotals) error {
@@ -87,6 +92,33 @@ func formatMissingCoverageManifestServiceRoots(lane string, missing []string, me
 		"validate go coverage manifest: measured %s services have no root manifest entry:\n%s",
 		lane, strings.Join(lines, "\n"),
 	)
+}
+
+func formatMissingCoverageManifestServiceRootDiagnostics(
+	lane string,
+	measuredPackages []string,
+	declared map[string]struct{},
+	measuredTotals map[string]packageCoverageTotals,
+) []string {
+	missing := missingCoverageManifestServiceRoots(measuredPackages, declared)
+	if len(missing) == 0 {
+		return nil
+	}
+
+	diagnostics := make([]string, 0, len(missing))
+	for _, root := range missing {
+		diagnostic := fmt.Sprintf(
+			"coverage manifest missing entry: package=%s lane=%s (measured service has no root manifest entry; record one entry for the service root)",
+			root,
+			lane,
+		)
+		if measuredTotals != nil {
+			totals := measuredTotals[root]
+			diagnostic += fmt.Sprintf("; root package measures %d/%d statements", totals.coveredStatements, totals.totalStatements)
+		}
+		diagnostics = append(diagnostics, diagnostic)
+	}
+	return diagnostics
 }
 
 // isCoverageManifestServiceRoot reports whether importPath is a service root.

--- a/scripts/ci/coverage-report.mjs
+++ b/scripts/ci/coverage-report.mjs
@@ -42,6 +42,9 @@ function summarizeCoverageArtifact(coverage, limits) {
 	if (!coverage || typeof coverage !== "object" || !Array.isArray(coverage.packages)) {
 		return {
 			available: false,
+			packageFloorPolicy: "",
+			packageFloorFindings: [],
+			manifestDiagnostics: [],
 			violations: [],
 			violationCount: 0,
 			omittedViolations: 0,
@@ -86,6 +89,9 @@ function summarizeCoverageArtifact(coverage, limits) {
 	const nearFloor = contenders.slice(0, limits.packages);
 	return {
 		available: true,
+		packageFloorPolicy: textValue(coverage.packageFloorPolicy),
+		packageFloorFindings: diagnosticEntries(coverage.packageFloorFindings),
+		manifestDiagnostics: diagnosticEntries(coverage.manifestDiagnostics),
 		complete: coverage.complete !== false,
 		measurementReason: textValue(coverage.measurementReason),
 		coveredStatements: finiteNumber(coverage.coveredStatements),
@@ -161,6 +167,20 @@ export function renderCoverageReportBody(summary, options = {}) {
 			`### Closest to their floor\n\n${nearFloor}\n- ${summary.coverage.omitted} additional gated package(s) omitted.`,
 		);
 	}
+	const packageFloorFindings = renderDiagnostics(
+		"### Package-floor findings",
+		summary.coverage.packageFloorFindings,
+	);
+	if (packageFloorFindings) {
+		sections.push(packageFloorFindings);
+	}
+	const manifestDiagnostics = renderDiagnostics(
+		"### Manifest findings",
+		summary.coverage.manifestDiagnostics,
+	);
+	if (manifestDiagnostics) {
+		sections.push(manifestDiagnostics);
+	}
 	sections.push(renderTimingOverview(summary.timing, timingArtifactName));
 	const slowest = renderSlowestTable(summary.timing.slowest);
 	if (slowest) {
@@ -184,12 +204,28 @@ function renderCoverageOverview(coverage, artifactName) {
 		`- Gated packages: ${coverage.gatedCount}`,
 		`- Floor violations: ${coverage.violationCount}`,
 	];
+	if (coverage.packageFloorPolicy === "advisory") {
+		lines.push(
+			"!!! COVERAGE FLOOR POLICY: advisory !!!",
+			"- Package floors and missing-manifest findings are report-only during the test-corpus rebuild.",
+			"- Set `-package-floor-policy=blocking` to restore blocking enforcement.",
+		);
+	} else if (coverage.packageFloorPolicy) {
+		lines.push(`- Package-floor policy: ${coverage.packageFloorPolicy}`);
+	}
 	if (!coverage.complete) {
 		lines.push(
 			`- Measurement status: incomplete — partial diagnostics only${coverage.measurementReason ? ` (${coverage.measurementReason})` : ""}`,
 		);
 	}
 	return lines.join("\n");
+}
+
+function renderDiagnostics(heading, diagnostics) {
+	if (!diagnostics || diagnostics.length === 0) {
+		return "";
+	}
+	return `${heading}\n\n${diagnostics.map((diagnostic) => `- ${diagnostic}`).join("\n")}`;
 }
 
 function renderTimingOverview(timing, artifactName) {
@@ -332,4 +368,11 @@ function measuredCoveragePercent(entry) {
 
 function textValue(value) {
 	return typeof value === "string" ? value.trim() : "";
+}
+
+function diagnosticEntries(value) {
+	if (!Array.isArray(value)) {
+		return [];
+	}
+	return value.filter((entry) => typeof entry === "string" && entry.trim()).map((entry) => entry.trim());
 }

--- a/scripts/ci/functional-coverage-verdict.mjs
+++ b/scripts/ci/functional-coverage-verdict.mjs
@@ -4,6 +4,8 @@ import { pathToFileURL } from "node:url";
 
 const inventoryPrefix = "Functional suite inventory:";
 const ordinaryGocoverageExitCode = 1;
+const advisoryPolicyBanner = "!!! COVERAGE FLOOR POLICY: advisory !!!";
+const failedCoverageTestDiagnostic = "package floors were NOT checked because the coverage test run failed";
 
 export function parseRecordedExitCode(value, source = "recorded exit code") {
 	const normalized = String(value).trim();
@@ -27,6 +29,9 @@ function normalizedLines(log) {
 
 function isCompactVerdictLine(line) {
 	return (
+		line === advisoryPolicyBanner ||
+		line.startsWith("Package floors and missing-manifest findings are report-only") ||
+		line.startsWith("Set -package-floor-policy=blocking to restore blocking enforcement.") ||
 		line.startsWith(inventoryPrefix) ||
 		line.startsWith("total: (statements)") ||
 		line.startsWith("Functional package coverage verdict:") ||
@@ -35,6 +40,7 @@ function isCompactVerdictLine(line) {
 		line.startsWith("  package=") ||
 		line.startsWith("  tally:") ||
 		line.startsWith("package coverage regression:") ||
+		line.startsWith("coverage manifest missing entry:") ||
 		line.startsWith("coverage not evaluated:") ||
 		/^(?:go|Go) coverage (?:found |.* below minimum |.* meets minimum )/.test(line)
 	);
@@ -51,11 +57,33 @@ function hasCoverageGateFailure(lines) {
 }
 
 function hasOrdinaryTestFailure(lines) {
-	return lines.some((line) => line.startsWith("coverage not evaluated:"));
+	return lines.some(
+		(line) =>
+			line.startsWith("coverage not evaluated: ") &&
+			line.includes(failedCoverageTestDiagnostic),
+	);
 }
 
 function hasGreenGate(lines) {
 	return lines.some((line) => /^Go coverage .* meets minimum /.test(line));
+}
+
+function isAdvisoryPolicyLine(line) {
+	return (
+		line === advisoryPolicyBanner ||
+		line.startsWith("Package floors and missing-manifest findings are report-only") ||
+		line.startsWith("Set -package-floor-policy=blocking to restore blocking enforcement.")
+	);
+}
+
+function hasAdvisoryFinding(lines) {
+	return lines.some(
+		(line) =>
+			line.startsWith("package coverage regression:") ||
+			line.startsWith("coverage manifest missing entry:") ||
+			line.startsWith("coverage not evaluated: package=") ||
+			line.startsWith("package coverage warning:"),
+	);
 }
 
 export function extractFunctionalCoverageVerdict(log) {
@@ -71,11 +99,17 @@ export function extractFunctionalCoverageVerdict(log) {
 			hasCoverageGateFailure: false,
 			hasOrdinaryTestFailure: false,
 			hasGreenGate: false,
+			hasAdvisoryPolicy: false,
+			hasAdvisoryFindings: false,
 		};
 	}
 
 	const tail = lines.slice(inventoryIndex);
-	const verdictLines = tail.filter(isCompactVerdictLine);
+	const advisoryLines = lines.filter(isAdvisoryPolicyLine);
+	const verdictLines = [
+		...advisoryLines,
+		...tail.filter((line) => isCompactVerdictLine(line) && !isAdvisoryPolicyLine(line)),
+	];
 	const text = verdictLines.length > 0 ? `${verdictLines.join("\n")}\n` : "";
 	return {
 		foundInventory: true,
@@ -84,6 +118,8 @@ export function extractFunctionalCoverageVerdict(log) {
 		hasCoverageGateFailure: hasCoverageGateFailure(tail),
 		hasOrdinaryTestFailure: hasOrdinaryTestFailure(tail),
 		hasGreenGate: hasGreenGate(tail),
+		hasAdvisoryPolicy: advisoryLines.length > 0,
+		hasAdvisoryFindings: hasAdvisoryFinding(lines),
 	};
 }
 
@@ -117,12 +153,28 @@ export function classifyFunctionalCoverageRun({ commandExitCode = 0, gocoverageE
 		};
 	}
 	if (gocoverageExitCode === 0 && extraction.foundInventory && extraction.hasGreenGate) {
+		const advisoryOnly = extraction.hasAdvisoryPolicy && extraction.hasAdvisoryFindings;
 		return {
-			outcome: "green",
+			outcome: advisoryOnly ? "advisory" : "green",
 			shouldDeferFailure: false,
 			exitCode: 0,
 			extraction,
-			reason: "functional coverage and test gates passed",
+			reason: advisoryOnly
+				? "functional coverage passed with report-only package-floor findings"
+				: "functional coverage and test gates passed",
+		};
+	}
+	if (
+		gocoverageExitCode === ordinaryGocoverageExitCode &&
+		extraction.foundInventory &&
+		extraction.hasOrdinaryTestFailure
+	) {
+		return {
+			outcome: "test-failure",
+			shouldDeferFailure: true,
+			exitCode: gocoverageExitCode,
+			extraction,
+			reason: "gocoveragecheck recorded an ordinary test failure",
 		};
 	}
 	if (
@@ -138,17 +190,13 @@ export function classifyFunctionalCoverageRun({ commandExitCode = 0, gocoverageE
 			reason: "gocoveragecheck recorded a coverage-gate failure",
 		};
 	}
-	if (
-		gocoverageExitCode === ordinaryGocoverageExitCode &&
-		extraction.foundInventory &&
-		extraction.hasOrdinaryTestFailure
-	) {
+	if (extraction.foundInventory) {
 		return {
-			outcome: "test-failure",
-			shouldDeferFailure: true,
-			exitCode: gocoverageExitCode,
+			outcome: "incomplete",
+			shouldDeferFailure: false,
+			exitCode: gocoverageExitCode || 1,
 			extraction,
-			reason: "gocoveragecheck recorded an ordinary test failure",
+			reason: `gocoveragecheck exit ${gocoverageExitCode} had no recognized complete verdict`,
 		};
 	}
 	return {
@@ -186,14 +234,15 @@ export function writeFunctionalCoverageVerdict({ logPath, exitCodePath, outputPa
 		gocoverageExitCode,
 		log,
 	});
-	if (classification.outcome === "infrastructure-failure") {
+	if (["infrastructure-failure", "incomplete"].includes(classification.outcome)) {
 		throw new Error(classification.reason);
 	}
 	if (!classification.extraction.text) {
 		throw new Error("functional coverage verdict extract is empty");
 	}
 	mkdirSync(dirname(resolve(outputPath)), { recursive: true });
-	writeFileSync(outputPath, classification.extraction.text, "utf8");
+	const output = `Functional coverage outcome: ${classification.outcome}\n${classification.extraction.text}`;
+	writeFileSync(outputPath, output, "utf8");
 	return classification;
 }
 

--- a/scripts/ci/functional-coverage-verdict.test.mjs
+++ b/scripts/ci/functional-coverage-verdict.test.mjs
@@ -50,6 +50,22 @@ case "${outcome}" in
     printf '%s\\n' 'full functional stream remains in command.log'
     printf '%s\\n' '0' > "$exit_file"
     ;;
+  advisory)
+    printf '%s\\n' '!!! COVERAGE FLOOR POLICY: advisory !!!'
+    printf '%s\\n' 'Package floors and missing-manifest findings are report-only during the test-corpus rebuild.'
+    printf '%s\\n' 'Set -package-floor-policy=blocking to restore blocking enforcement.'
+    printf '%s\\n' 'Functional suite inventory: discovered-packages=2 observed-packages=2 (pass=2 fail=0 skip=0) top-level-tests=2 (pass=2 fail=0 skip=0) deferred-short-tests=0 wall=1.000s complete=true'
+    printf '%s\\n' 'total: (statements) 70.0%'
+    printf '%s\\n' 'Functional package coverage verdict:'
+    printf '%s\\n' '  floor violation: package=github.com/portpowered/infinite-you/pkg/alpha floor=75.0000% actual=70.0000% delta=-5.0000 percentage-points covered=7/10 statements uncovered-blocks=3'
+    printf '%s\\n' '  package=github.com/portpowered/infinite-you/pkg/alpha coverage=70.0% floor=75.0% delta=-5.0pp gate=fail lane=functional'
+    printf '%s\\n' '  tally: measured-packages=1 gated-packages=1 below-floor=1 near-floor=0 gate-failures=0'
+    printf '%s\\n' 'package coverage regression: package=github.com/portpowered/infinite-you/pkg/alpha lane=functional expected-minimum=75.00% actual=70.0000% delta=-5.0000 percentage-points covered=7/10 statements'
+    printf '%s\\n' 'coverage manifest missing entry: package=github.com/portpowered/infinite-you/pkg/services/factory_runtime lane=functional (measured service has no root manifest entry; record one entry for the service root)'
+    printf '%s\\n' 'coverage not evaluated: package=github.com/portpowered/infinite-you/pkg/beta lane=functional (no measurement in profile)'
+    printf '%s\\n' 'Go coverage 70.0% meets minimum 33.1%.'
+    printf '%s\\n' '0' > "$exit_file"
+    ;;
   gate)
     printf '%s\\n' 'full functional stream remains in command.log'
     printf '%s\\n' 'Functional suite inventory: discovered-packages=2 observed-packages=2 (pass=2 fail=0 skip=0) top-level-tests=2 (pass=2 fail=0 skip=0) deferred-short-tests=0 wall=1.000s complete=true'
@@ -124,6 +140,26 @@ test("extracts the compact verdict and every package regression without raw stre
 	assert.match(extracted.text, /Functional suite inventory:/);
 });
 
+test("retains the advisory banner and distinguishes report-only findings from failed tests", () => {
+	const extracted = extractFunctionalCoverageVerdict(
+		[
+			"!!! COVERAGE FLOOR POLICY: advisory !!!",
+			"Package floors and missing-manifest findings are report-only during the test-corpus rebuild.",
+			"Set -package-floor-policy=blocking to restore blocking enforcement.",
+			"Functional suite inventory: discovered-packages=2 observed-packages=2 complete=true",
+			"package coverage regression: package=p lane=functional expected-minimum=75.00% actual=70.0000% delta=-5.0000 percentage-points",
+			"coverage manifest missing entry: package=service-root lane=functional",
+			"coverage not evaluated: package=unmeasured lane=functional (no measurement in profile)",
+			"Go coverage 80.0% meets minimum 33.1%.",
+		].join("\n"),
+	);
+	assert.equal(extracted.hasAdvisoryPolicy, true);
+	assert.equal(extracted.hasAdvisoryFindings, true);
+	assert.equal(extracted.hasOrdinaryTestFailure, false);
+	assert.match(extracted.text, /COVERAGE FLOOR POLICY: advisory/);
+	assert.match(extracted.text, /coverage manifest missing entry: package=service-root/);
+});
+
 test("captures the exact recorded gocoveragecheck exit code", () => {
 	assert.equal(parseRecordedExitCode("17\n", "test exit file"), 17);
 	assert.throws(() => parseRecordedExitCode("17 18", "test exit file"), /one non-negative integer/);
@@ -147,10 +183,18 @@ test("defers ordinary test and coverage-gate failures but propagates timeout and
 	const testFailure = classifyFunctionalCoverageRun({
 		commandExitCode: 0,
 		gocoverageExitCode: 1,
-		log: "Functional suite inventory: discovered-packages=1 observed-packages=1 (pass=0 fail=1 skip=0)\ncoverage not evaluated: test failed",
+		log: "Functional suite inventory: discovered-packages=1 observed-packages=1 (pass=0 fail=1 skip=0)\ncoverage not evaluated: 1 failed tests observed; package floors were NOT checked because the coverage test run failed",
 	});
 	assert.equal(testFailure.outcome, "test-failure");
 	assert.equal(testFailure.shouldDeferFailure, true);
+
+	const missingMeasurement = classifyFunctionalCoverageRun({
+		commandExitCode: 0,
+		gocoverageExitCode: 1,
+		log: "Functional suite inventory: discovered-packages=1 observed-packages=1 (pass=1 fail=0 skip=0)\ncoverage not evaluated: package=p lane=functional (no measurement in profile)",
+	});
+	assert.equal(missingMeasurement.outcome, "incomplete");
+	assert.equal(missingMeasurement.extraction.hasOrdinaryTestFailure, false);
 
 	const gateFailure = classifyFunctionalCoverageRun({
 		commandExitCode: 0,
@@ -174,6 +218,34 @@ test("defers ordinary test and coverage-gate failures but propagates timeout and
 	assert.equal(infrastructure.shouldDeferFailure, false);
 });
 
+test("classifies advisory-only coverage as successful and keeps a real test failure authoritative", () => {
+	const advisory = classifyFunctionalCoverageRun({
+		commandExitCode: 0,
+		gocoverageExitCode: 0,
+		log: [
+			"!!! COVERAGE FLOOR POLICY: advisory !!!",
+			"Functional suite inventory: discovered-packages=1 observed-packages=1 (pass=1 fail=0 skip=0)",
+			"package coverage regression: package=p lane=functional expected-minimum=75.00% actual=70.0000% delta=-5.0000 percentage-points",
+			"Go coverage 70.0% meets minimum 33.1%.",
+		].join("\n"),
+	});
+	assert.equal(advisory.outcome, "advisory");
+	assert.equal(advisory.shouldDeferFailure, false);
+	assert.equal(advisory.exitCode, 0);
+
+	const failedTest = classifyFunctionalCoverageRun({
+		commandExitCode: 0,
+		gocoverageExitCode: 1,
+		log: [
+			"!!! COVERAGE FLOOR POLICY: advisory !!!",
+			"Functional suite inventory: discovered-packages=1 observed-packages=1 (pass=0 fail=1 skip=0)",
+			"coverage not evaluated: 1 failed tests observed; package floors were NOT checked because the coverage test run failed",
+		].join("\n"),
+	});
+	assert.equal(failedTest.outcome, "test-failure");
+	assert.equal(failedTest.shouldDeferFailure, true);
+});
+
 test("green runner remains successful and records its compact verdict", (t) => {
 	if (!requireBash(t)) return;
 	const { artifactRoot, result } = runFunctionalRunner(t, "green");
@@ -181,6 +253,19 @@ test("green runner remains successful and records its compact verdict", (t) => {
 	const verdictPath = join(artifactRoot, "functional-coverage-verdict.txt");
 	assert.ok(existsSync(verdictPath));
 	assert.match(readFileSync(verdictPath, "utf8"), /Go coverage 80\.0% meets minimum/);
+	assert.equal(readFileSync(join(artifactRoot, "gocoveragecheck-exit-code.txt"), "utf8").trim(), "0");
+});
+
+test("advisory runner remains successful and retains policy plus findings", (t) => {
+	if (!requireBash(t)) return;
+	const { artifactRoot, result } = runFunctionalRunner(t, "advisory");
+	assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+	const verdict = readFileSync(join(artifactRoot, "functional-coverage-verdict.txt"), "utf8");
+	assert.match(verdict, /Functional coverage outcome: advisory/);
+	assert.match(verdict, /COVERAGE FLOOR POLICY: advisory/);
+	assert.ok(verdict.includes("package=github.com/portpowered/infinite-you/pkg/alpha"));
+	assert.match(verdict, /coverage manifest missing entry: package=.*factory_runtime/);
+	assert.ok(verdict.includes("coverage not evaluated: package=github.com/portpowered/infinite-you/pkg/beta"));
 	assert.equal(readFileSync(join(artifactRoot, "gocoveragecheck-exit-code.txt"), "utf8").trim(), "0");
 });
 

--- a/scripts/ci/unit-coverage-report.test.mjs
+++ b/scripts/ci/unit-coverage-report.test.mjs
@@ -20,6 +20,14 @@ import {
 function coverageArtifact() {
 	return {
 		complete: true,
+		packageFloorPolicy: "advisory",
+		packageFloorFindings: [
+			"package coverage regression: package=pkg/regressed lane=unit expected-minimum=70.00% actual=40.0000% delta=-30.0000 percentage-points",
+		],
+		manifestDiagnostics: [
+			"coverage manifest missing entry: package=pkg/services/example lane=unit",
+			"coverage not evaluated: package=pkg/unmeasured lane=unit (no measurement in profile)",
+		],
 		coveredStatements: 30,
 		measurableStatements: 40,
 		coveragePercent: 75,
@@ -145,6 +153,18 @@ test("renders a package table ordered by headroom, not by import path", () => {
 	assert.ok(body.indexOf("`pkg/near`") < body.indexOf("`pkg/ample`"));
 	// A package held to the 0.00 lane-default floor cannot be close to failing.
 	assert.ok(!body.includes("`pkg/lane-default`"));
+});
+
+test("renders advisory policy and all retained floor and manifest diagnostics", () => {
+	const body = renderUnitCoverageJobSummary(
+		summarizeUnitCoverage(coverageArtifact(), timingArtifact()),
+	);
+	assert.match(body, /!!! COVERAGE FLOOR POLICY: advisory !!!/);
+	assert.match(body, /Package floors and missing-manifest findings are report-only/);
+	assert.match(body, /Set `-package-floor-policy=blocking` to restore blocking enforcement/);
+	assert.match(body, /package coverage regression: package=pkg\/regressed/);
+	assert.match(body, /coverage manifest missing entry: package=pkg\/services\/example/);
+	assert.match(body, /coverage not evaluated: package=pkg\/unmeasured/);
 });
 
 test("renders the slowest unit tests with real durations, ordered descending", () => {

--- a/scripts/verification-policy.test.mjs
+++ b/scripts/verification-policy.test.mjs
@@ -211,6 +211,24 @@ test("summary records touched areas, each decision, reason, and terminal result"
 	assert.match(summary, /Verification Policy passed/);
 });
 
+test("a successful coverage lane stays successful when its reason contains advisory findings", () => {
+	const evaluation = evaluateVerificationPolicy(
+		policy({
+			classification: "backend",
+			areas: "ci-tooling",
+			lanes: [
+				...laneNames.filter((name) => name !== "Backend").map((name) => lane(name)),
+				lane("Backend", true, "success", {
+					reason:
+						"COVERAGE FLOOR POLICY: advisory; package coverage regression and missing-manifest findings are report-only.",
+				}),
+			],
+		}),
+	);
+
+	assert.deepEqual(evaluation, { ok: true, failures: [] });
+});
+
 test("summary falls back to the classifier's global reason for a selected lane", () => {
 	const input = policy({
 		classificationReason: "Unknown paths require conservative full verification.",

--- a/tests/functional/observability/verification/functional_runner_contract_test.go
+++ b/tests/functional/observability/verification/functional_runner_contract_test.go
@@ -83,6 +83,34 @@ func TestFunctionalCoverageCommandSmoke_ReportsExplicitTierSelection(t *testing.
 	}
 }
 
+// TestCoverageTargetsSmoke_ForwardOneFloorPolicy proves unit and functional
+// coverage invoke the checker with the same explicit reversible policy.
+func TestCoverageTargetsSmoke_ForwardOneFloorPolicy(t *testing.T) {
+	repoRoot := testutil.MustRepoPath(t, ".")
+	goStub := writeMakeEchoScript(t, "stub-go-coverage-policy")
+
+	for _, target := range []string{"test-unit-coverage", "test-functional-coverage"} {
+		t.Run(target, func(t *testing.T) {
+			makefilePath := writeVerifyFastWrapperMakefile(t, repoRoot, map[string]string{
+				"functional-boundary-check": "@printf '%s\\n' 'stub:boundary-ok'\n",
+			})
+			output, err := runMakefileTargetWithArgs(
+				repoRoot,
+				makefilePath,
+				fmt.Sprintf("GO=%s", goStub),
+				"GO_COVERAGE_FLOOR_POLICY=advisory",
+				target,
+			)
+			if err != nil {
+				t.Fatalf("run %s: %v\n%s", target, err, output)
+			}
+			if !strings.Contains(output, "-package-floor-policy advisory") {
+				t.Fatalf("%s did not forward the advisory policy to gocoveragecheck:\n%s", target, output)
+			}
+		})
+	}
+}
+
 // TestFunctionalCoverageCommandSmoke_DefersOrdinaryGocoverageFailure proves
 // the CI-only handoff preserves gocoveragecheck's exact exit code while
 // allowing the compact verdict step to own an ordinary exit-1 outcome.


### PR DESCRIPTION
{
  "project": "Make Coverage Floors Advisory During the Test Rebuild",
  "branchName": "cov-floors-advisory-during-test-rebuild",
  "description": "Temporarily make per-package coverage-floor regressions and missing-manifest-entry findings report-only in CI while retaining their measurements and diagnostics, preserving actual failed tests as hard failures, and providing one explicit switch that restores blocking enforcement after the test corpus is rebuilt.",
  "context": {
    "customerAsk": "Stand down only the blocking effect of per-package coverage-floor regressions and missing-manifest-entry findings while the test corpus is audited and rebuilt. Keep measurements and diagnostics visible, preserve the coverage-not-evaluated failed-tests signal as blocking, verify all CI consumers, provide a one-step restoration path, and avoid test-corpus, manifest-floor, lane, orchestration-phase, and unrelated-baseline changes.",
    "problem": "Coverage floors currently defend ratios from a test corpus known to contain tests and scaffolding the owner intends to audit, so they can block healthy cleanup and create lane churn. The same checker also reports genuine failed tests through a distinct coverage-not-evaluated result; weakening or misclassifying that result could allow real defects to merge.",
    "solution": "Add one explicit advisory/blocking floor-policy switch owned by gocoveragecheck, have CI select advisory mode, continue measuring and printing floor and manifest findings with a loud banner, keep test-execution failure policy-independent and nonzero, and align downstream verdict publication and Verification Policy consumption with those distinct outcomes."
  },
  "acceptanceCriteria": [
    "With advisory floor policy selected, a completed test run that drops a package below its floor exits successfully and still prints the full package coverage regression diagnostic, including package, lane, expected minimum, actual coverage, and delta.",
    "With advisory floor policy selected, a measured package lacking the required manifest entry does not fail the checker or downstream CI policy and still emits a clear missing-manifest diagnostic identifying the lane and package.",
    "A run containing one or more genuinely failing tests remains nonzero in every floor-policy mode and emits `coverage not evaluated: N failed tests observed; package floors were NOT checked because the coverage test run failed`; no floor finding or advisory setting can mask or reclassify it.",
    "CI emits a loud explanation that floors are advisory, continues publishing coverage measurements and findings, treats coverage jobs and Verification Policy as successful for advisory-only findings, and still fails the originating coverage job and Verification Policy for actual test failures. Switching the single policy setting back to blocking restores the prior blocking behavior for both floor regressions and missing-manifest findings.",
    "The final diff does not delete or rewrite the audited product test corpus, edit manifest floor values, change unit or functional lane definitions, change gocoveragecheck orchestration phases, touch Backend Lint/deadcode/packaged-factory-consumption baselines, hand-edit generated files, or restart, kill, or reconfigure the live factory daemon on port 7437.",
    "Final quality gate: Typecheck passes; focused checker and CI-verdict Tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "cov-floors-advisory-during-test-rebuild-001",
      "title": "Classify floor findings separately from failed tests",
      "description": "As a repository maintainer, I want the coverage checker to apply one explicit floor-enforcement policy so I can observe floor drift without allowing that policy to hide a broken test run.",
      "acceptanceCriteria": [
        "The checker exposes one explicit blocking/advisory floor-policy switch; its existing or safe default remains unambiguous, and CI can select advisory mode without changing a manifest or coverage lane.",
        "Advisory mode prints a prominent banner explaining that package floors and manifest-completeness findings are report-only during the test-corpus rebuild and names the same switch value used to restore blocking behavior.",
        "After a successful test execution, every below-floor package retains its numeric regression diagnostic and every applicable missing-manifest package retains its package-and-lane diagnostic, while advisory-only findings produce a successful process exit.",
        "Blocking mode returns the prior nonzero outcome for the same floor-regression and missing-manifest fixtures, demonstrating that policy restoration changes enforcement rather than measurement.",
        "When test execution fails, both advisory and blocking modes return nonzero and emit the exact coverage-not-evaluated failed-test diagnostic; no floor evaluation result replaces that error.",
        "Focused checker tests cover the advisory floor-regression path, advisory missing-manifest path, blocking restoration path, and failed-test path without deleting or rewriting the audited product test corpus.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented and tested the blocking/advisory package-floor policy switch, advisory floor and missing service-root diagnostics, blocking restoration, and policy-independent failed-test hard failure."
    },
    {
      "id": "cov-floors-advisory-during-test-rebuild-002",
      "title": "Preserve verdict semantics through CI",
      "description": "As a pull-request author, I want all coverage-result consumers to distinguish advisory floor findings from actual test failures so harmless floor drift does not fail my PR and broken tests still do.",
      "acceptanceCriteria": [
        "Unit and functional coverage CI invocations select the same advisory policy and surface the advisory banner, measurements, regression diagnostics, and missing-manifest diagnostics in job output and retained verdict artifacts.",
        "An advisory-only checker result leaves the originating coverage job successful, and the Verification Policy aggregator recognizes that selected job as successful rather than recreating a failure from grepped diagnostics or a stored exit-code artifact.",
        "A failed-test checker result leaves the originating coverage job failed and therefore leaves Verification Policy failed, with the coverage-not-evaluated diagnostic available to identify the actionable cause.",
        "Functional verdict publication distinguishes advisory findings, ordinary test failures, incomplete or unrecognized results, and infrastructure errors without interpreting the presence of a regression line alone as a failed test.",
        "Coverage test patterns, functional quarantine behavior, job and lane selection, command orchestration phases, concurrency controls, and the set of required policy jobs remain unchanged.",
        "Focused script and workflow-consumer tests exercise advisory success and failed-test failure using observable exit statuses, classifications, and published diagnostics rather than route, command, or registration inventories.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Propagated GO_COVERAGE_FLOOR_POLICY=advisory through both hosted coverage lanes, retained policy/floor/manifest diagnostics in unit and functional artifacts, and updated functional verdict classification plus Verification Policy coverage tests so advisory findings succeed while exact test-run failures remain blocking."
    },
    {
      "id": "cov-floors-advisory-during-test-rebuild-003",
      "title": "Demonstrate reversibility and the protected failure signal",
      "description": "As the repository owner, I want concrete same-change evidence for all three verdict classes so I can stand floors down confidently and later restore them without archaeology.",
      "acceptanceCriteria": [
        "A property-specific run deliberately lowers a package below its floor, observes a successful advisory result, and captures the printed package, lane, expected minimum, actual coverage, and delta; the temporary probe is reverted before the final head.",
        "A property-specific run exercises a measured package absent from the manifest, observes a successful advisory result, and captures the emitted package-and-lane diagnostic; the temporary probe is reverted before the final head.",
        "A temporary genuinely failing test produces a nonzero job result and the exact `coverage not evaluated: N failed tests observed; package floors were NOT checked because the coverage test run failed` diagnostic; the failing test is reverted before the final head and is never part of the PR diff.",
        "Re-running the floor-regression and missing-manifest probes with blocking policy restores nonzero results while preserving the same measurements and diagnostics.",
        "The ready PR body contains one sentence stating exactly how to turn floor enforcement back on. One PR comment records only values actually observed, along with run and job IDs; any unexecuted repeated-run work appears under Operator-owned verification and is not claimed as passing.",
        "Before final push, the branch is rebased onto current origin/main; generated files, if unexpectedly implicated, are regenerated rather than hand-merged, and neither prd.json nor progress.txt is committed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Collected and reverted temporary property probes: advisory floor regression exited 0 with package github.com/portpowered/infinite-you/pkg/config, lane unit, expected 80.00%, actual 0.0000%, delta -80.0000 percentage-points, covered 0/3; blocking exited 1 with the same diagnostic. Advisory missing-manifest probe exited 0 with package github.com/portpowered/infinite-you/pkg/services/factory_runtime, lane unit, while measured package github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/rootobservation reported 95.6%; blocking exited 1. Advisory and blocking failed-test probes both exited 1 with the exact 2-failure coverage-not-evaluated diagnostic. Focused checker/CI-verdict tests, typecheck, vet, and all lint targets except two unchanged baseline failures passed."
    }
  ]
}


Restoration: set GO_COVERAGE_FLOOR_POLICY=blocking to restore blocking enforcement for package floors and missing-manifest findings.