### PR TITLE
test: prove offline priced and unpriced replay costs

### DIFF
--- a/tests/functional/factory/visualization/runtime_metrics/replay_priced_cost_test.go
+++ b/tests/functional/factory/visualization/runtime_metrics/replay_priced_cost_test.go
@@ -1,0 +1,180 @@
+package runtime_metrics_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	generatedclient "github.com/portpowered/infinite-you/pkg/transports/http/client"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	replayPricedInputTokens      int64 = 1_000_000
+	replayPricedOutputTokens     int64 = 2_000_000
+	replayPricedTotalTokens      int64 = 3_000_000
+	replayPricedInputRateCents   int64 = 125
+	replayPricedOutputRateCents  int64 = 1_000
+	replayPricedMillionTokenUnit int64 = 1_000_000
+)
+
+func TestReplayPricedUsageReachesPublicCosts(t *testing.T) {
+	repoRoot := testutil.MustRepoRoot(t)
+	fixturePath := filepath.Join(
+		repoRoot,
+		"tests", "functional", "factory", "visualization", "runtime_metrics", "testdata",
+		"codex-gpt-5-codex.factory-recording.v1.json",
+	)
+	homeDir := t.TempDir()
+	environment := append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	providerRunner := support.NewRecordingCommandRunner("unexpected provider execution")
+	scriptRunner := support.NewRecordingCommandRunner("unexpected script execution")
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                t.TempDir(),
+		Args:                      []string{"--replay", fixturePath, "--no-record"},
+		Env:                       environment,
+		WaitForServiceModeRuntime: true,
+		Edges: serviceedges.Edges{
+			ProviderCommandRunner: providerRunner,
+			ScriptCommandRunner:   scriptRunner,
+		},
+	})
+	status := support.WaitForTerminalStatus(t, server.URL(), 15*time.Second)
+	if status.Categories.Terminal != 1 || status.Categories.Failed != 0 {
+		t.Fatalf("replayed Factory Session categories = %#v, want one terminal Work and no failures", status.Categories)
+	}
+
+	process := support.BuildProcess(t, serviceedges.Edges{
+		ProviderCommandRunner: providerRunner,
+		ScriptCommandRunner:   scriptRunner,
+	})
+	support.CleanupProcess(t, process)
+
+	humanOutput := executeReplayCostsCLI(t, process, environment, server.URL(), false)
+	wantCost := expectedPricedReplayCost()
+	if !strings.Contains(humanOutput, "Status: PRICED") ||
+		!strings.Contains(humanOutput, "Cost (USD): $"+wantCost) ||
+		!strings.Contains(humanOutput, "Total tokens: 3000000") {
+		t.Fatalf("human replay costs output = %q, want PRICED/$%s/3000000", humanOutput, wantCost)
+	}
+
+	jsonOutput := executeReplayCostsCLI(t, process, environment, server.URL(), true)
+	var cliReport generatedclient.CostsReport
+	if err := json.Unmarshal([]byte(jsonOutput), &cliReport); err != nil {
+		t.Fatalf("decode replay costs CLI JSON: %v\nstdout=%s", err, jsonOutput)
+	}
+	assertPricedReplayCostsReport(t, cliReport)
+
+	apiReport := getReplayCostsHTTP(t, server.URL())
+	assertPricedReplayCostsReport(t, apiReport)
+	if got, want := apiReport, cliReport; !reportsHaveSamePricedCostFacts(got, want) {
+		t.Fatalf("HTTP and CLI replay cost reports differ:\nHTTP=%#v\nCLI=%#v", got, want)
+	}
+
+	if providerRunner.CallCount() != 0 || scriptRunner.CallCount() != 0 {
+		t.Fatalf("replay external execution calls = provider:%d script:%d, want zero", providerRunner.CallCount(), scriptRunner.CallCount())
+	}
+}
+
+func executeReplayCostsCLI(
+	t *testing.T,
+	process support.Process,
+	environment []string,
+	serverURL string,
+	jsonOutput bool,
+) string {
+	t.Helper()
+	args := []string{"you", "metrics", "costs", "--server", serverURL}
+	if jsonOutput {
+		args = []string{"you", "--json", "metrics", "costs", "--server", serverURL}
+	}
+	inputs := support.FakeInputs(t.Context(), args)
+	inputs.Input.Env = append([]string(nil), environment...)
+	inputs.Input.WorkingDirectory = t.TempDir()
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf("execute replay metrics costs CLI: %v\nstderr=%s", err, inputs.Stderr())
+	}
+	return inputs.Stdout()
+}
+
+func getReplayCostsHTTP(t *testing.T, serverURL string) generatedclient.CostsReport {
+	t.Helper()
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, strings.TrimSuffix(serverURL, "/")+"/metrics/costs", nil)
+	if err != nil {
+		t.Fatalf("build replay costs HTTP request: %v", err)
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET /metrics/costs for replay: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("GET /metrics/costs status = %d, want 200", response.StatusCode)
+	}
+	var report generatedclient.CostsReport
+	if err := json.NewDecoder(response.Body).Decode(&report); err != nil {
+		t.Fatalf("decode replay costs HTTP response: %v", err)
+	}
+	return report
+}
+
+func assertPricedReplayCostsReport(t *testing.T, report generatedclient.CostsReport) {
+	t.Helper()
+	if report.Status != generatedclient.CostsReportStatus("PRICED") || report.Currency != generatedclient.CostsReportCurrency("USD") {
+		t.Fatalf("replay cost status/currency = %q/%q, want PRICED/USD", report.Status, report.Currency)
+	}
+	wantCost := expectedPricedReplayCost()
+	if report.KnownCost == nil || *report.KnownCost != wantCost {
+		t.Fatalf("replay known cost = %v, want exact %s", report.KnownCost, wantCost)
+	}
+	if report.UnpricedDispatchCount != 0 || len(report.UnpricedPairs) != 0 {
+		t.Fatalf("replay unpriced facts = count:%d pairs:%#v, want zero", report.UnpricedDispatchCount, report.UnpricedPairs)
+	}
+	if report.Coverage.EncounteredRows != 1 || report.Coverage.PricedRows != 1 || report.Coverage.UnpricedRows != 0 ||
+		report.Coverage.EncounteredProviderModels != 1 || report.Coverage.PricedProviderModels != 1 || report.Coverage.UnpricedProviderModels != 0 {
+		t.Fatalf("replay cost coverage = %#v, want one priced row and provider/model", report.Coverage)
+	}
+	assertReplayTokenTotals(t, report.TokenTotals, replayPricedInputTokens, replayPricedOutputTokens, replayPricedTotalTokens)
+	if len(report.LineItems) != 1 || len(report.WorkerSessions) != 1 || len(report.ProviderModels) != 1 || len(report.FactorySessions) != 1 {
+		t.Fatalf("replay report dimensions = line:%d workers:%d providers:%d sessions:%d, want one each", len(report.LineItems), len(report.WorkerSessions), len(report.ProviderModels), len(report.FactorySessions))
+	}
+	item := report.LineItems[0]
+	if item.Status != generatedclient.CostsLineItemStatus("PRICED") || item.Provider == nil || *item.Provider != "CODEX" || item.Model == nil || *item.Model != "gpt-5-codex" ||
+		item.WorkerSessionId == nil || *item.WorkerSessionId != "cost-replay-priced-worker-session" || item.PricedAmount == nil || *item.PricedAmount != wantCost {
+		t.Fatalf("replay priced line item = %#v, want Codex identity, Worker Session lineage, and %s", item, wantCost)
+	}
+	rollup := report.ProviderModels[0]
+	if rollup.Key != "CODEX/gpt-5-codex" || rollup.Status != generatedclient.CostsProviderModelRollupStatus("PRICED") || rollup.KnownCost == nil || *rollup.KnownCost != wantCost {
+		t.Fatalf("replay provider/model rollup = %#v, want priced CODEX/gpt-5-codex at %s", rollup, wantCost)
+	}
+	if report.WorkerSessions[0].Key != "cost-replay-priced-worker-session" {
+		t.Fatalf("replay Worker Session rollup key = %q, want recorded Worker Session lineage", report.WorkerSessions[0].Key)
+	}
+}
+
+func expectedPricedReplayCost() string {
+	// Hand-compute the expected shipped-rate value in cents so the test does not
+	// use the production valuation function as its oracle:
+	// (1,000,000 × 1.25 + 2,000,000 × 10) / 1,000,000 = 21.25 USD.
+	totalCents := (replayPricedInputTokens*replayPricedInputRateCents + replayPricedOutputTokens*replayPricedOutputRateCents) / replayPricedMillionTokenUnit
+	return fmt.Sprintf("%d.%02d", totalCents/100, totalCents%100)
+}
+
+func assertReplayTokenTotals(t *testing.T, totals generatedclient.CostsTokenTotals, input, output, total int64) {
+	t.Helper()
+	if totals.InputTokens == nil || *totals.InputTokens != input || totals.OutputTokens == nil || *totals.OutputTokens != output || totals.TotalTokens == nil || *totals.TotalTokens != total {
+		t.Fatalf("replay token totals = %#v, want input/output/total %d/%d/%d", totals, input, output, total)
+	}
+}
+
+func reportsHaveSamePricedCostFacts(left, right generatedclient.CostsReport) bool {
+	return reflect.DeepEqual(left, right)
+}

