### PR TITLE
coverage: assert a functional floor instead of asserting nothing

### DIFF
--- a/cmd/gocoveragecheck/manifest_default_floor.go
+++ b/cmd/gocoveragecheck/manifest_default_floor.go
@@ -11,15 +11,31 @@ import (
 // is held to its lane's default floor instead of failing the manifest
 // completeness check, so adding a package no longer requires a manifest edit.
 //
-// The values come from the measured distribution of existing floors: the unit
+// Both values come from the measured distribution of existing floors: the unit
 // lane's tenth percentile is 50.00, so a new package that reaches the default
-// sits in the bottom decile rather than failing on arrival. Functional tests
-// exercise flows rather than packages, so a positive functional default would
-// fail ordinary packages en masse; 0.00 keeps a package measured and reported
-// without demanding that a flow reach it.
+// sits in the bottom decile rather than failing on arrival.
+//
+// The functional default was 0.00, justified on the grounds that a positive
+// default would fail ordinary packages en masse. That is a statement about
+// blast radius, not about correctness, and it made the functional gate assert
+// nothing for any unregistered package. Functional tests exist to prove
+// systematic correctness end to end, so a package no functional flow reaches is
+// precisely the package worth reporting: if nothing exercises it, there is no
+// evidence the system works when it is involved.
+//
+// The cost of the old default is concrete. pkg/services/costs and its
+// internal/service and transports/http packages all sat at zero functional
+// coverage, and a price table that defaulted to zero models produced no cost
+// figure at all for a month while every unit test passed. Nothing exercised
+// that path end to end, and nothing was required to.
+//
+// 15.00 is the tenth percentile of the functional floors of packages that ARE
+// exercised (the whole-population tenth percentile is 0.00, which is itself the
+// finding). It is deliberately a low bar meaning "some flow genuinely reaches
+// this package", not unit-like density, and it is expected to ratchet upward.
 const (
 	unitLaneDefaultFloorPercent       = "50.00"
-	functionalLaneDefaultFloorPercent = "0.00"
+	functionalLaneDefaultFloorPercent = "15.00"
 )
 
 // laneDefaultCoverageFloor reports the built-in default floor for lane. It is

--- a/cmd/gocoveragecheck/manifest_default_floor_test.go
+++ b/cmd/gocoveragecheck/manifest_default_floor_test.go
@@ -14,15 +14,15 @@ func TestCoverageDefaultFloorIsLaneSpecific(t *testing.T) {
 	if got := laneDefaultCoverageFloor("unit").String(); got != "50.00" {
 		t.Fatalf("unit lane default = %s, want 50.00", got)
 	}
-	if got := laneDefaultCoverageFloor("functional").String(); got != "0.00" {
-		t.Fatalf("functional lane default = %s, want 0.00", got)
+	if got := laneDefaultCoverageFloor("functional").String(); got != "15.00" {
+		t.Fatalf("functional lane default = %s, want 15.00", got)
 	}
 	unitManifest := coverageManifest{Lane: "unit"}
 	if got := unitManifest.defaultFloor().String(); got != "50.00" {
 		t.Fatalf("unit manifest without defaultFloorPercent = %s, want the unit lane default", got)
 	}
 	functionalManifest := coverageManifest{Lane: "functional"}
-	if got := functionalManifest.defaultFloor().String(); got != "0.00" {
+	if got := functionalManifest.defaultFloor().String(); got != "15.00" {
 		t.Fatalf("functional manifest without defaultFloorPercent = %s, want the functional lane default", got)
 	}
 	declared := coverageManifest{Lane: "functional", DefaultFloorPercent: json.RawMessage("25.00")}
@@ -73,14 +73,26 @@ func TestCheckCoverageDefaultFloorEvaluatesUnlistedPackagesPerLane(t *testing.T)
 			rejectText:  "floor-source=lane-default",
 		},
 		{
-			name:   "functional unlisted at the unit-failing measurement passes its 0.00 default",
+			name:   "functional unlisted at the unit-failing measurement passes its lower functional default",
 			lane:   "functional",
 			totals: packageCoverageTotals{coveredStatements: 40, totalStatements: 100},
 		},
 		{
-			name:   "functional unlisted with no covered statements passes",
+			// The point of the functional lane default. A package that has
+			// measurable statements and that NO functional flow reaches is the
+			// case most worth reporting: nothing proves the system works when
+			// that package is involved. This previously passed under a 0.00
+			// default, which is how packages like pkg/services/costs carried
+			// zero end-to-end coverage indefinitely.
+			name:        "functional unlisted that no flow reaches is reported",
+			lane:        "functional",
+			totals:      packageCoverageTotals{coveredStatements: 0, totalStatements: 100},
+			wantFailure: "package coverage regression: package=" + unlisted + " lane=functional floor-source=lane-default expected-minimum=15.00% actual=0.0000% delta=-15.0000 percentage-points covered=0/100 statements",
+		},
+		{
+			name:   "functional unlisted with no measurable statements still passes vacuously",
 			lane:   "functional",
-			totals: packageCoverageTotals{coveredStatements: 0, totalStatements: 100},
+			totals: packageCoverageTotals{coveredStatements: 0, totalStatements: 0},
 		},
 		{
 			name:         "functional unlisted below a declared default fails",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "lane": "functional",
-  "defaultFloorPercent": 0.00,
+  "defaultFloorPercent": 15.00,
   "packages": [
     {
       "package": "github.com/portpowered/infinite-you/pkg/initializer/application",


### PR DESCRIPTION
> **Stacked on #2163** (`operator-restore-blocking-coverage-floors`) so this measurement runs
> with enforcement actually blocking. Retarget to `main` once #2163 merges.

## The problem

The functional lane default floor was `0.00`, justified in the code as:

> Functional tests exercise flows rather than packages, so a positive functional default would
> fail ordinary packages en masse.

That is a statement about **blast radius, not about correctness**. Its effect was that the
functional gate asserted *nothing* for any package without an explicit manifest entry.

Functional tests exist to prove systematic correctness end to end. A package that no functional
flow reaches is the case **most** worth reporting: if nothing exercises it, there is no
evidence the system works when that package is involved.

## The cost is already paid

`pkg/services/costs`, `pkg/services/costs/internal/service` and
`pkg/services/costs/transports/http` all sit at **zero** functional coverage.

A price table that defaulted to zero models produced **no cost figure at all for a month**
while every unit test passed — because nothing exercised that path end to end, and nothing was
required to. The same list includes `pkg/services/automations/internal/services/hosted_sources`
and 83 others.

## Measured state of the functional lane

| | count |
|---|---|
| Registered packages pinned at exactly `0.00` | 86 of 354 |
| Measured packages with no entry at all, held to the `0.00` default | 119 |
| **Total with no effective functional gate** | **205 of ~475 (43%)** |

## The change

Functional default `0.00` → **`15.00`**, the tenth percentile of the functional floors of
packages that *are* exercised. (The whole-population tenth percentile is `0.00` — which is
itself the finding.) Deliberately a low bar meaning "some flow genuinely reaches this package",
not unit-like density, and expected to ratchet upward.

Unchanged: explicit entries always win; a manifest-level `defaultFloorPercent` overrides the
built-in default; **a package with no measurable statements still passes vacuously**, since a
floor cannot be evaluated against an empty denominator. That case now has its own test so it
can never be conflated with the zero-coverage case.

## On the test changes

The two failing tests encoded the *old policy*, so they had to move. They were updated to
assert the new intent, not to accommodate it — the case previously named
`functional unlisted with no covered statements passes` now asserts that such a package **is
reported**, which is the entire point of this PR. `go test ./cmd/gocoveragecheck/` passes.

## Read this PR's CI as the measurement

This newly gates the **119** packages that currently pass vacuously. That blast radius is
unknown until measured, and this PR is the measurement. The diagnostics name every package,
lane, expected minimum, actual and delta.

If the number is large, that is the finding rather than a reason to revert: it is the count of
packages the system cannot currently prove it exercises. The dial to turn is the `15.00`
constant, and burning down the 86 explicitly zero-pinned packages is separate follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
