### PR TITLE
intake-setup-workspace-dirty-root-diagnostic

### DIFF
--- a/api/components/schemas/data-models/Work.yaml
+++ b/api/components/schemas/data-models/Work.yaml
@@ -69,3 +69,6 @@ properties:
   humanApproval:
     $ref: '../api/HumanApproval.yaml'
     description: Pending HUMAN_APPROVAL request currently owning this Work item, when present.
+  failureDetail:
+    $ref: './FailureDetail.yaml'
+    description: Most recent bounded failure detail when this Work item is currently in a failed state.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -14494,6 +14494,9 @@ components:
         humanApproval:
           $ref: '#/components/schemas/HumanApproval'
           description: Pending HUMAN_APPROVAL request currently owning this Work item, when present.
+        failureDetail:
+          $ref: '#/components/schemas/FailureDetail'
+          description: Most recent bounded failure detail when this Work item is currently in a failed state.
     WorkContent:
       type: array
       description: Ordered canonical content parts for one work item.

--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -29,9 +29,109 @@ ROOT_SYNC_LOCK_FILENAME = "setup-workspace-root-sync.lock"
 MAX_ANCESTOR_RESIDUE_PATHS = 20
 MAX_DIRTY_ROOT_SAMPLE_ENTRIES = 12
 MAX_STATUS_FAILURE_DETAILS = 512
+MAX_FAILURE_DETAILS = 1024
 MAX_DISPLAYED_STATUS_PATH_LENGTH = 240
+WINDOWS_RESERVED_PATH_COMPONENT = re.compile(
+    r"(?<![a-z0-9])(?:nul|con|prn|aux|com[1-9]|lpt[1-9])"
+    r"(?:\.[^\\/:*?\"<>|\r\n]*)?(?![a-z0-9])",
+    re.IGNORECASE,
+)
 _ROOT_SYNC_THREAD_LOCKS = {}
 _ROOT_SYNC_THREAD_LOCKS_GUARD = threading.Lock()
+
+
+class DirtyRootError(RuntimeError):
+    """A bounded, already-rendered diagnostic for an operator-owned root."""
+
+
+def raw_failure_details(error):
+    """Return an exception's text without allowing rendering to raise again."""
+    try:
+        return str(error).strip()
+    except Exception as render_error:  # noqa: BLE001 - defensive boundary
+        return (
+            f"{type(error).__name__} details could not be rendered: "
+            f"{type(render_error).__name__}"
+        )
+
+
+def bounded_failure_details(value, limit=MAX_FAILURE_DETAILS):
+    """Safely render and bound command or exception details for the terminal."""
+    details = (
+        raw_failure_details(value)
+        if not isinstance(value, str)
+        else value.strip()
+    )
+    rendered = []
+    for character in details:
+        codepoint = ord(character)
+        if character == "\n":
+            rendered.append("\n")
+        elif character == "\t":
+            rendered.append("\\t")
+        elif character == "\r":
+            rendered.append("\\r")
+        elif (
+            codepoint < 0x20
+            or codepoint == 0x7F
+            or 0xD800 <= codepoint <= 0xDFFF
+        ):
+            rendered.append(f"\\u{codepoint:04x}")
+        else:
+            rendered.append(character)
+
+    result = "".join(rendered)
+    if len(result) <= limit:
+        return result
+    omitted = len(result) - limit
+    suffix = f"... ({omitted} more characters)"
+    return f"{result[: max(0, limit - len(suffix))]}{suffix}"
+
+
+def is_platform_invalid_path_failure(details):
+    """Recognize Git and Windows messages for paths unavailable to the host."""
+    lowered = details.casefold()
+    if "\x00" in lowered or "\\u0000" in lowered:
+        return True
+    if "invalid path" in lowered or "invalid filename" in lowered:
+        return True
+    if "path" in lowered and "invalid" in lowered:
+        return True
+
+    has_reserved_component = bool(WINDOWS_RESERVED_PATH_COMPONENT.search(details))
+    if not has_reserved_component:
+        return False
+    return any(
+        marker in lowered
+        for marker in (
+            "not allowed",
+            "not valid",
+            "cannot create",
+            "could not create",
+            "checkout",
+            "worktree",
+            "windows",
+            "win32",
+        )
+    )
+
+
+def format_stage_failure(stage, error):
+    """Render bounded, actionable failure text while preserving the stage."""
+    raw_details = raw_failure_details(error)
+    details = bounded_failure_details(raw_details)
+    if not details:
+        details = f"unexpected {type(error).__name__} without additional details"
+
+    if is_platform_invalid_path_failure(raw_details):
+        return (
+            f"{stage}: Git rejected a Windows-reserved or otherwise "
+            "platform-invalid path (for example, the literal NUL device name). "
+            "Inspect the reported path, manually back up any needed content, "
+            "then remove or rename that path before retrying; setup-workspace "
+            f"does not modify it automatically. Details: {details}"
+        )
+    return f"{stage}: {details}"
 
 
 def run_git(*args, cwd=None, check=True, env=None):
@@ -47,7 +147,9 @@ def run_git(*args, cwd=None, check=True, env=None):
     )
     if check and result.returncode != 0:
         raise RuntimeError(
-            f"git {' '.join(args)} failed (exit {result.returncode}): {result.stderr.strip()}"
+            f"git {bounded_failure_details(' '.join(args))} failed "
+            f"(exit {result.returncode}): "
+            f"{command_failure_details(result)}"
         )
     return result
 
@@ -73,10 +175,7 @@ def working_tree_has_local_changes(repo_path):
 
 def truncate_status_details(details):
     """Keep status-command failures useful without emitting unbounded output."""
-    if len(details) <= MAX_STATUS_FAILURE_DETAILS:
-        return details
-    omitted = len(details) - MAX_STATUS_FAILURE_DETAILS
-    return f"{details[:MAX_STATUS_FAILURE_DETAILS]}... ({omitted} more characters)"
+    return bounded_failure_details(details, MAX_STATUS_FAILURE_DETAILS)
 
 
 def parse_porcelain_status(output):
@@ -236,12 +335,15 @@ def ensure_clean_repository_root(repo_root):
     """Refuse setup before any root synchronization or workspace mutation."""
     entries = repository_status_entries(repo_root)
     if entries:
-        raise RuntimeError(dirty_root_diagnostic(repo_root, entries))
+        raise DirtyRootError(dirty_root_diagnostic(repo_root, entries))
 
 
 def command_failure_details(result):
     """Return useful stderr/stdout text from a failed git command."""
-    return (result.stderr or result.stdout).strip() or "no details available"
+    return (
+        bounded_failure_details(result.stderr or result.stdout)
+        or "no details available"
+    )
 
 
 def require_git_output(result, description):
@@ -553,9 +655,9 @@ def restore_stashed_changes(repo_path, snapshot_id, scope_label):
             cwd=repo_path, check=False,
         )
         if fallback_result.returncode != 0:
-            details = (fallback_result.stderr or fallback_result.stdout).strip()
-            if not details:
-                details = (apply_result.stderr or apply_result.stdout).strip()
+            details = command_failure_details(fallback_result)
+            if details == "no details available":
+                details = command_failure_details(apply_result)
             # A failed apply leaves a half-applied, possibly conflicted tree.
             # Unmerged index entries make every later snapshot capture fail,
             # which wedges all future workspace setups until a human cleans
@@ -837,11 +939,14 @@ def _sync_main(repo_root):
     fetch_succeeded = fetch_result.returncode == 0
     if not fetch_succeeded:
         if local_main_ref_exists(repo_root):
-            return f"skipped (fetch failed: {fetch_result.stderr.strip()})"
+            return (
+                "skipped (fetch failed: "
+                f"{command_failure_details(fetch_result)})"
+            )
         if not origin_main_ref_exists(repo_root):
             raise RuntimeError(
                 "fetch failed and refs/heads/main is missing: "
-                f"{fetch_result.stderr.strip()}"
+                f"{command_failure_details(fetch_result)}"
             )
 
     remote_sha = resolve_remote_main_sha(repo_root, fetch_succeeded)
@@ -1086,8 +1191,11 @@ def copy_standing_rules(repo_root, worktree_path):
     try:
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(str(source), str(dest))
-    except OSError as e:
-        print(f"Standing-rules copy skipped: {e}", file=sys.stderr)
+    except Exception as e:  # noqa: BLE001 - this optional copy must stay non-fatal
+        print(
+            format_stage_failure("Standing-rules copy skipped", e),
+            file=sys.stderr,
+        )
         return None
 
     return dest
@@ -1102,14 +1210,20 @@ def main():
 
     try:
         repo_root = get_repo_root()
-    except RuntimeError as e:
-        print(f"Failed to discover repo root: {e}", file=sys.stderr)
+    except Exception as e:  # noqa: BLE001 - CLI boundary must classify all failures
+        print(format_stage_failure("Failed to discover repo root", e), file=sys.stderr)
         sys.exit(1)
 
     # Locate PRD files.
     prd_json_path = repo_root / "tasks" / "todo" / f"{prd_name}.json"
     if not prd_json_path.exists():
