### PR TITLE
fix(setup-workspace): survive dirty operator roots

### DIFF
--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -44,6 +44,10 @@ class DirtyRootError(RuntimeError):
     """A bounded, already-rendered diagnostic for an operator-owned root."""
 
 
+class RootStatusError(RuntimeError):
+    """A root status inspection failure that belongs to the setup preflight."""
+
+
 def raw_failure_details(error):
     """Return an exception's text without allowing rendering to raise again."""
     try:
@@ -336,6 +340,14 @@ def ensure_clean_repository_root(repo_root):
     entries = repository_status_entries(repo_root)
     if entries:
         raise DirtyRootError(dirty_root_diagnostic(repo_root, entries))
+
+
+def root_status_for_setup(repo_root):
+    """Inspect root dirt after fetch while preserving the preflight failure stage."""
+    try:
+        return repository_status_entries(repo_root)
+    except Exception as error:  # noqa: BLE001 - preserve the CLI stage boundary
+        raise RootStatusError(str(error)) from error
 
 
 def command_failure_details(result):
@@ -925,12 +937,19 @@ def _sync_main(repo_root):
     """Best-effort root main sync without disturbing the working tree.
 
     Uses fetch plus refs/heads/main fast-forward when safe instead of git pull,
-    so dirty-root checkouts can continue workspace setup from local state.
+    so clean-root checkouts can continue workspace setup from local state.
+    Dirty roots skip root synchronization after fetch when a local or remote
+    main ref can provide a safe start point for the requested lane.
     Returns a human-readable outcome string for logging.
     """
     if not has_origin_remote(repo_root):
+        entries = root_status_for_setup(repo_root)
         if local_main_ref_exists(repo_root):
+            if entries:
+                return "skipped (dirty root; using local main without root sync)"
             return "skipped (no origin remote)"
+        if entries:
+            raise DirtyRootError(dirty_root_diagnostic(repo_root, entries))
         raise RuntimeError(
             "no origin remote and refs/heads/main is missing"
         )
@@ -950,6 +969,17 @@ def _sync_main(repo_root):
             )
 
     remote_sha = resolve_remote_main_sha(repo_root, fetch_succeeded)
+    entries = root_status_for_setup(repo_root)
+    if entries:
+        if remote_sha is not None:
+            return (
+                "skipped (dirty root; using origin/main "
+                f"{remote_sha[:8]} without root sync)"
+            )
+        if local_main_ref_exists(repo_root):
+            return "skipped (dirty root; using local main without root sync)"
+        raise DirtyRootError(dirty_root_diagnostic(repo_root, entries))
+
     if remote_sha is None:
         if local_main_ref_exists(repo_root):
             return "skipped (origin has no main branch)"
@@ -1242,26 +1272,14 @@ def main():
         print("PRD name must not be empty", file=sys.stderr)
         sys.exit(1)
 
