### PR TITLE
Reserve named runtime artifacts in canonical dated path

### DIFF
--- a/pkg/platform/internal/runtimeartifact/paths.go
+++ b/pkg/platform/internal/runtimeartifact/paths.go
@@ -38,6 +38,23 @@ func RuntimeArtifactPath(rootDir string, at time.Time, kind RuntimeArtifactKind,
 	return RuntimeArtifactPathWithCollision(rootDir, at, kind, suffix, 0)
 }
 
+// RuntimeNamedArtifactPath builds root/YYYY/MM/DD/<name><ext> using the
+// supplied UTC-normalized time.
+func RuntimeNamedArtifactPath(rootDir string, at time.Time, name, ext string) string {
+	return RuntimeNamedArtifactPathWithCollision(rootDir, at, name, ext, 0)
+}
+
+// RuntimeNamedArtifactPathWithCollision builds a named runtime artifact path
+// and, when collisionIndex is greater than zero, appends the next human
+// numbered candidate before the extension.
+func RuntimeNamedArtifactPathWithCollision(rootDir string, at time.Time, name, ext string, collisionIndex int) string {
+	filename := name + ext
+	if collisionIndex > 0 {
+		filename = name + "-" + strconv.Itoa(collisionIndex+1) + ext
+	}
+	return filepath.Join(calendarDatedDir(rootDir, at), filename)
+}
+
 // RuntimeArtifactPathWithCollision builds a runtime artifact path and, when
 // collisionIndex is greater than zero, appends a numeric uniqueness segment
 // after the optional suffix while preserving the time-kind prefix.

--- a/pkg/platform/runtimeartifact/reserve.go
+++ b/pkg/platform/runtimeartifact/reserve.go
@@ -15,6 +15,10 @@ import (
 
 const maxPathCollisions = 1000
 
+// ErrNamedReservationExhausted indicates that every bounded candidate for a
+// caller-named runtime artifact was already occupied.
+var ErrNamedReservationExhausted = errors.New("named runtime artifact reservation exhausted")
+
 // FileSystem is the exact filesystem effect used to reserve artifact paths.
 type FileSystem interface {
 	MkdirAll(string, fs.FileMode) error
@@ -41,7 +45,7 @@ func (r *reserver) Reserve(root string, at time.Time, kind, suffix string) (stri
 		return internalartifact.RuntimeArtifactPathWithCollision(
 			root, at, internalartifact.RuntimeArtifactKind(kind), suffix, collision,
 		)
-	})
+	}, nil)
 }
 
 // ReserveNamed atomically selects a unique caller-named path under a dated
@@ -49,10 +53,10 @@ func (r *reserver) Reserve(root string, at time.Time, kind, suffix string) (stri
 func (r *reserver) ReserveNamed(root string, at time.Time, name, ext string) (string, error) {
 	return r.reserve(root, func(collision int) string {
 		return internalartifact.RuntimeNamedArtifactPathWithCollision(root, at, name, ext, collision)
-	})
+	}, ErrNamedReservationExhausted)
 }
 
