### PR TITLE
doc1-example-corpus-under-examples-dir

### DIFF
--- a/examples/expected-artifacts-json/factory.json
+++ b/examples/expected-artifacts-json/factory.json
@@ -1,0 +1,36 @@
+{
+  "workTypes": [
+    {
+      "name": "task",
+      "handlingBehavior": ["DEFAULT"],
+      "states": [
+        { "name": "init", "type": "INITIAL" },
+        { "name": "complete", "type": "TERMINAL" },
+        { "name": "failed", "type": "FAILED" }
+      ],
+      "expectedArtifacts": [
+        {
+          "name": "task-report",
+          "pattern": "reports/{{ (index .Inputs 0).Name }}.json",
+          "nonEmpty": true
+        }
+      ]
+    }
+  ],
+  "workers": [{ "name": "processor" }],
+  "workstations": [
+    {
+      "name": "process-task",
+      "worker": "processor",
+      "inputs": [{ "workType": "task", "state": "init" }],
+      "outputs": [{ "workType": "task", "state": "complete" }],
+      "onFailure": [{ "workType": "task", "state": "failed" }],
+      "expectedArtifacts": [
+        {
+          "name": "manifest",
+          "pattern": "reports/{{ (index .Inputs 0).Name }}.manifest.json"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/expected-artifacts-yaml/factory.yaml
+++ b/examples/expected-artifacts-yaml/factory.yaml
@@ -1,0 +1,32 @@
+workTypes:
+  - name: task
+    handlingBehavior:
+      - DEFAULT
+    states:
+      - name: init
+        type: INITIAL
+      - name: complete
+        type: TERMINAL
+      - name: failed
+        type: FAILED
+    expectedArtifacts:
+      - name: task-report
+        pattern: 'reports/{{ (index .Inputs 0).Name }}.json'
+        nonEmpty: true
+workers:
+  - name: processor
+workstations:
+  - name: process-task
+    worker: processor
+    inputs:
+      - workType: task
+        state: init
+    outputs:
+      - workType: task
+        state: complete
+    onFailure:
+      - workType: task
+        state: failed
+    expectedArtifacts:
+      - name: manifest
+        pattern: 'reports/{{ (index .Inputs 0).Name }}.manifest.json'

--- a/examples/first-workflow/factory.json
+++ b/examples/first-workflow/factory.json
@@ -1,0 +1,49 @@
+{
+  "id": "sample-service",
+  "resources": [
+    { "name": "agent-slot", "capacity": 1 }
+  ],
+  "workTypes": [
+    {
+      "name": "story",
+      "states": [
+        { "name": "init", "type": "INITIAL" },
+        { "name": "in-review", "type": "PROCESSING" },
+        { "name": "complete", "type": "TERMINAL" },
+        { "name": "failed", "type": "FAILED" }
+      ]
+    }
+  ],
+  "workers": [
+    { "name": "executor" },
+    { "name": "reviewer" }
+  ],
+  "workstations": [
+    {
+      "name": "execute-story",
+      "behavior": "REPEATER",
+      "worker": "executor",
+      "inputs": [{ "workType": "story", "state": "init" }],
+      "outputs": [{ "workType": "story", "state": "in-review" }],
+      "onContinue": [{ "workType": "story", "state": "init" }],
+      "onFailure": [{ "workType": "story", "state": "failed" }],
+      "resources": [{ "name": "agent-slot", "capacity": 1 }]
+    },
+    {
+      "name": "review-story",
+      "worker": "reviewer",
+      "inputs": [{ "workType": "story", "state": "in-review" }],
+      "outputs": [{ "workType": "story", "state": "complete" }],
+      "onRejection": [{ "workType": "story", "state": "init" }],
+      "onFailure": [{ "workType": "story", "state": "failed" }],
+      "resources": [{ "name": "agent-slot", "capacity": 1 }]
+    },
+    {
+      "name": "review-loop-breaker",
+      "type": "LOGICAL_MOVE",
+      "guards": [{ "type": "VISIT_COUNT", "workstation": "review-story", "maxVisits": 3 }],
+      "inputs": [{ "workType": "story", "state": "init" }],
+      "outputs": [{ "workType": "story", "state": "failed" }]
+    }
+  ]
+}

--- a/examples/first-workflow/workers/executor/AGENTS.md
+++ b/examples/first-workflow/workers/executor/AGENTS.md
@@ -1,0 +1,11 @@
+---
+type: AGENT_WORKER
+model: gpt-5-codex
+modelProvider: CODEX
+executorProvider: SCRIPT_WRAP
+timeout: 1h
+skipPermissions: true
+---
+
+You are a software engineer. Implement the requested story and run focused
+verification before finishing.

--- a/examples/first-workflow/workers/reviewer/AGENTS.md
+++ b/examples/first-workflow/workers/reviewer/AGENTS.md
@@ -1,0 +1,11 @@
+---
+type: AGENT_WORKER
+model: gpt-5-codex
+modelProvider: CODEX
+executorProvider: SCRIPT_WRAP
+timeout: 30m
+skipPermissions: true
+---
+
+You review the story implementation and return ACCEPTED only when the change is
+ready.

--- a/examples/first-workflow/workstations/execute-story/AGENTS.md
+++ b/examples/first-workflow/workstations/execute-story/AGENTS.md
@@ -1,0 +1,14 @@
+---
+type: AGENT_RUN
+limits:
+  maxExecutionTime: 1h
+---
+
+Implement the story.
+
+Story payload:
+{{ (index .Inputs 0).Payload }}
+
+Return CONTINUE when the story made ordinary partial progress but needs another
+execution pass.
+Return COMPLETE only when the story is ready to advance into review.

--- a/examples/first-workflow/workstations/review-story/AGENTS.md
+++ b/examples/first-workflow/workstations/review-story/AGENTS.md
@@ -1,0 +1,13 @@
+---
+type: AGENT_RUN
+limits:
+  maxExecutionTime: 30m
+---
+
+Review the story implementation.
+
+Story payload:
+{{ (index .Inputs 0).Payload }}
+
+Return ACCEPTED when the story is ready.
+Return REJECTED with concrete feedback when another pass is needed.

--- a/examples/inference-throttle-guard/factory.json
+++ b/examples/inference-throttle-guard/factory.json
@@ -1,0 +1,31 @@
+{
+  "name": "throttled-factory",
+  "guards": [
+    {
+      "type": "INFERENCE_THROTTLE_GUARD",
+      "modelProvider": "CLAUDE",
+      "model": "claude-sonnet-4-20250514",
+      "refreshWindow": "15m"
+    }
+  ],
+  "workTypes": [
+    {
+      "name": "story",
+      "states": [
+        { "name": "init", "type": "INITIAL" },
+        { "name": "complete", "type": "TERMINAL" },
+        { "name": "failed", "type": "FAILED" }
+      ]
+    }
+  ],
+  "workers": [{ "name": "executor" }],
+  "workstations": [
+    {
+      "name": "execute-story",
+      "worker": "executor",
+      "inputs": [{ "workType": "story", "state": "init" }],
+      "outputs": [{ "workType": "story", "state": "complete" }],
+      "onFailure": [{ "workType": "story", "state": "failed" }]
+    }
+  ]
+}

--- a/examples/local-omnivoice-tts/factory.json
+++ b/examples/local-omnivoice-tts/factory.json
@@ -1,0 +1,40 @@
+{
+  "workTypes": [
+    {
+      "name": "speech",
+      "states": [
+        { "name": "init", "type": "INITIAL" },
+        { "name": "complete", "type": "TERMINAL" },
+        { "name": "failed", "type": "FAILED" }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "name": "omnivoice-cache",
+      "type": "MODEL",
+      "capacity": 1,
+      "model": "OMNIVOICE_Q4_K_M",
+      "backend": "LLAMACPP",
+      "loadPolicy": "ON_DEMAND"
+    }
+  ],
+  "workers": [{ "name": "tts-worker" }],
+  "workstations": [
+    {
+      "name": "speak",
+      "type": "INFERENCE_RUN",
+      "operation": "TTS",
+      "worker": "tts-worker",
+      "operationBindings": [
+        {
+          "slot": "text",
+          "selector": { "type": "TEXT", "label": "utterance" }
+        }
+      ],
+      "inputs": [{ "workType": "speech", "state": "init" }],
+      "outputs": [{ "workType": "speech", "state": "complete" }],
+      "onFailure": [{ "workType": "speech", "state": "failed" }]
+    }
+  ]
+}

--- a/examples/local-omnivoice-tts/workers/tts-worker/AGENTS.md
+++ b/examples/local-omnivoice-tts/workers/tts-worker/AGENTS.md
@@ -1,0 +1,21 @@
+---
+type: INFERENCE_WORKER
+model: OMNIVOICE_Q4_K_M
+modelProvider: CODEX
+modelLocality: LOCAL
+resources:
+  - name: omnivoice-cache
+    capacity: 1
+operations:
+  - name: TTS
+    inputs:
+      - name: text
+        required: true
+        contentTypes:
+          - TEXT
+    outputs:
+      - name: audio
+        contentTypes:
+          - AUDIO
+---
+Synthesize speech from the resolved utterance.

--- a/examples/minimal-workflow-shape/factory.json
+++ b/examples/minimal-workflow-shape/factory.json
@@ -1,0 +1,35 @@
+{
+  "workTypes": [
+    {
+      "name": "story",
+      "states": [
+        { "name": "init", "type": "INITIAL" },
+        { "name": "in-review", "type": "PROCESSING" },
+        { "name": "complete", "type": "TERMINAL" },
+        { "name": "failed", "type": "FAILED" }
+      ]
+    }
+  ],
+  "workers": [
+    { "name": "executor" },
+    { "name": "reviewer" }
+  ],
+  "workstations": [
+    {
+      "name": "execute-story",
+      "behavior": "REPEATER",
+      "worker": "executor",
+      "inputs": [{ "workType": "story", "state": "init" }],
+      "outputs": [{ "workType": "story", "state": "in-review" }],
+      "onFailure": [{ "workType": "story", "state": "failed" }]
+    },
+    {
+      "name": "review-story",
+      "worker": "reviewer",
+      "inputs": [{ "workType": "story", "state": "in-review" }],
+      "outputs": [{ "workType": "story", "state": "complete" }],
+      "onRejection": [{ "workType": "story", "state": "init" }],
+      "onFailure": [{ "workType": "story", "state": "failed" }]
+    }
+  ]
+}

--- a/examples/minimal-workflow-shape/workers/executor/AGENTS.md
+++ b/examples/minimal-workflow-shape/workers/executor/AGENTS.md
@@ -1,0 +1,5 @@
+---
+type: AGENT_WORKER
+---
+
+Execute the story and report ordinary progress or completion.

--- a/examples/minimal-workflow-shape/workers/reviewer/AGENTS.md
+++ b/examples/minimal-workflow-shape/workers/reviewer/AGENTS.md
@@ -1,0 +1,5 @@
+---
+type: AGENT_WORKER
+---
+
+Review the story and accept it or send it back for another pass.

--- a/examples/minimal-workflow-shape/workstations/execute-story/AGENTS.md
+++ b/examples/minimal-workflow-shape/workstations/execute-story/AGENTS.md
@@ -1,0 +1,5 @@
+---
+type: AGENT_RUN
+---
+
+Implement the story described by the current work item.

--- a/examples/minimal-workflow-shape/workstations/review-story/AGENTS.md
+++ b/examples/minimal-workflow-shape/workstations/review-story/AGENTS.md
@@ -1,0 +1,5 @@
+---
+type: AGENT_RUN
+---
+
+Review the current story implementation and return a decision.

--- a/examples/minimal-workflow/factory.json
+++ b/examples/minimal-workflow/factory.json
@@ -1,0 +1,51 @@
+{
+  "name": "minimal-workflow",
+  "workTypes": [
+    {
+      "name": "task",
+      "states": [
+        {
+          "name": "init",
+          "type": "INITIAL"
+        },
+        {
+          "name": "complete",
+          "type": "TERMINAL"
+        },
+        {
+          "name": "failed",
+          "type": "FAILED"
+        }
+      ]
+    }
+  ],
+  "workers": [
+    {
+      "name": "processor"
+    }
+  ],
+  "workstations": [
+    {
+      "name": "process-task",
+      "worker": "processor",
+      "inputs": [
+        {
+          "workType": "task",
+          "state": "init"
+        }
+      ],
+      "outputs": [
+        {
+          "workType": "task",
+          "state": "complete"
+        }
+      ],
+      "onFailure": [
+        {
+          "workType": "task",
+          "state": "failed"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/minimum-authoring-contract/factory.json
+++ b/examples/minimum-authoring-contract/factory.json
@@ -1,0 +1,26 @@
+{
+  "id": "review-factory",
+  "workTypes": [
+    {
+      "name": "task",
+      "handlingBehavior": ["DEFAULT"],
+      "states": [
+        { "name": "init", "type": "INITIAL" },
+        { "name": "complete", "type": "TERMINAL" },
+        { "name": "failed", "type": "FAILED" }
+      ]
+    }
+  ],
+  "workers": [
+    { "name": "reviewer" }
+  ],
+  "workstations": [
+    {
+      "name": "review",
+      "worker": "reviewer",
+      "inputs": [{ "workType": "task", "state": "init" }],
+      "outputs": [{ "workType": "task", "state": "complete" }],
+      "onFailure": [{ "workType": "task", "state": "failed" }]
+    }
+  ]
+}

--- a/examples/script-poller/factory.json
+++ b/examples/script-poller/factory.json
@@ -1,0 +1,25 @@
+{
+  "name": "github-intake",
+  "workTypes": [
+    {
+      "name": "task",
+      "states": [
+        { "name": "init", "type": "INITIAL" },
+        { "name": "complete", "type": "TERMINAL" },
+        { "name": "failed", "type": "FAILED" }
+      ]
+    }
+  ],
+  "workers": [
+    { "name": "github-poller" }
+  ],
+  "workstations": [
+    {
+      "name": "github-intake",
+      "behavior": "POLLER",
+      "worker": "github-poller",
+      "outputs": [{ "workType": "task", "state": "init" }],
+      "onFailure": [{ "workType": "task", "state": "failed" }]
+    }
+  ]
+}

--- a/examples/script-poller/scripts/poll-github.sh
+++ b/examples/script-poller/scripts/poll-github.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Replace this deterministic smoke payload with the repository's GitHub query.
+# The poller contract is one FACTORY_REQUEST_BATCH JSON document per run.
+printf '%s\n' '{"requestId":"github-intake-smoke","type":"FACTORY_REQUEST_BATCH","works":[]}'

--- a/examples/script-poller/workers/github-poller/AGENTS.md
+++ b/examples/script-poller/workers/github-poller/AGENTS.md
@@ -1,0 +1,8 @@
+---
+type: SCRIPT_WORKER
+command: bash
+args: ["scripts/poll-github.sh"]
+timeout: 2m
+---
+
+Poll GitHub and emit one canonical batch payload on stdout per run.

--- a/tests/functional/factory/definitions/example_corpus_test.go
+++ b/tests/functional/factory/definitions/example_corpus_test.go
@@ -71,6 +71,43 @@ func TestMinimalWorkflowExampleValidation(t *testing.T) {
 	}
 }
 
+func TestAuthoringFactoryExamplesValidation(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		rel  string
+	}{
+		{name: "expected artifacts JSON", rel: "examples/expected-artifacts-json"},
+		{name: "expected artifacts YAML", rel: "examples/expected-artifacts-yaml"},
+		{name: "first workflow", rel: "examples/first-workflow"},
+		{name: "local OMNIVOICE TTS", rel: "examples/local-omnivoice-tts"},
+		{name: "script poller", rel: "examples/script-poller"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			factoryPath := support.AgentFactoryPath(t, test.rel)
+			inputs := support.FakeInputs(t.Context(), []string{
+				"you", "factory", "config", "validate", factoryPath,
+			})
+			inputs.Input.Env = isolatedHomeEnvironment(t)
+			inputs.Input.WorkingDirectory = filepath.Dir(factoryPath)
+
+			err := buildDefinitionsProcess(t).Execute(inputs.Input)
+			if err != nil {
+				t.Fatalf(
+					"Process.Execute(factory config validate %s) error = %v\nstdout:\n%s\nstderr:\n%s",
+					factoryPath,
+					err,
+					inputs.Stdout(),
+					inputs.Stderr(),
+				)
+			}
+			diagnostic := inputs.Stdout() + "\n" + inputs.Stderr()
+			if !strings.Contains(diagnostic, "Factory validation passed.") {
+				t.Fatalf("validation diagnostic missing success message:\n%s", diagnostic)
+			}
+		})
+	}
+}
+
 func copyWithFormerObjectOnFailure(t *testing.T, sourceDir string) string {
 	t.Helper()
 

--- a/tests/functional/factory/definitions/example_corpus_test.go
+++ b/tests/functional/factory/definitions/example_corpus_test.go
@@ -1,0 +1,123 @@
+package definitions
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+func TestMinimalWorkflowExampleValidation(t *testing.T) {
+	minimalWorkflow := support.AgentFactoryPath(t, filepath.Join("examples", "minimal-workflow"))
+	formerObjectShape := copyWithFormerObjectOnFailure(t, minimalWorkflow)
+
+	for _, test := range []struct {
+		name        string
+		path        string
+		wantErr     bool
+		diagnostics []string
+	}{
+		{
+			name: "corrected array shape",
+			path: minimalWorkflow,
+			diagnostics: []string{
+				"Factory validation passed.",
+			},
+		},
+		{
+			name:    "former object shape",
+			path:    formerObjectShape,
+			wantErr: true,
+			diagnostics: []string{
+				"onFailure",
+				"cannot unmarshal object",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			inputs := support.FakeInputs(t.Context(), []string{
+				"you", "factory", "config", "validate", test.path,
+			})
+			inputs.Input.Env = isolatedHomeEnvironment(t)
+			inputs.Input.WorkingDirectory = filepath.Dir(test.path)
+
+			err := buildDefinitionsProcess(t).Execute(inputs.Input)
+			if test.wantErr && err == nil {
+				t.Fatal("Process.Execute(factory config validate) error = nil, want rejection")
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf(
+					"Process.Execute(factory config validate %s) error = %v\nstdout:\n%s\nstderr:\n%s",
+					test.path,
+					err,
+					inputs.Stdout(),
+					inputs.Stderr(),
+				)
+			}
+
+			diagnostic := inputs.Stdout() + "\n" + inputs.Stderr()
+			if err != nil {
+				diagnostic += "\n" + err.Error()
+			}
+			for _, want := range test.diagnostics {
+				if !strings.Contains(diagnostic, want) {
+					t.Fatalf("validation diagnostic missing %q:\n%s", want, diagnostic)
+				}
+			}
+		})
+	}
+}
+
+func copyWithFormerObjectOnFailure(t *testing.T, sourceDir string) string {
+	t.Helper()
+
+	sourcePath := filepath.Join(sourceDir, "factory.json")
+	source, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read minimal workflow example: %v", err)
+	}
+
+	var factory map[string]json.RawMessage
+	if err := json.Unmarshal(source, &factory); err != nil {
+		t.Fatalf("decode minimal workflow example: %v", err)
+	}
+	var workstations []map[string]json.RawMessage
+	if err := json.Unmarshal(factory["workstations"], &workstations); err != nil {
+		t.Fatalf("decode minimal workflow workstations: %v", err)
+	}
+	if len(workstations) != 1 {
+		t.Fatalf("minimal workflow workstations = %d, want 1", len(workstations))
+	}
+	var failureRoutes []json.RawMessage
+	if err := json.Unmarshal(workstations[0]["onFailure"], &failureRoutes); err != nil {
+		t.Fatalf("decode minimal workflow onFailure: %v", err)
+	}
+	if len(failureRoutes) != 1 {
+		t.Fatalf("minimal workflow onFailure routes = %d, want 1", len(failureRoutes))
+	}
+	workstations[0]["onFailure"] = failureRoutes[0]
+	workstationsJSON, err := json.Marshal(workstations)
+	if err != nil {
+		t.Fatalf("encode former object-shaped workstations: %v", err)
+	}
+	factory["workstations"] = workstationsJSON
+	mutated, err := json.MarshalIndent(factory, "", "  ")
+	if err != nil {
+		t.Fatalf("encode former object-shaped minimal workflow: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "factory.json")
+	if err := os.WriteFile(path, mutated, 0o600); err != nil {
+		t.Fatalf("write former object-shaped factory: %v", err)
+	}
+	return path
+}
+
+func isolatedHomeEnvironment(t *testing.T) []string {
+	t.Helper()
+	home := t.TempDir()
+	return append(os.Environ(), "HOME="+home, "USERPROFILE="+home)
+}

--- a/tests/functional/factory/definitions/example_corpus_test.go
+++ b/tests/functional/factory/definitions/example_corpus_test.go
@@ -71,7 +71,7 @@ func TestMinimalWorkflowExampleValidation(t *testing.T) {
 	}
 }
 
-func TestAuthoringFactoryExamplesValidation(t *testing.T) {
+func TestReferenceFactoryExamplesValidation(t *testing.T) {
 	for _, test := range []struct {
 		name string
 		rel  string
@@ -81,6 +81,9 @@ func TestAuthoringFactoryExamplesValidation(t *testing.T) {
 		{name: "first workflow", rel: "examples/first-workflow"},
 		{name: "local OMNIVOICE TTS", rel: "examples/local-omnivoice-tts"},
 		{name: "script poller", rel: "examples/script-poller"},
+		{name: "minimum authoring contract", rel: "examples/minimum-authoring-contract"},
+		{name: "inference throttle guard", rel: "examples/inference-throttle-guard"},
+		{name: "minimal workflow shape", rel: "examples/minimal-workflow-shape"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			factoryPath := support.AgentFactoryPath(t, test.rel)


### PR DESCRIPTION
{
  "project": "PLAN-DOC-001 DOC-1: Functional-Tier-Validated Example Corpus",
  "branchName": "doc1-example-corpus-under-examples-dir",
  "description": "Materialize every eligible graph Factory example currently embedded in docs/reference as a clearly named real directory under examples, correct schema drift such as the Minimal Workflow onFailure object-versus-array defect, and validate every corpus entry through the ordinary functional tier and the delivered CLI artifact. This is the independently mergeable DOC-1 foundation for later documentation transclusion; reference prose, generators, projection support, docs-check gating, and worker execution remain outside this lane.",
  "context": {
    "customerAsk": "Move every complete or directory-forming Factory configuration example currently embedded in docs/reference into a corresponding real directory under examples, add functional-tier coverage that runs you factory config validate against each entry and asserts pass or a documented expected failure, correct and prove the known onFailure shape defect, and keep make docs-reference-smoke passing without migrating reference prose.",
    "problem": "Documentation examples are authored independently of the real Factory contract, while docs-reference-smoke checks Markdown and the docs command but never validates copied configurations. This allowed the documented Minimal Workflow to use an onFailure object where the schema requires an array, leaving customers with an invalid first example and no automated signal.",
    "solution": "Create a bounded corpus of ordinary Factory directories under examples for the eligible reference headings, preserve each example's teaching intent and format, and add a table-driven Factory Definitions functional scenario that constructs through root.BuildProcess, invokes the public factory config validate command through Process.Execute, and checks the outcome and diagnostic for every real corpus entry. Seed the corpus with the corrected Minimal Workflow and an explicit regression exercise of its former invalid shape, then extend the same validation path to the remaining authoring, config, guard, and workstation examples."
  },
  "acceptanceCriteria": [
    "Every eligible Factory example in the scoped authoring-factories, config, guards, and workstations reference headings has a corresponding clearly named directory under examples containing the real root configuration and any minimal supporting split files; the example retains the behavior and format variant its source heading teaches.",
    "Functional-tier coverage invokes you factory config validate through the canonical root.BuildProcess and Process.Execute path for every new corpus entry, asserts validation success for valid examples, and asserts the intended actionable diagnostic for any documented expected-failure example.",
    "The Minimal Workflow uses an array for onFailure; focused regression coverage demonstrates that the former object shape is rejected, and the PR body records the verbatim before/after validation commands and outputs as evidence that the new coverage has teeth.",
    "DOC-1 remains isolated: no cmd/docscodegen, transclusion or projection markers, reference-topic migration, docs-check required gate, mock-worker execution coverage, unrelated cleanup, or substantive docs/reference prose change is included; make docs-reference-smoke continues to pass.",
    "Runtime-proof classification: applicable, because this lane adds runtime-observable CLI validation coverage. Build the real delivered you artifact to a temporary path, redirect both HOME and USERPROFILE to an isolated temporary directory, invoke that artifact end to end with factory config validate against every new example, and record the verbatim build/validation commands, exit results, stdout, and stderr in a PR comment. Green tests, an inspected diff, or implementer assertions alone do not satisfy this proof.",
    "Quality gates pass: Typecheck passes; Tests pass, including the focused functional corpus validation and make docs-reference-smoke; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "doc1-example-corpus-under-examples-dir-001",
      "title": "Validate the corrected Minimal Workflow as a real example",
      "description": "As a customer copying the Minimal Workflow, I want a real example directory that the shipped validator accepts so the first configuration I try is schema-correct.",
      "acceptanceCriteria": [
        "A clearly named examples/minimal-workflow directory contains the documented minimal work type, worker, workstation, success route, and failure route, with onFailure represented as the schema-required array.",
        "Invoking you factory config validate for the real Minimal Workflow through root.BuildProcess and Process.Execute succeeds and emits the public validation-success diagnostic.",
        "Focused regression coverage changes only the exercised onFailure value back to the former object shape and observes validation failure with an actionable shape diagnostic, proving that the corpus test would catch the known defect.",
        "The PR body includes the verbatim failing result for the former object shape and succeeding result for the corrected array shape.",
        "The test uses the public CLI boundary, adds no sleep or provider fake, and does not create a second application graph or inspect internal validator state.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented examples/minimal-workflow/factory.json and a table-driven functional validation regression through the existing root.BuildProcess/Process.Execute composition. The corrected array shape passes with the public success diagnostic; a temporary copy with only onFailure restored to an object is rejected with the public JSON shape diagnostic. Focused test and make typecheck pass. The broader Definitions package had one unrelated flaky TestGlobalConfigSuppliesDefaultProviderAndModel failure; rerunning that named test passed. Verbatim artifact evidence for the PR body: COMMAND: \"C:\\Users\\andre\\AppData\\Local\\Temp\\doc1-artifact-proof-52b04259f2194b49b7f543077c015e17\\you.exe\" \"factory\" \"config\" \"validate\" \"C:\\Users\\andre\\work\\portos\\infinite-you\\.claude\\worktrees\\doc1-example-corpus-under-examples-dir\\examples\\minimal-workflow\"; EXIT: 0; STDOUT: Factory validation passed. Runtime taxonomy: worker processor: unspecified worker type; workstation process-task: legacy agent-run default (worker=processor); STDERR: (empty). Former shape COMMAND: \"C:\\Users\\andre\\AppData\\Local\\Temp\\doc1-artifact-proof-52b04259f2194b49b7f543077c015e17\\you.exe\" \"--debug\" \"factory\" \"config\" \"validate\" \"C:\\Users\\andre\\AppData\\Local\\Temp\\doc1-artifact-proof-52b04259f2194b49b7f543077c015e17\\minimal-workflow-former-object-factory.json\"; EXIT: 1; STDOUT: (empty); STDERR: {\"code\":\"CLI_COMMAND_FAILED\",\"family\":\"INTERNAL_SERVER_ERROR\",\"message\":\"command failed\"}; debug: cause[0]=Factory Definition source C:\\Users\\andre\\AppData\\Local\\Temp\\doc1-artifact-proof-52b04259f2194b49b7f543077c015e17\\minimal-workflow-former-object-factory.json (JSON): parse factory config: unmarshal factory api model: error reading 'onFailure': json: cannot unmarshal object into Go value of type []generated.WorkstationIO."
    },
    {
      "id": "doc1-example-corpus-under-examples-dir-002",
      "title": "Validate the remaining authoring-guide Factory examples",
      "description": "As a customer following the Factory authoring guide, I want each complete walkthrough and format variant to exist as an independently valid example so I can validate the configuration before running it.",
      "acceptanceCriteria": [
        "Clearly named real directories cover the authoring guide's expected-artifacts JSON variant, expected-artifacts YAML variant, first-workflow walkthrough, local OMNIVOICE TTS example, and script-poller example, with the root extension and taught behavior preserved.",
        "Each directory includes the minimum supporting worker, workstation, prompt, script, or topology content required by the real Factory contract; placeholder secrets or live provider access are not required for static validation.",
        "The functional corpus scenario invokes the public factory config validate command for each directory and asserts the declared success outcome and public success diagnostic independently, so one failure identifies the affected customer example.",
        "Any intentionally invalid authoring example discovered within this bounded set is retained only when its teaching purpose is a validator rejection, and its case asserts the specific documented failure outcome rather than weakening it into a success expectation.",
        "No example is executed with workers in this story; DOC-6 owns execution coverage.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added examples/expected-artifacts-json and examples/expected-artifacts-yaml with the complete expected-artifact topology, examples/first-workflow with the documented split workers and workstations, examples/local-omnivoice-tts with its local inference worker, and examples/script-poller with its script worker and smoke payload. TestAuthoringFactoryExamplesValidation invokes factory config validate through root.BuildProcess and Process.Execute for every directory. Focused functional validation, make typecheck, and make docs-reference-smoke pass. The script-poller also needed the required terminal completion state omitted by the reference snippet."
    },
    {
      "id": "doc1-example-corpus-under-examples-dir-003",
      "title": "Complete and prove the reference Factory corpus",
      "description": "As a maintainer preparing documentation transclusion, I want the remaining reference Factory examples covered by the same real validation path and direct artifact proof so later docs generation can depend on a complete, tested corpus.",
      "acceptanceCriteria": [
        "Clearly named real directories cover Minimum Factory Authoring Contract, Factory INFERENCE_THROTTLE_GUARD, and Minimal Workflow Shape, and a final review confirms that every eligible entry defined by the PRD corpus boundary has exactly one corresponding corpus directory or a documented shared canonical directory when two headings intentionally teach the identical Factory.",
        "The functional corpus scenario validates every new example directory, asserting success for valid examples and the stable actionable diagnostic for any documented expected-failure example; it reads the real example assets rather than copied test fixtures.",
        "make docs-reference-smoke passes with existing reference prose and hand-typed snippets unchanged, except for a strictly necessary pre-existing path reference adjustment if one is required.",
        "No DOC-2 through DOC-6 implementation or new required CI gate is introduced, and no unrelated example or validation cleanup is bundled into this lane.",
        "Runtime-proof classification: applicable, because this lane adds runtime-observable CLI validation coverage. Build the real delivered you artifact to a temporary path, redirect both HOME and USERPROFILE to an isolated temporary directory, invoke that artifact end to end with factory config validate against every new example, and record the verbatim build/validation commands, exit results, stdout, and stderr in a PR comment. Green tests, an inspected diff, or implementer assertions alone do not satisfy this proof.",
        "Quality verification records focused functional-test output and make docs-reference-smoke; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added examples/minimum-authoring-contract, examples/inference-throttle-guard, and examples/minimal-workflow-shape, including the minimal split worker/workstation assets. The functional corpus table now validates all nine DOC-1 directories through root.BuildProcess and Process.Execute, and the final audit maps each eligible PRD heading to exactly one corpus directory (the authoring-guide Minimal Workflow and workstation Minimal Workflow Shape intentionally teach different scopes). Focused and full Definitions tests, make docs-reference-smoke, make typecheck, and make test pass. make lint passes all relevant gates and reproduces one unchanged packaged-factory-consumption baseline violation in internal/migrationledgercheck/packaged_factory_matrix.go outside this diff. A temporary delivered you artifact validated every directory with isolated HOME and USERPROFILE; the PR comment records verbatim build/validation commands, exits, stdout, and stderr, including the former object-shaped onFailure rejection under --debug. No DOC-2 through DOC-6 work, docs/reference prose change, or new required CI gate was added."
    }
  ]
}
