### PR TITLE
cov-floor-costs-edges

### DIFF
--- a/pkg/services/costs/transports/http/adapter_test.go
+++ b/pkg/services/costs/transports/http/adapter_test.go
@@ -179,3 +179,12 @@ func TestNewAdapterRejectsMissingQuery(t *testing.T) {
 		t.Fatalf("NewAdapter(nil) = %#v, want nil", got)
 	}
 }
+
+func TestAdapterRejectsNilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var adapter *Adapter
+	if _, err := adapter.GetMetricsCosts(context.Background(), "session-a"); err == nil || err.Error() != "Costs query is required" {
+		t.Fatalf("nil Adapter.GetMetricsCosts() error = %v, want missing-query error", err)
+	}
+}

--- a/pkg/services/costs/transports/http/handler_test.go
+++ b/pkg/services/costs/transports/http/handler_test.go
@@ -246,4 +246,52 @@ func TestHandlerMapsCanceledCostsQueryToRequestTimeout(t *testing.T) {
 	}
 }
 
+func TestUnavailableHandlerReturnsTypedInternalError(t *testing.T) {
+	t.Parallel()
+
+	var handler *Handler
+	recorder := httptest.NewRecorder()
+	handler.GetMetricsCosts(recorder, httptest.NewRequest(http.MethodGet, "/metrics/costs", nil), factoryapi.GetMetricsCostsParams{})
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", recorder.Code)
+	}
+	var response factoryapi.ErrorResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode unavailable response: %v", err)
+	}
+	if response.Family != factoryapi.ErrorFamilyInternalServerError || response.Code != factoryapi.ErrorResponseCode("INTERNAL_ERROR") || response.Message != "Costs handler is unavailable" {
+		t.Fatalf("unavailable response = %#v, want typed internal error", response)
+	}
+}
+
+func TestHandlerRejectsAlreadyCanceledRequestWithoutQuery(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	query := costs.CostsQuery(func(context.Context, costs.QueryRequest) (costs.Report, error) {
+		called = true
+		return costs.Report{Status: costs.StatusNoUsage}, nil
+	})
+	handler := NewHandler(NewAdapter(query, "metrics", "settings"), zap.NewNop())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	recorder := httptest.NewRecorder()
+	handler.GetMetricsCosts(recorder, httptest.NewRequest(http.MethodGet, "/metrics/costs", nil).WithContext(ctx), factoryapi.GetMetricsCostsParams{})
+
+	if called {
+		t.Fatal("canceled request invoked the Costs query")
+	}
+	if recorder.Code != http.StatusRequestTimeout {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusRequestTimeout)
+	}
+	var response factoryapi.ErrorResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode canceled request response: %v", err)
+	}
+	if response.Family != factoryapi.ErrorFamilyInternalServerError || response.Code != factoryapi.ErrorResponseCode("COSTS_QUERY_CANCELED") {
+		t.Fatalf("canceled request response = %#v, want typed cancellation", response)
+	}
+}
+
 func stringPointer(value string) *string { return &value }

--- a/pkg/services/edges/definition_test.go
+++ b/pkg/services/edges/definition_test.go
@@ -389,6 +389,69 @@ func TestMergeUsesCallerOwnedAgyPTYClock(t *testing.T) {
 	}
 }
 