-    # Root setup is deliberately fail-closed: the legacy synchronization path
-    # can snapshot and restore local changes, but intake must not mutate an
-    # operator's repository before the lane has even been created.
-    try:
-        ensure_clean_repository_root(repo_root)
-    except DirtyRootError as e:
-        print(f"Root cleanliness check failed: {e}", file=sys.stderr)
-        sys.exit(1)
-    except Exception as e:  # noqa: BLE001 - CLI boundary must classify all failures
-        print(
-            format_stage_failure("Root cleanliness check failed", e),
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
     # Sync main and prune worktrees.
     try:
         sync_outcome = sync_main(repo_root)
         print(f"Root sync: {sync_outcome}", file=sys.stderr)
         prune_worktrees(repo_root)
+    except (DirtyRootError, RootStatusError) as e:
+        print(f"Root cleanliness check failed: {e}", file=sys.stderr)
+        sys.exit(1)
     except Exception as e:  # noqa: BLE001 - CLI boundary must classify all failures
         print(format_stage_failure("Root sync failed", e), file=sys.stderr)
         sys.exit(1)

--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -11,6 +11,7 @@ Exit 0 on success (stdout = JSON blob), exit 1 on failure (stderr = stage-specif
 """
 
 import contextlib
+import hashlib
 import json
 import os
 import re
@@ -28,9 +29,12 @@ SNAPSHOT_REF_PREFIX = "refs/factory-snapshots/"
 ROOT_SYNC_LOCK_FILENAME = "setup-workspace-root-sync.lock"
 MAX_ANCESTOR_RESIDUE_PATHS = 20
 MAX_DIRTY_ROOT_SAMPLE_ENTRIES = 12
+MAX_DIRTY_ROOT_ATTRIBUTION_PATHS = 5
+MAX_DIRTY_ROOT_ATTRIBUTION_WORKTREES = 20
 MAX_STATUS_FAILURE_DETAILS = 512
 MAX_FAILURE_DETAILS = 1024
 MAX_DISPLAYED_STATUS_PATH_LENGTH = 240
+FILE_DIGEST_CHUNK_SIZE = 1024 * 1024
 WINDOWS_RESERVED_PATH_COMPONENT = re.compile(
     r"(?<![a-z0-9])(?:nul|con|prn|aux|com[1-9]|lpt[1-9])"
     r"(?:\.[^\\/:*?\"<>|\r\n]*)?(?![a-z0-9])",
@@ -38,6 +42,8 @@ WINDOWS_RESERVED_PATH_COMPONENT = re.compile(
 )
 _ROOT_SYNC_THREAD_LOCKS = {}
 _ROOT_SYNC_THREAD_LOCKS_GUARD = threading.Lock()
+_MISSING_PATH = object()
+_UNAVAILABLE_PATH = object()
 
 
 class DirtyRootError(RuntimeError):
@@ -291,6 +297,156 @@ def dirty_root_sample(entries):
     return sample
 
 
+def path_content_digest(path):
+    """Return a bounded-memory digest for a file, or a path-state sentinel."""
+    try:
+        if not path.exists():
+            return _MISSING_PATH
+        if not path.is_file():
+            return _UNAVAILABLE_PATH
+
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            for chunk in iter(
+                lambda: stream.read(FILE_DIGEST_CHUNK_SIZE),
+                b"",
+            ):
+                digest.update(chunk)
+        return digest.digest()
+    except (OSError, ValueError):
+        return _UNAVAILABLE_PATH
+
+
+def git_revision_path_digest(repo_path, revision, relative_path):
+    """Return a digest for a revision path without mutating the repository."""
+    try:
+        result = run_git(
+            "show",
+            f"{revision}:{relative_path}",
+            cwd=repo_path,
+            check=False,
+        )
+    except Exception:  # noqa: BLE001 - attribution must never replace refusal
+        return _UNAVAILABLE_PATH
+
+    if result.returncode != 0:
+        return _MISSING_PATH
+    try:
+        contents = result.stdout.encode("utf-8", "surrogateescape")
+    except (AttributeError, UnicodeEncodeError):
+        return _UNAVAILABLE_PATH
+    return hashlib.sha256(contents).digest()
+
+
+def dirty_root_attribution_fingerprints(repo_path, entries):
+    """Capture at most five root changes relative to the fetched baseline."""
+    try:
+        if not origin_main_ref_exists(repo_path):
+            return []
+
+        fingerprints = []
+        for entry in dirty_root_sample(entries)[:MAX_DIRTY_ROOT_ATTRIBUTION_PATHS]:
+            paths = entry.get("paths", ())
+            if not paths:
+                continue
+            relative_path = paths[0]
+            baseline = git_revision_path_digest(
+                repo_path,
+                "refs/remotes/origin/main",
+                relative_path,
+            )
+            if baseline is _UNAVAILABLE_PATH:
+                continue
+
+            current = path_content_digest(repo_path / relative_path)
+            if current is _UNAVAILABLE_PATH or current == baseline:
+                continue
+            fingerprints.append((relative_path, baseline, current))
+        return fingerprints
+    except Exception:  # noqa: BLE001 - attribution is best effort only
+        return []
+
+
+def sibling_worktree_candidates(repo_path):
+    """Return a deterministic, bounded list of sibling directories."""
+    worktrees_dir = repo_path / ".claude" / "worktrees"
+    try:
+        children = sorted(
+            worktrees_dir.iterdir(),
+            key=lambda path: os.fsencode(path.name),
+        )
+    except (OSError, UnicodeError, ValueError):
+        return []
+
+    candidates = []
+    for candidate in children:
+        try:
+            if not candidate.is_dir():
+                continue
+        except OSError:
+            continue
+        candidates.append(candidate)
+        if len(candidates) >= MAX_DIRTY_ROOT_ATTRIBUTION_WORKTREES:
+            break
+    return candidates
+
+
+def is_valid_sibling_worktree(candidate):
+    """Check one sibling independently so stale entries cannot abort refusal."""
+    try:
+        result = run_git(
+            "rev-parse",
+            "--show-toplevel",
+            cwd=candidate,
+            check=False,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return False
+        return Path(result.stdout.strip()).resolve() == candidate.resolve()
+    except Exception:  # noqa: BLE001 - one broken candidate is non-fatal
+        return False
+
+
+def dirty_root_sibling_attribution(repo_path, entries):
+    """Find bounded sibling worktrees carrying the same sampled root changes."""
+    fingerprints = dirty_root_attribution_fingerprints(repo_path, entries)
+    if not fingerprints:
+        return []
+
+    matches = []
+    for candidate in sibling_worktree_candidates(repo_path):
+        if not is_valid_sibling_worktree(candidate):
+            continue
+
+        matching_paths = []
+        for relative_path, baseline, current in fingerprints:
+            sibling_current = path_content_digest(candidate / relative_path)
+            if sibling_current is _UNAVAILABLE_PATH:
+                continue
+            if sibling_current == current and sibling_current != baseline:
+                matching_paths.append(relative_path)
+        if matching_paths:
+            matches.append((candidate.name, matching_paths))
+
+    if not matches:
+        return []
+
+    lines = [
+        "likely sibling worktree matches (same changes relative to origin/main):",
+    ]
+    for candidate_name, matching_paths in matches:
+        rendered_paths = ", ".join(
+            json.dumps(path, ensure_ascii=True)
+            for path in matching_paths
+        )
+        lines.append(
+            "  sibling worktree "
+            f"{json.dumps(candidate_name, ensure_ascii=True)} "
+            f"matches path(s): {rendered_paths}"
+        )
+    return lines
+
+
 def dirty_root_diagnostic(repo_path, entries):
     """Describe dirty-root evidence and safe manual recovery guidance."""
     tracked_count = sum(
@@ -332,6 +488,7 @@ def dirty_root_diagnostic(repo_path, entries):
         "Inspect the repository root manually, then commit the changes or "
         "back them up and restore them manually before retrying."
     )
+    lines.extend(dirty_root_sibling_attribution(repo_path, entries))
     return "\n".join(lines)
 
 

--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -492,13 +492,6 @@ def dirty_root_diagnostic(repo_path, entries):
     return "\n".join(lines)
 
 
-def ensure_clean_repository_root(repo_root):
-    """Refuse setup before any root synchronization or workspace mutation."""
-    entries = repository_status_entries(repo_root)
-    if entries:
-        raise DirtyRootError(dirty_root_diagnostic(repo_root, entries))
-
-
 def root_status_for_setup(repo_root):
     """Inspect root dirt after fetch while preserving the preflight failure stage."""
     try:
@@ -1120,6 +1113,9 @@ def _sync_main(repo_root):
                 f"{command_failure_details(fetch_result)})"
             )
         if not origin_main_ref_exists(repo_root):
+            entries = root_status_for_setup(repo_root)
+            if entries:
+                raise DirtyRootError(dirty_root_diagnostic(repo_root, entries))
             raise RuntimeError(
                 "fetch failed and refs/heads/main is missing: "
                 f"{command_failure_details(fetch_result)}"

--- a/tests/factory/scripts/test_setup_workspace_dirty_root.py
+++ b/tests/factory/scripts/test_setup_workspace_dirty_root.py
@@ -420,6 +420,47 @@ class SetupWorkspaceDirtyRootTest(unittest.TestCase):
             ),
         )
 
+    def test_subprocess_dirty_root_refusal_survives_fetch_failure_without_main_refs(
+        self,
+    ):
+        operator_path, _upstream_path = create_remote_operator(self.repo_path)
+        prd_name = "dirty-root-fetch-failure-prd"
+        write_prd(operator_path, prd_name)
+
+        git(["checkout", "--detach", "HEAD"], operator_path)
+        git(["update-ref", "-d", "refs/heads/main"], operator_path)
+        git(["update-ref", "-d", "refs/remotes/origin/main"], operator_path)
+        git(
+            ["remote", "set-url", "origin", str(self.repo_path / "missing.git")],
+            operator_path,
+        )
+        (operator_path / "README.md").write_text(
+            "operator tracked edit\n", encoding="utf-8",
+        )
+        untracked_path = operator_path / "operator-untracked.txt"
+        untracked_path.write_text("operator untracked\n", encoding="utf-8")
+
+        entries = self.module.repository_status_entries(operator_path)
+        expected_core = self.module.dirty_root_diagnostic(operator_path, entries)
+        result = run_setup_workspace(operator_path, prd_name)
+
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertEqual(result.stdout, "")
+        expected_lines = expected_core.splitlines()
+        self.assertEqual(
+            result.stderr.splitlines(),
+            [
+                "Root cleanliness check failed: "
+                + expected_lines[0],
+                *expected_lines[1:],
+            ],
+        )
+        self.assertIn("repository root is dirty", result.stderr)
+        self.assertNotIn(
+            "fetch failed and refs/heads/main is missing",
+            result.stderr,
+        )
+
     def test_residual_refusal_attributes_matching_sibling_without_changing_core_text(self):
         operator_path = create_residual_refusal_repository(self.repo_path)
         prd_name = "residual-attribution-prd"

--- a/tests/factory/scripts/test_setup_workspace_dirty_root.py
+++ b/tests/factory/scripts/test_setup_workspace_dirty_root.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Regression tests for refusing a dirty repository root during setup."""
+"""Regression tests for safe setup from a dirty repository root."""
 
 import importlib.util
 import io
@@ -66,13 +66,46 @@ def write_prd(repo_path, prd_name):
     )
 
 
-def run_setup_workspace(repo_path, prd_name):
+def create_remote_operator(base_path):
+    """Create an operator clone whose remote can advance independently."""
+    remote_path = base_path / "remote.git"
+    remote_path.mkdir()
+    git(["init", "--bare", "-b", "main"], remote_path)
+
+    upstream_path = base_path / "upstream"
+    upstream_path.mkdir()
+    init_repository(upstream_path)
+    git(["remote", "add", "origin", str(remote_path)], upstream_path)
+    git(["push", "-u", "origin", "main"], upstream_path)
+
+    operator_path = base_path / "operator"
+    git(["clone", str(remote_path), operator_path.name], base_path)
+    git(
+        ["config", "user.email", "setup-workspace-test@example.com"],
+        operator_path,
+    )
+    git(
+        ["config", "user.name", "Setup Workspace Test"],
+        operator_path,
+    )
+    (operator_path / ".git" / "info" / "exclude").write_text(
+        "tasks/todo/\n.claude/\n",
+        encoding="utf-8",
+    )
+    return operator_path, upstream_path
+
+
+def run_setup_workspace(repo_path, prd_name, env=None):
+    environment = os.environ.copy()
+    if env:
+        environment.update(env)
     return subprocess.run(
         [sys.executable, str(SCRIPT_PATH), prd_name],
         cwd=repo_path,
         capture_output=True,
         text=True,
         check=False,
+        env=environment,
     )
 
 
@@ -85,55 +118,66 @@ class SetupWorkspaceDirtyRootTest(unittest.TestCase):
     def tearDown(self):
         self.temp_dir.cleanup()
 
-    def run_refusal_case(self, mutate_root):
+    def run_safe_case(self, mutate_root):
         init_repository(self.repo_path)
         prd_name = "dirty-root-prd"
         write_prd(self.repo_path, prd_name)
         mutate_root()
 
-        head_before = git(["rev-parse", "HEAD"], self.repo_path).stdout
+        head_before = git(["rev-parse", "HEAD"], self.repo_path).stdout.strip()
+        branch_before = git(
+            ["branch", "--show-current"], self.repo_path,
+        ).stdout.strip()
+        main_before = git(
+            ["rev-parse", "refs/heads/main"], self.repo_path,
+        ).stdout.strip()
         status_before = git(["status", "--porcelain=v1"], self.repo_path).stdout
+        index_before = git(["ls-files", "--stage"], self.repo_path).stdout
         result = run_setup_workspace(self.repo_path, prd_name)
 
-        self.assertEqual(result.returncode, 1, result.stdout)
-        self.assertEqual(result.stdout, "")
-        self.assertIn("repository root is dirty", result.stderr.lower())
-        self.assertIn(str(self.repo_path), result.stderr)
-        self.assertIn("total entries=", result.stderr)
-        self.assertIn("tracked changes=", result.stderr)
-        self.assertIn("untracked files=", result.stderr)
-        self.assertIn("Inspect the repository root manually", result.stderr)
-        self.assertIn("commit the changes", result.stderr)
-        self.assertIn("back them up and restore them manually", result.stderr)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "ready")
+        self.assertTrue(Path(payload["worktree"]).exists())
         self.assertEqual(
-            git(["rev-parse", "HEAD"], self.repo_path).stdout,
+            git(["rev-parse", "HEAD"], self.repo_path).stdout.strip(),
             head_before,
         )
         self.assertEqual(
             git(["status", "--porcelain=v1"], self.repo_path).stdout,
             status_before,
         )
