### PR TITLE
price-table-operator-override

### DIFF
--- a/api/components/schemas/api/CostsLineItem.yaml
+++ b/api/components/schemas/api/CostsLineItem.yaml
@@ -37,6 +37,12 @@ properties:
       - PRICED
       - UNPRICED
     description: PRICED means every measured token class has a configured rate; UNPRICED means the row is retained with its tokens but cannot be fully valued.
+  price_source:
+    type: string
+    enum:
+      - BUILT_IN
+      - OPERATOR_SUPPLIED
+    description: Pricing authority for the complete row used for a PRICED line item; omitted for UNPRICED rows.
   priced_amount:
     type: string
     description: Exact USD decimal amount; absent for UNPRICED rows and present as "0" for explicitly free usage.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4162,6 +4162,12 @@ components:
             - PRICED
             - UNPRICED
           description: PRICED means every measured token class has a configured rate; UNPRICED means the row is retained with its tokens but cannot be fully valued.
+        price_source:
+          type: string
+          enum:
+            - BUILT_IN
+            - OPERATOR_SUPPLIED
+          description: Pricing authority for the complete row used for a PRICED line item; omitted for UNPRICED rows.
         priced_amount:
           type: string
           description: Exact USD decimal amount; absent for UNPRICED rows and present as "0" for explicitly free usage.

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -178,26 +178,64 @@ workflow. Global `--server` selects the Factory API; global `--json` emits the
 API-shaped report. A route failure returns an error without a partial success
 document.
 
-### Provider-Owned Price Facts
+### Provider-Owned And Operator Price Facts
 
