### PR TITLE
models-list-readiness-truth

### DIFF
--- a/pkg/services/models/internal/services/catalog/internal/service/service.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/service.go
@@ -61,7 +61,7 @@ func (s *service) ListCatalog(
 				}
 				return models.ListModelsResult{}, models.ErrUnavailable
 			}
-			summary.ManagedRuntime = overlayCacheFacts(summary.ManagedRuntime, current)
+			summary.ManagedRuntime = overlayResolvedRuntime(summary.ManagedRuntime, current)
 		}
 		result.Models = append(result.Models, summary)
 	}
@@ -72,9 +72,29 @@ func (s *service) ListCatalog(
 	return result, nil
 }
 
-func overlayCacheFacts(base, current models.Runtime) models.Runtime {
+// overlayResolvedRuntime applies the Models-owned readiness observation to a
+// catalog projection while retaining the stable catalog identity and shape.
+// Collection and detail callers must consume the same resolved state; copying
+// only cache facts would leave the collection projection at its static
+// MISSING/NOT_INSTALLED baseline.
+func overlayResolvedRuntime(base, current models.Runtime) models.Runtime {
 	projected := base.Clone()
 	current = current.Clone()
+	if current.Identity != "" {
+		projected.Identity = current.Identity
+	}
+	if current.Locality != "" {
+		projected.Locality = current.Locality
+	}
+	if current.ReadinessState != "" {
+		projected.ReadinessState = current.ReadinessState
+	}
+	if current.LifecycleState != "" {
+		projected.LifecycleState = current.LifecycleState
+	}
+	if current.SupportedOperations != nil {
+		projected.SupportedOperations = current.SupportedOperations
+	}
 	if current.Revision != nil {
 		projected.Revision = current.Revision
 	}
@@ -83,6 +103,16 @@ func overlayCacheFacts(base, current models.Runtime) models.Runtime {
 	}
 	if current.CacheBytes != nil {
 		projected.CacheBytes = current.CacheBytes
+	}
+	projected.Diagnostics = mergeDiagnostics(projected.Diagnostics, current.Diagnostics)
+	if projected.Diagnostics == nil {
+		projected.Diagnostics = map[string]string{}
+	}
+	if projected.ReadinessState != "" {
+		projected.Diagnostics["readinessState"] = string(projected.ReadinessState)
+	}
+	if projected.LifecycleState != "" {
+		projected.Diagnostics["lifecycleState"] = string(projected.LifecycleState)
 	}
 	return projected
 }
@@ -118,7 +148,7 @@ func (s *service) GetCatalogModel(
 			}
 			return models.GetModelResult{}, models.ErrUnavailable
 		}
-		detail.Summary.ManagedRuntime = overlayCacheFacts(detail.Summary.ManagedRuntime, current)
+		detail.Summary.ManagedRuntime = overlayResolvedRuntime(detail.Summary.ManagedRuntime, current)
 	}
 	return models.GetModelResult{Model: detail}, nil
 }

--- a/pkg/services/models/internal/services/catalog/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/service_test.go
@@ -143,7 +143,7 @@ func TestGetCatalogModelReturnsStableDetachedDetail(t *testing.T) {
 	assertCatalogDetail(t, afterMutation.Model)
 }
 