-        self.assertFalse(
-            (self.repo_path / ".claude" / "worktrees" / prd_name).exists()
+        self.assertEqual(
+            git(["ls-files", "--stage"], self.repo_path).stdout,
+            index_before,
         )
+        self.assertEqual(
+            git(["branch", "--show-current"], self.repo_path).stdout.strip(),
+            branch_before,
+        )
+        self.assertEqual(
+            git(["rev-parse", "refs/heads/main"], self.repo_path).stdout.strip(),
+            main_before,
+        )
+        return result
 
-    def test_refuses_unstaged_tracked_change_before_mutation(self):
+    def test_allows_unstaged_tracked_change_without_root_mutation(self):
         def mutate():
             (self.repo_path / "README.md").write_text(
                 "operator edit\n", encoding="utf-8",
             )
 
-        self.run_refusal_case(mutate)
+        self.run_safe_case(mutate)
 
-    def test_refuses_staged_tracked_change_before_mutation(self):
+    def test_allows_staged_tracked_change_without_root_mutation(self):
         def mutate():
             staged_path = self.repo_path / "staged.txt"
             staged_path.write_text("staged\n", encoding="utf-8")
             git(["add", staged_path.name], self.repo_path)
 
-        self.run_refusal_case(mutate)
+        self.run_safe_case(mutate)
 
-    def test_refuses_mixed_tracked_and_untracked_changes_with_separate_counts(self):
+    def test_all_dirty_root_change_types_remain_eligible(self):
         def mutate():
             (self.repo_path / "README.md").write_text(
                 "operator edit\n", encoding="utf-8",
@@ -142,10 +186,7 @@ class SetupWorkspaceDirtyRootTest(unittest.TestCase):
                 "operator data\n", encoding="utf-8",
             )
 
-        self.run_refusal_case(mutate)
-        result = run_setup_workspace(self.repo_path, "dirty-root-prd")
-        self.assertIn("tracked changes=1", result.stderr)
-        self.assertIn("untracked files=1", result.stderr)
+        self.run_safe_case(mutate)
 
     def test_ignored_only_root_remains_eligible(self):
         init_repository(self.repo_path)
@@ -161,7 +202,7 @@ class SetupWorkspaceDirtyRootTest(unittest.TestCase):
         self.assertEqual(json.loads(result.stdout)["status"], "ready")
         self.assertTrue(ignored_path.exists())
 
-    def test_unusual_path_is_safely_escaped(self):
+    def test_unusual_path_does_not_block_safe_setup(self):
         init_repository(self.repo_path)
         prd_name = "unusual-path-prd"
         write_prd(self.repo_path, prd_name)
@@ -172,14 +213,10 @@ class SetupWorkspaceDirtyRootTest(unittest.TestCase):
 
         result = run_setup_workspace(self.repo_path, prd_name)
 
-        self.assertEqual(result.returncode, 1, result.stdout)
-        self.assertIn(
-            json.dumps(unusual_name, ensure_ascii=True),
-            result.stderr,
-        )
-        self.assertNotIn(unusual_name, result.stderr)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue((self.repo_path / unusual_name).exists())
 
-    def test_sample_is_bounded_deterministic_and_reports_omitted_paths(self):
+    def test_many_dirty_paths_do_not_block_safe_setup(self):
         init_repository(self.repo_path)
         prd_name = "bounded-sample-prd"
         write_prd(self.repo_path, prd_name)
@@ -188,19 +225,9 @@ class SetupWorkspaceDirtyRootTest(unittest.TestCase):
                 "operator data\n", encoding="utf-8",
             )
 
-        first = run_setup_workspace(self.repo_path, prd_name)
-        second = run_setup_workspace(self.repo_path, prd_name)
-
-        self.assertEqual(first.returncode, 1, first.stdout)
-        self.assertEqual(second.returncode, 1, second.stdout)
-        self.assertEqual(first.stderr, second.stderr)
-        sample_entries = [
-            line for line in first.stderr.splitlines() if line.startswith("    ?? ")
-        ]
-        self.assertEqual(
-            len(sample_entries), self.module.MAX_DIRTY_ROOT_SAMPLE_ENTRIES,
-        )
-        self.assertIn("5 additional path(s) omitted", first.stderr)
+        result = run_setup_workspace(self.repo_path, prd_name)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["status"], "ready")
 
     def test_status_command_failure_stops_before_mutation(self):
         init_repository(self.repo_path)
@@ -222,19 +249,18 @@ class SetupWorkspaceDirtyRootTest(unittest.TestCase):
         os.chdir(self.repo_path)
         try:
             with mock.patch.object(self.module, "run_git", side_effect=failing_status):
