### PR TITLE
int-harness-validation-tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,6 +533,39 @@ jobs:
           CHANGED_TEST_STABILITY_BUDGET: 15m
         run: make test-changed-test-stability
 
+  backend-integration:
+    name: Backend Integration
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: Verify Backend Integration event selection
+        env:
+          BACKEND_INTEGRATION_EVENT_NAME: ${{ github.event_name }}
+          BACKEND_INTEGRATION_REF: ${{ github.ref }}
+        run: |
+          node --input-type=module <<'NODE'
+          import { selectBackendIntegration } from './scripts/ci/backend-integration-workflow.mjs';
+
+          const selection = selectBackendIntegration({
+            eventName: process.env.BACKEND_INTEGRATION_EVENT_NAME,
+            ref: process.env.BACKEND_INTEGRATION_REF,
+          });
+          if (!selection.selected || selection.error) {
+            throw new Error(`Backend Integration was not selected for its hosted event: ${JSON.stringify(selection)}`);
+          }
+          console.log(`Backend Integration selected for ${process.env.BACKEND_INTEGRATION_EVENT_NAME}`);
+          NODE
+      - run: make test-integration
+
   backend-lint:
     name: Backend Lint
     if: github.event_name == 'pull_request' || github.event_name == 'push'
@@ -752,7 +785,7 @@ jobs:
 
   verification-policy:
     name: Verification Policy
-    needs: [classify, workflow-lint, docs-reference, readme, frontend, frontend-component, ui-coverage, frontend-browser, frontend-storybook, backend-coverage, backend-test-stability, backend-lint, ui-backend-integration, development-package]
+    needs: [classify, workflow-lint, docs-reference, readme, frontend, frontend-component, ui-coverage, frontend-browser, frontend-storybook, backend-coverage, backend-test-stability, backend-integration, backend-lint, ui-backend-integration, development-package]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -782,6 +815,8 @@ jobs:
           FRONTEND_REASON: ${{ needs.classify.outputs.frontend_reason }}
           BACKEND_REASON: ${{ needs.classify.outputs.backend_reason }}
           UI_BACKEND_REASON: ${{ needs.classify.outputs.ui_backend_integration_reason }}
+          RUN_BACKEND_INTEGRATION: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+          BACKEND_INTEGRATION_REASON: "The installed-binary validation tier is required on pull requests and protected-main pushes."
           API_REASON: ${{ needs.classify.outputs.api_package_reason }}
           PACKAGED_REASON: ${{ needs.classify.outputs.packaged_factories_package_reason }}
           PROVIDERS_REASON: ${{ needs.classify.outputs.model_providers_package_reason }}
@@ -803,6 +838,7 @@ jobs:
           RUN_WORKFLOW_LINT: "true"
           WORKFLOW_LINT_REASON: "Every repository workflow must pass pinned schema-aware lint on every pull request and push to main."
           WORKFLOW_LINT_RESULT: ${{ needs.workflow-lint.result }}
+          BACKEND_INTEGRATION_RESULT: ${{ needs.backend-integration.result }}
           UI_BACKEND_RESULT: ${{ needs.ui-backend-integration.result }}
           PACKAGE_WORKFLOW_RESULT: ${{ needs.development-package.result }}
           API_RESULT: ${{ needs.development-package.outputs.api_package_result }}

--- a/Makefile
+++ b/Makefile
@@ -493,7 +493,7 @@ readme-check:
 test: test-unit test-ci-workflows
 
 test-ci-workflows:
-	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs scripts/ci/lane-budget.test.mjs scripts/ci/backend-lint-report.test.mjs scripts/ci/backend-lint-workflow.test.mjs scripts/ci/functional-coverage-comment.test.mjs scripts/ci/functional-coverage-verdict.test.mjs scripts/ci/unit-coverage-report.test.mjs scripts/ci/workflow-lint.test.mjs scripts/localai-backend-artifact-workflow.test.mjs
+	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs scripts/ci/lane-budget.test.mjs scripts/ci/backend-integration-workflow.test.mjs scripts/ci/backend-lint-report.test.mjs scripts/ci/backend-lint-workflow.test.mjs scripts/ci/functional-coverage-comment.test.mjs scripts/ci/functional-coverage-verdict.test.mjs scripts/ci/unit-coverage-report.test.mjs scripts/ci/workflow-lint.test.mjs scripts/localai-backend-artifact-workflow.test.mjs
 
 test-full:
 	$(GO) test ./... -timeout $(GO_TEST_TIMEOUT)
@@ -519,6 +519,8 @@ test-maintenance:
 	$(GO) test -short -p=$(UNIT_DEFAULT_JOBS) ./cmd/... ./internal/... ./packages/model-providers ./packages/packaged-factories ./tests/functional/internal/... ./ui ./pkg/services/factory_runtime/internal/exhaustiontests -count=1 -timeout $(GO_TEST_TIMEOUT)
 
 test-integration:
+	$(GO) test -short ./tests/integration -count=1 -timeout $(GO_TEST_TIMEOUT)
+	$(GO) test -short ./tests/integration/harness -count=1 -timeout $(GO_TEST_TIMEOUT)
 	$(GO) test -short -p=$(UNIT_DEFAULT_JOBS) ./pkg/services/factory_definitions/internal/services/compilation/runtimetests ./pkg/services/factory_definitions/internal/services/catalog/persistence/integrationtests ./pkg/services/factory_definitions/internal/services/snapshots_portability/portableconfig/integrationtests ./pkg/services/factory_sessions/internal/execution/fixtures ./pkg/transports/http/servertests/... ./tests/integration/factory/visualization/runtime_metrics ./tests/integration/transport/cli/process ./tests/integration/transport/server_binding -count=1 -timeout $(GO_TEST_TIMEOUT)
 	$(GO) test ./pkg/services/automations/internal/services/filesystem_watchers/internal/service -run '^TestFileWatcher_' -count=1 -timeout $(GO_TEST_TIMEOUT)
 	$(GO) test ./pkg/platform/process -run '^TestExecCommandRunner_' -count=1 -timeout $(GO_TEST_TIMEOUT)

--- a/scripts/ci/backend-integration-workflow.mjs
+++ b/scripts/ci/backend-integration-workflow.mjs
@@ -1,0 +1,6 @@
+export function selectBackendIntegration({ eventName = "", ref = "" } = {}) {
+	const selected =
+		eventName === "pull_request" ||
+		(eventName === "push" && ref === "refs/heads/main");
+	return { selected, error: "" };
+}

--- a/scripts/ci/backend-integration-workflow.test.mjs
+++ b/scripts/ci/backend-integration-workflow.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { selectBackendIntegration } from "./backend-integration-workflow.mjs";
+
+test("selects pull requests and protected-main pushes", () => {
+	assert.deepEqual(
+		selectBackendIntegration({
+			eventName: "pull_request",
+			ref: "refs/pull/42/merge",
+		}),
+		{ selected: true, error: "" },
+	);
+	assert.deepEqual(
+		selectBackendIntegration({
+			eventName: "push",
+			ref: "refs/heads/main",
+		}),
+		{ selected: true, error: "" },
+	);
+});
+
+test("does not select unrelated events or branch pushes", () => {
+	for (const input of [
+		{ eventName: "push", ref: "refs/heads/feature" },
+		{ eventName: "workflow_dispatch", ref: "refs/heads/main" },
+		{ eventName: "", ref: "" },
+	]) {
+		assert.deepEqual(selectBackendIntegration(input), { selected: false, error: "" });
+	}
+});

--- a/scripts/verification-policy.mjs
+++ b/scripts/verification-policy.mjs
@@ -232,6 +232,12 @@ function policyInputFromEnvironment() {
 				"BACKEND_STABILITY_RESULT",
 			),
 			directLane(
+				"Backend Integration",
+				"RUN_BACKEND_INTEGRATION",
+				"BACKEND_INTEGRATION_REASON",
+				"BACKEND_INTEGRATION_RESULT",
+			),
+			directLane(
 				"Backend Lint",
 				"RUN_BACKEND_LINT",
 				"BACKEND_LINT_REASON",

--- a/scripts/verification-policy.test.mjs
+++ b/scripts/verification-policy.test.mjs
@@ -12,6 +12,7 @@ const laneNames = [
 	"Frontend",
 	"Backend",
 	"Backend Test Stability",
+	"Backend Integration",
 	"Backend Lint",
 	"Workflow Lint",
 	"UI Backend Integration",
@@ -156,6 +157,28 @@ test("required Workflow Lint fails the policy when its hosted job is skipped or 
 
 		assert.equal(evaluation.ok, false, `${result} must fail the required workflow lint lane`);
 		assert.ok(evaluation.failures.some((failure) => /Workflow Lint was selected/.test(failure)));
+	}
+});
+
+test("required Backend Integration fails the policy when its hosted job fails or is canceled", () => {
+	for (const result of ["skipped", "cancelled", "timed_out", "failure"]) {
+		const evaluation = evaluateVerificationPolicy(
+			policy({
+				lanes: [
+					...laneNames
+						.filter((name) => name !== "Backend Integration")
+						.map((name) => lane(name)),
+					lane("Backend Integration", true, result, {
+						reason: "The installed-binary validation tier is required on pull requests.",
+					}),
+				],
+			}),
+		);
+
+		assert.equal(evaluation.ok, false, `${result} must fail the required policy lane`);
+		assert.ok(
+			evaluation.failures.some((failure) => /Backend Integration was selected/.test(failure)),
+		);
 	}
 });
 