-func TestListCatalogOverlaysCacheFactsWithoutChangingCatalogStates(t *testing.T) {
+func TestCatalogReadsOverlayResolvedRuntimeStateAndCacheFacts(t *testing.T) {
 	t.Parallel()
 
 	revision := "rev-installed"
@@ -168,9 +168,9 @@ func TestListCatalogOverlaysCacheFactsWithoutChangingCatalogStates(t *testing.T)
 	scope := publicScope(t, openCatalogScope(t, scopes, "cache-model", "generate"))
 	listCatalogCacheFacts(t, service, scope, revision, cachePath, cacheBytes)
 	detail := inspectCatalogCacheFacts(t, service, scope, revision, cachePath, cacheBytes)
-	if detail.Model.ManagedRuntime.ReadinessState != models.ReadinessStateMissing ||
-		detail.Model.ManagedRuntime.LifecycleState != models.LifecycleStateNotInstalled {
-		t.Fatalf("inspect runtime states = (%s, %s), want MISSING/NOT_INSTALLED", detail.Model.ManagedRuntime.ReadinessState, detail.Model.ManagedRuntime.LifecycleState)
+	if detail.Model.ManagedRuntime.ReadinessState != models.ReadinessStateFailed ||
+		detail.Model.ManagedRuntime.LifecycleState != models.LifecycleStateInstalling {
+		t.Fatalf("inspect runtime states = (%s, %s), want FAILED/INSTALLING", detail.Model.ManagedRuntime.ReadinessState, detail.Model.ManagedRuntime.LifecycleState)
 	}
 }
 
@@ -190,14 +190,18 @@ func listCatalogCacheFacts(
 		t.Fatalf("models = %#v, want one model", result.Models)
 	}
 	runtime := result.Models[0].ManagedRuntime
-	if runtime.ReadinessState != models.ReadinessStateMissing ||
-		runtime.LifecycleState != models.LifecycleStateNotInstalled {
-		t.Fatalf("catalog states = (%s, %s), want MISSING/NOT_INSTALLED", runtime.ReadinessState, runtime.LifecycleState)
+	if runtime.ReadinessState != models.ReadinessStateFailed ||
+		runtime.LifecycleState != models.LifecycleStateInstalling {
+		t.Fatalf("catalog states = (%s, %s), want FAILED/INSTALLING", runtime.ReadinessState, runtime.LifecycleState)
 	}
 	if runtime.Revision == nil || *runtime.Revision != revision ||
 		runtime.CachePath == nil || *runtime.CachePath != cachePath ||
 		runtime.CacheBytes == nil || *runtime.CacheBytes != cacheBytes {
 		t.Fatalf("catalog cache facts = revision=%v path=%v bytes=%v, want rev-installed/path/1234", runtime.Revision, runtime.CachePath, runtime.CacheBytes)
+	}
+	if runtime.Diagnostics["readinessState"] != string(models.ReadinessStateFailed) ||
+		runtime.Diagnostics["lifecycleState"] != string(models.LifecycleStateInstalling) {
+		t.Fatalf("catalog diagnostics state = %#v, want FAILED/INSTALLING", runtime.Diagnostics)
 	}
 }
 
@@ -216,12 +220,12 @@ func inspectCatalogCacheFacts(
 		t.Fatalf("GetCatalogModel: %v", err)
 	}
 	inspectRuntime := detail.Model.ManagedRuntime
-	if inspectRuntime.ReadinessState != models.ReadinessStateMissing ||
-		inspectRuntime.LifecycleState != models.LifecycleStateNotInstalled ||
+	if inspectRuntime.ReadinessState != models.ReadinessStateFailed ||
+		inspectRuntime.LifecycleState != models.LifecycleStateInstalling ||
 		inspectRuntime.CachePath == nil || *inspectRuntime.CachePath != cachePath ||
 		inspectRuntime.Revision == nil || *inspectRuntime.Revision != revision ||
 		inspectRuntime.CacheBytes == nil || *inspectRuntime.CacheBytes != cacheBytes {
-		t.Fatalf("inspect runtime = %#v, want preserved states and cache facts", inspectRuntime)
+		t.Fatalf("inspect runtime = %#v, want resolved states and cache facts", inspectRuntime)
 	}
 	return detail
 }

--- a/pkg/services/models/transports/http/catalog_operations.go
+++ b/pkg/services/models/transports/http/catalog_operations.go
@@ -41,13 +41,6 @@ func (a *Adapter) GetModel(ctx context.Context, modelName string) (factoryapi.Mo
 	if err != nil {
 		return factoryapi.ModelDetail{}, err
 	}
-	readiness, err := a.models.GetModelReadiness(ctx, models.GetModelReadinessRequest{
-		Scope: a.scope, Name: request.Name, Operation: request.Operation,
-	})
-	if err != nil {
-		return factoryapi.ModelDetail{}, err
-	}
-	scoped.Model.ManagedRuntime = readiness.Readiness.Clone()
 	return detailToGenerated(scoped.Model), nil
 }
 

--- a/pkg/transports/http/server_factory_test.go
+++ b/pkg/transports/http/server_factory_test.go
@@ -390,7 +390,7 @@ func TestGetModel_ReturnsDiscoveredModelDetail(t *testing.T) {
 					ManagedRuntime: modelinference.Runtime{
 						Identity:       "OMNIVOICE_Q4_K_M",
 						ReadinessState: modelinference.ReadinessStateReady,
-						LifecycleState: modelinference.LifecycleStateNotInstalled,
+						LifecycleState: modelinference.LifecycleStateInstalled,
 						Locality:       modelinference.LocalityLocal,
 						SupportedOperations: []modelinference.Operation{{
 							Name: "TTS",
@@ -410,14 +410,6 @@ func TestGetModel_ReturnsDiscoveredModelDetail(t *testing.T) {
 					ResourceNames:    []string{"omnivoice-cache"},
 				}},
 				Diagnostics: map[string]string{"workerCount": "1"},
-			}, nil
-		},
-		readiness: func(_ context.Context, name string) (modelinference.Runtime, error) {
-			return modelinference.Runtime{
-				Identity:       name,
-				ReadinessState: modelinference.ReadinessStateReady,
-				LifecycleState: modelinference.LifecycleStateInstalled,
-				Locality:       modelinference.LocalityLocal,
 			}, nil
 		},
 	})