-func (r *reserver) reserve(root string, pathForCollision func(int) string) (string, error) {
+func (r *reserver) reserve(root string, pathForCollision func(int) string, exhaustion error) (string, error) {
 	if root == "" {
 		return "", fmt.Errorf("runtime artifact root is required")
 	}
@@ -78,6 +82,9 @@ func (r *reserver) reserve(root string, pathForCollision func(int) string) (stri
 		if !errors.Is(err, fs.ErrExist) {
 			return "", fmt.Errorf("reserve runtime artifact %s: %w", path, err)
 		}
+	}
+	if exhaustion != nil {
+		return "", fmt.Errorf("%w under %s", exhaustion, root)
 	}
 	return "", fmt.Errorf("runtime artifact path collision budget exhausted under %s", root)
 }

--- a/pkg/platform/runtimeartifact/reserve.go
+++ b/pkg/platform/runtimeartifact/reserve.go
@@ -24,6 +24,7 @@ type FileSystem interface {
 // Reserver atomically selects a unique path under a dated artifact root.
 type Reserver interface {
 	Reserve(string, time.Time, string, string) (string, error)
+	ReserveNamed(string, time.Time, string, string) (string, error)
 }
 
 type reserver struct{ filesystem FileSystem }
@@ -36,13 +37,27 @@ func NewReserver(filesystem FileSystem) (Reserver, error) {
 }
 
 func (r *reserver) Reserve(root string, at time.Time, kind, suffix string) (string, error) {
+	return r.reserve(root, func(collision int) string {
+		return internalartifact.RuntimeArtifactPathWithCollision(
+			root, at, internalartifact.RuntimeArtifactKind(kind), suffix, collision,
+		)
+	})
+}
+
+// ReserveNamed atomically selects a unique caller-named path under a dated
+// artifact root. The extension is appended exactly as supplied.
+func (r *reserver) ReserveNamed(root string, at time.Time, name, ext string) (string, error) {
+	return r.reserve(root, func(collision int) string {
+		return internalartifact.RuntimeNamedArtifactPathWithCollision(root, at, name, ext, collision)
+	})
+}
+
+func (r *reserver) reserve(root string, pathForCollision func(int) string) (string, error) {
 	if root == "" {
 		return "", fmt.Errorf("runtime artifact root is required")
 	}
 	for collision := 0; collision < maxPathCollisions; collision++ {
-		path := internalartifact.RuntimeArtifactPathWithCollision(
-			root, at, internalartifact.RuntimeArtifactKind(kind), suffix, collision,
-		)
+		path := pathForCollision(collision)
 		if err := r.filesystem.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			return "", fmt.Errorf("create runtime artifact dir %s: %w", filepath.Dir(path), err)
 		}

--- a/pkg/platform/runtimeartifact/reserve_test.go
+++ b/pkg/platform/runtimeartifact/reserve_test.go
@@ -1,6 +1,7 @@
 package runtimeartifact
 
 import (
+	"errors"
 	"io"
 	"io/fs"
 	"os"
@@ -58,6 +59,130 @@ func TestReserverCreatesDatedPathAndAvoidsExistingArtifact(t *testing.T) {
 		t.Fatalf("reserved parents = %q, %q; want %q", filepath.Dir(first), filepath.Dir(second), wantParent)
 	}
 }
+
+func TestReserverReserveNamedUsesUTCNameAndOrderedCollisions(t *testing.T) {
+	reserver, err := NewReserver(localFileSystem{})
+	if err != nil {
+		t.Fatalf("NewReserver: %v", err)
+	}
+	root := t.TempDir()
+	at := time.Date(2026, time.May, 29, 23, 45, 3, 0, time.FixedZone("PDT", -7*60*60))
+
+	first, err := reserver.ReserveNamed(root, at, "session", ".jsonl")
+	if err != nil {
+		t.Fatalf("ReserveNamed first: %v", err)
+	}
+	if err := os.WriteFile(first, []byte("first"), 0o644); err != nil {
+		t.Fatalf("WriteFile(first): %v", err)
+	}
+	second, err := reserver.ReserveNamed(root, at, "session", ".jsonl")
+	if err != nil {
+		t.Fatalf("ReserveNamed second: %v", err)
+	}
+	if err := os.WriteFile(second, []byte("second"), 0o644); err != nil {
+		t.Fatalf("WriteFile(second): %v", err)
+	}
+	third, err := reserver.ReserveNamed(root, at, "session", ".jsonl")
+	if err != nil {
+		t.Fatalf("ReserveNamed third: %v", err)
+	}
+
+	wantParent := filepath.Join(root, "2026", "05", "30")
+	wantPaths := []string{
+		filepath.Join(wantParent, "session.jsonl"),
+		filepath.Join(wantParent, "session-2.jsonl"),
+		filepath.Join(wantParent, "session-3.jsonl"),
+	}
+	for index, path := range []string{first, second, third} {
+		if path != wantPaths[index] {
+			t.Errorf("ReserveNamed candidate %d = %q, want %q", index, path, wantPaths[index])
+		}
+	}
+	if got, err := os.ReadFile(first); err != nil || string(got) != "first" {
+		t.Fatalf("first artifact = %q, %v; want preserved contents", got, err)
+	}
+	if got, err := os.ReadFile(second); err != nil || string(got) != "second" {
+		t.Fatalf("second artifact = %q, %v; want preserved contents", got, err)
+	}
+	info, err := os.Stat(first)
+	if err != nil {
+		t.Fatalf("Stat(first): %v", err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Fatalf("named artifact mode = %#o, want %#o", info.Mode().Perm(), 0o600)
+	}
+}
+
+func TestReserverReserveNamedReturnsNonCollisionFailures(t *testing.T) {
+	mkdirErr := errors.New("mkdir failed")
+	openErr := errors.New("open failed")
+	closeErr := errors.New("close failed")
+	tests := []struct {
+		name       string
+		fileSystem *reserveNamedFailureFileSystem
+		wantErr    error
+		wantOpens  int
+	}{
+		{
+			name:       "mkdir",
+			fileSystem: &reserveNamedFailureFileSystem{mkdirErr: mkdirErr},
+			wantErr:    mkdirErr,
+		},
+		{
+			name:       "open",
+			fileSystem: &reserveNamedFailureFileSystem{openErr: openErr},
+			wantErr:    openErr,
+			wantOpens:  1,
+		},
+		{
+			name:       "close",
+			fileSystem: &reserveNamedFailureFileSystem{file: closeErrorFile{err: closeErr}},
+			wantErr:    closeErr,
+			wantOpens:  1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reserver, err := NewReserver(test.fileSystem)
+			if err != nil {
+				t.Fatalf("NewReserver: %v", err)
+			}
+			_, err = reserver.ReserveNamed(t.TempDir(), time.Date(2026, time.May, 29, 4, 45, 3, 0, time.UTC), "session", ".jsonl")
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("ReserveNamed error = %v, want %v", err, test.wantErr)
+			}
+			if len(test.fileSystem.opened) != test.wantOpens {
+				t.Fatalf("OpenFile calls = %d, want %d", len(test.fileSystem.opened), test.wantOpens)
+			}
+		})
+	}
+}
+
+type reserveNamedFailureFileSystem struct {
+	mkdirErr error
+	openErr  error
+	file     io.WriteCloser
+	opened   []string
+}
+
+func (filesystem *reserveNamedFailureFileSystem) MkdirAll(string, fs.FileMode) error {
+	return filesystem.mkdirErr
+}
+
+func (filesystem *reserveNamedFailureFileSystem) OpenFile(path string, _ int, _ fs.FileMode) (io.WriteCloser, error) {
+	filesystem.opened = append(filesystem.opened, path)
+	if filesystem.openErr != nil {
+		return nil, filesystem.openErr
+	}
+	return filesystem.file, nil
+}
+
+type closeErrorFile struct{ err error }
+
+func (closeErrorFile) Write(p []byte) (int, error) { return len(p), nil }
+
+func (file closeErrorFile) Close() error { return file.err }
 
 func TestReserverAvoidsConcurrentCollisions(t *testing.T) {
 	reserver, err := NewReserver(localFileSystem{})

--- a/pkg/platform/runtimeartifact/reserve_test.go
+++ b/pkg/platform/runtimeartifact/reserve_test.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	internalartifact "github.com/portpowered/infinite-you/pkg/platform/internal/runtimeartifact"
 )
 
 type localFileSystem struct{}
@@ -93,11 +95,7 @@ func TestReserverReserveNamedUsesUTCNameAndOrderedCollisions(t *testing.T) {
 		filepath.Join(wantParent, "session-2.jsonl"),
 		filepath.Join(wantParent, "session-3.jsonl"),
 	}
-	for index, path := range []string{first, second, third} {
-		if path != wantPaths[index] {
-			t.Errorf("ReserveNamed candidate %d = %q, want %q", index, path, wantPaths[index])
-		}
-	}
+	assertNamedReservationPaths(t, []string{first, second, third}, wantPaths)
 	if got, err := os.ReadFile(first); err != nil || string(got) != "first" {
 		t.Fatalf("first artifact = %q, %v; want preserved contents", got, err)
 	}
@@ -110,6 +108,15 @@ func TestReserverReserveNamedUsesUTCNameAndOrderedCollisions(t *testing.T) {
 	}
 	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Fatalf("named artifact mode = %#o, want %#o", info.Mode().Perm(), 0o600)
+	}
+}
+
+func assertNamedReservationPaths(t *testing.T, got, want []string) {
+	t.Helper()
+	for index, path := range got {
+		if path != want[index] {
+			t.Errorf("ReserveNamed candidate %d = %q, want %q", index, path, want[index])
+		}
 	}
 }
 
