### PR TITLE
fix(sessions): join durable terminal persistence

### DIFF
--- a/pkg/services/factory_sessions/internal/execution/control.go
+++ b/pkg/services/factory_sessions/internal/execution/control.go
@@ -440,7 +440,15 @@ func (s *JavaScriptRuntimeService) applyRuntimeExtendedLifecycleControl(
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	var runDone <-chan struct{}
+	defer func() {
+		// The terminal finalizer needs this lock before it can finish its
+		// durable write, so release it before joining the run.
+		s.mu.Unlock()
+		if runDone != nil {
+			<-runDone
+		}
+	}()
 
 	state, ok := s.sessions[id]
 	if !ok {
@@ -492,10 +500,14 @@ func (s *JavaScriptRuntimeService) applyRuntimeExtendedLifecycleControl(
 		previousStatus := state.session.Status
 		if operation == LifecycleControlInterruptDispatch {
 			s.recordAcceptedRuntimeInterrupt(state, dispatchSummary, interrupt)
+			runDone = state.runDone
 		} else {
 			interruptRuntime := applyRuntimeAcceptedLifecycleControl(s, state, operation, retry, interrupt)
-			if interruptRuntime && state.runCancel != nil {
-				state.runCancel()
+			if interruptRuntime {
+				if state.runCancel != nil {
+					state.runCancel()
+				}
+				runDone = state.runDone
 			}
 			if operation == LifecycleControlPause || operation == LifecycleControlResume {
 				state.events = appendAcceptedSessionLifecycleEventIfNeeded(

--- a/pkg/services/factory_sessions/internal/execution/idempotency.go
+++ b/pkg/services/factory_sessions/internal/execution/idempotency.go
@@ -434,11 +434,13 @@ func (s *JavaScriptRuntimeService) startWaitingSyncSession(
 		startedAt,
 	)
 	runCtx, runCancel := workflowRunContext(context.Background(), policyResolution.Policy)
+	runDone := make(chan struct{})
 	s.mu.Lock()
 	reserved.state.session = running.session
 	reserved.state.result = running.result
 	reserved.state.events = running.events
 	reserved.state.runCancel = runCancel
+	reserved.state.runDone = runDone
 	reserved.state.startRequest = cloneStartRequest(normalized)
 	reserved.state.resolvedSource = resolved
 	reserved.state.sourceContent = sourceContent
@@ -452,6 +454,7 @@ func (s *JavaScriptRuntimeService) startWaitingSyncSession(
 		sourceContent,
 		policyResolution,
 		startedAt,
+		runDone,
 	)
 
 	result, err := s.waitSyncCompletion(

--- a/pkg/services/factory_sessions/internal/execution/javascript_runtime_persistence_test.go
+++ b/pkg/services/factory_sessions/internal/execution/javascript_runtime_persistence_test.go
@@ -439,6 +439,95 @@ func assertPersistenceFailureClearedInternalRuntimeState(t *testing.T, service *
 	}
 }
 
+func TestJavaScriptRuntimeService_TerminateWaitsForTerminalPersistence(t *testing.T) {
+	store := newBlockingRuntimePersistenceStore()
+	t.Cleanup(store.release)
+	service := newConfiguredJavaScriptRuntimeService(javaScriptRuntimeServiceConfig{
+		ProjectRoot: t.TempDir(),
+		Persistence: store,
+		Workflows:   scriptedBlockingRuntimeWorkflows(),
+	})
+
+	started, err := service.StartAsync(context.Background(), inlineWorkflowStartRequest(
+		"req-runtime-terminate-persist-barrier-001",
+		busyLoopWorkflowSource,
+		nil,
+		nil,
+	))
+	if err != nil {
+		t.Fatalf("StartAsync: %v", err)
+	}
+
+	controlDone := make(chan struct{})
+	var controlResult LifecycleControlResult
+	var controlErr error
+	go func() {
+		controlResult, controlErr = service.Terminate(context.Background(), started.SessionID, ControlRequest{})
+		close(controlDone)
+	}()
+
+	select {
+	case <-store.saveStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("terminal persistence did not start")
+	}
+	select {
+	case <-controlDone:
+		t.Fatal("Terminate returned before terminal persistence completed")
+	default:
+	}
+
+	store.release()
+	select {
+	case <-controlDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Terminate did not return after terminal persistence completed")
+	}
+	if controlErr != nil {
+		t.Fatalf("Terminate: %v", controlErr)
+	}
+	if controlResult.Outcome != LifecycleControlOutcomeAccepted || controlResult.Status != LifecycleStatusTerminated {
+		t.Fatalf("Terminate result = %#v, want accepted TERMINATED control", controlResult)
+	}
+	select {
+	case <-store.saveCompleted:
+	default:
+		t.Fatal("Terminate returned before the persistence writer completed")
+	}
+}
+
+type blockingRuntimePersistenceStore struct {
+	saveStarted    chan struct{}
+	releaseSave    chan struct{}
+	saveCompleted  chan struct{}
+	releaseOnce    sync.Once
+	saveStartOnce  sync.Once
+	saveFinishOnce sync.Once
+}
+
+func newBlockingRuntimePersistenceStore() *blockingRuntimePersistenceStore {
+	return &blockingRuntimePersistenceStore{
+		saveStarted:   make(chan struct{}),
+		releaseSave:   make(chan struct{}),
+		saveCompleted: make(chan struct{}),
+	}
+}
+
+func (s *blockingRuntimePersistenceStore) Save(string, []byte) error {
+	s.saveStartOnce.Do(func() { close(s.saveStarted) })
+	<-s.releaseSave
+	s.saveFinishOnce.Do(func() { close(s.saveCompleted) })
+	return nil
+}
+
+func (s *blockingRuntimePersistenceStore) Load(string) ([]byte, error) {
+	return nil, os.ErrNotExist
+}
+
+func (s *blockingRuntimePersistenceStore) release() {
+	s.releaseOnce.Do(func() { close(s.releaseSave) })
+}
+
 type runtimeRecordingStore struct {
 	mu        sync.Mutex
 	saveCalls int

--- a/pkg/services/factory_sessions/internal/execution/resume.go
+++ b/pkg/services/factory_sessions/internal/execution/resume.go
@@ -59,11 +59,14 @@ func (s *JavaScriptRuntimeService) ResumeInterruptedSession(
 	state.session.Lifecycle.ResumedAt = &resumingAt
 	resumed := cloneRuntimeSessionState(&state)
 	resumed.events = rebuildRuntimeSessionCanonicalEvents(&resumed)
+	resumed.runDone = make(chan struct{})
 	s.sessions[id] = &resumed
 	s.mu.Unlock()
 	if err := s.ensureSessionResponseEventsIfNeeded(&resumed); err != nil {
 		s.mu.Lock()
 		if active, ok := s.sessions[id]; ok && active == &resumed {
+			active.runCancel = nil
+			close(resumed.runDone)
 			delete(s.sessions, id)
 		}
 		s.mu.Unlock()
@@ -83,6 +86,7 @@ func (s *JavaScriptRuntimeService) ResumeInterruptedSession(
 	if active, ok := s.sessions[id]; ok {
 		active.runCancel = runCancel
 	}
+	runDone := resumed.runDone
 	s.mu.Unlock()
 
 	go s.runResumedAsyncSession(
@@ -95,6 +99,7 @@ func (s *JavaScriptRuntimeService) ResumeInterruptedSession(
 		state.checkpointSummary,
 		state.runtimeRecords,
 		resumingAt,
+		runDone,
 	)
 
 	snapshot, err := s.snapshotSessionState(id)
@@ -353,12 +358,14 @@ func (s *JavaScriptRuntimeService) runResumedAsyncSession(
 	checkpointSummary *workflowresult.JavaScriptCheckpointSummary,
 	priorRecords []workflowresult.JavaScriptRuntimeRecord,
 	startedAt time.Time,
+	runDone chan struct{},
 ) {
 	defer func() {
 		s.mu.Lock()
 		if state, ok := s.sessions[sessionID]; ok {
 			state.runCancel = nil
 		}
+		close(runDone)
 		s.mu.Unlock()
 	}()
 

--- a/pkg/services/factory_sessions/internal/execution/runtime_service.go
+++ b/pkg/services/factory_sessions/internal/execution/runtime_service.go
@@ -48,6 +48,7 @@ type runtimeSessionState struct {
 	sourceContent             string
 	events                    []json.RawMessage
 	runCancel                 context.CancelFunc
+	runDone                   chan struct{} // closed under mu after the async run and terminal persistence return
 	eventConsumer             FactoryEventConsumer
 	presentedEventIDs         map[string]struct{}
 	responseEvents            *responseeventstore.SessionResponseEventStore
@@ -422,22 +423,28 @@ func (s *JavaScriptRuntimeService) StartAsync(ctx context.Context, req StartRequ
 		startedAt,
 	)
 	runCtx, runCancel := workflowRunContext(context.Background(), policyResolution.Policy)
+	runDone := make(chan struct{})
 	s.mu.Lock()
 	reserved.state.session = running.session
 	reserved.state.result = running.result
 	reserved.state.events = running.events
 	reserved.state.runCancel = runCancel
+	reserved.state.runDone = runDone
 	reserved.state.startRequest = cloneStartRequest(normalized)
 	reserved.state.resolvedSource = resolved
 	reserved.state.sourceContent = sourceContent
 	s.mu.Unlock()
 	if err := s.ensureSessionResponseEventsIfNeeded(reserved.state); err != nil {
+		s.mu.Lock()
+		reserved.state.runCancel = nil
+		close(runDone)
+		s.mu.Unlock()
 		return AsyncStartResult{}, err
 	}
 	s.mu.RLock()
 	startState := cloneRuntimeSessionState(reserved.state)
 	s.mu.RUnlock()
-	go s.runAsyncSession(runCtx, reserved.state.session.SessionID, normalized, resolved, sourceContent, policyResolution, startedAt)
+	go s.runAsyncSession(runCtx, reserved.state.session.SessionID, normalized, resolved, sourceContent, policyResolution, startedAt, runDone)
 
 	result := s.asyncStartFromState(startState)
 	s.recordAsyncStartReplay(normalized.RequestID, result)
@@ -732,12 +739,14 @@ func (s *JavaScriptRuntimeService) runAsyncSession(
 	sourceContent string,
 	policyResolution factory.JavaScriptPolicyResolution,
 	startedAt time.Time,
+	runDone chan struct{},
 ) {
 	defer func() {
 		s.mu.Lock()
 		if state, ok := s.sessions[sessionID]; ok {
 			state.runCancel = nil
 		}
+		close(runDone)
 		s.mu.Unlock()
 	}()
 
@@ -903,6 +912,7 @@ func cloneRuntimeSessionState(state *runtimeSessionState) runtimeSessionState {
 		startRequest:              cloneStartRequestPtr(state.startRequest),
 		resolvedSource:            state.resolvedSource,
 		sourceContent:             state.sourceContent,
+		runDone:                   state.runDone,
 		responseEvents:            state.responseEvents,
 	}
 	if len(state.events) > 0 {

--- a/pkg/services/factory_sessions/internal/execution/runtime_service.go
+++ b/pkg/services/factory_sessions/internal/execution/runtime_service.go
@@ -53,7 +53,6 @@ type runtimeSessionState struct {
 	presentedEventIDs         map[string]struct{}
 	responseEvents            *responseeventstore.SessionResponseEventStore
 }
-
 type startInflightFlight struct {
 	done chan struct{}
 }


### PR DESCRIPTION
{
  "project": "Stop Run-Cancellation Writers Before Test Teardown",
  "branchName": "run-cancellation-leaks-a-writer-past-test-teardown",
  "description": "Restore main by identifying the component that continues writing beneath the Factory directory after local or remote run cancellation, correcting the proven lifecycle or test completion boundary without weakening TempDir cleanup or PR #2247's complete-metric-set behavior, and proving 0 failures across 50 final-head repetitions.",
  "context": {
    "customerAsk": "Decisively bisect the TempDir cleanup failure across b89a119bb, ca2943b66, and 0e7db8e44; identify the precise component writing after run cancellation; fix the correct lifecycle or test synchronization boundary without sleeps, quarantine, cleanup workarounds, or reverting PR #2247; and provide repeat-run and focused-suite evidence that shutdown is complete before teardown.",
    "problem": "At 0e7db8e44, TestCLILocalAndRemoteRunCancellationParityThroughRootProcess returns before a component has stopped creating or writing content below .you-agent-factory/factories. Go's deferred t.TempDir cleanup races with that writer and fails with directory not empty. PR #2247 changed shutdown ordering and is the prime suspect, but its merge-only run was cancelled, so neither it nor the Costs-only PR #2248 can be blamed without the prescribed bisection and exact writer trace.",
    "solution": "Run the target test 20 times at each prescribed commit in isolated worktrees, identify the exact writer and escaped completion signal, and correct the smallest proven owner. Production cancellation must not return while a runtime-owned writer can touch the Factory directory; a test-only wait is allowed only if production shutdown is proven complete and a legitimate bounded flush exposes a real completion signal. Preserve complete metrics, keep t.TempDir authoritative, add deterministic regression coverage for production ordering changes, and verify 50 clean repetitions plus focused suites."
  },
  "reviewEvidence": {
    "rawBisectionCommand": "go test ./tests/functional/sessions/lifecycle/ -run TestCLILocalAndRemoteRunCancellationParityThroughRootProcess -count=20",
    "rawBisectionTableMarkdown": "| Commit | Failures out of 20 | Raw output |\n| --- | ---: | --- |\n| `b89a119bb` | `0/20` | `ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 569.842s` |\n| `ca2943b66` | `0/20` | `ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 281.731s` |\n| `0e7db8e44` | `0/20` | `ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 282.980s` |",
    "rawBisectionOutput": [
      "$ go test ./tests/functional/sessions/lifecycle/ -run TestCLILocalAndRemoteRunCancellationParityThroughRootProcess -count=20 # b89a119bb\nok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 569.842s",
      "$ go test ./tests/functional/sessions/lifecycle/ -run TestCLILocalAndRemoteRunCancellationParityThroughRootProcess -count=20 # ca2943b66\n ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 281.731s",
      "$ go test ./tests/functional/sessions/lifecycle/ -run TestCLILocalAndRemoteRunCancellationParityThroughRootProcess -count=20 # 0e7db8e44\n ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 282.980s"
    ],
    "preFixRegressionResult": "No failure occurred in the prescribed 20-run samples, including b89a119bb; this is reported as a measured pre-existing sampled race that was not reproduced, not reclassified as a clean historical guarantee.",
    "writerAndOrdering": "The exact writer is the remote service-mode JavaScript durable session's asynchronous runAsyncSession/runResumedAsyncSession terminal finalizer. Its recordCanonicalTerminalState calls persistTerminalSessionState, whose runtimepersist DirectoryStore.Save writes .you-agent-factory/durable-sessions/<session>.json below the Factory directory. Previously cancellation marked the session terminal and called runCancel, then returned while the detached goroutine could still persist and present terminal state. Each active run now owns runDone; terminal persistence and event presentation finish before runDone closes, and Cancel, Terminate, and dispatch interruption unlock the service mutex before joining it.",
    "rawFinal50Output": "$ go test ./tests/functional/sessions/lifecycle/ -run TestCLILocalAndRemoteRunCancellationParityThroughRootProcess -count=50\nok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 446.919s\nFAILURES=0",
    "rawFocusedSuiteOutput": "$ go test ./tests/functional/sessions/lifecycle/... ./pkg/services/factory_runtime/...\nok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 44.436s\nok github.com/portpowered/infinite-you/pkg/services/factory_runtime 0.428s\nok github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/host 1.070s\nok github.com/portpowered/infinite-you/pkg/services/factory_runtime/wire 0.092s"
  },
  "acceptanceCriteria": [
    "The PR body contains a raw bisection table with failures out of 20 for b89a119bb, ca2943b66, and 0e7db8e44, produced by the exact target-test command at each commit; attribution states the measured result even if the race also reproduces at the last known green commit.",
    "The PR body names the exact component that retained or performed writes beneath .you-agent-factory/factories, the completion signal it previously escaped, and the exact ordering change that prevents writes after cancellation/shutdown returns; added a wait is not sufficient.",
    "After the correction, go test ./tests/functional/sessions/lifecycle/ -run TestCLILocalAndRemoteRunCancellationParityThroughRootProcess -count=50 reports 0 failures, with raw output quoted in the PR body, while t.TempDir remains enabled and no sleep, skip, quarantine, swallowed cleanup error, or manually managed replacement directory is introduced.",
    "If production shutdown behavior changes, a deterministic regression test fails without the correction and proves shutdown cannot return while the implicated writer can still touch the Factory directory; PR #2247's complete-metric-set behavior remains covered and correct.",
    "Scope stays with tests/functional/sessions/lifecycle/remote_lifecycle_test.go and, when the measured writer trace implicates production shutdown, the proven owner under pkg/services/factory_sessions/internal/execution (including its control, resume, persistence, and runtime-service files); pkg/services/factory_runtime/internal/host/lifecycle.go and bundle.go are in scope only if the trace implicates those owners. PR #2247 is not reverted, Costs is untouched unless the bisection implicates PR #2248, and model invoke/pull contract surfaces are untouched.",
    "Quality gates pass: Typecheck passes; go test ./tests/functional/sessions/lifecycle/... ./pkg/services/factory_runtime/... passes; Tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Required PR checks are Backend Lint and Verification Policy; the known always-failing localai-backend-artifacts check is not a lane blocker.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "run-cancellation-leaks-a-writer-past-test-teardown-001",
      "title": "Attribute the surviving writer",
      "description": "As a runtime maintainer, I want measured commit-level attribution and an exact writer trace so that the correction targets the real lifecycle defect rather than a suspected merge.",
      "acceptanceCriteria": [
        "In separate clean worktrees, run go test ./tests/functional/sessions/lifecycle/ -run TestCLILocalAndRemoteRunCancellationParityThroughRootProcess -count=20 at b89a119bb, ca2943b66, and 0e7db8e44.",
        "Record raw output and a failures-out-of-20 table for all three commits in the PR body; a failure at b89a119bb is reported plainly as evidence of a pre-existing sampled race rather than hidden or reclassified.",
        "Read and account for commit ba0856225 so the investigation distinguishes the already-added lifecycle-server close from the still-missing completion boundary.",
        "Identify the exact component performing or retaining the ability to perform writes below .you-agent-factory/factories, and identify the lifecycle transition or completion signal that currently allows the test body to return first.",
        "Do not change production code until the bisection and writer trace justify its owning layer; do not infer that PR #2247 or #2248 caused the failure from merge order alone.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Completed the exact target command in separate clean worktrees at all three prescribed commits. Raw results: b89a119bb => ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 569.842s (0/20 failures); ca2943b66 => ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 281.731s (0/20 failures); 0e7db8e44 => ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 282.980s (0/20 failures). The bisection therefore does not attribute the sampled race to PR #2247 or PR #2248. ba0856225 was read: it added the lifecycle server Stop/Close defer but does not join the durable execution worker. The exact surviving writer is the remote service-mode JavaScript durable session's asynchronous runAsyncSession finalizer: recordCanonicalTerminalState calls persistTerminalSessionState, whose runtimepersist DirectoryStore.Save writes <serverFactoryDir>/.you-agent-factory/durable-sessions/<session>.json beneath the Factory directory. StartAsync launches runAsyncSession with go; Terminate marks the session terminal and invokes runCancel, then returns the HTTP control acknowledgement without waiting for that goroutine's persistence/publication boundary. ProcessCommand.Stop and the Factory Runtime host RunDone signal consequently cover the CLI/runtime lifecycle but not this detached durable-session finalizer. Local standalone execution selects disabled persistence, while the remote service path explicitly selects enabled persistence. No production code was changed before this attribution was established; typecheck and the exact target tests passed in all three cells."
    },
    {
      "id": "run-cancellation-leaks-a-writer-past-test-teardown-002",
      "title": "Make cancellation wait for the real completion boundary",
      "description": "As an operator, I want a cancelled Factory run to be fully stopped when cancellation returns so no runtime writer can mutate my Factory directory afterward.",
      "acceptanceCriteria": [
        "The correction targets the layer proven by story 001: production lifecycle ordering when cancellation returns before the writer stops, or the functional test's real asynchronous completion signal only when production shutdown is proven complete.",
        "After cancellation/shutdown reports completion, the identified component cannot create, recreate, or modify content beneath the Factory directory.",
        "The PR body names the component, the old ordering, and the corrected happens-before relationship, including why the chosen completion signal covers the final write.",
        "No time.Sleep, blind polling delay, t.Skip, flake quarantine, cleanup-error suppression, manual temp-directory replacement, or disabling/workaround of t.TempDir is introduced.",
        "PR #2247 is not reverted, and its requirement that complete metric sets finish before shutdown remains intact; the fix reconciles writer completion with that guarantee.",
        "If production shutdown changes, a deterministic package-level regression test blocks the writer at a controlled point and proves shutdown does not return until the writer is released and complete; the test does not depend on timing luck.",
        "Changes remain inside the owned lifecycle test and, because the writer trace transfers ownership to the durable execution service, pkg/services/factory_sessions/internal/execution; host lifecycle/bundle files remain untouched unless a future trace implicates them. Costs and concurrent models invoke/pull surfaces remain unchanged unless the measured bisection explicitly transfers ownership.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added a per-session runDone completion channel to the JavaScript durable execution owner, covering async starts, sync-wait starts, and resumed sessions. Terminate, Cancel, and dispatch interruption release the session mutex before joining that channel; the channel closes only after runAsyncSession/runResumedAsyncSession finish terminal persistence and event presentation, so the control acknowledgement happens after the final DirectoryStore.Save. Added TestJavaScriptRuntimeService_TerminateWaitsForTerminalPersistence with a channel-gated persistence store. Verified go test ./pkg/services/factory_sessions/internal/execution -count=1 and the exact local/remote cancellation functional test with -count=1; both pass. A local -race attempt was unavailable because ThreadSanitizer could not allocate Windows shadow memory. PR #2247 host metric ordering was untouched."
    },
    {
      "id": "run-cancellation-leaks-a-writer-past-test-teardown-003",
      "title": "Prove teardown stability and hand off delivery",
      "description": "As a reviewer, I want repeatable regression and suite evidence at the final head so that the cancellation fix can be distinguished from a low-rate lucky pass and safely delivered.",
      "acceptanceCriteria": [
        "At the final rebased head, go test ./tests/functional/sessions/lifecycle/ -run TestCLILocalAndRemoteRunCancellationParityThroughRootProcess -count=50 completes with 0 failures, and its raw output is quoted in the PR body.",
        "go test ./tests/functional/sessions/lifecycle/... ./pkg/services/factory_runtime/... passes at the final head.",
        "The final regression evidence demonstrates both cancellation parity and absence of Factory-directory writes after completion; it does not replace the behavioral proof with source scans, registration inventories, or timeout-only assertions.",
        "The PR body includes the bisection table, exact writer, old and new ordering, pre-fix regression failure where applicable, final 50-run output, and focused-suite output.",
        "Rebase onto origin/main before the final push and reconcile any shared lifecycle changes without taking changes from the concurrent model invoke or pull-result lanes.",
        "Typecheck passes",
        "Tests pass",
        "After the final head is pushed and CI has started, CI-run evidence is added only as a PR comment and never committed; implementation does not poll or re-check CI after its finish line."
      ],
      "priority": 3,
      "passes": true,
      "notes": "Completed review follow-up on rebased head 0ea9f8fd3 (parent implementation commits df5845408 and 0ea9f8fd3, rebased on origin/main 6b56a4225). Required final 50-run command raw output: `ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 446.919s` (0/50 failures), with t.TempDir still authoritative. A pre-rebase quiet rerun also passed; the only failed attempt was invalidated by a separate concurrent -count=20 run of the same target and timed out in Windows TempDir cleanup. Post-rebase focused command `go test ./tests/functional/sessions/lifecycle/... ./pkg/services/factory_runtime/...` passed with `ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 44.436s`, `ok github.com/portpowered/infinite-you/pkg/services/factory_runtime 0.428s`, `ok github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/host 1.070s`, and `ok github.com/portpowered/infinite-you/pkg/services/factory_runtime/wire 0.092s`; remaining packages were `ok` or `[no test files]`. `make typecheck` passed with raw output `cd ui && bun run tsc` and `$ bunx --no-install tsc -b --noEmit --pretty false`. `make test` passed with `Unit lane timing summary`, `Total wall time: 197.955s`, `Package count: 440/440`, and zero failed packages; its workflow tests also passed 91 with 4 documented skips. Changed execution package passed: `ok github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/execution 2.069s`. Backend-size, pkg-maint, pkg-file-count, pkg-structure, and vet passed; local aggregate make lint reports only the pre-existing untouched packaged-factory-consumption-check baseline in internal/migrationledgercheck/packaged_factory_matrix.go, while the hosted ratchet treats that one baseline finding as allowed. PR-body bisection table from story 001: b89a119bb = 0/20 failures (`ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 569.842s`); ca2943b66 = 0/20 (`ok ... 281.731s`); 0e7db8e44 = 0/20 (`ok ... 282.980s`). These measured samples do not attribute the race to PR #2247 or #2248, and that result is reported plainly. Exact writer: the remote service-mode JavaScript durable session's asynchronous `runAsyncSession`/`runResumedAsyncSession` terminal finalizer, whose `recordCanonicalTerminalState` calls `persistTerminalSessionState` and `runtimepersist DirectoryStore.Save` beneath `.you-agent-factory/durable-sessions`. Old ordering: cancellation/termination marked the session terminal and called `runCancel`, then returned while the detached goroutine could still persist and present terminal state. New ordering: each active run owns `runDone`; terminal publication and final DirectoryStore.Save complete before the goroutine closes it, and Cancel, Terminate, and dispatch interruption release the mutex before joining it. The deterministic regression test gates Save and proves control cannot return until the writer is released and complete; no timing-only pre-fix sample failed, so the prescribed bisection remains 0/20 at every commit. No sleep, skip, quarantine, cleanup suppression, manual temp directory, or PR #2247 revert was introduced. Rebase completed cleanly immediately before this final validation/push; concurrent model lanes were not modified."
    }
  ]
}
---

# Rendered review evidence

The PR description above is the `prd.json` used for this work item. The following section renders the required evidence as Markdown so the command, table, and outputs are directly reviewable.

## Prescribed bisection

The exact command was run in separate clean worktrees at each commit:

```text
go test ./tests/functional/sessions/lifecycle/ -run TestCLILocalAndRemoteRunCancellationParityThroughRootProcess -count=20
```

| Commit | Failures out of 20 | Raw output |
| --- | ---: | --- |
| `b89a119bb` | `0/20` | `ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 569.842s` |
| `ca2943b66` | `0/20` | `ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 281.731s` |
| `0e7db8e44` | `0/20` | `ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 282.980s` |

Raw command/output by commit:

```text
$ go test ./tests/functional/sessions/lifecycle/ -run TestCLILocalAndRemoteRunCancellationParityThroughRootProcess -count=20 # b89a119bb
ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 569.842s

$ go test ./tests/functional/sessions/lifecycle/ -run TestCLILocalAndRemoteRunCancellationParityThroughRootProcess -count=20 # ca2943b66
ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 281.731s

$ go test ./tests/functional/sessions/lifecycle/ -run TestCLILocalAndRemoteRunCancellationParityThroughRootProcess -count=20 # 0e7db8e44
ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 282.980s
```

All three measured samples were `0/20`; this does not claim a clean historical guarantee and does not attribute the sampled race to PR #2247 or PR #2248. Commit `ba0856225` was accounted for: its lifecycle-server `Stop`/`Close` does not join the detached durable execution worker.

## Exact writer and ordering correction

The surviving writer is the remote service-mode JavaScript durable session's asynchronous `runAsyncSession`/`runResumedAsyncSession` terminal finalizer. `recordCanonicalTerminalState` calls `persistTerminalSessionState`, whose runtime-persistence `DirectoryStore.Save` writes `.you-agent-factory/durable-sessions/<session>.json` below the Factory directory.

Previously, cancellation/termination marked the session terminal and called `runCancel`, then returned while the detached goroutine could still persist and present terminal state. `ProcessCommand.Stop` and the Factory Runtime host `RunDone` signal therefore did not cover this finalizer.

Now each active run owns `runDone`. Terminal persistence and event presentation finish before the finalizer closes `runDone`; `Cancel`, `Terminate`, and dispatch interruption release the service mutex before joining that channel. The control acknowledgement therefore happens after the final `DirectoryStore.Save`, so the runtime cannot write below the Factory directory after cancellation returns. The deterministic `TestJavaScriptRuntimeService_TerminateWaitsForTerminalPersistence` gates `Save` and proves the ordering without timing sleeps.

## Final validation at head `0ea9f8fd31d395be05225ae3b2911b2cdb84f134`

```text
$ go test ./tests/functional/sessions/lifecycle/ -run TestCLILocalAndRemoteRunCancellationParityThroughRootProcess -count=50
ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 446.919s
FAILURES=0
```

```text
$ go test ./tests/functional/sessions/lifecycle/... ./pkg/services/factory_runtime/...
ok github.com/portpowered/infinite-you/tests/functional/sessions/lifecycle 44.436s
ok github.com/portpowered/infinite-you/pkg/services/factory_runtime 0.428s
ok github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/host 1.070s
ok github.com/portpowered/infinite-you/pkg/services/factory_runtime/wire 0.092s
```

The final head also passed typecheck, the changed execution package, and the recorded full test/lint-ratchet gates. `t.TempDir` remains authoritative; no sleep, skip, quarantine, cleanup suppression, replacement directory, or PR #2247 revert was introduced.