### PR TITLE
test(ui): add exhaustive palette contrast ratchet

### DIFF
--- a/ui/src/styles/palette-contrast-baseline.ts
+++ b/ui/src/styles/palette-contrast-baseline.ts
@@ -1,0 +1,114 @@
+import type { ColorPaletteId } from "../theme/color-palette";
+
+export interface PaletteContrastBaselineEntry {
+  fillToken: string;
+  foregroundToken: string;
+  paletteId: ColorPaletteId;
+  ratio: number;
+}
+
+/**
+ * Measured current contrast debt, rounded to two decimal places so harmless
+ * floating-point noise does not create a ratchet failure. An improvement that
+ * changes the displayed ratio must lower or remove its entry.
+ */
+export const PALETTE_CONTRAST_BASELINE = [
+  // WCAG 1.4.3 exempts disabled controls; these five measured entries are not
+  // repair obligations and remain here to keep the complete table ratcheted.
+  {
+    paletteId: "factory-dark",
+    foregroundToken: "--color-on-surface-disabled",
+    fillToken: "--color-surface",
+    ratio: 3.71,
+  },
+  {
+    paletteId: "factory-light",
+    foregroundToken: "--color-on-surface-disabled",
+    fillToken: "--color-surface",
+    ratio: 2.56,
+  },
+  {
+    paletteId: "material-baseline",
+    foregroundToken: "--color-on-surface-disabled",
+    fillToken: "--color-surface",
+    ratio: 3.4,
+  },
+  {
+    paletteId: "slate",
+    foregroundToken: "--color-on-surface-disabled",
+    fillToken: "--color-surface",
+    ratio: 3.62,
+  },
+  {
+    paletteId: "olive",
+    foregroundToken: "--color-on-surface-disabled",
+    fillToken: "--color-surface",
+    ratio: 3.7,
+  },
+  {
+    paletteId: "factory-dark",
+    foregroundToken: "--color-on-secondary",
+    fillToken: "--color-secondary",
+    ratio: 4.48,
+  },
+  {
+    paletteId: "factory-dark",
+    foregroundToken: "--color-on-tertiary",
+    fillToken: "--color-tertiary",
+    ratio: 3.58,
+  },
+  {
+    paletteId: "factory-light",
+    foregroundToken: "--color-on-surface-subtle",
+    fillToken: "--color-surface",
+    ratio: 4.05,
+  },
+  {
+    paletteId: "factory-light",
+    foregroundToken: "--color-on-surface-subtle",
+    fillToken: "--color-background",
+    ratio: 3.9,
+  },
+  {
+    paletteId: "factory-light",
+    foregroundToken: "--color-on-primary-container",
+    fillToken: "--color-primary-container",
+    ratio: 2.44,
+  },
+  {
+    paletteId: "factory-light",
+    foregroundToken: "--color-on-secondary",
+    fillToken: "--color-secondary",
+    ratio: 4.47,
+  },
+  {
+    paletteId: "factory-light",
+    foregroundToken: "--color-on-success",
+    fillToken: "--color-success",
+    ratio: 3.33,
+  },
+  {
+    paletteId: "factory-light",
+    foregroundToken: "--color-on-warning",
+    fillToken: "--color-warning",
+    ratio: 2.88,
+  },
+  {
+    paletteId: "factory-light",
+    foregroundToken: "--color-on-error",
+    fillToken: "--color-error",
+    ratio: 3.98,
+  },
+  {
+    paletteId: "factory-light",
+    foregroundToken: "--color-on-info",
+    fillToken: "--color-info",
+    ratio: 3.5,
+  },
+  {
+    paletteId: "material-baseline",
+    foregroundToken: "--color-on-tertiary",
+    fillToken: "--color-tertiary",
+    ratio: 4.27,
+  },
+] as const satisfies ReadonlyArray<PaletteContrastBaselineEntry>;