-        print(f"PRD not found: {prd_json_path}", file=sys.stderr)
+        print(
+            format_stage_failure(
+                "Failed to read PRD",
+                f"PRD not found: {prd_json_path}",
+            ),
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     prd_md_path = repo_root / "tasks" / "todo" / f"{prd_name}.md"
@@ -1119,8 +1233,8 @@ def main():
     # Read the PRD to catch malformed input; the branch name is the work item name.
     try:
         read_prd(prd_json_path)
-    except (json.JSONDecodeError, OSError) as e:
-        print(f"Failed to read PRD: {e}", file=sys.stderr)
+    except Exception as e:  # noqa: BLE001 - CLI boundary must classify all failures
+        print(format_stage_failure("Failed to read PRD", e), file=sys.stderr)
         sys.exit(1)
 
     branch = f"{prd_name}"
@@ -1133,8 +1247,14 @@ def main():
     # operator's repository before the lane has even been created.
     try:
         ensure_clean_repository_root(repo_root)
-    except RuntimeError as e:
+    except DirtyRootError as e:
         print(f"Root cleanliness check failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:  # noqa: BLE001 - CLI boundary must classify all failures
+        print(
+            format_stage_failure("Root cleanliness check failed", e),
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     # Sync main and prune worktrees.
@@ -1142,23 +1262,26 @@ def main():
         sync_outcome = sync_main(repo_root)
         print(f"Root sync: {sync_outcome}", file=sys.stderr)
         prune_worktrees(repo_root)
-    except RuntimeError as e:
-        print(f"Root sync failed: {e}", file=sys.stderr)
+    except Exception as e:  # noqa: BLE001 - CLI boundary must classify all failures
+        print(format_stage_failure("Root sync failed", e), file=sys.stderr)
         sys.exit(1)
 
     # Create or reuse worktree.
     worktree_dir = repo_root / ".claude" / "worktrees" / normalize_branch(branch)
     try:
         reused = create_or_reuse_worktree(repo_root, branch, worktree_dir)
-    except RuntimeError as e:
-        print(f"Worktree preparation failed: {e}", file=sys.stderr)
+    except Exception as e:  # noqa: BLE001 - CLI boundary must classify all failures
+        print(
+            format_stage_failure("Worktree preparation failed", e),
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     # Copy PRD files into worktree.
     try:
         dest_json, dest_md = copy_prd_files(prd_json_path, prd_md_path, worktree_dir)
-    except OSError as e:
-        print(f"PRD copy failed: {e}", file=sys.stderr)
+    except Exception as e:  # noqa: BLE001 - CLI boundary must classify all failures
+        print(format_stage_failure("PRD copy failed", e), file=sys.stderr)
         sys.exit(1)
 
     # Copy the operator standing-rules doc referenced by lane payloads.

--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -27,6 +27,9 @@ IMMUTABLE_OBJECT_ID = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
 SNAPSHOT_REF_PREFIX = "refs/factory-snapshots/"
 ROOT_SYNC_LOCK_FILENAME = "setup-workspace-root-sync.lock"
 MAX_ANCESTOR_RESIDUE_PATHS = 20
+MAX_DIRTY_ROOT_SAMPLE_ENTRIES = 12
+MAX_STATUS_FAILURE_DETAILS = 512
+MAX_DISPLAYED_STATUS_PATH_LENGTH = 240
 _ROOT_SYNC_THREAD_LOCKS = {}
 _ROOT_SYNC_THREAD_LOCKS_GUARD = threading.Lock()
 
@@ -38,6 +41,8 @@ def run_git(*args, cwd=None, check=True, env=None):
         cwd=cwd,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="surrogateescape",
         env=env,
     )
     if check and result.returncode != 0:
@@ -64,6 +69,174 @@ def working_tree_has_local_changes(repo_path):
     """True when the working tree has staged, unstaged, or untracked changes."""
     status = run_git("status", "--porcelain", cwd=repo_path, check=False)
     return bool(status.stdout.strip())
+
+
+def truncate_status_details(details):
+    """Keep status-command failures useful without emitting unbounded output."""
+    if len(details) <= MAX_STATUS_FAILURE_DETAILS:
+        return details
+    omitted = len(details) - MAX_STATUS_FAILURE_DETAILS
+    return f"{details[:MAX_STATUS_FAILURE_DETAILS]}... ({omitted} more characters)"
+
+
+def parse_porcelain_status(output):
+    """Parse NUL-delimited porcelain-v1 status entries safely."""
+    entries = []
+    tokens = output.split("\0")
+    token_index = 0
+    while token_index < len(tokens):
+        token = tokens[token_index]
+        token_index += 1
+        if not token:
+            continue
+        if len(token) < 4 or token[2] != " ":
+            raise RuntimeError(
+                "git status returned malformed porcelain output"
+            )
+
+        status = token[:2]
+        paths = [token[3:]]
+        if "R" in status or "C" in status:
+            if token_index >= len(tokens) or not tokens[token_index]:
+                raise RuntimeError(
+                    "git status returned an incomplete rename or copy entry"
+                )
+            paths.append(tokens[token_index])
+            token_index += 1
+        entries.append({"status": status, "paths": tuple(paths)})
+
+    return entries
+
+
+def repository_status_entries(repo_path):
+    """Return non-ignored root status entries, or raise a bounded failure."""
+    try:
+        result = run_git(
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+            cwd=repo_path,
+            check=False,
+        )
+    except OSError as error:
+        raise RuntimeError(f"could not run git status: {error}") from error
+
+    if result.returncode != 0:
+        details = truncate_status_details(command_failure_details(result))
+        raise RuntimeError(
+            "git status --porcelain=v1 failed "
+            f"(exit {result.returncode}): {details}"
+        )
+
+    try:
+        return parse_porcelain_status(result.stdout)
+    except RuntimeError as error:
+        raise RuntimeError(f"could not inspect repository status: {error}") from error
+
+
+def status_entry_kind(entry):
+    """Return the operator-facing category for one porcelain status entry."""
+    return "untracked" if entry["status"] == "??" else "tracked"
+
+
+def status_entry_sort_key(entry):
+    """Return a stable sort key independent of Git's presentation order."""
+    kind_order = 0 if status_entry_kind(entry) == "tracked" else 1
+    return kind_order, entry["paths"], entry["status"]
+
+
+def status_entry_path(entry):
+    """Render one status path as a safely escaped, bounded display value."""
+    paths = entry["paths"]
+    if "R" in entry["status"] or "C" in entry["status"]:
+        paths = tuple(reversed(paths))
+
+    rendered_paths = []
+    for path in paths:
+        if len(path) > MAX_DISPLAYED_STATUS_PATH_LENGTH:
+            path = (
+                path[: MAX_DISPLAYED_STATUS_PATH_LENGTH - 1]
+                + "…"
+            )
+        rendered_paths.append(json.dumps(path, ensure_ascii=True))
+    return " -> ".join(rendered_paths)
+
+
+def dirty_root_sample(entries):
+    """Select a stable bounded sample while retaining both status categories."""
+    grouped = {
+        "tracked": sorted(
+            (entry for entry in entries if status_entry_kind(entry) == "tracked"),
+            key=status_entry_sort_key,
+        ),
+        "untracked": sorted(
+            (entry for entry in entries if status_entry_kind(entry) == "untracked"),
+            key=status_entry_sort_key,
+        ),
+    }
+
+    sample = [group[0] for group in grouped.values() if group]
+    remaining = [
+        entry
+        for entry in entries
+        if all(entry is not selected for selected in sample)
+    ]
+    remaining.sort(key=status_entry_sort_key)
+    sample.extend(remaining[: max(0, MAX_DIRTY_ROOT_SAMPLE_ENTRIES - len(sample))])
+    sample.sort(key=status_entry_sort_key)
+    return sample
+
+
+def dirty_root_diagnostic(repo_path, entries):
+    """Describe dirty-root evidence and safe manual recovery guidance."""
+    tracked_count = sum(
+        status_entry_kind(entry) == "tracked" for entry in entries
+    )
+    untracked_count = len(entries) - tracked_count
+    sample = dirty_root_sample(entries)
+    omitted_count = len(entries) - len(sample)
+
+    lines = [
+        f"repository root is dirty: {repo_path}",
+        "status counts: "
+        f"total entries={len(entries)}; "
+        f"tracked changes={tracked_count}; "
+        f"untracked files={untracked_count}",
+        "workspace setup stopped before root synchronization, snapshot "
+        "capture, worktree preparation, pruning, or PRD copy",
+        f"status sample (up to {MAX_DIRTY_ROOT_SAMPLE_ENTRIES} entries):",
+    ]
+
+    for kind in ("tracked", "untracked"):
+        lines.append(f"  {kind}:")
+        category_sample = [
+            entry for entry in sample if status_entry_kind(entry) == kind
+        ]
+        if not category_sample:
+            lines.append("    (none)")
+            continue
+        for entry in category_sample:
+            lines.append(
+                f"    {entry['status']} {status_entry_path(entry)}"
+            )
+
+    if omitted_count:
+        lines.append(
+            f"  {omitted_count} additional path(s) omitted from the sample"
+        )
+    lines.append(
+        "Inspect the repository root manually, then commit the changes or "
+        "back them up and restore them manually before retrying."
+    )
+    return "\n".join(lines)
+
+
+def ensure_clean_repository_root(repo_root):
+    """Refuse setup before any root synchronization or workspace mutation."""
+    entries = repository_status_entries(repo_root)
+    if entries:
+        raise RuntimeError(dirty_root_diagnostic(repo_root, entries))
 
 
 def command_failure_details(result):
@@ -953,6 +1126,15 @@ def main():
     branch = f"{prd_name}"
     if not branch:
         print("PRD name must not be empty", file=sys.stderr)
+        sys.exit(1)
+
+    # Root setup is deliberately fail-closed: the legacy synchronization path
+    # can snapshot and restore local changes, but intake must not mutate an
+    # operator's repository before the lane has even been created.
+    try:
+        ensure_clean_repository_root(repo_root)
+    except RuntimeError as e:
+        print(f"Root cleanliness check failed: {e}", file=sys.stderr)
         sys.exit(1)
 
     # Sync main and prune worktrees.

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -31,7 +31,7 @@
       "path": "generated/cli/command-manifest.schema.json"
     },
     "generated.cli.commands": {
-      "artifactHash": "489d07a09fc14d56fbc430a0a99351cf64302fb2bc7041ddf4bebd2050377591",
+      "artifactHash": "89990b22778c04ab1ae634d4642d3691d50ba13d2992c2f398400b4288425c7c",
       "documentation": {
         "documentation": {
           "description": {
@@ -48,7 +48,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.cli.commands",
-        "sourceHash": "489d07a09fc14d56fbc430a0a99351cf64302fb2bc7041ddf4bebd2050377591",
+        "sourceHash": "89990b22778c04ab1ae634d4642d3691d50ba13d2992c2f398400b4288425c7c",
         "visibility": "public"
       },
       "family": "cli",
@@ -211,7 +211,7 @@
       "path": "generated/mcp/tools.json"
     },
     "generated.openapi.openapi": {
-      "artifactHash": "f8234ce4d701672361736d8956eb8544df123b1c7132ecdcf4298c45c2afe445",
+      "artifactHash": "90e5e78ee73818817361b8fa7d0a08dda0ce87295bda77849439b26c30f30bdb",
       "documentation": {
         "documentation": {
           "description": {
@@ -228,7 +228,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.openapi.openapi",
-        "sourceHash": "f8234ce4d701672361736d8956eb8544df123b1c7132ecdcf4298c45c2afe445",
+        "sourceHash": "90e5e78ee73818817361b8fa7d0a08dda0ce87295bda77849439b26c30f30bdb",
         "visibility": "public"
       },
       "family": "openapi",
@@ -241,7 +241,7 @@
       "path": "generated/openapi/openapi.yaml"
     },
     "generated.schemas.factory": {
-      "artifactHash": "d26a1c738988affd80b2960fad22b1efc2c68101cb42bc8ddfa18900833ee280",
+      "artifactHash": "a313b32507311120a11b305a675dfeb6fe2a31e56d9db4c4c19b202edf36d7be",
       "documentation": {
         "documentation": {
           "description": {
@@ -258,7 +258,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.factory",
-        "sourceHash": "d26a1c738988affd80b2960fad22b1efc2c68101cb42bc8ddfa18900833ee280",
+        "sourceHash": "a313b32507311120a11b305a675dfeb6fe2a31e56d9db4c4c19b202edf36d7be",
         "visibility": "public"
       },
       "family": "config",
@@ -271,7 +271,7 @@
       "path": "generated/schemas/factory.schema.json"
     },
     "generated.schemas.factory-event": {
-      "artifactHash": "a51c022d0d44efd0f48e36dc4b0b5527fab4f53af7c3bf10f2e20cd2d6c8b103",
+      "artifactHash": "151f5df2488a258d45fe55ca833f01ade4bd015d82acb05ab27449fb4c11bee7",
       "documentation": {
         "documentation": {
           "description": {
@@ -288,7 +288,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.factory-event",
-        "sourceHash": "a51c022d0d44efd0f48e36dc4b0b5527fab4f53af7c3bf10f2e20cd2d6c8b103",
+        "sourceHash": "151f5df2488a258d45fe55ca833f01ade4bd015d82acb05ab27449fb4c11bee7",
         "visibility": "public"
       },
       "family": "config",
@@ -301,7 +301,7 @@
       "path": "generated/schemas/factory-event.schema.json"
     },
     "generated.schemas.factory-recording": {
-      "artifactHash": "ee8360214d9509b64af0403e627a900d2f9da19e81643aed61f7bb5e79c1944b",
+      "artifactHash": "c42092c4205fcc0c6c538e87f5de4500eb28370fb755eb28df3c21658d4d2c21",
       "documentation": {
         "documentation": {
           "description": {
@@ -318,7 +318,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.factory-recording",
-        "sourceHash": "ee8360214d9509b64af0403e627a900d2f9da19e81643aed61f7bb5e79c1944b",
+        "sourceHash": "c42092c4205fcc0c6c538e87f5de4500eb28370fb755eb28df3c21658d4d2c21",
         "visibility": "public"
       },
       "family": "config",
@@ -331,7 +331,7 @@
       "path": "generated/schemas/factory-recording.schema.json"
     },
     "generated.schemas.mock-workers": {
-      "artifactHash": "1aad74057b85a8c0d5c195e945832b373a0d37bbc7fc7efece5aa88085efd7d3",
+      "artifactHash": "870e7628e4a89e47af780d451db82585b9a7928d8f01cffe7af517eafe2f1816",
       "documentation": {
         "documentation": {
           "description": {
@@ -348,7 +348,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.mock-workers",
-        "sourceHash": "1aad74057b85a8c0d5c195e945832b373a0d37bbc7fc7efece5aa88085efd7d3",
+        "sourceHash": "870e7628e4a89e47af780d451db82585b9a7928d8f01cffe7af517eafe2f1816",
         "visibility": "public"
       },
       "family": "config",
@@ -361,7 +361,7 @@
       "path": "generated/schemas/mock-workers.schema.json"
     },
     "generated.schemas.you-config": {
-      "artifactHash": "4c0ba04cac5e3a1a3834cc52a799425d81c52474b31b4d1df3d8a49b5166dcce",
+      "artifactHash": "0ba6a3c72e917dc867f24703865bb1072bbc84e162faad48c41d9f45f3de8481",
       "documentation": {
         "documentation": {
           "description": {
@@ -378,7 +378,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.you-config",
-        "sourceHash": "4c0ba04cac5e3a1a3834cc52a799425d81c52474b31b4d1df3d8a49b5166dcce",
+        "sourceHash": "0ba6a3c72e917dc867f24703865bb1072bbc84e162faad48c41d9f45f3de8481",
         "visibility": "public"
       },
       "family": "config",

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -211,7 +211,7 @@
       "path": "generated/mcp/tools.json"
     },
     "generated.openapi.openapi": {
-      "artifactHash": "87d87dbd8fff48a88ee3d72d9f87e7becbb3a898865dc48000d215d46491f0df",
+      "artifactHash": "f42e1a8d666f353b72e17ec98f26c3649b42853c2340b2f51e22e9e529973c67",
       "documentation": {
         "documentation": {
           "description": {
@@ -228,7 +228,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.openapi.openapi",
-        "sourceHash": "87d87dbd8fff48a88ee3d72d9f87e7becbb3a898865dc48000d215d46491f0df",
+        "sourceHash": "f42e1a8d666f353b72e17ec98f26c3649b42853c2340b2f51e22e9e529973c67",
         "visibility": "public"
       },
       "family": "openapi",

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -31,7 +31,7 @@
       "path": "generated/cli/command-manifest.schema.json"
     },
     "generated.cli.commands": {
-      "artifactHash": "be469194f879aad3679df27069c1bce58fe90166a4a40f39548c10035b1a9b64",
+      "artifactHash": "489d07a09fc14d56fbc430a0a99351cf64302fb2bc7041ddf4bebd2050377591",
       "documentation": {
         "documentation": {
           "description": {
@@ -48,7 +48,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.cli.commands",
-        "sourceHash": "be469194f879aad3679df27069c1bce58fe90166a4a40f39548c10035b1a9b64",
+        "sourceHash": "489d07a09fc14d56fbc430a0a99351cf64302fb2bc7041ddf4bebd2050377591",
         "visibility": "public"
       },
       "family": "cli",
@@ -211,7 +211,7 @@
       "path": "generated/mcp/tools.json"
     },
     "generated.openapi.openapi": {
-      "artifactHash": "22916e370b244c02ac0c76e8acd23036506226793977d22c8a535b23ec192dd3",
+      "artifactHash": "f8234ce4d701672361736d8956eb8544df123b1c7132ecdcf4298c45c2afe445",
       "documentation": {
         "documentation": {
           "description": {
@@ -228,7 +228,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.openapi.openapi",
-        "sourceHash": "22916e370b244c02ac0c76e8acd23036506226793977d22c8a535b23ec192dd3",
+        "sourceHash": "f8234ce4d701672361736d8956eb8544df123b1c7132ecdcf4298c45c2afe445",
         "visibility": "public"
       },
       "family": "openapi",
@@ -241,7 +241,7 @@
       "path": "generated/openapi/openapi.yaml"
     },
     "generated.schemas.factory": {
-      "artifactHash": "a313b32507311120a11b305a675dfeb6fe2a31e56d9db4c4c19b202edf36d7be",
+      "artifactHash": "d26a1c738988affd80b2960fad22b1efc2c68101cb42bc8ddfa18900833ee280",
       "documentation": {
         "documentation": {
           "description": {
@@ -258,7 +258,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.factory",
-        "sourceHash": "a313b32507311120a11b305a675dfeb6fe2a31e56d9db4c4c19b202edf36d7be",
+        "sourceHash": "d26a1c738988affd80b2960fad22b1efc2c68101cb42bc8ddfa18900833ee280",
         "visibility": "public"
       },
       "family": "config",
@@ -271,7 +271,7 @@
       "path": "generated/schemas/factory.schema.json"
     },
     "generated.schemas.factory-event": {
-      "artifactHash": "35b2970d6b4f222d14280e6d9047d7ca948f5d487333f7a7f91257cf1e7ae070",
+      "artifactHash": "a51c022d0d44efd0f48e36dc4b0b5527fab4f53af7c3bf10f2e20cd2d6c8b103",
       "documentation": {
         "documentation": {
           "description": {
@@ -288,7 +288,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.factory-event",
-        "sourceHash": "35b2970d6b4f222d14280e6d9047d7ca948f5d487333f7a7f91257cf1e7ae070",
+        "sourceHash": "a51c022d0d44efd0f48e36dc4b0b5527fab4f53af7c3bf10f2e20cd2d6c8b103",
         "visibility": "public"
       },
       "family": "config",
@@ -301,7 +301,7 @@
       "path": "generated/schemas/factory-event.schema.json"
     },
     "generated.schemas.factory-recording": {
-      "artifactHash": "5461e76ec5e11e07829a257878248a16d0a96b357d8755f61158a3f0f36679f2",
+      "artifactHash": "ee8360214d9509b64af0403e627a900d2f9da19e81643aed61f7bb5e79c1944b",
       "documentation": {
         "documentation": {
           "description": {
@@ -318,7 +318,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.factory-recording",
-        "sourceHash": "5461e76ec5e11e07829a257878248a16d0a96b357d8755f61158a3f0f36679f2",
+        "sourceHash": "ee8360214d9509b64af0403e627a900d2f9da19e81643aed61f7bb5e79c1944b",
         "visibility": "public"
       },
       "family": "config",
@@ -331,7 +331,7 @@
       "path": "generated/schemas/factory-recording.schema.json"
     },
     "generated.schemas.mock-workers": {
-      "artifactHash": "870e7628e4a89e47af780d451db82585b9a7928d8f01cffe7af517eafe2f1816",
+      "artifactHash": "1aad74057b85a8c0d5c195e945832b373a0d37bbc7fc7efece5aa88085efd7d3",
       "documentation": {
         "documentation": {
           "description": {
@@ -348,7 +348,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.mock-workers",
-        "sourceHash": "870e7628e4a89e47af780d451db82585b9a7928d8f01cffe7af517eafe2f1816",
+        "sourceHash": "1aad74057b85a8c0d5c195e945832b373a0d37bbc7fc7efece5aa88085efd7d3",
         "visibility": "public"
       },
       "family": "config",
@@ -361,7 +361,7 @@
       "path": "generated/schemas/mock-workers.schema.json"
     },
     "generated.schemas.you-config": {
-      "artifactHash": "0ba6a3c72e917dc867f24703865bb1072bbc84e162faad48c41d9f45f3de8481",
+      "artifactHash": "4c0ba04cac5e3a1a3834cc52a799425d81c52474b31b4d1df3d8a49b5166dcce",
       "documentation": {
         "documentation": {
           "description": {
@@ -378,7 +378,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.you-config",
-        "sourceHash": "0ba6a3c72e917dc867f24703865bb1072bbc84e162faad48c41d9f45f3de8481",
+        "sourceHash": "4c0ba04cac5e3a1a3834cc52a799425d81c52474b31b4d1df3d8a49b5166dcce",
         "visibility": "public"
       },
       "family": "config",

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -31,7 +31,7 @@
       "path": "generated/cli/command-manifest.schema.json"
     },
     "generated.cli.commands": {
-      "artifactHash": "89990b22778c04ab1ae634d4642d3691d50ba13d2992c2f398400b4288425c7c",
+      "artifactHash": "be469194f879aad3679df27069c1bce58fe90166a4a40f39548c10035b1a9b64",
       "documentation": {
         "documentation": {
           "description": {
@@ -48,7 +48,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.cli.commands",
-        "sourceHash": "89990b22778c04ab1ae634d4642d3691d50ba13d2992c2f398400b4288425c7c",
+        "sourceHash": "be469194f879aad3679df27069c1bce58fe90166a4a40f39548c10035b1a9b64",
         "visibility": "public"
       },
       "family": "cli",
@@ -211,7 +211,7 @@
       "path": "generated/mcp/tools.json"
     },
     "generated.openapi.openapi": {
-      "artifactHash": "641f6eff97cf0a79693efd0d744d3d7c29f0b1dd79e16c675cd3bb32cd42aca0",
+      "artifactHash": "87d87dbd8fff48a88ee3d72d9f87e7becbb3a898865dc48000d215d46491f0df",
       "documentation": {
         "documentation": {
           "description": {
@@ -228,7 +228,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.openapi.openapi",
-        "sourceHash": "641f6eff97cf0a79693efd0d744d3d7c29f0b1dd79e16c675cd3bb32cd42aca0",
+        "sourceHash": "87d87dbd8fff48a88ee3d72d9f87e7becbb3a898865dc48000d215d46491f0df",
         "visibility": "public"
       },
       "family": "openapi",

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -211,7 +211,7 @@
       "path": "generated/mcp/tools.json"
     },
     "generated.openapi.openapi": {
-      "artifactHash": "90e5e78ee73818817361b8fa7d0a08dda0ce87295bda77849439b26c30f30bdb",
+      "artifactHash": "641f6eff97cf0a79693efd0d744d3d7c29f0b1dd79e16c675cd3bb32cd42aca0",
       "documentation": {
         "documentation": {
           "description": {
@@ -228,7 +228,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.openapi.openapi",
-        "sourceHash": "90e5e78ee73818817361b8fa7d0a08dda0ce87295bda77849439b26c30f30bdb",
+        "sourceHash": "641f6eff97cf0a79693efd0d744d3d7c29f0b1dd79e16c675cd3bb32cd42aca0",
         "visibility": "public"
       },
       "family": "openapi",

--- a/packages/api/generated/openapi/openapi.yaml
+++ b/packages/api/generated/openapi/openapi.yaml
@@ -14494,6 +14494,9 @@ components:
         humanApproval:
           $ref: '#/components/schemas/HumanApproval'
           description: Pending HUMAN_APPROVAL request currently owning this Work item, when present.
+        failureDetail:
+          $ref: '#/components/schemas/FailureDetail'
+          description: Most recent bounded failure detail when this Work item is currently in a failed state.
     WorkContent:
       type: array
       description: Ordered canonical content parts for one work item.

--- a/packages/api/generated/schemas/factory-event.schema.json
+++ b/packages/api/generated/schemas/factory-event.schema.json
@@ -4533,6 +4533,9 @@
           },
           "type": "array"
         },
+        "failureDetail": {
+          "$ref": "#/$defs/FailureDetail"
+        },
         "humanApproval": {
           "$ref": "#/$defs/HumanApproval"
         },

--- a/packages/api/generated/schemas/factory-recording.schema.json
+++ b/packages/api/generated/schemas/factory-recording.schema.json
@@ -5161,6 +5161,9 @@
           },
           "type": "array"
         },
+        "failureDetail": {
+          "$ref": "#/$defs/FailureDetail"
+        },
         "humanApproval": {
           "$ref": "#/$defs/HumanApproval"
         },

--- a/pkg/services/factory_definitions/internal/contracts/factory_runtime.go
+++ b/pkg/services/factory_definitions/internal/contracts/factory_runtime.go
@@ -338,6 +338,7 @@ type CompletedDispatch struct {
 	Reason                      string                                        `json:"reason,omitempty"`
 	ArtifactVerification        *workerexecution.ExpectedArtifactVerification `json:"artifact_verification,omitempty"`
 	FailureMetadata             *workerexecution.WorkFailureMetadata          `json:"failure_metadata,omitempty"`
+	FailureDetail               *workerexecution.FailureDetail                `json:"failure_detail,omitempty"`
 	ProviderSession             *providers.SessionMetadata                    `json:"provider_session,omitempty"`
 	StartTime                   time.Time                                     `json:"start_time"`
 	EndTime                     time.Time                                     `json:"end_time"`

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/engine.go
@@ -220,6 +220,7 @@ func (e *FactoryEngine) retireCompletedDispatches(results []workerexecution.Work
 					Outcome:              r.Outcome,
 					Reason:               completedDispatchReasonFromResult(r),
 					ArtifactVerification: r.ArtifactVerification.Clone(),
+					FailureDetail:        workerexecution.CloneFailureDetail(r.FailureDetail),
 					ProviderSession:      (r.Continuation).SessionMetadata(),
 					StartTime:            entry.StartTime,
 					EndTime:              now,
@@ -255,6 +256,9 @@ func completedDispatchReasonFromResult(result workerexecution.WorkResult) string
 func workResultForCompletedDispatch(result workerexecution.WorkResult, completed interfaces.CompletedDispatch) workerexecution.WorkResult {
 	result.Outcome = completed.Outcome
 	result.SelectedClassificationLabel = completed.SelectedClassificationLabel
+	if completed.FailureDetail != nil {
+		result.FailureDetail = workerexecution.CloneFailureDetail(completed.FailureDetail)
+	}
 	switch completed.Outcome {
 	case workerexecution.OutcomeFailed:
 		result.Error = completed.Reason

--- a/pkg/services/factory_runtime/internal/services/orchestration/engine/runtime_state.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/engine/runtime_state.go
@@ -84,6 +84,7 @@ func deepCopyCompletedDispatch(d interfaces.CompletedDispatch) interfaces.Comple
 	cp := d
 	cp.ExpectedArtifactContext = cloneExpectedArtifactTemplateContext(d.ExpectedArtifactContext)
 	cp.ArtifactVerification = d.ArtifactVerification.Clone()
+	cp.FailureDetail = workerexecution.CloneFailureDetail(d.FailureDetail)
 	cp.ProviderSession = (d.ProviderSession).Clone()
 	cp.ConsumedTokens = cloneWorkerTokens(d.ConsumedTokens)
 	if d.OutputMutations != nil {
@@ -110,6 +111,7 @@ func deepCopyWorkResult(result workerexecution.WorkResult) workerexecution.WorkR
 	cp.StructuredResult = jsonvalue.Clone(result.StructuredResult)
 	cp.StructuredResultPresent = jsonvalue.Present(result.StructuredResult, result.StructuredResultPresent)
 	cp.ArtifactVerification = result.ArtifactVerification.Clone()
+	cp.FailureDetail = workerexecution.CloneFailureDetail(result.FailureDetail)
 	return cp
 }
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/invoke_worker_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/invoke_worker_test.go
@@ -556,6 +556,11 @@ func TestDetachedScriptProcessFailureDoesNotPropagateRetryMetadata(t *testing.T)
 	if result.Result.Outcome != workers.OutcomeFailed || result.Result.Error != "script exited with status 1" {
 		t.Fatalf("result = %#v, want terminal failed result", result.Result)
 	}
+	if result.Result.FailureDetail == nil ||
+		result.Result.FailureDetail.Reason != workers.WorkFailureTypeInternalServerError ||
+		result.Result.FailureDetail.Message != "script exited with status 1" {
+		t.Fatalf("failure detail = %#v, want canonical script diagnostic", result.Result.FailureDetail)
+	}
 }
 
 func TestAttemptLifecycleRejectsConflictingWorkerCorrelation(t *testing.T) {

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/work_output_materialization.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/work_output_materialization.go
@@ -321,13 +321,7 @@ func workstationDispatchResultFromExecute(
 	}
 	if result.Failure != nil {
 		workResult.Error = strings.TrimSpace(result.Failure.Message)
-		workResult.FailureDetail = workers.CloneFailureDetail(result.Failure.Detail)
-		if workResult.FailureDetail == nil && workResult.Error != "" {
-			workResult.FailureDetail = &workers.FailureDetail{
-				Reason:  result.Failure.Type,
-				Message: workResult.Error,
-			}
-		}
+		workResult.FailureDetail = workFailureDetail(result.Failure, workResult.Error)
 		if shouldPropagateFailureMetadata(request, result.Failure) {
 			workResult.FailureMetadata = &workers.WorkFailureMetadata{
 				Family: result.Failure.Family,
@@ -354,6 +348,14 @@ func workstationDispatchResultFromExecute(
 		Result:               workResult,
 		ProposedOutput:       &proposedOutput,
 	}, executeErr
+}
+
+func workFailureDetail(failure *workers.ExecutionFailure, message string) *workers.FailureDetail {
+	detail := workers.CloneFailureDetail(failure.Detail)
+	if detail != nil || message == "" {
+		return detail
+	}
+	return &workers.FailureDetail{Reason: failure.Type, Message: message}
 }
 
 func workstationDispatchRequestForResult(

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/work_output_materialization.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/work_output_materialization.go
@@ -321,6 +321,13 @@ func workstationDispatchResultFromExecute(
 	}
 	if result.Failure != nil {
 		workResult.Error = strings.TrimSpace(result.Failure.Message)
+		workResult.FailureDetail = workers.CloneFailureDetail(result.Failure.Detail)
+		if workResult.FailureDetail == nil && workResult.Error != "" {
+			workResult.FailureDetail = &workers.FailureDetail{
+				Reason:  result.Failure.Type,
+				Message: workResult.Error,
+			}
+		}
 		if shouldPropagateFailureMetadata(request, result.Failure) {
 			workResult.FailureMetadata = &workers.WorkFailureMetadata{
 				Family: result.Failure.Family,

--- a/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_transitioner.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/subsystems/subsystem_transitioner.go
@@ -304,6 +304,7 @@ func (t *TransitionerSubsystem) buildCompletedDispatch(
 		Reason:                      completedDispatchReason(resolved),
 		ArtifactVerification:        result.ArtifactVerification.Clone(),
 		FailureMetadata:             failureMetadata,
+		FailureDetail:               workerexecution.CloneFailureDetail(result.FailureDetail),
 		ProviderSession:             (result.Continuation).SessionMetadata(),
 		EndTime:                     endTime,
 		ConsumedTokens:              factorytoken.ToWorkerSlice(consumedTokens),

--- a/pkg/services/factory_sessions/internal/sessionservice/work_runtime_adapter.go
+++ b/pkg/services/factory_sessions/internal/sessionservice/work_runtime_adapter.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/portpowered/infinite-you/pkg/platform/jsonvalue"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
@@ -223,11 +224,55 @@ func runtimeWorkItem(
 		readFacts = facts[0]
 	}
 	name := runtimeFirstNonEmpty(token.Color.Name, token.Color.WorkID, token.ID)
-	item := work.ReadModel{CursorID: token.ID, Name: name, WorkID: token.Color.WorkID, RequestID: token.Color.RequestID, WorkTypeName: token.Color.WorkTypeID, State: runtimeWorkState(token, net, inFlight), ChainingTraceDepth: token.Color.ChainingTraceDepth, CurrentChainingTraceID: runtimeFirstNonEmpty(token.Color.CurrentChainingTraceID, token.Color.TraceID), PreviousChainingTraceIDs: append([]string(nil), token.Color.PreviousChainingTraceIDs...), TraceID: token.Color.TraceID, Content: work.CloneWorkContentParts(token.Color.Content), StructuredResult: jsonvalue.Clone(token.Color.StructuredResult), StructuredResultPresent: jsonvalue.Present(token.Color.StructuredResult, token.Color.StructuredResultPresent), Tags: work.CloneTags(token.Color.Tags), ExpectedArtifacts: (factoryruntime.WorkArtifactProjection{}).Project(factoryruntime.WorkArtifactProjectionInput{Token: token, Topology: net, Dispatches: readFacts.dispatches, DispatchHistory: readFacts.dispatchHistory, Results: readFacts.results})}
+	state := runtimeWorkState(token, net, inFlight)
+	item := work.ReadModel{CursorID: token.ID, Name: name, WorkID: token.Color.WorkID, RequestID: token.Color.RequestID, WorkTypeName: token.Color.WorkTypeID, State: state, FailureDetail: runtimeWorkFailureDetail(token.Color.WorkID, state, readFacts.dispatchHistory, readFacts.results), ChainingTraceDepth: token.Color.ChainingTraceDepth, CurrentChainingTraceID: runtimeFirstNonEmpty(token.Color.CurrentChainingTraceID, token.Color.TraceID), PreviousChainingTraceIDs: append([]string(nil), token.Color.PreviousChainingTraceIDs...), TraceID: token.Color.TraceID, Content: work.CloneWorkContentParts(token.Color.Content), StructuredResult: jsonvalue.Clone(token.Color.StructuredResult), StructuredResultPresent: jsonvalue.Present(token.Color.StructuredResult, token.Color.StructuredResultPresent), Tags: work.CloneTags(token.Color.Tags), ExpectedArtifacts: (factoryruntime.WorkArtifactProjection{}).Project(factoryruntime.WorkArtifactProjectionInput{Token: token, Topology: net, Dispatches: readFacts.dispatches, DispatchHistory: readFacts.dispatchHistory, Results: readFacts.results})}
 	for _, relation := range token.Color.Relations {
 		item.Relations = append(item.Relations, work.ReadRelation{Type: relation.Type, SourceWorkName: name, TargetWorkName: runtimeFirstNonEmpty(names[relation.TargetWorkID], relation.TargetWorkID), TargetWorkID: relation.TargetWorkID, RequiredState: relation.RequiredState})
 	}
 	return item
+}
+
+func runtimeWorkFailureDetail(
+	workID string,
+	state *work.State,
+	history []factoryruntime.CompletedDispatch,
+	results []workers.WorkResult,
+) *work.FailureDetail {
+	if strings.TrimSpace(workID) == "" || state == nil || state.Type != work.StateTypeFailed {
+		return nil
+	}
+	for index := len(history) - 1; index >= 0; index-- {
+		dispatch := history[index]
+		if dispatch.Outcome != workers.OutcomeFailed || !runtimeCompletedDispatchContainsWork(dispatch, workID) {
+			continue
+		}
+		if dispatch.FailureDetail != nil {
+			return &work.FailureDetail{Reason: string(dispatch.FailureDetail.Reason), Message: dispatch.FailureDetail.Message}
+		}
+		for resultIndex := len(results) - 1; resultIndex >= 0; resultIndex-- {
+			result := results[resultIndex]
+			if result.DispatchID != dispatch.DispatchID || result.FailureDetail == nil {
+				continue
+			}
+			return &work.FailureDetail{Reason: string(result.FailureDetail.Reason), Message: result.FailureDetail.Message}
+		}
+		return nil
+	}
+	return nil
+}
+
+func runtimeCompletedDispatchContainsWork(dispatch factoryruntime.CompletedDispatch, workID string) bool {
+	for _, token := range dispatch.ConsumedTokens {
+		if token.Color.WorkID == workID {
+			return true
+		}
+	}
+	for _, mutation := range dispatch.OutputMutations {
+		if mutation.TokenID == workID || (mutation.Token != nil && mutation.Token.Color.WorkID == workID) {
+			return true
+		}
+	}
+	return false
 }
 
 func runtimeWorkState(token *workers.Token, net *legacysnapshot.RuntimeTopology, inFlight bool) *work.State {

--- a/pkg/services/factory_sessions/internal/sessionservice/work_runtime_resolver_test.go
+++ b/pkg/services/factory_sessions/internal/sessionservice/work_runtime_resolver_test.go
@@ -634,6 +634,33 @@ func TestWorkRuntimeAdapterProjectsDispatchOnlyWorkAsProcessing(t *testing.T) {
 	}
 }
 
+func TestWorkRuntimeAdapterProjectsLatestFailureDetailOnlyForCurrentFailedWork(t *testing.T) {
+	token := &workers.Token{ID: "tok-failed", State: "failed", Color: workers.Color{WorkID: "work-failed", WorkTypeID: "story"}}
+	net := &factory.Net{WorkTypes: map[string]*factory.WorkType{"story": {ID: "story", States: []factory.StateDefinition{{Value: "failed", Category: factory.StateCategoryFailed}}}}}
+	history := []factory.CompletedDispatch{
+		{
+			DispatchID: "dispatch-old", Outcome: workers.OutcomeFailed,
+			FailureDetail:  &workers.FailureDetail{Reason: workers.WorkFailureTypeUnknown, Message: "old failure"},
+			ConsumedTokens: []workers.Token{{Color: workers.Color{WorkID: "work-failed"}}},
+		},
+		{
+			DispatchID: "dispatch-latest", Outcome: workers.OutcomeFailed,
+			FailureDetail:  &workers.FailureDetail{Reason: workers.WorkFailureTypeInternalServerError, Message: "repository root is dirty"},
+			ConsumedTokens: []workers.Token{{Color: workers.Color{WorkID: "work-failed"}}},
+		},
+	}
+	got := runtimeWorkItem(token, net, false, nil, runtimeReadFacts{dispatchHistory: history})
+	if got.FailureDetail == nil || got.FailureDetail.Reason != string(workers.WorkFailureTypeInternalServerError) || got.FailureDetail.Message != "repository root is dirty" {
+		t.Fatalf("runtimeWorkItem failure detail = %#v, want latest typed failure", got.FailureDetail)
+	}
+
+	token.State = "done"
+	got = runtimeWorkItem(token, net, false, nil, runtimeReadFacts{dispatchHistory: history})
+	if got.FailureDetail != nil {
+		t.Fatalf("non-failed Work failure detail = %#v, want nil", got.FailureDetail)
+	}
+}
+
 func TestWorkRuntimeAdapterDetachesFactorySessionStopSummary(t *testing.T) {
 	workID := "work-1"
 	summary := &factorysessions.StopSummary{

--- a/pkg/services/recordings/internal/events/event_history.go
+++ b/pkg/services/recordings/internal/events/event_history.go
@@ -874,6 +874,14 @@ func failureDetailsForResult(result workers.WorkResult) (string, string) {
 
 	reason := failureReasonForResult(result)
 	message := strings.TrimSpace(result.Error)
+	if result.FailureDetail != nil {
+		if typedReason := strings.TrimSpace(string(result.FailureDetail.Reason)); typedReason != "" {
+			reason = typedReason
+		}
+		if typedMessage := strings.TrimSpace(result.FailureDetail.Message); typedMessage != "" {
+			message = typedMessage
+		}
+	}
 	if message == "" {
 		message = failureMessageUnavailable
 	}

--- a/pkg/services/recordings/internal/events/event_history_dispatch_lifecycle_test.go
+++ b/pkg/services/recordings/internal/events/event_history_dispatch_lifecycle_test.go
@@ -289,6 +289,27 @@ func TestFailureDetailsForResult_FailureMetadataOverridesWorkerErrorReason(t *te
 	}
 }
 
+func TestFailureDetailsForResult_TypedDetailOverridesFallbacks(t *testing.T) {
+	reason, message := failureDetailsForResult(workerexecution.WorkResult{
+		DispatchID:      "dispatch-script-failure",
+		TransitionID:    "build",
+		Outcome:         workerexecution.OutcomeFailed,
+		Error:           "script exited with status 1",
+		FailureMetadata: &workerexecution.WorkFailureMetadata{Type: workerexecution.WorkFailureTypeUnknown},
+		FailureDetail: &workerexecution.FailureDetail{
+			Reason:  workerexecution.WorkFailureTypeInternalServerError,
+			Message: "script exited with status 1: repository root is dirty",
+		},
+	})
+
+	if reason != string(workerexecution.WorkFailureTypeInternalServerError) {
+		t.Fatalf("failure reason = %q, want internal server error", reason)
+	}
+	if message != "script exited with status 1: repository root is dirty" {
+		t.Fatalf("failure message = %q, want typed diagnostic", message)
+	}
+}
+
 func TestFailureDetailsForResult_ClassifierInvalidOutputPreservesRawOutputEvidence(t *testing.T) {
 	reason, message := failureDetailsForResult(workerexecution.WorkResult{
 		DispatchID:   "dispatch-classifier-invalid",

--- a/pkg/services/recordings/wire/work_snapshot_projection.go
+++ b/pkg/services/recordings/wire/work_snapshot_projection.go
@@ -66,6 +66,7 @@ func readModelFromWorkItem(
 		StructuredResultPresent:  jsonvalue.Present(item.StructuredResult, item.StructuredResultPresent),
 		Tags:                     work.CloneTags(item.Tags),
 		ExpectedArtifacts:        expectedArtifactsFromWorldItem(item, state),
+		FailureDetail:            currentWorkFailureDetail(item, state),
 	}
 	read.State = workStateFromItem(item, state, inFlight)
 	read.HumanApproval = humanApprovalForWork(item.ID, state)
@@ -79,6 +80,43 @@ func readModelFromWorkItem(
 		})
 	}
 	return read
+}
+
+// currentWorkFailureDetail exposes only the detail for the dispatch that left
+// the Work in its current FAILED state. FailureDetailsByWorkID intentionally
+// retains historical diagnostics for replay, so it must not be projected onto
+// a Work that has since recovered or was never failed.
+func currentWorkFailureDetail(
+	item work.FactoryWorkItem,
+	state factorydefinitions.FactoryWorldState,
+) *work.FailureDetail {
+	if _, failed := state.FailedWorkItemsByID[item.ID]; !failed {
+		return nil
+	}
+	for index := len(state.FailedDispatches) - 1; index >= 0; index-- {
+		dispatch := state.FailedDispatches[index]
+		if !worldDispatchContainsWork(
+			dispatch.WorkItemIDs,
+			dispatch.ConsumedInputs,
+			dispatch.InputWorkItems,
+			dispatch.OutputWorkItems,
+			item.ID,
+		) {
+			continue
+		}
+		return detachedWorkFailureDetail(dispatch.Result.FailureDetail)
+	}
+	if detail, ok := state.FailureDetailsByWorkID[item.ID]; ok {
+		return detachedWorkFailureDetail(detail.FailureDetail)
+	}
+	return nil
+}
+
+func detachedWorkFailureDetail(detail *workers.FailureDetail) *work.FailureDetail {
+	if detail == nil {
+		return nil
+	}
+	return &work.FailureDetail{Reason: string(detail.Reason), Message: detail.Message}
 }
 
 func humanApprovalForWork(workID string, state factorydefinitions.FactoryWorldState) *work.HumanApprovalReadModel {

--- a/pkg/services/recordings/wire/work_snapshot_projection_test.go
+++ b/pkg/services/recordings/wire/work_snapshot_projection_test.go
@@ -141,6 +141,61 @@ func TestReadSnapshotFromFactoryWorldStateMapsActiveFailedTerminalAndRelations(t
 	}
 }
 
+func TestReadSnapshotFromFactoryWorldStateProjectsOnlyCurrentLatestWorkFailure(t *testing.T) {
+	t.Parallel()
+
+	state := factorydefinitions.FactoryWorldState{
+		WorkItemsByID: map[string]work.FactoryWorkItem{
+			"work-failed":    {ID: "work-failed", WorkTypeID: "story", State: "rejected"},
+			"work-recovered": {ID: "work-recovered", WorkTypeID: "story", State: "review"},
+			"work-unrelated": {ID: "work-unrelated", WorkTypeID: "story", State: "review"},
+		},
+		FailedWorkItemsByID: map[string]work.FactoryWorkItem{
+			"work-failed": {ID: "work-failed", WorkTypeID: "story", State: "rejected"},
+		},
+		FailedDispatches: []factorydefinitions.FactoryWorldDispatchCompletion{
+			{
+				DispatchID: "dispatch-old", WorkItemIDs: []string{"work-failed"},
+				Result: workers.WorkstationResult{FailureDetail: &workers.FailureDetail{
+					Reason: workers.WorkFailureTypeUnknown, Message: "old setup failure",
+				}},
+			},
+			{
+				DispatchID: "dispatch-unrelated", WorkItemIDs: []string{"work-unrelated"},
+				Result: workers.WorkstationResult{FailureDetail: &workers.FailureDetail{
+					Reason: workers.WorkFailureTypeUnknown, Message: "unrelated failure",
+				}},
+			},
+			{
+				DispatchID: "dispatch-new", WorkItemIDs: []string{"work-failed"},
+				Result: workers.WorkstationResult{FailureDetail: &workers.FailureDetail{
+					Reason: workers.WorkFailureTypeInternalServerError, Message: "latest setup failure",
+				}},
+			},
+		},
+		FailureDetailsByWorkID: map[string]factorydefinitions.FactoryWorldFailureDetail{
+			"work-recovered": {
+				FailureDetail: &workers.FailureDetail{
+					Reason: workers.WorkFailureTypeUnknown, Message: "stale recovered failure",
+				},
+			},
+		},
+	}
+
+	snapshot := readSnapshotFromFactoryWorldState(state)
+	byID := make(map[string]work.ReadModel, len(snapshot.Items))
+	for _, item := range snapshot.Items {
+		byID[item.WorkID] = item
+	}
+	failed := byID["work-failed"].FailureDetail
+	if failed == nil || failed.Reason != string(workers.WorkFailureTypeInternalServerError) || failed.Message != "latest setup failure" {
+		t.Fatalf("current failed detail = %#v, want latest matching dispatch", failed)
+	}
+	if byID["work-recovered"].FailureDetail != nil || byID["work-unrelated"].FailureDetail != nil {
+		t.Fatalf("stale or unrelated failure details = recovered=%#v unrelated=%#v, want nil", byID["work-recovered"].FailureDetail, byID["work-unrelated"].FailureDetail)
+	}
+}
+
 func TestReadSnapshotFromFactoryWorldStateLinksPendingHumanApprovalsToWork(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/work/internal/services/state_access/internal/service/read.go
+++ b/pkg/services/work/internal/services/state_access/internal/service/read.go
@@ -210,6 +210,12 @@ func annotatedReadModels(snapshot work.ReadSnapshot) []work.ReadModel {
 	for index, item := range annotatedItems {
 		if index < len(models) {
 			models[index].SupersededBy = item.SupersededBy
+			if item.SupersededBy != "" {
+				// A superseded failed attempt is historical context, not the
+				// current failure for this Work name. Do not expose its detail
+				// through the public read projection.
+				models[index].FailureDetail = nil
+			}
 		}
 	}
 	return models

--- a/pkg/services/work/internal/services/state_access/internal/service/read.go
+++ b/pkg/services/work/internal/services/state_access/internal/service/read.go
@@ -232,6 +232,10 @@ func detachReadModel(item work.ReadModel) work.ReadModel {
 	item.Tags = work.CloneTags(item.Tags)
 	item.Relations = append([]work.ReadRelation(nil), item.Relations...)
 	item.ExpectedArtifacts = append([]work.ExpectedArtifactReadModel(nil), item.ExpectedArtifacts...)
+	if item.FailureDetail != nil {
+		detail := *item.FailureDetail
+		item.FailureDetail = &detail
+	}
 	if item.State != nil {
 		state := *item.State
 		item.State = &state

--- a/pkg/services/work/internal/services/state_access/internal/service/read_test.go
+++ b/pkg/services/work/internal/services/state_access/internal/service/read_test.go
@@ -76,7 +76,7 @@ func TestListWorkDerivesSupersessionBeforeCountsAndPagination(t *testing.T) {
 func supersessionReadSnapshot() work.ReadSnapshot {
 	return work.ReadSnapshot{
 		Items: []work.ReadModel{
-			{CursorID: "tok-old", WorkID: "work-old", Name: "same name", State: &work.State{Type: work.StateTypeFailed}},
+			{CursorID: "tok-old", WorkID: "work-old", Name: "same name", State: &work.State{Type: work.StateTypeFailed}, FailureDetail: &work.FailureDetail{Reason: "SETUP_FAILED", Message: "old setup failure"}},
 			{CursorID: "tok-new", WorkID: "work-new", Name: "same name", State: &work.State{Type: work.StateTypeProcessing}},
 			{CursorID: "tok-fresh", WorkID: "work-fresh", Name: "fresh failure", State: &work.State{Type: work.StateTypeFailed}},
 		},
@@ -142,6 +142,9 @@ func assertIncludedSupersessionHistory(t *testing.T, svc *internalservice.Servic
 	if old.SupersededBy != "work-new" {
 		t.Fatalf("old history row SupersededBy = %q, want work-new", old.SupersededBy)
 	}
+	if old.FailureDetail != nil {
+		t.Fatalf("old history row FailureDetail = %#v, want nil for superseded failed Work", old.FailureDetail)
+	}
 
 	got, err := svc.GetWork(context.Background(), "session-1", "work-old")
 	if err != nil {
@@ -149,6 +152,9 @@ func assertIncludedSupersessionHistory(t *testing.T, svc *internalservice.Servic
 	}
 	if got.SupersededBy != "work-new" {
 		t.Fatalf("GetWork(old).SupersededBy = %q, want work-new", got.SupersededBy)
+	}
+	if got.FailureDetail != nil {
+		t.Fatalf("GetWork(old).FailureDetail = %#v, want nil for superseded failed Work", got.FailureDetail)
 	}
 }
 

--- a/pkg/services/work/read_contract.go
+++ b/pkg/services/work/read_contract.go
@@ -59,9 +59,18 @@ type ReadModel struct {
 	StructuredResultPresent bool
 	Tags                    map[string]string
 	Relations               []ReadRelation
+	FailureDetail           *FailureDetail
 	StopSummary             *StopSummary
 	HumanApproval           *HumanApprovalReadModel
 	ExpectedArtifacts       []ExpectedArtifactReadModel
+}
+
+// FailureDetail is the bounded, customer-safe explanation of the dispatch
+// that currently leaves this Work in a failed state. Work owns this detached
+// read shape so transports do not depend on the Workers execution contract.
+type FailureDetail struct {
+	Reason  string
+	Message string
 }
 
 // HumanApprovalReadModel links a Work read to the durable pending operator

--- a/pkg/services/work/transports/cli/show.go
+++ b/pkg/services/work/transports/cli/show.go
@@ -175,7 +175,21 @@ func renderShowResult(output io.Writer, work factoryapi.Work) error {
 	if err := writeWorkStopSummary(output, work.StopSummary); err != nil {
 		return err
 	}
+	if err := writeWorkFailureDetail(output, work.FailureDetail); err != nil {
+		return err
+	}
 	return nil
+}
+
+func writeWorkFailureDetail(output io.Writer, detail *factoryapi.FailureDetail) error {
+	if detail == nil {
+		return nil
+	}
+	if _, err := fmt.Fprintf(output, "Failure reason:\t%s\n", detail.Reason); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(output, "Failure message:\t%s\n", detail.Message)
+	return err
 }
 
 func primaryWorkTrace(work factoryapi.Work) string {

--- a/pkg/services/work/transports/cli/work/show_test.go
+++ b/pkg/services/work/transports/cli/work/show_test.go
@@ -76,6 +76,64 @@ func TestShow_HumanOutputIncludesWorkSummary(t *testing.T) {
 	}
 }
 
+func TestShow_HumanOutputIncludesCurrentFailureDetail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(factoryapi.Work{
+			Name:   "Plan intake",
+			WorkId: stringPtr("work-plan"),
+			State:  &factoryapi.WorkState{Name: "failed", Type: factoryapi.WorkStateTypeFAILED},
+			FailureDetail: &factoryapi.FailureDetail{
+				Reason:  factoryapi.WorkFailureTypeInternalServerError,
+				Message: "repository root is dirty; inspect and commit or back up changes",
+			},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	if err := NewShow(testHTTPProtocol(t))(ShowConfig{
+		Context: context.Background(), Server: serverBase(t, srv), WorkID: "work-plan", Output: &out,
+	}); err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	want := "Failure reason:\tinternal_server_error\n" +
+		"Failure message:\trepository root is dirty; inspect and commit or back up changes\n"
+	if !strings.Contains(out.String(), want) {
+		t.Fatalf("output = %q, want current failure detail %q", out.String(), want)
+	}
+}
+
+func TestShow_JSONOutputIncludesFailureDetail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(factoryapi.Work{
+			WorkId: stringPtr("work-json-failed"),
+			FailureDetail: &factoryapi.FailureDetail{
+				Reason:  factoryapi.WorkFailureTypeInternalServerError,
+				Message: "root setup failed",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	if err := NewShow(testHTTPProtocol(t))(ShowConfig{
+		Context: context.Background(), Server: serverBase(t, srv), WorkID: "work-json-failed", JSON: true, Output: &out,
+	}); err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	var got factoryapi.Work
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("decode JSON: %v\n%s", err, out.String())
+	}
+	if got.FailureDetail == nil || got.FailureDetail.Reason != factoryapi.WorkFailureTypeInternalServerError || got.FailureDetail.Message != "root setup failed" {
+		t.Fatalf("failure detail = %#v, want structured JSON detail", got.FailureDetail)
+	}
+}
+
 func TestHumanApprovalCompatibilityWrappersDelegateToApprovalTransport(t *testing.T) {
 	var requestPaths []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/services/work/transports/http/read_mapping.go
+++ b/pkg/services/work/transports/http/read_mapping.go
@@ -90,6 +90,7 @@ func WorkReadModelToAPI(item work.ReadModel) factoryapi.Work {
 		SupersededBy:             optional.NonEmptyStringPtr(item.SupersededBy),
 		Content:                  contentcontract.GeneratedPtrFromParts(item.Content),
 		Tags:                     optional.CopiedStringMapPtr(item.Tags),
+		FailureDetail:            workFailureDetailToAPI(item.FailureDetail),
 		StopSummary:              workStopSummaryToAPI(item.StopSummary),
 	}
 	if jsonvalue.Present(item.StructuredResult, item.StructuredResultPresent) {
@@ -158,6 +159,16 @@ func WorkReadModelToAPI(item work.ReadModel) factoryapi.Work {
 		result.ExpectedArtifacts = &expectedArtifacts
 	}
 	return result
+}
+
+func workFailureDetailToAPI(detail *work.FailureDetail) *factoryapi.FailureDetail {
+	if detail == nil {
+		return nil
+	}
+	return &factoryapi.FailureDetail{
+		Reason:  factoryapi.WorkFailureType(detail.Reason),
+		Message: detail.Message,
+	}
 }
 
 func WorkReadModelToGenerated(item work.ReadModel) factoryapi.Work {

--- a/pkg/services/work/transports/http/read_mapping_test.go
+++ b/pkg/services/work/transports/http/read_mapping_test.go
@@ -138,6 +138,9 @@ func TestWorkReadModelToAPI_EncodesDetachedReadModel(t *testing.T) {
 			{Type: work.WorkContentPartTypeText, Text: "Review screenshot"},
 		},
 		Tags: map[string]string{"owner": "docs"},
+		FailureDetail: &work.FailureDetail{
+			Reason: "internal_server_error", Message: "repository root is dirty",
+		},
 		Relations: []work.ReadRelation{{
 			Type:           work.RelationDependsOn,
 			SourceWorkName: "Review PRD",
@@ -171,6 +174,9 @@ func TestWorkReadModelToAPI_EncodesDetachedReadModel(t *testing.T) {
 		t.Fatalf("human approval = %#v, want safe pending approval projection", got.HumanApproval)
 	}
 	assertExpectedArtifactAPI(t, got)
+	if got.FailureDetail == nil || got.FailureDetail.Reason != factoryapi.WorkFailureTypeInternalServerError || got.FailureDetail.Message != "repository root is dirty" {
+		t.Fatalf("failure detail = %#v, want mapped current Work failure", got.FailureDetail)
+	}
 }
 
 func TestWorkReadModelToAPI_PreservesOrderedMixedContentParts(t *testing.T) {
@@ -337,7 +343,7 @@ func TestWorkReadModelToAPI_OmitsEmptyOptionalCollections(t *testing.T) {
 	if err := json.Unmarshal(raw, &fields); err != nil {
 		t.Fatal(err)
 	}
-	for _, field := range []string{"content", "tags", "relations", "expectedArtifacts", "previousChainingTraceIds", "stopSummary"} {
+	for _, field := range []string{"content", "tags", "relations", "expectedArtifacts", "previousChainingTraceIds", "failureDetail", "stopSummary"} {
 		if _, present := fields[field]; present {
 			t.Fatalf("optional field %q unexpectedly present: %s", field, string(raw))
 		}

--- a/pkg/services/workers/execution_contracts.go
+++ b/pkg/services/workers/execution_contracts.go
@@ -423,6 +423,7 @@ type WorkResult struct {
 	StructuredResult            any                           `json:"structuredResult,omitempty"`
 	RecordedOutputWork          []work.FactoryWorkItem        `json:"recorded_output_work,omitempty"`
 	Error                       string                        `json:"error,omitempty"`
+	FailureDetail               *FailureDetail                `json:"failureDetail,omitempty"`
 	Feedback                    string                        `json:"feedback,omitempty"`
 	SelectedClassificationLabel string                        `json:"selected_classification_label,omitempty"`
 	ArtifactVerification        *ExpectedArtifactVerification `json:"artifact_verification,omitempty"`

--- a/pkg/services/workers/internal/services/workstations/executor/provider_invocation.go
+++ b/pkg/services/workers/internal/services/workstations/executor/provider_invocation.go
@@ -142,6 +142,7 @@ func providerInvocationFailure(
 		TransitionID:    request.Dispatch.TransitionID,
 		Outcome:         workerexecution.OutcomeFailed,
 		FailureMetadata: result.FailureMetadata,
+		FailureDetail:   workerexecution.CloneFailureDetail(result.FailureDetail),
 		Continuation:    cloneContinuation(result.Continuation),
 	}
 	if result.FailureDetail != nil {

--- a/pkg/transports/http/client/client.gen.go
+++ b/pkg/transports/http/client/client.gen.go
@@ -8054,6 +8054,7 @@ type Work struct {
 
 	// ExpectedArtifacts Effective expected artifact declarations and their latest recorded verification state.
 	ExpectedArtifacts *[]WorkExpectedArtifact `json:"expectedArtifacts,omitempty"`
+	FailureDetail     *FailureDetail          `json:"failureDetail,omitempty"`
 
 	// HumanApproval Safe read-only projection of one durable pending HUMAN_APPROVAL dispatch. The event ledger owns identity and status; display metadata is resolved from the effective factory topology.
 	HumanApproval *HumanApproval `json:"humanApproval,omitempty"`

--- a/pkg/transports/http/generated/server.gen.go
+++ b/pkg/transports/http/generated/server.gen.go
@@ -8080,6 +8080,7 @@ type Work struct {
 
 	// ExpectedArtifacts Effective expected artifact declarations and their latest recorded verification state.
 	ExpectedArtifacts *[]WorkExpectedArtifact `json:"expectedArtifacts,omitempty"`
+	FailureDetail     *FailureDetail          `json:"failureDetail,omitempty"`
 
 	// HumanApproval Safe read-only projection of one durable pending HUMAN_APPROVAL dispatch. The event ledger owns identity and status; display metadata is resolved from the effective factory topology.
 	HumanApproval *HumanApproval `json:"humanApproval,omitempty"`

--- a/tests/factory/scripts/test_setup_workspace_dirty_root.py
+++ b/tests/factory/scripts/test_setup_workspace_dirty_root.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Regression tests for refusing a dirty repository root during setup."""
+
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "factory" / "scripts" / "setup-workspace.py"
+
+
+def load_setup_workspace_module():
+    spec = importlib.util.spec_from_file_location(
+        "setup_workspace_dirty_root", SCRIPT_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def git(args, cwd, check=True):
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def init_repository(repo_path):
+    git(["init", "-b", "main"], repo_path)
+    git(
+        ["config", "user.email", "setup-workspace-test@example.com"],
+        repo_path,
+    )
+    git(["config", "user.name", "Setup Workspace Test"], repo_path)
+    (repo_path / "README.md").write_text("base\n", encoding="utf-8")
+    git(["add", "README.md"], repo_path)
+    git(["commit", "-m", "base"], repo_path)
+
+    exclude_path = repo_path / ".git" / "info" / "exclude"
+    exclude_path.write_text(
+        "tasks/todo/\nignored/\n.claude/\n",
+        encoding="utf-8",
+    )
+
+
+def write_prd(repo_path, prd_name):
+    tasks_dir = repo_path / "tasks" / "todo"
+    tasks_dir.mkdir(parents=True)
+    prd_path = tasks_dir / f"{prd_name}.json"
+    prd_path.write_text(
+        json.dumps({"branchName": prd_name}),
+        encoding="utf-8",
+    )
+
+
+def run_setup_workspace(repo_path, prd_name):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), prd_name],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class SetupWorkspaceDirtyRootTest(unittest.TestCase):
+    def setUp(self):
+        self.module = load_setup_workspace_module()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo_path = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def run_refusal_case(self, mutate_root):
+        init_repository(self.repo_path)
+        prd_name = "dirty-root-prd"
+        write_prd(self.repo_path, prd_name)
+        mutate_root()
+
+        head_before = git(["rev-parse", "HEAD"], self.repo_path).stdout
+        status_before = git(["status", "--porcelain=v1"], self.repo_path).stdout
+        result = run_setup_workspace(self.repo_path, prd_name)
+
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("repository root is dirty", result.stderr.lower())
+        self.assertIn(str(self.repo_path), result.stderr)
+        self.assertIn("total entries=", result.stderr)
+        self.assertIn("tracked changes=", result.stderr)
+        self.assertIn("untracked files=", result.stderr)
+        self.assertIn("Inspect the repository root manually", result.stderr)
+        self.assertIn("commit the changes", result.stderr)
+        self.assertIn("back them up and restore them manually", result.stderr)
+        self.assertEqual(
+            git(["rev-parse", "HEAD"], self.repo_path).stdout,
+            head_before,
+        )
+        self.assertEqual(
+            git(["status", "--porcelain=v1"], self.repo_path).stdout,
+            status_before,
+        )
+        self.assertFalse(
+            (self.repo_path / ".claude" / "worktrees" / prd_name).exists()
+        )
+
+    def test_refuses_unstaged_tracked_change_before_mutation(self):
+        def mutate():
+            (self.repo_path / "README.md").write_text(
+                "operator edit\n", encoding="utf-8",
+            )
+
+        self.run_refusal_case(mutate)
+
+    def test_refuses_staged_tracked_change_before_mutation(self):
+        def mutate():
+            staged_path = self.repo_path / "staged.txt"
+            staged_path.write_text("staged\n", encoding="utf-8")
+            git(["add", staged_path.name], self.repo_path)
+
+        self.run_refusal_case(mutate)
+
+    def test_refuses_mixed_tracked_and_untracked_changes_with_separate_counts(self):
+        def mutate():
+            (self.repo_path / "README.md").write_text(
+                "operator edit\n", encoding="utf-8",
+            )
+            (self.repo_path / "untracked.txt").write_text(
+                "operator data\n", encoding="utf-8",
+            )
+
+        self.run_refusal_case(mutate)
+        result = run_setup_workspace(self.repo_path, "dirty-root-prd")
+        self.assertIn("tracked changes=1", result.stderr)
+        self.assertIn("untracked files=1", result.stderr)
+
+    def test_ignored_only_root_remains_eligible(self):
+        init_repository(self.repo_path)
+        prd_name = "ignored-root-prd"
+        write_prd(self.repo_path, prd_name)
+        ignored_path = self.repo_path / "ignored" / "build-output.bin"
+        ignored_path.parent.mkdir()
+        ignored_path.write_bytes(b"ignored\0artifact")
+
+        result = run_setup_workspace(self.repo_path, prd_name)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["status"], "ready")
+        self.assertTrue(ignored_path.exists())
+
+    def test_unusual_path_is_safely_escaped(self):
+        init_repository(self.repo_path)
+        prd_name = "unusual-path-prd"
+        write_prd(self.repo_path, prd_name)
+        unusual_name = "operator [path] café.txt"
+        (self.repo_path / unusual_name).write_text(
+            "operator data\n", encoding="utf-8",
+        )
+
+        result = run_setup_workspace(self.repo_path, prd_name)
+
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn(
+            json.dumps(unusual_name, ensure_ascii=True),
+            result.stderr,
+        )
+        self.assertNotIn(unusual_name, result.stderr)
+
+    def test_sample_is_bounded_deterministic_and_reports_omitted_paths(self):
+        init_repository(self.repo_path)
+        prd_name = "bounded-sample-prd"
+        write_prd(self.repo_path, prd_name)
+        for index in range(self.module.MAX_DIRTY_ROOT_SAMPLE_ENTRIES + 5):
+            (self.repo_path / f"operator-{index:02d}.txt").write_text(
+                "operator data\n", encoding="utf-8",
+            )
+
+        first = run_setup_workspace(self.repo_path, prd_name)
+        second = run_setup_workspace(self.repo_path, prd_name)
+
+        self.assertEqual(first.returncode, 1, first.stdout)
+        self.assertEqual(second.returncode, 1, second.stdout)
+        self.assertEqual(first.stderr, second.stderr)
+        sample_entries = [
+            line for line in first.stderr.splitlines() if line.startswith("    ?? ")
+        ]
+        self.assertEqual(
+            len(sample_entries), self.module.MAX_DIRTY_ROOT_SAMPLE_ENTRIES,
+        )
+        self.assertIn("5 additional path(s) omitted", first.stderr)
+
+    def test_status_command_failure_stops_before_mutation(self):
+        init_repository(self.repo_path)
+        prd_name = "status-failure-prd"
+        write_prd(self.repo_path, prd_name)
+        original_run_git = self.module.run_git
+
+        def failing_status(*args, **kwargs):
+            if args[:1] == ("status",):
+                return SimpleNamespace(
+                    returncode=128,
+                    stdout="",
+                    stderr="simulated status failure\n",
+                )
+            return original_run_git(*args, **kwargs)
+
+        stderr = io.StringIO()
+        original_cwd = os.getcwd()
+        os.chdir(self.repo_path)
+        try:
+            with mock.patch.object(self.module, "run_git", side_effect=failing_status):
+                with mock.patch.object(self.module, "sync_main") as sync_main:
+                    with mock.patch.object(
+                        self.module, "prune_worktrees",
+                    ) as prune_worktrees:
+                        with mock.patch.object(
+                            self.module, "create_or_reuse_worktree",
+                        ) as create_worktree:
+                            with mock.patch.object(
+                                sys, "argv", ["setup-workspace.py", prd_name],
+                            ):
+                                with redirect_stderr(stderr):
+                                    with self.assertRaises(SystemExit) as raised:
+                                        self.module.main()
+        finally:
+            os.chdir(original_cwd)
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertIn("Root cleanliness check failed", stderr.getvalue())
+        self.assertIn("git status --porcelain=v1 failed", stderr.getvalue())
+        self.assertIn("simulated status failure", stderr.getvalue())
+        sync_main.assert_not_called()
+        prune_worktrees.assert_not_called()
+        create_worktree.assert_not_called()
+
+    def test_dirty_root_stops_before_mutation_capable_stages(self):
+        init_repository(self.repo_path)
+        prd_name = "dirty-stage-order-prd"
+        write_prd(self.repo_path, prd_name)
+        (self.repo_path / "README.md").write_text(
+            "operator edit\n", encoding="utf-8",
+        )
+
+        stderr = io.StringIO()
+        original_cwd = os.getcwd()
+        os.chdir(self.repo_path)
+        try:
+            with mock.patch.object(self.module, "sync_main") as sync_main, \
+                    mock.patch.object(
+                        self.module, "prune_worktrees",
+                    ) as prune_worktrees, \
+                    mock.patch.object(
+                        self.module, "create_or_reuse_worktree",
+                    ) as create_worktree, \
+                    mock.patch.object(
+                        self.module, "copy_prd_files",
+                    ) as copy_prd_files:
+                with mock.patch.object(
+                    sys, "argv", ["setup-workspace.py", prd_name],
+                ):
+                    with redirect_stderr(stderr):
+                        with self.assertRaises(SystemExit) as raised:
+                            self.module.main()
+        finally:
+            os.chdir(original_cwd)
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertIn("repository root is dirty", stderr.getvalue().lower())
+        sync_main.assert_not_called()
+        prune_worktrees.assert_not_called()
+        create_worktree.assert_not_called()
+        copy_prd_files.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/factory/scripts/test_setup_workspace_failures.py
+++ b/tests/factory/scripts/test_setup_workspace_failures.py
@@ -118,7 +118,7 @@ class SetupWorkspaceFailureTest(unittest.TestCase):
         original_prune = self.module.prune_worktrees
 
         def failing_prune(_repo_root):
-            raise RuntimeError(
+            raise ValueError(
                 "git worktree prune failed (exit 128): simulated prune failure"
             )
 
@@ -133,6 +133,171 @@ class SetupWorkspaceFailureTest(unittest.TestCase):
         self.assertIn("simulated prune failure", stderr)
         self.assertNotIn("Worktree preparation failed", stderr)
         self.assertNotIn("PRD copy failed", stderr)
+
+    def test_reports_prd_read_failure_with_bounded_unexpected_detail(self):
+        init_local_repo(self.repo_path)
+        prd_name = "prd-read-fail-prd"
+        write_prd(self.repo_path, prd_name)
+
+        def failing_read(_prd_path):
+            raise ValueError("malformed PRD detail\n" + ("x" * 5000))
+
+        original_read = self.module.read_prd
+        self.module.read_prd = failing_read
+        try:
+            exit_code, stderr = self.run_main_in_repo(prd_name)
+        finally:
+            self.module.read_prd = original_read
+
+        self.assertEqual(exit_code, 1)
+        self.assertLess(len(stderr), 1300)
+        self.assertLess(stderr.count("x"), 1100)
+        self.assertIn("Failed to read PRD: malformed PRD detail", stderr)
+        self.assertIn("more characters", stderr)
+        self.assertNotIn("Traceback", stderr)
+        self.assertNotIn("Root sync failed", stderr)
+
+    def test_reports_missing_prd_as_a_prd_read_failure(self):
+        init_local_repo(self.repo_path)
+        prd_name = "missing-prd"
+
+        result = run_setup_workspace(self.repo_path, prd_name)
+
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("Failed to read PRD:", result.stderr)
+        self.assertIn("PRD not found", result.stderr)
+        self.assertNotIn("Root sync failed", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_reports_unexpected_worktree_failure_with_stage_and_detail(self):
+        init_local_repo(self.repo_path)
+        prd_name = "worktree-unexpected-fail-prd"
+        write_prd(self.repo_path, prd_name)
+
+        def failing_worktree(*_args):
+            raise ValueError("simulated worktree preparation failure")
+
+        original_create = self.module.create_or_reuse_worktree
+        self.module.create_or_reuse_worktree = failing_worktree
+        try:
+            exit_code, stderr = self.run_main_in_repo(prd_name)
+        finally:
+            self.module.create_or_reuse_worktree = original_create
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn(
+            "Worktree preparation failed: simulated worktree preparation failure",
+            stderr,
+        )
+        self.assertNotIn("Traceback", stderr)
+        self.assertNotIn("Root sync failed", stderr)
+        self.assertNotIn("PRD copy failed", stderr)
+
+    def test_classifies_windows_reserved_path_with_manual_recovery(self):
+        init_local_repo(self.repo_path)
+        prd_name = "windows-reserved-path-prd"
+        write_prd(self.repo_path, prd_name)
+
+        def failing_worktree(*_args):
+            raise RuntimeError(
+                "git worktree add failed (exit 128): error: invalid path 'NUL'"
+            )
+
+        original_create = self.module.create_or_reuse_worktree
+        self.module.create_or_reuse_worktree = failing_worktree
+        try:
+            exit_code, stderr = self.run_main_in_repo(prd_name)
+        finally:
+            self.module.create_or_reuse_worktree = original_create
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("Worktree preparation failed:", stderr)
+        self.assertIn("Windows-reserved", stderr)
+        self.assertIn("literal NUL device name", stderr)
+        self.assertIn("manually back up", stderr)
+        self.assertIn("remove or rename", stderr)
+        self.assertIn("invalid path 'NUL'", stderr)
+        self.assertNotIn("Traceback", stderr)
+
+    @unittest.skipUnless(os.name == "nt", "Git path restriction is Windows-specific")
+    def test_classifies_reproducible_windows_reserved_nul_worktree_failure(self):
+        init_local_repo(self.repo_path)
+        prd_name = "windows-nul-fixture-prd"
+        write_prd(self.repo_path, prd_name)
+
+        blob = subprocess.run(
+            ["git", "hash-object", "-w", "--stdin"],
+            cwd=self.repo_path,
+            input=b"reserved path\n",
+            capture_output=True,
+            check=True,
+        ).stdout.decode().strip()
+        tree = subprocess.run(
+            ["git", "mktree"],
+            cwd=self.repo_path,
+            input=(
+                "100644 blob "
+                + blob
+                + chr(9)
+                + "NUL"
+                + chr(10)
+            ).encode(),
+            capture_output=True,
+            check=True,
+        ).stdout.decode().strip()
+        commit = subprocess.run(
+            ["git", "commit-tree", tree, "-m", "reserved path fixture"],
+            cwd=self.repo_path,
+            capture_output=True,
+            check=True,
+        ).stdout.decode().strip()
+        subprocess.run(
+            ["git", "update-ref", f"refs/heads/{prd_name}", commit],
+            cwd=self.repo_path,
+            check=True,
+        )
+
+        result = run_setup_workspace(self.repo_path, prd_name)
+
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("Worktree preparation failed:", result.stderr)
+        self.assertIn("Windows-reserved", result.stderr)
+        self.assertIn("literal NUL device name", result.stderr)
+        self.assertIn("manually back up", result.stderr)
+        self.assertIn("remove or rename", result.stderr)
+        self.assertIn("invalid path 'NUL'", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_reports_unexpected_prd_copy_failure_with_stage_and_detail(self):
+        init_local_repo(self.repo_path)
+        prd_name = "prd-copy-unexpected-fail-prd"
+        write_prd(self.repo_path, prd_name)
+
+        with mock.patch.object(
+            self.module,
+            "sync_main",
+            return_value="already up to date",
+        ), mock.patch.object(
+            self.module,
+            "prune_worktrees",
+        ), mock.patch.object(
+            self.module,
+            "create_or_reuse_worktree",
+            return_value=False,
+        ), mock.patch.object(
+            self.module,
+            "copy_prd_files",
+            side_effect=ValueError("simulated PRD copy failure"),
+        ):
+            exit_code, stderr = self.run_main_in_repo(prd_name)
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("PRD copy failed: simulated PRD copy failure", stderr)
+        self.assertNotIn("Traceback", stderr)
+        self.assertNotIn("Root sync failed", stderr)
+        self.assertNotIn("Worktree preparation failed", stderr)
 
     def test_reports_root_sync_failure_when_no_origin_and_local_main_missing(self):
         init_local_repo(self.repo_path)

--- a/tests/factory/scripts/test_setup_workspace_failures.py
+++ b/tests/factory/scripts/test_setup_workspace_failures.py
@@ -44,6 +44,26 @@ def init_local_repo(repo_path):
 
 
 def write_prd(repo_path, prd_name, include_md=False):
+    exclude_path = repo_path / ".git" / "info" / "exclude"
+    existing_excludes = (
+        exclude_path.read_text(encoding="utf-8")
+        if exclude_path.exists()
+        else ""
+    )
+    missing_excludes = [
+        entry
+        for entry in ("tasks/todo/", ".claude/")
+        if entry not in existing_excludes.splitlines()
+    ]
+    if missing_excludes:
+        exclude_path.write_text(
+            existing_excludes.rstrip("\n")
+            + "\n"
+            + "\n".join(missing_excludes)
+            + "\n",
+            encoding="utf-8",
+        )
+
     tasks_dir = repo_path / "tasks" / "todo"
     tasks_dir.mkdir(parents=True)
     prd_json = tasks_dir / f"{prd_name}.json"

--- a/tests/factory/scripts/test_setup_workspace_root_residue.py
+++ b/tests/factory/scripts/test_setup_workspace_root_residue.py
@@ -85,6 +85,10 @@ def create_remote_repository(root, remote_ahead):
 
     local = root / "local"
     git(["clone", str(remote), local.name], root)
+    (local / ".git" / "info" / "exclude").write_text(
+        "tasks/todo/\n.claude/\n",
+        encoding="utf-8",
+    )
     if remote_ahead:
         git(["reset", "--hard", "HEAD^"], local)
         git(["fetch", "origin"], local)
@@ -485,8 +489,6 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
         git(["push", "-u", "origin", lane], upstream)
         git(["fetch", "origin"], local)
 
-        root_only_file = local / "root-only-untracked.txt"
-        root_only_file.write_bytes(b"root only\n")
         tasks_dir = local / "tasks" / "todo"
         tasks_dir.mkdir(parents=True, exist_ok=True)
         (tasks_dir / f"{lane}.json").write_text(
@@ -513,7 +515,6 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
             git(["rev-parse", f"origin/{lane}"], worktree).stdout.strip(),
             lane_sha,
         )
-        self.assertFalse((worktree / root_only_file.name).exists())
         self.assertEqual(
             git(["rev-parse", "HEAD"], local).stdout.strip(), remote_sha,
         )
@@ -551,13 +552,12 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
             lane_next_sha,
         )
         self.assertEqual(marker.read_bytes(), b"keep lane marker\n")
-        self.assertFalse((worktree / root_only_file.name).exists())
         self.assertEqual(
             git(["rev-parse", "HEAD"], local).stdout.strip(), remote_sha,
         )
         self.assertEqual(
             git(["status", "--porcelain"], local).stdout,
-            f"?? {root_only_file.name}\n",
+            "",
         )
 
     def test_guard_rejects_ancestor_equivalent_index_and_worktree_without_repairing(self):
@@ -725,8 +725,8 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
         )
 
         self.assertEqual(result.returncode, 1, result.stdout)
-        self.assertIn("Root sync failed:", result.stderr)
-        self.assertIn("ancestor-residue guard", result.stderr)
+        self.assertIn("Root cleanliness check failed", result.stderr)
+        self.assertIn("repository root is dirty", result.stderr.lower())
         self.assertIn("merged.txt", result.stderr)
         self.assertFalse(
             (local / ".claude" / "worktrees" / prd_name).exists(),

--- a/tests/factory/scripts/test_setup_workspace_sync.py
+++ b/tests/factory/scripts/test_setup_workspace_sync.py
@@ -38,6 +38,10 @@ def init_local_repo(repo_path):
     readme.write_text("setup-workspace test repo\n", encoding="utf-8")
     subprocess.run(["git", "add", "README.md"], cwd=repo_path, check=True)
     subprocess.run(["git", "commit", "-m", "init"], cwd=repo_path, check=True)
+    (repo_path / ".git" / "info" / "exclude").write_text(
+        "tasks/todo/\n.claude/\n",
+        encoding="utf-8",
+    )
 
 
 def git(args, cwd, check=True):
@@ -72,6 +76,10 @@ def setup_repo_with_origin_main_ahead(local_repo, repo_root):
     git(["push", "origin", "main"], upstream)
 
     git(["clone", str(bare_remote), str(local_repo.name)], repo_root)
+    (local_repo / ".git" / "info" / "exclude").write_text(
+        "tasks/todo/\n.claude/\n",
+        encoding="utf-8",
+    )
     git(["reset", "--hard", "HEAD~1"], local_repo)
     git(["checkout", "-b", "feature-branch"], local_repo)
     (local_repo / "dirty.txt").write_text("unstaged change\n", encoding="utf-8")
@@ -380,9 +388,7 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             encoding="utf-8",
         )
 
-        original_root = self.module.get_repo_root
         original_restore = self.module.restore_stashed_changes
-        original_argv = self.module.sys.argv
         captured_snapshot = []
         interfering_stash = []
 
@@ -423,26 +429,22 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             self.assertNotEqual(snapshot_check.returncode, 0)
             return original_restore(repo_path, snapshot_id, scope_label)
 
-        self.module.get_repo_root = lambda: local_repo
         self.module.restore_stashed_changes = invalidate_snapshot
-        self.module.sys.argv = ["setup-workspace.py", prd_name]
         stderr = io.StringIO()
         try:
             with contextlib.redirect_stderr(stderr):
-                with self.assertRaises(SystemExit) as exit_context:
-                    self.module.main()
+                with self.assertRaises(RuntimeError) as raised:
+                    self.module.sync_main(local_repo)
         finally:
-            self.module.get_repo_root = original_root
             self.module.restore_stashed_changes = original_restore
-            self.module.sys.argv = original_argv
 
-        self.assertEqual(exit_context.exception.code, 1)
+        self.assertIn("could not verify snapshot", str(raised.exception))
         self.assertEqual(len(captured_snapshot), 1)
         self.assertEqual(len(interfering_stash), 1)
         snapshot_id = captured_snapshot[0]
         self.assertIn(
-            f"Root sync failed: root main sync could not verify snapshot {snapshot_id}",
-            stderr.getvalue(),
+            f"root main sync could not verify snapshot {snapshot_id}",
+            str(raised.exception),
         )
         self.assertEqual(stash_list(local_repo), [interfering_stash[0], *stack_before])
         self.assertFalse((local_repo / "interfering-only.txt").exists())
@@ -607,7 +609,7 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
         )
         self.assertFalse(any(args and args[0] == "checkout" for args in recorded))
 
-    def test_setup_workspace_exits_zero_through_sync_on_dirty_tree(self):
+    def test_setup_workspace_refuses_dirty_tree_before_sync(self):
         local_repo = self.repo_path / "local"
         setup_repo_with_origin_main_ahead(local_repo, self.repo_path)
 
@@ -628,21 +630,18 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             check=False,
         )
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-        origin_main_sha = git(
-            ["rev-parse", "refs/remotes/origin/main"],
-            local_repo,
-        ).stdout.strip()
-        local_main_sha = git(
-            ["rev-parse", "refs/heads/main"],
-            local_repo,
-        ).stdout.strip()
-        self.assertEqual(local_main_sha, origin_main_sha)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("repository root is dirty", result.stderr.lower())
+        self.assertNotIn("Root sync:", result.stderr)
         self.assertEqual(
             git(["branch", "--show-current"], local_repo).stdout.strip(),
             "feature-branch",
         )
         self.assertIn("?? dirty.txt", git(["status", "--porcelain"], local_repo).stdout)
+        self.assertFalse(
+            (local_repo / ".claude" / "worktrees" / prd_name).exists()
+        )
 
     def test_setup_workspace_continues_after_sync_skip(self):
         init_local_repo(self.repo_path)
@@ -696,18 +695,18 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             check=False,
         )
 
-        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("repository root is dirty", result.stderr.lower())
         self.assertIn("A  staged.txt", git(["status", "--porcelain"], local_repo).stdout)
         self.assertIn("?? dirty.txt", git(["status", "--porcelain"], local_repo).stdout)
         self.assertEqual(
             staged_file.read_text(encoding="utf-8"),
             "staged change\n",
         )
-        payload = json.loads(result.stdout)
-        worktree_path = Path(payload["worktree"])
-        self.assertTrue(worktree_path.exists())
-        self.assertTrue((worktree_path / "prd.json").exists())
-        self.assertIn("Root sync:", result.stderr)
+        self.assertFalse(
+            (local_repo / ".claude" / "worktrees" / prd_name).exists()
+        )
 
     def test_setup_workspace_reports_stashed_sync_on_dirty_main_checkout(self):
         local_repo = self.repo_path / "local"
@@ -734,11 +733,12 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             check=False,
         )
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("Root sync:", result.stderr)
-        self.assertIn("stashed local changes", result.stderr.lower())
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("repository root is dirty", result.stderr.lower())
+        self.assertNotIn("Root sync:", result.stderr)
         self.assertIn("?? dirty-main.txt", git(["status", "--porcelain"], local_repo).stdout)
-        self.assertEqual(
+        self.assertNotEqual(
             git(["rev-parse", "refs/heads/main"], local_repo).stdout.strip(),
             git(["rev-parse", "refs/remotes/origin/main"], local_repo).stdout.strip(),
         )

--- a/tests/factory/scripts/test_setup_workspace_worktree.py
+++ b/tests/factory/scripts/test_setup_workspace_worktree.py
@@ -59,6 +59,26 @@ def git(args, cwd, check=True):
 
 
 def write_prd(repo_path, prd_name, include_md=False):
+    exclude_path = repo_path / ".git" / "info" / "exclude"
+    existing_excludes = (
+        exclude_path.read_text(encoding="utf-8")
+        if exclude_path.exists()
+        else ""
+    )
+    missing_excludes = [
+        entry
+        for entry in ("tasks/todo/", ".claude/")
+        if entry not in existing_excludes.splitlines()
+    ]
+    if missing_excludes:
+        exclude_path.write_text(
+            existing_excludes.rstrip("\n")
+            + "\n"
+            + "\n".join(missing_excludes)
+            + "\n",
+            encoding="utf-8",
+        )
+
     tasks_dir = repo_path / "tasks" / "todo"
     tasks_dir.mkdir(parents=True)
     prd_json = tasks_dir / f"{prd_name}.json"
@@ -93,7 +113,10 @@ def setup_repo_with_origin_main_ahead(local_repo, repo_root):
     git(["clone", str(bare_remote), str(local_repo.name)], repo_root)
     git(["reset", "--hard", "HEAD~1"], local_repo)
     git(["checkout", "-b", "feature-branch"], local_repo)
-    (local_repo / "dirty.txt").write_text("unstaged change\n", encoding="utf-8")
+    (local_repo / ".git" / "info" / "exclude").write_text(
+        "tasks/todo/\n.claude/\n",
+        encoding="utf-8",
+    )
     git(["fetch", "origin"], local_repo)
 
     return bare_remote
@@ -312,10 +335,6 @@ class SetupWorkspaceWorktreeTest(unittest.TestCase):
         local_repo = self.repo_path / "local"
         setup_repo_with_origin_main_ahead(local_repo, self.repo_path)
 
-        staged_file = local_repo / "staged.txt"
-        staged_file.write_text("staged change\n", encoding="utf-8")
-        git(["add", "staged.txt"], local_repo)
-
         prd_name = "reuse-dirty-root-prd"
         write_prd(local_repo, prd_name)
 
@@ -325,14 +344,16 @@ class SetupWorkspaceWorktreeTest(unittest.TestCase):
         marker = Path(first_payload["worktree"]) / "reuse-marker.txt"
         marker.write_text("keep me\n", encoding="utf-8")
 
+        staged_file = local_repo / "staged.txt"
+        staged_file.write_text("staged change\n", encoding="utf-8")
+        git(["add", "staged.txt"], local_repo)
+
         second = run_setup_workspace(local_repo, prd_name)
-        self.assertEqual(second.returncode, 0, second.stderr)
-        second_payload = json.loads(second.stdout)
-        self.assertTrue(second_payload["reused"])
-        self.assertEqual(second_payload["worktree"], first_payload["worktree"])
+        self.assertEqual(second.returncode, 1, second.stdout)
+        self.assertEqual(second.stdout, "")
+        self.assertIn("repository root is dirty", second.stderr.lower())
         self.assertTrue(marker.exists())
         self.assertIn("A  staged.txt", git(["status", "--porcelain"], local_repo).stdout)
-        self.assertIn("?? dirty.txt", git(["status", "--porcelain"], local_repo).stdout)
 
     def test_reused_worktree_stashes_local_changes_before_syncing_upstream(self):
         bare_remote = self.repo_path / "remote.git"

--- a/tests/functional/workers/script/execution_test.go
+++ b/tests/functional/workers/script/execution_test.go
@@ -2,6 +2,7 @@ package script_test
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -88,6 +89,96 @@ func TestScriptWorkerNonZeroExitMapsToFailedOutcome(t *testing.T) {
 	}
 
 	assertScriptNonZeroExitDispatchFailure(t, events, scriptNonZeroExitMessage)
+}
+
+// TestScriptWorkerFailureReachesWorkShowThroughRootProcess proves the complete
+// customer path for an actionable setup-workspace failure: the script result
+// is recorded on the dispatch, projected onto failed Work, returned by the
+// session-scoped HTTP read, and rendered by both root-built CLI output modes.
+func TestScriptWorkerFailureReachesWorkShowThroughRootProcess(t *testing.T) {
+	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "script_executor_dir"))
+	testutil.WriteSeedFile(t, dir, "task", []byte("setup-workspace failure payload"))
+	const diagnostic = "repository root is dirty: 2 tracked changes, 1 untracked file; inspect and commit or back up changes"
+
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir: dir,
+		Edges: serviceedges.Edges{
+			ScriptCommandRunner: nonZeroExitCommandRunner{stderr: diagnostic, exitCode: 1},
+		},
+	})
+	support.WaitForTerminalStatus(t, server.URL(), 10*time.Second)
+
+	listed := support.ListDefaultSessionWork(t, server.URL())
+	failedWorkID := failedScriptWorkID(t, listed)
+	listItem := workByID(t, listed, failedWorkID)
+	assertWorkFailureDetail(t, listItem.FailureDetail, diagnostic)
+
+	got := support.GetDefaultSessionWorkByID(t, server.URL(), failedWorkID)
+	assertWorkFailureDetail(t, got.FailureDetail, diagnostic)
+
+	dispatches := support.ObserveDispatchEvents(t, support.GetFactoryEventsAt(t, server.URL()))
+	if len(dispatches) != 1 || dispatches[0].Response == nil {
+		t.Fatalf("dispatch observations = %#v, want one failed response", dispatches)
+	}
+	assertWorkFailureDetail(t, dispatches[0].Response.FailureDetail, diagnostic)
+
+	cliProcess := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, cliProcess)
+
+	humanInputs := support.FakeInputs(t.Context(), []string{
+		"you", "--server", server.URL(), "work", "show", failedWorkID,
+	})
+	if err := cliProcess.Execute(humanInputs.Input); err != nil {
+		t.Fatalf("root work show human error = %v\nstdout=%s\nstderr=%s", err, humanInputs.Stdout(), humanInputs.Stderr())
+	}
+	if !strings.Contains(humanInputs.Stdout(), "Failure reason:\tinternal_server_error") ||
+		!strings.Contains(humanInputs.Stdout(), "Failure message:\t"+diagnostic) {
+		t.Fatalf("root work show human output = %q, want typed actionable failure", humanInputs.Stdout())
+	}
+
+	jsonInputs := support.FakeInputs(t.Context(), []string{
+		"you", "--server", server.URL(), "--json", "work", "show", failedWorkID,
+	})
+	if err := cliProcess.Execute(jsonInputs.Input); err != nil {
+		t.Fatalf("root work show JSON error = %v\nstdout=%s\nstderr=%s", err, jsonInputs.Stdout(), jsonInputs.Stderr())
+	}
+	var jsonWork factoryapi.Work
+	if err := json.Unmarshal([]byte(jsonInputs.Stdout()), &jsonWork); err != nil {
+		t.Fatalf("decode root work show JSON: %v\nstdout=%s", err, jsonInputs.Stdout())
+	}
+	assertWorkFailureDetail(t, jsonWork.FailureDetail, diagnostic)
+}
+
+func failedScriptWorkID(t *testing.T, listed factoryapi.ListWorkResponse) string {
+	t.Helper()
+	for _, item := range listed.Results {
+		if item.State == nil || item.State.Name != "failed" {
+			continue
+		}
+		if id := support.StringPointerValue(item.WorkId); id != "" {
+			return id
+		}
+	}
+	t.Fatalf("failed script Work missing from listing: %#v", listed.Results)
+	return ""
+}
+
+func workByID(t *testing.T, listed factoryapi.ListWorkResponse, workID string) factoryapi.Work {
+	t.Helper()
+	for _, item := range listed.Results {
+		if support.StringPointerValue(item.WorkId) == workID {
+			return item
+		}
+	}
+	t.Fatalf("Work %q missing from listing: %#v", workID, listed.Results)
+	return factoryapi.Work{}
+}
+
+func assertWorkFailureDetail(t *testing.T, detail *factoryapi.FailureDetail, diagnostic string) {
+	t.Helper()
+	if detail == nil || detail.Reason != factoryapi.WorkFailureTypeInternalServerError || detail.Message != diagnostic {
+		t.Fatalf("Work failure detail = %#v, want internal_server_error/%q", detail, diagnostic)
+	}
 }
 
 // TestScriptWorkerCancellationTerminatesChildProcess proves cancelling a

--- a/ui/packages/client/src/generated/factory-event.schema.json
+++ b/ui/packages/client/src/generated/factory-event.schema.json
@@ -4533,6 +4533,9 @@
           },
           "type": "array"
         },
+        "failureDetail": {
+          "$ref": "#/$defs/FailureDetail"
+        },
         "humanApproval": {
           "$ref": "#/$defs/HumanApproval"
         },

--- a/ui/packages/client/src/generated/openapi.ts
+++ b/ui/packages/client/src/generated/openapi.ts
@@ -6997,6 +6997,31 @@ export interface components {
     } & {
       [key: string]: unknown;
     };
+    /** @description Operator-authored USD rates per one million tokens. Omit this property to use an empty table; no provider or model prices are supplied by default. */
+    GlobalConfigPriceTable: {
+      /**
+       * @description Currency used by every configured rate. This contract supports USD only.
+       * @enum {string}
+       */
+      currency: GlobalConfigPriceTableCurrency;
+      /** @description Deterministic provider/model price entries. */
+      models: components["schemas"]["GlobalConfigPriceTableModel"][];
+    };
+    /** @description Exact operator-authored rates for one provider and model identity. */
+    GlobalConfigPriceTableModel: {
+      /** @description Canonical provider identity or a supported built-in alias; the Operator Settings decoder trims and canonicalizes this value. */
+      provider: string;
+      /** @description Exact model identifier. It is trimmed but never guessed or aliased. */
+      model: string;
+      /** @description Non-negative USD rate per one million uncached input tokens. */
+      inputPerMillionTokens: string;
+      /** @description Non-negative USD rate per one million non-reasoning output tokens. */
+      outputPerMillionTokens: string;
+      /** @description Optional non-negative USD rate per one million cached input tokens. */
+      cachedInputPerMillionTokens?: string;
+      /** @description Optional non-negative USD rate per one million reasoning output tokens. */
+      reasoningOutputPerMillionTokens?: string;
+    };
     /** @description Runtime observability settings loaded from operator configuration before command-line overrides. */
     GlobalConfigRuntime: {
       /** @description Structured runtime log storage settings. Omitted values use the documented production defaults. */
@@ -7141,6 +7166,8 @@ export interface components {
       stopSummary?: components["schemas"]["FactoryStopSummary"];
       /** @description Pending HUMAN_APPROVAL request currently owning this Work item, when present. */
       humanApproval?: components["schemas"]["HumanApproval"];
+      /** @description Most recent bounded failure detail when this Work item is currently in a failed state. */
+      failureDetail?: components["schemas"]["FailureDetail"];
     };
     /** @description Ordered canonical content parts for one work item. */
     WorkContent: components["schemas"]["WorkContentPart"][];

--- a/ui/packages/client/src/generated/openapi.ts
+++ b/ui/packages/client/src/generated/openapi.ts
@@ -6997,31 +6997,6 @@ export interface components {
     } & {
       [key: string]: unknown;
     };
-    /** @description Operator-authored USD rates per one million tokens. Omit this property to use an empty table; no provider or model prices are supplied by default. */
-    GlobalConfigPriceTable: {
-      /**
-       * @description Currency used by every configured rate. This contract supports USD only.
-       * @enum {string}
-       */
-      currency: GlobalConfigPriceTableCurrency;
-      /** @description Deterministic provider/model price entries. */
-      models: components["schemas"]["GlobalConfigPriceTableModel"][];
-    };
-    /** @description Exact operator-authored rates for one provider and model identity. */
-    GlobalConfigPriceTableModel: {
-      /** @description Canonical provider identity or a supported built-in alias; the Operator Settings decoder trims and canonicalizes this value. */
-      provider: string;
-      /** @description Exact model identifier. It is trimmed but never guessed or aliased. */
-      model: string;
-      /** @description Non-negative USD rate per one million uncached input tokens. */
-      inputPerMillionTokens: string;
-      /** @description Non-negative USD rate per one million non-reasoning output tokens. */
-      outputPerMillionTokens: string;
-      /** @description Optional non-negative USD rate per one million cached input tokens. */
-      cachedInputPerMillionTokens?: string;
-      /** @description Optional non-negative USD rate per one million reasoning output tokens. */
-      reasoningOutputPerMillionTokens?: string;
-    };
     /** @description Runtime observability settings loaded from operator configuration before command-line overrides. */
     GlobalConfigRuntime: {
       /** @description Structured runtime log storage settings. Omitted values use the documented production defaults. */

--- a/ui/src/api/generated/openapi.ts
+++ b/ui/src/api/generated/openapi.ts
@@ -7135,6 +7135,8 @@ export interface components {
       stopSummary?: components["schemas"]["FactoryStopSummary"];
       /** @description Pending HUMAN_APPROVAL request currently owning this Work item, when present. */
       humanApproval?: components["schemas"]["HumanApproval"];
+      /** @description Most recent bounded failure detail when this Work item is currently in a failed state. */
+      failureDetail?: components["schemas"]["FailureDetail"];
     };
     /** @description Ordered canonical content parts for one work item. */
     WorkContent: components["schemas"]["WorkContentPart"][];


### PR DESCRIPTION
{
  "project": "Surface Actionable setup-workspace Root Diagnostics",
  "branchName": "intake-setup-workspace-dirty-root-diagnostic",
  "description": "Prevent a dirty main repository checkout from causing a silent intake outage. setup-workspace will refuse before root synchronization or snapshot work, return a bounded diagnostic with repository identity and tracked/untracked counts, recommend only manual non-destructive recovery, and preserve the existing private recovery-ref mechanism. The canonical script failure will also be projected onto failed Work reads so human and JSON you work show output explains why a plan lane failed.",
  "context": {
    "customerAsk": "Make setup-workspace detect a dirty repository root before any sync or stash work, report an explicit bounded diagnostic with file counts and separate tracked/untracked evidence, and surface that diagnostic on the failing Work item through the normal operator path. Preserve the private recovery-ref behavior and all existing worktree, branch, PRD-copy, Factory-topology, and visit-cap behavior. Audit other opaque early failures, including the Windows literal NUL case, and give confirmed actionable cases specific messages.",
    "problem": "In the operator-confirmed 2026-08-22 incident, a root with 117 modified files caused three new lanes to die at plan/failed while already-running lanes continued. The useful Git error reached only daemon stderr, so the board and CLI gave no actionable explanation and diagnosis took about 20 minutes. Because setup-workspace fronts every new lane, this one opaque failure produced a silent total intake outage.",
    "solution": "Evaluate Git's non-ignored porcelain status at the repository root before sync, pruning, snapshot capture, worktree mutation, or copying. Refuse dirty roots with total/tracked/untracked counts, a deterministic bounded and safely rendered path sample, and commit-or-backup/restore guidance without performing remediation. Preserve canonical script failure details through dispatch events, project the latest relevant failure onto current failed Work reads, expose it through the authored Work API and human/JSON you work show output, and narrowly classify other confirmed actionable early setup failures while preserving all clean-root and private recovery-ref behavior."
  },
  "acceptanceCriteria": [
    "With staged or unstaged tracked changes or non-ignored untracked files, setup-workspace exits non-zero before root sync, snapshot, prune, worktree, or copy side effects; stderr names the repository root as dirty, reports total/tracked/untracked counts, shows a deterministic bounded safe path sample, and recommends manual inspection plus commit or backup/restore without mutating the root.",
    "The script-worker failure text remains the canonical failed-dispatch diagnostic and is projected onto the current failed Work item; both human and JSON you work show output expose the actionable message for a plan/failed lane without showing stale failures on successful, retried, unrelated, or non-failed Work.",
    "With a clean root, setup-workspace retains its exact branch/worktree/PRD/rules behavior, emits the established success JSON on stdout, and exits 0; ignored artifacts do not trigger refusal, while every non-ignored untracked file intentionally does.",
    "The existing private-recovery-ref snapshot behavior remains stack-independent, no shared refs/stash storage or pop is introduced, and the new guard never auto-cleans, stashes, checks out, resets, deletes, or otherwise changes operator root work.",
    "Confirmed early setup failures, including a reproducible Windows-reserved literal NUL path failure where applicable, identify their setup stage and safe operator action; the PR reports audited cases and real observed command/output evidence and labels any unmeasured host-specific behavior as Operator-owned verification.",
    "Quality gates pass: focused Python setup-workspace regression tests, Work projection/API/CLI tests, Typecheck passes, Tests pass, no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green; generated clients are regenerated from authored OpenAPI when the Work contract changes.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "intake-setup-workspace-dirty-root-diagnostic-001",
      "title": "Refuse a dirty repository root with bounded actionable evidence",
      "description": "As a factory operator, I want workspace setup to refuse a dirty repository root before any mutation and tell me exactly what category of changes blocked intake so I can recover safely in seconds.",
      "acceptanceCriteria": [
        "Before root sync, snapshot capture, prune, worktree preparation, or PRD copy, status is evaluated against the discovered repository root using Git's non-ignored porcelain view.",
        "A dirty root produces exit code 1, no success JSON on stdout, and stage-specific stderr containing the phrase repository root is dirty, the root path, total entry count, tracked-change count, and untracked-file count.",
        "The diagnostic lists a deterministic sample capped at a documented small maximum, labels tracked and untracked entries separately, safely renders unusual path characters, and reports how many additional paths were omitted.",
        "The remedy tells the operator to inspect and commit the changes or back them up and restore them manually; the guard does not clean, stash, checkout, reset, delete, or otherwise alter the dirty root.",
        "Ignored files do not count because Git omits them from the status contract; every non-ignored untracked file counts by design, including a build artifact not covered by ignore rules.",
        "Focused regression tests cover staged, unstaged, mixed tracked/untracked, ignored-only, unusual-path, bounded-sample, and status-command-failure behavior and prove mutation-capable later stages were not invoked after refusal.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added a pre-sync non-ignored porcelain status guard with tracked/untracked counts, bounded deterministic safely escaped samples, manual recovery guidance, and bounded status-command failure handling. Added staged, unstaged, mixed, ignored-only, unusual-path, bounded-sample, failure-order, and no-mutation regressions; all focused setup-workspace suites pass."
    },
    {
      "id": "intake-setup-workspace-dirty-root-diagnostic-002",
      "title": "Show the setup failure on the failed Work item",
      "description": "As a factory operator, I want you work show to display the workspace setup failure attached to the failed plan Work so I do not need daemon access to diagnose an intake outage.",
      "acceptanceCriteria": [
        "A non-zero script-worker result retains its bounded stderr diagnostic in the canonical dispatch failure detail and Factory Event history without substituting a generic message.",
        "When Work is currently in a failed state, its read projection exposes the most recent failed dispatch that consumed that Work as an optional typed failure detail with reason and message, using deterministic ordering for multiple matching attempts.",
        "A later successful or current non-failed state, unrelated dispatch, or superseded attempt does not leave a stale failure detail on the Work item.",
        "The authored Work API contract includes the optional failure detail, mapping preserves it in list and get JSON, and generated Go and TypeScript clients are regenerated rather than edited by hand.",
        "Human you work show prints a clearly labeled failure reason and actionable message, JSON output emits the same structured detail, and existing success output is unchanged when no current failure exists.",
        "A root-composed behavioral test drives a script non-zero result through dispatch, failed Work projection, HTTP mapping, and CLI rendering and proves the dirty-root text is visible through you work show rather than only raw stderr or an internal event.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Carried the bounded script failure detail through WorkResult, dispatch history, Factory Events, and live/historical failed Work projections; added the optional Work API field with regenerated Go/TypeScript clients, human/JSON work show output, and a root-composed script-worker regression. Review follow-up clears failure detail from superseded failed Work rows in both include-superseded ListWork and GetWork. Focused affected Go suites, API/contract smoke, package verification, and dashboard typecheck pass."
    },
    {
      "id": "intake-setup-workspace-dirty-root-diagnostic-003",
      "title": "Classify other actionable early workspace setup failures",
      "description": "As a factory operator, I want early workspace setup failures to name their stage and safe remedy so other platform-specific faults do not recreate the same opaque outage.",
      "acceptanceCriteria": [
        "The implementer exercises each early setup stage through focused failure fixtures and documents in the PR which failures already surface adequate stage context and which confirmed cases required new classification.",
        "On Windows, a reproducible reserved literal NUL path or equivalent Git path failure receives a specific bounded message identifying the problematic path class and recommending manual backup and removal or rename; if the host cannot reproduce it, the PR records the exact unverified Operator-owned verification step rather than claiming success.",
        "PRD read, root sync, worktree preparation, and copy failures retain distinct stage labels and useful safe command details; unexpected failures use a stage-specific fallback rather than losing the actionable underlying text.",
        "Failure classification does not auto-remediate, expose unbounded command output, change successful stdout JSON, or alter worktree layout, branch naming, PRD or rules copying, Factory topology, or visit caps.",
        "Focused tests fail on the pre-change generic or opaque behavior and assert observable exit status and operator message, not source inventories or helper topology.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added bounded safe stage-failure rendering for PRD read, root sync, worktree preparation, and PRD/rules copy paths, preserving actionable underlying details without tracebacks. Invalid Git paths receive a Windows-reserved/literal-NUL message with manual backup and remove-or-rename guidance. Audited missing and malformed PRD, unexpected root sync/worktree/copy, optional rules-copy, and root-discovery failures. Focused setup-workspace tests pass (58 tests), py_compile and dashboard typecheck pass. On Windows, a Git plumbing fixture reproduced: `error: invalid path 'NUL'`; the end-to-end setup failure now includes the classified remedy."
    }
  ]
}