-                with mock.patch.object(self.module, "sync_main") as sync_main:
+                with mock.patch.object(
+                    self.module, "prune_worktrees",
+                ) as prune_worktrees:
                     with mock.patch.object(
-                        self.module, "prune_worktrees",
-                    ) as prune_worktrees:
+                        self.module, "create_or_reuse_worktree",
+                    ) as create_worktree:
                         with mock.patch.object(
-                            self.module, "create_or_reuse_worktree",
-                        ) as create_worktree:
-                            with mock.patch.object(
-                                sys, "argv", ["setup-workspace.py", prd_name],
-                            ):
-                                with redirect_stderr(stderr):
-                                    with self.assertRaises(SystemExit) as raised:
-                                        self.module.main()
+                            sys, "argv", ["setup-workspace.py", prd_name],
+                        ):
+                            with redirect_stderr(stderr):
+                                with self.assertRaises(SystemExit) as raised:
+                                    self.module.main()
         finally:
             os.chdir(original_cwd)
 
@@ -242,47 +268,113 @@ class SetupWorkspaceDirtyRootTest(unittest.TestCase):
         self.assertIn("Root cleanliness check failed", stderr.getvalue())
         self.assertIn("git status --porcelain=v1 failed", stderr.getvalue())
         self.assertIn("simulated status failure", stderr.getvalue())
-        sync_main.assert_not_called()
         prune_worktrees.assert_not_called()
         create_worktree.assert_not_called()
 
-    def test_dirty_root_stops_before_mutation_capable_stages(self):
-        init_repository(self.repo_path)
-        prd_name = "dirty-stage-order-prd"
-        write_prd(self.repo_path, prd_name)
-        (self.repo_path / "README.md").write_text(
-            "operator edit\n", encoding="utf-8",
+    def test_subprocess_setup_uses_fresh_origin_main_and_preserves_dirty_root(self):
+        operator_path, upstream_path = create_remote_operator(self.repo_path)
+        prd_name = "dirty-root-remote-prd"
+        write_prd(operator_path, prd_name)
+
+        (upstream_path / "remote-only.txt").write_text(
+            "fresh remote start\n", encoding="utf-8",
+        )
+        git(["add", "remote-only.txt"], upstream_path)
+        git(["commit", "-m", "advance remote main"], upstream_path)
+        git(["push", "origin", "main"], upstream_path)
+        remote_sha = git(["rev-parse", "HEAD"], upstream_path).stdout.strip()
+
+        (operator_path / "README.md").write_text(
+            "operator tracked edit\n", encoding="utf-8",
+        )
+        staged_path = operator_path / "operator-staged.txt"
+        staged_path.write_text("operator staged\n", encoding="utf-8")
+        git(["add", staged_path.name], operator_path)
+        untracked_path = operator_path / "operator-untracked.txt"
+        untracked_path.write_text("operator untracked\n", encoding="utf-8")
+
+        before = {
+            "head": git(["rev-parse", "HEAD"], operator_path).stdout.strip(),
+            "branch": git(
+                ["branch", "--show-current"], operator_path,
+            ).stdout.strip(),
+            "main": git(
+                ["rev-parse", "refs/heads/main"], operator_path,
+            ).stdout.strip(),
+            "status": git(
+                ["status", "--porcelain=v1"], operator_path,
+            ).stdout,
+            "index": git(["ls-files", "--stage"], operator_path).stdout,
+        }
+        trace_path = self.repo_path / "git-trace.json"
+        result = run_setup_workspace(
+            operator_path,
+            prd_name,
+            env={"GIT_TRACE2_EVENT": str(trace_path)},
         )
 
-        stderr = io.StringIO()
-        original_cwd = os.getcwd()
-        os.chdir(self.repo_path)
-        try:
-            with mock.patch.object(self.module, "sync_main") as sync_main, \
-                    mock.patch.object(
-                        self.module, "prune_worktrees",
-                    ) as prune_worktrees, \
-                    mock.patch.object(
-                        self.module, "create_or_reuse_worktree",
-                    ) as create_worktree, \
-                    mock.patch.object(
-                        self.module, "copy_prd_files",
-                    ) as copy_prd_files:
-                with mock.patch.object(
-                    sys, "argv", ["setup-workspace.py", prd_name],
-                ):
-                    with redirect_stderr(stderr):
-                        with self.assertRaises(SystemExit) as raised:
-                            self.module.main()
-        finally:
-            os.chdir(original_cwd)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "ready")
+        worktree_path = Path(payload["worktree"])
+        self.assertEqual(
+            git(["rev-parse", "HEAD"], worktree_path).stdout.strip(),
+            remote_sha,
+        )
+        self.assertEqual(
+            git(
+                ["rev-parse", f"refs/heads/{prd_name}"],
+                worktree_path,
+            ).stdout.strip(),
+            remote_sha,
+        )
+        self.assertEqual(
+            git(["rev-parse", "HEAD"], operator_path).stdout.strip(),
+            before["head"],
+        )
+        self.assertEqual(
+            git(["branch", "--show-current"], operator_path).stdout.strip(),
+            before["branch"],
+        )
+        self.assertEqual(
+            git(["rev-parse", "refs/heads/main"], operator_path).stdout.strip(),
+            before["main"],
+        )
+        self.assertEqual(
+            git(["status", "--porcelain=v1"], operator_path).stdout,
+            before["status"],
+        )
+        self.assertEqual(
+            git(["ls-files", "--stage"], operator_path).stdout,
+            before["index"],
+        )
+        self.assertEqual(
+            staged_path.read_text(encoding="utf-8"),
+            "operator staged\n",
+        )
+        self.assertEqual(
+            untracked_path.read_text(encoding="utf-8"),
+            "operator untracked\n",
+        )
 