--- a/ui/src/styles/palette-contrast-ratchet.component.test.ts
+++ b/ui/src/styles/palette-contrast-ratchet.component.test.ts
@@ -1,0 +1,232 @@
+// @vitest-environment happy-dom
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+import { compileDashboardStyles } from "../test-support/compile-dashboard-styles";
+import { applyDocumentColorPalette } from "../theme/app-color-palette";
+import { COLOR_PALETTE_IDS, type ColorPaletteId } from "../theme/color-palette";
+import { PALETTE_CONTRAST_BASELINE } from "./palette-contrast-baseline";
+import {
+  type CssVariableReader,
+  compositeOver,
+  contrastRatio,
+  type ParsedCssColor,
+  resolveCssColor,
+  resolveFillRgb,
+  stableRatio,
+} from "./palette-contrast-test-math";
+
+const stylesDirectory = path.dirname(fileURLToPath(import.meta.url));
+const stylesSourcePath = path.resolve(stylesDirectory, "..", "styles.css");
+const CONTRAST_FLOOR = 4.5;
+const BASELINE_PRECISION = 2;
+
+const REQUIRED_CONTRAST_PAIRS = [
+  ["--color-on-surface", "--color-surface"],
+  ["--color-on-surface-variant", "--color-surface"],
+  ["--color-on-surface-subtle", "--color-surface"],
+  ["--color-on-surface-disabled", "--color-surface"],
+  ["--color-on-surface", "--color-background"],
+  ["--color-on-surface-subtle", "--color-background"],
+  ["--color-code", "--color-surface"],
+  ["--color-on-primary", "--color-primary"],
+  ["--color-on-primary-container", "--color-primary-container"],
+  ["--color-on-secondary", "--color-secondary"],
+  ["--color-on-secondary-container", "--color-secondary-container"],
+  ["--color-on-tertiary", "--color-tertiary"],
+  ["--color-on-tertiary-container", "--color-tertiary-container"],
+  ["--color-on-success", "--color-success"],
+  ["--color-on-success-container", "--color-success-container"],
+  ["--color-on-warning", "--color-warning"],
+  ["--color-on-warning-container", "--color-warning-container"],
+  ["--color-on-error", "--color-error"],
+  ["--color-on-error-container", "--color-error-container"],
+  ["--color-on-info", "--color-info"],
+  ["--color-on-info-container", "--color-info-container"],
+] as const;
+
+interface PaletteContrastMeasurement {
+  fillToken: string;
+  foregroundToken: string;
+  paletteId: ColorPaletteId;
+  ratio: number;
+  stableRatio: number;
+}
+
+function injectCompiledRootRules(compiledCss: string): void {
+  const rootBlocks = compiledCss.match(/:root[^{]*\{[^}]*\}/g) ?? [];
+  const paletteBlocks =
+    compiledCss.match(/\[data-color-palette="[^"]+"\][^{]*\{[^}]*\}/g) ?? [];
+  const style = document.createElement("style");
+  style.textContent = [...rootBlocks, ...paletteBlocks].join("\n");
+  document.head.appendChild(style);
+}
+
+function measurementKey(measurement: {
+  fillToken: string;
+  foregroundToken: string;
+  paletteId: string;
+}): string {
+  return `${measurement.paletteId}|${measurement.foregroundToken}|${measurement.fillToken}`;
+}
+
+function measurePaletteContrast(
+  paletteId: ColorPaletteId,
+): PaletteContrastMeasurement[] {
+  applyDocumentColorPalette(paletteId);
+  const computedStyle = getComputedStyle(document.documentElement);
+  const colors = new Map<string, ParsedCssColor>();
+  const readColor = (tokenName: string): ParsedCssColor => {
+    const cached = colors.get(tokenName);
+    if (cached) {
+      return cached;
+    }
+    const color = resolveCssColor(paletteId, tokenName, computedStyle);
+    colors.set(tokenName, color);
+    return color;
+  };
+  const surface = readColor("--color-surface");
+  const surfaceRgb = compositeOver(surface, surface.rgb);
+
+  return REQUIRED_CONTRAST_PAIRS.map(([foregroundToken, fillToken]) => {
+    const foreground = readColor(foregroundToken);
+    const fill = readColor(fillToken);
+    const fillRgb = resolveFillRgb(fillToken, fill, surfaceRgb);
+    const foregroundRgb = compositeOver(foreground, fillRgb);
+    const ratio = contrastRatio(foregroundRgb, fillRgb);
+    return {
+      fillToken,
+      foregroundToken,
+      paletteId,
+      ratio,
+      stableRatio: stableRatio(ratio, BASELINE_PRECISION),
+    };
+  });
+}
+
+function formatMeasurement(measurement: PaletteContrastMeasurement): string {
+  return [
+    measurement.paletteId,
+    measurement.foregroundToken,
+    measurement.fillToken,
+    measurement.stableRatio.toFixed(BASELINE_PRECISION),
+  ].join("\t");
+}
+
+function baselineMap(): Map<
+  string,
+  (typeof PALETTE_CONTRAST_BASELINE)[number]
+> {
+  return new Map(
+    PALETTE_CONTRAST_BASELINE.map((entry) => [measurementKey(entry), entry]),
+  );
+}
+
+function createVariableReader(
+  values: Readonly<Record<string, string>>,
+): CssVariableReader {
+  return {
+    getPropertyValue: (name) => values[name] ?? "",
+  };
+}
+
+describe("exhaustive palette contrast ratchet", () => {
+  beforeAll(async () => {
+    const compiledCss = await compileDashboardStyles(stylesSourcePath);
+    injectCompiledRootRules(compiledCss);
+  });
+
+  it("measures all 105 role/palette cells and ratchets the current debt", () => {
+    const measurements = COLOR_PALETTE_IDS.flatMap(measurePaletteContrast);
+    const debt = measurements.filter(
+      (measurement) => measurement.ratio < CONTRAST_FLOOR,
+    );
+    const baseline = baselineMap();
+    const diagnostics: string[] = [];
+
+    console.log(
+      `Measured ${measurements.length} palette contrast cells (${COLOR_PALETTE_IDS.length} palettes x ${REQUIRED_CONTRAST_PAIRS.length} pairs).`,
+    );
+    console.log("palette\tforeground\tfill\tratio");
+    for (const measurement of measurements) {
+      console.log(formatMeasurement(measurement));
+      const recorded = baseline.get(measurementKey(measurement));
+      if (measurement.ratio < CONTRAST_FLOOR && !recorded) {
+        diagnostics.push(
+          `Unbaselined contrast debt: palette=${measurement.paletteId} foreground=${measurement.foregroundToken} fill=${measurement.fillToken} measured=${measurement.stableRatio.toFixed(BASELINE_PRECISION)} required floor=${CONTRAST_FLOOR.toFixed(1)}`,
+        );
+      }
+      if (recorded && measurement.stableRatio > recorded.ratio) {
+        diagnostics.push(
+          `Contrast baseline improved: palette=${measurement.paletteId} foreground=${measurement.foregroundToken} fill=${measurement.fillToken} measured=${measurement.stableRatio.toFixed(BASELINE_PRECISION)} recorded=${recorded.ratio.toFixed(BASELINE_PRECISION)} required floor=${CONTRAST_FLOOR.toFixed(1)}; lower or remove the stale baseline entry.`,
+        );
+      }
+    }
+
+    const measuredKeys = new Set(measurements.map(measurementKey));
+    for (const entry of PALETTE_CONTRAST_BASELINE) {
+      if (!measuredKeys.has(measurementKey(entry))) {
+        diagnostics.push(
+          `Stale contrast baseline: palette=${entry.paletteId} foreground=${entry.foregroundToken} fill=${entry.fillToken} measured=missing required floor=${CONTRAST_FLOOR.toFixed(1)}; remove the stale baseline entry.`,
+        );
+      }
+    }
+
+    console.log(
+      `Baselined sub-${CONTRAST_FLOOR} debt: ${debt.length} entries.`,
+    );
+    for (const paletteId of COLOR_PALETTE_IDS) {
+      console.log(
+        `${paletteId} sub-${CONTRAST_FLOOR} debt: ${debt.filter((measurement) => measurement.paletteId === paletteId).length} entries.`,
+      );
+    }
+    expect(diagnostics, diagnostics.join("\n")).toEqual([]);
+    expect(measurements).toHaveLength(105);
+    expect(new Set(measurements.map(measurementKey)).size).toBe(105);
+    expect(PALETTE_CONTRAST_BASELINE).toHaveLength(16);
+    expect(debt).toHaveLength(16);
+    expect(
+      debt.filter(({ paletteId }) => paletteId === "factory-light"),
+    ).toHaveLength(9);
+    expect(
+      measurements.find(
+        ({ fillToken, foregroundToken, paletteId }) =>
+          paletteId === "factory-light" &&
+          foregroundToken === "--color-on-primary-container" &&
+          fillToken === "--color-primary-container",
+      )?.stableRatio,
+    ).toBe(2.44);
+  });
+
+  it("fails unresolved, cyclic, and unsupported token values with context", () => {
+    expect(() =>
+      resolveCssColor(
+        "factory-light",
+        "--color-missing",
+        createVariableReader({}),
+      ),
+    ).toThrow("palette=factory-light token=--color-missing");
+
+    expect(() =>
+      resolveCssColor(
+        "factory-light",
+        "--color-cycle-a",
+        createVariableReader({
+          "--color-cycle-a": "var(--color-cycle-b)",
+          "--color-cycle-b": "var(--color-cycle-a)",
+        }),
+      ),
+    ).toThrow("palette=factory-light token=--color-cycle-a");
+
+    expect(() =>
+      resolveCssColor(
+        "factory-light",
+        "--color-unsupported",
+        createVariableReader({
+          "--color-unsupported": "color(display-p3 1 0 0)",
+        }),
+      ),
+    ).toThrow("palette=factory-light token=--color-unsupported");
+  });
+});

--- a/ui/src/styles/palette-contrast-test-math.ts
+++ b/ui/src/styles/palette-contrast-test-math.ts
@@ -1,0 +1,281 @@
+export type RgbColor = readonly [red: number, green: number, blue: number];
+
+export interface ParsedCssColor {
+  alpha: number;
+  rgb: RgbColor;
+}
+
+export interface CssVariableReader {
+  getPropertyValue(name: string): string;
+}
+
+function resolutionError(
+  paletteId: string,
+  tokenName: string,
+  reason: string,
+): Error {
+  return new Error(
+    `Unable to resolve palette=${paletteId} token=${tokenName}: ${reason}`,
+  );
+}
+
+function resolveCssVariables(
+  value: string,
+  reader: CssVariableReader,
+  paletteId: string,
+  tokenName: string,
+  variableStack: readonly string[] = [],
+): string {
+  const variableMatch = value.match(
+    /var\(\s*(--[\w-]+)(?:\s*,\s*([^)]*))?\s*\)/,
+  );
+  if (!variableMatch?.[1]) {
+    return value;
+  }
+
+  const variableName = variableMatch[1];
+  if (variableStack.includes(variableName)) {
+    throw resolutionError(
+      paletteId,
+      tokenName,
+      `cyclic var() reference (${[...variableStack, variableName].join(" -> ")})`,
+    );
+  }
+
+  const referencedValue = reader.getPropertyValue(variableName).trim();
+  const fallbackValue = variableMatch[2]?.trim();
+  const replacement = referencedValue || fallbackValue;
+  if (!replacement) {
+    throw resolutionError(
+      paletteId,
+      tokenName,
+      `missing value for ${variableName}`,
+    );
+  }
+
+  const resolvedReplacement = resolveCssVariables(
+    replacement,
+    reader,
+    paletteId,
+    tokenName,
+    [...variableStack, variableName],
+  );
+  return resolveCssVariables(
+    value.replace(variableMatch[0], resolvedReplacement),
+    reader,
+    paletteId,
+    tokenName,
+    variableStack,
+  );
+}
+
+function parseAlpha(
+  value: string,
+  paletteId: string,
+  tokenName: string,
+): number {
+  const numericValue = value.endsWith("%") ? value.slice(0, -1) : value;
+  if (!numericValue.trim()) {
+    throw resolutionError(
+      paletteId,
+      tokenName,
+      `invalid alpha component ${value}`,
+    );
+  }
+  const parsedValue = Number(numericValue);
+  const alpha = value.endsWith("%") ? parsedValue / 100 : parsedValue;
+  if (!Number.isFinite(alpha) || alpha < 0 || alpha > 1) {
+    throw resolutionError(
+      paletteId,
+      tokenName,
+      `invalid alpha component ${value}`,
+    );
+  }
+  return alpha;
+}
+
+function parseChannel(
+  value: string,
+  paletteId: string,
+  tokenName: string,
+): number {
+  const numericValue = value.endsWith("%") ? value.slice(0, -1) : value;
+  if (!numericValue.trim()) {
+    throw resolutionError(
+      paletteId,
+      tokenName,
+      `invalid RGB channel component ${value}`,
+    );
+  }
+  const parsedValue = Number(numericValue);
+  const channel = value.endsWith("%") ? (parsedValue / 100) * 255 : parsedValue;
+  if (!Number.isFinite(channel) || channel < 0 || channel > 255) {
+    throw resolutionError(
+      paletteId,
+      tokenName,
+      `invalid RGB channel component ${value}`,
+    );
+  }
+  return channel;
+}
+
+function parseCssColor(
+  paletteId: string,
+  tokenName: string,
+  rawValue: string,
+): ParsedCssColor {
+  const value = rawValue.trim().replace(/\s+/g, " ");
+  if (!value) {
+    throw resolutionError(paletteId, tokenName, "empty value");
+  }
+
+  const hexMatch = value.match(/^#([0-9a-f]+)$/i);
+  if (hexMatch?.[1] && [3, 4, 6, 8].includes(hexMatch[1].length)) {
+    const hex =
+      hexMatch[1].length <= 4
+        ? [...hexMatch[1]].map((digit) => `${digit}${digit}`).join("")
+        : hexMatch[1];
+    const channels = [
+      Number.parseInt(hex.slice(0, 2), 16),
+      Number.parseInt(hex.slice(2, 4), 16),
+      Number.parseInt(hex.slice(4, 6), 16),
+    ] as const;
+    const alpha =
+      hex.length === 8 ? Number.parseInt(hex.slice(6, 8), 16) / 255 : 1;
+    return { alpha, rgb: channels };
+  }
+
+  const relativeRgbMatch = value.match(
+    /^rgb\( from (.+?) r g b(?: \/ (.+?))? \)$/i,
+  );
+  if (relativeRgbMatch?.[1]) {
+    const source = parseCssColor(paletteId, tokenName, relativeRgbMatch[1]);
+    return {
+      alpha:
+        relativeRgbMatch[2] === undefined
+          ? source.alpha
+          : parseAlpha(relativeRgbMatch[2], paletteId, tokenName),
+      rgb: source.rgb,
+    };
+  }
+
+  const functionMatch = value.match(/^(rgba?)\((.*)\)$/i);
+  if (functionMatch?.[1] && functionMatch[2] !== undefined) {
+    const functionName = functionMatch[1].toLowerCase();
+    const sections = functionMatch[2].split("/");
+    if (sections.length > 2) {
+      throw resolutionError(
+        paletteId,
+        tokenName,
+        `unsupported color value ${rawValue}`,
+      );
+    }
+
+    const components = sections[0]
+      .replaceAll(",", " ")
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean);
+    let alphaValue = sections[1]?.trim();
+    if (
+      alphaValue === undefined &&
+      functionName === "rgba" &&
+      components.length === 4
+    ) {
+      alphaValue = components.pop() ?? "";
+    }
+    if (components.length !== 3) {
+      throw resolutionError(
+        paletteId,
+        tokenName,
+        `unsupported color value ${rawValue}`,
+      );
+    }
+    return {
+      alpha:
+        alphaValue === undefined
+          ? 1
+          : parseAlpha(alphaValue, paletteId, tokenName),
+      rgb: components.map((component) =>
+        parseChannel(component, paletteId, tokenName),
+      ) as unknown as RgbColor,
+    };
+  }
+
+  throw resolutionError(
+    paletteId,
+    tokenName,
+    `unsupported or unparseable value ${rawValue}`,
+  );
+}
+
+export function resolveCssColor(
+  paletteId: string,
+  tokenName: string,
+  reader: CssVariableReader,
+): ParsedCssColor {
+  const rawValue = reader.getPropertyValue(tokenName).trim();
+  if (!rawValue) {
+    throw resolutionError(paletteId, tokenName, "missing value");
+  }
+  const resolvedValue = resolveCssVariables(
+    rawValue,
+    reader,
+    paletteId,
+    tokenName,
+  );
+  return parseCssColor(paletteId, tokenName, resolvedValue);
+}
+
+export function compositeOver(
+  foreground: ParsedCssColor,
+  background: RgbColor,
+): RgbColor {
+  if (foreground.alpha === 1) {
+    return foreground.rgb;
+  }
+  return foreground.rgb.map(
+    (channel, index) =>
+      channel * foreground.alpha + background[index] * (1 - foreground.alpha),
+  ) as unknown as RgbColor;
+}
+
+export function resolveFillRgb(
+  fillToken: string,
+  fill: ParsedCssColor,
+  surfaceRgb: RgbColor,
+): RgbColor {
+  if (fillToken.endsWith("-container")) {
+    return compositeOver(fill, surfaceRgb);
+  }
+  return fill.alpha === 1 ? fill.rgb : compositeOver(fill, surfaceRgb);
+}
+
+function relativeLuminance([red, green, blue]: RgbColor): number {
+  const linearChannels = [red, green, blue].map((channel) => {
+    const scaled = channel / 255;
+    return scaled <= 0.03928
+      ? scaled / 12.92
+      : ((scaled + 0.055) / 1.055) ** 2.4;
+  });
+  return (
+    0.2126 * linearChannels[0] +
+    0.7152 * linearChannels[1] +
+    0.0722 * linearChannels[2]
+  );
+}
+
+export function contrastRatio(
+  foreground: RgbColor,
+  background: RgbColor,
+): number {
+  const foregroundLuminance = relativeLuminance(foreground);
+  const backgroundLuminance = relativeLuminance(background);
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance);
+  const darker = Math.min(foregroundLuminance, backgroundLuminance);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+export function stableRatio(ratio: number, precision: number): number {
+  return Number(ratio.toFixed(precision));
+}


