### PR TITLE
cli-run-blocks-on-unbounded-stdin

### DIFF
--- a/docs/reference/batch-inputs.md
+++ b/docs/reference/batch-inputs.md
@@ -244,6 +244,13 @@ Read batch JSON from stdin explicitly:
 you submit batch - < batch.json
 ```
 
+The CLI reads at most 16,777,216 bytes (16 MiB) from an intentional batch
+stdin source, inclusive. This applies to implicit piped stdin, the explicit
+`-` argument, and `--file -`. Exactly 16,777,216 bytes is accepted; a larger
+stream is rejected before batch preparation or the HTTP request. Use a batch
+file for larger input. This is a CLI aggregate stdin bound; each Work's
+independent 65,536-byte `payload` admission limit remains unchanged.
+
 Inline JSON positional (convenient for small batches; shell argument length limits apply):
 
 ```bash

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -246,6 +246,14 @@ you --server http://localhost:7437 worker-sessions stream --worker-session-id <w
 you --server http://localhost:7437 worker-sessions read --worker-session-id <worker-session-id>
 ```
 
+Direct Worker Session stdin is limited to 1,048,576 bytes, inclusive. This
+limit applies to `--execution -` and to non-terminal stdin used for direct
+Worker messages, continuation input, or replacement input.
+
+Input at the limit is accepted. Larger input fails before Worker Session
+admission. Use `--execution FILE`, `--user-message`, or
+`--replacement-message` when the selected command supports those alternatives.
+
 To resume a terminal direct Worker Session, continue it through the server-owned
 Provider Session association. The command reserves a distinct successor and
 returns its lineage after admission; use `--async` to return before terminal

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -81,6 +81,12 @@ Non-interactive stdin is the alternative input source:
 printf '%s\n' 'Review the release notes' | you run --factory ./factory.json
 ```
 
+Intentional declarative-Factory invocation stdin for `--factory` and `--named`
+is limited to 1,048,576 bytes (1 MiB), inclusive. Exactly 1,048,576 bytes is
+accepted. A larger stream fails before Factory execution starts; use
+`--to-file` when a prompt needs more space. This limit applies to the stdin
+source only and does not change the Factory, HTTP, or replay contracts.
+
 Do not supply positional text and stdin together. Factories with an
 `invocationSignature` may instead define named, file-path, repeated, or
 defaulted arguments. Inspect their exact input boundary with

--- a/docs/reference/work.md
+++ b/docs/reference/work.md
@@ -317,6 +317,21 @@ Use the same `--server` base URI and `--session` target as `you work list` and
 `you work show` when verifying work in a non-default factory session. See
 `you docs sessions` for session list, routing tables, and run-mode guidance.
 
+To supply a payload through process stdin, pass `--payload -`:
+
+```bash
+cat request.md | you submit \
+  --name driver-incident-review \
+  --work-type-name task \
+  --payload -
+```
+
+The CLI accepts at most 65,536 bytes from this stdin source, inclusive, for
+both JSON and text payloads. Exactly 65,536 bytes is accepted; a larger stream
+is rejected before the HTTP request is made. Use a payload file when more
+input is required. This stdin bound does not change the Work admission or
+HTTP contract.
+
 ### Human success output
 
 Human-mode stdout (default) includes accepted work metadata and a one-line verify

