### PR TITLE
model-pull-reports-pulled-on-source-fetch-failure

### DIFF
--- a/api/components/schemas/api/ModelPullOutcome.yaml
+++ b/api/components/schemas/api/ModelPullOutcome.yaml
@@ -3,7 +3,11 @@ description: >
   Compatibility pull outcome projection for one managed runtime. Prefer
   `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary.
   `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT`
-  maps to managed pull outcome `ALREADY_PRESENT`.
+  maps to managed pull outcomes `ALREADY_PRESENT` and `ALREADY_READY`; and
+  `FAILED` maps to `STILL_LOADING`, `TIMED_OUT`, `SOURCE_FETCH_FAILED`, and
+  `UNSUPPORTED_RUNTIME`. Unknown managed pull outcomes also map to `FAILED` so
+  an unrecognized value cannot be projected as a successful pull.
 enum:
   - PULLED
   - ALREADY_PRESENT
+  - FAILED

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5350,10 +5350,11 @@ components:
     ModelPullOutcome:
       type: string
       description: |
-        Compatibility pull outcome projection for one managed runtime. Prefer `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary. `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT` maps to managed pull outcome `ALREADY_PRESENT`.
+        Compatibility pull outcome projection for one managed runtime. Prefer `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary. `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT` maps to managed pull outcomes `ALREADY_PRESENT` and `ALREADY_READY`; and `FAILED` maps to `STILL_LOADING`, `TIMED_OUT`, `SOURCE_FETCH_FAILED`, and `UNSUPPORTED_RUNTIME`. Unknown managed pull outcomes also map to `FAILED` so an unrecognized value cannot be projected as a successful pull.
       enum:
         - PULLED
         - ALREADY_PRESENT
+        - FAILED
     ModelPullResponse:
       type: object
       required:

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -211,7 +211,7 @@
       "path": "generated/mcp/tools.json"
     },
     "generated.openapi.openapi": {
-      "artifactHash": "4643ecfd6b4d4727930909fa06605e91b6cda378d6ec28b30cba997f38e38c49",
+      "artifactHash": "a681374d0b9a82cb366dd2b7529e0d7015cfdd8641cd3e87017939446ff4d235",
       "documentation": {
         "documentation": {
           "description": {
@@ -228,7 +228,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.openapi.openapi",
-        "sourceHash": "4643ecfd6b4d4727930909fa06605e91b6cda378d6ec28b30cba997f38e38c49",
+        "sourceHash": "a681374d0b9a82cb366dd2b7529e0d7015cfdd8641cd3e87017939446ff4d235",
         "visibility": "public"
       },
       "family": "openapi",

--- a/packages/api/generated/openapi/openapi.yaml
+++ b/packages/api/generated/openapi/openapi.yaml
@@ -5350,10 +5350,11 @@ components:
     ModelPullOutcome:
       type: string
       description: |
-        Compatibility pull outcome projection for one managed runtime. Prefer `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary. `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT` maps to managed pull outcome `ALREADY_PRESENT`.
+        Compatibility pull outcome projection for one managed runtime. Prefer `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary. `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT` maps to managed pull outcomes `ALREADY_PRESENT` and `ALREADY_READY`; and `FAILED` maps to `STILL_LOADING`, `TIMED_OUT`, `SOURCE_FETCH_FAILED`, and `UNSUPPORTED_RUNTIME`. Unknown managed pull outcomes also map to `FAILED` so an unrecognized value cannot be projected as a successful pull.
       enum:
         - PULLED
         - ALREADY_PRESENT
+        - FAILED
     ModelPullResponse:
       type: object
       required:

--- a/pkg/services/models/internal/local/catalog.go
+++ b/pkg/services/models/internal/local/catalog.go
@@ -787,6 +787,7 @@ func classifiedPullFailure(
 	if strings.TrimSpace(result.ProviderLocality) == "" {
 		result.ProviderLocality = string(providerLocality)
 	}
+	result.Outcome = legacyPullOutcomeFailed
 	result.ManagedPullOutcome = pullOutcome
 	result.ReadinessState = readiness
 	result.LifecycleState = managedLifecycleNotInstalled
@@ -858,6 +859,7 @@ func SelectInvocationWorker(
 const (
 	legacyPullOutcomePulled         = "PULLED"
 	legacyPullOutcomeAlreadyPresent = "ALREADY_PRESENT"
+	legacyPullOutcomeFailed         = "FAILED"
 
 	managedPullOutcomeAlreadyReady          = "ALREADY_READY"
 	managedPullOutcomeInstalledSuccessfully = "INSTALLED_SUCCESSFULLY"

--- a/pkg/services/models/internal/local/catalog_pull_test.go
+++ b/pkg/services/models/internal/local/catalog_pull_test.go
@@ -152,6 +152,29 @@ func TestPullModelWithOptions_ReportsVerificationFailure(t *testing.T) {
 	}
 }
 
+func TestPullModelWithOptions_ReportsSourceFetchFailureWithoutSuccessProjection(t *testing.T) {
+	t.Parallel()
+	loaded := mustLoadedCatalogConfig(t, catalogFactoryConfig(true))
+	result, err := PullModelWithOptions(
+		&managedPullTestAssetPuller{
+			result: apisurface.PullResult{
+				ModelName: "OMNIVOICE_Q4_K_M", Outcome: legacyPullOutcomePulled,
+			},
+			err: apisurface.ErrSourceFetchFailed,
+		},
+		context.Background(), loaded, "OMNIVOICE_Q4_K_M", PullOptions{},
+	)
+	if !errors.Is(err, apisurface.ErrSourceFetchFailed) {
+		t.Fatalf("PullModelWithOptions error = %v, want source-fetch failure", err)
+	}
+	var pullErr *apisurface.PullError
+	if !errors.As(err, &pullErr) || result.Outcome != legacyPullOutcomeFailed ||
+		result.ManagedPullOutcome != managedPullOutcomeSourceFetchFailed ||
+		result.ReadinessState != managedReadinessFailed || result.LifecycleState != managedLifecycleNotInstalled {
+		t.Fatalf("pull result = %#v, error = %v, want FAILED/SOURCE_FETCH_FAILED/FAILED/NOT_INSTALLED", result, err)
+	}
+}
+
 func TestPullModelWithOptions_DoesNotSucceedAfterCallerCancellation(t *testing.T) {
 	t.Parallel()
 	loaded := mustLoadedCatalogConfig(t, catalogFactoryConfig(true))

--- a/pkg/services/models/internal/local/catalog_pull_test.go
+++ b/pkg/services/models/internal/local/catalog_pull_test.go
@@ -146,7 +146,8 @@ func TestPullModelWithOptions_ReportsVerificationFailure(t *testing.T) {
 	}
 	var pullErr *apisurface.PullError
 	if !errors.As(err, &pullErr) || result.ManagedPullOutcome != managedPullOutcomeSourceFetchFailed ||
-		result.ReadinessState != managedReadinessFailed || result.LifecycleState != managedLifecycleNotInstalled {
+		result.Outcome != legacyPullOutcomeFailed || result.ReadinessState != managedReadinessFailed ||
+		result.LifecycleState != managedLifecycleNotInstalled {
 		t.Fatalf("pull result = %#v, error = %v, want classified terminal verification failure", result, err)
 	}
 }

--- a/pkg/services/models/internal/local/puller.go
+++ b/pkg/services/models/internal/local/puller.go
@@ -62,6 +62,7 @@ func (p *assetPuller) PullModel(ctx context.Context, _ *models.RuntimeConfig, mo
 	})
 	projected := pullResultFromAssets(result)
 	if err != nil {
+		projected.Outcome = legacyPullOutcomeFailed
 		projected.ManagedPullOutcome = ""
 		projected.ReadinessState = "FAILED"
 		projected.LifecycleState = "NOT_INSTALLED"

--- a/pkg/services/models/internal/service/pull.go
+++ b/pkg/services/models/internal/service/pull.go
@@ -163,6 +163,7 @@ func (s *Service) pullWithModelHost(
 	if strings.TrimSpace(result.ModelName) == "" {
 		result.ModelName = strings.TrimSpace(modelName)
 	}
+	result.Outcome = "FAILED"
 	if strings.TrimSpace(result.ManagedPullOutcome) == "" {
 		result.ManagedPullOutcome = pullOutcome
 	}

--- a/pkg/services/models/transports/cli/models.go
+++ b/pkg/services/models/transports/cli/models.go
@@ -443,7 +443,7 @@ type pullOptions struct {
 func pullModel(cfg pullOptions) (factoryapi.ModelPullResponse, error) {
 	var response factoryapi.ModelPullResponse
 	path := "/models/" + url.PathEscape(strings.TrimSpace(cfg.ModelName)) + "/pull"
-	if err := doModelsPOST(cfg.Context, cfg.HTTP, cfg.Server, path, map[string]any{}, &response, requestDiagnostics{
+	err := doModelsPOST(cfg.Context, cfg.HTTP, cfg.Server, path, map[string]any{}, &response, requestDiagnostics{
 		Enabled:   cfg.Verbose,
 		Output:    cfg.Diagnostics,
 		Command:   "models pull",
@@ -457,10 +457,19 @@ func pullModel(cfg pullOptions) (factoryapi.ModelPullResponse, error) {
 				len(response.DownloadedFiles),
 			)
 		},
-	}); err != nil {
+	})
+	projectPullResponseOutcome(&response)
+	if err != nil {
 		return response, err
 	}
 	return response, nil
+}
+
+func projectPullResponseOutcome(response *factoryapi.ModelPullResponse) {
+	if response == nil || strings.TrimSpace(string(response.ManagedRuntimePull.PullOutcome)) == "" {
+		return
+	}
+	response.Outcome = modelPullOutcomeFromManagedRuntime(response.ManagedRuntimePull.PullOutcome)
 }
 
 type requestDiagnostics struct {

--- a/pkg/services/models/transports/cli/models_test.go
+++ b/pkg/services/models/transports/cli/models_test.go
@@ -542,7 +542,7 @@ func TestInvoke_AudioUnreachableUsesBootstrapInsteadOfTransportMessage(t *testin
 func TestPull_ClassifiedFailureReturnsManagedRuntimeOutcome(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
-		_, _ = io.WriteString(w, `{"modelName":"OMNIVOICE_Q4_K_M","providerLocality":"LOCAL","outcome":"","cachePath":"","revision":"","downloadedFiles":[],"managedRuntimePull":{"identity":"OMNIVOICE_Q4_K_M","pullOutcome":"SOURCE_FETCH_FAILED","readinessState":"FAILED"}}`)
+		_, _ = io.WriteString(w, `{"modelName":"OMNIVOICE_Q4_K_M","providerLocality":"LOCAL","outcome":"PULLED","cachePath":"","revision":"","downloadedFiles":[],"managedRuntimePull":{"identity":"OMNIVOICE_Q4_K_M","pullOutcome":"SOURCE_FETCH_FAILED","readinessState":"FAILED"}}`)
 	}))
 	defer server.Close()
 
@@ -565,6 +565,37 @@ func TestPull_ClassifiedFailureReturnsManagedRuntimeOutcome(t *testing.T) {
 	}
 	if response.ManagedRuntimePull.PullOutcome != factoryapi.ManagedRuntimePullOutcomeSOURCEFETCHFAILED {
 		t.Fatalf("pull outcome = %s, want SOURCE_FETCH_FAILED", response.ManagedRuntimePull.PullOutcome)
+	}
+	if response.Outcome != factoryapi.ModelPullOutcomeFAILED {
+		t.Fatalf("pull JSON = %q, want top-level outcome FAILED", strings.TrimSpace(out.String()))
+	}
+}
+
+func TestModelPullCompatibilityOutcomeProjectsManagedOutcomeTotally(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		managed factoryapi.ManagedRuntimePullOutcome
+		want    factoryapi.ModelPullOutcome
+	}{
+		{name: "installed", managed: factoryapi.ManagedRuntimePullOutcomeINSTALLEDSUCCESSFULLY, want: factoryapi.ModelPullOutcomePULLED},
+		{name: "already present", managed: factoryapi.ManagedRuntimePullOutcomeALREADYPRESENT, want: factoryapi.ModelPullOutcomeALREADYPRESENT},
+		{name: "already ready", managed: factoryapi.ManagedRuntimePullOutcomeALREADYREADY, want: factoryapi.ModelPullOutcomeALREADYPRESENT},
+		{name: "still loading", managed: factoryapi.ManagedRuntimePullOutcomeSTILLLOADING, want: factoryapi.ModelPullOutcomeFAILED},
+		{name: "timed out", managed: factoryapi.ManagedRuntimePullOutcomeTIMEDOUT, want: factoryapi.ModelPullOutcomeFAILED},
+		{name: "source fetch failed", managed: factoryapi.ManagedRuntimePullOutcomeSOURCEFETCHFAILED, want: factoryapi.ModelPullOutcomeFAILED},
+		{name: "unsupported", managed: factoryapi.ManagedRuntimePullOutcomeUNSUPPORTEDRUNTIME, want: factoryapi.ModelPullOutcomeFAILED},
+		{name: "future outcome", managed: factoryapi.ManagedRuntimePullOutcome("FUTURE_OUTCOME"), want: factoryapi.ModelPullOutcomeFAILED},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := pullResultToGenerated(modelinference.PullResult{
+				ModelName: "voice", Outcome: "PULLED", ManagedPullOutcome: string(tc.managed),
+			})
+			if result.Outcome != tc.want {
+				t.Fatalf("managed outcome %q projected as %q, want %q", tc.managed, result.Outcome, tc.want)
+			}
+		})
 	}
 }
 

--- a/pkg/services/models/transports/cli/pull_mapping.go
+++ b/pkg/services/models/transports/cli/pull_mapping.go
@@ -16,13 +16,31 @@ func pullResultToGenerated(result models.PullResult) factoryapi.ModelPullRespons
 		}
 		files = append(files, current)
 	}
+	managedPull := managedRuntimePullResultToGenerated(result, files)
 	response := factoryapi.ModelPullResponse{
 		ModelName: result.ModelName, ProviderLocality: factoryapi.WorkerModelLocality(result.ProviderLocality),
-		Outcome: factoryapi.ModelPullOutcome(result.Outcome), CachePath: result.CachePath,
+		Outcome: modelPullOutcomeFromManagedRuntime(managedPull.PullOutcome), CachePath: result.CachePath,
 		Revision: result.Revision, DownloadedFiles: files,
+		ManagedRuntimePull: managedPull,
 	}
-	response.ManagedRuntimePull = managedRuntimePullResultToGenerated(result, files)
 	return response
+}
+
+func modelPullOutcomeFromManagedRuntime(outcome factoryapi.ManagedRuntimePullOutcome) factoryapi.ModelPullOutcome {
+	switch outcome {
+	case factoryapi.ManagedRuntimePullOutcomeINSTALLEDSUCCESSFULLY:
+		return factoryapi.ModelPullOutcomePULLED
+	case factoryapi.ManagedRuntimePullOutcomeALREADYPRESENT,
+		factoryapi.ManagedRuntimePullOutcomeALREADYREADY:
+		return factoryapi.ModelPullOutcomeALREADYPRESENT
+	case factoryapi.ManagedRuntimePullOutcomeSTILLLOADING,
+		factoryapi.ManagedRuntimePullOutcomeTIMEDOUT,
+		factoryapi.ManagedRuntimePullOutcomeSOURCEFETCHFAILED,
+		factoryapi.ManagedRuntimePullOutcomeUNSUPPORTEDRUNTIME:
+		return factoryapi.ModelPullOutcomeFAILED
+	default:
+		return factoryapi.ModelPullOutcomeFAILED
+	}
 }
 
 func managedRuntimePullResultToGenerated(result models.PullResult, files []factoryapi.ModelPullDownloadedFile) factoryapi.ManagedRuntimePullResult {

--- a/pkg/services/models/transports/http/pull_mapping.go
+++ b/pkg/services/models/transports/http/pull_mapping.go
@@ -23,13 +23,31 @@ func modelPullResponseFromService(result models.PullResult) factoryapi.ModelPull
 		}
 		files = append(files, current)
 	}
+	managedPull := managedRuntimePullResultToGenerated(result, files)
 	response := factoryapi.ModelPullResponse{
 		ModelName: result.ModelName, ProviderLocality: factoryapi.WorkerModelLocality(result.ProviderLocality),
-		Outcome: factoryapi.ModelPullOutcome(result.Outcome), CachePath: result.CachePath,
+		Outcome: modelPullOutcomeFromManagedRuntime(managedPull.PullOutcome), CachePath: result.CachePath,
 		Revision: result.Revision, DownloadedFiles: files,
+		ManagedRuntimePull: managedPull,
 	}
-	response.ManagedRuntimePull = managedRuntimePullResultToGenerated(result, files)
 	return response
+}
+
+func modelPullOutcomeFromManagedRuntime(outcome factoryapi.ManagedRuntimePullOutcome) factoryapi.ModelPullOutcome {
+	switch outcome {
+	case factoryapi.ManagedRuntimePullOutcomeINSTALLEDSUCCESSFULLY:
+		return factoryapi.ModelPullOutcomePULLED
+	case factoryapi.ManagedRuntimePullOutcomeALREADYPRESENT,
+		factoryapi.ManagedRuntimePullOutcomeALREADYREADY:
+		return factoryapi.ModelPullOutcomeALREADYPRESENT
+	case factoryapi.ManagedRuntimePullOutcomeSTILLLOADING,
+		factoryapi.ManagedRuntimePullOutcomeTIMEDOUT,
+		factoryapi.ManagedRuntimePullOutcomeSOURCEFETCHFAILED,
+		factoryapi.ManagedRuntimePullOutcomeUNSUPPORTEDRUNTIME:
+		return factoryapi.ModelPullOutcomeFAILED
+	default:
+		return factoryapi.ModelPullOutcomeFAILED
+	}
 }
 
 func modelRemoveResponseFromService(result models.RemoveModelAssetsResult) factoryapi.ModelRemoveResponse {

--- a/pkg/services/models/transports/http/pull_operations_test.go
+++ b/pkg/services/models/transports/http/pull_operations_test.go
@@ -191,7 +191,9 @@ func TestAdapter_BuiltInPullSurfacesThroughHTTP(t *testing.T) {
 			if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
 				t.Fatalf("decode response: %v", err)
 			}
-			if response.ModelName != name || response.ManagedRuntimePull.PullOutcome != factoryapi.ManagedRuntimePullOutcomeINSTALLEDSUCCESSFULLY {
+			if response.ModelName != name || response.Outcome != factoryapi.ModelPullOutcomePULLED ||
+				response.ManagedRuntimePull.PullOutcome != factoryapi.ManagedRuntimePullOutcomeINSTALLEDSUCCESSFULLY ||
+				response.ManagedRuntimePull.ReadinessState != factoryapi.ManagedRuntimeReadinessStateREADY {
 				t.Fatalf("response = %#v, want successful built-in pull", response)
 			}
 		})

--- a/pkg/services/models/transports/http/pull_operations_test.go
+++ b/pkg/services/models/transports/http/pull_operations_test.go
@@ -93,6 +93,71 @@ func TestAdapter_PullModelEncodesPullErrorOutcome(t *testing.T) {
 	}
 }
 
+func TestAdapter_PullModelProjectsSourceFetchFailureAsFailed(t *testing.T) {
+	t.Parallel()
+
+	failure := models.PullResult{
+		ModelName:          "voice",
+		ProviderLocality:   string(models.LocalityLocal),
+		Outcome:            "PULLED",
+		ManagedPullOutcome: "SOURCE_FETCH_FAILED",
+		ReadinessState:     "FAILED",
+		LifecycleState:     "NOT_INSTALLED",
+	}
+	root := &rootFake{
+		pull: func(context.Context, string) (models.PullResult, error) {
+			return models.PullResult{}, &models.PullError{Result: failure, Cause: models.ErrSourceFetchFailed}
+		},
+	}
+	handler := NewHandlerFromRoot(testRootBinding(root), zap.NewNop())
+	recorder := httptest.NewRecorder()
+
+	handler.PullModel(recorder, httptest.NewRequest(http.MethodPost, "/models/voice/pull", nil), "voice")
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422 body = %s", recorder.Code, recorder.Body.String())
+	}
+	var response factoryapi.ModelPullResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if string(response.Outcome) != "FAILED" {
+		t.Fatalf("response = %s, want top-level outcome FAILED", recorder.Body.String())
+	}
+	if response.ManagedRuntimePull.PullOutcome != factoryapi.ManagedRuntimePullOutcomeSOURCEFETCHFAILED ||
+		response.ManagedRuntimePull.ReadinessState != factoryapi.ManagedRuntimeReadinessStateFAILED {
+		t.Fatalf("managed runtime pull = %#v, want SOURCE_FETCH_FAILED/FAILED", response.ManagedRuntimePull)
+	}
+}
+
+func TestModelPullCompatibilityOutcomeProjectsManagedOutcomeTotally(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		managed factoryapi.ManagedRuntimePullOutcome
+		want    factoryapi.ModelPullOutcome
+	}{
+		{name: "installed", managed: factoryapi.ManagedRuntimePullOutcomeINSTALLEDSUCCESSFULLY, want: factoryapi.ModelPullOutcomePULLED},
+		{name: "already present", managed: factoryapi.ManagedRuntimePullOutcomeALREADYPRESENT, want: factoryapi.ModelPullOutcomeALREADYPRESENT},
+		{name: "already ready", managed: factoryapi.ManagedRuntimePullOutcomeALREADYREADY, want: factoryapi.ModelPullOutcomeALREADYPRESENT},
+		{name: "still loading", managed: factoryapi.ManagedRuntimePullOutcomeSTILLLOADING, want: factoryapi.ModelPullOutcomeFAILED},
+		{name: "timed out", managed: factoryapi.ManagedRuntimePullOutcomeTIMEDOUT, want: factoryapi.ModelPullOutcomeFAILED},
+		{name: "source fetch failed", managed: factoryapi.ManagedRuntimePullOutcomeSOURCEFETCHFAILED, want: factoryapi.ModelPullOutcomeFAILED},
+		{name: "unsupported", managed: factoryapi.ManagedRuntimePullOutcomeUNSUPPORTEDRUNTIME, want: factoryapi.ModelPullOutcomeFAILED},
+		{name: "future outcome", managed: factoryapi.ManagedRuntimePullOutcome("FUTURE_OUTCOME"), want: factoryapi.ModelPullOutcomeFAILED},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := modelPullResponseFromService(models.PullResult{
+				ModelName: "voice", Outcome: "PULLED", ManagedPullOutcome: string(tc.managed),
+			})
+			if result.Outcome != tc.want {
+				t.Fatalf("managed outcome %q projected as %q, want %q", tc.managed, result.Outcome, tc.want)
+			}
+		})
+	}
+}
+
 func TestAdapter_BuiltInPullSurfacesThroughHTTP(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/transports/http/client/client.gen.go
+++ b/pkg/transports/http/client/client.gen.go
@@ -975,6 +975,7 @@ const (
 // Defines values for ModelPullOutcome.
 const (
 	ModelPullOutcomeALREADYPRESENT ModelPullOutcome = "ALREADY_PRESENT"
+	ModelPullOutcomeFAILED         ModelPullOutcome = "FAILED"
 	ModelPullOutcomePULLED         ModelPullOutcome = "PULLED"
 )
 
@@ -6370,7 +6371,7 @@ type ModelPullDownloadedFile struct {
 	Sha256 *string `json:"sha256,omitempty"`
 }
 
-// ModelPullOutcome Compatibility pull outcome projection for one managed runtime. Prefer `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary. `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT` maps to managed pull outcome `ALREADY_PRESENT`.
+// ModelPullOutcome Compatibility pull outcome projection for one managed runtime. Prefer `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary. `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT` maps to managed pull outcomes `ALREADY_PRESENT` and `ALREADY_READY`; and `FAILED` maps to `STILL_LOADING`, `TIMED_OUT`, `SOURCE_FETCH_FAILED`, and `UNSUPPORTED_RUNTIME`. Unknown managed pull outcomes also map to `FAILED` so an unrecognized value cannot be projected as a successful pull.
 type ModelPullOutcome string
 
 // ModelPullResponse defines model for ModelPullResponse.
