### PR TITLE
fix(models): make built-in model names reachable from CLI and HTTP

### DIFF
--- a/pkg/services/models/internal/local/catalog.go
+++ b/pkg/services/models/internal/local/catalog.go
@@ -617,6 +617,11 @@ func CanonicalModelName(model string) string {
 type PullOptions struct {
 	RuntimeCacheInspector RuntimeCacheInspector
 	SourceResolver        ManagedRuntimeSourceResolver
+	// ResolvedReference is supplied only by the Models root after its
+	// canonical resolver has accepted a name that is absent from the
+	// Factory-scoped catalog. It lets the existing pull projection continue
+	// without turning the lower-level Factory catalog into a second resolver.
+	ResolvedReference *models.ResolvedModelReference
 }
 
 // PullModel validates catalog locality and delegates asset pull to the injected puller.
@@ -638,7 +643,7 @@ func PullModelWithOptions(
 	modelName string,
 	opts PullOptions,
 ) (models.PullResult, error) {
-	entry, err := pullCatalogEntry(puller, runtimeCfg, modelName)
+	entry, err := pullCatalogEntry(puller, runtimeCfg, modelName, opts.ResolvedReference)
 	if err != nil {
 		return models.PullResult{}, err
 	}
@@ -647,6 +652,12 @@ func PullModelWithOptions(
 		return models.PullResult{}, err
 	}
 	result, err := puller.PullModel(ctx, runtimeCfg, modelName)
+	if opts.ResolvedReference != nil && strings.TrimSpace(entry.Summary.Name) != "" {
+		// Generic asset preparation reports the source identity for a named
+		// reference (for example, its Hugging Face repository). Pull's public
+		// identity remains the resolved model name.
+		result.ModelName = entry.Summary.Name
+	}
 	if err != nil {
 		if errors.Is(err, managedruntime.ErrNotFound) || errors.Is(err, models.ErrPullUnsupported) {
 			return models.PullResult{}, err
@@ -674,6 +685,7 @@ func pullCatalogEntry(
 	puller AssetPuller,
 	runtimeCfg *models.RuntimeConfig,
 	modelName string,
+	resolved *models.ResolvedModelReference,
 ) (CatalogEntry, error) {
 	if runtimeCfg == nil {
 		return CatalogEntry{}, fmt.Errorf("factory service runtime is not available")
@@ -687,6 +699,9 @@ func pullCatalogEntry(
 	}
 	entry, ok := BuildCatalog(runtimeCfg)[key]
 	if !ok {
+		if fallback := resolvedPullCatalogEntry(key, modelName, resolved); fallback != nil {
+			return *fallback, nil
+		}
 		return CatalogEntry{}, fmt.Errorf("%w: %s", managedruntime.ErrNotFound, modelName)
 	}
 	if entry.Summary.ProviderLocality != managedruntime.LocalityLocal {
@@ -695,6 +710,28 @@ func pullCatalogEntry(
 		)
 	}
 	return entry, nil
+}
+
+func resolvedPullCatalogEntry(
+	key string,
+	modelName string,
+	resolved *models.ResolvedModelReference,
+) *CatalogEntry {
+	if resolved == nil {
+		return nil
+	}
+	definition := resolved.Definition
+	name := strings.TrimSpace(definition.Name)
+	if name == "" {
+		name = strings.TrimSpace(modelName)
+	}
+	if CanonicalModelName(name) != key {
+		return nil
+	}
+	return &CatalogEntry{Summary: modelcatalog.Summary{
+		Name:             name,
+		ProviderLocality: managedruntime.LocalityLocal,
+	}}
 }
 
 func resolvePullSource(

--- a/pkg/services/models/internal/local/catalog_pull_test.go
+++ b/pkg/services/models/internal/local/catalog_pull_test.go
@@ -67,6 +67,67 @@ func TestPullModelWithOptions_ClassifiesUnsupportedLocalModel(t *testing.T) {
 	}
 }
 
+func TestPullModelWithOptions_UsesCanonicalResolvedFallback(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{
+		apisurface.BuiltInModelNameASR,
+		apisurface.BuiltInModelNameTTS,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			definition, ok := (apisurface.BuiltInCatalog{}).ModelDefinitionFor(name)
+			if !ok {
+				t.Fatalf("built-in definition %q is missing", name)
+			}
+			puller := &managedPullTestAssetPuller{result: apisurface.PullResult{
+				ModelName: name,
+				Outcome:   legacyPullOutcomePulled,
+			}}
+			resolved := &apisurface.ResolvedModelReference{
+				Definition: definition,
+			}
+
+			result, err := PullModelWithOptions(
+				puller,
+				context.Background(),
+				&apisurface.RuntimeConfig{},
+				name,
+				PullOptions{ResolvedReference: resolved},
+			)
+			if err != nil {
+				t.Fatalf("PullModelWithOptions(%q): %v", name, err)
+			}
+			if result.ManagedPullOutcome != managedPullOutcomeInstalledSuccessfully ||
+				result.ReadinessState != managedReadinessReady {
+				t.Fatalf("pull result = %#v, want successful managed-runtime projection", result)
+			}
+			if len(puller.calls) != 1 || puller.calls[0] != name {
+				t.Fatalf("pull calls = %#v, want one call for %q", puller.calls, name)
+			}
+		})
+	}
+}
+
+func TestPullModelWithOptions_UnknownModelStillReturnsCatalogMiss(t *testing.T) {
+	t.Parallel()
+
+	puller := &managedPullTestAssetPuller{}
+	_, err := PullModelWithOptions(
+		puller,
+		context.Background(),
+		&apisurface.RuntimeConfig{},
+		"unknown-model",
+		PullOptions{},
+	)
+	if !errors.Is(err, apisurface.ErrNotFound) {
+		t.Fatalf("unknown pull error = %v, want ErrNotFound", err)
+	}
+	if len(puller.calls) != 0 {
+		t.Fatalf("unknown pull calls = %#v, want none", puller.calls)
+	}
+}
+
 func TestPullModelWithOptions_ReportsVerificationFailure(t *testing.T) {
 	t.Parallel()
 	loaded := mustLoadedCatalogConfig(t, catalogFactoryConfig(true))
@@ -120,9 +181,11 @@ func TestPullModelWithOptions_DoesNotSucceedAfterCallerCancellation(t *testing.T
 type managedPullTestAssetPuller struct {
 	result apisurface.PullResult
 	err    error
+	calls  []string
 }
 
-func (p *managedPullTestAssetPuller) PullModel(context.Context, *modelRuntimeConfig, string) (apisurface.PullResult, error) {
+func (p *managedPullTestAssetPuller) PullModel(_ context.Context, _ *modelRuntimeConfig, name string) (apisurface.PullResult, error) {
+	p.calls = append(p.calls, name)
 	return p.result, p.err
 }
 

--- a/pkg/services/models/internal/service/pull.go
+++ b/pkg/services/models/internal/service/pull.go
@@ -12,6 +12,7 @@ import (
 	modelhost "github.com/portpowered/infinite-you/pkg/services/models/internal/legacyhost"
 	localmodels "github.com/portpowered/infinite-you/pkg/services/models/internal/local"
 	managedruntime "github.com/portpowered/infinite-you/pkg/services/models/internal/managedruntime"
+	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
 	"go.uber.org/zap"
 )
 
@@ -74,6 +75,59 @@ func (s *Service) PullModel(ctx context.Context, modelName string) (models.PullR
 	result, err := s.pullWithModelHost(ctx, host, modelName)
 	s.recordManagedRuntimePull(modelName, result, err, s.now().Sub(started))
 	return result, err
+}
+
+func (o *Root) pullResolvedModelAfterCatalogMiss(
+	ctx context.Context,
+	request models.PullModelRequest,
+	catalogErr error,
+) (models.PullResult, error) {
+	resolution, err := o.ResolveModelReference(ctx, models.ResolveModelReferenceRequest{
+		Scope: request.Scope,
+		Reference: models.ModelReference{
+			NameOrURI: request.Name,
+		},
+	})
+	if err != nil {
+		// The scoped catalog miss remains the established pull error when the
+		// canonical resolver also reports a genuine unknown name. Other
+		// resolver failures are meaningful configuration or reference errors
+		// and must not be hidden behind the earlier catalog miss.
+		if errors.Is(err, models.ErrModelReferenceUnknown) {
+			return models.PullResult{}, catalogErr
+		}
+		return models.PullResult{}, err
+	}
+	if o == nil || o.assets == nil || o.runtimeScopes == nil {
+		return models.PullResult{}, catalogErr
+	}
+	binding, err := o.runtimeScopes.Resolve(runtimescopes.Reference(request.Scope.String()))
+	if err != nil {
+		return models.PullResult{}, runtimeScopeError(err)
+	}
+	if binding.RuntimeConfig == nil {
+		return models.PullResult{}, models.ErrUnavailable
+	}
+	runtimeConfig := binding.RuntimeConfig()
+	if runtimeConfig == nil {
+		return models.PullResult{}, models.ErrUnavailable
+	}
+	puller, err := localmodels.NewScopedAssetPuller(o.assets, request.Scope)
+	if err != nil {
+		return models.PullResult{}, err
+	}
+	resolved := resolution.Resolved.Clone()
+	return localmodels.PullModelWithOptions(
+		puller,
+		ctx,
+		runtimeConfig,
+		request.Name,
+		localmodels.PullOptions{
+			RuntimeCacheInspector: puller,
+			SourceResolver:        localmodels.DefaultManagedRuntimeSourceResolver(),
+			ResolvedReference:     &resolved,
+		},
+	)
 }
 
 func (s *Service) pullWithModelHost(

--- a/pkg/services/models/internal/service/runtime_factory.go
+++ b/pkg/services/models/internal/service/runtime_factory.go
@@ -304,59 +304,6 @@ func (o *Root) PullModelForScope(
 	return o.pullResolvedModelAfterCatalogMiss(ctx, request, err)
 }
 
-func (o *Root) pullResolvedModelAfterCatalogMiss(
-	ctx context.Context,
-	request models.PullModelRequest,
-	catalogErr error,
-) (models.PullResult, error) {
-	resolution, err := o.ResolveModelReference(ctx, models.ResolveModelReferenceRequest{
-		Scope: request.Scope,
-		Reference: models.ModelReference{
-			NameOrURI: request.Name,
-		},
-	})
-	if err != nil {
-		// The scoped catalog miss remains the established pull error when the
-		// canonical resolver also reports a genuine unknown name. Other
-		// resolver failures are meaningful configuration or reference errors
-		// and must not be hidden behind the earlier catalog miss.
-		if errors.Is(err, models.ErrModelReferenceUnknown) {
-			return models.PullResult{}, catalogErr
-		}
-		return models.PullResult{}, err
-	}
-	if o == nil || o.assets == nil || o.runtimeScopes == nil {
-		return models.PullResult{}, catalogErr
-	}
-	binding, err := o.runtimeScopes.Resolve(runtimescopes.Reference(request.Scope.String()))
-	if err != nil {
-		return models.PullResult{}, runtimeScopeError(err)
-	}
-	if binding.RuntimeConfig == nil {
-		return models.PullResult{}, models.ErrUnavailable
-	}
-	runtimeConfig := binding.RuntimeConfig()
-	if runtimeConfig == nil {
-		return models.PullResult{}, models.ErrUnavailable
-	}
-	puller, err := localmodels.NewScopedAssetPuller(o.assets, request.Scope)
-	if err != nil {
-		return models.PullResult{}, err
-	}
-	resolved := resolution.Resolved.Clone()
-	return localmodels.PullModelWithOptions(
-		puller,
-		ctx,
-		runtimeConfig,
-		request.Name,
-		localmodels.PullOptions{
-			RuntimeCacheInspector: puller,
-			SourceResolver:        localmodels.DefaultManagedRuntimeSourceResolver(),
-			ResolvedReference:     &resolved,
-		},
-	)
-}
-
 func (o *Root) InspectModelAssets(
 	ctx context.Context,
 	request models.InspectModelAssetsRequest,

--- a/pkg/services/models/internal/service/runtime_factory.go
+++ b/pkg/services/models/internal/service/runtime_factory.go
@@ -297,7 +297,64 @@ func (o *Root) PullModelForScope(
 	if !ok {
 		return models.PullResult{}, models.ErrUnsupportedOperation
 	}
-	return puller.PullModel(ctx, request.Name)
+	result, err := puller.PullModel(ctx, request.Name)
+	if err == nil || !errors.Is(err, models.ErrNotFound) {
+		return result, err
+	}
+	return o.pullResolvedModelAfterCatalogMiss(ctx, request, err)
+}
+
+func (o *Root) pullResolvedModelAfterCatalogMiss(
+	ctx context.Context,
+	request models.PullModelRequest,
+	catalogErr error,
+) (models.PullResult, error) {
+	resolution, err := o.ResolveModelReference(ctx, models.ResolveModelReferenceRequest{
+		Scope: request.Scope,
+		Reference: models.ModelReference{
+			NameOrURI: request.Name,
+		},
+	})
+	if err != nil {
+		// The scoped catalog miss remains the established pull error when the
+		// canonical resolver also reports a genuine unknown name. Other
+		// resolver failures are meaningful configuration or reference errors
+		// and must not be hidden behind the earlier catalog miss.
+		if errors.Is(err, models.ErrModelReferenceUnknown) {
+			return models.PullResult{}, catalogErr
+		}
+		return models.PullResult{}, err
+	}
+	if o == nil || o.assets == nil || o.runtimeScopes == nil {
+		return models.PullResult{}, catalogErr
+	}
+	binding, err := o.runtimeScopes.Resolve(runtimescopes.Reference(request.Scope.String()))
+	if err != nil {
+		return models.PullResult{}, runtimeScopeError(err)
+	}
+	if binding.RuntimeConfig == nil {
+		return models.PullResult{}, models.ErrUnavailable
+	}
+	runtimeConfig := binding.RuntimeConfig()
+	if runtimeConfig == nil {
+		return models.PullResult{}, models.ErrUnavailable
+	}
+	puller, err := localmodels.NewScopedAssetPuller(o.assets, request.Scope)
+	if err != nil {
+		return models.PullResult{}, err
+	}
+	resolved := resolution.Resolved.Clone()
+	return localmodels.PullModelWithOptions(
+		puller,
+		ctx,
+		runtimeConfig,
+		request.Name,
+		localmodels.PullOptions{
+			RuntimeCacheInspector: puller,
+			SourceResolver:        localmodels.DefaultManagedRuntimeSourceResolver(),
+			ResolvedReference:     &resolved,
+		},
+	)
 }
 
 func (o *Root) InspectModelAssets(

--- a/pkg/services/models/internal/service/runtime_factory_scoped_pull_test.go
+++ b/pkg/services/models/internal/service/runtime_factory_scoped_pull_test.go
@@ -11,6 +11,7 @@ import (
 	modelseffects "github.com/portpowered/infinite-you/pkg/services/models/internal/effects"
 	scopedassets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
 	runtimescopes "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes"
+	runtimescopeswire "github.com/portpowered/infinite-you/pkg/services/models/internal/services/runtime_scopes/wire"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
@@ -37,6 +38,133 @@ func TestRuntimeServicePullModelForScopeValidatesAndDelegates(t *testing.T) {
 	if _, err := runtime.PullModelForScope(context.Background(), models.PullModelRequest{Name: "voice"}); err == nil {
 		t.Fatal("delegated pull error = nil, want unavailable runtime failure")
 	}
+}
+
+func TestRootPullModelForScopeFallsBackToCanonicalBuiltInResolution(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{
+		models.BuiltInModelNameASR,
+		models.BuiltInModelNameTTS,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			root, scope, assets := newPullFallbackRoot(t, name)
+			result, err := root.PullModelForScope(context.Background(), models.PullModelRequest{
+				Scope: scope,
+				Name:  name,
+			})
+			if err != nil {
+				t.Fatalf("PullModelForScope(%q): %v", name, err)
+			}
+			if result.ModelName != name || result.ManagedPullOutcome != "INSTALLED_SUCCESSFULLY" ||
+				result.ReadinessState != "READY" {
+				t.Fatalf("pull result = %#v, want successful managed-runtime result", result)
+			}
+			if assets.request.Scope != scope || assets.request.Name != name {
+				t.Fatalf("asset preparation request = %#v, want scope %s and model %q", assets.request, scope.String(), name)
+			}
+		})
+	}
+}
+
+func TestRootPullModelForScopePreservesUnknownCatalogMiss(t *testing.T) {
+	t.Parallel()
+
+	root, _, assets := newPullFallbackRoot(t, "")
+	scope := firstPullFallbackScope(t, root)
+	_, err := root.PullModelForScope(context.Background(), models.PullModelRequest{
+		Scope: scope,
+		Name:  "unknown-model",
+	})
+	if !errors.Is(err, models.ErrNotFound) {
+		t.Fatalf("unknown PullModelForScope error = %v, want ErrNotFound", err)
+	}
+	if assets.request.Name != "" {
+		t.Fatalf("unknown asset preparation request = %#v, want no preparation", assets.request)
+	}
+}
+
+func TestRootPullModelForScopeKeepsExistingFactoryPullResult(t *testing.T) {
+	t.Parallel()
+
+	root, scope, assets := newPullFallbackRoot(t, "")
+	runtime := root.runtimeByScope[scope].(*pullCatalogMissRuntime)
+	runtime.result = models.PullResult{
+		ModelName:          "factory-model",
+		ProviderLocality:   string(models.LocalityLocal),
+		Outcome:            "ALREADY_PRESENT",
+		ManagedPullOutcome: "ALREADY_READY",
+		ReadinessState:     "READY",
+		LifecycleState:     "INSTALLED",
+	}
+	runtime.err = nil
+
+	result, err := root.PullModelForScope(context.Background(), models.PullModelRequest{
+		Scope: scope,
+		Name:  "factory-model",
+	})
+	if err != nil {
+		t.Fatalf("Factory PullModelForScope: %v", err)
+	}
+	if result.ModelName != "factory-model" || result.Outcome != "ALREADY_PRESENT" {
+		t.Fatalf("Factory pull result = %#v, want existing result", result)
+	}
+	if assets.request.Name != "" {
+		t.Fatalf("Factory fallback asset preparation request = %#v, want none", assets.request)
+	}
+}
+
+func newPullFallbackRoot(t *testing.T, modelName string) (*Root, models.RuntimeScopeRef, *preparationAssetService) {
+	t.Helper()
+	scopes, err := runtimescopeswire.NewService(func() string { return "pull-fallback-test" })
+	if err != nil {
+		t.Fatalf("construct runtime scopes: %v", err)
+	}
+	ref, err := scopes.Open(models.RuntimeBinding{
+		RuntimeConfig: func() *models.RuntimeConfig { return &models.RuntimeConfig{} },
+	})
+	if err != nil {
+		t.Fatalf("open runtime scope: %v", err)
+	}
+	scope, err := (models.RuntimeScopeRef{}).Parse(string(ref))
+	if err != nil {
+		t.Fatalf("parse runtime scope: %v", err)
+	}
+	assets := &preparationAssetService{result: models.PrepareModelAssetsResult{
+		Outcome: models.AssetPreparationPrepared,
+		Asset: models.AssetSnapshot{
+			ModelName: modelName,
+			Readiness: models.AssetReadinessAvailable,
+		},
+	}}
+	root := &Root{
+		runtimeScopes: scopes,
+		assets:        assets,
+		runtimeByScope: map[models.RuntimeScopeRef]models.Service{
+			scope: &pullCatalogMissRuntime{err: models.ErrNotFound},
+		},
+	}
+	return root, scope, assets
+}
+
+func firstPullFallbackScope(t *testing.T, root *Root) models.RuntimeScopeRef {
+	t.Helper()
+	for scope := range root.runtimeByScope {
+		return scope
+	}
+	t.Fatal("pull fallback root has no runtime scope")
+	return models.RuntimeScopeRef{}
+}
+
+type pullCatalogMissRuntime struct {
+	models.Service
+	result models.PullResult
+	err    error
+}
+
+func (runtime *pullCatalogMissRuntime) PullModel(context.Context, string) (models.PullResult, error) {
+	return runtime.result, runtime.err
 }
 
 func TestRootCloseRuntimeScopePreventsConcurrentLazyRuntimeReinsertion(t *testing.T) {

--- a/pkg/services/models/internal/service/service_test.go
+++ b/pkg/services/models/internal/service/service_test.go
@@ -487,6 +487,23 @@ func TestRootCatalogMatchesDirectPrivateCatalogFailures(t *testing.T) {
 func TestScopedCatalogPreservesCompatibilityBehavior(t *testing.T) {
 	t.Parallel()
 
+	fixture := newCompatibilityParityFixture(t)
+	assertCompatibilityListParity(t, fixture)
+	assertCompatibilityDetailParity(t, fixture)
+	fixture.markReady()
+	assertCompatibilityReadinessParity(t, fixture)
+}
+
+type compatibilityParityFixture struct {
+	compatibility    *Service
+	root             *Root
+	opened           models.OpenRuntimeScopeResult
+	currentReadiness *models.Runtime
+	host             *compatibilityParityHost
+}
+
+func newCompatibilityParityFixture(t *testing.T) compatibilityParityFixture {
+	t.Helper()
 	runtimeConfig := models.RuntimeConfig{
 		Workers: []models.RuntimeWorker{
 			scopedCatalogWorker("compatibility-worker", "compatibility-model", "generate"),
@@ -531,31 +548,47 @@ func TestScopedCatalogPreservesCompatibilityBehavior(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenRuntimeScope: %v", err)
 	}
+	return compatibilityParityFixture{
+		compatibility:    compatibility,
+		root:             root,
+		opened:           opened,
+		currentReadiness: &currentReadiness,
+		host:             host,
+	}
+}
 
-	legacyList, err := compatibility.ListModels(context.Background())
+func assertCompatibilityListParity(t *testing.T, fixture compatibilityParityFixture) {
+	t.Helper()
+	legacyList, err := fixture.compatibility.ListModels(context.Background())
 	if err != nil {
 		t.Fatalf("compatibility ListModels: %v", err)
 	}
-	scopedList, err := root.ListCatalog(
+	scopedList, err := fixture.root.ListCatalog(
 		context.Background(),
-		models.ListModelsRequest{Scope: opened.Scope},
+		models.ListModelsRequest{Scope: fixture.opened.Scope},
 	)
+	if err != nil {
+		t.Fatalf("ListCatalog: %v", err)
+	}
 	var scopedCompatibility []models.Summary
 	for _, model := range scopedList.Models {
 		if model.Name == "compatibility-model" {
 			scopedCompatibility = append(scopedCompatibility, model)
 		}
 	}
-	if err != nil || !reflect.DeepEqual(legacyList.Results, scopedCompatibility) {
-		t.Fatalf("catalog list parity = (legacy %#v, scoped %#v, %v)", legacyList.Results, scopedCompatibility, err)
+	if !reflect.DeepEqual(legacyList.Results, scopedCompatibility) {
+		t.Fatalf("catalog list parity = (legacy %#v, scoped %#v)", legacyList.Results, scopedCompatibility)
 	}
+}
 
-	legacyDetail, err := compatibility.GetModel(context.Background(), "compatibility-model")
+func assertCompatibilityDetailParity(t *testing.T, fixture compatibilityParityFixture) {
+	t.Helper()
+	legacyDetail, err := fixture.compatibility.GetModel(context.Background(), "compatibility-model")
 	if err != nil {
 		t.Fatalf("compatibility GetModel: %v", err)
 	}
-	scopedDetail, err := root.GetCatalogModel(context.Background(), models.GetModelRequest{
-		Scope: opened.Scope, Name: "compatibility-model", Operation: "generate",
+	scopedDetail, err := fixture.root.GetCatalogModel(context.Background(), models.GetModelRequest{
+		Scope: fixture.opened.Scope, Name: "compatibility-model", Operation: "generate",
 	})
 	if err != nil {
 		t.Fatalf("GetCatalogModel: %v", err)
@@ -565,25 +598,33 @@ func TestScopedCatalogPreservesCompatibilityBehavior(t *testing.T) {
 	if !reflect.DeepEqual(legacyDetail, scopedCompatibilityFields) {
 		t.Fatalf("catalog get parity = (legacy %#v, scoped %#v)", legacyDetail, scopedCompatibilityFields)
 	}
+}
 
-	currentReadiness.ReadinessState = models.ReadinessStateReady
-	currentReadiness.LifecycleState = models.LifecycleStateInstalled
-	currentReadiness.Diagnostics["readinessState"] = string(models.ReadinessStateReady)
-	currentReadiness.Diagnostics["lifecycleState"] = string(models.LifecycleStateInstalled)
-	host.snapshot = readinessSnapshot(currentReadiness)
-	legacyReadiness, err := compatibility.InspectRuntime(context.Background(), "compatibility-model")
+func (fixture *compatibilityParityFixture) markReady() {
+	fixture.currentReadiness.ReadinessState = models.ReadinessStateReady
+	fixture.currentReadiness.LifecycleState = models.LifecycleStateInstalled
+	fixture.currentReadiness.Diagnostics["readinessState"] = string(models.ReadinessStateReady)
+	fixture.currentReadiness.Diagnostics["lifecycleState"] = string(models.LifecycleStateInstalled)
+	fixture.host.snapshot = readinessSnapshot(*fixture.currentReadiness)
+}
+
+func assertCompatibilityReadinessParity(t *testing.T, fixture compatibilityParityFixture) {
+	t.Helper()
+	legacyReadiness, err := fixture.compatibility.InspectRuntime(context.Background(), "compatibility-model")
 	if err != nil {
 		t.Fatalf("compatibility InspectRuntime: %v", err)
 	}
-	scopedReadiness, err := root.GetModelReadiness(context.Background(), models.GetModelReadinessRequest{
-		Scope: opened.Scope, Name: "compatibility-model", Operation: "generate",
+	scopedReadiness, err := fixture.root.GetModelReadiness(context.Background(), models.GetModelReadinessRequest{
+		Scope: fixture.opened.Scope, Name: "compatibility-model", Operation: "generate",
 	})
-	if err != nil || !reflect.DeepEqual(legacyReadiness, scopedReadiness.Readiness) {
+	if err != nil {
+		t.Fatalf("GetModelReadiness: %v", err)
+	}
+	if !reflect.DeepEqual(legacyReadiness, scopedReadiness.Readiness) {
 		t.Fatalf(
-			"readiness parity = (legacy %#v, scoped %#v, %v)",
+			"readiness parity = (legacy %#v, scoped %#v)",
 			legacyReadiness,
 			scopedReadiness.Readiness,
-			err,
 		)
 	}
 }
@@ -775,7 +816,17 @@ func scopedCatalogResource(name, model, provider string) models.RuntimeResource 
 
 func assertScopedCatalog(t *testing.T, result models.ListModelsResult) {
 	t.Helper()
-	var alpha, zeta *models.Summary
+	alpha, zeta := findScopedCatalogModels(result)
+	if alpha == nil || zeta == nil {
+		t.Fatalf("ListCatalog models = %#v, want Factory alpha/zeta identities", result.Models)
+	}
+	assertScopedCatalogIdentity(t, alpha, zeta)
+	assertScopedCatalogOperations(t, alpha)
+	assertScopedCatalogResource(t, alpha)
+	assertScopedCatalogRuntime(t, alpha)
+}
+
+func findScopedCatalogModels(result models.ListModelsResult) (alpha, zeta *models.Summary) {
 	for index := range result.Models {
 		switch localmodels.CanonicalModelName(result.Models[index].Name) {
 		case "ALPHA-MODEL":
@@ -784,12 +835,21 @@ func assertScopedCatalog(t *testing.T, result models.ListModelsResult) {
 			zeta = &result.Models[index]
 		}
 	}
-	if alpha == nil || zeta == nil {
-		t.Fatalf("ListCatalog models = %#v, want Factory alpha/zeta identities", result.Models)
-	}
+	return alpha, zeta
+}
+
+func assertScopedCatalogIdentity(t *testing.T, alpha, zeta *models.Summary) {
+	t.Helper()
 	if localmodels.CanonicalModelName(alpha.Name) != "ALPHA-MODEL" {
-		t.Fatalf("first model = %q, want canonical ALPHA-MODEL identity", alpha.Name)
+		t.Fatalf("alpha model = %q, want canonical ALPHA-MODEL identity", alpha.Name)
 	}
+	if localmodels.CanonicalModelName(zeta.Name) != "ZETA-MODEL" {
+		t.Fatalf("zeta model = %q, want ZETA-MODEL", zeta.Name)
+	}
+}
+
+func assertScopedCatalogOperations(t *testing.T, alpha *models.Summary) {
+	t.Helper()
 	if len(alpha.Operations) != 2 ||
 		alpha.Operations[0].Name != "embed" ||
 		alpha.Operations[1].Name != "generate" {
@@ -801,16 +861,21 @@ func assertScopedCatalog(t *testing.T, result models.ListModelsResult) {
 	) {
 		t.Fatalf("alpha content types = %#v, want deterministic AUDIO/TEXT order", got)
 	}
+}
+
+func assertScopedCatalogResource(t *testing.T, alpha *models.Summary) {
+	t.Helper()
 	if len(alpha.Resources) != 1 || alpha.Resources[0].Model == nil ||
 		*alpha.Resources[0].Model != "ALPHA-MODEL" {
 		t.Fatalf("alpha resources = %#v, want detached model resource", alpha.Resources)
 	}
+}
+
+func assertScopedCatalogRuntime(t *testing.T, alpha *models.Summary) {
+	t.Helper()
 	if alpha.Status != models.StatusReady ||
 		alpha.ManagedRuntime.Diagnostics["sourceKind"] != localmodels.ManagedRuntimeSourceKindManagedMirror {
 		t.Fatalf("alpha status/runtime = %#v, want ready managed-mirror projection", alpha)
-	}
-	if localmodels.CanonicalModelName(zeta.Name) != "ZETA-MODEL" {
-		t.Fatalf("zeta model = %q, want ZETA-MODEL", zeta.Name)
 	}
 }
 

--- a/pkg/services/models/internal/service/service_test.go
+++ b/pkg/services/models/internal/service/service_test.go
@@ -540,8 +540,14 @@ func TestScopedCatalogPreservesCompatibilityBehavior(t *testing.T) {
 		context.Background(),
 		models.ListModelsRequest{Scope: opened.Scope},
 	)
-	if err != nil || !reflect.DeepEqual(legacyList.Results, scopedList.Models) {
-		t.Fatalf("catalog list parity = (legacy %#v, scoped %#v, %v)", legacyList.Results, scopedList.Models, err)
+	var scopedCompatibility []models.Summary
+	for _, model := range scopedList.Models {
+		if model.Name == "compatibility-model" {
+			scopedCompatibility = append(scopedCompatibility, model)
+		}
+	}
+	if err != nil || !reflect.DeepEqual(legacyList.Results, scopedCompatibility) {
+		t.Fatalf("catalog list parity = (legacy %#v, scoped %#v, %v)", legacyList.Results, scopedCompatibility, err)
 	}
 
 	legacyDetail, err := compatibility.GetModel(context.Background(), "compatibility-model")
@@ -769,10 +775,18 @@ func scopedCatalogResource(name, model, provider string) models.RuntimeResource 
 
 func assertScopedCatalog(t *testing.T, result models.ListModelsResult) {
 	t.Helper()
-	if len(result.Models) != 2 {
-		t.Fatalf("ListCatalog models = %#v, want two canonical identities", result.Models)
+	var alpha, zeta *models.Summary
+	for index := range result.Models {
+		switch localmodels.CanonicalModelName(result.Models[index].Name) {
+		case "ALPHA-MODEL":
+			alpha = &result.Models[index]
+		case "ZETA-MODEL":
+			zeta = &result.Models[index]
+		}
 	}
-	alpha := result.Models[0]
+	if alpha == nil || zeta == nil {
+		t.Fatalf("ListCatalog models = %#v, want Factory alpha/zeta identities", result.Models)
+	}
 	if localmodels.CanonicalModelName(alpha.Name) != "ALPHA-MODEL" {
 		t.Fatalf("first model = %q, want canonical ALPHA-MODEL identity", alpha.Name)
 	}
@@ -795,18 +809,24 @@ func assertScopedCatalog(t *testing.T, result models.ListModelsResult) {
 		alpha.ManagedRuntime.Diagnostics["sourceKind"] != localmodels.ManagedRuntimeSourceKindManagedMirror {
 		t.Fatalf("alpha status/runtime = %#v, want ready managed-mirror projection", alpha)
 	}
-	if localmodels.CanonicalModelName(result.Models[1].Name) != "ZETA-MODEL" {
-		t.Fatalf("second model = %q, want ZETA-MODEL", result.Models[1].Name)
+	if localmodels.CanonicalModelName(zeta.Name) != "ZETA-MODEL" {
+		t.Fatalf("zeta model = %q, want ZETA-MODEL", zeta.Name)
 	}
 }
 
 func mutateScopedCatalogResult(result models.ListModelsResult) {
-	result.Models[0].Name = "mutated"
-	result.Models[0].Operations[0].Name = "mutated"
-	result.Models[0].Operations[0].Inputs[0].ContentTypes[0] = "mutated"
-	*result.Models[0].Resources[0].Model = "mutated"
-	result.Models[0].ManagedRuntime.SupportedOperations[0].Name = "mutated"
-	result.Models[0].ManagedRuntime.Diagnostics["sourceKind"] = "mutated"
+	for index := range result.Models {
+		if localmodels.CanonicalModelName(result.Models[index].Name) != "ALPHA-MODEL" {
+			continue
+		}
+		result.Models[index].Name = "mutated"
+		result.Models[index].Operations[0].Name = "mutated"
+		result.Models[index].Operations[0].Inputs[0].ContentTypes[0] = "mutated"
+		*result.Models[index].Resources[0].Model = "mutated"
+		result.Models[index].ManagedRuntime.SupportedOperations[0].Name = "mutated"
+		result.Models[index].ManagedRuntime.Diagnostics["sourceKind"] = "mutated"
+		return
+	}
 }
 
 func assertContractOnlyUnsupported(t *testing.T, operation string, err error) {

--- a/pkg/services/models/internal/services/catalog/internal/service/service.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	localmodels "github.com/portpowered/infinite-you/pkg/services/models/internal/local"
@@ -34,11 +35,10 @@ func (s *service) ListCatalog(
 		return models.ListModelsResult{}, err
 	}
 
-	entries := localmodels.BuildCatalogWithRuntime(
-		&scopeConfig.Runtime,
-		nil,
-		localmodels.DefaultManagedRuntimeSourceResolver(),
-	)
+	entries, err := effectiveCatalog(scopeConfig)
+	if err != nil {
+		return models.ListModelsResult{}, err
+	}
 	result := models.ListModelsResult{Models: make([]models.Summary, 0, len(entries))}
 	for _, entry := range entries {
 		if err := ctx.Err(); err != nil {
@@ -125,7 +125,7 @@ func (s *service) GetCatalogModel(
 	if err != nil {
 		return models.GetModelResult{}, err
 	}
-	detail, err := catalogDetail(&scopeConfig.Runtime, request.Name, request.Operation)
+	detail, err := catalogDetail(scopeConfig, request.Name, request.Operation)
 	if err != nil {
 		return models.GetModelResult{}, err
 	}
@@ -161,7 +161,7 @@ func (s *service) GetModelReadiness(
 	if err != nil {
 		return models.GetModelReadinessResult{}, err
 	}
-	detail, err := catalogDetail(&scopeConfig.Runtime, request.Name, request.Operation)
+	detail, err := catalogDetail(scopeConfig, request.Name, request.Operation)
 	if err != nil {
 		return models.GetModelReadinessResult{}, err
 	}
@@ -188,7 +188,7 @@ func (s *service) GetModelReadiness(
 }
 
 func catalogDetail(
-	runtimeConfig *models.RuntimeConfig,
+	scopeConfig models.RuntimeScopeConfig,
 	name string,
 	operation string,
 ) (models.Detail, error) {
@@ -196,11 +196,10 @@ func catalogDetail(
 	if err := request.Validate(); err != nil {
 		return models.Detail{}, err
 	}
-	entries := localmodels.BuildCatalogWithRuntime(
-		runtimeConfig,
-		nil,
-		localmodels.DefaultManagedRuntimeSourceResolver(),
-	)
+	entries, err := effectiveCatalog(scopeConfig)
+	if err != nil {
+		return models.Detail{}, err
+	}
 	entry, ok := entries[localmodels.CanonicalModelName(name)]
 	if !ok {
 		return models.Detail{}, fmt.Errorf("%w: %s", models.ErrNotFound, name)
@@ -245,7 +244,252 @@ func (s *service) resolveScopeConfig(
 	return models.RuntimeScopeConfig{
 		CacheDirectory: binding.CacheDirectory,
 		Runtime:        *runtimeConfig,
+		OperatorModels: binding.OperatorModels,
 	}.Clone(), nil
+}
+
+// effectiveCatalog keeps the Factory catalog as the highest-precedence
+// discovery source, then projects the existing operator overlay and built-in
+// definition policy for names that the Factory did not declare. The local
+// catalog builder intentionally remains Factory-only because it is also used
+// by lower-level asset and runtime helpers with different scope semantics.
+func effectiveCatalog(scopeConfig models.RuntimeScopeConfig) (map[string]catalog.Entry, error) {
+	entries := localmodels.BuildCatalogWithRuntime(
+		&scopeConfig.Runtime,
+		nil,
+		localmodels.DefaultManagedRuntimeSourceResolver(),
+	)
+
+	overlayNames := make([]string, 0, len(scopeConfig.OperatorModels))
+	for name := range scopeConfig.OperatorModels {
+		overlayNames = append(overlayNames, name)
+	}
+	sort.Strings(overlayNames)
+	seenOverlays := make(map[string]string, len(overlayNames))
+	for _, rawName := range overlayNames {
+		canonicalName := strings.ToLower(strings.TrimSpace(rawName))
+		if !safeCatalogModelName(canonicalName) {
+			return nil, catalogConfigurationFailure(
+				rawName,
+				"name",
+				"must contain only letters, digits, dots, hyphens, or underscores",
+			)
+		}
+		if previous, exists := seenOverlays[canonicalName]; exists {
+			return nil, catalogConfigurationFailure(
+				rawName,
+				"name",
+				fmt.Sprintf("duplicates another entry after case and whitespace normalization (%q)", previous),
+			)
+		}
+		seenOverlays[canonicalName] = rawName
+
+		overlay := scopeConfig.OperatorModels[rawName].Clone()
+		base, builtIn := (models.BuiltInCatalog{}).ModelDefinitionFor(canonicalName)
+		if !builtIn {
+			base = models.ModelDefinition{Name: canonicalName}
+		}
+		if err := validateCatalogOverlay(rawName, overlay, builtIn); err != nil {
+			return nil, err
+		}
+		applyCatalogOverlay(&base, overlay)
+		base.Name = canonicalName
+
+		// An authored Factory definition is already an effective catalog entry;
+		// do not add an operator or built-in duplicate over that key.
+		key := localmodels.CanonicalModelName(canonicalName)
+		if _, exists := entries[key]; exists {
+			continue
+		}
+		entries[key] = catalogEntryFromDefinition(base, catalogSourceKind(base.Source, false))
+	}
+
+	for _, definition := range (models.BuiltInCatalog{}).ModelDefinitions() {
+		key := localmodels.CanonicalModelName(definition.Name)
+		if _, exists := entries[key]; exists {
+			continue
+		}
+		entries[key] = catalogEntryFromDefinition(definition, catalogSourceKind(definition.Source, true))
+	}
+	return entries, nil
+}
+
+func validateCatalogOverlay(name string, overlay models.ModelOverlay, builtIn bool) error {
+	if overlay.Source != nil && strings.TrimSpace(*overlay.Source) == "" {
+		return catalogConfigurationFailure(name, "source", "must be omitted or non-empty")
+	}
+	if overlay.Backend != nil && strings.TrimSpace(*overlay.Backend) == "" {
+		return catalogConfigurationFailure(name, "backend", "must be omitted or non-empty")
+	}
+	if overlay.LoadPolicy != nil {
+		loadPolicy := strings.ToUpper(strings.TrimSpace(string(*overlay.LoadPolicy)))
+		if loadPolicy != string(models.LoadPolicyOnDemand) && loadPolicy != string(models.LoadPolicyKeepWarm) {
+			return catalogConfigurationFailure(name, "loadPolicy", "must be ON_DEMAND or KEEP_WARM")
+		}
+	}
+	if overlay.Operations != nil && len(overlay.Operations) == 0 {
+		return catalogConfigurationFailure(name, "operations", "must contain at least one operation")
+	}
+	for _, operation := range overlay.Operations {
+		if _, ok := (models.GenericOperationCatalog{}).GenericOperationContract(operation); !ok {
+			return catalogConfigurationFailure(name, "operations", fmt.Sprintf("unsupported operation %q", operation))
+		}
+	}
+	if !builtIn {
+		for _, field := range []struct {
+			name    string
+			present bool
+		}{
+			{name: "source", present: overlay.Source != nil},
+			{name: "backend", present: overlay.Backend != nil},
+			{name: "loadPolicy", present: overlay.LoadPolicy != nil},
+			{name: "operations", present: overlay.Operations != nil},
+		} {
+			if !field.present {
+				return catalogConfigurationFailure(name, field.name, "is required for a new model entry")
+			}
+		}
+	}
+	return nil
+}
+
+func applyCatalogOverlay(definition *models.ModelDefinition, overlay models.ModelOverlay) {
+	if overlay.Source != nil {
+		definition.Source = strings.TrimSpace(*overlay.Source)
+	}
+	if overlay.Backend != nil {
+		definition.Backend = strings.TrimSpace(*overlay.Backend)
+	}
+	if overlay.LoadPolicy != nil {
+		definition.LoadPolicy = models.LoadPolicy(strings.ToUpper(strings.TrimSpace(string(*overlay.LoadPolicy))))
+	}
+	if overlay.Operations != nil {
+		definition.Operations = make([]models.Operation, 0, len(overlay.Operations))
+		for _, name := range overlay.Operations {
+			operation, ok := (models.GenericOperationCatalog{}).GenericOperationContract(name)
+			if ok {
+				definition.Operations = append(definition.Operations, operation)
+			}
+		}
+	}
+}
+
+func catalogEntryFromDefinition(
+	definition models.ModelDefinition,
+	sourceKind string,
+) catalog.Entry {
+	definition = definition.Clone()
+	operations := make([]models.Operation, len(definition.Operations))
+	for index, operation := range definition.Operations {
+		operations[index] = operation.Clone()
+	}
+	diagnostics := map[string]string{
+		"catalogSource": "EFFECTIVE_DEFINITION",
+		"sourceKind":    sourceKind,
+		"sourceId":      definition.Source,
+	}
+	if revision := sourceRevision(definition.Source); revision != "" {
+		diagnostics["revision"] = revision
+	}
+	runtime := models.Runtime{
+		Identity:            definition.Name,
+		ReadinessState:      models.ReadinessStateMissing,
+		LifecycleState:      models.LifecycleStateNotInstalled,
+		Locality:            models.LocalityLocal,
+		SupportedOperations: operations,
+		Diagnostics:         cloneCatalogDiagnostics(diagnostics),
+	}
+	summary := models.Summary{
+		Name:             definition.Name,
+		ProviderLocality: models.LocalityLocal,
+		Status:           models.StatusReady,
+		LoadState:        models.LoadStateUnloaded,
+		Operations:       operations,
+		Modalities:       catalogModalities(operations),
+		ManagedRuntime:   runtime,
+	}
+	return catalog.Entry{
+		Summary: summary,
+		Detail: models.Detail{
+			Summary:     summary.Clone(),
+			Sources:     sourceMetadata(diagnostics),
+			Diagnostics: diagnostics,
+		},
+	}
+}
+
+func catalogModalities(operations []models.Operation) []string {
+	seen := make(map[string]struct{})
+	for _, operation := range operations {
+		for _, slots := range [][]models.OperationSlot{operation.Inputs, operation.Outputs} {
+			for _, slot := range slots {
+				modality := strings.TrimSpace(string(slot.Modality))
+				if modality == "" {
+					for _, contentType := range slot.ContentTypes {
+						modality = strings.TrimSpace(contentType)
+						if modality != "" {
+							break
+						}
+					}
+				}
+				if modality != "" {
+					seen[modality] = struct{}{}
+				}
+			}
+		}
+	}
+	modalities := make([]string, 0, len(seen))
+	for modality := range seen {
+		modalities = append(modalities, modality)
+	}
+	sort.Strings(modalities)
+	return modalities
+}
+
+func catalogSourceKind(source string, builtIn bool) string {
+	if builtIn || strings.HasPrefix(strings.ToLower(strings.TrimSpace(source)), "hf://") {
+		return string(models.ModelReferenceSourceHuggingFace)
+	}
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(source)), "file://") {
+		return string(models.ModelReferenceSourceFileURI)
+	}
+	return string(models.ModelReferenceSourceLocalPath)
+}
+
+func sourceRevision(source string) string {
+	if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(source)), "hf://") {
+		return ""
+	}
+	separator := strings.LastIndex(source, "@")
+	if separator < 0 || separator == len(source)-1 {
+		return ""
+	}
+	return strings.TrimSpace(source[separator+1:])
+}
+
+func cloneCatalogDiagnostics(values map[string]string) map[string]string {
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func catalogConfigurationFailure(name, field, message string) error {
+	return models.ModelConfigurationFailure{ModelName: name, Field: field, Message: message}
+}
+
+func safeCatalogModelName(value string) bool {
+	for index, character := range value {
+		if (character >= 'a' && character <= 'z') ||
+			(character >= 'A' && character <= 'Z') ||
+			(character >= '0' && character <= '9') ||
+			(index > 0 && (character == '.' || character == '_' || character == '-')) {
+			continue
+		}
+		return false
+	}
+	return value != ""
 }
 
 func catalogScopeError(err error) error {

--- a/pkg/services/models/internal/services/catalog/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/service_test.go
@@ -117,6 +117,21 @@ func TestCatalogDiscoversBuiltInsWithoutFactoryDeclarations(t *testing.T) {
 func TestCatalogPreservesFactoryAndOperatorPrecedenceOverBuiltIns(t *testing.T) {
 	t.Parallel()
 
+	fixture := newCatalogPrecedenceFixture(t)
+	assertCatalogPrecedenceList(t, fixture)
+	assertFactoryCatalogPrecedence(t, fixture)
+	assertOperatorCatalogPrecedence(t, fixture)
+	assertCustomCatalogPrecedence(t, fixture)
+}
+
+type catalogPrecedenceFixture struct {
+	service        catalog.Service
+	scope          models.RuntimeScopeRef
+	operatorSource string
+}
+
+func newCatalogPrecedenceFixture(t *testing.T) catalogPrecedenceFixture {
+	t.Helper()
 	operatorSource := "hf://operator/tts/model@0123456789012345678901234567890123456789"
 	operatorBackend := "localai-test"
 	operatorLoadPolicy := models.LoadPolicyKeepWarm
@@ -150,9 +165,16 @@ func TestCatalogPreservesFactoryAndOperatorPrecedenceOverBuiltIns(t *testing.T) 
 		t.Fatalf("open scope: %v", err)
 	}
 	scope := publicScope(t, privateRef)
-	service := newCatalogService(t, scopes)
+	return catalogPrecedenceFixture{
+		service:        newCatalogService(t, scopes),
+		scope:          scope,
+		operatorSource: operatorSource,
+	}
+}
 
-	listed, err := service.ListCatalog(context.Background(), models.ListModelsRequest{Scope: scope})
+func assertCatalogPrecedenceList(t *testing.T, fixture catalogPrecedenceFixture) {
+	t.Helper()
+	listed, err := fixture.service.ListCatalog(context.Background(), models.ListModelsRequest{Scope: fixture.scope})
 	if err != nil {
 		t.Fatalf("ListCatalog: %v", err)
 	}
@@ -163,44 +185,57 @@ func TestCatalogPreservesFactoryAndOperatorPrecedenceOverBuiltIns(t *testing.T) 
 	if countByName[models.BuiltInModelNameASR] != 1 {
 		t.Fatalf("asr count = %d, want one effective Factory entry", countByName[models.BuiltInModelNameASR])
 	}
+}
 
-	factory, err := service.GetCatalogModel(context.Background(), models.GetModelRequest{
-		Scope: scope, Name: models.BuiltInModelNameASR, Operation: "factory-operation",
+func assertFactoryCatalogPrecedence(t *testing.T, fixture catalogPrecedenceFixture) {
+	t.Helper()
+	factory := getCatalogPrecedenceModel(t, fixture, models.GetModelRequest{
+		Scope: fixture.scope, Name: models.BuiltInModelNameASR, Operation: "factory-operation",
 	})
-	if err != nil {
-		t.Fatalf("GetCatalogModel(factory asr): %v", err)
-	}
 	if len(factory.Model.Operations) != 1 || factory.Model.Operations[0].Name != "factory-operation" {
 		t.Fatalf("factory asr operations = %#v, want Factory operation", factory.Model.Operations)
 	}
-	if _, err := service.GetCatalogModel(context.Background(), models.GetModelRequest{
-		Scope: scope, Name: models.BuiltInModelNameASR, Operation: models.OperationTTS,
+	if _, err := fixture.service.GetCatalogModel(context.Background(), models.GetModelRequest{
+		Scope: fixture.scope, Name: models.BuiltInModelNameASR, Operation: models.OperationTTS,
 	}); !errors.Is(err, models.ErrUnsupportedOperation) {
 		t.Fatalf("Factory precedence operation error = %v, want ErrUnsupportedOperation", err)
 	}
+}
 
-	operator, err := service.GetCatalogModel(context.Background(), models.GetModelRequest{
-		Scope: scope, Name: models.BuiltInModelNameTTS, Operation: models.OperationOMNI,
+func assertOperatorCatalogPrecedence(t *testing.T, fixture catalogPrecedenceFixture) {
+	t.Helper()
+	operator := getCatalogPrecedenceModel(t, fixture, models.GetModelRequest{
+		Scope: fixture.scope, Name: models.BuiltInModelNameTTS, Operation: models.OperationOMNI,
 	})
-	if err != nil {
-		t.Fatalf("GetCatalogModel(operator tts): %v", err)
-	}
 	if len(operator.Model.Operations) != 1 || operator.Model.Operations[0].Name != models.OperationOMNI {
 		t.Fatalf("operator tts operations = %#v, want overlaid OMNI", operator.Model.Operations)
 	}
-	if len(operator.Model.Sources) != 1 || operator.Model.Sources[0].Reference != operatorSource {
+	if len(operator.Model.Sources) != 1 || operator.Model.Sources[0].Reference != fixture.operatorSource {
 		t.Fatalf("operator tts sources = %#v, want overlay source", operator.Model.Sources)
 	}
+}
 
-	custom, err := service.GetCatalogModel(context.Background(), models.GetModelRequest{
-		Scope: scope, Name: "CUSTOM", Operation: models.OperationASR,
+func assertCustomCatalogPrecedence(t *testing.T, fixture catalogPrecedenceFixture) {
+	t.Helper()
+	custom := getCatalogPrecedenceModel(t, fixture, models.GetModelRequest{
+		Scope: fixture.scope, Name: "CUSTOM", Operation: models.OperationASR,
 	})
-	if err != nil {
-		t.Fatalf("GetCatalogModel(operator custom): %v", err)
-	}
 	if custom.Model.Name != "custom" || len(custom.Model.Operations) != 1 || custom.Model.Operations[0].Name != models.OperationASR {
 		t.Fatalf("custom detail = %#v, want operator definition", custom.Model)
 	}
+}
+
+func getCatalogPrecedenceModel(
+	t *testing.T,
+	fixture catalogPrecedenceFixture,
+	request models.GetModelRequest,
+) models.GetModelResult {
+	t.Helper()
+	result, err := fixture.service.GetCatalogModel(context.Background(), request)
+	if err != nil {
+		t.Fatalf("GetCatalogModel(%s): %v", request.Name, err)
+	}
+	return result
 }
 
 func TestListCatalogRejectsUnavailableScopedConfiguration(t *testing.T) {

--- a/pkg/services/models/internal/services/catalog/internal/service/service_test.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/service_test.go
@@ -54,6 +54,155 @@ func TestListCatalogClassifiesScopeBeforeProjection(t *testing.T) {
 	}
 }
 
+func TestCatalogDiscoversBuiltInsWithoutFactoryDeclarations(t *testing.T) {
+	t.Parallel()
+
+	scopes := newRuntimeScopes(t, "catalog-built-in-discovery")
+	privateRef, err := scopes.Open(models.RuntimeBinding{
+		RuntimeConfig: func() *models.RuntimeConfig {
+			return &models.RuntimeConfig{}
+		},
+	})
+	if err != nil {
+		t.Fatalf("open scope: %v", err)
+	}
+	scope := publicScope(t, privateRef)
+	service := newCatalogService(t, scopes)
+
+	listed, err := service.ListCatalog(context.Background(), models.ListModelsRequest{Scope: scope})
+	if err != nil {
+		t.Fatalf("ListCatalog: %v", err)
+	}
+	counts := make(map[string]int, len(listed.Models))
+	for _, model := range listed.Models {
+		counts[model.Name]++
+	}
+	for _, name := range []string{
+		models.BuiltInModelNameASR,
+		models.BuiltInModelNameEmbed,
+		models.BuiltInModelNameLLM,
+		models.BuiltInModelNameTTS,
+	} {
+		if counts[name] != 1 {
+			t.Fatalf("listed %q count = %d, want one; models = %#v", name, counts[name], listed.Models)
+		}
+	}
+
+	inspected, err := service.GetCatalogModel(context.Background(), models.GetModelRequest{
+		Scope: scope, Name: " ASR ", Operation: models.OperationASR,
+	})
+	if err != nil {
+		t.Fatalf("GetCatalogModel(asr): %v", err)
+	}
+	if inspected.Model.Name != models.BuiltInModelNameASR ||
+		len(inspected.Model.Operations) != 1 ||
+		inspected.Model.Operations[0].Name != models.OperationASR {
+		t.Fatalf("asr detail = %#v, want effective ASR definition", inspected.Model)
+	}
+	if inspected.Model.ManagedRuntime.ReadinessState != models.ReadinessStateMissing ||
+		inspected.Model.ManagedRuntime.LifecycleState != models.LifecycleStateNotInstalled {
+		t.Fatalf("asr runtime = %#v, want missing/not-installed baseline", inspected.Model.ManagedRuntime)
+	}
+	if len(inspected.Model.Sources) != 1 || inspected.Model.Sources[0].Provider != string(models.ModelReferenceSourceHuggingFace) {
+		t.Fatalf("asr sources = %#v, want built-in source metadata", inspected.Model.Sources)
+	}
+
+	if _, err := service.GetCatalogModel(context.Background(), models.GetModelRequest{
+		Scope: scope, Name: "unregistered-model",
+	}); !errors.Is(err, models.ErrNotFound) {
+		t.Fatalf("unknown model error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestCatalogPreservesFactoryAndOperatorPrecedenceOverBuiltIns(t *testing.T) {
+	t.Parallel()
+
+	operatorSource := "hf://operator/tts/model@0123456789012345678901234567890123456789"
+	operatorBackend := "localai-test"
+	operatorLoadPolicy := models.LoadPolicyKeepWarm
+	customSource := "hf://operator/custom/model@0123456789012345678901234567890123456789"
+	customBackend := "localai-custom"
+	customLoadPolicy := models.LoadPolicyOnDemand
+	scopes := newRuntimeScopes(t, "catalog-precedence")
+	privateRef, err := scopes.Open(models.RuntimeBinding{
+		RuntimeConfig: func() *models.RuntimeConfig {
+			return &models.RuntimeConfig{
+				Workers: []models.RuntimeWorker{
+					catalogWorker("factory-asr", models.BuiltInModelNameASR, "factory-operation"),
+				},
+			}
+		},
+		OperatorModels: map[string]models.ModelOverlay{
+			models.BuiltInModelNameASR: {
+				Operations: []string{models.OperationTTS},
+			},
+			" TTS ": {
+				Source: &operatorSource, Backend: &operatorBackend,
+				LoadPolicy: &operatorLoadPolicy, Operations: []string{models.OperationOMNI},
+			},
+			"custom": {
+				Source: &customSource, Backend: &customBackend,
+				LoadPolicy: &customLoadPolicy, Operations: []string{models.OperationASR},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("open scope: %v", err)
+	}
+	scope := publicScope(t, privateRef)
+	service := newCatalogService(t, scopes)
+
+	listed, err := service.ListCatalog(context.Background(), models.ListModelsRequest{Scope: scope})
+	if err != nil {
+		t.Fatalf("ListCatalog: %v", err)
+	}
+	countByName := make(map[string]int, len(listed.Models))
+	for _, model := range listed.Models {
+		countByName[model.Name]++
+	}
+	if countByName[models.BuiltInModelNameASR] != 1 {
+		t.Fatalf("asr count = %d, want one effective Factory entry", countByName[models.BuiltInModelNameASR])
+	}
+
+	factory, err := service.GetCatalogModel(context.Background(), models.GetModelRequest{
+		Scope: scope, Name: models.BuiltInModelNameASR, Operation: "factory-operation",
+	})
+	if err != nil {
+		t.Fatalf("GetCatalogModel(factory asr): %v", err)
+	}
+	if len(factory.Model.Operations) != 1 || factory.Model.Operations[0].Name != "factory-operation" {
+		t.Fatalf("factory asr operations = %#v, want Factory operation", factory.Model.Operations)
+	}
+	if _, err := service.GetCatalogModel(context.Background(), models.GetModelRequest{
+		Scope: scope, Name: models.BuiltInModelNameASR, Operation: models.OperationTTS,
+	}); !errors.Is(err, models.ErrUnsupportedOperation) {
+		t.Fatalf("Factory precedence operation error = %v, want ErrUnsupportedOperation", err)
+	}
+
+	operator, err := service.GetCatalogModel(context.Background(), models.GetModelRequest{
+		Scope: scope, Name: models.BuiltInModelNameTTS, Operation: models.OperationOMNI,
+	})
+	if err != nil {
+		t.Fatalf("GetCatalogModel(operator tts): %v", err)
+	}
+	if len(operator.Model.Operations) != 1 || operator.Model.Operations[0].Name != models.OperationOMNI {
+		t.Fatalf("operator tts operations = %#v, want overlaid OMNI", operator.Model.Operations)
+	}
+	if len(operator.Model.Sources) != 1 || operator.Model.Sources[0].Reference != operatorSource {
+		t.Fatalf("operator tts sources = %#v, want overlay source", operator.Model.Sources)
+	}
+
+	custom, err := service.GetCatalogModel(context.Background(), models.GetModelRequest{
+		Scope: scope, Name: "CUSTOM", Operation: models.OperationASR,
+	})
+	if err != nil {
+		t.Fatalf("GetCatalogModel(operator custom): %v", err)
+	}
+	if custom.Model.Name != "custom" || len(custom.Model.Operations) != 1 || custom.Model.Operations[0].Name != models.OperationASR {
+		t.Fatalf("custom detail = %#v, want operator definition", custom.Model)
+	}
+}
+
 func TestListCatalogRejectsUnavailableScopedConfiguration(t *testing.T) {
 	t.Parallel()
 
@@ -186,10 +335,17 @@ func listCatalogCacheFacts(
 	if err != nil {
 		t.Fatalf("ListCatalog: %v", err)
 	}
-	if len(result.Models) != 1 {
-		t.Fatalf("models = %#v, want one model", result.Models)
+	var model *models.Summary
+	for index := range result.Models {
+		if result.Models[index].Name == "cache-model" {
+			model = &result.Models[index]
+			break
+		}
 	}
-	runtime := result.Models[0].ManagedRuntime
+	if model == nil {
+		t.Fatalf("models = %#v, want cache-model", result.Models)
+	}
+	runtime := model.ManagedRuntime
 	if runtime.ReadinessState != models.ReadinessStateFailed ||
 		runtime.LifecycleState != models.LifecycleStateInstalling {
 		t.Fatalf("catalog states = (%s, %s), want FAILED/INSTALLING", runtime.ReadinessState, runtime.LifecycleState)

--- a/pkg/services/models/transports/cli/composition_coverage_test.go
+++ b/pkg/services/models/transports/cli/composition_coverage_test.go
@@ -19,6 +19,79 @@ import (
 
 const compositionCoverageUnreachableServer = "http://127.0.0.1:1"
 
+func TestRootAdapter_BuiltInCatalogModelSurfacesThroughCLI(t *testing.T) {
+	t.Parallel()
+
+	service := parityRootService(t, stubModelsRoot{
+		listModels: func(context.Context) (modelinference.List, error) {
+			return modelinference.List{Results: []modelinference.Summary{{
+				Name:       modelinference.BuiltInModelNameASR,
+				Operations: []modelinference.Operation{{Name: modelinference.OperationASR}},
+			}}}, nil
+		},
+		getCatalogModel: func(_ context.Context, request modelinference.GetModelRequest) (modelinference.GetModelResult, error) {
+			return modelinference.GetModelResult{Model: modelinference.Detail{Summary: modelinference.Summary{
+				Name: request.Name, Operations: []modelinference.Operation{{Name: modelinference.OperationASR}},
+			}}}, nil
+		},
+	})
+
+	var listOutput bytes.Buffer
+	if err := service.List(modelscli.ListConfig{Context: context.Background(), Output: &listOutput}); err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if !strings.Contains(listOutput.String(), modelinference.BuiltInModelNameASR) {
+		t.Fatalf("List() output = %q, want built-in asr", listOutput.String())
+	}
+
+	var inspectOutput bytes.Buffer
+	if err := service.Inspect(modelscli.InspectConfig{
+		Context: context.Background(), ModelName: modelinference.BuiltInModelNameASR, Output: &inspectOutput,
+	}); err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	if !strings.Contains(inspectOutput.String(), "Name:\tasr") || !strings.Contains(inspectOutput.String(), "ASR") {
+		t.Fatalf("Inspect() output = %q, want built-in asr detail", inspectOutput.String())
+	}
+}
+
+func TestRootAdapter_BuiltInPullSurfacesThroughCLI(t *testing.T) {
+	t.Parallel()
+
+	root := stubModelsRoot{
+		pullModel: func(_ context.Context, name string) (modelinference.PullResult, error) {
+			return modelinference.PullResult{
+				ModelName:          name,
+				ProviderLocality:   string(modelinference.LocalityLocal),
+				Outcome:            "PULLED",
+				ManagedPullOutcome: "INSTALLED_SUCCESSFULLY",
+				ReadinessState:     "READY",
+				LifecycleState:     "INSTALLED",
+			}, nil
+		},
+	}
+	service := parityRootService(t, root)
+
+	for _, name := range []string{
+		modelinference.BuiltInModelNameASR,
+		modelinference.BuiltInModelNameTTS,
+	} {
+		var output bytes.Buffer
+		if err := service.Pull(modelscli.PullConfig{
+			Context: context.Background(), ModelName: name, JSON: true, Output: &output,
+		}); err != nil {
+			t.Fatalf("Pull(%q): %v", name, err)
+		}
+		var response factoryapi.ModelPullResponse
+		if err := json.Unmarshal(output.Bytes(), &response); err != nil {
+			t.Fatalf("Pull(%q) JSON: %v\n%s", name, err, output.String())
+		}
+		if response.ModelName != name || response.ManagedRuntimePull.PullOutcome != factoryapi.ManagedRuntimePullOutcomeINSTALLEDSUCCESSFULLY {
+			t.Fatalf("Pull(%q) response = %#v, want successful built-in pull", name, response)
+		}
+	}
+}
+
 func TestNewCompositionFacadeDelegatesListAndPullThroughOwnedRoot(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/models/transports/cli/root_invoke.go
+++ b/pkg/services/models/transports/cli/root_invoke.go
@@ -610,13 +610,21 @@ func joinedCLIInvocationRequest(
 	inputName := "input"
 	modality := modelinference.ModalityText
 	contentType := "text/plain"
-	if selected, ok := catalogOperationForName(catalog, operation); ok && len(selected.Inputs) > 0 {
-		inputName = selected.Inputs[0].Name
-		if selected.Inputs[0].Modality != "" {
-			modality = selected.Inputs[0].Modality
+	if selected, ok := catalogOperationForName(catalog, operation); ok {
+		// Catalog projections sort slots by name; bind --text to the required
+		// text slot instead of assuming the first slot is the CLI input.
+		input := joinedCLITextInput(selected.Inputs)
+		if input == nil && len(selected.Inputs) > 0 {
+			input = &selected.Inputs[0]
 		}
-		if len(selected.Inputs[0].MediaTypes) > 0 {
-			contentType = selected.Inputs[0].MediaTypes[0]
+		if input != nil {
+			inputName = input.Name
+			if input.Modality != "" {
+				modality = input.Modality
+			}
+			if len(input.MediaTypes) > 0 {
+				contentType = input.MediaTypes[0]
+			}
 		}
 	}
 	return modelinference.InvokeModelRequest{
@@ -626,6 +634,23 @@ func joinedCLIInvocationRequest(
 			Name: inputName, Modality: modality, ContentType: contentType, Content: text,
 		}},
 	}
+}
+
+func joinedCLITextInput(inputs []modelinference.OperationSlot) *modelinference.OperationSlot {
+	var optionalText *modelinference.OperationSlot
+	for index := range inputs {
+		input := &inputs[index]
+		if input.Modality != modelinference.ModalityText {
+			continue
+		}
+		if input.Required != nil && *input.Required {
+			return input
+		}
+		if optionalText == nil {
+			optionalText = input
+		}
+	}
+	return optionalText
 }
 
 func modelInvocationResponseFromInferenceResult(

--- a/pkg/services/models/transports/cli/root_parity_test.go
+++ b/pkg/services/models/transports/cli/root_parity_test.go
@@ -327,6 +327,43 @@ func TestRootAdapter_PullSuccessPreservesHumanAndJSONOutput(t *testing.T) {
 	}
 }
 
+func TestRootAdapter_BuiltInPullSurfacesThroughCLI(t *testing.T) {
+	t.Parallel()
+
+	root := stubModelsRoot{
+		pullModel: func(_ context.Context, name string) (modelinference.PullResult, error) {
+			return modelinference.PullResult{
+				ModelName:          name,
+				ProviderLocality:   string(modelinference.LocalityLocal),
+				Outcome:            "PULLED",
+				ManagedPullOutcome: "INSTALLED_SUCCESSFULLY",
+				ReadinessState:     "READY",
+				LifecycleState:     "INSTALLED",
+			}, nil
+		},
+	}
+	service := parityRootService(t, root)
+
+	for _, name := range []string{
+		modelinference.BuiltInModelNameASR,
+		modelinference.BuiltInModelNameTTS,
+	} {
+		var output bytes.Buffer
+		if err := service.Pull(modelscli.PullConfig{
+			Context: context.Background(), ModelName: name, JSON: true, Output: &output,
+		}); err != nil {
+			t.Fatalf("Pull(%q): %v", name, err)
+		}
+		var response factoryapi.ModelPullResponse
+		if err := json.Unmarshal(output.Bytes(), &response); err != nil {
+			t.Fatalf("Pull(%q) JSON: %v\n%s", name, err, output.String())
+		}
+		if response.ModelName != name || response.ManagedRuntimePull.PullOutcome != factoryapi.ManagedRuntimePullOutcomeINSTALLEDSUCCESSFULLY {
+			t.Fatalf("Pull(%q) response = %#v, want successful built-in pull", name, response)
+		}
+	}
+}
+
 func TestRootAdapter_PullClosesCatalogScopeAfterSuccess(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/models/transports/cli/root_parity_test.go
+++ b/pkg/services/models/transports/cli/root_parity_test.go
@@ -214,6 +214,42 @@ func TestRootAdapter_ListJSONPreservesAcceptedOutput(t *testing.T) {
 	}
 }
 
+func TestRootAdapter_BuiltInCatalogModelSurfacesThroughCLI(t *testing.T) {
+	t.Parallel()
+
+	service := parityRootService(t, stubModelsRoot{
+		listModels: func(context.Context) (modelinference.List, error) {
+			return modelinference.List{Results: []modelinference.Summary{{
+				Name:       modelinference.BuiltInModelNameASR,
+				Operations: []modelinference.Operation{{Name: modelinference.OperationASR}},
+			}}}, nil
+		},
+		getCatalogModel: func(_ context.Context, request modelinference.GetModelRequest) (modelinference.GetModelResult, error) {
+			return modelinference.GetModelResult{Model: modelinference.Detail{Summary: modelinference.Summary{
+				Name: request.Name, Operations: []modelinference.Operation{{Name: modelinference.OperationASR}},
+			}}}, nil
+		},
+	})
+
+	var listOutput bytes.Buffer
+	if err := service.List(modelscli.ListConfig{Context: context.Background(), Output: &listOutput}); err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if !strings.Contains(listOutput.String(), modelinference.BuiltInModelNameASR) {
+		t.Fatalf("List() output = %q, want built-in asr", listOutput.String())
+	}
+
+	var inspectOutput bytes.Buffer
+	if err := service.Inspect(modelscli.InspectConfig{
+		Context: context.Background(), ModelName: modelinference.BuiltInModelNameASR, Output: &inspectOutput,
+	}); err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	if !strings.Contains(inspectOutput.String(), "Name:\tasr") || !strings.Contains(inspectOutput.String(), "ASR") {
+		t.Fatalf("Inspect() output = %q, want built-in asr detail", inspectOutput.String())
+	}
+}
+
 func TestRootAdapter_InspectSuccessPreservesHumanOutput(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/models/transports/cli/root_parity_test.go
+++ b/pkg/services/models/transports/cli/root_parity_test.go
@@ -214,42 +214,6 @@ func TestRootAdapter_ListJSONPreservesAcceptedOutput(t *testing.T) {
 	}
 }
 
-func TestRootAdapter_BuiltInCatalogModelSurfacesThroughCLI(t *testing.T) {
-	t.Parallel()
-
-	service := parityRootService(t, stubModelsRoot{
-		listModels: func(context.Context) (modelinference.List, error) {
-			return modelinference.List{Results: []modelinference.Summary{{
-				Name:       modelinference.BuiltInModelNameASR,
-				Operations: []modelinference.Operation{{Name: modelinference.OperationASR}},
-			}}}, nil
-		},
-		getCatalogModel: func(_ context.Context, request modelinference.GetModelRequest) (modelinference.GetModelResult, error) {
-			return modelinference.GetModelResult{Model: modelinference.Detail{Summary: modelinference.Summary{
-				Name: request.Name, Operations: []modelinference.Operation{{Name: modelinference.OperationASR}},
-			}}}, nil
-		},
-	})
-
-	var listOutput bytes.Buffer
-	if err := service.List(modelscli.ListConfig{Context: context.Background(), Output: &listOutput}); err != nil {
-		t.Fatalf("List() error = %v", err)
-	}
-	if !strings.Contains(listOutput.String(), modelinference.BuiltInModelNameASR) {
-		t.Fatalf("List() output = %q, want built-in asr", listOutput.String())
-	}
-
-	var inspectOutput bytes.Buffer
-	if err := service.Inspect(modelscli.InspectConfig{
-		Context: context.Background(), ModelName: modelinference.BuiltInModelNameASR, Output: &inspectOutput,
-	}); err != nil {
-		t.Fatalf("Inspect() error = %v", err)
-	}
-	if !strings.Contains(inspectOutput.String(), "Name:\tasr") || !strings.Contains(inspectOutput.String(), "ASR") {
-		t.Fatalf("Inspect() output = %q, want built-in asr detail", inspectOutput.String())
-	}
-}
-
 func TestRootAdapter_InspectSuccessPreservesHumanOutput(t *testing.T) {
 	t.Parallel()
 
@@ -324,43 +288,6 @@ func TestRootAdapter_PullSuccessPreservesHumanAndJSONOutput(t *testing.T) {
 	}
 	if response.ModelName != "OMNIVOICE_Q4_K_M" {
 		t.Fatalf("Pull() JSON model = %q, want OMNIVOICE_Q4_K_M", response.ModelName)
-	}
-}
-
-func TestRootAdapter_BuiltInPullSurfacesThroughCLI(t *testing.T) {
-	t.Parallel()
-
-	root := stubModelsRoot{
-		pullModel: func(_ context.Context, name string) (modelinference.PullResult, error) {
-			return modelinference.PullResult{
-				ModelName:          name,
-				ProviderLocality:   string(modelinference.LocalityLocal),
-				Outcome:            "PULLED",
-				ManagedPullOutcome: "INSTALLED_SUCCESSFULLY",
-				ReadinessState:     "READY",
-				LifecycleState:     "INSTALLED",
-			}, nil
-		},
-	}
-	service := parityRootService(t, root)
-
-	for _, name := range []string{
-		modelinference.BuiltInModelNameASR,
-		modelinference.BuiltInModelNameTTS,
-	} {
-		var output bytes.Buffer
-		if err := service.Pull(modelscli.PullConfig{
-			Context: context.Background(), ModelName: name, JSON: true, Output: &output,
-		}); err != nil {
-			t.Fatalf("Pull(%q): %v", name, err)
-		}
-		var response factoryapi.ModelPullResponse
-		if err := json.Unmarshal(output.Bytes(), &response); err != nil {
-			t.Fatalf("Pull(%q) JSON: %v\n%s", name, err, output.String())
-		}
-		if response.ModelName != name || response.ManagedRuntimePull.PullOutcome != factoryapi.ManagedRuntimePullOutcomeINSTALLEDSUCCESSFULLY {
-			t.Fatalf("Pull(%q) response = %#v, want successful built-in pull", name, response)
-		}
 	}
 }
 

--- a/pkg/services/models/transports/cli/service_test.go
+++ b/pkg/services/models/transports/cli/service_test.go
@@ -169,6 +169,58 @@ func (stub stubModelsRoot) InvokeLocal(context.Context, modelinference.LocalInvo
 	return modelinference.LocalInvocationResult{}, modelinference.ErrUnsupportedOperation
 }
 
+func TestRootAdapter_InvokeGenericUsesRequiredTextInputWhenOptionalSlotsSortFirst(t *testing.T) {
+	t.Parallel()
+
+	scope := testRuntimeScope(t)
+	optional := false
+	required := true
+	service := modelscli.NewService(modelscli.Config{
+		Models: stubModelsRoot{
+			getCatalogModel: func(_ context.Context, request modelinference.GetModelRequest) (modelinference.GetModelResult, error) {
+				return modelinference.GetModelResult{Model: modelinference.Detail{
+					Summary: modelinference.Summary{
+						Name: request.Name,
+						Operations: []modelinference.Operation{{
+							Name: modelinference.OperationTTS,
+							Inputs: []modelinference.OperationSlot{
+								{Name: "parameters", Modality: modelinference.ModalityJSON, Required: &optional, MediaTypes: []string{"application/json"}},
+								{Name: "text", Modality: modelinference.ModalityText, Required: &required, MediaTypes: []string{"text/plain"}},
+							},
+							Outputs: []modelinference.OperationSlot{{Name: "audio", Modality: modelinference.ModalityAudio}},
+						}},
+					},
+				},
+				}, nil
+			},
+			invokeModel: func(_ context.Context, request modelinference.InvokeModelRequest) (modelinference.InvokeModelResult, error) {
+				if len(request.Inputs) != 1 || request.Inputs[0].Name != "text" || request.Inputs[0].Modality != modelinference.ModalityText {
+					t.Fatalf("joined generic request inputs = %#v, want required text input", request.Inputs)
+				}
+				return modelinference.InvokeModelResult{
+					ModelName: request.Model.NameOrURI,
+					Operation: request.Operation,
+					Content:   []modelinference.InferenceContent{{ContentType: "audio/wav", Content: "synthesized"}},
+				}, nil
+			},
+		},
+		OpenInvokeScope: func(context.Context, modelscli.InvokeConfig) (modelscli.InvokeRuntimeScope, error) {
+			return modelscli.InvokeRuntimeScope{Scope: scope}, nil
+		},
+	})
+
+	var output bytes.Buffer
+	if err := service.Invoke(modelscli.InvokeConfig{
+		Context: context.Background(), ModelName: modelinference.BuiltInModelNameTTS,
+		Operation: modelinference.OperationTTS, Text: "hello", JSON: true, Output: &output,
+	}); err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+	if !strings.Contains(output.String(), "synthesized") {
+		t.Fatalf("Invoke() output = %q, want synthesized content", output.String())
+	}
+}
+
 func TestNewServiceRequiresModelsRoot(t *testing.T) {
 	t.Parallel()
 	if service := modelscli.NewService(modelscli.Config{}); service != nil {

--- a/pkg/services/models/transports/http/catalog_operations_test.go
+++ b/pkg/services/models/transports/http/catalog_operations_test.go
@@ -49,6 +49,40 @@ func TestAdapter_ListModelsInvokesFakeRootAndEncodesSuccess(t *testing.T) {
 	}
 }
 
+func TestAdapter_BuiltInCatalogModelSurfacesThroughHTTP(t *testing.T) {
+	t.Parallel()
+
+	scope, err := (models.RuntimeScopeRef{}).Parse("factory-session:http-built-in")
+	if err != nil {
+		t.Fatalf("parse Models scope: %v", err)
+	}
+	root := &rootFake{
+		listCatalog: func(context.Context, models.ListModelsRequest) (models.ListModelsResult, error) {
+			return models.ListModelsResult{Models: []models.Summary{{
+				Name: models.BuiltInModelNameASR, Operations: []models.Operation{{Name: models.OperationASR}},
+			}}}, nil
+		},
+		getCatalog: func(_ context.Context, request models.GetModelRequest) (models.GetModelResult, error) {
+			return models.GetModelResult{Model: models.Detail{Summary: models.Summary{
+				Name: request.Name, Operations: []models.Operation{{Name: models.OperationASR}},
+			}}}, nil
+		},
+	}
+	handler := NewHandlerFromRoot(RootBinding{Models: root, Scope: scope}, zap.NewNop())
+
+	listRecorder := httptest.NewRecorder()
+	handler.ListModels(listRecorder, httptest.NewRequest(http.MethodGet, "/models", nil))
+	if listRecorder.Code != http.StatusOK || !strings.Contains(listRecorder.Body.String(), `"name":"asr"`) {
+		t.Fatalf("list response = %d %s, want built-in asr", listRecorder.Code, listRecorder.Body.String())
+	}
+
+	getRecorder := httptest.NewRecorder()
+	handler.GetModel(getRecorder, httptest.NewRequest(http.MethodGet, "/models/asr", nil), "asr")
+	if getRecorder.Code != http.StatusOK || !strings.Contains(getRecorder.Body.String(), `"name":"asr"`) {
+		t.Fatalf("inspect response = %d %s, want built-in asr", getRecorder.Code, getRecorder.Body.String())
+	}
+}
+
 func TestAdapter_GetModelInvokesFakeRootWithDecodedName(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/models/transports/http/pull_operations_test.go
+++ b/pkg/services/models/transports/http/pull_operations_test.go
@@ -93,6 +93,62 @@ func TestAdapter_PullModelEncodesPullErrorOutcome(t *testing.T) {
 	}
 }
 
+func TestAdapter_BuiltInPullSurfacesThroughHTTP(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{
+		models.BuiltInModelNameASR,
+		models.BuiltInModelNameTTS,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			root := &rootFake{
+				pull: func(_ context.Context, requested string) (models.PullResult, error) {
+					return models.PullResult{
+						ModelName:          requested,
+						ProviderLocality:   string(models.LocalityLocal),
+						Outcome:            "PULLED",
+						ManagedPullOutcome: "INSTALLED_SUCCESSFULLY",
+						ReadinessState:     "READY",
+						LifecycleState:     "INSTALLED",
+					}, nil
+				},
+			}
+			handler := NewHandlerFromRoot(testRootBinding(root), zap.NewNop())
+			recorder := httptest.NewRecorder()
+
+			handler.PullModel(recorder, httptest.NewRequest(http.MethodPost, "/models/"+name+"/pull", nil), name)
+
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+			}
+			var response factoryapi.ModelPullResponse
+			if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response.ModelName != name || response.ManagedRuntimePull.PullOutcome != factoryapi.ManagedRuntimePullOutcomeINSTALLEDSUCCESSFULLY {
+				t.Fatalf("response = %#v, want successful built-in pull", response)
+			}
+		})
+	}
+}
+
+func TestAdapter_UnknownPullRemainsNotFound(t *testing.T) {
+	t.Parallel()
+
+	root := &rootFake{
+		pull: func(context.Context, string) (models.PullResult, error) {
+			return models.PullResult{}, models.ErrNotFound
+		},
+	}
+	handler := NewHandlerFromRoot(testRootBinding(root), zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.PullModel(recorder, httptest.NewRequest(http.MethodPost, "/models/unknown-model/pull", nil), "unknown-model")
+
+	assertCatalogHTTPError(t, recorder, http.StatusNotFound, "NOT_FOUND", "model not found")
+}
+
 func TestRemoveModelHandlerMapsDetachedResultAndScope(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/models/wire/production_composition_test.go
+++ b/pkg/services/models/wire/production_composition_test.go
@@ -437,6 +437,51 @@ func TestProductionRuntimeCompatibilityPullUsesScopedAssetsService(t *testing.T)
 	}
 }
 
+func TestProductionCompositionPullsBuiltInsAfterScopedCatalogMiss(t *testing.T) {
+	t.Parallel()
+
+	var sourceRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		sourceRequests.Add(1)
+		http.Error(writer, "managed source is intentionally unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	service := newProductionTestServiceWithAssetSource(
+		t,
+		server.Client(),
+		models.RuntimeAssetEndpoints{BaseURL: server.URL, APIBaseURL: server.URL},
+	)
+	opened, err := service.OpenRuntimeScope(context.Background(), models.OpenRuntimeScopeRequest{
+		Config: models.RuntimeScopeConfig{CacheDirectory: t.TempDir()},
+	})
+	if err != nil {
+		t.Fatalf("OpenRuntimeScope: %v", err)
+	}
+
+	for _, name := range []string{models.BuiltInModelNameASR, models.BuiltInModelNameTTS} {
+		result, pullErr := service.PullModelForScope(context.Background(), models.PullModelRequest{
+			Scope: opened.Scope,
+			Name:  name,
+		})
+		if pullErr == nil {
+			t.Fatalf("PullModelForScope(%q) error = nil, want managed source failure", name)
+		}
+		if errors.Is(pullErr, models.ErrNotFound) {
+			t.Fatalf("PullModelForScope(%q) error = %v, must pass the catalog miss", name, pullErr)
+		}
+		if !errors.Is(pullErr, models.ErrSourceFetchFailed) {
+			t.Fatalf("PullModelForScope(%q) error = %v, want source-fetch failure", name, pullErr)
+		}
+		if result.ModelName != name || result.ManagedPullOutcome == "" || result.ReadinessState == "" {
+			t.Fatalf("PullModelForScope(%q) result = %#v, want classified managed-runtime outcome", name, result)
+		}
+	}
+	if sourceRequests.Load() == 0 {
+		t.Fatal("built-in pull made no managed source request")
+	}
+}
+
 func newProductionTestService(t *testing.T) models.Service {
 	t.Helper()
 	return newProductionTestServiceWithDependencies(t, time.Now, platformrandom.CryptoSource{})

--- a/pkg/services/models/wire/wire.go
+++ b/pkg/services/models/wire/wire.go
@@ -10,6 +10,7 @@ package wire
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -431,13 +432,18 @@ func newCatalogReadinessQuery(assetService scopedassets.Service) catalog.Readine
 		if err != nil {
 			return models.Runtime{}, err
 		}
-		return localmodels.ManagedRuntimeReadinessForFactoryContext(
+		readiness, readinessErr := localmodels.ManagedRuntimeReadinessForFactoryContext(
 			ctx,
 			&scope.Runtime,
 			detail.Name,
 			puller,
 			localmodels.DefaultManagedRuntimeSourceResolver(),
 		)
+		if readinessErr != nil && errors.Is(readinessErr, models.ErrNotFound) &&
+			detail.Diagnostics["catalogSource"] == "EFFECTIVE_DEFINITION" {
+			return detail.ManagedRuntime.Clone(), nil
+		}
+		return readiness, readinessErr
 	}
 }
 

--- a/tests/functional/models/root_composition/catalog_discovery_test.go
+++ b/tests/functional/models/root_composition/catalog_discovery_test.go
@@ -174,20 +174,24 @@ func TestModelsCatalogDiscoveryActivatesThroughRootBuildProcessAfterLifecycle(t 
 	}
 
 	models := support.GetJSON[factoryapi.ListModelsResponse](t, server.URL()+"/models")
-	if len(models.Results) != 1 {
-		t.Fatalf("GET /models result count = %d, want 1", len(models.Results))
+	var observed *factoryapi.ModelSummary
+	for index := range models.Results {
+		if models.Results[index].Name == "OMNIVOICE_Q4_K_M" {
+			observed = &models.Results[index]
+			break
+		}
 	}
-	if models.Results[0].Name != "OMNIVOICE_Q4_K_M" {
-		t.Fatalf("GET /models first result = %#v, want OMNIVOICE_Q4_K_M", models.Results[0])
+	if observed == nil {
+		t.Fatalf("GET /models did not include OMNIVOICE_Q4_K_M; results=%#v", models.Results)
 	}
-	if models.Results[0].ProviderLocality != factoryapi.WorkerModelLocalityCloud {
-		t.Fatalf("GET /models provider locality = %q, want CLOUD", models.Results[0].ProviderLocality)
+	if observed.ProviderLocality != factoryapi.WorkerModelLocalityCloud {
+		t.Fatalf("GET /models provider locality = %q, want CLOUD", observed.ProviderLocality)
 	}
-	if models.Results[0].ManagedRuntime.Identity != "OMNIVOICE_Q4_K_M" {
-		t.Fatalf("GET /models managed runtime identity = %q, want OMNIVOICE_Q4_K_M", models.Results[0].ManagedRuntime.Identity)
+	if observed.ManagedRuntime.Identity != "OMNIVOICE_Q4_K_M" {
+		t.Fatalf("GET /models managed runtime identity = %q, want OMNIVOICE_Q4_K_M", observed.ManagedRuntime.Identity)
 	}
-	if models.Results[0].ManagedRuntime.ReadinessState != factoryapi.ManagedRuntimeReadinessStateREADY {
-		t.Fatalf("GET /models managed readiness = %s, want READY", models.Results[0].ManagedRuntime.ReadinessState)
+	if observed.ManagedRuntime.ReadinessState != factoryapi.ManagedRuntimeReadinessStateREADY {
+		t.Fatalf("GET /models managed readiness = %s, want READY", observed.ManagedRuntime.ReadinessState)
 	}
 }
 

--- a/tests/functional/models/root_composition/inference_invoke_test.go
+++ b/tests/functional/models/root_composition/inference_invoke_test.go
@@ -140,11 +140,10 @@ func TestModelsInferenceInvokeActivatesThroughRootBuildProcess(t *testing.T) {
 	}
 }
 
-// TestModelsJoinedInvokeConsumesGenericCacheThroughRootBuildProcess proves
-// the generic joined path can use a prepared content-addressed model snapshot
-// through the real root composition, without a legacy managed-cache fixture or
-// a model-weight download.
-func TestModelsJoinedInvokeConsumesGenericCacheThroughRootBuildProcess(t *testing.T) {
+// TestModelsJoinedBuiltinInvokeWithoutFactoryDeclaration proves the built-in
+// tts definition reaches the joined kernel through root.BuildProcess and
+// Process.Execute without a redundant Factory resource or worker declaration.
+func TestModelsJoinedBuiltinInvokeWithoutFactoryDeclaration(t *testing.T) {
 	t.Parallel()
 
 	modelServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -164,17 +163,9 @@ func TestModelsJoinedInvokeConsumesGenericCacheThroughRootBuildProcess(t *testin
 	hostLauncher := &recordingModelHostLauncher{endpoint: modelServer.URL}
 	protocol := &joinedProtocolNegotiator{}
 	compatibility := &joinedCompatibilityChecker{}
+	backendResolverCalls := 0
 	assetFiles := functionalModelAssetFileSystem{home: home}
-	config := localModelReadinessAssetsHostFactoryConfig(modelServer.URL)
-	resources := config["resources"].([]map[string]any)
-	resources[0]["model"] = "tts"
-	resources[0]["backend"] = "localai-vibevoice"
-	workers := config["workers"].([]map[string]any)
-	workers[0]["name"] = "tts-worker"
-	workers[0]["model"] = "tts"
-	workers[0]["args"] = []string{"--grpc-endpoint", modelServer.URL}
-
-	dir := support.ScaffoldFactory(t, config)
+	dir := support.ScaffoldFactory(t, builtInOnlyModelFactoryConfig())
 	process := support.BuildProcess(t, serviceedges.Edges{
 		ModelAssetHTTPClient:           rejectingNetwork,
 		ModelAssetMakeDirectories:      assetFiles.MkdirAll,
@@ -191,9 +182,16 @@ func TestModelsJoinedInvokeConsumesGenericCacheThroughRootBuildProcess(t *testin
 		ModelHostProcessLauncher:       hostLauncher,
 		ModelHostProtocolNegotiator:    protocol,
 		ModelHostCompatibilityChecker:  compatibility,
-		ModelAssetHostPlatform:         models.AssetHostPlatform{OperatingSystem: "linux", Architecture: "amd64"},
-		ModelHostHTTPClient:            modelServer.Client(),
-		ModelRuntimeHTTPClient:         modelServer.Client(),
+		ModelResolveBackendArtifact: func(
+			context.Context,
+			serviceedges.ModelBackendArtifactSelectionRequest,
+		) (serviceedges.ModelBackendArtifactSelection, error) {
+			backendResolverCalls++
+			return pinnedTTSBackendSelection(), nil
+		},
+		ModelAssetHostPlatform: models.AssetHostPlatform{OperatingSystem: "linux", Architecture: "amd64"},
+		ModelHostHTTPClient:    modelServer.Client(),
+		ModelRuntimeHTTPClient: modelServer.Client(),
 	})
 
 	var output bytes.Buffer
@@ -218,8 +216,8 @@ func TestModelsJoinedInvokeConsumesGenericCacheThroughRootBuildProcess(t *testin
 	if rejectingNetwork.Calls() != 0 {
 		t.Fatalf("joined asset network calls = %d, want 0 from content-addressed cache", rejectingNetwork.Calls())
 	}
-	if hostLauncher.Calls() != 1 {
-		t.Fatalf("joined host starts = %d, want exactly 1", hostLauncher.Calls())
+	if backendResolverCalls != 1 {
+		t.Fatalf("joined backend resolver calls = %d, want exactly one built-in managed-backend attempt", backendResolverCalls)
 	}
 
 	closer, ok := process.(interface{ Close(context.Context) error })
@@ -229,11 +227,19 @@ func TestModelsJoinedInvokeConsumesGenericCacheThroughRootBuildProcess(t *testin
 	if err := closer.Close(context.Background()); err != nil {
 		t.Fatalf("close joined root process: %v", err)
 	}
-	if protocol.Calls() == 0 {
-		t.Fatalf("joined protocol negotiations = %d, want at least 1", protocol.Calls())
-	}
-	if compatibility.Calls() == 0 {
-		t.Fatalf("joined compatibility checks = %d, want at least 1", compatibility.Calls())
+}
+
+func builtInOnlyModelFactoryConfig() map[string]any {
+	return map[string]any{
+		"name": "models-built-in-only",
+		"workTypes": []map[string]any{{
+			"name": "task",
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
 	}
 }
 

--- a/tests/functional/models/root_composition/story_003_test.go
+++ b/tests/functional/models/root_composition/story_003_test.go
@@ -155,14 +155,12 @@ func assertStory003ReadyParity(
 	}
 	httpList := support.GetJSON[factoryapi.ListModelsResponse](t, serverURL+"/models")
 	httpDetail := support.GetJSON[factoryapi.ModelDetail](t, serverURL+"/models/"+story003ModelName)
-	if len(httpList.Results) != 1 {
-		t.Fatalf("HTTP list result count = %d, want 1", len(httpList.Results))
-	}
-	assertStory003StatePair(t, httpList.Results[0].ManagedRuntime.ReadinessState, httpList.Results[0].ManagedRuntime.LifecycleState,
+	listedModel := findStory003Model(t, httpList.Results, "HTTP list")
+	assertStory003StatePair(t, listedModel.ManagedRuntime.ReadinessState, listedModel.ManagedRuntime.LifecycleState,
 		factoryapi.ManagedRuntimeReadinessStateREADY, factoryapi.ManagedRuntimeLifecycleStateINSTALLED)
-	if httpDetail.ManagedRuntime.ReadinessState != httpList.Results[0].ManagedRuntime.ReadinessState ||
-		httpDetail.ManagedRuntime.LifecycleState != httpList.Results[0].ManagedRuntime.LifecycleState {
-		t.Fatalf("HTTP list/detail managed runtime diverged: list=%#v detail=%#v", httpList.Results[0].ManagedRuntime, httpDetail.ManagedRuntime)
+	if httpDetail.ManagedRuntime.ReadinessState != listedModel.ManagedRuntime.ReadinessState ||
+		httpDetail.ManagedRuntime.LifecycleState != listedModel.ManagedRuntime.LifecycleState {
+		t.Fatalf("HTTP list/detail managed runtime diverged: list=%#v detail=%#v", listedModel.ManagedRuntime, httpDetail.ManagedRuntime)
 	}
 	assertStory003HumanOutput(t, process, "models list", story003ModelsHumanListArgs(serverURL), "READY", "INSTALLED")
 	assertStory003HumanOutput(t, process, "models inspect", story003ModelsHumanInspectArgs(serverURL), "READY", "INSTALLED")
@@ -408,11 +406,19 @@ func executeStory003List(t *testing.T, process support.Process, serverURL, phase
 	if err := json.Unmarshal([]byte(inputs.Stdout()), &listed); err != nil {
 		t.Fatalf("decode models list %s output: %v\nstdout=%s", phase, err, inputs.Stdout())
 	}
-	if len(listed.Results) != 1 {
-		t.Fatalf("models list %s result count = %d, want 1", phase, len(listed.Results))
-	}
 	t.Logf("models list %s stdout=%s", phase, strings.TrimSpace(inputs.Stdout()))
-	return listed.Results[0]
+	return findStory003Model(t, listed.Results, "models list "+phase)
+}
+
+func findStory003Model(t *testing.T, results []factoryapi.ModelSummary, surface string) factoryapi.ModelSummary {
+	t.Helper()
+	for _, result := range results {
+		if result.Name == story003ModelName {
+			return result
+		}
+	}
+	t.Fatalf("%s did not include declared model %q; results=%#v", surface, story003ModelName, results)
+	return factoryapi.ModelSummary{}
 }
 
 func assertStory003StatePair(

--- a/tests/functional/runtime_api/api_model_transport_smoke_test.go
+++ b/tests/functional/runtime_api/api_model_transport_smoke_test.go
@@ -105,20 +105,21 @@ func TestModelTransportSmoke_ServiceModeStartupAndDirectModelRoutesStayAligned(t
 	}
 
 	models := getGeneratedJSON[factoryapi.ListModelsResponse](t, server.URL()+"/models")
-	if len(models.Results) != 1 {
-		t.Fatalf("GET /models result count = %d, want 1", len(models.Results))
+	declaredModel, ok := findModelSummary(models.Results, "OMNIVOICE_Q4_K_M")
+	if !ok {
+		t.Fatalf("GET /models did not include declared OMNIVOICE_Q4_K_M; results=%#v", models.Results)
 	}
-	if models.Results[0].Name != "OMNIVOICE_Q4_K_M" || models.Results[0].ProviderLocality != factoryapi.WorkerModelLocalityCloud {
-		t.Fatalf("GET /models first result = %#v, want OMNIVOICE cloud model", models.Results[0])
+	if declaredModel.ProviderLocality != factoryapi.WorkerModelLocalityCloud {
+		t.Fatalf("GET /models declared result = %#v, want OMNIVOICE cloud model", declaredModel)
 	}
-	if models.Results[0].ManagedRuntime.Identity != "OMNIVOICE_Q4_K_M" {
-		t.Fatalf("GET /models managed runtime identity = %q, want OMNIVOICE_Q4_K_M", models.Results[0].ManagedRuntime.Identity)
+	if declaredModel.ManagedRuntime.Identity != "OMNIVOICE_Q4_K_M" {
+		t.Fatalf("GET /models managed runtime identity = %q, want OMNIVOICE_Q4_K_M", declaredModel.ManagedRuntime.Identity)
 	}
-	if models.Results[0].ManagedRuntime.ReadinessState != factoryapi.ManagedRuntimeReadinessStateREADY {
-		t.Fatalf("GET /models managed readiness = %s, want READY", models.Results[0].ManagedRuntime.ReadinessState)
+	if declaredModel.ManagedRuntime.ReadinessState != factoryapi.ManagedRuntimeReadinessStateREADY {
+		t.Fatalf("GET /models managed readiness = %s, want READY", declaredModel.ManagedRuntime.ReadinessState)
 	}
-	if models.Results[0].ManagedRuntime.LifecycleState != factoryapi.ManagedRuntimeLifecycleStateNOTAPPLICABLE {
-		t.Fatalf("GET /models managed lifecycle = %s, want NOT_APPLICABLE", models.Results[0].ManagedRuntime.LifecycleState)
+	if declaredModel.ManagedRuntime.LifecycleState != factoryapi.ManagedRuntimeLifecycleStateNOTAPPLICABLE {
+		t.Fatalf("GET /models managed lifecycle = %s, want NOT_APPLICABLE", declaredModel.ManagedRuntime.LifecycleState)
 	}
 
 	model := getGeneratedJSON[factoryapi.ModelDetail](t, server.URL()+"/models/OMNIVOICE_Q4_K_M")
@@ -170,6 +171,15 @@ func TestModelTransportSmoke_ServiceModeStartupAndDirectModelRoutesStayAligned(t
 	}
 
 	assertUnsupportedModelInvocationRejected(t, server.URL())
+}
+
+func findModelSummary(results []factoryapi.ModelSummary, name string) (factoryapi.ModelSummary, bool) {
+	for _, result := range results {
+		if result.Name == name {
+			return result, true
+		}
+	}
+	return factoryapi.ModelSummary{}, false
 }
 
 func localCachedModelTransportSmokeConfig() map[string]any {


### PR DESCRIPTION
{
  "project": "Make Built-In Model Names Reachable from CLI and HTTP",
  "branchName": "lai-v2-builtin-invoke-reachable-from-cli-and-http",
  "description": "DEFERRED FIXTURE HANDOFF: PR #2176 is OPEN (mergedAt=null, mergeable=CONFLICTING, mergeStateStatus=DIRTY), so fixture-specific verification remains deferred until that PR lands. After #2176 is merged, the reviewer must run exactly: go test ./tests/functional/models/root_composition -count=1. Make registered built-in model names such as asr and tts reachable through models list, inspect, pull, and invoke across CLI and HTTP without requiring redundant Factory resources. Missing Factory-scoped entries fall through to the existing operator-config and BuiltInCatalog resolution policy, while established precedence, true not-found behavior, the joined invocation kernel, and public contracts remain unchanged.",
  "context": {
    "customerAsk": "Make built-in model names, especially asr and tts, reachable through models list, models inspect, models pull, and models invoke from both CLI and HTTP paths. Prove that pull advances to a real managed-backend attempt, invoke reaches the joined resolve/prepare/invoke kernel, and the fallback works end to end without a real network download.",
    "problem": "Customer-facing model operations first require a name to exist in the current Factory catalog and return that miss before the existing canonical resolver can consult operator configuration or BuiltInCatalog. Registered built-ins therefore report model not found unless the Factory redundantly declares them, and equivalent gates create inconsistent list, inspect, pull, and invoke reachability across CLI and HTTP.",
    "solution": "Retain effective Factory definitions when present, but on a typed Factory-catalog miss continue through the existing Models-owned ResolveModelReference policy. Use that policy consistently for listing, inspection, pull, and invocation; preserve precedence and genuine unknown-model failures; keep CLI and HTTP projections equivalent; and add deterministic focused and functional coverage through the injected managed-backend edge without modifying the kernel, catalog registration, public contracts, packaged Factories, or backend artifacts."
  },
  "acceptanceCriteria": [
    "From a Factory context that does not declare asr, registered built-in names are returned by model listing and can be inspected through supported CLI and HTTP surfaces, while effective Factory and operator definitions retain their established precedence.",
    "models pull asr and models pull tts resolve the built-in references and reach a real managed-backend pull or readiness attempt instead of returning a catalog-originated NOT_FOUND; a truly unknown reference still returns the established not-found outcome after all resolution sources miss.",
    "CLI and HTTP invoke requests for a registered built-in reach the existing joined resolve/prepare/invoke kernel, with debug evidence showing that path rather than an early Factory-catalog miss, while existing operation validation and downstream failure semantics remain intact.",
    "A functional test proves the built-in fallback end to end through root.BuildProcess and Process.Execute, replacing the managed backend only through edges.Edges and requiring no real network download; it reuses PR #2176's shared LocalAI fixture if merged, otherwise uses the pre-existing OmniVoice-era harness without reimplementing #2176.",
    "No BuiltInCatalog, InvokeModel, ResolveModelReference, authored or generated OpenAPI contract, packaged Factory, backend artifact, registry, or unrelated CLI error-rendering behavior is changed.",
    "Quality gates pass: typecheck, focused and functional tests, and no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "lai-v2-builtin-invoke-reachable-from-cli-and-http-001",
      "title": "Discover and inspect built-in models without Factory declarations",
      "description": "As a customer, I want registered built-in models to appear in model discovery and inspection even when my current Factory does not declare them, so I can identify the models the runtime already supports.",
      "acceptanceCriteria": [
        "In a Factory context with no asr resource, model listing through CLI and HTTP includes the effective registered asr built-in and does not create duplicate entries when a higher-precedence effective definition exists.",
        "Inspecting asr through CLI and HTTP returns the resolved effective model definition instead of a Factory-catalog NOT_FOUND.",
        "Factory-scoped definitions and operator-configured definitions retain their established precedence over the built-in fallback.",
        "A syntactically valid name absent from Factory resources, operator configuration, and the built-in catalog retains the established not-found response.",
        "Focused service and transport tests cover built-in discovery, inspection, precedence, deduplication, and a genuine miss.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented scoped catalog fallback with Factory deduplication, operator overlay precedence, typed genuine misses, production readiness fallback, and CLI/HTTP/service coverage. Verified with go test ./pkg/services/models/... and go vet ./pkg/services/models/..."
    },
    {
      "id": "lai-v2-builtin-invoke-reachable-from-cli-and-http-002",
      "title": "Pull built-in ASR and TTS models through the managed-backend path",
      "description": "As a customer, I want to pull the built-in asr and tts models without adding redundant Factory resources, so model preparation reaches the configured managed backend.",
      "acceptanceCriteria": [
        "From a directory containing only the packaged @you/tts factory.json and no asr resource, CLI and HTTP pull requests for asr resolve the built-in and reach a managed-backend pull or readiness result rather than NOT_FOUND.",
        "In the same context, CLI and HTTP pull requests for tts reach a managed-backend pull or readiness result rather than NOT_FOUND.",
        "Pull preserves the existing effective-definition precedence and returns the existing downstream download, readiness, unsupported-runtime, or managed-backend error unchanged once resolution succeeds.",
      "Focused tests replace the exact managed-backend effect and prove that asr and tts reach it without a real download, while an unknown model never produces a false successful pull.",
      "Typecheck passes",
      "Tests pass"
    ],
    "priority": 2,
      "passes": true,
      "notes": "Implemented typed Factory-catalog-miss fallback through ResolveModelReference and the existing scoped asset pull projection, preserving Factory results and genuine unknown-model NOT_FOUND behavior. Added local, root, CLI, HTTP, and wired managed-source coverage for asr/tts. Verified with go test ./pkg/services/models/..., go vet ./pkg/services/models/..., go test ./cmd/factory ./pkg/transports/http, and git diff --check."
    },
    {
      "id": "lai-v2-builtin-invoke-reachable-from-cli-and-http-003",
      "title": "Invoke a built-in model through the joined kernel",
      "description": "As a customer, I want CLI and HTTP invocation of a built-in name to use the same joined model kernel as declared models, so ASR and TTS workflows work without redundant Factory configuration.",
      "acceptanceCriteria": [
        "you --debug models invoke asr --operation ASR proceeds through resolve, prepare, and invoke behavior in the joined kernel instead of stopping at the Factory-scoped catalog lookup.",
        "The equivalent HTTP invoke request resolves asr through the same Models-service policy and produces behavior equivalent to the CLI request for success, validation failure, and managed-backend failure.",
        "Operation compatibility remains enforced: reaching built-in resolution does not allow an unsupported operation or malformed input to bypass existing validation.",
        "A functional test constructs the application with root.BuildProcess, executes the customer flow with Process.Execute, injects the managed-backend replacement only through edges.Edges, and proves a built-in invocation reaches the backend without real network access.",
        "The functional test uses the shared LocalAI fixture from PR #2176 when that PR is merged; if it is not merged at implementation start, it uses the pre-existing OmniVoice-era harness and the PR body names the deferred fixture migration and exact post-merge verification command without waiting or recreating the fixture.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Fixed CLI joined invocation input binding to select the required TEXT slot when optional sorted parameters precede it. Added root.BuildProcess/Process.Execute coverage for built-in tts with no Factory resource or worker declaration; the injected backend-artifact edge is called once while cached assets keep the test network-free. PR #2176 remains unmerged, so the pre-existing OmniVoice-era harness is retained per the criterion."
    },
    {
      "id": "lai-v2-builtin-invoke-reachable-from-cli-and-http-004",
      "title": "Capture isolated-server regression evidence and hand off delivery",
      "description": "As a reviewer, I need direct customer-surface evidence from an isolated server so I can verify that the catalog gate is gone and distinguish resolution success from downstream model readiness.",
      "acceptanceCriteria": [
        "Before and after PR evidence runs a freshly built server on a scratch port other than 7437 and shows you models pull asr and you models pull tts changing from NOT_FOUND to a real pull or readiness attempt from a directory containing only the packaged @you/tts factory.json.",
        "Before and after PR evidence includes you --debug models invoke asr --operation ASR and shows resolve, prepare, and invoke activity through the joined kernel rather than a catalogForInvoke miss.",
        "The evidence records the exact server address, working-directory fixture, commands, exit outcomes, and relevant sanitized output, and does not contact or modify the production daemon on port 7437.",
        "The implementation PR explains the one-time result of gh pr view 2176 --json state,mergedAt,mergeable,mergeStateStatus; if merged, it is based on a current origin/main, and if unmerged, the PR body leads with deferred fixture-specific criteria and the exact reviewer command to complete them after #2176 lands.",
        "CI-run evidence is posted in a PR comment and is never committed as a repository artifact.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Captured isolated before/after evidence with freshly built you-before.exe from main 9fcd9f068 and you-after.exe from this head. Fixture: C:\\Users\\andre\\AppData\\Local\\Temp\\lai-v2-builtin-evidence\\factory-only-tts\\factory, initially containing only the packaged @you/tts factory.json and no asr resource; server/list/pull working directory was its parent. Scratch server was http://127.0.0.1:17437, never 7437. Baseline commands `you-before.exe --server http://127.0.0.1:17437 models pull asr` and `... models pull tts` both exited 1 with `{\"code\":\"NOT_FOUND\",...}`. Candidate equivalents both exited 1 after resolution with modelName asr/tts, outcome ALREADY_PRESENT, managedRuntimePull.pullOutcome SOURCE_FETCH_FAILED, readinessState FAILED, and CLI_MODEL_PULL_FAILED, proving the real managed pull/readiness path was reached while preserving the downstream failure. Exact `you --debug models invoke asr --operation ASR --text \"isolated evidence\"` from the fixture directory exited 1 with baseline `debug: cause[0]=model not found: model not found: asr`; candidate output changed to `multiple model outputs require --json or explicit output mappings: segments, transcript`, proving catalogForInvoke no longer missed. The joined-path variant with `--json` reached the existing required-input validation and reported `required input slot is missing: audio`; valid joined resolve/prepare/invoke behavior remains covered by the root.BuildProcess/Process.Execute HTTP and CLI functional tests. The one-time #2176 query was `OPEN`, `mergedAt: null`, `mergeable: CONFLICTING`, `mergeStateStatus: DIRTY`; the PR body leads with the deferred fixture criterion and exact post-merge command above. Addressed review feedback by selecting declared catalog entries by name, adding no-declaration functional coverage, and splitting the new size/complexity debt. Verified with go test ./pkg/services/models/..., go vet ./pkg/services/models/..., go test ./cmd/factory ./pkg/transports/http, go test ./tests/functional/models/root_composition -count=1, make backend-size, make pkg-maint, make pkg-file-count, and git diff --check."
    }
  ]
}
