### PR TITLE
deflake-contractscheck-repo-mutation

### DIFF
--- a/cmd/ciclassify/main.go
+++ b/cmd/ciclassify/main.go
@@ -236,6 +236,7 @@ func normalizeChangedPath(path string) string {
 func isAPIContractPath(path string) bool {
 	return strings.HasPrefix(path, "api/") ||
 		strings.HasPrefix(path, "contracts/") ||
+		strings.HasPrefix(path, "cmd/contractscheck/") ||
 		strings.HasPrefix(path, "pkg/transports/http/") ||
 		strings.HasPrefix(path, "pkg/transports/mapping/") ||
 		strings.Contains(path, "/transports/http/") ||

--- a/cmd/ciclassify/main_test.go
+++ b/cmd/ciclassify/main_test.go
@@ -23,6 +23,7 @@ func TestClassifierValidationMatrixEmitsExactLaneSets(t *testing.T) {
 		{"frontend", []string{"ui/src/App.tsx"}, "frontend", []string{laneFrontend}},
 		{"backend or CLI", []string{"cmd/factory/main.go"}, "backend", []string{laneBackend, laneUIBackendIntegration}},
 		{"API contract", []string{"api/openapi-main.yaml"}, "api-contract", []string{laneFrontend, laneBackend, laneUIBackendIntegration, laneAPIPackage}},
+		{"contracts check", []string{"cmd/contractscheck/repository_mutation_test.go"}, "api-contract", []string{laneFrontend, laneBackend, laneUIBackendIntegration, laneAPIPackage}},
 		{"API package", []string{"packages/api/package.json"}, "api-package", []string{laneFrontend, laneBackend, laneUIBackendIntegration, laneAPIPackage}},
 		{"Packaged Factories package", []string{"packages/packaged-factories/package.json"}, "packaged-factories-package", []string{laneBackend, lanePackagedFactoriesPackage}},
 		{"Model Providers package", []string{"packages/model-providers/package.json"}, "model-providers-package", []string{laneBackend, laneModelProvidersPackage}},

--- a/cmd/contractscheck/main_test.go
+++ b/cmd/contractscheck/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -155,17 +158,36 @@ func commandFixture(t *testing.T) string {
 
 func commandTree(t *testing.T, root string) commandTreeSnapshot {
 	t.Helper()
+	return snapshotCommandTree(t, root, filepath.WalkDir, os.ReadFile)
+}
+
+func snapshotCommandTree(
+	t *testing.T,
+	root string,
+	walkDir func(string, fs.WalkDirFunc) error,
+	readFile func(string) ([]byte, error),
+) commandTreeSnapshot {
+	t.Helper()
 	result := make(commandTreeSnapshot)
-	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
-		if err != nil || entry.IsDir() {
+	if err := walkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
 			return err
+		}
+		if entry.IsDir() {
+			return nil
 		}
 		relative, err := filepath.Rel(root, path)
 		if err != nil {
 			return err
 		}
-		payload, err := os.ReadFile(path)
+		payload, err := readFile(path)
 		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
 			return err
 		}
 		result[filepath.ToSlash(relative)] = payload
@@ -174,6 +196,59 @@ func commandTree(t *testing.T, root string) commandTreeSnapshot {
 		t.Fatalf("walk repository: %v", err)
 	}
 	return result
+}
+
+func TestSnapshotCommandTreeSkipsTransientMissingEntriesAndReportsRemovals(t *testing.T) {
+	root := t.TempDir()
+	for _, path := range []string{"kept.txt", "walk-missing.txt", "read-missing.txt"} {
+		writeCommandFixture(t, root, path, path)
+	}
+	before := commandTree(t, root)
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read fixture directory: %v", err)
+	}
+	entryByName := make(map[string]os.DirEntry, len(entries))
+	for _, entry := range entries {
+		entryByName[entry.Name()] = entry
+	}
+	wrappedNotExist := func(path string) error {
+		return fmt.Errorf("fixture entry disappeared at %s: %w", path, fs.ErrNotExist)
+	}
+
+	after := snapshotCommandTree(
+		t,
+		root,
+		func(_ string, walkFn fs.WalkDirFunc) error {
+			for _, path := range []string{"kept.txt", "walk-missing.txt", "read-missing.txt"} {
+				fullPath := filepath.Join(root, path)
+				var callbackErr error
+				if path == "walk-missing.txt" {
+					callbackErr = wrappedNotExist(path)
+				}
+				if err := walkFn(fullPath, entryByName[path], callbackErr); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		func(path string) ([]byte, error) {
+			if filepath.Base(path) == "read-missing.txt" {
+				return nil, wrappedNotExist(filepath.Base(path))
+			}
+			return os.ReadFile(path)
+		},
+	)
+
+	diff := formatCommandTreeDiff(before, after)
+	for _, fragment := range []string{
+		"  removed: read-missing.txt",
+		"  removed: walk-missing.txt",
+	} {
+		if !strings.Contains(diff, fragment) {
+			t.Fatalf("formatCommandTreeDiff() = %q, want fragment %q", diff, fragment)
+		}
+	}
 }
 
 func writeCommandFixture(t *testing.T, root, path, contents string) {

--- a/cmd/contractscheck/main_test.go
+++ b/cmd/contractscheck/main_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -23,9 +22,7 @@ func TestRunPassesCleanStagingWithoutWriting(t *testing.T) {
 	if got := stdout.String(); got != successMessage+"\n" || stderr.Len() != 0 {
 		t.Fatalf("run() stdout = %q, stderr = %q", got, stderr.String())
 	}
-	if after := commandTree(t, root); !reflect.DeepEqual(after, before) {
-		t.Fatal("run() changed repository bytes on success")
-	}
+	assertCommandTreeUnchanged(t, "run() changed repository bytes on success", before, commandTree(t, root))
 }
 
 func TestRunReportsCombinedDriftDeterministicallyWithoutWriting(t *testing.T) {
@@ -71,9 +68,7 @@ func TestRunReportsCombinedDriftDeterministicallyWithoutWriting(t *testing.T) {
 			t.Fatalf("run %d stdout = %q, stderr = %q, want %q", runIndex, stdout, stderr, want)
 		}
 	}
-	if after := commandTree(t, root); !reflect.DeepEqual(after, before) {
-		t.Fatal("run() changed repository bytes on failure")
-	}
+	assertCommandTreeUnchanged(t, "run() changed repository bytes on failure", before, commandTree(t, root))
 }
 
 func TestRunReportsPackagedFactorySchemaDriftWithRegenerationRemedy(t *testing.T) {
@@ -115,9 +110,7 @@ func TestRunReportsPackagedFactorySchemaDriftWithRegenerationRemedy(t *testing.T
 					t.Fatalf("run() stderr = %q, want fragment %q", stderr, fragment)
 				}
 			}
-			if after := commandTree(t, root); !reflect.DeepEqual(after, before) {
-				t.Fatal("run() changed repository bytes on failure")
-			}
+			assertCommandTreeUnchanged(t, "run() changed repository bytes on failure", before, commandTree(t, root))
 		})
 	}
 }