--- a/tests/integration/harness/audit.go
+++ b/tests/integration/harness/audit.go
@@ -1,0 +1,384 @@
+package harness
+
+import (
+	"bufio"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type traceRecord struct {
+	line       string
+	pid        int
+	name       string
+	args       string
+	result     string
+	unfinished bool
+	resumed    bool
+}
+
+type traceState struct {
+	cwd string
+	fds map[int]string
+}
+
+type tracePath struct {
+	raw  string
+	base string
+}
+
+var tracePID = regexp.MustCompile(`^\s*(?:\[pid\s+)?(\d+)(?:\])?\s+`)
+var traceFDPath = regexp.MustCompile(`(?:AT_FDCWD|\d+)<([^>]+)>`)
+var traceQuoted = regexp.MustCompile(`"(?:\\.|[^"\\])*"`)
+var resumedCall = regexp.MustCompile(`^<\.\.\.\s+([[:alnum:]_]+)\s+resumed>\s*`)
+
+func auditTrace(repoRoot, initialCWD string, data []byte) (*SourceTreeReadError, error) {
+	canonicalRoot, err := canonicalPath(repoRoot, "")
+	if err != nil {
+		return nil, fmt.Errorf("resolve repository root: %w", err)
+	}
+	canonicalCWD, err := canonicalPath(initialCWD, "")
+	if err != nil {
+		return nil, fmt.Errorf("resolve invocation directory: %w", err)
+	}
+
+	states := make(map[int]*traceState)
+	pending := make(map[int]traceRecord)
+	events := 0
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	scanner.Buffer(make([]byte, 4096), 1024*1024)
+	for scanner.Scan() {
+		record, ok := parseTraceRecord(scanner.Text())
+		if !ok {
+			continue
+		}
+		events++
+		if record.resumed {
+			unfinished, ok := pending[record.pid]
+			if !ok {
+				continue
+			}
+			delete(pending, record.pid)
+			record.name = unfinished.name
+			record.args = unfinished.args
+			record.line = unfinished.line + " " + record.line
+		}
+		state := stateFor(states, record.pid, canonicalCWD)
+		paths, err := tracePaths(record, state)
+		if err != nil {
+			return nil, err
+		}
+		resolved, err := resolveTracePaths(paths)
+		if err != nil {
+			return nil, fmt.Errorf("resolve trace path on %q: %w", record.line, err)
+		}
+		for _, path := range resolved {
+			if pathWithin(canonicalRoot, path) {
+				return &SourceTreeReadError{Path: path, TraceLine: record.line}, nil
+			}
+		}
+		updateTraceState(states, record, state, resolved)
+		if record.unfinished {
+			pending[record.pid] = record
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read strace output: %w", err)
+	}
+	if len(pending) > 0 {
+		return nil, fmt.Errorf("strace output ended with unfinished file-access syscalls")
+	}
+	if events == 0 {
+		return nil, fmt.Errorf("strace output contained no file-access events")
+	}
+	return nil, nil
+}
+
+func parseTraceRecord(line string) (traceRecord, bool) {
+	matches := tracePID.FindStringSubmatch(line)
+	pid := 0
+	lineOffset := 0
+	if len(matches) == 2 {
+		parsedPID, err := strconv.Atoi(matches[1])
+		if err != nil {
+			return traceRecord{}, false
+		}
+		pid = parsedPID
+		lineOffset = len(matches[0])
+	}
+	rest := strings.TrimSpace(line[lineOffset:])
+	if resumed := resumedCall.FindStringSubmatch(rest); len(resumed) == 2 {
+		end := strings.LastIndex(rest, ") = ")
+		if end < 0 {
+			return traceRecord{}, false
+		}
+		return traceRecord{
+			line:    line,
+			pid:     pid,
+			name:    resumed[1],
+			result:  strings.TrimSpace(rest[end+4:]),
+			resumed: true,
+		}, true
+	}
+	open := strings.IndexByte(rest, '(')
+	if open <= 0 {
+		return traceRecord{}, false
+	}
+	name := strings.TrimSpace(rest[:open])
+	end := strings.LastIndex(rest, ") = ")
+	unfinished := false
+	if end < 0 {
+		end = strings.LastIndex(rest, " <unfinished ...>")
+		unfinished = end >= 0
+	}
+	if end <= open {
+		return traceRecord{}, false
+	}
+	return traceRecord{
+		line:       line,
+		pid:        pid,
+		name:       name,
+		args:       rest[open+1 : end],
+		result:     traceResult(rest, end, unfinished),
+		unfinished: unfinished,
+	}, true
+}
+
+func traceResult(rest string, end int, unfinished bool) string {
+	if unfinished {
+		return ""
+	}
+	return strings.TrimSpace(rest[end+4:])
+}
+
+func stateFor(states map[int]*traceState, pid int, initialCWD string) *traceState {
+	if state, ok := states[pid]; ok {
+		return state
+	}
+	state := &traceState{cwd: initialCWD, fds: make(map[int]string)}
+	states[pid] = state
+	return state
+}
+
+func tracePaths(record traceRecord, state *traceState) ([]tracePath, error) {
+	args := splitTraceArgs(record.args)
+	if len(args) == 0 {
+		return nil, nil
+	}
+
+	var references []tracePath
+	switch record.name {
+	case "open", "creat", "stat", "lstat", "stat64", "lstat64", "access", "eaccess",
+		"readlink", "truncate", "chroot", "chmod", "chown", "lchown", "listxattr",
+		"llistxattr", "getxattr", "lgetxattr":
+		references = appendStringReference(references, args, 0, state.cwd)
+	case "openat", "openat2", "newfstatat", "fstatat", "faccessat", "faccessat2", "statx",
+		"readlinkat", "unlinkat", "mkdirat", "mknodat", "fchmodat", "fchownat", "utimensat",
+		"name_to_handle_at":
+		base, err := descriptorBase(args, 0, state)
+		if err != nil {
+			return nil, err
+		}
+		references = appendStringReference(references, args, 1, base)
+	case "execve":
+		references = appendStringReference(references, args, 0, state.cwd)
+	case "execveat":
+		base, err := descriptorBase(args, 0, state)
+		if err != nil {
+			return nil, err
+		}
+		references = appendStringReference(references, args, 1, base)
+	case "getdents", "getdents64", "fstat", "fstatfs", "fstatfs64", "fchdir":
+		if base, ok := descriptorPath(args, 0, state); ok {
+			references = append(references, tracePath{raw: base, base: state.cwd})
+		}
+	default:
+		for _, raw := range quotedValues(record.args) {
+			references = append(references, tracePath{raw: raw, base: state.cwd})
+		}
+	}
+	return references, nil
+}
+
+func appendStringReference(references []tracePath, args []string, index int, base string) []tracePath {
+	if index >= len(args) {
+		return references
+	}
+	raw, ok := decodeTraceString(args[index])
+	if !ok || raw == "" {
+		return references
+	}
+	return append(references, tracePath{raw: raw, base: base})
+}
+
+func descriptorBase(args []string, index int, state *traceState) (string, error) {
+	if index >= len(args) {
+		return "", fmt.Errorf("missing directory descriptor")
+	}
+	if strings.HasPrefix(strings.TrimSpace(args[index]), "AT_FDCWD") {
+		return state.cwd, nil
+	}
+	if path, ok := descriptorPath(args, index, state); ok {
+		return path, nil
+	}
+	return "", fmt.Errorf("directory descriptor %q was not resolved", args[index])
+}
+
+func descriptorPath(args []string, index int, state *traceState) (string, bool) {
+	if index >= len(args) {
+		return "", false
+	}
+	raw := strings.TrimSpace(args[index])
+	if match := traceFDPath.FindStringSubmatch(raw); len(match) == 2 {
+		return match[1], true
+	}
+	fdText := raw
+	if comma := strings.IndexByte(fdText, '<'); comma >= 0 {
+		fdText = fdText[:comma]
+	}
+	fd, err := strconv.Atoi(strings.TrimSpace(fdText))
+	if err != nil {
+		return "", false
+	}
+	path, ok := state.fds[fd]
+	return path, ok
+}
+
+func resolveTracePaths(paths []tracePath) ([]string, error) {
+	resolved := make([]string, 0, len(paths))
+	for _, reference := range paths {
+		path, err := canonicalPath(reference.raw, reference.base)
+		if err != nil {
+			return nil, err
+		}
+		resolved = append(resolved, path)
+	}
+	return resolved, nil
+}
+
+func updateTraceState(states map[int]*traceState, record traceRecord, state *traceState, resolved []string) {
+	args := splitTraceArgs(record.args)
+	if record.name == "chdir" && len(resolved) > 0 {
+		state.cwd = resolved[0]
+	}
+	if record.name == "fchdir" && len(resolved) > 0 {
+		state.cwd = resolved[0]
+	}
+	if isOpenCall(record.name) && len(resolved) > 0 {
+		if fd, ok := resultNumber(record.result); ok {
+			state.fds[fd] = resolved[0]
+		}
+	}
+	if record.name == "close" && len(args) > 0 {
+		if fd, err := strconv.Atoi(strings.TrimSpace(args[0])); err == nil {
+			delete(state.fds, fd)
+		}
+	}
+	if isDupCall(record.name) && len(args) > 0 {
+		if source, err := strconv.Atoi(strings.TrimSpace(args[0])); err == nil {
+			if target, ok := resultNumber(record.result); ok {
+				if path, exists := state.fds[source]; exists {
+					state.fds[target] = path
+				}
+			}
+		}
+	}
+	if isForkCall(record.name) {
+		if child, ok := resultNumber(record.result); ok {
+			states[child] = cloneTraceState(state)
+		}
+	}
+}
+
+func isOpenCall(name string) bool {
+	return name == "open" || name == "openat" || name == "openat2" || name == "creat"
+}
+
+func isDupCall(name string) bool {
+	return name == "dup" || name == "dup2" || name == "dup3" || name == "fcntl"
+}
+
+func isForkCall(name string) bool {
+	return name == "clone" || name == "clone3" || name == "fork" || name == "vfork"
+}
+
+func cloneTraceState(state *traceState) *traceState {
+	fds := make(map[int]string, len(state.fds))
+	for fd, path := range state.fds {
+		fds[fd] = path
+	}
+	return &traceState{cwd: state.cwd, fds: fds}
+}
+
+func resultNumber(result string) (int, bool) {
+	fields := strings.Fields(result)
+	if len(fields) == 0 {
+		return 0, false
+	}
+	number, err := strconv.Atoi(fields[0])
+	return number, err == nil && number >= 0
+}
+
+func quotedValues(args string) []string {
+	matches := traceQuoted.FindAllString(args, -1)
+	values := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if value, ok := decodeTraceString(match); ok {
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
+func decodeTraceString(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if len(value) < 2 || value[0] != '"' || value[len(value)-1] != '"' {
+		return "", false
+	}
+	decoded, err := strconv.Unquote(value)
+	return decoded, err == nil
+}
+
+func splitTraceArgs(args string) []string {
+	var result []string
+	start := 0
+	depth := 0
+	inString := false
+	escaped := false
+	for index, character := range args {
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if character == '\\' {
+				escaped = true
+				continue
+			}
+			if character == '"' {
+				inString = false
+			}
+			continue
+		}
+		switch character {
+		case '"':
+			inString = true
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				result = append(result, strings.TrimSpace(args[start:index]))
+				start = index + 1
+			}
+		}
+	}
+	if tail := strings.TrimSpace(args[start:]); tail != "" {
+		result = append(result, tail)
+	}
+	return result
+}

--- a/tests/integration/harness/audit.go
+++ b/tests/integration/harness/audit.go
@@ -32,6 +32,7 @@ var tracePID = regexp.MustCompile(`^\s*(?:\[pid\s+)?(\d+)(?:\])?\s+`)
 var traceFDPath = regexp.MustCompile(`(?:AT_FDCWD|\d+)<([^>]+)>`)
 var traceQuoted = regexp.MustCompile(`"(?:\\.|[^"\\])*"`)
 var resumedCall = regexp.MustCompile(`^<\.\.\.\s+([[:alnum:]_]+)\s+resumed>\s*`)
+var traceReturn = regexp.MustCompile(`\)\s*=\s*`)
 
 func auditTrace(repoRoot, initialCWD string, data []byte) (*SourceTreeReadError, error) {
 	canonicalRoot, err := canonicalPath(repoRoot, "")
@@ -109,7 +110,7 @@ func parseTraceRecord(line string) (traceRecord, bool) {
 	}
 	rest := strings.TrimSpace(line[lineOffset:])
 	if resumed := resumedCall.FindStringSubmatch(rest); len(resumed) == 2 {
-		end := strings.LastIndex(rest, ") = ")
+		end, resultStart := traceReturnBounds(rest)
 		if end < 0 {
 			return traceRecord{}, false
 		}
@@ -117,7 +118,7 @@ func parseTraceRecord(line string) (traceRecord, bool) {
 			line:    line,
 			pid:     pid,
 			name:    resumed[1],
-			result:  strings.TrimSpace(rest[end+4:]),
+			result:  strings.TrimSpace(rest[resultStart:]),
 			resumed: true,
 		}, true
 	}
@@ -126,7 +127,7 @@ func parseTraceRecord(line string) (traceRecord, bool) {
 		return traceRecord{}, false
 	}
 	name := strings.TrimSpace(rest[:open])
-	end := strings.LastIndex(rest, ") = ")
+	end, resultStart := traceReturnBounds(rest)
 	unfinished := false
 	if end < 0 {
 		end = strings.LastIndex(rest, " <unfinished ...>")
@@ -140,16 +141,25 @@ func parseTraceRecord(line string) (traceRecord, bool) {
 		pid:        pid,
 		name:       name,
 		args:       rest[open+1 : end],
-		result:     traceResult(rest, end, unfinished),
+		result:     traceResult(rest, resultStart, unfinished),
 		unfinished: unfinished,
 	}, true
 }
 
-func traceResult(rest string, end int, unfinished bool) string {
-	if unfinished {
+func traceReturnBounds(rest string) (int, int) {
+	matches := traceReturn.FindAllStringIndex(rest, -1)
+	if len(matches) == 0 {
+		return -1, -1
+	}
+	match := matches[len(matches)-1]
+	return match[0], match[1]
+}
+
+func traceResult(rest string, resultStart int, unfinished bool) string {
+	if unfinished || resultStart < 0 {
 		return ""
 	}
-	return strings.TrimSpace(rest[end+4:])
+	return strings.TrimSpace(rest[resultStart:])
 }
 
 func stateFor(states map[int]*traceState, pid int, initialCWD string) *traceState {
@@ -312,12 +322,19 @@ func cloneTraceState(state *traceState) *traceState {
 }
 
 func resultNumber(result string) (int, bool) {
-	fields := strings.Fields(result)
-	if len(fields) == 0 {
+	result = strings.TrimSpace(result)
+	if result == "" {
 		return 0, false
 	}
-	number, err := strconv.Atoi(fields[0])
-	return number, err == nil && number >= 0
+	end := 0
+	for end < len(result) && result[end] >= '0' && result[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return 0, false
+	}
+	number, err := strconv.Atoi(result[:end])
+	return number, err == nil
 }
 
 func quotedValues(args string) []string {

--- a/tests/integration/harness/audit.go
+++ b/tests/integration/harness/audit.go
@@ -2,11 +2,14 @@ package harness
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 )
+
+var errNoFileAccessEvents = errors.New("strace output contained no file-access events")
 
 type traceRecord struct {
 	line       string
@@ -47,10 +50,21 @@ func auditTrace(repoRoot, initialCWD string, data []byte) (*SourceTreeReadError,
 	states := make(map[int]*traceState)
 	pending := make(map[int]traceRecord)
 	events := 0
+	unknownExitArtifact := false
+	processExited := false
 	scanner := bufio.NewScanner(strings.NewReader(string(data)))
 	scanner.Buffer(make([]byte, 4096), 1024*1024)
 	for scanner.Scan() {
-		record, ok := parseTraceRecord(scanner.Text())
+		line := scanner.Text()
+		if isStraceUnknownExitArtifact(line) {
+			unknownExitArtifact = true
+			continue
+		}
+		if isStraceProcessExit(line) {
+			processExited = true
+			continue
+		}
+		record, ok := parseTraceRecord(line)
 		if !ok {
 			continue
 		}
@@ -58,7 +72,7 @@ func auditTrace(repoRoot, initialCWD string, data []byte) (*SourceTreeReadError,
 		if record.resumed {
 			unfinished, ok := pending[record.pid]
 			if !ok {
-				continue
+				return nil, fmt.Errorf("strace resumed %s for pid %d without an unfinished record", record.name, record.pid)
 			}
 			delete(pending, record.pid)
 			record.name = unfinished.name
@@ -87,13 +101,30 @@ func auditTrace(repoRoot, initialCWD string, data []byte) (*SourceTreeReadError,
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("read strace output: %w", err)
 	}
+	if unknownExitArtifact && !processExited {
+		return nil, fmt.Errorf("strace output contained an unknown unfinished syscall without a process exit")
+	}
 	if len(pending) > 0 {
 		return nil, fmt.Errorf("strace output ended with unfinished file-access syscalls")
 	}
 	if events == 0 {
-		return nil, fmt.Errorf("strace output contained no file-access events")
+		return nil, errNoFileAccessEvents
 	}
 	return nil, nil
+}
+
+// strace can emit this synthetic record when a traced thread dies immediately
+// after syscall entry. With -ff the record is isolated to that thread's log;
+// it has no syscall name or path to audit and is not a real file-access event.
+// A genuinely unfinished named syscall remains fail-closed below.
+func isStraceUnknownExitArtifact(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.Contains(trimmed, "???(") && strings.Contains(trimmed, "<unfinished ...>")
+}
+
+func isStraceProcessExit(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.Contains(trimmed, "+++ exited") || strings.Contains(trimmed, "+++ killed")
 }
 
 func parseTraceRecord(line string) (traceRecord, bool) {

--- a/tests/integration/harness/harness.go
+++ b/tests/integration/harness/harness.go
@@ -222,7 +222,7 @@ func (i *Invocation) Run(ctx context.Context, args ...string) (Result, error) {
 		return Result{}, err
 	}
 	auditLog := filepath.Join(i.env.RuntimeDirectory, "file-access.strace")
-	cmdArgs := []string{"-f", "-yy", "-e", "trace=%file", "-o", auditLog, binary}
+	cmdArgs := []string{"-ff", "-yy", "-e", "trace=%file", "-o", auditLog, binary}
 	cmdArgs = append(cmdArgs, args...)
 	cmd := exec.CommandContext(ctx, i.harness.tracer, cmdArgs...)
 	cmd.Dir = i.env.WorkingDirectory
@@ -255,18 +255,52 @@ func (i *Invocation) Run(ctx context.Context, args ...string) (Result, error) {
 }
 
 func (i *Invocation) checkAudit(auditLog string, result Result) error {
-	data, err := os.ReadFile(auditLog)
+	logs, err := auditLogFiles(auditLog)
 	if err != nil {
-		return fmt.Errorf("%w: read strace output: %v; stderr=%q", ErrAuditUnavailable, err, strings.TrimSpace(result.Stderr))
+		return fmt.Errorf("%w: find strace output: %v; stderr=%q", ErrAuditUnavailable, err, strings.TrimSpace(result.Stderr))
 	}
-	violation, err := auditTrace(i.harness.repoRoot, i.env.WorkingDirectory, data)
-	if err != nil {
-		return fmt.Errorf("%w: %v; stderr=%q", ErrAuditUnavailable, err, strings.TrimSpace(result.Stderr))
+	sawFileAccess := false
+	for _, logPath := range logs {
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			return fmt.Errorf("%w: read strace output %s: %v; stderr=%q", ErrAuditUnavailable, logPath, err, strings.TrimSpace(result.Stderr))
+		}
+		violation, err := auditTrace(i.harness.repoRoot, i.env.WorkingDirectory, data)
+		if errors.Is(err, errNoFileAccessEvents) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("%w: %v; stderr=%q", ErrAuditUnavailable, err, strings.TrimSpace(result.Stderr))
+		}
+		sawFileAccess = true
+		if violation != nil {
+			return violation
+		}
 	}
-	if violation != nil {
-		return violation
+	if !sawFileAccess {
+		return fmt.Errorf("%w: %v; stderr=%q", ErrAuditUnavailable, errNoFileAccessEvents, strings.TrimSpace(result.Stderr))
 	}
 	return nil
+}
+
+func auditLogFiles(prefix string) ([]string, error) {
+	directory := filepath.Dir(prefix)
+	filePrefix := filepath.Base(prefix) + "."
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), filePrefix) {
+			continue
+		}
+		paths = append(paths, filepath.Join(directory, entry.Name()))
+	}
+	if len(paths) == 0 {
+		return nil, errors.New("strace produced no per-process output files")
+	}
+	return paths, nil
 }
 
 func exitCode(cmd *exec.Cmd, runErr error) int {

--- a/tests/integration/harness/harness.go
+++ b/tests/integration/harness/harness.go
@@ -186,16 +186,6 @@ func (h *Harness) NewInvocation() (*Invocation, error) {
 	}, nil
 }
 
-// Run is a convenience for invocations that do not need to seed files first.
-func (h *Harness) Run(ctx context.Context, args ...string) (Result, error) {
-	invocation, err := h.NewInvocation()
-	if err != nil {
-		return Result{}, err
-	}
-	defer invocation.Close()
-	return invocation.Run(ctx, args...)
-}
-
 func (h *Harness) requireExternalPath(path string) error {
 	canonical, err := canonicalPath(path, "")
 	if err != nil {

--- a/tests/integration/harness/harness.go
+++ b/tests/integration/harness/harness.go
@@ -1,0 +1,351 @@
+package harness
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+const (
+	traceCommand = "strace"
+	buildPackage = "./cmd/factory"
+)
+
+// ErrAuditUnavailable means the host cannot enforce the source-tree read
+// boundary required by the installed-binary integration tier.
+var ErrAuditUnavailable = errors.New("source-tree read auditing is unavailable")
+
+// Harness owns one integration run. Its binary is built lazily at most once;
+// each invocation still gets a new customer-like process environment.
+type Harness struct {
+	repoRoot string
+	root     string
+	tracer   string
+
+	buildOnce sync.Once
+	binary    string
+	buildErr  error
+
+	mu     sync.Mutex
+	closed bool
+}
+
+// InvocationEnvironment describes the isolated locations given to one
+// process invocation. All paths are outside the repository's canonical root.
+type InvocationEnvironment struct {
+	WorkingDirectory string
+	HomeDirectory    string
+	UserProfile      string
+	RuntimeDirectory string
+}
+
+// Invocation is single-use. Files such as a copied Factory fixture can be
+// written into its working directory before Run is called.
+type Invocation struct {
+	harness *Harness
+	root    string
+	env     InvocationEnvironment
+
+	mu   sync.Mutex
+	used bool
+}
+
+// Result contains the process verdict and captured output. A non-zero
+// ExitCode is a valid result for callers that are checking a CLI rejection.
+type Result struct {
+	ExitCode     int
+	Stdout       string
+	Stderr       string
+	AuditLogPath string
+}
+
+// SourceTreeReadError identifies the canonical path that crossed the source
+// tree boundary.
+type SourceTreeReadError struct {
+	Path      string
+	TraceLine string
+}
+
+func (e *SourceTreeReadError) Error() string {
+	return fmt.Sprintf("source-tree read detected at %s (trace: %s)", e.Path, e.TraceLine)
+}
+
+// New creates a harness and fails closed unless Linux strace is available.
+func New(repoRoot string) (*Harness, error) {
+	canonicalRoot, err := canonicalPath(repoRoot, "")
+	if err != nil {
+		return nil, fmt.Errorf("resolve repository root: %w", err)
+	}
+	if info, err := os.Stat(canonicalRoot); err != nil || !info.IsDir() {
+		if err == nil {
+			err = errors.New("path is not a directory")
+		}
+		return nil, fmt.Errorf("repository root: %w", err)
+	}
+
+	tracer, err := findTracer()
+	if err != nil {
+		return nil, err
+	}
+	root, err := makeExternalTempRoot(canonicalRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Harness{repoRoot: canonicalRoot, root: root, tracer: tracer}, nil
+}
+
+func findTracer() (string, error) {
+	if runtime.GOOS != "linux" {
+		return "", fmt.Errorf("%w: supported enforcement uses Linux strace (GOOS=%s)", ErrAuditUnavailable, runtime.GOOS)
+	}
+	tracer, err := exec.LookPath(traceCommand)
+	if err != nil {
+		return "", fmt.Errorf("%w: %s is not on PATH: %v", ErrAuditUnavailable, traceCommand, err)
+	}
+	return tracer, nil
+}
+
+func makeExternalTempRoot(repoRoot string) (string, error) {
+	for range 3 {
+		root, err := os.MkdirTemp("", "you-integration-")
+		if err != nil {
+			return "", fmt.Errorf("create integration temp root: %w", err)
+		}
+		canonicalRoot, canonicalErr := canonicalPath(root, "")
+		if canonicalErr == nil && !pathWithin(repoRoot, canonicalRoot) {
+			return canonicalRoot, nil
+		}
+		_ = os.RemoveAll(root)
+	}
+	return "", fmt.Errorf("%w: temporary integration root is reachable from repository %s", ErrAuditUnavailable, repoRoot)
+}
+
+// Build builds cmd/factory once and returns the shared executable path.
+func (h *Harness) Build(ctx context.Context) (string, error) {
+	h.buildOnce.Do(func() {
+		h.binary = filepath.Join(h.root, "you"+executableSuffix())
+		cmd := exec.CommandContext(ctx, "go", "build", "-o", h.binary, buildPackage)
+		cmd.Dir = h.repoRoot
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			h.buildErr = fmt.Errorf("build %s: %w\n%s", buildPackage, err, strings.TrimSpace(string(output)))
+		}
+	})
+	if h.buildErr != nil {
+		return "", h.buildErr
+	}
+	return h.binary, nil
+}
+
+// NewInvocation creates fresh HOME, USERPROFILE, working, and runtime paths.
+func (h *Harness) NewInvocation() (*Invocation, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return nil, errors.New("integration harness is closed")
+	}
+
+	root, err := os.MkdirTemp(h.root, "invocation-")
+	if err != nil {
+		return nil, fmt.Errorf("create invocation root: %w", err)
+	}
+	paths := map[string]string{
+		"working directory": filepath.Join(root, "work"),
+		"home directory":    filepath.Join(root, "home"),
+		"user profile":      filepath.Join(root, "userprofile"),
+		"runtime directory": filepath.Join(root, "runtime"),
+	}
+	for label, path := range paths {
+		if err := os.Mkdir(path, 0o700); err != nil {
+			_ = os.RemoveAll(root)
+			return nil, fmt.Errorf("create %s: %w", label, err)
+		}
+		if err := h.requireExternalPath(path); err != nil {
+			_ = os.RemoveAll(root)
+			return nil, err
+		}
+	}
+
+	return &Invocation{
+		harness: h,
+		root:    root,
+		env: InvocationEnvironment{
+			WorkingDirectory: paths["working directory"],
+			HomeDirectory:    paths["home directory"],
+			UserProfile:      paths["user profile"],
+			RuntimeDirectory: paths["runtime directory"],
+		},
+	}, nil
+}
+
+// Run is a convenience for invocations that do not need to seed files first.
+func (h *Harness) Run(ctx context.Context, args ...string) (Result, error) {
+	invocation, err := h.NewInvocation()
+	if err != nil {
+		return Result{}, err
+	}
+	defer invocation.Close()
+	return invocation.Run(ctx, args...)
+}
+
+func (h *Harness) requireExternalPath(path string) error {
+	canonical, err := canonicalPath(path, "")
+	if err != nil {
+		return fmt.Errorf("resolve isolated path %s: %w", path, err)
+	}
+	if pathWithin(h.repoRoot, canonical) {
+		return fmt.Errorf("%w: isolated path %s is inside repository %s", ErrAuditUnavailable, canonical, h.repoRoot)
+	}
+	return nil
+}
+
+// Environment returns the paths that may be populated before Run.
+func (i *Invocation) Environment() InvocationEnvironment {
+	return i.env
+}
+
+// Run executes the shared binary under strace -f, which follows forked and
+// exec'd descendants. A process exit status is returned as a verdict; setup,
+// tracing, and source-boundary errors are returned as Go errors.
+func (i *Invocation) Run(ctx context.Context, args ...string) (Result, error) {
+	i.mu.Lock()
+	if i.used {
+		i.mu.Unlock()
+		return Result{}, errors.New("integration invocation is single-use")
+	}
+	i.used = true
+	i.mu.Unlock()
+
+	if len(args) == 0 {
+		return Result{}, errors.New("integration invocation requires a command")
+	}
+	binary, err := i.harness.Build(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	auditLog := filepath.Join(i.env.RuntimeDirectory, "file-access.strace")
+	cmdArgs := []string{"-f", "-yy", "-e", "trace=%file", "-o", auditLog, binary}
+	cmdArgs = append(cmdArgs, args...)
+	cmd := exec.CommandContext(ctx, i.harness.tracer, cmdArgs...)
+	cmd.Dir = i.env.WorkingDirectory
+	cmd.Env = isolatedEnvironment(i.env)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	result := Result{
+		ExitCode:     exitCode(cmd, runErr),
+		Stdout:       stdout.String(),
+		Stderr:       stderr.String(),
+		AuditLogPath: auditLog,
+	}
+	if err := i.checkAudit(auditLog, result); err != nil {
+		return result, err
+	}
+	if runErr == nil {
+		return result, nil
+	}
+	if ctx.Err() != nil {
+		return result, ctx.Err()
+	}
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		return result, nil
+	}
+	return result, fmt.Errorf("run installed binary: %w", runErr)
+}
+
+func (i *Invocation) checkAudit(auditLog string, result Result) error {
+	data, err := os.ReadFile(auditLog)
+	if err != nil {
+		return fmt.Errorf("%w: read strace output: %v; stderr=%q", ErrAuditUnavailable, err, strings.TrimSpace(result.Stderr))
+	}
+	violation, err := auditTrace(i.harness.repoRoot, i.env.WorkingDirectory, data)
+	if err != nil {
+		return fmt.Errorf("%w: %v; stderr=%q", ErrAuditUnavailable, err, strings.TrimSpace(result.Stderr))
+	}
+	if violation != nil {
+		return violation
+	}
+	return nil
+}
+
+func exitCode(cmd *exec.Cmd, runErr error) int {
+	if cmd.ProcessState != nil {
+		return cmd.ProcessState.ExitCode()
+	}
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+// Close releases all harness state, including any invocation directories.
+func (h *Harness) Close() error {
+	h.mu.Lock()
+	if h.closed {
+		h.mu.Unlock()
+		return nil
+	}
+	h.closed = true
+	h.mu.Unlock()
+	return os.RemoveAll(h.root)
+}
+
+// Close removes this invocation's files while leaving the shared binary for
+// other invocations in the same harness run.
+func (i *Invocation) Close() error {
+	return os.RemoveAll(i.root)
+}
+
+func isolatedEnvironment(env InvocationEnvironment) []string {
+	overrides := map[string]string{
+		"HOME":            env.HomeDirectory,
+		"USERPROFILE":     env.UserProfile,
+		"HOMEDRIVE":       filepath.VolumeName(env.UserProfile),
+		"HOMEPATH":        string(os.PathSeparator),
+		"PWD":             env.WorkingDirectory,
+		"OLDPWD":          env.WorkingDirectory,
+		"TMPDIR":          env.RuntimeDirectory,
+		"TMP":             env.RuntimeDirectory,
+		"TEMP":            env.RuntimeDirectory,
+		"XDG_CONFIG_HOME": filepath.Join(env.HomeDirectory, ".config"),
+		"XDG_CACHE_HOME":  filepath.Join(env.HomeDirectory, ".cache"),
+		"XDG_DATA_HOME":   filepath.Join(env.HomeDirectory, ".local", "share"),
+		"APPDATA":         filepath.Join(env.UserProfile, "AppData", "Roaming"),
+		"LOCALAPPDATA":    filepath.Join(env.UserProfile, "AppData", "Local"),
+	}
+
+	result := make([]string, 0, len(os.Environ())+len(overrides))
+	for _, entry := range os.Environ() {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		if _, replaced := overrides[strings.ToUpper(key)]; replaced {
+			continue
+		}
+		result = append(result, entry)
+	}
+	for key, value := range overrides {
+		result = append(result, key+"="+value)
+	}
+	return result
+}
+
+func executableSuffix() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+	return ""
+}

--- a/tests/integration/harness/harness_test.go
+++ b/tests/integration/harness/harness_test.go
@@ -127,6 +127,38 @@ func TestParseTraceRecordSupportsPidAndUnfinishedForms(t *testing.T) {
 	}
 }
 
+func TestParseTraceRecordSupportsPaddedDecodedResumedReturn(t *testing.T) {
+	resumed, ok := parseTraceRecord(`364   <... openat resumed>)             = 7</tmp/factory.json>`)
+	if !ok {
+		t.Fatal("failed to parse padded resumed strace record")
+	}
+	if resumed.pid != 364 || resumed.name != "openat" || !resumed.resumed || resumed.result != "7</tmp/factory.json>" {
+		t.Fatalf("padded resumed record = %#v", resumed)
+	}
+	if number, ok := resultNumber(resumed.result); !ok || number != 7 {
+		t.Fatalf("result number = (%d, %t), want (7, true)", number, ok)
+	}
+}
+
+func TestAuditTracePairsPaddedResumedRecords(t *testing.T) {
+	repoRoot := t.TempDir()
+	workDir := t.TempDir()
+	externalPath := filepath.Join(workDir, "factory.json")
+	trace := fmt.Sprintf(
+		"364 openat(AT_FDCWD<%s>, %q, O_RDONLY <unfinished ...>\n364 <... openat resumed>)             = 7<%s>\n",
+		filepath.ToSlash(workDir),
+		filepath.Base(externalPath),
+		filepath.ToSlash(externalPath),
+	)
+	violation, err := auditTrace(repoRoot, workDir, []byte(trace))
+	if err != nil {
+		t.Fatalf("audit trace: %v", err)
+	}
+	if violation != nil {
+		t.Fatalf("audit reported an external read: %v", violation)
+	}
+}
+
 func TestAuditTraceResolvesDirectoryDescriptorReads(t *testing.T) {
 	repoRoot := t.TempDir()
 	workDir := t.TempDir()

--- a/tests/integration/harness/harness_test.go
+++ b/tests/integration/harness/harness_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -156,6 +157,56 @@ func TestAuditTracePairsPaddedResumedRecords(t *testing.T) {
 	}
 	if violation != nil {
 		t.Fatalf("audit reported an external read: %v", violation)
+	}
+}
+
+func TestAuditTraceRejectsUnpairedUnknownRecord(t *testing.T) {
+	_, err := auditTrace(t.TempDir(), t.TempDir(), []byte("123 ???( <unfinished ...>\n"))
+	if err == nil || !strings.Contains(err.Error(), "without a process exit") {
+		t.Fatalf("audit error = %v, want an incomplete-trace error", err)
+	}
+}
+
+func TestAuditLogFilesCollectsOnlyPerProcessOutputs(t *testing.T) {
+	runtimeDir := t.TempDir()
+	prefix := filepath.Join(runtimeDir, "file-access.strace")
+	for _, name := range []string{"file-access.strace.12", "file-access.strace.3"} {
+		if err := os.WriteFile(filepath.Join(runtimeDir, name), nil, 0o600); err != nil {
+			t.Fatalf("write trace file: %v", err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(runtimeDir, "unrelated.log"), nil, 0o600); err != nil {
+		t.Fatalf("write unrelated file: %v", err)
+	}
+	paths, err := auditLogFiles(prefix)
+	if err != nil {
+		t.Fatalf("audit log files: %v", err)
+	}
+	want := []string{filepath.Join(runtimeDir, "file-access.strace.12"), filepath.Join(runtimeDir, "file-access.strace.3")}
+	if !reflect.DeepEqual(paths, want) {
+		t.Fatalf("audit log files = %#v, want %#v", paths, want)
+	}
+}
+
+func TestCheckAuditAllowsEmptyPerProcessOutput(t *testing.T) {
+	repoRoot := t.TempDir()
+	workDir := t.TempDir()
+	runtimeDir := t.TempDir()
+	prefix := filepath.Join(runtimeDir, "file-access.strace")
+	if err := os.WriteFile(prefix+".12", []byte("12 ???( <unfinished ...>\n12 +++ exited with 0 +++\n"), 0o600); err != nil {
+		t.Fatalf("write empty trace: %v", err)
+	}
+	externalFile := filepath.Join(workDir, "factory.json")
+	trace := fmt.Sprintf("3 openat(AT_FDCWD, %q, O_RDONLY) = 3<%s>\n", filepath.Base(externalFile), externalFile)
+	if err := os.WriteFile(prefix+".3", []byte(trace), 0o600); err != nil {
+		t.Fatalf("write file trace: %v", err)
+	}
+	i := &Invocation{
+		harness: &Harness{repoRoot: repoRoot},
+		env:     InvocationEnvironment{WorkingDirectory: workDir},
+	}
+	if err := i.checkAudit(prefix, Result{}); err != nil {
+		t.Fatalf("check audit: %v", err)
 	}
 }
 

--- a/tests/integration/harness/harness_test.go
+++ b/tests/integration/harness/harness_test.go
@@ -1,0 +1,192 @@
+package harness
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewInvocationUsesFreshExternalDirectories(t *testing.T) {
+	repoRoot := t.TempDir()
+	root, err := makeExternalTempRoot(repoRoot)
+	if err != nil {
+		t.Fatalf("make external temp root: %v", err)
+	}
+	h := &Harness{repoRoot: repoRoot, root: root}
+	t.Cleanup(func() {
+		if err := h.Close(); err != nil {
+			t.Errorf("close harness: %v", err)
+		}
+	})
+
+	first, err := h.NewInvocation()
+	if err != nil {
+		t.Fatalf("first invocation: %v", err)
+	}
+	second, err := h.NewInvocation()
+	if err != nil {
+		t.Fatalf("second invocation: %v", err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+	t.Cleanup(func() { _ = second.Close() })
+
+	firstEnv := first.Environment()
+	secondEnv := second.Environment()
+	for label, path := range map[string]string{
+		"first working directory":  firstEnv.WorkingDirectory,
+		"first home directory":     firstEnv.HomeDirectory,
+		"first user profile":       firstEnv.UserProfile,
+		"second working directory": secondEnv.WorkingDirectory,
+		"second home directory":    secondEnv.HomeDirectory,
+		"second user profile":      secondEnv.UserProfile,
+	} {
+		if pathWithin(repoRoot, path) {
+			t.Errorf("%s %q is reachable below repository %q", label, path, repoRoot)
+		}
+	}
+	if firstEnv.WorkingDirectory == secondEnv.WorkingDirectory || firstEnv.HomeDirectory == secondEnv.HomeDirectory || firstEnv.UserProfile == secondEnv.UserProfile {
+		t.Fatal("invocations reused an isolated directory")
+	}
+}
+
+func TestAuditTraceResolvesRelativeSourceRead(t *testing.T) {
+	repoRoot := t.TempDir()
+	workDir := t.TempDir()
+	sourcePath := filepath.Join(repoRoot, "pkg", "internal.txt")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o700); err != nil {
+		t.Fatalf("create source directory: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("source"), 0o600); err != nil {
+		t.Fatalf("write source fixture: %v", err)
+	}
+	relativePath, err := filepath.Rel(workDir, sourcePath)
+	if err != nil {
+		t.Fatalf("relative source path: %v", err)
+	}
+
+	trace := fmt.Sprintf("123 openat(AT_FDCWD, %q, O_RDONLY) = 3<%s>\n", filepath.ToSlash(relativePath), filepath.ToSlash(sourcePath))
+	violation, err := auditTrace(repoRoot, workDir, []byte(trace))
+	if err != nil {
+		t.Fatalf("audit trace: %v", err)
+	}
+	if violation == nil {
+		t.Fatal("audit accepted a source-tree read")
+	}
+	canonicalSource, err := canonicalPath(sourcePath, "")
+	if err != nil {
+		t.Fatalf("canonical source path: %v", err)
+	}
+	if violation.Path != canonicalSource {
+		t.Fatalf("violation path = %q, want %q", violation.Path, canonicalSource)
+	}
+	if !strings.Contains(violation.Error(), canonicalSource) {
+		t.Fatalf("violation error %q does not name canonical source path %q", violation.Error(), canonicalSource)
+	}
+}
+
+func TestAuditTraceFollowsDescendantRelativeReads(t *testing.T) {
+	repoRoot := t.TempDir()
+	workDir := t.TempDir()
+	sourcePath := filepath.Join(repoRoot, "README.md")
+	if err := os.WriteFile(sourcePath, []byte("source"), 0o600); err != nil {
+		t.Fatalf("write source fixture: %v", err)
+	}
+	relativePath, err := filepath.Rel(workDir, sourcePath)
+	if err != nil {
+		t.Fatalf("relative source path: %v", err)
+	}
+	trace := fmt.Sprintf(
+		"100 clone(child_stack, flags) = 101\n101 openat(AT_FDCWD, %q, O_RDONLY) = 3\n",
+		filepath.ToSlash(relativePath),
+	)
+	violation, err := auditTrace(repoRoot, workDir, []byte(trace))
+	if err != nil {
+		t.Fatalf("audit trace: %v", err)
+	}
+	if violation == nil {
+		t.Fatal("audit accepted a descendant source-tree read")
+	}
+}
+
+func TestParseTraceRecordSupportsPidAndUnfinishedForms(t *testing.T) {
+	unfinished, ok := parseTraceRecord(`[pid 123] openat(AT_FDCWD, "relative", O_RDONLY <unfinished ...>`)
+	if !ok {
+		t.Fatal("failed to parse unfinished strace record")
+	}
+	if unfinished.pid != 123 || unfinished.name != "openat" || !unfinished.unfinished {
+		t.Fatalf("unfinished record = %#v", unfinished)
+	}
+	resumed, ok := parseTraceRecord(`[pid 123] <... openat resumed>) = 3`)
+	if !ok {
+		t.Fatal("failed to parse resumed strace record")
+	}
+	if resumed.pid != 123 || resumed.name != "openat" || !resumed.resumed || resumed.result != "3" {
+		t.Fatalf("resumed record = %#v", resumed)
+	}
+}
+
+func TestAuditTraceResolvesDirectoryDescriptorReads(t *testing.T) {
+	repoRoot := t.TempDir()
+	workDir := t.TempDir()
+	externalDir := filepath.Join(workDir, "external")
+	if err := os.Mkdir(externalDir, 0o700); err != nil {
+		t.Fatalf("create external directory: %v", err)
+	}
+	sourcePath := filepath.Join(repoRoot, "docs", "README.md")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o700); err != nil {
+		t.Fatalf("create source directory: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("source"), 0o600); err != nil {
+		t.Fatalf("write source fixture: %v", err)
+	}
+	relativePath, err := filepath.Rel(externalDir, sourcePath)
+	if err != nil {
+		t.Fatalf("relative source path: %v", err)
+	}
+	trace := fmt.Sprintf(
+		"123 openat(AT_FDCWD, %q, O_RDONLY|O_DIRECTORY) = 3<%s>\n123 openat(3<%s>, %q, O_RDONLY) = 4\n",
+		filepath.ToSlash(filepath.Join("external")),
+		filepath.ToSlash(externalDir),
+		filepath.ToSlash(externalDir),
+		filepath.ToSlash(relativePath),
+	)
+	violation, err := auditTrace(repoRoot, workDir, []byte(trace))
+	if err != nil {
+		t.Fatalf("audit trace: %v", err)
+	}
+	if violation == nil {
+		t.Fatal("audit accepted a directory-descriptor source-tree read")
+	}
+}
+
+func TestIsolatedEnvironmentReplacesHomeAndWorkingDirectory(t *testing.T) {
+	env := InvocationEnvironment{
+		WorkingDirectory: t.TempDir(),
+		HomeDirectory:    t.TempDir(),
+		UserProfile:      t.TempDir(),
+		RuntimeDirectory: t.TempDir(),
+	}
+	values := isolatedEnvironment(env)
+	for key, want := range map[string]string{
+		"HOME":        env.HomeDirectory,
+		"USERPROFILE": env.UserProfile,
+		"PWD":         env.WorkingDirectory,
+		"TMPDIR":      env.RuntimeDirectory,
+	} {
+		if got := environmentValue(values, key); got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func environmentValue(environment []string, key string) string {
+	prefix := key + "="
+	for _, entry := range environment {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix)
+		}
+	}
+	return ""
+}

--- a/tests/integration/harness/paths.go
+++ b/tests/integration/harness/paths.go
@@ -1,0 +1,67 @@
+package harness
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func canonicalPath(path, base string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+	if !filepath.IsAbs(path) {
+		if base == "" {
+			base, _ = os.Getwd()
+		}
+		path = filepath.Join(base, path)
+	}
+	path, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", err
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return filepath.Abs(filepath.Clean(resolved))
+	}
+
+	return canonicalPathWithMissingSuffix(path)
+}
+
+func canonicalPathWithMissingSuffix(path string) (string, error) {
+	missing := make([]string, 0, 4)
+	candidate := path
+	for {
+		if _, err := os.Lstat(candidate); err == nil {
+			resolved, err := filepath.EvalSymlinks(candidate)
+			if err != nil {
+				return "", err
+			}
+			for index := len(missing) - 1; index >= 0; index-- {
+				resolved = filepath.Join(resolved, missing[index])
+			}
+			return filepath.Abs(filepath.Clean(resolved))
+		}
+		parent := filepath.Dir(candidate)
+		if parent == candidate {
+			return path, nil
+		}
+		missing = append(missing, filepath.Base(candidate))
+		candidate = parent
+	}
+}
+
+func pathWithin(root, path string) bool {
+	relative, err := filepath.Rel(root, path)
+	if err != nil || filepath.IsAbs(relative) {
+		return false
+	}
+	if relative == "." {
+		return true
+	}
+	parentPrefix := ".." + string(filepath.Separator)
+	return relative != ".." && !hasPathPrefix(relative, parentPrefix)
+}
+
+func hasPathPrefix(path, prefix string) bool {
+	return len(path) >= len(prefix) && path[:len(prefix)] == prefix
+}

--- a/tests/integration/i8_test.go
+++ b/tests/integration/i8_test.go
@@ -1,0 +1,94 @@
+package integration
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/tests/integration/harness"
+)
+
+const i8Timeout = 90 * time.Second
+
+//go:embed testdata/i8/valid/*.json testdata/i8/invalid/*.json
+var i8Corpus embed.FS
+
+// TestI8FactoryConfigValidation proves the installed binary's validate-only
+// verdict across a compact Factory corpus. The corpus is copied out of the
+// checkout before any child process starts so the harness audits only the
+// installed-binary boundary.
+func TestI8FactoryConfigValidation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), i8Timeout)
+	defer cancel()
+
+	run, err := harness.New(repositoryRoot(t))
+	if err != nil {
+		t.Fatalf("create installed-binary harness: %v", err)
+	}
+	defer func() {
+		if err := run.Close(); err != nil {
+			t.Errorf("close installed-binary harness: %v", err)
+		}
+	}()
+
+	cases := []struct {
+		name  string
+		valid bool
+	}{
+		{name: "valid/minimal.json", valid: true},
+		{name: "valid/logical-move.json", valid: true},
+		{name: "valid/resource-backed.json", valid: true},
+		{name: "invalid/malformed.json", valid: false},
+		{name: "invalid/unknown-output-state.json", valid: false},
+		{name: "invalid/duplicate-worker.json", valid: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateFixture(ctx, run, tc.name)
+			if err != nil {
+				t.Fatalf("validate %s: %v", tc.name, err)
+			}
+			if got != tc.valid {
+				t.Fatalf("validation verdict = %t, want %t", got, tc.valid)
+			}
+		})
+	}
+}
+
+func validateFixture(ctx context.Context, run *harness.Harness, name string) (bool, error) {
+	invocation, err := run.NewInvocation()
+	if err != nil {
+		return false, err
+	}
+	defer invocation.Close()
+
+	fixture, err := i8Corpus.ReadFile(filepath.ToSlash(filepath.Join("testdata/i8", name)))
+	if err != nil {
+		return false, fmt.Errorf("read embedded fixture: %w", err)
+	}
+	env := invocation.Environment()
+	factoryPath := filepath.Join(env.WorkingDirectory, "factory"+filepath.Ext(name))
+	if err := os.WriteFile(factoryPath, fixture, 0o600); err != nil {
+		return false, fmt.Errorf("stage fixture: %w", err)
+	}
+
+	result, err := invocation.Run(ctx, "factory", "config", "validate", factoryPath)
+	if err != nil {
+		return false, err
+	}
+	return result.ExitCode == 0, nil
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	_, sourcePath, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate integration test source")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(sourcePath), "..", ".."))
+}

--- a/tests/integration/testdata/i8/invalid/duplicate-worker.json
+++ b/tests/integration/testdata/i8/invalid/duplicate-worker.json
@@ -1,0 +1,26 @@
+{
+  "name": "i8-duplicate-worker",
+  "workTypes": [
+    {
+      "name": "task",
+      "states": [
+        {"name": "init", "type": "INITIAL"},
+        {"name": "complete", "type": "TERMINAL"},
+        {"name": "failed", "type": "FAILED"}
+      ]
+    }
+  ],
+  "workers": [
+    {"name": "processor"},
+    {"name": "processor"}
+  ],
+  "workstations": [
+    {
+      "name": "process",
+      "worker": "processor",
+      "inputs": [{"workType": "task", "state": "init"}],
+      "outputs": [{"workType": "task", "state": "complete"}],
+      "onFailure": [{"workType": "task", "state": "failed"}]
+    }
+  ]
+}

--- a/tests/integration/testdata/i8/invalid/malformed.json
+++ b/tests/integration/testdata/i8/invalid/malformed.json
@@ -1,0 +1,1 @@
+{"name":"i8-malformed",

--- a/tests/integration/testdata/i8/invalid/unknown-output-state.json
+++ b/tests/integration/testdata/i8/invalid/unknown-output-state.json
@@ -1,0 +1,25 @@
+{
+  "name": "i8-unknown-output-state",
+  "workTypes": [
+    {
+      "name": "task",
+      "states": [
+        {"name": "init", "type": "INITIAL"},
+        {"name": "complete", "type": "TERMINAL"},
+        {"name": "failed", "type": "FAILED"}
+      ]
+    }
+  ],
+  "workers": [
+    {"name": "processor"}
+  ],
+  "workstations": [
+    {
+      "name": "process",
+      "worker": "processor",
+      "inputs": [{"workType": "task", "state": "init"}],
+      "outputs": [{"workType": "task", "state": "missing"}],
+      "onFailure": [{"workType": "task", "state": "failed"}]
+    }
+  ]
+}

--- a/tests/integration/testdata/i8/valid/logical-move.json
+++ b/tests/integration/testdata/i8/valid/logical-move.json
@@ -1,0 +1,22 @@
+{
+  "name": "i8-logical-move",
+  "workTypes": [
+    {
+      "name": "task",
+      "states": [
+        {"name": "init", "type": "INITIAL"},
+        {"name": "complete", "type": "TERMINAL"},
+        {"name": "failed", "type": "FAILED"}
+      ]
+    }
+  ],
+  "workstations": [
+    {
+      "name": "complete",
+      "type": "LOGICAL_MOVE",
+      "worker": "",
+      "inputs": [{"workType": "task", "state": "init"}],
+      "outputs": [{"workType": "task", "state": "complete"}]
+    }
+  ]
+}

--- a/tests/integration/testdata/i8/valid/minimal.json
+++ b/tests/integration/testdata/i8/valid/minimal.json
@@ -1,0 +1,25 @@
+{
+  "name": "i8-minimal",
+  "workTypes": [
+    {
+      "name": "task",
+      "states": [
+        {"name": "init", "type": "INITIAL"},
+        {"name": "complete", "type": "TERMINAL"},
+        {"name": "failed", "type": "FAILED"}
+      ]
+    }
+  ],
+  "workers": [
+    {"name": "processor"}
+  ],
+  "workstations": [
+    {
+      "name": "process",
+      "worker": "processor",
+      "inputs": [{"workType": "task", "state": "init"}],
+      "outputs": [{"workType": "task", "state": "complete"}],
+      "onFailure": [{"workType": "task", "state": "failed"}]
+    }
+  ]
+}

--- a/tests/integration/testdata/i8/valid/resource-backed.json
+++ b/tests/integration/testdata/i8/valid/resource-backed.json
@@ -1,0 +1,29 @@
+{
+  "name": "i8-resource-backed",
+  "resources": [
+    {"name": "slot", "capacity": 1}
+  ],
+  "workTypes": [
+    {
+      "name": "task",
+      "states": [
+        {"name": "init", "type": "INITIAL"},
+        {"name": "complete", "type": "TERMINAL"},
+        {"name": "failed", "type": "FAILED"}
+      ]
+    }
+  ],
+  "workers": [
+    {"name": "processor"}
+  ],
+  "workstations": [
+    {
+      "name": "process",
+      "worker": "processor",
+      "inputs": [{"workType": "task", "state": "init"}],
+      "outputs": [{"workType": "task", "state": "complete"}],
+      "onFailure": [{"workType": "task", "state": "failed"}],
+      "resources": [{"name": "slot", "capacity": 1}]
+    }
+  ]
+}


### PR DESCRIPTION
{
  "project": "Installed-Binary Integration Harness and Validation Tier",
  "branchName": "int-harness-validation-tier",
  "description": "Create the first required CI tier that runs the shipped you binary from a customer-like isolated environment, prohibits source-tree reads, and ships exactly one verdict-only config validation test (I8) before later lanes add I1-I7.",
  "context": {
    "customerAsk": "Add tests/integration/ with a harness that builds cmd/factory once, reuses the binary from fresh isolated HOME, USERPROFILE, and working directories with no repository in their parent chain, and fails with the path on any source-tree read. Ship exactly I8 over a small valid/invalid Factory corpus, assert only config validate pass/fail verdicts, and make Backend Integration a required pull-request job while the tier contains only I8.",
    "problem": "No pull-request CI tier currently exercises the shipped binary as an installed customer would. The existing release smoke is not invoked by the active workflows or coverage lanes, repository-root execution hides dependencies on internal files, and adding the gate only after the larger matrix would make new-gate failures indistinguishable from product regressions.",
    "solution": "Build the customer binary once per integration run, invoke it only from isolated temporary runtime roots, audit the complete child-process tree for reads beneath the canonical checkout and fail closed with the offending path, then exercise that substrate with the single verdict-only I8 corpus. Add a stable Backend Integration job to pull-request CI and include its result in Verification Policy, with hosted timing and deliberate-failure evidence recorded only in the PR conversation."
  },
  "acceptanceCriteria": [
    "The integration run builds cmd/factory once and all I8 corpus cases use that shared executable while each invocation receives fresh isolated HOME, USERPROFILE, and working directories whose parent chain cannot reach the checkout.",
    "File-read auditing covers the compiled process and its descendants, fails closed when enforcement is unavailable, and fails with the resolved offending path whenever any file below the source-tree root is read.",
    "tests/integration/ contains exactly one test, I8, with a small set of valid Factories that receive a passing config validate verdict and invalid Factories that receive a failing verdict; no diagnostic text is asserted.",
    "A PR comment from the lane's own hosted run shows that a temporary repository read makes the guard fail with the path, temporarily breaking one corpus Factory makes I8 fail, and the restored tier completes in under two minutes on a four-core hosted runner; CI-run evidence is never committed.",
    "Backend Integration runs on pull requests and is included in the required Verification Policy outcome, with no I1-I7 scenarios, unhappy-path matrix, real provider calls, tests/release/ changes, dead-code baseline edits, or unrelated cleanup.",
    "Typecheck and focused integration/workflow-policy tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. The pre-existing packaged-service-structure migration debt is not made a lane blocker, coverage floors remain report-only for this rebuild, and the unrelated localai-backend-artifacts failure is not treated as required evidence.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "int-harness-validation-tier-001",
      "title": "Run the shipped binary in enforced isolation",
      "description": "As a maintainer, I want integration commands to run from a customer-like temporary environment with source-tree reads prohibited so repository-only runtime dependencies fail before release.",
      "acceptanceCriteria": [
        "One compiled cmd/factory executable is built for the integration package run and reused by every invocation rather than rebuilt per corpus case.",
        "Every invocation uses fresh temporary locations for its working directory, HOME, and USERPROFILE, and no repository directory is reachable by walking upward from those locations.",
        "Read auditing applies to the child process and descendants, resolves relative and indirect file access to canonical paths, and fails closed when the supported hosted environment cannot enforce the rule.",
        "A temporary reintroduction of a source-tree read produces a failing integration result that names the offending repository path; the demonstration and command output are recorded in a PR comment and are not committed as an additional test or fixture.",
        "Harness state and process side effects are explicit and scoped to the integration run; no production service, public contract, generated file, or release test is changed to support the harness.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added a Linux strace -f installed-binary harness with one shared cmd/factory build, fresh isolated HOME/USERPROFILE/working/runtime roots, canonical source-tree read detection, fail-closed audit setup, and focused harness tests."
    },
    {
      "id": "int-harness-validation-tier-002",
      "title": "Validate a compact Factory corpus by verdict",
      "description": "As a customer, I want the installed CLI to accept valid Factory configurations and reject invalid ones from a clean environment so validation remains usable outside the repository.",
      "acceptanceCriteria": [
        "The package ships with exactly one top-level integration test, I8, and does not add any I1-I7 test or other process-level scenario.",
        "I8 invokes the shared compiled binary's config validate behavior for a handful of small valid Factories and observes a passing verdict for each.",
        "I8 invokes the same behavior for a handful of small invalid Factories and observes a failing verdict for each; these invalid corpus cases are limited to the required validation-verdict contract and do not expand into an unhappy-path CLI matrix.",
        "Assertions inspect only the pass/fail verdict and never depend on diagnostic text, message wording, source layout, registration inventories, or fixture-bundle internals.",
        "Temporarily making one committed valid Factory invalid makes I8 red, and the demonstration is restored before the final push with evidence placed only in a PR comment.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added the single top-level TestI8FactoryConfigValidation with three valid and three invalid embedded Factory fixtures. Each case is staged in a fresh harness invocation and asserts only the installed binary's zero/non-zero config validate verdict."
    },
    {
      "id": "int-harness-validation-tier-003",
      "title": "Require the bounded integration tier on pull requests",
      "description": "As a maintainer, I want the small installed-binary validation tier to be a required pull-request check so later integration regressions are attributable to product changes rather than introduction of a new gate.",
      "acceptanceCriteria": [
        "Pull requests run a job whose stable check name is Backend Integration, using the repository's pinned Go toolchain and the supported hosted environment needed for source-read enforcement.",
        "The job runs the dedicated integration command containing I8 and reports failure when I8 or the no-internal-files rule fails; it is included in Verification Policy's required job results rather than being optional or report-only.",
        "The unmodified job completes in under two minutes on a four-core hosted runner, and the measured wall time from the lane's own PR run is posted in a PR comment rather than committed.",
        "Workflow behavior tests prove that the new job is selected for pull requests and that Verification Policy cannot pass when the selected Backend Integration job fails or is canceled; they assert workflow outcomes rather than scanning a job inventory.",
        "The implementation rebases onto origin/main before its final push and does not alter docs/internal/baselines/deadcode-baseline.txt, delete the two dead-code symbols owned by another lane, modify tests/release/, or respond to the non-required localai-backend-artifacts failure.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added the required Backend Integration job for pull requests and protected-main pushes, wired I8 into make test-integration, and made Verification Policy fail closed for skipped, canceled, timed-out, or failed integration results. Final head is pushed, PR #2222 is open, and required CI has started on that head."
    }
  ]
}