-        self.assertEqual(raised.exception.code, 1)
-        self.assertIn("repository root is dirty", stderr.getvalue().lower())
-        sync_main.assert_not_called()
-        prune_worktrees.assert_not_called()
-        create_worktree.assert_not_called()
-        copy_prd_files.assert_not_called()
+        trace_events = [
+            json.loads(line)
+            for line in trace_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        child_commands = [
+            event.get("child_argv", [])
+            for event in trace_events
+            if event.get("event") == "child_start"
+        ]
+        self.assertTrue(child_commands)
+        self.assertFalse(
+            any(
+                command[:1] == ["stash"]
+                or command[:2] == ["git", "stash"]
+                for command in child_commands
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/factory/scripts/test_setup_workspace_dirty_root.py
+++ b/tests/factory/scripts/test_setup_workspace_dirty_root.py
@@ -95,6 +95,50 @@ def create_remote_operator(base_path):
     return operator_path, upstream_path
 
 
+def create_residual_refusal_repository(base_path):
+    """Create a root with stale origin/main but no safe local or remote main."""
+    remote_path = base_path / "residual-remote.git"
+    remote_path.mkdir()
+    git(["init", "--bare", "-b", "main"], remote_path)
+
+    upstream_path = base_path / "residual-upstream"
+    upstream_path.mkdir()
+    init_repository(upstream_path)
+    git(["remote", "add", "origin", str(remote_path)], upstream_path)
+    git(["push", "-u", "origin", "main"], upstream_path)
+
+    operator_path = base_path / "residual-operator"
+    git(["clone", str(remote_path), operator_path.name], base_path)
+    (operator_path / ".git" / "info" / "exclude").write_text(
+        "tasks/todo/\n.claude/\n",
+        encoding="utf-8",
+    )
+
+    git(["checkout", "--detach", "HEAD"], operator_path)
+    git(["update-ref", "-d", "refs/heads/main"], operator_path)
+    git(["update-ref", "-d", "refs/heads/main"], remote_path)
+    # A normal fetch retains the stale remote-tracking ref without --prune.
+    git(["fetch", "origin"], operator_path)
+    return operator_path
+
+
+def add_sibling_worktree(repo_path, name):
+    worktree_path = repo_path / ".claude" / "worktrees" / name
+    worktree_path.parent.mkdir(parents=True, exist_ok=True)
+    git(
+        [
+            "worktree",
+            "add",
+            "-b",
+            f"{name}-branch",
+            str(worktree_path),
+            "refs/remotes/origin/main",
+        ],
+        repo_path,
+    )
+    return worktree_path
+
+
 def run_setup_workspace(repo_path, prd_name, env=None):
     environment = os.environ.copy()
     if env:
@@ -375,6 +419,189 @@ class SetupWorkspaceDirtyRootTest(unittest.TestCase):
                 for command in child_commands
             ),
         )
+
+    def test_residual_refusal_attributes_matching_sibling_without_changing_core_text(self):
+        operator_path = create_residual_refusal_repository(self.repo_path)
+        prd_name = "residual-attribution-prd"
+        write_prd(operator_path, prd_name)
+        sibling_path = add_sibling_worktree(operator_path, "matching-sibling")
+
+        (operator_path / "README.md").write_text(
+            "same operator edit\n", encoding="utf-8",
+        )
+        (sibling_path / "README.md").write_text(
+            "same operator edit\n", encoding="utf-8",
+        )
+        unusual_name = "operator [path] café.txt"
+        (operator_path / unusual_name).write_text(
+            "same untracked edit\n", encoding="utf-8",
+        )
+        (sibling_path / unusual_name).write_text(
+            "same untracked edit\n", encoding="utf-8",
+        )
+
+        entries = self.module.repository_status_entries(operator_path)
+        with mock.patch.object(
+            self.module,
+            "dirty_root_sibling_attribution",
+            return_value=[],
+        ):
+            expected_core = self.module.dirty_root_diagnostic(
+                operator_path,
+                entries,
+            )
+
+        trace_path = self.repo_path / "residual-attribution-trace.json"
+        result = run_setup_workspace(
+            operator_path,
+            prd_name,
+            env={"GIT_TRACE2_EVENT": str(trace_path)},
+        )
+
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(
+            result.stderr.splitlines()[: len(expected_core.splitlines())],
+            [
+                "Root cleanliness check failed: "
+                + expected_core.splitlines()[0],
+                *expected_core.splitlines()[1:],
+            ],
+        )
+        self.assertIn(
+            'likely sibling worktree matches (same changes relative to origin/main):',
+            result.stderr,
+        )
+        self.assertIn(
+            'sibling worktree "matching-sibling" matches path(s): "README.md", '
+            '"operator [path] caf\\u00e9.txt"',
+            result.stderr,
+        )
+        self.assertIn("repository root is dirty", result.stderr)
+        self.assertIn("Inspect the repository root manually", result.stderr)
+
+        trace_events = [
+            json.loads(line)
+            for line in trace_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        child_commands = [
+            event.get("child_argv", [])
+            for event in trace_events
+            if event.get("event") == "child_start"
+        ]
+        self.assertFalse(
+            any(
+                command[:1] == ["stash"]
+                or command[:2] == ["git", "stash"]
+                for command in child_commands
+            ),
+        )
+
+    def test_residual_refusal_omits_attribution_for_nonmatching_sibling(self):
+        operator_path = create_residual_refusal_repository(self.repo_path)
+        prd_name = "residual-negative-prd"
+        write_prd(operator_path, prd_name)
+        sibling_path = add_sibling_worktree(operator_path, "different-sibling")
+
+        (operator_path / "README.md").write_text(
+            "operator edit\n", encoding="utf-8",
+        )
+        (sibling_path / "README.md").write_text(
+            "different edit\n", encoding="utf-8",
+        )
+
+        result = run_setup_workspace(operator_path, prd_name)
+
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("Root cleanliness check failed", result.stderr)
+        self.assertIn("repository root is dirty", result.stderr)
+        self.assertNotIn("likely sibling worktree matches", result.stderr)
+        self.assertNotIn("different-sibling", result.stderr)
+
+    def test_residual_attribution_caps_paths_and_sibling_candidates(self):
+        operator_path = create_residual_refusal_repository(self.repo_path)
+        worktrees_dir = operator_path / ".claude" / "worktrees"
+        worktrees_dir.mkdir(parents=True, exist_ok=True)
+        for index in range(
+            self.module.MAX_DIRTY_ROOT_ATTRIBUTION_WORKTREES + 5
+        ):
+            (worktrees_dir / f"candidate-{index:02d}").mkdir()
+
+        for index in range(self.module.MAX_DIRTY_ROOT_ATTRIBUTION_PATHS + 5):
+            (operator_path / f"operator-{index:02d}.txt").write_text(
+                f"operator-{index}\n", encoding="utf-8",
+            )
+        entries = self.module.repository_status_entries(operator_path)
+
+        recorded = []
+        original_run_git = self.module.run_git
+
+        def recording_run_git(*args, **kwargs):
+            recorded.append((args, kwargs.get("cwd")))
+            return original_run_git(*args, **kwargs)
+
+        self.module.run_git = recording_run_git
+        try:
+            attribution = self.module.dirty_root_sibling_attribution(
+                operator_path,
+                entries,
+            )
+        finally:
+            self.module.run_git = original_run_git
+
+        self.assertEqual(attribution, [])
+        baseline_commands = [
+            args for args, _cwd in recorded if args[:1] == ("show",)
+        ]
+        candidate_commands = [
+            args
+            for args, cwd in recorded
+            if args[:2] == ("rev-parse", "--show-toplevel")
+            and Path(cwd).parent == worktrees_dir
+        ]
+        self.assertLessEqual(
+            len(baseline_commands),
+            self.module.MAX_DIRTY_ROOT_ATTRIBUTION_PATHS,
+        )
+        self.assertLessEqual(
+            len(candidate_commands),
+            self.module.MAX_DIRTY_ROOT_ATTRIBUTION_WORKTREES,
+        )
+
+    def test_residual_refusal_survives_missing_unusual_and_stale_paths(self):
+        operator_path = create_residual_refusal_repository(self.repo_path)
+        prd_name = "residual-malformed-prd"
+        write_prd(operator_path, prd_name)
+        (operator_path / "README.md").unlink()
+        unusual_name = "operator [path] café.txt"
+        (operator_path / unusual_name).write_text(
+            "operator data\n", encoding="utf-8",
+        )
+
+        worktrees_dir = operator_path / ".claude" / "worktrees"
+        invalid_path = worktrees_dir / "invalid-directory"
+        invalid_path.mkdir(parents=True)
+        stale_path = worktrees_dir / "stale-worktree"
+        stale_path.mkdir()
+        (stale_path / ".git").write_text(
+            "gitdir: missing-worktree-metadata\n",
+            encoding="utf-8",
+        )
+
+        result = run_setup_workspace(operator_path, prd_name)
+
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("Root cleanliness check failed", result.stderr)
+        self.assertIn("repository root is dirty", result.stderr)
+        self.assertIn("README.md", result.stderr)
+        self.assertIn(
+            json.dumps(unusual_name, ensure_ascii=True),
+            result.stderr,
+        )
+        self.assertNotIn("likely sibling worktree matches", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/factory/scripts/test_setup_workspace_root_residue.py
+++ b/tests/factory/scripts/test_setup_workspace_root_residue.py
@@ -157,6 +157,7 @@ def tree_report(module, repo_path):
     for line in refs.splitlines():
         ref_name, object_id = line.split(maxsplit=1)
         private_refs[ref_name] = object_id
+    ancestor = git(["rev-parse", "HEAD^:"], repo_path, check=False)
 
     return {
         "head": git(["rev-parse", "HEAD"], repo_path).stdout.strip(),
@@ -165,7 +166,7 @@ def tree_report(module, repo_path):
         "index_tree": git(["write-tree"], repo_path).stdout.strip(),
         "worktree_tree": module.working_tree_tree(repo_path),
         "head_tree": git(["rev-parse", "HEAD:"], repo_path).stdout.strip(),
-        "ancestor_tree": git(["rev-parse", "HEAD^:"], repo_path).stdout.strip(),
+        "ancestor_tree": ancestor.stdout.strip() if ancestor.returncode == 0 else "",
         "private_refs": private_refs,
     }
 
@@ -220,7 +221,20 @@ def run_root_sync_process(
         raise ValueError(f"unknown root sync process role: {role}")
 
     try:
-        result_queue.put((role, "ok", module.sync_main(Path(repo_path))))
+        remote_sha = original_run_git(
+            "rev-parse",
+            "refs/remotes/origin/main",
+            cwd=repo_path,
+        ).stdout.strip()
+        result_queue.put(
+            (
+                role,
+                "ok",
+                module.sync_checked_out_main_with_stash(
+                    Path(repo_path), remote_sha,
+                ),
+            )
+        )
     except BaseException as error:  # report child failures in the parent test
         result_queue.put((role, "error", f"{type(error).__name__}: {error}"))
     finally:
@@ -279,14 +293,28 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
                         self.module.snapshot_ref_name(stale_snapshot): stale_snapshot,
                     }
 
+                root_head_before = git(["rev-parse", "HEAD"], local).stdout.strip()
+                root_main_before = git(
+                    ["rev-parse", "refs/heads/main"], local,
+                ).stdout.strip()
                 outcome = self.module.sync_main(local)
                 report = tree_report(self.module, local)
+                expected_head = (
+                    remote_sha
+                    if label in {"clean", "stale-private-ref"}
+                    else root_head_before
+                )
+                expected_main = (
+                    remote_sha
+                    if label in {"clean", "stale-private-ref"}
+                    else root_main_before
+                )
                 self.assertEqual(
-                    report["head"], remote_sha,
+                    report["head"], expected_head,
                     report_message(f"{label} outcome={outcome}", report),
                 )
                 self.assertEqual(
-                    report["main"], remote_sha,
+                    report["main"], expected_main,
                     report_message(f"{label} outcome={outcome}", report),
                 )
                 self.assertEqual(
@@ -419,11 +447,15 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_bytes(contents)
 
+        root_head_before = git(["rev-parse", "HEAD"], local).stdout.strip()
+        root_main_before = git(
+            ["rev-parse", "refs/heads/main"], local,
+        ).stdout.strip()
         outcome = self.module.sync_main(local)
         report = tree_report(self.module, local)
 
-        self.assertEqual(report["head"], remote_sha, report_message(outcome, report))
-        self.assertEqual(report["main"], remote_sha, report_message(outcome, report))
+        self.assertEqual(report["head"], root_head_before, report_message(outcome, report))
+        self.assertEqual(report["main"], root_main_before, report_message(outcome, report))
         self.assertEqual(
             git_bytes(["show", ":README.md"], local).stdout,
             staged_bytes,
@@ -663,7 +695,7 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
                 RuntimeError,
                 r"recovery snapshot preserved at refs/factory-snapshots/",
             ) as raised:
-                self.module.sync_main(local)
+                self.module.sync_checked_out_main_with_stash(local, remote_sha)
         finally:
             self.module.restore_stashed_changes = original_restore
 
@@ -680,28 +712,24 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
         self.assertIn("merged.txt", report["porcelain"])
         self.assertIn(self.module.snapshot_ref_name(snapshot_id), str(raised.exception))
 
-    def test_sync_guard_checks_residue_when_main_is_already_current(self):
-        """A previous silent residue is rejected even when no fast-forward is needed."""
+    def test_sync_skips_root_residue_when_main_is_already_current(self):
+        """A dirty checkout can stay untouched when no root sync is needed."""
         local, _upstream, remote_sha = create_remote_repository(
             self.root / "guard-current", remote_ahead=True,
         )
         git(["reset", "--hard", remote_sha], local)
         git(["read-tree", "--reset", "-u", "HEAD^"], local)
 
-        with self.assertRaisesRegex(
-            RuntimeError,
-            r"no root snapshot was captured for automatic recovery",
-        ):
-            self.module.sync_main(local)
+        outcome = self.module.sync_main(local)
 
         report = tree_report(self.module, local)
-        self.assertEqual(report["head"], remote_sha, report_message("current", report))
-        self.assertEqual(report["main"], remote_sha, report_message("current", report))
+        self.assertEqual(report["head"], remote_sha, report_message(outcome, report))
+        self.assertEqual(report["main"], remote_sha, report_message(outcome, report))
         self.assertIn("merged.txt", report["porcelain"])
         self.assertEqual(report["private_refs"], {})
 
-    def test_setup_stops_before_lane_creation_on_ancestor_residue(self):
-        """The integrated guard fails before the requested lane is prepared."""
+    def test_setup_creates_lane_without_repairing_ancestor_residue(self):
+        """Lane setup leaves unrelated root residue untouched."""
         local, _upstream, remote_sha = create_remote_repository(
             self.root / "guard-setup", remote_ahead=True,
         )
@@ -724,13 +752,12 @@ class SetupWorkspaceRootResidueTest(unittest.TestCase):
             check=False,
         )
 
-        self.assertEqual(result.returncode, 1, result.stdout)
-        self.assertIn("Root cleanliness check failed", result.stderr)
-        self.assertIn("repository root is dirty", result.stderr.lower())
-        self.assertIn("merged.txt", result.stderr)
-        self.assertFalse(
-            (local / ".claude" / "worktrees" / prd_name).exists(),
-            result.stderr,
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "ready")
+        self.assertEqual(
+            git(["rev-parse", "HEAD"], Path(payload["worktree"])).stdout.strip(),
+            remote_sha,
         )
         report = tree_report(self.module, local)
         self.assertEqual(report["head"], remote_sha, report_message("setup", report))

--- a/tests/factory/scripts/test_setup_workspace_sync.py
+++ b/tests/factory/scripts/test_setup_workspace_sync.py
@@ -214,7 +214,7 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             )
         )
 
-    def test_sync_main_stashes_and_restores_dirty_checked_out_main(self):
+    def test_sync_main_skips_dirty_checked_out_main_without_stash(self):
         local_repo = self.repo_path / "local"
         setup_repo_with_origin_main_ahead(local_repo, self.repo_path)
         git(["checkout", "main"], local_repo)
@@ -242,9 +242,9 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
 
         self.assertEqual(
             git(["rev-parse", "refs/heads/main"], local_repo).stdout.strip(),
-            origin_main_sha,
+            local_main_sha_before,
         )
-        self.assertEqual(git(["rev-parse", "HEAD"], local_repo).stdout.strip(), origin_main_sha)
+        self.assertEqual(git(["rev-parse", "HEAD"], local_repo).stdout.strip(), head_before)
         self.assertEqual(
             git(["branch", "--show-current"], local_repo).stdout.strip(),
             branch_before,
@@ -261,13 +261,12 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             )
         )
         self.assertFalse(any(args[:2] == ("stash", "push") for args in recorded))
