### PR TITLE
feat(automations): durable cursors and watcher diagnostics

### DIFF
--- a/pkg/services/automations/internal/runtime_lifecycle.go
+++ b/pkg/services/automations/internal/runtime_lifecycle.go
@@ -166,6 +166,36 @@ func (s *Service) ActivateRuntime(
 	}, nil
 }
 
+func (s *Service) getCursorFromActiveRuntime(
+	ctx context.Context,
+	request automations.GetCursorRequest,
+) (automations.GetCursorResult, bool, error) {
+	if s == nil {
+		return automations.GetCursorResult{}, false, nil
+	}
+	s.runtimeMu.Lock()
+	instances := make([]*runtimeInstance, 0, len(s.runtimes))
+	for _, instance := range s.runtimes {
+		instances = append(instances, instance)
+	}
+	s.runtimeMu.Unlock()
+
+	for _, instance := range instances {
+		if instance == nil || instance.owner == nil || instance.owner == s {
+			continue
+		}
+		result, err := instance.owner.GetCursor(ctx, request)
+		if err == nil {
+			return result, true, nil
+		}
+		if errors.Is(err, automations.ErrNotFound) {
+			continue
+		}
+		return automations.GetCursorResult{}, true, err
+	}
+	return automations.GetCursorResult{}, false, nil
+}
+
 func (s *Service) StartRuntime(ctx context.Context, runtimeID string) error {
 	runtimeID = strings.TrimSpace(runtimeID)
 	if runtimeID == "" {

--- a/pkg/services/automations/internal/runtime_lifecycle.go
+++ b/pkg/services/automations/internal/runtime_lifecycle.go
@@ -24,6 +24,7 @@ type runtimeInstance struct {
 	owner            *Service
 	runtimeConfig    *runtimeSnapshotConfig
 	watcher          automations.FilesystemWatcher
+	watcherRoot      string
 	submit           automations.WorkRequestSubmitter
 	startSchedulers  bool
 	ctx              context.Context
@@ -347,12 +348,14 @@ func (s *Service) buildRuntimeInstance(
 	filesystemInputs := request.Inputs.Filesystem
 	if filesystemInputs.Files != nil && filesystemInputs.WalkDirectory != nil &&
 		filesystemInputs.WorkRequestIDs != nil && request.Inputs.Submitter != nil {
-		instance.watcher = owner.NewFilesystemWatcher(runtimeFilesystemConfig(
+		watcherConfig := runtimeFilesystemConfig(
 			request.Snapshot.FactoryDir,
 			filesystemInputs,
 			s.logger(),
 			request.Inputs.Submitter,
-		))
+		)
+		instance.watcherRoot = watcherConfig.Dir
+		instance.watcher = owner.NewFilesystemWatcher(watcherConfig)
 	}
 	if instance.watcher != nil {
 		if err := instance.watcher.PreseedInputs(ctx); err != nil {
@@ -437,10 +440,36 @@ func (instance *runtimeInstance) start(ctx context.Context) error {
 		instance.sidecars.Add(1)
 		go func() {
 			defer instance.sidecars.Done()
-			_ = instance.watcher.Watch(instance.ctx)
+			instance.observeWatcherTermination(instance.watcher.Watch(instance.ctx))
 		}()
 	}
 	return nil
+}
+
+func (instance *runtimeInstance) observeWatcherTermination(err error) {
+	if instance == nil {
+		return
+	}
+	if instance.ctx != nil && instance.ctx.Err() != nil {
+		return
+	}
+	if errors.Is(err, context.Canceled) {
+		return
+	}
+
+	fields := []zap.Field{
+		zap.String("runtime_id", instance.runtimeID),
+		zap.String("watch_root", instance.watcherRoot),
+	}
+	logger := instance.owner.logger()
+	if err != nil {
+		logger.Error("filesystem watcher stopped with error", append(fields, zap.Error(err))...)
+		return
+	}
+	logger.Warn(
+		"filesystem watcher stopped unexpectedly",
+		append(fields, zap.String("reason", "event stream closed"))...,
+	)
 }
 
 func (instance *runtimeInstance) stop(ctx context.Context) error {

--- a/pkg/services/automations/internal/runtime_lifecycle.go
+++ b/pkg/services/automations/internal/runtime_lifecycle.go
@@ -322,9 +322,9 @@ func (s *Service) buildRuntimeInstance(
 	if strings.TrimSpace(workflowID) == "" {
 		workflowID = s.workflowID
 	}
-	owner := New(
+	owner := NewWithCursorFileSystem(
 		s.logger(), s.clock, s.commandRunner(), workflowID, request.Snapshot.FactoryDir,
-		s.hostedPollers, s.resolveTemplates, s.executionPolicy,
+		s.hostedPollers, s.resolveTemplates, s.executionPolicy, s.cursorFileSystem,
 	)
 	if owner == nil {
 		return nil, runtimeLifecycleError(

--- a/pkg/services/automations/internal/runtime_lifecycle_test.go
+++ b/pkg/services/automations/internal/runtime_lifecycle_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestRuntimeLifecycle_IsolatesOwnersAndClassifiesDuplicates(t *testing.T) {
@@ -131,6 +133,117 @@ func TestRuntimeLifecycle_StartsAndStopsSchedulerOwnership(t *testing.T) {
 	if _, err := service.DeactivateRuntime(context.Background(), automations.RuntimeDeactivationRequest{RuntimeID: request.RuntimeID}); err != nil {
 		t.Fatalf("DeactivateRuntime() error = %v", err)
 	}
+}
+
+func TestRuntimeLifecycle_ReportsFilesystemWatcherTermination(t *testing.T) {
+	watchErr := errors.New("watch sidecar failed with distinctive detail")
+	tests := []struct {
+		name       string
+		watch      func(context.Context) error
+		message    string
+		level      zapcore.Level
+		reason     string
+		errorValue string
+	}{
+		{
+			name:       "error",
+			watch:      func(context.Context) error { return watchErr },
+			message:    "filesystem watcher stopped with error",
+			level:      zapcore.ErrorLevel,
+			errorValue: watchErr.Error(),
+		},
+		{
+			name:    "event stream closure",
+			watch:   func(context.Context) error { return nil },
+			message: "filesystem watcher stopped unexpectedly",
+			level:   zapcore.WarnLevel,
+			reason:  "event stream closed",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logCore, observedLogs := observer.New(zap.InfoLevel)
+			instance, cancel := runtimeInstanceForWatcherTest(zap.New(logCore), test.watch)
+			defer cancel()
+
+			if err := instance.start(context.Background()); err != nil {
+				t.Fatalf("runtimeInstance.start() error = %v", err)
+			}
+			instance.sidecars.Wait()
+
+			entries := observedLogs.FilterMessage(test.message).All()
+			if len(entries) != 1 {
+				t.Fatalf("%s logs = %d, want 1", test.message, len(entries))
+			}
+			entry := entries[0]
+			if entry.Level != test.level {
+				t.Fatalf("termination log level = %v, want %v", entry.Level, test.level)
+			}
+			contextMap := entry.ContextMap()
+			if got := contextMap["runtime_id"]; got != "runtime-watcher-diagnostic" {
+				t.Fatalf("runtime_id = %#v, want runtime-watcher-diagnostic", got)
+			}
+			if got := contextMap["watch_root"]; got != "/factories/example/inputs" {
+				t.Fatalf("watch_root = %#v, want /factories/example/inputs", got)
+			}
+			if test.reason != "" && contextMap["reason"] != test.reason {
+				t.Fatalf("termination reason = %#v, want %s", contextMap["reason"], test.reason)
+			}
+			if test.errorValue != "" && contextMap["error"] != test.errorValue {
+				t.Fatalf("termination error = %#v, want %s", contextMap["error"], test.errorValue)
+			}
+		})
+	}
+}
+
+func TestRuntimeLifecycle_DoesNotReportFilesystemWatcherCancellation(t *testing.T) {
+	logCore, observedLogs := observer.New(zap.InfoLevel)
+	instance, cancel := runtimeInstanceForWatcherTest(zap.New(logCore), func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	if err := instance.start(context.Background()); err != nil {
+		t.Fatalf("runtimeInstance.start() error = %v", err)
+	}
+	cancel()
+	instance.sidecars.Wait()
+
+	if got := observedLogs.FilterMessage("filesystem watcher stopped with error").Len(); got != 0 {
+		t.Fatalf("watcher error logs after context cancellation = %d, want 0", got)
+	}
+	if got := observedLogs.FilterMessage("filesystem watcher stopped unexpectedly").Len(); got != 0 {
+		t.Fatalf("watcher terminal logs after context cancellation = %d, want 0", got)
+	}
+}
+
+type runtimeLifecycleWatcher struct {
+	watch func(context.Context) error
+}
+
+func (w runtimeLifecycleWatcher) PreseedInputs(context.Context) error { return nil }
+
+func (w runtimeLifecycleWatcher) Watch(ctx context.Context) error {
+	if w.watch == nil {
+		return nil
+	}
+	return w.watch(ctx)
+}
+
+func runtimeInstanceForWatcherTest(
+	logger *zap.Logger,
+	watch func(context.Context) error,
+) (*runtimeInstance, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &runtimeInstance{
+		runtimeID:   "runtime-watcher-diagnostic",
+		watcherRoot: "/factories/example/inputs",
+		owner:       New(logger, nil, nil, "", "", nil, nil, nil),
+		watcher:     runtimeLifecycleWatcher{watch: watch},
+		ctx:         ctx,
+		cancel:      cancel,
+	}, cancel
 }
 
 func TestRuntimeLifecycle_SnapshotConfigAndInputHelpers(t *testing.T) {

--- a/pkg/services/automations/internal/service.go
+++ b/pkg/services/automations/internal/service.go
@@ -10,6 +10,7 @@ package internal
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 
 	"github.com/jonboulle/clockwork"
@@ -142,7 +143,10 @@ func newService(
 
 func (s *Service) newScriptPollers() scriptpollers.Service {
 	cursorRecorder := scriptpollers.NewMemoryCursorRecorder()
-	if s.cursorFileSystem != nil {
+	// The process-scoped root has no factory-local base until a runtime is
+	// activated. Keep that inert owner memory-backed rather than allowing an
+	// empty base to resolve durable state relative to the daemon CWD.
+	if strings.TrimSpace(s.defaultFactoryDir) != "" && s.cursorFileSystem != nil {
 		if durable, err := scriptpollerswire.NewDurableCursorRecorder(s.defaultFactoryDir, s.cursorFileSystem); err == nil {
 			cursorRecorder = durable
 		}
@@ -236,6 +240,9 @@ func (s *Service) GetCursor(
 	request automations.GetCursorRequest,
 ) (automations.GetCursorResult, error) {
 	if s != nil && s.scriptPollers != nil && scriptpollers.IsScriptPollerInstanceID(request.InstanceID) {
+		if result, handled, err := s.getCursorFromActiveRuntime(ctx, request); handled {
+			return result, err
+		}
 		return s.scriptPollers.GetCursor(ctx, request)
 	}
 	return s.reconciler.GetCursor(ctx, request)

--- a/pkg/services/automations/internal/service.go
+++ b/pkg/services/automations/internal/service.go
@@ -44,6 +44,7 @@ type Service struct {
 	hostedPollers      automations.HostedPollers
 	resolveTemplates   workers.TemplateFieldResolver
 	executionPolicy    factorydefinitions.WorkstationExecutionPolicyService
+	cursorFileSystem   scriptpollers.CursorPersistenceFileSystem
 	reconciler         reconciliation.Service
 	scriptPollers      scriptpollers.Service
 	cron               cron.Service
@@ -67,6 +68,57 @@ func New(
 	resolveTemplates workers.TemplateFieldResolver,
 	executionPolicy factorydefinitions.WorkstationExecutionPolicyService,
 ) *Service {
+	return newService(
+		logger,
+		clock,
+		commandRunner,
+		workflowID,
+		defaultFactoryDir,
+		hostedPollers,
+		resolveTemplates,
+		executionPolicy,
+		nil,
+	)
+}
+
+// NewWithCursorFileSystem constructs an owner with the production cursor
+// persistence effect. Direct owner-local callers can use New and retain the
+// in-memory recorder.
+func NewWithCursorFileSystem(
+	logger *zap.Logger,
+	clock Clock,
+	commandRunner workers.CommandRunner,
+	workflowID string,
+	defaultFactoryDir string,
+	hostedPollers automations.HostedPollers,
+	resolveTemplates workers.TemplateFieldResolver,
+	executionPolicy factorydefinitions.WorkstationExecutionPolicyService,
+	cursorFileSystem scriptpollers.CursorPersistenceFileSystem,
+) *Service {
+	return newService(
+		logger,
+		clock,
+		commandRunner,
+		workflowID,
+		defaultFactoryDir,
+		hostedPollers,
+		resolveTemplates,
+		executionPolicy,
+		cursorFileSystem,
+	)
+}
+
+func newService(
+	logger *zap.Logger,
+	clock Clock,
+	commandRunner workers.CommandRunner,
+	workflowID string,
+	defaultFactoryDir string,
+	hostedPollers automations.HostedPollers,
+	resolveTemplates workers.TemplateFieldResolver,
+	executionPolicy factorydefinitions.WorkstationExecutionPolicyService,
+	cursorFileSystem scriptpollers.CursorPersistenceFileSystem,
+) *Service {
 	service := &Service{
 		loggerValue:       logger,
 		clock:             clock,
@@ -76,6 +128,7 @@ func New(
 		hostedPollers:     hostedPollers,
 		resolveTemplates:  resolveTemplates,
 		executionPolicy:   executionPolicy,
+		cursorFileSystem:  cursorFileSystem,
 		schedulerSources:  make(map[automations.SourceIdentity]*schedulerSource),
 		runtimes:          make(map[string]*runtimeInstance),
 		runtimeActivating: make(map[string]struct{}),
@@ -88,13 +141,19 @@ func New(
 }
 
 func (s *Service) newScriptPollers() scriptpollers.Service {
+	cursorRecorder := scriptpollers.NewMemoryCursorRecorder()
+	if s.cursorFileSystem != nil {
+		if durable, err := scriptpollers.NewDurableCursorRecorder(s.defaultFactoryDir, s.cursorFileSystem); err == nil {
+			cursorRecorder = durable
+		}
+	}
 	return scriptpollerswire.NewService(scriptpollers.Dependencies{
 		Logger:           s.pollerLogger,
 		Clock:            s.supervisorClock,
 		CommandRunner:    s.commandRunner,
 		ResolveTemplates: s.resolveTemplates,
 		ExecutionPolicy:  s.executionPolicy,
-		CursorRecorder:   scriptpollers.NewMemoryCursorRecorder(),
+		CursorRecorder:   cursorRecorder,
 	})
 }
 

--- a/pkg/services/automations/internal/service.go
+++ b/pkg/services/automations/internal/service.go
@@ -44,7 +44,7 @@ type Service struct {
 	hostedPollers      automations.HostedPollers
 	resolveTemplates   workers.TemplateFieldResolver
 	executionPolicy    factorydefinitions.WorkstationExecutionPolicyService
-	cursorFileSystem   scriptpollers.CursorPersistenceFileSystem
+	cursorFileSystem   scriptpollerswire.CursorPersistenceFileSystem
 	reconciler         reconciliation.Service
 	scriptPollers      scriptpollers.Service
 	cron               cron.Service
@@ -93,7 +93,7 @@ func NewWithCursorFileSystem(
 	hostedPollers automations.HostedPollers,
 	resolveTemplates workers.TemplateFieldResolver,
 	executionPolicy factorydefinitions.WorkstationExecutionPolicyService,
-	cursorFileSystem scriptpollers.CursorPersistenceFileSystem,
+	cursorFileSystem scriptpollerswire.CursorPersistenceFileSystem,
 ) *Service {
 	return newService(
 		logger,
@@ -117,7 +117,7 @@ func newService(
 	hostedPollers automations.HostedPollers,
 	resolveTemplates workers.TemplateFieldResolver,
 	executionPolicy factorydefinitions.WorkstationExecutionPolicyService,
-	cursorFileSystem scriptpollers.CursorPersistenceFileSystem,
+	cursorFileSystem scriptpollerswire.CursorPersistenceFileSystem,
 ) *Service {
 	service := &Service{
 		loggerValue:       logger,
@@ -143,7 +143,7 @@ func newService(
 func (s *Service) newScriptPollers() scriptpollers.Service {
 	cursorRecorder := scriptpollers.NewMemoryCursorRecorder()
 	if s.cursorFileSystem != nil {
-		if durable, err := scriptpollers.NewDurableCursorRecorder(s.defaultFactoryDir, s.cursorFileSystem); err == nil {
+		if durable, err := scriptpollerswire.NewDurableCursorRecorder(s.defaultFactoryDir, s.cursorFileSystem); err == nil {
 			cursorRecorder = durable
 		}
 	}

--- a/pkg/services/automations/internal/services/script_pollers/durable_cursor.go
+++ b/pkg/services/automations/internal/services/script_pollers/durable_cursor.go
@@ -1,0 +1,212 @@
+package script_pollers
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	automations "github.com/portpowered/infinite-you/pkg/services/automations"
+)
+
+const (
+	durableCursorSchemaVersion = "automations-script-poller-cursor/v1"
+	durableCursorStateDir      = ".infinite-you/poller-cursors"
+)
+
+// CursorPersistenceFileSystem is the exact filesystem effect needed by the
+// durable script-poller cursor recorder. Path and replacement policy remain
+// owned by Automations.
+type CursorPersistenceFileSystem interface {
+	ReadFile(string) ([]byte, error)
+	MkdirAll(string, fs.FileMode) error
+	WriteFile(string, []byte, fs.FileMode) error
+	Rename(string, string) error
+}
+
+type durableCursorRecorder struct {
+	dir   string
+	files CursorPersistenceFileSystem
+	mu    sync.RWMutex
+}
+
+var _ CursorRecorder = (*durableCursorRecorder)(nil)
+
+type persistedCursor struct {
+	SchemaVersion string             `json:"schemaVersion"`
+	AutomationID  string             `json:"automationId"`
+	InstanceID    string             `json:"instanceId"`
+	Cursor        automations.Cursor `json:"cursor"`
+	Checkpoint    string             `json:"checkpoint,omitempty"`
+}
+
+// NewDurableCursorRecorder constructs an Automations-owned cursor recorder.
+// baseDir is the runtime or factory directory beneath which the stable
+// .infinite-you state convention is applied. Construction performs no IO.
+func NewDurableCursorRecorder(
+	baseDir string,
+	files CursorPersistenceFileSystem,
+) (CursorRecorder, error) {
+	if files == nil {
+		return nil, errors.New("script poller cursor filesystem is required")
+	}
+	return &durableCursorRecorder{
+		dir:   cursorStateDir(baseDir),
+		files: files,
+	}, nil
+}
+
+func cursorStateDir(baseDir string) string {
+	return filepath.Join(strings.TrimSpace(baseDir), filepath.FromSlash(durableCursorStateDir))
+}
+
+func (r *durableCursorRecorder) GetCursor(
+	ctx context.Context,
+	request automations.GetCursorRequest,
+) (automations.GetCursorResult, error) {
+	if err := cursorContextError(ctx); err != nil {
+		return automations.GetCursorResult{}, err
+	}
+	instanceID := strings.TrimSpace(request.InstanceID)
+	if instanceID == "" || instanceID != request.InstanceID {
+		return automations.GetCursorResult{}, invalidCursorOperationError(GetCursorOperation, "malformed instance identity")
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	persisted, err := r.load(instanceID)
+	if errors.Is(err, fs.ErrNotExist) {
+		return automations.GetCursorResult{}, &automations.Error{
+			Op:   GetCursorOperation,
+			Code: automations.ErrorCodeNotFound,
+			Err:  automations.ErrNotFound,
+		}
+	}
+	if err != nil {
+		return automations.GetCursorResult{}, durableCursorReadError(err)
+	}
+	if request.ExpectedCursor != "" && request.ExpectedCursor != persisted.Cursor {
+		return automations.GetCursorResult{}, CursorConflictError(GetCursorOperation)
+	}
+	return automations.GetCursorResult{
+		AutomationID: persisted.AutomationID,
+		InstanceID:   persisted.InstanceID,
+		Cursor:       persisted.Cursor,
+		Checkpoint:   persisted.Checkpoint,
+	}, nil
+}
+
+func (r *durableCursorRecorder) CommitCursor(
+	ctx context.Context,
+	request CommitCursorRequest,
+) error {
+	if err := cursorContextError(ctx); err != nil {
+		return err
+	}
+	instanceID := strings.TrimSpace(request.InstanceID)
+	if instanceID == "" || instanceID != request.InstanceID {
+		return invalidCursorOperationError(CommitCursorOperation, "malformed instance identity")
+	}
+	if strings.TrimSpace(string(request.Cursor)) == "" {
+		return invalidCursorOperationError(CommitCursorOperation, "cursor must be non-empty")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	current, err := r.load(instanceID)
+	exists := err == nil
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("read script poller cursor before commit: %w", err)
+	}
+	if request.ExpectedCursor != "" {
+		if !exists || current.Cursor != request.ExpectedCursor {
+			return CursorConflictError(CommitCursorOperation)
+		}
+	} else if exists && current.Cursor != "" {
+		return CursorConflictError(CommitCursorOperation)
+	}
+
+	persisted := persistedCursor{
+		SchemaVersion: durableCursorSchemaVersion,
+		AutomationID:  strings.TrimSpace(request.AutomationID),
+		InstanceID:    instanceID,
+		Cursor:        request.Cursor,
+		Checkpoint:    request.Checkpoint,
+	}
+	payload, err := json.Marshal(persisted)
+	if err != nil {
+		return fmt.Errorf("encode script poller cursor: %w", err)
+	}
+	if err := r.files.MkdirAll(r.dir, 0o700); err != nil {
+		return fmt.Errorf("create script poller cursor directory %q: %w", r.dir, err)
+	}
+	if err := cursorContextError(ctx); err != nil {
+		return err
+	}
+	target := r.cursorPath(instanceID)
+	temporary := target + ".tmp"
+	if err := r.files.WriteFile(temporary, payload, 0o600); err != nil {
+		return fmt.Errorf("write temporary script poller cursor %q: %w", temporary, err)
+	}
+	if err := cursorContextError(ctx); err != nil {
+		return err
+	}
+	if err := r.files.Rename(temporary, target); err != nil {
+		return fmt.Errorf("commit script poller cursor %q: %w", target, err)
+	}
+	return nil
+}
+
+func (r *durableCursorRecorder) load(instanceID string) (persistedCursor, error) {
+	encoded, err := r.files.ReadFile(r.cursorPath(instanceID))
+	if err != nil {
+		return persistedCursor{}, err
+	}
+	var persisted persistedCursor
+	if err := json.Unmarshal(encoded, &persisted); err != nil {
+		return persistedCursor{}, fmt.Errorf("decode script poller cursor: %w", err)
+	}
+	if persisted.SchemaVersion != durableCursorSchemaVersion {
+		return persistedCursor{}, fmt.Errorf(
+			"unsupported script poller cursor schema version %q",
+			persisted.SchemaVersion,
+		)
+	}
+	if persisted.InstanceID != instanceID {
+		return persistedCursor{}, fmt.Errorf(
+			"script poller cursor instance identity mismatch: got %q, want %q",
+			persisted.InstanceID,
+			instanceID,
+		)
+	}
+	if strings.TrimSpace(string(persisted.Cursor)) == "" {
+		return persistedCursor{}, errors.New("script poller cursor is empty")
+	}
+	return persisted, nil
+}
+
+func (r *durableCursorRecorder) cursorPath(instanceID string) string {
+	digest := sha256.Sum256([]byte(instanceID))
+	return filepath.Join(r.dir, hex.EncodeToString(digest[:])+".json")
+}
+
+func durableCursorReadError(err error) error {
+	return &automations.Error{
+		Op:   GetCursorOperation,
+		Code: automations.ErrorCodeFailed,
+		Err:  fmt.Errorf("read script poller cursor persistence failed: %w", err),
+	}
+}
+
+func cursorContextError(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Err()
+}

--- a/pkg/services/automations/internal/services/script_pollers/durable_cursor_test.go
+++ b/pkg/services/automations/internal/services/script_pollers/durable_cursor_test.go
@@ -1,0 +1,202 @@
+package script_pollers_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	automations "github.com/portpowered/infinite-you/pkg/services/automations"
+	scriptpollers "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/script_pollers"
+)
+
+func TestDurableCursorRecorder_RestartRecoversExactOpaqueFacts(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	ctx := context.Background()
+	const (
+		automationID = "automation durable / exact"
+		instanceID   = "script-poller-instance:durable-exact"
+		cursor       = "opaque cursor / page=7?token=keep"
+		checkpoint   = `{"last":"issue-7","updated":"2026-08-21T12:34:56Z"}`
+	)
+
+	first, err := scriptpollers.NewDurableCursorRecorder(baseDir, osFileSystem{})
+	if err != nil {
+		t.Fatalf("NewDurableCursorRecorder(first): %v", err)
+	}
+	if err := first.CommitCursor(ctx, scriptpollers.CommitCursorRequest{
+		AutomationID: automationID,
+		InstanceID:   instanceID,
+		Cursor:       cursor,
+		Checkpoint:   checkpoint,
+	}); err != nil {
+		t.Fatalf("first CommitCursor(): %v", err)
+	}
+
+	second, err := scriptpollers.NewDurableCursorRecorder(baseDir, osFileSystem{})
+	if err != nil {
+		t.Fatalf("NewDurableCursorRecorder(second): %v", err)
+	}
+	got, err := second.GetCursor(ctx, automations.GetCursorRequest{
+		InstanceID:     instanceID,
+		ExpectedCursor: cursor,
+	})
+	if err != nil {
+		t.Fatalf("second GetCursor(): %v", err)
+	}
+	if got.AutomationID != automationID || got.InstanceID != instanceID ||
+		got.Cursor != cursor || got.Checkpoint != checkpoint {
+		t.Fatalf("second GetCursor() = %+v, want exact durable facts", got)
+	}
+}
+
+func TestDurableCursorRecorder_PreservesOptimisticSemantics(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	recorder, err := scriptpollers.NewDurableCursorRecorder(baseDir, osFileSystem{})
+	if err != nil {
+		t.Fatalf("NewDurableCursorRecorder(): %v", err)
+	}
+	ctx := context.Background()
+	const instanceID = "script-poller-instance:durable-conflict"
+	if err := recorder.CommitCursor(ctx, scriptpollers.CommitCursorRequest{
+		AutomationID: "automation-conflict",
+		InstanceID:   instanceID,
+		Cursor:       "cursor-current",
+	}); err != nil {
+		t.Fatalf("initial CommitCursor(): %v", err)
+	}
+
+	_, err = recorder.GetCursor(ctx, automations.GetCursorRequest{
+		InstanceID:     instanceID,
+		ExpectedCursor: "cursor-stale",
+	})
+	assertAutomationsError(t, err, scriptpollers.GetCursorOperation, automations.ErrorCodeConflict, automations.ErrConflict)
+
+	err = recorder.CommitCursor(ctx, scriptpollers.CommitCursorRequest{
+		AutomationID:   "automation-conflict",
+		InstanceID:     instanceID,
+		ExpectedCursor: "cursor-stale",
+		Cursor:         "cursor-replacement",
+	})
+	assertAutomationsError(t, err, scriptpollers.CommitCursorOperation, automations.ErrorCodeConflict, automations.ErrConflict)
+
+	got, err := recorder.GetCursor(ctx, automations.GetCursorRequest{InstanceID: instanceID})
+	if err != nil {
+		t.Fatalf("GetCursor() after stale replacement: %v", err)
+	}
+	if got.Cursor != "cursor-current" {
+		t.Fatalf("cursor after stale replacement = %q, want cursor-current", got.Cursor)
+	}
+}
+
+func TestDurableCursorRecorder_FailedReplacementLeavesLastCommitReadable(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	ctx := context.Background()
+	const instanceID = "script-poller-instance:durable-failure"
+	first, err := scriptpollers.NewDurableCursorRecorder(baseDir, osFileSystem{})
+	if err != nil {
+		t.Fatalf("NewDurableCursorRecorder(first): %v", err)
+	}
+	if err := first.CommitCursor(ctx, scriptpollers.CommitCursorRequest{
+		AutomationID: "automation-failure",
+		InstanceID:   instanceID,
+		Cursor:       "cursor-committed",
+		Checkpoint:   "checkpoint-committed",
+	}); err != nil {
+		t.Fatalf("initial CommitCursor(): %v", err)
+	}
+
+	persistErr := errors.New("rename destination is unavailable")
+	failing, err := scriptpollers.NewDurableCursorRecorder(baseDir, osFileSystem{renameErr: persistErr})
+	if err != nil {
+		t.Fatalf("NewDurableCursorRecorder(failing): %v", err)
+	}
+	err = failing.CommitCursor(ctx, scriptpollers.CommitCursorRequest{
+		AutomationID:   "automation-failure",
+		InstanceID:     instanceID,
+		ExpectedCursor: "cursor-committed",
+		Cursor:         "cursor-not-committed",
+		Checkpoint:     "checkpoint-not-committed",
+	})
+	if err == nil || !strings.Contains(err.Error(), persistErr.Error()) {
+		t.Fatalf("failed CommitCursor() error = %v, want actionable persistence failure", err)
+	}
+
+	second, err := scriptpollers.NewDurableCursorRecorder(baseDir, osFileSystem{})
+	if err != nil {
+		t.Fatalf("NewDurableCursorRecorder(second): %v", err)
+	}
+	got, err := second.GetCursor(ctx, automations.GetCursorRequest{InstanceID: instanceID})
+	if err != nil {
+		t.Fatalf("GetCursor() after failed replacement: %v", err)
+	}
+	if got.Cursor != "cursor-committed" || got.Checkpoint != "checkpoint-committed" {
+		t.Fatalf("cursor after failed replacement = %+v, want last committed values", got)
+	}
+}
+
+func TestDurableCursorRecorder_ClassifiesCorruptState(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	recorder, err := scriptpollers.NewDurableCursorRecorder(baseDir, osFileSystem{})
+	if err != nil {
+		t.Fatalf("NewDurableCursorRecorder(): %v", err)
+	}
+	const instanceID = "script-poller-instance:durable-corrupt"
+	if err := recorder.CommitCursor(context.Background(), scriptpollers.CommitCursorRequest{
+		AutomationID: "automation-corrupt",
+		InstanceID:   instanceID,
+		Cursor:       "cursor-valid",
+	}); err != nil {
+		t.Fatalf("CommitCursor(): %v", err)
+	}
+	paths, err := filepath.Glob(filepath.Join(baseDir, ".infinite-you", "poller-cursors", "*.json"))
+	if err != nil || len(paths) != 1 {
+		t.Fatalf("cursor state paths = %#v, glob error = %v, want one state file", paths, err)
+	}
+	if err := os.WriteFile(paths[0], []byte("not-json"), 0o600); err != nil {
+		t.Fatalf("corrupt cursor state: %v", err)
+	}
+
+	_, err = recorder.GetCursor(context.Background(), automations.GetCursorRequest{InstanceID: instanceID})
+	if err == nil {
+		t.Fatal("GetCursor() on corrupt state = nil, want classified failure")
+	}
+	typed, ok := err.(*automations.Error)
+	if !ok || typed.Op != scriptpollers.GetCursorOperation || typed.Code != automations.ErrorCodeFailed {
+		t.Fatalf("corrupt state error = %#v, want typed failed cursor read error", err)
+	}
+	if !strings.Contains(err.Error(), "decode script poller cursor") {
+		t.Fatalf("corrupt state error = %v, want decode context", err)
+	}
+}
+
+type osFileSystem struct {
+	renameErr error
+}
+
+func (osFileSystem) ReadFile(path string) ([]byte, error) { return os.ReadFile(path) }
+
+func (osFileSystem) MkdirAll(path string, mode os.FileMode) error {
+	return os.MkdirAll(path, mode)
+}
+
+func (osFileSystem) WriteFile(path string, payload []byte, mode os.FileMode) error {
+	return os.WriteFile(path, payload, mode)
+}
+
+func (f osFileSystem) Rename(oldPath, newPath string) error {
+	if f.renameErr != nil {
+		return f.renameErr
+	}
+	return os.Rename(oldPath, newPath)
+}

--- a/pkg/services/automations/internal/services/script_pollers/durable_cursor_test.go
+++ b/pkg/services/automations/internal/services/script_pollers/durable_cursor_test.go
@@ -55,6 +55,15 @@ func TestDurableCursorRecorder_RestartRecoversExactOpaqueFacts(t *testing.T) {
 	}
 }
 
+func TestDurableCursorRecorder_RequiresFactoryLocalBaseDirectory(t *testing.T) {
+	t.Parallel()
+
+	_, err := scriptpollerswire.NewDurableCursorRecorder(" ", osFileSystem{})
+	if err == nil || err.Error() != "script poller cursor base directory is required" {
+		t.Fatalf("NewDurableCursorRecorder(blank base) error = %v, want explicit base-directory failure", err)
+	}
+}
+
 func TestDurableCursorRecorder_PreservesOptimisticSemantics(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/automations/internal/services/script_pollers/durable_cursor_test.go
+++ b/pkg/services/automations/internal/services/script_pollers/durable_cursor_test.go
@@ -10,6 +10,7 @@ import (
 
 	automations "github.com/portpowered/infinite-you/pkg/services/automations"
 	scriptpollers "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/script_pollers"
+	scriptpollerswire "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/script_pollers/wire"
 )
 
 func TestDurableCursorRecorder_RestartRecoversExactOpaqueFacts(t *testing.T) {
@@ -24,7 +25,7 @@ func TestDurableCursorRecorder_RestartRecoversExactOpaqueFacts(t *testing.T) {
 		checkpoint   = `{"last":"issue-7","updated":"2026-08-21T12:34:56Z"}`
 	)
 
-	first, err := scriptpollers.NewDurableCursorRecorder(baseDir, osFileSystem{})
+	first, err := scriptpollerswire.NewDurableCursorRecorder(baseDir, osFileSystem{})
 	if err != nil {
 		t.Fatalf("NewDurableCursorRecorder(first): %v", err)
 	}
@@ -37,7 +38,7 @@ func TestDurableCursorRecorder_RestartRecoversExactOpaqueFacts(t *testing.T) {
 		t.Fatalf("first CommitCursor(): %v", err)
 	}
 
-	second, err := scriptpollers.NewDurableCursorRecorder(baseDir, osFileSystem{})
+	second, err := scriptpollerswire.NewDurableCursorRecorder(baseDir, osFileSystem{})
 	if err != nil {
 		t.Fatalf("NewDurableCursorRecorder(second): %v", err)
 	}
@@ -58,7 +59,7 @@ func TestDurableCursorRecorder_PreservesOptimisticSemantics(t *testing.T) {
 	t.Parallel()
 
 	baseDir := t.TempDir()
-	recorder, err := scriptpollers.NewDurableCursorRecorder(baseDir, osFileSystem{})
+	recorder, err := scriptpollerswire.NewDurableCursorRecorder(baseDir, osFileSystem{})
 	if err != nil {
 		t.Fatalf("NewDurableCursorRecorder(): %v", err)
 	}
@@ -101,7 +102,7 @@ func TestDurableCursorRecorder_FailedReplacementLeavesLastCommitReadable(t *test
 	baseDir := t.TempDir()
 	ctx := context.Background()
 	const instanceID = "script-poller-instance:durable-failure"
-	first, err := scriptpollers.NewDurableCursorRecorder(baseDir, osFileSystem{})
+	first, err := scriptpollerswire.NewDurableCursorRecorder(baseDir, osFileSystem{})
 	if err != nil {
 		t.Fatalf("NewDurableCursorRecorder(first): %v", err)
 	}
@@ -115,7 +116,7 @@ func TestDurableCursorRecorder_FailedReplacementLeavesLastCommitReadable(t *test
 	}
 
 	persistErr := errors.New("rename destination is unavailable")
-	failing, err := scriptpollers.NewDurableCursorRecorder(baseDir, osFileSystem{renameErr: persistErr})
+	failing, err := scriptpollerswire.NewDurableCursorRecorder(baseDir, osFileSystem{renameErr: persistErr})
 	if err != nil {
 		t.Fatalf("NewDurableCursorRecorder(failing): %v", err)
 	}
@@ -130,7 +131,7 @@ func TestDurableCursorRecorder_FailedReplacementLeavesLastCommitReadable(t *test
 		t.Fatalf("failed CommitCursor() error = %v, want actionable persistence failure", err)
 	}
 
-	second, err := scriptpollers.NewDurableCursorRecorder(baseDir, osFileSystem{})
+	second, err := scriptpollerswire.NewDurableCursorRecorder(baseDir, osFileSystem{})
 	if err != nil {
 		t.Fatalf("NewDurableCursorRecorder(second): %v", err)
 	}
@@ -147,7 +148,7 @@ func TestDurableCursorRecorder_ClassifiesCorruptState(t *testing.T) {
 	t.Parallel()
 
 	baseDir := t.TempDir()
-	recorder, err := scriptpollers.NewDurableCursorRecorder(baseDir, osFileSystem{})
+	recorder, err := scriptpollerswire.NewDurableCursorRecorder(baseDir, osFileSystem{})
 	if err != nil {
 		t.Fatalf("NewDurableCursorRecorder(): %v", err)
 	}

--- a/pkg/services/automations/internal/services/script_pollers/internal/service/durable_cursor.go
+++ b/pkg/services/automations/internal/services/script_pollers/internal/service/durable_cursor.go
@@ -57,6 +57,10 @@ func NewDurableCursorRecorder(
 	if files == nil {
 		return nil, errors.New("script poller cursor filesystem is required")
 	}
+	baseDir = strings.TrimSpace(baseDir)
+	if baseDir == "" {
+		return nil, errors.New("script poller cursor base directory is required")
+	}
 	return &durableCursorRecorder{
 		dir:   cursorStateDir(baseDir),
 		files: files,

--- a/pkg/services/automations/internal/services/script_pollers/internal/service/durable_cursor.go
+++ b/pkg/services/automations/internal/services/script_pollers/internal/service/durable_cursor.go
@@ -1,4 +1,4 @@
-package script_pollers
+package service
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	automations "github.com/portpowered/infinite-you/pkg/services/automations"
+	scriptpollers "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/script_pollers"
 )
 
 const (
@@ -36,7 +37,7 @@ type durableCursorRecorder struct {
 	mu    sync.RWMutex
 }
 
-var _ CursorRecorder = (*durableCursorRecorder)(nil)
+var _ scriptpollers.CursorRecorder = (*durableCursorRecorder)(nil)
 
 type persistedCursor struct {
 	SchemaVersion string             `json:"schemaVersion"`
@@ -52,7 +53,7 @@ type persistedCursor struct {
 func NewDurableCursorRecorder(
 	baseDir string,
 	files CursorPersistenceFileSystem,
-) (CursorRecorder, error) {
+) (scriptpollers.CursorRecorder, error) {
 	if files == nil {
 		return nil, errors.New("script poller cursor filesystem is required")
 	}
@@ -75,7 +76,7 @@ func (r *durableCursorRecorder) GetCursor(
 	}
 	instanceID := strings.TrimSpace(request.InstanceID)
 	if instanceID == "" || instanceID != request.InstanceID {
-		return automations.GetCursorResult{}, invalidCursorOperationError(GetCursorOperation, "malformed instance identity")
+		return automations.GetCursorResult{}, invalidCursorOperationError(scriptpollers.GetCursorOperation, "malformed instance identity")
 	}
 
 	r.mu.RLock()
@@ -83,7 +84,7 @@ func (r *durableCursorRecorder) GetCursor(
 	persisted, err := r.load(instanceID)
 	if errors.Is(err, fs.ErrNotExist) {
 		return automations.GetCursorResult{}, &automations.Error{
-			Op:   GetCursorOperation,
+			Op:   scriptpollers.GetCursorOperation,
 			Code: automations.ErrorCodeNotFound,
 			Err:  automations.ErrNotFound,
 		}
@@ -92,7 +93,7 @@ func (r *durableCursorRecorder) GetCursor(
 		return automations.GetCursorResult{}, durableCursorReadError(err)
 	}
 	if request.ExpectedCursor != "" && request.ExpectedCursor != persisted.Cursor {
-		return automations.GetCursorResult{}, CursorConflictError(GetCursorOperation)
+		return automations.GetCursorResult{}, scriptpollers.CursorConflictError(scriptpollers.GetCursorOperation)
 	}
 	return automations.GetCursorResult{
 		AutomationID: persisted.AutomationID,
@@ -104,34 +105,65 @@ func (r *durableCursorRecorder) GetCursor(
 
 func (r *durableCursorRecorder) CommitCursor(
 	ctx context.Context,
-	request CommitCursorRequest,
+	request scriptpollers.CommitCursorRequest,
 ) error {
 	if err := cursorContextError(ctx); err != nil {
 		return err
 	}
-	instanceID := strings.TrimSpace(request.InstanceID)
-	if instanceID == "" || instanceID != request.InstanceID {
-		return invalidCursorOperationError(CommitCursorOperation, "malformed instance identity")
-	}
-	if strings.TrimSpace(string(request.Cursor)) == "" {
-		return invalidCursorOperationError(CommitCursorOperation, "cursor must be non-empty")
+	instanceID, err := commitCursorInstanceID(request)
+	if err != nil {
+		return err
 	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	current, err := r.load(instanceID)
-	exists := err == nil
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("read script poller cursor before commit: %w", err)
+	current, exists, err := r.loadForCommit(instanceID)
+	if err != nil {
+		return err
 	}
-	if request.ExpectedCursor != "" {
-		if !exists || current.Cursor != request.ExpectedCursor {
-			return CursorConflictError(CommitCursorOperation)
-		}
-	} else if exists && current.Cursor != "" {
-		return CursorConflictError(CommitCursorOperation)
+	if err := validateExpectedCursor(request.ExpectedCursor, current, exists); err != nil {
+		return err
 	}
+	return r.persist(ctx, instanceID, request)
+}
 
+func commitCursorInstanceID(request scriptpollers.CommitCursorRequest) (string, error) {
+	instanceID := strings.TrimSpace(request.InstanceID)
+	if instanceID == "" || instanceID != request.InstanceID {
+		return "", invalidCursorOperationError(scriptpollers.CommitCursorOperation, "malformed instance identity")
+	}
+	if strings.TrimSpace(string(request.Cursor)) == "" {
+		return "", invalidCursorOperationError(scriptpollers.CommitCursorOperation, "cursor must be non-empty")
+	}
+	return instanceID, nil
+}
+
+func (r *durableCursorRecorder) loadForCommit(instanceID string) (persistedCursor, bool, error) {
+	current, err := r.load(instanceID)
+	if errors.Is(err, fs.ErrNotExist) {
+		return persistedCursor{}, false, nil
+	}
+	if err != nil {
+		return persistedCursor{}, false, fmt.Errorf("read script poller cursor before commit: %w", err)
+	}
+	return current, true, nil
+}
+
+func validateExpectedCursor(expected automations.Cursor, current persistedCursor, exists bool) error {
+	if expected != "" && (!exists || current.Cursor != expected) {
+		return scriptpollers.CursorConflictError(scriptpollers.CommitCursorOperation)
+	}
+	if expected == "" && exists && current.Cursor != "" {
+		return scriptpollers.CursorConflictError(scriptpollers.CommitCursorOperation)
+	}
+	return nil
+}
+
+func (r *durableCursorRecorder) persist(
+	ctx context.Context,
+	instanceID string,
+	request scriptpollers.CommitCursorRequest,
+) error {
 	persisted := persistedCursor{
 		SchemaVersion: durableCursorSchemaVersion,
 		AutomationID:  strings.TrimSpace(request.AutomationID),
@@ -198,9 +230,17 @@ func (r *durableCursorRecorder) cursorPath(instanceID string) string {
 
 func durableCursorReadError(err error) error {
 	return &automations.Error{
-		Op:   GetCursorOperation,
+		Op:   scriptpollers.GetCursorOperation,
 		Code: automations.ErrorCodeFailed,
 		Err:  fmt.Errorf("read script poller cursor persistence failed: %w", err),
+	}
+}
+
+func invalidCursorOperationError(op, message string) error {
+	return &automations.Error{
+		Op:   op,
+		Code: automations.ErrorCodeInvalid,
+		Err:  fmt.Errorf("%w: %s", automations.ErrInvalidRequest, message),
 	}
 }
 

--- a/pkg/services/automations/internal/services/script_pollers/wire/wire.go
+++ b/pkg/services/automations/internal/services/script_pollers/wire/wire.go
@@ -6,8 +6,21 @@ import (
 	scriptpollersservice "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/script_pollers/internal/service"
 )
 
+// CursorPersistenceFileSystem is the filesystem effect accepted by the
+// script-poller composition boundary.
+type CursorPersistenceFileSystem = scriptpollersservice.CursorPersistenceFileSystem
+
 // NewService constructs an inert script-poller service with injected runtime
 // dependencies. Construction never invokes the supplied functions.
 func NewService(dependencies scriptpollers.Dependencies) scriptpollers.Service {
 	return scriptpollersservice.New(dependencies)
+}
+
+// NewDurableCursorRecorder constructs the Automations-owned durable cursor
+// implementation behind the script-poller wire boundary.
+func NewDurableCursorRecorder(
+	baseDir string,
+	files CursorPersistenceFileSystem,
+) (scriptpollers.CursorRecorder, error) {
+	return scriptpollersservice.NewDurableCursorRecorder(baseDir, files)
 }

--- a/pkg/services/automations/wire/wire.go
+++ b/pkg/services/automations/wire/wire.go
@@ -16,7 +16,7 @@ import (
 	automationinternal "github.com/portpowered/infinite-you/pkg/services/automations/internal"
 	hostedsources "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources"
 	hostedsourceswire "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources/wire"
-	scriptpollers "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/script_pollers"
+	scriptpollerswire "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/script_pollers/wire"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	"go.uber.org/zap"
@@ -32,7 +32,7 @@ type HostedSourceInputs struct {
 	SecretResolver   automations.HostedLinearSecretResolver
 	LinearEndpoint   string
 	CheckpointStore  automations.HostedLinearCheckpointStore
-	CursorFileSystem scriptpollers.CursorPersistenceFileSystem
+	CursorFileSystem scriptpollerswire.CursorPersistenceFileSystem
 }
 
 // NewRoot constructs the singular Automations root. Hosted-source mechanics
@@ -108,7 +108,7 @@ func newService(
 	hostedPollers automations.HostedPollers,
 	resolveTemplates workers.TemplateFieldResolver,
 	executionPolicy factorydefinitions.WorkstationExecutionPolicyService,
-	cursorFileSystem scriptpollers.CursorPersistenceFileSystem,
+	cursorFileSystem scriptpollerswire.CursorPersistenceFileSystem,
 ) (*automationinternal.Service, error) {
 	if err := validateDirectDependencies(
 		logger,

--- a/pkg/services/automations/wire/wire.go
+++ b/pkg/services/automations/wire/wire.go
@@ -16,21 +16,23 @@ import (
 	automationinternal "github.com/portpowered/infinite-you/pkg/services/automations/internal"
 	hostedsources "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources"
 	hostedsourceswire "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources/wire"
+	scriptpollers "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/script_pollers"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	"go.uber.org/zap"
 )
 
 // HostedSourceInputs is the cohesive set of external effects needed to
-// compose hosted-source implementations inside the Automations owner. The
-// application graph selects these effects once; it never constructs or passes
-// a hosted-source service into Runtime opening.
+// compose Automations-owned hosted-source and cursor-persistence
+// implementations. The application graph selects these effects once; it
+// never constructs or passes a hosted-source service into Runtime opening.
 type HostedSourceInputs struct {
-	Clock           automations.HostedLinearClock
-	HTTPClient      automations.HostedLinearHTTPDoer
-	SecretResolver  automations.HostedLinearSecretResolver
-	LinearEndpoint  string
-	CheckpointStore automations.HostedLinearCheckpointStore
+	Clock            automations.HostedLinearClock
+	HTTPClient       automations.HostedLinearHTTPDoer
+	SecretResolver   automations.HostedLinearSecretResolver
+	LinearEndpoint   string
+	CheckpointStore  automations.HostedLinearCheckpointStore
+	CursorFileSystem scriptpollers.CursorPersistenceFileSystem
 }
 
 // NewRoot constructs the singular Automations root. Hosted-source mechanics
@@ -46,6 +48,9 @@ func NewRoot(
 	resolveTemplates workers.TemplateFieldResolver,
 	executionPolicy factorydefinitions.WorkstationExecutionPolicyService,
 ) (automations.Root, error) {
+	if hosted.CursorFileSystem == nil {
+		return automations.Root{}, fmt.Errorf("construct Automations: script poller cursor filesystem is required")
+	}
 	service, err := newService(
 		logger,
 		clock,
@@ -55,6 +60,7 @@ func NewRoot(
 		composeHostedPollers(logger, hosted),
 		resolveTemplates,
 		executionPolicy,
+		hosted.CursorFileSystem,
 	)
 	if err != nil {
 		return automations.Root{}, err
@@ -85,6 +91,7 @@ func NewService(
 		hostedPollers,
 		resolveTemplates,
 		executionPolicy,
+		nil,
 	)
 	if err != nil {
 		return nil, err
@@ -101,6 +108,7 @@ func newService(
 	hostedPollers automations.HostedPollers,
 	resolveTemplates workers.TemplateFieldResolver,
 	executionPolicy factorydefinitions.WorkstationExecutionPolicyService,
+	cursorFileSystem scriptpollers.CursorPersistenceFileSystem,
 ) (*automationinternal.Service, error) {
 	if err := validateDirectDependencies(
 		logger,
@@ -113,7 +121,7 @@ func newService(
 		return nil, err
 	}
 
-	service := automationinternal.NewService(
+	service := automationinternal.NewWithCursorFileSystem(
 		logger,
 		clock,
 		commandRunner,
@@ -122,6 +130,7 @@ func newService(
 		hostedPollers,
 		resolveTemplates,
 		executionPolicy,
+		cursorFileSystem,
 	)
 	if service == nil {
 		return nil, fmt.Errorf("construct Automations: implementation rejected its dependencies")

--- a/pkg/services/automations/wire/wire_test.go
+++ b/pkg/services/automations/wire/wire_test.go
@@ -14,6 +14,7 @@ import (
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	automations "github.com/portpowered/infinite-you/pkg/services/automations"
 	hostedsourceswire "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/hosted_sources/wire"
+	scriptpollers "github.com/portpowered/infinite-you/pkg/services/automations/internal/services/script_pollers"
 	automationswire "github.com/portpowered/infinite-you/pkg/services/automations/wire"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/work"
@@ -349,10 +350,11 @@ func TestNewRootComposesHostedEffectsAndPublishesRuntimeCapabilities(t *testing.
 		"automations-root",
 		"",
 		automationswire.HostedSourceInputs{
-			Clock:           ports.clock,
-			SecretResolver:  func(context.Context, automations.HostedRuntimePaths, string) (string, error) { return "secret", nil },
-			LinearEndpoint:  "",
-			CheckpointStore: store,
+			Clock:            ports.clock,
+			SecretResolver:   func(context.Context, automations.HostedRuntimePaths, string) (string, error) { return "secret", nil },
+			LinearEndpoint:   "",
+			CheckpointStore:  store,
+			CursorFileSystem: platformfilesystem.Local{},
 		},
 		ports.resolveTemplates,
 		ports.executionPolicy,
@@ -363,6 +365,158 @@ func TestNewRootComposesHostedEffectsAndPublishesRuntimeCapabilities(t *testing.
 	if root.Operations == nil || root.Lifecycle == nil || root.Runtime == nil {
 		t.Fatalf("NewRoot() = %#v, want operations, lifecycle, and runtime capabilities", root)
 	}
+}
+
+func TestNewRootRequiresCursorPersistenceEffect(t *testing.T) {
+	t.Parallel()
+
+	ports := validConstructionPorts(t)
+	store, err := automationswire.NewHostedLinearCheckpointStore(platformfilesystem.Local{})
+	if err != nil {
+		t.Fatalf("NewHostedLinearCheckpointStore() error = %v", err)
+	}
+	_, err = automationswire.NewRoot(
+		ports.logger,
+		ports.clock,
+		ports.commandRunner,
+		"automations-root",
+		"",
+		automationswire.HostedSourceInputs{
+			Clock:           ports.clock,
+			SecretResolver:  func(context.Context, automations.HostedRuntimePaths, string) (string, error) { return "secret", nil },
+			CheckpointStore: store,
+		},
+		ports.resolveTemplates,
+		ports.executionPolicy,
+	)
+	if err == nil || err.Error() != "construct Automations: script poller cursor filesystem is required" {
+		t.Fatalf("NewRoot() error = %v, want missing cursor persistence effect", err)
+	}
+}
+
+func TestNewRootUsesDurableCursorRecorderAcrossReconstruction(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	ports := validConstructionPorts(t)
+	store, err := automationswire.NewHostedLinearCheckpointStore(platformfilesystem.Local{})
+	if err != nil {
+		t.Fatalf("NewHostedLinearCheckpointStore() error = %v", err)
+	}
+	inputs := automationswire.HostedSourceInputs{
+		Clock:            ports.clock,
+		SecretResolver:   func(context.Context, automations.HostedRuntimePaths, string) (string, error) { return "secret", nil },
+		CheckpointStore:  store,
+		CursorFileSystem: platformfilesystem.Local{},
+	}
+	first, err := automationswire.NewRoot(
+		ports.logger,
+		ports.clock,
+		cursorCommandRunner{stdout: durableCursorStdout},
+		"workflow-durable-root",
+		baseDir,
+		inputs,
+		ports.resolveTemplates,
+		ports.executionPolicy,
+	)
+	if err != nil {
+		t.Fatalf("NewRoot(first): %v", err)
+	}
+	operation, ok := first.Operations.(interface {
+		RunScriptPoller(
+			context.Context,
+			workers.CommandRunner,
+			factorydefinitions.RuntimeConfigLookup,
+			factorydefinitions.FactoryWorkstationConfig,
+			*factorydefinitions.FactoryWorkerConfig,
+			automations.WorkRequestSubmitter,
+		) error
+	})
+	if !ok {
+		t.Fatal("NewRoot(first) operations do not expose script-poller execution")
+	}
+	poller := factorydefinitions.FactoryWorkstationConfig{
+		Name:           "durable-poller",
+		Kind:           factorydefinitions.WorkstationKindPoller,
+		WorkerTypeName: "durable-script",
+	}
+	worker := &factorydefinitions.FactoryWorkerConfig{
+		Name:    "durable-script",
+		Type:    factorydefinitions.WorkerTypeScript,
+		Command: "poller.sh",
+	}
+	if err := operation.RunScriptPoller(
+		context.Background(),
+		cursorCommandRunner{stdout: durableCursorStdout},
+		cursorRuntimeConfig{factoryDir: baseDir, worker: worker, workstation: poller},
+		poller,
+		worker,
+		func(context.Context, work.WorkRequest) error { return nil },
+	); err == nil {
+		t.Fatal("RunScriptPoller() error = nil, want terminal poller exit after commit")
+	}
+
+	second, err := automationswire.NewRoot(
+		ports.logger,
+		ports.clock,
+		cursorCommandRunner{stdout: durableCursorStdout},
+		"workflow-durable-root",
+		baseDir,
+		inputs,
+		ports.resolveTemplates,
+		ports.executionPolicy,
+	)
+	if err != nil {
+		t.Fatalf("NewRoot(second): %v", err)
+	}
+	instanceID := scriptpollers.SupervisionFor("workflow-durable-root", poller.Name).InstanceID
+	got, err := second.GetCursor(context.Background(), automations.GetCursorRequest{InstanceID: instanceID})
+	if err != nil {
+		t.Fatalf("second.GetCursor(): %v", err)
+	}
+	if got.AutomationID != "workflow-durable-root" || got.InstanceID != instanceID ||
+		got.Cursor != "durable-cursor" || got.Checkpoint != "durable-checkpoint" {
+		t.Fatalf("second.GetCursor() = %+v, want exact recovered cursor facts", got)
+	}
+}
+
+const durableCursorStdout = `{"requestId":"durable-request","type":"FACTORY_REQUEST_BATCH","works":[{"name":"durable-work","workTypeName":"task"}],"cursor":"durable-cursor","checkpoint":"durable-checkpoint"}`
+
+type cursorCommandRunner struct {
+	stdout string
+}
+
+func (r cursorCommandRunner) Run(context.Context, workers.CommandRequest) (workers.CommandResult, error) {
+	return workers.CommandResult{Stdout: []byte(r.stdout)}, nil
+}
+
+type cursorRuntimeConfig struct {
+	factoryDir  string
+	worker      *factorydefinitions.FactoryWorkerConfig
+	workstation factorydefinitions.FactoryWorkstationConfig
+}
+
+func (c cursorRuntimeConfig) FactoryDir() string { return c.factoryDir }
+
+func (c cursorRuntimeConfig) RuntimeBaseDir() string { return c.factoryDir }
+
+func (c cursorRuntimeConfig) FactoryConfig() *factorydefinitions.FactoryConfig {
+	return &factorydefinitions.FactoryConfig{}
+}
+
+func (c cursorRuntimeConfig) Worker(name string) (*factorydefinitions.FactoryWorkerConfig, bool) {
+	if c.worker != nil && c.worker.Name == name {
+		return c.worker, true
+	}
+	return nil, false
+}
+
+func (c cursorRuntimeConfig) Workstation(name string) (*factorydefinitions.FactoryWorkstationConfig, bool) {
+	if c.workstation.Name == name {
+		workstation := c.workstation
+		return &workstation, true
+	}
+	return nil, false
 }
 
 func TestNewServiceConstructsInertRoot(t *testing.T) {

--- a/pkg/services/automations/wire/wire_test.go
+++ b/pkg/services/automations/wire/wire_test.go
@@ -480,6 +480,181 @@ func TestNewRootUsesDurableCursorRecorderAcrossReconstruction(t *testing.T) {
 	}
 }
 
+func TestNewRootRoutesActivatedRuntimeCursorToFactoryLocalRecorder(t *testing.T) {
+	t.Parallel()
+
+	const (
+		workflowID = "workflow-runtime-local-cursor"
+		runtimeID  = "runtime-runtime-local-cursor"
+	)
+	factoryDir := t.TempDir()
+	runner := &runtimeCursorCommandRunner{
+		stdout:  []byte(`{"requestId":"runtime-local-cursor","type":"FACTORY_REQUEST_BATCH","works":[{"name":"runtime-local-work","workTypeName":"task"}],"cursor":"runtime-local-cursor","checkpoint":"runtime-local-checkpoint"}`),
+		started: make(chan struct{}),
+	}
+	ports := validConstructionPorts(t)
+	composition := newRuntimeCursorComposition(t, factoryDir, workflowID, runtimeID, ports.clock)
+	first := newRuntimeCursorRoot(t, ports, runner, workflowID, composition.inputs)
+	if _, err := first.ActivateRuntime(context.Background(), composition.request); err != nil {
+		t.Fatalf("first.ActivateRuntime(): %v", err)
+	}
+	if err := first.StartRuntime(context.Background(), runtimeID); err != nil {
+		t.Fatalf("first.StartRuntime(): %v", err)
+	}
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("script poller did not start")
+	}
+	supervision := scriptpollers.SupervisionFor(workflowID, composition.poller.Name)
+	got := waitForRuntimeCursor(t, first, supervision.InstanceID)
+	assertRuntimeCursor(t, got, workflowID, supervision.InstanceID, "first.GetCursor()")
+	if _, err := first.DeactivateRuntime(context.Background(), automations.RuntimeDeactivationRequest{RuntimeID: runtimeID}); err != nil {
+		t.Fatalf("first.DeactivateRuntime(): %v", err)
+	}
+
+	second := newRuntimeCursorRoot(t, ports, stubCommandRunner{}, workflowID, composition.inputs)
+	if _, err := second.ActivateRuntime(context.Background(), composition.request); err != nil {
+		t.Fatalf("second.ActivateRuntime(): %v", err)
+	}
+	defer func() {
+		_, _ = second.DeactivateRuntime(context.Background(), automations.RuntimeDeactivationRequest{RuntimeID: runtimeID})
+	}()
+	recovered := waitForRuntimeCursor(t, second, supervision.InstanceID)
+	assertRuntimeCursor(t, recovered, workflowID, supervision.InstanceID, "second.GetCursor()")
+}
+
+type runtimeCursorComposition struct {
+	inputs  automationswire.HostedSourceInputs
+	request automations.RuntimeActivationRequest
+	poller  factorydefinitions.FactoryWorkstationConfig
+}
+
+func newRuntimeCursorComposition(
+	t *testing.T,
+	factoryDir, workflowID, runtimeID string,
+	clock clockwork.Clock,
+) runtimeCursorComposition {
+	t.Helper()
+	store, err := automationswire.NewHostedLinearCheckpointStore(platformfilesystem.Local{})
+	if err != nil {
+		t.Fatalf("NewHostedLinearCheckpointStore() error = %v", err)
+	}
+	inputs := automationswire.HostedSourceInputs{
+		Clock:            clock,
+		SecretResolver:   func(context.Context, automations.HostedRuntimePaths, string) (string, error) { return "secret", nil },
+		CheckpointStore:  store,
+		CursorFileSystem: platformfilesystem.Local{},
+	}
+	poller := factorydefinitions.FactoryWorkstationConfig{
+		Name:           "runtime-local-poller",
+		Kind:           factorydefinitions.WorkstationKindPoller,
+		WorkerTypeName: "runtime-local-script",
+	}
+	worker := factorydefinitions.FactoryWorkerConfig{
+		Name:    "runtime-local-script",
+		Type:    factorydefinitions.WorkerTypeScript,
+		Command: "poller.sh",
+	}
+	return runtimeCursorComposition{
+		inputs: inputs,
+		poller: poller,
+		request: automations.RuntimeActivationRequest{
+			RuntimeID:        runtimeID,
+			FactorySessionID: "session-runtime-local-cursor",
+			Snapshot: factorydefinitions.RuntimeSnapshot{
+				FactoryDir:     factoryDir,
+				RuntimeBaseDir: factoryDir,
+				Invocation: factorydefinitions.RuntimeSnapshotInvocationContext{
+					FactorySessionID: "session-runtime-local-cursor",
+					WorkflowID:       workflowID,
+				},
+				EffectiveFactory: factorydefinitions.FactoryConfig{
+					Name:         "runtime-local-factory",
+					Workers:      []factorydefinitions.FactoryWorkerConfig{worker},
+					Workstations: []factorydefinitions.FactoryWorkstationConfig{poller},
+				},
+			},
+			Inputs: automations.RuntimeActivationInputs{
+				StartSchedulers: true,
+				Submitter:       func(context.Context, work.WorkRequest) error { return nil },
+			},
+		},
+	}
+}
+
+func newRuntimeCursorRoot(
+	t *testing.T,
+	ports constructionPorts,
+	runner workers.CommandRunner,
+	workflowID string,
+	inputs automationswire.HostedSourceInputs,
+) automations.Root {
+	t.Helper()
+	root, err := automationswire.NewRoot(
+		ports.logger,
+		ports.clock,
+		runner,
+		workflowID,
+		"",
+		inputs,
+		ports.resolveTemplates,
+		ports.executionPolicy,
+	)
+	if err != nil {
+		t.Fatalf("NewRoot(): %v", err)
+	}
+	return root
+}
+
+func assertRuntimeCursor(
+	t *testing.T,
+	got automations.GetCursorResult,
+	workflowID, instanceID, label string,
+) {
+	t.Helper()
+	if got.AutomationID != workflowID || got.InstanceID != instanceID ||
+		got.Cursor != "runtime-local-cursor" || got.Checkpoint != "runtime-local-checkpoint" {
+		t.Fatalf("%s = %+v, want exact factory-local runtime facts", label, got)
+	}
+}
+
+func waitForRuntimeCursor(
+	t *testing.T,
+	root automations.Root,
+	instanceID string,
+) automations.GetCursorResult {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		cursor, err := root.GetCursor(context.Background(), automations.GetCursorRequest{InstanceID: instanceID})
+		if err == nil {
+			return cursor
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("GetCursor() did not recover within deadline: %v", err)
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+type runtimeCursorCommandRunner struct {
+	stdout  []byte
+	started chan struct{}
+	once    sync.Once
+}
+
+func (runner *runtimeCursorCommandRunner) Run(ctx context.Context, _ workers.CommandRequest) (workers.CommandResult, error) {
+	runner.once.Do(func() { close(runner.started) })
+	select {
+	case <-ctx.Done():
+		return workers.CommandResult{}, ctx.Err()
+	default:
+		return workers.CommandResult{Stdout: runner.stdout}, nil
+	}
+}
+
 const durableCursorStdout = `{"requestId":"durable-request","type":"FACTORY_REQUEST_BATCH","works":[{"name":"durable-work","workTypeName":"task"}],"cursor":"durable-cursor","checkpoint":"durable-checkpoint"}`
 
 type cursorCommandRunner struct {

--- a/pkg/services/edges/definition.go
+++ b/pkg/services/edges/definition.go
@@ -58,7 +58,13 @@ type Edges struct {
 	HostedSecretResolver          automations.HostedLinearSecretResolver
 	HostedLinearCheckpointStore   automations.HostedLinearCheckpointStore
 	HostedClock                   automations.HostedLinearClock
-	FactoryWebhookHTTPClient      interface {
+	AutomationsCursorFileSystem   interface {
+		ReadFile(string) ([]byte, error)
+		MkdirAll(string, fs.FileMode) error
+		WriteFile(string, []byte, fs.FileMode) error
+		Rename(string, string) error
+	}
+	FactoryWebhookHTTPClient interface {
 		Do(*http.Request) (*http.Response, error)
 	}
 	FactoryWebhookClock interface {
@@ -279,6 +285,9 @@ func Merge(defaults Edges, replacements Edges) Edges {
 	}
 	if replacements.HostedClock != nil {
 		defaults.HostedClock = replacements.HostedClock
+	}
+	if replacements.AutomationsCursorFileSystem != nil {
+		defaults.AutomationsCursorFileSystem = replacements.AutomationsCursorFileSystem
 	}
 	if replacements.FactoryWebhookHTTPClient != nil {
 		defaults.FactoryWebhookHTTPClient = replacements.FactoryWebhookHTTPClient

--- a/pkg/services/providers/internal/services/acp/internal/service/protocol_failure_classification_test.go
+++ b/pkg/services/providers/internal/services/acp/internal/service/protocol_failure_classification_test.go
@@ -62,7 +62,7 @@ func TestProtocolFailuresMapToStableExecuteFailureKinds(t *testing.T) {
 				Model:              "test-model",
 				UserMessage:        "classify ACP failure",
 				WorkingDirectory:   cwd,
-				ProcessEnvironment: append(os.Environ(), protocolHelperEnvironment+"="+test.mode),
+				ProcessEnvironment: protocolHelperProcessEnvironment(test.mode),
 			})
 			var failure providers.ExecuteFailure
 			if !errors.As(err, &failure) {
@@ -107,7 +107,7 @@ func TestPromptCancelledStopReasonMapsToExecuteFailureKindCanceled(t *testing.T)
 		Model:              "test-model",
 		UserMessage:        "cancelled turn",
 		WorkingDirectory:   t.TempDir(),
-		ProcessEnvironment: append(os.Environ(), protocolHelperEnvironment+"=cancelled-turn"),
+		ProcessEnvironment: protocolHelperProcessEnvironment("cancelled-turn"),
 	})
 	var failure providers.ExecuteFailure
 	if !errors.As(err, &failure) {
@@ -139,7 +139,7 @@ func TestACPExecuteObservesProviderSessionWhileAttemptIsLive(t *testing.T) {
 	go func() {
 		result, executeErr := serviceValue.Execute(context.Background(), "cursor-acp", providers.ExecuteRequest{
 			Provider: "cursor-acp", AttemptID: "attempt-live-observation", UserMessage: "observe the provider session",
-			WorkingDirectory: workingDirectory, ProcessEnvironment: append(os.Environ(), protocolHelperEnvironment+"=normal"),
+			WorkingDirectory: workingDirectory, ProcessEnvironment: protocolHelperProcessEnvironment("normal"),
 			SessionObserver: func(reference providers.SessionRef) {
 				observed <- reference
 				<-releaseObservation
@@ -195,7 +195,7 @@ func TestContinuationResumesExactSessionThroughSessionLoad(t *testing.T) {
 		AttemptID:          "attempt-resume",
 		UserMessage:        "continue the prior turn",
 		WorkingDirectory:   t.TempDir(),
-		ProcessEnvironment: append(os.Environ(), protocolHelperEnvironment+"=resume"),
+		ProcessEnvironment: protocolHelperProcessEnvironment("resume"),
 	}, reference)
 	if err != nil {
 		t.Fatalf("Execute() error = %v, want nil - the peer only implements session/load in resume mode", err)
@@ -234,7 +234,7 @@ func TestContinuationSessionLoadFailureDoesNotFallBackToFreshSession(t *testing.
 		AttemptID:          "attempt-resume-not-found",
 		UserMessage:        "continue the prior turn",
 		WorkingDirectory:   t.TempDir(),
-		ProcessEnvironment: append(os.Environ(), protocolHelperEnvironment+"=resume-not-found"),
+		ProcessEnvironment: protocolHelperProcessEnvironment("resume-not-found"),
 	}, reference)
 	var failure providers.ExecuteFailure
 	if !errors.As(err, &failure) {
@@ -290,15 +290,12 @@ func TestInitializeFailureRedactsConfiguredSecretsFromStderr(t *testing.T) {
 	t.Cleanup(func() { _ = serviceValue.Close(context.Background()) })
 
 	_, err = serviceValue.Execute(context.Background(), "cursor-acp", providers.ExecuteRequest{
-		Provider:         "cursor-acp",
-		AttemptID:        "attempt-stderr",
-		UserMessage:      "redact stderr",
-		WorkingDirectory: t.TempDir(),
-		EnvVars:          map[string]string{"ACP_TEST_API_TOKEN": "super-secret-token"},
-		ProcessEnvironment: append(os.Environ(),
-			protocolHelperEnvironment+"=stderr",
-			"ACP_TEST_API_TOKEN=super-secret-token",
-		),
+		Provider:           "cursor-acp",
+		AttemptID:          "attempt-stderr",
+		UserMessage:        "redact stderr",
+		WorkingDirectory:   t.TempDir(),
+		EnvVars:            map[string]string{"ACP_TEST_API_TOKEN": "super-secret-token"},
+		ProcessEnvironment: append(protocolHelperProcessEnvironment("stderr"), "ACP_TEST_API_TOKEN=super-secret-token"),
 	})
 	var failure providers.ExecuteFailure
 	if !errors.As(err, &failure) {
@@ -349,6 +346,18 @@ func protocolHelperCommandFactory(starts *atomic.Int32) func(name string, args .
 		}
 		return exec.Command(name, args...)
 	}
+}
+
+func protocolHelperProcessEnvironment(mode string) []string {
+	environment := make([]string, 0, len(os.Environ())+1)
+	for _, entry := range os.Environ() {
+		name, _, _ := strings.Cut(entry, "=")
+		if strings.EqualFold(name, protocolHelperEnvironment) {
+			continue
+		}
+		environment = append(environment, entry)
+	}
+	return append(environment, protocolHelperEnvironment+"="+mode)
 }
 
 // pkgmaintcheck:ignore-cyclomatic-complexity pre-existing baseline debt recorded 2026-08-08; refactor this code below the maintainability threshold and remove this exemption

--- a/pkg/wire/hosted_sources.go
+++ b/pkg/wire/hosted_sources.go
@@ -40,12 +40,17 @@ func provideAutomationHostedSourceInputs(
 	if secretResolver == nil {
 		secretResolver = automationswire.NewHostedLinearSecretResolver(os.Getenv, os.ReadFile)
 	}
+	cursorFileSystem := edges.AutomationsCursorFileSystem
+	if cursorFileSystem == nil {
+		cursorFileSystem = platformfilesystem.Local{}
+	}
 	return automationswire.HostedSourceInputs{
-		Clock:           clock,
-		HTTPClient:      httpClient,
-		SecretResolver:  secretResolver,
-		LinearEndpoint:  edges.HostedLinearEndpoint,
-		CheckpointStore: checkpointStore,
+		Clock:            clock,
+		HTTPClient:       httpClient,
+		SecretResolver:   secretResolver,
+		LinearEndpoint:   edges.HostedLinearEndpoint,
+		CheckpointStore:  checkpointStore,
+		CursorFileSystem: cursorFileSystem,
 	}, nil
 }
 


### PR DESCRIPTION
{
  "project": "Durable Script-Poller Cursors and Observable Watcher Failures",
  "branchName": "automations-durable-cursor-and-watcher-errors",
  "description": "Make production Automations recovery reliable and diagnosable by persisting script-poller cursor/checkpoint values across daemon reconstruction and emitting watcher-identity diagnostics when filesystem watcher sidecars fail or unexpectedly stop, without changing scheduling, cron, public interfaces, hosted sources, or Work-submission behavior.",
  "context": {
    "customerAsk": "Replace the production script poller's inert in-memory cursor recorder with durable Automations-owned persistence that survives process restart, and stop silently discarding filesystem watcher termination. Prove restart recovery with a newly constructed recorder that returns the exact committed values, and prove watcher failure observability with a diagnostic containing both watcher identity and the exact failure message.",
    "problem": "Production script pollers commit cursor and checkpoint values only to process-local memory, so every daemon restart loses the resume position and can re-poll old input. Separately, the runtime lifecycle discards the result of FilesystemWatcher.Watch; startup/watch errors and nil termination after an event-channel closure leave no operator signal, making a dead watcher indistinguishable from an idle factory.",
    "solution": "Add a durable implementation of the existing script-poller CursorRecorder using exact injected platform filesystem effects and a stable runtime/factory-local .infinite-you state path, wire it through canonical production Automations composition while retaining the memory recorder for tests, and observe watcher completion in the runtime lifecycle so non-cancellation errors and unexpected nil termination emit structured identity-bearing diagnostics. Preserve all existing scheduling, cursor conflict, cancellation, cron, public-interface, hosted-source, and Work-submission semantics."
  },
  "acceptanceCriteria": [
    "A script-poller cursor and checkpoint committed before a simulated process restart are returned with their exact automation ID, instance ID, cursor value, and checkpoint by a newly constructed recorder using the same durable location; the proof does not reuse the original recorder instance.",
    "The canonical production Automations composition uses the durable recorder through injected platform filesystem/storage effects and a stable runtime- or factory-local Automations state path, while the in-memory recorder remains available for isolated tests.",
    "Existing optimistic cursor semantics remain intact: a stale expected cursor is rejected, a successful durable replacement is readable, and a failed persistence attempt reports an actionable persistence failure without falsely reporting the new cursor as committed.",
    "A filesystem watcher that returns an error emits a structured error diagnostic containing a stable watcher identity or watched-root identity and the exact observed error; a watcher whose event stream closes and returns nil emits a distinct terminal diagnostic naming that watcher and the closure reason, while ordinary context-driven shutdown is not misreported as an operational failure.",
    "Scope remains inside Automations-owned composition, service.go, runtime_lifecycle.go, and the script-poller/filesystem-watcher internal packages as required; poll scheduling, cron behavior, public poller/watcher interfaces, hosted_sources, public API contracts, and generated artifacts are unchanged.",
    "Final quality gate: Typecheck passes; Tests pass for the focused Automations packages and required repository verification; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. Before its final push, implementation rebases onto current origin/main; the PR is opened ready for review, never as a draft."
  ],
  "userStories": [
    {
      "id": "automations-durable-cursor-and-watcher-errors-001",
      "title": "Resume script pollers from durable cursors",
      "description": "As an operator, I want a script poller's last committed cursor and checkpoint to survive daemon restarts so resumed polling does not start over and repeat old work.",
      "acceptanceCriteria": [
        "Committing a cursor persists the automation ID, stable instance ID, opaque cursor value, and opaque checkpoint at a deterministic Automations-owned location under the established runtime/factory-local .infinite-you state convention.",
        "A test commits a distinctive cursor and checkpoint, discards the recorder, constructs a new recorder over the same location, and asserts the exact recovered automation ID, instance ID, cursor, and checkpoint values.",
        "Production construction receives the exact filesystem/storage effect through the canonical Automations/wire composition path and selects the durable recorder; production code does not reach directly for os, process-global mutable state, or a second dependency graph.",
        "The in-memory recorder remains usable by existing focused tests and is not the production default.",
        "Missing state retains the current not-found behavior, stale expected cursors retain conflict behavior, and corrupt or unreadable durable state produces a classified, actionable error rather than silently resetting the cursor.",
        "Durable replacement is atomic enough that a failed write/commit does not erase or replace the last successfully committed cursor, and the caller receives the existing cursor-persistence failure classification.",
        "Focused tests assert recovered values and failure outcomes rather than only asserting that no error occurred or that storage artifacts exist.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented durable script-poller cursor/checkpoint persistence, canonical filesystem injection, restart reconstruction coverage, conflict/corruption classification, and atomic replacement coverage."
    },
    {
      "id": "automations-durable-cursor-and-watcher-errors-002",
      "title": "Report filesystem watcher termination",
      "description": "As an operator, I want a filesystem watcher that fails or unexpectedly stops to leave an identifiable diagnostic so I can distinguish a dead input watcher from an idle factory.",
      "acceptanceCriteria": [
        "When Watch returns a non-cancellation error, the runtime sidecar emits a structured error-level diagnostic that contains the runtime or watched-root identity and the exact returned error text.",
        "A focused lifecycle test injects a watcher failure with a distinctive message and asserts that the observed diagnostic contains both the watcher identity and that exact message; asserting only that some log exists is insufficient.",
        "When the underlying watcher event channel closes and Watch returns nil, the runtime emits a distinct warning-level terminal diagnostic naming the watcher and stating that its event stream closed or the watcher stopped unexpectedly.",
        "Normal runtime deactivation or context cancellation remains a normal shutdown path and is not logged as a watcher operational failure.",
        "This lane records watcher termination but does not add an Automations health-state transition: no existing public health contract represents a dead watcher, and adding one would expand the public lifecycle/interface scope. The PR explains this decision and identifies health-state propagation as separate follow-up work if desired.",
        "Poll scheduling, watcher retry/restart behavior, watcher and poller public interfaces, cron behavior, and Work-submission semantics are unchanged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented runtime watcher termination diagnostics with runtime and watched-root identity, exact returned errors, distinct event-stream closure warnings, cancellation suppression, and focused lifecycle coverage."
    }
  ]
}
