### PR TITLE
functional-test-verbose-output-cleanup

### DIFF
--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -444,7 +444,7 @@ func configureFunctionalTimingSnapshot(plan *coverageInvocationPlan, cfg config,
 
 func finalizeFunctionalTiming(cfg config, snapshotter *functionalTimingSnapshotter, stdout string, testPackages []string, wallSeconds float64, laneErr error, expectedFunctionalInventory *functionalTestInventory) error {
 	runtimeInventoryGate := expectedFunctionalInventory != nil
-	if strings.TrimSpace(cfg.timingOutput) == "" && !runtimeInventoryGate {
+	if strings.TrimSpace(cfg.timingOutput) == "" && !runtimeInventoryGate && cfg.suite != functionalCoverageSuite {
 		if snapshotter != nil {
 			snapshotter.stopAndWait()
 		}
@@ -472,8 +472,13 @@ func finalizeFunctionalTiming(cfg config, snapshotter *functionalTimingSnapshott
 	} else {
 		err = writeFunctionalTimingSummaryJSON(cfg.timingOutput, summary)
 	}
-	if err == nil && cfg.suite == "functional" {
+	if err == nil && cfg.suite == functionalCoverageSuite {
 		writeFunctionalTimingInventorySummary(summary, cfg.short)
+		if summary.Complete {
+			if reportErr := writeFunctionalTimingReport(summary); reportErr != nil {
+				err = errors.Join(err, reportErr)
+			}
+		}
 	}
 	return errors.Join(err, inventoryErr)
 }

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -359,7 +359,7 @@ func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, test
 			failedTestCountKnown = failedTestCountKnown && known
 		}
 
-		detail := mergeGoTestFailureDetail(batchStderr, coverageFailureDetailStdout(cfg, batchStdout))
+		detail := coverageFailureDetail(cfg, batchStdout, batchStderr)
 		batchFailurePrefix := failurePrefix
 		if len(plan.invocations) > 1 {
 			batchFailurePrefix = fmt.Sprintf("%s (batch %d/%d)", failurePrefix, index+1, len(plan.invocations))
@@ -412,13 +412,13 @@ func configureFunctionalTimingSnapshot(plan *coverageInvocationPlan, cfg config,
 	}
 	var reporter *functionalStreamReporter
 	if cfg.stream {
-		reporter = configureCoverageInvocationStreaming(plan, true, observer)
+		reporter = configureCoverageInvocationStreamingForSuite(plan, true, cfg.suite == functionalCoverageSuite, observer)
 	} else {
 		reporter = configureCoverageInvocationObservation(plan, observer)
 	}
 	sink := io.Writer(nil)
 	var sinkMu *sync.Mutex
-	if cfg.stream {
+	if cfg.stream && cfg.suite != functionalCoverageSuite {
 		sink = stdoutWriter
 		sinkMu = &reporter.sinkMu
 	}
@@ -630,6 +630,10 @@ func runCommand(invocation commandInvocation) (string, string, error) {
 }
 
 func configureCoverageInvocationStreaming(plan *coverageInvocationPlan, enabled bool, observers ...func(goTestTimingEvent)) *functionalStreamReporter {
+	return configureCoverageInvocationStreamingForSuite(plan, enabled, false, observers...)
+}
+
+func configureCoverageInvocationStreamingForSuite(plan *coverageInvocationPlan, enabled bool, suppressHumanOutput bool, observers ...func(goTestTimingEvent)) *functionalStreamReporter {
 	if !enabled {
 		return nil
 	}
@@ -637,10 +641,14 @@ func configureCoverageInvocationStreaming(plan *coverageInvocationPlan, enabled 
 	if len(observers) > 0 {
 		observer = observers[0]
 	}
-	reporter := newFunctionalStreamReporterWithObserver(stdoutWriter, observer)
+	reporter := newFunctionalStreamReporterWithObserverMode(stdoutWriter, observer, suppressHumanOutput)
 	for index := range plan.invocations {
 		plan.invocations[index].stdoutWriter = reporter.stdoutWriter()
-		plan.invocations[index].stderrWriter = reporter.stderrWriter(stderrWriter)
+		stderrSink := io.Writer(stderrWriter)
+		if suppressHumanOutput {
+			stderrSink = io.Discard
+		}
+		plan.invocations[index].stderrWriter = reporter.stderrWriter(stderrSink)
 	}
 	return reporter
 }
@@ -664,13 +672,21 @@ func configureCoverageInvocationObservation(plan *coverageInvocationPlan, observ
 // keeps a failing unit lane exactly as diagnosable as it is with timing capture
 // switched off.
 //
-// A streaming lane already forwarded the human text to its sink line by line,
-// so its buffer is returned unchanged.
+// A non-quiet streaming lane already forwarded the human text to its sink line
+// by line, so its buffer is returned unchanged. The functional lane uses a
+// quiet streaming reporter and is rendered by coverageFailureDetail instead.
 func coverageFailureDetailStdout(cfg config, stdout string) string {
 	if cfg.stream || strings.TrimSpace(cfg.timingOutput) == "" {
 		return stdout
 	}
 	return renderGoTestEventOutput(stdout)
+}
+
+func coverageFailureDetail(cfg config, stdout string, stderr string) string {
+	if cfg.suite == functionalCoverageSuite && (cfg.stream || strings.TrimSpace(cfg.timingOutput) != "") {
+		return mergeGoTestFailureDetail(stderr, renderFunctionalFailureDetail(stdout))
+	}
+	return mergeGoTestFailureDetail(stderr, coverageFailureDetailStdout(cfg, stdout))
 }
 
 // renderGoTestEventOutput reconstitutes the human-readable go test stream from

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -473,7 +473,6 @@ func finalizeFunctionalTiming(cfg config, snapshotter *functionalTimingSnapshott
 		err = writeFunctionalTimingSummaryJSON(cfg.timingOutput, summary)
 	}
 	if err == nil && cfg.suite == functionalCoverageSuite {
-		writeFunctionalTimingInventorySummary(summary, cfg.short)
 		if summary.Complete {
 			if reportErr := writeFunctionalTimingReport(summary); reportErr != nil {
 				err = errors.Join(err, reportErr)

--- a/cmd/gocoveragecheck/coverage_verdict.go
+++ b/cmd/gocoveragecheck/coverage_verdict.go
@@ -80,7 +80,6 @@ func writeCoverageVerdict(label string, result coverageResult, failures []string
 	} else {
 		fmt.Fprintf(stdoutWriter, "%s package coverage verdict:\n", label)
 	}
-	writeBelowFloorCoverageLines(belowFloor)
 	for _, verdict := range verdicts {
 		writePackageCoverageVerdictLine(verdict, coverageLaneNoun(label), result)
 	}

--- a/cmd/gocoveragecheck/coverage_verdict.go
+++ b/cmd/gocoveragecheck/coverage_verdict.go
@@ -75,7 +75,12 @@ func writeCoverageVerdict(label string, result coverageResult, failures []string
 	belowFloor, _, nearFloor := partitionPackageCoverageVerdicts(verdicts)
 	slices.SortStableFunc(verdicts, comparePackageCoverageVerdicts)
 
-	fmt.Fprintf(stdoutWriter, "%s package coverage verdict:\n", label)
+	if label == coverageLaneLabel(functionalCoverageSuite) {
+		fmt.Fprintln(stdoutWriter, "pkg/ functional coverage:")
+	} else {
+		fmt.Fprintf(stdoutWriter, "%s package coverage verdict:\n", label)
+	}
+	writeBelowFloorCoverageLines(belowFloor)
 	for _, verdict := range verdicts {
 		writePackageCoverageVerdictLine(verdict, coverageLaneNoun(label), result)
 	}

--- a/cmd/gocoveragecheck/coverage_verdict_test.go
+++ b/cmd/gocoveragecheck/coverage_verdict_test.go
@@ -163,9 +163,16 @@ func TestFunctionalCoverageRunSuppressesPerPackageCoverageLines(t *testing.T) {
 	if err == nil {
 		t.Fatalf("execute() error = nil, want a non-zero floor-violation outcome")
 	}
+	if !strings.Contains(stdout, "pkg/ functional coverage:\n") {
+		t.Fatalf("functional coverage report missing its explicit pkg/ section:\n%s", stdout)
+	}
 	for _, coverPackage := range functionalVerdictCoverPackages {
 		if raw := coverPackage + "\tcoverage: "; strings.Contains(stdout, raw) {
 			t.Fatalf("functional stdout still streams the raw per-package line %q:\n%s", raw, stdout)
+		}
+		row := "  package=" + coverPackage + " coverage="
+		if got := strings.Count(stdout, row); got != 1 {
+			t.Fatalf("functional coverage row %q appears %d times, want one:\n%s", row, got, stdout)
 		}
 	}
 	if strings.Contains(stdout, "coverage: 71.4% of statements") {

--- a/cmd/gocoveragecheck/functional_failure.go
+++ b/cmd/gocoveragecheck/functional_failure.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// renderFunctionalFailureDetail reduces one captured go test -json stream to
+// the packages that actually failed. Successful packages can share the same
+// invocation as a failing package, so replaying the whole stream would put
+// their debug output back into the failure diagnostic.
+func renderFunctionalFailureDetail(jsonOutput string) string {
+	records := parseFunctionalFailureRecords(jsonOutput)
+	failedPackages := make(map[string]struct{})
+	failedTests := make(map[string]map[string]struct{})
+	for _, record := range records {
+		if record.event.Action != timingOutcomeFail || record.event.Package == "" {
+			continue
+		}
+		failedPackages[record.event.Package] = struct{}{}
+		if record.event.Test == "" {
+			continue
+		}
+		if failedTests[record.event.Package] == nil {
+			failedTests[record.event.Package] = make(map[string]struct{})
+		}
+		failedTests[record.event.Package][record.event.Test] = struct{}{}
+	}
+
+	if len(failedPackages) == 0 {
+		return renderFunctionalFailureFallback(jsonOutput)
+	}
+
+	packages := make([]string, 0, len(failedPackages))
+	for packageName := range failedPackages {
+		packages = append(packages, packageName)
+	}
+	sort.Strings(packages)
+
+	var detail strings.Builder
+	for _, packageName := range packages {
+		testNames := sortedFunctionalFailureTests(failedTests[packageName])
+		reason := firstFunctionalFailureReason(records, packageName, failedTests[packageName])
+		fmt.Fprintf(&detail, "functional test failure: package=%s", packageName)
+		if len(testNames) > 0 {
+			fmt.Fprintf(&detail, " test=%s", strings.Join(testNames, ","))
+		}
+		if reason != "" {
+			fmt.Fprintf(&detail, " reason=%s", reason)
+		}
+		if reason == "" {
+			detail.WriteString(" reason=package failure reported without diagnostic output")
+		}
+		detail.WriteByte('\n')
+	}
+	return strings.TrimSpace(detail.String())
+}
+
+type functionalFailureRecord struct {
+	event goTestTimingEvent
+}
+
+func parseFunctionalFailureRecords(jsonOutput string) []functionalFailureRecord {
+	records := make([]functionalFailureRecord, 0)
+	for _, line := range strings.Split(jsonOutput, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var event goTestTimingEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil || event.Package == "" {
+			continue
+		}
+		records = append(records, functionalFailureRecord{event: event})
+	}
+	return records
+}
+
+func sortedFunctionalFailureTests(tests map[string]struct{}) []string {
+	if len(tests) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(tests))
+	for testName := range tests {
+		result = append(result, testName)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func firstFunctionalFailureReason(records []functionalFailureRecord, packageName string, failedTests map[string]struct{}) string {
+	for _, record := range records {
+		if record.event.Package != packageName || record.event.Action != "output" {
+			continue
+		}
+		if record.event.Test != "" && len(failedTests) > 0 {
+			if _, failed := failedTests[record.event.Test]; !failed {
+				continue
+			}
+		}
+		if reason := compactFunctionalFailureReason(record.event.Output); reason != "" {
+			return reason
+		}
+	}
+	return ""
+}
+
+func compactFunctionalFailureReason(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "=== RUN") || strings.HasPrefix(line, "=== PAUSE") || strings.HasPrefix(line, "=== CONT") {
+			continue
+		}
+		if strings.HasPrefix(line, "coverage: ") || strings.HasPrefix(line, "ok ") || strings.HasPrefix(line, "ok\t") {
+			continue
+		}
+		if len(line) > maxTimingFailureReasonLength {
+			return line[:maxTimingFailureReasonLength] + "..."
+		}
+		return line
+	}
+	return ""
+}
+
+func renderFunctionalFailureFallback(output string) string {
+	rendered := renderGoTestEventOutput(output)
+	lines := make([]string, 0)
+	for _, line := range strings.Split(rendered, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !isFunctionalFailureDiagnosticLine(line) {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	return strings.Join(lines, "\n")
+}
+
+func isFunctionalFailureDiagnosticLine(line string) bool {
+	for _, prefix := range []string{
+		"--- FAIL:",
+		"FAIL",
+		"panic:",
+		"fatal error:",
+		"test timed out",
+		"timeout",
+		"error:",
+		"syntax error",
+		"undefined:",
+	} {
+		if strings.HasPrefix(line, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/gocoveragecheck/functional_failure_test.go
+++ b/cmd/gocoveragecheck/functional_failure_test.go
@@ -63,6 +63,7 @@ func TestFunctionalRunSuppressesSuccessfulChildChatterAndKeepsArtifacts(t *testi
 	}
 
 	for _, forbidden := range []string{
+		"Functional suite inventory:",
 		"TestNoisy",
 		"=== RUN",
 		"--- PASS",
@@ -70,6 +71,7 @@ func TestFunctionalRunSuppressesSuccessfulChildChatterAndKeepsArtifacts(t *testi
 		"ok  ",
 		"Functional package result:",
 		"Functional timing snapshot:",
+		"reason=PASS",
 		`{"Action"`,
 	} {
 		if strings.Contains(stdout, forbidden) {

--- a/cmd/gocoveragecheck/functional_failure_test.go
+++ b/cmd/gocoveragecheck/functional_failure_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenderFunctionalFailureDetailExcludesSuccessfulPackageOutput(t *testing.T) {
+	successPackage := modulePath + "/tests/functional/quiet/success"
+	failingPackage := modulePath + "/tests/functional/quiet/failure"
+	stream := strings.Join([]string{
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: "output", Package: successPackage, Test: "TestGreen", Output: "=== RUN   TestGreen\nsuccessful test debug log\n--- PASS: TestGreen (0.01s)\n"}),
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: timingOutcomePass, Package: successPackage, Test: "TestGreen", Elapsed: 0.01}),
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: timingOutcomePass, Package: successPackage, Elapsed: 0.02}),
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: "output", Package: failingPackage, Test: "TestBroken", Output: "=== RUN   TestBroken\nexpected 2 workstations, got 1\n--- FAIL: TestBroken (0.03s)\n"}),
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: timingOutcomeFail, Package: failingPackage, Test: "TestBroken", Elapsed: 0.03}),
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: timingOutcomeFail, Package: failingPackage, Elapsed: 0.04}),
+	}, "\n")
+
+	got := renderFunctionalFailureDetail(stream)
+	want := "functional test failure: package=" + failingPackage + " test=TestBroken reason=expected 2 workstations, got 1"
+	if got != want {
+		t.Fatalf("functional failure detail = %q, want %q", got, want)
+	}
+	if strings.Contains(got, successPackage) || strings.Contains(got, "successful test debug log") {
+		t.Fatalf("functional failure detail retained successful-package output: %q", got)
+	}
+}
+
+func TestFunctionalFailureDetailSortsMultipleFailedPackages(t *testing.T) {
+	firstPackage := modulePath + "/tests/functional/quiet/zeta"
+	secondPackage := modulePath + "/tests/functional/quiet/alpha"
+	stream := strings.Join([]string{
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: "output", Package: firstPackage, Output: "panic: zeta failure\n"}),
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: timingOutcomeFail, Package: firstPackage, Elapsed: 0.2}),
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: "output", Package: secondPackage, Output: "panic: alpha failure\n"}),
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: timingOutcomeFail, Package: secondPackage, Elapsed: 0.1}),
+	}, "\n")
+
+	got := renderFunctionalFailureDetail(stream)
+	want := strings.Join([]string{
+		"functional test failure: package=" + secondPackage + " reason=panic: alpha failure",
+		"functional test failure: package=" + firstPackage + " reason=panic: zeta failure",
+	}, "\n")
+	if got != want {
+		t.Fatalf("multiple functional failure detail = %q, want sorted %q", got, want)
+	}
+}
+
+func TestFunctionalRunSuppressesSuccessfulChildChatterAndKeepsArtifacts(t *testing.T) {
+	packageNames := []string{
+		modulePath + "/tests/functional/quiet/alpha",
+		modulePath + "/tests/functional/quiet/beta",
+	}
+	stream := functionalQuietSuccessEventStream(packageNames)
+	stdout, _, timingPath, err := captureFunctionalQuietRun(t, packageNames, stream, nil)
+	if err != nil {
+		t.Fatalf("functional quiet run error = %v\n%s", err, stdout)
+	}
+
+	for _, forbidden := range []string{
+		"TestNoisy",
+		"=== RUN",
+		"--- PASS",
+		"successful test debug log",
+		"ok  ",
+		"Functional package result:",
+		"Functional timing snapshot:",
+		`{"Action"`,
+	} {
+		if strings.Contains(stdout, forbidden) {
+			t.Fatalf("functional quiet stdout contains %q:\n%s", forbidden, stdout)
+		}
+	}
+	if strings.Count(stdout, functionalTimingReportHeader+"\n") != 1 {
+		t.Fatalf("functional timing section count = %d, want one:\n%s", strings.Count(stdout, functionalTimingReportHeader+"\n"), stdout)
+	}
+	for _, packageName := range packageNames {
+		row := "  package=" + packageName + " elapsed="
+		if strings.Count(stdout, row) != 1 {
+			t.Fatalf("functional timing row %q count = %d, want one:\n%s", row, strings.Count(stdout, row), stdout)
+		}
+	}
+	if _, err := os.Stat(timingPath); err != nil {
+		t.Fatalf("functional timing artifact was not written: %v", err)
+	}
+}
+
+func TestFunctionalRunFailureNamesOnlyFailedPackage(t *testing.T) {
+	packageNames := []string{
+		modulePath + "/tests/functional/quiet/success",
+		modulePath + "/tests/functional/quiet/failure",
+	}
+	stream := functionalQuietFailureEventStream(packageNames)
+	stdout, _, _, err := captureFunctionalQuietRun(t, packageNames, stream, errors.New("exit status 1"))
+	if err == nil {
+		t.Fatal("functional quiet run unexpectedly succeeded")
+	}
+
+	detail := err.Error()
+	if !strings.Contains(detail, "functional test failure: package="+packageNames[1]) ||
+		!strings.Contains(detail, "test=TestBroken") ||
+		!strings.Contains(detail, "reason=expected failure") {
+		t.Fatalf("functional failure detail = %q, want failed package, test, and reason", detail)
+	}
+	if strings.Contains(detail, packageNames[0]) || strings.Contains(detail, "successful test debug log") {
+		t.Fatalf("functional failure detail retained unrelated successful output: %q", detail)
+	}
+	if strings.Contains(stdout, "successful test debug log") || strings.Contains(stdout, "=== RUN") {
+		t.Fatalf("functional failure stdout retained child chatter:\n%s", stdout)
+	}
+}
+
+func captureFunctionalQuietRun(t *testing.T, packageNames []string, stream string, commandErr error) (string, string, string, error) {
+	t.Helper()
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	t.Cleanup(func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	})
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+	timingPath := filepath.Join(t.TempDir(), "functional-timing-summary.json")
+	commandRunner = func(invocation commandInvocation) (string, string, error) {
+		if invocation.name != "go" || len(invocation.args) == 0 || invocation.args[0] != "test" {
+			return "", "", fmt.Errorf("unexpected invocation: %q %v", invocation.name, invocation.args)
+		}
+		profilePath := helperCoverProfilePath(invocation.args[1:])
+		if profilePath == "" {
+			return "", "", errors.New("missing -coverprofile")
+		}
+		if err := writeFakeCoverageProfile(profilePath, strings.Join([]string{
+			"mode: count",
+			modulePath + "/pkg/config/config.go:1.1,2.1 3 1",
+			"",
+		}, "\n")); err != nil {
+			return "", "", err
+		}
+		if invocation.stdoutWriter != nil {
+			if _, err := invocation.stdoutWriter.Write([]byte(stream)); err != nil {
+				return "", "", err
+			}
+		}
+		return stream, "", commandErr
+	}
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	_, err := run(config{
+		min:          0,
+		suite:        functionalCoverageSuite,
+		totalOnly:    true,
+		stream:       true,
+		coverpkg:     modulePath + "/pkg/config",
+		packages:     strings.Join(packageNames, " "),
+		profile:      filepath.Join(t.TempDir(), "coverage.out"),
+		timingOutput: timingPath,
+	})
+	return stdout.String(), stderr.String(), timingPath, err
+}
+
+func functionalQuietSuccessEventStream(packageNames []string) string {
+	var events []string
+	for index, packageName := range packageNames {
+		events = append(events,
+			marshalGoTestEventOrPanic(goTestTimingEvent{Action: "run", Package: packageName, Test: "TestNoisy"}),
+			marshalGoTestEventOrPanic(goTestTimingEvent{Action: "output", Package: packageName, Test: "TestNoisy", Output: "=== RUN   TestNoisy\nsuccessful test debug log\n--- PASS: TestNoisy (0.01s)\n"}),
+			marshalGoTestEventOrPanic(goTestTimingEvent{Action: timingOutcomePass, Package: packageName, Test: "TestNoisy", Elapsed: 0.01}),
+			marshalGoTestEventOrPanic(goTestTimingEvent{Action: "output", Package: packageName, Output: "ok  \t" + packageName + "\t0.0" + fmt.Sprint(index+1) + "s\n"}),
+			marshalGoTestEventOrPanic(goTestTimingEvent{Action: timingOutcomePass, Package: packageName, Elapsed: float64(index+1) / 10}),
+		)
+	}
+	return strings.Join(events, "\n") + "\n"
+}
+
+func functionalQuietFailureEventStream(packageNames []string) string {
+	success := functionalQuietSuccessEventStream(packageNames[:1])
+	failurePackage := packageNames[1]
+	failure := strings.Join([]string{
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: "run", Package: failurePackage, Test: "TestBroken"}),
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: "output", Package: failurePackage, Test: "TestBroken", Output: "=== RUN   TestBroken\nexpected failure\n--- FAIL: TestBroken (0.02s)\n"}),
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: timingOutcomeFail, Package: failurePackage, Test: "TestBroken", Elapsed: 0.02}),
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: timingOutcomeFail, Package: failurePackage, Elapsed: 0.03}),
+	}, "\n")
+	return success + failure + "\n"
+}

