### PR TITLE
REC-1 Recording Characterization

### DIFF
--- a/pkg/services/recordings/internal/lifecycle_effects_test.go
+++ b/pkg/services/recordings/internal/lifecycle_effects_test.go
@@ -1,12 +1,17 @@
 package internal
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"testing"
 	"time"
 
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	"github.com/portpowered/infinite-you/pkg/services/recordings/internal/canonical"
+	recordingevents "github.com/portpowered/infinite-you/pkg/services/recordings/internal/events"
+	replayimpl "github.com/portpowered/infinite-you/pkg/services/recordings/internal/replay"
 )
 
 func TestNewRecordingSnapshotWriterNilWriteReturnsNil(t *testing.T) {
@@ -75,6 +80,152 @@ func TestNewReplayRecordingSnapshotWriterNilWriteReturnsNil(t *testing.T) {
 
 	if writer := NewReplayRecordingSnapshotWriter(nil); writer != nil {
 		t.Fatalf("writer = %#v, want nil", writer)
+	}
+}
+
+func TestNewReplayRecordingSnapshotWriterPinsReplayV1JSONBytes(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 2, 3, 18, 45, 12, 0, time.UTC)
+	finishedAt := startedAt.Add(2 * time.Minute)
+	factorySnapshot, err := factorydefinitions.NewFactorySnapshot(map[string]any{
+		"id": "factory-1",
+		"metadata": map[string]any{
+			"factory_hash":        "sha256:factory",
+			"workers_hash":        "sha256:workers",
+			"workstations_hash":   "sha256:workstations",
+			"runtime_config_hash": "sha256:runtime",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFactorySnapshot: %v", err)
+	}
+	started, err := replayimpl.NewEventLogArtifact(
+		startedAt,
+		factorySnapshot,
+		&recordings.ReplayWallClockMetadata{StartedAt: startedAt},
+		recordings.ReplayDiagnostics{},
+	)
+	if err != nil {
+		t.Fatalf("NewEventLogArtifact: %v", err)
+	}
+
+	work := recordings.FactoryEvent{
+		Id:   "work-request-1",
+		Type: recordings.FactoryEventTypeWorkRequest,
+		Context: recordings.FactoryEventContext{
+			EventTime: startedAt.Add(time.Minute),
+			Sequence:  1,
+			Tick:      3,
+		},
+		Payload: []byte(`{"workId":"work-1","contentHash":"sha256:work"}`),
+	}
+	finished := recordingevents.RunFinishedFactoryEvent(startedAt, finishedAt)
+	finished.Context.Sequence = 2
+	events := []recordings.CanonicalEvent{
+		canonical.CanonicalEventFromFactory(started.Events[0], "generation-1"),
+		canonical.CanonicalEventFromFactory(work, "generation-1"),
+		canonical.CanonicalEventFromFactory(finished, "generation-1"),
+	}
+	for sequence := range events {
+		events[sequence].Scope = recordings.CanonicalEventScope{FactorySessionID: "~default"}
+		events[sequence].Sequence = recordings.CanonicalEventSequence(sequence)
+		events[sequence].Cursor.Sequence = recordings.CanonicalEventSequence(sequence)
+	}
+	var writtenPayload []byte
+	writer := NewReplayRecordingSnapshotWriter(func(_ string, payload []byte) error {
+		writtenPayload = append([]byte(nil), payload...)
+		return nil
+	})
+	finalizedAt := finishedAt
+	if err := writer("recording.json", recordings.RecordingSnapshot{
+		Status: recordings.RecordingStatusFacts{
+			RecordingID:    "recording-byte-golden",
+			State:          recordings.RecordingFinalized,
+			AcceptedEvents: len(events),
+			FinalizedAt:    &finalizedAt,
+		},
+		Events: events,
+	}); err != nil {
+		t.Fatalf("write replay snapshot: %v", err)
+	}
+
+	want := []byte(`{
+  "schemaVersion": "agent-factory.replay.v1",
+  "recordedAt": "2026-02-03T18:45:12Z",
+  "events": [
+    {
+      "context": {
+        "eventTime": "2026-02-03T18:45:12Z",
+        "sequence": 0,
+        "sessionId": "~default",
+        "tick": 0
+      },
+      "id": "factory-event/run-started",
+      "payload": {
+        "diagnostics": {},
+        "factory": {
+          "id": "factory-1",
+          "metadata": {
+            "factory_hash": "sha256:factory",
+            "runtime_config_hash": "sha256:runtime",
+            "workers_hash": "sha256:workers",
+            "workstations_hash": "sha256:workstations"
+          }
+        },
+        "recordedAt": "2026-02-03T18:45:12Z",
+        "wallClock": {
+          "startedAt": "2026-02-03T18:45:12Z"
+        }
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "RUN_REQUEST"
+    },
+    {
+      "context": {
+        "eventTime": "2026-02-03T18:46:12Z",
+        "sequence": 1,
+        "sessionId": "~default",
+        "tick": 3
+      },
+      "id": "work-request-1",
+      "payload": {
+        "workId": "work-1",
+        "contentHash": "sha256:work"
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "WORK_REQUEST"
+    },
+    {
+      "context": {
+        "eventTime": "2026-02-03T18:47:12Z",
+        "sequence": 2,
+        "sessionId": "~default",
+        "tick": 0
+      },
+      "id": "factory-event/run-finished",
+      "payload": {
+        "state": "COMPLETED",
+        "wallClock": {
+          "finishedAt": "2026-02-03T18:47:12Z",
+          "startedAt": "2026-02-03T18:45:12Z"
+        }
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "RUN_RESPONSE"
+    }
+  ]
+}
+`)
+	if !bytes.Equal(writtenPayload, want) {
+		t.Fatalf("replay v1 bytes =\n%s\nwant =\n%s", writtenPayload, want)
+	}
+	if !json.Valid(bytes.TrimSuffix(writtenPayload, []byte{'\n'})) {
+		t.Fatal("replay v1 payload without terminal newline is not valid JSON")
+	}
+	if !bytes.HasSuffix(writtenPayload, []byte("}\n")) ||
+		bytes.HasSuffix(writtenPayload, []byte("}\n\n")) {
+		t.Fatal("replay v1 payload does not have exactly one terminal newline")
 	}
 }
 

--- a/pkg/services/recordings/internal/lifecycle_effects_test.go
+++ b/pkg/services/recordings/internal/lifecycle_effects_test.go
@@ -83,6 +83,74 @@ func TestNewReplayRecordingSnapshotWriterNilWriteReturnsNil(t *testing.T) {
 	}
 }
 
+const replayV1GoldenJSON = `{
+  "schemaVersion": "agent-factory.replay.v1",
+  "recordedAt": "2026-02-03T18:45:12Z",
+  "events": [
+    {
+      "context": {
+        "eventTime": "2026-02-03T18:45:12Z",
+        "sequence": 0,
+        "sessionId": "~default",
+        "tick": 0
+      },
+      "id": "factory-event/run-started",
+      "payload": {
+        "diagnostics": {},
+        "factory": {
+          "id": "factory-1",
+          "metadata": {
+            "factory_hash": "sha256:factory",
+            "runtime_config_hash": "sha256:runtime",
+            "workers_hash": "sha256:workers",
+            "workstations_hash": "sha256:workstations"
+          }
+        },
+        "recordedAt": "2026-02-03T18:45:12Z",
+        "wallClock": {
+          "startedAt": "2026-02-03T18:45:12Z"
+        }
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "RUN_REQUEST"
+    },
+    {
+      "context": {
+        "eventTime": "2026-02-03T18:46:12Z",
+        "sequence": 1,
+        "sessionId": "~default",
+        "tick": 3
+      },
+      "id": "work-request-1",
+      "payload": {
+        "workId": "work-1",
+        "contentHash": "sha256:work"
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "WORK_REQUEST"
+    },
+    {
+      "context": {
+        "eventTime": "2026-02-03T18:47:12Z",
+        "sequence": 2,
+        "sessionId": "~default",
+        "tick": 0
+      },
+      "id": "factory-event/run-finished",
+      "payload": {
+        "state": "COMPLETED",
+        "wallClock": {
+          "finishedAt": "2026-02-03T18:47:12Z",
+          "startedAt": "2026-02-03T18:45:12Z"
+        }
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "RUN_RESPONSE"
+    }
+  ]
+}
+`
+
 func TestNewReplayRecordingSnapshotWriterPinsReplayV1JSONBytes(t *testing.T) {
 	t.Parallel()
 
@@ -150,73 +218,7 @@ func TestNewReplayRecordingSnapshotWriterPinsReplayV1JSONBytes(t *testing.T) {
 		t.Fatalf("write replay snapshot: %v", err)
 	}
 
-	want := []byte(`{
-  "schemaVersion": "agent-factory.replay.v1",
-  "recordedAt": "2026-02-03T18:45:12Z",
-  "events": [
-    {
-      "context": {
-        "eventTime": "2026-02-03T18:45:12Z",
-        "sequence": 0,
-        "sessionId": "~default",
-        "tick": 0
-      },
-      "id": "factory-event/run-started",
-      "payload": {
-        "diagnostics": {},
-        "factory": {
-          "id": "factory-1",
-          "metadata": {
-            "factory_hash": "sha256:factory",
-            "runtime_config_hash": "sha256:runtime",
-            "workers_hash": "sha256:workers",
-            "workstations_hash": "sha256:workstations"
-          }
-        },
-        "recordedAt": "2026-02-03T18:45:12Z",
-        "wallClock": {
-          "startedAt": "2026-02-03T18:45:12Z"
-        }
-      },
-      "schemaVersion": "agent-factory.event.v1",
-      "type": "RUN_REQUEST"
-    },
-    {
-      "context": {
-        "eventTime": "2026-02-03T18:46:12Z",
-        "sequence": 1,
-        "sessionId": "~default",
-        "tick": 3
-      },
-      "id": "work-request-1",
-      "payload": {
-        "workId": "work-1",
-        "contentHash": "sha256:work"
-      },
-      "schemaVersion": "agent-factory.event.v1",
-      "type": "WORK_REQUEST"
-    },
-    {
-      "context": {
-        "eventTime": "2026-02-03T18:47:12Z",
-        "sequence": 2,
-        "sessionId": "~default",
-        "tick": 0
-      },
-      "id": "factory-event/run-finished",
-      "payload": {
-        "state": "COMPLETED",
-        "wallClock": {
-          "finishedAt": "2026-02-03T18:47:12Z",
-          "startedAt": "2026-02-03T18:45:12Z"
-        }
-      },
-      "schemaVersion": "agent-factory.event.v1",
-      "type": "RUN_RESPONSE"
-    }
-  ]
-}
-`)
+	want := []byte(replayV1GoldenJSON)
 	if !bytes.Equal(writtenPayload, want) {
 		t.Fatalf("replay v1 bytes =\n%s\nwant =\n%s", writtenPayload, want)
 	}

--- a/pkg/services/recordings/internal/services/recording_lifecycle/internal/service/flush_characterization_test.go
+++ b/pkg/services/recordings/internal/services/recording_lifecycle/internal/service/flush_characterization_test.go
@@ -1,0 +1,284 @@
+package service_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	recordings "github.com/portpowered/infinite-you/pkg/services/recordings"
+	recordingsinternal "github.com/portpowered/infinite-you/pkg/services/recordings/internal"
+	"github.com/portpowered/infinite-you/pkg/services/recordings/internal/canonical"
+	replayimpl "github.com/portpowered/infinite-you/pkg/services/recordings/internal/replay"
+)
+
+type characterizedFlushWrite struct {
+	target  string
+	payload []byte
+}
+
+type characterizedReplayEnvelope struct {
+	SchemaVersion string `json:"schemaVersion"`
+	Events        []struct {
+		ID      string `json:"id"`
+		Context struct {
+			Sequence int `json:"sequence"`
+		} `json:"context"`
+	} `json:"events"`
+}
+
+const characterizedDefaultFlushInterval = 250 * time.Millisecond
+
+func TestActiveFlushCharacterizesDefaultCadenceAndCompleteV1Rewrites(t *testing.T) {
+	t.Parallel()
+
+	ticker := newManualFlushTicker()
+	events := characterizedFlushEvents(t)
+	writes := make(chan characterizedFlushWrite, 4)
+	var observedInterval time.Duration
+	root := newActiveFlushRoot(
+		recordingsinternal.NewReplayRecordingSnapshotWriter(
+			func(target string, payload []byte) error {
+				writes <- characterizedFlushWrite{
+					target:  target,
+					payload: append([]byte(nil), payload...),
+				}
+				return nil
+			},
+		),
+		func(interval time.Duration) recordings.RecordingFlushTicker {
+			observedInterval = interval
+			return manualTickerHandle(ticker)
+		},
+	)
+	recordingID := startActiveRecording(t, root, "recording-flush-characterization", 0)
+	t.Cleanup(func() { stopRecording(t, root, recordingID) })
+
+	if observedInterval != characterizedDefaultFlushInterval {
+		t.Fatalf("default flush interval = %s, want 250ms", observedInterval)
+	}
+
+	recordEvent(t, root, recordingID, events[0])
+	ticker.ticks <- time.Date(2026, 2, 3, 18, 45, 12, 0, time.UTC)
+	first := requireCharacterizedFlushWrite(t, writes)
+	assertCharacterizedReplayWrite(t, first, []recordings.CanonicalEvent{events[0]})
+
+	if _, err := root.FlushRecording(recordings.FlushRecordingRequest{
+		RecordingID: recordingID,
+	}); err != nil {
+		t.Fatalf("clean FlushRecording: %v", err)
+	}
+	if len(writes) != 0 {
+		t.Fatalf("clean flush queued %d additional writes, want none", len(writes))
+	}
+
+	recordEvent(t, root, recordingID, events[1])
+	ticker.ticks <- time.Date(2026, 2, 3, 18, 45, 13, 0, time.UTC)
+	second := requireCharacterizedFlushWrite(t, writes)
+	assertCharacterizedReplayWrite(t, second, events[:2])
+	if _, err := root.FlushRecording(recordings.FlushRecordingRequest{
+		RecordingID: recordingID,
+	}); err != nil {
+		t.Fatalf("second clean FlushRecording: %v", err)
+	}
+
+	status := recordingStatus(t, root, recordingID)
+	if status.FlushedThrough == nil || *status.FlushedThrough != events[1].Cursor {
+		t.Fatalf("flushed status = %#v, want second event cursor", status)
+	}
+}
+
+func TestFinishRecordingCharacterizesJoinedFinalPersistenceAndNoPostStopWrite(t *testing.T) {
+	t.Parallel()
+
+	ticker := newManualFlushTicker()
+	events := characterizedFlushEvents(t)
+	writes := make(chan characterizedFlushWrite, 4)
+	writeStarted := make(chan struct{})
+	releaseWrite := make(chan struct{})
+	writeCount := 0
+	root := newActiveFlushRoot(
+		recordingsinternal.NewReplayRecordingSnapshotWriter(
+			func(target string, payload []byte) error {
+				writeCount++
+				if writeCount == 1 {
+					close(writeStarted)
+					<-releaseWrite
+				}
+				writes <- characterizedFlushWrite{
+					target:  target,
+					payload: append([]byte(nil), payload...),
+				}
+				return nil
+			},
+		),
+		func(time.Duration) recordings.RecordingFlushTicker {
+			return manualTickerHandle(ticker)
+		},
+	)
+	recordingID := startActiveRecording(t, root, "recording-final-flush-characterization", time.Second)
+	recordEvent(t, root, recordingID, events[0])
+	ticker.ticks <- time.Date(2026, 2, 3, 18, 45, 12, 0, time.UTC)
+	<-writeStarted
+
+	// The second event is accepted while the first complete document is still
+	// being persisted. Finalization must join that write before its final one.
+	recordEvent(t, root, recordingID, events[1])
+	finished := make(chan recordings.FinishRecordingResult, 1)
+	finishErrors := make(chan error, 1)
+	go func() {
+		result, err := root.FinishRecording(recordings.FinishRecordingRequest{
+			RecordingID: recordingID,
+			FinishedAt:  time.Date(2026, 2, 3, 18, 46, 0, 0, time.UTC),
+		})
+		finished <- result
+		finishErrors <- err
+	}()
+
+	select {
+	case <-finished:
+		t.Fatal("FinishRecording returned while the periodic write was blocked")
+	default:
+	}
+	close(releaseWrite)
+	result := <-finished
+	if err := <-finishErrors; err != nil {
+		t.Fatalf("FinishRecording: %v", err)
+	}
+	if writeCount != 2 || result.Status.FlushedThrough == nil ||
+		*result.Status.FlushedThrough != events[1].Cursor ||
+		result.Status.State != recordings.RecordingFinalized {
+		t.Fatalf("final status = %#v with %d writes, want latest event durably finalized", result.Status, writeCount)
+	}
+
+	first := requireCharacterizedFlushWrite(t, writes)
+	assertCharacterizedReplayWrite(t, first, []recordings.CanonicalEvent{events[0]})
+	second := requireCharacterizedFlushWrite(t, writes)
+	assertCharacterizedReplayWrite(t, second, events[:2])
+	if len(writes) != 0 {
+		t.Fatalf("finalization queued %d unexpected writes", len(writes))
+	}
+
+	// FinishRecording has stopped and joined the ticker loop. A tick delivered
+	// after that boundary must not create another persistence effect.
+	ticker.ticks <- time.Date(2026, 2, 3, 18, 46, 1, 0, time.UTC)
+	if len(writes) != 0 || writeCount != 2 {
+		t.Fatalf("post-stop writes = %d buffered / %d total, want none", len(writes), writeCount)
+	}
+}
+
+func TestFailedFlushCharacterizesUnadvancedDurablePosition(t *testing.T) {
+	t.Parallel()
+
+	writeErr := errors.New("storage unavailable")
+	root := newActiveFlushRoot(
+		func(string, recordings.RecordingSnapshot) error { return writeErr },
+		func(time.Duration) recordings.RecordingFlushTicker {
+			return manualTickerHandle(newManualFlushTicker())
+		},
+	)
+	recordingID := startActiveRecording(t, root, "recording-failed-flush-characterization", 0)
+	t.Cleanup(func() { stopRecording(t, root, recordingID) })
+	recordEvent(t, root, recordingID, characterizedFlushEvents(t)[0])
+
+	if _, err := root.FlushRecording(recordings.FlushRecordingRequest{
+		RecordingID: recordingID,
+	}); !errors.Is(err, writeErr) {
+		t.Fatalf("FlushRecording error = %v, want storage error", err)
+	}
+	status := recordingStatus(t, root, recordingID)
+	if status.FlushedThrough != nil {
+		t.Fatalf("failed flush advanced durable position: %#v", status)
+	}
+}
+
+func requireCharacterizedFlushWrite(
+	t *testing.T,
+	writes <-chan characterizedFlushWrite,
+) characterizedFlushWrite {
+	t.Helper()
+	select {
+	case write := <-writes:
+		return write
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for controlled recording flush")
+		return characterizedFlushWrite{}
+	}
+}
+
+func assertCharacterizedReplayWrite(
+	t *testing.T,
+	write characterizedFlushWrite,
+	wantEvents []recordings.CanonicalEvent,
+) {
+	t.Helper()
+	if write.target != "artifact:active" {
+		t.Fatalf("flush target = %q, want artifact:active", write.target)
+	}
+	var envelope characterizedReplayEnvelope
+	if err := json.Unmarshal(write.payload, &envelope); err != nil {
+		t.Fatalf("decode persisted replay document: %v", err)
+	}
+	if !bytes.HasSuffix(write.payload, []byte("}\n")) ||
+		bytes.HasSuffix(write.payload, []byte("}\n\n")) {
+		t.Fatal("persisted replay document does not have exactly one terminal newline")
+	}
+	if envelope.SchemaVersion != "agent-factory.replay.v1" {
+		t.Fatalf("persisted schema version = %q, want agent-factory.replay.v1", envelope.SchemaVersion)
+	}
+	if len(envelope.Events) != len(wantEvents) {
+		t.Fatalf("persisted event count = %d, want %d", len(envelope.Events), len(wantEvents))
+	}
+	for index, want := range wantEvents {
+		if envelope.Events[index].ID != string(want.ID) ||
+			envelope.Events[index].Context.Sequence != int(want.Sequence) {
+			t.Fatalf("persisted event %d = %#v, want id=%q sequence=%d", index, envelope.Events[index], want.ID, want.Sequence)
+		}
+	}
+}
+
+func characterizedFlushEvents(t *testing.T) []recordings.CanonicalEvent {
+	t.Helper()
+	startedAt := time.Date(2026, 2, 3, 18, 45, 12, 0, time.UTC)
+	factorySnapshot, err := factorydefinitions.NewFactorySnapshot(map[string]any{
+		"id": "factory-flush-characterization",
+		"metadata": map[string]any{
+			"factory_hash": "sha256:factory-flush",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFactorySnapshot: %v", err)
+	}
+	started, err := replayimpl.NewEventLogArtifact(
+		startedAt,
+		factorySnapshot,
+		&recordings.ReplayWallClockMetadata{StartedAt: startedAt},
+		recordings.ReplayDiagnostics{},
+	)
+	if err != nil {
+		t.Fatalf("NewEventLogArtifact: %v", err)
+	}
+	work := recordings.FactoryEvent{
+		Id:   "work-request-flush-1",
+		Type: recordings.FactoryEventTypeWorkRequest,
+		Context: recordings.FactoryEventContext{
+			EventTime: startedAt.Add(time.Minute),
+			Sequence:  1,
+			Tick:      1,
+		},
+		Payload: []byte(`{"workId":"work-flush-1"}`),
+	}
+	events := []recordings.CanonicalEvent{
+		canonical.CanonicalEventFromFactory(started.Events[0], "generation-flush-characterization"),
+		canonical.CanonicalEventFromFactory(work, "generation-flush-characterization"),
+	}
+	scope := recordings.CanonicalEventScope{FactorySessionID: "session-active"}
+	for index := range events {
+		events[index].Scope = scope
+		events[index].Sequence = recordings.CanonicalEventSequence(index)
+		events[index].Cursor.Sequence = recordings.CanonicalEventSequence(index)
+	}
+	return events
+}

--- a/pkg/services/recordings/internal/services/recording_lifecycle/live_recording_target_test.go
+++ b/pkg/services/recordings/internal/services/recording_lifecycle/live_recording_target_test.go
@@ -2,13 +2,18 @@ package recordinglifecycle_test
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
 	recordings "github.com/portpowered/infinite-you/pkg/services/recordings"
+	recordinglifecycle "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/recording_lifecycle"
+	recordinglifecyclewire "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/recording_lifecycle/wire"
 	recordingswire "github.com/portpowered/infinite-you/pkg/services/recordings/wire"
 )
+
+const characterizedLiveRecordingSessionToken = "__factory_session_id__"
 
 func TestLiveRecordingTargetPlannerOwnsDefaultLayoutAndReportedSessionPath(t *testing.T) {
 	t.Parallel()
@@ -79,5 +84,121 @@ func TestLiveRecordingTargetPlannerUsesInjectedIdentityForUniqueNames(t *testing
 	}
 	if first.ServicePath == second.ServicePath {
 		t.Fatalf("recording paths matched: %q", first.ServicePath)
+	}
+}
+
+func TestLiveRecordingLifecycleCharacterizesDistinctSameDayDefaultTargets(t *testing.T) {
+	t.Parallel()
+
+	clock := platformclock.NewDeterministic(time.Date(2026, 2, 3, 18, 45, 12, 0, time.UTC), time.Second)
+	identities := []string{"uuid-1", "uuid-2"}
+	planner := recordingswire.NewLiveRecordingTargetPlanner(
+		clock,
+		func() string {
+			identity := identities[0]
+			identities = identities[1:]
+			return identity
+		},
+		filepath.Join,
+	)
+	var serviceTargets []string
+	service := recordinglifecyclewire.NewService(
+		planner,
+		func(target string, _ recordings.RecordingSnapshot) error {
+			serviceTargets = append(serviceTargets, target)
+			return nil
+		},
+		nil,
+		clock,
+	)
+	home := filepath.Join("home", "operator")
+	scope := recordings.CanonicalEventScope{FactorySessionID: "~default"}
+
+	var reportedTargets []string
+	for index := range 2 {
+		reportedTargets = append(reportedTargets, recordSameDayLifecycleRun(t, service, clock, scope, home, index+1))
+	}
+
+	wantDir := filepath.Join(home, ".you-agent-factory", "recordings", "2026-02", "2026-02-03")
+	wantServiceTargets := []string{
+		filepath.Join(wantDir, "factory-session-"+characterizedLiveRecordingSessionToken+"-184512-uuid-1.json"),
+		filepath.Join(wantDir, "factory-session-"+characterizedLiveRecordingSessionToken+"-184512-uuid-2.json"),
+	}
+	wantReportedTargets := []string{
+		filepath.Join(wantDir, "factory-session-~default-184512-uuid-1.json"),
+		filepath.Join(wantDir, "factory-session-~default-184512-uuid-2.json"),
+	}
+	assertSameDayTargetPaths(t, serviceTargets, reportedTargets, wantServiceTargets, wantReportedTargets)
+	t.Logf("current behavior: same-day default-session recording targets are distinct: service=%q reported=%q", serviceTargets, reportedTargets)
+}
+
+func recordSameDayLifecycleRun(
+	t *testing.T,
+	service recordinglifecycle.Service,
+	clock recordings.RecordingClock,
+	scope recordings.CanonicalEventScope,
+	home string,
+	run int,
+) string {
+	t.Helper()
+	started, err := service.StartRecording(recordings.StartRecordingRequest{
+		Enabled: true,
+		Scope:   scope,
+		Target: recordings.RecordingTargetRequest{
+			HomeDir:           home,
+			ReportedSessionID: "~default",
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartRecording run %d: %v", run, err)
+	}
+	recordingID := started.Status.RecordingID
+	if _, err := service.RecordRecordingEvent(recordings.RecordRecordingEventRequest{
+		RecordingID: recordingID,
+		Event: recordings.CanonicalEvent{
+			ID:         recordings.CanonicalEventID("event-" + string(recordingID)),
+			Sequence:   0,
+			Scope:      scope,
+			Kind:       "WORK_REQUEST",
+			RecordedAt: clock.Now(),
+			Cursor: recordings.CanonicalEventCursor{
+				StreamGenerationID: string(recordingID),
+				Sequence:           0,
+			},
+			Payload: "{}",
+		},
+	}); err != nil {
+		t.Fatalf("RecordRecordingEvent run %d: %v", run, err)
+	}
+	if _, err := service.FlushRecording(recordings.FlushRecordingRequest{RecordingID: recordingID}); err != nil {
+		t.Fatalf("FlushRecording run %d: %v", run, err)
+	}
+	if _, err := service.StopRecording(recordings.StopRecordingRequest{RecordingID: recordingID}); err != nil {
+		t.Fatalf("StopRecording run %d: %v", run, err)
+	}
+	return string(started.Status.Artifact)
+}
+
+func assertSameDayTargetPaths(
+	t *testing.T,
+	serviceTargets, reportedTargets, wantServiceTargets, wantReportedTargets []string,
+) {
+	t.Helper()
+	if got := strings.Join(serviceTargets, "\n"); got != strings.Join(wantServiceTargets, "\n") {
+		t.Fatalf("observed service recording targets = %q, want literal targets %q", got, strings.Join(wantServiceTargets, "\n"))
+	}
+	if got := strings.Join(reportedTargets, "\n"); got != strings.Join(wantReportedTargets, "\n") {
+		t.Fatalf("observed reported recording targets = %q, want literal targets %q", got, strings.Join(wantReportedTargets, "\n"))
+	}
+	for index := range wantServiceTargets {
+		if strings.Contains(serviceTargets[index], "~default") || !strings.Contains(serviceTargets[index], characterizedLiveRecordingSessionToken) {
+			t.Fatalf("service target %q did not retain the placeholder token", serviceTargets[index])
+		}
+		if strings.Contains(reportedTargets[index], characterizedLiveRecordingSessionToken) || !strings.Contains(reportedTargets[index], "~default") {
+			t.Fatalf("reported target %q did not substitute ReportedSessionID only", reportedTargets[index])
+		}
+	}
+	if serviceTargets[0] == serviceTargets[1] || reportedTargets[0] == reportedTargets[1] {
+		t.Fatalf("current same-day default-session recording targets collide: service=%q reported=%q", serviceTargets, reportedTargets)
 	}
 }


### PR DESCRIPTION
{
  "project": "REC-1 Recording Characterization",
  "branchName": "rec-1-recording-characterization",
  "description": "Add characterization tests, without changing production behavior, that pin today's recording path, exact service and reported filenames, same-day default-session uniqueness result, v1 JSON bytes, and dirty/clean/final flush outcomes before REC-3 and REC-4 change those behaviors.",
  "context": {
    "customerAsk": "Before any recording filename or format change lands, add characterization tests that pin the current recording path, exact filename construction, on-disk format, and flush behavior. Include the regression guard that runs two same-day default sessions, pastes both literal observed filenames, and explicitly says whether they are distinct or colliding. Change no production behavior, and identify in the PR body which expectations REC-3 and REC-4 will intentionally change.",
    "problem": "PLAN-REC-001 is an eight-step strangler prompted by the 2026-08-22 loss of a Factory Session board after a hard kill left durable state without recording history. REC-3 will change recording paths and filenames, REC-4 will change whole-document JSON persistence to append-only JSONL, and current coverage does not provide one explicit literal before-state that lets those lanes distinguish intended assertion updates from regressions. The D2 same-day collision guard must be merged before the filename changes.",
    "solution": "Add deterministic behavioral tests at the Recordings and narrowly necessary Factory Sessions boundaries. Pin the current home-rooted YYYY-MM/YYYY-MM-DD layout, service placeholder filename, ReportedSessionID-substituted reported filename, and two-run distinctness result; pin the agent-factory.replay.v1 indented newline-terminated document; and pin the 250-millisecond dirty full-rewrite, clean no-op, failed-write, and final persistence outcomes using controlled clocks, identities, tickers, and storage observations. Make no production, contract, generated-artifact, ReserveNamed, or runtimepersist change."
  },
  "acceptanceCriteria": [
    "Characterization tests pin the literal global path layout <home>/.you-agent-factory/recordings/2026-02/2026-02-03, the literal service filename factory-session-__factory_session_id__-184512-uuid-1.json, and the literal reported filename factory-session-~default-184512-uuid-1.json; the assertions prove that only the reported path substitutes ReportedSessionID and that today's filename does not read livesession.CanonicalID.",
    "A deterministic behavioral test executes two same-day default-session recording runs through the relevant recording/session lifecycle, observes two actual recording targets or files, and asserts the literal service filenames factory-session-__factory_session_id__-184512-uuid-1.json and factory-session-__factory_session_id__-184512-uuid-2.json plus their ~default-substituted reported forms. The test and PR body state explicitly that the files are distinct today; if implementation observation instead proves a collision, the test pins that collision without changing production behavior and the PR body calls it out prominently for REC-3.",
    "Characterization tests pin the on-disk recording as one newline-terminated, two-space-indented agent-factory.replay.v1 JSON document and pin flush behavior at the literal 250-millisecond default: dirty state rewrites the complete current document, a clean flush performs no write, and stop/finalization leaves the latest accepted ordered events durably represented.",
    "The diff changes tests and test fixtures only, with no changes to recording path, filename, format, content, flush implementation, replay semantics, public contracts, generated artifacts, ReserveNamed adoption, or runtimepersist; the PR body pastes the literal characterization evidence and states that REC-3 is expected to change the path/filename/token/identity assertions while REC-4 is expected to change the extension/format/full-rewrite assertions.",
    "Final quality gate: Typecheck passes; targeted tests near pkg/services/recordings/ and pkg/services/factory_sessions/internal/execution/ pass; make test passes; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. Before its final push, implementation rebases onto current origin/main and reconciles shared test-file changes without weakening characterization assertions."
  ],
  "userStories": [
    {
      "id": "rec-1-recording-characterization-001",
      "title": "Pin current recording paths and same-day uniqueness",
      "description": "As a maintainer preparing the recording identity migration, I want literal tests for today's path and filenames so REC-3 can change only the intended layout and identity behavior.",
      "acceptanceCriteria": [
        "With home home/operator, time 2026-02-03T18:45:12Z, identity uuid-1, and reported session ~default, the characterized dated directory is literally home/operator/.you-agent-factory/recordings/2026-02/2026-02-03 using platform-native separators.",
        "The service filename is literally factory-session-__factory_session_id__-184512-uuid-1.json, while the reported filename is literally factory-session-~default-184512-uuid-1.json.",
        "The test proves the placeholder remains in the actual service target and substitution occurs only in the reported path from ReportedSessionID; it does not claim that today's path uses livesession.CanonicalID.",
        "Two default-session runs at the same fixed date and time use deterministic identities and assert the literal service filenames factory-session-__factory_session_id__-184512-uuid-1.json and factory-session-__factory_session_id__-184512-uuid-2.json, plus the corresponding factory-session-~default-184512-uuid-1.json and factory-session-~default-184512-uuid-2.json reported filenames; the test proves whether two actual recording targets/files are distinct or colliding without changing the result.",
        "The observed current result is stated explicitly in the test failure/output context and PR body. Based on current behavior, the expected finding is distinct files; any contrary observation is pinned and reported rather than corrected in REC-1.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added deterministic lifecycle characterization for the dated layout, placeholder service targets, ReportedSessionID substitution, and distinct same-day default-session targets."
    },
    {
      "id": "rec-1-recording-characterization-002",
      "title": "Pin the current recording document bytes",
      "description": "As a maintainer preparing the JSONL migration, I want today's exact persisted document shape characterized so REC-4 cannot accidentally change event content or ordering while changing the format.",
      "acceptanceCriteria": [
        "A deterministic fixture pins a literal complete recording payload whose schemaVersion is agent-factory.replay.v1.",
        "The literal expected bytes prove the artifact is one two-space-indented JSON document, not JSONL, and ends with exactly one newline.",
        "The characterized document retains events in sequence order and preserves the current header, event content, hashes, and terminal data represented by the fixture; the test does not introduce v2 framing or change replay semantics.",
        "The assertion compares observable serialized bytes or a checked-in focused golden with a reviewable literal payload, not source registrations, helper inventories, or file topology.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added a literal replay-v1 byte golden for the current indented JSON document, including ordered events, metadata/content hashes, and terminal wall-clock data; verified the single trailing newline and JSON-document shape."
    },
    {
      "id": "rec-1-recording-characterization-003",
      "title": "Pin current dirty, clean, and final flush outcomes",
      "description": "As a maintainer preparing append-only persistence, I want deterministic proof of today's flush outcomes so REC-4 can replace whole-document rewrites without losing cadence, ordering, or final persistence.",
      "acceptanceCriteria": [
        "A controlled ticker observes the literal default flush interval 250ms without a wall-clock sleep.",
        "After an accepted event makes a recording dirty, the next flush writes a complete v1 document containing all events accepted through that snapshot; after another accepted event, the next flush writes another complete replacement document containing both events in order.",
        "A flush while no newer state is dirty performs no additional storage write.",
        "Stop/finalization joins any active flush, performs the required final persistence for dirty state, and leaves the latest accepted ordered events represented; no write occurs after stop.",
        "A failed write does not advance the reported durable/flushed-through position, preserving the current observable failure behavior.",
        "Tests use controlled side effects and deterministic synchronization rather than sleep-padded timing, and they assert persistence outcomes rather than private helper calls.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added deterministic controlled-ticker characterization for the literal 250ms cadence, complete v1 dirty rewrites, clean no-op flush, joined final persistence/no post-stop writes, and failed-write durable-position behavior."
    }
  ]
}

---

## Current characterization evidence

The characterization runs use home home/operator and the fixed instant 2026-02-03T18:45:12Z (18:45:12 in the filename). The observed platform-native dated directory is:

home/operator/.you-agent-factory/recordings/2026-02/2026-02-03

The two same-day default-session runs observed these literal targets:

- service: home/operator/.you-agent-factory/recordings/2026-02/2026-02-03/factory-session-__factory_session_id__-184512-uuid-1.json
- service: home/operator/.you-agent-factory/recordings/2026-02/2026-02-03/factory-session-__factory_session_id__-184512-uuid-2.json
- reported: home/operator/.you-agent-factory/recordings/2026-02/2026-02-03/factory-session-~default-184512-uuid-1.json
- reported: home/operator/.you-agent-factory/recordings/2026-02/2026-02-03/factory-session-~default-184512-uuid-2.json

Observed result: the two same-day default-session recording targets/files are distinct today. The actual service targets retain the literal __factory_session_id__ placeholder; only the reported targets substitute ReportedSessionID (~default). The current filename characterization does not read livesession.CanonicalID.

The persisted replay evidence is the literal current v1 shape:

~~~json
{
  "schemaVersion": "agent-factory.replay.v1",
  "recordedAt": "2026-02-03T18:45:12Z",
  "events": [
    {
      "id": "factory-event/run-started",
      "context": {
        "sequence": 0
      }
    },
    {
      "id": "work-request-1",
      "context": {
        "sequence": 1
      }
    },
    {
      "id": "factory-event/run-finished",
      "context": {
        "sequence": 2
      }
    }
  ]
}
~~~

The checked-in byte golden contains the complete event/header/payload fields for those three ordered events. It is one two-space-indented JSON document, not JSONL, and its serialized bytes end with exactly one terminal newline: }\n (not }\n\n).

Flush characterization evidence:

- default cadence observed: 250ms;
- dirty event 0 causes one complete v1 document rewrite containing event 0;
- dirty event 1 causes another complete replacement document containing events 0 then 1 in order;
- a clean flush performs no additional storage write;
- finalization joins an active write, persists the latest accepted events, reports finalized state, and a post-stop tick produces no write;
- a failed write returns the storage error and does not advance FlushedThrough.

This is intentionally test/fixture-only. REC-3 is expected to change the path, filename, token, and identity assertions. REC-4 is expected to change the extension, format, and full-rewrite assertions.
