### PR TITLE
deflake-generic-assets-concurrent-download-and-main-functional

### DIFF
--- a/pkg/services/models/internal/services/assets/internal/service/generic_cache.go
+++ b/pkg/services/models/internal/services/assets/internal/service/generic_cache.go
@@ -41,6 +41,9 @@ func (s *service) acquireGenericCache(
 	if call, ok := s.inflight[key]; ok {
 		done := call.done
 		s.cacheMu.Unlock()
+		if s.cacheJoinObserver != nil {
+			s.cacheJoinObserver()
+		}
 		select {
 		case <-ctx.Done():
 			return genericCacheResult{}, ctx.Err()

--- a/pkg/services/models/internal/services/assets/internal/service/generic_cache_concurrency_test.go
+++ b/pkg/services/models/internal/services/assets/internal/service/generic_cache_concurrency_test.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+)
+
+func TestPrepareGenericAssetsSharesConcurrentFirstDownload(t *testing.T) {
+	t.Parallel()
+
+	const callers = 8
+
+	body := []byte("concurrent payload")
+	digest := sha256Hex(body)
+	downloadStarted := make(chan struct{})
+	releaseDownload := make(chan struct{})
+	var downloadStartedOnce sync.Once
+	var releaseDownloadOnce sync.Once
+	var downloads atomic.Int32
+	client := genericManifestClient("weights.bin", body, func() []byte {
+		downloads.Add(1)
+		downloadStartedOnce.Do(func() { close(downloadStarted) })
+		<-releaseDownload
+		return body
+	})
+	scopes := newScopes(t, "generic-singleflight")
+	scope := openScope(t, scopes, t.TempDir(), models.RuntimeConfig{})
+	service := newGenericService(t, scopes, client, func(string) string { return "" })
+	var joined atomic.Int32
+	allJoined := make(chan struct{})
+	var allJoinedOnce sync.Once
+	service.cacheJoinObserver = func() {
+		if joined.Add(1) == callers-1 {
+			allJoinedOnce.Do(func() { close(allJoined) })
+		}
+	}
+	request := models.PrepareModelAssetsRequest{
+		Scope:     scope,
+		Reference: models.ModelReference{NameOrURI: "hf://owner/repo/weights.bin@" + genericTestRevision},
+		Artifacts: []models.AssetRequirement{{Name: "weights.bin", SHA256: digest, Bytes: int64(len(body))}},
+	}
+	results := make(chan error, callers)
+	for index := 0; index < callers; index++ {
+		go func() {
+			_, err := service.PrepareModelAssets(context.Background(), request)
+			results <- err
+		}()
+	}
+	t.Cleanup(func() { releaseDownloadOnce.Do(func() { close(releaseDownload) }) })
+	<-downloadStarted
+	<-allJoined
+	releaseDownloadOnce.Do(func() { close(releaseDownload) })
+	for index := 0; index < callers; index++ {
+		if err := <-results; err != nil {
+			t.Fatalf("concurrent preparation %d: %v", index, err)
+		}
+	}
+	if got := joined.Load(); got != callers-1 {
+		t.Fatalf("joined caller count = %d, want %d", got, callers-1)
+	}
+	if got := downloads.Load(); got != 1 {
+		t.Fatalf("download count = %d, want 1", got)
+	}
+}

--- a/pkg/services/models/internal/services/assets/internal/service/generic_cache_test.go
+++ b/pkg/services/models/internal/services/assets/internal/service/generic_cache_test.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -630,64 +629,6 @@ func TestPrepareGenericAssetsDiskFailureLeavesNoPartialSnapshot(t *testing.T) {
 	}
 	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
 		t.Fatalf("read cache root after disk failure: %v", readErr)
-	}
-}
-
-func TestPrepareGenericAssetsSharesConcurrentFirstDownload(t *testing.T) {
-	t.Parallel()
-
-	const callers = 8
-
-	body := []byte("concurrent payload")
-	digest := sha256Hex(body)
-	downloadStarted := make(chan struct{})
-	releaseDownload := make(chan struct{})
-	var downloadStartedOnce sync.Once
-	var releaseDownloadOnce sync.Once
-	var downloads atomic.Int32
-	client := genericManifestClient("weights.bin", body, func() []byte {
-		downloads.Add(1)
-		downloadStartedOnce.Do(func() { close(downloadStarted) })
-		<-releaseDownload
-		return body
-	})
-	scopes := newScopes(t, "generic-singleflight")
-	scope := openScope(t, scopes, t.TempDir(), models.RuntimeConfig{})
-	service := newGenericService(t, scopes, client, func(string) string { return "" })
-	var joined atomic.Int32
-	allJoined := make(chan struct{})
-	var allJoinedOnce sync.Once
-	service.cacheJoinObserver = func() {
-		if joined.Add(1) == callers-1 {
-			allJoinedOnce.Do(func() { close(allJoined) })
-		}
-	}
-	request := models.PrepareModelAssetsRequest{
-		Scope:     scope,
-		Reference: models.ModelReference{NameOrURI: "hf://owner/repo/weights.bin@" + genericTestRevision},
-		Artifacts: []models.AssetRequirement{{Name: "weights.bin", SHA256: digest, Bytes: int64(len(body))}},
-	}
-	results := make(chan error, callers)
-	for index := 0; index < callers; index++ {
-		go func() {
-			_, err := service.PrepareModelAssets(context.Background(), request)
-			results <- err
-		}()
-	}
-	t.Cleanup(func() { releaseDownloadOnce.Do(func() { close(releaseDownload) }) })
-	<-downloadStarted
-	<-allJoined
-	releaseDownloadOnce.Do(func() { close(releaseDownload) })
-	for index := 0; index < callers; index++ {
-		if err := <-results; err != nil {
-			t.Fatalf("concurrent preparation %d: %v", index, err)
-		}
-	}
-	if got := joined.Load(); got != callers-1 {
-		t.Fatalf("joined caller count = %d, want %d", got, callers-1)
-	}
-	if got := downloads.Load(); got != 1 {
-		t.Fatalf("download count = %d, want 1", got)
 	}
 }
 

