### PR TITLE
fix: remove unreachable deadcode wrappers

### DIFF
--- a/pkg/platform/internal/runtimeartifact/paths.go
+++ b/pkg/platform/internal/runtimeartifact/paths.go
@@ -38,12 +38,6 @@ func RuntimeArtifactPath(rootDir string, at time.Time, kind RuntimeArtifactKind,
 	return RuntimeArtifactPathWithCollision(rootDir, at, kind, suffix, 0)
 }
 
-// RuntimeNamedArtifactPath builds root/YYYY/MM/DD/<name><ext> using the
-// supplied UTC-normalized time.
-func RuntimeNamedArtifactPath(rootDir string, at time.Time, name, ext string) string {
-	return RuntimeNamedArtifactPathWithCollision(rootDir, at, name, ext, 0)
-}
-
 // RuntimeNamedArtifactPathWithCollision builds a named runtime artifact path
 // and, when collisionIndex is greater than zero, appends the next human
 // numbered candidate before the extension.

--- a/pkg/services/costs/internal/service/valuation.go
+++ b/pkg/services/costs/internal/service/valuation.go
@@ -385,10 +385,6 @@ func (target *summary) unpricedPairsValue() []costs.UnpricedPair {
 	return result
 }
 
-func (target *summary) rollup(key string) (costs.Rollup, error) {
-	return target.rollupWithCurrency(key, "")
-}
-
 func (target *summary) rollupWithCurrency(key, currency string) (costs.Rollup, error) {
 	status, amount, coverage, err := target.result()
 	if err != nil {


### PR DESCRIPTION
{
  "project": "Restore Main's Deadcode Baseline by Removing Two Unreachable Functions",
  "branchName": "dcx-delete-two-unreachable-funcs-unblocking-main",
  "description": "Remove only RuntimeNamedArtifactPath and summary.rollup after verifying that neither has callers, restoring the freshly measured deadcode count from 400 to the committed 398-finding baseline without changing the baseline or LocalAI workflow surface. If current origin/main already contains the repair, complete as an explicit no-op.",
  "context": {
    "customerAsk": "Unblock main and the affected open pull requests by deleting RuntimeNamedArtifactPath and summary.rollup only, while preserving docs/internal/baselines/deadcode-baseline.txt, excluding generated measurement artifacts, and leaving the LocalAI workflow owned by PR #2132 untouched.",
    "problem": "Main's required Backend Lint check reports baseline findings: 398, current findings: 400 because two unreachable wrappers are present. The derived Verification Policy also fails, preventing pull requests from merging, while the same repair is trapped in PR #2132 behind unrelated review work.",
    "solution": "Search all committed Go sources, including tests and build-tagged files, for callers of both symbols. If both remain unreachable, remove only those wrappers, regenerate the ignored deadcode measurement from scratch, and prove it matches the existing 398-finding baseline. Stop and report any real caller, and use a no-diff completion if current origin/main already contains the repair."
  },
  "acceptanceCriteria": [
    "A repository-wide search covering tests and build-tagged Go files finds no caller of RuntimeNamedArtifactPath or summary.rollup; if a real caller exists, implementation stops without forcing the deletion and identifies the caller in the PR body.",
    "When the symbols are still present and unreachable, the implementation diff touches exactly pkg/platform/internal/runtimeartifact/paths.go and pkg/services/costs/internal/service/valuation.go, removes only the two named wrappers and their directly associated comments, and leaves live neighboring implementations unchanged; if current origin/main already contains the repair, a fresh baseline match and relevant file history support an explicit no-diff completion.",
    "After bin/deadcode-current.txt is deleted, make deadcode emits [agent-factory:deadcode] baseline matches at 398 findings, and the PR body records both the prior baseline findings: 398, current findings: 400 line and the fresh after line.",
    "The deadcode baseline, ignored measurement artifact, deadcode checker and allowances, ui-deadcode, LocalAI workflow surface, public contracts, generated code, and unrelated lint findings are unchanged; the PR body names both symbols and records that tests and build-tagged files were searched.",
    "Typecheck passes; Tests pass, including go test ./pkg/platform/internal/runtimeartifact/... ./pkg/services/costs/internal/service/...; git diff --check passes; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The review-stage worker/reviewer cycle continues until required CI, including Backend Lint and Verification Policy, is terminal and passing, every blocking PR conversation is explicitly addressed, conflicts are resolved, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "dcx-delete-two-unreachable-funcs-unblocking-main-001",
      "title": "Restore the required deadcode gate",
      "description": "As a repository maintainer, I want the two verified-unreachable wrappers removed so that the deadcode measurement matches the committed baseline and required checks no longer block unrelated pull requests.",
      "acceptanceCriteria": [
        "A whole-repository caller search includes _test.go and build-tagged Go files and finds no real caller for either symbol before any deletion; discovery of a caller stops the deletion and is reported in the PR body.",
        "RuntimeNamedArtifactPath and summary.rollup are removed without changing their live neighboring implementations or any runtime, API, CLI, event, persistence, or UI contract.",
        "The implementation diff contains only deletions in the two owned Go files; docs/internal/baselines/deadcode-baseline.txt, bin/deadcode-current.txt, deadcode tooling and allowances, ui-deadcode, LocalAI workflow files, and unrelated lint findings remain untouched.",
        "With the ignored measurement artifact removed first, make deadcode prints [agent-factory:deadcode] baseline matches at 398 findings.",
        "go test ./pkg/platform/internal/runtimeartifact/... ./pkg/services/costs/internal/service/... passes.",
        "git diff --check passes.",
        "Typecheck passes",
        "Tests pass",
        "If current origin/main already produces a fresh baseline match and history confirms the deletion landed, the story completes with no diff and plainly records that another lane won the race."
      ],
      "priority": 1,
      "passes": true,
      "notes": "Caller audit covered all tracked Go sources, including tests and build-tagged files: RuntimeNamedArtifactPath and summary.rollup had no callers. Removed only those wrappers/comments from the two specified files. Fresh make deadcode after deleting bin/deadcode-current.txt reported [agent-factory:deadcode] baseline matches with 398 findings; the prior run reported baseline findings: 398, current findings: 400. Focused Go tests, full typecheck, targeted vet, git diff --check, and all deletion-relevant lint gates pass. make lint has one reproduced pre-existing packaged-factory-consumption-check violation in untouched internal/migrationledgercheck/packaged_factory_matrix.go; no public, generated, baseline, LocalAI, or UI workflow files changed."
    }
  ]
}
