### PR TITLE
docs(plans): integration tier, recordings, JS parity, docs codegen, mock workers, meta plan

### DIFF
--- a/docs/internal/development/plans/adversarial-findings-extensions.md
+++ b/docs/internal/development/plans/adversarial-findings-extensions.md
@@ -1,0 +1,298 @@
+# Adversarial Findings — Extensions To The Standing Plans
+
+---
+author: operator
+last modified: 2026, august, 22
+doc-id: PLAN-EXT-001
+status: proposed
+---
+
+# problem statement
+
+The second adversarial evaluation produced 281 findings and 40 blockers. Most map onto plans we already have, a handful have no owner, and several are refutations of round-one claims that are still shaping how we brief lanes.
+
+## customer ask
+
+Add extensions and corresponding designs for the findings in the evaluation, alongside the
+existing plans rather than replacing them.
+
+## solution
+
+Route every material finding to exactly one owning plan, design the ones with no home, and
+record the refutations so we stop paying for beliefs that have already been disproved.
+
+# original document
+
+The 41-agent adversarial evaluation of v0.0.8 ("The Gigabyte Session File", 281 findings,
+40 blockers, 22 Aug 2026), read in full.
+
+## How to read this document
+
+Findings fall into three buckets, and conflating them is how a 281-finding report becomes
+unusable.
+
+- **Routed** — already owned by a standing plan. Listed once, with the owning story. No
+  new design; the plan is amended only if the finding sharpens an acceptance criterion.
+- **Homeless** — real, material, and owned by nothing. These get designs below.
+- **Refuted** — claims from round one that this round disproved. These get corrections,
+  because at least one of them is currently written into an operator skill document and is
+  actively misinforming lanes.
+
+Claims marked **(verified here)** were checked against this tree at `74e1d6341`. Claims
+marked **(reported)** are taken from the evaluation and have **not** been independently
+confirmed. A reported claim is a lead, not a fact; the story that owns it opens with a
+characterization test that is allowed to refute it. That distinction is the difference
+between this document and a bug list.
+
+## Part 1 — Routed findings
+
+| Finding | Status | Owner |
+|---|---|---|
+| Durable session `~default.json` grew to 2^30 bytes and cut mid-string; server cannot start | verified here | `PLAN-REC-001` REC-0 |
+| Durable write is a non-atomic in-place overwrite | verified here (`runtimepersist/store.go:112`) | `PLAN-REC-001` REC-0 |
+| `token.history.failure_log` appends with no truncation anywhere | verified here | `PLAN-REC-001` REC-0 / D4 |
+| Durable sessions are a strictly weaker copy of the recording | verified here | `PLAN-REC-001` D5 |
+| `~default` collides silently across runs from one directory | verified here (`durableSessionIDPattern` accepts it) | `PLAN-REC-001` D2 |
+| Rolling-file caps exist and are wired to logs/metrics but not to session artifacts | verified here | `PLAN-REC-001` D4 |
+| `you run --work` exits 0 when every work item FAILED | reported | `ci-integration-test-matrix.md` Story 0 |
+| No machine-readable failure signal at any verbosity, `--json` included | reported | `ci-integration-test-matrix.md` Story 0 |
+| `work show` on a FAILED item reports no reason; `_last_output` can contradict the state | reported | `PLAN-MOCK-001` MOCK-4 |
+| `READ_ONLY` is behaviourally identical to `DISABLED` at the provider boundary | verified here (adapters gate on `SkipPermissions` only) | `PLAN-JS-001` Part 1 |
+| `onFailure` documented as an object where the schema requires an array | reported | `PLAN-DOC-001` DOC-1, DOC-3 |
+| Docs use `places` / `transitions`, which are absent from the real schema | reported | `PLAN-DOC-001` DOC-3 + vocabulary rule below |
+| `contracts/javascript/runtime-api.json` missing two of nine `agent.run` fields | verified here | `PLAN-JS-001` JS-P7 = `PLAN-DOC-001` DOC-4 |
+| No auth on any HTTP route | reported | `next-work-meta-plan.md` SEC-1 |
+| `factory create --dir` path traversal | reported | `next-work-meta-plan.md` SEC-1 |
+| `SCRIPT_WORKER` inherits the full parent environment | reported | `next-work-meta-plan.md` SEC-1 |
+
+Two of these deserve a sharpened criterion rather than a new story:
+
+- **Story 0's acceptance must include the all-failed case explicitly.** "Exit non-zero on
+  failure" is satisfiable by a run with one failure among many. The row that matters is
+  *every* work item FAILED and the process still exits 0, because that is the shape that
+  makes the entire integration tier unfalsifiable.
+- **MOCK-4's acceptance must forbid contradiction, not just require a reason.** A failure
+  reason that coexists with a `_last_output` tag asserting success is worse than no reason
+  at all, because it survives review.
+
+## Part 2 — Homeless findings, with designs
+
+### EXT-1. Deleting the default session kills the server
+
+**(reported, 4/4 reproductions.)** `you session delete <default-session-id>` prints
+success, exits 0, and the server dies roughly five seconds later. Deleting a non-default
+session returns 204 and the process survives. `cancel` and `terminate` return 501.
+
+The exit code is the worst part. A command that reports success and then removes the
+process that served it is indistinguishable, to any caller, from a command that worked.
+
+Design:
+
+- **The default session is not deletable.** The request is refused with a diagnostic
+  naming the session as the default and stating what would have to change first. Refusal
+  is a defined outcome with a defined exit code, not a 500 and not a crash.
+- **Deletion of any session with a live runtime is refused** unless the runtime is stopped
+  first. Deletion is not an implicit shutdown.
+- **`cancel` and `terminate` stop returning 501.** They are the operations that make the
+  refusal above actionable — refusing a delete because a runtime is live is only
+  reasonable if there is a supported way to stop that runtime. Either they are implemented
+  in this story, or they are removed from the surface. A documented command that returns
+  501 is a worse contract than an absent one.
+- **Flag parity is part of acceptance.** `session delete` is reported to ignore `--server`
+  and require `--port`; every session subcommand must accept the same server-addressing
+  flags, and a flag that is accepted must be used. This is the same class as the
+  `@you/goal --provider` defect in `PLAN-DOC-001`: accepted, ignored, no diagnostic.
+
+Acceptance: deleting the default session refuses with a named diagnostic and a non-zero
+exit, and the server is still serving afterwards. Deleting a stopped non-default session
+still succeeds. This is an unhappy path, so it is asserted in the **functional** tier —
+the integration tier is happy-path only and carries no row for it.
+
+### EXT-2. One error code absorbs twenty root causes
+
+**(reported.)** `CLI_COMMAND_FAILED` / "command failed" is emitted for at least 20 distinct
+root causes across 12+ commands. Critically, `--debug` shows the real cause **is computed**
+— and then discarded before it reaches the user.
+
+This is not a missing-diagnostics problem. It is a **reporting** problem: the information
+exists at the point of failure and is destroyed on the way out. That is the same shape as
+the mock-worker no-match fall-through in `PLAN-MOCK-001` — the system distinguishes two
+outcomes and then throws the distinction away.
+
+Design:
+
+- **Errors carry a stable, specific code from origin to exit.** The code is assigned where
+  the failure is detected, not where it is printed.
+- **`CLI_COMMAND_FAILED` becomes reserved for genuinely unclassified failures**, and its
+  occurrence count becomes a ratchet: a counted drift gate, in the same shape as backend
+  lint, so the number can only go down. This is the mechanism that makes the cleanup
+  finishable rather than perpetual.
+- **The default verbosity carries the cause.** If `--debug` can name it, the default
+  output can name it. `--debug` adds detail, never the identity of the failure.
+- **One functional-tier case per reclassified code**, asserting the exact code for a
+  constructed failure. A code with no test is the next code to rot. These do not belong in
+  the integration tier, whose I8 asserts a validation verdict and never a message.
+
+Acceptance: the unclassified-failure count is measured before and after, is strictly lower,
+and is gated so it cannot rise; three named causes that today produce `CLI_COMMAND_FAILED`
+produce distinct codes at default verbosity.
+
+### EXT-3. Unknown fields warn instead of failing
+
+**(reported.)** Unknown fields in a factory definition produce a warning and validation
+still passes. Combined with the documentation defects in `PLAN-DOC-001`, this is why a
+copied-from-docs config runs and does the wrong thing: the misspelled or obsolete key is
+silently ignored.
+
+This is the `non-empty is not a validity check` failure in another costume — the system
+accepts input it does not understand and reports success.
+
+Design:
+
+- **Unknown fields are validation errors by default.** The diagnostic names the field, its
+  path, and the nearest valid field name.
+- **One escape, explicit and narrow**: a documented flag or manifest key that downgrades
+  unknown fields to warnings, for forward-compatibility during an upgrade. It is opt-in,
+  and its use appears in the run diagnostics.
+- **The migration is bounded and measurable.** Before flipping the default, run validation
+  in strict mode across every factory in `examples/`, `packages/packaged-factories/`, and
+  the `PLAN-DOC-001` DOC-1 corpus, and fix what it finds. Flip the default only when that
+  set is clean — otherwise strictness lands as a mass breakage rather than as a gate.
+- Sequenced **after** DOC-1, because DOC-1 is what makes the corpus exist to measure
+  against.
+
+Acceptance: a config with a misspelled key fails validation naming the key and the
+suggestion; the escape hatch is documented and its use is visible in diagnostics; every
+shipped and documented factory validates clean in strict mode.
+
+### EXT-4. `you metrics` ignores `--server` and scans the machine
+
+**(reported: 23,743 files, 972 MB, 26–50 s.)** The command accepts a `--server` flag,
+disregards it, and walks the machine-wide artifact tree instead of the addressed server's
+scope.
+
+Two defects stacked: a flag accepted and ignored, and an unbounded scan presented as a
+query. The second is why the first has never been noticed — the command does eventually
+return something.
+
+Design:
+
+- **`--server` scopes the query.** Metrics for a server are the metrics that server wrote.
+- **The scan is bounded by default** — a time window, defaulting to something small, with
+  the window stated in the output. An unbounded scan is available explicitly, never by
+  default.
+- **The dated layout is what makes bounding cheap.** Metrics already write
+  `YYYY/MM/DD/`, so a window is a directory-prefix filter rather than a full walk. This is
+  the same property `PLAN-REC-001` REC-5 relies on for the history half of
+  `you session list`, and the two commands should share the window-selection helper rather
+  than each growing their own.
+- **Accepted-and-ignored flags are a class, not an incident.** This story adds a check
+  that every flag a command declares is read somewhere in that command's path. The
+  `@you/goal --provider` defect, the `session delete --server` defect and this one are the
+  same bug three times.
+
+Acceptance: `you metrics --server <a>` and `--server <b>` return different results on a
+host running both; the default query completes in under a second on this machine's current
+tree; the flag-usage check fails on a deliberately re-introduced ignored flag.
+
+### EXT-5. Replay serves stale output after a prompt change
+
+**(reported.)** Changing a prompt and re-running serves the recorded output for the old
+prompt. Drift is detected — but only as a WARN on stderr, indistinguishable from ordinary
+noise.
+
+The detection exists. The reporting is the defect, exactly as in EXT-2.
+
+Design:
+
+- **Input drift is an error by default in replay**, naming the input that changed and the
+  recording it diverged from. Serving output recorded for a different input is not a
+  degraded success; it is a wrong answer delivered confidently.
+- **`--allow-drift` is the explicit opt-in** for the legitimate case of replaying an old
+  recording against edited inputs, and it prints what it is ignoring.
+- **The drift signal is part of the artifact**, not only stderr. It appears in the
+  recording's terminal record so a later reader can tell that a replay was served over
+  drift.
+
+Acceptance: an edited prompt replayed without the flag exits non-zero naming the changed
+input; with the flag it succeeds and reports the drift; the recording records that drift
+was tolerated.
+
+### EXT-6. Secrets in recordings
+
+**(reported.)** Recordings store worker secrets verbatim. This is separated from
+`PLAN-REC-001` deliberately: redaction policy deserves review on its own merits, not as a
+rider on a storage-path migration.
+
+Design (story **EXT-SEC-2**):
+
+- **Redaction at the recording boundary, not at the read surface.** A secret that reaches
+  disk is already leaked; filtering it on the way out protects nothing.
+- **Redaction is by declared provenance, not by pattern matching.** Values that arrived
+  from a secret source are marked at the source and redacted structurally.
+  Regex-scanning for things that look like secrets is a detector that fails open, and
+  fails open silently.
+- **Redaction is visible.** A redacted field is present, typed, and marked redacted, so a
+  reader can tell the difference between "absent" and "withheld" — the same reason a
+  truncated failure log must carry its dropped-count.
+- Pattern scanning is worth exactly one thing: a **test** that greps a recording produced
+  by a factory holding known secrets and fails if any appears. That is a guard, not a
+  mechanism.
+
+Acceptance: a run with a declared secret produces a recording containing no occurrence of
+the secret value, with the field present and marked redacted; the grep guard fails when
+the redaction is removed.
+
+## Part 3 — Refutations, and one correction we owe
+
+Round two disproved several round-one claims. Recording them matters because a false
+finding costs the same as a real one, and one of these is currently written down where
+lanes will read it.
+
+Refuted by this round:
+
+- Workspace-location suppression.
+- `--provider` / `--model` silently dropped by `@you/goal`. *(The flags-accepted-and-ignored
+  class is still real — see EXT-4 — but this specific instance did not reproduce.)*
+- **Codex requiring a git repository.** This one lives in an operator skill document, where
+  it is wrong and is briefing every lane that reads it. Correcting it is the one action
+  item in this section, and it is operator work, not lane work.
+- `agy-clip-qa` rejecting `outputContract`.
+- `factory list --json` non-determinism.
+- A global run lock.
+- **Their own earlier claim that durable sessions preserved work across a crash.** They do
+  not — this round measured that a durable session does not survive a hard kill, which is
+  part of why `PLAN-REC-001` can retire them without loss.
+
+Confirmed working, and worth stating because a report of 40 blockers reads as a system in
+worse shape than this one is: the JavaScript orchestrator sandbox, recordings themselves,
+the rolling-file infrastructure, server startup, the dashboard, `session list`,
+`session create`, loopback-only binding, and codex at 7 for 7.
+
+## Part 4 — Sequencing
+
+Only three ordering constraints are real; everything else is parallel.
+
+1. **EXT-3 after `PLAN-DOC-001` DOC-1.** Strict validation needs the corpus to measure
+   against, or it lands as a mass breakage.
+2. **EXT-2 before the integration tier's error-code rows.** Asserting a code that is about
+   to be reclassified is churn.
+3. **EXT-4 and `PLAN-REC-001` REC-5 share the window-selection helper.** Whichever lands
+   first builds it; the second consumes it. Neither waits on the other, but the standing
+   rules doc must say which owns it, or both will write one.
+
+EXT-1, EXT-5 and EXT-6 are independent and can start immediately.
+
+## Verification
+
+`make test` for all stories. EXT-1 and EXT-4 are unhappy paths and are asserted in the
+functional tier, not the integration tier — but both remain gated on Story 0's truthful
+exit codes, because a case that cannot fail proves nothing wherever it lives. EXT-3 requires `make test-functional` plus a
+strict-mode pass over every shipped factory. EXT-6 requires the grep guard to be
+demonstrated failing before it is trusted; a guard nobody has watched fail is not evidence.
+
+## Delivery loop
+
+Implementation finishes when its final head is pushed, the PR is open, CI has started,
+and blocking review feedback is addressed. Review owns terminal-and-passing CI, conflict
+resolution, and merge. CI-run evidence goes in a PR comment, never a commit.

