### PR TITLE
feat(javascript): generate runtime contract and drift checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ LINT_JOBS ?= $(GO_LANE_BUDGET)
 # during -n so recursive builds can receive the dry-run flag.
 LINT_MAKE ?= $(MAKE)
 LINT_REPORT_FILE ?=
-LINT_TARGETS ?= ui-lint ui-deadcode vet backend-size pkg-maint pkg-file-count pkg-boundary pkg-structure service-cycle-check package-target-manifest-check packaged-factory-source-check packaged-factory-consumption-check packaged-factory-catalog-check provider-catalog-check model-provider-package-check durable-runtime-construction-check logging-boundary-check compatibility-alias-check retired-surface-check ownership-inventory-check deadcode fmt-check
+LINT_TARGETS ?= ui-lint ui-deadcode vet backend-size pkg-maint pkg-file-count pkg-boundary pkg-structure service-cycle-check package-target-manifest-check packaged-factory-source-check packaged-factory-consumption-check packaged-factory-catalog-check provider-catalog-check model-provider-package-check durable-runtime-construction-check logging-boundary-check compatibility-alias-check retired-surface-check ownership-inventory-check deadcode fmt-check contracts-check
 
 define run_lint_checker
 $(if $(LINT_CHECKER_DRIVER),"$(LINT_CHECKER_DRIVER)",$(GO) run $(LINT_CHECKER_DRIVER_PACKAGE)) -cache-dir "$(LINT_CHECKER_CACHE_DIR)" -go "$(GO)" $(if $(filter 1 true yes,$(LINT_CHECKER_FALLBACK)),-fallback,) -package "$(1)" -- $(2)

--- a/cmd/contractscheck/main.go
+++ b/cmd/contractscheck/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/portpowered/infinite-you/internal/contractstaging"
+	"github.com/portpowered/infinite-you/internal/javascriptcontract"
 )
 
 const successMessage = "[agent-factory:contracts-check] approved contract artifacts are current"
@@ -23,7 +24,12 @@ func run(root string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "[agent-factory:contracts-check] check failed: %v\n", err)
 		return 1
 	}
-	if drift.Empty() {
+	javascriptDiagnostics, err := javascriptcontract.CheckGeneratedOutputs(root)
+	if err != nil {
+		fmt.Fprintf(stderr, "[agent-factory:contracts-check] check failed: %v\n", err)
+		return 1
+	}
+	if drift.Empty() && len(javascriptDiagnostics) == 0 {
 		fmt.Fprintln(stdout, successMessage)
 		return 0
 	}
@@ -31,7 +37,13 @@ func run(root string, stdout, stderr io.Writer) int {
 	writePaths(stderr, "stale", drift.Stale)
 	writePaths(stderr, "missing", drift.Missing)
 	writePaths(stderr, "unexpected", drift.Unexpected)
-	fmt.Fprintln(stderr, "[agent-factory:contracts-check] contract staging differs from canonical sources; run `make contracts-generate` and remove every unexpected file from staging")
+	writeJavaScriptDiagnostics(stderr, javascriptDiagnostics)
+	if !drift.Empty() {
+		fmt.Fprintln(stderr, "[agent-factory:contracts-check] contract staging differs from canonical sources; run `make contracts-generate` and remove every unexpected file from staging")
+	}
+	if len(javascriptDiagnostics) > 0 {
+		fmt.Fprintln(stderr, "[agent-factory:contracts-check] generated JavaScript runtime contract differs from runtime truth; run `make contracts-generate`")
+	}
 	return 1
 }
 
@@ -42,5 +54,17 @@ func writePaths(writer io.Writer, category string, paths []string) {
 	fmt.Fprintf(writer, "[agent-factory:contracts-check] %s:\n", category)
 	for _, path := range paths {
 		fmt.Fprintf(writer, "  %s\n", path)
+	}
+}
+
+func writeJavaScriptDiagnostics(writer io.Writer, diagnostics []javascriptcontract.Diagnostic) {
+	for _, diagnostic := range diagnostics {
+		fmt.Fprintf(
+			writer,
+			"[agent-factory:contracts-check] %s (%s): %s\n",
+			diagnostic.Path,
+			diagnostic.Code,
+			diagnostic.Message,
+		)
 	}
 }

--- a/cmd/contractscheck/main_test.go
+++ b/cmd/contractscheck/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -12,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/portpowered/infinite-you/internal/contractstaging"
+	"github.com/portpowered/infinite-you/internal/javascriptcontract"
 )
 
 func TestRunPassesCleanStagingWithoutWriting(t *testing.T) {
@@ -118,6 +120,35 @@ func TestRunReportsPackagedFactorySchemaDriftWithRegenerationRemedy(t *testing.T
 	}
 }
 
