### PR TITLE
test: make pprof opt-in public run path deterministic

### DIFF
--- a/tests/functional/transport/http/server/startup_shutdown_test.go
+++ b/tests/functional/transport/http/server/startup_shutdown_test.go
@@ -76,7 +76,7 @@ func TestAPIServerPprofIsOptInThroughThePublicRunPath(t *testing.T) {
 		runtimeSnapshot.SysBytes < runtimeSnapshot.HeapInuseBytes || runtimeSnapshot.Goroutines <= 0 {
 		t.Fatalf("default runtime snapshot = %+v, want plausible live runtime values", runtimeSnapshot)
 	}
-	defaultServer.Close(t)
+	defaultServer.Stop(t)
 	assertRuntimeMemoryMetrics(t, metricsDir)
 
 	enabledServer := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
@@ -86,6 +86,7 @@ func TestAPIServerPprofIsOptInThroughThePublicRunPath(t *testing.T) {
 		Args:                      []string{"--pprof"},
 	})
 	assertEnabledPprofServer(t, enabledServer)
+	enabledServer.Stop(t)
 }
 
 func assertEnabledPprofServer(t *testing.T, enabledServer *support.FunctionalAPIServer) {


### PR DESCRIPTION
{
  "project": "Deflake pprof opt-in verification through the public run path",
  "branchName": "deflake-pprof-optin-public-run-path",
  "description": "Make TestAPIServerPprofIsOptInThroughThePublicRunPath deterministic while preserving its customer-observable contract: diagnostics routes are unavailable by default, --pprof exposes valid live profiles on the loopback API server created through the canonical public run path, and shutdown releases the server cleanly. The intent is to restore a reliable Backend Functional Coverage and Verification Policy baseline by fixing the flake itself without weakening the test, changing product behavior, editing coverage-floor manifests, or overlapping PR #2189's sibling CLI flake.",
  "context": {
    "customerAsk": "Deflake only TestAPIServerPprofIsOptInThroughThePublicRunPath and its immediate package, record the same focused test's before-and-after 50-run pass/fail counts in the PR body, and leave PR #2189's TestCLITextStreamInterruptedRunDoesNotClaimCompletion work and all coverage-floor manifests untouched.",
    "problem": "The cited latest main run 32688142876 at head 076924a890f7d3ba105223cc0dd5f42f711a7e87 failed Backend Functional Coverage because this pprof functional test flakes, causing the required Verification Policy check to fail and taxing unrelated pull requests. The test combines two application lifecycles, live diagnostics requests, runtime metrics observation, and profile collection, so an unreliable readiness, shutdown, shared profiling-state, port-ownership, or timing assumption can make a correct product appear broken.",
    "solution": "Capture the actual focused failure signature, trace it to the smallest nondeterministic observation or lifecycle boundary in tests/functional/transport/http/server, and replace that assumption with deterministic synchronization or assertion design while retaining the real public application run path, loopback HTTP behavior, and parseable profile checks. Record the verbatim focused command and pre-fix and post-fix counts; the post-fix run must pass 50 of 50."
  },
  "acceptanceCriteria": [
    "TestAPIServerPprofIsOptInThroughThePublicRunPath deterministically proves through the public application run path that the documented diagnostics routes return normal not-found behavior without --pprof, that --pprof serves non-empty parseable live pprof data, and that each started server is cleanly shut down; no assertion is removed or weakened merely to obtain a pass.",
    "The PR body records the verbatim focused command go test ./tests/functional/transport/http/server -run '^TestAPIServerPprofIsOptInThroughThePublicRunPath$' -count=50, the pre-fix pass/fail count and representative failure signature, and the post-fix pass/fail count; the post-fix result is 50 passes and 0 failures.",
    "The fix uses deterministic observation or synchronization appropriate to the identified cause and introduces no skip, deletion, xfail/quarantine, retry-until-pass masking, or unjustified sleep/timeout padding. Changes remain within the failing test and its immediate tests/functional/transport/http/server package, do not touch TestCLITextStreamInterruptedRunDoesNotClaimCompletion or its file as owned by PR #2189, and do not edit any coverage-floor manifest.",
    "Runtime-proof classification: this lane does not change runtime-observable CLI, API, UI, emitted-event, or runtime-lifecycle behavior; runtime proof with a built delivered artifact is not applicable because the change is test-only. The required direct proof is the real public-run-path functional test and its recorded 50-run before/after evidence.",
    "Quality gate: the focused test passes 50/50 after the fix, relevant package tests and the applicable backend verification tier pass, Typecheck passes, Tests pass, and there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "deflake-pprof-optin-public-run-path-001",
      "title": "Make pprof opt-in functional verification deterministic",
      "description": "As a maintainer, I want the public-run-path pprof opt-in test to make deterministic lifecycle and diagnostics observations so required functional CI reliably distinguishes a real pprof regression from test timing or shared-state noise.",
      "acceptanceCriteria": [
        "A focused pre-fix stress run captures the observed pass/fail count and representative failure signature without changing the tested behavior, and that evidence identifies the lifecycle, resource, shared profiling state, or assertion assumption that must be made deterministic.",
        "The test continues to start the application through the canonical public run path and proves that pprof routes are absent by default while the normal runtime diagnostics behavior remains available.",
        "With --pprof, the test deterministically receives successful, non-empty, parseable live pprof responses and completes clean shutdown without relying on an unjustified sleep, timeout padding, skip, quarantine, retry-until-pass loop, or fixed-port assumption.",
        "Running go test ./tests/functional/transport/http/server -run '^TestAPIServerPprofIsOptInThroughThePublicRunPath$' -count=50 after the fix reports 50 passes and 0 failures; the PR body includes the verbatim command and both pre-fix and post-fix pass/fail counts.",
        "The diff is confined to the failing test and its immediate tests/functional/transport/http/server package, does not touch TestCLITextStreamInterruptedRunDoesNotClaimCompletion or its file, does not edit coverage-floor manifests, and contains no broad unrelated cleanup.",
        "Runtime-proof classification: this lane does not change runtime-observable CLI, API, UI, emitted-event, or runtime-lifecycle behavior; runtime proof with a built delivered artifact is not applicable because the change is test-only. The required direct proof is the real public-run-path functional test and its recorded 50-run before/after evidence.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Focused command: go test ./tests/functional/transport/http/server -run '^TestAPIServerPprofIsOptInThroughThePublicRunPath$' -count=50. Pre-fix local run: 50 passes, 0 failures in 203.822s; representative failure from main run 32688142876: startup_shutdown_test.go:80 reported runtime memory observation count = 4, want a positive multiple of 7, with names heap_alloc, heap_inuse, sys, num_gc. Fix: stop and join each active public invocation before reading metrics or finishing the pprof lifecycle. Post-fix run: 50 passes, 0 failures in 303.504s. Broader verification: make test, make typecheck, make backend-size, make pkg-maint, make pkg-file-count, make pkg-structure, and go vet ./... passed. Aggregate make lint reproduced one existing packaged-factory-consumption-check violation in untouched internal/migrationledgercheck/packaged_factory_matrix.go; no new lint violation is present in this diff."
    }
  ]
}