--- a/docs/internal/development/plans/ci-integration-test-matrix.md
+++ b/docs/internal/development/plans/ci-integration-test-matrix.md
@@ -1,0 +1,197 @@
+# CI Integration Tier — One Test Per Entrypoint, Installed Binary, Clean Directory
+
+---
+author: operator
+last modified: 2026, august, 22
+doc-id: PLAN-INT-001
+status: proposed
+---
+
+# problem statement
+
+We have no CI tier that runs the shipped binary the way a customer runs it, so an entire class of defect reaches users unopposed — including entrypoints that cannot work at all once installed, because they read files that only exist inside our repository.
+
+## customer ask
+
+One integration test per entrypoint of sufficient complexity, happy path only, kept
+extremely small because the tier is expensive: ad-hoc invocation with mock workers across
+a couple of packaged factories, JavaScript invocation, server mode, MCP mode, resume, and
+replay. Validation may run, but pass/fail only.
+
+## solution
+
+Eight tests. Each spawns the compiled binary in a clean directory with no repository
+reachable, drives one entrypoint end to end, and asserts an observable outcome that is not
+the exit code. Every entrypoint the adversarial review found broken is represented, paired
+with the system-level fix that has to land for its test to be passable at all.
+
+# original document
+
+The 33-agent and 41-agent adversarial evaluations of `you-agent-factory` v0.0.8, plus
+`docs/internal/development/plans/next-work-meta-plan.md` for sequencing.
+
+## Why a small tier, and why it still finds things
+
+Three measured facts shape the design.
+
+**1. The test already exists and does not run on pull requests.**
+`tests/release/root_process_smoke_test.go::TestRootProcessCompiledBinaryModeMatrix`
+already builds the binary, points `HOME`/`USERPROFILE` at a `t.TempDir()`, and runs
+`run --dir <factory> --with-mock-workers`. But `./tests/release/...` is in neither
+coverage lane — `cmd/gocoveragecheck/main.go:55` pins `unitTestPatterns` to `./pkg/...`
+and line 56 pins the functional lane to `tests/functional`. The package appears only in
+`development-package.yml` and `release-candidate.yml`, and there only two
+`TestGoInstallSmoke_*` tests are invoked by name. The binary-mode matrix is never called
+by any workflow.
+
+**2. If it did run, it could not fail.** Its strongest assertion is
+`if err != nil { t.Fatalf }`. Batch mode exits 0 regardless of work outcome
+(`orchestration/runtime/factory.go:587` — a token routed to a failed place is not an
+engine error). A happy-path suite built on exit codes alone would inherit exactly that
+defect, which is why every test below asserts a **terminal state or a produced artifact**,
+never only the exit status.
+
+**3. It exercises no endpoint.** No HTTP surface, no `mcp serve`, no
+`session list --scope persisted`. That is precisely where the installed-binary defects
+live, and they are invisible to every tier we run.
+
+**Why happy-path-only is the right trade.** Unhappy paths are cheap to test near the code
+and expensive to test through a process boundary. Their value at this level is mostly
+duplicated by the functional tier. What is *not* duplicated anywhere — and what no unit
+test can reach — is whether the shipped artifact starts and completes a real journey with
+no repository underneath it. That is the entire job of this tier, and it needs eight
+tests, not sixty.
+
+## Story 0 — Truthful exit codes (BLOCKING PREREQUISITE)
+
+Batch `you run` must exit non-zero when a submitted work reaches a failed terminal state,
+when a circuit breaker trips, or when a script worker exits non-zero. One-shot
+`you run --named` already does this correctly and returns parseable detail, so the
+semantics are settled; only the batch path needs aligning.
+
+**A happy-path tier makes this more important, not less.** If exit 0 is unconditional,
+a suite of eight happy-path tests is eight assertions that the process did not crash.
+Story 0 is what converts them into assertions that the work succeeded.
+
+Acceptance: a factory whose single work routes to a failed terminal state exits non-zero
+from batch mode with the failed work name and terminal state on stdout; a factory whose
+work completes exits 0; **a factory where every work item fails still exits non-zero** —
+that last case is the one the evaluation measured returning 0. All asserted from a
+compiled binary.
+
+This is its own lane and merges on its own. Nothing else here is meaningful until it lands.
+
+## The tier
+
+Every test runs one process spawned from the compiled binary, with `HOME`/`USERPROFILE`
+and the working directory both set to a fresh `t.TempDir()`, and **no repository reachable
+by walking parents**. All eight are fixture-free by construction; the harness enforces it
+(see "The no-internal-files rule").
+
+| ID | Entrypoint | What it drives | Observable assertion (not the exit code) |
+|---|---|---|---|
+| **I1** | Ad-hoc invocation, packaged factory A | `run --named` against a shipped packaged factory with mock workers | Primary result present on stdout; work reaches a complete terminal state |
+| **I2** | Ad-hoc invocation, packaged factory B | A second shipped packaged factory with a different topology (multi-workstation) | Every work reaches a complete terminal state; dispatch count matches the topology |
+| **I3** | JavaScript invocation | A factory whose orchestration is a JS workflow, children served by mock workers | The workflow's JSON return value is on stdout and matches the expected shape |
+| **I4** | Server mode | `serve`, then over HTTP: list sessions, list work, list workers | Bound URL printed; a submitted work is enumerable and reaches a complete terminal state through the API |
+| **I5** | MCP mode | `mcp serve`, handshake, tool listing, one tool call | Handshake completes and the expected tool set is returned, from a temp directory |
+| **I6** | Resume | Start a run, stop the process, resume it | The resumed run continues from recorded progress and reaches a complete terminal state |
+| **I7** | Replay | Record a run, replay it | Replay reproduces the recorded events for the unchanged input |
+| **I8** | Validation | `config validate` over a small corpus | **Pass/fail verdict only** — every valid factory passes, every invalid one fails. No assertion on diagnostic text |
+
+Notes that are part of the contract, not commentary:
+
+- **I1 and I2 use real shipped packaged factories**, not bespoke test fixtures. A fixture
+  we author for this tier proves the harness works; a shipped factory proves the product
+  does. Two is the right number — one is an existence proof, three is a matrix.
+- **I8 asserts the verdict, never the message.** Diagnostic wording is owned by the unit
+  tier. Asserting it here buys nothing and makes the tier brittle to correct changes.
+- **No unhappy-path rows.** Mock-worker failure modes, selector no-match, breaker trips,
+  pagination edges, flag rejection, port collisions and error-code classification are all
+  owned elsewhere — `PLAN-MOCK-001`, `PLAN-EXT-001` EXT-2, and the functional tier. If one
+  of them regresses, this tier is not where it should be caught.
+
+## Adverse-review failures this tier owns
+
+These are the entrypoint-level failures from the adversarial review. Each is paired with
+the **system-level fix** required for its test to be passable, because in every case the
+test cannot be written first — the entrypoint does not work at all.
+
+| Finding | Status | Covered by | System-level fix required |
+|---|---|---|---|
+| MCP surface unreachable from an installed binary — `execution_contract.go:28` hardcodes `ContractFixtureCatalogRelativePath` to `pkg/transports/http/testdata/durable-session-contract-fixtures.json`, and `executionopening/factory.go:285-308` walks parent dirs for it, failing `fixture catalog not found; run from the repository root` | **verified here** | I5 | The runtime must not read a repository test file. Embed the catalog, derive it from the contract, or remove the dependency — but the released binary must carry everything it needs |
+| `session list --scope persisted` / `session dispatches` unusable when installed | verified here (same root cause) | I4 | Same fix as above |
+| Batch `you run` exits 0 when every work item FAILED; no machine-readable failure signal at any verbosity including `--json` | reported | Story 0, then all of I1–I7 | Story 0 |
+| Resume does not survive a hard kill — durable sessions are not flushed and stay at `RUNNING` / `FinishedAt: null` after a clean exit | verified here | I6 | `PLAN-REC-001` — resume reads the recording, which is flushed every 250 ms, rather than the durable snapshot, which is not |
+| Replay serves stale output after an input change; drift is detected only as a WARN on stderr | reported | I7 | `PLAN-EXT-001` EXT-5 — drift is an error by default, with an explicit opt-in, and the tolerance is recorded in the artifact |
+| Canonical JavaScript examples use bare top-level `await`, which the runtime rejects; the required wrapper is documented nowhere | reported | I3 | `PLAN-DOC-001` — the JS example becomes a real transcluded directory, which I3 then runs |
+| Two of nine `agent.run` fields absent from the shipped contract artifact | verified here | I3 (indirectly — the workflow exercises the fields) | `PLAN-JS-001` JS-P7 / `PLAN-DOC-001` DOC-4 |
+| Dead entries in the shipped factory catalog | reported | I1, I2 | Whichever packaged factories I1/I2 select must load; a dead catalog entry is a delivery defect, not a test-fixture problem |
+
+The pattern across the first two rows is the one worth naming: **an entrypoint that only
+works inside our repository is not a tested entrypoint, it is an untested one that
+happened to pass.** Every one of our existing tiers runs with the repository as the
+working directory, so none of them can see this class at all.
+
+## The no-internal-files rule
+
+The mechanism matters more than the list above, because the list is only what two
+evaluations happened to find.
+
+The harness asserts that a test process **reads nothing under the source tree**. Any
+access to a repository path from a binary running in an isolated `HOME` and working
+directory fails the test, naming the path. That turns "does this entrypoint smuggle a
+repo dependency" from a thing we discover in a customer report into a thing that fails in
+CI on the PR that introduces it.
+
+This single rule is the highest-value line in the plan. It is what would have caught the
+fixture catalog years earlier, and it is what will catch the next one without anyone
+having to think of it.
+
+## Delivery steps
+
+Each merges on its own and leaves `main` releasable.
+
+1. **Story 0 — truthful batch exit codes.** Blocking prerequisite.
+2. **Harness package `tests/integration/`** — builds the binary once per run, spawns it in
+   an isolated `HOME` and working directory, and enforces the no-internal-files rule.
+   Ships with **I8 only**, because validation needs no server and proves the harness
+   cheaply.
+3. **Wire the job into `ci.yml`** as `Backend Integration`, required. Adding it while it
+   holds only I8 means the gate exists before it has teeth, so a later red is
+   unambiguously a product regression rather than a new gate.
+4. **I1, I2, I3** — the invocation entrypoints. Depend on Story 0.
+5. **I4** — server mode.
+6. **I5** — MCP mode. Cannot pass until the fixture-catalog dependency is removed; that
+   removal is its own lane and this test is its acceptance evidence.
+7. **I6, I7** — resume and replay. Sequenced last: I6 depends on `PLAN-REC-001` REC-6, and
+   I7 depends on `PLAN-EXT-001` EXT-5.
+
+Steps 4 through 7 are independent of one another and can run in parallel once Story 0 and
+the harness are in.
+
+## Non-goals
+
+- **No real provider calls.** Every test runs against mock workers or stub binaries.
+- **No unhappy-path coverage.** Stated above and repeated here because it is the
+  constraint most likely to erode: the first person to add "just one" failure row should
+  be pointed at this line.
+- **No replacement of the functional tier.** This tier answers "does the shipped artifact
+  work", not "is this package correct".
+- **No growth without removal.** The tier has a budget; a ninth test means a case has been
+  made that an existing one is redundant.
+- **No new assertions inside `tests/release/`.** That package keeps its release-artifact
+  role; the binary-mode matrix moves here rather than being duplicated.
+
+## Verification and budget
+
+Target wall time **under two minutes** on a four-core hosted runner. Eight tests, one
+shared binary build, all independent and run in parallel. If the tier exceeds budget, the
+answer is to remove a test, not to move it off the required path — an expensive tier that
+is not required is a tier that does not exist.
+
+## Delivery loop
+
+Implementation finishes when its final head is pushed, the PR is open, CI has started,
+and blocking review feedback is addressed. Review owns terminal-and-passing CI, conflict
+resolution, and merge. CI-run evidence goes in a PR comment, never a commit.

