### PR TITLE
deflake-await-continue-replay-cancellation-race

### DIFF
--- a/pkg/services/worker_sessions/internal/service/internal_test.go
+++ b/pkg/services/worker_sessions/internal/service/internal_test.go
@@ -3785,8 +3785,8 @@ func TestAwaitContinueReplayReturnsCompletedReplayAfterCallerCancellation(t *tes
 	ctxDone := make(chan struct{})
 	ctx := signaledCancellationContext{done: ctxDone}
 	go func() {
-		ctxDone <- struct{}{}
 		close(replay.done)
+		ctxDone <- struct{}{}
 	}()
 
 	result, err := awaitContinueReplay(ctx, replay)

--- a/pkg/services/worker_sessions/internal/service/internal_test.go
+++ b/pkg/services/worker_sessions/internal/service/internal_test.go
@@ -3782,7 +3782,7 @@ func TestAwaitContinueReplayReturnsCompletedReplayAfterCallerCancellation(t *tes
 		result: workersessions.ContinueResult{RequestID: "replayed"},
 		err:    replayErr,
 	}
-	ctxDone := make(chan struct{})
+	ctxDone := make(chan struct{}, 1)
 	ctx := signaledCancellationContext{done: ctxDone}
 	go func() {
 		close(replay.done)


### PR DESCRIPTION
{
  "project": "Deflake Await-Continue Replay Cancellation Preference",
  "branchName": "deflake-await-continue-replay-cancellation-race",
  "description": "Restore reliable required CI by fixing the ordering in TestAwaitContinueReplayReturnsCompletedReplayAfterCallerCancellation. Close replay.done before cancellation becomes observable so the existing test deterministically proves that an already-completed replay wins over caller cancellation, while leaving production semantics unchanged and limiting implementation to the owned Worker Sessions internal test file.",
  "context": {
    "customerAsk": "Deflake TestAwaitContinueReplayReturnsCompletedReplayAfterCallerCancellation, which intermittently fails the required backend tier on main, by establishing replay completion before signalling cancellation. Demonstrate the race at the unfixed branch point, prove zero failures at the fixed head with repeated and race-enabled runs, audit surrounding tests in the same file for the identical ordering mistake, and do not touch continue.go, another package, coverage manifests, or baselines.",
    "problem": "The test currently performs an unbuffered cancellation-channel send before closing replay.done. Once awaitContinueReplay receives the cancellation, the sender's later close and the implementation's inner non-blocking replay check are unordered. If the inner default branch runs first, the production function correctly returns an empty ContinueResult with context canceled, causing the exact intermittent failure observed in main CI run 32655212385 at commit 4b5b8aa67. The test lacks the happens-before edge required by its own assertion; production behavior is correct.",
    "solution": "In the existing regression test, close replay.done before sending the cancellation signal so replay completion happens-before cancellation observation. Preserve the assertion that the completed replay result and replay error are returned, audit only the surrounding tests in internal_test.go for the same unbuffered-send-then-close defect, and correct genuine matches in place. Prove the change with raw before/after -count=2000 and -race -count=500 results plus the complete Worker Sessions package suite, without sleeps, retries, skips, new tests, production edits, or coverage and baseline changes."
  },
  "acceptanceCriteria": [
    "When replay completion is arranged before cancellation becomes observable, awaitContinueReplay returns a clone of the completed replay result and its replay error regardless of which ready outer select arm is chosen; it does not return an empty result with context canceled in this scenario.",
    "At the unfixed branch point, go test ./pkg/services/worker_sessions/internal/service/ -run TestAwaitContinueReplayReturnsCompletedReplayAfterCallerCancellation -count=2000 and the corresponding -race -count=500 run are executed and their raw failure counts are recorded in the PR body; the known CI failure is cited if local scheduling does not reproduce a failure in a particular run.",
    "At the fixed head, the focused test reports zero failures with -count=2000 and zero failures with -race -count=500, the exact command outputs are quoted in the PR body, and go test ./pkg/services/worker_sessions/... passes.",
    "The implementation diff changes only pkg/services/worker_sessions/internal/service/internal_test.go; it does not touch continue.go, another package, coverage manifests, or baseline files, and it does not add sleeps, retries, t.Skip, t.Parallel, or add/remove tests. The PR body lists any same-shape surrounding fixes or explicitly reports no others found.",
    "Quality gate: Typecheck passes; Tests pass for the focused stress commands and go test ./pkg/services/worker_sessions/...; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. This is not a blanket requirement that make lint pass end-to-end while pkg-boundary retains the pre-existing packaged-service-structure migration debt recorded 2026-08-08.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "deflake-await-continue-replay-cancellation-race-001",
      "title": "Make completed-replay preference deterministic under cancellation",
      "description": "As a Worker Sessions maintainer, I want the existing cancellation regression test to establish replay completion before exposing cancellation so that it deterministically verifies the production contract instead of failing according to goroutine scheduling.",
      "acceptanceCriteria": [
        "The existing test closes replay.done before its cancellation signal can be received, establishing a happens-before edge from replay completion to cancellation observation.",
        "The test continues to assert the completed replay request ID and replay error, and succeeds whether the production outer select chooses the replay-ready arm or the cancellation-ready arm.",
        "The unfixed -count=2000 and -race -count=500 commands are run and raw failure counts are recorded in the PR body; the fixed head reports zero failures for both commands with exact outputs recorded in the PR body.",
        "go test ./pkg/services/worker_sessions/... passes at the fixed head.",
        "Surrounding tests in internal_test.go are checked for the same unbuffered-send-then-close ordering mistake; genuine matches are corrected in place with deterministic ordering and listed in the PR body, or the PR body states no others found.",
        "No sleeps, retries, skips, t.Parallel, new tests, deleted tests, weakened assertions, production changes, coverage changes, baseline changes, or unrelated cleanup are introduced.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented the test-only happens-before fix and addressed PR #2245 review feedback by buffering the cancellation signal so the helper goroutine cannot leak when the replay-ready arm wins. The Windows host race runtime fails before test execution with a ThreadSanitizer allocation error; the exact fixed race command passes under Ubuntu WSL.",
      "validationEvidence": {
        "unfixedFocused": {
          "command": "go test ./pkg/services/worker_sessions/internal/service/ -run TestAwaitContinueReplayReturnsCompletedReplayAfterCallerCancellation -count=2000",
          "environment": "Windows host at the unfixed branch point",
          "observedFailureCount": 1,
          "rawOutput": [
            "--- FAIL: TestAwaitContinueReplayReturnsCompletedReplayAfterCallerCancellation (0.00s)",
            "    internal_test.go:3794: awaitContinueReplay() = workersessions.ContinueResult{RequestID:\"\", SourceWorkerSessionID:\"\", SuccessorWorkerSessionID:\"\", Session:workersessions.Session{ID:\"\", State:\"\", Model:(*string)(nil), ReasoningEffort:(*string)(nil), Result:(*workersessions.TerminalResult)(nil), ProviderSessionAssociation:(*workersessions.ProviderSessionAssociation)(nil), PredecessorWorkerSessionID:\"\", SuccessorWorkerSessionID:\"\"}}, context canceled, want completed replay after cancellation",
            "FAIL",
            "FAIL github.com/portpowered/infinite-you/pkg/services/worker_sessions/internal/service 0.116s",
            "FAIL"
          ]
        },
        "unfixedRace": {
          "command": "go test ./pkg/services/worker_sessions/internal/service/ -run TestAwaitContinueReplayReturnsCompletedReplayAfterCallerCancellation -race -count=500",
          "environment": "Windows host at the unfixed branch point",
          "observedFailureCount": "not reached; ThreadSanitizer failed before test execution",
          "rawOutput": [
            "==16004==ERROR: ThreadSanitizer failed to allocate 0x000000a00000 (10485760) bytes at 0x100eca77f0000 (error code: 87)",
            "FAIL github.com/portpowered/infinite-you/pkg/services/worker_sessions/internal/service 0.046s",
            "FAIL"
          ],
          "knownCIFailure": "The race is documented in main CI run 32655212385 at commit 4b5b8aa67."
        },
        "fixedFocused": [
          {
            "command": "go test ./pkg/services/worker_sessions/internal/service/ -run TestAwaitContinueReplayReturnsCompletedReplayAfterCallerCancellation -count=2000",
            "environment": "Ubuntu WSL",
            "rawOutput": [
            "ok  github.com/portpowered/infinite-you/pkg/services/worker_sessions/internal/service 0.106s"
            ]
          },
          {
            "command": "go test ./pkg/services/worker_sessions/internal/service/ -run TestAwaitContinueReplayReturnsCompletedReplayAfterCallerCancellation -race -count=500",
            "environment": "Ubuntu WSL",
            "rawOutput": [
            "ok  github.com/portpowered/infinite-you/pkg/services/worker_sessions/internal/service 1.535s"
            ]
          }
        ],
        "packageSuite": {
          "command": "go test ./pkg/services/worker_sessions/...",
          "environment": "Ubuntu WSL",
          "rawOutput": [
            "ok  github.com/portpowered/infinite-you/pkg/services/worker_sessions (cached)",
            "ok  github.com/portpowered/infinite-you/pkg/services/worker_sessions/internal/service 0.071s",
            "ok  github.com/portpowered/infinite-you/pkg/services/worker_sessions/transports/cli (cached)",
            "?   github.com/portpowered/infinite-you/pkg/services/worker_sessions/transports/cli/worker_sessions [no test files]",
            "ok  github.com/portpowered/infinite-you/pkg/services/worker_sessions/transports/http (cached)",
            "ok  github.com/portpowered/infinite-you/pkg/services/worker_sessions/wire (cached)"
          ]
        },
        "quality": "go vet ./pkg/services/worker_sessions/... passed; git diff --check passed; the focused diff is limited to internal_test.go; the cancellation signal is buffered to avoid a helper-goroutine leak; no additional same-shape surrounding matches were found."
      }
    }
  ]
}