-        self.assertTrue(any(args[:2] == ("stash", "apply") for args in recorded))
-        self.assertFalse(any(args[:2] == ("stash", "drop") for args in recorded))
-        self.assertTrue(any(args and args[0] == "commit-tree" for args in recorded))
+        self.assertFalse(any(args and args[0] == "stash" for args in recorded))
+        self.assertFalse(any(args and args[0] == "commit-tree" for args in recorded))
         self.assertFalse(
             any("stash@{" in str(argument) for args in recorded for argument in args)
         )
-        self.assertTrue(any(args[:2] == ("pull", "--ff-only") for args in recorded))
+        self.assertFalse(any(args and args[0] == "pull" for args in recorded))
         self.assertEqual(head_before, local_main_sha_before)
 
     def test_restores_owned_snapshot_when_another_stash_is_created_before_restore(self):
@@ -388,6 +387,10 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             encoding="utf-8",
         )
 
+        remote_sha = git(
+            ["rev-parse", "refs/remotes/origin/main"],
+            local_repo,
+        ).stdout.strip()
         original_restore = self.module.restore_stashed_changes
         captured_snapshot = []
         interfering_stash = []
@@ -434,7 +437,9 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
         try:
             with contextlib.redirect_stderr(stderr):
                 with self.assertRaises(RuntimeError) as raised:
