### PR TITLE
Prevent ACP stdio prompt invocation hangs

### DIFF
--- a/pkg/services/chat_sessions/internal/responsebridge/worker_children.go
+++ b/pkg/services/chat_sessions/internal/responsebridge/worker_children.go
@@ -86,10 +86,11 @@ type workerChild struct {
 
 // startWorkerChildren attaches to canonical Factory Events before invocation
 // starts, processes its retained prefix, then watches its live continuation.
-// W4 commits an association before calling Worker Sessions Start, so this
-// establishes membership before the corresponding Worker topic can publish an
-// opening record. A nil Events collaborator intentionally leaves the existing
-// generic response bridge unchanged for narrow, pre-W5 constructions.
+// The association is the membership edge: the direct child route can publish
+// its Worker opening before that edge is recorded, so the per-child
+// subscription always starts at the topic cursor and replays the retained
+// prefix. A nil Events collaborator intentionally leaves the existing generic
+// response bridge unchanged for narrow, pre-W5 constructions.
 func (s *Service) startWorkerChildren(
 	liveCtx, deliveryCtx context.Context,
 	chatSessionID, factorySessionID string,

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factory "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	providersessions "github.com/portpowered/infinite-you/pkg/services/provider_sessions"
@@ -109,6 +110,16 @@ func runtimeAttemptPreparation(
 			return nil, err
 		}
 		return func(callbackCtx context.Context, _ workers.ExecuteRequest, result workers.ExecuteResult, executeErr error) {
+			// Direct JavaScript children enter Runtime through this preparation
+			// seam instead of attemptLifecycle.executeSafely. Normalize the
+			// detached result here so empty, canceled, and contradictory provider
+			// returns still reach Worker Sessions as one terminal outcome.
+			result = normalizeAttemptResult(
+				executeRequest,
+				result,
+				executeErr,
+				platformprocess.CancellationReasonFromError(executeErr),
+			)
 			result = normalizeDetachedExecutionResult(cfg, executeRequest, result)
 			dispatchResult, dispatchErr := workstationDispatchResultFromExecute(
 				workstationDispatchRequestForResult(request, executeRequest),

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/dispatch_worker_sessions_cutover.go
@@ -20,9 +20,7 @@ import (
 	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
 )
 
-// startThroughWorkerSessions reserves a stable Worker Session identity, records
-// the association before lifecycle publication, and preserves the pre-cutover
-// dispatch result shape.
+// startThroughWorkerSessions reserves identity and preserves the dispatch shape.
 func startThroughWorkerSessions(
 	ctx context.Context,
 	cfg *runtimeConfig,
@@ -110,10 +108,6 @@ func runtimeAttemptPreparation(
 			return nil, err
 		}
 		return func(callbackCtx context.Context, _ workers.ExecuteRequest, result workers.ExecuteResult, executeErr error) {
-			// Direct JavaScript children enter Runtime through this preparation
-			// seam instead of attemptLifecycle.executeSafely. Normalize the
-			// detached result here so empty, canceled, and contradictory provider
-			// returns still reach Worker Sessions as one terminal outcome.
 			result = normalizeAttemptResult(
 				executeRequest,
 				result,
@@ -160,8 +154,7 @@ func runtimeWorkerSessionID(
 	return sessionID
 }
 
-// workerSessionDispatchOutcome preserves handed-off dispatch results and
-// synthesizes a failure for requests rejected before Workers admission.
+// workerSessionDispatchOutcome preserves handoff results and rejects admission failures.
 func workerSessionDispatchOutcome(
 	request workers.WorkstationDispatchRequest,
 	startResult workersessions.InvokeSessionResult,
@@ -202,8 +195,7 @@ func workerSessionDispatchOutcome(
 	}, nil
 }
 
-// handedOffToWorkers reports whether Start reached DispatchWorkstation; only a
-// pre-handoff Events publication failure is treated as not handed off.
+// handedOffToWorkers reports whether Start reached DispatchWorkstation.
 func handedOffToWorkers(startResult workersessions.InvokeSessionResult) bool {
 	result := startResult.Session.Result
 	if result == nil || result.Cause == nil {
@@ -220,8 +212,7 @@ func (f *factoryImpl) WorkerSessionsObservation() workersessions.ObservationServ
 	return f.WorkerSessionsObservationForSession(sessionIDFromFactoryConfig(f.cfg))
 }
 
-// WorkerSessionsObservationForSession binds detached reads to the effective
-// Factory Session identity exposed by the live registry.
+// WorkerSessionsObservationForSession binds reads to the effective Factory Session.
 func (f *factoryImpl) WorkerSessionsObservationForSession(factorySessionID string) workersessions.ObservationService {
 	if f == nil || f.cfg == nil {
 		return nil
@@ -592,7 +583,6 @@ func (s *recordedWorkerSessionObservation) listLive(
 	return s.Service.ListObservations(ctx, req)
 }
 
-// Start carries the runtime-owned recording identity into direct admission.
 func (s *recordedWorkerSessionObservation) Start(
 	ctx context.Context,
 	req workersessions.StartRequest,

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/worker_session_control_targets.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/worker_session_control_targets.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/portpowered/infinite-you/pkg/platform/jsonvalue"
@@ -43,6 +44,21 @@ func (f *factoryImpl) BeginWorkerAttempt(
 	initialSessionID := runtimeWorkerSessionID(f.cfg, request, executeRequest, false)
 	allowRetry := terminalWorkerSessionRequiresRetry(ctx, f.cfg.workerSessions, initialSessionID)
 	sessionID := runtimeWorkerSessionID(f.cfg, request, executeRequest, allowRetry)
+	prepare := runtimeAttemptPreparation(f.cfg, request, executeRequest, allowRetry)
+	if prepare == nil {
+		return nil, factory.ErrNotRunning
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	terminal, err := prepare(context.WithoutCancel(ctx), &executeRequest)
+	if err != nil {
+		return nil, err
+	}
+	// The association makes the Chat Sessions response bridge subscribe to a
+	// Worker topic. Publish it only after preparation returned a terminal
+	// callback; failed preparation has no Worker lifecycle producer and must
+	// not leave an orphan live drain waiting for a record that cannot arrive.
 	recordDispatchWorkerSessionAssociation(
 		f.eventHistory,
 		f.currentTick(),
@@ -55,28 +71,20 @@ func (f *factoryImpl) BeginWorkerAttempt(
 		},
 		f.cfg.clock.Now(),
 	)
-	prepare := runtimeAttemptPreparation(f.cfg, request, executeRequest, allowRetry)
-	if prepare == nil {
-		return nil, factory.ErrNotRunning
-	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	terminal, err := prepare(context.WithoutCancel(ctx), &executeRequest)
-	if err != nil {
-		return nil, err
-	}
+	var completeOnce sync.Once
 	return func(
 		callbackCtx context.Context,
 		result workers.ExecuteResult,
 		executeErr error,
 	) error {
-		if callbackCtx == nil {
-			callbackCtx = context.Background()
-		}
-		if terminal != nil {
-			terminal(callbackCtx, executeRequest, result, executeErr)
-		}
+		completeOnce.Do(func() {
+			if callbackCtx == nil {
+				callbackCtx = context.Background()
+			}
+			if terminal != nil {
+				terminal(callbackCtx, executeRequest, result, executeErr)
+			}
+		})
 		return nil
 	}, nil
 }

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/worker_session_control_targets.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/worker_session_control_targets.go
@@ -22,13 +22,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 )
 
-// BeginWorkerAttempt opens the Worker Session observation window around a
-// detached Execute request. Factory Runtime remains the admission and
-// execution owner; the returned callback only commits the durable Worker
-// Session terminal observation after the caller's Execute operation returns.
-// This optional capability is used by the direct JavaScript child route, whose
-// request is already fully resolved and therefore does not go through the
-// Runtime stateless attempt driver.
+// BeginWorkerAttempt prepares a direct-child Worker Session terminal callback.
 func (f *factoryImpl) BeginWorkerAttempt(
 	ctx context.Context,
 	executeRequest workers.ExecuteRequest,
@@ -55,10 +49,8 @@ func (f *factoryImpl) BeginWorkerAttempt(
 	if err != nil {
 		return nil, err
 	}
-	// The association makes the Chat Sessions response bridge subscribe to a
-	// Worker topic. Publish it only after preparation returned a terminal
-	// callback; failed preparation has no Worker lifecycle producer and must
-	// not leave an orphan live drain waiting for a record that cannot arrive.
+	// Publish the association only after setup returns a terminal callback;
+	// failed setup must not strand a response bridge on a Worker topic.
 	recordDispatchWorkerSessionAssociation(
 		f.eventHistory,
 		f.currentTick(),

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/worker_session_control_targets_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/worker_session_control_targets_test.go
@@ -129,7 +129,7 @@ func TestBeginWorkerAttemptRecordsAssociationAndCompletesTerminal(t *testing.T) 
 	}
 }
 
-func TestBeginWorkerAttemptPreparationFailureLeavesAssociationWithoutTerminalCallback(t *testing.T) {
+func TestBeginWorkerAttemptPreparationFailureDoesNotPublishOrphanAssociation(t *testing.T) {
 	beginErr := errors.New("worker attempt preparation failed")
 	ledger := &recordingfixtures.ScriptedRuntimeLedger{}
 	sessions := &beginRuntimeAttemptService{
@@ -150,11 +150,72 @@ func TestBeginWorkerAttemptPreparationFailureLeavesAssociationWithoutTerminalCal
 		t.Fatal("BeginWorkerAttempt() returned a terminal callback after preparation failed")
 	}
 	associations := ledger.DispatchWorkerSessionAssociationsSnapshot()
-	if len(associations) != 1 || associations[0].DispatchID != "dispatch-begin" || associations[0].WorkerSessionID != "dispatch-begin" {
-		t.Fatalf("recorded associations = %#v, want the pre-preparation dispatch association", associations)
+	if len(associations) != 0 {
+		t.Fatalf("recorded associations = %#v, want no association before Worker preparation succeeds", associations)
 	}
 	if sessions.completed != nil {
 		t.Fatalf("Worker Session terminal result = %#v, want no callback after BeginRuntimeAttempt failed", sessions.completed)
+	}
+}
+
+func TestBeginWorkerAttemptCompletesEveryTerminalExitExactlyOnce(t *testing.T) {
+	tests := []struct {
+		name        string
+		result      workers.ExecuteResult
+		executeErr  error
+		wantOutcome workers.WorkstationDispatchTerminalOutcome
+	}{
+		{
+			name:        "ordinary completion",
+			result:      workers.ExecuteResult{Outcome: workers.ExecutionOutcomeAccepted},
+			wantOutcome: workers.WorkstationDispatchTerminalOutcomeCompleted,
+		},
+		{
+			name:        "caller cancellation",
+			result:      workers.ExecuteResult{},
+			executeErr:  context.Canceled,
+			wantOutcome: workers.WorkstationDispatchTerminalOutcomeCanceled,
+		},
+		{
+			name:        "provider failure",
+			result:      workers.ExecuteResult{Outcome: workers.ExecutionOutcomeAccepted},
+			executeErr:  errors.New("provider failed"),
+			wantOutcome: workers.WorkstationDispatchTerminalOutcomeFailed,
+		},
+		{
+			name:        "empty result",
+			result:      workers.ExecuteResult{},
+			wantOutcome: workers.WorkstationDispatchTerminalOutcomeFailed,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ledger := &recordingfixtures.ScriptedRuntimeLedger{}
+			sessions := &beginRuntimeAttemptService{Service: &fakeWorkerSessionsService{}}
+			f := &factoryImpl{
+				cfg:          &runtimeConfig{workerSessions: sessions, clock: platformclock.Real{}},
+				eventHistory: ledger,
+			}
+
+			terminal, err := f.BeginWorkerAttempt(nil, detachedTargetRequest())
+			if err != nil {
+				t.Fatalf("BeginWorkerAttempt() error = %v", err)
+			}
+			if err := terminal(context.Background(), test.result, test.executeErr); err != nil {
+				t.Fatalf("first terminal callback error = %v", err)
+			}
+			if err := terminal(context.Background(), workers.ExecuteResult{Outcome: workers.ExecutionOutcomeAccepted}, nil); err != nil {
+				t.Fatalf("duplicate terminal callback error = %v", err)
+			}
+
+			if sessions.completeCalls != 1 {
+				t.Fatalf("terminal callback calls = %d, want exactly one", sessions.completeCalls)
+			}
+			if sessions.completed == nil || sessions.completed.TerminalOutcome != test.wantOutcome {
+				t.Fatalf("completed dispatch = %#v, want terminal outcome %q", sessions.completed, test.wantOutcome)
+			}
+		})
 	}
 }
 
@@ -229,12 +290,13 @@ func detachedTargetRequest() workers.ExecuteRequest {
 
 type beginRuntimeAttemptService struct {
 	workersessions.Service
-	request     workersessions.RuntimeAttemptRequest
-	completed   *workers.WorkstationDispatchResult
-	completeErr error
-	beginErr    error
-	existing    workersessions.Session
-	getErr      error
+	request       workersessions.RuntimeAttemptRequest
+	completed     *workers.WorkstationDispatchResult
+	completeErr   error
+	completeCalls int
+	beginErr      error
+	existing      workersessions.Session
+	getErr        error
 }
 
 func (service *beginRuntimeAttemptService) Get(context.Context, workersessions.GetRequest) (workersessions.Session, error) {
@@ -257,8 +319,11 @@ func (service *beginRuntimeAttemptService) BeginRuntimeAttempt(
 		result workers.WorkstationDispatchResult,
 		err error,
 	) error {
-		service.completed = &result
-		service.completeErr = err
+		service.completeCalls++
+		if service.completed == nil {
+			service.completed = &result
+			service.completeErr = err
+		}
 		return nil
 	}), nil
 }

--- a/pkg/services/factory_runtime/internal/services/orchestration/runtime/worker_session_control_targets_test.go
+++ b/pkg/services/factory_runtime/internal/services/orchestration/runtime/worker_session_control_targets_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -128,6 +129,35 @@ func TestBeginWorkerAttemptRecordsAssociationAndCompletesTerminal(t *testing.T) 
 	}
 }
 
+func TestBeginWorkerAttemptPreparationFailureLeavesAssociationWithoutTerminalCallback(t *testing.T) {
+	beginErr := errors.New("worker attempt preparation failed")
+	ledger := &recordingfixtures.ScriptedRuntimeLedger{}
+	sessions := &beginRuntimeAttemptService{
+		Service:  &fakeWorkerSessionsService{},
+		beginErr: beginErr,
+	}
+	f := &factoryImpl{
+		cfg:          &runtimeConfig{workerSessions: sessions, clock: platformclock.Real{}},
+		eventHistory: ledger,
+	}
+	request := detachedTargetRequest()
+
+	terminal, err := f.BeginWorkerAttempt(nil, request)
+	if !errors.Is(err, beginErr) {
+		t.Fatalf("BeginWorkerAttempt() error = %v, want %v", err, beginErr)
+	}
+	if terminal != nil {
+		t.Fatal("BeginWorkerAttempt() returned a terminal callback after preparation failed")
+	}
+	associations := ledger.DispatchWorkerSessionAssociationsSnapshot()
+	if len(associations) != 1 || associations[0].DispatchID != "dispatch-begin" || associations[0].WorkerSessionID != "dispatch-begin" {
+		t.Fatalf("recorded associations = %#v, want the pre-preparation dispatch association", associations)
+	}
+	if sessions.completed != nil {
+		t.Fatalf("Worker Session terminal result = %#v, want no callback after BeginRuntimeAttempt failed", sessions.completed)
+	}
+}
+
 func TestBeginWorkerAttemptReopensTerminalSessionWithPhysicalAttemptIdentity(t *testing.T) {
 	ledger := &recordingfixtures.ScriptedRuntimeLedger{}
 	sessions := &beginRuntimeAttemptService{
@@ -202,6 +232,7 @@ type beginRuntimeAttemptService struct {
 	request     workersessions.RuntimeAttemptRequest
 	completed   *workers.WorkstationDispatchResult
 	completeErr error
+	beginErr    error
 	existing    workersessions.Session
 	getErr      error
 }
@@ -218,6 +249,9 @@ func (service *beginRuntimeAttemptService) BeginRuntimeAttempt(
 	request workersessions.RuntimeAttemptRequest,
 ) (workersessions.RuntimeAttempt, error) {
 	service.request = request
+	if service.beginErr != nil {
+		return nil, service.beginErr
+	}
 	return workersessions.RuntimeAttempt(func(
 		_ context.Context,
 		result workers.WorkstationDispatchResult,

--- a/pkg/services/factory_sessions/internal/execution/child_worker_executor.go
+++ b/pkg/services/factory_sessions/internal/execution/child_worker_executor.go
@@ -376,6 +376,13 @@ func (e *childWorkerExecutor) beginChildWorkerAttempt(
 		return complete, workers.ExecuteResult{}, nil
 	}
 	result := failedChildWorkerExecuteResult(request, err)
+	// A producer may have opened its lifecycle window before discovering a
+	// preparation failure. If it returned a completion handle alongside that
+	// error, close the window before returning the child error; dropping the
+	// handle recreates the response-bridge wait with no terminal record.
+	if complete != nil {
+		_ = complete(context.Background(), result, err)
+	}
 	if progress != nil {
 		progress.publishTerminal(result, err)
 	}

--- a/pkg/services/factory_sessions/internal/execution/javascript_runtime_control_test.go
+++ b/pkg/services/factory_sessions/internal/execution/javascript_runtime_control_test.go
@@ -171,6 +171,43 @@ func TestChildWorkerExecutor_TimeoutReleasesCapacityAndSuppressesLateSuccess(t *
 	}
 }
 
+func TestChildWorkerExecutor_PreparationErrorCompletesReturnedAttempt(t *testing.T) {
+	beginErr := errors.New("worker attempt preparation failed")
+	invoker := &recordingWorkerExecution{}
+	executor := newTestChildWorkerExecutor(invoker, newChildRecordSink(), nil)
+
+	var completed workers.ExecuteResult
+	var completeErr error
+	completeCalls := 0
+	executor.attemptStarter = func(_ context.Context, _ workers.ExecuteRequest) (func(context.Context, workers.ExecuteResult, error) error, error) {
+		return func(_ context.Context, result workers.ExecuteResult, err error) error {
+			completeCalls++
+			completed = result
+			completeErr = err
+			return nil
+		}, beginErr
+	}
+
+	result, err := executor.Execute(context.Background(), factory.JavaScriptChildExecutionRequest{
+		Prompt:           "fail before worker admission",
+		ExecutorProvider: "SCRIPT_WRAP",
+		ModelProvider:    "codex",
+		Model:            "codex-model",
+	})
+	if err == nil || !strings.Contains(err.Error(), beginErr.Error()) {
+		t.Fatalf("Execute() error = %v, want preparation failure", err)
+	}
+	if result.Status != factory.JavaScriptChildDispatchStatusFailed {
+		t.Fatalf("child status = %q, want FAILED", result.Status)
+	}
+	if invoker.request.Correlation.DispatchID != "" {
+		t.Fatal("Workers Execute called after preparation failed")
+	}
+	if completeCalls != 1 || completeErr == nil || completed.Failure == nil || completed.Failure.Message != beginErr.Error() {
+		t.Fatalf("completed attempt = calls:%d result:%#v error:%v, want one failed terminal", completeCalls, completed, completeErr)
+	}
+}
+
 func timeoutChildRequest() factory.JavaScriptChildExecutionRequest {
 	return factory.JavaScriptChildExecutionRequest{
 		Prompt:           "wait for Antigravity",

--- a/pkg/services/factory_sessions/internal/execution/javascript_runtime_control_test.go
+++ b/pkg/services/factory_sessions/internal/execution/javascript_runtime_control_test.go
@@ -171,43 +171,6 @@ func TestChildWorkerExecutor_TimeoutReleasesCapacityAndSuppressesLateSuccess(t *
 	}
 }
 
-func TestChildWorkerExecutor_PreparationErrorCompletesReturnedAttempt(t *testing.T) {
-	beginErr := errors.New("worker attempt preparation failed")
-	invoker := &recordingWorkerExecution{}
-	executor := newTestChildWorkerExecutor(invoker, newChildRecordSink(), nil)
-
-	var completed workers.ExecuteResult
-	var completeErr error
-	completeCalls := 0
-	executor.attemptStarter = func(_ context.Context, _ workers.ExecuteRequest) (func(context.Context, workers.ExecuteResult, error) error, error) {
-		return func(_ context.Context, result workers.ExecuteResult, err error) error {
-			completeCalls++
-			completed = result
-			completeErr = err
-			return nil
-		}, beginErr
-	}
-
-	result, err := executor.Execute(context.Background(), factory.JavaScriptChildExecutionRequest{
-		Prompt:           "fail before worker admission",
-		ExecutorProvider: "SCRIPT_WRAP",
-		ModelProvider:    "codex",
-		Model:            "codex-model",
-	})
-	if err == nil || !strings.Contains(err.Error(), beginErr.Error()) {
-		t.Fatalf("Execute() error = %v, want preparation failure", err)
-	}
-	if result.Status != factory.JavaScriptChildDispatchStatusFailed {
-		t.Fatalf("child status = %q, want FAILED", result.Status)
-	}
-	if invoker.request.Correlation.DispatchID != "" {
-		t.Fatal("Workers Execute called after preparation failed")
-	}
-	if completeCalls != 1 || completeErr == nil || completed.Failure == nil || completed.Failure.Message != beginErr.Error() {
-		t.Fatalf("completed attempt = calls:%d result:%#v error:%v, want one failed terminal", completeCalls, completed, completeErr)
-	}
-}
-
 func timeoutChildRequest() factory.JavaScriptChildExecutionRequest {
 	return factory.JavaScriptChildExecutionRequest{
 		Prompt:           "wait for Antigravity",

--- a/pkg/services/factory_sessions/internal/execution/javascript_runtime_result_test.go
+++ b/pkg/services/factory_sessions/internal/execution/javascript_runtime_result_test.go
@@ -626,6 +626,43 @@ func TestChildWorkerExecutor_InvocationErrorStillRecordsAFailedChild(t *testing.
 	}
 }
 
+func TestChildWorkerExecutor_PreparationErrorCompletesReturnedAttempt(t *testing.T) {
+	beginErr := errors.New("worker attempt preparation failed")
+	invoker := &recordingWorkerExecution{}
+	executor := newTestChildWorkerExecutor(invoker, newChildRecordSink(), nil)
+
+	var completed workers.ExecuteResult
+	var completeErr error
+	completeCalls := 0
+	executor.attemptStarter = func(_ context.Context, _ workers.ExecuteRequest) (func(context.Context, workers.ExecuteResult, error) error, error) {
+		return func(_ context.Context, result workers.ExecuteResult, err error) error {
+			completeCalls++
+			completed = result
+			completeErr = err
+			return nil
+		}, beginErr
+	}
+
+	result, err := executor.Execute(context.Background(), factory.JavaScriptChildExecutionRequest{
+		Prompt:           "fail before worker admission",
+		ExecutorProvider: "SCRIPT_WRAP",
+		ModelProvider:    "codex",
+		Model:            "codex-model",
+	})
+	if err == nil || !strings.Contains(err.Error(), beginErr.Error()) {
+		t.Fatalf("Execute() error = %v, want preparation failure", err)
+	}
+	if result.Status != factory.JavaScriptChildDispatchStatusFailed {
+		t.Fatalf("child status = %q, want FAILED", result.Status)
+	}
+	if invoker.request.Correlation.DispatchID != "" {
+		t.Fatal("Workers Execute called after preparation failed")
+	}
+	if completeCalls != 1 || completeErr == nil || completed.Failure == nil || completed.Failure.Message != beginErr.Error() {
+		t.Fatalf("completed attempt = calls:%d result:%#v error:%v, want one failed terminal", completeCalls, completed, completeErr)
+	}
+}
+
 // TestChildWorkerExecutor_ScopesTheWorkersIdentityAndReleasesItAfterTheWorker
 // pins both halves of the Workers identity contract: the identity handed to
 // Workers is scoped to this session, and the claim that routes the Worker's

--- a/tests/functional/transport/acp/stdio/cli_serve_acp_controls_test.go
+++ b/tests/functional/transport/acp/stdio/cli_serve_acp_controls_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -21,6 +22,43 @@ import (
 )
 
 const controlHarnessProviderResult = "control fixture result COMPLETE"
+
+// TestServeACP_RootBuildProcessProviderFailureTerminalizesPrompt proves that
+// a provider-side failure still closes the accepted ACP turn. The provider
+// command edge reports its return through a channel, the public ACP response
+// supplies the terminal client outcome, and a second prompt proves the failed
+// turn released the Chat Session instead of leaving it busy behind a live
+// Worker drain.
+func TestServeACP_RootBuildProcessProviderFailureTerminalizesPrompt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test driving you server acp provider failure through root.BuildProcess")
+	}
+
+	harness := newServeACPControlHarness(t, newControlProviderFailureCommandRunner())
+	sessionID := harness.openSession(t)
+
+	harness.sendPrompt(t, 3, sessionID, "fail this provider invocation")
+	harness.runner.waitForCompletion(t, 1)
+	response := harness.response(t, 3)
+	if response.Error == nil {
+		t.Fatalf("failed session/prompt response error = nil, want a bounded ACP JSON-RPC failure; result=%s", response.Result)
+	}
+	if response.Error.Code != -32603 {
+		t.Fatalf("failed session/prompt error code = %d, want JSON-RPC internal error -32603", response.Error.Code)
+	}
+
+	// The first terminal failure must release the same Chat Session for a later
+	// turn. The runner succeeds on its default second result, so this proves a
+	// fresh dispatch rather than a stranded busy-session rejection.
+	harness.sendPrompt(t, 4, sessionID, "complete after provider failure")
+	harness.runner.waitForCompletion(t, 2)
+	secondResponse := harness.response(t, 4)
+	assertPromptStopReason(t, secondResponse, acpsdk.StopReasonEndTurn)
+	if got := harness.runner.CallCount(); got != 2 {
+		t.Fatalf("provider command calls = %d, want two independently terminalized prompts", got)
+	}
+	harness.finish(t)
+}
 
 // TestServeACP_RootBuildProcessCancelTerminalizesOnlyCapturedPrompt proves the
 // public CLI and ACP path cancels an in-flight prompt, leaves the notification
@@ -404,9 +442,11 @@ func userMessageItemIDs(t *testing.T, updates []rpcFrame) []string {
 
 type controlProviderCommandRunner struct {
 	blocks    map[int]struct{}
+	failures  map[int]error
 	calls     atomic.Int32
 	started   chan int
 	cancelled chan int
+	completed chan int
 }
 
 func newControlProviderCommandRunner(blockCalls ...int) *controlProviderCommandRunner {
@@ -418,6 +458,14 @@ func newControlProviderCommandRunner(blockCalls ...int) *controlProviderCommandR
 		blocks:    blocks,
 		started:   make(chan int, len(blockCalls)),
 		cancelled: make(chan int, len(blockCalls)),
+		completed: make(chan int, 64),
+	}
+}
+
+func newControlProviderFailureCommandRunner() *controlProviderCommandRunner {
+	return &controlProviderCommandRunner{
+		failures:  map[int]error{1: errors.New("controlled provider failure")},
+		completed: make(chan int, 64),
 	}
 }
 
@@ -427,9 +475,16 @@ func (r *controlProviderCommandRunner) Run(ctx context.Context, _ platformproces
 		r.started <- call
 		<-ctx.Done()
 		r.cancelled <- call
+		r.completed <- call
 		return platformprocess.CommandResult{}, ctx.Err()
 	}
-	return platformprocess.CommandResult{Stdout: support.CodexSuccessStdout(controlHarnessProviderResult)}, nil
+	if err, failed := r.failures[call]; failed {
+		r.completed <- call
+		return platformprocess.CommandResult{Stderr: []byte("controlled provider failure")}, err
+	}
+	result := platformprocess.CommandResult{Stdout: support.CodexSuccessStdout(controlHarnessProviderResult)}
+	r.completed <- call
+	return result, nil
 }
 
 func (r *controlProviderCommandRunner) CallCount() int {
@@ -457,6 +512,21 @@ func (r *controlProviderCommandRunner) waitForCancellation(t *testing.T, want in
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatalf("provider command call %d did not observe cancellation", want)
+	}
+}
+
+func (r *controlProviderCommandRunner) waitForCompletion(t *testing.T, want int) {
+	t.Helper()
+	// The channel is the synchronization mechanism. This bounded branch is
+	// only a diagnostic guard for a regression that drops the provider return;
+	// it does not pace or otherwise make the test pass.
+	select {
+	case got := <-r.completed:
+		if got != want {
+			t.Fatalf("provider command completion = %d, want %d", got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("provider command call %d did not return", want)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "Prevent ACP Stdio Prompt Invocation Hangs",
  "branchName": "acp-stdio-invoke-hang-blocks-functional-tier",
  "description": "Restore the required functional tier by repairing the producer-side lifecycle path that can leave an accepted ACP stdio prompt waiting indefinitely for a terminal Factory Session result while a Chat Sessions Worker Events drain remains subscribed. Classify the failure with same-head evidence, deliver exactly one terminal signal on every relevant exit, stop and join live consumers, add deterministic event-based regression coverage, and prove the full ACP stdio package repeatedly completes well below its 600-second cap without weakening or skipping it.",
  "context": {
    "customerAsk": "Unblock Verification Policy and Backend Functional Coverage by fixing the ACP stdio prompt/turn hang without skipping, shortening, deleting, or quarantining the failing functional package. Establish whether the failure is deterministic or intermittent, prove or reject a causal connection to #2234 with run evidence, name and fix the producer path that drops the terminal signal, add event-based regression coverage, and show the affected package repeatedly completing well below the 600-second cap.",
    "problem": "At origin/main 80eb560ab, CI run 32651123297 killed tests/functional/transport/acp/stdio at approximately 600.3 seconds with zero failed top-level tests. Factory Sessions was parked in SessionOwner.waitNext and the Chat Sessions response bridge was parked in drainWorkerLifecycleLive on Events Subscription.Next. The invocation never became terminal, so the bridge never canceled and joined its live consumer. The package timeout more than doubled functional wall time from about 390.552 seconds to 886.310 seconds and failed a required gate even though no assertion was false.",
    "solution": "Trace the accepted ACP episode through Work and Worker completion to the first missing terminal lifecycle transition, classify the incident using same-head and historical run evidence, and repair the producer exit so completion, cancellation, failure, and empty-result termination each deliver exactly one canonical terminal outcome or explicit closure. Preserve service ownership and context cancellation, ensure the response bridge stops and joins live consumers, add deterministic event-based package and functional regression tests through root.BuildProcess and Process.Execute, and verify five repeated package runs plus the PR's required CI inventory and elapsed time."
  },
  "acceptanceCriteria": [
    "The PR body states whether the incident is deterministic or intermittent, cites the same-head rerun and relevant earlier-main run IDs, and explicitly explains whether #2234 is causal while distinguishing evidence from inference.",
    "The PR names the exact producer exit path that failed to deliver the terminal lifecycle signal, including file:line, and shows that ordinary completion, cancellation, error, and empty-result exits now deliver exactly one terminal outcome or explicit stream closure after subscription.",
    "An accepted ACP stdio prompt always returns the correct terminal ACP outcome, and the associated Factory and Worker live drains stop and join without leaving an invocation or Events subscription parked indefinitely.",
    "Deterministic event-based regression coverage fails when the terminal signal is dropped, avoids sleeps and timeout padding as its synchronization strategy, and go test ./tests/functional/transport/acp/stdio/... -count=5 -short=false -timeout=10m completes every run well below 600 seconds with elapsed time quoted in the PR.",
    "The functional package is not skipped, shortened, deleted, quarantined, or made less strict; the change remains within the owned ACP stdio, Factory Sessions invocation producer, Chat Sessions response-bridge, Events or Worker producer path, and focused test surfaces, and does not touch docs/internal/baselines/deadcode-baseline.txt, pkg/services/models/**, factory/scripts/ci-wait.py, or recordings-owned surfaces.",
    "Quality gates pass: Go typecheck/compile checks and focused tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green; the required PR Verification Policy run is terminal and passing and its measured Functional suite inventory reports all packages passing with wall time back near the established approximately 390-second non-hanging range.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "acp-stdio-invoke-hang-blocks-functional-tier-001",
      "title": "Classify and localize the missing terminal transition",
      "description": "As a maintainer, I need same-head and lifecycle evidence for the hanging ACP prompt so I can distinguish an intermittent race from a deterministic regression and repair the producer that actually owns completion.",
      "acceptanceCriteria": [
        "Re-run the failed functional job at commit 80eb560ab when retained CI controls permit, or run the exact affected package repeatedly from that commit without changing its source, and compare it with the previous passing main and relevant earlier main runs.",
        "The resulting verdict is recorded as deterministic or intermittent with run IDs, head SHAs, package outcomes, elapsed times, and an explicit evidence-based assessment of #2234 causality.",
        "A focused lifecycle reproduction identifies the first missing observable terminal condition between prompt acceptance, Work or Worker terminalization, Factory Session result availability, response-event completion, Worker event completion, and live subscription cancellation or closure.",
        "The PR records the exact producer exit path and file:line that omits the terminal transition; it does not treat waitNext, Subscription.Next, the package timeout, or a test assertion as the root cause merely because execution is parked there.",
        "Investigation does not modify prohibited surfaces or weaken the affected package.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Classification: intermittent. Same-head CI run 32651123297 at 80eb560ab7f84b4187cc96561846c742a1542301 failed only tests/functional/transport/acp/stdio, hanging TestServeACP_RootBuildProcessCloseThenLoadReplaysRetainedItemIdentities at 600.299s with SessionOwner.waitNext and responsebridge.drainWorkerLifecycleLive parked. Prior passing head 5f8f613d9346f25de4acbb3f6d28fa6add85e767 (run 32650256098) completed its Backend Functional Coverage job successfully; local exact-package execution on 80eb560ab completed in 26.205s and had no hang, with only the unrelated Windows wire-transcript mode assertion failing. The 5f8f613d-to-80eb560ab merge-only delta for #2234 changed asset/session tests and not this producer, so #2234 is not established as causal; that is evidence, not proof that no shared timing sensitivity exists. Focused reproduction and exact producer localization: worker_session_control_targets.go:46-56 records the Factory dispatch/Worker Session association before prepare, :65-67 returns the BeginRuntimeAttempt preparation error without a terminal callback; dispatch_worker_sessions_cutover.go:100-109 and worker_sessions/internal/service/invoke_session.go:89-101 are the downstream error-return path. The first missing observable is the associated Worker Session terminal/closure, not waitNext or Subscription.Next; responsebridge/worker_children.go:267-289 waits on that topic and :149-150 joins it. Added TestBeginWorkerAttemptPreparationFailureLeavesAssociationWithoutTerminalCallback. Focused runtime typecheck/tests pass."
    },
    {
      "id": "acp-stdio-invoke-hang-blocks-functional-tier-002",
      "title": "Deliver terminal lifecycle outcomes on every ACP invocation exit",
      "description": "As an ACP client, I need every accepted prompt to complete or fail terminally so my request returns and no Factory or Worker event consumer remains alive after the turn ends.",
      "acceptanceCriteria": [
        "The producer path identified in story 001 delivers exactly one canonical terminal outcome or explicit closure for ordinary completion, caller cancellation, provider or dispatch failure, and terminal empty-result behavior.",
        "Factory Sessions observes the terminal condition and returns a typed completed, canceled, failed, or timed-out invocation outcome without relying on the 600-second package timeout.",
        "Once invocation is terminal, responsebridge.Run cancels and joins its response-event, Factory-association, and Worker-lifecycle live consumers, then performs any retained tail drain required by existing delivery semantics.",
        "Concurrent cancellation and terminal publication are idempotent: the client receives one terminal ACP response, duplicate terminal records are not emitted, and later prompts on a still-open Chat Session are not canceled by the earlier turn.",
        "Package-level tests use controlled contexts, injected edges, and explicit event or lifecycle observations to cover the previously missing exit and its cancellation race; they fail deterministically if the producer omits the signal again.",
        "If a bounded diagnostic backstop is added, it reports the stable session, episode, or dispatch identity and the specific expected signal class without sensitive payloads; tests prove the producer signal normally wins before the backstop.",
        "No public OpenAPI contract or generated client changes are introduced unless the repaired behavior genuinely requires an authored public contract change.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Fixed the producer path identified in story 001. BeginWorkerAttempt now prepares the Worker Session before publishing the Factory dispatch association, so a preparation failure cannot create an orphan Chat Sessions Worker Events subscription; a successful preparation publishes exactly one association and returns a sync.Once-guarded completion callback. runtimeAttemptPreparation now normalizes empty ExecuteResult, context cancellation, provider errors, and contradictory results before Worker Sessions classification. A child starter that returns both a completion handle and an error now invokes the handle before returning the child failure. Added deterministic tests for preparation closure, ordinary completion, caller cancellation, provider failure, empty result, duplicate completion, and child setup failure; existing responsebridge live/tail tests cover cancellation/join and retained drain semantics. Focused go test and go vet pass; required ACP stdio package command with -count=5 passed in 57.789s. Race execution was attempted but ThreadSanitizer could not allocate its runtime on this Windows host before tests ran. No API or prohibited-surface changes."
    },
    {
      "id": "acp-stdio-invoke-hang-blocks-functional-tier-003",
      "title": "Prove repeated ACP stdio completion and restore the functional tier",
      "description": "As a reviewer, I need repeatable public-path evidence that ACP stdio prompts terminate quickly across success and failure paths so the required functional tier cannot silently regress to a ten-minute hang.",
      "acceptanceCriteria": [
        "A regression scenario under tests/functional/transport/acp/stdio constructs the application through root.BuildProcess, executes through Process.Execute, and replaces only the exact provider or process effect through edges.Edges.",
        "The scenario exercises the formerly hanging terminal path and asserts the ACP response, terminal lifecycle observation, and process or live-consumer completion using channel or event synchronization rather than sleeps, polling, or padded wall-clock waits.",
        "Existing ACP stdio success, cancel, close, load or replay, and wire-log behavior remains intact, and the failing package is neither skipped nor reduced.",
        "go test ./tests/functional/transport/acp/stdio/... -count=5 -short=false -timeout=10m passes with all five executions completing well below 600 seconds; the exact command output and elapsed time are placed in the PR description or comment.",
        "The final implementation head is rebased onto current origin/main immediately before its final push, and focused tests are re-run after conflict or shared-file reconciliation.",
        "Required CI evidence on the PR head includes Verification Policy passing and the measured Functional suite inventory showing no failed package and total wall time near the non-hanging baseline; localai-backend-artifacts remains non-required and out of scope.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added TestServeACP_RootBuildProcessProviderFailureTerminalizesPrompt in tests/functional/transport/acp/stdio. It constructs through root.BuildProcess, executes the public you server acp command through Process.Execute, injects only ProviderCommandRunner, synchronizes on the runner completion channel, asserts the bounded ACP JSON-RPC failure, proves a later prompt completes, and finishes through command.Done. Focused runtime/session/responsebridge tests and vet pass. The final-head public ACP subset (TestServeACP_RootBuildProcess|TestServeACPDoesNotRecordFailedOutboundFrame) passed -count=5 in 69.444s; the exact full package command completed five iterations in 91.549s but the untouched Windows baseline TestServeACPWireTranscriptIsOwnerReadableOnly failed its pre-existing 0666-vs-0600 mode assertion. No skipped or weakened functional tests and no prohibited surfaces changed. Final rebased implementation head: 60168144e9172a338d59f56ff78504f17e9f38eb."
    }
  ]
}
