### PR TITLE
metrics-retention-never-reaps-its-coordination-markers

### DIFF
--- a/pkg/platform/metrics/runtime_metrics_coordination.go
+++ b/pkg/platform/metrics/runtime_metrics_coordination.go
@@ -97,7 +97,7 @@ func acquireRuntimeMetricsLock(
 	if err := prepareRuntimeMetricsCoordinationRoot(filepath.Dir(lockPath)); err != nil {
 		return nil, err
 	}
-	file, err := openRuntimeMetricsLockFile(lockPath)
+	file, err := openRuntimeMetricsLockFile(lockPath, true)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func acquireExistingRuntimeMetricsLock(path string) (io.Closer, error) {
 	if err != nil {
 		return nil, err
 	}
-	file, err := openExistingRuntimeMetricsLockFile(path)
+	file, err := openRuntimeMetricsLockFile(path, false)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func acquireRuntimeMetricsFile(
 	}
 }
 
-func openRuntimeMetricsLockFile(path string) (*os.File, error) {
+func openRuntimeMetricsLockFile(path string, create bool) (*os.File, error) {
 	if info, err := os.Lstat(path); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {
 			return nil, fmt.Errorf("runtime metrics coordination file %q is a symlink", path)
@@ -190,22 +190,11 @@ func openRuntimeMetricsLockFile(path string) (*os.File, error) {
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, fmt.Errorf("inspect runtime metrics coordination file %q: %w", path, err)
 	}
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
-	if err != nil {
-		return nil, fmt.Errorf("open runtime metrics coordination file %q: %w", path, err)
+	flags := os.O_RDWR
+	if create {
+		flags |= os.O_CREATE
 	}
-	return file, nil
-}
-
-func openExistingRuntimeMetricsLockFile(path string) (*os.File, error) {
-	info, err := os.Lstat(path)
-	if err != nil {
-		return nil, fmt.Errorf("inspect runtime metrics coordination file %q: %w", path, err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("runtime metrics coordination file %q is not a regular file", path)
-	}
-	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	file, err := os.OpenFile(path, flags, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open runtime metrics coordination file %q: %w", path, err)
 	}

--- a/pkg/platform/metrics/runtime_metrics_coordination.go
+++ b/pkg/platform/metrics/runtime_metrics_coordination.go
@@ -37,6 +37,7 @@ type RuntimeMetricsCoordination interface {
 	TryLockRoot(string) (io.Closer, error)
 	Claim(string) (io.Closer, error)
 	TryClaim(string) (io.Closer, error)
+	TryClaimMarker(string) (io.Closer, error)
 }
 
 type runtimeMetricsCoordination struct{}
@@ -80,6 +81,10 @@ func (runtimeMetricsCoordination) TryClaim(path string) (io.Closer, error) {
 	return acquireRuntimeMetricsLock(context.Background(), path, runtimeMetricsClaimPath(path), false, true)
 }
 
+func (runtimeMetricsCoordination) TryClaimMarker(path string) (io.Closer, error) {
+	return acquireExistingRuntimeMetricsLock(path)
+}
+
 func acquireRuntimeMetricsLock(
 	ctx context.Context,
 	resourcePath, lockPath string,
@@ -97,6 +102,18 @@ func acquireRuntimeMetricsLock(
 		return nil, err
 	}
 	return acquireRuntimeMetricsFile(ctx, file, lockPath, wait, artifactClaim)
+}
+
+func acquireExistingRuntimeMetricsLock(path string) (io.Closer, error) {
+	ctx, err := validateRuntimeMetricsCoordinationContext(context.Background(), path)
+	if err != nil {
+		return nil, err
+	}
+	file, err := openExistingRuntimeMetricsLockFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return acquireRuntimeMetricsFile(ctx, file, path, false, true)
 }
 
 func validateRuntimeMetricsCoordinationContext(
@@ -174,6 +191,21 @@ func openRuntimeMetricsLockFile(path string) (*os.File, error) {
 		return nil, fmt.Errorf("inspect runtime metrics coordination file %q: %w", path, err)
 	}
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open runtime metrics coordination file %q: %w", path, err)
+	}
+	return file, nil
+}
+
+func openExistingRuntimeMetricsLockFile(path string) (*os.File, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("inspect runtime metrics coordination file %q: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("runtime metrics coordination file %q is not a regular file", path)
+	}
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
 		return nil, fmt.Errorf("open runtime metrics coordination file %q: %w", path, err)
 	}

--- a/pkg/platform/metrics/runtime_metrics_retention.go
+++ b/pkg/platform/metrics/runtime_metrics_retention.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -42,8 +43,9 @@ type RuntimeMetricsRetentionTotals struct {
 	Bytes int64
 }
 
-// RuntimeMetricsRetentionFailure identifies one artifact that could not be
-// safely inspected or removed. The path is always beneath the selected root.
+// RuntimeMetricsRetentionFailure identifies one artifact or claim marker that
+// could not be safely inspected or removed. The path is always beneath the
+// selected root.
 type RuntimeMetricsRetentionFailure struct {
 	Path  string
 	Error error
@@ -52,7 +54,8 @@ type RuntimeMetricsRetentionFailure struct {
 // RuntimeMetricsRetentionReport describes one deterministic root sweep.
 // Before and After count recognized regular metrics artifacts only. Protected
 // and Failed count artifacts that were not safe to remove; unrecognized files
-// are deliberately absent from every total.
+// are deliberately absent from every total. Failures can also describe claim
+// marker cleanup without changing those artifact totals.
 type RuntimeMetricsRetentionReport struct {
 	RootDirectory string
 	Skipped       bool
@@ -161,7 +164,7 @@ func (retention *RuntimeMetricsRetention) sweepLocked(
 		return err
 	}
 	report.After = retentionTotals(after.artifacts)
-	return nil
+	return retention.reapOrphanedMarkers(ctx, preparation.root, after, report)
 }
 
 func (retention *RuntimeMetricsRetention) pruneAge(
@@ -230,16 +233,21 @@ type retentionOutcome struct {
 }
 
 type retentionInventory struct {
-	artifacts map[string]retentionArtifact
-	protected []retentionOutcome
-	failed    []retentionOutcome
+	artifacts  map[string]retentionArtifact
+	recognized map[string]struct{}
+	protected  []retentionOutcome
+	failed     []retentionOutcome
+	incomplete bool
 }
 
 func (retention *RuntimeMetricsRetention) inventory(
 	ctx context.Context,
 	root string,
 ) (retentionInventory, error) {
-	inventory := retentionInventory{artifacts: make(map[string]retentionArtifact)}
+	inventory := retentionInventory{
+		artifacts:  make(map[string]retentionArtifact),
+		recognized: make(map[string]struct{}),
+	}
 	err := retention.filesystem.WalkDir(root, func(
 		path string,
 		entry fs.DirEntry,
@@ -249,6 +257,7 @@ func (retention *RuntimeMetricsRetention) inventory(
 			return err
 		}
 		if walkErr != nil {
+			inventory.incomplete = true
 			if entry != nil && isRuntimeMetricsArtifact(entry.Name()) {
 				inventory.failed = append(inventory.failed, retentionOutcome{path: path, err: walkErr})
 			}
@@ -257,8 +266,10 @@ func (retention *RuntimeMetricsRetention) inventory(
 		if entry == nil || entry.IsDir() || !isRuntimeMetricsArtifact(entry.Name()) {
 			return nil
 		}
+		inventory.recognized[path] = struct{}{}
 		info, err := retention.filesystem.Lstat(path)
 		if err != nil {
+			inventory.incomplete = true
 			inventory.failed = append(inventory.failed, retentionOutcome{path: path, err: err})
 			return nil
 		}
@@ -283,6 +294,145 @@ func (retention *RuntimeMetricsRetention) inventory(
 		return inventory, fmt.Errorf("inventory runtime metrics under %q: %w", root, err)
 	}
 	return inventory, nil
+}
+
+func (retention *RuntimeMetricsRetention) reapOrphanedMarkers(
+	ctx context.Context,
+	root string,
+	inventory retentionInventory,
+	report *RuntimeMetricsRetentionReport,
+) error {
+	if inventory.incomplete {
+		appendRetentionFailure(
+			report,
+			filepath.Join(root, runtimeMetricsClaimsDirectory),
+			errors.New("runtime metrics artifact inventory is incomplete; claim marker cleanup skipped"),
+		)
+		return nil
+	}
+	claimsDirectory := filepath.Join(root, runtimeMetricsClaimsDirectory)
+	info, err := retention.filesystem.Lstat(claimsDirectory)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		appendRetentionFailure(report, claimsDirectory, fmt.Errorf("inspect claim marker directory: %w", err))
+		return nil
+	}
+	if info.Mode()&fs.ModeSymlink != 0 || !info.IsDir() {
+		appendRetentionFailure(report, claimsDirectory, errors.New("claim marker path is not a directory"))
+		return nil
+	}
+	entries, err := retention.filesystem.ReadDir(claimsDirectory)
+	if err != nil {
+		appendRetentionFailure(report, claimsDirectory, fmt.Errorf("read claim marker directory: %w", err))
+		return nil
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	markerNames := make(map[string]struct{}, len(inventory.recognized))
+	for artifactPath := range inventory.recognized {
+		markerNames[filepath.Base(runtimeMetricsClaimPath(artifactPath))] = struct{}{}
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("reap runtime metrics claim markers: %w", err)
+		}
+		if entry == nil {
+			appendRetentionFailure(report, claimsDirectory, errors.New("claim marker directory returned an empty entry"))
+			continue
+		}
+		markerPath, valid := runtimeMetricsClaimMarkerPath(claimsDirectory, entry.Name())
+		if !valid {
+			appendRetentionFailure(report, filepath.Join(claimsDirectory, entry.Name()), errors.New("unexpected claim marker entry"))
+			continue
+		}
+		if _, live := markerNames[entry.Name()]; live {
+			continue
+		}
+		if err := retention.reapOrphanedMarker(report, markerPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runtimeMetricsClaimMarkerPath(claimsDirectory, name string) (string, bool) {
+	if len(name) != sha256HexLength+len(runtimeMetricsClaimSuffix) ||
+		!strings.HasSuffix(name, runtimeMetricsClaimSuffix) {
+		return "", false
+	}
+	digest := strings.TrimSuffix(name, runtimeMetricsClaimSuffix)
+	if !isLowerHexDigest(digest) {
+		return "", false
+	}
+	path := filepath.Join(filepath.Clean(claimsDirectory), name)
+	if !pathWithinRoot(claimsDirectory, path) {
+		return "", false
+	}
+	return path, true
+}
+
+func isLowerHexDigest(value string) bool {
+	if len(value) != sha256HexLength {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	if err != nil {
+		return false
+	}
+	return value == strings.ToLower(value)
+}
+
+func (retention *RuntimeMetricsRetention) reapOrphanedMarker(
+	report *RuntimeMetricsRetentionReport,
+	markerPath string,
+) error {
+	info, err := retention.filesystem.Lstat(markerPath)
+	if err != nil {
+		appendRetentionFailure(report, markerPath, fmt.Errorf("inspect orphaned claim marker: %w", err))
+		return nil
+	}
+	if info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Size() != 0 {
+		appendRetentionFailure(report, markerPath, errors.New("claim marker is not a zero-byte regular file"))
+		return nil
+	}
+	claim, err := retention.coordination.TryClaimMarker(markerPath)
+	if errors.Is(err, ErrRuntimeMetricsArtifactBusy) {
+		return nil
+	}
+	if err != nil {
+		appendRetentionFailure(report, markerPath, fmt.Errorf("claim orphaned marker: %w", err))
+		return nil
+	}
+	if claim == nil {
+		appendRetentionFailure(report, markerPath, errors.New("claim orphaned marker returned a nil lock"))
+		return nil
+	}
+	closeErr := claim.Close()
+	if closeErr != nil {
+		appendRetentionFailure(report, markerPath, fmt.Errorf("release orphaned claim marker: %w", closeErr))
+		return nil
+	}
+	// The root lock prevents normal openers from acquiring this marker between
+	// the nonblocking proof above and removal. Release before Remove because
+	// Windows refuses to unlink an open coordination handle.
+	if err := retention.filesystem.Remove(markerPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		appendRetentionFailure(report, markerPath, fmt.Errorf("remove orphaned claim marker: %w", err))
+	}
+	return nil
+}
+
+const sha256HexLength = 64
+
+func appendRetentionFailure(
+	report *RuntimeMetricsRetentionReport,
+	path string,
+	err error,
+) {
+	report.Failures = append(report.Failures, RuntimeMetricsRetentionFailure{Path: path, Error: err})
 }
 
 func runtimeMetricsArtifactTimestamp(root, path string) (time.Time, string, bool) {

--- a/pkg/platform/metrics/runtime_metrics_retention_test.go
+++ b/pkg/platform/metrics/runtime_metrics_retention_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -192,7 +194,7 @@ func TestRuntimeMetricsRootRetentionYieldsWhenRootSweepIsAlreadyClaimed(t *testi
 	}
 }
 
-func TestRuntimeMetricsRootRetentionReclaimsReleasedStaleClaim(t *testing.T) {
+func TestRuntimeMetricsRootRetentionReclaimsReleasedStaleClaimAndMarker(t *testing.T) {
 	root := t.TempDir()
 	artifact := writeRetentionArtifact(t, root, "2026/07/01", "010000.000000000", "stale-claim-runtime-stale-collision", 9)
 	claimPath := runtimeMetricsClaimPath(artifact)
@@ -213,9 +215,200 @@ func TestRuntimeMetricsRootRetentionReclaimsReleasedStaleClaim(t *testing.T) {
 	if _, err := os.Stat(artifact); !os.IsNotExist(err) {
 		t.Fatalf("artifact protected by released stale claim, stat error = %v", err)
 	}
-	if _, err := os.Stat(claimPath); err != nil {
-		t.Fatalf("stable stale claim marker was not reusable, stat error = %v", err)
+	if _, err := os.Stat(claimPath); !os.IsNotExist(err) {
+		t.Fatalf("released stale claim marker remains after cleanup, stat error = %v", err)
 	}
+}
+
+func TestRuntimeMetricsRootRetentionPreservesLiveClaimMarkerAfterArtifactMissing(t *testing.T) {
+	root := t.TempDir()
+	artifact := writeRetentionArtifact(t, root, "2026/07/01", "010000.000000000", "live-missing-runtime-live-collision", 9)
+	coordination, err := NewRuntimeMetricsCoordination()
+	if err != nil {
+		t.Fatalf("NewRuntimeMetricsCoordination(): %v", err)
+	}
+	claim, err := coordination.Claim(artifact)
+	if err != nil {
+		t.Fatalf("Claim(): %v", err)
+	}
+	claimPath := runtimeMetricsClaimPath(artifact)
+	if err := os.Remove(artifact); err != nil {
+		t.Fatalf("Remove(artifact): %v", err)
+	}
+
+	retention := newTestRuntimeMetricsRetention(t, time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC))
+	if _, err := retention.Sweep(t.Context(), RuntimeMetricsRetentionRequest{
+		RootDirectory: root,
+		Config:        RuntimeMetricsConfig{MaxSize: 1, MaxAge: 1},
+	}); err != nil {
+		t.Fatalf("Sweep(live missing artifact): %v", err)
+	}
+	assertRetentionPathExists(t, claimPath, "live claim marker after missing-artifact sweep")
+
+	if err := claim.Close(); err != nil {
+		t.Fatalf("Close(live claim): %v", err)
+	}
+	if _, err := retention.Sweep(t.Context(), RuntimeMetricsRetentionRequest{
+		RootDirectory: root,
+		Config:        RuntimeMetricsConfig{MaxSize: 1, MaxAge: 1},
+	}); err != nil {
+		t.Fatalf("Sweep(released missing artifact): %v", err)
+	}
+	assertRetentionPathAbsent(t, claimPath, "released claim marker after missing-artifact sweep")
+}
+
+func TestRuntimeMetricsRootRetentionBoundsClaimMarkersAcrossEightCycles(t *testing.T) {
+	root := t.TempDir()
+	coordination, err := NewRuntimeMetricsCoordination()
+	if err != nil {
+		t.Fatalf("NewRuntimeMetricsCoordination(): %v", err)
+	}
+	retention := newTestRuntimeMetricsRetention(t, time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC))
+	for cycle := 0; cycle < 8; cycle++ {
+		artifact := writeRetentionArtifact(
+			t, root, "2026/07/01", fmt.Sprintf("%06d.000000000", cycle+1),
+			fmt.Sprintf("session-%d-runtime-cycle-collision", cycle), 9,
+		)
+		claim, err := coordination.Claim(artifact)
+		if err != nil {
+			t.Fatalf("Claim(cycle %d): %v", cycle+1, err)
+		}
+		if err := claim.Close(); err != nil {
+			t.Fatalf("Close(cycle %d): %v", cycle+1, err)
+		}
+		report, err := retention.Sweep(t.Context(), RuntimeMetricsRetentionRequest{
+			RootDirectory: root,
+			Config:        RuntimeMetricsConfig{MaxSize: 1, MaxAge: 1},
+		})
+		if err != nil {
+			t.Fatalf("Sweep(cycle %d): %v", cycle+1, err)
+		}
+		if report.Removed.Files != 1 || report.After.Files != 0 {
+			t.Fatalf("cycle %d report = %#v, want one removed artifact and no remaining artifacts", cycle+1, report)
+		}
+		if got := countRuntimeMetricsClaimMarkers(t, root); got != 0 {
+			t.Fatalf("cycle %d claim marker count = %d, want zero", cycle+1, got)
+		}
+	}
+}
+
+func TestRuntimeMetricsRootRetentionPreservesMalformedClaimEntries(t *testing.T) {
+	root := t.TempDir()
+	artifact := writeRetentionArtifact(t, root, "2026/07/01", "010000.000000000", "malformed-runtime-malformed-collision", 9)
+	coordination, err := NewRuntimeMetricsCoordination()
+	if err != nil {
+		t.Fatalf("NewRuntimeMetricsCoordination(): %v", err)
+	}
+	claim, err := coordination.Claim(artifact)
+	if err != nil {
+		t.Fatalf("Claim(): %v", err)
+	}
+	if err := claim.Close(); err != nil {
+		t.Fatalf("Close(): %v", err)
+	}
+	claimsDirectory := filepath.Join(root, runtimeMetricsClaimsDirectory)
+	malformed := filepath.Join(claimsDirectory, strings.Repeat("a", sha256HexLength)+runtimeMetricsClaimSuffix)
+	if err := os.WriteFile(malformed, []byte("not empty"), 0o600); err != nil {
+		t.Fatalf("WriteFile(malformed): %v", err)
+	}
+	unexpected := filepath.Join(claimsDirectory, "operator-note.txt")
+	if err := os.WriteFile(unexpected, []byte("preserve"), 0o600); err != nil {
+		t.Fatalf("WriteFile(unexpected): %v", err)
+	}
+
+	retention := newTestRuntimeMetricsRetention(t, time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC))
+	report, err := retention.Sweep(t.Context(), RuntimeMetricsRetentionRequest{
+		RootDirectory: root,
+		Config:        RuntimeMetricsConfig{MaxSize: 1, MaxAge: 1},
+	})
+	if err != nil {
+		t.Fatalf("Sweep(): %v", err)
+	}
+	if len(report.Failures) != 2 {
+		t.Fatalf("Failures = %#v, want malformed and unexpected claim entries", report.Failures)
+	}
+	assertRetentionPathAbsent(t, runtimeMetricsClaimPath(artifact), "well-formed orphan claim marker")
+	assertRetentionPathExists(t, malformed, "malformed claim marker")
+	assertRetentionPathExists(t, unexpected, "unexpected claim entry")
+}
+
+func TestRuntimeMetricsRootRetentionRetriesFailedClaimMarkerRemoval(t *testing.T) {
+	root := t.TempDir()
+	artifact := writeRetentionArtifact(t, root, "2026/07/01", "010000.000000000", "retry-marker-runtime-retry-collision", 9)
+	coordination, err := NewRuntimeMetricsCoordination()
+	if err != nil {
+		t.Fatalf("NewRuntimeMetricsCoordination(): %v", err)
+	}
+	claim, err := coordination.Claim(artifact)
+	if err != nil {
+		t.Fatalf("Claim(): %v", err)
+	}
+	if err := claim.Close(); err != nil {
+		t.Fatalf("Close(): %v", err)
+	}
+	claimPath := runtimeMetricsClaimPath(artifact)
+	filesystem := &failRuntimeMetricsClaimMarkerRemoveFileSystem{
+		Local:    platformfilesystem.Local{},
+		failPath: claimPath,
+	}
+	retention, err := NewRuntimeMetricsRetention(
+		filesystem,
+		func() time.Time { return time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC) },
+		coordination,
+	)
+	if err != nil {
+		t.Fatalf("NewRuntimeMetricsRetention(): %v", err)
+	}
+	report, err := retention.Sweep(t.Context(), RuntimeMetricsRetentionRequest{
+		RootDirectory: root,
+		Config:        RuntimeMetricsConfig{MaxSize: 1, MaxAge: 1},
+	})
+	if err != nil {
+		t.Fatalf("Sweep(first): %v", err)
+	}
+	if len(report.Failures) != 1 {
+		t.Fatalf("first sweep failures = %#v, want marker removal failure", report.Failures)
+	}
+	assertRetentionPathExists(t, claimPath, "claim marker after failed removal")
+
+	filesystem.failPath = ""
+	if _, err := retention.Sweep(t.Context(), RuntimeMetricsRetentionRequest{
+		RootDirectory: root,
+		Config:        RuntimeMetricsConfig{MaxSize: 1, MaxAge: 1},
+	}); err != nil {
+		t.Fatalf("Sweep(retry): %v", err)
+	}
+	assertRetentionPathAbsent(t, claimPath, "claim marker after successful retry")
+}
+
+func countRuntimeMetricsClaimMarkers(t *testing.T, root string) int {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(root, runtimeMetricsClaimsDirectory))
+	if errors.Is(err, os.ErrNotExist) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("ReadDir(claim markers): %v", err)
+	}
+	count := 0
+	for _, entry := range entries {
+		if _, valid := runtimeMetricsClaimMarkerPath(filepath.Join(root, runtimeMetricsClaimsDirectory), entry.Name()); valid {
+			count++
+		}
+	}
+	return count
+}
+
+type failRuntimeMetricsClaimMarkerRemoveFileSystem struct {
+	platformfilesystem.Local
+	failPath string
+}
+
+func (filesystem *failRuntimeMetricsClaimMarkerRemoveFileSystem) Remove(path string) error {
+	if path == filesystem.failPath {
+		return errors.New("claim marker removal failed")
+	}
+	return filesystem.Local.Remove(path)
 }
 
 func TestRuntimeMetricsCoordinationClaimClosePreservesConcurrentReplacement(t *testing.T) {


### PR DESCRIPTION
{
  "project": "Bound Runtime Metrics Coordination Marker Growth",
  "branchName": "metrics-retention-never-reaps-its-coordination-markers",
  "description": "Make runtime metrics retention remove orphaned hashed .active coordination markers after artifact pruning so repeated Factory Sessions do not grow the metrics tree without bound in file count, while preserving every marker held by a live cross-process claim and leaving byte-based retention and metric emission unchanged.",
  "context": {
    "customerAsk": "Stop runtime metrics coordination markers from accumulating forever. Remove markers whose artifacts have been pruned, prove a marker held by a live cross-process claim is never reaped, and report reproducible before/after marker counts from at least eight sessions while preserving the working byte-retention behavior.",
    "problem": "Every runtime metrics artifact creates one zero-byte marker named sha256(clean artifact path).active under .runtime-metrics-retention-claims. Claim close releases the operating-system lock but keeps the marker for safe handoff, while Sweep inventories only .log and .log.gz artifacts and therefore never removes any marker. An operator measured eight surviving markers after eight sessions, and the affected metrics tree previously reached 24,371 files and 1.05 GB; bytes are now bounded but marker file count is not.",
    "solution": "Use sweep-based orphan cleanup rather than release-time deletion. While Sweep holds the root coordination lock, finish age and size pruning, build the set of marker digests for artifacts still present, then inspect the claims directory. Remove only well-formed orphan markers whose operating-system lock can be acquired nonblockingly; preserve live, uncertain, malformed, or unsafe candidates and surface cleanup failures. Keep ordinary close's stable marker handoff, artifact retention policy and totals, metric emission, and isRuntimeMetricsArtifact unchanged.",
    "regressionProbe": {
      "sessions": 8,
      "beforeChangeMarkerCountsAfterEachCycle": [1, 2, 3, 4, 5, 6, 7, 8],
      "beforeChangeFinalMarkerCount": 8,
      "correctedMarkerCountsAfterEachCycle": [0, 0, 0, 0, 0, 0, 0, 0],
      "correctedFinalMarkerCount": 0,
      "result": "The eight-cycle regression assertion failed on the unchanged base because every pruned artifact left its marker; the same probe passes after post-prune orphan cleanup."
    }
  },
  "acceptanceCriteria": [
    "After a sweep prunes a runtime metrics artifact, no unheld .active marker for that artifact remains; cleanup runs after artifact pruning and applies only to orphan markers in .runtime-metrics-retention-claims.",
    "A marker whose operating-system claim is held by a live process is not removed, even when its artifact is absent, and it remains usable until release; incomplete inventory, lock contention, unexpected entries, symlinks, and inspection failures fail safe by preserving the marker.",
    "A reproducible before/after probe runs at least eight session and retention cycles against unchanged and corrected behavior. The PR body reports the session count and exact marker counts, states plainly that the regression assertion failed before the change, and demonstrates that marker count does not grow with artifacts already deleted by retention.",
    "Runtime metrics artifact retention remains policy compatible: MaxAge, MaxSize, MaxBackups, compression, artifact recognition, report artifact totals, and metric emission are unchanged; .active is not added to isRuntimeMetricsArtifact, pkg/services/factory_runtime is untouched, and existing retention tests pass.",
    "Quality gate: Typecheck passes; Tests pass; go test ./pkg/platform/metrics/... passes at the final head; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Backend Lint and Verification Policy are the only required CI checks for this lane; localai-backend-artifacts is not required and is not changed.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "metrics-retention-never-reaps-its-coordination-markers-001",
      "title": "Reap orphaned markers without releasing live claims",
      "description": "As an operator running many Factory Sessions, I want retention to remove coordination markers only after their artifacts are gone and their claims are not live so file count stays bounded without exposing active metrics writers to concurrent deletion.",
      "acceptanceCriteria": [
        "A package-level regression scenario creates and prunes artifacts across N >= 8 retention cycles and asserts that no marker survives for an artifact deleted by retention and that marker count does not grow monotonically with N; the same assertion is recorded as failing before the production change.",
        "Marker reaping occurs after both age and aggregate-size pruning while the sweep owns the root coordination lock, and its live digest set reflects the final artifact state rather than the pre-prune inventory.",
        "Each orphan candidate is removed only after a nonblocking operating-system lock proves no live owner holds that marker; a marker held by a live claim is preserved even if the corresponding artifact is absent.",
        "Failed or incomplete artifact inventory, a busy claim, an unexpected claim-directory entry, a symlink, or a marker inspection or removal failure cannot cause a possibly live marker to be deleted; actionable failures remain observable and retryable on a later sweep.",
        "Ordinary claim close retains the stable marker-path handoff behavior, and the PR body explains why release-time unlinking was rejected in favor of post-prune, root-locked orphan cleanup.",
        "Existing MaxAge, MaxSize, MaxBackups, compression, artifact totals, and active-writer protection behavior remain unchanged, and .active does not become a runtime metrics artifact.",
        "The PR body reports exact marker counts before and after the correction for the same probe with at least eight sessions and states plainly that the regression proof failed before the change.",
        "Changes remain inside pkg/platform/metrics; no metric emission path, pkg/services/factory_runtime surface, model surface, run-cancellation teardown, generated contract, or unrelated cleanup is changed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Ready for review at final head 6743e4c96d166126069f5b66d7b828d3056c6f44. PR #2253 is open with CI run 32671577572 started; no blocking review conversation exists. Focused metrics tests, consumer package tests, typecheck, make test, vet, backend-size, pkg-maint, pkg-file-count, pkg-boundary, and pkg-structure pass. make lint reports only the pre-existing packaged-factory-consumption-check violation in internal/migrationledgercheck/packaged_factory_matrix.go, outside this diff; all changed-target lint checks pass."
    }
  ]
}