--- a/tests/functional/factory/visualization/runtime_metrics/replay_priced_cost_test.go
+++ b/tests/functional/factory/visualization/runtime_metrics/replay_priced_cost_test.go
@@ -75,7 +75,7 @@ func TestReplayPricedUsageReachesPublicCosts(t *testing.T) {
 
 	apiReport := getReplayCostsHTTP(t, server.URL())
 	assertPricedReplayCostsReport(t, apiReport)
-	if got, want := apiReport, cliReport; !reportsHaveSamePricedCostFacts(got, want) {
+	if got, want := apiReport, cliReport; !reportsHaveSameReplayCostFacts(got, want) {
 		t.Fatalf("HTTP and CLI replay cost reports differ:\nHTTP=%#v\nCLI=%#v", got, want)
 	}
 
@@ -175,6 +175,6 @@ func assertReplayTokenTotals(t *testing.T, totals generatedclient.CostsTokenTota
 	}
 }
 
-func reportsHaveSamePricedCostFacts(left, right generatedclient.CostsReport) bool {
+func reportsHaveSameReplayCostFacts(left, right generatedclient.CostsReport) bool {
 	return reflect.DeepEqual(left, right)
 }

--- a/tests/functional/factory/visualization/runtime_metrics/replay_unpriced_cost_test.go
+++ b/tests/functional/factory/visualization/runtime_metrics/replay_unpriced_cost_test.go
@@ -1,0 +1,124 @@
+package runtime_metrics_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	generatedclient "github.com/portpowered/infinite-you/pkg/transports/http/client"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	replayUnpricedInputTokens  int64 = 1_200
+	replayUnpricedOutputTokens int64 = 300
+	replayUnpricedTotalTokens  int64 = 1_500
+)
+
+func TestReplayUnpricedUsageRemainsTruthfulInPublicCosts(t *testing.T) {
+	repoRoot := testutil.MustRepoRoot(t)
+	fixturePath := filepath.Join(
+		repoRoot,
+		"tests", "functional", "factory", "visualization", "runtime_metrics", "testdata",
+		"claude-sonnet-4-6.factory-recording.v1.json",
+	)
+	homeDir := t.TempDir()
+	environment := append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	providerRunner := support.NewRecordingCommandRunner("unexpected provider execution")
+	scriptRunner := support.NewRecordingCommandRunner("unexpected script execution")
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                t.TempDir(),
+		Args:                      []string{"--replay", fixturePath, "--no-record"},
+		Env:                       environment,
+		WaitForServiceModeRuntime: true,
+		Edges: serviceedges.Edges{
+			ProviderCommandRunner: providerRunner,
+			ScriptCommandRunner:   scriptRunner,
+		},
+	})
+	status := support.WaitForTerminalStatus(t, server.URL(), 15*time.Second)
+	if status.Categories.Terminal != 1 || status.Categories.Failed != 0 {
+		t.Fatalf("replayed Factory Session categories = %#v, want one terminal Work and no failures", status.Categories)
+	}
+
+	process := support.BuildProcess(t, serviceedges.Edges{
+		ProviderCommandRunner: providerRunner,
+		ScriptCommandRunner:   scriptRunner,
+	})
+	support.CleanupProcess(t, process)
+
+	humanOutput := executeReplayCostsCLI(t, process, environment, server.URL(), false)
+	if !strings.Contains(humanOutput, "Status: UNPRICED") ||
+		!strings.Contains(humanOutput, "Cost (USD): ?? unknown") ||
+		!strings.Contains(humanOutput, "CLAUDE/claude-sonnet-4-6") ||
+		!strings.Contains(humanOutput, "Total tokens: 1500") ||
+		strings.Contains(humanOutput, "$0.00") || strings.Contains(humanOutput, "Status: NO_USAGE") {
+		t.Fatalf("human replay costs output = %q, want truthful UNPRICED Claude usage", humanOutput)
+	}
+
+	jsonOutput := executeReplayCostsCLI(t, process, environment, server.URL(), true)
+	var cliReport generatedclient.CostsReport
+	if err := json.Unmarshal([]byte(jsonOutput), &cliReport); err != nil {
+		t.Fatalf("decode unpriced replay costs CLI JSON: %v\nstdout=%s", err, jsonOutput)
+	}
+	assertUnpricedReplayCostsReport(t, cliReport)
+
+	apiReport := getReplayCostsHTTP(t, server.URL())
+	assertUnpricedReplayCostsReport(t, apiReport)
+	if got, want := apiReport, cliReport; !reportsHaveSameReplayCostFacts(got, want) {
+		t.Fatalf("HTTP and CLI unpriced replay cost reports differ:\nHTTP=%#v\nCLI=%#v", got, want)
+	}
+
+	if providerRunner.CallCount() != 0 || scriptRunner.CallCount() != 0 {
+		t.Fatalf("replay external execution calls = provider:%d script:%d, want zero", providerRunner.CallCount(), scriptRunner.CallCount())
+	}
+}
+
+func assertUnpricedReplayCostsReport(t *testing.T, report generatedclient.CostsReport) {
+	t.Helper()
+	if report.Status != generatedclient.CostsReportStatus("UNPRICED") || report.Currency != generatedclient.CostsReportCurrency("USD") {
+		t.Fatalf("unpriced replay cost status/currency = %q/%q, want UNPRICED/USD", report.Status, report.Currency)
+	}
+	if report.KnownCost != nil || report.PricedSubtotal != nil {
+		t.Fatalf("unpriced replay amounts = known:%v subtotal:%v, want both absent", report.KnownCost, report.PricedSubtotal)
+	}
+	if report.UnpricedDispatchCount != 1 || len(report.UnpricedPairs) != 1 {
+		t.Fatalf("unpriced replay facts = dispatches:%d pairs:%#v, want one dispatch and one pair", report.UnpricedDispatchCount, report.UnpricedPairs)
+	}
+	pair := report.UnpricedPairs[0]
+	if pair.Provider == nil || *pair.Provider != "CLAUDE" || pair.Model == nil || *pair.Model != "claude-sonnet-4-6" || pair.DispatchCount != 1 {
+		t.Fatalf("unpriced replay pair = %#v, want CLAUDE/claude-sonnet-4-6 with one dispatch", pair)
+	}
+	if report.Coverage.EncounteredRows != 1 || report.Coverage.PricedRows != 0 || report.Coverage.UnpricedRows != 1 ||
+		report.Coverage.EncounteredProviderModels != 1 || report.Coverage.PricedProviderModels != 0 || report.Coverage.UnpricedProviderModels != 1 {
+		t.Fatalf("unpriced replay cost coverage = %#v, want one unpriced row and provider/model", report.Coverage)
+	}
+	assertReplayTokenTotals(t, report.TokenTotals, replayUnpricedInputTokens, replayUnpricedOutputTokens, replayUnpricedTotalTokens)
+	if len(report.LineItems) != 1 || len(report.WorkItems) != 1 || len(report.WorkerSessions) != 1 || len(report.ProviderModels) != 1 || len(report.FactorySessions) != 1 {
+		t.Fatalf("unpriced replay report dimensions = line:%d work:%d workers:%d providers:%d sessions:%d, want one each", len(report.LineItems), len(report.WorkItems), len(report.WorkerSessions), len(report.ProviderModels), len(report.FactorySessions))
+	}
+
+	item := report.LineItems[0]
+	if item.Status != generatedclient.CostsLineItemStatus("UNPRICED") || item.Provider == nil || *item.Provider != "CLAUDE" ||
+		item.Model == nil || *item.Model != "claude-sonnet-4-6" || item.WorkerSessionId == nil ||
+		*item.WorkerSessionId != "cost-replay-unpriced-worker-session" || item.PricedAmount != nil {
+		t.Fatalf("unpriced replay line item = %#v, want Claude identity, Worker Session lineage, and no amount", item)
+	}
+	if item.InputTokens == nil || *item.InputTokens != replayUnpricedInputTokens || item.OutputTokens == nil || *item.OutputTokens != replayUnpricedOutputTokens {
+		t.Fatalf("unpriced replay line-item tokens = input:%v output:%v, want %d/%d", item.InputTokens, item.OutputTokens, replayUnpricedInputTokens, replayUnpricedOutputTokens)
+	}
+
+	rollup := report.ProviderModels[0]
+	if rollup.Key != "CLAUDE/claude-sonnet-4-6" || rollup.Status != generatedclient.CostsProviderModelRollupStatus("UNPRICED") || rollup.KnownCost != nil {
+		t.Fatalf("unpriced replay provider/model rollup = %#v, want unpriced CLAUDE/claude-sonnet-4-6 with null cost", rollup)
+	}
+	assertReplayTokenTotals(t, rollup.TokenTotals, replayUnpricedInputTokens, replayUnpricedOutputTokens, replayUnpricedTotalTokens)
+	if report.WorkerSessions[0].Key != "cost-replay-unpriced-worker-session" {
+		t.Fatalf("unpriced replay Worker Session rollup key = %q, want recorded Worker Session lineage", report.WorkerSessions[0].Key)
+	}
+}