@@ -160,9 +153,9 @@ func commandFixture(t *testing.T) string {
 	return root
 }
 
-func commandTree(t *testing.T, root string) map[string]string {
+func commandTree(t *testing.T, root string) commandTreeSnapshot {
 	t.Helper()
-	result := make(map[string]string)
+	result := make(commandTreeSnapshot)
 	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
 		if err != nil || entry.IsDir() {
 			return err
@@ -175,7 +168,7 @@ func commandTree(t *testing.T, root string) map[string]string {
 		if err != nil {
 			return err
 		}
-		result[filepath.ToSlash(relative)] = string(payload)
+		result[filepath.ToSlash(relative)] = payload
 		return nil
 	}); err != nil {
 		t.Fatalf("walk repository: %v", err)

--- a/cmd/contractscheck/repository_mutation_test.go
+++ b/cmd/contractscheck/repository_mutation_test.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const (
+	mutationExcerptMaxBytes = 256
+	mutationExcerptContext  = 32
+)
+
+type commandTreeSnapshot map[string][]byte
+
+type commandTreeChange struct {
+	path   string
+	kind   string
+	before []byte
+	after  []byte
+}
+
+func assertCommandTreeUnchanged(t *testing.T, message string, before, after commandTreeSnapshot) {
+	t.Helper()
+	if reflect.DeepEqual(before, after) {
+		return
+	}
+	t.Fatalf("%s:\n%s", message, formatCommandTreeDiff(before, after))
+}
+
+func formatCommandTreeDiff(before, after commandTreeSnapshot) string {
+	changes := commandTreeChanges(before, after)
+	if len(changes) == 0 {
+		return ""
+	}
+
+	var output strings.Builder
+	output.WriteString("repository mutation details:\n")
+	for _, change := range changes {
+		fmt.Fprintf(&output, "  %s: %s\n", change.kind, change.path)
+		if change.kind != "modified" {
+			continue
+		}
+
+		prefix := commonPrefixLength(change.before, change.after)
+		suffix := commonSuffixLength(change.before[prefix:], change.after[prefix:])
+		beforeEnd := len(change.before) - suffix
+		afterEnd := len(change.after) - suffix
+		fmt.Fprintf(
+			&output,
+			"    byte diff (first differing byte at offset %d; before %d bytes, after %d bytes):\n",
+			prefix,
+			len(change.before),
+			len(change.after),
+		)
+		fmt.Fprintf(
+			&output,
+			"      before: %s\n",
+			formatMutationExcerpt(change.before, prefix, beforeEnd),
+		)
+		fmt.Fprintf(
+			&output,
+			"      after:  %s\n",
+			formatMutationExcerpt(change.after, prefix, afterEnd),
+		)
+	}
+	return output.String()
+}
+
+func commandTreeChanges(before, after commandTreeSnapshot) []commandTreeChange {
+	paths := make(map[string]struct{}, len(before)+len(after))
+	for path := range before {
+		paths[path] = struct{}{}
+	}
+	for path := range after {
+		paths[path] = struct{}{}
+	}
+
+	orderedPaths := make([]string, 0, len(paths))
+	for path := range paths {
+		orderedPaths = append(orderedPaths, path)
+	}
+	sort.Strings(orderedPaths)
+
+	changes := make([]commandTreeChange, 0, len(orderedPaths))
+	for _, path := range orderedPaths {
+		beforePayload, beforeExists := before[path]
+		afterPayload, afterExists := after[path]
+		switch {
+		case !beforeExists:
+			changes = append(changes, commandTreeChange{path: path, kind: "added", after: afterPayload})
+		case !afterExists:
+			changes = append(changes, commandTreeChange{path: path, kind: "removed", before: beforePayload})
+		case !bytes.Equal(beforePayload, afterPayload):
+			changes = append(changes, commandTreeChange{
+				path:   path,
+				kind:   "modified",
+				before: beforePayload,
+				after:  afterPayload,
+			})
+		}
+	}
+	return changes
+}
+
+func commonPrefixLength(before, after []byte) int {
+	limit := len(before)
+	if len(after) < limit {
+		limit = len(after)
+	}
+	for index := 0; index < limit; index++ {
+		if before[index] != after[index] {
+			return index
+		}
+	}
+	return limit
+}
+
+func commonSuffixLength(before, after []byte) int {
+	limit := len(before)
+	if len(after) < limit {
+		limit = len(after)
+	}
+	for offset := 0; offset < limit; offset++ {
+		if before[len(before)-1-offset] != after[len(after)-1-offset] {
+			return offset
+		}
+	}
+	return limit
+}
+
+func formatMutationExcerpt(payload []byte, changedStart, changedEnd int) string {
+	if len(payload) == 0 {
+		return `""`
+	}
+
+	start := changedStart - mutationExcerptContext
+	if start < 0 {
+		start = 0
+	}
+	end := changedEnd + mutationExcerptContext
+	if end > len(payload) {
+		end = len(payload)
+	}
+	if end < start {
+		end = start
+	}
+	if end-start > mutationExcerptMaxBytes {
+		start = changedStart - mutationExcerptMaxBytes/4
+		if start < 0 {
+			start = 0
+		}
+		end = start + mutationExcerptMaxBytes
+		if end > len(payload) {
+			end = len(payload)
+			start = end - mutationExcerptMaxBytes
+			if start < 0 {
+				start = 0
+			}
+		}
+	}
+
+	excerpt := strconv.Quote(string(payload[start:end]))
+	if start > 0 {
+		excerpt = "…" + excerpt
+	}
+	if end < len(payload) {
+		excerpt += "…"
+	}
+	return excerpt
+}
+
+func TestCommandTreeDiffReportsAllChangesInStablePathOrder(t *testing.T) {
+	before := commandTreeSnapshot{
+		"same.txt":    []byte("same"),
+		"removed.txt": []byte("gone"),
+		"changed.txt": []byte("old"),
+		"z-last.txt":  []byte("last"),
+	}
+	after := commandTreeSnapshot{
+		"same.txt":    []byte("same"),
+		"changed.txt": []byte("new"),
+		"added.txt":   []byte("new file"),
+		"z-last.txt":  []byte("last"),
+	}
+
+	got := formatCommandTreeDiff(before, after)
+	want := strings.Join([]string{
+		"repository mutation details:",
+		"  added: added.txt",
+		"  modified: changed.txt",
+		"    byte diff (first differing byte at offset 0; before 3 bytes, after 3 bytes):",
+		"      before: \"old\"",
+		"      after:  \"new\"",
+		"  removed: removed.txt",
+		"",
+	}, "\n")
+	if got != want {
+		t.Fatalf("formatCommandTreeDiff() = %q, want %q", got, want)
+	}
+}
+
+func TestCommandTreeDiffShowsFixtureByteMutationAndSilencesUnchanged(t *testing.T) {
+	root := commandFixture(t)
+	const path = "unrelated.txt"
+	writeCommandFixture(t, root, path, "alpha\nbeta\n")
+	before := commandTree(t, root)
+	writeCommandFixture(t, root, path, "alpha\r\nbeta\n")
+	after := commandTree(t, root)
+
+	diff := formatCommandTreeDiff(before, after)
+	for _, fragment := range []string{
+		"  modified: " + path,
+		`before: "alpha\nbeta\n"`,
+		`after:  "alpha\r\nbeta\n"`,
+	} {
+		if !strings.Contains(diff, fragment) {
+			t.Fatalf("formatCommandTreeDiff() = %q, want fragment %q", diff, fragment)
+		}
+	}
+	if unchanged := formatCommandTreeDiff(after, after); unchanged != "" {
+		t.Fatalf("formatCommandTreeDiff() for unchanged snapshots = %q, want empty", unchanged)
+	}
+}
+
+func TestCommandTreeDiffBoundsLargeByteChanges(t *testing.T) {
+	before := bytes.Repeat([]byte("a"), mutationExcerptMaxBytes*4)
+	after := bytes.Repeat([]byte("b"), mutationExcerptMaxBytes*4)
+	diff := formatCommandTreeDiff(
+		commandTreeSnapshot{"large.txt": before},
+		commandTreeSnapshot{"large.txt": after},
+	)
+	if !strings.Contains(diff, "…") {
+		t.Fatalf("formatCommandTreeDiff() = %q, want bounded excerpt marker", diff)
+	}
+	if len(diff) > mutationExcerptMaxBytes*4 {
+		t.Fatalf("formatCommandTreeDiff() length = %d, want <= %d", len(diff), mutationExcerptMaxBytes*4)
+	}
+}


### PR DESCRIPTION
{
  "project": "Deflake cmd/contractscheck Repository Mutation Detection",
  "branchName": "deflake-contractscheck-repo-mutation",
  "description": "Outcome (b): Make the cmd/contractscheck failure path reliably read-only and self-diagnosing so intermittent Linux CI mutations can be investigated without weakening the strict check-only contract. This delivery adds actionable path-and-byte-diff instrumentation and an honest bounded non-reproduction analysis; it does not claim a root-cause fix without a demonstrated reproducer.",
  "deliveryOutcome": "(b) Instrumented analysis with a targeted observer fix and bounded non-reproduction of the original repository mutation. The diagnostic remains strict, identifies added, removed, and byte-modified paths, and now tolerates only transient entries that disappear with fs.ErrNotExist so the comparison can report them as removed. The observed .git maintenance-lock failure was an observer race, not proof of a stale-schema writer; the real stale-schema mutation did not reproduce under the final Windows/WSL2 stress matrix, so no speculative production root-cause fix is claimed.",
  "context": {
    "customerAsk": "Own cmd/contractscheck and the determinism of its check path so contract verification cannot intermittently mutate repository bytes and tax every open pull request with an unrelated required-check failure. Reproduce first where possible, add actionable mutation diagnostics, fix the demonstrated root cause without weakening the test, and otherwise report non-reproduction honestly with a bounded technical analysis.",
    "problem": "Main CI run 32540606609 at dad7e4b0a failed make contracts-smoke because TestRunReportsPackagedFactorySchemaDriftWithRegenerationRemedy/stale_YAML detected changed repository bytes after run(). The same signature passed immediately before and after and cleared on a same-code rerun, but the current assertion reports no changed path or byte difference, preventing attribution of the intermittent Linux-associated mutation.",
    "solution": "Preserve deterministic before-and-after snapshots of the hermetic fixture, report every added, removed, or byte-modified path with a bounded readable diff, and stress the real run() failure path on Linux with repeated, race-enabled, shuffled, and neighboring-package-load executions. If reproduced, fix the owning write or nondeterministic generation mechanism and prove the reproducer fails before and passes after; otherwise ship the diagnostics and document exactly what was exercised and excluded without claiming a fix."
  },
  "acceptanceCriteria": [
    "A failed no-mutation assertion reports each added, removed, or byte-modified repository-relative path and a bounded, readable before/after byte diff; unchanged paths are omitted, and the strict equality assertion still fails on any mutation.",
    "The existing clean and drift command behaviors remain intact: clean staging exits successfully without writes, drift exits unsuccessfully with deterministic remediation output, and neither path silently changes repository bytes.",
    "Delivery follows one of two explicitly identified outcomes: (a) a deterministic reproduction and root-cause fix, with the exact command and iteration count shown failing before and passing after; or (b) instrumentation plus a written non-reproduction analysis naming the exact commands, iteration counts, environments, and mechanisms ruled out. The PR body states plainly which outcome was delivered and does not claim a fix without a demonstrated reproduction.",
    "The implementation does not retry, skip, weaken, or remove the mutation test; does not modify packaged-factory contents, .github/workflows/localai-backend-artifacts.yml, coverage floors, or the baseline manifest; and includes no broad unrelated cleanup.",
    "Typecheck, focused cmd/contractscheck tests, make contracts-smoke, and applicable repository tests pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "deflake-contractscheck-repo-mutation-001",
      "title": "Make repository mutation failures actionable",
      "description": "As a maintainer investigating a contracts-check failure, I want the no-write assertion to identify exactly what changed so a CI-only recurrence provides evidence that can be acted on.",
      "acceptanceCriteria": [
        "When the post-run snapshot differs, the failure output identifies every added, removed, or byte-modified repository-relative path instead of only reporting that repository bytes changed.",
        "For each byte-modified path, the failure output includes a bounded, readable before/after diff that makes line-ending and ordering differences distinguishable without dumping unrelated repository content.",
        "A focused regression case deliberately changes fixture content and proves the diagnostic names the affected path and byte difference while the unchanged-fixture command cases remain quiet.",
        "Snapshot comparison and diagnostic ordering are deterministic across repeated executions and supported path separators.",
        "The strict no-mutation assertion remains intact and fails for any added, removed, or modified file; it is not retried, skipped, or relaxed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "deflake-contractscheck-repo-mutation-002",
      "title": "Eliminate or honestly characterize the intermittent check-path mutation",
      "description": "As a contributor relying on required contract verification, I want the real stale-schema failure path stressed and corrected when reproducible so unrelated pull requests are not intermittently blocked by repository mutation.",
      "acceptanceCriteria": [
        "The real TestRunReportsPackagedFactorySchemaDriftWithRegenerationRemedy failure path is exercised on Linux where available with the exact repeated, race-enabled, shuffled, and neighboring-package-load commands recorded, prioritizing -count=200 with -shuffle=on; no retry is added to production or test behavior.",
        "If the mutation is reproduced, the changed-path diagnostic is used to identify the owning write or nondeterministic generation mechanism, that root cause is corrected with isolated side effects or deterministic output, and the exact reproducer is shown failing on the pre-fix revision and passing on the final revision with command and iteration count.",
        "If the mutation is not reproduced after genuine effort, no speculative fix is claimed; the delivered analysis names the environments, exact commands and iteration counts exercised, observed results, and concrete candidate mechanisms excluded, while retaining the diagnostic from story 001 for the next occurrence.",
        "Clean staging and stale JSON, stale YAML, missing JSON, and missing YAML outcomes preserve their exit status and deterministic user-facing remediation while leaving the fixture byte-for-byte unchanged.",
        "No packaged-factory content, .github/workflows/localai-backend-artifacts.yml, coverage floor, or baseline manifest is changed, and the mutation assertion is neither weakened nor skipped.",
        "The PR body explicitly labels delivery outcome (a) demonstrated root-cause fix or (b) instrumented non-reproduction analysis and provides property-specific evidence; CI-run evidence is posted only as a PR comment.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Outcome (b), not a demonstrated production root-cause fix. The operator later reproduced the observer failure on main in run 32549396401: `commandTree` aborted with `walk repository: .../.git/objects/maintenance.lock: no such file or directory` while a transient entry disappeared. The fix handles wrapped `fs.ErrNotExist` generically at both WalkDir and ReadFile boundaries; the vanished path is omitted from that snapshot and remains visible as `removed` in the strict before/after diff. A deterministic injected walk/read regression covers both boundaries. Environments: Windows go1.25.0 windows/amd64 and WSL2 Ubuntu go1.25.0 linux/amd64. Windows `go test ./cmd/contractscheck -run TestRunReportsPackagedFactorySchemaDriftWithRegenerationRemedy -count=200 -shuffle=on -timeout 30m` passed (200 shuffled runs; 581.344s); its subsequent race attempt was stopped because host filesystem I/O made the bounded run impractical, with no failure output. WSL2 passed `go test ./cmd/contractscheck -run TestRunReportsPackagedFactorySchemaDriftWithRegenerationRemedy -count=200 -shuffle=on -timeout 30m` (200 shuffled runs; 70.510s), `go test -race ./cmd/contractscheck -run TestRunReportsPackagedFactorySchemaDriftWithRegenerationRemedy -count=200 -shuffle=on -timeout 30m` (200 shuffled race runs; 132.150s), and `go test ./internal/contract... ./cmd/contracts... -run ^TestRunReportsPackagedFactorySchemaDriftWithRegenerationRemedy$ -count=200 -shuffle=on -timeout 30m` (neighboring contract-package load; target ran 200 times; 146.218s). The classifier now selects the hosted API Contract And Package job for cmd/contractscheck changes, whose command includes `make ui-deps contracts-smoke api-smoke api-package-verify`. `go test ./cmd/contractscheck ./cmd/ciclassify -count=1`, `go test -race ./cmd/contractscheck -count=1`, and `make contracts-smoke` passed on the rebased tree. Source inspection and hermetic fixture behavior rule out Check/Join/generation writers, shared repository staging, and fixture cross-talk as the original stale-schema mutation cause; the final stress matrix observed no repository mutation or race."
    }
  ],
  "latestIteration": {
    "at": "2026-08-22 00:37 -07:00",
    "head": "afca13b93f4ea4588038d4d02865885b76490397",
    "base": "b005f4f3ca72a39fff7d6bd24c84769fcb81cd48",
    "summary": "Rebased after blocking review feedback; focused normal/race tests and make contracts-smoke pass. Fresh PR CI is running; review follow-up is limited to one rerun of the prior UI Backend Integration port-collision check if it recurs."
  }
}
