### PR TITLE
fix(factory): pin new lanes to fetched origin main

### DIFF
--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -54,6 +54,15 @@ class RootStatusError(RuntimeError):
     """A root status inspection failure that belongs to the setup preflight."""
 
 
+class RootSyncResult(str):
+    """Describe root synchronization and its optional fresh remote baseline."""
+
+    def __new__(cls, message, fresh_origin_main_sha=None):
+        result = super().__new__(cls, message)
+        result.fresh_origin_main_sha = fresh_origin_main_sha
+        return result
+
+
 def raw_failure_details(error):
     """Return an exception's text without allowing rendering to raise again."""
     try:
@@ -884,24 +893,14 @@ def remote_main_sha(repo_root):
     return result.stdout.strip().split()[0]
 
 
-def stale_origin_main_sha(repo_root):
-    """Return local origin/main sha when the remote-tracking ref exists."""
-    if not origin_main_ref_exists(repo_root):
-        return None
-    result = run_git(
-        "rev-parse", "refs/remotes/origin/main",
-        cwd=repo_root, check=False,
-    )
-    if result.returncode != 0:
-        return None
-    return result.stdout.strip()
-
-
 def resolve_remote_main_sha(repo_root, fetch_succeeded):
-    """Resolve the best available origin/main sha for root sync."""
-    if fetch_succeeded:
-        return remote_main_sha(repo_root)
-    return stale_origin_main_sha(repo_root)
+    """Resolve origin/main only when the current fetch succeeded."""
+    if not fetch_succeeded:
+        return None
+    sha = remote_main_sha(repo_root)
+    if sha is None or not immutable_object_id(sha):
+        return None
+    return sha
 
 
 def can_fast_forward_main(repo_root, local_sha, remote_sha):
@@ -1090,14 +1089,21 @@ def _sync_main(repo_root):
     so clean-root checkouts can continue workspace setup from local state.
     Dirty roots skip root synchronization after fetch when a local or remote
     main ref can provide a safe start point for the requested lane.
-    Returns a human-readable outcome string for logging.
+    Returns a string-compatible result carrying any fresh origin/main SHA.
     """
+    fresh_origin_main_sha = None
+
+    def result(message):
+        return RootSyncResult(message, fresh_origin_main_sha)
+
     if not has_origin_remote(repo_root):
         entries = root_status_for_setup(repo_root)
         if local_main_ref_exists(repo_root):
             if entries:
-                return "skipped (dirty root; using local main without root sync)"
-            return "skipped (no origin remote)"
+                return result(
+                    "skipped (dirty root; using local main without root sync)"
+                )
+            return result("skipped (no origin remote)")
         if entries:
             raise DirtyRootError(dirty_root_diagnostic(repo_root, entries))
         raise RuntimeError(
@@ -1108,7 +1114,7 @@ def _sync_main(repo_root):
     fetch_succeeded = fetch_result.returncode == 0
     if not fetch_succeeded:
         if local_main_ref_exists(repo_root):
-            return (
+            return result(
                 "skipped (fetch failed: "
                 f"{command_failure_details(fetch_result)})"
             )
@@ -1122,64 +1128,61 @@ def _sync_main(repo_root):
             )
 
     remote_sha = resolve_remote_main_sha(repo_root, fetch_succeeded)
+    fresh_origin_main_sha = remote_sha
     entries = root_status_for_setup(repo_root)
     if entries:
         if remote_sha is not None:
-            return (
+            return result(
                 "skipped (dirty root; using origin/main "
                 f"{remote_sha[:8]} without root sync)"
             )
         if local_main_ref_exists(repo_root):
-            return "skipped (dirty root; using local main without root sync)"
+            return result(
+                "skipped (dirty root; using local main without root sync)"
+            )
         raise DirtyRootError(dirty_root_diagnostic(repo_root, entries))
 
     if remote_sha is None:
         if local_main_ref_exists(repo_root):
-            return "skipped (origin has no main branch)"
+            return result("skipped (origin has no main branch)")
         raise RuntimeError(
             "origin has no main branch and refs/heads/main is missing"
         )
 
     if not local_main_ref_exists(repo_root):
         run_git("update-ref", "refs/heads/main", remote_sha, cwd=repo_root)
-        return f"created refs/heads/main at {remote_sha[:8]}"
+        return result(f"created refs/heads/main at {remote_sha[:8]}")
 
     local_sha = run_git("rev-parse", "refs/heads/main", cwd=repo_root).stdout.strip()
     if local_sha == remote_sha:
         if current_branch(repo_root) == "main":
             verify_root_after_restore(repo_root, None)
-        return "already up to date"
+        return result("already up to date")
 
     if not can_fast_forward_main(repo_root, local_sha, remote_sha):
-        return "skipped (local main is not a fast-forward behind origin/main)"
+        return result(
+            "skipped (local main is not a fast-forward behind origin/main)"
+        )
 
     if current_branch(repo_root) == "main":
-        return _sync_checked_out_main_with_stash(repo_root, remote_sha)
+        return result(_sync_checked_out_main_with_stash(repo_root, remote_sha))
 
     run_git("update-ref", "refs/heads/main", remote_sha, cwd=repo_root)
-    return (
+    return result(
         f"fast-forwarded refs/heads/main to {remote_sha[:8]} "
         "(fetch-only; did not run git pull)"
     )
 
 
-def resolve_worktree_start_point(repo_root):
+def resolve_worktree_start_point(fresh_origin_main_sha):
     """Resolve the start point for brand-new lane branches.
 
