### PR TITLE
models-pull-fails-because-resolve-runtime-cache-ignores-prepared-assets

### DIFF
--- a/pkg/services/models/internal/local/managed_runtime.go
+++ b/pkg/services/models/internal/local/managed_runtime.go
@@ -218,6 +218,62 @@ func ManagedRuntimeReadinessForFactoryContext(
 	return detail.ManagedRuntime, err
 }
 
+// ManagedRuntimeReadinessForEffectiveDefinitionContext applies current cache
+// facts to a catalog entry that came from an effective definition rather than
+// a Factory worker/resource projection. Built-in and operator model entries
+// use this path when a catalog scope has no authored runtime resources.
+func ManagedRuntimeReadinessForEffectiveDefinitionContext(
+	ctx context.Context,
+	baseline models.Runtime,
+	runtimeCfg *models.RuntimeConfig,
+	modelName string,
+	runtimeCacheInspector RuntimeCacheInspector,
+) (models.Runtime, error) {
+	if err := ctx.Err(); err != nil {
+		return models.Runtime{}, err
+	}
+	if runtimeCacheInspector == nil {
+		return baseline.Clone(), nil
+	}
+	inspection, err := runtimeCacheInspector.InspectRuntimeCache(ctx, runtimeCfg, modelName)
+	if err != nil {
+		return models.Runtime{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return models.Runtime{}, err
+	}
+	return projectManagedRuntimeCacheInspection(baseline, inspection), nil
+}
+
+func projectManagedRuntimeCacheInspection(
+	baseline models.Runtime,
+	inspection RuntimeCacheInspection,
+) models.Runtime {
+	projection := buildManagedRuntimeProjection(managedRuntimeProjection{
+		summary: managedRuntimeSummary{
+			name:       baseline.Identity,
+			locality:   managedruntime.Locality(baseline.Locality),
+			readiness:  managedruntime.ReadinessState(baseline.ReadinessState),
+			lifecycle:  managedruntime.LifecycleState(baseline.LifecycleState),
+			operations: baseline.SupportedOperations,
+		},
+		baseDiagnostics: baseline.Diagnostics,
+		cacheInspection: &inspection,
+		includeInspect:  true,
+	})
+	return models.Runtime{
+		Identity:            projection.Identity,
+		ReadinessState:      projection.ReadinessState,
+		LifecycleState:      projection.LifecycleState,
+		Locality:            projection.Locality,
+		Revision:            projection.Revision,
+		CachePath:           projection.CachePath,
+		CacheBytes:          projection.CacheBytes,
+		SupportedOperations: projection.SupportedOperations,
+		Diagnostics:         projection.Diagnostics,
+	}
+}
+
 type fixedRuntimeCacheInspector struct {
 	inspection RuntimeCacheInspection
 }

--- a/pkg/services/models/internal/local/puller.go
+++ b/pkg/services/models/internal/local/puller.go
@@ -125,7 +125,15 @@ func (p *assetPuller) InspectRuntimeCache(ctx context.Context, runtimeCfg *model
 		return RuntimeCacheInspection{}, fmt.Errorf("runtime config is not available")
 	}
 	if modelScopedResource(runtimeCfg, modelName) == nil {
-		return RuntimeCacheInspection{}, nil
+		// Factory workers without an explicit model resource retain the legacy
+		// catalog-only behavior. Effective built-in definitions, which are
+		// absent from RuntimeConfig, still need the durable generic cache probe.
+		if factoryModelWorker(runtimeCfg, modelName) != nil {
+			return RuntimeCacheInspection{}, nil
+		}
+		if _, builtIn := (models.BuiltInCatalog{}).ModelDefinitionFor(strings.ToLower(strings.TrimSpace(modelName))); !builtIn {
+			return RuntimeCacheInspection{}, nil
+		}
 	}
 	scope, err := p.currentScope()
 	if err != nil {
@@ -175,6 +183,20 @@ func (p *assetPuller) currentScope() (models.RuntimeScopeRef, error) {
 	}
 	p.scope = scope
 	return scope, nil
+}
+
+func factoryModelWorker(runtimeCfg *models.RuntimeConfig, modelName string) *models.RuntimeWorker {
+	if runtimeCfg == nil {
+		return nil
+	}
+	key := strings.ToUpper(strings.TrimSpace(modelName))
+	for index := range runtimeCfg.Workers {
+		worker := &runtimeCfg.Workers[index]
+		if strings.ToUpper(strings.TrimSpace(worker.Model)) == key {
+			return worker
+		}
+	}
+	return nil
 }
 
 func pullResultFromAssets(result models.PrepareModelAssetsResult) models.PullResult {

--- a/pkg/services/models/internal/services/assets/internal/service/generic.go
+++ b/pkg/services/models/internal/services/assets/internal/service/generic.go
@@ -126,28 +126,41 @@ func (s *service) prepareGenericAssets(
 	if err := genericPreparationError(modelErr, backendErr); err != nil {
 		return genericAssetFailureResult(plan.source, modelResult, backendResult), err
 	}
+	var runtimeInspection scopedassets.RuntimeCacheInspection
+	if modelResult.snapshotPath != "" {
+		runtimeInspection, err = s.publishGenericRuntimeCache(
+			ctx, plan.cacheDirectory, request.Name, plan.source, modelResult,
+		)
+		if err != nil {
+			return genericAssetFailureResult(plan.source, modelResult, backendResult), err
+		}
+	}
 	if modelResult.snapshotPath != "" || backendResult.snapshotPath != "" {
-		s.rememberPreparedRuntime(request.Scope, request.Name, scopedassets.RuntimeCacheInspection{
-			Supported:             true,
-			Installed:             modelResult.snapshotPath != "",
-			ManifestPresent:       true,
-			ManifestValid:         true,
-			ExpectedArtifacts:     append([]models.AssetRequirement(nil), expected...),
-			ObservedArtifacts:     append([]models.AssetArtifact(nil), append(modelResult.artifacts, backendResult.artifacts...)...),
-			IntegrityVerified:     true,
-			Revision:              plan.source.revision,
-			CachePath:             modelResult.snapshotPath,
-			InstalledFileCount:    len(modelResult.artifacts),
-			BackendRequired:       len(plan.backendRequirements) > 0,
-			BackendCachePath:      backendResult.snapshotPath,
-			BackendRevision:       plan.backendSource.revision,
-			BackendInstalledFiles: len(backendResult.artifacts),
-		})
+		if !runtimeInspection.Supported {
+			runtimeInspection = scopedassets.RuntimeCacheInspection{
+				Supported:          true,
+				Installed:          modelResult.snapshotPath != "",
+				ManifestPresent:    modelResult.snapshotPath != "",
+				ManifestValid:      modelResult.snapshotPath != "",
+				ExpectedArtifacts:  append([]models.AssetRequirement(nil), expected...),
+				ObservedArtifacts:  append([]models.AssetArtifact(nil), append(modelResult.artifacts, backendResult.artifacts...)...),
+				IntegrityVerified:  modelResult.snapshotPath != "",
+				Revision:           plan.source.revision,
+				CachePath:          modelResult.snapshotPath,
+				InstalledFileCount: len(modelResult.artifacts),
+			}
+		}
+		runtimeInspection.BackendRequired = len(plan.backendRequirements) > 0
+		runtimeInspection.BackendCachePath = backendResult.snapshotPath
+		runtimeInspection.BackendRevision = plan.backendSource.revision
+		runtimeInspection.BackendInstalledFiles = len(backendResult.artifacts)
+		s.rememberPreparedRuntime(request.Scope, request.Name, runtimeInspection)
 	}
 	return genericAssetResult(plan.source, modelResult, backendResult), nil
 }
 
 type genericPreparationPlan struct {
+	cacheDirectory      string
 	source              genericSource
 	modelRequirements   []genericArtifact
 	modelRoots          []string
@@ -192,6 +205,7 @@ func (s *service) genericPreparationPlan(
 	}
 	backendSource.modelName = request.Name
 	return genericPreparationPlan{
+		cacheDirectory:      scope.CacheDirectory,
 		source:              source,
 		modelRequirements:   modelRequirements,
 		modelRoots:          modelRoots,

--- a/pkg/services/models/internal/services/assets/internal/service/generic_runtime.go
+++ b/pkg/services/models/internal/services/assets/internal/service/generic_runtime.go
@@ -1,0 +1,543 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	assets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
+)
+
+// publishGenericRuntimeCache promotes a verified content-addressed model
+// snapshot into the managed runtime layout. The content snapshot remains the
+// reusable source cache; the managed layout is the durable contract consumed
+// by runtime resolution and inspection.
+func (s *service) publishGenericRuntimeCache(
+	ctx context.Context,
+	cacheDirectory string,
+	modelName string,
+	source genericSource,
+	result genericCacheResult,
+) (assets.RuntimeCacheInspection, error) {
+	if strings.TrimSpace(modelName) == "" || result.snapshotPath == "" {
+		return assets.RuntimeCacheInspection{}, nil
+	}
+	metadataFiles, err := genericRuntimeMetadataFiles(result.artifacts)
+	if err != nil {
+		return assets.RuntimeCacheInspection{}, err
+	}
+	if len(metadataFiles) != len(result.paths) {
+		return assets.RuntimeCacheInspection{}, fmt.Errorf(
+			"%w: generic runtime snapshot is incomplete",
+			models.ErrAssetPreparationInterrupted,
+		)
+	}
+	if err := assetContextError(ctx); err != nil {
+		return assets.RuntimeCacheInspection{}, err
+	}
+
+	publication, err := s.newGenericRuntimePublication(
+		cacheDirectory, canonicalModelName(modelName), genericRuntimeRevision(source, result.artifacts),
+	)
+	if err != nil {
+		return assets.RuntimeCacheInspection{}, err
+	}
+	defer func() {
+		publication.rollback(s)
+	}()
+	if err := s.stageGenericRuntimePublication(ctx, publication, result, metadataFiles); err != nil {
+		return assets.RuntimeCacheInspection{}, err
+	}
+	if err := s.commitGenericRuntimePublication(ctx, &publication); err != nil {
+		return assets.RuntimeCacheInspection{}, err
+	}
+	publication.committed = true
+	publication.removeBackups(s)
+
+	inspection := genericRuntimeInspectionFromArtifacts(
+		publication.finalPath, publication.revision, metadataFiles, result.artifacts,
+	)
+	return inspection, nil
+}
+
+type genericRuntimePublication struct {
+	modelName         string
+	revision          string
+	finalPath         string
+	stagePath         string
+	metadataPath      string
+	metadataStagePath string
+	finalBackup       string
+	metadataBackup    string
+	hadFinal          bool
+	hadMetadata       bool
+	finalPromoted     bool
+	committed         bool
+}
+
+func (s *service) newGenericRuntimePublication(
+	cacheDirectory, modelName, revision string,
+) (genericRuntimePublication, error) {
+	root, err := s.modelCacheRoot(cacheDirectory, modelName)
+	if err != nil {
+		return genericRuntimePublication{}, err
+	}
+	publication := genericRuntimePublication{
+		modelName:         modelName,
+		revision:          revision,
+		finalPath:         filepath.Join(root, revision),
+		stagePath:         filepath.Join(root, revision+".partial"),
+		metadataPath:      filepath.Join(root, metadataFileName),
+		metadataStagePath: filepath.Join(root, metadataFileName+".partial"),
+	}
+	if err := s.ensureStageAbsent(publication.stagePath); err != nil {
+		return genericRuntimePublication{}, err
+	}
+	if err := s.ensureStageAbsent(publication.metadataStagePath); err != nil {
+		return genericRuntimePublication{}, err
+	}
+	if err := s.makeDirectory(publication.stagePath, 0o755); err != nil {
+		return genericRuntimePublication{}, interruptedAssetError(
+			"prepare managed runtime staging directory", err,
+		)
+	}
+	return publication, nil
+}
+
+func (s *service) stageGenericRuntimePublication(
+	ctx context.Context,
+	publication genericRuntimePublication,
+	result genericCacheResult,
+	metadataFiles []metadataFile,
+) error {
+	for index := range result.artifacts {
+		if err := assetContextError(ctx); err != nil {
+			return err
+		}
+		target := filepath.Join(publication.stagePath, filepath.FromSlash(metadataFiles[index].Path))
+		if err := s.makeDirectory(filepath.Dir(target), 0o755); err != nil {
+			return interruptedAssetError("prepare managed runtime asset directory", err)
+		}
+		sourcePath := filepath.Join(result.snapshotPath, filepath.FromSlash(metadataFiles[index].Path))
+		if err := s.copyCachedFile(ctx, sourcePath, target); err != nil {
+			return interruptedAssetError("copy verified generic asset into managed runtime", err)
+		}
+		if _, err := s.verifyCachedFile(ctx, target, metadataFiles[index]); err != nil {
+			return interruptedAssetError("verify managed runtime asset", err)
+		}
+	}
+	metadata := cacheMetadata{
+		ModelName: publication.modelName,
+		Revision:  publication.revision,
+		Files:     metadataFiles,
+	}
+	body, err := json.Marshal(metadata)
+	if err != nil {
+		return interruptedAssetError("encode managed runtime metadata", err)
+	}
+	if err := s.writeFile(publication.metadataStagePath, body, 0o644); err != nil {
+		return interruptedAssetError("stage managed runtime metadata", err)
+	}
+	return assetContextError(ctx)
+}
+
+func (s *service) commitGenericRuntimePublication(
+	ctx context.Context,
+	publication *genericRuntimePublication,
+) error {
+	var err error
+	publication.finalBackup, publication.hadFinal, err = s.moveExistingGenericSnapshot(publication.finalPath)
+	if err != nil {
+		return fmt.Errorf("%w: replace managed runtime snapshot: %v", models.ErrAssetPreparationInterrupted, err)
+	}
+	publication.metadataBackup, publication.hadMetadata, err = s.moveExistingGenericMetadata(publication.metadataPath)
+	if err != nil {
+		return fmt.Errorf("%w: replace managed runtime metadata: %v", models.ErrAssetPreparationInterrupted, err)
+	}
+	if err := s.renamePath(publication.stagePath, publication.finalPath); err != nil {
+		return fmt.Errorf("%w: publish managed runtime snapshot: %v", models.ErrAssetPreparationInterrupted, err)
+	}
+	publication.finalPromoted = true
+	if err := assetContextError(ctx); err != nil {
+		return err
+	}
+	if err := s.renamePath(publication.metadataStagePath, publication.metadataPath); err != nil {
+		return fmt.Errorf("%w: publish managed runtime metadata: %v", models.ErrAssetPreparationInterrupted, err)
+	}
+	return nil
+}
+
+func (publication *genericRuntimePublication) rollback(s *service) {
+	if publication == nil || publication.committed {
+		return
+	}
+	_ = s.removeTree(publication.stagePath)
+	_ = s.removePath(publication.metadataStagePath)
+	if publication.finalPromoted {
+		_ = s.removeTree(publication.finalPath)
+	}
+	if publication.hadFinal {
+		_ = s.renamePath(publication.finalBackup, publication.finalPath)
+	}
+	if publication.hadMetadata {
+		_ = s.renamePath(publication.metadataBackup, publication.metadataPath)
+	}
+}
+
+func (publication *genericRuntimePublication) removeBackups(s *service) {
+	if publication == nil {
+		return
+	}
+	if publication.hadFinal {
+		_ = s.removeTree(publication.finalBackup)
+	}
+	if publication.hadMetadata {
+		_ = s.removePath(publication.metadataBackup)
+	}
+}
+
+func genericRuntimeMetadataFiles(artifacts []models.AssetArtifact) ([]metadataFile, error) {
+	files := make([]metadataFile, 0, len(artifacts))
+	seen := make(map[string]struct{}, len(artifacts))
+	for _, artifact := range artifacts {
+		name := filepath.ToSlash(strings.TrimSpace(artifact.Name))
+		requirement := models.AssetRequirement{
+			Name: name, Bytes: artifact.Bytes, SHA256: strings.ToLower(strings.TrimSpace(artifact.SHA256)),
+		}
+		if err := requirement.Validate(); err != nil {
+			return nil, fmt.Errorf("%w: generic runtime artifact %q is invalid", models.ErrAssetPreparationInterrupted, name)
+		}
+		if _, exists := seen[name]; exists {
+			return nil, fmt.Errorf("%w: generic runtime artifact %q is duplicated", models.ErrAssetPreparationInterrupted, name)
+		}
+		seen[name] = struct{}{}
+		files = append(files, metadataFile{
+			Path: name, Bytes: artifact.Bytes, SHA256: requirement.SHA256,
+		})
+	}
+	return files, nil
+}
+
+func genericRuntimeRevision(source genericSource, artifacts []models.AssetArtifact) string {
+	if revision := strings.TrimSpace(source.revision); revision != "" {
+		return revision
+	}
+	generic := make([]genericArtifact, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		generic = append(generic, genericArtifact{requirement: models.AssetRequirement{
+			Name: artifact.Name, Bytes: artifact.Bytes, SHA256: artifact.SHA256,
+		}})
+	}
+	return genericArtifactIdentityHash(assetKindModel, source, generic)
+}
+
+func genericRuntimeInspectionFromArtifacts(
+	cachePath string,
+	revision string,
+	metadataFiles []metadataFile,
+	artifacts []models.AssetArtifact,
+) assets.RuntimeCacheInspection {
+	expected := make([]models.AssetRequirement, 0, len(metadataFiles))
+	for _, file := range metadataFiles {
+		expected = append(expected, models.AssetRequirement{
+			Name: file.Path, Bytes: file.Bytes, SHA256: file.SHA256,
+		})
+	}
+	var cacheBytes int64
+	for _, artifact := range artifacts {
+		cacheBytes += artifact.Bytes
+	}
+	return assets.RuntimeCacheInspection{
+		Supported:          true,
+		Installed:          true,
+		Revision:           revision,
+		CachePath:          cachePath,
+		CacheBytes:         cacheBytes,
+		InstalledFileCount: len(artifacts),
+		ManifestPresent:    true,
+		ManifestValid:      true,
+		ExpectedArtifacts:  expected,
+		ObservedArtifacts:  append([]models.AssetArtifact(nil), artifacts...),
+		IntegrityVerified:  hasVerifiableMetadata(expected),
+	}
+}
+
+func (s *service) moveExistingGenericMetadata(path string) (string, bool, error) {
+	info, err := s.inspectPath(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	if info == nil || info.IsDir() {
+		return "", false, fmt.Errorf("managed runtime metadata destination is not a file")
+	}
+	backupPath := path + ".previous"
+	if err := s.removePath(backupPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", false, err
+	}
+	if err := s.renamePath(path, backupPath); err != nil {
+		return "", false, err
+	}
+	return backupPath, true, nil
+}
+
+// inspectGenericRuntimeCache reads the durable managed layout without using
+// process-local preparation state or contacting the source.
+func (s *service) inspectGenericRuntimeCache(
+	ctx context.Context,
+	cacheDirectory string,
+	modelName string,
+	source genericSource,
+) (assets.RuntimeCacheInspection, bool, error) {
+	inspection := assets.RuntimeCacheInspection{
+		Supported:         true,
+		ExpectedArtifacts: genericRuntimeExpectedArtifacts(source),
+	}
+	root, err := s.modelCacheRoot(cacheDirectory, canonicalModelName(modelName))
+	if err != nil {
+		return assets.RuntimeCacheInspection{}, false, err
+	}
+	metadata, present, err := s.readGenericRuntimeMetadata(ctx, filepath.Join(root, metadataFileName))
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return assets.RuntimeCacheInspection{}, present, err
+		}
+		if !errors.Is(err, models.ErrAssetUnavailable) {
+			return assets.RuntimeCacheInspection{}, present, err
+		}
+		inspection.ManifestPresent = present
+		inspection.FailureReason = "managed cache manifest is invalid"
+		return inspection, present, nil
+	}
+	if !present {
+		return inspection, false, nil
+	}
+	inspection.ManifestPresent = true
+	if !validGenericRuntimeMetadata(metadata) {
+		inspection.FailureReason = "managed cache manifest is invalid"
+		return inspection, true, nil
+	}
+	inspection.ManifestValid = true
+	inspection.ExpectedArtifacts = genericRuntimeRequirements(metadata)
+	revisionPath, err := managedCacheChildPath(root, metadata.Revision, "revision")
+	if err != nil {
+		inspection.ManifestValid = false
+		inspection.FailureReason = "managed cache manifest is invalid"
+		return inspection, true, nil
+	}
+	observed, missing, failureReason, err := s.inspectGenericRuntimeFiles(ctx, revisionPath, metadata.Files)
+	if err != nil {
+		return assets.RuntimeCacheInspection{}, true, err
+	}
+	inspection.ObservedArtifacts = observed
+	inspection.MissingAssets = missing
+	inspection.PartialArtifacts = len(observed) > 0 && len(missing) > 0
+	if failureReason != "" {
+		inspection.InstalledFileCount = len(observed)
+		inspection.PartialArtifacts = len(observed) > 0
+		inspection.FailureReason = failureReason
+		return inspection, true, nil
+	}
+	if len(missing) > 0 {
+		return inspection, true, nil
+	}
+	inspection.Installed = true
+	inspection.Revision = metadata.Revision
+	inspection.CachePath = revisionPath
+	inspection.InstalledFileCount = len(observed)
+	inspection.IntegrityVerified = hasVerifiableMetadata(inspection.ExpectedArtifacts)
+	inspection.CacheBytes, err = s.measureRevisionBytes(ctx, revisionPath)
+	if err != nil {
+		return assets.RuntimeCacheInspection{}, true, err
+	}
+	return inspection, true, nil
+}
+
+func (s *service) inspectGenericRuntimeFiles(
+	ctx context.Context,
+	revisionPath string,
+	files []metadataFile,
+) ([]models.AssetArtifact, []string, string, error) {
+	observed := make([]models.AssetArtifact, 0, len(files))
+	missing := make([]string, 0)
+	for _, file := range files {
+		if err := assetContextError(ctx); err != nil {
+			return nil, nil, "", err
+		}
+		artifact, verifyErr := s.verifyCachedFile(
+			ctx, filepath.Join(revisionPath, filepath.FromSlash(file.Path)), file,
+		)
+		if errors.Is(verifyErr, os.ErrNotExist) {
+			missing = append(missing, file.Path)
+			continue
+		}
+		if verifyErr != nil {
+			observed = append(observed, artifact)
+			return observed, missing, safeAssetFailureReason(verifyErr), nil
+		}
+		observed = append(observed, artifact)
+	}
+	return observed, missing, "", nil
+}
+
+func (s *service) resolveGenericRuntimeCache(
+	ctx context.Context,
+	scope models.RuntimeScopeConfig,
+	modelName string,
+) (assets.RuntimeCacheLayout, error) {
+	// Source resolution is used only to classify a generic runtime as a
+	// supported model and to provide a useful expected artifact when the
+	// durable record is absent. The cache record itself remains authoritative.
+	source, sourceErr := s.resolveGenericSource(ctx, scope, modelName)
+	inspection, persisted, err := s.inspectGenericRuntimeCache(
+		ctx, scope.CacheDirectory, modelName, source,
+	)
+	if err != nil {
+		return assets.RuntimeCacheLayout{}, err
+	}
+	if sourceErr != nil && !persisted {
+		return assets.RuntimeCacheLayout{}, fmt.Errorf(
+			"%w: required assets missing for %s", models.ErrNotAvailable, canonicalModelName(modelName),
+		)
+	}
+	if !inspection.Installed {
+		return assets.RuntimeCacheLayout{}, fmt.Errorf(
+			"%w: required assets missing for %s", models.ErrNotAvailable, canonicalModelName(modelName),
+		)
+	}
+	files := make([]string, 0, len(inspection.ObservedArtifacts))
+	for _, artifact := range inspection.ObservedArtifacts {
+		files = append(files, filepath.Join(inspection.CachePath, filepath.FromSlash(artifact.Name)))
+	}
+	return assets.RuntimeCacheLayout{
+		ModelName: canonicalModelName(modelName),
+		CachePath: inspection.CachePath,
+		Revision:  inspection.Revision,
+		Files:     files,
+	}, nil
+}
+
+func mergeGenericRuntimeBackendFacts(
+	inspection assets.RuntimeCacheInspection,
+	prepared assets.RuntimeCacheInspection,
+) assets.RuntimeCacheInspection {
+	if !prepared.BackendRequired {
+		return inspection
+	}
+	inspection.BackendRequired = true
+	inspection.BackendCachePath = prepared.BackendCachePath
+	inspection.BackendRevision = prepared.BackendRevision
+	inspection.BackendInstalledFiles = prepared.BackendInstalledFiles
+	return inspection
+}
+
+func (s *service) readGenericRuntimeMetadata(
+	ctx context.Context,
+	path string,
+) (cacheMetadata, bool, error) {
+	if err := assetContextError(ctx); err != nil {
+		return cacheMetadata{}, false, err
+	}
+	body, err := s.readFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return cacheMetadata{}, false, nil
+	}
+	if err != nil {
+		return cacheMetadata{}, true, fmt.Errorf("read managed cache metadata: %w", err)
+	}
+	var metadata cacheMetadata
+	if err := json.Unmarshal(body, &metadata); err != nil {
+		return cacheMetadata{}, true, fmt.Errorf(
+			"%w: decode managed cache metadata: %v", models.ErrAssetUnavailable, err,
+		)
+	}
+	return metadata, true, nil
+}
+
+func validGenericRuntimeMetadata(metadata cacheMetadata) bool {
+	if strings.TrimSpace(metadata.Revision) == "" || len(metadata.Files) == 0 {
+		return false
+	}
+	seen := make(map[string]struct{}, len(metadata.Files))
+	for _, file := range metadata.Files {
+		name := filepath.ToSlash(strings.TrimSpace(file.Path))
+		if name != file.Path {
+			return false
+		}
+		if err := (models.AssetRequirement{
+			Name: name, Bytes: file.Bytes, SHA256: strings.ToLower(strings.TrimSpace(file.SHA256)),
+		}).Validate(); err != nil {
+			return false
+		}
+		if _, exists := seen[name]; exists {
+			return false
+		}
+		seen[name] = struct{}{}
+	}
+	return true
+}
+
+func genericRuntimeRequirements(metadata cacheMetadata) []models.AssetRequirement {
+	result := make([]models.AssetRequirement, 0, len(metadata.Files))
+	for _, file := range metadata.Files {
+		result = append(result, models.AssetRequirement{
+			Name: file.Path, Bytes: file.Bytes, SHA256: strings.ToLower(strings.TrimSpace(file.SHA256)),
+		})
+	}
+	return result
+}
+
+func genericRuntimeExpectedArtifacts(source genericSource) []models.AssetRequirement {
+	if name := filepath.ToSlash(strings.TrimSpace(source.file)); name != "" {
+		return []models.AssetRequirement{{Name: name}}
+	}
+	return nil
+}
+
+func (s *service) inspectConfiguredRuntimeCache(
+	ctx context.Context,
+	scope models.RuntimeScopeConfig,
+	modelName string,
+	active activePullState,
+	isActive bool,
+	pullFailure string,
+) (assets.RuntimeCacheInspection, bool, error) {
+	spec, source, supported, err := s.resolveRuntimeCacheSource(scope.Runtime, modelName)
+	if err != nil {
+		return assets.RuntimeCacheInspection{}, true, err
+	}
+	if !supported {
+		return assets.RuntimeCacheInspection{}, false, nil
+	}
+	expected := assetRequirementsForSpec(spec)
+	cacheRoot, err := s.modelCacheRoot(scope.CacheDirectory, spec.modelName)
+	if err != nil {
+		return assets.RuntimeCacheInspection{}, true, err
+	}
+	metadata, manifestPresent, err := s.readMetadata(
+		ctx, filepath.Join(cacheRoot, metadataFileName),
+	)
+	if err != nil {
+		inspection, inspectionErr := s.invalidRuntimeCacheInspection(
+			ctx, expected, active, isActive, pullFailure,
+		)
+		return inspection, true, inspectionErr
+	}
+	if manifestPresent {
+		expected = requirementsFromMetadata(spec, metadata)
+	}
+	result, err := s.inspectRuntimeCacheFiles(
+		ctx, scope.CacheDirectory, spec, source, expected, cacheRoot, metadata, manifestPresent,
+	)
+	if err != nil {
+		return assets.RuntimeCacheInspection{}, true, err
+	}
+	return s.applyActivePullFacts(result, active, isActive, pullFailure), true, nil
+}

--- a/pkg/services/models/internal/services/assets/internal/service/generic_runtime_test.go
+++ b/pkg/services/models/internal/services/assets/internal/service/generic_runtime_test.go
@@ -1,0 +1,160 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	models "github.com/portpowered/infinite-you/pkg/services/models"
+	assets "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets"
+)
+
+func TestPrepareGenericAssetsPublishesDurableRuntimeCacheAcrossServiceReconstruction(t *testing.T) {
+	t.Parallel()
+
+	cacheDirectory, scope, service, localPath, body := newNamedGenericRuntimeFixture(t, "durable-runtime")
+	request := models.PrepareModelAssetsRequest{
+		Scope:     scope,
+		Name:      "joined-model",
+		Reference: models.ModelReference{NameOrURI: localPath},
+		Artifacts: []models.AssetRequirement{{
+			Name: filepath.Base(localPath), Bytes: int64(len(body)), SHA256: sha256Hex(body),
+		}},
+	}
+	if _, err := service.PrepareModelAssets(context.Background(), request); err != nil {
+		t.Fatalf("PrepareModelAssets: %v", err)
+	}
+
+	first := inspectNamedGenericRuntime(t, service, scope, "joined-model")
+	assertNamedGenericRuntimeReady(t, first)
+	assertGenericRuntimeMetadataExists(t, cacheDirectory, "joined-model")
+
+	secondScopes := newScopes(t, "durable-runtime-reconstructed")
+	secondScope := openScope(t, secondScopes, cacheDirectory, models.RuntimeConfig{})
+	second := newGenericService(t, secondScopes, httpDoerFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("reconstructed runtime inspection must not use network")
+	}), func(string) string { return "" })
+	secondInspection := inspectNamedGenericRuntime(t, second, secondScope, "joined-model")
+	assertNamedGenericRuntimeReady(t, secondInspection)
+	if secondInspection.CachePath != first.CachePath || secondInspection.Revision != first.Revision {
+		t.Fatalf("reconstructed inspection = %#v, first inspection = %#v", secondInspection, first)
+	}
+
+	layout, err := second.ResolveRuntimeCache(context.Background(), models.InspectModelAssetsRequest{
+		Scope: secondScope,
+		Name:  "joined-model",
+	})
+	if err != nil {
+		t.Fatalf("ResolveRuntimeCache after reconstruction: %v", err)
+	}
+	if layout.CachePath != secondInspection.CachePath || len(layout.Files) != 1 {
+		t.Fatalf("reconstructed runtime layout = %#v, inspection = %#v", layout, secondInspection)
+	}
+}
+
+func TestPrepareGenericAssetsDoesNotPublishManagedRuntimeAfterRuntimeCommitFailure(t *testing.T) {
+	t.Parallel()
+
+	cacheDirectory, scope, service, localPath, body := newNamedGenericRuntimeFixture(t, "atomic-runtime")
+	originalRename := service.renamePath
+	service.renamePath = func(oldPath, newPath string) error {
+		if strings.HasSuffix(newPath, metadataFileName) {
+			return errors.New("injected managed runtime metadata commit failure")
+		}
+		return originalRename(oldPath, newPath)
+	}
+	_, err := service.PrepareModelAssets(context.Background(), models.PrepareModelAssetsRequest{
+		Scope:     scope,
+		Name:      "atomic-model",
+		Reference: models.ModelReference{NameOrURI: localPath},
+		Artifacts: []models.AssetRequirement{{
+			Name: filepath.Base(localPath), Bytes: int64(len(body)), SHA256: sha256Hex(body),
+		}},
+	})
+	if !errors.Is(err, models.ErrAssetPreparationInterrupted) {
+		t.Fatalf("PrepareModelAssets error = %v, want interrupted preparation", err)
+	}
+
+	assertNoGenericRuntimePublication(t, cacheDirectory, "atomic-model")
+	inspection := inspectNamedGenericRuntime(t, service, scope, "atomic-model")
+	if inspection.Installed || inspection.ManifestPresent {
+		t.Fatalf("failed runtime publication inspection = %#v, want no installed cache", inspection)
+	}
+}
+
+func newNamedGenericRuntimeFixture(
+	t *testing.T,
+	issuer string,
+) (string, models.RuntimeScopeRef, *service, string, []byte) {
+	t.Helper()
+	cacheDirectory := t.TempDir()
+	localPath := filepath.Join(t.TempDir(), "weights.gguf")
+	body := []byte("durable runtime weights")
+	if err := os.WriteFile(localPath, body, 0o644); err != nil {
+		t.Fatalf("write local fixture: %v", err)
+	}
+	scopes := newScopes(t, issuer)
+	scope := openScope(t, scopes, cacheDirectory, models.RuntimeConfig{})
+	service := newGenericService(t, scopes, httpDoerFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("local generic preparation must not use network")
+	}), func(string) string { return "" })
+	return cacheDirectory, scope, service, localPath, body
+}
+
+func inspectNamedGenericRuntime(
+	t *testing.T,
+	service *service,
+	scope models.RuntimeScopeRef,
+	modelName string,
+) assets.RuntimeCacheInspection {
+	t.Helper()
+	inspection, err := service.InspectRuntimeCache(context.Background(), models.InspectModelAssetsRequest{
+		Scope: scope,
+		Name:  modelName,
+	})
+	if err != nil {
+		t.Fatalf("InspectRuntimeCache: %v", err)
+	}
+	return inspection
+}
+
+func assertNamedGenericRuntimeReady(t *testing.T, inspection assets.RuntimeCacheInspection) {
+	t.Helper()
+	if !inspection.Supported || !inspection.Installed || !inspection.ManifestPresent ||
+		!inspection.ManifestValid || inspection.CachePath == "" || inspection.InstalledFileCount != 1 {
+		t.Fatalf("runtime inspection = %#v, want durable ready cache", inspection)
+	}
+	if _, err := os.Stat(filepath.Join(inspection.CachePath, "weights.gguf")); err != nil {
+		t.Fatalf("runtime artifact in %q: %v", inspection.CachePath, err)
+	}
+}
+
+func assertGenericRuntimeMetadataExists(t *testing.T, cacheDirectory, modelName string) {
+	t.Helper()
+	path := filepath.Join(cacheDirectory, canonicalModelName(modelName), metadataFileName)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("managed runtime metadata %q: %v", path, err)
+	}
+}
+
+func assertNoGenericRuntimePublication(t *testing.T, cacheDirectory, modelName string) {
+	t.Helper()
+	root := filepath.Join(cacheDirectory, canonicalModelName(modelName))
+	entries, err := os.ReadDir(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("read managed runtime root %q: %v", root, err)
+	}
+	for _, entry := range entries {
+		if entry.Name() == metadataFileName || strings.HasSuffix(entry.Name(), ".partial") ||
+			strings.HasSuffix(entry.Name(), ".previous") {
+			t.Fatalf("failed publication left %q in %q", entry.Name(), root)
+		}
+	}
+}

