### PR TITLE
ciwait-transient-gh-failure-must-not-kill-a-lane

### DIFF
--- a/factory/scripts/ci-wait.py
+++ b/factory/scripts/ci-wait.py
@@ -23,8 +23,9 @@ hold, which routes the task back through this gate — a cheap, bounded
 re-queue rather than a lane-killing failure.
 
 Special cases:
-  - No PR yet: the processor may have just pushed; retry for ~2 minutes,
-    then exit 1 with a clear stderr message.
+  - No PR yet: successful lookups that return no matching PR may race a
+    processor push; retry for ~2 minutes, then exit 1 with a clear stderr
+    message.
   - PR already MERGED (and no open PR for the branch): exit 0 immediately;
     the review workstation's merged-PR short-circuit handles the rest.
   - Only CLOSED PRs: exit 0 immediately; the reviewer decides what a closed,
@@ -91,9 +92,16 @@ def resolve_pr(branch):
     Returns a dict {number, state} for the PR to gate on, preferring an OPEN
     PR, then MERGED, then CLOSED. Exits 1 when no PR exists after retries.
     """
+    successful_empty_lookups = 0
     for attempt in range(1, PR_LOOKUP_ATTEMPTS + 1):
         prs = list_prs_for_head(branch)
-        if prs:
+        if prs is not None:
+            if not prs:
+                successful_empty_lookups += 1
+                log(
+                    f"successful PR lookup found no matching PR for head branch "
+                    f"{branch!r} (attempt {attempt}/{PR_LOOKUP_ATTEMPTS})"
+                )
             for state in ("OPEN", "MERGED", "CLOSED"):
                 matches = [pr for pr in prs if pr.get("state") == state]
                 if matches:
@@ -106,13 +114,22 @@ def resolve_pr(branch):
             )
             time.sleep(PR_LOOKUP_INTERVAL_SECONDS)
 
-    print(
-        f"ci-wait: no PR exists with head branch {branch!r} after "
-        f"{PR_LOOKUP_ATTEMPTS} lookups over ~2 minutes. The process "
-        "workstation must open a PR named after the lane before the task can "
-        "enter review.",
-        file=sys.stderr,
-    )
+    if successful_empty_lookups == PR_LOOKUP_ATTEMPTS:
+        print(
+            f"ci-wait: successful PR lookups found no PR for head branch "
+            f"{branch!r} after {PR_LOOKUP_ATTEMPTS} lookups over ~2 minutes. "
+            "The process workstation must open a PR named after the lane "
+            "before the task can enter review.",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"ci-wait: no PR exists with head branch {branch!r} after "
+            f"{PR_LOOKUP_ATTEMPTS} lookups over ~2 minutes. The process "
+            "workstation must open a PR named after the lane before the task "
+            "can enter review.",
+            file=sys.stderr,
+        )
     sys.exit(1)
 
 

--- a/factory/scripts/ci-wait.py
+++ b/factory/scripts/ci-wait.py
@@ -26,6 +26,8 @@ Special cases:
   - No PR yet: successful lookups that return no matching PR may race a
     processor push; retry for ~2 minutes, then exit 1 with a clear stderr
     message.
+  - GitHub lookup unavailable: retry a bounded infrastructure budget with
+    backoff, then exit 0 for the review hold-and-requeue path.
   - PR already MERGED (and no open PR for the branch): exit 0 immediately;
     the review workstation's merged-PR short-circuit handles the rest.
   - Only CLOSED PRs: exit 0 immediately; the reviewer decides what a closed,
@@ -40,16 +42,38 @@ import json
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
+from enum import Enum
 
 POLL_INTERVAL_SECONDS = 120
 DEADLINE_SECONDS = 100 * 60  # one-shot budget, well below the 2h hard timeout
 GH_CALL_TIMEOUT_SECONDS = 120
 PR_LOOKUP_ATTEMPTS = 5
 PR_LOOKUP_INTERVAL_SECONDS = 30  # ~2 minutes of retries for a just-pushed PR
+PR_LOOKUP_INFRASTRUCTURE_ATTEMPTS = 3
+PR_LOOKUP_INFRASTRUCTURE_BACKOFF_SECONDS = 5
+PR_LOOKUP_INFRASTRUCTURE_MAX_BACKOFF_SECONDS = 60
 NO_CHECKS_GRACE_SECONDS = 10 * 60
 
 NON_TERMINAL_BUCKETS = {"pending"}
 NON_TERMINAL_STATES = {"PENDING", "QUEUED", "IN_PROGRESS", "WAITING", "REQUESTED", "EXPECTED"}
+PR_STATE_PREFERENCE = ("OPEN", "MERGED", "CLOSED")
+
+
+class PRLookupStatus(Enum):
+    """Classification of a GitHub PR lookup response."""
+
+    FOUND = "found"
+    NOT_FOUND = "not-found"
+    INFRASTRUCTURE_FAILURE = "infrastructure-failure"
+
+
+@dataclass(frozen=True)
+class PRLookupResult:
+    """A typed result that keeps an empty response distinct from a failure."""
+
+    status: PRLookupStatus
+    prs: tuple = ()
 
 
 def log(message):
@@ -68,68 +92,159 @@ def run_gh(*args):
 
 
 def list_prs_for_head(branch):
-    """Return the PR list for a head branch, or None when gh fails."""
-    result = run_gh(
-        "pr", "list",
-        "--head", branch,
-        "--state", "all",
-        "--json", "number,state",
-        "--limit", "20",
-    )
-    if result.returncode != 0:
-        log(f"gh pr list failed (exit {result.returncode}): {result.stderr.strip()}")
-        return None
+    """Return a typed result for the lane's GitHub PR lookup."""
     try:
-        return json.loads(result.stdout or "[]")
-    except json.JSONDecodeError as error:
-        log(f"gh pr list returned unparseable JSON: {error}")
-        return None
+        result = run_gh(
+            "pr", "list",
+            "--head", branch,
+            "--state", "all",
+            "--json", "number,state",
+            "--limit", "20",
+        )
+    except subprocess.TimeoutExpired:
+        log("gh pr list timed out; treating lookup as an infrastructure failure")
+        return PRLookupResult(PRLookupStatus.INFRASTRUCTURE_FAILURE)
+    except OSError:
+        log("gh pr list could not be executed; treating lookup as an infrastructure failure")
+        return PRLookupResult(PRLookupStatus.INFRASTRUCTURE_FAILURE)
+
+    if result.returncode != 0:
+        log(
+            f"gh pr list failed (exit {result.returncode}); "
+            "treating lookup as an infrastructure failure"
+        )
+        return PRLookupResult(PRLookupStatus.INFRASTRUCTURE_FAILURE)
+
+    stdout = (result.stdout or "").strip()
+    if not stdout:
+        log(
+            "gh pr list returned no output; treating lookup as an infrastructure "
+            "failure"
+        )
+        return PRLookupResult(PRLookupStatus.INFRASTRUCTURE_FAILURE)
+
+    try:
+        prs = json.loads(stdout)
+    except (TypeError, json.JSONDecodeError):
+        log(
+            "gh pr list returned unparseable JSON; treating lookup as an "
+            "infrastructure failure"
+        )
+        return PRLookupResult(PRLookupStatus.INFRASTRUCTURE_FAILURE)
+
+    if not isinstance(prs, list) or any(
+        not isinstance(pr, dict)
+        or not isinstance(pr.get("number"), int)
+        or pr.get("state") not in PR_STATE_PREFERENCE
+        for pr in prs
+    ):
+        log(
+            "gh pr list returned unusable JSON; treating lookup as an infrastructure "
+            "failure"
+        )
+        return PRLookupResult(PRLookupStatus.INFRASTRUCTURE_FAILURE)
+
+    status = PRLookupStatus.FOUND if prs else PRLookupStatus.NOT_FOUND
+    return PRLookupResult(status, tuple(prs))
+
+
+def infrastructure_backoff_seconds(attempt):
+    """Return bounded exponential backoff for an infrastructure retry."""
+    return min(
+        PR_LOOKUP_INFRASTRUCTURE_BACKOFF_SECONDS * (2 ** (attempt - 1)),
+        PR_LOOKUP_INFRASTRUCTURE_MAX_BACKOFF_SECONDS,
+    )
+
+
+def release_for_infrastructure_requeue(branch, attempts):
+    """Emit the successful result that routes dependency failure to review."""
+    log(
+        f"ci-wait: GitHub PR lookup infrastructure retry budget exhausted "
+        f"for head branch {branch!r} after {attempts} failures; releasing to "
+        "review for hold-and-requeue"
+    )
+    emit_result(
+        branch=branch,
+        reason="pr-lookup-infrastructure-requeue",
+        lookup=PRLookupStatus.INFRASTRUCTURE_FAILURE.value,
+        infrastructureAttempts=attempts,
+    )
 
 
 def resolve_pr(branch):
-    """Resolve the lane's PR, retrying briefly because pushes race this gate.
+    """Resolve the lane's PR with separate absence and infrastructure budgets.
 
     Returns a dict {number, state} for the PR to gate on, preferring an OPEN