--- a/docs/internal/development/plans/docs-generation-from-testable-sources.md
+++ b/docs/internal/development/plans/docs-generation-from-testable-sources.md
@@ -1,0 +1,198 @@
+# Documentation Generated From Testable Sources
+
+---
+author: operator
+last modified: 2026, august, 22
+doc-id: PLAN-DOC-001
+status: proposed
+---
+
+# problem statement
+
+Documentation is authored independently of the code it describes, so consistency is maintained by hand and fails silently; copying from `you docs` is a reliable way to produce a broken configuration.
+
+## customer ask
+
+Stop relying on docs being consistent. Make the docs reference actual factory files and other testable artifacts, fill the doc files in by codegen, and let the examples run as functional tests rather than needing a bespoke CI harness.
+
+## solution
+
+Invert the dependency. Every checkable element of a doc becomes a projection of an artifact that already has to be correct — a real factory directory, the Cobra command tree, or a Go contract. Prose stays hand-written; everything a reader could copy is transcluded or generated, and a CI check fails when a doc and its source disagree.
+
+# original document
+
+The 33-agent adversarial evaluation of v0.0.8 — root cause R6, "the documentation's own
+examples do not run" — and this repository's `docs/reference/` packaging contract.
+
+## Evidence
+
+Every one of these was found by an agent copying from our own documentation.
+
+| Defect | Where | Cost |
+|---|---|---|
+| `onFailure` shown as an object where the schema requires an array | authoring guide, "Minimal Workflow" `factory.json` | Three separate agents lost time to one snippet |
+| Canonical examples use bare top-level `await`, which the runtime rejects | JavaScript guide | Two agents reported it as two different bugs; the mandatory `(async function(){…})()` wrapper is documented nowhere |
+| A `you workflow status\|result\|dispatches\|artifacts` command family that does not exist | JS docs and the orchestrators topic | `you workflow --help` prints root help and exits 0, so the mistake hides itself |
+| `@you/goal` example uses `--provider` / `--model`, which that factory does not bind | reference example | Flags accepted, ignored, run fails with an error that never mentions flags |
+| `contracts/javascript/runtime-api.json` missing `executorProvider` and `resourceId` | generated contract artifact | Two of nine `agent.run` fields absent; three sources disagree on the field list |
+
+The last row is the tell. That artifact is nominally generated, and it still drifted by
+two fields. **The problem is not authoring discipline. It is that nothing fails when a
+doc and its subject disagree.**
+
+### What `docs-reference-smoke` actually does
+
+```
+docs-reference-smoke:
+	$(MAKE) docs-reference-check              # markdown lint
+	go test ./pkg/transports/cli/docs/...     # the docs command
+	go test ./pkg/transports/cli -run TestDocsCommand_
+	go test ./tests/functional/smoke -run TestDocsCommandSmoke_
+	go test ./tests/functional/factory/definitions -run '^TestFactoryValidationDocsCommandDescribesStaticGate$$'
+```
+
+It lints markdown and tests that the `docs` *command* works. It never parses, validates,
+or executes a single example inside a doc. Every defect in the table above passes it.
+
+## Design — three classes of doc content
+
+The whole plan is one classification rule.
+
+**Class P — prose.** Concepts, rationale, when-to-use. Hand-written, unconstrained,
+never generated. This is most of the words and none of the risk.
+
+**Class T — transcluded.** Anything a reader could copy and run: factory JSON/YAML,
+workflow scripts, batch payloads, command invocations. These **must not exist in the doc
+file as authored text.** They are pulled at generation time from a real artifact on disk
+that is independently validated and executed. If the artifact changes, the doc changes.
+If the artifact stops working, a test goes red before the doc is ever regenerated.
+
+**Class G — projected.** Tables and lists derived from a contract: `agent.run` field
+tables, flag lists, subcommand families, error-code tables, policy field references.
+Generated from the Go source of truth — `javascript_child.go`, the Cobra command tree,
+the error-code registry — never hand-maintained.
+
+The rule for reviewers is one sentence: **if a reader could paste it, it is Class T or G,
+and it may not be typed into a markdown file by a human.**
+
+## Mechanism
+
+### Transclusion markers
+
+A doc declares what it includes and from where:
+
+```markdown
+<!-- transclude: examples/minimal-workflow/factory.json -->
+<!-- /transclude -->
+```
+
+`cmd/docscodegen` fills the fenced block between the markers from the named path.
+Region selection for partial includes uses named anchors in the source file (a comment
+marker in JSON/YAML, a `// region:` comment in Go), never line numbers — line numbers
+are the same silent-drift failure in a new costume.
+
+### Projection markers
+
+```markdown
+<!-- project: agent-run-fields -->
+<!-- /project -->
+```
+
+Each projection id maps to a generator function reading a Go source of truth. Adding a
+field to `javascript_child.go` changes the table on the next generate; nobody edits the
+doc.
+
+### The gate
+
+`make docs-generate` rewrites in place. `make docs-check` regenerates into a temp tree
+and diffs — non-zero on any difference, naming the doc, the marker, and the source. This
+is the same shape as `make interfaces-all` for generated clients, and it belongs in the
+same CI job so the class of failure is familiar.
+
+A transclusion pointing at a nonexistent path, or a projection id with no generator, is a
+hard error. A dangling pointer must never degrade to an empty block — that is how the
+current `rules:` pointer problem happened in payloads, and it is the same failure mode.
+
+## Where the examples actually run
+
+This is the part that answers "run them via functional tests rather than CI".
+
+Because Class T content lives in **real directories** rather than inside markdown, it is
+already reachable by the normal test tiers, and no doc-specific harness is needed:
+
+- **Validation** — every transcluded factory directory is validated in the functional
+  tier. `config validate` must pass on all of them. The `onFailure`-shape defect dies
+  here, at parse time, in under a second. The integration tier's I8 asserts only that the
+  validator's verdict is right on a small corpus; it is not where the whole corpus runs.
+- **Execution** — every transcluded factory that is meant to be runnable gets a
+  mock-worker run in the functional tier. It must reach a complete terminal state and exit
+  0. The bare-top-level-`await` defect dies here, and the JavaScript example specifically
+  is also the factory that integration test I3 drives.
+- **Command existence** — the projected subcommand families come from the Cobra tree, so
+  a documented command that does not exist cannot be projected. `you workflow
+  status|result|dispatches|artifacts` becomes unrepresentable rather than wrong.
+- **Flag binding** — a documented invocation for a named factory is checked against that
+  factory's `invocationSignature`. The `@you/goal --provider` defect dies at generation
+  time, before CI.
+
+So the doc examples are not tested *by a docs harness*. They are tested because they are
+ordinary factories in the ordinary suite, and the docs merely point at them. That is the
+whole idea: **there is no separate thing to keep consistent.**
+
+## Delivery — strangler, six independently mergeable steps
+
+**DOC-1. Example corpus.** Move the factories currently embedded in reference docs into
+real directories under `examples/`, and add them to functional-tier validation. Docs are left
+untouched and still contain their hand-typed copies. Merging this alone is already
+valuable: it is the first time those examples are checked at all, and it will surface the
+`onFailure` defect immediately.
+
+**DOC-2. `cmd/docscodegen` with transclusion only.** Generator, markers, `docs-generate`,
+`docs-check`. Convert exactly one topic as the proof case. `docs-check` is advisory in
+this step, not gating.
+
+**DOC-3. Migrate reference topics in reviewable batches.** Each batch converts a group of
+topics from authored snippets to transclusions of the DOC-1 corpus. Each batch merges on
+its own and each leaves `docs/reference/` correct. Diffs are large but mechanical, and a
+regenerate reproduces them exactly.
+
+**DOC-4. Projection support.** Add `project:` markers and the first three generators:
+`agent-run-fields` from `javascript_child.go`, the command tree from Cobra, and the
+policy field table. `agent-run-fields` is the proof case, because it is a known-stale
+artifact — verified 2026-08-22 as missing two of nine fields — so the first generate
+produces a real, previously invisible correction. This step is also
+`javascript-workflow-parity-and-permissions.md` story JS-P7.
+
+**DOC-5. Turn on the gate.** `docs-check` becomes required in the lint job. Landing it
+after DOC-3 and DOC-4 means the gate goes green-to-red only on genuine future drift,
+never on the migration itself.
+
+**DOC-6. Execution.** Add the runnable subset of the corpus to the functional tier under
+mock workers. Sequenced last because it depends on truthful exit codes (integration
+Story 0) — before that, a broken example would run and report success. Only the
+JavaScript example graduates to the integration tier, as test I3; the rest stay
+functional, because the integration tier is capped and a ninth test requires retiring an
+existing one.
+
+## Non-goals
+
+- **No generated prose.** Explanations stay hand-written. Generating them would produce
+  worse docs and would not fix a single defect above.
+- **No literate-programming rewrite.** Docs stay markdown; only bounded regions are
+  machine-owned.
+- **No change to `you docs <topic>` packaging.** `docs/reference/` remains the canonical
+  authored location and continues to be embedded. Generation runs before packaging.
+- **No line-number-based includes**, ever.
+
+## Verification
+
+`make docs-reference-smoke` after any change under `docs/reference/`, plus the new
+`make docs-check`. DOC-1 and DOC-6 additionally require the integration tier from
+`ci-integration-test-matrix.md`. DOC-4 requires `make interfaces-all`, since it changes a
+generated contract artifact.
+
+## Delivery loop
+
+Implementation finishes when its final head is pushed, the PR is open, CI has started,
+and blocking review feedback is addressed. Review owns terminal-and-passing CI, conflict
+resolution, and merge. CI-run evidence goes in a PR comment, never a commit.