--- a/tests/functional/models/root_composition/story_003_test.go
+++ b/tests/functional/models/root_composition/story_003_test.go
@@ -67,6 +67,9 @@ func TestModelsPublicPullWorkflowProvesTruthfulTerminalState(t *testing.T) {
 	inspectProcess := support.BuildProcess(t, serviceedges.Edges{})
 	support.CleanupProcess(t, inspectProcess)
 
+	beforeList := executeStory003List(t, inspectProcess, server.URL(), "before pull")
+	assertStory003StatePair(t, beforeList.ManagedRuntime.ReadinessState, beforeList.ManagedRuntime.LifecycleState,
+		factoryapi.ManagedRuntimeReadinessStateMISSING, factoryapi.ManagedRuntimeLifecycleStateNOTINSTALLED)
 	before := executeStory003Inspect(t, inspectProcess, server.URL(), cacheDirectory, "before pull")
 	assertStory003State(t, before, factoryapi.ManagedRuntimeReadinessStateMISSING, factoryapi.ManagedRuntimeLifecycleStateNOTINSTALLED)
 
@@ -81,6 +84,9 @@ func TestModelsPublicPullWorkflowProvesTruthfulTerminalState(t *testing.T) {
 	waitStory003Signal(t, source.firstDownloadStarted, "first asset download")
 	during := executeStory003Inspect(t, inspectProcess, server.URL(), cacheDirectory, "during pull")
 	assertStory003State(t, during, factoryapi.ManagedRuntimeReadinessStateLOADING, factoryapi.ManagedRuntimeLifecycleStateINSTALLING)
+	duringList := executeStory003List(t, inspectProcess, server.URL(), "during pull")
+	assertStory003StatePair(t, duringList.ManagedRuntime.ReadinessState, duringList.ManagedRuntime.LifecycleState,
+		factoryapi.ManagedRuntimeReadinessStateLOADING, factoryapi.ManagedRuntimeLifecycleStateINSTALLING)
 
 	close(source.releaseFirstDownload)
 	select {
@@ -108,7 +114,7 @@ func TestModelsPublicPullWorkflowProvesTruthfulTerminalState(t *testing.T) {
 		story003TokenizerAsset: tokenizerBody,
 	})
 
-	assertStory003ListAfterPull(t, inspectProcess, server.URL(), cacheDirectory)
+	afterList := assertStory003ListAfterPull(t, inspectProcess, server.URL(), cacheDirectory)
 
 	after := executeStory003Inspect(t, inspectProcess, server.URL(), cacheDirectory, "after pull")
 	if after.Detail.ManagedRuntime.ReadinessState != factoryapi.ManagedRuntimeReadinessStateREADY {
@@ -118,6 +124,7 @@ func TestModelsPublicPullWorkflowProvesTruthfulTerminalState(t *testing.T) {
 		after.Detail.ManagedRuntime.LifecycleState != factoryapi.ManagedRuntimeLifecycleStateLOADED {
 		t.Fatalf("after-pull lifecycle = %s, want INSTALLED or LOADED", after.Detail.ManagedRuntime.LifecycleState)
 	}
+	assertStory003ReadyParity(t, inspectProcess, server.URL(), afterList, after)
 	if before.state() == during.state() || during.state() == after.state() || before.state() == after.state() {
 		t.Fatalf("inspect state pairs were not all distinct: before=%s during=%s after=%s", before.state(), during.state(), after.state())
 	}
@@ -128,34 +135,66 @@ func TestModelsPublicPullWorkflowProvesTruthfulTerminalState(t *testing.T) {
 	t.Run("controlled source failure", testStory003ControlledSourceFailure)
 }
 
+func assertStory003ReadyParity(
+	t *testing.T,
+	process support.Process,
+	serverURL string,
+	listed factoryapi.ModelSummary,
+	inspected story003InspectCapture,
+) {
+	t.Helper()
+	assertStory003StatePair(t, listed.ManagedRuntime.ReadinessState, listed.ManagedRuntime.LifecycleState,
+		factoryapi.ManagedRuntimeReadinessStateREADY, factoryapi.ManagedRuntimeLifecycleStateINSTALLED)
+	if listed.ManagedRuntime.ReadinessState != inspected.Detail.ManagedRuntime.ReadinessState ||
+		listed.ManagedRuntime.LifecycleState != inspected.Detail.ManagedRuntime.LifecycleState ||
+		listed.ManagedRuntime.Revision == nil || inspected.Detail.ManagedRuntime.Revision == nil ||
+		*listed.ManagedRuntime.Revision != *inspected.Detail.ManagedRuntime.Revision ||
+		listed.ManagedRuntime.CacheBytes == nil || inspected.Detail.ManagedRuntime.CacheBytes == nil ||
+		*listed.ManagedRuntime.CacheBytes != *inspected.Detail.ManagedRuntime.CacheBytes {
+		t.Fatalf("list/inspect managed runtime diverged: list=%#v inspect=%#v", listed.ManagedRuntime, inspected.Detail.ManagedRuntime)
+	}
+	httpList := support.GetJSON[factoryapi.ListModelsResponse](t, serverURL+"/models")
+	httpDetail := support.GetJSON[factoryapi.ModelDetail](t, serverURL+"/models/"+story003ModelName)
+	if len(httpList.Results) != 1 {
+		t.Fatalf("HTTP list result count = %d, want 1", len(httpList.Results))
+	}
+	assertStory003StatePair(t, httpList.Results[0].ManagedRuntime.ReadinessState, httpList.Results[0].ManagedRuntime.LifecycleState,
+		factoryapi.ManagedRuntimeReadinessStateREADY, factoryapi.ManagedRuntimeLifecycleStateINSTALLED)
+	if httpDetail.ManagedRuntime.ReadinessState != httpList.Results[0].ManagedRuntime.ReadinessState ||
+		httpDetail.ManagedRuntime.LifecycleState != httpList.Results[0].ManagedRuntime.LifecycleState {
+		t.Fatalf("HTTP list/detail managed runtime diverged: list=%#v detail=%#v", httpList.Results[0].ManagedRuntime, httpDetail.ManagedRuntime)
+	}
+	assertStory003HumanOutput(t, process, "models list", story003ModelsHumanListArgs(serverURL), "READY", "INSTALLED")
+	assertStory003HumanOutput(t, process, "models inspect", story003ModelsHumanInspectArgs(serverURL), "READY", "INSTALLED")
+}
+
 func assertStory003ListAfterPull(
 	t *testing.T,
 	process support.Process,
 	serverURL string,
 	cacheDirectory string,
-) {
+) factoryapi.ModelSummary {
 	t.Helper()
-	listOutput := executeStory003ListOutput(t, process, serverURL, "after pull")
-	var listed factoryapi.ListModelsResponse
-	if err := json.Unmarshal([]byte(listOutput), &listed); err != nil {
-		t.Fatalf("decode models list after pull output: %v\nstdout=%s", err, listOutput)
-	}
-	if len(listed.Results) != 1 || listed.Results[0].ManagedRuntime.CacheBytes == nil {
-		t.Fatalf("models list after pull = %#v, want one cached model with exact bytes", listed)
+	listedModel := executeStory003List(t, process, serverURL, "after pull")
+	if listedModel.ManagedRuntime.CacheBytes == nil {
+		t.Fatalf("models list after pull = %#v, want one cached model with exact bytes", listedModel)
 	}
 	independentRevisionBytes := story003RegularFileBytes(
 		t, filepath.Join(cacheDirectory, story003ModelName, story003Revision),
 	)
-	if got := *listed.Results[0].ManagedRuntime.CacheBytes; got != independentRevisionBytes {
+	if got := *listedModel.ManagedRuntime.CacheBytes; got != independentRevisionBytes {
 		t.Fatalf("models list cacheBytes = %d, independent revision sum = %d", got, independentRevisionBytes)
 	}
+	assertStory003StatePair(t, listedModel.ManagedRuntime.ReadinessState, listedModel.ManagedRuntime.LifecycleState,
+		factoryapi.ManagedRuntimeReadinessStateREADY, factoryapi.ManagedRuntimeLifecycleStateINSTALLED)
 	t.Logf(
 		"models list after pull stdout=%s independentRevisionBytes=%d cacheBytes=%d revisionPath=%s",
-		strings.TrimSpace(listOutput),
+		strings.TrimSpace(mustStory003ModelJSON(t, listedModel)),
 		independentRevisionBytes,
-		*listed.Results[0].ManagedRuntime.CacheBytes,
+		*listedModel.ManagedRuntime.CacheBytes,
 		filepath.Join(cacheDirectory, story003ModelName, story003Revision),
 	)
+	return listedModel
 }
 
 func TestModelsPublicRemoveWorkflowProvesReclamationAndInUseRefusal(t *testing.T) {
@@ -359,13 +398,63 @@ func executeStory003Inspect(
 	return capture
 }
 
-func executeStory003ListOutput(t *testing.T, process support.Process, serverURL, phase string) string {
+func executeStory003List(t *testing.T, process support.Process, serverURL, phase string) factoryapi.ModelSummary {
 	t.Helper()
 	inputs := support.FakeInputs(t.Context(), story003ModelsListArgs(serverURL))
 	if err := process.Execute(inputs.Input); err != nil {
 		t.Fatalf("Process.Execute(models list %s) error = %v\nstdout=%s\nstderr=%s", phase, err, inputs.Stdout(), inputs.Stderr())
 	}
-	return inputs.Stdout()
+	var listed factoryapi.ListModelsResponse
+	if err := json.Unmarshal([]byte(inputs.Stdout()), &listed); err != nil {
+		t.Fatalf("decode models list %s output: %v\nstdout=%s", phase, err, inputs.Stdout())
+	}
+	if len(listed.Results) != 1 {
+		t.Fatalf("models list %s result count = %d, want 1", phase, len(listed.Results))
+	}
+	t.Logf("models list %s stdout=%s", phase, strings.TrimSpace(inputs.Stdout()))
+	return listed.Results[0]
+}
+
+func assertStory003StatePair(
+	t *testing.T,
+	readiness factoryapi.ManagedRuntimeReadinessState,
+	lifecycle factoryapi.ManagedRuntimeLifecycleState,
+	wantReadiness factoryapi.ManagedRuntimeReadinessState,
+	wantLifecycle factoryapi.ManagedRuntimeLifecycleState,
+) {
+	t.Helper()
+	if readiness != wantReadiness || lifecycle != wantLifecycle {
+		t.Fatalf("managed runtime state = %s/%s, want %s/%s", readiness, lifecycle, wantReadiness, wantLifecycle)
+	}
+}
+
+func mustStory003ModelJSON(t *testing.T, model factoryapi.ModelSummary) string {
+	t.Helper()
+	body, err := json.Marshal(model)
+	if err != nil {
+		t.Fatalf("marshal models list model: %v", err)
+	}
+	return string(body)
+}
+
+func assertStory003HumanOutput(
+	t *testing.T,
+	process support.Process,
+	phase string,
+	args []string,
+	wants ...string,
+) {
+	t.Helper()
+	inputs := support.FakeInputs(t.Context(), args)
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf("Process.Execute(%s) error = %v\nstdout=%s\nstderr=%s", phase, err, inputs.Stdout(), inputs.Stderr())
+	}
+	for _, want := range wants {
+		if !strings.Contains(inputs.Stdout(), want) {
+			t.Fatalf("%s output missing %q:\n%s", phase, want, inputs.Stdout())
+		}
+	}
+	t.Logf("%s human output=%s", phase, strings.TrimSpace(inputs.Stdout()))
 }
 
 func assertStory003State(
@@ -467,6 +556,19 @@ func story003ModelsInspectArgs(serverURL string) []string {
 func story003ModelsListArgs(serverURL string) []string {
 	return []string{
 		"you", "--json", "--server", strings.TrimSuffix(serverURL, "/"), "models", "list",
+	}
+}
+
+func story003ModelsHumanListArgs(serverURL string) []string {
+	return []string{
+		"you", "--server", strings.TrimSuffix(serverURL, "/"), "models", "list",
+	}
+}
+
+func story003ModelsHumanInspectArgs(serverURL string) []string {
+	return []string{
+		"you", "--server", strings.TrimSuffix(serverURL, "/"),
+		"models", "inspect", story003ModelName,
 	}
 }
 


### PR DESCRIPTION
{
  "project": "Models List and Inspect Readiness Truth",
  "branchName": "models-list-readiness-truth",
  "description": "Verify the installed-cache list/inspect discrepancy on current main after the cache inspection/removal lane merges, close with evidence if already fixed, or make both public paths consume one Models-owned readiness/lifecycle resolution and prove exact READY/INSTALLED parity with a functional regression.",
  "context": {
    "customerAsk": "After models-cache-inspect-and-remove merges, re-run the complete-cache probe on current main. If list and inspect still disagree, make them share one readiness/lifecycle resolution and add a functional test proving agreement for the same installed model; if they already agree, close without inventing scope.",
    "problem": "Against one running server and one complete, manifest-valid OMNIVOICE_Q4_K_M cache, human CLI, CLI JSON, and HTTP list reported MISSING/NOT_INSTALLED while inspect reported READY/INSTALLED with both expected files present. The empty-cache control agrees, so the list discovery surface specifically misrepresents installed state.",
    "solution": "Gate work on the overlapping cache lane, repeat the public probe first, then only if needed keep readiness/lifecycle derivation in Models and feed its single resolved state to collection and detail reads. Prove the correction end to end through root.BuildProcess and Process.Execute using an isolated complete cache, while preserving empty-cache behavior and public contracts."
  },
  "acceptanceCriteria": [
    "Work starts only after models-cache-inspect-and-remove is merged, and current main is probed before any code change using one isolated server, one isolated state directory, and a complete manifest-valid OMNIVOICE_Q4_K_M cache; human CLI, CLI JSON, and HTTP list/inspect results are captured as evidence.",
    "If the current-main probe shows matching readinessState and lifecycleState on list and inspect, the item closes with that evidence and no production diff, replacement scope, or speculative cleanup.",
    "If the defect remains, list and inspect report the same READY/INSTALLED state for the same complete cache, while both retain MISSING/NOT_INSTALLED for the empty-cache control and do not misclassify partial, invalid, or stale caches as installed.",
    "Models owns one readiness/lifecycle resolution from observed cache and runtime facts; collection and detail reads consume it, and CLI/HTTP mappings only present the resolved state without list-only policy or public contract drift.",
    "A functional regression fails on the pre-fix parent and passes after the correction by exercising public models list and models inspect commands through root.BuildProcess and Process.Execute against an isolated complete on-disk cache; mapper-only and meta-tests do not satisfy this proof.",
    "Typecheck passes; focused Models unit/integration tests and the public CLI functional regression pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "models-list-readiness-truth-001",
      "title": "Re-measure list and inspect parity on current main",
      "description": "As a maintainer, I want the shipped discrepancy re-measured after the prerequisite lane lands so that we fix only behavior that remains broken and do not manufacture duplicate scope.",
      "acceptanceCriteria": [
        "models-cache-inspect-and-remove is confirmed merged before work begins, and the probe runs from current main rather than the old 3180f14f4 measurement build.",
        "One isolated running server is configured with a complete, manifest-valid OMNIVOICE_Q4_K_M cache containing both expected artifacts, and list and inspect are captured through human CLI, CLI JSON, and HTTP for that same server and model.",
        "The evidence records both commands' readinessState and lifecycleState, manifest validity, installed and expected file counts, revision, and cache identity sufficiently to prove both observations refer to the same complete installation.",
        "An isolated empty-cache control confirms both surfaces still return MISSING/NOT_INSTALLED.",
        "If all complete-cache outputs already agree, the work item closes with evidence and no code, replacement feature, or mapper cleanup; otherwise the exact failing comparison becomes the before-state for story 002.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Confirmed prerequisite PR #2203 merged before work. The independent current-main-equivalent probe reproduced the defect before code changes: empty and interrupted-partial caches agreed at MISSING/NOT_INSTALLED, while the same complete manifest-valid cache had list JSON at MISSING/NOT_INSTALLED and inspect at READY/INSTALLED with matching revision, cache bytes, and expected/observed file counts. The affected Models/CLI/wire/functional paths were byte-identical to origin/main at probe time. Typecheck passed."
    },
    {
      "id": "models-list-readiness-truth-002",
      "title": "Make public list and inspect share truthful model state",
      "description": "As a customer, I want list and inspect to agree about whether my managed local model is installed so that discovery output is safe to use for operational decisions.",
      "acceptanceCriteria": [
        "For a complete cache with a valid manifest, matching revision, and every expected artifact present at its expected size, models list JSON and models inspect JSON both report readinessState READY and lifecycleState INSTALLED for the same model.",
        "Human list and inspect plus raw HTTP list/detail responses present the same canonical state without changing response shapes or enum vocabulary.",
        "For an empty cache, both commands continue to report MISSING/NOT_INSTALLED, and missing, partial, invalid, or stale cache facts are not promoted to installed.",
        "Readiness and lifecycle are resolved once by Models-owned catalog/runtime behavior from observed facts and supplied to both callers; transport mapping contains no list-only install-state policy.",
        "A functional test constructs through root.BuildProcess, executes public list and inspect through Process.Execute, uses an isolated temporary cache rather than a developer cache or real download, and asserts equality plus the exact installed state pair for the same model.",
        "The functional test is demonstrated failing against the pre-fix parent and passing after the change; focused lower-level tests cover changed pure resolution logic, and no meta-test, route inventory, source scan, or mapper-only assertion substitutes for the public proof.",
        "The unknown-model CLI error remains owned by cli-error-detail-passthrough; this lane checks that work before noting the observation and makes no central error-renderer change.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Catalog collection and detail now consume the same Models-owned resolved runtime, including readiness, lifecycle, cache facts, and diagnostics; the HTTP detail adapter no longer performs a second readiness-policy lookup. The root.BuildProcess/Process.Execute regression proves empty MISSING/NOT_INSTALLED, active LOADING/INSTALLING, and complete-cache READY/INSTALLED parity across human CLI, CLI JSON, and HTTP list/detail, including revision and cache-byte equality. Models tests, functional Models tests, typecheck, backend-size, pkg-maint, pkg-file-count, pkg-structure, and go vet ./... passed."
    }
  ]
}
