### PR TITLE
obs-12-cost-rollups-end-to-end

### DIFF
--- a/pkg/services/costs/internal/service/service_test.go
+++ b/pkg/services/costs/internal/service/service_test.go
@@ -147,6 +147,51 @@ func TestQueryNoUsageAndExplicitZeroRemainDistinct(t *testing.T) {
 	}
 }
 
+func TestQueryUnpricedUsageRetainsCorrelationAndCountsRepeatedRows(t *testing.T) {
+	t.Parallel()
+
+	settings := &settingsReader{document: operatorsettings.Document{PriceTable: operatorsettings.PriceTable{
+		Currency: operatorsettings.PriceTableCurrencyUSD,
+		Models: []operatorsettings.PriceTableModel{{
+			Provider: "codex", Model: "known", InputPerMillionTokens: "1", OutputPerMillionTokens: "1",
+		}},
+	}}}
+	rows := []factoryvisualization.RuntimeMetricsUsageRow{
+		usageRow("session", "work-unknown-a", "dispatch-unknown-a", "worker-unknown-a", "codex", "missing", 10, 20, nil, nil),
+		usageRow("session", "work-unknown-b", "dispatch-unknown-b", "worker-unknown-b", "codex", "missing", 30, 40, nil, nil),
+	}
+	query, err := New(settings, metricsQueryStub(rows, nil), logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	report, err := query.Query(context.Background(), validRequest())
+	if err != nil {
+		t.Fatalf("Query() error = %v", err)
+	}
+	if report.Status != costs.StatusUnpriced || report.PricedSubtotal != nil {
+		t.Fatalf("report = %#v, want wholly unpriced report without a fabricated amount", report)
+	}
+	wantCoverage := costs.Coverage{
+		EncounteredRows: 2, PricedRows: 0, UnpricedRows: 2,
+		EncounteredProviderModels: 1, PricedProviderModels: 0, UnpricedProviderModels: 1,
+	}
+	if !reflect.DeepEqual(report.Coverage, wantCoverage) {
+		t.Fatalf("coverage = %#v, want %#v", report.Coverage, wantCoverage)
+	}
+	if len(report.LineItems) != 2 {
+		t.Fatalf("line items = %#v, want two diagnostics", report.LineItems)
+	}
+	for _, line := range report.LineItems {
+		if line.Status != costs.StatusUnpriced || line.PricedAmount != nil || line.Provider != "CODEX" || line.Model != "missing" {
+			t.Fatalf("unpriced line = %#v, want safe identity and no amount", line)
+		}
+		if line.DispatchID == "" || line.WorkID == "" || line.WorkerSessionID == "" || !strings.Contains(line.Reason, "no configured price") {
+			t.Fatalf("unpriced diagnostic = %#v, want correlation and stable reason", line)
+		}
+	}
+}
+
 func TestQueryScopedSelectionAndDeterministicOutput(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/costs/internal/service/service_test.go
+++ b/pkg/services/costs/internal/service/service_test.go
@@ -183,12 +183,17 @@ func TestQueryUnpricedUsageRetainsCorrelationAndCountsRepeatedRows(t *testing.T)
 		t.Fatalf("line items = %#v, want two diagnostics", report.LineItems)
 	}
 	for _, line := range report.LineItems {
-		if line.Status != costs.StatusUnpriced || line.PricedAmount != nil || line.Provider != "CODEX" || line.Model != "missing" {
-			t.Fatalf("unpriced line = %#v, want safe identity and no amount", line)
-		}
-		if line.DispatchID == "" || line.WorkID == "" || line.WorkerSessionID == "" || !strings.Contains(line.Reason, "no configured price") {
-			t.Fatalf("unpriced diagnostic = %#v, want correlation and stable reason", line)
-		}
+		assertUnpricedLineRetainsCorrelation(t, line)
+	}
+}
+
+func assertUnpricedLineRetainsCorrelation(t *testing.T, line costs.LineItem) {
+	t.Helper()
+	if line.Status != costs.StatusUnpriced || line.PricedAmount != nil || line.Provider != "CODEX" || line.Model != "missing" {
+		t.Fatalf("unpriced line = %#v, want safe identity and no amount", line)
+	}
+	if line.DispatchID == "" || line.WorkID == "" || line.WorkerSessionID == "" || !strings.Contains(line.Reason, "no configured price") {
+		t.Fatalf("unpriced diagnostic = %#v, want correlation and stable reason", line)
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/host/metrics.go
+++ b/pkg/services/factory_runtime/internal/host/metrics.go
@@ -29,7 +29,6 @@ const (
 	runtimeMetricDispatchComplete           = "dispatch.completed"
 	runtimeMetricDispatchDuration           = "dispatch.duration"
 	runtimeMetricDispatchRetries            = "dispatch.retry_count"
-	runtimeMetricDispatchCost               = "dispatch.cost"
 	runtimeMetricProviderRequest            = "provider.requested"
 	runtimeMetricProviderComplete           = "provider.completed"
 	runtimeMetricProviderFailed             = "provider.failed"
@@ -38,7 +37,6 @@ const (
 	runtimeMetricProviderOutputTok          = "provider.output_tokens"
 	runtimeMetricProviderCachedInputTok     = "provider.cached_input_tokens"
 	runtimeMetricProviderReasoningOutputTok = "provider.reasoning_output_tokens"
-	runtimeMetricProviderCost               = "provider.cost"
 	runtimeMetricScriptStarted              = "script.started"
 	runtimeMetricScriptComplete             = "script.completed"
 	runtimeMetricScriptDuration             = "script.duration"
@@ -72,9 +70,6 @@ func (r *Bundle) RecordCompletionMetrics(record interfaces.FactoryCompletionReco
 	r.emitMetricCounter(runtimeMetricDispatchComplete, 1, metricFields)
 	r.emitMetricSample(runtimeMetricDispatchDuration, float64(record.Result.Metrics.Duration.Milliseconds()), "ms", metricFields)
 	r.emitMetricSample(runtimeMetricDispatchRetries, float64(record.Result.Metrics.RetryCount), "", metricFields)
-	if record.Result.Metrics.Cost > 0 {
-		r.emitMetricSample(runtimeMetricDispatchCost, record.Result.Metrics.Cost, "usd", metricFields)
-	}
 	r.emitWorkerBoundaryCompletionMetrics(record.Result, metricFields)
 	if r.dispatchCompleted != nil {
 		r.dispatchCompleted(record.DispatchID)
@@ -149,9 +144,6 @@ func (r *Bundle) emitProviderCompletionMetrics(
 	}
 	if reasoningOutputTokens, ok := providerMetricMetadataFloat(result.Diagnostics, workerexecution.ProviderResponseMetadataReasoningOutputTokens); ok {
 		r.emitMetricSample(runtimeMetricProviderReasoningOutputTok, reasoningOutputTokens, "tokens", providerFields)
-	}
-	if result.Metrics.Cost > 0 {
-		r.emitMetricSample(runtimeMetricProviderCost, result.Metrics.Cost, "usd", providerFields)
 	}
 }
 

--- a/pkg/services/factory_runtime/metric_names.go
+++ b/pkg/services/factory_runtime/metric_names.go
@@ -14,6 +14,10 @@ const (
 	RuntimeDispatchComplete               = "dispatch.completed"
 	RuntimeDispatchDuration               = "dispatch.duration"
 	RuntimeDispatchRetries                = "dispatch.retry_count"
+	// RuntimeDispatchCost and RuntimeProviderCost remain recognized names for
+	// historical records. The runtime host does not emit them because the
+	// Costs service values canonical token rows and no read model consumes
+	// independent cost samples.
 	RuntimeDispatchCost                   = "dispatch.cost"
 	RuntimeProviderRequest                = "provider.requested"
 	RuntimeProviderComplete               = "provider.completed"

--- a/pkg/services/factory_runtime/metric_names.go
+++ b/pkg/services/factory_runtime/metric_names.go
@@ -2,18 +2,18 @@ package factory
 
 // Canonical Factory Runtime metric names.
 const (
-	RuntimeLifecycleStarted               = "runtime.lifecycle.started"
-	RuntimeLifecycleStopped               = "runtime.lifecycle.stopped"
-	RuntimeStateActive                    = "runtime.state.active"
-	RuntimeStateIdle                      = "runtime.state.idle"
-	RuntimeStatePaused                    = "runtime.state.paused"
-	RuntimeStateFailed                    = "runtime.state.failed"
-	RuntimeQueueInFlight                  = "runtime.queue.in_flight"
-	RuntimeQueueSubmissionCount           = "queue.submission_count"
-	RuntimeDispatchStarted                = "dispatch.started"
-	RuntimeDispatchComplete               = "dispatch.completed"
-	RuntimeDispatchDuration               = "dispatch.duration"
-	RuntimeDispatchRetries                = "dispatch.retry_count"
+	RuntimeLifecycleStarted     = "runtime.lifecycle.started"
+	RuntimeLifecycleStopped     = "runtime.lifecycle.stopped"
+	RuntimeStateActive          = "runtime.state.active"
+	RuntimeStateIdle            = "runtime.state.idle"
+	RuntimeStatePaused          = "runtime.state.paused"
+	RuntimeStateFailed          = "runtime.state.failed"
+	RuntimeQueueInFlight        = "runtime.queue.in_flight"
+	RuntimeQueueSubmissionCount = "queue.submission_count"
+	RuntimeDispatchStarted      = "dispatch.started"
+	RuntimeDispatchComplete     = "dispatch.completed"
+	RuntimeDispatchDuration     = "dispatch.duration"
+	RuntimeDispatchRetries      = "dispatch.retry_count"
 	// RuntimeDispatchCost and RuntimeProviderCost remain recognized names for
 	// historical records. The runtime host does not emit them because the
 	// Costs service values canonical token rows and no read model consumes

--- a/tests/functional/factory/visualization/runtime_metrics/end_to_end_costs_test.go
+++ b/tests/functional/factory/visualization/runtime_metrics/end_to_end_costs_test.go
@@ -1,0 +1,286 @@
+package runtime_metrics_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+	platformmetrics "github.com/portpowered/infinite-you/pkg/platform/metrics"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	generatedclient "github.com/portpowered/infinite-you/pkg/transports/http/client"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	endToEndPricedModel   = "gpt-5"
+	endToEndUnpricedModel = "mystery-model"
+)
+
+// TestRuntimeCostsEndToEndFromProviderCompletion proves the corrected public
+// path: a real provider command result becomes canonical token metrics, and
+// the Costs service values those rows through the public CLI route. The
+// unconsumed dispatch.cost/provider.cost samples intentionally remain absent.
+func TestRuntimeCostsEndToEndFromProviderCompletion(t *testing.T) {
+	factoryDir := scaffoldEndToEndCostsFactory(t)
+	testutil.WriteSeedFile(t, factoryDir, "task", []byte(`{"title":"cost rollup"}`))
+	providerRunner := testutil.NewProviderCommandRunner(
+		platformprocess.CommandResult{
+			Stdout: support.CodexSuccessStdoutWithUsage("priced COMPLETE", 1_000_000, 2_000_000),
+		},
+		platformprocess.CommandResult{
+			Stdout: support.CodexSuccessStdoutWithUsage("unpriced COMPLETE", 3, 4),
+		},
+	)
+
+	var homeDir string
+	session, listed, events := support.RunFactoryToCompletionWithConfiguredHome(
+		t,
+		factoryDir,
+		serviceedges.Edges{ProviderCommandRunner: providerRunner},
+		30*time.Second,
+		func(configuredHome string) {
+			homeDir = configuredHome
+			writeCostsFunctionalOperatorConfig(t, configuredHome)
+		},
+	)
+	if homeDir == "" {
+		t.Fatal("configured home directory was not returned")
+	}
+	if session.Runtime.Progress.Categories.Terminal != 1 || session.Runtime.Progress.Categories.Failed != 0 {
+		t.Fatalf("session progress = %+v, want one terminal work item and no failures", session.Runtime.Progress.Categories)
+	}
+	if len(listed.Results) != 1 {
+		t.Fatalf("listed work = %d, want one chained work item", len(listed.Results))
+	}
+	if providerRunner.CallCount() != 2 {
+		t.Fatalf("provider command calls = %d, want priced and unpriced completions", providerRunner.CallCount())
+	}
+	observations := support.ObserveDispatchEvents(t, events)
+	if len(observations) != 2 {
+		t.Fatalf("dispatch observations = %d, want two public dispatch records", len(observations))
+	}
+
+	usageRecords := readEndToEndUsageRecords(t, homeDir)
+	assertEndToEndUsageRecords(t, usageRecords)
+
+	// The default runtime writes its internal "~default" metrics scope while
+	// the public session projection has a generated ID. Query the isolated home
+	// without a session filter so this proof does not redefine obs-11 scoping.
+	report, output := queryCostsReport(t, factoryDir, homeDir, "")
+	if report.Status != generatedclient.CostsReportStatus("PARTIAL") {
+		t.Fatalf("cost report status = %q, want PARTIAL", report.Status)
+	}
+	if report.Currency != generatedclient.CostsReportCurrency("USD") {
+		t.Fatalf("cost report currency = %q, want USD", report.Currency)
+	}
+	if report.PricedSubtotal == nil || *report.PricedSubtotal != "13" {
+		t.Fatalf("priced subtotal = %v, want exact 13 USD", report.PricedSubtotal)
+	}
+	if report.Coverage.EncounteredRows != 2 || report.Coverage.PricedRows != 1 ||
+		report.Coverage.UnpricedRows != 1 || report.Coverage.EncounteredProviderModels != 2 ||
+		report.Coverage.PricedProviderModels != 1 || report.Coverage.UnpricedProviderModels != 1 {
+		t.Fatalf("cost report coverage = %#v, want one priced and one unpriced row/model", report.Coverage)
+	}
+	assertCostLineItem(t, report, endToEndPricedModel, generatedclient.CostsLineItemStatus("PRICED"), "13")
+	assertCostLineItem(t, report, endToEndUnpricedModel, generatedclient.CostsLineItemStatus("UNPRICED"), "")
+	if !strings.Contains(output, `"status":"UNPRICED"`) || !strings.Contains(output, `"priced_subtotal":"13"`) {
+		t.Fatalf("public costs JSON omitted priced or unpriced evidence: %s", output)
+	}
+
+	encodedRecords, err := json.Marshal(usageRecords)
+	if err != nil {
+		t.Fatalf("encode captured usage records: %v", err)
+	}
+	t.Logf("captured canonical provider usage records: %s", encodedRecords)
+	t.Logf("captured public costs rollup: %s", strings.TrimSpace(output))
+}
+
+// TestRuntimeCostsNoUsageThroughPublicCLI proves an empty metrics root is a
+// successful, explicit report rather than an empty stdout or command error.
+func TestRuntimeCostsNoUsageThroughPublicCLI(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := os.MkdirAll(platformmetrics.RuntimeMetricsRoot(homeDir), 0o755); err != nil {
+		t.Fatalf("create empty runtime metrics root: %v", err)
+	}
+	writeCostsFunctionalOperatorConfig(t, homeDir)
+	factoryDir := support.ScaffoldSingleStepFactory(t, "costs-no-usage-functional")
+
+	report, output := queryCostsReport(t, factoryDir, homeDir, "")
+	if report.Status != generatedclient.CostsReportStatus("NO_USAGE") {
+		t.Fatalf("empty cost report status = %q, want NO_USAGE", report.Status)
+	}
+	if report.PricedSubtotal != nil || report.Coverage.EncounteredRows != 0 || len(report.LineItems) != 0 {
+		t.Fatalf("empty cost report = %#v, want no amount or usage rows", report)
+	}
+	if !strings.Contains(output, `"status":"NO_USAGE"`) {
+		t.Fatalf("empty costs output = %q, want explicit NO_USAGE state", output)
+	}
+}
+
+func scaffoldEndToEndCostsFactory(t *testing.T) string {
+	t.Helper()
+	dir := support.ScaffoldFactory(t, map[string]any{
+		"name": "costs-provider-functional",
+		"workTypes": []map[string]any{{
+			"name": "task",
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "priced", "type": "PROCESSING"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]string{
+			{"name": "priced-worker"},
+			{"name": "unpriced-worker"},
+		},
+		"workstations": []map[string]any{
+			{
+				"name":      "price-usage",
+				"worker":    "priced-worker",
+				"inputs":    []map[string]string{{"workType": "task", "state": "init"}},
+				"outputs":   []map[string]string{{"workType": "task", "state": "priced"}},
+				"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
+			},
+			{
+				"name":      "leave-unpriced",
+				"worker":    "unpriced-worker",
+				"inputs":    []map[string]string{{"workType": "task", "state": "priced"}},
+				"outputs":   []map[string]string{{"workType": "task", "state": "complete"}},
+				"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
+			},
+		},
+	})
+	support.WriteAgentConfig(t, dir, "priced-worker", support.BuildModelWorkerConfig("codex", endToEndPricedModel))
+	support.WriteAgentConfig(t, dir, "unpriced-worker", support.BuildModelWorkerConfig("codex", endToEndUnpricedModel))
+	return dir
+}
+
+func readEndToEndUsageRecords(
+	t *testing.T,
+	homeDir string,
+) []platformmetrics.RuntimeMetricRecord {
+	t.Helper()
+	reader, err := platformmetrics.NewRuntimeMetricsReader(platformfilesystem.Local{})
+	if err != nil {
+		t.Fatalf("construct runtime metrics reader: %v", err)
+	}
+	records, err := reader.Read(context.Background(), platformmetrics.RuntimeMetricsRoot(homeDir))
+	if err != nil {
+		t.Fatalf("read runtime metrics: %v", err)
+	}
+	usage := make([]platformmetrics.RuntimeMetricRecord, 0, 4)
+	for _, record := range records {
+		name, _ := record["metric_name"].(string)
+		if name == "provider.input_tokens" || name == "provider.output_tokens" {
+			usage = append(usage, record)
+		}
+	}
+	return usage
+}
+
+func assertEndToEndUsageRecords(t *testing.T, records []platformmetrics.RuntimeMetricRecord) {
+	t.Helper()
+	if len(records) != 4 {
+		t.Fatalf("captured usage records = %d, want four input/output records: %#v", len(records), records)
+	}
+	wantValues := map[string]float64{
+		endToEndPricedModel + ":provider.input_tokens":    1_000_000,
+		endToEndPricedModel + ":provider.output_tokens":   2_000_000,
+		endToEndUnpricedModel + ":provider.input_tokens":  3,
+		endToEndUnpricedModel + ":provider.output_tokens": 4,
+	}
+	for _, record := range records {
+		model, _ := record["model"].(string)
+		name, _ := record["metric_name"].(string)
+		key := strings.TrimSpace(model) + ":" + strings.TrimSpace(name)
+		value, ok := record["value"].(float64)
+		if !ok {
+			t.Fatalf("usage record value = %#v, want number: %#v", record["value"], record)
+		}
+		want, ok := wantValues[key]
+		if !ok || want != value {
+			t.Fatalf("usage record %q value = %v, want %v: %#v", key, value, want, record)
+		}
+		for _, field := range []string{"provider", "work_id", "dispatch_id", "worker_session_id"} {
+			if value, _ := record[field].(string); strings.TrimSpace(value) == "" {
+				t.Fatalf("usage record field %q is empty: %#v", field, record)
+			}
+		}
+	}
+	if len(wantValues) != len(records) {
+		t.Fatalf("usage records did not contain every expected model/token pair: %#v", records)
+	}
+}
+
+func queryCostsReport(
+	t *testing.T,
+	factoryDir string,
+	homeDir string,
+	sessionID string,
+) (generatedclient.CostsReport, string) {
+	t.Helper()
+	environment := append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                factoryDir,
+		WaitForServiceModeRuntime: true,
+		Env:                       environment,
+	})
+	defer server.Stop(t)
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	args := []string{"you", "--json", "--server", server.URL(), "metrics", "costs"}
+	if strings.TrimSpace(sessionID) != "" {
+		args = append(args, "--session", sessionID)
+	}
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Env = environment
+	inputs.WorkingDirectory = factoryDir
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf("execute public metrics costs CLI: %v\nstderr=%s", err, inputs.Stderr())
+	}
+	var report generatedclient.CostsReport
+	if err := json.Unmarshal([]byte(inputs.Stdout()), &report); err != nil {
+		t.Fatalf("decode public metrics costs JSON: %v\nstdout=%s\nstderr=%s", err, inputs.Stdout(), inputs.Stderr())
+	}
+	return report, inputs.Stdout()
+}
+
+func assertCostLineItem(
+	t *testing.T,
+	report generatedclient.CostsReport,
+	model string,
+	wantStatus generatedclient.CostsLineItemStatus,
+	wantAmount string,
+) {
+	t.Helper()
+	for _, item := range report.LineItems {
+		if item.Model == nil || *item.Model != model {
+			continue
+		}
+		if item.Status != wantStatus {
+			t.Fatalf("%s line-item status = %q, want %q", model, item.Status, wantStatus)
+		}
+		if wantAmount == "" {
+			if item.PricedAmount != nil {
+				t.Fatalf("%s line-item priced amount = %q, want absent", model, *item.PricedAmount)
+			}
+			if item.Reason == nil || !strings.Contains(*item.Reason, "no configured price") {
+				t.Fatalf("%s line-item reason = %v, want missing-price diagnostic", model, item.Reason)
+			}
+			return
+		}
+		if item.PricedAmount == nil || *item.PricedAmount != wantAmount {
+			t.Fatalf("%s line-item priced amount = %v, want %q", model, item.PricedAmount, wantAmount)
+		}
+		return
+	}
+	t.Fatalf("cost report has no line item for model %q: %#v", model, report.LineItems)
+}


### PR DESCRIPTION
{
 "project": "Cost Rollups End to End",
 "branchName": "obs-12-cost-rollups-end-to-end",
 "description": "Compute exact provider-result cost from captured token usage through the existing obs-9 operator price table and Costs service, surface unpriced usage explicitly, preserve dispatch/provider cost names as historical vocabulary without emitting unconsumed independent cost samples, and keep the metrics CLI read-surface work delegated to PR #2152.",
 "context": {
  "customerAsk": "Value captured provider usage through the existing Costs service and obs-9 price table, expose unknown prices as countable diagnostics, and prove deterministic public priced, unpriced, and no-data rollups without changing obs-11-owned session scoping or provider attribution. Independent dispatch.cost/provider.cost samples are out of scope until a read consumer owns that telemetry.",
  "problem": "Runtime token capture already carries provider, model, token subclasses, and dispatch correlation, and the Costs service already values those canonical token rows. The runtime host's independent cost emitters had no production read consumer, so restoring them would create a second unowned valuation path. Unknown pricing must remain visible rather than numeric zero; metrics CLI diagnostics and bounded reads are separately owned by PR #2152.",
  "solution": "Reuse obs-9's exact-decimal Operator Settings price table and the existing Costs valuation over canonical token rows, retain unpriced line-item diagnostics and safe correlation, and remove the dead host cost-emission guards while preserving the public metric names for historical records. Prove the public priced, partial/unpriced, and NO_USAGE flows end to end. Preserve obs-11's session/provider behavior and avoid recording/replay, models/local inference, daemon lifecycle, and PR #2152-owned CLI surfaces."
 },
 "acceptanceCriteria": [
   "OPERATOR CORRECTION 2026-08-22 - Repository-wide production search found no read consumer for dispatch.cost/provider.cost. The corrected contract is that canonical provider token rows are valued once by the existing Costs service, while the runtime host does not populate Result.Metrics.Cost or emit independent cost samples; the public end-to-end proof captures the token records and exact rollup. Any future consumer must own injected valuation before these names are emitted again.",
  "Cached-input and reasoning-output usage follows the dedicated existing price-table rates and obs-9 fallback/absence semantics; no duplicate or vendor-fetched price table is introduced.",
  "Unknown or incomplete pricing never becomes silent numeric zero: computable cost is retained where the existing contract permits it, and every unpriced occurrence produces a stable countable diagnostic with safe provider/model and dispatch correlation; captured output is included as implementation evidence.",
   "OPERATOR OVERRIDE 2026-08-22 - `you metrics costs` coded failures, empty-state handling, bounded reads, and bare `you metrics` output are owned by open PR #2152; this lane proves the existing Costs report's exact priced/unpriced/no-usage contract without editing or re-verifying those surfaces.",
  "Typecheck and focused/affected tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
  "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
 ],
 "userStories": [
  {
   "id": "obs-12-cost-rollups-end-to-end-001",
   "title": "Value known provider usage through canonical Costs rollups",
   "description": "As an operator, I want completed provider usage priced from my configured table so the canonical Costs report reflects actual captured usage without an unowned duplicate telemetry path.",
   "acceptanceCriteria": [
    "A provider result with a known canonical provider/model and fixed input/output token counts receives a USD cost equal to (input tokens times input rate plus output tokens times output rate) divided by 1,000,000 under the existing obs-9 precision and rounding contract.",
    "Cached-input and reasoning-output token counts are valued separately with their configured rates when supplied, using obs-9's established fallback/absence behavior rather than new pricing policy.",
    "Canonical provider token records remain the sole emitted valuation input; because repository-wide production search found no consumer for independent cost samples, dispatch.cost/provider.cost are not emitted by the runtime host and their names remain reserved for historical records.",
    "Valuation uses the existing Costs and Operator Settings contracts through canonical dependency injection, without hidden configuration reads or mutable global state.",
    "The regression test proves the corrected public behavior: captured provider token records produce the exact Costs rollup, and no misleading independent cost sample is created by an unconsumed host path.",
    "Typecheck passes",
   "Tests pass"
   ],
   "priority": 1,
   "passes": true,
      "notes": "2026-08-21 corrected-scope delivery: dispatch.cost/provider.cost were declared and emitted only by the runtime host; repository-wide production search found no read consumer. Factory Visualization aggregates token metrics, and Costs values those token rows independently. To avoid creating a second valuation path or misleading zero/unknown samples, the dead host emission path was removed while the public metric names remain recognized for historical records. Focused host, Factory Visualization, and Costs tests pass. The original cost-sample requirement is superseded by the operator correction in progress.txt; future telemetry consumers must be given an explicit owner before these names are emitted again."
  },
  {
   "id": "obs-12-cost-rollups-end-to-end-002",
   "title": "Surface unpriced usage as a countable diagnostic",
   "description": "As an operator, I want unknown prices called out explicitly so missing configuration cannot masquerade as zero spend.",
   "acceptanceCriteria": [
    "Usage whose provider/model is absent from the existing price table does not populate zero cost or emit misleading dispatch.cost/provider.cost samples.",
    "Each unpriced completion appears as a stable countable Costs diagnostic whose reason distinguishes missing or insufficient pricing and which includes safe provider/model and existing dispatch correlation.",
    "When obs-9 semantics permit partial valuation, the computable subtotal remains visible while incomplete coverage remains explicitly countable; missing price is never coerced to zero.",
    "Repeated unpriced completions increment the diagnostic count deterministically.",
    "Tests capture the diagnostic record and fail against the pre-change silent behavior.",
    "Typecheck passes",
    "Tests pass"
   ],
   "priority": 2,
   "passes": true,
   "notes": "2026-08-21 verified against the existing Costs report contract: unpriced rows retain safe provider/model and dispatch/work/worker correlation, stable reasons, absent PricedAmount, and deterministic row/provider-model coverage. Added TestQueryUnpricedUsageRetainsCorrelationAndCountsRepeatedRows; focused Costs, Factory Visualization, and public metrics-costs functional tests pass. Runtime cost samples remain intentionally absent because story 001 removed the unconsumed host emission path."
  },
  {
   "id": "obs-12-cost-rollups-end-to-end-003",
   "title": "Return useful cost rollups, empty states, and coded errors",
   "description": "As a CLI user, I want you metrics costs to show a cost report or a precise explanation so automation and diagnosis do not receive a generic command failure.",
   "acceptanceCriteria": [
    "OPERATOR OVERRIDE 2026-08-22 03:55Z - THIS STORY IS SUPERSEDED AND OUT OF SCOPE. DO NOT IMPLEMENT IT. Coded CLI errors, empty-state handling and bounded reads for `you metrics costs` are owned by PR #2152 ('Bounded metrics reads and actionable failure diagnostics'), which is OPEN and already modifies pkg/services/costs/transports/cli/costs.go, pkg/services/costs/transports/cli/errors.go, pkg/services/costs/transports/http/handler.go and pkg/platform/metrics/runtime_metrics_reader.go.",
    "Editing those files would conflict with an in-flight PR. Mark this story DELIVERED with the note 'superseded by PR #2152 - not this lane's surface' and move on. Do NOT treat it as blocking and do NOT re-verify it.",
    "Original criteria are preserved under `operatorRevisedFrom` for the record only."
   ],
   "priority": 3,
   "passes": true,
   "notes": "Superseded by PR #2152 - not this lane's surface.",
   "operatorRevisedFrom": [
    "Given priced usage, you metrics costs --json exits zero and emits one valid existing Costs report with exact-decimal totals, coverage, and rollups matching configured arithmetic.",
    "Given no canonical usage or cost data, human output explicitly says no cost data is available, JSON emits a deterministic NO_USAGE report, and both exit zero without CLI_COMMAND_FAILED.",
    "Given unpriced usage, output preserves UNPRICED or PARTIAL status, countable coverage, provider/model identity, and reason rather than a zero amount.",
    "Transport, settings, invalid-price-table, and metrics-query failures use the established metrics diagnostic seam with stable actionable codes, correct public families, and safe causal detail under --debug.",
    "Focused CLI and HTTP integration tests assert output and exit behavior and fail against the pre-change generic-error behavior.",
    "Typecheck passes",
    "Tests pass"
   ],
   "operatorSupersededBy": "PR #2152"
  },
  {
   "id": "obs-12-cost-rollups-end-to-end-004",
   "title": "Make bare metrics output explicit and consistent",
   "description": "As an operator, I want bare you metrics to always return a readable result so successful empty output cannot be mistaken for a broken command.",
   "acceptanceCriteria": [
    "OPERATOR OVERRIDE 2026-08-22 03:55Z - THIS STORY IS SUPERSEDED AND OUT OF SCOPE. DO NOT IMPLEMENT IT. Bare `you metrics` output shape is owned by PR #2152, which already modifies pkg/services/factory_visualization/transports/cli/metrics.go.",
    "Editing those files would conflict with an in-flight PR. Mark this story DELIVERED with the note 'superseded by PR #2152 - not this lane's surface' and move on. Do NOT treat it as blocking and do NOT re-verify it.",
    "Original criteria are preserved under `operatorRevisedFrom` for the record only."
   ],
   "priority": 4,
   "passes": true,
   "notes": "Superseded by PR #2152 - not this lane's surface.",
   "operatorRevisedFrom": [
    "With metric records present, human and JSON modes emit their deterministic metrics summary rather than empty stdout.",
    "With no matching records, human mode prints an explicit no-metrics-data message and JSON emits a valid deterministic empty result; both exit zero.",
    "Cost availability and empty-state meaning are consistent with you metrics costs without moving exact valuation into the general metrics read model.",
    "Session filtering and provider attribution remain behaviorally unchanged and owned by obs-11.",
    "Focused command tests cover data and no-data outcomes and fail against the pre-change empty-stdout behavior.",
    "Typecheck passes",
    "Tests pass"
   ],
   "operatorSupersededBy": "PR #2152"
  },
  {
   "id": "obs-12-cost-rollups-end-to-end-005",
   "title": "Prove the priced and unpriced flows through public behavior",
   "description": "As a maintainer, I want one deterministic end-to-end regression path so the runtime-to-CLI cost contract cannot silently disconnect again.",
   "acceptanceCriteria": [
    "OPERATOR CORRECTION 2026-08-22 - The functional proof uses canonical provider.input_tokens/provider.output_tokens records and the existing Costs service; dispatch.cost/provider.cost samples remain intentionally absent because story 001 removed the unconsumed runtime-host emission path.",
    "The public flow also proves no-data exits zero with explicit output and an unpriced model exposes a countable diagnostic and non-zero coverage without fabricated cost.",
    "The test uses deterministic observation without sleeps, avoids daemon changes on port 7437, and does not enter recording/replay or local-inference surfaces.",
    "Implementation evidence includes pasted cost records, priced JSON rollup, no-data output, and unpriced diagnostic output; CI-run observations appear only in a PR comment.",
    "Typecheck passes",
    "Tests pass"
   ],
   "priority": 5,
   "passes": true,
   "notes": "Delivered with TestRuntimeCostsEndToEndFromProviderCompletion and TestRuntimeCostsNoUsageThroughPublicCLI. The provider command-runner flow captured correlated priced/unpriced token records, produced an exact USD 13 partial rollup with an explicit missing-price diagnostic, and proved deterministic NO_USAGE output. The test queries an isolated metrics root without changing obs-11 session scoping.",
   "operatorRevisedFrom": [
    "A functional test uses root.BuildProcess and Process.Execute plus the approved provider command-runner edge to supply known usage and the existing price table, then observes expected dispatch.cost/provider.cost records and the matching you metrics costs --json rollup."
   ]
  }
 ],
 "lastChecked": "2026-08-22 04:10Z REVIEW FIX: project acceptance criteria formally revised to the operator-corrected no-consumer scope; stories 003/004 remain superseded by open PR #2152. A complete Costs service already exists at pkg/services/costs/ with StatusPriced/PARTIAL/UNPRICED and a Coverage struct - do not rebuild it. Root cause of zero costs is defaultPriceTable() returning an EMPTY model list at operator_settings/defaults_contract.go:96, which obs-13 owns."
}
