### PR TITLE
test(functional): raise Factory Definitions coverage floor

### DIFF
--- a/tests/functional/factory/definitions/authored_layout_test.go
+++ b/tests/functional/factory/definitions/authored_layout_test.go
@@ -1,0 +1,253 @@
+package definitions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	authoredLayoutFactoryName     = "authored-layout-round-trip"
+	authoredLayoutWorkerName      = "executor"
+	authoredLayoutWorkstationName = "execute-task"
+	authoredLayoutWorkTypeName    = "task"
+)
+
+// TestFactoryConfigFlattenExpandRoundTripsThroughRootProcess proves the
+// customer-facing flatten and expand commands preserve a representative
+// Factory definition when they are executed through the reusable root process.
+func TestFactoryConfigFlattenExpandRoundTripsThroughRootProcess(t *testing.T) {
+	dir := t.TempDir()
+	factoryPath := filepath.Join(dir, "factory.json")
+	if err := os.WriteFile(factoryPath, authoredLayoutFactoryJSON(), 0o644); err != nil {
+		t.Fatalf("write authored Factory: %v", err)
+	}
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+
+	beforePayload, err := support.FlattenFactoryConfigWithProcess(t, process, dir)
+	if err != nil {
+		t.Fatalf("Process.Execute(factory config flatten before expand): %v", err)
+	}
+	before, err := support.DecodeFactoryDefinition(beforePayload)
+	if err != nil {
+		t.Fatalf("decode Factory before expand: %v", err)
+	}
+
+	expandInputs := support.FakeInputs(t.Context(), []string{
+		"you", "factory", "config", "expand", factoryPath,
+	})
+	expandInputs.Input.WorkingDirectory = dir
+	if err := process.Execute(expandInputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(factory config expand): %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			expandInputs.Stdout(),
+			expandInputs.Stderr(),
+		)
+	}
+	if !strings.Contains(expandInputs.Stdout(), "Expanded factory config into") {
+		t.Fatalf("expand output = %q, want success marker", expandInputs.Stdout())
+	}
+
+	assertAuthoredLayoutFilesMaterialized(t, dir)
+	afterPayload, err := support.FlattenFactoryConfigWithProcess(t, process, dir)
+	if err != nil {
+		t.Fatalf("Process.Execute(factory config flatten after expand): %v", err)
+	}
+	after, err := support.DecodeFactoryDefinition(afterPayload)
+	if err != nil {
+		t.Fatalf("decode Factory after expand: %v", err)
+	}
+
+	assertAuthoredLayoutFactoryPreserved(t, before, after)
+}
+
+func assertAuthoredLayoutFilesMaterialized(t *testing.T, dir string) {
+	t.Helper()
+
+	for _, relativePath := range []string{
+		filepath.Join("workers", authoredLayoutWorkerName, "AGENTS.md"),
+		filepath.Join("workstations", authoredLayoutWorkstationName, "AGENTS.md"),
+	} {
+		path := filepath.Join(dir, relativePath)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read expanded authored file %s: %v", relativePath, err)
+		}
+		if strings.TrimSpace(string(content)) == "" {
+			t.Fatalf("expanded authored file %s is empty", relativePath)
+		}
+	}
+}
+
+func assertAuthoredLayoutFactoryPreserved(
+	t *testing.T,
+	before factoryapi.Factory,
+	after factoryapi.Factory,
+) {
+	t.Helper()
+
+	if after.Name != before.Name || after.Name != authoredLayoutFactoryName {
+		t.Fatalf("Factory name after round trip = %q, want %q", after.Name, before.Name)
+	}
+
+	beforeWorkType, ok := authoredLayoutWorkType(before)
+	if !ok {
+		t.Fatalf("Factory before round trip missing work type %q", authoredLayoutWorkTypeName)
+	}
+	afterWorkType, ok := authoredLayoutWorkType(after)
+	if !ok {
+		t.Fatalf("Factory after round trip missing work type %q", authoredLayoutWorkTypeName)
+	}
+	if len(afterWorkType.States) != len(beforeWorkType.States) {
+		t.Fatalf("work type state count after round trip = %d, want %d", len(afterWorkType.States), len(beforeWorkType.States))
+	}
+	for index := range beforeWorkType.States {
+		beforeState := beforeWorkType.States[index]
+		afterState := afterWorkType.States[index]
+		if afterState.Name != beforeState.Name || afterState.Type != beforeState.Type {
+			t.Fatalf("work state %d after round trip = %#v, want %#v", index, afterState, beforeState)
+		}
+	}
+
+	beforeWorker, ok := support.FindFactoryWorker(before, authoredLayoutWorkerName)
+	if !ok {
+		t.Fatalf("Factory before round trip missing worker %q", authoredLayoutWorkerName)
+	}
+	afterWorker, ok := support.FindFactoryWorker(after, authoredLayoutWorkerName)
+	if !ok {
+		t.Fatalf("Factory after round trip missing worker %q", authoredLayoutWorkerName)
+	}
+	if stringValue(afterWorker.Body) != stringValue(beforeWorker.Body) {
+		t.Fatalf("worker body after round trip = %q, want %q", stringValue(afterWorker.Body), stringValue(beforeWorker.Body))
+	}
+
+	beforeWorkstation, ok := support.FindFactoryWorkstation(before, authoredLayoutWorkstationName)
+	if !ok {
+		t.Fatalf("Factory before round trip missing workstation %q", authoredLayoutWorkstationName)
+	}
+	afterWorkstation, ok := support.FindFactoryWorkstation(after, authoredLayoutWorkstationName)
+	if !ok {
+		t.Fatalf("Factory after round trip missing workstation %q", authoredLayoutWorkstationName)
+	}
+	if stringValue(afterWorkstation.Worker) != stringValue(beforeWorkstation.Worker) {
+		t.Fatalf("workstation worker after round trip = %q, want %q", stringValue(afterWorkstation.Worker), stringValue(beforeWorkstation.Worker))
+	}
+	assertWorkstationReferencesPreserved(t, beforeWorkstation, afterWorkstation)
+}
+
+func assertWorkstationReferencesPreserved(
+	t *testing.T,
+	before factoryapi.Workstation,
+	after factoryapi.Workstation,
+) {
+	t.Helper()
+
+	if len(after.Inputs) != len(before.Inputs) {
+		t.Fatalf("workstation input count after round trip = %d, want %d", len(after.Inputs), len(before.Inputs))
+	}
+	for index := range before.Inputs {
+		assertWorkstationIOPreserved(t, "input", index, before.Inputs[index], after.Inputs[index])
+	}
+	assertOptionalWorkstationReferences(t, "outputs", before.Outputs, after.Outputs)
+	assertOptionalWorkstationReferences(t, "onFailure", before.OnFailure, after.OnFailure)
+}
+
+func assertOptionalWorkstationReferences(
+	t *testing.T,
+	label string,
+	before *[]factoryapi.WorkstationIO,
+	after *[]factoryapi.WorkstationIO,
+) {
+	t.Helper()
+
+	if before == nil || after == nil {
+		if before != nil || after != nil {
+			t.Fatalf("workstation %s after round trip = %#v, want %#v", label, after, before)
+		}
+		return
+	}
+	if len(*after) != len(*before) {
+		t.Fatalf("workstation %s count after round trip = %d, want %d", label, len(*after), len(*before))
+	}
+	for index := range *before {
+		assertWorkstationIOPreserved(t, label, index, (*before)[index], (*after)[index])
+	}
+}
+
+func assertWorkstationIOPreserved(
+	t *testing.T,
+	label string,
+	index int,
+	before factoryapi.WorkstationIO,
+	after factoryapi.WorkstationIO,
+) {
+	t.Helper()
+
+	if after.WorkType != before.WorkType || after.State != before.State {
+		t.Fatalf("workstation %s %d after round trip = %#v, want workType=%q state=%q", label, index, after, before.WorkType, before.State)
+	}
+}
+
+func authoredLayoutWorkType(factory factoryapi.Factory) (factoryapi.WorkType, bool) {
+	if factory.WorkTypes == nil {
+		return factoryapi.WorkType{}, false
+	}
+	for _, workType := range *factory.WorkTypes {
+		if workType.Name == authoredLayoutWorkTypeName {
+			return workType, true
+		}
+	}
+	return factoryapi.WorkType{}, false
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func authoredLayoutFactoryJSON() []byte {
+	return []byte(`{
+  "name": "` + authoredLayoutFactoryName + `",
+  "workTypes": [{
+    "name": "` + authoredLayoutWorkTypeName + `",
+    "states": [
+      {"name": "init", "type": "INITIAL"},
+      {"name": "complete", "type": "TERMINAL"},
+      {"name": "failed", "type": "FAILED"}
+    ]
+  }],
+  "workers": [{
+    "name": "` + authoredLayoutWorkerName + `",
+    "type": "MODEL_WORKER",
+    "model": "claude-sonnet-4-20250514",
+    "modelProvider": "CLAUDE",
+    "stopToken": "COMPLETE",
+    "body": "You are the authored-layout executor."
+  }],
+  "workstations": [{
+    "id": "execute-task-id",
+    "name": "` + authoredLayoutWorkstationName + `",
+    "behavior": "STANDARD",
+    "worker": "` + authoredLayoutWorkerName + `",
+    "inputs": [{"workType": "` + authoredLayoutWorkTypeName + `", "state": "init"}],
+    "outputs": [{"workType": "` + authoredLayoutWorkTypeName + `", "state": "complete"}],
+    "onFailure": [{"workType": "` + authoredLayoutWorkTypeName + `", "state": "failed"}],
+    "definition": {
+      "type": "MODEL_WORKSTATION",
+      "worker": "` + authoredLayoutWorkerName + `",
+      "body": "Complete {{ (index .Inputs 0).WorkID }}.",
+      "stopWords": ["DONE"]
+    }
+  }]
+}`)
+}

--- a/tests/functional/factory/definitions/authored_layout_test.go
+++ b/tests/functional/factory/definitions/authored_layout_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
@@ -28,7 +28,7 @@ func TestFactoryConfigFlattenExpandRoundTripsThroughRootProcess(t *testing.T) {
 		t.Fatalf("write authored Factory: %v", err)
 	}
 
-	process := support.BuildProcess(t, serviceedges.Edges{})
+	process := buildDefinitionsProcess(t)
 	support.CleanupProcess(t, process)
 
 	beforePayload, err := support.FlattenFactoryConfigWithProcess(t, process, dir)
@@ -67,6 +67,44 @@ func TestFactoryConfigFlattenExpandRoundTripsThroughRootProcess(t *testing.T) {
 	}
 
 	assertAuthoredLayoutFactoryPreserved(t, before, after)
+}
+
+// TestFactoryDefinitionsServiceRootFlattensAndExpandsLayout exercises the
+// public Factory Definitions service-root operations behind the same authored
+// layout represented by the customer-facing Process.Execute scenario above.
+func TestFactoryDefinitionsServiceRootFlattensAndExpandsLayout(t *testing.T) {
+	dir := t.TempDir()
+	factoryPath := filepath.Join(dir, factorydefinitions.FactoryConfigFile)
+	if err := os.WriteFile(factoryPath, authoredLayoutFactoryJSON(), 0o644); err != nil {
+		t.Fatalf("write authored Factory: %v", err)
+	}
+
+	service := newFunctionalDefinitionsService(t)
+	flattened, err := service.FlattenFactoryLayout(
+		t.Context(),
+		factorydefinitions.FlattenFactoryLayoutRequest{Path: dir},
+	)
+	if err != nil {
+		t.Fatalf("Definitions.FlattenFactoryLayout: %v", err)
+	}
+	if len(strings.TrimSpace(string(flattened.Canonical))) == 0 {
+		t.Fatal("Definitions.FlattenFactoryLayout returned empty canonical source")
+	}
+	if err := os.WriteFile(factoryPath, flattened.Canonical, 0o644); err != nil {
+		t.Fatalf("write flattened Factory source: %v", err)
+	}
+
+	expanded, err := service.ExpandFactoryLayout(
+		t.Context(),
+		factorydefinitions.ExpandFactoryLayoutRequest{Path: factoryPath},
+	)
+	if err != nil {
+		t.Fatalf("Definitions.ExpandFactoryLayout: %v", err)
+	}
+	if expanded.FactoryDir != dir {
+		t.Fatalf("expanded FactoryDir = %q, want %q", expanded.FactoryDir, dir)
+	}
+	assertAuthoredLayoutFilesMaterialized(t, dir)
 }
 
 func assertAuthoredLayoutFilesMaterialized(t *testing.T, dir string) {

--- a/tests/functional/factory/definitions/compilation_test.go
+++ b/tests/functional/factory/definitions/compilation_test.go
@@ -1,0 +1,222 @@
+package definitions
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	compilationFactoryName     = "compilation-equivalence"
+	compilationWorkerName      = "executor"
+	compilationWorkstationName = "execute-story"
+	compilationWorkTypeName    = "story"
+	compilationInvalidFactory  = "compilation-invalid"
+	compilationMissingWorker   = "missing-executor"
+)
+
+// TestFactoryDefinitionsCompileAuthoredAndCanonicalSources proves the public
+// Factory Definitions root compiles an authored directory and its flattened
+// canonical representation into the same effective customer-visible source.
+func TestFactoryDefinitionsCompileAuthoredAndCanonicalSources(t *testing.T) {
+	dir := support.ScaffoldFactory(t, compilationFactoryConfig())
+	support.WriteAgentConfig(t, dir, compilationWorkerName, `---
+type: SCRIPT_WORKER
+command: go
+args: ["test", "./..."]
+---
+Execute the story.
+`)
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	canonical, err := support.FlattenFactoryConfigWithProcess(
+		t,
+		process,
+		dir,
+	)
+	if err != nil {
+		t.Fatalf("Process.Execute(factory config flatten): %v", err)
+	}
+	if len(strings.TrimSpace(string(canonical))) == 0 {
+		t.Fatal("flattened canonical Factory source is empty")
+	}
+
+	service := newFunctionalDefinitionsService(t)
+	fromDirectory, err := service.CompileEffectiveFactorySource(
+		t.Context(),
+		factorydefinitions.CompileEffectiveFactorySourceRequest{FactoryDir: dir},
+	)
+	if err != nil {
+		t.Fatalf("Definitions.CompileEffectiveFactorySource(directory): %v", err)
+	}
+	fromCanonical, err := service.CompileEffectiveFactorySource(
+		t.Context(),
+		factorydefinitions.CompileEffectiveFactorySourceRequest{
+			Canonical:  canonical,
+			FactoryDir: dir,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Definitions.CompileEffectiveFactorySource(canonical): %v", err)
+	}
+
+	if fromDirectory.Effective.FactoryDir != dir ||
+		fromDirectory.Effective.RuntimeBaseDir != dir {
+		t.Fatalf(
+			"directory effective identity = %#v, want FactoryDir and RuntimeBaseDir %q",
+			fromDirectory.Effective,
+			dir,
+		)
+	}
+	if fromCanonical.Effective.FactoryDir != dir ||
+		fromCanonical.Effective.RuntimeBaseDir != dir {
+		t.Fatalf(
+			"canonical effective identity = %#v, want FactoryDir and RuntimeBaseDir %q",
+			fromCanonical.Effective,
+			dir,
+		)
+	}
+	if fromDirectory.Effective.ContentIdentity != fromCanonical.Effective.ContentIdentity {
+		t.Fatalf(
+			"equivalent Factory sources produced different effective identities:\n directory=%s\n canonical=%s",
+			fromDirectory.Effective.ContentIdentity,
+			fromCanonical.Effective.ContentIdentity,
+		)
+	}
+
+	effective := decodeCompiledFactory(t, fromDirectory.Effective.ContentIdentity)
+	if effective.Name != compilationFactoryName {
+		t.Fatalf("effective Factory name = %q, want %q", effective.Name, compilationFactoryName)
+	}
+	worker, ok := support.FindFactoryWorker(effective, compilationWorkerName)
+	if !ok {
+		t.Fatalf("effective Factory is missing worker %q", compilationWorkerName)
+	}
+	if worker.Command == nil || *worker.Command != "go" || worker.Args == nil || len(*worker.Args) != 2 || (*worker.Args)[0] != "test" || (*worker.Args)[1] != "./..." {
+		t.Fatalf("effective worker = %#v, want authored command and args", worker)
+	}
+	workstation, ok := support.FindFactoryWorkstation(effective, compilationWorkstationName)
+	if !ok {
+		t.Fatalf("effective Factory is missing workstation %q", compilationWorkstationName)
+	}
+	if workstation.Worker == nil || *workstation.Worker != compilationWorkerName {
+		t.Fatalf("effective workstation worker = %v, want %q", workstation.Worker, compilationWorkerName)
+	}
+	if len(workstation.Inputs) != 1 || workstation.Inputs[0].WorkType != compilationWorkTypeName {
+		t.Fatalf("effective workstation inputs = %#v, want one %q input; effective=%#v", workstation.Inputs, compilationWorkTypeName, effective)
+	}
+
+	assertCompileFailures(t, service)
+}
+
+func decodeCompiledFactory(t *testing.T, identity string) factoryapi.Factory {
+	t.Helper()
+	var effective factoryapi.Factory
+	if err := json.Unmarshal([]byte(identity), &effective); err != nil {
+		t.Fatalf("decode effective Factory identity: %v", err)
+	}
+	return effective
+}
+
+func assertCompileFailures(t *testing.T, service factorydefinitions.Service) {
+	t.Helper()
+	if _, err := service.CompileEffectiveFactorySource(
+		t.Context(),
+		factorydefinitions.CompileEffectiveFactorySourceRequest{Canonical: []byte("{")},
+	); !errors.Is(err, factorydefinitions.ErrInvalidAuthoredFactorySource) {
+		t.Fatalf("invalid canonical compile error = %v, want ErrInvalidAuthoredFactorySource", err)
+	}
+	if _, err := service.CompileEffectiveFactorySource(
+		t.Context(),
+		factorydefinitions.CompileEffectiveFactorySourceRequest{
+			Canonical: []byte(`{"worker":"$unresolved"}`),
+		},
+	); !errors.Is(err, factorydefinitions.ErrUnresolvedDefinitionReference) {
+		t.Fatalf("unresolved canonical compile error = %v, want ErrUnresolvedDefinitionReference", err)
+	}
+}
+
+// TestFactoryDefinitionsRejectInvalidReferenceWithoutPersistence proves a
+// customer-facing named Factory create rejects an unresolved worker reference
+// before it creates or activates a durable Factory directory.
+func TestFactoryDefinitionsRejectInvalidReferenceWithoutPersistence(t *testing.T) {
+	dir := support.ScaffoldFactory(t, compilationInvalidFactoryConfig())
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	namedFactoriesRoot := filepath.Join(t.TempDir(), "factories")
+	if err := os.MkdirAll(namedFactoriesRoot, 0o755); err != nil {
+		t.Fatalf("create named Factory root: %v", err)
+	}
+
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "--json", "factory", "create", compilationInvalidFactory,
+		"--from", filepath.Join(dir, factorydefinitions.FactoryConfigFile),
+		"--dir", namedFactoriesRoot,
+	})
+	inputs.Input.WorkingDirectory = dir
+	err := process.Execute(inputs.Input)
+	if err == nil {
+		t.Fatalf(
+			"Process.Execute(factory create invalid reference) error = nil; stdout=%q stderr=%q",
+			inputs.Stdout(),
+			inputs.Stderr(),
+		)
+	}
+	diagnostic := err.Error() + "\n" + inputs.Stdout() + "\n" + inputs.Stderr()
+	for _, want := range []string{
+		"invalid factory config",
+		validationCodeDanglingWorkerReference,
+		compilationMissingWorker,
+	} {
+		if !strings.Contains(diagnostic, want) {
+			t.Fatalf("customer diagnostic = %q, want %q", diagnostic, want)
+		}
+	}
+	if _, statErr := os.Stat(filepath.Join(namedFactoriesRoot, compilationInvalidFactory)); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf(
+			"invalid Factory target stat error = %v, want target directory to remain absent",
+			statErr,
+		)
+	}
+}
+
+func compilationFactoryConfig() map[string]any {
+	return map[string]any{
+		"name": compilationFactoryName,
+		"workTypes": []map[string]any{{
+			"name": compilationWorkTypeName,
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "complete", "type": "TERMINAL"},
+			},
+		}},
+		"workers": []map[string]string{{"name": compilationWorkerName}},
+		"workstations": []map[string]any{{
+			"name":    compilationWorkstationName,
+			"worker":  compilationWorkerName,
+			"inputs":  []map[string]string{{"workType": compilationWorkTypeName, "state": "init"}},
+			"outputs": []map[string]string{{"workType": compilationWorkTypeName, "state": "complete"}},
+		}},
+	}
+}
+
+func compilationInvalidFactoryConfig() map[string]any {
+	config := compilationFactoryConfig()
+	config["name"] = compilationInvalidFactory
+	config["workstations"] = []map[string]any{{
+		"name":    compilationWorkstationName,
+		"worker":  compilationMissingWorker,
+		"inputs":  []map[string]string{{"workType": compilationWorkTypeName, "state": "init"}},
+		"outputs": []map[string]string{{"workType": compilationWorkTypeName, "state": "complete"}},
+	}}
+	return config
+}

