### PR TITLE
JS-P3: allowed permissions validation

### DIFF
--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/globals.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/globals.go
@@ -17,6 +17,7 @@ import (
 type runtimeGlobals struct {
 	vm                    *goja.Runtime
 	policy                workflowpolicy.EffectivePolicy
+	factoryName           string
 	sessionID             string
 	ctx                   context.Context
 	records               *recordCollector

--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_children.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_children.go
@@ -92,7 +92,13 @@ func (g *runtimeGlobals) denyChildSlots(count int) error {
 }
 
 func (g *runtimeGlobals) denyChildRequest(req ChildExecutionRequest) error {
-	return workflowpolicy.ValidateChildRequest(g.policy, childPolicyRequest(req))
+	return workflowpolicy.ValidateChildRequest(g.policy, g.childPolicyRequest(req))
+}
+
+func (g *runtimeGlobals) childPolicyRequest(req ChildExecutionRequest) workflowpolicy.ChildRequest {
+	request := childPolicyRequest(req)
+	request.FactoryName = g.factoryName
+	return request
 }
 
 func (g *runtimeGlobals) denyArtifactSize(sizeBytes int64) error {

--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_children_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_children_test.go
@@ -833,85 +833,38 @@ func TestRun_AgentRunPermissionsResolveCanonicalAndLegacyPrecedence(t *testing.T
 	}
 }
 
-func TestRun_AgentRunDisallowedPermissionFailsBeforeDispatch(t *testing.T) {
-	const want = `policy denied: Factory "named-factory" child "skip-child" requested permission "SKIP_PERMISSIONS" not listed in allowedPermissions`
-
-	policy := workflowpolicy.DefaultEffectivePolicy()
-	policy.AllowedPermissions = []string{workflowpolicy.PermissionModeDefault}
-	calls := 0
-	outcome, err := runtimeWorkflows.Run(context.Background(), factory.JavaScriptRuntimeRequest{
-		Source:      `agent.run({ prompt: "review", label: "skip-child", skipPermissions: true }); return { ok: true };`,
-		SourceRef:   "inline",
-		SessionID:   "session-disallowed-permission",
-		FactoryName: "named-factory",
-		Policy:      policy,
-	}, factory.JavaScriptRuntimeHooks{NewChildExecutor: func(string, factory.JavaScriptChildRecordSink, workflowpolicy.EffectivePolicy) factory.JavaScriptChildExecutor {
-		return childExecutorFunc(func(_ context.Context, _ factory.JavaScriptChildExecutionRequest) (factory.JavaScriptChildExecutionResult, error) {
-			calls++
-			return factory.JavaScriptChildExecutionResult{}, nil
-		})
-	}})
-	if err != nil {
-		t.Fatalf("Run() error = %v", err)
+func TestRun_AgentRunDynamicObjectRejectsUnsupportedFieldsBeforeDispatch(t *testing.T) {
+	unsupported := []string{
+		"writableRoots", "allowNetwork", "network", "allowDangerFullAccess", "dangerFullAccess",
+		"schema", "outputSchema", "concurrency", "maxAgents", "duration", "timeout", "timeoutMs",
 	}
-	if outcome.OK || outcome.Failure.Message != want {
-		t.Fatalf("Run() outcome = %#v, want exact diagnostic %q", outcome, want)
-	}
-	if calls != 0 {
-		t.Fatalf("child executor calls = %d, want zero before dispatch admission", calls)
-	}
-	if len(outcome.Records) != 0 {
-		t.Fatalf("runtime records = %#v, want no Dispatch record before denial", outcome.Records)
-	}
-}
-
-func TestRun_AgentRunAllowedAndOmittedPermissionPoliciesPreserveExecution(t *testing.T) {
-	tests := []struct {
-		name     string
-		allowed  []string
-		skip     bool
-		wantSkip bool
-	}{
-		{
-			name:    "allowed default",
-			allowed: []string{workflowpolicy.PermissionModeDefault},
-		},
-		{
-			name:     "allowed skip permissions",
-			allowed:  []string{workflowpolicy.PermissionModeSkipPermissions},
-			skip:     true,
-			wantSkip: true,
-		},
-		{
-			name:     "omitted allowlist",
-			skip:     true,
-			wantSkip: true,
-		},
-	}
-
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			policy := workflowpolicy.DefaultEffectivePolicy()
-			policy.AllowedPermissions = test.allowed
-			calls := 0
-			var captured factory.JavaScriptChildExecutionRequest
+	for _, field := range unsupported {
+		t.Run(field, func(t *testing.T) {
+			stub := &stubChildExecutor{mode: stubChildExecutionMode}
+			source := fmt.Sprintf(`const child = { prompt: "prompt-secret" }; child[%q] = "value-secret"; agent.run(child);`, field)
 			outcome, err := runtimeWorkflows.Run(context.Background(), factory.JavaScriptRuntimeRequest{
-				Source: fmt.Sprintf(`return agent.run({ prompt: "review", label: %q, skipPermissions: %t });`, test.name, test.skip),
-				Policy: policy,
+				Source: source, SourceRef: "inline", SessionID: "unsupported-child-field",
+				Policy: workflowpolicy.DefaultEffectivePolicy(),
 			}, factory.JavaScriptRuntimeHooks{NewChildExecutor: func(string, factory.JavaScriptChildRecordSink, workflowpolicy.EffectivePolicy) factory.JavaScriptChildExecutor {
-				return childExecutorFunc(func(_ context.Context, req factory.JavaScriptChildExecutionRequest) (factory.JavaScriptChildExecutionResult, error) {
-					calls++
-					captured = req
-					return factory.JavaScriptChildExecutionResult{Status: factory.JavaScriptChildDispatchStatusCompleted, Request: req}, nil
-				})
+				return stub
 			}})
-			if err != nil || !outcome.OK {
-				t.Fatalf("Run() outcome=%#v err=%v", outcome, err)
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
 			}
-			if calls != 1 || captured.SkipPermissions != test.wantSkip {
-				t.Fatalf("child executor calls=%d request=%#v, want one call with skipPermissions=%t", calls, captured, test.wantSkip)
+			if outcome.OK {
+				t.Fatalf("Run() outcome = %#v, want script failure", outcome)
 			}
+			want := `agent.run() does not support field "` + field + `"`
+			if !strings.Contains(outcome.Failure.Message, want) {
+				t.Fatalf("failure message = %q, want %q", outcome.Failure.Message, want)
+			}
+			if strings.Contains(outcome.Failure.Message, "value-secret") || strings.Contains(outcome.Failure.Message, "prompt-secret") {
+				t.Fatalf("failure message = %q, want redacted diagnostic", outcome.Failure.Message)
+			}
+			if len(stub.executionRequests()) != 0 {
+				t.Fatalf("executor requests = %#v, want none", stub.executionRequests())
+			}
+			assertNoChildDispatchRecords(t, outcome.Records)
 		})
 	}
 }

--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_children_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_children_test.go
@@ -833,42 +833,6 @@ func TestRun_AgentRunPermissionsResolveCanonicalAndLegacyPrecedence(t *testing.T
 	}
 }
 
-func TestRun_AgentRunDynamicObjectRejectsUnsupportedFieldsBeforeDispatch(t *testing.T) {
-	unsupported := []string{
-		"writableRoots", "allowNetwork", "network", "allowDangerFullAccess", "dangerFullAccess",
-		"schema", "outputSchema", "concurrency", "maxAgents", "duration", "timeout", "timeoutMs",
-	}
-	for _, field := range unsupported {
-		t.Run(field, func(t *testing.T) {
-			stub := &stubChildExecutor{mode: stubChildExecutionMode}
-			source := fmt.Sprintf(`const child = { prompt: "prompt-secret" }; child[%q] = "value-secret"; agent.run(child);`, field)
-			outcome, err := runtimeWorkflows.Run(context.Background(), factory.JavaScriptRuntimeRequest{
-				Source: source, SourceRef: "inline", SessionID: "unsupported-child-field",
-				Policy: workflowpolicy.DefaultEffectivePolicy(),
-			}, factory.JavaScriptRuntimeHooks{NewChildExecutor: func(string, factory.JavaScriptChildRecordSink, workflowpolicy.EffectivePolicy) factory.JavaScriptChildExecutor {
-				return stub
-			}})
-			if err != nil {
-				t.Fatalf("Run() error = %v", err)
-			}
-			if outcome.OK {
-				t.Fatalf("Run() outcome = %#v, want script failure", outcome)
-			}
-			want := `agent.run() does not support field "` + field + `"`
-			if !strings.Contains(outcome.Failure.Message, want) {
-				t.Fatalf("failure message = %q, want %q", outcome.Failure.Message, want)
-			}
-			if strings.Contains(outcome.Failure.Message, "value-secret") || strings.Contains(outcome.Failure.Message, "prompt-secret") {
-				t.Fatalf("failure message = %q, want redacted diagnostic", outcome.Failure.Message)
-			}
-			if len(stub.executionRequests()) != 0 {
-				t.Fatalf("executor requests = %#v, want none", stub.executionRequests())
-			}
-			assertNoChildDispatchRecords(t, outcome.Records)
-		})
-	}
-}
-
 func (s *stubChildExecutor) labelOrder() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_children_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_children_test.go
@@ -833,6 +833,89 @@ func TestRun_AgentRunPermissionsResolveCanonicalAndLegacyPrecedence(t *testing.T
 	}
 }
 
+func TestRun_AgentRunDisallowedPermissionFailsBeforeDispatch(t *testing.T) {
+	const want = `policy denied: Factory "named-factory" child "skip-child" requested permission "SKIP_PERMISSIONS" not listed in allowedPermissions`
+
+	policy := workflowpolicy.DefaultEffectivePolicy()
+	policy.AllowedPermissions = []string{workflowpolicy.PermissionModeDefault}
+	calls := 0
+	outcome, err := runtimeWorkflows.Run(context.Background(), factory.JavaScriptRuntimeRequest{
+		Source:      `agent.run({ prompt: "review", label: "skip-child", skipPermissions: true }); return { ok: true };`,
+		SourceRef:   "inline",
+		SessionID:   "session-disallowed-permission",
+		FactoryName: "named-factory",
+		Policy:      policy,
+	}, factory.JavaScriptRuntimeHooks{NewChildExecutor: func(string, factory.JavaScriptChildRecordSink, workflowpolicy.EffectivePolicy) factory.JavaScriptChildExecutor {
+		return childExecutorFunc(func(_ context.Context, _ factory.JavaScriptChildExecutionRequest) (factory.JavaScriptChildExecutionResult, error) {
+			calls++
+			return factory.JavaScriptChildExecutionResult{}, nil
+		})
+	}})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if outcome.OK || outcome.Failure.Message != want {
+		t.Fatalf("Run() outcome = %#v, want exact diagnostic %q", outcome, want)
+	}
+	if calls != 0 {
+		t.Fatalf("child executor calls = %d, want zero before dispatch admission", calls)
+	}
+	if len(outcome.Records) != 0 {
+		t.Fatalf("runtime records = %#v, want no Dispatch record before denial", outcome.Records)
+	}
+}
+
+func TestRun_AgentRunAllowedAndOmittedPermissionPoliciesPreserveExecution(t *testing.T) {
+	tests := []struct {
+		name     string
+		allowed  []string
+		skip     bool
+		wantSkip bool
+	}{
+		{
+			name:    "allowed default",
+			allowed: []string{workflowpolicy.PermissionModeDefault},
+		},
+		{
+			name:     "allowed skip permissions",
+			allowed:  []string{workflowpolicy.PermissionModeSkipPermissions},
+			skip:     true,
+			wantSkip: true,
+		},
+		{
+			name:     "omitted allowlist",
+			skip:     true,
+			wantSkip: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			policy := workflowpolicy.DefaultEffectivePolicy()
+			policy.AllowedPermissions = test.allowed
+			calls := 0
+			var captured factory.JavaScriptChildExecutionRequest
+			outcome, err := runtimeWorkflows.Run(context.Background(), factory.JavaScriptRuntimeRequest{
+				Source: fmt.Sprintf(`return agent.run({ prompt: "review", label: %q, skipPermissions: %t });`, test.name, test.skip),
+				Policy: policy,
+			}, factory.JavaScriptRuntimeHooks{NewChildExecutor: func(string, factory.JavaScriptChildRecordSink, workflowpolicy.EffectivePolicy) factory.JavaScriptChildExecutor {
+				return childExecutorFunc(func(_ context.Context, req factory.JavaScriptChildExecutionRequest) (factory.JavaScriptChildExecutionResult, error) {
+					calls++
+					captured = req
+					return factory.JavaScriptChildExecutionResult{Status: factory.JavaScriptChildDispatchStatusCompleted, Request: req}, nil
+				})
+			}})
+			if err != nil || !outcome.OK {
+				t.Fatalf("Run() outcome=%#v err=%v", outcome, err)
+			}
+			if calls != 1 || captured.SkipPermissions != test.wantSkip {
+				t.Fatalf("child executor calls=%d request=%#v, want one call with skipPermissions=%t", calls, captured, test.wantSkip)
+			}
+		})
+	}
+}
+
 func (s *stubChildExecutor) labelOrder() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_pipeline_policy_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_pipeline_policy_test.go
@@ -2,6 +2,7 @@ package workflowruntime_test
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -26,6 +27,89 @@ func assertParallelResultOrder(t *testing.T, sessionID string, outcome factory.J
 		if !ok || child["label"] != wantLabel || child["status"] != factory.JavaScriptChildDispatchStatusCompleted {
 			t.Fatalf("results[%d] = %#v, want completed child %q", i, results[i], wantLabel)
 		}
+	}
+}
+
+func TestRun_AgentRunDisallowedPermissionFailsBeforeDispatch(t *testing.T) {
+	const want = `policy denied: Factory "named-factory" child "skip-child" requested permission "SKIP_PERMISSIONS" not listed in allowedPermissions`
+
+	policy := workflowpolicy.DefaultEffectivePolicy()
+	policy.AllowedPermissions = []string{workflowpolicy.PermissionModeDefault}
+	calls := 0
+	outcome, err := runtimeWorkflows.Run(context.Background(), factory.JavaScriptRuntimeRequest{
+		Source:      `agent.run({ prompt: "review", label: "skip-child", skipPermissions: true }); return { ok: true };`,
+		SourceRef:   "inline",
+		SessionID:   "session-disallowed-permission",
+		FactoryName: "named-factory",
+		Policy:      policy,
+	}, factory.JavaScriptRuntimeHooks{NewChildExecutor: func(string, factory.JavaScriptChildRecordSink, workflowpolicy.EffectivePolicy) factory.JavaScriptChildExecutor {
+		return childExecutorFunc(func(_ context.Context, _ factory.JavaScriptChildExecutionRequest) (factory.JavaScriptChildExecutionResult, error) {
+			calls++
+			return factory.JavaScriptChildExecutionResult{}, nil
+		})
+	}})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if outcome.OK || outcome.Failure.Message != want {
+		t.Fatalf("Run() outcome = %#v, want exact diagnostic %q", outcome, want)
+	}
+	if calls != 0 {
+		t.Fatalf("child executor calls = %d, want zero before dispatch admission", calls)
+	}
+	if len(outcome.Records) != 0 {
+		t.Fatalf("runtime records = %#v, want no Dispatch record before denial", outcome.Records)
+	}
+}
+
+func TestRun_AgentRunAllowedAndOmittedPermissionPoliciesPreserveExecution(t *testing.T) {
+	tests := []struct {
+		name     string
+		allowed  []string
+		skip     bool
+		wantSkip bool
+	}{
+		{
+			name:    "allowed default",
+			allowed: []string{workflowpolicy.PermissionModeDefault},
+		},
+		{
+			name:     "allowed skip permissions",
+			allowed:  []string{workflowpolicy.PermissionModeSkipPermissions},
+			skip:     true,
+			wantSkip: true,
+		},
+		{
+			name:     "omitted allowlist",
+			skip:     true,
+			wantSkip: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			policy := workflowpolicy.DefaultEffectivePolicy()
+			policy.AllowedPermissions = test.allowed
+			calls := 0
+			var captured factory.JavaScriptChildExecutionRequest
+			outcome, err := runtimeWorkflows.Run(context.Background(), factory.JavaScriptRuntimeRequest{
+				Source: fmt.Sprintf(`return agent.run({ prompt: "review", label: %q, skipPermissions: %t });`, test.name, test.skip),
+				Policy: policy,
+			}, factory.JavaScriptRuntimeHooks{NewChildExecutor: func(string, factory.JavaScriptChildRecordSink, workflowpolicy.EffectivePolicy) factory.JavaScriptChildExecutor {
+				return childExecutorFunc(func(_ context.Context, req factory.JavaScriptChildExecutionRequest) (factory.JavaScriptChildExecutionResult, error) {
+					calls++
+					captured = req
+					return factory.JavaScriptChildExecutionResult{Status: factory.JavaScriptChildDispatchStatusCompleted, Request: req}, nil
+				})
+			}})
+			if err != nil || !outcome.OK {
+				t.Fatalf("Run() outcome=%#v err=%v", outcome, err)
+			}
+			if calls != 1 || captured.SkipPermissions != test.wantSkip {
+				t.Fatalf("child executor calls=%d request=%#v, want one call with skipPermissions=%t", calls, captured, test.wantSkip)
+			}
+		})
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_pipeline_policy_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_pipeline_policy_test.go
@@ -2,7 +2,6 @@ package workflowruntime_test
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -27,89 +26,6 @@ func assertParallelResultOrder(t *testing.T, sessionID string, outcome factory.J
 		if !ok || child["label"] != wantLabel || child["status"] != factory.JavaScriptChildDispatchStatusCompleted {
 			t.Fatalf("results[%d] = %#v, want completed child %q", i, results[i], wantLabel)
 		}
-	}
-}
-
-func TestRun_AgentRunDisallowedPermissionFailsBeforeDispatch(t *testing.T) {
-	const want = `policy denied: Factory "named-factory" child "skip-child" requested permission "SKIP_PERMISSIONS" not listed in allowedPermissions`
-
-	policy := workflowpolicy.DefaultEffectivePolicy()
-	policy.AllowedPermissions = []string{workflowpolicy.PermissionModeDefault}
-	calls := 0
-	outcome, err := runtimeWorkflows.Run(context.Background(), factory.JavaScriptRuntimeRequest{
-		Source:      `agent.run({ prompt: "review", label: "skip-child", skipPermissions: true }); return { ok: true };`,
-		SourceRef:   "inline",
-		SessionID:   "session-disallowed-permission",
-		FactoryName: "named-factory",
-		Policy:      policy,
-	}, factory.JavaScriptRuntimeHooks{NewChildExecutor: func(string, factory.JavaScriptChildRecordSink, workflowpolicy.EffectivePolicy) factory.JavaScriptChildExecutor {
-		return childExecutorFunc(func(_ context.Context, _ factory.JavaScriptChildExecutionRequest) (factory.JavaScriptChildExecutionResult, error) {
-			calls++
-			return factory.JavaScriptChildExecutionResult{}, nil
-		})
-	}})
-	if err != nil {
-		t.Fatalf("Run() error = %v", err)
-	}
-	if outcome.OK || outcome.Failure.Message != want {
-		t.Fatalf("Run() outcome = %#v, want exact diagnostic %q", outcome, want)
-	}
-	if calls != 0 {
-		t.Fatalf("child executor calls = %d, want zero before dispatch admission", calls)
-	}
-	if len(outcome.Records) != 0 {
-		t.Fatalf("runtime records = %#v, want no Dispatch record before denial", outcome.Records)
-	}
-}
-
-func TestRun_AgentRunAllowedAndOmittedPermissionPoliciesPreserveExecution(t *testing.T) {
-	tests := []struct {
-		name     string
-		allowed  []string
-		skip     bool
-		wantSkip bool
-	}{
-		{
-			name:    "allowed default",
-			allowed: []string{workflowpolicy.PermissionModeDefault},
-		},
-		{
-			name:     "allowed skip permissions",
-			allowed:  []string{workflowpolicy.PermissionModeSkipPermissions},
-			skip:     true,
-			wantSkip: true,
-		},
-		{
-			name:     "omitted allowlist",
-			skip:     true,
-			wantSkip: true,
-		},
-	}
-
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			policy := workflowpolicy.DefaultEffectivePolicy()
-			policy.AllowedPermissions = test.allowed
-			calls := 0
-			var captured factory.JavaScriptChildExecutionRequest
-			outcome, err := runtimeWorkflows.Run(context.Background(), factory.JavaScriptRuntimeRequest{
-				Source: fmt.Sprintf(`return agent.run({ prompt: "review", label: %q, skipPermissions: %t });`, test.name, test.skip),
-				Policy: policy,
-			}, factory.JavaScriptRuntimeHooks{NewChildExecutor: func(string, factory.JavaScriptChildRecordSink, workflowpolicy.EffectivePolicy) factory.JavaScriptChildExecutor {
-				return childExecutorFunc(func(_ context.Context, req factory.JavaScriptChildExecutionRequest) (factory.JavaScriptChildExecutionResult, error) {
-					calls++
-					captured = req
-					return factory.JavaScriptChildExecutionResult{Status: factory.JavaScriptChildDispatchStatusCompleted, Request: req}, nil
-				})
-			}})
-			if err != nil || !outcome.OK {
-				t.Fatalf("Run() outcome=%#v err=%v", outcome, err)
-			}
-			if calls != 1 || captured.SkipPermissions != test.wantSkip {
-				t.Fatalf("child executor calls=%d request=%#v, want one call with skipPermissions=%t", calls, captured, test.wantSkip)
-			}
-		})
 	}
 }
 

