### PR TITLE
require-validation-declarations-across-ideafy-plan-and-review

### DIFF
--- a/docs/internal/standards/code/general-backend-standards.md
+++ b/docs/internal/standards/code/general-backend-standards.md
@@ -204,6 +204,7 @@ The expected testing layers are:
 - functional tests for user-visible or system-visible flows across subsystem boundaries
 - stress or race-oriented tests for concurrency, throughput, resource exhaustion, and long-running behavior
 - contract tests for schema alignment, generated artifacts, and public surface guarantees
+- asset conformance tests for declared external artifacts, pinned dependencies, and published locations
 
 Rules:
 
@@ -228,6 +229,11 @@ Rules:
 - External effects **MUST** be replaced only through `edges.Edges`. Functional
   tests **MUST** prefer `ProviderCommandRunner` and other command-runner edge
   mocks over custom in-process provider fakes.
+- Asset conformance tests **MUST** read the real declared artifact. The
+  `edges.Edges` substitution rule does not apply to an asset conformance test. An
+  asset conformance test **MUST** fail when a declared artifact is absent,
+  unresolvable, or smaller than its documented minimum size. A hermetic test
+  **MUST NOT** be cited as evidence that a real pinned dependency is intact.
 - Functional tests **MUST** prefer mocked Codex or another real
   inference-provider variant through the command-runner edge and sanitized
   goldens over `--with-mock-workers` / `MockWorkers`, except for cells under

--- a/factory/workstations/ideafy/AGENTS.md
+++ b/factory/workstations/ideafy/AGENTS.md
@@ -234,6 +234,32 @@ PRD with behavioral acceptance criteria.
 
 The Plan should be generally verbose enough such that the model won't screw up your intentions. 
 
+Every idea MUST carry an explicit validation declaration. The plan workstation
+inherits this declaration; it does not invent one.
+
+State, in the idea payload:
+
+1. the observable behavior that proves the work functions, in customer terms:
+   a command and its expected output, an emitted event, a readiness state, or a
+   rendered surface
+2. how that behavior will be observed: runtime proof against a real built
+   artifact, an asset conformance check against a real declared artifact, or an
+   automated test
+3. when no runtime-observable behavior exists, the words "runtime proof not
+   applicable" and a one-line reason
+
+Do not accept "compiles", "typechecks", "tests pass", or "the diff is correct"
+as a validation declaration. Those describe the change, not the behavior.
+
+When an idea depends on an external artifact, a downloaded asset, a pinned
+binary, or a network dependency, the declaration MUST name that dependency and
+MUST state that the real dependency is exercised. Do not let a substitute stand
+in for a real artifact the idea claims to reach.
+
+Order ideas by failure order when several defects sit on one path. A defect
+downstream of another defect cannot be observed until the upstream defect is
+fixed, so an idea chartered against it cannot produce its validation evidence.
+
 ### Work Batch Guidance
 
 Prefer batches that move forward in vertical slices:

--- a/factory/workstations/plan/AGENTS.md
+++ b/factory/workstations/plan/AGENTS.md
@@ -88,6 +88,13 @@ so the last implementation iteration owns the proof or the explicit
 not-applicable reason. Do not weaken, defer, or replace this final-story
 criterion with a structural check such as file presence, typecheck, or tests.
 
+Do not write two criteria that disagree. A criterion may state that the lane
+reaches, pulls, or invokes a real external artifact. When a criterion states
+this, no other criterion in the same plan may exempt that artifact from its
+proof. Do not describe that proof as "requiring no real network download" or as
+"replacing the backend only through `edges.Edges`". Write the real-artifact
+check as a separate asset conformance criterion instead.
+
 
 The markdown PRD should include, when relevant:
 - context with customer ask, concrete problem, and high-level solution

--- a/factory/workstations/review/AGENTS.md
+++ b/factory/workstations/review/AGENTS.md
@@ -89,6 +89,17 @@ If the change involves modification to the website, you should use the playwrigh
   comment at most once and stay silent on later holds for the same flake. Never
   demand code changes for a baseline flake in a package the diff does not touch.
 
+### Step 2.1a - Reject a plan that disagrees with itself
+
+1. Read the plan acceptance criteria.
+2. Find every criterion that says the lane reaches, pulls, or invokes a real
+   external artifact, backend, model, or pinned dependency.
+3. Find every criterion that describes the proof for that same behavior as a
+   substitute, a controlled response, or a test requiring no real download.
+4. When both apply to the same behavior, respond BLOCKING.
+5. Quote both criteria verbatim, side by side, in the review comment.
+6. Decide this by the two quoted sentences, not by judgement.
+
 ### Step 2.2 — Independently verify conditional runtime proof
 
 Before Step 3, independently classify the lane and record which case applies:


### PR DESCRIPTION
{
  "project": "Require Validation Declarations Across Ideafy, Plan, and Review",
  "branchName": "require-validation-declarations-across-ideafy-plan-and-review",
  "description": "Close the governance gap that allowed green pull requests to ship unusable declared artifacts by adding an asset conformance test layer, forbidding self-contradicting real-artifact proof in plans, requiring deterministic blocking review, and making ideafy declare how each idea will be proven. The implementation is limited to four exact additive documentation edits and requires no daemon restart.",
  "context": {
    "customerAsk": "Add the supplied asset-conformance, plan-consistency, review-rejection, and validation-declaration rules verbatim to docs/internal/standards/code/general-backend-standards.md, factory/workstations/plan/AGENTS.md, factory/workstations/review/AGENTS.md, and factory/workstations/ideafy/AGENTS.md only. Preserve surrounding prose and headings, leave factory/factory.json unchanged, do not restart the daemon, record the requested validation evidence, and carry the pull request through the implementation/review delivery loop to merge.",
    "problem": "The backend standards have no test layer that reads real declared external data, while the edges.Edges substitution rule can be misapplied to artifact integrity. Ideafy does not require a validation declaration, plan can pair a real-artifact claim with proof that avoids the real dependency, and review lacks a deterministic rejection rule. This gap allowed six green local-model capability pull requests to merge even though production pulls remained broken.",
    "solution": "Add four exact governance blocks: define asset conformance and its real-artifact rules in backend standards; forbid contradictory proof criteria in plan; require review to block and quote conflicting criteria; and require ideafy to supply observable, dependency-aware validation declarations ordered by failure order. Make no code, runtime, CI, verification-policy, daemon-configuration, or unrelated prompt changes."
  },
  "acceptanceCriteria": [
    "The four owned documents contain only the specified additive blocks verbatim, at their stated anchors, with every existing heading and all surrounding prose preserved.",
    "git diff --stat shows exactly docs/internal/standards/code/general-backend-standards.md, factory/workstations/plan/AGENTS.md, factory/workstations/review/AGENTS.md, and factory/workstations/ideafy/AGENTS.md changed; factory/factory.json, factory/workstations/process/AGENTS.md, scripts/verification-policy.mjs, Go files, UI files, and all other files are unchanged.",
    "you factory config validate factory/factory.json passes with verbatim output recorded, and git diff --exit-code factory/factory.json confirms the daemon configuration is unchanged; no daemon restart is requested. This configuration check is scope validation, not runtime proof of delivered product behavior.",
    "Runtime-proof classification: NOT APPLICABLE. Reason: this lane changes prompt and standards documents only and has no runtime-observable product behavior. Do not invent runtime proof, build a binary, or treat tests, typecheck, compilation, or diff inspection as runtime proof.",
    "The PR body quotes all four added blocks verbatim and states the runtime-proof classification and reason exactly; requested validation outputs and exact four-file diff evidence are posted, while CI-run evidence goes in a PR comment and never in a commit.",
    "Quality gates pass: Typecheck passes; required tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. No meta-tests, CI jobs, or verification-policy changes are introduced.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "require-validation-declarations-across-ideafy-plan-and-review-001",
      "title": "Establish the asset conformance test layer",
      "description": "As a backend maintainer, I want the testing standard to distinguish real declared artifacts from replaceable external effects so a hermetic substitute cannot prove that a pinned dependency is intact.",
      "acceptanceCriteria": [
        "Immediately after the existing contract-test bullet, section 7 contains verbatim: - asset conformance tests for declared external artifacts, pinned dependencies, and published locations",
        "Immediately after the complete edges.Edges and ProviderCommandRunner rule, section 7 contains verbatim: - Asset conformance tests **MUST** read the real declared artifact. The\n`edges.Edges` substitution rule does not apply to an asset conformance test. An\nasset conformance test **MUST** fail when a declared artifact is absent,\nunresolvable, or smaller than its documented minimum size. A hermetic test\n**MUST NOT** be cited as evidence that a real pinned dependency is intact.",
        "The resulting standard observably distinguishes hermetic functional-test substitution from real declared-artifact conformance and requires failure for absent, unresolvable, or undersized artifacts.",
        "No existing section heading, functional-test rule, or surrounding prose changes.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "require-validation-declarations-across-ideafy-plan-and-review-002",
      "title": "Prevent contradictory proof criteria during planning",
      "description": "As a planner, I want real-artifact claims to retain real-artifact proof so one plan cannot both require and exempt the dependency it claims to exercise.",
      "acceptanceCriteria": [
        "Immediately after the Conditional runtime-proof planning contract paragraph ending with file presence, typecheck, or tests., the plan workstation contains verbatim: Do not write two criteria that disagree. A criterion may state that the lane\nreaches, pulls, or invokes a real external artifact. When a criterion states\nthis, no other criterion in the same plan may exempt that artifact from its\nproof. Do not describe that proof as \"requiring no real network download\" or as\n\"replacing the backend only through `edges.Edges`\". Write the real-artifact\ncheck as a separate asset conformance criterion instead.",
        "A plan that says a lane reaches, pulls, or invokes a real external artifact cannot exempt that same artifact through a no-download or edges.Edges substitution criterion.",
        "The plan contract directs the real-artifact check into a separate asset conformance criterion.",
        "No existing heading or surrounding plan-workstation prose changes.",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added the exact contradiction-proof planning rule immediately after the conditional runtime-proof contract; make typecheck passed."
    },
    {
      "id": "require-validation-declarations-across-ideafy-plan-and-review-003",
      "title": "Make review block self-contradicting plans deterministically",
      "description": "As a reviewer, I want a sentence-level blocking rule for contradictory real-artifact proof so approval cannot depend on subjective interpretation.",
      "acceptanceCriteria": [
        "Immediately before the existing Step 2.2 heading, the review workstation contains verbatim: ### Step 2.1a - Reject a plan that disagrees with itself\n\n1. Read the plan acceptance criteria.\n2. Find every criterion that says the lane reaches, pulls, or invokes a real\n   external artifact, backend, model, or pinned dependency.\n3. Find every criterion that describes the proof for that same behavior as a\n   substitute, a controlled response, or a test requiring no real download.\n4. When both apply to the same behavior, respond BLOCKING.\n5. Quote both criteria verbatim, side by side, in the review comment.\n6. Decide this by the two quoted sentences, not by judgement.",
        "Reviewers are instructed to respond BLOCKING when one criterion claims a real artifact, backend, model, or pinned dependency is reached while another proves the same behavior with a substitute, controlled response, or no-real-download test.",
        "The review comment must quote both conflicting criteria verbatim side by side and decide from those sentences rather than judgement.",
        "No existing review heading, step numbering, or surrounding prose changes.",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added the exact sentence-level blocking review rule immediately before Step 2.2; make typecheck and git diff --check passed."
    },
    {
      "id": "require-validation-declarations-across-ideafy-plan-and-review-004",
      "title": "Require ideas to declare valid proof and deliver the bounded change",
      "description": "As an operator, I want every idea to declare its observable proof before planning so downstream plan and review stages inherit a concrete, dependency-aware validation contract.",
      "acceptanceCriteria": [
        "Immediately after the paragraph ending The Plan should be generally verbose enough such that the model won't screw up your intentions., the ideafy workstation contains verbatim: Every idea MUST carry an explicit validation declaration. The plan workstation\ninherits this declaration; it does not invent one.\n\nState, in the idea payload:\n\n1. the observable behavior that proves the work functions, in customer terms:\n   a command and its expected output, an emitted event, a readiness state, or a\n   rendered surface\n2. how that behavior will be observed: runtime proof against a real built\n   artifact, an asset conformance check against a real declared artifact, or an\n   automated test\n3. when no runtime-observable behavior exists, the words \"runtime proof not\n   applicable\" and a one-line reason\n\nDo not accept \"compiles\", \"typechecks\", \"tests pass\", or \"the diff is correct\"\nas a validation declaration. Those describe the change, not the behavior.\n\nWhen an idea depends on an external artifact, a downloaded asset, a pinned\nbinary, or a network dependency, the declaration MUST name that dependency and\nMUST state that the real dependency is exercised. Do not let a substitute stand\nin for a real artifact the idea claims to reach.\n\nOrder ideas by failure order when several defects sit on one path. A defect\ndownstream of another defect cannot be observed until the upstream defect is\nfixed, so an idea chartered against it cannot produce its validation evidence.",
        "Every idea must name the customer-observable behavior, how it will be observed, and either the real external dependency it exercises or the exact not-applicable runtime-proof classification and reason.",
        "Compilation, typecheck, passing tests, and diff correctness are rejected as validation declarations, and ideas with several defects on one path are ordered by failure order.",
        "No existing ideafy heading or surrounding prose changes.",
        "The delivered diff contains exactly the four owned documentation files; you factory config validate factory/factory.json passes; git diff --exit-code factory/factory.json confirms unchanged daemon configuration; the PR body contains the four verbatim additions plus the required not-applicable statement; no daemon restart is requested.",
        "Runtime-proof classification: NOT APPLICABLE. Reason: this lane changes prompt and standards documents only and has no runtime-observable product behavior. Do not invent runtime proof, build a binary, or replace this classification with file presence, typecheck, tests, compilation, or diff inspection.",
        "Typecheck passes"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Added the exact validation-declaration contract immediately after the ideafy plan-verbosity paragraph; make typecheck and factory config validation passed."
    }
  ]
}

## Implementation validation evidence

Runtime-proof classification: NOT APPLICABLE. Reason: this lane changes prompt and standards documents only and has no runtime-observable product behavior. Do not invent runtime proof, build a binary, or treat tests, typecheck, compilation, or diff inspection as runtime proof.

- `make typecheck`: passed.
- `make verify-fast`: passed. Dashboard typecheck, MCP contract boundary, 369 Vitest files / 3,100 tests, and the short Go suite passed; existing platform-dependent skips remained skips.
- `you factory config validate factory/factory.json`: passed. Verbatim output: `Factory validation passed.`
- `git diff --exit-code factory/factory.json`: passed; `factory/factory.json` is unchanged.
- No daemon restart was requested.

Final diff evidence against `origin/main`:

```text
 docs/internal/standards/code/general-backend-standards.md |  6 +++++
 factory/workstations/ideafy/AGENTS.md                   | 26 ++++++++++++++++++++++
 factory/workstations/plan/AGENTS.md                     |  7 ++++++
 factory/workstations/review/AGENTS.md                   | 11 +++++++++
 4 files changed, 50 insertions(+)
```

Exact changed paths:

```text
docs/internal/standards/code/general-backend-standards.md
factory/workstations/ideafy/AGENTS.md
factory/workstations/plan/AGENTS.md
factory/workstations/review/AGENTS.md
```

## Verbatim added blocks

### Backend standards

```text
- asset conformance tests for declared external artifacts, pinned dependencies, and published locations

- Asset conformance tests **MUST** read the real declared artifact. The
  `edges.Edges` substitution rule does not apply to an asset conformance test. An
  asset conformance test **MUST** fail when a declared artifact is absent,
  unresolvable, or smaller than its documented minimum size. A hermetic test
  **MUST NOT** be cited as evidence that a real pinned dependency is intact.
```

### Plan workstation

```text
Do not write two criteria that disagree. A criterion may state that the lane
reaches, pulls, or invokes a real external artifact. When a criterion states
this, no other criterion in the same plan may exempt that artifact from its
proof. Do not describe that proof as "requiring no real network download" or as
"replacing the backend only through `edges.Edges`". Write the real-artifact
check as a separate asset conformance criterion instead.
```

### Review workstation

```text
### Step 2.1a - Reject a plan that disagrees with itself

1. Read the plan acceptance criteria.
2. Find every criterion that says the lane reaches, pulls, or invokes a real
   external artifact, backend, model, or pinned dependency.
3. Find every criterion that describes the proof for that same behavior as a
   substitute, a controlled response, or a test requiring no real download.
4. When both apply to the same behavior, respond BLOCKING.
5. Quote both criteria verbatim, side by side, in the review comment.
6. Decide this by the two quoted sentences, not by judgement.
```

### Ideafy workstation

```text
Every idea MUST carry an explicit validation declaration. The plan workstation
inherits this declaration; it does not invent one.

State, in the idea payload:

1. the observable behavior that proves the work functions, in customer terms:
   a command and its expected output, an emitted event, a readiness state, or a
   rendered surface
2. how that behavior will be observed: runtime proof against a real built
   artifact, an asset conformance check against a real declared artifact, or an
   automated test
3. when no runtime-observable behavior exists, the words "runtime proof not
   applicable" and a one-line reason

Do not accept "compiles", "typechecks", "tests pass", or "the diff is correct"
as a validation declaration. Those describe the change, not the behavior.

When an idea depends on an external artifact, a downloaded asset, a pinned
binary, or a network dependency, the declaration MUST name that dependency and
MUST state that the real dependency is exercised. Do not let a substitute stand
in for a real artifact the idea claims to reach.

Order ideas by failure order when several defects sit on one path. A defect
downstream of another defect cannot be observed until the upstream defect is
fixed, so an idea chartered against it cannot produce its validation evidence.
```

CI-run evidence belongs in a PR comment and will not be committed.