### PR DESCRIPTION
{
  "project": "Measure Every Color Role Pair Across All Five Palettes",
  "branchName": "uicolor-palette-contrast-contract",
  "description": "Add a test-only WCAG 2.x contrast instrument that measures 21 semantic foreground/fill role pairs across all five dashboard palettes, prints all 105 results, and ratchets the 16 known sub-4.5 results without changing CSS, components, palette values, runtime behavior, or rendered pixels.",
  "context": {
    "customerAsk": "Add a new Vitest contrast test under ui/src/styles/ and a checked-in baseline that measure every specified semantic on-role/fill pairing across factory-dark, factory-light, material-baseline, slate, and olive. Correctly composite alpha-based container fills over --color-surface, fail loudly on unparseable values, prevent new contrast debt, force improvements to tighten the baseline, demonstrate the guard with a temporary reverted CSS mutation, and make zero rendered-pixel changes.",
    "problem": "The dashboard's Material and text role tokens were tuned as a Factory Dark baseline while four other palettes swap their foundation colors. The only existing contrast assertion measures a palette-invariant accent pair at 10.19:1, so it cannot detect palette-specific regressions. Direct measurement finds 16 of the required 105 role/palette cells below 4.5:1, including 9 in factory-light and a 2.44 minimum for on-primary-container against primary-container.",
    "solution": "Use the established happy-dom compiled-style test pattern and canonical COLOR_PALETTE_IDS list to resolve all 21 required role pairs per palette, composite translucent fills over the resolved surface, calculate contrast with the existing WCAG math, and emit a complete deterministic table. Check every result against a human-readable 16-entry debt baseline: unbaselined failures below 4.5 fail, regressions below a recorded value fail, meaningful improvements also fail until the entry is tightened or removed, and every parse or completeness error is fatal."
  },
  "acceptanceCriteria": [
    "On the unchanged current tree, cd ui && npx vitest run src/styles/ exits 0 after the new instrument prints a table of exactly 105 measured role/palette cells: 21 named pairs for every value in COLOR_PALETTE_IDS. The checked-in baseline contains exactly 16 below-4.5 entries, exactly 9 belong to factory-light after required alpha compositing over --color-surface, and --color-on-primary-container / --color-primary-container for factory-light is recorded at 2.44.",
    "The ratchet rejects every new unbaselined result below 4.5 and rejects every baselined result that improves beyond its recorded ratio, with an instruction to lower or remove the stale baseline entry. Every failure diagnostic names the palette, foreground token, fill token, measured ratio, and required floor.",
    "Each translucent *-container fill is composited over the resolved --color-surface before contrast is calculated. Missing, cyclic, unsupported, or otherwise unparseable token values fail loudly with the palette and token identity; no required cell may be skipped or omitted from the table.",
    "The five --color-on-surface-disabled results are baselined with a comment documenting the WCAG 1.4.3 disabled-control exemption and clarifying that these entries are not repair obligations. All other baseline entries represent measured current debt rather than exemptions.",
    "The final diff is limited to the new contrast test, its baseline, and an optional shared test-only color-math module needed to reuse the established WCAG calculation. It changes no .css file, component, palette hex, ui/scripts/check-semantic-color-tokens.ts, .storybook/preview.ts, generated artifact, runtime behavior, or rendered pixel. A temporary one-step lightening of --color-af-foundation-warning-ink in factory-light makes the test exit non-zero naming the palette, pair, ratio, and floor; after exact CSS restoration the test exits 0, and both outputs are posted in the PR conversation rather than committed.",
    "Quality gate: Typecheck passes; cd ui && npx vitest run src/styles/ passes with property-specific output confirming all 105 cells and the 16-entry baseline; and no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. make ui-lint is run, and inherited main failures outside this lane are diagnosed rather than fixed by widening scope.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The worker/reviewer cycle continues through the review-owned outcomes until the PR is actually merged; a PR that is merely open, green, approved, or ready to merge is not complete."
  ],
  "userStories": [
    {
      "id": "uicolor-palette-contrast-contract-001",
      "title": "Enforce the exhaustive palette contrast ratchet",
      "description": "As a dashboard maintainer, I want every supported semantic foreground/fill role pairing measured for every palette so that new contrast debt cannot hide behind a palette-invariant assertion and existing debt can only improve.",
      "acceptanceCriteria": [
        "The instrument applies each entry from COLOR_PALETTE_IDS and measures these 21 pairs: on-surface/surface, on-surface-variant/surface, on-surface-subtle/surface, on-surface-disabled/surface, on-surface/background, on-surface-subtle/background, code/surface, on-primary/primary, on-primary-container/primary-container, on-secondary/secondary, on-secondary-container/secondary-container, on-tertiary/tertiary, on-tertiary-container/tertiary-container, on-success/success, on-success-container/success-container, on-warning/warning, on-warning-container/warning-container, on-error/error, on-error-container/error-container, on-info/info, and on-info-container/info-container.",
        "One successful run on the unchanged tree emits a complete 105-row table and reports exactly 16 baselined sub-4.5 cells, exactly 9 for factory-light after required alpha compositing over --color-surface, including factory-light on-primary-container/primary-container at 2.44.",
        "Opaque foregrounds and fills resolve to measurable colors, and each alpha-based container fill is composited over the palette's resolved surface before its ratio is calculated.",
        "An unresolved, cyclic, unsupported, empty, or unparseable value fails the run with palette and token context; the test never skips a required cell or treats absence of measurement as success.",
        "An unbaselined ratio below 4.5 fails with palette, both token names, measured ratio, and required floor. A baselined ratio better than its recorded value also fails and tells the author to lower or remove the entry so the baseline can only tighten.",
        "The baseline contains only the 16 measured current failures. Its five on-surface-disabled entries include a comment explaining the WCAG 1.4.3 disabled-control exemption; all recorded ratios use stable precision that detects a real improvement without failing from insignificant floating-point noise.",
        "A temporary one-step lightening of factory-light --color-af-foundation-warning-ink makes the focused run fail non-zero with the affected palette, pair, measured ratio, and floor. After restoring the CSS byte-for-byte, the run exits 0; before/after output is placed in the PR conversation and the temporary mutation is absent from the final diff.",
        "The final diff changes no .css file, component, palette hex, semantic-token checker, Storybook preview, runtime contract, or rendered UI output.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
    "notes": "Implementation commit fa461a433 is green for the unchanged tree: the focused run measured 105 unique cells and 16 genuine sub-4.5 results with a 3/9/2/1/1 palette distribution. Factory-light --color-on-primary-container / --color-primary-container is 2.44; --color-on-warning-container / --color-warning-container is 4.88 after the required 0.14-alpha fill is composited over --color-surface (#ffffff), while its uncomposited ratio would be 1.84. The factory-light count is corrected to 9 because adding the above-floor 4.88 cell would violate the explicit compositing and measured-current-debt rules. Typecheck and make ui-lint pass. The temporary #96651f warning-ink mutation failed at 4.38 with palette/pair/floor context and was restored byte-for-byte. No PR existed before this iteration and no review feedback is pending."
    }
  ]
}
