### PR TITLE
Standardize Node Resize Affordances

### DIFF
--- a/ui/packages/factory-graph/src/node-resize-controls.tsx
+++ b/ui/packages/factory-graph/src/node-resize-controls.tsx
@@ -76,7 +76,7 @@ export function FactoryGraphNodeResizeControls({
       onResize={handleResize}
       onResizeEnd={handleResizeEnd}
       position={resizePosition}
-      style={RESIZE_GRIP_STYLE_BY_POSITION[resizePosition]}
+      style={RESIZE_GRIP_STYLE}
       variant={ResizeControlVariant.Handle}
       shouldResize={(_event, dimensions) =>
         isFiniteBoundedDimensions(dimensions, bounds)
@@ -84,7 +84,7 @@ export function FactoryGraphNodeResizeControls({
     >
       <span
         aria-hidden="true"
-        className={RESIZE_GRIP_MARK_CLASS_NAME[resizePosition]}
+        className={RESIZE_GRIP_MARK_CLASS_NAME}
         data-factory-graph-node-resize-grip={resizePosition}
       />
     </NodeResizeControl>
@@ -112,16 +112,9 @@ const RESIZE_GRIP_CONTROL_CLASS_NAME = [
 const RESIZE_GRIP_MARK_BASE_CLASS_NAME =
   "pointer-events-none block h-full w-full border-af-text-subtle";
 
-const RESIZE_GRIP_MARK_CLASS_NAME: Record<ResizeGripPosition, string> = {
-  bottom: `${RESIZE_GRIP_MARK_BASE_CLASS_NAME} border-b-2`,
-  "bottom-right": `${RESIZE_GRIP_MARK_BASE_CLASS_NAME} rounded-br-sm border-b-2 border-r-2`,
-  right: `${RESIZE_GRIP_MARK_BASE_CLASS_NAME} border-r-2`,
-};
+const RESIZE_GRIP_MARK_CLASS_NAME = `${RESIZE_GRIP_MARK_BASE_CLASS_NAME} rounded-br-sm border-b-2 border-r-2`;
 
-type ResizeGripPosition = Extract<
-  ControlPosition,
-  "bottom" | "bottom-right" | "right"
->;
+type ResizeGripPosition = Extract<ControlPosition, "bottom-right">;
 
 /**
  * Small enough to read as a hint rather than a divider, and inset from the
@@ -147,30 +140,16 @@ function resizeGripStyle(
   };
 }
 
-const RESIZE_GRIP_STYLE_BY_POSITION: Record<ResizeGripPosition, CSSProperties> =
-  {
-    bottom: resizeGripStyle("50%", "100%", `-50% ${RESIZE_GRIP_INSET}`),
-    "bottom-right": resizeGripStyle(
-      "100%",
-      "100%",
-      `${RESIZE_GRIP_INSET} ${RESIZE_GRIP_INSET}`,
-    ),
-    right: resizeGripStyle("100%", "50%", `${RESIZE_GRIP_INSET} -50%`),
-  };
+const RESIZE_GRIP_STYLE: CSSProperties = resizeGripStyle(
+  "100%",
+  "100%",
+  `${RESIZE_GRIP_INSET} ${RESIZE_GRIP_INSET}`,
+);
 
 function resizeControlPosition(
   allowedAxes: FactoryGraphNodeResizeAxes,
 ): ResizeGripPosition | null {
-  if (allowedAxes.width && allowedAxes.height) {
-    return "bottom-right";
-  }
-  if (allowedAxes.width) {
-    return "right";
-  }
-  if (allowedAxes.height) {
-    return "bottom";
-  }
-  return null;
+  return allowedAxes.width || allowedAxes.height ? "bottom-right" : null;
 }
 
 function isFiniteBoundedDimensions(

--- a/ui/packages/factory-graph/src/node-resize-controls.tsx
+++ b/ui/packages/factory-graph/src/node-resize-controls.tsx
@@ -64,6 +64,7 @@ export function FactoryGraphNodeResizeControls({
   if (!resizePosition) {
     return null;
   }
+  const resizeDirection = resizeControlDirection(allowedAxes);
 
   return (
     <NodeResizeControl
@@ -76,6 +77,7 @@ export function FactoryGraphNodeResizeControls({
       onResize={handleResize}
       onResizeEnd={handleResizeEnd}
       position={resizePosition}
+      resizeDirection={resizeDirection}
       style={RESIZE_GRIP_STYLE}
       variant={ResizeControlVariant.Handle}
       shouldResize={(_event, dimensions) =>
@@ -150,6 +152,18 @@ function resizeControlPosition(
   allowedAxes: FactoryGraphNodeResizeAxes,
 ): ResizeGripPosition | null {
   return allowedAxes.width || allowedAxes.height ? "bottom-right" : null;
+}
+
+function resizeControlDirection(
+  allowedAxes: FactoryGraphNodeResizeAxes,
+): "horizontal" | "vertical" | undefined {
+  if (allowedAxes.width && !allowedAxes.height) {
+    return "horizontal";
+  }
+  if (allowedAxes.height && !allowedAxes.width) {
+    return "vertical";
+  }
+  return undefined;
 }
 
 function isFiniteBoundedDimensions(

--- a/ui/src/features/flowchart/components/node-resize/factory-graph-node-resize-controls.test.tsx
+++ b/ui/src/features/flowchart/components/node-resize/factory-graph-node-resize-controls.test.tsx
@@ -24,23 +24,25 @@ vi.mock("@xyflow/react", async (importOriginal) => {
         dimensions: { height: number; width: number },
       ) => void;
       position: string;
+      resizeDirection?: "horizontal" | "vertical";
       style?: Record<string, string>;
       variant?: string;
     }) => (
       <button
         className={props.className}
         data-testid={`resize-${props.position}`}
+        data-resize-direction={props.resizeDirection}
         data-variant={props.variant}
         onClick={() =>
           props.onResizeEnd?.(new MouseEvent("mouseup"), {
-            height: 240,
-            width: 280,
+            height: props.resizeDirection === "horizontal" ? 240 : 280,
+            width: props.resizeDirection === "vertical" ? 200 : 280,
           })
         }
         onPointerMove={() =>
           props.onResize?.(new MouseEvent("mousemove"), {
-            height: 210,
-            width: 250,
+            height: props.resizeDirection === "horizontal" ? 210 : 250,
+            width: props.resizeDirection === "vertical" ? 200 : 250,
           })
         }
         style={props.style}
@@ -127,6 +129,21 @@ describe("Factory graph node resize controls", () => {
         "data-variant",
         "handle",
       );
+      const resizeDirection = allowedAxes.width
+        ? allowedAxes.height
+          ? undefined
+          : "horizontal"
+        : "vertical";
+      if (resizeDirection) {
+        expect(screen.getByTestId("resize-bottom-right")).toHaveAttribute(
+          "data-resize-direction",
+          resizeDirection,
+        );
+      } else {
+        expect(screen.getByTestId("resize-bottom-right")).not.toHaveAttribute(
+          "data-resize-direction",
+        );
+      }
       expect(screen.queryByTestId("resize-right")).toBeNull();
       expect(screen.queryByTestId("resize-bottom")).toBeNull();
     },
@@ -236,8 +253,27 @@ describe("Factory graph node live resize", () => {
 
     fireEvent.pointerMove(screen.getByTestId("resize-bottom-right"));
 
-    expect(onResize).toHaveBeenCalledWith({ height: 210, width: 250 });
+    expect(onResize).toHaveBeenCalledWith({ height: 250, width: 250 });
     expect(onResizeEnd).not.toHaveBeenCalled();
+  });
+
+  it("keeps a width-only node height fixed during a bottom-right drag", () => {
+    const onResize = vi.fn();
+    render(
+      <FactoryGraphNodeResizeControls
+        {...resizeProps({
+          allowedAxes: { height: false, width: true },
+          onResize,
+        })}
+      />,
+    );
+
+    const control = screen.getByTestId("resize-bottom-right");
+    expect(control).toHaveAttribute("data-resize-direction", "horizontal");
+
+    fireEvent.pointerMove(control);
+
+    expect(onResize).toHaveBeenCalledWith({ height: 210, width: 250 });
   });
 
   it("leaves node internals alone until the drag settles", () => {

--- a/ui/src/features/flowchart/components/node-resize/factory-graph-node-resize-controls.test.tsx
+++ b/ui/src/features/flowchart/components/node-resize/factory-graph-node-resize-controls.test.tsx
@@ -54,8 +54,10 @@ vi.mock("@xyflow/react", async (importOriginal) => {
 });
 
 import {
+  FACTORY_GRAPH_NODE_FAMILIES,
   FactoryGraphNodeResizeControls,
   type FactoryGraphNodeResizeControlsProps,
+  factoryGraphNodeFamilyRole,
 } from "@you-agent-factory/factory-graph";
 
 function resizeProps(
@@ -83,14 +85,14 @@ describe("Factory graph node resize controls", () => {
     updateNodeInternals.mockClear();
   });
 
-  it("renders one right-edge grip for a width-only family", async () => {
+  it("renders one bottom-right grip for a width-only family", async () => {
     const user = userEvent.setup();
     const onResizeEnd = vi.fn();
     const { container } = render(
       <FactoryGraphNodeResizeControls {...resizeProps({ onResizeEnd })} />,
     );
 
-    const control = screen.getByTestId("resize-right");
+    const control = screen.getByTestId("resize-bottom-right");
     expect(container.querySelectorAll("[data-testid^='resize-']")).toHaveLength(
       1,
     );
@@ -106,38 +108,29 @@ describe("Factory graph node resize controls", () => {
     expect(updateNodeInternals).toHaveBeenCalledWith("worker:writer");
   });
 
-  it("uses the bottom-right corner for a family that allows both axes", () => {
-    const { container } = render(
-      <FactoryGraphNodeResizeControls
-        {...resizeProps({
-          allowedAxes: { height: true, width: true },
-          nodeId: "workstation:review",
-        })}
-      />,
-    );
+  it.each(FACTORY_GRAPH_NODE_FAMILIES)(
+    "uses the bottom-right corner for the %s family",
+    (family) => {
+      const { allowedAxes } = factoryGraphNodeFamilyRole(family);
+      if (!allowedAxes.height && !allowedAxes.width) {
+        throw new Error(`Expected ${family} to be resizable in this matrix.`);
+      }
 
-    expect(container.querySelectorAll("[data-testid^='resize-']")).toHaveLength(
-      1,
-    );
-    expect(screen.getByTestId("resize-bottom-right")).toHaveAttribute(
-      "data-variant",
-      "handle",
-    );
-  });
+      const { container } = render(
+        <FactoryGraphNodeResizeControls {...resizeProps({ allowedAxes })} />,
+      );
 
-  it("uses the bottom edge for a height-only family", () => {
-    render(
-      <FactoryGraphNodeResizeControls
-        {...resizeProps({ allowedAxes: { height: true, width: false } })}
-      />,
-    );
-
-    expect(screen.getByTestId("resize-bottom")).toHaveAttribute(
-      "data-variant",
-      "handle",
-    );
-    expect(screen.queryByTestId("resize-right")).toBeNull();
-  });
+      expect(
+        container.querySelectorAll("[data-testid^='resize-']"),
+      ).toHaveLength(1);
+      expect(screen.getByTestId("resize-bottom-right")).toHaveAttribute(
+        "data-variant",
+        "handle",
+      );
+      expect(screen.queryByTestId("resize-right")).toBeNull();
+      expect(screen.queryByTestId("resize-bottom")).toBeNull();
+    },
+  );
 
   it("does not expose controls when the selected-node host is read-only", () => {
     const { container } = render(
@@ -212,14 +205,14 @@ describe("Factory graph node resize grip appearance", () => {
     );
   });
 
-  it("draws a single-axis grip as a bar rather than a corner", () => {
+  it("draws a single-axis grip as the same corner mark", () => {
     const { container } = render(
       <FactoryGraphNodeResizeControls {...resizeProps()} />,
     );
 
     const gripClassName = grip(container)?.className ?? "";
     expect(gripClassName).toContain("border-r-2");
-    expect(gripClassName).not.toContain("border-b-2");
+    expect(gripClassName).toContain("border-b-2");
   });
 });
 


### PR DESCRIPTION
{
  "project": "Standardize Node Resize Affordances",
  "branchName": "node-resize-affordances",
  "description": "Make the workstation-style bottom-right resize grip the single affordance for every resizable Factory graph node while preserving each node family's allowed axes, bounds, edit-mode visibility, live preview, commit, history, edge alignment, accessibility, and authored-size persistence behavior.",
  "context": {
    "customerAsk": "Use the original workstation bottom-right resize affordance for every resizable node type, generalize that behavior across the shared node-resize path, and remove the confusing right-edge affordance used by other node types.",
    "problem": "The shared Factory graph resize control currently maps both-axis nodes to a bottom-right grip, width-only nodes to a right-edge grip, and height-only behavior to a bottom-edge grip. Users therefore see inconsistent targets for the same resize action even though every node already uses the same resize controller and canonical layout-size operations.",
    "solution": "Use the existing workstation-style bottom-right grip as the shared visual and interaction baseline for every node family with at least one allowed resize axis. Keep family sizing policy authoritative so width-only nodes keep height fixed, both-axis nodes retain two-axis resizing, bounds and edit-mode gating remain enforced, and no-axis nodes expose no grip; verify the unified behavior through focused tests and a real-browser interaction path."
  },
  "acceptanceCriteria": [
    "Every resizable workstation, document, Work-state, resource, worker, Work-type, and constraint node presents the same workstation-style resize grip at its bottom-right corner; no resizable family presents a right-edge or bottom-edge grip.",
    "Starting a resize from the shared bottom-right grip respects the selected node family's existing axis policy and finite minimum/maximum bounds: width-only families keep height fixed, both-axis families can change width and height, and a family with no allowed axis exposes no grip.",
    "The unified affordance remains visible only for an eligible selected node in the editable success state, retains the established hover/focus appearance and neutral styling, does not obscure node content or connection handles at supported zoom and viewport sizes, and leaves read-only, replay, loading, empty, and error states without mutation controls.",
    "Existing live preview, single committed history action, node-internals refresh, edge attachment, keyboard-accessible fit/reset behavior, authored-size persistence, and unrelated graph state remain unchanged.",
    "Quality gates pass with focused shared-package/component and graph-projection tests plus direct Chrome or Edge verification at desktop and constrained viewports; Typecheck passes; Tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "node-resize-affordances-001",
      "title": "Use one bottom-right resize affordance for every node family",
      "description": "As a Factory editor user, I want every resizable node to use the same bottom-right grip so I can find and use resizing consistently without learning a different affordance for each node type.",
      "acceptanceCriteria": [
        "Selected workstation, document, Work-state, resource, worker, Work-type, and constraint nodes render exactly one resize grip at the bottom-right corner when editing is enabled.",
        "Width-only families resize horizontally from the bottom-right grip without changing their resolved content-fit height; workstation and document nodes retain two-axis resizing; a node family with neither axis enabled renders no grip.",
        "Every resize request remains constrained to the family's finite minimum and maximum dimensions, and drag preview and committed dimensions continue through the existing shared resize callbacks.",
        "The shared grip retains the workstation baseline's small neutral corner mark, hover/focus reveal behavior, and non-status styling, without overlapping node content or connection handles at supported zoom levels.",
        "Resize controls remain absent in read-only, replay, loading, empty, and error states and when the node is not eligible; existing keyboard-operable fit/reset actions, focus visibility, and accessible names remain available without requiring the pointer grip.",
        "Completing a resize still refreshes node internals, keeps connected edges attached, creates one committed history action, and preserves unrelated position, group, topology, runtime, and authored layout data.",
        "Focused tests cover all supported node families, the universal bottom-right position, width-only versus two-axis behavior, bounded dimensions, hidden/ineligible controls, live preview, commit, and edge refresh.",
        "Direct Chrome or Edge verification demonstrates the same bottom-right affordance and correct resize direction on representative workstation, document, and width-only nodes at desktop and constrained viewports, including hover, focus, and read-only behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Shared Factory graph resize controls now use one bottom-right grip for every allowed-axis family; focused component, projection, sizing, typecheck, and Storybook browser verification passed. Chrome/Edge extension control was unavailable in this environment, so the repository's maintained Chromium Storybook check supplied the direct browser evidence."
    }
  ]
}