-    PR, then MERGED, then CLOSED. Exits 1 when no PR exists after retries.
+    PR, then MERGED, then CLOSED. Exits 1 when successful empty lookups exhaust
+    the missing-PR budget. Returns None after an infrastructure budget is
+    exhausted, having emitted the exit-0 requeue result.
     """
     successful_empty_lookups = 0
-    for attempt in range(1, PR_LOOKUP_ATTEMPTS + 1):
-        prs = list_prs_for_head(branch)
-        if prs is not None:
-            if not prs:
-                successful_empty_lookups += 1
-                log(
-                    f"successful PR lookup found no matching PR for head branch "
-                    f"{branch!r} (attempt {attempt}/{PR_LOOKUP_ATTEMPTS})"
-                )
-            for state in ("OPEN", "MERGED", "CLOSED"):
-                matches = [pr for pr in prs if pr.get("state") == state]
-                if matches:
-                    return matches[0]
-        if attempt < PR_LOOKUP_ATTEMPTS:
-            log(
-                f"no PR found for head branch {branch!r} "
-                f"(attempt {attempt}/{PR_LOOKUP_ATTEMPTS}); retrying in "
-                f"{PR_LOOKUP_INTERVAL_SECONDS}s"
-            )
-            time.sleep(PR_LOOKUP_INTERVAL_SECONDS)
+    infrastructure_failures = 0
+    while successful_empty_lookups < PR_LOOKUP_ATTEMPTS:
+        lookup = list_prs_for_head(branch)
+        if lookup.status == PRLookupStatus.INFRASTRUCTURE_FAILURE:
+            infrastructure_failures += 1
+            if infrastructure_failures >= PR_LOOKUP_INFRASTRUCTURE_ATTEMPTS:
+                release_for_infrastructure_requeue(branch, infrastructure_failures)
+                return None
 
-    if successful_empty_lookups == PR_LOOKUP_ATTEMPTS:
-        print(
-            f"ci-wait: successful PR lookups found no PR for head branch "
-            f"{branch!r} after {PR_LOOKUP_ATTEMPTS} lookups over ~2 minutes. "
-            "The process workstation must open a PR named after the lane "
-            "before the task can enter review.",
-            file=sys.stderr,
+            backoff = infrastructure_backoff_seconds(infrastructure_failures)
+            log(
+                f"ci-wait: GitHub PR lookup infrastructure failure for head branch "
+                f"{branch!r} (attempt {infrastructure_failures}/"
+                f"{PR_LOOKUP_INFRASTRUCTURE_ATTEMPTS}); retrying in {backoff}s"
+            )
+            time.sleep(backoff)
+            continue
+
+        # A successful response means the dependency recovered. Do not let
+        # earlier transport failures consume the separate infrastructure
+        # budget or change the meaning of this response.
+        infrastructure_failures = 0
+
+        if lookup.status == PRLookupStatus.NOT_FOUND:
+            successful_empty_lookups += 1
+            log(
+                f"successful PR lookup found no matching PR for head branch "
+                f"{branch!r} (successful empty lookup "
+                f"{successful_empty_lookups}/{PR_LOOKUP_ATTEMPTS})"
+            )
+            if successful_empty_lookups < PR_LOOKUP_ATTEMPTS:
+                log(
+                    f"ci-wait: retrying successful empty PR lookup for head branch "
+                    f"{branch!r} in {PR_LOOKUP_INTERVAL_SECONDS}s"
+                )
+                time.sleep(PR_LOOKUP_INTERVAL_SECONDS)
+            continue
+
+        for state in PR_STATE_PREFERENCE:
+            matches = [pr for pr in lookup.prs if pr.get("state") == state]
+            if matches:
+                return matches[0]
+
+        # Valid gh output currently has only OPEN, MERGED, or CLOSED states,
+        # so reaching this point would indicate a future response shape that
+        # cannot be selected safely. Treat it like an infrastructure failure
+        # without spending a successful-not-found attempt.
+        infrastructure_failures += 1
+        log(
+            f"ci-wait: GitHub PR lookup returned no selectable PR for head branch "
+            f"{branch!r}; treating response as an infrastructure failure"
         )
-    else:
-        print(
-            f"ci-wait: no PR exists with head branch {branch!r} after "
-            f"{PR_LOOKUP_ATTEMPTS} lookups over ~2 minutes. The process "
-            "workstation must open a PR named after the lane before the task "
-            "can enter review.",
-            file=sys.stderr,
-        )
+        if infrastructure_failures >= PR_LOOKUP_INFRASTRUCTURE_ATTEMPTS:
+            release_for_infrastructure_requeue(branch, infrastructure_failures)
+            return None
+        backoff = infrastructure_backoff_seconds(infrastructure_failures)
+        time.sleep(backoff)
+
+    print(
+        f"ci-wait: successful PR lookups found no PR for head branch "
+        f"{branch!r} after {successful_empty_lookups} successful lookups. "
+        "The process workstation must open a PR named after the lane before "
+        "the task can enter review.",
+        file=sys.stderr,
+    )
     sys.exit(1)
 
 
@@ -183,6 +298,8 @@ def main():
 
     branch = sys.argv[1]
     pr = resolve_pr(branch)
+    if pr is None:
+        return
     pr_number = pr.get("number")
     pr_state = pr.get("state")
 

--- a/tests/factory/scripts/test_ci_wait.py
+++ b/tests/factory/scripts/test_ci_wait.py
@@ -26,6 +26,150 @@ class CIWaitPRLookupTest(unittest.TestCase):
     def setUp(self):
         self.module = load_ci_wait_module()
 
+    def test_always_failing_github_lookup_requeues_without_no_pr_diagnosis(self):
+        branch = "ciwait-transient-gh-failure-must-not-kill-a-lane"
+        gh_calls = []
+        sleeps = []
+
+        def run_gh(*args):
+            gh_calls.append(args)
+            return subprocess.CompletedProcess(
+                ["gh", *args],
+                1,
+                stdout="",
+                stderr="token=should-not-be-logged",
+            )
+
+        stderr = io.StringIO()
+        stdout = io.StringIO()
+        with patch.object(self.module, "run_gh", side_effect=run_gh), patch.object(
+            self.module.time, "sleep", side_effect=sleeps.append
+        ), redirect_stdout(stdout), redirect_stderr(stderr):
+            result = self.module.resolve_pr(branch)
+
+        self.assertIsNone(result)
+        self.assertEqual(
+            len(gh_calls), self.module.PR_LOOKUP_INFRASTRUCTURE_ATTEMPTS
+        )
+        self.assertEqual(
+            sleeps,
+            [
+                self.module.infrastructure_backoff_seconds(attempt)
+                for attempt in range(1, self.module.PR_LOOKUP_INFRASTRUCTURE_ATTEMPTS)
+            ],
+        )
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["status"], "ready")
+        self.assertEqual(payload["reason"], "pr-lookup-infrastructure-requeue")
+        self.assertEqual(payload["lookup"], "infrastructure-failure")
+        self.assertEqual(
+            payload["infrastructureAttempts"],
+            self.module.PR_LOOKUP_INFRASTRUCTURE_ATTEMPTS,
+        )
+        diagnostic = stderr.getvalue()
+        self.assertIn("infrastructure failure", diagnostic)
+        self.assertIn("retrying", diagnostic)
+        self.assertIn("hold-and-requeue", diagnostic)
+        self.assertNotIn("no PR exists", diagnostic)
+        self.assertNotIn("should-not-be-logged", diagnostic)
+
+    def test_timeout_and_unusable_lookup_responses_requeue(self):
+        def timeout(*args):
+            raise subprocess.TimeoutExpired(
+                ["gh", *args], self.module.GH_CALL_TIMEOUT_SECONDS
+            )
+
+        def malformed(*args):
+            return subprocess.CompletedProcess(
+                ["gh", *args],
+                0,
+                stdout="not-json",
+                stderr="",
+            )
+
+        for response in (timeout, malformed):
+            with self.subTest(response=response.__name__):
+                sleeps = []
+                stderr = io.StringIO()
+                stdout = io.StringIO()
+                with (
+                    patch.object(self.module, "run_gh", side_effect=response),
+                    patch.object(self.module.time, "sleep", side_effect=sleeps.append),
+                    redirect_stdout(stdout),
+                    redirect_stderr(stderr),
+                ):
+                    result = self.module.resolve_pr("ciwait-unavailable-github")
+
+                self.assertIsNone(result)
+                self.assertEqual(
+                    len(sleeps), self.module.PR_LOOKUP_INFRASTRUCTURE_ATTEMPTS - 1
+                )
+                payload = json.loads(stdout.getvalue())
+                self.assertEqual(payload["status"], "ready")
+                self.assertEqual(
+                    payload["reason"], "pr-lookup-infrastructure-requeue"
+                )
+                self.assertNotIn("no PR exists", stderr.getvalue())
+
+    def test_infrastructure_retry_can_recover_to_a_found_pr(self):
+        responses = iter(
+            [
+                subprocess.CompletedProcess(
+                    ["gh"], 1, stdout="", stderr="temporary outage"
+                ),
+                subprocess.CompletedProcess(
+                    ["gh"], 0, stdout='[{"number": 42, "state": "OPEN"}]', stderr=""
+                ),
+            ]
+        )
+        sleeps = []
+
+        with (
+            patch.object(
+                self.module, "run_gh", side_effect=lambda *args: next(responses)
+            ),
+            patch.object(self.module.time, "sleep", side_effect=sleeps.append),
+        ):
+            result = self.module.resolve_pr("ciwait-recovered-github")
+
+        self.assertEqual(result, {"number": 42, "state": "OPEN"})
+        self.assertEqual(sleeps, [self.module.infrastructure_backoff_seconds(1)])
+
+    def test_infrastructure_failure_does_not_consume_missing_pr_budget(self):
+        responses = iter(
+            [
+                subprocess.CompletedProcess(
+                    ["gh"], 1, stdout="", stderr="temporary outage"
+                )
+            ]
+            + [
+                subprocess.CompletedProcess(["gh"], 0, stdout="[]", stderr="")
+                for _ in range(self.module.PR_LOOKUP_ATTEMPTS)
+            ]
+        )
+        sleeps = []
+        stderr = io.StringIO()
+
+        with (
+            patch.object(
+                self.module, "run_gh", side_effect=lambda *args: next(responses)
+            ),
+            patch.object(self.module.time, "sleep", side_effect=sleeps.append),
+            redirect_stderr(stderr),
+        ):
+            with self.assertRaises(SystemExit) as exit_error:
+                self.module.resolve_pr("ciwait-recovered-empty")
+
+        self.assertEqual(exit_error.exception.code, 1)
+        self.assertEqual(len(sleeps), self.module.PR_LOOKUP_ATTEMPTS)
+        self.assertEqual(sleeps[0], self.module.infrastructure_backoff_seconds(1))
+        self.assertEqual(
+            sleeps[1:],
+            [self.module.PR_LOOKUP_INTERVAL_SECONDS]
+            * (self.module.PR_LOOKUP_ATTEMPTS - 1),
+        )
+        self.assertIn("successful PR lookups found no PR", stderr.getvalue())
+
     def test_successful_empty_lookups_exit_1_after_missing_pr_budget(self):
         branch = "ciwait-transient-gh-failure-must-not-kill-a-lane"
         gh_calls = []

--- a/tests/factory/scripts/test_ci_wait.py
+++ b/tests/factory/scripts/test_ci_wait.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Behavioral tests for the ci-wait PR lookup gate."""
+
+import importlib.util
+import io
+import json
+import subprocess
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "factory" / "scripts" / "ci-wait.py"
+
+
+def load_ci_wait_module():
+    spec = importlib.util.spec_from_file_location("ci_wait", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class CIWaitPRLookupTest(unittest.TestCase):
+    def setUp(self):
+        self.module = load_ci_wait_module()
+
+    def test_successful_empty_lookups_exit_1_after_missing_pr_budget(self):
+        branch = "ciwait-transient-gh-failure-must-not-kill-a-lane"
+        gh_calls = []
+        sleeps = []
+
+        def run_gh(*args):
+            gh_calls.append(args)
+            return subprocess.CompletedProcess(
+                ["gh", *args],
+                0,
+                stdout="[]\n",
+                stderr="",
+            )
+
+        stderr = io.StringIO()
+        stdout = io.StringIO()
+        with patch.object(self.module, "run_gh", side_effect=run_gh), patch.object(
+            self.module.time, "sleep", side_effect=sleeps.append
+        ), redirect_stdout(stdout), redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as exit_error:
+                self.module.resolve_pr(branch)
+
+        self.assertEqual(exit_error.exception.code, 1)
+        self.assertEqual(len(gh_calls), self.module.PR_LOOKUP_ATTEMPTS)
+        self.assertEqual(
+            sleeps,
+            [self.module.PR_LOOKUP_INTERVAL_SECONDS]
+            * (self.module.PR_LOOKUP_ATTEMPTS - 1),
+        )
+        self.assertEqual(stdout.getvalue(), "")
+        diagnostic = stderr.getvalue()
+        self.assertIn("successful PR lookups found no PR", diagnostic)
+        self.assertIn(branch, diagnostic)
+        self.assertNotIn("infrastructure", diagnostic.lower())
+
+    def test_successful_lookup_preserves_preferred_pr_state_selection(self):
+        cases = (
+            (
+                [
+                    {"number": 17, "state": "CLOSED"},
+                    {"number": 18, "state": "MERGED"},
+                    {"number": 19, "state": "OPEN"},
+                ],
+                {"number": 19, "state": "OPEN"},
+            ),
+            ([{"number": 20, "state": "MERGED"}], {"number": 20, "state": "MERGED"}),
+            ([{"number": 21, "state": "CLOSED"}], {"number": 21, "state": "CLOSED"}),
+        )
+
+        for prs, expected in cases:
+            with self.subTest(expected=expected):
+                def run_gh(*args):
+                    return subprocess.CompletedProcess(
+                        ["gh", *args],
+                        0,
+                        stdout=json.dumps(prs),
+                        stderr="",
+                    )
+
+                with patch.object(self.module, "run_gh", side_effect=run_gh):
+                    self.assertEqual(
+                        self.module.resolve_pr("ciwait-found-state"),
+                        expected,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/factory/scripts/test_ci_wait.py
+++ b/tests/factory/scripts/test_ci_wait.py
@@ -26,6 +26,27 @@ class CIWaitPRLookupTest(unittest.TestCase):
     def setUp(self):
         self.module = load_ci_wait_module()
 
+    def invoke_main(self, branch, run_gh):
+        """Run the script entrypoint while keeping process outcomes observable."""
+        sleeps = []
+        stderr = io.StringIO()
+        stdout = io.StringIO()
+        with (
+            patch.object(self.module, "run_gh", side_effect=run_gh),
+            patch.object(self.module.sys, "argv", ["ci-wait.py", branch]),
+            patch.object(self.module.time, "sleep", side_effect=sleeps.append),
+            patch.object(self.module.time, "monotonic", return_value=0),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            try:
+                self.module.main()
+            except SystemExit as error:
+                exit_code = error.code
+            else:
+                exit_code = 0
+        return exit_code, stdout.getvalue(), stderr.getvalue(), sleeps
+
     def test_always_failing_github_lookup_requeues_without_no_pr_diagnosis(self):
         branch = "ciwait-transient-gh-failure-must-not-kill-a-lane"
         gh_calls = []
@@ -234,6 +255,187 @@ class CIWaitPRLookupTest(unittest.TestCase):
                         self.module.resolve_pr("ciwait-found-state"),
                         expected,
                     )
+
+    def test_main_infrastructure_exhaustion_is_successful_requeue(self):
+        def run_gh(*args):
+            return subprocess.CompletedProcess(
+                ["gh", *args],
+                1,
+                stdout="",
+                stderr="temporary outage",
+            )
+
+        exit_code, stdout, stderr, sleeps = self.invoke_main(
+            "ciwait-routing-infrastructure", run_gh
+        )
+
+        self.assertEqual(exit_code, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["reason"], "pr-lookup-infrastructure-requeue")
+        self.assertEqual(payload["status"], "ready")
+        self.assertEqual(
+            sleeps,
+            [
+                self.module.infrastructure_backoff_seconds(attempt)
+                for attempt in range(1, self.module.PR_LOOKUP_INFRASTRUCTURE_ATTEMPTS)
+            ],
+        )
+        self.assertIn("hold-and-requeue", stderr)
+        self.assertNotIn("successful PR lookups found no PR", stderr)
+
+    def test_main_successful_missing_pr_remains_terminal_failure(self):
+        def run_gh(*args):
+            return subprocess.CompletedProcess(
+                ["gh", *args],
+                0,
+                stdout="[]",
+                stderr="",
+            )
+
+        exit_code, stdout, stderr, sleeps = self.invoke_main(
+            "ciwait-routing-missing", run_gh
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout, "")
+        self.assertEqual(
+            sleeps,
+            [self.module.PR_LOOKUP_INTERVAL_SECONDS]
+            * (self.module.PR_LOOKUP_ATTEMPTS - 1),
+        )
+        self.assertIn("successful PR lookups found no PR", stderr)
+        self.assertNotIn("hold-and-requeue", stderr)
+
+    def test_main_merged_and_closed_prs_keep_short_circuit_results(self):
+        for state, reason in (("MERGED", "pr-merged"), ("CLOSED", "pr-closed")):
+            with self.subTest(state=state):
+                def run_gh(*args):
+                    return subprocess.CompletedProcess(
+                        ["gh", *args],
+                        0,
+                        stdout=json.dumps([{"number": 99, "state": state}]),
+                        stderr="",
+                    )
+
+                exit_code, stdout, stderr, sleeps = self.invoke_main(
+                    "ciwait-routing-closed-state", run_gh
+                )
+
+                self.assertEqual(exit_code, 0)
+                self.assertEqual(
+                    json.loads(stdout),
+                    {
+                        "status": "ready",
+                        "pr": 99,
+                        "prState": state,
+                        "reason": reason,
+                    },
+                )
+                self.assertEqual(sleeps, [])
+                self.assertNotIn("gh pr checks", stderr)
+
+    def test_main_open_pr_releases_after_terminal_checks(self):
+        def run_gh(*args):
+            if args[1] == "list":
+                return subprocess.CompletedProcess(
+                    ["gh", *args],
+                    0,
+                    stdout='[{"number": 100, "state": "OPEN"}]',
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(
+                ["gh", *args],
+                0,
+                stdout='[{"name": "Verification", "state": "SUCCESS", "bucket": "pass"}]',
+                stderr="",
+            )
+
+        exit_code, stdout, stderr, sleeps = self.invoke_main(
+            "ciwait-routing-terminal", run_gh
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(json.loads(stdout)["reason"], "checks-terminal")
+        self.assertEqual(json.loads(stdout)["prState"], "OPEN")
+        self.assertEqual(json.loads(stdout)["checks"], 1)
+        self.assertEqual(sleeps, [])
+        self.assertIn("terminal", stderr)
+
+    def test_main_pending_checks_wait_then_keep_terminal_policy(self):
+        checks = iter(
+            [
+                '[{"name": "Verification", "state": "IN_PROGRESS", "bucket": "pending"}]',
+                '[{"name": "Verification", "state": "SUCCESS", "bucket": "pass"}]',
+            ]
+        )
+
+        def run_gh(*args):
+            if args[1] == "list":
+                return subprocess.CompletedProcess(
+                    ["gh", *args],
+                    0,
+                    stdout='[{"number": 101, "state": "OPEN"}]',
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(
+                ["gh", *args], 0, stdout=next(checks), stderr=""
+            )
+
+        exit_code, stdout, stderr, sleeps = self.invoke_main(
+            "ciwait-routing-pending", run_gh
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(json.loads(stdout)["reason"], "checks-terminal")
+        self.assertEqual(sleeps, [self.module.POLL_INTERVAL_SECONDS])
+        self.assertIn("non-terminal", stderr)
+
+    def test_main_deadline_releases_pending_checks_for_requeue(self):
+        def run_gh(*args):
+            if args[1] == "list":
+                return subprocess.CompletedProcess(
+                    ["gh", *args],
+                    0,
+                    stdout='[{"number": 102, "state": "OPEN"}]',
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(
+                ["gh", *args],
+                0,
+                stdout='[{"name": "Verification", "state": "IN_PROGRESS", "bucket": "pending"}]',
+                stderr="",
+            )
+
+        with patch.object(self.module, "DEADLINE_SECONDS", 0):
+            exit_code, stdout, stderr, sleeps = self.invoke_main(
+                "ciwait-routing-deadline", run_gh
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(json.loads(stdout)["reason"], "deadline-requeue")
+        self.assertEqual(sleeps, [])
+        self.assertIn("hold-and-requeue", stderr)
+
+    def test_main_no_checks_after_grace_releases_without_failure(self):
+        def run_gh(*args):
+            if args[1] == "list":
+                return subprocess.CompletedProcess(
+                    ["gh", *args],
+                    0,
+                    stdout='[{"number": 103, "state": "OPEN"}]',
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(["gh", *args], 0, stdout="[]", stderr="")
+
+        with patch.object(self.module, "NO_CHECKS_GRACE_SECONDS", 0):
+            exit_code, stdout, stderr, sleeps = self.invoke_main(
+                "ciwait-routing-no-checks", run_gh
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(json.loads(stdout)["reason"], "no-checks-reported")
+        self.assertEqual(sleeps, [])
+        self.assertIn("no checks", stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
{
  "project": "ci-wait Must Not Kill a Lane When GitHub Lookup Fails",
  "branchName": "ciwait-transient-gh-failure-must-not-kill-a-lane",
  "description": "Make ci-wait distinguish GitHub lookup infrastructure failures from successful empty PR lookups. Infrastructure failures receive a separate bounded retry/backoff policy and exit 0 into hold-and-requeue on exhaustion, while a genuine repeatedly confirmed missing PR remains fatal with exit 1. Existing behavior after a PR is found remains unchanged.",
  "context": {
    "customerAsk": "Prevent a transient GitHub lookup failure from permanently killing a lane. Distinguish GitHub call failure from a successful empty PR lookup, retry transport failures separately with backoff, release exhausted transport failures for hold-and-requeue with exit code 0, preserve exit code 1 for a genuinely absent PR, and provide direct behavioral regression evidence for both outcomes.",
    "problem": "ci-wait currently represents both an unusable GitHub response and a successful lookup with no matching PR as None. Both consume the same five-attempt budget and eventually emit a false no-PR diagnosis with exit 1. Because the ci-wait workstation routes any failure directly to task:failed, a brief GitHub outage can permanently kill a valid lane, as happened to deflake-cli-text-stream-interrupted while PR #2189 remained open.",
    "solution": "Represent found, successfully not found, and infrastructure failure as distinct lookup outcomes. Count successful empty responses only against the missing-PR budget, and count non-zero exits, timeouts, and unusable responses against a separate bounded infrastructure retry/backoff budget. Exhausted infrastructure failures emit a ready/requeue result and exit 0 through the existing in-review hold path; exhausted successful empty lookups retain the actionable exit 1. Preserve all post-discovery CI behavior and document whether an optional onContinue transition adds safe defense in depth without weakening terminal no-PR failure."
  },
  "acceptanceCriteria": [
    "When every PR lookup attempt fails because gh exits non-zero, times out, or returns unusable output, ci-wait exhausts a separate infrastructure retry budget, emits an infrastructure/requeue diagnostic, and exits 0 into the existing hold-and-requeue path without saying that no PR exists.",
    "When every PR lookup completes successfully and returns an empty list, ci-wait exhausts only the not-found budget, emits the existing actionable missing-PR diagnosis, and exits 1 so the lane reaches its terminal failure state.",
    "Infrastructure failures do not consume the successful-not-found budget; a later successful found or empty response is handled according to that response, and retry/backoff behavior is bounded and directly testable without live GitHub access or real-time sleeps.",
    "Once a PR is found, existing observable treatment of open, merged, closed, red, pending, slow, and no-checks-reported cases remains unchanged; no general retry framework or unrelated CI policy is introduced.",
    "Quality gates pass: focused ci-wait behavioral tests, Typecheck passes, Tests pass, no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Required PR checks are Backend Lint and Verification Policy; coverage-floor reports and localai-backend-artifacts are not treated as merge blockers under the current operator policy.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "ciwait-transient-gh-failure-must-not-kill-a-lane-001",
      "title": "Preserve the genuine missing-PR failure",
      "description": "As a factory operator, I want a successful GitHub lookup that repeatedly finds no matching PR to remain fatal so that a process stage that never opened its required PR cannot loop forever.",
      "acceptanceCriteria": [
        "A stubbed gh pr list that succeeds and returns an empty PR list for every allowed lookup causes ci-wait to exit 1 after the successful-not-found retry budget is exhausted.",
        "The terminal diagnostic identifies the lane branch and says that successful lookups found no PR; it does not describe an infrastructure outage.",
        "A successful lookup that returns an open, merged, or closed matching PR continues to select the existing preferred state and does not consume additional missing-PR attempts.",
        "Retry timing is controllable in tests so the regression test uses no real network and no real-time sleep.",
        "The focused missing-PR test name and output are included in the PR description or a PR comment as behavioral evidence.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented explicit successful-empty lookup handling and added tests/factory/scripts/test_ci_wait.py covering the bounded exit-1 retry path and existing OPEN/MERGED/CLOSED preference. Focused tests pass."
    },
    {
      "id": "ciwait-transient-gh-failure-must-not-kill-a-lane-002",
      "title": "Requeue when GitHub lookup infrastructure is unavailable",
      "description": "As a factory operator, I want GitHub transport and response failures to release the task for hold-and-requeue instead of failing the lane so that a temporary dependency outage cannot destroy valid work.",
      "acceptanceCriteria": [
        "A stubbed gh pr list that exits non-zero on every attempt exhausts the infrastructure retry budget and causes the script process to exit 0 with a machine-readable ready result for requeue.",
        "Timeout and unparseable-response lookup failures follow the same non-fatal infrastructure path and cannot be reported as proof that no PR exists.",
        "Infrastructure failures are counted separately from successful empty lookups and use a bounded backoff policy; diagnostics show the dependency failure, attempt progress, and final hold-and-requeue outcome without leaking credentials or unsafe response content.",
        "If GitHub later returns a usable response during infrastructure retries, a found PR proceeds to normal CI gating and a successful empty response proceeds through the missing-PR policy rather than inheriting consumed not-found attempts.",
        "The focused always-failing-GitHub test name and output are included in the PR description or a PR comment as behavioral evidence.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented explicit found/successful-empty/infrastructure-failure lookup outcomes. Non-zero, timeout, empty-output, malformed, and unusable responses use a separate three-attempt bounded 5s/10s backoff budget, emit a machine-readable ready requeue result, and exit 0; successful empty responses retain the missing-PR exit-1 policy. Added deterministic tests including test_always_failing_github_lookup_requeues_without_no_pr_diagnosis, recovery to a found PR, and budget separation. Focused tests, Typecheck, and CI workflow tests pass."
    },
    {
      "id": "ciwait-transient-gh-failure-must-not-kill-a-lane-003",
      "title": "Preserve downstream CI-wait routing and policy",
      "description": "As a lane maintainer, I want the new lookup classification to integrate with the existing factory transitions without changing CI verdict policy so that resilience does not create a new infinite loop or alter review ownership.",
      "acceptanceCriteria": [
        "An exhausted infrastructure lookup exits through the same successful release to in-review used by deadline requeue, allowing the reviewer hold to route the task back through ci-wait; it never reaches the workstation's terminal failure transition.",
        "An exhausted successful-not-found lookup still exits non-zero and reaches the existing terminal failure transition.",
        "The implementation evaluates whether an onContinue transition adds defense in depth, records the decision and rationale in the PR, and does not remove or bypass terminal onFailure behavior for a genuine missing PR.",
        "Existing behavioral tests for found open, merged, and closed PRs and terminal, pending, deadline, and no-check states continue to pass without changed exit-code or result semantics.",
        "No behavior is added for judging red CI, changing required checks, polling CI after the implementation finish line, or creating a repository-wide retry abstraction.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Preserved the existing factory routing: ci-wait SCRIPT_RUN success outputs task:in-review, non-zero exit remains onFailure to task:failed, and review onContinue returns task:awaiting-ci for the hold-and-requeue loop. No ci-wait onContinue was added because script workers expose only exit-code success/failure outcomes, so that transition would be unreachable; the existing successful deadline/requeue result already provides the defense in depth. Added deterministic main-entrypoint behavioral coverage for infrastructure requeue, successful missing-PR failure, open/merged/closed PRs, terminal/pending/deadline/no-check CI states. Focused tests, typecheck, and CI workflow tests pass; broad make test hit the known untouched-package network timeout in pkg/services/work/transports/cli."
    }
  ]
}
