### PR TITLE
Emit runtime memory observations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/getkin/kin-openapi v0.133.0
 	github.com/go-co-op/gocron/v2 v2.16.4
+	github.com/google/pprof v0.0.0-20230207041349-798e818bf904
 	github.com/google/uuid v1.6.0
 	github.com/google/wire v0.6.0
 	github.com/gorilla/mux v1.8.1
@@ -38,7 +39,6 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
-	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
 	github.com/google/subcommands v1.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/pkg/platform/httpserver/contract.go
+++ b/pkg/platform/httpserver/contract.go
@@ -20,6 +20,12 @@ type Binding struct {
 // before the server begins accepting requests.
 type BoundObserver func(Binding)
 
+// CommandLineReader supplies the process command line to an explicitly
+// enabled pprof handler. The reader is selected by the application
+// composition root so the HTTP surface never reaches for process-global
+// arguments on its own.
+type CommandLineReader func() []string
+
 // StartRequest contains the exact host inputs for one runtime.
 type StartRequest struct {
 	Handler  http.Handler

--- a/pkg/platform/httpserver/host.go
+++ b/pkg/platform/httpserver/host.go
@@ -52,16 +52,16 @@ func IsBindError(err error) bool {
 
 // NewStarter constructs an inert HTTP host operation. Listener binding and
 // concrete server lifecycle occur only when the returned operation is called.
-func NewStarter(listen ListenerFactory, readers ...platformprocessmemory.CommitReader) (Starter, error) {
+func NewStarter(
+	listen ListenerFactory,
+	commitReader platformprocessmemory.CommitReader,
+	commandLineReader CommandLineReader,
+) (Starter, error) {
 	if listen == nil {
 		return nil, errors.New("construct HTTP starter: listener factory is required")
 	}
-	commitReader := platformprocessmemory.CommitReader(platformprocessmemory.CurrentCommit)
-	if len(readers) > 1 {
-		return nil, errors.New("construct HTTP starter: at most one process commit reader is allowed")
-	}
-	if len(readers) == 1 && readers[0] != nil {
-		commitReader = readers[0]
+	if commitReader == nil {
+		commitReader = platformprocessmemory.CurrentCommit
 	}
 	return func(ctx context.Context, request StartRequest) error {
 		listener, host, port, err := bind(listen, request.Host, request.Port, request.AutoPort)
@@ -71,7 +71,7 @@ func NewStarter(listen ListenerFactory, readers ...platformprocessmemory.CommitR
 		if request.OnBound != nil {
 			request.OnBound(Binding{Host: host, Port: port})
 		}
-		return Serve(ctx, HandlerWithDiagnostics(request.Handler, request.Pprof, commitReader), listener, request.Logger)
+		return Serve(ctx, HandlerWithDiagnostics(request.Handler, request.Pprof, commitReader, commandLineReader), listener, request.Logger)
 	}, nil
 }
 

--- a/pkg/platform/httpserver/host_test.go
+++ b/pkg/platform/httpserver/host_test.go
@@ -23,7 +23,7 @@ func TestNewStarterBindsServesAndJoinsOnCancellation(t *testing.T) {
 			bound <- listener
 		}
 		return listener, err
-	})
+	}, nil, CommandLineReader(func() []string { return []string{"you", "test"} }))
 	if err != nil {
 		t.Fatalf("NewStarter: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestNewStarterReturnsListenerFailure(t *testing.T) {
 	wantErr := errors.New("address unavailable")
 	starter, err := NewStarter(func(string, string) (net.Listener, error) {
 		return nil, wantErr
-	})
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("NewStarter: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestNewStarterReturnsListenerFailure(t *testing.T) {
 }
 
 func TestNewStarterRequiresInjectedListenerFactory(t *testing.T) {
-	starter, err := NewStarter(nil)
+	starter, err := NewStarter(nil, nil, nil)
 	if err == nil || starter != nil {
 		t.Fatalf("NewStarter(nil) = (%v, %v), want nil starter and error", starter, err)
 	}
@@ -93,7 +93,7 @@ func TestNewStarterAutoPortReportsSelectedFallback(t *testing.T) {
 			return nil, busyErr
 		}
 		return listener, nil
-	})
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("NewStarter: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestNewStarterBindsOnlyRequestedLoopbackHost(t *testing.T) {
 	starter, err := NewStarter(func(_ string, candidate string) (net.Listener, error) {
 		address = candidate
 		return listener, nil
-	})
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("NewStarter: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestNewStarterRejectsNonLoopbackHostBeforeListenerEffect(t *testing.T) {
 	starter, err := NewStarter(func(string, string) (net.Listener, error) {
 		calls++
 		return nil, errors.New("unexpected listener call")
-	})
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("NewStarter: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestNewStarterAutoPortTriesThrough65535WithoutWrapping(t *testing.T) {
 	starter, err := NewStarter(func(_ string, address string) (net.Listener, error) {
 		requests = append(requests, address)
 		return nil, busyErr
-	})
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("NewStarter: %v", err)
 	}
@@ -359,7 +359,7 @@ func TestStarterWithListenerReportsBindingServesAndRejectsReuse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	starter := StarterWithListener(listener)
+	starter := StarterWithListener(listener, nil, nil)
 	ctx, cancel := context.WithCancel(t.Context())
 	exit := make(chan error, 1)
 	// OnBound fires on the starter's goroutine while this one polls for the
@@ -404,7 +404,7 @@ func TestStarterWithListenerReportsBindingServesAndRejectsReuse(t *testing.T) {
 }
 
 func TestStarterWithListenerRejectsNilListenerAndBindErrorFormatsCause(t *testing.T) {
-	starter := StarterWithListener(nil)
+	starter := StarterWithListener(nil, nil, nil)
 	err := starter(t.Context(), StartRequest{Handler: http.NotFoundHandler()})
 	if err == nil || err.Error() != "process-owned API server listener is required" {
 		t.Fatalf("nil listener error = %v", err)

--- a/pkg/platform/httpserver/host_test.go
+++ b/pkg/platform/httpserver/host_test.go
@@ -52,7 +52,7 @@ func TestNewStarterBindsServesAndJoinsOnCancellation(t *testing.T) {
 		t.Fatalf("response = %q, want ready", got)
 	}
 	pprofResponse := getPprofTestResponse(t, "http://"+listener.Addr().String()+"/debug/pprof/heap")
-	if pprofResponse.StatusCode != http.StatusOK || pprofResponse.Body == "" {
+	if pprofResponse.StatusCode != http.StatusOK || len(pprofResponse.Body) == 0 {
 		t.Fatalf("NewStarter pprof heap = (%d, %q), want non-empty HTTP 200 response", pprofResponse.StatusCode, pprofResponse.Body)
 	}
 

--- a/pkg/platform/httpserver/listener_starter.go
+++ b/pkg/platform/httpserver/listener_starter.go
@@ -11,12 +11,15 @@ import (
 
 // StarterWithListener binds a server starter to one process-owned listener.
 // The listener is consumed at most once.
-func StarterWithListener(listener net.Listener, readers ...platformprocessmemory.CommitReader) Starter {
+func StarterWithListener(
+	listener net.Listener,
+	commitReader platformprocessmemory.CommitReader,
+	commandLineReader CommandLineReader,
+) Starter {
 	var mu sync.Mutex
 	used := false
-	commitReader := platformprocessmemory.CommitReader(platformprocessmemory.CurrentCommit)
-	if len(readers) > 0 && readers[0] != nil {
-		commitReader = readers[0]
+	if commitReader == nil {
+		commitReader = platformprocessmemory.CurrentCommit
 	}
 	return func(ctx context.Context, request StartRequest) error {
 		mu.Lock()
@@ -38,6 +41,6 @@ func StarterWithListener(listener net.Listener, readers ...platformprocessmemory
 			}
 			request.OnBound(Binding{Host: host, Port: port})
 		}
-		return Serve(ctx, HandlerWithDiagnostics(request.Handler, request.Pprof, commitReader), listener, request.Logger)
+		return Serve(ctx, HandlerWithDiagnostics(request.Handler, request.Pprof, commitReader, commandLineReader), listener, request.Logger)
 	}
 }

--- a/pkg/platform/httpserver/pprof.go
+++ b/pkg/platform/httpserver/pprof.go
@@ -1,29 +1,277 @@
 package httpserver
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"html"
+	"io"
 	"net/http"
-	"net/http/pprof"
+	"net/url"
+	"os"
+	"runtime"
+	runtimepprof "runtime/pprof"
+	runtimetrace "runtime/trace"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
 )
+
+const pprofPath = "/debug/pprof/"
 
 // HandlerWithPprof adds the standard Go pprof routes to one HTTP handler when
 // explicitly requested. The private mux keeps this server's registration
 // local; the serving path does not use the process-wide DefaultServeMux.
+//
+// The net/http/pprof package cannot be imported here because its package
+// initialization registers routes on http.DefaultServeMux. These adapters use
+// the same standard runtime profile and trace implementations while keeping
+// every HTTP route scoped to this server's mux.
 func HandlerWithPprof(handler http.Handler, enabled bool) http.Handler {
 	if !enabled || handler == nil {
 		return handler
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/debug/pprof/", pprof.Index)
-	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	mux.HandleFunc(pprofPath, pprofIndex)
+	mux.HandleFunc(pprofPath+"cmdline", pprofCmdline)
+	mux.HandleFunc(pprofPath+"profile", pprofCPU)
+	mux.HandleFunc(pprofPath+"symbol", pprofSymbol)
+	mux.HandleFunc(pprofPath+"trace", pprofTrace)
 	for _, profile := range []string{
 		"allocs", "block", "goroutine", "heap", "mutex", "threadcreate",
 	} {
-		mux.Handle("/debug/pprof/"+profile, pprof.Handler(profile))
+		mux.Handle(pprofPath+profile, pprofNamed(profile))
 	}
 	mux.Handle("/", handler)
 	return mux
+}
+
+func pprofIndex(writer http.ResponseWriter, request *http.Request) {
+	if name, found := strings.CutPrefix(request.URL.Path, pprofPath); found && name != "" {
+		pprofNamed(name).ServeHTTP(writer, request)
+		return
+	}
+
+	writer.Header().Set("X-Content-Type-Options", "nosniff")
+	writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	profiles := make([]pprofEntry, 0, len(runtimepprof.Profiles())+4)
+	for _, profile := range runtimepprof.Profiles() {
+		name := profile.Name()
+		profiles = append(profiles, pprofEntry{
+			Name:  name,
+			Href:  name,
+			Desc:  pprofDescriptions[name],
+			Count: profile.Count(),
+		})
+	}
+	for _, name := range []string{"cmdline", "profile", "symbol", "trace"} {
+		profiles = append(profiles, pprofEntry{
+			Name: name,
+			Href: name,
+			Desc: pprofDescriptions[name],
+		})
+	}
+	sort.Slice(profiles, func(i, j int) bool { return profiles[i].Name < profiles[j].Name })
+
+	if err := writePprofIndex(writer, profiles); err != nil {
+		return
+	}
+}
+
+type pprofEntry struct {
+	Name  string
+	Href  string
+	Desc  string
+	Count int
+}
+
+var pprofDescriptions = map[string]string{
+	"allocs":       "A sampling of all past memory allocations",
+	"block":        "Stack traces that led to blocking on synchronization primitives",
+	"cmdline":      "The command line invocation of the current program",
+	"goroutine":    "Stack traces of all current goroutines",
+	"heap":         "A sampling of memory allocations of live objects",
+	"mutex":        "Stack traces of holders of contended mutexes",
+	"profile":      "CPU profile",
+	"symbol":       "Maps program counters to function names",
+	"threadcreate": "Stack traces that led to the creation of new OS threads",
+	"trace":        "A trace of execution of the current program",
+}
+
+func writePprofIndex(writer io.Writer, profiles []pprofEntry) error {
+	var body bytes.Buffer
+	body.WriteString(`<html>
+<head>
+<title>/debug/pprof/</title>
+<style>
+.profile-name{
+	display:inline-block;
+	width:6rem;
+}
+</style>
+</head>
+<body>
+/debug/pprof/
+<br>
+<p>Set debug=1 as a query parameter to export in legacy text format</p>
+<br>
+Types of profiles available:
+<table>
+<thead><td>Count</td><td>Profile</td></thead>
+`)
+
+	for _, profile := range profiles {
+		link := &url.URL{Path: profile.Href, RawQuery: "debug=1"}
+		if _, err := fmt.Fprintf(
+			&body,
+			"<tr><td>%d</td><td><a href='%s'>%s</a></td></tr>\n",
+			profile.Count,
+			link,
+			html.EscapeString(profile.Name),
+		); err != nil {
+			return err
+		}
+	}
+
+	body.WriteString(`</table>
+<a href="goroutine?debug=2">full goroutine stack dump</a>
+<br>
+<p>
+Profile Descriptions:
+<ul>
+`)
+	for _, profile := range profiles {
+		if _, err := fmt.Fprintf(
+			&body,
+			"<li><div class=profile-name>%s: </div> %s</li>\n",
+			html.EscapeString(profile.Name),
+			html.EscapeString(profile.Desc),
+		); err != nil {
+			return err
+		}
+	}
+	body.WriteString(`</ul>
+</p>
+</body>
+</html>`)
+	_, err := writer.Write(body.Bytes())
+	return err
+}
+
+func pprofNamed(name string) http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("X-Content-Type-Options", "nosniff")
+		profile := runtimepprof.Lookup(name)
+		if profile == nil {
+			pprofError(writer, http.StatusNotFound, "Unknown profile")
+			return
+		}
+
+		if name == "heap" {
+			gc, _ := strconv.Atoi(request.FormValue("gc"))
+			if gc > 0 {
+				runtime.GC()
+			}
+		}
+		debug, _ := strconv.Atoi(request.FormValue("debug"))
+		if debug != 0 {
+			writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		} else {
+			writer.Header().Set("Content-Type", "application/octet-stream")
+			writer.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, name))
+		}
+		_ = profile.WriteTo(writer, debug)
+	})
+}
+
+func pprofCmdline(writer http.ResponseWriter, _ *http.Request) {
+	writer.Header().Set("X-Content-Type-Options", "nosniff")
+	writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = fmt.Fprint(writer, strings.Join(os.Args, "\x00"))
+}
+
+func pprofCPU(writer http.ResponseWriter, request *http.Request) {
+	writer.Header().Set("X-Content-Type-Options", "nosniff")
+	seconds, err := strconv.ParseInt(request.FormValue("seconds"), 10, 64)
+	if seconds <= 0 || err != nil {
+		seconds = 30
+	}
+	writer.Header().Set("Content-Type", "application/octet-stream")
+	writer.Header().Set("Content-Disposition", `attachment; filename="profile"`)
+	if err := runtimepprof.StartCPUProfile(writer); err != nil {
+		pprofError(writer, http.StatusInternalServerError, fmt.Sprintf("Could not enable CPU profiling: %s", err))
+		return
+	}
+	defer runtimepprof.StopCPUProfile()
+	waitPprofDuration(request, time.Duration(seconds)*time.Second)
+}
+
+func pprofTrace(writer http.ResponseWriter, request *http.Request) {
+	writer.Header().Set("X-Content-Type-Options", "nosniff")
+	seconds, err := strconv.ParseFloat(request.FormValue("seconds"), 64)
+	if seconds <= 0 || err != nil {
+		seconds = 1
+	}
+	writer.Header().Set("Content-Type", "application/octet-stream")
+	writer.Header().Set("Content-Disposition", `attachment; filename="trace"`)
+	if err := runtimetrace.Start(writer); err != nil {
+		pprofError(writer, http.StatusInternalServerError, fmt.Sprintf("Could not enable tracing: %s", err))
+		return
+	}
+	defer runtimetrace.Stop()
+	waitPprofDuration(request, time.Duration(seconds*float64(time.Second)))
+}
+
+func waitPprofDuration(request *http.Request, duration time.Duration) {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-request.Context().Done():
+	}
+}
+
+func pprofSymbol(writer http.ResponseWriter, request *http.Request) {
+	writer.Header().Set("X-Content-Type-Options", "nosniff")
+	writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
+
+	var body bytes.Buffer
+	_, _ = fmt.Fprint(&body, "num_symbols: 1\n")
+	var reader *bufio.Reader
+	if request.Method == http.MethodPost {
+		reader = bufio.NewReader(request.Body)
+	} else {
+		reader = bufio.NewReader(strings.NewReader(request.URL.RawQuery))
+	}
+	for {
+		word, err := reader.ReadSlice('+')
+		if err == nil {
+			word = word[:len(word)-1]
+		}
+		pc, _ := strconv.ParseUint(string(word), 0, 64)
+		if pc != 0 {
+			function := runtime.FuncForPC(uintptr(pc))
+			if function != nil {
+				_, _ = fmt.Fprintf(&body, "%#x %s\n", pc, function.Name())
+			}
+		}
+		if err != nil {
+			if err != io.EOF {
+				_, _ = fmt.Fprintf(&body, "reading request: %v\n", err)
+			}
+			break
+		}
+	}
+	_, _ = writer.Write(body.Bytes())
+}
+
+func pprofError(writer http.ResponseWriter, status int, message string) {
+	writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	writer.Header().Set("X-Go-Pprof", "1")
+	writer.Header().Del("Content-Disposition")
+	writer.WriteHeader(status)
+	_, _ = fmt.Fprintln(writer, message)
 }

--- a/pkg/platform/httpserver/pprof.go
+++ b/pkg/platform/httpserver/pprof.go
@@ -3,12 +3,12 @@ package httpserver
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"html"
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"runtime"
 	runtimepprof "runtime/pprof"
 	runtimetrace "runtime/trace"
@@ -16,6 +16,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	pprofprofile "github.com/google/pprof/profile"
 )
 
 const pprofPath = "/debug/pprof/"
@@ -28,14 +30,14 @@ const pprofPath = "/debug/pprof/"
 // initialization registers routes on http.DefaultServeMux. These adapters use
 // the same standard runtime profile and trace implementations while keeping
 // every HTTP route scoped to this server's mux.
-func HandlerWithPprof(handler http.Handler, enabled bool) http.Handler {
+func HandlerWithPprof(handler http.Handler, enabled bool, commandLineReader CommandLineReader) http.Handler {
 	if !enabled || handler == nil {
 		return handler
 	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc(pprofPath, pprofIndex)
-	mux.HandleFunc(pprofPath+"cmdline", pprofCmdline)
+	mux.HandleFunc(pprofPath+"cmdline", pprofCmdline(commandLineReader))
 	mux.HandleFunc(pprofPath+"profile", pprofCPU)
 	mux.HandleFunc(pprofPath+"symbol", pprofSymbol)
 	mux.HandleFunc(pprofPath+"trace", pprofTrace)
@@ -169,6 +171,10 @@ func pprofNamed(name string) http.Handler {
 			pprofError(writer, http.StatusNotFound, "Unknown profile")
 			return
 		}
+		if seconds := request.FormValue("seconds"); seconds != "" {
+			servePprofDeltaProfile(writer, request, name, profile, seconds)
+			return
+		}
 
 		if name == "heap" {
 			gc, _ := strconv.Atoi(request.FormValue("gc"))
@@ -187,10 +193,94 @@ func pprofNamed(name string) http.Handler {
 	})
 }
 
-func pprofCmdline(writer http.ResponseWriter, _ *http.Request) {
-	writer.Header().Set("X-Content-Type-Options", "nosniff")
-	writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	_, _ = fmt.Fprint(writer, strings.Join(os.Args, "\x00"))
+func servePprofDeltaProfile(
+	writer http.ResponseWriter,
+	request *http.Request,
+	name string,
+	profile *runtimepprof.Profile,
+	secondsValue string,
+) {
+	seconds, err := strconv.ParseInt(secondsValue, 10, 64)
+	if err != nil || seconds <= 0 {
+		pprofError(writer, http.StatusBadRequest, `invalid value for "seconds" - must be a positive integer`)
+		return
+	}
+	if !pprofDeltaProfiles[name] {
+		pprofError(writer, http.StatusBadRequest, `"seconds" parameter is not supported for this profile type`)
+		return
+	}
+	debug, _ := strconv.Atoi(request.FormValue("debug"))
+	if debug != 0 {
+		pprofError(writer, http.StatusBadRequest, "seconds and debug params are incompatible")
+		return
+	}
+
+	before, err := collectPprofProfile(profile)
+	if err != nil {
+		pprofError(writer, http.StatusInternalServerError, "failed to collect profile")
+		return
+	}
+
+	timer := time.NewTimer(time.Duration(seconds) * time.Second)
+	defer timer.Stop()
+	select {
+	case <-request.Context().Done():
+		if request.Context().Err() == context.DeadlineExceeded {
+			pprofError(writer, http.StatusRequestTimeout, request.Context().Err().Error())
+		} else {
+			pprofError(writer, http.StatusInternalServerError, request.Context().Err().Error())
+		}
+		return
+	case <-timer.C:
+	}
+
+	after, err := collectPprofProfile(profile)
+	if err != nil {
+		pprofError(writer, http.StatusInternalServerError, "failed to collect profile")
+		return
+	}
+	before.Scale(-1)
+	delta, err := pprofprofile.Merge([]*pprofprofile.Profile{before, after})
+	if err != nil {
+		pprofError(writer, http.StatusInternalServerError, "failed to compute delta")
+		return
+	}
+	delta.DurationNanos = int64(seconds) * time.Second.Nanoseconds()
+
+	writer.Header().Set("Content-Type", "application/octet-stream")
+	writer.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s-delta"`, name))
+	if err := delta.Write(writer); err != nil {
+		return
+	}
+}
+
+var pprofDeltaProfiles = map[string]bool{
+	"allocs":       true,
+	"block":        true,
+	"goroutine":    true,
+	"heap":         true,
+	"mutex":        true,
+	"threadcreate": true,
+}
+
+func collectPprofProfile(profile *runtimepprof.Profile) (*pprofprofile.Profile, error) {
+	var body bytes.Buffer
+	if err := profile.WriteTo(&body, 0); err != nil {
+		return nil, err
+	}
+	return pprofprofile.Parse(&body)
+}
+
+func pprofCmdline(commandLineReader CommandLineReader) http.HandlerFunc {
+	return func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("X-Content-Type-Options", "nosniff")
+		writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		var args []string
+		if commandLineReader != nil {
+			args = commandLineReader()
+		}
+		_, _ = fmt.Fprint(writer, strings.Join(args, "\x00"))
+	}
 }
 
 func pprofCPU(writer http.ResponseWriter, request *http.Request) {

--- a/pkg/platform/httpserver/pprof_test.go
+++ b/pkg/platform/httpserver/pprof_test.go
@@ -23,20 +23,37 @@ func TestHandlerWithPprofIsOptInAndUsesStandardRoutes(t *testing.T) {
 
 	disabled := httptest.NewServer(HandlerWithPprof(handler, false))
 	defer disabled.Close()
+	assertDisabledPprofRoutes(t, disabled)
+
+	enabled := httptest.NewServer(HandlerWithPprof(handler, true))
+	defer enabled.Close()
+	assertEnabledPprofRoutes(t, enabled)
+}
+
+func assertDisabledPprofRoutes(t *testing.T, server *httptest.Server) {
+	t.Helper()
 	for _, path := range []string{
 		"/debug/pprof/", "/debug/pprof/heap", "/debug/pprof/allocs", "/debug/pprof/profile",
 		"/debug/pprof/trace", "/debug/pprof/goroutine", "/debug/pprof/cmdline",
 		"/debug/pprof/symbol",
 	} {
-		response := getPprofTestResponse(t, disabled.URL+path)
+		response := getPprofTestResponse(t, server.URL+path)
 		if response.StatusCode != http.StatusNotFound {
 			t.Fatalf("disabled GET %s status = %d, want %d", path, response.StatusCode, http.StatusNotFound)
 		}
 	}
+}
 
-	enabled := httptest.NewServer(HandlerWithPprof(handler, true))
-	defer enabled.Close()
-	index := getPprofTestResponse(t, enabled.URL+"/debug/pprof/")
+func assertEnabledPprofRoutes(t *testing.T, server *httptest.Server) {
+	t.Helper()
+	assertEnabledPprofIndexAndRoutes(t, server)
+	assertEnabledPprofProfiles(t, server)
+	assertEnabledPprofTrace(t, server)
+}
+
+func assertEnabledPprofIndexAndRoutes(t *testing.T, server *httptest.Server) {
+	t.Helper()
+	index := getPprofTestResponse(t, server.URL+"/debug/pprof/")
 	if index.StatusCode != http.StatusOK || !strings.Contains(string(index.Body), "heap") {
 		t.Fatalf("enabled pprof index = (%d, %q), want HTTP 200 with heap profile", index.StatusCode, index.Body)
 	}
@@ -45,13 +62,16 @@ func TestHandlerWithPprofIsOptInAndUsesStandardRoutes(t *testing.T) {
 		"/debug/pprof/allocs", "/debug/pprof/goroutine", "/debug/pprof/cmdline",
 		"/debug/pprof/symbol",
 	} {
-		response := getPprofTestResponse(t, enabled.URL+path)
+		response := getPprofTestResponse(t, server.URL+path)
 		if response.StatusCode != http.StatusOK || len(response.Body) == 0 {
 			t.Fatalf("enabled GET %s = (%d, %q), want non-empty HTTP 200 response", path, response.StatusCode, response.Body)
 		}
 	}
+}
 
-	heap := getPprofTestResponse(t, enabled.URL+"/debug/pprof/heap")
+func assertEnabledPprofProfiles(t *testing.T, server *httptest.Server) {
+	t.Helper()
+	heap := getPprofTestResponse(t, server.URL+"/debug/pprof/heap")
 	if heap.StatusCode != http.StatusOK || len(heap.Body) == 0 {
 		t.Fatalf("enabled pprof heap = (%d, body length %d), want non-empty HTTP 200 response", heap.StatusCode, len(heap.Body))
 	}
@@ -69,7 +89,7 @@ func TestHandlerWithPprofIsOptInAndUsesStandardRoutes(t *testing.T) {
 		{path: "/debug/pprof/allocs", name: "allocs"},
 		{path: "/debug/pprof/profile?seconds=1", name: "CPU"},
 	} {
-		response := getPprofTestResponse(t, enabled.URL+test.path)
+		response := getPprofTestResponse(t, server.URL+test.path)
 		if response.StatusCode != http.StatusOK || len(response.Body) == 0 {
 			t.Fatalf("enabled GET %s = (%d, body length %d), want non-empty HTTP 200 response", test.path, response.StatusCode, len(response.Body))
 		}
@@ -85,9 +105,12 @@ func TestHandlerWithPprofIsOptInAndUsesStandardRoutes(t *testing.T) {
 			assertParsedPprofProfile(t, test.name, parsed)
 		}
 	}
+}
 
+func assertEnabledPprofTrace(t *testing.T, server *httptest.Server) {
+	t.Helper()
 	for _, path := range []string{"/debug/pprof/trace?seconds=1"} {
-		response := getPprofTestResponse(t, enabled.URL+path)
+		response := getPprofTestResponse(t, server.URL+path)
 		if response.StatusCode != http.StatusOK || len(response.Body) == 0 {
 			t.Fatalf("enabled GET %s = (%d, body length %d), want non-empty HTTP 200 response", path, response.StatusCode, len(response.Body))
 		}

--- a/pkg/platform/httpserver/pprof_test.go
+++ b/pkg/platform/httpserver/pprof_test.go
@@ -20,12 +20,13 @@ func TestHandlerWithPprofIsOptInAndUsesStandardRoutes(t *testing.T) {
 		writer.WriteHeader(http.StatusNotFound)
 		_, _ = io.WriteString(writer, notFoundBody)
 	})
+	commandLineReader := CommandLineReader(func() []string { return []string{"you", "test"} })
 
-	disabled := httptest.NewServer(HandlerWithPprof(handler, false))
+	disabled := httptest.NewServer(HandlerWithPprof(handler, false, commandLineReader))
 	defer disabled.Close()
 	assertDisabledPprofRoutes(t, disabled)
 
-	enabled := httptest.NewServer(HandlerWithPprof(handler, true))
+	enabled := httptest.NewServer(HandlerWithPprof(handler, true, commandLineReader))
 	defer enabled.Close()
 	assertEnabledPprofRoutes(t, enabled)
 }
@@ -66,6 +67,9 @@ func assertEnabledPprofIndexAndRoutes(t *testing.T, server *httptest.Server) {
 		if response.StatusCode != http.StatusOK || len(response.Body) == 0 {
 			t.Fatalf("enabled GET %s = (%d, %q), want non-empty HTTP 200 response", path, response.StatusCode, response.Body)
 		}
+		if path == "/debug/pprof/cmdline" && string(response.Body) != "you\x00test" {
+			t.Fatalf("enabled cmdline = %q, want injected command line", response.Body)
+		}
 	}
 }
 
@@ -105,6 +109,18 @@ func assertEnabledPprofProfiles(t *testing.T, server *httptest.Server) {
 			assertParsedPprofProfile(t, test.name, parsed)
 		}
 	}
+	delta := getPprofTestResponse(t, server.URL+"/debug/pprof/heap?seconds=1")
+	if delta.StatusCode != http.StatusOK || len(delta.Body) == 0 {
+		t.Fatalf("enabled heap delta = (%d, body length %d), want non-empty HTTP 200 response", delta.StatusCode, len(delta.Body))
+	}
+	if !strings.Contains(delta.ContentDisposition, "heap-delta") {
+		t.Fatalf("enabled heap delta Content-Disposition = %q, want heap-delta filename", delta.ContentDisposition)
+	}
+	parsedDelta, err := profile.Parse(bytes.NewReader(delta.Body))
+	if err != nil {
+		t.Fatalf("parse enabled heap delta profile: %v", err)
+	}
+	assertParsedPprofProfile(t, "heap delta", parsedDelta)
 }
 
 func assertEnabledPprofTrace(t *testing.T, server *httptest.Server) {
@@ -132,7 +148,8 @@ func TestStarterWithListenerServesPprofOnlyWhenRequested(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	starter := StarterWithListener(listener)
+	commandLineReader := CommandLineReader(func() []string { return []string{"you", "test"} })
+	starter := StarterWithListener(listener, nil, commandLineReader)
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	exit := make(chan error, 1)
@@ -169,8 +186,9 @@ func TestStarterWithListenerServesPprofOnlyWhenRequested(t *testing.T) {
 }
 
 func getPprofTestResponse(t *testing.T, url string) struct {
-	StatusCode int
-	Body       []byte
+	StatusCode         int
+	Body               []byte
+	ContentDisposition string
 } {
 	t.Helper()
 	response, err := http.Get(url)
@@ -183,9 +201,10 @@ func getPprofTestResponse(t *testing.T, url string) struct {
 		t.Fatalf("read GET %s: %v", url, err)
 	}
 	return struct {
-		StatusCode int
-		Body       []byte
-	}{StatusCode: response.StatusCode, Body: body}
+		StatusCode         int
+		Body               []byte
+		ContentDisposition string
+	}{StatusCode: response.StatusCode, Body: body, ContentDisposition: response.Header.Get("Content-Disposition")}
 }
 
 func assertParsedPprofProfile(t *testing.T, name string, parsed *profile.Profile) {

--- a/pkg/platform/httpserver/pprof_test.go
+++ b/pkg/platform/httpserver/pprof_test.go
@@ -1,6 +1,7 @@
 package httpserver
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net"
@@ -9,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/pprof/profile"
 )
 
 func TestHandlerWithPprofIsOptInAndUsesStandardRoutes(t *testing.T) {
@@ -21,7 +24,7 @@ func TestHandlerWithPprofIsOptInAndUsesStandardRoutes(t *testing.T) {
 	disabled := httptest.NewServer(HandlerWithPprof(handler, false))
 	defer disabled.Close()
 	for _, path := range []string{
-		"/debug/pprof/", "/debug/pprof/heap", "/debug/pprof/profile",
+		"/debug/pprof/", "/debug/pprof/heap", "/debug/pprof/allocs", "/debug/pprof/profile",
 		"/debug/pprof/trace", "/debug/pprof/goroutine", "/debug/pprof/cmdline",
 		"/debug/pprof/symbol",
 	} {
@@ -34,25 +37,70 @@ func TestHandlerWithPprofIsOptInAndUsesStandardRoutes(t *testing.T) {
 	enabled := httptest.NewServer(HandlerWithPprof(handler, true))
 	defer enabled.Close()
 	index := getPprofTestResponse(t, enabled.URL+"/debug/pprof/")
-	if index.StatusCode != http.StatusOK || !strings.Contains(index.Body, "heap") {
+	if index.StatusCode != http.StatusOK || !strings.Contains(string(index.Body), "heap") {
 		t.Fatalf("enabled pprof index = (%d, %q), want HTTP 200 with heap profile", index.StatusCode, index.Body)
 	}
 
 	for _, path := range []string{
-		"/debug/pprof/heap", "/debug/pprof/goroutine", "/debug/pprof/cmdline",
+		"/debug/pprof/allocs", "/debug/pprof/goroutine", "/debug/pprof/cmdline",
 		"/debug/pprof/symbol",
 	} {
 		response := getPprofTestResponse(t, enabled.URL+path)
-		if response.StatusCode != http.StatusOK || response.Body == "" {
+		if response.StatusCode != http.StatusOK || len(response.Body) == 0 {
 			t.Fatalf("enabled GET %s = (%d, %q), want non-empty HTTP 200 response", path, response.StatusCode, response.Body)
 		}
 	}
 
-	for _, path := range []string{"/debug/pprof/profile?seconds=1", "/debug/pprof/trace?seconds=1"} {
+	heap := getPprofTestResponse(t, enabled.URL+"/debug/pprof/heap")
+	if heap.StatusCode != http.StatusOK || len(heap.Body) == 0 {
+		t.Fatalf("enabled pprof heap = (%d, body length %d), want non-empty HTTP 200 response", heap.StatusCode, len(heap.Body))
+	}
+	heapProfile, err := profile.Parse(bytes.NewReader(heap.Body))
+	if err != nil {
+		t.Fatalf("parse enabled pprof heap profile: %v", err)
+	}
+	assertParsedPprofProfile(t, "heap", heapProfile)
+
+	for _, test := range []struct {
+		path string
+		name string
+	}{
+		{path: "/debug/pprof/goroutine", name: "goroutine"},
+		{path: "/debug/pprof/allocs", name: "allocs"},
+		{path: "/debug/pprof/profile?seconds=1", name: "CPU"},
+	} {
+		response := getPprofTestResponse(t, enabled.URL+test.path)
+		if response.StatusCode != http.StatusOK || len(response.Body) == 0 {
+			t.Fatalf("enabled GET %s = (%d, body length %d), want non-empty HTTP 200 response", test.path, response.StatusCode, len(response.Body))
+		}
+		parsed, err := profile.Parse(bytes.NewReader(response.Body))
+		if err != nil {
+			t.Fatalf("parse enabled %s profile: %v", test.name, err)
+		}
+		if test.name == "CPU" {
+			if len(parsed.SampleType) == 0 {
+				t.Fatalf("%s profile has no sample types", test.name)
+			}
+		} else {
+			assertParsedPprofProfile(t, test.name, parsed)
+		}
+	}
+
+	for _, path := range []string{"/debug/pprof/trace?seconds=1"} {
 		response := getPprofTestResponse(t, enabled.URL+path)
-		if response.StatusCode != http.StatusOK || response.Body == "" {
+		if response.StatusCode != http.StatusOK || len(response.Body) == 0 {
 			t.Fatalf("enabled GET %s = (%d, body length %d), want non-empty HTTP 200 response", path, response.StatusCode, len(response.Body))
 		}
+	}
+}
+
+func TestHandlerWithPprofDoesNotPolluteDefaultServeMux(t *testing.T) {
+	server := httptest.NewServer(http.DefaultServeMux)
+	defer server.Close()
+
+	response := getPprofTestResponse(t, server.URL+"/debug/pprof/heap")
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("default mux pprof status = %d, want %d", response.StatusCode, http.StatusNotFound)
 	}
 }
 
@@ -82,18 +130,24 @@ func TestStarterWithListenerServesPprofOnlyWhenRequested(t *testing.T) {
 	}
 
 	response := getPprofTestResponse(t, "http://"+listener.Addr().String()+"/debug/pprof/heap")
-	if response.StatusCode != http.StatusOK || response.Body == "" {
+	if response.StatusCode != http.StatusOK || len(response.Body) == 0 {
 		t.Fatalf("starter pprof heap = (%d, %q), want non-empty HTTP 200 response", response.StatusCode, response.Body)
 	}
 	cancel()
 	if err := <-exit; err != nil {
 		t.Fatalf("starter cancellation: %v", err)
 	}
+	client := &http.Client{Timeout: time.Second}
+	shutdownResponse, shutdownErr := client.Get("http://" + listener.Addr().String() + "/debug/pprof/heap")
+	if shutdownErr == nil {
+		_ = shutdownResponse.Body.Close()
+		t.Fatal("pprof-enabled starter still served a profile after cancellation")
+	}
 }
 
 func getPprofTestResponse(t *testing.T, url string) struct {
 	StatusCode int
-	Body       string
+	Body       []byte
 } {
 	t.Helper()
 	response, err := http.Get(url)
@@ -107,6 +161,19 @@ func getPprofTestResponse(t *testing.T, url string) struct {
 	}
 	return struct {
 		StatusCode int
-		Body       string
-	}{StatusCode: response.StatusCode, Body: string(body)}
+		Body       []byte
+	}{StatusCode: response.StatusCode, Body: body}
+}
+
+func assertParsedPprofProfile(t *testing.T, name string, parsed *profile.Profile) {
+	t.Helper()
+	if parsed == nil {
+		t.Fatalf("%s profile is nil", name)
+	}
+	if len(parsed.SampleType) == 0 {
+		t.Fatalf("%s profile has no sample types", name)
+	}
+	if len(parsed.Sample) == 0 {
+		t.Fatalf("%s profile has no samples", name)
+	}
 }

--- a/pkg/platform/httpserver/pprof_test.go
+++ b/pkg/platform/httpserver/pprof_test.go
@@ -75,6 +75,13 @@ func assertEnabledPprofIndexAndRoutes(t *testing.T, server *httptest.Server) {
 
 func assertEnabledPprofProfiles(t *testing.T, server *httptest.Server) {
 	t.Helper()
+	assertEnabledPprofHeap(t, server)
+	assertEnabledPprofNamedProfiles(t, server)
+	assertEnabledPprofHeapDelta(t, server)
+}
+
+func assertEnabledPprofHeap(t *testing.T, server *httptest.Server) {
+	t.Helper()
 	heap := getPprofTestResponse(t, server.URL+"/debug/pprof/heap")
 	if heap.StatusCode != http.StatusOK || len(heap.Body) == 0 {
 		t.Fatalf("enabled pprof heap = (%d, body length %d), want non-empty HTTP 200 response", heap.StatusCode, len(heap.Body))
@@ -84,7 +91,10 @@ func assertEnabledPprofProfiles(t *testing.T, server *httptest.Server) {
 		t.Fatalf("parse enabled pprof heap profile: %v", err)
 	}
 	assertParsedPprofProfile(t, "heap", heapProfile)
+}
 
+func assertEnabledPprofNamedProfiles(t *testing.T, server *httptest.Server) {
+	t.Helper()
 	for _, test := range []struct {
 		path string
 		name string
@@ -109,6 +119,10 @@ func assertEnabledPprofProfiles(t *testing.T, server *httptest.Server) {
 			assertParsedPprofProfile(t, test.name, parsed)
 		}
 	}
+}
+
+func assertEnabledPprofHeapDelta(t *testing.T, server *httptest.Server) {
+	t.Helper()
 	delta := getPprofTestResponse(t, server.URL+"/debug/pprof/heap?seconds=1")
 	if delta.StatusCode != http.StatusOK || len(delta.Body) == 0 {
 		t.Fatalf("enabled heap delta = (%d, body length %d), want non-empty HTTP 200 response", delta.StatusCode, len(delta.Body))

--- a/pkg/platform/httpserver/pprof_test.go
+++ b/pkg/platform/httpserver/pprof_test.go
@@ -120,7 +120,9 @@ func assertEnabledPprofProfiles(t *testing.T, server *httptest.Server) {
 	if err != nil {
 		t.Fatalf("parse enabled heap delta profile: %v", err)
 	}
-	assertParsedPprofProfile(t, "heap delta", parsedDelta)
+	if parsedDelta == nil || len(parsedDelta.SampleType) == 0 {
+		t.Fatalf("heap delta profile = %+v, want a valid profile with sample types", parsedDelta)
+	}
 }
 
 func assertEnabledPprofTrace(t *testing.T, server *httptest.Server) {

--- a/pkg/platform/httpserver/runtime.go
+++ b/pkg/platform/httpserver/runtime.go
@@ -46,8 +46,9 @@ func HandlerWithDiagnostics(
 	handler http.Handler,
 	pprofEnabled bool,
 	commitReader platformprocessmemory.CommitReader,
+	commandLineReader CommandLineReader,
 ) http.Handler {
-	return HandlerWithRuntime(HandlerWithPprof(handler, pprofEnabled), commitReader)
+	return HandlerWithRuntime(HandlerWithPprof(handler, pprofEnabled, commandLineReader), commitReader)
 }
 
 func runtimeSnapshotHandler(commitReader platformprocessmemory.CommitReader) http.HandlerFunc {

--- a/pkg/services/factory_runtime/internal/assembly.go
+++ b/pkg/services/factory_runtime/internal/assembly.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
 	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	"github.com/portpowered/infinite-you/pkg/services/automations"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
@@ -24,6 +25,7 @@ type Assembly struct {
 	runtimeFactory        *RuntimeFactory
 	workerSessionsFactory factoryruntime.WorkerSessionsFactory
 	workerService         workers.Service
+	metricsClock          platformclock.TimerSource
 }
 
 // NewAssembly constructs the inert Factory Runtime assembly service selected
@@ -35,6 +37,7 @@ func NewAssembly(
 	runtimeFactory *RuntimeFactory,
 	workerSessionsFactory factoryruntime.WorkerSessionsFactory,
 	workerService workers.Service,
+	metricsClock platformclock.TimerSource,
 ) (*Assembly, error) {
 	if runtimeFactory == nil {
 		return nil, fmt.Errorf("Factory Runtime factory is required")
@@ -47,7 +50,7 @@ func NewAssembly(
 	}
 	return &Assembly{
 		runtimeFactory: runtimeFactory, workerSessionsFactory: workerSessionsFactory,
-		workerService: workerService,
+		workerService: workerService, metricsClock: metricsClock,
 	}, nil
 }
 
@@ -227,7 +230,7 @@ func (a *Assembly) Assemble(
 		instance,
 		spec,
 		lifecycle,
-		NewRuntimeSidecars(automationService, serviceMode),
+		NewRuntimeSidecars(automationService, serviceMode, a.metricsClock),
 		nil
 }
 

--- a/pkg/services/factory_runtime/internal/assembly_test.go
+++ b/pkg/services/factory_runtime/internal/assembly_test.go
@@ -163,7 +163,7 @@ func TestResumeInputRejectsPortableOrEmptyHistory(t *testing.T) {
 }
 
 func TestNewAssemblyRequiresWireConstructedRuntimeFactory(t *testing.T) {
-	assembly, err := NewAssembly(nil, stubWorkerSessionsFactory, nil)
+	assembly, err := NewAssembly(nil, stubWorkerSessionsFactory, nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "Factory Runtime factory is required") {
 		t.Fatalf("NewAssembly(nil) error = %v, want required dependency", err)
 	}
@@ -174,7 +174,7 @@ func TestNewAssemblyRequiresWireConstructedRuntimeFactory(t *testing.T) {
 
 func TestNewAssemblyRequiresWorkerSessionsFactory(t *testing.T) {
 	runtimeFactory := &RuntimeFactory{}
-	assembly, err := NewAssembly(runtimeFactory, nil, stubWorkersService{})
+	assembly, err := NewAssembly(runtimeFactory, nil, stubWorkersService{}, nil)
 	if err == nil || !strings.Contains(err.Error(), "Worker Sessions factory is required") {
 		t.Fatalf("NewAssembly(nil factory) error = %v, want required dependency", err)
 	}
@@ -185,7 +185,7 @@ func TestNewAssemblyRequiresWorkerSessionsFactory(t *testing.T) {
 
 func TestNewAssemblyRequiresWorkersService(t *testing.T) {
 	runtimeFactory := &RuntimeFactory{}
-	assembly, err := NewAssembly(runtimeFactory, stubWorkerSessionsFactory, nil)
+	assembly, err := NewAssembly(runtimeFactory, stubWorkerSessionsFactory, nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "Workers service is required") {
 		t.Fatalf("NewAssembly(nil Workers service) error = %v, want required dependency", err)
 	}
@@ -197,7 +197,7 @@ func TestNewAssemblyRequiresWorkersService(t *testing.T) {
 func TestNewAssemblyBindsRuntimeFactory(t *testing.T) {
 	runtimeFactory := &RuntimeFactory{}
 	workerService := stubWorkersService{}
-	assembly, err := NewAssembly(runtimeFactory, stubWorkerSessionsFactory, workerService)
+	assembly, err := NewAssembly(runtimeFactory, stubWorkerSessionsFactory, workerService, platformclock.Real{})
 	if err != nil {
 		t.Fatalf("NewAssembly() error = %v", err)
 	}

--- a/pkg/services/factory_runtime/internal/host/lifecycle.go
+++ b/pkg/services/factory_runtime/internal/host/lifecycle.go
@@ -141,13 +141,22 @@ func (h *Handle) LifecycleMetricsOnce() *sync.Once {
 	return &h.lifecycleMetricsOnce
 }
 
-const runtimeMetricsObserverPollInterval = 5 * time.Millisecond
+const (
+	runtimeMetricsObserverPollInterval = 5 * time.Millisecond
+	runtimeMemoryObservationInterval   = 10 * time.Second
+)
 
 type runtimeMetricsObservation struct {
 	runtimeStatus interfaces.RuntimeStatus
 	factoryState  interfaces.FactoryState
 	inFlightCount int
 	initialized   bool
+}
+
+type runtimeMetricsObserver struct {
+	last           runtimeMetricsObservation
+	lastMemoryAt   time.Time
+	memoryObserved bool
 }
 
 // WaitForStart blocks until the hosted runtime reports running readiness or fails early.
@@ -255,33 +264,75 @@ func CloseBundleSinks(logSink factory.RuntimeLogSink, metricsSink factory.Runtim
 // ObserveRuntimeMetrics polls engine snapshots and emits runtime state gauges until the
 // hosted run loop completes or observerCtx is canceled.
 func ObserveRuntimeMetrics(observerCtx context.Context, handle *Handle) {
+	ticker := time.NewTicker(runtimeMetricsObserverPollInterval)
+	defer ticker.Stop()
+	observeRuntimeMetrics(observerCtx, handle, ticker.C, time.Now)
+}
+
+func observeRuntimeMetrics(
+	observerCtx context.Context,
+	handle *Handle,
+	ticks <-chan time.Time,
+	now func() time.Time,
+) {
 	if handle == nil || handle.Bundle == nil || handle.Bundle.Factory == nil {
 		return
 	}
-	ticker := time.NewTicker(runtimeMetricsObserverPollInterval)
-	defer ticker.Stop()
-	var last runtimeMetricsObservation
+	if now == nil {
+		now = time.Now
+	}
+	observer := runtimeMetricsObserver{}
+	observer.observe(handle, now())
 	for {
-		snapshot, err := handle.Bundle.Factory.GetEngineStateSnapshot(context.Background())
-		if err == nil {
-			current := metricsObservationFromSnapshot(snapshot)
-			if current.changedFrom(last) {
-				handle.Bundle.EmitRuntimeStateMetrics(snapshot)
-				last = current
-			}
-		}
 		select {
 		case <-handle.RunDone:
-			finalizeRuntimeLifecycleMetrics(handle, last)
+			finalizeRuntimeLifecycleMetrics(handle, observer.last)
 			return
 		case <-observerCtx.Done():
 			// Temporary sidecar shutdown (for example during session runtime replacement)
 			// must not block on runDone or emit lifecycle stop metrics; Stop finalizes
 			// lifecycle telemetry after the runtime actually exits.
 			return
-		case <-ticker.C:
+		case observedAt, ok := <-ticks:
+			if !ok {
+				return
+			}
+			select {
+			case <-handle.RunDone:
+				finalizeRuntimeLifecycleMetrics(handle, observer.last)
+				return
+			default:
+			}
+			observer.observe(handle, observedAt)
 		}
 	}
+}
+
+func (o *runtimeMetricsObserver) observe(handle *Handle, observedAt time.Time) {
+	if o == nil || handle == nil || handle.Bundle == nil || handle.Bundle.Factory == nil {
+		return
+	}
+	snapshot, err := handle.Bundle.Factory.GetEngineStateSnapshot(context.Background())
+	if err == nil {
+		current := metricsObservationFromSnapshot(snapshot)
+		if current.changedFrom(o.last) {
+			handle.Bundle.EmitRuntimeStateMetrics(snapshot)
+			o.last = current
+		}
+	}
+	o.observeMemory(handle.Bundle, observedAt)
+}
+
+func (o *runtimeMetricsObserver) observeMemory(bundle *Bundle, observedAt time.Time) {
+	if o == nil || bundle == nil {
+		return
+	}
+	if o.memoryObserved && observedAt.Before(o.lastMemoryAt.Add(runtimeMemoryObservationInterval)) {
+		return
+	}
+	bundle.EmitRuntimeMemoryMetrics()
+	o.lastMemoryAt = observedAt
+	o.memoryObserved = true
 }
 
 // RuntimeStopOutcome derives lifecycle-stop labels from the terminal engine snapshot and run error.

--- a/pkg/services/factory_runtime/internal/host/lifecycle.go
+++ b/pkg/services/factory_runtime/internal/host/lifecycle.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri"
@@ -263,40 +264,38 @@ func CloseBundleSinks(logSink factory.RuntimeLogSink, metricsSink factory.Runtim
 
 // ObserveRuntimeMetrics polls engine snapshots and emits runtime state gauges until the
 // hosted run loop completes or observerCtx is canceled.
-func ObserveRuntimeMetrics(observerCtx context.Context, handle *Handle) {
-	ticker := time.NewTicker(runtimeMetricsObserverPollInterval)
-	defer ticker.Stop()
-	observeRuntimeMetrics(observerCtx, handle, ticker.C, time.Now)
+func ObserveRuntimeMetrics(
+	observerCtx context.Context,
+	handle *Handle,
+	clock platformclock.TimerSource,
+) {
+	observeRuntimeMetrics(observerCtx, handle, clock)
 }
 
 func observeRuntimeMetrics(
 	observerCtx context.Context,
 	handle *Handle,
-	ticks <-chan time.Time,
-	now func() time.Time,
+	clock platformclock.TimerSource,
 ) {
-	if handle == nil || handle.Bundle == nil || handle.Bundle.Factory == nil {
+	if handle == nil || handle.Bundle == nil || handle.Bundle.Factory == nil || clock == nil {
 		return
 	}
-	if now == nil {
-		now = time.Now
-	}
 	observer := runtimeMetricsObserver{}
-	observer.observe(handle, now())
+	observer.observe(handle, clock.Now())
 	for {
+		timer := clock.NewTimer(runtimeMetricsObserverPollInterval)
 		select {
 		case <-handle.RunDone:
+			timer.Stop()
 			finalizeRuntimeLifecycleMetrics(handle, observer.last)
 			return
 		case <-observerCtx.Done():
+			timer.Stop()
 			// Temporary sidecar shutdown (for example during session runtime replacement)
 			// must not block on runDone or emit lifecycle stop metrics; Stop finalizes
 			// lifecycle telemetry after the runtime actually exits.
 			return
-		case observedAt, ok := <-ticks:
-			if !ok {
-				return
-			}
+		case observedAt := <-timer.C():
 			select {
 			case <-handle.RunDone:
 				finalizeRuntimeLifecycleMetrics(handle, observer.last)

--- a/pkg/services/factory_runtime/internal/host/lifecycle_memory_test.go
+++ b/pkg/services/factory_runtime/internal/host/lifecycle_memory_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	"github.com/portpowered/infinite-you/pkg/services/work"
@@ -47,13 +48,11 @@ func TestObserveRuntimeMetricsStopsMemorySamplingWithRunLifecycle(t *testing.T) 
 		Bundle:  &Bundle{Factory: engine, MetricsSink: sink},
 		RunDone: make(chan struct{}),
 	}
-	ticks := make(chan time.Time, 1)
+	clock := platformclock.NewDeterministic(time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC), time.Millisecond)
 	observerDone := make(chan struct{})
 	go func() {
 		defer close(observerDone)
-		observeRuntimeMetrics(context.Background(), handle, ticks, func() time.Time {
-			return time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
-		})
+		observeRuntimeMetrics(context.Background(), handle, clock)
 	}()
 
 	select {
@@ -69,7 +68,6 @@ func TestObserveRuntimeMetricsStopsMemorySamplingWithRunLifecycle(t *testing.T) 
 	}
 
 	sampleCount := len(sink.samples)
-	ticks <- time.Date(2026, 8, 23, 12, 0, 1, 0, time.UTC)
 	if got := len(sink.samples); got != sampleCount {
 		t.Fatalf("memory samples after observer stop = %d, want %d", got, sampleCount)
 	}

--- a/pkg/services/factory_runtime/internal/host/lifecycle_memory_test.go
+++ b/pkg/services/factory_runtime/internal/host/lifecycle_memory_test.go
@@ -1,0 +1,164 @@
+package host
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+)
+
+func TestRuntimeMetricsObserverSamplesMemoryAtExistingCadence(t *testing.T) {
+	t.Parallel()
+
+	sink := &runtimeMemoryTestSink{}
+	observer := runtimeMetricsObserver{}
+	bundle := &Bundle{MetricsSink: sink}
+	start := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+
+	observer.observeMemory(bundle, start)
+	if got := len(sink.samples); got != 7 {
+		t.Fatalf("initial memory samples = %d, want 7", got)
+	}
+	observer.observeMemory(bundle, start.Add(runtimeMemoryObservationInterval-time.Nanosecond))
+	if got := len(sink.samples); got != 7 {
+		t.Fatalf("memory samples before cadence = %d, want 7", got)
+	}
+	observer.observeMemory(bundle, start.Add(runtimeMemoryObservationInterval))
+	if got := len(sink.samples); got != 14 {
+		t.Fatalf("memory samples at cadence = %d, want 14", got)
+	}
+}
+
+func TestObserveRuntimeMetricsStopsMemorySamplingWithRunLifecycle(t *testing.T) {
+	t.Parallel()
+
+	sink := &runtimeMemoryTestSink{samplesReady: make(chan struct{})}
+	engine := &runtimeMetricsTestEngine{
+		snapshot: &interfaces.EngineStateSnapshot[factoryruntime.PetriMarkingSnapshot, *factoryruntime.RuntimeNet]{
+			RuntimeStatus: interfaces.RuntimeStatusActive,
+			FactoryState:  string(interfaces.FactoryStateRunning),
+		},
+	}
+	handle := &Handle{
+		Bundle:  &Bundle{Factory: engine, MetricsSink: sink},
+		RunDone: make(chan struct{}),
+	}
+	ticks := make(chan time.Time, 1)
+	observerDone := make(chan struct{})
+	go func() {
+		defer close(observerDone)
+		observeRuntimeMetrics(context.Background(), handle, ticks, func() time.Time {
+			return time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+		})
+	}()
+
+	select {
+	case <-sink.samplesReady:
+	case <-time.After(time.Second):
+		t.Fatal("observer did not emit its initial memory samples")
+	}
+	close(handle.RunDone)
+	select {
+	case <-observerDone:
+	case <-time.After(time.Second):
+		t.Fatal("observer did not stop with the runtime lifecycle")
+	}
+
+	sampleCount := len(sink.samples)
+	ticks <- time.Date(2026, 8, 23, 12, 0, 1, 0, time.UTC)
+	if got := len(sink.samples); got != sampleCount {
+		t.Fatalf("memory samples after observer stop = %d, want %d", got, sampleCount)
+	}
+}
+
+type runtimeMemoryTestSink struct {
+	mu           sync.Mutex
+	samples      []string
+	samplesReady chan struct{}
+	readyOnce    sync.Once
+}
+
+func (*runtimeMemoryTestSink) Counter(context.Context, string, float64, factoryruntime.Fields) error {
+	return nil
+}
+
+func (*runtimeMemoryTestSink) Gauge(context.Context, string, float64, factoryruntime.Fields) error {
+	return nil
+}
+
+func (sink *runtimeMemoryTestSink) Sample(
+	_ context.Context,
+	name string,
+	_ float64,
+	_ string,
+	_ factoryruntime.Fields,
+) error {
+	sink.mu.Lock()
+	sink.samples = append(sink.samples, name)
+	ready := len(sink.samples) == 7
+	sink.mu.Unlock()
+	if ready && sink.samplesReady != nil {
+		sink.readyOnce.Do(func() { close(sink.samplesReady) })
+	}
+	return nil
+}
+
+func (*runtimeMemoryTestSink) Close() error { return nil }
+func (*runtimeMemoryTestSink) Path() string { return "memory://runtime-metrics" }
+func (*runtimeMemoryTestSink) Artifact() factoryruntime.RuntimeMetricsArtifact {
+	return factoryruntime.RuntimeMetricsArtifact{Path: "memory://runtime-metrics"}
+}
+
+type runtimeMetricsTestEngine struct {
+	snapshot *interfaces.EngineStateSnapshot[factoryruntime.PetriMarkingSnapshot, *factoryruntime.RuntimeNet]
+}
+
+func (*runtimeMetricsTestEngine) SubmitWorkRequest(
+	context.Context,
+	work.WorkRequest,
+) (work.WorkRequestSubmitResult, error) {
+	return work.WorkRequestSubmitResult{}, nil
+}
+
+func (*runtimeMetricsTestEngine) SubscribeFactoryEvents(
+	context.Context,
+	*interfaces.FactoryEventReconnectCursor,
+	interfaces.FactoryEventReconnectScope,
+) (*interfaces.FactoryEventStream, error) {
+	return &interfaces.FactoryEventStream{Events: make(chan interfaces.FactoryEvent)}, nil
+}
+
+func (engine *runtimeMetricsTestEngine) GetEngineStateSnapshot(
+	context.Context,
+) (*interfaces.EngineStateSnapshot[factoryruntime.PetriMarkingSnapshot, *factoryruntime.RuntimeNet], error) {
+	return engine.snapshot, nil
+}
+
+func (*runtimeMetricsTestEngine) MoveWork(
+	context.Context,
+	string,
+	string,
+	work.WorkStateChangeSource,
+	string,
+) (work.OperatorMoveResult, error) {
+	return work.OperatorMoveResult{}, nil
+}
+
+func (*runtimeMetricsTestEngine) Pause(context.Context) error  { return nil }
+func (*runtimeMetricsTestEngine) Resume(context.Context) error { return nil }
+func (*runtimeMetricsTestEngine) GetFactoryEvents(context.Context) ([]interfaces.FactoryEvent, error) {
+	return nil, nil
+}
+func (*runtimeMetricsTestEngine) WaitToComplete() <-chan struct{} {
+	completed := make(chan struct{})
+	close(completed)
+	return completed
+}
+func (*runtimeMetricsTestEngine) Run(context.Context) error { return nil }
+
+var _ Engine = (*runtimeMetricsTestEngine)(nil)
+var _ factoryruntime.RuntimeMetricsSink = (*runtimeMemoryTestSink)(nil)

--- a/pkg/services/factory_runtime/internal/host/lifecycle_test.go
+++ b/pkg/services/factory_runtime/internal/host/lifecycle_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/work"
 
 	"github.com/jonboulle/clockwork"
+	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factoryhost "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/host"
@@ -369,7 +370,7 @@ func TestStop_EmitsCompletedLifecycleMetricWithoutRootService(t *testing.T) {
 
 	observerCtx, cancelObserver := context.WithCancel(runCtx)
 	defer cancelObserver()
-	go factoryhost.ObserveRuntimeMetrics(observerCtx, handle)
+	go factoryhost.ObserveRuntimeMetrics(observerCtx, handle, platformclock.Real{})
 
 	handle.SetRunResult(nil)
 	if err := factoryhost.Stop(handle, clockwork.NewFakeClock()); err != nil {

--- a/pkg/services/factory_runtime/internal/host/metrics.go
+++ b/pkg/services/factory_runtime/internal/host/metrics.go
@@ -3,10 +3,13 @@ package host
 import (
 	"context"
 	"encoding/json"
+	"runtime"
 	"strconv"
 	"strings"
 
+	platformprocessmemory "github.com/portpowered/infinite-you/pkg/platform/processmemory"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/metrics"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/state"
@@ -42,6 +45,9 @@ const (
 	runtimeMetricScriptDuration             = "script.duration"
 	runtimeMetricScriptTimedOut             = "script.timed_out"
 	runtimeMetricScriptFailed               = "script.failed"
+	runtimeMemoryUnitBytes                  = "bytes"
+	runtimeMemoryUnitCount                  = "count"
+	runtimeMemoryUnitBoolean                = "boolean"
 )
 
 func (r *Bundle) RecordSubmissionMetric(record work.FactorySubmissionRecord) {
@@ -401,4 +407,54 @@ func (r *Bundle) EmitRuntimeStateMetrics(snapshot *interfaces.EngineStateSnapsho
 	r.emitMetricGauge(runtimeMetricStatePaused, boolMetricValue(snapshot.FactoryState == string(interfaces.FactoryStatePaused)), metrics.Fields{})
 	r.emitMetricGauge(runtimeMetricStateFailed, boolMetricValue(snapshot.FactoryState == string(interfaces.FactoryStateFailed)), metrics.Fields{})
 	r.emitMetricGauge(runtimeMetricQueueInFlight, float64(snapshot.InFlightCount), metrics.Fields{})
+}
+
+// EmitRuntimeMemoryMetrics records one point-in-time runtime observation on
+// the bundle's existing runtime metrics sink. The Go memory fields and the
+// process-commit result are collected before any record is emitted, so all
+// fields describe one observer pass.
+func (r *Bundle) EmitRuntimeMemoryMetrics() {
+	if r == nil {
+		return
+	}
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	commitBytes, commitErr := platformprocessmemory.CurrentCommit()
+	r.emitRuntimeMemoryStats(runtimeMemoryStats{
+		heapAlloc:              stats.HeapAlloc,
+		heapInuse:              stats.HeapInuse,
+		sys:                    stats.Sys,
+		numGC:                  stats.NumGC,
+		goroutines:             runtime.NumGoroutine(),
+		processCommit:          commitBytes,
+		processCommitAvailable: commitErr == nil && commitBytes > 0,
+	})
+}
+
+type runtimeMemoryStats struct {
+	heapAlloc              uint64
+	heapInuse              uint64
+	sys                    uint64
+	numGC                  uint32
+	goroutines             int
+	processCommit          uint64
+	processCommitAvailable bool
+}
+
+func (r *Bundle) emitRuntimeMemoryStats(stats runtimeMemoryStats) {
+	if r == nil {
+		return
+	}
+	fields := metrics.Fields{}
+	r.emitMetricSample(factoryruntime.RuntimeMemoryHeapAlloc, float64(stats.heapAlloc), runtimeMemoryUnitBytes, fields)
+	r.emitMetricSample(factoryruntime.RuntimeMemoryHeapInuse, float64(stats.heapInuse), runtimeMemoryUnitBytes, fields)
+	r.emitMetricSample(factoryruntime.RuntimeMemorySys, float64(stats.sys), runtimeMemoryUnitBytes, fields)
+	r.emitMetricSample(factoryruntime.RuntimeMemoryNumGC, float64(stats.numGC), runtimeMemoryUnitCount, fields)
+	r.emitMetricSample(factoryruntime.RuntimeMemoryGoroutines, float64(stats.goroutines), runtimeMemoryUnitCount, fields)
+	r.emitMetricSample(factoryruntime.RuntimeMemoryProcessCommit, float64(stats.processCommit), runtimeMemoryUnitBytes, fields)
+	commitAvailable := 0.0
+	if stats.processCommitAvailable {
+		commitAvailable = 1
+	}
+	r.emitMetricSample(factoryruntime.RuntimeMemoryProcessCommitAvailable, commitAvailable, runtimeMemoryUnitBoolean, fields)
 }

--- a/pkg/services/factory_runtime/internal/host/metrics_test.go
+++ b/pkg/services/factory_runtime/internal/host/metrics_test.go
@@ -3,6 +3,7 @@ package host_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -12,6 +13,105 @@ import (
 	factoryhost "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/host"
 	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
 )
+
+func TestEmitRuntimeMemoryMetricsRecordsOneCoherentRuntimeSnapshot(t *testing.T) {
+	t.Parallel()
+
+	sink := &hostMetricsSinkFake{}
+	bundle := &factoryhost.Bundle{MetricsSink: sink}
+	bundle.EmitRuntimeMemoryMetrics()
+
+	values, units := runtimeMemorySinkRecords(t, sink)
+	assertRuntimeMemoryUnits(t, units)
+	assertRuntimeMemoryValues(t, values)
+}
+
+func runtimeMemorySinkRecords(t *testing.T, sink *hostMetricsSinkFake) (map[string]float64, map[string]string) {
+	t.Helper()
+	if len(sink.names) != 7 {
+		t.Fatalf("runtime memory metric count = %d, want 7; names = %#v", len(sink.names), sink.names)
+	}
+	values := make(map[string]float64, len(sink.names))
+	units := make(map[string]string, len(sink.names))
+	for index, name := range sink.names {
+		if sink.kinds[index] != factoryruntime.RuntimeMetricTypeSample {
+			t.Fatalf("metric %s type = %q, want sample", name, sink.kinds[index])
+		}
+		values[name] = sink.values[index]
+		units[name] = sink.units[index]
+	}
+	for _, name := range runtimeMemoryMetricNames() {
+		if _, ok := values[name]; !ok {
+			t.Fatalf("runtime memory metric %q was not emitted; values = %#v", name, values)
+		}
+	}
+	return values, units
+}
+
+func runtimeMemoryMetricNames() []string {
+	return []string{
+		factoryruntime.RuntimeMemoryHeapAlloc,
+		factoryruntime.RuntimeMemoryHeapInuse,
+		factoryruntime.RuntimeMemorySys,
+		factoryruntime.RuntimeMemoryNumGC,
+		factoryruntime.RuntimeMemoryGoroutines,
+		factoryruntime.RuntimeMemoryProcessCommit,
+		factoryruntime.RuntimeMemoryProcessCommitAvailable,
+	}
+}
+
+func assertRuntimeMemoryUnits(t *testing.T, units map[string]string) {
+	t.Helper()
+	want := map[string]string{
+		factoryruntime.RuntimeMemoryHeapAlloc:              "bytes",
+		factoryruntime.RuntimeMemoryHeapInuse:              "bytes",
+		factoryruntime.RuntimeMemorySys:                    "bytes",
+		factoryruntime.RuntimeMemoryNumGC:                  "count",
+		factoryruntime.RuntimeMemoryGoroutines:             "count",
+		factoryruntime.RuntimeMemoryProcessCommit:          "bytes",
+		factoryruntime.RuntimeMemoryProcessCommitAvailable: "boolean",
+	}
+	for name, unit := range want {
+		if units[name] != unit {
+			t.Fatalf("runtime memory unit for %s = %q, want %q", name, units[name], unit)
+		}
+	}
+}
+
+func assertRuntimeMemoryValues(t *testing.T, values map[string]float64) {
+	t.Helper()
+	heapAlloc := values[factoryruntime.RuntimeMemoryHeapAlloc]
+	heapInuse := values[factoryruntime.RuntimeMemoryHeapInuse]
+	sys := values[factoryruntime.RuntimeMemorySys]
+	if heapAlloc <= 0 || heapInuse < heapAlloc || sys < heapInuse {
+		t.Fatalf("runtime memory heap values = alloc:%v inuse:%v sys:%v, want positive and ordered", heapAlloc, heapInuse, sys)
+	}
+	if values[factoryruntime.RuntimeMemoryNumGC] < 0 {
+		t.Fatalf("NumGC metric = %v, want a non-negative value", values[factoryruntime.RuntimeMemoryNumGC])
+	}
+	if values[factoryruntime.RuntimeMemoryGoroutines] <= 0 {
+		t.Fatalf("Goroutines metric = %v, want a positive value", values[factoryruntime.RuntimeMemoryGoroutines])
+	}
+	commitAvailable := values[factoryruntime.RuntimeMemoryProcessCommitAvailable]
+	if commitAvailable != 0 && commitAvailable != 1 {
+		t.Fatalf("ProcessCommitAvailable metric = %v, want 0 or 1", commitAvailable)
+	}
+	if commitAvailable == 1 && values[factoryruntime.RuntimeMemoryProcessCommit] <= 0 {
+		t.Fatalf("ProcessCommit metric = %v, want positive when available", values[factoryruntime.RuntimeMemoryProcessCommit])
+	}
+}
+
+func TestEmitRuntimeMemoryMetricsKeepsExistingSinkFailurePolicy(t *testing.T) {
+	t.Parallel()
+
+	sink := &hostMetricsSinkFake{sampleErr: errors.New("sink unavailable")}
+	bundle := &factoryhost.Bundle{MetricsSink: sink}
+	bundle.EmitRuntimeMemoryMetrics()
+
+	if sink.sampleCalls != 7 {
+		t.Fatalf("runtime memory sample attempts = %d, want 7 despite sink errors", sink.sampleCalls)
+	}
+}
 
 func TestScriptMetricHelpers_PreferFailureMetadataAndDiagnostics(t *testing.T) {
 	t.Parallel()
@@ -148,26 +248,41 @@ func TestRecordCompletionMetricsDoesNotPersistUnresolvedProvider(t *testing.T) {
 }
 
 type hostMetricsSinkFake struct {
-	names  []string
-	fields []factoryruntime.Fields
+	names       []string
+	kinds       []string
+	values      []float64
+	units       []string
+	fields      []factoryruntime.Fields
+	sampleErr   error
+	sampleCalls int
 }
 
-func (sink *hostMetricsSinkFake) Counter(_ context.Context, name string, _ float64, fields factoryruntime.Fields) error {
+func (sink *hostMetricsSinkFake) Counter(_ context.Context, name string, value float64, fields factoryruntime.Fields) error {
 	sink.names = append(sink.names, name)
+	sink.kinds = append(sink.kinds, factoryruntime.RuntimeMetricTypeCounter)
+	sink.values = append(sink.values, value)
+	sink.units = append(sink.units, "")
 	sink.fields = append(sink.fields, fields)
 	return nil
 }
 
-func (sink *hostMetricsSinkFake) Gauge(_ context.Context, name string, _ float64, fields factoryruntime.Fields) error {
+func (sink *hostMetricsSinkFake) Gauge(_ context.Context, name string, value float64, fields factoryruntime.Fields) error {
 	sink.names = append(sink.names, name)
+	sink.kinds = append(sink.kinds, factoryruntime.RuntimeMetricTypeGauge)
+	sink.values = append(sink.values, value)
+	sink.units = append(sink.units, "")
 	sink.fields = append(sink.fields, fields)
 	return nil
 }
 
-func (sink *hostMetricsSinkFake) Sample(_ context.Context, name string, _ float64, _ string, fields factoryruntime.Fields) error {
+func (sink *hostMetricsSinkFake) Sample(_ context.Context, name string, value float64, unit string, fields factoryruntime.Fields) error {
+	sink.sampleCalls++
 	sink.names = append(sink.names, name)
+	sink.kinds = append(sink.kinds, factoryruntime.RuntimeMetricTypeSample)
+	sink.values = append(sink.values, value)
+	sink.units = append(sink.units, unit)
 	sink.fields = append(sink.fields, fields)
-	return nil
+	return sink.sampleErr
 }
 
 func (sink *hostMetricsSinkFake) Close() error { return nil }

--- a/pkg/services/factory_runtime/internal/services/instance_host/internal/service/terminate_test.go
+++ b/pkg/services/factory_runtime/internal/services/instance_host/internal/service/terminate_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
+	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factoryhost "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/host"
@@ -292,7 +293,7 @@ func TestStopEmitsLifecycleStopMetricOnce(t *testing.T) {
 
 	observerCtx, cancelObserver := context.WithCancel(runCtx)
 	defer cancelObserver()
-	go factoryhost.ObserveRuntimeMetrics(observerCtx, handle)
+	go factoryhost.ObserveRuntimeMetrics(observerCtx, handle, platformclock.Real{})
 
 	handle.SetRunResult(nil)
 	if err := host.Stop(handle); err != nil {
@@ -339,7 +340,7 @@ func TestReplacementSidecarShutdownDoesNotEmitFalseTerminalStop(t *testing.T) {
 	t.Cleanup(runCancel)
 	observerCtx, cancelObserver := context.WithCancel(runCtx)
 	defer cancelObserver()
-	go factoryhost.ObserveRuntimeMetrics(observerCtx, current)
+	go factoryhost.ObserveRuntimeMetrics(observerCtx, current, platformclock.Real{})
 
 	replacementFactory := newLifecycleControlFactory(interfaces.FactoryStateRunning)
 	replacementBundle := testBundle(replacementFactory, "runtime-terminate-replace-sidecar-next")

--- a/pkg/services/factory_runtime/internal/sidecars.go
+++ b/pkg/services/factory_runtime/internal/sidecars.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"sync"
 
+	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
 	"github.com/portpowered/infinite-you/pkg/services/automations"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/factory_runtime"
@@ -21,8 +22,9 @@ import (
 // automation. Initializer decides when to start it; Factory Runtime owns what
 // starting it means.
 type RuntimeSidecars struct {
-	automation automations.Service
-	enabled    bool
+	automation   automations.Service
+	enabled      bool
+	metricsClock platformclock.TimerSource
 }
 
 // runtimeAutomationService is the optional runtime-owned capability set
@@ -76,8 +78,14 @@ func PreseedRuntimeInputs(ctx context.Context, automation automations.Service, b
 	return nil
 }
 
-func NewRuntimeSidecars(automation automations.Service, enabled bool) *RuntimeSidecars {
-	return &RuntimeSidecars{automation: automation, enabled: enabled}
+func NewRuntimeSidecars(
+	automation automations.Service,
+	enabled bool,
+	metricsClock platformclock.TimerSource,
+) *RuntimeSidecars {
+	return &RuntimeSidecars{
+		automation: automation, enabled: enabled, metricsClock: metricsClock,
+	}
 }
 
 func (s *RuntimeSidecars) Preseed(ctx context.Context, instance factory.RuntimeRecord) error {
@@ -187,7 +195,7 @@ func (s *RuntimeSidecars) Start(ctx context.Context, hosted factory.RuntimeRun) 
 	handle.Sidecars.Add(1)
 	go func() {
 		defer handle.Sidecars.Done()
-		factoryhost.ObserveRuntimeMetrics(sidecarCtx, handle)
+		factoryhost.ObserveRuntimeMetrics(sidecarCtx, handle, s.metricsClock)
 	}()
 	return nil
 }

--- a/pkg/services/factory_runtime/metric_names.go
+++ b/pkg/services/factory_runtime/metric_names.go
@@ -2,13 +2,24 @@ package factory
 
 // Canonical Factory Runtime metric names.
 const (
-	RuntimeLifecycleStarted     = "runtime.lifecycle.started"
-	RuntimeLifecycleStopped     = "runtime.lifecycle.stopped"
-	RuntimeStateActive          = "runtime.state.active"
-	RuntimeStateIdle            = "runtime.state.idle"
-	RuntimeStatePaused          = "runtime.state.paused"
-	RuntimeStateFailed          = "runtime.state.failed"
-	RuntimeQueueInFlight        = "runtime.queue.in_flight"
+	RuntimeLifecycleStarted             = "runtime.lifecycle.started"
+	RuntimeLifecycleStopped             = "runtime.lifecycle.stopped"
+	RuntimeStateActive                  = "runtime.state.active"
+	RuntimeStateIdle                    = "runtime.state.idle"
+	RuntimeStatePaused                  = "runtime.state.paused"
+	RuntimeStateFailed                  = "runtime.state.failed"
+	RuntimeQueueInFlight                = "runtime.queue.in_flight"
+	RuntimeMemoryHeapAlloc              = "runtime.memory.heap_alloc"
+	RuntimeMemoryHeapInuse              = "runtime.memory.heap_inuse"
+	RuntimeMemorySys                    = "runtime.memory.sys"
+	RuntimeMemoryNumGC                  = "runtime.memory.num_gc"
+	RuntimeMemoryGoroutines             = "runtime.memory.goroutines"
+	RuntimeMemoryProcessCommit          = "runtime.memory.process_commit"
+	RuntimeMemoryProcessCommitAvailable = "runtime.memory.process_commit_available"
+	// RuntimeMemoryHeapSys is retained as a source-compatible name for callers
+	// that used the initial HeapSys wording. The runtime snapshot's
+	// corresponding field is the Go MemStats Sys value.
+	RuntimeMemoryHeapSys        = RuntimeMemorySys
 	RuntimeQueueSubmissionCount = "queue.submission_count"
 	RuntimeDispatchStarted      = "dispatch.started"
 	RuntimeDispatchComplete     = "dispatch.completed"

--- a/pkg/services/factory_runtime/wire/assembly.go
+++ b/pkg/services/factory_runtime/wire/assembly.go
@@ -3,6 +3,7 @@ package wire
 import (
 	"io/fs"
 
+	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factoryruntimeinternal "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal"
@@ -74,8 +75,9 @@ func NewAssembly(
 	runtimeFactory *RuntimeFactory,
 	workerSessionsFactory factoryruntime.WorkerSessionsFactory,
 	workerService workers.Service,
+	metricsClock platformclock.TimerSource,
 ) (*Assembly, error) {
-	return factoryruntimeinternal.NewAssembly(runtimeFactory, workerSessionsFactory, workerService)
+	return factoryruntimeinternal.NewAssembly(runtimeFactory, workerSessionsFactory, workerService, metricsClock)
 }
 
 // NewOrchestratorDefinitionValidator returns the runtime-owned orchestrator

--- a/pkg/transports/cli/run/api_server.go
+++ b/pkg/transports/cli/run/api_server.go
@@ -10,5 +10,5 @@ import (
 // to one process-owned listener. The listener is consumed at most once and the
 // normal API server remains responsible for serving and closing it.
 func APIServerStarterWithListener(listener net.Listener) platformhttpserver.Starter {
-	return platformhttpserver.StarterWithListener(listener)
+	return platformhttpserver.StarterWithListener(listener, nil, nil)
 }

--- a/pkg/wire/http_host_test.go
+++ b/pkg/wire/http_host_test.go
@@ -38,7 +38,7 @@ func TestProvideAPIServerStarterHonorsRootEdgeOverride(t *testing.T) {
 		}
 		return nil
 	})
-	starter, err := provideAPIServerStarter(serviceedges.Edges{APIServerStarter: override})
+	starter, err := provideAPIServerStarter(serviceedges.Edges{APIServerStarter: override}, nil)
 	if err != nil {
 		t.Fatalf("provideAPIServerStarter: %v", err)
 	}

--- a/pkg/wire/profiles.go
+++ b/pkg/wire/profiles.go
@@ -449,15 +449,31 @@ func provideFactoryRuntimeClockResolver() factoryruntime.ClockResolver {
 	}
 }
 
+func provideFactoryRuntimeMetricsClock(edges serviceedges.Edges) platformclock.TimerSource {
+	if clock, ok := edges.Clock.(platformclock.TimerSource); ok {
+		return clock
+	}
+	return platformclock.Real{}
+}
+
+func providePprofCommandLineReader() platformhttpserver.CommandLineReader {
+	return func() []string {
+		return append([]string(nil), os.Args...)
+	}
+}
+
 func provideFactoryRuntimeSessionLoggerFactory() factoryruntime.SessionLoggerFactory {
 	return factoryruntime.NewSessionLogger
 }
 
-func provideAPIServerStarter(edges serviceedges.Edges) (platformhttpserver.Starter, error) {
+func provideAPIServerStarter(
+	edges serviceedges.Edges,
+	commandLineReader platformhttpserver.CommandLineReader,
+) (platformhttpserver.Starter, error) {
 	if edges.APIServerStarter != nil {
 		return edges.APIServerStarter, nil
 	}
-	return platformhttpserver.NewStarter(net.Listen, platformprocessmemory.CurrentCommit)
+	return platformhttpserver.NewStarter(net.Listen, platformprocessmemory.CurrentCommit, commandLineReader)
 }
 
 func provideRuntimeHostOperation(

--- a/pkg/wire/wire.go
+++ b/pkg/wire/wire.go
@@ -206,6 +206,8 @@ var servicesSet = wire.NewSet(
 	provideFactoryDefinitionLoader,
 	provideFactoryRuntimeClockResolver,
 	provideFactoryRuntimeClock,
+	provideFactoryRuntimeMetricsClock,
+	providePprofCommandLineReader,
 	provideFactoryRuntimeProviderOverride,
 	provideFactoryRuntimeSubmissionRecorder,
 	provideFactoryRuntimeDispatchRecorder,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -228,7 +228,8 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	v20, err := wire2.NewAssembly(v14, workerSessionsFactory, workersService)
+	timerSource := provideFactoryRuntimeMetricsClock(edges2)
+	v20, err := wire2.NewAssembly(v14, workerSessionsFactory, workersService, timerSource)
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +342,8 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	factoryScaffoldInitializer := provideFactoryScaffoldInitializer(v47)
 	v48 := provideDefinitionValidationOperation(validationOperations)
 	editableFactoryValidator := provideEditableFactoryValidator(v48, v29)
-	starter, err := provideAPIServerStarter(edges2)
+	commandLineReader := providePprofCommandLineReader()
+	starter, err := provideAPIServerStarter(edges2, commandLineReader)
 	if err != nil {
 		return nil, err
 	}
@@ -999,6 +1001,8 @@ var servicesSet = wire5.NewSet(
 	provideFactoryDefinitionLoader,
 	provideFactoryRuntimeClockResolver,
 	provideFactoryRuntimeClock,
+	provideFactoryRuntimeMetricsClock,
+	providePprofCommandLineReader,
 	provideFactoryRuntimeProviderOverride,
 	provideFactoryRuntimeSubmissionRecorder,
 	provideFactoryRuntimeDispatchRecorder,

--- a/tests/functional/cli/root_discovery/root_discovery_test.go
+++ b/tests/functional/cli/root_discovery/root_discovery_test.go
@@ -355,7 +355,7 @@ func TestServerBindExhaustionWritesDeclaredErrorWithoutResidualEffects(t *testin
 	starter, err := platformhttpserver.NewStarter(func(_ string, address string) (net.Listener, error) {
 		attempts = append(attempts, address)
 		return nil, errors.New("address unavailable")
-	})
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("NewStarter() error = %v", err)
 	}

--- a/tests/functional/internal/support/process_api_server.go
+++ b/tests/functional/internal/support/process_api_server.go
@@ -76,7 +76,7 @@ func (server *ProcessAPIServer) Start(
 	server.started = true
 	close(server.startedSignal)
 	httpServer := httptest.NewServer(platformhttpserver.HandlerWithDiagnostics(
-		request.Handler, request.Pprof, platformprocessmemory.CurrentCommit,
+		request.Handler, request.Pprof, platformprocessmemory.CurrentCommit, nil,
 	))
 	server.url = httpServer.URL
 	if request.OnBound != nil {

--- a/tests/functional/transport/http/server/startup_shutdown_test.go
+++ b/tests/functional/transport/http/server/startup_shutdown_test.go
@@ -39,15 +39,30 @@ func TestAPIServerPprofIsOptInThroughThePublicRunPath(t *testing.T) {
 	for _, path := range []string{
 		"/debug/pprof/", "/debug/pprof/heap", "/debug/pprof/profile",
 		"/debug/pprof/trace", "/debug/pprof/goroutine", "/debug/pprof/cmdline",
-		"/debug/pprof/symbol",
+		"/debug/pprof/symbol", "/debug/vars",
 	} {
 		response, err := http.Get(defaultServer.URL() + path)
 		if err != nil {
 			t.Fatalf("default GET %s: %v", path, err)
 		}
+		body, err := io.ReadAll(response.Body)
 		_ = response.Body.Close()
+		if err != nil {
+			t.Fatalf("read default GET %s: %v", path, err)
+		}
 		if response.StatusCode != http.StatusNotFound {
 			t.Fatalf("default GET %s status = %d, want %d", path, response.StatusCode, http.StatusNotFound)
+		}
+		if path != "/debug/pprof/heap" {
+			continue
+		}
+		var notFound factoryapi.ErrorResponse
+		if err := json.Unmarshal(body, &notFound); err != nil {
+			t.Fatalf("decode default GET %s error response: %v; body=%q", path, err, body)
+		}
+		if notFound.Code != factoryapi.ErrorResponseCode("NOT_FOUND") ||
+			notFound.Family != factoryapi.ErrorFamily("NOT_FOUND") {
+			t.Fatalf("default GET %s error response = %+v, want NOT_FOUND JSON", path, notFound)
 		}
 	}
 	runtimeSnapshot := support.GetJSON[platformhttpserver.RuntimeSnapshot](t, defaultServer.URL()+"/debug/runtime")

--- a/tests/functional/transport/http/server/startup_shutdown_test.go
+++ b/tests/functional/transport/http/server/startup_shutdown_test.go
@@ -21,7 +21,6 @@ import (
 	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
 	platformmetrics "github.com/portpowered/infinite-you/pkg/platform/metrics"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
-	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
@@ -183,27 +182,27 @@ func assertRuntimeMemoryMetrics(t *testing.T, root string) {
 		}
 		values[name] = value
 		units[name], _ = record["unit"].(string)
-		if metricType, _ := record["metric_type"].(string); metricType != factoryruntime.RuntimeMetricTypeSample {
+		if metricType, _ := record["metric_type"].(string); metricType != "sample" {
 			t.Fatalf("runtime memory metric %q type = %q, want sample", name, metricType)
 		}
 	}
-	heapAlloc, allocOK := values[factoryruntime.RuntimeMemoryHeapAlloc]
-	heapInuse, inuseOK := values[factoryruntime.RuntimeMemoryHeapInuse]
-	sys, sysOK := values[factoryruntime.RuntimeMemorySys]
-	numGC, gcOK := values[factoryruntime.RuntimeMemoryNumGC]
-	goroutines, goroutinesOK := values[factoryruntime.RuntimeMemoryGoroutines]
-	processCommit, commitOK := values[factoryruntime.RuntimeMemoryProcessCommit]
-	processCommitAvailable, commitAvailableOK := values[factoryruntime.RuntimeMemoryProcessCommitAvailable]
+	heapAlloc, allocOK := values["runtime.memory.heap_alloc"]
+	heapInuse, inuseOK := values["runtime.memory.heap_inuse"]
+	sys, sysOK := values["runtime.memory.sys"]
+	numGC, gcOK := values["runtime.memory.num_gc"]
+	goroutines, goroutinesOK := values["runtime.memory.goroutines"]
+	processCommit, commitOK := values["runtime.memory.process_commit"]
+	processCommitAvailable, commitAvailableOK := values["runtime.memory.process_commit_available"]
 	if !allocOK || !inuseOK || !sysOK || !gcOK || !goroutinesOK || !commitOK || !commitAvailableOK {
 		t.Fatalf("runtime memory records = %#v, want the complete runtime snapshot metric set", values)
 	}
-	if units[factoryruntime.RuntimeMemoryHeapAlloc] != "bytes" ||
-		units[factoryruntime.RuntimeMemoryHeapInuse] != "bytes" ||
-		units[factoryruntime.RuntimeMemorySys] != "bytes" ||
-		units[factoryruntime.RuntimeMemoryNumGC] != "count" ||
-		units[factoryruntime.RuntimeMemoryGoroutines] != "count" ||
-		units[factoryruntime.RuntimeMemoryProcessCommit] != "bytes" ||
-		units[factoryruntime.RuntimeMemoryProcessCommitAvailable] != "boolean" {
+	if units["runtime.memory.heap_alloc"] != "bytes" ||
+		units["runtime.memory.heap_inuse"] != "bytes" ||
+		units["runtime.memory.sys"] != "bytes" ||
+		units["runtime.memory.num_gc"] != "count" ||
+		units["runtime.memory.goroutines"] != "count" ||
+		units["runtime.memory.process_commit"] != "bytes" ||
+		units["runtime.memory.process_commit_available"] != "boolean" {
 		t.Fatalf("runtime memory units = %#v, want bytes/count/boolean fields", units)
 	}
 	if heapAlloc <= 0 || heapInuse < heapAlloc || sys < heapInuse || numGC < 0 || goroutines <= 0 {
@@ -219,13 +218,13 @@ func assertRuntimeMemoryMetrics(t *testing.T, root string) {
 
 func isRuntimeMemoryMetric(name string) bool {
 	switch name {
-	case factoryruntime.RuntimeMemoryHeapAlloc,
-		factoryruntime.RuntimeMemoryHeapInuse,
-		factoryruntime.RuntimeMemorySys,
-		factoryruntime.RuntimeMemoryNumGC,
-		factoryruntime.RuntimeMemoryGoroutines,
-		factoryruntime.RuntimeMemoryProcessCommit,
-		factoryruntime.RuntimeMemoryProcessCommitAvailable:
+	case "runtime.memory.heap_alloc",
+		"runtime.memory.heap_inuse",
+		"runtime.memory.sys",
+		"runtime.memory.num_gc",
+		"runtime.memory.goroutines",
+		"runtime.memory.process_commit",
+		"runtime.memory.process_commit_available":
 		return true
 	default:
 		return false
@@ -332,7 +331,7 @@ func TestAPIServerBindFailureUnwindsStartedLifecycleRoles(t *testing.T) {
 	starter, err := platformhttpserver.NewStarter(func(_ string, address string) (net.Listener, error) {
 		attempts = append(attempts, address)
 		return nil, errors.New("address unavailable")
-	})
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("NewStarter() error = %v", err)
 	}

--- a/tests/functional/transport/http/server/startup_shutdown_test.go
+++ b/tests/functional/transport/http/server/startup_shutdown_test.go
@@ -17,8 +17,11 @@ import (
 	"time"
 
 	"github.com/google/pprof/profile"
+	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
+	platformmetrics "github.com/portpowered/infinite-you/pkg/platform/metrics"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	modelprovider "github.com/portpowered/infinite-you/pkg/services/models"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
@@ -33,10 +36,12 @@ func TestAPIServerPprofIsOptInThroughThePublicRunPath(t *testing.T) {
 	support.WriteAgentConfig(t, dir, "worker-a", support.BuildModelWorkerConfig(modelprovider.ProviderCodex, "gpt-5-codex"))
 	edges := serviceedges.Edges{}
 	support.ConfigureWorkerCommands(t, &edges, support.NewStaticSuccessCommandRunner("pprof diagnostics"), nil)
+	metricsDir := t.TempDir()
 	defaultServer := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:                dir,
 		WaitForServiceModeRuntime: true,
 		Edges:                     edges,
+		Args:                      []string{"--runtime-metrics-dir", metricsDir},
 	})
 	for _, path := range []string{
 		"/debug/pprof/", "/debug/pprof/heap", "/debug/pprof/profile",
@@ -73,6 +78,7 @@ func TestAPIServerPprofIsOptInThroughThePublicRunPath(t *testing.T) {
 		t.Fatalf("default runtime snapshot = %+v, want plausible live runtime values", runtimeSnapshot)
 	}
 	defaultServer.Close(t)
+	assertRuntimeMemoryMetrics(t, metricsDir)
 
 	enabledServer := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:                dir,
@@ -80,6 +86,11 @@ func TestAPIServerPprofIsOptInThroughThePublicRunPath(t *testing.T) {
 		Edges:                     edges,
 		Args:                      []string{"--pprof"},
 	})
+	assertEnabledPprofServer(t, enabledServer)
+}
+
+func assertEnabledPprofServer(t *testing.T, enabledServer *support.FunctionalAPIServer) {
+	t.Helper()
 	index, err := http.Get(enabledServer.URL() + "/debug/pprof/")
 	if err != nil {
 		t.Fatalf("enabled GET pprof index: %v", err)
@@ -145,6 +156,79 @@ func TestAPIServerPprofIsOptInThroughThePublicRunPath(t *testing.T) {
 	}
 	if len(cpuProfile.SampleType) == 0 {
 		t.Fatalf("enabled live CPU profile = %+v, want sample types", cpuProfile)
+	}
+}
+
+func assertRuntimeMemoryMetrics(t *testing.T, root string) {
+	t.Helper()
+
+	reader, err := platformmetrics.NewRuntimeMetricsReader(platformfilesystem.Local{})
+	if err != nil {
+		t.Fatalf("construct runtime metrics reader: %v", err)
+	}
+	records, err := reader.Read(t.Context(), root)
+	if err != nil {
+		t.Fatalf("read runtime metrics: %v", err)
+	}
+	values := make(map[string]float64, 7)
+	units := make(map[string]string, 7)
+	for _, record := range records {
+		name, _ := record["metric_name"].(string)
+		if !isRuntimeMemoryMetric(name) {
+			continue
+		}
+		value, ok := record["value"].(float64)
+		if !ok {
+			t.Fatalf("runtime memory metric %q value = %#v, want JSON number", name, record["value"])
+		}
+		values[name] = value
+		units[name], _ = record["unit"].(string)
+		if metricType, _ := record["metric_type"].(string); metricType != factoryruntime.RuntimeMetricTypeSample {
+			t.Fatalf("runtime memory metric %q type = %q, want sample", name, metricType)
+		}
+	}
+	heapAlloc, allocOK := values[factoryruntime.RuntimeMemoryHeapAlloc]
+	heapInuse, inuseOK := values[factoryruntime.RuntimeMemoryHeapInuse]
+	sys, sysOK := values[factoryruntime.RuntimeMemorySys]
+	numGC, gcOK := values[factoryruntime.RuntimeMemoryNumGC]
+	goroutines, goroutinesOK := values[factoryruntime.RuntimeMemoryGoroutines]
+	processCommit, commitOK := values[factoryruntime.RuntimeMemoryProcessCommit]
+	processCommitAvailable, commitAvailableOK := values[factoryruntime.RuntimeMemoryProcessCommitAvailable]
+	if !allocOK || !inuseOK || !sysOK || !gcOK || !goroutinesOK || !commitOK || !commitAvailableOK {
+		t.Fatalf("runtime memory records = %#v, want the complete runtime snapshot metric set", values)
+	}
+	if units[factoryruntime.RuntimeMemoryHeapAlloc] != "bytes" ||
+		units[factoryruntime.RuntimeMemoryHeapInuse] != "bytes" ||
+		units[factoryruntime.RuntimeMemorySys] != "bytes" ||
+		units[factoryruntime.RuntimeMemoryNumGC] != "count" ||
+		units[factoryruntime.RuntimeMemoryGoroutines] != "count" ||
+		units[factoryruntime.RuntimeMemoryProcessCommit] != "bytes" ||
+		units[factoryruntime.RuntimeMemoryProcessCommitAvailable] != "boolean" {
+		t.Fatalf("runtime memory units = %#v, want bytes/count/boolean fields", units)
+	}
+	if heapAlloc <= 0 || heapInuse < heapAlloc || sys < heapInuse || numGC < 0 || goroutines <= 0 {
+		t.Fatalf("runtime memory values = heap_alloc:%v heap_inuse:%v sys:%v num_gc:%v goroutines:%v, want plausible values", heapAlloc, heapInuse, sys, numGC, goroutines)
+	}
+	if processCommitAvailable != 0 && processCommitAvailable != 1 {
+		t.Fatalf("runtime memory process commit availability = %v, want 0 or 1", processCommitAvailable)
+	}
+	if processCommitAvailable == 1 && processCommit <= 0 {
+		t.Fatalf("runtime memory process commit = %v, want positive when available", processCommit)
+	}
+}
+
+func isRuntimeMemoryMetric(name string) bool {
+	switch name {
+	case factoryruntime.RuntimeMemoryHeapAlloc,
+		factoryruntime.RuntimeMemoryHeapInuse,
+		factoryruntime.RuntimeMemorySys,
+		factoryruntime.RuntimeMemoryNumGC,
+		factoryruntime.RuntimeMemoryGoroutines,
+		factoryruntime.RuntimeMemoryProcessCommit,
+		factoryruntime.RuntimeMemoryProcessCommitAvailable:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/tests/functional/transport/http/server/startup_shutdown_test.go
+++ b/tests/functional/transport/http/server/startup_shutdown_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -15,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/pprof/profile"
 	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
@@ -102,6 +104,47 @@ func TestAPIServerPprofIsOptInThroughThePublicRunPath(t *testing.T) {
 	}
 	if heap.StatusCode != http.StatusOK || len(heapBody) == 0 {
 		t.Fatalf("enabled pprof heap = (%d, body length %d), want non-empty HTTP 200 response", heap.StatusCode, len(heapBody))
+	}
+	heapProfile, err := profile.Parse(bytes.NewReader(heapBody))
+	if err != nil {
+		t.Fatalf("parse enabled live heap profile: %v", err)
+	}
+	if len(heapProfile.SampleType) == 0 || len(heapProfile.Sample) == 0 {
+		t.Fatalf("enabled live heap profile = %+v, want sample types and samples", heapProfile)
+	}
+
+	for _, path := range []string{"/debug/pprof/allocs", "/debug/pprof/goroutine"} {
+		response, err := http.Get(enabledServer.URL() + path)
+		if err != nil {
+			t.Fatalf("enabled GET %s: %v", path, err)
+		}
+		body, err := io.ReadAll(response.Body)
+		_ = response.Body.Close()
+		if err != nil {
+			t.Fatalf("read enabled GET %s: %v", path, err)
+		}
+		if response.StatusCode != http.StatusOK || len(body) == 0 {
+			t.Fatalf("enabled GET %s = (%d, body length %d), want non-empty HTTP 200 response", path, response.StatusCode, len(body))
+		}
+	}
+	cpu, err := http.Get(enabledServer.URL() + "/debug/pprof/profile?seconds=1")
+	if err != nil {
+		t.Fatalf("enabled GET CPU profile: %v", err)
+	}
+	cpuBody, err := io.ReadAll(cpu.Body)
+	_ = cpu.Body.Close()
+	if err != nil {
+		t.Fatalf("read enabled CPU profile: %v", err)
+	}
+	if cpu.StatusCode != http.StatusOK || len(cpuBody) == 0 {
+		t.Fatalf("enabled CPU profile = (%d, body length %d), want non-empty HTTP 200 response", cpu.StatusCode, len(cpuBody))
+	}
+	cpuProfile, err := profile.Parse(bytes.NewReader(cpuBody))
+	if err != nil {
+		t.Fatalf("parse enabled live CPU profile: %v", err)
+	}
+	if len(cpuProfile.SampleType) == 0 {
+		t.Fatalf("enabled live CPU profile = %+v, want sample types", cpuProfile)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "Opt-In pprof and Runtime Memory Visibility",
  "branchName": "obs-pprof-memory-visibility",
  "description": "Add a secure, explicit opt-in for standard Go pprof handlers on the daemon's existing HTTP server and emit low-cadence runtime snapshot observations through the existing runtime operational stream. The stream includes heap, GC, goroutine, and process-commit signals while preserving the default listener's current 404 behavior and avoiding any new dashboard, listener, sink, reader, or retention path.",
  "context": {
    "customerAsk": "Give operators a secure, opt-in pprof surface that produces real profiles and an always-on, low-cadence runtime snapshot record on the existing operational stream. Preserve the default listener's current debug-route behavior, and surface changing heap, GC, goroutine, and process-commit values without requiring a diagnostic URL.",
    "problem": "The production daemon exhausted memory on 2026-08-23 without an in-process diagnostic surface. The pprof and expvar debug paths on clean main returned 404, forcing operators to infer growth from external Win32_Process.PageFileUsage sampling, which could not identify retained allocations. Always exposing pprof would disclose process internals, while relying only on an opt-in profiler would leave normal default-off deployments without a lightweight trend signal.",
    "solution": "Follow the existing optional server-surface and CLI configuration pattern to carry a default-false pprof choice into HTTP server construction, then mount isolated standard-library pprof handlers on the existing server mux only when enabled. Independently sample the values represented by the always-on runtime snapshot at a pinned low cadence and write stable heap, GC, goroutine, and process-commit measurements to the already-open stream. Prove behavior with emitted JSONL records from a running daemon and deterministic cadence/lifecycle assertions."
  },
  "acceptanceCriteria": [
    "With no pprof opt-in, a normally configured daemon returns the established JSON 404 response for /debug/pprof/heap, and no standard pprof handler is reachable on the default listener.",
    "The existing operator configuration pattern exposes an explicit, default-false pprof opt-in for every daemon-starting mode in scope, and enabling it does not create a separate listener or silently broaden the configured bind address.",
    "With pprof enabled, the existing daemon listener serves the standard pprof index and the heap, allocs, goroutine, and CPU profile handlers; a fetched /debug/pprof/heap body parses as a real pprof profile.",
    "With pprof disabled, the running daemon still emits low-cadence runtime snapshot records through the existing operational stream containing plausible HeapAlloc, HeapInuse, Sys, NumGC, Goroutines, and process-commit values without a new sink, file family, or retention path.",
    "The PR body includes actual emitted metric lines from a running daemon at two observation timestamps, showing changing heap/GC/process-commit values and explicit units. pkg/platform/metrics/runtime_metrics_reader.go, the retention scheduler, and docs/internal/baselines/deadcode-baseline.txt remain untouched.",
    "Quality gate: Typecheck passes; focused HTTP-server, CLI/configuration, lifecycle, and runtime-memory tests pass; make verify-fast passes; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The worker/reviewer cycle continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, conflicts are resolved, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "obs-pprof-memory-visibility-001",
      "title": "Preserve default-off security through explicit operator opt-in",
      "description": "As an operator, I want pprof to remain absent unless I explicitly enable it so that normal daemon listeners do not disclose runtime internals.",
      "acceptanceCriteria": [
        "The daemon's established optional-server configuration path accepts a pprof opt-in whose default is false and carries the resolved value into the existing HTTP server lifecycle.",
        "Starting each affected daemon mode without the opt-in leaves /debug/pprof/heap on the same not-found path as today; an integration test asserts the 404 response from a live server.",
        "Explicit false behaves the same as omission, and the pprof choice does not change the listener address, open a second port, or enable /debug/vars.",
        "Configuration help and validation make the opt-in discoverable and reject combinations that cannot start an HTTP server using the repository's existing optional-surface behavior.",
        "Focused tests cover default resolution, explicit true/false resolution, valid daemon modes, and invalid no-server combinations without asserting route-registration inventories.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "The existing optional-server path already carries a default-false --pprof setting through you server and server-enabled you run modes, rejects serverless placement, keeps ACP/MCP stdio isolated, and preserves loopback binding. Strengthened the live root.BuildProcess/Process.Execute scenario to assert the established JSON NOT_FOUND response for /debug/pprof/heap and /debug/vars; focused HTTP-server, CLI, and functional tests pass."
    },
    {
      "id": "obs-pprof-memory-visibility-002",
      "title": "Retrieve and analyze a real profile from an enabled daemon",
      "description": "As an operator investigating memory growth, I want an opted-in daemon to return standard Go profiles so that I can identify allocations and retained memory inside the process.",
      "acceptanceCriteria": [
        "When explicitly enabled, the daemon's existing listener serves the standard pprof index and /debug/pprof/heap, /debug/pprof/allocs, /debug/pprof/goroutine, and /debug/pprof/profile handlers without replacing or weakening existing API routing.",
        "An integration test starts the enabled server, fetches /debug/pprof/heap, and parses the response with github.com/google/pprof/profile.Parse or an equivalent profile parser; HTTP 200 or a non-empty body alone is not sufficient proof.",
        "The enabled handlers are scoped to the configured server mux and do not make pprof reachable from another server through process-global default-mux side effects.",
        "Cancellation and shutdown of a pprof-enabled daemon retain the existing HTTP server lifecycle behavior and do not leave a listener or profiling task running.",
        "The existing main-line pprof implementation and its parser-backed live-server coverage satisfy the profile usability requirement; this lane's PR body is reserved for runtime-metrics evidence.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "The enabled local server behavior and parser-backed live profile coverage are already present on main through the merged diagnostics work. Review follow-up also preserves standard named-profile seconds=N delta behavior with parser-backed heap-delta coverage."
    },
    {
      "id": "obs-pprof-memory-visibility-003",
      "title": "Emit periodic runtime memory observations on the existing stream",
      "description": "As an operator running with pprof disabled, I want lightweight runtime memory observations in the normal operational stream so that I can see memory creep and decide when to enable deeper profiling.",
      "acceptanceCriteria": [
        "The daemon periodically samples the existing runtime snapshot values on the existing low-cadence runtime metrics lifecycle and emits stable records through the existing sink; it does not add a new file, output channel, scheduler, or independently managed goroutine.",
        "Each emitted record contains HeapAlloc, HeapInuse, Sys, NumGC, Goroutines, ProcessCommit, and ProcessCommitAvailable measurements with unambiguous units and types suitable for trend comparison.",
        "A behavioral test observes the emitted stream from a running runtime path and asserts plausible values, including HeapAlloc > 0, Sys >= HeapInuse >= HeapAlloc, a positive Goroutines count, a valid non-negative NumGC, and coherent process-commit availability while pprof remains disabled.",
        "Deterministic lifecycle tests prove repeated observations follow the existing cadence and stop with the owning runtime lifecycle, without sleep-based timing assertions.",
        "Sampling or emission failure follows the existing runtime-metrics error policy, does not crash the daemon, and does not leak payload or process-sensitive data into logs.",
        "pkg/platform/metrics/runtime_metrics_reader.go, runtime-metrics retention behavior, and retention scheduling are unchanged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "The existing runtime observer now emits the /debug/runtime-equivalent heap, GC, goroutine, and process-commit fields through the existing sink as seven typed samples, with an immediate first observation and a pinned 10-second cadence. The observer clock/timer is injected through Factory Runtime assembly and selected by pkg/wire. Deterministic host tests cover cadence, sink failure continuation, and lifecycle shutdown; the live server test reads the JSONL stream with pprof disabled and asserts plausible values."
    }
  ],
  "verificationEvidence": {
    "runtimeMetrics": {
      "mode": "Built you binary started with run --with-server --continuously --listen 127.0.0.1:17438 from the worktree's factory directory, with pprof disabled",
      "stream": "C:\\Users\\andre\\AppData\\Local\\Temp\\you-obs-pprof-memory-visibility-metrics\\2026\\08\\23\\083402.249283500-runtime-metrics-default-480c322c-170d-4725-bf9b-33947dd90fa0-69a06e71-992d-4cde-9ea6-cb1fd93d4237.log",
      "lines": [
        "{\"ts\":\"2026-08-23T08:34:02.4135232Z\",\"metric_name\":\"runtime.memory.heap_alloc\",\"metric_type\":\"sample\",\"value\":9871256,\"unit\":\"bytes\"}",
        "{\"ts\":\"2026-08-23T08:34:02.4135232Z\",\"metric_name\":\"runtime.memory.num_gc\",\"metric_type\":\"sample\",\"value\":37,\"unit\":\"count\"}",
        "{\"ts\":\"2026-08-23T08:34:02.4135232Z\",\"metric_name\":\"runtime.memory.process_commit\",\"metric_type\":\"sample\",\"value\":38531072,\"unit\":\"bytes\"}",
        "{\"ts\":\"2026-08-23T08:34:12.4146507Z\",\"metric_name\":\"runtime.memory.heap_alloc\",\"metric_type\":\"sample\",\"value\":8630248,\"unit\":\"bytes\"}",
        "{\"ts\":\"2026-08-23T08:34:12.4146507Z\",\"metric_name\":\"runtime.memory.num_gc\",\"metric_type\":\"sample\",\"value\":242,\"unit\":\"count\"}",
        "{\"ts\":\"2026-08-23T08:34:12.4146507Z\",\"metric_name\":\"runtime.memory.process_commit\",\"metric_type\":\"sample\",\"value\":40198144,\"unit\":\"bytes\"}"
      ]
    },
    "reviewFixes": {
      "focusedTests": "go test ./pkg/platform/httpserver ./pkg/services/factory_runtime/internal/host ./pkg/services/factory_runtime/internal ./pkg/services/factory_runtime/wire ./pkg/wire ./pkg/transports/cli/run ./tests/functional/transport/http/server -count=1",
      "backendGates": "make pkg-boundary, make pkg-maint, make pkg-structure, make backend-size, make pkg-file-count, and make vet pass. make verify-fast remains blocked by the pre-existing UI TS2688 missing Bun type definitions before Go tests run.",
      "protectedFiles": "pkg/platform/metrics/runtime_metrics_reader.go, runtime-metrics retention behavior/scheduling, and docs/internal/baselines/deadcode-baseline.txt remain untouched.",
      "latestReviewFix": "Split assertEnabledPprofProfiles into focused heap, named-profile, and heap-delta assertions; go test ./pkg/platform/httpserver ./pkg/services/factory_runtime/internal/host -count=1 -timeout=120s and make pkg-maint pass."
    }
  }
}
