### PR TITLE
Extend Semantic Color Guard to Published Package Source

### DIFF
--- a/ui/packages/components/src/graphs/graph-node-state.ts
+++ b/ui/packages/components/src/graphs/graph-node-state.ts
@@ -16,12 +16,12 @@ export function graphNodeShellStateClassName(state: GraphNodeState): string {
     case "selected":
       return cn(
         "border-2 border-primary bg-primary-container",
-        "shadow-[0_0_0_1px_rgb(from_var(--color-primary)_r_g_b_/_0.28),0_0_0_4px_rgb(from_var(--color-primary)_r_g_b_/_0.08)]",
+        "shadow-af-graph-selected",
       );
     case "error":
       return cn(
         "border-2 border-dashed border-error bg-error-container",
-        "shadow-[0_0_0_3px_var(--color-error-container)]",
+        "shadow-af-graph-error",
       );
     case "disabled":
       return "border-outline-variant bg-surface-container text-on-surface";
@@ -35,9 +35,9 @@ export function graphNodeShellStateClassName(state: GraphNodeState): string {
 export function graphNodeButtonStateClassName(state: GraphNodeState): string {
   switch (state) {
     case "selected":
-      return "ring-2 ring-primary/30";
+      return "ring-2 ring-af-graph-selected-ring";
     case "error":
-      return "ring-2 ring-error/40";
+      return "ring-2 ring-af-graph-error-ring";
     case "disabled":
     case "loading":
       return "cursor-not-allowed";

--- a/ui/packages/components/src/graphs/graph-node-states.test.tsx
+++ b/ui/packages/components/src/graphs/graph-node-states.test.tsx
@@ -28,22 +28,52 @@ function renderNode(ui: ReactElement) {
 function renderShell(state: GraphNodeState, label = "Example node") {
   return renderNode(
     <GraphNodeShell handles={genericHandles} nodeKind="example" state={state}>
-      <GraphNodeButton>{label}</GraphNodeButton>
+      <GraphNodeButton graphState={state} stateLabel={label}>
+        {label}
+      </GraphNodeButton>
     </GraphNodeShell>,
   );
 }
 
-describe("graph node states", () => {
+describe("graph node base roles", () => {
+  it("keeps the default shell and button on their neutral semantic roles", () => {
+    renderShell("default", "Default node");
+
+    const shell = document.querySelector('[data-graph-node-kind="example"]');
+    const button = screen.getByRole("button", { name: "Default node" });
+
+    expect(shell).toHaveClass(
+      "border-outline",
+      "bg-surface",
+      "text-on-surface",
+    );
+    expect(shell).not.toHaveAttribute("data-graph-node-state");
+    expect(button).not.toHaveClass(
+      "ring-af-graph-selected-ring",
+      "ring-af-graph-error-ring",
+      "cursor-not-allowed",
+    );
+    expect(button).not.toBeDisabled();
+  });
+
   it("renders selected shell state with non-color-only emphasis and aria-selected", () => {
     renderShell("selected", "Selected node");
 
     const shell = document.querySelector('[data-graph-node-kind="example"]');
     expect(shell).toHaveAttribute("data-graph-node-state", "selected");
     expect(shell).toHaveAttribute("aria-selected", "true");
-    expect(shell?.className).toContain("border-primary");
-    expect(shell?.className).toContain("shadow-[");
-  });
+    expect(shell).toHaveClass(
+      "border-primary",
+      "bg-primary-container",
+      "shadow-af-graph-selected",
+    );
 
+    const button = screen.getByRole("button", { name: "Selected node" });
+    expect(button).toHaveClass("ring-2", "ring-af-graph-selected-ring");
+  });
+});
+
+describe("graph node status roles", () => {
   it("renders error shell state with dashed border, alert text, and aria-invalid", () => {
     renderNode(
       <GraphNodeShell
@@ -51,14 +81,19 @@ describe("graph node states", () => {
         state="error"
         stateLabel="Connection failed"
       >
-        <GraphNodeButton>Error node</GraphNodeButton>
+        <GraphNodeButton graphState="error">Error node</GraphNodeButton>
       </GraphNodeShell>,
     );
 
     const shell = document.querySelector('[data-graph-node-state="error"]');
     expect(shell).toHaveAttribute("aria-invalid", "true");
-    expect(shell?.className).toContain("border-dashed");
+    expect(shell).toHaveClass("border-dashed", "shadow-af-graph-error");
     expect(screen.getByRole("alert")).toHaveTextContent("Connection failed");
+
+    expect(screen.getByRole("button", { name: "Error node" })).toHaveClass(
+      "ring-2",
+      "ring-af-graph-error-ring",
+    );
   });
 
   it("renders loading shell state with spinner, aria-busy, and stable content height", () => {
@@ -112,8 +147,14 @@ describe("graph node states", () => {
 
     const shell = document.querySelector('[data-graph-node-state="disabled"]');
     expect(shell).toHaveAttribute("aria-disabled", "true");
+    expect(shell).toHaveClass("border-outline-variant", "bg-surface-container");
+    expect(screen.getByRole("button", { name: "Example node" })).toHaveClass(
+      "cursor-not-allowed",
+    );
   });
+});
 
+describe("graph node button interactions", () => {
   it("prevents disabled graph node button activation while keeping label readable", async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();

--- a/ui/packages/components/src/overlays/dialog.tsx
+++ b/ui/packages/components/src/overlays/dialog.tsx
@@ -8,7 +8,7 @@ import {
 } from "./overlay-layout";
 
 const DIALOG_CLOSE_BUTTON_CLASS =
-  "absolute right-4 top-4 inline-flex min-h-9 w-9 items-center justify-center rounded-full border border-outline bg-transparent p-0 text-on-surface transition-colors hover:bg-surface-container-low disabled:pointer-events-none disabled:opacity-50";
+  "absolute right-4 top-4 inline-flex min-h-9 w-9 items-center justify-center rounded-full border border-outline bg-transparent p-0 text-on-surface transition-colors hover:bg-surface-container-low disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-surface-container-low disabled:text-on-surface-disabled";
 
 function DialogCloseIcon() {
   return (
@@ -42,7 +42,7 @@ export function DialogOverlay({
   return (
     <DialogPrimitive.Overlay
       className={cn(
-        "fixed inset-0 z-50 bg-black/70 backdrop-blur-sm data-[state=closed]:animate-out data-[state=open]:animate-in",
+        "fixed inset-0 z-50 bg-scrim backdrop-blur-sm data-[state=closed]:animate-out data-[state=open]:animate-in",
         className,
       )}
       {...props}

--- a/ui/packages/components/src/overlays/overlays.behavior.test.tsx
+++ b/ui/packages/components/src/overlays/overlays.behavior.test.tsx
@@ -169,6 +169,49 @@ describe("Dialog focus and keyboard behavior", () => {
     });
     expect(trigger).toHaveAttribute("aria-expanded", "false");
   });
+
+  it("uses the palette scrim role and keeps a disabled close control semantic", async () => {
+    const user = userEvent.setup();
+
+    renderPackageComponent(
+      <Dialog defaultOpen>
+        <DialogContent
+          aria-describedby={undefined}
+          closeDisabled
+          closeLabel="Close unavailable dialog"
+        >
+          <DialogTitle>Unavailable close dialog</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Unavailable close dialog",
+    });
+    const overlay = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-state="open"]'),
+    ).find((element) => element.classList.contains("bg-scrim"));
+    const closeButton = screen.getByRole("button", {
+      name: "Close unavailable dialog",
+    });
+
+    expect(overlay).toBeDefined();
+    if (!overlay) {
+      throw new Error("Expected the open dialog overlay");
+    }
+    expect(overlay).toHaveClass("bg-scrim");
+    expect(overlay).not.toHaveClass("bg-black/70");
+    expect(closeButton).toBeDisabled();
+    expect(closeButton).toHaveClass(
+      "disabled:pointer-events-none",
+      "disabled:bg-surface-container-low",
+      "disabled:text-on-surface-disabled",
+    );
+    expect(closeButton).not.toHaveClass("disabled:opacity-50");
+
+    await user.click(closeButton);
+    expect(dialog).toBeInTheDocument();
+  });
 });
 
 describe("Popover focus and keyboard behavior", () => {

--- a/ui/packages/components/src/styles/color-role-tokens.css
+++ b/ui/packages/components/src/styles/color-role-tokens.css
@@ -37,10 +37,7 @@
     0.1
   );
   /* Modal scrims follow the active palette while preserving the dark baseline. */
-  --color-scrim: rgb(
-    from var(--color-af-foundation-background) r g b /
-    0.7
-  );
+  --color-scrim: rgb(from var(--color-af-foundation-background) r g b / 0.7);
   /* on-surface text roles: text-color-role-tokens.css */
   --color-outline: rgb(from var(--color-af-foundation-overlay) r g b / 0.1);
   --color-outline-variant: rgb(
@@ -112,6 +109,19 @@
     0.12
   );
   --color-on-info-container: var(--color-af-foundation-info-ink);
+
+  /* --- Graph visual-state emphasis --- */
+  --color-af-graph-selected-ring: rgb(from var(--color-primary) r g b / 0.3);
+  --color-af-graph-selected-outline: rgb(
+    from var(--color-primary) r g b /
+    0.28
+  );
+  --color-af-graph-selected-glow: rgb(from var(--color-primary) r g b / 0.08);
+  --color-af-graph-error-ring: rgb(from var(--color-error) r g b / 0.4);
+  --shadow-af-graph-selected:
+    0 0 0 1px var(--color-af-graph-selected-outline),
+    0 0 0 4px var(--color-af-graph-selected-glow);
+  --shadow-af-graph-error: 0 0 0 3px var(--color-error-container);
 
   /* --- Product af-* keys (role-backed; formerly color-role-aliases.css) --- */
   --color-af-background: var(--color-background);

--- a/ui/packages/components/src/styles/color-role-tokens.css
+++ b/ui/packages/components/src/styles/color-role-tokens.css
@@ -36,6 +36,11 @@
     from var(--color-af-foundation-overlay) r g b /
     0.1
   );
+  /* Modal scrims follow the active palette while preserving the dark baseline. */
+  --color-scrim: rgb(
+    from var(--color-af-foundation-background) r g b /
+    0.7
+  );
   /* on-surface text roles: text-color-role-tokens.css */
   --color-outline: rgb(from var(--color-af-foundation-overlay) r g b / 0.1);
   --color-outline-variant: rgb(

--- a/ui/packages/components/src/styles/package-token-styles-fixture.css
+++ b/ui/packages/components/src/styles/package-token-styles-fixture.css
@@ -8,4 +8,4 @@
 
 @source "./package-token-fixture-usage.ts";
 @source "../**/*.{ts,tsx}";
-@source inline("bg-primary text-on-surface text-on-surface-variant text-body-medium text-title-large text-label-medium gap-layout-section gap-layout-tight gap-layout-element gap-layout-group p-layout-inset-dialog font-display shadow-xl border-outline bg-surface-container-high bg-surface-container-low bg-black/70 bg-outline-variant hover:bg-surface-container-low hover:bg-on-surface-variant");
+@source inline("bg-primary text-on-surface text-on-surface-variant text-body-medium text-title-large text-label-medium gap-layout-section gap-layout-tight gap-layout-element gap-layout-group p-layout-inset-dialog font-display shadow-xl border-outline bg-surface-container-high bg-surface-container-low bg-scrim bg-outline-variant hover:bg-surface-container-low hover:bg-on-surface-variant");

--- a/ui/packages/components/src/styles/package-token-styles-fixture.css
+++ b/ui/packages/components/src/styles/package-token-styles-fixture.css
@@ -8,4 +8,4 @@
 
 @source "./package-token-fixture-usage.ts";
 @source "../**/*.{ts,tsx}";
-@source inline("bg-primary text-on-surface text-on-surface-variant text-body-medium text-title-large text-label-medium gap-layout-section gap-layout-tight gap-layout-element gap-layout-group p-layout-inset-dialog font-display shadow-xl border-outline bg-surface-container-high bg-surface-container-low bg-scrim bg-outline-variant hover:bg-surface-container-low hover:bg-on-surface-variant");
+@source inline("bg-primary text-on-surface text-on-surface-variant text-body-medium text-title-large text-label-medium gap-layout-section gap-layout-tight gap-layout-element gap-layout-group p-layout-inset-dialog font-display shadow-xl shadow-af-graph-selected shadow-af-graph-error border-outline bg-surface-container-high bg-surface-container-low bg-scrim bg-outline-variant ring-af-graph-selected-ring ring-af-graph-error-ring hover:bg-surface-container-low hover:bg-on-surface-variant");

--- a/ui/packages/components/src/styles/token-styles.test.ts
+++ b/ui/packages/components/src/styles/token-styles.test.ts
@@ -54,4 +54,25 @@ describe("@you-agent-factory/components token styles entrypoint", () => {
     expect(factoryLightBackground.toLowerCase()).toBe("#f4f1e8");
     expect(factoryLightBackground).not.toBe(factoryDarkBackground);
   });
+
+  it("defines the dialog scrim role from the active palette background", () => {
+    documentRoot.dataset.colorPalette = "factory-dark";
+    const factoryDarkScrim = readDocumentCssVariable(
+      documentRoot,
+      "--color-scrim",
+    );
+    documentRoot.dataset.colorPalette = "factory-light";
+    const factoryLightScrim = readDocumentCssVariable(
+      documentRoot,
+      "--color-scrim",
+    );
+
+    expect(factoryDarkScrim.replace(/\s+/g, " ")).toBe(
+      "rgb( from #050b10 r g b / 0.7 )",
+    );
+    expect(factoryLightScrim.replace(/\s+/g, " ")).toBe(
+      "rgb( from #f4f1e8 r g b / 0.7 )",
+    );
+    expect(factoryLightScrim).not.toBe(factoryDarkScrim);
+  });
 });

--- a/ui/packages/components/src/styles/token-styles.test.ts
+++ b/ui/packages/components/src/styles/token-styles.test.ts
@@ -7,13 +7,21 @@ import {
   readDocumentCssVariable,
 } from "./compile-package-token-styles";
 
+let documentRoot: HTMLElement;
+
+beforeAll(async () => {
+  documentRoot = await injectCompiledPackageTokenStyles(document);
+});
+
+function normalizeCssValue(value: string): string {
+  return value
+    .replace(/\s+/g, " ")
+    .replace(/\(\s+/g, "(")
+    .replace(/\s+\)/g, ")")
+    .trim();
+}
+
 describe("@you-agent-factory/components token styles entrypoint", () => {
-  let documentRoot: HTMLElement;
-
-  beforeAll(async () => {
-    documentRoot = await injectCompiledPackageTokenStyles(document);
-  });
-
   it("exposes role tokens on the document root after importing package styles", () => {
     expect(
       readDocumentCssVariable(documentRoot, "--color-primary"),
@@ -67,12 +75,64 @@ describe("@you-agent-factory/components token styles entrypoint", () => {
       "--color-scrim",
     );
 
-    expect(factoryDarkScrim.replace(/\s+/g, " ")).toBe(
-      "rgb( from #050b10 r g b / 0.7 )",
+    expect(normalizeCssValue(factoryDarkScrim)).toBe(
+      "rgb(from #050b10 r g b / 0.7)",
     );
-    expect(factoryLightScrim.replace(/\s+/g, " ")).toBe(
-      "rgb( from #f4f1e8 r g b / 0.7 )",
+    expect(normalizeCssValue(factoryLightScrim)).toBe(
+      "rgb(from #f4f1e8 r g b / 0.7)",
     );
     expect(factoryLightScrim).not.toBe(factoryDarkScrim);
+  });
+});
+
+describe("@you-agent-factory/components graph emphasis roles", () => {
+  it("exposes palette-derived graph emphasis roles", () => {
+    documentRoot.dataset.colorPalette = "factory-dark";
+
+    const selectedRing = readDocumentCssVariable(
+      documentRoot,
+      "--color-af-graph-selected-ring",
+    );
+    const errorRing = readDocumentCssVariable(
+      documentRoot,
+      "--color-af-graph-error-ring",
+    );
+    const selectedShadow = readDocumentCssVariable(
+      documentRoot,
+      "--shadow-af-graph-selected",
+    );
+    const errorShadow = readDocumentCssVariable(
+      documentRoot,
+      "--shadow-af-graph-error",
+    );
+
+    expect(normalizeCssValue(selectedRing)).toBe(
+      "rgb(from #f5c76f r g b / 0.3)",
+    );
+    expect(normalizeCssValue(errorRing)).toBe("rgb(from #f05f5f r g b / 0.4)");
+    expect(normalizeCssValue(selectedShadow)).toContain(
+      "0 0 0 1px rgb(from #f5c76f r g b / 0.28)",
+    );
+    expect(normalizeCssValue(selectedShadow)).toContain(
+      "0 0 0 4px rgb(from #f5c76f r g b / 0.08)",
+    );
+    expect(normalizeCssValue(errorShadow)).toContain("0 0 0 3px");
+
+    documentRoot.dataset.colorPalette = "factory-light";
+    const factoryLightSelectedRing = readDocumentCssVariable(
+      documentRoot,
+      "--color-af-graph-selected-ring",
+    );
+    const factoryLightErrorRing = readDocumentCssVariable(
+      documentRoot,
+      "--color-af-graph-error-ring",
+    );
+
+    expect(normalizeCssValue(factoryLightSelectedRing)).toBe(
+      "rgb(from #f5c76f r g b / 0.3)",
+    );
+    expect(normalizeCssValue(factoryLightErrorRing)).toBe(
+      "rgb(from #d94848 r g b / 0.4)",
+    );
   });
 });

--- a/ui/scripts/check-semantic-color-tokens.test.ts
+++ b/ui/scripts/check-semantic-color-tokens.test.ts
@@ -1,11 +1,22 @@
+import { execFile } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { scanSemanticColorTokens } from "./check-semantic-color-tokens";
+import {
+  discoverSemanticColorSourceRoots,
+  scanSemanticColorTokens,
+  scanSemanticColorTokensInRoots,
+} from "./check-semantic-color-tokens";
 
 const tempRoots: string[] = [];
+const execFileAsync = promisify(execFile);
+const scriptPath = path.resolve(
+  process.cwd(),
+  "scripts/check-semantic-color-tokens.ts",
+);
 
 async function writeSourceFile(
   rootDir: string,
@@ -17,16 +28,139 @@ async function writeSourceFile(
   await writeFile(absolutePath, content, "utf8");
 }
 
-describe("scanSemanticColorTokens", () => {
-  afterEach(async () => {
-    await Promise.all(
-      tempRoots.map(async (rootDir) => {
-        await rm(rootDir, { force: true, recursive: true });
-      }),
+async function writeExcludedColorSources(sourceRoot: string) {
+  const excludedPaths = [
+    "features/ignored.test.ts",
+    "features/ignored.test.tsx",
+    "features/ignored.stories.tsx",
+    "generated/ignored.ts",
+    "testing/ignored.ts",
+    "stories/ignored.ts",
+    "messages/ignored.ts",
+  ];
+  await Promise.all(
+    excludedPaths.map((relativePath) =>
+      writeSourceFile(
+        sourceRoot,
+        relativePath,
+        'export const ignored = "bg-red-500/50";\n',
+      ),
+    ),
+  );
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.map(async (rootDir) => {
+      await rm(rootDir, { force: true, recursive: true });
+    }),
+  );
+  tempRoots.length = 0;
+});
+
+describe("semantic color source roots", () => {
+  it("discovers dashboard and package roots while preserving focused-root mode", async () => {
+    const uiRoot = await mkdtemp(path.join(os.tmpdir(), "semantic-color-ui-"));
+    tempRoots.push(uiRoot);
+    const packageSourceRoot = path.join(
+      uiRoot,
+      "packages",
+      "components",
+      "src",
     );
-    tempRoots.length = 0;
+    await mkdir(path.join(uiRoot, "src"), { recursive: true });
+    await mkdir(packageSourceRoot, { recursive: true });
+    await mkdir(path.join(uiRoot, "packages", "without-src"), {
+      recursive: true,
+    });
+
+    const roots = await discoverSemanticColorSourceRoots(null, uiRoot);
+
+    expect(
+      roots.map((root) =>
+        path.relative(uiRoot, root.sourceDirectory).split(path.sep).join("/"),
+      ),
+    ).toEqual(["src", "packages/components/src"]);
+
+    await expect(
+      discoverSemanticColorSourceRoots(packageSourceRoot, uiRoot),
+    ).resolves.toEqual([
+      {
+        reportDirectory: path.join(uiRoot, "packages", "components"),
+        sourceDirectory: packageSourceRoot,
+      },
+    ]);
   });
 
+  it("scans every supplied root and applies exclusions relative to each root", async () => {
+    const uiRoot = await mkdtemp(path.join(os.tmpdir(), "semantic-color-ui-"));
+    tempRoots.push(uiRoot);
+    const dashboardSourceRoot = path.join(uiRoot, "src");
+    const packageSourceRoot = path.join(
+      uiRoot,
+      "packages",
+      "components",
+      "src",
+    );
+    const sourceRoots = [
+      {
+        reportDirectory: uiRoot,
+        sourceDirectory: dashboardSourceRoot,
+      },
+      {
+        reportDirectory: uiRoot,
+        sourceDirectory: packageSourceRoot,
+      },
+    ];
+
+    await writeSourceFile(
+      dashboardSourceRoot,
+      "features/dashboard.tsx",
+      'export const dashboard = "bg-blue-500/50";\n',
+    );
+    await writeSourceFile(
+      packageSourceRoot,
+      "features/package.tsx",
+      'export const packageSource = "bg-red-500/50";\n',
+    );
+
+    for (const sourceRoot of [dashboardSourceRoot, packageSourceRoot]) {
+      await writeExcludedColorSources(sourceRoot);
+    }
+
+    const violations = await scanSemanticColorTokensInRoots(sourceRoots);
+
+    expect(violations).toHaveLength(2);
+    expect(
+      violations.map((violation) => ({
+        filePath: path
+          .relative(uiRoot, violation.filePath)
+          .split(path.sep)
+          .join("/"),
+        rootDirectory: path
+          .relative(uiRoot, violation.rootDirectory)
+          .split(path.sep)
+          .join("/"),
+        token: violation.token,
+      })),
+    ).toEqual(
+      expect.arrayContaining([
+        {
+          filePath: "src/features/dashboard.tsx",
+          rootDirectory: "src",
+          token: "bg-blue-500/50",
+        },
+        {
+          filePath: "packages/components/src/features/package.tsx",
+          rootDirectory: "packages/components/src",
+          token: "bg-red-500/50",
+        },
+      ]),
+    );
+  });
+});
+
+describe("scanSemanticColorTokens", () => {
   it("reports slash-opacity color utilities, opacity shortcuts, filter color math, local alpha math, and forbidden foundation tokens", async () => {
     const rootDir = await mkdtemp(
       path.join(os.tmpdir(), "semantic-color-token-guard-"),
@@ -120,5 +254,53 @@ describe("scanSemanticColorTokens", () => {
     const violations = await scanSemanticColorTokens(rootDir);
 
     expect(violations).toHaveLength(0);
+  });
+});
+
+describe("semantic color command", () => {
+  it("uses AGENT_FACTORY_UI_SRC_DIR as a focused root and reports root-relative diagnostics", async () => {
+    const tempRoot = await mkdtemp(
+      path.join(os.tmpdir(), "semantic-color-command-"),
+    );
+    tempRoots.push(tempRoot);
+    const focusedSourceRoot = path.join(tempRoot, "focused", "src");
+    const otherSourceRoot = path.join(tempRoot, "other", "src");
+    await writeSourceFile(
+      focusedSourceRoot,
+      "features/clean.tsx",
+      'export const clean = "bg-primary";\n',
+    );
+    await writeSourceFile(
+      otherSourceRoot,
+      "features/other.tsx",
+      'export const other = "bg-red-500/50";\n',
+    );
+
+    await expect(
+      execFileAsync("bun", [scriptPath], {
+        cwd: tempRoot,
+        env: {
+          ...process.env,
+          AGENT_FACTORY_UI_SRC_DIR: focusedSourceRoot,
+        },
+      }),
+    ).resolves.toMatchObject({
+      stdout: expect.stringContaining(
+        "Semantic color token guard passed: src (0 violations).",
+      ),
+    });
+
+    await expect(
+      execFileAsync("bun", [scriptPath], {
+        cwd: tempRoot,
+        env: {
+          ...process.env,
+          AGENT_FACTORY_UI_SRC_DIR: otherSourceRoot,
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("src/features/other.tsx:1:"),
+    });
   });
 });

--- a/ui/scripts/check-semantic-color-tokens.test.ts
+++ b/ui/scripts/check-semantic-color-tokens.test.ts
@@ -1,7 +1,8 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -10,6 +11,7 @@ import {
   scanSemanticColorTokens,
   scanSemanticColorTokensInRoots,
 } from "./check-semantic-color-tokens";
+import { forbiddenFoundationTokenNames } from "./semantic-color-foundation-policy";
 
 const tempRoots: string[] = [];
 const execFileAsync = promisify(execFile);
@@ -17,6 +19,21 @@ const scriptPath = path.resolve(
   process.cwd(),
   "scripts/check-semantic-color-tokens.ts",
 );
+const packagePaletteCssPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "packages/components/src/styles/color-palette-presets.css",
+);
+
+function declaredFoundationTokenNames(source: string) {
+  return [
+    ...new Set(
+      [...source.matchAll(/^\s*(--color-af-foundation-[a-z0-9-]+)\s*:/gm)].map(
+        (match) => match[1],
+      ),
+    ),
+  ].sort();
+}
 
 async function writeSourceFile(
   rootDir: string,
@@ -156,6 +173,93 @@ describe("semantic color source roots", () => {
           token: "bg-red-500/50",
         },
       ]),
+    );
+  });
+});
+
+describe("foundation token policy", () => {
+  it("keeps every canonical package foundation key represented by the forbidden policy", async () => {
+    const packagePaletteCss = await readFile(packagePaletteCssPath, "utf8");
+    const declaredTokens = declaredFoundationTokenNames(packagePaletteCss);
+    const policyTokens = forbiddenFoundationTokenNames
+      .filter((token) => token.startsWith("af-foundation-"))
+      .map((token) => `--color-${token}`)
+      .sort();
+
+    expect(
+      declaredTokens.filter((token) => !policyTokens.includes(token)),
+    ).toEqual([]);
+    expect(declaredTokens).toHaveLength(28);
+  });
+
+  it("rejects direct utility and variable consumption of package foundation keys with positions", async () => {
+    const rootDir = await mkdtemp(
+      path.join(os.tmpdir(), "semantic-color-foundation-guard-"),
+    );
+    tempRoots.push(rootDir);
+    const packagePaletteCss = await readFile(packagePaletteCssPath, "utf8");
+    const foundationTokens = declaredFoundationTokenNames(
+      packagePaletteCss,
+    ).map((token) => token.replace("--color-", ""));
+    const source = foundationTokens
+      .flatMap((token) => [
+        `export const utility = "bg-${token}";`,
+        `export const variable = "var(--color-${token})";`,
+      ])
+      .join("\n");
+    await writeSourceFile(rootDir, "components/foundation.tsx", source);
+
+    const violations = await scanSemanticColorTokens(rootDir);
+
+    expect(violations).toHaveLength(foundationTokens.length * 2);
+    expect(
+      violations.every(
+        (violation) => violation.kind === "foundation-color-token",
+      ),
+    ).toBe(true);
+    expect(violations.map((violation) => violation.token)).toEqual(
+      expect.arrayContaining([
+        "bg-af-foundation-accent",
+        "var(--color-af-foundation-accent)",
+        "bg-af-foundation-worker-ink",
+        "var(--color-af-foundation-worker-ink)",
+      ]),
+    );
+
+    const firstUtility = violations.find(
+      (violation) => violation.token === "bg-af-foundation-accent",
+    );
+    expect(firstUtility).toMatchObject({
+      filePath: path.join(rootDir, "components/foundation.tsx"),
+      position: {
+        line: 1,
+        column: source.indexOf("bg-af-foundation-accent") + 1,
+      },
+    });
+  });
+
+  it("continues rejecting every legacy foundation alias", async () => {
+    const rootDir = await mkdtemp(
+      path.join(os.tmpdir(), "semantic-color-legacy-guard-"),
+    );
+    tempRoots.push(rootDir);
+    const legacyTokens = forbiddenFoundationTokenNames.filter(
+      (token) => !token.startsWith("af-foundation-"),
+    );
+    const source = legacyTokens
+      .flatMap((token) => [
+        `export const utility = "bg-${token}";`,
+        `export const variable = "var(--color-${token})";`,
+      ])
+      .join("\n");
+    await writeSourceFile(rootDir, "components/legacy.tsx", source);
+
+    const violations = await scanSemanticColorTokens(rootDir);
+
+    expect(legacyTokens).toHaveLength(10);
+    expect(violations).toHaveLength(legacyTokens.length * 2);
+    expect(new Set(violations.map((violation) => violation.kind))).toEqual(
+      new Set(["foundation-color-token"]),
     );
   });
 });

--- a/ui/scripts/check-semantic-color-tokens.ts
+++ b/ui/scripts/check-semantic-color-tokens.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
+import { forbiddenFoundationTokenNames } from "./semantic-color-foundation-policy";
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const defaultUiDir = path.resolve(scriptDir, "..");
 const sourceDir = process.env.AGENT_FACTORY_UI_SRC_DIR
@@ -20,18 +22,6 @@ const skippedPathFragments = [
 ];
 const semanticColorExceptionMarker =
   "semantic-color-exception: system-integration";
-const forbiddenFoundationTokenNames = [
-  "af-bg",
-  "af-bg-start",
-  "af-bg-mid",
-  "af-canvas",
-  "af-ink",
-  "af-danger-bright",
-  "af-danger-ink",
-  "af-info-ink",
-  "af-success-ink",
-  "af-warning-ink",
-] as const;
 const forbiddenFoundationTokenPattern = forbiddenFoundationTokenNames.join("|");
 const colorUtilityWithAlphaPattern =
   /(?:^|[\s"'`])((?:[a-z-]+:)*(?:bg|text|border|fill|stroke|decoration|outline|ring|ring-offset)-[^\s"'`]+\/\d{1,3}\b)/g;
@@ -40,12 +30,13 @@ const opacityUtilityPattern =
 const brightnessUtilityPattern =
   /(?:^|[\s"'`])((?:[a-z-]+:)*brightness-(\d{1,3})\b)/g;
 const rgbFromVarAlphaPattern = /rgb\(from[^\n]*?\/[^\n]*?\)/g;
+const foundationTokenBoundary = "(?![a-z0-9-])";
 const forbiddenFoundationUtilityPattern = new RegExp(
-  `(?:^|[\\s"'\\\`])((?:[a-z-]+:)*(?:bg|text|border|fill|stroke|decoration|outline|ring|ring-offset)-(?:${forbiddenFoundationTokenPattern})\\b)`,
+  `(?:^|[\\s"'\\\`])((?:[a-z-]+:)*(?:bg|text|border|fill|stroke|decoration|outline|ring|ring-offset)-(?:${forbiddenFoundationTokenPattern})${foundationTokenBoundary})`,
   "g",
 );
 const forbiddenFoundationVarPattern = new RegExp(
-  String.raw`var\(--color-(?:${forbiddenFoundationTokenPattern})\b[^)]*\)`,
+  String.raw`var\(--color-(?:${forbiddenFoundationTokenPattern})${foundationTokenBoundary}[^)]*\)`,
   "g",
 );
 

--- a/ui/scripts/check-semantic-color-tokens.ts
+++ b/ui/scripts/check-semantic-color-tokens.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile } from "node:fs/promises";
+import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -8,7 +8,6 @@ const defaultUiDir = path.resolve(scriptDir, "..");
 const sourceDir = process.env.AGENT_FACTORY_UI_SRC_DIR
   ? path.resolve(process.env.AGENT_FACTORY_UI_SRC_DIR)
   : path.join(defaultUiDir, "src");
-const uiDir = path.dirname(sourceDir);
 const sourceExtensions = new Set([".ts", ".tsx"]);
 const skippedFileSuffixes = [".test.ts", ".test.tsx", ".stories.tsx"];
 const skippedDirectoryNames = new Set(["generated"]);
@@ -64,6 +63,75 @@ export interface SemanticColorTokenViolation {
     line: number;
   };
   token: string;
+}
+
+export interface SemanticColorSourceRoot {
+  reportDirectory: string;
+  sourceDirectory: string;
+}
+
+export type RootedSemanticColorTokenViolation = SemanticColorTokenViolation & {
+  rootDirectory: string;
+};
+
+async function isDirectory(directory: string) {
+  try {
+    return (await stat(directory)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export async function discoverSemanticColorSourceRoots(
+  focusedSourceDirectory: string | null | undefined = process.env
+    .AGENT_FACTORY_UI_SRC_DIR,
+  uiDirectory = defaultUiDir,
+): Promise<SemanticColorSourceRoot[]> {
+  const resolvedUiDirectory = path.resolve(uiDirectory);
+  if (focusedSourceDirectory) {
+    const sourceDirectory = path.resolve(focusedSourceDirectory);
+    return [
+      {
+        reportDirectory: path.dirname(sourceDirectory),
+        sourceDirectory,
+      },
+    ];
+  }
+
+  const sourceRoots: SemanticColorSourceRoot[] = [
+    {
+      reportDirectory: resolvedUiDirectory,
+      sourceDirectory: path.join(resolvedUiDirectory, "src"),
+    },
+  ];
+  const packagesDirectory = path.join(resolvedUiDirectory, "packages");
+
+  if (!(await isDirectory(packagesDirectory))) {
+    return sourceRoots;
+  }
+
+  const packageEntries = await readdir(packagesDirectory, {
+    withFileTypes: true,
+  });
+  for (const packageEntry of packageEntries
+    .filter((entry) => entry.isDirectory())
+    .sort((left, right) => left.name.localeCompare(right.name))) {
+    const sourceDirectory = path.join(
+      packagesDirectory,
+      packageEntry.name,
+      "src",
+    );
+    if (!(await isDirectory(sourceDirectory))) {
+      continue;
+    }
+
+    sourceRoots.push({
+      reportDirectory: resolvedUiDirectory,
+      sourceDirectory,
+    });
+  }
+
+  return sourceRoots;
 }
 
 function shouldSkipFile(filePath: string) {
@@ -317,11 +385,42 @@ export async function scanSemanticColorTokens(rootDirectory = sourceDir) {
   });
 }
 
+export async function scanSemanticColorTokensInRoots(
+  sourceRoots: readonly SemanticColorSourceRoot[],
+): Promise<RootedSemanticColorTokenViolation[]> {
+  const violations: RootedSemanticColorTokenViolation[] = [];
+
+  for (const sourceRoot of sourceRoots) {
+    const rootViolations = await scanSemanticColorTokens(
+      sourceRoot.sourceDirectory,
+    );
+    violations.push(
+      ...rootViolations.map((violation) => ({
+        ...violation,
+        rootDirectory: sourceRoot.sourceDirectory,
+      })),
+    );
+  }
+
+  return violations.sort((left, right) => {
+    if (left.filePath !== right.filePath) {
+      return left.filePath.localeCompare(right.filePath);
+    }
+    if (left.position.line !== right.position.line) {
+      return left.position.line - right.position.line;
+    }
+    return left.position.column - right.position.column;
+  });
+}
+
 function formatViolation(
-  rootDirectory: string,
+  reportDirectory: string,
   violation: SemanticColorTokenViolation,
 ) {
-  const relativeFilePath = path.relative(rootDirectory, violation.filePath);
+  const relativeFilePath = path
+    .relative(reportDirectory, violation.filePath)
+    .split(path.sep)
+    .join("/");
   return [
     `${relativeFilePath}:${violation.position.line}:${violation.position.column}`,
     `  ${violation.token}`,
@@ -330,18 +429,52 @@ function formatViolation(
 }
 
 async function main() {
-  const violations = await scanSemanticColorTokens(sourceDir);
+  const sourceRoots = await discoverSemanticColorSourceRoots();
+  const violations = await scanSemanticColorTokensInRoots(sourceRoots);
 
   if (violations.length === 0) {
+    const rootLabels = sourceRoots
+      .map((sourceRoot) =>
+        path
+          .relative(
+            sourceRoots[0]?.reportDirectory ?? defaultUiDir,
+            sourceRoot.sourceDirectory,
+          )
+          .split(path.sep)
+          .join("/"),
+      )
+      .join(", ");
+    console.log(
+      `Semantic color token guard passed: ${rootLabels} (0 violations).`,
+    );
     return;
   }
 
   const report = violations
-    .map((violation) => formatViolation(uiDir, violation))
+    .map((violation) => {
+      const sourceRoot = sourceRoots.find(
+        (candidate) => candidate.sourceDirectory === violation.rootDirectory,
+      );
+      return formatViolation(
+        sourceRoot?.reportDirectory ?? path.dirname(violation.rootDirectory),
+        violation,
+      );
+    })
     .join("\n\n");
   console.error(
     [
       "Semantic color token guard failed.",
+      `Checked source roots: ${sourceRoots
+        .map((sourceRoot) =>
+          path
+            .relative(
+              sourceRoots[0]?.reportDirectory ?? defaultUiDir,
+              sourceRoot.sourceDirectory,
+            )
+            .split(path.sep)
+            .join("/"),
+        )
+        .join(", ")}`,
       "Use semantic color tokens in component-facing ui/src code and keep local alpha math inside the shared token owner when a new integration token is needed.",
       `Document rare integration-only exceptions with \`${semanticColorExceptionMarker}\` immediately above the usage.`,
       report,

--- a/ui/scripts/semantic-color-foundation-policy.ts
+++ b/ui/scripts/semantic-color-foundation-policy.ts
@@ -1,0 +1,48 @@
+const legacyFoundationTokenNames = [
+  "af-bg",
+  "af-bg-start",
+  "af-bg-mid",
+  "af-canvas",
+  "af-ink",
+  "af-danger-bright",
+  "af-danger-ink",
+  "af-info-ink",
+  "af-success-ink",
+  "af-warning-ink",
+] as const;
+
+const packageFoundationTokenNames = [
+  "af-foundation-accent",
+  "af-foundation-accent-ink",
+  "af-foundation-accent-strong",
+  "af-foundation-background",
+  "af-foundation-background-mid",
+  "af-foundation-background-start",
+  "af-foundation-canvas",
+  "af-foundation-code-ink",
+  "af-foundation-danger",
+  "af-foundation-danger-bright",
+  "af-foundation-danger-ink",
+  "af-foundation-info",
+  "af-foundation-info-bright",
+  "af-foundation-info-ink",
+  "af-foundation-info-strong",
+  "af-foundation-ink",
+  "af-foundation-overlay",
+  "af-foundation-secondary-accent",
+  "af-foundation-secondary-accent-ink",
+  "af-foundation-success",
+  "af-foundation-success-ink",
+  "af-foundation-surface",
+  "af-foundation-tertiary-accent",
+  "af-foundation-tertiary-accent-ink",
+  "af-foundation-warning",
+  "af-foundation-warning-ink",
+  "af-foundation-worker",
+  "af-foundation-worker-ink",
+] as const;
+
+export const forbiddenFoundationTokenNames = [
+  ...legacyFoundationTokenNames,
+  ...packageFoundationTokenNames,
+] as const;

--- a/ui/src/components/ui/color-role-accent-contrast.tsx
+++ b/ui/src/components/ui/color-role-accent-contrast.tsx
@@ -27,8 +27,8 @@ const LEGACY_REFERENCE_SWATCHES = [
     id: "legacy-info",
     label: "Prior secondary hue (info foundation)",
     style: {
-      backgroundColor: "var(--color-af-foundation-info)",
-      color: "var(--color-af-foundation-canvas)",
+      backgroundColor: "var(--color-af-legacy-info)",
+      color: "var(--color-af-legacy-info-ink)",
     },
     subtitle: "Semantic info / legacy vibrant cyan",
   },
@@ -36,8 +36,8 @@ const LEGACY_REFERENCE_SWATCHES = [
     id: "legacy-worker",
     label: "Prior tertiary hue (worker foundation)",
     style: {
-      backgroundColor: "var(--color-af-foundation-worker)",
-      color: "var(--color-af-foundation-canvas)",
+      backgroundColor: "var(--color-af-legacy-worker)",
+      color: "var(--color-af-legacy-worker-ink)",
     },
     subtitle: "Legacy vibrant violet chrome",
   },

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -90,6 +90,11 @@
     from var(--color-af-foundation-tertiary-accent) r g b /
     0.3
   );
+  /* Reference-only roles keep the migration showcase out of foundation call sites. */
+  --color-af-legacy-info: var(--color-info);
+  --color-af-legacy-info-ink: var(--color-on-info);
+  --color-af-legacy-worker: var(--color-af-foundation-worker);
+  --color-af-legacy-worker-ink: var(--color-af-foundation-canvas);
   --color-af-bg: var(--color-af-background);
   --color-af-bg-start: var(--color-af-foundation-background-start);
   --color-af-bg-mid: var(--color-af-foundation-background-mid);


### PR DESCRIPTION
{
  "project": "Extend the Semantic Color Guard to Published Package Source",
  "branchName": "uicolor-color-guard-package-scope",
  "description": "Extend the existing UI semantic-color guard so its normal command scans dashboard and published package source in one invocation, repair the six known components-package violations with palette-aware semantic roles, and ensure every declared foundation color is forbidden at component call sites.",
  "context": {
    "customerAsk": "Make cd ui && bun run check:semantic-colors scan ui/src and ui/packages/*/src in one invocation while retaining AGENT_FACTORY_UI_SRC_DIR and all existing exclusions. Repair the six current components-package findings without exception markers, make the dialog scrim palette-aware, move graph alpha/ring intent into named role tokens, and test that every declared --color-af-foundation-* key is covered by the forbidden-token policy. Provide deliberate failure/restoration output and Factory Light/Factory Dark screenshots in PR comments.",
    "problem": "The lint-wired command defaults to ui/src, leaving published package sources outside semantic-color enforcement. Six violations already exist in the components package, including a palette-invariant black 70% modal scrim, while the guard's ten-name foundation denylist does not represent all 28 foundation keys declared by package CSS. New package color debt and new direct foundation-token usage can therefore ship undetected.",
    "solution": "Make the guard's default mode aggregate ui/src with every existing ui/packages/*/src root, preserving the environment override as focused single-root mode and applying skip rules per root. Define palette-derived scrim and graph emphasis roles in the package role layer, consume semantic disabled treatment in the dialog, and add focused behavioral tests for multi-root rejection, clean success, exclusions, diagnostic paths, and complete foundation-key rejection."
  },
  "acceptanceCriteria": [
    "cd ui && bun run check:semantic-colors checks ui/src and every existing ui/packages/*/src root in one invocation and exits non-zero for a violation in any checked root. AGENT_FACTORY_UI_SRC_DIR continues to select one focused root, and .test.ts, .test.tsx, .stories.tsx, generated/, testing/, stories/, and messages/ exclusions retain their current behavior relative to each checked root.",
    "The clean tree produces zero semantic-color violations, including zero findings at the six reported sites in graphs/graph-node-state.ts and overlays/dialog.tsx; none is suppressed with semantic-color-exception: system-integration.",
    "A shared dialog opened under Factory Light uses a scrim computed from the active palette rather than a literal black value; the same dialog under Factory Dark remains visually equivalent to the current treatment. Dialog keyboard, focus, dismissal, accessibility, and responsive behavior remain intact, and screenshots for both palettes are posted in a PR comment.",
    "Selected and error graph-node shell/button emphasis and the disabled dialog close treatment consume named semantic roles instead of slash-opacity utilities, general opacity utilities, or component-local rgb(from ... / alpha) expressions. Existing default, selected, error, disabled, and loading semantics remain intact, with focused tests and direct browser verification.",
    "A focused guard test enumerates all 28 distinct --color-af-foundation-* keys declared by canonical package CSS and fails by token name if any lacks a forbidden consumer representation, while existing legacy aliases remain forbidden. A temporary unlisted foundation declaration makes the test fail naming that key; exact restoration makes it pass, and both outputs are posted in a PR comment rather than committed.",
    "Quality gate: Typecheck passes; Tests pass via make ui-test; cd ui && bun run check:semantic-colors passes with property-specific clean output; make ui-lint is run; and there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Inherited failures are diagnosed without widening this lane.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The worker/reviewer cycle continues through those review-owned outcomes until the PR is actually merged; a PR that is merely open, green, approved, or ready to merge is not complete."
  ],
  "userStories": [
    {
      "id": "uicolor-color-guard-package-scope-001",
      "title": "Make shared dialog color treatments semantic",
      "description": "As a user of the shared dialog, I want its scrim and disabled close control to derive from active color roles so that the modal is coherent in light and dark palettes without losing established accessibility or interaction behavior.",
      "acceptanceCriteria": [
        "The dialog overlay consumes a named role-layer scrim token and contains no literal bg-black/70 or equivalent component-local hardcoded/alpha color treatment.",
        "Under Factory Light, the resolved scrim is derived from the active palette rather than pure black; under Factory Dark, it remains visually equivalent to the current black 70% treatment.",
        "The disabled close control uses semantic disabled treatment without disabled:opacity-50, remains non-interactive when disabled, and retains a discernible accessible label.",
        "Opening, focus containment, Escape behavior, close-button keyboard activation, and existing responsive dialog layout remain unchanged.",
        "Factory Light and Factory Dark screenshots from direct browser verification are posted in a PR comment, not committed.",
        "No semantic-color exception marker is added.",
        "Typecheck passes",
        "Tests pass",
        "Verify in a browser using available browser tooling"
      ],
      "priority": 1,
      "passes": false,
      "latestVerification": "2026-08-23 18:45-18:47 -0700: package tests 56 files/293 tests, full UI tests 369 files/3098 tests, package and dashboard typechecks, UI lint, and the seven-root semantic guard passed. The required in-app browser availability check returned zero instances, so direct interaction and Factory Light/Dark screenshot evidence remain blocked.",
      "notes": "Implemented the palette-derived bg-scrim role and semantic disabled close treatment with focused package coverage. Components package tests (56 files, 291/291 tests) and package typecheck pass. Revalidated the full UI test suite (369 files, 3098 tests), UI typecheck, UI lint, and the seven-root semantic guard on 2026-08-23 at 12:52 -07:00. Retried the required browser verification at 13:12 -07:00, 13:23 -07:00, 13:25 -07:00, 13:27 -07:00, 13:32 -07:00, 13:36 -07:00, 13:45 -07:00, 18:38 -07:00, 18:40 -07:00, and 18:42 -07:00; the browser runtime returned no available instances after the prescribed troubleshooting and availability check, so direct keyboard/focus/palette verification and Factory Light/Dark screenshots remain pending. Do not mark passes true until that evidence is available."
    },
    {
      "id": "uicolor-color-guard-package-scope-002",
      "title": "Make graph node emphasis consume named roles",
      "description": "As a graph user, I want selected and error nodes to retain clear, consistent emphasis through centrally owned color roles so that package consumers do not depend on component-local alpha math.",
      "acceptanceCriteria": [
        "Selected graph-node shell and button treatments contain no local relative-color alpha expression and no ring-primary/30 utility; both consume named semantic role tokens owned by the package role layer.",
        "Error graph-node button treatment contains no ring-error/40 utility and consumes a named semantic error emphasis role.",
        "Focused component tests prove the classes/variables used for default, selected, error, disabled, and loading states and preserve existing ARIA and disabled-state outcomes.",
        "Selected and error states remain visually distinguishable under Factory Light and Factory Dark in direct browser verification, with no interaction or responsive-layout regression.",
        "No semantic-color exception marker is added.",
        "Typecheck passes",
        "Tests pass",
        "Verify in a browser using available browser tooling"
      ],
      "priority": 2,
      "passes": false,
      "notes": "Implemented package-owned graph emphasis roles and migrated selected/error shell and button treatments in commit 9d0a1780d. Focused graph/token assertions (14 tests), the full components package suite (56 files, 293 tests), package typecheck/build, Biome, and the package-focused semantic guard pass. Direct browser verification for selected/error palette rendering remains blocked because the in-app browser runtime reports no available instances; keep passes false until that evidence is available."
    },
    {
      "id": "uicolor-color-guard-package-scope-003",
      "title": "Enforce package source in the normal guard command",
      "description": "As a maintainer and package consumer, I want the standard semantic-color command to inspect published package source as well as dashboard source so that non-semantic color usage cannot ship through an unscanned workspace.",
      "acceptanceCriteria": [
        "With no override, one bun run check:semantic-colors invocation checks ui/src plus every existing ui/packages/*/src directory and reports violations using unambiguous root-relative paths with line and column.",
        "With AGENT_FACTORY_UI_SRC_DIR set, the command scans only the requested root and retains the current focused-run workflow.",
        "Focused tests prove that each supported root participates and that .test.ts, .test.tsx, .stories.tsx, generated/, testing/, stories/, and messages/ paths remain excluded relative to each root.",
        "A temporary bg-red-500/50 usage in ui/packages/components/src makes the standard command exit non-zero and name its file, line, and column; after exact restoration, the command exits zero. Both outputs are posted in a PR comment and the mutation is absent from the final diff.",
        "The clean normal invocation reports no violations across dashboard or package source.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": false,
      "notes": "Implemented in commit a226b72af. The default command now scans ui/src plus all seven existing package src roots; AGENT_FACTORY_UI_SRC_DIR remains focused single-root mode. Focused guard tests (6), clean seven-root output, UI typecheck, and Biome pass. A reversible package probe exited 1 with packages/components/src/semantic-color-guard-probe.ts:1:41 and bg-red-500/50, then was removed and the clean command passed. Keep passes false until the captured failure/clean evidence is posted in the PR comment; stories 001/002 still await unavailable browser evidence."
    },
    {
      "id": "uicolor-color-guard-package-scope-004",
      "title": "Keep foundation-token prohibition complete",
      "description": "As a design-system maintainer, I want every foundation color declared by the package styles to be forbidden at component call sites so that new foundation keys cannot silently bypass semantic role ownership.",
      "acceptanceCriteria": [
        "The focused test reads canonical package CSS declarations and accounts for all 28 distinct --color-af-foundation-* keys currently present, including keys repeated across palettes only once.",
        "Every declared foundation key has a matching forbidden consumer representation recognized by the guard, and the ten previously protected legacy alias names remain forbidden.",
        "A fixture proves that direct utility and var(...) consumption of representative foundation keys produces foundation-color-token violations with useful token and position diagnostics.",
        "Temporarily declaring a new --color-af-foundation-* key without adding its forbidden representation makes the focused test fail and name the missing key; removing the declaration restores a passing run. The failing and passing outputs go in a PR comment, never a commit.",
        "The test verifies the behavioral mapping between declared foundation tokens and guard rejection; it does not enforce unrelated file, route, registration, documentation-link, or asset inventories.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": false,
      "notes": "Implemented in commit d090c10bd. The policy now covers all 28 unique foundation keys declared by canonical package CSS, retains all ten legacy aliases, rejects direct utility and var(...) consumption with token/position diagnostics, and keeps the clean seven-root command green. A temporary --color-af-foundation-unlisted-probe caused the focused test to fail naming that key; exact restoration returned 9/9 tests to green. Keep passes false until the failure/restoration output is posted in a PR comment; stories 001/002 still await unavailable browser evidence and story 003 awaits its PR evidence."
    }
  ]
}
