### PR TITLE
fix(models): code local mode diagnostics

### DIFF
--- a/pkg/services/models/transports/cli/root_errors.go
+++ b/pkg/services/models/transports/cli/root_errors.go
@@ -10,6 +10,7 @@ import (
 )
 
 const (
+	modelsRootModelNotFoundCode  = "NOT_FOUND"
 	modelsRootCacheNotFoundCode  = "MODEL_CACHE_NOT_FOUND"
 	modelsRootCacheInUseCode     = "MODEL_CACHE_IN_USE"
 	modelsRootCacheUnsafeCode    = "BAD_REQUEST"
@@ -113,7 +114,13 @@ func mapModelsRootError(err error) error {
 			err,
 		)
 	case errors.Is(err, modelinference.ErrNotFound):
-		return fmt.Errorf("%w: %s", ErrModelNotFound, err.Error())
+		return newModelsRootError(
+			modelsRootModelNotFoundCode,
+			factoryapi.ErrorFamilyNotFound,
+			modelNotFoundMessage(err),
+			ErrModelNotFound,
+			err,
+		)
 	case errors.Is(err, modelinference.ErrMissing),
 		errors.Is(err, modelinference.ErrLoading),
 		errors.Is(err, modelinference.ErrFailed),
@@ -143,6 +150,14 @@ func modelCacheNotFoundMessage(err error) string {
 		return modelsRootMissingCachePrefix + " <model> first"
 	}
 	return fmt.Sprintf("%s %s first", modelsRootMissingCachePrefix, modelName)
+}
+
+func modelNotFoundMessage(err error) string {
+	modelName := modelNameFromError(err, modelinference.ErrNotFound.Error())
+	if modelName == "" {
+		return modelinference.ErrNotFound.Error()
+	}
+	return fmt.Sprintf("%s: %s", modelinference.ErrNotFound, modelName)
 }
 
 func modelNameFromError(err error, marker string) string {

--- a/pkg/services/models/transports/cli/root_errors.go
+++ b/pkg/services/models/transports/cli/root_errors.go
@@ -3,9 +3,85 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	modelinference "github.com/portpowered/infinite-you/pkg/services/models"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 )
+
+const (
+	modelsRootCacheNotFoundCode  = "MODEL_CACHE_NOT_FOUND"
+	modelsRootCacheInUseCode     = "MODEL_CACHE_IN_USE"
+	modelsRootCacheUnsafeCode    = "BAD_REQUEST"
+	modelsRootDefaultErrorText   = "models command failed"
+	modelsRootMissingCachePrefix = "model cache is not installed; run you models pull"
+)
+
+// modelsRootError preserves a Models CLI sentinel and the originating Models
+// error while exposing the safe diagnostic fields expected by the central CLI
+// renderer. Its message is authored at this adapter boundary; the original
+// cause remains available to errors.Is/errors.As and --debug callers.
+type modelsRootError struct {
+	code     string
+	family   factoryapi.ErrorFamily
+	message  string
+	sentinel error
+	cause    error
+}
+
+func (err *modelsRootError) Error() string {
+	if err == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s: %s", err.CLIErrorCode(), err.CLIErrorMessage())
+}
+
+func (err *modelsRootError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+	return err.cause
+}
+
+func (err *modelsRootError) Is(target error) bool {
+	if err == nil || err.sentinel == nil {
+		return false
+	}
+	return errors.Is(err.sentinel, target)
+}
+
+func (err *modelsRootError) CLIErrorCode() string {
+	if err == nil || strings.TrimSpace(err.code) == "" {
+		return modelsRootCacheNotFoundCode
+	}
+	return strings.TrimSpace(err.code)
+}
+
+func (err *modelsRootError) CLIErrorFamily() factoryapi.ErrorFamily {
+	if err == nil || err.family == "" {
+		return factoryapi.ErrorFamilyInternalServerError
+	}
+	return err.family
+}
+
+func (err *modelsRootError) CLIErrorMessage() string {
+	if err == nil || strings.TrimSpace(err.message) == "" {
+		return modelsRootDefaultErrorText
+	}
+	return strings.TrimSpace(err.message)
+}
+
+func newModelsRootError(
+	code string,
+	family factoryapi.ErrorFamily,
+	message string,
+	sentinel error,
+	cause error,
+) error {
+	return &modelsRootError{
+		code: code, family: family, message: message, sentinel: sentinel, cause: cause,
+	}
+}
 
 func mapModelsRootError(err error) error {
 	if err == nil {
@@ -13,11 +89,29 @@ func mapModelsRootError(err error) error {
 	}
 	switch {
 	case errors.Is(err, modelinference.ErrModelCacheNotFound):
-		return fmt.Errorf("%w: %s", ErrModelCacheNotFound, err.Error())
+		return newModelsRootError(
+			modelsRootCacheNotFoundCode,
+			factoryapi.ErrorFamilyNotFound,
+			modelCacheNotFoundMessage(err),
+			ErrModelCacheNotFound,
+			err,
+		)
 	case errors.Is(err, modelinference.ErrModelCacheInUse):
-		return fmt.Errorf("%w: %s", ErrModelCacheInUse, err.Error())
+		return newModelsRootError(
+			modelsRootCacheInUseCode,
+			factoryapi.ErrorFamilyConflict,
+			strings.TrimSpace(err.Error()),
+			ErrModelCacheInUse,
+			err,
+		)
 	case errors.Is(err, modelinference.ErrModelCacheUnsafe):
-		return fmt.Errorf("%w: %s", ErrModelCacheUnsafe, err.Error())
+		return newModelsRootError(
+			modelsRootCacheUnsafeCode,
+			factoryapi.ErrorFamilyBadRequest,
+			strings.TrimSpace(err.Error()),
+			ErrModelCacheUnsafe,
+			err,
+		)
 	case errors.Is(err, modelinference.ErrNotFound):
 		return fmt.Errorf("%w: %s", ErrModelNotFound, err.Error())
 	case errors.Is(err, modelinference.ErrMissing),
@@ -41,4 +135,26 @@ func mapModelsRootError(err error) error {
 		}
 		return err
 	}
+}
+
+func modelCacheNotFoundMessage(err error) string {
+	modelName := modelNameFromError(err, modelinference.ErrModelCacheNotFound.Error())
+	if modelName == "" {
+		return modelsRootMissingCachePrefix + " <model> first"
+	}
+	return fmt.Sprintf("%s %s first", modelsRootMissingCachePrefix, modelName)
+}
+
+func modelNameFromError(err error, marker string) string {
+	if err == nil {
+		return ""
+	}
+	message := strings.TrimSpace(err.Error())
+	markerIndex := strings.LastIndex(message, marker)
+	if markerIndex < 0 {
+		return ""
+	}
+	modelName := strings.TrimSpace(message[markerIndex+len(marker):])
+	modelName = strings.TrimPrefix(modelName, ":")
+	return strings.TrimSpace(modelName)
 }

--- a/tests/functional/models/model_list/presentation_collaborator_coverage_test.go
+++ b/tests/functional/models/model_list/presentation_collaborator_coverage_test.go
@@ -64,7 +64,7 @@ func TestProcessModelsList_ReusesCatalogScopeAcrossCommands(t *testing.T) {
 				t.Fatalf("Process.Execute(local models %s #%d) error = nil, want failure without catalog fixture", args[3], i+1)
 			}
 			stderr := inputs.Stderr()
-			support.RequireSafeCLIDiagnostic(t, stderr)
+			support.RequireNotFoundCLIDiagnostic(t, stderr)
 		default:
 			t.Fatalf("unexpected command args: %v", args)
 		}