+func TestRunReportsMissingJavaScriptFieldWithFieldSpecificRemedyWithoutWriting(t *testing.T) {
+	root := commandFixture(t)
+	path := filepath.Join(root, filepath.FromSlash(javascriptcontract.RuntimeCatalogPath))
+	removeRuntimeCatalogField(t, path, "resourceId")
+	before := commandTree(t, root)
+
+	for runIndex := 0; runIndex < 2; runIndex++ {
+		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+		if status := run(root, stdout, stderr); status != 1 {
+			t.Fatalf("run %d status = %d, want 1", runIndex, status)
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("run %d stdout = %q, want empty", runIndex, stdout.String())
+		}
+		output := stderr.String()
+		for _, want := range []string{
+			javascriptcontract.RuntimeCatalogPath,
+			`field "resourceId"`,
+			"javascript.agent_run.field.missing",
+			"make contracts-generate",
+		} {
+			if !strings.Contains(output, want) {
+				t.Fatalf("run %d stderr = %q, want %q", runIndex, output, want)
+			}
+		}
+	}
+	assertCommandTreeUnchanged(t, "run() changed repository bytes on JavaScript field drift", before, commandTree(t, root))
+}
+
 func mutatePackagedSchema(t *testing.T, path, category string) {
 	t.Helper()
 	if category == "missing" {
@@ -151,12 +182,41 @@ func commandFixture(t *testing.T) string {
 		}
 		writeCommandFixture(t, root, artifact.Source, contents)
 	}
+	writeCommandFixture(t, root, javascriptcontract.JavaScriptWorkflowReferencePath, "# JavaScript Workflows\n\n"+javascriptcontract.AgentRunFieldsStartMarker+"\nold generated fields\n"+javascriptcontract.AgentRunFieldsEndMarker+"\n")
 	writeCommandFixture(t, root, "unrelated.txt", "unrelated")
 	initCommandGitRepo(t, root)
 	if err := contractstaging.Generate(root); err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
+	if err := javascriptcontract.GenerateJavaScriptWorkflowReference(root); err != nil {
+		t.Fatalf("GenerateJavaScriptWorkflowReference() error = %v", err)
+	}
 	return root
+}
+
+func removeRuntimeCatalogField(t *testing.T, path, field string) {
+	t.Helper()
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read runtime catalog: %v", err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(payload, &document); err != nil {
+		t.Fatalf("decode runtime catalog: %v", err)
+	}
+	sharedSchemas := document["sharedSchemas"].(map[string]any)
+	agentRun := sharedSchemas["javascript.schema.agent_run_spec"].(map[string]any)
+	schema := agentRun["schema"].(map[string]any)
+	properties := schema["properties"].(map[string]any)
+	delete(properties, field)
+	updated, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		t.Fatalf("encode runtime catalog: %v", err)
+	}
+	updated = append(updated, '\n')
+	if err := os.WriteFile(path, updated, 0o644); err != nil {
+		t.Fatalf("write runtime catalog: %v", err)
+	}
 }
 
 func commandTree(t *testing.T, root string) commandTreeSnapshot {

--- a/cmd/contractscheck/main_test.go
+++ b/cmd/contractscheck/main_test.go
@@ -143,6 +143,9 @@ func commandFixture(t *testing.T) string {
 	writeCommandFixture(t, root, "contracts/manifest.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/manifest.schema.json","properties":{"packageId":{"$ref":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"}}}`)
 	for _, artifact := range contractstaging.RawArtifacts() {
 		contents := "canonical:" + artifact.Source
+		if artifact.Source == "contracts/javascript/runtime-api.json" {
+			contents = `{"sharedSchemas":{"javascript.schema.agent_run_spec":{"schema":{"type":"object","additionalProperties":false,"properties":{"prompt":{"type":"string"}},"required":["prompt"]}}}}`
+		}
 		if artifact.Source == "api/openapi.yaml" {
 			contents = "components:\n  schemas:\n    Factory:\n      type: object\n      properties:\n        child:\n          $ref: '#/components/schemas/Child'\n    Child:\n      type: string\n    FactoryEvent:\n      type: object\n      required: [schemaVersion, id, type, context, payload]\n      properties:\n        schemaVersion:\n          type: string\n        id:\n          type: string\n        type:\n          type: string\n          enum: [TEST]\n        context:\n          type: object\n        payload:\n          $ref: '#/components/schemas/Child'\n      discriminator:\n        propertyName: type\n        mapping:\n          TEST: '#/components/schemas/Child'\n    FactoryRecording:\n      type: object\n      required: [schemaVersion, sessionId, events]\n      properties:\n        schemaVersion:\n          type: string\n        sessionId:\n          type: string\n        events:\n          type: array\n          items:\n            $ref: '#/components/schemas/FactoryEvent'\n"
 		}

--- a/cmd/contractsgenerate/main.go
+++ b/cmd/contractsgenerate/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/portpowered/infinite-you/internal/contractstaging"
+	"github.com/portpowered/infinite-you/internal/javascriptcontract"
 )
 
 const successMessage = "[agent-factory:contracts-generate] approved contract artifacts generated"
@@ -18,6 +19,10 @@ func main() {
 }
 
 func run(root string, stdout, stderr io.Writer) int {
+	if err := javascriptcontract.GenerateJavaScriptWorkflowReference(root); err != nil {
+		fmt.Fprintf(stderr, "[agent-factory:contracts-generate] generation failed: %v\n", err)
+		return 1
+	}
 	if err := contractstaging.Generate(root); err != nil {
 		fmt.Fprintf(stderr, "[agent-factory:contracts-generate] generation failed: %v\n", err)
 		return 1

--- a/cmd/contractsgenerate/main_test.go
+++ b/cmd/contractsgenerate/main_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/portpowered/infinite-you/internal/contractstaging"
+	"github.com/portpowered/infinite-you/internal/javascriptcontract"
 )
 
 func TestRunGeneratesApprovedArtifactsReproduciblyWithoutChangingOtherFiles(t *testing.T) {
@@ -115,11 +116,15 @@ func writeRawArtifactSources(t *testing.T, root string) {
 	t.Helper()
 	for _, artifact := range contractstaging.RawArtifacts() {
 		contents := "canonical:" + artifact.Source
-		if artifact.Source == "api/openapi.yaml" {
+		switch artifact.Source {
+		case "contracts/javascript/runtime-api.json":
+			contents = `{"sharedSchemas":{"javascript.schema.agent_run_spec":{"schema":{"type":"object","additionalProperties":false,"properties":{"prompt":{"type":"string"}},"required":["prompt"]}}}}`
+		case "api/openapi.yaml":
 			contents = "components:\n  schemas:\n    Factory:\n      type: object\n      properties:\n        child:\n          $ref: '#/components/schemas/Child'\n    Child:\n      type: string\n    FactoryEvent:\n      type: object\n      required: [schemaVersion, id, type, context, payload]\n      properties:\n        schemaVersion:\n          type: string\n        id:\n          type: string\n        type:\n          type: string\n        context:\n          type: object\n        payload:\n          $ref: '#/components/schemas/Child'\n      discriminator:\n        propertyName: type\n        mapping:\n          TEST: '#/components/schemas/Child'\n    FactoryRecording:\n      type: object\n      required: [schemaVersion, sessionId, events]\n      properties:\n        schemaVersion:\n          type: string\n        sessionId:\n          type: string\n        events:\n          type: array\n          items:\n            $ref: '#/components/schemas/FactoryEvent'\n"
 		}
 		writeFixture(t, root, artifact.Source, contents)
 	}
+	writeFixture(t, root, javascriptcontract.JavaScriptWorkflowReferencePath, "# JavaScript Workflows\n\n<!-- BEGIN GENERATED: javascript.agent.run.fields -->\nold generated fields\n<!-- END GENERATED: javascript.agent.run.fields -->\n")
 }
 
 func fileDigests(t *testing.T, root string, paths []string) map[string][sha256.Size]byte {

--- a/contracts/javascript/runtime-api.json
+++ b/contracts/javascript/runtime-api.json
@@ -221,6 +221,9 @@
           "preset": {
             "type": "string"
           },
+          "executorProvider": {
+            "type": "string"
+          },
           "modelProvider": {
             "type": "string"
           },
@@ -228,6 +231,9 @@
             "type": "string"
           },
           "reasoningEffort": {
+            "type": "string"
+          },
+          "resourceId": {
             "type": "string"
           },
           "schema": {

--- a/docs/reference/javascript-workflows.md
+++ b/docs/reference/javascript-workflows.md
@@ -127,6 +127,23 @@ to the facts that remain inspectable.
 | `workflow.artifact` | `workflow.artifact({kind: string, label: string, content?: JSON, visibility?: string}): string` | Creates a session-owned `FactoryArtifact` and returns its stable `you-artifact://` reference. |
 | `workflow.final` | `workflow.final(value: JSON): void` | Selects the final result and takes precedence over a top-level return. |
 
+<!-- BEGIN GENERATED: javascript.agent.run.fields -->
+### `agent.run` request fields
+
+| Field | JSON type | Requiredness |
+|-------|-----------|--------------|
+| `prompt` | `string` | required |
+| `label` | `string` | optional |
+| `preset` | `string` | optional |
+| `executorProvider` | `string` | optional |
+| `modelProvider` | `string` | optional |
+| `model` | `string` | optional |
+| `reasoningEffort` | `string` | optional |
+| `resourceId` | `string` | optional |
+| `schema` | `object` | optional |
+| `permissions` | `string` | optional |
+<!-- END GENERATED: javascript.agent.run.fields -->
+
 Promises returned by `agent.run`, `parallel`, and `pipeline` must be awaited or
 otherwise resolved before the workflow completes.
 

--- a/docs/reference/javascript-workflows.md
+++ b/docs/reference/javascript-workflows.md
@@ -130,18 +130,18 @@ to the facts that remain inspectable.
 <!-- BEGIN GENERATED: javascript.agent.run.fields -->
 ### `agent.run` request fields
 
-| Field | JSON type | Requiredness |
-|-------|-----------|--------------|
-| `prompt` | `string` | required |
-| `label` | `string` | optional |
-| `preset` | `string` | optional |
-| `executorProvider` | `string` | optional |
-| `modelProvider` | `string` | optional |
-| `model` | `string` | optional |
-| `reasoningEffort` | `string` | optional |
-| `resourceId` | `string` | optional |
-| `schema` | `object` | optional |
-| `permissions` | `string` | optional |
+| Field | JSON type | Requiredness | Allowed values |
+|-------|-----------|--------------|----------------|
+| `prompt` | `string` | required | — |
+| `label` | `string` | optional | — |
+| `preset` | `string` | optional | — |
+| `executorProvider` | `string` | optional | — |
+| `modelProvider` | `string` | optional | — |
+| `model` | `string` | optional | — |
+| `reasoningEffort` | `string` | optional | — |
+| `resourceId` | `string` | optional | — |
+| `schema` | `object` | optional | — |
+| `permissions` | `string` | optional | DEFAULT, SKIP_PERMISSIONS |
 <!-- END GENERATED: javascript.agent.run.fields -->
 
 Promises returned by `agent.run`, `parallel`, and `pipeline` must be awaited or

--- a/internal/contractstaging/artifacts_orchestration_test.go
+++ b/internal/contractstaging/artifacts_orchestration_test.go
@@ -59,6 +59,9 @@ func TestArtifactsWithDependenciesOrchestratesPipelineInExpectedOrder(t *testing
 			}
 			return []byte("manifest"), nil
 		},
+		ProjectJavaScriptCatalog: func(payload []byte) ([]byte, error) {
+			return payload, nil
+		},
 	}
 
 	artifacts, err := ArtifactsWithDependencies(inputRoot, deps)
@@ -111,6 +114,9 @@ func TestArtifactsWithDependencies_PropagatesRawArtifactReadFailure(t *testing.T
 			}
 			return []byte("ok"), nil
 		},
+		ProjectJavaScriptCatalog: func(payload []byte) ([]byte, error) {
+			return payload, nil
+		},
 	})
 	if err == nil || !strings.Contains(err.Error(), "read canonical raw artifact") {
 		t.Fatalf("expected read failure, got %v", err)
@@ -124,7 +130,10 @@ func TestArtifactsWithDependencies_PropagatesFactorySchemaFailure(t *testing.T) 
 			return []contractjoiner.Document{}, nil
 		},
 		ReadRawArtifact: func(string) ([]byte, error) { return []byte("raw"), nil },
-		GenerateSchema:  func(string) ([]byte, error) { return nil, errors.New("schema failed") },
+		ProjectJavaScriptCatalog: func(payload []byte) ([]byte, error) {
+			return payload, nil
+		},
+		GenerateSchema: func(string) ([]byte, error) { return nil, errors.New("schema failed") },
 	})
 	if err == nil || !strings.Contains(err.Error(), "schema failed") {
 		t.Fatalf("expected schema failure, got %v", err)
@@ -138,7 +147,10 @@ func TestArtifactsWithDependencies_PropagatesManifestFailure(t *testing.T) {
 			return []contractjoiner.Document{}, nil
 		},
 		ReadRawArtifact: func(string) ([]byte, error) { return []byte("raw"), nil },
-		GenerateSchema:  func(string) ([]byte, error) { return []byte("{\"type\":\"object\"}\n"), nil },
+		ProjectJavaScriptCatalog: func(payload []byte) ([]byte, error) {
+			return payload, nil
+		},
+		GenerateSchema: func(string) ([]byte, error) { return []byte("{\"type\":\"object\"}\n"), nil },
 		GenerateStandaloneSchemas: func(string) (map[string][]byte, error) {
 			return map[string][]byte{}, nil
 		},

--- a/internal/contractstaging/check.go
+++ b/internal/contractstaging/check.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/portpowered/infinite-you/internal/contractjoiner"
 	"github.com/portpowered/infinite-you/internal/contractvalidator"
+	"github.com/portpowered/infinite-you/internal/javascriptcontract"
 )
 
 const (
@@ -40,6 +41,7 @@ type ArtifactsDependencies struct {
 	GenerateSchema            func(repositoryRoot string) ([]byte, error)
 	GenerateStandaloneSchemas func(repositoryRoot string) (map[string][]byte, error)
 	GenerateManifest          func(repositoryRoot string, artifacts map[string][]byte) ([]byte, error)
+	ProjectJavaScriptCatalog  func(canonical []byte) ([]byte, error)
 }
 
 // Empty reports whether package staging exactly matches canonical joined output.
@@ -93,6 +95,17 @@ func compareArtifacts(repositoryRoot string, expected map[string][]byte, actual 
 	drift := Drift{}
 	for path, expectedPayload := range expected {
 		if path == FactorySchemaAuthoredPath {
+			continue
+		}
+		if path == javascriptcontract.RuntimeCatalogPath {
+			if category, authoredPath := authoredArtifactDrift(repositoryRoot, path, expectedPayload); category != "" {
+				switch category {
+				case "stale":
+					drift.Stale = append(drift.Stale, authoredPath)
+				case "missing":
+					drift.Missing = append(drift.Missing, authoredPath)
+				}
+			}
 			continue
 		}
 		actualFile, exists := actual[path]
@@ -175,6 +188,13 @@ func artifactsWithDependencies(repositoryRoot string, dependencies ArtifactsDepe
 		if err != nil {
 			return nil, fmt.Errorf("read canonical raw artifact %s: %w", artifact.Source, err)
 		}
+		if artifact.Source == javascriptcontract.RuntimeCatalogPath {
+			payload, err = dependencies.ProjectJavaScriptCatalog(payload)
+			if err != nil {
+				return nil, fmt.Errorf("project JavaScript runtime catalog: %w", err)
+			}
+			expected[artifact.Source] = payload
+		}
 		if artifact.Source == CanonicalOpenAPIPath {
 			payload, err = dependencies.ProjectOpenAPI(payload, ReviewedOpenAPIBytePolicy)
 			if err != nil {
@@ -222,6 +242,7 @@ func normalizeArtifactsDependencies(repositoryRoot string, requested ArtifactsDe
 		GenerateSchema:            generateFactorySchema,
 		GenerateStandaloneSchemas: generateStandaloneFactorySchemas,
 		GenerateManifest:          generateManifest,
+		ProjectJavaScriptCatalog:  javascriptcontract.GenerateRuntimeCatalog,
 	}
 	if requested.Join != nil {
 		resolved.Join = requested.Join
@@ -240,6 +261,9 @@ func normalizeArtifactsDependencies(repositoryRoot string, requested ArtifactsDe
 	}
 	if requested.GenerateManifest != nil {
 		resolved.GenerateManifest = requested.GenerateManifest
+	}
+	if requested.ProjectJavaScriptCatalog != nil {
+		resolved.ProjectJavaScriptCatalog = requested.ProjectJavaScriptCatalog
 	}
 	return normalizedRoot, resolved, nil
 }

--- a/internal/contractstaging/check_test.go
+++ b/internal/contractstaging/check_test.go
@@ -169,5 +169,8 @@ func canonicalFixture(path string) string {
       type: object
 `
 	}
+	if path == "contracts/javascript/runtime-api.json" {
+		return `{"sharedSchemas":{"javascript.schema.agent_run_spec":{"schema":{"type":"object","additionalProperties":false,"properties":{"prompt":{"type":"string"}},"required":["prompt"]}}}}`
+	}
 	return "canonical:" + path
 }

--- a/internal/javascriptcontract/check.go
+++ b/internal/javascriptcontract/check.go
@@ -1,0 +1,346 @@
+package javascriptcontract
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+const (
+	// StagedRuntimeCatalogPath is the package-facing copy of the canonical
+	// runtime catalog.
+	StagedRuntimeCatalogPath = "packages/api/generated/javascript/runtime-api.json"
+	generatedContractCommand = "make contracts-generate"
+)
+
+// Diagnostic identifies one field-level difference in a generated JavaScript
+// runtime projection. Path is repository-relative and Field is the affected
+// agent.run property.
+type Diagnostic struct {
+	Code    string
+	Path    string
+	Field   string
+	Message string
+}
+
+type fieldShape struct {
+	JSONType string
+	Required bool
+}
+
+// CheckGeneratedOutputs computes the canonical catalog and documentation
+// projections in memory, then compares them with the committed outputs. It is
+// deliberately read-only; contracts-generate is the corresponding write path.
+func CheckGeneratedOutputs(repositoryRoot string) ([]Diagnostic, error) {
+	root, err := filepath.Abs(repositoryRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repository root: %w", err)
+	}
+
+	canonical, err := readGeneratedOutput(root, RuntimeCatalogPath)
+	if err != nil {
+		return nil, err
+	}
+	expectedCatalog, err := GenerateRuntimeCatalog(canonical)
+	if err != nil {
+		return nil, fmt.Errorf("generate expected %s: %w", RuntimeCatalogPath, err)
+	}
+
+	diagnostics, err := checkCatalogOutput(RuntimeCatalogPath, canonical, expectedCatalog)
+	if err != nil {
+		return nil, err
+	}
+	staged, err := readGeneratedOutput(root, StagedRuntimeCatalogPath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+	} else {
+		stagedDiagnostics, err := checkCatalogOutput(StagedRuntimeCatalogPath, staged, expectedCatalog)
+		if err != nil {
+			return nil, err
+		}
+		diagnostics = append(diagnostics, stagedDiagnostics...)
+	}
+
+	documentation, err := readGeneratedOutput(root, JavaScriptWorkflowReferencePath)
+	if err != nil {
+		return nil, err
+	}
+	expectedDocumentation, err := ProjectJavaScriptWorkflowReference(documentation, factoryruntime.JavaScriptChildFieldDescriptors())
+	if err != nil {
+		return nil, fmt.Errorf("generate expected %s: %w", JavaScriptWorkflowReferencePath, err)
+	}
+	documentationDiagnostics, err := checkDocumentationOutput(documentation, expectedDocumentation)
+	if err != nil {
+		return nil, err
+	}
+	diagnostics = append(diagnostics, documentationDiagnostics...)
+
+	sortDiagnostics(diagnostics)
+	return diagnostics, nil
+}
+
+func readGeneratedOutput(repositoryRoot, path string) ([]byte, error) {
+	payload, err := os.ReadFile(filepath.Join(repositoryRoot, filepath.FromSlash(path)))
+	if err != nil {
+		return nil, fmt.Errorf("read generated output %s: %w; run `%s`", path, err, generatedContractCommand)
+	}
+	return payload, nil
+}
+
+func checkCatalogOutput(path string, actual, expected []byte) ([]Diagnostic, error) {
+	if bytes.Equal(actual, expected) {
+		return nil, nil
+	}
+	actualFields, err := parseRuntimeCatalogFields(actual)
+	if err != nil {
+		return nil, fmt.Errorf("inspect stale generated output %s: %w; run `%s`", path, err, generatedContractCommand)
+	}
+	expectedFields, err := parseRuntimeCatalogFields(expected)
+	if err != nil {
+		return nil, fmt.Errorf("inspect expected generated output %s: %w", path, err)
+	}
+	diagnostics := compareFieldShapes(path, "artifact", expectedFields, actualFields)
+	if len(diagnostics) > 0 {
+		return diagnostics, nil
+	}
+	return []Diagnostic{{
+		Code:    "javascript.generated.output.stale",
+		Path:    path,
+		Message: fmt.Sprintf("%s differs from the runtime-generated agent.run projection; run `%s`", path, generatedContractCommand),
+	}}, nil
+}
+
+func checkDocumentationOutput(actual, expected []byte) ([]Diagnostic, error) {
+	if bytes.Equal(actual, expected) {
+		return nil, nil
+	}
+	actualFields, err := parseDocumentationFields(actual)
+	if err != nil {
+		return nil, fmt.Errorf("inspect stale generated output %s: %w; run `%s`", JavaScriptWorkflowReferencePath, err, generatedContractCommand)
+	}
+	expectedFields, err := parseDocumentationFields(expected)
+	if err != nil {
+		return nil, fmt.Errorf("inspect expected generated output %s: %w", JavaScriptWorkflowReferencePath, err)
+	}
+	diagnostics := compareFieldShapes(JavaScriptWorkflowReferencePath, "documentation", expectedFields, actualFields)
+	if len(diagnostics) > 0 {
+		return diagnostics, nil
+	}
+	return []Diagnostic{{
+		Code:    "javascript.generated.output.stale",
+		Path:    JavaScriptWorkflowReferencePath,
+		Message: fmt.Sprintf("%s differs from the runtime-generated agent.run documentation projection; run `%s`", JavaScriptWorkflowReferencePath, generatedContractCommand),
+	}}, nil
+}
+
+func compareFieldShapes(path, surface string, expected, actual map[string]fieldShape) []Diagnostic {
+	names := make(map[string]struct{}, len(expected)+len(actual))
+	for name := range expected {
+		names[name] = struct{}{}
+	}
+	for name := range actual {
+		names[name] = struct{}{}
+	}
+	orderedNames := make([]string, 0, len(names))
+	for name := range names {
+		orderedNames = append(orderedNames, name)
+	}
+	sort.Strings(orderedNames)
+
+	diagnostics := make([]Diagnostic, 0)
+	for _, name := range orderedNames {
+		want, expectedPresent := expected[name]
+		got, actualPresent := actual[name]
+		switch {
+		case !expectedPresent:
+			diagnostics = append(diagnostics, fieldDiagnostic(path, surface, name, "extra", ""))
+		case !actualPresent:
+			diagnostics = append(diagnostics, fieldDiagnostic(path, surface, name, "missing", ""))
+		default:
+			if want.JSONType != got.JSONType {
+				detail := fmt.Sprintf("got %q, expected %q", got.JSONType, want.JSONType)
+				diagnostics = append(diagnostics, fieldDiagnostic(path, surface, name, "type", detail))
+			}
+			if want.Required != got.Required {
+				gotRequiredness := requiredness(got.Required)
+				wantRequiredness := requiredness(want.Required)
+				detail := fmt.Sprintf("got %s, expected %s", gotRequiredness, wantRequiredness)
+				diagnostics = append(diagnostics, fieldDiagnostic(path, surface, name, "requiredness", detail))
+			}
+		}
+	}
+	return diagnostics
+}
+
+func fieldDiagnostic(path, surface, field, issue, detail string) Diagnostic {
+	code := "javascript.agent_run.field." + issue
+	message := fmt.Sprintf("%s has %s generated agent.run field %q", path, surface, field)
+	switch issue {
+	case "missing":
+		message += " missing"
+	case "extra":
+		message += " that is not in the runtime descriptor"
+	case "type":
+		message += " with a mismatched JSON type"
+	case "requiredness":
+		message += " with mismatched requiredness"
+	}
+	if detail != "" {
+		message += " (" + detail + ")"
+	}
+	message += fmt.Sprintf("; run `%s`", generatedContractCommand)
+	return Diagnostic{Code: code, Path: path, Field: field, Message: message}
+}
+
+func requiredness(required bool) string {
+	if required {
+		return "required"
+	}
+	return "optional"
+}
+
+func parseRuntimeCatalogFields(payload []byte) (map[string]fieldShape, error) {
+	var document map[string]any
+	if err := json.Unmarshal(payload, &document); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", RuntimeCatalogPath, err)
+	}
+	schema, err := agentRunSchema(document)
+	if err != nil {
+		return nil, err
+	}
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s has no object /sharedSchemas/javascript.schema.agent_run_spec/schema/properties", RuntimeCatalogPath)
+	}
+	requiredValues, ok := schema["required"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s has no array /sharedSchemas/javascript.schema.agent_run_spec/schema/required", RuntimeCatalogPath)
+	}
+	required := make(map[string]bool, len(requiredValues))
+	for _, value := range requiredValues {
+		name, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s has a non-string required agent.run field", RuntimeCatalogPath)
+		}
+		required[name] = true
+	}
+
+	fields := make(map[string]fieldShape, len(properties))
+	for name, value := range properties {
+		property, ok := value.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("%s field %q is not an object", RuntimeCatalogPath, name)
+		}
+		jsonType, ok := property["type"].(string)
+		if !ok || jsonType == "" {
+			return nil, fmt.Errorf("%s field %q has no JSON type", RuntimeCatalogPath, name)
+		}
+		fields[name] = fieldShape{JSONType: jsonType, Required: required[name]}
+	}
+	for name := range required {
+		if _, ok := fields[name]; !ok {
+			return nil, fmt.Errorf("%s requires unknown agent.run field %q", RuntimeCatalogPath, name)
+		}
+	}
+	return fields, nil
+}
+
+func parseDocumentationFields(document []byte) (map[string]fieldShape, error) {
+	region, err := generatedDocumentationRegion(document)
+	if err != nil {
+		return nil, err
+	}
+	fields := make(map[string]fieldShape)
+	for _, line := range strings.Split(strings.ReplaceAll(string(region), "\r\n", "\n"), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "### ") || trimmed == "| Field | JSON type | Requiredness |" || trimmed == "|-------|-----------|--------------|" {
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "|") {
+			continue
+		}
+		field, shape, err := parseDocumentationRow(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("%s has invalid generated agent.run field row: %w", JavaScriptWorkflowReferencePath, err)
+		}
+		if _, exists := fields[field]; exists {
+			return nil, fmt.Errorf("%s repeats generated agent.run field %q", JavaScriptWorkflowReferencePath, field)
+		}
+		fields[field] = shape
+	}
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("%s has no generated agent.run field rows", JavaScriptWorkflowReferencePath)
+	}
+	return fields, nil
+}
+
+func generatedDocumentationRegion(document []byte) ([]byte, error) {
+	if _, err := replaceGeneratedAgentRunRegion(document, nil); err != nil {
+		return nil, err
+	}
+	startMarker := bytes.Index(document, []byte(AgentRunFieldsStartMarker))
+	endMarker := bytes.Index(document, []byte(AgentRunFieldsEndMarker))
+	_, startLineEnd := markdownLineBounds(document, startMarker)
+	endLineStart, _ := markdownLineBounds(document, endMarker)
+	regionStart := startLineEnd
+	for regionStart < len(document) && (document[regionStart] == '\r' || document[regionStart] == '\n') {
+		regionStart++
+	}
+	return document[regionStart:endLineStart], nil
+}
+
+func parseDocumentationRow(line string) (string, fieldShape, error) {
+	parts := strings.Split(line, "|")
+	if len(parts) != 5 {
+		return "", fieldShape{}, fmt.Errorf("expected three cells")
+	}
+	name, err := parseDocumentationCodeCell(parts[1])
+	if err != nil {
+		return "", fieldShape{}, fmt.Errorf("field name: %w", err)
+	}
+	jsonType, err := parseDocumentationCodeCell(parts[2])
+	if err != nil {
+		return "", fieldShape{}, fmt.Errorf("JSON type: %w", err)
+	}
+	requiredness := strings.TrimSpace(parts[3])
+	if requiredness != "required" && requiredness != "optional" {
+		return "", fieldShape{}, fmt.Errorf("requiredness %q is invalid", requiredness)
+	}
+	return name, fieldShape{JSONType: jsonType, Required: requiredness == "required"}, nil
+}
+
+func parseDocumentationCodeCell(cell string) (string, error) {
+	trimmed := strings.TrimSpace(cell)
+	if len(trimmed) < 2 || trimmed[0] != '`' || trimmed[len(trimmed)-1] != '`' {
+		return "", fmt.Errorf("%q is not a code cell", trimmed)
+	}
+	value := trimmed[1 : len(trimmed)-1]
+	if value == "" {
+		return "", fmt.Errorf("code cell is empty")
+	}
+	return value, nil
+}
+
+func sortDiagnostics(diagnostics []Diagnostic) {
+	sort.Slice(diagnostics, func(left, right int) bool {
+		if diagnostics[left].Path != diagnostics[right].Path {
+			return diagnostics[left].Path < diagnostics[right].Path
+		}
+		if diagnostics[left].Field != diagnostics[right].Field {
+			return diagnostics[left].Field < diagnostics[right].Field
+		}
+		if diagnostics[left].Code != diagnostics[right].Code {
+			return diagnostics[left].Code < diagnostics[right].Code
+		}
+		return diagnostics[left].Message < diagnostics[right].Message
+	})
+}

--- a/internal/javascriptcontract/check.go
+++ b/internal/javascriptcontract/check.go
@@ -33,6 +33,7 @@ type Diagnostic struct {
 type fieldShape struct {
 	JSONType string
 	Required bool
+	Enum     []string
 }
 
 // CheckGeneratedOutputs computes the canonical catalog and documentation
@@ -176,6 +177,10 @@ func compareFieldShapes(path, surface string, expected, actual map[string]fieldS
 				detail := fmt.Sprintf("got %s, expected %s", gotRequiredness, wantRequiredness)
 				diagnostics = append(diagnostics, fieldDiagnostic(path, surface, name, "requiredness", detail))
 			}
+			if !equalStrings(want.Enum, got.Enum) {
+				detail := fmt.Sprintf("got %v, expected %v", got.Enum, want.Enum)
+				diagnostics = append(diagnostics, fieldDiagnostic(path, surface, name, "enum", detail))
+			}
 		}
 	}
 	return diagnostics
@@ -193,6 +198,8 @@ func fieldDiagnostic(path, surface, field, issue, detail string) Diagnostic {
 		message += " with a mismatched JSON type"
 	case "requiredness":
 		message += " with mismatched requiredness"
+	case "enum":
+		message += " with mismatched allowed values"
 	}
 	if detail != "" {
 		message += " (" + detail + ")"
@@ -244,7 +251,11 @@ func parseRuntimeCatalogFields(payload []byte) (map[string]fieldShape, error) {
 		if !ok || jsonType == "" {
 			return nil, fmt.Errorf("%s field %q has no JSON type", RuntimeCatalogPath, name)
 		}
-		fields[name] = fieldShape{JSONType: jsonType, Required: required[name]}
+		enum, err := parseJSONEnum(property["enum"])
+		if err != nil {
+			return nil, fmt.Errorf("%s field %q has invalid enum: %w", RuntimeCatalogPath, name, err)
+		}
+		fields[name] = fieldShape{JSONType: jsonType, Required: required[name], Enum: enum}
 	}
 	for name := range required {
 		if _, ok := fields[name]; !ok {
@@ -262,7 +273,7 @@ func parseDocumentationFields(document []byte) (map[string]fieldShape, error) {
 	fields := make(map[string]fieldShape)
 	for _, line := range strings.Split(strings.ReplaceAll(string(region), "\r\n", "\n"), "\n") {
 		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || strings.HasPrefix(trimmed, "### ") || trimmed == "| Field | JSON type | Requiredness |" || trimmed == "|-------|-----------|--------------|" {
+		if trimmed == "" || strings.HasPrefix(trimmed, "### ") || trimmed == "| Field | JSON type | Requiredness | Allowed values |" || trimmed == "|-------|-----------|--------------|----------------|" {
 			continue
 		}
 		if !strings.HasPrefix(trimmed, "|") {
@@ -300,8 +311,8 @@ func generatedDocumentationRegion(document []byte) ([]byte, error) {
 
 func parseDocumentationRow(line string) (string, fieldShape, error) {
 	parts := strings.Split(line, "|")
-	if len(parts) != 5 {
-		return "", fieldShape{}, fmt.Errorf("expected three cells")
+	if len(parts) != 6 {
+		return "", fieldShape{}, fmt.Errorf("expected four cells")
 	}
 	name, err := parseDocumentationCodeCell(parts[1])
 	if err != nil {
@@ -315,7 +326,49 @@ func parseDocumentationRow(line string) (string, fieldShape, error) {
 	if requiredness != "required" && requiredness != "optional" {
 		return "", fieldShape{}, fmt.Errorf("requiredness %q is invalid", requiredness)
 	}
-	return name, fieldShape{JSONType: jsonType, Required: requiredness == "required"}, nil
+	allowed := strings.TrimSpace(parts[4])
+	var enum []string
+	if allowed != "—" {
+		for _, value := range strings.Split(allowed, ",") {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				return "", fieldShape{}, fmt.Errorf("allowed values contain an empty value")
+			}
+			enum = append(enum, value)
+		}
+	}
+	return name, fieldShape{JSONType: jsonType, Required: requiredness == "required", Enum: enum}, nil
+}
+
+func parseJSONEnum(value any) ([]string, error) {
+	if value == nil {
+		return nil, nil
+	}
+	values, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("enum is not an array")
+	}
+	enum := make([]string, 0, len(values))
+	for _, value := range values {
+		text, ok := value.(string)
+		if !ok || text == "" {
+			return nil, fmt.Errorf("enum contains a non-empty string requirement")
+		}
+		enum = append(enum, text)
+	}
+	return enum, nil
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
 }
 
 func parseDocumentationCodeCell(cell string) (string, error) {

--- a/internal/javascriptcontract/check.go
+++ b/internal/javascriptcontract/check.go
@@ -31,9 +31,10 @@ type Diagnostic struct {
 }
 
 type fieldShape struct {
-	JSONType string
-	Required bool
-	Enum     []string
+	JSONType             string
+	Required             bool
+	Enum                 []string
+	AdditionalProperties *bool
 }
 
 // CheckGeneratedOutputs computes the canonical catalog and documentation
@@ -181,6 +182,10 @@ func compareFieldShapes(path, surface string, expected, actual map[string]fieldS
 				detail := fmt.Sprintf("got %v, expected %v", got.Enum, want.Enum)
 				diagnostics = append(diagnostics, fieldDiagnostic(path, surface, name, "enum", detail))
 			}
+			if !equalOptionalBool(want.AdditionalProperties, got.AdditionalProperties) {
+				detail := fmt.Sprintf("got %v, expected %v", optionalBoolValue(got.AdditionalProperties), optionalBoolValue(want.AdditionalProperties))
+				diagnostics = append(diagnostics, fieldDiagnostic(path, surface, name, "additionalProperties", detail))
+			}
 		}
 	}
 	return diagnostics
@@ -200,6 +205,8 @@ func fieldDiagnostic(path, surface, field, issue, detail string) Diagnostic {
 		message += " with mismatched requiredness"
 	case "enum":
 		message += " with mismatched allowed values"
+	case "additionalProperties":
+		message += " with mismatched additionalProperties metadata"
 	}
 	if detail != "" {
 		message += " (" + detail + ")"
@@ -255,7 +262,11 @@ func parseRuntimeCatalogFields(payload []byte) (map[string]fieldShape, error) {
 		if err != nil {
 			return nil, fmt.Errorf("%s field %q has invalid enum: %w", RuntimeCatalogPath, name, err)
 		}
-		fields[name] = fieldShape{JSONType: jsonType, Required: required[name], Enum: enum}
+		additionalProperties, err := parseJSONBoolPointer(property["additionalProperties"])
+		if err != nil {
+			return nil, fmt.Errorf("%s field %q has invalid additionalProperties: %w", RuntimeCatalogPath, name, err)
+		}
+		fields[name] = fieldShape{JSONType: jsonType, Required: required[name], Enum: enum, AdditionalProperties: additionalProperties}
 	}
 	for name := range required {
 		if _, ok := fields[name]; !ok {
@@ -369,6 +380,31 @@ func equalStrings(left, right []string) bool {
 		}
 	}
 	return true
+}
+
+func parseJSONBoolPointer(value any) (*bool, error) {
+	if value == nil {
+		return nil, nil
+	}
+	boolean, ok := value.(bool)
+	if !ok {
+		return nil, fmt.Errorf("additionalProperties must be a boolean")
+	}
+	return &boolean, nil
+}
+
+func equalOptionalBool(left, right *bool) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
+func optionalBoolValue(value *bool) any {
+	if value == nil {
+		return nil
+	}
+	return *value
 }
 
 func parseDocumentationCodeCell(cell string) (string, error) {

--- a/internal/javascriptcontract/check_test.go
+++ b/internal/javascriptcontract/check_test.go
@@ -1,0 +1,205 @@
+package javascriptcontract
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+func TestCheckGeneratedOutputsPassesAlignedOutputsDeterministicallyWithoutWriting(t *testing.T) {
+	root := generatedCheckFixture(t)
+	before := generatedCheckTree(t, root)
+
+	first, err := CheckGeneratedOutputs(root)
+	if err != nil {
+		t.Fatalf("first CheckGeneratedOutputs() error = %v", err)
+	}
+	second, err := CheckGeneratedOutputs(root)
+	if err != nil {
+		t.Fatalf("second CheckGeneratedOutputs() error = %v", err)
+	}
+	if len(first) != 0 || len(second) != 0 {
+		t.Fatalf("aligned diagnostics = first=%+v second=%+v, want none", first, second)
+	}
+	if after := generatedCheckTree(t, root); !reflect.DeepEqual(before, after) {
+		t.Fatalf("CheckGeneratedOutputs() changed aligned outputs")
+	}
+}
+
+func TestCheckGeneratedOutputsReportsMissingCanonicalFieldWithoutWriting(t *testing.T) {
+	root := generatedCheckFixture(t)
+	path := filepath.Join(root, filepath.FromSlash(RuntimeCatalogPath))
+	mutateCatalog(t, path, func(properties map[string]any) {
+		delete(properties, "resourceId")
+	})
+	before := generatedCheckTree(t, root)
+
+	first, err := CheckGeneratedOutputs(root)
+	if err != nil {
+		t.Fatalf("first CheckGeneratedOutputs() error = %v", err)
+	}
+	second, err := CheckGeneratedOutputs(root)
+	if err != nil {
+		t.Fatalf("second CheckGeneratedOutputs() error = %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("diagnostics are not deterministic: first=%+v second=%+v", first, second)
+	}
+	assertFieldDiagnostic(t, first, RuntimeCatalogPath, "resourceId", "missing")
+	if !strings.Contains(first[0].Message, "make contracts-generate") {
+		t.Fatalf("diagnostic message = %q, want regeneration command", first[0].Message)
+	}
+	if after := generatedCheckTree(t, root); !reflect.DeepEqual(before, after) {
+		t.Fatalf("CheckGeneratedOutputs() rewrote missing-field fixture")
+	}
+}
+
+func TestCheckGeneratedOutputsReportsExtraStagedFieldWithoutWriting(t *testing.T) {
+	root := generatedCheckFixture(t)
+	path := filepath.Join(root, filepath.FromSlash(StagedRuntimeCatalogPath))
+	mutateCatalog(t, path, func(properties map[string]any) {
+		properties["futureField"] = map[string]any{"type": "string"}
+	})
+	before := generatedCheckTree(t, root)
+
+	diagnostics, err := CheckGeneratedOutputs(root)
+	if err != nil {
+		t.Fatalf("CheckGeneratedOutputs() error = %v", err)
+	}
+	assertFieldDiagnostic(t, diagnostics, StagedRuntimeCatalogPath, "futureField", "extra")
+	if after := generatedCheckTree(t, root); !reflect.DeepEqual(before, after) {
+		t.Fatalf("CheckGeneratedOutputs() rewrote extra-field fixture")
+	}
+}
+
+func TestCheckGeneratedOutputsReportsStaleDocumentationFieldWithoutWriting(t *testing.T) {
+	root := generatedCheckFixture(t)
+	path := filepath.Join(root, filepath.FromSlash(JavaScriptWorkflowReferencePath))
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read documentation: %v", err)
+	}
+	updated := bytes.Replace(payload, []byte("| `resourceId` | `string` | optional |\n"), nil, 1)
+	if bytes.Equal(payload, updated) {
+		t.Fatal("documentation fixture did not contain resourceId row")
+	}
+	if err := os.WriteFile(path, updated, 0o644); err != nil {
+		t.Fatalf("write documentation: %v", err)
+	}
+	before := generatedCheckTree(t, root)
+
+	diagnostics, err := CheckGeneratedOutputs(root)
+	if err != nil {
+		t.Fatalf("CheckGeneratedOutputs() error = %v", err)
+	}
+	assertFieldDiagnostic(t, diagnostics, JavaScriptWorkflowReferencePath, "resourceId", "missing")
+	if after := generatedCheckTree(t, root); !reflect.DeepEqual(before, after) {
+		t.Fatalf("CheckGeneratedOutputs() rewrote documentation fixture")
+	}
+}
+
+func TestCheckGeneratedOutputsRejectsInvalidDocumentationProjection(t *testing.T) {
+	root := generatedCheckFixture(t)
+	path := filepath.Join(root, filepath.FromSlash(JavaScriptWorkflowReferencePath))
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read documentation: %v", err)
+	}
+	updated := bytes.Replace(payload, []byte("| `resourceId` | `string` | optional |\n"), []byte("| resourceId | `string` | optional |\n"), 1)
+	if err := os.WriteFile(path, updated, 0o644); err != nil {
+		t.Fatalf("write documentation: %v", err)
+	}
+
+	_, err = CheckGeneratedOutputs(root)
+	if err == nil || !strings.Contains(err.Error(), JavaScriptWorkflowReferencePath) || !strings.Contains(err.Error(), "make contracts-generate") {
+		t.Fatalf("CheckGeneratedOutputs() error = %v, want actionable documentation error", err)
+	}
+}
+
+func generatedCheckFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	catalog, err := GenerateRuntimeCatalog([]byte(minimalCatalog))
+	if err != nil {
+		t.Fatalf("GenerateRuntimeCatalog() = %v", err)
+	}
+	documentation, err := ProjectJavaScriptWorkflowReference(documentationFixtureBytes(), factoryruntime.JavaScriptChildFieldDescriptors())
+	if err != nil {
+		t.Fatalf("ProjectJavaScriptWorkflowReference() = %v", err)
+	}
+	writeGeneratedCheckFixture(t, root, RuntimeCatalogPath, catalog)
+	writeGeneratedCheckFixture(t, root, StagedRuntimeCatalogPath, catalog)
+	writeGeneratedCheckFixture(t, root, JavaScriptWorkflowReferencePath, documentation)
+	return root
+}
+
+func documentationFixtureBytes() []byte {
+	return []byte("before prose\n\n" + AgentRunFieldsStartMarker + "\nold generated fields\n" + AgentRunFieldsEndMarker + "\n\nafter prose\n")
+}
+
+func mutateCatalog(t *testing.T, path string, mutate func(map[string]any)) {
+	t.Helper()
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read catalog: %v", err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(payload, &document); err != nil {
+		t.Fatalf("decode catalog: %v", err)
+	}
+	sharedSchemas := document["sharedSchemas"].(map[string]any)
+	agentRun := sharedSchemas["javascript.schema.agent_run_spec"].(map[string]any)
+	schema := agentRun["schema"].(map[string]any)
+	properties := schema["properties"].(map[string]any)
+	mutate(properties)
+	updated, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		t.Fatalf("encode catalog: %v", err)
+	}
+	updated = append(updated, '\n')
+	if err := os.WriteFile(path, updated, 0o644); err != nil {
+		t.Fatalf("write catalog: %v", err)
+	}
+}
+
+func writeGeneratedCheckFixture(t *testing.T, root, path string, payload []byte) {
+	t.Helper()
+	target := filepath.Join(root, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("create fixture directory: %v", err)
+	}
+	if err := os.WriteFile(target, payload, 0o644); err != nil {
+		t.Fatalf("write fixture %s: %v", path, err)
+	}
+}
+
+func generatedCheckTree(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+	paths := []string{RuntimeCatalogPath, StagedRuntimeCatalogPath, JavaScriptWorkflowReferencePath}
+	tree := make(map[string][]byte, len(paths))
+	for _, path := range paths {
+		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(path)))
+		if err != nil {
+			t.Fatalf("read fixture %s: %v", path, err)
+		}
+		tree[path] = append([]byte(nil), payload...)
+	}
+	return tree
+}
+
+func assertFieldDiagnostic(t *testing.T, diagnostics []Diagnostic, path, field, issue string) {
+	t.Helper()
+	code := "javascript.agent_run.field." + issue
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Path == path && diagnostic.Field == field && diagnostic.Code == code {
+			return
+		}
+	}
+	t.Fatalf("diagnostics = %+v, want %s for %s/%s", diagnostics, code, path, field)
+}

--- a/internal/javascriptcontract/check_test.go
+++ b/internal/javascriptcontract/check_test.go
@@ -85,7 +85,7 @@ func TestCheckGeneratedOutputsReportsStaleDocumentationFieldWithoutWriting(t *te
 	if err != nil {
 		t.Fatalf("read documentation: %v", err)
 	}
-	updated := bytes.Replace(payload, []byte("| `resourceId` | `string` | optional |\n"), nil, 1)
+	updated := bytes.Replace(payload, []byte("| `resourceId` | `string` | optional | — |\n"), nil, 1)
 	if bytes.Equal(payload, updated) {
 		t.Fatal("documentation fixture did not contain resourceId row")
 	}
@@ -111,7 +111,7 @@ func TestCheckGeneratedOutputsRejectsInvalidDocumentationProjection(t *testing.T
 	if err != nil {
 		t.Fatalf("read documentation: %v", err)
 	}
-	updated := bytes.Replace(payload, []byte("| `resourceId` | `string` | optional |\n"), []byte("| resourceId | `string` | optional |\n"), 1)
+	updated := bytes.Replace(payload, []byte("| `resourceId` | `string` | optional | — |\n"), []byte("| resourceId | `string` | optional | — |\n"), 1)
 	if err := os.WriteFile(path, updated, 0o644); err != nil {
 		t.Fatalf("write documentation: %v", err)
 	}

--- a/internal/javascriptcontract/documentation.go
+++ b/internal/javascriptcontract/documentation.go
@@ -54,6 +54,11 @@ func ProjectJavaScriptWorkflowReference(document []byte, fields []factoryruntime
 		if strings.ContainsAny(field.Name, "|`\r\n") {
 			return nil, fmt.Errorf("%s cannot render runtime descriptor field %q in the generated Markdown table", JavaScriptWorkflowReferencePath, field.Name)
 		}
+		for _, allowed := range field.Enum {
+			if strings.ContainsAny(allowed, "|`\r\n") {
+				return nil, fmt.Errorf("%s cannot render enum value %q for runtime descriptor field %q in the generated Markdown table", JavaScriptWorkflowReferencePath, allowed, field.Name)
+			}
+		}
 	}
 	payload := renderAgentRunFields(fields)
 	return replaceGeneratedAgentRunRegion(document, payload)
@@ -62,14 +67,18 @@ func ProjectJavaScriptWorkflowReference(document []byte, fields []factoryruntime
 func renderAgentRunFields(fields []factoryruntime.JavaScriptChildFieldDescriptor) []byte {
 	var table strings.Builder
 	table.WriteString("### `agent.run` request fields\n\n")
-	table.WriteString("| Field | JSON type | Requiredness |\n")
-	table.WriteString("|-------|-----------|--------------|\n")
+	table.WriteString("| Field | JSON type | Requiredness | Allowed values |\n")
+	table.WriteString("|-------|-----------|--------------|----------------|\n")
 	for _, field := range fields {
 		requiredness := "optional"
 		if field.Required {
 			requiredness = "required"
 		}
-		fmt.Fprintf(&table, "| `%s` | `%s` | %s |\n", field.Name, field.JSONType, requiredness)
+		allowed := "—"
+		if len(field.Enum) > 0 {
+			allowed = strings.Join(field.Enum, ", ")
+		}
+		fmt.Fprintf(&table, "| `%s` | `%s` | %s | %s |\n", field.Name, field.JSONType, requiredness, allowed)
 	}
 	return []byte(strings.TrimSuffix(table.String(), "\n"))
 }

--- a/internal/javascriptcontract/documentation.go
+++ b/internal/javascriptcontract/documentation.go
@@ -1,0 +1,125 @@
+package javascriptcontract
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+const (
+	// JavaScriptWorkflowReferencePath is the canonical source for the packaged
+	// you docs javascript-workflows topic.
+	JavaScriptWorkflowReferencePath = "docs/reference/javascript-workflows.md"
+
+	// AgentRunFieldsStartMarker and AgentRunFieldsEndMarker bound the generated
+	// field table. All prose outside these markers remains hand-authored.
+	AgentRunFieldsStartMarker = "<!-- BEGIN GENERATED: javascript.agent.run.fields -->"
+	AgentRunFieldsEndMarker   = "<!-- END GENERATED: javascript.agent.run.fields -->"
+)
+
+// GenerateJavaScriptWorkflowReference projects the runtime-owned agent.run
+// descriptor into the canonical packaged reference topic.
+func GenerateJavaScriptWorkflowReference(repositoryRoot string) error {
+	path := filepath.Join(repositoryRoot, filepath.FromSlash(JavaScriptWorkflowReferencePath))
+	document, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", JavaScriptWorkflowReferencePath, err)
+	}
+	projected, err := ProjectJavaScriptWorkflowReference(document, factoryruntime.JavaScriptChildFieldDescriptors())
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(document, projected) {
+		return nil
+	}
+	if err := os.WriteFile(path, projected, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", JavaScriptWorkflowReferencePath, err)
+	}
+	return nil
+}
+
+// ProjectJavaScriptWorkflowReference replaces only the bounded agent.run
+// field table in a reference document. The explicit fields parameter keeps
+// forward-evolution tests independent from filesystem state while production
+// generation supplies the runtime-owned descriptor.
+func ProjectJavaScriptWorkflowReference(document []byte, fields []factoryruntime.JavaScriptChildFieldDescriptor) ([]byte, error) {
+	if err := validateFields(fields); err != nil {
+		return nil, err
+	}
+	for _, field := range fields {
+		if strings.ContainsAny(field.Name, "|`\r\n") {
+			return nil, fmt.Errorf("%s cannot render runtime descriptor field %q in the generated Markdown table", JavaScriptWorkflowReferencePath, field.Name)
+		}
+	}
+	payload := renderAgentRunFields(fields)
+	return replaceGeneratedAgentRunRegion(document, payload)
+}
+
+func renderAgentRunFields(fields []factoryruntime.JavaScriptChildFieldDescriptor) []byte {
+	var table strings.Builder
+	table.WriteString("### `agent.run` request fields\n\n")
+	table.WriteString("| Field | JSON type | Requiredness |\n")
+	table.WriteString("|-------|-----------|--------------|\n")
+	for _, field := range fields {
+		requiredness := "optional"
+		if field.Required {
+			requiredness = "required"
+		}
+		fmt.Fprintf(&table, "| `%s` | `%s` | %s |\n", field.Name, field.JSONType, requiredness)
+	}
+	return []byte(strings.TrimSuffix(table.String(), "\n"))
+}
+
+func replaceGeneratedAgentRunRegion(document, payload []byte) ([]byte, error) {
+	if count := bytes.Count(document, []byte(AgentRunFieldsStartMarker)); count != 1 {
+		return nil, fmt.Errorf("%s must contain exactly one %s marker; found %d; restore the generated region before running make contracts-generate", JavaScriptWorkflowReferencePath, AgentRunFieldsStartMarker, count)
+	}
+	if count := bytes.Count(document, []byte(AgentRunFieldsEndMarker)); count != 1 {
+		return nil, fmt.Errorf("%s must contain exactly one %s marker; found %d; restore the generated region before running make contracts-generate", JavaScriptWorkflowReferencePath, AgentRunFieldsEndMarker, count)
+	}
+	startMarker := bytes.Index(document, []byte(AgentRunFieldsStartMarker))
+	endMarker := bytes.Index(document, []byte(AgentRunFieldsEndMarker))
+	if endMarker <= startMarker {
+		return nil, fmt.Errorf("%s has an invalid generated agent.run marker order; %s must precede %s", JavaScriptWorkflowReferencePath, AgentRunFieldsStartMarker, AgentRunFieldsEndMarker)
+	}
+	startLineStart, startLineEnd := markdownLineBounds(document, startMarker)
+	endLineStart, endLineEnd := markdownLineBounds(document, endMarker)
+	if string(document[startLineStart:startLineEnd]) != AgentRunFieldsStartMarker {
+		return nil, fmt.Errorf("%s has an invalid generated agent.run start marker line; keep %s on its own line", JavaScriptWorkflowReferencePath, AgentRunFieldsStartMarker)
+	}
+	if string(document[endLineStart:endLineEnd]) != AgentRunFieldsEndMarker {
+		return nil, fmt.Errorf("%s has an invalid generated agent.run end marker line; keep %s on its own line", JavaScriptWorkflowReferencePath, AgentRunFieldsEndMarker)
+	}
+	lineEnding := []byte("\n")
+	if startLineEnd < len(document) && document[startLineEnd] == '\r' {
+		lineEnding = []byte("\r\n")
+	}
+	replacement := make([]byte, 0, len(AgentRunFieldsStartMarker)+len(lineEnding)*2+len(payload)+len(AgentRunFieldsEndMarker))
+	replacement = append(replacement, AgentRunFieldsStartMarker...)
+	replacement = append(replacement, lineEnding...)
+	replacement = append(replacement, payload...)
+	replacement = append(replacement, lineEnding...)
+	replacement = append(replacement, AgentRunFieldsEndMarker...)
+	projected := make([]byte, 0, len(document)-(endLineEnd-startLineStart)+len(replacement))
+	projected = append(projected, document[:startLineStart]...)
+	projected = append(projected, replacement...)
+	projected = append(projected, document[endLineEnd:]...)
+	return projected, nil
+}
+
+func markdownLineBounds(document []byte, position int) (start, end int) {
+	start = bytes.LastIndexByte(document[:position], '\n') + 1
+	lineEnd := bytes.IndexByte(document[position:], '\n')
+	if lineEnd < 0 {
+		return start, len(document)
+	}
+	end = position + lineEnd
+	if end > start && document[end-1] == '\r' {
+		return start, end - 1
+	}
+	return start, end
+}

--- a/internal/javascriptcontract/documentation_test.go
+++ b/internal/javascriptcontract/documentation_test.go
@@ -18,10 +18,10 @@ func TestProjectJavaScriptWorkflowReferenceProjectsRuntimeFields(t *testing.T) {
 	}
 	text := string(projected)
 	for _, want := range []string{
-		"| `prompt` | `string` | required |",
-		"| `executorProvider` | `string` | optional |",
-		"| `resourceId` | `string` | optional |",
-		"| `skipPermissions` | `boolean` | optional |",
+		"| `prompt` | `string` | required | — |",
+		"| `executorProvider` | `string` | optional | — |",
+		"| `resourceId` | `string` | optional | — |",
+		"| `permissions` | `string` | optional | DEFAULT, SKIP_PERMISSIONS |",
 	} {
 		if !strings.Contains(text, want) {
 			t.Errorf("projected reference does not contain %q:\n%s", want, text)
@@ -52,7 +52,7 @@ func TestProjectRuntimeAndDocumentationOutputsSupportForwardFieldEvolution(t *te
 	if err != nil {
 		t.Fatalf("ProjectJavaScriptWorkflowReference() error = %v", err)
 	}
-	if !strings.Contains(string(documentation), "| `futureField` | `string` | optional |") {
+	if !strings.Contains(string(documentation), "| `futureField` | `string` | optional | — |") {
 		t.Fatalf("projected documentation omitted forward-evolved futureField:\n%s", documentation)
 	}
 }
@@ -136,7 +136,7 @@ func TestGenerateJavaScriptWorkflowReferenceWritesOnlyProjectedRegion(t *testing
 	if string(first) != string(second) {
 		t.Fatal("repeated file generation changed bytes")
 	}
-	if !strings.Contains(string(first), "| `resourceId` | `string` | optional |") {
+	if !strings.Contains(string(first), "| `resourceId` | `string` | optional | — |") {
 		t.Fatal("file generation did not project the runtime resourceId field")
 	}
 }

--- a/internal/javascriptcontract/documentation_test.go
+++ b/internal/javascriptcontract/documentation_test.go
@@ -1,0 +1,142 @@
+package javascriptcontract
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+const documentationFixture = "before prose\n\n" + AgentRunFieldsStartMarker + "\nold generated fields\n" + AgentRunFieldsEndMarker + "\n\nafter prose\n"
+
+func TestProjectJavaScriptWorkflowReferenceProjectsRuntimeFields(t *testing.T) {
+	projected, err := ProjectJavaScriptWorkflowReference([]byte(documentationFixture), factoryruntime.JavaScriptChildFieldDescriptors())
+	if err != nil {
+		t.Fatalf("ProjectJavaScriptWorkflowReference() error = %v", err)
+	}
+	text := string(projected)
+	for _, want := range []string{
+		"| `prompt` | `string` | required |",
+		"| `executorProvider` | `string` | optional |",
+		"| `resourceId` | `string` | optional |",
+		"| `skipPermissions` | `boolean` | optional |",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("projected reference does not contain %q:\n%s", want, text)
+		}
+	}
+	if !strings.Contains(text, "before prose\n") || !strings.Contains(text, "\nafter prose\n") {
+		t.Fatal("projection changed hand-authored prose outside the generated region")
+	}
+	if strings.Contains(text, "old generated fields") {
+		t.Fatal("projection retained stale generated field content")
+	}
+}
+
+func TestProjectRuntimeAndDocumentationOutputsSupportForwardFieldEvolution(t *testing.T) {
+	fields := append(factoryruntime.JavaScriptChildFieldDescriptors(), factoryruntime.JavaScriptChildFieldDescriptor{
+		Name: "futureField", JSONType: "string",
+	})
+
+	catalog, err := ProjectRuntimeCatalog([]byte(minimalCatalog), fields)
+	if err != nil {
+		t.Fatalf("ProjectRuntimeCatalog() error = %v", err)
+	}
+	if !strings.Contains(string(catalog), `"futureField"`) {
+		t.Fatal("projected catalog omitted forward-evolved futureField")
+	}
+
+	documentation, err := ProjectJavaScriptWorkflowReference([]byte(documentationFixture), fields)
+	if err != nil {
+		t.Fatalf("ProjectJavaScriptWorkflowReference() error = %v", err)
+	}
+	if !strings.Contains(string(documentation), "| `futureField` | `string` | optional |") {
+		t.Fatalf("projected documentation omitted forward-evolved futureField:\n%s", documentation)
+	}
+}
+
+func TestProjectJavaScriptWorkflowReferenceIsDeterministic(t *testing.T) {
+	fields := factoryruntime.JavaScriptChildFieldDescriptors()
+	first, err := ProjectJavaScriptWorkflowReference([]byte(documentationFixture), fields)
+	if err != nil {
+		t.Fatalf("first projection error = %v", err)
+	}
+	second, err := ProjectJavaScriptWorkflowReference([]byte(documentationFixture), fields)
+	if err != nil {
+		t.Fatalf("second projection error = %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatal("repeated documentation projection changed bytes")
+	}
+}
+
+func TestProjectJavaScriptWorkflowReferenceRejectsInvalidMarkers(t *testing.T) {
+	tests := []struct {
+		name       string
+		document   string
+		wantErrors []string
+	}{
+		{
+			name:       "missing end marker",
+			document:   "before\n" + AgentRunFieldsStartMarker + "\nold\n",
+			wantErrors: []string{"exactly one", AgentRunFieldsEndMarker, "make contracts-generate"},
+		},
+		{
+			name:       "reversed markers",
+			document:   "before\n" + AgentRunFieldsEndMarker + "\nold\n" + AgentRunFieldsStartMarker + "\n",
+			wantErrors: []string{"invalid generated agent.run marker order"},
+		},
+		{
+			name:       "marker is not on its own line",
+			document:   "before " + AgentRunFieldsStartMarker + "\nold\n" + AgentRunFieldsEndMarker + "\n",
+			wantErrors: []string{"invalid generated agent.run start marker line", AgentRunFieldsStartMarker},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ProjectJavaScriptWorkflowReference([]byte(test.document), factoryruntime.JavaScriptChildFieldDescriptors())
+			if err == nil {
+				t.Fatal("projection succeeded for invalid marker input")
+			}
+			for _, want := range test.wantErrors {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error = %q, want substring %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateJavaScriptWorkflowReferenceWritesOnlyProjectedRegion(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, filepath.FromSlash(JavaScriptWorkflowReferencePath))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create docs directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(documentationFixture), 0o644); err != nil {
+		t.Fatalf("write docs fixture: %v", err)
+	}
+
+	if err := GenerateJavaScriptWorkflowReference(root); err != nil {
+		t.Fatalf("GenerateJavaScriptWorkflowReference() error = %v", err)
+	}
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read generated docs: %v", err)
+	}
+	if err := GenerateJavaScriptWorkflowReference(root); err != nil {
+		t.Fatalf("second GenerateJavaScriptWorkflowReference() error = %v", err)
+	}
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read second generated docs: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatal("repeated file generation changed bytes")
+	}
+	if !strings.Contains(string(first), "| `resourceId` | `string` | optional |") {
+		t.Fatal("file generation did not project the runtime resourceId field")
+	}
+}

--- a/internal/javascriptcontract/generate.go
+++ b/internal/javascriptcontract/generate.go
@@ -1,0 +1,335 @@
+// Package javascriptcontract projects the runtime-owned agent.run descriptor
+// into the published JavaScript runtime catalog.
+package javascriptcontract
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+const RuntimeCatalogPath = "contracts/javascript/runtime-api.json"
+
+// GenerateRuntimeCatalog replaces the agent.run schema projection with the
+// current runtime descriptor while preserving the catalog's hand-authored
+// symbols and explanatory metadata.
+func GenerateRuntimeCatalog(catalog []byte) ([]byte, error) {
+	return ProjectRuntimeCatalog(catalog, factoryruntime.JavaScriptChildFieldDescriptors())
+}
+
+// ProjectRuntimeCatalog projects fields into a catalog. The explicit fields
+// parameter keeps forward-evolution tests independent from filesystem state
+// while production generation always supplies the runtime-owned descriptor.
+func ProjectRuntimeCatalog(catalog []byte, fields []factoryruntime.JavaScriptChildFieldDescriptor) ([]byte, error) {
+	var document map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(catalog))
+	decoder.UseNumber()
+	if err := decoder.Decode(&document); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", RuntimeCatalogPath, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("decode %s: trailing JSON value", RuntimeCatalogPath)
+		}
+		return nil, fmt.Errorf("decode %s: trailing content: %w", RuntimeCatalogPath, err)
+	}
+
+	if err := validateFields(fields); err != nil {
+		return nil, err
+	}
+	if _, err := agentRunSchema(document); err != nil {
+		return nil, err
+	}
+	properties, err := marshalProperties(fields)
+	if err != nil {
+		return nil, err
+	}
+	required := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if field.Required {
+			required = append(required, field.Name)
+		}
+	}
+	requiredPayload, err := json.MarshalIndent(required, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode generated required fields: %w", err)
+	}
+
+	propertyRange, err := jsonPathValueRange(catalog, "properties")
+	if err != nil {
+		return nil, err
+	}
+	requiredRange, err := jsonPathValueRange(catalog, "required")
+	if err != nil {
+		return nil, err
+	}
+	replacements := []jsonReplacement{
+		{start: propertyRange.valueStart, end: propertyRange.valueEnd, payload: indentJSON(properties, propertyRange.keyIndent)},
+		{start: requiredRange.valueStart, end: requiredRange.valueEnd, payload: indentJSON(requiredPayload, requiredRange.keyIndent)},
+	}
+	sort.Slice(replacements, func(left, right int) bool {
+		return replacements[left].start > replacements[right].start
+	})
+	projected := bytes.Clone(catalog)
+	for _, replacement := range replacements {
+		projected = append(projected[:replacement.start], append(replacement.payload, projected[replacement.end:]...)...)
+	}
+	return projected, nil
+}
+
+func agentRunSchema(document map[string]any) (map[string]any, error) {
+	sharedSchemas, ok := document["sharedSchemas"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s is missing object /sharedSchemas", RuntimeCatalogPath)
+	}
+	agentRun, ok := sharedSchemas["javascript.schema.agent_run_spec"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s is missing object /sharedSchemas/javascript.schema.agent_run_spec", RuntimeCatalogPath)
+	}
+	schema, ok := agentRun["schema"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s is missing object /sharedSchemas/javascript.schema.agent_run_spec/schema", RuntimeCatalogPath)
+	}
+	return schema, nil
+}
+
+func validateFields(fields []factoryruntime.JavaScriptChildFieldDescriptor) error {
+	if len(fields) == 0 {
+		return fmt.Errorf("agent.run runtime descriptor is empty")
+	}
+	seen := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		if field.Name == "" {
+			return fmt.Errorf("agent.run runtime descriptor contains an empty field name")
+		}
+		if _, exists := seen[field.Name]; exists {
+			return fmt.Errorf("agent.run runtime descriptor contains duplicate field %q", field.Name)
+		}
+		seen[field.Name] = struct{}{}
+		switch field.JSONType {
+		case "string", "boolean", "object":
+		default:
+			return fmt.Errorf("agent.run runtime descriptor field %q has unsupported JSON type %q", field.Name, field.JSONType)
+		}
+	}
+	return nil
+}
+
+type jsonValueRange struct {
+	valueStart int
+	valueEnd   int
+	keyIndent  int
+}
+
+type jsonReplacement struct {
+	start   int
+	end     int
+	payload []byte
+}
+
+func jsonPathValueRange(document []byte, leaf string) (jsonValueRange, error) {
+	path := []string{"sharedSchemas", "javascript.schema.agent_run_spec", "schema", leaf}
+	objectStart := skipJSONWhitespace(document, 0)
+	for _, segment := range path {
+		rangeValue, err := findObjectMember(document, objectStart, segment)
+		if err != nil {
+			return jsonValueRange{}, fmt.Errorf("%s cannot locate /%s: %w", RuntimeCatalogPath, joinJSONPath(path), err)
+		}
+		if segment == leaf {
+			return rangeValue, nil
+		}
+		objectStart = skipJSONWhitespace(document, rangeValue.valueStart)
+		if objectStart >= len(document) || document[objectStart] != '{' {
+			return jsonValueRange{}, fmt.Errorf("%s path segment %q is not an object", RuntimeCatalogPath, segment)
+		}
+	}
+	return jsonValueRange{}, fmt.Errorf("%s cannot locate generated field %q", RuntimeCatalogPath, leaf)
+}
+
+func findObjectMember(document []byte, objectStart int, wanted string) (jsonValueRange, error) {
+	if objectStart >= len(document) || document[objectStart] != '{' {
+		return jsonValueRange{}, fmt.Errorf("expected object")
+	}
+	position := skipJSONWhitespace(document, objectStart+1)
+	if position < len(document) && document[position] == '}' {
+		return jsonValueRange{}, fmt.Errorf("member %q is missing", wanted)
+	}
+	for position < len(document) {
+		keyStart := position
+		keyEnd, err := scanJSONString(document, keyStart)
+		if err != nil {
+			return jsonValueRange{}, err
+		}
+		var key string
+		if err := json.Unmarshal(document[keyStart:keyEnd], &key); err != nil {
+			return jsonValueRange{}, fmt.Errorf("decode member name: %w", err)
+		}
+		position = skipJSONWhitespace(document, keyEnd)
+		if position >= len(document) || document[position] != ':' {
+			return jsonValueRange{}, fmt.Errorf("member %q is missing a colon", key)
+		}
+		valueStart := skipJSONWhitespace(document, position+1)
+		valueEnd, err := scanJSONValue(document, valueStart)
+		if err != nil {
+			return jsonValueRange{}, err
+		}
+		if key == wanted {
+			return jsonValueRange{
+				valueStart: valueStart,
+				valueEnd:   valueEnd,
+				keyIndent:  lineIndent(document, keyStart),
+			}, nil
+		}
+		position = skipJSONWhitespace(document, valueEnd)
+		if position >= len(document) || document[position] == '}' {
+			break
+		}
+		if document[position] != ',' {
+			return jsonValueRange{}, fmt.Errorf("member %q is missing a comma", key)
+		}
+		position = skipJSONWhitespace(document, position+1)
+	}
+	return jsonValueRange{}, fmt.Errorf("member %q is missing", wanted)
+}
+
+func scanJSONString(document []byte, start int) (int, error) {
+	if start >= len(document) || document[start] != '"' {
+		return 0, fmt.Errorf("expected JSON string")
+	}
+	escaped := false
+	for position := start + 1; position < len(document); position++ {
+		switch {
+		case escaped:
+			escaped = false
+		case document[position] == '\\':
+			escaped = true
+		case document[position] == '"':
+			return position + 1, nil
+		}
+	}
+	return 0, fmt.Errorf("unterminated JSON string")
+}
+
+func scanJSONValue(document []byte, start int) (int, error) {
+	if start >= len(document) {
+		return 0, fmt.Errorf("missing JSON value")
+	}
+	if document[start] == '"' {
+		return scanJSONString(document, start)
+	}
+	if document[start] == '{' || document[start] == '[' {
+		opening := document[start]
+		closing := byte('}')
+		if opening == '[' {
+			closing = ']'
+		}
+		depth := 0
+		inString := false
+		escaped := false
+		for position := start; position < len(document); position++ {
+			character := document[position]
+			if inString {
+				if escaped {
+					escaped = false
+				} else if character == '\\' {
+					escaped = true
+				} else if character == '"' {
+					inString = false
+				}
+				continue
+			}
+			switch character {
+			case '"':
+				inString = true
+			case opening:
+				depth++
+			case closing:
+				depth--
+				if depth == 0 {
+					return position + 1, nil
+				}
+			}
+		}
+		return 0, fmt.Errorf("unterminated JSON composite value")
+	}
+	position := start
+	for position < len(document) {
+		character := document[position]
+		if character == ',' || character == '}' || character == ']' || character == ' ' || character == '\n' || character == '\r' || character == '\t' {
+			break
+		}
+		position++
+	}
+	return position, nil
+}
+
+func skipJSONWhitespace(document []byte, start int) int {
+	for start < len(document) {
+		switch document[start] {
+		case ' ', '\n', '\r', '\t':
+			start++
+		default:
+			return start
+		}
+	}
+	return start
+}
+
+func lineIndent(document []byte, position int) int {
+	lineStart := bytes.LastIndexByte(document[:position], '\n') + 1
+	indent := 0
+	for lineStart+indent < len(document) && (document[lineStart+indent] == ' ' || document[lineStart+indent] == '\t') {
+		indent++
+	}
+	return indent
+}
+
+func indentJSON(payload []byte, indent int) []byte {
+	if indent == 0 || !bytes.Contains(payload, []byte{'\n'}) {
+		return payload
+	}
+	prefix := bytes.Repeat([]byte(" "), indent)
+	return bytes.ReplaceAll(payload, []byte{'\n'}, append([]byte{'\n'}, prefix...))
+}
+
+func marshalProperties(fields []factoryruntime.JavaScriptChildFieldDescriptor) ([]byte, error) {
+	var result bytes.Buffer
+	result.WriteString("{")
+	for index, field := range fields {
+		name, err := json.Marshal(field.Name)
+		if err != nil {
+			return nil, fmt.Errorf("encode field name %q: %w", field.Name, err)
+		}
+		if index == 0 {
+			result.WriteString("\n  ")
+		} else {
+			result.WriteString(",\n  ")
+		}
+		result.Write(name)
+		result.WriteString(": {\n    \"type\": ")
+		typeName, err := json.Marshal(field.JSONType)
+		if err != nil {
+			return nil, fmt.Errorf("encode JSON type for %q: %w", field.Name, err)
+		}
+		result.Write(typeName)
+		result.WriteString("\n  }")
+	}
+	if len(fields) > 0 {
+		result.WriteString("\n")
+	}
+	result.WriteString("}")
+	return result.Bytes(), nil
+}
+
+func joinJSONPath(path []string) string {
+	result := ""
+	for _, segment := range path {
+		result += "/" + segment
+	}
+	return result
+}

--- a/internal/javascriptcontract/generate.go
+++ b/internal/javascriptcontract/generate.go
@@ -116,6 +116,19 @@ func validateFields(fields []factoryruntime.JavaScriptChildFieldDescriptor) erro
 		default:
 			return fmt.Errorf("agent.run runtime descriptor field %q has unsupported JSON type %q", field.Name, field.JSONType)
 		}
+		seenEnums := make(map[string]struct{}, len(field.Enum))
+		for _, allowed := range field.Enum {
+			if allowed == "" {
+				return fmt.Errorf("agent.run runtime descriptor field %q contains an empty enum value", field.Name)
+			}
+			if _, exists := seenEnums[allowed]; exists {
+				return fmt.Errorf("agent.run runtime descriptor field %q contains duplicate enum value %q", field.Name, allowed)
+			}
+			seenEnums[allowed] = struct{}{}
+		}
+		if len(field.Enum) > 0 && field.JSONType != "string" {
+			return fmt.Errorf("agent.run runtime descriptor field %q cannot declare enum values for JSON type %q", field.Name, field.JSONType)
+		}
 	}
 	return nil
 }
@@ -317,6 +330,22 @@ func marshalProperties(fields []factoryruntime.JavaScriptChildFieldDescriptor) (
 			return nil, fmt.Errorf("encode JSON type for %q: %w", field.Name, err)
 		}
 		result.Write(typeName)
+		if len(field.Enum) > 0 {
+			result.WriteString(",\n    \"enum\": [")
+			for enumIndex, allowed := range field.Enum {
+				encoded, err := json.Marshal(allowed)
+				if err != nil {
+					return nil, fmt.Errorf("encode enum value for %q: %w", field.Name, err)
+				}
+				if enumIndex == 0 {
+					result.WriteString("\n      ")
+				} else {
+					result.WriteString(",\n      ")
+				}
+				result.Write(encoded)
+			}
+			result.WriteString("\n    ]")
+		}
 		result.WriteString("\n  }")
 	}
 	if len(fields) > 0 {

--- a/internal/javascriptcontract/generate.go
+++ b/internal/javascriptcontract/generate.go
@@ -129,6 +129,9 @@ func validateFields(fields []factoryruntime.JavaScriptChildFieldDescriptor) erro
 		if len(field.Enum) > 0 && field.JSONType != "string" {
 			return fmt.Errorf("agent.run runtime descriptor field %q cannot declare enum values for JSON type %q", field.Name, field.JSONType)
 		}
+		if field.AdditionalProperties != nil && field.JSONType != "object" {
+			return fmt.Errorf("agent.run runtime descriptor field %q cannot declare additionalProperties for JSON type %q", field.Name, field.JSONType)
+		}
 	}
 	return nil
 }
@@ -330,6 +333,14 @@ func marshalProperties(fields []factoryruntime.JavaScriptChildFieldDescriptor) (
 			return nil, fmt.Errorf("encode JSON type for %q: %w", field.Name, err)
 		}
 		result.Write(typeName)
+		if field.AdditionalProperties != nil {
+			result.WriteString(",\n    \"additionalProperties\": ")
+			additionalProperties, err := json.Marshal(*field.AdditionalProperties)
+			if err != nil {
+				return nil, fmt.Errorf("encode additionalProperties for %q: %w", field.Name, err)
+			}
+			result.Write(additionalProperties)
+		}
 		if len(field.Enum) > 0 {
 			result.WriteString(",\n    \"enum\": [")
 			for enumIndex, allowed := range field.Enum {

--- a/internal/javascriptcontract/generate_test.go
+++ b/internal/javascriptcontract/generate_test.go
@@ -37,6 +37,11 @@ func TestGenerateRuntimeCatalogProjectsEveryRuntimeField(t *testing.T) {
 				t.Errorf("projected field %q enum = %#v, want %#v", descriptor.Name, projected["enum"], wantEnum)
 			}
 		}
+		if descriptor.AdditionalProperties != nil {
+			if got := projected["additionalProperties"]; got != *descriptor.AdditionalProperties {
+				t.Errorf("projected field %q additionalProperties = %#v, want %t", descriptor.Name, got, *descriptor.AdditionalProperties)
+			}
+		}
 	}
 	required := projectedRequired(t, payload)
 	if !reflect.DeepEqual(required, []any{"prompt"}) {

--- a/internal/javascriptcontract/generate_test.go
+++ b/internal/javascriptcontract/generate_test.go
@@ -28,6 +28,15 @@ func TestGenerateRuntimeCatalogProjectsEveryRuntimeField(t *testing.T) {
 		if projected["type"] != descriptor.JSONType {
 			t.Errorf("projected field %q type = %#v, want %q", descriptor.Name, projected["type"], descriptor.JSONType)
 		}
+		if len(descriptor.Enum) > 0 {
+			wantEnum := make([]any, len(descriptor.Enum))
+			for index, allowed := range descriptor.Enum {
+				wantEnum[index] = allowed
+			}
+			if !reflect.DeepEqual(projected["enum"], wantEnum) {
+				t.Errorf("projected field %q enum = %#v, want %#v", descriptor.Name, projected["enum"], wantEnum)
+			}
+		}
 	}
 	required := projectedRequired(t, payload)
 	if !reflect.DeepEqual(required, []any{"prompt"}) {

--- a/internal/javascriptcontract/generate_test.go
+++ b/internal/javascriptcontract/generate_test.go
@@ -1,0 +1,96 @@
+package javascriptcontract
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+)
+
+const minimalCatalog = `{"sharedSchemas":{"javascript.schema.agent_run_spec":{"schema":{"type":"object","additionalProperties":false,"properties":{"prompt":{"type":"string"}},"required":["prompt"]}}}}`
+
+func TestGenerateRuntimeCatalogProjectsEveryRuntimeField(t *testing.T) {
+	payload, err := GenerateRuntimeCatalog([]byte(minimalCatalog))
+	if err != nil {
+		t.Fatalf("GenerateRuntimeCatalog() error = %v", err)
+	}
+	fields := projectedFields(t, payload)
+	want := factoryruntime.JavaScriptChildFieldDescriptors()
+	if len(fields) != len(want) {
+		t.Fatalf("projected field count = %d, want %d", len(fields), len(want))
+	}
+	for _, descriptor := range want {
+		projected, ok := fields[descriptor.Name].(map[string]any)
+		if !ok {
+			t.Fatalf("projected field %q = %#v, want object", descriptor.Name, fields[descriptor.Name])
+		}
+		if projected["type"] != descriptor.JSONType {
+			t.Errorf("projected field %q type = %#v, want %q", descriptor.Name, projected["type"], descriptor.JSONType)
+		}
+	}
+	required := projectedRequired(t, payload)
+	if !reflect.DeepEqual(required, []any{"prompt"}) {
+		t.Fatalf("required = %#v, want [prompt]", required)
+	}
+}
+
+func TestProjectRuntimeCatalogSupportsForwardFieldEvolution(t *testing.T) {
+	fields := factoryruntime.JavaScriptChildFieldDescriptors()
+	fields = append(fields, factoryruntime.JavaScriptChildFieldDescriptor{
+		Name: "futureField", JSONType: "string",
+	})
+	payload, err := ProjectRuntimeCatalog([]byte(minimalCatalog), fields)
+	if err != nil {
+		t.Fatalf("ProjectRuntimeCatalog() error = %v", err)
+	}
+	projected := projectedFields(t, payload)
+	if _, ok := projected["futureField"]; !ok {
+		t.Fatalf("projected fields = %#v, want futureField", projected)
+	}
+}
+
+func TestProjectRuntimeCatalogIsDeterministic(t *testing.T) {
+	first, err := GenerateRuntimeCatalog([]byte(minimalCatalog))
+	if err != nil {
+		t.Fatalf("first projection error = %v", err)
+	}
+	second, err := GenerateRuntimeCatalog([]byte(minimalCatalog))
+	if err != nil {
+		t.Fatalf("second projection error = %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatalf("repeated projection changed bytes")
+	}
+}
+
+func TestProjectRuntimeCatalogRejectsMissingSchema(t *testing.T) {
+	_, err := GenerateRuntimeCatalog([]byte(`{"sharedSchemas":{}}`))
+	if err == nil || err.Error() != "contracts/javascript/runtime-api.json is missing object /sharedSchemas/javascript.schema.agent_run_spec" {
+		t.Fatalf("error = %v, want actionable missing schema error", err)
+	}
+}
+
+func projectedFields(t *testing.T, payload []byte) map[string]any {
+	t.Helper()
+	var document map[string]any
+	if err := json.Unmarshal(payload, &document); err != nil {
+		t.Fatalf("decode projected catalog: %v", err)
+	}
+	shared := document["sharedSchemas"].(map[string]any)
+	agentRun := shared["javascript.schema.agent_run_spec"].(map[string]any)
+	schema := agentRun["schema"].(map[string]any)
+	return schema["properties"].(map[string]any)
+}
+
+func projectedRequired(t *testing.T, payload []byte) []any {
+	t.Helper()
+	var document map[string]any
+	if err := json.Unmarshal(payload, &document); err != nil {
+		t.Fatalf("decode projected catalog: %v", err)
+	}
+	shared := document["sharedSchemas"].(map[string]any)
+	agentRun := shared["javascript.schema.agent_run_spec"].(map[string]any)
+	schema := agentRun["schema"].(map[string]any)
+	return schema["required"].([]any)
+}

--- a/packages/api/generated/javascript/runtime-api.json
+++ b/packages/api/generated/javascript/runtime-api.json
@@ -221,6 +221,9 @@
           "preset": {
             "type": "string"
           },
+          "executorProvider": {
+            "type": "string"
+          },
           "modelProvider": {
             "type": "string"
           },
@@ -228,6 +231,9 @@
             "type": "string"
           },
           "reasoningEffort": {
+            "type": "string"
+          },
+          "resourceId": {
             "type": "string"
           },
           "schema": {

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -61,7 +61,7 @@
       "path": "generated/cli/commands.json"
     },
     "generated.javascript.runtime-api": {
-      "artifactHash": "32de58ddd1e50e60330c6f8317b6a54633a6ba419ceaf28af49a389a545accab",
+      "artifactHash": "33d62b4b2daca14a9fb2401ded49463fcf663e25302e46ddc2711c288d5ae4c1",
       "documentation": {
         "documentation": {
           "description": {
@@ -78,7 +78,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.javascript.runtime-api",
-        "sourceHash": "32de58ddd1e50e60330c6f8317b6a54633a6ba419ceaf28af49a389a545accab",
+        "sourceHash": "33d62b4b2daca14a9fb2401ded49463fcf663e25302e46ddc2711c288d5ae4c1",
         "visibility": "public"
       },
       "family": "javascript",

--- a/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_pipeline_policy_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/javascript/runtime/host_pipeline_policy_test.go
@@ -882,3 +882,51 @@ func TestRun_ParallelFakeChildren_RepresentsFailedChildExplicitly(t *testing.T) 
 		t.Fatal("failed child should not emit COMPLETED child_dispatch record")
 	}
 }
+
+func TestRun_AgentRunPermissionsResolveCanonicalValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		source     string
+		wantBypass bool
+		permission factory.JavaScriptChildPermission
+	}{
+		{
+			name:       "static default",
+			source:     `return agent.run({ prompt: "review", permissions: "DEFAULT" });`,
+			permission: factory.JavaScriptChildPermissionDefault,
+		},
+		{
+			name:       "dynamic skip",
+			source:     `const child = { prompt: "review", permissions: "SKIP_PERMISSIONS" }; return agent.run(child);`,
+			wantBypass: true,
+			permission: factory.JavaScriptChildPermissionSkipPermissions,
+		},
+		{
+			name:       "omitted",
+			source:     `return agent.run({ prompt: "review" });`,
+			permission: factory.JavaScriptChildPermissionDefault,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stub := &stubChildExecutor{mode: stubChildExecutionMode}
+			outcome, err := runtimeWorkflows.Run(context.Background(), factory.JavaScriptRuntimeRequest{
+				Source: test.source, SourceRef: "inline", SessionID: "permissions-resolution-" + test.name,
+				Policy: workflowpolicy.DefaultEffectivePolicy(),
+			}, factory.JavaScriptRuntimeHooks{NewChildExecutor: func(string, factory.JavaScriptChildRecordSink, workflowpolicy.EffectivePolicy) factory.JavaScriptChildExecutor {
+				return stub
+			}})
+			if err != nil || !outcome.OK {
+				t.Fatalf("Run() outcome = %#v, error = %v", outcome, err)
+			}
+			requests := stub.executionRequests()
+			if len(requests) != 1 {
+				t.Fatalf("executor request count = %d, want 1", len(requests))
+			}
+			request := requests[0]
+			if request.SkipPermissions != test.wantBypass || request.Permissions != test.permission {
+				t.Fatalf("executor request = %#v, want permission=%q bypass=%v", request, test.permission, test.wantBypass)
+			}
+		})
+	}
+}

