### PR TITLE
ci: bound Windows LocalAI backend builds

### DIFF
--- a/.github/workflows/localai-backend-artifacts.yml
+++ b/.github/workflows/localai-backend-artifacts.yml
@@ -204,6 +204,9 @@ jobs:
         if: runner.os == 'Windows'
         working-directory: you-agent-factory
         shell: msys2 {0}
+        # Keep the Windows build below the job ceiling without changing the
+        # existing Darwin/Linux build budget.
+        timeout-minutes: 60
         run: |
           set -euo pipefail
           bash scripts/build-localai-backend-artifact.sh

--- a/scripts/localai-backend-artifact-workflow.test.mjs
+++ b/scripts/localai-backend-artifact-workflow.test.mjs
@@ -353,6 +353,38 @@ test("the Windows build plan resolves Git from the runner path bridge", async (t
 	assert.match(plan.git.replaceAll("\\", "/"), /\/git-bin\/git$/);
 });
 
+function windowsBuildTimeout(workflow) {
+	const jobTimeout = workflow.match(/^\s+timeout-minutes:\s+(\d+)\s*$/m);
+	const buildStep = workflow.match(/^\s+- name: Build the backend package\s+([\s\S]*?)(?=^\s+- name: )/m);
+	if (!jobTimeout || !buildStep) throw new Error("workflow is missing the build job or backend build step");
+	const stepTimeout = buildStep[1].match(/^\s+timeout-minutes:\s+\$\{\{\s*matrix\.target\s*==\s*'windows-amd64'\s*&&\s*(\d+)\s*\|\|\s*(\d+)\s*\}\}\s*$/m);
+	if (!stepTimeout) throw new Error("Windows backend build must have a target-specific step timeout");
+	const jobMinutes = Number(jobTimeout[1]);
+	const windowsMinutes = Number(stepTimeout[1]);
+	const unixMinutes = Number(stepTimeout[2]);
+	if (windowsMinutes < 45 || windowsMinutes > 60) throw new Error("Windows backend build timeout must be between 45 and 60 minutes");
+	if (windowsMinutes >= jobMinutes) throw new Error("Windows backend build timeout must be below the build job timeout");
+	if (unixMinutes !== jobMinutes) throw new Error("Darwin/Linux backend build timeout must remain equal to the job timeout");
+	return { jobMinutes, windowsMinutes, unixMinutes };
+}
+
+test("the Windows backend build has a bounded target-specific step timeout", async () => {
+	const workflow = await readFile(".github/workflows/localai-backend-artifacts.yml", "utf8");
+	assert.deepEqual(windowsBuildTimeout(workflow), { jobMinutes: 90, windowsMinutes: 60, unixMinutes: 90 });
+	assert.throws(
+		() => windowsBuildTimeout(workflow.replace("&& 60 || 90", "&& 44 || 90")),
+		/Windows backend build timeout must be between 45 and 60 minutes/,
+	);
+	assert.throws(
+		() => windowsBuildTimeout(workflow.replace("timeout-minutes: 90", "timeout-minutes: 60")),
+		/Windows backend build timeout must be below the build job timeout/,
+	);
+	assert.throws(
+		() => windowsBuildTimeout(workflow.replace("timeout-minutes: ${{ matrix.target == 'windows-amd64' && 60 || 90 }}", "timeout-minutes: 60")),
+		/Windows backend build must have a target-specific step timeout/,
+	);
+});
+
 test("manifest verification rejects bytes tampered after manifest creation", async (t) => {
 	const root = await matrixArtifactFixture(t);
 	const manifest = createManifest({ config, artifactDirectory: root, repository: "portpowered/infinite-you" });

--- a/scripts/localai-backend-artifact-workflow.test.mjs
+++ b/scripts/localai-backend-artifact-workflow.test.mjs
@@ -354,34 +354,38 @@ test("the Windows build plan resolves Git from the runner path bridge", async (t
 });
 
 function windowsBuildTimeout(workflow) {
-	const jobTimeout = workflow.match(/^\s+timeout-minutes:\s+(\d+)\s*$/m);
-	const buildStep = workflow.match(/^\s+- name: Build the backend package\s+([\s\S]*?)(?=^\s+- name: )/m);
-	if (!jobTimeout || !buildStep) throw new Error("workflow is missing the build job or backend build step");
-	const stepTimeout = buildStep[1].match(/^\s+timeout-minutes:\s+\$\{\{\s*matrix\.target\s*==\s*'windows-amd64'\s*&&\s*(\d+)\s*\|\|\s*(\d+)\s*\}\}\s*$/m);
-	if (!stepTimeout) throw new Error("Windows backend build must have a target-specific step timeout");
+	const jobTimeout = workflow.match(/^    timeout-minutes:\s+(\d+)\s*$/m);
+	const windowsBuild = workflow.match(/^\s+- name: Build the backend package on Windows\s+([\s\S]*?)(?=^\s+- name: Build the backend package on Unix)/m);
+	const unixBuild = workflow.match(/^\s+- name: Build the backend package on Unix\s+([\s\S]*?)(?=^\s+- name: Archive the Unix backend package)/m);
+	if (!jobTimeout || !windowsBuild || !unixBuild) throw new Error("workflow is missing the build job or platform-specific backend build steps");
+	const stepTimeout = windowsBuild[1].match(/^\s+timeout-minutes:\s+(\d+)\s*$/m);
+	if (!stepTimeout) throw new Error("Windows backend build must have an explicit step timeout");
 	const jobMinutes = Number(jobTimeout[1]);
 	const windowsMinutes = Number(stepTimeout[1]);
-	const unixMinutes = Number(stepTimeout[2]);
 	if (windowsMinutes < 45 || windowsMinutes > 60) throw new Error("Windows backend build timeout must be between 45 and 60 minutes");
 	if (windowsMinutes >= jobMinutes) throw new Error("Windows backend build timeout must be below the build job timeout");
-	if (unixMinutes !== jobMinutes) throw new Error("Darwin/Linux backend build timeout must remain equal to the job timeout");
-	return { jobMinutes, windowsMinutes, unixMinutes };
+	if (/^\s+timeout-minutes:/m.test(unixBuild[1])) throw new Error("Darwin/Linux backend build must retain the job timeout");
+	return { jobMinutes, windowsMinutes };
 }
 
-test("the Windows backend build has a bounded target-specific step timeout", async () => {
+test("the Windows backend build has a bounded platform-specific step timeout", async () => {
 	const workflow = await readFile(".github/workflows/localai-backend-artifacts.yml", "utf8");
-	assert.deepEqual(windowsBuildTimeout(workflow), { jobMinutes: 90, windowsMinutes: 60, unixMinutes: 90 });
+	assert.deepEqual(windowsBuildTimeout(workflow), { jobMinutes: 360, windowsMinutes: 60 });
 	assert.throws(
-		() => windowsBuildTimeout(workflow.replace("&& 60 || 90", "&& 44 || 90")),
+		() => windowsBuildTimeout(workflow.replace("timeout-minutes: 60", "timeout-minutes: 44")),
 		/Windows backend build timeout must be between 45 and 60 minutes/,
 	);
 	assert.throws(
-		() => windowsBuildTimeout(workflow.replace("timeout-minutes: 90", "timeout-minutes: 60")),
+		() => windowsBuildTimeout(workflow.replace("timeout-minutes: 60", "timeout-minutes: 61")),
+		/Windows backend build timeout must be between 45 and 60 minutes/,
+	);
+	assert.throws(
+		() => windowsBuildTimeout(workflow.replace("timeout-minutes: 360", "timeout-minutes: 60")),
 		/Windows backend build timeout must be below the build job timeout/,
 	);
 	assert.throws(
-		() => windowsBuildTimeout(workflow.replace("timeout-minutes: ${{ matrix.target == 'windows-amd64' && 60 || 90 }}", "timeout-minutes: 60")),
-		/Windows backend build must have a target-specific step timeout/,
+		() => windowsBuildTimeout(workflow.replace("        timeout-minutes: 60\n", "")),
+		/Windows backend build must have an explicit step timeout/,
 	);
 });
 


### PR DESCRIPTION
{
  "project": "Bound and Diagnose LocalAI Windows Backend Builds",
  "branchName": "localai-windows-backend-build-hang",
  "description": "Investigate the repeatedly wedged Windows backend package builds in the pinned LocalAI artifact workflow, add a 45-to-60-minute Windows step timeout below the 90-minute job limit, directly fix any evidence-supported Windows-only blocking cause, and prove on real windows-2022 jobs that all three Windows legs complete or fail visibly without changing Darwin/Linux behavior or PR #2132.",
  "context": {
    "customerAsk": "Own only .github/workflows/localai-backend-artifacts.yml's Windows build-step timeout and reliability and Windows-specific behavior in its invoked script. Investigate interactive or cancellation-resistant processes, GitHub timeout behavior, and vcpkg/MSYS2 cache or lock poisoning; ship an explicit Windows step timeout shorter than 90 minutes; fix a confirmed cause if found; and state the result plainly in the PR without touching Darwin/Linux or the separate completed PR #2132.",
    "problem": "Runs 32696933626 and 32709670989 independently wedged all three windows-amd64 backend jobs on the backend package build step while all six Darwin/Linux legs succeeded. The second run stayed in progress for 166 minutes despite timeout-minutes: 90 at the job level, both runs required operator cancellation, and repeated review polling exhausted the blocked lane's process visits. The Windows command chain includes external Make/CMake/Go and dependency inspection operations but has no shorter step-level termination boundary.",
    "solution": "Trace the real Windows command and child-process chain, record evidence for or against prompting, cancellation, unbounded waits, and persistent cache or locks, then enforce a GitHub Actions step timeout of 45 through 60 minutes on every Windows backend package build. Correct only a confirmed Windows-owned cause, preserve failure propagation so timed-out legs cannot archive or publish, and dispatch the delivered workflow against real pinned inputs on windows-2022 to prove completion or bounded visible failure."
  },
  "diagnosis": {
    "processAndPrompts": "The delivered Windows build enters the pinned MSYS2 shell with `set -euo pipefail` and invokes foreground Make/CMake/Go commands. The workflow uses `bootstrap-vcpkg.bat -disableMetrics`; no read, background process, or interactive prompt handling appears in the Windows build path. Existing hosted evidence shows the build step remained active until operator cancellation, but does not identify a child-process-specific cancellation defect.",
    "githubTimeout": "The confirmed reliability gap is the missing step-level boundary on the backend package build. After the independent PR #2132 schema repair merged, the delivered workflow was reconciled onto the repaired Windows/Unix split and now applies an explicit 60-minute step timeout to every windows-amd64 backend build. The 60-minute bound remains below the requested 90-minute threshold and the current 360-minute build-job ceiling, which now includes the long first-run dependency installation introduced by PR #2132; Unix build-step behavior remains unchanged by this lane. The repository declares only `workflow_dispatch`, and a search of `.github` and `scripts` found no repository-side caller for this workflow.",
    "cacheAndLocks": "The workflow disables MSYS2 updates, checks out an immutable vcpkg commit, does not use an Actions dependency cache, and the build script removes its per-checkout generated gRPC/build/install directories before rebuilding. No persistent cache or lock reuse cause was confirmed; no speculative cache or dependency redesign was shipped.",
    "priorHostedEvidence": "Run 32709670989 (head fb9d54a75a170ae8ee533f5015fb717189038eb5) completed Windows setup and vcpkg installation for all three Windows legs, then the backend build steps ran until operator cancellation at 2026-08-24T11:53:18Z. Build intervals were 47m11s (llamacpp), 18m51s (whisper), and 17m58s (vibevoice); archive and upload steps were skipped for all three. This is supporting diagnosis only, not proof of the delivered exact head.",
    "exactHeadDispatch": "PR #2132 merged at `501c5fe658adfe4ace94c0e9cf605897fa866320`; this lane reconciled onto that base, preserved the Windows-only 60-minute step timeout, and pushed head `69ab3882d92ae6f7299515bf90e9d82a510b192d`. The exact delivered workflow dispatch was accepted at `2026-08-24T18:47:23Z` as run [32764393466](https://github.com/portpowered/you-agent-factory/actions/runs/32764393466). Validation succeeded at `18:47:40Z`, and all nine matrix build jobs—including the three windows-amd64 legs—started at `18:47:42Z`-`18:47:43Z`. All six Darwin/Linux legs completed and uploaded artifacts. Each Windows build reached its real pinned build command, then failed visibly at the 60-minute step boundary without operator cancellation: whisper `21:17:31Z`-`22:17:38Z`, vibevoice `21:31:01Z`-`22:31:09Z`, and llamacpp `21:33:19Z`-`22:33:26Z`. Windows archive/upload were skipped for all three legs, no Windows artifacts were published, and the join/publication jobs were skipped. Story 002 is now complete."
  },
  "latestExactHeadObservation": "Run `32764393466` completed with failure at `2026-08-24T22:33:38Z` on head `69ab3882d92ae6f7299515bf90e9d82a510b192d`. All three Windows backend build steps emitted `The action 'Build the backend package on Windows' has timed out after 60 minutes.`; their archive/upload steps and the join/publication jobs were skipped. All six Darwin/Linux legs completed and uploaded non-empty artifacts. No operator cancellation was used.",
  "acceptanceCriteria": [
    "The PR body reports the result of all three investigation areas: Windows command/process cancellation and prompting, GitHub job/step timeout behavior, and vcpkg/MSYS2/cache or lock reuse. It names the supported root cause and evidence, or states that none was confirmed and that only the timeout backstop is being shipped.",
    "Every windows-amd64 backend package build is governed by an explicit step-level timeout-minutes value from 45 through 60, strictly below the build job's 90-minute limit; expiration produces a visible failed/cancelled terminal step and prevents later archive/publication behavior for that leg.",
    "Any confirmed blocking cause is corrected on the Windows-only path with explicit isolated process, network, cache, or lock behavior and focused regression evidence; if none is confirmed, no speculative cache, dependency, or cross-platform rewrite is introduced.",
    "The Darwin/Linux build commands, conditions, timeout behavior, artifacts, and matrix-validation semantics are unchanged, and no commit touches or supersedes the implementation in PR #2132.",
    "Runtime-proof classification: applicable, because this lane changes the observable GitHub Actions runtime lifecycle of the Windows CLI/build process. Build and dispatch the real delivered workflow revision, exercise the three Windows backend builds end to end on windows-2022 against the real pinned LocalAI, vcpkg, MSYS2, and toolchain inputs, and record the verbatim commands and output plus run URL, head SHA, step start/end state, duration, and artifact or bounded-failure result in a PR comment. Green tests, an inspected diff, or implementer testimony alone do not satisfy this proof.",
    "Quality gate: focused workflow/schema and Windows build reliability tests, typecheck, and applicable test suites pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. This is not a blanket make lint requirement because pkg-boundary retains the pre-existing packaged-service-structure migration debt recorded 2026-08-08.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The worker/reviewer cycle continues through the review-owned outcomes until required CI is terminal and passing, conflicts are resolved, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "localai-windows-backend-build-hang-001",
      "title": "Bound Windows backend package execution",
      "description": "As a release operator, I want each Windows backend package build to terminate within a dedicated step budget so that a silent child-process wedge cannot hold the workflow for hours.",
      "acceptanceCriteria": [
        "The Windows backend package build has an explicit step-level timeout from 45 through 60 minutes and strictly below the job's 90-minute timeout.",
        "The timeout applies to each of the three windows-amd64 backend builds; when it expires, the affected step and job become visibly terminal and that leg cannot archive, upload, join, or publish a purported successful result.",
        "Inspection covers the actual Windows child-command chain, interactive flags/prompts, cancellation propagation, network waits, vcpkg/MSYS2 caches, and lock reuse. Any evidence-supported cause is fixed only on the Windows path; if evidence is inconclusive, the implementation adds no speculative cross-platform or cache redesign.",
        "Focused validation rejects a missing Windows step timeout, a value outside 45-to-60 minutes, or a value not strictly below the job timeout, while schema-aware validation accepts the delivered workflow.",
        "Existing Darwin/Linux command and artifact behavior remains unchanged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "After rebasing onto current origin/main at 584f10528, the repaired workflow keeps separate Windows and Unix build steps and this lane adds an explicit 60-minute timeout only to the Windows step. Focused validation rejects a missing timeout, values outside 45-60 minutes, and values not strictly below the configured 360-minute build job; `node --test scripts/localai-backend-artifact-workflow.test.mjs` passes 9 tests with one environment skip (10 total). The schema-invalid shared shell expression is gone through the merged independent fix; this lane did not modify or supersede that implementation. `make typecheck` and a complete `make test` pass, and the hosted run 32764393466 proved all three Windows legs terminate at the configured boundary while Darwin/Linux behavior remains successful. Final rebased head `59af69b354e1858e94b421f85502da5fbf6c4894` is pushed for review."
    },
    {
      "id": "localai-windows-backend-build-hang-002",
      "title": "Prove hosted Windows termination and record the diagnosis",
      "description": "As a maintainer reviewing the reliability fix, I want evidence from the delivered hosted workflow so that I can distinguish a working Windows build or bounded failure from another indefinite wedge.",
      "acceptanceCriteria": [
        "The PR body separately states the finding for process/prompt behavior, GitHub timeout behavior, and cache/lock reuse, including the evidence for a confirmed cause or the statement that no cause could be confirmed.",
        "A dispatch of the delivered revision runs the real pinned Windows build path on windows-2022; all three Windows legs either complete and upload their verified artifacts or terminate visibly within the configured step limit, with no operator cancellation needed to enforce that limit.",
        "A successful Windows leg still produces a non-empty amd64 PE executable, required runtime closure, metadata, and archive under the existing contract; a failed or timed-out leg blocks join and publication rather than appearing successful.",
        "Runtime-proof classification: applicable, because this lane changes the observable GitHub Actions runtime lifecycle of the Windows CLI/build process. Build and dispatch the real delivered workflow revision, exercise the three Windows backend builds end to end on windows-2022 against the real pinned LocalAI, vcpkg, MSYS2, and toolchain inputs, and record the verbatim commands and output plus run URL, head SHA, step start/end state, duration, and artifact or bounded-failure result in a PR comment. Green tests, an inspected diff, or implementer testimony alone do not satisfy this proof.",
        "Runtime and CI-run evidence is placed in a PR comment and never committed; implementation stops at its delivery finish line without polling or re-checking CI afterward.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Static diagnosis remains: no interactive prompt, background-process, persistent cache, or lock-reuse cause was confirmed; the missing Windows step-level boundary was the supported reliability gap, so no speculative dependency/cache rewrite was made. Exact-head run [32764393466](https://github.com/portpowered/you-agent-factory/actions/runs/32764393466) on `69ab3882d92ae6f7299515bf90e9d82a510b192d` ran the real pinned `windows-2022` matrix. The Windows commands logged `set -euo pipefail`, `bash scripts/build-localai-backend-artifact.sh`, the MSYS2 shell, and `LOCALAI_BACKEND_SOURCE_OK`, then each build step ended with GitHub's exact `timed out after 60 minutes` error: whisper `21:17:31Z`-`22:17:38Z`, vibevoice `21:31:01Z`-`22:31:09Z`, llamacpp `21:33:19Z`-`22:33:26Z`. No operator cancellation was needed; all Windows archive/upload steps and join/publication jobs were skipped, and the artifact list contains only the six successful Darwin/Linux artifacts. Post-rebase local `make test-unit-coverage` measured 80.5% against a 75.9% overall minimum with zero gate failures, and Git-Bash `make test-functional-coverage` measured 59.1% against a 33.1% minimum with zero gate failures; the default Windows `cmd.exe` invocation is incompatible with this POSIX recipe. Exact commands, log excerpts, job links, and outcomes are recorded in PR #2279 comments. Final rebased head `59af69b354e1858e94b421f85502da5fbf6c4894` is pushed, and required CI run 32933236319 has started."
    }
  ],
  "operatorOverride": "OPERATOR OVERRIDE 2026-08-25 (post loop-breaker restore). This task was force-failed by the factory's review-loop-breaker (12 review visits / 24 process<->review round trips with no merge) -- every individual session in the worker-session history shows COMPLETED, this was NOT a crash. The operator has moved this work item back to init and cleared its visit history, so you have a fresh visit budget.\n\nROOT CAUSE (verified by the operator): PR #2279's branch (head 69ab3882d) is 121 COMMITS BEHIND origin/main -- its merge-base is `501c5fe65` (#2132), a very old point on main. A prior progress.txt entry on this lane (2026-08-25) claimed the failing 'Backend Unit Coverage' / 'Backend Functional Coverage' checks were 'previously documented base-reproduced failures' owned by a deflake lane -- that conclusion was reached WITHOUT rebasing onto current main, so it cannot be trusted. The failing run (databaseId 32764393516, headSha 69ab3882d, run from 2026-08-24) shows ~18 unit-coverage packages failing with large deltas (e.g. pkg/platform/httpserver -20.7pp, pkg/services/factory_definitions/.../runtime_snapshot/internal -13.0pp, pkg/transports/cli/clihttp -12.5pp, pkg/platform/metrics -6.9pp, pkg/services/models/wire -6.9pp) spread across packages that have NOTHING to do with this PR's LocalAI-Windows-build topic -- the classic signature of measuring against a stale coverage-floor manifest. Current main has since merged several PRs specifically rebalancing model coverage baselines (see main history: PR #2293 'cov-floor-models' merge and its siblings 'test(models): rebalance coverage test files', 'test(models): align output-path coverage with current CLI routing', etc.) that this branch predates entirely.\n\nDO THIS FIRST, before touching any test or baseline file: (1) `git fetch origin main`. (2) Rebase this branch onto `origin/main` in this worktree -- resolve any conflict in favour of already-merged main content; if a GENERATED file conflicts (openapi, *.gen.go, catalogs, manifests), do not hand-merge it -- rerun its generator on the rebased tree and commit the regenerated output. (3) Re-run `make test-unit-coverage` and `make test-functional-coverage` and compare against the SAME package list above. Expect most or all of these deltas to disappear once measured against current main's already-corrected coverage-minimums manifest. (4) Only if a failure in this exact package list still reproduces after the rebase should you treat it as a real, lane-owned or baseline defect and investigate further -- do not assume 'main is red' again without checking a LATER main post-merge run first. (5) Push the rebased head and let review re-check.\n\nDELIVERY BOUNDARY: your criterion is satisfied once the rebased, re-measured head is pushed, CI has started, and blocking review feedback is addressed -- review owns the merge. Do not poll CI in a loop or commit CI-evidence updates; that creates a new head and invalidates the run you just recorded. Put CI evidence in a PR comment only."
}