@@ -6385,7 +6386,7 @@ type ModelPullResponse struct {
 	// ModelName Stable managed runtime identity such as `OMNIVOICE_Q4_K_M`. Mirrors `managedRuntimePull.identity` for compatibility with earlier pull fields.
 	ModelName string `json:"modelName"`
 
-	// Outcome Compatibility pull outcome projection for one managed runtime. Prefer `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary. `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT` maps to managed pull outcome `ALREADY_PRESENT`.
+	// Outcome Compatibility pull outcome projection for one managed runtime. Prefer `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary. `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT` maps to managed pull outcomes `ALREADY_PRESENT` and `ALREADY_READY`; and `FAILED` maps to `STILL_LOADING`, `TIMED_OUT`, `SOURCE_FETCH_FAILED`, and `UNSUPPORTED_RUNTIME`. Unknown managed pull outcomes also map to `FAILED` so an unrecognized value cannot be projected as a successful pull.
 	Outcome ModelPullOutcome `json:"outcome"`
 
 	// ProviderLocality Provider locality for a model worker capability declaration.

--- a/pkg/transports/http/generated/server.gen.go
+++ b/pkg/transports/http/generated/server.gen.go
@@ -972,6 +972,7 @@ const (
 // Defines values for ModelPullOutcome.
 const (
 	ModelPullOutcomeALREADYPRESENT ModelPullOutcome = "ALREADY_PRESENT"
+	ModelPullOutcomeFAILED         ModelPullOutcome = "FAILED"
 	ModelPullOutcomePULLED         ModelPullOutcome = "PULLED"
 )
 
@@ -6396,7 +6397,7 @@ type ModelPullDownloadedFile struct {
 	Sha256 *string `json:"sha256,omitempty"`
 }
 
-// ModelPullOutcome Compatibility pull outcome projection for one managed runtime. Prefer `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary. `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT` maps to managed pull outcome `ALREADY_PRESENT`.
+// ModelPullOutcome Compatibility pull outcome projection for one managed runtime. Prefer `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary. `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT` maps to managed pull outcomes `ALREADY_PRESENT` and `ALREADY_READY`; and `FAILED` maps to `STILL_LOADING`, `TIMED_OUT`, `SOURCE_FETCH_FAILED`, and `UNSUPPORTED_RUNTIME`. Unknown managed pull outcomes also map to `FAILED` so an unrecognized value cannot be projected as a successful pull.
 type ModelPullOutcome string
 
 // ModelPullResponse defines model for ModelPullResponse.
@@ -6411,7 +6412,7 @@ type ModelPullResponse struct {
 	// ModelName Stable managed runtime identity such as `OMNIVOICE_Q4_K_M`. Mirrors `managedRuntimePull.identity` for compatibility with earlier pull fields.
 	ModelName string `json:"modelName"`
 
-	// Outcome Compatibility pull outcome projection for one managed runtime. Prefer `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary. `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT` maps to managed pull outcome `ALREADY_PRESENT`.
+	// Outcome Compatibility pull outcome projection for one managed runtime. Prefer `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary. `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT` maps to managed pull outcomes `ALREADY_PRESENT` and `ALREADY_READY`; and `FAILED` maps to `STILL_LOADING`, `TIMED_OUT`, `SOURCE_FETCH_FAILED`, and `UNSUPPORTED_RUNTIME`. Unknown managed pull outcomes also map to `FAILED` so an unrecognized value cannot be projected as a successful pull.
 	Outcome ModelPullOutcome `json:"outcome"`
 
 	// ProviderLocality Provider locality for a model worker capability declaration.

--- a/tests/functional/models/model_list/cli_test.go
+++ b/tests/functional/models/model_list/cli_test.go
@@ -106,6 +106,11 @@ func TestProcessModelsPull_UsesServerFlagAndReturnsPullJSON(t *testing.T) {
 	if response.ModelName != "OMNIVOICE_Q4_K_M" {
 		t.Fatalf("pull response = %#v, want OMNIVOICE_Q4_K_M", response)
 	}
+	if response.Outcome != factoryapi.ModelPullOutcomePULLED ||
+		response.ManagedRuntimePull.PullOutcome != factoryapi.ManagedRuntimePullOutcomeINSTALLEDSUCCESSFULLY ||
+		response.ManagedRuntimePull.ReadinessState != factoryapi.ManagedRuntimeReadinessStateREADY {
+		t.Fatalf("pull response = %#v, want PULLED/INSTALLED_SUCCESSFULLY/READY", response)
+	}
 }
 
 // TestProcessModelsList_ReturnsHumanReadableCatalog proves list human presentation.

--- a/tests/functional/models/root_composition/story_003_test.go
+++ b/tests/functional/models/root_composition/story_003_test.go
@@ -356,8 +356,14 @@ func testStory003ControlledSourceFailure(t *testing.T) {
 		t.Fatalf("failed pull diagnostic leaked generic fallback or source body: %q", failureInputs.Stderr())
 	}
 
+	assertStory003ControlledSourceHTTPFailure(t, failureServer.URL())
+	t.Logf("controlled source failure CLI exitStatus=non-zero error=%q stdout=%s stderr=%s", cliErr, strings.TrimSpace(failureInputs.Stdout()), strings.TrimSpace(failureInputs.Stderr()))
+}
+
+func assertStory003ControlledSourceHTTPFailure(t *testing.T, serverURL string) {
+	t.Helper()
 	httpFailure, err := http.Post(
-		failureServer.URL()+"/models/"+story003ModelName+"/pull",
+		serverURL+"/models/"+story003ModelName+"/pull",
 		"application/json",
 		strings.NewReader("{}"),
 	)
@@ -385,7 +391,6 @@ func testStory003ControlledSourceFailure(t *testing.T) {
 		httpFailureResponse.Outcome == factoryapi.ModelPullOutcomeALREADYPRESENT {
 		t.Fatalf("POST /models/%s/pull retained a success compatibility outcome: %#v", story003ModelName, httpFailureResponse)
 	}
-	t.Logf("controlled source failure CLI exitStatus=non-zero error=%q stdout=%s stderr=%s", cliErr, strings.TrimSpace(failureInputs.Stdout()), strings.TrimSpace(failureInputs.Stderr()))
 	t.Logf("controlled source failure HTTP status=%d body=%s", httpFailure.StatusCode, strings.TrimSpace(string(httpFailureBody)))
 }
 

--- a/tests/functional/models/root_composition/story_003_test.go
+++ b/tests/functional/models/root_composition/story_003_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -313,12 +314,12 @@ func testStory003ControlledSourceFailure(t *testing.T) {
 	support.CleanupProcess(t, failureProcess)
 	failureInputs := support.FakeInputs(t.Context(), story003ModelsPullArgs(failureServer.URL()))
 	failureInputs.Input.WorkingDirectory = failureFactoryDir
-	err := failureProcess.Execute(failureInputs.Input)
-	if err == nil {
+	cliErr := failureProcess.Execute(failureInputs.Input)
+	if cliErr == nil {
 		t.Fatalf("Process.Execute(failed models pull) error = nil, want non-zero exit\nstdout:\n%s", failureInputs.Stdout())
 	}
-	if !strings.Contains(err.Error(), string(factoryapi.ManagedRuntimePullOutcomeSOURCEFETCHFAILED)) {
-		t.Fatalf("failed pull error = %v, want SOURCE_FETCH_FAILED classification", err)
+	if !strings.Contains(cliErr.Error(), string(factoryapi.ManagedRuntimePullOutcomeSOURCEFETCHFAILED)) {
+		t.Fatalf("failed pull error = %v, want SOURCE_FETCH_FAILED classification", cliErr)
 	}
 
 	var failureResponse factoryapi.ModelPullResponse
@@ -326,8 +327,13 @@ func testStory003ControlledSourceFailure(t *testing.T) {
 		t.Fatalf("decode failed models pull response: %v\nstdout:\n%s\nstderr:\n%s", decodeErr, failureInputs.Stdout(), failureInputs.Stderr())
 	}
 	if failureResponse.ManagedRuntimePull.PullOutcome != factoryapi.ManagedRuntimePullOutcomeSOURCEFETCHFAILED ||
-		failureResponse.ManagedRuntimePull.ReadinessState != factoryapi.ManagedRuntimeReadinessStateFAILED {
+		failureResponse.ManagedRuntimePull.ReadinessState != factoryapi.ManagedRuntimeReadinessStateFAILED ||
+		failureResponse.Outcome != factoryapi.ModelPullOutcomeFAILED {
 		t.Fatalf("failed pull response = %#v, want SOURCE_FETCH_FAILED/FAILED", failureResponse)
+	}
+	if failureResponse.Outcome == factoryapi.ModelPullOutcomePULLED ||
+		failureResponse.Outcome == factoryapi.ModelPullOutcomeALREADYPRESENT {
+		t.Fatalf("failed pull retained a success compatibility outcome: %#v", failureResponse)
 	}
 	if strings.TrimSpace(failureInputs.Stderr()) == "" {
 		t.Fatal("failed pull stderr was empty, want the typed CLI diagnostic envelope")
@@ -349,6 +355,38 @@ func testStory003ControlledSourceFailure(t *testing.T) {
 		strings.Contains(failureInputs.Stderr(), "controlled source failure") {
 		t.Fatalf("failed pull diagnostic leaked generic fallback or source body: %q", failureInputs.Stderr())
 	}
+
+	httpFailure, err := http.Post(
+		failureServer.URL()+"/models/"+story003ModelName+"/pull",
+		"application/json",
+		strings.NewReader("{}"),
+	)
+	if err != nil {
+		t.Fatalf("POST /models/%s/pull: %v", story003ModelName, err)
+	}
+	defer httpFailure.Body.Close()
+	httpFailureBody, err := io.ReadAll(httpFailure.Body)
+	if err != nil {
+		t.Fatalf("read POST /models/%s/pull response: %v", story003ModelName, err)
+	}
+	if httpFailure.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("POST /models/%s/pull status = %d body = %s, want 422", story003ModelName, httpFailure.StatusCode, httpFailureBody)
+	}
+	var httpFailureResponse factoryapi.ModelPullResponse
+	if err := json.Unmarshal(httpFailureBody, &httpFailureResponse); err != nil {
+		t.Fatalf("decode POST /models/%s/pull response: %v\nbody=%s", story003ModelName, err, httpFailureBody)
+	}
+	if httpFailureResponse.Outcome != factoryapi.ModelPullOutcomeFAILED ||
+		httpFailureResponse.ManagedRuntimePull.PullOutcome != factoryapi.ManagedRuntimePullOutcomeSOURCEFETCHFAILED ||
+		httpFailureResponse.ManagedRuntimePull.ReadinessState != factoryapi.ManagedRuntimeReadinessStateFAILED {
+		t.Fatalf("POST /models/%s/pull response = %#v, want FAILED/SOURCE_FETCH_FAILED/FAILED", story003ModelName, httpFailureResponse)
+	}
+	if httpFailureResponse.Outcome == factoryapi.ModelPullOutcomePULLED ||
+		httpFailureResponse.Outcome == factoryapi.ModelPullOutcomeALREADYPRESENT {
+		t.Fatalf("POST /models/%s/pull retained a success compatibility outcome: %#v", story003ModelName, httpFailureResponse)
+	}
+	t.Logf("controlled source failure CLI exitStatus=non-zero error=%q stdout=%s stderr=%s", cliErr, strings.TrimSpace(failureInputs.Stdout()), strings.TrimSpace(failureInputs.Stderr()))
+	t.Logf("controlled source failure HTTP status=%d body=%s", httpFailure.StatusCode, strings.TrimSpace(string(httpFailureBody)))
 }
 
 type story003InspectCapture struct {

--- a/ui/packages/client/src/generated/openapi.ts
+++ b/ui/packages/client/src/generated/openapi.ts
@@ -2489,7 +2489,7 @@ export interface components {
       sha256?: string;
     };
     /**
-     * @description Compatibility pull outcome projection for one managed runtime. Prefer `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary. `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT` maps to managed pull outcome `ALREADY_PRESENT`.
+     * @description Compatibility pull outcome projection for one managed runtime. Prefer `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary. `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT` maps to managed pull outcomes `ALREADY_PRESENT` and `ALREADY_READY`; and `FAILED` maps to `STILL_LOADING`, `TIMED_OUT`, `SOURCE_FETCH_FAILED`, and `UNSUPPORTED_RUNTIME`. Unknown managed pull outcomes also map to `FAILED` so an unrecognized value cannot be projected as a successful pull.
      * @enum {string}
      */
     ModelPullOutcome: ModelPullOutcome;
@@ -10571,6 +10571,7 @@ export type ModelInvocationResponseMode =
 export const ModelPullOutcome = {
   PULLED: "PULLED",
   ALREADY_PRESENT: "ALREADY_PRESENT",
+  FAILED: "FAILED",
 } as const;
 export type ModelPullOutcome =
   (typeof ModelPullOutcome)[keyof typeof ModelPullOutcome];

--- a/ui/src/api/generated/openapi.ts
+++ b/ui/src/api/generated/openapi.ts
@@ -2483,7 +2483,7 @@ export interface components {
       sha256?: string;
     };
     /**
-     * @description Compatibility pull outcome projection for one managed runtime. Prefer `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary. `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT` maps to managed pull outcome `ALREADY_PRESENT`.
+     * @description Compatibility pull outcome projection for one managed runtime. Prefer `managedRuntimePull.pullOutcome` for the canonical managed-runtime vocabulary. `PULLED` maps to managed pull outcome `INSTALLED_SUCCESSFULLY`; `ALREADY_PRESENT` maps to managed pull outcomes `ALREADY_PRESENT` and `ALREADY_READY`; and `FAILED` maps to `STILL_LOADING`, `TIMED_OUT`, `SOURCE_FETCH_FAILED`, and `UNSUPPORTED_RUNTIME`. Unknown managed pull outcomes also map to `FAILED` so an unrecognized value cannot be projected as a successful pull.
      * @enum {string}
      */
     ModelPullOutcome: ModelPullOutcome;
@@ -10565,6 +10565,7 @@ export type ModelInvocationResponseMode =
 export const ModelPullOutcome = {
   PULLED: "PULLED",
   ALREADY_PRESENT: "ALREADY_PRESENT",
+  FAILED: "FAILED",
 } as const;
 export type ModelPullOutcome =
   (typeof ModelPullOutcome)[keyof typeof ModelPullOutcome];


### PR DESCRIPTION
## PRD used (verbatim)

```json
{
  "project": "Truthful Model Pull Failure Outcomes",
  "branchName": "model-pull-reports-pulled-on-source-fetch-failure",
  "description": "Make failed local-model pulls report an explicit FAILED compatibility outcome, consistent failed readiness and lifecycle state, and equivalent truthful CLI JSON and HTTP responses while preserving successful, already-present, and non-zero-exit behavior.",
  "context": {
    "customerAsk": "Ensure a local-model pull whose source fetch fails never reports top-level PULLED, READY, or INSTALLED; make the managed-to-compatibility outcome projection total; preserve the non-zero CLI exit; and prove the correction through both you --json models pull <model> and POST /models/{model_name}/pull without changing source-fetch behavior, model list/inspect, or invoke routes.",
    "problem": "A 2026-08-23 operator probe observed one failed pull reporting top-level outcome PULLED while its canonical managed result reported SOURCE_FETCH_FAILED/FAILED and the CLI exited 1. The authored compatibility enum has no failure value, and the current construction path can retain an unconditional success projection after later failure classification corrects managed state.",
    "solution": "Add FAILED to the authored compatibility outcome contract, derive compatibility outcome explicitly and exhaustively from canonical managed pull outcomes, keep a failed source fetch at FAILED/FAILED/NOT_INSTALLED across outcome/readiness/lifecycle, regenerate all derived OpenAPI contracts, and prove CLI/HTTP parity, mapping totality, preserved happy paths, and unchanged non-zero exit behavior with direct before/after evidence."
  },
  "acceptanceCriteria": [
    "A controlled source-fetch failure returns top-level outcome: \"FAILED\" through both you --json models pull <model> and POST /models/{model_name}/pull; the same operation reports canonical pullOutcome: \"SOURCE_FETCH_FAILED\", readiness FAILED, and Models-owned lifecycle NOT_INSTALLED, never PULLED, READY, or INSTALLED.",
    "The managed-to-compatibility projection explicitly covers every defined managed pull outcome: successful installation maps to PULLED, already-present/already-ready maps to ALREADY_PRESENT, and failure outcomes map to FAILED; an unrecognized future value cannot fall through to a success outcome.",
    "Successful and already-present CLI and HTTP pulls retain their existing PULLED and ALREADY_PRESENT behavior, and a failed CLI pull retains its non-zero exit and actionable managed failure classification.",
    "The PR body contains independently captured exact before/after CLI JSON, exit status, and HTTP response for a controlled source-fetch failure, states that the new regression test failed before the correction, and reports the confirmed handler-to-service-to-local-puller construction path rather than relying only on the original transcript.",
    "The authored ModelPullOutcome fragment documents FAILED, make generate-api is run, all resulting bundled Go/TypeScript artifacts are committed without hand edits, and make api-smoke is run when feasible with any infeasibility recorded in the PR comment.",
    "Quality gates pass: Typecheck passes; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green; focused mapping tests and go test ./pkg/services/models/... ./tests/functional/models/... pass; required CI treats Backend Lint and Verification Policy as required and does not block on the known always-failing localai-backend-artifacts check.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "model-pull-reports-pulled-on-source-fetch-failure-001",
      "title": "Define a truthful and total pull outcome contract",
      "description": "As an API consumer, I want every managed pull result to have an explicit compatibility outcome so that a failure can never masquerade as a successful installation.",
      "acceptanceCriteria": [
        "Before changing behavior, a controlled source-fetch failure is reproduced locally and its exact CLI JSON, HTTP response, CLI exit status, and traced construction path are retained for the PR body.",
        "The authored compatibility outcome enum includes FAILED and documents the successful, already-present/already-ready, and failure projections from the canonical managed-runtime vocabulary.",
        "A source-fetch failure produces a Models-owned result with compatibility outcome FAILED, managed outcome SOURCE_FETCH_FAILED, readiness FAILED, and lifecycle NOT_INSTALLED.",
        "A table-driven totality test exercises every defined managed pull outcome and proves that none can use an implicit or default-to-PULLED fallback; unknown values are handled as an explicit non-success result or error.",
        "Successful installation still projects to PULLED, and already-present or already-ready assets still project to ALREADY_PRESENT.",
        "make generate-api regenerates and synchronizes the bundled OpenAPI, Go server/client, and TypeScript client from authored fragments; generated files are not hand-edited.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added the authored FAILED compatibility outcome, regenerated API artifacts, made Models/CLI/HTTP projections total from managed outcomes, and verified controlled source-fetch failure plus success/already-present mappings."
    },
    {
      "id": "model-pull-reports-pulled-on-source-fetch-failure-002",
      "title": "Report truthful failure through CLI and HTTP",
      "description": "As an operator or automation author, I want CLI JSON and HTTP model-pull responses to agree about failure so that either public interface can be trusted without interpreting contradictory fields.",
      "acceptanceCriteria": [
        "A controlled source-fetch failure through you --json models pull <model> returns JSON whose top-level outcome is FAILED and whose managed result is SOURCE_FETCH_FAILED/FAILED; it contains no success-state compatibility projection.",
        "The same controlled failure through POST /models/{model_name}/pull returns the same FAILED compatibility outcome and SOURCE_FETCH_FAILED/FAILED managed result, with no PULLED projection.",
        "The failed CLI command continues to exit non-zero and continues to expose the managed failure classification; neither the failure cause nor the non-zero behavior is suppressed.",
        "Direct CLI and HTTP regression tests fail against the pre-change behavior and pass after the correction; paired success and already-present cases prove their established projections remain unchanged.",
        "Exact before/after CLI JSON, exit status, HTTP response, and the confirmed request construction path are quoted in the PR body; CI and command-run evidence is posted in a PR comment, never committed as repository content.",
        "make api-smoke passes when feasible, and go test ./pkg/services/models/... ./tests/functional/models/... passes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added root-built CLI and direct functional HTTP source-fetch failure parity coverage, asserted FAILED/SOURCE_FETCH_FAILED/FAILED without success projections, preserved successful PULLED behavior, and captured independent parent-revision before/after evidence. Focused Models tests, full Models functional tests, typecheck, make generate-api, and make api-smoke pass."
    }
  ]
}
```

## Independent before/after evidence

Controlled source failure: the configured source endpoint for `Serveurperso/OmniVoice-GGUF` returned HTTP 503 while pulling `OMNIVOICE_Q4_K_M`. The before capture was run from parent revision `03ace72c7`; the after capture was run from final head `da4cc9939`.

The new regression assertion failed before correction: the canonical managed fields were `SOURCE_FETCH_FAILED`/`FAILED`, but the compatibility assertion observed `PULLED`.

### CLI (`you --json --server <functional-api> models pull OMNIVOICE_Q4_K_M`)

Before correction, CLI exit status was `1` (the root `Process.Execute` error is mapped to `cmd/factory`'s `exitFailure = 1`):

```json
{"cachePath":"","downloadedFiles":[],"managedRuntimePull":{"identity":"OMNIVOICE_Q4_K_M","pullOutcome":"SOURCE_FETCH_FAILED","readinessState":"FAILED","sourceDiagnostics":{"resolverNotes":"assets resolve through configured upstream repository source","sourceId":"upstream-repository:OMNIVOICE_Q4_K_M","sourceKind":"UPSTREAM_REPOSITORY"}},"modelName":"OMNIVOICE_Q4_K_M","outcome":"PULLED","providerLocality":"LOCAL","revision":""}
```

After correction, CLI exit status remains `1`, while the exact JSON is:

```json
{"cachePath":"","downloadedFiles":[],"managedRuntimePull":{"identity":"OMNIVOICE_Q4_K_M","pullOutcome":"SOURCE_FETCH_FAILED","readinessState":"FAILED","sourceDiagnostics":{"resolverNotes":"assets resolve through configured upstream repository source","sourceId":"upstream-repository:OMNIVOICE_Q4_K_M","sourceKind":"UPSTREAM_REPOSITORY"}},"modelName":"OMNIVOICE_Q4_K_M","outcome":"FAILED","providerLocality":"LOCAL","revision":""}
```

The CLI diagnostic remains structured and actionable in both captures:

```json
{"code":"CLI_MODEL_PULL_FAILED","family":"BAD_REQUEST","message":"managed runtime pull failed (pullOutcome=SOURCE_FETCH_FAILED readinessState=FAILED)"}
```

### HTTP (`POST /models/OMNIVOICE_Q4_K_M/pull`)

Before correction: HTTP `422` with the same body as the before CLI response, including `"outcome":"PULLED"`.

After correction: HTTP `422` with the same body as the after CLI response, including `"outcome":"FAILED"` and no success compatibility projection.

### Confirmed construction path

The generated `POST /models/{model_name}/pull` route in `pkg/transports/http/generated/server.gen.go` dispatches through `pkg/transports/http/handlers_models.go` to `pkg/services/models/transports/http/Handler.PullModel`, then `Adapter.PullModel`, `Models.PullModelForScope`, the Models local `assetPuller.PullModel` in `pkg/services/models/internal/local/puller.go`, and `PullModelWithOptions` in `pkg/services/models/internal/local/catalog.go`. The local puller reaches the configured `ModelAssetHTTPClient`; the classified failure returns a `models.PullError` carrying `FAILED`/`SOURCE_FETCH_FAILED`/`FAILED`/`NOT_INSTALLED`.

The CLI path in `pkg/services/models/transports/cli/models.go` uses `doModelsPOST` against that same HTTP route. On classified non-2xx responses it decodes the response body and `projectPullResponseOutcome` derives the compatibility outcome from `managedRuntimePull.pullOutcome`, keeping CLI and HTTP parity.

## Verification

- `go test ./pkg/services/models/... ./tests/functional/models/... -count=1 -timeout 10m`
- `make typecheck`
- `make generate-api`
- `make api-smoke`
- Focused service and transport tests passed.

CI-run evidence will be posted in a PR comment and is not committed to the branch.
