### PR TITLE
Gracefully skip unavailable browser verification tools

### DIFF
--- a/factory/workstations/plan/AGENTS.md
+++ b/factory/workstations/plan/AGENTS.md
@@ -151,7 +151,7 @@ Story-writing rules:
 - every story must include at least one behavioral acceptance criterion
 - `Typecheck passes` must appear in every story
 - add `Tests pass` when testable logic changes
-- add direct browser verification when the story changes visible UI behavior
+- add direct browser verification when the story changes visible UI behavior. When a story's acceptance criteria require browser verification, name a fallback explicitly: state that if no dev browser tool (built-in, Playwright, or otherwise) is available in the implementer's environment, the implementer should record that once and move on rather than treat it as unfinished work requiring further attempts. Visible UI changes still require some appropriate verification.
 - order stories by dependency so earlier stories do not depend on later ones
 
 Please ensure that the PRD and prd.json both contain an overall description of
@@ -244,10 +244,6 @@ Add priority levels to tasks so users can focus on what matters most. Tasks can 
 - Should we add keyboard shortcuts for priority changes?
 ```
 
-### Dev browser skill
-
-The requirement to use the dev browser skill can be any form of browser whether its the built in one, playwright or whatever. 
-If no dev browser skill is available then its okay to move forward without it. 
 ## Output JSON Format
 
 ```json

--- a/factory/workstations/process/AGENTS.md
+++ b/factory/workstations/process/AGENTS.md
@@ -23,6 +23,7 @@ You are an autonomous coding agent working on a software project.
   SHA, record the run URL + test name in a PR COMMENT, rerun failed jobs ONCE,
   and move on — baseline flakes are owned by dedicated deflake lanes; do not
   burn your session re-proving them.
+- Browser/screenshot verification: attempt the required browser tool (dev-browser skill, Playwright MCP, or whichever the PRD names) using its single supported connection/availability check ONCE per session. If it returns no available instance, record that exact result in progress.txt ONE time, mark the affected PRD item's evidence as "live browser verification unavailable in this environment" rather than passes:true, and move on to other PRD items this same session. Do NOT retry the same connection/availability check again within the session, and do NOT spend a subsequent session re-attempting a check that already returned unavailable in a prior session unless the PRD or an operator note explicitly asks you to recheck. An unavailable browser tool is a system limitation, not a task to solve; substitute other available automated evidence (component/unit tests, an existing passing CI browser job) when the PRD allows it, or explicitly note the item as blocked-by-environment and leave it for review, which is authorized to waive it (see review/AGENTS.md addenda).
 - NEVER commit CI results, audit notes, or verification records onto your
   branch: each such commit creates a new head, invalidates the CI run it
   describes, and restarts CI. Evidence about a CI run belongs in a PR comment.


