### PR TITLE
ci-coverage-report-terse-and-nonduplicated

### DIFF
--- a/cmd/gocoveragecheck/coverage_diagnostics.go
+++ b/cmd/gocoveragecheck/coverage_diagnostics.go
@@ -1,15 +1,56 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 func writeCoverageDiagnostics(result coverageResult) {
-	for _, warning := range result.packageMinimumWarnings {
+	for _, warning := range coverageDiagnosticsForOutput(result.detailedDiagnostics, result.packageMinimumWarnings) {
 		fmt.Fprintln(stderrWriter, warning)
 	}
-	for _, warning := range result.manifestCompletenessWarnings {
+	for _, warning := range coverageDiagnosticsForOutput(result.detailedDiagnostics, result.manifestCompletenessWarnings) {
 		fmt.Fprintln(stderrWriter, warning)
 	}
-	for _, diagnostic := range result.unmeasuredPackageDiagnostics {
+	for _, diagnostic := range coverageDiagnosticsForOutput(result.detailedDiagnostics, result.unmeasuredPackageDiagnostics) {
 		fmt.Fprintln(stderrWriter, diagnostic)
+	}
+}
+
+// coverageDiagnosticsForOutput keeps the evaluated finding intact while
+// making the default human-facing contract one line per finding. The optional
+// source-block detail is useful when investigating a regression, but it is
+// too noisy for ordinary stderr, JSON-backed reports, and verdict handoffs.
+func coverageDiagnosticsForOutput(detailed bool, groups ...[]string) []string {
+	count := 0
+	for _, group := range groups {
+		count += len(group)
+	}
+	diagnostics := make([]string, 0, count)
+	for _, group := range groups {
+		for _, diagnostic := range group {
+			if detailed {
+				diagnostics = append(diagnostics, diagnostic)
+				continue
+			}
+			diagnostics = append(diagnostics, compactCoverageDiagnostic(diagnostic))
+		}
+	}
+	return diagnostics
+}
+
+func compactCoverageDiagnostic(diagnostic string) string {
+	const uncoveredBlocksMarker = "; uncovered blocks:"
+	for {
+		markerIndex := strings.Index(diagnostic, uncoveredBlocksMarker)
+		if markerIndex < 0 {
+			return strings.TrimSpace(diagnostic)
+		}
+		tail := diagnostic[markerIndex+len(uncoveredBlocksMarker):]
+		if nextField := strings.Index(tail, "; "); nextField >= 0 {
+			diagnostic = diagnostic[:markerIndex] + tail[nextField:]
+			continue
+		}
+		return strings.TrimSpace(diagnostic[:markerIndex])
 	}
 }

--- a/cmd/gocoveragecheck/coverage_json.go
+++ b/cmd/gocoveragecheck/coverage_json.go
@@ -56,26 +56,10 @@ func buildCoverageSummaryJSON(result coverageResult) coverageSummaryJSON {
 		MeasurableStatements: measurable,
 		CoveragePercent:      roundCoveragePercent(result.actual),
 		PackageFloorPolicy:   policy,
-		PackageFloorFindings: appendCoverageDiagnostics(result.packageMinimumWarnings, result.packageMinimumFailures),
-		ManifestDiagnostics:  appendCoverageDiagnostics(result.manifestCompletenessWarnings, result.unmeasuredPackageDiagnostics),
+		PackageFloorFindings: coverageDiagnosticsForOutput(result.detailedDiagnostics, result.packageMinimumWarnings, result.packageMinimumFailures),
+		ManifestDiagnostics:  coverageDiagnosticsForOutput(result.detailedDiagnostics, result.manifestCompletenessWarnings, result.unmeasuredPackageDiagnostics),
 		Packages:             buildPackageCoverageJSON(result),
 	}
-}
-
-func appendCoverageDiagnostics(groups ...[]string) []string {
-	count := 0
-	for _, group := range groups {
-		count += len(group)
-	}
-	if count == 0 {
-		return nil
-	}
-
-	diagnostics := make([]string, 0, count)
-	for _, group := range groups {
-		diagnostics = append(diagnostics, group...)
-	}
-	return diagnostics
 }
 
 func buildPackageCoverageJSON(result coverageResult) []packageCoverageJSON {

--- a/cmd/gocoveragecheck/coverage_json_test.go
+++ b/cmd/gocoveragecheck/coverage_json_test.go
@@ -525,6 +525,20 @@ func TestExecuteWritesIncompleteJSONWhenMeasurementFailsWithProfile(t *testing.T
 	if len(summary.Packages) == 0 {
 		t.Fatalf("incomplete coverage summary packages = %+v, want retained partial package totals", summary.Packages)
 	}
+	if len(summary.Packages) != 2 {
+		t.Fatalf("incomplete coverage summary packages = %d, want both measured packages", len(summary.Packages))
+	}
+	for _, entry := range summary.Packages {
+		if entry.PackageFloor != nil {
+			t.Fatalf("partial package %s has floor %v, want n/a until manifest evaluation", entry.Package, *entry.PackageFloor)
+		}
+	}
+	if summary.Packages[0].Package != modulePath+"/pkg/config" || summary.Packages[0].CoveragePercent != 100.0 {
+		t.Fatalf("partial config package = %+v, want measured 100.0%%", summary.Packages[0])
+	}
+	if summary.Packages[1].Package != modulePath+"/pkg/service" || summary.Packages[1].CoveragePercent != 100.0 {
+		t.Fatalf("partial service package = %+v, want measured 100.0%%", summary.Packages[1])
+	}
 	if !strings.Contains(summary.MeasurementReason, "did not complete") {
 		t.Fatalf("measurement reason = %q, want incomplete-measurement explanation", summary.MeasurementReason)
 	}

--- a/cmd/gocoveragecheck/coverage_json_test.go
+++ b/cmd/gocoveragecheck/coverage_json_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -110,6 +111,45 @@ func TestCoverageSummaryRetainsFloorPolicyAndDiagnostics(t *testing.T) {
 	}
 }
 
+func TestDetailedDiagnosticsOnlyChangesJSONFindingPresentation(t *testing.T) {
+	floor := 80.0
+	detailedFinding := "package coverage regression: package=pkg/example lane=unit expected-minimum=80.00% actual=40.0000% delta=-40.0000 percentage-points covered=2/5 statements; uncovered blocks: pkg/example/file.go:41 (2 statements); restore coverage"
+	result := coverageResult{
+		actual:                 40,
+		packageFloorPolicy:     coverageFloorPolicyBlocking,
+		packageMinimumFailures: []string{detailedFinding},
+		packageSummaries:       []packageCoverageSummary{{importPath: "pkg/example", coverage: 40}},
+		packageTotals: map[string]packageCoverageTotals{
+			"pkg/example": {coveredStatements: 2, totalStatements: 5},
+		},
+		packageGates: map[string]packageCoverageGate{
+			"pkg/example": {Floor: &floor},
+		},
+	}
+
+	compact := buildCoverageSummaryJSON(result)
+	detailedResult := result
+	detailedResult.detailedDiagnostics = true
+	detailed := buildCoverageSummaryJSON(detailedResult)
+
+	wantCompactFinding := "package coverage regression: package=pkg/example lane=unit expected-minimum=80.00% actual=40.0000% delta=-40.0000 percentage-points covered=2/5 statements; restore coverage"
+	if compact.PackageFloorFindings[0] != wantCompactFinding {
+		t.Fatalf("default package finding = %q, want compact finding %q", compact.PackageFloorFindings[0], wantCompactFinding)
+	}
+	if detailed.PackageFloorFindings[0] != detailedFinding {
+		t.Fatalf("detailed package finding = %q, want full finding %q", detailed.PackageFloorFindings[0], detailedFinding)
+	}
+	if !reflect.DeepEqual(compact.Packages, detailed.Packages) {
+		t.Fatalf("package measurement changed with detailed diagnostics: compact=%+v detailed=%+v", compact.Packages, detailed.Packages)
+	}
+	if compact.CoveredStatements != detailed.CoveredStatements ||
+		compact.MeasurableStatements != detailed.MeasurableStatements ||
+		compact.CoveragePercent != detailed.CoveragePercent ||
+		compact.PackageFloorPolicy != detailed.PackageFloorPolicy {
+		t.Fatalf("coverage summary changed with detailed diagnostics: compact=%+v detailed=%+v", compact, detailed)
+	}
+}
+
 func TestExecuteOmitsJSONFileWhenJSONOutputOptionAbsent(t *testing.T) {
 	originalCommandRunner := commandRunner
 	originalStdout := stdoutWriter
@@ -146,10 +186,10 @@ func TestExecuteOmitsJSONFileWhenJSONOutputOptionAbsent(t *testing.T) {
 	if !strings.Contains(got, "total: (statements) 100.0%") {
 		t.Fatalf("execute() stdout = %q, want total coverage line", got)
 	}
-	if !strings.Contains(got, modulePath+"/pkg/config\tcoverage: 100.0% of statements") {
+	if !strings.Contains(got, "package="+modulePath+"/pkg/config coverage=100.0% floor=80.0% delta=+20.0pp status=PASS lane=unit") {
 		t.Fatalf("execute() stdout = %q, want package summary for pkg/config", got)
 	}
-	if !strings.Contains(got, modulePath+"/pkg/service\tcoverage: 100.0% of statements") {
+	if !strings.Contains(got, "package="+modulePath+"/pkg/service coverage=100.0% floor=80.0% delta=+20.0pp status=PASS lane=unit") {
 		t.Fatalf("execute() stdout = %q, want package summary for pkg/service", got)
 	}
 	wantSuccess := "Go coverage 100.0% meets minimum 80.0%."
@@ -656,10 +696,10 @@ func TestExecuteFloorFailureWithoutJSONOptionKeepsHumanDiagnostics(t *testing.T)
 	if !strings.Contains(got, "total: (statements) 100.0%") {
 		t.Fatalf("execute() stdout = %q, want total coverage line", got)
 	}
-	if !strings.Contains(got, modulePath+"/pkg/config\tcoverage: 100.0% of statements") {
+	if !strings.Contains(got, "package="+modulePath+"/pkg/config coverage=100.0% floor=80.0% delta=+20.0pp status=PASS lane=unit") {
 		t.Fatalf("execute() stdout = %q, want package summary for pkg/config", got)
 	}
-	if !strings.Contains(got, modulePath+"/pkg/service\tcoverage: 100.0% of statements") {
+	if !strings.Contains(got, "package="+modulePath+"/pkg/service coverage=100.0% floor=80.0% delta=+20.0pp status=PASS lane=unit") {
 		t.Fatalf("execute() stdout = %q, want package summary for pkg/service", got)
 	}
 	if strings.Contains(got, "meets minimum") {

--- a/cmd/gocoveragecheck/coverage_verdict.go
+++ b/cmd/gocoveragecheck/coverage_verdict.go
@@ -26,30 +26,16 @@ type packageCoverageVerdict struct {
 	floor           float64
 	actual          float64
 	headroom        float64
-	covered         int
 	measurable      int
-	uncoveredBlocks int
 }
 
 // writeCoverageLaneReport prints a lane's per-package coverage result.
 //
-// A reporting lane replaces the raw "coverage: N% of statements" line per
-// measured package — 300+ consecutive lines that bury the one actionable
-// verdict — with a compact ordered block: the existing floor diagnostics, one
-// complete package line per measured package, then a single tally line.
-//
-// Collapsing the listing is only safe when the complete per-package measurement
-// survives somewhere a reader can still reach. Two lanes qualify: the
-// functional lane, whose CI job always publishes the coverage-summary artifact,
-// and any lane invoked with -json-output, which is that artifact. An invocation
-// without one — an ordinary local `make test-unit-coverage`, or the
-// malformed-manifest abort path that returns before the JSON is written — has
-// the raw listing as the only copy of the measurement, so it keeps it.
+// The compact row is the default for both coverage lanes. The complete
+// measurement remains in the JSON artifact when one is requested, while the
+// row itself keeps the package, coverage, floor state, and outcome visible to a
+// reader of an ordinary command log.
 func writeCoverageLaneReport(cfg config, result coverageResult, failures []string) {
-	if cfg.suite != functionalCoverageSuite && strings.TrimSpace(cfg.jsonOutput) == "" {
-		writePackageCoverageSummaries(result.packageSummaries)
-		return
-	}
 	writeCoverageVerdict(coverageLaneLabel(cfg.suite), result, failures)
 }
 
@@ -74,9 +60,9 @@ func coverageLaneNoun(suite string) string {
 	return strings.ToLower(coverageLaneLabel(suite))
 }
 
-// writePackageCoverageSummaries prints one raw coverage line per measured
-// package. It remains the report for every non-functional lane and for the
-// malformed-manifest abort path, which never reaches the JSON summary.
+// writePackageCoverageSummaries is retained for callers that explicitly need
+// the legacy raw go-test listing while diagnosing a producer outside the
+// normal lane report.
 func writePackageCoverageSummaries(summaries []packageCoverageSummary) {
 	for _, summary := range summaries {
 		fmt.Fprintf(stdoutWriter, "%s\tcoverage: %.1f%% of statements\n", summary.importPath, summary.coverage)
@@ -86,14 +72,12 @@ func writePackageCoverageSummaries(summaries []packageCoverageSummary) {
 // writeCoverageVerdict renders one lane's ordered verdict block.
 func writeCoverageVerdict(label string, result coverageResult, failures []string) {
 	verdicts := collectPackageCoverageVerdicts(result)
-	belowFloor, heldFloor, nearFloor := partitionPackageCoverageVerdicts(verdicts)
+	belowFloor, _, nearFloor := partitionPackageCoverageVerdicts(verdicts)
 	slices.SortStableFunc(verdicts, comparePackageCoverageVerdicts)
 
 	fmt.Fprintf(stdoutWriter, "%s package coverage verdict:\n", label)
-	writeBelowFloorCoverageLines(belowFloor)
-	writeHeldCoverageLines(heldFloor)
 	for _, verdict := range verdicts {
-		writePackageCoverageVerdictLine(verdict, coverageLaneNoun(label))
+		writePackageCoverageVerdictLine(verdict, coverageLaneNoun(label), result)
 	}
 	fmt.Fprintf(
 		stdoutWriter,
@@ -106,47 +90,11 @@ func writeCoverageVerdict(label string, result coverageResult, failures []string
 	)
 }
 
-func writeBelowFloorCoverageLines(belowFloor []packageCoverageVerdict) {
-	if len(belowFloor) == 0 {
-		fmt.Fprintln(stdoutWriter, "  floor violations: none")
-		return
-	}
-	for _, verdict := range belowFloor {
-		fmt.Fprintf(
-			stdoutWriter,
-			"  floor violation: package=%s floor=%.4f%% actual=%.4f%% delta=%+.4f percentage-points covered=%d/%d statements uncovered-blocks=%d\n",
-			verdict.importPath,
-			verdict.floor,
-			verdict.actual,
-			verdict.headroom,
-			verdict.covered,
-			verdict.measurable,
-			verdict.uncoveredBlocks,
-		)
-	}
-}
-
-func writeHeldCoverageLines(heldFloor []packageCoverageVerdict) {
-	for _, verdict := range heldFloor {
-		fmt.Fprintf(
-			stdoutWriter,
-			"  floor hold: package=%s floor=%.4f%% actual=%.4f%% delta=%+.4f percentage-points covered=%d/%d statements uncovered-blocks=%d\n",
-			verdict.importPath,
-			verdict.floor,
-			verdict.actual,
-			verdict.headroom,
-			verdict.covered,
-			verdict.measurable,
-			verdict.uncoveredBlocks,
-		)
-	}
-}
-
-func writePackageCoverageVerdictLine(verdict packageCoverageVerdict, lane string) {
+func writePackageCoverageVerdictLine(verdict packageCoverageVerdict, lane string, result coverageResult) {
 	if !verdict.hasFloor {
 		fmt.Fprintf(
 			stdoutWriter,
-			"  package=%s coverage=%.1f%% floor=none delta=n/a gate=report-only lane=%s\n",
+			"  package=%s coverage=%.1f%% floor=n/a status=report-only lane=%s\n",
 			verdict.importPath,
 			verdict.actual,
 			lane,
@@ -154,40 +102,69 @@ func writePackageCoverageVerdictLine(verdict packageCoverageVerdict, lane string
 		return
 	}
 
-	gate := "pass"
-	if verdict.measurable > 0 && verdict.headroom < 0 {
-		gate = "fail"
-		if verdict.held {
-			gate = "hold"
+	status := "PASS"
+	if verdict.held {
+		status = "HOLD"
+	} else {
+		if verdict.measurable > 0 && verdict.headroom < 0 {
+			status = "FAIL"
+			if result.packageFloorPolicy == coverageFloorPolicyAdvisory {
+				status = "WARN"
+			}
+		}
+		if packageCoverageFinding(result.packageMinimumFailures, verdict.importPath) {
+			status = "FAIL"
+		} else if packageCoverageFinding(result.packageMinimumWarnings, verdict.importPath) {
+			status = "WARN"
+		} else if packageCoverageSummaryFinding(result.insufficientCoveragePackages, verdict.importPath) {
+			status = "FAIL"
+			if result.packageFloorPolicy == coverageFloorPolicyAdvisory {
+				status = "WARN"
+			}
 		}
 	}
 	fmt.Fprintf(
 		stdoutWriter,
-		"  package=%s coverage=%.1f%% floor=%.1f%% delta=%+.1fpp gate=%s lane=%s\n",
+		"  package=%s coverage=%.1f%% floor=%.1f%% delta=%+.1fpp status=%s lane=%s\n",
 		verdict.importPath,
 		verdict.actual,
 		verdict.floor,
 		verdict.headroom,
-		gate,
+		status,
 		lane,
 	)
+}
+
+func packageCoverageFinding(diagnostics []string, importPath string) bool {
+	for _, diagnostic := range diagnostics {
+		if strings.Contains(diagnostic, "package="+importPath+" ") {
+			return true
+		}
+	}
+	return false
+}
+
+func packageCoverageSummaryFinding(summaries []packageCoverageSummary, importPath string) bool {
+	for _, summary := range summaries {
+		if summary.importPath == importPath {
+			return true
+		}
+	}
+	return false
 }
 
 // collectPackageCoverageVerdicts reports one verdict per measured package.
 // Numeric floors produce gate headroom; packages with no floor, including
 // measurement exceptions, remain visible as report-only rows.
 func collectPackageCoverageVerdicts(result coverageResult) []packageCoverageVerdict {
-	uncovered := uncoveredCoverageBlockCounts(result.coverageBlocks)
 	verdicts := make([]packageCoverageVerdict, 0, len(result.packageSummaries))
 	for _, summary := range result.packageSummaries {
 		gate := result.packageGates[summary.importPath]
 		totals := result.packageTotals[summary.importPath]
 		verdict := packageCoverageVerdict{
-			importPath:      summary.importPath,
-			actual:          summary.coverage,
-			covered:         totals.coveredStatements,
-			measurable:      totals.totalStatements,
-			uncoveredBlocks: uncovered[summary.importPath],
+			importPath: summary.importPath,
+			actual:     summary.coverage,
+			measurable: totals.totalStatements,
 		}
 		if gate.Floor != nil {
 			verdict.hasFloor = true
@@ -268,18 +245,4 @@ func countGatedPackageCoverageVerdicts(verdicts []packageCoverageVerdict) int {
 		}
 	}
 	return count
-}
-
-// uncoveredCoverageBlockCounts counts zero-execution coverage blocks per
-// package in a single pass so the verdict block does not rescan every block
-// once per reported package.
-func uncoveredCoverageBlockCounts(blocks map[string]coverageBlock) map[string]int {
-	counts := make(map[string]int, len(blocks))
-	for _, block := range blocks {
-		if block.executionCount != 0 {
-			continue
-		}
-		counts[block.importPath]++
-	}
-	return counts
 }

--- a/cmd/gocoveragecheck/coverage_verdict.go
+++ b/cmd/gocoveragecheck/coverage_verdict.go
@@ -20,13 +20,13 @@ const nearFloorCoverageHeadroomPoints = 2.0
 // its distance to the package floor. Headroom is negative when a measurable
 // package is below its floor. A package without a numeric floor is report-only.
 type packageCoverageVerdict struct {
-	importPath      string
-	hasFloor        bool
-	held            bool
-	floor           float64
-	actual          float64
-	headroom        float64
-	measurable      int
+	importPath string
+	hasFloor   bool
+	held       bool
+	floor      float64
+	actual     float64
+	headroom   float64
+	measurable int
 }
 
 // writeCoverageLaneReport prints a lane's per-package coverage result.

--- a/cmd/gocoveragecheck/coverage_verdict_test.go
+++ b/cmd/gocoveragecheck/coverage_verdict_test.go
@@ -98,19 +98,18 @@ func TestFunctionalCoverageVerdictOrdersViolationsBeforeNearFloorAndTally(t *tes
 		t.Fatalf("execute() error = %v, want the pkg/config floor regression", err)
 	}
 
-	violation := strings.Index(stdout, "  floor violation: package="+modulePath+"/pkg/config ")
-	configLine := strings.Index(stdout, "  package="+modulePath+"/pkg/config coverage=25.0% floor=80.0% delta=-55.0pp gate=fail lane=functional\n")
-	serviceLine := strings.Index(stdout, "  package="+modulePath+"/pkg/service coverage=90.0% floor=89.0% delta=+1.0pp gate=pass lane=functional\n")
-	wireLine := strings.Index(stdout, "  package="+modulePath+"/pkg/wire coverage=100.0% floor=50.0% delta=+50.0pp gate=pass lane=functional\n")
+	configLine := strings.Index(stdout, "  package="+modulePath+"/pkg/config coverage=25.0% floor=80.0% delta=-55.0pp status=FAIL lane=functional\n")
+	serviceLine := strings.Index(stdout, "  package="+modulePath+"/pkg/service coverage=90.0% floor=89.0% delta=+1.0pp status=PASS lane=functional\n")
+	wireLine := strings.Index(stdout, "  package="+modulePath+"/pkg/wire coverage=100.0% floor=50.0% delta=+50.0pp status=PASS lane=functional\n")
 	tally := strings.Index(stdout, "  tally: ")
-	if violation < 0 || configLine < 0 || serviceLine < 0 || wireLine < 0 || tally < 0 {
-		t.Fatalf("verdict block missing sections (violation=%d config=%d service=%d wire=%d tally=%d):\n%s", violation, configLine, serviceLine, wireLine, tally, stdout)
+	if configLine < 0 || serviceLine < 0 || wireLine < 0 || tally < 0 {
+		t.Fatalf("verdict block missing sections (config=%d service=%d wire=%d tally=%d):\n%s", configLine, serviceLine, wireLine, tally, stdout)
 	}
-	if !(violation < configLine && configLine < serviceLine && serviceLine < wireLine && wireLine < tally) {
-		t.Fatalf("verdict block order = violation@%d config@%d service@%d wire@%d tally@%d, want headroom order and tally last:\n%s", violation, configLine, serviceLine, wireLine, tally, stdout)
+	if !(configLine < serviceLine && serviceLine < wireLine && wireLine < tally) {
+		t.Fatalf("verdict block order = config@%d service@%d wire@%d tally@%d, want headroom order and tally last:\n%s", configLine, serviceLine, wireLine, tally, stdout)
 	}
-	if !strings.Contains(stdout, "delta=-55.0000 percentage-points covered=1/4 statements uncovered-blocks=2") {
-		t.Fatalf("floor violation line missing floor/actual/delta/blocks detail:\n%s", stdout)
+	if strings.Contains(stdout, "uncovered blocks:") || strings.Contains(stdout, "file.go:") {
+		t.Fatalf("default verdict exposed uncovered source detail:\n%s", stdout)
 	}
 	if !strings.Contains(stdout, "  tally: measured-packages=3 gated-packages=3 below-floor=1 near-floor=1 gate-failures=1\n") {
 		t.Fatalf("verdict tally line missing or wrong:\n%s", stdout)
@@ -208,13 +207,10 @@ func TestFunctionalCoverageVerdictPassesWhenEveryPackageMeetsItsFloor(t *testing
 	if err != nil {
 		t.Fatalf("execute() error = %v, want a zero-exit outcome; stdout=%s", err, stdout)
 	}
-	if !strings.Contains(stdout, "  floor violations: none\n") {
-		t.Fatalf("verdict block missing the explicit no-violation line:\n%s", stdout)
-	}
 	for _, want := range []string{
-		"  package=" + modulePath + "/pkg/config coverage=25.0% floor=20.0% delta=+5.0pp gate=pass lane=functional\n",
-		"  package=" + modulePath + "/pkg/service coverage=90.0% floor=89.0% delta=+1.0pp gate=pass lane=functional\n",
-		"  package=" + modulePath + "/pkg/wire coverage=100.0% floor=50.0% delta=+50.0pp gate=pass lane=functional\n",
+		"  package=" + modulePath + "/pkg/config coverage=25.0% floor=20.0% delta=+5.0pp status=PASS lane=functional\n",
+		"  package=" + modulePath + "/pkg/service coverage=90.0% floor=89.0% delta=+1.0pp status=PASS lane=functional\n",
+		"  package=" + modulePath + "/pkg/wire coverage=100.0% floor=50.0% delta=+50.0pp status=PASS lane=functional\n",
 	} {
 		if strings.Count(stdout, want) != 1 {
 			t.Fatalf("verdict line count for %q = %d, want one:\n%s", want, strings.Count(stdout, want), stdout)
@@ -231,10 +227,7 @@ func TestFunctionalCoverageVerdictPassesWhenEveryPackageMeetsItsFloor(t *testing
 	}
 }
 
-// TestUnitCoverageRunKeepsRawPerPackageCoverageLines pins the invocation that
-// publishes no coverage-summary artifact. Its stdout listing is the only copy
-// of the per-package measurement, so it is never collapsed.
-func TestUnitCoverageRunKeepsRawPerPackageCoverageLines(t *testing.T) {
+func TestUnitCoverageRunUsesCompactVerdictWithoutJSONArtifact(t *testing.T) {
 	originalCommandRunner := commandRunner
 	originalStdout := stdoutWriter
 	originalStderr := stderrWriter
@@ -263,11 +256,14 @@ func TestUnitCoverageRunKeepsRawPerPackageCoverageLines(t *testing.T) {
 	}
 
 	got := stdout.String()
-	if !strings.Contains(got, configPackage+"\tcoverage: 100.0% of statements\n") {
-		t.Fatalf("unit lane lost its raw per-package coverage line:\n%s", got)
+	if !strings.Contains(got, "Unit package coverage verdict:\n") {
+		t.Fatalf("unit lane did not render its compact verdict:\n%s", got)
 	}
-	if strings.Contains(got, "package coverage verdict:") {
-		t.Fatalf("unit lane collapsed its only copy of the measurement into a verdict block:\n%s", got)
+	if !strings.Contains(got, "package="+configPackage+" coverage=100.0% floor=100.0% delta=+0.0pp status=PASS lane=unit") {
+		t.Fatalf("unit lane compact verdict omitted the measured package:\n%s", got)
+	}
+	if strings.Contains(got, "\tcoverage: ") {
+		t.Fatalf("unit lane still printed a raw per-package coverage line:\n%s", got)
 	}
 }
 
@@ -329,8 +325,8 @@ func TestCoverageVerdictReportsUngatedPackagesAfterGatedRows(t *testing.T) {
 	writeCoverageVerdict("Functional", result, nil)
 
 	got := stdout.String()
-	wantGated := "  package=" + gated + " coverage=25.0% floor=80.0% delta=-55.0pp gate=fail lane=functional\n"
-	wantUngated := "  package=" + ungated + " coverage=5.0% floor=none delta=n/a gate=report-only lane=functional\n"
+	wantGated := "  package=" + gated + " coverage=25.0% floor=80.0% delta=-55.0pp status=FAIL lane=functional\n"
+	wantUngated := "  package=" + ungated + " coverage=5.0% floor=n/a status=report-only lane=functional\n"
 	gatedIndex := strings.Index(got, wantGated)
 	ungatedIndex := strings.Index(got, wantUngated)
 	if gatedIndex < 0 || ungatedIndex < 0 || gatedIndex > ungatedIndex {

--- a/cmd/gocoveragecheck/coverage_verdict_test.go
+++ b/cmd/gocoveragecheck/coverage_verdict_test.go
@@ -144,10 +144,11 @@ func TestFunctionalCoverageVerdictNamesHeldFloorWithoutCallingItAnActiveViolatio
 	if strings.Contains(stderr, "advisory") || strings.Contains(stderr, "report-only") {
 		t.Fatalf("blocking staged run emitted advisory guidance: %s", stderr)
 	}
-	if !strings.Contains(stdout, "  floor violations: none\n") ||
-		!strings.Contains(stdout, "  floor hold: package="+configPackage) ||
-		!strings.Contains(stdout, "gate=hold lane=functional\n") {
+	if !strings.Contains(stdout, "  package="+configPackage+" coverage=25.0% floor=80.0% delta=-55.0pp status=HOLD lane=functional\n") {
 		t.Fatalf("verdict did not distinguish the held package from active violations:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "floor hold:") || strings.Contains(stdout, "uncovered-blocks=") {
+		t.Fatalf("held verdict exposed verbose floor diagnostics:\n%s", stdout)
 	}
 	if !strings.Contains(stdout, "below-floor=0 near-floor=1 gate-failures=0") {
 		t.Fatalf("verdict tally treated the held package as an active failure:\n%s", stdout)

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -105,6 +105,7 @@ type config struct {
 	packageMin                   float64
 	packageFloorEpsilon          float64
 	packageFloorPolicy           string
+	detailedDiagnostics          bool
 	packages                     string
 	profile                      string
 	short                        bool
@@ -128,6 +129,7 @@ type coverageResult struct {
 	manifestCompletenessWarnings []string
 	unmeasuredPackageDiagnostics []string
 	packageFloorPolicy           string
+	detailedDiagnostics          bool
 }
 
 type packageCoverageTotals struct {
@@ -169,17 +171,20 @@ func execute(cfg config) error {
 	}
 	result, err := run(cfg)
 	if err != nil {
+		result.packageFloorPolicy = cfg.packageFloorPolicyValue()
+		result.detailedDiagnostics = cfg.detailedDiagnostics
 		writeCoverageTestFailureWarning(err)
 		var validationErr *coverageManifestValidationError
 		if errors.As(err, &validationErr) {
 			// A malformed manifest aborts before the coverage-summary JSON is
-			// written, so this path keeps the complete per-package listing: it
-			// is the only surviving copy of the measurement.
+			// written, so keep the complete per-package listing: it is the
+			// only surviving copy of the measurement on this abort path.
 			writePackageCoverageSummaries(result.packageSummaries)
 		}
 		return err
 	}
 	result.packageFloorPolicy = cfg.packageFloorPolicyValue()
+	result.detailedDiagnostics = cfg.detailedDiagnostics
 
 	var failures []string
 	if result.actual < cfg.min {
@@ -211,7 +216,7 @@ func execute(cfg config) error {
 	cfg.finishCoveragePhase(coveragePhaseManifest, coveragePhaseStatusComplete)
 
 	if len(failures) > 0 {
-		return errors.New(strings.Join(failures, "\n"))
+		return errors.New(strings.Join(coverageDiagnosticsForOutput(cfg.detailedDiagnostics, failures), "\n"))
 	}
 	fmt.Fprintf(stdoutWriter, "Go coverage %.1f%% meets minimum %.1f%%.\n", result.actual, cfg.min)
 	return nil
@@ -240,6 +245,7 @@ func parseConfig() config {
 	flag.Float64Var(&cfg.packageMin, "package-min", defaultPackageCoverageMin, "minimum statement coverage required for each non-baselined backend package")
 	flag.Float64Var(&cfg.packageFloorEpsilon, "package-floor-epsilon", defaultPackageFloorEpsilon, "allowed manifest package-floor drift in percentage points; only applies with -package-manifest")
 	flag.StringVar(&cfg.packageFloorPolicy, "package-floor-policy", coverageFloorPolicyBlocking, "package-floor enforcement policy: blocking or advisory")
+	flag.BoolVar(&cfg.detailedDiagnostics, "detailed-diagnostics", false, "include uncovered source-block details in coverage diagnostics")
 	flag.StringVar(&cfg.packages, "packages", "", "space-separated go test package patterns; overrides -suite package discovery")
 	flag.StringVar(&cfg.profile, "profile", "", "coverage profile output path; defaults to a temp file")
 	flag.BoolVar(&cfg.short, "short", true, "run with go test -short")

--- a/cmd/gocoveragecheck/main_entrypoint_test.go
+++ b/cmd/gocoveragecheck/main_entrypoint_test.go
@@ -53,10 +53,10 @@ func TestMainFailsWhenCoverageBelowMinimumViaFailf(t *testing.T) {
 	if got := stdout.String(); !strings.Contains(got, "total: (statements) 100.0%") {
 		t.Fatalf("main() stdout = %q, want total coverage line", got)
 	}
-	if got := stdout.String(); !strings.Contains(got, modulePath+"/pkg/config\tcoverage: 100.0% of statements") {
+	if got := stdout.String(); !strings.Contains(got, "package="+modulePath+"/pkg/config coverage=100.0% floor=80.0% delta=+20.0pp status=PASS lane=unit") {
 		t.Fatalf("main() stdout = %q, want package summary for pkg/config", got)
 	}
-	if got := stdout.String(); !strings.Contains(got, modulePath+"/pkg/service\tcoverage: 100.0% of statements") {
+	if got := stdout.String(); !strings.Contains(got, "package="+modulePath+"/pkg/service coverage=100.0% floor=80.0% delta=+20.0pp status=PASS lane=unit") {
 		t.Fatalf("main() stdout = %q, want package summary for pkg/service", got)
 	}
 	if got := stdout.String(); strings.Contains(got, "meets minimum") {
@@ -197,6 +197,7 @@ func TestMainPackageFloorPolicyAdvisoryReportsRegressionAndBlockingRestoresEnfor
 		wantExit       int
 		wantBanner     bool
 		wantSuccess    bool
+		wantStatus     string
 		wantDiagnostic string
 	}{
 		{
@@ -204,12 +205,14 @@ func TestMainPackageFloorPolicyAdvisoryReportsRegressionAndBlockingRestoresEnfor
 			policy:         coverageFloorPolicyAdvisory,
 			wantBanner:     true,
 			wantSuccess:    true,
+			wantStatus:     "WARN",
 			wantDiagnostic: "package coverage regression: package=" + configPackage + " lane=unit expected-minimum=80.00% actual=0.0000% delta=-80.0000 percentage-points covered=0/3 statements",
 		},
 		{
 			name:           "blocking",
 			policy:         coverageFloorPolicyBlocking,
 			wantExit:       1,
+			wantStatus:     "FAIL",
 			wantDiagnostic: "package coverage regression: package=" + configPackage + " lane=unit expected-minimum=80.00% actual=0.0000% delta=-80.0000 percentage-points covered=0/3 statements",
 		},
 	} {
@@ -244,12 +247,37 @@ func TestMainPackageFloorPolicyAdvisoryReportsRegressionAndBlockingRestoresEnfor
 			if !strings.Contains(stderr, tc.wantDiagnostic) {
 				t.Fatalf("main() stderr = %q, want regression diagnostic containing %q", stderr, tc.wantDiagnostic)
 			}
+			wantVerdict := "package=" + configPackage + " coverage=0.0% floor=80.0% delta=-80.0pp status=" + tc.wantStatus + " lane=unit"
+			if !strings.Contains(stdout, wantVerdict) {
+				t.Fatalf("main() stdout = %q, want compact package verdict %q", stdout, wantVerdict)
+			}
+			if strings.Contains(stdout, "uncovered blocks:") || strings.Contains(stderr, "uncovered blocks:") {
+				t.Fatalf("main() default diagnostics exposed uncovered source detail: stdout=%q stderr=%q", stdout, stderr)
+			}
 			if tc.wantSuccess {
 				if !strings.Contains(stdout, "Go coverage 0.0% meets minimum 0.0%.") {
 					t.Fatalf("main() stdout = %q, want successful aggregate message", stdout)
 				}
 			} else if strings.Contains(stdout, "meets minimum") {
 				t.Fatalf("main() stdout = %q, did not expect success message", stdout)
+			}
+		})
+	}
+
+	for _, policy := range []string{coverageFloorPolicyAdvisory, coverageFloorPolicyBlocking} {
+		t.Run(policy+" detailed diagnostics", func(t *testing.T) {
+			args := []string{
+				"-min=0",
+				"-suite=unit",
+				"-detailed-diagnostics",
+				"-package-floor-policy=" + policy,
+				"-package-manifest=" + manifestPath,
+				"-coverpkg=" + configPackage,
+				"-packages=./pkg/config",
+			}
+			_, stderr, _ := runMainForTest(t, args, fakeGoCoverageCommandWithMeasuredZeroConfig)
+			if !strings.Contains(stderr, "uncovered blocks: pkg/config/config.go:1 (3 statements)") {
+				t.Fatalf("main() detailed stderr = %q, want uncovered source detail", stderr)
 			}
 		})
 	}
@@ -533,7 +561,7 @@ func TestMainFailsWhenZeroCoveragePackagesDetectedViaFailf(t *testing.T) {
 	if got := stdout.String(); !strings.Contains(got, "total: (statements) 100.0%") {
 		t.Fatalf("main() stdout = %q, want total coverage line", got)
 	}
-	if got := stdout.String(); !strings.Contains(got, modulePath+"/pkg/config\tcoverage: 0.0% of statements") {
+	if got := stdout.String(); !strings.Contains(got, "package="+modulePath+"/pkg/config coverage=0.0% floor=80.0% delta=-80.0pp status=FAIL lane=unit") {
 		t.Fatalf("main() stdout = %q, want package summary for pkg/config", got)
 	}
 	wantFailure := "go coverage found non-baselined backend packages below 80.0% statement coverage: " + modulePath + "/pkg/config (0.0%)\n"
@@ -591,7 +619,7 @@ func TestMainFailsWithZeroCoveragePackageSummary(t *testing.T) {
 	if got := stdout.String(); !strings.Contains(got, "total: (statements) 100.0%") {
 		t.Fatalf("main() stdout = %q, want total coverage line", got)
 	}
-	if got := stdout.String(); !strings.Contains(got, modulePath+"/pkg/config\tcoverage: 0.0% of statements") {
+	if got := stdout.String(); !strings.Contains(got, "package="+modulePath+"/pkg/config coverage=0.0% floor=80.0% delta=-80.0pp status=FAIL lane=unit") {
 		t.Fatalf("main() stdout = %q, want package summary for pkg/config", got)
 	}
 	wantFailure := "go coverage found non-baselined backend packages below 80.0% statement coverage: " + modulePath + "/pkg/config (0.0%)\n"
@@ -649,7 +677,7 @@ func TestMainFailsWithZeroCoverageOKPackageSummary(t *testing.T) {
 	if got := stdout.String(); !strings.Contains(got, "total: (statements) 100.0%") {
 		t.Fatalf("main() stdout = %q, want total coverage line", got)
 	}
-	if got := stdout.String(); !strings.Contains(got, modulePath+"/pkg/config\tcoverage: 0.0% of statements") {
+	if got := stdout.String(); !strings.Contains(got, "package="+modulePath+"/pkg/config coverage=0.0% floor=80.0% delta=-80.0pp status=FAIL lane=unit") {
 		t.Fatalf("main() stdout = %q, want package summary for pkg/config", got)
 	}
 	wantFailure := "go coverage found non-baselined backend packages below 80.0% statement coverage: " + modulePath + "/pkg/config (0.0%)\n"
@@ -707,7 +735,7 @@ func TestMainFailsWithZeroCoverageCoverpkgOKPackageSummary(t *testing.T) {
 	if got := stdout.String(); !strings.Contains(got, "total: (statements) 100.0%") {
 		t.Fatalf("main() stdout = %q, want total coverage line", got)
 	}
-	if got := stdout.String(); !strings.Contains(got, modulePath+"/pkg/config\tcoverage: 0.0% of statements") {
+	if got := stdout.String(); !strings.Contains(got, "package="+modulePath+"/pkg/config coverage=0.0% floor=80.0% delta=-80.0pp status=FAIL lane=unit") {
 		t.Fatalf("main() stdout = %q, want package summary for pkg/config", got)
 	}
 	wantFailure := "go coverage found non-baselined backend packages below 80.0% statement coverage: " + modulePath + "/pkg/config (0.0%)\n"

--- a/cmd/gocoveragecheck/main_repo_root_test.go
+++ b/cmd/gocoveragecheck/main_repo_root_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+)
+
+func TestRepoRootDirFindsNearestAncestorWithGoMod(t *testing.T) {
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	defer func() {
+		if chdirErr := os.Chdir(originalDir); chdirErr != nil {
+			t.Fatalf("restore working directory: %v", chdirErr)
+		}
+	}()
+
+	repoRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoRoot, "go.mod"), []byte("module example.com/test\n\ngo 1.25\n"), 0o600); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	nestedDir := filepath.Join(repoRoot, "pkg", "service", "nested")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.Chdir(nestedDir); err != nil {
+		t.Fatalf("Chdir() error = %v", err)
+	}
+
+	got, err := repoRootDir()
+	if err != nil {
+		t.Fatalf("repoRootDir() error = %v", err)
+	}
+	if testutil.CanonicalPath(got) != testutil.CanonicalPath(repoRoot) {
+		t.Fatalf("repoRootDir() = %q, want %q", got, repoRoot)
+	}
+}
+
+func tempDirOutsideRepo(t *testing.T) string {
+	t.Helper()
+
+	repoRoot := testutil.CanonicalPath(testutil.MustRepoRoot(t))
+	candidates := []string{os.TempDir()}
+	if runtime.GOOS != "windows" {
+		candidates = append(candidates, "/tmp")
+	}
+
+	for _, base := range candidates {
+		tempRoot, err := os.MkdirTemp(base, "gocoveragecheck-*")
+		if err != nil {
+			continue
+		}
+		canonicalTemp := testutil.CanonicalPath(tempRoot)
+		if isPathWithin(canonicalTemp, repoRoot) {
+			if removeErr := os.RemoveAll(tempRoot); removeErr != nil {
+				t.Fatalf("remove in-repo temp dir %q: %v", tempRoot, removeErr)
+			}
+			continue
+		}
+		t.Cleanup(func() {
+			if removeErr := os.RemoveAll(tempRoot); removeErr != nil {
+				t.Fatalf("remove temp dir %q: %v", tempRoot, removeErr)
+			}
+		})
+		return tempRoot
+	}
+
+	t.Fatal("could not create temp dir outside repository")
+	return ""
+}
+
+func isPathWithin(child, parent string) bool {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func TestRepoRootDirFailsWhenNoGoModExists(t *testing.T) {
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	defer func() {
+		if chdirErr := os.Chdir(originalDir); chdirErr != nil {
+			t.Fatalf("restore working directory: %v", chdirErr)
+		}
+	}()
+
+	workingDir := filepath.Join(tempDirOutsideRepo(t), "pkg", "service")
+	if err := os.MkdirAll(workingDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.Chdir(workingDir); err != nil {
+		t.Fatalf("Chdir() error = %v", err)
+	}
+
+	_, err = repoRootDir()
+	if err == nil {
+		t.Fatal("repoRootDir() unexpectedly succeeded")
+	}
+	if err.Error() != "resolve repository root: go.mod not found" {
+		t.Fatalf("repoRootDir() error = %q, want missing go.mod error", err.Error())
+	}
+}
+
+func TestFindZeroCoveragePackagesFromSummaries(t *testing.T) {
+	t.Parallel()
+
+	zeroCoveragePackages := findZeroCoveragePackagesFromSummaries(
+		[]packageCoverageSummary{
+			{importPath: modulePath + "/pkg/config", coverage: 0},
+			{importPath: modulePath + "/pkg/service", coverage: 100},
+		},
+		map[string]struct{}{
+			modulePath + "/pkg/config": {},
+		},
+	)
+	if len(zeroCoveragePackages) != 0 {
+		t.Fatalf("findZeroCoveragePackagesFromSummaries() = %v, want none", zeroCoveragePackages)
+	}
+}

--- a/cmd/gocoveragecheck/main_run_test.go
+++ b/cmd/gocoveragecheck/main_run_test.go
@@ -45,10 +45,10 @@ func TestExecuteReportsPassingCoverage(t *testing.T) {
 	if !strings.Contains(got, "total: (statements) 100.0%") {
 		t.Fatalf("execute() stdout = %q, want total coverage line", got)
 	}
-	if !strings.Contains(got, modulePath+"/pkg/config\tcoverage: 100.0% of statements") {
+	if !strings.Contains(got, "package="+modulePath+"/pkg/config coverage=100.0% floor=80.0% delta=+20.0pp status=PASS lane=unit") {
 		t.Fatalf("execute() stdout = %q, want package summary for pkg/config", got)
 	}
-	if !strings.Contains(got, modulePath+"/pkg/service\tcoverage: 100.0% of statements") {
+	if !strings.Contains(got, "package="+modulePath+"/pkg/service coverage=100.0% floor=80.0% delta=+20.0pp status=PASS lane=unit") {
 		t.Fatalf("execute() stdout = %q, want package summary for pkg/service", got)
 	}
 	if strings.Contains(got, "\t\tcoverage: 75.0% of statements") {
@@ -124,18 +124,18 @@ func TestExecuteReportsPackageSummariesForCompleteManifest(t *testing.T) {
 	stderrWriter = &stderr
 
 	err := execute(config{
-		min:             0,
-		suite:           "unit",
-		coverpkg:        configPackage,
-		packages:        "./pkg/config",
-		packageManifest: manifestPath,
+		min:                 0,
+		suite:               "unit",
+		coverpkg:            configPackage,
+		packages:            "./pkg/config",
+		packageManifest:     manifestPath,
 	})
 	if err != nil {
 		t.Fatalf("execute() error = %v", err)
 	}
 
 	got := stdout.String()
-	wantSummary := configPackage + "\tcoverage: 100.0% of statements\n"
+	wantSummary := "package=" + configPackage + " coverage=100.0% floor=100.0% delta=+0.0pp status=PASS lane=unit\n"
 	if strings.Count(got, wantSummary) != 1 {
 		t.Fatalf("execute() stdout = %q, want one package summary %q", got, wantSummary)
 	}
@@ -218,11 +218,12 @@ func TestExecuteReportsUncoveredBlocksForManifestRegression(t *testing.T) {
 	stderrWriter = &stderr
 
 	err := execute(config{
-		min:             0,
-		suite:           "unit",
-		coverpkg:        configPackage,
-		packages:        "./pkg/config",
-		packageManifest: manifestPath,
+		min:                 0,
+		suite:               "unit",
+		coverpkg:            configPackage,
+		packages:            "./pkg/config",
+		packageManifest:     manifestPath,
+		detailedDiagnostics: true,
 	})
 	if err == nil {
 		t.Fatal("execute() unexpectedly succeeded")
@@ -267,11 +268,12 @@ func TestExecuteReportsRootObservationCoverageRegressionWithExactCountsAndBlocks
 	stderrWriter = &stderr
 
 	err := execute(config{
-		min:             0,
-		suite:           "unit",
-		coverpkg:        strings.Join([]string{modulePath + "/pkg/services/factory_runtime", rootObservationPackage}, ","),
-		packages:        "./pkg/services/factory_runtime/internal/rootobservation",
-		packageManifest: manifestPath,
+		min:                 0,
+		suite:               "unit",
+		coverpkg:            strings.Join([]string{modulePath + "/pkg/services/factory_runtime", rootObservationPackage}, ","),
+		packages:            "./pkg/services/factory_runtime/internal/rootobservation",
+		packageManifest:     manifestPath,
+		detailedDiagnostics: true,
 	})
 	if err == nil {
 		t.Fatal("execute() unexpectedly succeeded")
@@ -288,8 +290,8 @@ func TestExecuteReportsRootObservationCoverageRegressionWithExactCountsAndBlocks
 	if strings.Count(err.Error(), "uncovered blocks:") != 1 || strings.Count(err.Error(), "(1 statement)") != 2 {
 		t.Fatalf("execute() error = %q, want exactly two uncovered blocks", err)
 	}
-	if !strings.Contains(stdout.String(), rootObservationPackage+"\tcoverage: 95.6% of statements") {
-		t.Fatalf("execute() stdout = %q, want rootobservation package summary", stdout.String())
+	if !strings.Contains(stdout.String(), "package="+rootObservationPackage+" coverage=95.6% floor=100.0% delta=-4.4pp status=FAIL lane=unit") {
+		t.Fatalf("execute() stdout = %q, want rootobservation package verdict", stdout.String())
 	}
 	wantDiagnostic := "coverage not evaluated: package=" + modulePath + "/pkg/services/factory_runtime lane=unit (no measurement in profile)\n"
 	if got := stderr.String(); got != wantDiagnostic {
@@ -362,7 +364,7 @@ func TestExecuteTotalOnlyReportsIndependentSuiteCoverageWithPackageSummaries(t *
 	if !strings.Contains(got, "total: (statements) 100.0%") {
 		t.Fatalf("execute() stdout = %q, want total coverage line", got)
 	}
-	if !strings.Contains(got, modulePath+"/pkg/config\tcoverage: 100.0% of statements") {
+	if !strings.Contains(got, "package="+modulePath+"/pkg/config coverage=100.0% floor=n/a status=report-only lane=unit") {
 		t.Fatalf("execute() stdout = %q, want package summary from the selected suite profile", got)
 	}
 	if stderr.Len() != 0 {
@@ -438,10 +440,10 @@ func TestExecuteFailsWhenCoverageBelowMinimum(t *testing.T) {
 	if !strings.Contains(got, "total: (statements) 100.0%") {
 		t.Fatalf("execute() stdout = %q, want total coverage line", got)
 	}
-	if !strings.Contains(got, modulePath+"/pkg/config\tcoverage: 100.0% of statements") {
+	if !strings.Contains(got, "package="+modulePath+"/pkg/config coverage=100.0% floor=80.0% delta=+20.0pp status=PASS lane=unit") {
 		t.Fatalf("execute() stdout = %q, want package summary for pkg/config", got)
 	}
-	if !strings.Contains(got, modulePath+"/pkg/service\tcoverage: 100.0% of statements") {
+	if !strings.Contains(got, "package="+modulePath+"/pkg/service coverage=100.0% floor=80.0% delta=+20.0pp status=PASS lane=unit") {
 		t.Fatalf("execute() stdout = %q, want package summary for pkg/service", got)
 	}
 	wantFailure := "go coverage 100.0% is below minimum 100.1%"
@@ -565,10 +567,10 @@ func TestExecuteFailsWhenCoverageBelowMinimumAndZeroCoveragePackage(t *testing.T
 	if !strings.Contains(got, "total: (statements) 100.0%") {
 		t.Fatalf("execute() stdout = %q, want total coverage line", got)
 	}
-	if !strings.Contains(got, modulePath+"/pkg/config\tcoverage: 0.0% of statements") {
+	if !strings.Contains(got, "package="+modulePath+"/pkg/config coverage=0.0% floor=80.0% delta=-80.0pp status=FAIL lane=unit") {
 		t.Fatalf("execute() stdout = %q, want package summary for pkg/config", got)
 	}
-	if !strings.Contains(got, modulePath+"/pkg/service\tcoverage: 100.0% of statements") {
+	if !strings.Contains(got, "package="+modulePath+"/pkg/service coverage=100.0% floor=80.0% delta=+20.0pp status=PASS lane=unit") {
 		t.Fatalf("execute() stdout = %q, want package summary for pkg/service", got)
 	}
 	wantFailure := strings.Join([]string{
@@ -620,10 +622,10 @@ func TestExecuteFailsWhenZeroCoveragePackageOnly(t *testing.T) {
 	if !strings.Contains(got, "total: (statements) 100.0%") {
 		t.Fatalf("execute() stdout = %q, want total coverage line", got)
 	}
-	if !strings.Contains(got, modulePath+"/pkg/config\tcoverage: 0.0% of statements") {
+	if !strings.Contains(got, "package="+modulePath+"/pkg/config coverage=0.0% floor=80.0% delta=-80.0pp status=FAIL lane=unit") {
 		t.Fatalf("execute() stdout = %q, want package summary for pkg/config", got)
 	}
-	if !strings.Contains(got, modulePath+"/pkg/service\tcoverage: 100.0% of statements") {
+	if !strings.Contains(got, "package="+modulePath+"/pkg/service coverage=100.0% floor=80.0% delta=+20.0pp status=PASS lane=unit") {
 		t.Fatalf("execute() stdout = %q, want package summary for pkg/service", got)
 	}
 	wantFailure := "go coverage found non-baselined backend packages below 80.0% statement coverage: " + modulePath + "/pkg/config (0.0%)"

--- a/cmd/gocoveragecheck/main_run_test.go
+++ b/cmd/gocoveragecheck/main_run_test.go
@@ -5,12 +5,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strings"
 	"testing"
-
-	"github.com/portpowered/infinite-you/internal/testutil"
 )
 
 func TestExecuteReportsPassingCoverage(t *testing.T) {
@@ -879,123 +876,5 @@ func TestListGoPackagesFiltersDuplicatesAndExcludedPackages(t *testing.T) {
 	}
 	if slices.Contains(testPackages, modulePath+"/pkg/config/exhaustiontests") {
 		t.Fatalf("listGoPackages() for test lane = %v, maintenance package must be excluded", testPackages)
-	}
-}
-
-func TestRepoRootDirFindsNearestAncestorWithGoMod(t *testing.T) {
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Getwd() error = %v", err)
-	}
-	defer func() {
-		if chdirErr := os.Chdir(originalDir); chdirErr != nil {
-			t.Fatalf("restore working directory: %v", chdirErr)
-		}
-	}()
-
-	repoRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(repoRoot, "go.mod"), []byte("module example.com/test\n\ngo 1.25\n"), 0o600); err != nil {
-		t.Fatalf("write go.mod: %v", err)
-	}
-	nestedDir := filepath.Join(repoRoot, "pkg", "service", "nested")
-	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
-	if err := os.Chdir(nestedDir); err != nil {
-		t.Fatalf("Chdir() error = %v", err)
-	}
-
-	got, err := repoRootDir()
-	if err != nil {
-		t.Fatalf("repoRootDir() error = %v", err)
-	}
-	if testutil.CanonicalPath(got) != testutil.CanonicalPath(repoRoot) {
-		t.Fatalf("repoRootDir() = %q, want %q", got, repoRoot)
-	}
-}
-
-func tempDirOutsideRepo(t *testing.T) string {
-	t.Helper()
-
-	repoRoot := testutil.CanonicalPath(testutil.MustRepoRoot(t))
-	candidates := []string{os.TempDir()}
-	if runtime.GOOS != "windows" {
-		candidates = append(candidates, "/tmp")
-	}
-
-	for _, base := range candidates {
-		tempRoot, err := os.MkdirTemp(base, "gocoveragecheck-*")
-		if err != nil {
-			continue
-		}
-		canonicalTemp := testutil.CanonicalPath(tempRoot)
-		if isPathWithin(canonicalTemp, repoRoot) {
-			if removeErr := os.RemoveAll(tempRoot); removeErr != nil {
-				t.Fatalf("remove in-repo temp dir %q: %v", tempRoot, removeErr)
-			}
-			continue
-		}
-		t.Cleanup(func() {
-			if removeErr := os.RemoveAll(tempRoot); removeErr != nil {
-				t.Fatalf("remove temp dir %q: %v", tempRoot, removeErr)
-			}
-		})
-		return tempRoot
-	}
-
-	t.Fatal("could not create temp dir outside repository")
-	return ""
-}
-
-func isPathWithin(child, parent string) bool {
-	rel, err := filepath.Rel(parent, child)
-	if err != nil {
-		return false
-	}
-	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
-}
-
-func TestRepoRootDirFailsWhenNoGoModExists(t *testing.T) {
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Getwd() error = %v", err)
-	}
-	defer func() {
-		if chdirErr := os.Chdir(originalDir); chdirErr != nil {
-			t.Fatalf("restore working directory: %v", chdirErr)
-		}
-	}()
-
-	workingDir := filepath.Join(tempDirOutsideRepo(t), "pkg", "service")
-	if err := os.MkdirAll(workingDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
-	if err := os.Chdir(workingDir); err != nil {
-		t.Fatalf("Chdir() error = %v", err)
-	}
-
-	_, err = repoRootDir()
-	if err == nil {
-		t.Fatal("repoRootDir() unexpectedly succeeded")
-	}
-	if err.Error() != "resolve repository root: go.mod not found" {
-		t.Fatalf("repoRootDir() error = %q, want missing go.mod error", err.Error())
-	}
-}
-
-func TestFindZeroCoveragePackagesFromSummaries(t *testing.T) {
-	t.Parallel()
-
-	zeroCoveragePackages := findZeroCoveragePackagesFromSummaries(
-		[]packageCoverageSummary{
-			{importPath: modulePath + "/pkg/config", coverage: 0},
-			{importPath: modulePath + "/pkg/service", coverage: 100},
-		},
-		map[string]struct{}{
-			modulePath + "/pkg/config": {},
-		},
-	)
-	if len(zeroCoveragePackages) != 0 {
-		t.Fatalf("findZeroCoveragePackagesFromSummaries() = %v, want none", zeroCoveragePackages)
 	}
 }

--- a/cmd/gocoveragecheck/main_run_test.go
+++ b/cmd/gocoveragecheck/main_run_test.go
@@ -124,11 +124,11 @@ func TestExecuteReportsPackageSummariesForCompleteManifest(t *testing.T) {
 	stderrWriter = &stderr
 
 	err := execute(config{
-		min:                 0,
-		suite:               "unit",
-		coverpkg:            configPackage,
-		packages:            "./pkg/config",
-		packageManifest:     manifestPath,
+		min:             0,
+		suite:           "unit",
+		coverpkg:        configPackage,
+		packages:        "./pkg/config",
+		packageManifest: manifestPath,
 	})
 	if err != nil {
 		t.Fatalf("execute() error = %v", err)

--- a/scripts/ci/coverage-report.mjs
+++ b/scripts/ci/coverage-report.mjs
@@ -32,9 +32,18 @@ const HEADROOM_EPSILON = 1e-9;
  */
 export function summarizeCoverageReport(coverage, timing, limits = {}) {
 	const resolved = { ...DEFAULT_COVERAGE_REPORT_LIMITS, ...limits };
+	const coverageSummary = summarizeCoverageArtifact(coverage, resolved);
+	const timingSummary = summarizeTimingArtifact(timing, resolved);
+	const timingByPackage = new Map(
+		timingSummary.packages.map((entry) => [entry.package, entry]),
+	);
+	coverageSummary.reportOnly = coverageSummary.reportOnly.map((entry) => ({
+		...entry,
+		timing: timingByPackage.get(entry.package) || null,
+	}));
 	return {
-		coverage: summarizeCoverageArtifact(coverage, resolved),
-		timing: summarizeTimingArtifact(timing, resolved),
+		coverage: coverageSummary,
+		timing: timingSummary,
 	};
 }
 
@@ -45,6 +54,7 @@ function summarizeCoverageArtifact(coverage, limits) {
 			packageFloorPolicy: "",
 			packageFloorFindings: [],
 			manifestDiagnostics: [],
+			reportOnly: [],
 			violations: [],
 			violationCount: 0,
 			floorHoldCount: 0,
@@ -54,7 +64,7 @@ function summarizeCoverageArtifact(coverage, limits) {
 			omitted: 0,
 		};
 	}
-	const ranked = coverage.packages
+	const packages = coverage.packages
 		.filter((entry) => entry && typeof entry.package === "string")
 		.map((entry) => ({
 			package: entry.package,
@@ -64,7 +74,8 @@ function summarizeCoverageArtifact(coverage, limits) {
 				typeof entry.packageFloor === "number" && Number.isFinite(entry.packageFloor)
 					? entry.packageFloor
 					: null,
-		}))
+		}));
+	const ranked = packages
 		.filter((entry) => entry.floor !== null)
 		.map((entry) => ({ ...entry, headroom: entry.coveragePercent - entry.floor }))
 		.sort((left, right) =>
@@ -97,6 +108,9 @@ function summarizeCoverageArtifact(coverage, limits) {
 		packageFloorPolicy: textValue(coverage.packageFloorPolicy),
 		packageFloorFindings: diagnosticEntries(coverage.packageFloorFindings),
 		manifestDiagnostics: diagnosticEntries(coverage.manifestDiagnostics),
+		reportOnly: packages
+			.filter((entry) => entry.floor === null)
+			.sort((left, right) => left.package.localeCompare(right.package)),
 		complete: coverage.complete !== false,
 		measurementReason: textValue(coverage.measurementReason),
 		coveredStatements: finiteNumber(coverage.coveredStatements),
@@ -115,8 +129,18 @@ function summarizeCoverageArtifact(coverage, limits) {
 
 function summarizeTimingArtifact(timing, limits) {
 	if (!timing || typeof timing !== "object" || !Array.isArray(timing.tests)) {
-		return { available: false, slowest: [], observed: 0, omitted: 0 };
+		return { available: false, packages: [], slowest: [], observed: 0, omitted: 0 };
 	}
+	const packages = Array.isArray(timing.packages)
+		? timing.packages
+			.filter((entry) => entry && typeof entry.package === "string")
+			.map((entry) => ({
+				package: entry.package,
+				seconds: finiteNumber(entry.seconds),
+				outcome: textValue(entry.outcome) || "unknown",
+			}))
+			.sort((left, right) => left.package.localeCompare(right.package))
+		: [];
 	const slowest = timing.tests
 		.filter((entry) => entry && typeof entry.package === "string" && typeof entry.test === "string")
 		.map((entry) => ({
@@ -133,6 +157,7 @@ function summarizeTimingArtifact(timing, limits) {
 	const shown = slowest.slice(0, limits.slowestTests);
 	return {
 		available: true,
+		packages,
 		complete: timing.complete !== false,
 		captureReason: textValue(timing.captureReason),
 		wallSeconds: finiteNumber(timing.wallSeconds),
@@ -191,6 +216,13 @@ export function renderCoverageReportBody(summary, options = {}) {
 	);
 	if (manifestDiagnostics) {
 		sections.push(manifestDiagnostics);
+	}
+	const reportOnly = renderReportOnlyPackageTable(
+		summary.coverage.reportOnly,
+		!summary.coverage.complete,
+	);
+	if (reportOnly) {
+		sections.push(`### Measured packages without a floor\n\n${reportOnly}`);
 	}
 	sections.push(renderTimingOverview(summary.timing, timingArtifactName, options));
 	const slowest = renderSlowestTable(summary.timing.slowest);
@@ -284,6 +316,24 @@ function renderPackageTable(rows) {
 	for (const row of rows) {
 		lines.push(
 			`| \`${row.package}\` | ${row.coveragePercent.toFixed(2)} | ${row.floor.toFixed(2)} | ${row.headroom.toFixed(2)} |`,
+		);
+	}
+	return lines.join("\n");
+}
+
+function renderReportOnlyPackageTable(rows, partial) {
+	if (!rows || rows.length === 0) {
+		return "";
+	}
+	const lines = [
+		"| Package | Coverage % | Floor | Status | Duration (s) |",
+		"| --- | ---: | --- | --- | ---: |",
+	];
+	for (const row of rows) {
+		const floor = partial ? "n/a (partial run)" : "n/a (report-only)";
+		const duration = row.timing ? row.timing.seconds.toFixed(3) : "unavailable";
+		lines.push(
+			`| \`${row.package}\` | ${row.coveragePercent.toFixed(2)} | ${floor} | report-only | ${duration} |`,
 		);
 	}
 	return lines.join("\n");

--- a/scripts/ci/coverage-report.mjs
+++ b/scripts/ci/coverage-report.mjs
@@ -41,6 +41,10 @@ export function summarizeCoverageReport(coverage, timing, limits = {}) {
 		...entry,
 		timing: timingByPackage.get(entry.package) || null,
 	}));
+	coverageSummary.packageVerdicts = coverageSummary.packageVerdicts.map((entry) => ({
+		...entry,
+		timing: timingByPackage.get(entry.package) || null,
+	}));
 	return {
 		coverage: coverageSummary,
 		timing: timingSummary,
@@ -55,6 +59,7 @@ function summarizeCoverageArtifact(coverage, limits) {
 			packageFloorFindings: [],
 			manifestDiagnostics: [],
 			reportOnly: [],
+			packageVerdicts: [],
 			violations: [],
 			violationCount: 0,
 			floorHoldCount: 0,
@@ -75,6 +80,8 @@ function summarizeCoverageArtifact(coverage, limits) {
 					? entry.packageFloor
 					: null,
 		}));
+	const complete = coverage.complete !== false;
+	const packageFloorPolicy = textValue(coverage.packageFloorPolicy);
 	const ranked = packages
 		.filter((entry) => entry.floor !== null)
 		.map((entry) => ({ ...entry, headroom: entry.coveragePercent - entry.floor }))
@@ -103,15 +110,24 @@ function summarizeCoverageArtifact(coverage, limits) {
 	);
 	const violations = allViolations.slice(0, limits.violations);
 	const nearFloor = contenders.slice(0, limits.packages);
+	const reportOnly = packages
+		.filter((entry) => entry.floor === null)
+		.sort((left, right) => left.package.localeCompare(right.package));
+	const packageVerdicts = [
+		...ranked.map((entry) => ({
+			...entry,
+			status: packageVerdictStatus(entry, packageFloorPolicy),
+		})),
+		...reportOnly.map((entry) => ({ ...entry, status: "report-only" })),
+	];
 	return {
 		available: true,
-		packageFloorPolicy: textValue(coverage.packageFloorPolicy),
+		packageFloorPolicy,
 		packageFloorFindings: diagnosticEntries(coverage.packageFloorFindings),
 		manifestDiagnostics: diagnosticEntries(coverage.manifestDiagnostics),
-		reportOnly: packages
-			.filter((entry) => entry.floor === null)
-			.sort((left, right) => left.package.localeCompare(right.package)),
-		complete: coverage.complete !== false,
+		reportOnly,
+		packageVerdicts,
+		complete,
 		measurementReason: textValue(coverage.measurementReason),
 		coveredStatements: finiteNumber(coverage.coveredStatements),
 		measurableStatements: finiteNumber(coverage.measurableStatements),
@@ -136,7 +152,7 @@ function summarizeTimingArtifact(timing, limits) {
 			.filter((entry) => entry && typeof entry.package === "string")
 			.map((entry) => ({
 				package: entry.package,
-				seconds: finiteNumber(entry.seconds),
+				seconds: finiteNumberOrNull(entry.seconds),
 				outcome: textValue(entry.outcome) || "unknown",
 			}))
 			.sort((left, right) => left.package.localeCompare(right.package))
@@ -191,21 +207,18 @@ export function renderCoverageReportBody(summary, options = {}) {
 	}
 	sections.push(`## ${heading}`, renderCoverageOverview(summary.coverage, coverageArtifactName));
 
-	const violations = renderPackageTable(summary.coverage.violations);
-	if (violations) {
-		sections.push(
-			`### Floor violations\n\n${violations}\n- ${summary.coverage.omittedViolations} additional violation(s) omitted.`,
-		);
-	}
-	const nearFloor = renderPackageTable(summary.coverage.nearFloor);
-	if (nearFloor) {
-		sections.push(
-			`### Closest to their floor\n\n${nearFloor}\n- ${summary.coverage.omitted} additional gated package(s) omitted.`,
-		);
+	const packageVerdicts = renderPackageVerdictTable(summary.coverage.packageVerdicts, {
+		includeDuration: options.includePackageDuration === true,
+		packageLimit: options.packageLimit,
+		partial: !summary.coverage.complete,
+	});
+	if (packageVerdicts) {
+		sections.push(`### Package verdicts\n\n${packageVerdicts}`);
 	}
 	const packageFloorFindings = renderDiagnostics(
 		"### Package-floor findings",
 		summary.coverage.packageFloorFindings,
+		options.includeUncoveredDetails === true,
 	);
 	if (packageFloorFindings) {
 		sections.push(packageFloorFindings);
@@ -213,16 +226,14 @@ export function renderCoverageReportBody(summary, options = {}) {
 	const manifestDiagnostics = renderDiagnostics(
 		"### Manifest findings",
 		summary.coverage.manifestDiagnostics,
+		options.includeUncoveredDetails === true,
 	);
 	if (manifestDiagnostics) {
 		sections.push(manifestDiagnostics);
 	}
-	const reportOnly = renderReportOnlyPackageTable(
-		summary.coverage.reportOnly,
-		!summary.coverage.complete,
-	);
-	if (reportOnly) {
-		sections.push(`### Measured packages without a floor\n\n${reportOnly}`);
+	if (options.includePackageTiming === true) {
+		const packageTiming = renderTimingPackageTable(summary.timing);
+		sections.push(`### ${options.packageTimingHeading || "Package timing"}\n\n${packageTiming}`);
 	}
 	sections.push(renderTimingOverview(summary.timing, timingArtifactName, options));
 	const slowest = renderSlowestTable(summary.timing.slowest);
@@ -267,11 +278,13 @@ function renderCoverageOverview(coverage, artifactName) {
 	return lines.join("\n");
 }
 
-function renderDiagnostics(heading, diagnostics) {
+function renderDiagnostics(heading, diagnostics, includeUncoveredDetails) {
 	if (!diagnostics || diagnostics.length === 0) {
 		return "";
 	}
-	return `${heading}\n\n${diagnostics.map((diagnostic) => `- ${diagnostic}`).join("\n")}`;
+	return `${heading}\n\n${diagnostics
+		.map((diagnostic) => `- ${includeUncoveredDetails ? diagnostic : compactCoverageDiagnostic(diagnostic)}`)
+		.join("\n")}`;
 }
 
 function renderTimingOverview(timing, artifactName, options = {}) {
@@ -308,32 +321,61 @@ function renderEffectiveConcurrencyUnavailable() {
 	return "- Effective concurrency: unavailable — requires a finite, non-negative packageElapsedSecondsSum and a positive finite wallSeconds";
 }
 
-function renderPackageTable(rows) {
+function renderPackageVerdictTable(rows, options = {}) {
 	if (!rows || rows.length === 0) {
 		return "";
 	}
-	const lines = ["| Package | Coverage % | Floor | Headroom |", "| --- | ---: | ---: | ---: |"];
-	for (const row of rows) {
+	const limit = Number.isInteger(options.packageLimit) && options.packageLimit > 0
+		? options.packageLimit
+		: rows.length;
+	const shownRows = rows.slice(0, limit);
+	const columns = ["Package", "Coverage %", "Floor", "Headroom", "Status"];
+	if (options.includeDuration) {
+		columns.push("Duration (s)", "Outcome");
+	}
+	const lines = [
+		`| ${columns.join(" | ")} |`,
+		`| ${columns.map((column) => (column === "Package" || column === "Status" || column === "Outcome" ? "---" : "---:")).join(" | ")} |`,
+	];
+	for (const row of shownRows) {
+		const floor = row.floor === null
+			? options.partial
+				? "n/a (partial run)"
+				: "n/a (report-only)"
+			: row.floor.toFixed(2);
+		const headroom = row.headroom === undefined ? "n/a" : row.headroom.toFixed(2);
+		const values = [
+			`\`${row.package}\``,
+			row.coveragePercent.toFixed(2),
+			floor,
+			headroom,
+			row.status,
+		];
+		if (options.includeDuration) {
+			values.push(
+				row.timing && row.timing.seconds !== null ? row.timing.seconds.toFixed(3) : "unavailable",
+				row.timing ? row.timing.outcome : "unavailable",
+			);
+		}
 		lines.push(
-			`| \`${row.package}\` | ${row.coveragePercent.toFixed(2)} | ${row.floor.toFixed(2)} | ${row.headroom.toFixed(2)} |`,
+			`| ${values.join(" | ")} |`,
 		);
+	}
+	const omitted = rows.length - shownRows.length;
+	if (omitted > 0) {
+		lines.push(`- ${omitted} additional package verdict(s) omitted.`);
 	}
 	return lines.join("\n");
 }
 
-function renderReportOnlyPackageTable(rows, partial) {
-	if (!rows || rows.length === 0) {
-		return "";
+function renderTimingPackageTable(timing) {
+	if (!timing.available || !timing.packages || timing.packages.length === 0) {
+		return "- Package timing: unavailable";
 	}
-	const lines = [
-		"| Package | Coverage % | Floor | Status | Duration (s) |",
-		"| --- | ---: | --- | --- | ---: |",
-	];
-	for (const row of rows) {
-		const floor = partial ? "n/a (partial run)" : "n/a (report-only)";
-		const duration = row.timing ? row.timing.seconds.toFixed(3) : "unavailable";
+	const lines = ["| Package | Duration (s) | Outcome |", "| --- | ---: | --- |"];
+	for (const row of timing.packages) {
 		lines.push(
-			`| \`${row.package}\` | ${row.coveragePercent.toFixed(2)} | ${floor} | report-only | ${duration} |`,
+			`| \`${row.package}\` | ${row.seconds === null ? "unavailable" : row.seconds.toFixed(3)} | ${row.outcome} |`,
 		);
 	}
 	return lines.join("\n");
@@ -423,6 +465,10 @@ function finiteNumber(value) {
 	return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
+function finiteNumberOrNull(value) {
+	return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
 function deriveEffectiveConcurrency(packageElapsedSecondsSum, wallSeconds) {
 	if (
 		typeof packageElapsedSecondsSum !== "number" ||
@@ -464,6 +510,30 @@ function measuredCoveragePercent(entry) {
 
 function textValue(value) {
 	return typeof value === "string" ? value.trim() : "";
+}
+
+function packageVerdictStatus(entry, policy) {
+	if (entry.headroom < -HEADROOM_EPSILON) {
+		return policy === "advisory" ? "WARN" : "FAIL";
+	}
+	return "PASS";
+}
+
+function compactCoverageDiagnostic(diagnostic) {
+	const marker = "; uncovered blocks:";
+	let compact = diagnostic;
+	while (true) {
+		const markerIndex = compact.indexOf(marker);
+		if (markerIndex < 0) {
+			return compact.trim();
+		}
+		const tail = compact.slice(markerIndex + marker.length);
+		const nextField = tail.indexOf("; ");
+		if (nextField < 0) {
+			return compact.slice(0, markerIndex).trim();
+		}
+		compact = compact.slice(0, markerIndex) + tail.slice(nextField);
+	}
 }
 
 function diagnosticEntries(value) {

--- a/scripts/ci/functional-coverage-comment.mjs
+++ b/scripts/ci/functional-coverage-comment.mjs
@@ -36,6 +36,9 @@ const FUNCTIONAL_COVERAGE_RENDER_OPTIONS = {
 	coverageArtifactName: "coverage-summary.json",
 	timingArtifactName: "functional-timing-summary.json",
 	slowestHeading: "Slowest top-level tests",
+	includePackageTiming: true,
+	packageTimingHeading: "Functional test package timing",
+	packageLimit: FUNCTIONAL_COVERAGE_PACKAGE_LIMIT,
 };
 
 /**

--- a/scripts/ci/functional-coverage-comment.test.mjs
+++ b/scripts/ci/functional-coverage-comment.test.mjs
@@ -36,6 +36,10 @@ function timingArtifact() {
 		wallSeconds: 61.5,
 		packageCount: 2,
 		expectedPackageCount: 2,
+		packages: [
+			{ package: "tests/functional/alpha", seconds: 41.25, outcome: "fail" },
+			{ package: "tests/functional/beta", seconds: 12.5, outcome: "pass" },
+		],
 		testCount: 3,
 		testFailCount: 1,
 		tests: [
@@ -80,16 +84,18 @@ test("renders a marked body distinct from the backend lint comment", () => {
 	assert.ok(body.startsWith(FUNCTIONAL_COVERAGE_COMMENT_MARKER));
 	assert.notEqual(FUNCTIONAL_COVERAGE_COMMENT_MARKER, BACKEND_LINT_COMMENT_MARKER);
 	assert.ok(!body.includes(BACKEND_LINT_COMMENT_MARKER));
-	assert.ok(body.includes("### Floor violations"));
-	assert.ok(body.includes("| `pkg/regressed` | 40.00 | 70.00 | -30.00 |"));
+	assert.ok(body.includes("### Package verdicts"));
+	assert.ok(body.includes("| `pkg/regressed` | 40.00 | 70.00 | -30.00 | FAIL |"));
+	assert.ok(body.includes("### Functional test package timing"));
+	assert.ok(body.includes("| `tests/functional/alpha` | 41.250 | fail |"));
 	assert.ok(body.includes("### Slowest top-level tests"));
 	assert.ok(body.includes("| `TestSlow` | `tests/functional/alpha` | 40.125 | fail |"));
 	assert.ok(body.includes("- 0 additional row(s) omitted."));
 	assert.ok(body.includes("- Hosted head: `abc123`"));
 	assert.ok(body.includes("https://example.test/run/1"));
-	assert.ok(body.indexOf("### Floor violations") < body.indexOf("### Closest to their floor"));
-	// A package held to the 0.00 lane-default floor cannot be close to failing.
-	assert.ok(!body.includes("`pkg/lane-default`"));
+	// Every measured package has one compact verdict row, including a package
+	// held to the 0.00 lane-default floor.
+	assert.ok(body.includes("`pkg/lane-default`"));
 });
 
 test("caps both tables and states the omitted row counts", () => {
@@ -121,7 +127,7 @@ test("caps both tables and states the omitted row counts", () => {
 	assert.equal(summary.timing.omitted, 7);
 
 	const body = renderFunctionalCoverageComment(summary);
-	assert.ok(body.includes("- 4 additional gated package(s) omitted."));
+	assert.ok(body.includes("- 4 additional package verdict(s) omitted."));
 	assert.ok(body.includes("- 7 additional row(s) omitted."));
 	assert.ok(!body.includes("`TestCase00`"));
 });
@@ -143,10 +149,27 @@ test("caps the violation table while reporting the true violation count", () => 
 
 	const body = renderFunctionalCoverageComment(summary);
 	assert.ok(body.includes(`- Floor violations: ${FUNCTIONAL_COVERAGE_VIOLATION_LIMIT + 3}`));
-	assert.ok(body.includes("- 3 additional violation(s) omitted."));
+	assert.ok(body.includes("additional package verdict(s) omitted."));
 	// The worst regression is always kept; the mildest ones are dropped.
 	assert.ok(body.includes("`pkg/broken00`"));
 	assert.ok(!body.includes("`pkg/broken27`"));
+});
+
+test("renders advisory findings as WARN and suppresses uncovered source details by default", () => {
+	const summary = summarizeFunctionalCoverage(
+		{
+			...coverageArtifact(),
+			packageFloorPolicy: "advisory",
+			packageFloorFindings: [
+				"package coverage regression: package=pkg/regressed; uncovered blocks: pkg/regressed/file.go:41 (2 statements); restore coverage",
+			],
+		},
+		timingArtifact(),
+	);
+	const body = renderFunctionalCoverageComment(summary);
+	assert.ok(body.includes("| `pkg/regressed` | 40.00 | 70.00 | -30.00 | WARN |"));
+	assert.ok(body.includes("package coverage regression: package=pkg/regressed; restore coverage"));
+	assert.ok(!body.includes("file.go:41 (2 statements)"));
 });
 
 test("reports missing and malformed artifacts instead of throwing", () => {

--- a/scripts/ci/functional-coverage-verdict.mjs
+++ b/scripts/ci/functional-coverage-verdict.mjs
@@ -29,21 +29,11 @@ function normalizedLines(log) {
 
 function isCompactVerdictLine(line) {
 	return (
-		line === advisoryPolicyBanner ||
-		line.startsWith("Package floors and missing-manifest findings are report-only") ||
-		line.startsWith("Set -package-floor-policy=blocking to restore blocking enforcement.") ||
 		line.startsWith(inventoryPrefix) ||
 		line.startsWith("total: (statements)") ||
 		line.startsWith("Functional package coverage verdict:") ||
-		line.startsWith("  floor violation:") ||
-		line.startsWith("  floor hold:") ||
-		line === "  floor violations: none" ||
 		line.startsWith("  package=") ||
 		line.startsWith("  tally:") ||
-		line.startsWith("package coverage regression:") ||
-		line.startsWith("package coverage hold:") ||
-		line.startsWith("coverage manifest missing entry:") ||
-		line.startsWith("coverage not evaluated:") ||
 		/^(?:go|Go) coverage (?:found |.* below minimum |.* meets minimum )/.test(line)
 	);
 }
@@ -107,11 +97,11 @@ export function extractFunctionalCoverageVerdict(log) {
 	}
 
 	const tail = lines.slice(inventoryIndex);
-	const advisoryLines = lines.filter(isAdvisoryPolicyLine);
-	const verdictLines = [
+	const advisoryLines = [...new Set(lines.filter(isAdvisoryPolicyLine))];
+	const verdictLines = [...new Set([
 		...advisoryLines,
 		...tail.filter((line) => isCompactVerdictLine(line) && !isAdvisoryPolicyLine(line)),
-	];
+	])];
 	const text = verdictLines.length > 0 ? `${verdictLines.join("\n")}\n` : "";
 	return {
 		foundInventory: true,

--- a/scripts/ci/functional-coverage-verdict.test.mjs
+++ b/scripts/ci/functional-coverage-verdict.test.mjs
@@ -116,7 +116,7 @@ function runFunctionalRunner(t, outcome) {
 	};
 }
 
-test("extracts the compact verdict and every package regression without raw stream noise", () => {
+test("extracts only the compact verdict contract without verbose diagnostics", () => {
 	const rawLine = `{"Time":"2026-08-20T00:00:00Z","Action":"run","Package":"github.com/portpowered/infinite-you/tests/functional"}`;
 	const log = [
 		rawLine,
@@ -124,20 +124,27 @@ test("extracts the compact verdict and every package regression without raw stre
 		"total: (statements) 70.0%",
 		"Functional package coverage verdict:",
 		"  floor violation: package=github.com/portpowered/infinite-you/pkg/alpha floor=75.0000% actual=70.0000% delta=-5.0000 percentage-points covered=7/10 statements uncovered-blocks=3",
+		"    pkg/alpha/file.go:41 (2 statements)",
+		"  package=github.com/portpowered/infinite-you/pkg/alpha coverage=70.0% floor=75.0% delta=-5.0pp gate=fail lane=functional",
 		"  package=github.com/portpowered/infinite-you/pkg/alpha coverage=70.0% floor=75.0% delta=-5.0pp gate=fail lane=functional",
 		"  tally: measured-packages=2 gated-packages=2 below-floor=1 near-floor=0 gate-failures=1",
 		"package coverage regression: package=github.com/portpowered/infinite-you/pkg/alpha lane=functional expected-minimum=75.00% actual=70.0000% delta=-5.0000 percentage-points covered=7/10 statements",
 		"package coverage regression: package=github.com/portpowered/infinite-you/pkg/beta lane=functional expected-minimum=75.00% actual=60.0000% delta=-15.0000 percentage-points covered=6/10 statements",
+		"coverage manifest missing entry: package=service-root lane=functional",
+		"coverage not evaluated: package=unmeasured lane=functional (no measurement in profile)",
 		"make: *** [functional-test-viz] Error 1",
 	].join("\n");
 
 	const extracted = extractFunctionalCoverageVerdict(log);
 	assert.equal(extracted.foundInventory, true);
 	assert.equal(extracted.hasCoverageGateFailure, true);
-	assert.equal(extracted.lines.filter((line) => line.startsWith("package coverage regression:")).length, 2);
+	assert.equal(extracted.lines.filter((line) => line.startsWith("  package=")).length, 1);
+	assert.equal(new Set(extracted.lines).size, extracted.lines.length);
 	assert.equal(extracted.text.includes(rawLine), false);
 	assert.equal(extracted.text.includes("make: ***"), false);
+	assert.doesNotMatch(extracted.text, /floor violation|package coverage regression|coverage manifest missing|coverage not evaluated|uncovered blocks|file\.go:/);
 	assert.match(extracted.text, /Functional suite inventory:/);
+	assert.match(extracted.text, /  tally:/);
 });
 
 test("retains the advisory banner and distinguishes report-only findings from failed tests", () => {
@@ -157,7 +164,8 @@ test("retains the advisory banner and distinguishes report-only findings from fa
 	assert.equal(extracted.hasAdvisoryFindings, true);
 	assert.equal(extracted.hasOrdinaryTestFailure, false);
 	assert.match(extracted.text, /COVERAGE FLOOR POLICY: advisory/);
-	assert.match(extracted.text, /coverage manifest missing entry: package=service-root/);
+	assert.match(extracted.text, /Functional suite inventory:/);
+	assert.doesNotMatch(extracted.text, /package coverage regression|coverage manifest missing entry|coverage not evaluated/);
 });
 
 test("captures the exact recorded gocoveragecheck exit code", () => {
@@ -252,8 +260,12 @@ test("green runner remains successful and records its compact verdict", (t) => {
 	assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
 	const verdictPath = join(artifactRoot, "functional-coverage-verdict.txt");
 	assert.ok(existsSync(verdictPath));
-	assert.match(readFileSync(verdictPath, "utf8"), /Go coverage 80\.0% meets minimum/);
+	const verdict = readFileSync(verdictPath, "utf8");
+	assert.match(verdict, /Go coverage 80\.0% meets minimum/);
+	assert.equal(verdict.match(/  package=.*lane=functional/g)?.length, 1);
+	assert.doesNotMatch(verdict, /floor violation|uncovered blocks/);
 	assert.equal(readFileSync(join(artifactRoot, "gocoveragecheck-exit-code.txt"), "utf8").trim(), "0");
+	assert.doesNotMatch(result.stdout, /Functional package coverage verdict:|  package=.*lane=functional|Go coverage .* meets minimum/);
 });
 
 test("advisory runner remains successful and retains policy plus findings", (t) => {
@@ -264,8 +276,8 @@ test("advisory runner remains successful and retains policy plus findings", (t) 
 	assert.match(verdict, /Functional coverage outcome: advisory/);
 	assert.match(verdict, /COVERAGE FLOOR POLICY: advisory/);
 	assert.ok(verdict.includes("package=github.com/portpowered/infinite-you/pkg/alpha"));
-	assert.match(verdict, /coverage manifest missing entry: package=.*factory_runtime/);
-	assert.ok(verdict.includes("coverage not evaluated: package=github.com/portpowered/infinite-you/pkg/beta"));
+	assert.doesNotMatch(verdict, /floor violation|coverage manifest missing entry|coverage not evaluated|uncovered blocks/);
+	assert.doesNotMatch(result.stdout, /Functional package coverage verdict:|  package=.*lane=functional|Go coverage .* meets minimum/);
 	assert.equal(readFileSync(join(artifactRoot, "gocoveragecheck-exit-code.txt"), "utf8").trim(), "0");
 });
 
@@ -288,6 +300,8 @@ test("recorded nonzero verdict fails only in the final verdict step", (t) => {
 	assert.equal(publish.status, 1, `${publish.stdout}\n${publish.stderr}`);
 	assert.equal(publish.stdout.includes(verdict), true);
 	assert.equal(readFileSync(summaryPath, "utf8").includes(verdict), true);
+	assert.equal(`${result.stdout}\n${publish.stdout}`.match(/  package=.*lane=functional/g)?.length, 1);
+	assert.doesNotMatch(`${result.stdout}\n${publish.stdout}`, /floor violation|uncovered blocks/);
 });
 
 test("infrastructure failure keeps the full runner step red", (t) => {

--- a/scripts/ci/run-functional-test-viz.sh
+++ b/scripts/ci/run-functional-test-viz.sh
@@ -40,6 +40,27 @@ handle_interrupt() {
 trap 'handle_interrupt 130' INT
 trap 'handle_interrupt 143' TERM
 
+# The make invocation is the full diagnostic source of truth, so retain every
+# byte in command.log. The compact inventory and verdict are handed to the
+# always-run publisher below; suppressing those same lines from this step keeps
+# the coverage step and verdict-report step complementary instead of repeated.
+filter_compact_functional_verdict() {
+  awk '
+    /^!!! COVERAGE FLOOR POLICY: advisory !!!$/ { next }
+    /^Package floors and missing-manifest findings are report-only/ { next }
+    /^Set -package-floor-policy=blocking to restore blocking enforcement\./ { next }
+    /^Functional suite inventory:/ { next }
+    /^total: \(statements\)/ { next }
+    /^Functional package coverage verdict:/ { next }
+    /^  floor violation:/ { next }
+    /^  floor violations: none$/ { next }
+    /^  package=/ { next }
+    /^  tally:/ { next }
+    /^(Go|go) coverage (found |.* below minimum |.* meets minimum )/ { next }
+    { print }
+  '
+}
+
 if ! command -v timeout >/dev/null 2>&1; then
   printf '%s\n' "Functional CI runner: GNU timeout is required to enforce budget=$budget; diagnostics retained under $artifact_root." \
     | tee -a "$log_path" >&2
@@ -56,16 +77,22 @@ timeout --signal=TERM --kill-after=30s "$budget" \
     FUNCTIONAL_SHORT="$short" \
     FUNCTIONAL_QUARANTINE="$quarantine" \
     FUNCTIONAL_GOCOVERAGE_EXIT_FILE="$gocoverage_exit_path" \
-    2>&1 | tee -a "$log_path"
+    2>&1 | tee -a "$log_path" | filter_compact_functional_verdict
 pipeline_status=("${PIPESTATUS[@]}")
 set -e
 
 command_status="${pipeline_status[0]}"
 tee_status="${pipeline_status[1]}"
+filter_status="${pipeline_status[2]}"
 if [ "$tee_status" -ne 0 ]; then
   printf '%s\n' "Functional CI runner: diagnostic log writer failed with exit=$tee_status; tier failed closed." \
     | tee -a "$log_path" >&2
   exit "$tee_status"
+fi
+if [ "$filter_status" -ne 0 ]; then
+  printf '%s\n' "Functional CI runner: compact verdict filter failed with exit=$filter_status; tier failed closed." \
+    | tee -a "$log_path" >&2
+  exit "$filter_status"
 fi
 
 if [ "$command_status" -eq 124 ]; then

--- a/scripts/ci/unit-coverage-report.mjs
+++ b/scripts/ci/unit-coverage-report.mjs
@@ -47,6 +47,8 @@ const UNIT_COVERAGE_RENDER_OPTIONS = {
 	timingArtifactName: "unit-timing-summary.json",
 	slowestHeading: "Slowest unit tests",
 	includeEffectiveConcurrency: true,
+	includePackageDuration: true,
+	packageLimit: UNIT_COVERAGE_PACKAGE_LIMIT,
 };
 
 /**
@@ -76,7 +78,11 @@ export function renderUnitCoverageComment(summary, metadata = {}) {
  * the comment marker, which is only meaningful on a pull request thread.
  */
 export function renderUnitCoverageJobSummary(summary, metadata = {}) {
-	return renderCoverageReportBody(summary, { ...UNIT_COVERAGE_RENDER_OPTIONS, metadata });
+	return renderCoverageReportBody(summary, {
+		...UNIT_COVERAGE_RENDER_OPTIONS,
+		packageLimit: UNIT_COVERAGE_SUMMARY_PACKAGE_LIMIT,
+		metadata,
+	});
 }
 
 /**

--- a/scripts/ci/unit-coverage-report.test.mjs
+++ b/scripts/ci/unit-coverage-report.test.mjs
@@ -51,6 +51,9 @@ function timingArtifact() {
 		packageElapsedSecondsSum: 52.875,
 		packageCount: 2,
 		expectedPackageCount: 2,
+		packages: [
+			{ package: "pkg/ungated", seconds: 3.75, outcome: "fail" },
+		],
 		testCount: 3,
 		testFailCount: 1,
 		tests: [
@@ -60,6 +63,46 @@ function timingArtifact() {
 		],
 	};
 }
+
+test("retains measured partial packages with an explicit report-only floor and matching duration", () => {
+	const summary = summarizeUnitCoverage(
+		{
+			complete: false,
+			measurementReason: "unit test failed after the profile flushed",
+			coveredStatements: 2,
+			measurableStatements: 4,
+			coveragePercent: 50,
+			packages: [
+				{
+					package: "pkg/measured",
+					coveredStatements: 2,
+					measurableStatements: 4,
+					coveragePercent: 50,
+					packageFloor: null,
+				},
+			],
+		},
+		{
+			complete: false,
+			packages: [{ package: "pkg/measured", seconds: 3.75, outcome: "fail" }],
+			tests: [],
+		},
+	);
+
+	assert.deepEqual(summary.coverage.reportOnly, [
+		{
+			package: "pkg/measured",
+			coveragePercent: 50,
+			floor: null,
+			timing: { package: "pkg/measured", seconds: 3.75, outcome: "fail" },
+		},
+	]);
+	assert.equal(summary.coverage.gatedCount, 0);
+	const body = renderUnitCoverageJobSummary(summary);
+	assert.match(body, /Measured packages without a floor/);
+	assert.match(body, /`pkg\/measured` \| 50\.00 \| n\/a \(partial run\) \| report-only \| 3\.750/);
+	assert.doesNotMatch(body, /Headroom/);
+});
 
 test("orders gated packages by headroom ascending with violations first", () => {
 	const summary = summarizeUnitCoverage(coverageArtifact(), timingArtifact());

--- a/scripts/ci/unit-coverage-report.test.mjs
+++ b/scripts/ci/unit-coverage-report.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { BACKEND_LINT_COMMENT_MARKER } from "./backend-lint-report.mjs";
+import { renderCoverageReportBody } from "./coverage-report.mjs";
 import { FUNCTIONAL_COVERAGE_COMMENT_MARKER } from "./functional-coverage-comment.mjs";
 import {
 	UNIT_COVERAGE_COMMENT_MARKER,
@@ -99,9 +100,8 @@ test("retains measured partial packages with an explicit report-only floor and m
 	]);
 	assert.equal(summary.coverage.gatedCount, 0);
 	const body = renderUnitCoverageJobSummary(summary);
-	assert.match(body, /Measured packages without a floor/);
-	assert.match(body, /`pkg\/measured` \| 50\.00 \| n\/a \(partial run\) \| report-only \| 3\.750/);
-	assert.doesNotMatch(body, /Headroom/);
+	assert.match(body, /Package verdicts/);
+	assert.match(body, /`pkg\/measured` \| 50\.00 \| n\/a \(partial run\) \| n\/a \| report-only \| 3\.750 \| fail/);
 });
 
 test("orders gated packages by headroom ascending with violations first", () => {
@@ -217,13 +217,14 @@ test("renders a package table ordered by headroom, not by import path", () => {
 		summarizeUnitCoverage(coverageArtifact(), timingArtifact()),
 	);
 	assert.ok(body.includes("## Backend Unit Coverage"));
-	assert.ok(body.includes("| `pkg/regressed` | 40.00 | 70.00 | -30.00 |"));
-	assert.ok(body.indexOf("### Floor violations") < body.indexOf("### Closest to their floor"));
+	assert.ok(body.includes("| `pkg/regressed` | 40.00 | 70.00 | -30.00 | WARN |"));
+	assert.ok(body.includes("| `pkg/regressed` | 40.00 | 70.00 | -30.00 | WARN | unavailable | unavailable |"));
 	// pkg/near has 0.50 headroom and pkg/ample has 89.00, so headroom ordering
 	// puts pkg/near first even though pkg/ample sorts first by import path.
 	assert.ok(body.indexOf("`pkg/near`") < body.indexOf("`pkg/ample`"));
-	// A package held to the 0.00 lane-default floor cannot be close to failing.
-	assert.ok(!body.includes("`pkg/lane-default`"));
+	// Every measured package has one compact verdict row, including the package
+	// held to the 0.00 lane-default floor.
+	assert.ok(body.includes("`pkg/lane-default`"));
 });
 
 test("renders advisory policy and all retained floor and manifest diagnostics", () => {
@@ -236,6 +237,38 @@ test("renders advisory policy and all retained floor and manifest diagnostics", 
 	assert.match(body, /package coverage regression: package=pkg\/regressed/);
 	assert.match(body, /coverage manifest missing entry: package=pkg\/services\/example/);
 	assert.match(body, /coverage not evaluated: package=pkg\/unmeasured/);
+});
+
+test("suppresses uncovered source details in default unit Markdown while retaining the compact finding", () => {
+	const summary = summarizeUnitCoverage(
+		{
+			...coverageArtifact(),
+			packageFloorFindings: [
+				"package coverage regression: package=pkg/regressed; uncovered blocks: pkg/regressed/file.go:41 (2 statements); restore coverage",
+			],
+		},
+		timingArtifact(),
+	);
+	const body = renderUnitCoverageJobSummary(summary);
+	assert.ok(body.includes("package coverage regression: package=pkg/regressed; restore coverage"));
+	assert.ok(!body.includes("file.go:41 (2 statements)"));
+});
+
+test("renders uncovered source details only when explicitly enabled", () => {
+	const summary = summarizeUnitCoverage(
+		{
+			...coverageArtifact(),
+			packageFloorFindings: [
+				"package coverage regression: package=pkg/regressed; uncovered blocks: pkg/regressed/file.go:41 (2 statements); restore coverage",
+			],
+		},
+		timingArtifact(),
+	);
+	const body = renderCoverageReportBody(summary, {
+		heading: "Detailed coverage",
+		includeUncoveredDetails: true,
+	});
+	assert.ok(body.includes("file.go:41 (2 statements)"));
 });
 
 test("renders the slowest unit tests with real durations, ordered descending", () => {
@@ -322,7 +355,7 @@ test("states the omitted counts for every capped table instead of truncating sil
 	assert.equal(summary.timing.omitted, 7);
 
 	const body = renderUnitCoverageComment(summary);
-	assert.ok(body.includes("- 4 additional gated package(s) omitted."));
+	assert.ok(body.includes("- 4 additional package verdict(s) omitted."));
 	assert.ok(body.includes("- 7 additional row(s) omitted."));
 	assert.ok(!body.includes("`TestCase00`"));
 });
@@ -343,7 +376,7 @@ test("caps the violation table while reporting the true violation count", () => 
 
 	const body = renderUnitCoverageComment(summary);
 	assert.ok(body.includes(`- Floor violations: ${UNIT_COVERAGE_VIOLATION_LIMIT + 3}`));
-	assert.ok(body.includes("- 3 additional violation(s) omitted."));
+	assert.ok(body.includes("additional package verdict(s) omitted."));
 	// The worst regression is always kept; the mildest ones are dropped.
 	assert.ok(body.includes("`pkg/broken00`"));
 	assert.ok(!body.includes("`pkg/broken27`"));
@@ -379,7 +412,7 @@ test("the job summary carries more rows than the comment and omits the marker", 
 
 	assert.ok(!jobSummary.includes(UNIT_COVERAGE_COMMENT_MARKER));
 	assert.ok(jobSummary.startsWith("## Backend Unit Coverage"));
-	assert.ok(jobSummary.includes("- 2 additional gated package(s) omitted."));
+	assert.ok(jobSummary.includes("- 2 additional package verdict(s) omitted."));
 	assert.ok(jobSummary.includes("- 2 additional row(s) omitted."));
 	assert.equal(
 		jobSummary.split("\n").filter((line) => line.startsWith("| `pkg/p")).length,

--- a/scripts/ci/unit-coverage-report.test.mjs
+++ b/scripts/ci/unit-coverage-report.test.mjs
@@ -94,6 +94,7 @@ test("retains measured partial packages with an explicit report-only floor and m
 		{
 			package: "pkg/measured",
 			coveragePercent: 50,
+			held: false,
 			floor: null,
 			timing: { package: "pkg/measured", seconds: 3.75, outcome: "fail" },
 		},


### PR DESCRIPTION
{
  "project": "you-agent-factory",
  "branchName": "ci-coverage-report-terse-and-nonduplicated",
  "description": "Restore useful per-package coverage reporting on failed unit runs, make default unit and functional coverage diagnostics concise, and prevent the functional verdict pipeline from publishing the same verbose diagnostic block twice. Preserve coverage measurement, floor values, advisory policy, and exit behavior; do not touch cmd/functionalboundarycheck, floor manifests, the workflow policy setting, or the verdict publisher shell script.",
  "context": {
    "customerAsk": "When a backend unit test fails, keep measured package coverage and duration visible instead of rendering only timing; for both coverage lanes, print terse package verdicts by default with uncovered source-line detail available only by explicit opt-in; and ensure the functional verdict-report step does not duplicate verbose diagnostics from the coverage step.",
    "problem": "A failed unit run writes a trustworthy but incomplete coverage summary in which measured packages have packageFloor:null because manifest evaluation never ran. The shared renderer filters null-floor entries, so the cited artifact lost all 541 package coverage rows. Separately, advisory floors demote detailed package failures to warnings and write their multi-line uncovered-source blocks on ordinary runs. The functional verdict extractor classifies those verbose diagnostics as compact and saves them for a second publication step, producing byte-identical duplicate blocks.",
    "solution": "Report measured coverage independently from floor availability, explicitly label null floors as n/a for an incomplete run, and join exact-match unit package timings without suppressing coverage when timing is absent. Use one suite-agnostic compact diagnostic contract by default, gate uncovered source-line detail behind an explicit option that CI leaves off, and narrow functional verdict extraction to the compact inventory, policy, package verdict, tally, and terminal outcome records required for classification. Keep functional test-package durations separate from exercised production-package coverage because they are different package sets."
  },
  "acceptanceCriteria": [
    "A unit coverage run containing at least one failing test still publishes and renders every trustworthy measured package needed by the report with package name, coverage percentage, available package duration, and an explicit `floor: n/a (partial run)` state when no floor comparison occurred; the result is not a timing-only summary.",
    "Default unit and functional coverage output contains one concise line per reported package with package name, coverage percentage, floor state, and PASS/WARN/report-only status, plus duration where the lane measures the same package; it contains no per-source-line uncovered blocks. Functional-test package durations under tests/functional/... and exercised production-package coverage under pkg/... remain separate concise listings. Detailed uncovered-line output requires an explicit opt-in that CI leaves off.",
    "The functional coverage step and subsequent verdict-report step do not print the same diagnostic block twice; the saved verdict retains the compact inventory, policy, package verdict, tally, and terminal outcome required to classify the run while excluding verbose uncovered-line diagnostics and continuations.",
    "Coverage measurement, manifest evaluation, floor values, advisory-versus-blocking classification, and process exit behavior are unchanged. The lane does not modify cmd/functionalboundarycheck, advisory floor policy or its workflow setting, scripts/ci/publish-functional-coverage-verdict.sh, or any coverage-floor manifest entry.",
    "Runtime-proof classification: applicable because this lane changes runtime-observable CLI and CI-script output. Build the real delivered gocoveragecheck artifact, exercise a small unit package set containing a failing test, and exercise the functional coverage plus verdict extraction/publication flow end to end. Record the verbatim commands and outputs in a PR comment. The proof must show retained unit package coverage, terse default output with no uncovered source-line block, and no duplicate functional block; green tests, an inspected diff, or implementer assertions alone do not satisfy it.",
    "Quality gate: Typecheck passes; tests pass for the affected Go and Node reporting behavior; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. `make lint` is not required to pass end to end while the pkg-boundary target carries pre-existing packaged-service-structure migration debt recorded 2026-08-08.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "ci-coverage-report-terse-and-nonduplicated-001",
      "title": "Failed unit runs retain package coverage",
      "description": "As a contributor investigating a failed backend unit coverage job, I want the report to retain measured package coverage and timing even when floors were not evaluated, so the failure is diagnosable without reading a raw profile.",
      "acceptanceCriteria": [
        "Given a readable partial coverage profile produced before a unit-test failure, the coverage summary remains explicitly incomplete and contains each trustworthy measured package and its measured coverage percentage.",
        "The shared report renderer does not discard a measured package solely because packageFloor is null; it renders the package with its coverage percentage and `floor: n/a (partial run)` without assigning PASS, WARN, or headroom that implies floor evaluation occurred.",
        "When the timing artifact contains the same unit-test package, its package duration and outcome appear on that package's single terse report row; missing or incomplete timing is labeled unavailable rather than causing the coverage row to disappear.",
        "A regression fixture with at least one failing unit test produces a rendered report containing per-package coverage and duration information, not only the duration or slow-test section.",
        "Complete runs with real floors preserve their existing floor/headroom ordering and violation classification.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Partial coverage JSON already retained trustworthy measured packages; the shared renderer now preserves null-floor rows as report-only partial measurements and joins exact package durations. Focused Node and full cmd/gocoveragecheck tests pass."
    },
    {
      "id": "ci-coverage-report-terse-and-nonduplicated-002",
      "title": "Default diagnostics are compact",
      "description": "As a maintainer reading a unit or functional coverage run, I want one concise package verdict per measured production package and no source-line dump by default, so advisory findings remain actionable without overwhelming the job log.",
      "acceptanceCriteria": [
        "Default output for blocking and advisory runs reports each measured production package once with package name, coverage percentage, floor or n/a/report-only state, and PASS/WARN/report-only status.",
        "Default stderr, generated Markdown, and compact verdict artifacts do not contain multi-line uncovered-source detail such as `file.go:LINE (N statements)` continuations.",
        "Full uncovered-source detail is emitted only when the caller explicitly enables a clearly named diagnostic option; the option defaults off and existing CI invocations do not enable it.",
        "Enabling detailed diagnostics changes presentation only: coverage totals, package floors, advisory/blocking classification, JSON measurement data, and exit status match the same run without the option.",
        "Unit and functional lanes use the same suite-agnostic compact diagnostic rules; no duplicate unit-only or functional-only policy implementation is introduced.",
        "Focused tests prove compact default output and explicit opt-in detail for both advisory and blocking findings.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added shared compact diagnostics with -detailed-diagnostics opt-in, one PASS/WARN/report-only package verdict row per measured package, and separate package timing presentation for unit and functional reports. Coverage JSON measurements, floors, policy, and exit behavior remain unchanged; focused Go and CI-report tests, full scripts/ci tests, go vet, and typecheck pass."
    },
    {
      "id": "ci-coverage-report-terse-and-nonduplicated-003",
      "title": "Functional verdict publication is nonduplicating",
      "description": "As a contributor reading the functional coverage job, I want the coverage step and verdict-report step to publish complementary concise output, so I do not see the same diagnostic block twice.",
      "acceptanceCriteria": [
        "Functional verdict extraction retains the terminal suite inventory, advisory policy notice when applicable, concise package verdict rows, tally, and terminal coverage outcome needed by run classification.",
        "A verbose package-floor diagnostic and each indented or source-line continuation are not classified as compact verdict content and therefore are absent from functional-coverage-verdict.txt.",
        "Exercising the coverage step followed by the existing verdict-report publication produces no byte-identical repeated diagnostic block and no repeated package verdict line, while advisory-only runs remain successful and real test, gate, and infrastructure failures keep their existing outcomes.",
        "The final rendered state is concise for both lanes: unit-test packages show package coverage plus available package duration in one row; functional-test packages show durations under tests/functional/..., and exercised production packages show coverage under pkg/... in a separate terse listing.",
        "Tests directly cover null-floor partial rendering, default diagnostic suppression, explicit detailed-diagnostic opt-in, and rejection of verbose diagnostic lines by functional verdict extraction.",
        "Runtime-proof classification: applicable because this lane changes runtime-observable CLI and CI-script output. Build the real delivered gocoveragecheck artifact, exercise a small unit package set containing a failing test, and exercise the functional coverage plus verdict extraction/publication flow end to end. Record the verbatim commands and outputs in a PR comment. The proof must show retained unit package coverage, terse default output with no uncovered source-line block, and no duplicate functional block; tests or diff inspection alone are insufficient.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Narrowed functional verdict extraction to the terminal compact contract, deduplicated extracted records, and deferred those same compact lines from the runner's visible stream while retaining the full command log. Verbose floor/source diagnostics remain in the full log only. POSIX runner/publisher smoke tests pass; real gocoveragecheck unit-failure and functional coverage flows were exercised with retained partial measurements and one compact functional package row. Review follow-up formatting is gofmt-clean, the oversized main_run_test.go was split into a same-package repository-root test file, and final head 170e1019a was pushed after rebasing onto current origin/main and resolving coverage-verdict and functional-extractor conflicts. Staged floor holds remain compact status=HOLD rows and do not count as active failures. Main's independent coverage-floor failures and the current-head API-package test failure remain documented in the PR discussion; required checks started on the new head for review-stage terminal evaluation."
    }
  ]
}
