### PR TITLE
Coverage floors become hard blockers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
       # so adding a package does not require a manifest edit.
       #
       # Do not reintroduce an advisory override here.
-    strategy:
+      strategy:
       fail-fast: false
       matrix:
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
       # so adding a package does not require a manifest edit.
       #
       # Do not reintroduce an advisory override here.
-      strategy:
+    strategy:
       fail-fast: false
       matrix:
         include:

--- a/Makefile
+++ b/Makefile
@@ -698,8 +698,8 @@ test-coverage-go:
 # is forwarded only when it is set, so an invocation with none of them set runs
 # exactly the command it ran before reporting existed. Setting the JSON or
 # timing path never changes the gate: gocoveragecheck's exit code stays the sole
-# pass/fail signal. Floor policy defaults to blocking for local callers; hosted
-# CI sets GO_COVERAGE_FLOOR_POLICY=advisory for both coverage lanes.
+# pass/fail signal. Both local callers and hosted CI inherit the blocking
+# default; a manifest floor hold is the only lane-scoped staged exception.
 test-unit-coverage:
 	$(GO) run ./cmd/gocoveragecheck -suite unit -min $(GO_UNIT_COVERAGE_MIN) -package-manifest $(GO_UNIT_COVERAGE_MANIFEST) -package-floor-policy $(GO_COVERAGE_FLOOR_POLICY) -timeout $(GO_COVERAGE_TIMEOUT) $(if $(GO_UNIT_COVERAGE_PROFILE),-profile $(GO_UNIT_COVERAGE_PROFILE),) $(if $(GO_UNIT_COVERAGE_JSON_OUTPUT),-json-output $(GO_UNIT_COVERAGE_JSON_OUTPUT),) $(if $(GO_UNIT_COVERAGE_TIMING_OUTPUT),-timing-output $(GO_UNIT_COVERAGE_TIMING_OUTPUT),)
 

--- a/cmd/contractscheck/main_test.go
+++ b/cmd/contractscheck/main_test.go
@@ -240,6 +240,14 @@ func snapshotCommandTree(
 			return err
 		}
 		if entry.IsDir() {
+			// Git may create or remove transient administrative files (for
+			// example .git/objects/maintenance.lock) asynchronously after the
+			// fixture is initialized. Those files are outside the worktree that
+			// run is required to leave unchanged and would make this snapshot
+			// assertion flaky.
+			if path != root && filepath.Base(path) == ".git" {
+				return fs.SkipDir
+			}
 			return nil
 		}
 		relative, err := filepath.Rel(root, path)

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -428,7 +428,14 @@ func configureFunctionalTimingSnapshot(plan *coverageInvocationPlan, cfg config,
 		sink,
 		sinkMu,
 		func() error {
-			return writePartialCoverageSnapshot(cfg.jsonOutput, profilePath, repoRoot, coverPackages, partialCoverageReason(nil))
+			return writePartialCoverageSnapshot(
+				cfg.jsonOutput,
+				profilePath,
+				repoRoot,
+				coverPackages,
+				cfg.packageFloorPolicyValue(),
+				partialCoverageReason(nil),
+			)
 		},
 	)
 	snapshotter.publish(false, coverageLaneNoun(cfg.suite)+" run started", false)
@@ -494,6 +501,7 @@ func publishPartialCoverageIfNeeded(cfg config, profilePath string, repoRoot str
 		profilePath,
 		repoRoot,
 		coverPackages,
+		cfg.packageFloorPolicyValue(),
 		partialCoverageReason(errors.Join(laneErr, mergeErr)),
 	)
 }

--- a/cmd/gocoveragecheck/coverage_json.go
+++ b/cmd/gocoveragecheck/coverage_json.go
@@ -23,21 +23,24 @@ type coverageSummaryJSON struct {
 }
 
 // packageCoverageJSON reports one measured production package, including the
-// package-gate floor or measurement exception used for that run.
+// package-gate floor, staged hold, or measurement exception used for that run.
 type packageCoverageJSON struct {
 	Package              string                     `json:"package"`
 	CoveredStatements    int                        `json:"coveredStatements"`
 	MeasurableStatements int                        `json:"measurableStatements"`
 	CoveragePercent      float64                    `json:"coveragePercent"`
 	PackageFloor         *float64                   `json:"packageFloor"`
+	PackageFloorHeld     bool                       `json:"packageFloorHeld,omitempty"`
 	MeasurementException *coverageManifestException `json:"measurementException"`
 }
 
 // packageCoverageGate is the package-local floor or exception policy applied
 // during a coverage run. Exactly one of Floor or Exception is set when a gate
-// applies; both remain nil when the package is ungated for that run.
+// applies; FloorHold optionally scopes enforcement for a measured baseline
+// finding. Both Floor and Exception remain nil when the package is ungated.
 type packageCoverageGate struct {
 	Floor     *float64
+	FloorHold *coverageManifestFloorHold
 	Exception *coverageManifestException
 }
 
@@ -86,6 +89,7 @@ func buildPackageCoverageJSON(result coverageResult) []packageCoverageJSON {
 			MeasurableStatements: totals.totalStatements,
 			CoveragePercent:      roundCoveragePercent(summary.coverage),
 			PackageFloor:         gate.Floor,
+			PackageFloorHeld:     gate.FloorHold != nil,
 			MeasurementException: cloneCoverageManifestException(gate.Exception),
 		}
 		packages = append(packages, entry)
@@ -114,8 +118,17 @@ func cloneCoverageManifestException(exception *coverageManifestException) *cover
 	return &cloned
 }
 
+func cloneCoverageManifestFloorHold(hold *coverageManifestFloorHold) *coverageManifestFloorHold {
+	if hold == nil {
+		return nil
+	}
+	cloned := *hold
+	return &cloned
+}
+
 func packageGatesFromManifest(manifest coverageManifest) map[string]packageCoverageGate {
 	gates := make(map[string]packageCoverageGate, len(manifest.Packages))
+	holds := coverageManifestFloorHoldMap(manifest)
 	for _, entry := range manifest.Packages {
 		if entry.Exception != nil {
 			gates[entry.Package] = packageCoverageGate{
@@ -129,7 +142,11 @@ func packageGatesFromManifest(manifest coverageManifest) map[string]packageCover
 			continue
 		}
 		percent := float64(floor) / 100
-		gates[entry.Package] = packageCoverageGate{Floor: &percent}
+		gate := packageCoverageGate{Floor: &percent}
+		if hold, held := holds[entry.Package]; held {
+			gate.FloorHold = cloneCoverageManifestFloorHold(&hold)
+		}
+		gates[entry.Package] = gate
 	}
 	return gates
 }

--- a/cmd/gocoveragecheck/coverage_json_test.go
+++ b/cmd/gocoveragecheck/coverage_json_test.go
@@ -241,6 +241,52 @@ func TestExecuteJSONReportsPackageFloorsFromManifest(t *testing.T) {
 	}
 }
 