--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_primitives_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_primitives_test.go
@@ -12,6 +12,87 @@ import (
 	workflowpolicy "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract"
 )
 
+func TestRun_AgentRunDisallowedPermissionFailsBeforeDispatch(t *testing.T) {
+	const want = `policy denied: Factory "named-factory" child "skip-child" requested permission "SKIP_PERMISSIONS" not listed in allowedPermissions`
+
+	policy := workflowpolicy.DefaultEffectivePolicy()
+	policy.AllowedPermissions = []string{workflowpolicy.PermissionModeDefault}
+	calls := 0
+	outcome, err := runtimeWorkflows.Run(context.Background(), factory.JavaScriptRuntimeRequest{
+		Source:      `agent.run({ prompt: "review", label: "skip-child", skipPermissions: true }); return { ok: true };`,
+		SourceRef:   "inline",
+		SessionID:   "session-disallowed-permission",
+		FactoryName: "named-factory",
+		Policy:      policy,
+	}, factory.JavaScriptRuntimeHooks{NewChildExecutor: func(string, factory.JavaScriptChildRecordSink, workflowpolicy.EffectivePolicy) factory.JavaScriptChildExecutor {
+		return childExecutorFunc(func(_ context.Context, _ factory.JavaScriptChildExecutionRequest) (factory.JavaScriptChildExecutionResult, error) {
+			calls++
+			return factory.JavaScriptChildExecutionResult{}, nil
+		})
+	}})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if outcome.OK || outcome.Failure.Message != want {
+		t.Fatalf("Run() outcome = %#v, want exact diagnostic %q", outcome, want)
+	}
+	if calls != 0 {
+		t.Fatalf("child executor calls = %d, want zero before dispatch admission", calls)
+	}
+	assertNoChildDispatchRecords(t, outcome.Records)
+}
+
+func TestRun_AgentRunAllowedAndOmittedPermissionPoliciesPreserveExecution(t *testing.T) {
+	tests := []struct {
+		name     string
+		allowed  []string
+		skip     bool
+		wantSkip bool
+	}{
+		{
+			name:    "allowed default",
+			allowed: []string{workflowpolicy.PermissionModeDefault},
+		},
+		{
+			name:     "allowed skip permissions",
+			allowed:  []string{workflowpolicy.PermissionModeSkipPermissions},
+			skip:     true,
+			wantSkip: true,
+		},
+		{
+			name:     "omitted allowlist",
+			skip:     true,
+			wantSkip: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			policy := workflowpolicy.DefaultEffectivePolicy()
+			policy.AllowedPermissions = test.allowed
+			calls := 0
+			var captured factory.JavaScriptChildExecutionRequest
+			outcome, err := runtimeWorkflows.Run(context.Background(), factory.JavaScriptRuntimeRequest{
+				Source: fmt.Sprintf(`return agent.run({ prompt: "review", label: %q, skipPermissions: %t });`, test.name, test.skip),
+				Policy: policy,
+			}, factory.JavaScriptRuntimeHooks{NewChildExecutor: func(string, factory.JavaScriptChildRecordSink, workflowpolicy.EffectivePolicy) factory.JavaScriptChildExecutor {
+				return childExecutorFunc(func(_ context.Context, req factory.JavaScriptChildExecutionRequest) (factory.JavaScriptChildExecutionResult, error) {
+					calls++
+					captured = req
+					return factory.JavaScriptChildExecutionResult{Status: factory.JavaScriptChildDispatchStatusCompleted, Request: req}, nil
+				})
+			}})
+			if err != nil || !outcome.OK {
+				t.Fatalf("Run() outcome=%#v err=%v", outcome, err)
+			}
+			if calls != 1 || captured.SkipPermissions != test.wantSkip {
+				t.Fatalf("child executor calls=%d request=%#v, want one call with skipPermissions=%t", calls, captured, test.wantSkip)
+			}
+		})
+	}
+}
+
 func TestResolveChildWorkerSettings_AntigravityUsesModelEmbeddedEffort(t *testing.T) {
 	for _, executorProvider := range []string{"", "SCRIPT_WRAP"} {
 		t.Run("executorProvider="+executorProvider, func(t *testing.T) {

--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/runtime.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/runtime.go
@@ -35,6 +35,7 @@ func Run(ctx context.Context, req Request, hooks Hooks) (Outcome, error) {
 	globals := &runtimeGlobals{
 		vm:             vm,
 		policy:         policy,
+		factoryName:    factoryNameForRequest(req),
 		sessionID:      sessionID,
 		ctx:            ctx,
 		records:        records,
@@ -111,6 +112,16 @@ func Run(ctx context.Context, req Request, hooks Hooks) (Outcome, error) {
 		}
 	}
 	return Outcome{OK: true, Value: typed, Records: records.list()}, nil
+}
+
+func factoryNameForRequest(req Request) string {
+	if name := strings.TrimSpace(req.FactoryName); name != "" {
+		return name
+	}
+	if name := strings.TrimSpace(req.Metadata["factoryName"]); name != "" {
+		return name
+	}
+	return strings.TrimSpace(req.Metadata["name"])
 }
 
 func preExecutionOutcome(req Request) *Outcome {

--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/types.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/types.go
@@ -21,12 +21,15 @@ const (
 
 // Request carries explicit runtime inputs for one simple workflow execution.
 type Request struct {
-	Source         string
-	SourceRef      string
-	SessionID      string
-	Args           json.RawMessage
-	ArgsSchema     json.RawMessage
-	Metadata       map[string]string
+	Source     string
+	SourceRef  string
+	SessionID  string
+	Args       json.RawMessage
+	ArgsSchema json.RawMessage
+	Metadata   map[string]string
+	// FactoryName identifies the named Factory owning this runtime. Direct
+	// callers may omit it; runtime execution falls back to request metadata.
+	FactoryName    string
 	Policy         workflowpolicy.EffectivePolicy
 	Resume         *ResumeContext
 	Agents         map[string]interfaces.FactoryOrchestratorJavaScriptAgent

--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/source/lookup.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/source/lookup.go
@@ -19,6 +19,7 @@ const (
 
 type lookupCandidate struct {
 	stage         LookupStage
+	factoryName   string
 	sourceRef     string
 	filePath      string
 	content       string
@@ -149,6 +150,7 @@ func factoryWorkflowCandidate(files fileSystem, factoryName, factoryDir string, 
 		content := jsCfg.InlineSource.Inline
 		return lookupCandidate{
 			stage:         LookupStageNamedJavaScript,
+			factoryName:   factoryName,
 			sourceRef:     fmt.Sprintf("factory:%s:inline", factoryName),
 			content:       content,
 			agents:        jsCfg.Agents,
@@ -168,6 +170,7 @@ func factoryWorkflowCandidate(files fileSystem, factoryName, factoryDir string, 
 	}
 	return lookupCandidate{
 		stage:         LookupStageNamedJavaScript,
+		factoryName:   factoryName,
 		sourceRef:     fmt.Sprintf("factory:%s:%s", factoryName, filepath.ToSlash(sourceRef)),
 		filePath:      filepath.Join(factoryDir, filepath.FromSlash(sourceRef)),
 		content:       content,
@@ -360,12 +363,22 @@ func resolveInlineSource(kind Kind, value, inline string) (Resolution, bool) {
 	if len(issues) > 0 {
 		return resolutionWithLoadIssues(kind, value, LookupStageExplicitSourceKind, "inline", issues), true
 	}
+	factoryName := ""
+	if kind == KindFactoryInline {
+		var declaration struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal([]byte(value), &declaration); err == nil {
+			factoryName = strings.TrimSpace(declaration.Name)
+		}
+	}
 
 	return Resolution{
 		RequestKind:      kind,
 		RequestValue:     value,
 		ResolvedKind:     kind,
 		LookupStage:      LookupStageExplicitSourceKind,
+		FactoryName:      factoryName,
 		SourceRef:        "inline",
 		SourceHash:       loaded.SourceHash,
 		OrchestratorKind: interfaces.OrchestratorKindJavaScript,
@@ -398,6 +411,7 @@ func resolutionFromCandidate(files fileSystem, requestKind Kind, requestValue st
 		RequestValue:     requestValue,
 		ResolvedKind:     KindWorkflowFile,
 		LookupStage:      candidate.stage,
+		FactoryName:      strings.TrimSpace(candidate.factoryName),
 		SourceRef:        candidate.sourceRef,
 		SourceHash:       loaded.SourceHash,
 		OrchestratorKind: interfaces.OrchestratorKindJavaScript,

--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/source/types.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/source/types.go
@@ -63,10 +63,13 @@ type ArtifactRootDecision struct {
 
 // Resolution is the shared workflow source resolution contract.
 type Resolution struct {
-	RequestKind      Kind
-	RequestValue     string
-	ResolvedKind     Kind
-	LookupStage      LookupStage
+	RequestKind  Kind
+	RequestValue string
+	ResolvedKind Kind
+	LookupStage  LookupStage
+	// FactoryName is the authoritative name of the named JavaScript Factory
+	// that owns the resolved source, when the source came from one.
+	FactoryName      string
 	SourceRef        string
 	SourceHash       string
 	OrchestratorKind string

--- a/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract/policy_child_request.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract/policy_child_request.go
@@ -7,6 +7,7 @@ import (
 
 // ChildRequest is the policy-relevant subset of one child-agent host request.
 type ChildRequest struct {
+	FactoryName     string
 	Label           string
 	Model           string
 	ReasoningEffort string
@@ -25,6 +26,9 @@ type ChildRequest struct {
 // before runtime side effects. It returns a stable diagnostic naming the denied
 // policy field or capability and including safe request context.
 func ValidateChildRequest(policy EffectivePolicy, req ChildRequest) error {
+	if err := validateChildPermission(policy, req); err != nil {
+		return err
+	}
 	if err := validateChildModel(policy, req); err != nil {
 		return err
 	}
@@ -47,6 +51,28 @@ func ValidateChildRequest(policy EffectivePolicy, req ChildRequest) error {
 		return err
 	}
 	return nil
+}
+
+func validateChildPermission(policy EffectivePolicy, req ChildRequest) error {
+	if len(policy.AllowedPermissions) == 0 {
+		return nil
+	}
+
+	requested := PermissionModeDefault
+	if req.SkipPermissions {
+		requested = PermissionModeSkipPermissions
+	}
+	for _, allowed := range policy.AllowedPermissions {
+		if strings.TrimSpace(allowed) == requested {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"policy denied: Factory %q child %q requested permission %q not listed in allowedPermissions",
+		safeFactoryName(req.FactoryName),
+		safeChildLabel(req.Label),
+		requested,
+	)
 }
 
 func validateChildModel(policy EffectivePolicy, req ChildRequest) error {
@@ -203,4 +229,8 @@ func safeChildLabel(label string) string {
 		return "-"
 	}
 	return label
+}
+
+func safeFactoryName(name string) string {
+	return safeChildLabel(name)
 }

--- a/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract/policy_codes.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract/policy_codes.go
@@ -12,6 +12,7 @@ const (
 	CodeUnsupportedRouteProfile   = "workflow.policy.unsupportedRouteProfile"
 	CodeUnsupportedCommand        = "workflow.policy.unsupportedCommand"
 	CodeUnsupportedSandboxMode    = "workflow.policy.unsupportedSandboxMode"
+	CodeUnsupportedPermission     = "workflow.policy.unsupportedPermission"
 	CodeDeniedCapability          = "workflow.policy.deniedCapability"
 	CodeInvalidPolicyDocument     = "workflow.policy.invalidDocument"
 	CodeUnsupportedPolicyMode     = "workflow.policy.unsupportedMode"

--- a/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract/policy_resolve.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract/policy_resolve.go
@@ -24,8 +24,11 @@ func Resolve(request Request) Resolution {
 		return Resolution{Policy: policy, Hash: Hash(policy), Issues: issues}
 	}
 
+	cap := deploymentCap(request)
+	policyIssues := validatePolicyMap(merged, cap)
 	policy, err = policyFromMap(merged)
 	if err != nil {
+		issues = append(issues, policyIssues...)
 		issues = append(issues, Issue{
 			Code:    CodeInvalidPolicyDocument,
 			Message: fmt.Sprintf("invalid effective policy: %v", err),
@@ -34,8 +37,7 @@ func Resolve(request Request) Resolution {
 		return Resolution{Policy: policy, Hash: Hash(policy), Issues: issues}
 	}
 
-	cap := deploymentCap(request)
-	issues = append(issues, validatePolicyMap(merged, cap)...)
+	issues = append(issues, policyIssues...)
 	issues = append(issues, Validate(policy, cap)...)
 	return Resolution{
 		Policy: policy,

--- a/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract/policy_types.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract/policy_types.go
@@ -3,8 +3,10 @@ package orchestratorcontract
 import "encoding/json"
 
 const (
-	ModeReadOnly        = "READ_ONLY"
-	OutputAuditModeAuto = "AUTO"
+	ModeReadOnly                  = "READ_ONLY"
+	OutputAuditModeAuto           = "AUTO"
+	PermissionModeDefault         = "DEFAULT"
+	PermissionModeSkipPermissions = "SKIP_PERMISSIONS"
 )
 
 // Issue is one workflow policy validation diagnostic.
@@ -44,6 +46,7 @@ type EffectivePolicy struct {
 	AllowDangerFullAccess   bool     `json:"allowDangerFullAccess"`
 	WritableRoots           []string `json:"writableRoots"`
 	OutputAuditMode         string   `json:"outputAuditMode"`
+	AllowedPermissions      []string `json:"allowedPermissions,omitempty"`
 	AllowedRunners          []string `json:"allowedRunners,omitempty"`
 	AllowedModels           []string `json:"allowedModels,omitempty"`
 	AllowedReasoningEfforts []string `json:"allowedReasoningEfforts,omitempty"`

--- a/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract/policy_validate.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract/policy_validate.go
@@ -19,6 +19,10 @@ var (
 		"read-only":       {},
 		"workspace-write": {},
 	}
+	knownPermissionModes = map[string]struct{}{
+		PermissionModeDefault:         {},
+		PermissionModeSkipPermissions: {},
+	}
 )
 
 func validatePolicyMap(document map[string]any, deploymentCap int) []Issue {
@@ -28,7 +32,52 @@ func validatePolicyMap(document map[string]any, deploymentCap int) []Issue {
 	issues = append(issues, validatePolicyWritableRootOverride(document)...)
 	issues = append(issues, validatePolicyConcurrencyOverride(document)...)
 	issues = append(issues, validatePolicyMaxAgentsOverride(document, deploymentCap)...)
+	issues = append(issues, validatePolicyAllowedPermissionsShape(document)...)
 	return issues
+}
+
+func validatePolicyAllowedPermissionsShape(document map[string]any) []Issue {
+	value, ok := document["allowedPermissions"]
+	if !ok {
+		return nil
+	}
+
+	values, ok := policyAllowlistValues(value)
+	if !ok {
+		return []Issue{{
+			Code:    CodeUnsupportedPermission,
+			Message: fmt.Sprintf("allowedPermissions must be an array containing only %q or %q", PermissionModeDefault, PermissionModeSkipPermissions),
+			Path:    "policy.allowedPermissions",
+		}}
+	}
+
+	var issues []Issue
+	for index, value := range values {
+		if _, ok := value.(string); ok {
+			continue
+		}
+		issues = append(issues, Issue{
+			Code:    CodeUnsupportedPermission,
+			Message: fmt.Sprintf("allowedPermissions[%d] must be a string containing %q or %q", index, PermissionModeDefault, PermissionModeSkipPermissions),
+			Path:    fmt.Sprintf("policy.allowedPermissions[%d]", index),
+		})
+	}
+	return issues
+}
+
+func policyAllowlistValues(value any) ([]any, bool) {
+	switch typed := value.(type) {
+	case []any:
+		return typed, true
+	case []string:
+		values := make([]any, len(typed))
+		for index, value := range typed {
+			values[index] = value
+		}
+		return values, true
+	default:
+		return nil, false
+	}
 }
 
 func validatePolicyModeOverride(document map[string]any) []Issue {
@@ -184,6 +233,7 @@ func Validate(policy EffectivePolicy, deploymentCap int) []Issue {
 	issues = append(issues, validateStringAllowlist("allowedReasoningEfforts", policy.AllowedReasoningEfforts, validateReasoningEffort)...)
 	issues = append(issues, validateStringAllowlist("allowedRouteProfiles", policy.AllowedRouteProfiles, validateRouteProfile)...)
 	issues = append(issues, validateStringAllowlist("allowedCommands", policy.AllowedCommands, validateCommand)...)
+	issues = append(issues, validateStringAllowlist("allowedPermissions", policy.AllowedPermissions, validatePermission)...)
 	if sandbox := strings.TrimSpace(policy.SandboxMode); sandbox != "" {
 		if _, ok := knownSandboxModes[sandbox]; !ok {
 			issues = append(issues, Issue{
@@ -271,4 +321,14 @@ func validateCommand(value string) *Issue {
 		}
 	}
 	return nil
+}
+
+func validatePermission(value string) *Issue {
+	if _, ok := knownPermissionModes[value]; ok {
+		return nil
+	}
+	return &Issue{
+		Code:    CodeUnsupportedPermission,
+		Message: fmt.Sprintf("unsupported permission %q; allowedPermissions accepts only %q or %q", value, PermissionModeDefault, PermissionModeSkipPermissions),
+	}
 }

--- a/pkg/services/factory_runtime/javascript_policy_child_request_test.go
+++ b/pkg/services/factory_runtime/javascript_policy_child_request_test.go
@@ -102,6 +102,34 @@ func TestValidateChildRequest_AllowlistAndCapabilityDenials(t *testing.T) {
 	}
 }
 
+func TestValidateChildRequest_AllowedPermissionsNamesFactoryChildAndRequestedValue(t *testing.T) {
+	t.Parallel()
+	policy := factory.DefaultJavaScriptPolicy()
+	policy.AllowedPermissions = []string{factory.JavaScriptPolicyPermissionDefault}
+	request := factory.JavaScriptPolicyChildRequest{
+		FactoryName:     "named-factory",
+		Label:           "skip-child",
+		SkipPermissions: true,
+	}
+
+	err := factory.ValidateJavaScriptPolicyChildRequest(policy, request)
+	const want = `policy denied: Factory "named-factory" child "skip-child" requested permission "SKIP_PERMISSIONS" not listed in allowedPermissions`
+	if err == nil || err.Error() != want {
+		t.Fatalf("ValidateChildRequest() error = %v, want exact diagnostic %q", err, want)
+	}
+
+	request.SkipPermissions = false
+	if err := factory.ValidateJavaScriptPolicyChildRequest(policy, request); err != nil {
+		t.Fatalf("ValidateChildRequest() default permission error = %v, want nil", err)
+	}
+
+	policy.AllowedPermissions = nil
+	request.SkipPermissions = true
+	if err := factory.ValidateJavaScriptPolicyChildRequest(policy, request); err != nil {
+		t.Fatalf("ValidateChildRequest() omitted allowlist error = %v, want nil", err)
+	}
+}
+
 func TestValidateChildRequest_AllowsPermittedRequest(t *testing.T) {
 	t.Parallel()
 	policy := factory.DefaultJavaScriptPolicy()

--- a/pkg/services/factory_runtime/javascript_policy_contract.go
+++ b/pkg/services/factory_runtime/javascript_policy_contract.go
@@ -3,8 +3,10 @@ package factory
 import orchestratorcontract "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract"
 
 const (
-	JavaScriptPolicyModeReadOnly        = orchestratorcontract.ModeReadOnly
-	JavaScriptPolicyOutputAuditModeAuto = orchestratorcontract.OutputAuditModeAuto
+	JavaScriptPolicyModeReadOnly              = orchestratorcontract.ModeReadOnly
+	JavaScriptPolicyOutputAuditModeAuto       = orchestratorcontract.OutputAuditModeAuto
+	JavaScriptPolicyPermissionDefault         = orchestratorcontract.PermissionModeDefault
+	JavaScriptPolicyPermissionSkipPermissions = orchestratorcontract.PermissionModeSkipPermissions
 
 	JavaScriptPolicyCapabilityWorkspaceWrite   = orchestratorcontract.CapabilityWorkspaceWrite
 	JavaScriptPolicyCapabilityFilesystemWrite  = orchestratorcontract.CapabilityFilesystemWrite
@@ -24,6 +26,7 @@ const (
 	JavaScriptPolicyCodeUnsupportedRouteProfile   = orchestratorcontract.CodeUnsupportedRouteProfile
 	JavaScriptPolicyCodeUnsupportedCommand        = orchestratorcontract.CodeUnsupportedCommand
 	JavaScriptPolicyCodeUnsupportedSandboxMode    = orchestratorcontract.CodeUnsupportedSandboxMode
+	JavaScriptPolicyCodeUnsupportedPermission     = orchestratorcontract.CodeUnsupportedPermission
 	JavaScriptPolicyCodeDeniedCapability          = orchestratorcontract.CodeDeniedCapability
 	JavaScriptPolicyCodeInvalidPolicyDocument     = orchestratorcontract.CodeInvalidPolicyDocument
 	JavaScriptPolicyCodeUnsupportedPolicyMode     = orchestratorcontract.CodeUnsupportedPolicyMode

--- a/pkg/services/factory_runtime/javascript_policy_test.go
+++ b/pkg/services/factory_runtime/javascript_policy_test.go
@@ -3,6 +3,7 @@ package factory_test
 import (
 	"encoding/json"
 	"reflect"
+	"slices"
 	"testing"
 
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
@@ -35,6 +36,80 @@ func TestDefaultEffectivePolicy_MatchesReadOnlyMVPDefaults(t *testing.T) {
 	if policy.OutputAuditMode != factory.JavaScriptPolicyOutputAuditModeAuto {
 		t.Fatalf("outputAuditMode = %q, want AUTO", policy.OutputAuditMode)
 	}
+	if len(policy.AllowedPermissions) != 0 {
+		t.Fatalf("allowedPermissions = %#v, want omitted by default", policy.AllowedPermissions)
+	}
+}
+
+func TestResolve_AllowedPermissionsAcceptsCanonicalValues(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{
+			name: "default",
+			raw:  `{"allowedPermissions":["DEFAULT"]}`,
+			want: []string{factory.JavaScriptPolicyPermissionDefault},
+		},
+		{
+			name: "skip permissions",
+			raw:  `{"allowedPermissions":["SKIP_PERMISSIONS"]}`,
+			want: []string{factory.JavaScriptPolicyPermissionSkipPermissions},
+		},
+		{
+			name: "both",
+			raw:  `{"allowedPermissions":["DEFAULT","SKIP_PERMISSIONS"]}`,
+			want: []string{
+				factory.JavaScriptPolicyPermissionDefault,
+				factory.JavaScriptPolicyPermissionSkipPermissions,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resolution := factory.ResolveJavaScriptFactoryDefaultPolicy(json.RawMessage(tc.raw))
+			if len(resolution.Issues) != 0 {
+				t.Fatalf("policy issues = %#v, want none", resolution.Issues)
+			}
+			if got := resolution.Policy.AllowedPermissions; !slices.Equal(got, tc.want) {
+				t.Fatalf("allowedPermissions = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolve_RejectsUnsupportedAllowedPermissionAtIndexedPolicyPath(t *testing.T) {
+	t.Parallel()
+	resolution := factory.ResolveJavaScriptPolicy(factory.JavaScriptPolicyRequest{
+		Requested: map[string]any{
+			"allowedPermissions": []any{
+				factory.JavaScriptPolicyPermissionDefault,
+				"WRITE",
+			},
+		},
+	})
+
+	for _, issue := range resolution.Issues {
+		if issue.Code == factory.JavaScriptPolicyCodeUnsupportedPermission && issue.Path == "policy.allowedPermissions[1]" {
+			return
+		}
+	}
+	t.Fatalf("policy issues = %#v, want unsupported permission at policy.allowedPermissions[1]", resolution.Issues)
+}
+
+func TestResolve_RejectsMalformedAllowedPermissionEntryAtIndexedPolicyPath(t *testing.T) {
+	t.Parallel()
+	resolution := factory.ResolveJavaScriptFactoryDefaultPolicy(json.RawMessage(`{"allowedPermissions":["DEFAULT",7]}`))
+
+	for _, issue := range resolution.Issues {
+		if issue.Code == factory.JavaScriptPolicyCodeUnsupportedPermission && issue.Path == "policy.allowedPermissions[1]" {
+			return
+		}
+	}
+	t.Fatalf("policy issues = %#v, want malformed permission at policy.allowedPermissions[1]", resolution.Issues)
 }
 
 func TestHash_StableAcrossMapOrdering(t *testing.T) {
@@ -289,4 +364,30 @@ func TestOrchestratorTargets_RejectsInvalidDefaultPolicy(t *testing.T) {
 	if !found {
 		t.Fatalf("targets = %#v, want excessiveMaxAgents from orchestrator policy validation", targets)
 	}
+}
+
+func TestOrchestratorTargets_MapsAllowedPermissionIssueToDefaultPolicyPath(t *testing.T) {
+	t.Parallel()
+	cfg := &interfaces.FactoryConfig{
+		Orchestrator: &interfaces.FactoryOrchestratorConfig{
+			Kind: interfaces.OrchestratorKindJavaScript,
+			JavaScript: &interfaces.FactoryOrchestratorJavaScriptConfig{
+				SourceRef:     "factory/workflows/review.js",
+				DefaultPolicy: json.RawMessage(`{"allowedPermissions":["DEFAULT","WRITE"]}`),
+			},
+		},
+	}
+	targets := factoryruntimewire.NewOrchestratorDefinitionValidator(testJavaScriptWorkflows()).
+		ValidateJavaScriptFactoryDefinition(
+			t.Context(),
+			cfg.Orchestrator.JavaScript,
+			nil,
+		)
+	for _, target := range targets {
+		if target.Code == factory.JavaScriptPolicyCodeUnsupportedPermission &&
+			target.Path == "factory.orchestrator.javascript.defaultPolicy.allowedPermissions[1]" {
+			return
+		}
+	}
+	t.Fatalf("targets = %#v, want unsupported permission at defaultPolicy.allowedPermissions[1]", targets)
 }

--- a/pkg/services/factory_runtime/javascript_source_test.go
+++ b/pkg/services/factory_runtime/javascript_source_test.go
@@ -177,11 +177,48 @@ func TestResolve_FactoryID_ResolvesJavaScriptFactory(t *testing.T) {
 	if resolution.SourceRef != "factory:review-flow:workflows/review.js" {
 		t.Fatalf("source ref = %q", resolution.SourceRef)
 	}
+	if resolution.FactoryName != "review-flow" {
+		t.Fatalf("factory name = %q, want review-flow", resolution.FactoryName)
+	}
 	if !bytes.Contains(resolution.ArgsSchema, []byte(`"topic"`)) {
 		t.Fatalf("args schema = %s, want authored factory schema", resolution.ArgsSchema)
 	}
 	if !bytes.Contains(resolution.DefaultPolicy, []byte(`"maxAgents":2`)) {
 		t.Fatalf("default policy = %s, want authored factory policy", resolution.DefaultPolicy)
+	}
+}
+
+func TestResolve_WorkflowName_PreservesOwningFactoryNameWhenSourceNameDiffers(t *testing.T) {
+	t.Parallel()
+	projectRoot := t.TempDir()
+	factoryRoot := filepath.Join(projectRoot, interfaces.FactoryDir)
+	factoryDir := writeJavaScriptFactorySourceFixture(
+		t,
+		factoryRoot,
+		"named-factory",
+		"workflows/review.js",
+	)
+	workflowDir := filepath.Join(factoryDir, "workflows")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("mkdir workflows: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "review.js"), []byte(sourceValidWorkflowSource), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	resolution := factoryWorkflowDefinitions.ResolveSource(factory.WorkflowSourceRequest{
+		Kind:  factory.WorkflowSourceKindWorkflowName,
+		Value: "review",
+	}, testContext(t, projectRoot))
+
+	if !resolution.Found {
+		t.Fatalf("resolution = %#v, want found named Factory workflow", resolution)
+	}
+	if resolution.SourceRef != "factory:named-factory:workflows/review.js" {
+		t.Fatalf("source ref = %q, want named Factory source ref", resolution.SourceRef)
+	}
+	if resolution.FactoryName != "named-factory" {
+		t.Fatalf("factory name = %q, want named-factory", resolution.FactoryName)
 	}
 }
 
@@ -222,6 +259,26 @@ func TestResolve_InlineWorkflow_ComputesStableHash(t *testing.T) {
 
 	if !first.Found || first.SourceHash == "" || first.SourceHash != second.SourceHash {
 		t.Fatalf("hashes = (%q, %q), want stable non-empty hash", first.SourceHash, second.SourceHash)
+	}
+}
+
+func TestResolve_FactoryInline_PreservesDeclaredFactoryName(t *testing.T) {
+	t.Parallel()
+	projectRoot := t.TempDir()
+	factoryDir := filepath.Join(projectRoot, interfaces.FactoryDir)
+	if err := os.MkdirAll(factoryDir, 0o755); err != nil {
+		t.Fatalf("mkdir factory root: %v", err)
+	}
+	resolution := factoryWorkflowDefinitions.ResolveSource(factory.WorkflowSourceRequest{
+		Kind:  factory.WorkflowSourceKindFactoryInline,
+		Value: javascriptFactoryPayload("named-factory", "workflows/review.js"),
+	}, testContext(t, projectRoot))
+
+	if !resolution.Found {
+		t.Fatalf("resolution = %#v, want found Factory inline source", resolution)
+	}
+	if resolution.FactoryName != "named-factory" {
+		t.Fatalf("factory name = %q, want named-factory", resolution.FactoryName)
 	}
 }
 

--- a/pkg/services/factory_sessions/internal/execution/normalize.go
+++ b/pkg/services/factory_sessions/internal/execution/normalize.go
@@ -83,7 +83,11 @@ func normalizeSource(source Source) (Source, error) {
 		if workflowFile == "" {
 			return Source{}, NewValidationError("source.workflowFile", "workflowFile is required when source.kind is WORKFLOW_FILE")
 		}
-		return Source{Kind: source.Kind, WorkflowFile: workflowFile}, nil
+		return Source{
+			Kind:           source.Kind,
+			WorkflowFile:   workflowFile,
+			InlineWorkflow: cloneInlineWorkflowSource(source.InlineWorkflow),
+		}, nil
 	case workflowsource.WorkflowSourceKindWorkflowName:
 		workflowName := strings.TrimSpace(source.WorkflowName)
 		if workflowName == "" {
@@ -124,6 +128,18 @@ func cloneJavaScriptAgents(agents map[string]interfaces.FactoryOrchestratorJavaS
 		cloned[name] = agent
 	}
 	return cloned
+}
+
+func cloneInlineWorkflowSource(source *InlineWorkflowSource) *InlineWorkflowSource {
+	if source == nil {
+		return nil
+	}
+	cloned := *source
+	cloned.Metadata = cloneStringMap(source.Metadata)
+	cloned.Agents = cloneJavaScriptAgents(source.Agents)
+	cloned.ArgsSchema = append(json.RawMessage(nil), source.ArgsSchema...)
+	cloned.DefaultPolicy = append(json.RawMessage(nil), source.DefaultPolicy...)
+	return &cloned
 }
 
 func cloneArgs(args map[string]any) map[string]any {
@@ -237,7 +253,10 @@ func isKnownWorkflowSourceKind(kind workflowsource.WorkflowSourceKind) bool {
 	}
 }
 
-func factoryNameFromStart(req StartRequest) string {
+func factoryNameFromStart(req StartRequest, resolved ResolvedSource) string {
+	if name := strings.TrimSpace(resolved.Metadata["factoryName"]); name != "" {
+		return name
+	}
 	switch req.Source.Kind {
 	case workflowsource.WorkflowSourceKindFactoryID:
 		return strings.TrimSpace(req.Source.FactoryID)

--- a/pkg/services/factory_sessions/internal/execution/normalize.go
+++ b/pkg/services/factory_sessions/internal/execution/normalize.go
@@ -237,6 +237,26 @@ func isKnownWorkflowSourceKind(kind workflowsource.WorkflowSourceKind) bool {
 	}
 }
 
+func factoryNameFromStart(req StartRequest) string {
+	switch req.Source.Kind {
+	case workflowsource.WorkflowSourceKindFactoryID:
+		return strings.TrimSpace(req.Source.FactoryID)
+	case workflowsource.WorkflowSourceKindFactoryInline:
+		var declaration struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(req.Source.FactoryInline, &declaration); err == nil {
+			return strings.TrimSpace(declaration.Name)
+		}
+	}
+	if req.Source.InlineWorkflow != nil {
+		if name := strings.TrimSpace(req.Source.InlineWorkflow.Metadata["factoryName"]); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
 func validateTimeRange(field string, after, before *time.Time) error {
 	if after != nil && before != nil && after.After(*before) {
 		return NewValidationError(field, "after must be before or equal to before")

--- a/pkg/services/factory_sessions/internal/execution/prepare_start.go
+++ b/pkg/services/factory_sessions/internal/execution/prepare_start.go
@@ -180,6 +180,9 @@ func resolveStartSourceWithResolution(
 		ArgsSchema:    append(json.RawMessage(nil), resolution.ArgsSchema...),
 		DefaultPolicy: append(json.RawMessage(nil), resolution.DefaultPolicy...),
 	}
+	if factoryName := strings.TrimSpace(resolution.FactoryName); factoryName != "" {
+		resolved.Metadata["factoryName"] = factoryName
+	}
 	if stage := resolutionOrderForLookupStage(resolution.LookupStage); stage != "" {
 		resolved.ResolutionOrder = []string{stage}
 	}
@@ -191,6 +194,9 @@ func applyInlineFactoryDeclaration(resolution *factory.WorkflowSourceResolution,
 		return
 	}
 	inline := source.InlineWorkflow
+	if factoryName := strings.TrimSpace(inline.Metadata["factoryName"]); factoryName != "" {
+		resolution.FactoryName = factoryName
+	}
 	switch source.Kind {
 	case factory.WorkflowSourceKindInlineWorkflow:
 		if sourceRef := strings.TrimSpace(inline.Metadata["sourceRef"]); sourceRef != "" {

--- a/pkg/services/factory_sessions/internal/execution/resume.go
+++ b/pkg/services/factory_sessions/internal/execution/resume.go
@@ -440,7 +440,7 @@ func (s *JavaScriptRuntimeService) invokeWorkflowRuntimeWithResume(
 		Args:        argsJSON,
 		ArgsSchema:  resolved.ArgsSchema,
 		Metadata:    workflowMetadataFromResolved(resolved, normalized),
-		FactoryName: factoryNameFromStart(normalized),
+		FactoryName: factoryNameFromStart(normalized, resolved),
 		Policy:      policyResolution.Policy,
 		Resume:      resume,
 	}, s.childExecutorHooks(resolveChildExecutorMode(s.childExecutorMode, normalized), sessionID))

--- a/pkg/services/factory_sessions/internal/execution/resume.go
+++ b/pkg/services/factory_sessions/internal/execution/resume.go
@@ -434,14 +434,15 @@ func (s *JavaScriptRuntimeService) invokeWorkflowRuntimeWithResume(
 		return workflowresult.JavaScriptRuntimeOutcome{}, err
 	}
 	return s.orchestration.RunJavaScript(ctx, workflowresult.JavaScriptRuntimeRequest{
-		Source:     sourceContent,
-		SourceRef:  resolved.SourceRef,
-		SessionID:  sessionID,
-		Args:       argsJSON,
-		ArgsSchema: resolved.ArgsSchema,
-		Metadata:   workflowMetadataFromResolved(resolved, normalized),
-		Policy:     policyResolution.Policy,
-		Resume:     resume,
+		Source:      sourceContent,
+		SourceRef:   resolved.SourceRef,
+		SessionID:   sessionID,
+		Args:        argsJSON,
+		ArgsSchema:  resolved.ArgsSchema,
+		Metadata:    workflowMetadataFromResolved(resolved, normalized),
+		FactoryName: factoryNameFromStart(normalized),
+		Policy:      policyResolution.Policy,
+		Resume:      resume,
 	}, s.childExecutorHooks(resolveChildExecutorMode(s.childExecutorMode, normalized), sessionID))
 }
 

--- a/pkg/services/factory_sessions/internal/execution/runtime_service.go
+++ b/pkg/services/factory_sessions/internal/execution/runtime_service.go
@@ -794,7 +794,7 @@ func (s *JavaScriptRuntimeService) invokeWorkflowRuntime(
 		Args:           argsJSON,
 		ArgsSchema:     resolved.ArgsSchema,
 		Metadata:       workflowMetadataFromResolved(resolved, normalized),
-		FactoryName:    factoryNameFromStart(normalized),
+		FactoryName:    factoryNameFromStart(normalized, resolved),
 		Policy:         policyResolution.Policy,
 		Agents:         resolved.Agents,
 		WorkerSettings: s.workerSettings,

--- a/pkg/services/factory_sessions/internal/execution/runtime_service.go
+++ b/pkg/services/factory_sessions/internal/execution/runtime_service.go
@@ -794,10 +794,31 @@ func (s *JavaScriptRuntimeService) invokeWorkflowRuntime(
 		Args:           argsJSON,
 		ArgsSchema:     resolved.ArgsSchema,
 		Metadata:       workflowMetadataFromResolved(resolved, normalized),
+		FactoryName:    factoryNameFromStart(normalized),
 		Policy:         policyResolution.Policy,
 		Agents:         resolved.Agents,
 		WorkerSettings: s.workerSettings,
 	}, s.childExecutorHooks(resolveChildExecutorMode(s.childExecutorMode, normalized), sessionID))
+}
+
+func factoryNameFromStart(req StartRequest) string {
+	switch req.Source.Kind {
+	case factory.WorkflowSourceKindFactoryID:
+		return strings.TrimSpace(req.Source.FactoryID)
+	case factory.WorkflowSourceKindFactoryInline:
+		var declaration struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(req.Source.FactoryInline, &declaration); err == nil {
+			return strings.TrimSpace(declaration.Name)
+		}
+	}
+	if req.Source.InlineWorkflow != nil {
+		if name := strings.TrimSpace(req.Source.InlineWorkflow.Metadata["factoryName"]); name != "" {
+			return name
+		}
+	}
+	return ""
 }
 
 func workflowRunContext(parent context.Context, policy factory.JavaScriptPolicy) (context.Context, context.CancelFunc) {

--- a/pkg/services/factory_sessions/internal/execution/runtime_service.go
+++ b/pkg/services/factory_sessions/internal/execution/runtime_service.go
@@ -801,26 +801,6 @@ func (s *JavaScriptRuntimeService) invokeWorkflowRuntime(
 	}, s.childExecutorHooks(resolveChildExecutorMode(s.childExecutorMode, normalized), sessionID))
 }
 
-func factoryNameFromStart(req StartRequest) string {
-	switch req.Source.Kind {
-	case factory.WorkflowSourceKindFactoryID:
-		return strings.TrimSpace(req.Source.FactoryID)
-	case factory.WorkflowSourceKindFactoryInline:
-		var declaration struct {
-			Name string `json:"name"`
-		}
-		if err := json.Unmarshal(req.Source.FactoryInline, &declaration); err == nil {
-			return strings.TrimSpace(declaration.Name)
-		}
-	}
-	if req.Source.InlineWorkflow != nil {
-		if name := strings.TrimSpace(req.Source.InlineWorkflow.Metadata["factoryName"]); name != "" {
-			return name
-		}
-	}
-	return ""
-}
-
 func workflowRunContext(parent context.Context, policy factory.JavaScriptPolicy) (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(parent)
 	if policy.MaxRunDurationMs == nil || *policy.MaxRunDurationMs <= 0 {

--- a/pkg/services/factory_sessions/internal/runtimeopening/invocation/operation.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/invocation/operation.go
@@ -427,7 +427,7 @@ func javaScriptWorkflowSource(
 		source.Kind = factoryruntime.WorkflowSourceKindInlineWorkflow
 		source.InlineWorkflow = &factorysessions.InlineWorkflowSource{
 			Dialect: js.Dialect, InlineSource: js.InlineSource.Inline, Entrypoint: js.Entrypoint,
-			Metadata: cloneStringMap(js.Metadata), Agents: cloneJavaScriptAgents(js.Agents),
+			Metadata: javaScriptFactoryMetadata(js, projection), Agents: cloneJavaScriptAgents(js.Agents),
 			ArgsSchema:    append(json.RawMessage(nil), js.ArgsSchema...),
 			DefaultPolicy: append(json.RawMessage(nil), js.DefaultPolicy...),
 		}
@@ -445,14 +445,33 @@ func javaScriptWorkflowSource(
 		}
 		source.WorkflowFile = filepath.Join(factoryDir, source.WorkflowFile)
 	}
-	if len(js.DefaultPolicy) > 0 || len(js.ArgsSchema) > 0 || len(js.Agents) > 0 {
+	metadata := javaScriptFactoryMetadata(js, projection)
+	if len(js.DefaultPolicy) > 0 || len(js.ArgsSchema) > 0 || len(js.Agents) > 0 || len(metadata) > 0 {
 		source.InlineWorkflow = &factorysessions.InlineWorkflowSource{
+			Metadata:      metadata,
 			Agents:        cloneJavaScriptAgents(js.Agents),
 			ArgsSchema:    append(json.RawMessage(nil), js.ArgsSchema...),
 			DefaultPolicy: append(json.RawMessage(nil), js.DefaultPolicy...),
 		}
 	}
 	return source, nil
+}
+
+func javaScriptFactoryMetadata(
+	js *factorydefinitions.FactoryOrchestratorJavaScriptConfig,
+	projection factorysessions.ProjectionContext,
+) map[string]string {
+	metadata := cloneStringMap(js.Metadata)
+	if projection.FactoryCfg == nil {
+		return metadata
+	}
+	if factoryName := strings.TrimSpace(projection.FactoryCfg.Name); factoryName != "" {
+		if metadata == nil {
+			metadata = make(map[string]string)
+		}
+		metadata["factoryName"] = factoryName
+	}
+	return metadata
 }
 
 func factoryDefaultPolicyMap(raw json.RawMessage) map[string]any {

--- a/tests/functional/orchestration/javascript/workers/permissions_matrix_test.go
+++ b/tests/functional/orchestration/javascript/workers/permissions_matrix_test.go
@@ -1,13 +1,27 @@
 package workers_test
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/portpowered/infinite-you/pkg/root"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
+
+const stableDisallowedPermissionDiagnostic = `policy denied: Factory "named-factory" child "skip-child" requested permission "SKIP_PERMISSIONS" not listed in allowedPermissions`
+
+const disallowedPermissionWorkflow = `return (async function () {
+  return await agent.run({
+    prompt: "permission denial child",
+    label: "skip-child",
+    modelProvider: "codex",
+    skipPermissions: true
+  });
+})();`
 
 func TestJavaScriptAgentRunCodexCommandCharacterization(t *testing.T) {
 	tests := []struct {
@@ -85,6 +99,50 @@ func TestJavaScriptAgentRunCodexCommandCharacterization(t *testing.T) {
 	}
 }
 
+func TestJavaScriptAgentRunDisallowedPermissionFailsThroughPublicCLI(t *testing.T) {
+	t.Parallel()
+
+	dir := support.ScaffoldFactory(t, disallowedPermissionFactoryConfig())
+	workflowDir := filepath.Join(dir, "workflows")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("create workflow directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "review.js"), []byte(disallowedPermissionWorkflow), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	runner := support.NewRecordingCommandRunner("unexpected provider execution")
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "--json", "run",
+		"--factory", filepath.Join(dir, "factory.json"),
+		"--output", "primary",
+		"--no-record",
+		"permission denial prompt",
+	})
+	inputs.Input.WorkingDirectory = dir
+	homeDir := t.TempDir()
+	inputs.Input.Env = append(inputs.Input.Env, "HOME="+homeDir, "USERPROFILE="+homeDir)
+
+	process, err := root.BuildProcess(t.Context(), serviceedges.Edges{
+		ProviderCommandRunner: runner,
+	})
+	if err != nil {
+		t.Fatalf("root.BuildProcess() error = %v", err)
+	}
+	support.CleanupProcess(t, process)
+
+	err = process.Execute(inputs.Input)
+	if err == nil {
+		t.Fatalf("Process.Execute() error = nil; stdout:\n%s\nstderr:\n%s", inputs.Stdout(), inputs.Stderr())
+	}
+	output := strings.Join([]string{inputs.Stdout(), inputs.Stderr(), err.Error()}, "\n")
+	if !strings.Contains(output, stableDisallowedPermissionDiagnostic) {
+		t.Fatalf("public denial diagnostic = %q, want %q", output, stableDisallowedPermissionDiagnostic)
+	}
+	if runner.CallCount() != 0 {
+		t.Fatalf("provider command runner call count = %d, want 0 before denied child dispatch", runner.CallCount())
+	}
+}
+
 func permissionMatrixFactoryConfig(mode, source string) map[string]any {
 	defaultPolicy := map[string]any{}
 	if mode != "" {
@@ -112,6 +170,19 @@ func permissionMatrixFactoryConfig(mode, source string) map[string]any {
 			},
 			"defaultPolicy": defaultPolicy,
 		},
+	}
+	return config
+}
+
+func disallowedPermissionFactoryConfig() map[string]any {
+	config := permissionMatrixFactoryConfig("", disallowedPermissionWorkflow)
+	config["name"] = "named-factory"
+	orchestrator := config["orchestrator"].(map[string]any)
+	javascript := orchestrator["javascript"].(map[string]any)
+	javascript["sourceRef"] = "workflows/review.js"
+	delete(javascript, "inlineSource")
+	javascript["defaultPolicy"] = map[string]any{
+		"allowedPermissions": []any{"DEFAULT"},
 	}
 	return config
 }


### PR DESCRIPTION
{
  "project": "JS-P3 Allowed Permissions Validation",
  "branchName": "js-p3-allowed-permissions-validation",
  "description": "Add defaultPolicy.allowedPermissions as an auditable allowlist over the JavaScript agent.run permissions enum, reject disallowed child requests before any Dispatch exists with a diagnostic naming the Factory, child label, and requested value, and preserve allowed provider command behavior and JS-P2 compatibility.",
  "context": {
    "customerAsk": "Implement PLAN-JS-001 step JS-P3 only: introduce allowedPermissions, reject a child requesting SKIP_PERMISSIONS when the Factory allows only DEFAULT before dispatch, provide an operator-actionable diagnostic, preserve allowed execution, and leave JS-P1 characterization and JS-P4-owned deletion work unchanged.",
    "problem": "JavaScript workflow policy cannot currently audit or prohibit the provider permission mode selected by a child before work is dispatched. READ_ONLY capability language cannot safely fill this gap because the Factory does not control provider-owned shell, filesystem, or network tools.",
    "solution": "Resolve an optional allowedPermissions allowlist containing canonical DEFAULT and SKIP_PERMISSIONS values in Factory Runtime, validate each child against it at the existing pre-side-effect admission boundary using explicit Factory and child context, and preserve current behavior when the permission is allowed or the field is omitted."
  },
  "acceptanceCriteria": [
    "A JavaScript Factory defaultPolicy accepts allowedPermissions as an allowlist over the canonical DEFAULT and SKIP_PERMISSIONS values; unsupported entries produce a policy validation issue at the relevant policy path, and omitting the field preserves existing behavior.",
    "Given a named Factory whose allowedPermissions is [\"DEFAULT\"], a labeled child requesting SKIP_PERMISSIONS fails validation with a stable diagnostic that explicitly contains the Factory name, child label, and requested value; the focused test asserts the complete literal diagnostic and the PR evidence pastes it and identifies all three values.",
    "The disallowed request is rejected before dispatch: behavioral evidence asserts that the outcome contains no Dispatch record of any status and that the child executor/provider command runner was never invoked, with the negative assertions explained in the PR body or comment.",
    "Allowed combinations still execute with the provider command line unchanged under JS-P1 characterization; JS-P1 assertions remain unmodified, while skipPermissions and all capability-policy fields reserved for JS-P4 remain present.",
    "Quality gates: Typecheck and make test pass, along with targeted Factory Runtime policy and JavaScript orchestration tests; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Known inherited Backend Lint or derived Verification Policy failures are diagnosed against current main without changing the dead-code baseline or unrelated symbols.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "js-p3-allowed-permissions-validation-001",
      "title": "Declare an auditable permission allowlist",
      "description": "As a Factory author, I want defaultPolicy.allowedPermissions to accept only the permission modes the runtime actually controls so that the Factory manifest truthfully describes permitted child requests.",
      "acceptanceCriteria": [
        "A Factory policy containing allowedPermissions with DEFAULT, SKIP_PERMISSIONS, or both resolves with those canonical values available to child validation.",
        "An unsupported or malformed allowlist entry is reported as a policy validation issue at its allowedPermissions path before workflow execution begins.",
        "Omitting allowedPermissions leaves JS-P2 child permission behavior backward compatible and does not create an implicit denial.",
        "The resolved policy remains explicit request data owned by Factory Runtime and introduces no hidden mutable state or provider-side enforcement claim.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added optional EffectivePolicy.allowedPermissions with canonical DEFAULT/SKIP_PERMISSIONS values, indexed validation diagnostics for unsupported or malformed entries, Factory Definition path mapping coverage, and focused runtime tests."
    },
    {
      "id": "js-p3-allowed-permissions-validation-002",
      "title": "Reject disallowed child permissions before dispatch",
      "description": "As an operator, I want a disallowed child permission request rejected before Dispatch creation with enough context to identify the request so that prohibited provider bypasses cannot begin silently.",
      "acceptanceCriteria": [
        "For a named Factory with allowedPermissions [DEFAULT], a labeled child requesting permissions SKIP_PERMISSIONS fails at the pre-dispatch validation boundary.",
        "The denial diagnostic's complete literal text is asserted and includes the Factory name, child label, and SKIP_PERMISSIONS requested value; the same literal is pasted into the PR evidence with those three portions identified.",
        "The denied outcome has no Dispatch record of any status, and the child executor/provider command runner records zero calls; the PR evidence explains both absence checks.",
        "A child requesting an allowed permission succeeds, and the provider command line remains exactly the JS-P1-characterized command for that permission mode.",
        "Existing JS-P1 characterization assertions are unchanged and green, and neither skipPermissions nor the JS-P4-owned capability axis is removed or weakened.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Enforced allowedPermissions at the JavaScript child pre-dispatch boundary with Factory/child/requested-value diagnostics, zero executor/record side effects on denial, allowed and omitted compatibility coverage, named Factory propagation for live/resumed execution, and a public root.BuildProcess CLI regression for differing review.js/named-factory identity. Focused runtime/session/functional tests, the full make test lane on rebased origin/main, typecheck, vet, and structural gates pass; make lint has one unrelated packaged-factory-consumption baseline failure in untouched internal/migrationledgercheck/packaged_factory_matrix.go."
    }
  ]
}