--- a/docs/internal/development/plans/javascript-workflow-parity-and-permissions.md
+++ b/docs/internal/development/plans/javascript-workflow-parity-and-permissions.md
@@ -1,0 +1,236 @@
+# JavaScript Workflow Parity and Permission Model Simplification
+
+---
+author: operator
+last modified: 2026, august, 22
+doc-id: PLAN-JS-001
+status: proposed
+---
+
+# problem statement
+
+Our JavaScript orchestrator carries a two-axis permission model whose safety axis cannot be enforced at the provider boundary, and it diverges from the Claude Code `Workflow` surface in three ways that cost real reliability.
+
+## customer ask
+
+Make the JavaScript workflow surface behave consistently with how it works in Claude, and replace the `READ_ONLY` / `skipPermissions` split with a single flag — `DEFAULT` or `SKIP_PERMISSIONS` — that propagates parameters down to the agent instead of pretending to sandbox it.
+
+## solution
+
+Collapse the permission model to one per-call enum that maps directly onto the flag we actually pass to the provider, keep the declarative policy layer strictly as an allowlist over that enum, and close three specific parity gaps: structured child output, variadic pipeline stages, and contract truth.
+
+# original document
+
+`C:\Users\andre\.claude\skills\dispatching-you-subagents\references\claude-workflow-tool.md`
+
+## Part 1 — The permission model
+
+### Measured current state
+
+There are two independent axes, and they do not compose.
+
+**Axis 1, declarative:** `defaultPolicy` resolves into `EffectivePolicy`
+(`pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract/policy_types.go:36`)
+carrying `Mode`, `AllowNetwork`, `AllowConnectors`, `AllowDangerFullAccess`,
+`WritableRoots`, plus allowlists for runners, models, efforts, route profiles and
+commands. `ModeReadOnly = "READ_ONLY"` is the **only** mode constant defined — the enum
+is already effectively binary, expressed as `READ_ONLY` versus unset, and then softened
+by four independent escape hatches.
+
+**Axis 2, per-call:** `skipPermissions` is one of nine fields on `agent.run`
+(`orchestratorcontract/javascript_child.go:12-20`), normalized by
+`NormalizeJavaScriptChild` with `additionalProperties: false`.
+
+### Why the safety axis is not real
+
+`ValidateCapability` and `DeniedCapabilitiesForReadOnly`
+(`orchestratorcontract/policy_capability.go`) are referenced by exactly five files, all
+inside the same orchestrator-contract package. Nothing in `pkg/services/workers` or
+`pkg/services/providers` consumes them.
+
+Meanwhile the provider adapters do this:
+
+- `providers/internal/services/execution/internal/adapters/codex/command.go:61` appends
+  `--dangerously-bypass-approvals-and-sandbox`
+- `.../adapters/claude/command.go:62` appends `--dangerously-skip-permissions`
+- `.../adapters/agy/command.go:126` appends `--dangerously-skip-permissions`
+
+each gated on `request.SkipPermissions` — **axis 2**, never axis 1.
+
+So `policy.mode: READ_ONLY` denies a set of capability names to the in-process bounded
+tool executor (`workers/.../agentrun/tools.go`, which implements `read_file`,
+`list_directory`, `write_file`), and denies nothing to the provider's own shell, file
+and network tools. A child agent under `READ_ONLY` can still write files, execute
+processes, and reach the network, because those actions happen inside the provider, and
+the provider's sandbox is being explicitly disabled on the adjacent line.
+
+This was independently observed under adversarial test: a live `@you/subagent` run under
+`agentTools.policy: READ_ONLY` created a file via shell redirect with no denial and no
+diagnostic, executed `python -c`, and fetched a URL over the open network — while the
+documentation promised "Write tools are denied."
+
+**The defect is not that enforcement is missing. It is that the field implies a
+guarantee the architecture cannot deliver from where it sits.** Two axes, one of which
+is unenforceable at the only boundary that matters, is strictly worse than one honest
+axis — it converts an absent guarantee into a false one.
+
+### Target model
+
+One per-call field. One value passed down. No inference.
+
+```
+agent.run({ ..., permissions: "DEFAULT" | "SKIP_PERMISSIONS" })
+```
+
+- `DEFAULT` — the provider is launched with **no** bypass flag. Its own approval and
+  sandbox behavior applies, whatever the user has configured for that provider.
+- `SKIP_PERMISSIONS` — the provider is launched with its bypass flag, exactly as today.
+
+The value we hold is the value we pass. There is nothing to enforce, because there is
+nothing being claimed beyond the flag itself.
+
+### What to keep, and why (recommendation, with the tradeoff stated)
+
+The instinct to "remove all that complexity" is right about the capability booleans and
+wrong about one thing, so I want the tradeoff explicit rather than buried.
+
+`defaultPolicy` is genuinely our advantage over Claude Code's single `isolation` knob: it
+is an **auditable manifest checked before a Dispatch exists**. A factory author can
+declare what a workflow is permitted to do, and an operator can read it without running
+anything. Claude Code has no equivalent. Deleting the whole policy layer would trade a
+real capability for tidiness.
+
+So the recommendation is:
+
+- **Delete** `AllowNetwork`, `AllowConnectors`, `AllowDangerFullAccess`,
+  `WritableRoots`, `Mode`, the six `Capability` constants, `ValidateCapability`, and
+  `DeniedCapabilitiesForReadOnly`. Every one of these describes a boundary we do not
+  hold. They are the false guarantee.
+- **Keep** the policy layer as an **allowlist over the new enum**: a factory may declare
+  `allowedPermissions: ["DEFAULT"]`, and a child requesting `SKIP_PERMISSIONS` is
+  rejected *before dispatch* with a named diagnostic. This is enforceable — it gates a
+  value we control — and it preserves the audit property.
+- **Keep** `AllowedModels`, `AllowedReasoningEfforts`, `AllowedRunners`, `MaxAgents`,
+  `Concurrency`, `MaxDepth`, `MaxRetries` and the duration/size bounds. All of these
+  gate values or counts the runtime genuinely owns.
+
+If we later gain a real sandbox boundary — a container, a restricted provider mode, an
+OS-level jail — capability names can come back, attached to something that enforces them.
+Reintroducing an honest guarantee is cheap. Living with a dishonest one is not.
+
+### Delivery — strangler, four independently mergeable steps
+
+**JS-P1. Characterization tests first.** Pin today's behavior before changing it: what
+`agent.run` accepts and rejects, which provider flags result from each combination of
+`policy.mode` and `skipPermissions`, and what `DeniedCapabilitiesForReadOnly` returns.
+Coverage of this surface is currently concentrated in
+`javascript_policy_test.go` and `policy_capability.go`'s own tests, neither of which
+asserts the provider command line. That gap is why the divergence survived. Add the
+provider-command assertion as the characterization.
+
+**JS-P2. Introduce `permissions` alongside `skipPermissions`.** Both accepted;
+`permissions` wins when both are present; `skipPermissions: true` maps to
+`SKIP_PERMISSIONS`. Emit a deprecation diagnostic naming the replacement. No behavior
+change for existing workflows — every current script keeps working.
+
+**JS-P3. Introduce `allowedPermissions` and reject at validation.** A factory declaring
+`allowedPermissions: ["DEFAULT"]` causes a `SKIP_PERMISSIONS` child request to fail
+validation with a diagnostic naming the factory, the child label, and the requested
+value. Acceptance is a rejection observable before any dispatch record exists.
+
+**JS-P4. Delete the old axis.** Remove `skipPermissions` from the field list, remove
+`Mode` and the four capability escape hatches, delete the capability constants and their
+validators, and update the packaged docs. This is the step that changes behavior for
+authored factories, so it lands alone and last.
+
+Each step leaves `main` releasable. No step exists to repair fallout from an earlier one.
+
+## Part 2 — Parity with the Claude Code `Workflow` surface
+
+Both are policy-bounded JavaScript orchestrators over agent children in a locked-down VM
+with no imports, filesystem, shell or network, returning JSON-only final values. The
+naming overlap is near-total. Three divergences cost us something real.
+
+### JS-P5. Structured child output (highest value)
+
+`agent.run` **explicitly rejects** `schema` and `outputSchema` — they are pinned in the
+rejected-field test alongside `writableRoots`, `allowNetwork`, `concurrency`, `maxAgents`
+and the timeout family. Children therefore return prose that the parent must parse or
+re-prompt.
+
+The residue is visible in our own shipped output: `@you/spawn` and `@you/deep-research`
+both emit `"schemaValidated": false` and `"subject": ""` — vestigial fields for a feature
+that was never wired.
+
+Claude Code's model is worth copying exactly: `schema` forces the child to call a
+structured-output tool, validation happens at the tool-call layer, and the model retries
+on mismatch rather than the parent receiving something unparseable. For fan-out-then-merge
+work, validated child output is most of the reliability.
+
+Acceptance: a child declared with a schema returns a validated object; a child that
+produces a non-conforming value retries and then fails with a diagnostic naming the
+violated path; the vestigial `schemaValidated` field reports truthfully.
+
+### JS-P6. Variadic `pipeline` stages
+
+Ours is `pipeline(items, worker, next?)` — capped at two stages. Claude Code's is
+variadic with no barrier between stages, so item A can be in stage 3 while item B is
+still in stage 1, and wall-clock equals the slowest single-item chain rather than the sum
+of per-stage slowest.
+
+With two stages, a `review → verify → synthesize` shape forces either a nested `parallel`
+inside `next` — losing ordering — or an explicit barrier, which idles every fast item
+until the slowest one catches up. This is the one place the reference is plainly better
+and the fix is contained.
+
+Acceptance: a three-stage pipeline over N items completes in slowest-chain time rather
+than sum-of-stage-maxima, demonstrated with recorded dispatch timestamps; a stage that
+throws drops that item and skips its remaining stages without failing the run.
+
+### JS-P7. Contract truth
+
+Three sources disagree on the `agent.run` field list. Verified 2026-08-22:
+`contracts/javascript/runtime-api.json` contains `skipPermissions` and `preset` but is
+**missing `executorProvider` and `resourceId`** — two of the nine fields that
+`javascript_child.go` actually accepts. The shipped JSON artifact is stale, and
+`you docs javascript-workflows` disagrees with both.
+
+A hand-maintained contract artifact will drift again. The fix is to generate it from the
+Go contract, which is the same mechanism proposed in
+`docs-generation-from-testable-sources.md` — this story is that plan's first consumer and
+its proof case.
+
+Acceptance: the JSON artifact is generated from `javascript_child.go`; a CI check fails
+when they disagree; a field added to the Go contract appears in the artifact and in the
+packaged docs without anyone editing either.
+
+### Deliberately not copied
+
+- **`Date.now()` / `Math.random()` throwing.** That constraint exists because Claude Code
+  replays the longest unchanged prefix of agent calls from cache, and nondeterminism
+  would poison it. Our resume model is the inverse — explicit
+  `workflow.checkpoint({label, state})` and `workflow.resumeState()`, which does not
+  snapshot the VM and therefore has no determinism requirement. Ours is manual but
+  survives process death; theirs is free but fragile across edits. Different bets, not a
+  ranking, and adopting their constraint without their cache would be pure cost.
+- **`isolation: 'worktree'` as the sole sandbox knob.** We are moving toward *fewer*
+  false guarantees, not toward a knob that implies isolation we would then have to
+  deliver per-child.
+- **Dropping the invocation surface.** `invocationSignature` turning a workflow into a
+  distributable CLI with generated help and positional/stdin/named bindings is ours
+  alone and is worth keeping, even though it is the reason the `--model` flag-collision
+  bug class exists at all.
+
+## Verification
+
+`make test` plus targeted functional tests near
+`pkg/services/factory_runtime/internal/services/orchestration/javascript/`. JS-P1's
+provider-command assertion is the regression guard for the entire permissions sequence
+and must stay green through JS-P4. JS-P7 additionally requires
+`make interfaces-all`, since it changes a generated contract artifact.
+
+## Delivery loop
+
+Implementation finishes when its final head is pushed, the PR is open, CI has started,
+and blocking review feedback is addressed. Review owns terminal-and-passing CI, conflict
+resolution, and merge. CI-run evidence goes in a PR comment, never a commit.