@@ -84,7 +84,7 @@ func TestProcessModelsPull_RoutesThroughCompositionProviderWithoutServer(t *test
 	if err := process.Execute(inputs.Input); err == nil {
 		t.Fatalf("Process.Execute(local models pull) error = nil, want failure without catalog fixture")
 	}
-	support.RequireSafeCLIDiagnostic(t, inputs.Stderr())
+	support.RequireNotFoundCLIDiagnostic(t, inputs.Stderr())
 }
 
 // TestProcessModelsInvokeJSON_RoutesThroughCompositionProviderWithoutServer proves
@@ -119,5 +119,5 @@ func TestProcessModelsInspect_RoutesThroughCompositionProviderWithoutServer(t *t
 	if err := process.Execute(inputs.Input); err == nil {
 		t.Fatalf("Process.Execute(local models inspect) error = nil, want not-found failure without catalog fixture")
 	}
-	support.RequireSafeCLIDiagnostic(t, inputs.Stderr())
+	support.RequireNotFoundCLIDiagnostic(t, inputs.Stderr())
 }

--- a/tests/functional/models/root_composition/coded_diagnostics_test.go
+++ b/tests/functional/models/root_composition/coded_diagnostics_test.go
@@ -1,0 +1,131 @@
+package root_composition_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	modelservice "github.com/portpowered/infinite-you/pkg/services/models"
+	modelscli "github.com/portpowered/infinite-you/pkg/services/models/transports/cli"
+	runcli "github.com/portpowered/infinite-you/pkg/transports/cli/run"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const codedDiagnosticModelName = "OMNIVOICE_Q4_K_M"
+
+func TestModelsLocalRemoveMissingCacheRendersCodedDiagnostic(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		flags []string
+		debug bool
+	}{
+		{name: "normal"},
+		{name: "json", flags: []string{"--json"}},
+		{name: "debug", flags: []string{"--debug"}, debug: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			inputs, err := executeLocalMissingCache(t, test.flags)
+			if err == nil {
+				t.Fatal("Process.Execute(models remove) error = nil, want missing-cache failure")
+			}
+			if !errors.Is(err, modelscli.ErrModelCacheNotFound) {
+				t.Fatalf("Process.Execute(models remove) error = %v, want ErrModelCacheNotFound", err)
+			}
+			if !errors.Is(err, modelservice.ErrModelCacheNotFound) {
+				t.Fatalf("Process.Execute(models remove) error = %v, want underlying Models cache-not-found cause", err)
+			}
+			if inputs.Stdout() != "" {
+				t.Fatalf("models remove failure stdout = %q, want empty", inputs.Stdout())
+			}
+
+			response := decodeFirstDiagnostic(t, inputs.Stderr())
+			wantMessage := "model cache is not installed; run you models pull " + codedDiagnosticModelName + " first"
+			if response.Code != factoryapi.ErrorResponseCodeMODELCACHENOTFOUND ||
+				response.Family != factoryapi.ErrorFamilyNotFound || response.Message != wantMessage {
+				t.Fatalf("models remove diagnostic = %#v, want code/family/message %q/%q/%q", response, factoryapi.ErrorResponseCodeMODELCACHENOTFOUND, factoryapi.ErrorFamilyNotFound, wantMessage)
+			}
+			for _, fallback := range []string{"CLI_COMMAND_FAILED", "INTERNAL_SERVER_ERROR", "command failed"} {
+				if strings.Contains(inputs.Stderr(), fallback) {
+					t.Fatalf("models remove diagnostic contains fallback %q: %q", fallback, inputs.Stderr())
+				}
+			}
+			if test.debug && !strings.Contains(inputs.Stderr(), "managed model cache not found") {
+				t.Fatalf("debug models remove diagnostic = %q, want underlying cache-not-found cause", inputs.Stderr())
+			}
+		})
+	}
+}
+
+func TestModelsLocalRemoveMissingCacheMatchesHTTPDiagnostic(t *testing.T) {
+	const message = "model cache is not installed; run you models pull " + codedDiagnosticModelName + " first"
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodDelete || request.URL.Path != "/models/"+codedDiagnosticModelName {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(writer).Encode(factoryapi.ErrorResponse{
+			Code: factoryapi.ErrorResponseCodeMODELCACHENOTFOUND, Family: factoryapi.ErrorFamilyNotFound, Message: message,
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	localInputs, localErr := executeLocalMissingCache(t, nil)
+	if localErr == nil {
+		t.Fatal("local Process.Execute(models remove) error = nil, want missing-cache failure")
+	}
+	localResponse := decodeFirstDiagnostic(t, localInputs.Stderr())
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	remoteInputs := support.FakeInputs(t.Context(), []string{
+		"you", "--server", server.URL, "models", "remove", codedDiagnosticModelName,
+	})
+	remoteInputs.Input.WorkingDirectory = t.TempDir()
+	remoteErr := process.Execute(remoteInputs.Input)
+	if remoteErr == nil || !errors.Is(remoteErr, modelscli.ErrModelCacheNotFound) {
+		t.Fatalf("remote Process.Execute(models remove) error = %v, want ErrModelCacheNotFound", remoteErr)
+	}
+	remoteResponse := decodeFirstDiagnostic(t, remoteInputs.Stderr())
+	if localResponse.Code != remoteResponse.Code || localResponse.Family != remoteResponse.Family || localResponse.Message != remoteResponse.Message {
+		t.Fatalf("local diagnostic = %#v, remote diagnostic = %#v, want parity", localResponse, remoteResponse)
+	}
+	if localResponse.Code != factoryapi.ErrorResponseCodeMODELCACHENOTFOUND || localResponse.Family != factoryapi.ErrorFamilyNotFound {
+		t.Fatalf("local diagnostic = %#v, want MODEL_CACHE_NOT_FOUND/NOT_FOUND", localResponse)
+	}
+}
+
+func executeLocalMissingCache(t *testing.T, flags []string) (*support.CapturedInputs, error) {
+	t.Helper()
+	factoryDir := support.ScaffoldFactory(t, localModelReadinessAssetsHostFactoryConfig("http://127.0.0.1:1"))
+	cacheDirectory := t.TempDir()
+	inputsArgs := append([]string{"you"}, flags...)
+	inputsArgs = append(inputsArgs, "models", "remove", codedDiagnosticModelName)
+	inputs := support.FakeInputs(t.Context(), inputsArgs)
+	inputs.Input.Env = append(
+		functionalHomeEnvironment(t.TempDir()),
+		runcli.ModelCacheDirEnvironment+"="+cacheDirectory,
+	)
+	inputs.Input.WorkingDirectory = factoryDir
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	return inputs, process.Execute(inputs.Input)
+}
+
+func decodeFirstDiagnostic(t *testing.T, stderr string) factoryapi.ErrorResponse {
+	t.Helper()
+	firstLine := strings.SplitN(strings.TrimSpace(stderr), "\n", 2)[0]
+	var response factoryapi.ErrorResponse
+	if err := json.Unmarshal([]byte(firstLine), &response); err != nil {
+		t.Fatalf("decode rendered diagnostic: %v\nstderr=%q", err, stderr)
+	}
+	return response
+}

--- a/tests/functional/models/root_composition/coded_diagnostics_test.go
+++ b/tests/functional/models/root_composition/coded_diagnostics_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 const codedDiagnosticModelName = "OMNIVOICE_Q4_K_M"
+const codedDiagnosticUnknownModelName = "missing-model"
 
 func TestModelsLocalRemoveMissingCacheRendersCodedDiagnostic(t *testing.T) {
 	for _, test := range []struct {
@@ -102,6 +103,93 @@ func TestModelsLocalRemoveMissingCacheMatchesHTTPDiagnostic(t *testing.T) {
 	}
 }
 
+func TestModelsLocalInspectUnknownRendersCodedDiagnostic(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		flags []string
+		debug bool
+	}{
+		{name: "normal"},
+		{name: "json", flags: []string{"--json"}},
+		{name: "debug", flags: []string{"--debug"}, debug: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			inputs, err := executeLocalUnknownModel(t, test.flags)
+			if err == nil {
+				t.Fatal("Process.Execute(models inspect) error = nil, want not-found failure")
+			}
+			if inputs.Stdout() != "" {
+				t.Fatalf("models inspect failure stdout = %q, want empty", inputs.Stdout())
+			}
+
+			response := decodeFirstDiagnostic(t, inputs.Stderr())
+			wantMessage := "model not found: " + codedDiagnosticUnknownModelName
+			if response.Code != factoryapi.ErrorResponseCodeNOTFOUND ||
+				response.Family != factoryapi.ErrorFamilyNotFound || response.Message != wantMessage {
+				t.Fatalf("models inspect diagnostic = %#v, want code/family/message %q/%q/%q; stdout=%q stderr=%q", response, factoryapi.ErrorResponseCodeNOTFOUND, factoryapi.ErrorFamilyNotFound, wantMessage, inputs.Stdout(), inputs.Stderr())
+			}
+			for _, fallback := range []string{"CLI_COMMAND_FAILED", "INTERNAL_SERVER_ERROR", "command failed"} {
+				if strings.Contains(inputs.Stderr(), fallback) {
+					t.Fatalf("models inspect diagnostic contains fallback %q: %q", fallback, inputs.Stderr())
+				}
+			}
+			if !errors.Is(err, modelscli.ErrModelNotFound) {
+				t.Fatalf("Process.Execute(models inspect) error = %v, want ErrModelNotFound; stdout=%q stderr=%q", err, inputs.Stdout(), inputs.Stderr())
+			}
+			if !errors.Is(err, modelservice.ErrNotFound) {
+				t.Fatalf("Process.Execute(models inspect) error = %v, want underlying Models not-found cause; stdout=%q stderr=%q", err, inputs.Stdout(), inputs.Stderr())
+			}
+			if test.debug && !strings.Contains(inputs.Stderr(), "debug: cause[1]=model not found: "+codedDiagnosticUnknownModelName) {
+				t.Fatalf("debug models inspect diagnostic = %q, want underlying not-found cause", inputs.Stderr())
+			}
+		})
+	}
+}
+
+func TestModelsLocalInspectUnknownMatchesHTTPDiagnostic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodGet || request.URL.Path != "/models/"+codedDiagnosticUnknownModelName {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(writer).Encode(factoryapi.ErrorResponse{
+			Code:    factoryapi.ErrorResponseCodeNOTFOUND,
+			Family:  factoryapi.ErrorFamilyNotFound,
+			Message: "model not found",
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	localInputs, localErr := executeLocalUnknownModel(t, nil)
+	if localErr == nil {
+		t.Fatal("local Process.Execute(models inspect) error = nil, want not-found failure")
+	}
+	localResponse := decodeFirstDiagnostic(t, localInputs.Stderr())
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	remoteInputs := support.FakeInputs(t.Context(), []string{
+		"you", "--server", server.URL, "models", "inspect", codedDiagnosticUnknownModelName,
+	})
+	remoteInputs.Input.WorkingDirectory = t.TempDir()
+	remoteErr := process.Execute(remoteInputs.Input)
+	if remoteErr == nil || !errors.Is(remoteErr, modelscli.ErrModelNotFound) {
+		t.Fatalf("remote Process.Execute(models inspect) error = %v, want ErrModelNotFound", remoteErr)
+	}
+	remoteResponse := decodeFirstDiagnostic(t, remoteInputs.Stderr())
+	if localResponse.Code != remoteResponse.Code || localResponse.Family != remoteResponse.Family {
+		t.Fatalf("local diagnostic = %#v, remote diagnostic = %#v, want code/family parity", localResponse, remoteResponse)
+	}
+	if localResponse.Code != factoryapi.ErrorResponseCodeNOTFOUND || localResponse.Family != factoryapi.ErrorFamilyNotFound {
+		t.Fatalf("local diagnostic = %#v, want NOT_FOUND/NOT_FOUND", localResponse)
+	}
+	if !strings.Contains(localResponse.Message, codedDiagnosticUnknownModelName) {
+		t.Fatalf("local diagnostic message = %q, want requested model name", localResponse.Message)
+	}
+}
+
 func executeLocalMissingCache(t *testing.T, flags []string) (*support.CapturedInputs, error) {
 	t.Helper()
 	factoryDir := support.ScaffoldFactory(t, localModelReadinessAssetsHostFactoryConfig("http://127.0.0.1:1"))
@@ -113,6 +201,20 @@ func executeLocalMissingCache(t *testing.T, flags []string) (*support.CapturedIn
 		functionalHomeEnvironment(t.TempDir()),
 		runcli.ModelCacheDirEnvironment+"="+cacheDirectory,
 	)
+	inputs.Input.WorkingDirectory = factoryDir
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	return inputs, process.Execute(inputs.Input)
+}
+
+func executeLocalUnknownModel(t *testing.T, flags []string) (*support.CapturedInputs, error) {
+	t.Helper()
+	factoryDir := support.ScaffoldFactory(t, localModelReadinessAssetsHostFactoryConfig("http://127.0.0.1:1"))
+	inputsArgs := append([]string{"you"}, flags...)
+	inputsArgs = append(inputsArgs, "models", "inspect", codedDiagnosticUnknownModelName)
+	inputs := support.FakeInputs(t.Context(), inputsArgs)
+	inputs.Input.Env = functionalHomeEnvironment(t.TempDir())
 	inputs.Input.WorkingDirectory = factoryDir
 
 	process := support.BuildProcess(t, serviceedges.Edges{})


### PR DESCRIPTION
{
  "project": "Models Local-Mode Coded Diagnostics",
  "branchName": "models-local-mode-coded-diagnostics",
  "description": "Make the default in-process `you models remove` and `you models inspect` paths render specific, actionable coded diagnostics instead of `CLI_COMMAND_FAILED` / `INTERNAL_SERVER_ERROR`. The Models CLI adapter will preserve existing sentinel and debug behavior, align local code/family outcomes with the existing HTTP contract, and add no-server root-composition regression and parity coverage without changing routing, HTTP, OpenAPI, shared CLI diagnostics, or another service.",
  "context": {
    "customerAsk": "Correct the documented default local-mode diagnostics for `you models remove` and `you models inspect`, build on merged PRs #2225 and #2227, preserve local routing and HTTP behavior, add functional coverage with no `--server`, prove local/HTTP parity and debug continuity, and complete the implementation/review loop through merge.",
    "problem": "Known Models root failures are mapped to four plain CLI sentinel errors that do not implement the coded-error contract used by the central renderer. The default in-process route therefore collapses absent models and caches into the misleading generic `CLI_COMMAND_FAILED` / `INTERNAL_SERVER_ERROR` diagnostic, while existing regression tests cover only the explicit-server HTTP route and leave the documented local route untested.",
    "solution": "Add one small unexported family-coded error representation in the Models CLI adapter, use it when mapping the four known local Models failures, preserve unwrapping to the existing exported sentinels and underlying causes, and use the exact code/family pairs already emitted by the Models HTTP handlers. Add canonical root-composition tests for no-server remove and inspect in normal, JSON, debug, and representative local/HTTP parity scenarios."
  },
  "acceptanceCriteria": [
    "A bare local `you models remove <not-installed-model>` fails non-zero and renders `MODEL_CACHE_NOT_FOUND` / `NOT_FOUND` with an actionable message naming the model and directing the operator to pull it first, never the generic command-failed/internal-server fallback.",
    "A bare local `you models inspect <unknown-model>` fails non-zero and renders the current HTTP-aligned `NOT_FOUND` / `NOT_FOUND` diagnostic with a message naming the model and never `command failed`.",
    "Known local mappings preserve `errors.Is` for `ErrModelNotFound`, `ErrModelCacheNotFound`, `ErrModelCacheInUse`, and `ErrModelCacheUnsafe`, with respective HTTP-aligned code/family pairs `NOT_FOUND`/`NOT_FOUND`, `MODEL_CACHE_NOT_FOUND`/`NOT_FOUND`, `MODEL_CACHE_IN_USE`/`CONFLICT`, and `BAD_REQUEST`/`BAD_REQUEST`.",
    "Functional root-composition evidence covers local remove and inspect with no `--server`, normal and `--json` rendering, representative local/HTTP parity, non-zero failure results, and retained `--debug` cause detail; the PR body states that the new local cases fail before the fix and records real before/after command output.",
    "The diff is based on current `origin/main`, preserves merged #2225/#2227 behavior, and is confined to `pkg/services/models/transports/cli/root_errors.go`, the sentinel block in `pkg/services/models/transports/cli/models.go`, new tests under `tests/functional/models/root_composition/`, and the existing `tests/functional/models/model_list/presentation_collaborator_coverage_test.go` only where its stale generic-fallback expectations must be updated for the shared `ErrNotFound` mapping; `clidiag`, Models HTTP handlers, OpenAPI, routing, and every other service remain unchanged.",
    "Quality gates pass: Typecheck passes; `go test ./pkg/services/models/... ./tests/functional/models/...` passes; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green; required PR checks `Backend Lint` and `Verification Policy` pass, while `localai-backend-artifacts` is not required.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "models-local-mode-coded-diagnostics-001",
      "title": "Render actionable local remove diagnostics",
      "description": "As an operator removing a managed model in the default local mode, I want a specific and actionable diagnostic when its cache is absent so I can recover without enabling debug output or mistaking the condition for a server failure.",
      "acceptanceCriteria": [
        "Invoking `you models remove <not-installed-model>` through `root.BuildProcess` and `Process.Execute` with no `--server` returns a non-nil/non-zero failure and renders code `MODEL_CACHE_NOT_FOUND`, family `NOT_FOUND`, and a message that names the model and tells the operator to run `you models pull <model>` first.",
        "The local missing-cache failure has the same code and family in normal and `--json` modes, emits no `CLI_COMMAND_FAILED`, `INTERNAL_SERVER_ERROR`, or `command failed` fallback, and keeps failure output on the established diagnostic stream.",
        "For the same missing-cache condition, local invocation and explicit `--server` invocation render identical code and family with safe actionable messages.",
        "`--debug` still includes the underlying Models cache-not-found cause chain in addition to the new default coded diagnostic.",
        "Mapped cache-not-found, cache-in-use, and unsafe-cache failures retain `errors.Is` compatibility with their existing exported CLI sentinels and present `MODEL_CACHE_NOT_FOUND`/`NOT_FOUND`, `MODEL_CACHE_IN_USE`/`CONFLICT`, and `BAD_REQUEST`/`BAD_REQUEST`, respectively.",
        "Functional coverage uses canonical root composition and deterministic scratch state, with no built-binary subprocess, sleep, or unrelated external effect.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented the local remove family-coded error mapping and root-composition normal/JSON/debug plus local/HTTP parity coverage. Models and functional Go suites pass; make typecheck reaches the UI compiler but remains blocked by pre-existing Assertion.not errors in untouched UI test helpers."
    },
    {
      "id": "models-local-mode-coded-diagnostics-002",
      "title": "Render actionable local inspect diagnostics and record delivery evidence",
      "description": "As an operator inspecting a model in the default local mode, I want an accurate not-found diagnostic that names my requested model so local and remote usage have the same understandable failure semantics.",
      "acceptanceCriteria": [
        "Invoking `you models inspect <unknown-model>` through `root.BuildProcess` and `Process.Execute` with no `--server` returns a non-nil/non-zero failure and renders the current HTTP-aligned code `NOT_FOUND`, family `NOT_FOUND`, and a message naming the requested model.",
        "Normal and `--json` local inspect failures contain neither `CLI_COMMAND_FAILED` nor `INTERNAL_SERVER_ERROR` nor `command failed`, and their structured diagnostic remains decodable through the established CLI output contract.",
        "`--debug` still displays the underlying Models not-found cause in addition to the default coded diagnostic.",
        "The mapped model-not-found failure retains `errors.Is(err, ErrModelNotFound)` compatibility.",
        "The PR body states that the new no-server regression cases fail before the fix and quotes real before/after captured command output for local remove and inspect in default and `--json` modes, identifies diagnostic stderr versus empty stdout accurately, records non-zero exit behavior, and explains that catalog not-found uses the handler's existing `NOT_FOUND` code.",
        "Before final push, the branch is rebased onto current `origin/main`; merged PRs #2225 and #2227 remain intact and the diff contains no reversal or unrelated cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented local ErrNotFound family-coded mapping with model-naming messages, preserved CLI/Models sentinel unwrapping and debug cause detail, added root-composition normal/JSON/debug and local/HTTP parity coverage, and updated stale local characterization expectations. Models and functional suites plus Go vet pass. make typecheck remains blocked by pre-existing Assertion.not errors in untouched UI test helpers; make lint also reports pre-existing missing vitest/knip binaries and a packaged-factory consumption baseline violation. Captured before/after default and --json stdout/stderr and non-zero behavior for local remove and inspect for the PR body."
    }
  ]
}

## Implementation and delivery evidence

The PRD above is the source description for this change. The branch was rebased onto the current `origin/main` immediately before the final push. Merged PRs #2225 and #2227 remain intact; no routing, HTTP handlers, OpenAPI, shared CLI diagnostics, or other service code changed.

### Captured local CLI output

These cases were captured through the canonical root composition (`root.BuildProcess` + `Process.Execute`) with no `--server`; each returned a non-zero failure, wrote no stdout, and wrote the JSON diagnostic to stderr. The base captures were run at the pre-fix base SHA, and the after captures were run with the implementation.

Before the fix (default and `--json` were identical):

```text
$ you models remove OMNIVOICE_Q4_K_M
stdout: ""
stderr: {"code":"CLI_COMMAND_FAILED","family":"INTERNAL_SERVER_ERROR","message":"command failed"}
exit: non-zero (CLI_COMMAND_FAILED: command failed: model cache not found: managed model cache not found: OMNIVOICE_Q4_K_M)

$ you models inspect missing-model
stdout: ""
stderr: {"code":"CLI_COMMAND_FAILED","family":"INTERNAL_SERVER_ERROR","message":"command failed"}
exit: non-zero (CLI_COMMAND_FAILED: command failed: model not found: model not found: missing-model)
```

After the fix (default and `--json` were identical):

```text
$ you models remove OMNIVOICE_Q4_K_M
stdout: ""
stderr: {"code":"MODEL_CACHE_NOT_FOUND","family":"NOT_FOUND","message":"model cache is not installed; run you models pull OMNIVOICE_Q4_K_M first"}
exit: non-zero (MODEL_CACHE_NOT_FOUND: model cache is not installed; run you models pull OMNIVOICE_Q4_K_M first)

$ you models inspect missing-model
stdout: ""
stderr: {"code":"NOT_FOUND","family":"NOT_FOUND","message":"model not found: missing-model"}
exit: non-zero (NOT_FOUND: model not found: missing-model)
```

The inspect local/HTTP parity test confirms the handler's existing catalog-not-found code is `NOT_FOUND` with family `NOT_FOUND`; the local message additionally names the requested model. Debug mode retains the underlying Models cause chain, and the mapped errors preserve `errors.Is` compatibility with the existing CLI and Models sentinels.

### Verification

- `go test ./pkg/services/models/... ./tests/functional/models/...` — pass.
- `go vet ./pkg/services/models/... ./tests/functional/models/...` — pass.
- Relevant backend lint/structure/vet gates — pass.
- `make typecheck` — blocked by pre-existing `Assertion.not` errors in untouched UI test helpers.
- `make lint` — reports pre-existing environment/baseline issues: missing UI `vitest`/`knip` binaries and the existing packaged-factory consumption violation.

The shared Models root mapper serves list, inspect, pull, invoke, and remove, so stale local fallback characterization expectations were updated alongside the new root-composition regressions.