### PR TITLE
lai-v7-dangling-backend-reference-guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       run_readme: ${{ steps.classify.outputs.run_readme != 'false' }}
       run_frontend: ${{ steps.classify.outputs.run_frontend != 'false' }}
       run_backend: ${{ steps.classify.outputs.run_backend != 'false' }}
+      run_backend_conformance: ${{ steps.classify.outputs.run_backend_conformance != 'false' }}
       run_ui_backend_integration: ${{ steps.classify.outputs.run_ui_backend_integration != 'false' }}
       run_api_package: ${{ steps.classify.outputs.run_api_package != 'false' }}
       run_packaged_factories_package: ${{ steps.classify.outputs.run_packaged_factories_package != 'false' }}
@@ -41,6 +42,7 @@ jobs:
       readme_reason: ${{ steps.classify.outputs.readme_reason || steps.classify.outputs.reason || 'Conservative full verification.' }}
       frontend_reason: ${{ steps.classify.outputs.frontend_reason || steps.classify.outputs.reason || 'Conservative full verification.' }}
       backend_reason: ${{ steps.classify.outputs.backend_reason || steps.classify.outputs.reason || 'Conservative full verification.' }}
+      backend_conformance_reason: ${{ steps.classify.outputs.backend_conformance_reason || steps.classify.outputs.reason || 'Conservative full verification.' }}
       ui_backend_integration_reason: ${{ steps.classify.outputs.ui_backend_integration_reason || steps.classify.outputs.reason || 'Conservative full verification.' }}
       api_package_reason: ${{ steps.classify.outputs.api_package_reason || steps.classify.outputs.reason || 'Conservative full verification.' }}
       packaged_factories_package_reason: ${{ steps.classify.outputs.packaged_factories_package_reason || steps.classify.outputs.reason || 'Conservative full verification.' }}
@@ -59,7 +61,7 @@ jobs:
         run: go run ./cmd/ciclassify -base "${{ github.event.pull_request.base.sha }}" -head "${{ github.event.pull_request.head.sha }}"
       - if: github.event_name != 'pull_request'
         run: |
-          for lane in docs_reference readme frontend backend ui_backend_integration api_package packaged_factories_package model_providers_package; do
+          for lane in docs_reference readme frontend backend backend_conformance ui_backend_integration api_package packaged_factories_package model_providers_package; do
             echo "run_${lane}=true" >> "$GITHUB_OUTPUT"
           done
           echo "classification=full" >> "$GITHUB_OUTPUT"
@@ -533,6 +535,23 @@ jobs:
           CHANGED_TEST_STABILITY_BUDGET: 15m
         run: make test-changed-test-stability
 
+  backend-conformance:
+    name: Backend Conformance
+    needs: classify
+    if: always() && needs.classify.outputs.run_backend_conformance != 'false'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: Run offline backend conformance guard
+        run: make test-backend-conformance
+
   backend-lint:
     name: Backend Lint
     if: github.event_name == 'pull_request' || github.event_name == 'push'
@@ -752,7 +771,7 @@ jobs:
 
   verification-policy:
     name: Verification Policy
-    needs: [classify, workflow-lint, docs-reference, readme, frontend, frontend-component, ui-coverage, frontend-browser, frontend-storybook, backend-coverage, backend-test-stability, backend-lint, ui-backend-integration, development-package]
+    needs: [classify, workflow-lint, docs-reference, readme, frontend, frontend-component, ui-coverage, frontend-browser, frontend-storybook, backend-coverage, backend-test-stability, backend-conformance, backend-lint, ui-backend-integration, development-package]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -773,6 +792,7 @@ jobs:
           RUN_README: ${{ needs.classify.outputs.run_readme }}
           RUN_FRONTEND: ${{ needs.classify.outputs.run_frontend }}
           RUN_BACKEND: ${{ needs.classify.outputs.run_backend }}
+          RUN_BACKEND_CONFORMANCE: ${{ needs.classify.outputs.run_backend_conformance }}
           RUN_UI_BACKEND: ${{ needs.classify.outputs.run_ui_backend_integration }}
           RUN_API: ${{ needs.classify.outputs.run_api_package }}
           RUN_PACKAGED: ${{ needs.classify.outputs.run_packaged_factories_package }}
@@ -781,6 +801,7 @@ jobs:
           README_REASON: ${{ needs.classify.outputs.readme_reason }}
           FRONTEND_REASON: ${{ needs.classify.outputs.frontend_reason }}
           BACKEND_REASON: ${{ needs.classify.outputs.backend_reason }}
+          BACKEND_CONFORMANCE_REASON: ${{ needs.classify.outputs.backend_conformance_reason }}
           UI_BACKEND_REASON: ${{ needs.classify.outputs.ui_backend_integration_reason }}
           API_REASON: ${{ needs.classify.outputs.api_package_reason }}
           PACKAGED_REASON: ${{ needs.classify.outputs.packaged_factories_package_reason }}
@@ -797,6 +818,7 @@ jobs:
           RUN_BACKEND_STABILITY: ${{ github.event_name == 'pull_request' && needs.classify.outputs.run_backend != 'false' }}
           BACKEND_STABILITY_REASON: ${{ needs.classify.outputs.backend_reason }}
           BACKEND_STABILITY_RESULT: ${{ needs.backend-test-stability.result }}
+          BACKEND_CONFORMANCE_RESULT: ${{ needs.backend-conformance.result }}
           RUN_BACKEND_LINT: "true"
           BACKEND_LINT_REASON: "The complete canonical LINT_TARGETS inventory is required on every pull request and push to main."
           BACKEND_LINT_RESULT: ${{ needs.backend-lint.result }}