### PR DESCRIPTION
{
  "project": "Gracefully Skip Unavailable Browser Verification Tools",
  "branchName": "process-browser-tool-unavailable-graceful-skip",
  "description": "Prevent prompt-driven implementation lanes from exhausting their visit cap when required browser verification has no available tool instance by adding bounded graceful degradation to process instructions and making the fallback a standing planning rule, without weakening verification or changing product runtime code.",
  "context": {
    "customerAsk": "Close the instruction gap exposed by PR #2258, where a fully implemented, all-green lane repeatedly checked an unavailable browser MCP connection until it exhausted its process visits. Apply the supplied process rule verbatim, relocate and strengthen the planning fallback, and leave review unchanged unless a genuine contradiction is found.",
    "problem": "The process workstation that performs browser verification has no browser-tool unavailability rule, while the planning fallback is positioned beside example/template content. An empty browser instance list is therefore repeatedly treated as unfinished implementation work even though review already has authority to waive the external tool outage.",
    "solution": "Add a once-per-session, no-repeat browser availability rule to the process workstation; place the explicit unavailable-tool fallback beside the plan workstation's direct-browser-verification story rule; preserve review's compatible waiver; and verify configuration validity and strict prompt-document scope."
  },
  "acceptanceCriteria": [
    "factory/workstations/process/AGENTS.md contains the supplied browser/screenshot verification bullet verbatim in ## Important immediately after the Keep CI green baseline-flake bullet; an unavailable instance is checked once, recorded exactly once in progress.txt, labeled live browser verification unavailable in this environment rather than passes:true, followed by continued work, and not retried in a later session without an explicit PRD or operator request.",
    "factory/workstations/plan/AGENTS.md contains this standing instruction in the main story-writing prose beside add direct browser verification when the story changes visible UI behavior: When a story's acceptance criteria require browser verification, name a fallback explicitly: state that if no dev browser tool (built-in, Playwright, or otherwise) is available in the implementer's environment, the implementer should record that once and move on rather than treat it as unfinished work requiring further attempts. The former Dev browser skill note between the sample PRD and JSON example is removed, and visible UI changes still require some appropriate verification.",
    "factory/workstations/review/AGENTS.md remains unchanged because its existing waiver is compatible, unless implementation finds and documents a genuine contradiction; git diff --stat otherwise shows only factory/workstations/process/AGENTS.md and factory/workstations/plan/AGENTS.md, no prohibited source or standards changes, and you factory config validate factory/factory.json exits successfully with verbatim output recorded in the PR conversation while factory/factory.json remains untouched.",
    "Runtime-proof classification: not applicable. This lane changes prompt/process documents only and does not change runtime-observable CLI, API, UI, emitted-event, or runtime-lifecycle behavior; record this one-line reason as a first-class non-blocking outcome.",
    "Final quality gate: Typecheck passes and relevant tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Verification remains proportional to this prompt-only change, includes factory configuration validation, and adds no meta tests that scan source or enforce file inventories.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "process-browser-tool-unavailable-graceful-skip-001",
      "title": "Bound unavailable browser checks in process sessions",
      "description": "As a process worker, I want explicit graceful-degradation behavior when the required browser tool has no available instance so that I preserve truthful verification state, continue useful work, and do not exhaust the lane's visit cap repeating an environmental failure.",
      "acceptanceCriteria": [
        "The process workstation's ## Important section includes the customer-supplied browser/screenshot verification bullet verbatim immediately after the Keep CI green baseline-flake bullet.",
        "When the named browser tool's single supported availability check returns no instance, the instruction requires the worker to record that exact result once in progress.txt, label the affected evidence live browser verification unavailable in this environment instead of setting passes:true, and continue other PRD work in the same session.",
        "The instruction prohibits retrying that availability check within the session and prohibits spending a later session rechecking a previously unavailable tool unless the PRD or an operator note explicitly requests it.",
        "The instruction preserves verification intent by directing the worker to substitute allowed automated evidence or leave an explicit environment-blocked item for review's existing waiver; code and test failures are not waivable tool outages.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added the supplied browser/screenshot verification rule verbatim to the process workstation's ## Important section immediately after the Keep CI green baseline-flake bullet. The rule bounds availability checks to once per session, records an unavailable result once without claiming passes:true, continues other PRD work, preserves allowed substitute evidence and review handoff, and prohibits later retries without an explicit request."
    },
    {
      "id": "process-browser-tool-unavailable-graceful-skip-002",
      "title": "Make browser fallback a standing planning rule and verify delivery scope",
      "description": "As an implementer receiving a generated PRD, I want browser-tool fallback guidance next to the planning rule that creates browser acceptance criteria so that an unavailable tool is handled once and never mistaken for endlessly unfinished work.",
      "acceptanceCriteria": [
        "The exact replacement sentence from the project acceptance criteria appears in the plan workstation's main story-writing prose beside the direct-browser-verification instruction and explicitly applies whenever a generated story requires browser verification.",
        "The old Dev browser skill note is removed from between the sample PRD and output JSON example, while generated plans still require direct browser verification for visible UI changes and name graceful fallback when the tool is unavailable.",
        "factory/workstations/review/AGENTS.md is unchanged unless a genuine contradiction with its existing waiver addendum is found and documented; no contradiction is introduced between planning, processing, and review responsibilities.",
        "you factory config validate factory/factory.json exits successfully, and the PR conversation contains the verbatim command output; factory/factory.json itself remains unchanged.",
        "The final diff is confined to factory/workstations/process/AGENTS.md and factory/workstations/plan/AGENTS.md, plus factory/workstations/review/AGENTS.md only if a genuine contradiction required reconciliation; no Go, UI, website-standard, or unrelated documentation file changes are included.",
        "Runtime-proof classification: not applicable. This lane changes prompt/process documents only and does not change runtime-observable CLI, API, UI, emitted-event, or runtime-lifecycle behavior; record this one-line reason as a first-class non-blocking outcome.",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Moved the browser fallback into the main story-writing rule beside direct browser verification, retained the requirement for appropriate verification of visible UI changes, and removed the former Dev browser skill note between the sample PRD and JSON example. `you factory config validate factory/factory.json` passed; factory/factory.json and review/AGENTS.md remain unchanged. Runtime-proof classification: not applicable — this lane changes prompt/process documents only and does not change runtime-observable CLI, API, UI, emitted-event, or runtime-lifecycle behavior."
    }
  ]
}
