### PR TITLE
Clear visual group focus when graph focus moves

### DIFF
--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.tsx
@@ -224,6 +224,9 @@ function CurrentActivityGraphSurfaceContent({
           handleGraphSelectionChange={model.handleGraphSelectionChange}
           handleGraphSelectionStart={model.handleGraphSelectionStart}
           handleNodesChange={model.handleNodesChange}
+          clearSelectedVisualGroup={
+            visualGroupControls.clearSelectedVisualGroup
+          }
           hasPendingChanges={controller.status.hasSharedGraphChanges}
           headingID={headingID}
           imports={imports}
@@ -249,10 +252,7 @@ function CurrentActivityGraphSurfaceContent({
           waypointAriaLabel={edgeWaypointControls.waypointAriaLabel}
           waypointControls={edgeWaypointControls.waypointControls}
           onCreateVisualGroup={visualGroupControls.handleCreateVisualGroup}
-          onEditorNodeClick={(nodeId) => {
-            visualGroupControls.clearSelectedVisualGroup();
-            removalControls.deleteNode(nodeId);
-          }}
+          onEditorNodeClick={removalControls.deleteNode}
           onMoveVisualGroup={visualGroupControls.handleMoveVisualGroup}
           onResizeVisualGroup={visualGroupControls.handleResizeVisualGroup}
           onSelectVisualGroup={visualGroupControls.handleSelectVisualGroup}

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.test.tsx
@@ -10,6 +10,7 @@ const setViewport = vi.fn().mockResolvedValue(true);
 const graphStore = { nodeLookup: new Map() };
 const mockUpdateNodeInternals = vi.fn();
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: the React Flow mock keeps callback wiring in one observable test surface.
 vi.mock("@xyflow/react", async () => {
   const actual = await vi.importActual("@xyflow/react");
 
@@ -35,8 +36,8 @@ vi.mock("@xyflow/react", async () => {
       onPointerDownCapture,
       onPointerMoveCapture,
       onPointerUpCapture,
-      onPaneClick: _onPaneClick,
-      onSelectionChange: _onSelectionChange,
+      onPaneClick,
+      onSelectionChange,
       onSelectionStart: _onSelectionStart,
       panOnDrag,
       panOnScroll,
@@ -107,7 +108,10 @@ vi.mock("@xyflow/react", async () => {
           {(nodes ?? []).map((node) => (
             <button
               key={node.id}
-              onClick={() => onNodeClick?.(null, { id: node.id })}
+              onClick={() => {
+                onSelectionChange?.({ edges: [], nodes: [node] });
+                onNodeClick?.(null, node);
+              }}
               type="button"
             >
               {node.id}
@@ -116,12 +120,31 @@ vi.mock("@xyflow/react", async () => {
           {(edges ?? []).map((edge) => (
             <button
               key={edge.id}
-              onClick={() => onEdgeClick?.(null, edge)}
+              onClick={() => {
+                onSelectionChange?.({ edges: [edge], nodes: [] });
+                onEdgeClick?.(null, edge);
+              }}
               type="button"
             >
               {edge.id}
             </button>
           ))}
+          <button
+            data-testid="mock-react-flow-multi-selection"
+            onClick={() =>
+              onSelectionChange?.({ edges: edges ?? [], nodes: nodes ?? [] })
+            }
+            type="button"
+          >
+            Trigger multi-selection
+          </button>
+          <button
+            data-testid="mock-react-flow-pane-action"
+            onClick={onPaneClick}
+            type="button"
+          >
+            Trigger pane click
+          </button>
           {children}
         </div>
       );
@@ -443,10 +466,12 @@ describe("CurrentActivityGraphViewport", () => {
 
   it("uses selection-first React Flow gesture defaults and clears selection on Escape", async () => {
     const clearGraphSelection = vi.fn();
+    const clearSelectedVisualGroup = vi.fn();
     const handleGraphSelectionChange = vi.fn();
 
     renderViewport({
       clearGraphSelection,
+      clearSelectedVisualGroup,
       handleGraphSelectionChange,
     });
 
@@ -461,6 +486,85 @@ describe("CurrentActivityGraphViewport", () => {
       screen.getByRole("region", { name: "Work graph viewport" }),
       { key: "Escape" },
     );
+    expect(clearGraphSelection).toHaveBeenCalledTimes(1);
+    expect(clearSelectedVisualGroup).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears group focus when a node or edge selection is established", async () => {
+    const clearSelectedVisualGroup = vi.fn();
+    const handleGraphSelectionChange = vi.fn();
+    const node: Node = {
+      id: "workstation:review",
+      position: { x: 0, y: 0 },
+    };
+    const edge: Edge = {
+      id: "edge-review-done",
+      source: node.id,
+      target: "work-state:story:done",
+    };
+
+    renderViewport({
+      clearSelectedVisualGroup,
+      edges: [edge],
+      handleGraphSelectionChange,
+      nodes: [node],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: node.id }));
+    expect(clearSelectedVisualGroup).toHaveBeenCalledTimes(1);
+    expect(handleGraphSelectionChange).toHaveBeenLastCalledWith({
+      edges: [],
+      nodes: [node],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: edge.id }));
+    expect(clearSelectedVisualGroup).toHaveBeenCalledTimes(2);
+    expect(handleGraphSelectionChange).toHaveBeenLastCalledWith({
+      edges: [edge],
+      nodes: [],
+    });
+  });
+
+  it("clears group focus for multi-selection and empty canvas activation", async () => {
+    const clearGraphSelection = vi.fn();
+    const clearSelectedVisualGroup = vi.fn();
+    const handleGraphSelectionChange = vi.fn();
+
+    renderViewport({
+      clearGraphSelection,
+      clearSelectedVisualGroup,
+      edges: [
+        {
+          id: "edge-review-done",
+          source: "workstation:review",
+          target: "work-state:story:done",
+        },
+      ],
+      handleGraphSelectionChange,
+      nodes: [
+        { id: "workstation:review", position: { x: 0, y: 0 } },
+        { id: "work-state:story:done", position: { x: 240, y: 0 } },
+      ],
+    });
+
+    fireEvent.click(screen.getByTestId("mock-react-flow-multi-selection"));
+    expect(clearSelectedVisualGroup).toHaveBeenCalledTimes(1);
+    expect(handleGraphSelectionChange).toHaveBeenLastCalledWith({
+      edges: [
+        {
+          id: "edge-review-done",
+          source: "workstation:review",
+          target: "work-state:story:done",
+        },
+      ],
+      nodes: [
+        { id: "workstation:review", position: { x: 0, y: 0 } },
+        { id: "work-state:story:done", position: { x: 240, y: 0 } },
+      ],
+    });
+
+    fireEvent.click(screen.getByTestId("mock-react-flow-pane-action"));
+    expect(clearSelectedVisualGroup).toHaveBeenCalledTimes(2);
     expect(clearGraphSelection).toHaveBeenCalledTimes(1);
   });
 
@@ -533,6 +637,7 @@ function renderViewport({
   activeTool = null,
   canDeleteGraphSelection = false,
   clearGraphSelection = vi.fn(),
+  clearSelectedVisualGroup = vi.fn(),
   deleteGraphSelection = vi.fn(),
   edges = [],
   editorMode = false,
@@ -544,6 +649,7 @@ function renderViewport({
   activeTool?: "add" | "connect" | "delete" | null;
   canDeleteGraphSelection?: boolean;
   clearGraphSelection?: () => void;
+  clearSelectedVisualGroup?: () => void;
   deleteGraphSelection?: () => void;
   edges?: Edge[];
   editorMode?: boolean;
@@ -562,6 +668,7 @@ function renderViewport({
       addControls={{}}
       canDeleteGraphSelection={canDeleteGraphSelection}
       clearGraphSelection={clearGraphSelection}
+      clearSelectedVisualGroup={clearSelectedVisualGroup}
       deleteGraphSelection={deleteGraphSelection}
       editorControls={{
         activeTool,

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
@@ -373,6 +373,7 @@ export function CurrentActivityGraphViewport({
   addControls,
   canDeleteGraphSelection,
   clearGraphSelection,
+  clearSelectedVisualGroup,
   deleteGraphSelection,
   editorControls,
   graphSelectionToolbarState,
@@ -421,6 +422,7 @@ export function CurrentActivityGraphViewport({
   addControls: CurrentActivityGraphViewportAddControls;
   canDeleteGraphSelection?: boolean;
   clearGraphSelection?: () => void;
+  clearSelectedVisualGroup?: () => void;
   deleteGraphSelection?: () => void;
   editorControls: CurrentActivityGraphViewportEditorControls;
   graphSelectionToolbarState?: FactoryGraphEditorToolbarSelectionState;
@@ -602,6 +604,7 @@ export function CurrentActivityGraphViewport({
     (event: KeyboardEvent<HTMLElement>) => {
       if (event.key === "Escape") {
         clearGraphSelection?.();
+        clearSelectedVisualGroup?.();
         return;
       }
 
@@ -643,10 +646,31 @@ export function CurrentActivityGraphViewport({
       canDeleteGraphSelection,
       canEditGraph,
       clearGraphSelection,
+      clearSelectedVisualGroup,
       deleteGraphSelection,
       layoutControls,
     ],
   );
+  const handleReactFlowSelectionChange = useCallback<OnSelectionChangeFunc>(
+    (params) => {
+      if (params.nodes.length > 0 || params.edges.length > 0) {
+        clearSelectedVisualGroup?.();
+      }
+
+      handleGraphSelectionChange?.(params);
+    },
+    [clearSelectedVisualGroup, handleGraphSelectionChange],
+  );
+  const handleGraphPaneClick = useCallback(() => {
+    clearSelectedVisualGroup?.();
+    if (editorControls.activeTool !== "delete") {
+      clearGraphSelection?.();
+    }
+  }, [
+    clearGraphSelection,
+    clearSelectedVisualGroup,
+    editorControls.activeTool,
+  ]);
 
   return (
     <div
@@ -729,6 +753,7 @@ export function CurrentActivityGraphViewport({
               onError={handleCurrentActivityReactFlowError}
               onEdgeClick={(_event, edge) => {
                 if (canEditGraph && editorControls.activeTool === "delete") {
+                  clearSelectedVisualGroup?.();
                   onEditorEdgeClick?.(
                     factoryGraphEdgeIdForRenderedEdge(nodes, edge),
                   );
@@ -762,6 +787,7 @@ export function CurrentActivityGraphViewport({
               nodesDraggable={canPersistLayoutChanges}
               onNodeClick={(_, node) => {
                 if (canEditGraph && editorControls.activeTool === "delete") {
+                  clearSelectedVisualGroup?.();
                   onEditorNodeClick?.(
                     factoryGraphNodeIdForRenderedNode(nodes, node.id),
                   );
@@ -851,12 +877,8 @@ export function CurrentActivityGraphViewport({
               }}
               onEdgesChange={handleEdgesChange}
               onNodesChange={handleAuthorizedNodesChange}
-              onPaneClick={() => {
-                if (editorControls.activeTool !== "delete") {
-                  clearGraphSelection?.();
-                }
-              }}
-              onSelectionChange={handleGraphSelectionChange}
+              onPaneClick={handleGraphPaneClick}
+              onSelectionChange={handleReactFlowSelectionChange}
               onSelectionStart={(event) => {
                 handleGraphSelectionStart?.({
                   shiftKey: event.shiftKey,

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.component.test.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.component.test.ts
@@ -173,6 +173,7 @@ function renderGraphViewModelWithLayout(
     >;
     expandedNodeIds?: ReadonlySet<string>;
     renderedLayout?: FactoryLayout;
+    onGraphTargetSelected?: () => void;
     selectedWaypointEdgeId?: string | null;
     snapshot?: DashboardSnapshot;
     visibleGraphEdges?: GraphLayout["edges"];
@@ -244,6 +245,7 @@ function renderGraphViewModelWithLayout(
         onSelectWorker: noop,
         onSelectWorkType: noop,
         onSelectWorkstation: noop,
+        onGraphTargetSelected: options.onGraphTargetSelected,
         selection: null,
         snapshot: currentSnapshot ?? snapshot,
       }),
@@ -1118,6 +1120,45 @@ describe("useCurrentActivityGraphViewModel node positions", () => {
     );
     expect((bounds?.y ?? 0) + (bounds?.height ?? 0)).toBeGreaterThanOrEqual(
       1000 + 120,
+    );
+  });
+
+  it("notifies the visual-group focus bridge when a semantic node is selected", () => {
+    const onGraphTargetSelected = vi.fn();
+    const graphLayout: GraphLayout = {
+      edges: [],
+      height: 360,
+      nodes: [
+        {
+          column: 0,
+          height: 120,
+          nodeId: "workstation:review",
+          nodeKind: "workstation",
+          row: 0,
+          width: 220,
+          workstationNodeId: "review",
+          x: 40,
+          y: 40,
+        },
+      ],
+      width: 600,
+    };
+    const { result } = renderGraphViewModelWithLayout(graphLayout, {
+      onGraphTargetSelected,
+    });
+    const selectWorkstation = (
+      result.current.nodes[0]?.data as
+        | { onSelectWorkstation?: (nodeId: string) => void }
+        | undefined
+    )?.onSelectWorkstation;
+
+    act(() => {
+      selectWorkstation?.("review");
+    });
+
+    expect(onGraphTargetSelected).toHaveBeenCalledTimes(1);
+    expect(result.current.graphSelection.state.selectedNodeIds).toEqual(
+      new Set(["workstation:review"]),
     );
   });
 

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
@@ -97,6 +97,7 @@ export type CurrentActivityGraphViewModelInput = {
   onSelectWorker: (workerName: string) => void;
   onSelectWorkType: (workTypeName: string) => void;
   onSelectWorkstation: (nodeId: string) => void;
+  onGraphTargetSelected?: () => void;
   selection: CurrentActivitySelection | null;
   snapshot: DashboardSnapshot;
 };
@@ -636,6 +637,7 @@ export function useCurrentActivityGraphViewModel({
   onSelectWorker,
   onSelectWorkType,
   onSelectWorkstation,
+  onGraphTargetSelected,
   selection,
   snapshot,
 }: CurrentActivityGraphViewModelInput): CurrentActivityGraphViewModelResult {
@@ -709,12 +711,13 @@ export function useCurrentActivityGraphViewModel({
   const { replaceSelection: replaceGraphSelection } = graphSelection;
   const handleGraphSelectNode = useCallback(
     (nodeId: string) => {
+      onGraphTargetSelected?.();
       replaceGraphSelection({
         nodeIds: [nodeId],
         primaryTarget: { id: nodeId, kind: "node" },
       });
     },
-    [replaceGraphSelection],
+    [onGraphTargetSelected, replaceGraphSelection],
   );
   const graphSelectionEnabled =
     !editor.editorMode || editor.activeTool !== "delete";

--- a/ui/src/features/workflow-activity/hooks/use-current-activity-graph-card-view-model.test.tsx
+++ b/ui/src/features/workflow-activity/hooks/use-current-activity-graph-card-view-model.test.tsx
@@ -355,6 +355,18 @@ describe("useCurrentActivityGraphCardViewModel visual groups", () => {
     expect(
       result.current.visualGroupControls.visualGroupControls?.group.id,
     ).toBe("group-1");
+
+    const onGraphTargetSelected =
+      graphViewModelMock.useCurrentActivityGraphViewModel.mock.calls[0]?.[0]
+        ?.onGraphTargetSelected;
+    expect(onGraphTargetSelected).toBeInstanceOf(Function);
+
+    act(() => {
+      onGraphTargetSelected?.();
+    });
+
+    expect(result.current.visualGroupControls.selectedGroupId).toBeNull();
+    expect(result.current.visualGroupControls.visualGroupControls).toBeNull();
   });
 });
 

--- a/ui/src/features/workflow-activity/hooks/use-current-activity-graph-card-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/use-current-activity-graph-card-view-model.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useFactoryGraphVisualGroupEditor } from "../../factory-graph-editor/hooks/layout/factory-graph-visual-group-editor-hook";
 import type { FactoryLayoutGroupNodeGeometry } from "../../factory-graph-editor/lib/layout/visual-groups/factory-graph-layout-groups";
 import { pruneFactoryGraphEditorSelectionAfterRemoval } from "../../factory-graph-editor/lib/selection/factory-graph-editor-selection-batch-delete";
@@ -34,6 +34,10 @@ export function useCurrentActivityGraphCardViewModel(
 ): CurrentActivityGraphCardViewModel {
   const [addNodePlacementViewport, setAddNodePlacementViewport] =
     useState<GraphEditorAddNodePlacementViewport | null>(null);
+  const clearVisualGroupFocusRef = useRef<() => void>(() => undefined);
+  const clearVisualGroupFocus = useCallback(() => {
+    clearVisualGroupFocusRef.current();
+  }, []);
   const {
     connectionControls,
     graphProjection: editorGraphProjection,
@@ -76,6 +80,7 @@ export function useCurrentActivityGraphCardViewModel(
   );
   const graph = useCurrentActivityGraphViewModel({
     ...input,
+    onGraphTargetSelected: clearVisualGroupFocus,
     editor: {
       activeTool: publicEditor.editorControls.activeTool,
       canInteractWithEditor: publicEditor.editorControls.canInteract,
@@ -220,6 +225,8 @@ export function useCurrentActivityGraphCardViewModel(
     setVisualGroupColor: publicEditor.layoutControls.setVisualGroupColor,
     selectedNodeIds: [...selectionState.selectedNodeIds],
   });
+  clearVisualGroupFocusRef.current =
+    visualGroupControls.clearSelectedVisualGroup;
   const {
     canonicalLayoutViewport: _canonicalLayoutViewport,
     initialFitViewKey,


### PR DESCRIPTION
{
  "project": "Clear Group Focus When Factory Graph Focus Moves",
  "branchName": "group-editing",
  "description": "Make factory graph focus unambiguous by clearing a selected visual group's outline and controls when the user selects a node, workstation, edge, multi-selection, or empty canvas, without changing group data or discarding the new graph selection.",
  "context": {
    "customerAsk": "Make it possible to unselect a group by moving focus from the group to an edge, workstation/node, or another graph target, so the group box no longer remains focused.",
    "problem": "Visual-group selection is maintained separately from node and edge selection, so changing the apparent factory graph selection can leave the group outline and controls active and create an ambiguous, stuck editing context.",
    "solution": "Use the existing visual-group clear operation at the graph interaction boundary whenever a non-empty node or edge selection is established or the empty canvas is activated. Preserve the selected graph targets and keep canonical group layout data unchanged, with focused UI tests and direct browser verification for pointer and keyboard-accessible paths."
  },
  "acceptanceCriteria": [
    "With a visual group selected, selecting a workstation, another node type, an edge, or a node/edge multi-selection clears the group's selected outline and closes its group-specific controls while leaving the newly selected graph target(s) selected.",
    "With a visual group selected, activating empty canvas space clears the group's selected outline and controls; the behavior works through supported pointer and keyboard-accessible graph interactions and does not require selecting the same group again.",
    "Selecting and editing a visual group still works when no competing graph target is selected, and clearing group focus does not alter group membership, bounds, label, color, layout, or persisted factory data.",
    "Typecheck and focused UI tests pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Direct browser verification confirms the group-to-node, group-to-edge, and group-to-empty-canvas transitions at representative desktop and narrow viewport sizes.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "group-editing-001",
      "title": "Move focus away from a selected group",
      "description": "As a factory editor user, I want a selected group to lose focus when I select another graph target or the empty canvas so that the editor shows one clear interaction context.",
      "acceptanceCriteria": [
        "Starting with a selected visual group, selecting a workstation or any other selectable graph node clears the group's selected outline and closes the group controls without canceling the node selection.",
        "Starting with a selected visual group, selecting an edge clears the group's selected outline and closes the group controls without canceling the edge selection.",
        "Node/edge multi-selection clears group focus and preserves the resulting graph selection.",
        "Activating empty canvas space clears group focus and leaves the canvas in its normal no-selection state.",
        "Pointer and supported keyboard-accessible graph selection paths produce the same focus transition, with visible focus behavior and accessible semantics preserved.",
        "Group properties and layout data remain unchanged when focus moves away, and selecting a group again restores its existing controls and edit behavior.",
        "Focused component/integration regression tests cover group-to-node, group-to-edge, multi-selection, and group-to-empty-canvas transitions.",
        "Typecheck passes",
        "Tests pass",
        "Verify directly in a browser at representative desktop and narrow viewport sizes"
      ],
      "priority": 1,
      "passes": false,
    "notes": "Implemented graph-boundary and semantic-node group-focus clearing with focused regression coverage. Revalidated 49 focused UI tests, typecheck, full UI lint, focused Biome, and diff checks successfully. Direct desktop/narrow browser verification remains blocked because the supported browser runtime has no connected browser; passes remains false until that acceptance check is performed."
    }
  ]
}
