### PR TITLE
Support script, model, and poller workstations in Current Selection

### DIFF
--- a/ui/scripts/component-test-files.ts
+++ b/ui/scripts/component-test-files.ts
@@ -26,6 +26,7 @@ const BUN_INCOMPATIBLE_WORKSPACE_GRAPH_FILES = new Set([
   "src/features/current-selection/workstation-selection/components/detail-card/workstation-detail-card.localization.test.tsx",
   "src/features/current-selection/workstation-selection/components/detail-card/workstation-detail-card.test.tsx",
   "src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.bun.component.test.tsx",
+  "src/features/current-selection/workstation-selection/components/editable/poller/workstation-editable-configuration-section.poller.bun.component.test.tsx",
   "src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.cron.test.tsx",
   "src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.overwrite.test.tsx",
   "src/features/current-selection/workstation-selection/components/workstation-model-invoke-fields.test.tsx",

--- a/ui/src/features/current-factory-definition/lib/worker-workstation-taxonomy.bun.unit.test.ts
+++ b/ui/src/features/current-factory-definition/lib/worker-workstation-taxonomy.bun.unit.test.ts
@@ -15,10 +15,13 @@ import {
   isLegacyRunnableWorkstationType,
   isModelProviderWorkerType,
   isPollerWorkerType,
+  isScriptRunWorkstationType,
+  isWorkerCompatibleWithWorkstationType,
   resolveEditableWorkerTypeOptions,
   resolveEditableWorkstationTypeConversionOptions,
 } from "./worker-workstation-taxonomy";
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: taxonomy cases keep the public compatibility matrix together.
 describe("worker-workstation taxonomy helpers", () => {
   it("prefers new taxonomy defaults for factory creation", () => {
     expect(DEFAULT_WORKER_TYPE).toBe(WorkerType.INFERENCE_WORKER);
@@ -108,12 +111,51 @@ describe("worker-workstation taxonomy helpers", () => {
     ).toEqual([WorkstationType.CLASSIFIER_WORKSTATION]);
   });
 
-  it("returns preferred conversion options for unsupported workstation types", () => {
+  it("retains promptless conversion options for script and poller workstations", () => {
     expect(
       resolveEditableWorkstationTypeConversionOptions(
         WorkstationType.SCRIPT_RUN,
       ),
-    ).toEqual(EDITABLE_WORKSTATION_TYPE_CONVERSION_OPTIONS);
+    ).toEqual([WorkstationType.SCRIPT_RUN]);
+    expect(
+      resolveEditableWorkstationTypeConversionOptions(
+        WorkstationType.POLLER_RUN,
+      ),
+    ).toEqual([WorkstationType.POLLER_RUN]);
+    expect(isScriptRunWorkstationType(WorkstationType.SCRIPT_RUN)).toBe(true);
+  });
+
+  it("filters explicit workstation types by canonical worker compatibility", () => {
+    expect(
+      isWorkerCompatibleWithWorkstationType(
+        WorkerType.SCRIPT_WORKER,
+        WorkstationType.SCRIPT_RUN,
+      ),
+    ).toBe(true);
+    expect(
+      isWorkerCompatibleWithWorkstationType(
+        WorkerType.MODEL_WORKER,
+        WorkstationType.SCRIPT_RUN,
+      ),
+    ).toBe(false);
+    expect(
+      isWorkerCompatibleWithWorkstationType(
+        WorkerType.SCRIPT_WORKER,
+        WorkstationType.POLLER_RUN,
+      ),
+    ).toBe(true);
+    expect(
+      isWorkerCompatibleWithWorkstationType(
+        WorkerType.HOSTED_WORKER,
+        WorkstationType.POLLER_RUN,
+      ),
+    ).toBe(true);
+    expect(
+      isWorkerCompatibleWithWorkstationType(
+        WorkerType.INFERENCE_WORKER,
+        WorkstationType.POLLER_RUN,
+      ),
+    ).toBe(false);
   });
 
   it("retains unsupported worker types before preferred options", () => {

--- a/ui/src/features/current-factory-definition/lib/worker-workstation-taxonomy.ts
+++ b/ui/src/features/current-factory-definition/lib/worker-workstation-taxonomy.ts
@@ -72,6 +72,12 @@ export function isScriptWorkerType(
   return workerType === WorkerType.SCRIPT_WORKER;
 }
 
+export function isScriptRunWorkstationType(
+  workstationType: ApiWorkstationType | string | null | undefined,
+): boolean {
+  return workstationType === WorkstationType.SCRIPT_RUN;
+}
+
 export function isPollerWorkerType(
   workerType: ApiWorkerType | string | null | undefined,
 ): boolean {
@@ -120,6 +126,45 @@ export function isHumanApprovalWorkstationType(
   return workstationType === WorkstationType.HUMAN_APPROVAL;
 }
 
+/**
+ * Returns the worker classes accepted by an explicitly typed workstation.
+ * Omitted workstation types retain the legacy broad worker catalog until the
+ * authored definition is migrated to an explicit runtime type.
+ */
+export function isWorkerCompatibleWithWorkstationType(
+  workerType: ApiWorkerType | string | null | undefined,
+  workstationType: ApiWorkstationType | string | null | undefined,
+): boolean {
+  if (!workstationType) {
+    return true;
+  }
+
+  if (isScriptRunWorkstationType(workstationType)) {
+    return isScriptWorkerType(workerType);
+  }
+
+  if (isPollerRunWorkstationType(workstationType)) {
+    return isPollerWorkerType(workerType) || isScriptWorkerType(workerType);
+  }
+
+  switch (workstationType) {
+    case WorkstationType.INFERENCE_RUN:
+      return isInferenceWorkerType(workerType);
+    case WorkstationType.AGENT_RUN:
+      return isAgentWorkerType(workerType);
+    case WorkstationType.MODEL_INVOKE:
+      return isModelProviderWorkerType(workerType);
+    case WorkstationType.MODEL_WORKSTATION:
+      return (
+        workerType === WorkerType.MODEL_WORKER ||
+        isAgentWorkerType(workerType) ||
+        isScriptWorkerType(workerType)
+      );
+    default:
+      return true;
+  }
+}
+
 export function isLegacyWorkerType(
   workerType: ApiWorkerType | string | null | undefined,
 ): boolean {
@@ -160,6 +205,12 @@ export function resolveEditableWorkstationTypeConversionOptions(
   }
   if (workstationType === WorkstationType.HUMAN_APPROVAL) {
     return [WorkstationType.HUMAN_APPROVAL];
+  }
+  if (
+    workstationType === WorkstationType.SCRIPT_RUN ||
+    workstationType === WorkstationType.POLLER_RUN
+  ) {
+    return [workstationType];
   }
 
   const preferred = EDITABLE_WORKSTATION_TYPE_CONVERSION_OPTIONS;

--- a/ui/src/features/current-factory-definition/lib/workstation-behavior.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation-behavior.ts
@@ -1,4 +1,5 @@
 import type { CanonicalFactoryDefinition } from "../../../api/current-factory-definition";
+import { WorkstationKind } from "../../../api/generated/openapi";
 import {
   isPollerRunWorkstationType,
   isPollerWorkerType,
@@ -17,12 +18,12 @@ export type EditableWorkstationBehavior = NonNullable<
 >;
 
 export const DEFAULT_WORKSTATION_BEHAVIOR: EditableWorkstationBehavior =
-  "STANDARD";
+  WorkstationKind.STANDARD;
 
 const BASE_EDITABLE_WORKSTATION_BEHAVIORS: EditableWorkstationBehavior[] = [
-  "STANDARD",
-  "REPEATER",
-  "POLLER",
+  WorkstationKind.STANDARD,
+  WorkstationKind.REPEATER,
+  WorkstationKind.POLLER,
 ];
 
 export function resolveEditableWorkstationBehavior(
@@ -30,7 +31,7 @@ export function resolveEditableWorkstationBehavior(
     Partial<Pick<CanonicalWorkstation, "type">>,
 ): EditableWorkstationBehavior {
   if (isPollerRunWorkstationType(workstation.type)) {
-    return "POLLER";
+    return WorkstationKind.POLLER;
   }
 
   return workstation.behavior ?? DEFAULT_WORKSTATION_BEHAVIOR;
@@ -41,17 +42,17 @@ export function resolveEditableWorkstationBehaviorOptions(
   workstationType?: CanonicalWorkstation["type"] | string | null,
 ): EditableWorkstationBehavior[] {
   if (isPollerRunWorkstationType(workstationType)) {
-    return ["POLLER"];
+    return [WorkstationKind.POLLER];
   }
 
-  return currentBehavior === "CRON"
-    ? [...BASE_EDITABLE_WORKSTATION_BEHAVIORS, "CRON"]
+  return currentBehavior === WorkstationKind.CRON
+    ? [...BASE_EDITABLE_WORKSTATION_BEHAVIORS, WorkstationKind.CRON]
     : BASE_EDITABLE_WORKSTATION_BEHAVIORS;
 }
 
 /** Graph add-workstation exposes CRON at creation time, not only when editing cron workstations. */
 export function resolveFactoryGraphAddWorkstationBehaviorOptions(): EditableWorkstationBehavior[] {
-  return [...BASE_EDITABLE_WORKSTATION_BEHAVIORS, "CRON"];
+  return [...BASE_EDITABLE_WORKSTATION_BEHAVIORS, WorkstationKind.CRON];
 }
 
 export function workerSupportsPollerBehavior(
@@ -63,12 +64,15 @@ export function workerSupportsPollerBehavior(
 export function workstationBehaviorRequiresPrompt(
   behavior: EditableWorkstationBehavior,
 ): boolean {
-  return behavior !== "POLLER";
+  return behavior !== WorkstationKind.POLLER;
 }
 
 export function workstationUsesRunnerEditing(
   workstationType: CanonicalWorkstation["type"] | string | null | undefined,
   behavior: EditableWorkstationBehavior,
 ): boolean {
-  return behavior !== "POLLER" && !isPollerRunWorkstationType(workstationType);
+  return (
+    behavior !== WorkstationKind.POLLER &&
+    !isPollerRunWorkstationType(workstationType)
+  );
 }

--- a/ui/src/features/current-factory-definition/lib/workstation-behavior.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation-behavior.ts
@@ -1,5 +1,6 @@
 import type { CanonicalFactoryDefinition } from "../../../api/current-factory-definition";
 import {
+  isPollerRunWorkstationType,
   isPollerWorkerType,
   isScriptWorkerType,
 } from "./worker-workstation-taxonomy";
@@ -25,14 +26,24 @@ const BASE_EDITABLE_WORKSTATION_BEHAVIORS: EditableWorkstationBehavior[] = [
 ];
 
 export function resolveEditableWorkstationBehavior(
-  workstation: Pick<CanonicalWorkstation, "behavior">,
+  workstation: Pick<CanonicalWorkstation, "behavior"> &
+    Partial<Pick<CanonicalWorkstation, "type">>,
 ): EditableWorkstationBehavior {
+  if (isPollerRunWorkstationType(workstation.type)) {
+    return "POLLER";
+  }
+
   return workstation.behavior ?? DEFAULT_WORKSTATION_BEHAVIOR;
 }
 
 export function resolveEditableWorkstationBehaviorOptions(
   currentBehavior: EditableWorkstationBehavior,
+  workstationType?: CanonicalWorkstation["type"] | string | null,
 ): EditableWorkstationBehavior[] {
+  if (isPollerRunWorkstationType(workstationType)) {
+    return ["POLLER"];
+  }
+
   return currentBehavior === "CRON"
     ? [...BASE_EDITABLE_WORKSTATION_BEHAVIORS, "CRON"]
     : BASE_EDITABLE_WORKSTATION_BEHAVIORS;
@@ -53,4 +64,11 @@ export function workstationBehaviorRequiresPrompt(
   behavior: EditableWorkstationBehavior,
 ): boolean {
   return behavior !== "POLLER";
+}
+
+export function workstationUsesRunnerEditing(
+  workstationType: CanonicalWorkstation["type"] | string | null | undefined,
+  behavior: EditableWorkstationBehavior,
+): boolean {
+  return behavior !== "POLLER" && !isPollerRunWorkstationType(workstationType);
 }

--- a/ui/src/features/current-factory-definition/lib/workstation-editable-values.test.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation-editable-values.test.ts
@@ -62,11 +62,7 @@ describe("resolveEditableWorkstationValues", () => {
         source: "default",
       },
       runnerName: null,
-      runnerOptions: [
-        "codex",
-        "claude",
-        "antigravity",
-      ],
+      runnerOptions: ["codex", "claude", "antigravity"],
       runnerSelectionSource: "default",
       sharedWorkerWorkstationNamesByWorkerName: {},
       sharedWorkerWorkstationNames: [],
@@ -446,11 +442,7 @@ describe("resolveEditableWorkstationValues", () => {
         source: "default",
       },
       runnerName: null,
-      runnerOptions: [
-        "codex",
-        "claude",
-        "antigravity",
-      ],
+      runnerOptions: ["codex", "claude", "antigravity"],
       runnerSelectionSource: "default",
       sharedWorkerWorkstationNamesByWorkerName: {},
       sharedWorkerWorkstationNames: [],
@@ -627,11 +619,7 @@ describe("resolveEditableWorkstationValues", () => {
         source: "default",
       },
       runnerName: null,
-      runnerOptions: [
-        "codex",
-        "claude",
-        "antigravity",
-      ],
+      runnerOptions: ["codex", "claude", "antigravity"],
       runnerSelectionSource: "default",
       sharedWorkerWorkstationNamesByWorkerName: {
         coder: ["Code"],
@@ -2064,6 +2052,89 @@ describe("editable workstation name draft", () => {
 });
 
 describe("workstation taxonomy save projection", () => {
+  it("projects and saves promptless SCRIPT_RUN workstations without adding a body", () => {
+    const scriptNode: DashboardWorkstationNode = {
+      model: "script",
+      node_id: "run-script",
+      transition_id: "run-script",
+      workstation_kind: WorkstationType.SCRIPT_RUN,
+      workstation_name: "Run Script",
+    };
+    const scriptFactory: CanonicalFactoryDefinition = {
+      metadata: { description: "Script factory metadata survives edits." },
+      name: "Script Factory",
+      resources: [{ initial: 1, name: "script-slot" }],
+      version: { logical: "4", physical: "2026-06-01T00:00:00Z" },
+      workers: [
+        {
+          args: ["--input", "story.json"],
+          command: "node",
+          name: "script-runner",
+          type: WorkerType.SCRIPT_WORKER,
+        },
+        {
+          model: "gpt-5.4",
+          name: "unrelated-model",
+          type: WorkerType.MODEL_WORKER,
+        },
+      ],
+      workTypes: [{ name: "story" }],
+      workstations: [
+        {
+          behavior: "STANDARD",
+          guards: [{ maxVisits: 2, type: "VISIT_COUNT" }],
+          id: "run-script",
+          inputs: [{ state: "queued", workType: "story" }],
+          name: "Run Script",
+          outputs: [{ state: "done", workType: "story" }],
+          runner: "codex",
+          type: WorkstationType.SCRIPT_RUN,
+          worker: "script-runner",
+        },
+        {
+          body: "Leave this workstation unchanged.",
+          id: "unrelated",
+          name: "Unrelated",
+          worker: "unrelated-model",
+        },
+      ],
+    };
+
+    const values = resolveEditableWorkstationValues(scriptFactory, scriptNode);
+    expect(values).toMatchObject({
+      prompt: null,
+      workerName: "script-runner",
+      workerOptions: ["script-runner"],
+      workstationType: WorkstationType.SCRIPT_RUN,
+      workstationTypeOptions: [WorkstationType.SCRIPT_RUN],
+    });
+    if (!values) {
+      throw new Error("expected editable script workstation values");
+    }
+
+    const saved = applyEditableWorkstationDraft(scriptFactory, scriptNode, {
+      ...editableWorkstationDraftFromValues(values),
+      name: "Run Script Updated",
+    });
+
+    expect(saved?.workers).toEqual(scriptFactory.workers);
+    expect(saved?.workTypes).toEqual(scriptFactory.workTypes);
+    expect(saved?.resources).toEqual(scriptFactory.resources);
+    expect(saved?.workstations?.[0]).toMatchObject({
+      behavior: "STANDARD",
+      guards: [{ maxVisits: 2, type: "VISIT_COUNT" }],
+      id: "run-script",
+      inputs: [{ state: "queued", workType: "story" }],
+      name: "Run Script Updated",
+      outputs: [{ state: "done", workType: "story" }],
+      runner: "codex",
+      type: WorkstationType.SCRIPT_RUN,
+      worker: "script-runner",
+    });
+    expect(saved?.workstations?.[0]).not.toHaveProperty("body");
+    expect(saved?.workstations?.[1]).toEqual(scriptFactory.workstations?.[1]);
+  });
+
   it("round-trips new taxonomy workstation saves without downgrading to legacy names", () => {
     const taxonomyFactory: CanonicalFactoryDefinition = {
       name: "Legacy Factory",

--- a/ui/src/features/current-factory-definition/lib/workstation-editable-values.test.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation-editable-values.test.ts
@@ -2052,6 +2052,111 @@ describe("editable workstation name draft", () => {
 });
 
 describe("workstation taxonomy save projection", () => {
+  it("projects and saves MODEL_WORKSTATION/MODEL_WORKER without coercing the legacy aliases", () => {
+    const modelNode: DashboardWorkstationNode = {
+      model: "gpt-5.4",
+      node_id: "legacy-review",
+      transition_id: "legacy-review",
+      workstation_kind: WorkstationType.MODEL_WORKSTATION,
+      workstation_name: "Legacy Review",
+      worker_type: "legacy-model",
+    };
+    const modelFactory: CanonicalFactoryDefinition = {
+      metadata: { description: "Legacy model metadata survives edits." },
+      name: "Legacy Model Factory",
+      resources: [{ initial: 1, name: "review-slot" }],
+      version: { logical: "9", physical: "2026-06-01T00:00:00Z" },
+      workers: [
+        {
+          args: ["--json"],
+          command: "model-runner",
+          model: "gpt-5.4",
+          modelProvider: "CODEX",
+          name: "legacy-model",
+          type: WorkerType.MODEL_WORKER,
+        },
+        {
+          model: "gpt-5.4",
+          name: "inference-worker",
+          type: WorkerType.INFERENCE_WORKER,
+        },
+        {
+          command: "review.sh",
+          name: "script-worker",
+          type: WorkerType.SCRIPT_WORKER,
+        },
+      ],
+      workTypes: [{ name: "story" }],
+      workstations: [
+        {
+          behavior: "REPEATER",
+          body: "Review the story before approval.",
+          guards: [{ maxVisits: 2, type: "VISIT_COUNT" }],
+          id: "legacy-review",
+          inputs: [{ state: "queued", workType: "story" }],
+          name: "Legacy Review",
+          onFailure: [{ state: "failed", workType: "story" }],
+          onRejection: [{ state: "queued", workType: "story" }],
+          outputs: [{ state: "approved", workType: "story" }],
+          promptFile: "prompts/legacy-review.md",
+          runner: "codex",
+          type: WorkstationType.MODEL_WORKSTATION,
+          worker: "legacy-model",
+        },
+        {
+          body: "Leave this workstation unchanged.",
+          id: "unrelated",
+          name: "Unrelated",
+          worker: "script-worker",
+        },
+      ],
+    };
+
+    const values = resolveEditableWorkstationValues(modelFactory, modelNode);
+    if (!values) {
+      throw new Error("expected legacy model workstation editable values");
+    }
+
+    expect(values.workstationType).toBe(WorkstationType.MODEL_WORKSTATION);
+    expect(values.workerName).toBe("legacy-model");
+    expect(values.prompt).toBe("Review the story before approval.");
+    expect(values.workerOptions).toEqual(["legacy-model", "script-worker"]);
+    expect(values.workstationTypeOptions).toEqual([
+      WorkstationType.MODEL_WORKSTATION,
+      WorkstationType.AGENT_RUN,
+      WorkstationType.INFERENCE_RUN,
+    ]);
+
+    const saved = applyEditableWorkstationDraft(modelFactory, modelNode, {
+      ...editableWorkstationDraftFromValues(values),
+      behavior: "STANDARD",
+      name: "Legacy Review Updated",
+      prompt: "Review the updated story before approval.",
+      runnerName: "claude",
+    });
+
+    expect(saved?.metadata).toEqual(modelFactory.metadata);
+    expect(saved?.resources).toEqual(modelFactory.resources);
+    expect(saved?.workTypes).toEqual(modelFactory.workTypes);
+    expect(saved?.workers).toEqual(modelFactory.workers);
+    expect(saved?.workstations?.[0]).toEqual({
+      behavior: "STANDARD",
+      body: "Review the updated story before approval.",
+      guards: [{ maxVisits: 2, type: "VISIT_COUNT" }],
+      id: "legacy-review",
+      inputs: [{ state: "queued", workType: "story" }],
+      name: "Legacy Review Updated",
+      onFailure: [{ state: "failed", workType: "story" }],
+      onRejection: [{ state: "queued", workType: "story" }],
+      outputs: [{ state: "approved", workType: "story" }],
+      promptFile: "prompts/legacy-review.md",
+      runner: "claude",
+      type: WorkstationType.MODEL_WORKSTATION,
+      worker: "legacy-model",
+    });
+    expect(saved?.workstations?.[1]).toEqual(modelFactory.workstations?.[1]);
+  });
+
   it("projects and saves promptless SCRIPT_RUN workstations without adding a body", () => {
     const scriptNode: DashboardWorkstationNode = {
       model: "script",

--- a/ui/src/features/current-factory-definition/lib/workstation-editable-values.test.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation-editable-values.test.ts
@@ -2240,6 +2240,90 @@ describe("workstation taxonomy save projection", () => {
     expect(saved?.workstations?.[1]).toEqual(scriptFactory.workstations?.[1]);
   });
 
+  it("projects POLLER_RUN workstations with poller behavior and saves without prompt fields", () => {
+    const pollerNode: DashboardWorkstationNode = {
+      node_id: "ingress",
+      transition_id: "ingress",
+      workstation_kind: WorkstationType.POLLER_RUN,
+      workstation_name: "Ingress",
+    };
+    const pollerFactory: CanonicalFactoryDefinition = {
+      name: "Poller Factory",
+      version: { logical: "5", physical: "2026-06-02T00:00:00Z" },
+      workers: [
+        {
+          auth: { secretRef: "secrets/linear" },
+          name: "linear-poller",
+          provider: "LINEAR",
+          type: WorkerType.HOSTED_WORKER,
+        },
+        {
+          args: ["--watch"],
+          command: "./ingress.sh",
+          name: "script-poller",
+          type: WorkerType.SCRIPT_WORKER,
+        },
+        { name: "native-poller", type: WorkerType.POLLER_WORKER },
+        { model: "gpt-5.4", name: "reviewer", type: WorkerType.MODEL_WORKER },
+      ],
+      workstations: [
+        {
+          body: "This prompt is not part of poller execution.",
+          id: "ingress",
+          inputs: [{ state: "queued", workType: "story" }],
+          name: "Ingress",
+          outputs: [{ state: "received", workType: "story" }],
+          promptFile: "prompts/unused.md",
+          runner: "codex",
+          type: WorkstationType.POLLER_RUN,
+          worker: "linear-poller",
+        },
+        {
+          body: "Leave this workstation unchanged.",
+          id: "review",
+          inputs: [{ state: "received", workType: "story" }],
+          name: "Review",
+          worker: "reviewer",
+        },
+      ],
+      workTypes: [{ name: "story" }],
+    };
+
+    const values = resolveEditableWorkstationValues(pollerFactory, pollerNode);
+    expect(values).toMatchObject({
+      behavior: "POLLER",
+      behaviorOptions: ["POLLER"],
+      prompt: null,
+      workerName: "linear-poller",
+      workerOptions: ["linear-poller", "script-poller", "native-poller"],
+      workstationType: WorkstationType.POLLER_RUN,
+      workstationTypeOptions: [WorkstationType.POLLER_RUN],
+    });
+    if (!values) {
+      throw new Error("expected editable poller workstation values");
+    }
+
+    const saved = applyEditableWorkstationDraft(pollerFactory, pollerNode, {
+      ...editableWorkstationDraftFromValues(values),
+      name: "Ingress Updated",
+    });
+
+    expect(saved?.workers).toEqual(pollerFactory.workers);
+    expect(saved?.workstations?.[1]).toEqual(pollerFactory.workstations?.[1]);
+    expect(saved?.workstations?.[0]).toMatchObject({
+      behavior: "POLLER",
+      id: "ingress",
+      inputs: [{ state: "queued", workType: "story" }],
+      name: "Ingress Updated",
+      outputs: [{ state: "received", workType: "story" }],
+      type: WorkstationType.POLLER_RUN,
+      worker: "linear-poller",
+    });
+    expect(saved?.workstations?.[0]).not.toHaveProperty("body");
+    expect(saved?.workstations?.[0]).not.toHaveProperty("promptFile");
+    expect(saved?.workstations?.[0]).not.toHaveProperty("runner");
+  });
+
   it("round-trips new taxonomy workstation saves without downgrading to legacy names", () => {
     const taxonomyFactory: CanonicalFactoryDefinition = {
       name: "Legacy Factory",

--- a/ui/src/features/current-factory-definition/lib/workstation-editable-values.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation-editable-values.ts
@@ -9,7 +9,9 @@ import {
   resolveRunnerSelection,
 } from "./runner-selection";
 import {
+  isPollerRunWorkstationType,
   isScriptRunWorkstationType,
+  isWorkerCompatibleWithWorkstationType,
   preferredInferenceRunWorkstationType,
 } from "./worker-workstation-taxonomy";
 import {
@@ -44,6 +46,7 @@ import {
   type EditableWorkstationBehavior,
   resolveEditableWorkstationBehavior,
   resolveEditableWorkstationBehaviorOptions,
+  workstationUsesRunnerEditing,
 } from "./workstation-behavior";
 import {
   normalizeEditableInputGuards,
@@ -159,7 +162,10 @@ export function resolveEditableWorkstationValues(
 
   return {
     behavior,
-    behaviorOptions: resolveEditableWorkstationBehaviorOptions(behavior),
+    behaviorOptions: resolveEditableWorkstationBehaviorOptions(
+      behavior,
+      workstationType,
+    ),
     cron:
       behavior === "CRON" ? resolveEditableWorkstationCron(workstation) : null,
     effectiveRunnerName: resolvedRunnerSelection.runnerId,
@@ -176,7 +182,11 @@ export function resolveEditableWorkstationValues(
           resolveEditableModelInvokeBindings(workstation.operationBindings),
         )
       : [],
-    prompt: workstation.body ?? null,
+    prompt:
+      isScriptRunWorkstationType(workstationType) ||
+      isPollerRunWorkstationType(workstationType)
+        ? null
+        : (workstation.body ?? null),
     resolvedRunnerSelection,
     runnerName: workstation.runner ?? null,
     runnerOptions: BUILT_IN_RUNNER_IDS,
@@ -264,6 +274,22 @@ export function applyEditableWorkstationDraft(
     return null;
   }
 
+  const legacyDefaultTypeIsUnchanged =
+    !workstation.type &&
+    draft.workstationType === resolveEditableWorkstationType(workstation);
+  const compatibilityWorkstationType = legacyDefaultTypeIsUnchanged
+    ? workstation.type
+    : draft.workstationType;
+
+  if (
+    !isWorkerCompatibleWithWorkstationType(
+      factory.workers.find((worker) => worker.name === draft.workerName)?.type,
+      compatibilityWorkstationType,
+    )
+  ) {
+    return null;
+  }
+
   const nextWorkstation = isModelInvokeWorkstationType(draft.workstationType)
     ? buildModelInvokeWorkstationFromDraft(workstation, draft, trimmedName)
     : buildPromptOrScriptWorkstationFromDraft(workstation, draft, trimmedName);
@@ -283,6 +309,7 @@ function buildPromptOrScriptWorkstationFromDraft(
   trimmedName: string,
 ): CanonicalWorkstation {
   const {
+    body: _existingBody,
     behavior: existingBehavior,
     cron: _existingCron,
     guards: _existingGuards,
@@ -293,6 +320,10 @@ function buildPromptOrScriptWorkstationFromDraft(
     ...workstationWithoutCronRunner
   } = workstation;
 
+  const behavior = isPollerRunWorkstationType(draft.workstationType)
+    ? "POLLER"
+    : draft.behavior;
+
   const nextWorkstation = {
     ...workstationWithoutCronRunner,
     inputs: applyEditableWorkstationInputs(draft.inputs),
@@ -300,19 +331,29 @@ function buildPromptOrScriptWorkstationFromDraft(
     type: draft.workstationType,
     worker: draft.workerName,
     ...(draft.guards.length > 0 ? { guards: draft.guards } : {}),
-    ...(draft.runnerName ? { runner: draft.runnerName } : {}),
-    ...(draft.behavior === DEFAULT_WORKSTATION_BEHAVIOR &&
+    ...(workstationUsesRunnerEditing(draft.workstationType, behavior) &&
+    draft.runnerName
+      ? { runner: draft.runnerName }
+      : {}),
+    ...(behavior === DEFAULT_WORKSTATION_BEHAVIOR &&
     existingBehavior === undefined
       ? {}
-      : { behavior: draft.behavior }),
-    ...(draft.behavior === "CRON" && draft.cron
+      : { behavior }),
+    ...(behavior === "CRON" && draft.cron
       ? { cron: buildCanonicalWorkstationCronFromDraft(draft.cron) }
       : {}),
   };
 
-  return isScriptRunWorkstationType(draft.workstationType)
-    ? nextWorkstation
-    : { ...nextWorkstation, body: draft.prompt };
+  const isPromptless =
+    isScriptRunWorkstationType(draft.workstationType) ||
+    isPollerRunWorkstationType(draft.workstationType);
+  if (isPromptless) {
+    const { promptFile: _promptFile, ...promptlessWorkstation } =
+      nextWorkstation;
+    return promptlessWorkstation;
+  }
+
+  return { ...nextWorkstation, body: draft.prompt };
 }
 
 function buildModelInvokeWorkstationFromDraft(

--- a/ui/src/features/current-factory-definition/lib/workstation-editable-values.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation-editable-values.ts
@@ -8,7 +8,10 @@ import {
   type RunnerSelectionSource,
   resolveRunnerSelection,
 } from "./runner-selection";
-import { preferredInferenceRunWorkstationType } from "./worker-workstation-taxonomy";
+import {
+  isScriptRunWorkstationType,
+  preferredInferenceRunWorkstationType,
+} from "./worker-workstation-taxonomy";
 import {
   applyEditableWorkstationInputs,
   resolveCanonicalWorkstation,
@@ -188,7 +191,7 @@ export function resolveEditableWorkstationValues(
     workerTypeByName: resolveWorkerTypeByName(factory),
     workerModelProvider,
     workerName: workstation.worker ?? "",
-    workerOptions: resolveWorkerOptions(factory),
+    workerOptions: resolveWorkerOptions(factory, workstation.type),
     guards: resolveEditableWorkstationGuards(workstation),
     inputs: resolveEditableWorkstationInputs(workstation),
     workstationName: workstation.name,
@@ -263,7 +266,7 @@ export function applyEditableWorkstationDraft(
 
   const nextWorkstation = isModelInvokeWorkstationType(draft.workstationType)
     ? buildModelInvokeWorkstationFromDraft(workstation, draft, trimmedName)
-    : buildPromptOrientedWorkstationFromDraft(workstation, draft, trimmedName);
+    : buildPromptOrScriptWorkstationFromDraft(workstation, draft, trimmedName);
 
   return applyWorkstationNameChangeToFactory(
     factory,
@@ -274,7 +277,7 @@ export function applyEditableWorkstationDraft(
   );
 }
 
-function buildPromptOrientedWorkstationFromDraft(
+function buildPromptOrScriptWorkstationFromDraft(
   workstation: CanonicalWorkstation,
   draft: EditableWorkstationDraft,
   trimmedName: string,
@@ -290,9 +293,8 @@ function buildPromptOrientedWorkstationFromDraft(
     ...workstationWithoutCronRunner
   } = workstation;
 
-  return {
+  const nextWorkstation = {
     ...workstationWithoutCronRunner,
-    body: draft.prompt,
     inputs: applyEditableWorkstationInputs(draft.inputs),
     name: trimmedName,
     type: draft.workstationType,
@@ -307,6 +309,10 @@ function buildPromptOrientedWorkstationFromDraft(
       ? { cron: buildCanonicalWorkstationCronFromDraft(draft.cron) }
       : {}),
   };
+
+  return isScriptRunWorkstationType(draft.workstationType)
+    ? nextWorkstation
+    : { ...nextWorkstation, body: draft.prompt };
 }
 
 function buildModelInvokeWorkstationFromDraft(

--- a/ui/src/features/current-factory-definition/lib/workstation/workstation-editable-resolution.bun.unit.test.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation/workstation-editable-resolution.bun.unit.test.ts
@@ -98,6 +98,25 @@ describe("workstation editable resolution lookups", () => {
     ]);
   });
 
+  it("retains legacy model workers for explicit MODEL_WORKSTATION choices", () => {
+    const factory = {
+      name: "Factory",
+      workers: [
+        { name: "legacy-model", type: "MODEL_WORKER" as const },
+        { name: "inference", type: "INFERENCE_WORKER" as const },
+        { name: "agent", type: "AGENT_WORKER" as const },
+        { name: "script", type: "SCRIPT_WORKER" as const },
+      ],
+      workstations: [],
+    };
+
+    expect(resolveWorkerOptions(factory, "MODEL_WORKSTATION")).toEqual([
+      "legacy-model",
+      "agent",
+      "script",
+    ]);
+  });
+
   it("returns no shared worker workstations when the selected workstation has no worker", () => {
     expect(
       resolveSharedWorkerWorkstationNames(

--- a/ui/src/features/current-factory-definition/lib/workstation/workstation-editable-resolution.bun.unit.test.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation/workstation-editable-resolution.bun.unit.test.ts
@@ -78,6 +78,26 @@ describe("workstation editable resolution lookups", () => {
     expect(resolveWorkerModelProvider(factory, "missing")).toBeNull();
   });
 
+  it("limits explicit script and poller workstation choices to compatible workers", () => {
+    const factory = {
+      name: "Factory",
+      workers: [
+        { name: "model", type: "MODEL_WORKER" as const },
+        { name: "script", type: "SCRIPT_WORKER" as const },
+        { name: "poller", type: "POLLER_WORKER" as const },
+        { name: "hosted", type: "HOSTED_WORKER" as const },
+      ],
+      workstations: [],
+    };
+
+    expect(resolveWorkerOptions(factory, "SCRIPT_RUN")).toEqual(["script"]);
+    expect(resolveWorkerOptions(factory, "POLLER_RUN")).toEqual([
+      "script",
+      "poller",
+      "hosted",
+    ]);
+  });
+
   it("returns no shared worker workstations when the selected workstation has no worker", () => {
     expect(
       resolveSharedWorkerWorkstationNames(

--- a/ui/src/features/current-factory-definition/lib/workstation/workstation-editable-resolution.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation/workstation-editable-resolution.ts
@@ -1,5 +1,9 @@
 import type { CanonicalFactoryDefinition } from "../../../../api/current-factory-definition";
 import type { DashboardWorkstationNode } from "../../../../api/dashboard/types";
+import {
+  type ApiWorkstationType,
+  isWorkerCompatibleWithWorkstationType,
+} from "../worker-workstation-taxonomy";
 import type { EditableWorkstationInputDraft } from "../workstation-editable-values";
 import { normalizeEditableInputGuards } from "../workstation-guards";
 
@@ -58,8 +62,12 @@ export function resolveWorkerModelProvider(
 
 export function resolveWorkerOptions(
   factory: CanonicalFactoryDefinition,
+  workstationType?: ApiWorkstationType | string | null,
 ): string[] {
   return (factory.workers ?? [])
+    .filter((worker) =>
+      isWorkerCompatibleWithWorkstationType(worker.type, workstationType),
+    )
     .map((worker) => worker.name)
     .filter((name) => name.length > 0);
 }

--- a/ui/src/features/current-factory-definition/lib/workstation/workstation-model-invoke.bun.unit.test.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation/workstation-model-invoke.bun.unit.test.ts
@@ -66,6 +66,7 @@ describe("workstation model invoke type helpers", () => {
     expect(workstationUsesPromptOrientedEditing("MODEL_WORKSTATION")).toBe(
       true,
     );
+    expect(workstationUsesPromptOrientedEditing("SCRIPT_RUN")).toBe(false);
   });
 
   it("resolves compatible model workers and operations from the factory", () => {

--- a/ui/src/features/current-factory-definition/lib/workstation/workstation-model-invoke.bun.unit.test.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation/workstation-model-invoke.bun.unit.test.ts
@@ -67,6 +67,7 @@ describe("workstation model invoke type helpers", () => {
       true,
     );
     expect(workstationUsesPromptOrientedEditing("SCRIPT_RUN")).toBe(false);
+    expect(workstationUsesPromptOrientedEditing("POLLER_RUN")).toBe(false);
   });
 
   it("resolves compatible model workers and operations from the factory", () => {

--- a/ui/src/features/current-factory-definition/lib/workstation/workstation-model-invoke.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation/workstation-model-invoke.ts
@@ -3,6 +3,7 @@ import type { components } from "../../../../api/generated/openapi";
 import {
   isInferenceRunWorkstationType,
   isModelProviderWorkerType,
+  isPollerRunWorkstationType,
   isScriptRunWorkstationType,
 } from "../worker-workstation-taxonomy";
 import type { EditableWorkstationType } from "./workstation-type";
@@ -46,7 +47,8 @@ export function workstationUsesPromptOrientedEditing(
 ): boolean {
   return (
     !isModelInvokeWorkstationType(workstationType) &&
-    !isScriptRunWorkstationType(workstationType)
+    !isScriptRunWorkstationType(workstationType) &&
+    !isPollerRunWorkstationType(workstationType)
   );
 }
 

--- a/ui/src/features/current-factory-definition/lib/workstation/workstation-model-invoke.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation/workstation-model-invoke.ts
@@ -3,6 +3,7 @@ import type { components } from "../../../../api/generated/openapi";
 import {
   isInferenceRunWorkstationType,
   isModelProviderWorkerType,
+  isScriptRunWorkstationType,
 } from "../worker-workstation-taxonomy";
 import type { EditableWorkstationType } from "./workstation-type";
 
@@ -43,7 +44,10 @@ export function isModelInvokeWorkstationType(
 export function workstationUsesPromptOrientedEditing(
   workstationType: EditableWorkstationType,
 ): boolean {
-  return !isModelInvokeWorkstationType(workstationType);
+  return (
+    !isModelInvokeWorkstationType(workstationType) &&
+    !isScriptRunWorkstationType(workstationType)
+  );
 }
 
 export function modelOperationHasCompatibleSlots(

--- a/ui/src/features/current-selection/workstation-selection/components/detail-card/workstation-detail-card.editable-configuration.bun.component.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/detail-card/workstation-detail-card.editable-configuration.bun.component.test.tsx
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import {
   cleanup,
   fireEvent,
@@ -6,14 +7,6 @@ import {
   within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-} from "bun:test";
 
 const vi = { fn: mock };
 
@@ -262,14 +255,7 @@ function buildReadyEditableConfigurationState(overrides?: {
         source: "workstation",
       },
       runnerName: "gemini",
-      runnerOptions: [
-        "codex",
-        "gemini",
-        "kiro",
-        "codex",
-        "opencode",
-        "pi",
-      ],
+      runnerOptions: ["codex", "gemini", "kiro", "codex", "opencode", "pi"],
       runnerSelectionSource: "workstation",
       workerModelProvider: null,
       sharedWorkerWorkstationNamesByWorkerName: {
@@ -2556,6 +2542,9 @@ describe("WorkstationDetailCard editable configuration", () => {
       within(resolvedSummarySection).getByText("Worker type"),
     ).toBeTruthy();
     expect(
+      within(resolvedSummarySection).getByText("MODEL_WORKER"),
+    ).toBeTruthy();
+    expect(
       within(resolvedSummarySection).getByText("Selected runner"),
     ).toBeTruthy();
     expect(within(resolvedSummarySection).getByText("Kind")).toBeTruthy();
@@ -2587,6 +2576,11 @@ describe("WorkstationDetailCard editable configuration", () => {
     );
 
     const configuration = editableConfigurationSection();
+    expect(
+      within(configuration).getByRole("combobox", {
+        name: "Workstation type",
+      }),
+    ).toHaveTextContent("Model workstation (legacy)");
     expect(within(configuration).getByLabelText("Worker")).toBeTruthy();
     expect(within(configuration).getByLabelText("Kind")).toBeTruthy();
     expect(within(configuration).getByLabelText("Runner")).toBeTruthy();

--- a/ui/src/features/current-selection/workstation-selection/components/editable/poller/workstation-editable-configuration-section.poller.bun.component.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/editable/poller/workstation-editable-configuration-section.poller.bun.component.test.tsx
@@ -1,13 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { cleanup, render, screen } from "@testing-library/react";
 
-import { installDashboardBrowserTestShims } from "../../../../../components/dashboard/test-browser-shims";
-import { EditableConfigurationSection } from "./workstation-editable-configuration-section";
+import { installDashboardBrowserTestShims } from "../../../../../../components/dashboard/test-browser-shims";
+import { EditableConfigurationSection } from "../workstation-editable-configuration-section";
 import {
   buildEditableConfigurationSectionReadyState,
   editableConfigurationSectionMessages,
   expandEditableConfigurationSection,
-} from "./workstation-editable-configuration-section.test-helpers";
+} from "../workstation-editable-configuration-section.test-helpers";
 
 const messages = editableConfigurationSectionMessages;
 

--- a/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.bun.component.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.bun.component.test.tsx
@@ -1,13 +1,6 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-} from "bun:test";
 
 const vi = { fn: mock };
 
@@ -395,6 +388,30 @@ describe("EditableConfigurationSection model workstation fields", () => {
     expect(
       screen.getAllByText(messages.editableConfigurationServerFieldChangedHint),
     ).toHaveLength(4);
+  });
+});
+
+describe("EditableConfigurationSection script workstation fields", () => {
+  it("renders script workstation controls without a prompt field", () => {
+    render(
+      <EditableConfigurationSection
+        messages={messages}
+        state={buildEditableConfigurationSectionReadyState({
+          workstationType: "SCRIPT_RUN",
+        })}
+      />,
+    );
+
+    expandEditableConfigurationSection();
+
+    expect(screen.getByRole("combobox", { name: "Worker" })).toHaveTextContent(
+      "script-runner",
+    );
+    expect(screen.getByRole("combobox", { name: "Kind" })).toHaveTextContent(
+      "Standard",
+    );
+    expect(screen.getByLabelText("Runner")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Prompt")).toBeNull();
   });
 });
 

--- a/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.poller.bun.component.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.poller.bun.component.test.tsx
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { installDashboardBrowserTestShims } from "../../../../../components/dashboard/test-browser-shims";
+import { EditableConfigurationSection } from "./workstation-editable-configuration-section";
+import {
+  buildEditableConfigurationSectionReadyState,
+  editableConfigurationSectionMessages,
+  expandEditableConfigurationSection,
+} from "./workstation-editable-configuration-section.test-helpers";
+
+const messages = editableConfigurationSectionMessages;
+
+let restoreBrowserShims: (() => void) | undefined;
+
+beforeEach(() => {
+  restoreBrowserShims = installDashboardBrowserTestShims();
+});
+
+afterEach(() => {
+  cleanup();
+  restoreBrowserShims?.();
+  restoreBrowserShims = undefined;
+});
+
+describe("EditableConfigurationSection poller workstation fields", () => {
+  it("keeps poller behavior fixed, filters workers, and omits prompt and runner fields", () => {
+    render(
+      <EditableConfigurationSection
+        messages={messages}
+        state={buildEditableConfigurationSectionReadyState({
+          workstationType: "POLLER_RUN",
+        })}
+      />,
+    );
+
+    expandEditableConfigurationSection();
+
+    expect(screen.getByRole("combobox", { name: "Worker" })).toHaveTextContent(
+      "linear-poller",
+    );
+    expect(screen.getByRole("combobox", { name: "Kind" })).toHaveTextContent(
+      "Poller",
+    );
+    expect(screen.queryByLabelText("Runner")).toBeNull();
+    expect(screen.queryByLabelText("Prompt")).toBeNull();
+    expect(
+      screen.queryByRole("combobox", { name: "Workstation type" }),
+    ).toBeNull();
+  });
+});

--- a/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.test-helpers.ts
+++ b/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.test-helpers.ts
@@ -56,7 +56,8 @@ function buildEditableConfigurationSectionDraftDefaults(
     | "INFERENCE_RUN"
     | "MODEL_WORKSTATION"
     | "MODEL_INVOKE"
-    | "LOGICAL_MOVE" = "AGENT_RUN",
+    | "LOGICAL_MOVE"
+    | "SCRIPT_RUN" = "AGENT_RUN",
 ) {
   const behavior = overrides?.behavior ?? ("STANDARD" as const);
   const cron =
@@ -86,9 +87,13 @@ function buildEditableConfigurationSectionDraftDefaults(
         selector: { label: "utterance", role: "", slot: "", type: "TEXT" },
       },
     ],
-    prompt: overrides?.prompt ?? "Review prompt",
+    prompt:
+      overrides?.prompt ??
+      (workstationType === "SCRIPT_RUN" ? "" : "Review prompt"),
     runnerName: overrides?.runnerName ?? ("gemini" as const),
-    workerName: overrides?.workerName ?? "reviewer",
+    workerName:
+      overrides?.workerName ??
+      (workstationType === "SCRIPT_RUN" ? "script-runner" : "reviewer"),
     workstationType,
   };
 }
@@ -102,8 +107,11 @@ function buildEditableConfigurationSectionInitialValues(
     | "INFERENCE_RUN"
     | "MODEL_WORKSTATION"
     | "MODEL_INVOKE"
-    | "LOGICAL_MOVE" = "AGENT_RUN",
+    | "LOGICAL_MOVE"
+    | "SCRIPT_RUN" = "AGENT_RUN",
 ) {
+  const isScriptRun = workstationType === "SCRIPT_RUN";
+
   return {
     behavior: "STANDARD" as const,
     behaviorOptions: ["STANDARD", "REPEATER", "POLLER"] as const,
@@ -131,7 +139,7 @@ function buildEditableConfigurationSectionInitialValues(
         selector: { label: "utterance", role: "", slot: "", type: "TEXT" },
       },
     ],
-    prompt: "Review prompt",
+    prompt: isScriptRun ? null : "Review prompt",
     resolvedRunnerSelection: {
       runnerId: "gemini",
       source: "workstation" as const,
@@ -143,11 +151,12 @@ function buildEditableConfigurationSectionInitialValues(
     sharedWorkerWorkstationNamesByWorkerName:
       overrides?.sharedWorkerWorkstationNamesByWorkerName ?? {},
     workerModelProvider: null,
-    workerName: "reviewer",
-    workerOptions: ["reviewer", "planner"],
+    workerName: isScriptRun ? "script-runner" : "reviewer",
+    workerOptions: isScriptRun ? ["script-runner"] : ["reviewer", "planner"],
     workerTypeByName: {
       planner: "MODEL_WORKER" as const,
       reviewer: "MODEL_WORKER" as const,
+      ...(isScriptRun ? { "script-runner": "SCRIPT_WORKER" as const } : {}),
     },
     workstationName: "Review",
     workstationOptions: ["Plan", "Review"],
@@ -223,7 +232,8 @@ export function buildEditableConfigurationSectionReadyState(
       | "INFERENCE_RUN"
       | "MODEL_WORKSTATION"
       | "MODEL_INVOKE"
-      | "LOGICAL_MOVE";
+      | "LOGICAL_MOVE"
+      | "SCRIPT_RUN";
   }>,
 ): EditableConfigurationSectionReadyState {
   const workstationType = overrides?.workstationType ?? "AGENT_RUN";
@@ -282,7 +292,10 @@ export function buildEditableConfigurationSectionReadyState(
       status: "ready" as const,
     },
     workerOptionsState: overrides?.workerOptionsState ?? {
-      options: ["reviewer", "planner"],
+      options:
+        workstationType === "SCRIPT_RUN"
+          ? ["script-runner"]
+          : ["reviewer", "planner"],
       status: "ready" as const,
     },
     workstationOptionsState: {

--- a/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.test-helpers.ts
+++ b/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.test-helpers.ts
@@ -57,9 +57,13 @@ function buildEditableConfigurationSectionDraftDefaults(
     | "MODEL_WORKSTATION"
     | "MODEL_INVOKE"
     | "LOGICAL_MOVE"
+    | "POLLER_RUN"
     | "SCRIPT_RUN" = "AGENT_RUN",
 ) {
-  const behavior = overrides?.behavior ?? ("STANDARD" as const);
+  const isPollerRun = workstationType === "POLLER_RUN";
+  const behavior = isPollerRun
+    ? ("POLLER" as const)
+    : (overrides?.behavior ?? ("STANDARD" as const));
   const cron =
     overrides?.cron !== undefined
       ? overrides.cron
@@ -89,11 +93,16 @@ function buildEditableConfigurationSectionDraftDefaults(
     ],
     prompt:
       overrides?.prompt ??
-      (workstationType === "SCRIPT_RUN" ? "" : "Review prompt"),
-    runnerName: overrides?.runnerName ?? ("gemini" as const),
+      (workstationType === "SCRIPT_RUN" || isPollerRun ? "" : "Review prompt"),
+    runnerName:
+      overrides?.runnerName ?? (isPollerRun ? null : ("gemini" as const)),
     workerName:
       overrides?.workerName ??
-      (workstationType === "SCRIPT_RUN" ? "script-runner" : "reviewer"),
+      (workstationType === "SCRIPT_RUN"
+        ? "script-runner"
+        : isPollerRun
+          ? "linear-poller"
+          : "reviewer"),
     workstationType,
   };
 }
@@ -108,13 +117,17 @@ function buildEditableConfigurationSectionInitialValues(
     | "MODEL_WORKSTATION"
     | "MODEL_INVOKE"
     | "LOGICAL_MOVE"
+    | "POLLER_RUN"
     | "SCRIPT_RUN" = "AGENT_RUN",
 ) {
   const isScriptRun = workstationType === "SCRIPT_RUN";
+  const isPollerRun = workstationType === "POLLER_RUN";
 
   return {
-    behavior: "STANDARD" as const,
-    behaviorOptions: ["STANDARD", "REPEATER", "POLLER"] as const,
+    behavior: isPollerRun ? ("POLLER" as const) : ("STANDARD" as const),
+    behaviorOptions: isPollerRun
+      ? (["POLLER"] as const)
+      : (["STANDARD", "REPEATER", "POLLER"] as const),
     cron: null,
     effectiveRunnerName: "gemini",
     factoryRunnerName: "codex",
@@ -139,23 +152,33 @@ function buildEditableConfigurationSectionInitialValues(
         selector: { label: "utterance", role: "", slot: "", type: "TEXT" },
       },
     ],
-    prompt: isScriptRun ? null : "Review prompt",
+    prompt: isScriptRun || isPollerRun ? null : "Review prompt",
     resolvedRunnerSelection: {
       runnerId: "gemini",
       source: "workstation" as const,
     },
-    runnerName: "gemini",
+    runnerName: isPollerRun ? null : "gemini",
     runnerOptions: ["codex", "gemini"],
     runnerSelectionSource: "workstation" as const,
     sharedWorkerWorkstationNames: [],
     sharedWorkerWorkstationNamesByWorkerName:
       overrides?.sharedWorkerWorkstationNamesByWorkerName ?? {},
     workerModelProvider: null,
-    workerName: isScriptRun ? "script-runner" : "reviewer",
-    workerOptions: isScriptRun ? ["script-runner"] : ["reviewer", "planner"],
+    workerName: isScriptRun
+      ? "script-runner"
+      : isPollerRun
+        ? "linear-poller"
+        : "reviewer",
+    workerOptions: isScriptRun
+      ? ["script-runner"]
+      : isPollerRun
+        ? ["linear-poller", "script-poller"]
+        : ["reviewer", "planner"],
     workerTypeByName: {
       planner: "MODEL_WORKER" as const,
       reviewer: "MODEL_WORKER" as const,
+      "linear-poller": "HOSTED_WORKER" as const,
+      "script-poller": "SCRIPT_WORKER" as const,
       ...(isScriptRun ? { "script-runner": "SCRIPT_WORKER" as const } : {}),
     },
     workstationName: "Review",
@@ -233,10 +256,12 @@ export function buildEditableConfigurationSectionReadyState(
       | "MODEL_WORKSTATION"
       | "MODEL_INVOKE"
       | "LOGICAL_MOVE"
+      | "POLLER_RUN"
       | "SCRIPT_RUN";
   }>,
 ): EditableConfigurationSectionReadyState {
   const workstationType = overrides?.workstationType ?? "AGENT_RUN";
+  const isPollerRun = workstationType === "POLLER_RUN";
 
   return {
     draft: buildEditableConfigurationSectionDraftDefaults(
@@ -292,8 +317,9 @@ export function buildEditableConfigurationSectionReadyState(
       status: "ready" as const,
     },
     workerOptionsState: overrides?.workerOptionsState ?? {
-      options:
-        workstationType === "SCRIPT_RUN"
+      options: isPollerRun
+        ? ["linear-poller", "script-poller"]
+        : workstationType === "SCRIPT_RUN"
           ? ["script-runner"]
           : ["reviewer", "planner"],
       status: "ready" as const,

--- a/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.tsx
@@ -52,6 +52,7 @@ import {
   resolveWorkstationSummaryRequiresWorkerAssignment,
   resolveWorkstationSummaryRunnerValue,
   resolveWorkstationSummaryTypeValue,
+  resolveWorkstationSummaryWorkerTypeValue,
 } from "../fields/workstation-summary-field-values";
 import { EditableConfigurationModelInvokeFields } from "../workstation-model-invoke-fields";
 import { EditableConfigurationServerChangedHint } from "./editable-configuration-server-changed-hint";
@@ -586,7 +587,11 @@ export function WorkstationSummary({
         {requiresWorkerAssignment ? (
           <WorkstationSummaryItem
             label={messages.workerTypeLabel}
-            value={selectedNode.worker_type || messages.unknownWorkerTypeValue}
+            value={resolveWorkstationSummaryWorkerTypeValue(
+              editableConfigurationState,
+              selectedNode,
+              messages,
+            )}
           />
         ) : null}
         <WorkstationSummaryItem

--- a/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.tsx
@@ -21,7 +21,10 @@ import {
 } from "../../../../current-factory-definition/lib/workstation/workstation-model-invoke";
 import type { EditableWorkstationType } from "../../../../current-factory-definition/lib/workstation/workstation-type";
 import { supportsEditableWorkstationTypeConversion } from "../../../../current-factory-definition/lib/workstation/workstation-type";
-import { workstationBehaviorRequiresPrompt } from "../../../../current-factory-definition/lib/workstation-behavior";
+import {
+  workstationBehaviorRequiresPrompt,
+  workstationUsesRunnerEditing,
+} from "../../../../current-factory-definition/lib/workstation-behavior";
 import type { WorkstationLevelGuard } from "../../../../current-factory-definition/lib/workstation-guards";
 import { workstationRequiresWorkerAssignment } from "../../../../current-factory-definition/lib/workstation-worker-assignment";
 import { GraphSemanticIcon } from "../../../../flowchart/components/graph-semantic-icon";
@@ -139,6 +142,10 @@ function EditableConfigurationReadyForm({
   const showPromptField =
     workstationUsesPromptOrientedEditing(state.draft.workstationType) &&
     workstationBehaviorRequiresPrompt(state.draft.behavior);
+  const showRunnerField = workstationUsesRunnerEditing(
+    state.draft.workstationType,
+    state.draft.behavior,
+  );
   const showWorkstationTypeField =
     requiresWorkerAssignment &&
     supportsEditableWorkstationTypeConversion(
@@ -252,24 +259,26 @@ function EditableConfigurationReadyForm({
             messages={messages}
             state={renderState}
           />
-          <EditableConfigurationField
-            fieldId="editable-workstation-runner"
-            errorMessage={validationErrors.runnerName}
-            input={
-              <EditableConfigurationRunnerField
-                messages={messages}
-                state={renderState}
-              />
-            }
-            label={messages.runnerFieldLabel}
-            supportingContent={
-              <EditableConfigurationServerChangedHint
-                fieldName="runner"
-                messages={messages}
-                state={state}
-              />
-            }
-          />
+          {showRunnerField ? (
+            <EditableConfigurationField
+              fieldId="editable-workstation-runner"
+              errorMessage={validationErrors.runnerName}
+              input={
+                <EditableConfigurationRunnerField
+                  messages={messages}
+                  state={renderState}
+                />
+              }
+              label={messages.runnerFieldLabel}
+              supportingContent={
+                <EditableConfigurationServerChangedHint
+                  fieldName="runner"
+                  messages={messages}
+                  state={state}
+                />
+              }
+            />
+          ) : null}
           {showPromptField ? (
             <EditableConfigurationField
               errorMessage={validationErrors.prompt}

--- a/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.tsx
@@ -8,25 +8,30 @@ import { surfacePanelVariants } from "@you-agent-factory/components/layout";
 import { Label, Text } from "@you-agent-factory/components/primitives";
 import { type ReactNode, useId } from "react";
 
-import { AlertPanel, AlertPanelText } from "../../../../../components/ui/alert-panel";
-import { Input } from "../../../../../components/ui/input";
+import {
+  AlertPanel,
+  AlertPanelText,
+} from "../../../../../components/ui/alert-panel";
 import { formatList } from "../../../../../components/ui/formatters";
+import { Input } from "../../../../../components/ui/input";
 import { cn } from "../../../../../lib/cn";
-import { isModelInvokeWorkstationType } from "../../../../current-factory-definition/lib/workstation/workstation-model-invoke";
+import {
+  isModelInvokeWorkstationType,
+  workstationUsesPromptOrientedEditing,
+} from "../../../../current-factory-definition/lib/workstation/workstation-model-invoke";
 import type { EditableWorkstationType } from "../../../../current-factory-definition/lib/workstation/workstation-type";
 import { supportsEditableWorkstationTypeConversion } from "../../../../current-factory-definition/lib/workstation/workstation-type";
+import { workstationBehaviorRequiresPrompt } from "../../../../current-factory-definition/lib/workstation-behavior";
 import type { WorkstationLevelGuard } from "../../../../current-factory-definition/lib/workstation-guards";
 import { workstationRequiresWorkerAssignment } from "../../../../current-factory-definition/lib/workstation-worker-assignment";
 import { GraphSemanticIcon } from "../../../../flowchart/components/graph-semantic-icon";
+import { CurrentSelectionDetailFeedback } from "../../../base/components/detail/current-selection-detail-feedback";
 import { CurrentSelectionExpandableSection } from "../../../base/components/detail/current-selection-expandable-section";
-import { mergeDetailCardSaveFieldErrors } from "../../../base/components/save/detail-card-factory-save-feedback";
-import {
-  CurrentSelectionDetailFeedback,
-} from "../../../base/components/detail/current-selection-detail-feedback";
 import {
   CurrentSelectionFormField,
   CurrentSelectionFormFields,
 } from "../../../base/components/layout/current-selection-form-layout";
+import { mergeDetailCardSaveFieldErrors } from "../../../base/components/save/detail-card-factory-save-feedback";
 import { formatEditableOverwriteFieldLabels } from "../../editing/editable-workstation-overwrite-fields";
 import type {
   EditableWorkstationOverwriteField,
@@ -130,6 +135,9 @@ function EditableConfigurationReadyForm({
   const isModelInvoke = isModelInvokeWorkstationType(
     state.draft.workstationType,
   );
+  const showPromptField =
+    workstationUsesPromptOrientedEditing(state.draft.workstationType) &&
+    workstationBehaviorRequiresPrompt(state.draft.behavior);
   const showWorkstationTypeField =
     requiresWorkerAssignment &&
     supportsEditableWorkstationTypeConversion(
@@ -261,24 +269,26 @@ function EditableConfigurationReadyForm({
               />
             }
           />
-          <EditableConfigurationField
-            errorMessage={validationErrors.prompt}
-            fieldId="editable-workstation-prompt"
-            input={
-              <EditableConfigurationPromptInput
-                messages={messages}
-                state={renderState}
-              />
-            }
-            label={messages.promptFieldLabel}
-            supportingContent={
-              <EditableConfigurationServerChangedHint
-                fieldName="prompt"
-                messages={messages}
-                state={state}
-              />
-            }
-          />
+          {showPromptField ? (
+            <EditableConfigurationField
+              errorMessage={validationErrors.prompt}
+              fieldId="editable-workstation-prompt"
+              input={
+                <EditableConfigurationPromptInput
+                  messages={messages}
+                  state={renderState}
+                />
+              }
+              label={messages.promptFieldLabel}
+              supportingContent={
+                <EditableConfigurationServerChangedHint
+                  fieldName="prompt"
+                  messages={messages}
+                  state={state}
+                />
+              }
+            />
+          ) : null}
         </CurrentSelectionFormFields>
       ) : null}
       <EditableConfigurationWorkstationGuardsField

--- a/ui/src/features/current-selection/workstation-selection/components/fields/workstation-summary-field-values.bun.unit.test.ts
+++ b/ui/src/features/current-selection/workstation-selection/components/fields/workstation-summary-field-values.bun.unit.test.ts
@@ -8,6 +8,7 @@ import {
   resolveWorkstationSummaryRequiresWorkerAssignment,
   resolveWorkstationSummaryRunnerValue,
   resolveWorkstationSummaryTypeValue,
+  resolveWorkstationSummaryWorkerTypeValue,
 } from "./workstation-summary-field-values";
 
 const readyEditableConfigurationState = {
@@ -42,7 +43,7 @@ const readyEditableConfigurationState = {
     sharedWorkerWorkstationNames: [],
     workerName: "reviewer",
     workerOptions: ["reviewer"],
-    workerTypeByName: {},
+    workerTypeByName: { reviewer: "MODEL_WORKER" },
     workstationName: "Review",
     workstationOptions: ["Review"],
     workstationType: "MODEL_WORKSTATION" as const,
@@ -162,6 +163,40 @@ describe("resolveWorkstationSummaryTypeValue", () => {
         messages,
       ),
     ).toBe("Logical move");
+  });
+});
+
+describe("resolveWorkstationSummaryWorkerTypeValue", () => {
+  const messages = getWorkstationDetailMessages("en");
+
+  it("uses the canonical worker type for a ready legacy model workstation", () => {
+    expect(
+      resolveWorkstationSummaryWorkerTypeValue(
+        readyEditableConfigurationState,
+        {
+          ...modelWorkstationNode,
+          worker_type: "reviewer",
+        },
+        messages,
+      ),
+    ).toBe("MODEL_WORKER");
+  });
+
+  it("falls back to topology worker data before editable configuration is ready", () => {
+    expect(
+      resolveWorkstationSummaryWorkerTypeValue(
+        { status: "loading" },
+        { ...modelWorkstationNode, worker_type: "reviewer" },
+        messages,
+      ),
+    ).toBe("reviewer");
+    expect(
+      resolveWorkstationSummaryWorkerTypeValue(
+        undefined,
+        { ...modelWorkstationNode, worker_type: undefined },
+        messages,
+      ),
+    ).toBe("Unknown");
   });
 });
 

--- a/ui/src/features/current-selection/workstation-selection/components/fields/workstation-summary-field-values.ts
+++ b/ui/src/features/current-selection/workstation-selection/components/fields/workstation-summary-field-values.ts
@@ -81,6 +81,22 @@ export function resolveWorkstationSummaryTypeValue(
   return messages.localizeWorkstationType(state.draft.workstationType);
 }
 
+export function resolveWorkstationSummaryWorkerTypeValue(
+  state: WorkstationDetailCardProps["editableConfigurationState"],
+  selectedNode: DashboardWorkstationNode,
+  messages: ReturnType<typeof getWorkstationDetailMessages>,
+): string {
+  if (state?.status === "ready") {
+    const workerType =
+      state.initialValues.workerTypeByName[state.draft.workerName];
+    if (workerType) {
+      return workerType;
+    }
+  }
+
+  return selectedNode.worker_type || messages.unknownWorkerTypeValue;
+}
+
 export function resolveWorkstationSummaryPresentation(
   editableConfigurationState:
     | WorkstationDetailCardProps["editableConfigurationState"]

--- a/ui/src/features/current-selection/workstation-selection/components/fields/workstation-summary-field-values.ts
+++ b/ui/src/features/current-selection/workstation-selection/components/fields/workstation-summary-field-values.ts
@@ -1,5 +1,6 @@
 import type { DashboardWorkstationNode } from "../../../../../api/dashboard/types";
 import { WorkstationType } from "../../../../../api/generated/openapi";
+import { workstationUsesRunnerEditing } from "../../../../current-factory-definition/lib/workstation-behavior";
 import { workstationRequiresWorkerAssignment } from "../../../../current-factory-definition/lib/workstation-worker-assignment";
 import {
   workstationBehaviorSemanticKind,
@@ -130,6 +131,16 @@ export function resolveWorkstationSummaryRunnerValue(
   selectedNode: DashboardWorkstationNode,
 ): string | null {
   if (!resolveWorkstationSummaryRequiresWorkerAssignment(state, selectedNode)) {
+    return null;
+  }
+
+  if (
+    state?.status === "ready" &&
+    !workstationUsesRunnerEditing(
+      state.draft.workstationType,
+      state.draft.behavior,
+    )
+  ) {
     return null;
   }
 

--- a/ui/src/features/current-selection/workstation-selection/editing/editable-workstation-cron-draft-mutators.ts
+++ b/ui/src/features/current-selection/workstation-selection/editing/editable-workstation-cron-draft-mutators.ts
@@ -1,3 +1,4 @@
+import { isPollerRunWorkstationType } from "../../../current-factory-definition/lib/worker-workstation-taxonomy";
 import type { EditableWorkstationBehavior } from "../../../current-factory-definition/lib/workstation-behavior";
 import {
   createEmptyEditableWorkstationCronDraft,
@@ -11,6 +12,16 @@ export function resolveDraftForBehaviorChange(
   behavior: EditableWorkstationBehavior,
   selectedEditableValues: EditableWorkstationValues,
 ): EditableWorkstationDraft {
+  if (isPollerRunWorkstationType(draft.workstationType)) {
+    return {
+      ...draft,
+      behavior: "POLLER",
+      cron: null,
+      prompt: "",
+      runnerName: null,
+    };
+  }
+
   if (behavior === "CRON") {
     return {
       ...draft,

--- a/ui/src/features/current-selection/workstation-selection/editing/type/editable-workstation-type-mutators.ts
+++ b/ui/src/features/current-selection/workstation-selection/editing/type/editable-workstation-type-mutators.ts
@@ -1,3 +1,7 @@
+import {
+  isPollerRunWorkstationType,
+  isWorkerCompatibleWithWorkstationType,
+} from "../../../../current-factory-definition/lib/worker-workstation-taxonomy";
 import { isModelInvokeWorkstationType } from "../../../../current-factory-definition/lib/workstation/workstation-model-invoke";
 import type { EditableWorkstationType } from "../../../../current-factory-definition/lib/workstation/workstation-type";
 import type {
@@ -29,6 +33,27 @@ export function resolveDraftForWorkstationTypeChange(
         selectedEditableValues,
       ),
       workstationType,
+    };
+  }
+
+  if (isPollerRunWorkstationType(workstationType)) {
+    const workerName = selectedEditableValues.workerOptions.find((name) =>
+      isWorkerCompatibleWithWorkstationType(
+        selectedEditableValues.workerTypeByName[name],
+        workstationType,
+      ),
+    );
+
+    return {
+      ...draft,
+      behavior: "POLLER",
+      cron: null,
+      operation: "",
+      operationBindings: [],
+      prompt: "",
+      runnerName: null,
+      workstationType,
+      ...(workerName ? { workerName } : {}),
     };
   }
 

--- a/ui/src/features/current-selection/workstation-selection/hooks/editable-workstation-ready-configuration-state.test.ts
+++ b/ui/src/features/current-selection/workstation-selection/hooks/editable-workstation-ready-configuration-state.test.ts
@@ -375,17 +375,18 @@ describe("buildReadyEditableWorkstationConfigurationState model invoke handlers"
     ]);
     readyState.onNameChange("Speak Story Invoke");
 
-    expect(getSessionState().draft).toMatchObject({
-      name: "Speak Story Invoke",
-      operation: "STT",
-      workerName: "tts-worker",
-      workstationType: "MODEL_INVOKE",
-      operationBindings: [
-        expect.objectContaining({
-          slot: "audio",
-          selector: expect.objectContaining({ label: "clip", type: "AUDIO" }),
-        }),
-      ],
+    const draft = getSessionState().draft;
+    expect(draft.name).toBe("Speak Story Invoke");
+    expect(draft.operation).toBe("STT");
+    expect(draft.workerName).toBe("tts-worker");
+    expect(draft.workstationType).toBe("MODEL_INVOKE");
+    expect(draft.operationBindings).toHaveLength(1);
+    expect(draft.operationBindings[0]?.slot).toBe("audio");
+    expect(draft.operationBindings[0]?.selector).toEqual({
+      label: "clip",
+      role: "",
+      slot: "input.audio",
+      type: "AUDIO",
     });
     expect(buildReady().operationOptionsState).toEqual({
       operations: expect.any(Array),

--- a/ui/src/features/current-selection/workstation-selection/hooks/editable-workstation-ready-configuration-state.ts
+++ b/ui/src/features/current-selection/workstation-selection/hooks/editable-workstation-ready-configuration-state.ts
@@ -3,6 +3,7 @@ import type { DashboardWorkstationNode } from "../../../../api/dashboard/types";
 import {
   type EditableModelInvokeBindingDraft,
   isModelInvokeWorkstationType,
+  workstationUsesPromptOrientedEditing,
 } from "../../../current-factory-definition/lib/workstation/workstation-model-invoke";
 import type { EditableWorkstationType } from "../../../current-factory-definition/lib/workstation/workstation-type";
 import {
@@ -206,7 +207,7 @@ export function buildReadyEditableWorkstationConfigurationState({
     resolvedValidationErrors,
   );
   const promptValidationBlocksPendingFactory =
-    !isModelInvokeWorkstationType(sessionState.draft.workstationType) &&
+    workstationUsesPromptOrientedEditing(sessionState.draft.workstationType) &&
     workstationRequiresWorkerAssignment({
       type: sessionState.draft.workstationType,
     }) &&

--- a/ui/src/features/current-selection/workstation-selection/hooks/use-editable-workstation-configuration-state.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/hooks/use-editable-workstation-configuration-state.test.tsx
@@ -675,14 +675,7 @@ describe("useEditableWorkstationConfigurationState", () => {
         source: "default",
       },
       runnerName: null,
-      runnerOptions: [
-        "codex",
-        "gemini",
-        "kiro",
-        "codex",
-        "opencode",
-        "pi",
-      ],
+      runnerOptions: ["codex", "gemini", "kiro", "codex", "opencode", "pi"],
       runnerSelectionSource: "default",
       sharedWorkerWorkstationNamesByWorkerName: {},
       sharedWorkerWorkstationNames: [],
@@ -910,14 +903,7 @@ describe("useEditableWorkstationConfigurationState guards and cron", () => {
         source: "default",
       },
       runnerName: null,
-      runnerOptions: [
-        "codex",
-        "gemini",
-        "kiro",
-        "codex",
-        "opencode",
-        "pi",
-      ],
+      runnerOptions: ["codex", "gemini", "kiro", "codex", "opencode", "pi"],
       runnerSelectionSource: "default",
       sharedWorkerWorkstationNamesByWorkerName: {},
       sharedWorkerWorkstationNames: [],
@@ -1050,6 +1036,67 @@ describe("useEditableWorkstationConfigurationState guards and cron", () => {
         },
       ],
     });
+  });
+
+  it("projects promptless script workstations with compatible workers only", async () => {
+    vi.mocked(useCurrentFactoryDocument).mockReturnValue(
+      buildEditableDefinitionResult(
+        buildEditableFactoryDefinition({
+          prompt: undefined,
+          workerName: "script-runner",
+          workerOptions: [
+            { name: "script-runner", type: "SCRIPT_WORKER" },
+            { name: "reviewer", type: "MODEL_WORKER" },
+          ],
+          workstationType: "SCRIPT_RUN",
+        }),
+      ),
+    );
+
+    const { result } = renderHook(() =>
+      useEditableWorkstationConfigurationState(selection, selectedNode),
+    );
+
+    await waitFor(() => {
+      expect(result.current?.status).toBe("ready");
+    });
+
+    expect(result.current).toMatchObject({
+      draft: {
+        prompt: "",
+        workerName: "script-runner",
+        workstationType: "SCRIPT_RUN",
+      },
+      hasValidationErrors: false,
+      initialValues: {
+        prompt: null,
+        workerOptions: ["script-runner"],
+      },
+      status: "ready",
+      validationErrors: {},
+      workerOptionsState: {
+        options: ["script-runner"],
+        status: "ready",
+      },
+    });
+    expect(
+      result.current?.status === "ready"
+        ? result.current.pendingFactoryDefinition
+        : undefined,
+    ).toMatchObject({
+      workstations: [
+        {
+          type: "SCRIPT_RUN",
+          worker: "script-runner",
+        },
+      ],
+    });
+    expect(
+      vi.mocked(useCurrentWorkstationPromptTemplateContract),
+    ).toHaveBeenLastCalledWith("Review", false);
+    expect(
+      vi.mocked(useCurrentWorkstationPromptTemplateValidation),
+    ).toHaveBeenLastCalledWith("Review", "", false);
   });
 
   it("validates cron fields for CRON workstations and skips them for other behaviors", () => {
@@ -1313,7 +1360,7 @@ function buildEditableFactoryDefinition(overrides?: {
     name: string;
     type: "HOSTED_WORKER" | "MODEL_WORKER" | "SCRIPT_WORKER";
   }>;
-  workstationType?: "MODEL_WORKSTATION" | "LOGICAL_MOVE";
+  workstationType?: "MODEL_WORKSTATION" | "LOGICAL_MOVE" | "SCRIPT_RUN";
 }): CurrentFactoryDocument {
   return {
     name: "Current Factory",
@@ -1329,15 +1376,21 @@ function buildEditableFactoryDefinition(overrides?: {
     ).map((worker, index) => ({
       model: worker.type === "MODEL_WORKER" ? `gpt-5.${index + 5}` : undefined,
       name: worker.name,
-      ...(worker.type === "SCRIPT_WORKER" ? { command: "./poller.sh" } : {}),
+      ...(worker.type === "SCRIPT_WORKER"
+        ? { command: "./poller.sh", args: ["--mode", "script"] }
+        : {}),
       type: worker.type,
     })),
     workstations: [
       {
         behavior: overrides?.behavior,
-        body:
-          overrides?.prompt ??
-          "Review the latest story changes before approval.",
+        ...(overrides?.workstationType === "SCRIPT_RUN"
+          ? {}
+          : {
+              body:
+                overrides?.prompt ??
+                "Review the latest story changes before approval.",
+            }),
         ...(overrides?.behavior === "CRON" && overrides.cron
           ? {
               cron: {
@@ -1352,7 +1405,9 @@ function buildEditableFactoryDefinition(overrides?: {
         inputs: [{ state: "queued", workType: "story" }],
         name: "Review",
         outputs: [{ state: "approved", workType: "story" }],
-        promptFile: "prompts/review.md",
+        ...(overrides?.workstationType === "SCRIPT_RUN"
+          ? {}
+          : { promptFile: "prompts/review.md" }),
         runner: overrides?.runnerName ?? "gemini",
         type: overrides?.workstationType,
         worker: overrides?.workerName ?? "reviewer",

--- a/ui/src/features/current-selection/workstation-selection/hooks/use-editable-workstation-configuration-state.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/hooks/use-editable-workstation-configuration-state.test.tsx
@@ -117,6 +117,50 @@ describe("useEditableWorkstationConfigurationState", () => {
     ).toBeNull();
   });
 
+  it("keeps an explicit legacy model workstation and worker binding in the ready state", async () => {
+    vi.mocked(useCurrentFactoryDocument).mockReturnValue(
+      buildEditableDefinitionResult(
+        buildEditableFactoryDefinition({
+          workerName: "legacy-model",
+          workerOptions: [
+            { name: "legacy-model", type: "MODEL_WORKER" },
+            { name: "script-worker", type: "SCRIPT_WORKER" },
+          ],
+          workstationType: "MODEL_WORKSTATION",
+        }),
+      ),
+    );
+
+    const { result } = renderHook(() =>
+      useEditableWorkstationConfigurationState(selection, selectedNode),
+    );
+
+    await waitFor(() => {
+      expect(result.current?.status).toBe("ready");
+    });
+
+    expect(result.current).toMatchObject({
+      draft: {
+        workstationType: "MODEL_WORKSTATION",
+        workerName: "legacy-model",
+      },
+      initialValues: {
+        workerOptions: ["legacy-model", "script-worker"],
+        workstationType: "MODEL_WORKSTATION",
+      },
+      hasValidationErrors: false,
+      status: "ready",
+    });
+    expect(
+      result.current?.status === "ready"
+        ? result.current.pendingFactoryDefinition?.workstations?.[0]
+        : undefined,
+    ).toMatchObject({
+      type: "MODEL_WORKSTATION",
+      worker: "legacy-model",
+    });
+  });
+
   it("blocks save when the workstation name duplicates another workstation", async () => {
     vi.mocked(useCurrentFactoryDocument).mockReturnValue(
       buildEditableDefinitionResult(

--- a/ui/src/features/current-selection/workstation-selection/hooks/use-editable-workstation-configuration-state.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/hooks/use-editable-workstation-configuration-state.test.tsx
@@ -1143,6 +1143,86 @@ describe("useEditableWorkstationConfigurationState guards and cron", () => {
     ).toHaveBeenLastCalledWith("Review", "", false);
   });
 
+  it("projects POLLER_RUN as a promptless poller and keeps its behavior invariant", async () => {
+    vi.mocked(useCurrentFactoryDocument).mockReturnValue(
+      buildEditableDefinitionResult(
+        buildEditableFactoryDefinition({
+          workerName: "linear-poller",
+          workerOptions: [
+            { name: "linear-poller", type: "HOSTED_WORKER" },
+            { name: "script-poller", type: "SCRIPT_WORKER" },
+            { name: "reviewer", type: "MODEL_WORKER" },
+          ],
+          workstationType: "POLLER_RUN",
+        }),
+      ),
+    );
+
+    const { result } = renderHook(() =>
+      useEditableWorkstationConfigurationState(selection, selectedNode),
+    );
+
+    await waitFor(() => {
+      expect(result.current?.status).toBe("ready");
+    });
+
+    expect(result.current).toMatchObject({
+      draft: {
+        behavior: "POLLER",
+        prompt: "",
+        workerName: "linear-poller",
+        workstationType: "POLLER_RUN",
+      },
+      hasValidationErrors: false,
+      initialValues: {
+        behavior: "POLLER",
+        behaviorOptions: ["POLLER"],
+        workerOptions: ["linear-poller", "script-poller"],
+        workstationType: "POLLER_RUN",
+        workstationTypeOptions: ["POLLER_RUN"],
+      },
+      status: "ready",
+      validationErrors: {},
+      workerOptionsState: {
+        options: ["linear-poller", "script-poller"],
+        status: "ready",
+      },
+    });
+    expect(
+      result.current?.status === "ready"
+        ? result.current.pendingFactoryDefinition
+        : undefined,
+    ).toMatchObject({
+      workstations: [
+        {
+          behavior: "POLLER",
+          type: "POLLER_RUN",
+          worker: "linear-poller",
+        },
+      ],
+    });
+
+    act(() => {
+      if (result.current?.status !== "ready") {
+        throw new Error("expected editable configuration to be ready");
+      }
+      result.current.onBehaviorChange("STANDARD");
+    });
+
+    expect(
+      result.current?.status === "ready" ? result.current.draft : null,
+    ).toMatchObject({
+      behavior: "POLLER",
+      workstationType: "POLLER_RUN",
+    });
+    expect(
+      vi.mocked(useCurrentWorkstationPromptTemplateContract),
+    ).toHaveBeenLastCalledWith("Review", false);
+    expect(
+      vi.mocked(useCurrentWorkstationPromptTemplateValidation),
+    ).toHaveBeenLastCalledWith("Review", "", false);
+  });
+
   it("validates cron fields for CRON workstations and skips them for other behaviors", () => {
     const cronDraft = {
       behavior: "CRON" as const,
@@ -1402,9 +1482,13 @@ function buildEditableFactoryDefinition(overrides?: {
   workerName?: string;
   workerOptions?: Array<{
     name: string;
-    type: "HOSTED_WORKER" | "MODEL_WORKER" | "SCRIPT_WORKER";
+    type: "HOSTED_WORKER" | "MODEL_WORKER" | "POLLER_WORKER" | "SCRIPT_WORKER";
   }>;
-  workstationType?: "MODEL_WORKSTATION" | "LOGICAL_MOVE" | "SCRIPT_RUN";
+  workstationType?:
+    | "MODEL_WORKSTATION"
+    | "LOGICAL_MOVE"
+    | "POLLER_RUN"
+    | "SCRIPT_RUN";
 }): CurrentFactoryDocument {
   return {
     name: "Current Factory",
@@ -1428,7 +1512,8 @@ function buildEditableFactoryDefinition(overrides?: {
     workstations: [
       {
         behavior: overrides?.behavior,
-        ...(overrides?.workstationType === "SCRIPT_RUN"
+        ...(overrides?.workstationType === "SCRIPT_RUN" ||
+        overrides?.workstationType === "POLLER_RUN"
           ? {}
           : {
               body:
@@ -1449,7 +1534,8 @@ function buildEditableFactoryDefinition(overrides?: {
         inputs: [{ state: "queued", workType: "story" }],
         name: "Review",
         outputs: [{ state: "approved", workType: "story" }],
-        ...(overrides?.workstationType === "SCRIPT_RUN"
+        ...(overrides?.workstationType === "SCRIPT_RUN" ||
+        overrides?.workstationType === "POLLER_RUN"
           ? {}
           : { promptFile: "prompts/review.md" }),
         runner: overrides?.runnerName ?? "gemini",

--- a/ui/src/features/current-selection/workstation-selection/hooks/use-editable-workstation-configuration-state.ts
+++ b/ui/src/features/current-selection/workstation-selection/hooks/use-editable-workstation-configuration-state.ts
@@ -1,10 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { CurrentFactoryDocument } from "../../../../api/current-factory-definition";
 import type { DashboardWorkstationNode } from "../../../../api/dashboard/types";
-import {
-  isModelInvokeWorkstationType,
-  workstationUsesPromptOrientedEditing,
-} from "../../../current-factory-definition/lib/workstation/workstation-model-invoke";
+import { workstationUsesPromptOrientedEditing } from "../../../current-factory-definition/lib/workstation/workstation-model-invoke";
 import { workstationBehaviorRequiresPrompt } from "../../../current-factory-definition/lib/workstation-behavior";
 import {
   type EditableWorkstationDraft,
@@ -64,7 +61,7 @@ export function useEditableWorkstationConfigurationState(
     sessionState != null &&
     selectedEditableValues != null &&
     draftWorkstationType != null &&
-    !isModelInvokeWorkstationType(draftWorkstationType) &&
+    workstationUsesPromptOrientedEditing(draftWorkstationType) &&
     workstationRequiresWorkerAssignment({
       type: draftWorkstationType,
     }) &&

--- a/ui/src/features/current-selection/workstation-selection/hooks/use-save-editable-workstation-configuration.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/hooks/use-save-editable-workstation-configuration.test.tsx
@@ -139,6 +139,75 @@ describe("useSaveEditableWorkstationConfiguration", () => {
     expect(result.current.saveState).toEqual({ status: "idle" });
   });
 
+  it("saves a promptless script definition without adding a workstation body", async () => {
+    const scriptFactory = {
+      name: "Script Factory",
+      version: {
+        logical: "7",
+        physical: "2026-05-23T15:52:00Z",
+      },
+      workers: [
+        {
+          args: ["--mode", "script"],
+          command: "./run-script.sh",
+          name: "script-runner",
+          type: "SCRIPT_WORKER" as const,
+        },
+      ],
+      workstations: [
+        {
+          id: "run-script",
+          inputs: [{ state: "queued", workType: "story" }],
+          name: "Run Script",
+          outputs: [{ state: "done", workType: "story" }],
+          type: "SCRIPT_RUN" as const,
+          worker: "script-runner",
+        },
+      ],
+    };
+    const saveAsync = vi.fn().mockResolvedValue(scriptFactory);
+    vi.spyOn(
+      factoryDocumentSaveHooks,
+      "useFactoryDocumentSave",
+    ).mockReturnValue({
+      isPending: false,
+      saveAsync,
+    } as never);
+
+    const { result } = renderHook(
+      () =>
+        useSaveEditableWorkstationConfiguration({
+          editableConfigurationState: buildReadyEditableConfigurationState({
+            pendingFactoryDefinition: scriptFactory,
+            prompt: "",
+            workstationType: "SCRIPT_RUN",
+            draft: {
+              prompt: "",
+              workerName: "script-runner",
+              workstationType: "SCRIPT_RUN",
+            },
+          }),
+          scopeKey: "run-script:transition:Run Script",
+        }),
+      { wrapper: createQueryClientWrapper() },
+    );
+
+    expect(result.current.canSave).toBe(true);
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(saveAsync).toHaveBeenCalledWith({
+      baseVersion: {
+        logical: "7",
+        physical: "2026-05-23T15:52:00Z",
+      },
+      factory: scriptFactory,
+    });
+    expect(scriptFactory.workstations[0]).not.toHaveProperty("body");
+  });
+
   it("saves workstation edits through the selected session current-factory route", async () => {
     useDashboardSessionStore.setState({ selectedSessionID: "session-beta" });
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
@@ -669,7 +738,6 @@ function buildModelInvokeSaveScenario() {
   };
 }
 
-// biome-ignore lint/complexity/noExcessiveLinesPerFunction: the fixture builder keeps the complete ready-state defaults visible for save-hook cases.
 function buildReadyEditableConfigurationState(overrides?: {
   behavior?: "STANDARD" | "REPEATER" | "POLLER" | "CRON";
   cron?: {
@@ -702,7 +770,11 @@ function buildReadyEditableConfigurationState(overrides?: {
     EditableWorkstationConfigurationState,
     { status: "ready" }
   >["validationErrors"];
-  workstationType?: "MODEL_WORKSTATION" | "MODEL_INVOKE" | "LOGICAL_MOVE";
+  workstationType?:
+    | "MODEL_WORKSTATION"
+    | "MODEL_INVOKE"
+    | "LOGICAL_MOVE"
+    | "SCRIPT_RUN";
 }): EditableWorkstationConfigurationState {
   const behavior = overrides?.behavior ?? "STANDARD";
   const cron =
@@ -743,14 +815,7 @@ function buildReadyEditableConfigurationState(overrides?: {
         source: "default",
       },
       runnerName: null,
-      runnerOptions: [
-        "codex",
-        "gemini",
-        "kiro",
-        "codex",
-        "opencode",
-        "pi",
-      ],
+      runnerOptions: ["codex", "gemini", "kiro", "codex", "opencode", "pi"],
       runnerSelectionSource: "default",
       sharedWorkerWorkstationNamesByWorkerName: {},
       sharedWorkerWorkstationNames: [],

--- a/ui/src/features/current-selection/workstation-selection/hooks/use-save-editable-workstation-configuration.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/hooks/use-save-editable-workstation-configuration.test.tsx
@@ -208,6 +208,87 @@ describe("useSaveEditableWorkstationConfiguration", () => {
     expect(scriptFactory.workstations[0]).not.toHaveProperty("body");
   });
 
+  it("saves a poller definition with POLLER_RUN and no prompt or runner fields", async () => {
+    const pollerFactory = {
+      name: "Poller Factory",
+      version: {
+        logical: "7",
+        physical: "2026-05-23T15:52:00Z",
+      },
+      workers: [
+        {
+          auth: { secretRef: "secrets/linear" },
+          name: "linear-poller",
+          provider: "LINEAR" as const,
+          type: "HOSTED_WORKER" as const,
+        },
+      ],
+      workstations: [
+        {
+          behavior: "POLLER" as const,
+          id: "linear-ingress",
+          inputs: [{ state: "queued", workType: "story" }],
+          name: "Linear Ingress",
+          outputs: [{ state: "received", workType: "story" }],
+          type: "POLLER_RUN" as const,
+          worker: "linear-poller",
+        },
+      ],
+    };
+    const saveAsync = vi.fn().mockResolvedValue(pollerFactory);
+    const markChangesSaved = vi.fn();
+    vi.spyOn(
+      factoryDocumentSaveHooks,
+      "useFactoryDocumentSave",
+    ).mockReturnValue({
+      isPending: false,
+      saveAsync,
+    } as never);
+
+    const { result } = renderHook(
+      () =>
+        useSaveEditableWorkstationConfiguration({
+          editableConfigurationState: buildReadyEditableConfigurationState({
+            draft: {
+              behavior: "POLLER",
+              prompt: "",
+              runnerName: null,
+              workerName: "linear-poller",
+              workstationType: "POLLER_RUN",
+            },
+            markChangesSaved,
+            pendingFactoryDefinition: pollerFactory,
+            prompt: "",
+            workstationType: "POLLER_RUN",
+          }),
+          scopeKey: "linear-ingress:transition:Linear Ingress",
+        }),
+      { wrapper: createQueryClientWrapper() },
+    );
+
+    expect(result.current.canSave).toBe(true);
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(saveAsync).toHaveBeenCalledWith({
+      baseVersion: {
+        logical: "7",
+        physical: "2026-05-23T15:52:00Z",
+      },
+      factory: pollerFactory,
+    });
+    expect(pollerFactory.workstations[0]).toMatchObject({
+      behavior: "POLLER",
+      type: "POLLER_RUN",
+      worker: "linear-poller",
+    });
+    expect(pollerFactory.workstations[0]).not.toHaveProperty("body");
+    expect(pollerFactory.workstations[0]).not.toHaveProperty("runner");
+    expect(markChangesSaved).toHaveBeenCalledTimes(1);
+  });
+
   it("saves legacy model workstations without changing their type or worker alias", async () => {
     const legacyModelFactory = {
       name: "Legacy Model Factory",
@@ -853,9 +934,12 @@ function buildReadyEditableConfigurationState(overrides?: {
     | "MODEL_WORKSTATION"
     | "MODEL_INVOKE"
     | "LOGICAL_MOVE"
+    | "POLLER_RUN"
     | "SCRIPT_RUN";
 }): EditableWorkstationConfigurationState {
-  const behavior = overrides?.behavior ?? "STANDARD";
+  const workstationType = overrides?.workstationType ?? "MODEL_WORKSTATION";
+  const isPollerRun = workstationType === "POLLER_RUN";
+  const behavior = isPollerRun ? "POLLER" : (overrides?.behavior ?? "STANDARD");
   const cron =
     behavior === "CRON"
       ? {
@@ -875,45 +959,21 @@ function buildReadyEditableConfigurationState(overrides?: {
       name: "Review",
       operation: overrides?.draft?.operation ?? "",
       operationBindings: overrides?.draft?.operationBindings ?? [],
-      prompt: overrides?.prompt ?? "Review the story.",
-      runnerName: null,
-      workerName: overrides?.draft?.workerName ?? "reviewer",
+      prompt: overrides?.prompt ?? (isPollerRun ? "" : "Review the story."),
+      runnerName: isPollerRun ? null : null,
+      workerName:
+        overrides?.draft?.workerName ??
+        (isPollerRun ? "linear-poller" : "reviewer"),
       ...overrides?.draft,
     },
     hasValidationErrors: overrides?.hasValidationErrors ?? false,
-    initialValues: {
+    initialValues: buildReadyEditableConfigurationInitialValues({
       behavior,
-      behaviorOptions:
-        behavior === "CRON" ? ["CRON"] : ["STANDARD", "REPEATER", "POLLER"],
-      cron,
-      effectiveRunnerName: "codex",
-      factoryRunnerName: null,
-      prompt: overrides?.prompt ?? "Review the story.",
-      resolvedRunnerSelection: {
-        runnerId: "codex",
-        source: "default",
-      },
-      runnerName: null,
-      runnerOptions: ["codex", "gemini", "kiro", "codex", "opencode", "pi"],
-      runnerSelectionSource: "default",
-      sharedWorkerWorkstationNamesByWorkerName: {},
-      sharedWorkerWorkstationNames: [],
-      workerModelProvider: null,
-      workerName: "reviewer",
-      workerOptions: ["reviewer"],
-      workerTypeByName: {
-        reviewer: "MODEL_WORKER",
-      },
-      workstationName: "Review",
-      workstationOptions: ["Review"],
-      workstationType: overrides?.workstationType ?? "MODEL_WORKSTATION",
-      guards: [],
-      inputs: [],
-      modelInvokeWorkerOptions: [],
-      modelOperationsByWorkerName: {},
       operation: overrides?.draft?.operation ?? "",
       operationBindings: overrides?.draft?.operationBindings ?? [],
-    },
+      prompt: overrides?.prompt ?? (isPollerRun ? null : "Review the story."),
+      workstationType,
+    }),
     isDirty: true,
     markChangesSaved: overrides?.markChangesSaved ?? vi.fn(),
     baseVersion: {
@@ -967,9 +1027,68 @@ function buildReadyEditableConfigurationState(overrides?: {
     status: "ready",
     validationErrors: overrides?.validationErrors ?? {},
     workerOptionsState: {
-      options: ["reviewer"],
+      options: isPollerRun ? ["linear-poller", "script-poller"] : ["reviewer"],
       status: "ready",
     },
+  };
+}
+
+type ReadyEditableConfigurationState = Extract<
+  EditableWorkstationConfigurationState,
+  { status: "ready" }
+>;
+
+function buildReadyEditableConfigurationInitialValues({
+  behavior,
+  operation,
+  operationBindings,
+  prompt,
+  workstationType,
+}: {
+  behavior: ReadyEditableConfigurationState["draft"]["behavior"];
+  operation: ReadyEditableConfigurationState["draft"]["operation"];
+  operationBindings: ReadyEditableConfigurationState["draft"]["operationBindings"];
+  prompt: ReadyEditableConfigurationState["initialValues"]["prompt"];
+  workstationType: ReadyEditableConfigurationState["draft"]["workstationType"];
+}): ReadyEditableConfigurationState["initialValues"] {
+  const isPollerRun = workstationType === "POLLER_RUN";
+
+  return {
+    behavior,
+    behaviorOptions: isPollerRun
+      ? ["POLLER"]
+      : behavior === "CRON"
+        ? ["CRON"]
+        : ["STANDARD", "REPEATER", "POLLER"],
+    cron: null,
+    effectiveRunnerName: "codex",
+    factoryRunnerName: null,
+    prompt,
+    resolvedRunnerSelection: { runnerId: "codex", source: "default" },
+    runnerName: null,
+    runnerOptions: ["codex", "gemini", "kiro", "codex", "opencode", "pi"],
+    runnerSelectionSource: "default",
+    sharedWorkerWorkstationNamesByWorkerName: {},
+    sharedWorkerWorkstationNames: [],
+    workerModelProvider: null,
+    workerName: isPollerRun ? "linear-poller" : "reviewer",
+    workerOptions: isPollerRun
+      ? ["linear-poller", "script-poller"]
+      : ["reviewer"],
+    workerTypeByName: {
+      "linear-poller": "HOSTED_WORKER",
+      reviewer: "MODEL_WORKER",
+      "script-poller": "SCRIPT_WORKER",
+    },
+    workstationName: "Review",
+    workstationOptions: ["Review"],
+    workstationType,
+    guards: [],
+    inputs: [],
+    modelInvokeWorkerOptions: [],
+    modelOperationsByWorkerName: {},
+    operation,
+    operationBindings,
   };
 }
 

--- a/ui/src/features/current-selection/workstation-selection/hooks/use-save-editable-workstation-configuration.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/hooks/use-save-editable-workstation-configuration.test.tsx
@@ -208,6 +208,85 @@ describe("useSaveEditableWorkstationConfiguration", () => {
     expect(scriptFactory.workstations[0]).not.toHaveProperty("body");
   });
 
+  it("saves legacy model workstations without changing their type or worker alias", async () => {
+    const legacyModelFactory = {
+      name: "Legacy Model Factory",
+      version: {
+        logical: "7",
+        physical: "2026-05-23T15:52:00Z",
+      },
+      workers: [
+        {
+          args: ["--json"],
+          command: "model-runner",
+          model: "gpt-5.4",
+          name: "legacy-model",
+          type: "MODEL_WORKER" as const,
+        },
+      ],
+      workstations: [
+        {
+          behavior: "STANDARD" as const,
+          body: "Review the updated story.",
+          guards: [{ maxVisits: 2, type: "VISIT_COUNT" as const }],
+          id: "legacy-review",
+          inputs: [{ state: "queued", workType: "story" }],
+          name: "Legacy Review Updated",
+          outputs: [{ state: "approved", workType: "story" }],
+          promptFile: "prompts/legacy-review.md",
+          runner: "claude" as const,
+          type: "MODEL_WORKSTATION" as const,
+          worker: "legacy-model",
+        },
+      ],
+    };
+    const saveAsync = vi.fn().mockResolvedValue(legacyModelFactory);
+    const markChangesSaved = vi.fn();
+    vi.spyOn(
+      factoryDocumentSaveHooks,
+      "useFactoryDocumentSave",
+    ).mockReturnValue({
+      isPending: false,
+      saveAsync,
+    } as never);
+
+    const { result } = renderHook(
+      () =>
+        useSaveEditableWorkstationConfiguration({
+          editableConfigurationState: buildReadyEditableConfigurationState({
+            markChangesSaved,
+            pendingFactoryDefinition: legacyModelFactory,
+            prompt: "Review the updated story.",
+            workstationType: "MODEL_WORKSTATION",
+            draft: {
+              name: "Legacy Review Updated",
+              prompt: "Review the updated story.",
+              runnerName: "claude",
+              workerName: "legacy-model",
+              workstationType: "MODEL_WORKSTATION",
+            },
+          }),
+          scopeKey: "legacy-review:transition:Legacy Review",
+        }),
+      { wrapper: createQueryClientWrapper() },
+    );
+
+    expect(result.current.canSave).toBe(true);
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(saveAsync).toHaveBeenCalledWith({
+      baseVersion: {
+        logical: "7",
+        physical: "2026-05-23T15:52:00Z",
+      },
+      factory: legacyModelFactory,
+    });
+    expect(markChangesSaved).toHaveBeenCalledTimes(1);
+  });
+
   it("saves workstation edits through the selected session current-factory route", async () => {
     useDashboardSessionStore.setState({ selectedSessionID: "session-beta" });
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(

--- a/ui/src/features/current-selection/workstation-selection/lib/editable-workstation-configuration-validation.worker-options.test.ts
+++ b/ui/src/features/current-selection/workstation-selection/lib/editable-workstation-configuration-validation.worker-options.test.ts
@@ -111,3 +111,46 @@ describe("resolveWorkerOptionsState model workstation", () => {
     });
   });
 });
+
+describe("resolveWorkerOptionsState script workstation", () => {
+  it("keeps compatible script choices ready and reports an unavailable binding", () => {
+    const scriptValues = {
+      ...modelWorkstationValues,
+      workerName: "script-runner",
+      workerOptions: ["script-runner"],
+      workerTypeByName: { "script-runner": "SCRIPT_WORKER" as const },
+      workstationType: "SCRIPT_RUN" as const,
+      workstationTypeOptions: ["SCRIPT_RUN"] as const,
+    };
+
+    expect(
+      resolveWorkerOptionsState(
+        {
+          ...baseEditableWorkstationDraft,
+          prompt: "",
+          workerName: "script-runner",
+          workstationType: "SCRIPT_RUN",
+        },
+        scriptValues,
+        editableWorkstationValidationMessages,
+      ),
+    ).toEqual({ options: ["script-runner"], status: "ready" });
+
+    expect(
+      resolveWorkerOptionsState(
+        {
+          ...baseEditableWorkstationDraft,
+          prompt: "",
+          workerName: "missing-model-worker",
+          workstationType: "SCRIPT_RUN",
+        },
+        scriptValues,
+        editableWorkstationValidationMessages,
+      ),
+    ).toEqual({
+      message:
+        editableWorkstationValidationMessages.editableConfigurationWorkerMissing,
+      status: "error",
+    });
+  });
+});

--- a/ui/src/features/current-selection/workstation-selection/lib/validation/editable-workstation-configuration-validation.test.ts
+++ b/ui/src/features/current-selection/workstation-selection/lib/validation/editable-workstation-configuration-validation.test.ts
@@ -239,6 +239,59 @@ describe("validateEditableWorkstationDraft model workstation", () => {
   });
 });
 
+describe("validateEditableWorkstationDraft script workstation", () => {
+  const scriptValues = {
+    ...modelWorkstationValues,
+    prompt: null,
+    workerName: "script-runner",
+    workerOptions: ["script-runner"],
+    workerTypeByName: { "script-runner": "SCRIPT_WORKER" as const },
+    workstationType: "SCRIPT_RUN" as const,
+    workstationTypeOptions: ["SCRIPT_RUN"] as const,
+  };
+
+  it("does not require prompt content or prompt validation for SCRIPT_RUN", () => {
+    const errors = validateEditableWorkstationDraft(
+      {
+        ...baseEditableWorkstationDraft,
+        prompt: "",
+        workerName: "script-runner",
+        workstationType: "SCRIPT_RUN",
+      },
+      scriptValues,
+      {
+        diagnostics: [
+          { message: "prompt should not be checked", severity: "error" },
+        ],
+        result: { diagnostics: [], valid: false },
+        status: "ready",
+      },
+      editableWorkstationValidationMessages,
+    );
+
+    expect(errors).toEqual({});
+  });
+
+  it("blocks a missing or incompatible script worker with worker feedback", () => {
+    const errors = validateEditableWorkstationDraft(
+      {
+        ...baseEditableWorkstationDraft,
+        prompt: "",
+        workerName: "reviewer",
+        workstationType: "SCRIPT_RUN",
+      },
+      scriptValues,
+      { status: "idle" },
+      editableWorkstationValidationMessages,
+    );
+
+    expect(errors.workerName).toBe(
+      editableWorkstationValidationMessages.editableConfigurationWorkerUnavailable,
+    );
+    expect(errors.prompt).toBeUndefined();
+  });
+});
+
 describe("validateEditableWorkstationDraft MATCHES_FIELDS guards", () => {
   it("requires inputKey for empty or whitespace-only selectors", () => {
     const errors = validateEditableWorkstationDraft(

--- a/ui/src/features/current-selection/workstation-selection/lib/validation/editable-workstation-configuration-validation.test.ts
+++ b/ui/src/features/current-selection/workstation-selection/lib/validation/editable-workstation-configuration-validation.test.ts
@@ -278,6 +278,56 @@ describe("validateEditableWorkstationDraft model workstation", () => {
   });
 });
 
+describe("validateEditableWorkstationDraft poller workstation", () => {
+  it("accepts poller-capable workers and rejects inference workers", () => {
+    const pollerValues = {
+      ...modelWorkstationValues,
+      behavior: "POLLER" as const,
+      behaviorOptions: ["POLLER" as const],
+      prompt: null,
+      workerName: "linear-poller",
+      workerOptions: ["linear-poller", "script-poller"],
+      workerTypeByName: {
+        "linear-poller": "HOSTED_WORKER" as const,
+        "script-poller": "SCRIPT_WORKER" as const,
+        reviewer: "MODEL_WORKER" as const,
+      },
+      workstationType: "POLLER_RUN" as const,
+      workstationTypeOptions: ["POLLER_RUN" as const],
+    };
+
+    const validErrors = validateEditableWorkstationDraft(
+      {
+        ...baseEditableWorkstationDraft,
+        behavior: "POLLER",
+        prompt: "",
+        workerName: "linear-poller",
+        workstationType: "POLLER_RUN",
+      },
+      pollerValues,
+      { status: "idle" },
+      editableWorkstationValidationMessages,
+    );
+    expect(validErrors).toEqual({});
+
+    const incompatibleErrors = validateEditableWorkstationDraft(
+      {
+        ...baseEditableWorkstationDraft,
+        behavior: "POLLER",
+        prompt: "",
+        workerName: "reviewer",
+        workstationType: "POLLER_RUN",
+      },
+      pollerValues,
+      { status: "idle" },
+      editableWorkstationValidationMessages,
+    );
+    expect(incompatibleErrors.workerName).toBe(
+      editableWorkstationValidationMessages.editableConfigurationWorkerUnavailable,
+    );
+  });
+});
+
 describe("validateEditableWorkstationDraft script workstation", () => {
   const scriptValues = {
     ...modelWorkstationValues,

--- a/ui/src/features/current-selection/workstation-selection/lib/validation/editable-workstation-configuration-validation.test.ts
+++ b/ui/src/features/current-selection/workstation-selection/lib/validation/editable-workstation-configuration-validation.test.ts
@@ -136,6 +136,45 @@ describe("validateEditableWorkstationDraft logical move", () => {
 });
 
 describe("validateEditableWorkstationDraft model workstation", () => {
+  it("keeps the legacy MODEL_WORKER binding valid while rejecting an incompatible worker", () => {
+    const legacyModelValues = {
+      ...modelWorkstationValues,
+      workerName: "legacy-model",
+      workerOptions: ["legacy-model", "script-worker"],
+      workerTypeByName: {
+        "legacy-model": "MODEL_WORKER" as const,
+        "script-worker": "SCRIPT_WORKER" as const,
+        "inference-worker": "INFERENCE_WORKER" as const,
+      },
+    };
+
+    const validErrors = validateEditableWorkstationDraft(
+      {
+        ...baseEditableWorkstationDraft,
+        prompt: "Review the configured story.",
+        workerName: "legacy-model",
+      },
+      legacyModelValues,
+      { status: "idle" },
+      editableWorkstationValidationMessages,
+    );
+    expect(validErrors.workerName).toBeUndefined();
+
+    const incompatibleErrors = validateEditableWorkstationDraft(
+      {
+        ...baseEditableWorkstationDraft,
+        prompt: "Review the configured story.",
+        workerName: "inference-worker",
+      },
+      legacyModelValues,
+      { status: "idle" },
+      editableWorkstationValidationMessages,
+    );
+    expect(incompatibleErrors.workerName).toBe(
+      editableWorkstationValidationMessages.editableConfigurationWorkerUnavailable,
+    );
+  });
+
   it("requires worker and prompt for MODEL_WORKSTATION drafts", () => {
     const errors = validateEditableWorkstationDraft(
       baseEditableWorkstationDraft,

--- a/ui/src/features/current-selection/workstation-selection/lib/validation/editable-workstation-configuration-validation.ts
+++ b/ui/src/features/current-selection/workstation-selection/lib/validation/editable-workstation-configuration-validation.ts
@@ -3,6 +3,7 @@ import {
   isModelInvokeWorkstationType,
   resolveModelOperationByName,
   validateEditableModelInvokeBindings,
+  workstationUsesPromptOrientedEditing,
 } from "../../../../current-factory-definition/lib/workstation/workstation-model-invoke";
 import {
   workerSupportsPollerBehavior,
@@ -86,7 +87,7 @@ export function validateEditableWorkstationDraft(
   const isModelInvoke = isModelInvokeWorkstationType(draft.workstationType);
   const promptIsRequired =
     requiresWorkerAssignment &&
-    !isModelInvoke &&
+    workstationUsesPromptOrientedEditing(draft.workstationType) &&
     workstationBehaviorRequiresPrompt(draft.behavior);
 
   if (isModelInvoke && selectedEditableValues != null) {

--- a/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.test.tsx
+++ b/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.test.tsx
@@ -1,3 +1,4 @@
+import "../../../testing/vitest-dom-capabilities.setup";
 import "@testing-library/jest-dom/vitest";
 import {
   fireEvent,

--- a/ui/src/testing/bun/component-test-files.test.ts
+++ b/ui/src/testing/bun/component-test-files.test.ts
@@ -79,4 +79,17 @@ describe("classifyComponentTestSource", () => {
       runner: "vitest",
     });
   });
+
+  it("routes nested workstation graph tests through Vitest before explicit Bun suffixes", () => {
+    expect(
+      classifyComponentTestSource(
+        "src/features/current-selection/workstation-selection/components/editable/poller/workstation-editable-configuration-section.poller.bun.component.test.tsx",
+        "",
+      ),
+    ).toMatchObject({
+      reason:
+        "imports workspace graph packages that Bun resolves through declaration files",
+      runner: "vitest",
+    });
+  });
 });


### PR DESCRIPTION
{
  "project": "Support script, model, and poller workstations in Current Selection",
  "branchName": "current-selection-configuration",
  "description": "Update the dashboard Current Selection workstation editor so script, supported legacy model, and poller workstations are projected, validated, edited, and saved according to their canonical runtime classes, including promptless script and poller paths and preservation of model-worker aliases.",
  "context": {
    "customerAsk": "Update workstation Current Selection configuration to support script workstations backed by script workers without requiring a prompt, and add the missing support for model-worker workstations and poller workstations.",
    "problem": "Current Selection exposes only a partial workstation taxonomy and routes most worker-backed definitions through one prompt-oriented draft and save path. Valid SCRIPT_RUN, MODEL_WORKSTATION/MODEL_WORKER, and POLLER_RUN definitions can therefore show inappropriate fields, fail prompt validation, offer incompatible workers, be coerced to another type, or save fields that change runtime meaning.",
    "solution": "Treat the current Factory document as canonical and derive a type-aware editable projection using one worker/workstation compatibility policy aligned with Factory Definitions. Script and poller workstations omit prompt loading, UI, validation, and serialization; supported legacy model workstations retain their authored type, model-worker binding, and prompt behavior; saving preserves unrelated topology and worker-owned configuration through the existing version-aware mutation path."
  },
  "acceptanceCriteria": [
    "Selecting a script, supported legacy model, or poller workstation produces a ready Current Selection configuration with the authored workstation type and worker binding intact; loading, empty, and error states remain explicit and actionable.",
    "The editor derives visible fields, required fields, compatible worker choices, and save validation from the workstation and worker runtime classes: script and poller paths do not require or write a prompt, while model prompt behavior remains available and valid.",
    "Saving any supported class produces a canonical Factory definition that preserves its runtime meaning and unrelated workstation topology, guards, inputs, names, runner/behavior fields where applicable, and concurrent-edit/reset semantics; an incompatible worker/type pairing is blocked before save with field-level feedback.",
    "The visible editor remains keyboard operable, uses accessible labels and associated error/help text, and works at narrow and wide dashboard widths; direct browser verification covers script, model, and poller selections plus save feedback.",
    "No public API or generated contract change is introduced unless implementation proves the canonical contract is missing required data; if a contract change becomes necessary, authored OpenAPI, generated clients, mapping, and contract tests remain aligned.",
    "Quality gate: Typecheck passes, focused current-factory and Current Selection state/component/save tests pass, direct browser verification passes, and no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. make lint end-to-end is not required to pass because pkg-boundary carries recorded pre-existing packaged-service-structure migration debt (recorded 2026-08-08).",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. Before pushing, implementation fetches and rebases the reused lane onto origin/main, proves origin/main is an ancestor of HEAD, preserves its intact commits, and does not edit docs/internal/baselines/deadcode-baseline.txt."
  ],
  "userStories": [
    {
      "id": "current-selection-configuration-001",
      "title": "Edit promptless script workstations",
      "description": "As an operator, I want Current Selection to recognize a script workstation and its script worker so that I can update and save the workstation without authoring an irrelevant prompt.",
      "acceptanceCriteria": [
        "Selecting an authored SCRIPT_RUN workstation bound to a SCRIPT_WORKER keeps that workstation type and binding in the ready editable state and summary.",
        "The editable form shows the applicable identity, script-worker assignment, behavior, runner, guard, and input controls, but does not show, load help for, or validate a workstation prompt.",
        "Worker choices for a script workstation include compatible script workers and exclude worker types that the Factory Definitions compatibility contract would reject; missing or incompatible bindings show accessible field-level feedback and cannot be saved.",
        "Saving a valid script workstation succeeds with no body added solely by the editor, preserves the script worker's command/arguments and unrelated Factory data, and keeps dirty, reset, conflict, success, and failure feedback behavior intact.",
        "Focused projection, validation, draft-application, hook, component, and save tests cover a promptless script definition and fail against the prior behavior.",
        "Typecheck passes",
        "Tests pass",
        "Verify in a browser with keyboard-only interaction at narrow and wide dashboard widths, including selection, compatible worker choice, prompt absence, save, and save feedback"
      ],
      "priority": 1,
      "passes": true,
    "notes": "Implementation and focused non-browser gates are complete. Live browser verification unavailable in this environment; the single supported availability inspection returned [] on 2026-08-23, so the browser criterion is recorded as unavailable."
    },
    {
      "id": "current-selection-configuration-002",
      "title": "Preserve model-worker workstation configuration",
      "description": "As an operator of an existing model-based Factory, I want Current Selection to retain and edit a supported model workstation bound to a model worker so that saving does not silently migrate or invalidate the Factory.",
      "acceptanceCriteria": [
        "Selecting a supported MODEL_WORKSTATION bound to MODEL_WORKER retains both authored legacy aliases in the ready state, summary, type selector, and pending saved definition.",
        "The editor exposes the applicable prompt-oriented workstation fields and model-worker choice, and compatible worker options do not invite pairings that canonical Factory validation would reject.",
        "Editing and saving the name, prompt, worker, behavior, runner, guards, or inputs preserves the supported model workstation runtime class and all untouched Factory data rather than coercing it to an unrelated workstation type.",
        "Existing prompt loading, syntax diagnostics, required-field behavior, save blocking, reset, concurrent-change warnings, success, and failure feedback continue to work for the model workstation path.",
        "Focused projection, compatibility, mutation, hook, component, and save tests cover the legacy model pairing and demonstrate that the saved definition retains its type and binding.",
        "Typecheck passes",
        "Tests pass",
        "Verify in a browser with keyboard-only interaction at narrow and wide dashboard widths, including the retained type, model-worker options, prompt validation, save, and save feedback"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implementation and focused non-browser gates pass, including canonical MODEL_WORKSTATION/MODEL_WORKER projection, compatibility validation, ready-state, component, and save coverage. Live browser verification unavailable in this environment; the prior supported availability inspection returned [] and the browser criterion is recorded as unavailable."
    },
    {
      "id": "current-selection-configuration-003",
      "title": "Edit poller workstations with poller-capable workers",
      "description": "As an operator, I want Current Selection to understand poller workstations so that I can maintain long-lived ingress configuration without being asked for prompt-oriented settings.",
      "acceptanceCriteria": [
        "Selecting an authored POLLER_RUN workstation resolves to POLLER behavior, retains its authored worker binding, and shows a clear localized poller summary and editable state.",
        "The editable form omits prompt and ordinary model-runner requirements, presents only applicable workstation controls, and keeps the POLLER_RUN/POLLER invariant when the draft is edited or reset.",
        "Worker choices include the poller-capable worker types accepted by the canonical contract, including supported script-backed pollers and legacy hosted pollers where present, and exclude incompatible inference or agent workers.",
        "Saving a valid poller workstation emits POLLER_RUN with POLLER behavior, does not add a prompt, preserves worker-owned polling/provider/script configuration and unrelated Factory data, and blocks missing or incompatible bindings with accessible feedback.",
        "Loading, empty worker catalog, unavailable current worker, validation error, dirty, concurrent-change, save-success, and save-failure states remain explicit and do not discard the local draft.",
        "Focused projection, invariant, compatibility, validation, hook, component, and save tests cover poller-worker, script-poller, and supported legacy hosted-poller examples and fail against the prior behavior.",
        "Typecheck passes",
        "Tests pass",
        "Verify in a browser with keyboard-only interaction at narrow and wide dashboard widths, including poller type/behavior presentation, compatible worker choice, prompt absence, save, and save feedback"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented and verified explicit POLLER_RUN projection, POLLER invariant, poller/script/hosted worker compatibility, promptless UI and save serialization, validation, hook, component, and save coverage. Live browser verification unavailable in this environment; the prior supported availability inspection returned [] and the browser criterion is recorded as unavailable."
    }
  ]
}