--- a/docs/internal/development/plans/mock-worker-validation-and-failed-states.md
+++ b/docs/internal/development/plans/mock-worker-validation-and-failed-states.md
@@ -1,0 +1,173 @@
+# Mock Worker Validation and Failed-State Fidelity
+
+---
+author: operator
+last modified: 2026, august, 22
+doc-id: PLAN-MOCK-001
+status: proposed
+---
+
+# problem statement
+
+The mock-worker harness silently falls through to default-accept when its selector matches nothing, so a misconfigured harness reports success — and it cannot reproduce most of the failure modes the real runtime produces, so no test can assert them.
+
+## customer ask
+
+Mock workers must be a trustworthy substrate for integration testing: a selector that matches nothing must say so, and a mock worker must be able to fail in every way a real worker fails.
+
+## solution
+
+Make no-match an explicit, loud configuration error rather than a silent fall-through, then extend the mock contract to cover the runtime's actual failure taxonomy so integration tests can assert each terminal state by construction.
+
+# original document
+
+`docs/internal/development/plans/ci-integration-test-matrix.md`. That tier is happy-path
+only and carries no failure rows, so this plan's failure taxonomy is exercised in the
+**functional** tier. Two connections to the integration tier remain, and both are load-
+bearing: MOCK-1/MOCK-2 decide whether the mock workers backing integration tests I1, I2
+and I3 actually bind their inputs, and MOCK-3's routed-to-failed-state mode is the
+acceptance evidence for integration Story 0.
+
+## Why this comes before the integration tier
+
+A harness that cannot fail is worse than no harness, because it manufactures confidence.
+The adversarial evaluation of v0.0.8 reported that the `workInputs` selector never
+matched anything, so **all three shipped example configs silently fell through to
+default-accept while reporting success**. If that holds, every test written against mock
+workers today is green by construction, in the same way that
+`TestRootProcessCompiledBinaryModeMatrix` is green by construction.
+
+This is the same failure shape as accepting a non-empty result as a valid one: the system
+distinguishes "matched and accepted" from "matched nothing, so accepted anyway" and then
+discards the distinction. The two outcomes are indistinguishable to the caller, and the
+uninteresting one is the default.
+
+**The selector claim is not yet confirmed in the current tree.** The machinery is present
+— `pkg/services/workers/mock_workers_contracts.go:42` declares
+`WorkInputs []MockWorkInputSelector`, and
+`pkg/services/workers/internal/interface/` carries an input index, a config decoder, and
+baseline inventories for `workId`, `workType`, `state`, `inputName`, `traceId`,
+`channel`, and `payloadHash`. Whether a selector actually *binds at runtime* cannot be
+settled by reading code; it needs a run. Story MOCK-1 exists to settle it either way, and
+its result is a finding regardless of which way it lands.
+
+## Story MOCK-1 — Settle the selector question (characterization)
+
+Before changing anything, pin the current behavior with a test that distinguishes the
+three outcomes the caller currently cannot tell apart:
+
+1. a selector that matches an input, and the matched input binds
+2. a selector that matches nothing, and the worker accepts anyway
+3. no selector configured, and the worker accepts by default
+
+Run each of the three shipped example configs and record which outcome each produces.
+
+Acceptance: a characterization test that passes against today's behavior and records the
+verdict in its assertions, so the subsequent change is a visible, reviewable diff rather
+than a claim. If outcome 2 does not occur, say so plainly — the evaluation finding is
+then refuted, and MOCK-2 narrows to a guard rather than a fix.
+
+## Story MOCK-2 — No-match is an error, not a fall-through
+
+A configured selector that matches no input must fail the run with a diagnostic naming
+the worker, the selector, the fields it matched on, and what was actually available.
+
+Rules:
+
+- A selector that matches nothing is a **configuration error**, surfaced at run start
+  where possible, not at dispatch time.
+- Default-accept remains the behavior when **no selector is configured**. That case is
+  legitimate and common; it is only the configured-but-unmatched case that is a lie.
+- The three shipped example configs must be corrected as part of this story, and each
+  becomes a functional-tier case. If a selector silently falls through, integration tests
+  I1–I3 are green by construction, because mock workers are what they run on — that is the
+  path by which this defect would silently disable the new tier.
+
+Acceptance: a config whose selector matches nothing exits non-zero with the selector and
+the available input names in the diagnostic; a config with no selector still accepts; a
+config whose selector matches binds the selected input, observable in the dispatch record.
+
+## Story MOCK-3 — Failure taxonomy
+
+The functional tier needs mock workers that fail the way real workers fail.
+Today the contract carries `MockWorkerRejectConfig` with `Stderr` and `ExitCode`
+(exercised in `pkg/transports/cli/run/run_config_test.go:419`), which covers one mode.
+The runtime produces several, and each drives different downstream behavior.
+
+| Mode | What the mock must do | What it lets a test assert |
+|---|---|---|
+| Reject with output | Non-zero exit, stderr, no result | The failure detail reaches `work show`, and batch mode exits non-zero |
+| Route to a failed state | Complete normally but emit an output routing the token to a failed place | The engine-completed-but-work-failed case — the exact shape that makes batch exit 0 today |
+| Hard timeout | Exceed the configured worker duration bound | Timeout classification is distinct from crash, and the bound is enforced |
+| Crash mid-stream | Exit after partial output | Partial output is not mistaken for a result; no half-written state |
+| Oversized output | Exceed `MaxOutputBytesPerWorker` | The bound is enforced and the diagnostic names it, rather than the record being silently discarded |
+| Consecutive failures | Fail deterministically on N successive attempts | The circuit breaker trips at exactly three and names the transition |
+| Slow but successful | Complete after a bounded delay | Concurrency limits are observable; capacity 1/2/4 rows are meaningful |
+
+Each mode is one field or one enum value on the mock worker config, declaratively
+selected. None of them requires a real provider.
+
+Acceptance: for each mode, a factory using it produces the documented terminal state and
+the documented exit code, asserted from a compiled binary. The routed-to-failed-state
+mode is the acceptance evidence for integration Story 0 (truthful batch exit codes) and
+must be written to fail against today's behavior.
+
+## Story MOCK-4 — Failed-state observability
+
+A test that can only see the process exit code cannot tell a circuit breaker from a
+timeout. Each failure mode above must be distinguishable through the read surfaces the
+integration tier uses.
+
+Acceptance: for every mode in MOCK-3, `work show` reports a failure reason that names the
+mode, `worker-sessions list --work-id` reports a lifecycle classification distinguishing
+it from the others, and `_last_output` does not contradict the terminal state. This
+directly closes the adversarial finding that `work show` on a FAILED item returns no
+reason and that its `_last_output` tag can contradict the FAILED state.
+
+## Story MOCK-5 — Selector coverage across the declared field set
+
+The input index declares seven selector fields: `workId`, `workType`, `state`,
+`inputName`, `traceId`, `channel`, `payloadHash`. A field that is declared but never
+matched is a trap for the next author.
+
+Acceptance: one integration row per field, proving each selects and each rejects; any
+field that cannot be made to match is removed from the contract in this story rather than
+left declared. A declared-but-dead selector field is not a smaller problem than a broken
+one — it is the same problem with a longer fuse.
+
+## Delivery order
+
+MOCK-1 → MOCK-2 → MOCK-3 → MOCK-4 → MOCK-5. Each merges on its own.
+
+MOCK-1 and MOCK-2 block integration tests I1, I2 and I3 — not because those tests assert
+selector behavior, but because they run on mock workers and a silent fall-through would
+make them unfalsifiable. MOCK-3, MOCK-4 and MOCK-5 land in the functional tier and block
+nothing in the integration tier, except that MOCK-3's routed-to-failed-state mode is
+Story 0's acceptance evidence.
+
+MOCK-3's routed-to-failed-state mode has a cross-dependency worth naming: it is written
+as a failing test *before* integration Story 0 lands, and Story 0's acceptance is that
+this test goes green. Neither lane should wait on the other — the test lands red-and-
+skipped with a pointer to Story 0, and Story 0 removes the skip.
+
+## Non-goals
+
+- **No new provider adapters.** Mock workers exist so tests need no provider at all.
+- **No mock-worker support for real model behavior** — token accounting, streaming
+  semantics, or provider-specific output shapes. Those belong to provider characterization
+  tests, and conflating them would make the mock harness a second implementation of the
+  thing it is supposed to stand in for.
+- **No changes to real worker execution.** This plan touches the mock path and the read
+  surfaces that report failure; it does not alter how real workers run.
+
+## Verification
+
+`make test`, plus targeted tests near `pkg/services/workers/` and the integration tier
+from `ci-integration-test-matrix.md`. MOCK-2 changes behavior for existing mock configs,
+so `make test-functional` is warranted for that story specifically.
+
+## Delivery loop
+
+Implementation finishes when its final head is pushed, the PR is open, CI has started,
+and blocking review feedback is addressed. Review owns terminal-and-passing CI, conflict
+resolution, and merge. CI-run evidence goes in a PR comment, never a commit.

