### PR TITLE
Grade Backend Size on the Current PR Merge Result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,11 +493,11 @@ jobs:
       LINT_REPORT_FILE: .artifacts/backend-lint/report.json
       LINT_LOG_FILE: .artifacts/backend-lint/lint.log
       LINT_COMMENT_FILE: .artifacts/backend-lint/comment.md
-      BACKEND_LINT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      BACKEND_LINT_TESTED_SHA: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
@@ -518,7 +518,6 @@ jobs:
         env:
           BACKEND_LINT_EVENT_NAME: ${{ github.event_name }}
           BACKEND_LINT_REF: ${{ github.ref }}
-          BACKEND_LINT_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
           BACKEND_LINT_SHA: ${{ github.sha }}
         run: |
           node --input-type=module <<'NODE'
@@ -526,13 +525,15 @@ jobs:
           const selection = selectBackendLint({
             eventName: process.env.BACKEND_LINT_EVENT_NAME,
             ref: process.env.BACKEND_LINT_REF,
-            pullRequestHeadSha: process.env.BACKEND_LINT_PR_HEAD_SHA,
             sha: process.env.BACKEND_LINT_SHA,
           });
-          if (!selection.selected || !selection.headSha) {
+          if (!selection.selected || selection.error) {
             throw new Error(`Backend Lint was not selected for its hosted event: ${JSON.stringify(selection)}`);
           }
-          console.log(`Backend Lint selected at ${selection.headSha}`);
+          if (selection.checkoutRef !== process.env.BACKEND_LINT_SHA) {
+            throw new Error(`Backend Lint checkout identity disagrees with its tested identity: ${JSON.stringify(selection)}`);
+          }
+          console.log(`Backend Lint selected tested SHA ${selection.testedSha}`);
           NODE
       - name: Compile functionallong test packages
         id: compile-functionallong

--- a/cmd/backendsizecheck/main_test.go
+++ b/cmd/backendsizecheck/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -302,6 +303,159 @@ func TestMakeBackendSizeAllowsRemovingDirectiveWithBaselineEntry(t *testing.T) {
 	writeGoFile(t, fixtureRoot, "pkg/service/legacy.go", "package service\n")
 	writeExemptionBaseline(t, fixtureRoot)
 	assertMakeBackendSizePasses(t, repoRoot, fixtureRoot)
+}
+
+func TestMakeBackendSizeRejectsViolationCreatedOnlyByCleanMerge(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve source repository root: %v", err)
+	}
+	fixtureRoot := t.TempDir()
+	fixturePath := "pkg/mergefixture/merge_fixture.go"
+	commonSource := backendSizeMergeFixtureSource()
+	writeGoFile(t, fixtureRoot, fixturePath, commonSource)
+	assertFixtureLineCount(t, fixtureRoot, fixturePath, 950)
+
+	initBackendSizeGitFixture(t, fixtureRoot)
+	runGitFixtureCommand(t, fixtureRoot, "add", "--all")
+	runGitFixtureCommand(t, fixtureRoot, "commit", "--quiet", "-m", "common ancestor")
+	runGitFixtureCommand(t, fixtureRoot, "branch", "base")
+
+	runGitFixtureCommand(t, fixtureRoot, "checkout", "--quiet", "base")
+	insertBackendSizeFixtureLines(t, fixtureRoot, fixturePath, "// base insertion point", 39, "base")
+	assertFixtureLineCount(t, fixtureRoot, fixturePath, 989)
+	runGitFixtureCommand(t, fixtureRoot, "add", "--all")
+	runGitFixtureCommand(t, fixtureRoot, "commit", "--quiet", "-m", "base side")
+
+	baseOutput, err := runBackendSizeMake(t, repoRoot, fixtureRoot)
+	if err != nil {
+		t.Fatalf("base side should pass backend-size: %v\n%s", err, baseOutput)
+	}
+	if !strings.Contains(baseOutput, "all owned Go backend files are within file limit 1000") {
+		t.Fatalf("base output = %q, want the unchanged 1000-line gate to pass", baseOutput)
+	}
+
+	runGitFixtureCommand(t, fixtureRoot, "checkout", "--quiet", "-b", "pull-request", "main")
+	insertBackendSizeFixtureLines(t, fixtureRoot, fixturePath, "// pull-request insertion point", 40, "pull-request")
+	assertFixtureLineCount(t, fixtureRoot, fixturePath, 990)
+	runGitFixtureCommand(t, fixtureRoot, "add", "--all")
+	runGitFixtureCommand(t, fixtureRoot, "commit", "--quiet", "-m", "pull-request side")
+
+	prOutput, err := runBackendSizeMake(t, repoRoot, fixtureRoot)
+	if err != nil {
+		t.Fatalf("head-only pull-request side should pass backend-size: %v\n%s", err, prOutput)
+	}
+	if !strings.Contains(prOutput, "all owned Go backend files are within file limit 1000") {
+		t.Fatalf("head-only pull-request output = %q, want the unchanged 1000-line gate to pass", prOutput)
+	}
+
+	runGitFixtureCommand(t, fixtureRoot, "checkout", "--quiet", "base")
+	runGitFixtureCommand(t, fixtureRoot, "merge", "--no-ff", "--no-commit", "pull-request")
+	assertFixtureLineCount(t, fixtureRoot, fixturePath, 1029)
+
+	combinedOutput, err := runBackendSizeMake(t, repoRoot, fixtureRoot)
+	if err == nil {
+		t.Fatalf("clean combined tree should fail backend-size, output:\n%s", combinedOutput)
+	}
+	for _, want := range []string{
+		"pkg/mergefixture | file pkg/mergefixture/merge_fixture.go has 1029 lines (limit 1000)",
+		"LINT_VIOLATION_COUNT: 1",
+	} {
+		if !strings.Contains(combinedOutput, want) {
+			t.Fatalf("combined backend-size output = %q, want property-specific diagnostic %q", combinedOutput, want)
+		}
+	}
+	t.Logf("combined backend-size diagnostic:\n%s", strings.TrimSpace(combinedOutput))
+}
+
+func backendSizeMergeFixtureSource() string {
+	lines := []string{"package mergefixture", ""}
+	for len(lines) < 400 {
+		lines = append(lines, fmt.Sprintf("// common line %03d", len(lines)+1))
+	}
+	lines = append(lines, "// pull-request insertion point")
+	for len(lines) < 800 {
+		lines = append(lines, fmt.Sprintf("// common line %03d", len(lines)+1))
+	}
+	lines = append(lines, "// base insertion point")
+	for len(lines) < 950 {
+		lines = append(lines, fmt.Sprintf("// common line %03d", len(lines)+1))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func initBackendSizeGitFixture(t *testing.T, repoRoot string) {
+	t.Helper()
+	runGitFixtureCommand(t, repoRoot, "init", "--quiet")
+	runGitFixtureCommand(t, repoRoot, "branch", "-M", "main")
+	runGitFixtureCommand(t, repoRoot, "config", "user.email", "backend-size-test@example.invalid")
+	runGitFixtureCommand(t, repoRoot, "config", "user.name", "Backend Size Test")
+	runGitFixtureCommand(t, repoRoot, "config", "commit.gpgSign", "false")
+}
+
+func insertBackendSizeFixtureLines(t *testing.T, repoRoot, relativePath, marker string, count int, label string) {
+	t.Helper()
+	path := filepath.Join(repoRoot, filepath.FromSlash(relativePath))
+	source, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", relativePath, err)
+	}
+	lines := strings.Split(string(source), "\n")
+	markerIndex := -1
+	for index, line := range lines {
+		if line == marker {
+			markerIndex = index
+			break
+		}
+	}
+	if markerIndex == -1 {
+		t.Fatalf("fixture %s does not contain insertion marker %q", relativePath, marker)
+	}
+	additions := make([]string, count)
+	for index := range additions {
+		additions[index] = fmt.Sprintf("// %s line %02d", label, index+1)
+	}
+	updated := make([]string, 0, len(lines)+len(additions))
+	updated = append(updated, lines[:markerIndex+1]...)
+	updated = append(updated, additions...)
+	updated = append(updated, lines[markerIndex+1:]...)
+	if err := os.WriteFile(path, []byte(strings.Join(updated, "\n")), 0o644); err != nil {
+		t.Fatalf("write fixture %s: %v", relativePath, err)
+	}
+}
+
+func assertFixtureLineCount(t *testing.T, repoRoot, relativePath string, want int) {
+	t.Helper()
+	source, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(relativePath)))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", relativePath, err)
+	}
+	got := 0
+	if len(source) > 0 {
+		got = strings.Count(string(source), "\n") + 1
+	}
+	if got != want {
+		t.Fatalf("fixture %s has %d lines, want %d", relativePath, got, want)
+	}
+}
+
+func runGitFixtureCommand(t *testing.T, repoRoot string, args ...string) string {
+	t.Helper()
+	commandArgs := append([]string{"-C", repoRoot}, args...)
+	command := exec.Command("git", commandArgs...)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}
+
+func runBackendSizeMake(t *testing.T, repoRoot, fixtureRoot string) (string, error) {
+	t.Helper()
+	command := exec.Command("make", "backend-size", "BACKEND_SIZE_ROOT="+filepath.ToSlash(fixtureRoot))
+	command.Dir = repoRoot
+	output, err := command.CombinedOutput()
+	return string(output), err
 }
 
 func assertMakeBackendSizePasses(t *testing.T, repoRoot, fixtureRoot string) {

--- a/scripts/ci/backend-lint-report.mjs
+++ b/scripts/ci/backend-lint-report.mjs
@@ -440,8 +440,8 @@ export function renderBackendLintSummary(summary) {
 
 export function renderBackendLintComment(summary, metadata = {}) {
 	const lines = [BACKEND_LINT_COMMENT_MARKER, renderBackendLintSummary(summary).trim()];
-	if (textValue(metadata.headSha)) {
-		lines.push(`- Hosted head: \`${textValue(metadata.headSha)}\``);
+	if (textValue(metadata.testedSha)) {
+		lines.push(`- Hosted tested SHA: \`${textValue(metadata.testedSha)}\``);
 	}
 	if (textValue(metadata.runUrl)) {
 		lines.push(`- Hosted run: ${textValue(metadata.runUrl)}`);
@@ -483,7 +483,7 @@ function runCli() {
 	const markdown = renderBackendLintSummary(summary);
 	appendFileSync(summaryPath, markdown);
 	writeFileSync(commentPath, renderBackendLintComment(summary, {
-		headSha: process.env.BACKEND_LINT_HEAD_SHA || process.env.GITHUB_SHA,
+		testedSha: process.env.BACKEND_LINT_TESTED_SHA,
 		runUrl: process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
 			? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
 			: "",

--- a/scripts/ci/backend-lint-report.test.mjs
+++ b/scripts/ci/backend-lint-report.test.mjs
@@ -68,7 +68,7 @@ function unallowlistedTarget(name, output) {
 	};
 }
 
-function runReporterCli(t, reportValue) {
+function runReporterCli(t, reportValue, environment = {}) {
 	const directory = mkdtempSync(join(tmpdir(), "backend-lint-report-test-"));
 	t.after(() => rmSync(directory, { recursive: true, force: true }));
 	const reportPath = join(directory, "report.json");
@@ -86,11 +86,16 @@ function runReporterCli(t, reportValue) {
 			"--comment",
 			commentPath,
 		],
-		{ cwd: process.cwd(), encoding: "utf8" },
+		{
+			cwd: process.cwd(),
+			encoding: "utf8",
+			env: { ...process.env, ...environment },
+		},
 	);
 	return {
 		...result,
 		summary: readFileSync(summaryPath, "utf8"),
+		comment: readFileSync(commentPath, "utf8"),
 	};
 }
 
@@ -459,13 +464,21 @@ test("a structurally valid report with zero checkers is a harness failure", () =
 
 test("PR publication includes a stable marker and hosted identity", () => {
 	const comment = renderBackendLintComment(summarizeBackendLintReport(report()), {
-		headSha: "abc123",
+		testedSha: "abc123",
 		runUrl: "https://github.com/example/repo/actions/runs/42",
 	});
 
 	assert.match(comment, new RegExp(BACKEND_LINT_COMMENT_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
-	assert.match(comment, /Hosted head: `abc123`/);
+	assert.match(comment, /Hosted tested SHA: `abc123`/);
 	assert.match(comment, /actions\/runs\/42/);
+});
+
+test("reporter CLI publishes the explicitly supplied tested SHA", (t) => {
+	const result = runReporterCli(t, report(), {
+		BACKEND_LINT_TESTED_SHA: "a".repeat(40),
+	});
+
+	assert.match(result.comment, /Hosted tested SHA: `a{40}`/);
 });
 
 test("a no-allowance target is gated from its first failing run", () => {

--- a/scripts/ci/backend-lint-workflow.mjs
+++ b/scripts/ci/backend-lint-workflow.mjs
@@ -4,6 +4,7 @@ export const BACKEND_LINT_EVENTS = Object.freeze(["pull_request", "push"]);
 // Keep this positive: the workflow must never pass an empty jobs value to
 // lintlane when runner parallelism discovery is unavailable.
 export const BACKEND_LINT_FALLBACK_JOBS = 2;
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/i;
 
 const RUNNER_PARALLELISM_MODULE = "./runner-parallelism.mjs";
 
@@ -66,17 +67,29 @@ export async function resolveBackendLintParallelism(
 export function selectBackendLint({
 	eventName = "",
 	ref = "",
-	pullRequestHeadSha = "",
 	sha = "",
 } = {}) {
 	const selected =
 		eventName === "pull_request" ||
 		(eventName === "push" && ref === "refs/heads/main");
-	const headSha = String(pullRequestHeadSha || sha).trim();
+	if (!selected) {
+		return {
+			selected: false,
+			testedSha: "",
+			checkoutRef: "",
+			error: "",
+		};
+	}
+
+	const testedSha = String(sha || "").trim();
+	const error = COMMIT_SHA_PATTERN.test(testedSha)
+		? ""
+		: `Backend Lint requires github.sha to be a 40-character commit SHA for ${eventName} events; received ${testedSha || "(empty)"}.`;
 	return {
 		selected,
-		headSha,
-		checkoutRef: selected ? headSha : "",
+		testedSha: error ? "" : testedSha,
+		checkoutRef: error ? "" : testedSha,
+		error,
 	};
 }
 

--- a/scripts/ci/backend-lint-workflow.test.mjs
+++ b/scripts/ci/backend-lint-workflow.test.mjs
@@ -15,28 +15,44 @@ import {
 } from "./backend-lint-workflow.mjs";
 import { resolveRunnerParallelism } from "./runner-parallelism.mjs";
 
-test("selects pull requests and pushes to main at the tested head", () => {
+const SHA = (character) => character.repeat(40);
+
+test("selects pull requests at the merge result and pushes to main at the tested commit", () => {
 	assert.deepEqual(
 		selectBackendLint({
 			eventName: "pull_request",
 			ref: "refs/pull/42/merge",
-			pullRequestHeadSha: "pr-head",
-			sha: "merge-sha",
+			pullRequestHeadSha: SHA("b"),
+			sha: SHA("a"),
 		}),
-		{ selected: true, headSha: "pr-head", checkoutRef: "pr-head" },
+		{ selected: true, testedSha: SHA("a"), checkoutRef: SHA("a"), error: "" },
 	);
 	assert.deepEqual(
 		selectBackendLint({
 			eventName: "push",
 			ref: "refs/heads/main",
-			sha: "main-head",
+			sha: SHA("b"),
 		}),
-		{ selected: true, headSha: "main-head", checkoutRef: "main-head" },
+		{ selected: true, testedSha: SHA("b"), checkoutRef: SHA("b"), error: "" },
 	);
-	assert.equal(
-		selectBackendLint({ eventName: "push", ref: "refs/heads/feature", sha: "feature-head" }).selected,
-		false,
+	assert.deepEqual(
+		selectBackendLint({ eventName: "push", ref: "refs/heads/feature", sha: SHA("c") }),
+		{ selected: false, testedSha: "", checkoutRef: "", error: "" },
 	);
+});
+
+test("fails selected events when the required tested identity is missing or invalid", () => {
+	for (const sha of ["", "not-a-commit-sha", "0".repeat(39)]) {
+		const selection = selectBackendLint({
+			eventName: "pull_request",
+			ref: "refs/pull/42/merge",
+			sha,
+		});
+		assert.equal(selection.selected, true);
+		assert.equal(selection.testedSha, "");
+		assert.equal(selection.checkoutRef, "");
+		assert.match(selection.error, /requires github\.sha/);
+	}
 });
 
 test("uses all valid logical CPUs for the exclusive CI runner", () => {


### PR DESCRIPTION
{
  "project": "Grade Backend Size on the Current PR Merge Result",
  "branchName": "ci-current-merge-backend-lint-gate",
  "description": "Make the backend-size policy evaluate the tree that a pull request would place on main, rather than the pull request head in isolation, and close the associated enforcement gap as far as repository permissions allow. The project prevents two independently compliant changes from combining into an oversized backend file that lands on main and makes Backend Lint red for unrelated pull requests.",
  "context": {
    "customerAsk": "Identify with evidence whether Backend Lint measures a pull request head instead of its merge result, whether branch enforcement can block a failing result, or both; fix the in-repository cause; demonstrate backend-size rejecting a two-sided combination that passes on each independently changed side; audit other counted whole-tree gates for the same exposure; and explicitly identify any repository-settings action that requires operator permission.",
    "problem": "The current Backend Lint selection contract prefers pull_request.head.sha, so a whole-tree checker can approve a branch that is below its limit while missing a violation created only when that branch is combined with the latest base. Main also currently has no branch protection, so even a correctly measured failure is not established as merge-blocking. This allowed an oversized merged file to turn the default branch and every subsequent pull request red.",
    "solution": "Use the hosted pull-request merge-result identity as the canonical checkout and reporting identity for Backend Lint while retaining the pushed commit for main runs. Add a deterministic behavioral demonstration that creates a common ancestor and two independently compliant sides, proves both sides pass at or below 1000 lines, then proves their clean combined tree reaches 1029 lines and is rejected with property-specific output. Audit the other counted Backend Lint gates for combined-tree dependence. If branch-protection settings cannot be changed by the worker, deliver the code/configuration half and state the exact required check-enforcement change for an operator without substituting a weaker workaround."
  },
  "acceptanceCriteria": [
    "The current workflow trigger, checkout/ref selection, tested-SHA reporting, and main branch-protection or ruleset state are re-derived with dated evidence; the report explicitly distinguishes head-only measurement from non-blocking enforcement and corrects the incident reconstruction if current evidence contradicts it.",
    "On a pull request, Backend Lint evaluates GitHub's current synthetic merge result for the pull request and reports that same tested identity; on a push to main, it evaluates the pushed main commit. Missing or invalid required identities fail explicitly rather than silently falling back to the PR head.",
    "An automated behavioral demonstration constructs a 950-line common ancestor, a 990-line pull-request side, a 989-line base side, and a clean 1029-line combined tree; it proves both independent sides pass the unchanged 1000-line rule and quotes property-specific checker output proving the combined tree fails because 1029 exceeds 1000.",
    "The audit names every other counted Backend Lint gate evaluated for combined-tree dependence and its disposition. The required repository ruleset or branch-protection change is applied when permissions allow; otherwise the PR clearly names the exact protected branch and required status checks, explains why the worker could not apply it, and states which in-repository half was delivered.",
    "Quality gate: Typecheck passes; tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. The pre-existing pkg-boundary packaged-service-structure migration debt recorded 2026-08-08 is not treated as an in-scope failure or an excuse for unrelated cleanup.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "ci-current-merge-backend-lint-gate-001",
      "title": "Evaluate Backend Lint on the merge result",
      "description": "As a maintainer merging concurrent backend changes, I want Backend Lint to inspect the pull request's current combined tree so a violation created only by the merge cannot be approved from head-only evidence.",
      "acceptanceCriteria": [
        "Before changing behavior, the implementation records the current pull-request event identity, checkout identity, reported tested SHA, push-to-main behavior, and branch-protection or ruleset result, explicitly classifying whether the observed gaps are head-only measurement, missing enforcement, or both.",
        "A pull-request Backend Lint run selects and checks out the event's current synthetic merge-result SHA, and the tested-SHA value used in its report and PR comment names that same merge-result SHA rather than the pull-request head.",
        "A push-to-main Backend Lint run continues to select and inspect the pushed main SHA, while unrelated push events remain unselected.",
        "A selected event with a blank, unavailable, or inconsistent required tested identity fails with an actionable selection/checkout error and does not claim to have measured the pull-request merge result.",
        "Focused workflow-selection tests cover pull-request merge-result selection, push-to-main selection, unselected events, and invalid identity failure.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented merge-result selection with explicit 40-character SHA validation, merge-result checkout/reporting, push-to-main selection, and fail-closed identity checks. Focused workflow/report tests and make test-ci-workflows pass; make typecheck passes after standard UI dependency setup. Baseline evidence recorded in progress.txt; ruleset enforcement remains story 003."
    },
    {
      "id": "ci-current-merge-backend-lint-gate-002",
      "title": "Demonstrate the two-sided size violation",
      "description": "As a reviewer, I want a deterministic reproduction of the escaped regression so I can see the unchanged size gate reject a violation that exists only in the combined tree.",
      "acceptanceCriteria": [
        "A repeatable isolated test creates a temporary Git history with a 950-line common ancestor and non-conflicting changes that yield a 990-line pull-request side, a 989-line base side, and a 1029-line combined tree without changing the repository's production Go files.",
        "The demonstration runs the actual backend-size enforcement path against both independent sides and proves each passes the unchanged 1000-line limit.",
        "The same demonstration runs the actual enforcement path against the combined tree, asserts a non-zero result, and captures property-specific output naming the fixture path, observed 1029-line count, and 1000-line limit.",
        "The demonstration fails on the parent behavior because head-only selection measures the 990-line side, and passes after merge-result selection because the 1029-line combined tree is the measured input; the PR body or comment quotes the failing-gate output.",
        "The test is deterministic, uses no network access or live GitHub mutation, and cleans up its isolated temporary repository.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added a deterministic temporary Git fixture with a 950-line common ancestor, 990-line PR side, 989-line base side, and clean 1029-line merge. The test runs make backend-size against both independent sides and the merged tree, asserting the exact 1029-versus-1000 property diagnostic and LINT_VIOLATION_COUNT marker. Focused cmd/backendsizecheck tests, make test, and make typecheck pass."
    },
    {
      "id": "ci-current-merge-backend-lint-gate-003",
      "title": "Close enforcement and audit combined-tree gates",
      "description": "As a repository operator, I want the merge-result check to be enforceable and adjacent counted gates assessed so the known escape cannot recur through an unprotected merge or an equivalent whole-tree checker.",
      "acceptanceCriteria": [
        "The audit evaluates the counted gates currently green on main—backend-size, pkg-maint, pkg-file-count, pkg-structure, and vet—and records for each whether its verdict can change because of the combined tree, whether the corrected Backend Lint checkout covers it, and whether any separate action is required.",
        "The audit does not modify or rebaseline deadcode, packaged-factory-consumption-check, pkg-boundary, or any unrelated checker, and it does not turn the lane into a command, route, registration, or repository inventory test.",
        "If the worker can manage repository rules, main is configured so the canonical Backend Lint/Verification Policy checks required by current repository policy must pass before merge. If permissions do not allow that change, the PR names the exact branch/ruleset and required check names, includes the observed API/permission response, and plainly states that merge-result measurement was delivered while enforcement still requires operator action.",
        "No weaker in-repository workaround is presented as equivalent to protected-branch enforcement, and no claim that the repository is protected is made without a successful read-back of the applied setting.",
        "Final evidence identifies the tested merge-result SHA, shows the two-sided backend-size failure output, and summarizes the sibling-gate audit in the PR discussion; CI-run evidence is posted only as a PR comment and is never committed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Audited backend-size, pkg-maint, pkg-file-count, pkg-structure, and vet: each evaluates the checked-out tree, so the merge-result checkout covers combined-tree dependence and no separate checker action is required. Legacy main protection remains absent (GET /branches/main/protection returned 404), while active ruleset must-pass-pr (15943501) was updated and read back on 2026-08-22 to require both Verification Policy and Backend Lint; main-protect (15809936) retains deletion/non-fast-forward rules. No deadcode, packaged-factory-consumption-check, pkg-boundary, or unrelated checker was changed."
    }
  ]
}