-    Prefer the origin/main remote-tracking ref (freshly fetched by sync_main
-    just before worktree creation), so lanes never inherit unpushed local-main
-    commits when local main is ahead of origin/main. Fall back to local main
-    only when no origin/main ref is available (no origin remote, or origin has
-    no main branch).
+    Use only the immutable SHA captured by the current successful fetch. A
+    missing SHA means setup is using its existing local-main fallback; a stale
+    remote-tracking ref must never become a new lane's baseline.
     """
-    if origin_main_ref_exists(repo_root):
-        result = run_git(
-            "rev-parse", "refs/remotes/origin/main",
-            cwd=repo_root, check=False,
-        )
-        sha = result.stdout.strip()
-        if result.returncode == 0 and sha:
-            return sha
+    if fresh_origin_main_sha and immutable_object_id(fresh_origin_main_sha):
+        return fresh_origin_main_sha
     return "main"
 
 
@@ -1305,7 +1308,9 @@ def sync_reused_worktree_branch(repo_root, worktree_path, branch):
         restore_stashed_changes(worktree_path, snapshot_id, f"worktree branch {branch}")
 
 
-def create_or_reuse_worktree(repo_root, branch, worktree_path):
+def create_or_reuse_worktree(
+    repo_root, branch, worktree_path, fresh_origin_main_sha=None,
+):
     """Create a new worktree or reuse an existing one. Returns reused flag."""
     if worktree_path.exists() and worktree_is_valid(worktree_path):
         sync_outcome = sync_reused_worktree_branch(repo_root, worktree_path, branch)
@@ -1333,7 +1338,7 @@ def create_or_reuse_worktree(repo_root, branch, worktree_path):
     else:
         run_git(
             "worktree", "add", "-b", branch, str(worktree_path),
-            resolve_worktree_start_point(repo_root),
+            resolve_worktree_start_point(fresh_origin_main_sha),
             cwd=repo_root,
         )
 
@@ -1427,7 +1432,11 @@ def main():
 
     # Sync main and prune worktrees.
     try:
-        sync_outcome = sync_main(repo_root)
+        sync_result = sync_main(repo_root)
+        sync_outcome = str(sync_result)
+        fresh_origin_main_sha = getattr(
+            sync_result, "fresh_origin_main_sha", None,
+        )
         print(f"Root sync: {sync_outcome}", file=sys.stderr)
         prune_worktrees(repo_root)
     except (DirtyRootError, RootStatusError) as e:
@@ -1440,7 +1449,12 @@ def main():
     # Create or reuse worktree.
     worktree_dir = repo_root / ".claude" / "worktrees" / normalize_branch(branch)
     try:
-        reused = create_or_reuse_worktree(repo_root, branch, worktree_dir)
+        reused = create_or_reuse_worktree(
+            repo_root,
+            branch,
+            worktree_dir,
+            fresh_origin_main_sha,
+        )
     except Exception as e:  # noqa: BLE001 - CLI boundary must classify all failures
         print(
             format_stage_failure("Worktree preparation failed", e),

--- a/tests/factory/scripts/test_setup_workspace_worktree.py
+++ b/tests/factory/scripts/test_setup_workspace_worktree.py
@@ -282,6 +282,17 @@ class SetupWorkspaceWorktreeTest(unittest.TestCase):
             check=False,
         )
         self.assertNotEqual(ancestor_check.returncode, 0)
+        self.assertEqual(
+            git(
+                ["merge-base", "HEAD", "refs/remotes/origin/main"],
+                worktree_path,
+            ).stdout.strip(),
+            origin_main_sha,
+        )
+        self.assertEqual(
+            git(["rev-parse", f"refs/heads/{prd_name}"], local_repo).stdout.strip(),
+            origin_main_sha,
+        )
 
         # Local main must be untouched: the ahead commits stay on it.
         self.assertEqual(
@@ -292,9 +303,45 @@ class SetupWorkspaceWorktreeTest(unittest.TestCase):
     def test_resolve_worktree_start_point_falls_back_to_main_without_origin(self):
         init_local_repo(self.repo_path)
         self.assertEqual(
-            self.module.resolve_worktree_start_point(self.repo_path),
+            self.module.resolve_worktree_start_point(None),
             "main",
         )
+
+    def test_fetch_failure_with_stale_origin_main_uses_local_main(self):
+        local_repo = self.repo_path / "local"
+        setup_repo_with_local_main_ahead(local_repo, self.repo_path, ahead_commits=2)
+
+        stale_origin_main_sha = git(
+            ["rev-parse", "refs/remotes/origin/main"],
+            local_repo,
+        ).stdout.strip()
+        local_main_sha = git(
+            ["rev-parse", "refs/heads/main"],
+            local_repo,
+        ).stdout.strip()
+        self.assertNotEqual(local_main_sha, stale_origin_main_sha)
+
+        missing_remote = self.repo_path / "missing-remote.git"
+        git(["remote", "set-url", "origin", str(missing_remote)], local_repo)
+
+        prd_name = "fetch-failure-stale-origin-prd"
+        write_prd(local_repo, prd_name)
+
+        result = run_setup_workspace(local_repo, prd_name)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        payload = json.loads(result.stdout)
+        worktree_path = Path(payload["worktree"])
+        worktree_head = git(["rev-parse", "HEAD"], worktree_path).stdout.strip()
+        self.assertEqual(worktree_head, local_main_sha)
+        self.assertNotEqual(worktree_head, stale_origin_main_sha)
+        self.assertEqual(
+            git(["rev-parse", f"refs/heads/{prd_name}"], local_repo).stdout.strip(),
+            local_main_sha,
+        )
+        for index in range(2):
+            self.assertTrue((worktree_path / f"unpushed-{index}.txt").exists())
+        self.assertIn("fetch failed", result.stderr.lower())
 
     def test_copies_prd_json_and_optional_markdown(self):
         init_local_repo(self.repo_path)


### PR DESCRIPTION
{
  "project": "Setup Workspace Branches New Lanes from origin/main",
  "branchName": "fct-setup-branch-from-origin-main",
  "description": "Change the missing-lane creation behavior in factory/scripts/setup-workspace.py so a new lane branch starts at the immutable origin/main SHA obtained by the current successful fetch even when root local main is ahead or diverged. Preserve the local-main fallback when origin is absent or fetching fails, and preserve every existing root-sync, stash, branch-reuse, copy, and worktree-reuse behavior.",
  "context": {
    "customerAsk": "Ensure factory/scripts/setup-workspace.py creates a missing lane branch from the freshly fetched origin/main SHA regardless of whether local main is ahead or diverged. This lane exclusively owns factory/scripts/setup-workspace.py and its directly relevant tests under tests/factory/scripts/. It must not change root checkout synchronization, stash restoration, existing-branch handling, PRD or standing-rules copying, worktree reuse, or offline/fetch-failure behavior. It must not touch factory/factory.json, workstation AGENTS.md files, any Go package, pkg/services/models/, pkg/platform/metrics, the Factory Sessions session-read path, or tests/functional/sessions/lifecycle/.",
    "problem": "sync_main() correctly refuses to rewrite local main when that ref is ahead of or diverged from origin/main, protecting local work. The missing-branch arm of create_or_reuse_worktree() can nevertheless start from unchanged local main, causing local-only commits to enter every new lane. On 2026-08-20, affected lane PRs inherited 18 unrelated commits, approximately 265 unrelated changed files, and five unrelated failing required checks; two otherwise complete lanes exhausted their review visit caps. GitHub MERGEABLE means only that there are no conflicts and does not prove that a branch is current with main, so PR state cannot reliably detect the bad branch point before CI falsely attributes another lane's failures.",
    "solution": "Keep root synchronization and new-lane start-point selection separate. In the main() flow, retain whether the existing best-effort fetch obtained a current origin/main commit and pass that immutable SHA only to the missing-branch creation path in create_or_reuse_worktree(). If the current fetch does not produce a remote SHA because origin is absent or fetch fails, use local main under the existing fallback rules, even if a stale refs/remotes/origin/main exists. Existing local or remote lane branches and valid reused worktrees must bypass the new start-point choice. Do not add, remove, or modify any git stash operation: the stash stack is shared across roughly 257 live worktrees and a stray stash operation can destroy other lanes' uncommitted work. The relevant existing symbols are main(), sync_main(), _sync_main(), create_or_reuse_worktree(), stash_local_changes(), and restore_stashed_changes(); only the explicit data flow needed to choose the missing-branch start commit is in scope. Direct regression evidence belongs in tests/factory/scripts/ and must use real disposable Git repositories rather than source inventories or mocks of the resulting commit graph. Delivery constraints: rebase onto origin/main before the final push; open one PR based directly on main, not a stacked chain; never hand-merge generated files; put CI-run evidence in a PR comment and never a commit. Backend Lint and Verification Policy are the only required checks. localai-backend-artifacts fails on main, is not required, and is out of scope. Backend Lint is a counted drift ratchet, so use verdict lines and observed deltas rather than a raw target-level FAIL."
  },
  "acceptanceCriteria": [
    "In a disposable repository where local main is at least one commit ahead of origin/main, setup for a missing lane branch succeeds; the new worktree HEAD and branch ref equal the immutable origin/main SHA obtained by the current successful fetch; git merge-base HEAD origin/main returns that SHA; no local-only commit is an ancestor of the lane branch; and root refs/heads/main remains at its original ahead commit.",
    "With no origin remote, a missing lane branch continues to start from local main. When the current fetch fails, the existing permitted local-main fallback remains in effect, including when a stale refs/remotes/origin/main exists; setup neither uses that stale ref nor fails solely because no fresh remote SHA is available.",
    "Root checkout synchronization, dirty-root preservation, stash/snapshot restoration, existing local and remote lane-branch handling, valid worktree reuse, PRD copying, and standing-rules copying retain their current observable behavior. No git stash invocation or related stash-stack behavior is added, removed, or modified; the stack is shared by roughly 257 live worktrees.",
    "Scope is limited to factory/scripts/setup-workspace.py and directly relevant tests under tests/factory/scripts/. Do not touch factory/factory.json, workstation AGENTS.md files, any Go package, pkg/services/models/, pkg/platform/metrics, the Factory Sessions session-read path, tests/functional/sessions/lifecycle/, or unrelated setup behavior.",
    "Runtime-proof classification: applicable because this lane changes the setup CLI's runtime lifecycle and the Git history created for a new worktree. Compile/build-check the real final delivered Python artifact, for example with python -m py_compile factory/scripts/setup-workspace.py, then invoke that exact final script end to end against disposable Git repositories for both the ahead-local-main/current-fetch case and the no-origin or fetch-failure fallback case. Record the verbatim commands and output in a PR comment. Green tests, an inspected diff, or implementer assertions alone do not satisfy this proof.",
    "Quality gate: Typecheck passes; focused setup-workspace tests and the existing setup-workspace suite pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Backend Lint is a counted drift ratchet, so evaluate verdict lines and observed deltas rather than treating a raw target-level FAIL as a new violation.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. Before that final push, implementation rebases onto origin/main, keeps the single PR based directly on main, and marks every prd.json item passes:true; review evaluates the required Backend Lint and Verification Policy checks and does not treat the non-required localai-backend-artifacts failure on main as lane work."
  ],
  "userStories": [
    {
      "id": "fct-setup-branch-from-origin-main-001",
      "title": "Create missing lanes from the correct baseline",
      "description": "As a factory operator, I want a missing lane branch to use the freshly fetched remote-main baseline without rewriting local main so unrelated local commits cannot contaminate the lane while offline setup remains available.",
      "acceptanceCriteria": [
        "Given a real temporary Git remote and root repository where local main has at least two unpushed commits beyond origin/main, invoking the final factory/scripts/setup-workspace.py for a missing PRD name exits successfully and creates the requested worktree.",
        "The created worktree HEAD and lane branch ref equal the immutable origin/main SHA obtained by the current successful fetch, and git merge-base HEAD origin/main returns that same SHA.",
        "Every local-only commit is absent from the lane branch ancestry and its files are absent from the worktree, while refs/heads/main in the root repository remains at its original ahead commit.",
        "A no-origin fixture still creates the missing lane from local main; a current-fetch-failure fixture, including one with a stale refs/remotes/origin/main, uses the existing local-main fallback instead of the stale ref and does not fail solely because the fetch failed.",
        "The start-point choice applies only when create_or_reuse_worktree() creates a branch that exists neither locally nor as origin/<lane>. Existing local lane branches, existing remote lane branches, and valid reused worktrees retain current behavior.",
        "sync_main(), _sync_main(), dirty-root handling, stash_local_changes(), restore_stashed_changes(), PRD and standing-rules copying, and worktree-reuse semantics remain behaviorally unchanged. No git stash usage is added or modified because roughly 257 live worktrees share the stack. If an unavoidable existing-stash touch is discovered, the PR body explicitly states the reason before review.",
        "Focused tests under tests/factory/scripts/ use real disposable repositories and directly assert commit IDs, merge base, ancestry, root-main preservation, successful no-origin fallback, and successful current-fetch-failure fallback; mocks or source-inventory assertions do not substitute for the resulting Git graph.",
        "Runtime-proof classification: applicable because this story changes the setup CLI's runtime lifecycle. Compile/build-check the real final delivered factory/scripts/setup-workspace.py, then invoke that exact script end to end in disposable repositories for the ahead-local-main/current-fetch case and the no-origin or fetch-failure fallback case. Record the verbatim commands and output in a PR comment; passing tests, a diff, or implementer assertions alone are insufficient.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}