--- a/docs/internal/development/plans/next-work-meta-plan.md
+++ b/docs/internal/development/plans/next-work-meta-plan.md
@@ -1,0 +1,307 @@
+# Next Work — Meta Plan, WIP State, and Program Verification Probes
+
+---
+author: operator
+last modified: 2026, august, 22
+doc-id: PLAN-META-001
+status: proposed
+---
+
+# problem statement
+
+Four programs reported complete while an adversarial evaluation found the capabilities they were meant to deliver absent or unverified, and we have no mechanism that re-opens a program when its delivered capability fails in customer posture.
+
+## customer ask
+
+Say what is in progress, what is next, and add probes that induce a loopback when newly generated work — cost modelling, observability, resume, local models — does not actually succeed.
+
+## solution
+
+Sequence the four implementation plans behind one blocking prerequisite, and give every completed program an adversarial probe whose negative verdict automatically produces remediation work rather than a report nobody acts on.
+
+# original document
+
+Companion plans in this directory:
+
+- `ci-integration-test-matrix.md`
+- `javascript-workflow-parity-and-permissions.md`
+- `docs-generation-from-testable-sources.md`
+- `mock-worker-validation-and-failed-states.md`
+
+## Part 1 — The systematic failure, named
+
+Four programs merged cleanly and were reported complete. An independent evaluation then
+found:
+
+- **no token or cost reporting anywhere in the product**, after the cost lanes had merged
+- **checkpoint/resume untested**, with no CLI entry point that could be exercised at all
+- the entire **MCP surface unreachable** from an installed binary
+- **`session list --scope persisted`** dead for the same reason
+- two shipped **catalog factories that do not load**
+
+These are not four unrelated misses. They share one cause:
+
+> **Every acceptance criterion was satisfiable from inside the repository.**
+
+Lanes proved their code correct with unit and functional tests run from a repo checkout,
+where `pkg/transports/http/testdata/` exists, where the working directory has a parent
+containing a `go.mod`, and where fixtures resolve. Nobody ran the shipped binary from a
+directory that has none of those things. The tests were not wrong; they were measuring a
+posture no customer occupies.
+
+That is the same root cause as the integration-test gap, at a different altitude. The
+integration tier fixes it going forward. The probes below fix it retroactively, for work
+already merged.
+
+**Corollary for future planning:** an acceptance criterion that can be satisfied without
+leaving the repository is not evidence of delivery for any capability a customer reaches
+through the installed binary.
+
+## Part 2 — Work in progress
+
+State as of 2026-08-22, reconstructed from GitHub because the daemon is down.
+
+### Infrastructure
+
+The factory has been down since roughly 08:30Z. `bin/you.exe` was built at 04:39Z and
+`main` moved at 08:09Z, so **the binary must be rebuilt before any restart** — a merged
+schema change against a stale binary fails at startup in a way that is indistinguishable
+from a broken config. 125 worktrees hold no unpushed commits, so nothing is stranded.
+
+### Open PRs — 24
+
+**Clean and mergeable now (8):** #2132 (lmx-p3b), #2133 (perf-c1), #2161 (tts contract),
+#2162 (obs-13), #2163 (operator coverage floors), #2170 (lint deadcode gate), #2172
+(deflake worker cancel), #2173 (ci current-merge lint gate). These are finished work
+blocked only because review is a factory workstation and the factory is dead.
+
+**Conflicted (2):** #2158, #2171.
+
+**Blocked (14) — three causes, not fourteen:**
+
+| Cause | PRs | Owner |
+|---|---|---|
+| Functional flake cluster on main | #2150, #2151, #2169, and contributing to #2152, #2155, #2174, #2175, #2176 | Baseline, not the lane |
+| Backend Lint — head predates #2165 (`cmd/gocoveragecheck/main.go` 1030 > 1000) | #2128, #2146 | Legitimate rebase; the comment must name #2165 |
+| Backend Lint — lane's own oversized file | #2177 (1242 lines), #2178 (137 > 100), #2154, #2175 | Lane; mechanical split |
+
+`Verification Policy` red is **derived** — it is green on healthy PRs and must never be
+diagnosed as an independent cause.
+
+### Main is ~40% green
+
+Of the last ten uncancelled CI runs on `main`, four passed and six failed, each failing a
+*different* test: `TestPackagedFactoryInvokedByCLICanBeInspectedByAPI`,
+`TestCancel_BeforeBoundaryAdmissionEitherWaitsOrTerminatesTheExactSupervision`,
+`TestRunReportsPackagedFactorySchemaDriftWithRegenerationRemedy` (twice),
+`TestACPExecuteObservesProviderSessionWhileAttemptIsLive`; one red run failed outside the
+test set. On lanes additionally `TestLargeRolloutNeverFailsWithoutCause` — on two
+unrelated diffs, which makes it baseline-owned by definition — and
+`TestBTRCP0OneShotCancellationCharacterization`.
+
+A rotating cast of failures is scattered async flake, not one bad test. Every lane
+inherits a coin-flip chance of a red required check it did not cause. **This is the
+throughput ceiling and it sits upstream of every program in this document.**
+
+## Part 3 — Standalone lanes that block the plans
+
+Three defects are not part of any plan above but gate them.
+
+**SEC-1 — READ_ONLY does not sandbox anything.** Provider adapters append
+`--dangerously-bypass-approvals-and-sandbox` (codex) and `--dangerously-skip-permissions`
+(claude, agy) gated on `SkipPermissions`, while the capability validators are referenced
+only inside their own package. Detail and remedy in
+`javascript-workflow-parity-and-permissions.md`. **This is security-shaped and must not
+ride behind a test-infrastructure program** — it lands on its own schedule.
+
+**FIX-1 — Bundle or remove the fixture-catalog dependency.**
+`pkg/services/factory_sessions/execution_contract.go:28` and
+`internal/executionopening/factory.go:305` make `mcp serve`, `session list --scope`, and
+`session dispatches` unreachable from an installed binary. Blocks integration tests I4 and
+I5, and is the clearest instance of the class the integration tier's no-internal-files rule
+exists to catch: an entrypoint that works only inside our repository.
+
+**FLAKE-1 — Deflake the main functional tier.** Six named tests above. Higher priority
+than any feature program, because it taxes all of them. The prepared batch
+`docs/temp/batches/2026-08-22/flakepolicy.json` also fixes the reviewer's flake escape
+hatch, which currently requires reproducing a CI-only flake on the base SHA — an
+unsatisfiable condition that forces correct reviewers to block healthy lanes.
+
+## Part 4 — Sequencing
+
+```
+FLAKE-1 ──────────────────────────────► (unblocks everything, do first)
+SEC-1 ────────────────────────────────► (independent, security)
+
+INT Story 0 (truthful batch exit codes)
+   ├─► MOCK-1..2 ──► MOCK-3..5
+   ├─► INT harness + I8 ──► INT job wired ──► I1,I2,I3 ──► I4
+   └─► DOC-6
+FIX-1 ────────────────────────────────► INT I4, I5
+REC-6 ────────────────────────────────► INT I6   (resume reads the recording)
+EXT-5 ────────────────────────────────► INT I7   (replay drift is an error)
+
+DOC-1 ──► DOC-2 ──► DOC-3 ──► DOC-4 ──► DOC-5
+                              (DOC-4 == JS-P7)
+
+JS-P1 ──► JS-P2 ──► JS-P3 ──► JS-P4     (permissions strangler)
+JS-P5, JS-P6                             (parity, independent)
+```
+
+**Integration Story 0 is the single highest-leverage item after FLAKE-1.** Until batch
+mode exits non-zero on a failed work state, every end-to-end assertion anyone writes is
+green by construction — including the probes in Part 5.
+
+## Part 5 — Program verification probes with induced loopback
+
+### Shape
+
+Each probe is one lane that:
+
+1. Runs from a **blanked-out working directory** with the **installed binary** — no
+   repository on any parent path, `HOME` pointed at a fresh directory.
+2. Attempts the capability the way a customer would.
+3. Emits a **structured verdict**: `PASS` / `FAIL` / `INCONCLUSIVE`, with the exact
+   command, output, and the falsifier it applied.
+4. On `FAIL`, writes a **remediation batch file** naming the specific lanes needed.
+
+A single `thoughts` work, `program-verification-loopback`, `DEPENDS_ON` all four probes.
+Its mission is to read every verdict and submit the remediation batches. That is the
+induced loopback: a failing probe produces work automatically rather than a report that
+waits for someone to notice.
+
+**`INCONCLUSIVE` is a first-class verdict and must be treated as `FAIL` by the loopback.**
+The resume capability was recorded as unverified rather than working, and an unverifiable
+capability is not a delivered one. A probe that cannot reach the capability has found
+something — usually a missing entry point — and that is remediation work.
+
+### Design rules
+
+- **Adversarial default.** Each probe assumes the capability does not work and must
+  produce positive evidence. "No error" is not evidence.
+- **Named falsifiers.** Every check states what result would prove failure, in advance.
+  The dominant failure mode in this codebase is a field that is present but always empty —
+  `schemaValidated: false`, `subject: ""`, a cost of zero after a billed call. A probe
+  that only checks for presence will pass on exactly the defect we are hunting. **Assert
+  values, never presence.**
+- **No live-system mutation.** Probes run against their own instance in their own
+  directory. The live daemon on port 7437 is off limits beyond read-only queries.
+- **Bounded.** Each probe is timeboxed and reports partial results with explicit gaps
+  rather than hanging.
+
+### PROBE-COST — cost modelling
+
+Covers obs-2, obs-9, obs-12, obs-13.
+
+| Check | Falsifier |
+|---|---|
+| A dispatch that consumed tokens reports a non-zero cost | Cost absent, or zero where a call occurred |
+| Session rollup equals the sum of its dispatch costs | Rollup present but zero, or disagreeing with its parts |
+| The price table resolves the provider and model actually used | Falls back to a default while reporting success |
+| A partially-known cost is marked partial | Reported as a complete zero |
+| `metrics` CLI surfaces the same numbers as the API | Two surfaces disagree |
+
+### PROBE-OBS — observability
+
+Covers obs-1, obs-3 through obs-8, obs-10, obs-11.
+
+| Check | Falsifier |
+|---|---|
+| Metrics reader returns non-empty data after a run | Empty, or a 500 |
+| Error codes are coded, not free text | A generic string where a code is contracted |
+| The model captured on the dispatch route equals the model actually invoked | Captured field empty, or the requested rather than resolved model |
+| Worker sessions carry provider attribution and session scope | Field present, always empty |
+| Turn count and context growth are non-zero after a multi-turn run | Zero after a run that clearly had turns |
+| Every metrics field declared in the contract is populated by at least one real run | A declared-but-dead field — the `schemaValidated` shape |
+
+### PROBE-RESUME — checkpoint and resume
+
+Covers rsm-1 through rsm-9. **Highest operational value of the four**: this capability was
+recorded as untested, and we lost a ~185-work board to a machine restart on 2026-08-22.
+
+| Check | Falsifier |
+|---|---|
+| A CLI entry point exists that exercises genuine crash-resume | No entry point — records `INCONCLUSIVE`, which the loopback treats as `FAIL` |
+| Hard-kill mid-run, restart with resume: the board is restored | Board empty, or short |
+| In-flight work resumes rather than restarting from zero | Work re-dispatched from the beginning |
+| The resumed run reaches the same terminal states as an uninterrupted control | Divergent outcomes |
+| Durable session state survives when the process is killed without cleanup | Corrupt or unreadable state |
+
+This probe's result also determines the priority of #2128 (`fr-board-persistence`), which
+is currently blocked.
+
+### PROBE-LOCALMODELS — local models
+
+Covers lmx-p0 through p3b, lai-p0, lai-p05, lai-t1, tts.
+
+| Check | Falsifier |
+|---|---|
+| Model pull and readiness from an empty model cache | Reports ready without the asset present |
+| TTS → STT roundtrip preserves the input text within tolerance | Empty output, or silent fallback to a remote provider |
+| Embeddings return vectors of the declared dimension | Wrong dimension, or zeros |
+| Backend artifacts resolve to pinned versions | Floating resolution while reporting pinned |
+| A missing backend fails loudly | Silent fallback, or a success verdict with no model |
+
+### Submission shape
+
+One batch: four `idea`-typed probe lanes plus one `thoughts`-typed
+`program-verification-loopback` with a `DEPENDS_ON` edge to each probe at
+`requiredState: complete`. Cross-batch dependency, if ever needed, uses `targetWorkId`
+(`batch-<requestId>-<name>`) rather than `targetWorkName`, which raises an ambiguity
+error when the name already exists on the board.
+
+Probes must not be scheduled until integration Story 0 has merged. Before that, a probe
+running a factory in batch mode receives exit 0 regardless of outcome and will report
+`PASS` on a broken capability — reproducing the exact failure this whole document exists
+to stop.
+
+## Part 6 — Immediate operator actions
+
+1. Rebuild `bin/you.exe`, restart the daemon. Nothing moves otherwise, and eight finished
+   PRs are waiting on review.
+2. Submit `flakepolicy.json` (FLAKE-1), extended with the four newly identified tests.
+3. Unblock the cheap ones: name #2165 to #2128 and #2146; tell #2154, #2175, #2177, #2178
+   to split their oversized files.
+4. Submit SEC-1 as its own lane.
+5. Submit integration Story 0.
+6. Merge #2162 to close observability; land perf-c1/f5/u6/u7 to close the three-minute
+   test target.
+7. Schedule the probe batch only after Story 0 merges.
+
+## Part 7 — Second-evaluation extensions
+
+Two further plans were added on 2026-08-22 after the 41-agent evaluation
+("The Gigabyte Session File"), and they change the sequencing above.
+
+- `recordings-as-single-session-artifact.md` (`PLAN-REC-001`) — retire durable sessions,
+  move recordings to the `YYYY/MM/DD/<session-id>.jsonl` layout that logs and metrics
+  already use, and bound them with the rotation machinery already in the binary. **REC-0
+  is the highest-priority lane in this document**: it caps the unbounded failure log and
+  makes the durable write atomic, and it is the fix for a measured, reproducible outage in
+  which a session file reached exactly 1 GiB and left the server unable to start.
+- `adversarial-findings-extensions.md` (`PLAN-EXT-001`) — routes every material finding to
+  one owning plan and designs the six that had no owner: the default-session delete that
+  kills the server, the single error code absorbing twenty root causes, unknown fields
+  warning instead of failing, `you metrics` ignoring `--server`, replay serving stale
+  output over detected drift, and secrets stored verbatim in recordings.
+
+Both reinforce Part 1 rather than contradicting it. Every one of those defects is
+reachable only by running the shipped binary as a customer would; none is visible from
+inside the repository. The corpus of failures keeps arriving from the same place because
+that is the only place we are still not looking.
+
+### Amendments to Part 6
+
+Insert as item 0: **submit REC-0**. It is independent of the daemon restart, of the flake
+policy, and of Story 0, and it is the only item here with a reproduced outage behind it.
+
+Add as an operator action, not a lane: **correct the claim that codex requires a git
+repository**, which is written into an operator skill document and was refuted by this
+round. A false finding in a briefing document costs a lane the same as a real defect.
+
+## Delivery loop
+
+Every lane derived from this document: implementation finishes when its final head is
+pushed, the PR is open, CI has started, and blocking review feedback is addressed. Review
+owns terminal-and-passing CI, conflict resolution, and merge. CI-run evidence goes in a
+PR comment, never a commit.