-                    self.module.sync_main(local_repo)
+                    self.module.sync_checked_out_main_with_stash(
+                        local_repo, remote_sha,
+                    )
         finally:
             self.module.restore_stashed_changes = original_restore
 
@@ -563,7 +568,7 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             0,
         )
 
-    def test_sync_main_fast_forwards_main_without_pull_on_dirty_tree(self):
+    def test_sync_main_skips_dirty_tree_without_fast_forwarding_main(self):
         local_repo = self.repo_path / "local"
         setup_repo_with_origin_main_ahead(local_repo, self.repo_path)
 
@@ -587,7 +592,7 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             ["rev-parse", "refs/heads/main"],
             local_repo,
         ).stdout.strip()
-        self.assertEqual(local_main_sha_after, origin_main_sha)
+        self.assertEqual(local_main_sha_after, local_main_sha_before)
         self.assertEqual(
             git(["branch", "--show-current"], local_repo).stdout.strip(),
             "feature-branch",
@@ -601,7 +606,7 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
 
         self.assertFalse(any(args and args[0] == "pull" for args in recorded))
         self.assertTrue(any(args[:2] == ("fetch", "origin") for args in recorded))
-        self.assertTrue(
+        self.assertFalse(
             any(
                 args[:3] == ("update-ref", "refs/heads/main", origin_main_sha)
                 for args in recorded
@@ -609,9 +614,12 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
         )
         self.assertFalse(any(args and args[0] == "checkout" for args in recorded))
 
-    def test_setup_workspace_refuses_dirty_tree_before_sync(self):
+    def test_setup_workspace_uses_origin_start_point_for_dirty_tree(self):
         local_repo = self.repo_path / "local"
         setup_repo_with_origin_main_ahead(local_repo, self.repo_path)
+        origin_main_sha = git(
+            ["rev-parse", "refs/remotes/origin/main"], local_repo,
+        ).stdout.strip()
 
         prd_name = "dirty-tree-prd"
         tasks_dir = local_repo / "tasks" / "todo"
@@ -630,18 +638,20 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             check=False,
         )
 
-        self.assertEqual(result.returncode, 1, result.stdout)
-        self.assertEqual(result.stdout, "")
-        self.assertIn("repository root is dirty", result.stderr.lower())
-        self.assertNotIn("Root sync:", result.stderr)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "ready")
+        self.assertEqual(
+            git(["rev-parse", "HEAD"], Path(payload["worktree"])).stdout.strip(),
+            origin_main_sha,
+        )
+        self.assertIn("Root sync:", result.stderr)
         self.assertEqual(
             git(["branch", "--show-current"], local_repo).stdout.strip(),
             "feature-branch",
         )
         self.assertIn("?? dirty.txt", git(["status", "--porcelain"], local_repo).stdout)
-        self.assertFalse(
-            (local_repo / ".claude" / "worktrees" / prd_name).exists()
-        )
+        self.assertTrue((local_repo / ".claude" / "worktrees" / prd_name).exists())
 
     def test_setup_workspace_continues_after_sync_skip(self):
         init_local_repo(self.repo_path)
@@ -695,20 +705,19 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             check=False,
         )
 
-        self.assertEqual(result.returncode, 1, result.stdout)
-        self.assertEqual(result.stdout, "")
-        self.assertIn("repository root is dirty", result.stderr.lower())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "ready")
+        self.assertTrue(Path(payload["worktree"]).exists())
         self.assertIn("A  staged.txt", git(["status", "--porcelain"], local_repo).stdout)
         self.assertIn("?? dirty.txt", git(["status", "--porcelain"], local_repo).stdout)
         self.assertEqual(
             staged_file.read_text(encoding="utf-8"),
             "staged change\n",
         )
-        self.assertFalse(
-            (local_repo / ".claude" / "worktrees" / prd_name).exists()
-        )
+        self.assertTrue((local_repo / ".claude" / "worktrees" / prd_name).exists())
 
-    def test_setup_workspace_reports_stashed_sync_on_dirty_main_checkout(self):
+    def test_setup_workspace_skips_root_sync_on_dirty_main_checkout(self):
         local_repo = self.repo_path / "local"
         setup_repo_with_origin_main_ahead(local_repo, self.repo_path)
         git(["checkout", "main"], local_repo)
@@ -733,13 +742,17 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             check=False,
         )
 
-        self.assertEqual(result.returncode, 1, result.stdout)
-        self.assertEqual(result.stdout, "")
-        self.assertIn("repository root is dirty", result.stderr.lower())
-        self.assertNotIn("Root sync:", result.stderr)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "ready")
+        self.assertIn("Root sync:", result.stderr)
         self.assertIn("?? dirty-main.txt", git(["status", "--porcelain"], local_repo).stdout)
         self.assertNotEqual(
             git(["rev-parse", "refs/heads/main"], local_repo).stdout.strip(),
+            git(["rev-parse", "refs/remotes/origin/main"], local_repo).stdout.strip(),
+        )
+        self.assertEqual(
+            git(["rev-parse", "HEAD"], Path(payload["worktree"])).stdout.strip(),
             git(["rev-parse", "refs/remotes/origin/main"], local_repo).stdout.strip(),
         )
 

--- a/tests/factory/scripts/test_setup_workspace_worktree.py
+++ b/tests/factory/scripts/test_setup_workspace_worktree.py
@@ -349,9 +349,8 @@ class SetupWorkspaceWorktreeTest(unittest.TestCase):
         git(["add", "staged.txt"], local_repo)
 
         second = run_setup_workspace(local_repo, prd_name)
-        self.assertEqual(second.returncode, 1, second.stdout)
-        self.assertEqual(second.stdout, "")
-        self.assertIn("repository root is dirty", second.stderr.lower())
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertTrue(json.loads(second.stdout)["reused"])
         self.assertTrue(marker.exists())
         self.assertIn("A  staged.txt", git(["status", "--porcelain"], local_repo).stdout)
 


