### PR TITLE
obs-13-provider-price-table-and-partial-costs

### DIFF
--- a/api/components/schemas/api/CostsProviderModelRollup.yaml
+++ b/api/components/schemas/api/CostsProviderModelRollup.yaml
@@ -4,7 +4,12 @@ required:
   - provider
   - model
   - key
+  - currency
   - status
+  - known_cost
+  - token_totals
+  - unpriced_dispatch_count
+  - unpriced_pairs
   - coverage
 properties:
   provider:
@@ -16,6 +21,11 @@ properties:
   key:
     type: string
     description: Stable public provider/model pair key in the form provider/model.
+  currency:
+    type: string
+    enum:
+      - USD
+    description: Currency of the known cost amount.
   input_tokens:
     type: integer
     format: int64
@@ -40,8 +50,24 @@ properties:
       - UNPRICED
       - NO_USAGE
     description: PRICED means all usage rows for this provider/model are valued; PARTIAL means some are valued; UNPRICED means usage exists but none is valued; NO_USAGE means this pair has no usage rows.
+  known_cost:
+    type: string
+    nullable: true
+    description: Exact USD decimal for the priced portion of this provider/model rollup; PARTIAL never implies a complete total.
   priced_subtotal:
     type: string
+    deprecated: true
     description: Exact USD decimal subtotal; absent when no usage is priced.
+  token_totals:
+    $ref: './CostsTokenTotals.yaml'
+  unpriced_dispatch_count:
+    type: integer
+    minimum: 0
+    description: Number of distinct dispatches whose usage is not fully valued for this provider/model.
+  unpriced_pairs:
+    type: array
+    description: Deterministically ordered unpriced provider/model facts for this rollup.
+    items:
+      $ref: './CostsUnpricedPair.yaml'
   coverage:
     $ref: './CostsCoverage.yaml'

--- a/api/components/schemas/api/CostsReport.yaml
+++ b/api/components/schemas/api/CostsReport.yaml
@@ -4,6 +4,10 @@ required:
   - scope
   - currency
   - status
+  - known_cost
+  - token_totals
+  - unpriced_dispatch_count
+  - unpriced_pairs
   - coverage
   - line_items
   - work_items
@@ -26,9 +30,25 @@ properties:
       - UNPRICED
       - NO_USAGE
     description: PRICED means every usage row is valued; PARTIAL means some rows are valued; UNPRICED means usage exists but none is valued; NO_USAGE means no canonical usage rows were encountered. Missing price is never represented as zero.
+  known_cost:
+    type: string
+    nullable: true
+    description: Exact USD decimal for the priced portion. Null means no usage row had a known price; PARTIAL never implies a complete total.
   priced_subtotal:
     type: string
+    deprecated: true
     description: Exact USD decimal subtotal for fully priced rows; absent when no row is priced.
+  token_totals:
+    $ref: './CostsTokenTotals.yaml'
+  unpriced_dispatch_count:
+    type: integer
+    minimum: 0
+    description: Number of distinct dispatches whose usage is not fully valued.
+  unpriced_pairs:
+    type: array
+    description: Deterministically ordered provider/model pairs contributing unpriced dispatches; null identities are explicit unknowns.
+    items:
+      $ref: './CostsUnpricedPair.yaml'
   coverage:
     $ref: './CostsCoverage.yaml'
   line_items:

--- a/api/components/schemas/api/CostsRollup.yaml
+++ b/api/components/schemas/api/CostsRollup.yaml
@@ -2,12 +2,22 @@ type: object
 additionalProperties: false
 required:
   - key
+  - currency
   - status
+  - known_cost
+  - token_totals
+  - unpriced_dispatch_count
+  - unpriced_pairs
   - coverage
 properties:
   key:
     type: string
     description: Stable dimension key for this rollup.
+  currency:
+    type: string
+    enum:
+      - USD
+    description: Currency of the known cost amount.
   input_tokens:
     type: integer
     format: int64
@@ -32,8 +42,24 @@ properties:
       - UNPRICED
       - NO_USAGE
     description: PRICED means all usage rows in the rollup are valued; PARTIAL means some are valued; UNPRICED means usage exists but none is valued; NO_USAGE means no canonical usage rows were encountered.
+  known_cost:
+    type: string
+    nullable: true
+    description: Exact USD decimal for the priced portion of this rollup; PARTIAL never implies a complete total.
   priced_subtotal:
     type: string
+    deprecated: true
     description: Exact USD decimal subtotal; absent when no usage is priced.
+  token_totals:
+    $ref: './CostsTokenTotals.yaml'
+  unpriced_dispatch_count:
+    type: integer
+    minimum: 0
+    description: Number of distinct dispatches whose usage is not fully valued in this rollup.
+  unpriced_pairs:
+    type: array
+    description: Deterministically ordered provider/model pairs contributing unpriced dispatches in this rollup.
+    items:
+      $ref: './CostsUnpricedPair.yaml'
   coverage:
     $ref: './CostsCoverage.yaml'

--- a/api/components/schemas/api/CostsTokenTotals.yaml
+++ b/api/components/schemas/api/CostsTokenTotals.yaml
@@ -1,0 +1,39 @@
+type: object
+additionalProperties: false
+required:
+  - total_tokens
+  - input_tokens
+  - output_tokens
+  - cached_input_tokens
+  - reasoning_output_tokens
+properties:
+  total_tokens:
+    type: integer
+    format: int64
+    minimum: 0
+    nullable: true
+    description: Input tokens plus output tokens; subclass counts are not added a second time.
+  input_tokens:
+    type: integer
+    format: int64
+    minimum: 0
+    nullable: true
+    description: Aggregate input-token count, or null when the source measurement was absent.
+  output_tokens:
+    type: integer
+    format: int64
+    minimum: 0
+    nullable: true
+    description: Aggregate output-token count, or null when the source measurement was absent.
+  cached_input_tokens:
+    type: integer
+    format: int64
+    minimum: 0
+    nullable: true
+    description: Aggregate cached-input subclass count, or null when no subclass measurement was present.
+  reasoning_output_tokens:
+    type: integer
+    format: int64
+    minimum: 0
+    nullable: true
+    description: Aggregate reasoning-output subclass count, or null when no subclass measurement was present.

--- a/api/components/schemas/api/CostsUnpricedPair.yaml
+++ b/api/components/schemas/api/CostsUnpricedPair.yaml
@@ -1,0 +1,19 @@
+type: object
+additionalProperties: false
+required:
+  - provider
+  - model
+  - dispatch_count
+properties:
+  provider:
+    type: string
+    nullable: true
+    description: Canonical provider identity, or null when the usage identity was unavailable.
+  model:
+    type: string
+    nullable: true
+    description: Resolved model identity, or null when the usage identity was unavailable.
+  dispatch_count:
+    type: integer
+    minimum: 1
+    description: Distinct unpriced dispatches for this provider/model pair in the containing scope.

--- a/api/openapi-main.yaml
+++ b/api/openapi-main.yaml
@@ -2588,6 +2588,10 @@ components:
       $ref: './components/schemas/api/CostsScope.yaml'
     CostsCoverage:
       $ref: './components/schemas/api/CostsCoverage.yaml'
+    CostsTokenTotals:
+      $ref: './components/schemas/api/CostsTokenTotals.yaml'
+    CostsUnpricedPair:
+      $ref: './components/schemas/api/CostsUnpricedPair.yaml'
     CostsLineItem:
       $ref: './components/schemas/api/CostsLineItem.yaml'
     CostsRollup:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3982,6 +3982,66 @@ components:
           type: integer
           minimum: 0
           description: Distinct provider/model pairs with one or more unpriced rows.
+    CostsTokenTotals:
+      type: object
+      additionalProperties: false
+      required:
+        - total_tokens
+        - input_tokens
+        - output_tokens
+        - cached_input_tokens
+        - reasoning_output_tokens
+      properties:
+        total_tokens:
+          type: integer
+          format: int64
+          minimum: 0
+          nullable: true
+          description: Input tokens plus output tokens; subclass counts are not added a second time.
+        input_tokens:
+          type: integer
+          format: int64
+          minimum: 0
+          nullable: true
+          description: Aggregate input-token count, or null when the source measurement was absent.
+        output_tokens:
+          type: integer
+          format: int64
+          minimum: 0
+          nullable: true
+          description: Aggregate output-token count, or null when the source measurement was absent.
+        cached_input_tokens:
+          type: integer
+          format: int64
+          minimum: 0
+          nullable: true
+          description: Aggregate cached-input subclass count, or null when no subclass measurement was present.
+        reasoning_output_tokens:
+          type: integer
+          format: int64
+          minimum: 0
+          nullable: true
+          description: Aggregate reasoning-output subclass count, or null when no subclass measurement was present.
+    CostsUnpricedPair:
+      type: object
+      additionalProperties: false
+      required:
+        - provider
+        - model
+        - dispatch_count
+      properties:
+        provider:
+          type: string
+          nullable: true
+          description: Canonical provider identity, or null when the usage identity was unavailable.
+        model:
+          type: string
+          nullable: true
+          description: Resolved model identity, or null when the usage identity was unavailable.
+        dispatch_count:
+          type: integer
+          minimum: 1
+          description: Distinct unpriced dispatches for this provider/model pair in the containing scope.
     CostsLineItem:
       type: object
       additionalProperties: false
@@ -4033,12 +4093,22 @@ components:
       additionalProperties: false
       required:
         - key
+        - currency
         - status
+        - known_cost
+        - token_totals
+        - unpriced_dispatch_count
+        - unpriced_pairs
         - coverage
       properties:
         key:
           type: string
           description: Stable dimension key for this rollup.
+        currency:
+          type: string
+          enum:
+            - USD
+          description: Currency of the known cost amount.
         input_tokens:
           type: integer
           format: int64
@@ -4063,9 +4133,25 @@ components:
             - UNPRICED
             - NO_USAGE
           description: PRICED means all usage rows in the rollup are valued; PARTIAL means some are valued; UNPRICED means usage exists but none is valued; NO_USAGE means no canonical usage rows were encountered.
+        known_cost:
+          type: string
+          nullable: true
+          description: Exact USD decimal for the priced portion of this rollup; PARTIAL never implies a complete total.
         priced_subtotal:
           type: string
+          deprecated: true
           description: Exact USD decimal subtotal; absent when no usage is priced.
+        token_totals:
+          $ref: '#/components/schemas/CostsTokenTotals'
+        unpriced_dispatch_count:
+          type: integer
+          minimum: 0
+          description: Number of distinct dispatches whose usage is not fully valued in this rollup.
+        unpriced_pairs:
+          type: array
+          description: Deterministically ordered provider/model pairs contributing unpriced dispatches in this rollup.
+          items:
+            $ref: '#/components/schemas/CostsUnpricedPair'
         coverage:
           $ref: '#/components/schemas/CostsCoverage'
     CostsProviderModelRollup:
@@ -4075,7 +4161,12 @@ components:
         - provider
         - model
         - key
+        - currency
         - status
+        - known_cost
+        - token_totals
+        - unpriced_dispatch_count
+        - unpriced_pairs
         - coverage
       properties:
         provider:
@@ -4087,6 +4178,11 @@ components:
         key:
           type: string
           description: Stable public provider/model pair key in the form provider/model.
+        currency:
+          type: string
+          enum:
+            - USD
+          description: Currency of the known cost amount.
         input_tokens:
           type: integer
           format: int64
@@ -4111,9 +4207,25 @@ components:
             - UNPRICED
             - NO_USAGE
           description: PRICED means all usage rows for this provider/model are valued; PARTIAL means some are valued; UNPRICED means usage exists but none is valued; NO_USAGE means this pair has no usage rows.
+        known_cost:
+          type: string
+          nullable: true
+          description: Exact USD decimal for the priced portion of this provider/model rollup; PARTIAL never implies a complete total.
         priced_subtotal:
           type: string
+          deprecated: true
           description: Exact USD decimal subtotal; absent when no usage is priced.
+        token_totals:
+          $ref: '#/components/schemas/CostsTokenTotals'
+        unpriced_dispatch_count:
+          type: integer
+          minimum: 0
+          description: Number of distinct dispatches whose usage is not fully valued for this provider/model.
+        unpriced_pairs:
+          type: array
+          description: Deterministically ordered unpriced provider/model facts for this rollup.
+          items:
+            $ref: '#/components/schemas/CostsUnpricedPair'
         coverage:
           $ref: '#/components/schemas/CostsCoverage'
     CostsReport:
@@ -4123,6 +4235,10 @@ components:
         - scope
         - currency
         - status
+        - known_cost
+        - token_totals
+        - unpriced_dispatch_count
+        - unpriced_pairs
         - coverage
         - line_items
         - work_items
@@ -4145,9 +4261,25 @@ components:
             - UNPRICED
             - NO_USAGE
           description: PRICED means every usage row is valued; PARTIAL means some rows are valued; UNPRICED means usage exists but none is valued; NO_USAGE means no canonical usage rows were encountered. Missing price is never represented as zero.
+        known_cost:
+          type: string
+          nullable: true
+          description: Exact USD decimal for the priced portion. Null means no usage row had a known price; PARTIAL never implies a complete total.
         priced_subtotal:
           type: string
+          deprecated: true
           description: Exact USD decimal subtotal for fully priced rows; absent when no row is priced.
+        token_totals:
+          $ref: '#/components/schemas/CostsTokenTotals'
+        unpriced_dispatch_count:
+          type: integer
+          minimum: 0
+          description: Number of distinct dispatches whose usage is not fully valued.
+        unpriced_pairs:
+          type: array
+          description: Deterministically ordered provider/model pairs contributing unpriced dispatches; null identities are explicit unknowns.
+          items:
+            $ref: '#/components/schemas/CostsUnpricedPair'
         coverage:
           $ref: '#/components/schemas/CostsCoverage'
         line_items:

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -178,45 +178,40 @@ workflow. Global `--server` selects the Factory API; global `--json` emits the
 API-shaped report. A route failure returns an error without a partial success
 document.
 
-### Configure The Price Table
+### Provider-Owned Price Facts
 