--- a/docs/internal/development/plans/recordings-as-single-session-artifact.md
+++ b/docs/internal/development/plans/recordings-as-single-session-artifact.md
@@ -1,0 +1,324 @@
+# Recordings As The Single Session Artifact
+
+---
+author: operator
+last modified: 2026, august, 22
+doc-id: PLAN-REC-001
+status: proposed
+---
+
+# problem statement
+
+We keep two session artifacts for the same run. The weaker one has no size bound and a non-atomic write, and it took the server down by growing to exactly 1 GiB and truncating mid-string. The stronger one is atomic and complete, but it is stored under a bespoke date layout matching neither logs nor metrics, and it is rewritten in full every 250 ms.
+
+## customer ask
+
+Remove durable sessions and replace them with recordings. Write recordings in `yyyy/mm/dd/` format the way metrics and logs already are, with the filename being only `<session-id>.jsonl`.
+
+## solution
+
+Promote the dated-path helper that logs and metrics already use into a shared platform
+surface, key the recording filename on the session's UUID and nothing else, through a
+collision-safe reservation, change the recording from a whole-file rewrite to an
+append-only JSONL stream, bound it with the rotation machinery already in the binary, and
+then retire `runtimepersist` behind those read surfaces.
+
+# original document
+
+The 41-agent adversarial evaluation of v0.0.8 ("The Gigabyte Session File", 281 findings,
+40 blockers, 22 Aug 2026), verified line by line against this tree at `74e1d6341`.
+
+## Evidence — measured in this tree, not quoted from the report
+
+| | Recording | Durable session |
+|---|---|---|
+| Root | `~/.you-agent-factory/recordings/` (global, documented) | `<cwd>/.you-agent-factory/durable-sessions/` (cwd-relative, undocumented) |
+| Path | `YYYY-MM/YYYY-MM-DD/factory-session-<token>-<HHMMSS>-<uuid>.json` | `<session-id>.json` |
+| Built at | `recordings/internal/services/recording_lifecycle/internal/service/live_recording_target.go:51-58` | `execution/runtimepersist/store.go:88` |
+| Write | `platform/replay.Local.WriteFile` — `MkdirAll` → `CreateTemp` → `Sync` → `Close` → `Rename`, with a Windows replace-retry loop (`storage.go:37-88`) | `files.WriteFile(path, encoded, 0o600)` — in-place overwrite, no temp, no rename (`store.go:112`) |
+| Content | 15 ordered events, factory definition and hashes, full payloads | 2 + 3 records, output text only |
+| Terminal state | recorded on `Finalize` | stuck at `RUNNING` / `FinishedAt: null` / `NOT_READY` after a clean exit 0 |
+| Survives a hard kill | yes (flushed every 250 ms) | no |
+| Read back by `you run` | yes, for replay | **never** |
+| Size bound | none | none |
+
+The comparison settles the question the customer ask implies. Durable sessions are not a
+smaller, cheaper artifact that recordings duplicate. They are a **strictly weaker copy**
+of an artifact we already write, on the only one of the two write paths that is unsafe.
+
+### The outage mechanism
+
+`~default.json` reached exactly 2^30 bytes and cut mid-string, so the server could no
+longer parse it and could no longer start. Growth was quadratic in retry count
+(`73.45k² + 1362.83k + 3634.09`, R² = 1.000000) because every snapshot re-embeds the
+entire `token.history.failure_log`, which has `append()` and no truncation anywhere in the
+tree. The write is a plain in-place overwrite, so a process death mid-write leaves a file
+that is neither the old snapshot nor the new one.
+
+Three independent guards were all absent on this one path, and all three exist elsewhere
+in the same binary:
+
+- **Atomicity** — `platform/replay.Local.WriteFile` does temp-write-sync-rename. Recordings
+  get it. `runtimepersist` does not.
+- **Rotation and caps** — `platform/rollingfile` carries `MaxSizeMB`, `MaxBackups`,
+  `MaxAgeDays`, `rotateForReservation()` and backup pruning
+  (`rollingfile.go:37,337,495-508`), wired to logs, metrics and wire transcripts. Neither
+  session artifact is wired to it.
+- **Collision safety** — `platform/runtimeartifact.Reserver` opens with
+  `O_CREATE|O_EXCL` and walks a bounded collision index (`reserve.go:42-58`). Recordings
+  avoid collisions only by accident, via the timestamp and UUID in the filename.
+  `durableSessionIDPattern` (`store.go:85`) explicitly **accepts `~default` as a storage
+  key**, so two sequential runs from one directory overwrite each other with no warning —
+  reproduced in the evaluation.
+
+### What nobody reads
+
+`grep` for `WalkDir`, `filepath.Glob` and `ReadDir` across `pkg/services/recordings`
+returns nothing outside tests. No production code enumerates the recordings root; every
+reader is handed an explicit path. And the `2006-01`/`2006-01-02` layout is constructed in
+**exactly one place** (`live_recording_target.go:52`) with no consumer parsing it back.
+
+That is both the reason the layout was free to diverge from logs and metrics, and the
+reason correcting it is contained. It is also why REC-5 in this plan adds the enumeration
+surface: a dated layout with no reader is a convention, not a capability.
+
+## Design
+
+### D1. One dated layout, one implementation
+
+`calendarDatedDir` — `filepath.Join(rootDir, at.Format("2006"), at.Format("01"),
+at.Format("02"))` — already exists at
+`pkg/platform/internal/runtimeartifact/paths.go:58` and is exactly what the customer ask
+describes. It is unexported, and it lives under `pkg/platform/internal/`, so
+`pkg/services/recordings` **cannot import it**.
+
+Copying the four-line function into recordings is the wrong fix: it would make three
+implementations of one convention, which is the same drift class this plan exists to
+close.
+
+Instead, extend the public wrapper that already sits over it.
+`pkg/platform/runtimeartifact` exports `Reserver`, whose `Reserve(root, at, kind, suffix)`
+already composes the dated directory with an `O_CREATE|O_EXCL` reservation and a bounded
+collision walk. It builds the *filename* from a timestamp, which is not what we want here.
+Add a sibling:
+
+```
+ReserveNamed(root string, at time.Time, name, ext string) (string, error)
+    → root/2006/01/02/<name><ext>, reserved O_EXCL,
+      falling to <name>-2<ext>, <name>-3<ext>, … on collision,
+      bounded by the existing maxPathCollisions
+```
+
+Recordings consume `ReserveNamed`. Logs, metrics and recordings then share one dated-path
+implementation and one collision policy.
+
+### D2. The filename is the session UUID, and nothing else
+
+`<session-id>.jsonl` where the session id is **solely the UUID**. No `factory-session-`
+prefix, no `HHMMSS`, no `dur-sess-` prefix, no registry alias, no extra identity appended.
+The name of the file is the identity of the session.
+
+The mechanism for this already exists and is already correct — it is simply not the one
+the recording target reads.
+
+- `livesession.EnsureRuntimeID` (`livesession/session.go:116-134`) **already mints a UUID**
+  for any session still carrying the `~default` registry alias, at construction, and fails
+  loudly if the generator returns empty.
+- `livesession.CanonicalID` (`session.go:99-107`) **already returns that UUID** in
+  preference to the alias. Its own doc comment says it: *"Default-route sessions keep the
+  ~default registry alias but expose a UUID runtime identity to clients."*
+- `livesession.IsUUIDID` (`session.go:109`) already exists as the predicate.
+
+So a UUID is available on the same object at the moment the recording target is planned.
+The alias reaches the filename because the recording path reads a different field:
+
+- `recordings/transports/cli/adapter.go:76-78` — when `ReportedSessionID` is empty it
+  substitutes the **literal string** `"~default"`
+  (`DefaultReportedFactorySessionID`, line 15).
+- `pkg/transports/cli/run/run.go:684` passes `defaultFactorySessionID` — the alias — in.
+- `live_recording_target.go:61` then string-substitutes that alias into the filename.
+
+That is the whole defect. A UUID identity was minted, a canonical accessor for it exists,
+and the transport hands the recording the registry alias instead.
+
+**Rules:**
+
+1. **`~default` is a registry alias, never a stored identity.** It may appear in a request,
+   a URL, or a flag; it may not appear in a filename, a storage key, or a recording header.
+   The recording target takes `CanonicalID`, not `ReportedSessionID`.
+2. **A non-UUID identity is a planning error, not a fallback.** `IsUUIDID` gates it. If the
+   identity is not a UUID, the target is refused with a diagnostic naming the identity —
+   we do not quietly write under an alias, and we do not mint a second one behind the
+   caller's back at a layer that has no business owning identity.
+3. **The identity vocabulary collapses to one shape.** `durableSessionIDPattern`
+   (`runtimepersist/store.go:85`) currently accepts three — `dur-sess-[a-f0-9]{32}`,
+   `~default`, and a UUID. Two of those disappear with the package at REC-7; the point of
+   naming it here is that the *reason* it accepts three is that no layer ever decided which
+   one was canonical. This plan decides: the UUID.
+4. **Collision safety stays as a guard, not as the mechanism.** Because a UUID is unique
+   per session, same-day collisions should not occur at all — which is exactly why
+   `ReserveNamed`'s `O_EXCL` open matters. A collision now means an identity was reused,
+   and that must surface as an error. It must never be absorbed by an overwrite, which is
+   the durable-sessions defect, nor hidden by a timestamp in the name, which is how
+   recordings have been avoiding the question.
+
+One thing gets simpler for free. `live_recording_target.go:60-64` currently produces two
+paths — a `ServicePath` containing a placeholder token and a `ReportedPath` derived from it
+by `strings.ReplaceAll` of that token with the session id. Once the filename is the UUID,
+the two paths are the same path and the substitution is deleted.
+
+### D3. JSONL, and why the format change is the actual fix
+
+The requested extension change is not cosmetic. `.jsonl` is the fix for a defect
+recordings share with durable sessions.
+
+`Recorder.Flush` calls `MarshalArtifact`, which is `json.MarshalIndent` over the **entire**
+artifact (`replay/artifact.go:143-160`), on a 250 ms dirty-flush loop
+(`recorder.go:19,186,244`). File size is O(events), but **bytes written is O(events²)**.
+Recordings survived where durable sessions did not because the recording does not re-embed
+an ever-growing failure log inside every record — it hit the linear term, not the quadratic
+one. The write amplification is real either way.
+
+Target format, `agent-factory.replay.v2`:
+
+- **Line 1** — header record: schema version, `recordedAt`, the session UUID,
+  factory identity and hashes.
+- **Lines 2..n** — one event per line, in sequence order, appended as they are recorded.
+- **Final line** — terminal record: `finishedAt`, terminal state, flush diagnostics.
+
+Flush appends only the bytes recorded since the last flush and syncs. There is no rename,
+because there is nothing to replace. Atomicity moves from whole-file replacement to
+per-line append, which is the property this format actually offers:
+
+> A truncated `.json` artifact costs the whole file. A truncated `.jsonl` artifact costs
+> the last line.
+
+That is the difference between "the server cannot start" and "the last event is missing" —
+and the 1 GiB file that caused the outage would have been fully readable up to its last
+complete line.
+
+The reader accepts both versions: `v1` (single JSON document, old layout) stays readable
+forever; nothing writes it after REC-4.
+
+### D4. Bounds, from machinery already in the binary
+
+Two separate bounds, because the two growth terms have different causes.
+
+- **Format-level (quadratic).** Removed by D3. Append-only means no record is rewritten,
+  so no field can be re-embedded per flush.
+- **Content-level (linear).** `token.history.failure_log` is append-only with no
+  truncation anywhere. Cap it: retain a head and a tail with an explicit dropped-count in
+  between. A truncated history that says how much it dropped is honest; an unbounded one
+  is a time bomb with a linear fuse.
+- **File-level.** Wire recordings to `platform/rollingfile`'s existing `MaxSizeMB` /
+  `MaxBackups` / `MaxAgeDays`. It is the same machinery already governing logs, metrics
+  and wire transcripts, and no session artifact is currently attached to it.
+
+### D5. Retiring durable sessions
+
+Everything durable sessions carry is a proper subset of the recording — session identity,
+state, start/finish, per-work terminal state, and output text. Retirement is therefore not
+a feature deletion; it is removing the second, weaker implementation of an artifact we
+already write.
+
+The order matters. `runtimepersist` is imported by 16 files, 11 of them tests, plus
+`cmd/durableruntimeconstructioncheck`, `pkg/services/factory_sessions/wire/application_graph.go`
+and `cmd/pkgboundarycheck/converged_boundaries_test.go`. The read surfaces move first, the
+writes go quiet second, the package dies last.
+
+**One behavior change must be decided, not absorbed.** Durable sessions are
+**cwd-relative**; recordings are **global**. Retiring one into the other moves a
+per-project artifact into a shared root. The recommendation is to keep the global root and
+rely on session identity for separation, because session ids are unique across projects
+and the global root is the documented one — but this is a visible change for anyone
+running two projects side by side, and it belongs in the release note rather than in a
+diff nobody reads.
+
+### D6. Migration and compatibility
+
+- **No conversion of historical recordings.** Old paths stay readable under the v1 reader.
+  A converter is a non-goal — it is work proportional to history, for a read surface that
+  has to support both versions anyway.
+- **Existing `durable-sessions/*.json` are left on disk**, unread after REC-7, and
+  documented as safe to delete. We do not delete a user's files as a side effect of a
+  refactor.
+- **The corrupt artifact in the wild is a diagnostic, not a silent skip.** A 1 GiB
+  unparseable file must produce a message naming the path and the fact that it is
+  oversized, not a generic parse error. That is REC-7's second half.
+
+## Delivery — eight independently mergeable steps
+
+**REC-0. Stop the bleeding.** Cap `token.history.failure_log`, and make the
+`runtimepersist` write atomic by routing it through the same temp-sync-rename shape
+`platform/replay` already uses. Lands first and alone. The atomic write becomes moot at
+REC-7, and is still worth its thirty lines today, because the retirement is seven merges
+away and the outage is not hypothetical.
+
+**REC-1. Characterization.** Pin today's path, filename, format and flush behavior —
+including an assertion that **two same-day default-session runs produce two distinct
+files**. That assertion is the regression guard for D2, and it must be written before the
+filename changes, not after.
+
+**REC-2. `ReserveNamed`.** Add it to `pkg/platform/runtimeartifact`, delegating to the
+single `calendarDatedDir`. No recordings change in this step. Mergeable on its own value:
+it makes the dated layout a shared surface rather than a private one.
+
+**REC-3. Adopt the layout and the filename.** Recordings move to
+`YYYY/MM/DD/<session-uuid>.json` via `ReserveNamed`, reading `livesession.CanonicalID`
+rather than `ReportedSessionID`; `ServicePath` and
+`ReportedPath` converge and the token substitution is deleted. Still `.json`, still
+whole-file. Separating the *path* change from the *format* change is deliberate — a
+bisect can then tell them apart.
+
+**REC-4. JSONL v2.** Append-only writer, dual-version reader, extension becomes `.jsonl`.
+This is the format change, alone, with the write-amplification measurement as its
+acceptance evidence: bytes written for an N-event run must be linear in N.
+
+**REC-5. Enumeration, through `you session list`.** There is no `you recording list`.
+A recording *is* a session's history, so a second command listing them would be a second
+vocabulary for one concept — the same duplication this plan exists to remove, reintroduced
+at the read surface. `you session list` today enumerates the live registry; this step
+extends it to the recorded history under the dated layout, so one command answers "what
+sessions are there" for both live and finished runs, keyed by the same UUID in both halves.
+Live-only and history-only views are flags on that command, not commands of their own.
+This is also the read surface REC-6 needs, and the first time anything has enumerated
+recordings at all.
+
+**REC-6. Back the durable read surfaces with recordings.** Session inspection reads the
+recording. Durable writes go behind a flag defaulting to off. No package is deleted yet,
+so this step is revertible.
+
+**REC-7. Delete.** Remove `runtimepersist`, `DirForProjectRoot`, `durableSessionIDPattern`,
+`cmd/durableruntimeconstructioncheck`, and the wire and boundary-check entries. Add the
+oversized-artifact diagnostic. `make lint` and `cmd/pkgboundarycheck` are the gates here.
+
+## Non-goals
+
+- **No change to what a recording contains**, beyond header and terminal framing. Content
+  changes are a separate plan, and mixing them into a format migration would make the diff
+  unreviewable.
+- **No conversion of historical artifacts**, and no deletion of files already on disk.
+- **No new export or remote destination** for recordings.
+- **No replay-semantics change.** Replay reads the same events in the same order; only the
+  bytes on disk are reshaped.
+- **No secret redaction here.** Recordings storing worker secrets verbatim is a real
+  finding, and it is owned by `adversarial-findings-extensions.md` story EXT-SEC-2 so the
+  redaction policy is reviewed on its own merits rather than as a rider on a path change.
+
+## Verification
+
+`make test`, plus targeted tests near `pkg/services/recordings/`,
+`pkg/platform/runtimeartifact/`, and
+`pkg/services/factory_sessions/internal/execution/`. REC-3 and REC-4 warrant
+`make test-functional`, since replay and session lifecycle both cross the changed surface.
+REC-7 requires `make lint` for the boundary and construction checks. REC-6 is what makes
+integration test I6 (resume) passable, since resume then reads the recording rather than
+the durable snapshot that does not survive a hard kill; that test is REC-6's acceptance
+evidence. REC-3, REC-4 and REC-5 add no integration tests of their own — the tier is
+capped at eight.
+
+## Delivery loop
+
+Implementation finishes when its final head is pushed, the PR is open, CI has started,
+and blocking review feedback is addressed. Review owns terminal-and-passing CI, conflict
+resolution, and merge. CI-run evidence goes in a PR comment, never a commit.