+func TestExecuteJSONReportsHeldFloorWithoutDisablingBlockingPolicy(t *testing.T) {
+	_, stderr := stubCoverageExecute(t, fakeGoCoverageCommandWithMeasuredZeroConfig)
+
+	configPackage := modulePath + "/pkg/config"
+	manifestPath := writePackageMinimumManifestWithEntries(t, "unit", []manifestPackageSpec{
+		{
+			importPath: configPackage,
+			minimum:    "80.00",
+			floorHold: &coverageManifestFloorHold{
+				Justification: "The current-main baseline is below the existing unit floor while matching-lane tests are restored.",
+				Owner:         "coverage-remediation",
+				Deadline:      "2027-07-15",
+				RemovalGate:   "Matching unit coverage reaches the existing floor and this hold is removed.",
+			},
+		},
+	})
+	jsonPath := filepath.Join(t.TempDir(), "coverage-summary.json")
+
+	err := execute(config{
+		suite:           "unit",
+		min:             0,
+		coverpkg:        configPackage,
+		packages:        "./pkg/config",
+		packageManifest: manifestPath,
+		jsonOutput:      jsonPath,
+	})
+	if err != nil {
+		t.Fatalf("execute() error = %v, want the staged hold to keep the blocking lane green", err)
+	}
+	if strings.Contains(stderr.String(), "COVERAGE FLOOR POLICY: advisory") || strings.Contains(stderr.String(), "report-only") {
+		t.Fatalf("held blocking run emitted advisory policy guidance: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "package coverage hold: package="+configPackage) ||
+		!strings.Contains(stderr.String(), "expected-minimum=80.00% actual=0.0000% delta=-80.0000 percentage-points") {
+		t.Fatalf("held blocking run lost the complete remediation diagnostic: %q", stderr.String())
+	}
+
+	summary := readCoverageSummaryJSONFile(t, jsonPath)
+	if summary.PackageFloorPolicy != coverageFloorPolicyBlocking {
+		t.Fatalf("packageFloorPolicy = %q, want blocking", summary.PackageFloorPolicy)
+	}
+	if len(summary.Packages) != 1 || !summary.Packages[0].PackageFloorHeld {
+		t.Fatalf("package floor hold = %+v, want one held package", summary.Packages)
+	}
+}
+
 func TestExecuteJSONReportsMeasurementExceptionFromManifest(t *testing.T) {
 	_, stderr := stubCoverageExecute(t, fakeGoCoverageCommandPassing)
 
@@ -611,6 +657,7 @@ type manifestPackageSpec struct {
 	importPath string
 	minimum    string
 	exception  *coverageManifestException
+	floorHold  *coverageManifestFloorHold
 }
 
 func stubCoverageExecute(t *testing.T, runner commandRunnerFunc) (stdout *bytes.Buffer, stderr *bytes.Buffer) {
@@ -675,7 +722,17 @@ func writePackageMinimumManifestWithEntries(t *testing.T, lane string, entries [
 	t.Helper()
 	manifestPath := filepath.Join(t.TempDir(), lane+"-minimums.json")
 	var packageBlocks []string
+	var floorHoldBlocks []string
 	for _, entry := range entries {
+		if entry.floorHold != nil {
+			floorHoldBlocks = append(floorHoldBlocks, fmt.Sprintf(`    {
+      "package": %q,
+      "justification": %q,
+      "owner": %q,
+      "deadline": %q,
+      "removalGate": %q
+    }`, entry.importPath, entry.floorHold.Justification, entry.floorHold.Owner, entry.floorHold.Deadline, entry.floorHold.RemovalGate))
+		}
 		if entry.exception != nil {
 			packageBlocks = append(packageBlocks, fmt.Sprintf(`    {
       "package": %q,
@@ -694,7 +751,11 @@ func writePackageMinimumManifestWithEntries(t *testing.T, lane string, entries [
       "minimum": %s
     }`, entry.importPath, entry.minimum))
 	}
-	data := fmt.Sprintf("{\n  \"version\": 1,\n  \"lane\": %q,\n  \"packages\": [\n%s\n  ]\n}\n", lane, strings.Join(packageBlocks, ",\n"))
+	floorHolds := ""
+	if len(floorHoldBlocks) > 0 {
+		floorHolds = fmt.Sprintf("\n  \"floorHolds\": [\n%s\n  ],", strings.Join(floorHoldBlocks, ",\n"))
+	}
+	data := fmt.Sprintf("{\n  \"version\": 1,\n  \"lane\": %q,%s\n  \"packages\": [\n%s\n  ]\n}\n", lane, floorHolds, strings.Join(packageBlocks, ",\n"))
 	if err := os.WriteFile(manifestPath, []byte(data), 0o600); err != nil {
 		t.Fatalf("write package minimum manifest: %v", err)
 	}

--- a/cmd/gocoveragecheck/coverage_json_test.go
+++ b/cmd/gocoveragecheck/coverage_json_test.go
@@ -530,6 +530,78 @@ func TestExecuteWritesIncompleteJSONWhenMeasurementFailsWithProfile(t *testing.T
 	}
 }
 
+func TestExecuteFailedTestsDoNotEvaluatePackageFloors(t *testing.T) {
+	stdout, stderr := stubCoverageExecute(t, fakeGoCoverageCommandTestFailsWithObservedFailures)
+	configPackage := modulePath + "/pkg/config"
+	manifestPath := writePackageMinimumManifest(t, "unit", configPackage, "80.00")
+	outputDir := t.TempDir()
+	jsonPath := filepath.Join(outputDir, "coverage-summary.json")
+
+	err := execute(config{
+		suite:              "unit",
+		min:                0,
+		packageFloorPolicy: coverageFloorPolicyBlocking,
+		packageManifest:    manifestPath,
+		coverpkg:           configPackage,
+		packages:           "./pkg/config",
+		profile:            filepath.Join(outputDir, "coverage.out"),
+		jsonOutput:         jsonPath,
+	})
+	if err == nil {
+		t.Fatal("execute() unexpectedly succeeded for failed coverage tests")
+	}
+	if strings.Contains(err.Error(), "package coverage regression") {
+		t.Fatalf("execute() reclassified failed tests as a floor regression: %v", err)
+	}
+	wantDiagnostic := "coverage not evaluated: 2 failed tests observed; package floors were NOT checked because the coverage test run failed"
+	if got := stderr.String(); !strings.Contains(got, wantDiagnostic) {
+		t.Fatalf("execute() stderr = %q, want failed-test diagnostic containing %q", got, wantDiagnostic)
+	}
+	if strings.Contains(stdout.String(), "meets minimum") {
+		t.Fatalf("execute() stdout = %q, did not expect aggregate success", stdout.String())
+	}
+
+	summary := readCoverageSummaryJSONFile(t, jsonPath)
+	if summary.Complete {
+		t.Fatal("failed-test coverage summary marked complete")
+	}
+	if summary.PackageFloorPolicy != coverageFloorPolicyBlocking {
+		t.Fatalf("packageFloorPolicy = %q, want active blocking policy", summary.PackageFloorPolicy)
+	}
+	if len(summary.PackageFloorFindings) != 0 {
+		t.Fatalf("packageFloorFindings = %v, want floors not evaluated", summary.PackageFloorFindings)
+	}
+	if len(summary.ManifestDiagnostics) != 0 {
+		t.Fatalf("manifestDiagnostics = %v, want no manifest findings from an incomplete run", summary.ManifestDiagnostics)
+	}
+}
+
+func TestExecuteIncompleteJSONRetainsAdvisoryPolicy(t *testing.T) {
+	stubCoverageExecute(t, fakeGoCoverageCommandTestFailsWithoutDetail)
+	outputDir := t.TempDir()
+	jsonPath := filepath.Join(outputDir, "coverage-summary.json")
+
+	err := execute(config{
+		suite:              "unit",
+		packageFloorPolicy: coverageFloorPolicyAdvisory,
+		coverpkg:           modulePath + "/pkg/config",
+		packages:           "./pkg/config",
+		profile:            filepath.Join(outputDir, "coverage.out"),
+		jsonOutput:         jsonPath,
+	})
+	if err == nil {
+		t.Fatal("execute() unexpectedly succeeded for failed coverage tests")
+	}
+
+	summary := readCoverageSummaryJSONFile(t, jsonPath)
+	if summary.PackageFloorPolicy != coverageFloorPolicyAdvisory {
+		t.Fatalf("packageFloorPolicy = %q, want active advisory policy", summary.PackageFloorPolicy)
+	}
+	if len(summary.PackageFloorFindings) != 0 {
+		t.Fatalf("packageFloorFindings = %v, want floors not evaluated", summary.PackageFloorFindings)
+	}
+}
+
 func TestExecuteFloorFailureWithoutJSONOptionKeepsHumanDiagnostics(t *testing.T) {
 	originalCommandRunner := commandRunner
 	originalStdout := stdoutWriter

--- a/cmd/gocoveragecheck/coverage_partial.go
+++ b/cmd/gocoveragecheck/coverage_partial.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-func writePartialCoverageSnapshot(path, profilePath, repoRoot string, coverPackages []string, reason string) error {
+func writePartialCoverageSnapshot(path, profilePath, repoRoot string, coverPackages []string, packageFloorPolicy string, reason string) error {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return nil
@@ -18,6 +18,7 @@ func writePartialCoverageSnapshot(path, profilePath, repoRoot string, coverPacka
 		// inventory name this coverage item as unavailable instead.
 		return nil
 	}
+	result.packageFloorPolicy = packageFloorPolicy
 	return writeCoverageSummaryJSONWithStatus(path, result, false, reason)
 }
 

--- a/cmd/gocoveragecheck/coverage_verdict.go
+++ b/cmd/gocoveragecheck/coverage_verdict.go
@@ -22,6 +22,7 @@ const nearFloorCoverageHeadroomPoints = 2.0
 type packageCoverageVerdict struct {
 	importPath      string
 	hasFloor        bool
+	held            bool
 	floor           float64
 	actual          float64
 	headroom        float64
@@ -85,11 +86,12 @@ func writePackageCoverageSummaries(summaries []packageCoverageSummary) {
 // writeCoverageVerdict renders one lane's ordered verdict block.
 func writeCoverageVerdict(label string, result coverageResult, failures []string) {
 	verdicts := collectPackageCoverageVerdicts(result)
-	belowFloor, nearFloor := partitionPackageCoverageVerdicts(verdicts)
+	belowFloor, heldFloor, nearFloor := partitionPackageCoverageVerdicts(verdicts)
 	slices.SortStableFunc(verdicts, comparePackageCoverageVerdicts)
 
 	fmt.Fprintf(stdoutWriter, "%s package coverage verdict:\n", label)
 	writeBelowFloorCoverageLines(belowFloor)
+	writeHeldCoverageLines(heldFloor)
 	for _, verdict := range verdicts {
 		writePackageCoverageVerdictLine(verdict, coverageLaneNoun(label))
 	}
@@ -124,6 +126,22 @@ func writeBelowFloorCoverageLines(belowFloor []packageCoverageVerdict) {
 	}
 }
 
+func writeHeldCoverageLines(heldFloor []packageCoverageVerdict) {
+	for _, verdict := range heldFloor {
+		fmt.Fprintf(
+			stdoutWriter,
+			"  floor hold: package=%s floor=%.4f%% actual=%.4f%% delta=%+.4f percentage-points covered=%d/%d statements uncovered-blocks=%d\n",
+			verdict.importPath,
+			verdict.floor,
+			verdict.actual,
+			verdict.headroom,
+			verdict.covered,
+			verdict.measurable,
+			verdict.uncoveredBlocks,
+		)
+	}
+}
+
 func writePackageCoverageVerdictLine(verdict packageCoverageVerdict, lane string) {
 	if !verdict.hasFloor {
 		fmt.Fprintf(
@@ -139,6 +157,9 @@ func writePackageCoverageVerdictLine(verdict packageCoverageVerdict, lane string
 	gate := "pass"
 	if verdict.measurable > 0 && verdict.headroom < 0 {
 		gate = "fail"
+		if verdict.held {
+			gate = "hold"
+		}
 	}
 	fmt.Fprintf(
 		stdoutWriter,
@@ -170,6 +191,7 @@ func collectPackageCoverageVerdicts(result coverageResult) []packageCoverageVerd
 		}
 		if gate.Floor != nil {
 			verdict.hasFloor = true
+			verdict.held = gate.FloorHold != nil
 			verdict.floor = *gate.Floor
 			verdict.headroom = verdict.actual - verdict.floor
 		}
@@ -178,17 +200,19 @@ func collectPackageCoverageVerdicts(result coverageResult) []packageCoverageVerd
 	return verdicts
 }
 
-// partitionPackageCoverageVerdicts splits verdicts into below-floor packages
-// and passing packages within the near-floor band for the established
-// diagnostics and tally. Report-only and vacuously passing packages do not
-// participate in either count. Both returned groups are ordered by headroom
-// ascending with import path as the deterministic tiebreak.
+// partitionPackageCoverageVerdicts splits verdicts into active below-floor
+// packages, staged floor holds, and passing packages within the near-floor
+// band for the established diagnostics and tally. Report-only, held, and
+// vacuously passing packages do not participate in the active failure or
+// near-floor counts. All returned groups are ordered by headroom ascending
+// with import path as the deterministic tiebreak.
 //
 // A zero floor is excluded from the near-floor band: coverage is never
 // negative, so a package sitting on a 0% floor cannot regress through it and
 // naming it would crowd out the packages that can.
-func partitionPackageCoverageVerdicts(verdicts []packageCoverageVerdict) (belowFloor, nearFloor []packageCoverageVerdict) {
+func partitionPackageCoverageVerdicts(verdicts []packageCoverageVerdict) (belowFloor, heldFloor, nearFloor []packageCoverageVerdict) {
 	belowFloor = make([]packageCoverageVerdict, 0)
+	heldFloor = make([]packageCoverageVerdict, 0)
 	nearFloor = make([]packageCoverageVerdict, 0)
 	for _, verdict := range verdicts {
 		if !verdict.hasFloor || verdict.measurable <= 0 {
@@ -196,14 +220,19 @@ func partitionPackageCoverageVerdicts(verdicts []packageCoverageVerdict) (belowF
 		}
 		switch {
 		case verdict.headroom < 0:
-			belowFloor = append(belowFloor, verdict)
+			if verdict.held {
+				heldFloor = append(heldFloor, verdict)
+			} else {
+				belowFloor = append(belowFloor, verdict)
+			}
 		case verdict.floor > 0 && verdict.headroom <= nearFloorCoverageHeadroomPoints:
 			nearFloor = append(nearFloor, verdict)
 		}
 	}
 	slices.SortStableFunc(belowFloor, comparePackageCoverageHeadroom)
+	slices.SortStableFunc(heldFloor, comparePackageCoverageHeadroom)
 	slices.SortStableFunc(nearFloor, comparePackageCoverageHeadroom)
-	return belowFloor, nearFloor
+	return belowFloor, heldFloor, nearFloor
 }
 
 func comparePackageCoverageVerdicts(left packageCoverageVerdict, right packageCoverageVerdict) int {

--- a/cmd/gocoveragecheck/coverage_verdict_test.go
+++ b/cmd/gocoveragecheck/coverage_verdict_test.go
@@ -120,6 +120,41 @@ func TestFunctionalCoverageVerdictOrdersViolationsBeforeNearFloorAndTally(t *tes
 	}
 }
 
+func TestFunctionalCoverageVerdictNamesHeldFloorWithoutCallingItAnActiveViolation(t *testing.T) {
+	jsonPath := filepath.Join(t.TempDir(), "coverage-summary.json")
+	configPackage := modulePath + "/pkg/config"
+	manifestPath := writePackageMinimumManifestWithEntries(t, "functional", []manifestPackageSpec{
+		{
+			importPath: configPackage,
+			minimum:    "80.00",
+			floorHold: &coverageManifestFloorHold{
+				Justification: "current-main baseline is being restored",
+				Owner:         "coverage-remediation",
+				Deadline:      "2027-07-15",
+				RemovalGate:   "matching functional tests restore the existing floor",
+			},
+		},
+		{importPath: modulePath + "/pkg/service", minimum: "89.00"},
+		{importPath: modulePath + "/pkg/wire", minimum: "50.00"},
+	})
+
+	stdout, stderr, err := captureFunctionalVerdictRun(t, functionalVerdictConfig(manifestPath, jsonPath))
+	if err != nil {
+		t.Fatalf("execute() error = %v, want the staged hold to keep the blocking lane green; stdout=%s stderr=%s", err, stdout, stderr)
+	}
+	if strings.Contains(stderr, "advisory") || strings.Contains(stderr, "report-only") {
+		t.Fatalf("blocking staged run emitted advisory guidance: %s", stderr)
+	}
+	if !strings.Contains(stdout, "  floor violations: none\n") ||
+		!strings.Contains(stdout, "  floor hold: package="+configPackage) ||
+		!strings.Contains(stdout, "gate=hold lane=functional\n") {
+		t.Fatalf("verdict did not distinguish the held package from active violations:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "below-floor=0 near-floor=1 gate-failures=0") {
+		t.Fatalf("verdict tally treated the held package as an active failure:\n%s", stdout)
+	}
+}
+
 func TestFunctionalCoverageRunSuppressesPerPackageCoverageLines(t *testing.T) {
 	jsonPath := filepath.Join(t.TempDir(), "coverage-summary.json")
 	cfg := functionalVerdictConfig(functionalVerdictManifest(t, "80.00"), jsonPath)

--- a/cmd/gocoveragecheck/functional_diagnostics_test.go
+++ b/cmd/gocoveragecheck/functional_diagnostics_test.go
@@ -114,6 +114,7 @@ func TestWritePartialCoverageSnapshotSkipsUntrustworthyProfile(t *testing.T) {
 		filepath.Join(t.TempDir(), "missing-coverage.out"),
 		".",
 		[]string{modulePath + "/pkg/config"},
+		coverageFloorPolicyBlocking,
 		"tier budget expired",
 	)
 	if err != nil {

--- a/cmd/gocoveragecheck/main_entrypoint_test.go
+++ b/cmd/gocoveragecheck/main_entrypoint_test.go
@@ -255,6 +255,29 @@ func TestMainPackageFloorPolicyAdvisoryReportsRegressionAndBlockingRestoresEnfor
 	}
 }
 
+func TestMainDefaultPackageFloorPolicyBlocksRegression(t *testing.T) {
+	configPackage := modulePath + "/pkg/config"
+	manifestPath := writePackageMinimumManifest(t, "unit", configPackage, "80.00")
+	stdout, stderr, exitCode := runMainForTest(t, []string{
+		"-min=0",
+		"-suite=unit",
+		"-package-manifest=" + manifestPath,
+		"-coverpkg=" + configPackage,
+		"-packages=./pkg/config",
+	}, fakeGoCoverageCommandWithMeasuredZeroConfig)
+
+	if exitCode != 1 {
+		t.Fatalf("main() default policy exit code = %d, want 1; stdout=%q stderr=%q", exitCode, stdout, stderr)
+	}
+	if strings.Contains(stderr, "COVERAGE FLOOR POLICY: advisory") || strings.Contains(stderr, "report-only") {
+		t.Fatalf("main() default policy emitted advisory guidance: %q", stderr)
+	}
+	want := "package coverage regression: package=" + configPackage + " lane=unit expected-minimum=80.00% actual=0.0000% delta=-80.0000 percentage-points"
+	if !strings.Contains(stderr, want) {
+		t.Fatalf("main() default policy stderr = %q, want %q", stderr, want)
+	}
+}
+
 func TestMainPackageFloorPolicyAdvisoryReportsMissingManifestEntryAndBlockingRestoresEnforcement(t *testing.T) {
 	rootObservationPackage := modulePath + "/pkg/services/factory_runtime/internal/rootobservation"
 	manifestPath := writePackageMinimumManifest(t, "unit", rootObservationPackage, "0.00")

--- a/cmd/gocoveragecheck/manifest.go
+++ b/cmd/gocoveragecheck/manifest.go
@@ -26,14 +26,32 @@ type coverageManifest struct {
 	// DefaultFloorPercent is the floor applied to a measured package with no
 	// entry in Packages. It is optional; when absent the lane's built-in
 	// default applies. Explicit Packages entries always win over it.
-	DefaultFloorPercent json.RawMessage         `json:"defaultFloorPercent,omitempty"`
-	Packages            []coverageManifestEntry `json:"packages"`
+	DefaultFloorPercent json.RawMessage `json:"defaultFloorPercent,omitempty"`
+	// FloorHolds keep a measured baseline finding visible without turning the
+	// entire lane back into report-only mode. A hold is a temporary exception
+	// to enforcement for one package; the package's existing floor remains the
+	// value that matching-lane remediation must restore.
+	FloorHolds []coverageManifestFloorHold `json:"floorHolds,omitempty"`
+	Packages   []coverageManifestEntry     `json:"packages"`
 }
 
 type coverageManifestEntry struct {
 	Package   string                     `json:"package"`
 	Minimum   json.RawMessage            `json:"minimum,omitempty"`
 	Exception *coverageManifestException `json:"exception,omitempty"`
+}
+
+// coverageManifestFloorHold is a staged-cutover record for a package whose
+// current measured coverage is below its existing floor. It is deliberately
+// separate from a measurement exception: the package remains measured and
+// keeps its floor, while only enforcement is held until the removal gate is
+// met.
+type coverageManifestFloorHold struct {
+	Package       string `json:"package"`
+	Justification string `json:"justification"`
+	Owner         string `json:"owner"`
+	Deadline      string `json:"deadline"`
+	RemovalGate   string `json:"removalGate"`
 }
 
 type coverageManifestException struct {
@@ -254,6 +272,9 @@ func validateCoverageManifestAtModeWithTotals(manifest coverageManifest, expecte
 		seen[entry.Package] = struct{}{}
 		previous = entry.Package
 	}
+	if err := validateCoverageManifestFloorHolds(manifest.FloorHolds, expectedLane, measured, manifest.Packages, now); err != nil {
+		return err
+	}
 	// A measured package with no entry is not a completeness gap: it resolves to
 	// the lane default floor. Completeness only requires that every measured
 	// service declares a floor at its root.
@@ -312,6 +333,7 @@ func checkCoverageManifestWithEpsilon(manifest coverageManifest, totals map[stri
 func checkCoverageManifestWithEpsilonAndBlocks(manifest coverageManifest, totals map[string]packageCoverageTotals, manifestPath string, epsilon float64, coverageBlocks map[string]coverageBlock) ([]string, []string) {
 	failures := make([]string, 0)
 	warnings := make([]string, 0)
+	holds := coverageManifestFloorHoldMap(manifest)
 	for _, entry := range manifest.Packages {
 		if entry.Exception != nil {
 			continue
@@ -328,6 +350,10 @@ func checkCoverageManifestWithEpsilonAndBlocks(manifest coverageManifest, totals
 			actualPercent = float64(actual.coveredStatements) * 100 / float64(actual.totalStatements)
 		}
 		expectedPercent := float64(minimum) / 100
+		if hold, held := holds[entry.Package]; held {
+			warnings = append(warnings, formatHeldCoverageRegression(manifest, entry.Package, minimum, actual, coverageBlocks, hold))
+			continue
+		}
 		if coverageFloorDriftWithinEpsilon(minimum, actual, epsilon) {
 			warnings = append(warnings, fmt.Sprintf(
 				"package coverage warning: tolerated drift: package=%s lane=%s expected-minimum=%s%% actual=%.4f%% delta=%+.4f percentage-points epsilon=%.4f percentage-points",
@@ -353,8 +379,38 @@ func checkCoverageManifestWithEpsilonAndBlocks(manifest coverageManifest, totals
 			manifest.Lane, manifestPath,
 		))
 	}
-	failures = append(failures, checkCoverageDefaultFloor(manifest, totals, manifestPath, coverageBlocks)...)
+	defaultFailures, defaultWarnings := checkCoverageDefaultFloorWithHolds(manifest, totals, manifestPath, coverageBlocks, holds)
+	failures = append(failures, defaultFailures...)
+	warnings = append(warnings, defaultWarnings...)
 	return failures, warnings
+}
+
+func formatHeldCoverageRegression(manifest coverageManifest, importPath string, minimum coverageFloor, actual packageCoverageTotals, coverageBlocks map[string]coverageBlock, hold coverageManifestFloorHold) string {
+	actualPercent := 0.0
+	if actual.totalStatements > 0 {
+		actualPercent = float64(actual.coveredStatements) * 100 / float64(actual.totalStatements)
+	}
+	diagnostic := fmt.Sprintf(
+		"package coverage hold: package=%s lane=%s expected-minimum=%s%% actual=%.4f%% delta=%+.4f percentage-points covered=%d/%d statements",
+		importPath,
+		manifest.Lane,
+		minimum.String(),
+		actualPercent,
+		actualPercent-float64(minimum)/100,
+		actual.coveredStatements,
+		actual.totalStatements,
+	)
+	if uncovered := formatUncoveredCoverageBlocks(coverageBlocks, importPath); uncovered != "" {
+		diagnostic += "; " + uncovered
+	}
+	return diagnostic + fmt.Sprintf(
+		"; staged blocking hold owner=%s deadline=%s; restore matching-%s-lane coverage to %s%% before removing this hold: %s",
+		hold.Owner,
+		hold.Deadline,
+		manifest.Lane,
+		minimum.String(),
+		hold.RemovalGate,
+	)
 }
 
 func coverageFloorDriftWithinEpsilon(minimum coverageFloor, actual packageCoverageTotals, epsilon float64) bool {
@@ -390,6 +446,67 @@ func validateCoverageManifestEntry(entry coverageManifestEntry) error {
 		return err
 	}
 	return validateCoverageManifestException(*entry.Exception)
+}
+
+func validateCoverageManifestFloorHolds(holds []coverageManifestFloorHold, expectedLane string, measured map[string]struct{}, entries []coverageManifestEntry, now time.Time) error {
+	entryByPackage := make(map[string]coverageManifestEntry, len(entries))
+	for _, entry := range entries {
+		entryByPackage[entry.Package] = entry
+	}
+	seen := make(map[string]struct{}, len(holds))
+	previous := ""
+	for index, hold := range holds {
+		if strings.TrimSpace(hold.Package) == "" {
+			return fmt.Errorf("validate go coverage manifest: floorHolds[%d].package is required", index)
+		}
+		if _, duplicate := seen[hold.Package]; duplicate {
+			return fmt.Errorf("validate go coverage manifest: duplicate floor hold for package %q", hold.Package)
+		}
+		if previous != "" && hold.Package < previous {
+			return fmt.Errorf("validate go coverage manifest: floorHolds must be sorted by package; %q appears after %q", hold.Package, previous)
+		}
+		if _, measuredPackage := measured[hold.Package]; !measuredPackage {
+			return fmt.Errorf("validate go coverage manifest: floor hold package %q is outside the %s measured package set", hold.Package, expectedLane)
+		}
+		if entry, explicit := entryByPackage[hold.Package]; explicit && entry.Exception != nil {
+			return fmt.Errorf("validate go coverage manifest: floor hold package %q cannot use a measurement exception", hold.Package)
+		}
+		if err := validateCoverageManifestFloorHold(hold); err != nil {
+			return fmt.Errorf("validate go coverage manifest floor hold package %q: %w", hold.Package, err)
+		}
+		deadline, _ := time.Parse("2006-01-02", hold.Deadline)
+		if deadline.Before(dateOnlyUTC(now)) {
+			return fmt.Errorf("validate go coverage manifest: expired floor hold for package %q: deadline %s passed; satisfy removal gate: %s", hold.Package, hold.Deadline, hold.RemovalGate)
+		}
+		seen[hold.Package] = struct{}{}
+		previous = hold.Package
+	}
+	return nil
+}
+
+func validateCoverageManifestFloorHold(hold coverageManifestFloorHold) error {
+	for name, value := range map[string]string{
+		"justification": hold.Justification,
+		"owner":         hold.Owner,
+		"deadline":      hold.Deadline,
+		"removalGate":   hold.RemovalGate,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("floor hold %s is required", name)
+		}
+	}
+	if _, err := time.Parse("2006-01-02", hold.Deadline); err != nil {
+		return fmt.Errorf("floor hold deadline %q must use YYYY-MM-DD", hold.Deadline)
+	}
+	return nil
+}
+
+func coverageManifestFloorHoldMap(manifest coverageManifest) map[string]coverageManifestFloorHold {
+	holds := make(map[string]coverageManifestFloorHold, len(manifest.FloorHolds))
+	for _, hold := range manifest.FloorHolds {
+		holds[hold.Package] = hold
+	}
+	return holds
 }
 
 func parseCoverageFloor(raw json.RawMessage) (coverageFloor, error) {

--- a/cmd/gocoveragecheck/manifest_default_floor.go
+++ b/cmd/gocoveragecheck/manifest_default_floor.go
@@ -73,9 +73,21 @@ func checkCoverageDefaultFloor(
 	manifestPath string,
 	coverageBlocks map[string]coverageBlock,
 ) []string {
+	failures, _ := checkCoverageDefaultFloorWithHolds(manifest, totals, manifestPath, coverageBlocks, coverageManifestFloorHoldMap(manifest))
+	return failures
+}
+
+func checkCoverageDefaultFloorWithHolds(
+	manifest coverageManifest,
+	totals map[string]packageCoverageTotals,
+	manifestPath string,
+	coverageBlocks map[string]coverageBlock,
+	holds map[string]coverageManifestFloorHold,
+) ([]string, []string) {
 	listed := manifestPackageSet(manifest)
 	floor := manifest.defaultFloor()
 	failures := make([]string, 0)
+	warnings := make([]string, 0)
 	for _, importPath := range slices.Sorted(maps.Keys(totals)) {
 		if _, explicit := listed[importPath]; explicit {
 			continue
@@ -84,9 +96,45 @@ func checkCoverageDefaultFloor(
 		if coveragePassesFloor(floor, actual) {
 			continue
 		}
+		if hold, held := holds[importPath]; held {
+			warnings = append(warnings, formatHeldDefaultFloorRegression(manifest, importPath, floor, actual, coverageBlocks, hold))
+			continue
+		}
 		failures = append(failures, formatDefaultFloorRegression(manifest, importPath, floor, actual, manifestPath, coverageBlocks))
 	}
-	return failures
+	return failures, warnings
+}
+
+func formatHeldDefaultFloorRegression(
+	manifest coverageManifest,
+	importPath string,
+	floor coverageFloor,
+	actual packageCoverageTotals,
+	coverageBlocks map[string]coverageBlock,
+	hold coverageManifestFloorHold,
+) string {
+	actualPercent := float64(actual.coveredStatements) * 100 / float64(actual.totalStatements)
+	diagnostic := fmt.Sprintf(
+		"package coverage hold: package=%s lane=%s floor-source=lane-default expected-minimum=%s%% actual=%.4f%% delta=%+.4f percentage-points covered=%d/%d statements",
+		importPath,
+		manifest.Lane,
+		floor.String(),
+		actualPercent,
+		actualPercent-float64(floor)/100,
+		actual.coveredStatements,
+		actual.totalStatements,
+	)
+	if uncovered := formatUncoveredCoverageBlocks(coverageBlocks, importPath); uncovered != "" {
+		diagnostic += "; " + uncovered
+	}
+	return diagnostic + fmt.Sprintf(
+		"; staged blocking hold owner=%s deadline=%s; restore matching-%s-lane coverage to %s%% before removing this hold: %s",
+		hold.Owner,
+		hold.Deadline,
+		manifest.Lane,
+		floor.String(),
+		hold.RemovalGate,
+	)
 }
 
 // coveragePassesFloor reports whether actual satisfies floor. A package with no
@@ -133,6 +181,7 @@ func formatDefaultFloorRegression(
 // than an explicit entry.
 func coverageManifestGatedPackages(manifest coverageManifest, totals map[string]packageCoverageTotals) map[string]packageCoverageGate {
 	gates := packageGatesFromManifest(manifest)
+	holds := coverageManifestFloorHoldMap(manifest)
 	floor := manifest.defaultFloor()
 	for importPath, actual := range totals {
 		if _, explicit := gates[importPath]; explicit {
@@ -142,7 +191,11 @@ func coverageManifestGatedPackages(manifest coverageManifest, totals map[string]
 			continue
 		}
 		percent := float64(floor) / 100
-		gates[importPath] = packageCoverageGate{Floor: &percent}
+		gate := packageCoverageGate{Floor: &percent}
+		if hold, held := holds[importPath]; held {
+			gate.FloorHold = cloneCoverageManifestFloorHold(&hold)
+		}
+		gates[importPath] = gate
 	}
 	return gates
 }

--- a/cmd/gocoveragecheck/manifest_default_floor_test.go
+++ b/cmd/gocoveragecheck/manifest_default_floor_test.go
@@ -112,6 +112,40 @@ func TestCheckCoverageDefaultFloorEvaluatesUnlistedFunctionalPackages(t *testing
 	})
 }
 
+func TestCheckCoverageDefaultFloorSupportsHeldUnlistedPackages(t *testing.T) {
+	t.Parallel()
+
+	unlisted := modulePath + "/pkg/platform/unlisted"
+	manifest := coverageManifest{
+		Version: coverageManifestVersion,
+		Lane:    "functional",
+		FloorHolds: []coverageManifestFloorHold{{
+			Package:       unlisted,
+			Justification: "current-main baseline is being restored",
+			Owner:         "coverage-remediation",
+			Deadline:      "2027-07-15",
+			RemovalGate:   "matching functional tests restore the lane default floor",
+		}},
+	}
+
+	failures, warnings := checkCoverageManifestWithEpsilon(
+		manifest,
+		map[string]packageCoverageTotals{unlisted: {coveredStatements: 0, totalStatements: 100}},
+		"minimums.json",
+		0,
+	)
+	if len(failures) != 0 || len(warnings) != 1 {
+		t.Fatalf("held default-floor result = failures %v warnings %v, want no failures and one warning", failures, warnings)
+	}
+	if !strings.Contains(warnings[0], "floor-source=lane-default") || !strings.Contains(warnings[0], "package coverage hold: package="+unlisted) {
+		t.Fatalf("held default-floor warning = %q, want package and lane-default details", warnings[0])
+	}
+	gates := coverageManifestGatedPackages(manifest, map[string]packageCoverageTotals{unlisted: {coveredStatements: 0, totalStatements: 100}})
+	if gate := gates[unlisted]; gate.FloorHold == nil || *gate.FloorHold != manifest.FloorHolds[0] {
+		t.Fatalf("held default-floor gate = %+v, want the staged hold", gate)
+	}
+}
+
 func runCoverageDefaultFloorCases(t *testing.T, unlisted string, tests []coverageDefaultFloorCase) {
 	t.Helper()
 	for _, tt := range tests {

--- a/cmd/gocoveragecheck/manifest_test.go
+++ b/cmd/gocoveragecheck/manifest_test.go
@@ -151,7 +151,7 @@ func TestReadCoverageManifestValidatesContract(t *testing.T) {
 
 	configPackage := modulePath + "/pkg/config"
 	servicePackage := modulePath + "/pkg/service"
-	valid := `{"version":1,"lane":"unit","packages":[{"package":"` + configPackage + `","minimum":80.00},{"package":"` + servicePackage + `","exception":{"kind":"measurement","justification":"coverage profile omits generated bridge statements","owner":"backend-quality","deadline":"2026-12-31","removalGate":"profile records bridge statements"}}]}`
+	valid := `{"version":1,"lane":"unit","floorHolds":[{"package":"` + configPackage + `","justification":"current-main baseline is being restored","owner":"coverage-remediation","deadline":"2027-07-15","removalGate":"matching unit tests restore the existing floor"}],"packages":[{"package":"` + configPackage + `","minimum":80.00},{"package":"` + servicePackage + `","exception":{"kind":"measurement","justification":"coverage profile omits generated bridge statements","owner":"backend-quality","deadline":"2026-12-31","removalGate":"profile records bridge statements"}}]}`
 	if _, err := readCoverageManifest([]byte(valid), "unit", []string{configPackage, servicePackage}); err != nil {
 		t.Fatalf("readCoverageManifest() error = %v", err)
 	}
@@ -324,6 +324,53 @@ func TestCheckCoverageManifestReportsOrderedPackageUncoveredBlocks(t *testing.T)
 	}
 	if !strings.Contains(failure, "restore coverage before running `go run ./cmd/gocoveragecheck") {
 		t.Fatalf("failure = %q, want existing remediation wording", failure)
+	}
+}
+
+func TestCheckCoverageManifestKeepsHeldRegressionOutOfBlockingFailures(t *testing.T) {
+	t.Parallel()
+
+	importPath := modulePath + "/pkg/config"
+	manifest := coverageManifest{
+		Version: coverageManifestVersion,
+		Lane:    "unit",
+		FloorHolds: []coverageManifestFloorHold{{
+			Package:       importPath,
+			Justification: "current-main baseline is being restored",
+			Owner:         "coverage-remediation",
+			Deadline:      "2027-07-15",
+			RemovalGate:   "matching unit tests restore the existing floor",
+		}},
+		Packages: []coverageManifestEntry{{Package: importPath, Minimum: json.RawMessage("80.00")}},
+	}
+
+	failures, warnings := checkCoverageManifestWithEpsilon(
+		manifest,
+		map[string]packageCoverageTotals{importPath: {coveredStatements: 40, totalStatements: 100}},
+		"minimums.json",
+		0,
+	)
+	if len(failures) != 0 {
+		t.Fatalf("held regression failures = %v, want none", failures)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("held regression warnings = %v, want one", warnings)
+	}
+	for _, want := range []string{
+		"package coverage hold: package=" + importPath,
+		"lane=unit",
+		"expected-minimum=80.00%",
+		"actual=40.0000%",
+		"delta=-40.0000 percentage-points",
+		"staged blocking hold",
+		"matching-unit-lane coverage",
+	} {
+		if !strings.Contains(warnings[0], want) {
+			t.Fatalf("held regression warning = %q, want %q", warnings[0], want)
+		}
+	}
+	if strings.Contains(warnings[0], "package coverage regression") || strings.Contains(warnings[0], "report-only") {
+		t.Fatalf("held regression warning used the wrong policy classification: %q", warnings[0])
 	}
 }
 

--- a/cmd/gocoveragecheck/manifest_update.go
+++ b/cmd/gocoveragecheck/manifest_update.go
@@ -142,6 +142,7 @@ func planCoverageManifestUpdate(manifest coverageManifest, minimums map[string]p
 		Version:             manifest.Version,
 		Lane:                manifest.Lane,
 		DefaultFloorPercent: manifest.DefaultFloorPercent,
+		FloorHolds:          slices.Clone(manifest.FloorHolds),
 		Packages:            make([]coverageManifestEntry, 0, len(packages)),
 	}
 	updates := make([]coverageManifestUpdate, 0, len(packages))

--- a/cmd/gocoveragecheck/manifest_update_test.go
+++ b/cmd/gocoveragecheck/manifest_update_test.go
@@ -103,13 +103,24 @@ func TestPlanCoverageManifestUpdateUsesMinimumAndPreservesException(t *testing.T
 	}
 }
 
-func TestUpdateCoverageManifestFileWritesMinimumsAndIsByteIdempotent(t *testing.T) {
+func TestUpdateCoverageManifestFilePreservesFloorHoldsAndIsByteIdempotent(t *testing.T) {
 	alpha := modulePath + "/pkg/config"
 	beta := modulePath + "/pkg/service"
-	manifest := coverageManifest{Version: coverageManifestVersion, Lane: "unit", Packages: []coverageManifestEntry{
-		{Package: alpha, Minimum: json.RawMessage("80.00")},
-		{Package: beta, Minimum: json.RawMessage("50.00")},
-	}}
+	manifest := coverageManifest{
+		Version: coverageManifestVersion,
+		Lane:    "unit",
+		FloorHolds: []coverageManifestFloorHold{{
+			Package:       alpha,
+			Justification: "current-main baseline is being restored",
+			Owner:         "coverage-remediation",
+			Deadline:      "2027-07-15",
+			RemovalGate:   "matching unit tests restore the existing floor",
+		}},
+		Packages: []coverageManifestEntry{
+			{Package: alpha, Minimum: json.RawMessage("80.00")},
+			{Package: beta, Minimum: json.RawMessage("50.00")},
+		},
+	}
 	data, err := renderCoverageManifest(manifest)
 	if err != nil {
 		t.Fatalf("render manifest: %v", err)
@@ -142,6 +153,13 @@ func TestUpdateCoverageManifestFileWritesMinimumsAndIsByteIdempotent(t *testing.
 	}
 	if !strings.Contains(string(first), `"minimum": 79.00`) || !strings.Contains(string(first), `"minimum": 60.00`) {
 		t.Fatalf("updated manifest = %s, want sampled minimum floors", first)
+	}
+	updated, err := readCoverageManifest(first, "unit", []string{alpha, beta})
+	if err != nil {
+		t.Fatalf("read updated manifest: %v", err)
+	}
+	if len(updated.FloorHolds) != 1 || updated.FloorHolds[0].Package != alpha || updated.FloorHolds[0].Owner != "coverage-remediation" {
+		t.Fatalf("updated floor holds = %+v, want the original hold preserved", updated.FloorHolds)
 	}
 	if _, err := updateCoverageManifestFile(filename, "unit", samples); err != nil {
 		t.Fatalf("second update error = %v", err)

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -74,6 +74,13 @@
       "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/internal/service",
+      "justification": "Complete current-head functional coverage is below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/mcp",
       "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
       "owner": "coverage-remediation",
@@ -142,6 +149,13 @@
       "owner": "coverage-remediation",
       "deadline": "2027-07-15",
       "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/serverstop",
+      "justification": "Complete current-head functional coverage is below the functional default floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the functional default floor and this hold is removed."
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/workerdiagnostics",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -2,6 +2,155 @@
   "version": 1,
   "lane": "functional",
   "defaultFloorPercent": 15.00,
+  "floorHolds": [
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/platform/httpserver",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/platform/internal/runtimeartifact",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/platform/metrics",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/platform/runtimeartifact",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/platform/wiretranscript",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/chat_sessions/internal/responsebridge",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/costs/transports/cli",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtimeopening",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/activation_lifecycle",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_visualization/internal/services/live_view_projection",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/operator_settings/transports/mcp",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/events/kinds",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/services/projection_query/internal/service",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/wire",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/work/internal/services/content_materialization",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/workers/internal/services/runners/runner",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/acp/internal/negotiation",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/acp/internal/protocol",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/clidiag",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/clihttp",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/mapping/workerdiagnostics",
+      "justification": "Complete current-main functional coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching functional coverage reaches the existing floor and this hold is removed."
+    }
+  ],
   "packages": [
     {
       "package": "github.com/portpowered/infinite-you/pkg/initializer/application",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -2,6 +2,113 @@
   "version": 1,
   "lane": "unit",
   "defaultFloorPercent": 50.00,
+  "floorHolds": [
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/platform/filesystem",
+      "justification": "Complete current-main unit coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/platform/httpserver",
+      "justification": "Complete current-main unit coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/platform/metrics",
+      "justification": "Complete current-main unit coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/costs/transports/http",
+      "justification": "Complete current-main unit coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/edges",
+      "justification": "Complete current-main unit coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_definitions/internal/services/runtime_snapshot/internal",
+      "justification": "Complete current-main unit coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/instance_host/build",
+      "justification": "Complete current-main unit coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/service",
+      "justification": "Complete current-main unit coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/assets/internal/service",
+      "justification": "Complete current-main unit coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/internal/services/catalog/internal/service",
+      "justification": "Complete current-main unit coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/transports/cli",
+      "justification": "Complete current-main unit coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/worker_sessions",
+      "justification": "Complete current-main unit coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/worker_sessions/internal/service",
+      "justification": "Complete current-main unit coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/workers/wire",
+      "justification": "Complete current-main unit coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/clihttp",
+      "justification": "Complete current-main unit coverage measured below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    }
+  ],
   "packages": [
     {
       "package": "github.com/portpowered/infinite-you/pkg/initializer",

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -81,6 +81,34 @@
       "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/models/wire",
+      "justification": "Complete current-head unit coverage is below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal",
+      "justification": "Complete current-head unit coverage is below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/events",
+      "justification": "Complete current-head unit coverage is below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
+      "package": "github.com/portpowered/infinite-you/pkg/services/recordings/internal/projections",
+      "justification": "Complete current-head unit coverage is below the existing floor; hold until matching-lane tests restore it.",
+      "owner": "coverage-remediation",
+      "deadline": "2027-07-15",
+      "removalGate": "Matching unit coverage reaches the existing floor and this hold is removed."
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/worker_sessions",
       "justification": "Complete current-main unit coverage measured below the existing floor; hold until matching-lane tests restore it.",
       "owner": "coverage-remediation",

--- a/scripts/ci/coverage-report.mjs
+++ b/scripts/ci/coverage-report.mjs
@@ -47,6 +47,7 @@ function summarizeCoverageArtifact(coverage, limits) {
 			manifestDiagnostics: [],
 			violations: [],
 			violationCount: 0,
+			floorHoldCount: 0,
 			omittedViolations: 0,
 			nearFloor: [],
 			gatedCount: 0,
@@ -58,6 +59,7 @@ function summarizeCoverageArtifact(coverage, limits) {
 		.map((entry) => ({
 			package: entry.package,
 			coveragePercent: measuredCoveragePercent(entry),
+			held: entry.packageFloorHeld === true,
 			floor:
 				typeof entry.packageFloor === "number" && Number.isFinite(entry.packageFloor)
 					? entry.packageFloor
@@ -77,13 +79,16 @@ function summarizeCoverageArtifact(coverage, limits) {
 	// because 63.75 is not representable in binary. The tolerance is far below
 	// the two decimals a floor is authored with, so it can only absorb
 	// representation error, never a real shortfall.
-	const allViolations = ranked.filter((entry) => entry.headroom < -HEADROOM_EPSILON);
+	const allHolds = ranked.filter((entry) => entry.held && entry.headroom < -HEADROOM_EPSILON);
+	const allViolations = ranked.filter(
+		(entry) => !entry.held && entry.headroom < -HEADROOM_EPSILON,
+	);
 	// Coverage is never negative, so a package sitting on a 0% floor cannot
 	// regress through it. Unlisted packages in the functional lane now use a
 	// positive 15.00 default (unit uses 50.00), while explicit zero floors
 	// remain report-only for this near-floor table.
 	const contenders = ranked.filter(
-		(entry) => entry.headroom >= -HEADROOM_EPSILON && entry.floor > 0,
+		(entry) => !entry.held && entry.headroom >= -HEADROOM_EPSILON && entry.floor > 0,
 	);
 	const violations = allViolations.slice(0, limits.violations);
 	const nearFloor = contenders.slice(0, limits.packages);
@@ -100,6 +105,7 @@ function summarizeCoverageArtifact(coverage, limits) {
 		packageCount: coverage.packages.length,
 		gatedCount: ranked.length,
 		violationCount: allViolations.length,
+		floorHoldCount: allHolds.length,
 		violations,
 		omittedViolations: allViolations.length - violations.length,
 		nearFloor,
@@ -209,6 +215,9 @@ function renderCoverageOverview(coverage, artifactName) {
 		`- Gated packages: ${coverage.gatedCount}`,
 		`- Floor violations: ${coverage.violationCount}`,
 	];
+	if (coverage.floorHoldCount > 0) {
+		lines.push(`- Remediation holds: ${coverage.floorHoldCount}`);
+	}
 	if (coverage.packageFloorPolicy === "advisory") {
 		lines.push(
 			"!!! COVERAGE FLOOR POLICY: advisory !!!",

--- a/scripts/ci/functional-coverage-verdict.mjs
+++ b/scripts/ci/functional-coverage-verdict.mjs
@@ -36,10 +36,12 @@ function isCompactVerdictLine(line) {
 		line.startsWith("total: (statements)") ||
 		line.startsWith("Functional package coverage verdict:") ||
 		line.startsWith("  floor violation:") ||
+		line.startsWith("  floor hold:") ||
 		line === "  floor violations: none" ||
 		line.startsWith("  package=") ||
 		line.startsWith("  tally:") ||
 		line.startsWith("package coverage regression:") ||
+		line.startsWith("package coverage hold:") ||
 		line.startsWith("coverage manifest missing entry:") ||
 		line.startsWith("coverage not evaluated:") ||
 		/^(?:go|Go) coverage (?:found |.* below minimum |.* meets minimum )/.test(line)

--- a/scripts/ci/unit-coverage-report.test.mjs
+++ b/scripts/ci/unit-coverage-report.test.mjs
@@ -75,6 +75,33 @@ test("orders gated packages by headroom ascending with violations first", () => 
 	assert.equal(summary.coverage.violationCount, 1);
 });
 
+test("keeps staged floor holds out of active violation counts", () => {
+	const heldPackage = {
+		package: "pkg/held",
+		coveragePercent: 40,
+		packageFloor: 70,
+		packageFloorHeld: true,
+	};
+	const artifact = {
+		...coverageArtifact(),
+		packageFloorPolicy: "blocking",
+		packageFloorFindings: [
+			"package coverage hold: package=pkg/held lane=unit expected-minimum=70.00% actual=40.0000% delta=-30.0000 percentage-points",
+		],
+		packages: [...coverageArtifact().packages, heldPackage],
+	};
+	const summary = summarizeUnitCoverage(artifact, timingArtifact());
+	assert.equal(summary.coverage.violationCount, 1);
+	assert.equal(summary.coverage.floorHoldCount, 1);
+	assert.deepEqual(
+		summary.coverage.violations.map((entry) => entry.package),
+		["pkg/regressed"],
+	);
+	const body = renderUnitCoverageJobSummary(summary);
+	assert.match(body, /- Remediation holds: 1/);
+	assert.match(body, /package coverage hold: package=pkg\/held/);
+});
+
 // Regression: the first real CI run of this report accused 33 passing packages
 // of breaking their floor. The producer rounds coveragePercent to one decimal
 // but authors floors in basis points, so a package measured at 73.3333% against

--- a/tests/functional/observability/verification/functional_runner_contract_test.go
+++ b/tests/functional/observability/verification/functional_runner_contract_test.go
@@ -83,9 +83,10 @@ func TestFunctionalCoverageCommandSmoke_ReportsExplicitTierSelection(t *testing.
 	}
 }
 
-// TestCoverageTargetsSmoke_ForwardOneFloorPolicy proves unit and functional
-// coverage invoke the checker with the same explicit reversible policy.
-func TestCoverageTargetsSmoke_ForwardOneFloorPolicy(t *testing.T) {
+// TestCoverageTargetsSmoke_UseBlockingFloorPolicy proves unit and functional
+// coverage inherit the checker default used by required CI. Any staged
+// exceptions are scoped to manifest floor holds, not an advisory invocation.
+func TestCoverageTargetsSmoke_UseBlockingFloorPolicy(t *testing.T) {
 	repoRoot := testutil.MustRepoPath(t, ".")
 	goStub := writeMakeEchoScript(t, "stub-go-coverage-policy")
 
@@ -98,14 +99,13 @@ func TestCoverageTargetsSmoke_ForwardOneFloorPolicy(t *testing.T) {
 				repoRoot,
 				makefilePath,
 				fmt.Sprintf("GO=%s", goStub),
-				"GO_COVERAGE_FLOOR_POLICY=advisory",
 				target,
 			)
 			if err != nil {
 				t.Fatalf("run %s: %v\n%s", target, err, output)
 			}
-			if !strings.Contains(output, "-package-floor-policy advisory") {
-				t.Fatalf("%s did not forward the advisory policy to gocoveragecheck:\n%s", target, output)
+			if !strings.Contains(output, "-package-floor-policy blocking") {
+				t.Fatalf("%s did not forward the blocking policy to gocoveragecheck:\n%s", target, output)
 			}
 		})
 	}


### PR DESCRIPTION
{
  "project": "Coverage Floors Become Hard Blockers",
  "branchName": "coverage-floors-become-hard-blockers",
  "description": "Make the unit and functional per-package coverage floors hard merge blockers without retroactively punishing work accepted under the advisory regime. Measure both disjoint lanes on current main, re-pin only entries proven above measured reality or stage the cutover when necessary, activate truthful blocking enforcement in the checker and required CI, preserve distinct failed-test diagnostics, document remediation for in-flight factory lanes, and prove both a deliberate failure and a clean-head pass.",
  "context": {
    "customerAsk": "Implement the 2026-08-23 operator decision to make per-package coverage floors blocking. Measure both current-main coverage lanes before enforcing, choose and justify a safe cutover, update checker policy output and required CI behavior, retain actionable floor-regression and failed-test diagnostics, publish direct failure/pass and open-PR blast-radius evidence, update the scale-program rules, and implement fresh rather than rebasing or reviving stale PR #2163.",
    "problem": "Hosted CI explicitly sets GO_COVERAGE_FLOOR_POLICY=advisory even though the Makefile and checker default to blocking. A measured package can therefore fall below its floor, print a warning, and merge. About 24 open PRs were authored under that advisory policy, so flipping the override without measuring current main and reconciling honest floor drift could turn unrelated work red. Failed tests also prevent floor evaluation entirely and must not be confused with an evaluated floor regression.",
    "solution": "Record complete unit ./pkg/... and functional ./tests/functional/... measurements at a current origin/main SHA, list every below-floor package, and select direct enforcement, exact measured-reality re-pinning followed by enforcement, or a documented staged cutover when drift is too broad. Make required CI propagate the checker's blocking verdict, ensure active policy output is truthful, retain detailed regression and coverage-not-evaluated diagnostics, demonstrate a scratch regression failing and the final head passing, disclose the open-PR blast radius, and update factory guidance without touching prohibited files or product source solely to manipulate coverage."
  },
  "deliveryEvidence": {
    "finalOriginMainSha": "77f908148099f6d5dd74a655964143cce8b2f814",
    "cutover": {
      "selection": "Staged cutover with exact lane-scoped manifest holds.",
      "reason": "The initial complete baseline had 36 below-floor findings across the two disjoint lanes, including 12 functional default-floor packages at 0-13.3% and drops as large as 26.4 percentage points. Lowering floors would hide drift, so existing floors remain and only the measured packages are held until matching-lane tests restore them.",
      "unit": {
        "command": "make test-unit-coverage GO_UNIT_COVERAGE_PROFILE=.artifacts/coverage-baseline-latest/unit-coverage.out GO_UNIT_COVERAGE_JSON_OUTPUT=.artifacts/coverage-baseline-latest/unit-coverage-summary.json GO_UNIT_COVERAGE_TIMING_OUTPUT=.artifacts/coverage-baseline-latest/unit-timing-summary.json",
        "currentMainResult": "At 0e7db8e4, complete=true, 540 measured packages, 81.1% aggregate coverage, zero failed tests, no active floor regressions, 14 below-floor findings held, and one additional recovered package still listed in the staged hold manifest. The separate manifest-only diagnostic is pkg/services/webhooks with no measurement in the unit profile; it is not a failed-test result.",
        "belowFloorHeldPackages": [
          "pkg/platform/filesystem",
          "pkg/platform/httpserver",
          "pkg/platform/metrics",
          "pkg/services/costs/transports/http",
          "pkg/services/edges",
          "pkg/services/factory_definitions/internal/services/runtime_snapshot/internal",
          "pkg/services/factory_runtime/internal/services/instance_host/build",
          "pkg/services/models/internal/service",
          "pkg/services/models/internal/services/catalog/internal/service",
          "pkg/services/models/transports/cli",
          "pkg/services/worker_sessions",
          "pkg/services/worker_sessions/internal/service",
          "pkg/services/workers/wire",
          "pkg/transports/cli/clihttp"
        ]
      },
      "functional": {
        "command": "$env:GOFLAGS='-parallel=1'; make test-functional-coverage FUNCTIONAL_DEFAULT_JOBS=1 GO_FUNCTIONAL_COVERAGE_PROFILE=.artifacts/coverage-baseline-latest/functional-coverage.out GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT=.artifacts/coverage-baseline-latest/functional-coverage-summary.json GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT=.artifacts/coverage-baseline-latest/functional-timing-summary.json",
        "completeBaseline": {
          "sha": "9fcd9f068c3176c8480422ac02b2b3ced40a90c3",
          "result": "complete=true, 143/143 functional packages, 1,111 top-level tests (1,012 pass, 99 skip, 0 fail), 58.1% aggregate coverage, and 21 below-floor findings.",
          "belowFloorHeldPackages": [
            "pkg/platform/httpserver",
            "pkg/platform/internal/runtimeartifact",
            "pkg/platform/metrics",
            "pkg/platform/runtimeartifact",
            "pkg/platform/wiretranscript",
            "pkg/services/costs/transports/cli",
            "pkg/services/factory_sessions/internal/runtimeopening",
            "pkg/transports/cli/clidiag",
            "pkg/transports/cli/clihttp",
            "pkg/services/chat_sessions/internal/responsebridge",
            "pkg/services/factory_visualization/internal/services/activation_lifecycle",
            "pkg/services/factory_visualization/internal/services/live_view_projection",
            "pkg/services/operator_settings/transports/mcp",
            "pkg/services/recordings/internal/events/kinds",
            "pkg/services/recordings/internal/services/projection_query/internal/service",
            "pkg/services/recordings/wire",
            "pkg/services/work/internal/services/content_materialization",
            "pkg/services/workers/internal/services/runners/runner",
            "pkg/transports/acp/internal/negotiation",
            "pkg/transports/acp/internal/protocol",
            "pkg/transports/mapping/workerdiagnostics"
          ]
        },
        "finalMainRefreshDiagnostic": "The final-base serialized refresh at 0e7db8e4 was not used as floor evidence because the test run failed four tests. It observed all 143 packages and 1,122 top-level tests (1,018 pass, 100 skip, 4 fail); each failure reported process API server starter was never invoked; --with-server was probably omitted: tests/functional/providers/acp TestBTRCP0ACPTargetSuccessCharacterization, tests/functional/work/routing TestClassifierReworkFailureTerminatesWithoutCompletion, tests/functional/workers/inference/codex TestCodexGoldenDerivesProviderSessionAndResponseEvents, and tests/functional/workers/transports/cli/run/lifecycle TestCLIRunServerAttachedInvocationTargetsExistingFactorySession. All four passed isolated reruns. The checker summary remained complete=false with coverage not evaluated and no floor findings; the complete baseline above remains the only functional floor evidence used.",
        "currentMainRefreshPolicy": "The failed refresh is retained as diagnostic evidence only; it does not claim floors were checked, aggregate coverage passed, or produce a below-floor list. The complete baseline above is the floor evidence used for the staged cutover."
      }
    },
    "regressionProof": "Scratch commit f03ddeb99 removed only pkg/platform/contentstaging/adapters_test.go. The owning blocking unit command returned non-zero with package=.../pkg/platform/contentstaging, lane=unit, expected-minimum=100.00%, actual=0.0000%, and delta=-100.0000 percentage-points. The scratch commit was removed; the same command passed at 100.0% on the final head.",
    "failedTestProof": "Focused command-boundary tests show two observed failures return non-zero, preserve package-floor-policy=blocking, emit coverage not evaluated: 2 failed tests observed; package floors were NOT checked because the coverage test run failed, emit no package coverage regression, and emit no aggregate floor success.",
    "blastRadius": {
      "observedAt": "2026-08-23",
      "openPrCount": 31,
      "expectedRedUpperBound": 21,
      "method": "GitHub GraphQL listed the 31 open PRs; for each latest unit-coverage-report and functional-coverage-report issue comment, the observed package-floor rows were compared with the current lane hold lists. Twenty-one PRs had at least one latest-report package-floor violation outside the staged holds.",
      "boundedUncertainty": "This is an evidence-backed upper bound from the latest available report comments, not a prediction of fresh same-head CI: comments may be stale, partial, or predate a PR's latest head. Only the required CI run on each current head can confirm the final red set.",
      "pr2163": "PR #2163 (ci: restore blocking coverage-floor enforcement) was read for intent and remains open, but was not rebased, revived, or used as this implementation branch. Its workflow-only diff did not include the measured staged baseline, checker diagnostics, failed-test semantics, or factory guidance required here."
    },
    "postRebaseRefresh": {
      "originMainSha": "501c5fe658adfe4ace94c0e9cf605897fa866320",
      "headSha": "419a832dd577cb991579dc022c213062a654126c",
      "unit": {
        "command": "make test-unit-coverage GO_UNIT_COVERAGE_PROFILE=.artifacts/coverage-final-head/unit-coverage.out GO_UNIT_COVERAGE_JSON_OUTPUT=.artifacts/coverage-final-head/unit-coverage-summary.json GO_UNIT_COVERAGE_TIMING_OUTPUT=.artifacts/coverage-final-head/unit-timing-summary.json",
        "result": "incomplete; the refreshed process returned make Error -1; the timing artifact remained complete=false and was not used as floor evidence"
      },
      "functional": {
        "makeWrapperDiagnostic": "The make test-functional-coverage wrapper failed before starting its checker command with The system cannot find the path specified; functional-boundary-check passed standalone.",
        "command": "$env:GOFLAGS='-parallel=1'; go run ./cmd/gocoveragecheck -suite functional -stream -jobs 1 -min 33.1 -package-manifest docs/internal/baselines/go-functional-coverage-package-minimums.json -package-floor-policy blocking -functional-quarantine tests/functional/functional-quarantine.json -timeout 10m -profile .artifacts/coverage-final-head/functional-direct-coverage.out -json-output .artifacts/coverage-final-head/functional-direct-summary.json -timing-output .artifacts/coverage-final-head/functional-direct-timing.json",
        "result": "incomplete; direct refresh discovered 156 packages and 1,154 tests, selected 147 packages and 1,153 tests after quarantine, then returned Error -1 after 19 packages; no failed-test count or complete summary was produced and the partial run was not used as floor evidence"
      },
      "evidencePolicy": "The complete 0e7db8e4 unit refresh and complete 9fcd9f0 functional baseline remain the only floor evidence; these post-rebase runs are retained as diagnostics only."
    },
    "reviewFollowUp": {
      "originMainSha": "7843d2bdbecae45f25960c83e11b59ae9d600a80",
      "headSha": "74eee0bcea4122e4a1cb70d45a92f0c5b10e465b",
      "changes": [
        "manifest update now preserves FloorHolds and has a successful update/reload regression test",
        "six current-head coverage violations are represented by exact lane-scoped holds without lowering floors",
        "contractscheck fixture snapshots ignore transient .git administrative metadata so required API/package verification is stable"
      ],
      "localVerification": [
        "make contracts-smoke",
        "go test ./cmd/gocoveragecheck -count=1",
        "make typecheck",
        "git diff --check"
      ],
      "ciRun": "https://github.com/portpowered/you-agent-factory/actions/runs/32809630076",
      "status": "Required CI started on the pushed head; terminal coverage results remain review-stage evidence."
    },
    "finalSync": {
      "originMainSha": "77f908148099f6d5dd74a655964143cce8b2f814",
      "measuredBaselineSha": "7843d2bdbecae45f25960c83e11b59ae9d600a80",
      "assessment": "origin/main advanced only through UI source and test changes after the complete Go baseline measurement; no Go source/tests, Makefile, coverage manifests, or coverage selectors changed, so neither coverage lane was affected and no refresh was required. The branch was rebased onto this final synchronized origin/main before push."
    },
    "currentOriginMainRefresh": {
      "originMainSha": "7843d2bdbecae45f25960c83e11b59ae9d600a80",
      "unit": {
        "command": "make test-unit-coverage GO_COVERAGE_FLOOR_POLICY=blocking GO_UNIT_COVERAGE_PROFILE=.artifacts/coverage-origin-main-rerun/unit-coverage.out GO_UNIT_COVERAGE_JSON_OUTPUT=.artifacts/coverage-origin-main-rerun/unit-coverage-summary.json GO_UNIT_COVERAGE_TIMING_OUTPUT=.artifacts/coverage-origin-main-rerun/unit-timing-summary.json",
        "result": "checker summary complete=true, 544 measured coverpkg rows, 80.8% aggregate coverage (108427/134135 statements), 443/443 unit test packages observed, 11284 tests (11215 pass, 69 skip, 0 fail), and 19 package-floor findings; the non-zero exit is the expected current-main baseline drift under blocking policy, not a failed-test run",
        "belowFloorFindings": [
          "pkg/platform/filesystem (floor 75.00%, actual 72.3404%, delta -2.6596)",
          "pkg/platform/httpserver (floor 97.46%, actual 76.7123%, delta -20.7477)",
          "pkg/platform/metrics (floor 82.66%, actual 75.2955%, delta -7.3645)",
          "pkg/services/costs/transports/http (floor 87.30%, actual 86.6667%, delta -0.6333)",
          "pkg/services/edges (floor 71.65%, actual 70.9779%, delta -0.6721)",
          "pkg/services/factory_definitions/internal/services/runtime_snapshot/internal (floor 83.50%, actual 70.5128%, delta -12.9872)",
          "pkg/services/factory_runtime/internal/services/instance_host/build (floor 79.00%, actual 77.1739%, delta -1.8261)",
          "pkg/services/models/internal/service (floor 76.95%, actual 76.3551%, delta -0.5949)",
          "pkg/services/models/internal/services/assets/internal/service (floor 80.24%, actual 79.2760%, delta -0.9640)",
          "pkg/services/models/internal/services/catalog/internal/service (floor 87.31%, actual 82.9932%, delta -4.3168)",
          "pkg/services/models/transports/cli (floor 80.64%, actual 75.2399%, delta -5.4001)",
          "pkg/services/models/wire (floor 71.18%, actual 64.3275%, delta -6.8525)",
          "pkg/services/recordings/internal (floor 81.00%, actual 77.3637%, delta -3.6363)",
          "pkg/services/recordings/internal/events (floor 81.33%, actual 77.7247%, delta -3.6053)",
          "pkg/services/recordings/internal/projections (floor 89.77%, actual 89.0719%, delta -0.6981)",
          "pkg/services/worker_sessions (floor 100.00%, actual 99.6021%, delta -0.3979)",
          "pkg/services/worker_sessions/internal/service (floor 98.72%, actual 97.6665%, delta -1.0535)",
          "pkg/services/workers/wire (floor 82.14%, actual 78.2609%, delta -3.8791)",
          "pkg/transports/cli/clihttp (floor 90.00%, actual 77.5362%, delta -12.4638)"
        ]
      },
      "functional": {
        "wrapperDiagnostic": "The make test-functional-coverage wrapper failed before starting the checker with The system cannot find the path specified; the direct checker command below completed the same functional selection.",
        "command": "go run ./cmd/gocoveragecheck -suite functional -stream -jobs 1 -min 33.1 -package-manifest docs/internal/baselines/go-functional-coverage-package-minimums.json -package-floor-policy blocking -functional-quarantine tests/functional/functional-quarantine.json -timeout 10m -profile .artifacts/coverage-origin-main/functional-coverage.out -json-output .artifacts/coverage-origin-main/functional-coverage-summary.json -timing-output .artifacts/coverage-origin-main/functional-timing-summary.json",
        "result": "checker summary complete=true, 147/147 functional packages observed, 1153 tests (1052 pass, 101 skip, 0 fail), 58.8% aggregate coverage (76826/130681 statements), and 21 package-floor findings (20 hard regressions plus one tolerated epsilon warning); the non-zero exit is current-main baseline drift under blocking policy, not a failed-test run",
        "belowFloorFindings": [
          "pkg/services/factory_sessions/internal/runtimeopening (floor 71.48%, actual 71.4094%, delta -0.0706; tolerated epsilon warning)",
          "pkg/platform/httpserver (floor 56.96%, actual 45.2055%, delta -11.7545)",
          "pkg/platform/metrics (floor 74.66%, actual 57.2104%, delta -17.4496)",
          "pkg/platform/runtimeartifact (floor 58.82%, actual 57.6923%, delta -1.1277)",
          "pkg/platform/wiretranscript (floor 68.37%, actual 57.9710%, delta -10.3990)",
          "pkg/services/models/internal/services/catalog/internal/service (floor 66.41%, actual 59.8639%, delta -6.5461)",
          "pkg/transports/cli/clidiag (floor 80.00%, actual 65.9794%, delta -14.0206)",
          "pkg/transports/cli/clihttp (floor 67.50%, actual 55.7971%, delta -11.7029)",
          "pkg/services/chat_sessions/internal/responsebridge (floor 15.00%, actual 0.3344%, delta -14.6656)",
          "pkg/services/factory_visualization/internal/services/activation_lifecycle (floor 15.00%, actual 0.0000%, delta -15.0000)",
          "pkg/services/factory_visualization/internal/services/live_view_projection (floor 15.00%, actual 0.0000%, delta -15.0000)",
          "pkg/services/operator_settings/transports/mcp (floor 15.00%, actual 11.2903%, delta -3.7097)",
          "pkg/services/recordings/internal/events/kinds (floor 15.00%, actual 5.2356%, delta -9.7644)",
          "pkg/services/recordings/internal/services/projection_query/internal/service (floor 15.00%, actual 13.3333%, delta -1.6667)",
          "pkg/services/recordings/wire (floor 15.00%, actual 12.6984%, delta -2.3016)",
          "pkg/services/work/internal/services/content_materialization (floor 15.00%, actual 0.0000%, delta -15.0000)",
          "pkg/services/workers/internal/services/runners/runner (floor 15.00%, actual 11.5385%, delta -3.4615)",
          "pkg/transports/acp/internal/negotiation (floor 15.00%, actual 0.0000%, delta -15.0000)",
          "pkg/transports/acp/internal/protocol (floor 15.00%, actual 0.0000%, delta -15.0000)",
          "pkg/transports/cli/serverstop (floor 15.00%, actual 2.1053%, delta -12.8947)",
          "pkg/transports/mapping/workerdiagnostics (floor 15.00%, actual 0.0000%, delta -15.0000)"
        ]
      },
      "reconciliation": "The 19 unit and 21 functional findings are covered by the branch's owning-lane FloorHolds without lowering any floor; origin/main itself has no staged holds, so these commands intentionally return non-zero as the baseline measurement. The complete summaries, not the earlier incomplete refreshes, are the evidence used for the staged cutover."
    },
    "verification": [
      "go test ./cmd/gocoveragecheck passed on the rebased head.",
      "make contracts-smoke passed, including three repeated contracts-check passes around generation.",
      "make typecheck passed on the rebased head.",
      "The final current-main unit coverage command completed with blocking policy and no active floor regressions.",
      "No prohibited files were changed and no product-package source was changed solely to influence coverage."
    ]
  },
  "acceptanceCriteria": [
    "At a recorded current origin/main SHA, complete unit and functional coverage commands produce per-package measurements for their respective disjoint trees; the PR body or a PR comment includes the commands and complete below-floor list for each lane, or an explicit empty-list statement, and does not treat a failed or incomplete test run as coverage evidence.",
    "The PR states which cutover option was selected and why. Every re-pinned entry, if any, is confined to its measured lane and lists package, old floor, measured value, and new floor; no new floor is above the supporting measurement or below measured reality. If drift is too broad for honest re-pinning, the staged policy identifies exactly where blocking and advisory behavior apply and how the final blocking state is reached.",
    "A real package-floor regression returns non-zero in its owning lane and prints package, lane, expected minimum, actual coverage, and delta. A scratch commit temporarily removes test coverage without changing product source to demonstrate the failure, that scratch commit is removed from the branch before the final push, and the same command passes on the final head.",
    "An underlying failing test remains a separate non-zero outcome containing 'coverage not evaluated', the observed failed-test count, and 'package floors were NOT checked because the coverage test run failed'; it is not reported as a package-floor regression and does not claim floors were checked.",
    "The active factory rules describe blocking floors, both failure classes, lane-scoped test remediation, and the prohibition on lowering manifests. The PR reports the evidence-backed number of currently open PRs expected to become red and why the blast radius is acceptable; it does not revive PR #2163, edit docs/internal/baselines/deadcode-baseline.txt or factory/scripts/ci-wait.py, or change product-package source solely to influence coverage.",
    "Typecheck passes; focused checker tests and relevant unit and functional coverage verification pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. The required Backend Lint and Verification Policy checks govern merge, while the non-required localai-backend-artifacts failure is ignored.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The worker/reviewer cycle continues through the review-owned outcomes until the PR is actually merged; a PR that is merely open, green, approved, or ready to merge is not complete."
  ],
  "userStories": [
    {
      "id": "coverage-floors-become-hard-blockers-001",
      "title": "Establish the measured cutover baseline",
      "description": "As an operator enabling a new merge blocker, I want both coverage lanes measured on current main before enforcement so the cutover does not punish already-accepted drift or weaken a floor below reality.",
      "acceptanceCriteria": [
        "Record the tested origin/main commit SHA and run complete unit and functional coverage measurements with their normal manifests and lane selectors: unit measures ./pkg/..., and functional measures ./tests/functional/....",
        "For each lane, publish the exact command, confirmation that the test run and coverage measurement completed, and every package whose actual coverage is below its current floor; if none are below, publish an explicit empty-list statement.",
        "Do not cite a run containing 'coverage not evaluated' as floor evidence; fix or obtain a complete test run before making a floor decision.",
        "Select direct enforcement when both below-floor lists are empty; otherwise select exact measured-reality re-pinning when drift is small, or a documented staged cutover when drift is too large for an honest re-pin.",
        "For every re-pin, record lane, package, old floor, measured value, and new floor. The new floor equals the supported measured value at manifest precision, is never raised beyond that measurement, is never lowered below that measurement, and is never justified by a measurement from the other lane.",
        "If origin/main changes in a way that can affect a coverage lane before the final rebase, refresh the affected measurement and reconcile any in-scope manifest entry before the final push.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Initial complete baseline recorded at origin/main SHA 9fcd9f068c3176c8480422ac02b2b3ced40a90c3. Unit command: make test-unit-coverage GO_UNIT_COVERAGE_PROFILE=.artifacts/coverage-baseline/unit-coverage.out GO_UNIT_COVERAGE_JSON_OUTPUT=.artifacts/coverage-baseline/unit-coverage-summary.json GO_UNIT_COVERAGE_TIMING_OUTPUT=.artifacts/coverage-baseline/unit-timing-summary.json; coverage summary complete=true, 539 packages, 81.1%, 15 below-floor findings (11 hard gate failures plus 4 epsilon warnings), no failed tests. Functional command: $env:GOFLAGS='-parallel=1'; make test-functional-coverage FUNCTIONAL_DEFAULT_JOBS=1 GO_FUNCTIONAL_COVERAGE_PROFILE=.artifacts/coverage-baseline/functional-final2-coverage.out GO_FUNCTIONAL_COVERAGE_JSON_OUTPUT=.artifacts/coverage-baseline/functional-final2-coverage-summary.json GO_FUNCTIONAL_COVERAGE_TIMING_OUTPUT=.artifacts/coverage-baseline/functional-final2-timing-summary.json; inventory complete=true, 143/143 packages, 1,111 top-level tests (1,012 pass, 99 skipped, 0 fail), 58.1%, 21 below-floor findings. Unit below-floor packages: pkg/platform/filesystem, pkg/platform/httpserver, pkg/platform/metrics, pkg/services/costs/transports/http, pkg/services/factory_runtime/internal/services/instance_host/build, pkg/services/models/internal/service, pkg/services/models/internal/services/assets/internal/service, pkg/services/models/internal/services/catalog/internal/service, pkg/services/worker_sessions, pkg/services/worker_sessions/internal/service, pkg/services/workers/wire, pkg/transports/cli/clihttp, pkg/services/edges, pkg/services/factory_definitions/internal/services/runtime_snapshot/internal, pkg/services/models/transports/cli. Functional below-floor packages: pkg/platform/httpserver, pkg/platform/internal/runtimeartifact, pkg/platform/metrics, pkg/platform/runtimeartifact, pkg/platform/wiretranscript, pkg/services/costs/transports/cli, pkg/services/factory_sessions/internal/runtimeopening, pkg/transports/cli/clidiag, pkg/transports/cli/clihttp, pkg/services/chat_sessions/internal/responsebridge, pkg/services/factory_visualization/internal/services/activation_lifecycle, pkg/services/factory_visualization/internal/services/live_view_projection, pkg/services/operator_settings/transports/mcp, pkg/services/recordings/internal/events/kinds, pkg/services/recordings/internal/services/projection_query/internal/service, pkg/services/recordings/wire, pkg/services/work/internal/services/content_materialization, pkg/services/workers/internal/services/runners/runner, pkg/transports/acp/internal/negotiation, pkg/transports/acp/internal/protocol, pkg/transports/mapping/workerdiagnostics. Selected staged cutover: retain all existing floors; blocking applies to packages at/above their current lane floors, while these exact below-floor sets remain explicitly advisory/remediation-scoped until matching-lane tests restore coverage and the hold is removed. No manifest re-pins are honest because drift is broad (36 findings across lanes, 12 functional default-floor packages at 0-13.3%, and multiple 8.6-26.4 percentage-point drops). origin/main advanced to 4b5b8aa672fe019de4b3cd4453d112ad2446a892 after the measurement through model-asset and functional test changes; refresh affected lanes before final push. Manifest-only no-measurement diagnostics (unit webhooks; functional factory_definitions/definition and webhooks) were distinguished from failed-test runs and were not used as floor evidence."
    },
    {
      "id": "coverage-floors-become-hard-blockers-002",
      "title": "Reject package-floor regressions",
      "description": "As a maintainer, I want required coverage jobs to fail on a package-floor regression so coverage cannot silently decline after the safe baseline is established.",
      "acceptanceCriteria": [
        "The required unit and functional CI lanes execute the selected blocking policy after the baseline/re-pin decision; an active blocking invocation never prints advisory or report-only policy guidance.",
        "A measured package below its floor causes the checker and owning CI lane to return non-zero.",
        "The failure diagnostic names the package and lane and includes expected-minimum, actual, and negative delta values in percentage points.",
        "Entrypoint tests assert the real active policy and its exit behavior, including the default/current CI path; any explicitly retained advisory or staged mode is isolated, truthfully labeled, and cannot make the final required blocking lanes report-only.",
        "In a scratch commit, temporarily remove or disable test coverage for a selected package without editing product-package source, run the owning coverage command, and put its non-zero output in the PR body or a PR comment; remove the scratch commit before the final push.",
        "On the final head with no artificial regression, the same owning coverage command completes successfully and its passing output is recorded in a PR comment.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented in commit 4312b9724: required CI now inherits blocking policy; both manifests carry 15 unit/21 functional measured baseline floor holds without changing existing minima; checker, JSON, terminal, report, and focused policy tests distinguish held findings from active regressions. Focused checker tests, CI workflow tests (96 total; 92 passed, 4 POSIX-only skips), typecheck, fmt-check, and the final lane-scoped unit command pass. Scratch commit f03ddeb99 removed only pkg/platform/contentstaging/adapters_test.go and the same blocking command returned non-zero with package, lane, expected 100.00%, actual 0.0000%, and delta -100.0000 percentage-points; the scratch commit was reset before the final 100.0% pass. The complete current-main baseline and evidence still belong in the eventual PR body/comment after the final main refresh; next story is failed-test diagnosis."
    },
    {
      "id": "coverage-floors-become-hard-blockers-003",
      "title": "Preserve failed-test diagnosis",
      "description": "As an operator investigating a red coverage job, I want a failed test run to remain distinguishable from a measured floor regression so I apply the correct fix.",
      "acceptanceCriteria": [
        "A coverage run with two observed failing tests returns non-zero and emits 'coverage not evaluated: 2 failed tests observed; package floors were NOT checked because the coverage test run failed'.",
        "The failed-test scenario does not emit 'package coverage regression', does not print aggregate floor success, and does not produce floor findings from an incomplete profile.",
        "The blocking-policy output in a failed-test run remains truthful and does not display advisory or report-only guidance.",
        "Focused command-boundary tests prove the failed-test diagnostic and exit outcome separately from the measured floor-regression case.",
        "The PR includes output from a deliberate failing-test invocation showing the distinct diagnostic; the temporary failure is removed before the final push.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented in commit e4b20d911: incomplete coverage JSON snapshots retain the active package-floor policy, remain complete=false, and contain no package-floor or manifest findings because floors were not evaluated. Added focused command-boundary coverage for two observed failures, non-zero exit behavior, no aggregate success, and separate advisory-policy truthfulness. Focused gocoveragecheck tests pass; the deliberate failing-test output is captured by TestMainPackageFloorPolicyAdvisoryDoesNotMaskFailedTests and TestMainReportsSkippedPackageFloorsWhenCoverageTestsFail."
    },
    {
      "id": "coverage-floors-become-hard-blockers-004",
      "title": "Communicate and bound the cutover impact",
      "description": "As a factory worker or reviewer with work already in flight, I want the blocking policy, remediation, and rollout impact documented so I can respond without weakening the manifests or testing the wrong lane.",
      "acceptanceCriteria": [
        "The scale-program floor-policy section states that a measured package below its floor blocks the owning lane and shows the diagnostic shape with package, lane, expected minimum, actual, and delta.",
        "The guidance says a real regression is fixed with tests in the matching lane, never by lowering the floor manifest, and explains that unit ./pkg/... and functional ./tests/functional/... measurements are disjoint.",
        "The guidance preserves the separate 'coverage not evaluated: N failed tests observed' meaning and tells workers to fix the named tests before re-measuring rather than editing a manifest.",
        "The PR body reports an evidence-backed count of currently open PRs expected to become red under the selected cutover, identifies the observation method and any explicitly bounded uncertainty, and explains why the number is acceptable.",
        "The PR body states that PR #2163 was read for intent but was not rebased, revived, or used as the implementation branch, and explains why its workflow-only diff was not the complete safe cutover.",
        "Scope remains limited to checker policy/diagnostics and tests, directly supported lane manifest re-pins, required coverage/verification workflow wiring, and floor-policy factory guidance; prohibited files and unrelated product source remain untouched.",
        "Typecheck passes"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Updated the active scale-program floor-policy section in docs/temp/scale-program-rules.md (the operator-injected, ignored standing-rules copy) to state blocking package/lane/expected/actual/delta diagnostics, matching-lane remediation, disjoint ./pkg/... versus ./tests/functional/... measurement, staged holds, and separate failed-test coverage-not-evaluated handling; it explicitly prohibits lowering manifests. Final origin/main is 0e7db8e4428a8574ea012ecf40ce26ec8a42b4a9. The final-base unit refresh is complete with blocking policy and no active regressions. The final-base functional refresh observed four baseline process-startup failures and is diagnostic-only; all four named tests pass isolated reruns, and the complete 9fcd9f baseline remains the only functional floor evidence used. The PR delivery evidence records the exact final-base commands and complete below-floor lists, the scratch regression/final pass, the distinct failed-test diagnostics, 31 open PRs with a bounded 21-PR expected-red upper bound from latest report comments, and that #2163 was read but not revived."
    }
  ]
}