-The operator price table lives in `~/.you-agent-factory/config.json` under
-`priceTable`. Rates are USD per one million tokens and must be decimal strings:
+Costs uses the immutable, Providers-owned price table shipped with the
+application. It is not operator configuration, and editing
+`~/.you-agent-factory/config.json` does not change cost valuation. Maintainers
+add a row only for a provider/model pair observed in live metrics after finding
+an authoritative vendor price. Every row records USD-per-million-token rates,
+the source URL, and an ISO-8601 as-of date. The current shipped row is
+`codex/gpt-5-codex`; its source is the
+[OpenAI GPT-5-Codex pricing page](https://developers.openai.com/api/docs/models/gpt-5-codex),
+dated 2026-08-21.
 
-```json
-{
-  "priceTable": {
-    "currency": "USD",
-    "models": [
-      {
-        "provider": "CODEX",
-        "model": "gpt-5",
-        "inputPerMillionTokens": "2.5",
-        "cachedInputPerMillionTokens": "0.5",
-        "outputPerMillionTokens": "5.25",
-        "reasoningOutputPerMillionTokens": "10"
-      }
-    ]
-  }
-}
-```
-
-Input and output rates are required for every table entry. Cached-input and
-reasoning-output rates are optional, but a measured token class with no rate
-is `UNPRICED`. An omitted token measurement is distinct from an explicit zero;
-an explicit zero rate is valid and produces an exact `"0"` amount. Missing
-provider/model identity or an absent model entry also remains `UNPRICED`.
-Cached input is deducted from total input, and reasoning output is deducted
-from total output before the corresponding rates are applied.
+Input and output rates are required for every row. Cached-input and
+reasoning-output rates are optional; a measured class with no explicit rate is
+`UNPRICED`. When a subclass intentionally uses the standard input or output
+rate, the provider data declares that equality explicitly. An omitted token
+measurement is distinct from an explicit zero, and an explicit zero rate is
+valid. Missing provider/model identity or an absent price row remains
+`UNPRICED`. Cached input is deducted from total input, and reasoning output is
+deducted from total output before the corresponding rates are applied.
 
 ### Cost Report Fields And Status
 
-The JSON report contains `scope`, `currency`, `status`, `priced_subtotal`,
-`coverage`, `line_items`, `work_items`, `worker_sessions`, `provider_models`,
-and `factory_sessions`. Every money field is an exact decimal string; absent
-amounts are omitted rather than reported as zero. Arrays are deterministic.
-`coverage` reports `encountered_rows`, `priced_rows`, `unpriced_rows`, and the
-matching encountered/priced/unpriced distinct `provider_models` counts.
+The JSON report and every rollup contain `status`, `currency`, nullable exact
+decimal `known_cost`, `token_totals`, `unpriced_dispatch_count`, and
+deterministically ordered `unpriced_pairs` as separate fields. `token_totals`
+always contains `total_tokens`, `input_tokens`, `output_tokens`,
+`cached_input_tokens`, and `reasoning_output_tokens`; total tokens is input
+plus output and does not double-count the subclasses. Every money field is an
+exact decimal string; unknown amounts are null or absent according to the
+field contract and are never substituted with zero. The deprecated
+`priced_subtotal` remains available for compatibility. Arrays are
+deterministic. `coverage` reports encountered, priced, and unpriced rows and
+distinct provider/models.
 
 `PRICED` means every usage row is valued, `PARTIAL` means some rows are valued,
 `UNPRICED` means usage exists but no row is valued, and `NO_USAGE` means no
@@ -225,8 +220,12 @@ identity and all observed input, cached-input, output, and reasoning-output
 counts, plus an actionable `reason` when it is unpriced. Rollups cover all four
 dimensions: Work, Worker Session, provider/model, and Factory Session.
 
-The table is operator-authored reporting configuration. The command does not
-fetch live vendor pricing, query provider billing, or enforce billing limits.
+Human output makes coverage explicit: fully priced usage shows the exact
+rounded USD amount and token totals, unpriced usage shows `?? unknown` and
+never `$0.00`, and mixed usage uses the form `$X.XX + ?? unknown`. Mixed and
+unpriced reports also list the unpriced dispatch count and each provider/model
+pair, including unknown identities. The command does not fetch live vendor
+pricing, query provider billing, or enforce billing limits.
 
 ## Related Topics
 

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -211,7 +211,7 @@
       "path": "generated/mcp/tools.json"
     },
     "generated.openapi.openapi": {
-      "artifactHash": "32a26725aac6144ec44f0b602cca47d1421b48324c766949a63956d42c6b5a2f",
+      "artifactHash": "22916e370b244c02ac0c76e8acd23036506226793977d22c8a535b23ec192dd3",
       "documentation": {
         "documentation": {
           "description": {
@@ -228,7 +228,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.openapi.openapi",
-        "sourceHash": "32a26725aac6144ec44f0b602cca47d1421b48324c766949a63956d42c6b5a2f",
+        "sourceHash": "22916e370b244c02ac0c76e8acd23036506226793977d22c8a535b23ec192dd3",
         "visibility": "public"
       },
       "family": "openapi",

--- a/packages/api/generated/openapi/openapi.yaml
+++ b/packages/api/generated/openapi/openapi.yaml
@@ -3982,6 +3982,66 @@ components:
           type: integer
           minimum: 0
           description: Distinct provider/model pairs with one or more unpriced rows.
+    CostsTokenTotals:
+      type: object
+      additionalProperties: false
+      required:
+        - total_tokens
+        - input_tokens
+        - output_tokens
+        - cached_input_tokens
+        - reasoning_output_tokens
+      properties:
+        total_tokens:
+          type: integer
+          format: int64
+          minimum: 0
+          nullable: true
+          description: Input tokens plus output tokens; subclass counts are not added a second time.
+        input_tokens:
+          type: integer
+          format: int64
+          minimum: 0
+          nullable: true
+          description: Aggregate input-token count, or null when the source measurement was absent.
+        output_tokens:
+          type: integer
+          format: int64
+          minimum: 0
+          nullable: true
+          description: Aggregate output-token count, or null when the source measurement was absent.
+        cached_input_tokens:
+          type: integer
+          format: int64
+          minimum: 0
+          nullable: true
+          description: Aggregate cached-input subclass count, or null when no subclass measurement was present.
+        reasoning_output_tokens:
+          type: integer
+          format: int64
+          minimum: 0
+          nullable: true
+          description: Aggregate reasoning-output subclass count, or null when no subclass measurement was present.
+    CostsUnpricedPair:
+      type: object
+      additionalProperties: false
+      required:
+        - provider
+        - model
+        - dispatch_count
+      properties:
+        provider:
+          type: string
+          nullable: true
+          description: Canonical provider identity, or null when the usage identity was unavailable.
+        model:
+          type: string
+          nullable: true
+          description: Resolved model identity, or null when the usage identity was unavailable.
+        dispatch_count:
+          type: integer
+          minimum: 1
+          description: Distinct unpriced dispatches for this provider/model pair in the containing scope.
     CostsLineItem:
       type: object
       additionalProperties: false
@@ -4033,12 +4093,22 @@ components:
       additionalProperties: false
       required:
         - key
+        - currency
         - status
+        - known_cost
+        - token_totals
+        - unpriced_dispatch_count
+        - unpriced_pairs
         - coverage
       properties:
         key:
           type: string
           description: Stable dimension key for this rollup.
+        currency:
+          type: string
+          enum:
+            - USD
+          description: Currency of the known cost amount.
         input_tokens:
           type: integer
           format: int64
@@ -4063,9 +4133,25 @@ components:
             - UNPRICED
             - NO_USAGE
           description: PRICED means all usage rows in the rollup are valued; PARTIAL means some are valued; UNPRICED means usage exists but none is valued; NO_USAGE means no canonical usage rows were encountered.
+        known_cost:
+          type: string
+          nullable: true
+          description: Exact USD decimal for the priced portion of this rollup; PARTIAL never implies a complete total.
         priced_subtotal:
           type: string
+          deprecated: true
           description: Exact USD decimal subtotal; absent when no usage is priced.
+        token_totals:
+          $ref: '#/components/schemas/CostsTokenTotals'
+        unpriced_dispatch_count:
+          type: integer
+          minimum: 0
+          description: Number of distinct dispatches whose usage is not fully valued in this rollup.
+        unpriced_pairs:
+          type: array
+          description: Deterministically ordered provider/model pairs contributing unpriced dispatches in this rollup.
+          items:
+            $ref: '#/components/schemas/CostsUnpricedPair'
         coverage:
           $ref: '#/components/schemas/CostsCoverage'
     CostsProviderModelRollup:
@@ -4075,7 +4161,12 @@ components:
         - provider
         - model
         - key
+        - currency
         - status
+        - known_cost
+        - token_totals
+        - unpriced_dispatch_count
+        - unpriced_pairs
         - coverage
       properties:
         provider:
@@ -4087,6 +4178,11 @@ components:
         key:
           type: string
           description: Stable public provider/model pair key in the form provider/model.
+        currency:
+          type: string
+          enum:
+            - USD
+          description: Currency of the known cost amount.
         input_tokens:
           type: integer
           format: int64
@@ -4111,9 +4207,25 @@ components:
             - UNPRICED
             - NO_USAGE
           description: PRICED means all usage rows for this provider/model are valued; PARTIAL means some are valued; UNPRICED means usage exists but none is valued; NO_USAGE means this pair has no usage rows.
+        known_cost:
+          type: string
+          nullable: true
+          description: Exact USD decimal for the priced portion of this provider/model rollup; PARTIAL never implies a complete total.
         priced_subtotal:
           type: string
+          deprecated: true
           description: Exact USD decimal subtotal; absent when no usage is priced.
+        token_totals:
+          $ref: '#/components/schemas/CostsTokenTotals'
+        unpriced_dispatch_count:
+          type: integer
+          minimum: 0
+          description: Number of distinct dispatches whose usage is not fully valued for this provider/model.
+        unpriced_pairs:
+          type: array
+          description: Deterministically ordered unpriced provider/model facts for this rollup.
+          items:
+            $ref: '#/components/schemas/CostsUnpricedPair'
         coverage:
           $ref: '#/components/schemas/CostsCoverage'
     CostsReport:
@@ -4123,6 +4235,10 @@ components:
         - scope
         - currency
         - status
+        - known_cost
+        - token_totals
+        - unpriced_dispatch_count
+        - unpriced_pairs
         - coverage
         - line_items
         - work_items
@@ -4145,9 +4261,25 @@ components:
             - UNPRICED
             - NO_USAGE
           description: PRICED means every usage row is valued; PARTIAL means some rows are valued; UNPRICED means usage exists but none is valued; NO_USAGE means no canonical usage rows were encountered. Missing price is never represented as zero.
+        known_cost:
+          type: string
+          nullable: true
+          description: Exact USD decimal for the priced portion. Null means no usage row had a known price; PARTIAL never implies a complete total.
         priced_subtotal:
           type: string
+          deprecated: true
           description: Exact USD decimal subtotal for fully priced rows; absent when no row is priced.
+        token_totals:
+          $ref: '#/components/schemas/CostsTokenTotals'
+        unpriced_dispatch_count:
+          type: integer
+          minimum: 0
+          description: Number of distinct dispatches whose usage is not fully valued.
+        unpriced_pairs:
+          type: array
+          description: Deterministically ordered provider/model pairs contributing unpriced dispatches; null identities are explicit unknowns.
+          items:
+            $ref: '#/components/schemas/CostsUnpricedPair'
         coverage:
           $ref: '#/components/schemas/CostsCoverage'
         line_items:

--- a/pkg/services/costs/costs.go
+++ b/pkg/services/costs/costs.go
@@ -6,15 +6,12 @@ import (
 	"fmt"
 	"strings"
 
-	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
-// PriceTableReader is the narrow Operator Settings capability required by the
-// Costs operation. Costs does not need the settings service's update or
-// precedence operations.
-type PriceTableReader interface {
-	LoadDocument(operatorsettings.LoadDocumentRequest) (operatorsettings.LoadDocumentResult, error)
-}
+// PriceTableReader is retained as a descriptive alias for the narrow
+// Providers-owned pricing capability consumed by Costs.
+type PriceTableReader = providers.PriceTableReader
 
 // CostsQuery is the stateless operation over canonical runtime usage rows.
 // The request supplies artifact/configuration paths as data; the operation
@@ -38,7 +35,9 @@ func (query CostsQuery) QueryCosts(ctx context.Context, request QueryRequest) (R
 // Query is the short compatibility name for the Costs operation type.
 type Query = CostsQuery
 
-// QueryRequest identifies the canonical metrics and operator-settings inputs.
+// QueryRequest identifies the canonical metrics input and optional scope
+// filters. OperatorSettingsPath is retained as an ignored compatibility field
+// for existing CLI/API callers; pricing is now read only from Providers.
 // FactorySessionID and RuntimeInstanceID are optional independent filters;
 // both are passed to the canonical Factory Visualization query.
 type QueryRequest struct {
@@ -53,9 +52,6 @@ type QueryRequest struct {
 func (request QueryRequest) Validate() error {
 	if strings.TrimSpace(request.MetricsRoot) == "" {
 		return fmt.Errorf("metrics root is required")
-	}
-	if strings.TrimSpace(request.OperatorSettingsPath) == "" {
-		return fmt.Errorf("operator settings path is required")
 	}
 	return nil
 }

--- a/pkg/services/costs/costs.go
+++ b/pkg/services/costs/costs.go
@@ -109,6 +109,27 @@ type TokenCounts struct {
 	ReasoningOutputTokens *int64 `json:"reasoning_output_tokens,omitempty"`
 }
 
+// TokenTotals is the complete aggregate token shape used by reports and
+// rollups. Nullable fields preserve the distinction between an absent source
+// measurement and an observed zero while keeping every JSON key present.
+// TotalTokens is input plus output and never adds cached-input or
+// reasoning-output subclasses a second time.
+type TokenTotals struct {
+	TotalTokens           *int64 `json:"total_tokens"`
+	InputTokens           *int64 `json:"input_tokens"`
+	OutputTokens          *int64 `json:"output_tokens"`
+	CachedInputTokens     *int64 `json:"cached_input_tokens"`
+	ReasoningOutputTokens *int64 `json:"reasoning_output_tokens"`
+}
+
+// UnpricedPair identifies one provider/model pair whose usage could not be
+// valued. Nil identities are explicit unknowns rather than omitted facts.
+type UnpricedPair struct {
+	Provider      *string `json:"provider"`
+	Model         *string `json:"model"`
+	DispatchCount int     `json:"dispatch_count"`
+}
+
 // LineItem is one canonical usage row and its complete valuation outcome.
 // Unpriced rows retain their identity and observed token counts; PricedAmount
 // is absent for unpriced rows and is present as "0" for explicitly free usage.
@@ -130,9 +151,14 @@ type LineItem struct {
 type Rollup struct {
 	Key string `json:"key"`
 	TokenCounts
-	Status         Status   `json:"status"`
-	PricedSubtotal *string  `json:"priced_subtotal,omitempty"`
-	Coverage       Coverage `json:"coverage"`
+	Currency              string         `json:"currency"`
+	Status                Status         `json:"status"`
+	KnownCost             *string        `json:"known_cost"`
+	PricedSubtotal        *string        `json:"priced_subtotal,omitempty"` // Deprecated compatibility alias; use KnownCost.
+	TokenTotals           TokenTotals    `json:"token_totals"`
+	UnpricedDispatchCount int            `json:"unpriced_dispatch_count"`
+	UnpricedPairs         []UnpricedPair `json:"unpriced_pairs"`
+	Coverage              Coverage       `json:"coverage"`
 }
 
 // ProviderModelRollup is a rollup keyed by an exact provider/model identity.
@@ -145,16 +171,20 @@ type ProviderModelRollup struct {
 // Report is the complete deterministic Costs result. All monetary values are
 // exact decimal strings in Currency; no floating-point amount is exposed.
 type Report struct {
-	Scope           Scope                 `json:"scope"`
-	Currency        string                `json:"currency"`
-	Status          Status                `json:"status"`
-	PricedSubtotal  *string               `json:"priced_subtotal,omitempty"`
-	Coverage        Coverage              `json:"coverage"`
-	LineItems       []LineItem            `json:"line_items"`
-	WorkItems       []Rollup              `json:"work_items"`
-	WorkerSessions  []Rollup              `json:"worker_sessions"`
-	ProviderModels  []ProviderModelRollup `json:"provider_models"`
-	FactorySessions []Rollup              `json:"factory_sessions"`
+	Scope                 Scope                 `json:"scope"`
+	Currency              string                `json:"currency"`
+	Status                Status                `json:"status"`
+	KnownCost             *string               `json:"known_cost"`
+	PricedSubtotal        *string               `json:"priced_subtotal,omitempty"` // Deprecated compatibility alias; use KnownCost.
+	TokenTotals           TokenTotals           `json:"token_totals"`
+	UnpricedDispatchCount int                   `json:"unpriced_dispatch_count"`
+	UnpricedPairs         []UnpricedPair        `json:"unpriced_pairs"`
+	Coverage              Coverage              `json:"coverage"`
+	LineItems             []LineItem            `json:"line_items"`
+	WorkItems             []Rollup              `json:"work_items"`
+	WorkerSessions        []Rollup              `json:"worker_sessions"`
+	ProviderModels        []ProviderModelRollup `json:"provider_models"`
+	FactorySessions       []Rollup              `json:"factory_sessions"`
 }
 
 // CostsQueryResult is the descriptive alias for Report.

--- a/pkg/services/costs/costs.go
+++ b/pkg/services/costs/costs.go
@@ -14,7 +14,7 @@ import (
 // facts; this consumer port keeps Costs independent of the provider service's
 // broader identity and execution operations.
 type PriceTableReader interface {
-	providers.PriceTableReader
+	ReadPriceTable() (providers.PriceTable, error)
 }
 
 // CostsQuery is the stateless operation over canonical runtime usage rows.

--- a/pkg/services/costs/costs.go
+++ b/pkg/services/costs/costs.go
@@ -1,4 +1,4 @@
-// Package costs values canonical runtime usage with operator-authored prices.
+// Package costs values canonical runtime usage with Providers-owned prices.
 package costs
 
 import (
@@ -9,9 +9,13 @@ import (
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
-// PriceTableReader is retained as a descriptive alias for the narrow
-// Providers-owned pricing capability consumed by Costs.
-type PriceTableReader = providers.PriceTableReader
+// PriceTableReader is the Costs-side view of the narrow Providers-owned
+// pricing capability. Providers remains the authority for the table and its
+// facts; this consumer port keeps Costs independent of the provider service's
+// broader identity and execution operations.
+type PriceTableReader interface {
+	providers.PriceTableReader
+}
 
 // CostsQuery is the stateless operation over canonical runtime usage rows.
 // The request supplies artifact/configuration paths as data; the operation

--- a/pkg/services/costs/costs_test.go
+++ b/pkg/services/costs/costs_test.go
@@ -18,8 +18,8 @@ func TestQueryNilOperationAndRequestValidation(t *testing.T) {
 	if err := (QueryRequest{}).Validate(); err == nil {
 		t.Fatal("empty QueryRequest.Validate() = nil, want error")
 	}
-	if err := (QueryRequest{MetricsRoot: "metrics"}).Validate(); err == nil {
-		t.Fatal("missing settings path validation = nil, want error")
+	if err := (QueryRequest{MetricsRoot: "metrics"}).Validate(); err != nil {
+		t.Fatalf("missing compatibility settings path = %v, want no validation error", err)
 	}
 	operation := CostsQuery(func(context.Context, QueryRequest) (Report, error) {
 		return Report{Status: StatusNoUsage}, nil

--- a/pkg/services/costs/costs_test.go
+++ b/pkg/services/costs/costs_test.go
@@ -2,6 +2,7 @@ package costs
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 )
@@ -44,5 +45,34 @@ func TestQueryErrorUnwrapAndAliases(t *testing.T) {
 	var nilError *QueryError
 	if nilError.Error() != "" || nilError.Unwrap() != nil {
 		t.Fatalf("nil QueryError methods = %q/%v, want empty/nil", nilError.Error(), nilError.Unwrap())
+	}
+}
+
+func TestPartialReportJSONRetainsKnownCostAndUnknownCoverage(t *testing.T) {
+	t.Parallel()
+
+	knownCost := "1.25"
+	input, output, total := int64(100), int64(25), int64(125)
+	provider, model := "CODEX", "unknown"
+	report := Report{
+		Status:                StatusPartial,
+		KnownCost:             &knownCost,
+		TokenTotals:           TokenTotals{TotalTokens: &total, InputTokens: &input, OutputTokens: &output},
+		UnpricedDispatchCount: 1,
+		UnpricedPairs:         []UnpricedPair{{Provider: &provider, Model: &model, DispatchCount: 1}},
+	}
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal partial report: %v", err)
+	}
+	var shape map[string]any
+	if err := json.Unmarshal(encoded, &shape); err != nil {
+		t.Fatalf("decode partial report: %v", err)
+	}
+	if shape["status"] != string(StatusPartial) || shape["known_cost"] != knownCost {
+		t.Fatalf("partial JSON = %s, want PARTIAL and known cost", encoded)
+	}
+	if shape["unpriced_dispatch_count"] != float64(1) || shape["unpriced_pairs"] == nil || shape["token_totals"] == nil {
+		t.Fatalf("partial JSON = %s, want distinct unknown and token facts", encoded)
 	}
 }

--- a/pkg/services/costs/internal/service/public_boundary_test.go
+++ b/pkg/services/costs/internal/service/public_boundary_test.go
@@ -1,0 +1,417 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/platform/logging"
+	costs "github.com/portpowered/infinite-you/pkg/services/costs"
+	costscli "github.com/portpowered/infinite-you/pkg/services/costs/transports/cli"
+	costshttp "github.com/portpowered/infinite-you/pkg/services/costs/transports/http"
+	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	generatedclient "github.com/portpowered/infinite-you/pkg/transports/http/client"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"go.uber.org/zap"
+)
+
+func TestPublicCostsBoundaryCoversPricingCases(t *testing.T) {
+	t.Parallel()
+
+	knownTable := publicBoundaryPriceTable(publicBoundaryKnownModel("known"))
+	knownRow := usageRow("session-a", "work-a", "dispatch-a", "worker-a", "codex", "known", 1_000_000, 2_000_000, int64Ptr(250_000), int64Ptr(500_000))
+	unknownRow := usageRow("session-b", "work-b", "dispatch-b", "worker-b", "codex", "unpriced", 100, 50, int64Ptr(25), int64Ptr(10))
+	unknownModelRow := usageRow("session-c", "work-c", "dispatch-c", "worker-c", "codex", "unknown-model", 20, 10, int64Ptr(5), int64Ptr(3))
+	cases := publicBoundaryPricingCases(knownTable, knownRow, unknownRow, unknownModelRow)
+
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			query, err := New(
+				&settingsReader{document: operatorsettings.Document{PriceTable: testCase.table}},
+				metricsQueryStub(testCase.rows, nil),
+				logging.NoopLogger{},
+			)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			report, err := query.Query(context.Background(), validRequest())
+			if err != nil {
+				t.Fatalf("Costs query error = %v", err)
+			}
+			assertPublicDomainReport(t, report, testCase)
+
+			apiReport, responseBody := publicBoundaryAPIReport(t, query)
+			assertPublicAPIReport(t, apiReport, testCase)
+			assertPublicJSONShape(t, responseBody, testCase.knownCost != "")
+			assertPublicCLIOutputs(t, apiReport, testCase)
+		})
+	}
+}
+
+func assertPublicCLIOutputs(t *testing.T, report factoryapi.CostsReport, testCase publicBoundaryCase) {
+	t.Helper()
+	humanOutput := runPublicBoundaryCLI(t, report, false)
+	for _, want := range testCase.human {
+		if !strings.Contains(humanOutput, want) {
+			t.Fatalf("human output missing %q:\n%s", want, humanOutput)
+		}
+	}
+	for _, unwanted := range testCase.noHuman {
+		if strings.Contains(humanOutput, unwanted) {
+			t.Fatalf("human output contains %q:\n%s", unwanted, humanOutput)
+		}
+	}
+
+	jsonOutput := runPublicBoundaryCLI(t, report, true)
+	var cliReport factoryapi.CostsReport
+	if err := json.Unmarshal([]byte(jsonOutput), &cliReport); err != nil {
+		t.Fatalf("decode --json output: %v\n%s", err, jsonOutput)
+	}
+	if cliReport.Status != report.Status || cliReport.KnownCost == nil && report.KnownCost != nil || cliReport.KnownCost != nil && report.KnownCost == nil {
+		t.Fatalf("CLI JSON report = %#v, want API report status/cost %#v/%#v", cliReport, report.Status, report.KnownCost)
+	}
+	if testCase.knownCost != "" && cliReport.KnownCost != nil && *cliReport.KnownCost != testCase.knownCost {
+		t.Fatalf("CLI JSON known cost = %q, want %q", *cliReport.KnownCost, testCase.knownCost)
+	}
+}
+
+func publicBoundaryPricingCases(
+	knownTable operatorsettings.PriceTable,
+	knownRow, unknownRow, unknownModelRow factoryvisualization.RuntimeMetricsUsageRow,
+) []publicBoundaryCase {
+	return []publicBoundaryCase{
+		{
+			name:      "all-priced",
+			table:     knownTable,
+			rows:      []factoryvisualization.RuntimeMetricsUsageRow{knownRow},
+			status:    costs.StatusPriced,
+			knownCost: "11.75",
+			tokens:    publicBoundaryTokens(1_000_000, 2_000_000, 3_000_000, 250_000, 500_000),
+			human:     []string{"Status: PRICED", "Cost (USD): $11.75", "Total tokens: 3000000"},
+			noHuman:   []string{"?? unknown"},
+		},
+		{
+			name:                  "none-priced",
+			table:                 knownTable,
+			rows:                  []factoryvisualization.RuntimeMetricsUsageRow{unknownRow},
+			status:                costs.StatusUnpriced,
+			tokens:                publicBoundaryTokens(100, 50, 150, 25, 10),
+			unpricedDispatchCount: 1,
+			unpricedPair:          "CODEX/unpriced",
+			human:                 []string{"Status: UNPRICED", "Cost (USD): ?? unknown", "Unpriced dispatches: 1", "CODEX/unpriced: 1 dispatches", "Total tokens: 150"},
+			noHuman:               []string{"$0.00"},
+		},
+		{
+			name:                  "mixed",
+			table:                 knownTable,
+			rows:                  []factoryvisualization.RuntimeMetricsUsageRow{knownRow, unknownRow},
+			status:                costs.StatusPartial,
+			knownCost:             "11.75",
+			tokens:                publicBoundaryTokens(1_000_100, 2_000_050, 3_000_150, 250_025, 500_010),
+			unpricedDispatchCount: 1,
+			unpricedPair:          "CODEX/unpriced",
+			human:                 []string{"Status: PARTIAL", "Cost (USD): $11.75 + ?? unknown", "Unpriced dispatches: 1", "CODEX/unpriced: 1 dispatches", "Total tokens: 3000150"},
+		},
+		{
+			name:                  "unknown-model",
+			table:                 knownTable,
+			rows:                  []factoryvisualization.RuntimeMetricsUsageRow{unknownModelRow},
+			status:                costs.StatusUnpriced,
+			tokens:                publicBoundaryTokens(20, 10, 30, 5, 3),
+			unpricedDispatchCount: 1,
+			unpricedPair:          "CODEX/unknown-model",
+			human:                 []string{"Status: UNPRICED", "Cost (USD): ?? unknown", "CODEX/unknown-model: 1 dispatches", "Total tokens: 30"},
+			noHuman:               []string{"$0.00"},
+		},
+	}
+}
+
+func TestPublicCostsTokenTotalsIgnorePriceCoverage(t *testing.T) {
+	t.Parallel()
+
+	rows := []factoryvisualization.RuntimeMetricsUsageRow{
+		usageRow("session", "work-a", "dispatch-a", "worker-a", "codex", "known", 1_000_000, 2_000_000, int64Ptr(250_000), int64Ptr(500_000)),
+		usageRow("session", "work-b", "dispatch-b", "worker-b", "codex", "unpriced", 100, 50, int64Ptr(25), int64Ptr(10)),
+	}
+	cases := []struct {
+		name   string
+		table  operatorsettings.PriceTable
+		status costs.Status
+	}{
+		{name: "full", table: publicBoundaryPriceTable(publicBoundaryKnownModel("known"), publicBoundaryKnownModel("unpriced")), status: costs.StatusPriced},
+		{name: "partial", table: publicBoundaryPriceTable(publicBoundaryKnownModel("known")), status: costs.StatusPartial},
+		{name: "empty", table: publicBoundaryPriceTable(), status: costs.StatusUnpriced},
+	}
+
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			query, err := New(
+				&settingsReader{document: operatorsettings.Document{PriceTable: testCase.table}},
+				metricsQueryStub(rows, nil),
+				logging.NoopLogger{},
+			)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			report, err := query.Query(context.Background(), validRequest())
+			if err != nil {
+				t.Fatalf("Costs query error = %v", err)
+			}
+			if report.Status != testCase.status {
+				t.Fatalf("status = %q, want %q", report.Status, testCase.status)
+			}
+			assertTokenTotals(t, report.TokenTotals, 1_000_100, 2_000_050, 3_000_150)
+			if report.TokenTotals.CachedInputTokens == nil || *report.TokenTotals.CachedInputTokens != 250_025 || report.TokenTotals.ReasoningOutputTokens == nil || *report.TokenTotals.ReasoningOutputTokens != 500_010 {
+				t.Fatalf("subclass token totals = %#v, want cached 250025 and reasoning 500010", report.TokenTotals)
+			}
+		})
+	}
+}
+
+type publicBoundaryCase struct {
+	name                  string
+	table                 operatorsettings.PriceTable
+	rows                  []factoryvisualization.RuntimeMetricsUsageRow
+	status                costs.Status
+	knownCost             string
+	tokens                publicBoundaryTokenWant
+	unpricedDispatchCount int
+	unpricedPair          string
+	human                 []string
+	noHuman               []string
+}
+
+type publicBoundaryTokenWant struct {
+	input, output, total, cached, reasoning int64
+}
+
+func assertPublicDomainReport(t *testing.T, report costs.Report, testCase publicBoundaryCase) {
+	t.Helper()
+	if report.Status != testCase.status {
+		t.Fatalf("domain status = %q, want %q", report.Status, testCase.status)
+	}
+	if testCase.knownCost == "" {
+		if report.KnownCost != nil {
+			t.Fatalf("domain known cost = %q, want absent", *report.KnownCost)
+		}
+	} else if report.KnownCost == nil || *report.KnownCost != testCase.knownCost {
+		t.Fatalf("domain known cost = %v, want %q", report.KnownCost, testCase.knownCost)
+	}
+	assertTokenTotals(t, report.TokenTotals, testCase.tokens.input, testCase.tokens.output, testCase.tokens.total)
+	if report.TokenTotals.CachedInputTokens == nil || *report.TokenTotals.CachedInputTokens != testCase.tokens.cached || report.TokenTotals.ReasoningOutputTokens == nil || *report.TokenTotals.ReasoningOutputTokens != testCase.tokens.reasoning {
+		t.Fatalf("domain subclass token totals = %#v, want %#v", report.TokenTotals, testCase.tokens)
+	}
+	if report.UnpricedDispatchCount != testCase.unpricedDispatchCount {
+		t.Fatalf("domain unpriced dispatch count = %d, want %d", report.UnpricedDispatchCount, testCase.unpricedDispatchCount)
+	}
+	assertDomainUnpricedPair(t, report.UnpricedPairs, testCase.unpricedPair)
+}
+
+func assertPublicAPIReport(t *testing.T, report factoryapi.CostsReport, testCase publicBoundaryCase) {
+	t.Helper()
+	if report.Status != factoryapi.CostsReportStatus(testCase.status) || report.Currency != "USD" {
+		t.Fatalf("API status/currency = %q/%q, want %q/USD", report.Status, report.Currency, testCase.status)
+	}
+	if testCase.knownCost == "" {
+		if report.KnownCost != nil {
+			t.Fatalf("API known cost = %q, want absent", *report.KnownCost)
+		}
+	} else if report.KnownCost == nil || *report.KnownCost != testCase.knownCost {
+		t.Fatalf("API known cost = %v, want %q", report.KnownCost, testCase.knownCost)
+	}
+	assertPublicTokenTotals(t, report.TokenTotals, testCase.tokens)
+	if report.UnpricedDispatchCount != testCase.unpricedDispatchCount {
+		t.Fatalf("API unpriced dispatch count = %d, want %d", report.UnpricedDispatchCount, testCase.unpricedDispatchCount)
+	}
+	assertPublicUnpricedPair(t, report.UnpricedPairs, testCase.unpricedPair)
+	if len(report.LineItems) != len(testCase.rows) {
+		t.Fatalf("API line items = %d, want %d", len(report.LineItems), len(testCase.rows))
+	}
+	for _, rollup := range report.WorkItems {
+		assertPublicTokenTotalsPresent(t, rollup.TokenTotals)
+	}
+	for _, rollup := range report.WorkerSessions {
+		assertPublicTokenTotalsPresent(t, rollup.TokenTotals)
+	}
+	for _, rollup := range report.FactorySessions {
+		assertPublicTokenTotalsPresent(t, rollup.TokenTotals)
+	}
+	for _, rollup := range report.ProviderModels {
+		assertPublicTokenTotalsPresent(t, rollup.TokenTotals)
+	}
+}
+
+func assertPublicTokenTotals(t *testing.T, totals factoryapi.CostsTokenTotals, want publicBoundaryTokenWant) {
+	t.Helper()
+	values := []struct {
+		name string
+		got  *int64
+		want int64
+	}{
+		{name: "total", got: totals.TotalTokens, want: want.total},
+		{name: "input", got: totals.InputTokens, want: want.input},
+		{name: "output", got: totals.OutputTokens, want: want.output},
+		{name: "cached-input", got: totals.CachedInputTokens, want: want.cached},
+		{name: "reasoning-output", got: totals.ReasoningOutputTokens, want: want.reasoning},
+	}
+	for _, value := range values {
+		if value.got == nil || *value.got != value.want {
+			t.Fatalf("API %s token total = %v, want %d", value.name, value.got, value.want)
+		}
+	}
+}
+
+func assertPublicTokenTotalsPresent(t *testing.T, totals factoryapi.CostsTokenTotals) {
+	t.Helper()
+	if totals.TotalTokens == nil || totals.InputTokens == nil || totals.OutputTokens == nil || totals.CachedInputTokens == nil || totals.ReasoningOutputTokens == nil {
+		t.Fatalf("API rollup token totals = %#v, want every token class present", totals)
+	}
+	if *totals.TotalTokens != *totals.InputTokens+*totals.OutputTokens {
+		t.Fatalf("API rollup total tokens = %d, want input plus output %d", *totals.TotalTokens, *totals.InputTokens+*totals.OutputTokens)
+	}
+}
+
+func assertPublicJSONShape(t *testing.T, body string, wantKnownCost bool) {
+	t.Helper()
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(body), &fields); err != nil {
+		t.Fatalf("decode public Costs JSON: %v\n%s", err, body)
+	}
+	for _, field := range []string{"status", "currency", "known_cost", "token_totals", "unpriced_dispatch_count", "unpriced_pairs"} {
+		if _, ok := fields[field]; !ok {
+			t.Fatalf("public Costs JSON missing %q: %s", field, body)
+		}
+	}
+	if wantKnownCost && string(fields["known_cost"]) != `"11.75"` {
+		t.Fatalf("public Costs JSON known_cost = %s, want exact 11.75", fields["known_cost"])
+	}
+	if !wantKnownCost && string(fields["known_cost"]) != "null" {
+		t.Fatalf("public Costs JSON known_cost = %s, want null", fields["known_cost"])
+	}
+	var tokenFields map[string]json.RawMessage
+	if err := json.Unmarshal(fields["token_totals"], &tokenFields); err != nil {
+		t.Fatalf("decode public token_totals: %v", err)
+	}
+	for _, field := range []string{"total_tokens", "input_tokens", "output_tokens", "cached_input_tokens", "reasoning_output_tokens"} {
+		if _, ok := tokenFields[field]; !ok {
+			t.Fatalf("public token_totals missing %q: %s", field, fields["token_totals"])
+		}
+	}
+}
+
+func publicBoundaryAPIReport(t *testing.T, query costs.CostsQuery) (factoryapi.CostsReport, string) {
+	t.Helper()
+	handler := costshttp.NewHandler(costshttp.NewAdapter(query, "metrics-root", "settings.json"), zap.NewNop())
+	recorder := httptest.NewRecorder()
+	handler.GetMetricsCosts(
+		recorder,
+		httptest.NewRequest(http.MethodGet, "/metrics/costs", nil),
+		factoryapi.GetMetricsCostsParams{},
+	)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("public Costs HTTP status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	var report factoryapi.CostsReport
+	if err := json.Unmarshal(recorder.Body.Bytes(), &report); err != nil {
+		t.Fatalf("decode public Costs HTTP JSON: %v", err)
+	}
+	return report, recorder.Body.String()
+}
+
+func runPublicBoundaryCLI(t *testing.T, report factoryapi.CostsReport, jsonOutput bool) string {
+	t.Helper()
+	clientReport := publicBoundaryClientReport(t, report)
+	command := costscli.NewCostsCommand(costscli.CostsCommandConfig{
+		Operation: costscli.NewOperation(func(string) (costscli.Client, error) {
+			return &publicBoundaryClient{report: clientReport}, nil
+		}),
+		Server: func() string { return "https://factory.example" },
+		JSON:   func() bool { return jsonOutput },
+	})
+	output := &bytes.Buffer{}
+	command.SetOut(output)
+	command.SetErr(io.Discard)
+	if err := command.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute public Costs CLI: %v", err)
+	}
+	return output.String()
+}
+
+type publicBoundaryClient struct {
+	report generatedclient.CostsReport
+}
+
+func (client *publicBoundaryClient) GetMetricsCostsWithResponse(
+	context.Context,
+	*generatedclient.GetMetricsCostsParams,
+	...generatedclient.RequestEditorFn,
+) (*generatedclient.GetMetricsCostsClientResponse, error) {
+	return &generatedclient.GetMetricsCostsClientResponse{JSON200: &client.report}, nil
+}
+
+func publicBoundaryClientReport(t *testing.T, report factoryapi.CostsReport) generatedclient.CostsReport {
+	t.Helper()
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("encode public API report for client: %v", err)
+	}
+	var clientReport generatedclient.CostsReport
+	if err := json.Unmarshal(encoded, &clientReport); err != nil {
+		t.Fatalf("decode public API report for client: %v", err)
+	}
+	return clientReport
+}
+
+func publicBoundaryPriceTable(models ...operatorsettings.PriceTableModel) operatorsettings.PriceTable {
+	return operatorsettings.PriceTable{Currency: operatorsettings.PriceTableCurrencyUSD, Models: models}
+}
+
+func publicBoundaryKnownModel(model string) operatorsettings.PriceTableModel {
+	cached := "1"
+	reasoning := "8"
+	return operatorsettings.PriceTableModel{
+		Provider: "codex", Model: model, InputPerMillionTokens: "2", OutputPerMillionTokens: "4",
+		CachedInputPerMillionTokens: &cached, ReasoningOutputPerMillionTokens: &reasoning,
+	}
+}
+
+func publicBoundaryTokens(input, output, total, cached, reasoning int64) publicBoundaryTokenWant {
+	return publicBoundaryTokenWant{input: input, output: output, total: total, cached: cached, reasoning: reasoning}
+}
+
+func assertDomainUnpricedPair(t *testing.T, pairs []costs.UnpricedPair, want string) {
+	t.Helper()
+	if want == "" {
+		if len(pairs) != 0 {
+			t.Fatalf("domain unpriced pairs = %#v, want none", pairs)
+		}
+		return
+	}
+	if len(pairs) != 1 || pairs[0].Provider == nil || pairs[0].Model == nil || *pairs[0].Provider+"/"+*pairs[0].Model != want || pairs[0].DispatchCount != 1 {
+		t.Fatalf("domain unpriced pairs = %#v, want one %s pair", pairs, want)
+	}
+}
+
+func assertPublicUnpricedPair(t *testing.T, pairs []factoryapi.CostsUnpricedPair, want string) {
+	t.Helper()
+	if want == "" {
+		if len(pairs) != 0 {
+			t.Fatalf("API unpriced pairs = %#v, want none", pairs)
+		}
+		return
+	}
+	if len(pairs) != 1 || pairs[0].Provider == nil || pairs[0].Model == nil || *pairs[0].Provider+"/"+*pairs[0].Model != want || pairs[0].DispatchCount != 1 {
+		t.Fatalf("API unpriced pairs = %#v, want one %s pair", pairs, want)
+	}
+}

--- a/pkg/services/costs/internal/service/public_boundary_test.go
+++ b/pkg/services/costs/internal/service/public_boundary_test.go
@@ -15,7 +15,7 @@ import (
 	costscli "github.com/portpowered/infinite-you/pkg/services/costs/transports/cli"
 	costshttp "github.com/portpowered/infinite-you/pkg/services/costs/transports/http"
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
-	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 	generatedclient "github.com/portpowered/infinite-you/pkg/transports/http/client"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"go.uber.org/zap"
@@ -36,7 +36,7 @@ func TestPublicCostsBoundaryCoversPricingCases(t *testing.T) {
 			t.Parallel()
 
 			query, err := New(
-				&settingsReader{document: operatorsettings.Document{PriceTable: testCase.table}},
+				&priceReader{table: testCase.table},
 				metricsQueryStub(testCase.rows, nil),
 				logging.NoopLogger{},
 			)
@@ -85,7 +85,7 @@ func assertPublicCLIOutputs(t *testing.T, report factoryapi.CostsReport, testCas
 }
 
 func publicBoundaryPricingCases(
-	knownTable operatorsettings.PriceTable,
+	knownTable providers.PriceTable,
 	knownRow, unknownRow, unknownModelRow factoryvisualization.RuntimeMetricsUsageRow,
 ) []publicBoundaryCase {
 	return []publicBoundaryCase{
@@ -144,7 +144,7 @@ func TestPublicCostsTokenTotalsIgnorePriceCoverage(t *testing.T) {
 	}
 	cases := []struct {
 		name   string
-		table  operatorsettings.PriceTable
+		table  providers.PriceTable
 		status costs.Status
 	}{
 		{name: "full", table: publicBoundaryPriceTable(publicBoundaryKnownModel("known"), publicBoundaryKnownModel("unpriced")), status: costs.StatusPriced},
@@ -157,7 +157,7 @@ func TestPublicCostsTokenTotalsIgnorePriceCoverage(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			query, err := New(
-				&settingsReader{document: operatorsettings.Document{PriceTable: testCase.table}},
+				&priceReader{table: testCase.table},
 				metricsQueryStub(rows, nil),
 				logging.NoopLogger{},
 			)
@@ -181,7 +181,7 @@ func TestPublicCostsTokenTotalsIgnorePriceCoverage(t *testing.T) {
 
 type publicBoundaryCase struct {
 	name                  string
-	table                 operatorsettings.PriceTable
+	table                 providers.PriceTable
 	rows                  []factoryvisualization.RuntimeMetricsUsageRow
 	status                costs.Status
 	knownCost             string
@@ -373,16 +373,17 @@ func publicBoundaryClientReport(t *testing.T, report factoryapi.CostsReport) gen
 	return clientReport
 }
 
-func publicBoundaryPriceTable(models ...operatorsettings.PriceTableModel) operatorsettings.PriceTable {
-	return operatorsettings.PriceTable{Currency: operatorsettings.PriceTableCurrencyUSD, Models: models}
+func publicBoundaryPriceTable(models ...providers.PriceTableModel) providers.PriceTable {
+	return providers.PriceTable{Currency: providers.PriceTableCurrencyUSD, Models: models}
 }
 
-func publicBoundaryKnownModel(model string) operatorsettings.PriceTableModel {
+func publicBoundaryKnownModel(model string) providers.PriceTableModel {
 	cached := "1"
 	reasoning := "8"
-	return operatorsettings.PriceTableModel{
+	return providers.PriceTableModel{
 		Provider: "codex", Model: model, InputPerMillionTokens: "2", OutputPerMillionTokens: "4",
 		CachedInputPerMillionTokens: &cached, ReasoningOutputPerMillionTokens: &reasoning,
+		SourceURL: "https://example.com/test-pricing", AsOfDate: "2026-08-21",
 	}
 }
 

--- a/pkg/services/costs/internal/service/service.go
+++ b/pkg/services/costs/internal/service/service.go
@@ -8,48 +8,45 @@ import (
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	costs "github.com/portpowered/infinite-you/pkg/services/costs"
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
-	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
 // Service owns valuation policy while retaining no report or request state.
-// File and metrics access remain behind the two injected owner contracts.
+// Provider pricing and canonical metrics remain behind two injected owner
+// contracts.
 type Service struct {
-	settings PriceTableReader
-	metrics  factoryvisualization.RuntimeMetricsQuery
-	logger   logging.Logger
+	pricing providers.PriceTableReader
+	metrics factoryvisualization.RuntimeMetricsQuery
+	logger  logging.Logger
 }
-
-// PriceTableReader is kept private so the implementation depends on the
-// narrow Costs contract rather than the complete Operator Settings service.
-type PriceTableReader = costs.PriceTableReader
 
 // New constructs the stateless Costs operation.
 func New(
-	settings PriceTableReader,
+	pricing providers.PriceTableReader,
 	metrics factoryvisualization.RuntimeMetricsQuery,
 	logger logging.Logger,
 ) (costs.CostsQuery, error) {
 	switch {
-	case settings == nil:
+	case pricing == nil:
 		return nil, errors.New("construct Costs query: price-table reader is required")
 	case metrics == nil:
 		return nil, errors.New("construct Costs query: runtime metrics query is required")
 	}
 	service := &Service{
-		settings: settings,
-		metrics:  metrics,
-		logger:   logging.EnsureLogger(logger),
+		pricing: pricing,
+		metrics: metrics,
+		logger:  logging.EnsureLogger(logger),
 	}
 	return service.QueryCosts, nil
 }
 
-// QueryCosts loads the operator-owned table, queries canonical usage, and
+// QueryCosts loads the provider-owned table, queries canonical usage, and
 // calculates one deterministic report from detached local accumulators.
 func (service *Service) QueryCosts(
 	ctx context.Context,
 	request costs.QueryRequest,
 ) (costs.Report, error) {
-	if service == nil || service.settings == nil || service.metrics == nil {
+	if service == nil || service.pricing == nil || service.metrics == nil {
 		return costs.Report{}, &costs.QueryError{
 			Kind:    costs.QueryErrorInvalidInput,
 			Message: "query runtime costs: dependencies are required",
@@ -78,13 +75,13 @@ func (service *Service) QueryCosts(
 		"runtime_instance_id", runtimeID,
 	)
 
-	table, err := service.loadPriceTable(request.OperatorSettingsPath)
+	table, err := service.readPriceTable()
 	if err != nil {
 		service.logger.Error(
 			"runtime costs query failed",
 			"scope_kind", scopeForRequest(request).Kind,
 			"factory_session_id", sessionID,
-			"status", "SETTINGS_ERROR",
+			"status", "PRICING_ERROR",
 			"error_kind", queryErrorKind(err),
 		)
 		return costs.Report{}, err
@@ -145,22 +142,20 @@ func (service *Service) QueryCosts(
 	return report, nil
 }
 
-func (service *Service) loadPriceTable(path string) (operatorsettings.PriceTable, error) {
-	loaded, err := service.settings.LoadDocument(operatorsettings.LoadDocumentRequest{
-		Path: strings.TrimSpace(path),
-	})
+func (service *Service) readPriceTable() (providers.PriceTable, error) {
+	table, err := service.pricing.ReadPriceTable()
 	if err != nil {
-		return operatorsettings.PriceTable{}, &costs.QueryError{
+		return providers.PriceTable{}, &costs.QueryError{
 			Kind:    costs.QueryErrorSettingsReadFailed,
-			Message: "query runtime costs: load operator price table",
+			Message: "query runtime costs: read provider price table",
 			Cause:   err,
 		}
 	}
-	table, err := loaded.Document.PriceTable.Normalize()
+	table, err = table.Normalize()
 	if err != nil {
-		return operatorsettings.PriceTable{}, &costs.QueryError{
+		return providers.PriceTable{}, &costs.QueryError{
 			Kind:    costs.QueryErrorInvalidPriceTable,
-			Message: "query runtime costs: normalize operator price table",
+			Message: "query runtime costs: validate provider price table",
 			Cause:   err,
 		}
 	}

--- a/pkg/services/costs/internal/service/service.go
+++ b/pkg/services/costs/internal/service/service.go
@@ -15,14 +15,14 @@ import (
 // Provider pricing and canonical metrics remain behind two injected owner
 // contracts.
 type Service struct {
-	pricing providers.PriceTableReader
+	pricing costs.PriceTableReader
 	metrics factoryvisualization.RuntimeMetricsQuery
 	logger  logging.Logger
 }
 
 // New constructs the stateless Costs operation.
 func New(
-	pricing providers.PriceTableReader,
+	pricing costs.PriceTableReader,
 	metrics factoryvisualization.RuntimeMetricsQuery,
 	logger logging.Logger,
 ) (costs.CostsQuery, error) {

--- a/pkg/services/costs/internal/service/service_test.go
+++ b/pkg/services/costs/internal/service/service_test.go
@@ -12,20 +12,20 @@ import (
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	costs "github.com/portpowered/infinite-you/pkg/services/costs"
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
-	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
 func TestQueryExactValuationCoverageAndRollups(t *testing.T) {
 	t.Parallel()
 
-	settings := &settingsReader{document: operatorsettings.Document{PriceTable: operatorsettings.PriceTable{
-		Currency: operatorsettings.PriceTableCurrencyUSD,
-		Models: []operatorsettings.PriceTableModel{
-			{Provider: "codex", Model: "gpt-5", InputPerMillionTokens: "2.5", OutputPerMillionTokens: "5.25", CachedInputPerMillionTokens: stringPtr("0.5"), ReasoningOutputPerMillionTokens: stringPtr("10")},
-			{Provider: "codex", Model: "gpt-zero", InputPerMillionTokens: "0", OutputPerMillionTokens: "0"},
-			{Provider: "codex", Model: "gpt-no-cache", InputPerMillionTokens: "1", OutputPerMillionTokens: "1"},
+	pricing := &priceReader{table: providers.PriceTable{
+		Currency: providers.PriceTableCurrencyUSD,
+		Models: []providers.PriceTableModel{
+			testPriceModel("gpt-5", "2.5", "5.25", stringPtr("0.5"), stringPtr("10")),
+			testPriceModel("gpt-zero", "0", "0", nil, nil),
+			testPriceModel("gpt-no-cache", "1", "1", nil, nil),
 		},
-	}}}
+	}}
 	rows := []factoryvisualization.RuntimeMetricsUsageRow{
 		usageRow("session-b", "work-b", "dispatch-b", "worker-b", "codex", "gpt-5", 2_000_000, 1_000_000, int64Ptr(500_000), int64Ptr(200_000)),
 		usageRow("session-a", "work-a", "dispatch-a", "worker-a", "codex", "gpt-zero", 3, 4, nil, nil),
@@ -33,7 +33,7 @@ func TestQueryExactValuationCoverageAndRollups(t *testing.T) {
 		usageRow("session-a", "work-a2", "dispatch-a2", "worker-a2", "codex", "gpt-no-cache", 1_000, 1_000, int64Ptr(500), nil),
 		usageRow("session-a", "work-a3", "dispatch-a3", "worker-a3", "codex", "", 8, 9, nil, nil),
 	}
-	query, err := New(settings, metricsQueryStub(rows, nil), logging.NoopLogger{})
+	query, err := New(pricing, metricsQueryStub(rows, nil), logging.NoopLogger{})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -140,10 +140,11 @@ func assertFactorySessionRollup(t *testing.T, rollup costs.Rollup) {
 func TestQueryNoUsageAndExplicitZeroRemainDistinct(t *testing.T) {
 	t.Parallel()
 
-	settings := &settingsReader{document: operatorsettings.Document{PriceTable: operatorsettings.PriceTable{
-		Models: []operatorsettings.PriceTableModel{{Provider: "codex", Model: "free", InputPerMillionTokens: "0", OutputPerMillionTokens: "0"}},
-	}}}
-	query, err := New(settings, metricsQueryStub(nil, nil), logging.NoopLogger{})
+	pricing := &priceReader{table: providers.PriceTable{
+		Currency: providers.PriceTableCurrencyUSD,
+		Models:   []providers.PriceTableModel{testPriceModel("free", "0", "0", nil, nil)},
+	}}
+	query, err := New(pricing, metricsQueryStub(nil, nil), logging.NoopLogger{})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -155,7 +156,7 @@ func TestQueryNoUsageAndExplicitZeroRemainDistinct(t *testing.T) {
 		t.Fatalf("empty report = %#v, want NO_USAGE with absent amount", empty)
 	}
 
-	query, err = New(settings, metricsQueryStub([]factoryvisualization.RuntimeMetricsUsageRow{
+	query, err = New(pricing, metricsQueryStub([]factoryvisualization.RuntimeMetricsUsageRow{
 		usageRow("session", "work", "dispatch", "worker", "codex", "free", 0, 0, nil, nil),
 	}, nil), logging.NoopLogger{})
 	if err != nil {
@@ -176,15 +177,16 @@ func TestQueryNoUsageAndExplicitZeroRemainDistinct(t *testing.T) {
 func TestQueryUnpricedFactsDeduplicateDispatchesAndRetainUnknownIdentity(t *testing.T) {
 	t.Parallel()
 
-	settings := &settingsReader{document: operatorsettings.Document{PriceTable: operatorsettings.PriceTable{
-		Models: []operatorsettings.PriceTableModel{{Provider: "codex", Model: "known", InputPerMillionTokens: "1", OutputPerMillionTokens: "1"}},
-	}}}
+	pricing := &priceReader{table: providers.PriceTable{
+		Currency: providers.PriceTableCurrencyUSD,
+		Models:   []providers.PriceTableModel{testPriceModel("known", "1", "1", nil, nil)},
+	}}
 	rows := []factoryvisualization.RuntimeMetricsUsageRow{
 		usageRow("session", "work", "dispatch-a", "worker-a", "codex", "unknown", 2, 3, nil, nil),
 		usageRow("session", "work", "dispatch-a", "worker-a", "CODEX", "unknown", 4, 5, nil, nil),
 		usageRow("session", "work", "dispatch-b", "worker-b", "", "", 6, 7, nil, nil),
 	}
-	query, err := New(settings, metricsQueryStub(rows, nil), logging.NoopLogger{})
+	query, err := New(pricing, metricsQueryStub(rows, nil), logging.NoopLogger{})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -267,14 +269,15 @@ func assertUnpricedLineRetainsCorrelation(t *testing.T, line costs.LineItem) {
 func TestQueryScopedSelectionAndDeterministicOutput(t *testing.T) {
 	t.Parallel()
 
-	settings := &settingsReader{document: operatorsettings.Document{PriceTable: operatorsettings.PriceTable{
-		Models: []operatorsettings.PriceTableModel{{Provider: "codex", Model: "model", InputPerMillionTokens: "1", OutputPerMillionTokens: "1"}},
-	}}}
+	pricing := &priceReader{table: providers.PriceTable{
+		Currency: providers.PriceTableCurrencyUSD,
+		Models:   []providers.PriceTableModel{testPriceModel("model", "1", "1", nil, nil)},
+	}}
 	rows := []factoryvisualization.RuntimeMetricsUsageRow{
 		usageRow("session-b", "work-b", "dispatch-b", "worker-b", "codex", "model", 2, 2, nil, nil),
 		usageRow("session-a", "work-a", "dispatch-a", "worker-a", "codex", "model", 1, 1, nil, nil),
 	}
-	query, err := New(settings, metricsQueryStub(rows, nil), logging.NoopLogger{})
+	query, err := New(pricing, metricsQueryStub(rows, nil), logging.NoopLogger{})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -310,16 +313,16 @@ func TestQueryErrorsAreTypedAndLogsSafeTerminalOutcome(t *testing.T) {
 
 func assertSettingsReadFailureIsSafe(t *testing.T) {
 	t.Helper()
-	settingsErr := errors.New("settings unavailable")
+	pricingErr := errors.New("provider pricing unavailable")
 	logger := &captureLogger{}
-	query, err := New(&settingsReader{err: settingsErr}, metricsQueryStub(nil, nil), logger)
+	query, err := New(&priceReader{err: pricingErr}, metricsQueryStub(nil, nil), logger)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
 	_, err = query.Query(context.Background(), validRequest())
 	var queryErr *costs.QueryError
-	if !errors.As(err, &queryErr) || queryErr.Kind != costs.QueryErrorSettingsReadFailed || !errors.Is(err, settingsErr) {
-		t.Fatalf("settings error = %v, want typed wrapped settings failure", err)
+	if !errors.As(err, &queryErr) || queryErr.Kind != costs.QueryErrorSettingsReadFailed || !errors.Is(err, pricingErr) {
+		t.Fatalf("pricing error = %v, want typed wrapped provider-pricing failure", err)
 	}
 	if !logger.hasMessage("runtime costs query started") || !logger.hasMessage("runtime costs query failed") {
 		t.Fatalf("log messages = %#v, want start and safe terminal failure", logger.messages)
@@ -327,7 +330,7 @@ func assertSettingsReadFailureIsSafe(t *testing.T) {
 	if strings.Contains(logger.fieldsText(), "inputPerMillion") || strings.Contains(logger.fieldsText(), "gpt") {
 		t.Fatalf("logs contain configuration identity/content: %#v", logger.fields)
 	}
-	if strings.Contains(logger.fieldsText(), settingsErr.Error()) {
+	if strings.Contains(logger.fieldsText(), pricingErr.Error()) {
 		t.Fatalf("logs contain dependency error details: %#v", logger.fields)
 	}
 }
@@ -335,7 +338,7 @@ func assertSettingsReadFailureIsSafe(t *testing.T) {
 func assertMetricsFailureIsTyped(t *testing.T) {
 	t.Helper()
 	metricsErr := errors.New("metrics unavailable")
-	query, err := New(&settingsReader{document: operatorsettings.Document{}}, metricsQueryStub(nil, metricsErr), logging.NoopLogger{})
+	query, err := New(&priceReader{table: providers.PriceTable{Currency: providers.PriceTableCurrencyUSD}}, metricsQueryStub(nil, metricsErr), logging.NoopLogger{})
 	if err != nil {
 		t.Fatalf("New(metrics error) error = %v", err)
 	}
@@ -348,13 +351,13 @@ func assertMetricsFailureIsTyped(t *testing.T) {
 
 func assertInvalidRequestIsTyped(t *testing.T) {
 	t.Helper()
-	query, err := New(&settingsReader{document: operatorsettings.Document{}}, metricsQueryStub(nil, nil), logging.NoopLogger{})
+	query, err := New(&priceReader{table: providers.PriceTable{Currency: providers.PriceTableCurrencyUSD}}, metricsQueryStub(nil, nil), logging.NoopLogger{})
 	if err != nil {
 		t.Fatalf("New(invalid request) error = %v", err)
 	}
-	_, err = query.Query(context.Background(), costs.QueryRequest{MetricsRoot: "metrics-root"})
+	_, err = query.Query(context.Background(), costs.QueryRequest{})
 	var queryErr *costs.QueryError
-	if !errors.As(err, &queryErr) || queryErr.Kind != costs.QueryErrorInvalidInput || !strings.Contains(err.Error(), "operator settings path") {
+	if !errors.As(err, &queryErr) || queryErr.Kind != costs.QueryErrorInvalidInput || !strings.Contains(err.Error(), "metrics root") {
 		t.Fatalf("invalid request error = %v, want actionable invalid input", err)
 	}
 }
@@ -429,16 +432,36 @@ func metricsQueryStub(rows []factoryvisualization.RuntimeMetricsUsageRow, err er
 	}
 }
 
-type settingsReader struct {
-	document operatorsettings.Document
-	err      error
+type priceReader struct {
+	table providers.PriceTable
+	err   error
 }
 
-func (reader *settingsReader) LoadDocument(operatorsettings.LoadDocumentRequest) (operatorsettings.LoadDocumentResult, error) {
+func (reader *priceReader) ReadPriceTable() (providers.PriceTable, error) {
 	if reader.err != nil {
-		return operatorsettings.LoadDocumentResult{}, reader.err
+		return providers.PriceTable{}, reader.err
 	}
-	return operatorsettings.LoadDocumentResult{Document: reader.document}, nil
+	return reader.table.Clone(), nil
+}
+
+func testPriceModel(model, input, output string, cached, reasoning *string) providers.PriceTableModel {
+	entry := providers.PriceTableModel{
+		Provider:                        providers.IDCodex,
+		Model:                           model,
+		InputPerMillionTokens:           input,
+		OutputPerMillionTokens:          output,
+		CachedInputPerMillionTokens:     cached,
+		ReasoningOutputPerMillionTokens: reasoning,
+		SourceURL:                       "https://example.com/test-pricing",
+		AsOfDate:                        "2026-08-21",
+	}
+	if cached != nil && *cached == input {
+		entry.EqualRateClasses = append(entry.EqualRateClasses, providers.PriceClassCachedInput)
+	}
+	if reasoning != nil && *reasoning == output {
+		entry.EqualRateClasses = append(entry.EqualRateClasses, providers.PriceClassReasoningOutput)
+	}
+	return entry
 }
 
 type captureLogger struct {

--- a/pkg/services/costs/internal/service/service_test.go
+++ b/pkg/services/costs/internal/service/service_test.go
@@ -58,6 +58,21 @@ func assertExactReport(t *testing.T, report costs.Report) {
 	if report.PricedSubtotal == nil || *report.PricedSubtotal != "10.2" {
 		t.Fatalf("priced subtotal = %v, want exact 10.2", report.PricedSubtotal)
 	}
+	if report.KnownCost == nil || *report.KnownCost != "10.2" {
+		t.Fatalf("known cost = %v, want exact 10.2", report.KnownCost)
+	}
+	assertTokenTotals(t, report.TokenTotals, 2_001_021, 1_001_018, 3_002_039)
+	if report.TokenTotals.CachedInputTokens == nil || *report.TokenTotals.CachedInputTokens != 500_500 || report.TokenTotals.ReasoningOutputTokens == nil || *report.TokenTotals.ReasoningOutputTokens != 200_000 {
+		t.Fatalf("subclass token totals = %#v, want cached 500500 and reasoning 200000", report.TokenTotals)
+	}
+	if report.UnpricedDispatchCount != 3 {
+		t.Fatalf("unpriced dispatch count = %d, want 3", report.UnpricedDispatchCount)
+	}
+	assertUnpricedPairs(t, report.UnpricedPairs, []unpricedPairWant{
+		{model: nil, dispatchCount: 1},
+		{model: stringPtr("gpt-no-cache"), dispatchCount: 1},
+		{model: stringPtr("unknown"), dispatchCount: 1},
+	})
 	wantCoverage := costs.Coverage{
 		EncounteredRows: 5, PricedRows: 2, UnpricedRows: 3,
 		EncounteredProviderModels: 4, PricedProviderModels: 2, UnpricedProviderModels: 2,
@@ -97,6 +112,14 @@ func assertExactRollups(t *testing.T, report costs.Report) {
 	}
 	for _, rollup := range report.FactorySessions {
 		assertFactorySessionRollup(t, rollup)
+	}
+	for _, rollup := range report.WorkItems {
+		if rollup.Currency != "USD" {
+			t.Fatalf("work rollup currency = %q, want USD", rollup.Currency)
+		}
+		if rollup.TokenTotals.TotalTokens == nil {
+			t.Fatalf("work rollup %#v has no total token fact", rollup)
+		}
 	}
 }
 
@@ -144,6 +167,50 @@ func TestQueryNoUsageAndExplicitZeroRemainDistinct(t *testing.T) {
 	}
 	if free.Status != costs.StatusPriced || free.PricedSubtotal == nil || *free.PricedSubtotal != "0" {
 		t.Fatalf("explicit zero report = %#v, want PRICED amount 0", free)
+	}
+	if free.KnownCost == nil || *free.KnownCost != "0" || free.TokenTotals.TotalTokens == nil || *free.TokenTotals.TotalTokens != 0 {
+		t.Fatalf("explicit zero facts = %#v, want known zero and total zero", free)
+	}
+}
+
+func TestQueryUnpricedFactsDeduplicateDispatchesAndRetainUnknownIdentity(t *testing.T) {
+	t.Parallel()
+
+	settings := &settingsReader{document: operatorsettings.Document{PriceTable: operatorsettings.PriceTable{
+		Models: []operatorsettings.PriceTableModel{{Provider: "codex", Model: "known", InputPerMillionTokens: "1", OutputPerMillionTokens: "1"}},
+	}}}
+	rows := []factoryvisualization.RuntimeMetricsUsageRow{
+		usageRow("session", "work", "dispatch-a", "worker-a", "codex", "unknown", 2, 3, nil, nil),
+		usageRow("session", "work", "dispatch-a", "worker-a", "CODEX", "unknown", 4, 5, nil, nil),
+		usageRow("session", "work", "dispatch-b", "worker-b", "", "", 6, 7, nil, nil),
+	}
+	query, err := New(settings, metricsQueryStub(rows, nil), logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	report, err := query.Query(context.Background(), validRequest())
+	if err != nil {
+		t.Fatalf("Query() error = %v", err)
+	}
+	if report.Status != costs.StatusUnpriced || report.KnownCost != nil {
+		t.Fatalf("report = %#v, want wholly unpriced with no known cost", report)
+	}
+	assertTokenTotals(t, report.TokenTotals, 12, 15, 27)
+	if report.TokenTotals.CachedInputTokens != nil || report.TokenTotals.ReasoningOutputTokens != nil {
+		t.Fatalf("absent subclass totals = %#v, want nil cached/reasoning facts", report.TokenTotals)
+	}
+	if report.UnpricedDispatchCount != 2 {
+		t.Fatalf("unpriced dispatch count = %d, want two distinct dispatches", report.UnpricedDispatchCount)
+	}
+	if len(report.UnpricedPairs) != 2 {
+		t.Fatalf("unpriced pairs = %#v, want canonical unknown and missing pairs", report.UnpricedPairs)
+	}
+	if report.UnpricedPairs[0].Provider != nil || report.UnpricedPairs[0].Model != nil || report.UnpricedPairs[0].DispatchCount != 1 {
+		t.Fatalf("missing identity pair = %#v, want explicit nil identities", report.UnpricedPairs[0])
+	}
+	if report.UnpricedPairs[1].Provider == nil || *report.UnpricedPairs[1].Provider != "CODEX" || report.UnpricedPairs[1].Model == nil || *report.UnpricedPairs[1].Model != "unknown" || report.UnpricedPairs[1].DispatchCount != 1 {
+		t.Fatalf("canonical pair = %#v, want CODEX/unknown with one dispatch", report.UnpricedPairs[1])
 	}
 }
 
@@ -426,5 +493,49 @@ func assertLine(t *testing.T, lines []costs.LineItem, model string, status costs
 
 func int64Ptr(value int64) *int64    { return &value }
 func stringPtr(value string) *string { return &value }
+
+type unpricedPairWant struct {
+	model         *string
+	dispatchCount int
+}
+
+func assertTokenTotals(t *testing.T, totals costs.TokenTotals, input, output, total int64) {
+	t.Helper()
+	values := []struct {
+		name string
+		got  *int64
+		want int64
+	}{
+		{"input", totals.InputTokens, input},
+		{"output", totals.OutputTokens, output},
+		{"total", totals.TotalTokens, total},
+	}
+	for _, value := range values {
+		if value.got == nil || *value.got != value.want {
+			t.Fatalf("%s token total = %v, want %d", value.name, value.got, value.want)
+		}
+	}
+}
+
+func assertUnpricedPairs(t *testing.T, got []costs.UnpricedPair, want []unpricedPairWant) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("unpriced pairs = %#v, want %d pairs", got, len(want))
+	}
+	for index, expected := range want {
+		if got[index].Model == nil && expected.model != nil || got[index].Model != nil && expected.model == nil {
+			t.Fatalf("unpriced pair %d model = %#v, want %#v", index, got[index].Model, expected.model)
+		}
+		if got[index].Model != nil && *got[index].Model != *expected.model {
+			t.Fatalf("unpriced pair %d model = %q, want %q", index, *got[index].Model, *expected.model)
+		}
+		if got[index].Provider == nil || *got[index].Provider != "CODEX" {
+			t.Fatalf("unpriced pair %d provider = %#v, want CODEX", index, got[index].Provider)
+		}
+		if got[index].DispatchCount != expected.dispatchCount {
+			t.Fatalf("unpriced pair %d dispatch count = %d, want %d", index, got[index].DispatchCount, expected.dispatchCount)
+		}
+	}
+}
 
 var _ logging.Logger = (*captureLogger)(nil)

--- a/pkg/services/costs/internal/service/service_test.go
+++ b/pkg/services/costs/internal/service/service_test.go
@@ -195,6 +195,11 @@ func TestQueryUnpricedFactsDeduplicateDispatchesAndRetainUnknownIdentity(t *test
 	if err != nil {
 		t.Fatalf("Query() error = %v", err)
 	}
+	assertUnpricedReportFacts(t, report)
+}
+
+func assertUnpricedReportFacts(t *testing.T, report costs.Report) {
+	t.Helper()
 	if report.Status != costs.StatusUnpriced || report.KnownCost != nil {
 		t.Fatalf("report = %#v, want wholly unpriced with no known cost", report)
 	}
@@ -205,14 +210,29 @@ func TestQueryUnpricedFactsDeduplicateDispatchesAndRetainUnknownIdentity(t *test
 	if report.UnpricedDispatchCount != 2 {
 		t.Fatalf("unpriced dispatch count = %d, want two distinct dispatches", report.UnpricedDispatchCount)
 	}
-	if len(report.UnpricedPairs) != 2 {
-		t.Fatalf("unpriced pairs = %#v, want canonical unknown and missing pairs", report.UnpricedPairs)
+	assertUnpricedPairFacts(t, report.UnpricedPairs)
+}
+
+func assertUnpricedPairFacts(t *testing.T, pairs []costs.UnpricedPair) {
+	t.Helper()
+	if len(pairs) != 2 {
+		t.Fatalf("unpriced pairs = %#v, want canonical unknown and missing pairs", pairs)
 	}
-	if report.UnpricedPairs[0].Provider != nil || report.UnpricedPairs[0].Model != nil || report.UnpricedPairs[0].DispatchCount != 1 {
-		t.Fatalf("missing identity pair = %#v, want explicit nil identities", report.UnpricedPairs[0])
+	assertMissingIdentityPair(t, pairs[0])
+	assertCanonicalUnknownPair(t, pairs[1])
+}
+
+func assertMissingIdentityPair(t *testing.T, pair costs.UnpricedPair) {
+	t.Helper()
+	if pair.Provider != nil || pair.Model != nil || pair.DispatchCount != 1 {
+		t.Fatalf("missing identity pair = %#v, want explicit nil identities", pair)
 	}
-	if report.UnpricedPairs[1].Provider == nil || *report.UnpricedPairs[1].Provider != "CODEX" || report.UnpricedPairs[1].Model == nil || *report.UnpricedPairs[1].Model != "unknown" || report.UnpricedPairs[1].DispatchCount != 1 {
-		t.Fatalf("canonical pair = %#v, want CODEX/unknown with one dispatch", report.UnpricedPairs[1])
+}
+
+func assertCanonicalUnknownPair(t *testing.T, pair costs.UnpricedPair) {
+	t.Helper()
+	if pair.Provider == nil || *pair.Provider != "CODEX" || pair.Model == nil || *pair.Model != "unknown" || pair.DispatchCount != 1 {
+		t.Fatalf("canonical pair = %#v, want CODEX/unknown with one dispatch", pair)
 	}
 }
 

--- a/pkg/services/costs/internal/service/service_test.go
+++ b/pkg/services/costs/internal/service/service_test.go
@@ -239,17 +239,15 @@ func assertCanonicalUnknownPair(t *testing.T, pair costs.UnpricedPair) {
 func TestQueryUnpricedUsageRetainsCorrelationAndCountsRepeatedRows(t *testing.T) {
 	t.Parallel()
 
-	settings := &settingsReader{document: operatorsettings.Document{PriceTable: operatorsettings.PriceTable{
-		Currency: operatorsettings.PriceTableCurrencyUSD,
-		Models: []operatorsettings.PriceTableModel{{
-			Provider: "codex", Model: "known", InputPerMillionTokens: "1", OutputPerMillionTokens: "1",
-		}},
-	}}}
+	pricing := &priceReader{table: providers.PriceTable{
+		Currency: providers.PriceTableCurrencyUSD,
+		Models:   []providers.PriceTableModel{testPriceModel("known", "1", "1", nil, nil)},
+	}}
 	rows := []factoryvisualization.RuntimeMetricsUsageRow{
 		usageRow("session", "work-unknown-a", "dispatch-unknown-a", "worker-unknown-a", "codex", "missing", 10, 20, nil, nil),
 		usageRow("session", "work-unknown-b", "dispatch-unknown-b", "worker-unknown-b", "codex", "missing", 30, 40, nil, nil),
 	}
-	query, err := New(settings, metricsQueryStub(rows, nil), logging.NoopLogger{})
+	query, err := New(pricing, metricsQueryStub(rows, nil), logging.NoopLogger{})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}

--- a/pkg/services/costs/internal/service/valuation.go
+++ b/pkg/services/costs/internal/service/valuation.go
@@ -23,16 +23,26 @@ type normalizedPrice struct {
 type priceIndex map[string]normalizedPrice
 
 type summary struct {
-	amount   *big.Rat
-	coverage costs.Coverage
-	tokens   tokenAccumulator
-	pairs    map[string]*pairCoverage
+	amount                 *big.Rat
+	coverage               costs.Coverage
+	tokens                 tokenAccumulator
+	pairs                  map[string]*pairCoverage
+	unpricedDispatches     map[string]struct{}
+	unpricedDispatchesNoID int
+	unpricedPairs          map[string]*unpricedPairCoverage
 }
 
 type pairCoverage struct {
 	provider string
 	model    string
 	unpriced bool
+}
+
+type unpricedPairCoverage struct {
+	provider            *string
+	model               *string
+	dispatches          map[string]struct{}
+	dispatchesWithoutID int
 }
 
 type tokenAccumulator struct {
@@ -55,6 +65,7 @@ func calculateReport(
 	report := costs.Report{
 		Scope:           scope,
 		Currency:        table.Currency,
+		UnpricedPairs:   []costs.UnpricedPair{},
 		LineItems:       []costs.LineItem{},
 		WorkItems:       []costs.Rollup{},
 		WorkerSessions:  []costs.Rollup{},
@@ -101,19 +112,23 @@ func calculateReport(
 	if err != nil {
 		return costs.Report{}, err
 	}
-	report.WorkItems, err = rollups(work)
+	report.KnownCost = report.PricedSubtotal
+	report.TokenTotals = overall.tokens.totals()
+	report.UnpricedDispatchCount = overall.unpricedDispatchCount()
+	report.UnpricedPairs = overall.unpricedPairsValue()
+	report.WorkItems, err = rollups(work, table.Currency)
 	if err != nil {
 		return costs.Report{}, err
 	}
-	report.WorkerSessions, err = rollups(workerSessions)
+	report.WorkerSessions, err = rollups(workerSessions, table.Currency)
 	if err != nil {
 		return costs.Report{}, err
 	}
-	report.FactorySessions, err = rollups(factorySessions)
+	report.FactorySessions, err = rollups(factorySessions, table.Currency)
 	if err != nil {
 		return costs.Report{}, err
 	}
-	report.ProviderModels, err = providerRollups(providerModels)
+	report.ProviderModels, err = providerRollups(providerModels, table.Currency)
 	if err != nil {
 		return costs.Report{}, err
 	}
@@ -253,7 +268,11 @@ func exactAmountString(amount *big.Rat) (*string, error) {
 }
 
 func newSummary() *summary {
-	return &summary{pairs: make(map[string]*pairCoverage)}
+	return &summary{
+		pairs:              make(map[string]*pairCoverage),
+		unpricedDispatches: make(map[string]struct{}),
+		unpricedPairs:      make(map[string]*unpricedPairCoverage),
+	}
 }
 
 func (target *summary) add(line costs.LineItem, amount *big.Rat, priced bool) {
@@ -264,6 +283,14 @@ func (target *summary) add(line costs.LineItem, amount *big.Rat, priced bool) {
 		target.coverage.UnpricedRows++
 	}
 	target.tokens.add(line.TokenCounts)
+	if !priced {
+		if dispatchID := strings.TrimSpace(line.DispatchID); dispatchID == "" {
+			target.unpricedDispatchesNoID++
+		} else {
+			target.unpricedDispatches[dispatchID] = struct{}{}
+		}
+		target.addUnpricedPair(line)
+	}
 	provider, model := canonicalProvider(line.Provider), strings.TrimSpace(line.Model)
 	if provider == "" || model == "" {
 		return
@@ -287,6 +314,8 @@ func (target *summary) add(line costs.LineItem, amount *big.Rat, priced bool) {
 }
 
 func (target *summary) result() (costs.Status, *string, costs.Coverage, error) {
+	target.coverage.PricedProviderModels = 0
+	target.coverage.UnpricedProviderModels = 0
 	for _, pair := range target.pairs {
 		if !pair.unpriced {
 			target.coverage.PricedProviderModels++
@@ -314,17 +343,68 @@ func (target *summary) result() (costs.Status, *string, costs.Coverage, error) {
 	return status, amount, target.coverage, nil
 }
 
+func (target *summary) addUnpricedPair(line costs.LineItem) {
+	provider := canonicalProvider(line.Provider)
+	model := strings.TrimSpace(line.Model)
+	key := provider + "\x00" + model
+	pair := target.unpricedPairs[key]
+	if pair == nil {
+		pair = &unpricedPairCoverage{
+			provider:   optionalIdentity(provider),
+			model:      optionalIdentity(model),
+			dispatches: make(map[string]struct{}),
+		}
+		target.unpricedPairs[key] = pair
+	}
+	if dispatchID := strings.TrimSpace(line.DispatchID); dispatchID == "" {
+		pair.dispatchesWithoutID++
+	} else {
+		pair.dispatches[dispatchID] = struct{}{}
+	}
+}
+
+func (target *summary) unpricedDispatchCount() int {
+	return len(target.unpricedDispatches) + target.unpricedDispatchesNoID
+}
+
+func (target *summary) unpricedPairsValue() []costs.UnpricedPair {
+	keys := make([]string, 0, len(target.unpricedPairs))
+	for key := range target.unpricedPairs {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	result := make([]costs.UnpricedPair, 0, len(keys))
+	for _, key := range keys {
+		pair := target.unpricedPairs[key]
+		result = append(result, costs.UnpricedPair{
+			Provider:      cloneStringPointer(pair.provider),
+			Model:         cloneStringPointer(pair.model),
+			DispatchCount: len(pair.dispatches) + pair.dispatchesWithoutID,
+		})
+	}
+	return result
+}
+
 func (target *summary) rollup(key string) (costs.Rollup, error) {
+	return target.rollupWithCurrency(key, "")
+}
+
+func (target *summary) rollupWithCurrency(key, currency string) (costs.Rollup, error) {
 	status, amount, coverage, err := target.result()
 	if err != nil {
 		return costs.Rollup{}, err
 	}
 	return costs.Rollup{
-		Key:            key,
-		TokenCounts:    target.tokens.value(),
-		Status:         status,
-		PricedSubtotal: amount,
-		Coverage:       coverage,
+		Key:                   key,
+		TokenCounts:           target.tokens.value(),
+		Currency:              currency,
+		Status:                status,
+		KnownCost:             amount,
+		PricedSubtotal:        amount,
+		TokenTotals:           target.tokens.totals(),
+		UnpricedDispatchCount: target.unpricedDispatchCount(),
+		UnpricedPairs:         target.unpricedPairsValue(),
+		Coverage:              coverage,
 	}, nil
 }
 
@@ -341,7 +421,7 @@ func addDimension(groups map[string]*summary, key string, line costs.LineItem, a
 	target.add(line, amount, priced)
 }
 
-func rollups(groups map[string]*summary) ([]costs.Rollup, error) {
+func rollups(groups map[string]*summary, currency string) ([]costs.Rollup, error) {
 	keys := make([]string, 0, len(groups))
 	for key := range groups {
 		keys = append(keys, key)
@@ -349,7 +429,7 @@ func rollups(groups map[string]*summary) ([]costs.Rollup, error) {
 	sort.Strings(keys)
 	result := make([]costs.Rollup, 0, len(keys))
 	for _, key := range keys {
-		rollup, err := groups[key].rollup(key)
+		rollup, err := groups[key].rollupWithCurrency(key, currency)
 		if err != nil {
 			return nil, err
 		}
@@ -358,7 +438,7 @@ func rollups(groups map[string]*summary) ([]costs.Rollup, error) {
 	return result, nil
 }
 
-func providerRollups(groups map[string]*summary) ([]costs.ProviderModelRollup, error) {
+func providerRollups(groups map[string]*summary, currency string) ([]costs.ProviderModelRollup, error) {
 	keys := make([]string, 0, len(groups))
 	for key := range groups {
 		keys = append(keys, key)
@@ -368,7 +448,7 @@ func providerRollups(groups map[string]*summary) ([]costs.ProviderModelRollup, e
 	for _, key := range keys {
 		group := groups[key]
 		pair := group.pairs[key]
-		rollup, err := group.rollup(publicProviderModelKey(pair.provider, pair.model))
+		rollup, err := group.rollupWithCurrency(publicProviderModelKey(pair.provider, pair.model), currency)
 		if err != nil {
 			return nil, err
 		}
@@ -393,6 +473,23 @@ func (tokens tokenAccumulator) value() costs.TokenCounts {
 	}
 }
 
+func (tokens tokenAccumulator) totals() costs.TokenTotals {
+	input := cloneInt64(tokens.input)
+	output := cloneInt64(tokens.output)
+	var total *int64
+	if input != nil && output != nil {
+		value := *input + *output
+		total = &value
+	}
+	return costs.TokenTotals{
+		TotalTokens:           total,
+		InputTokens:           input,
+		OutputTokens:          output,
+		CachedInputTokens:     cloneInt64(tokens.cached),
+		ReasoningOutputTokens: cloneInt64(tokens.reasoning),
+	}
+}
+
 func addToken(current, value *int64) *int64 {
 	if value == nil {
 		return current
@@ -406,6 +503,22 @@ func addToken(current, value *int64) *int64 {
 }
 
 func cloneInt64(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func optionalIdentity(value string) *string {
+	if value == "" {
+		return nil
+	}
+	cloned := value
+	return &cloned
+}
+
+func cloneStringPointer(value *string) *string {
 	if value == nil {
 		return nil
 	}

--- a/pkg/services/costs/internal/service/valuation.go
+++ b/pkg/services/costs/internal/service/valuation.go
@@ -10,7 +10,7 @@ import (
 	costs "github.com/portpowered/infinite-you/pkg/services/costs"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
-	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
 type normalizedPrice struct {
@@ -54,7 +54,7 @@ type tokenAccumulator struct {
 
 func calculateReport(
 	ctx context.Context,
-	table operatorsettings.PriceTable,
+	table providers.PriceTable,
 	rows []factoryvisualization.RuntimeMetricsUsageRow,
 	scope costs.Scope,
 ) (costs.Report, error) {
@@ -135,7 +135,7 @@ func calculateReport(
 	return report, nil
 }
 
-func buildPriceIndex(table operatorsettings.PriceTable) (priceIndex, error) {
+func buildPriceIndex(table providers.PriceTable) (priceIndex, error) {
 	index := make(priceIndex, len(table.Models))
 	for _, model := range table.Models {
 		input, err := parseDecimal(model.InputPerMillionTokens)
@@ -159,7 +159,7 @@ func buildPriceIndex(table operatorsettings.PriceTable) (priceIndex, error) {
 				return nil, fmt.Errorf("parse reasoning-output rate for %q/%q: %w", model.Provider, model.Model, err)
 			}
 		}
-		index[providerModelKey(model.Provider, model.Model)] = price
+		index[providerModelKey(model.Provider.String(), model.Model)] = price
 	}
 	return index, nil
 }

--- a/pkg/services/costs/transports/cli/costs_test.go
+++ b/pkg/services/costs/transports/cli/costs_test.go
@@ -104,21 +104,41 @@ func assertJSONCostsReport(t *testing.T, output string) {
 	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
 		t.Fatalf("decode API-shaped JSON: %v\n%s", err, output)
 	}
+	assertJSONCostAmounts(t, decoded)
+	assertJSONUnpricedFacts(t, decoded)
+	assertJSONReportDimensions(t, decoded)
+	assertNoLegacyJSONEnvelope(t, output)
+}
+
+func assertJSONCostAmounts(t *testing.T, decoded generatedclient.CostsReport) {
+	t.Helper()
 	if decoded.PricedSubtotal == nil || *decoded.PricedSubtotal != "12.345678" {
 		t.Fatalf("decoded subtotal = %#v, want exact amount", decoded.PricedSubtotal)
 	}
 	if decoded.KnownCost == nil || *decoded.KnownCost != "12.345678" || decoded.TokenTotals.TotalTokens == nil || *decoded.TokenTotals.TotalTokens != 10 {
 		t.Fatalf("decoded partial facts = %#v, want known cost and total tokens", decoded)
 	}
+}
+
+func assertJSONUnpricedFacts(t *testing.T, decoded generatedclient.CostsReport) {
+	t.Helper()
 	if decoded.UnpricedDispatchCount != 1 || len(decoded.UnpricedPairs) != 1 || decoded.UnpricedPairs[0].DispatchCount != 1 {
 		t.Fatalf("decoded unpriced facts = %#v, want one unpriced dispatch/pair", decoded)
 	}
+}
+
+func assertJSONReportDimensions(t *testing.T, decoded generatedclient.CostsReport) {
+	t.Helper()
 	if decoded.Coverage.PricedRows != 1 || len(decoded.LineItems) != 2 || len(decoded.WorkItems) != 1 || len(decoded.WorkerSessions) != 1 {
 		t.Fatalf("decoded report dimensions = %#v, want complete API report", decoded)
 	}
 	if len(decoded.ProviderModels) != 1 || decoded.ProviderModels[0].Key != "openai/mystery" || len(decoded.FactorySessions) != 1 {
 		t.Fatalf("decoded provider/session rollups = %#v, want complete API report", decoded)
 	}
+}
+
+func assertNoLegacyJSONEnvelope(t *testing.T, output string) {
+	t.Helper()
 	if strings.Contains(output, "group_by") || strings.Contains(output, "\"totals\"") || strings.Contains(output, "\\u0000") {
 		t.Fatalf("JSON output used the legacy metrics envelope:\n%s", output)
 	}

--- a/pkg/services/costs/transports/cli/costs_test.go
+++ b/pkg/services/costs/transports/cli/costs_test.go
@@ -107,13 +107,19 @@ func assertJSONCostsReport(t *testing.T, output string) {
 	if decoded.PricedSubtotal == nil || *decoded.PricedSubtotal != "12.345678" {
 		t.Fatalf("decoded subtotal = %#v, want exact amount", decoded.PricedSubtotal)
 	}
+	if decoded.KnownCost == nil || *decoded.KnownCost != "12.345678" || decoded.TokenTotals.TotalTokens == nil || *decoded.TokenTotals.TotalTokens != 10 {
+		t.Fatalf("decoded partial facts = %#v, want known cost and total tokens", decoded)
+	}
+	if decoded.UnpricedDispatchCount != 1 || len(decoded.UnpricedPairs) != 1 || decoded.UnpricedPairs[0].DispatchCount != 1 {
+		t.Fatalf("decoded unpriced facts = %#v, want one unpriced dispatch/pair", decoded)
+	}
 	if decoded.Coverage.PricedRows != 1 || len(decoded.LineItems) != 2 || len(decoded.WorkItems) != 1 || len(decoded.WorkerSessions) != 1 {
 		t.Fatalf("decoded report dimensions = %#v, want complete API report", decoded)
 	}
 	if len(decoded.ProviderModels) != 1 || decoded.ProviderModels[0].Key != "openai/mystery" || len(decoded.FactorySessions) != 1 {
 		t.Fatalf("decoded provider/session rollups = %#v, want complete API report", decoded)
 	}
-	if strings.Contains(output, "group_by") || strings.Contains(output, "totals") || strings.Contains(output, "\\u0000") {
+	if strings.Contains(output, "group_by") || strings.Contains(output, "\"totals\"") || strings.Contains(output, "\\u0000") {
 		t.Fatalf("JSON output used the legacy metrics envelope:\n%s", output)
 	}
 }
@@ -168,9 +174,16 @@ func costsReportForCLI() generatedclient.CostsReport {
 		EncounteredRows: 2, PricedRows: 1, UnpricedRows: 1,
 		EncounteredProviderModels: 2, PricedProviderModels: 1, UnpricedProviderModels: 1,
 	}
+	total := int64(10)
+	tokenTotals := generatedclient.CostsTokenTotals{
+		TotalTokens: &total, InputTokens: &input, OutputTokens: &output,
+		CachedInputTokens: &cached, ReasoningOutputTokens: &reasoning,
+	}
+	unpricedPair := generatedclient.CostsUnpricedPair{Provider: &provider, Model: &model, DispatchCount: 1}
 	rollup := generatedclient.CostsRollup{
-		Key: "work-a", Status: generatedclient.CostsRollupStatus("PRICED"),
-		PricedSubtotal: &amount, Coverage: coverage,
+		Key: "work-a", Currency: generatedclient.CostsRollupCurrency("USD"), Status: generatedclient.CostsRollupStatus("PRICED"),
+		KnownCost: &amount, PricedSubtotal: &amount, TokenTotals: tokenTotals,
+		UnpricedDispatchCount: 1, UnpricedPairs: []generatedclient.CostsUnpricedPair{unpricedPair}, Coverage: coverage,
 		InputTokens: &input, CachedInputTokens: &cached,
 		OutputTokens: &output, ReasoningOutputTokens: &reasoning,
 	}
@@ -178,18 +191,19 @@ func costsReportForCLI() generatedclient.CostsReport {
 		Scope: generatedclient.CostsScope{
 			Kind: generatedclient.CostsScopeKind("FACTORY_SESSION"), FactorySessionId: &session,
 		},
-		Currency:       generatedclient.CostsReportCurrency("USD"),
-		Status:         generatedclient.CostsReportStatus("PARTIAL"),
-		PricedSubtotal: &amount,
-		Coverage:       coverage,
+		Currency:  generatedclient.CostsReportCurrency("USD"),
+		Status:    generatedclient.CostsReportStatus("PARTIAL"),
+		KnownCost: &amount, PricedSubtotal: &amount, TokenTotals: tokenTotals,
+		UnpricedDispatchCount: 1, UnpricedPairs: []generatedclient.CostsUnpricedPair{unpricedPair},
+		Coverage: coverage,
 		LineItems: []generatedclient.CostsLineItem{
 			{Provider: &provider, Model: &model, Status: generatedclient.CostsLineItemStatus("UNPRICED"), Reason: &reason,
 				InputTokens: &input, CachedInputTokens: &cached, OutputTokens: &output, ReasoningOutputTokens: &reasoning},
 			{Status: generatedclient.CostsLineItemStatus("PRICED"), PricedAmount: &amount},
 		},
 		WorkItems:       []generatedclient.CostsRollup{rollup},
-		WorkerSessions:  []generatedclient.CostsRollup{{Key: "worker-a", Status: generatedclient.CostsRollupStatus("PRICED"), Coverage: coverage}},
-		ProviderModels:  []generatedclient.CostsProviderModelRollup{{Provider: "openai", Model: "mystery", Key: "openai/mystery", Status: generatedclient.CostsProviderModelRollupStatus("UNPRICED"), Coverage: coverage}},
-		FactorySessions: []generatedclient.CostsRollup{{Key: "session-a", Status: generatedclient.CostsRollupStatus("PARTIAL"), Coverage: coverage}},
+		WorkerSessions:  []generatedclient.CostsRollup{{Key: "worker-a", Currency: generatedclient.CostsRollupCurrency("USD"), Status: generatedclient.CostsRollupStatus("PRICED"), TokenTotals: tokenTotals, UnpricedPairs: []generatedclient.CostsUnpricedPair{}, Coverage: coverage}},
+		ProviderModels:  []generatedclient.CostsProviderModelRollup{{Provider: "openai", Model: "mystery", Key: "openai/mystery", Currency: generatedclient.CostsProviderModelRollupCurrency("USD"), Status: generatedclient.CostsProviderModelRollupStatus("UNPRICED"), TokenTotals: tokenTotals, UnpricedDispatchCount: 1, UnpricedPairs: []generatedclient.CostsUnpricedPair{unpricedPair}, Coverage: coverage}},
+		FactorySessions: []generatedclient.CostsRollup{{Key: "session-a", Currency: generatedclient.CostsRollupCurrency("USD"), Status: generatedclient.CostsRollupStatus("PARTIAL"), TokenTotals: tokenTotals, UnpricedDispatchCount: 1, UnpricedPairs: []generatedclient.CostsUnpricedPair{unpricedPair}, Coverage: coverage}},
 	}
 }

--- a/pkg/services/costs/transports/cli/output.go
+++ b/pkg/services/costs/transports/cli/output.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
+	"sort"
 	"strings"
 
 	generatedclient "github.com/portpowered/infinite-you/pkg/transports/http/client"
@@ -24,8 +26,11 @@ func renderHumanCosts(report generatedclient.CostsReport) string {
 	renderCostsScope(&output, report.Scope)
 	fmt.Fprintf(&output, "Currency: %s\n", report.Currency)
 	fmt.Fprintf(&output, "Status: %s\n", report.Status)
+	renderCostSummary(&output, "", string(report.Status), report.KnownCost)
 	renderPricedAmount(&output, "Priced subtotal", report.PricedSubtotal)
+	renderTokenCounts(&output, "", report.TokenTotals)
 	renderCoverage(&output, report.Coverage)
+	renderUnpricedCoverage(&output, report.UnpricedDispatchCount, report.UnpricedPairs)
 	fmt.Fprintln(&output)
 
 	renderRollupDimension(&output, "Work items", rollupViews(report.WorkItems))
@@ -52,6 +57,34 @@ func renderPricedAmount(output *strings.Builder, label string, amount *string) {
 	fmt.Fprintf(output, "%s (USD): %s\n", label, *amount)
 }
 
+func renderCostSummary(output *strings.Builder, indent, status string, knownCost *string) {
+	switch status {
+	case "PARTIAL":
+		fmt.Fprintf(output, "%sCost (USD): %s + ?? unknown\n", indent, formatHumanUSD(knownCost))
+	case "UNPRICED":
+		fmt.Fprintf(output, "%sCost (USD): ?? unknown\n", indent)
+	case "NO_USAGE":
+		fmt.Fprintf(output, "%sCost (USD): no usage\n", indent)
+	default:
+		fmt.Fprintf(output, "%sCost (USD): %s\n", indent, formatHumanUSD(knownCost))
+	}
+}
+
+// formatHumanUSD rounds an exact API decimal to cents with math/big's
+// deterministic half-away-from-zero rule. The API retains the unrounded
+// decimal; this conversion is only for human-readable USD output.
+func formatHumanUSD(amount *string) string {
+	if amount == nil {
+		return "?? unknown"
+	}
+	raw := strings.TrimSpace(*amount)
+	value, ok := new(big.Rat).SetString(raw)
+	if !ok || value.Sign() < 0 {
+		return "?? unknown"
+	}
+	return "$" + value.FloatString(2)
+}
+
 func renderCoverage(output *strings.Builder, coverage generatedclient.CostsCoverage) {
 	fmt.Fprintf(output, "Coverage: rows priced %d/%d; provider/models priced %d/%d\n",
 		coverage.PricedRows, coverage.EncounteredRows,
@@ -59,24 +92,21 @@ func renderCoverage(output *strings.Builder, coverage generatedclient.CostsCover
 }
 
 type humanRollup struct {
-	Key                   string
-	Status                string
-	PricedSubtotal        *string
-	Coverage              generatedclient.CostsCoverage
-	InputTokens           *int64
-	CachedInputTokens     *int64
-	OutputTokens          *int64
-	ReasoningOutputTokens *int64
+	Key            string
+	Status         string
+	KnownCost      *string
+	PricedSubtotal *string
+	Coverage       generatedclient.CostsCoverage
+	TokenTotals    generatedclient.CostsTokenTotals
 }
 
 func rollupViews(rollups []generatedclient.CostsRollup) []humanRollup {
 	views := make([]humanRollup, 0, len(rollups))
 	for _, rollup := range rollups {
 		views = append(views, humanRollup{
-			Key: rollup.Key, Status: string(rollup.Status), PricedSubtotal: rollup.PricedSubtotal,
-			Coverage: rollup.Coverage, InputTokens: rollup.InputTokens,
-			CachedInputTokens: rollup.CachedInputTokens, OutputTokens: rollup.OutputTokens,
-			ReasoningOutputTokens: rollup.ReasoningOutputTokens,
+			Key: rollup.Key, Status: string(rollup.Status), KnownCost: rollup.KnownCost,
+			PricedSubtotal: rollup.PricedSubtotal, Coverage: rollup.Coverage,
+			TokenTotals: rollup.TokenTotals,
 		})
 	}
 	return views
@@ -87,9 +117,8 @@ func providerModelViews(rollups []generatedclient.CostsProviderModelRollup) []hu
 	for _, rollup := range rollups {
 		views = append(views, humanRollup{
 			Key: rollup.Provider + "/" + rollup.Model, Status: string(rollup.Status),
-			PricedSubtotal: rollup.PricedSubtotal, Coverage: rollup.Coverage,
-			InputTokens: rollup.InputTokens, CachedInputTokens: rollup.CachedInputTokens,
-			OutputTokens: rollup.OutputTokens, ReasoningOutputTokens: rollup.ReasoningOutputTokens,
+			KnownCost: rollup.KnownCost, PricedSubtotal: rollup.PricedSubtotal,
+			Coverage: rollup.Coverage, TokenTotals: rollup.TokenTotals,
 		})
 	}
 	return views
@@ -100,11 +129,12 @@ func renderRollupDimension(output *strings.Builder, name string, rollups []human
 	for _, rollup := range rollups {
 		fmt.Fprintf(output, "  %s:\n", displayValue(rollup.Key))
 		fmt.Fprintf(output, "    Status: %s\n", rollup.Status)
+		renderCostSummary(output, "    ", rollup.Status, rollup.KnownCost)
 		renderPricedAmount(output, "    Priced subtotal", rollup.PricedSubtotal)
 		fmt.Fprintf(output, "    Coverage: rows priced %d/%d; provider/models priced %d/%d\n",
 			rollup.Coverage.PricedRows, rollup.Coverage.EncounteredRows,
 			rollup.Coverage.PricedProviderModels, rollup.Coverage.EncounteredProviderModels)
-		renderTokenCounts(output, "    ", rollup.InputTokens, rollup.CachedInputTokens, rollup.OutputTokens, rollup.ReasoningOutputTokens)
+		renderTokenCounts(output, "    ", rollup.TokenTotals)
 	}
 }
 
@@ -125,15 +155,51 @@ func renderUnpricedItems(output *strings.Builder, items []generatedclient.CostsL
 		if item.Reason != nil && strings.TrimSpace(*item.Reason) != "" {
 			fmt.Fprintf(output, "    Reason: %s\n", *item.Reason)
 		}
-		renderTokenCounts(output, "    ", item.InputTokens, item.CachedInputTokens, item.OutputTokens, item.ReasoningOutputTokens)
+		renderTokenCounts(output, "    ", generatedclient.CostsTokenTotals{
+			TotalTokens:           sumTokenClasses(item.InputTokens, item.OutputTokens),
+			InputTokens:           item.InputTokens,
+			CachedInputTokens:     item.CachedInputTokens,
+			OutputTokens:          item.OutputTokens,
+			ReasoningOutputTokens: item.ReasoningOutputTokens,
+		})
 	}
 }
 
-func renderTokenCounts(output *strings.Builder, indent string, input, cached, outputTokens, reasoning *int64) {
-	fmt.Fprintf(output, "%sInput tokens: %s\n", indent, displayInt64(input))
-	fmt.Fprintf(output, "%sCached-input tokens: %s\n", indent, displayInt64(cached))
-	fmt.Fprintf(output, "%sOutput tokens: %s\n", indent, displayInt64(outputTokens))
-	fmt.Fprintf(output, "%sReasoning-output tokens: %s\n", indent, displayInt64(reasoning))
+func renderUnpricedCoverage(output *strings.Builder, dispatchCount int, pairs []generatedclient.CostsUnpricedPair) {
+	fmt.Fprintf(output, "Unpriced dispatches: %d\n", dispatchCount)
+	fmt.Fprintf(output, "Unpriced provider/models: %d\n", len(pairs))
+	for _, pair := range orderedUnpricedPairs(pairs) {
+		fmt.Fprintf(output, "  %s/%s: %d dispatches\n",
+			displayPointer(pair.Provider), displayPointer(pair.Model), pair.DispatchCount)
+	}
+}
+
+func orderedUnpricedPairs(pairs []generatedclient.CostsUnpricedPair) []generatedclient.CostsUnpricedPair {
+	ordered := append([]generatedclient.CostsUnpricedPair(nil), pairs...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return unpricedPairKey(ordered[i]) < unpricedPairKey(ordered[j])
+	})
+	return ordered
+}
+
+func unpricedPairKey(pair generatedclient.CostsUnpricedPair) string {
+	return displayPointer(pair.Provider) + "/" + displayPointer(pair.Model)
+}
+
+func renderTokenCounts(output *strings.Builder, indent string, totals generatedclient.CostsTokenTotals) {
+	fmt.Fprintf(output, "%sTotal tokens: %s\n", indent, displayInt64(totals.TotalTokens))
+	fmt.Fprintf(output, "%sInput tokens: %s\n", indent, displayInt64(totals.InputTokens))
+	fmt.Fprintf(output, "%sCached-input tokens: %s\n", indent, displayInt64(totals.CachedInputTokens))
+	fmt.Fprintf(output, "%sOutput tokens: %s\n", indent, displayInt64(totals.OutputTokens))
+	fmt.Fprintf(output, "%sReasoning-output tokens: %s\n", indent, displayInt64(totals.ReasoningOutputTokens))
+}
+
+func sumTokenClasses(input, output *int64) *int64 {
+	if input == nil || output == nil {
+		return nil
+	}
+	total := *input + *output
+	return &total
 }
 
 func displayInt64(value *int64) string {

--- a/pkg/services/costs/transports/cli/output_test.go
+++ b/pkg/services/costs/transports/cli/output_test.go
@@ -10,23 +10,9 @@ import (
 	generatedclient "github.com/portpowered/infinite-you/pkg/transports/http/client"
 )
 
-func TestCostsHumanOutputExactGoldens(t *testing.T) {
-	t.Parallel()
-
+func TestCostsHumanOutputAllPricedGolden(t *testing.T) {
 	amount := "1.235"
-	mixedAmount := "12.345678"
-	openAIProvider, mysteryModel := "openai", "mystery"
-	codexProvider, alphaModel := "codex", "alpha"
-	unknownProvider, unknownModel := "codex", "unknown-model"
-	cases := []struct {
-		name   string
-		report generatedclient.CostsReport
-		want   string
-	}{
-		{
-			name:   "all-priced",
-			report: humanReport("PRICED", &amount, 0, nil),
-			want: `Scope: all Factory Sessions
+	assertHumanOutputGolden(t, "all-priced", humanReport("PRICED", &amount, 0, nil), `Scope: all Factory Sessions
 Currency: USD
 Status: PRICED
 Cost (USD): $1.24
@@ -46,13 +32,14 @@ Provider/models: 0
 Factory Sessions: 0
 Unpriced usage: 0 rows
 `,
-		},
-		{
-			name: "none-priced",
-			report: humanReport("UNPRICED", nil, 2, []generatedclient.CostsUnpricedPair{
-				{Provider: &codexProvider, Model: &mysteryModel, DispatchCount: 2},
-			}),
-			want: `Scope: all Factory Sessions
+	)
+}
+
+func TestCostsHumanOutputNonePricedGolden(t *testing.T) {
+	codexProvider, mysteryModel := "codex", "mystery"
+	assertHumanOutputGolden(t, "none-priced", humanReport("UNPRICED", nil, 2, []generatedclient.CostsUnpricedPair{
+		{Provider: &codexProvider, Model: &mysteryModel, DispatchCount: 2},
+	}), `Scope: all Factory Sessions
 Currency: USD
 Status: UNPRICED
 Cost (USD): ?? unknown
@@ -73,14 +60,17 @@ Provider/models: 0
 Factory Sessions: 0
 Unpriced usage: 0 rows
 `,
-		},
-		{
-			name: "mixed",
-			report: humanReport("PARTIAL", &mixedAmount, 2, []generatedclient.CostsUnpricedPair{
-				{Provider: &openAIProvider, Model: &mysteryModel, DispatchCount: 1},
-				{Provider: &codexProvider, Model: &alphaModel, DispatchCount: 1},
-			}),
-			want: `Scope: all Factory Sessions
+	)
+}
+
+func TestCostsHumanOutputMixedGolden(t *testing.T) {
+	mixedAmount := "12.345678"
+	openAIProvider, mysteryModel := "openai", "mystery"
+	codexProvider, alphaModel := "codex", "alpha"
+	assertHumanOutputGolden(t, "mixed", humanReport("PARTIAL", &mixedAmount, 2, []generatedclient.CostsUnpricedPair{
+		{Provider: &openAIProvider, Model: &mysteryModel, DispatchCount: 1},
+		{Provider: &codexProvider, Model: &alphaModel, DispatchCount: 1},
+	}), `Scope: all Factory Sessions
 Currency: USD
 Status: PARTIAL
 Cost (USD): $12.35 + ?? unknown
@@ -102,13 +92,14 @@ Provider/models: 0
 Factory Sessions: 0
 Unpriced usage: 0 rows
 `,
-		},
-		{
-			name: "unknown-model",
-			report: humanReport("UNPRICED", nil, 1, []generatedclient.CostsUnpricedPair{
-				{Provider: &unknownProvider, Model: &unknownModel, DispatchCount: 1},
-			}),
-			want: `Scope: all Factory Sessions
+	)
+}
+
+func TestCostsHumanOutputUnknownModelGolden(t *testing.T) {
+	unknownProvider, unknownModel := "codex", "unknown-model"
+	assertHumanOutputGolden(t, "unknown-model", humanReport("UNPRICED", nil, 1, []generatedclient.CostsUnpricedPair{
+		{Provider: &unknownProvider, Model: &unknownModel, DispatchCount: 1},
+	}), `Scope: all Factory Sessions
 Currency: USD
 Status: UNPRICED
 Cost (USD): ?? unknown
@@ -129,18 +120,17 @@ Provider/models: 0
 Factory Sessions: 0
 Unpriced usage: 0 rows
 `,
-		},
+	)
+}
+
+func assertHumanOutputGolden(t *testing.T, name string, report generatedclient.CostsReport, want string) {
+	t.Helper()
+	output, err := runHumanCostsOutput(t, report)
+	if err != nil {
+		t.Fatalf("execute %s costs command: %v", name, err)
 	}
-	for _, testCase := range cases {
-		t.Run(testCase.name, func(t *testing.T) {
-			output, err := runHumanCostsOutput(t, testCase.report)
-			if err != nil {
-				t.Fatalf("execute %s costs command: %v", testCase.name, err)
-			}
-			if output != testCase.want {
-				t.Errorf("%s output mismatch:\n--- want ---\n%s--- got ---\n%s", testCase.name, testCase.want, output)
-			}
-		})
+	if output != want {
+		t.Errorf("%s output mismatch:\n--- want ---\n%s--- got ---\n%s", name, want, output)
 	}
 }
 

--- a/pkg/services/costs/transports/cli/output_test.go
+++ b/pkg/services/costs/transports/cli/output_test.go
@@ -4,112 +4,143 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"strings"
 	"testing"
 
 	costscli "github.com/portpowered/infinite-you/pkg/services/costs/transports/cli"
 	generatedclient "github.com/portpowered/infinite-you/pkg/transports/http/client"
 )
 
-func TestCostsHumanOutputAllPricedShowsRoundedCostAndAllTokenClasses(t *testing.T) {
+func TestCostsHumanOutputExactGoldens(t *testing.T) {
 	t.Parallel()
 
 	amount := "1.235"
-	report := humanReport("PRICED", &amount, 0, nil)
-	output, err := runHumanCostsOutput(t, report)
-	if err != nil {
-		t.Fatalf("execute all-priced costs command: %v", err)
-	}
-	for _, want := range []string{
-		"Cost (USD): $1.24",
-		"Total tokens: 10",
-		"Input tokens: 7",
-		"Cached-input tokens: 2",
-		"Output tokens: 3",
-		"Reasoning-output tokens: 4",
-	} {
-		if !strings.Contains(output, want) {
-			t.Fatalf("all-priced output missing %q:\n%s", want, output)
-		}
-	}
-	if strings.Contains(output, "?? unknown") {
-		t.Fatalf("all-priced output contains an unknown marker:\n%s", output)
-	}
-}
-
-func TestCostsHumanOutputNonePricedShowsUnknownCoverage(t *testing.T) {
-	t.Parallel()
-
-	provider, model := "codex", "mystery"
-	report := humanReport("UNPRICED", nil, 2, []generatedclient.CostsUnpricedPair{
-		{Provider: &provider, Model: &model, DispatchCount: 2},
-	})
-	output, err := runHumanCostsOutput(t, report)
-	if err != nil {
-		t.Fatalf("execute none-priced costs command: %v", err)
-	}
-	for _, want := range []string{
-		"Cost (USD): ?? unknown",
-		"Unpriced dispatches: 2",
-		"Unpriced provider/models: 1",
-		"codex/mystery: 2 dispatches",
-		"Total tokens: 10",
-	} {
-		if !strings.Contains(output, want) {
-			t.Fatalf("none-priced output missing %q:\n%s", want, output)
-		}
-	}
-	if strings.Contains(output, "$0.00") {
-		t.Fatalf("none-priced output presents unknown usage as zero:\n%s", output)
-	}
-}
-
-func TestCostsHumanOutputMixedShowsKnownCostAndUnknownRemainder(t *testing.T) {
-	t.Parallel()
-
-	amount := "12.345678"
+	mixedAmount := "12.345678"
 	openAIProvider, mysteryModel := "openai", "mystery"
 	codexProvider, alphaModel := "codex", "alpha"
-	report := humanReport("PARTIAL", &amount, 2, []generatedclient.CostsUnpricedPair{
-		{Provider: &openAIProvider, Model: &mysteryModel, DispatchCount: 1},
-		{Provider: &codexProvider, Model: &alphaModel, DispatchCount: 1},
-	})
-	output, err := runHumanCostsOutput(t, report)
-	if err != nil {
-		t.Fatalf("execute mixed costs command: %v", err)
-	}
-	for _, want := range []string{
-		"Cost (USD): $12.35 + ?? unknown",
-		"Unpriced dispatches: 2",
-		"openai/mystery: 1 dispatches",
-		"codex/alpha: 1 dispatches",
-		"Total tokens: 10",
-	} {
-		if !strings.Contains(output, want) {
-			t.Fatalf("mixed output missing %q:\n%s", want, output)
-		}
-	}
-	if strings.Index(output, "codex/alpha: 1 dispatches") > strings.Index(output, "openai/mystery: 1 dispatches") {
-		t.Fatalf("mixed unpriced pairs are not deterministically ordered:\n%s", output)
-	}
-}
+	unknownProvider, unknownModel := "codex", "unknown-model"
+	cases := []struct {
+		name   string
+		report generatedclient.CostsReport
+		want   string
+	}{
+		{
+			name:   "all-priced",
+			report: humanReport("PRICED", &amount, 0, nil),
+			want: `Scope: all Factory Sessions
+Currency: USD
+Status: PRICED
+Cost (USD): $1.24
+Priced subtotal (USD): 1.235
+Total tokens: 10
+Input tokens: 7
+Cached-input tokens: 2
+Output tokens: 3
+Reasoning-output tokens: 4
+Coverage: rows priced 0/0; provider/models priced 0/0
+Unpriced dispatches: 0
+Unpriced provider/models: 0
 
-func TestCostsHumanOutputUnknownModelRemainsUnpriced(t *testing.T) {
-	t.Parallel()
+Work items: 0
+Worker Sessions: 0
+Provider/models: 0
+Factory Sessions: 0
+Unpriced usage: 0 rows
+`,
+		},
+		{
+			name: "none-priced",
+			report: humanReport("UNPRICED", nil, 2, []generatedclient.CostsUnpricedPair{
+				{Provider: &codexProvider, Model: &mysteryModel, DispatchCount: 2},
+			}),
+			want: `Scope: all Factory Sessions
+Currency: USD
+Status: UNPRICED
+Cost (USD): ?? unknown
+Priced subtotal (USD): unavailable
+Total tokens: 10
+Input tokens: 7
+Cached-input tokens: 2
+Output tokens: 3
+Reasoning-output tokens: 4
+Coverage: rows priced 0/0; provider/models priced 0/0
+Unpriced dispatches: 2
+Unpriced provider/models: 1
+  codex/mystery: 2 dispatches
 
-	provider, model := "codex", "unknown-model"
-	report := humanReport("UNPRICED", nil, 1, []generatedclient.CostsUnpricedPair{
-		{Provider: &provider, Model: &model, DispatchCount: 1},
-	})
-	output, err := runHumanCostsOutput(t, report)
-	if err != nil {
-		t.Fatalf("execute unknown-model costs command: %v", err)
+Work items: 0
+Worker Sessions: 0
+Provider/models: 0
+Factory Sessions: 0
+Unpriced usage: 0 rows
+`,
+		},
+		{
+			name: "mixed",
+			report: humanReport("PARTIAL", &mixedAmount, 2, []generatedclient.CostsUnpricedPair{
+				{Provider: &openAIProvider, Model: &mysteryModel, DispatchCount: 1},
+				{Provider: &codexProvider, Model: &alphaModel, DispatchCount: 1},
+			}),
+			want: `Scope: all Factory Sessions
+Currency: USD
+Status: PARTIAL
+Cost (USD): $12.35 + ?? unknown
+Priced subtotal (USD): 12.345678
+Total tokens: 10
+Input tokens: 7
+Cached-input tokens: 2
+Output tokens: 3
+Reasoning-output tokens: 4
+Coverage: rows priced 0/0; provider/models priced 0/0
+Unpriced dispatches: 2
+Unpriced provider/models: 2
+  codex/alpha: 1 dispatches
+  openai/mystery: 1 dispatches
+
+Work items: 0
+Worker Sessions: 0
+Provider/models: 0
+Factory Sessions: 0
+Unpriced usage: 0 rows
+`,
+		},
+		{
+			name: "unknown-model",
+			report: humanReport("UNPRICED", nil, 1, []generatedclient.CostsUnpricedPair{
+				{Provider: &unknownProvider, Model: &unknownModel, DispatchCount: 1},
+			}),
+			want: `Scope: all Factory Sessions
+Currency: USD
+Status: UNPRICED
+Cost (USD): ?? unknown
+Priced subtotal (USD): unavailable
+Total tokens: 10
+Input tokens: 7
+Cached-input tokens: 2
+Output tokens: 3
+Reasoning-output tokens: 4
+Coverage: rows priced 0/0; provider/models priced 0/0
+Unpriced dispatches: 1
+Unpriced provider/models: 1
+  codex/unknown-model: 1 dispatches
+
+Work items: 0
+Worker Sessions: 0
+Provider/models: 0
+Factory Sessions: 0
+Unpriced usage: 0 rows
+`,
+		},
 	}
-	if !strings.Contains(output, "codex/unknown-model: 1 dispatches") {
-		t.Fatalf("unknown model was not shown as an unpriced pair:\n%s", output)
-	}
-	if strings.Contains(output, "$0.00") {
-		t.Fatalf("unknown model was silently valued at zero:\n%s", output)
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			output, err := runHumanCostsOutput(t, testCase.report)
+			if err != nil {
+				t.Fatalf("execute %s costs command: %v", testCase.name, err)
+			}
+			if output != testCase.want {
+				t.Errorf("%s output mismatch:\n--- want ---\n%s--- got ---\n%s", testCase.name, testCase.want, output)
+			}
+		})
 	}
 }
 

--- a/pkg/services/costs/transports/cli/output_test.go
+++ b/pkg/services/costs/transports/cli/output_test.go
@@ -1,0 +1,159 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	costscli "github.com/portpowered/infinite-you/pkg/services/costs/transports/cli"
+	generatedclient "github.com/portpowered/infinite-you/pkg/transports/http/client"
+)
+
+func TestCostsHumanOutputAllPricedShowsRoundedCostAndAllTokenClasses(t *testing.T) {
+	t.Parallel()
+
+	amount := "1.235"
+	report := humanReport("PRICED", &amount, 0, nil)
+	output, err := runHumanCostsOutput(t, report)
+	if err != nil {
+		t.Fatalf("execute all-priced costs command: %v", err)
+	}
+	for _, want := range []string{
+		"Cost (USD): $1.24",
+		"Total tokens: 10",
+		"Input tokens: 7",
+		"Cached-input tokens: 2",
+		"Output tokens: 3",
+		"Reasoning-output tokens: 4",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("all-priced output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "?? unknown") {
+		t.Fatalf("all-priced output contains an unknown marker:\n%s", output)
+	}
+}
+
+func TestCostsHumanOutputNonePricedShowsUnknownCoverage(t *testing.T) {
+	t.Parallel()
+
+	provider, model := "codex", "mystery"
+	report := humanReport("UNPRICED", nil, 2, []generatedclient.CostsUnpricedPair{
+		{Provider: &provider, Model: &model, DispatchCount: 2},
+	})
+	output, err := runHumanCostsOutput(t, report)
+	if err != nil {
+		t.Fatalf("execute none-priced costs command: %v", err)
+	}
+	for _, want := range []string{
+		"Cost (USD): ?? unknown",
+		"Unpriced dispatches: 2",
+		"Unpriced provider/models: 1",
+		"codex/mystery: 2 dispatches",
+		"Total tokens: 10",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("none-priced output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "$0.00") {
+		t.Fatalf("none-priced output presents unknown usage as zero:\n%s", output)
+	}
+}
+
+func TestCostsHumanOutputMixedShowsKnownCostAndUnknownRemainder(t *testing.T) {
+	t.Parallel()
+
+	amount := "12.345678"
+	openAIProvider, mysteryModel := "openai", "mystery"
+	codexProvider, alphaModel := "codex", "alpha"
+	report := humanReport("PARTIAL", &amount, 2, []generatedclient.CostsUnpricedPair{
+		{Provider: &openAIProvider, Model: &mysteryModel, DispatchCount: 1},
+		{Provider: &codexProvider, Model: &alphaModel, DispatchCount: 1},
+	})
+	output, err := runHumanCostsOutput(t, report)
+	if err != nil {
+		t.Fatalf("execute mixed costs command: %v", err)
+	}
+	for _, want := range []string{
+		"Cost (USD): $12.35 + ?? unknown",
+		"Unpriced dispatches: 2",
+		"openai/mystery: 1 dispatches",
+		"codex/alpha: 1 dispatches",
+		"Total tokens: 10",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("mixed output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Index(output, "codex/alpha: 1 dispatches") > strings.Index(output, "openai/mystery: 1 dispatches") {
+		t.Fatalf("mixed unpriced pairs are not deterministically ordered:\n%s", output)
+	}
+}
+
+func TestCostsHumanOutputUnknownModelRemainsUnpriced(t *testing.T) {
+	t.Parallel()
+
+	provider, model := "codex", "unknown-model"
+	report := humanReport("UNPRICED", nil, 1, []generatedclient.CostsUnpricedPair{
+		{Provider: &provider, Model: &model, DispatchCount: 1},
+	})
+	output, err := runHumanCostsOutput(t, report)
+	if err != nil {
+		t.Fatalf("execute unknown-model costs command: %v", err)
+	}
+	if !strings.Contains(output, "codex/unknown-model: 1 dispatches") {
+		t.Fatalf("unknown model was not shown as an unpriced pair:\n%s", output)
+	}
+	if strings.Contains(output, "$0.00") {
+		t.Fatalf("unknown model was silently valued at zero:\n%s", output)
+	}
+}
+
+func runHumanCostsOutput(t *testing.T, report generatedclient.CostsReport) (string, error) {
+	t.Helper()
+	command := costscli.NewCostsCommand(costscli.CostsCommandConfig{
+		Operation: costscli.NewOperation(func(string) (costscli.Client, error) {
+			return &humanOutputClientStub{
+				response: &generatedclient.GetMetricsCostsClientResponse{JSON200: &report},
+			}, nil
+		}),
+		Server: func() string { return "https://factory.example" },
+	})
+	output := &bytes.Buffer{}
+	command.SetOut(output)
+	command.SetErr(io.Discard)
+	err := command.ExecuteContext(context.Background())
+	return output.String(), err
+}
+
+func humanReport(status string, knownCost *string, unpricedDispatchCount int, pairs []generatedclient.CostsUnpricedPair) generatedclient.CostsReport {
+	input, cached, output, reasoning := int64(7), int64(2), int64(3), int64(4)
+	total := input + output
+	return generatedclient.CostsReport{
+		Currency:  generatedclient.CostsReportCurrency("USD"),
+		Status:    generatedclient.CostsReportStatus(status),
+		KnownCost: knownCost, PricedSubtotal: knownCost,
+		TokenTotals: generatedclient.CostsTokenTotals{
+			TotalTokens: &total, InputTokens: &input, OutputTokens: &output,
+			CachedInputTokens: &cached, ReasoningOutputTokens: &reasoning,
+		},
+		UnpricedDispatchCount: unpricedDispatchCount,
+		UnpricedPairs:         pairs,
+	}
+}
+
+type humanOutputClientStub struct {
+	response *generatedclient.GetMetricsCostsClientResponse
+}
+
+func (stub *humanOutputClientStub) GetMetricsCostsWithResponse(
+	_ context.Context,
+	_ *generatedclient.GetMetricsCostsParams,
+	_ ...generatedclient.RequestEditorFn,
+) (*generatedclient.GetMetricsCostsClientResponse, error) {
+	return stub.response, nil
+}

--- a/pkg/services/costs/transports/http/adapter_test.go
+++ b/pkg/services/costs/transports/http/adapter_test.go
@@ -14,6 +14,11 @@ func TestAdapterMapsExactReportAndRuntimeInputs(t *testing.T) {
 	t.Parallel()
 	inputTokens := int64(12)
 	outputTokens := int64(0)
+	totalTokens := int64(12)
+	provider := "provider"
+	model := "known"
+	dispatchCount := 1
+	knownPair := costs.UnpricedPair{Provider: &provider, Model: &model, DispatchCount: dispatchCount}
 	query := costs.CostsQuery(func(_ context.Context, request costs.QueryRequest) (costs.Report, error) {
 		if request.MetricsRoot != "metrics-root" || request.OperatorSettingsPath != "settings.json" || request.FactorySessionID != "session-a" {
 			t.Fatalf("Costs request = %#v", request)
@@ -23,13 +28,19 @@ func TestAdapterMapsExactReportAndRuntimeInputs(t *testing.T) {
 			Scope:          costs.Scope{Kind: costs.ScopeFactorySession, FactorySessionID: "session-a"},
 			Currency:       "USD",
 			Status:         costs.StatusPartial,
+			KnownCost:      &amount,
 			PricedSubtotal: &amount,
-			Coverage:       costs.Coverage{EncounteredRows: 2, PricedRows: 1, UnpricedRows: 1, EncounteredProviderModels: 2, PricedProviderModels: 1, UnpricedProviderModels: 1},
+			TokenTotals: costs.TokenTotals{
+				TotalTokens: &totalTokens, InputTokens: &inputTokens, OutputTokens: &outputTokens,
+			},
+			UnpricedDispatchCount: 1,
+			UnpricedPairs:         []costs.UnpricedPair{knownPair},
+			Coverage:              costs.Coverage{EncounteredRows: 2, PricedRows: 1, UnpricedRows: 1, EncounteredProviderModels: 2, PricedProviderModels: 1, UnpricedProviderModels: 1},
 			LineItems: []costs.LineItem{
 				{Model: "known", Status: costs.StatusPriced, PricedAmount: &amount, TokenCounts: costs.TokenCounts{InputTokens: &inputTokens, OutputTokens: &outputTokens}},
 				{Model: "unknown", Status: costs.StatusUnpriced, Reason: "no configured price"},
 			},
-			ProviderModels: []costs.ProviderModelRollup{{Provider: "provider", Model: "known", Rollup: costs.Rollup{Key: "provider/known", Status: costs.StatusPriced, PricedSubtotal: &amount}}},
+			ProviderModels: []costs.ProviderModelRollup{{Provider: "provider", Model: "known", Rollup: costs.Rollup{Key: "provider/known", Currency: "USD", Status: costs.StatusPriced, KnownCost: &amount, PricedSubtotal: &amount, TokenTotals: costs.TokenTotals{TotalTokens: &totalTokens, InputTokens: &inputTokens, OutputTokens: &outputTokens}, UnpricedPairs: []costs.UnpricedPair{}}}},
 		}, nil
 	})
 	adapter := NewAdapter(query, " metrics-root ", " settings.json ")
@@ -55,8 +66,11 @@ func assertMappedReport(t *testing.T, got factoryapi.CostsReport, inputTokens, o
 
 func assertMappedReportHeader(t *testing.T, got factoryapi.CostsReport) {
 	t.Helper()
-	if got.Currency != "USD" || got.Status != "PARTIAL" || got.PricedSubtotal == nil || *got.PricedSubtotal != "123456789.000001" {
+	if got.Currency != "USD" || got.Status != "PARTIAL" || got.KnownCost == nil || *got.KnownCost != "123456789.000001" || got.PricedSubtotal == nil || *got.PricedSubtotal != "123456789.000001" {
 		t.Fatalf("mapped report = %#v", got)
+	}
+	if got.TokenTotals.TotalTokens == nil || *got.TokenTotals.TotalTokens != 12 || got.UnpricedDispatchCount != 1 || len(got.UnpricedPairs) != 1 {
+		t.Fatalf("mapped report partial facts = %#v", got)
 	}
 }
 
@@ -79,7 +93,7 @@ func assertMappedReportProviderRollup(t *testing.T, got factoryapi.CostsReport) 
 	if got.LineItems[1].PricedAmount != nil || got.LineItems[1].Reason == nil || *got.LineItems[1].Reason != "no configured price" {
 		t.Fatalf("unpriced line item = %#v", got.LineItems[1])
 	}
-	if len(got.ProviderModels) != 1 || got.ProviderModels[0].Key != "provider/known" || got.ProviderModels[0].PricedSubtotal == nil || *got.ProviderModels[0].PricedSubtotal != "123456789.000001" {
+	if len(got.ProviderModels) != 1 || got.ProviderModels[0].Key != "provider/known" || got.ProviderModels[0].PricedSubtotal == nil || *got.ProviderModels[0].PricedSubtotal != "123456789.000001" || got.ProviderModels[0].Currency != "USD" {
 		t.Fatalf("provider rollups = %#v", got.ProviderModels)
 	}
 }

--- a/pkg/services/costs/transports/http/mapping.go
+++ b/pkg/services/costs/transports/http/mapping.go
@@ -7,16 +7,20 @@ import (
 
 func reportToAPI(report costs.Report) factoryapi.CostsReport {
 	return factoryapi.CostsReport{
-		Scope:           scopeToAPI(report.Scope),
-		Currency:        factoryapi.CostsReportCurrency(report.Currency),
-		Status:          factoryapi.CostsReportStatus(report.Status),
-		PricedSubtotal:  report.PricedSubtotal,
-		Coverage:        coverageToAPI(report.Coverage),
-		LineItems:       lineItemsToAPI(report.LineItems),
-		WorkItems:       rollupsToAPI(report.WorkItems),
-		WorkerSessions:  rollupsToAPI(report.WorkerSessions),
-		ProviderModels:  providerRollupsToAPI(report.ProviderModels),
-		FactorySessions: rollupsToAPI(report.FactorySessions),
+		Scope:                 scopeToAPI(report.Scope),
+		Currency:              factoryapi.CostsReportCurrency(report.Currency),
+		Status:                factoryapi.CostsReportStatus(report.Status),
+		KnownCost:             report.KnownCost,
+		PricedSubtotal:        report.PricedSubtotal,
+		TokenTotals:           tokenTotalsToAPI(report.TokenTotals),
+		UnpricedDispatchCount: report.UnpricedDispatchCount,
+		UnpricedPairs:         unpricedPairsToAPI(report.UnpricedPairs),
+		Coverage:              coverageToAPI(report.Coverage),
+		LineItems:             lineItemsToAPI(report.LineItems),
+		WorkItems:             rollupsToAPI(report.WorkItems),
+		WorkerSessions:        rollupsToAPI(report.WorkerSessions),
+		ProviderModels:        providerRollupsToAPI(report.ProviderModels),
+		FactorySessions:       rollupsToAPI(report.FactorySessions),
 	}
 }
 
@@ -78,12 +82,17 @@ func providerRollupsToAPI(rollups []costs.ProviderModelRollup) []factoryapi.Cost
 			Provider:              rollup.Provider,
 			Model:                 rollup.Model,
 			Key:                   mapped.Key,
+			Currency:              factoryapi.CostsProviderModelRollupCurrency(mapped.Currency),
 			InputTokens:           mapped.InputTokens,
 			OutputTokens:          mapped.OutputTokens,
 			CachedInputTokens:     mapped.CachedInputTokens,
 			ReasoningOutputTokens: mapped.ReasoningOutputTokens,
 			Status:                factoryapi.CostsProviderModelRollupStatus(mapped.Status),
+			KnownCost:             mapped.KnownCost,
 			PricedSubtotal:        mapped.PricedSubtotal,
+			TokenTotals:           mapped.TokenTotals,
+			UnpricedDispatchCount: mapped.UnpricedDispatchCount,
+			UnpricedPairs:         mapped.UnpricedPairs,
 			Coverage:              mapped.Coverage,
 		})
 	}
@@ -93,14 +102,41 @@ func providerRollupsToAPI(rollups []costs.ProviderModelRollup) []factoryapi.Cost
 func rollupToAPI(rollup costs.Rollup) factoryapi.CostsRollup {
 	return factoryapi.CostsRollup{
 		Key:                   rollup.Key,
+		Currency:              factoryapi.CostsRollupCurrency(rollup.Currency),
 		InputTokens:           rollup.InputTokens,
 		OutputTokens:          rollup.OutputTokens,
 		CachedInputTokens:     rollup.CachedInputTokens,
 		ReasoningOutputTokens: rollup.ReasoningOutputTokens,
 		Status:                factoryapi.CostsRollupStatus(rollup.Status),
+		KnownCost:             rollup.KnownCost,
 		PricedSubtotal:        rollup.PricedSubtotal,
+		TokenTotals:           tokenTotalsToAPI(rollup.TokenTotals),
+		UnpricedDispatchCount: rollup.UnpricedDispatchCount,
+		UnpricedPairs:         unpricedPairsToAPI(rollup.UnpricedPairs),
 		Coverage:              coverageToAPI(rollup.Coverage),
 	}
+}
+
+func tokenTotalsToAPI(totals costs.TokenTotals) factoryapi.CostsTokenTotals {
+	return factoryapi.CostsTokenTotals{
+		TotalTokens:           totals.TotalTokens,
+		InputTokens:           totals.InputTokens,
+		OutputTokens:          totals.OutputTokens,
+		CachedInputTokens:     totals.CachedInputTokens,
+		ReasoningOutputTokens: totals.ReasoningOutputTokens,
+	}
+}
+
+func unpricedPairsToAPI(pairs []costs.UnpricedPair) []factoryapi.CostsUnpricedPair {
+	result := make([]factoryapi.CostsUnpricedPair, 0, len(pairs))
+	for _, pair := range pairs {
+		result = append(result, factoryapi.CostsUnpricedPair{
+			Provider:      cloneStringPointer(pair.Provider),
+			Model:         cloneStringPointer(pair.Model),
+			DispatchCount: pair.DispatchCount,
+		})
+	}
+	return result
 }
 
 func optionalString(value string) *string {
@@ -108,4 +144,12 @@ func optionalString(value string) *string {
 		return nil
 	}
 	return &value
+}
+
+func cloneStringPointer(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }

--- a/pkg/services/costs/wire/wire.go
+++ b/pkg/services/costs/wire/wire.go
@@ -6,14 +6,15 @@ import (
 	costs "github.com/portpowered/infinite-you/pkg/services/costs"
 	costsservice "github.com/portpowered/infinite-you/pkg/services/costs/internal/service"
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
 // NewCostsQuery constructs the stateless Costs operation from its two narrow
 // owner capabilities and the process logger.
 func NewCostsQuery(
-	settings costs.PriceTableReader,
+	pricing providers.PriceTableReader,
 	metrics factoryvisualization.RuntimeMetricsQuery,
 	logger logging.Logger,
 ) (costs.CostsQuery, error) {
-	return costsservice.New(settings, metrics, logger)
+	return costsservice.New(pricing, metrics, logger)
 }

--- a/pkg/services/costs/wire/wire.go
+++ b/pkg/services/costs/wire/wire.go
@@ -6,13 +6,12 @@ import (
 	costs "github.com/portpowered/infinite-you/pkg/services/costs"
 	costsservice "github.com/portpowered/infinite-you/pkg/services/costs/internal/service"
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
-	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
 // NewCostsQuery constructs the stateless Costs operation from its two narrow
 // owner capabilities and the process logger.
 func NewCostsQuery(
-	pricing providers.PriceTableReader,
+	pricing costs.PriceTableReader,
 	metrics factoryvisualization.RuntimeMetricsQuery,
 	logger logging.Logger,
 ) (costs.CostsQuery, error) {

--- a/pkg/services/costs/wire/wire_test.go
+++ b/pkg/services/costs/wire/wire_test.go
@@ -7,14 +7,16 @@ import (
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	costs "github.com/portpowered/infinite-you/pkg/services/costs"
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
-	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
 func TestNewCostsQueryUsesNarrowDependencies(t *testing.T) {
 	t.Parallel()
 
 	query, err := NewCostsQuery(
-		settingsReader{document: operatorsettings.Document{}},
+		providers.PriceTableReaderFunc(func() (providers.PriceTable, error) {
+			return providers.PriceTable{Currency: providers.PriceTableCurrencyUSD, Models: []providers.PriceTableModel{}}, nil
+		}),
 		func(context.Context, factoryvisualization.RuntimeMetricsQueryRequest) (factoryvisualization.RuntimeMetricsQueryResult, error) {
 			return factoryvisualization.RuntimeMetricsQueryResult{}, nil
 		},
@@ -33,12 +35,4 @@ func TestNewCostsQueryUsesNarrowDependencies(t *testing.T) {
 	if result.Status != costs.StatusNoUsage || result.Currency != "USD" {
 		t.Fatalf("result = %#v, want empty USD report", result)
 	}
-}
-
-type settingsReader struct {
-	document operatorsettings.Document
-}
-
-func (reader settingsReader) LoadDocument(operatorsettings.LoadDocumentRequest) (operatorsettings.LoadDocumentResult, error) {
-	return operatorsettings.LoadDocumentResult{Document: reader.document}, nil
 }

--- a/pkg/services/operator_settings/acp_integrations_test.go
+++ b/pkg/services/operator_settings/acp_integrations_test.go
@@ -149,6 +149,33 @@ func TestPriceTableNormalizeRoundTripsCanonicalIdentitiesAndExplicitZero(t *test
 	}
 }
 
+func TestDefaultPriceTableContainsSourcedObservedModel(t *testing.T) {
+	t.Parallel()
+
+	table := defaultPriceTable()
+	if table.Currency != PriceTableCurrencyUSD || len(table.Models) != 1 {
+		t.Fatalf("defaultPriceTable() = %#v, want one USD model", table)
+	}
+
+	normalized, err := table.Normalize()
+	if err != nil {
+		t.Fatalf("defaultPriceTable().Normalize() = %v", err)
+	}
+	model := normalized.Models[0]
+	if model.Provider != "CODEX" || model.Model != "gpt-5-codex" {
+		t.Fatalf("default model identity = %#v, want CODEX/gpt-5-codex", model)
+	}
+	if model.InputPerMillionTokens != "1.25" || model.OutputPerMillionTokens != "10" {
+		t.Fatalf("default base rates = %#v, want 1.25/10", model)
+	}
+	if model.CachedInputPerMillionTokens == nil || *model.CachedInputPerMillionTokens != "0.125" {
+		t.Fatalf("default cached-input rate = %#v, want explicit 0.125", model.CachedInputPerMillionTokens)
+	}
+	if model.ReasoningOutputPerMillionTokens == nil || *model.ReasoningOutputPerMillionTokens != "10" {
+		t.Fatalf("default reasoning-output rate = %#v, want explicit output-equivalent 10", model.ReasoningOutputPerMillionTokens)
+	}
+}
+
 func TestPriceTableNormalizeRejectsInvalidEntries(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/operator_settings/acp_integrations_test.go
+++ b/pkg/services/operator_settings/acp_integrations_test.go
@@ -149,30 +149,12 @@ func TestPriceTableNormalizeRoundTripsCanonicalIdentitiesAndExplicitZero(t *test
 	}
 }
 
-func TestDefaultPriceTableContainsSourcedObservedModel(t *testing.T) {
+func TestDefaultPriceTableDoesNotPublishProviderPricing(t *testing.T) {
 	t.Parallel()
 
 	table := defaultPriceTable()
-	if table.Currency != PriceTableCurrencyUSD || len(table.Models) != 1 {
-		t.Fatalf("defaultPriceTable() = %#v, want one USD model", table)
-	}
-
-	normalized, err := table.Normalize()
-	if err != nil {
-		t.Fatalf("defaultPriceTable().Normalize() = %v", err)
-	}
-	model := normalized.Models[0]
-	if model.Provider != "CODEX" || model.Model != "gpt-5-codex" {
-		t.Fatalf("default model identity = %#v, want CODEX/gpt-5-codex", model)
-	}
-	if model.InputPerMillionTokens != "1.25" || model.OutputPerMillionTokens != "10" {
-		t.Fatalf("default base rates = %#v, want 1.25/10", model)
-	}
-	if model.CachedInputPerMillionTokens == nil || *model.CachedInputPerMillionTokens != "0.125" {
-		t.Fatalf("default cached-input rate = %#v, want explicit 0.125", model.CachedInputPerMillionTokens)
-	}
-	if model.ReasoningOutputPerMillionTokens == nil || *model.ReasoningOutputPerMillionTokens != "10" {
-		t.Fatalf("default reasoning-output rate = %#v, want explicit output-equivalent 10", model.ReasoningOutputPerMillionTokens)
+	if table.Currency != PriceTableCurrencyUSD || len(table.Models) != 0 {
+		t.Fatalf("defaultPriceTable() = %#v, want empty legacy USD table", table)
 	}
 }
 

--- a/pkg/services/operator_settings/defaults_contract.go
+++ b/pkg/services/operator_settings/defaults_contract.go
@@ -94,7 +94,25 @@ type PriceTableModel struct {
 }
 
 func defaultPriceTable() PriceTable {
-	return PriceTable{Currency: PriceTableCurrencyUSD, Models: []PriceTableModel{}}
+	// Observed in the live 2026-08-22 metrics day: codex/gpt-5-codex had
+	// 192 usage rows. The local codex/OMNIVOICE_Q4_K_M model had 12 rows but
+	// has no authoritative published token price, so it remains unpriced.
+	// The other observed pairs were test fixtures, not shipped factory models.
+	// Source: https://developers.openai.com/api/docs/models/gpt-5-codex
+	// Source as-of: 2026-08-21. The source publishes $1.25 input, $0.125
+	// cached input, and $10 output per million tokens. It does not publish a
+	// separate reasoning-output rate; reasoning is intentionally represented at
+	// the standard output rate rather than silently treated as free or unknown.
+	reasoningRate := "10"
+	cachedInputRate := "0.125"
+	return PriceTable{Currency: PriceTableCurrencyUSD, Models: []PriceTableModel{{
+		Provider:                        "CODEX",
+		Model:                           "gpt-5-codex",
+		InputPerMillionTokens:           "1.25",
+		OutputPerMillionTokens:          "10",
+		CachedInputPerMillionTokens:     &cachedInputRate,
+		ReasoningOutputPerMillionTokens: &reasoningRate,
+	}}}
 }
 
 // Clone returns a detached price table whose model slice and optional rates do

--- a/pkg/services/operator_settings/defaults_contract.go
+++ b/pkg/services/operator_settings/defaults_contract.go
@@ -94,25 +94,11 @@ type PriceTableModel struct {
 }
 
 func defaultPriceTable() PriceTable {
-	// Observed in the live 2026-08-22 metrics day: codex/gpt-5-codex had
-	// 192 usage rows. The local codex/OMNIVOICE_Q4_K_M model had 12 rows but
-	// has no authoritative published token price, so it remains unpriced.
-	// The other observed pairs were test fixtures, not shipped factory models.
-	// Source: https://developers.openai.com/api/docs/models/gpt-5-codex
-	// Source as-of: 2026-08-21. The source publishes $1.25 input, $0.125
-	// cached input, and $10 output per million tokens. It does not publish a
-	// separate reasoning-output rate; reasoning is intentionally represented at
-	// the standard output rate rather than silently treated as free or unknown.
-	reasoningRate := "10"
-	cachedInputRate := "0.125"
-	return PriceTable{Currency: PriceTableCurrencyUSD, Models: []PriceTableModel{{
-		Provider:                        "CODEX",
-		Model:                           "gpt-5-codex",
-		InputPerMillionTokens:           "1.25",
-		OutputPerMillionTokens:          "10",
-		CachedInputPerMillionTokens:     &cachedInputRate,
-		ReasoningOutputPerMillionTokens: &reasoningRate,
-	}}}
+	// Pricing facts are Providers-owned and are intentionally not part of the
+	// operator-authored configuration. Keep this legacy compatibility shape
+	// empty so absent-file and decoded-file settings cannot become a second
+	// valuation authority.
+	return PriceTable{Currency: PriceTableCurrencyUSD, Models: []PriceTableModel{}}
 }
 
 // Clone returns a detached price table whose model slice and optional rates do

--- a/pkg/services/providers/root_contract_characterization_test.go
+++ b/pkg/services/providers/root_contract_characterization_test.go
@@ -395,4 +395,39 @@ func TestPriceTableNormalizeCanonicalizesAndDetachesEntries(t *testing.T) {
 	}
 }
 
+func TestPriceTableReaderFuncReturnsDetachedEntries(t *testing.T) {
+	t.Parallel()
+
+	cached := "0"
+	table := providers.PriceTable{
+		Currency: providers.PriceTableCurrencyUSD,
+		Models: []providers.PriceTableModel{{
+			Provider:                    providers.IDCodex,
+			Model:                       "gpt-5",
+			InputPerMillionTokens:       "1",
+			OutputPerMillionTokens:      "2",
+			CachedInputPerMillionTokens: &cached,
+			SourceURL:                   "https://example.com/pricing",
+			AsOfDate:                    "2026-08-21",
+		}},
+	}
+	reader := providers.PriceTableReaderFunc(func() (providers.PriceTable, error) {
+		return table, nil
+	})
+
+	first, err := reader.ReadPriceTable()
+	if err != nil {
+		t.Fatalf("ReadPriceTable() = %v", err)
+	}
+	first.Models[0].Model = "mutated"
+	*first.Models[0].CachedInputPerMillionTokens = "9"
+	second, err := reader.ReadPriceTable()
+	if err != nil {
+		t.Fatalf("second ReadPriceTable() = %v", err)
+	}
+	if second.Models[0].Model != "gpt-5" || *second.Models[0].CachedInputPerMillionTokens != "0" {
+		t.Fatalf("ReadPriceTable() returned aliased data: %#v", second.Models[0])
+	}
+}
+
 func stringPointer(value string) *string { return &value }

--- a/pkg/services/providers/root_contract_characterization_test.go
+++ b/pkg/services/providers/root_contract_characterization_test.go
@@ -9,6 +9,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"testing"
 
@@ -313,3 +314,85 @@ func providersRepositoryRoot(t *testing.T) string {
 	}
 	return root
 }
+
+func TestPriceTableNormalizeRequiresProvenanceAndExplicitEqualRates(t *testing.T) {
+	t.Parallel()
+
+	reasoning := "2"
+	valid := providers.PriceTable{
+		Currency: providers.PriceTableCurrencyUSD,
+		Models: []providers.PriceTableModel{{
+			Provider:                        providers.IDCodex,
+			Model:                           "gpt-5",
+			InputPerMillionTokens:           "1",
+			OutputPerMillionTokens:          "2",
+			ReasoningOutputPerMillionTokens: &reasoning,
+			SourceURL:                       "https://example.com/pricing",
+			AsOfDate:                        "2026-08-21",
+			EqualRateClasses:                []providers.PriceClass{providers.PriceClassReasoningOutput},
+		}},
+	}
+	if _, err := valid.Normalize(); err != nil {
+		t.Fatalf("valid price table Normalize() = %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*providers.PriceTable)
+	}{
+		{name: "missing source", mutate: func(table *providers.PriceTable) { table.Models[0].SourceURL = "" }},
+		{name: "missing date", mutate: func(table *providers.PriceTable) { table.Models[0].AsOfDate = "" }},
+		{name: "negative rate", mutate: func(table *providers.PriceTable) { table.Models[0].InputPerMillionTokens = "-1" }},
+		{name: "unsupported currency", mutate: func(table *providers.PriceTable) { table.Currency = "EUR" }},
+		{name: "implicit equal rate", mutate: func(table *providers.PriceTable) { table.Models[0].EqualRateClasses = nil }},
+		{name: "mismatched equality", mutate: func(table *providers.PriceTable) {
+			table.Models[0].ReasoningOutputPerMillionTokens = stringPointer("3")
+		}},
+		{name: "duplicate pair", mutate: func(table *providers.PriceTable) { table.Models = append(table.Models, table.Models[0].Clone()) }},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			candidate := valid.Clone()
+			testCase.mutate(&candidate)
+			if _, err := candidate.Normalize(); !errors.Is(err, providers.ErrPriceTableInvalid) {
+				t.Fatalf("Normalize() error = %v, want ErrPriceTableInvalid", err)
+			}
+		})
+	}
+}
+
+func TestPriceTableNormalizeCanonicalizesAndDetachesEntries(t *testing.T) {
+	t.Parallel()
+
+	cached := "0"
+	table := providers.PriceTable{
+		Currency: providers.PriceTableCurrencyUSD,
+		Models: []providers.PriceTableModel{{
+			Provider:                    providers.ID(" CODEX "),
+			Model:                       " gpt-5 ",
+			InputPerMillionTokens:       " 1 ",
+			OutputPerMillionTokens:      "2",
+			CachedInputPerMillionTokens: &cached,
+			SourceURL:                   "https://example.com/pricing",
+			AsOfDate:                    "2026-08-21",
+		}},
+	}
+	normalized, err := table.Normalize()
+	if err != nil {
+		t.Fatalf("Normalize() = %v", err)
+	}
+	if normalized.Models[0].Provider != providers.IDCodex || normalized.Models[0].Model != "gpt-5" || normalized.Models[0].InputPerMillionTokens != "1" {
+		t.Fatalf("normalized identity/rate = %#v", normalized.Models[0])
+	}
+	cloned := normalized.Clone()
+	cloned.Models[0].Model = "mutated"
+	*cloned.Models[0].CachedInputPerMillionTokens = "9"
+	if normalized.Models[0].Model == "mutated" || *normalized.Models[0].CachedInputPerMillionTokens != "0" {
+		t.Fatal("Clone() shares mutable pricing state")
+	}
+	if reflect.DeepEqual(normalized, cloned) {
+		t.Fatal("Clone() did not detach the entry")
+	}
+}
+
+func stringPointer(value string) *string { return &value }

--- a/pkg/services/providers/service_contract.go
+++ b/pkg/services/providers/service_contract.go
@@ -142,16 +142,12 @@ type PriceTableModel struct {
 	EqualRateClasses                []PriceClass
 }
 
-// PriceTableReader is the narrow Providers-owned capability required by
-// consumers such as Costs. Implementations must return detached values.
-type PriceTableReader interface {
-	ReadPriceTable() (PriceTable, error)
-}
-
-// PriceTableReaderFunc adapts a pure reader function to PriceTableReader.
+// PriceTableReaderFunc adapts a pure Providers-owned price-table read to the
+// narrow consumer capability used by Costs. The function form keeps pricing
+// out of the singular Providers service root while retaining detached reads.
 type PriceTableReaderFunc func() (PriceTable, error)
 
-// ReadPriceTable implements PriceTableReader.
+// ReadPriceTable implements the narrow price-table consumer capability.
 func (reader PriceTableReaderFunc) ReadPriceTable() (PriceTable, error) {
 	if reader == nil {
 		return PriceTable{}, fmt.Errorf("read provider price table: reader is required")

--- a/pkg/services/providers/service_contract.go
+++ b/pkg/services/providers/service_contract.go
@@ -156,7 +156,11 @@ func (reader PriceTableReaderFunc) ReadPriceTable() (PriceTable, error) {
 	if reader == nil {
 		return PriceTable{}, fmt.Errorf("read provider price table: reader is required")
 	}
-	return reader()
+	table, err := reader()
+	if err != nil {
+		return PriceTable{}, err
+	}
+	return table.Clone(), nil
 }
 
 // Clone returns a detached price table.

--- a/pkg/services/providers/service_contract.go
+++ b/pkg/services/providers/service_contract.go
@@ -291,30 +291,17 @@ func validateProvenance(index int, sourceURL, asOfDate string) error {
 func normalizeEqualRateClasses(index int, classes []PriceClass, input, output string, cached, reasoning *string) ([]PriceClass, error) {
 	seen := make(map[PriceClass]struct{}, len(classes))
 	for _, class := range classes {
-		class = PriceClass(strings.ToLower(strings.TrimSpace(string(class))))
-		if class != PriceClassCachedInput && class != PriceClassReasoningOutput {
-			return nil, fmt.Errorf("%w: models[%d].equalRateClasses contains unsupported class %q", ErrPriceTableInvalid, index, class)
+		class, err := normalizeEqualRateClass(index, class, input, output, cached, reasoning)
+		if err != nil {
+			return nil, err
 		}
 		if _, exists := seen[class]; exists {
 			return nil, fmt.Errorf("%w: models[%d].equalRateClasses duplicates %q", ErrPriceTableInvalid, index, class)
 		}
 		seen[class] = struct{}{}
-		switch class {
-		case PriceClassCachedInput:
-			if cached == nil || *cached != input {
-				return nil, fmt.Errorf("%w: models[%d] cached-input equality declaration does not match its input rate", ErrPriceTableInvalid, index)
-			}
-		case PriceClassReasoningOutput:
-			if reasoning == nil || *reasoning != output {
-				return nil, fmt.Errorf("%w: models[%d] reasoning-output equality declaration does not match its output rate", ErrPriceTableInvalid, index)
-			}
-		}
 	}
-	if cached != nil && *cached == input && !containsPriceClass(classes, PriceClassCachedInput) {
-		return nil, fmt.Errorf("%w: models[%d] equal cached-input rate must be explicitly declared", ErrPriceTableInvalid, index)
-	}
-	if reasoning != nil && *reasoning == output && !containsPriceClass(classes, PriceClassReasoningOutput) {
-		return nil, fmt.Errorf("%w: models[%d] equal reasoning-output rate must be explicitly declared", ErrPriceTableInvalid, index)
+	if err := validateImplicitEqualRateClasses(index, classes, input, output, cached, reasoning); err != nil {
+		return nil, err
 	}
 	result := make([]PriceClass, 0, len(seen))
 	for class := range seen {
@@ -322,6 +309,34 @@ func normalizeEqualRateClasses(index int, classes []PriceClass, input, output st
 	}
 	sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
 	return result, nil
+}
+
+func normalizeEqualRateClass(index int, class PriceClass, input, output string, cached, reasoning *string) (PriceClass, error) {
+	class = PriceClass(strings.ToLower(strings.TrimSpace(string(class))))
+	if class != PriceClassCachedInput && class != PriceClassReasoningOutput {
+		return "", fmt.Errorf("%w: models[%d].equalRateClasses contains unsupported class %q", ErrPriceTableInvalid, index, class)
+	}
+	switch class {
+	case PriceClassCachedInput:
+		if cached == nil || *cached != input {
+			return "", fmt.Errorf("%w: models[%d] cached-input equality declaration does not match its input rate", ErrPriceTableInvalid, index)
+		}
+	case PriceClassReasoningOutput:
+		if reasoning == nil || *reasoning != output {
+			return "", fmt.Errorf("%w: models[%d] reasoning-output equality declaration does not match its output rate", ErrPriceTableInvalid, index)
+		}
+	}
+	return class, nil
+}
+
+func validateImplicitEqualRateClasses(index int, classes []PriceClass, input, output string, cached, reasoning *string) error {
+	if cached != nil && *cached == input && !containsPriceClass(classes, PriceClassCachedInput) {
+		return fmt.Errorf("%w: models[%d] equal cached-input rate must be explicitly declared", ErrPriceTableInvalid, index)
+	}
+	if reasoning != nil && *reasoning == output && !containsPriceClass(classes, PriceClassReasoningOutput) {
+		return fmt.Errorf("%w: models[%d] equal reasoning-output rate must be explicitly declared", ErrPriceTableInvalid, index)
+	}
+	return nil
 }
 
 func containsPriceClass(classes []PriceClass, want PriceClass) bool {

--- a/pkg/services/providers/service_contract.go
+++ b/pkg/services/providers/service_contract.go
@@ -2,8 +2,13 @@ package providers
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/url"
+	"regexp"
+	"sort"
 	"strings"
+	"time"
 )
 
 // Service is the singular cross-service Providers root authority. Peer packages
@@ -93,4 +98,241 @@ func (result ContinueReferenceResult) Clone() ContinueReferenceResult {
 func (ref ContinuationRef) String() string {
 	normalized := ref.Normalize()
 	return fmt.Sprintf("%s/%s/%s", normalized.Provider, normalized.Kind, firstContinuationIdentity(normalized))
+}
+
+// PriceTableCurrency identifies the currency used by every published rate.
+// Providers currently publishes USD only.
+const PriceTableCurrencyUSD = "USD"
+
+// PriceClass identifies one optional token subclass rate.
+type PriceClass string
+
+const (
+	PriceClassCachedInput     PriceClass = "cached-input"
+	PriceClassReasoningOutput PriceClass = "reasoning-output"
+)
+
+// ErrPriceTableInvalid reports a malformed or insufficient provider-owned
+// pricing fact before it can reach valuation.
+var ErrPriceTableInvalid = errors.New("provider price table is invalid")
+
+var priceProviderPattern = regexp.MustCompile(`^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$`)
+var priceRatePattern = regexp.MustCompile(`^[0-9]+(?:\.[0-9]+)?$`)
+
+// PriceTable is the detached, declarative provider pricing catalog consumed by
+// Costs. It is not operator configuration and has no mutation operation.
+type PriceTable struct {
+	Currency string
+	Models   []PriceTableModel
+}
+
+// PriceTableModel publishes exact USD rates for one canonical provider/model
+// pair. A nil subclass rate means that coverage is unknown. EqualRateClasses
+// explicitly records when a subclass uses its standard class rate; equality
+// is never inferred from omission.
+type PriceTableModel struct {
+	Provider                        ID
+	Model                           string
+	InputPerMillionTokens           string
+	OutputPerMillionTokens          string
+	CachedInputPerMillionTokens     *string
+	ReasoningOutputPerMillionTokens *string
+	SourceURL                       string
+	AsOfDate                        string
+	EqualRateClasses                []PriceClass
+}
+
+// PriceTableReader is the narrow Providers-owned capability required by
+// consumers such as Costs. Implementations must return detached values.
+type PriceTableReader interface {
+	ReadPriceTable() (PriceTable, error)
+}
+
+// PriceTableReaderFunc adapts a pure reader function to PriceTableReader.
+type PriceTableReaderFunc func() (PriceTable, error)
+
+// ReadPriceTable implements PriceTableReader.
+func (reader PriceTableReaderFunc) ReadPriceTable() (PriceTable, error) {
+	if reader == nil {
+		return PriceTable{}, fmt.Errorf("read provider price table: reader is required")
+	}
+	return reader()
+}
+
+// Clone returns a detached price table.
+func (table PriceTable) Clone() PriceTable {
+	cloned := table
+	if table.Models == nil {
+		return cloned
+	}
+	cloned.Models = make([]PriceTableModel, len(table.Models))
+	for index, model := range table.Models {
+		cloned.Models[index] = model.Clone()
+	}
+	return cloned
+}
+
+// Clone returns a detached model-price entry.
+func (model PriceTableModel) Clone() PriceTableModel {
+	cloned := model
+	cloned.CachedInputPerMillionTokens = clonePriceRate(model.CachedInputPerMillionTokens)
+	cloned.ReasoningOutputPerMillionTokens = clonePriceRate(model.ReasoningOutputPerMillionTokens)
+	cloned.EqualRateClasses = append([]PriceClass(nil), model.EqualRateClasses...)
+	return cloned
+}
+
+// Normalize trims and validates a complete provider-owned table. It also
+// canonicalizes provider IDs and produces deterministic equal-rate ordering.
+func (table PriceTable) Normalize() (PriceTable, error) {
+	if strings.TrimSpace(table.Currency) != PriceTableCurrencyUSD {
+		return PriceTable{}, fmt.Errorf("%w: currency %q is unsupported; only %s is accepted", ErrPriceTableInvalid, table.Currency, PriceTableCurrencyUSD)
+	}
+	normalized := PriceTable{Currency: PriceTableCurrencyUSD, Models: make([]PriceTableModel, len(table.Models))}
+	seen := make(map[string]struct{}, len(table.Models))
+	for index, model := range table.Models {
+		entry, err := normalizePriceTableModel(index, model)
+		if err != nil {
+			return PriceTable{}, err
+		}
+		key := string(entry.Provider) + "\x00" + entry.Model
+		if _, exists := seen[key]; exists {
+			return PriceTable{}, fmt.Errorf("%w: models[%d] duplicates provider/model %q/%q", ErrPriceTableInvalid, index, entry.Provider, entry.Model)
+		}
+		seen[key] = struct{}{}
+		normalized.Models[index] = entry
+	}
+	return normalized, nil
+}
+
+func normalizePriceTableModel(index int, model PriceTableModel) (PriceTableModel, error) {
+	provider := ID(strings.ToLower(strings.TrimSpace(model.Provider.String())))
+	if !priceProviderPattern.MatchString(string(provider)) {
+		return PriceTableModel{}, fmt.Errorf("%w: models[%d].provider %q must be a canonical provider identity", ErrPriceTableInvalid, index, model.Provider)
+	}
+	modelName := strings.TrimSpace(model.Model)
+	if modelName == "" {
+		return PriceTableModel{}, fmt.Errorf("%w: models[%d].model must be non-empty", ErrPriceTableInvalid, index)
+	}
+	input, err := normalizePriceRate(index, "inputPerMillionTokens", model.InputPerMillionTokens, true)
+	if err != nil {
+		return PriceTableModel{}, err
+	}
+	output, err := normalizePriceRate(index, "outputPerMillionTokens", model.OutputPerMillionTokens, true)
+	if err != nil {
+		return PriceTableModel{}, err
+	}
+	if err := validateProvenance(index, model.SourceURL, model.AsOfDate); err != nil {
+		return PriceTableModel{}, err
+	}
+	normalized := PriceTableModel{
+		Provider:               provider,
+		Model:                  modelName,
+		InputPerMillionTokens:  input,
+		OutputPerMillionTokens: output,
+		SourceURL:              strings.TrimSpace(model.SourceURL),
+		AsOfDate:               strings.TrimSpace(model.AsOfDate),
+	}
+	if normalized.CachedInputPerMillionTokens, err = normalizeOptionalRate(index, "cachedInputPerMillionTokens", model.CachedInputPerMillionTokens); err != nil {
+		return PriceTableModel{}, err
+	}
+	if normalized.ReasoningOutputPerMillionTokens, err = normalizeOptionalRate(index, "reasoningOutputPerMillionTokens", model.ReasoningOutputPerMillionTokens); err != nil {
+		return PriceTableModel{}, err
+	}
+	normalized.EqualRateClasses, err = normalizeEqualRateClasses(index, model.EqualRateClasses, input, output, normalized.CachedInputPerMillionTokens, normalized.ReasoningOutputPerMillionTokens)
+	if err != nil {
+		return PriceTableModel{}, err
+	}
+	return normalized, nil
+}
+
+func normalizePriceRate(index int, field, value string, required bool) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		if required {
+			return "", fmt.Errorf("%w: models[%d].%s is required", ErrPriceTableInvalid, index, field)
+		}
+		return "", nil
+	}
+	if !priceRatePattern.MatchString(value) {
+		return "", fmt.Errorf("%w: models[%d].%s %q must be a non-negative decimal string", ErrPriceTableInvalid, index, field, value)
+	}
+	return value, nil
+}
+
+func normalizeOptionalRate(index int, field string, value *string) (*string, error) {
+	if value == nil {
+		return nil, nil
+	}
+	normalized, err := normalizePriceRate(index, field, *value, false)
+	if err != nil {
+		return nil, err
+	}
+	return &normalized, nil
+}
+
+func validateProvenance(index int, sourceURL, asOfDate string) error {
+	sourceURL = strings.TrimSpace(sourceURL)
+	parsed, err := url.Parse(sourceURL)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "https" && parsed.Scheme != "http") {
+		return fmt.Errorf("%w: models[%d].sourceURL must be an authoritative http(s) URL", ErrPriceTableInvalid, index)
+	}
+	asOfDate = strings.TrimSpace(asOfDate)
+	parsedDate, err := time.Parse("2006-01-02", asOfDate)
+	if err != nil || parsedDate.Format("2006-01-02") != asOfDate {
+		return fmt.Errorf("%w: models[%d].asOfDate must be an ISO-8601 date", ErrPriceTableInvalid, index)
+	}
+	return nil
+}
+
+func normalizeEqualRateClasses(index int, classes []PriceClass, input, output string, cached, reasoning *string) ([]PriceClass, error) {
+	seen := make(map[PriceClass]struct{}, len(classes))
+	for _, class := range classes {
+		class = PriceClass(strings.ToLower(strings.TrimSpace(string(class))))
+		if class != PriceClassCachedInput && class != PriceClassReasoningOutput {
+			return nil, fmt.Errorf("%w: models[%d].equalRateClasses contains unsupported class %q", ErrPriceTableInvalid, index, class)
+		}
+		if _, exists := seen[class]; exists {
+			return nil, fmt.Errorf("%w: models[%d].equalRateClasses duplicates %q", ErrPriceTableInvalid, index, class)
+		}
+		seen[class] = struct{}{}
+		switch class {
+		case PriceClassCachedInput:
+			if cached == nil || *cached != input {
+				return nil, fmt.Errorf("%w: models[%d] cached-input equality declaration does not match its input rate", ErrPriceTableInvalid, index)
+			}
+		case PriceClassReasoningOutput:
+			if reasoning == nil || *reasoning != output {
+				return nil, fmt.Errorf("%w: models[%d] reasoning-output equality declaration does not match its output rate", ErrPriceTableInvalid, index)
+			}
+		}
+	}
+	if cached != nil && *cached == input && !containsPriceClass(classes, PriceClassCachedInput) {
+		return nil, fmt.Errorf("%w: models[%d] equal cached-input rate must be explicitly declared", ErrPriceTableInvalid, index)
+	}
+	if reasoning != nil && *reasoning == output && !containsPriceClass(classes, PriceClassReasoningOutput) {
+		return nil, fmt.Errorf("%w: models[%d] equal reasoning-output rate must be explicitly declared", ErrPriceTableInvalid, index)
+	}
+	result := make([]PriceClass, 0, len(seen))
+	for class := range seen {
+		result = append(result, class)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
+	return result, nil
+}
+
+func containsPriceClass(classes []PriceClass, want PriceClass) bool {
+	for _, class := range classes {
+		if PriceClass(strings.ToLower(strings.TrimSpace(string(class)))) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func clonePriceRate(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }

--- a/pkg/services/providers/wire/pricing.go
+++ b/pkg/services/providers/wire/pricing.go
@@ -1,0 +1,51 @@
+package wire
+
+import providers "github.com/portpowered/infinite-you/pkg/services/providers"
+
+// NewPriceTableReader constructs the immutable Providers-owned pricing facts
+// used by valuation. The returned reader exposes detached values and validates
+// every authored row before it enters the process graph.
+func NewPriceTableReader() (providers.PriceTableReader, error) {
+	table, err := defaultPriceTable().Normalize()
+	if err != nil {
+		return nil, err
+	}
+	return staticPriceTableReader{table: table}, nil
+}
+
+type staticPriceTableReader struct {
+	table providers.PriceTable
+}
+
+func (reader staticPriceTableReader) ReadPriceTable() (providers.PriceTable, error) {
+	return reader.table.Clone(), nil
+}
+
+// defaultPriceTable is the only shipped pricing data source. The observed
+// provider/model inventory came from the live 2026-08-22 metrics day: the
+// factory used codex/gpt-5-codex for 192 rows and codex/OMNIVOICE_Q4_K_M for 12
+// rows. The local voice model remains intentionally absent because no
+// authoritative token price was found; fixture-only pairs are absent too.
+//
+// Source: https://developers.openai.com/api/docs/models/gpt-5-codex
+// Source as-of: 2026-08-21. The source publishes $1.25 input, $0.125 cached
+// input, and $10 output per million tokens. It does not publish a separate
+// reasoning-output rate, so equality with output is explicit in the data.
+func defaultPriceTable() providers.PriceTable {
+	reasoningRate := "10"
+	cachedInputRate := "0.125"
+	return providers.PriceTable{
+		Currency: providers.PriceTableCurrencyUSD,
+		Models: []providers.PriceTableModel{{
+			Provider:                        providers.IDCodex,
+			Model:                           "gpt-5-codex",
+			InputPerMillionTokens:           "1.25",
+			OutputPerMillionTokens:          "10",
+			CachedInputPerMillionTokens:     &cachedInputRate,
+			ReasoningOutputPerMillionTokens: &reasoningRate,
+			SourceURL:                       "https://developers.openai.com/api/docs/models/gpt-5-codex",
+			AsOfDate:                        "2026-08-21",
+			EqualRateClasses:                []providers.PriceClass{providers.PriceClassReasoningOutput},
+		}},
+	}
+}

--- a/pkg/services/providers/wire/pricing.go
+++ b/pkg/services/providers/wire/pricing.go
@@ -5,20 +5,14 @@ import providers "github.com/portpowered/infinite-you/pkg/services/providers"
 // NewPriceTableReader constructs the immutable Providers-owned pricing facts
 // used by valuation. The returned reader exposes detached values and validates
 // every authored row before it enters the process graph.
-func NewPriceTableReader() (providers.PriceTableReader, error) {
+func NewPriceTableReader() (providers.PriceTableReaderFunc, error) {
 	table, err := defaultPriceTable().Normalize()
 	if err != nil {
 		return nil, err
 	}
-	return staticPriceTableReader{table: table}, nil
-}
-
-type staticPriceTableReader struct {
-	table providers.PriceTable
-}
-
-func (reader staticPriceTableReader) ReadPriceTable() (providers.PriceTable, error) {
-	return reader.table.Clone(), nil
+	return func() (providers.PriceTable, error) {
+		return table.Clone(), nil
+	}, nil
 }
 
 // defaultPriceTable is the only shipped pricing data source. The observed

--- a/pkg/services/providers/wire/pricing_test.go
+++ b/pkg/services/providers/wire/pricing_test.go
@@ -1,0 +1,42 @@
+package wire
+
+import (
+	"testing"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+)
+
+func TestNewPriceTableReaderPublishesObservedSourcedFacts(t *testing.T) {
+	t.Parallel()
+
+	reader, err := NewPriceTableReader()
+	if err != nil {
+		t.Fatalf("NewPriceTableReader() error = %v", err)
+	}
+	first, err := reader.ReadPriceTable()
+	if err != nil {
+		t.Fatalf("ReadPriceTable() error = %v", err)
+	}
+	if len(first.Models) != 1 {
+		t.Fatalf("price models = %#v, want only the observed authoritative pair", first.Models)
+	}
+	model := first.Models[0]
+	if model.Provider != providers.IDCodex || model.Model != "gpt-5-codex" {
+		t.Fatalf("price identity = %#v, want codex/gpt-5-codex", model)
+	}
+	if model.SourceURL == "" || model.AsOfDate == "" {
+		t.Fatalf("price provenance = %#v, want source URL and as-of date", model)
+	}
+	if len(model.EqualRateClasses) != 1 || model.EqualRateClasses[0] != providers.PriceClassReasoningOutput {
+		t.Fatalf("equal-rate declarations = %#v, want explicit reasoning/output equality", model.EqualRateClasses)
+	}
+
+	first.Models[0].Model = "mutated"
+	second, err := reader.ReadPriceTable()
+	if err != nil {
+		t.Fatalf("second ReadPriceTable() error = %v", err)
+	}
+	if second.Models[0].Model != "gpt-5-codex" {
+		t.Fatal("ReadPriceTable() returned aliased mutable data")
+	}
+}

--- a/pkg/transports/http/client/client.gen.go
+++ b/pkg/transports/http/client/client.gen.go
@@ -52,6 +52,11 @@ const (
 	CostsLineItemStatusUNPRICED CostsLineItemStatus = "UNPRICED"
 )
 
+// Defines values for CostsProviderModelRollupCurrency.
+const (
+	CostsProviderModelRollupCurrencyUSD CostsProviderModelRollupCurrency = "USD"
+)
+
 // Defines values for CostsProviderModelRollupStatus.
 const (
 	CostsProviderModelRollupStatusNOUSAGE  CostsProviderModelRollupStatus = "NO_USAGE"
@@ -71,6 +76,11 @@ const (
 	CostsReportStatusPARTIAL  CostsReportStatus = "PARTIAL"
 	CostsReportStatusPRICED   CostsReportStatus = "PRICED"
 	CostsReportStatusUNPRICED CostsReportStatus = "UNPRICED"
+)
+
+// Defines values for CostsRollupCurrency.
+const (
+	CostsRollupCurrencyUSD CostsRollupCurrency = "USD"
 )
 
 // Defines values for CostsRollupStatus.
@@ -1691,16 +1701,23 @@ type CostsLineItemStatus string
 type CostsProviderModelRollup struct {
 	CachedInputTokens *int64        `json:"cached_input_tokens,omitempty"`
 	Coverage          CostsCoverage `json:"coverage"`
-	InputTokens       *int64        `json:"input_tokens,omitempty"`
+
+	// Currency Currency of the known cost amount.
+	Currency    CostsProviderModelRollupCurrency `json:"currency"`
+	InputTokens *int64                           `json:"input_tokens,omitempty"`
 
 	// Key Stable public provider/model pair key in the form provider/model.
 	Key string `json:"key"`
+
+	// KnownCost Exact USD decimal for the priced portion of this provider/model rollup; PARTIAL never implies a complete total.
+	KnownCost *string `json:"known_cost"`
 
 	// Model Exact resolved model identity, when known.
 	Model        string `json:"model"`
 	OutputTokens *int64 `json:"output_tokens,omitempty"`
 
 	// PricedSubtotal Exact USD decimal subtotal; absent when no usage is priced.
+	// Deprecated: this property has been marked as deprecated upstream, but no `x-deprecated-reason` was set
 	PricedSubtotal *string `json:"priced_subtotal,omitempty"`
 
 	// Provider Canonical provider identity, when known.
@@ -1708,8 +1725,18 @@ type CostsProviderModelRollup struct {
 	ReasoningOutputTokens *int64 `json:"reasoning_output_tokens,omitempty"`
 
 	// Status PRICED means all usage rows for this provider/model are valued; PARTIAL means some are valued; UNPRICED means usage exists but none is valued; NO_USAGE means this pair has no usage rows.
-	Status CostsProviderModelRollupStatus `json:"status"`
+	Status      CostsProviderModelRollupStatus `json:"status"`
+	TokenTotals CostsTokenTotals               `json:"token_totals"`
+
+	// UnpricedDispatchCount Number of distinct dispatches whose usage is not fully valued for this provider/model.
+	UnpricedDispatchCount int `json:"unpriced_dispatch_count"`
+
+	// UnpricedPairs Deterministically ordered unpriced provider/model facts for this rollup.
+	UnpricedPairs []CostsUnpricedPair `json:"unpriced_pairs"`
 }
+
+// CostsProviderModelRollupCurrency Currency of the known cost amount.
+type CostsProviderModelRollupCurrency string
 
 // CostsProviderModelRollupStatus PRICED means all usage rows for this provider/model are valued; PARTIAL means some are valued; UNPRICED means usage exists but none is valued; NO_USAGE means this pair has no usage rows.
 type CostsProviderModelRollupStatus string
@@ -1724,10 +1751,14 @@ type CostsReport struct {
 	// FactorySessions Rollups keyed by Factory Session identity.
 	FactorySessions []CostsRollup `json:"factory_sessions"`
 
+	// KnownCost Exact USD decimal for the priced portion. Null means no usage row had a known price; PARTIAL never implies a complete total.
+	KnownCost *string `json:"known_cost"`
+
 	// LineItems Deterministically ordered canonical usage rows and their valuation status.
 	LineItems []CostsLineItem `json:"line_items"`
 
 	// PricedSubtotal Exact USD decimal subtotal for fully priced rows; absent when no row is priced.
+	// Deprecated: this property has been marked as deprecated upstream, but no `x-deprecated-reason` was set
 	PricedSubtotal *string `json:"priced_subtotal,omitempty"`
 
 	// ProviderModels Rollups keyed by canonical provider/model pair.
@@ -1735,7 +1766,14 @@ type CostsReport struct {
 	Scope          CostsScope                 `json:"scope"`
 
 	// Status PRICED means every usage row is valued; PARTIAL means some rows are valued; UNPRICED means usage exists but none is valued; NO_USAGE means no canonical usage rows were encountered. Missing price is never represented as zero.
-	Status CostsReportStatus `json:"status"`
+	Status      CostsReportStatus `json:"status"`
+	TokenTotals CostsTokenTotals  `json:"token_totals"`
+
+	// UnpricedDispatchCount Number of distinct dispatches whose usage is not fully valued.
+	UnpricedDispatchCount int `json:"unpriced_dispatch_count"`
+
+	// UnpricedPairs Deterministically ordered provider/model pairs contributing unpriced dispatches; null identities are explicit unknowns.
+	UnpricedPairs []CostsUnpricedPair `json:"unpriced_pairs"`
 
 	// WorkItems Rollups keyed by Work item identity.
 	WorkItems []CostsRollup `json:"work_items"`
@@ -1754,19 +1792,36 @@ type CostsReportStatus string
 type CostsRollup struct {
 	CachedInputTokens *int64        `json:"cached_input_tokens,omitempty"`
 	Coverage          CostsCoverage `json:"coverage"`
-	InputTokens       *int64        `json:"input_tokens,omitempty"`
+
+	// Currency Currency of the known cost amount.
+	Currency    CostsRollupCurrency `json:"currency"`
+	InputTokens *int64              `json:"input_tokens,omitempty"`
 
 	// Key Stable dimension key for this rollup.
-	Key          string `json:"key"`
-	OutputTokens *int64 `json:"output_tokens,omitempty"`
+	Key string `json:"key"`
+
+	// KnownCost Exact USD decimal for the priced portion of this rollup; PARTIAL never implies a complete total.
+	KnownCost    *string `json:"known_cost"`
+	OutputTokens *int64  `json:"output_tokens,omitempty"`
 
 	// PricedSubtotal Exact USD decimal subtotal; absent when no usage is priced.
+	// Deprecated: this property has been marked as deprecated upstream, but no `x-deprecated-reason` was set
 	PricedSubtotal        *string `json:"priced_subtotal,omitempty"`
 	ReasoningOutputTokens *int64  `json:"reasoning_output_tokens,omitempty"`
 
 	// Status PRICED means all usage rows in the rollup are valued; PARTIAL means some are valued; UNPRICED means usage exists but none is valued; NO_USAGE means no canonical usage rows were encountered.
-	Status CostsRollupStatus `json:"status"`
+	Status      CostsRollupStatus `json:"status"`
+	TokenTotals CostsTokenTotals  `json:"token_totals"`
+
+	// UnpricedDispatchCount Number of distinct dispatches whose usage is not fully valued in this rollup.
+	UnpricedDispatchCount int `json:"unpriced_dispatch_count"`
+
+	// UnpricedPairs Deterministically ordered provider/model pairs contributing unpriced dispatches in this rollup.
+	UnpricedPairs []CostsUnpricedPair `json:"unpriced_pairs"`
 }
+
+// CostsRollupCurrency Currency of the known cost amount.
+type CostsRollupCurrency string
 
 // CostsRollupStatus PRICED means all usage rows in the rollup are valued; PARTIAL means some are valued; UNPRICED means usage exists but none is valued; NO_USAGE means no canonical usage rows were encountered.
 type CostsRollupStatus string
@@ -1782,6 +1837,36 @@ type CostsScope struct {
 
 // CostsScopeKind Selection scope used to produce the report.
 type CostsScopeKind string
+
+// CostsTokenTotals defines model for CostsTokenTotals.
+type CostsTokenTotals struct {
+	// CachedInputTokens Aggregate cached-input subclass count, or null when no subclass measurement was present.
+	CachedInputTokens *int64 `json:"cached_input_tokens"`
+
+	// InputTokens Aggregate input-token count, or null when the source measurement was absent.
+	InputTokens *int64 `json:"input_tokens"`
+
+	// OutputTokens Aggregate output-token count, or null when the source measurement was absent.
+	OutputTokens *int64 `json:"output_tokens"`
+
+	// ReasoningOutputTokens Aggregate reasoning-output subclass count, or null when no subclass measurement was present.
+	ReasoningOutputTokens *int64 `json:"reasoning_output_tokens"`
+
+	// TotalTokens Input tokens plus output tokens; subclass counts are not added a second time.
+	TotalTokens *int64 `json:"total_tokens"`
+}
+
+// CostsUnpricedPair defines model for CostsUnpricedPair.
+type CostsUnpricedPair struct {
+	// DispatchCount Distinct unpriced dispatches for this provider/model pair in the containing scope.
+	DispatchCount int `json:"dispatch_count"`
+
+	// Model Resolved model identity, or null when the usage identity was unavailable.
+	Model *string `json:"model"`
+
+	// Provider Canonical provider identity, or null when the usage identity was unavailable.
+	Provider *string `json:"provider"`
+}
 
 // Diagnostics defines model for Diagnostics.
 type Diagnostics struct {

--- a/pkg/transports/http/contracttests/openapi_contract_factory_validation_test.go
+++ b/pkg/transports/http/contracttests/openapi_contract_factory_validation_test.go
@@ -47,6 +47,16 @@ func TestOpenAPIContract_CostsReportIsTypedAndAmountsAreOptionalStrings(t *testi
 	doc := loadBundledOpenAPIDocument(t)
 	paths := objectField(t, doc, "paths")
 	operation := pathOperation(t, paths, "/metrics/costs", "get")
+	assertCostsOperation(t, operation)
+
+	schemas := componentSchemas(t, doc)
+	assertCostsReportSchema(t, schemas)
+	assertCostsTokenTotalsSchema(t, schemas)
+	assertCostsRollupSchema(t, schemas)
+}
+
+func assertCostsOperation(t *testing.T, operation map[string]any) {
+	t.Helper()
 	if operation["operationId"] != "getMetricsCosts" {
 		t.Fatalf("costs operationId = %v, want getMetricsCosts", operation["operationId"])
 	}
@@ -60,8 +70,10 @@ func TestOpenAPIContract_CostsReportIsTypedAndAmountsAreOptionalStrings(t *testi
 	}
 	assertResponseRef(t, operation, "400", "#/components/responses/BadRequest")
 	assertResponseRef(t, operation, "500", "#/components/responses/InternalError")
+}
 
-	schemas := componentSchemas(t, doc)
+func assertCostsReportSchema(t *testing.T, schemas map[string]any) {
+	t.Helper()
 	report := schemaObject(t, schemas, "CostsReport")
 	assertRequiredFields(t, report, "scope", "currency", "status", "known_cost", "token_totals", "unpriced_dispatch_count", "unpriced_pairs", "coverage", "line_items", "work_items", "worker_sessions", "provider_models", "factory_sessions")
 	reportProperties := schemaProperties(t, report, "CostsReport")
@@ -86,6 +98,10 @@ func TestOpenAPIContract_CostsReportIsTypedAndAmountsAreOptionalStrings(t *testi
 		t.Fatalf("CostsReport.status = %#v", reportProperties["status"])
 	}
 	assertEnumValues(t, status, "CostsReport.status", []string{"PRICED", "PARTIAL", "UNPRICED", "NO_USAGE"})
+}
+
+func assertCostsTokenTotalsSchema(t *testing.T, schemas map[string]any) {
+	t.Helper()
 	tokenTotals := schemaObject(t, schemas, "CostsTokenTotals")
 	assertRequiredFields(t, tokenTotals, "total_tokens", "input_tokens", "output_tokens", "cached_input_tokens", "reasoning_output_tokens")
 	for _, field := range []string{"total_tokens", "input_tokens", "output_tokens", "cached_input_tokens", "reasoning_output_tokens"} {
@@ -94,6 +110,10 @@ func TestOpenAPIContract_CostsReportIsTypedAndAmountsAreOptionalStrings(t *testi
 			t.Fatalf("CostsTokenTotals.%s = %#v, want nullable integer", field, property)
 		}
 	}
+}
+
+func assertCostsRollupSchema(t *testing.T, schemas map[string]any) {
+	t.Helper()
 	unpricedPair := schemaObject(t, schemas, "CostsUnpricedPair")
 	assertRequiredFields(t, unpricedPair, "provider", "model", "dispatch_count")
 	rollup := schemaObject(t, schemas, "CostsRollup")

--- a/pkg/transports/http/contracttests/openapi_contract_factory_validation_test.go
+++ b/pkg/transports/http/contracttests/openapi_contract_factory_validation_test.go
@@ -63,8 +63,12 @@ func TestOpenAPIContract_CostsReportIsTypedAndAmountsAreOptionalStrings(t *testi
 
 	schemas := componentSchemas(t, doc)
 	report := schemaObject(t, schemas, "CostsReport")
-	assertRequiredFields(t, report, "scope", "currency", "status", "coverage", "line_items", "work_items", "worker_sessions", "provider_models", "factory_sessions")
+	assertRequiredFields(t, report, "scope", "currency", "status", "known_cost", "token_totals", "unpriced_dispatch_count", "unpriced_pairs", "coverage", "line_items", "work_items", "worker_sessions", "provider_models", "factory_sessions")
 	reportProperties := schemaProperties(t, report, "CostsReport")
+	knownCost, ok := reportProperties["known_cost"].(map[string]any)
+	if !ok || knownCost["type"] != "string" || knownCost["nullable"] != true {
+		t.Fatalf("CostsReport.known_cost = %#v, want nullable string", reportProperties["known_cost"])
+	}
 	pricedSubtotal, ok := reportProperties["priced_subtotal"].(map[string]any)
 	if !ok || pricedSubtotal["type"] != "string" {
 		t.Fatalf("CostsReport.priced_subtotal = %#v, want optional string", reportProperties["priced_subtotal"])
@@ -82,6 +86,18 @@ func TestOpenAPIContract_CostsReportIsTypedAndAmountsAreOptionalStrings(t *testi
 		t.Fatalf("CostsReport.status = %#v", reportProperties["status"])
 	}
 	assertEnumValues(t, status, "CostsReport.status", []string{"PRICED", "PARTIAL", "UNPRICED", "NO_USAGE"})
+	tokenTotals := schemaObject(t, schemas, "CostsTokenTotals")
+	assertRequiredFields(t, tokenTotals, "total_tokens", "input_tokens", "output_tokens", "cached_input_tokens", "reasoning_output_tokens")
+	for _, field := range []string{"total_tokens", "input_tokens", "output_tokens", "cached_input_tokens", "reasoning_output_tokens"} {
+		property := schemaProperties(t, tokenTotals, "CostsTokenTotals")[field].(map[string]any)
+		if property["type"] != "integer" || property["nullable"] != true {
+			t.Fatalf("CostsTokenTotals.%s = %#v, want nullable integer", field, property)
+		}
+	}
+	unpricedPair := schemaObject(t, schemas, "CostsUnpricedPair")
+	assertRequiredFields(t, unpricedPair, "provider", "model", "dispatch_count")
+	rollup := schemaObject(t, schemas, "CostsRollup")
+	assertRequiredFields(t, rollup, "key", "currency", "status", "known_cost", "token_totals", "unpriced_dispatch_count", "unpriced_pairs", "coverage")
 }
 
 func TestGeneratedGoClientBuildsMetricsCostsRequestAndExposesTypedResponses(t *testing.T) {

--- a/pkg/transports/http/generated/server.gen.go
+++ b/pkg/transports/http/generated/server.gen.go
@@ -49,6 +49,11 @@ const (
 	CostsLineItemStatusUNPRICED CostsLineItemStatus = "UNPRICED"
 )
 
+// Defines values for CostsProviderModelRollupCurrency.
+const (
+	CostsProviderModelRollupCurrencyUSD CostsProviderModelRollupCurrency = "USD"
+)
+
 // Defines values for CostsProviderModelRollupStatus.
 const (
 	CostsProviderModelRollupStatusNOUSAGE  CostsProviderModelRollupStatus = "NO_USAGE"
@@ -68,6 +73,11 @@ const (
 	CostsReportStatusPARTIAL  CostsReportStatus = "PARTIAL"
 	CostsReportStatusPRICED   CostsReportStatus = "PRICED"
 	CostsReportStatusUNPRICED CostsReportStatus = "UNPRICED"
+)
+
+// Defines values for CostsRollupCurrency.
+const (
+	CostsRollupCurrencyUSD CostsRollupCurrency = "USD"
 )
 
 // Defines values for CostsRollupStatus.
@@ -1717,16 +1727,23 @@ type CostsLineItemStatus string
 type CostsProviderModelRollup struct {
 	CachedInputTokens *int64        `json:"cached_input_tokens,omitempty"`
 	Coverage          CostsCoverage `json:"coverage"`
-	InputTokens       *int64        `json:"input_tokens,omitempty"`
+
+	// Currency Currency of the known cost amount.
+	Currency    CostsProviderModelRollupCurrency `json:"currency"`
+	InputTokens *int64                           `json:"input_tokens,omitempty"`
 
 	// Key Stable public provider/model pair key in the form provider/model.
 	Key string `json:"key"`
+
+	// KnownCost Exact USD decimal for the priced portion of this provider/model rollup; PARTIAL never implies a complete total.
+	KnownCost *string `json:"known_cost"`
 
 	// Model Exact resolved model identity, when known.
 	Model        string `json:"model"`
 	OutputTokens *int64 `json:"output_tokens,omitempty"`
 
 	// PricedSubtotal Exact USD decimal subtotal; absent when no usage is priced.
+	// Deprecated: this property has been marked as deprecated upstream, but no `x-deprecated-reason` was set
 	PricedSubtotal *string `json:"priced_subtotal,omitempty"`
 
 	// Provider Canonical provider identity, when known.
@@ -1734,8 +1751,18 @@ type CostsProviderModelRollup struct {
 	ReasoningOutputTokens *int64 `json:"reasoning_output_tokens,omitempty"`
 
 	// Status PRICED means all usage rows for this provider/model are valued; PARTIAL means some are valued; UNPRICED means usage exists but none is valued; NO_USAGE means this pair has no usage rows.
-	Status CostsProviderModelRollupStatus `json:"status"`
+	Status      CostsProviderModelRollupStatus `json:"status"`
+	TokenTotals CostsTokenTotals               `json:"token_totals"`
+
+	// UnpricedDispatchCount Number of distinct dispatches whose usage is not fully valued for this provider/model.
+	UnpricedDispatchCount int `json:"unpriced_dispatch_count"`
+
+	// UnpricedPairs Deterministically ordered unpriced provider/model facts for this rollup.
+	UnpricedPairs []CostsUnpricedPair `json:"unpriced_pairs"`
 }
+
+// CostsProviderModelRollupCurrency Currency of the known cost amount.
+type CostsProviderModelRollupCurrency string
 
 // CostsProviderModelRollupStatus PRICED means all usage rows for this provider/model are valued; PARTIAL means some are valued; UNPRICED means usage exists but none is valued; NO_USAGE means this pair has no usage rows.
 type CostsProviderModelRollupStatus string
@@ -1750,10 +1777,14 @@ type CostsReport struct {
 	// FactorySessions Rollups keyed by Factory Session identity.
 	FactorySessions []CostsRollup `json:"factory_sessions"`
 
+	// KnownCost Exact USD decimal for the priced portion. Null means no usage row had a known price; PARTIAL never implies a complete total.
+	KnownCost *string `json:"known_cost"`
+
 	// LineItems Deterministically ordered canonical usage rows and their valuation status.
 	LineItems []CostsLineItem `json:"line_items"`
 
 	// PricedSubtotal Exact USD decimal subtotal for fully priced rows; absent when no row is priced.
+	// Deprecated: this property has been marked as deprecated upstream, but no `x-deprecated-reason` was set
 	PricedSubtotal *string `json:"priced_subtotal,omitempty"`
 
 	// ProviderModels Rollups keyed by canonical provider/model pair.
@@ -1761,7 +1792,14 @@ type CostsReport struct {
 	Scope          CostsScope                 `json:"scope"`
 
 	// Status PRICED means every usage row is valued; PARTIAL means some rows are valued; UNPRICED means usage exists but none is valued; NO_USAGE means no canonical usage rows were encountered. Missing price is never represented as zero.
-	Status CostsReportStatus `json:"status"`
+	Status      CostsReportStatus `json:"status"`
+	TokenTotals CostsTokenTotals  `json:"token_totals"`
+
+	// UnpricedDispatchCount Number of distinct dispatches whose usage is not fully valued.
+	UnpricedDispatchCount int `json:"unpriced_dispatch_count"`
+
+	// UnpricedPairs Deterministically ordered provider/model pairs contributing unpriced dispatches; null identities are explicit unknowns.
+	UnpricedPairs []CostsUnpricedPair `json:"unpriced_pairs"`
 
 	// WorkItems Rollups keyed by Work item identity.
 	WorkItems []CostsRollup `json:"work_items"`
@@ -1780,19 +1818,36 @@ type CostsReportStatus string
 type CostsRollup struct {
 	CachedInputTokens *int64        `json:"cached_input_tokens,omitempty"`
 	Coverage          CostsCoverage `json:"coverage"`
-	InputTokens       *int64        `json:"input_tokens,omitempty"`
+
+	// Currency Currency of the known cost amount.
+	Currency    CostsRollupCurrency `json:"currency"`
+	InputTokens *int64              `json:"input_tokens,omitempty"`
 
 	// Key Stable dimension key for this rollup.
-	Key          string `json:"key"`
-	OutputTokens *int64 `json:"output_tokens,omitempty"`
+	Key string `json:"key"`
+
+	// KnownCost Exact USD decimal for the priced portion of this rollup; PARTIAL never implies a complete total.
+	KnownCost    *string `json:"known_cost"`
+	OutputTokens *int64  `json:"output_tokens,omitempty"`
 
 	// PricedSubtotal Exact USD decimal subtotal; absent when no usage is priced.
+	// Deprecated: this property has been marked as deprecated upstream, but no `x-deprecated-reason` was set
 	PricedSubtotal        *string `json:"priced_subtotal,omitempty"`
 	ReasoningOutputTokens *int64  `json:"reasoning_output_tokens,omitempty"`
 
 	// Status PRICED means all usage rows in the rollup are valued; PARTIAL means some are valued; UNPRICED means usage exists but none is valued; NO_USAGE means no canonical usage rows were encountered.
-	Status CostsRollupStatus `json:"status"`
+	Status      CostsRollupStatus `json:"status"`
+	TokenTotals CostsTokenTotals  `json:"token_totals"`
+
+	// UnpricedDispatchCount Number of distinct dispatches whose usage is not fully valued in this rollup.
+	UnpricedDispatchCount int `json:"unpriced_dispatch_count"`
+
+	// UnpricedPairs Deterministically ordered provider/model pairs contributing unpriced dispatches in this rollup.
+	UnpricedPairs []CostsUnpricedPair `json:"unpriced_pairs"`
 }
+
+// CostsRollupCurrency Currency of the known cost amount.
+type CostsRollupCurrency string
 
 // CostsRollupStatus PRICED means all usage rows in the rollup are valued; PARTIAL means some are valued; UNPRICED means usage exists but none is valued; NO_USAGE means no canonical usage rows were encountered.
 type CostsRollupStatus string
@@ -1808,6 +1863,36 @@ type CostsScope struct {
 
 // CostsScopeKind Selection scope used to produce the report.
 type CostsScopeKind string
+
+// CostsTokenTotals defines model for CostsTokenTotals.
+type CostsTokenTotals struct {
+	// CachedInputTokens Aggregate cached-input subclass count, or null when no subclass measurement was present.
+	CachedInputTokens *int64 `json:"cached_input_tokens"`
+
+	// InputTokens Aggregate input-token count, or null when the source measurement was absent.
+	InputTokens *int64 `json:"input_tokens"`
+
+	// OutputTokens Aggregate output-token count, or null when the source measurement was absent.
+	OutputTokens *int64 `json:"output_tokens"`
+
+	// ReasoningOutputTokens Aggregate reasoning-output subclass count, or null when no subclass measurement was present.
+	ReasoningOutputTokens *int64 `json:"reasoning_output_tokens"`
+
+	// TotalTokens Input tokens plus output tokens; subclass counts are not added a second time.
+	TotalTokens *int64 `json:"total_tokens"`
+}
+
+// CostsUnpricedPair defines model for CostsUnpricedPair.
+type CostsUnpricedPair struct {
+	// DispatchCount Distinct unpriced dispatches for this provider/model pair in the containing scope.
+	DispatchCount int `json:"dispatch_count"`
+
+	// Model Resolved model identity, or null when the usage identity was unavailable.
+	Model *string `json:"model"`
+
+	// Provider Canonical provider identity, or null when the usage identity was unavailable.
+	Provider *string `json:"provider"`
+}
 
 // Diagnostics defines model for Diagnostics.
 type Diagnostics struct {

--- a/pkg/wire/session_runtime_providers.go
+++ b/pkg/wire/session_runtime_providers.go
@@ -630,15 +630,20 @@ func provideRuntimeMetricsQueryCapability(
 	return runtimeMetricsQueryCapability{query: query}, nil
 }
 
-// provideCostsQuery composes valuation over the existing canonical metrics
-// query and the narrow Operator Settings document reader. Costs reads no
-// artifacts or configuration directly.
+// provideProviderPriceTableReader exposes the immutable pricing facts owned by
+// Providers. It is separate from the configurable Operator Settings document.
+func provideProviderPriceTableReader() (providers.PriceTableReader, error) {
+	return providerswire.NewPriceTableReader()
+}
+
+// provideCostsQuery composes valuation over canonical metrics and the narrow
+// Providers pricing reader. Costs reads no artifacts or operator files.
 func provideCostsQuery(
-	settings operatorsettings.Service,
+	pricing providers.PriceTableReader,
 	metrics factoryvisualization.RuntimeMetricsQuery,
 	logger logging.Logger,
 ) (costs.CostsQuery, error) {
-	return costswire.NewCostsQuery(settings, metrics, logger)
+	return costswire.NewCostsQuery(pricing, metrics, logger)
 }
 
 func provideCostsQueryCapability(

--- a/pkg/wire/session_runtime_providers.go
+++ b/pkg/wire/session_runtime_providers.go
@@ -632,14 +632,14 @@ func provideRuntimeMetricsQueryCapability(
 
 // provideProviderPriceTableReader exposes the immutable pricing facts owned by
 // Providers. It is separate from the configurable Operator Settings document.
-func provideProviderPriceTableReader() (providers.PriceTableReader, error) {
+func provideProviderPriceTableReader() (providers.PriceTableReaderFunc, error) {
 	return providerswire.NewPriceTableReader()
 }
 
 // provideCostsQuery composes valuation over canonical metrics and the narrow
 // Providers pricing reader. Costs reads no artifacts or operator files.
 func provideCostsQuery(
-	pricing providers.PriceTableReader,
+	pricing costs.PriceTableReader,
 	metrics factoryvisualization.RuntimeMetricsQuery,
 	logger logging.Logger,
 ) (costs.CostsQuery, error) {

--- a/pkg/wire/session_runtime_providers.go
+++ b/pkg/wire/session_runtime_providers.go
@@ -632,7 +632,7 @@ func provideRuntimeMetricsQueryCapability(
 
 // provideProviderPriceTableReader exposes the immutable pricing facts owned by
 // Providers. It is separate from the configurable Operator Settings document.
-func provideProviderPriceTableReader() (providers.PriceTableReaderFunc, error) {
+func provideProviderPriceTableReader() (costs.PriceTableReader, error) {
 	return providerswire.NewPriceTableReader()
 }
 

--- a/pkg/wire/wire.go
+++ b/pkg/wire/wire.go
@@ -150,6 +150,7 @@ var servicesSet = wire.NewSet(
 	provideFactoryVisualizationMetricsQuery,
 	provideRuntimeMetricsQueryCapability,
 	provideFactorySessionExecutionRuntimeOpening,
+	provideProviderPriceTableReader,
 	provideCostsQuery,
 	provideCostsQueryCapability,
 	provideFactorySessionsRuntimeAssembly,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -537,11 +537,15 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	handler := http.NewHandler(httpAdapter, logger)
 	contentPreparation := work.NewContentPreparation()
 	requestPreparation := provideFactorySessionHTTPRequestPreparation(v69)
+	priceTableReader, err := provideProviderPriceTableReader()
+	if err != nil {
+		return nil, err
+	}
 	runtimeMetricsQuery, err := provideFactoryVisualizationMetricsQuery(loggingLogger)
 	if err != nil {
 		return nil, err
 	}
-	costsQuery, err := provideCostsQuery(operatorsettingsService, runtimeMetricsQuery, loggingLogger)
+	costsQuery, err := provideCostsQuery(priceTableReader, runtimeMetricsQuery, loggingLogger)
 	if err != nil {
 		return nil, err
 	}
@@ -926,6 +930,7 @@ var servicesSet = wire5.NewSet(
 	provideFactoryVisualizationMetricsQuery,
 	provideRuntimeMetricsQueryCapability,
 	provideFactorySessionExecutionRuntimeOpening,
+	provideProviderPriceTableReader,
 	provideCostsQuery,
 	provideCostsQueryCapability,
 	provideFactorySessionsRuntimeAssembly,

--- a/tests/functional/factory/visualization/runtime_metrics/costs_cli_test.go
+++ b/tests/functional/factory/visualization/runtime_metrics/costs_cli_test.go
@@ -21,7 +21,6 @@ func TestMetricsCostsCLITraversesProductionHTTPRoute(t *testing.T) {
 	homeDir := t.TempDir()
 	factoryDir := support.ScaffoldSingleStepFactory(t, "costs-cli-functional")
 	const sessionID = "costs-session-functional"
-	writeCostsFunctionalOperatorConfig(t, homeDir)
 	writeCostsFunctionalMetrics(t, homeDir, sessionID)
 
 	environment := append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
@@ -64,8 +63,8 @@ func TestMetricsCostsCLITraversesProductionHTTPRoute(t *testing.T) {
 	if report.Status != generatedclient.CostsReportStatus("PARTIAL") {
 		t.Fatalf("report status = %q, want PARTIAL", report.Status)
 	}
-	if report.PricedSubtotal == nil || *report.PricedSubtotal != "15.175" {
-		t.Fatalf("priced subtotal = %v, want exact 15.175 USD", report.PricedSubtotal)
+	if report.PricedSubtotal == nil || *report.PricedSubtotal != "21.1375" {
+		t.Fatalf("priced subtotal = %v, want exact 21.1375 USD", report.PricedSubtotal)
 	}
 	if report.Coverage.EncounteredRows != 2 || report.Coverage.PricedRows != 1 ||
 		report.Coverage.UnpricedRows != 1 || report.Coverage.EncounteredProviderModels != 2 ||
@@ -84,18 +83,6 @@ func TestMetricsCostsCLITraversesProductionHTTPRoute(t *testing.T) {
 	functionalevidence.Covers(t, "cli/you.metrics.costs")
 }
 
-func writeCostsFunctionalOperatorConfig(t *testing.T, homeDir string) {
-	t.Helper()
-	path := filepath.Join(homeDir, ".you-agent-factory", "config.json")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("create operator config directory: %v", err)
-	}
-	const config = `{"priceTable":{"currency":"USD","models":[{"provider":"CODEX","model":"gpt-5","inputPerMillionTokens":"2.5","outputPerMillionTokens":"5.25","cachedInputPerMillionTokens":"0.5","reasoningOutputPerMillionTokens":"10"}]}}`
-	if err := os.WriteFile(path, []byte(config), 0o600); err != nil {
-		t.Fatalf("write operator price table: %v", err)
-	}
-}
-
 func writeCostsFunctionalMetrics(t *testing.T, homeDir, sessionID string) {
 	t.Helper()
 	root := platformmetrics.RuntimeMetricsRoot(homeDir)
@@ -104,7 +91,7 @@ func writeCostsFunctionalMetrics(t *testing.T, homeDir, sessionID string) {
 			"metric_name": metricName, "value": value, "unit": "tokens",
 			"session_id": sessionID, "runtime_instance_id": "runtime-costs-functional",
 			"work_id": "work-known", "dispatch_id": "dispatch-known",
-			"worker_session_id": "worker-known", "provider": "CODEX", "model": "gpt-5",
+			"worker_session_id": "worker-known", "provider": "CODEX", "model": "gpt-5-codex",
 			"workstation": "build", "worker_type": "processor",
 		}
 	}

--- a/tests/functional/factory/visualization/runtime_metrics/end_to_end_costs_test.go
+++ b/tests/functional/factory/visualization/runtime_metrics/end_to_end_costs_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	endToEndPricedModel   = "gpt-5"
+	endToEndPricedModel   = "gpt-5-codex"
 	endToEndUnpricedModel = "mystery-model"
 )
 
@@ -46,7 +46,6 @@ func TestRuntimeCostsEndToEndFromProviderCompletion(t *testing.T) {
 		30*time.Second,
 		func(configuredHome string) {
 			homeDir = configuredHome
-			writeCostsFunctionalOperatorConfig(t, configuredHome)
 		},
 	)
 	if homeDir == "" {
@@ -79,17 +78,17 @@ func TestRuntimeCostsEndToEndFromProviderCompletion(t *testing.T) {
 	if report.Currency != generatedclient.CostsReportCurrency("USD") {
 		t.Fatalf("cost report currency = %q, want USD", report.Currency)
 	}
-	if report.PricedSubtotal == nil || *report.PricedSubtotal != "13" {
-		t.Fatalf("priced subtotal = %v, want exact 13 USD", report.PricedSubtotal)
+	if report.PricedSubtotal == nil || *report.PricedSubtotal != "21.25" {
+		t.Fatalf("priced subtotal = %v, want exact 21.25 USD", report.PricedSubtotal)
 	}
 	if report.Coverage.EncounteredRows != 2 || report.Coverage.PricedRows != 1 ||
 		report.Coverage.UnpricedRows != 1 || report.Coverage.EncounteredProviderModels != 2 ||
 		report.Coverage.PricedProviderModels != 1 || report.Coverage.UnpricedProviderModels != 1 {
 		t.Fatalf("cost report coverage = %#v, want one priced and one unpriced row/model", report.Coverage)
 	}
-	assertCostLineItem(t, report, endToEndPricedModel, generatedclient.CostsLineItemStatus("PRICED"), "13")
+	assertCostLineItem(t, report, endToEndPricedModel, generatedclient.CostsLineItemStatus("PRICED"), "21.25")
 	assertCostLineItem(t, report, endToEndUnpricedModel, generatedclient.CostsLineItemStatus("UNPRICED"), "")
-	if !strings.Contains(output, `"status":"UNPRICED"`) || !strings.Contains(output, `"priced_subtotal":"13"`) {
+	if !strings.Contains(output, `"status":"UNPRICED"`) || !strings.Contains(output, `"priced_subtotal":"21.25"`) {
 		t.Fatalf("public costs JSON omitted priced or unpriced evidence: %s", output)
 	}
 
@@ -108,7 +107,6 @@ func TestRuntimeCostsNoUsageThroughPublicCLI(t *testing.T) {
 	if err := os.MkdirAll(platformmetrics.RuntimeMetricsRoot(homeDir), 0o755); err != nil {
 		t.Fatalf("create empty runtime metrics root: %v", err)
 	}
-	writeCostsFunctionalOperatorConfig(t, homeDir)
 	factoryDir := support.ScaffoldSingleStepFactory(t, "costs-no-usage-functional")
 
 	report, output := queryCostsReport(t, factoryDir, homeDir, "")

--- a/ui/packages/client/src/generated/openapi.ts
+++ b/ui/packages/client/src/generated/openapi.ts
@@ -10,6 +10,26 @@
  */
 
 export interface paths {
+  "/metrics": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get canonical runtime metrics
+     * @description Reads the canonical Factory Visualization metrics projection. The default scope covers all retained Factory Sessions. When session_id is supplied, the server resolves that public live Factory Session ID through Factory Sessions before reading retained metrics; it never guesses a scope from the current working directory or definition. A valid resolved scope with no retained facts returns an explicit empty report.
+     */
+    get: operations["getMetrics"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/metrics/costs": {
     parameters: {
       query?: never;
@@ -640,6 +660,26 @@ export interface paths {
     get: operations["listModels"];
     put?: never;
     post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/models/invocations": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Invoke a model through the generic contract
+     * @description Invokes a configured model or supported source reference through the provider-neutral Models contract. Ordered inputs and named outputs remain detached from backend and cache details.
+     */
+    post: operations["invokeGenericModel"];
     delete?: never;
     options?: never;
     head?: never;
@@ -1834,6 +1874,41 @@ export interface components {
       /** @description Distinct provider/model pairs with one or more unpriced rows. */
       unpriced_provider_models: number;
     };
+    CostsTokenTotals: {
+      /**
+       * Format: int64
+       * @description Input tokens plus output tokens; subclass counts are not added a second time.
+       */
+      total_tokens: number | null;
+      /**
+       * Format: int64
+       * @description Aggregate input-token count, or null when the source measurement was absent.
+       */
+      input_tokens: number | null;
+      /**
+       * Format: int64
+       * @description Aggregate output-token count, or null when the source measurement was absent.
+       */
+      output_tokens: number | null;
+      /**
+       * Format: int64
+       * @description Aggregate cached-input subclass count, or null when no subclass measurement was present.
+       */
+      cached_input_tokens: number | null;
+      /**
+       * Format: int64
+       * @description Aggregate reasoning-output subclass count, or null when no subclass measurement was present.
+       */
+      reasoning_output_tokens: number | null;
+    };
+    CostsUnpricedPair: {
+      /** @description Canonical provider identity, or null when the usage identity was unavailable. */
+      provider: string | null;
+      /** @description Resolved model identity, or null when the usage identity was unavailable. */
+      model: string | null;
+      /** @description Distinct unpriced dispatches for this provider/model pair in the containing scope. */
+      dispatch_count: number;
+    };
     CostsLineItem: {
       factory_session_id?: string;
       work_id?: string;
@@ -1862,6 +1937,11 @@ export interface components {
     CostsRollup: {
       /** @description Stable dimension key for this rollup. */
       key: string;
+      /**
+       * @description Currency of the known cost amount.
+       * @enum {string}
+       */
+      currency: CostsRollupCurrency;
       /** Format: int64 */
       input_tokens?: number;
       /** Format: int64 */
@@ -1875,8 +1955,18 @@ export interface components {
        * @enum {string}
        */
       status: CostsRollupStatus;
-      /** @description Exact USD decimal subtotal; absent when no usage is priced. */
+      /** @description Exact USD decimal for the priced portion of this rollup; PARTIAL never implies a complete total. */
+      known_cost: string | null;
+      /**
+       * @deprecated
+       * @description Exact USD decimal subtotal; absent when no usage is priced.
+       */
       priced_subtotal?: string;
+      token_totals: components["schemas"]["CostsTokenTotals"];
+      /** @description Number of distinct dispatches whose usage is not fully valued in this rollup. */
+      unpriced_dispatch_count: number;
+      /** @description Deterministically ordered provider/model pairs contributing unpriced dispatches in this rollup. */
+      unpriced_pairs: components["schemas"]["CostsUnpricedPair"][];
       coverage: components["schemas"]["CostsCoverage"];
     };
     CostsProviderModelRollup: {
@@ -1886,6 +1976,11 @@ export interface components {
       model: string;
       /** @description Stable public provider/model pair key in the form provider/model. */
       key: string;
+      /**
+       * @description Currency of the known cost amount.
+       * @enum {string}
+       */
+      currency: CostsProviderModelRollupCurrency;
       /** Format: int64 */
       input_tokens?: number;
       /** Format: int64 */
@@ -1899,8 +1994,18 @@ export interface components {
        * @enum {string}
        */
       status: CostsProviderModelRollupStatus;
-      /** @description Exact USD decimal subtotal; absent when no usage is priced. */
+      /** @description Exact USD decimal for the priced portion of this provider/model rollup; PARTIAL never implies a complete total. */
+      known_cost: string | null;
+      /**
+       * @deprecated
+       * @description Exact USD decimal subtotal; absent when no usage is priced.
+       */
       priced_subtotal?: string;
+      token_totals: components["schemas"]["CostsTokenTotals"];
+      /** @description Number of distinct dispatches whose usage is not fully valued for this provider/model. */
+      unpriced_dispatch_count: number;
+      /** @description Deterministically ordered unpriced provider/model facts for this rollup. */
+      unpriced_pairs: components["schemas"]["CostsUnpricedPair"][];
       coverage: components["schemas"]["CostsCoverage"];
     };
     CostsReport: {
@@ -1915,8 +2020,18 @@ export interface components {
        * @enum {string}
        */
       status: CostsReportStatus;
-      /** @description Exact USD decimal subtotal for fully priced rows; absent when no row is priced. */
+      /** @description Exact USD decimal for the priced portion. Null means no usage row had a known price; PARTIAL never implies a complete total. */
+      known_cost: string | null;
+      /**
+       * @deprecated
+       * @description Exact USD decimal subtotal for fully priced rows; absent when no row is priced.
+       */
       priced_subtotal?: string;
+      token_totals: components["schemas"]["CostsTokenTotals"];
+      /** @description Number of distinct dispatches whose usage is not fully valued. */
+      unpriced_dispatch_count: number;
+      /** @description Deterministically ordered provider/model pairs contributing unpriced dispatches; null identities are explicit unknowns. */
+      unpriced_pairs: components["schemas"]["CostsUnpricedPair"][];
       coverage: components["schemas"]["CostsCoverage"];
       /** @description Deterministically ordered canonical usage rows and their valuation status. */
       line_items: components["schemas"]["CostsLineItem"][];
@@ -1928,6 +2043,66 @@ export interface components {
       provider_models: components["schemas"]["CostsProviderModelRollup"][];
       /** @description Rollups keyed by Factory Session identity. */
       factory_sessions: components["schemas"]["CostsRollup"][];
+    };
+    MetricsScope: {
+      /** @description Selection scope used to produce the report: ALL_FACTORY_SESSIONS or FACTORY_SESSION. */
+      kind: string;
+      /** @description Public Factory Session identity when kind is FACTORY_SESSION. */
+      factory_session_id?: string;
+    };
+    MetricsCost: {
+      /** @description Cost is unavailable on the canonical metrics projection; no numeric price is implied. */
+      availability: string;
+    };
+    MetricsDuration: {
+      unit: string;
+      samples: number;
+      /** Format: double */
+      p50?: number | null;
+      /** Format: double */
+      p95?: number | null;
+    };
+    MetricsAggregate: {
+      /** Format: double */
+      input_tokens: number;
+      /** Format: double */
+      output_tokens: number;
+      /** Format: double */
+      completed_dispatches: number;
+      failures_by_reason: {
+        [key: string]: number;
+      };
+      dispatch_latency: components["schemas"]["MetricsDuration"];
+      provider_latency: components["schemas"]["MetricsDuration"];
+    };
+    MetricsBreakdown: {
+      key: string;
+      aggregate: components["schemas"]["MetricsAggregate"];
+    };
+    MetricsUsageRow: {
+      factory_session_id?: string;
+      work_id?: string;
+      dispatch_id?: string;
+      worker_session_id?: string;
+      provider?: string;
+      model?: string;
+      /** Format: int64 */
+      input_tokens?: number;
+      /** Format: int64 */
+      output_tokens?: number;
+      /** Format: int64 */
+      cached_input_tokens?: number;
+      /** Format: int64 */
+      reasoning_output_tokens?: number;
+    };
+    MetricsReport: {
+      scope: components["schemas"]["MetricsScope"];
+      cost: components["schemas"]["MetricsCost"];
+      totals: components["schemas"]["MetricsAggregate"];
+      workstations: components["schemas"]["MetricsBreakdown"][];
+      worker_types: components["schemas"]["MetricsBreakdown"][];
+      providers: components["schemas"]["MetricsBreakdown"][];
+      usage_rows: components["schemas"]["MetricsUsageRow"][];
     };
     WorkerSessionProviderSessionRef: {
       /** @description Provider identity that issued the correlated session. */
@@ -7688,6 +7863,15 @@ export interface components {
         "application/json": components["schemas"]["ErrorResponse"];
       };
     };
+    /** @description The selected live Factory Session has no retained metrics scope. */
+    MetricsSessionScopeUnavailable: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": components["schemas"]["ErrorResponse"];
+      };
+    };
   };
   parameters: {
     /** @description Stable live factory session identifier. Use `~default` to target the default compatibility session explicitly. */
@@ -7767,6 +7951,32 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+  getMetrics: {
+    parameters: {
+      query?: {
+        /** @description Optional discoverable live Factory Session identity. */
+        session_id?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Canonical runtime metrics for the selected scope. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["MetricsReport"];
+        };
+      };
+      400: components["responses"]["BadRequest"];
+      404: components["responses"]["NotFound"];
+      503: components["responses"]["MetricsSessionScopeUnavailable"];
+    };
+  };
   getMetricsCosts: {
     parameters: {
       query?: {
@@ -8808,6 +9018,33 @@ export interface operations {
           "application/json": components["schemas"]["ListModelsResponse"];
         };
       };
+      500: components["responses"]["InternalError"];
+    };
+  };
+  invokeGenericModel: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["GenericModelInvocationRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful generic model invocation result. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GenericModelInvocationResponse"];
+        };
+      };
+      400: components["responses"]["BadRequest"];
+      404: components["responses"]["NotFound"];
       500: components["responses"]["InternalError"];
     };
   };
@@ -10031,6 +10268,11 @@ export const CostsLineItemStatus = {
 } as const;
 export type CostsLineItemStatus =
   (typeof CostsLineItemStatus)[keyof typeof CostsLineItemStatus];
+export const CostsRollupCurrency = {
+  USD: "USD",
+} as const;
+export type CostsRollupCurrency =
+  (typeof CostsRollupCurrency)[keyof typeof CostsRollupCurrency];
 export const CostsRollupStatus = {
   PRICED: "PRICED",
   PARTIAL: "PARTIAL",
@@ -10039,6 +10281,11 @@ export const CostsRollupStatus = {
 } as const;
 export type CostsRollupStatus =
   (typeof CostsRollupStatus)[keyof typeof CostsRollupStatus];
+export const CostsProviderModelRollupCurrency = {
+  USD: "USD",
+} as const;
+export type CostsProviderModelRollupCurrency =
+  (typeof CostsProviderModelRollupCurrency)[keyof typeof CostsProviderModelRollupCurrency];
 export const CostsProviderModelRollupStatus = {
   PRICED: "PRICED",
   PARTIAL: "PARTIAL",
@@ -10296,13 +10543,19 @@ export const ErrorResponseCode = {
   WORKER_SESSION_RECORDING_UNAVAILABLE: "WORKER_SESSION_RECORDING_UNAVAILABLE",
   // Provider Sessions could not project the normalized Worker Session transcript.
   WORKER_SESSION_STREAM_UNAVAILABLE: "WORKER_SESSION_STREAM_UNAVAILABLE",
-  // The requested resource does not exist.
+  // The metrics request could not be interpreted by the canonical metrics route.
   WORKER_SESSION_TRANSCRIPT_ACTIVE: "WORKER_SESSION_TRANSCRIPT_ACTIVE",
-  // The server failed while handling an otherwise valid request.
+  // The requested live Factory Session identity was not discoverable.
   WORKER_SESSION_TRANSCRIPT_UNAVAILABLE:
     "WORKER_SESSION_TRANSCRIPT_UNAVAILABLE",
+  // The live Factory Session was discoverable, but no retained metrics scope was available.
   WORKER_SESSION_TRANSCRIPT_PROJECTION_UNAVAILABLE:
     "WORKER_SESSION_TRANSCRIPT_PROJECTION_UNAVAILABLE",
+  // The requested resource does not exist.
+  METRICS_INVALID_REQUEST: "METRICS_INVALID_REQUEST",
+  // The server failed while handling an otherwise valid request.
+  METRICS_SESSION_NOT_FOUND: "METRICS_SESSION_NOT_FOUND",
+  METRICS_SESSION_SCOPE_UNAVAILABLE: "METRICS_SESSION_SCOPE_UNAVAILABLE",
   NOT_FOUND: "NOT_FOUND",
   INTERNAL_ERROR: "INTERNAL_ERROR",
 } as const;

--- a/ui/src/api/generated/openapi.ts
+++ b/ui/src/api/generated/openapi.ts
@@ -1868,6 +1868,41 @@ export interface components {
       /** @description Distinct provider/model pairs with one or more unpriced rows. */
       unpriced_provider_models: number;
     };
+    CostsTokenTotals: {
+      /**
+       * Format: int64
+       * @description Input tokens plus output tokens; subclass counts are not added a second time.
+       */
+      total_tokens: number | null;
+      /**
+       * Format: int64
+       * @description Aggregate input-token count, or null when the source measurement was absent.
+       */
+      input_tokens: number | null;
+      /**
+       * Format: int64
+       * @description Aggregate output-token count, or null when the source measurement was absent.
+       */
+      output_tokens: number | null;
+      /**
+       * Format: int64
+       * @description Aggregate cached-input subclass count, or null when no subclass measurement was present.
+       */
+      cached_input_tokens: number | null;
+      /**
+       * Format: int64
+       * @description Aggregate reasoning-output subclass count, or null when no subclass measurement was present.
+       */
+      reasoning_output_tokens: number | null;
+    };
+    CostsUnpricedPair: {
+      /** @description Canonical provider identity, or null when the usage identity was unavailable. */
+      provider: string | null;
+      /** @description Resolved model identity, or null when the usage identity was unavailable. */
+      model: string | null;
+      /** @description Distinct unpriced dispatches for this provider/model pair in the containing scope. */
+      dispatch_count: number;
+    };
     CostsLineItem: {
       factory_session_id?: string;
       work_id?: string;
@@ -1896,6 +1931,11 @@ export interface components {
     CostsRollup: {
       /** @description Stable dimension key for this rollup. */
       key: string;
+      /**
+       * @description Currency of the known cost amount.
+       * @enum {string}
+       */
+      currency: CostsRollupCurrency;
       /** Format: int64 */
       input_tokens?: number;
       /** Format: int64 */
@@ -1909,8 +1949,18 @@ export interface components {
        * @enum {string}
        */
       status: CostsRollupStatus;
-      /** @description Exact USD decimal subtotal; absent when no usage is priced. */
+      /** @description Exact USD decimal for the priced portion of this rollup; PARTIAL never implies a complete total. */
+      known_cost: string | null;
+      /**
+       * @deprecated
+       * @description Exact USD decimal subtotal; absent when no usage is priced.
+       */
       priced_subtotal?: string;
+      token_totals: components["schemas"]["CostsTokenTotals"];
+      /** @description Number of distinct dispatches whose usage is not fully valued in this rollup. */
+      unpriced_dispatch_count: number;
+      /** @description Deterministically ordered provider/model pairs contributing unpriced dispatches in this rollup. */
+      unpriced_pairs: components["schemas"]["CostsUnpricedPair"][];
       coverage: components["schemas"]["CostsCoverage"];
     };
     CostsProviderModelRollup: {
@@ -1920,6 +1970,11 @@ export interface components {
       model: string;
       /** @description Stable public provider/model pair key in the form provider/model. */
       key: string;
+      /**
+       * @description Currency of the known cost amount.
+       * @enum {string}
+       */
+      currency: CostsProviderModelRollupCurrency;
       /** Format: int64 */
       input_tokens?: number;
       /** Format: int64 */
@@ -1933,8 +1988,18 @@ export interface components {
        * @enum {string}
        */
       status: CostsProviderModelRollupStatus;
-      /** @description Exact USD decimal subtotal; absent when no usage is priced. */
+      /** @description Exact USD decimal for the priced portion of this provider/model rollup; PARTIAL never implies a complete total. */
+      known_cost: string | null;
+      /**
+       * @deprecated
+       * @description Exact USD decimal subtotal; absent when no usage is priced.
+       */
       priced_subtotal?: string;
+      token_totals: components["schemas"]["CostsTokenTotals"];
+      /** @description Number of distinct dispatches whose usage is not fully valued for this provider/model. */
+      unpriced_dispatch_count: number;
+      /** @description Deterministically ordered unpriced provider/model facts for this rollup. */
+      unpriced_pairs: components["schemas"]["CostsUnpricedPair"][];
       coverage: components["schemas"]["CostsCoverage"];
     };
     CostsReport: {
@@ -1949,8 +2014,18 @@ export interface components {
        * @enum {string}
        */
       status: CostsReportStatus;
-      /** @description Exact USD decimal subtotal for fully priced rows; absent when no row is priced. */
+      /** @description Exact USD decimal for the priced portion. Null means no usage row had a known price; PARTIAL never implies a complete total. */
+      known_cost: string | null;
+      /**
+       * @deprecated
+       * @description Exact USD decimal subtotal for fully priced rows; absent when no row is priced.
+       */
       priced_subtotal?: string;
+      token_totals: components["schemas"]["CostsTokenTotals"];
+      /** @description Number of distinct dispatches whose usage is not fully valued. */
+      unpriced_dispatch_count: number;
+      /** @description Deterministically ordered provider/model pairs contributing unpriced dispatches; null identities are explicit unknowns. */
+      unpriced_pairs: components["schemas"]["CostsUnpricedPair"][];
       coverage: components["schemas"]["CostsCoverage"];
       /** @description Deterministically ordered canonical usage rows and their valuation status. */
       line_items: components["schemas"]["CostsLineItem"][];
@@ -10187,6 +10262,11 @@ export const CostsLineItemStatus = {
 } as const;
 export type CostsLineItemStatus =
   (typeof CostsLineItemStatus)[keyof typeof CostsLineItemStatus];
+export const CostsRollupCurrency = {
+  USD: "USD",
+} as const;
+export type CostsRollupCurrency =
+  (typeof CostsRollupCurrency)[keyof typeof CostsRollupCurrency];
 export const CostsRollupStatus = {
   PRICED: "PRICED",
   PARTIAL: "PARTIAL",
@@ -10195,6 +10275,11 @@ export const CostsRollupStatus = {
 } as const;
 export type CostsRollupStatus =
   (typeof CostsRollupStatus)[keyof typeof CostsRollupStatus];
+export const CostsProviderModelRollupCurrency = {
+  USD: "USD",
+} as const;
+export type CostsProviderModelRollupCurrency =
+  (typeof CostsProviderModelRollupCurrency)[keyof typeof CostsProviderModelRollupCurrency];
 export const CostsProviderModelRollupStatus = {
   PRICED: "PRICED",
   PARTIAL: "PARTIAL",


### PR DESCRIPTION
{
  "project": "Provider-Attached Price Table and First-Class Partial Cost Reporting",
  "branchName": "obs-13-provider-price-table-and-partial-costs",
  "description": "Attach a sourced declarative token-price table to Providers and make partial cost reporting a truthful first-class contract. Reports and rollups always retain token totals, distinguish exact known cost from unknown coverage, render mixed results as `$X.XX + ?? unknown`, and expose known cost, token totals, unpriced dispatch count, and unpriced provider/model pairs as distinct JSON fields without taking over obs-11 session/attribution or obs-12 cost-emission and CLI-failure work.",
  "context": {
    "customerAsk": "Own the provider-attached price table, its sourced data, and the partial/mixed cost-reporting contract, including `$X.XX + ?? unknown` human output and an unambiguous JSON shape. Do not populate Metrics.Cost, fix the metrics CLI failure, change metrics session scope, or change provider attribution; those behaviors belong to obs-12 and obs-11.",
    "problem": "The runtime records input, output, cached-input, and reasoning-output token usage with provider/model and dispatch lineage, yet August 2026 evidence found no emitted cost records. The current Costs path reads operator-authored prices instead of Providers-owned facts and does not expose total tokens, unpriced dispatch count, and unpriced pairs as required first-class report fields. Mixed human output can show a known subtotal without the owner-specified visible unknown suffix, so partial values can be mistaken for complete costs.",
    "solution": "Give Providers a validated, declarative, read-only USD price catalog keyed by canonical provider/model, with separate per-million rates and authoritative source/date provenance. Populate only live-observed pairs with authoritative prices. Have Costs consume that narrow provider contract and produce exact known cost, invariant token totals, status, unpriced dispatch count, and deterministic unpriced pairs at report and rollup scope. Align authored OpenAPI, generated clients, JSON, and CLI rendering for fully priced, none-priced, mixed, and unknown-model behavior while preserving sibling-lane ownership."
  },
  "acceptanceCriteria": [
    "A Providers-owned declarative table supplies USD per-million-token prices by canonical provider/model and input, output, cached-input, and reasoning-output class; every shipped row has an authoritative source URL and as-of date, explicitly states intentionally equal class rates, and only covers live-observed pairs for which authoritative prices were found.",
    "Every report and every Work, Worker Session, provider/model, and Factory Session rollup exposes total_tokens plus all four token-class totals regardless of price coverage; total_tokens is input plus output and never double-counts cached-input or reasoning-output subclasses.",
    "Human output proves all four cases: all-priced shows exact known cost and tokens; none-priced shows tokens and an explicit unknown marker and never $0.00; mixed shows `$X.XX + ?? unknown` with unpriced dispatch count and pairs; an unknown model enters the unpriced bucket without error or silent zero.",
    "The public JSON contract exposes status, currency, known_cost, token_totals, unpriced_dispatch_count, and unpriced_pairs as distinct fields at report and rollup scope; PARTIAL retains the exact priced portion and cannot serialize like a complete total.",
    "The implementation does not populate Metrics.Cost, change dispatch.cost or provider.cost emission guards, repair the obs-12 metrics CLI failure path, or alter obs-11 metrics session scope/provider attribution; authored and generated reporting contracts remain synchronized.",
    "Quality gates pass: focused Providers pricing, Costs valuation, transport contract, CLI rendering, and four-case behavioral tests; Typecheck passes; Tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "obs-13-provider-price-table-and-partial-costs-001",
      "title": "Publish sourced provider pricing facts",
      "description": "As a maintainer, I want token prices to be sourced, dated Providers-owned data so pricing coverage can expand without changing valuation logic or creating a second authority.",
      "acceptanceCriteria": [
        "Derive the provider/model inventory from the live metrics dataset named in the customer evidence and record the observation date and pair counts in the PR body; do not guess pairings from registrations or catalogs.",
        "The Providers pricing contract returns detached entries keyed by canonical provider/model with USD per-million-token rates for input, output, cached-input, and reasoning-output usage.",
        "Every shipped entry contains an authoritative pricing source URL and ISO-8601 as-of date; pairs without authoritative prices remain absent rather than estimated.",
        "Cached-input or reasoning-output rates equal to a standard class are explicitly represented and documented; omission means unknown rather than zero or inheritance.",
        "Duplicate canonical pairs, malformed or negative rates, unsupported currency, missing provenance, and incomplete class declarations fail deterministic validation before valuation.",
        "Adding a supported model price requires a provider-owned declarative data edit only and no model-specific lookup, valuation, transport, or renderer branch.",
        "The PR body explains Providers ownership with the service-ownership rationale and lists observed pairs deliberately left unpriced because no authoritative source was available.",
        "Focused tests prove canonical lookup, detached results, provenance validation, explicit equal-rate handling, and absent unknown pairs.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Moved shipped pricing into the Providers-owned validated PriceTableReader and declarative providers/wire data. The live 2026-08-22 observation set used two real-factory pairs (CODEX/gpt-5-codex, 192 rows; CODEX/OMNIVOICE_Q4_K_M, 12 rows) plus fixture-only codex/fixture-model, claude/test-model, antigravity/gemini-3.6-flash-high, and claude/claude-sonnet-4 pairs; only CODEX/gpt-5-codex has authoritative published token pricing. Its OpenAI source URL/as-of date, cached-input rate, and explicit reasoning-output/output equality are validated and returned through detached Providers reads. Costs no longer reads Operator Settings pricing, and the legacy settings default is empty for consistent absent-file layering."
    },
    {
      "id": "obs-13-provider-price-table-and-partial-costs-002",
      "title": "Return complete token and partial valuation facts",
      "description": "As an API or automation consumer, I want cost reports to separate known money from unknown coverage so I can use partial results without treating them as complete.",
      "acceptanceCriteria": [
        "The Costs operation consumes the narrow Providers price reader and does not read an operator-authored or parallel price registry as its canonical source.",
        "The report and every Work, Worker Session, provider/model, and Factory Session rollup contain status, currency, nullable exact-decimal known_cost, token_totals, unpriced_dispatch_count, and unpriced_pairs as distinct fields.",
        "token_totals always contains total_tokens, input_tokens, output_tokens, cached_input_tokens, and reasoning_output_tokens; total_tokens equals input plus output and does not double-count subclasses.",
        "Fully priced usage produces PRICED with an exact known cost and empty unpriced coverage; entirely unpriced usage produces UNPRICED with no known cost, complete tokens, and actionable unpriced coverage.",
        "Mixed usage produces PARTIAL, retains the exact priced portion and all tokens, and reports the unpriced dispatch count plus each distinct unpriced provider/model pair with its dispatch count.",
        "An unknown model, absent pair, or positive token subclass lacking an explicit rate becomes unpriced without error or zero substitution; known zero/free usage remains distinguishable from unknown.",
        "Unpriced pairs are canonicalized, deduplicated, and deterministically ordered, while missing identities remain explicitly unknown instead of disappearing.",
        "Authored OpenAPI, boundary mapping, generated Go and TypeScript clients, and contract tests share the same required and nullable semantics and reject ambiguous partial shapes.",
        "Focused tests cover all-priced, none-priced, mixed, unknown-model, explicit-zero, and missing-class-rate cases, including a regression assertion that fails if PARTIAL serializes like a complete total.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Extended the existing exact-decimal Costs valuation with known_cost, required nullable token_totals, unpriced dispatch counts, and deterministic canonical unpriced provider/model pairs at report and every rollup scope. Authored OpenAPI, generated Go/TypeScript clients, boundary mappings, and focused all-priced/none-priced/mixed/unknown-model/explicit-zero/missing-class-rate/deduplication regressions are synchronized. Refactored changed assertions to satisfy pkg-maint and restored the narrow Costs-side consumer port while Providers remains the pricing authority. Affected Providers, Costs, Operator Settings, and Wire tests plus go vet pass; repository UI typecheck and two unrelated HTTP contract tests remain baseline failures outside this diff."
    },
    {
      "id": "obs-13-provider-price-table-and-partial-costs-003",
      "title": "Render unmistakable complete and partial costs",
      "description": "As an operator, I want cost output to show known money and missing coverage together so I can act on useful partial information without being misled.",
      "acceptanceCriteria": [
        "Fully priced human output shows the known USD cost and total and class token counts without an unknown marker.",
        "Entirely unpriced human output shows all token totals, `?? unknown`, the unpriced dispatch count, and unpriced provider/model pairs and never renders $0.00 as the cost for unknown usage.",
        "Mixed human output renders the primary summary in the exact form `$X.XX + ?? unknown` and lists the unpriced dispatch count and deterministically ordered unpriced provider/model pairs.",
        "An unknown model is shown as an unpriced provider/model pair and the command succeeds rather than erroring or silently valuing it at zero.",
        "--json emits the structured contract without human formatting, and a mixed fixture visibly contains separate known_cost, token_totals, unpriced_dispatch_count, and unpriced_pairs fields.",
        "Valuation uses exact decimal arithmetic; human USD formatting applies one documented deterministic cent-rounding rule without changing the exact JSON decimal.",
        "CLI tests paste or golden-compare all-priced, none-priced, mixed, and unknown-model output, including a regression test that fails if partial output loses `+ ?? unknown`.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Updated human Costs rendering to show rounded known USD cost, explicit `?? unknown` coverage, report and rollup token totals, unpriced dispatch counts, and deterministically ordered provider/model pairs. Replaced substring-only CLI assertions and the temporary output logger with exact full-output golden comparisons for all-priced, none-priced, mixed, and unknown-model cases, including the `$X.XX + ?? unknown` suffix and pair ordering. Focused Costs tests, go vet, and diff checks pass."
    },
    {
      "id": "obs-13-provider-price-table-and-partial-costs-004",
      "title": "Integrate the contract without crossing sibling-lane boundaries",
      "description": "As a reviewer, I want end-to-end evidence for the price-data and partial-reporting contract so it can merge safely alongside the session/attribution and cost-emission lanes.",
      "acceptanceCriteria": [
        "A public-boundary behavioral test supplies canonical usage for all-priced, none-priced, mixed, and unknown-model scenarios and proves report, JSON, and human outcomes without relying on populated Metrics.Cost records.",
        "Mixed-case evidence includes `$X.XX + ?? unknown`, total and class token counts, exact known JSON decimal, unpriced dispatch count, and the complete unpriced pair list.",
        "Focused regression coverage proves token totals are invariant when identical usage is evaluated with full, partial, or empty pricing coverage.",
        "Metrics session filtering, provider/model attribution, cost-record emission, and the obs-12-owned CLI failure behavior remain unchanged.",
        "Generated artifacts come only from authored contracts through repository generators and are reconciled with current origin/main without hand-merging generated files.",
        "Open the PR ready for review by the second or third implementation iteration, rebase the final branch onto current origin/main, and do not introduce an implementation commit containing prd.json, progress.txt, stash state, or daemon reconfiguration.",
        "Focused tests and applicable API contract smoke coverage pass, with reviewer-verifiable project-level lint and CI evidence and no unrelated cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Added a public-boundary behavioral regression using canonical UsageRows only (Metrics.Cost remains unset) and driving valuation through the HTTP JSON boundary and CLI human/--json surfaces for all-priced, none-priced, mixed, and unknown-model cases. Captured primary human summaries are PRICED/$11.75, UNPRICED/?? unknown, PARTIAL/$11.75 + ?? unknown, and UNPRICED/CODEX/unknown-model; the same test proves report and rollup token totals remain complete, and a full/partial/empty pricing regression proves token totals are invariant. Removed the Providers root second-interface structure finding, regenerated staged API package artifacts through repository generators, split exact CLI goldens under maintainability limits, fixed the stale rebased Costs fixture, made the Wire consumer-port binding explicit, and rebased onto current origin/main. Post-rebase affected tests, API smoke, contract staging, wire-smoke, pkg-maint, pkg-file-count, pkg-structure, and targeted go vet pass; backend-size reports only the pre-existing untouched cmd/gocoveragecheck violation, while the broad aggregate retains the known unrelated Codex adapter timeout baseline. Addressed review feedback by switching production-route fixtures to the shipped codex/gpt-5-codex provider row, removing operator price-table setup, updating exact expected amounts, and correcting docs/reference/metrics.md to describe Providers-owned pricing and partial fields; the full runtime_metrics package and make docs-reference-smoke pass. Rebased again onto current origin/main ca8334afa after review requested the stale-base update; the rebased focused tests, vet, docs smoke, and make interfaces-all are clean. After the later generated-artifact conflict, rebased onto current origin/main b005f4f3, regenerated through make interfaces-all, and confirmed focused tests, runtime-metrics, docs/API smoke, vet, and generator drift checks pass. Final integration rebased onto current origin/main 74e1d634, regenerated the conflicted package manifest through make interfaces-all, and confirmed the second generator pass, merge-tree, affected tests, targeted vet, runtime-metrics, API smoke, and docs smoke are clean; final head 6bc7bd5fb was force-pushed to PR #2162 and required CI started in run 32562542672."
    }
  ]
}