--- a/pkg/services/models/internal/services/assets/internal/service/service.go
+++ b/pkg/services/models/internal/services/assets/internal/service/service.go
@@ -186,6 +186,9 @@ func (s *service) ResolveRuntimeCache(
 		return assets.RuntimeCacheLayout{}, err
 	}
 	spec, source, err := s.resolveSource(scope.Runtime, request.Name)
+	if errors.Is(err, models.ErrAssetSourceUnsupported) {
+		return s.resolveGenericRuntimeCache(ctx, scope, request.Name)
+	}
 	if err != nil {
 		return assets.RuntimeCacheLayout{}, err
 	}
@@ -230,46 +233,41 @@ func (s *service) InspectRuntimeCache(
 		return assets.RuntimeCacheInspection{}, err
 	}
 	active, isActive, pullFailure := s.activePullStateFor(request.Scope, request.Name)
-	if inspection, ok := s.preparedRuntimeInspection(request.Scope, request.Name); ok {
-		inspection = s.applyActivePullFacts(inspection, active, isActive, pullFailure)
-		if inspection.Installed && strings.TrimSpace(inspection.CachePath) != "" {
-			cacheBytes, measureErr := s.measureRevisionBytes(ctx, inspection.CachePath)
+	configured, handled, err := s.inspectConfiguredRuntimeCache(
+		ctx, scope, request.Name, active, isActive, pullFailure,
+	)
+	if err != nil {
+		return assets.RuntimeCacheInspection{}, err
+	}
+	if handled {
+		return configured, nil
+	}
+
+	genericSource, sourceErr := s.resolveGenericSource(ctx, scope, request.Name)
+	genericInspection, persisted, inspectErr := s.inspectGenericRuntimeCache(
+		ctx, scope.CacheDirectory, request.Name, genericSource,
+	)
+	if inspectErr != nil {
+		return assets.RuntimeCacheInspection{}, inspectErr
+	}
+	if sourceErr == nil || persisted {
+		if prepared, ok := s.preparedRuntimeInspection(request.Scope, request.Name); ok {
+			genericInspection = mergeGenericRuntimeBackendFacts(genericInspection, prepared)
+		}
+		return s.applyActivePullFacts(genericInspection, active, isActive, pullFailure), nil
+	}
+	if prepared, ok := s.preparedRuntimeInspection(request.Scope, request.Name); ok {
+		prepared = s.applyActivePullFacts(prepared, active, isActive, pullFailure)
+		if prepared.Installed && strings.TrimSpace(prepared.CachePath) != "" {
+			cacheBytes, measureErr := s.measureRevisionBytes(ctx, prepared.CachePath)
 			if measureErr != nil {
 				return assets.RuntimeCacheInspection{}, measureErr
 			}
-			inspection.CacheBytes = cacheBytes
+			prepared.CacheBytes = cacheBytes
 		}
-		return inspection, nil
+		return prepared, nil
 	}
-	spec, source, supported, err := s.resolveRuntimeCacheSource(scope.Runtime, request.Name)
-	if err != nil {
-		return assets.RuntimeCacheInspection{}, err
-	}
-	if !supported {
-		return assets.RuntimeCacheInspection{}, nil
-	}
-	expected := assetRequirementsForSpec(spec)
-	cacheRoot, rootErr := s.modelCacheRoot(scope.CacheDirectory, spec.modelName)
-	if rootErr != nil {
-		return assets.RuntimeCacheInspection{}, rootErr
-	}
-	metadata, manifestPresent, metadataErr := s.readMetadata(
-		ctx,
-		filepath.Join(cacheRoot, metadataFileName),
-	)
-	if metadataErr != nil {
-		return s.invalidRuntimeCacheInspection(ctx, expected, active, isActive, pullFailure)
-	}
-	if manifestPresent {
-		expected = requirementsFromMetadata(spec, metadata)
-	}
-	result, err := s.inspectRuntimeCacheFiles(
-		ctx, scope.CacheDirectory, spec, source, expected, cacheRoot, metadata, manifestPresent,
-	)
-	if err != nil {
-		return assets.RuntimeCacheInspection{}, err
-	}
-	return s.applyActivePullFacts(result, active, isActive, pullFailure), nil
+	return assets.RuntimeCacheInspection{}, nil
 }
 
 func (s *service) resolveRuntimeCacheSource(

--- a/pkg/services/models/internal/services/catalog/internal/service/service.go
+++ b/pkg/services/models/internal/services/catalog/internal/service/service.go
@@ -168,6 +168,16 @@ func (s *service) GetModelReadiness(
 	if s.readiness == nil {
 		return models.GetModelReadinessResult{}, models.ErrUnavailable
 	}
+	// Effective definitions are discovery entries, not Factory-declared
+	// invocation workers. Keep the direct invocation preflight at its stable
+	// missing baseline; catalog list/detail still query the durable cache so
+	// operators can see a pulled built-in model as READY.
+	if detail.Diagnostics["catalogSource"] == "EFFECTIVE_DEFINITION" {
+		return models.GetModelReadinessResult{
+			ModelName: detail.Name,
+			Readiness: stableReadiness(detail, detail.ManagedRuntime),
+		}, nil
+	}
 	readiness, err := s.readiness(ctx, request.Scope, scopeConfig.Clone(), detail.Clone())
 	if err != nil {
 		if contextError := ctx.Err(); contextError != nil {

--- a/pkg/services/models/wire/wire.go
+++ b/pkg/services/models/wire/wire.go
@@ -441,7 +441,13 @@ func newCatalogReadinessQuery(assetService scopedassets.Service) catalog.Readine
 		)
 		if readinessErr != nil && errors.Is(readinessErr, models.ErrNotFound) &&
 			detail.Diagnostics["catalogSource"] == "EFFECTIVE_DEFINITION" {
-			return detail.ManagedRuntime.Clone(), nil
+			return localmodels.ManagedRuntimeReadinessForEffectiveDefinitionContext(
+				ctx,
+				detail.ManagedRuntime,
+				&scope.Runtime,
+				detail.Name,
+				puller,
+			)
 		}
 		return readiness, readinessErr
 	}

--- a/tests/functional/models/root_composition/pull_to_ready_test.go
+++ b/tests/functional/models/root_composition/pull_to_ready_test.go
@@ -1,0 +1,294 @@
+package root_composition_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/root"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	modelsservice "github.com/portpowered/infinite-you/pkg/services/models"
+	runcli "github.com/portpowered/infinite-you/pkg/transports/cli/run"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	pullToReadyModelName = modelsservice.BuiltInModelNameASR
+	pullToReadyRevision  = "5359861c739e955e79d9a303bcbc70fb988958b1"
+	pullToReadyAsset     = "ggml-base.en.bin"
+)
+
+// TestModelsPullToReadySurvivesProcessReconstruction proves the public local
+// Models lifecycle without a daemon or network. The HTTP effect is replaced at
+// the root.BuildProcess edge, while the pull, inspect, and list commands remain
+// ordinary customer Process.Execute invocations.
+func TestModelsPullToReadySurvivesProcessReconstruction(t *testing.T) {
+	assetBody := []byte("network-free ASR asset")
+	assetClient := newPullToReadyAssetClient(assetBody)
+	homeDirectory := t.TempDir()
+	edges := serviceedges.Edges{
+		ModelAssetHTTPClient: assetClient,
+		ModelAssetEndpoints: modelsservice.RuntimeAssetEndpoints{
+			BaseURL:    "https://assets.invalid",
+			APIBaseURL: "https://api.invalid",
+		},
+		ModelAssetResolveHomeDirectory: func() (string, error) {
+			return homeDirectory, nil
+		},
+	}
+
+	firstProcess := buildPullToReadyProcess(t, edges)
+	pull := executePullToReadyCommand(t, firstProcess, homeDirectory, "models", "pull", pullToReadyModelName)
+	assertPullToReadySuccess(t, pull, assetBody)
+	inspect := executePullToReadyCommand(t, firstProcess, homeDirectory, "models", "inspect", pullToReadyModelName)
+	assertPullToReadyInspect(t, inspect, homeDirectory, assetBody)
+	listed := executePullToReadyCommand(t, firstProcess, homeDirectory, "models", "list")
+	assertPullToReadyList(t, listed, assetBody)
+	closePullToReadyProcess(t, firstProcess)
+
+	secondProcess := buildPullToReadyProcess(t, serviceedges.Edges{
+		ModelAssetHTTPClient: assetClient,
+		ModelAssetEndpoints: modelsservice.RuntimeAssetEndpoints{
+			BaseURL:    "https://assets.invalid",
+			APIBaseURL: "https://api.invalid",
+		},
+		ModelAssetResolveHomeDirectory: func() (string, error) {
+			return homeDirectory, nil
+		},
+	})
+	secondInspect := executePullToReadyCommand(t, secondProcess, homeDirectory, "models", "inspect", pullToReadyModelName)
+	assertPullToReadyInspect(t, secondInspect, homeDirectory, assetBody)
+	secondList := executePullToReadyCommand(t, secondProcess, homeDirectory, "models", "list")
+	assertPullToReadyList(t, secondList, assetBody)
+	closePullToReadyProcess(t, secondProcess)
+
+	if got := assetClient.Calls(); got != 2 {
+		t.Fatalf("asset edge requests = %d, want one manifest and one asset request", got)
+	}
+	t.Logf(
+		"pull-to-ready commands passed: downloadedBytes=%d inspectCacheBytes=%d restartInspectCacheBytes=%d cacheRoot=%s assetRequests=%d",
+		pull.downloadedBytes, inspect.cacheBytes, secondInspect.cacheBytes,
+		filepath.Join(homeDirectory, ".agent-factory", "models"), assetClient.Calls(),
+	)
+}
+
+// rootProcess keeps the test's public process capability narrow while allowing
+// the test to close the exact process returned by root.BuildProcess.
+type rootProcess interface {
+	Execute(root.Input) error
+	Close(context.Context) error
+}
+
+func buildPullToReadyProcess(t *testing.T, edges serviceedges.Edges) rootProcess {
+	t.Helper()
+	process, err := root.BuildProcess(context.Background(), edges)
+	if err != nil {
+		t.Fatalf("root.BuildProcess() error = %v", err)
+	}
+	support.CleanupProcess(t, process)
+	return process
+}
+
+type pullToReadyCapture struct {
+	raw             string
+	downloadedBytes int64
+	cacheBytes      int64
+}
+
+func executePullToReadyCommand(
+	t *testing.T,
+	process rootProcess,
+	homeDirectory string,
+	arguments ...string,
+) pullToReadyCapture {
+	t.Helper()
+	inputs := support.FakeInputs(t.Context(), append([]string{"you", "--json"}, arguments...))
+	inputs.Input.Env = append(inputs.Input.Env,
+		"HOME="+homeDirectory,
+		"USERPROFILE="+homeDirectory,
+		runcli.ModelCacheDirEnvironment+"="+filepath.Join(homeDirectory, "managed-cache"),
+	)
+	inputs.Input.WorkingDirectory = t.TempDir()
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf(
+			"Process.Execute(%s) error = %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(arguments, " "), err, inputs.Stdout(), inputs.Stderr(),
+		)
+	}
+	return pullToReadyCapture{raw: inputs.Stdout(), downloadedBytes: pullToReadyDownloadedBytes(t, arguments, inputs.Stdout()), cacheBytes: pullToReadyCacheBytes(t, arguments, inputs.Stdout())}
+}
+
+func closePullToReadyProcess(t *testing.T, process rootProcess) {
+	t.Helper()
+	closeContext, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := process.Close(closeContext); err != nil {
+		t.Fatalf("close root.BuildProcess() process: %v", err)
+	}
+}
+
+func pullToReadyDownloadedBytes(t *testing.T, arguments []string, raw string) int64 {
+	t.Helper()
+	if len(arguments) < 2 || arguments[0] != "models" || arguments[1] != "pull" {
+		return 0
+	}
+	var response factoryapi.ModelPullResponse
+	decodePullToReadyJSON(t, raw, &response)
+	var total int64
+	for _, file := range response.DownloadedFiles {
+		total += file.Bytes
+	}
+	return total
+}
+
+func pullToReadyCacheBytes(t *testing.T, arguments []string, raw string) int64 {
+	t.Helper()
+	var cacheBytes *int64
+	switch {
+	case len(arguments) >= 2 && arguments[0] == "models" && arguments[1] == "inspect":
+		var response factoryapi.ModelDetail
+		decodePullToReadyJSON(t, raw, &response)
+		cacheBytes = response.ManagedRuntime.CacheBytes
+	case len(arguments) >= 2 && arguments[0] == "models" && arguments[1] == "list":
+		var response factoryapi.ListModelsResponse
+		decodePullToReadyJSON(t, raw, &response)
+		for _, model := range response.Results {
+			if model.Name == pullToReadyModelName {
+				cacheBytes = model.ManagedRuntime.CacheBytes
+				break
+			}
+		}
+	}
+	if cacheBytes == nil {
+		return 0
+	}
+	return *cacheBytes
+}
+
+func decodePullToReadyJSON(t *testing.T, raw string, target any) {
+	t.Helper()
+	if err := json.Unmarshal([]byte(raw), target); err != nil {
+		t.Fatalf("decode Models JSON output: %v\noutput:\n%s", err, raw)
+	}
+}
+
+func assertPullToReadySuccess(t *testing.T, capture pullToReadyCapture, assetBody []byte) {
+	t.Helper()
+	var response factoryapi.ModelPullResponse
+	decodePullToReadyJSON(t, capture.raw, &response)
+	if response.ModelName != pullToReadyModelName || response.Outcome != factoryapi.ModelPullOutcomePULLED {
+		t.Fatalf("models pull response = %#v, want asr/PULLED", response)
+	}
+	if response.ManagedRuntimePull.PullOutcome != factoryapi.ManagedRuntimePullOutcomeINSTALLEDSUCCESSFULLY ||
+		response.ManagedRuntimePull.ReadinessState != factoryapi.ManagedRuntimeReadinessStateREADY {
+		t.Fatalf("models pull managed result = %#v, want INSTALLED_SUCCESSFULLY/READY", response.ManagedRuntimePull)
+	}
+	if len(response.DownloadedFiles) != 1 || response.DownloadedFiles[0].Path != pullToReadyAsset ||
+		response.DownloadedFiles[0].Bytes != int64(len(assetBody)) {
+		t.Fatalf("models pull downloaded files = %#v, want %s/%d bytes", response.DownloadedFiles, pullToReadyAsset, len(assetBody))
+	}
+	if response.ManagedRuntimePull.CachePath == nil || *response.ManagedRuntimePull.CachePath == "" {
+		t.Fatalf("models pull managed cache path = %#v, want installed path", response.ManagedRuntimePull.CachePath)
+	}
+	if capture.downloadedBytes != int64(len(assetBody)) {
+		t.Fatalf("models pull downloaded bytes = %d, want %d", capture.downloadedBytes, len(assetBody))
+	}
+}
+
+func assertPullToReadyInspect(t *testing.T, capture pullToReadyCapture, homeDirectory string, assetBody []byte) {
+	t.Helper()
+	var response factoryapi.ModelDetail
+	decodePullToReadyJSON(t, capture.raw, &response)
+	if response.Name != pullToReadyModelName ||
+		response.ManagedRuntime.ReadinessState != factoryapi.ManagedRuntimeReadinessStateREADY ||
+		response.ManagedRuntime.LifecycleState != factoryapi.ManagedRuntimeLifecycleStateINSTALLED {
+		t.Fatalf("models inspect response = %#v, want asr READY/INSTALLED", response)
+	}
+	if response.ManagedRuntime.CachePath == nil || !strings.HasPrefix(*response.ManagedRuntime.CachePath, filepath.Join(homeDirectory, ".agent-factory", "models")) {
+		t.Fatalf("models inspect cache path = %#v, want isolated home cache", response.ManagedRuntime.CachePath)
+	}
+	if response.ManagedRuntime.CacheBytes == nil || *response.ManagedRuntime.CacheBytes != int64(len(assetBody)) {
+		t.Fatalf("models inspect cache bytes = %#v, want %d", response.ManagedRuntime.CacheBytes, len(assetBody))
+	}
+}
+
+func assertPullToReadyList(t *testing.T, capture pullToReadyCapture, assetBody []byte) {
+	t.Helper()
+	var response factoryapi.ListModelsResponse
+	decodePullToReadyJSON(t, capture.raw, &response)
+	for _, model := range response.Results {
+		if model.Name != pullToReadyModelName {
+			continue
+		}
+		if model.ManagedRuntime.ReadinessState != factoryapi.ManagedRuntimeReadinessStateREADY ||
+			model.ManagedRuntime.LifecycleState != factoryapi.ManagedRuntimeLifecycleStateINSTALLED {
+			t.Fatalf("models list ASR managed result = %#v, want READY/INSTALLED", model.ManagedRuntime)
+		}
+		if model.ManagedRuntime.CacheBytes == nil || *model.ManagedRuntime.CacheBytes != int64(len(assetBody)) {
+			t.Fatalf("models list ASR cache bytes = %#v, want %d", model.ManagedRuntime.CacheBytes, len(assetBody))
+		}
+		return
+	}
+	t.Fatalf("models list did not contain %q: %#v", pullToReadyModelName, response.Results)
+}
+
+type pullToReadyAssetClient struct {
+	manifest []byte
+	body     []byte
+	calls    atomic.Int64
+}
+
+func newPullToReadyAssetClient(body []byte) *pullToReadyAssetClient {
+	digest := sha256.Sum256(body)
+	manifest, err := json.Marshal(map[string]any{
+		"sha": pullToReadyRevision,
+		"siblings": []map[string]any{{
+			"rfilename": pullToReadyAsset,
+			"size":      len(body),
+			"lfs": map[string]any{
+				"oid":  hex.EncodeToString(digest[:]),
+				"size": len(body),
+			},
+		}},
+	})
+	if err != nil {
+		panic(fmt.Sprintf("marshal pull-to-ready manifest: %v", err))
+	}
+	return &pullToReadyAssetClient{manifest: manifest, body: append([]byte(nil), body...)}
+}
+
+func (client *pullToReadyAssetClient) Do(request *http.Request) (*http.Response, error) {
+	client.calls.Add(1)
+	var body io.Reader
+	switch request.URL.Path {
+	case "/models/ggerganov/whisper.cpp":
+		body = bytes.NewReader(client.manifest)
+	case "/ggerganov/whisper.cpp/resolve/" + pullToReadyRevision + "/" + pullToReadyAsset:
+		body = bytes.NewReader(client.body)
+	default:
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("unexpected asset request")),
+			Request:    request,
+		}, nil
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(body),
+		Request:    request,
+	}, nil
+}
+
+func (client *pullToReadyAssetClient) Calls() int64 {
+	return client.calls.Load()
+}


