### PR TITLE
cov-floor-cli-transports

### DIFF
--- a/pkg/transports/cli/clihttp/clihttp_test.go
+++ b/pkg/transports/cli/clihttp/clihttp_test.go
@@ -457,43 +457,103 @@ func TestDecodeAPIErrorRejectsMissingOrMalformedBodies(t *testing.T) {
 	}
 }
 
-func TestAPIErrorSafeFallbacksAndNilAccessors(t *testing.T) {
+func TestAPIErrorNilAccessors(t *testing.T) {
 	t.Parallel()
 	var nilError *APIError
-	if nilError.Error() != "" || nilError.Unwrap() != nil || nilError.CLIErrorCode() != "" || nilError.CLIErrorFamily() != "" || nilError.CLIErrorMessage() != "" || nilError.CLIHTTPMethod() != "" || nilError.CLIHTTPURL() != "" || nilError.CLIHTTPStatus() != 0 {
-		t.Fatal("nil APIError did not expose safe zero values")
+	if nilError.Error() != "" {
+		t.Fatalf("nil APIError error = %q", nilError.Error())
+	}
+	if nilError.Unwrap() != nil {
+		t.Fatal("nil APIError unwrap was non-nil")
+	}
+	if nilError.CLIErrorCode() != "" {
+		t.Fatalf("nil APIError code = %q", nilError.CLIErrorCode())
+	}
+	if nilError.CLIErrorFamily() != "" {
+		t.Fatalf("nil APIError family = %q", nilError.CLIErrorFamily())
+	}
+	if nilError.CLIErrorMessage() != "" {
+		t.Fatalf("nil APIError message = %q", nilError.CLIErrorMessage())
+	}
+	if nilError.CLIHTTPMethod() != "" {
+		t.Fatalf("nil APIError method = %q", nilError.CLIHTTPMethod())
+	}
+	if nilError.CLIHTTPURL() != "" {
+		t.Fatalf("nil APIError URL = %q", nilError.CLIHTTPURL())
+	}
+	if nilError.CLIHTTPStatus() != 0 {
+		t.Fatalf("nil APIError status = %d", nilError.CLIHTTPStatus())
 	}
 	if got := nilError.CLIErrorResponse(); got != (factoryapi.ErrorResponse{}) {
 		t.Fatalf("nil API response = %#v", got)
 	}
+}
 
+func TestAPIErrorMessageOnlyFallback(t *testing.T) {
+	t.Parallel()
 	messageOnly := NewAPIError(0, factoryapi.ErrorResponse{Message: " server message "}, " ", nil)
 	if messageOnly.Error() != "server message" || messageOnly.CLIErrorMessage() != "server message" {
 		t.Fatalf("message-only error = %q / %q", messageOnly.Error(), messageOnly.CLIErrorMessage())
 	}
+}
+
+func TestAPIErrorStatusOnlyFallback(t *testing.T) {
+	t.Parallel()
 	statusOnly := NewAPIError(http.StatusServiceUnavailable, factoryapi.ErrorResponse{}, "", nil)
 	if statusOnly.Error() != "HTTP request failed (503)" {
 		t.Fatalf("status-only error = %q", statusOnly.Error())
 	}
+}
+
+func TestAPIErrorEmptyFallback(t *testing.T) {
+	t.Parallel()
 	empty := NewAPIErrorFromResponse(nil, factoryapi.ErrorResponse{}, "", nil)
 	if empty.Error() != "HTTP request failed" || empty.CLIHTTPMethod() != "" || empty.CLIHTTPURL() != "" || empty.CLIHTTPStatus() != 0 {
 		t.Fatalf("empty error = %#v", empty)
 	}
 }
 
-func TestHTTPErrorSafeFallbacksAndMetadataWrappers(t *testing.T) {
+func TestHTTPErrorNilAccessors(t *testing.T) {
 	t.Parallel()
 	var nilError *HTTPError
-	if nilError.Error() != "" || nilError.Unwrap() != nil || nilError.CLIHTTPMethod() != "" || nilError.CLIHTTPURL() != "" || nilError.CLIHTTPStatus() != 0 {
-		t.Fatal("nil HTTPError did not expose safe zero values")
+	if nilError.Error() != "" {
+		t.Fatalf("nil HTTPError error = %q", nilError.Error())
 	}
+	if nilError.Unwrap() != nil {
+		t.Fatal("nil HTTPError unwrap was non-nil")
+	}
+	if nilError.CLIHTTPMethod() != "" {
+		t.Fatalf("nil HTTPError method = %q", nilError.CLIHTTPMethod())
+	}
+	if nilError.CLIHTTPURL() != "" {
+		t.Fatalf("nil HTTPError URL = %q", nilError.CLIHTTPURL())
+	}
+	if nilError.CLIHTTPStatus() != 0 {
+		t.Fatalf("nil HTTPError status = %d", nilError.CLIHTTPStatus())
+	}
+}
+
+func TestHTTPErrorEmptyAndNilConstructors(t *testing.T) {
+	t.Parallel()
 	if (&HTTPError{}).Error() != "HTTP request failed" {
 		t.Fatal("empty HTTPError did not use the safe fallback")
 	}
-	if NewHTTPError(http.MethodGet, "http://factory.test", 0, nil) != nil || NewHTTPErrorFromResponse(nil, nil) != nil || NewHTTPErrorFromRequest(nil, nil) != nil || WithHTTPResponse(nil, nil) != nil {
-		t.Fatal("nil HTTP causes should not manufacture errors")
+	if NewHTTPError(http.MethodGet, "http://factory.test", 0, nil) != nil {
+		t.Fatal("nil NewHTTPError cause manufactured an error")
 	}
+	if NewHTTPErrorFromResponse(nil, nil) != nil {
+		t.Fatal("nil response cause manufactured an error")
+	}
+	if NewHTTPErrorFromRequest(nil, nil) != nil {
+		t.Fatal("nil request cause manufactured an error")
+	}
+	if WithHTTPResponse(nil, nil) != nil {
+		t.Fatal("nil response wrapper manufactured an error")
+	}
+}
 
+func TestHTTPErrorMetadataWrappers(t *testing.T) {
+	t.Parallel()
 	request, err := http.NewRequest(http.MethodDelete, "https://factory.test/work", nil)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/transports/cli/clihttp/clihttp_test.go
+++ b/pkg/transports/cli/clihttp/clihttp_test.go
@@ -266,3 +266,254 @@ func TestProtocolDecodeFailurePreservesHTTPDebugMetadata(t *testing.T) {
 		t.Fatalf("decode HTTP metadata = (%q, %q, %d)", metadata.CLIHTTPMethod(), metadata.CLIHTTPURL(), metadata.CLIHTTPStatus())
 	}
 }
+
+func TestProtocolJSONMethodsDecodeBodiesAndReturnResponse(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name, method string
+		status       int
+		invoke       func(Protocol, any) (Response, error)
+	}{
+		{name: "post", method: http.MethodPost, status: http.StatusOK, invoke: func(p Protocol, dst any) (Response, error) {
+			return p.PostJSON(context.Background(), "http://factory.test/work", strings.NewReader(`{"name":"request"}`), dst)
+		}},
+		{name: "post created", method: http.MethodPost, status: http.StatusCreated, invoke: func(p Protocol, dst any) (Response, error) {
+			return p.PostJSONCreated(context.Background(), "http://factory.test/work", strings.NewReader(`{"name":"request"}`), dst)
+		}},
+		{name: "put", method: http.MethodPut, status: http.StatusOK, invoke: func(p Protocol, dst any) (Response, error) {
+			return p.PutJSON(context.Background(), "http://factory.test/work", strings.NewReader(`{"name":"request"}`), dst)
+		}},
+		{name: "put created", method: http.MethodPut, status: http.StatusCreated, invoke: func(p Protocol, dst any) (Response, error) {
+			return p.PutJSONCreated(context.Background(), "http://factory.test/work", strings.NewReader(`{"name":"request"}`), dst)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clock := &clockSequence{values: []time.Time{time.Unix(3, 0), time.Unix(3, int64(23*time.Millisecond))}}
+			protocol, err := NewProtocol(doerFunc(func(request *http.Request) (*http.Response, error) {
+				if request.Method != test.method {
+					t.Fatalf("method = %s, want %s", request.Method, test.method)
+				}
+				if request.Header.Get("Content-Type") != "application/json" {
+					t.Fatalf("Content-Type = %q", request.Header.Get("Content-Type"))
+				}
+				body, readErr := io.ReadAll(request.Body)
+				if readErr != nil {
+					t.Fatalf("request body: %v", readErr)
+				}
+				if string(body) != `{"name":"request"}` {
+					t.Fatalf("request body = %q", body)
+				}
+				return &http.Response{
+					StatusCode: test.status,
+					Request:    request,
+					Body:       io.NopCloser(strings.NewReader(`{"name":"response"}`)),
+				}, nil
+			}), clock)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var decoded struct {
+				Name string `json:"name"`
+			}
+			result, err := test.invoke(protocol, &decoded)
+			if err != nil {
+				t.Fatalf("invoke: %v", err)
+			}
+			if result.HTTP == nil || result.HTTP.StatusCode != test.status {
+				t.Fatalf("response = %#v", result.HTTP)
+			}
+			if result.Duration != 23*time.Millisecond {
+				t.Fatalf("duration = %s", result.Duration)
+			}
+			if decoded.Name != "response" {
+				t.Fatalf("decoded response = %#v", decoded)
+			}
+			_ = result.HTTP.Body.Close()
+		})
+	}
+}
+
+func TestProtocolReturnsUnexpectedStatusWithoutDecoding(t *testing.T) {
+	t.Parallel()
+	clock := &clockSequence{values: []time.Time{time.Unix(4, 0), time.Unix(4, int64(7*time.Millisecond))}}
+	body := &trackedBody{Reader: strings.NewReader(`{"message":"server rejected request"}`)}
+	protocol, err := NewProtocol(doerFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusAccepted, Request: request, Body: body}, nil
+	}), clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded struct {
+		Message string `json:"message"`
+	}
+	result, err := protocol.GetJSON(context.Background(), "http://factory.test/work", &decoded)
+	if err != nil {
+		t.Fatalf("GetJSON: %v", err)
+	}
+	if result.HTTP == nil || result.HTTP.StatusCode != http.StatusAccepted {
+		t.Fatalf("response = %#v", result.HTTP)
+	}
+	if result.Duration != 7*time.Millisecond {
+		t.Fatalf("duration = %s", result.Duration)
+	}
+	if decoded.Message != "" {
+		t.Fatalf("unexpected status was decoded into %#v", decoded)
+	}
+	if body.closed {
+		t.Fatal("unexpected-status response body was closed before the caller could decode it")
+	}
+	_ = result.HTTP.Body.Close()
+}
+
+func TestProtocolRejectsInvalidURLWithTypedMetadata(t *testing.T) {
+	clock := &clockSequence{values: []time.Time{time.Unix(5, 0)}}
+	protocol, err := NewProtocol(doerFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("invalid URL reached the HTTP doer")
+		return nil, nil
+	}), clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const invalidURL = "://not-a-url"
+	_, gotErr := protocol.GetJSON(context.Background(), invalidURL, nil)
+	var httpErr *HTTPError
+	if !errors.As(gotErr, &httpErr) {
+		t.Fatalf("error = %T %v, want *HTTPError", gotErr, gotErr)
+	}
+	if httpErr.CLIHTTPMethod() != http.MethodGet || httpErr.CLIHTTPURL() != invalidURL || httpErr.CLIHTTPStatus() != 0 {
+		t.Fatalf("HTTP metadata = (%q, %q, %d)", httpErr.CLIHTTPMethod(), httpErr.CLIHTTPURL(), httpErr.CLIHTTPStatus())
+	}
+	if !strings.Contains(httpErr.Error(), "build request") {
+		t.Fatalf("error = %q, want request construction context", httpErr.Error())
+	}
+}
+
+func TestProtocolTransportFailureUsesResponseRequestMetadata(t *testing.T) {
+	t.Parallel()
+	request, err := http.NewRequest(http.MethodPost, "https://factory.test/original", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	responseRequest, err := http.NewRequest(http.MethodPut, "https://factory.test/actual?token=secret", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cause := errors.New("connection reset")
+	clock := &clockSequence{values: []time.Time{time.Unix(6, 0), time.Unix(6, int64(13*time.Millisecond))}}
+	response := &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Request:    responseRequest,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+	protocol, err := NewProtocol(doerFunc(func(*http.Request) (*http.Response, error) {
+		return response, cause
+	}), clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, gotErr := protocol.Execute(request)
+	if result.HTTP != response || result.Duration != 13*time.Millisecond {
+		t.Fatalf("result = %#v", result)
+	}
+	if !errors.Is(gotErr, cause) {
+		t.Fatalf("error = %v, want cause %v", gotErr, cause)
+	}
+	var metadata interface {
+		CLIHTTPMethod() string
+		CLIHTTPURL() string
+		CLIHTTPStatus() int
+	}
+	if !errors.As(gotErr, &metadata) {
+		t.Fatalf("error = %T, want HTTP metadata", gotErr)
+	}
+	if metadata.CLIHTTPMethod() != http.MethodPut || metadata.CLIHTTPURL() != responseRequest.URL.String() || metadata.CLIHTTPStatus() != http.StatusBadGateway {
+		t.Fatalf("HTTP metadata = (%q, %q, %d)", metadata.CLIHTTPMethod(), metadata.CLIHTTPURL(), metadata.CLIHTTPStatus())
+	}
+	_ = response.Body.Close()
+}
+
+func TestDecodeAPIErrorRejectsMissingOrMalformedBodies(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		response *http.Response
+	}{
+		{name: "nil response"},
+		{name: "nil body", response: &http.Response{}},
+		{name: "malformed JSON", response: &http.Response{Body: io.NopCloser(strings.NewReader("{"))}},
+		{name: "message-less JSON", response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"code":"NOT_FOUND"}`))}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decoded, ok := DecodeAPIError(test.response)
+			if ok {
+				t.Fatalf("decoded = %#v, want rejection", decoded)
+			}
+			if test.response != nil && test.response.Body != nil {
+				_ = test.response.Body.Close()
+			}
+		})
+	}
+}
+
+func TestAPIErrorSafeFallbacksAndNilAccessors(t *testing.T) {
+	t.Parallel()
+	var nilError *APIError
+	if nilError.Error() != "" || nilError.Unwrap() != nil || nilError.CLIErrorCode() != "" || nilError.CLIErrorFamily() != "" || nilError.CLIErrorMessage() != "" || nilError.CLIHTTPMethod() != "" || nilError.CLIHTTPURL() != "" || nilError.CLIHTTPStatus() != 0 {
+		t.Fatal("nil APIError did not expose safe zero values")
+	}
+	if got := nilError.CLIErrorResponse(); got != (factoryapi.ErrorResponse{}) {
+		t.Fatalf("nil API response = %#v", got)
+	}
+
+	messageOnly := NewAPIError(0, factoryapi.ErrorResponse{Message: " server message "}, " ", nil)
+	if messageOnly.Error() != "server message" || messageOnly.CLIErrorMessage() != "server message" {
+		t.Fatalf("message-only error = %q / %q", messageOnly.Error(), messageOnly.CLIErrorMessage())
+	}
+	statusOnly := NewAPIError(http.StatusServiceUnavailable, factoryapi.ErrorResponse{}, "", nil)
+	if statusOnly.Error() != "HTTP request failed (503)" {
+		t.Fatalf("status-only error = %q", statusOnly.Error())
+	}
+	empty := NewAPIErrorFromResponse(nil, factoryapi.ErrorResponse{}, "", nil)
+	if empty.Error() != "HTTP request failed" || empty.CLIHTTPMethod() != "" || empty.CLIHTTPURL() != "" || empty.CLIHTTPStatus() != 0 {
+		t.Fatalf("empty error = %#v", empty)
+	}
+}
+
+func TestHTTPErrorSafeFallbacksAndMetadataWrappers(t *testing.T) {
+	t.Parallel()
+	var nilError *HTTPError
+	if nilError.Error() != "" || nilError.Unwrap() != nil || nilError.CLIHTTPMethod() != "" || nilError.CLIHTTPURL() != "" || nilError.CLIHTTPStatus() != 0 {
+		t.Fatal("nil HTTPError did not expose safe zero values")
+	}
+	if (&HTTPError{}).Error() != "HTTP request failed" {
+		t.Fatal("empty HTTPError did not use the safe fallback")
+	}
+	if NewHTTPError(http.MethodGet, "http://factory.test", 0, nil) != nil || NewHTTPErrorFromResponse(nil, nil) != nil || NewHTTPErrorFromRequest(nil, nil) != nil || WithHTTPResponse(nil, nil) != nil {
+		t.Fatal("nil HTTP causes should not manufacture errors")
+	}
+
+	request, err := http.NewRequest(http.MethodDelete, "https://factory.test/work", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cause := errors.New("server unavailable")
+	response := &http.Response{StatusCode: http.StatusServiceUnavailable, Request: request}
+	wrapped := NewHTTPErrorFromResponse(response, cause)
+	if !errors.Is(wrapped, cause) || wrapped.(interface{ CLIHTTPMethod() string }).CLIHTTPMethod() != http.MethodDelete {
+		t.Fatalf("wrapped response error = %v", wrapped)
+	}
+	if WithHTTPResponse(response, wrapped) != wrapped {
+		t.Fatal("WithHTTPResponse replaced existing HTTP metadata")
+	}
+	withMetadata := WithHTTPResponse(response, cause)
+	var metadata interface {
+		CLIHTTPMethod() string
+		CLIHTTPURL() string
+		CLIHTTPStatus() int
+	}
+	if !errors.As(withMetadata, &metadata) || metadata.CLIHTTPMethod() != http.MethodDelete || metadata.CLIHTTPURL() != request.URL.String() || metadata.CLIHTTPStatus() != http.StatusServiceUnavailable {
+		t.Fatalf("wrapped metadata = %T (%v)", withMetadata, withMetadata)
+	}
+}

--- a/pkg/transports/cli/serverstop/serverstop_test.go
+++ b/pkg/transports/cli/serverstop/serverstop_test.go
@@ -119,6 +119,27 @@ func TestOperationMapsUnreachableAndRequestTimeout(t *testing.T) {
 	}
 }
 
+func TestOperationMapsCanceledRequestToTypedFailure(t *testing.T) {
+	op := NewOperationWithDependencies(
+		func(string) (Client, error) {
+			return &fakeClient{err: context.Canceled}, nil
+		},
+		StopObserverFunc(func(context.Context, string, time.Duration) error {
+			return errors.New("must not observe canceled request")
+		}),
+		time.Second,
+		time.Second,
+	)
+
+	err := op(context.Background(), Config{
+		Server: "http://localhost:7437", Output: io.Discard,
+	})
+	assertServerStopError(t, err, CanceledCode)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled request error = %v, want context.Canceled cause", err)
+	}
+}
+
 func TestOperationReturnsObservationTimeoutWhenListenerStaysOpen(t *testing.T) {
 	op := NewOperationWithDependencies(
 		func(string) (Client, error) { return &fakeClient{response: acceptedShutdownResponse()}, nil },

--- a/tests/functional/transport/cli/diagnostics/remote_http_test.go
+++ b/tests/functional/transport/cli/diagnostics/remote_http_test.go
@@ -2,6 +2,7 @@ package diagnostics_test
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/pkg/transports/cli/clihttp"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
@@ -294,6 +296,17 @@ func TestRemoteSessionShowPreservesStructuredServerDiagnostic(t *testing.T) {
 				response.Family != factoryapi.ErrorFamilyNotFound ||
 				response.Message != "remote session is unavailable" {
 				t.Fatalf("server failure diagnostic = %#v, want preserved NOT_FOUND response", response)
+			}
+			if !debug {
+				var apiError *clihttp.APIError
+				if !errors.As(err, &apiError) {
+					t.Fatalf("server failure error = %T, want clihttp.APIError", err)
+				}
+				fallback := *apiError
+				fallback.DisplayMessage = ""
+				if got := fallback.Error(); got != response.Message {
+					t.Fatalf("APIError fallback message = %q, want %q", got, response.Message)
+				}
 			}
 			if debug {
 				for _, want := range []string{

--- a/tests/functional/transport/cli/diagnostics/remote_http_test.go
+++ b/tests/functional/transport/cli/diagnostics/remote_http_test.go
@@ -1,0 +1,401 @@
+package diagnostics_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+type observedHTTPCall struct {
+	method      string
+	path        string
+	contentType string
+	body        []byte
+}
+
+func TestRemoteFactoryReplaceCurrentUsesJSONPutAndRendersSuccess(t *testing.T) {
+	var calls []observedHTTPCall
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			http.Error(writer, "could not read request", http.StatusBadRequest)
+			return
+		}
+		calls = append(calls, observedHTTPCall{
+			method:      request.Method,
+			path:        request.URL.Path,
+			contentType: request.Header.Get("Content-Type"),
+			body:        body,
+		})
+
+		if request.URL.Path != "/factory-sessions/~default/factory" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		switch request.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(writer).Encode(factoryapi.Factory{Name: "remote"})
+		case http.MethodPut:
+			if request.Header.Get("Content-Type") != "application/json" {
+				http.Error(writer, "missing JSON content type", http.StatusBadRequest)
+				return
+			}
+			var payload factoryapi.SaveFactoryForSessionRequest
+			if err := json.Unmarshal(body, &payload); err != nil || payload.Factory.Name != "remote" {
+				http.Error(writer, "invalid replacement payload", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(writer).Encode(factoryapi.Factory{Name: "remote"})
+		default:
+			http.Error(writer, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	inputs := remoteInputs(t, "you", "--json", "--server", server.URL, "factory", "replace-current")
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf("Process.Execute(factory replace-current) error = %v\nstdout=%q\nstderr=%q", err, inputs.Stdout(), inputs.Stderr())
+	}
+	if inputs.Stderr() != "" {
+		t.Fatalf("successful remote replacement stderr = %q, want empty", inputs.Stderr())
+	}
+	var result factoryapi.Factory
+	if err := json.Unmarshal([]byte(inputs.Stdout()), &result); err != nil {
+		t.Fatalf("decode successful replacement stdout: %v\nstdout=%q", err, inputs.Stdout())
+	}
+	if result.Name != "remote" {
+		t.Fatalf("successful replacement result name = %q, want remote", result.Name)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("observed HTTP calls = %#v, want GET followed by PUT", calls)
+	}
+	if calls[0].method != http.MethodGet || calls[1].method != http.MethodPut {
+		t.Fatalf("observed HTTP methods = %#v, want GET followed by PUT", calls)
+	}
+	if calls[1].contentType != "application/json" {
+		t.Fatalf("PUT content type = %q, want application/json", calls[1].contentType)
+	}
+}
+
+func TestRemoteSubmitUsesCreatedResponseAndPreservesPayloadContract(t *testing.T) {
+	var received factoryapi.SubmitWorkRequest
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost || request.URL.Path != "/factory-sessions/~default/work" {
+			http.NotFound(writer, request)
+			return
+		}
+		if request.Header.Get("Content-Type") != "application/json" {
+			http.Error(writer, "missing JSON content type", http.StatusBadRequest)
+			return
+		}
+		if err := json.NewDecoder(request.Body).Decode(&received); err != nil {
+			http.Error(writer, "invalid submit payload", http.StatusBadRequest)
+			return
+		}
+		name := "remote-submit"
+		workType := "task"
+		workID := "work-remote-submit"
+		sessionID := "~default"
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(writer).Encode(factoryapi.SubmitWorkResponse{
+			Name:         &name,
+			WorkTypeName: &workType,
+			WorkId:       &workID,
+			SessionId:    &sessionID,
+			TraceId:      "trace-remote-submit",
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	payloadPath := filepath.Join(t.TempDir(), "request.md")
+	if err := os.WriteFile(payloadPath, []byte("remote payload"), 0o644); err != nil {
+		t.Fatalf("write submit payload: %v", err)
+	}
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	inputs := remoteInputs(t,
+		"you", "--json", "--server", server.URL,
+		"submit", "--name", "remote-submit", "--work-type-name", "task", "--payload", payloadPath,
+	)
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf("Process.Execute(submit) error = %v\nstdout=%q\nstderr=%q", err, inputs.Stdout(), inputs.Stderr())
+	}
+	if inputs.Stderr() != "" {
+		t.Fatalf("successful remote submit stderr = %q, want empty", inputs.Stderr())
+	}
+	var result struct {
+		WorkID       string `json:"workId"`
+		Name         string `json:"name"`
+		WorkTypeName string `json:"workTypeName"`
+		TraceID      string `json:"traceId"`
+		SessionID    string `json:"sessionId"`
+	}
+	if err := json.Unmarshal([]byte(inputs.Stdout()), &result); err != nil {
+		t.Fatalf("decode submit stdout: %v\nstdout=%q", err, inputs.Stdout())
+	}
+	if result.WorkID != "work-remote-submit" || result.Name != "remote-submit" ||
+		result.WorkTypeName != "task" || result.TraceID != "trace-remote-submit" || result.SessionID != "~default" {
+		t.Fatalf("submit result = %#v, want created response fields", result)
+	}
+	if received.Name == nil || *received.Name != "remote-submit" || received.WorkTypeName != "task" {
+		t.Fatalf("received submit request = %#v, want name and work type", received)
+	}
+	payload, err := json.Marshal(received.Payload)
+	if err != nil {
+		t.Fatalf("marshal received payload: %v", err)
+	}
+	if string(payload) != `"remote payload"` {
+		t.Fatalf("received payload = %s, want JSON string payload", payload)
+	}
+}
+
+func TestRunFlagConflictRendersCodedBadRequest(t *testing.T) {
+	inputs := remoteInputs(t, "you", "--json", "run", "--resume", "resume.json", "--no-record")
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	if err := process.Execute(inputs.Input); err == nil {
+		t.Fatal("Process.Execute(run flag conflict) error = nil, want rejected flags")
+	}
+	if inputs.Stdout() != "" {
+		t.Fatalf("run flag conflict stdout = %q, want empty", inputs.Stdout())
+	}
+	response := decodeFirstErrorResponse(t, inputs.Stderr())
+	if response.Code != factoryapi.ErrorResponseCode("CLI_FLAG_CONFLICT") ||
+		response.Family != factoryapi.ErrorFamilyBadRequest ||
+		response.Message != "--resume cannot be used with --no-record" {
+		t.Fatalf("run flag conflict diagnostic = %#v, want coded bad-request response", response)
+	}
+}
+
+func TestRemoteTransportFailureUsesSafeFallbackAndDebugMetadata(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	serverURL := server.URL
+	server.Close()
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	inputs := remoteInputs(t, "you", "--json", "--debug", "--server", serverURL, "session", "show", "missing")
+	if err := process.Execute(inputs.Input); err == nil {
+		t.Fatal("Process.Execute(unreachable remote session) error = nil, want transport failure")
+	}
+	if inputs.Stdout() != "" {
+		t.Fatalf("unreachable remote session stdout = %q, want empty", inputs.Stdout())
+	}
+	response := decodeFirstErrorResponse(t, inputs.Stderr())
+	if response.Code != factoryapi.ErrorResponseCode("CLI_COMMAND_FAILED") ||
+		response.Family != factoryapi.ErrorFamilyInternalServerError ||
+		response.Message != "command failed" {
+		t.Fatalf("transport failure diagnostic = %#v, want safe fallback", response)
+	}
+	for _, want := range []string{
+		"debug: http method=GET",
+		"url=" + serverURL + "/factory-sessions/missing",
+		"status=<unavailable>",
+	} {
+		if !strings.Contains(inputs.Stderr(), want) {
+			t.Fatalf("transport failure debug diagnostic = %q, want %q", inputs.Stderr(), want)
+		}
+	}
+}
+
+func TestRemoteRunPreservesStructuredAdmissionDiagnostic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost || request.URL.Path != "/factory-sessions/async" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusBadGateway)
+		_ = json.NewEncoder(writer).Encode(factoryapi.ErrorResponse{
+			Code:    factoryapi.ErrorResponseCode("REMOTE_ADMISSION_REJECTED"),
+			Family:  factoryapi.ErrorFamilyInternalServerError,
+			Message: "remote admission is unavailable",
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	factoryPath := filepath.Join(t.TempDir(), "remote-factory.json")
+	if err := os.WriteFile(factoryPath, []byte(remoteDiagnosticFactoryJSON), 0o600); err != nil {
+		t.Fatalf("write remote run factory: %v", err)
+	}
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	inputs := remoteInputs(t,
+		"you", "--json", "--remote", "--server", server.URL,
+		"run", "--factory", factoryPath, "--no-record", "remote request",
+	)
+	if err := process.Execute(inputs.Input); err == nil {
+		t.Fatal("Process.Execute(remote run) error = nil, want admission failure")
+	}
+	if inputs.Stdout() != "" {
+		t.Fatalf("remote run admission stdout = %q, want empty", inputs.Stdout())
+	}
+	response := decodeFirstErrorResponse(t, inputs.Stderr())
+	if response.Code != factoryapi.ErrorResponseCode("REMOTE_DURABLE_START_FAILED") ||
+		response.Family != factoryapi.ErrorFamilyInternalServerError ||
+		!strings.Contains(response.Message, "remote admission is unavailable") {
+		t.Fatalf("remote run admission diagnostic = %#v, want preserved failure context", response)
+	}
+}
+
+func TestRemoteSessionShowPreservesStructuredServerDiagnostic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodGet || request.URL.Path != "/factory-sessions/missing" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(writer).Encode(factoryapi.ErrorResponse{
+			Code:    factoryapi.ErrorResponseCodeNOTFOUND,
+			Family:  factoryapi.ErrorFamilyNotFound,
+			Message: "remote session is unavailable",
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	for _, debug := range []bool{false, true} {
+		name := "normal"
+		args := []string{"you", "--json"}
+		if debug {
+			name = "debug"
+			args = append(args, "--debug")
+		}
+		args = append(args, "--server", server.URL, "session", "show", "missing")
+
+		t.Run(name, func(t *testing.T) {
+			inputs := remoteInputs(t, args...)
+			err := process.Execute(inputs.Input)
+			if err == nil {
+				t.Fatal("Process.Execute(session show) error = nil, want server failure")
+			}
+			if inputs.Stdout() != "" {
+				t.Fatalf("server failure stdout = %q, want empty", inputs.Stdout())
+			}
+			response := decodeFirstErrorResponse(t, inputs.Stderr())
+			if response.Code != factoryapi.ErrorResponseCodeNOTFOUND ||
+				response.Family != factoryapi.ErrorFamilyNotFound ||
+				response.Message != "remote session is unavailable" {
+				t.Fatalf("server failure diagnostic = %#v, want preserved NOT_FOUND response", response)
+			}
+			if debug {
+				for _, want := range []string{
+					"debug: http method=GET",
+					"status=404",
+					"url=" + server.URL + "/factory-sessions/missing",
+				} {
+					if !strings.Contains(inputs.Stderr(), want) {
+						t.Fatalf("debug diagnostic = %q, want %q", inputs.Stderr(), want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRemoteFactoryShowMalformedResponseUsesSafeDebugDiagnostic(t *testing.T) {
+	const opaqueResponseMarker = "opaque-response-secret"
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodGet || request.URL.Path != "/factory-sessions/~default/factory" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(writer, `{"name":"`+opaqueResponseMarker+`"`)
+	}))
+	t.Cleanup(server.Close)
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	inputs := remoteInputs(t, "you", "--debug", "--server", server.URL, "factory", "show")
+	if err := process.Execute(inputs.Input); err == nil {
+		t.Fatal("Process.Execute(factory show) error = nil, want malformed-response failure")
+	}
+	if inputs.Stdout() != "" {
+		t.Fatalf("malformed-response stdout = %q, want empty", inputs.Stdout())
+	}
+	response := decodeFirstErrorResponse(t, inputs.Stderr())
+	if response.Code != factoryapi.ErrorResponseCode("CLI_COMMAND_FAILED") ||
+		response.Family != factoryapi.ErrorFamilyInternalServerError ||
+		response.Message != "command failed" {
+		t.Fatalf("malformed-response diagnostic = %#v, want safe CLI_COMMAND_FAILED fallback", response)
+	}
+	for _, want := range []string{
+		"debug: http method=GET",
+		"status=200",
+		"url=" + server.URL + "/factory-sessions/~default/factory",
+	} {
+		if !strings.Contains(inputs.Stderr(), want) {
+			t.Fatalf("malformed-response debug diagnostic = %q, want %q", inputs.Stderr(), want)
+		}
+	}
+	if strings.Contains(inputs.Stderr(), opaqueResponseMarker) {
+		t.Fatalf("malformed-response debug diagnostic leaked opaque response body: %q", inputs.Stderr())
+	}
+}
+
+func remoteInputs(t *testing.T, args ...string) *support.CapturedInputs {
+	t.Helper()
+	inputs := support.FakeInputs(t.Context(), args)
+	home := t.TempDir()
+	inputs.Input.Env = append(os.Environ(), "HOME="+home, "USERPROFILE="+home)
+	inputs.Input.WorkingDirectory = t.TempDir()
+	return inputs
+}
+
+func decodeFirstErrorResponse(t *testing.T, stderr string) factoryapi.ErrorResponse {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(stderr), "\n") {
+		var response factoryapi.ErrorResponse
+		if err := json.Unmarshal([]byte(line), &response); err == nil && response.Code != "" {
+			return response
+		}
+	}
+	t.Fatalf("decode CLI error response: stderr=%q", stderr)
+	return factoryapi.ErrorResponse{}
+}
+
+const remoteDiagnosticFactoryJSON = `{
+  "name": "remote-diagnostics",
+  "invocationSignature": {
+    "parameters": [{
+      "name": "prompt",
+      "required": true,
+      "bindings": [{"kind": "POSITIONAL", "position": 1}]
+    }]
+  },
+  "workTypes": [{
+    "name": "task",
+    "states": [
+      {"name": "init", "type": "INITIAL"},
+      {"name": "complete", "type": "TERMINAL"},
+      {"name": "failed", "type": "FAILED"}
+    ]
+  }],
+  "workers": [{"name": "processor"}],
+  "workstations": [{
+    "name": "process",
+    "inputs": [{"workType": "task", "state": "init"}],
+    "outputs": [{"workType": "task", "state": "complete"}],
+    "onFailure": [{"workType": "task", "state": "failed"}],
+    "worker": "processor"
+  }]
+}`

--- a/tests/functional/transport/cli/diagnostics/server_stop_test.go
+++ b/tests/functional/transport/cli/diagnostics/server_stop_test.go
@@ -1,0 +1,315 @@
+package diagnostics_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const serverStopFunctionalObservationTimeout = 2 * time.Second
+
+func TestServerStopStopsComposedLoopbackServerAndRendersSuccess(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		jsonOutput bool
+	}{{name: "human"}, {name: "json", jsonOutput: true}} {
+		t.Run(test.name, func(t *testing.T) {
+			server := startObservedLoopbackServer(t)
+			inputs, err := executeServerStop(t, server.process, context.Background(), server.url, test.jsonOutput)
+			if err != nil {
+				t.Fatalf("Process.Execute(server stop) error = %v\nstdout=%q\nstderr=%q", err, inputs.Stdout(), inputs.Stderr())
+			}
+			if inputs.Stderr() != "" {
+				t.Fatalf("successful server stop stderr = %q, want empty", inputs.Stderr())
+			}
+
+			calls := server.shutdownRequests.Calls()
+			if len(calls) != 1 {
+				t.Fatalf("shutdown HTTP calls = %#v, want exactly one typed request", calls)
+			}
+			if calls[0].method != http.MethodPost || calls[0].path != "/shutdown" {
+				t.Fatalf("shutdown HTTP call = %#v, want POST /shutdown", calls[0])
+			}
+			assertLoopbackListenerClosed(t, server.url)
+			waitForProcessDone(t, server.daemon)
+
+			if test.jsonOutput {
+				var result struct {
+					Server string `json:"server"`
+					Status string `json:"status"`
+				}
+				if err := json.Unmarshal([]byte(strings.TrimSpace(inputs.Stdout())), &result); err != nil {
+					t.Fatalf("decode JSON server-stop success: %v\nstdout=%q", err, inputs.Stdout())
+				}
+				if result.Server != server.url || result.Status != "stopped" {
+					t.Fatalf("JSON server-stop result = %#v, want server=%q status=stopped", result, server.url)
+				}
+				return
+			}
+			if got, want := inputs.Stdout(), fmt.Sprintf("Server stopped: %s\n", server.url); got != want {
+				t.Fatalf("human server-stop stdout = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestServerStopComposedFailureDiagnostics(t *testing.T) {
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+
+	t.Run("non-loopback target is rejected before request", func(t *testing.T) {
+		inputs, err := executeServerStop(t, process, context.Background(), "http://203.0.113.10:7437", true)
+		assertServerStopDiagnostic(t, inputs, err, "SERVER_STOP_INVALID_TARGET", factoryapi.ErrorFamilyBadRequest, "not a local bind target")
+	})
+
+	t.Run("unreachable loopback endpoint", func(t *testing.T) {
+		server := httptest.NewServer(http.NotFoundHandler())
+		endpoint := server.URL
+		server.Close()
+
+		inputs, err := executeServerStop(t, process, context.Background(), endpoint, true)
+		assertServerStopDiagnostic(t, inputs, err, "SERVER_STOP_UNREACHABLE", factoryapi.ErrorFamilyInternalServerError, "cannot reach Factory API")
+	})
+
+	t.Run("server-declared rejection", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			writer.Header().Set("Content-Type", "application/json")
+			writer.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(writer).Encode(factoryapi.ErrorResponse{
+				Code:    factoryapi.ErrorResponseCode("SHUTDOWN_CONTROL_REJECTED"),
+				Family:  factoryapi.ErrorFamilyBadRequest,
+				Message: "shutdown control requires a loopback peer",
+			})
+		}))
+		t.Cleanup(server.Close)
+
+		inputs, err := executeServerStop(t, process, context.Background(), server.URL, true)
+		assertServerStopDiagnostic(t, inputs, err, "SHUTDOWN_CONTROL_REJECTED", factoryapi.ErrorFamilyBadRequest, "requires a loopback peer")
+	})
+
+	t.Run("listener remains open until observation deadline", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			if request.Method != http.MethodPost || request.URL.Path != "/shutdown" {
+				http.NotFound(writer, request)
+				return
+			}
+			writer.Header().Set("Content-Type", "application/json")
+			writer.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(writer).Encode(factoryapi.ShutdownAcceptedResponse{
+				Status:  factoryapi.Accepted,
+				Message: "graceful shutdown accepted",
+			})
+		}))
+		t.Cleanup(server.Close)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		inputs, err := executeServerStop(t, process, ctx, server.URL, true)
+		assertServerStopDiagnostic(t, inputs, err, "SERVER_STOP_OBSERVATION_TIMEOUT", factoryapi.ErrorFamilyInternalServerError, "did not stop")
+		if inputs.Stdout() != "" {
+			t.Fatalf("listener-open server-stop stdout = %q, want empty", inputs.Stdout())
+		}
+	})
+}
+
+func TestServerStopCanceledRequestPreservesProcessCancellationContract(t *testing.T) {
+	requestStarted := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		close(requestStarted)
+		<-request.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	support.CleanupProcess(t, process)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	inputs := support.FakeInputs(ctx, []string{"you", "--json", "--server", server.URL, "server", "stop"})
+
+	result := make(chan error, 1)
+	go func() { result <- process.Execute(inputs.Input) }()
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("canceled server-stop request did not reach the HTTP boundary")
+	}
+	cancel()
+
+	err := <-result
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled server-stop error = %v, want context.Canceled", err)
+	}
+	if inputs.Stdout() != "" {
+		t.Fatalf("canceled server-stop stdout = %q, want empty", inputs.Stdout())
+	}
+	if got, want := inputs.Stderr(), "Error: context canceled\n"; got != want {
+		t.Fatalf("canceled server-stop stderr = %q, want existing process-control diagnostic %q", got, want)
+	}
+}
+
+func startObservedLoopbackServer(t *testing.T) *composedLoopbackServer {
+	t.Helper()
+
+	api := support.NewProcessAPIServer()
+	requests := &shutdownRequestProbe{}
+	process := support.BuildProcess(t, serviceedges.Edges{
+		APIServerStarter: func(ctx context.Context, request platformhttpserver.StartRequest) error {
+			handler := request.Handler
+			request.Handler = http.HandlerFunc(func(writer http.ResponseWriter, incoming *http.Request) {
+				if incoming.Method == http.MethodPost && incoming.URL.Path == "/shutdown" {
+					requests.Record(incoming)
+				}
+				handler.ServeHTTP(writer, incoming)
+			})
+			return api.Start(ctx, request)
+		},
+	})
+	support.CleanupProcess(t, process)
+
+	factoryDir := support.ScaffoldSingleStepFactory(t, "server-stop-functional")
+	homeDir := t.TempDir()
+	daemonInputs := support.FakeInputs(context.Background(), []string{
+		"you", "run",
+		"--dir", factoryDir,
+		"--continuously",
+		"--with-server",
+		"--quiet",
+		"--no-record",
+	})
+	daemonInputs.Input.Env = serverStopEnvironment(homeDir)
+	daemonInputs.Input.WorkingDirectory = factoryDir
+	daemon := support.StartProcessCommand(t, process, daemonInputs.Input)
+
+	return &composedLoopbackServer{
+		process:          process,
+		daemon:           daemon,
+		url:              api.WaitForURL(t),
+		shutdownRequests: requests,
+	}
+}
+
+type composedLoopbackServer struct {
+	process          support.Process
+	daemon           *support.ProcessCommand
+	url              string
+	shutdownRequests *shutdownRequestProbe
+}
+
+type shutdownRequest struct {
+	method string
+	path   string
+}
+
+type shutdownRequestProbe struct {
+	mu    sync.Mutex
+	calls []shutdownRequest
+}
+
+func (probe *shutdownRequestProbe) Record(request *http.Request) {
+	if probe == nil || request == nil {
+		return
+	}
+	probe.mu.Lock()
+	defer probe.mu.Unlock()
+	probe.calls = append(probe.calls, shutdownRequest{method: request.Method, path: request.URL.Path})
+}
+
+func (probe *shutdownRequestProbe) Calls() []shutdownRequest {
+	if probe == nil {
+		return nil
+	}
+	probe.mu.Lock()
+	defer probe.mu.Unlock()
+	return append([]shutdownRequest(nil), probe.calls...)
+}
+
+func executeServerStop(
+	t testing.TB,
+	process support.Process,
+	ctx context.Context,
+	endpoint string,
+	jsonOutput bool,
+) (*support.CapturedInputs, error) {
+	t.Helper()
+	args := []string{"you"}
+	if jsonOutput {
+		args = append(args, "--json")
+	}
+	args = append(args, "--server", endpoint, "server", "stop")
+	inputs := support.FakeInputs(ctx, args)
+	homeDir := t.TempDir()
+	inputs.Input.Env = serverStopEnvironment(homeDir)
+	inputs.Input.WorkingDirectory = homeDir
+	return inputs, process.Execute(inputs.Input)
+}
+
+func serverStopEnvironment(homeDir string) []string {
+	return append(os.Environ(), "HOME="+homeDir, "USERPROFILE="+homeDir)
+}
+
+func assertServerStopDiagnostic(
+	t testing.TB,
+	inputs *support.CapturedInputs,
+	err error,
+	wantCode string,
+	wantFamily factoryapi.ErrorFamily,
+	wantMessage string,
+) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("server-stop error = nil, want %s", wantCode)
+	}
+	if inputs.Stdout() != "" {
+		t.Fatalf("server-stop failure stdout = %q, want empty", inputs.Stdout())
+	}
+	var response factoryapi.ErrorResponse
+	if decodeErr := json.Unmarshal([]byte(strings.TrimSpace(inputs.Stderr())), &response); decodeErr != nil {
+		t.Fatalf("decode server-stop diagnostic: %v\nstderr=%q\nerror=%v", decodeErr, inputs.Stderr(), err)
+	}
+	if response.Code != factoryapi.ErrorResponseCode(wantCode) || response.Family != wantFamily || !strings.Contains(response.Message, wantMessage) {
+		t.Fatalf("server-stop diagnostic = %#v, want code=%s family=%s message containing %q", response, wantCode, wantFamily, wantMessage)
+	}
+}
+
+func assertLoopbackListenerClosed(t *testing.T, endpoint string) {
+	t.Helper()
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		t.Fatalf("parse stopped server URL: %v", err)
+	}
+	address := net.JoinHostPort(parsed.Hostname(), parsed.Port())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	connection, err := (&net.Dialer{}).DialContext(ctx, "tcp", address)
+	if err == nil {
+		_ = connection.Close()
+		t.Fatalf("stopped listener at %s still accepted a TCP connection", address)
+	}
+}
+
+func waitForProcessDone(t *testing.T, command *support.ProcessCommand) {
+	t.Helper()
+	select {
+	case <-command.Done():
+		if err := command.Err(); err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("composed server process error after server stop = %v", err)
+		}
+	case <-time.After(serverStopFunctionalObservationTimeout):
+		t.Fatalf("composed server process did not finish within %s after listener shutdown", serverStopFunctionalObservationTimeout)
+	}
+}

--- a/tests/functional/transport/cli/diagnostics/server_stop_test.go
+++ b/tests/functional/transport/cli/diagnostics/server_stop_test.go
@@ -117,6 +117,11 @@ func TestServerStopComposedFailureDiagnostics(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
+		// The live HTTP boundary must exercise the production observer's
+		// observation-timeout classification when the accepted server stays
+		// open. This caller deadline is the bounded negative-case contract
+		// observation; an injected observer or manual cancellation would test a
+		// different error path and would not prove the composed behavior.
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 		inputs, err := executeServerStop(t, process, ctx, server.URL, true)
@@ -143,6 +148,10 @@ func TestServerStopCanceledRequestPreservesProcessCancellationContract(t *testin
 
 	result := make(chan error, 1)
 	go func() { result <- process.Execute(inputs.Input) }()
+	// requestStarted is the deterministic signal that the composed command
+	// reached the HTTP boundary. The timer is only a hang guard for a
+	// regression that prevents request dispatch; an injected edge would skip
+	// the live transport boundary this cancellation scenario is meant to prove.
 	select {
 	case <-requestStarted:
 	case <-time.After(time.Second):
@@ -293,9 +302,12 @@ func assertLoopbackListenerClosed(t *testing.T, endpoint string) {
 		t.Fatalf("parse stopped server URL: %v", err)
 	}
 	address := net.JoinHostPort(parsed.Hostname(), parsed.Port())
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	connection, err := (&net.Dialer{}).DialContext(ctx, "tcp", address)
+	// Process.Execute returns success only after the production listener
+	// observer has seen this loopback endpoint stop accepting connections. A
+	// direct dial is therefore the deterministic postcondition check; the
+	// listener is numeric loopback, so a separate dial timeout would add no
+	// useful synchronization or contract coverage.
+	connection, err := net.Dial("tcp", address)
 	if err == nil {
 		_ = connection.Close()
 		t.Fatalf("stopped listener at %s still accepted a TCP connection", address)
@@ -304,6 +316,10 @@ func assertLoopbackListenerClosed(t *testing.T, endpoint string) {
 
 func waitForProcessDone(t *testing.T, command *support.ProcessCommand) {
 	t.Helper()
+	// Done is the deterministic signal that the composed daemon's
+	// Process.Execute invocation returned. The timer is only a bounded hang
+	// guard for a lifecycle regression; replacing it with an edge would remove
+	// the process-boundary behavior this functional scenario verifies.
 	select {
 	case <-command.Done():
 		if err := command.Err(); err != nil && !errors.Is(err, context.Canceled) {


### PR DESCRIPTION
{
  "project": "Recover CLI transport package coverage floors",
  "branchName": "cov-floor-cli-transports",
  "description": "Restore blocking unit and functional coverage for the CLI HTTP protocol, central CLI diagnostics, and loopback server-stop command through meaningful behavioral tests, without changing runtime contracts, lowering floors, or touching packages outside the three-package ownership lane.",
  "context": {
    "customerAsk": "Raise only pkg/transports/cli/clihttp, pkg/transports/cli/clidiag, and pkg/transports/cli/serverstop back to their blocking package floors through package-owned unit tests and functional CLI scenarios, quote fresh before/after measurements, and reconcile concurrent shared-manifest edits immediately before the final push.",
    "problem": "After an advisory enforcement window, origin/main CI run 32733189021 measured clihttp at 77.5% unit against 90.0% and 56.5% functional against 67.5%, clidiag at 66.0% functional against 80.0%, and serverstop at 2.1% functional against 15.0%. PR #2163 restored blocking enforcement, so these gaps now fail required coverage and Verification Policy checks.",
    "solution": "Add focused clihttp unit scenarios plus composed functional CLI scenarios for remote HTTP diagnostics and loopback server shutdown. Verify observable stdout, stderr, typed failures, HTTP requests, and listener lifecycle; rerun the real unit and functional coverage instruments; and preserve all floors, policy settings, contracts, and sibling-owned package entries."
  },
  "acceptanceCriteria": [
    "Package-owned unit tests exercise clihttp request construction, expected-status decoding, response metadata, and representative transport or malformed-response failures; a fresh make test-unit-coverage run reports pkg/transports/cli/clihttp at or above its unchanged 90.0% floor.",
    "Functional scenarios invoke the composed CLI through supported process boundaries and prove remote HTTP success/failure diagnostics plus loopback server-stop success/failure outcomes; a fresh make test-functional-coverage run reports pkg/transports/cli/clihttp at or above 67.5%, pkg/transports/cli/clidiag at or above 80.0%, and pkg/transports/cli/serverstop at or above 15.0%.",
    "Coverage is raised through assertions on observable CLI/HTTP behavior, not private-helper-only calls, meta-tests, lowered floors, policy changes, exclusions, skips, or manifest edits outside the three owned package entries; no package outside this lane has its floor or test behavior changed, and docs/internal/baselines/deadcode-baseline.txt is untouched.",
    "Runtime-proof classification: this lane does not change runtime-observable CLI, API, UI, emitted-event, or lifecycle behavior; runtime proof is not applicable because it adds regression coverage for existing CLI transport behavior without changing the delivered artifact or its contracts.",
    "Typecheck passes; focused package and functional tests, make test-unit-coverage, make test-functional-coverage, and the relevant short backend tests pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "finalHeadEvidence": {
    "head": "46dae7d18f84cf987171253e5f220704548b1e3c",
    "base": "7843d2bdbecae45f25960c83e11b59ae9d600a80",
    "startingPercentages": {
      "clihttpUnit": "77.5%",
      "clihttpFunctional": "56.5%",
      "clidiagFunctional": "66.0%",
      "serverstopFunctional": "2.1%"
    },
    "hostedPropertySpecificPercentages": {
      "clihttpUnit": "99.3%",
      "clidiagUnit": "91.2%",
      "serverstopUnit": "66.3%",
      "clihttpFunctional": "68.1%",
      "clidiagFunctional": "82.0%",
      "serverstopFunctional": "68.4%"
    },
    "coverageRun": "https://github.com/portpowered/you-agent-factory/actions/runs/32804597031",
    "baselineRun": "https://github.com/portpowered/you-agent-factory/actions/runs/32733189021",
    "classification": "Owned package floors pass on this PR head. The remaining unit and functional gate failures are unrelated package-floor debt reproduced on base (with one additional untouched unit package not present in the selected base run); no top-level functional tests failed."
  },
  "userStories": [
    {
      "id": "cov-floor-cli-transports-001",
      "title": "Cover CLI HTTP protocol outcomes in the unit lane",
      "description": "As a CLI maintainer, I want package-level tests to pin HTTP protocol success and failure outcomes so request construction, decoding, timing, and diagnostic metadata remain reliable.",
      "acceptanceCriteria": [
        "Package-owned tests exercise the supported GET, POST, and PUT JSON operations with their expected success statuses and verify method, content type, decoded result, returned response, and observed duration where applicable.",
        "Non-success statuses remain available to the calling CLI command without decoding a success payload, while transport errors, nil responses, invalid request URLs, and malformed successful JSON return typed errors with the available method, sanitized request target metadata, HTTP status, duration, and cause.",
        "API-error decoding accepts a valid server error response with a message and safely rejects nil, malformed, or message-less bodies without manufacturing server fields.",
        "Tests use injected HTTP and clock roles and assert public protocol/error behavior rather than calling private helpers solely to execute lines.",
        "A fresh unit-lane measurement reports pkg/transports/cli/clihttp at or above 90.0% without lowering or otherwise changing its floor.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added behavioral clihttp unit coverage for JSON request construction/decoding, expected and unexpected statuses, invalid URLs, transport/decode metadata, malformed API errors, and typed-error fallbacks. Focused go test coverage is 99.3% (up from 76.1%) and focused vet/tests pass. The full make test-unit-coverage run reached package-floor evaluation but exited on unrelated existing package-floor regressions outside this lane; no floor or policy was changed."
    },
    {
      "id": "cov-floor-cli-transports-002",
      "title": "Preserve remote CLI HTTP diagnostics in the functional lane",
      "description": "As a CLI user, I want remote commands to return decoded results on success and safe structured diagnostics on failure so automation and operators can distinguish server and transport outcomes.",
      "acceptanceCriteria": [
        "Focused functional scenarios construct through root.BuildProcess and invoke ordinary remote CLI flows through Process.Execute, using an HTTP boundary only as the external server behavior under test.",
        "A successful remote command sends the expected HTTP method and JSON content type, decodes the server response, and emits the existing success result on stdout without a failure diagnostic on stderr.",
        "A server-declared non-2xx response produces the existing structured CLI error code, family, message, and relevant HTTP status on stderr with a failing command result and no success-shaped stdout payload.",
        "A transport or malformed-response failure produces the existing safe fallback diagnostic; debug output, when enabled, includes useful method/status context while redacting credentials, query secrets, and sensitive cause text.",
        "Functional tests exercise clihttp and clidiag through the composed command path rather than importing private helpers, use deterministic server observations instead of sleeps, and do not duplicate or alter behavior owned by sibling CLI lanes.",
        "Fresh functional-lane measurement reports pkg/transports/cli/clihttp at or above 67.5% and pkg/transports/cli/clidiag at or above 80.0% without changing either floor.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added composed functional scenarios for remote factory replacement, 201 Created submit payloads, structured session and durable-run failures, transport failures, malformed responses, debug metadata, local flag conflicts, and the public APIError response-message fallback. Focused tests/vet pass; the fresh 148-package functional profile measures clihttp at 68.1159% (94/138) and clidiag at 81.9588% (159/194), above their unchanged 67.5% and 80.0% floors. The checker withheld its floor report because an unrelated recordings/process byte-volume test failed; serverstop remains for story 003."
    },
    {
      "id": "cov-floor-cli-transports-003",
      "title": "Prove bounded loopback server shutdown behavior",
      "description": "As an operator, I want you server stop to stop the selected local Factory API and report actionable failures so shutdown is safe, bounded, and scriptable.",
      "acceptanceCriteria": [
        "A functional scenario starts a composed Factory API on a loopback listener, invokes you --server <loopback-url> server stop through Process.Execute, observes exactly one typed shutdown request, and confirms the listener stops within the configured observation bound.",
        "Human and JSON success modes emit their existing success shape on stdout, keep stderr free of failure diagnostics, and return success only after listener shutdown is observed.",
        "A non-loopback target is rejected before any shutdown request, and an unreachable endpoint, rejected HTTP response, canceled request, or listener-that-remains-open returns the existing typed code, family, and actionable message without a false success payload.",
        "The scenario uses canonical process composition, isolates network/time effects through established edges where available, and uses listener or request observations rather than unexplained sleeps or timeout-padded polling.",
        "Fresh functional-lane measurement reports pkg/transports/cli/serverstop at or above 15.0% without changing its floor.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added composed Process.Execute scenarios for loopback server-stop human/JSON success, exactly one POST /shutdown, listener closure, non-loopback rejection, unreachable endpoints, server-declared rejection, canceled requests, and bounded still-open listeners. Addressed review feedback by documenting the live negative-case deadline and deterministic request/process signals, and by making the listener postcondition a direct loopback dial without a replaceable dial timeout. Focused tests, vet, and pkg-maint pass; a fresh functional profile measures pkg/transports/cli/serverstop at 68.4% (above its unchanged 15.0% floor). The package-level cancellation test preserves the typed SERVER_STOP_CANCELED outcome and the composed process test records the existing process-control rendering for cancellation; no runtime contract or floor changed. Story 004 remains for final full-lane measurements and PR delivery evidence."
    },
    {
      "id": "cov-floor-cli-transports-004",
      "title": "Reconcile and report final-head coverage evidence",
      "description": "As a reviewer, I want fresh final-head measurements for the complete owned package set so concurrent coverage lanes cannot hide or reintroduce a CLI transport floor regression.",
      "acceptanceCriteria": [
        "Immediately before the final push, the branch is rebased onto current origin/main, ancestry is verified, and shared coverage files are reconciled so only the entries for pkg/transports/cli/clihttp, pkg/transports/cli/clidiag, and pkg/transports/cli/serverstop may differ because of this lane; sibling-owned entries are preserved.",
        "Fresh local make test-unit-coverage and make test-functional-coverage invocations reach package-floor evaluation and report clihttp unit at least 90.0%, clihttp functional at least 67.5%, clidiag functional at least 80.0%, and serverstop functional at least 15.0%; a failed test run or output that never evaluates floors is not evidence.",
        "The PR body quotes the starting and final percentages for every required lane/package pair, including 77.5%, 56.5%, 66.0%, and 2.1%, and states that floors and blocking policy were not relaxed.",
        "Final-head CI evidence is property-specific, comes from this PR, and is recorded in a PR comment rather than a commit; unrelated or flaky tier failures are classified from the individual job log before any in-scope change is proposed.",
        "Runtime-proof classification: this lane does not change runtime-observable CLI, API, UI, emitted-event, or lifecycle behavior; runtime proof is not applicable because it adds regression coverage for existing CLI transport behavior without changing the delivered artifact or its contracts.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Final-head reconciliation is clean after rebase onto current origin/main (7843d2bdb); no shared coverage manifest or docs/internal/baselines/deadcode-baseline.txt entry differs, and the branch diff remains limited to the four intended behavioral test files in the three owned CLI transport areas. Starting measurements: clihttp unit 77.5%, clihttp functional 56.5%, clidiag functional 66.0%, serverstop functional 2.1%. Final hosted property-specific evidence on head 46dae7d reports clihttp unit 99.3%, clidiag unit 91.2%, serverstop unit 66.3%, clihttp functional 68.1%, clidiag functional 82.0%, and serverstop functional 68.4%, all above unchanged floors. The rerun hosted unit and functional checks still fail only on package-floor violations outside this lane (16 of 17 unit failures overlap base run 32733189021; the additional untouched models/wire failure is absent from that base report; all 14 functional failures reproduce on base), with 1,200 top-level functional tests and zero failures; Verification Policy fails only because those selected coverage checks fail. The failed jobs were rerun once as required, and no unrelated package, floor, policy, manifest, or baseline change is authorized by this lane. Focused package/functional tests, go vet, make typecheck, and make pkg-maint pass; the server-stop synchronization review feedback is resolved. Final head 46dae7d18f84cf987171253e5f220704548b1e3c is pushed, PR #2286 is open, and hosted CI run 32804597031 has completed. Floors and blocking policy were not changed."
    }
  ]
}