### PR DESCRIPTION
Documentation only. Seven planning documents under `docs/internal/development/plans/`, covering the work identified by the two adversarial evaluations of v0.0.8.

| doc-id | Document | Scope |
|---|---|---|
| PLAN-INT-001 | `ci-integration-test-matrix.md` | Eight happy-path integration tests, one per entrypoint, run from the installed binary in a clean directory. Adds the no-internal-files rule. |
| PLAN-REC-001 | `recordings-as-single-session-artifact.md` | Retire durable sessions into recordings; `YYYY/MM/DD/<session-uuid>.jsonl`; append-only writes; bounded artifacts. |
| PLAN-EXT-001 | `adversarial-findings-extensions.md` | Routes each finding to one owning plan, designs the six with no owner, records the refutations. |
| PLAN-JS-001 | `javascript-workflow-parity-and-permissions.md` | Collapse the two-axis permission model to one enum; three parity gaps. |
| PLAN-DOC-001 | `docs-generation-from-testable-sources.md` | Docs projected from real artifacts and Go contracts; `make docs-check` gate. |
| PLAN-MOCK-001 | `mock-worker-validation-and-failed-states.md` | Selector no-match becomes an error; failure taxonomy; failed-state observability. |
| PLAN-META-001 | `next-work-meta-plan.md` | WIP state, sequencing, and program-verification probes with induced loopback. |

No product code changes. These are pointers that lane payloads reference, so they need to be on `main` for worktree-based lanes to open them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178zD5WHNqjQvwBeQ8eFyed
