### PR TITLE
ci-flake-prevention-stability-gate-and-quarantine-discipline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,6 +482,31 @@ jobs:
               body: publication.body,
             });
 
+  backend-test-stability:
+    name: Backend Test Stability
+    needs: classify
+    # This is a pull-request hard gate. Classification-driven skips remain
+    # observable to Verification Policy, which rejects an unexpected skip.
+    if: github.event_name == 'pull_request' && needs.classify.outputs.run_backend != 'false'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Run changed-test stability hard gate
+        env:
+          CHANGED_TEST_STABILITY_BASE: ${{ github.event.pull_request.base.sha }}
+          CHANGED_TEST_STABILITY_HEAD: ${{ github.event.pull_request.head.sha }}
+          CHANGED_TEST_STABILITY_ATTEMPTS: "20"
+          CHANGED_TEST_STABILITY_BUDGET: 15m
+        run: make test-changed-test-stability
+
   backend-lint:
     name: Backend Lint
     if: github.event_name == 'pull_request' || github.event_name == 'push'
@@ -701,7 +726,7 @@ jobs:
 
   verification-policy:
     name: Verification Policy
-    needs: [classify, docs-reference, readme, frontend, frontend-component, ui-coverage, frontend-browser, frontend-storybook, backend-coverage, backend-lint, ui-backend-integration, development-package]
+    needs: [classify, docs-reference, readme, frontend, frontend-component, ui-coverage, frontend-browser, frontend-storybook, backend-coverage, backend-test-stability, backend-lint, ui-backend-integration, development-package]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -743,6 +768,9 @@ jobs:
           FRONTEND_BROWSER_RESULT: ${{ needs.frontend-browser.result }}
           FRONTEND_STORYBOOK_RESULT: ${{ needs.frontend-storybook.result }}
           BACKEND_RESULT: ${{ needs.backend-coverage.result }}
+          RUN_BACKEND_STABILITY: ${{ github.event_name == 'pull_request' && needs.classify.outputs.run_backend != 'false' }}
+          BACKEND_STABILITY_REASON: ${{ needs.classify.outputs.backend_reason }}
+          BACKEND_STABILITY_RESULT: ${{ needs.backend-test-stability.result }}
           RUN_BACKEND_LINT: "true"
           BACKEND_LINT_REASON: "The complete canonical LINT_TARGETS inventory is required on every pull request and push to main."
           BACKEND_LINT_RESULT: ${{ needs.backend-lint.result }}

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,10 @@ FUNCTIONAL_TEST_TIER ?= pr-short
 FUNCTIONAL_TEST_TRIGGER ?= local
 FUNCTIONAL_TEST_BUDGET ?= 35m
 FUNCTIONAL_SHORT ?= true
+CHANGED_TEST_STABILITY_BASE ?=
+CHANGED_TEST_STABILITY_HEAD ?= HEAD
+CHANGED_TEST_STABILITY_ATTEMPTS ?= 20
+CHANGED_TEST_STABILITY_BUDGET ?= 15m
 GO_UNIT_COVERAGE_PROFILE ?=
 GO_UNIT_COVERAGE_JSON_OUTPUT ?=
 GO_UNIT_COVERAGE_TIMING_OUTPUT ?=
@@ -498,6 +502,13 @@ test-unit:
 
 test-unit-fresh:
 	$(GO) run ./cmd/unitlane -jobs $(UNIT_DEFAULT_JOBS) -count=1 -timeout $(GO_TEST_TIMEOUT)
+
+# Merge-base-aware changed-test flake prevention. The caller must provide the
+# pull-request base ref/SHA; the command resolves its merge-base with head,
+# then gives every selected top-level Go test 20 isolated attempts within one
+# 15-minute total budget.
+test-changed-test-stability:
+	$(GO) run ./cmd/teststability -base "$(CHANGED_TEST_STABILITY_BASE)" -head "$(CHANGED_TEST_STABILITY_HEAD)" -attempts $(CHANGED_TEST_STABILITY_ATTEMPTS) -budget $(CHANGED_TEST_STABILITY_BUDGET)
 
 test-lane-audit:
 	$(GO) run ./cmd/testlanecheck

--- a/cmd/gocoveragecheck/functional_quarantine.go
+++ b/cmd/gocoveragecheck/functional_quarantine.go
@@ -845,43 +845,6 @@ func validateFunctionalQuarantineEntry(entry functionalQuarantineEntry, index in
 	return validateFunctionalQuarantineEntryMetadata(entry)
 }
 