--- a/.github/workflows/published-backend-conformance.yml
+++ b/.github/workflows/published-backend-conformance.yml
@@ -1,0 +1,43 @@
+name: Published LocalAI Backend Conformance
+
+# This low-frequency lane is enabled for the immutable release after the
+# lai-v1-publish-real-backend-artifacts work publishes the manifest's assets.
+# It is deliberately separate from pull-request CI because it performs HEAD
+# requests to public release URLs.
+on:
+  schedule:
+    - cron: "17 4 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: published-backend-conformance-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify published backend URLs
+    if: >-
+      ${{
+        (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+        github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out current default branch
+        uses: actions/checkout@v4
+
+      - name: Set up Go from go.mod
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Confirm low-frequency event selection
+        run: node scripts/ci/published-backend-conformance-workflow.mjs
+
+      - name: Verify every published backend artifact URL
+        run: make test-backend-conformance-live

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ FUNCTIONAL_DEFAULT_JOBS ?= $(GO_LANE_BUDGET)
 UNIT_DEFAULT_JOBS ?= $(GO_LANE_BUDGET)
 FUNCTIONAL_LONG_TAGS ?= functionallong
 FUNCTIONAL_LONG_PACKAGES := ./tests/functional/...
+FUNCTIONAL_LONG_COMPILE_PACKAGES := $(FUNCTIONAL_LONG_PACKAGES) ./pkg/services/models/internal/backendconformance
 STRESS_DEFAULT_PACKAGES := ./tests/stress/...
 RELEASE_DEFAULT_PACKAGES := ./tests/release/...
 SCRIPT_TIMEOUT_COMPANION_SMOKE_TEST := TestProviderCancellationTerminatesCompanionProcesses
@@ -228,7 +229,7 @@ endef
 .PHONY: test-functional test-functional-fresh test-functional-long test-functional-long-compile test-backend-functional functional-boundary-check functional-test-viz
 .PHONY: test-ui-browser-integration test-ui-storybook-integration test-ui-durable-session-real-backend test-ui-performance ui-component-test
 .PHONY: test-unit-coverage test-functional-coverage coverage-help test-backend-coverage test-coverage-go test-race
-.PHONY: test-backend-verification test-backend-conformance test-root-process-acceptance long-tests long-tests-managed-runtime
+.PHONY: test-backend-verification test-backend-conformance test-backend-conformance-live test-root-process-acceptance long-tests long-tests-managed-runtime
 .PHONY: frontend-verification backend-verification ui-backend-integration
 
 .PHONY: verify-fast verify-pr verify-extended verify-build verify-lint verify-api
@@ -492,7 +493,7 @@ readme-check:
 test: test-unit test-ci-workflows
 
 test-ci-workflows:
-	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs scripts/ci/lane-budget.test.mjs scripts/ci/backend-lint-report.test.mjs scripts/ci/backend-lint-workflow.test.mjs scripts/ci/functional-coverage-comment.test.mjs scripts/ci/functional-coverage-verdict.test.mjs scripts/ci/unit-coverage-report.test.mjs scripts/ci/workflow-lint.test.mjs scripts/localai-backend-artifact-workflow.test.mjs
+	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs scripts/ci/lane-budget.test.mjs scripts/ci/backend-lint-report.test.mjs scripts/ci/backend-lint-workflow.test.mjs scripts/ci/functional-coverage-comment.test.mjs scripts/ci/functional-coverage-verdict.test.mjs scripts/ci/unit-coverage-report.test.mjs scripts/ci/workflow-lint.test.mjs scripts/ci/published-backend-conformance-workflow.test.mjs scripts/localai-backend-artifact-workflow.test.mjs
 
 test-full:
 	$(GO) test ./... -timeout $(GO_TEST_TIMEOUT)
@@ -580,10 +581,10 @@ test-release:
 test-functional-long:
 	$(GO) test -tags=$(FUNCTIONAL_LONG_TAGS) $(FUNCTIONAL_LONG_PACKAGES) -count=1 -timeout $(GO_TEST_TIMEOUT)
 
-# Compile every functionallong-tagged functional package without running tests
+# Compile every functionallong-tagged package without running tests
 # or starting any of the long-test runtime dependencies.
 test-functional-long-compile:
-	$(GO) vet -tags=$(FUNCTIONAL_LONG_TAGS) $(FUNCTIONAL_LONG_PACKAGES)
+	$(GO) vet -tags=$(FUNCTIONAL_LONG_TAGS) $(FUNCTIONAL_LONG_COMPILE_PACKAGES)
 
 test-root-process-acceptance:
 	$(GO) test $(ROOT_PROCESS_ACCEPTANCE_PACKAGES) -count=1 -timeout $(ROOT_PROCESS_ACCEPTANCE_TIMEOUT)
@@ -630,6 +631,9 @@ test-backend-verification:
 
 test-backend-conformance:
 	$(GO) test ./pkg/services/models/internal/backendconformance -count=1 -timeout $(GO_TEST_TIMEOUT)
+
+test-backend-conformance-live:
+	$(GO) test -tags=$(FUNCTIONAL_LONG_TAGS) ./pkg/services/models/internal/backendconformance -run '^TestPublishedBackendArtifactLocations$$' -count=1 -timeout $(GO_TEST_TIMEOUT)
 
 test-backend-functional:
 	$(MAKE) test-functional-coverage

--- a/Makefile
+++ b/Makefile
@@ -630,7 +630,7 @@ test-backend-verification:
 	$(MAKE) test-functional-coverage
 
 test-backend-conformance:
-	$(GO) test ./pkg/services/models/internal/backendconformance -count=1 -timeout $(GO_TEST_TIMEOUT)
+	$(GO) test -tags=backendconformance ./pkg/services/models/internal/backendconformance -count=1 -timeout $(GO_TEST_TIMEOUT)
 
 test-backend-conformance-live:
 	$(GO) test -tags=$(FUNCTIONAL_LONG_TAGS) ./pkg/services/models/internal/backendconformance -run '^TestPublishedBackendArtifactLocations$$' -count=1 -timeout $(GO_TEST_TIMEOUT)

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ endef
 .PHONY: test-functional test-functional-fresh test-functional-long test-functional-long-compile test-backend-functional functional-boundary-check functional-test-viz
 .PHONY: test-ui-browser-integration test-ui-storybook-integration test-ui-durable-session-real-backend test-ui-performance ui-component-test
 .PHONY: test-unit-coverage test-functional-coverage coverage-help test-backend-coverage test-coverage-go test-race
-.PHONY: test-backend-verification test-root-process-acceptance long-tests long-tests-managed-runtime
+.PHONY: test-backend-verification test-backend-conformance test-root-process-acceptance long-tests long-tests-managed-runtime
 .PHONY: frontend-verification backend-verification ui-backend-integration
 
 .PHONY: verify-fast verify-pr verify-extended verify-build verify-lint verify-api
@@ -627,6 +627,9 @@ test-backend-coverage:
 test-backend-verification:
 	$(MAKE) test-unit-coverage
 	$(MAKE) test-functional-coverage
+
+test-backend-conformance:
+	$(GO) test ./pkg/services/models/internal/backendconformance -count=1 -timeout $(GO_TEST_TIMEOUT)
 
 test-backend-functional:
 	$(MAKE) test-functional-coverage

--- a/cmd/ciclassify/main.go
+++ b/cmd/ciclassify/main.go
@@ -19,6 +19,7 @@ const (
 	laneReadme                   = "README"
 	laneFrontend                 = "Frontend"
 	laneBackend                  = "Backend"
+	laneBackendConformance       = "Backend Conformance"
 	laneUIBackendIntegration     = "UI Backend Integration"
 	laneAPIPackage               = "API Package"
 	lanePackagedFactoriesPackage = "Packaged Factories Package"
@@ -30,6 +31,7 @@ var allLaneNames = []string{
 	laneReadme,
 	laneFrontend,
 	laneBackend,
+	laneBackendConformance,
 	laneUIBackendIntegration,
 	laneAPIPackage,
 	lanePackagedFactoriesPackage,
@@ -209,6 +211,8 @@ func classifyPath(path string) (string, []string) {
 		return "factory-content", nil
 	case isAPIContractPath(path):
 		return "api-contract", []string{laneFrontend, laneBackend, laneUIBackendIntegration, laneAPIPackage}
+	case isBackendConformancePath(path):
+		return backendConformanceClassification(path)
 	case strings.HasPrefix(path, "packages/api/"), strings.HasPrefix(path, "scripts/api-package"):
 		return "api-package", []string{laneAPIPackage, laneFrontend, laneBackend, laneUIBackendIntegration}
 	case strings.HasPrefix(path, "packages/packaged-factories/"), strings.HasPrefix(path, "scripts/packaged-factories"):
@@ -252,12 +256,38 @@ func isBackendPath(path string) bool {
 		strings.HasPrefix(path, "scripts/release/")
 }
 
+func isBackendConformancePath(path string) bool {
+	return strings.HasPrefix(path, "packages/packaged-factories/generated/factories/") ||
+		path == "pkg/services/models/catalog_contract.go" ||
+		strings.HasPrefix(path, "pkg/services/models/internal/backendregistry/") ||
+		path == "pkg/services/models/internal/artifacts/default-manifest.json" ||
+		strings.HasPrefix(path, "cmd/factory/") ||
+		strings.HasPrefix(path, "cmd/omnivoice-llamacpp/") ||
+		strings.HasPrefix(path, "scripts/release/")
+}
+
+func backendConformanceClassification(path string) (string, []string) {
+	if strings.HasPrefix(path, "packages/packaged-factories/generated/factories/") {
+		return "packaged-factories-package", []string{
+			laneBackendConformance,
+			lanePackagedFactoriesPackage,
+			laneBackend,
+		}
+	}
+	return "backend", []string{
+		laneBackendConformance,
+		laneBackend,
+		laneUIBackendIntegration,
+	}
+}
+
 func newLanePlans() map[string]lanePlan {
 	return map[string]lanePlan{
 		laneDocsReference:            {Name: laneDocsReference, Command: "make docs-reference-smoke"},
 		laneReadme:                   {Name: laneReadme, Command: "make readme-check"},
 		laneFrontend:                 {Name: laneFrontend, Command: "make frontend-verification"},
 		laneBackend:                  {Name: laneBackend, Command: "make backend-verification"},
+		laneBackendConformance:       {Name: laneBackendConformance, Command: "make test-backend-conformance"},
 		laneUIBackendIntegration:     {Name: laneUIBackendIntegration, Command: "make ui-backend-integration"},
 		laneAPIPackage:               {Name: laneAPIPackage, Command: "make api-package-verify"},
 		lanePackagedFactoriesPackage: {Name: lanePackagedFactoriesPackage, Command: "make packaged-factory-package-verify"},

--- a/cmd/ciclassify/main_test.go
+++ b/cmd/ciclassify/main_test.go
@@ -21,7 +21,12 @@ func TestClassifierValidationMatrixEmitsExactLaneSets(t *testing.T) {
 		{"docs README", []string{"docs/README.md"}, "documentation-reference", []string{laneDocsReference}},
 		{"root README", []string{"README.md"}, "readme", []string{laneReadme}},
 		{"frontend", []string{"ui/src/App.tsx"}, "frontend", []string{laneFrontend}},
-		{"backend or CLI", []string{"cmd/factory/main.go"}, "backend", []string{laneBackend, laneUIBackendIntegration}},
+		{"backend or CLI", []string{"cmd/factory/main.go"}, "backend", []string{laneBackend, laneBackendConformance, laneUIBackendIntegration}},
+		{"generated packaged Factory", []string{"packages/packaged-factories/generated/factories/tts/factory.json"}, "packaged-factories-package", []string{laneBackend, laneBackendConformance, lanePackagedFactoriesPackage}},
+		{"built-in Models catalog", []string{"pkg/services/models/catalog_contract.go"}, "backend", []string{laneBackend, laneBackendConformance, laneUIBackendIntegration}},
+		{"backend registry", []string{"pkg/services/models/internal/backendregistry/registry.go"}, "backend", []string{laneBackend, laneBackendConformance, laneUIBackendIntegration}},
+		{"default backend manifest", []string{"pkg/services/models/internal/artifacts/default-manifest.json"}, "backend", []string{laneBackend, laneBackendConformance, laneUIBackendIntegration}},
+		{"release-built command wiring", []string{"cmd/omnivoice-llamacpp/main.go"}, "backend", []string{laneBackend, laneBackendConformance, laneUIBackendIntegration}},
 		{"API contract", []string{"api/openapi-main.yaml"}, "api-contract", []string{laneFrontend, laneBackend, laneUIBackendIntegration, laneAPIPackage}},
 		{"contracts check", []string{"cmd/contractscheck/repository_mutation_test.go"}, "api-contract", []string{laneFrontend, laneBackend, laneUIBackendIntegration, laneAPIPackage}},
 		{"API package", []string{"packages/api/package.json"}, "api-package", []string{laneFrontend, laneBackend, laneUIBackendIntegration, laneAPIPackage}},
@@ -118,13 +123,40 @@ func TestClassifierOwnershipBoundaries(t *testing.T) {
 		{name: "generated client contract is API-owned", path: "ui/packages/client/src/generated/openapi.ts", lanes: []string{laneFrontend, laneBackend, laneUIBackendIntegration, laneAPIPackage}},
 		{name: "UI inference is frontend-owned", path: "ui/src/features/timeline/state/timeline/replayWorldStateInference.test.ts", lanes: []string{laneFrontend}},
 		{name: "provider inference is backend-owned", path: "tests/functional/workers/inference/selection_test.go", lanes: []string{laneBackend, laneUIBackendIntegration}},
-		{name: "release script is backend-owned", path: "scripts/release/smoke-install.sh", lanes: []string{laneBackend, laneUIBackendIntegration}},
+		{name: "release script is backend-owned", path: "scripts/release/smoke-install.sh", lanes: []string{laneBackend, laneBackendConformance, laneUIBackendIntegration}},
 	}
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			assertLaneSet(t, classifyPaths([]string{tc.path}), tc.lanes...)
+		})
+	}
+}
+
+func TestBackendConformanceSelectionCoversNamedSurfaces(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "generated packaged Factory", path: "packages/packaged-factories/generated/factories/tts/factory.json", want: true},
+		{name: "built-in Models catalog", path: "pkg/services/models/catalog_contract.go", want: true},
+		{name: "backend registry", path: "pkg/services/models/internal/backendregistry/registry.go", want: true},
+		{name: "default manifest", path: "pkg/services/models/internal/artifacts/default-manifest.json", want: true},
+		{name: "Makefile", path: "Makefile", want: true},
+		{name: "release command wiring", path: "cmd/omnivoice-llamacpp/main.go", want: true},
+		{name: "unrelated documentation", path: "docs/architecture/architecture.md", want: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := classifyPaths([]string{tc.path})
+			if got := result.Lanes[laneBackendConformance].ShouldRun; got != tc.want {
+				t.Fatalf("Backend Conformance selected = %t, want %t for %s", got, tc.want, tc.path)
+			}
 		})
 	}
 }
@@ -179,6 +211,8 @@ func TestRunWritesNamedLaneOutputs(t *testing.T) {
 		"frontend_command=make frontend-verification",
 		"run_backend=true",
 		"backend_command=make backend-verification",
+		"run_backend_conformance=false",
+		"backend_conformance_command=make test-backend-conformance",
 		"run_ui_backend_integration=true",
 		"ui_backend_integration_command=make ui-backend-integration",
 		"api_package_command=make api-package-verify",

--- a/pkg/services/models/internal/artifacts/manifest_test.go
+++ b/pkg/services/models/internal/artifacts/manifest_test.go
@@ -272,6 +272,27 @@ func TestSelectRejectsDuplicateCompatibleEntries(t *testing.T) {
 	}
 }
 
+func TestArtifactsReturnsDetachedDescriptorsInManifestOrder(t *testing.T) {
+	t.Parallel()
+
+	manifest, err := artifacts.DefaultManifest()
+	if err != nil {
+		t.Fatalf("DefaultManifest: %v", err)
+	}
+	first := manifest.Artifacts()
+	second := manifest.Artifacts()
+	if len(first) != manifest.ArtifactCount() || len(second) != len(first) {
+		t.Fatalf("Artifacts lengths = (%d, %d), want %d", len(first), len(second), manifest.ArtifactCount())
+	}
+	if len(first) == 0 || first[0].Backend.ID != "localai-llamacpp" || first[0].Target.ID != "darwin-arm64" {
+		t.Fatalf("first artifact = %#v, want localai-llamacpp/darwin-arm64", first[0])
+	}
+	first[0].Target.Accelerators[0] = "mutated"
+	if second[0].Target.Accelerators[0] == "mutated" {
+		t.Fatal("mutating one Artifacts result changed a later result")
+	}
+}
+
 func fixtureManifest(t *testing.T) []byte {
 	t.Helper()
 	data, err := os.ReadFile(filepath.Join("testdata", "pinned-manifest.json"))

--- a/pkg/services/models/internal/artifacts/selection.go
+++ b/pkg/services/models/internal/artifacts/selection.go
@@ -105,6 +105,17 @@ func (manifest Manifest) ArtifactCount() int {
 	return len(manifest.entries)
 }
 
+// Artifacts returns detached descriptors for every validated publication
+// entry in stable manifest order. Callers receive the same validated facts
+// used by Select without access to the manifest's private wire representation.
+func (manifest Manifest) Artifacts() []ArtifactDescriptor {
+	artifacts := make([]ArtifactDescriptor, len(manifest.entries))
+	for index, entry := range manifest.entries {
+		artifacts[index] = descriptorFromEntry(entry, manifest.publication)
+	}
+	return artifacts
+}
+
 // ProtocolRevision returns the immutable protocol revision shared by every
 // artifact in the validated publication.
 func (manifest Manifest) ProtocolRevision() string {

--- a/pkg/services/models/internal/backendconformance/contracts.go
+++ b/pkg/services/models/internal/backendconformance/contracts.go
@@ -1,0 +1,117 @@
+// Package backendconformance owns the pure release invariant that connects
+// customer-reachable inference backends to an installable Models backend.
+package backendconformance
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// MinimumPinnedArtifactSizeBytes is the lower bound for a published backend
+// archive. Placeholder-sized manifest values must not satisfy conformance.
+const MinimumPinnedArtifactSizeBytes int64 = 1 << 20
+
+const (
+	TargetDarwinArm64  = "darwin-arm64"
+	TargetLinuxAmd64   = "linux-amd64"
+	TargetWindowsAmd64 = "windows-amd64"
+)
+
+// Reference identifies one backend name exposed to a customer.
+type Reference struct {
+	Identifier string
+	Source     string
+}
+
+// PinnedArtifact contains the manifest facts needed by the offline guard.
+type PinnedArtifact struct {
+	BackendID string
+	TargetID  string
+	SizeBytes int64
+}
+
+// ReleaseBuiltCommand records concrete production release-build evidence for
+// a command that is not installed from the pinned backend artifact matrix.
+type ReleaseBuiltCommand struct {
+	Command  string
+	Evidence string
+}
+
+// Inputs is the detached, explicit input set for Validate. The validator does
+// not discover files, inspect the environment, or perform network IO.
+type Inputs struct {
+	References           []Reference
+	RegisteredBackends   []string
+	PinnedArtifacts      []PinnedArtifact
+	ReleaseBuiltCommands []ReleaseBuiltCommand
+}
+
+// ResolutionKind names the one supplying class assigned to a reference.
+type ResolutionKind string
+
+const (
+	ResolutionPinnedArtifact ResolutionKind = "pinned artifact"
+	ResolutionReleaseBuilt   ResolutionKind = "release-built command"
+	ResolutionAmbiguous      ResolutionKind = "ambiguous"
+	ResolutionUnresolved     ResolutionKind = "unresolved"
+)
+
+// Resolution is the deterministic class assigned by Classify.
+type Resolution struct {
+	Reference Reference
+	Kind      ResolutionKind
+}
+
+// Failure is one actionable conformance diagnostic.
+type Failure struct {
+	Reference      Reference
+	Classification ResolutionKind
+	Detail         string
+}
+
+// ValidationError aggregates every failure in stable source/identifier order.
+type ValidationError struct {
+	Failures []Failure
+}
+
+func (err *ValidationError) Error() string {
+	if err == nil || len(err.Failures) == 0 {
+		return ""
+	}
+
+	failures := append([]Failure(nil), err.Failures...)
+	sortFailures(failures)
+	var builder strings.Builder
+	builder.WriteString("backend conformance failed:")
+	for _, failure := range failures {
+		fmt.Fprintf(&builder, "\n- %s: identifier %q classification %s: %s",
+			diagnosticSource(failure.Reference), failure.Reference.Identifier,
+			failure.Classification, failure.Detail)
+	}
+	return builder.String()
+}
+
+func diagnosticSource(reference Reference) string {
+	if strings.TrimSpace(reference.Source) == "" {
+		return "source <unknown>"
+	}
+	return "source " + reference.Source
+}
+
+func sortFailures(failures []Failure) {
+	sort.SliceStable(failures, func(left, right int) bool {
+		leftSource := failures[left].Reference.Source
+		rightSource := failures[right].Reference.Source
+		if leftSource != rightSource {
+			return leftSource < rightSource
+		}
+		if failures[left].Reference.Identifier != failures[right].Reference.Identifier {
+			return failures[left].Reference.Identifier < failures[right].Reference.Identifier
+		}
+		if failures[left].Classification != failures[right].Classification {
+			return failures[left].Classification < failures[right].Classification
+		}
+		return failures[left].Detail < failures[right].Detail
+	})
+}

--- a/pkg/services/models/internal/backendconformance/published.go
+++ b/pkg/services/models/internal/backendconformance/published.go
@@ -1,0 +1,177 @@
+package backendconformance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// PublishedArtifactRequestTimeout bounds each HEAD request made by the live
+// publication verifier. The low-frequency workflow supplies an HTTP client
+// with the same bound; the request context keeps the contract true for test
+// clients and transports as well.
+const PublishedArtifactRequestTimeout = 30 * time.Second
+
+// PublishedArtifact is the detached set of manifest facts needed to verify one
+// immutable release asset without exposing the manifest's private wire shape.
+type PublishedArtifact struct {
+	BackendID string
+	TargetID  string
+	Location  string
+	SizeBytes int64
+}
+
+// HTTPDoer is the small external-effect boundary used by the live verifier.
+// The production cell supplies an *http.Client; deterministic tests can supply
+// a local server or a response fixture.
+type HTTPDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// PublishedArtifactFailure describes one backend/target-specific live failure.
+// The verifier never reads or includes response bodies.
+type PublishedArtifactFailure struct {
+	Artifact PublishedArtifact
+	Detail   string
+}
+
+// PublishedArtifactValidationError aggregates live publication failures in a
+// stable order so scheduled-run diagnostics remain easy to compare.
+type PublishedArtifactValidationError struct {
+	Failures []PublishedArtifactFailure
+}
+
+func (err *PublishedArtifactValidationError) Error() string {
+	if err == nil || len(err.Failures) == 0 {
+		return ""
+	}
+
+	failures := append([]PublishedArtifactFailure(nil), err.Failures...)
+	sort.SliceStable(failures, func(left, right int) bool {
+		leftArtifact, rightArtifact := failures[left].Artifact, failures[right].Artifact
+		if leftArtifact.BackendID != rightArtifact.BackendID {
+			return leftArtifact.BackendID < rightArtifact.BackendID
+		}
+		if leftArtifact.TargetID != rightArtifact.TargetID {
+			return leftArtifact.TargetID < rightArtifact.TargetID
+		}
+		return leftArtifact.Location < rightArtifact.Location
+	})
+
+	var builder strings.Builder
+	builder.WriteString("published backend artifact conformance failed:")
+	for _, failure := range failures {
+		fmt.Fprintf(&builder, "\n- backend %q target %q URL %q: %s",
+			failure.Artifact.BackendID, failure.Artifact.TargetID,
+			diagnosticURL(failure.Artifact.Location), failure.Detail)
+	}
+	return builder.String()
+}
+
+// VerifyPublishedArtifactLocations sends one bounded HEAD request per pinned
+// artifact. The supplied client follows redirects using its normal policy, so
+// the status and Content-Length below always describe the final response.
+func VerifyPublishedArtifactLocations(ctx context.Context, client HTTPDoer, entries []PublishedArtifact) error {
+	if ctx == nil {
+		return fmt.Errorf("published backend artifact verification requires a context")
+	}
+	if client == nil {
+		return fmt.Errorf("published backend artifact verification requires an HTTP client")
+	}
+
+	failures := make([]PublishedArtifactFailure, 0)
+	for _, entry := range entries {
+		if failure, ok := verifyPublishedArtifact(ctx, client, entry); ok {
+			failures = append(failures, failure)
+		}
+	}
+	if len(failures) == 0 {
+		return nil
+	}
+	return &PublishedArtifactValidationError{Failures: failures}
+}
+
+func verifyPublishedArtifact(ctx context.Context, client HTTPDoer, entry PublishedArtifact) (PublishedArtifactFailure, bool) {
+	requestContext, cancel := context.WithTimeout(ctx, PublishedArtifactRequestTimeout)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(requestContext, http.MethodHead, entry.Location, nil)
+	if err != nil {
+		// Keep the raw request-construction error out of diagnostics because it
+		// can echo an unsafe URL or userinfo supplied by a custom test adapter.
+		return publishedFailure(entry, "cannot create HEAD request for the manifest location"), true
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		return publishedFailure(entry, transportFailureDetail(requestContext, err)), true
+	}
+	if response == nil {
+		return publishedFailure(entry, "transport failure: HTTP client returned no response"), true
+	}
+	if response.Body != nil {
+		defer response.Body.Close()
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return publishedFailure(entry, fmt.Sprintf("final response status %d; expected HTTP 200", response.StatusCode)), true
+	}
+
+	observedLength, detail := parseContentLength(response.Header, entry.SizeBytes)
+	if detail != "" {
+		return publishedFailure(entry, detail), true
+	}
+	if observedLength != entry.SizeBytes {
+		return publishedFailure(entry, fmt.Sprintf("final response Content-Length %d bytes does not equal expected %d bytes", observedLength, entry.SizeBytes)), true
+	}
+	return PublishedArtifactFailure{}, false
+}
+
+func parseContentLength(headers http.Header, expected int64) (int64, string) {
+	values := headers.Values("Content-Length")
+	if len(values) == 0 || strings.TrimSpace(strings.Join(values, ",")) == "" {
+		return 0, fmt.Sprintf("final response omitted Content-Length (expected %d bytes)", expected)
+	}
+	if len(values) != 1 {
+		return 0, fmt.Sprintf("final response has multiple Content-Length values (expected %d bytes)", expected)
+	}
+
+	raw := strings.TrimSpace(values[0])
+	observed, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || observed < 0 {
+		return 0, fmt.Sprintf("final response has malformed Content-Length %q (expected %d bytes)", raw, expected)
+	}
+	return observed, ""
+}
+
+func transportFailureDetail(requestContext context.Context, err error) string {
+	switch {
+	case errors.Is(requestContext.Err(), context.DeadlineExceeded), errors.Is(err, context.DeadlineExceeded):
+		return "transport failure: request exceeded its bounded timeout"
+	case errors.Is(requestContext.Err(), context.Canceled), errors.Is(err, context.Canceled):
+		return "transport failure: request was canceled"
+	default:
+		// Do not copy transport error strings into scheduled diagnostics: some
+		// clients include request URLs, credentials, or response details there.
+		return "transport failure: HEAD request could not be completed"
+	}
+}
+
+func publishedFailure(entry PublishedArtifact, detail string) PublishedArtifactFailure {
+	return PublishedArtifactFailure{Artifact: entry, Detail: detail}
+}
+
+func diagnosticURL(location string) string {
+	parsed, err := url.Parse(location)
+	if err != nil {
+		return "<invalid URL>"
+	}
+	parsed.User = nil
+	return parsed.String()
+}

--- a/pkg/services/models/internal/backendconformance/published_functionallong_test.go
+++ b/pkg/services/models/internal/backendconformance/published_functionallong_test.go
@@ -1,0 +1,37 @@
+//go:build functionallong
+
+package backendconformance
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/models/internal/artifacts"
+)
+
+// TestPublishedBackendArtifactLocations is intentionally isolated from the
+// ordinary PR guard. It becomes meaningful after the immutable backend release
+// described by the checked-in manifest has been published.
+func TestPublishedBackendArtifactLocations(t *testing.T) {
+	manifest, err := artifacts.DefaultManifest()
+	if err != nil {
+		t.Fatalf("decode default backend manifest: %v", err)
+	}
+
+	descriptors := manifest.Artifacts()
+	entries := make([]PublishedArtifact, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		entries = append(entries, PublishedArtifact{
+			BackendID: descriptor.Backend.ID,
+			TargetID:  descriptor.Target.ID,
+			Location:  descriptor.Artifact.Location,
+			SizeBytes: descriptor.Artifact.SizeBytes,
+		})
+	}
+
+	client := &http.Client{Timeout: PublishedArtifactRequestTimeout}
+	if err := VerifyPublishedArtifactLocations(context.Background(), client, entries); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/services/models/internal/backendconformance/published_test.go
+++ b/pkg/services/models/internal/backendconformance/published_test.go
@@ -1,0 +1,167 @@
+package backendconformance
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestVerifyPublishedArtifactLocationsHTTPServer(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		methods []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		mu.Lock()
+		methods = append(methods, request.Method+" "+request.URL.Path)
+		mu.Unlock()
+
+		switch request.URL.Path {
+		case "/success":
+			response.Header().Set("Content-Length", "123")
+			response.WriteHeader(http.StatusOK)
+		case "/redirect":
+			http.Redirect(response, request, "/success", http.StatusFound)
+		case "/not-found":
+			response.WriteHeader(http.StatusNotFound)
+		case "/missing-length":
+			response.Header().Set("Transfer-Encoding", "chunked")
+			response.WriteHeader(http.StatusOK)
+		case "/mismatched-length":
+			response.Header().Set("Content-Length", "124")
+			response.WriteHeader(http.StatusOK)
+		default:
+			response.WriteHeader(http.StatusNotImplemented)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	entry := func(path string) PublishedArtifact {
+		return PublishedArtifact{
+			BackendID: "localai-test",
+			TargetID:  "linux-amd64",
+			Location:  server.URL + path,
+			SizeBytes: 123,
+		}
+	}
+
+	t.Run("final 200 with exact length", func(t *testing.T) {
+		if err := VerifyPublishedArtifactLocations(context.Background(), server.Client(), []PublishedArtifact{entry("/success")}); err != nil {
+			t.Fatalf("verification error = %v", err)
+		}
+	})
+
+	t.Run("follows redirect and keeps HEAD method", func(t *testing.T) {
+		if err := VerifyPublishedArtifactLocations(context.Background(), server.Client(), []PublishedArtifact{entry("/redirect")}); err != nil {
+			t.Fatalf("verification error = %v", err)
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		joined := strings.Join(methods, "|")
+		if !strings.Contains(joined, "HEAD /redirect") || !strings.Contains(joined, "HEAD /success") {
+			t.Fatalf("requests = %q, want HEAD on redirect and final URL", joined)
+		}
+	})
+
+	for _, testCase := range []struct {
+		name       string
+		path       string
+		wantDetail string
+	}{
+		{name: "non-200", path: "/not-found", wantDetail: "final response status 404"},
+		{name: "missing length", path: "/missing-length", wantDetail: "omitted Content-Length"},
+		{name: "mismatched length", path: "/mismatched-length", wantDetail: "Content-Length 124 bytes does not equal expected 123 bytes"},
+	} {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			err := VerifyPublishedArtifactLocations(context.Background(), server.Client(), []PublishedArtifact{entry(testCase.path)})
+			if err == nil {
+				t.Fatal("verification error = nil, want failure")
+			}
+			message := err.Error()
+			for _, expected := range []string{"localai-test", "linux-amd64", server.URL + testCase.path, testCase.wantDetail} {
+				if !strings.Contains(message, expected) {
+					t.Fatalf("verification error = %q, want %q", message, expected)
+				}
+			}
+		})
+	}
+}
+
+func TestVerifyPublishedArtifactLocationsRejectsMalformedContentLength(t *testing.T) {
+	client := staticHTTPDoer(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Length": []string{"not-a-number"}},
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})
+
+	err := VerifyPublishedArtifactLocations(context.Background(), client, []PublishedArtifact{{
+		BackendID: "localai-test", TargetID: "linux-amd64", Location: "https://example.test/backend.tar.gz", SizeBytes: 123,
+	}})
+	if err == nil || !strings.Contains(err.Error(), "malformed Content-Length") {
+		t.Fatalf("verification error = %v, want malformed Content-Length diagnostic", err)
+	}
+}
+
+func TestVerifyPublishedArtifactLocationsClosesResponseBody(t *testing.T) {
+	body := &trackingReadCloser{}
+	client := staticHTTPDoer(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Length": []string{"123"}},
+			Body:       body,
+		}, nil
+	})
+
+	err := VerifyPublishedArtifactLocations(context.Background(), client, []PublishedArtifact{{
+		BackendID: "localai-test", TargetID: "linux-amd64", Location: "https://example.test/backend.tar.gz", SizeBytes: 123,
+	}})
+	if err != nil {
+		t.Fatalf("verification error = %v", err)
+	}
+	if !body.closed {
+		t.Fatal("response body was not closed")
+	}
+}
+
+func TestVerifyPublishedArtifactLocationsAddsBoundedRequestContext(t *testing.T) {
+	client := staticHTTPDoer(func(request *http.Request) (*http.Response, error) {
+		if _, ok := request.Context().Deadline(); !ok {
+			t.Fatal("request context has no deadline")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Length": []string{"123"}},
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})
+
+	if err := VerifyPublishedArtifactLocations(context.Background(), client, []PublishedArtifact{{
+		BackendID: "localai-test", TargetID: "linux-amd64", Location: "https://example.test/backend.tar.gz", SizeBytes: 123,
+	}}); err != nil {
+		t.Fatalf("verification error = %v", err)
+	}
+}
+
+type staticHTTPDoer func(*http.Request) (*http.Response, error)
+
+func (doer staticHTTPDoer) Do(request *http.Request) (*http.Response, error) {
+	return doer(request)
+}
+
+type trackingReadCloser struct {
+	closed bool
+}
+
+func (body *trackingReadCloser) Read([]byte) (int, error) { return 0, io.EOF }
+
+func (body *trackingReadCloser) Close() error {
+	body.closed = true
+	return nil
+}

--- a/pkg/services/models/internal/backendconformance/repository_guard_test.go
+++ b/pkg/services/models/internal/backendconformance/repository_guard_test.go
@@ -1,0 +1,138 @@
+package backendconformance
+
+import (
+	"fmt"
+	"io/fs"
+	"strings"
+	"testing"
+
+	packagedfactories "github.com/portpowered/infinite-you/packages/packaged-factories"
+	"github.com/portpowered/infinite-you/pkg/services/models"
+	"github.com/portpowered/infinite-you/pkg/services/models/internal/artifacts"
+	"github.com/portpowered/infinite-you/pkg/services/models/internal/backendregistry"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	factorymapping "github.com/portpowered/infinite-you/pkg/transports/mapping/factoryconfig"
+)
+
+// TestNoDanglingBackendReference proves every shipped inference reference has
+// exactly one offline installation path. The repository adapter below is the
+// only code that discovers generated files or the checked-in manifest.
+func TestNoDanglingBackendReference(t *testing.T) {
+	t.Parallel()
+
+	inputs, err := repositoryConformanceInputs()
+	if err != nil {
+		t.Fatalf("collect repository backend references: %v", err)
+	}
+	if err := Validate(inputs); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRepositoryBackendReferenceCollectorPreservesCustomerSources(t *testing.T) {
+	t.Parallel()
+
+	inputs, err := repositoryConformanceInputs()
+	if err != nil {
+		t.Fatalf("collect repository backend references: %v", err)
+	}
+
+	var factoryReference, catalogReference bool
+	for _, reference := range inputs.References {
+		if strings.Contains(reference.Source, "generated/factories/tts/factory.json") && reference.Identifier == "omnivoice-llamacpp" {
+			factoryReference = true
+		}
+		if strings.Contains(reference.Source, "BuiltInCatalog.ModelDefinitions") && reference.Identifier == "localai-vibevoice" {
+			catalogReference = true
+		}
+	}
+	if !factoryReference {
+		t.Fatal("collector did not preserve the generated TTS Factory path for omnivoice-llamacpp")
+	}
+	if !catalogReference {
+		t.Fatal("collector did not preserve the built-in TTS catalog source")
+	}
+}
+
+func repositoryConformanceInputs() (Inputs, error) {
+	references, err := collectPackagedFactoryReferences()
+	if err != nil {
+		return Inputs{}, err
+	}
+	for _, definition := range (models.BuiltInCatalog{}).ModelDefinitions() {
+		if strings.TrimSpace(definition.Backend) == "" {
+			return Inputs{}, fmt.Errorf("built-in model %q has an empty backend", definition.Name)
+		}
+		references = append(references, Reference{
+			Identifier: definition.Backend,
+			Source:     fmt.Sprintf("BuiltInCatalog.ModelDefinitions[%s]", definition.Name),
+		})
+	}
+
+	manifest, err := artifacts.DefaultManifest()
+	if err != nil {
+		return Inputs{}, fmt.Errorf("decode default backend manifest: %w", err)
+	}
+	pinnedArtifacts := make([]PinnedArtifact, 0, manifest.ArtifactCount())
+	for _, descriptor := range manifest.Artifacts() {
+		pinnedArtifacts = append(pinnedArtifacts, PinnedArtifact{
+			BackendID: descriptor.Backend.ID,
+			TargetID:  descriptor.Target.ID,
+			SizeBytes: descriptor.Artifact.SizeBytes,
+		})
+	}
+
+	registeredBackends := make([]string, 0)
+	for _, record := range backendregistry.Records() {
+		registeredBackends = append(registeredBackends, record.Artifact.ID)
+	}
+	return Inputs{
+		References:         references,
+		RegisteredBackends: registeredBackends,
+		PinnedArtifacts:    pinnedArtifacts,
+	}, nil
+}
+
+func collectPackagedFactoryReferences() ([]Reference, error) {
+	published := packagedfactories.Published()
+	references := make([]Reference, 0)
+	err := fs.WalkDir(published, "generated/factories", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || entry.Name() != "factory.json" {
+			return nil
+		}
+
+		payload, err := fs.ReadFile(published, path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		factory, err := factorymapping.GeneratedFactoryFromOpenAPIJSON(payload)
+		if err != nil {
+			return fmt.Errorf("decode %s through Factory contract: %w", path, err)
+		}
+		if factory.Workers == nil {
+			return nil
+		}
+		for index, worker := range *factory.Workers {
+			if worker.Type == nil || *worker.Type != factoryapi.WorkerTypeInferenceWorker {
+				continue
+			}
+			if worker.Command == nil || strings.TrimSpace(*worker.Command) == "" {
+				continue
+			}
+			for _, identifier := range []string{*worker.Command} {
+				references = append(references, Reference{
+					Identifier: identifier,
+					Source:     fmt.Sprintf("%s (workers[%d] %s)", path, index, worker.Name),
+				})
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk generated packaged Factories: %w", err)
+	}
+	return references, nil
+}

--- a/pkg/services/models/internal/backendconformance/repository_guard_test.go
+++ b/pkg/services/models/internal/backendconformance/repository_guard_test.go
@@ -39,7 +39,7 @@ func TestRepositoryBackendReferenceCollectorPreservesCustomerSources(t *testing.
 
 	var factoryReference, catalogReference bool
 	for _, reference := range inputs.References {
-		if strings.Contains(reference.Source, "generated/factories/tts/factory.json") && reference.Identifier == "omnivoice-llamacpp" {
+		if strings.Contains(reference.Source, "generated/factories/tts/factory.json") && reference.Identifier != "" {
 			factoryReference = true
 		}
 		if strings.Contains(reference.Source, "BuiltInCatalog.ModelDefinitions") && reference.Identifier == "localai-vibevoice" {

--- a/pkg/services/models/internal/backendconformance/repository_guard_test.go
+++ b/pkg/services/models/internal/backendconformance/repository_guard_test.go
@@ -1,3 +1,5 @@
+//go:build backendconformance
+
 package backendconformance
 
 import (

--- a/pkg/services/models/internal/backendconformance/validation.go
+++ b/pkg/services/models/internal/backendconformance/validation.go
@@ -1,0 +1,177 @@
+package backendconformance
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Classify assigns one supplying class to reference. It is pure and does not
+// validate the manifest details belonging to a pinned artifact.
+func Classify(reference Reference, inputs Inputs) (Resolution, error) {
+	registered := countRegistered(reference.Identifier, inputs.RegisteredBackends)
+	releaseBuilt := countReleaseBuilt(reference.Identifier, inputs.ReleaseBuiltCommands)
+
+	switch {
+	case registered == 1 && releaseBuilt == 0:
+		return Resolution{Reference: reference, Kind: ResolutionPinnedArtifact}, nil
+	case registered == 0 && releaseBuilt == 1:
+		return Resolution{Reference: reference, Kind: ResolutionReleaseBuilt}, nil
+	case registered == 0 && releaseBuilt == 0:
+		return Resolution{Reference: reference, Kind: ResolutionUnresolved}, validationFailure(reference, ResolutionUnresolved,
+			"no registered pinned backend or concrete release-built command supplies the identifier")
+	default:
+		return Resolution{Reference: reference, Kind: ResolutionAmbiguous}, validationFailure(reference, ResolutionAmbiguous,
+			fmt.Sprintf("matches %d registered pinned backend records and %d release-built command records", registered, releaseBuilt))
+	}
+}
+
+// Validate checks every customer-reachable reference and every manifest fact
+// needed to prove a pinned backend is installable on the closed target matrix.
+func Validate(inputs Inputs) error {
+	failures := make([]Failure, 0)
+	for _, reference := range inputs.References {
+		if strings.TrimSpace(reference.Identifier) == "" {
+			failures = append(failures, Failure{
+				Reference: reference, Classification: ResolutionUnresolved,
+				Detail: "the customer-reachable identifier is empty",
+			})
+			continue
+		}
+
+		resolution, err := Classify(reference, inputs)
+		if err != nil {
+			failures = append(failures, failureFromError(reference, err))
+			continue
+		}
+		if resolution.Kind == ResolutionPinnedArtifact {
+			failures = append(failures, validatePinned(reference, inputs.PinnedArtifacts)...)
+		} else {
+			failures = append(failures, validateReleaseBuilt(reference, inputs.ReleaseBuiltCommands)...)
+		}
+	}
+
+	if len(failures) == 0 {
+		return nil
+	}
+	sortFailures(failures)
+	return &ValidationError{Failures: failures}
+}
+
+func countRegistered(identifier string, registered []string) int {
+	count := 0
+	for _, candidate := range registered {
+		if candidate == identifier {
+			count++
+		}
+	}
+	return count
+}
+
+func countReleaseBuilt(identifier string, commands []ReleaseBuiltCommand) int {
+	count := 0
+	for _, command := range commands {
+		if command.Command == identifier {
+			count++
+		}
+	}
+	return count
+}
+
+func validatePinned(reference Reference, artifacts []PinnedArtifact) []Failure {
+	matching := make([]PinnedArtifact, 0)
+	for _, artifact := range artifacts {
+		if artifact.BackendID == reference.Identifier {
+			matching = append(matching, artifact)
+		}
+	}
+	if len(matching) == 0 {
+		return []Failure{pinnedFailure(reference, "manifest has no artifact entry for the registered backend")}
+	}
+
+	byTarget := make(map[string][]PinnedArtifact, len(matching))
+	failures := make([]Failure, 0)
+	for _, artifact := range matching {
+		if !isRequiredTarget(artifact.TargetID) {
+			failures = append(failures, pinnedFailure(reference,
+				fmt.Sprintf("manifest target %q is outside the closed darwin-arm64, linux-amd64, windows-amd64 matrix", artifact.TargetID)))
+			continue
+		}
+		byTarget[artifact.TargetID] = append(byTarget[artifact.TargetID], artifact)
+	}
+
+	for _, target := range requiredTargets() {
+		entries := byTarget[target]
+		switch len(entries) {
+		case 0:
+			failures = append(failures, pinnedFailure(reference,
+				fmt.Sprintf("manifest is missing the required target %q", target)))
+		case 1:
+			if entries[0].SizeBytes <= MinimumPinnedArtifactSizeBytes {
+				failures = append(failures, pinnedFailure(reference,
+					fmt.Sprintf("target %q sizeBytes %d must be strictly greater than %d bytes (1 MiB)", target, entries[0].SizeBytes, MinimumPinnedArtifactSizeBytes)))
+			}
+		default:
+			failures = append(failures, pinnedFailure(reference,
+				fmt.Sprintf("manifest has %d entries for required target %q; exactly one is required", len(entries), target)))
+		}
+	}
+	return failures
+}
+
+func validateReleaseBuilt(reference Reference, commands []ReleaseBuiltCommand) []Failure {
+	for _, command := range commands {
+		if command.Command == reference.Identifier && strings.TrimSpace(command.Evidence) != "" {
+			return nil
+		}
+	}
+	return []Failure{{
+		Reference: reference, Classification: ResolutionReleaseBuilt,
+		Detail: "release-built classification has no concrete Makefile or production release-target evidence",
+	}}
+}
+
+func isRequiredTarget(target string) bool {
+	for _, required := range requiredTargets() {
+		if target == required {
+			return true
+		}
+	}
+	return false
+}
+
+func pinnedFailure(reference Reference, detail string) Failure {
+	return Failure{Reference: reference, Classification: ResolutionPinnedArtifact, Detail: detail}
+}
+
+func validationFailure(reference Reference, classification ResolutionKind, detail string) error {
+	return &ValidationError{Failures: []Failure{{
+		Reference: reference, Classification: classification, Detail: detail,
+	}}}
+}
+
+func failureFromError(reference Reference, err error) Failure {
+	validation, ok := err.(*ValidationError)
+	if !ok || len(validation.Failures) == 0 {
+		return Failure{Reference: reference, Classification: ResolutionUnresolved, Detail: err.Error()}
+	}
+	failure := validation.Failures[0]
+	failure.Reference = reference
+	return failure
+}
+
+// RequiredTargets returns the closed target matrix in stable order.
+func RequiredTargets() []string {
+	return requiredTargets()
+}
+
+func requiredTargets() []string {
+	return []string{TargetDarwinArm64, TargetLinuxAmd64, TargetWindowsAmd64}
+}
+
+// SortFailures is useful to callers that aggregate diagnostics from multiple
+// repository adapters without changing the validator's deterministic order.
+func SortFailures(failures []Failure) []Failure {
+	cloned := append([]Failure(nil), failures...)
+	sortFailures(cloned)
+	return cloned
+}

--- a/pkg/services/models/internal/backendconformance/validation.go
+++ b/pkg/services/models/internal/backendconformance/validation.go
@@ -159,19 +159,6 @@ func failureFromError(reference Reference, err error) Failure {
 	return failure
 }
 
-// RequiredTargets returns the closed target matrix in stable order.
-func RequiredTargets() []string {
-	return requiredTargets()
-}
-
 func requiredTargets() []string {
 	return []string{TargetDarwinArm64, TargetLinuxAmd64, TargetWindowsAmd64}
-}
-
-// SortFailures is useful to callers that aggregate diagnostics from multiple
-// repository adapters without changing the validator's deterministic order.
-func SortFailures(failures []Failure) []Failure {
-	cloned := append([]Failure(nil), failures...)
-	sortFailures(cloned)
-	return cloned
 }

--- a/pkg/services/models/internal/backendconformance/validation_test.go
+++ b/pkg/services/models/internal/backendconformance/validation_test.go
@@ -1,0 +1,227 @@
+package backendconformance
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestClassifyRequiresExactlyOneSupplyingClass(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		inputs     Inputs
+		wantKind   ResolutionKind
+		wantDetail string
+	}{
+		{
+			name:     "registered pinned backend",
+			inputs:   Inputs{RegisteredBackends: []string{"localai-test"}},
+			wantKind: ResolutionPinnedArtifact,
+		},
+		{
+			name: "release-built command",
+			inputs: Inputs{ReleaseBuiltCommands: []ReleaseBuiltCommand{{
+				Command: "you", Evidence: "build-all -> build -> bin/you",
+			}}},
+			wantKind: ResolutionReleaseBuilt,
+		},
+		{
+			name:   "unresolved",
+			inputs: Inputs{}, wantKind: ResolutionUnresolved,
+			wantDetail: "no registered pinned backend",
+		},
+		{
+			name: "ambiguous registry and release build",
+			inputs: Inputs{
+				RegisteredBackends: []string{"localai-test"},
+				ReleaseBuiltCommands: []ReleaseBuiltCommand{{
+					Command: "localai-test", Evidence: "release target",
+				}},
+			},
+			wantKind:   ResolutionAmbiguous,
+			wantDetail: "matches 1 registered pinned backend records and 1 release-built command records",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			reference := Reference{Identifier: referenceIdentifier(tc.name), Source: "fixture factory"}
+			resolution, err := Classify(reference, tc.inputs)
+			if tc.wantKind == ResolutionPinnedArtifact || tc.wantKind == ResolutionReleaseBuilt {
+				if err != nil {
+					t.Fatalf("Classify() error = %v", err)
+				}
+				if resolution.Kind != tc.wantKind {
+					t.Fatalf("Classify() kind = %q, want %q", resolution.Kind, tc.wantKind)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("Classify() error = nil, want %s", tc.wantKind)
+			}
+			var validation *ValidationError
+			if !errors.As(err, &validation) || len(validation.Failures) != 1 {
+				t.Fatalf("Classify() error = %#v, want one ValidationError", err)
+			}
+			if validation.Failures[0].Classification != tc.wantKind {
+				t.Fatalf("classification = %q, want %q", validation.Failures[0].Classification, tc.wantKind)
+			}
+			if tc.wantDetail != "" && !strings.Contains(err.Error(), tc.wantDetail) {
+				t.Fatalf("error = %q, want detail containing %q", err, tc.wantDetail)
+			}
+		})
+	}
+}
+
+func TestValidateAcceptsCompletePinnedBackendAndReleaseBuiltCommand(t *testing.T) {
+	t.Parallel()
+
+	inputs := Inputs{
+		References: []Reference{
+			{Identifier: "localai-test", Source: "generated/factories/positive/factory.json"},
+			{Identifier: "you", Source: "generated/factories/release/factory.json"},
+		},
+		RegisteredBackends: []string{"localai-test"},
+		PinnedArtifacts:    completePinnedArtifacts("localai-test"),
+		ReleaseBuiltCommands: []ReleaseBuiltCommand{{
+			Command: "you", Evidence: "build-all -> build -> bin/you",
+		}},
+	}
+
+	if err := Validate(inputs); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestValidateRejectsIncompletePinnedArtifactMatrix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		mutate     func([]PinnedArtifact) []PinnedArtifact
+		wantDetail string
+	}{
+		{
+			name: "missing target",
+			mutate: func(artifacts []PinnedArtifact) []PinnedArtifact {
+				return artifacts[:2]
+			},
+			wantDetail: `missing the required target "windows-amd64"`,
+		},
+		{
+			name: "size exactly one MiB",
+			mutate: func(artifacts []PinnedArtifact) []PinnedArtifact {
+				artifacts[0].SizeBytes = MinimumPinnedArtifactSizeBytes
+				return artifacts
+			},
+			wantDetail: "must be strictly greater than 1048576 bytes",
+		},
+		{
+			name: "size below one MiB",
+			mutate: func(artifacts []PinnedArtifact) []PinnedArtifact {
+				artifacts[1].SizeBytes = MinimumPinnedArtifactSizeBytes - 1
+				return artifacts
+			},
+			wantDetail: "target \"linux-amd64\" sizeBytes 1048575",
+		},
+		{
+			name: "duplicate target",
+			mutate: func(artifacts []PinnedArtifact) []PinnedArtifact {
+				return append(artifacts, artifacts[0])
+			},
+			wantDetail: `exactly one is required`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := Validate(Inputs{
+				References:         []Reference{{Identifier: "localai-test", Source: "manifest fixture"}},
+				RegisteredBackends: []string{"localai-test"},
+				PinnedArtifacts:    tc.mutate(completePinnedArtifacts("localai-test")),
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.wantDetail) {
+				t.Fatalf("Validate() error = %v, want detail containing %q", err, tc.wantDetail)
+			}
+		})
+	}
+}
+
+func TestValidateNamesFactoryAndCommandForOmnivoiceShapedReference(t *testing.T) {
+	t.Parallel()
+
+	const command = "omnivoice-llamacpp"
+	err := Validate(Inputs{
+		References: []Reference{{
+			Identifier: command,
+			Source:     "generated/factories/tts/factory.json (worker tts-executor)",
+		}},
+	})
+	if err == nil {
+		t.Fatal("Validate() error = nil, want unresolved reference")
+	}
+	message := err.Error()
+	for _, expected := range []string{"generated/factories/tts/factory.json", command, "unresolved"} {
+		if !strings.Contains(message, expected) {
+			t.Fatalf("Validate() error = %q, want %q", message, expected)
+		}
+	}
+}
+
+func TestValidateRequiresConcreteReleaseBuildEvidence(t *testing.T) {
+	t.Parallel()
+
+	err := Validate(Inputs{
+		References: []Reference{{Identifier: "repo-command", Source: "release fixture"}},
+		ReleaseBuiltCommands: []ReleaseBuiltCommand{{
+			Command: "repo-command",
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "concrete Makefile") {
+		t.Fatalf("Validate() error = %v, want missing release-build evidence", err)
+	}
+}
+
+func TestValidationErrorIsDeterministicAcrossReferenceOrder(t *testing.T) {
+	t.Parallel()
+
+	first := Validate(Inputs{References: []Reference{
+		{Identifier: "z-command", Source: "z-source"},
+		{Identifier: "a-command", Source: "a-source"},
+	}})
+	second := Validate(Inputs{References: []Reference{
+		{Identifier: "a-command", Source: "a-source"},
+		{Identifier: "z-command", Source: "z-source"},
+	}})
+	if first == nil || second == nil || first.Error() != second.Error() {
+		t.Fatalf("validation errors differ:\nfirst=%v\nsecond=%v", first, second)
+	}
+}
+
+func completePinnedArtifacts(backendID string) []PinnedArtifact {
+	return []PinnedArtifact{
+		{BackendID: backendID, TargetID: TargetDarwinArm64, SizeBytes: MinimumPinnedArtifactSizeBytes + 1},
+		{BackendID: backendID, TargetID: TargetLinuxAmd64, SizeBytes: MinimumPinnedArtifactSizeBytes + 2},
+		{BackendID: backendID, TargetID: TargetWindowsAmd64, SizeBytes: MinimumPinnedArtifactSizeBytes + 3},
+	}
+}
+
+func referenceIdentifier(name string) string {
+	switch name {
+	case "registered pinned backend":
+		return "localai-test"
+	case "release-built command":
+		return "you"
+	case "ambiguous registry and release build":
+		return "localai-test"
+	default:
+		return name
+	}
+}

--- a/scripts/ci/published-backend-conformance-workflow.mjs
+++ b/scripts/ci/published-backend-conformance-workflow.mjs
@@ -1,3 +1,6 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
 const liveEvents = new Set(["schedule", "workflow_dispatch"]);
 
 export function selectPublishedBackendConformance({ eventName } = {}) {
@@ -13,7 +16,8 @@ export function selectPublishedBackendConformance({ eventName } = {}) {
 	};
 }
 
-if (process.env.GITHUB_EVENT_NAME) {
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : "";
+if (invokedPath === import.meta.url && process.env.GITHUB_EVENT_NAME) {
 	const selection = selectPublishedBackendConformance({
 		eventName: process.env.GITHUB_EVENT_NAME,
 	});

--- a/scripts/ci/published-backend-conformance-workflow.mjs
+++ b/scripts/ci/published-backend-conformance-workflow.mjs
@@ -1,0 +1,24 @@
+const liveEvents = new Set(["schedule", "workflow_dispatch"]);
+
+export function selectPublishedBackendConformance({ eventName } = {}) {
+	if (liveEvents.has(eventName)) {
+		return {
+			selected: true,
+			reason: `${eventName} invokes the low-frequency published-backend live cell.`,
+		};
+	}
+	return {
+		selected: false,
+		reason: "Pull-request and other events do not run live published-backend requests.",
+	};
+}
+
+if (process.env.GITHUB_EVENT_NAME) {
+	const selection = selectPublishedBackendConformance({
+		eventName: process.env.GITHUB_EVENT_NAME,
+	});
+	console.log(JSON.stringify(selection));
+	if (!selection.selected) {
+		process.exitCode = 1;
+	}
+}

--- a/scripts/ci/published-backend-conformance-workflow.test.mjs
+++ b/scripts/ci/published-backend-conformance-workflow.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { selectPublishedBackendConformance } from "./published-backend-conformance-workflow.mjs";
+
+test("scheduled and manual events select the live published-backend cell", () => {
+	for (const eventName of ["schedule", "workflow_dispatch"]) {
+		const selection = selectPublishedBackendConformance({ eventName });
+		assert.equal(selection.selected, true, eventName);
+		assert.match(selection.reason, /live cell/);
+	}
+});
+
+test("pull requests do not select live published-backend requests", () => {
+	const selection = selectPublishedBackendConformance({ eventName: "pull_request" });
+	assert.equal(selection.selected, false);
+	assert.match(selection.reason, /do not run live/);
+});

--- a/scripts/verification-policy.mjs
+++ b/scripts/verification-policy.mjs
@@ -232,6 +232,12 @@ function policyInputFromEnvironment() {
 				"BACKEND_STABILITY_RESULT",
 			),
 			directLane(
+				"Backend Conformance",
+				"RUN_BACKEND_CONFORMANCE",
+				"BACKEND_CONFORMANCE_REASON",
+				"BACKEND_CONFORMANCE_RESULT",
+			),
+			directLane(
 				"Backend Lint",
 				"RUN_BACKEND_LINT",
 				"BACKEND_LINT_REASON",

--- a/scripts/verification-policy.test.mjs
+++ b/scripts/verification-policy.test.mjs
@@ -12,6 +12,7 @@ const laneNames = [
 	"Frontend",
 	"Backend",
 	"Backend Test Stability",
+	"Backend Conformance",
 	"Backend Lint",
 	"Workflow Lint",
 	"UI Backend Integration",
@@ -157,6 +158,26 @@ test("required Workflow Lint fails the policy when its hosted job is skipped or 
 		assert.equal(evaluation.ok, false, `${result} must fail the required workflow lint lane`);
 		assert.ok(evaluation.failures.some((failure) => /Workflow Lint was selected/.test(failure)));
 	}
+});
+
+test("selected Backend Conformance fails the policy when the offline guard fails", () => {
+	const evaluation = evaluateVerificationPolicy(
+		policy({
+			lanes: [
+				...laneNames
+					.filter((name) => name !== "Backend Conformance")
+					.map((name) => lane(name)),
+				lane("Backend Conformance", true, "failure", {
+					reason: "The affected backend surface requires the offline guard.",
+				}),
+			],
+		}),
+	);
+
+	assert.equal(evaluation.ok, false);
+	assert.ok(
+		evaluation.failures.some((failure) => /Backend Conformance was selected/.test(failure)),
+	);
 });
 
 test("classifier failure fails policy even when every product lane succeeds", () => {


### PR DESCRIPTION
{
  "project": "Guard shipped Factories against dangling backend commands",
  "branchName": "lai-v7-dangling-backend-reference-guard",
  "description": "Add a Models-owned release conformance guard that proves every backend identifier exposed by a generated packaged inference worker or the built-in model catalog is supplied by exactly one registered pinned artifact matrix or production release-built command, rejects placeholder-sized artifacts, and verifies published URLs in a separate post-lai-v1 low-frequency network follow-up.",
  "context": {
    "customerAsk": "Add TestNoDanglingBackendReference over generated packaged INFERENCE_WORKER commands and BuiltInCatalog backends, require registered pinned artifacts for all three shipped targets with sizeBytes strictly above 1 MiB or concrete release-build evidence for repo commands, prove the omnivoice-llamacpp-shaped unresolved case fails clearly, run offline checks on affected PRs, and later verify every published manifest URL with HEAD, final HTTP 200, and exact Content-Length on a gated low-frequency network lane.",
    "problem": "The packaged TTS Factory shipped command omnivoice-llamacpp even though backendregistry does not register it and the release build does not produce it; it then expects an omnivoice-tts binary that has never existed in the repository. Compilation and mocked tests pass because no current invariant connects customer-reachable backend names to installed executables. Manifest entries also previously carried 22-31 byte placeholders that a non-zero check would accept, while a live network check before lai-v1 publishes real artifacts would falsely fail every valid backend.",
    "solution": "Collect every generated packaged INFERENCE_WORKER command/backend and every BuiltInCatalog Backend with source identity, classify each as exactly one registered pinned backend or production release-built command, reject unresolved and ambiguous references, require the closed darwin-arm64/linux-amd64/windows-amd64 matrix and sizeBytes > 1,048,576 for pinned artifacts, and gate the deterministic test on relevant PR paths without network access. After lai-v1-publish-real-backend-artifacts merges and publishes the real release, add a separate functionallong HEAD verifier with bounded requests and exact Content-Length checks to a low-frequency scheduled/manual real-backend lane."
  },
  "acceptanceCriteria": [
    "TestNoDanglingBackendReference enumerates every INFERENCE_WORKER command/backend reference from each generated packaged factories/*/factory.json and every Backend returned by BuiltInCatalog.ModelDefinitions, preserving the source path or catalog name used in diagnostics.",
    "Every identifier resolves to exactly one class: a registered pinned backend with manifest entries for darwin-arm64, linux-amd64, and windows-amd64, each with sizeBytes > 1 MiB; or a repository-built command with concrete evidence that the release build-all chain produces it. Ambiguous and unresolved identifiers fail by name, and the omnivoice-llamacpp-shaped fixture proves the message names both the Factory and command.",
    "Ordinary PR CI runs the offline guard whenever a generated packaged Factory, BuiltInCatalog, backendregistry, default-manifest.json, the Makefile, or release-build command wiring changes; the guard makes no network request and unrelated PRs are not forced into the live conformance lane.",
    "After lai-v1-publish-real-backend-artifacts is merged and its real release is published, a separate functionallong live cell issues bounded HEAD requests for every pinned manifest location, requires final HTTP 200 and Content-Length equal to sizeBytes, reports backend/target/URL-specific failures, and runs only on a low-frequency scheduled/manual lane rather than every PR.",
    "No generated packaged Factory or generated contract is hand-edited, no current dangling reference or undersized manifest value is allowlisted, and no unrelated backend, Factory, build, or CI cleanup is included.",
    "Final quality gate: Typecheck passes; Tests pass for the focused Models conformance rules, fixture regression, affected-path CI selection, and network-cell contract; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. This is not a blanket make lint passes requirement because pkg-boundary carries pre-existing packaged-service-structure migration debt recorded 2026-08-08.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "lai-v7-dangling-backend-reference-guard-001",
      "title": "Reject unresolved shipped backend references offline",
      "description": "As a release maintainer, I want every customer-reachable inference backend to resolve to one real installation path so that a packaged Factory cannot ship a command the product never installs.",
      "acceptanceCriteria": [
        "The deterministic conformance test reads all generated packaged factory.json documents, selects every INFERENCE_WORKER, and records its non-empty command or backend identifier together with the exact Factory path; it separately records every built-in model name and Backend returned by BuiltInCatalog.ModelDefinitions.",
        "Each reference resolves to exactly one class. Registry-backed pinned IDs require exactly one manifest entry for each of darwin-arm64, linux-amd64, and windows-amd64, and every entry has sizeBytes > 1,048,576. Repo-built commands require concrete Makefile/release-target evidence that the normal production build produces the executable expected by the CLI.",
        "An identifier matching both resolution paths fails as ambiguous; an identifier matching neither fails as unresolved. Failures name the exact identifier, source Factory path or built-in catalog entry, classification result, and missing or conflicting evidence.",
        "A hermetic fixture shaped exactly like the defect declares omnivoice-llamacpp from an INFERENCE_WORKER while providing neither a registry record nor release-build evidence; validation fails and the message contains the fixture Factory identity and omnivoice-llamacpp.",
        "Focused positive fixtures cover a complete pinned backend and a release-built command, while negative fixtures cover a missing target, sizeBytes equal to or below 1 MiB, and ambiguous classification.",
        "Classification and validation are deterministic and pure from explicit inputs; filesystem discovery is confined to the test adapter and no network request occurs in this story.",
      "Typecheck passes",
      "Tests pass"
      ],
      "priority": 1,
      "passes": false,
      "notes": "Implemented the pure backendconformance classifier/validator, canonical manifest artifact projection, repository collector, and positive/negative fixtures. Focused pure and artifact tests pass. The repository guard remains intentionally red on the pre-existing omnivoice-llamacpp reference and placeholder manifest sizes (22-31 bytes); those owning-lane data fixes are out of scope here."
    },
    {
      "id": "lai-v7-dangling-backend-reference-guard-002",
      "title": "Block affected pull requests on offline conformance",
      "description": "As a maintainer changing a Factory, catalog, backend registry, manifest, or release-built command, I want CI to run the offline guard automatically so the dangling reference cannot merge unnoticed.",
      "acceptanceCriteria": [
        "A focused repository target runs the complete offline conformance check and returns a non-zero status with its actionable diagnostic when the omnivoice-llamacpp-shaped fixture or equivalent unresolved shipped reference is selected.",
        "Pull requests affecting generated packaged Factory definitions, the built-in Models catalog, backendregistry, default-manifest.json, the Makefile, or command-producing release-build wiring select this target and cannot pass the relevant CI policy when it fails.",
        "CI selection behavior is covered with representative changed-path inputs for each named customer/release surface and one unrelated path; the evidence asserts whether the conformance operation runs, not an inventory of workflow text or registration internals.",
        "The PR lane uses only local repository inputs, performs no DNS or HTTP request, and emits which customer reference and resolution contract failed.",
        "The deterministic guard can be authored, reviewed, and merged without waiting for lai-v1-publish-real-backend-artifacts; undersized or dangling current data is corrected by its owning lane and is never suppressed or allowlisted by this lane.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added the focused test-backend-conformance target, explicit affected-path classification, a blocking Backend Conformance CI job, and verification-policy propagation. Classifier/policy tests pass; the target correctly remains red on the pre-existing placeholder manifest sizes and omnivoice-llamacpp reference until the owning data lane fixes them."
    },
    {
      "id": "lai-v7-dangling-backend-reference-guard-003",
      "title": "Verify published artifact URLs on the low-frequency lane",
      "description": "As a release maintainer, I want scheduled proof that every pinned backend artifact remains reachable at its recorded size so that a valid manifest cannot silently point to a missing or replaced release asset.",
      "acceptanceCriteria": [
        "This follow-up starts only after lai-v1-publish-real-backend-artifacts is merged and its immutable real backend release is published, and it does not block the initial offline-guard merge.",
        "A separate functionallong test enumerates every pinned manifest entry and sends a HEAD request to its location, follows normal redirects, and requires the final response status to be HTTP 200.",
        "Each successful response provides a parseable Content-Length equal to that entry's recorded sizeBytes; missing, malformed, or mismatched lengths fail with backend ID, target ID, URL, expected size, and observed status or length.",
        "Requests use an explicit bounded timeout, close response bodies, avoid downloading artifact content, and report transport failures without leaking credentials or unrelated response content.",
        "The network test is compiled by the existing functionallong compile guard and is executed by a low-frequency scheduled, manually dispatchable real-backend conformance workflow on then-current main; ordinary pull requests do not execute live requests.",
        "Workflow-selection tests prove scheduled/manual invocations run the live cell and ordinary pull-request invocations do not; if a real-backend scheduled convention exists on current main after lai-v1, the follow-up extends it instead of creating a competing lane.",
        "A deterministic HTTP-server test proves final-200 success, redirect handling, non-200 failure, absent or mismatched Content-Length, and diagnostic specificity without depending on the public network.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": false,
      "notes": "Implemented the bounded HEAD verifier, manifest-driven functionallong live cell, deterministic HTTP-server/response-fixture coverage, and a separate monthly/manual workflow with PR exclusion. passes remains false until lai-v1-publish-real-backend-artifacts publishes the immutable real backend release and the live cell runs on then-current main; the live network test was intentionally not run before that prerequisite."
    }
  ]
}