--- a/tests/functional/factory/visualization/runtime_metrics/replay_usage_fixtures_test.go
+++ b/tests/functional/factory/visualization/runtime_metrics/replay_usage_fixtures_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/portpowered/infinite-you/internal/testutil"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
-	factorydefinitionswire "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	factoryconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/factoryconfig"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
@@ -88,6 +87,20 @@ func assertReplayUsageFixture(
 	seen map[string]string,
 ) {
 	t.Helper()
+	assertReplayUsageEvents(t, artifact, fixture)
+	assertReplayFactorySnapshot(t, artifact)
+	assertReplayWorkerSessionAssociation(t, artifact, fixture)
+	assertReplayDispatchUsage(t, artifact, fixture)
+	assertReplayProviderDiagnostics(t, artifact, fixture)
+	assertDistinctFixtureIdentity(t, fixture, seen)
+}
+
+func assertReplayUsageEvents(
+	t *testing.T,
+	artifact *interfaces.ReplayArtifact,
+	fixture replayUsageFixture,
+) {
+	t.Helper()
 	if artifact.SchemaVersion != interfaces.ReplayV1SourceFormat {
 		t.Fatalf("schema version = %q, want %q", artifact.SchemaVersion, interfaces.ReplayV1SourceFormat)
 	}
@@ -127,8 +140,10 @@ func assertReplayUsageFixture(
 			t.Fatalf("fixture contains an external execution event: %s", event.Type)
 		}
 	}
-	assertDistinctFixtureIdentity(t, fixture, seen)
+}
 