--- a/tests/functional/factory/definitions/doc.go
+++ b/tests/functional/factory/definitions/doc.go
@@ -1,0 +1,3 @@
+// Package definitions owns customer-level functional coverage for Factory
+// Definitions authoring, compilation, validation, and portability behavior.
+package definitions

--- a/tests/functional/factory/definitions/execution_catalog_test.go
+++ b/tests/functional/factory/definitions/execution_catalog_test.go
@@ -383,12 +383,13 @@ func functionalExecutionCatalogReferences() factorydefinitions.ExecutionCatalogR
 
 func newFunctionalDefinitionsService(t *testing.T) factorydefinitions.Service {
 	t.Helper()
+	loader := functionalDefinitionsLoader(t)
 	service, err := factorydefinitionswire.NewService(
 		functionalSessionHost{},
 		functionalActivationGateway{},
 		functionalValidator{},
 		functionalPersistence{},
-		&factorydefinitionswire.Loader{},
+		loader,
 		func(string, *factorydefinitions.FactoryConfig, bool, bool) error { return nil },
 		func(string, *factorydefinitions.FactoryConfig) error { return nil },
 		functionalNamedPaths{},
@@ -423,6 +424,24 @@ func newFunctionalDefinitionsService(t *testing.T) factorydefinitions.Service {
 		t.Fatal("public Definitions service is nil")
 	}
 	return service
+}
+
+func functionalDefinitionsLoader(t *testing.T) *factorydefinitionswire.Loader {
+	t.Helper()
+	fileSystem := platformfilesystem.Local{}
+	return factorydefinitionswire.NewLoader(
+		func(string, *factorydefinitions.FactoryConfig, bool, bool) error { return nil },
+		func(string, *factorydefinitions.FactoryConfig) error { return nil },
+		func(string, *factorydefinitions.FactoryConfig) ([]factorydefinitions.PortableBundledFileReplacement, error) {
+			return nil, nil
+		},
+		fileSystem,
+		functionalNamedPaths{},
+		fileSystem,
+		func(string, factorydefinitions.BundledFileConfig) (string, bool) { return "", false },
+		fileSystem,
+		functionalRequiredToolChecker{},
+	)
 }
 
 // These inert adapters keep this test focused on the public Definitions root.

--- a/tests/functional/factory/definitions/process.go
+++ b/tests/functional/factory/definitions/process.go
@@ -1,0 +1,13 @@
+package definitions
+
+import (
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+func buildDefinitionsProcess(t testing.TB) support.Process {
+	t.Helper()
+	return support.BuildProcess(t, serviceedges.Edges{})
+}

--- a/tests/functional/factory/definitions/snapshots_portability_test.go
+++ b/tests/functional/factory/definitions/snapshots_portability_test.go
@@ -1,0 +1,157 @@
+package definitions
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const snapshotPortabilityImportedName = "snapshot-service-import"
+
+// TestFactoryDefinitionsPortableSnapshotRoundTripThroughServiceRoot exercises
+// detached snapshot capture, prepare-import, and materialization through the
+// public Definitions root before importing the same payload through the public
+// named Factory command and observing its portable assets.
+func TestFactoryDefinitionsPortableSnapshotRoundTripThroughServiceRoot(t *testing.T) {
+	sourceDir := support.ScaffoldFactory(t, importExportPortableFactoryConfig())
+	seedImportExportPortableFilesOnDisk(t, sourceDir)
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	canonical, err := support.FlattenFactoryConfigWithProcess(
+		t,
+		process,
+		filepath.Join(sourceDir, factorydefinitions.FactoryConfigFile),
+	)
+	if err != nil {
+		t.Fatalf("Process.Execute(factory config flatten): %v", err)
+	}
+
+	service := newFunctionalDefinitionsService(t)
+	captured, err := service.CaptureFactorySnapshot(
+		t.Context(),
+		factorydefinitions.CaptureFactorySnapshotRequest{
+			FactoryDir: sourceDir,
+			Canonical:  canonical,
+			Name:       importExportSourceName,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Definitions.CaptureFactorySnapshot: %v", err)
+	}
+	if captured.Snapshot == nil {
+		t.Fatal("Definitions.CaptureFactorySnapshot returned a nil snapshot")
+	}
+
+	payload, err := json.Marshal(captured.Snapshot)
+	if err != nil {
+		t.Fatalf("marshal detached Factory snapshot: %v", err)
+	}
+	exportedFactory, err := support.DecodeFactoryDefinition(payload)
+	if err != nil {
+		t.Fatalf("decode detached Factory snapshot: %v", err)
+	}
+	assertImportExportPortableBundledFileInline(
+		t,
+		exportedFactory,
+		factoryapi.BundledFileTypeDOC,
+		importExportPortableDocPath,
+		importExportPortableDocBody,
+		"captured snapshot",
+	)
+	assertImportExportPortableBundledFileInline(
+		t,
+		exportedFactory,
+		factoryapi.BundledFileTypeSCRIPT,
+		importExportPortableScriptPath,
+		importExportPortableScriptBody,
+		"captured snapshot",
+	)
+	assertImportExportPortableLayoutNote(t, exportedFactory, "captured snapshot")
+
+	prepared, err := service.PrepareFactorySnapshotImport(
+		t.Context(),
+		factorydefinitions.PrepareFactorySnapshotImportRequest{Payload: payload},
+	)
+	if err != nil {
+		t.Fatalf("Definitions.PrepareFactorySnapshotImport: %v", err)
+	}
+	if prepared.Snapshot == nil || prepared.Name != importExportSourceName {
+		t.Fatalf("prepared snapshot result = %#v, want %q identity", prepared, importExportSourceName)
+	}
+	if prepared.Portable.FactoryDir != sourceDir {
+		t.Fatalf("prepared snapshot FactoryDir = %q, want %q", prepared.Portable.FactoryDir, sourceDir)
+	}
+
+	materializedDir := t.TempDir()
+	materialized, err := service.MaterializeFactorySnapshot(
+		t.Context(),
+		factorydefinitions.MaterializeFactorySnapshotRequest{
+			TargetDir: materializedDir,
+			Snapshot:  prepared.Snapshot,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Definitions.MaterializeFactorySnapshot: %v", err)
+	}
+	if materialized.TargetDir != materializedDir || materialized.Portable.FactoryDir != materializedDir {
+		t.Fatalf("materialized snapshot result = %#v, want target %q", materialized, materializedDir)
+	}
+
+	snapshotPath := filepath.Join(t.TempDir(), "factory-snapshot.json")
+	if err := os.WriteFile(snapshotPath, payload, 0o644); err != nil {
+		t.Fatalf("write detached Factory snapshot: %v", err)
+	}
+	homeDir := t.TempDir()
+	workingDir := t.TempDir()
+	env := append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	importedDir := support.CreateNamedFactoryWithProcess(
+		t,
+		process,
+		homeDir,
+		workingDir,
+		snapshotPortabilityImportedName,
+		snapshotPath,
+	)
+	assertImportExportPortableFileOnDisk(
+		t,
+		filepath.Join(importedDir, "docs", "standards", "review.md"),
+		importExportPortableDocBody,
+	)
+	assertImportExportPortableFileOnDisk(
+		t,
+		filepath.Join(importedDir, "scripts", "execute-task.sh"),
+		importExportPortableScriptBody,
+	)
+
+	importedFactory, err := support.LoadedFactoryWithProcessAndEnv(
+		t,
+		process,
+		env,
+		filepath.Join(importedDir, factorydefinitions.FactoryConfigFile),
+	)
+	if err != nil {
+		t.Fatalf("load named Factory imported from snapshot: %v", err)
+	}
+	assertImportExportPortableBundledFile(
+		t,
+		importedFactory,
+		factoryapi.BundledFileTypeDOC,
+		importExportPortableDocPath,
+		"named imported Factory",
+	)
+	assertImportExportPortableBundledFile(
+		t,
+		importedFactory,
+		factoryapi.BundledFileTypeSCRIPT,
+		importExportPortableScriptPath,
+		"named imported Factory",
+	)
+	assertImportExportPortableLayoutNote(t, importedFactory, "named imported Factory")
+}

--- a/tests/functional/factory/definitions/snapshots_portability_test.go
+++ b/tests/functional/factory/definitions/snapshots_portability_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
@@ -22,8 +21,20 @@ func TestFactoryDefinitionsPortableSnapshotRoundTripThroughServiceRoot(t *testin
 	sourceDir := support.ScaffoldFactory(t, importExportPortableFactoryConfig())
 	seedImportExportPortableFilesOnDisk(t, sourceDir)
 
-	process := support.BuildProcess(t, serviceedges.Edges{})
+	process := buildDefinitionsProcess(t)
 	support.CleanupProcess(t, process)
+	canonical := snapshotCanonicalSource(t, process, sourceDir)
+
+	service := newFunctionalDefinitionsService(t)
+	payload := captureSnapshotPayload(t, service, sourceDir, canonical)
+	prepared := prepareSnapshotImport(t, service, payload, sourceDir)
+	materializeSnapshot(t, service, prepared.Snapshot)
+	importedDir, env := importSnapshotThroughNamedFactory(t, process, payload)
+	assertImportedSnapshot(t, process, importedDir, env)
+}
+
+func snapshotCanonicalSource(t *testing.T, process support.Process, sourceDir string) []byte {
+	t.Helper()
 	canonical, err := support.FlattenFactoryConfigWithProcess(
 		t,
 		process,
@@ -32,8 +43,11 @@ func TestFactoryDefinitionsPortableSnapshotRoundTripThroughServiceRoot(t *testin
 	if err != nil {
 		t.Fatalf("Process.Execute(factory config flatten): %v", err)
 	}
+	return canonical
+}
 
-	service := newFunctionalDefinitionsService(t)
+func captureSnapshotPayload(t *testing.T, service factorydefinitions.Service, sourceDir string, canonical []byte) []byte {
+	t.Helper()
 	captured, err := service.CaptureFactorySnapshot(
 		t.Context(),
 		factorydefinitions.CaptureFactorySnapshotRequest{
@@ -48,7 +62,6 @@ func TestFactoryDefinitionsPortableSnapshotRoundTripThroughServiceRoot(t *testin
 	if captured.Snapshot == nil {
 		t.Fatal("Definitions.CaptureFactorySnapshot returned a nil snapshot")
 	}
-
 	payload, err := json.Marshal(captured.Snapshot)
 	if err != nil {
 		t.Fatalf("marshal detached Factory snapshot: %v", err)
@@ -57,24 +70,14 @@ func TestFactoryDefinitionsPortableSnapshotRoundTripThroughServiceRoot(t *testin
 	if err != nil {
 		t.Fatalf("decode detached Factory snapshot: %v", err)
 	}
-	assertImportExportPortableBundledFileInline(
-		t,
-		exportedFactory,
-		factoryapi.BundledFileTypeDOC,
-		importExportPortableDocPath,
-		importExportPortableDocBody,
-		"captured snapshot",
-	)
-	assertImportExportPortableBundledFileInline(
-		t,
-		exportedFactory,
-		factoryapi.BundledFileTypeSCRIPT,
-		importExportPortableScriptPath,
-		importExportPortableScriptBody,
-		"captured snapshot",
-	)
+	assertImportExportPortableBundledFileInline(t, exportedFactory, factoryapi.BundledFileTypeDOC, importExportPortableDocPath, importExportPortableDocBody, "captured snapshot")
+	assertImportExportPortableBundledFileInline(t, exportedFactory, factoryapi.BundledFileTypeSCRIPT, importExportPortableScriptPath, importExportPortableScriptBody, "captured snapshot")
 	assertImportExportPortableLayoutNote(t, exportedFactory, "captured snapshot")
+	return payload
+}
 
+func prepareSnapshotImport(t *testing.T, service factorydefinitions.Service, payload []byte, sourceDir string) factorydefinitions.PrepareFactorySnapshotImportResult {
+	t.Helper()
 	prepared, err := service.PrepareFactorySnapshotImport(
 		t.Context(),
 		factorydefinitions.PrepareFactorySnapshotImportRequest{Payload: payload},
@@ -88,14 +91,15 @@ func TestFactoryDefinitionsPortableSnapshotRoundTripThroughServiceRoot(t *testin
 	if prepared.Portable.FactoryDir != sourceDir {
 		t.Fatalf("prepared snapshot FactoryDir = %q, want %q", prepared.Portable.FactoryDir, sourceDir)
 	}
+	return prepared
+}
 
+func materializeSnapshot(t *testing.T, service factorydefinitions.Service, snapshot *factorydefinitions.FactorySnapshot) {
+	t.Helper()
 	materializedDir := t.TempDir()
 	materialized, err := service.MaterializeFactorySnapshot(
 		t.Context(),
-		factorydefinitions.MaterializeFactorySnapshotRequest{
-			TargetDir: materializedDir,
-			Snapshot:  prepared.Snapshot,
-		},
+		factorydefinitions.MaterializeFactorySnapshotRequest{TargetDir: materializedDir, Snapshot: snapshot},
 	)
 	if err != nil {
 		t.Fatalf("Definitions.MaterializeFactorySnapshot: %v", err)
@@ -103,7 +107,10 @@ func TestFactoryDefinitionsPortableSnapshotRoundTripThroughServiceRoot(t *testin
 	if materialized.TargetDir != materializedDir || materialized.Portable.FactoryDir != materializedDir {
 		t.Fatalf("materialized snapshot result = %#v, want target %q", materialized, materializedDir)
 	}
+}
 
+func importSnapshotThroughNamedFactory(t *testing.T, process support.Process, payload []byte) (string, []string) {
+	t.Helper()
 	snapshotPath := filepath.Join(t.TempDir(), "factory-snapshot.json")
 	if err := os.WriteFile(snapshotPath, payload, 0o644); err != nil {
 		t.Fatalf("write detached Factory snapshot: %v", err)
@@ -111,47 +118,19 @@ func TestFactoryDefinitionsPortableSnapshotRoundTripThroughServiceRoot(t *testin
 	homeDir := t.TempDir()
 	workingDir := t.TempDir()
 	env := append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
-	importedDir := support.CreateNamedFactoryWithProcess(
-		t,
-		process,
-		homeDir,
-		workingDir,
-		snapshotPortabilityImportedName,
-		snapshotPath,
-	)
-	assertImportExportPortableFileOnDisk(
-		t,
-		filepath.Join(importedDir, "docs", "standards", "review.md"),
-		importExportPortableDocBody,
-	)
-	assertImportExportPortableFileOnDisk(
-		t,
-		filepath.Join(importedDir, "scripts", "execute-task.sh"),
-		importExportPortableScriptBody,
-	)
+	importedDir := support.CreateNamedFactoryWithProcess(t, process, homeDir, workingDir, snapshotPortabilityImportedName, snapshotPath)
+	assertImportExportPortableFileOnDisk(t, filepath.Join(importedDir, "docs", "standards", "review.md"), importExportPortableDocBody)
+	assertImportExportPortableFileOnDisk(t, filepath.Join(importedDir, "scripts", "execute-task.sh"), importExportPortableScriptBody)
+	return importedDir, env
+}
 
-	importedFactory, err := support.LoadedFactoryWithProcessAndEnv(
-		t,
-		process,
-		env,
-		filepath.Join(importedDir, factorydefinitions.FactoryConfigFile),
-	)
+func assertImportedSnapshot(t *testing.T, process support.Process, importedDir string, env []string) {
+	t.Helper()
+	importedFactory, err := support.LoadedFactoryWithProcessAndEnv(t, process, env, filepath.Join(importedDir, factorydefinitions.FactoryConfigFile))
 	if err != nil {
 		t.Fatalf("load named Factory imported from snapshot: %v", err)
 	}
-	assertImportExportPortableBundledFile(
-		t,
-		importedFactory,
-		factoryapi.BundledFileTypeDOC,
-		importExportPortableDocPath,
-		"named imported Factory",
-	)
-	assertImportExportPortableBundledFile(
-		t,
-		importedFactory,
-		factoryapi.BundledFileTypeSCRIPT,
-		importExportPortableScriptPath,
-		"named imported Factory",
-	)
+	assertImportExportPortableBundledFile(t, importedFactory, factoryapi.BundledFileTypeDOC, importExportPortableDocPath, "named imported Factory")
+	assertImportExportPortableBundledFile(t, importedFactory, factoryapi.BundledFileTypeSCRIPT, importExportPortableScriptPath, "named imported Factory")
 	assertImportExportPortableLayoutNote(t, importedFactory, "named imported Factory")
 }


### PR DESCRIPTION
{
  "project": "Exercise five Factory Definitions packages above the functional default floor",
  "branchName": "cov-functional-floor-factory-definitions",
  "description": "Add focused customer-level functional scenarios for existing Factory Definitions authoring, compilation, and portable snapshot behavior so five named packages each reach the unchanged 15.00% functional default in the PR's own hosted Backend Functional Coverage run, without changing product behavior or coverage policy.",
  "context": {
    "customerAsk": "Exercise authoring_layout/expand, authoring_layout/flatten, authoring_layout/internal/service, compilation/internal/service, and snapshots_portability/internal/service through public or service-root customer behavior so each reaches the existing 15.00% functional default; do not lower, pin, exempt, quarantine, or bypass the floor.",
    "problem": "Final-head CI run 32558871495 measured all five unlisted Factory Definitions packages below 15.00%. Hosted job 97000065243 reported 0.00%, 0.00%, 4.8780%, 4.0000%, and 3.1746% respectively, while advisory policy allowed the behavioral coverage gap to remain non-blocking.",
    "solution": "Add deterministic functional scenarios built through root.BuildProcess and executed through Process.Execute or Factory Definitions service-root operations. Cover split-layout flatten/expand round trips, effective-source compilation, and portable snapshot export/import, then verify package-specific percentages in this PR's hosted Backend Functional Coverage output without changing production behavior or any coverage control."
  },
  "acceptanceCriteria": [
    "Focused functional scenarios construct through root.BuildProcess and use Process.Execute or the Factory Definitions service-root contract to traverse customer behavior; functional tests do not import private implementation packages merely to manufacture coverage.",
    "Public authored-layout, effective-source compilation, and portable snapshot scenarios assert resulting Factory definitions, diagnostics, and materialized assets from a customer or service-root perspective without changing production behavior.",
    "The PR's own hosted Backend Functional Coverage property-specific output names authoring_layout/expand, authoring_layout/flatten, authoring_layout/internal/service, compilation/internal/service, and snapshots_portability/internal/service, and reports each at or above 15.00%.",
    "No coverage floor, manifest entry, explicit zero pin, exemption, quarantine, selector, or advisory-policy setting changes are included.",
    "Typecheck passes; focused functional tests and make test pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "cov-functional-floor-factory-definitions-001",
      "title": "Round-trip an authored split layout",
      "description": "As a Factory author, I want a split Factory layout to flatten and expand through public commands so that moving between supported authoring forms preserves my definition.",
      "acceptanceCriteria": [
        "A focused functional scenario invokes you factory config flatten and you factory config expand through Process.Execute on a representative split-layout Factory.",
        "The expanded result preserves the Factory identity and representative work types, work states, workstations, workers, and authored references observable through a subsequent public flatten or load.",
        "The scenario uses root.BuildProcess and public functional-test support only; it does not import the authoring-layout private packages.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added tests/functional/factory/definitions/authored_layout_test.go. The scenario builds through support.BuildProcess/root.BuildProcess, executes public config flatten and expand commands, verifies split AGENTS.md materialization, and compares public Factory topology and references after flattening again. Focused test passes; the full package run had unrelated order-sensitive API-server starter failures, while the affected tests pass when run alone."
    },
    {
      "id": "cov-functional-floor-factory-definitions-002",
      "title": "Compile equivalent Factory sources through customer flows",
      "description": "As a Factory author, I want supported authored and canonical sources to produce the same effective Factory behavior so that validation and loading are independent of the supported representation I use.",
      "acceptanceCriteria": [
        "Focused functional scenarios submit a valid authored Factory directory and its flattened canonical representation through public validation, create, or load behavior that compiles effective Factory sources.",
        "Both representations succeed and expose equivalent customer-visible Factory identity and selected definition facts.",
        "A representative unresolved or invalid authored reference is rejected with the existing actionable customer-facing diagnostic, without persisting or activating an invalid Factory.",
        "The scenarios traverse Process.Execute or the Factory Definitions service-root contract and do not import the compilation private package.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added tests/functional/factory/definitions/compilation_test.go. The scenario uses root.BuildProcess for flattening and the public Factory Definitions service root for authored/canonical effective-source equivalence, public identity/fact assertions, typed invalid-source failures, and a customer-facing invalid create with no persisted target. Focused and full package tests, go vet, typecheck, backend-size, and pkg-boundary pass; focused compilation coverage is 60.0%. The repository make test lane times out at its existing five-minute unit limit, and make lint retains unrelated packaged-factory-consumption/deadcode baseline drift."
    },
    {
      "id": "cov-functional-floor-factory-definitions-003",
      "title": "Preserve portable snapshot assets across export and import",
      "description": "As a Factory author, I want exported portable Factory content to import with its supported bundled files and metadata intact so that I can move a Factory without silent data loss.",
      "acceptanceCriteria": [
        "A focused functional scenario exports a Factory containing representative nested documentation, an executable script, and portable layout metadata through a public customer path, then imports it into a separate named Factory.",
        "Public readback and filesystem observation show the imported Factory preserves the supported bundled-file target paths, exact contents, file roles, and representative layout metadata.",
        "The imported Factory remains valid through the public validation or load path, and the scenario does not import the snapshot-portability private package.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added tests/functional/factory/definitions/snapshots_portability_test.go. The scenario builds the canonical source through support.BuildProcess/root.BuildProcess, traverses the public Factory Definitions snapshot service root for capture, prepare-import, and materialize, then imports the same detached payload into a named Factory and verifies nested DOC/SCRIPT files, roles, exact contents, and layout metadata through public readback. Focused story tests, go vet, and package compile pass; the focused snapshot coverage measurement is 57.1% for snapshots_portability/internal/service."
    }
  ]
}
