### PR TITLE
models: preserve opaque remove failure diagnostics

### DIFF
--- a/pkg/services/models/transports/cli/models.go
+++ b/pkg/services/models/transports/cli/models.go
@@ -880,9 +880,17 @@ func modelsRequestError(statusCode int, body []byte, response ...*http.Response)
 	if json.Unmarshal(body, &errResp) == nil && errResp.Message != "" {
 		switch errResp.Code {
 		case factoryapi.ErrorResponseCodeMODELCACHENOTFOUND:
-			return fmt.Errorf("%w: %s", ErrModelCacheNotFound, errResp.Message)
+			displayMessage := fmt.Sprintf("%s: %s", ErrModelCacheNotFound, errResp.Message)
+			if httpResponse != nil {
+				return clihttp.NewAPIErrorFromResponse(httpResponse, errResp, displayMessage, ErrModelCacheNotFound)
+			}
+			return clihttp.NewAPIError(statusCode, errResp, displayMessage, ErrModelCacheNotFound)
 		case factoryapi.ErrorResponseCodeMODELCACHEINUSE:
-			return fmt.Errorf("%w: %s", ErrModelCacheInUse, errResp.Message)
+			displayMessage := fmt.Sprintf("%s: %s", ErrModelCacheInUse, errResp.Message)
+			if httpResponse != nil {
+				return clihttp.NewAPIErrorFromResponse(httpResponse, errResp, displayMessage, ErrModelCacheInUse)
+			}
+			return clihttp.NewAPIError(statusCode, errResp, displayMessage, ErrModelCacheInUse)
 		}
 		if statusCode == http.StatusNotFound && errResp.Code == factoryapi.ErrorResponseCodeNOTFOUND {
 			if httpResponse != nil {

--- a/pkg/services/models/transports/cli/root_commands.go
+++ b/pkg/services/models/transports/cli/root_commands.go
@@ -303,7 +303,7 @@ func doModelsDELETE(
 	}
 	if resp.StatusCode != http.StatusOK {
 		logModelsResponse(diagnostics, endpoint, resp.StatusCode, response.Duration, fmt.Sprintf("responseBytes=%d", len(body)))
-		return modelsRequestError(resp.StatusCode, body)
+		return modelsRequestError(resp.StatusCode, body, resp)
 	}
 	if out != nil && len(body) > 0 {
 		if err := json.Unmarshal(body, out); err != nil {

--- a/tests/functional/models/root_composition/story_001_test.go
+++ b/tests/functional/models/root_composition/story_001_test.go
@@ -1,0 +1,64 @@
+package root_composition_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	modelscli "github.com/portpowered/infinite-you/pkg/services/models/transports/cli"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+func TestModelsPublicRemoveMissingCacheRendersServerDiagnostic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodDelete || request.URL.Path != "/models/not-cached-model" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(writer).Encode(factoryapi.ErrorResponse{
+			Code:    factoryapi.ErrorResponseCodeMODELCACHENOTFOUND,
+			Family:  factoryapi.ErrorFamilyNotFound,
+			Message: "model cache is not installed; run you models pull not-cached-model first",
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "--server", server.URL, "models", "remove", "not-cached-model",
+	})
+	inputs.Input.WorkingDirectory = t.TempDir()
+	err := process.Execute(inputs.Input)
+	if err == nil {
+		t.Fatal("Process.Execute(models remove) error = nil, want missing-cache failure")
+	}
+	if !errors.Is(err, modelscli.ErrModelCacheNotFound) {
+		t.Fatalf("Process.Execute(models remove) error = %v, want ErrModelCacheNotFound", err)
+	}
+
+	var response factoryapi.ErrorResponse
+	if decodeErr := json.Unmarshal([]byte(strings.TrimSpace(inputs.Stderr())), &response); decodeErr != nil {
+		t.Fatalf("decode rendered models remove diagnostic: %v\nstderr=%q", decodeErr, inputs.Stderr())
+	}
+	if response.Code != factoryapi.ErrorResponseCodeMODELCACHENOTFOUND ||
+		response.Family != factoryapi.ErrorFamilyNotFound ||
+		response.Message != "model cache is not installed; run you models pull not-cached-model first" {
+		t.Fatalf("rendered models remove diagnostic = %#v, want server response", response)
+	}
+	for _, fallback := range []string{"CLI_COMMAND_FAILED", "INTERNAL_SERVER_ERROR"} {
+		if strings.Contains(inputs.Stderr(), fallback) {
+			t.Fatalf("rendered models remove diagnostic contains fallback %q: %q", fallback, inputs.Stderr())
+		}
+	}
+	if inputs.Stdout() != "" {
+		t.Fatalf("models remove failure stdout = %q, want empty", inputs.Stdout())
+	}
+}

--- a/tests/functional/models/root_composition/story_002_test.go
+++ b/tests/functional/models/root_composition/story_002_test.go
@@ -1,0 +1,65 @@
+package root_composition_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	modelscli "github.com/portpowered/infinite-you/pkg/services/models/transports/cli"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+func TestModelsPublicRemoveMissingCachePreservesJSONDiagnostic(t *testing.T) {
+	const safeMessage = "model cache is not installed; run you models pull not-cached-model first"
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodDelete || request.URL.Path != "/models/not-cached-model" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(writer).Encode(factoryapi.ErrorResponse{
+			Code:    factoryapi.ErrorResponseCodeMODELCACHENOTFOUND,
+			Family:  factoryapi.ErrorFamilyNotFound,
+			Message: safeMessage,
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "--json", "--server", server.URL, "models", "remove", "not-cached-model",
+	})
+	inputs.Input.WorkingDirectory = t.TempDir()
+	err := process.Execute(inputs.Input)
+	if err == nil {
+		t.Fatal("Process.Execute(json models remove) error = nil, want missing-cache failure")
+	}
+	if !errors.Is(err, modelscli.ErrModelCacheNotFound) {
+		t.Fatalf("Process.Execute(json models remove) error = %v, want ErrModelCacheNotFound", err)
+	}
+	if inputs.Stdout() != "" {
+		t.Fatalf("json models remove failure stdout = %q, want empty", inputs.Stdout())
+	}
+
+	var response factoryapi.ErrorResponse
+	if decodeErr := json.Unmarshal([]byte(strings.TrimSpace(inputs.Stderr())), &response); decodeErr != nil {
+		t.Fatalf("decode rendered json models remove diagnostic: %v\nstderr=%q", decodeErr, inputs.Stderr())
+	}
+	if response.Code != factoryapi.ErrorResponseCodeMODELCACHENOTFOUND ||
+		response.Family != factoryapi.ErrorFamilyNotFound || response.Message != safeMessage {
+		t.Fatalf("rendered json models remove diagnostic = %#v, want server response", response)
+	}
+	for _, fallback := range []string{"CLI_COMMAND_FAILED", "INTERNAL_SERVER_ERROR"} {
+		if strings.Contains(inputs.Stderr(), fallback) {
+			t.Fatalf("rendered json models remove diagnostic contains fallback %q: %q", fallback, inputs.Stderr())
+		}
+	}
+}


### PR DESCRIPTION
{
  "project": "Preserve Structured Server Errors for models remove",
  "branchName": "models-inspect-opaque-failure-diagnostics",
  "description": "Fix the you models remove CLI error-mapping outlier so removing a model that is not cached exits non-zero and renders the server's existing MODEL_CACHE_NOT_FOUND / NOT_FOUND diagnostic without --debug instead of substituting CLI_COMMAND_FAILED / INTERNAL_SERVER_ERROR. Preserve JSON automation behavior, empty failure stdout, and successful cached removal while leaving the server, wire contract, adjacent models commands, catalog/list behavior, and prohibited deadcode baseline unchanged.",
  "context": {
    "customerAsk": "Make you models remove <not-cached-model> surface the server's real structured error by default, following the established models inspect, models pull, and PR #2200 passthrough behavior. Prove the actual rendered CLI output and non-zero exit, explicitly guard against INTERNAL_SERVER_ERROR, preserve successful cached removal, and include real before/after terminal output in the PR body.",
    "problem": "A clean operator probe showed that DELETE /models/{model_name} correctly returns HTTP 404 with code MODEL_CACHE_NOT_FOUND, family NOT_FOUND, and an actionable message, and that the CLI receives the response. The models remove CLI path discards that body and emits CLI_COMMAND_FAILED / INTERNAL_SERVER_ERROR instead. This misclassifies an ordinary client-side not-found condition as a server failure. Adjacent inspect and pull commands already propagate structured errors correctly, and existing remove coverage checks an internal error value rather than the customer-visible rendered diagnostic.",
    "solution": "Align only the remote models remove error path with the existing safe structured-server-error propagation used by adjacent model commands and the common CLI renderer. Preserve the received code, family, and safe message through the command boundary, prove default and JSON stderr plus exit/stdout behavior through the composed CLI process, and retain direct cached-removal success coverage. Do not add a new error mechanism or change any server or public wire contract."
  },
  "deliveryEvidence": {
    "before": "$ you models remove not-cached-model\n{\"code\":\"CLI_COMMAND_FAILED\",\"family\":\"INTERNAL_SERVER_ERROR\",\"message\":\"command failed\"}\n$ echo $?\n1",
    "after": "$ you models remove not-cached-model\n{\"code\":\"MODEL_CACHE_NOT_FOUND\",\"family\":\"NOT_FOUND\",\"message\":\"model cache is not installed; run you models pull not-cached-model first\"}\n$ echo $?\n1\nstdout: <empty>"
  },
  "acceptanceCriteria": [
    "Against a controlled server returning HTTP 404 with MODEL_CACHE_NOT_FOUND, you models remove <not-cached-model> exits non-zero and renders one structured error containing code MODEL_CACHE_NOT_FOUND, family NOT_FOUND, and the server-provided safe message without --debug.",
    "The rendered missing-cache diagnostic contains neither CLI_COMMAND_FAILED nor INTERNAL_SERVER_ERROR, with a direct regression assertion specifically protecting the family classification.",
    "you --json models remove <not-cached-model> preserves the same code, family, and message, exits non-zero, and emits no success-shaped response on stdout.",
    "Removing a cached model still exits successfully, reports the established removal result, and removes the selected cached revision and its bytes.",
    "The implementation follows the established structured CLI error-passthrough pattern and does not add a new error type or change the server handler, HTTP status/body, OpenAPI or generated contracts, models inspect, models pull, models invoke, models list/catalog behavior, or docs/internal/baselines/deadcode-baseline.txt; the PR body includes the supplied before output and real after output with exit status.",
    "Quality gates pass: Typecheck passes; focused rendered-CLI failure and cached-removal tests pass; required Backend Lint and Verification Policy CI complete successfully; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Advisory coverage-floor output and the non-required localai-backend-artifacts result are interpreted separately from actual test failures.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "models-inspect-opaque-failure-diagnostics-001",
      "title": "Surface the missing-cache error in default CLI output",
      "description": "As an operator, I want models remove to report the server's actual missing-cache diagnostic without special flags so I can distinguish a normal not-found condition from a server failure.",
      "acceptanceCriteria": [
        "Given a controlled DELETE response with HTTP 404, code MODEL_CACHE_NOT_FOUND, family NOT_FOUND, and a safe message, you models remove <model> exits non-zero and stderr renders those same three fields without --debug.",
        "A test executes the composed CLI command and decodes or inspects the rendered stderr rather than asserting only an internal Go error value.",
        "The regression test independently asserts that rendered stderr contains neither INTERNAL_SERVER_ERROR nor CLI_COMMAND_FAILED.",
        "Failure stdout is empty and stderr contains one customer-facing structured diagnostic.",
        "No new error type or alternate error-rendering mechanism is introduced; the remove path uses the established structured server-error propagation behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Preserved the existing clihttp.APIError contract and cache sentinel identity through models remove; added a root-composed rendered-stderr regression test. Focused functional, Models CLI, clihttp/clidiag, and root tests pass."
    },
    {
      "id": "models-inspect-opaque-failure-diagnostics-002",
      "title": "Preserve structured remove failures for JSON automation",
      "description": "As an automation author, I want models remove failures to retain their server classification in JSON mode so scripts receive an accurate failure object and no success-shaped output.",
      "acceptanceCriteria": [
        "you --json models remove <not-cached-model> exits non-zero and emits a parseable error with code MODEL_CACHE_NOT_FOUND, family NOT_FOUND, and the server-provided safe message.",
        "JSON-mode failure stdout is empty; no zero-valued or success-shaped model removal response is emitted.",
        "The JSON-mode rendered error contains neither INTERNAL_SERVER_ERROR nor CLI_COMMAND_FAILED.",
        "Default and JSON modes preserve the same server classification without requiring --debug or --verbose.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
        "passes": true,
        "notes": "Added root-composed JSON-mode regression coverage proving non-zero execution, empty stdout, preserved MODEL_CACHE_NOT_FOUND / NOT_FOUND / safe message on stderr, and no CLI_COMMAND_FAILED or INTERNAL_SERVER_ERROR fallback. Focused test passes."
    },
    {
      "id": "models-inspect-opaque-failure-diagnostics-003",
      "title": "Preserve successful cached removal",
      "description": "As an operator, I want cached model removal to continue succeeding after the failure-path fix so I can reclaim the selected cache revision without regression.",
      "acceptanceCriteria": [
        "Given a model with a cached revision, you models remove <model> exits successfully and retains the established success response fields, including the removed model/revision, removal outcome, and measured bytes removed.",
        "After the command succeeds, direct filesystem observation confirms the selected cached revision is absent and its removed byte count is no longer present.",
        "Focused coverage exercises the success behavior through the composed CLI process using isolated cache and server effects.",
        "The change does not alter server response behavior or any models pull, models invoke, models inspect, or models list/catalog behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Verified the existing root-composed cached-removal regression: Process.Execute succeeds in JSON mode, preserves model/revision/outcome/bytesRemoved, and direct filesystem checks confirm the selected revision is absent with zero remaining bytes. Focused test passes."
    }
  ]
}
