### PR TITLE
fix(runtime): reject unknown JavaScript worker presets

### DIFF
--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/callbehavior_inventory_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/callbehavior_inventory_test.go
@@ -259,10 +259,16 @@ func testAgentRunInventoryErrors(t *testing.T, record callbehavior.CallBehaviorR
 		t.Run(errCase.Condition, func(t *testing.T) {
 			source := agentRunErrorSource(errCase.Condition)
 			if source == "" {
-				t.Skip("condition not observable from installed JS host surface")
+				t.Fatalf("missing inline source for inventory error condition %q", errCase.Condition)
 			}
 			outcome := runInlineWorkflowFailure(t, "agent-run-"+errCase.Condition, source)
 			assertInventoryFailureMessage(t, outcome, errCase.Message)
+			if errCase.Condition == "unknown-preset" {
+				const want = `agent.run() references unknown operator worker preset "definitely-not-a-preset" from agent.run`
+				if !strings.Contains(outcome.Failure.Message, want) {
+					t.Fatalf("failure message = %q, want source-specific TypeError message %q", outcome.Failure.Message, want)
+				}
+			}
 			assertNoChildDispatchRecords(t, outcome.Records)
 		})
 	}
@@ -602,7 +608,7 @@ func agentRunErrorSource(condition string) string {
 	case "missing-prompt":
 		return `const child = {}; child.label = "missing-prompt"; return agent.run(child);`
 	case "unknown-preset":
-		return ""
+		return `return agent.run({ prompt: "review", preset: "definitely-not-a-preset" });`
 	case "unsupported-model-provider":
 		return `return agent.run({ prompt: "review", modelProvider: "Not_A_Provider" });`
 	case "unsupported-reasoning-effort":

--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/child_execution.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/child_execution.go
@@ -77,7 +77,7 @@ func ResolveChildWorkerSettings(req ChildExecutionRequest, agents map[string]int
 	if selectedPreset != "" {
 		var ok bool
 		preset, ok = config.Presets[selectedPreset]
-		if !ok && source == "factory agent" {
+		if !ok {
 			return ChildExecutionRequest{}, fmt.Errorf("agent.run() references unknown operator worker preset %q from %s", selectedPreset, source)
 		}
 	}

--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_children_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_children_test.go
@@ -151,9 +151,9 @@ func TestResolveChildWorkerSettings_CanonicalizesExplicitModelProvider(t *testin
 }
 
 func TestResolveChildWorkerSettings_UnknownPresetNamesSource(t *testing.T) {
-	got, err := workflowruntime.ResolveChildWorkerSettings(factory.JavaScriptChildExecutionRequest{Preset: "missing"}, nil, factory.JavaScriptWorkerSettings{})
-	if err != nil || got.Preset != "missing" {
-		t.Fatalf("explicit child preset = %#v, error = %v", got, err)
+	_, err := workflowruntime.ResolveChildWorkerSettings(factory.JavaScriptChildExecutionRequest{Preset: "missing"}, nil, factory.JavaScriptWorkerSettings{})
+	if err == nil || !strings.Contains(err.Error(), `"missing" from agent.run`) {
+		t.Fatalf("explicit child preset error = %v, want source-specific unknown-preset diagnostic", err)
 	}
 	_, err = workflowruntime.ResolveChildWorkerSettings(factory.JavaScriptChildExecutionRequest{AgentID: "reviewer"}, map[string]interfaces.FactoryOrchestratorJavaScriptAgent{"reviewer": {Preset: "missing"}}, factory.JavaScriptWorkerSettings{})
 	if err == nil || !strings.Contains(err.Error(), `"missing" from factory agent`) {

--- a/tests/fixtures/javascript_runtime/agent-run-fake-child.workflow.js
+++ b/tests/fixtures/javascript_runtime/agent-run-fake-child.workflow.js
@@ -3,7 +3,6 @@ return (async function () {
   const child = await agent.run({
     prompt: "summarize workflows",
     label: "summarize-findings",
-    preset: "careful",
     modelProvider: "codex",
     model: "gpt-test",
     reasoningEffort: "medium",


### PR DESCRIPTION
{
  "project": "Reject Unknown agent.run() Worker Presets",
  "branchName": "js-agent-run-unknown-preset",
  "description": "Make unknown worker-preset validation unconditional for JavaScript agent.run() calls so inline and factory-authored preset typos both stop the workflow with the published TypeError, retain source-specific diagnostics, emit no child dispatch, and are proven through the installed JavaScript host without changing the already-correct contract or other call behaviors.",
  "context": {
    "customerAsk": "Reject an unknown worker preset from either supported preset source, convert the existing explicit-preset test from acceptance to rejection, and prove through an actual JavaScript workflow call that the installed agent.run() host surfaces the contract's TypeError. Resolve the stale unknown-preset inventory skip without changing the contract, descriptor, or any other call behavior.",
    "problem": "Preset resolution currently reports an unknown name only when it came from a factory-authored agent. The same unknown name supplied inline to agent.run() bypasses the error branch, allowing the run to proceed with unintended settings and no diagnostic. A package test encodes that defect as expected success, while the contract inventory test marks the condition unobservable despite the host's TypeError translation path.",
    "solution": "Apply unknown-preset validation to every non-empty selected preset while retaining the existing source text in the diagnostic. Update regression coverage so both agent.run and factory agent sources are rejected and named. Give the contract inventory's unknown-preset case an inline workflow source, execute it through the installed JavaScript host, and assert the observable TypeError message and absence of child dispatch records."
  },
  "acceptanceCriteria": [
    "A non-empty preset name absent from operator worker presets is rejected whether it is supplied inline by agent.run() or selected from a factory-authored agent, and each error identifies the selected name and its source.",
    "An installed-host workflow call using agent.run({ prompt: \"review\", preset: \"definitely-not-a-preset\" }) fails before child dispatch with a JavaScript TypeError whose observed message includes agent.run() references unknown operator worker preset \"definitely-not-a-preset\" from agent.run.",
    "The unknown-preset call-behavior inventory case executes rather than skips, matches the existing contract text, and asserts that no child dispatch record is emitted; unrelated call behaviors remain unchanged.",
    "Production and test changes are confined to javascript/runtime/child_execution.go, runtime/host_children_test.go, and runtime/callbehavior_inventory_test.go under Factory Runtime, plus the existing integration fixture tests/fixtures/javascript_runtime/agent-run-fake-child.workflow.js whose stale unconfigured preset selection is removed while its explicit settings remain; contracts/javascript/runtime-api.json and callbehavior/descriptor.go remain unchanged, with no generated-contract churn, preset-resolution redesign, source rename, other call-behavior change, or unrelated cleanup.",
    "Final quality gate: Typecheck passes; Tests pass for the focused JavaScript runtime package and required repository verification; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. The customer-identified inherited backend-size and cmd/contractscheck failures are documented with matching main evidence rather than investigated or changed in this lane, and allowed deadcode and packaged-factory-consumption baselines are not modified.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. Before its final push, implementation rebases onto current origin/main; the PR is opened ready for review, never as a draft."
  ],
  "userStories": [
    {
      "id": "js-agent-run-unknown-preset-001",
      "title": "Surface unknown presets as an agent.run() TypeError",
      "description": "As a JavaScript workflow author, I want every unknown worker preset to stop agent.run() with a clear TypeError so a typo cannot silently run a child with unintended settings.",
      "acceptanceCriteria": [
        "Resolving a missing inline preset returns an error containing \"missing\" from agent.run instead of a successful request, while a missing factory-agent preset continues to return an error containing \"missing\" from factory agent.",
        "Both source cases use the same unknown-preset rule after source selection; valid presets and empty preset selection retain their established behavior.",
        "An actual inline workflow call agent.run({ prompt: \"review\", preset: \"definitely-not-a-preset\" }) fails through the installed JavaScript host as a TypeError with the observed message agent.run() references unknown operator worker preset \"definitely-not-a-preset\" from agent.run.",
        "The end-to-end failure occurs before execution and emits no child_dispatch record.",
        "The unknown-preset inventory case has executable JavaScript source and no longer takes the generic condition-not-observable skip; its message assertion continues to derive from the existing inventory contract.",
        "contracts/javascript/runtime-api.json and callbehavior/descriptor.go are not changed, and no other call behavior is changed.",
        "The focused regression test is demonstrated to fail on the parent behavior and pass after the fix, with the observed JavaScript error message quoted in the pull request.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implementation and review follow-up are complete locally: the shared real-backend fixture no longer selects the unconfigured careful preset, the focused runtime and UI backend integration checks pass, parent reproduction evidence is recorded, and the PR remains open for the final pushed head."
    }
  ]
}
