### PR TITLE
Invoke discovered built-in models by name

### DIFF
--- a/pkg/services/factory_sessions/internal/runtimeopening/models_config.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/models_config.go
@@ -3,6 +3,7 @@ package runtimeopening
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -139,8 +140,8 @@ func (invoker *runtimeModelInvoker) InvokeModel(
 	if err != nil {
 		return models.Result{}, err
 	}
-	worker, operation, err := directRuntimeModelWorker(
-		projection.Context.FactoryCfg, modelName, request.Operation,
+	worker, operation, err := invoker.resolveRuntimeModelWorker(
+		ctx, projection.Context.FactoryCfg, modelName, request.Operation,
 	)
 	if err != nil {
 		return models.Result{}, classifyRuntimeModelError(err, failureContext)
@@ -186,6 +187,79 @@ func (invoker *runtimeModelInvoker) InvokeModel(
 		StreamFile:        streamFile,
 		StreamContentType: streamContentType,
 	}, nil
+}
+
+func (invoker *runtimeModelInvoker) resolveRuntimeModelWorker(
+	ctx context.Context,
+	factoryConfig *factorydefinitions.FactoryConfig,
+	modelName, operationName string,
+) (*factorydefinitions.FactoryWorkerConfig, factorydefinitions.ModelOperation, error) {
+	worker, operation, err := directRuntimeModelWorker(factoryConfig, modelName, operationName)
+	if err == nil || (!errors.Is(err, models.ErrNotFound) && factoryConfig != nil) {
+		return worker, operation, err
+	}
+	resolved, resolveErr := invoker.config.Models.ResolveModelReference(ctx, models.ResolveModelReferenceRequest{
+		Scope: invoker.config.Scope,
+		Reference: models.ModelReference{
+			NameOrURI: strings.TrimSpace(modelName),
+		},
+	})
+	if resolveErr != nil {
+		return nil, factorydefinitions.ModelOperation{}, resolveErr
+	}
+	return effectiveRuntimeModelWorker(resolved.Resolved.Definition, operationName)
+}
+
+func effectiveRuntimeModelWorker(
+	definition models.ModelDefinition,
+	operationName string,
+) (*factorydefinitions.FactoryWorkerConfig, factorydefinitions.ModelOperation, error) {
+	modelName := strings.TrimSpace(definition.Name)
+	if modelName == "" {
+		return nil, factorydefinitions.ModelOperation{}, fmt.Errorf(
+			"%w: resolved model has no name", models.ErrNotFound,
+		)
+	}
+	worker := &factorydefinitions.FactoryWorkerConfig{
+		Name:          modelName,
+		Type:          factorydefinitions.WorkerTypeInference,
+		Model:         modelName,
+		ModelLocality: models.RuntimeModelLocalityLocal,
+	}
+	for _, candidate := range definition.Operations {
+		operation := projectEffectiveRuntimeModelOperation(candidate)
+		worker.Operations = append(worker.Operations, operation)
+		if strings.TrimSpace(operation.Name) == strings.TrimSpace(operationName) {
+			return worker, operation, nil
+		}
+	}
+	return nil, factorydefinitions.ModelOperation{}, fmt.Errorf(
+		"%w: model %q does not support operation %q",
+		models.ErrUnsupportedOperation, modelName, operationName,
+	)
+}
+
+func projectEffectiveRuntimeModelOperation(operation models.Operation) factorydefinitions.ModelOperation {
+	return factorydefinitions.ModelOperation{
+		Name:    operation.Name,
+		Inputs:  projectEffectiveRuntimeModelSlots(operation.Inputs),
+		Outputs: projectEffectiveRuntimeModelSlots(operation.Outputs),
+	}
+}
+
+func projectEffectiveRuntimeModelSlots(slots []models.OperationSlot) []factorydefinitions.ModelOperationSlot {
+	if len(slots) == 0 {
+		return nil
+	}
+	projected := make([]factorydefinitions.ModelOperationSlot, len(slots))
+	for index, slot := range slots {
+		projected[index] = factorydefinitions.ModelOperationSlot{
+			Name:         slot.Name,
+			ContentTypes: append([]string(nil), slot.ContentTypes...),
+			Required:     slot.Required != nil && *slot.Required,
+		}
+	}
+	return projected
 }
 
 func (invoker *runtimeModelInvoker) invokeRuntimeModel(

--- a/pkg/services/factory_sessions/internal/runtimeopening/models_config.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/models_config.go
@@ -205,9 +205,65 @@ func (invoker *runtimeModelInvoker) resolveRuntimeModelWorker(
 		},
 	})
 	if resolveErr != nil {
-		return nil, factorydefinitions.ModelOperation{}, resolveErr
+		return nil, factorydefinitions.ModelOperation{}, normalizeRuntimeModelResolutionError(
+			modelName, operationName, resolveErr,
+		)
 	}
-	return effectiveRuntimeModelWorker(resolved.Resolved.Definition, operationName)
+	worker, operation, effectiveErr := effectiveRuntimeModelWorker(
+		resolved.Resolved.Definition, operationName,
+	)
+	worker = attachEffectiveRuntimeResource(
+		worker, factoryConfig, resolved.Resolved.Definition,
+	)
+	return worker, operation, normalizeRuntimeModelResolutionError(
+		modelName, operationName, effectiveErr,
+	)
+}
+
+func attachEffectiveRuntimeResource(
+	worker *factorydefinitions.FactoryWorkerConfig,
+	factoryConfig *factorydefinitions.FactoryConfig,
+	definition models.ModelDefinition,
+) *factorydefinitions.FactoryWorkerConfig {
+	if worker == nil || factoryConfig == nil || len(factoryConfig.Resources) == 0 {
+		return worker
+	}
+	for _, resource := range factoryConfig.Resources {
+		if !strings.EqualFold(strings.TrimSpace(resource.Type), factorydefinitions.ResourceTypeModel) ||
+			!strings.EqualFold(strings.TrimSpace(resource.Model), strings.TrimSpace(definition.Name)) {
+			continue
+		}
+		if strings.TrimSpace(resource.Backend) != "" && strings.TrimSpace(definition.Backend) != "" &&
+			!strings.EqualFold(strings.TrimSpace(resource.Backend), strings.TrimSpace(definition.Backend)) {
+			continue
+		}
+		worker.Resources = []factorydefinitions.ResourceConfig{{
+			Name: resource.Name, Capacity: resource.Capacity,
+		}}
+		break
+	}
+	return worker
+}
+
+func normalizeRuntimeModelResolutionError(modelName, operationName string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var failure *models.InvocationFailure
+	if errors.As(err, &failure) && failure != nil {
+		return err
+	}
+	if !errors.Is(err, models.ErrNotFound) {
+		return err
+	}
+	name := strings.TrimSpace(modelName)
+	return &models.InvocationFailure{
+		Class:     models.InvocationFailureClassInvalidModelReference,
+		Message:   fmt.Sprintf("model %q is not available", name),
+		Model:     models.ModelReference{NameOrURI: name},
+		Operation: strings.TrimSpace(operationName),
+		Cause:     err,
+	}
 }
 
 func effectiveRuntimeModelWorker(
@@ -706,6 +762,10 @@ func runtimeModelStream(
 }
 
 func classifyRuntimeModelError(err error, context workers.InferenceFailureContext) error {
+	var invocationFailure *models.InvocationFailure
+	if errors.As(err, &invocationFailure) && invocationFailure != nil {
+		return err
+	}
 	if failure, ok := workers.ClassifyInferenceFailure(err, context); ok {
 		return failure
 	}

--- a/pkg/services/factory_sessions/internal/runtimeopening/models_config_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/models_config_test.go
@@ -705,8 +705,13 @@ func assertRuntimeModelInvokerLookupFailures(
 
 	configWithoutModel := &factorydefinitions.FactoryConfig{}
 	missingWorkerSessions := &runtimeInvokerSessionsStub{projection: factorysessions.SessionProjection{Context: factorysessions.ProjectionContext{FactoryCfg: configWithoutModel}}}
-	if _, err := NewRuntimeModelInvoker(RuntimeModelInvokerConfig{Models: readyModels, Scope: scope, Sessions: missingWorkerSessions}).InvokeModel(context.Background(), "missing-model", request); err == nil || !strings.Contains(err.Error(), "model not found") {
-		t.Fatalf("missing worker error = %v, want model-not-found classification", err)
+	missingWorkerErr := func() error {
+		_, err := NewRuntimeModelInvoker(RuntimeModelInvokerConfig{Models: readyModels, Scope: scope, Sessions: missingWorkerSessions}).InvokeModel(context.Background(), "missing-model", request)
+		return err
+	}()
+	var missingModelFailure *models.InvocationFailure
+	if missingWorkerErr == nil || !errors.As(missingWorkerErr, &missingModelFailure) || missingModelFailure.Class != models.InvocationFailureClassInvalidModelReference {
+		t.Fatalf("missing worker error = %v, want invalid-model-reference classification", missingWorkerErr)
 	}
 
 	readinessErrorModels := &runtimeInvokerModelsStub{readinessErr: errors.New("readiness lookup failed")}

--- a/pkg/services/factory_sessions/internal/runtimeopening/models_config_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/models_config_test.go
@@ -405,11 +405,24 @@ func TestRuntimeModelInvokerUsesEffectiveBuiltinWithoutDeclaredWorker(t *testing
 	t.Parallel()
 
 	scope := mustRuntimeModelScope(t, "factory-session:models:effective-builtin")
+	modelsService := newEffectiveBuiltinModelsStub(t)
+	workersService := effectiveBuiltinWorkersStub()
+	invoker := NewRuntimeModelInvoker(RuntimeModelInvokerConfig{
+		Models: modelsService, Scope: scope, Sessions: sessionsWithConfig(&factorydefinitions.FactoryConfig{}),
+		Workers: workersService,
+	})
+	result, err := invoker.InvokeModel(context.Background(), models.BuiltInModelNameTTS, effectiveBuiltinRequest())
+
+	assertEffectiveBuiltinInvocation(t, scope, modelsService, workersService, result, err)
+}
+
+func newEffectiveBuiltinModelsStub(t *testing.T) *runtimeInvokerModelsStub {
+	t.Helper()
 	definition, ok := (models.BuiltInCatalog{}).ModelDefinitionFor(models.BuiltInModelNameTTS)
 	if !ok {
 		t.Fatal("built-in TTS definition is unavailable")
 	}
-	modelsService := &runtimeInvokerModelsStub{
+	return &runtimeInvokerModelsStub{
 		resolution: models.ResolveModelReferenceResult{
 			Resolved: models.ResolvedModelReference{Definition: definition},
 		},
@@ -418,22 +431,42 @@ func TestRuntimeModelInvokerUsesEffectiveBuiltinWithoutDeclaredWorker(t *testing
 			Readiness: models.Runtime{ReadinessState: models.ReadinessStateReady},
 		},
 	}
-	workersService := &runtimeInvokerWorkersStub{result: workers.ExecuteResult{
+}
+
+func effectiveBuiltinWorkersStub() *runtimeInvokerWorkersStub {
+	return &runtimeInvokerWorkersStub{result: workers.ExecuteResult{
 		Outcome: workers.ExecutionOutcomeAccepted,
 		Output: workers.ProposedOutput{Primary: []work.WorkContentPart{{
 			Type: work.WorkContentPartTypeAudio, File: "/tmp/tts.wav", ContentType: "audio/wav",
 		}}},
 	}}
-	invoker := NewRuntimeModelInvoker(RuntimeModelInvokerConfig{
-		Models: modelsService, Scope: scope, Sessions: sessionsWithConfig(&factorydefinitions.FactoryConfig{}),
-		Workers: workersService,
-	})
-	result, err := invoker.InvokeModel(context.Background(), models.BuiltInModelNameTTS, models.Request{
+}
+
+func effectiveBuiltinRequest() models.Request {
+	return models.Request{
 		Operation: models.OperationTTS,
 		Content: []work.WorkContentPart{{
 			Slot: "text", Type: work.WorkContentPartTypeText, Text: "hello",
 		}},
-	})
+	}
+}
+
+func assertEffectiveBuiltinInvocation(
+	t *testing.T,
+	scope models.RuntimeScopeRef,
+	modelsService *runtimeInvokerModelsStub,
+	workersService *runtimeInvokerWorkersStub,
+	result models.Result,
+	err error,
+) {
+	t.Helper()
+	assertEffectiveBuiltinResult(t, result, err)
+	assertEffectiveBuiltinResolution(t, scope, modelsService)
+	assertEffectiveBuiltinExecution(t, workersService)
+}
+
+func assertEffectiveBuiltinResult(t *testing.T, result models.Result, err error) {
+	t.Helper()
 	if err != nil {
 		t.Fatalf("InvokeModel(effective built-in) error = %v, want nil", err)
 	}
@@ -444,6 +477,10 @@ func TestRuntimeModelInvokerUsesEffectiveBuiltinWithoutDeclaredWorker(t *testing
 	if len(result.Content) != 1 || result.Content[0].Type != work.WorkContentPartTypeAudio {
 		t.Fatalf("effective built-in content = %#v, want one audio part", result.Content)
 	}
+}
+
+func assertEffectiveBuiltinResolution(t *testing.T, scope models.RuntimeScopeRef, modelsService *runtimeInvokerModelsStub) {
+	t.Helper()
 	if len(modelsService.resolutionRequests) != 1 {
 		t.Fatalf("resolution requests = %#v, want one effective-definition lookup", modelsService.resolutionRequests)
 	}
@@ -455,6 +492,10 @@ func TestRuntimeModelInvokerUsesEffectiveBuiltinWithoutDeclaredWorker(t *testing
 		modelsService.readinessRequests[0].Operation != models.OperationTTS {
 		t.Fatalf("readiness requests = %#v, want effective tts operation", modelsService.readinessRequests)
 	}
+}
+
+func assertEffectiveBuiltinExecution(t *testing.T, workersService *runtimeInvokerWorkersStub) {
+	t.Helper()
 	if len(workersService.requests) != 1 {
 		t.Fatalf("Workers Execute requests = %d, want one", len(workersService.requests))
 	}

--- a/pkg/services/factory_sessions/internal/runtimeopening/models_config_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/models_config_test.go
@@ -401,6 +401,102 @@ func TestRuntimeModelInvokerUsesSharedWorkersForManagedModel(t *testing.T) {
 	assertManagedModelInvocation(t, result, err, scope, modelsService, workersService)
 }
 
+func TestRuntimeModelInvokerUsesEffectiveBuiltinWithoutDeclaredWorker(t *testing.T) {
+	t.Parallel()
+
+	scope := mustRuntimeModelScope(t, "factory-session:models:effective-builtin")
+	definition, ok := (models.BuiltInCatalog{}).ModelDefinitionFor(models.BuiltInModelNameTTS)
+	if !ok {
+		t.Fatal("built-in TTS definition is unavailable")
+	}
+	modelsService := &runtimeInvokerModelsStub{
+		resolution: models.ResolveModelReferenceResult{
+			Resolved: models.ResolvedModelReference{Definition: definition},
+		},
+		readiness: models.GetModelReadinessResult{
+			ModelName: models.BuiltInModelNameTTS,
+			Readiness: models.Runtime{ReadinessState: models.ReadinessStateReady},
+		},
+	}
+	workersService := &runtimeInvokerWorkersStub{result: workers.ExecuteResult{
+		Outcome: workers.ExecutionOutcomeAccepted,
+		Output: workers.ProposedOutput{Primary: []work.WorkContentPart{{
+			Type: work.WorkContentPartTypeAudio, File: "/tmp/tts.wav", ContentType: "audio/wav",
+		}}},
+	}}
+	invoker := NewRuntimeModelInvoker(RuntimeModelInvokerConfig{
+		Models: modelsService, Scope: scope, Sessions: sessionsWithConfig(&factorydefinitions.FactoryConfig{}),
+		Workers: workersService,
+	})
+	result, err := invoker.InvokeModel(context.Background(), models.BuiltInModelNameTTS, models.Request{
+		Operation: models.OperationTTS,
+		Content: []work.WorkContentPart{{
+			Slot: "text", Type: work.WorkContentPartTypeText, Text: "hello",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("InvokeModel(effective built-in) error = %v, want nil", err)
+	}
+	if result.ModelName != models.BuiltInModelNameTTS || result.Worker != models.BuiltInModelNameTTS ||
+		result.Operation != models.OperationTTS || result.ProviderLocality != models.RuntimeModelLocalityLocal {
+		t.Fatalf("effective built-in result = %#v, want tts identity/locality", result)
+	}
+	if len(result.Content) != 1 || result.Content[0].Type != work.WorkContentPartTypeAudio {
+		t.Fatalf("effective built-in content = %#v, want one audio part", result.Content)
+	}
+	if len(modelsService.resolutionRequests) != 1 {
+		t.Fatalf("resolution requests = %#v, want one effective-definition lookup", modelsService.resolutionRequests)
+	}
+	resolution := modelsService.resolutionRequests[0]
+	if resolution.Scope != scope || resolution.Reference.NameOrURI != models.BuiltInModelNameTTS {
+		t.Fatalf("resolution request = %#v, want opened scope and tts name", resolution)
+	}
+	if len(modelsService.readinessRequests) != 1 || modelsService.readinessRequests[0].Name != models.BuiltInModelNameTTS ||
+		modelsService.readinessRequests[0].Operation != models.OperationTTS {
+		t.Fatalf("readiness requests = %#v, want effective tts operation", modelsService.readinessRequests)
+	}
+	if len(workersService.requests) != 1 {
+		t.Fatalf("Workers Execute requests = %d, want one", len(workersService.requests))
+	}
+	execute := workersService.requests[0]
+	if execute.Target.WorkerName != models.BuiltInModelNameTTS || execute.Target.WorkerType != factorydefinitions.WorkerTypeInference ||
+		execute.Target.Model.Name != models.BuiltInModelNameTTS || execute.Target.Model.Locality != models.RuntimeModelLocalityLocal {
+		t.Fatalf("effective built-in target = %#v, want synthetic inference target", execute.Target)
+	}
+	if execute.Input.ModelRuntime == nil || execute.Input.ModelRuntime.Worker.Model != models.BuiltInModelNameTTS {
+		t.Fatalf("effective built-in runtime input = %#v, want managed model projection", execute.Input.ModelRuntime)
+	}
+	if len(execute.Input.ModelBindings) != 3 || execute.Input.ModelBindings[0].Slot != "text" ||
+		execute.Input.ModelBindings[0].Source != workers.ModelOperationBindingSourceInput ||
+		execute.Input.ModelBindings[1].Source != workers.ModelOperationBindingSourceOmitted {
+		t.Fatalf("effective built-in bindings = %#v, want projected TTS slots", execute.Input.ModelBindings)
+	}
+}
+
+func TestRuntimeModelInvokerPreservesEffectiveBuiltinUnsupportedOperation(t *testing.T) {
+	t.Parallel()
+
+	scope := mustRuntimeModelScope(t, "factory-session:models:effective-unsupported")
+	definition, ok := (models.BuiltInCatalog{}).ModelDefinitionFor(models.BuiltInModelNameTTS)
+	if !ok {
+		t.Fatal("built-in TTS definition is unavailable")
+	}
+	modelsService := &runtimeInvokerModelsStub{resolution: models.ResolveModelReferenceResult{
+		Resolved: models.ResolvedModelReference{Definition: definition},
+	}}
+	invoker := NewRuntimeModelInvoker(RuntimeModelInvokerConfig{
+		Models: modelsService, Scope: scope, Sessions: sessionsWithConfig(&factorydefinitions.FactoryConfig{}),
+		Workers: &runtimeInvokerWorkersStub{},
+	})
+	_, err := invoker.InvokeModel(context.Background(), models.BuiltInModelNameTTS, models.Request{Operation: models.OperationASR})
+	if err == nil || !errors.Is(err, models.ErrUnsupportedOperation) {
+		t.Fatalf("unsupported effective operation error = %v, want ErrUnsupportedOperation", err)
+	}
+	if len(modelsService.resolutionRequests) != 1 || len(modelsService.readinessRequests) != 0 {
+		t.Fatalf("effective unsupported lookup state = resolutions=%d readiness=%d, want resolution only", len(modelsService.resolutionRequests), len(modelsService.readinessRequests))
+	}
+}
+
 func assertManagedModelInvocation(
 	t *testing.T,
 	result models.Result,
@@ -418,6 +514,9 @@ func assertManagedModelInvocation(
 	}
 	if len(modelsService.readinessRequests) != 1 || modelsService.readinessRequests[0].Scope != scope {
 		t.Fatalf("readiness requests = %#v, want opened runtime scope", modelsService.readinessRequests)
+	}
+	if len(modelsService.resolutionRequests) != 0 {
+		t.Fatalf("effective-definition resolution requests = %#v, want declared worker precedence", modelsService.resolutionRequests)
 	}
 	if len(workersService.requests) != 1 {
 		t.Fatalf("Workers Execute requests = %d, want one", len(workersService.requests))
@@ -675,14 +774,22 @@ func sessionsWithConfig(config *factorydefinitions.FactoryConfig) *runtimeInvoke
 
 type runtimeInvokerModelsStub struct {
 	models.Service
-	readiness         models.GetModelReadinessResult
-	readinessErr      error
-	readinessRequests []models.GetModelReadinessRequest
+	readiness          models.GetModelReadinessResult
+	readinessErr       error
+	readinessRequests  []models.GetModelReadinessRequest
+	resolution         models.ResolveModelReferenceResult
+	resolutionErr      error
+	resolutionRequests []models.ResolveModelReferenceRequest
 }
 
 func (stub *runtimeInvokerModelsStub) GetModelReadiness(_ context.Context, request models.GetModelReadinessRequest) (models.GetModelReadinessResult, error) {
 	stub.readinessRequests = append(stub.readinessRequests, request)
 	return stub.readiness, stub.readinessErr
+}
+
+func (stub *runtimeInvokerModelsStub) ResolveModelReference(_ context.Context, request models.ResolveModelReferenceRequest) (models.ResolveModelReferenceResult, error) {
+	stub.resolutionRequests = append(stub.resolutionRequests, request)
+	return stub.resolution, stub.resolutionErr
 }
 
 type runtimeInvokerSessionsStub struct {

--- a/tests/functional/models/root_composition/inference_invoke_test.go
+++ b/tests/functional/models/root_composition/inference_invoke_test.go
@@ -243,6 +243,15 @@ func builtInOnlyModelFactoryConfig() map[string]any {
 	}
 }
 
+func findModelSummary(results []factoryapi.ModelSummary, name string) (factoryapi.ModelSummary, bool) {
+	for _, result := range results {
+		if result.Name == name {
+			return result, true
+		}
+	}
+	return factoryapi.ModelSummary{}, false
+}
+
 // TestModelsGenericHTTPInvocationReachesJoinedRootThroughProcess proves the
 // registered generic HTTP route uses the live Models scope and returns named
 // output from the joined root rather than the legacy model-invocation envelope.
@@ -388,6 +397,97 @@ func TestModelsNamedAndGenericHTTPInvocationShareBuiltinResolution(t *testing.T)
 	}
 	if rejectingNetwork.Calls() != 0 || hostLauncher.Calls() != 0 || protocol.Calls() != 0 || compatibility.Calls() != 0 {
 		t.Fatalf("built-in parity effects = network %d, starts %d, protocol %d, compatibility %d; want no external effects for the cache-backed generic attempt or named readiness rejection", rejectingNetwork.Calls(), hostLauncher.Calls(), protocol.Calls(), compatibility.Calls())
+	}
+}
+
+// TestModelsNamedBuiltinRouteUsesEffectiveDefinitionWithoutWorker proves the
+// named route uses the discovered built-in definition even when the Factory
+// declares no matching inference worker, and preserves actionable readiness
+// and unknown-reference failures.
+func TestModelsNamedBuiltinRouteUsesEffectiveDefinitionWithoutWorker(t *testing.T) {
+	t.Parallel()
+
+	dir := support.ScaffoldFactory(t, builtInOnlyModelFactoryConfig())
+	runner := support.NewRecordingCommandRunner("provider should not run before managed readiness")
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		WaitForServiceModeRuntime: true,
+		Edges:                     serviceedges.Edges{ProviderCommandRunner: runner},
+	})
+
+	assertEffectiveBuiltinDiscovery(t, server.URL())
+	assertEffectiveBuiltinReadinessFailures(t, server.URL())
+	assertUnknownBuiltinFailure(t, server.URL())
+	if runner.CallCount() != 0 {
+		t.Fatalf("provider command runner calls = %d, want readiness to reject unavailable built-ins before execution", runner.CallCount())
+	}
+}
+
+func assertEffectiveBuiltinDiscovery(t *testing.T, serverURL string) {
+	t.Helper()
+	listed := support.GetJSON[factoryapi.ListModelsResponse](t, serverURL+"/models")
+	if _, ok := findModelSummary(listed.Results, models.BuiltInModelNameTTS); !ok {
+		t.Fatalf("GET /models did not expose effective built-in %q; results=%#v", models.BuiltInModelNameTTS, listed.Results)
+	}
+	inspected := support.GetJSON[factoryapi.ModelDetail](t, serverURL+"/models/"+models.BuiltInModelNameTTS)
+	if inspected.Name != models.BuiltInModelNameTTS || len(inspected.Operations) != 1 || inspected.Operations[0].Name != models.OperationTTS {
+		t.Fatalf("GET /models/%s = %#v, want effective TTS definition", models.BuiltInModelNameTTS, inspected)
+	}
+}
+
+func assertEffectiveBuiltinReadinessFailures(t *testing.T, serverURL string) {
+	t.Helper()
+	for _, modelName := range []string{models.BuiltInModelNameTTS, models.BuiltInModelNameASR} {
+		operation := models.OperationTTS
+		if modelName == models.BuiltInModelNameASR {
+			operation = models.OperationASR
+		}
+		failure := postNamedBuiltinFailure(t, serverURL, modelName, operation)
+		if failure.StatusCode != http.StatusNotFound || string(failure.Body.Code) != "MODEL_NOT_AVAILABLE" {
+			t.Fatalf("POST /models/%s/invocations = status %d, failure %#v; want effective-definition readiness failure", modelName, failure.StatusCode, failure.Body)
+		}
+		if strings.Contains(strings.ToLower(failure.Body.Message), "model not found") ||
+			strings.Contains(string(failure.Body.Code), "MODEL_INFERENCE_RUNTIME_FAILURE") ||
+			failure.Body.Family == factoryapi.ErrorFamilyInternalServerError {
+			t.Fatalf("POST /models/%s/invocations retained a worker-lookup failure: %#v", modelName, failure.Body)
+		}
+	}
+}
+
+type namedBuiltinFailure struct {
+	StatusCode int
+	Body       factoryapi.ErrorResponse
+}
+
+func postNamedBuiltinFailure(t *testing.T, serverURL, modelName, operation string) namedBuiltinFailure {
+	t.Helper()
+	body, err := json.Marshal(factoryapi.ModelInvocationRequest{Operation: operation})
+	if err != nil {
+		t.Fatalf("marshal %s invocation: %v", modelName, err)
+	}
+	response, err := http.Post(serverURL+"/models/"+modelName+"/invocations", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /models/%s/invocations: %v", modelName, err)
+	}
+	defer response.Body.Close()
+	var failure factoryapi.ErrorResponse
+	if err := json.NewDecoder(response.Body).Decode(&failure); err != nil {
+		t.Fatalf("decode %s invocation failure: %v", modelName, err)
+	}
+	return namedBuiltinFailure{StatusCode: response.StatusCode, Body: failure}
+}
+
+func assertUnknownBuiltinFailure(t *testing.T, serverURL string) {
+	t.Helper()
+	failure := postNamedBuiltinFailure(t, serverURL, "unknown-discovered-model", models.OperationTTS)
+	if failure.StatusCode != http.StatusNotFound ||
+		string(failure.Body.Code) != "MODEL_NOT_AVAILABLE" ||
+		failure.Body.Family != factoryapi.ErrorFamilyNotFound {
+		t.Fatalf("POST /models/unknown-discovered-model/invocations = status %d, failure %#v; want actionable model-not-available 404", failure.StatusCode, failure.Body)
+	}
+	if strings.Contains(string(failure.Body.Code), "MODEL_INFERENCE_RUNTIME_FAILURE") ||
+		failure.Body.Family == factoryapi.ErrorFamilyInternalServerError {
+		t.Fatalf("unknown model invocation retained an internal failure classification: %#v", failure.Body)
 	}
 }
 

--- a/tests/functional/models/root_composition/inference_invoke_test.go
+++ b/tests/functional/models/root_composition/inference_invoke_test.go
@@ -304,6 +304,93 @@ func TestModelsGenericHTTPInvocationReachesJoinedRootThroughProcess(t *testing.T
 	functionalevidence.Covers(t, "rest/invokeGenericModel")
 }
 
+// TestModelsNamedAndGenericHTTPInvocationShareBuiltinResolution proves both
+// public invocation routes use the same effective built-in definition when no
+// Factory worker is declared. The generic route keeps its slot-named output
+// contract; the named route keeps its legacy worker/content response shape.
+func TestModelsNamedAndGenericHTTPInvocationShareBuiltinResolution(t *testing.T) {
+	t.Parallel()
+
+	modelServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/health" {
+			writer.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(writer, request)
+	}))
+	t.Cleanup(modelServer.Close)
+
+	home := t.TempDir()
+	writeGenericBuiltinTTSCache(t, home)
+	writeGenericBuiltinTTSBackendCache(t, home)
+	rejectingNetwork := &rejectingModelAssetHTTP{}
+	hostLauncher := &recordingModelHostLauncher{endpoint: modelServer.URL}
+	protocol := &joinedProtocolNegotiator{}
+	compatibility := &joinedCompatibilityChecker{}
+	assetFiles := functionalModelAssetFileSystem{home: home}
+	dir := support.ScaffoldFactory(t, builtInOnlyModelFactoryConfig())
+	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
+		FactoryDir:                dir,
+		WaitForServiceModeRuntime: true,
+		Env:                       functionalHomeEnvironment(home),
+		Edges:                     genericHTTPInvocationEdges(rejectingNetwork, assetFiles, hostLauncher, protocol, compatibility, modelServer),
+	})
+
+	text := "builtin parity input"
+	inputs := []factoryapi.ModelInvocationInput{{
+		Name: "text", Modality: factoryapi.ModelInvocationContentTypeText,
+		Content: &text,
+	}}
+	genericResponse := postFunctionalJSON[factoryapi.GenericModelInvocationResponse](
+		t,
+		server.URL()+"/models/invocations",
+		factoryapi.GenericModelInvocationRequest{
+			Scope: "factory-session:parity-generic", Holder: "functional-parity",
+			Model: factoryapi.ModelReference{NameOrUri: "tts"}, Operation: "TTS", Inputs: &inputs,
+		},
+		"POST /models/invocations built-in parity",
+	)
+	if len(genericResponse.Outputs) != 1 || genericResponse.Outputs[0].Name != "audio" ||
+		genericResponse.Outputs[0].Modality != factoryapi.ModelInvocationContentTypeAudio ||
+		genericResponse.Outputs[0].Content == nil || *genericResponse.Outputs[0].Content != text {
+		t.Fatalf("generic built-in parity response = %#v, want one audio output containing input", genericResponse)
+	}
+
+	namedContent := factoryapi.WorkContent{mustFunctionalTextPart(t, text)}
+	namedRequest := factoryapi.ModelInvocationRequest{
+		Operation: "TTS", Bindings: localModelReadinessAssetsHostBindings(), Content: &namedContent,
+	}
+	namedBody, err := json.Marshal(namedRequest)
+	if err != nil {
+		t.Fatalf("marshal named built-in parity request: %v", err)
+	}
+	namedHTTPResponse, err := http.Post(
+		server.URL()+"/models/tts/invocations", "application/json", bytes.NewReader(namedBody),
+	)
+	if err != nil {
+		t.Fatalf("POST /models/{model_name}/invocations built-in parity: %v", err)
+	}
+	var namedFailure factoryapi.ErrorResponse
+	if err := json.NewDecoder(namedHTTPResponse.Body).Decode(&namedFailure); err != nil {
+		namedHTTPResponse.Body.Close()
+		t.Fatalf("decode named built-in parity response: %v", err)
+	}
+	namedHTTPResponse.Body.Close()
+	if namedHTTPResponse.StatusCode != http.StatusNotFound ||
+		string(namedFailure.Code) != "MODEL_NOT_AVAILABLE" ||
+		namedFailure.Family != factoryapi.ErrorFamilyNotFound {
+		t.Fatalf("named built-in parity response = status %d, %#v; want effective-definition readiness 404", namedHTTPResponse.StatusCode, namedFailure)
+	}
+	if strings.Contains(strings.ToLower(namedFailure.Message), "model not found") ||
+		strings.Contains(string(namedFailure.Code), "MODEL_INFERENCE_RUNTIME_FAILURE") ||
+		namedFailure.Family == factoryapi.ErrorFamilyInternalServerError {
+		t.Fatalf("named built-in parity retained a worker-lookup failure: %#v", namedFailure)
+	}
+	if rejectingNetwork.Calls() != 0 || hostLauncher.Calls() != 0 || protocol.Calls() != 0 || compatibility.Calls() != 0 {
+		t.Fatalf("built-in parity effects = network %d, starts %d, protocol %d, compatibility %d; want no external effects for the cache-backed generic attempt or named readiness rejection", rejectingNetwork.Calls(), hostLauncher.Calls(), protocol.Calls(), compatibility.Calls())
+	}
+}
+
 func TestModelsGenericCLIOutputModesReachJoinedRootThroughProcess(t *testing.T) {
 	t.Parallel()
 

--- a/tests/functional/runtime_api/api_model_transport_smoke_test.go
+++ b/tests/functional/runtime_api/api_model_transport_smoke_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -171,6 +172,70 @@ func TestModelTransportSmoke_ServiceModeStartupAndDirectModelRoutesStayAligned(t
 	}
 
 	assertUnsupportedModelInvocationRejected(t, server.URL())
+}
+
+func TestModelTransportSmoke_NamedBuiltinRouteUsesEffectiveDefinitionWithoutWorker(t *testing.T) {
+	dir := support.ScaffoldFactory(t, builtInNamedModelTransportSmokeConfig())
+	runner := support.NewRecordingCommandRunner("provider should not run before managed readiness")
+	server := startFunctionalServer(t, dir, false, withWorkerCommands(runner, nil))
+
+	listed := getGeneratedJSON[factoryapi.ListModelsResponse](t, server.URL()+"/models")
+	if _, ok := findModelSummary(listed.Results, modelprovider.BuiltInModelNameTTS); !ok {
+		t.Fatalf("GET /models did not expose effective built-in %q; results=%#v", modelprovider.BuiltInModelNameTTS, listed.Results)
+	}
+	inspected := getGeneratedJSON[factoryapi.ModelDetail](t, server.URL()+"/models/"+modelprovider.BuiltInModelNameTTS)
+	if inspected.Name != modelprovider.BuiltInModelNameTTS || len(inspected.Operations) != 1 || inspected.Operations[0].Name != modelprovider.OperationTTS {
+		t.Fatalf("GET /models/%s = %#v, want effective TTS definition", modelprovider.BuiltInModelNameTTS, inspected)
+	}
+
+	for _, modelName := range []string{modelprovider.BuiltInModelNameTTS, modelprovider.BuiltInModelNameASR} {
+		request := factoryapi.ModelInvocationRequest{Operation: modelprovider.OperationTTS}
+		if modelName == modelprovider.BuiltInModelNameASR {
+			request.Operation = modelprovider.OperationASR
+		}
+		body, err := json.Marshal(request)
+		if err != nil {
+			t.Fatalf("marshal %s invocation: %v", modelName, err)
+		}
+		response, err := http.Post(
+			server.URL()+"/models/"+modelName+"/invocations",
+			"application/json", bytes.NewReader(body),
+		)
+		if err != nil {
+			t.Fatalf("POST /models/%s/invocations: %v", modelName, err)
+		}
+		var failure factoryapi.ErrorResponse
+		decodeErr := json.NewDecoder(response.Body).Decode(&failure)
+		response.Body.Close()
+		if decodeErr != nil {
+			t.Fatalf("decode %s invocation failure: %v", modelName, decodeErr)
+		}
+		if response.StatusCode != http.StatusNotFound || string(failure.Code) != "MODEL_NOT_AVAILABLE" {
+			t.Fatalf("POST /models/%s/invocations = status %d, failure %#v; want effective-definition readiness failure", modelName, response.StatusCode, failure)
+		}
+		if strings.Contains(strings.ToLower(failure.Message), "model not found") ||
+			strings.Contains(string(failure.Code), "MODEL_INFERENCE_RUNTIME_FAILURE") ||
+			failure.Family == factoryapi.ErrorFamilyInternalServerError {
+			t.Fatalf("POST /models/%s/invocations retained a worker-lookup failure: %#v", modelName, failure)
+		}
+	}
+	if runner.CallCount() != 0 {
+		t.Fatalf("provider command runner calls = %d, want readiness to reject unavailable built-ins before execution", runner.CallCount())
+	}
+}
+
+func builtInNamedModelTransportSmokeConfig() map[string]any {
+	return map[string]any{
+		"name": "built-in-named-model-transport",
+		"workTypes": []map[string]any{{
+			"name": "task",
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+	}
 }
 
 func findModelSummary(results []factoryapi.ModelSummary, name string) (factoryapi.ModelSummary, bool) {

--- a/tests/functional/runtime_api/api_model_transport_smoke_test.go
+++ b/tests/functional/runtime_api/api_model_transport_smoke_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 
@@ -172,96 +171,6 @@ func TestModelTransportSmoke_ServiceModeStartupAndDirectModelRoutesStayAligned(t
 	}
 
 	assertUnsupportedModelInvocationRejected(t, server.URL())
-}
-
-func TestModelTransportSmoke_NamedBuiltinRouteUsesEffectiveDefinitionWithoutWorker(t *testing.T) {
-	dir := support.ScaffoldFactory(t, builtInNamedModelTransportSmokeConfig())
-	runner := support.NewRecordingCommandRunner("provider should not run before managed readiness")
-	server := startFunctionalServer(t, dir, false, withWorkerCommands(runner, nil))
-
-	listed := getGeneratedJSON[factoryapi.ListModelsResponse](t, server.URL()+"/models")
-	if _, ok := findModelSummary(listed.Results, modelprovider.BuiltInModelNameTTS); !ok {
-		t.Fatalf("GET /models did not expose effective built-in %q; results=%#v", modelprovider.BuiltInModelNameTTS, listed.Results)
-	}
-	inspected := getGeneratedJSON[factoryapi.ModelDetail](t, server.URL()+"/models/"+modelprovider.BuiltInModelNameTTS)
-	if inspected.Name != modelprovider.BuiltInModelNameTTS || len(inspected.Operations) != 1 || inspected.Operations[0].Name != modelprovider.OperationTTS {
-		t.Fatalf("GET /models/%s = %#v, want effective TTS definition", modelprovider.BuiltInModelNameTTS, inspected)
-	}
-
-	for _, modelName := range []string{modelprovider.BuiltInModelNameTTS, modelprovider.BuiltInModelNameASR} {
-		request := factoryapi.ModelInvocationRequest{Operation: modelprovider.OperationTTS}
-		if modelName == modelprovider.BuiltInModelNameASR {
-			request.Operation = modelprovider.OperationASR
-		}
-		body, err := json.Marshal(request)
-		if err != nil {
-			t.Fatalf("marshal %s invocation: %v", modelName, err)
-		}
-		response, err := http.Post(
-			server.URL()+"/models/"+modelName+"/invocations",
-			"application/json", bytes.NewReader(body),
-		)
-		if err != nil {
-			t.Fatalf("POST /models/%s/invocations: %v", modelName, err)
-		}
-		var failure factoryapi.ErrorResponse
-		decodeErr := json.NewDecoder(response.Body).Decode(&failure)
-		response.Body.Close()
-		if decodeErr != nil {
-			t.Fatalf("decode %s invocation failure: %v", modelName, decodeErr)
-		}
-		if response.StatusCode != http.StatusNotFound || string(failure.Code) != "MODEL_NOT_AVAILABLE" {
-			t.Fatalf("POST /models/%s/invocations = status %d, failure %#v; want effective-definition readiness failure", modelName, response.StatusCode, failure)
-		}
-		if strings.Contains(strings.ToLower(failure.Message), "model not found") ||
-			strings.Contains(string(failure.Code), "MODEL_INFERENCE_RUNTIME_FAILURE") ||
-			failure.Family == factoryapi.ErrorFamilyInternalServerError {
-			t.Fatalf("POST /models/%s/invocations retained a worker-lookup failure: %#v", modelName, failure)
-		}
-	}
-	unknownBody, err := json.Marshal(factoryapi.ModelInvocationRequest{Operation: modelprovider.OperationTTS})
-	if err != nil {
-		t.Fatalf("marshal unknown model invocation: %v", err)
-	}
-	unknownResponse, err := http.Post(
-		server.URL()+"/models/unknown-discovered-model/invocations",
-		"application/json", bytes.NewReader(unknownBody),
-	)
-	if err != nil {
-		t.Fatalf("POST /models/unknown-discovered-model/invocations: %v", err)
-	}
-	var unknownFailure factoryapi.ErrorResponse
-	decodeUnknownErr := json.NewDecoder(unknownResponse.Body).Decode(&unknownFailure)
-	unknownResponse.Body.Close()
-	if decodeUnknownErr != nil {
-		t.Fatalf("decode unknown model invocation failure: %v", decodeUnknownErr)
-	}
-	if unknownResponse.StatusCode != http.StatusNotFound ||
-		string(unknownFailure.Code) != "MODEL_NOT_AVAILABLE" ||
-		unknownFailure.Family != factoryapi.ErrorFamilyNotFound {
-		t.Fatalf("POST /models/unknown-discovered-model/invocations = status %d, failure %#v; want actionable model-not-available 404", unknownResponse.StatusCode, unknownFailure)
-	}
-	if strings.Contains(string(unknownFailure.Code), "MODEL_INFERENCE_RUNTIME_FAILURE") ||
-		unknownFailure.Family == factoryapi.ErrorFamilyInternalServerError {
-		t.Fatalf("unknown model invocation retained an internal failure classification: %#v", unknownFailure)
-	}
-	if runner.CallCount() != 0 {
-		t.Fatalf("provider command runner calls = %d, want readiness to reject unavailable built-ins before execution", runner.CallCount())
-	}
-}
-
-func builtInNamedModelTransportSmokeConfig() map[string]any {
-	return map[string]any{
-		"name": "built-in-named-model-transport",
-		"workTypes": []map[string]any{{
-			"name": "task",
-			"states": []map[string]string{
-				{"name": "init", "type": "INITIAL"},
-				{"name": "complete", "type": "TERMINAL"},
-				{"name": "failed", "type": "FAILED"},
-			},
-		}},
-	}
 }
 
 func findModelSummary(results []factoryapi.ModelSummary, name string) (factoryapi.ModelSummary, bool) {

--- a/tests/functional/runtime_api/api_model_transport_smoke_test.go
+++ b/tests/functional/runtime_api/api_model_transport_smoke_test.go
@@ -219,6 +219,32 @@ func TestModelTransportSmoke_NamedBuiltinRouteUsesEffectiveDefinitionWithoutWork
 			t.Fatalf("POST /models/%s/invocations retained a worker-lookup failure: %#v", modelName, failure)
 		}
 	}
+	unknownBody, err := json.Marshal(factoryapi.ModelInvocationRequest{Operation: modelprovider.OperationTTS})
+	if err != nil {
+		t.Fatalf("marshal unknown model invocation: %v", err)
+	}
+	unknownResponse, err := http.Post(
+		server.URL()+"/models/unknown-discovered-model/invocations",
+		"application/json", bytes.NewReader(unknownBody),
+	)
+	if err != nil {
+		t.Fatalf("POST /models/unknown-discovered-model/invocations: %v", err)
+	}
+	var unknownFailure factoryapi.ErrorResponse
+	decodeUnknownErr := json.NewDecoder(unknownResponse.Body).Decode(&unknownFailure)
+	unknownResponse.Body.Close()
+	if decodeUnknownErr != nil {
+		t.Fatalf("decode unknown model invocation failure: %v", decodeUnknownErr)
+	}
+	if unknownResponse.StatusCode != http.StatusNotFound ||
+		string(unknownFailure.Code) != "MODEL_NOT_AVAILABLE" ||
+		unknownFailure.Family != factoryapi.ErrorFamilyNotFound {
+		t.Fatalf("POST /models/unknown-discovered-model/invocations = status %d, failure %#v; want actionable model-not-available 404", unknownResponse.StatusCode, unknownFailure)
+	}
+	if strings.Contains(string(unknownFailure.Code), "MODEL_INFERENCE_RUNTIME_FAILURE") ||
+		unknownFailure.Family == factoryapi.ErrorFamilyInternalServerError {
+		t.Fatalf("unknown model invocation retained an internal failure classification: %#v", unknownFailure)
+	}
 	if runner.CallCount() != 0 {
 		t.Fatalf("provider command runner calls = %d, want readiness to reject unavailable built-ins before execution", runner.CallCount())
 	}


### PR DESCRIPTION
{
  "project": "Invoke Discovered Built-in Models by Name",
  "branchName": "models-name-invocations-cannot-invoke-discovered-builtins",
  "description": "Make POST /models/{model_name}/invocations honor its discovered-model contract by resolving effective built-in definitions when no Factory-declared inference worker matches, while preserving declared-worker precedence, readiness and unsupported-operation behavior, honest client-class failures, and route parity.",
  "deliveryNotes": {
    "contractReading": "Contract reading (a) keeps a matching Factory inference worker first and falls back only after that worker-only lookup misses, using the opened Models scope's effective definition.",
    "fallback": "The fallback projects the detached definition's operation slots into the existing direct invocation path, preserves typed resolver failures, normalizes raw catalog misses to INVALID_MODEL_REFERENCE, and reuses a matching model resource without requiring a duplicate inference worker.",
    "routeParity": "The no-worker functional fixture proves the generic route can complete a cache-backed effective built-in transaction and the named route reaches the same effective-definition resolution before its distinct legacy managed-runtime readiness boundary returns MODEL_NOT_AVAILABLE when no direct runtime capability is configured. The named ready-path Workers attempt and declared-worker precedence remain covered by runtime-opening tests; the response/request shapes remain intentionally different.",
    "preChangeEvidence": "Before this change, the new named built-in functional case failed with a worker-only catalog miss and MODEL_INFERENCE_RUNTIME_FAILURE / INTERNAL_SERVER_ERROR; after the change, unknown names return MODEL_NOT_AVAILABLE / NOT_FOUND and discovered built-ins no longer report worker-lookup failures.",
    "verification": "go test ./pkg/services/factory_sessions/... ./tests/functional/runtime_api/...; go test ./tests/functional/models/root_composition/...; go test ./pkg/services/models/...; go test ./pkg/services/workers/..."
  },
  "context": {
    "customerAsk": "Allow the path-parameterized model invocation route to invoke built-in tts or asr models that model listing and inspection report as discovered, even when the Factory declares no matching worker. Preserve declared-worker behavior and return client-class failures rather than internal-server failures when a named model cannot be served.",
    "problem": "The opened runtime's direct model resolver scans only Factory-declared inference workers and never consults the Models catalog's effective-definition resolution. As a result, built-ins discovered by list and inspect are unreachable through POST /models/{model_name}/invocations and are incorrectly reported as MODEL_INFERENCE_RUNTIME_FAILURE / INTERNAL_SERVER_ERROR with model not found diagnostics.",
    "solution": "Adopt contract reading (a): keep declared inference workers first, then on a miss resolve the name through the already-injected Models service in the opened runtime scope and adapt the detached effective definition into the existing readiness, slot-binding, Workers execution, output, and streaming path. Align unresolved named requests to actionable 4xx classifications and prove parity with the generic route without changing that route."
  },
  "acceptanceCriteria": [
    "A functional request to POST /models/tts/invocations or POST /models/asr/invocations in a Factory with no matching worker resolves the same effective built-in definition exposed by list and inspect and reaches the normal readiness/Workers/kernel path; it does not fail with model not found: tts, MODEL_INFERENCE_RUNTIME_FAILURE, or INTERNAL_SERVER_ERROR merely because the worker declaration is absent.",
    "A matching Factory-declared inference worker still takes precedence and retains its current identity, provider/locality, operation, slot-binding, readiness, output, and streaming behavior, including the existing OMNIVOICE_Q4_K_M smoke scenario.",
    "For the same built-in name, functional evidence records and asserts that /models/invocations and /models/{model_name}/invocations both resolve the effective definition and attempt invocation; any difference due to their distinct request or response contracts is stated in the PR body and asserted rather than left accidental.",
    "Unknown names, unsupported operations, missing/not-ready runtimes, and other caller-addressable inability to serve the named request produce the existing applicable typed 4xx response or a newly aligned client-class 4xx response, never a generic internal-server classification; ErrUnsupportedOperation behavior is not weakened.",
    "The change remains confined to the named-route model-resolution path and its functional/contract evidence: it does not change /models/invocations, discovery, list/inspect behavior, built-in definitions, or the pull result contract, and it does not revert any behavior from PR #2239. If OpenAPI wording is clarified, the authored source is changed and make generate-api output is committed without hand-editing generated artifacts.",
    "Typecheck passes; go test ./pkg/services/factory_sessions/... ./tests/functional/runtime_api/... and focused contract tests pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Required Backend Lint and Verification Policy CI checks pass; the known localai-backend-artifacts branch-independent failure is not treated as a required lane check.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "models-name-invocations-cannot-invoke-discovered-builtins-001",
      "title": "Invoke an effective built-in through the named route",
      "description": "As an API customer, I want to invoke a built-in model reported by discovery without declaring a duplicate Factory worker so that model discovery and named invocation describe the same usable catalog.",
      "acceptanceCriteria": [
        "With no Factory inference worker matching tts or asr, the named route resolves the requested model through the opened Models scope's effective definition and enters the existing request-scoped Workers execution path.",
        "The effective definition supplies the model identity, supported operation contract, provider/locality and managed-runtime policy, and input/output slot policy used for readiness, binding validation, execution, and result mapping.",
        "A matching declared inference worker remains the first-choice resolution and produces the same observable request, result, readiness, binding, output, and streaming behavior as before.",
        "A built-in request for an unsupported operation retains the typed unsupported-operation behavior, while missing, loading, failed, and unsupported readiness states retain their applicable actionable classifications.",
        "Focused runtime-opening tests and the pre-change-failing functional built-in invocation test pass; the test uses the canonical process/HTTP functional harness and injected command-runner edges rather than live network access, sleeps, or MockWorkers.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "models-name-invocations-cannot-invoke-discovered-builtins-002",
      "title": "Align named-route parity and client failures",
      "description": "As an API customer, I want both model invocation routes to agree on whether a discovered built-in can be resolved and to return honest client errors when it cannot so that integrations can choose either contract without receiving a false server-failure diagnosis.",
      "acceptanceCriteria": [
        "For the same effective built-in and equivalent operation input, functional coverage asserts that /models/invocations and /models/{model_name}/invocations both pass model resolution and attempt their documented invocation flows; asserted differences are limited to their published request/response shapes or execution contract.",
        "The PR body explicitly states contract reading (a), justifies the effective-definition fallback, documents the two routes' parity and intentional differences, and records that the new built-in named-route functional case failed before the change.",
        "An unknown model name or another caller-addressable named-route resolution failure returns an actionable typed 4xx response and never MODEL_INFERENCE_RUNTIME_FAILURE / INTERNAL_SERVER_ERROR caused by a catalog miss.",
        "Existing declared-worker success, unsupported-operation, readiness, generic-route, and OMNIVOICE_Q4_K_M smoke assertions remain green without relaxing their expectations.",
        "If public OpenAPI prose is clarified, the canonical authored contract continues to promise effective discovered-model invocation, make generate-api regenerates all derived outputs, and generated files are not edited by hand; otherwise no generated API artifact changes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Named fallback errors stay typed through Workers classification; functional route parity and unknown-name 404 coverage are green."
    }
  ]
}