--- a/docs/reference/work.md
+++ b/docs/reference/work.md
@@ -326,11 +326,13 @@ cat request.md | you submit \
   --payload -
 ```
 
-The CLI accepts at most 65,536 bytes from this stdin source, inclusive, for
-both JSON and text payloads. Exactly 65,536 bytes is accepted; a larger stream
-is rejected before the HTTP request is made. Use a payload file when more
-input is required. This stdin bound does not change the Work admission or
-HTTP contract.
+The CLI reads at most 65,536 source bytes from this stdin source, inclusive,
+and reads one additional sentinel byte only to detect overflow. It then applies
+the same 65,536-byte inclusive boundary to the compact JSON payload that Work
+admission measures. Exactly 65,536 compact JSON bytes is accepted; text that
+expands through JSON escaping past that boundary is rejected before the HTTP
+request is made. Use a payload file when more input is required. This stdin
+bound does not change the Work admission or HTTP contract.
 
 ### Human success output
 

--- a/pkg/root/root_submit_family_compatibility_test.go
+++ b/pkg/root/root_submit_family_compatibility_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -110,6 +111,41 @@ func TestSubmitBatchDocumentedIngressThroughRootBuildProcess(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			runBatchCompatibilityCase(t, test)
 		})
+	}
+}
+
+func TestSubmitBatchOversizedStdinFailsBeforeHTTPThroughRootBuildProcess(t *testing.T) {
+	t.Parallel()
+
+	const maxBatchStdinBytes = 16 * 1024 * 1024
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	reader := &countingRootStdinReader{
+		reader: bytes.NewReader(bytes.Repeat([]byte("x"), maxBatchStdinBytes+1)),
+	}
+	input := submitCompatibilityInputWithReader(
+		t,
+		[]string{"you", "--server", server.URL, "submit", "batch"},
+		reader,
+		false,
+	)
+	err := buildSubmitCompatibilityProcess(t).Execute(input)
+	if err == nil {
+		t.Fatal("Process.Execute(oversized batch stdin) succeeded, want limit error")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("batch stdin exceeds the %d-byte limit", maxBatchStdinBytes)) {
+		t.Fatalf("error = %q, want actionable batch limit", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("HTTP calls = %d, want 0 before overflow rejection", calls.Load())
+	}
+	if reader.bytesRead != maxBatchStdinBytes+1 {
+		t.Fatalf("bytes read = %d, want exactly %d", reader.bytesRead, maxBatchStdinBytes+1)
 	}
 }
 
@@ -310,18 +346,39 @@ func submitCompatibilityInput(
 	stdinIsTTY bool,
 ) Input {
 	t.Helper()
+	return submitCompatibilityInputWithReader(t, args, strings.NewReader(stdin), stdinIsTTY)
+}
+
+func submitCompatibilityInputWithReader(
+	t *testing.T,
+	args []string,
+	stdin io.Reader,
+	stdinIsTTY bool,
+) Input {
+	t.Helper()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	return Input{
 		Args:             args,
 		Env:              homeEnvironment(t.TempDir()),
-		Stdin:            strings.NewReader(stdin),
+		Stdin:            stdin,
 		Stdout:           &stdout,
 		Stderr:           &stderr,
 		Context:          context.Background(),
 		WorkingDirectory: t.TempDir(),
 		StdinIsTTY:       &stdinIsTTY,
 	}
+}
+
+type countingRootStdinReader struct {
+	reader    io.Reader
+	bytesRead int
+}
+
+func (r *countingRootStdinReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.bytesRead += n
+	return n, err
 }
 
 func inputOutput(input Input) string {

--- a/pkg/services/work/transports/cli/submit/batch_input.go
+++ b/pkg/services/work/transports/cli/submit/batch_input.go
@@ -13,6 +13,13 @@ const (
 	batchSourceFile   = "file"
 	batchSourceStdin  = "stdin"
 	batchSourceInline = "inline"
+
+	// maxSubmitBatchStdinBytes is the inclusive aggregate bound for batch JSON
+	// deliberately supplied through process stdin. It leaves room for
+	// multiple Work payloads while keeping a continuous producer bounded at
+	// this CLI boundary; the Work-owned per-payload admission limit remains
+	// the authoritative batch contract.
+	maxSubmitBatchStdinBytes = 16 * 1024 * 1024
 )
 
 type batchResolvedInput struct {
@@ -98,16 +105,38 @@ func resolveBatchFileFlag(cfg BatchConfig, path string) (batchResolvedInput, err
 }
 
 func readBatchStdin(cfg BatchConfig) ([]byte, error) {
-	stdin := cfg.Stdin
-	if stdin == nil {
-		return nil, fmt.Errorf("read batch stdin: process stdin reader is required")
-	}
-	data, err := io.ReadAll(stdin)
+	data, err := readBoundedStdin(
+		cfg.Stdin,
+		maxSubmitBatchStdinBytes,
+		"batch stdin",
+		"use a batch file for larger input",
+	)
 	if err != nil {
-		return nil, fmt.Errorf("read batch stdin: %w", err)
+		return nil, err
 	}
 	if isEmptyBatchInput(data) {
 		return nil, fmt.Errorf("batch stdin input is empty")
+	}
+	return data, nil
+}
+
+// readBoundedStdin reads at most limit plus one byte. The extra byte is an
+// overflow sentinel and is discarded when the inclusive limit is exceeded.
+func readBoundedStdin(stdin io.Reader, limit int, label, overflowGuidance string) ([]byte, error) {
+	if stdin == nil {
+		return nil, fmt.Errorf("read %s: process stdin reader is required", label)
+	}
+	data, err := io.ReadAll(io.LimitReader(stdin, int64(limit)+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", label, err)
+	}
+	if len(data) > limit {
+		return nil, fmt.Errorf(
+			"%s exceeds the %d-byte limit; %s",
+			label,
+			limit,
+			overflowGuidance,
+		)
 	}
 	return data, nil
 }

--- a/pkg/services/work/transports/cli/submit/batch_input_test.go
+++ b/pkg/services/work/transports/cli/submit/batch_input_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"io/fs"
 	"strings"
 	"testing"
@@ -205,6 +207,67 @@ func TestResolveBatchInput_ReadsPipedStdinWithNoArgs(t *testing.T) {
 	}
 }
 
+func TestReadBatchStdinAcceptsInclusiveByteLimit(t *testing.T) {
+	t.Parallel()
+
+	data := exactValidBatchJSON(maxSubmitBatchStdinBytes)
+	reader := &countingStdinReader{
+		reader: bytes.NewReader(data),
+	}
+	got, err := readBatchStdin(BatchConfig{Stdin: reader})
+	if err != nil {
+		t.Fatalf("readBatchStdin(exact limit): %v", err)
+	}
+	if len(got) != maxSubmitBatchStdinBytes || !json.Valid(got) {
+		t.Fatalf("batch bytes = %d, valid = %t, want valid JSON of %d bytes", len(got), json.Valid(got), maxSubmitBatchStdinBytes)
+	}
+	if reader.bytesRead > maxSubmitBatchStdinBytes+1 {
+		t.Fatalf("bytes read = %d, want <= %d", reader.bytesRead, maxSubmitBatchStdinBytes+1)
+	}
+}
+
+func exactValidBatchJSON(size int) []byte {
+	const prefix = `{"requestId":"batch-boundary","type":"FACTORY_REQUEST_BATCH","currentChainingTraceId":"`
+	const suffix = `","works":[{"name":"alpha","workTypeName":"task"}]}`
+	if size < len(prefix)+len(suffix) {
+		panic(fmt.Sprintf("batch boundary size %d is too small", size))
+	}
+	return []byte(prefix + strings.Repeat("x", size-len(prefix)-len(suffix)) + suffix)
+}
+
+func TestSubmitBatchRejectsOverflowAfterOneSentinelByteBeforePreparation(t *testing.T) {
+	t.Parallel()
+
+	reader := &countingStdinReader{
+		reader: bytes.NewReader(bytes.Repeat([]byte("x"), maxSubmitBatchStdinBytes+1)),
+	}
+	prepareCalls := 0
+	prepare := factoryRequestBatchPreparationFunc(func(context.Context, []byte) (workservice.PreparedFactoryRequestBatch, error) {
+		prepareCalls++
+		return workservice.PreparedFactoryRequestBatch{}, nil
+	})
+	err := SubmitBatch(prepare, BatchConfig{
+		Context:    context.Background(),
+		Stdin:      reader,
+		StdinIsTTY: func() bool { return false },
+		DryRun:     true,
+		Output:     io.Discard,
+		Server:     "http://127.0.0.1:1",
+	})
+	if err == nil {
+		t.Fatal("SubmitBatch(overflow): want limit error")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("batch stdin exceeds the %d-byte limit", maxSubmitBatchStdinBytes)) {
+		t.Fatalf("error = %q, want actionable batch limit", err)
+	}
+	if prepareCalls != 0 {
+		t.Fatalf("preparation calls = %d, want 0 before overflow rejection", prepareCalls)
+	}
+	if reader.bytesRead != maxSubmitBatchStdinBytes+1 {
+		t.Fatalf("bytes read = %d, want exactly %d", reader.bytesRead, maxSubmitBatchStdinBytes+1)
+	}
+}
+
 func TestResolveBatchInput_ReadsExplicitStdinDash(t *testing.T) {
 	t.Parallel()
 
@@ -227,7 +290,8 @@ func TestResolveBatchInput_ReadsInlineJSONPositional(t *testing.T) {
 	t.Parallel()
 
 	json := validBatchJSON("batch-inline", "alpha")
-	cfg := BatchConfig{Context: context.Background(), Args: []string{json}}
+	reader := &countingStdinReader{reader: strings.NewReader("unrelated stdin")}
+	cfg := BatchConfig{Context: context.Background(), Args: []string{json}, Stdin: reader}
 
 	resolved, err := resolveBatchInput(cfg)
 	if err != nil {
@@ -238,6 +302,9 @@ func TestResolveBatchInput_ReadsInlineJSONPositional(t *testing.T) {
 	}
 	if resolved.label != "inline JSON" {
 		t.Fatalf("label = %q, want inline JSON", resolved.label)
+	}
+	if reader.bytesRead != 0 {
+		t.Fatalf("inline JSON stdin bytes read = %d, want 0", reader.bytesRead)
 	}
 	if !bytes.Contains(resolved.data, []byte("batch-inline")) {
 		t.Fatalf("data = %q, want inline batch JSON", resolved.data)
@@ -351,9 +418,10 @@ func TestResolveBatchInput_FileFlagIgnoresStdin(t *testing.T) {
 	t.Parallel()
 
 	path := "batch-file-flag-ignores-stdin.json"
+	reader := &countingStdinReader{reader: strings.NewReader(`{"requestId":"wrong","type":"FACTORY_REQUEST_BATCH","works":[]}`)}
 	cfg := BatchConfig{Context: context.Background(),
 		FileFlag: path,
-		Stdin:    strings.NewReader(`{"requestId":"wrong","type":"FACTORY_REQUEST_BATCH","works":[]}`),
+		Stdin:    reader,
 		FileSystem: batchInputFileSystemFake{files: map[string][]byte{
 			path: []byte(validBatchJSON("batch-file-flag-ignores-stdin", "alpha")),
 		}},
@@ -369,15 +437,19 @@ func TestResolveBatchInput_FileFlagIgnoresStdin(t *testing.T) {
 	if !bytes.Contains(resolved.data, []byte("batch-file-flag-ignores-stdin")) {
 		t.Fatalf("data = %q, want --file contents", resolved.data)
 	}
+	if reader.bytesRead != 0 {
+		t.Fatalf("file flag stdin bytes read = %d, want 0", reader.bytesRead)
+	}
 }
 
 func TestResolveBatchInput_FilePathIgnoresStdin(t *testing.T) {
 	t.Parallel()
 
 	path := "batch-file-wins.json"
+	reader := &countingStdinReader{reader: strings.NewReader(`{"requestId":"wrong","type":"FACTORY_REQUEST_BATCH","works":[]}`)}
 	cfg := BatchConfig{Context: context.Background(),
 		Args:  []string{path},
-		Stdin: strings.NewReader(`{"requestId":"wrong","type":"FACTORY_REQUEST_BATCH","works":[]}`),
+		Stdin: reader,
 		FileSystem: batchInputFileSystemFake{files: map[string][]byte{
 			path: []byte(validBatchJSON("batch-file-wins", "alpha")),
 		}},
@@ -392,5 +464,8 @@ func TestResolveBatchInput_FilePathIgnoresStdin(t *testing.T) {
 	}
 	if !bytes.Contains(resolved.data, []byte("batch-file-wins")) {
 		t.Fatalf("data = %q, want file contents", resolved.data)
+	}
+	if reader.bytesRead != 0 {
+		t.Fatalf("file path stdin bytes read = %d, want 0", reader.bytesRead)
 	}
 }

--- a/pkg/services/work/transports/cli/submit/payload.go
+++ b/pkg/services/work/transports/cli/submit/payload.go
@@ -11,6 +11,10 @@ import (
 	"github.com/portpowered/infinite-you/pkg/transports/cli/clidiag"
 )
 
+// maxSubmitPayloadStdinBytes matches Work's inclusive per-payload JSON byte
+// limit for the raw payload document deliberately supplied through stdin.
+const maxSubmitPayloadStdinBytes = workdomain.MaxWorkPayloadBytes
+
 func readSubmitPayload(
 	read workdomain.PayloadFileReader,
 	payloadPath string,
@@ -52,12 +56,14 @@ func readSubmitPayload(
 }
 
 func readSubmitStdinPayload(stdin io.Reader) ([]byte, error) {
-	if stdin == nil {
-		return nil, fmt.Errorf("read payload stdin: process stdin reader is required")
-	}
-	data, err := io.ReadAll(stdin)
+	data, err := readBoundedStdin(
+		stdin,
+		maxSubmitPayloadStdinBytes,
+		"payload stdin",
+		"use a payload file for larger input",
+	)
 	if err != nil {
-		return nil, fmt.Errorf("read payload stdin: %w", err)
+		return nil, err
 	}
 	if len(bytes.TrimSpace(data)) == 0 {
 		return nil, fmt.Errorf("payload stdin input is empty")

--- a/pkg/services/work/transports/cli/submit/payload.go
+++ b/pkg/services/work/transports/cli/submit/payload.go
@@ -11,8 +11,9 @@ import (
 	"github.com/portpowered/infinite-you/pkg/transports/cli/clidiag"
 )
 
-// maxSubmitPayloadStdinBytes matches Work's inclusive per-payload JSON byte
-// limit for the raw payload document deliberately supplied through stdin.
+// maxSubmitPayloadStdinBytes is the inclusive source-byte cap for a payload
+// deliberately supplied through stdin. The same limit is also applied below
+// to the compact JSON representation that Work admission measures.
 const maxSubmitPayloadStdinBytes = workdomain.MaxWorkPayloadBytes
 
 func readSubmitPayload(
@@ -23,7 +24,8 @@ func readSubmitPayload(
 	if read == nil {
 		return nil, nil, "", fmt.Errorf("Work payload file reader is required")
 	}
-	if strings.TrimSpace(payloadPath) == "-" {
+	stdinPayload := strings.TrimSpace(payloadPath) == "-"
+	if stdinPayload {
 		raw, err = readSubmitStdinPayload(stdin)
 		if err != nil {
 			return nil, nil, "", err
@@ -45,12 +47,22 @@ func readSubmitPayload(
 			}
 			return nil, nil, "", fmt.Errorf("payload file is not valid JSON: %s", label)
 		}
+		if stdinPayload {
+			if err := validateSubmitStdinPayloadSize(raw); err != nil {
+				return nil, nil, "", err
+			}
+		}
 		return raw, raw, payloadType, nil
 	}
 
 	encoded, err := json.Marshal(string(raw))
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("encode payload: %w", err)
+	}
+	if stdinPayload {
+		if err := validateSubmitStdinPayloadSize(encoded); err != nil {
+			return nil, nil, "", err
+		}
 	}
 	return encoded, raw, payloadType, nil
 }
@@ -69,6 +81,25 @@ func readSubmitStdinPayload(stdin io.Reader) ([]byte, error) {
 		return nil, fmt.Errorf("payload stdin input is empty")
 	}
 	return data, nil
+}
+
+// validateSubmitStdinPayloadSize applies the Work admission boundary to the
+// compact JSON bytes that the CLI will send. Text stdin is JSON-encoded after
+// it is read, so checking only the source bytes would let escaping expand the
+// request past Work's limit.
+func validateSubmitStdinPayloadSize(payload []byte) error {
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, payload); err != nil {
+		return fmt.Errorf("validate payload stdin size: %w", err)
+	}
+	if compact.Len() <= maxSubmitPayloadStdinBytes {
+		return nil
+	}
+	return fmt.Errorf(
+		"payload stdin compact JSON exceeds the %d-byte Work payload limit (encoded size %d); use a payload file for larger input",
+		maxSubmitPayloadStdinBytes,
+		compact.Len(),
+	)
 }
 
 func classifySubmitPayloadBytes(raw []byte) string {

--- a/pkg/services/work/transports/cli/submit/payload_test.go
+++ b/pkg/services/work/transports/cli/submit/payload_test.go
@@ -3,6 +3,7 @@ package submit
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +17,17 @@ import (
 type errReader struct{ err error }
 
 func (r errReader) Read([]byte) (int, error) { return 0, r.err }
+
+type countingStdinReader struct {
+	reader    io.Reader
+	bytesRead int
+}
+
+func (r *countingStdinReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.bytesRead += n
+	return n, err
+}
 
 func TestSubmitBatch_LocalPayloadSizeErrorPreservesCLIDiagnostic(t *testing.T) {
 	var out bytes.Buffer
@@ -169,6 +181,59 @@ func TestReadSubmitStdinPayload_PropagatesReadError(t *testing.T) {
 	}
 	if !errors.Is(err, readErr) {
 		t.Fatalf("readSubmitStdinPayload(read error) = %v, want wrapped %v", err, readErr)
+	}
+}
+
+func TestReadSubmitStdinPayloadAcceptsInclusiveByteLimit(t *testing.T) {
+	t.Parallel()
+
+	const emptyJSONPayload = `{"text":""}`
+	rawJSON := `{"text":"` + strings.Repeat("x", maxSubmitPayloadStdinBytes-len(emptyJSONPayload)) + `"}`
+	reader := &countingStdinReader{
+		reader: bytes.NewReader([]byte(rawJSON)),
+	}
+	_, data, payloadType, err := readSubmitPayload(
+		func(string) ([]byte, error) { t.Fatal("file reader called for stdin"); return nil, nil },
+		"-",
+		reader,
+	)
+	if err != nil {
+		t.Fatalf("readSubmitPayload(exact limit): %v", err)
+	}
+	if payloadType != "json" {
+		t.Fatalf("payload type = %q, want json", payloadType)
+	}
+	if len(data) != maxSubmitPayloadStdinBytes || !json.Valid(data) {
+		t.Fatalf("payload bytes = %d, want %d", len(data), maxSubmitPayloadStdinBytes)
+	}
+	if reader.bytesRead > maxSubmitPayloadStdinBytes+1 {
+		t.Fatalf("bytes read = %d, want <= %d", reader.bytesRead, maxSubmitPayloadStdinBytes+1)
+	}
+}
+
+func TestReadSubmitStdinPayloadRejectsOverflowAfterOneSentinelByte(t *testing.T) {
+	t.Parallel()
+
+	reader := &countingStdinReader{
+		reader: bytes.NewReader(bytes.Repeat([]byte("x"), maxSubmitPayloadStdinBytes+1)),
+	}
+	data, err := readSubmitStdinPayload(reader)
+	if err == nil {
+		t.Fatal("readSubmitStdinPayload(overflow): want limit error")
+	}
+	if data != nil {
+		t.Fatalf("overflow data retained = %d bytes, want nil", len(data))
+	}
+	for _, want := range []string{
+		fmt.Sprintf("payload stdin exceeds the %d-byte limit", maxSubmitPayloadStdinBytes),
+		"use a payload file for larger input",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want %q", err, want)
+		}
+	}
+	if reader.bytesRead != maxSubmitPayloadStdinBytes+1 {
+		t.Fatalf("bytes read = %d, want exactly %d", reader.bytesRead, maxSubmitPayloadStdinBytes+1)
 	}
 }
 

--- a/pkg/services/work/transports/cli/submit/payload_test.go
+++ b/pkg/services/work/transports/cli/submit/payload_test.go
@@ -211,6 +211,62 @@ func TestReadSubmitStdinPayloadAcceptsInclusiveByteLimit(t *testing.T) {
 	}
 }
 
+func TestReadSubmitPayload_StdinTextAcceptsExactCompactPayloadLimit(t *testing.T) {
+	t.Parallel()
+
+	// json.Marshal escapes the newline, so this source is smaller than the
+	// source cap while its compact JSON representation is exactly the Work
+	// admission limit.
+	rawText := strings.Repeat("x", maxSubmitPayloadStdinBytes-4) + "\n"
+	reader := &countingStdinReader{reader: strings.NewReader(rawText)}
+	payload, raw, payloadType, err := readSubmitPayload(
+		func(string) ([]byte, error) { t.Fatal("file reader called for stdin"); return nil, nil },
+		"-",
+		reader,
+	)
+	if err != nil {
+		t.Fatalf("readSubmitPayload(exact encoded text limit): %v", err)
+	}
+	if payloadType != "markdown" {
+		t.Fatalf("payload type = %q, want markdown", payloadType)
+	}
+	if string(raw) != rawText {
+		t.Fatalf("raw payload changed: got %q", raw)
+	}
+	if len(payload) != maxSubmitPayloadStdinBytes || !json.Valid(payload) {
+		t.Fatalf("encoded payload bytes = %d, want valid JSON at %d bytes", len(payload), maxSubmitPayloadStdinBytes)
+	}
+	if reader.bytesRead != len(rawText) {
+		t.Fatalf("bytes read = %d, want %d", reader.bytesRead, len(rawText))
+	}
+}
+
+func TestReadSubmitPayload_StdinTextRejectsEscapedOverLimitPayload(t *testing.T) {
+	t.Parallel()
+
+	rawText := strings.Repeat("\"", maxSubmitPayloadStdinBytes/2)
+	reader := &countingStdinReader{reader: strings.NewReader(rawText)}
+	_, _, _, err := readSubmitPayload(
+		func(string) ([]byte, error) { t.Fatal("file reader called for stdin"); return nil, nil },
+		"-",
+		reader,
+	)
+	if err == nil {
+		t.Fatal("readSubmitPayload(escaped over-limit text) succeeded")
+	}
+	for _, want := range []string{
+		"payload stdin compact JSON exceeds the 65536-byte Work payload limit",
+		"use a payload file for larger input",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want %q", err, want)
+		}
+	}
+	if reader.bytesRead != len(rawText) {
+		t.Fatalf("bytes read = %d, want %d source bytes", reader.bytesRead, len(rawText))
+	}
+}
+
 func TestReadSubmitStdinPayloadRejectsOverflowAfterOneSentinelByte(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/work/transports/cli/submit/submit_test.go
+++ b/pkg/services/work/transports/cli/submit/submit_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	workdomain "github.com/portpowered/infinite-you/pkg/services/work"
@@ -177,6 +179,43 @@ func TestSubmit_MissingPayload(t *testing.T) {
 	}
 	if err.Error() != "--payload is required" {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSubmit_OversizedStdinFailsBeforeHTTP(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		calls.Add(1)
+	}))
+	defer srv.Close()
+
+	reader := &countingStdinReader{
+		reader: bytes.NewReader(bytes.Repeat([]byte("x"), maxSubmitPayloadStdinBytes+1)),
+	}
+	var out bytes.Buffer
+	err := Submit(t, SubmitConfig{
+		Context:      context.Background(),
+		Name:         "oversized-stdin",
+		WorkTypeName: "task",
+		Payload:      "-",
+		Stdin:        reader,
+		Server:       mustServerBase(t, srv.URL),
+		Output:       &out,
+	})
+	if err == nil {
+		t.Fatal("Submit(oversized stdin) succeeded, want limit error")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("payload stdin exceeds the %d-byte limit", maxSubmitPayloadStdinBytes)) {
+		t.Fatalf("error = %q, want actionable payload limit", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("HTTP calls = %d, want 0 before overflow rejection", calls.Load())
+	}
+	if reader.bytesRead != maxSubmitPayloadStdinBytes+1 {
+		t.Fatalf("bytes read = %d, want exactly %d", reader.bytesRead, maxSubmitPayloadStdinBytes+1)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty on overflow", out.String())
 	}
 }
 

--- a/pkg/services/work/transports/cli/submit/submit_test.go
+++ b/pkg/services/work/transports/cli/submit/submit_test.go
@@ -219,6 +219,42 @@ func TestSubmit_OversizedStdinFailsBeforeHTTP(t *testing.T) {
 	}
 }
 
+func TestSubmit_EscapedTextOverLimitFailsBeforeHTTP(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		calls.Add(1)
+	}))
+	defer srv.Close()
+
+	rawText := strings.Repeat("\"", maxSubmitPayloadStdinBytes/2)
+	reader := &countingStdinReader{reader: strings.NewReader(rawText)}
+	var out bytes.Buffer
+	err := Submit(t, SubmitConfig{
+		Context:      context.Background(),
+		Name:         "escaped-over-limit",
+		WorkTypeName: "task",
+		Payload:      "-",
+		Stdin:        reader,
+		Server:       mustServerBase(t, srv.URL),
+		Output:       &out,
+	})
+	if err == nil {
+		t.Fatal("Submit(escaped text over encoded limit) succeeded")
+	}
+	if !strings.Contains(err.Error(), "payload stdin compact JSON exceeds the 65536-byte Work payload limit") {
+		t.Fatalf("error = %q, want actionable compact payload limit", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("HTTP calls = %d, want 0 before encoded-overflow rejection", calls.Load())
+	}
+	if reader.bytesRead != len(rawText) {
+		t.Fatalf("bytes read = %d, want %d source bytes", reader.bytesRead, len(rawText))
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty on overflow", out.String())
+	}
+}
+
 func TestSubmit_PayloadFileNotFound(t *testing.T) {
 	err := Submit(t, SubmitConfig{Context: context.Background(), Name: "submit-task", WorkTypeName: "task", Payload: "/nonexistent/file.json", Server: "http://127.0.0.1:8080"})
 	if err == nil {

--- a/pkg/services/worker_sessions/transports/cli/continue.go
+++ b/pkg/services/worker_sessions/transports/cli/continue.go
@@ -178,9 +178,14 @@ func resolveContinueInput(config ContinueConfig) (string, error) {
 	if config.StdinIsTTY || config.Stdin == nil {
 		return "", nil
 	}
-	data, err := io.ReadAll(config.Stdin)
+	data, err := readBoundedWorkerSessionStdin(
+		config.Stdin,
+		maxWorkerSessionMessageStdinBytes,
+		"Worker Session follow-up input stdin",
+		"use --user-message or positional input for larger input",
+	)
 	if err != nil {
-		return "", newCLIError("WORKER_SESSION_INPUT_FAILED", "failed to read Worker Session follow-up input from stdin", err)
+		return "", newCLIError("WORKER_SESSION_INPUT_FAILED", fmt.Sprintf("failed to read Worker Session follow-up input from stdin: %v", err), err)
 	}
 	return strings.TrimSpace(string(data)), nil
 }

--- a/pkg/services/worker_sessions/transports/cli/interrupt.go
+++ b/pkg/services/worker_sessions/transports/cli/interrupt.go
@@ -200,9 +200,14 @@ func resolveInterruptInput(config InterruptConfig) (string, error) {
 	if config.StdinIsTTY || config.Stdin == nil {
 		return "", nil
 	}
-	data, err := io.ReadAll(config.Stdin)
+	data, err := readBoundedWorkerSessionStdin(
+		config.Stdin,
+		maxWorkerSessionMessageStdinBytes,
+		"Worker Session replacement input stdin",
+		"use --replacement-message or positional input for larger input",
+	)
 	if err != nil {
-		return "", newInterruptCLIError("WORKER_SESSION_INPUT_FAILED", "failed to read Worker Session replacement input from stdin", string(workersessions.InterruptPhaseValidation), err)
+		return "", newInterruptCLIError("WORKER_SESSION_INPUT_FAILED", fmt.Sprintf("failed to read Worker Session replacement input from stdin: %v", err), string(workersessions.InterruptPhaseValidation), err)
 	}
 	return strings.TrimSpace(string(data)), nil
 }

--- a/pkg/services/worker_sessions/transports/cli/invoke.go
+++ b/pkg/services/worker_sessions/transports/cli/invoke.go
@@ -334,9 +334,14 @@ func resolveInvokeMessage(config InvokeConfig) (string, error) {
 	if config.StdinIsTTY || config.Stdin == nil {
 		return "", nil
 	}
-	data, err := io.ReadAll(config.Stdin)
+	data, err := readBoundedWorkerSessionStdin(
+		config.Stdin,
+		maxWorkerSessionMessageStdinBytes,
+		"direct Worker input stdin",
+		"use --user-message or --execution FILE for larger input",
+	)
 	if err != nil {
-		return "", newCLIError("WORKER_SESSION_INPUT_FAILED", "failed to read direct Worker input from stdin", err)
+		return "", newCLIError("WORKER_SESSION_INPUT_FAILED", fmt.Sprintf("failed to read direct Worker input from stdin: %v", err), err)
 	}
 	return strings.TrimSpace(string(data)), nil
 }

--- a/pkg/services/worker_sessions/transports/cli/invoke_test.go
+++ b/pkg/services/worker_sessions/transports/cli/invoke_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -686,3 +687,288 @@ func (stub *invokeProtocolStub) PutJSONCreated(context.Context, string, io.Reade
 
 var _ LocalInvokeBoundary = (*invokeLocalFake)(nil)
 var _ clihttp.Protocol = (*invokeProtocolStub)(nil)
+
+func TestWorkerSessionStdinReadersAcceptExactInclusiveLimit(t *testing.T) {
+	t.Run("execution document", func(t *testing.T) {
+		document := exactWorkerSessionExecutionDocument(t, maxWorkerSessionExecutionStdinBytes)
+		reader := &workerSessionCountedReader{reader: bytes.NewReader(document)}
+		request, err := readInvokeRequest(InvokeConfig{ExecutionJSON: "-", Stdin: reader})
+		if err != nil {
+			t.Fatalf("read exact-limit execution document: %v", err)
+		}
+		if reader.bytesRead != maxWorkerSessionExecutionStdinBytes {
+			t.Fatalf("execution document bytes read = %d, want %d", reader.bytesRead, maxWorkerSessionExecutionStdinBytes)
+		}
+		if request.RequestId != "request" || request.WorkerSessionId != "session" {
+			t.Fatalf("execution document identity = (%q, %q), want request/session", request.RequestId, request.WorkerSessionId)
+		}
+	})
+
+	for _, test := range []struct {
+		name string
+		read func(io.Reader) (string, error)
+	}{
+		{
+			name: "invoke message",
+			read: func(reader io.Reader) (string, error) {
+				return resolveInvokeMessage(InvokeConfig{Stdin: reader})
+			},
+		},
+		{
+			name: "continue follow-up",
+			read: func(reader io.Reader) (string, error) {
+				return resolveContinueInput(ContinueConfig{Stdin: reader})
+			},
+		},
+		{
+			name: "interrupt replacement",
+			read: func(reader io.Reader) (string, error) {
+				return resolveInterruptInput(InterruptConfig{Stdin: reader})
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			input := strings.Repeat("x", maxWorkerSessionMessageStdinBytes)
+			reader := &workerSessionCountedReader{reader: strings.NewReader(input)}
+			got, err := test.read(reader)
+			if err != nil {
+				t.Fatalf("read exact-limit input: %v", err)
+			}
+			if len(got) != len(input) || strings.Trim(got, "x") != "" {
+				t.Fatalf("exact-limit input length/content = (%d, %q), want %d x bytes", len(got), got[:minWorkerSessionTestPreview(len(got))], len(input))
+			}
+			if reader.bytesRead != maxWorkerSessionMessageStdinBytes {
+				t.Fatalf("message bytes read = %d, want %d", reader.bytesRead, maxWorkerSessionMessageStdinBytes)
+			}
+		})
+	}
+}
+
+func TestWorkerSessionStdinOverflowReadsOnlySentinel(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int
+	}{
+		{name: "execution document", limit: maxWorkerSessionExecutionStdinBytes},
+		{name: "worker message", limit: maxWorkerSessionMessageStdinBytes},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reader := &workerSessionCountedReader{reader: bytes.NewReader(bytes.Repeat([]byte("x"), test.limit+32))}
+			_, err := readBoundedWorkerSessionStdin(reader, test.limit, test.name, "use a file for larger input")
+			if err == nil || !strings.Contains(err.Error(), "exceeds the "+strconv.Itoa(test.limit)+"-byte limit") {
+				t.Fatalf("overflow error = %v, want actionable byte-limit error", err)
+			}
+			if reader.bytesRead != test.limit+1 {
+				t.Fatalf("overflow bytes read = %d, want exactly %d", reader.bytesRead, test.limit+1)
+			}
+		})
+	}
+}
+
+func TestWorkerSessionExecutionStdinOverflowFailsBeforeDispatch(t *testing.T) {
+	local := &invokeLocalFake{}
+	reader := workerSessionOverflowReader(maxWorkerSessionExecutionStdinBytes)
+	var output bytes.Buffer
+	err := NewInvoke(nil, local)(InvokeConfig{
+		Context: context.Background(), Output: &output, OutputFormat: "json", Async: true,
+		ExecutionJSON: "-", Stdin: reader,
+	})
+	if err == nil || !strings.Contains(err.Error(), "direct Worker execution stdin exceeds") {
+		t.Fatalf("oversized execution stdin error = %v, want input-limit failure", err)
+	}
+	if reader.bytesRead != maxWorkerSessionExecutionStdinBytes+1 {
+		t.Fatalf("execution overflow bytes read = %d, want exactly %d", reader.bytesRead, maxWorkerSessionExecutionStdinBytes+1)
+	}
+	if len(local.startRequests) != 0 {
+		t.Fatalf("oversized execution stdin dispatched %d request(s), want none", len(local.startRequests))
+	}
+}
+
+func TestWorkerSessionInvokeMessageOverflowFailsBeforeDispatch(t *testing.T) {
+	local := &invokeLocalFake{}
+	reader := workerSessionOverflowReader(maxWorkerSessionMessageStdinBytes)
+	var output bytes.Buffer
+	err := NewInvoke(nil, local)(InvokeConfig{
+		Context: context.Background(), Output: &output, OutputFormat: "json", Async: true,
+		RequestID: "request", WorkerSessionID: "session", DispatchID: "dispatch",
+		WorkstationName: "coding", Stdin: reader,
+	})
+	if err == nil || !strings.Contains(err.Error(), "direct Worker input stdin exceeds") {
+		t.Fatalf("oversized invoke stdin error = %v, want input-limit failure", err)
+	}
+	if reader.bytesRead != maxWorkerSessionMessageStdinBytes+1 {
+		t.Fatalf("invoke overflow bytes read = %d, want exactly %d", reader.bytesRead, maxWorkerSessionMessageStdinBytes+1)
+	}
+	if len(local.startRequests) != 0 {
+		t.Fatalf("oversized invoke stdin dispatched %d request(s), want none", len(local.startRequests))
+	}
+}
+
+func TestWorkerSessionContinueAndInterruptOverflowFailBeforeDispatch(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*invokeLocalFake, io.Reader, *bytes.Buffer) error
+		seen func(*invokeLocalFake) int
+	}{
+		{
+			name: "continue",
+			run: func(local *invokeLocalFake, reader io.Reader, output *bytes.Buffer) error {
+				return NewContinue(nil, local)(ContinueConfig{
+					Context: context.Background(), Output: output, OutputFormat: "json", Async: true,
+					RequestID: "request", SourceWorkerSessionID: "source", SuccessorWorkerSessionID: "successor",
+					Stdin: reader,
+				})
+			},
+			seen: func(local *invokeLocalFake) int { return len(local.continueRequests) },
+		},
+		{
+			name: "interrupt",
+			run: func(local *invokeLocalFake, reader io.Reader, output *bytes.Buffer) error {
+				return NewInterrupt(nil, local)(InterruptConfig{
+					Context: context.Background(), Output: output, OutputFormat: "json", Async: true,
+					RequestID: "request", SourceWorkerSessionID: "source", SuccessorWorkerSessionID: "successor",
+					Stdin: reader,
+				})
+			},
+			seen: func(local *invokeLocalFake) int { return len(local.interruptRequests) },
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			local := &invokeLocalFake{}
+			reader := workerSessionOverflowReader(maxWorkerSessionMessageStdinBytes)
+			var output bytes.Buffer
+			err := test.run(local, reader, &output)
+			if err == nil || !strings.Contains(err.Error(), "exceeds the "+strconv.Itoa(maxWorkerSessionMessageStdinBytes)+"-byte limit") {
+				t.Fatalf("oversized %s stdin error = %v, want input-limit failure", test.name, err)
+			}
+			if reader.bytesRead != maxWorkerSessionMessageStdinBytes+1 {
+				t.Fatalf("%s overflow bytes read = %d, want exactly %d", test.name, reader.bytesRead, maxWorkerSessionMessageStdinBytes+1)
+			}
+			if dispatched := test.seen(local); dispatched != 0 {
+				t.Fatalf("oversized %s stdin dispatched %d request(s), want none", test.name, dispatched)
+			}
+		})
+	}
+}
+
+func TestWorkerSessionExplicitInputsDoNotReadUnrelatedStdin(t *testing.T) {
+	messageReader := &workerSessionCountedReader{reader: strings.NewReader("unrelated")}
+	request := factoryapi.WorkerSessionStartRequest{}
+	if err := applyInvokeMessageOverride(&request, InvokeConfig{UserMessage: "flag message", Stdin: messageReader}); err != nil {
+		t.Fatalf("invoke explicit message error = %v", err)
+	}
+	if messageReader.bytesRead != 0 {
+		t.Fatalf("invoke explicit message read %d stdin bytes, want 0", messageReader.bytesRead)
+	}
+	if request.Execution.UserMessage == nil || *request.Execution.UserMessage != "flag message" {
+		t.Fatalf("invoke explicit message = %#v, want flag message", request.Execution.UserMessage)
+	}
+
+	continueReader := &workerSessionCountedReader{reader: strings.NewReader("unrelated")}
+	got, err := resolveContinueInput(ContinueConfig{FollowUpInput: "flag follow-up", Stdin: continueReader})
+	if err != nil || got != "flag follow-up" {
+		t.Fatalf("continue explicit message = (%q, %v), want flag follow-up", got, err)
+	}
+	if continueReader.bytesRead != 0 {
+		t.Fatalf("continue explicit message read %d stdin bytes, want 0", continueReader.bytesRead)
+	}
+
+	interruptReader := &workerSessionCountedReader{reader: strings.NewReader("unrelated")}
+	got, err = resolveInterruptInput(InterruptConfig{ReplacementMessage: "flag replacement", Stdin: interruptReader})
+	if err != nil || got != "flag replacement" {
+		t.Fatalf("interrupt explicit message = (%q, %v), want flag replacement", got, err)
+	}
+	if interruptReader.bytesRead != 0 {
+		t.Fatalf("interrupt explicit message read %d stdin bytes, want 0", interruptReader.bytesRead)
+	}
+}
+
+func TestWorkerSessionTTYAndFileInputsDoNotReadUnrelatedStdin(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		read func(io.Reader) (string, error)
+	}{
+		{
+			name: "invoke TTY",
+			read: func(reader io.Reader) (string, error) {
+				return resolveInvokeMessage(InvokeConfig{Stdin: reader, StdinIsTTY: true})
+			},
+		},
+		{
+			name: "continue TTY",
+			read: func(reader io.Reader) (string, error) {
+				return resolveContinueInput(ContinueConfig{Stdin: reader, StdinIsTTY: true})
+			},
+		},
+		{
+			name: "interrupt TTY",
+			read: func(reader io.Reader) (string, error) {
+				return resolveInterruptInput(InterruptConfig{Stdin: reader, StdinIsTTY: true})
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			reader := &workerSessionCountedReader{reader: strings.NewReader("unrelated")}
+			got, err := test.read(reader)
+			if err != nil || got != "" {
+				t.Fatalf("TTY input resolution = (%q, %v), want empty input", got, err)
+			}
+			if reader.bytesRead != 0 {
+				t.Fatalf("TTY input read %d stdin bytes, want 0", reader.bytesRead)
+			}
+		})
+	}
+
+	fileReader := &workerSessionCountedReader{reader: strings.NewReader("unrelated")}
+	if _, err := readInvokeRequest(InvokeConfig{
+		ExecutionJSON: "request.json", Stdin: fileReader,
+		ReadFile: func(string) ([]byte, error) {
+			return []byte(`{"requestId":"request","workerSessionId":"session"}`), nil
+		},
+	}); err != nil {
+		t.Fatalf("file execution input error = %v", err)
+	}
+	if fileReader.bytesRead != 0 {
+		t.Fatalf("file execution input read %d unrelated stdin bytes, want 0", fileReader.bytesRead)
+	}
+}
+
+func exactWorkerSessionExecutionDocument(t *testing.T, size int) []byte {
+	t.Helper()
+	prefix := `{"requestId":"request","workerSessionId":"session","execution":{"workstationName":"coding","dispatch":{"dispatchId":"dispatch","workstationName":"coding"},"userMessage":"`
+	suffix := `"}}`
+	if padding := size - len(prefix) - len(suffix); padding < 1 {
+		t.Fatalf("execution document fixture size %d is too small", size)
+	} else {
+		document := []byte(prefix + strings.Repeat("x", padding) + suffix)
+		if len(document) != size || !json.Valid(document) {
+			t.Fatalf("execution document fixture length/validity = (%d, %t), want (%d, true)", len(document), json.Valid(document), size)
+		}
+		return document
+	}
+	return nil
+}
+
+func workerSessionOverflowReader(limit int) *workerSessionCountedReader {
+	return &workerSessionCountedReader{reader: bytes.NewReader(bytes.Repeat([]byte("x"), limit+32))}
+}
+
+type workerSessionCountedReader struct {
+	reader    io.Reader
+	bytesRead int
+}
+
+func (reader *workerSessionCountedReader) Read(p []byte) (int, error) {
+	n, err := reader.reader.Read(p)
+	reader.bytesRead += n
+	return n, err
+}
+
+func minWorkerSessionTestPreview(length int) int {
+	if length < 32 {
+		return length
+	}
+	return 32
+}

--- a/pkg/services/worker_sessions/transports/cli/service.go
+++ b/pkg/services/worker_sessions/transports/cli/service.go
@@ -38,6 +38,39 @@ func selectEffects(effects []Effects) Effects {
 	return effects[0]
 }
 
+const (
+	// maxWorkerSessionExecutionStdinBytes is the inclusive byte limit for a
+	// direct Worker execution document deliberately supplied through stdin.
+	maxWorkerSessionExecutionStdinBytes = 1 * 1024 * 1024
+
+	// maxWorkerSessionMessageStdinBytes is the inclusive byte limit for a
+	// direct Worker message deliberately supplied through stdin by invoke,
+	// continue, or interrupt.
+	maxWorkerSessionMessageStdinBytes = 1 * 1024 * 1024
+)
+
+// readBoundedWorkerSessionStdin reads at most limit plus one byte. The extra
+// byte is an overflow sentinel and is discarded when the inclusive limit is
+// exceeded.
+func readBoundedWorkerSessionStdin(stdin io.Reader, limit int, label, overflowGuidance string) ([]byte, error) {
+	if stdin == nil {
+		return nil, fmt.Errorf("read %s: process stdin reader is required", label)
+	}
+	data, err := io.ReadAll(io.LimitReader(stdin, int64(limit)+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", label, err)
+	}
+	if len(data) > limit {
+		return nil, fmt.Errorf(
+			"%s exceeds the %d-byte limit; %s",
+			label,
+			limit,
+			overflowGuidance,
+		)
+	}
+	return data, nil
+}
+
 func readInvokeRequest(config InvokeConfig) (factoryapi.WorkerSessionStartRequest, error) {
 	decoded, err := readInvokeRequestWithDiagnostics(config)
 	return decoded.Request, err
@@ -54,9 +87,14 @@ func readInvokeRequestWithDiagnostics(config InvokeConfig) (invokeRequestDecodeR
 			return invokeRequestDecodeResult{}, newCLIError("WORKER_SESSION_INPUT_MISSING", "--execution - requires JSON on stdin", nil)
 		}
 		var err error
-		data, err = io.ReadAll(config.Stdin)
+		data, err = readBoundedWorkerSessionStdin(
+			config.Stdin,
+			maxWorkerSessionExecutionStdinBytes,
+			"direct Worker execution stdin",
+			"use --execution FILE for larger input",
+		)
 		if err != nil {
-			return invokeRequestDecodeResult{}, newCLIError("WORKER_SESSION_INPUT_FAILED", "failed to read direct Worker execution from stdin", err)
+			return invokeRequestDecodeResult{}, newCLIError("WORKER_SESSION_INPUT_FAILED", fmt.Sprintf("failed to read direct Worker execution from stdin: %v", err), err)
 		}
 	} else if strings.HasPrefix(input, "{") {
 		data = []byte(input)

--- a/pkg/transports/cli/root_invocation_input_edge_test.go
+++ b/pkg/transports/cli/root_invocation_input_edge_test.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -167,9 +169,93 @@ func TestCollectRunInvocationStdinPreservesReaderFailure(t *testing.T) {
 	}
 }
 
+func TestCollectRunInvocationStdinAcceptsInclusiveByteLimit(t *testing.T) {
+	t.Parallel()
+
+	payload := bytes.Repeat([]byte("x"), maxRunInvocationStdinBytes)
+	reader := &countingBytesInvocationReader{reader: bytes.NewReader(payload)}
+	got, err := collectRunInvocationStdin(nil, reader, func() bool { return false })
+	if err != nil {
+		t.Fatalf("collect exact-limit stdin: %v", err)
+	}
+	if got == nil || len(*got) != maxRunInvocationStdinBytes {
+		t.Fatalf("collected stdin length = %d, want %d", lenOrZero(got), maxRunInvocationStdinBytes)
+	}
+	if reader.bytesRead > maxRunInvocationStdinBytes+1 {
+		t.Fatalf("exact-limit stdin bytes read = %d, want <= %d", reader.bytesRead, maxRunInvocationStdinBytes+1)
+	}
+}
+
+func TestCollectRunInvocationStdinRejectsOverflowAfterOneSentinelByte(t *testing.T) {
+	t.Parallel()
+
+	payload := bytes.Repeat([]byte("x"), maxRunInvocationStdinBytes+1024)
+	reader := &countingBytesInvocationReader{reader: bytes.NewReader(payload)}
+	_, err := collectRunInvocationStdin(nil, reader, func() bool { return false })
+	if err == nil {
+		t.Fatal("collect oversized stdin: want limit error")
+	}
+	for _, want := range []string{
+		fmt.Sprintf("invocation stdin exceeds the %d-byte limit", maxRunInvocationStdinBytes),
+		"use --to-file for larger input",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want %q", err, want)
+		}
+	}
+	if reader.bytesRead != maxRunInvocationStdinBytes+1 {
+		t.Fatalf("oversized stdin bytes read = %d, want exactly %d", reader.bytesRead, maxRunInvocationStdinBytes+1)
+	}
+}
+
+func TestResolveCompatibilityRunFactoryPromptRejectsOversizedStdinBeforePreparation(t *testing.T) {
+	t.Parallel()
+
+	reader := &countingBytesInvocationReader{
+		reader: bytes.NewReader(bytes.Repeat([]byte("x"), maxRunInvocationStdinBytes+1)),
+	}
+	cmd := &cobra.Command{Use: "run"}
+	cmd.SetContext(context.Background())
+	cmd.SetIn(reader)
+	preparation := rootInvocationInputScript{prepare: func(
+		context.Context,
+		work.InvocationInputPreparationRequest,
+	) (work.PreparedInvocationInput, error) {
+		t.Fatal("oversized invocation stdin must fail before Work preparation")
+		return work.PreparedInvocationInput{}, nil
+	}}
+	cfg := runcli.RunConfig{NamedFactoryName: "team-review"}
+
+	err := resolveCompatibilityRunFactoryPrompt(cmd, &cfg, nil, false, preparation)
+	if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("invocation stdin exceeds the %d-byte limit", maxRunInvocationStdinBytes)) {
+		t.Fatalf("resolve oversized invocation stdin error = %v", err)
+	}
+	if reader.bytesRead != maxRunInvocationStdinBytes+1 {
+		t.Fatalf("resolved oversized stdin bytes read = %d, want exactly %d", reader.bytesRead, maxRunInvocationStdinBytes+1)
+	}
+}
+
 type failingInvocationReader struct{ err error }
 
 func (reader failingInvocationReader) Read([]byte) (int, error) { return 0, reader.err }