+func TestMergeReplacesProcessEffectsAndPreservesDefaults(t *testing.T) {
+	t.Parallel()
+
+	defaultProviderRunner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{Stdout: []byte("provider-default")})
+	replacementProviderRunner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{Stdout: []byte("provider-replacement")})
+	defaultScriptRunner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{Stdout: []byte("script-default")})
+	replacementScriptRunner := testutil.NewProviderCommandRunner(platformprocess.CommandResult{Stdout: []byte("script-replacement")})
+	defaultClock := edgeProcessClock{now: time.Unix(100, 0)}
+	replacementClock := edgeProcessClock{now: time.Unix(200, 0)}
+	request := platformprocess.CommandRequest{Command: "injected-command"}
+
+	merged := Merge(
+		Edges{
+			ProviderCommandRunner: defaultProviderRunner,
+			ScriptCommandRunner:   defaultScriptRunner,
+			PlatformProcessClock:  defaultClock,
+		},
+		Edges{
+			ProviderCommandRunner: replacementProviderRunner,
+			ScriptCommandRunner:   replacementScriptRunner,
+			PlatformProcessClock:  replacementClock,
+		},
+	)
+	assertMergedCommandResult(t, merged.ProviderCommandRunner, request, "provider-replacement")
+	assertMergedCommandResult(t, merged.ScriptCommandRunner, request, "script-replacement")
+	if got := merged.PlatformProcessClock.Now(); !got.Equal(replacementClock.Now()) {
+		t.Fatalf("merged process clock time = %v, want replacement time %v", got, replacementClock.Now())
+	}
+	if defaultProviderRunner.CallCount() != 0 || defaultScriptRunner.CallCount() != 0 {
+		t.Fatal("merged replacements executed a default command runner")
+	}
+
+	preserved := Merge(
+		Edges{
+			ProviderCommandRunner: defaultProviderRunner,
+			ScriptCommandRunner:   defaultScriptRunner,
+			PlatformProcessClock:  defaultClock,
+		},
+		Edges{},
+	)
+	assertMergedCommandResult(t, preserved.ProviderCommandRunner, request, "provider-default")
+	assertMergedCommandResult(t, preserved.ScriptCommandRunner, request, "script-default")
+	if got := preserved.PlatformProcessClock.Now(); !got.Equal(defaultClock.Now()) {
+		t.Fatalf("preserved process clock time = %v, want default time %v", got, defaultClock.Now())
+	}
+}
+
+func assertMergedCommandResult(t *testing.T, runner platformprocess.CommandRunner, request platformprocess.CommandRequest, want string) {
+	t.Helper()
+	result, err := runner.Run(context.Background(), request)
+	if err != nil || string(result.Stdout) != want {
+		t.Fatalf("merged command result = (%q, %v), want (%q, nil)", result.Stdout, err, want)
+	}
+}
+
+type edgeProcessClock struct {
+	now time.Time
+}
+
+func (clock edgeProcessClock) Now() time.Time { return clock.now }
+
+func (edgeProcessClock) After(time.Duration) <-chan time.Time { return nil }
+
 func TestMergeAppendsAndDetachesProviderRegistrations(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
{
  "project": "Recover Costs HTTP and Edges Unit Coverage Floors",
  "branchName": "cov-floor-costs-edges",
  "description": "Restore blocking unit-coverage compliance for the Costs HTTP transport and process-edge aggregator with meaningful tests of typed HTTP outcomes and exact external-effect replacement behavior, without changing production behavior or weakening coverage policy.",
  "context": {
    "customerAsk": "Raise pkg/services/costs/transports/http from the operator-measured 86.7% unit coverage to at least 87.3% and pkg/services/edges from 71.4% to at least 71.65% using package-owned behavior-driven unit tests, while preserving blocking enforcement and avoiding all sibling-lane packages.",
    "problem": "The packages drifted below their recorded unit floors while enforcement was advisory under PR #2153. PR #2163 restored blocking enforcement, so Backend Unit Coverage and the derived Verification Policy fail on current main.",
    "solution": "Add focused unit tests through exported Costs HTTP and Edges contracts, rebase immediately before the final push, run the unit coverage instrument through package-floor adjudication, and report fresh before/after percentages without lowering floors or changing policy."
  },
  "acceptanceCriteria": [
    "Fresh make test-unit-coverage output measures pkg/services/costs/transports/http at or above 87.3% and pkg/services/edges at or above 71.65%; the command reaches package-floor measurement rather than failing earlier, and the PR body quotes the operator baseline and fresh after percentages.",
    "New tests exercise customer/operator-observable Costs HTTP outcomes and exact external-effect replacement behavior; private-helper-only, source-inventory, route-inventory, registration-inventory, and other meta-tests do not count as recovery evidence.",
    "The diff stays within pkg/services/costs/transports/http, pkg/services/edges, and their package-owned _test.go files, except for an in-scope reconciliation of only these two existing coverage-manifest entries if current origin/main requires it; neither floor is lowered, no other package entry or production policy changes, and docs/internal/baselines/deadcode-baseline.txt is untouched.",
    "Runtime-proof classification: Not applicable—this lane changes only automated regression coverage and does not change CLI, API, UI, emitted-event, or runtime-lifecycle behavior.",
    "Final quality gate: Typecheck passes; Tests pass, including focused package tests and a completed make test-unit-coverage; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "cov-floor-costs-edges-001",
      "title": "Cover typed Costs HTTP boundary outcomes",
      "description": "As an API operator, I want the Costs HTTP boundary's existing availability, cancellation, and request-normalization behavior protected so malformed or interrupted requests continue to produce the documented typed outcomes.",
      "acceptanceCriteria": [
        "Package-owned unit tests exercise previously uncovered public handler or adapter paths through exported entry points, including at least one typed error response and its HTTP status, error family, and code, without directly testing a private helper as the asserted behavior.",
        "Tests confirm that the Costs query receives the normalized request scope and that unavailable or already-canceled operation paths do not invoke an unintended side effect.",
        "Existing successful report mapping, timeout, invalid-input, and internal-failure behavior remains unchanged.",
        "Focused go test ./pkg/services/costs/transports/http passes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added exported-boundary tests for nil Adapter rejection, unavailable Handler typed internal errors, and pre-canceled requests suppressing the injected Costs query. Focused go test passes; direct package coverage is 91.4%, above the 87.3% floor."
    },
    {
      "id": "cov-floor-costs-edges-002",
      "title": "Cover exact process-edge replacement behavior",
      "description": "As a process builder or functional-test author, I want caller-supplied external-effect ports to replace their defaults exactly while omitted replacements preserve production defaults, so tests and hosts can control side effects without a service locator or hidden state.",
      "acceptanceCriteria": [
        "Package-owned unit tests invoke representative previously uncovered edges.Merge outcomes and prove that a non-zero caller replacement is the effect returned and executed by the merged aggregate.",
        "The same behavioral cell proves that an omitted replacement preserves the corresponding default, with independent values so accidental replacement or loss is observable.",
        "Tests cover exact injected ports or cohesive value fields and do not assert a command or field inventory, scan source topology, or duplicate sibling-lane package behavior.",
        "Slice-valued replacement coverage, if used, proves detached ownership so later caller mutation cannot change the merged result.",
        "Focused go test ./pkg/services/edges passes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added a package-owned behavioral test covering ProviderCommandRunner, ScriptCommandRunner, and PlatformProcessClock replacement and omitted-default paths. Replacement command results are executed and independent defaults are executed when replacements are absent. Focused go test passes; direct package coverage is 71.9%, above the 71.65% floor."
    },
    {
      "id": "cov-floor-costs-edges-003",
      "title": "Prove both floors on current main and prepare delivery",
      "description": "As the implementation-stage owner, I want a fresh, current-main coverage measurement and conflict reconciliation so reviewers receive trustworthy evidence that both owned packages clear their blocking floors without weakening policy or clobbering sibling work.",
      "acceptanceCriteria": [
        "Immediately before the final push, rebase onto current origin/main, resolve shared-file conflicts without changing any package or coverage entry outside this lane, and verify the two owned manifest floors remain at least 87.3% and 71.65% respectively.",
        "Run make test-unit-coverage to completed package-floor adjudication and record the verbatim command plus the before/after percentages for both packages in the PR body; absence of property-specific output or an earlier test failure is not passing evidence.",
        "The final diff contains no floor reduction, policy relaxation, functional-suite expansion, unrelated cleanup, sibling-lane duplication, or change to docs/internal/baselines/deadcode-baseline.txt.",
        "Runtime-proof classification: Not applicable—this lane changes only automated regression coverage and does not change CLI, API, UI, emitted-event, or runtime-lifecycle behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Rebased cleanly onto current origin/main; final diff remains limited to the three package-owned test files and both manifest floors remain 87.30% and 71.65%. On the rebased head, the verbatim `make test-unit-coverage` command reached completed package-floor adjudication and measured Costs HTTP at 92.4% (operator baseline 86.7%) and Edges at 71.9% (operator baseline 71.4%). The command exits on existing out-of-scope regressions in unrelated packages; focused tests, make test, typecheck, backend-size, pkg-maint, pkg-file-count, pkg-structure, and vet pass. Full lint has one unchanged baseline packaged-factory-consumption-check violation in internal/migrationledgercheck/packaged_factory_matrix.go."
    }
  ]
}