-func validateFunctionalQuarantineEntryMetadata(entry functionalQuarantineEntry) error {
-	if entry.Bucket != functionalBucketEnvironment && entry.Bucket != functionalBucketFailure && entry.Bucket != functionalBucketFlaky {
-		return fmt.Errorf("validate functional quarantine: selector %q has unsupported bucket %q; expected %s, %s, or %s", functionalSelectorDisplay(entry), entry.Bucket, functionalBucketEnvironment, functionalBucketFailure, functionalBucketFlaky)
-	}
-	if _, err := functionalQuarantineMeasurement(entry); err != nil {
-		return fmt.Errorf("validate functional quarantine: selector %q has invalid measurement metadata: %w", functionalSelectorDisplay(entry), err)
-	}
-	if strings.TrimSpace(entry.Reason) == "" {
-		return fmt.Errorf("validate functional quarantine: selector %q requires a non-empty reason", functionalSelectorDisplay(entry))
-	}
-	if entry.Bucket == functionalBucketFailure && strings.TrimSpace(entry.FollowUp) == "" {
-		return fmt.Errorf("validate functional quarantine: genuinely failing selector %q requires a non-empty followUp", functionalSelectorDisplay(entry))
-	}
-	if entry.Bucket == functionalBucketFlaky && strings.TrimSpace(entry.FollowUpIssue) == "" && strings.TrimSpace(entry.FollowUpLane) == "" {
-		return fmt.Errorf("validate functional quarantine: FLAKY selector %q requires a non-empty followUpIssue or followUpLane", functionalSelectorDisplay(entry))
-	}
-	return nil
-}
-
-func validateFunctionalQuarantineMetadata(manifest functionalQuarantine) error {
-	if manifest.Version != functionalQuarantineVersion {
-		return fmt.Errorf("validate functional quarantine: version %d is unsupported; expected %d", manifest.Version, functionalQuarantineVersion)
-	}
-	if manifest.Suite != functionalSuiteName {
-		return fmt.Errorf("validate functional quarantine: suite %q is unsupported; expected %q", manifest.Suite, functionalSuiteName)
-	}
-	if manifest.Entries == nil {
-		return errors.New("validate functional quarantine: entries must be an array")
-	}
-	for index, entry := range manifest.Entries {
-		if err := validateFunctionalQuarantineEntryMetadata(entry); err != nil {
-			return fmt.Errorf("entries[%d]: %w", index, err)
-		}
-	}
-	return nil
-}
-
 func buildFunctionalCoverageSelection(manifest functionalQuarantine, inventory functionalTestInventory) (functionalCoverageSelection, error) {
 	packageExcluded := make(map[string]struct{})
 	testExcluded := make(map[string]map[string]struct{})

--- a/cmd/gocoveragecheck/functional_quarantine.go
+++ b/cmd/gocoveragecheck/functional_quarantine.go
@@ -20,6 +20,7 @@ const (
 	functionalSuiteName                   = "functional"
 	functionalBucketEnvironment           = "ENVIRONMENT-DEPENDENT"
 	functionalBucketFailure               = "GENUINELY FAILING"
+	functionalBucketFlaky                 = "FLAKY"
 	functionalMeasurementIsolated         = "isolated"
 	functionalMeasurementPackageContext   = "package-context"
 	functionalMeasurementRepeatedIsolated = "repeated-isolated"
@@ -36,13 +37,15 @@ type functionalQuarantine struct {
 }
 
 type functionalQuarantineEntry struct {
-	Package     string `json:"package"`
-	Test        string `json:"test,omitempty"`
-	Bucket      string `json:"bucket"`
-	Reason      string `json:"reason"`
-	FollowUp    string `json:"followUp,omitempty"`
-	Measurement string `json:"measurement,omitempty"`
-	Attempts    int    `json:"attempts,omitempty"`
+	Package       string `json:"package"`
+	Test          string `json:"test,omitempty"`
+	Bucket        string `json:"bucket"`
+	Reason        string `json:"reason"`
+	FollowUp      string `json:"followUp,omitempty"`
+	FollowUpIssue string `json:"followUpIssue,omitempty"`
+	FollowUpLane  string `json:"followUpLane,omitempty"`
+	Measurement   string `json:"measurement,omitempty"`
+	Attempts      int    `json:"attempts,omitempty"`
 }
 
 type functionalTestInventory struct {
@@ -572,8 +575,8 @@ func formatFunctionalQuarantineMeasurement(measurement functionalQuarantineMeasu
 // a push to the default branch does not. A test that self-skips under
 // testing.Short() is therefore observed as a skip on the PR tier no matter
 // whether it fails, so asserting expected=fail there asks an unanswerable
-// question. Only a GENUINELY FAILING entry is affected; an ENVIRONMENT-DEPENDENT
-// entry already expects a skip.
+// question. Failure-oriented entries, including FLAKY, are affected; an
+// ENVIRONMENT-DEPENDENT entry already expects a skip.
 func unmeasurableFunctionalQuarantineOutcome(short bool, expected, observed string) bool {
 	return short &&
 		expected == functionalQuarantineOutcomeFail &&
@@ -584,7 +587,7 @@ func expectedFunctionalQuarantineOutcome(bucket string) (string, error) {
 	switch bucket {
 	case functionalBucketEnvironment:
 		return functionalQuarantineOutcomeSkip, nil
-	case functionalBucketFailure:
+	case functionalBucketFailure, functionalBucketFlaky:
 		return functionalQuarantineOutcomeFail, nil
 	default:
 		return "", fmt.Errorf("unsupported quarantine bucket")
@@ -839,8 +842,12 @@ func validateFunctionalQuarantineEntry(entry functionalQuarantineEntry, index in
 			return fmt.Errorf("validate functional quarantine: selector %q is not discoverable in package %q", entry.Test, entry.Package)
 		}
 	}
-	if entry.Bucket != functionalBucketEnvironment && entry.Bucket != functionalBucketFailure {
-		return fmt.Errorf("validate functional quarantine: selector %q has unsupported bucket %q; expected %s or %s", functionalSelectorDisplay(entry), entry.Bucket, functionalBucketEnvironment, functionalBucketFailure)
+	return validateFunctionalQuarantineEntryMetadata(entry)
+}
+
+func validateFunctionalQuarantineEntryMetadata(entry functionalQuarantineEntry) error {
+	if entry.Bucket != functionalBucketEnvironment && entry.Bucket != functionalBucketFailure && entry.Bucket != functionalBucketFlaky {
+		return fmt.Errorf("validate functional quarantine: selector %q has unsupported bucket %q; expected %s, %s, or %s", functionalSelectorDisplay(entry), entry.Bucket, functionalBucketEnvironment, functionalBucketFailure, functionalBucketFlaky)
 	}
 	if _, err := functionalQuarantineMeasurement(entry); err != nil {
 		return fmt.Errorf("validate functional quarantine: selector %q has invalid measurement metadata: %w", functionalSelectorDisplay(entry), err)
@@ -850,6 +857,27 @@ func validateFunctionalQuarantineEntry(entry functionalQuarantineEntry, index in
 	}
 	if entry.Bucket == functionalBucketFailure && strings.TrimSpace(entry.FollowUp) == "" {
 		return fmt.Errorf("validate functional quarantine: genuinely failing selector %q requires a non-empty followUp", functionalSelectorDisplay(entry))
+	}
+	if entry.Bucket == functionalBucketFlaky && strings.TrimSpace(entry.FollowUpIssue) == "" && strings.TrimSpace(entry.FollowUpLane) == "" {
+		return fmt.Errorf("validate functional quarantine: FLAKY selector %q requires a non-empty followUpIssue or followUpLane", functionalSelectorDisplay(entry))
+	}
+	return nil
+}
+
+func validateFunctionalQuarantineMetadata(manifest functionalQuarantine) error {
+	if manifest.Version != functionalQuarantineVersion {
+		return fmt.Errorf("validate functional quarantine: version %d is unsupported; expected %d", manifest.Version, functionalQuarantineVersion)
+	}
+	if manifest.Suite != functionalSuiteName {
+		return fmt.Errorf("validate functional quarantine: suite %q is unsupported; expected %q", manifest.Suite, functionalSuiteName)
+	}
+	if manifest.Entries == nil {
+		return errors.New("validate functional quarantine: entries must be an array")
+	}
+	for index, entry := range manifest.Entries {
+		if err := validateFunctionalQuarantineEntryMetadata(entry); err != nil {
+			return fmt.Errorf("entries[%d]: %w", index, err)
+		}
 	}
 	return nil
 }

--- a/cmd/gocoveragecheck/functional_quarantine_metadata.go
+++ b/cmd/gocoveragecheck/functional_quarantine_metadata.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func validateFunctionalQuarantineEntryMetadata(entry functionalQuarantineEntry) error {
+	if entry.Bucket != functionalBucketEnvironment && entry.Bucket != functionalBucketFailure && entry.Bucket != functionalBucketFlaky {
+		return fmt.Errorf("validate functional quarantine: selector %q has unsupported bucket %q; expected %s, %s, or %s", functionalSelectorDisplay(entry), entry.Bucket, functionalBucketEnvironment, functionalBucketFailure, functionalBucketFlaky)
+	}
+	if _, err := functionalQuarantineMeasurement(entry); err != nil {
+		return fmt.Errorf("validate functional quarantine: selector %q has invalid measurement metadata: %w", functionalSelectorDisplay(entry), err)
+	}
+	if strings.TrimSpace(entry.Reason) == "" {
+		return fmt.Errorf("validate functional quarantine: selector %q requires a non-empty reason", functionalSelectorDisplay(entry))
+	}
+	if entry.Bucket == functionalBucketFailure && strings.TrimSpace(entry.FollowUp) == "" {
+		return fmt.Errorf("validate functional quarantine: genuinely failing selector %q requires a non-empty followUp", functionalSelectorDisplay(entry))
+	}
+	if entry.Bucket == functionalBucketFlaky && strings.TrimSpace(entry.FollowUpIssue) == "" && strings.TrimSpace(entry.FollowUpLane) == "" {
+		return fmt.Errorf("validate functional quarantine: FLAKY selector %q requires a non-empty followUpIssue or followUpLane", functionalSelectorDisplay(entry))
+	}
+	return nil
+}
+
+func validateFunctionalQuarantineMetadata(manifest functionalQuarantine) error {
+	if manifest.Version != functionalQuarantineVersion {
+		return fmt.Errorf("validate functional quarantine: version %d is unsupported; expected %d", manifest.Version, functionalQuarantineVersion)
+	}
+	if manifest.Suite != functionalSuiteName {
+		return fmt.Errorf("validate functional quarantine: suite %q is unsupported; expected %q", manifest.Suite, functionalSuiteName)
+	}
+	if manifest.Entries == nil {
+		return errors.New("validate functional quarantine: entries must be an array")
+	}
+	for index, entry := range manifest.Entries {
+		if err := validateFunctionalQuarantineEntryMetadata(entry); err != nil {
+			return fmt.Errorf("entries[%d]: %w", index, err)
+		}
+	}
+	return nil
+}

--- a/cmd/gocoveragecheck/functional_quarantine_test.go
+++ b/cmd/gocoveragecheck/functional_quarantine_test.go
@@ -186,6 +186,11 @@ func functionalQuarantineValidationMeasurementCases(packagePath string) []functi
 			want:    "followUp",
 		},
 		{
+			name:    "flaky ownership",
+			entries: []functionalQuarantineEntry{{Package: packagePath, Test: "TestKnown", Bucket: functionalBucketFlaky, Reason: "intermittent failure"}},
+			want:    "followUpIssue or followUpLane",
+		},
+		{
 			name: "overlapping package and test",
 			entries: []functionalQuarantineEntry{
 				{Package: packagePath, Bucket: functionalBucketEnvironment, Reason: "whole package precondition"},
@@ -218,6 +223,114 @@ func TestReadFunctionalQuarantineRejectsUnknownFieldsAndTrailingValues(t *testin
 				t.Fatalf("readFunctionalQuarantineFile() error = %v, want substring %q", err, test.want)
 			}
 		})
+	}
+}
+
+func TestFunctionalQuarantineFlakyOwnershipUsesScratchManifest(t *testing.T) {
+	packagePath := modulePath + "/tests/functional/alpha"
+	inventory := functionalTestInventory{
+		Packages: []string{packagePath},
+		Tests:    map[string][]string{packagePath: {"TestKnown"}},
+	}
+	manifest := functionalQuarantine{
+		Version: functionalQuarantineVersion,
+		Suite:   functionalSuiteName,
+		Entries: []functionalQuarantineEntry{{
+			Package: packagePath,
+			Test:    "TestKnown",
+			Bucket:  functionalBucketFlaky,
+			Reason:  "intermittent failure fixture",
+		}},
+	}
+	path := filepath.Join(t.TempDir(), "functional-quarantine.json")
+
+	writeAndValidate := func() error {
+		data, err := json.MarshalIndent(manifest, "", "  ")
+		if err != nil {
+			t.Fatalf("marshal scratch manifest: %v", err)
+		}
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			t.Fatalf("write scratch manifest: %v", err)
+		}
+		parsed, err := readFunctionalQuarantineFile(path)
+		if err != nil {
+			return err
+		}
+		return validateFunctionalQuarantine(parsed, inventory)
+	}
+
+	err := writeAndValidate()
+	if err == nil || !strings.Contains(err.Error(), `selector "`+packagePath+`#TestKnown"`) || !strings.Contains(err.Error(), "followUpIssue or followUpLane") {
+		t.Fatalf("missing flaky ownership error = %v, want selector-specific follow-up diagnostic", err)
+	}
+
+	manifest.Entries[0].FollowUpIssue = "issue-123"
+	if err := writeAndValidate(); err != nil {
+		t.Fatalf("issue-owned flaky manifest validation error = %v, want success", err)
+	}
+	parsed, err := readFunctionalQuarantineFile(path)
+	if err != nil {
+		t.Fatalf("read issue-owned scratch manifest: %v", err)
+	}
+	if parsed.Entries[0].FollowUpIssue != "issue-123" {
+		t.Fatalf("parsed followUpIssue = %q, want issue-123", parsed.Entries[0].FollowUpIssue)
+	}
+
+	manifest.Entries[0].FollowUpIssue = ""
+	manifest.Entries[0].FollowUpLane = "ci/deflake-flaky-selector"
+	if err := writeAndValidate(); err != nil {
+		t.Fatalf("lane-owned flaky manifest validation error = %v, want success", err)
+	}
+
+	manifest.Entries[0].FollowUpLane = "  \t"
+	if err := writeAndValidate(); err == nil || !strings.Contains(err.Error(), "followUpIssue or followUpLane") {
+		t.Fatalf("blank flaky ownership error = %v, want required follow-up diagnostic", err)
+	}
+}
+
+func TestFunctionalQuarantineSelectorVerificationRejectsFlakyOwnershipBeforeListing(t *testing.T) {
+	originalRunner := commandRunner
+	originalStdout := stdoutWriter
+	t.Cleanup(func() {
+		commandRunner = originalRunner
+		stdoutWriter = originalStdout
+	})
+
+	path := filepath.Join(t.TempDir(), "functional-quarantine.json")
+	manifest := functionalQuarantine{
+		Version: functionalQuarantineVersion,
+		Suite:   functionalSuiteName,
+		Entries: []functionalQuarantineEntry{{
+			Package: modulePath + "/tests/functional/alpha",
+			Test:    "TestKnown",
+			Bucket:  functionalBucketFlaky,
+			Reason:  "missing ownership fixture",
+		}},
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal invalid flaky manifest: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write invalid flaky manifest: %v", err)
+	}
+	commandRunner = func(commandInvocation) (string, string, error) {
+		t.Fatal("invalid flaky metadata unexpectedly started selector listing")
+		return "", "", nil
+	}
+	stdoutWriter = &bytes.Buffer{}
+
+	verification := startFunctionalQuarantineSelectorVerification(
+		config{suite: functionalCoverageSuite, functionalQuarantine: path},
+		"linux",
+		2,
+		t.TempDir(),
+	)
+	if verification == nil {
+		t.Fatal("startFunctionalQuarantineSelectorVerification() returned nil for invalid metadata")
+	}
+	if err := verification.wait(); err == nil || !strings.Contains(err.Error(), "followUpIssue or followUpLane") {
+		t.Fatalf("selector verification error = %v, want ownership validation before listing", err)
 	}
 }
 
@@ -514,6 +627,58 @@ func TestFunctionalQuarantineRatchetRepeatedMeasurementRetainsExpectedFailures(t
 				t.Fatalf("expected failure sample was reported as unexpected-pass: %q", stdout.String())
 			}
 		})
+	}
+}
+
+func TestFunctionalQuarantineRatchetTreatsFlakyAsExpectedFailure(t *testing.T) {
+	originalRunner := commandRunner
+	originalStdout := stdoutWriter
+	t.Cleanup(func() {
+		commandRunner = originalRunner
+		stdoutWriter = originalStdout
+	})
+
+	packagePath := modulePath + "/tests/functional/repeated"
+	entry := functionalQuarantineEntry{
+		Package:      packagePath,
+		Test:         "TestIntermittentFailure",
+		Bucket:       functionalBucketFlaky,
+		Reason:       "repeated isolated measurements include an expected failure",
+		FollowUpLane: "ci/deflake-flaky-selector",
+		Measurement:  functionalMeasurementRepeatedIsolated,
+		Attempts:     3,
+	}
+	var stdout bytes.Buffer
+	stdoutWriter = &stdout
+	attempt := 0
+	commandRunner = func(invocation commandInvocation) (string, string, error) {
+		outcome := functionalQuarantineOutcomePass
+		if attempt == 1 {
+			outcome = functionalQuarantineOutcomeFail
+		}
+		attempt++
+		events := []goTestTimingEvent{
+			{Action: "start", Package: packagePath},
+			{Action: "run", Package: packagePath, Test: entry.Test},
+			{Action: outcome, Package: packagePath, Test: entry.Test},
+			{Action: outcome, Package: packagePath},
+		}
+		if outcome == functionalQuarantineOutcomeFail {
+			events[2].Output = "expected intermittent failure"
+			return marshalFunctionalTimingEvents(events...), "expected intermittent failure", errors.New("exit status 1")
+		}
+		return marshalFunctionalTimingEvents(events...), "", nil
+	}
+
+	if err := runFunctionalQuarantineRatchet(functionalQuarantine{Entries: []functionalQuarantineEntry{entry}}, time.Minute, false, t.TempDir()); err != nil {
+		t.Fatalf("runFunctionalQuarantineRatchet() error = %v, want expected flaky failure to retain the quarantine", err)
+	}
+	if attempt != entry.Attempts {
+		t.Fatalf("flaky invocations = %d, want %d", attempt, entry.Attempts)
+	}
+	wantStatus := `bucket=FLAKY expected=fail observed=fail status=expected measurement=repeated-isolated attempts=3 pass=2 fail=1 skip=0`
+	if !strings.Contains(stdout.String(), wantStatus) {
+		t.Fatalf("ratchet stdout = %q, want substring %q", stdout.String(), wantStatus)
 	}
 }
 