@@ -157,6 +164,86 @@ func TestReserverReserveNamedReturnsNonCollisionFailures(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReserverReserveNamedExhaustsAtCollisionBound(t *testing.T) {
+	filesystem := &namedReservationExhaustionFileSystem{}
+	reserver, err := NewReserver(filesystem)
+	if err != nil {
+		t.Fatalf("NewReserver: %v", err)
+	}
+
+	root := t.TempDir()
+	at := time.Date(2026, time.May, 29, 4, 45, 3, 0, time.UTC)
+	path, err := reserver.ReserveNamed(root, at, "session", ".jsonl")
+	if !errors.Is(err, ErrNamedReservationExhausted) {
+		t.Fatalf("ReserveNamed error = %v, want ErrNamedReservationExhausted", err)
+	}
+	if path != "" {
+		t.Fatalf("ReserveNamed path = %q, want empty path", path)
+	}
+	if len(filesystem.opened) != maxPathCollisions {
+		t.Fatalf("OpenFile calls = %d, want %d", len(filesystem.opened), maxPathCollisions)
+	}
+
+	wantFirst := filepath.Join(root, "2026", "05", "29", "session.jsonl")
+	wantLast := filepath.Join(root, "2026", "05", "29", "session-1000.jsonl")
+	if filesystem.opened[0] != wantFirst {
+		t.Fatalf("first exhausted candidate = %q, want %q", filesystem.opened[0], wantFirst)
+	}
+	if filesystem.opened[len(filesystem.opened)-1] != wantLast {
+		t.Fatalf("last exhausted candidate = %q, want %q", filesystem.opened[len(filesystem.opened)-1], wantLast)
+	}
+	for _, path := range filesystem.opened {
+		if filepath.Base(path) == "session-1001.jsonl" {
+			t.Fatalf("candidate walk exceeded bound with %q", path)
+		}
+	}
+}
+
+func TestReserverReserveNamedSharesCalendarDirectoryWithLogsAndMetrics(t *testing.T) {
+	root := t.TempDir()
+	at := time.Date(2026, time.May, 29, 23, 45, 3, 0, time.FixedZone("PDT", -7*60*60))
+	reserver, err := NewReserver(localFileSystem{})
+	if err != nil {
+		t.Fatalf("NewReserver: %v", err)
+	}
+
+	namedPath, err := reserver.ReserveNamed(root, at, "session", ".jsonl")
+	if err != nil {
+		t.Fatalf("ReserveNamed: %v", err)
+	}
+	logPath := internalartifact.RuntimeArtifactPath(root, at, internalartifact.RuntimeArtifactKindLog, "runtime")
+	metricsPath := internalartifact.RuntimeArtifactPath(root, at, internalartifact.RuntimeArtifactKindMetrics, "session-runtime")
+	wantDir := filepath.Join(root, "2026", "05", "30")
+	for name, path := range map[string]string{
+		"log":     logPath,
+		"metrics": metricsPath,
+		"named":   namedPath,
+	} {
+		if got := filepath.Dir(path); got != wantDir {
+			t.Errorf("%s parent = %q, want %q", name, got, wantDir)
+		}
+	}
+	if filepath.Dir(logPath) != internalartifact.RuntimeLogsDatedDir(root, at) {
+		t.Fatalf("log parent = %q, want platform log dated directory", filepath.Dir(logPath))
+	}
+	if filepath.Dir(metricsPath) != internalartifact.RuntimeMetricsDatedDir(root, at) {
+		t.Fatalf("metrics parent = %q, want platform metrics dated directory", filepath.Dir(metricsPath))
+	}
+}
+
+type namedReservationExhaustionFileSystem struct {
+	opened []string
+}
+
+func (filesystem *namedReservationExhaustionFileSystem) MkdirAll(string, fs.FileMode) error {
+	return nil
+}
+
+func (filesystem *namedReservationExhaustionFileSystem) OpenFile(path string, _ int, _ fs.FileMode) (io.WriteCloser, error) {
+	filesystem.opened = append(filesystem.opened, path)
+	return nil, fs.ErrExist
 }
 
 type reserveNamedFailureFileSystem struct {

--- a/pkg/platform/wiretranscript/wiretranscript_test.go
+++ b/pkg/platform/wiretranscript/wiretranscript_test.go
@@ -651,3 +651,10 @@ func (r *staticPathReserver) Reserve(root string, at time.Time, kind, suffix str
 	}
 	return r.path, nil
 }
+
+func (r *staticPathReserver) ReserveNamed(string, time.Time, string, string) (string, error) {
+	if r.err != nil {
+		return "", r.err
+	}
+	return r.path, nil
+}


### PR DESCRIPTION
{
  "project": "Reserve Named Runtime Artifacts in the Canonical Dated Path",
  "branchName": "rec-2-reserve-named-dated-path",
  "description": "Add a platform-owned ReserveNamed runtime-artifact capability that atomically reserves caller-owned filenames under the canonical UTC YYYY/MM/DD directory, resolves collisions as <name>-2<ext>, <name>-3<ext>, and later bounded candidates, and returns a recognizable named exhaustion error. Logs, metrics, and named reservations will share the existing platform calendar-directory implementation; recordings are explicitly unchanged in this lane.",
  "context": {
    "customerAsk": "Provide ReserveNamed(root string, at time.Time, name, ext string) on the platform runtime-artifact reserver. It must reserve root/YYYY/MM/DD/<name><ext> with O_CREATE|O_EXCL, use <name>-2<ext>, <name>-3<ext>, and later candidates on collision within the existing maxPathCollisions bound, return a named exhaustion error, prove agreement with log and metrics date directories, and not touch pkg/services/recordings.",
    "problem": "The platform's logs and metrics share a UTC YYYY/MM/DD calendar layout, but callers that own their artifact filename cannot use the existing timestamp-derived reserver. Recordings currently use a different layout, while the canonical calendar helper is private to the platform. Without a named platform capability, later adoption would require misusing the timestamp API or duplicating date and collision policy, recreating the drift this work is intended to prevent.",
    "solution": "Extend the existing platform Reserver with a sibling ReserveNamed operation. Compose named candidates through the same platform-internal calendar directory used by logs and metrics, preserve injected filesystem effects and owner-only exclusive creation, number collisions from -2, retain the existing bounded collision policy, and expose a stable error that callers can match when the budget is exhausted. Add focused behavioral coverage and defer all recording changes to a separate migration lane."
  },
  "acceptanceCriteria": [
    "For a supplied instant, ReserveNamed(root, at, name, ext) atomically creates and returns root/YYYY/MM/DD/<name><ext>, using the instant normalized to UTC and the platform's existing runtime-artifact directory and file permissions.",
    "Repeating a named reservation for the same root, UTC day, name, and extension never overwrites the first file; the second successful path is <name>-2<ext>, followed by <name>-3<ext> for the next collision.",
    "If every candidate in the existing maxPathCollisions budget already exists, named reservation stops at the bound and returns a stable named error recognizable without parsing its message.",
    "Direct behavioral coverage proves log paths, metrics paths, and named reservations resolve to the same YYYY/MM/DD directory for the same root and instant through the single platform calendar-directory policy.",
    "The change remains owned by pkg/platform/runtimeartifact and its platform-internal path mechanics, does not touch pkg/services/recordings, and includes no unrelated path migration, format change, or cleanup.",
    "Quality gates pass: Typecheck passes; focused runtime-artifact tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "rec-2-reserve-named-dated-path-001",
      "title": "Reserve a caller-named artifact without overwriting",
      "description": "As a runtime-artifact caller, I want to reserve a path using my own stable filename so that I can retain caller-owned identity while receiving the platform's canonical date partitioning and atomic uniqueness guarantees.",
      "acceptanceCriteria": [
        "The platform Reserver contract provides ReserveNamed(root string, at time.Time, name, ext string) (string, error) alongside the existing timestamp-derived reservation operation.",
        "Given an instant with a non-UTC location, the returned path is rooted at the corresponding UTC YYYY/MM/DD directory and has the exact base filename <name><ext>.",
        "Reservation creates the dated directory as needed and exclusively creates the reserved file with the existing owner-only runtime-artifact permissions.",
        "If <name><ext> already exists, a second reservation returns <name>-2<ext> and preserves the existing file and its contents; a further collision returns <name>-3<ext>.",
        "Non-collision filesystem and close failures return contextual errors and are not treated as collisions.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented ReserveNamed with shared UTC calendar path mechanics, exclusive owner-only creation, ordered -2/-3 collision candidates, and contextual filesystem/close failure handling. Focused runtimeartifact, internal runtimeartifact, wiretranscript, and all pkg/platform tests pass."
    },
    {
      "id": "rec-2-reserve-named-dated-path-002",
      "title": "Bound collision failure and prove one calendar convention",
      "description": "As a maintainer, I want collision exhaustion and directory agreement to be explicit and directly testable so that callers can handle a full namespace safely and future artifact types cannot silently drift from the platform date convention.",
      "acceptanceCriteria": [
        "Named reservation evaluates no more than the existing maxPathCollisions candidate budget, covering the unsuffixed base candidate and subsequent human-numbered candidates in order.",
        "When all candidates in that budget exist, the operation returns the platform's stable named collision-exhaustion error, recognizable through standard Go error matching, and does not overwrite any candidate.",
        "For the same root and instant, direct path assertions show that a log path, a metrics path, and a successfully reserved named path have the identical UTC YYYY/MM/DD parent directory.",
        "The named path delegates dated-directory construction to the same platform-internal calendar policy used by logs and metrics; no copied date-format implementation is introduced.",
        "Focused tests cover the successful base path, -2 and -3 collisions, exhaustion, UTC normalization, and shared log, metrics, and named directory behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added ErrNamedReservationExhausted with contextual wrapping while preserving timestamp-derived Reserve exhaustion behavior. Added deterministic coverage proving exactly maxPathCollisions candidates are evaluated, the final candidate is <name>-1000<ext>, and log, metrics, and named paths share the same UTC calendar parent. Focused runtimeartifact, internal runtimeartifact, logging, metrics, and wiretranscript tests pass."
    }
  ]
}