+
+type countingBytesInvocationReader struct {
+	reader    io.Reader
+	bytesRead int
+}
+
+func (reader *countingBytesInvocationReader) Read(p []byte) (int, error) {
+	n, err := reader.reader.Read(p)
+	reader.bytesRead += n
+	return n, err
+}
+
+func lenOrZero(value *string) int {
+	if value == nil {
+		return 0
+	}
+	return len(*value)
+}
 
 type countingInvocationReader struct{ reads int }
 

--- a/pkg/transports/cli/root_invocation_input_edge_test.go
+++ b/pkg/transports/cli/root_invocation_input_edge_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -80,6 +81,30 @@ func TestResolveFactoryInvocationInput_RequiresProcessStdinForExplicitDash(t *te
 	}
 }
 
+func TestResolveRunFactoryPromptDirectorySelectionDoesNotReadUnrequestedStdin(t *testing.T) {
+	t.Parallel()
+
+	reader := &countingInvocationReader{}
+	cmd := &cobra.Command{Use: "run"}
+	cmd.SetContext(context.Background())
+	cmd.SetIn(reader)
+	preparation := rootInvocationInputScript{prepare: func(
+		context.Context,
+		work.InvocationInputPreparationRequest,
+	) (work.PreparedInvocationInput, error) {
+		t.Fatal("directory-selected run must not prepare unrequested stdin")
+		return work.PreparedInvocationInput{}, nil
+	}}
+	cfg := runcli.RunConfig{Dir: t.TempDir()}
+
+	if err := resolveRunFactoryPrompt(cmd, &cfg, nil, preparation); err != nil {
+		t.Fatalf("resolve directory-selected run: %v", err)
+	}
+	if reader.reads != 0 {
+		t.Fatalf("directory-selected run stdin reads = %d, want 0", reader.reads)
+	}
+}
+
 func TestResolveRunFactoryPromptToFileRejectsNonPromptRunShapes(t *testing.T) {
 	t.Parallel()
 
@@ -145,6 +170,13 @@ func TestCollectRunInvocationStdinPreservesReaderFailure(t *testing.T) {
 type failingInvocationReader struct{ err error }
 
 func (reader failingInvocationReader) Read([]byte) (int, error) { return 0, reader.err }
+
+type countingInvocationReader struct{ reads int }
+
+func (reader *countingInvocationReader) Read([]byte) (int, error) {
+	reader.reads++
+	return 0, io.EOF
+}
 
 func TestResolveRunFactoryPromptNoSignatureSelectionsPreserveCompatibilityInput(t *testing.T) {
 	t.Parallel()

--- a/pkg/transports/cli/root_submit_batch.go
+++ b/pkg/transports/cli/root_submit_batch.go
@@ -696,7 +696,11 @@ func resolveLegacyRunFactoryPrompt(cmd *cobra.Command, promptArgs []string, prep
 			return fmt.Errorf("unknown flag: %s", arg)
 		}
 	}
-	if len(promptArgs) == 0 && runCommandInputIsTTY(cmd.Context()) {
+	// Directory-selected runs do not have a documented implicit stdin
+	// invocation. Only an explicit positional argument or a `-` token asks
+	// this compatibility path to inspect process stdin; otherwise a quiet pipe
+	// must not delay Factory startup.
+	if len(promptArgs) == 0 {
 		return nil
 	}
 	input, err := prepareRunInvocationInputWithFile(cmd, promptArgs, nil, nil, preparation)
@@ -900,10 +904,6 @@ func assignCompatibilityInvocationInput(cfg *runcli.RunConfig, input work.Prepar
 		cfg.InvocationStdinText = &payload
 	}
 	cfg.CleanInvocationInputSource = source
-}
-
-func runCommandInputIsTTY(ctx context.Context) bool {
-	return startupcli.StdinIsTTY(ctx)
 }
 
 func mapRunInvocationInputError(err error, factoryName string) error {

--- a/pkg/transports/cli/root_submit_batch.go
+++ b/pkg/transports/cli/root_submit_batch.go
@@ -24,6 +24,12 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// maxRunInvocationStdinBytes is the inclusive byte limit for intentional
+// Factory invocation stdin. The extra byte read by collectRunInvocationStdin
+// is only an overflow sentinel and is never passed to Work or retained after
+// rejection.
+const maxRunInvocationStdinBytes = 1 << 20
+
 func scalarTarget[T bool | string | int](value T) *T {
 	return &value
 }
@@ -883,9 +889,15 @@ func collectRunInvocationStdin(
 	if stdin == nil {
 		return nil, fmt.Errorf("read invocation stdin: process stdin is required")
 	}
-	data, err := io.ReadAll(stdin)
+	data, err := io.ReadAll(io.LimitReader(stdin, maxRunInvocationStdinBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read invocation stdin: %w", err)
+	}
+	if len(data) > maxRunInvocationStdinBytes {
+		return nil, fmt.Errorf(
+			"invocation stdin exceeds the %d-byte limit; use --to-file for larger input",
+			maxRunInvocationStdinBytes,
+		)
 	}
 	if len(data) == 0 && !explicitStdin {
 		return nil, nil

--- a/tests/functional/transport/cli/process/stdin_test.go
+++ b/tests/functional/transport/cli/process/stdin_test.go
@@ -1,8 +1,13 @@
 package process_test
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -10,6 +15,156 @@ import (
 	"github.com/portpowered/infinite-you/internal/builtcliacceptance"
 	"github.com/portpowered/infinite-you/internal/testutil"
 )
+
+// TestBuiltCLIRunDirectorySelectionIgnoresOpenStdin proves the descriptor
+// lifetime behavior of a separately built CLI process. Both live and replay
+// directory-selected runs must finish without an EOF from an unrelated pipe,
+// with byte-for-byte equivalent terminal streams to a closed-stdin control.
+func TestBuiltCLIRunDirectorySelectionIgnoresOpenStdin(t *testing.T) {
+	harness := builtcliacceptance.NewHarness(t, testutil.MustRepoRoot(t))
+	session := harness.NewSession(t).WithNoExternalServer(t)
+	factoryPath := writeStdinRunFactory(t, session.WorkDir)
+	factoryDir := filepath.Dir(factoryPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	binaryPath := buildYouBinary(t, ctx, testutil.MustRepoRoot(t))
+
+	baseArgs := append([]string{}, session.RuntimeLogDirFlags()...)
+	baseArgs = append(baseArgs, session.ServerFlags()...)
+	recordingPath := filepath.Join(session.WorkDir, "directory-run.replay.json")
+	recordArgs := append(append([]string{}, baseArgs...),
+		"run", "--dir", factoryDir, "--record", recordingPath, "--quiet",
+	)
+	if result, err := runBuiltCLIWithClosedStdin(t, binaryPath, session, recordArgs...); err != nil || result.ExitCode != 0 {
+		t.Fatalf("create directory-run replay recording: result=%#v err=%v", result, err)
+	}
+	if _, err := os.Stat(recordingPath); err != nil {
+		t.Fatalf("directory-run replay recording %q: %v", recordingPath, err)
+	}
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{name: "live", args: append(append([]string{}, baseArgs...), "run", "--dir", factoryDir, "--no-record", "--quiet")},
+		{name: "replay", args: append(append([]string{}, baseArgs...), "run", "--dir", factoryDir, "--replay", recordingPath, "--no-record", "--quiet")},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			closed, closedErr := runBuiltCLIWithClosedStdin(t, binaryPath, session, test.args...)
+			if closedErr != nil || closed.ExitCode != 0 {
+				t.Fatalf("closed-stdin %s run: result=%#v err=%v", test.name, closed, closedErr)
+			}
+
+			open, openErr := runBuiltCLIWithOpenStdin(t, binaryPath, session, test.args...)
+			if openErr != nil || open.ExitCode != 0 {
+				t.Fatalf("open-stdin %s run: result=%#v err=%v", test.name, open, openErr)
+			}
+			if open != closed {
+				t.Fatalf("open-stdin %s result=%#v differs from closed-stdin control=%#v", test.name, open, closed)
+			}
+		})
+	}
+
+	closedHelp, closedHelpErr := runBuiltCLIWithClosedStdin(t, binaryPath, session, "--help")
+	if closedHelpErr != nil || closedHelp.ExitCode != 0 {
+		t.Fatalf("closed-stdin help: result=%#v err=%v", closedHelp, closedHelpErr)
+	}
+	openHelp, openHelpErr := runBuiltCLIWithOpenStdin(t, binaryPath, session, "--help")
+	if openHelpErr != nil || openHelp.ExitCode != 0 {
+		t.Fatalf("open-stdin help: result=%#v err=%v", openHelp, openHelpErr)
+	}
+	if openHelp != closedHelp {
+		t.Fatalf("open-stdin help result=%#v differs from closed-stdin control=%#v", openHelp, closedHelp)
+	}
+	if !strings.Contains(openHelp.Stdout, "Available Commands:") {
+		t.Fatalf("open-stdin help omitted full command listing:\n%s", openHelp.Stdout)
+	}
+}
+
+func runBuiltCLIWithClosedStdin(
+	t testing.TB,
+	binaryPath string,
+	session *builtcliacceptance.Session,
+	args ...string,
+) (builtcliacceptance.RunResult, error) {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create closed-stdin pipe: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		_ = reader.Close()
+		t.Fatalf("close closed-stdin pipe writer: %v", err)
+	}
+	return runBuiltCLIWithStdin(t, binaryPath, session, reader, args...)
+}
+
+func runBuiltCLIWithOpenStdin(
+	t testing.TB,
+	binaryPath string,
+	session *builtcliacceptance.Session,
+	args ...string,
+) (builtcliacceptance.RunResult, error) {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create open-stdin pipe: %v", err)
+	}
+	defer writer.Close()
+	return runBuiltCLIWithStdin(t, binaryPath, session, reader, args...)
+}
+
+func runBuiltCLIWithStdin(
+	t testing.TB,
+	binaryPath string,
+	session *builtcliacceptance.Session,
+	stdin *os.File,
+	args ...string,
+) (builtcliacceptance.RunResult, error) {
+	t.Helper()
+	defer stdin.Close()
+
+	command := exec.Command(binaryPath, args...)
+	command.Dir = session.WorkDir
+	command.Env = session.ProcessEnv()
+	command.Stdin = stdin
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Start(); err != nil {
+		t.Fatalf("start built CLI with controlled stdin: %v", err)
+	}
+
+	waitResult := make(chan error, 1)
+	go func() { waitResult <- command.Wait() }()
+	var runErr error
+	select {
+	case runErr = <-waitResult:
+	case <-time.After(30 * time.Second):
+		// This is only a bounded failure guard for the OS-process test. The
+		// assertion is completion while the writer remains open, not a latency
+		// threshold.
+		_ = command.Process.Kill()
+		runErr = <-waitResult
+		t.Fatalf("built CLI did not finish with controlled stdin: %v", runErr)
+	}
+
+	exitCode := 0
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(runErr, &exitErr) {
+			t.Fatalf("built CLI wait: %v", runErr)
+		}
+		exitCode = exitErr.ExitCode()
+	}
+	return builtcliacceptance.RunResult{
+		ExitCode: exitCode,
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+	}, runErr
+}
 
 const (
 	stdinSubmitBatchRequestID = "functional-stdin-submit-batch"


### PR DESCRIPTION
{
  "project": "Prevent `you run` from blocking on unrequested stdin",
  "branchName": "cli-run-blocks-on-unbounded-stdin",
  "description": "Make directory-selected live and replay runs ignore unrequested process stdin, and apply finite counted byte limits to every in-scope CLI path that deliberately consumes stdin. The intent is to eliminate the deterministic startup hang and unbounded-memory vector while preserving supported Factory invocation, Work submission, batch submission, and Worker Session stdin workflows without changing server or replay contracts.",
  "context": {
    "customerAsk": "Stop `you run --dir` from reading unrequested stdin, prevent infinite or high-volume pipes from hanging or exhausting memory, preserve every supported CLI workflow that deliberately reads stdin, and prove the result with real terminal output plus deterministic counted-bound tests. Do not change server responses, recordings/replay formats, or the dead-code baseline.",
    "problem": "The `you run` input-normalization path treats non-terminal stdin as invocation content and reads it to EOF even for a directory-selected batch run with no documented piped-input contract. An open quiet pipe blocks startup before any output, and a continuous producer is buffered without bound; the 2026-08-23 probe observed 3.2 GB in six seconds. Adjacent submission and Worker Session commands intentionally read stdin, so a global disable would cause serious regressions, while leaving those reads unbounded would retain the same memory-exhaustion class.",
    "solution": "Keep stdin handling in the CLI transport, decide whether the selected command mode actually accepts stdin before reading any bytes, and make plain `--dir` live/replay runs perform no read. For intentional stdin paths, enforce a named finite inclusive byte limit by reading at most the limit plus one sentinel byte, accepting exact-limit valid input, and returning an actionable failure on overflow before execution or dispatch. Preserve existing parsing, precedence, output, exit codes, requests, and server behavior for valid inputs."
  },
  "acceptanceCriteria": [
    "With an isolated valid Factory, `python -c \"import time; time.sleep(999)\" | you run --dir <factory>` and the equivalent `--replay <recording>` invocation complete with the same stdout, stderr, and exit code as their closed-stdin controls; PR evidence includes before/after terminal output and timings.",
    "A directory-selected run does not call `Read` on stdin when no invocation input is requested, and a continuous producer cannot cause retained input to grow; regression coverage asserts whether a read occurs and enforces a counted byte cap rather than using elapsed time or process-memory assertions.",
    "Every in-scope CLI path that deliberately accepts stdin has a documented finite inclusive byte limit, accepts valid input at or below that limit, reads no more than limit plus one sentinel byte when detecting overflow, and rejects oversized input with an actionable non-success result.",
    "Supported piped Factory/named invocation, Work payload and batch submission, root batch submission, and Worker Session invoke/continue/interrupt/service workflows retain their established successful output and request behavior for representative valid input; `you --help` still succeeds with full help under a never-EOF pipe.",
    "No server response, HTTP status, wire contract, recordings/replay format, generated API artifact, or `docs/internal/baselines/deadcode-baseline.txt` changes, and no broad unrelated cleanup is included.",
    "Quality gate: focused regression and non-regression tests, relevant OS-process functional tests, and repository typecheck/tests pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. The required `Backend Lint` and `Verification Policy` PR checks are used for merge; advisory coverage output and the non-required `localai-backend-artifacts` result are interpreted from their actual logs.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "cli-run-blocks-on-unbounded-stdin-001",
      "title": "Ignore unrequested stdin for directory-selected runs",
      "description": "As a CLI user, I want `you run --dir` to start from the selected Factory without waiting on unrelated process stdin so long-lived parent processes and pipelines cannot silently block the run.",
      "acceptanceCriteria": [
        "A directory-selected run with no documented invocation-input request does not call `Read` on its stdin reader, whether stdin is terminal, closed, an open quiet pipe, or a continuous producer.",
        "Live and `--replay` directory-selected runs under an open never-EOF pipe complete with the same stdout, stderr, and exit code as their closed-stdin controls.",
        "A built-CLI OS-process regression proves the open-pipe behavior because descriptor lifetime is the behavior under test; lower-level coverage uses a reader that deterministically fails if `Read` is called and does not use sleep or memory sampling as its assertion.",
        "PR evidence records the supplied before result (no output and blocked; continuous-input peak 3.2 GB in six seconds) and after terminal output, exit codes, timings, and observed peak memory without claiming this defect caused the 2026-08-22 host OOM.",
        "`you --help` continues to exit successfully with full output while its stdin pipe remains open.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented no-read behavior for unrequested directory/current-Factory run stdin, with counted unit coverage and built-CLI live/replay/help open-pipe regression coverage. Focused CLI and process tests pass; unrelated baseline failures remain in the broader CLI subtree."
    },
    {
      "id": "cli-run-blocks-on-unbounded-stdin-002",
      "title": "Bound supported `you run` invocation stdin",
      "description": "As a user of a Factory whose invocation contract accepts stdin, I want normal piped input to keep working within a clear byte limit and oversized producers to fail safely so explicit stdin support cannot exhaust process memory.",
      "acceptanceCriteria": [
        "Factory-file and named-Factory invocations that accept stdin continue to resolve representative valid piped text through the same invocation argument/source semantics and produce the established successful result.",
        "Run invocation stdin has one named, documented finite inclusive byte limit; input exactly at the limit is accepted, while limit plus one byte is rejected with an actionable CLI error and non-zero exit before Factory execution starts.",
        "Overflow detection reads and retains no more than the configured limit plus one sentinel byte, proven with a counted reader rather than wall-clock timing or process-memory sampling.",
        "Existing empty-input, positional/stdin conflict, file-input, signature, and compatibility behavior remains unchanged for inputs within the limit.",
        "No recordings/replay representation, HTTP request/response contract, or server behavior changes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented a named 1 MiB inclusive limit for intentional Factory/named invocation stdin using limit-plus-one-sentinel reads. Added exact-limit, counted-overflow, pre-preparation rejection, compatibility, focused CLI, vet, and docs-smoke coverage; no server or generated contract changes."
    },
    {
      "id": "cli-run-blocks-on-unbounded-stdin-003",
      "title": "Bound Work payload and batch stdin without breaking submission",
      "description": "As a user submitting Work through stdin, I want valid payloads and batches to keep working while runaway input is rejected at a finite boundary so submission remains safe and predictable.",
      "acceptanceCriteria": [
        "`you submit` payload stdin, `you submit batch` stdin, and the root batch submission stdin path continue to accept representative valid JSON/text inputs and emit the same successful CLI output and HTTP request semantics.",
        "Each intentional Work stdin path enforces an explicit finite inclusive byte limit aligned with its payload or batch contract; an input exactly at the applicable limit is accepted when otherwise valid, and limit plus one byte is rejected before an unbounded allocation or request is made.",
        "Counted-reader tests prove overflow detection consumes no more than the applicable limit plus one sentinel byte and returns an actionable non-success result without relying on timing or memory measurements.",
        "File and inline input precedence remains unchanged, including the rule that an explicitly selected file ignores unrelated stdin.",
        "Existing server payload-size validation, HTTP statuses, response bodies, OpenAPI contracts, and generated clients remain unchanged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added a named 16 MiB inclusive batch-stdin cap and reused a limit-plus-one-sentinel reader for unary payload stdin. Unary stdin now checks both the 64 KiB source cap and the compact JSON Work-admission boundary after text escaping, with exact encoded-boundary and escaped-overflow pre-dispatch coverage; no server or generated contract changes."
    },
    {
      "id": "cli-run-blocks-on-unbounded-stdin-004",
      "title": "Bound Worker Session stdin without breaking direct control commands",
      "description": "As an operator invoking or controlling Worker Sessions through stdin, I want valid direct-execution and control documents to retain their behavior while oversized input is rejected safely.",
      "acceptanceCriteria": [
        "Worker Session invoke, continue, interrupt, and service commands continue to read stdin only on their established explicit input paths and produce the same successful output/request behavior for representative valid documents.",
        "Each in-scope Worker Session stdin reader enforces a named finite inclusive byte limit; valid input exactly at the limit is accepted when otherwise valid, and limit plus one byte returns the command's actionable input failure without dispatching a partial request.",
        "Counted-reader tests prove no overflow path reads or retains more than the applicable limit plus one sentinel byte, without wall-clock or process-memory assertions.",
        "Existing TTY handling, inline/file input, JSON single-document validation, async/synchronous behavior, and diagnostics remain unchanged for valid inputs.",
        "No Worker Session HTTP contract, server response, or generated client changes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Bounded all intentional Worker Session stdin readers with named 1 MiB inclusive limits and limit-plus-one sentinel reads. Added exact-limit, counted-overflow, pre-dispatch, TTY, file/explicit-precedence, focused CLI, worker functional, process, vet, and docs-smoke coverage; no server or generated contract changes. Backend lint gates pass; unrelated UI dependency and packaged-factory baseline checks remain environment/base failures."
    }
  ]
}