--- a/cmd/gocoveragecheck/functional_quarantine_verification.go
+++ b/cmd/gocoveragecheck/functional_quarantine_verification.go
@@ -61,6 +61,11 @@ func startFunctionalQuarantineSelectorVerification(cfg config, targetOS string, 
 		verification.done <- err
 		return verification
 	}
+	if err := validateFunctionalQuarantineMetadata(manifest); err != nil {
+		verification := newFunctionalQuarantineSelectorVerification(0)
+		verification.done <- err
+		return verification
+	}
 	selectorPackages := functionalTestSelectorPackages(manifest)
 	if len(selectorPackages) == 0 {
 		return nil

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -84,34 +84,35 @@ var (
 )
 
 type config struct {
-	covermode            string
-	coverpkg             string
-	functionalQuarantine string
-	jobs                 int
-	generateManifest     string
-	updateManifest       string
-	updateProfiles       string
-	packageManifest      string
-	varianceProfiles     string
-	varianceOutput       string
-	varianceCommit       string
-	varianceJobs         int
-	varianceAnnotations  string
-	jsonOutput           string
-	timingOutput         string
-	min                  float64
-	packageBaseline      string
-	packageMin           float64
-	packageFloorEpsilon  float64
-	packageFloorPolicy   string
-	packages             string
-	profile              string
-	short                bool
-	suite                string
-	stream               bool
-	timeout              time.Duration
-	totalOnly            bool
-	phaseTiming          *coveragePhaseTimer
+	covermode                    string
+	coverpkg                     string
+	functionalQuarantine         string
+	validateFunctionalQuarantine bool
+	jobs                         int
+	generateManifest             string
+	updateManifest               string
+	updateProfiles               string
+	packageManifest              string
+	varianceProfiles             string
+	varianceOutput               string
+	varianceCommit               string
+	varianceJobs                 int
+	varianceAnnotations          string
+	jsonOutput                   string
+	timingOutput                 string
+	min                          float64
+	packageBaseline              string
+	packageMin                   float64
+	packageFloorEpsilon          float64
+	packageFloorPolicy           string
+	packages                     string
+	profile                      string
+	short                        bool
+	suite                        string
+	stream                       bool
+	timeout                      time.Duration
+	totalOnly                    bool
+	phaseTiming                  *coveragePhaseTimer
 }
 
 type coverageResult struct {
@@ -149,6 +150,9 @@ func main() {
 func execute(cfg config) error {
 	if err := validateConfig(cfg); err != nil {
 		return err
+	}
+	if cfg.validateFunctionalQuarantine {
+		return executeFunctionalQuarantineValidation(cfg)
 	}
 	if cfg.varianceProfiles != "" || cfg.varianceOutput != "" {
 		return executeVarianceReport(cfg)
@@ -218,6 +222,7 @@ func parseConfig() config {
 	flag.StringVar(&cfg.covermode, "covermode", "count", "go test -covermode value")
 	flag.StringVar(&cfg.coverpkg, "coverpkg", "", "comma-separated import paths to measure; defaults to backend-owned packages")
 	flag.StringVar(&cfg.functionalQuarantine, "functional-quarantine", "", "strict functional quarantine JSON manifest; discovers and subtracts its package/test selectors")
+	flag.BoolVar(&cfg.validateFunctionalQuarantine, "validate-functional-quarantine", false, "validate a functional quarantine manifest and its selectors without running coverage")
 	flag.IntVar(&cfg.jobs, "jobs", 0, "maximum concurrent go test packages; defaults to runtime CPU count for non-Windows unit coverage, 1 for Windows unit coverage, and 2 for functional coverage")
 	flag.StringVar(&cfg.generateManifest, "generate-manifest", "", "create a deterministic package-minimum manifest from this lane's coverage profile")
 	flag.StringVar(&cfg.updateManifest, "update-manifest", "", "update an existing package-minimum manifest from a complete compatible profile sample set")
@@ -268,6 +273,9 @@ func validateConfig(cfg config) error {
 	if strings.TrimSpace(cfg.functionalQuarantine) != "" && cfg.suite != "functional" {
 		return fmt.Errorf("configure functional quarantine: -functional-quarantine requires -suite functional (got %q)", cfg.suite)
 	}
+	if cfg.validateFunctionalQuarantine && strings.TrimSpace(cfg.functionalQuarantine) == "" {
+		return errors.New("configure functional quarantine: -validate-functional-quarantine requires -functional-quarantine")
+	}
 	if strings.TrimSpace(cfg.updateProfiles) != "" && strings.TrimSpace(cfg.updateManifest) == "" {
 		return errors.New("configure go coverage manifest update: -update-profiles requires -update-manifest")
 	}
@@ -289,6 +297,50 @@ func validateConfig(cfg config) error {
 			return errors.New("configure coverage variance: -variance-commit must name the unchanged commit used for every profile")
 		}
 	}
+	return nil
+}
+
+func executeFunctionalQuarantineValidation(cfg config) error {
+	repoRoot, err := repoRootDir()
+	if err != nil {
+		return err
+	}
+	path := functionalQuarantinePath(cfg, repoRoot)
+	manifest, err := readFunctionalQuarantineFile(path)
+	if err != nil {
+		return err
+	}
+	if err := validateFunctionalQuarantineMetadata(manifest); err != nil {
+		return err
+	}
+
+	discoveryConfig := config{suite: functionalCoverageSuite}
+	packages, listedPackages, err := resolveFunctionalTestPackagesWithMetadata(discoveryConfig, repoRoot)
+	if err != nil {
+		return err
+	}
+	inventory, err := discoverFunctionalTestInventoryFromListedPackagesWithJobs(
+		packages,
+		listedPackages,
+		cfg.testJobs(runtime.GOOS, runtime.NumCPU()),
+	)
+	if err != nil {
+		return err
+	}
+	if err := validateFunctionalQuarantine(manifest, inventory); err != nil {
+		return err
+	}
+	if err := verifyFunctionalTestQuarantineSelectors(
+		manifest,
+		cfg.timeout,
+		cfg.short,
+		functionalQuarantineVerificationJobs(cfg.testJobs(runtime.GOOS, runtime.NumCPU())),
+		repoRoot,
+	); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(stdoutWriter, "Functional quarantine validation: manifest=%s selectors=%d status=pass\n", filepath.ToSlash(path), len(manifest.Entries))
 	return nil
 }
 

--- a/cmd/teststability/main.go
+++ b/cmd/teststability/main.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type config struct {
+	baseRef  string
+	headRef  string
+	repoRoot string
+	attempts int
+	budget   time.Duration
+}
+
+var (
+	stdoutWriter io.Writer = os.Stdout
+	stderrWriter io.Writer = os.Stderr
+	exitFunc               = os.Exit
+)
+
+func main() {
+	cfg := parseConfig()
+	if err := run(cfg); err != nil {
+		fmt.Fprintln(stderrWriter, err)
+		exitFunc(1)
+	}
+}
+
+func parseConfig() config {
+	cfg := config{}
+	flag.StringVar(&cfg.baseRef, "base", "", "pull-request base ref or SHA; its merge-base with head is used")
+	flag.StringVar(&cfg.headRef, "head", "", "pull-request head ref or SHA")
+	flag.StringVar(&cfg.repoRoot, "repo-root", ".", "repository working directory")
+	flag.IntVar(&cfg.attempts, "attempts", defaultStabilityAttempts, "isolated attempts per selected test")
+	flag.DurationVar(&cfg.budget, "budget", defaultStabilityBudget, "total stability execution budget")
+	flag.Parse()
+	return cfg
+}
+
+func run(cfg config) error {
+	if err := validateConfig(cfg); err != nil {
+		return err
+	}
+	repoRoot, err := resolveRepositoryRoot(cfg.repoRoot)
+	if err != nil {
+		return err
+	}
+	mergeBase, err := gitMergeBase(repoRoot, cfg.baseRef, cfg.headRef)
+	if err != nil {
+		return err
+	}
+	rawDiff, err := gitDiff(repoRoot, mergeBase, cfg.headRef)
+	if err != nil {
+		return err
+	}
+	selected, err := selectChangedTests(rawDiff, cfg.headRef, mergeBase, func(revision, path string) ([]byte, error) {
+		return gitShow(repoRoot, revision, path)
+	})
+	if err != nil {
+		return err
+	}
+	groups, err := groupSelectedTests(selected, func(path string) (string, error) {
+		return goPackageForFile(repoRoot, path)
+	})
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdoutWriter, "Changed-test stability: base=%s merge-base=%s head=%s\n", cfg.baseRef, mergeBase, cfg.headRef)
+	runner := stabilityRunner{
+		attempts: cfg.attempts,
+		budget:   cfg.budget,
+		run: func(ctx context.Context, group testGroup, testName string) (string, error) {
+			return runGoTestAttempt(ctx, repoRoot, group, testName)
+		},
+	}
+	return runner.runAll(groups, stdoutWriter)
+}
+
+func validateConfig(cfg config) error {
+	if strings.TrimSpace(cfg.baseRef) == "" || strings.TrimSpace(cfg.headRef) == "" {
+		return errors.New("changed-test stability requires both -base and -head")
+	}
+	if cfg.attempts < 1 {
+		return errors.New("changed-test stability -attempts must be greater than zero")
+	}
+	if cfg.budget <= 0 {
+		return errors.New("changed-test stability -budget must be greater than zero")
+	}
+	return nil
+}
+
+func resolveRepositoryRoot(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve repository root %q: %w", path, err)
+	}
+	command := exec.Command("git", "-C", absolute, "rev-parse", "--show-toplevel")
+	output, err := command.Output()
+	if err != nil {
+		return "", fmt.Errorf("resolve repository root %q: %w", path, err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func gitMergeBase(repoRoot, baseRef, headRef string) (string, error) {
+	command := exec.Command("git", "-C", repoRoot, "merge-base", baseRef, headRef)
+	output, err := command.Output()
+	if err != nil {
+		return "", fmt.Errorf("resolve merge base for %s and %s: %w", baseRef, headRef, err)
+	}
+	mergeBase := strings.TrimSpace(string(output))
+	if mergeBase == "" {
+		return "", fmt.Errorf("resolve merge base for %s and %s: empty result", baseRef, headRef)
+	}
+	return mergeBase, nil
+}
+
+func gitDiff(repoRoot, baseRevision, headRevision string) (string, error) {
+	command := exec.Command("git", "-C", repoRoot, "diff", "--find-renames", "--unified=0", "--no-ext-diff", baseRevision, headRevision, "--")
+	output, err := command.Output()
+	if err != nil {
+		return "", fmt.Errorf("read merge-base test diff %s..%s: %w", baseRevision, headRevision, err)
+	}
+	return string(output), nil
+}
+
+func gitShow(repoRoot, revision, path string) ([]byte, error) {
+	command := exec.Command("git", "-C", repoRoot, "show", revision+":"+filepath.ToSlash(path))
+	output, err := command.Output()
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func goPackageForFile(repoRoot, path string) (string, error) {
+	directory := filepath.ToSlash(filepath.Dir(filepath.FromSlash(path)))
+	pattern := "."
+	if directory != "." {
+		pattern = "./" + strings.TrimPrefix(directory, "./")
+	}
+	command := exec.Command("go", "list", "-f={{.ImportPath}}", pattern)
+	command.Dir = repoRoot
+	output, err := command.Output()
+	if err != nil {
+		return "", fmt.Errorf("go list %s: %w", pattern, err)
+	}
+	packagePath := strings.TrimSpace(string(output))
+	if strings.Contains(packagePath, "\n") {
+		return "", fmt.Errorf("go list %s returned multiple packages", pattern)
+	}
+	return packagePath, nil
+}

--- a/cmd/teststability/runner.go
+++ b/cmd/teststability/runner.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+)
+
+const (
+	defaultStabilityAttempts = 20
+	defaultStabilityBudget   = 15 * time.Minute
+)
+
+type testGroup struct {
+	Package string
+	Tests   []string
+}
+
+type attemptExecutor func(context.Context, testGroup, string) (string, error)
+
+type stabilityRunner struct {
+	attempts int
+	budget   time.Duration
+	now      func() time.Time
+	run      attemptExecutor
+}
+
+type attemptCounts map[string]int
+
+func groupSelectedTests(tests []selectedTest, packageForFile func(string) (string, error)) ([]testGroup, error) {
+	byPackage := make(map[string]map[string]struct{})
+	for _, test := range tests {
+		packagePath, err := packageForFile(test.File)
+		if err != nil {
+			return nil, fmt.Errorf("resolve package for %q: %w", test.File, err)
+		}
+		if strings.TrimSpace(packagePath) == "" {
+			return nil, fmt.Errorf("resolve package for %q: go list returned an empty package", test.File)
+		}
+		if byPackage[packagePath] == nil {
+			byPackage[packagePath] = make(map[string]struct{})
+		}
+		byPackage[packagePath][test.Name] = struct{}{}
+	}
+
+	groups := make([]testGroup, 0, len(byPackage))
+	for packagePath, names := range byPackage {
+		tests := make([]string, 0, len(names))
+		for name := range names {
+			tests = append(tests, name)
+		}
+		slices.Sort(tests)
+		groups = append(groups, testGroup{Package: packagePath, Tests: tests})
+	}
+	slices.SortFunc(groups, func(left, right testGroup) int {
+		return strings.Compare(left.Package, right.Package)
+	})
+	return groups, nil
+}
+
+func (runner stabilityRunner) runAll(groups []testGroup, output io.Writer) error {
+	if runner.attempts < 1 {
+		return errors.New("stability attempts must be greater than zero")
+	}
+	if runner.budget <= 0 {
+		return errors.New("stability budget must be greater than zero")
+	}
+	if runner.now == nil {
+		runner.now = time.Now
+	}
+	if runner.run == nil {
+		runner.run = func(ctx context.Context, group testGroup, testName string) (string, error) {
+			return runGoTestAttempt(ctx, ".", group, testName)
+		}
+	}
+	if len(groups) == 0 {
+		_, _ = fmt.Fprintf(output, "Changed-test stability: no qualifying tests; success (attempts=%d budget=%s)\n", runner.attempts, runner.budget)
+		return nil
+	}
+
+	totalTests := countGroupedTests(groups)
+	deadline := runner.now().Add(runner.budget)
+	_, _ = fmt.Fprintf(output, "Changed-test stability: selectors=%d attempts=%d expected-attempts=%d budget=%s\n", totalTests, runner.attempts, totalTests*runner.attempts, runner.budget)
+	completed := make(attemptCounts)
+	for _, group := range groups {
+		for _, testName := range group.Tests {
+			key := attemptKey(group.Package, testName)
+			for attempt := 1; attempt <= runner.attempts; attempt++ {
+				if !runner.now().Before(deadline) {
+					return budgetExpiredError(groups, completed, runner.attempts, deadline, output)
+				}
+				ctx, cancel := context.WithDeadline(context.Background(), deadline)
+				captured, err := runner.run(ctx, group, testName)
+				cancel()
+				if !runner.now().Before(deadline) {
+					completed[key]++
+					return budgetExpiredError(groups, completed, runner.attempts, deadline, output)
+				}
+				if err != nil {
+					return attemptFailureError(group.Package, testName, attempt, runner.attempts, captured, err, output)
+				}
+				completed[key]++
+			}
+		}
+	}
+	_, _ = fmt.Fprintf(output, "Changed-test stability: success selectors=%d attempts=%d measured=%d\n", totalTests, runner.attempts, totalTests*runner.attempts)
+	return nil
+}
+
+func countGroupedTests(groups []testGroup) int {
+	total := 0
+	for _, group := range groups {
+		total += len(group.Tests)
+	}
+	return total
+}
+
+func attemptKey(packagePath, testName string) string {
+	return packagePath + "\x00" + testName
+}
+
+func attemptFailureError(packagePath, testName string, attempt, attempts int, captured string, runErr error, output io.Writer) error {
+	if strings.TrimSpace(captured) == "" {
+		captured = "<go test produced no output>"
+	}
+	_, _ = fmt.Fprintf(output, "Changed-test stability: failure package=%s test=%s attempt=%d/%d\nGo test output:\n%s\nFocused reproduction: %s\n", packagePath, testName, attempt, attempts, captured, focusedReproductionCommand(packagePath, testName))
+	return fmt.Errorf("changed-test stability failed for package %s test %s attempt %d/%d: %w", packagePath, testName, attempt, attempts, runErr)
+}
+
+func budgetExpiredError(groups []testGroup, completed attemptCounts, attempts int, deadline time.Time, output io.Writer) error {
+	remaining := make([]string, 0)
+	completedTotal := 0
+	for _, group := range groups {
+		for _, testName := range group.Tests {
+			count := completed[attemptKey(group.Package, testName)]
+			completedTotal += count
+			if count < attempts {
+				remaining = append(remaining, fmt.Sprintf("%s %s (%d/%d)", group.Package, testName, count, attempts))
+			}
+		}
+	}
+	_, _ = fmt.Fprintf(output, "Changed-test stability: fail-closed budget expired deadline=%s completed-attempts=%d unmeasured=%s\n", deadline.Format(time.RFC3339Nano), completedTotal, strings.Join(remaining, ", "))
+	return fmt.Errorf("changed-test stability budget expired before all attempts completed: completed-attempts=%d unmeasured=%s", completedTotal, strings.Join(remaining, ", "))
+}
+
+func focusedReproductionCommand(packagePath, testName string) string {
+	return fmt.Sprintf("go test -count=1 -run=^%s$ %s", regexp.QuoteMeta(testName), packagePath)
+}
+
+func runGoTestAttempt(ctx context.Context, repoRoot string, group testGroup, testName string) (string, error) {
+	args := []string{"test", "-count=1", "-run=^" + regexp.QuoteMeta(testName) + "$", group.Package}
+	command := exec.CommandContext(ctx, "go", args...)
+	command.Dir = repoRoot
+	command.Env = os.Environ()
+	output, err := command.CombinedOutput()
+	return string(output), err
+}

--- a/cmd/teststability/selection.go
+++ b/cmd/teststability/selection.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+var changedTestNamePattern = regexp.MustCompile(`^Test[A-Z0-9_][A-Za-z0-9_]*$`)
+
+type diffFile struct {
+	oldPath string
+	newPath string
+}
+
+type selectedTest struct {
+	File string
+	Name string
+}
+
+type testFunction struct {
+	Name string
+	Body []byte
+}
+
+type sourceReader func(revision, path string) ([]byte, error)
+
+func selectChangedTests(rawDiff, headRevision, baseRevision string, readSource sourceReader) ([]selectedTest, error) {
+	files, err := parseGitDiff(rawDiff)
+	if err != nil {
+		return nil, err
+	}
+	oldBodies, err := collectOldTestBodies(files, baseRevision, readSource)
+	if err != nil {
+		return nil, err
+	}
+
+	selected := make([]selectedTest, 0)
+	for _, file := range files {
+		if !isGoTestPath(file.newPath) {
+			continue
+		}
+		source, err := readSource(headRevision, file.newPath)
+		if err != nil {
+			return nil, fmt.Errorf("read head test source %q: %w", file.newPath, err)
+		}
+		headTests, err := parseTopLevelTests(file.newPath, source)
+		if err != nil {
+			return nil, err
+		}
+		oldTests := map[string]testFunction{}
+		if file.oldPath != "" {
+			oldSource, err := readSource(baseRevision, file.oldPath)
+			if err != nil {
+				return nil, fmt.Errorf("read base test source %q: %w", file.oldPath, err)
+			}
+			parsed, err := parseTopLevelTests(file.oldPath, oldSource)
+			if err != nil {
+				return nil, err
+			}
+			for _, test := range parsed {
+				oldTests[test.Name] = test
+			}
+		}
+
+		for _, test := range headTests {
+			oldTest, samePath := oldTests[test.Name]
+			if samePath {
+				if bytes.Equal(oldTest.Body, test.Body) {
+					continue
+				}
+				selected = append(selected, selectedTest{File: file.newPath, Name: test.Name})
+				continue
+			}
+			if oldBody, moved := oldBodies[test.Name]; moved && bytes.Equal(oldBody, test.Body) {
+				continue
+			}
+			selected = append(selected, selectedTest{File: file.newPath, Name: test.Name})
+		}
+	}
+
+	return dedupeSelectedTests(selected), nil
+}
+
+func collectOldTestBodies(files []diffFile, baseRevision string, readSource sourceReader) (map[string][]byte, error) {
+	bodies := make(map[string][]byte)
+	for _, file := range files {
+		if !isGoTestPath(file.oldPath) {
+			continue
+		}
+		source, err := readSource(baseRevision, file.oldPath)
+		if err != nil {
+			return nil, fmt.Errorf("read base test source %q: %w", file.oldPath, err)
+		}
+		tests, err := parseTopLevelTests(file.oldPath, source)
+		if err != nil {
+			return nil, err
+		}
+		for _, test := range tests {
+			if _, exists := bodies[test.Name]; !exists {
+				bodies[test.Name] = append([]byte(nil), test.Body...)
+			}
+		}
+	}
+	return bodies, nil
+}
+
+func parseTopLevelTests(path string, source []byte) ([]testFunction, error) {
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, path, source, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parse Go test source %q: %w", path, err)
+	}
+	tests := make([]testFunction, 0)
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Recv != nil || function.Body == nil || !isGoTestFunction(function) {
+			continue
+		}
+		name := function.Name.Name
+		if name == "TestMain" || !changedTestNamePattern.MatchString(name) {
+			continue
+		}
+		start := fileSet.Position(function.Body.Lbrace).Offset
+		end := fileSet.Position(function.Body.Rbrace).Offset + 1
+		if start < 0 || end < start || end > len(source) {
+			return nil, fmt.Errorf("parse Go test source %q: invalid body range for %s", path, name)
+		}
+		tests = append(tests, testFunction{Name: name, Body: append([]byte(nil), source[start:end]...)})
+	}
+	slices.SortFunc(tests, func(left, right testFunction) int {
+		return strings.Compare(left.Name, right.Name)
+	})
+	return tests, nil
+}
+
+func isGoTestFunction(function *ast.FuncDecl) bool {
+	if function.Type.Params == nil || len(function.Type.Params.List) != 1 {
+		return false
+	}
+	parameter, ok := function.Type.Params.List[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	selector, ok := parameter.X.(*ast.SelectorExpr)
+	return ok && selector.Sel.Name == "T" && selectorPackageName(selector) == "testing"
+}
+
+func selectorPackageName(selector *ast.SelectorExpr) string {
+	identifier, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	return identifier.Name
+}
+
+func parseGitDiff(raw string) ([]diffFile, error) {
+	var files []diffFile
+	var current *diffFile
+	flush := func() {
+		if current == nil {
+			return
+		}
+		if current.newPath != "" || current.oldPath != "" {
+			files = append(files, *current)
+		}
+		current = nil
+	}
+
+	for _, line := range strings.Split(raw, "\n") {
+		switch {
+		case strings.HasPrefix(line, "diff --git "):
+			flush()
+			oldPath, newPath := parseGitHeaderPaths(strings.TrimPrefix(line, "diff --git "))
+			current = &diffFile{oldPath: oldPath, newPath: newPath}
+		case current == nil:
+			continue
+		case strings.HasPrefix(line, "--- "):
+			current.oldPath = parseDiffPath(strings.TrimPrefix(line, "--- "), "a/")
+		case strings.HasPrefix(line, "+++ "):
+			current.newPath = parseDiffPath(strings.TrimPrefix(line, "+++ "), "b/")
+		case strings.HasPrefix(line, "rename from "):
+			current.oldPath = normalizeDiffPath(strings.TrimPrefix(line, "rename from "))
+		case strings.HasPrefix(line, "rename to "):
+			current.newPath = normalizeDiffPath(strings.TrimPrefix(line, "rename to "))
+		}
+	}
+	flush()
+	return files, nil
+}
+
+func parseGitHeaderPaths(raw string) (string, string) {
+	parts := splitGitHeader(raw)
+	if len(parts) != 2 {
+		return "", ""
+	}
+	return parseDiffPath(parts[0], "a/"), parseDiffPath(parts[1], "b/")
+}
+
+func splitGitHeader(raw string) []string {
+	var parts []string
+	for len(raw) > 0 {
+		raw = strings.TrimLeft(raw, " \t")
+		if raw == "" {
+			break
+		}
+		if raw[0] != '"' {
+			end := strings.IndexAny(raw, " \t")
+			if end < 0 {
+				parts = append(parts, raw)
+				break
+			}
+			parts = append(parts, raw[:end])
+			raw = raw[end:]
+			continue
+		}
+		end := 1
+		for end < len(raw) {
+			if raw[end] == '\\' {
+				end += 2
+				continue
+			}
+			if raw[end] == '"' {
+				end++
+				break
+			}
+			end++
+		}
+		if end > len(raw) {
+			return nil
+		}
+		value, err := strconv.Unquote(raw[:end])
+		if err != nil {
+			return nil
+		}
+		parts = append(parts, value)
+		raw = raw[end:]
+	}
+	return parts
+}
+
+func parseDiffPath(raw, prefix string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "/dev/null" {
+		return ""
+	}
+	if strings.HasPrefix(raw, "\"") {
+		if value, err := strconv.Unquote(raw); err == nil {
+			raw = value
+		}
+	}
+	return normalizeDiffPath(strings.TrimPrefix(raw, prefix))
+}
+
+func normalizeDiffPath(path string) string {
+	path = strings.TrimSpace(strings.ReplaceAll(path, "\\", "/"))
+	path = strings.TrimPrefix(path, "./")
+	if path == "." || path == "" {
+		return ""
+	}
+	return path
+}
+
+func isGoTestPath(path string) bool {
+	return strings.HasSuffix(path, "_test.go")
+}
+
+func dedupeSelectedTests(tests []selectedTest) []selectedTest {
+	seen := make(map[string]struct{}, len(tests))
+	result := make([]selectedTest, 0, len(tests))
+	for _, test := range tests {
+		key := test.File + "\x00" + test.Name
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, test)
+	}
+	slices.SortFunc(result, func(left, right selectedTest) int {
+		if comparison := strings.Compare(left.File, right.File); comparison != 0 {
+			return comparison
+		}
+		return strings.Compare(left.Name, right.Name)
+	})
+	return result
+}

--- a/cmd/teststability/selection_test.go
+++ b/cmd/teststability/selection_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSelectChangedTestsOnlyReturnsNewOrBodyModifiedTopLevelTests(t *testing.T) {
+	base := map[string]string{
+		"pkg/example/example_test.go": `package example
+
+func TestUnchanged(t *testing.T) { t.Log("same") }
+func TestBodyChanged(t *testing.T) { t.Log("old") }
+func ExampleExample() {}
+func BenchmarkExample(b *testing.B) {}
+func helperTest(t *testing.T) {}
+`,
+	}
+	head := map[string]string{
+		"pkg/example/example_test.go": `package example
+
+func TestUnchanged(t *testing.T) { t.Log("same") }
+func TestBodyChanged(t *testing.T) { t.Log("new") }
+func TestNew(t *testing.T) {}
+func ExampleExample() {}
+func BenchmarkExample(b *testing.B) {}
+func helperTest(t *testing.T) {}
+`,
+	}
+	diff := "diff --git a/pkg/example/example_test.go b/pkg/example/example_test.go\n--- a/pkg/example/example_test.go\n+++ b/pkg/example/example_test.go\n@@ -1,7 +1,8 @@\n"
+	selected, err := selectChangedTests(diff, "head", "base", fixtureSourceReader(base, head))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSelectedTests(t, selected, []selectedTest{{File: "pkg/example/example_test.go", Name: "TestBodyChanged"}, {File: "pkg/example/example_test.go", Name: "TestNew"}})
+}
+
+func TestSelectChangedTestsHandlesRenameAndMovedUnchangedTest(t *testing.T) {
+	base := map[string]string{
+		"old/old_test.go":     "package old\nfunc TestMoved(t *testing.T) { t.Log(\"same\") }\n",
+		"pkg/changed_test.go": "package changed\nfunc TestRenamed(t *testing.T) { t.Log(\"old\") }\n",
+	}
+	head := map[string]string{
+		"new/new_test.go":     "package old\nfunc TestMoved(t *testing.T) { t.Log(\"same\") }\n",
+		"pkg/changed_test.go": "package changed\nfunc TestRenamed(t *testing.T) { t.Log(\"new\") }\n",
+	}
+	diff := strings.Join([]string{
+		"diff --git a/old/old_test.go b/new/new_test.go",
+		"similarity index 100%",
+		"rename from old/old_test.go",
+		"rename to new/new_test.go",
+		"diff --git a/pkg/changed_test.go b/pkg/changed_test.go",
+		"--- a/pkg/changed_test.go",
+		"+++ b/pkg/changed_test.go",
+		"@@ -1 +1 @@",
+	}, "\n")
+	selected, err := selectChangedTests(diff, "head", "base", fixtureSourceReader(base, head))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSelectedTests(t, selected, []selectedTest{{File: "pkg/changed_test.go", Name: "TestRenamed"}})
+}
+
+func TestSelectChangedTestsIgnoresDeletedTestsAndUnchangedFileEdits(t *testing.T) {
+	base := map[string]string{
+		"pkg/example_test.go": "package example\nfunc TestDeleted(t *testing.T) {}\nfunc TestKept(t *testing.T) {}\n",
+		"pkg/deleted_test.go": "package example\nfunc TestDeletedFile(t *testing.T) {}\n",
+	}
+	head := map[string]string{
+		"pkg/example_test.go": "package example\nfunc TestKept(t *testing.T) {}\n// unrelated change\n",
+	}
+	diff := strings.Join([]string{
+		"diff --git a/pkg/example_test.go b/pkg/example_test.go",
+		"--- a/pkg/example_test.go",
+		"+++ b/pkg/example_test.go",
+		"@@ -1,3 +1,3 @@",
+		"diff --git a/pkg/deleted_test.go b/pkg/deleted_test.go",
+		"--- a/pkg/deleted_test.go",
+		"+++ /dev/null",
+	}, "\n")
+	selected, err := selectChangedTests(diff, "head", "base", fixtureSourceReader(base, head))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(selected) != 0 {
+		t.Fatalf("selected = %#v, want no unchanged or deleted tests", selected)
+	}
+}
+
+func TestGroupSelectedTestsSortsPackagesAndTestNames(t *testing.T) {
+	packages := map[string]string{"z_test.go": "example/z", "a_test.go": "example/a", "m_test.go": "example/z"}
+	groups, err := groupSelectedTests([]selectedTest{
+		{File: "z_test.go", Name: "TestZ"},
+		{File: "a_test.go", Name: "TestB"},
+		{File: "m_test.go", Name: "TestA"},
+		{File: "z_test.go", Name: "TestZ"},
+	}, func(path string) (string, error) { return packages[path], nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []testGroup{{Package: "example/a", Tests: []string{"TestB"}}, {Package: "example/z", Tests: []string{"TestA", "TestZ"}}}
+	if fmt.Sprint(groups) != fmt.Sprint(want) {
+		t.Fatalf("groups = %#v, want %#v", groups, want)
+	}
+}
+
+func TestStabilityRunnerNoOpAndFullAttemptAccounting(t *testing.T) {
+	var output strings.Builder
+	starts := 0
+	runner := stabilityRunner{
+		attempts: 3,
+		budget:   time.Hour,
+		now:      func() time.Time { return time.Unix(100, 0) },
+		run: func(context.Context, testGroup, string) (string, error) {
+			starts++
+			return "ok", nil
+		},
+	}
+	if err := runner.runAll(nil, &output); err != nil {
+		t.Fatal(err)
+	}
+	if starts != 0 || !strings.Contains(output.String(), "no qualifying tests") {
+		t.Fatalf("no-op output=%q starts=%d", output.String(), starts)
+	}
+
+	output.Reset()
+	if err := runner.runAll([]testGroup{{Package: "example/pkg", Tests: []string{"TestOne", "TestTwo"}}}, &output); err != nil {
+		t.Fatal(err)
+	}
+	if starts != 6 || !strings.Contains(output.String(), "measured=6") {
+		t.Fatalf("success output=%q starts=%d", output.String(), starts)
+	}
+}
+
+func TestStabilityRunnerStopsAtFirstFailureWithDiagnostics(t *testing.T) {
+	var output strings.Builder
+	starts := 0
+	runner := stabilityRunner{
+		attempts: 20,
+		budget:   time.Hour,
+		now:      func() time.Time { return time.Unix(100, 0) },
+		run: func(context.Context, testGroup, string) (string, error) {
+			starts++
+			if starts == 2 {
+				return "--- FAIL: TestFlaky (0.00s)\nreceived diagnostic", errors.New("exit status 1")
+			}
+			return "ok", nil
+		},
+	}
+	err := runner.runAll([]testGroup{{Package: "example/pkg", Tests: []string{"TestFlaky"}}}, &output)
+	if err == nil || !strings.Contains(err.Error(), "attempt 2/20") {
+		t.Fatalf("error=%v, want first failed attempt", err)
+	}
+	if starts != 2 {
+		t.Fatalf("starts=%d, want 2", starts)
+	}
+	for _, want := range []string{"package=example/pkg", "test=TestFlaky", "attempt=2/20", "received diagnostic", "go test -count=1 -run=^TestFlaky$ example/pkg"} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("output=%q, want %q", output.String(), want)
+		}
+	}
+}
+
+func TestStabilityRunnerFailsClosedWhenBudgetExpires(t *testing.T) {
+	var output strings.Builder
+	current := time.Unix(100, 0)
+	runner := stabilityRunner{
+		attempts: 3,
+		budget:   10 * time.Second,
+		now:      func() time.Time { return current },
+		run: func(context.Context, testGroup, string) (string, error) {
+			current = current.Add(10 * time.Second)
+			return "ok", nil
+		},
+	}
+	err := runner.runAll([]testGroup{{Package: "example/pkg", Tests: []string{"TestSlow"}}}, &output)
+	if err == nil || !strings.Contains(err.Error(), "budget expired") {
+		t.Fatalf("error=%v, want budget failure", err)
+	}
+	if !strings.Contains(output.String(), "completed-attempts=1") || !strings.Contains(output.String(), "TestSlow (1/3)") {
+		t.Fatalf("output=%q, want completed and unmeasured attempt counts", output.String())
+	}
+}
+
+func fixtureSourceReader(base, head map[string]string) sourceReader {
+	return func(revision, path string) ([]byte, error) {
+		var source string
+		var ok bool
+		if revision == "base" {
+			source, ok = base[path]
+		} else {
+			source, ok = head[path]
+		}
+		if !ok {
+			return nil, fmt.Errorf("missing fixture %s:%s", revision, path)
+		}
+		return []byte(source), nil
+	}
+}
+
+func assertSelectedTests(t *testing.T, got, want []selectedTest) {
+	t.Helper()
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("selected = %#v, want %#v", got, want)
+	}
+}

--- a/scripts/ci/verify-functional-quarantine-packages.sh
+++ b/scripts/ci/verify-functional-quarantine-packages.sh
@@ -6,6 +6,8 @@ run_url="${FUNCTIONAL_QUARANTINE_EVIDENCE_RUN_URL:?FUNCTIONAL_QUARANTINE_EVIDENC
 head_sha="${FUNCTIONAL_QUARANTINE_EVIDENCE_SHA:?FUNCTIONAL_QUARANTINE_EVIDENCE_SHA is required}"
 output_path="${FUNCTIONAL_QUARANTINE_EVIDENCE_OUTPUT:-.artifacts/functional-test-viz/quarantine-package-evidence.txt}"
 test_timeout="${FUNCTIONAL_QUARANTINE_EVIDENCE_TIMEOUT:-15m}"
+quarantine="${FUNCTIONAL_QUARANTINE:-tests/functional/functional-quarantine.json}"
+go_bin="${GO:-go}"
 
 if ! command -v jq >/dev/null 2>&1; then
   printf '%s\n' 'jq is required to verify the structured go test package events' >&2
@@ -33,7 +35,15 @@ record() {
 
 record "functional-quarantine-evidence-run=$run_url"
 record "functional-quarantine-evidence-head-sha=$head_sha"
+record "functional-quarantine-validation-command=$go_bin run ./cmd/gocoveragecheck -suite functional -functional-quarantine $quarantine -validate-functional-quarantine -short=false -timeout=$test_timeout"
 record "functional-quarantine-evidence-command=go test -list=^Test -json -count=1 -short=false [-tags=functionallong] -timeout=$test_timeout <exact-package>"
+
+"$go_bin" run ./cmd/gocoveragecheck \
+  -suite functional \
+  -functional-quarantine "$quarantine" \
+  -validate-functional-quarantine \
+  -short=false \
+  "-timeout=$test_timeout"
 
 temporary_root="$(mktemp -d)"
 trap 'rm -rf "$temporary_root"' EXIT

--- a/scripts/verification-policy.mjs
+++ b/scripts/verification-policy.mjs
@@ -226,6 +226,12 @@ function policyInputFromEnvironment() {
 			},
 			directLane("Backend", "RUN_BACKEND", "BACKEND_REASON", "BACKEND_RESULT"),
 			directLane(
+				"Backend Test Stability",
+				"RUN_BACKEND_STABILITY",
+				"BACKEND_STABILITY_REASON",
+				"BACKEND_STABILITY_RESULT",
+			),
+			directLane(
 				"Backend Lint",
 				"RUN_BACKEND_LINT",
 				"BACKEND_LINT_REASON",

--- a/scripts/verification-policy.test.mjs
+++ b/scripts/verification-policy.test.mjs
@@ -11,6 +11,7 @@ const laneNames = [
 	"README",
 	"Frontend",
 	"Backend",
+	"Backend Test Stability",
 	"Backend Lint",
 	"UI Backend Integration",
 	"API Package",
@@ -86,6 +87,56 @@ test("required Backend Lint fails the policy when its hosted job is skipped", ()
 
 		assert.equal(evaluation.ok, false, `${result} must fail the required policy lane`);
 		assert.ok(evaluation.failures.some((failure) => /Backend Lint was selected/.test(failure)));
+	}
+});
+
+test("changed-test stability passes when selected, accepts a classifier-driven skip, and fails incomplete outcomes", () => {
+	const selectedPass = evaluateVerificationPolicy(
+		policy({
+			lanes: [
+				...laneNames
+					.filter((name) => name !== "Backend Test Stability")
+					.map((name) => lane(name)),
+				lane("Backend Test Stability", true, "success", {
+					reason: "Backend changes select the merge-base stability gate.",
+				}),
+			],
+		}),
+	);
+	assert.deepEqual(selectedPass, { ok: true, failures: [] });
+
+	const validSkip = evaluateVerificationPolicy(
+		policy({
+			classification: "factory-content",
+			areas: "factory-content",
+			lanes: [
+				...laneNames
+					.filter((name) => name !== "Backend Test Stability")
+					.map((name) => lane(name)),
+				lane("Backend Test Stability", false, "skipped", {
+					reason: "Factory-only changes do not select backend verification.",
+				}),
+			],
+		}),
+	);
+	assert.deepEqual(validSkip, { ok: true, failures: [] });
+
+	for (const result of ["failure", "cancelled", "skipped", "", "incomplete"]) {
+		const evaluation = evaluateVerificationPolicy(
+			policy({
+				lanes: [
+					...laneNames
+						.filter((name) => name !== "Backend Test Stability")
+						.map((name) => lane(name)),
+					lane("Backend Test Stability", true, result),
+				],
+			}),
+		);
+
+		assert.equal(evaluation.ok, false, `${result || "missing"} must fail the required stability gate`);
+		assert.ok(
+			evaluation.failures.some((failure) => /Backend Test Stability was selected/.test(failure)),
+		);
 	}
 });
 

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -55,13 +55,20 @@ as soon as tests are added there.
 
 The required functional coverage gate is subtractive. Its versioned manifest is
 `tests/functional/functional-quarantine.json`; each entry names a discovered
-package or an exact top-level test, an `ENVIRONMENT-DEPENDENT` or `GENUINELY
-FAILING` bucket, and a reason. Genuine failures must also name a follow-up.
+package or an exact top-level test, an `ENVIRONMENT-DEPENDENT`, `GENUINELY
+FAILING`, or `FLAKY` bucket, and a reason. Genuine failures must also name a
+follow-up. FLAKY entries must name a non-empty `followUpIssue` or
+`followUpLane`; they use the existing failure measurement path, so a repeated
+isolated measurement is appropriate when the selector is intermittent.
 Package-plus-test entries become package-specific `-run` selectors, while
 package entries remove the whole package. Duplicate, malformed, stale, or
 overlapping selectors fail closed before the instrumented run, so a new
 functional package or test is selected automatically without a manifest edit.
-Entries normally use one isolated observation, while unreliable selectors may
+The canonical strict validator is available without running coverage through
+`go run ./cmd/gocoveragecheck -suite functional -functional-quarantine
+tests/functional/functional-quarantine.json -validate-functional-quarantine`.
+The Linux quarantine inventory verifier invokes this validator before its
+package evidence checks. Entries normally use one isolated observation, while unreliable selectors may
 declare `"measurement": "repeated-isolated"` and an explicit `"attempts"`
 count from 2 through 15. Each repeated attempt starts a fresh exact-selector
 `go test` process; the ratchet reports aggregate pass, fail, and skip counts,


### PR DESCRIPTION
{
  "project": "Pre-Merge Test Stability Gate and Flake Quarantine Discipline",
  "branchName": "ci-flake-prevention-stability-gate-and-quarantine-discipline",
  "description": "Prevent newly introduced Go test flakes from reaching main by repeatedly exercising new or modified tests in a bounded required CI gate, and extend the strict functional quarantine contract with a distinct FLAKY bucket that requires a machine-validated follow-up issue or lane. This CI/tooling-only lane preserves existing coverage enforcement and quarantine entries and does not fix any specific flaky test.",
  "context": {
    "customerAsk": "Add a merge-base-aware stability gate that repeatedly runs new or modified Go tests before merge, reports the exact failed test and attempt, and stays within a justified total budget. Add a distinct FLAKY functional-quarantine bucket that is rejected unless it names a follow-up issue or lane. Demonstrate both failing and passing behavior without retaining a deliberate flake or changing existing quarantine entries.",
    "problem": "Intermittent tests can make Backend Functional Coverage and the required Verification Policy aggregate red for main and every in-flight pull request, forcing repeated manual diagnosis and reruns. New or modified tests are not stress-run before merge, and the quarantine contract has no explicit FLAKY classification whose removal owner is mandatory and machine-validated.",
    "solution": "Select new and body-modified top-level Go tests from the pull-request merge-base diff, group them by package, and run each for 20 isolated attempts within a 15-minute fail-closed total budget. Expose this as a hard classified backend CI job aggregated by Verification Policy. Extend canonical strict quarantine validation to accept FLAKY only with a non-empty followUpIssue or followUpLane, preserve existing bucket behavior, and prove rejection and acceptance through scratch fixtures."
  },
  "verificationEvidence": {
    "hardGateDecision": "Launch the changed-test stability job as a required hard gate for applicable pull requests. Merge-base scoping measures only new or body-modified top-level tests, and the single 15-minute budget bounds total disruption while fail-closed behavior prevents incomplete evidence from passing.",
    "temporaryFailingDemonstration": {
      "command": "make test-changed-test-stability CHANGED_TEST_STABILITY_BASE=01b3f93150140d1355f07fc63de4322f1a9ffa67 CHANGED_TEST_STABILITY_HEAD=a1d9e846ae8a8cf044b2797cfda96ce1404fb628 CHANGED_TEST_STABILITY_ATTEMPTS=20 CHANGED_TEST_STABILITY_BUDGET=15m",
      "output": "go run ./cmd/teststability -base \"01b3f93150140d1355f07fc63de4322f1a9ffa67\" -head \"a1d9e846ae8a8cf044b2797cfda96ce1404fb628\" -attempts 20 -budget 15m\nChanged-test stability: base=01b3f93150140d1355f07fc63de4322f1a9ffa67 merge-base=01b3f93150140d1355f07fc63de4322f1a9ffa67 head=a1d9e846ae8a8cf044b2797cfda96ce1404fb628\nChanged-test stability: selectors=1 attempts=20 expected-attempts=20 budget=15m0s\nChanged-test stability: failure package=github.com/portpowered/infinite-you/cmd/teststability test=TestStabilityGateDemonstrationFailsOnAttemptOne attempt=1/20\nGo test output:\n--- FAIL: TestStabilityGateDemonstrationFailsOnAttemptOne (0.00s)\n    stability_demo_test.go:6: deterministic stability-gate demonstration failure\nFAIL\nFAIL\tgithub.com/portpowered/infinite-you/cmd/teststability\t0.027s\nFAIL\n\nFocused reproduction: go test -count=1 -run=^TestStabilityGateDemonstrationFailsOnAttemptOne$ github.com/portpowered/infinite-you/cmd/teststability\nchanged-test stability failed for package github.com/portpowered/infinite-you/cmd/teststability test TestStabilityGateDemonstrationFailsOnAttemptOne attempt 1/20: exit status 1\nexit status 1\nmake: *** [Makefile:511: test-changed-test-stability] Error 1"
    },
    "cleanPassingGate": {
      "command": "make test-changed-test-stability CHANGED_TEST_STABILITY_BASE=origin/main CHANGED_TEST_STABILITY_HEAD=HEAD CHANGED_TEST_STABILITY_ATTEMPTS=20 CHANGED_TEST_STABILITY_BUDGET=15m",
      "output": "go run ./cmd/teststability -base \"origin/main\" -head \"HEAD\" -attempts 20 -budget 15m\nChanged-test stability: base=origin/main merge-base=20516bbf96ff18c7d6f62f4a520f1a3d8b2921dd head=HEAD\nChanged-test stability: selectors=10 attempts=20 expected-attempts=200 budget=15m0s\nChanged-test stability: success selectors=10 attempts=20 measured=200"
    }
  },
  "acceptanceCriteria": [
    "Against the pull request's merge base, the stability gate selects top-level Go test functions that are new or whose function bodies were modified, groups them by package, runs every selected test for 20 isolated attempts, reports a no-op success when none qualify, and does not select deleted tests or unchanged tests merely because the containing file changed elsewhere.",
    "The gate has a 15-minute total execution budget, fails closed when it cannot complete every selected attempt within that budget, and on a test failure reports the package, exact test name, failed attempt number, captured Go test output, and a focused reproduction command. The PR body states the hard-gate choice and explains that merge-base scoping plus this budget bounds disruption.",
    "The strict functional quarantine contract accepts FLAKY entries only when a non-empty followUpIssue or followUpLane is present, rejects missing or blank follow-up references with an actionable selector-specific error, preserves validation and measurement behavior for existing supported buckets, and requires no edits to the existing entries in tests/functional/functional-quarantine.json.",
    "A dedicated backend CI job uses the existing classify result, runs the stability target for applicable pull requests, and is included in Verification Policy so a failed, cancelled, or incomplete required stability run prevents policy success. A temporary deterministic demonstration test proves a failing attempt and is removed before the final push; the clean head proves the passing path. Verbatim local commands and output are recorded in the PR body, while hosted CI run links and evidence are recorded in a PR comment and never committed.",
    "Runtime-proof classification: this lane does not change runtime-observable CLI, API, UI, emitted-event, or product lifecycle behavior, so delivered-product runtime proof is not applicable. The real failing and passing stability-gate executions are required CI-tooling behavior evidence, not a substitute claim that product runtime changed.",
    "Final quality gates: Typecheck passes; focused cmd/gocoveragecheck and changed-test stability tests pass; CI workflow policy tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Existing coverage-floor enforcement and unrelated required checks are not weakened.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The implementation/review cycle continues through those review-owned outcomes until the PR is actually merged; an opened, green, approved, or ready-to-merge PR is not lane completion."
  ],
  "userStories": [
    {
      "id": "ci-flake-prevention-stability-gate-and-quarantine-discipline-001",
      "title": "Detect and repeatedly exercise changed Go tests",
      "description": "As a contributor, I want new and modified Go tests to be identified from my pull-request diff and stress-run locally so intermittent failures are exposed before merge without rerunning the entire repository repeatedly.",
      "acceptanceCriteria": [
        "Given a merge base and head, the selector returns each newly added top-level Test* function and each existing top-level Test* function with added or modified lines in its body, grouped under the package that go test can execute.",
        "Unchanged tests, deleted tests, examples, benchmarks, fuzz targets, helper functions, and edits outside a test function are not selected; table-case edits inside a top-level test's body select that test.",
        "Renames and file moves are handled from the diff without silently omitting a newly named or body-modified test, and a repository with no qualifying tests exits successfully with a clear no-op result.",
        "Every selected test receives 20 isolated attempts, stopping on the first failure; diagnostics name the package, exact test, failed attempt number, captured output, and a focused reproduction command.",
        "The runner enforces a 15-minute total budget across all selected tests, does not start work that cannot use the remaining deadline, and fails closed with the completed and unmeasured selectors when the budget expires.",
        "Pure selection, grouping, ordering, attempt accounting, no-op, first-failure, and budget-expiry behavior have deterministic focused tests without sleeps or real intermittent timing.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ci-flake-prevention-stability-gate-and-quarantine-discipline-002",
      "title": "Require ownership metadata for flaky quarantines",
      "description": "As a maintainer, I want every quarantined flake to name the issue or work lane that will remove it so a temporary safety measure cannot become an anonymous permanent exclusion.",
      "acceptanceCriteria": [
        "The strict functional quarantine parser recognizes FLAKY as distinct from ENVIRONMENT-DEPENDENT and all other existing supported buckets.",
        "A FLAKY entry with neither followUpIssue nor followUpLane, or with only blank values, is rejected before functional selection or coverage measurement with an error that names the affected selector and required fields.",
        "A FLAKY entry with a non-empty issue reference or lane reference passes ownership validation and continues through the existing selector discovery and quarantine measurement path appropriate for an expected intermittent failure.",
        "Unknown fields and unsupported bucket values remain fail-closed, and existing supported bucket semantics and their existing follow-up rules remain compatible.",
        "Fixture-based tests show the same scratch manifest rejected without follow-up metadata and accepted after followUpIssue or followUpLane is added; the real functional quarantine manifest receives no new FLAKY entry and its existing entries are not restructured.",
        "Any shell-side quarantine verification invokes or agrees with the canonical strict validation rather than defining a conflicting schema.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added strict FLAKY ownership metadata, canonical validation-only CLI mode, shell verifier integration, and fixture/ratchet coverage; existing quarantine manifest unchanged."
    },
    {
      "id": "ci-flake-prevention-stability-gate-and-quarantine-discipline-003",
      "title": "Enforce and demonstrate the stability policy in CI",
      "description": "As a repository operator, I want the changed-test stability result enforced by the required CI policy with concrete failing and passing evidence so flakes are stopped before they impose a cost on every open pull request.",
      "acceptanceCriteria": [
        "A documented Make target runs the changed-test stability behavior with explicit base and head inputs, repeat count 20, and total budget 15 minutes, and returns a non-zero status for any failed attempt or incomplete measurement.",
        "A dedicated backend CI job checks out sufficient history, uses pull-request base/head data, follows the existing classify backend selection, and exposes a stable result when intentionally skipped by classification or when no tests qualify.",
        "Verification Policy declares the stability job as a dependency and treats every applicable failed, cancelled, skipped unexpectedly, or incomplete result as blocking while preserving valid classification-driven skips.",
        "Workflow policy tests directly prove the aggregate succeeds for a passing or validly skipped stability result and fails for failed, cancelled, unexpectedly skipped, or missing/incomplete results.",
        "Before the final push, a temporary deterministic demonstration test fails on a known attempt and produces output naming that attempt; after the demonstration test is removed, the same real target passes on the clean branch. The PR body contains the verbatim commands and outputs, and no demonstration test remains in the final diff.",
        "The PR body records the decision to launch as a hard gate and justifies the 20-attempt, 15-minute budget; hosted run links and property-specific output are placed in a PR comment and never in a commit.",
        "Runtime-proof classification: this final story changes only CI/tooling and no runtime-observable CLI, API, UI, emitted-event, or product lifecycle behavior, so delivered-product runtime proof is not applicable. The real failing demonstration and clean passing gate executions remain mandatory CI-tooling behavior evidence.",
        "Existing Backend Functional Coverage selection, quarantine subtraction, package floors, and unrelated coverage manifest entries are unchanged in strength; the pprof test, the CLI text-stream interrupted-run test, docs/internal/baselines/deadcode-baseline.txt, and unrelated coverage-floor manifest entries are untouched.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added the classification-aware Backend Test Stability hard-gate job, Verification Policy dependency/result enforcement, direct policy tests for pass/skip/failure/cancellation/missing/incomplete outcomes, and recorded deterministic failing plus clean passing gate evidence above; no demonstration test remains in the final diff."
    }
  ]
}
