### PR TITLE
models-invoke-validation-error-diagnosability

### DIFF
--- a/pkg/services/models/transports/cli/bootstrap_invoke.go
+++ b/pkg/services/models/transports/cli/bootstrap_invoke.go
@@ -172,6 +172,9 @@ func mapBootstrapModelInvokeError(err error) error {
 	if errors.As(err, &failure) && failure != nil {
 		return failure
 	}
+	if mapped, ok := mapModelsInvocationError(err); ok {
+		return mapped
+	}
 	switch {
 	case errors.Is(err, modelinference.ErrNotFound):
 		return fmt.Errorf("%w: model not found", ErrModelNotFound)

--- a/pkg/services/models/transports/cli/command_handler_errors_test.go
+++ b/pkg/services/models/transports/cli/command_handler_errors_test.go
@@ -3,13 +3,16 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
 
 	startupcli "github.com/portpowered/infinite-you/pkg/initializer/process"
+	modelinference "github.com/portpowered/infinite-you/pkg/services/models"
 	operatorconfig "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	"github.com/portpowered/infinite-you/pkg/transports/cli/resolvedinput"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
@@ -395,5 +398,87 @@ func TestCommandHandlerOmitsManifestDefaultServerFromModelsConfig(t *testing.T) 
 	}
 	if gotServer != "" {
 		t.Fatalf("server = %q, want empty for manifest-default --server", gotServer)
+	}
+}
+
+func TestModelsClientErrorPreservesTypedInvocationDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("validation cause")
+	message := "required input slot is missing: audio"
+	for _, test := range []struct {
+		name       string
+		class      modelinference.InvocationFailureClass
+		code       string
+		family     factoryapi.ErrorFamily
+		badRequest bool
+	}{
+		{
+			name:       "missing required slot",
+			class:      modelinference.InvocationFailureClassInvalidSlot,
+			code:       "BAD_REQUEST",
+			family:     factoryapi.ErrorFamilyBadRequest,
+			badRequest: true,
+		},
+		{
+			name:   "unknown model reference",
+			class:  modelinference.InvocationFailureClassInvalidModelReference,
+			code:   "MODEL_NOT_AVAILABLE",
+			family: factoryapi.ErrorFamilyNotFound,
+		},
+		{
+			name:   "backend readiness",
+			class:  modelinference.InvocationFailureClassBackendReadiness,
+			code:   "MODEL_BACKEND_NOT_READY",
+			family: factoryapi.ErrorFamilyInternalServerError,
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			failure := &modelinference.InvocationFailure{
+				Class: test.class, Message: message, Cause: cause,
+			}
+			wrapped := fmt.Errorf("models invocation: %w", failure)
+			mapped := mapModelsClientError(wrapped)
+
+			var classified *modelinference.InvocationFailure
+			if !errors.As(mapped, &classified) || classified != failure {
+				t.Fatalf("mapped error = %v, failure = %#v, want the original typed failure", mapped, classified)
+			}
+			if !errors.Is(mapped, cause) {
+				t.Fatalf("mapped error = %v, want the original cause in the chain", mapped)
+			}
+			var coded interface {
+				CLIErrorCode() string
+				CLIErrorFamily() factoryapi.ErrorFamily
+				CLIErrorMessage() string
+			}
+			if !errors.As(mapped, &coded) {
+				t.Fatalf("mapped error = %T, want CLI diagnostic contract", mapped)
+			}
+			if coded.CLIErrorCode() != test.code || coded.CLIErrorFamily() != test.family || coded.CLIErrorMessage() != message {
+				t.Fatalf("CLI fields = (%q, %q, %q), want (%q, %q, %q)", coded.CLIErrorCode(), coded.CLIErrorFamily(), coded.CLIErrorMessage(), test.code, test.family, message)
+			}
+			if test.badRequest && coded.CLIErrorFamily() == factoryapi.ErrorFamilyInternalServerError {
+				t.Fatal("client validation was classified as INTERNAL_SERVER_ERROR")
+			}
+		})
+	}
+}
+
+func TestModelsRootErrorDoesNotReclassifyInvocationFailuresOutsideClientPaths(t *testing.T) {
+	t.Parallel()
+
+	failure := &modelinference.InvocationFailure{
+		Class:   modelinference.InvocationFailureClassInvalidSlot,
+		Message: "required input slot is missing: audio",
+	}
+	if mapped := mapModelsRootError(failure); mapped != failure {
+		t.Fatalf("mapModelsRootError() = %T, want the original failure for non-invocation paths", mapped)
+	}
+	if mapped := mapModelsRootError(modelinference.ErrNotFound); mapped == nil || !errors.Is(mapped, modelinference.ErrNotFound) {
+		t.Fatalf("mapModelsRootError(ErrNotFound) = %v, want unchanged not-found identity", mapped)
 	}
 }