+func assertReplayFactorySnapshot(t *testing.T, artifact *interfaces.ReplayArtifact) {
+	t.Helper()
 	var run interfaces.RunRequestEventPayload
 	if err := artifact.Events[0].DecodePayload(&run); err != nil {
 		t.Fatalf("decode RUN_REQUEST payload: %v", err)
@@ -143,10 +158,10 @@ func assertReplayUsageFixture(
 	if _, err := factoryconfigmapping.GeneratedFactoryFromOpenAPIJSON(snapshotJSON); err != nil {
 		t.Fatalf("decode Factory snapshot at public boundary: %v", err)
 	}
-	if _, err := factorydefinitionswire.ReplayRuntimeConfigDecoder()(run.Factory); err != nil {
-		t.Fatalf("decode replay runtime config: %v", err)
-	}
+}
 
+func assertReplayWorkerSessionAssociation(t *testing.T, artifact *interfaces.ReplayArtifact, fixture replayUsageFixture) {
+	t.Helper()
 	var association interfaces.DispatchWorkerSessionAssociationEventPayload
 	if err := artifact.Events[3].DecodePayload(&association); err != nil {
 		t.Fatalf("decode Worker Session association payload: %v", err)
@@ -157,7 +172,10 @@ func assertReplayUsageFixture(
 	if artifact.Events[3].Context.DispatchID == nil || *artifact.Events[3].Context.DispatchID != fixture.dispatchID {
 		t.Fatalf("association dispatch id = %v, want %q", artifact.Events[3].Context.DispatchID, fixture.dispatchID)
 	}
+}
 
+func assertReplayDispatchUsage(t *testing.T, artifact *interfaces.ReplayArtifact, fixture replayUsageFixture) {
+	t.Helper()
 	var response workers.DispatchResponseEventPayload
 	if err := artifact.Events[6].DecodePayload(&response); err != nil {
 		t.Fatalf("decode DISPATCH_RESPONSE payload: %v", err)
@@ -168,7 +186,10 @@ func assertReplayUsageFixture(
 	assertUsageValue(t, "input tokens", response.Usage.InputTokens, fixture.inputTokens)
 	assertUsageValue(t, "output tokens", response.Usage.OutputTokens, fixture.outputTokens)
 	assertUsageValue(t, "total tokens", response.Usage.TotalTokens, fixture.totalTokens)
+}
 
+func assertReplayProviderDiagnostics(t *testing.T, artifact *interfaces.ReplayArtifact, fixture replayUsageFixture) {
+	t.Helper()
 	var inference workers.InferenceResponseEventPayload
 	if err := artifact.Events[5].DecodePayload(&inference); err != nil {
 		t.Fatalf("decode INFERENCE_RESPONSE payload: %v", err)

--- a/tests/functional/factory/visualization/runtime_metrics/replay_usage_fixtures_test.go
+++ b/tests/functional/factory/visualization/runtime_metrics/replay_usage_fixtures_test.go
@@ -1,0 +1,252 @@
+package runtime_metrics_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorydefinitionswire "github.com/portpowered/infinite-you/pkg/services/factory_definitions/wire"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	factoryconfigmapping "github.com/portpowered/infinite-you/pkg/transports/mapping/factoryconfig"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+type replayUsageFixture struct {
+	name            string
+	file            string
+	sessionID       string
+	dispatchID      string
+	workerSessionID string
+	provider        string
+	model           string
+	inputTokens     int64
+	outputTokens    int64
+	totalTokens     int64
+}
+
+func TestReplayUsageFixturesAreCanonicalAndSideEffectFree(t *testing.T) {
+	repoRoot := testutil.MustRepoRoot(t)
+	fixtures := []replayUsageFixture{
+		{
+			name:            "priced_codex_gpt_5_codex",
+			file:            filepath.Join("tests", "functional", "factory", "visualization", "runtime_metrics", "testdata", "codex-gpt-5-codex.factory-recording.v1.json"),
+			sessionID:       "cost-replay-priced-session",
+			dispatchID:      "cost-replay-priced-dispatch",
+			workerSessionID: "cost-replay-priced-worker-session",
+			provider:        "codex",
+			model:           "gpt-5-codex",
+			inputTokens:     1_000_000,
+			outputTokens:    2_000_000,
+			totalTokens:     3_000_000,
+		},
+		{
+			name:            "unpriced_claude_sonnet_4_6",
+			file:            filepath.Join("tests", "functional", "factory", "visualization", "runtime_metrics", "testdata", "claude-sonnet-4-6.factory-recording.v1.json"),
+			sessionID:       "cost-replay-unpriced-session",
+			dispatchID:      "cost-replay-unpriced-dispatch",
+			workerSessionID: "cost-replay-unpriced-worker-session",
+			provider:        "claude",
+			model:           "claude-sonnet-4-6",
+			inputTokens:     1_200,
+			outputTokens:    300,
+			totalTokens:     1_500,
+		},
+	}
+	seen := map[string]string{}
+	for _, fixture := range fixtures {
+		fixture := fixture
+		t.Run(fixture.name, func(t *testing.T) {
+			path := filepath.Join(repoRoot, fixture.file)
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read fixture before replay: %v", err)
+			}
+			artifact := testutil.LoadReplayArtifact(t, path)
+			assertReplayUsageFixture(t, artifact, fixture, seen)
+			executeReplayUsageFixture(t, path)
+			after, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read fixture after replay: %v", err)
+			}
+			if !bytes.Equal(before, after) {
+				t.Fatal("replay modified the committed fixture")
+			}
+		})
+	}
+}
+
+func assertReplayUsageFixture(
+	t *testing.T,
+	artifact *interfaces.ReplayArtifact,
+	fixture replayUsageFixture,
+	seen map[string]string,
+) {
+	t.Helper()
+	if artifact.SchemaVersion != interfaces.ReplayV1SourceFormat {
+		t.Fatalf("schema version = %q, want %q", artifact.SchemaVersion, interfaces.ReplayV1SourceFormat)
+	}
+	if artifact.RecordedAt.IsZero() || len(artifact.Events) != 8 {
+		t.Fatalf("recording metadata = recordedAt %v, events %d; want non-zero and 8 events", artifact.RecordedAt, len(artifact.Events))
+	}
+	wantTypes := []interfaces.FactoryEventType{
+		interfaces.FactoryEventTypeRunRequest,
+		interfaces.FactoryEventTypeWorkRequest,
+		interfaces.FactoryEventTypeDispatchRequest,
+		interfaces.FactoryEventTypeDispatchWorkerSessionAssoc,
+		interfaces.FactoryEventTypeInferenceRequest,
+		interfaces.FactoryEventTypeInferenceResponse,
+		interfaces.FactoryEventTypeDispatchResponse,
+		interfaces.FactoryEventTypeRunResponse,
+	}
+	seenIDs := map[string]bool{}
+	for index, event := range artifact.Events {
+		if event.SchemaVersion != interfaces.FactoryEventSchemaVersionV1 {
+			t.Fatalf("event %d schema version = %q, want %q", index, event.SchemaVersion, interfaces.FactoryEventSchemaVersionV1)
+		}
+		if event.Type != wantTypes[index] || event.Context.Sequence != index || event.Id == "" {
+			t.Fatalf("event %d = type %q, sequence %d, id %q; want %q, %d, non-empty id", index, event.Type, event.Context.Sequence, event.Id, wantTypes[index], index)
+		}
+		if seenIDs[event.Id] {
+			t.Fatalf("event id %q is duplicated", event.Id)
+		}
+		seenIDs[event.Id] = true
+		if event.Context.SessionID == nil || *event.Context.SessionID != fixture.sessionID {
+			t.Fatalf("event %d session id = %v, want %q", index, event.Context.SessionID, fixture.sessionID)
+		}
+		switch event.Type {
+		case interfaces.FactoryEventTypeModelRequest,
+			interfaces.FactoryEventTypeModelResponse,
+			interfaces.FactoryEventTypeScriptRequest,
+			interfaces.FactoryEventTypeScriptResponse:
+			t.Fatalf("fixture contains an external execution event: %s", event.Type)
+		}
+	}
+	assertDistinctFixtureIdentity(t, fixture, seen)
+
+	var run interfaces.RunRequestEventPayload
+	if err := artifact.Events[0].DecodePayload(&run); err != nil {
+		t.Fatalf("decode RUN_REQUEST payload: %v", err)
+	}
+	if run.Factory == nil {
+		t.Fatal("RUN_REQUEST payload has no Factory snapshot")
+	}
+	snapshotJSON, err := json.Marshal(run.Factory)
+	if err != nil {
+		t.Fatalf("marshal Factory snapshot: %v", err)
+	}
+	if _, err := factoryconfigmapping.GeneratedFactoryFromOpenAPIJSON(snapshotJSON); err != nil {
+		t.Fatalf("decode Factory snapshot at public boundary: %v", err)
+	}
+	if _, err := factorydefinitionswire.ReplayRuntimeConfigDecoder()(run.Factory); err != nil {
+		t.Fatalf("decode replay runtime config: %v", err)
+	}
+
+	var association interfaces.DispatchWorkerSessionAssociationEventPayload
+	if err := artifact.Events[3].DecodePayload(&association); err != nil {
+		t.Fatalf("decode Worker Session association payload: %v", err)
+	}
+	if association.WorkerSessionID != fixture.workerSessionID {
+		t.Fatalf("Worker Session association = %q, want %q", association.WorkerSessionID, fixture.workerSessionID)
+	}
+	if artifact.Events[3].Context.DispatchID == nil || *artifact.Events[3].Context.DispatchID != fixture.dispatchID {
+		t.Fatalf("association dispatch id = %v, want %q", artifact.Events[3].Context.DispatchID, fixture.dispatchID)
+	}
+
+	var response workers.DispatchResponseEventPayload
+	if err := artifact.Events[6].DecodePayload(&response); err != nil {
+		t.Fatalf("decode DISPATCH_RESPONSE payload: %v", err)
+	}
+	if response.Usage == nil {
+		t.Fatal("DISPATCH_RESPONSE has no usage payload")
+	}
+	assertUsageValue(t, "input tokens", response.Usage.InputTokens, fixture.inputTokens)
+	assertUsageValue(t, "output tokens", response.Usage.OutputTokens, fixture.outputTokens)
+	assertUsageValue(t, "total tokens", response.Usage.TotalTokens, fixture.totalTokens)
+
+	var inference workers.InferenceResponseEventPayload
+	if err := artifact.Events[5].DecodePayload(&inference); err != nil {
+		t.Fatalf("decode INFERENCE_RESPONSE payload: %v", err)
+	}
+	diagnostics, err := workers.WorkDiagnosticsFromSafeEventPayload(inference.Diagnostics)
+	if err != nil {
+		t.Fatalf("decode replay-safe provider diagnostics: %v", err)
+	}
+	if diagnostics == nil || diagnostics.Provider == nil {
+		t.Fatal("INFERENCE_RESPONSE has no provider diagnostics")
+	}
+	if diagnostics.Provider.Provider != fixture.provider || diagnostics.Provider.Model != fixture.model {
+		t.Fatalf("provider diagnostics = %#v, want %s/%s", diagnostics.Provider, fixture.provider, fixture.model)
+	}
+}
+
+func assertDistinctFixtureIdentity(t *testing.T, fixture replayUsageFixture, seen map[string]string) {
+	t.Helper()
+	for label, value := range map[string]string{
+		"session":        fixture.sessionID,
+		"dispatch":       fixture.dispatchID,
+		"worker session": fixture.workerSessionID,
+	} {
+		if previous, exists := seen[value]; exists {
+			t.Fatalf("%s id %q is reused by %s and %s fixtures", label, value, previous, fixture.name)
+		}
+		seen[value] = fixture.name
+	}
+}
+
+func assertUsageValue(t *testing.T, label string, value *int64, want int64) {
+	t.Helper()
+	if value == nil {
+		t.Fatalf("%s = nil, want %d", label, want)
+	}
+	if *value != want {
+		t.Fatalf("%s = %d, want %d", label, *value, want)
+	}
+}
+
+func executeReplayUsageFixture(t *testing.T, fixturePath string) {
+	t.Helper()
+	homeDir := t.TempDir()
+	workingDirectory := t.TempDir()
+	api := support.NewProcessAPIServer()
+	providerRunner := support.NewRecordingCommandRunner("unexpected provider execution")
+	scriptRunner := support.NewRecordingCommandRunner("unexpected script execution")
+	process := support.BuildProcess(t, serviceedges.Edges{
+		APIServerStarter:      api.Start,
+		ProviderCommandRunner: providerRunner,
+		ScriptCommandRunner:   scriptRunner,
+	})
+	support.CleanupProcess(t, process)
+
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you",
+		"run",
+		"--dir",
+		workingDirectory,
+		"--server",
+		"http://127.0.0.1:1",
+		"--quiet",
+		"--replay",
+		fixturePath,
+		"--no-record",
+	})
+	inputs.Input.Env = append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+	inputs.Input.WorkingDirectory = workingDirectory
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf("you run --replay failed: %v\nstdout:\n%s\nstderr:\n%s", err, inputs.Stdout(), inputs.Stderr())
+	}
+	if strings.TrimSpace(inputs.Stdout()) != "" {
+		t.Fatalf("you run --replay stdout = %q, want empty output", inputs.Stdout())
+	}
+	if providerRunner.CallCount() != 0 {
+		t.Fatalf("provider command runner calls = %d, want 0", providerRunner.CallCount())
+	}
+	if scriptRunner.CallCount() != 0 {
+		t.Fatalf("script command runner calls = %d, want 0", scriptRunner.CallCount())
+	}
+}

--- a/tests/functional/factory/visualization/runtime_metrics/testdata/claude-sonnet-4-6.factory-recording.v1.json
+++ b/tests/functional/factory/visualization/runtime_metrics/testdata/claude-sonnet-4-6.factory-recording.v1.json
@@ -1,0 +1,295 @@
+{
+  "events": [
+    {
+      "context": {
+        "eventTime": "2026-08-20T13:00:00Z",
+        "sequence": 0,
+        "sessionId": "cost-replay-unpriced-session",
+        "tick": 0
+      },
+      "id": "factory-event/run-started/cost-replay-unpriced-session",
+      "payload": {
+        "factory": {
+          "name": "cost-pipeline-unpriced",
+          "factoryDirectory": "fixtures/cost-pipeline/unpriced",
+          "resources": [],
+          "workTypes": [
+            {
+              "name": "task",
+              "states": [
+                {
+                  "name": "init",
+                  "type": "INITIAL"
+                },
+                {
+                  "name": "complete",
+                  "type": "TERMINAL"
+                },
+                {
+                  "name": "failed",
+                  "type": "FAILED"
+                }
+              ]
+            }
+          ],
+          "workers": [
+            {
+              "modelProvider": "CLAUDE",
+              "model": "claude-sonnet-4-6",
+              "name": "unpriced-worker",
+              "type": "MODEL_WORKER",
+              "body": "Process the recorded cost fixture."
+            }
+          ],
+          "workstations": [
+            {
+              "id": "process",
+              "inputs": [
+                {
+                  "state": "init",
+                  "workType": "task"
+                }
+              ],
+              "name": "process",
+              "outputs": [
+                {
+                  "state": "complete",
+                  "workType": "task"
+                }
+              ],
+              "body": "Process {{ .WorkID }}.",
+              "type": "MODEL_WORKSTATION",
+              "worker": "unpriced-worker"
+            }
+          ]
+        },
+        "recordedAt": "2026-08-20T13:00:00Z",
+        "wallClock": {
+          "startedAt": "2026-08-20T13:00:00Z"
+        }
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "RUN_REQUEST"
+    },
+    {
+      "context": {
+        "eventTime": "2026-08-20T13:00:01Z",
+        "requestId": "cost-replay-unpriced-request",
+        "sequence": 1,
+        "sessionId": "cost-replay-unpriced-session",
+        "source": "api",
+        "tick": 1,
+        "traceIds": [
+          "cost-replay-unpriced-trace"
+        ],
+        "workIds": [
+          "cost-replay-unpriced-work"
+        ]
+      },
+      "id": "factory-event/work-request/cost-replay-unpriced-request",
+      "payload": {
+        "source": "api",
+        "type": "FACTORY_REQUEST_BATCH",
+        "works": [
+          {
+            "name": "Unpriced replay usage",
+            "payload": {
+              "title": "unpriced replay usage"
+            },
+            "requestId": "cost-replay-unpriced-request",
+            "traceId": "cost-replay-unpriced-trace",
+            "workId": "cost-replay-unpriced-work",
+            "workTypeName": "task"
+          }
+        ]
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "WORK_REQUEST"
+    },
+    {
+      "context": {
+        "currentChainingTraceId": "cost-replay-unpriced-trace",
+        "dispatchId": "cost-replay-unpriced-dispatch",
+        "eventTime": "2026-08-20T13:00:02Z",
+        "previousChainingTraceIds": [
+          "cost-replay-unpriced-trace"
+        ],
+        "requestId": "cost-replay-unpriced-request",
+        "sequence": 2,
+        "sessionId": "cost-replay-unpriced-session",
+        "tick": 2,
+        "traceIds": [
+          "cost-replay-unpriced-trace"
+        ],
+        "workIds": [
+          "cost-replay-unpriced-work"
+        ]
+      },
+      "id": "factory-event/dispatch-created/cost-replay-unpriced-dispatch",
+      "payload": {
+        "inputs": [
+          {
+            "workId": "cost-replay-unpriced-work"
+          }
+        ],
+        "metadata": {
+            "replayKey": "process/cost-replay-unpriced-trace/cost-replay-unpriced-work",
+          "runnerId": "claude",
+          "runnerSelectionSource": "legacy_provider"
+        },
+        "transitionId": "process"
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "DISPATCH_REQUEST"
+    },
+    {
+      "context": {
+        "dispatchId": "cost-replay-unpriced-dispatch",
+        "eventTime": "2026-08-20T13:00:02Z",
+        "requestId": "cost-replay-unpriced-request",
+        "sequence": 3,
+        "sessionId": "cost-replay-unpriced-session",
+        "tick": 2
+      },
+      "id": "factory-event/dispatch-worker-session-association/cost-replay-unpriced-worker-session",
+      "payload": {
+        "workerSessionId": "cost-replay-unpriced-worker-session"
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "DISPATCH_WORKER_SESSION_ASSOCIATION"
+    },
+    {
+      "context": {
+        "dispatchId": "cost-replay-unpriced-dispatch",
+        "eventTime": "2026-08-20T13:00:02Z",
+        "requestId": "cost-replay-unpriced-request",
+        "sequence": 4,
+        "sessionId": "cost-replay-unpriced-session",
+        "tick": 2,
+        "traceIds": [
+          "cost-replay-unpriced-trace"
+        ],
+        "workIds": [
+          "cost-replay-unpriced-work"
+        ]
+      },
+      "id": "factory-event/inference-request/cost-replay-unpriced-inference-request",
+      "payload": {
+        "attempt": 1,
+        "inferenceRequestId": "cost-replay-unpriced-inference-request",
+        "prompt": "Process cost-replay-unpriced-work.",
+        "workingDirectory": "/workspace/cost-pipeline",
+        "worktree": "/workspace/cost-pipeline/.worktrees/unpriced"
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "INFERENCE_REQUEST"
+    },
+    {
+      "context": {
+        "dispatchId": "cost-replay-unpriced-dispatch",
+        "eventTime": "2026-08-20T13:00:03Z",
+        "requestId": "cost-replay-unpriced-request",
+        "sequence": 5,
+        "sessionId": "cost-replay-unpriced-session",
+        "tick": 2,
+        "traceIds": [
+          "cost-replay-unpriced-trace"
+        ],
+        "workIds": [
+          "cost-replay-unpriced-work"
+        ]
+      },
+      "id": "factory-event/inference-response/cost-replay-unpriced-inference-request",
+      "payload": {
+        "attempt": 1,
+        "diagnostics": {
+          "provider": {
+            "provider": "claude",
+            "model": "claude-sonnet-4-6",
+            "responseMetadata": {
+              "input_tokens": "1200",
+              "output_tokens": "300"
+            }
+          }
+        },
+        "durationMillis": 125,
+        "inferenceRequestId": "cost-replay-unpriced-inference-request",
+        "outcome": "SUCCEEDED",
+        "response": "unpriced replay usage COMPLETE"
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "INFERENCE_RESPONSE"
+    },
+    {
+      "context": {
+        "currentChainingTraceId": "cost-replay-unpriced-trace",
+        "dispatchId": "cost-replay-unpriced-dispatch",
+        "eventTime": "2026-08-20T13:00:04Z",
+        "previousChainingTraceIds": [
+          "cost-replay-unpriced-trace"
+        ],
+        "requestId": "cost-replay-unpriced-request",
+        "sequence": 6,
+        "sessionId": "cost-replay-unpriced-session",
+        "tick": 3,
+        "traceIds": [
+          "cost-replay-unpriced-trace"
+        ],
+        "workIds": [
+          "cost-replay-unpriced-work"
+        ]
+      },
+      "id": "factory-event/dispatch-completed/cost-replay-unpriced-dispatch",
+      "payload": {
+        "completionId": "cost-replay-unpriced-completion",
+        "outcome": "ACCEPTED",
+        "output": "unpriced replay usage COMPLETE",
+        "outputWork": [
+          {
+            "name": "Unpriced replay usage",
+            "payload": {
+              "title": "unpriced replay usage"
+            },
+            "requestId": "cost-replay-unpriced-request",
+            "state": {
+              "name": "complete",
+              "type": "TERMINAL"
+            },
+            "traceId": "cost-replay-unpriced-trace",
+            "workId": "cost-replay-unpriced-work",
+            "workTypeName": "task"
+          }
+        ],
+        "transitionId": "process",
+        "usage": {
+          "durationMillis": 125,
+          "inputTokens": 1200,
+          "outputTokens": 300,
+          "totalTokens": 1500
+        }
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "DISPATCH_RESPONSE"
+    },
+    {
+      "context": {
+        "eventTime": "2026-08-20T13:00:05Z",
+        "sequence": 7,
+        "sessionId": "cost-replay-unpriced-session",
+        "tick": 3
+      },
+      "id": "factory-event/run-finished/cost-replay-unpriced-session",
+      "payload": {
+        "state": "COMPLETED",
+        "wallClock": {
+          "finishedAt": "2026-08-20T13:00:05Z",
+          "startedAt": "2026-08-20T13:00:00Z"
+        }
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "RUN_RESPONSE"
+    }
+  ],
+  "recordedAt": "2026-08-20T13:00:00Z",
+  "schemaVersion": "agent-factory.replay.v1"
+}

--- a/tests/functional/factory/visualization/runtime_metrics/testdata/claude-sonnet-4-6.factory-recording.v1.json
+++ b/tests/functional/factory/visualization/runtime_metrics/testdata/claude-sonnet-4-6.factory-recording.v1.json
@@ -57,7 +57,7 @@
                   "workType": "task"
                 }
               ],
-              "body": "Process {{ .WorkID }}.",
+              "body": "Process the recorded cost fixture.",
               "type": "MODEL_WORKSTATION",
               "worker": "unpriced-worker"
             }

--- a/tests/functional/factory/visualization/runtime_metrics/testdata/codex-gpt-5-codex.factory-recording.v1.json
+++ b/tests/functional/factory/visualization/runtime_metrics/testdata/codex-gpt-5-codex.factory-recording.v1.json
@@ -1,0 +1,295 @@
+{
+  "events": [
+    {
+      "context": {
+        "eventTime": "2026-08-20T12:00:00Z",
+        "sequence": 0,
+        "sessionId": "cost-replay-priced-session",
+        "tick": 0
+      },
+      "id": "factory-event/run-started/cost-replay-priced-session",
+      "payload": {
+        "factory": {
+          "name": "cost-pipeline-priced",
+          "factoryDirectory": "fixtures/cost-pipeline/priced",
+          "resources": [],
+          "workTypes": [
+            {
+              "name": "task",
+              "states": [
+                {
+                  "name": "init",
+                  "type": "INITIAL"
+                },
+                {
+                  "name": "complete",
+                  "type": "TERMINAL"
+                },
+                {
+                  "name": "failed",
+                  "type": "FAILED"
+                }
+              ]
+            }
+          ],
+          "workers": [
+            {
+              "modelProvider": "CODEX",
+              "model": "gpt-5-codex",
+              "name": "priced-worker",
+              "type": "MODEL_WORKER",
+              "body": "Process the recorded cost fixture."
+            }
+          ],
+          "workstations": [
+            {
+              "id": "process",
+              "inputs": [
+                {
+                  "state": "init",
+                  "workType": "task"
+                }
+              ],
+              "name": "process",
+              "outputs": [
+                {
+                  "state": "complete",
+                  "workType": "task"
+                }
+              ],
+              "body": "Process {{ .WorkID }}.",
+              "type": "MODEL_WORKSTATION",
+              "worker": "priced-worker"
+            }
+          ]
+        },
+        "recordedAt": "2026-08-20T12:00:00Z",
+        "wallClock": {
+          "startedAt": "2026-08-20T12:00:00Z"
+        }
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "RUN_REQUEST"
+    },
+    {
+      "context": {
+        "eventTime": "2026-08-20T12:00:01Z",
+        "requestId": "cost-replay-priced-request",
+        "sequence": 1,
+        "sessionId": "cost-replay-priced-session",
+        "source": "api",
+        "tick": 1,
+        "traceIds": [
+          "cost-replay-priced-trace"
+        ],
+        "workIds": [
+          "cost-replay-priced-work"
+        ]
+      },
+      "id": "factory-event/work-request/cost-replay-priced-request",
+      "payload": {
+        "source": "api",
+        "type": "FACTORY_REQUEST_BATCH",
+        "works": [
+          {
+            "name": "Priced replay usage",
+            "payload": {
+              "title": "priced replay usage"
+            },
+            "requestId": "cost-replay-priced-request",
+            "traceId": "cost-replay-priced-trace",
+            "workId": "cost-replay-priced-work",
+            "workTypeName": "task"
+          }
+        ]
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "WORK_REQUEST"
+    },
+    {
+      "context": {
+        "currentChainingTraceId": "cost-replay-priced-trace",
+        "dispatchId": "cost-replay-priced-dispatch",
+        "eventTime": "2026-08-20T12:00:02Z",
+        "previousChainingTraceIds": [
+          "cost-replay-priced-trace"
+        ],
+        "requestId": "cost-replay-priced-request",
+        "sequence": 2,
+        "sessionId": "cost-replay-priced-session",
+        "tick": 2,
+        "traceIds": [
+          "cost-replay-priced-trace"
+        ],
+        "workIds": [
+          "cost-replay-priced-work"
+        ]
+      },
+      "id": "factory-event/dispatch-created/cost-replay-priced-dispatch",
+      "payload": {
+        "inputs": [
+          {
+            "workId": "cost-replay-priced-work"
+          }
+        ],
+        "metadata": {
+            "replayKey": "process/cost-replay-priced-trace/cost-replay-priced-work",
+          "runnerId": "codex",
+          "runnerSelectionSource": "legacy_provider"
+        },
+        "transitionId": "process"
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "DISPATCH_REQUEST"
+    },
+    {
+      "context": {
+        "dispatchId": "cost-replay-priced-dispatch",
+        "eventTime": "2026-08-20T12:00:02Z",
+        "requestId": "cost-replay-priced-request",
+        "sequence": 3,
+        "sessionId": "cost-replay-priced-session",
+        "tick": 2
+      },
+      "id": "factory-event/dispatch-worker-session-association/cost-replay-priced-worker-session",
+      "payload": {
+        "workerSessionId": "cost-replay-priced-worker-session"
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "DISPATCH_WORKER_SESSION_ASSOCIATION"
+    },
+    {
+      "context": {
+        "dispatchId": "cost-replay-priced-dispatch",
+        "eventTime": "2026-08-20T12:00:02Z",
+        "requestId": "cost-replay-priced-request",
+        "sequence": 4,
+        "sessionId": "cost-replay-priced-session",
+        "tick": 2,
+        "traceIds": [
+          "cost-replay-priced-trace"
+        ],
+        "workIds": [
+          "cost-replay-priced-work"
+        ]
+      },
+      "id": "factory-event/inference-request/cost-replay-priced-inference-request",
+      "payload": {
+        "attempt": 1,
+        "inferenceRequestId": "cost-replay-priced-inference-request",
+        "prompt": "Process cost-replay-priced-work.",
+        "workingDirectory": "/workspace/cost-pipeline",
+        "worktree": "/workspace/cost-pipeline/.worktrees/priced"
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "INFERENCE_REQUEST"
+    },
+    {
+      "context": {
+        "dispatchId": "cost-replay-priced-dispatch",
+        "eventTime": "2026-08-20T12:00:03Z",
+        "requestId": "cost-replay-priced-request",
+        "sequence": 5,
+        "sessionId": "cost-replay-priced-session",
+        "tick": 2,
+        "traceIds": [
+          "cost-replay-priced-trace"
+        ],
+        "workIds": [
+          "cost-replay-priced-work"
+        ]
+      },
+      "id": "factory-event/inference-response/cost-replay-priced-inference-request",
+      "payload": {
+        "attempt": 1,
+        "diagnostics": {
+          "provider": {
+            "provider": "codex",
+            "model": "gpt-5-codex",
+            "responseMetadata": {
+              "input_tokens": "1000000",
+              "output_tokens": "2000000"
+            }
+          }
+        },
+        "durationMillis": 125,
+        "inferenceRequestId": "cost-replay-priced-inference-request",
+        "outcome": "SUCCEEDED",
+        "response": "priced replay usage COMPLETE"
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "INFERENCE_RESPONSE"
+    },
+    {
+      "context": {
+        "currentChainingTraceId": "cost-replay-priced-trace",
+        "dispatchId": "cost-replay-priced-dispatch",
+        "eventTime": "2026-08-20T12:00:04Z",
+        "previousChainingTraceIds": [
+          "cost-replay-priced-trace"
+        ],
+        "requestId": "cost-replay-priced-request",
+        "sequence": 6,
+        "sessionId": "cost-replay-priced-session",
+        "tick": 3,
+        "traceIds": [
+          "cost-replay-priced-trace"
+        ],
+        "workIds": [
+          "cost-replay-priced-work"
+        ]
+      },
+      "id": "factory-event/dispatch-completed/cost-replay-priced-dispatch",
+      "payload": {
+        "completionId": "cost-replay-priced-completion",
+        "outcome": "ACCEPTED",
+        "output": "priced replay usage COMPLETE",
+        "outputWork": [
+          {
+            "name": "Priced replay usage",
+            "payload": {
+              "title": "priced replay usage"
+            },
+            "requestId": "cost-replay-priced-request",
+            "state": {
+              "name": "complete",
+              "type": "TERMINAL"
+            },
+            "traceId": "cost-replay-priced-trace",
+            "workId": "cost-replay-priced-work",
+            "workTypeName": "task"
+          }
+        ],
+        "transitionId": "process",
+        "usage": {
+          "durationMillis": 125,
+          "inputTokens": 1000000,
+          "outputTokens": 2000000,
+          "totalTokens": 3000000
+        }
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "DISPATCH_RESPONSE"
+    },
+    {
+      "context": {
+        "eventTime": "2026-08-20T12:00:05Z",
+        "sequence": 7,
+        "sessionId": "cost-replay-priced-session",
+        "tick": 3
+      },
+      "id": "factory-event/run-finished/cost-replay-priced-session",
+      "payload": {
+        "state": "COMPLETED",
+        "wallClock": {
+          "finishedAt": "2026-08-20T12:00:05Z",
+          "startedAt": "2026-08-20T12:00:00Z"
+        }
+      },
+      "schemaVersion": "agent-factory.event.v1",
+      "type": "RUN_RESPONSE"
+    }
+  ],
+  "recordedAt": "2026-08-20T12:00:00Z",
+  "schemaVersion": "agent-factory.replay.v1"
+}

--- a/tests/functional/factory/visualization/runtime_metrics/testdata/codex-gpt-5-codex.factory-recording.v1.json
+++ b/tests/functional/factory/visualization/runtime_metrics/testdata/codex-gpt-5-codex.factory-recording.v1.json
@@ -57,7 +57,7 @@
                   "workType": "task"
                 }
               ],
-              "body": "Process {{ .WorkID }}.",
+              "body": "Process the recorded cost fixture.",
               "type": "MODEL_WORKSTATION",
               "worker": "priced-worker"
             }


### PR DESCRIPTION
{
  "project": "Offline Replay Fixture Proving Priced and Unpriced Costs",
  "branchName": "cost-pipeline-offline-usage-fixture",
  "description": "Add committed, deterministic Factory recordings and a functional replay harness that prove the shipped cost pipeline reaches PRICED and UNPRICED without paid provider calls. Replayed codex/gpt-5-codex usage must produce an exact 21.25 USD known cost, while replayed claude/claude-sonnet-4-6 usage must retain real non-zero token totals with a null known cost across human CLI, JSON CLI, and HTTP.",
  "context": {
    "customerAsk": "Provide a fully offline, reproducible cost-pipeline proof using two committed .factory-recording.v1.json fixtures: one with canonical Worker Session usage for priced codex/gpt-5-codex and one for unpriced claude/claude-sonnet-4-6. Replay each in an isolated HOME/USERPROFILE, assert the real you metrics costs and GET /metrics/costs results, include exact before/after CLI output in the PR, add functional assertions rather than a fixture alone, and do not change pricing logic, the price table, pkg/services/worker_sessions/**, or pkg/services/models/**.",
    "problem": "Measured origin/main commit 9fcd9f068c3176c8480422ac02b2b3ced40a90c3 can only produce NO_USAGE from an offline mock-only posture: mock workers emit no usage, real paid calls are disallowed in CI, and no committed recording carries priceable usage. Existing tests inject runtime metric rows or use mocked provider completions, so they do not prove that canonical recorded Factory Events survive replay into the customer-facing cost reports. Maintainers also lack regression proof that an unpriced provider/model retains its measured tokens rather than appearing free or absent.",
    "solution": "Commit a minimal priced recording with 1,000,000 input and 2,000,000 output tokens for codex/gpt-5-codex and a companion recording with 1,200 input and 300 output tokens for claude/claude-sonnet-4-6. Replay each through the normal root-composed command in a fresh isolated instance, preserve recorded dispatch and Worker Session lineage through the existing runtime-usage boundary, and query human CLI, JSON CLI, and public HTTP. Assert exact 21.25 USD for the priced case and null cost with 1,500 real tokens for the unpriced case. Add only a narrow replay-owned usage materialization seam if the current path drops recorded usage; leave Costs valuation and Providers price facts unchanged."
  },
  "acceptanceCriteria": [
    "Two committed replay recordings load successfully through you run --replay against a minimal Factory, contain coherent canonical Factory Events with distinct Worker Session lineage and non-zero usage, and execute no live provider, model-host, script, or mock-worker work.",
    "In a fresh HOME/USERPROFILE-scoped instance, replaying the codex/gpt-5-codex fixture makes both you metrics costs and GET /metrics/costs report PRICED, 1,000,000 input tokens, 2,000,000 output tokens, 3,000,000 total tokens, and exact known_cost 21.25 USD; the expected value is independently asserted as (1,000,000 × 1.25 + 2,000,000 × 10) / 1,000,000.",
    "In a separate fresh HOME/USERPROFILE-scoped instance, replaying the claude/claude-sonnet-4-6 fixture makes both cost surfaces report UNPRICED, null known_cost, 1,200 input tokens, 300 output tokens, and 1,500 total tokens; the report never substitutes zero tokens or $0.00 for unknown pricing.",
    "The functional proof uses normal root-composed replay and CLI paths plus the public HTTP route, performs no direct insertion of runtime metric rows, uses deterministic observation rather than sleeps, and leaves pricing logic, the shipped price table, pkg/services/worker_sessions/**, and pkg/services/models/** untouched. Shared helper naming is reconciled with mock-worker-usage-emission-seam without blocking this lane or duplicating equivalent harness code.",
    "The PR body or a PR comment contains exact captured output for you metrics costs and you --json metrics costs before the change showing offline NO_USAGE and after the change showing PRICED with 21.25 USD and UNPRICED with real token totals. Captured evidence identifies its fixture and isolated instance and is not committed as a generated evidence artifact.",
    "Typecheck passes; focused replay/cost functional tests and relevant backend tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The worker/reviewer cycle continues through the review-owned outcomes until the PR is actually merged; a PR that is merely open, green, approved, or ready to merge is not complete."
  ],
  "userStories": [
    {
      "id": "cost-pipeline-offline-usage-fixture-001",
      "title": "Establish deterministic replay usage fixtures",
      "description": "As a maintainer, I want small committed recordings with canonical priced and unpriced usage so offline tests and dependent pricing work share stable, realistic inputs.",
      "acceptanceCriteria": [
        "The priced recording represents one completed dispatch for a recorded Worker Session using provider codex, model gpt-5-codex, 1,000,000 input tokens, 2,000,000 output tokens, and 3,000,000 total tokens.",
        "The companion recording represents one completed dispatch for a distinct recorded Worker Session using provider claude, model claude-sonnet-4-6, 1,200 input tokens, 300 output tokens, and 1,500 total tokens.",
        "Each fixture has a minimal coherent Factory lifecycle and is accepted by the normal you run --replay path; replay output identifies the expected completed historical session rather than failing schema, event-order, or lineage validation.",
        "Replaying either fixture performs zero provider, model-host, script, and mock-worker executions and does not modify the source recording.",
        "Fixture IDs, timestamps, session IDs, dispatch IDs, Worker Session IDs, and token counts are stable and distinct so repeated isolated test runs produce the same assertions.",
        "Before adding a shared helper, reconcile current-main naming with mock-worker-usage-emission-seam; reuse a compatible helper when present, otherwise add one narrowly named replay-cost harness that price-table-operator-override can reuse. Coordination does not block delivery.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cost-pipeline-offline-usage-fixture-002",
      "title": "Prove the priced cost path offline",
      "description": "As a maintainer, I want a replay-only priced scenario so I can detect regressions in canonical usage ingestion and exact shipped-rate valuation without a paid provider call.",
      "acceptanceCriteria": [
        "The test creates a fresh isolated HOME and USERPROFILE, replays the committed codex/gpt-5-codex recording through the root-composed you run --replay command, and does not pre-seed or directly write runtime metric rows.",
        "Human you metrics costs output reports PRICED, USD 21.25, and the fixture's non-zero token totals without an unknown-cost marker.",
        "JSON you --json metrics costs output reports status PRICED, currency USD, known_cost 21.25, zero unpriced dispatches, and token totals of 1,000,000 input, 2,000,000 output, and 3,000,000 total.",
        "GET /metrics/costs in the same isolated instance returns the same status, exact amount, coverage, provider/model identity, Worker Session lineage, and token totals as the JSON CLI response.",
        "The expected 21.25 amount is hand-computed in the test from the fixture counts and the currently shipped 1.25 input and 10 output USD-per-million rates; the test does not call the production valuation function to calculate its expected value.",
        "The test fails if replay drops usage, changes a count to zero or null, returns NO_USAGE, PARTIAL, or UNPRICED, or rounds the exact JSON amount incorrectly.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added a root-composed replay functional proof covering human CLI, JSON CLI, and GET /metrics/costs with independently computed exact 21.25 USD valuation, token totals, coverage, provider/model identity, and Worker Session lineage."
    },
    {
      "id": "cost-pipeline-offline-usage-fixture-003",
      "title": "Prove unpriced usage remains truthful offline",
      "description": "As a maintainer, I want a replay-only unpriced scenario so unsupported provider/model usage remains measurable without being misrepresented as free or absent.",
      "acceptanceCriteria": [
        "The test uses a separate fresh HOME and USERPROFILE, replays the committed claude/claude-sonnet-4-6 recording through the root-composed you run --replay command, and does not inherit artifacts from the priced scenario.",
        "Human you metrics costs output reports UNPRICED, identifies claude/claude-sonnet-4-6, shows 1,500 total tokens, and uses the unknown-cost presentation rather than $0.00 or NO_USAGE.",
        "JSON you --json metrics costs output reports status UNPRICED, known_cost null, one unpriced dispatch, the unpriced provider/model pair, and token totals of 1,200 input, 300 output, and 1,500 total.",
        "GET /metrics/costs in the same isolated instance returns the same null cost, coverage, provider/model identity, Worker Session lineage, and non-zero token totals as the JSON CLI response.",
        "The test fails if the pair is silently priced, if known_cost becomes zero, if token totals are absent or zeroed, or if the result is contaminated by the priced fixture.",
        "Exact before/after human and JSON command output for the offline NO_USAGE, PRICED, and UNPRICED cases is included in the PR body or a PR comment; CI-run evidence is placed only in a PR comment and never in a commit.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added a root-composed replay functional proof covering isolated HOME/USERPROFILE replay, human CLI, JSON CLI, GET /metrics/costs parity, null known cost, unpriced dispatch/provider-model facts, Worker Session lineage, exact 1,200/300/1,500 token totals, and zero provider/script executions. Captured baseline NO_USAGE and replay PRICED/UNPRICED CLI output for the PR conversation."
    }
  ]
}