--- a/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract/javascript_child.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract/javascript_child.go
@@ -32,26 +32,31 @@ const (
 	JavaScriptChildPermissionSkipPermissions JavaScriptChildPermission = "SKIP_PERMISSIONS"
 )
 
-var supportedFields = []string{
-	FieldPrompt,
-	FieldLabel,
-	FieldPreset,
-	FieldExecutorProvider,
-	FieldModelProvider,
-	FieldModel,
-	FieldReasoningEffort,
-	FieldResourceID,
-	FieldSchema,
-	FieldPermissions,
+// JavaScriptChildFieldDescriptor is the runtime-owned contract for one
+// agent.run spec property. JSONType is the JSON value type accepted by the
+// request normalizer and emitted by generated runtime projections.
+type JavaScriptChildFieldDescriptor struct {
+	Name     string
+	JSONType string
+	Required bool
+	Enum     []string
 }
 
-var supportedFieldSet = func() map[string]struct{} {
-	set := make(map[string]struct{}, len(supportedFields))
-	for _, field := range supportedFields {
-		set[field] = struct{}{}
-	}
-	return set
-}()
+var javaScriptChildFieldDescriptors = [...]JavaScriptChildFieldDescriptor{
+	{Name: FieldPrompt, JSONType: "string", Required: true},
+	{Name: FieldLabel, JSONType: "string"},
+	{Name: FieldPreset, JSONType: "string"},
+	{Name: FieldExecutorProvider, JSONType: "string"},
+	{Name: FieldModelProvider, JSONType: "string"},
+	{Name: FieldModel, JSONType: "string"},
+	{Name: FieldReasoningEffort, JSONType: "string"},
+	{Name: FieldResourceID, JSONType: "string"},
+	{Name: FieldSchema, JSONType: "object"},
+	{Name: FieldPermissions, JSONType: "string", Enum: []string{
+		string(JavaScriptChildPermissionDefault),
+		string(JavaScriptChildPermissionSkipPermissions),
+	}},
+}
 
 // Spec is the normalized supported argument set for one agent.run call.
 type JavaScriptChildSpec struct {
@@ -69,13 +74,31 @@ type JavaScriptChildSpec struct {
 
 // SupportedFields returns the canonical beta agent.run field names.
 func JavaScriptChildSupportedFields() []string {
-	return append([]string(nil), supportedFields...)
+	fields := make([]string, 0, len(javaScriptChildFieldDescriptors))
+	for _, descriptor := range javaScriptChildFieldDescriptors {
+		fields = append(fields, descriptor.Name)
+	}
+	return fields
+}
+
+// JavaScriptChildFieldDescriptors returns a detached copy of the immutable
+// runtime field contract for generation and other representation projections.
+func JavaScriptChildFieldDescriptors() []JavaScriptChildFieldDescriptor {
+	fields := append([]JavaScriptChildFieldDescriptor(nil), javaScriptChildFieldDescriptors[:]...)
+	for index := range fields {
+		fields[index].Enum = append([]string(nil), fields[index].Enum...)
+	}
+	return fields
 }
 
 // IsSupportedField reports whether name belongs to the beta agent.run contract.
 func IsJavaScriptChildSupportedField(name string) bool {
-	_, ok := supportedFieldSet[name]
-	return ok
+	for _, descriptor := range javaScriptChildFieldDescriptors {
+		if descriptor.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 // Normalize validates and trims one dynamically constructed agent.run object.
@@ -91,42 +114,72 @@ func NormalizeJavaScriptChild(value map[string]any) (JavaScriptChildSpec, error)
 		return JavaScriptChildSpec{}, unsupportedJavaScriptChildFieldError(unknown[0])
 	}
 
-	prompt, err := requiredString(value, FieldPrompt)
-	if err != nil {
-		return JavaScriptChildSpec{}, err
-	}
-	optional := make(map[string]string, len(supportedFields)-3)
-	for _, field := range supportedFields {
-		switch field {
-		case FieldPrompt, FieldSchema, FieldPermissions:
-			continue
-		default:
-			optional[field], err = optionalString(value, field)
-			if err != nil {
-				return JavaScriptChildSpec{}, err
-			}
-		}
-	}
-	schema, err := optionalSchema(value, FieldSchema)
-	if err != nil {
-		return JavaScriptChildSpec{}, err
-	}
-	permissions, err := optionalPermission(value, FieldPermissions)
+	fields, err := normalizeJavaScriptChildFields(value)
 	if err != nil {
 		return JavaScriptChildSpec{}, err
 	}
 	return JavaScriptChildSpec{
-		Prompt:           prompt,
-		Label:            optional[FieldLabel],
-		Preset:           optional[FieldPreset],
-		ExecutorProvider: optional[FieldExecutorProvider],
-		ModelProvider:    optional[FieldModelProvider],
-		Model:            optional[FieldModel],
-		ReasoningEffort:  optional[FieldReasoningEffort],
-		ResourceID:       optional[FieldResourceID],
-		Schema:           schema,
-		Permissions:      permissions,
+		Prompt:           fields.strings[FieldPrompt],
+		Label:            fields.strings[FieldLabel],
+		Preset:           fields.strings[FieldPreset],
+		ExecutorProvider: fields.strings[FieldExecutorProvider],
+		ModelProvider:    fields.strings[FieldModelProvider],
+		Model:            fields.strings[FieldModel],
+		ReasoningEffort:  fields.strings[FieldReasoningEffort],
+		ResourceID:       fields.strings[FieldResourceID],
+		Schema:           fields.schema,
+		Permissions:      fields.permissions,
 	}, nil
+}
+
+type normalizedJavaScriptChildFields struct {
+	strings     map[string]string
+	schema      map[string]any
+	permissions JavaScriptChildPermission
+}
+
+func normalizeJavaScriptChildFields(value map[string]any) (normalizedJavaScriptChildFields, error) {
+	fields := normalizedJavaScriptChildFields{
+		strings:     make(map[string]string, len(javaScriptChildFieldDescriptors)),
+		permissions: JavaScriptChildPermissionDefault,
+	}
+	for _, descriptor := range javaScriptChildFieldDescriptors {
+		switch descriptor.JSONType {
+		case "string":
+			if descriptor.Name == FieldPermissions {
+				var err error
+				fields.permissions, err = optionalPermission(value, descriptor.Name)
+				if err != nil {
+					return normalizedJavaScriptChildFields{}, err
+				}
+				continue
+			}
+			normalized, err := normalizeJavaScriptChildString(value, descriptor)
+			if err != nil {
+				return normalizedJavaScriptChildFields{}, err
+			}
+			fields.strings[descriptor.Name] = normalized
+		case "object":
+			if descriptor.Name != FieldSchema {
+				return normalizedJavaScriptChildFields{}, fmt.Errorf("agent.run() contract has unsupported object field %q", descriptor.Name)
+			}
+			var err error
+			fields.schema, err = optionalSchema(value, descriptor.Name)
+			if err != nil {
+				return normalizedJavaScriptChildFields{}, err
+			}
+		default:
+			return normalizedJavaScriptChildFields{}, fmt.Errorf("agent.run() contract has unsupported JSON type %q for %q", descriptor.JSONType, descriptor.Name)
+		}
+	}
+	return fields, nil
+}
+
+func normalizeJavaScriptChildString(value map[string]any, descriptor JavaScriptChildFieldDescriptor) (string, error) {
+	if descriptor.Required {
+		return requiredString(value, descriptor.Name)
+	}
+	return optionalString(value, descriptor.Name)
 }
 
 const childOutputSchemaURL = "https://schemas.portpowered.com/you/runtime/child-output-schema.json"

--- a/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract/javascript_child.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract/javascript_child.go
@@ -36,11 +36,14 @@ const (
 // agent.run spec property. JSONType is the JSON value type accepted by the
 // request normalizer and emitted by generated runtime projections.
 type JavaScriptChildFieldDescriptor struct {
-	Name     string
-	JSONType string
-	Required bool
-	Enum     []string
+	Name                 string
+	JSONType             string
+	Required             bool
+	Enum                 []string
+	AdditionalProperties *bool
 }
+
+var schemaAdditionalProperties = false
 
 var javaScriptChildFieldDescriptors = [...]JavaScriptChildFieldDescriptor{
 	{Name: FieldPrompt, JSONType: "string", Required: true},
@@ -51,7 +54,7 @@ var javaScriptChildFieldDescriptors = [...]JavaScriptChildFieldDescriptor{
 	{Name: FieldModel, JSONType: "string"},
 	{Name: FieldReasoningEffort, JSONType: "string"},
 	{Name: FieldResourceID, JSONType: "string"},
-	{Name: FieldSchema, JSONType: "object"},
+	{Name: FieldSchema, JSONType: "object", AdditionalProperties: &schemaAdditionalProperties},
 	{Name: FieldPermissions, JSONType: "string", Enum: []string{
 		string(JavaScriptChildPermissionDefault),
 		string(JavaScriptChildPermissionSkipPermissions),
@@ -87,6 +90,10 @@ func JavaScriptChildFieldDescriptors() []JavaScriptChildFieldDescriptor {
 	fields := append([]JavaScriptChildFieldDescriptor(nil), javaScriptChildFieldDescriptors[:]...)
 	for index := range fields {
 		fields[index].Enum = append([]string(nil), fields[index].Enum...)
+		if fields[index].AdditionalProperties != nil {
+			additionalProperties := *fields[index].AdditionalProperties
+			fields[index].AdditionalProperties = &additionalProperties
+		}
 	}
 	return fields
 }

--- a/pkg/services/factory_runtime/javascript_child_contract.go
+++ b/pkg/services/factory_runtime/javascript_child_contract.go
@@ -3,26 +3,29 @@ package factory
 import orchestratorcontract "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/orchestratorcontract"
 
 const (
-	FieldPrompt          = orchestratorcontract.FieldPrompt
-	FieldLabel           = orchestratorcontract.FieldLabel
-	FieldPreset          = orchestratorcontract.FieldPreset
-	FieldModelProvider   = orchestratorcontract.FieldModelProvider
-	FieldModel           = orchestratorcontract.FieldModel
-	FieldReasoningEffort = orchestratorcontract.FieldReasoningEffort
-	FieldResourceID      = orchestratorcontract.FieldResourceID
-	FieldSchema          = orchestratorcontract.FieldSchema
-	FieldPermissions     = orchestratorcontract.FieldPermissions
+	FieldPrompt           = orchestratorcontract.FieldPrompt
+	FieldLabel            = orchestratorcontract.FieldLabel
+	FieldPreset           = orchestratorcontract.FieldPreset
+	FieldExecutorProvider = orchestratorcontract.FieldExecutorProvider
+	FieldModelProvider    = orchestratorcontract.FieldModelProvider
+	FieldModel            = orchestratorcontract.FieldModel
+	FieldReasoningEffort  = orchestratorcontract.FieldReasoningEffort
+	FieldResourceID       = orchestratorcontract.FieldResourceID
+	FieldSchema           = orchestratorcontract.FieldSchema
+	FieldPermissions      = orchestratorcontract.FieldPermissions
 
 	JavaScriptChildPermissionDefault         = orchestratorcontract.JavaScriptChildPermissionDefault
 	JavaScriptChildPermissionSkipPermissions = orchestratorcontract.JavaScriptChildPermissionSkipPermissions
 )
 
 type (
-	JavaScriptChildPermission = orchestratorcontract.JavaScriptChildPermission
-	JavaScriptChildSpec       = orchestratorcontract.JavaScriptChildSpec
+	JavaScriptChildFieldDescriptor = orchestratorcontract.JavaScriptChildFieldDescriptor
+	JavaScriptChildPermission      = orchestratorcontract.JavaScriptChildPermission
+	JavaScriptChildSpec            = orchestratorcontract.JavaScriptChildSpec
 )
 
 var (
+	JavaScriptChildFieldDescriptors        = orchestratorcontract.JavaScriptChildFieldDescriptors
 	JavaScriptChildSupportedFields         = orchestratorcontract.JavaScriptChildSupportedFields
 	IsJavaScriptChildSupportedField        = orchestratorcontract.IsJavaScriptChildSupportedField
 	UnsupportedJavaScriptChildFieldMessage = orchestratorcontract.UnsupportedJavaScriptChildFieldMessage

--- a/pkg/services/factory_runtime/javascript_child_contract_test.go
+++ b/pkg/services/factory_runtime/javascript_child_contract_test.go
@@ -152,6 +152,35 @@ func TestNormalize_AcceptsAndTrimsCanonicalFields(t *testing.T) {
 	}
 }
 
+func TestJavaScriptChildFieldDescriptorIsDetachedAndRuntimeAligned(t *testing.T) {
+	t.Parallel()
+
+	descriptors := factory.JavaScriptChildFieldDescriptors()
+	want := []factory.JavaScriptChildFieldDescriptor{
+		{Name: "prompt", JSONType: "string", Required: true},
+		{Name: "label", JSONType: "string"},
+		{Name: "preset", JSONType: "string"},
+		{Name: "executorProvider", JSONType: "string"},
+		{Name: "modelProvider", JSONType: "string"},
+		{Name: "model", JSONType: "string"},
+		{Name: "reasoningEffort", JSONType: "string"},
+		{Name: "resourceId", JSONType: "string"},
+		{Name: "schema", JSONType: "object"},
+		{Name: "permissions", JSONType: "string", Enum: []string{"DEFAULT", "SKIP_PERMISSIONS"}},
+	}
+	if !reflect.DeepEqual(descriptors, want) {
+		t.Fatalf("JavaScriptChildFieldDescriptors() = %#v, want %#v", descriptors, want)
+	}
+	descriptors[0].Name = "mutated"
+	descriptors[len(descriptors)-1].Enum[0] = "mutated"
+	if got := factory.JavaScriptChildSupportedFields()[0]; got != "prompt" {
+		t.Fatalf("mutating descriptor result changed runtime field name to %q", got)
+	}
+	if got := factory.JavaScriptChildFieldDescriptors()[len(descriptors)-1].Enum[0]; got != "DEFAULT" {
+		t.Fatalf("mutating descriptor result changed runtime enum to %q", got)
+	}
+}
+
 func TestNormalize_ClonesValidSchemaWithoutSharingNestedState(t *testing.T) {
 	t.Parallel()
 	schema := map[string]any{

--- a/pkg/services/factory_runtime/javascript_child_contract_test.go
+++ b/pkg/services/factory_runtime/javascript_child_contract_test.go
@@ -165,7 +165,7 @@ func TestJavaScriptChildFieldDescriptorIsDetachedAndRuntimeAligned(t *testing.T)
 		{Name: "model", JSONType: "string"},
 		{Name: "reasoningEffort", JSONType: "string"},
 		{Name: "resourceId", JSONType: "string"},
-		{Name: "schema", JSONType: "object"},
+		{Name: "schema", JSONType: "object", AdditionalProperties: boolPointer(false)},
 		{Name: "permissions", JSONType: "string", Enum: []string{"DEFAULT", "SKIP_PERMISSIONS"}},
 	}
 	if !reflect.DeepEqual(descriptors, want) {
@@ -179,6 +179,10 @@ func TestJavaScriptChildFieldDescriptorIsDetachedAndRuntimeAligned(t *testing.T)
 	if got := factory.JavaScriptChildFieldDescriptors()[len(descriptors)-1].Enum[0]; got != "DEFAULT" {
 		t.Fatalf("mutating descriptor result changed runtime enum to %q", got)
 	}
+}
+
+func boolPointer(value bool) *bool {
+	return &value
 }
 
 func TestNormalize_ClonesValidSchemaWithoutSharingNestedState(t *testing.T) {


### PR DESCRIPTION
{
  "project": "JS-P7 Generated JavaScript Runtime Contract",
  "branchName": "js-p7-generated-runtime-contract",
  "description": "Generate the shipped JavaScript agent.run JSON contract and its packaged reference documentation from the Go runtime contract, correct the missing executorProvider and resourceId fields, and make required CI reject field-level drift with actionable diagnostics.",
  "context": {
    "customerAsk": "Generate contracts/javascript/runtime-api.json from the Go agent.run contract, project the same field truth into you docs javascript-workflows, add a familiar generated-artifact CI check that names mismatched fields, run make interfaces-all, and reconcile any JS-P2/JS-P4 field-list changes by rebasing and regenerating before the final push.",
    "problem": "The runtime accepts nine agent.run fields, but the shipped JSON artifact omits executorProvider and resourceId. Existing checks can copy that stale authored artifact into the packaged projection without comparing its properties to runtime validation, while the packaged documentation is maintained independently and can drift again.",
    "solution": "Keep an immutable runtime-owned Go descriptor as the single source of field names, JSON types, and requiredness; deterministically generate the canonical JSON artifact, staged package copy, and bounded documentation projection from it; and add a non-mutating Backend Lint drift check with field-specific diagnostics."
  },
  "acceptanceCriteria": [
    "Running canonical contract/interface generation from the current runtime contract produces an agent.run schema with all nine accepted fields, including executorProvider and resourceId, with runtime-aligned types and requiredness; the first generated diff explicitly demonstrates those two corrections.",
    "A fixture-only tenth field added to the Go contract descriptor appears after regeneration in both contracts/javascript/runtime-api.json and the generated agent.run section used by you docs javascript-workflows, without hand-editing either output.",
    "Deleting a generated agent.run field by hand makes the read-only generated-contract check fail deterministically, names the missing field, identifies the stale output and regeneration command, and does not rewrite the repository during the check.",
    "The check runs in the existing generated-artifact/Backend Lint path and uses its familiar generate-then-diff contract; Verification Policy remains a derived result rather than an independently diagnosed failure cause. make interfaces-all is run after rebasing to current origin/main, generated files are produced by the generator rather than hand-merged, and all in-scope output is committed.",
    "Quality gates pass: typecheck/Go compile validation and focused contract, generation, documentation, and packaging tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. docs/internal/baselines/deadcode-baseline.txt is unchanged.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The worker/reviewer cycle continues through those review-owned outcomes until the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "js-p7-generated-runtime-contract-001",
      "title": "Generate the JSON contract from runtime truth",
      "description": "As a JavaScript workflow author, I want the shipped agent.run schema to be generated from the same contract the runtime enforces so that tooling describes every request field I can actually use.",
      "acceptanceCriteria": [
        "The runtime-owned Go descriptor is the single canonical definition of agent.run field names, JSON types, and requiredness used by both request normalization and artifact projection; generation does not parse Go source text or maintain a second independent allowlist.",
        "Generation from the current contract produces exactly the current nine supported properties and adds the previously missing executorProvider and resourceId string properties while preserving prompt as required.",
        "Repeated generation is byte-for-byte deterministic and confines writes to the declared generated contract/package outputs.",
        "make interfaces-all regenerates the canonical contract and staged package projection successfully.",
        "Focused generation and runtime-contract tests cover the nine-field regression and type/requiredness parity.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented the runtime-owned descriptor, normalization parity, deterministic catalog projection, canonical/staged artifact generation, and focused tests. After rebasing current main, the descriptor publishes the nine P7/P4 request fields plus current-main's JS-P2 schema object (ten generated properties total), including executorProvider and resourceId and the DEFAULT/SKIP_PERMISSIONS enum. make interfaces-all completed successfully."
    },
    {
      "id": "js-p7-generated-runtime-contract-002",
      "title": "Project the field contract into packaged docs",
      "description": "As a customer using you docs javascript-workflows, I want the documented agent.run fields to come from runtime truth so that copied workflow requests stay compatible as the contract evolves.",
      "acceptanceCriteria": [
        "The bounded agent.run field presentation in the canonical JavaScript workflow reference is generated from the same runtime-owned descriptor as the JSON artifact; explanatory prose remains hand-authored.",
        "you docs javascript-workflows presents the current supported field names, optionality, and types consistently with the generated JSON contract.",
        "In a fixture proving forward evolution, adding a tenth descriptor field and running generation updates both the JSON artifact and documentation projection without direct edits to either generated region.",
        "Missing or invalid documentation projection inputs fail with an actionable diagnostic rather than producing an empty or partial field list.",
        "The packaged docs smoke and focused projection tests pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added a bounded generated agent.run field table to docs/reference/javascript-workflows.md, wired it into contracts-generate/interfaces-all, and covered runtime/type/requiredness projection, forward evolution, determinism, marker validation, and file generation. The table now follows the rebased descriptor, including the current-main schema object and permissions enum. make docs-reference-smoke and make typecheck pass."
    },
    {
      "id": "js-p7-generated-runtime-contract-003",
      "title": "Reject runtime-contract drift in CI",
      "description": "As a maintainer, I want the required CI path to identify stale JavaScript contract fields so that runtime, artifact, and docs drift cannot merge unnoticed.",
      "acceptanceCriteria": [
        "The generated-contract check computes expected artifact and documentation output without mutating the checkout, compares it with committed output, and exits non-zero on a mismatch.",
        "Removing resourceId or another field from the committed artifact in a test fixture produces a deterministic diagnostic that names that field, the stale output, and the generation command needed to repair it.",
        "Extra artifact fields and stale documentation projections are also rejected with property-specific diagnostics, while aligned outputs pass without noise.",
        "The check runs in the existing Backend Lint/generated-artifact verification path so required CI blocks the PR on drift; it does not add a separate required workflow or treat Verification Policy as an independent root cause.",
        "Focused checker/CLI tests prove success, missing-field, extra-field, docs-drift, determinism, and non-mutation behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added the read-only field-aware catalog/docs projection checker, CLI diagnostics, focused non-mutation/determinism fixtures, and the contracts-check target to Backend Lint LINT_TARGETS. The checker also compares generated object additionalProperties metadata and allowed values. make contracts-check, constrained Backend Lint, contracts-smoke, contract package tests, go vet, and typecheck pass."
    },
    {
      "id": "js-p7-generated-runtime-contract-004",
      "title": "Reconcile concurrent contract changes and release generated outputs",
      "description": "As a maintainer landing JS-P7 alongside JS-P2 and JS-P4, I want final outputs regenerated from current main so that the merged contract includes sibling field-list changes without conflicting ownership or hand-edited artifacts.",
      "acceptanceCriteria": [
        "This lane does not change the worker permissions field, its enum, its allowlist, or docs/internal/baselines/deadcode-baseline.txt; JS-P1 through JS-P4 retain ownership of that surface.",
        "Immediately before the final push, the branch is rebased onto current origin/main, git merge-base origin/main HEAD proves the final head contains that main head, and generators are rerun after the rebase.",
        "If JS-P2 or JS-P4 changed the field list, the committed artifact and docs reflect the rebased Go source automatically; generated conflicts are resolved by regeneration, never by hand-merging generated files.",
        "make interfaces-all output is committed, and the PR description calls out the initial executorProvider and resourceId correction as evidence that generation closed a real drift gap.",
        "Required local quality evidence covers the final rebased head without polling hosted CI after the implementation finish line.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Immediately before the final push, rebased onto current origin/main at caf44eb1, reconciled JS-P2's schema object with the JS-P4 permissions-only contract, reran make interfaces-all and all contract generators, and committed the generated projections. The current descriptor/artifacts/docs publish the nine P7/P4 fields plus schema, preserve the permissions enum and schema additionalProperties metadata, and leave docs/internal/baselines/deadcode-baseline.txt unchanged. Full make test, contracts-smoke, docs-reference-smoke, typecheck, packaged-factory-catalog-check, backend-size, pkg-maint, pkg-file-count, pkg-structure, vet, and contracts-check pass."
    }
  ]
}