--- a/pkg/services/models/transports/cli/root_commands.go
+++ b/pkg/services/models/transports/cli/root_commands.go
@@ -53,7 +53,7 @@ func (service *rootService) Inspect(cfg InspectConfig) error {
 			Scope: scope, Name: modelName,
 		})
 		if err != nil {
-			return mapModelsRootError(err)
+			return mapModelsClientError(err)
 		}
 		response := detailToGenerated(result.Model)
 		if cfg.JSON {

--- a/pkg/services/models/transports/cli/root_errors.go
+++ b/pkg/services/models/transports/cli/root_errors.go
@@ -11,13 +11,15 @@ import (
 )
 
 const (
-	modelsRootModelNotFoundCode  = "NOT_FOUND"
-	modelsRootCacheNotFoundCode  = "MODEL_CACHE_NOT_FOUND"
-	modelsRootCacheInUseCode     = "MODEL_CACHE_IN_USE"
-	modelsRootCacheUnsafeCode    = "BAD_REQUEST"
-	modelsRootPullFailedCode     = "CLI_MODEL_PULL_FAILED"
-	modelsRootDefaultErrorText   = "models command failed"
-	modelsRootMissingCachePrefix = "model cache is not installed; run you models pull"
+	modelsRootModelNotFoundCode    = "NOT_FOUND"
+	modelsRootModelUnavailableCode = "MODEL_NOT_AVAILABLE"
+	modelsRootBadRequestCode       = "BAD_REQUEST"
+	modelsRootCacheNotFoundCode    = "MODEL_CACHE_NOT_FOUND"
+	modelsRootCacheInUseCode       = "MODEL_CACHE_IN_USE"
+	modelsRootCacheUnsafeCode      = modelsRootBadRequestCode
+	modelsRootPullFailedCode       = "CLI_MODEL_PULL_FAILED"
+	modelsRootDefaultErrorText     = "models command failed"
+	modelsRootMissingCachePrefix   = "model cache is not installed; run you models pull"
 )
 
 // modelsRootError preserves a Models CLI sentinel and the originating Models
@@ -84,6 +86,59 @@ func newModelsRootError(
 	return &modelsRootError{
 		code: code, family: family, message: message, sentinel: sentinel, cause: cause,
 	}
+}
+
+// mapModelsInvocationError preserves the Models invocation taxonomy at the
+// local CLI boundary. Generic invocation validation already carries a safe
+// public message; only the CLI diagnostic fields are missing when the error
+// crosses this adapter. The underlying typed failure remains in the cause so
+// callers and --debug diagnostics retain its identity.
+func mapModelsInvocationError(err error) (error, bool) {
+	if err == nil {
+		return nil, false
+	}
+	var failure *modelinference.InvocationFailure
+	if !errors.As(err, &failure) || failure == nil {
+		return nil, false
+	}
+	code, family := modelsInvocationDiagnostic(failure.Class)
+	return newModelsRootError(code, family, failure.Error(), nil, err), true
+}
+
+func modelsInvocationDiagnostic(class modelinference.InvocationFailureClass) (string, factoryapi.ErrorFamily) {
+	switch class {
+	case modelinference.InvocationFailureClassInvalidModelReference,
+		modelinference.InvocationFailureClassRevisionResolution:
+		return modelsRootModelUnavailableCode, factoryapi.ErrorFamilyNotFound
+	case modelinference.InvocationFailureClassInvalidOperation,
+		modelinference.InvocationFailureClassInvalidSlot,
+		modelinference.InvocationFailureClassSlotArity,
+		modelinference.InvocationFailureClassInvalidParameter,
+		modelinference.InvocationFailureClassMediaCapability,
+		modelinference.InvocationFailureClassArtifact:
+		return modelsRootBadRequestCode, factoryapi.ErrorFamilyBadRequest
+	case modelinference.InvocationFailureClassOfflineCache:
+		return "MODEL_OFFLINE_CACHE_UNAVAILABLE", factoryapi.ErrorFamilyConflict
+	case modelinference.InvocationFailureClassBackendReadiness:
+		return "MODEL_BACKEND_NOT_READY", factoryapi.ErrorFamilyInternalServerError
+	case modelinference.InvocationFailureClassBackendProtocol,
+		modelinference.InvocationFailureClassMalformedResponse:
+		return "MODEL_BACKEND_FAILURE", factoryapi.ErrorFamilyInternalServerError
+	case modelinference.InvocationFailureClassCancellation,
+		modelinference.InvocationFailureClassTimeout:
+		return "MODEL_INFERENCE_TIMEOUT", factoryapi.ErrorFamilyInternalServerError
+	case modelinference.InvocationFailureClassConfiguration:
+		return "MODEL_CONFIGURATION_FAILURE", factoryapi.ErrorFamilyInternalServerError
+	default:
+		return "MODEL_INFERENCE_RUNTIME_FAILURE", factoryapi.ErrorFamilyInternalServerError
+	}
+}
+
+func mapModelsClientError(err error) error {
+	if mapped, ok := mapModelsInvocationError(err); ok {
+		return mapped
+	}
+	return mapModelsRootError(err)
 }
 
 func mapModelsRootError(err error) error {

--- a/pkg/services/models/transports/cli/root_invoke.go
+++ b/pkg/services/models/transports/cli/root_invoke.go
@@ -44,7 +44,7 @@ func (service *rootService) Invoke(cfg InvokeConfig) error {
 	}
 	scope, err := service.openInvokeScope(cfg.Context, cfg)
 	if err != nil {
-		return mapModelsRootError(err)
+		return mapModelsClientError(err)
 	}
 	if scope.Close != nil {
 		defer func() {
@@ -102,7 +102,7 @@ func (service *rootService) catalogForInvoke(
 	if !cfg.JSON && strings.TrimSpace(cfg.OutputPath) == "" && errors.Is(err, modelinference.ErrUnsupportedOperation) {
 		return modelinference.Detail{}, fmt.Errorf("--output is required unless --json is set")
 	}
-	return modelinference.Detail{}, mapModelsRootError(err)
+	return modelinference.Detail{}, mapModelsClientError(err)
 }
 
 func (service *rootService) refreshInvokeReadiness(
@@ -122,7 +122,7 @@ func (service *rootService) refreshInvokeReadiness(
 	if errors.Is(err, modelinference.ErrUnsupportedOperation) {
 		return catalog, nil
 	}
-	return modelinference.Detail{}, mapModelsRootError(err)
+	return modelinference.Detail{}, mapModelsClientError(err)
 }
 
 func (service *rootService) tryJoinedInvocation(
@@ -144,7 +144,7 @@ func (service *rootService) tryJoinedInvocation(
 			errors.Is(err, modelinference.ErrModelReferenceUnknown) {
 			return false, nil
 		}
-		return false, mapModelsRootError(err)
+		return false, mapModelsClientError(err)
 	}
 	return true, service.writeJoinedInvocation(cfg, catalog, operation, joinedResult, text)
 }
@@ -553,14 +553,14 @@ func (service *rootService) invokePreparedLease(
 ) error {
 	if runtime := catalog.ManagedRuntime; strings.TrimSpace(runtime.Identity) != "" {
 		if err := runtime.InvocationError(); err != nil {
-			return mapModelsRootError(err)
+			return mapModelsClientError(err)
 		}
 	}
 	leaseResult, err := service.models.AcquireModelLease(cfg.Context, modelinference.AcquireModelLeaseRequest{
 		Scope: scope, Name: modelName, Holder: modelsCLIInvokeHolder,
 	})
 	if err != nil {
-		return mapModelsRootError(err)
+		return mapModelsClientError(err)
 	}
 	request := modelinference.InvokeModelRequest{
 		Scope:     scope,
@@ -579,7 +579,7 @@ func (service *rootService) invokePreparedLease(
 	}
 	result, err := service.models.InvokeModelWithLease(cfg.Context, request)
 	if err != nil {
-		return mapModelsRootError(err)
+		return mapModelsClientError(err)
 	}
 	if cfg.JSON {
 		response := modelInvocationResponseFromInferenceResult(result, catalog, text)
@@ -588,7 +588,7 @@ func (service *rootService) invokePreparedLease(
 	outputPath := strings.TrimSpace(cfg.OutputPath)
 	streamFile, err := inferenceArtifactSourcePath(result)
 	if err != nil {
-		return mapModelsRootError(err)
+		return mapModelsClientError(err)
 	}
 	if service.artifacts == nil {
 		return fmt.Errorf("model invocation artifact exporter is required")

--- a/pkg/services/models/transports/cli/service_test.go
+++ b/pkg/services/models/transports/cli/service_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -737,5 +738,48 @@ func assertCharacterizationJSON(t *testing.T, got, want string) {
 	t.Helper()
 	if strings.TrimSpace(got) != want {
 		t.Fatalf("JSON = %q, want exact %q", strings.TrimSpace(got), want)
+	}
+}
+
+func TestRootAdapter_InspectMapsTypedInvocationValidation(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("validation cause")
+	failure := &modelinference.InvocationFailure{
+		Class:   modelinference.InvocationFailureClassInvalidSlot,
+		Message: "required input slot is missing: audio",
+		Cause:   cause,
+	}
+	service := modelscli.NewService(modelscli.Config{
+		Models: stubModelsRoot{
+			getCatalogModel: func(context.Context, modelinference.GetModelRequest) (modelinference.GetModelResult, error) {
+				return modelinference.GetModelResult{}, failure
+			},
+		},
+		OpenCatalogScope: func(context.Context) (modelscli.InvokeRuntimeScope, error) {
+			return parityInvokeScope(t), nil
+		},
+	})
+
+	err := service.Inspect(modelscli.InspectConfig{
+		Context: context.Background(), ModelName: "asr", JSON: true, Output: io.Discard,
+	})
+	if err == nil {
+		t.Fatal("Inspect() error = nil, want typed validation failure")
+	}
+	var classified *modelinference.InvocationFailure
+	if !errors.As(err, &classified) || classified != failure || !errors.Is(err, cause) {
+		t.Fatalf("Inspect() error = %v, failure = %#v, want original typed failure and cause", err, classified)
+	}
+	var coded interface {
+		CLIErrorCode() string
+		CLIErrorFamily() factoryapi.ErrorFamily
+		CLIErrorMessage() string
+	}
+	if !errors.As(err, &coded) {
+		t.Fatalf("Inspect() error = %T, want CLI diagnostic contract", err)
+	}
+	if coded.CLIErrorCode() != "BAD_REQUEST" || coded.CLIErrorFamily() != factoryapi.ErrorFamilyBadRequest || coded.CLIErrorMessage() != failure.Message {
+		t.Fatalf("Inspect() CLI fields = (%q, %q, %q), want BAD_REQUEST/BAD_REQUEST/%q", coded.CLIErrorCode(), coded.CLIErrorFamily(), coded.CLIErrorMessage(), failure.Message)
 	}
 }

--- a/tests/functional/models/root_composition/coded_diagnostics_test.go
+++ b/tests/functional/models/root_composition/coded_diagnostics_test.go
@@ -19,6 +19,72 @@ import (
 const codedDiagnosticModelName = "OMNIVOICE_Q4_K_M"
 const codedDiagnosticUnknownModelName = "missing-model"
 
+func TestModelsLocalInvokeMissingRequiredSlotRendersBadRequest(t *testing.T) {
+	t.Parallel()
+
+	factoryDir := support.ScaffoldFactory(t, builtInOnlyModelFactoryConfig())
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	homeDir := t.TempDir()
+
+	for _, test := range []struct {
+		name  string
+		debug bool
+	}{
+		{name: "normal"},
+		{name: "debug", debug: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			args := []string{
+				"you", "models", "invoke", "asr",
+				"--operation", "ASR", "--text", "x", "--json",
+			}
+			if test.debug {
+				args = append(args, "--debug")
+			}
+			inputs := support.FakeInputs(t.Context(), args)
+			inputs.Input.Env = functionalHomeEnvironment(homeDir)
+			inputs.Input.WorkingDirectory = factoryDir
+
+			err := process.Execute(inputs.Input)
+			if err == nil {
+				t.Fatal("Process.Execute(models invoke asr) error = nil, want missing-slot failure")
+			}
+			if inputs.Stdout() != "" {
+				t.Fatalf("models invoke missing-slot stdout = %q, want empty", inputs.Stdout())
+			}
+			var failure *modelservice.InvocationFailure
+			if !errors.As(err, &failure) || failure == nil || failure.Class != modelservice.InvocationFailureClassInvalidSlot {
+				t.Fatalf("models invoke missing-slot error = %v, failure = %#v, want typed invalid-slot failure", err, failure)
+			}
+
+			response := decodeFirstDiagnostic(t, inputs.Stderr())
+			if response.Code != factoryapi.ErrorResponseCode("BAD_REQUEST") || response.Family != factoryapi.ErrorFamilyBadRequest ||
+				!strings.Contains(response.Message, "required input slot is missing: audio") {
+				t.Fatalf("models invoke missing-slot diagnostic = %#v, want BAD_REQUEST with actionable message; stderr=%q", response, inputs.Stderr())
+			}
+			for _, fallback := range []string{"CLI_COMMAND_FAILED", "INTERNAL_SERVER_ERROR", "command failed"} {
+				if strings.Contains(inputs.Stderr(), fallback) {
+					t.Fatalf("models invoke missing-slot diagnostic contains fallback %q: %q", fallback, inputs.Stderr())
+				}
+			}
+		})
+	}
+
+	pullInputs := support.FakeInputs(t.Context(), []string{
+		"you", "models", "pull", "missing-pull-model", "--json",
+	})
+	pullInputs.Input.Env = functionalHomeEnvironment(homeDir)
+	pullInputs.Input.WorkingDirectory = factoryDir
+	if err := process.Execute(pullInputs.Input); err == nil {
+		t.Fatal("Process.Execute(models pull missing-pull-model) error = nil, want not-found failure")
+	}
+	pullResponse := decodeFirstDiagnostic(t, pullInputs.Stderr())
+	if pullResponse.Code != factoryapi.ErrorResponseCodeNOTFOUND || pullResponse.Family != factoryapi.ErrorFamilyNotFound {
+		t.Fatalf("models pull missing-model diagnostic = %#v, want NOT_FOUND/NOT_FOUND", pullResponse)
+	}
+}
+
 func TestModelsLocalRemoveMissingCacheRendersCodedDiagnostic(t *testing.T) {
 	for _, test := range []struct {
 		name  string


### PR DESCRIPTION
{
  "project": "Make Models CLI Validation Errors Actionable",
  "branchName": "models-invoke-validation-error-diagnosability",
  "description": "Preserve actionable client-side validation messages for you models invoke and you models inspect in ordinary stderr output, classify those failures with the existing BAD_REQUEST family, and prove the missing-required-slot behavior without changing pull, cache, readiness, the shared CLI renderer, or the --input grammar.",
  "context": {
    "customerAsk": "Make the real validation message appear on stderr without -d for client-side you models invoke and you models inspect validation failures, classify those failures with the CLI's existing 4xx-style family rather than INTERNAL_SERVER_ERROR, and add regression coverage for a missing required invocation input slot. Preserve the already-correct pull not-found behavior and do not change pull, cache, readiness, or --input grammar behavior.",
    "problem": "Models invocation validation already identifies caller mistakes such as a missing required audio slot, but the Models CLI path does not expose that failure through the coded diagnostic contract consumed by the central renderer. Normal output therefore falls back to CLI_COMMAND_FAILED, INTERNAL_SERVER_ERROR, and command failed, while only debug output reveals the actionable cause. Customers and automation cannot correct the invocation or distinguish their input mistake from a server failure.",
    "solution": "At the Models CLI transport boundary, translate existing typed client-validation failures from models invoke and models inspect into the established coded diagnostic shape, preserving the safe message and cause identity while using the existing BAD_REQUEST convention. Add focused mapping and public CLI regression coverage, preserve non-client classifications and pull NOT_FOUND behavior, and prove the correction with the real built you artifact."
  },
  "acceptanceCriteria": [
    "From a factory-context working directory, you models invoke asr --operation ASR --text x --json without -d exits nonzero and emits a JSON diagnostic on stderr whose message contains required input slot is missing: audio, whose family is BAD_REQUEST and not INTERNAL_SERVER_ERROR, and whose output is not reduced to command failed.",
    "Existing client-side validation failures returned by models invoke and models inspect preserve their safe specific message in default stderr output and use the existing bad-input classification convention; --debug may add cause detail but does not replace or change the primary code, family, or message.",
    "Existing pull not-found behavior remains NOT_FOUND, and the implementation changes no pull, cache, readiness, managed-runtime lifecycle, provider execution, OpenAPI/generated contract, shared central CLI-rendering, or --input <slot>=<value> grammar behavior.",
    "Runtime-proof classification: this lane changes runtime-observable CLI behavior, so runtime proof is applicable. Build the real delivered you artifact, exercise the missing-required-slot command end to end from a factory-context directory without -d, and record the verbatim build command, invocation, exit result, stdout, and stderr. Green tests, an inspected diff, or implementer-only mapping evidence do not satisfy this proof.",
    "Final quality gate: Typecheck passes; focused Models CLI mapping tests and public CLI regression tests pass; relevant broader tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "models-invoke-validation-error-diagnosability-001",
      "title": "Surface and classify Models client-validation failures",
      "description": "As a CLI customer, I want models invoke and models inspect to report the specific validation mistake as a client error so I can correct the command without enabling debug mode or mistaking it for a server fault.",
      "acceptanceCriteria": [
        "Given the cataloged asr model requires an audio input, running you models invoke asr --operation ASR --text x --json without -d exits nonzero and writes a JSON diagnostic to stderr whose message contains required input slot is missing: audio.",
        "The missing-slot diagnostic uses the existing BAD_REQUEST family, never INTERNAL_SERVER_ERROR, and does not collapse its primary message to command failed.",
        "Other existing typed, caller-correctable validation failures from models invoke and models inspect follow the same default-message and bad-request-family contract without string matching; non-client failures retain their existing classifications.",
        "Running the same validation failure with --debug retains the same primary code, family, and actionable message while allowing additional safe cause detail.",
        "Focused automated coverage proves the Models CLI classification mapping and a public command path through root.BuildProcess plus Process.Execute; assertions exercise stderr, nonzero exit behavior, exact client-error family, actionable message, and unchanged pull NOT_FOUND behavior rather than source topology or command inventories.",
        "No shared central CLI renderer, pull/cache/readiness/lifecycle path, provider execution path, OpenAPI/generated artifact, or --input <slot>=<value> parsing behavior is changed, and no broad unrelated cleanup is included.",
        "Runtime-proof classification: this lane changes runtime-observable CLI behavior, so runtime proof is applicable. Build the real delivered you artifact, exercise the missing-required-slot command end to end from a factory-context directory without -d, and record the verbatim build command, invocation, exit result, stdout, and stderr. Green tests, an inspected diff, or implementer-only mapping evidence do not satisfy this proof.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented the Models CLI boundary mapping for typed InvocationFailure values, preserving actionable messages and causes while retaining the existing pull NOT_FOUND path and central renderer. Focused mapping, root Inspect, root.BuildProcess/Process.Execute, Models package, and model functional tests pass. Runtime proof: make build expanded to go build -buildvcs=false -o bin/you.exe ./cmd/factory/; from the checked-in factory directory, you.exe models invoke asr --operation ASR --text x --json exited 1 with empty stdout and stderr {\"code\":\"BAD_REQUEST\",\"family\":\"BAD_REQUEST\",\"message\":\"required input slot is missing: audio\"}. make typecheck, backend-size, pkg-maint, pkg-file-count, pkg-structure, and make vet pass. The unrelated CLI command-identity baseline test reproduces on base SHA with want 65858 bytes, got 66238 bytes."
    }
  ]
}