-Costs uses the immutable, Providers-owned price table shipped with the
-application. It is not operator configuration, and editing
-`~/.you-agent-factory/config.json` does not change cost valuation. Maintainers
-add a row only for a provider/model pair observed in live metrics after finding
-an authoritative vendor price. Every row records USD-per-million-token rates,
-the source URL, and an ISO-8601 as-of date. The current shipped row is
-`codex/gpt-5-codex`; its source is the
+Costs uses two pricing authorities. Providers owns the immutable built-in table
+shipped with the application. Operator Settings owns the optional `priceTable`
+in `~/.you-agent-factory/config.json`.
+
+The effective table uses the exact normalized provider/model pair as its key.
+An operator row supplements a missing built-in pair. A matching operator row
+replaces the complete built-in row. Costs never combines fields from both rows.
+
+An operator row must include `inputPerMillionTokens` and
+`outputPerMillionTokens`. `cachedInputPerMillionTokens` and
+`reasoningOutputPerMillionTokens` are optional. If an operator omits one of
+these optional rates, that measured class remains `UNPRICED`.
+
+The Operator Settings decoder trims provider and model values. It canonicalizes
+supported provider aliases and does not guess or alias model identifiers.
+Missing provider/model identity or a missing effective row remains `UNPRICED`.
+Cached input is deducted from total input. Reasoning output is deducted from
+total output before the corresponding rates are applied.
+
+To configure Claude pricing, add a complete `priceTable` object to the operator
+settings document:
+
+```json
+{
+  "priceTable": {
+    "currency": "USD",
+    "models": [
+      {
+        "provider": "claude",
+        "model": "claude-sonnet-4-6",
+        "inputPerMillionTokens": "3",
+        "outputPerMillionTokens": "15",
+        "cachedInputPerMillionTokens": "0.30",
+        "reasoningOutputPerMillionTokens": "15"
+      }
+    ]
+  }
+}
+```
+
+The required rates value uncached input and non-reasoning output tokens. The
+optional rates value cached input and reasoning output tokens. Rates are exact
+non-negative USD decimals per one million tokens.
+
+The example values are operator-authored valuation facts. They are not live
+vendor prices, billing records, or billing limits. Costs does not fetch vendor
+pricing or query provider billing.
+
+To remove an override, remove its model from `priceTable.models`. Use an empty
+`models` array when no operator rows remain. The next costs query falls back to
+the built-in row when one exists. A pair without either row becomes `UNPRICED`.
+
+The built-in table records a source URL and an ISO-8601 as-of date for each
+shipped row. The current shipped row is `codex/gpt-5-codex`; its source is the
 [OpenAI GPT-5-Codex pricing page](https://developers.openai.com/api/docs/models/gpt-5-codex),
 dated 2026-08-21.
-
-Input and output rates are required for every row. Cached-input and
-reasoning-output rates are optional; a measured class with no explicit rate is
-`UNPRICED`. When a subclass intentionally uses the standard input or output
-rate, the provider data declares that equality explicitly. An omitted token
-measurement is distinct from an explicit zero, and an explicit zero rate is
-valid. Missing provider/model identity or an absent price row remains
-`UNPRICED`. Cached input is deducted from total input, and reasoning output is
-deducted from total output before the corresponding rates are applied.
 
 ### Cost Report Fields And Status
 
@@ -219,6 +257,19 @@ canonical usage rows were found. Each `line_items` row retains provider/model
 identity and all observed input, cached-input, output, and reasoning-output
 counts, plus an actionable `reason` when it is unpriced. Rollups cover all four
 dimensions: Work, Worker Session, provider/model, and Factory Session.
+
+Each `PRICED` `line_items` row includes `price_source`. The value is exactly
+`BUILT_IN` or `OPERATOR_SUPPLIED`, and identifies the complete row used for
+valuation. An `UNPRICED` row omits `price_source` and `priced_amount`. It keeps
+its provider/model identity, observed token counts, and actionable `reason`.
+
+Human output repeats this provenance beside each priced line item:
+
+```text
+  PRICED provider=CLAUDE model=claude-sonnet-4-6
+    Priced amount (USD): 0.0081
+    Price source: OPERATOR_SUPPLIED
+```
 
 Human output makes coverage explicit: fully priced usage shows the exact
 rounded USD amount and token totals, unpriced usage shows `?? unknown` and

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -211,7 +211,7 @@
       "path": "generated/mcp/tools.json"
     },
     "generated.openapi.openapi": {
-      "artifactHash": "7d4a297968c06c69c63e4bd9da0f558df1df83f9327871fc4898aacf6bae6f78",
+      "artifactHash": "4643ecfd6b4d4727930909fa06605e91b6cda378d6ec28b30cba997f38e38c49",
       "documentation": {
         "documentation": {
           "description": {
@@ -228,7 +228,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.openapi.openapi",
-        "sourceHash": "7d4a297968c06c69c63e4bd9da0f558df1df83f9327871fc4898aacf6bae6f78",
+        "sourceHash": "4643ecfd6b4d4727930909fa06605e91b6cda378d6ec28b30cba997f38e38c49",
         "visibility": "public"
       },
       "family": "openapi",

--- a/packages/api/generated/openapi/openapi.yaml
+++ b/packages/api/generated/openapi/openapi.yaml
@@ -4162,6 +4162,12 @@ components:
             - PRICED
             - UNPRICED
           description: PRICED means every measured token class has a configured rate; UNPRICED means the row is retained with its tokens but cannot be fully valued.
+        price_source:
+          type: string
+          enum:
+            - BUILT_IN
+            - OPERATOR_SUPPLIED
+          description: Pricing authority for the complete row used for a PRICED line item; omitted for UNPRICED rows.
         priced_amount:
           type: string
           description: Exact USD decimal amount; absent for UNPRICED rows and present as "0" for explicitly free usage.

--- a/pkg/services/costs/costs.go
+++ b/pkg/services/costs/costs.go
@@ -88,6 +88,15 @@ const (
 	StatusNoUsage  Status = "NO_USAGE"
 )
 
+// PriceSource identifies the complete pricing row used for a priced line
+// item. An empty value is reserved for unpriced rows.
+type PriceSource string
+
+const (
+	PriceSourceBuiltIn          PriceSource = "BUILT_IN"
+	PriceSourceOperatorSupplied PriceSource = "OPERATOR_SUPPLIED"
+)
+
 // Coverage counts encountered and fully priced usage rows and distinct
 // provider/model identities. A provider/model pair is priced only when every
 // encountered row for that pair is priced in the same scope.
@@ -141,9 +150,10 @@ type LineItem struct {
 	Provider         string `json:"provider,omitempty"`
 	Model            string `json:"model,omitempty"`
 	TokenCounts
-	Status       Status  `json:"status"`
-	PricedAmount *string `json:"priced_amount,omitempty"`
-	Reason       string  `json:"reason,omitempty"`
+	Status       Status      `json:"status"`
+	PriceSource  PriceSource `json:"price_source,omitempty"`
+	PricedAmount *string     `json:"priced_amount,omitempty"`
+	Reason       string      `json:"reason,omitempty"`
 }
 
 // Rollup is a monetary and usage summary for one Work item, Worker Session,

--- a/pkg/services/costs/costs.go
+++ b/pkg/services/costs/costs.go
@@ -39,9 +39,9 @@ func (query CostsQuery) QueryCosts(ctx context.Context, request QueryRequest) (R
 // Query is the short compatibility name for the Costs operation type.
 type Query = CostsQuery
 
-// QueryRequest identifies the canonical metrics input and optional scope
-// filters. OperatorSettingsPath is retained as an ignored compatibility field
-// for existing CLI/API callers; pricing is now read only from Providers.
+// QueryRequest identifies the canonical metrics input, the explicit operator
+// settings document, and optional scope filters. The settings path is read on
+// every query so changes take effect without rebuilding the process.
 // FactorySessionID and RuntimeInstanceID are optional independent filters;
 // both are passed to the canonical Factory Visualization query.
 type QueryRequest struct {

--- a/pkg/services/costs/internal/service/public_boundary_test.go
+++ b/pkg/services/costs/internal/service/public_boundary_test.go
@@ -37,6 +37,7 @@ func TestPublicCostsBoundaryCoversPricingCases(t *testing.T) {
 
 			query, err := New(
 				&priceReader{table: testCase.table},
+				operatorSettingsStub(),
 				metricsQueryStub(testCase.rows, nil),
 				logging.NoopLogger{},
 			)
@@ -158,6 +159,7 @@ func TestPublicCostsTokenTotalsIgnorePriceCoverage(t *testing.T) {
 			t.Parallel()
 			query, err := New(
 				&priceReader{table: testCase.table},
+				operatorSettingsStub(),
 				metricsQueryStub(rows, nil),
 				logging.NoopLogger{},
 			)

--- a/pkg/services/costs/internal/service/service.go
+++ b/pkg/services/costs/internal/service/service.go
@@ -8,34 +8,40 @@ import (
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	costs "github.com/portpowered/infinite-you/pkg/services/costs"
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
 // Service owns valuation policy while retaining no report or request state.
-// Provider pricing and canonical metrics remain behind two injected owner
-// contracts.
+// Provider pricing, Operator Settings, and canonical metrics remain behind
+// injected owner contracts.
 type Service struct {
-	pricing costs.PriceTableReader
-	metrics factoryvisualization.RuntimeMetricsQuery
-	logger  logging.Logger
+	pricing  costs.PriceTableReader
+	settings operatorsettings.Service
+	metrics  factoryvisualization.RuntimeMetricsQuery
+	logger   logging.Logger
 }
 
 // New constructs the stateless Costs operation.
 func New(
 	pricing costs.PriceTableReader,
+	settings operatorsettings.Service,
 	metrics factoryvisualization.RuntimeMetricsQuery,
 	logger logging.Logger,
 ) (costs.CostsQuery, error) {
 	switch {
 	case pricing == nil:
 		return nil, errors.New("construct Costs query: price-table reader is required")
+	case settings == nil:
+		return nil, errors.New("construct Costs query: Operator Settings reader is required")
 	case metrics == nil:
 		return nil, errors.New("construct Costs query: runtime metrics query is required")
 	}
 	service := &Service{
-		pricing: pricing,
-		metrics: metrics,
-		logger:  logging.EnsureLogger(logger),
+		pricing:  pricing,
+		settings: settings,
+		metrics:  metrics,
+		logger:   logging.EnsureLogger(logger),
 	}
 	return service.QueryCosts, nil
 }
@@ -46,7 +52,7 @@ func (service *Service) QueryCosts(
 	ctx context.Context,
 	request costs.QueryRequest,
 ) (costs.Report, error) {
-	if service == nil || service.pricing == nil || service.metrics == nil {
+	if service == nil || service.pricing == nil || service.settings == nil || service.metrics == nil {
 		return costs.Report{}, &costs.QueryError{
 			Kind:    costs.QueryErrorInvalidInput,
 			Message: "query runtime costs: dependencies are required",
@@ -76,7 +82,7 @@ func (service *Service) QueryCosts(
 		"runtime_instance_id", runtimeID,
 	)
 
-	table, err := service.readPriceTable()
+	builtInTable, operatorTable, err := service.readPriceTables(request.OperatorSettingsPath)
 	if err != nil {
 		service.logger.Error(
 			"runtime costs query failed",
@@ -111,7 +117,7 @@ func (service *Service) QueryCosts(
 		return costs.Report{}, err
 	}
 
-	report, err := calculateReport(ctx, table, metrics.UsageRows, scope)
+	report, err := calculateReport(ctx, builtInTable, operatorTable, metrics.UsageRows, scope)
 	if err != nil {
 		wrapped := &costs.QueryError{
 			Kind:    costs.QueryErrorInvalidUsage,
@@ -143,24 +149,40 @@ func (service *Service) QueryCosts(
 	return report, nil
 }
 
-func (service *Service) readPriceTable() (providers.PriceTable, error) {
-	table, err := service.pricing.ReadPriceTable()
+func (service *Service) readPriceTables(path string) (providers.PriceTable, operatorsettings.PriceTable, error) {
+	builtInTable, err := service.pricing.ReadPriceTable()
 	if err != nil {
-		return providers.PriceTable{}, &costs.QueryError{
+		return providers.PriceTable{}, operatorsettings.PriceTable{}, &costs.QueryError{
 			Kind:    costs.QueryErrorSettingsReadFailed,
 			Message: "query runtime costs: read provider price table",
 			Cause:   err,
 		}
 	}
-	table, err = table.Normalize()
+	builtInTable, err = builtInTable.Normalize()
 	if err != nil {
-		return providers.PriceTable{}, &costs.QueryError{
+		return providers.PriceTable{}, operatorsettings.PriceTable{}, &costs.QueryError{
 			Kind:    costs.QueryErrorInvalidPriceTable,
 			Message: "query runtime costs: validate provider price table",
 			Cause:   err,
 		}
 	}
-	return table, nil
+	config, err := service.settings.LoadFileConfig(strings.TrimSpace(path))
+	if err != nil {
+		return providers.PriceTable{}, operatorsettings.PriceTable{}, &costs.QueryError{
+			Kind:    costs.QueryErrorSettingsReadFailed,
+			Message: "query runtime costs: read operator settings price table",
+			Cause:   err,
+		}
+	}
+	operatorTable, err := config.PriceTable.Normalize()
+	if err != nil {
+		return providers.PriceTable{}, operatorsettings.PriceTable{}, &costs.QueryError{
+			Kind:    costs.QueryErrorInvalidPriceTable,
+			Message: "query runtime costs: validate operator price table",
+			Cause:   err,
+		}
+	}
+	return builtInTable, operatorTable, nil
 }
 
 func scopeForRequest(request costs.QueryRequest) costs.Scope {

--- a/pkg/services/costs/internal/service/service_test.go
+++ b/pkg/services/costs/internal/service/service_test.go
@@ -95,6 +95,11 @@ func assertExactLineItems(t *testing.T, lines []costs.LineItem) {
 	assertLine(t, lines, "unknown", costs.StatusUnpriced, "", "no configured price")
 	assertLine(t, lines, "gpt-no-cache", costs.StatusUnpriced, "", "cached-input rate is not configured")
 	assertLine(t, lines, "", costs.StatusUnpriced, "", "model identity is unavailable")
+	assertLineSource(t, lines, "gpt-5", costs.StatusPriced, costs.PriceSourceBuiltIn)
+	assertLineSource(t, lines, "gpt-zero", costs.StatusPriced, costs.PriceSourceBuiltIn)
+	assertLineSource(t, lines, "unknown", costs.StatusUnpriced, "")
+	assertLineSource(t, lines, "gpt-no-cache", costs.StatusUnpriced, "")
+	assertLineSource(t, lines, "", costs.StatusUnpriced, "")
 }
 
 func assertExactRollups(t *testing.T, report costs.Report) {
@@ -422,6 +427,10 @@ func TestQueryOperatorPriceTableSupplementsOverridesAndDoesNotMixRates(t *testin
 	assertLineAmount(t, first.LineItems, "gpt-5", "50", "")
 	assertLineAmount(t, first.LineItems, "fallback", "3", "")
 	assertLineAmount(t, first.LineItems, "gpt-5", "", "cached-input rate is not configured")
+	assertLineSource(t, first.LineItems, "claude-sonnet", costs.StatusPriced, costs.PriceSourceOperatorSupplied)
+	assertLineSource(t, first.LineItems, "gpt-5", costs.StatusPriced, costs.PriceSourceOperatorSupplied)
+	assertLineSource(t, first.LineItems, "fallback", costs.StatusPriced, costs.PriceSourceBuiltIn)
+	assertLineSource(t, first.LineItems, "gpt-5", costs.StatusUnpriced, "")
 	if len(settings.paths) != 1 || settings.paths[0] != "explicit-settings.json" {
 		t.Fatalf("settings paths = %#v, want the explicit request path", settings.paths)
 	}
@@ -668,6 +677,20 @@ func assertLine(t *testing.T, lines []costs.LineItem, model string, status costs
 		return
 	}
 	t.Fatalf("line for model %q not found in %#v", model, lines)
+}
+
+func assertLineSource(t *testing.T, lines []costs.LineItem, model string, status costs.Status, want costs.PriceSource) {
+	t.Helper()
+	for _, line := range lines {
+		if line.Model != model || line.Status != status {
+			continue
+		}
+		if line.PriceSource != want {
+			t.Fatalf("line %q status %q source = %q, want %q", model, status, line.PriceSource, want)
+		}
+		return
+	}
+	t.Fatalf("line for model %q with status %q not found in %#v", model, status, lines)
 }
 
 func assertLineAmount(t *testing.T, lines []costs.LineItem, model, amount, reason string) {

--- a/pkg/services/costs/internal/service/service_test.go
+++ b/pkg/services/costs/internal/service/service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	costs "github.com/portpowered/infinite-you/pkg/services/costs"
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
@@ -33,7 +34,7 @@ func TestQueryExactValuationCoverageAndRollups(t *testing.T) {
 		usageRow("session-a", "work-a2", "dispatch-a2", "worker-a2", "codex", "gpt-no-cache", 1_000, 1_000, int64Ptr(500), nil),
 		usageRow("session-a", "work-a3", "dispatch-a3", "worker-a3", "codex", "", 8, 9, nil, nil),
 	}
-	query, err := New(pricing, metricsQueryStub(rows, nil), logging.NoopLogger{})
+	query, err := New(pricing, operatorSettingsStub(), metricsQueryStub(rows, nil), logging.NoopLogger{})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -144,7 +145,7 @@ func TestQueryNoUsageAndExplicitZeroRemainDistinct(t *testing.T) {
 		Currency: providers.PriceTableCurrencyUSD,
 		Models:   []providers.PriceTableModel{testPriceModel("free", "0", "0", nil, nil)},
 	}}
-	query, err := New(pricing, metricsQueryStub(nil, nil), logging.NoopLogger{})
+	query, err := New(pricing, operatorSettingsStub(), metricsQueryStub(nil, nil), logging.NoopLogger{})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -156,7 +157,7 @@ func TestQueryNoUsageAndExplicitZeroRemainDistinct(t *testing.T) {
 		t.Fatalf("empty report = %#v, want NO_USAGE with absent amount", empty)
 	}
 
-	query, err = New(pricing, metricsQueryStub([]factoryvisualization.RuntimeMetricsUsageRow{
+	query, err = New(pricing, operatorSettingsStub(), metricsQueryStub([]factoryvisualization.RuntimeMetricsUsageRow{
 		usageRow("session", "work", "dispatch", "worker", "codex", "free", 0, 0, nil, nil),
 	}, nil), logging.NoopLogger{})
 	if err != nil {
@@ -186,7 +187,7 @@ func TestQueryUnpricedFactsDeduplicateDispatchesAndRetainUnknownIdentity(t *test
 		usageRow("session", "work", "dispatch-a", "worker-a", "CODEX", "unknown", 4, 5, nil, nil),
 		usageRow("session", "work", "dispatch-b", "worker-b", "", "", 6, 7, nil, nil),
 	}
-	query, err := New(pricing, metricsQueryStub(rows, nil), logging.NoopLogger{})
+	query, err := New(pricing, operatorSettingsStub(), metricsQueryStub(rows, nil), logging.NoopLogger{})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -247,7 +248,7 @@ func TestQueryUnpricedUsageRetainsCorrelationAndCountsRepeatedRows(t *testing.T)
 		usageRow("session", "work-unknown-a", "dispatch-unknown-a", "worker-unknown-a", "codex", "missing", 10, 20, nil, nil),
 		usageRow("session", "work-unknown-b", "dispatch-unknown-b", "worker-unknown-b", "codex", "missing", 30, 40, nil, nil),
 	}
-	query, err := New(pricing, metricsQueryStub(rows, nil), logging.NoopLogger{})
+	query, err := New(pricing, operatorSettingsStub(), metricsQueryStub(rows, nil), logging.NoopLogger{})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -295,7 +296,7 @@ func TestQueryScopedSelectionAndDeterministicOutput(t *testing.T) {
 		usageRow("session-b", "work-b", "dispatch-b", "worker-b", "codex", "model", 2, 2, nil, nil),
 		usageRow("session-a", "work-a", "dispatch-a", "worker-a", "codex", "model", 1, 1, nil, nil),
 	}
-	query, err := New(pricing, metricsQueryStub(rows, nil), logging.NoopLogger{})
+	query, err := New(pricing, operatorSettingsStub(), metricsQueryStub(rows, nil), logging.NoopLogger{})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -333,7 +334,7 @@ func assertSettingsReadFailureIsSafe(t *testing.T) {
 	t.Helper()
 	pricingErr := errors.New("provider pricing unavailable")
 	logger := &captureLogger{}
-	query, err := New(&priceReader{err: pricingErr}, metricsQueryStub(nil, nil), logger)
+	query, err := New(&priceReader{err: pricingErr}, operatorSettingsStub(), metricsQueryStub(nil, nil), logger)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -356,7 +357,7 @@ func assertSettingsReadFailureIsSafe(t *testing.T) {
 func assertMetricsFailureIsTyped(t *testing.T) {
 	t.Helper()
 	metricsErr := errors.New("metrics unavailable")
-	query, err := New(&priceReader{table: providers.PriceTable{Currency: providers.PriceTableCurrencyUSD}}, metricsQueryStub(nil, metricsErr), logging.NoopLogger{})
+	query, err := New(&priceReader{table: providers.PriceTable{Currency: providers.PriceTableCurrencyUSD}}, operatorSettingsStub(), metricsQueryStub(nil, metricsErr), logging.NoopLogger{})
 	if err != nil {
 		t.Fatalf("New(metrics error) error = %v", err)
 	}
@@ -369,7 +370,7 @@ func assertMetricsFailureIsTyped(t *testing.T) {
 
 func assertInvalidRequestIsTyped(t *testing.T) {
 	t.Helper()
-	query, err := New(&priceReader{table: providers.PriceTable{Currency: providers.PriceTableCurrencyUSD}}, metricsQueryStub(nil, nil), logging.NoopLogger{})
+	query, err := New(&priceReader{table: providers.PriceTable{Currency: providers.PriceTableCurrencyUSD}}, operatorSettingsStub(), metricsQueryStub(nil, nil), logging.NoopLogger{})
 	if err != nil {
 		t.Fatalf("New(invalid request) error = %v", err)
 	}
@@ -377,6 +378,124 @@ func assertInvalidRequestIsTyped(t *testing.T) {
 	var queryErr *costs.QueryError
 	if !errors.As(err, &queryErr) || queryErr.Kind != costs.QueryErrorInvalidInput || !strings.Contains(err.Error(), "metrics root") {
 		t.Fatalf("invalid request error = %v, want actionable invalid input", err)
+	}
+}
+
+func TestQueryOperatorPriceTableSupplementsOverridesAndDoesNotMixRates(t *testing.T) {
+	t.Parallel()
+
+	builtIn := providers.PriceTable{
+		Currency: providers.PriceTableCurrencyUSD,
+		Models: []providers.PriceTableModel{
+			testPriceModel("gpt-5", "1", "2", stringPtr("0.5"), stringPtr("3")),
+			testPriceModel("fallback", "1", "2", nil, nil),
+		},
+	}
+	settings := &operatorSettingsReaderStub{config: operatorsettings.Config{
+		PriceTable: operatorsettings.PriceTable{
+			Currency: operatorsettings.PriceTableCurrencyUSD,
+			Models: []operatorsettings.PriceTableModel{
+				{Provider: " claude ", Model: "claude-sonnet", InputPerMillionTokens: "3", OutputPerMillionTokens: "15"},
+				{Provider: "codex", Model: "gpt-5", InputPerMillionTokens: "10", OutputPerMillionTokens: "20"},
+			},
+		},
+	}}
+	rows := []factoryvisualization.RuntimeMetricsUsageRow{
+		usageRow("session", "work-claude", "dispatch-claude", "worker-claude", "CLAUDE", "claude-sonnet", 1_000_000, 2_000_000, nil, nil),
+		usageRow("session", "work-override", "dispatch-override", "worker-override", "CODEX", "gpt-5", 1_000_000, 2_000_000, nil, nil),
+		usageRow("session", "work-no-mix", "dispatch-no-mix", "worker-no-mix", "CODEX", "gpt-5", 1_000_000, 2_000_000, int64Ptr(1), nil),
+		usageRow("session", "work-fallback", "dispatch-fallback", "worker-fallback", "CODEX", "fallback", 1_000_000, 1_000_000, nil, nil),
+	}
+	query, err := New(&priceReader{table: builtIn}, settings, metricsQueryStub(rows, nil), logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	first, err := query.Query(context.Background(), costs.QueryRequest{MetricsRoot: "metrics", OperatorSettingsPath: "explicit-settings.json"})
+	if err != nil {
+		t.Fatalf("first Query() error = %v", err)
+	}
+	if first.Status != costs.StatusPartial || first.Coverage.PricedRows != 3 || first.Coverage.UnpricedRows != 1 {
+		t.Fatalf("first report status/coverage = %q/%#v, want PARTIAL with three priced rows", first.Status, first.Coverage)
+	}
+	assertLineAmount(t, first.LineItems, "claude-sonnet", "33", "")
+	assertLineAmount(t, first.LineItems, "gpt-5", "50", "")
+	assertLineAmount(t, first.LineItems, "fallback", "3", "")
+	assertLineAmount(t, first.LineItems, "gpt-5", "", "cached-input rate is not configured")
+	if len(settings.paths) != 1 || settings.paths[0] != "explicit-settings.json" {
+		t.Fatalf("settings paths = %#v, want the explicit request path", settings.paths)
+	}
+
+	settings.config.PriceTable.Models[0].InputPerMillionTokens = "4"
+	second, err := query.Query(context.Background(), costs.QueryRequest{MetricsRoot: "metrics", OperatorSettingsPath: "explicit-settings.json"})
+	if err != nil {
+		t.Fatalf("second Query() error = %v", err)
+	}
+	assertLineAmount(t, second.LineItems, "claude-sonnet", "34", "")
+	if len(settings.paths) != 2 {
+		t.Fatalf("settings paths after repeat = %#v, want one read per query", settings.paths)
+	}
+}
+
+func TestQueryRejectsInvalidOrUnreadableOperatorPriceTableBeforeMetrics(t *testing.T) {
+	t.Parallel()
+
+	var metricsCalls int
+	metrics := factoryvisualization.RuntimeMetricsQuery(func(context.Context, factoryvisualization.RuntimeMetricsQueryRequest) (factoryvisualization.RuntimeMetricsQueryResult, error) {
+		metricsCalls++
+		return factoryvisualization.RuntimeMetricsQueryResult{}, nil
+	})
+	builtIn := &priceReader{table: providers.PriceTable{Currency: providers.PriceTableCurrencyUSD}}
+	invalidSettings := &operatorSettingsReaderStub{config: operatorsettings.Config{PriceTable: operatorsettings.PriceTable{
+		Currency: operatorsettings.PriceTableCurrencyUSD,
+		Models:   []operatorsettings.PriceTableModel{{Provider: "claude", Model: "sonnet", InputPerMillionTokens: "-1", OutputPerMillionTokens: "15"}},
+	}}}
+	query, err := New(builtIn, invalidSettings, metrics, logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("New(invalid settings) error = %v", err)
+	}
+	_, err = query.Query(context.Background(), validRequest())
+	var queryErr *costs.QueryError
+	if !errors.As(err, &queryErr) || queryErr.Kind != costs.QueryErrorInvalidPriceTable || !errors.Is(err, operatorsettings.ErrPriceTableInvalid) {
+		t.Fatalf("invalid operator price table error = %v, want typed actionable failure", err)
+	}
+	if metricsCalls != 0 {
+		t.Fatalf("metrics calls after invalid settings = %d, want none", metricsCalls)
+	}
+
+	readFailure := errors.New("settings unavailable")
+	settingsFailure := &operatorSettingsReaderStub{err: readFailure}
+	query, err = New(builtIn, settingsFailure, metrics, logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("New(settings failure) error = %v", err)
+	}
+	_, err = query.Query(context.Background(), validRequest())
+	if !errors.As(err, &queryErr) || queryErr.Kind != costs.QueryErrorSettingsReadFailed || !errors.Is(err, readFailure) {
+		t.Fatalf("operator settings read error = %v, want typed wrapped failure", err)
+	}
+	if metricsCalls != 0 {
+		t.Fatalf("metrics calls after settings failure = %d, want none", metricsCalls)
+	}
+}
+
+func TestQueryCancellationDoesNotReadDependencies(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	pricingCalls := 0
+	pricing := providers.PriceTableReaderFunc(func() (providers.PriceTable, error) {
+		pricingCalls++
+		return providers.PriceTable{Currency: providers.PriceTableCurrencyUSD}, nil
+	})
+	settings := &operatorSettingsReaderStub{}
+	query, err := New(pricing, settings, metricsQueryStub(nil, nil), logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	_, err = query.Query(ctx, validRequest())
+	if !errors.Is(err, context.Canceled) || pricingCalls != 0 || len(settings.paths) != 0 {
+		t.Fatalf("canceled query error/calls = %v/%d/%d, want canceled with no dependency reads", err, pricingCalls, len(settings.paths))
 	}
 }
 
@@ -462,6 +581,25 @@ func (reader *priceReader) ReadPriceTable() (providers.PriceTable, error) {
 	return reader.table.Clone(), nil
 }
 
+func operatorSettingsStub() *operatorSettingsReaderStub {
+	return &operatorSettingsReaderStub{}
+}
+
+type operatorSettingsReaderStub struct {
+	operatorsettings.Service
+	config operatorsettings.Config
+	err    error
+	paths  []string
+}
+
+func (reader *operatorSettingsReaderStub) LoadFileConfig(path string) (operatorsettings.Config, error) {
+	reader.paths = append(reader.paths, path)
+	if reader.err != nil {
+		return operatorsettings.Config{}, reader.err
+	}
+	return reader.config, nil
+}
+
 func testPriceModel(model, input, output string, cached, reasoning *string) providers.PriceTableModel {
 	entry := providers.PriceTableModel{
 		Provider:                        providers.IDCodex,
@@ -530,6 +668,25 @@ func assertLine(t *testing.T, lines []costs.LineItem, model string, status costs
 		return
 	}
 	t.Fatalf("line for model %q not found in %#v", model, lines)
+}
+
+func assertLineAmount(t *testing.T, lines []costs.LineItem, model, amount, reason string) {
+	t.Helper()
+	for _, line := range lines {
+		if line.Model != model {
+			continue
+		}
+		if amount != "" {
+			if line.Status == costs.StatusPriced && line.PricedAmount != nil && *line.PricedAmount == amount {
+				return
+			}
+			continue
+		}
+		if line.Status == costs.StatusUnpriced && strings.Contains(line.Reason, reason) {
+			return
+		}
+	}
+	t.Fatalf("line for model %q amount=%q reason=%q not found in %#v", model, amount, reason, lines)
 }
 
 func int64Ptr(value int64) *int64    { return &value }

--- a/pkg/services/costs/internal/service/valuation.go
+++ b/pkg/services/costs/internal/service/valuation.go
@@ -19,6 +19,7 @@ type normalizedPrice struct {
 	output    *big.Rat
 	cached    *big.Rat
 	reasoning *big.Rat
+	source    costs.PriceSource
 }
 
 type priceIndex map[string]normalizedPrice
@@ -30,6 +31,7 @@ type priceEntry struct {
 	output    string
 	cached    *string
 	reasoning *string
+	source    costs.PriceSource
 }
 
 type summary struct {
@@ -103,9 +105,10 @@ func calculateReport(
 			return costs.Report{}, err
 		}
 		line := runtimeUsageFromMetrics(row)
-		amount, reason := valueLine(line, prices)
+		amount, source, reason := valueLine(line, prices)
 		if reason == "" {
 			line.Status = costs.StatusPriced
+			line.PriceSource = source
 			line.PricedAmount, err = exactAmountString(amount)
 			if err != nil {
 				return costs.Report{}, err
@@ -165,6 +168,7 @@ func buildPriceIndex(table providers.PriceTable) (priceIndex, error) {
 			output:    model.OutputPerMillionTokens,
 			cached:    model.CachedInputPerMillionTokens,
 			reasoning: model.ReasoningOutputPerMillionTokens,
+			source:    costs.PriceSourceBuiltIn,
 		})
 	}
 	return buildPriceIndexFromEntries(entries)
@@ -180,6 +184,7 @@ func buildOperatorPriceIndex(table operatorsettings.PriceTable) (priceIndex, err
 			output:    model.OutputPerMillionTokens,
 			cached:    model.CachedInputPerMillionTokens,
 			reasoning: model.ReasoningOutputPerMillionTokens,
+			source:    costs.PriceSourceOperatorSupplied,
 		})
 	}
 	return buildPriceIndexFromEntries(entries)
@@ -196,7 +201,7 @@ func buildPriceIndexFromEntries(entries []priceEntry) (priceIndex, error) {
 		if err != nil {
 			return nil, fmt.Errorf("parse output rate for %q/%q: %w", entry.provider, entry.model, err)
 		}
-		price := normalizedPrice{input: input, output: output}
+		price := normalizedPrice{input: input, output: output, source: entry.source}
 		if entry.cached != nil {
 			price.cached, err = parseDecimal(*entry.cached)
 			if err != nil {
@@ -214,20 +219,20 @@ func buildPriceIndexFromEntries(entries []priceEntry) (priceIndex, error) {
 	return index, nil
 }
 
-func valueLine(line costs.LineItem, prices priceIndex) (*big.Rat, string) {
+func valueLine(line costs.LineItem, prices priceIndex) (*big.Rat, costs.PriceSource, string) {
 	provider := canonicalProvider(line.Provider)
 	model := strings.TrimSpace(line.Model)
 	price, reason := validateLine(line, prices, provider, model)
 	if reason != "" {
-		return nil, reason
+		return nil, "", reason
 	}
 	cached, reason := validateSubset("cached-input", "input", line.CachedInputTokens, line.InputTokens, price.cached, provider, model)
 	if reason != "" {
-		return nil, reason
+		return nil, "", reason
 	}
 	reasoning, reason := validateSubset("reasoning-output", "output", line.ReasoningOutputTokens, line.OutputTokens, price.reasoning, provider, model)
 	if reason != "" {
-		return nil, reason
+		return nil, "", reason
 	}
 
 	uncachedInput := *line.InputTokens - cached
@@ -236,7 +241,7 @@ func valueLine(line costs.LineItem, prices priceIndex) (*big.Rat, string) {
 	amount.Add(amount, new(big.Rat).Mul(big.NewRat(cached, 1), price.cachedOrZero()))
 	amount.Add(amount, new(big.Rat).Mul(big.NewRat(nonReasoningOutput, 1), price.output))
 	amount.Add(amount, new(big.Rat).Mul(big.NewRat(reasoning, 1), price.reasoningOrZero()))
-	return amount.Quo(amount, big.NewRat(millionTokenCount, 1)), ""
+	return amount.Quo(amount, big.NewRat(millionTokenCount, 1)), price.source, ""
 }
 
 func validateLine(

--- a/pkg/services/costs/internal/service/valuation.go
+++ b/pkg/services/costs/internal/service/valuation.go
@@ -10,6 +10,7 @@ import (
 	costs "github.com/portpowered/infinite-you/pkg/services/costs"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
@@ -21,6 +22,15 @@ type normalizedPrice struct {
 }
 
 type priceIndex map[string]normalizedPrice
+
+type priceEntry struct {
+	provider  string
+	model     string
+	input     string
+	output    string
+	cached    *string
+	reasoning *string
+}
 
 type summary struct {
 	amount                 *big.Rat
@@ -54,17 +64,27 @@ type tokenAccumulator struct {
 
 func calculateReport(
 	ctx context.Context,
-	table providers.PriceTable,
+	builtInTable providers.PriceTable,
+	operatorTable operatorsettings.PriceTable,
 	rows []factoryvisualization.RuntimeMetricsUsageRow,
 	scope costs.Scope,
 ) (costs.Report, error) {
-	prices, err := buildPriceIndex(table)
+	prices, err := buildPriceIndex(builtInTable)
 	if err != nil {
 		return costs.Report{}, err
 	}
+	operatorPrices, err := buildOperatorPriceIndex(operatorTable)
+	if err != nil {
+		return costs.Report{}, err
+	}
+	for key, price := range operatorPrices {
+		// Operator rows are complete replacements. In particular, an omitted
+		// optional subclass must not inherit a rate from the built-in row.
+		prices[key] = price
+	}
 	report := costs.Report{
 		Scope:           scope,
-		Currency:        table.Currency,
+		Currency:        builtInTable.Currency,
 		UnpricedPairs:   []costs.UnpricedPair{},
 		LineItems:       []costs.LineItem{},
 		WorkItems:       []costs.Rollup{},
@@ -116,19 +136,19 @@ func calculateReport(
 	report.TokenTotals = overall.tokens.totals()
 	report.UnpricedDispatchCount = overall.unpricedDispatchCount()
 	report.UnpricedPairs = overall.unpricedPairsValue()
-	report.WorkItems, err = rollups(work, table.Currency)
+	report.WorkItems, err = rollups(work, builtInTable.Currency)
 	if err != nil {
 		return costs.Report{}, err
 	}
-	report.WorkerSessions, err = rollups(workerSessions, table.Currency)
+	report.WorkerSessions, err = rollups(workerSessions, builtInTable.Currency)
 	if err != nil {
 		return costs.Report{}, err
 	}
-	report.FactorySessions, err = rollups(factorySessions, table.Currency)
+	report.FactorySessions, err = rollups(factorySessions, builtInTable.Currency)
 	if err != nil {
 		return costs.Report{}, err
 	}
-	report.ProviderModels, err = providerRollups(providerModels, table.Currency)
+	report.ProviderModels, err = providerRollups(providerModels, builtInTable.Currency)
 	if err != nil {
 		return costs.Report{}, err
 	}
@@ -136,30 +156,60 @@ func calculateReport(
 }
 
 func buildPriceIndex(table providers.PriceTable) (priceIndex, error) {
-	index := make(priceIndex, len(table.Models))
+	entries := make([]priceEntry, 0, len(table.Models))
 	for _, model := range table.Models {
-		input, err := parseDecimal(model.InputPerMillionTokens)
+		entries = append(entries, priceEntry{
+			provider:  model.Provider.String(),
+			model:     model.Model,
+			input:     model.InputPerMillionTokens,
+			output:    model.OutputPerMillionTokens,
+			cached:    model.CachedInputPerMillionTokens,
+			reasoning: model.ReasoningOutputPerMillionTokens,
+		})
+	}
+	return buildPriceIndexFromEntries(entries)
+}
+
+func buildOperatorPriceIndex(table operatorsettings.PriceTable) (priceIndex, error) {
+	entries := make([]priceEntry, 0, len(table.Models))
+	for _, model := range table.Models {
+		entries = append(entries, priceEntry{
+			provider:  model.Provider,
+			model:     model.Model,
+			input:     model.InputPerMillionTokens,
+			output:    model.OutputPerMillionTokens,
+			cached:    model.CachedInputPerMillionTokens,
+			reasoning: model.ReasoningOutputPerMillionTokens,
+		})
+	}
+	return buildPriceIndexFromEntries(entries)
+}
+
+func buildPriceIndexFromEntries(entries []priceEntry) (priceIndex, error) {
+	index := make(priceIndex, len(entries))
+	for _, entry := range entries {
+		input, err := parseDecimal(entry.input)
 		if err != nil {
-			return nil, fmt.Errorf("parse input rate for %q/%q: %w", model.Provider, model.Model, err)
+			return nil, fmt.Errorf("parse input rate for %q/%q: %w", entry.provider, entry.model, err)
 		}
-		output, err := parseDecimal(model.OutputPerMillionTokens)
+		output, err := parseDecimal(entry.output)
 		if err != nil {
-			return nil, fmt.Errorf("parse output rate for %q/%q: %w", model.Provider, model.Model, err)
+			return nil, fmt.Errorf("parse output rate for %q/%q: %w", entry.provider, entry.model, err)
 		}
 		price := normalizedPrice{input: input, output: output}
-		if model.CachedInputPerMillionTokens != nil {
-			price.cached, err = parseDecimal(*model.CachedInputPerMillionTokens)
+		if entry.cached != nil {
+			price.cached, err = parseDecimal(*entry.cached)
 			if err != nil {
-				return nil, fmt.Errorf("parse cached-input rate for %q/%q: %w", model.Provider, model.Model, err)
+				return nil, fmt.Errorf("parse cached-input rate for %q/%q: %w", entry.provider, entry.model, err)
 			}
 		}
-		if model.ReasoningOutputPerMillionTokens != nil {
-			price.reasoning, err = parseDecimal(*model.ReasoningOutputPerMillionTokens)
+		if entry.reasoning != nil {
+			price.reasoning, err = parseDecimal(*entry.reasoning)
 			if err != nil {
-				return nil, fmt.Errorf("parse reasoning-output rate for %q/%q: %w", model.Provider, model.Model, err)
+				return nil, fmt.Errorf("parse reasoning-output rate for %q/%q: %w", entry.provider, entry.model, err)
 			}
 		}
-		index[providerModelKey(model.Provider.String(), model.Model)] = price
+		index[providerModelKey(entry.provider, entry.model)] = price
 	}
 	return index, nil
 }

--- a/pkg/services/costs/transports/cli/costs_test.go
+++ b/pkg/services/costs/transports/cli/costs_test.go
@@ -136,6 +136,12 @@ func assertJSONReportDimensions(t *testing.T, decoded generatedclient.CostsRepor
 	if decoded.Coverage.PricedRows != 1 || len(decoded.LineItems) != 2 || len(decoded.WorkItems) != 1 || len(decoded.WorkerSessions) != 1 {
 		t.Fatalf("decoded report dimensions = %#v, want complete API report", decoded)
 	}
+	if decoded.LineItems[1].PriceSource == nil || *decoded.LineItems[1].PriceSource != generatedclient.CostsLineItemPriceSource("BUILT_IN") {
+		t.Fatalf("decoded priced line source = %#v, want BUILT_IN", decoded.LineItems[1].PriceSource)
+	}
+	if decoded.LineItems[0].PriceSource != nil {
+		t.Fatalf("decoded unpriced line source = %#v, want omitted", decoded.LineItems[0].PriceSource)
+	}
 	if len(decoded.ProviderModels) != 1 || decoded.ProviderModels[0].Key != "openai/mystery" || len(decoded.FactorySessions) != 1 {
 		t.Fatalf("decoded provider/session rollups = %#v, want complete API report", decoded)
 	}
@@ -359,6 +365,9 @@ func costsReportForCLI() generatedclient.CostsReport {
 	provider := "openai"
 	model := "mystery"
 	reason := "no configured price"
+	pricedProvider := "CODEX"
+	pricedModel := "gpt-5-codex"
+	builtInSource := generatedclient.CostsLineItemPriceSource("BUILT_IN")
 	input, cached, output, reasoning := int64(7), int64(2), int64(3), int64(4)
 	coverage := generatedclient.CostsCoverage{
 		EncounteredRows: 2, PricedRows: 1, UnpricedRows: 1,
@@ -389,7 +398,8 @@ func costsReportForCLI() generatedclient.CostsReport {
 		LineItems: []generatedclient.CostsLineItem{
 			{Provider: &provider, Model: &model, Status: generatedclient.CostsLineItemStatus("UNPRICED"), Reason: &reason,
 				InputTokens: &input, CachedInputTokens: &cached, OutputTokens: &output, ReasoningOutputTokens: &reasoning},
-			{Status: generatedclient.CostsLineItemStatus("PRICED"), PricedAmount: &amount},
+			{Provider: &pricedProvider, Model: &pricedModel, Status: generatedclient.CostsLineItemStatus("PRICED"), PriceSource: &builtInSource,
+				PricedAmount: &amount, InputTokens: &input, CachedInputTokens: &cached, OutputTokens: &output, ReasoningOutputTokens: &reasoning},
 		},
 		WorkItems:       []generatedclient.CostsRollup{rollup},
 		WorkerSessions:  []generatedclient.CostsRollup{{Key: "worker-a", Currency: generatedclient.CostsRollupCurrency("USD"), Status: generatedclient.CostsRollupStatus("PRICED"), TokenTotals: tokenTotals, UnpricedPairs: []generatedclient.CostsUnpricedPair{}, Coverage: coverage}},

--- a/pkg/services/costs/transports/cli/output.go
+++ b/pkg/services/costs/transports/cli/output.go
@@ -37,7 +37,7 @@ func renderHumanCosts(report generatedclient.CostsReport) string {
 	renderRollupDimension(&output, "Worker Sessions", rollupViews(report.WorkerSessions))
 	renderRollupDimension(&output, "Provider/models", providerModelViews(report.ProviderModels))
 	renderRollupDimension(&output, "Factory Sessions", rollupViews(report.FactorySessions))
-	renderUnpricedItems(&output, report.LineItems)
+	renderLineItems(&output, report.LineItems)
 	return output.String()
 }
 
@@ -138,14 +138,38 @@ func renderRollupDimension(output *strings.Builder, name string, rollups []human
 	}
 }
 
-func renderUnpricedItems(output *strings.Builder, items []generatedclient.CostsLineItem) {
-	count := 0
+func renderLineItems(output *strings.Builder, items []generatedclient.CostsLineItem) {
+	pricedCount := 0
 	for _, item := range items {
-		if string(item.Status) == "UNPRICED" {
-			count++
+		if string(item.Status) == "PRICED" {
+			pricedCount++
 		}
 	}
-	fmt.Fprintf(output, "Unpriced usage: %d rows\n", count)
+	fmt.Fprintf(output, "Priced usage: %d rows\n", pricedCount)
+	for _, item := range items {
+		if string(item.Status) != "PRICED" {
+			continue
+		}
+		fmt.Fprintf(output, "  PRICED provider=%s model=%s\n",
+			displayPointer(item.Provider), displayPointer(item.Model))
+		renderPricedAmount(output, "    Priced amount", item.PricedAmount)
+		fmt.Fprintf(output, "    Price source: %s\n", displayPriceSource(item.PriceSource))
+		renderTokenCounts(output, "    ", generatedclient.CostsTokenTotals{
+			TotalTokens:           sumTokenClasses(item.InputTokens, item.OutputTokens),
+			InputTokens:           item.InputTokens,
+			CachedInputTokens:     item.CachedInputTokens,
+			OutputTokens:          item.OutputTokens,
+			ReasoningOutputTokens: item.ReasoningOutputTokens,
+		})
+	}
+
+	unpricedCount := 0
+	for _, item := range items {
+		if string(item.Status) == "UNPRICED" {
+			unpricedCount++
+		}
+	}
+	fmt.Fprintf(output, "Unpriced usage: %d rows\n", unpricedCount)
 	for _, item := range items {
 		if string(item.Status) != "UNPRICED" {
 			continue
@@ -163,6 +187,13 @@ func renderUnpricedItems(output *strings.Builder, items []generatedclient.CostsL
 			ReasoningOutputTokens: item.ReasoningOutputTokens,
 		})
 	}
+}
+
+func displayPriceSource(source *generatedclient.CostsLineItemPriceSource) string {
+	if source == nil || strings.TrimSpace(string(*source)) == "" {
+		return "<unknown>"
+	}
+	return string(*source)
 }
 
 func renderUnpricedCoverage(output *strings.Builder, dispatchCount int, pairs []generatedclient.CostsUnpricedPair) {

--- a/pkg/services/costs/transports/cli/output_test.go
+++ b/pkg/services/costs/transports/cli/output_test.go
@@ -30,6 +30,7 @@ Work items: 0
 Worker Sessions: 0
 Provider/models: 0
 Factory Sessions: 0
+Priced usage: 0 rows
 Unpriced usage: 0 rows
 `,
 	)
@@ -58,6 +59,7 @@ Work items: 0
 Worker Sessions: 0
 Provider/models: 0
 Factory Sessions: 0
+Priced usage: 0 rows
 Unpriced usage: 0 rows
 `,
 	)
@@ -90,6 +92,7 @@ Work items: 0
 Worker Sessions: 0
 Provider/models: 0
 Factory Sessions: 0
+Priced usage: 0 rows
 Unpriced usage: 0 rows
 `,
 	)
@@ -118,9 +121,93 @@ Work items: 0
 Worker Sessions: 0
 Provider/models: 0
 Factory Sessions: 0
+Priced usage: 0 rows
 Unpriced usage: 0 rows
 `,
 	)
+}
+
+func TestCostsHumanOutputPricedLineItemsShowSourceAndUnpricedFactsGolden(t *testing.T) {
+	builtInProvider, builtInModel := "CODEX", "gpt-5-codex"
+	operatorProvider, operatorModel := "CLAUDE", "claude-sonnet-4-6"
+	unknownProvider, unknownModel := "CLAUDE", "unknown-model"
+	unknownReason := "no configured price"
+	builtInSource := generatedclient.CostsLineItemPriceSource("BUILT_IN")
+	operatorSource := generatedclient.CostsLineItemPriceSource("OPERATOR_SUPPLIED")
+	builtInAmount, operatorAmount := "21.25", "0.0081"
+	builtInInput, builtInOutput := int64(1_000_000), int64(2_000_000)
+	operatorInput, operatorOutput := int64(1_200), int64(300)
+	unknownInput, unknownOutput := int64(1_200), int64(300)
+	total := int64(3_003_000)
+	report := generatedclient.CostsReport{
+		Currency:  generatedclient.CostsReportCurrency("USD"),
+		Status:    generatedclient.CostsReportStatus("PARTIAL"),
+		KnownCost: &builtInAmount, PricedSubtotal: &builtInAmount,
+		TokenTotals: generatedclient.CostsTokenTotals{TotalTokens: &total},
+		LineItems: []generatedclient.CostsLineItem{
+			{
+				Provider: &builtInProvider, Model: &builtInModel,
+				Status:      generatedclient.CostsLineItemStatus("PRICED"),
+				PriceSource: &builtInSource, PricedAmount: &builtInAmount,
+				InputTokens: &builtInInput, OutputTokens: &builtInOutput,
+			},
+			{
+				Provider: &operatorProvider, Model: &operatorModel,
+				Status:      generatedclient.CostsLineItemStatus("PRICED"),
+				PriceSource: &operatorSource, PricedAmount: &operatorAmount,
+				InputTokens: &operatorInput, OutputTokens: &operatorOutput,
+			},
+			{
+				Provider: &unknownProvider, Model: &unknownModel,
+				Status: generatedclient.CostsLineItemStatus("UNPRICED"),
+				Reason: &unknownReason, InputTokens: &unknownInput, OutputTokens: &unknownOutput,
+			},
+		},
+	}
+	assertHumanOutputGolden(t, "priced-line-items", report, `Scope: all Factory Sessions
+Currency: USD
+Status: PARTIAL
+Cost (USD): $21.25 + ?? unknown
+Priced subtotal (USD): 21.25
+Total tokens: 3003000
+Input tokens: absent
+Cached-input tokens: absent
+Output tokens: absent
+Reasoning-output tokens: absent
+Coverage: rows priced 0/0; provider/models priced 0/0
+Unpriced dispatches: 0
+Unpriced provider/models: 0
+
+Work items: 0
+Worker Sessions: 0
+Provider/models: 0
+Factory Sessions: 0
+Priced usage: 2 rows
+  PRICED provider=CODEX model=gpt-5-codex
+    Priced amount (USD): 21.25
+    Price source: BUILT_IN
+    Total tokens: 3000000
+    Input tokens: 1000000
+    Cached-input tokens: absent
+    Output tokens: 2000000
+    Reasoning-output tokens: absent
+  PRICED provider=CLAUDE model=claude-sonnet-4-6
+    Priced amount (USD): 0.0081
+    Price source: OPERATOR_SUPPLIED
+    Total tokens: 1500
+    Input tokens: 1200
+    Cached-input tokens: absent
+    Output tokens: 300
+    Reasoning-output tokens: absent
+Unpriced usage: 1 rows
+  UNPRICED provider=CLAUDE model=unknown-model
+    Reason: no configured price
+    Total tokens: 1500
+    Input tokens: 1200
+    Cached-input tokens: absent
+    Output tokens: 300
+    Reasoning-output tokens: absent
+`)
 }
 
 func assertHumanOutputGolden(t *testing.T, name string, report generatedclient.CostsReport, want string) {

--- a/pkg/services/costs/transports/http/adapter_test.go
+++ b/pkg/services/costs/transports/http/adapter_test.go
@@ -55,6 +55,66 @@ func TestAdapterMapsExactReportAndRuntimeInputs(t *testing.T) {
 	assertMappedReport(t, got, inputTokens, outputTokens)
 }
 
+func TestAdapterMapsBothPriceSourcesAndOmitsSourceForUnpricedRows(t *testing.T) {
+	t.Parallel()
+
+	builtInAmount := "1.25"
+	operatorAmount := "2.50"
+	query := costs.CostsQuery(func(context.Context, costs.QueryRequest) (costs.Report, error) {
+		return costs.Report{
+			Currency: "USD",
+			Status:   costs.StatusPartial,
+			LineItems: []costs.LineItem{
+				{Provider: "CODEX", Model: "built-in", Status: costs.StatusPriced, PriceSource: costs.PriceSourceBuiltIn, PricedAmount: &builtInAmount},
+				{Provider: "CLAUDE", Model: "operator", Status: costs.StatusPriced, PriceSource: costs.PriceSourceOperatorSupplied, PricedAmount: &operatorAmount},
+				{Provider: "CLAUDE", Model: "unknown", Status: costs.StatusUnpriced, Reason: "no configured price"},
+			},
+		}, nil
+	})
+
+	got, err := NewAdapter(query, "metrics", "settings").GetMetricsCosts(context.Background(), "")
+	if err != nil {
+		t.Fatalf("GetMetricsCosts() error = %v", err)
+	}
+	if len(got.LineItems) != 3 {
+		t.Fatalf("mapped line items = %#v, want three rows", got.LineItems)
+	}
+	assertMappedPriceSource(t, got.LineItems[0].PriceSource, "BUILT_IN")
+	assertMappedPriceSource(t, got.LineItems[1].PriceSource, "OPERATOR_SUPPLIED")
+	if got.LineItems[2].PriceSource != nil {
+		t.Fatalf("unpriced mapped source = %q, want omitted", *got.LineItems[2].PriceSource)
+	}
+
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal mapped report: %v", err)
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		t.Fatalf("decode mapped report JSON: %v", err)
+	}
+	var lineItems []map[string]json.RawMessage
+	if err := json.Unmarshal(payload["line_items"], &lineItems); err != nil {
+		t.Fatalf("decode mapped line items JSON: %v", err)
+	}
+	if _, ok := lineItems[0]["price_source"]; !ok {
+		t.Fatalf("built-in JSON line item = %s, want price_source", encoded)
+	}
+	if _, ok := lineItems[1]["price_source"]; !ok {
+		t.Fatalf("operator JSON line item = %s, want price_source", encoded)
+	}
+	if _, ok := lineItems[2]["price_source"]; ok {
+		t.Fatalf("unpriced JSON line item = %s, want source-less row", encoded)
+	}
+}
+
+func assertMappedPriceSource(t *testing.T, source *factoryapi.CostsLineItemPriceSource, want string) {
+	t.Helper()
+	if source == nil || string(*source) != want {
+		t.Fatalf("mapped price source = %v, want %q", source, want)
+	}
+}
+
 func assertMappedReport(t *testing.T, got factoryapi.CostsReport, inputTokens, outputTokens int64) {
 	t.Helper()
 	assertMappedReportHeader(t, got)

--- a/pkg/services/costs/transports/http/mapping.go
+++ b/pkg/services/costs/transports/http/mapping.go
@@ -59,11 +59,20 @@ func lineItemsToAPI(items []costs.LineItem) []factoryapi.CostsLineItem {
 			CachedInputTokens:     item.CachedInputTokens,
 			ReasoningOutputTokens: item.ReasoningOutputTokens,
 			Status:                factoryapi.CostsLineItemStatus(item.Status),
+			PriceSource:           priceSourceToAPI(item.PriceSource),
 			PricedAmount:          item.PricedAmount,
 			Reason:                optionalString(item.Reason),
 		})
 	}
 	return result
+}
+
+func priceSourceToAPI(source costs.PriceSource) *factoryapi.CostsLineItemPriceSource {
+	if source == "" {
+		return nil
+	}
+	value := factoryapi.CostsLineItemPriceSource(source)
+	return &value
 }
 
 func rollupsToAPI(rollups []costs.Rollup) []factoryapi.CostsRollup {

--- a/pkg/services/costs/wire/wire.go
+++ b/pkg/services/costs/wire/wire.go
@@ -6,14 +6,16 @@ import (
 	costs "github.com/portpowered/infinite-you/pkg/services/costs"
 	costsservice "github.com/portpowered/infinite-you/pkg/services/costs/internal/service"
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 )
 
-// NewCostsQuery constructs the stateless Costs operation from its two narrow
-// owner capabilities and the process logger.
+// NewCostsQuery constructs the stateless Costs operation from its owner
+// capabilities and the process logger.
 func NewCostsQuery(
 	pricing costs.PriceTableReader,
+	settings operatorsettings.Service,
 	metrics factoryvisualization.RuntimeMetricsQuery,
 	logger logging.Logger,
 ) (costs.CostsQuery, error) {
-	return costsservice.New(pricing, metrics, logger)
+	return costsservice.New(pricing, settings, metrics, logger)
 }

--- a/pkg/services/costs/wire/wire_test.go
+++ b/pkg/services/costs/wire/wire_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	costs "github.com/portpowered/infinite-you/pkg/services/costs"
 	factoryvisualization "github.com/portpowered/infinite-you/pkg/services/factory_visualization"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	providers "github.com/portpowered/infinite-you/pkg/services/providers"
 )
 
@@ -17,6 +18,7 @@ func TestNewCostsQueryUsesNarrowDependencies(t *testing.T) {
 		providers.PriceTableReaderFunc(func() (providers.PriceTable, error) {
 			return providers.PriceTable{Currency: providers.PriceTableCurrencyUSD, Models: []providers.PriceTableModel{}}, nil
 		}),
+		operatorSettingsStub{},
 		func(context.Context, factoryvisualization.RuntimeMetricsQueryRequest) (factoryvisualization.RuntimeMetricsQueryResult, error) {
 			return factoryvisualization.RuntimeMetricsQueryResult{}, nil
 		},
@@ -35,4 +37,12 @@ func TestNewCostsQueryUsesNarrowDependencies(t *testing.T) {
 	if result.Status != costs.StatusNoUsage || result.Currency != "USD" {
 		t.Fatalf("result = %#v, want empty USD report", result)
 	}
+}
+
+type operatorSettingsStub struct {
+	operatorsettings.Service
+}
+
+func (operatorSettingsStub) LoadFileConfig(string) (operatorsettings.Config, error) {
+	return operatorsettings.Config{}, nil
 }

--- a/pkg/transports/http/client/client.gen.go
+++ b/pkg/transports/http/client/client.gen.go
@@ -46,6 +46,12 @@ const (
 	UNKNOWN      CheckpointResumabilityStatus = "UNKNOWN"
 )
 
+// Defines values for CostsLineItemPriceSource.
+const (
+	BUILTIN          CostsLineItemPriceSource = "BUILT_IN"
+	OPERATORSUPPLIED CostsLineItemPriceSource = "OPERATOR_SUPPLIED"
+)
+
 // Defines values for CostsLineItemStatus.
 const (
 	CostsLineItemStatusPRICED   CostsLineItemStatus = "PRICED"
@@ -1705,6 +1711,9 @@ type CostsLineItem struct {
 	Model             *string `json:"model,omitempty"`
 	OutputTokens      *int64  `json:"output_tokens,omitempty"`
 
+	// PriceSource Pricing authority for the complete row used for a PRICED line item; omitted for UNPRICED rows.
+	PriceSource *CostsLineItemPriceSource `json:"price_source,omitempty"`
+
 	// PricedAmount Exact USD decimal amount; absent for UNPRICED rows and present as "0" for explicitly free usage.
 	PricedAmount *string `json:"priced_amount,omitempty"`
 	Provider     *string `json:"provider,omitempty"`
@@ -1718,6 +1727,9 @@ type CostsLineItem struct {
 	WorkId          *string             `json:"work_id,omitempty"`
 	WorkerSessionId *string             `json:"worker_session_id,omitempty"`
 }
+
+// CostsLineItemPriceSource Pricing authority for the complete row used for a PRICED line item; omitted for UNPRICED rows.
+type CostsLineItemPriceSource string
 
 // CostsLineItemStatus PRICED means every measured token class has a configured rate; UNPRICED means the row is retained with its tokens but cannot be fully valued.
 type CostsLineItemStatus string

--- a/pkg/transports/http/contracttests/openapi_contract_factory_validation_test.go
+++ b/pkg/transports/http/contracttests/openapi_contract_factory_validation_test.go
@@ -93,6 +93,17 @@ func assertCostsReportSchema(t *testing.T, schemas map[string]any) {
 			t.Fatalf("CostsLineItem.%s = %#v, want integer", field, lineProperties[field])
 		}
 	}
+	priceSource, ok := lineProperties["price_source"].(map[string]any)
+	if !ok {
+		t.Fatalf("CostsLineItem.price_source = %#v, want optional enum", lineProperties["price_source"])
+	}
+	assertEnumValues(t, priceSource, "CostsLineItem.price_source", []string{"BUILT_IN", "OPERATOR_SUPPLIED"})
+	if description, ok := priceSource["description"].(string); !ok || description == "" {
+		t.Fatalf("CostsLineItem.price_source description = %#v, want documented presence rules", priceSource["description"])
+	}
+	if required, ok := lineItem["required"].([]any); ok && containsString(required, "price_source") {
+		t.Fatalf("CostsLineItem.price_source must be optional for UNPRICED rows")
+	}
 	status, ok := reportProperties["status"].(map[string]any)
 	if !ok {
 		t.Fatalf("CostsReport.status = %#v", reportProperties["status"])

--- a/pkg/transports/http/generated/server.gen.go
+++ b/pkg/transports/http/generated/server.gen.go
@@ -43,6 +43,12 @@ const (
 	UNKNOWN      CheckpointResumabilityStatus = "UNKNOWN"
 )
 
+// Defines values for CostsLineItemPriceSource.
+const (
+	BUILTIN          CostsLineItemPriceSource = "BUILT_IN"
+	OPERATORSUPPLIED CostsLineItemPriceSource = "OPERATOR_SUPPLIED"
+)
+
 // Defines values for CostsLineItemStatus.
 const (
 	CostsLineItemStatusPRICED   CostsLineItemStatus = "PRICED"
@@ -1731,6 +1737,9 @@ type CostsLineItem struct {
 	Model             *string `json:"model,omitempty"`
 	OutputTokens      *int64  `json:"output_tokens,omitempty"`
 
+	// PriceSource Pricing authority for the complete row used for a PRICED line item; omitted for UNPRICED rows.
+	PriceSource *CostsLineItemPriceSource `json:"price_source,omitempty"`
+
 	// PricedAmount Exact USD decimal amount; absent for UNPRICED rows and present as "0" for explicitly free usage.
 	PricedAmount *string `json:"priced_amount,omitempty"`
 	Provider     *string `json:"provider,omitempty"`
@@ -1744,6 +1753,9 @@ type CostsLineItem struct {
 	WorkId          *string             `json:"work_id,omitempty"`
 	WorkerSessionId *string             `json:"worker_session_id,omitempty"`
 }
+
+// CostsLineItemPriceSource Pricing authority for the complete row used for a PRICED line item; omitted for UNPRICED rows.
+type CostsLineItemPriceSource string
 
 // CostsLineItemStatus PRICED means every measured token class has a configured rate; UNPRICED means the row is retained with its tokens but cannot be fully valued.
 type CostsLineItemStatus string

--- a/pkg/wire/session_runtime_providers.go
+++ b/pkg/wire/session_runtime_providers.go
@@ -643,14 +643,16 @@ func provideProviderPriceTableReader() (costs.PriceTableReader, error) {
 	return providerswire.NewPriceTableReader()
 }
 
-// provideCostsQuery composes valuation over canonical metrics and the narrow
-// Providers pricing reader. Costs reads no artifacts or operator files.
+// provideCostsQuery composes valuation over canonical metrics, immutable
+// Providers pricing facts, and the singular Operator Settings root. Costs
+// receives the explicit settings path per request and does not read files.
 func provideCostsQuery(
 	pricing costs.PriceTableReader,
+	settings operatorsettings.Service,
 	metrics factoryvisualization.RuntimeMetricsQuery,
 	logger logging.Logger,
 ) (costs.CostsQuery, error) {
-	return costswire.NewCostsQuery(pricing, metrics, logger)
+	return costswire.NewCostsQuery(pricing, settings, metrics, logger)
 }
 
 func provideCostsQueryCapability(

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -560,7 +560,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	costsQuery, err := provideCostsQuery(priceTableReader, runtimeMetricsQuery, loggingLogger)
+	costsQuery, err := provideCostsQuery(priceTableReader, operatorsettingsService, runtimeMetricsQuery, loggingLogger)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/functional/factory/visualization/runtime_metrics/replay_operator_price_table_test.go
+++ b/tests/functional/factory/visualization/runtime_metrics/replay_operator_price_table_test.go
@@ -1,0 +1,34 @@
+package runtime_metrics_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
+	globalconfigmapping "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/globalconfig"
+)
+
+func writeReplayOperatorPriceTable(
+	t *testing.T,
+	homeDir string,
+	models ...operatorsettings.PriceTableModel,
+) {
+	t.Helper()
+	payload, err := globalconfigmapping.Encode(operatorsettings.Config{
+		PriceTable: operatorsettings.PriceTable{
+			Currency: operatorsettings.PriceTableCurrencyUSD,
+			Models:   models,
+		},
+	})
+	if err != nil {
+		t.Fatalf("encode replay operator price table: %v", err)
+	}
+	configPath := operatorsettings.DefaultConfigPath(homeDir)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("create replay operator settings directory: %v", err)
+	}
+	if err := os.WriteFile(configPath, payload, 0o600); err != nil {
+		t.Fatalf("write replay operator price table: %v", err)
+	}
+}

--- a/tests/functional/factory/visualization/runtime_metrics/replay_operator_price_table_test.go
+++ b/tests/functional/factory/visualization/runtime_metrics/replay_operator_price_table_test.go
@@ -24,7 +24,7 @@ func writeReplayOperatorPriceTable(
 	if err != nil {
 		t.Fatalf("encode replay operator price table: %v", err)
 	}
-	configPath := operatorsettings.DefaultConfigPath(homeDir)
+	configPath := filepath.Join(homeDir, ".you-agent-factory", "config.json")
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("create replay operator settings directory: %v", err)
 	}

--- a/tests/functional/factory/visualization/runtime_metrics/replay_priced_cost_test.go
+++ b/tests/functional/factory/visualization/runtime_metrics/replay_priced_cost_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/portpowered/infinite-you/internal/testutil"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	generatedclient "github.com/portpowered/infinite-you/pkg/transports/http/client"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
@@ -62,6 +63,8 @@ func TestReplayPricedUsageReachesPublicCosts(t *testing.T) {
 	wantCost := expectedPricedReplayCost()
 	if !strings.Contains(humanOutput, "Status: PRICED") ||
 		!strings.Contains(humanOutput, "Cost (USD): $"+wantCost) ||
+		!strings.Contains(humanOutput, "Priced amount (USD): "+wantCost) ||
+		!strings.Contains(humanOutput, "Price source: BUILT_IN") ||
 		!strings.Contains(humanOutput, "Total tokens: 3000000") {
 		t.Fatalf("human replay costs output = %q, want PRICED/$%s/3000000", humanOutput, wantCost)
 	}
@@ -77,6 +80,30 @@ func TestReplayPricedUsageReachesPublicCosts(t *testing.T) {
 	assertPricedReplayCostsReport(t, apiReport)
 	if got, want := apiReport, cliReport; !reportsHaveSameReplayCostFacts(got, want) {
 		t.Fatalf("HTTP and CLI replay cost reports differ:\nHTTP=%#v\nCLI=%#v", got, want)
+	}
+
+	cachedRate, reasoningRate := "0.5", "30"
+	writeReplayOperatorPriceTable(t, homeDir, operatorsettings.PriceTableModel{
+		Provider:                        "codex",
+		Model:                           "gpt-5-codex",
+		InputPerMillionTokens:           "2",
+		OutputPerMillionTokens:          "20",
+		CachedInputPerMillionTokens:     &cachedRate,
+		ReasoningOutputPerMillionTokens: &reasoningRate,
+	})
+	overrideHuman := executeReplayCostsCLI(t, process, environment, server.URL(), false)
+	if !strings.Contains(overrideHuman, "Status: PRICED") ||
+		!strings.Contains(overrideHuman, "Cost (USD): $42.00") ||
+		!strings.Contains(overrideHuman, "Priced amount (USD): 42") ||
+		!strings.Contains(overrideHuman, "Price source: OPERATOR_SUPPLIED") {
+		t.Fatalf("human replay costs output for Codex override = %q, want complete operator override", overrideHuman)
+	}
+	overrideCLIReport := decodeReplayCostsCLI(t, process, environment, server.URL())
+	assertOperatorCodexOverrideReplayCostsReport(t, overrideCLIReport)
+	overrideAPIReport := getReplayCostsHTTP(t, server.URL())
+	assertOperatorCodexOverrideReplayCostsReport(t, overrideAPIReport)
+	if got, want := overrideAPIReport, overrideCLIReport; !reportsHaveSameReplayCostFacts(got, want) {
+		t.Fatalf("HTTP and CLI Codex override reports differ:\nHTTP=%#v\nCLI=%#v", got, want)
 	}
 
 	if providerRunner.CallCount() != 0 || scriptRunner.CallCount() != 0 {
@@ -148,7 +175,8 @@ func assertPricedReplayCostsReport(t *testing.T, report generatedclient.CostsRep
 	}
 	item := report.LineItems[0]
 	if item.Status != generatedclient.CostsLineItemStatus("PRICED") || item.Provider == nil || *item.Provider != "CODEX" || item.Model == nil || *item.Model != "gpt-5-codex" ||
-		item.WorkerSessionId == nil || *item.WorkerSessionId != "cost-replay-priced-worker-session" || item.PricedAmount == nil || *item.PricedAmount != wantCost {
+		item.WorkerSessionId == nil || *item.WorkerSessionId != "cost-replay-priced-worker-session" || item.PricedAmount == nil || *item.PricedAmount != wantCost ||
+		item.PriceSource == nil || *item.PriceSource != generatedclient.CostsLineItemPriceSource("BUILT_IN") {
 		t.Fatalf("replay priced line item = %#v, want Codex identity, Worker Session lineage, and %s", item, wantCost)
 	}
 	rollup := report.ProviderModels[0]
@@ -157,6 +185,25 @@ func assertPricedReplayCostsReport(t *testing.T, report generatedclient.CostsRep
 	}
 	if report.WorkerSessions[0].Key != "cost-replay-priced-worker-session" {
 		t.Fatalf("replay Worker Session rollup key = %q, want recorded Worker Session lineage", report.WorkerSessions[0].Key)
+	}
+}
+
+func assertOperatorCodexOverrideReplayCostsReport(t *testing.T, report generatedclient.CostsReport) {
+	t.Helper()
+	const wantAmount = "42"
+	if report.Status != generatedclient.CostsReportStatus("PRICED") || report.KnownCost == nil || *report.KnownCost != wantAmount ||
+		report.PricedSubtotal == nil || *report.PricedSubtotal != wantAmount {
+		t.Fatalf("Codex override amounts/status = %q/%v/%v, want PRICED and %s", report.Status, report.KnownCost, report.PricedSubtotal, wantAmount)
+	}
+	assertReplayTokenTotals(t, report.TokenTotals, replayPricedInputTokens, replayPricedOutputTokens, replayPricedTotalTokens)
+	if len(report.LineItems) != 1 {
+		t.Fatalf("Codex override line items = %d, want one", len(report.LineItems))
+	}
+	item := report.LineItems[0]
+	if item.Status != generatedclient.CostsLineItemStatus("PRICED") || item.Provider == nil || *item.Provider != "CODEX" ||
+		item.Model == nil || *item.Model != "gpt-5-codex" || item.PricedAmount == nil || *item.PricedAmount != wantAmount ||
+		item.PriceSource == nil || *item.PriceSource != generatedclient.CostsLineItemPriceSource("OPERATOR_SUPPLIED") {
+		t.Fatalf("Codex override line item = %#v, want complete operator-priced row at %s", item, wantAmount)
 	}
 }
 

--- a/tests/functional/factory/visualization/runtime_metrics/replay_unpriced_cost_test.go
+++ b/tests/functional/factory/visualization/runtime_metrics/replay_unpriced_cost_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/portpowered/infinite-you/internal/testutil"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	operatorsettings "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	generatedclient "github.com/portpowered/infinite-you/pkg/transports/http/client"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
@@ -20,7 +21,7 @@ const (
 	replayUnpricedTotalTokens  int64 = 1_500
 )
 
-func TestReplayUnpricedUsageRemainsTruthfulInPublicCosts(t *testing.T) {
+func TestReplayOperatorPriceTableIsReversibleInPublicCosts(t *testing.T) {
 	repoRoot := testutil.MustRepoRoot(t)
 	fixturePath := filepath.Join(
 		repoRoot,
@@ -52,30 +53,122 @@ func TestReplayUnpricedUsageRemainsTruthfulInPublicCosts(t *testing.T) {
 	})
 	support.CleanupProcess(t, process)
 
-	humanOutput := executeReplayCostsCLI(t, process, environment, server.URL(), false)
-	if !strings.Contains(humanOutput, "Status: UNPRICED") ||
-		!strings.Contains(humanOutput, "Cost (USD): ?? unknown") ||
-		!strings.Contains(humanOutput, "CLAUDE/claude-sonnet-4-6") ||
-		!strings.Contains(humanOutput, "Total tokens: 1500") ||
-		strings.Contains(humanOutput, "$0.00") || strings.Contains(humanOutput, "Status: NO_USAGE") {
-		t.Fatalf("human replay costs output = %q, want truthful UNPRICED Claude usage", humanOutput)
+	beforeHuman := executeReplayCostsCLI(t, process, environment, server.URL(), false)
+	t.Logf("before operator price row — human you metrics costs:\n%s", beforeHuman)
+	if !strings.Contains(beforeHuman, "Status: UNPRICED") ||
+		!strings.Contains(beforeHuman, "Cost (USD): ?? unknown") ||
+		!strings.Contains(beforeHuman, "CLAUDE/claude-sonnet-4-6") ||
+		!strings.Contains(beforeHuman, "Reason: no configured price") ||
+		!strings.Contains(beforeHuman, "Input tokens: 1200") ||
+		!strings.Contains(beforeHuman, "Output tokens: 300") ||
+		!strings.Contains(beforeHuman, "Total tokens: 1500") ||
+		strings.Contains(beforeHuman, "$0.00") || strings.Contains(beforeHuman, "Status: NO_USAGE") {
+		t.Fatalf("human replay costs output before configuration = %q, want truthful UNPRICED Claude usage", beforeHuman)
+	}
+	beforeCLIReport := decodeReplayCostsCLI(t, process, environment, server.URL())
+	assertUnpricedReplayCostsReport(t, beforeCLIReport)
+	beforeAPIReport := getReplayCostsHTTP(t, server.URL())
+	assertUnpricedReplayCostsReport(t, beforeAPIReport)
+	if got, want := beforeAPIReport, beforeCLIReport; !reportsHaveSameReplayCostFacts(got, want) {
+		t.Fatalf("HTTP and CLI before-configuration reports differ:\nHTTP=%#v\nCLI=%#v", got, want)
 	}
 
-	jsonOutput := executeReplayCostsCLI(t, process, environment, server.URL(), true)
-	var cliReport generatedclient.CostsReport
-	if err := json.Unmarshal([]byte(jsonOutput), &cliReport); err != nil {
-		t.Fatalf("decode unpriced replay costs CLI JSON: %v\nstdout=%s", err, jsonOutput)
+	writeReplayOperatorPriceTable(t, homeDir, operatorsettings.PriceTableModel{
+		Provider:               "claude",
+		Model:                  "claude-sonnet-4-6",
+		InputPerMillionTokens:  "3",
+		OutputPerMillionTokens: "15",
+	})
+	configuredHuman := executeReplayCostsCLI(t, process, environment, server.URL(), false)
+	t.Logf("configured operator price row — human you metrics costs:\n%s", configuredHuman)
+	if !strings.Contains(configuredHuman, "Status: PRICED") ||
+		!strings.Contains(configuredHuman, "Cost (USD): $0.01") ||
+		!strings.Contains(configuredHuman, "Priced amount (USD): 0.0081") ||
+		!strings.Contains(configuredHuman, "Price source: OPERATOR_SUPPLIED") ||
+		!strings.Contains(configuredHuman, "Total tokens: 1500") {
+		t.Fatalf("human replay costs output while configured = %q, want exact operator valuation and source", configuredHuman)
 	}
-	assertUnpricedReplayCostsReport(t, cliReport)
+	configuredCLIReport := decodeReplayCostsCLI(t, process, environment, server.URL())
+	assertOperatorPricedReplayCostsReport(t, configuredCLIReport)
+	configuredAPIReport := getReplayCostsHTTP(t, server.URL())
+	assertOperatorPricedReplayCostsReport(t, configuredAPIReport)
+	if got, want := configuredAPIReport, configuredCLIReport; !reportsHaveSameReplayCostFacts(got, want) {
+		t.Fatalf("HTTP and CLI configured reports differ:\nHTTP=%#v\nCLI=%#v", got, want)
+	}
 
-	apiReport := getReplayCostsHTTP(t, server.URL())
-	assertUnpricedReplayCostsReport(t, apiReport)
-	if got, want := apiReport, cliReport; !reportsHaveSameReplayCostFacts(got, want) {
-		t.Fatalf("HTTP and CLI unpriced replay cost reports differ:\nHTTP=%#v\nCLI=%#v", got, want)
+	writeReplayOperatorPriceTable(t, homeDir)
+	removedHuman := executeReplayCostsCLI(t, process, environment, server.URL(), false)
+	t.Logf("removed operator price row — human you metrics costs:\n%s", removedHuman)
+	if !strings.Contains(removedHuman, "Status: UNPRICED") ||
+		!strings.Contains(removedHuman, "Reason: no configured price") ||
+		!strings.Contains(removedHuman, "Input tokens: 1200") ||
+		!strings.Contains(removedHuman, "Output tokens: 300") ||
+		!strings.Contains(removedHuman, "Total tokens: 1500") ||
+		strings.Contains(removedHuman, "Price source: OPERATOR_SUPPLIED") ||
+		strings.Contains(removedHuman, "$0.00") {
+		t.Fatalf("human replay costs output after removal = %q, want truthful reverted usage", removedHuman)
+	}
+	removedCLIReport := decodeReplayCostsCLI(t, process, environment, server.URL())
+	assertUnpricedReplayCostsReport(t, removedCLIReport)
+	removedAPIReport := getReplayCostsHTTP(t, server.URL())
+	assertUnpricedReplayCostsReport(t, removedAPIReport)
+	if got, want := removedAPIReport, removedCLIReport; !reportsHaveSameReplayCostFacts(got, want) {
+		t.Fatalf("HTTP and CLI after-removal reports differ:\nHTTP=%#v\nCLI=%#v", got, want)
 	}
 
 	if providerRunner.CallCount() != 0 || scriptRunner.CallCount() != 0 {
 		t.Fatalf("replay external execution calls = provider:%d script:%d, want zero", providerRunner.CallCount(), scriptRunner.CallCount())
+	}
+}
+
+func decodeReplayCostsCLI(
+	t *testing.T,
+	process support.Process,
+	environment []string,
+	serverURL string,
+) generatedclient.CostsReport {
+	t.Helper()
+	jsonOutput := executeReplayCostsCLI(t, process, environment, serverURL, true)
+	var report generatedclient.CostsReport
+	if err := json.Unmarshal([]byte(jsonOutput), &report); err != nil {
+		t.Fatalf("decode replay costs CLI JSON: %v\nstdout=%s", err, jsonOutput)
+	}
+	return report
+}
+
+func assertOperatorPricedReplayCostsReport(t *testing.T, report generatedclient.CostsReport) {
+	t.Helper()
+	const wantAmount = "0.0081"
+	if report.Status != generatedclient.CostsReportStatus("PRICED") || report.Currency != generatedclient.CostsReportCurrency("USD") {
+		t.Fatalf("configured replay cost status/currency = %q/%q, want PRICED/USD", report.Status, report.Currency)
+	}
+	if report.KnownCost == nil || *report.KnownCost != wantAmount || report.PricedSubtotal == nil || *report.PricedSubtotal != wantAmount {
+		t.Fatalf("configured replay amounts = known:%v subtotal:%v, want exact %s", report.KnownCost, report.PricedSubtotal, wantAmount)
+	}
+	if report.UnpricedDispatchCount != 0 || len(report.UnpricedPairs) != 0 {
+		t.Fatalf("configured replay unpriced facts = dispatches:%d pairs:%#v, want none", report.UnpricedDispatchCount, report.UnpricedPairs)
+	}
+	if report.Coverage.EncounteredRows != 1 || report.Coverage.PricedRows != 1 || report.Coverage.UnpricedRows != 0 ||
+		report.Coverage.EncounteredProviderModels != 1 || report.Coverage.PricedProviderModels != 1 || report.Coverage.UnpricedProviderModels != 0 {
+		t.Fatalf("configured replay cost coverage = %#v, want one priced row and provider/model", report.Coverage)
+	}
+	assertReplayTokenTotals(t, report.TokenTotals, replayUnpricedInputTokens, replayUnpricedOutputTokens, replayUnpricedTotalTokens)
+	if len(report.LineItems) != 1 || len(report.WorkItems) != 1 || len(report.WorkerSessions) != 1 || len(report.ProviderModels) != 1 || len(report.FactorySessions) != 1 {
+		t.Fatalf("configured replay report dimensions = line:%d work:%d workers:%d providers:%d sessions:%d, want one each", len(report.LineItems), len(report.WorkItems), len(report.WorkerSessions), len(report.ProviderModels), len(report.FactorySessions))
+	}
+	item := report.LineItems[0]
+	if item.Status != generatedclient.CostsLineItemStatus("PRICED") || item.Provider == nil || *item.Provider != "CLAUDE" ||
+		item.Model == nil || *item.Model != "claude-sonnet-4-6" || item.WorkerSessionId == nil ||
+		*item.WorkerSessionId != "cost-replay-unpriced-worker-session" || item.PricedAmount == nil || *item.PricedAmount != wantAmount ||
+		item.PriceSource == nil || *item.PriceSource != generatedclient.CostsLineItemPriceSource("OPERATOR_SUPPLIED") || item.Reason != nil {
+		t.Fatalf("configured replay line item = %#v, want priced Claude row with operator source and %s", item, wantAmount)
+	}
+	if item.InputTokens == nil || *item.InputTokens != replayUnpricedInputTokens || item.OutputTokens == nil || *item.OutputTokens != replayUnpricedOutputTokens {
+		t.Fatalf("configured replay line-item tokens = input:%v output:%v, want %d/%d", item.InputTokens, item.OutputTokens, replayUnpricedInputTokens, replayUnpricedOutputTokens)
+	}
+	rollup := report.ProviderModels[0]
+	if rollup.Key != "CLAUDE/claude-sonnet-4-6" || rollup.Status != generatedclient.CostsProviderModelRollupStatus("PRICED") || rollup.KnownCost == nil || *rollup.KnownCost != wantAmount {
+		t.Fatalf("configured replay provider/model rollup = %#v, want priced Claude at %s", rollup, wantAmount)
 	}
 }
 

--- a/ui/packages/client/src/generated/openapi.ts
+++ b/ui/packages/client/src/generated/openapi.ts
@@ -1933,6 +1933,11 @@ export interface components {
        * @enum {string}
        */
       status: CostsLineItemStatus;
+      /**
+       * @description Pricing authority for the complete row used for a PRICED line item; omitted for UNPRICED rows.
+       * @enum {string}
+       */
+      price_source?: CostsLineItemPrice_source;
       /** @description Exact USD decimal amount; absent for UNPRICED rows and present as "0" for explicitly free usage. */
       priced_amount?: string;
       /** @description Actionable reason when status is UNPRICED. */
@@ -10361,6 +10366,12 @@ export const CostsLineItemStatus = {
 } as const;
 export type CostsLineItemStatus =
   (typeof CostsLineItemStatus)[keyof typeof CostsLineItemStatus];
+export const CostsLineItemPrice_source = {
+  BUILT_IN: "BUILT_IN",
+  OPERATOR_SUPPLIED: "OPERATOR_SUPPLIED",
+} as const;
+export type CostsLineItemPrice_source =
+  (typeof CostsLineItemPrice_source)[keyof typeof CostsLineItemPrice_source];
 export const CostsRollupCurrency = {
   USD: "USD",
 } as const;

--- a/ui/packages/client/src/generated/openapi.ts
+++ b/ui/packages/client/src/generated/openapi.ts
@@ -646,6 +646,26 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/shutdown": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Request graceful shutdown of the local server
+     * @description Accepts a loopback-only administrative shutdown request for the invocation that owns this listener. The server acknowledges the request before it invokes the invocation-local cancellation authority; the caller remains responsible for observing that the selected listener has stopped.
+     */
+    post: operations["shutdownServer"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/models": {
     parameters: {
       query?: never;
@@ -2569,6 +2589,12 @@ export interface components {
       targets?: components["schemas"]["FactoryValidationTarget"][];
       /** @description Resource accounting for a rejected capacity reduction. */
       resourceCapacity?: components["schemas"]["FactorySessionResourceCapacityErrorDetails"];
+    };
+    ShutdownAcceptedResponse: {
+      /** @enum {string} */
+      status: ShutdownAcceptedResponseStatus;
+      /** @description Human-readable acknowledgment that graceful shutdown was accepted. */
+      message: string;
     };
     ErrorTarget: {
       /** @description Client-visible target category such as form, node, edge, field, or save. */
@@ -7879,6 +7905,24 @@ export interface components {
         "application/json": components["schemas"]["ErrorResponse"];
       };
     };
+    /** @description The shutdown control is restricted to a loopback peer on this local server. */
+    ShutdownControlRejected: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": components["schemas"]["ErrorResponse"];
+      };
+    };
+    /** @description The server cannot expose its invocation-local shutdown control. */
+    ShutdownControlUnavailable: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": components["schemas"]["ErrorResponse"];
+      };
+    };
     /** @description Response-event cursor or filter parameters were invalid. */
     ResponseEventBadRequest: {
       headers: {
@@ -9061,6 +9105,29 @@ export interface operations {
         };
       };
       500: components["responses"]["InternalError"];
+    };
+  };
+  shutdownServer: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The invocation-local shutdown request was accepted. */
+      202: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ShutdownAcceptedResponse"];
+        };
+      };
+      403: components["responses"]["ShutdownControlRejected"];
+      500: components["responses"]["InternalError"];
+      503: components["responses"]["ShutdownControlUnavailable"];
     };
   };
   listModels: {
@@ -10676,12 +10743,21 @@ export const ErrorResponseCode = {
   INTERNAL_ERROR: "INTERNAL_ERROR",
   // The metrics costs query exceeded its server-side completion bound.
   COSTS_INVALID_REQUEST: "COSTS_INVALID_REQUEST",
+  // The shutdown control request came from a non-loopback peer.
   COSTS_QUERY_CANCELED: "COSTS_QUERY_CANCELED",
+  // The invocation-local shutdown control is unavailable.
   COSTS_QUERY_FAILED: "COSTS_QUERY_FAILED",
   COSTS_QUERY_TIMEOUT: "COSTS_QUERY_TIMEOUT",
+  SHUTDOWN_CONTROL_REJECTED: "SHUTDOWN_CONTROL_REJECTED",
+  SHUTDOWN_CONTROL_UNAVAILABLE: "SHUTDOWN_CONTROL_UNAVAILABLE",
 } as const;
 export type ErrorResponseCode =
   (typeof ErrorResponseCode)[keyof typeof ErrorResponseCode];
+export const ShutdownAcceptedResponseStatus = {
+  accepted: "accepted",
+} as const;
+export type ShutdownAcceptedResponseStatus =
+  (typeof ShutdownAcceptedResponseStatus)[keyof typeof ShutdownAcceptedResponseStatus];
 export const FactorySessionTargetRefKind = {
   default: "default",
   named: "named",

--- a/ui/src/api/generated/openapi.ts
+++ b/ui/src/api/generated/openapi.ts
@@ -1947,6 +1947,11 @@ export interface components {
        * @enum {string}
        */
       status: CostsLineItemStatus;
+      /**
+       * @description Pricing authority for the complete row used for a PRICED line item; omitted for UNPRICED rows.
+       * @enum {string}
+       */
+      price_source?: CostsLineItemPrice_source;
       /** @description Exact USD decimal amount; absent for UNPRICED rows and present as "0" for explicitly free usage. */
       priced_amount?: string;
       /** @description Actionable reason when status is UNPRICED. */
@@ -10422,6 +10427,12 @@ export const CostsLineItemStatus = {
 } as const;
 export type CostsLineItemStatus =
   (typeof CostsLineItemStatus)[keyof typeof CostsLineItemStatus];
+export const CostsLineItemPrice_source = {
+  BUILT_IN: "BUILT_IN",
+  OPERATOR_SUPPLIED: "OPERATOR_SUPPLIED",
+} as const;
+export type CostsLineItemPrice_source =
+  (typeof CostsLineItemPrice_source)[keyof typeof CostsLineItemPrice_source];
 export const CostsRollupCurrency = {
   USD: "USD",
 } as const;


### PR DESCRIPTION
{
  "project": "Operator Price-Table Overrides",
  "branchName": "price-table-operator-override",
  "description": "Let operators supplement or deliberately override immutable built-in provider/model token-price rows through the existing Operator Settings priceTable, apply whole-row precedence in Costs, expose BUILT_IN or OPERATOR_SUPPLIED provenance on every priced line item in JSON and human output, preserve truthful unpriced token usage, and prove reversible Claude pricing with the landed offline replay fixture.",
  "context": {
    "customerAsk": "Allow an operator to declare a USD price row for a provider/model pair with required input/output per-million-token rates and optional cached-input/reasoning-output rates; supplement or deliberately override the built-in table, expose price_source on every priced line item, preserve real token counts for unpriced usage, update the packaged metrics reference, and demonstrate before/configured/removed behavior through the existing Claude replay fixture.",
    "problem": "Costs currently ignores the Operator Settings priceTable and values usage only against the immutable Providers-owned codex/gpt-5-codex row. Customers using Claude, Cursor, or any other unshipped pair remain permanently UNPRICED, and priced reports do not identify which pricing authority produced an amount.",
    "solution": "Load the detached operator table through the singular Operator Settings service for each Costs request, retain Providers as the immutable built-in authority, and resolve exact canonical provider/model keys in Costs with complete operator rows replacing or supplementing built-ins. Carry the selected source through the Costs domain, authored OpenAPI, generated clients, HTTP/CLI JSON, human CLI output, focused tests, the dependent offline replay scenario, and customer reference documentation."
  },
  "acceptanceCriteria": [
    "An operator can author a normalized USD price row for a provider/model pair absent from the built-in table, with required input/output decimal rates and optional cached-input/reasoning-output decimal rates, and the next Costs query values matching canonical usage using that complete operator row.",
    "Effective lookup is keyed by the exact normalized provider/model pair: an operator row replaces the complete built-in row for the same pair, an absent operator row falls back to the unchanged built-in row, and omitted optional operator rates are never filled from the built-in row.",
    "Every PRICED Costs line item includes price_source with exactly BUILT_IN or OPERATOR_SUPPLIED in GET /metrics/costs, you --json metrics costs, and human you metrics costs output; UNPRICED items remain source-less and include their reason and observed token counts.",
    "Reusing the landed claude/claude-sonnet-4-6 offline usage fixture shows three public-command states with the same usage: UNPRICED before configuration, PRICED or report-level PARTIAL with price_source OPERATOR_SUPPLIED and the exact expected dollar amount while configured, and UNPRICED again after removal; the PR includes the real human command output for all three states.",
    "Invalid operator price configuration fails with an actionable settings/pricing error rather than silently falling back, publishing a partial valuation, or changing the persisted document; missing provider/model identity and missing required or measured-class rates retain the existing truthful unpriced behavior.",
    "Quality gate: typecheck and focused Costs, Operator Settings, contract, CLI-rendering, and functional tests pass; generated OpenAPI Go and TypeScript clients are regenerated from authored components; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "price-table-operator-override-001",
      "title": "Resolve operator rows over built-in pricing",
      "description": "As an operator, I want Costs to use my configured provider/model row so previously unpriced usage is valued while unchanged built-in rows remain reliable fallbacks.",
      "acceptanceCriteria": [
        "A Costs query reads the operator price table through the singular injected Operator Settings root using the request's explicit settings path; Costs does not read configuration files directly and Providers remains the immutable built-in-table authority.",
        "A valid operator row for an exact normalized provider/model pair absent from the built-in table produces the mathematically correct exact-decimal amount from the required input/output rates and any supplied optional rates.",
        "For the same normalized provider/model pair, the complete operator row wins; no required or optional value is mixed with the built-in row, so a measured subclass omitted by the operator keeps the line item UNPRICED even if the built-in row has that subclass rate.",
        "With no matching operator row, the current codex/gpt-5-codex built-in values and existing valuation result remain unchanged; an empty or absent operator table is backward-compatible.",
        "Invalid operator table input returns a typed, actionable query failure before valuation, and cancellation or settings-read failure produces no partial report.",
        "Focused unit and package-integration tests cover supplementation, exact-pair override, no-mixing, built-in fallback, invalid input, read failure, cancellation, and detached state across repeated queries.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Costs now reads the explicit operator settings path through the injected Operator Settings root for every request, overlays normalized rows by exact canonical provider/model key with whole-row precedence, preserves built-in fallback/no-mixing semantics, and has focused coverage for supplementation, override, invalid/read failure, cancellation, and repeated detached reads."
    },
    {
      "id": "price-table-operator-override-002",
      "title": "Attribute every priced line item to its price source",
      "description": "As a customer or maintainer, I want each priced usage row to name its pricing authority so I can audit the dollar figure.",
      "acceptanceCriteria": [
        "The Costs domain line-item contract represents price provenance with exactly BUILT_IN and OPERATOR_SUPPLIED, and every PRICED line item is assigned the source of the complete row used for valuation.",
        "An UNPRICED line item does not claim a price_source, retains its provider/model identity, all observed token counts, and its actionable reason, and never substitutes a zero amount for missing pricing.",
        "The authored CostsLineItem OpenAPI schema exposes price_source with the two allowed values and documents that it is present for priced lines; bundled OpenAPI and generated Go/TypeScript clients are regenerated rather than hand-edited.",
        "HTTP mapping and you --json metrics costs preserve price_source without changing status, reason, exact amount, coverage, ordering, or rollup behavior.",
        "Contract and mapping tests prove both source values and the source-less unpriced case through observable response payloads.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Costs line items now carry exactly BUILT_IN or OPERATOR_SUPPLIED for successful valuation, with source-less UNPRICED rows. Authored OpenAPI, bundled schema, generated Go clients/server, dashboard TypeScript, and package-client TypeScript are synchronized; focused valuation, mapping JSON, contract, Go typecheck, and UI typecheck tests pass."
    },
    {
      "id": "price-table-operator-override-003",
      "title": "Show source and reversible override behavior in the public CLI",
      "description": "As an operator, I want the public Costs command to show when my row is active and to revert immediately when I remove it so I can verify configuration changes safely.",
      "acceptanceCriteria": [
        "Human you metrics costs output presents every priced line item with its status, exact or human-formatted amount, and Price source: BUILT_IN or Price source: OPERATOR_SUPPLIED; unpriced line items continue to show UNPRICED, their reason, and real token counts.",
        "The functional test reuses the exact landed claude/claude-sonnet-4-6 replay fixture and existing root.BuildProcess/Process.Execute public CLI harness rather than duplicating usage data or bypassing the production composition path.",
        "Against one unchanged replayed usage scenario, the test observes UNPRICED with no override, then writes a valid operator row and observes the exact expected priced amount with OPERATOR_SUPPLIED, then removes the row and observes UNPRICED with the same token counts on the next run.",
        "The same functional coverage confirms the unchanged built-in Codex pair reports BUILT_IN when not overridden and that a deliberate complete override of that pair reports OPERATOR_SUPPLIED without field mixing.",
        "The PR comment or body includes real human you metrics costs output for the required before/configured/removed states; CI-run evidence is placed only in a PR comment, never in a commit.",
        "Focused human-output golden tests and the dependent offline functional scenario pass deterministically without sleeps, live vendor calls, or changes under either protected package tree.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Human Costs output now renders every priced line item with its exact amount, status, identity, token counts, and BUILT_IN or OPERATOR_SUPPLIED source while preserving truthful unpriced reasons/counts. The offline Claude replay test exercises before/configured/removed states through root.BuildProcess and Process.Execute, and the Codex replay test proves built-in versus complete operator override provenance and valuation; focused CLI and replay tests pass."
    },
    {
      "id": "price-table-operator-override-004",
      "title": "Document built-in and operator-supplied price facts",
      "description": "As an operator, I want the packaged metrics reference to explain how to configure, audit, and remove price rows so I can price usage without mistaking estimates for provider billing.",
      "acceptanceCriteria": [
        "The Provider-Owned Price Facts guidance explains the split between immutable built-in rows and Operator Settings priceTable rows, including exact-pair whole-row precedence, built-in fallback, and no silent mixing of optional rates.",
        "The reference includes a valid claude/claude-sonnet-4-6 configuration example with required and optional rate semantics, explains removal/reversion, and states that rates are operator-authored valuation facts rather than live vendor billing data.",
        "The Cost Report section documents price_source values and presence rules beside status/reason behavior, and retains the never-zero-for-missing and token-preservation guarantees.",
        "Documentation examples and terminology match the generated JSON contract and verified human command output; no promise of automatic vendor-price fetching or billing enforcement is introduced.",
        "make docs-reference-smoke passes",
        "Typecheck passes"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Updated the packaged metrics reference with built-in versus Operator Settings price facts, exact-pair whole-row precedence, fallback and no-mixing semantics, a valid Claude configuration example, removal/reversion guidance, price_source rules, and verified human output. make docs-reference-smoke passes."
    }
  ]
}