### PR DESCRIPTION
{
  "project": "Plan Survives a Dirty Operator Root",
  "branchName": "plan-survives-a-dirty-operator-root",
  "description": "Make setup-workspace resilient to unrelated changes in the operator root by creating new lane worktrees from a safe freshly fetched start point without touching the root checkout, retaining refusal only when no safe route exists, and adding bounded sibling-worktree attribution to unavoidable refusals.",
  "context": {
    "customerAsk": "Stop a dirty operator repository root from killing every lane at plan, preserve the existing refusal diagnostic for the residual unsafe case, identify likely sibling worktrees when refusal occurs, and do so without git stash or changes to adjacent workspace behavior.",
    "problem": "setup-workspace currently refuses before fetch or worktree creation whenever any root status entry is dirty. Most setup paths need only ref updates or can create a new branch from freshly fetched origin/main, so the blanket guard rejects safe work and caused two incidents on 2026-08-23 that killed more than 15 lanes before they had worktrees or restorable state. When refusal occurs, operators also lack bounded evidence identifying a sibling worktree with the same change.",
    "solution": "Fetch and resolve the canonical worktree start point before treating root dirt as relevant; create new lane worktrees from the immutable origin/main commit while preserving all root state; refuse only when no ref-only or worktree-only route exists and root mutation would be required; and append deterministic attribution limited to five dirty paths and twenty sibling worktrees while preserving the existing diagnostic text. Verify behavior in disposable repositories and prove from recorded Git commands that no git stash is invoked.",
    "incidentAnalysis": "This change would have prevented both documented 2026-08-23 incidents (2 of 2): each blocked new-lane creation solely because unrelated operator-root changes triggered the old blanket refusal, even though a freshly fetched origin/main start point could create the lane without touching the root checkout."
  },
  "acceptanceCriteria": [
    "In a disposable repository whose operator root contains tracked, staged, or untracked changes, a new lane setup succeeds whenever a safe fetched start point exists, creates the requested worktree, and points the lane branch at that expected start point without changing the root's dirty content, index, checked-out commit, branch, or local-main ref.",
    "Dirty-root refusal occurs only when setup has no safe ref-only or worktree-only route and would otherwise have to mutate the dirty checked-out root; the pre-existing dirty_root_diagnostic message text remains present verbatim in that residual failure.",
    "A residual refusal examines no more than five sampled dirty paths across no more than twenty sibling directories under .claude/worktrees, names sibling worktrees whose version of a sampled dirty path matches the root change relative to origin/main, and emits no attribution line when there is no match.",
    "Recorded Git-command evidence across safe success and residual failure contains no git stash invocation; existing private recovery-ref helpers are not widened, and root dirt remains recoverable without shared-stash-stack mutation.",
    "Existing worktree reuse/fast-forward behavior, branch naming, PRD copying, clean-root setup, and stdout JSON/stderr failure contracts remain unchanged; no unrelated cleanup and no edit to docs/internal/baselines/deadcode-baseline.txt is included.",
    "Final quality gates pass: Typecheck passes; focused setup-workspace tests and relevant regression tests pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Required PR checks are Backend Lint and Verification Policy; report-only coverage floors and the main-failing localai-backend-artifacts check are not merge requirements.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "plan-survives-a-dirty-operator-root-001",
      "title": "Create a new lane without disturbing a dirty root",
      "description": "As a factory operator, I want a new lane workspace to be created from the current remote start point even when my root checkout has unrelated changes, so one dirty file cannot stop every lane at plan.",
      "acceptanceCriteria": [
        "A subprocess-level test creates a disposable repository with a remote, advances origin/main, dirties the checked-out root, runs the real setup entry point, and observes exit 0 with the normal ready JSON result.",
        "The created worktree exists, uses the requested lane branch, and its HEAD equals the freshly fetched origin/main commit rather than a stale local-main commit.",
        "The test proves the root's tracked content, untracked content, staged state, checked-out branch, HEAD, and local-main ref are unchanged by setup.",
        "Recorded Git commands for the dirty-root success path contain no command whose Git subcommand is stash.",
        "Existing clean-root setup and new-branch start-point behavior remain compatible.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented and verified dirty-root safe setup from fetched origin/main; focused setup-workspace tests (58 total) and make typecheck pass."
    },
    {
      "id": "plan-survives-a-dirty-operator-root-002",
      "title": "Keep residual refusal actionable with bounded attribution",
      "description": "As a factory operator, I want an unavoidable dirty-root refusal to preserve its trusted recovery guidance and identify a likely sibling-worktree source, so I can resolve the blockage without hand-diffing more than 100 worktrees.",
      "acceptanceCriteria": [
        "A focused test forces the residual condition in which no safe non-root-mutating setup route exists, observes refusal, and confirms all existing dirty_root_diagnostic lines and wording remain unchanged.",
        "When a sampled dirty path has the same change relative to origin/main in a sibling under .claude/worktrees, the refusal output appends an attribution line naming the correct sibling worktree.",
        "When no sibling worktree contains a matching change, no attribution line or misleading candidate name is emitted.",
        "Attribution inspects at most five deterministic dirty-path samples and at most twenty deterministic sibling worktree candidates; tests with inputs beyond both caps prove output and Git work remain bounded.",
        "Missing paths, untracked files, invalid or stale worktree directories, unusual path characters, and per-candidate Git failures do not replace or suppress the core refusal diagnostic.",
        "Recorded Git commands for the residual refusal and attribution paths contain no command whose Git subcommand is stash.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented residual dirty-root attribution with deterministic five-path/twenty-sibling bounds, exact worktree validation, best-effort handling for missing/untracked/unusual/stale paths, and no-stash trace coverage; focused setup-workspace suites (62 tests) and make typecheck pass."
    },
    {
      "id": "plan-survives-a-dirty-operator-root-003",
      "title": "Prove setup compatibility and incident prevention",
      "description": "As a reviewer, I want focused regression evidence and an explicit incident analysis, so the factory-wide setup change can merge without altering adjacent workspace behavior.",
      "acceptanceCriteria": [
        "Focused tests cover dirty-root success from a fetched start point, residual refusal text, positive and negative sibling attribution, bounded scanning, and absence of git stash in recorded commands.",
        "Existing tests for clean-root setup, no-origin fallback, new branches, existing branch and worktree reuse, reused-worktree fast-forward behavior, result JSON, failure stderr, and PRD copying continue to pass without changing their product contracts.",
        "The PR body states that the change would have prevented both documented 2026-08-23 incidents (2 of 2) because each blocked new-lane creation solely due to unrelated root dirt while a fetched start point could create the lane without touching the root checkout.",
        "The final implementation head is rebased onto current origin/main before push; inherited dead-code baseline failures are not fixed in this lane, and docs/internal/baselines/deadcode-baseline.txt remains untouched.",
        "Verification evidence distinguishes failures owned by this diff from inherited or non-required failures and records CI-run evidence only in a PR comment.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Verified focused setup-workspace coverage (62 passed), make typecheck, backend-size, pkg-maint, pkg-file-count, pkg-structure, and vet on the rebased head. Canonical lint had one inherited packaged-factory-consumption violation in an untouched file; all other targets passed. Added the explicit 2-of-2 incident analysis to this PRD, rebased onto current origin/main, pushed f057b2e78, opened PR #2228, and confirmed required CI started."
    }
  ]
}