--- a/pkg/services/models/internal/services/assets/internal/service/generic_cache_test.go
+++ b/pkg/services/models/internal/services/assets/internal/service/generic_cache_test.go
@@ -14,9 +14,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	modelseffects "github.com/portpowered/infinite-you/pkg/services/models/internal/effects"
@@ -636,45 +636,55 @@ func TestPrepareGenericAssetsDiskFailureLeavesNoPartialSnapshot(t *testing.T) {
 func TestPrepareGenericAssetsSharesConcurrentFirstDownload(t *testing.T) {
 	t.Parallel()
 
+	const callers = 8
+
 	body := []byte("concurrent payload")
 	digest := sha256Hex(body)
-	entered := make(chan struct{})
-	release := make(chan struct{})
+	downloadStarted := make(chan struct{})
+	releaseDownload := make(chan struct{})
+	var downloadStartedOnce sync.Once
+	var releaseDownloadOnce sync.Once
 	var downloads atomic.Int32
 	client := genericManifestClient("weights.bin", body, func() []byte {
 		downloads.Add(1)
-		select {
-		case entered <- struct{}{}:
-		default:
-		}
-		<-release
+		downloadStartedOnce.Do(func() { close(downloadStarted) })
+		<-releaseDownload
 		return body
 	})
 	scopes := newScopes(t, "generic-singleflight")
 	scope := openScope(t, scopes, t.TempDir(), models.RuntimeConfig{})
 	service := newGenericService(t, scopes, client, func(string) string { return "" })
+	var joined atomic.Int32
+	allJoined := make(chan struct{})
+	var allJoinedOnce sync.Once
+	service.cacheJoinObserver = func() {
+		if joined.Add(1) == callers-1 {
+			allJoinedOnce.Do(func() { close(allJoined) })
+		}
+	}
 	request := models.PrepareModelAssetsRequest{
 		Scope:     scope,
 		Reference: models.ModelReference{NameOrURI: "hf://owner/repo/weights.bin@" + genericTestRevision},
 		Artifacts: []models.AssetRequirement{{Name: "weights.bin", SHA256: digest, Bytes: int64(len(body))}},
 	}
-	results := make(chan error, 8)
-	for index := 0; index < 8; index++ {
+	results := make(chan error, callers)
+	for index := 0; index < callers; index++ {
 		go func() {
 			_, err := service.PrepareModelAssets(context.Background(), request)
 			results <- err
 		}()
 	}
-	select {
-	case <-entered:
-	case <-time.After(2 * time.Second):
-		t.Fatal("concurrent download did not start")
-	}
-	close(release)
-	for index := 0; index < 8; index++ {
+	t.Cleanup(func() { releaseDownloadOnce.Do(func() { close(releaseDownload) }) })
+	<-downloadStarted
+	<-allJoined
+	releaseDownloadOnce.Do(func() { close(releaseDownload) })
+	for index := 0; index < callers; index++ {
 		if err := <-results; err != nil {
 			t.Fatalf("concurrent preparation %d: %v", index, err)
 		}
+	}
+	if got := joined.Load(); got != callers-1 {
+		t.Fatalf("joined caller count = %d, want %d", got, callers-1)
 	}
 	if got := downloads.Load(); got != 1 {
 		t.Fatalf("download count = %d, want 1", got)

--- a/pkg/services/models/internal/services/assets/internal/service/service.go
+++ b/pkg/services/models/internal/services/assets/internal/service/service.go
@@ -41,6 +41,9 @@ type service struct {
 
 	cacheMu  sync.Mutex
 	inflight map[string]*assetCacheCall
+	// cacheJoinObserver is an optional concurrency observer used by tests to
+	// coordinate followers at the shared-cache boundary.
+	cacheJoinObserver func()
 
 	pullStateMu sync.RWMutex
 	activePulls map[string]activePullState

--- a/tests/functional/sessions/lifecycle/remote_lifecycle_test.go
+++ b/tests/functional/sessions/lifecycle/remote_lifecycle_test.go
@@ -239,17 +239,20 @@ func executeLocalPlacementRunWithReadiness(
 	command := support.StartProcessCommand(t, process, inputs.Input)
 	select {
 	case <-readinessOutput.started:
-		cancel()
+		// Stop uses the support command's existing bounded cancellation
+		// lifecycle, so a cancellation-controlled invocation cannot strand the
+		// test while it waits for Process.Execute to return.
+		command.Stop(t)
+	case <-command.Done():
+		// Preserve a pre-readiness bootstrap or invocation failure for the
+		// parity assertions instead of waiting for an outer test timeout.
+		command.AcceptError()
+		return placementObservation(command, readinessOutput)
 	case <-parentContext.Done():
 		command.Stop(t)
 		t.Fatalf("local run did not reach invocation readiness: %v\noutput:\n%s", parentContext.Err(), readinessOutput.String())
 	}
-	<-command.Done()
-	return placementRunObservation{
-		err:    command.Err(),
-		stdout: readinessOutput.String(),
-		stderr: readinessOutput.String(),
-	}
+	return placementObservation(command, readinessOutput)
 }
 
 func executeRemotePlacementRunWithReadiness(
@@ -282,7 +285,15 @@ func executeRemotePlacementRunWithReadiness(
 	command := support.StartProcessCommand(t, process, inputs.Input)
 	select {
 	case <-admissionOutput.started:
-		cancel()
+		// Stop uses the support command's existing bounded cancellation
+		// lifecycle, so a cancellation-controlled invocation cannot strand the
+		// test while it waits for Process.Execute to return.
+		command.Stop(t)
+	case <-command.Done():
+		// Preserve a pre-readiness bootstrap or invocation failure for the
+		// parity assertions instead of waiting for an outer test timeout.
+		command.AcceptError()
+		return placementObservation(command, admissionOutput)
 	case <-parentContext.Done():
 		command.Stop(t)
 		t.Fatalf("remote run did not reach durable-admission readiness: %v\noutput:\n%s", parentContext.Err(), admissionOutput.String())
@@ -293,11 +304,18 @@ func executeRemotePlacementRunWithReadiness(
 			t.Errorf("terminate cancellation parity durable session %s: %v", sessionID, err)
 		}
 	}()
-	<-command.Done()
+	return placementObservation(command, admissionOutput)
+}
+
+type placementOutput interface {
+	String() string
+}
+
+func placementObservation(command *support.ProcessCommand, output placementOutput) placementRunObservation {
 	return placementRunObservation{
 		err:    command.Err(),
-		stdout: admissionOutput.String(),
-		stderr: admissionOutput.String(),
+		stdout: output.String(),
+		stderr: output.String(),
 	}
 }
 

--- a/tests/functional/sessions/lifecycle/remote_lifecycle_test.go
+++ b/tests/functional/sessions/lifecycle/remote_lifecycle_test.go
@@ -76,21 +76,26 @@ func TestCLILocalAndRemoteRunDomainFailureParityThroughRootProcess(t *testing.T)
 // caller cancellation reaches both local and selected-server placements and
 // neither path reports a fabricated successful primary result.
 func TestCLILocalAndRemoteRunCancellationParityThroughRootProcess(t *testing.T) {
-	homeDir := t.TempDir()
-	namedFactoryDir := scaffoldNamedPlacementFactory(
+	// Keep independent public bootstraps from contending over server-owned
+	// packaged-Factory staging while this test exercises placement parity.
+	clientHomeDir := t.TempDir()
+	serverHomeDir := t.TempDir()
+	clientFactoryDir := scaffoldNamedPlacementFactory(
 		t,
-		homeDir,
+		clientHomeDir,
 		"session-parity-cancel",
 		`while (true) {}`,
 	)
-	server := startRemotePlacementServer(t, homeDir, namedFactoryDir)
+	serverFactoryDir := scaffoldNamedPlacementFactory(
+		t,
+		serverHomeDir,
+		"session-parity-cancel",
+		`while (true) {}`,
+	)
+	server := startRemotePlacementServer(t, serverHomeDir, serverFactoryDir)
 
-	localContext, cancelLocal := context.WithTimeout(t.Context(), 500*time.Millisecond)
-	defer cancelLocal()
-	remoteContext, cancelRemote := context.WithTimeout(t.Context(), 500*time.Millisecond)
-	defer cancelRemote()
-	local := executePlacementRunWithContext(localContext, t, homeDir, namedFactoryDir, "session-parity-cancel", "", false)
-	remote := executePlacementRunWithContext(remoteContext, t, homeDir, namedFactoryDir, "session-parity-cancel", server.URL(), true)
+	local := executePlacementRunWithContext(t.Context(), t, clientHomeDir, clientFactoryDir, "session-parity-cancel", "", false)
+	remote := executePlacementRunWithContext(t.Context(), t, clientHomeDir, clientFactoryDir, "session-parity-cancel", server.URL(), true)
 	assertPlacementCancellationParity(t, local, remote)
 }
 
@@ -174,28 +179,126 @@ func executePlacementRun(
 	remote bool,
 ) placementRunObservation {
 	t.Helper()
-	return executePlacementRunWithContext(t.Context(), t, homeDir, workingDirectory, factoryName, serverURL, remote)
-}
-
-func executePlacementRunWithContext(
-	ctx context.Context,
-	t *testing.T,
-	homeDir, workingDirectory, factoryName, serverURL string,
-	remote bool,
-) placementRunObservation {
-	t.Helper()
 	args := []string{"you"}
 	if remote {
 		args = append(args, "--remote", "--server", serverURL)
 	}
 	args = append(args, "--json", "run", "--named", factoryName, "--no-record", "placement parity")
-	inputs := support.FakeInputs(ctx, args)
+	inputs := support.FakeInputs(t.Context(), args)
 	inputs.Input.Env = []string{"HOME=" + homeDir, "USERPROFILE=" + homeDir}
 	inputs.Input.WorkingDirectory = workingDirectory
 	process := support.BuildProcess(t, serviceedges.Edges{})
 	support.CleanupProcess(t, process)
 	err := process.Execute(inputs.Input)
 	return placementRunObservation{err: err, stdout: inputs.Stdout(), stderr: inputs.Stderr()}
+}
+
+func executePlacementRunWithContext(
+	parentContext context.Context,
+	t *testing.T,
+	homeDir, workingDirectory, factoryName, serverURL string,
+	remote bool,
+) placementRunObservation {
+	t.Helper()
+	if remote {
+		return executeRemotePlacementRunWithReadiness(
+			parentContext, t, homeDir, workingDirectory, factoryName, serverURL,
+		)
+	}
+	return executeLocalPlacementRunWithReadiness(
+		parentContext, t, homeDir, workingDirectory, factoryName,
+	)
+}
+
+func executeLocalPlacementRunWithReadiness(
+	parentContext context.Context,
+	t *testing.T,
+	homeDir, workingDirectory, factoryName string,
+) placementRunObservation {
+	t.Helper()
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	placementEnvironment := []string{"HOME=" + homeDir, "USERPROFILE=" + homeDir}
+	// Complete public system initialization through the same process before the
+	// cancellation-controlled invocation. The invocation still waits for its
+	// observable response event before canceling.
+	support.InitializeCustomerHomeWithProcess(
+		t, process, placementEnvironment, workingDirectory,
+	)
+
+	runContext, cancel := context.WithCancel(parentContext)
+	defer cancel()
+	inputs := support.FakeInputs(runContext, []string{
+		"you", "--json", "run", "--named", factoryName, "--output", "response-stream", "--no-record", "placement parity",
+	})
+	readinessOutput := newLocalInvocationReadinessOutput()
+	inputs.Input.Stdout = readinessOutput
+	inputs.Input.Stderr = readinessOutput
+	inputs.Input.Env = placementEnvironment
+	inputs.Input.WorkingDirectory = workingDirectory
+	command := support.StartProcessCommand(t, process, inputs.Input)
+	select {
+	case <-readinessOutput.started:
+		cancel()
+	case <-parentContext.Done():
+		command.Stop(t)
+		t.Fatalf("local run did not reach invocation readiness: %v\noutput:\n%s", parentContext.Err(), readinessOutput.String())
+	}
+	<-command.Done()
+	return placementRunObservation{
+		err:    command.Err(),
+		stdout: readinessOutput.String(),
+		stderr: readinessOutput.String(),
+	}
+}
+
+func executeRemotePlacementRunWithReadiness(
+	parentContext context.Context,
+	t *testing.T,
+	homeDir, workingDirectory, factoryName, serverURL string,
+) placementRunObservation {
+	t.Helper()
+	args := []string{"you"}
+	args = append(args, "--remote", "--server", serverURL, "--verbose")
+	args = append(args, "--json", "run", "--named", factoryName, "--no-record", "placement parity")
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	placementEnvironment := []string{"HOME=" + homeDir, "USERPROFILE=" + homeDir}
+	// Complete public system initialization through the same process before the
+	// cancellation-controlled invocation. The invocation still waits for
+	// observable durable admission before canceling.
+	support.InitializeCustomerHomeWithProcess(
+		t, process, placementEnvironment, workingDirectory,
+	)
+
+	runContext, cancel := context.WithCancel(parentContext)
+	defer cancel()
+	inputs := support.FakeInputs(runContext, args)
+	admissionOutput := newRemoteAdmissionOutput()
+	inputs.Input.Stdout = admissionOutput
+	inputs.Input.Stderr = admissionOutput
+	inputs.Input.Env = placementEnvironment
+	inputs.Input.WorkingDirectory = workingDirectory
+	command := support.StartProcessCommand(t, process, inputs.Input)
+	select {
+	case <-admissionOutput.started:
+		cancel()
+	case <-parentContext.Done():
+		command.Stop(t)
+		t.Fatalf("remote run did not reach durable-admission readiness: %v\noutput:\n%s", parentContext.Err(), admissionOutput.String())
+	}
+	sessionID := remoteSessionIDFromAdmissionOutput(t, admissionOutput.String())
+	defer func() {
+		if err := terminateRemoteFunctionalSession(serverURL, sessionID); err != nil {
+			t.Errorf("terminate cancellation parity durable session %s: %v", sessionID, err)
+		}
+	}()
+	<-command.Done()
+	return placementRunObservation{
+		err:    command.Err(),
+		stdout: admissionOutput.String(),
+		stderr: admissionOutput.String(),
+	}
 }
 
 func assertPlacementSuccessParity(
@@ -279,6 +382,15 @@ func assertPlacementCancellationParity(
 		}
 		if strings.Contains(observation.stdout, "placement parity complete") {
 			t.Fatalf("%s stdout fabricated a successful primary result:\n%s", name, observation.stdout)
+		}
+		combinedOutput := strings.ToLower(observation.stdout + "\n" + observation.stderr)
+		for _, diagnostic := range []string{
+			"packaged factory installation",
+			"initialize system: system bootstrap initialize partial failure",
+		} {
+			if strings.Contains(combinedOutput, diagnostic) {
+				t.Fatalf("%s reported bootstrap diagnostic %q:\n%s", name, diagnostic, observation.stdout+"\n"+observation.stderr)
+			}
 		}
 	}
 }
@@ -452,6 +564,34 @@ func (writer *remoteAdmissionOutput) Write(p []byte) (int, error) {
 }
 
 func (writer *remoteAdmissionOutput) String() string {
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	return writer.output.String()
+}
+
+type localInvocationReadinessOutput struct {
+	mu      sync.Mutex
+	output  strings.Builder
+	started chan struct{}
+	once    sync.Once
+}
+
+func newLocalInvocationReadinessOutput() *localInvocationReadinessOutput {
+	return &localInvocationReadinessOutput{started: make(chan struct{})}
+}
+
+func (writer *localInvocationReadinessOutput) Write(p []byte) (int, error) {
+	writer.mu.Lock()
+	_, _ = writer.output.Write(p)
+	started := strings.Contains(writer.output.String(), `"recordType":"factory_event"`)
+	writer.mu.Unlock()
+	if started {
+		writer.once.Do(func() { close(writer.started) })
+	}
+	return len(p), nil
+}
+
+func (writer *localInvocationReadinessOutput) String() string {
 	writer.mu.Lock()
 	defer writer.mu.Unlock()
 	return writer.output.String()


### PR DESCRIPTION
{
  "project": "Restore Main Verification by Removing Two Test Timing Failures",
  "branchName": "deflake-generic-assets-concurrent-download-and-main-functional",
  "description": "Restore main's required Verification Policy by classifying and correcting the generic-assets concurrent first-download failure and the named local/remote cancellation functional failure. Preserve the guarded behaviors, replace elapsed-time dependence with deterministic counted or event-based synchronization when evidence proves a flake, correct any genuine regression instead of masking it, and provide repeat, race, focused functional, and final PR CI evidence without weakening tests or changing coverage floors.",
  "context": {
    "customerAsk": "Restore the required verification checks on main by fixing TestPrepareGenericAssetsSharesConcurrentFirstDownload and the one failing functional test. State the same-head rerun outcome and verdict for each failure, retain both tests at full behavioral strength, use counted/event-based synchronization rather than longer timeouts, provide repeat and race evidence, and land the smallest correct fix without entering sibling-owned models read/CLI surfaces or shared CI/baseline files.",
    "problem": "At origin/main bd7d18e16, run 32642126380 failed Backend Unit Coverage at exactly 2.00 seconds because TestPrepareGenericAssetsSharesConcurrentFirstDownload required a goroutine to begin an HTTP download within a fixed wall-clock window. PR #2211 run 32638912321 identifies the second failure as TestCLILocalAndRemoteRunCancellationParityThroughRootProcess in tests/functional/sessions/lifecycle, where a 500 ms caller deadline can expire during system initialization and produce a packaged-Factory installation/bootstrap error before the intended cancellation behavior is exercised. The test failures prevent coverage evaluation and make Verification Policy red for unrelated lanes; coverage floors are not the defect.",
    "solution": "Read the completed same-head rerun once and classify each failure before changing behavior. For a same-SHA pass, replace timing dependence with existing counted, channel, barrier, or readiness synchronization; for an identical same-SHA failure, correct and attribute the smallest owned production regression. Make the Models test prove that eight identical first callers join one in-flight acquisition and trigger exactly one download, and make the functional scenario wait for the intended root-built local and remote run paths before cancellation. Verify with 50 repeated unit runs, race coverage, repeated focused functional runs, and final PR coverage lanes that complete far enough to report real verdicts."
  },
  "acceptanceCriteria": [
    "The PR body links run 32642126380, states the completed same-head rerun result and flake/regression verdict for TestPrepareGenericAssetsSharesConcurrentFirstDownload, and confirms the Models assets path history between 5637f83a7 and bd7d18e16; a deterministic result identifies the responsible behavior or merge rather than being labeled a flake.",
    "TestPrepareGenericAssetsSharesConcurrentFirstDownload deterministically proves that all concurrent identical first callers join one in-flight operation, complete successfully, and cause exactly one underlying download, using counted/event-based synchronization rather than sleep, polling, memory observation, or a longer two-second timeout.",
    "The PR names TestCLILocalAndRemoteRunCancellationParityThroughRootProcess and its tests/functional/sessions/lifecycle failure, states its evidence-backed flake/regression verdict, and ensures both local and remote runs observe caller cancellation after the intended path is ready without reporting packaged-Factory initialization failure or fabricated success output.",
    "Neither failing test is deleted, skipped, weakened, or converted into an assertion on implementation topology; no coverage floor or manifest is changed, and the lane does not modify docs/internal/baselines/deadcode-baseline.txt, models CLI/read surfaces, or factory/scripts/ci-wait.py.",
    "Quality gate: Typecheck passes; the focused generic-assets test passes with -count=50 and with -race; the named functional test and appropriate focused package suites pass; and no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. On the final PR head, the review stage confirms Backend Lint and Verification Policy are terminal and passing, with both coverage lanes completing far enough to report their actual verdicts; advisory coverage floors and the non-required localai-backend-artifacts result are not substituted for this evidence.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "deflake-generic-assets-concurrent-download-and-main-functional-001",
      "title": "Classify both main failures from same-head evidence",
      "description": "As a maintainer, I want each failure classified from completed same-head and path-history evidence so that a timing flake receives a synchronization fix and a real regression receives a behavior fix.",
      "acceptanceCriteria": [
        "The completed attempt 2 result for run 32642126380 is read once and recorded with its URL, SHA, unit-test outcome, and explicit flake or regression verdict; implementation does not poll or re-check the run.",
        "The functional failure is recorded as TestCLILocalAndRemoteRunCancellationParityThroughRootProcess in tests/functional/sessions/lifecycle, including the observed local packaged-Factory initialization error and evidence from a same-head run or an unaffected-branch run showing whether the identical failure repeats.",
        "Git history over the Models assets path from 5637f83a7 through bd7d18e16 is recorded, and each deterministic regression is attributed to the behavior or intervening merge that introduced it.",
        "The selected correction for each test follows its verdict: event/readiness synchronization for a flake, or the smallest owned production-behavior correction for a deterministic regression.",
        "The PR evidence describes the observable behaviors being retained—one shared download and local/remote cancellation—rather than treating coverage floors or source topology as the target.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Classified from completed evidence: run 32642126380 (https://github.com/portpowered/you-agent-factory/actions/runs/32642126380) succeeded on exact main SHA bd7d18e16ef233f9051fa984cff93e43a5d7f366, so TestPrepareGenericAssetsSharesConcurrentFirstDownload is a timing flake, not a production regression. Git history shows no Models assets-path changes between 5637f83a757d8727cc5acf3d7d5e8e87d25d1a10 and bd7d18e16. Run 32638912321 (https://github.com/portpowered/you-agent-factory/actions/runs/32638912321) failed Backend Functional Coverage on unrelated head ba3d7666; the named TestCLILocalAndRemoteRunCancellationParityThroughRootProcess failure is the observed packaged-Factory bootstrap race, not a durable cancellation regression: the same test passes on current main. Selected corrections are counted/event synchronization for the generic download and readiness/event synchronization for local/remote cancellation. The focused current-main test compiled and passed, satisfying typecheck evidence for this story."
    },
    {
      "id": "deflake-generic-assets-concurrent-download-and-main-functional-002",
      "title": "Make concurrent first-download sharing deterministic",
      "description": "As a Models maintainer, I want concurrent identical first requests to be verified through deterministic coordination so that loaded runner scheduling cannot make correct singleflight behavior fail.",
      "acceptanceCriteria": [
        "The test deterministically observes counted caller progress into the shared in-flight cache operation before releasing the blocked download; no assertion depends on a goroutine being scheduled within two seconds.",
        "Eight concurrent identical first requests complete successfully and the injected download effect is called exactly once, preserving the existing generic asset result and cache behavior.",
        "The synchronization follows an existing nearby channel, barrier, wait-group, or counted-call idiom, has explicit ownership and cleanup, and cannot strand goroutines when an assertion or context fails.",
        "If same-head evidence instead shows a deterministic production regression, the in-flight cache implementation is corrected within Models assets ownership so the same one-download/eight-result behavior holds; no timeout increase is used as the fix.",
        "go test for TestPrepareGenericAssetsSharesConcurrentFirstDownload passes with -count=50, and the focused package test passes with the race detector; exact commands and outputs are placed in the PR conversation.",
        "The test is not deleted, skipped, relaxed to fewer callers, or changed to accept more than one download.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Replaced the best-effort unbuffered download-start notification and fixed two-second scheduler gate with an event-based download gate plus a counted observer at the shared in-flight cache boundary. The test waits for the leader download and all seven followers to join before releasing the blocked body, verifies eight successful results, and asserts one underlying download. The release gate is closed by cleanup on failure. Focused test passed with -count=50; the focused race command passed under WSL Go 1.25 (Windows ThreadSanitizer could not allocate its runtime region, error code 87); the full assets service package and make typecheck passed. The test was moved to generic_cache_concurrency_test.go during review to keep generic_cache_test.go under the 1000-line lint limit. Commit: e636530eb plus review follow-up."
    },
    {
      "id": "deflake-generic-assets-concurrent-download-and-main-functional-003",
      "title": "Make local and remote cancellation parity wait for readiness",
      "description": "As a CLI user, I want cancellation to reach both local and selected-server run placements consistently so that initialization timing cannot replace the requested cancellation outcome with an unrelated bootstrap failure.",
      "acceptanceCriteria": [
        "The functional scenario uses root.BuildProcess and Process.Execute and deterministically observes the readiness/event required to know the intended local and remote run paths are active before triggering cancellation.",
        "Both placements return errors matching context.Canceled or context.DeadlineExceeded, neither reports packaged-Factory installation/bootstrap failure as the cancellation outcome, and neither emits a fabricated successful primary result.",
        "The correction does not increase the 500 ms deadline, add a sleep, add timeout-padded polling, bypass system initialization, or replace the real process path with an implementation-only fake.",
        "If evidence identifies a deterministic regression, the smallest owning behavior is corrected and the introducing merge is named; unrelated Factory initialization, models read/CLI, and transport behavior remain unchanged.",
        "The named functional test passes repeatedly in its focused package, and relevant focused runs pass with the race detector when supported by the test harness; commands and outputs are placed in the PR conversation.",
        "The test is not deleted, skipped, or weakened, and it continues to assert both local and remote cancellation behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Updated TestCLILocalAndRemoteRunCancellationParityThroughRootProcess in tests/functional/sessions/lifecycle to use root.BuildProcess/Process.Execute with public readiness events: a local response-stream Factory Event and remote durable admission. System initialization completes through the same reusable process before the cancellation-controlled invocation; the prior 500 ms elapsed deadline is not increased or used as a startup gate. Client and server use independent homes to avoid concurrent packaged-Factory staging contention, and the admitted remote session is explicitly terminated after client cancellation so repetitions cannot retain infinite JS work. The readiness select now also returns a pre-readiness terminal Process.Execute error immediately, marking it accepted for cleanup, while the ready path uses the existing bounded ProcessCommand.Stop lifecycle. The assertion still requires context.Canceled or context.DeadlineExceeded, rejects packaged-Factory bootstrap diagnostics, and rejects fabricated success output. The named test passed with -count=50 (ok, 562.655s) and the review follow-up -count=3 (ok, 21.203s); the focused lifecycle placement suite passed (ok, 13.279s); WSL Go 1.25 race passed (ok, 13.349s). Windows race cannot allocate ThreadSanitizer memory (error code 87), matching the documented environment limitation. make typecheck and make test passed. No production behavior or unrelated CLI/read/transport surfaces changed. Commit: 03ff4582d plus review follow-up."
    }
  ]
}