### PR DESCRIPTION
{
  "project": "Make Prepared Managed Model Caches Durably Resolvable",
  "branchName": "models-pull-fails-because-resolve-runtime-cache-ignores-prepared-assets",
  "description": "Make successful built-in managed model preparation publish durable installed-cache state so models pull succeeds and inspect/list report READY in the pull process and in later processes, while preserving legacy .managed-cache.json compatibility.",
  "context": {
    "customerAsk": "Correct the disagreement between managed-cache preparation, ResolveRuntimeCache, and InspectRuntimeCache so a completed built-in model download produces a successful pull and durable READY readiness, including after the pull process exits. Preserve legacy cache compatibility and prove the behavior without downloading all four built-in models.",
    "problem": "All four built-in model pulls can download and verify their assets and still fail with CACHE_INSTALLATION_FAILED, after which inspect reports MISSING. Generic preparation records success only in process memory, InspectRuntimeCache can consult that transient record, and ResolveRuntimeCache instead reads durable managed-cache metadata that generic preparation never publishes. The pull completion path therefore rejects every prepared built-in cache, and the transient record cannot support a later process.",
    "solution": "After successful generic asset acquisition and verification, atomically publish the durable managed-cache metadata already understood by cache resolution. Make resolution and inspection agree on that durable source of truth, retain support for valid legacy .managed-cache.json caches, and prove pull-to-READY behavior with focused tests, a controlled network-free root.BuildProcess functional scenario, and a separate isolated real-ASR CLI runtime-proof run across separate processes."
  },
  "acceptanceCriteria": [
    "Controlled regression evidence: starting from an empty isolated managed cache, the network-free root.BuildProcess/Process.Execute scenario uses an edges.Edges download substitute and makes models pull asr report success, models inspect asr report READY, and models list show ASR as READY; the PR body records the controlled before-fix and after-fix commands and outputs verbatim, including the parent CACHE_INSTALLATION_FAILED pull, the resulting empty-cache MISSING inspection state, and the relevant byte counts.",
    "After the pull process has exited, a second, separately started process using the same isolated cache reports ASR as READY and can resolve the same installed cache layout without any process-memory preparation record.",
    "Existing populated .managed-cache.json caches continue to resolve and inspect as installed; malformed, incomplete, or missing cache state continues to produce the established unavailable/not-ready behavior rather than a false READY result.",
    "Controlled proof boundary: the network-free functional regression constructs the application with root.BuildProcess, executes the public CLI flow with Process.Execute, replaces only the download effect through edges.Edges, and asserts successful pull plus READY inspection/list in a reconstructed process; this controlled test is separate from, and does not replace, the real-artifact runtime proof below.",
    "Runtime-proof classification: applicable and independently required because this lane changes runtime-observable CLI behavior and runtime lifecycle across process boundaries. Build the real delivered artifact with go build -o <tempdir>/you-verify.exe ./cmd/factory; redirect both HOME and USERPROFILE to a scratch directory; use no production daemon or port 7437; exercise an ASR pull followed by inspect/list and a second separate-process inspect; and record the verbatim commands and outputs in the PR body or a PR comment. Green tests, an inspected diff, or implementer assertions alone do not satisfy this proof. Do not write bin/you.exe, run make build-all, or download the other built-in models.",
    "Final quality gate: typecheck/build validation and focused Models package and functional tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. No generated output is hand-merged; if generation becomes necessary, rerun the canonical generator and commit its result.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "models-pull-fails-because-resolve-runtime-cache-ignores-prepared-assets-001",
      "title": "Publish and resolve durable managed-cache readiness",
      "description": "As a local-model operator, I want a completed managed model download to become durable installed state so that pull succeeds and later processes can resolve the model without relying on the downloader's memory.",
      "acceptanceCriteria": [
        "Successful generic preparation of a built-in model publishes a complete durable cache record only after all required model assets have been acquired and verified; interrupted or failed preparation does not publish a false installed state.",
        "The pull completion path and inspection path agree on that durable state: resolution returns the prepared model's cache path, revision, and files, while inspection reports installed/ready for the same artifacts.",
        "Reconstructing the Models service in a new process context with the same cache makes resolution and inspection succeed without a remembered prepared-runtime entry.",
        "A pre-existing valid legacy .managed-cache.json remains resolvable, while missing, malformed, incomplete, or integrity-invalid cache data does not report installed readiness.",
        "Focused Models asset-service and local-puller tests cover successful durable publication, failure atomicity, restart reconstruction, resolution/inspection agreement, and legacy-cache compatibility.",
        "Changes remain within the Models asset-service and local-puller ownership needed for this behavior and do not alter pinned artifact catalogs, the packaged TTS factory, backend conformance, metrics, Factory Visualization, Factory Sessions, or session lifecycle tests.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented atomic durable managed-cache publication for generic model preparation, restart-safe generic resolution/inspection, legacy-cache preservation, and focused success/failure/reconstruction tests. Models package tests, race tests, vet, and package gates pass."
    },
    {
      "id": "models-pull-fails-because-resolve-runtime-cache-ignores-prepared-assets-002",
      "title": "Prove the pull-to-ready CLI lifecycle",
      "description": "As a customer and reviewer, I want the public CLI lifecycle to prove that downloaded assets remain ready after restart so that a successful download cannot again ship with an unusable model.",
      "acceptanceCriteria": [
        "Controlled network-free functional scenario: construct through root.BuildProcess, invoke models pull asr and readiness commands through Process.Execute, replace the download effect through edges.Edges, and observe a successful pull, models inspect asr as READY, and models list with ASR READY; this is the deterministic regression proof and is distinct from the real-artifact runtime proof.",
        "The functional scenario proves durable behavior by discarding the first process and constructing a second process against the same isolated cache before asserting READY; it does not depend on shared in-memory service state, real network access, sleeps, or timeout-padded polling.",
        "The controlled functional regression fails on the parent commit with the cache-installation/readiness mismatch and passes on the final head; the PR body records both exact test commands and outputs, including the parent CACHE_INSTALLATION_FAILED/MISSING state and the 22-byte controlled asset, while the separate real-artifact transcript records its own commands and outputs.",
        "Runtime-proof classification: applicable and independently required. Build the real delivered artifact with go build -o <tempdir>/you-verify.exe ./cmd/factory; redirect both HOME and USERPROFILE to a scratch directory; use no production daemon or port 7437; exercise an ASR pull followed by inspect/list and a second separate-process inspect; and record the verbatim commands and outputs in the PR body or a PR comment. Green tests, an inspected diff, or implementer assertions alone do not satisfy this proof. Do not write bin/you.exe, run make build-all, or download the other built-in models.",
        "Rebase onto origin/main before the final push; if generated output is affected, rerun its canonical generator rather than hand-merging it.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented the effective-definition durable cache projection and the public root.BuildProcess lifecycle regression. The controlled regression and mandatory real-artifact runtime proof are separate acceptance surfaces. Parent controlled proof command: go test ./tests/functional/models/root_composition -run TestModelsPullToReadySurvivesProcessReconstruction -count=1 -v. Parent output: Process.Execute(models pull asr) failed with CACHE_INSTALLATION_FAILED after downloadedBytes=22; the empty cache inspected as MISSING. Final head: abd5ede32. Final controlled proof output: PASS; downloadedBytes=22; inspectCacheBytes=22; restartInspectCacheBytes=22; assetRequests=2. Delivered artifact command: go build -o <tempdir>/you-verify.exe ./cmd/factory; exit 0. Separate artifact commands models pull asr, models inspect asr, models list, and a second-process models inspect asr all exited 0; the real ASR pull reported downloaded bytes=147964211, pullOutcome=INSTALLED_SUCCESSFULLY, readinessState=READY, and inspect/list/restart-inspect reported READY/INSTALLED at revision 5359861c739e955e79d9a303bcbc70fb988958b1. Focused Models tests, full Models package tests, race tests, and vet pass."
    }
  ]
}
## Verbatim controlled before/after evidence

This controlled, network-free proof uses `root.BuildProcess`, `Process.Execute`, and an `edges.Edges` HTTP effect substitute. It is intentionally separate from the mandatory real-artifact runtime proof described in the PRD.

### Before fix: parent regression (`892fc7e0c`)

Command:

```text
go test ./tests/functional/models/root_composition -run TestModelsPullToReadySurvivesProcessReconstruction -count=1 -v
```

Verbatim output:

```text
=== RUN   TestModelsPullToReadySurvivesProcessReconstruction
    pull_to_ready_test.go:51: Process.Execute(models pull asr) error = CLI_MODEL_PULL_FAILED: managed runtime pull for "asr" failed with outcome CACHE_INSTALLATION_FAILED (readiness FAILED)
        stdout:
        {"cachePath":"","downloadedFiles":[{"bytes":22,"path":"ggml-base.en.bin","sha256":"13ed50da6c2f8bcedff05edb6e7429453942075e88ea1bda3381282c84f6a6ae"}],"managedRuntimePull":{"downloadedFiles":[{"bytes":22,"path":"ggml-base.en.bin","sha256":"13ed50da6c2f8bcedff05edb6e7429453942075e88ea1bda3381282c84f6a6ae"}],"identity":"asr","pullDiagnostics":{"modelName":"asr","operation":"resolve managed runtime cache","resolvedRepository":"ggerganov/whisper.cpp","revision":"5359861c739e955e79d9a303bcbc70fb988958b1"},"pullOutcome":"CACHE_INSTALLATION_FAILED","readinessState":"FAILED","revision":"5359861c739e955e79d9a303bcbc70fb988958b1"},"modelName":"asr","outcome":"FAILED","providerLocality":"LOCAL","revision":"5359861c739e955e79d9a303bcbc70fb988958b1"}
        
        stderr:
        {"code":"CLI_MODEL_PULL_FAILED","family":"BAD_REQUEST","message":"managed runtime pull for \"asr\" failed with outcome CACHE_INSTALLATION_FAILED (readiness FAILED)"}
--- FAIL: TestModelsPullToReadySurvivesProcessReconstruction (0.10s)
FAIL
FAIL	github.com/portpowered/infinite-you/tests/functional/models/root_composition	0.146s
```

Before-fix state summary: the pull downloaded 22 bytes, ended in `CACHE_INSTALLATION_FAILED`, and the subsequent empty-cache inspection was `lifecycleState=NOT_INSTALLED` / `readinessState=MISSING`.

### After fix: final head (`abd5ede32770750c36f9c9fbae4e99d0c0cf1d0f`)

Command:

```text
go test ./tests/functional/models/root_composition -run TestModelsPullToReadySurvivesProcessReconstruction -count=1 -v
```

Verbatim output:

```text
=== RUN   TestModelsPullToReadySurvivesProcessReconstruction
    pull_to_ready_test.go:78: pull-to-ready commands passed: downloadedBytes=22 inspectCacheBytes=22 restartInspectCacheBytes=22 cacheRoot=C:\Users\andre\AppData\Local\Temp\TestModelsPullToReadySurvivesProcessReconstruction2374407729\001\.agent-factory\models assetRequests=2
--- PASS: TestModelsPullToReadySurvivesProcessReconstruction (0.30s)
PASS
ok  	github.com/portpowered/infinite-you/tests/functional/models/root_composition	0.335s
```

After-fix state: pull, same-process inspect/list, and reconstructed-process inspect/list all reported `READY`/`INSTALLED`; the controlled asset and inspected cache each measured 22 bytes.

## Separate real-artifact runtime proof

The fresh delivered-artifact proof is independent of the controlled regression. Its authoritative verbatim transcript is recorded in [PR comment 5390951575](https://github.com/portpowered/you-agent-factory/pull/2261#issuecomment-5390951575). It built `you-verify.exe`, redirected both `HOME` and `USERPROFILE` to an isolated scratch home, used no daemon or port 7437, downloaded only ASR, and ran pull, inspect, list, and a second-process inspect. The ASR pull downloaded 147964211 bytes and returned `INSTALLED_SUCCESSFULLY` / `READY`; every command exited 0 and all ASR readiness/lifecycle observations were `READY` / `INSTALLED` at revision `5359861c739e955e79d9a303bcbc70fb988958b1`.