--- a/cmd/gocoveragecheck/functional_stream.go
+++ b/cmd/gocoveragecheck/functional_stream.go
@@ -9,17 +9,20 @@ import (
 	"sync"
 )
 
-// functionalStreamReporter serializes the two child output streams so a
-// decoded test event and its human-readable package result reach the same
-// diagnostic sink as complete writes. Package completion is tracked across
+// functionalStreamReporter serializes the two child output streams so decoded
+// test events and any human-readable diagnostics reach the sink as complete
+// writes. Functional coverage uses the optional quiet mode: events still reach
+// the observer, while routine child text stays buffered in the command result
+// for failure-specific rendering. Package completion is tracked across
 // invocation batches because a functional selection can be split into more
 // than one go test process on Windows.
 type functionalStreamReporter struct {
-	sink              io.Writer
-	mu                sync.Mutex
-	sinkMu            sync.Mutex
-	completedPackages map[string]struct{}
-	onEvent           func(goTestTimingEvent)
+	sink                io.Writer
+	mu                  sync.Mutex
+	sinkMu              sync.Mutex
+	completedPackages   map[string]struct{}
+	onEvent             func(goTestTimingEvent)
+	suppressHumanOutput bool
 }
 
 type functionalStreamWriter struct {
@@ -52,8 +55,13 @@ func newFunctionalStreamReporter(sink io.Writer) *functionalStreamReporter {
 }
 
 func newFunctionalStreamReporterWithObserver(sink io.Writer, observer func(goTestTimingEvent)) *functionalStreamReporter {
+	return newFunctionalStreamReporterWithObserverMode(sink, observer, false)
+}
+
+func newFunctionalStreamReporterWithObserverMode(sink io.Writer, observer func(goTestTimingEvent), suppressHumanOutput bool) *functionalStreamReporter {
 	reporter := newFunctionalStreamReporter(sink)
 	reporter.onEvent = observer
+	reporter.suppressHumanOutput = suppressHumanOutput
 	return reporter
 }
 
@@ -90,6 +98,12 @@ func (writer *functionalStreamWriter) Write(data []byte) (int, error) {
 func (writer *functionalStreamWriter) Flush() error {
 	writer.reporter.mu.Lock()
 	defer writer.reporter.mu.Unlock()
+	if writer.reporter.suppressHumanOutput {
+		writer.pending = nil
+		writer.coverageContinuationBuffer = nil
+		writer.coverageOutputMode = functionalCoverageOutputNormal
+		return nil
+	}
 
 	if len(writer.pending) > 0 {
 		line := append([]byte(nil), writer.pending...)
@@ -104,10 +118,16 @@ func (writer *functionalStreamWriter) Flush() error {
 func (writer *functionalStreamWriter) writeLineLocked(line []byte) error {
 	var event goTestTimingEvent
 	if err := json.Unmarshal(bytes.TrimSpace(line), &event); err != nil || event.Package == "" {
+		if writer.reporter.suppressHumanOutput {
+			return nil
+		}
 		return writer.reporter.writeSink(line)
 	}
 	if writer.reporter.onEvent != nil {
 		writer.reporter.onEvent(event)
+	}
+	if writer.reporter.suppressHumanOutput {
+		return nil
 	}
 	if event.Action != "output" {
 		if err := writer.flushCoverageContinuationLocked(); err != nil {

--- a/cmd/gocoveragecheck/functional_stream.go
+++ b/cmd/gocoveragecheck/functional_stream.go
@@ -98,12 +98,6 @@ func (writer *functionalStreamWriter) Write(data []byte) (int, error) {
 func (writer *functionalStreamWriter) Flush() error {
 	writer.reporter.mu.Lock()
 	defer writer.reporter.mu.Unlock()
-	if writer.reporter.suppressHumanOutput {
-		writer.pending = nil
-		writer.coverageContinuationBuffer = nil
-		writer.coverageOutputMode = functionalCoverageOutputNormal
-		return nil
-	}
 
 	if len(writer.pending) > 0 {
 		line := append([]byte(nil), writer.pending...)
@@ -111,6 +105,11 @@ func (writer *functionalStreamWriter) Flush() error {
 		if err := writer.writeLineLocked(line); err != nil {
 			return err
 		}
+	}
+	if writer.reporter.suppressHumanOutput {
+		writer.coverageContinuationBuffer = nil
+		writer.coverageOutputMode = functionalCoverageOutputNormal
+		return nil
 	}
 	return writer.flushCoverageContinuationLocked()
 }

--- a/cmd/gocoveragecheck/functional_stream_test.go
+++ b/cmd/gocoveragecheck/functional_stream_test.go
@@ -83,6 +83,59 @@ func TestFunctionalStreamSuppressesKnownLifecycleActionsButNotObserverUpdates(t 
 	}
 }
 
+func TestFunctionalStreamQuietModeSuppressesConcurrentSuccessfulOutput(t *testing.T) {
+	var sink bytes.Buffer
+	var observedMu sync.Mutex
+	var observed []goTestTimingEvent
+	reporter := newFunctionalStreamReporterWithObserverMode(&sink, func(event goTestTimingEvent) {
+		observedMu.Lock()
+		defer observedMu.Unlock()
+		observed = append(observed, event)
+	}, true)
+	writer := reporter.stdoutWriter()
+	packages := []string{
+		modulePath + "/tests/functional/quiet/alpha",
+		modulePath + "/tests/functional/quiet/beta",
+	}
+	if _, err := writer.Write([]byte("raw successful test debug output\n")); err != nil {
+		t.Fatalf("write raw quiet functional output: %v", err)
+	}
+
+	var writes sync.WaitGroup
+	for index, packageName := range packages {
+		packageName := packageName
+		elapsed := float64(index+1) / 10
+		writes.Add(1)
+		go func() {
+			defer writes.Done()
+			for _, event := range []goTestTimingEvent{
+				{Action: "run", Package: packageName, Test: "TestNoisy"},
+				{Action: "output", Package: packageName, Test: "TestNoisy", Output: "=== RUN   TestNoisy\nsuccessful test debug log\n--- PASS: TestNoisy (0.01s)\n"},
+				{Action: timingOutcomePass, Package: packageName, Test: "TestNoisy", Elapsed: 0.01},
+				{Action: "output", Package: packageName, Output: "ok  \t" + packageName + "\t" + fmt.Sprintf("%.3fs\n", elapsed)},
+				{Action: timingOutcomePass, Package: packageName, Elapsed: elapsed},
+			} {
+				if _, err := writer.Write(marshalFunctionalStreamEvent(event)); err != nil {
+					t.Errorf("write %s event: %v", packageName, err)
+				}
+			}
+		}()
+	}
+	writes.Wait()
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("flush quiet functional stream: %v", err)
+	}
+
+	if got := sink.String(); got != "" {
+		t.Fatalf("quiet functional stream emitted child output: %q", got)
+	}
+	observedMu.Lock()
+	defer observedMu.Unlock()
+	if len(observed) != len(packages)*5 {
+		t.Fatalf("quiet functional stream observer saw %d events, want %d", len(observed), len(packages)*5)
+	}
+}
+
 func TestFunctionalStreamPreservesUnknownActionAndNormalOutputAndResult(t *testing.T) {
 	var sink bytes.Buffer
 	reporter := newFunctionalStreamReporter(&sink)

--- a/cmd/gocoveragecheck/functional_stream_test.go
+++ b/cmd/gocoveragecheck/functional_stream_test.go
@@ -136,6 +136,38 @@ func TestFunctionalStreamQuietModeSuppressesConcurrentSuccessfulOutput(t *testin
 	}
 }
 
+func TestFunctionalStreamQuietFlushObservesUnterminatedEvent(t *testing.T) {
+	var sink bytes.Buffer
+	var observed []goTestTimingEvent
+	reporter := newFunctionalStreamReporterWithObserverMode(&sink, func(event goTestTimingEvent) {
+		observed = append(observed, event)
+	}, true)
+	writer := reporter.stdoutWriter()
+	packageName := modulePath + "/tests/functional/quiet/timeout"
+	finalEvent := goTestTimingEvent{
+		Action:  timingOutcomeFail,
+		Package: packageName,
+		Elapsed: 2.5,
+	}
+	data, err := json.Marshal(finalEvent)
+	if err != nil {
+		t.Fatalf("marshal final quiet event: %v", err)
+	}
+	if _, err := writer.Write(data); err != nil {
+		t.Fatalf("write unterminated quiet event: %v", err)
+	}
+
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("flush unterminated quiet event: %v", err)
+	}
+	if sink.Len() != 0 {
+		t.Fatalf("quiet flush emitted child output: %q", sink.String())
+	}
+	if len(observed) != 1 || observed[0] != finalEvent {
+		t.Fatalf("quiet flush observed = %+v, want final event %+v", observed, finalEvent)
+	}
+}
+
 func TestFunctionalStreamPreservesUnknownActionAndNormalOutputAndResult(t *testing.T) {
 	var sink bytes.Buffer
 	reporter := newFunctionalStreamReporter(&sink)

--- a/cmd/gocoveragecheck/timing.go
+++ b/cmd/gocoveragecheck/timing.go
@@ -202,43 +202,6 @@ func countTimingTestOutcomes(tests []functionalTestTimingJSON) (pass, fail, skip
 	return pass, fail, skip
 }
 
-func writeFunctionalTimingInventorySummary(summary functionalTimingSummaryJSON, short bool) {
-	packagePassCount, packageFailCount, packageSkipCount := 0, 0, 0
-	for _, pkg := range summary.Packages {
-		switch pkg.Outcome {
-		case timingOutcomePass:
-			packagePassCount++
-		case timingOutcomeFail:
-			packageFailCount++
-		case timingOutcomeSkip:
-			packageSkipCount++
-		}
-	}
-	deferredShortTests := 0
-	if short {
-		// The short tier deliberately leaves tests guarded by testing.Short in
-		// the discovered selection. Their skip outcomes are deferred work, not
-		// quarantine: the complete merge tier runs them with -short=false.
-		deferredShortTests = summary.TestSkipCount
-	}
-	fmt.Fprintf(
-		stdoutWriter,
-		"Functional suite inventory: discovered-packages=%d observed-packages=%d (pass=%d fail=%d skip=%d) top-level-tests=%d (pass=%d fail=%d skip=%d) deferred-short-tests=%d wall=%.3fs complete=%t\n",
-		summary.ExpectedPackageCount,
-		summary.PackageCount,
-		packagePassCount,
-		packageFailCount,
-		packageSkipCount,
-		summary.TestCount,
-		summary.TestPassCount,
-		summary.TestFailCount,
-		summary.TestSkipCount,
-		deferredShortTests,
-		summary.WallSeconds,
-		summary.Complete,
-	)
-}
-
 func roundTimingSeconds(seconds float64) float64 {
 	return math.Round(seconds*1000) / 1000
 }
@@ -283,7 +246,7 @@ func renderFunctionalTimingReport(summary functionalTimingSummaryJSON) string {
 			pkg.Seconds,
 			pkg.Outcome,
 		)
-		if pkg.Reason != "" {
+		if pkg.Outcome != timingOutcomePass && pkg.Reason != "" {
 			fmt.Fprintf(&report, " reason=%s", strings.Join(strings.Fields(pkg.Reason), " "))
 		}
 		report.WriteByte('\n')

--- a/cmd/gocoveragecheck/timing.go
+++ b/cmd/gocoveragecheck/timing.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"slices"
 	"strings"
@@ -18,6 +19,8 @@ const (
 	timingOutcomeFail = "fail"
 	timingOutcomeSkip = "skip"
 )
+
+const functionalTimingReportHeader = "tests/ functional-package timing:"
 
 const (
 	functionalPackageStateCompleted  = "completed"
@@ -261,4 +264,72 @@ func writeFunctionalTimingSummaryJSON(path string, summary functionalTimingSumma
 		return fmt.Errorf("write go functional timing summary json: %w", err)
 	}
 	return nil
+}
+
+// renderFunctionalTimingReport renders the terminal package timing section
+// from the same summary that is written to the timing artifact. The input is
+// copied into a path-ordered, duplicate-free list so concurrent package
+// completion order never changes the human report.
+func renderFunctionalTimingReport(summary functionalTimingSummaryJSON) string {
+	packages := stableFunctionalPackageTimings(summary.Packages)
+	var report strings.Builder
+	report.WriteString(functionalTimingReportHeader)
+	report.WriteByte('\n')
+	for _, pkg := range packages {
+		fmt.Fprintf(
+			&report,
+			"  package=%s elapsed=%.3fs outcome=%s",
+			pkg.Package,
+			pkg.Seconds,
+			pkg.Outcome,
+		)
+		if pkg.Reason != "" {
+			fmt.Fprintf(&report, " reason=%s", strings.Join(strings.Fields(pkg.Reason), " "))
+		}
+		report.WriteByte('\n')
+	}
+	if len(packages) == 0 {
+		report.WriteString("  no functional-test package timings observed\n")
+	}
+	return report.String()
+}
+
+func writeFunctionalTimingReport(summary functionalTimingSummaryJSON) error {
+	_, err := io.WriteString(stdoutWriter, renderFunctionalTimingReport(summary))
+	return err
+}
+
+func stableFunctionalPackageTimings(packages []functionalPackageTimingJSON) []functionalPackageTimingJSON {
+	byPackage := make(map[string]functionalPackageTimingJSON, len(packages))
+	for _, pkg := range packages {
+		if strings.TrimSpace(pkg.Package) == "" {
+			continue
+		}
+		current, exists := byPackage[pkg.Package]
+		if !exists || compareFunctionalPackageTimings(pkg, current) < 0 {
+			byPackage[pkg.Package] = pkg
+		}
+	}
+	ordered := make([]functionalPackageTimingJSON, 0, len(byPackage))
+	for _, pkg := range byPackage {
+		ordered = append(ordered, pkg)
+	}
+	slices.SortFunc(ordered, compareFunctionalPackageTimings)
+	return ordered
+}
+
+func compareFunctionalPackageTimings(left, right functionalPackageTimingJSON) int {
+	if result := strings.Compare(left.Package, right.Package); result != 0 {
+		return result
+	}
+	if left.Seconds < right.Seconds {
+		return -1
+	}
+	if left.Seconds > right.Seconds {
+		return 1
+	}
+	if result := strings.Compare(left.Outcome, right.Outcome); result != 0 {
+		return result
+	}
+	return strings.Compare(left.Reason, right.Reason)
 }

--- a/cmd/gocoveragecheck/timing_test.go
+++ b/cmd/gocoveragecheck/timing_test.go
@@ -352,41 +352,14 @@ func TestRunWritesFunctionalTimingSummaryOnSuccess(t *testing.T) {
 	if summary.Packages[0].Outcome != timingOutcomePass {
 		t.Fatalf("Packages[0].Outcome = %q, want pass", summary.Packages[0].Outcome)
 	}
-	if !strings.Contains(stdout.String(), "Functional suite inventory: discovered-packages=1 observed-packages=1") ||
-		!strings.Contains(stdout.String(), "top-level-tests=1 (pass=1 fail=0 skip=0) deferred-short-tests=0") {
-		t.Fatalf("stdout = %q, want full functional inventory summary", stdout.String())
+	if strings.Contains(stdout.String(), "Functional suite inventory:") || strings.Contains(stdout.String(), "pass=1 fail=0 skip=0") {
+		t.Fatalf("stdout = %q, want no inventory/pass-count chatter", stdout.String())
 	}
 	if got := strings.Count(stdout.String(), "tests/ functional-package timing:\n"); got != 1 {
 		t.Fatalf("stdout timing section count = %d, want one:\n%s", got, stdout.String())
 	}
 	if got := strings.Count(stdout.String(), "  package="+modulePath+"/pkg/config elapsed=0.500s outcome=pass\n"); got != 1 {
 		t.Fatalf("stdout timing row count = %d, want one:\n%s", got, stdout.String())
-	}
-}
-
-func TestWriteFunctionalTimingInventorySummaryReportsShortDeferredTests(t *testing.T) {
-	originalStdout := stdoutWriter
-	defer func() { stdoutWriter = originalStdout }()
-
-	var stdout bytes.Buffer
-	stdoutWriter = &stdout
-	summary := functionalTimingSummaryJSON{
-		ExpectedPackageCount: 1,
-		PackageCount:         1,
-		TestCount:            4,
-		TestPassCount:        1,
-		TestSkipCount:        3,
-	}
-
-	writeFunctionalTimingInventorySummary(summary, true)
-	if !strings.Contains(stdout.String(), "deferred-short-tests=3") {
-		t.Fatalf("short-tier summary = %q, want deferred-short-tests=3", stdout.String())
-	}
-
-	stdout.Reset()
-	writeFunctionalTimingInventorySummary(summary, false)
-	if !strings.Contains(stdout.String(), "deferred-short-tests=0") {
-		t.Fatalf("full-tier summary = %q, want deferred-short-tests=0", stdout.String())
 	}
 }
 
@@ -472,8 +445,8 @@ func TestRunPreservesTimingForFailedPackageWhileKeepingLaneFailed(t *testing.T) 
 	if len(summary.Packages) != 1 || summary.Packages[0].Outcome != timingOutcomeFail || summary.Packages[0].Seconds != 0.4 {
 		t.Fatalf("Packages = %+v, want one failed package retained with elapsed 0.4", summary.Packages)
 	}
-	if !strings.Contains(stdout.String(), "top-level-tests=1 (pass=0 fail=1 skip=0)") {
-		t.Fatalf("stdout = %q, want failed top-level test inventory", stdout.String())
+	if !strings.Contains(stdout.String(), "tests/ functional-package timing:") || strings.Contains(stdout.String(), "Functional suite inventory:") {
+		t.Fatalf("stdout = %q, want only the failed package timing section", stdout.String())
 	}
 }
 
@@ -556,8 +529,8 @@ func TestRenderFunctionalTimingReportIsSortedAndDeduplicated(t *testing.T) {
 	summary := functionalTimingSummaryJSON{
 		Complete: true,
 		Packages: []functionalPackageTimingJSON{
-			{Package: beta, Seconds: 2.0, Outcome: timingOutcomePass},
-			{Package: alpha, Seconds: 1.0, Outcome: timingOutcomePass},
+			{Package: beta, Seconds: 2.0, Outcome: timingOutcomePass, Reason: "PASS"},
+			{Package: alpha, Seconds: 1.0, Outcome: timingOutcomePass, Reason: "PASS"},
 			{Package: alpha, Seconds: 1.0, Outcome: timingOutcomePass},
 		},
 	}
@@ -575,8 +548,30 @@ func TestRenderFunctionalTimingReportIsSortedAndDeduplicated(t *testing.T) {
 	if strings.Count(first, alphaRow) != 1 || strings.Count(first, betaRow) != 1 {
 		t.Fatalf("functional timing rows = %q, want one row per package:\n%s", []string{alphaRow, betaRow}, first)
 	}
+	if strings.Contains(first, "reason=PASS") {
+		t.Fatalf("successful timing report retained package PASS chatter:\n%s", first)
+	}
 	if strings.Index(first, alphaRow) >= strings.Index(first, betaRow) {
 		t.Fatalf("functional timing rows are not path ordered:\n%s", first)
+	}
+}
+
+func TestRenderFunctionalTimingReportRetainsFailureReason(t *testing.T) {
+	t.Parallel()
+
+	packageName := modulePath + "/tests/functional/failure"
+	report := renderFunctionalTimingReport(functionalTimingSummaryJSON{
+		Complete: true,
+		Packages: []functionalPackageTimingJSON{{
+			Package: packageName,
+			Seconds: 1.25,
+			Outcome: timingOutcomeFail,
+			Reason:  "expected failure",
+		}},
+	})
+
+	if !strings.Contains(report, "outcome=fail reason=expected failure") {
+		t.Fatalf("failure timing report omitted diagnostic reason:\n%s", report)
 	}
 }
 

--- a/cmd/gocoveragecheck/timing_test.go
+++ b/cmd/gocoveragecheck/timing_test.go
@@ -356,6 +356,12 @@ func TestRunWritesFunctionalTimingSummaryOnSuccess(t *testing.T) {
 		!strings.Contains(stdout.String(), "top-level-tests=1 (pass=1 fail=0 skip=0) deferred-short-tests=0") {
 		t.Fatalf("stdout = %q, want full functional inventory summary", stdout.String())
 	}
+	if got := strings.Count(stdout.String(), "tests/ functional-package timing:\n"); got != 1 {
+		t.Fatalf("stdout timing section count = %d, want one:\n%s", got, stdout.String())
+	}
+	if got := strings.Count(stdout.String(), "  package="+modulePath+"/pkg/config elapsed=0.500s outcome=pass\n"); got != 1 {
+		t.Fatalf("stdout timing row count = %d, want one:\n%s", got, stdout.String())
+	}
 }
 
 func TestWriteFunctionalTimingInventorySummaryReportsShortDeferredTests(t *testing.T) {
@@ -539,6 +545,38 @@ func TestRenderFunctionalTimingSummaryJSONIsDeterministic(t *testing.T) {
 	}
 	if !bytes.Equal(first, second) {
 		t.Fatalf("timing summary json was not deterministic:\nfirst=%s\nsecond=%s", first, second)
+	}
+}
+
+func TestRenderFunctionalTimingReportIsSortedAndDeduplicated(t *testing.T) {
+	t.Parallel()
+
+	alpha := modulePath + "/tests/functional/alpha"
+	beta := modulePath + "/tests/functional/beta"
+	summary := functionalTimingSummaryJSON{
+		Complete: true,
+		Packages: []functionalPackageTimingJSON{
+			{Package: beta, Seconds: 2.0, Outcome: timingOutcomePass},
+			{Package: alpha, Seconds: 1.0, Outcome: timingOutcomePass},
+			{Package: alpha, Seconds: 1.0, Outcome: timingOutcomePass},
+		},
+	}
+
+	first := renderFunctionalTimingReport(summary)
+	second := renderFunctionalTimingReport(summary)
+	if first != second {
+		t.Fatalf("functional timing report was not deterministic:\nfirst=%s\nsecond=%s", first, second)
+	}
+	if !strings.HasPrefix(first, functionalTimingReportHeader+"\n") {
+		t.Fatalf("functional timing report missing labeled section:\n%s", first)
+	}
+	alphaRow := "  package=" + alpha + " elapsed=1.000s outcome=pass\n"
+	betaRow := "  package=" + beta + " elapsed=2.000s outcome=pass\n"
+	if strings.Count(first, alphaRow) != 1 || strings.Count(first, betaRow) != 1 {
+		t.Fatalf("functional timing rows = %q, want one row per package:\n%s", []string{alphaRow, betaRow}, first)
+	}
+	if strings.Index(first, alphaRow) >= strings.Index(first, betaRow) {
+		t.Fatalf("functional timing rows are not path ordered:\n%s", first)
 	}
 }
 

--- a/scripts/ci/functional-coverage-verdict.mjs
+++ b/scripts/ci/functional-coverage-verdict.mjs
@@ -31,6 +31,8 @@ function isCompactVerdictLine(line) {
 	return (
 		line.startsWith(inventoryPrefix) ||
 		line.startsWith("total: (statements)") ||
+		line.startsWith("pkg/ functional coverage:") ||
+		line.startsWith("tests/ functional-package timing:") ||
 		line.startsWith("Functional package coverage verdict:") ||
 		line.startsWith("  package=") ||
 		line.startsWith("  tally:") ||

--- a/scripts/ci/functional-coverage-verdict.mjs
+++ b/scripts/ci/functional-coverage-verdict.mjs
@@ -3,6 +3,9 @@ import { dirname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const inventoryPrefix = "Functional suite inventory:";
+const functionalTimingPrefix = "tests/ functional-package timing:";
+const functionalCoveragePrefix = "pkg/ functional coverage:";
+const coverageFailurePrefix = "coverage not evaluated:";
 const ordinaryGocoverageExitCode = 1;
 const advisoryPolicyBanner = "!!! COVERAGE FLOOR POLICY: advisory !!!";
 const failedCoverageTestDiagnostic = "package floors were NOT checked because the coverage test run failed";
@@ -30,14 +33,31 @@ function normalizedLines(log) {
 function isCompactVerdictLine(line) {
 	return (
 		line.startsWith(inventoryPrefix) ||
+		line.startsWith(functionalTimingPrefix) ||
+		line.startsWith(functionalCoveragePrefix) ||
 		line.startsWith("total: (statements)") ||
-		line.startsWith("pkg/ functional coverage:") ||
-		line.startsWith("tests/ functional-package timing:") ||
 		line.startsWith("Functional package coverage verdict:") ||
 		line.startsWith("  package=") ||
 		line.startsWith("  tally:") ||
+		(line.startsWith(coverageFailurePrefix) && line.includes(failedCoverageTestDiagnostic)) ||
 		/^(?:go|Go) coverage (?:found |.* below minimum |.* meets minimum )/.test(line)
 	);
+}
+
+function lastLineIndex(lines, prefix) {
+	return lines.findLastIndex((line) => line.startsWith(prefix));
+}
+
+function findFunctionalVerdictStart(lines) {
+	// The current runner begins its compact terminal report with the timing
+	// section. Coverage-only failure paths can begin with the coverage section
+	// or its concise test-failure diagnostic. Keep the inventory marker as a
+	// legacy fallback for logs produced before the quiet report was introduced.
+	for (const prefix of [inventoryPrefix, functionalTimingPrefix, functionalCoveragePrefix, coverageFailurePrefix]) {
+		const index = lastLineIndex(lines, prefix);
+		if (index >= 0) return index;
+	}
+	return -1;
 }
 
 function hasCoverageGateFailure(lines) {
@@ -82,10 +102,8 @@ function hasAdvisoryFinding(lines) {
 
 export function extractFunctionalCoverageVerdict(log) {
 	const lines = normalizedLines(log);
-	// Use the terminal inventory when a test itself happens to print the same
-	// prefix earlier in the full stream.
-	const inventoryIndex = lines.findLastIndex((line) => line.startsWith(inventoryPrefix));
-	if (inventoryIndex < 0) {
+	const verdictStart = findFunctionalVerdictStart(lines);
+	if (verdictStart < 0) {
 		return {
 			foundInventory: false,
 			text: "",
@@ -98,7 +116,7 @@ export function extractFunctionalCoverageVerdict(log) {
 		};
 	}
 
-	const tail = lines.slice(inventoryIndex);
+	const tail = lines.slice(verdictStart);
 	const advisoryLines = [...new Set(lines.filter(isAdvisoryPolicyLine))];
 	const verdictLines = [...new Set([
 		...advisoryLines,

--- a/scripts/ci/functional-coverage-verdict.test.mjs
+++ b/scripts/ci/functional-coverage-verdict.test.mjs
@@ -122,7 +122,9 @@ test("extracts only the compact verdict contract without verbose diagnostics", (
 		rawLine,
 		"Functional suite inventory: discovered-packages=3 observed-packages=3 (pass=1 fail=0 skip=0) top-level-tests=1 (pass=1 fail=0 skip=0) deferred-short-tests=0 wall=1.000s complete=true",
 		"total: (statements) 70.0%",
-		"Functional package coverage verdict:",
+		"pkg/ functional coverage:",
+		"tests/ functional-package timing:",
+		"  package=github.com/portpowered/infinite-you/tests/functional/alpha elapsed=1.000s outcome=pass",
 		"  floor violation: package=github.com/portpowered/infinite-you/pkg/alpha floor=75.0000% actual=70.0000% delta=-5.0000 percentage-points covered=7/10 statements uncovered-blocks=3",
 		"    pkg/alpha/file.go:41 (2 statements)",
 		"  package=github.com/portpowered/infinite-you/pkg/alpha coverage=70.0% floor=75.0% delta=-5.0pp gate=fail lane=functional",
@@ -144,6 +146,8 @@ test("extracts only the compact verdict contract without verbose diagnostics", (
 	assert.equal(extracted.text.includes("make: ***"), false);
 	assert.doesNotMatch(extracted.text, /floor violation|package coverage regression|coverage manifest missing|coverage not evaluated|uncovered blocks|file\.go:/);
 	assert.match(extracted.text, /Functional suite inventory:/);
+	assert.match(extracted.text, /pkg\/ functional coverage:/);
+	assert.match(extracted.text, /tests\/ functional-package timing:/);
 	assert.match(extracted.text, /  tally:/);
 });
 

--- a/scripts/ci/functional-coverage-verdict.test.mjs
+++ b/scripts/ci/functional-coverage-verdict.test.mjs
@@ -120,10 +120,9 @@ test("extracts only the compact verdict contract without verbose diagnostics", (
 	const rawLine = `{"Time":"2026-08-20T00:00:00Z","Action":"run","Package":"github.com/portpowered/infinite-you/tests/functional"}`;
 	const log = [
 		rawLine,
-		"Functional suite inventory: discovered-packages=3 observed-packages=3 (pass=1 fail=0 skip=0) top-level-tests=1 (pass=1 fail=0 skip=0) deferred-short-tests=0 wall=1.000s complete=true",
+		"tests/ functional-package timing:",
 		"total: (statements) 70.0%",
 		"pkg/ functional coverage:",
-		"tests/ functional-package timing:",
 		"  package=github.com/portpowered/infinite-you/tests/functional/alpha elapsed=1.000s outcome=pass",
 		"  floor violation: package=github.com/portpowered/infinite-you/pkg/alpha floor=75.0000% actual=70.0000% delta=-5.0000 percentage-points covered=7/10 statements uncovered-blocks=3",
 		"    pkg/alpha/file.go:41 (2 statements)",
@@ -145,10 +144,22 @@ test("extracts only the compact verdict contract without verbose diagnostics", (
 	assert.equal(extracted.text.includes(rawLine), false);
 	assert.equal(extracted.text.includes("make: ***"), false);
 	assert.doesNotMatch(extracted.text, /floor violation|package coverage regression|coverage manifest missing|coverage not evaluated|uncovered blocks|file\.go:/);
-	assert.match(extracted.text, /Functional suite inventory:/);
 	assert.match(extracted.text, /pkg\/ functional coverage:/);
 	assert.match(extracted.text, /tests\/ functional-package timing:/);
 	assert.match(extracted.text, /  tally:/);
+	assert.equal(extracted.text.includes("Functional suite inventory:"), false);
+});
+
+test("uses the concise test-failure diagnostic when no timing report was completed", () => {
+	const extracted = extractFunctionalCoverageVerdict(
+		[
+			"raw successful child output is omitted",
+			"coverage not evaluated: 1 failed tests observed; package floors were NOT checked because the coverage test run failed",
+		].join("\n"),
+	);
+	assert.equal(extracted.foundInventory, true);
+	assert.equal(extracted.hasOrdinaryTestFailure, true);
+	assert.match(extracted.text, /coverage not evaluated: 1 failed tests observed/);
 });
 
 test("retains the advisory banner and distinguishes report-only findings from failed tests", () => {

--- a/scripts/ci/functional-coverage-verdict.test.mjs
+++ b/scripts/ci/functional-coverage-verdict.test.mjs
@@ -139,13 +139,14 @@ test("extracts only the compact verdict contract without verbose diagnostics", (
 	const extracted = extractFunctionalCoverageVerdict(log);
 	assert.equal(extracted.foundInventory, true);
 	assert.equal(extracted.hasCoverageGateFailure, true);
-	assert.equal(extracted.lines.filter((line) => line.startsWith("  package=")).length, 1);
+	assert.equal(extracted.lines.filter((line) => line.startsWith("  package=") && line.includes(" lane=functional")).length, 1);
 	assert.equal(new Set(extracted.lines).size, extracted.lines.length);
 	assert.equal(extracted.text.includes(rawLine), false);
 	assert.equal(extracted.text.includes("make: ***"), false);
 	assert.doesNotMatch(extracted.text, /floor violation|package coverage regression|coverage manifest missing|coverage not evaluated|uncovered blocks|file\.go:/);
 	assert.match(extracted.text, /pkg\/ functional coverage:/);
 	assert.match(extracted.text, /tests\/ functional-package timing:/);
+	assert.match(extracted.text, /tests\/functional\/alpha elapsed=1\.000s outcome=pass/);
 	assert.match(extracted.text, /  tally:/);
 	assert.equal(extracted.text.includes("Functional suite inventory:"), false);
 });


### PR DESCRIPTION
{
  "project": "Concise Functional-Test Coverage and Timing Output",
  "branchName": "functional-test-verbose-output-cleanup",
  "description": "Change the Make-driven functional-test lane to report only production-package functional coverage and functional-test-package duration on successful runs, while suppressing individual passing-test and debug output and preserving execution, coverage, failure, and artifact behavior.",
  "context": {
    "customerAsk": "Update the Make functional-test command so pull-request verification explicitly prints the pkg/ packages with their functional-test coverage and the tests/ packages containing functional tests with each package's duration, without printing every passing test or current debug log statements.",
    "problem": "The lane already measures coverage and package timing, but its active Make and CI path streams child test output, so successful test names and debug logs overwhelm the package-level coverage and latency information reviewers need.",
    "solution": "Build one deterministic human-readable report from the same structured functional-test execution and coverage measurement that decide the command result, suppress routine successful child output, and retain concise failure diagnostics, non-zero status, coverage policy, and existing machine-readable artifacts."
  },
  "acceptanceCriteria": [
    "A successful invocation of the Make-driven functional-test lane prints a clearly distinguishable pkg/ functional-coverage section with exactly one coverage value for every measured production package and a tests/ functional-package timing section with exactly one elapsed duration for every executed package that contains functional tests.",
    "The successful terminal report is deterministic for identical measurement data and contains no individual successful test names or pass lines, go test lifecycle chatter, raw test-event JSON, duplicate package-result lines, or test-produced debug logs.",
    "The change preserves the lane's selected package set, configured parallelism, cache/fresh semantics, coverage profile and floor evaluation, timing and coverage artifacts, timeout behavior, and exit status; a test, coverage, timeout, or infrastructure failure remains non-zero and exposes a concise failure-specific diagnostic.",
    "Quality gates pass: Typecheck passes; Tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "functional-test-verbose-output-cleanup-001",
      "title": "Report package coverage and functional-package duration concisely",
      "description": "As a developer reviewing a functional-test run, I want a compact package summary so I can see production coverage and slow functional-test packages without searching through individual test output.",
      "acceptanceCriteria": [
        "On success, the Make-driven functional-test lane prints one clearly labeled coverage row for every measured production package under pkg/, including the package identity and its functional-test coverage percentage.",
        "On success, the lane prints one clearly labeled timing row for every executed package under tests/ that contains functional tests, including the package identity and elapsed duration.",
        "Packages do not appear more than once in their respective sections, and row ordering is deterministic for identical measurement data.",
        "The reported coverage and duration values come from the same functional-test execution used to decide the command result rather than from a second test run or a stale summary.",
        "Existing package selection, parallelism, short/full tier selection, cache/fresh behavior, timeouts, coverage-floor evaluation, and command exit status remain unchanged.",
        "Focused runner tests prove complete, deduplicated, deterministic rendering from representative coverage and timing measurements.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented the deterministic pkg/ coverage and tests/ functional-package timing sections from the same gocoveragecheck execution; focused Go and CI extraction tests plus make typecheck pass. Story 002 remains for suppressing successful test/debug chatter and preserving concise failure diagnostics."
    },
    {
      "id": "functional-test-verbose-output-cleanup-002",
      "title": "Suppress successful-test chatter while retaining failure diagnostics",
      "description": "As a pull-request reviewer, I want routine functional-test logs to omit individual test and debug output while failures remain diagnosable, so the CI log is concise without concealing a broken lane.",
      "acceptanceCriteria": [
        "A successful run emits no individual test names, === RUN or --- PASS or package pass chatter, raw go test -json events, or test-produced debug-log statements; the two package summary sections are the only test-result details explicitly rendered.",
        "Output written by successful tests cannot interleave with or corrupt coverage and timing rows when packages execute concurrently.",
        "When a test package, coverage floor, timeout, or runner infrastructure step fails, the command exits non-zero and emits a concise diagnostic identifying the failing package or measurement and failure reason when available.",
        "A failed run does not dump buffered output from unrelated successful tests, while the existing machine-readable coverage, timing, command-log, and diagnostic artifacts remain available wherever the current lane produces them.",
        "Focused success and failure regression tests assert both required inclusions and prohibited output, including representative noisy test output and concurrent package completion.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented quiet functional -stream handling that continues observing the captured go test JSON while suppressing successful test/lifecycle/debug/package chatter and live snapshot output. Failure rendering now identifies only failed packages/tests with a compact reason, preserves timing/coverage artifacts, and has concurrent success plus mixed success/failure regression coverage. cmd/gocoveragecheck tests, CI verdict tests, typecheck, vet, and all lint targets except the reproduced unrelated packaged-factory-consumption baseline violation pass."
    }
  ]
}
