### PR TITLE
test: restore Factory Runtime and Sessions coverage floors

### DIFF
--- a/pkg/services/factory_definitions/internal/services/runtime_snapshot/service_test.go
+++ b/pkg/services/factory_definitions/internal/services/runtime_snapshot/service_test.go
@@ -303,57 +303,17 @@ func TestResolveRuntimeSnapshotPreservesTypedLoaderFailure(t *testing.T) {
 	}
 }
 
-func TestResolveRuntimeSnapshotCarriesInvocationProvenanceAndDetachesInputs(t *testing.T) {
+func TestResolveRuntimeSnapshotCarriesInvocationProvenance(t *testing.T) {
 	t.Parallel()
 
-	source := newTestLoadedSource()
-	source.config.Workers[0].ModelProvider = "codex"
-	source.config.Workers[0].Args = []string{"--token=${apiKey}", "--label=${label}"}
-	source.config.Workstations[0].Env["secret/name~value"] = "${apiKey}"
-	arguments := &work.InvocationArguments{Arguments: map[string]work.InvocationArgument{
-		"apiKey": {Values: []string{"super-secret"}, Sensitive: true},
-		"label":  {Values: []string{"public"}},
-	}}
-	workstationLoader := &testWorkstationLoader{}
-	var receivedPath string
-	var receivedWorkstationLoader factorydefinitions.WorkstationLoader
-	resolver, err := runtimesnapshotwire.NewService(
-		func(_ []byte, loader factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
-			receivedWorkstationLoader = loader
-			return source, nil
-		},
-		func(path string, loader factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
-			receivedPath = path
-			receivedWorkstationLoader = loader
-			return source, nil
-		},
-		func() factorydefinitions.WorkstationLoader { return workstationLoader },
-		factorydefinitions.FileReader(func(string) ([]byte, error) { return nil, nil }),
-	)
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
+	fixture := newInvocationSnapshotFixture(t)
+	snapshot := fixture.result.Snapshot
+	if fixture.receivedPath != "/factories/alpha" {
+		t.Fatalf("loaded Factory path = %q, want trimmed source path", fixture.receivedPath)
 	}
-
-	result, err := resolver.ResolveRuntimeSnapshot(context.Background(), factorydefinitions.ResolveRuntimeSnapshotRequest{
-		SourcePath:       "  /factories/alpha  ",
-		ExecutionBaseDir: "  /execution/base  ",
-		Invocation: factorydefinitions.RuntimeSnapshotInvocationContext{
-			FactorySessionID: "session-1",
-			WorkflowID:       "workflow-1",
-			Arguments:        arguments,
-		},
-	})
-	if err != nil {
-		t.Fatalf("ResolveRuntimeSnapshot() error = %v", err)
+	if fixture.receivedWorkstationLoader != fixture.workstationLoader {
+		t.Fatalf("workstation loader = %T, want injected loader %T", fixture.receivedWorkstationLoader, fixture.workstationLoader)
 	}
-	if receivedPath != "/factories/alpha" {
-		t.Fatalf("loaded Factory path = %q, want trimmed source path", receivedPath)
-	}
-	if receivedWorkstationLoader != workstationLoader {
-		t.Fatalf("workstation loader = %T, want injected loader %T", receivedWorkstationLoader, workstationLoader)
-	}
-
-	snapshot := result.Snapshot
 	if snapshot.FactoryDir != "/factories/alpha" || snapshot.RuntimeBaseDir != "/execution/base" {
 		t.Fatalf("snapshot paths = %q/%q, want Factory and execution roots", snapshot.FactoryDir, snapshot.RuntimeBaseDir)
 	}
@@ -366,25 +326,22 @@ func TestResolveRuntimeSnapshotCarriesInvocationProvenanceAndDetachesInputs(t *t
 	if got := snapshot.EffectiveFactory.Workstations[0].Env["secret/name~value"]; got != "super-secret" {
 		t.Fatalf("effective sensitive environment value = %q, want interpolated value", got)
 	}
-	wantPointers := []string{
-		"/workers/0/args/0",
-		"/workstations/0/env/secret~1name~0value",
-	}
-	if !reflect.DeepEqual(snapshot.InvocationSensitiveJSONPointers, wantPointers) {
-		t.Fatalf("sensitive JSON pointers = %#v, want %#v", snapshot.InvocationSensitiveJSONPointers, wantPointers)
-	}
-	if strings.Contains(strings.Join(snapshot.InvocationSensitiveJSONPointers, "\n"), "super-secret") {
-		t.Fatal("sensitive invocation value was exposed in JSON pointer provenance")
-	}
+	assertInvocationSensitivePointers(t, snapshot.InvocationSensitiveJSONPointers)
 	if len(snapshot.BundledFiles) != 1 || snapshot.BundledFiles[0].TargetPath != "docs/README.md" {
 		t.Fatalf("bundled files = %#v, want loaded portable replacement", snapshot.BundledFiles)
 	}
+}
 
-	arguments.Arguments["apiKey"] = work.InvocationArgument{Values: []string{"changed"}, Sensitive: true}
-	arguments.Arguments["label"].Values[0] = "changed"
-	source.config.Workers[0].Args[0] = "source-mutated"
-	source.config.Workstations[0].Env["secret/name~value"] = "source-mutated"
-	source.replacements[0].TargetPath = "source-mutated"
+func TestResolveRuntimeSnapshotDetachesInvocationAndSourceInputs(t *testing.T) {
+	t.Parallel()
+
+	fixture := newInvocationSnapshotFixture(t)
+	snapshot := fixture.result.Snapshot
+	fixture.arguments.Arguments["apiKey"] = work.InvocationArgument{Values: []string{"changed"}, Sensitive: true}
+	fixture.arguments.Arguments["label"].Values[0] = "changed"
+	fixture.source.config.Workers[0].Args[0] = "source-mutated"
+	fixture.source.config.Workstations[0].Env["secret/name~value"] = "source-mutated"
+	fixture.source.replacements[0].TargetPath = "source-mutated"
 	if snapshot.Invocation.Arguments.Arguments["apiKey"].Values[0] != "super-secret" ||
 		snapshot.Invocation.Arguments.Arguments["label"].Values[0] != "public" {
 		t.Fatalf("snapshot invocation arguments were not detached: %#v", snapshot.Invocation.Arguments)
@@ -395,6 +352,75 @@ func TestResolveRuntimeSnapshotCarriesInvocationProvenanceAndDetachesInputs(t *t
 	}
 	if snapshot.BundledFiles[0].TargetPath != "docs/README.md" {
 		t.Fatalf("snapshot bundled file was affected by source mutation: %#v", snapshot.BundledFiles)
+	}
+}
+
+func newInvocationSnapshotFixture(t *testing.T) invocationSnapshotFixture {
+	t.Helper()
+	source := newTestLoadedSource()
+	source.config.Workers[0].ModelProvider = "codex"
+	source.config.Workers[0].Args = []string{"--token=${apiKey}", "--label=${label}"}
+	source.config.Workstations[0].Env["secret/name~value"] = "${apiKey}"
+	arguments := &work.InvocationArguments{Arguments: map[string]work.InvocationArgument{
+		"apiKey": {Values: []string{"super-secret"}, Sensitive: true},
+		"label":  {Values: []string{"public"}},
+	}}
+	fixture := invocationSnapshotFixture{
+		source:            source,
+		arguments:         arguments,
+		workstationLoader: &testWorkstationLoader{},
+	}
+	resolver, err := runtimesnapshotwire.NewService(
+		func(_ []byte, loader factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+			fixture.receivedWorkstationLoader = loader
+			return source, nil
+		},
+		func(path string, loader factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+			fixture.receivedPath = path
+			fixture.receivedWorkstationLoader = loader
+			return source, nil
+		},
+		func() factorydefinitions.WorkstationLoader { return fixture.workstationLoader },
+		factorydefinitions.FileReader(func(string) ([]byte, error) { return nil, nil }),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	fixture.result, err = resolver.ResolveRuntimeSnapshot(context.Background(), factorydefinitions.ResolveRuntimeSnapshotRequest{
+		SourcePath:       "  /factories/alpha  ",
+		ExecutionBaseDir: "  /execution/base  ",
+		Invocation: factorydefinitions.RuntimeSnapshotInvocationContext{
+			FactorySessionID: "session-1",
+			WorkflowID:       "workflow-1",
+			Arguments:        arguments,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ResolveRuntimeSnapshot() error = %v", err)
+	}
+	return fixture
+}
+
+type invocationSnapshotFixture struct {
+	result                    factorydefinitions.ResolveRuntimeSnapshotResult
+	source                    *fakeLoadedSource
+	arguments                 *work.InvocationArguments
+	workstationLoader         *testWorkstationLoader
+	receivedPath              string
+	receivedWorkstationLoader factorydefinitions.WorkstationLoader
+}
+
+func assertInvocationSensitivePointers(t *testing.T, pointers []string) {
+	t.Helper()
+	want := []string{
+		"/workers/0/args/0",
+		"/workstations/0/env/secret~1name~0value",
+	}
+	if !reflect.DeepEqual(pointers, want) {
+		t.Fatalf("sensitive JSON pointers = %#v, want %#v", pointers, want)
+	}
+	if strings.Contains(strings.Join(pointers, "\n"), "super-secret") {
+		t.Fatal("sensitive invocation value was exposed in JSON pointer provenance")
 	}
 }
 
@@ -471,113 +497,128 @@ func TestResolveRuntimeSnapshotClassifiesEveryAutomationSourceKind(t *testing.T)
 	}
 }
 
-func TestResolveRuntimeSnapshotClassifiesContextAndDefinitionFailures(t *testing.T) {
+func TestResolveRuntimeSnapshotRejectsNilContext(t *testing.T) {
 	t.Parallel()
 
-	loaderCause := errors.New("loader failed")
-	canceledContext, cancel := context.WithCancel(context.Background())
+	resolver := newRuntimeSnapshotFailureResolver(t, nil, nil, nil)
+	assertRuntimeSnapshotFailure(
+		t,
+		resolver,
+		nil,
+		factorydefinitions.RuntimeSnapshotDiagnosticInvalidRequest,
+		nil,
+		false,
+	)
+}
+
+func TestResolveRuntimeSnapshotRejectsCanceledContextBeforeLoading(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
+	resolver := newRuntimeSnapshotFailureResolver(t, newTestLoadedSource(), nil, nil)
+	assertRuntimeSnapshotFailure(
+		t,
+		resolver,
+		ctx,
+		factorydefinitions.RuntimeSnapshotDiagnosticCanceled,
+		context.Canceled,
+		false,
+	)
+}
 
-	tests := []struct {
-		name           string
-		context        context.Context
-		loaded         factorydefinitions.MutableLoadedFactorySource
-		loaderError    error
-		cancelOnLoad   bool
-		wantCode       factorydefinitions.RuntimeSnapshotDiagnosticCode
-		wantUnderlying error
-		wantCause      bool
-	}{
-		{
-			name:     "nil context",
-			context:  nil,
-			wantCode: factorydefinitions.RuntimeSnapshotDiagnosticInvalidRequest,
-		},
-		{
-			name:           "canceled before loading",
-			context:        canceledContext,
-			wantCode:       factorydefinitions.RuntimeSnapshotDiagnosticCanceled,
-			wantUnderlying: context.Canceled,
-		},
-		{
-			name:           "canceled after loading",
-			context:        context.Background(),
-			loaded:         newTestLoadedSource(),
-			cancelOnLoad:   true,
-			wantCode:       factorydefinitions.RuntimeSnapshotDiagnosticCanceled,
-			wantUnderlying: context.Canceled,
-		},
-		{
-			name:           "loader failure",
-			context:        context.Background(),
-			loaderError:    loaderCause,
-			wantCode:       factorydefinitions.RuntimeSnapshotDiagnosticInvalidDefinition,
-			wantUnderlying: loaderCause,
-		},
-		{
-			name:     "nil loaded source",
-			context:  context.Background(),
-			wantCode: factorydefinitions.RuntimeSnapshotDiagnosticInvalidDefinition,
-		},
-		{
-			name:    "und detachable definition",
-			context: context.Background(),
-			loaded: func() factorydefinitions.MutableLoadedFactorySource {
-				source := newTestLoadedSource()
-				source.config = nil
-				return source
-			}(),
-			wantCode:  factorydefinitions.RuntimeSnapshotDiagnosticInvalidDefinition,
-			wantCause: true,
-		},
-	}
+func TestResolveRuntimeSnapshotRejectsCancellationAfterLoading(t *testing.T) {
+	t.Parallel()
 
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resolver := newRuntimeSnapshotFailureResolver(t, newTestLoadedSource(), nil, cancel)
+	assertRuntimeSnapshotFailure(
+		t,
+		resolver,
+		ctx,
+		factorydefinitions.RuntimeSnapshotDiagnosticCanceled,
+		context.Canceled,
+		false,
+	)
+}
 
-			ctx := test.context
-			if test.cancelOnLoad {
-				var cancelLoad context.CancelFunc
-				ctx, cancelLoad = context.WithCancel(context.Background())
-				defer cancelLoad()
-				loader := test.loaded
-				resolver, err := runtimesnapshotwire.NewService(
-					func(_ []byte, _ factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
-						cancelLoad()
-						return loader, nil
-					},
-					func(_ string, _ factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
-						cancelLoad()
-						return loader, nil
-					},
-					func() factorydefinitions.WorkstationLoader { return nil },
-					nil,
-				)
-				if err != nil {
-					t.Fatalf("New() error = %v", err)
-				}
-				assertRuntimeSnapshotFailure(t, resolver, ctx, test.wantCode, test.wantUnderlying, test.wantCause)
-				return
+func TestResolveRuntimeSnapshotPreservesLoaderFailure(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("loader failed")
+	resolver := newRuntimeSnapshotFailureResolver(t, nil, cause, nil)
+	assertRuntimeSnapshotFailure(
+		t,
+		resolver,
+		context.Background(),
+		factorydefinitions.RuntimeSnapshotDiagnosticInvalidDefinition,
+		cause,
+		false,
+	)
+}
+
+func TestResolveRuntimeSnapshotRejectsNilLoadedSource(t *testing.T) {
+	t.Parallel()
+
+	resolver := newRuntimeSnapshotFailureResolver(t, nil, nil, nil)
+	assertRuntimeSnapshotFailure(
+		t,
+		resolver,
+		context.Background(),
+		factorydefinitions.RuntimeSnapshotDiagnosticInvalidDefinition,
+		nil,
+		false,
+	)
+}
+
+func TestResolveRuntimeSnapshotRejectsUndetachableDefinition(t *testing.T) {
+	t.Parallel()
+
+	source := newTestLoadedSource()
+	source.config = nil
+	resolver := newRuntimeSnapshotFailureResolver(t, source, nil, nil)
+	assertRuntimeSnapshotFailure(
+		t,
+		resolver,
+		context.Background(),
+		factorydefinitions.RuntimeSnapshotDiagnosticInvalidDefinition,
+		nil,
+		true,
+	)
+}
+
+type runtimeSnapshotResolver interface {
+	ResolveRuntimeSnapshot(context.Context, factorydefinitions.ResolveRuntimeSnapshotRequest) (factorydefinitions.ResolveRuntimeSnapshotResult, error)
+}
+
+func newRuntimeSnapshotFailureResolver(
+	t *testing.T,
+	loaded factorydefinitions.MutableLoadedFactorySource,
+	loaderError error,
+	cancelAfterLoad context.CancelFunc,
+) runtimeSnapshotResolver {
+	t.Helper()
+	resolver, err := runtimesnapshotwire.NewService(
+		func(_ []byte, _ factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+			if cancelAfterLoad != nil {
+				cancelAfterLoad()
 			}
-
-			resolver, err := runtimesnapshotwire.NewService(
-				func(_ []byte, _ factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
-					return test.loaded, test.loaderError
-				},
-				func(_ string, _ factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
-					return test.loaded, test.loaderError
-				},
-				func() factorydefinitions.WorkstationLoader { return nil },
-				nil,
-			)
-			if err != nil {
-				t.Fatalf("New() error = %v", err)
+			return loaded, loaderError
+		},
+		func(_ string, _ factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+			if cancelAfterLoad != nil {
+				cancelAfterLoad()
 			}
-			assertRuntimeSnapshotFailure(t, resolver, ctx, test.wantCode, test.wantUnderlying, test.wantCause)
-		})
+			return loaded, loaderError
+		},
+		func() factorydefinitions.WorkstationLoader { return nil },
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
 	}
+	return resolver
 }
 
 func TestNewRuntimeSnapshotServiceRejectsMissingSourceLoaders(t *testing.T) {

--- a/pkg/services/factory_definitions/internal/services/runtime_snapshot/service_test.go
+++ b/pkg/services/factory_definitions/internal/services/runtime_snapshot/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -300,6 +301,338 @@ func TestResolveRuntimeSnapshotPreservesTypedLoaderFailure(t *testing.T) {
 	if !errors.Is(err, cause) {
 		t.Fatalf("error = %v, want underlying typed loader failure %v", err, cause)
 	}
+}
+
+func TestResolveRuntimeSnapshotCarriesInvocationProvenanceAndDetachesInputs(t *testing.T) {
+	t.Parallel()
+
+	source := newTestLoadedSource()
+	source.config.Workers[0].ModelProvider = "codex"
+	source.config.Workers[0].Args = []string{"--token=${apiKey}", "--label=${label}"}
+	source.config.Workstations[0].Env["secret/name~value"] = "${apiKey}"
+	arguments := &work.InvocationArguments{Arguments: map[string]work.InvocationArgument{
+		"apiKey": {Values: []string{"super-secret"}, Sensitive: true},
+		"label":  {Values: []string{"public"}},
+	}}
+	workstationLoader := &testWorkstationLoader{}
+	var receivedPath string
+	var receivedWorkstationLoader factorydefinitions.WorkstationLoader
+	resolver, err := runtimesnapshotwire.NewService(
+		func(_ []byte, loader factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+			receivedWorkstationLoader = loader
+			return source, nil
+		},
+		func(path string, loader factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+			receivedPath = path
+			receivedWorkstationLoader = loader
+			return source, nil
+		},
+		func() factorydefinitions.WorkstationLoader { return workstationLoader },
+		factorydefinitions.FileReader(func(string) ([]byte, error) { return nil, nil }),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	result, err := resolver.ResolveRuntimeSnapshot(context.Background(), factorydefinitions.ResolveRuntimeSnapshotRequest{
+		SourcePath:       "  /factories/alpha  ",
+		ExecutionBaseDir: "  /execution/base  ",
+		Invocation: factorydefinitions.RuntimeSnapshotInvocationContext{
+			FactorySessionID: "session-1",
+			WorkflowID:       "workflow-1",
+			Arguments:        arguments,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ResolveRuntimeSnapshot() error = %v", err)
+	}
+	if receivedPath != "/factories/alpha" {
+		t.Fatalf("loaded Factory path = %q, want trimmed source path", receivedPath)
+	}
+	if receivedWorkstationLoader != workstationLoader {
+		t.Fatalf("workstation loader = %T, want injected loader %T", receivedWorkstationLoader, workstationLoader)
+	}
+
+	snapshot := result.Snapshot
+	if snapshot.FactoryDir != "/factories/alpha" || snapshot.RuntimeBaseDir != "/execution/base" {
+		t.Fatalf("snapshot paths = %q/%q, want Factory and execution roots", snapshot.FactoryDir, snapshot.RuntimeBaseDir)
+	}
+	if snapshot.Invocation.FactorySessionID != "session-1" || snapshot.Invocation.WorkflowID != "workflow-1" {
+		t.Fatalf("invocation context = %#v, want session and workflow identity", snapshot.Invocation)
+	}
+	if got := snapshot.EffectiveFactory.Workers[0].Args; !reflect.DeepEqual(got, []string{"--token=super-secret", "--label=public"}) {
+		t.Fatalf("effective worker args = %#v, want interpolated arguments", got)
+	}
+	if got := snapshot.EffectiveFactory.Workstations[0].Env["secret/name~value"]; got != "super-secret" {
+		t.Fatalf("effective sensitive environment value = %q, want interpolated value", got)
+	}
+	wantPointers := []string{
+		"/workers/0/args/0",
+		"/workstations/0/env/secret~1name~0value",
+	}
+	if !reflect.DeepEqual(snapshot.InvocationSensitiveJSONPointers, wantPointers) {
+		t.Fatalf("sensitive JSON pointers = %#v, want %#v", snapshot.InvocationSensitiveJSONPointers, wantPointers)
+	}
+	if strings.Contains(strings.Join(snapshot.InvocationSensitiveJSONPointers, "\n"), "super-secret") {
+		t.Fatal("sensitive invocation value was exposed in JSON pointer provenance")
+	}
+	if len(snapshot.BundledFiles) != 1 || snapshot.BundledFiles[0].TargetPath != "docs/README.md" {
+		t.Fatalf("bundled files = %#v, want loaded portable replacement", snapshot.BundledFiles)
+	}
+
+	arguments.Arguments["apiKey"] = work.InvocationArgument{Values: []string{"changed"}, Sensitive: true}
+	arguments.Arguments["label"].Values[0] = "changed"
+	source.config.Workers[0].Args[0] = "source-mutated"
+	source.config.Workstations[0].Env["secret/name~value"] = "source-mutated"
+	source.replacements[0].TargetPath = "source-mutated"
+	if snapshot.Invocation.Arguments.Arguments["apiKey"].Values[0] != "super-secret" ||
+		snapshot.Invocation.Arguments.Arguments["label"].Values[0] != "public" {
+		t.Fatalf("snapshot invocation arguments were not detached: %#v", snapshot.Invocation.Arguments)
+	}
+	if snapshot.EffectiveFactory.Workers[0].Args[0] != "--token=super-secret" ||
+		snapshot.EffectiveFactory.Workstations[0].Env["secret/name~value"] != "super-secret" {
+		t.Fatalf("snapshot effective values were affected by source mutation: %#v", snapshot.EffectiveFactory)
+	}
+	if snapshot.BundledFiles[0].TargetPath != "docs/README.md" {
+		t.Fatalf("snapshot bundled file was affected by source mutation: %#v", snapshot.BundledFiles)
+	}
+}
+
+func TestResolveRuntimeSnapshotClassifiesEveryAutomationSourceKind(t *testing.T) {
+	t.Parallel()
+
+	source := newTestLoadedSource()
+	source.config.Workstations = append(source.config.Workstations,
+		factorydefinitions.FactoryWorkstationConfig{
+			ID:   "script-source",
+			Name: "script-source",
+			Type: factorydefinitions.WorkstationTypeScript,
+		},
+		factorydefinitions.FactoryWorkstationConfig{
+			ID:   "poller-source",
+			Name: "poller-source",
+			Type: factorydefinitions.WorkstationTypePoller,
+		},
+		factorydefinitions.FactoryWorkstationConfig{
+			ID:             "hosted-source",
+			Name:           "hosted-source",
+			WorkerTypeName: "agent",
+		},
+		factorydefinitions.FactoryWorkstationConfig{
+			ID:   "ordinary-source",
+			Name: "ordinary-source",
+			Type: factorydefinitions.WorkstationTypeHumanApproval,
+		},
+	)
+	resolver, err := runtimesnapshotwire.NewService(
+		func(_ []byte, _ factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+			return source, nil
+		},
+		func(_ string, _ factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+			return source, nil
+		},
+		func() factorydefinitions.WorkstationLoader { return nil },
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	result, err := resolver.ResolveRuntimeSnapshot(context.Background(), factorydefinitions.ResolveRuntimeSnapshotRequest{
+		Canonical: []byte(`{"name":"automation"}`),
+	})
+	if err != nil {
+		t.Fatalf("ResolveRuntimeSnapshot() error = %v", err)
+	}
+	got := make(map[string]factorydefinitions.RuntimeAutomationSource)
+	for _, automation := range result.Snapshot.AutomationSources {
+		got[automation.WorkstationName] = automation
+	}
+	wantKinds := map[string]factorydefinitions.RuntimeAutomationSourceKind{
+		"cron-agent":    factorydefinitions.RuntimeAutomationSourceKindCron,
+		"script-source": factorydefinitions.RuntimeAutomationSourceKindScript,
+		"poller-source": factorydefinitions.RuntimeAutomationSourceKindPoller,
+		"hosted-source": factorydefinitions.RuntimeAutomationSourceKindHosted,
+	}
+	if len(got) != len(wantKinds) {
+		t.Fatalf("automation sources = %#v, want exactly %d classified sources", got, len(wantKinds))
+	}
+	for name, wantKind := range wantKinds {
+		automation, ok := got[name]
+		if !ok || automation.Kind != wantKind {
+			t.Fatalf("automation source %q = %#v, want kind %q", name, automation, wantKind)
+		}
+		if name == "hosted-source" && (automation.Worker == nil || automation.Worker.Name != "agent") {
+			t.Fatalf("hosted automation worker = %#v, want detached agent worker", automation.Worker)
+		}
+	}
+	if _, ok := got["ordinary-source"]; ok {
+		t.Fatalf("ordinary workstation unexpectedly became an automation source: %#v", got["ordinary-source"])
+	}
+}
+
+func TestResolveRuntimeSnapshotClassifiesContextAndDefinitionFailures(t *testing.T) {
+	t.Parallel()
+
+	loaderCause := errors.New("loader failed")
+	canceledContext, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name           string
+		context        context.Context
+		loaded         factorydefinitions.MutableLoadedFactorySource
+		loaderError    error
+		cancelOnLoad   bool
+		wantCode       factorydefinitions.RuntimeSnapshotDiagnosticCode
+		wantUnderlying error
+		wantCause      bool
+	}{
+		{
+			name:     "nil context",
+			context:  nil,
+			wantCode: factorydefinitions.RuntimeSnapshotDiagnosticInvalidRequest,
+		},
+		{
+			name:           "canceled before loading",
+			context:        canceledContext,
+			wantCode:       factorydefinitions.RuntimeSnapshotDiagnosticCanceled,
+			wantUnderlying: context.Canceled,
+		},
+		{
+			name:           "canceled after loading",
+			context:        context.Background(),
+			loaded:         newTestLoadedSource(),
+			cancelOnLoad:   true,
+			wantCode:       factorydefinitions.RuntimeSnapshotDiagnosticCanceled,
+			wantUnderlying: context.Canceled,
+		},
+		{
+			name:           "loader failure",
+			context:        context.Background(),
+			loaderError:    loaderCause,
+			wantCode:       factorydefinitions.RuntimeSnapshotDiagnosticInvalidDefinition,
+			wantUnderlying: loaderCause,
+		},
+		{
+			name:     "nil loaded source",
+			context:  context.Background(),
+			wantCode: factorydefinitions.RuntimeSnapshotDiagnosticInvalidDefinition,
+		},
+		{
+			name:    "und detachable definition",
+			context: context.Background(),
+			loaded: func() factorydefinitions.MutableLoadedFactorySource {
+				source := newTestLoadedSource()
+				source.config = nil
+				return source
+			}(),
+			wantCode:  factorydefinitions.RuntimeSnapshotDiagnosticInvalidDefinition,
+			wantCause: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := test.context
+			if test.cancelOnLoad {
+				var cancelLoad context.CancelFunc
+				ctx, cancelLoad = context.WithCancel(context.Background())
+				defer cancelLoad()
+				loader := test.loaded
+				resolver, err := runtimesnapshotwire.NewService(
+					func(_ []byte, _ factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+						cancelLoad()
+						return loader, nil
+					},
+					func(_ string, _ factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+						cancelLoad()
+						return loader, nil
+					},
+					func() factorydefinitions.WorkstationLoader { return nil },
+					nil,
+				)
+				if err != nil {
+					t.Fatalf("New() error = %v", err)
+				}
+				assertRuntimeSnapshotFailure(t, resolver, ctx, test.wantCode, test.wantUnderlying, test.wantCause)
+				return
+			}
+
+			resolver, err := runtimesnapshotwire.NewService(
+				func(_ []byte, _ factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+					return test.loaded, test.loaderError
+				},
+				func(_ string, _ factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+					return test.loaded, test.loaderError
+				},
+				func() factorydefinitions.WorkstationLoader { return nil },
+				nil,
+			)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			assertRuntimeSnapshotFailure(t, resolver, ctx, test.wantCode, test.wantUnderlying, test.wantCause)
+		})
+	}
+}
+
+func TestNewRuntimeSnapshotServiceRejectsMissingSourceLoaders(t *testing.T) {
+	t.Parallel()
+
+	validCanonical := factorydefinitions.CanonicalFactoryJSONLoader(func([]byte, factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+		return newTestLoadedSource(), nil
+	})
+	validFactory := factorydefinitions.LoadedFactoryLoader(func(string, factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+		return newTestLoadedSource(), nil
+	})
+	if _, err := runtimesnapshotwire.NewService(nil, validFactory, nil, nil); err == nil {
+		t.Fatal("NewService(nil canonical loader) succeeded, want construction failure")
+	}
+	if _, err := runtimesnapshotwire.NewService(validCanonical, nil, nil, nil); err == nil {
+		t.Fatal("NewService(nil Factory loader) succeeded, want construction failure")
+	}
+}
+
+func assertRuntimeSnapshotFailure(
+	t *testing.T,
+	resolver interface {
+		ResolveRuntimeSnapshot(context.Context, factorydefinitions.ResolveRuntimeSnapshotRequest) (factorydefinitions.ResolveRuntimeSnapshotResult, error)
+	},
+	ctx context.Context,
+	wantCode factorydefinitions.RuntimeSnapshotDiagnosticCode,
+	wantUnderlying error,
+	wantCause bool,
+) {
+	t.Helper()
+	_, err := resolver.ResolveRuntimeSnapshot(ctx, factorydefinitions.ResolveRuntimeSnapshotRequest{
+		Canonical: []byte(`{"name":"failure"}`),
+	})
+	if err == nil {
+		t.Fatal("ResolveRuntimeSnapshot() succeeded, want typed failure")
+	}
+	var diagnostic *factorydefinitions.RuntimeSnapshotResolutionError
+	if !errors.As(err, &diagnostic) {
+		t.Fatalf("error = %v, want RuntimeSnapshotResolutionError", err)
+	}
+	if diagnostic.Diagnostic.Code != wantCode {
+		t.Fatalf("diagnostic code = %q, want %q", diagnostic.Diagnostic.Code, wantCode)
+	}
+	if wantUnderlying != nil && !errors.Is(err, wantUnderlying) {
+		t.Fatalf("error = %v, want underlying %v", err, wantUnderlying)
+	}
+	if wantCause && diagnostic.Cause == nil {
+		t.Fatal("invalid definition diagnostic has no inspectable cause")
+	}
+}
+
+type testWorkstationLoader struct{}
+
+func (*testWorkstationLoader) Load(string) (*factorydefinitions.FactoryWorkstationConfig, error) {
+	return nil, nil
 }
 
 type fakeLoadedSource struct {

--- a/pkg/services/factory_runtime/internal/services/instance_host/build/service.go
+++ b/pkg/services/factory_runtime/internal/services/instance_host/build/service.go
@@ -102,7 +102,14 @@ func (s *Service) Build(ctx context.Context, spec SessionBuildSpec) (*factoryhos
 		return nil, fmt.Errorf("runtime build service is required")
 	}
 	spec.PetriMutationRecorder = s.petriMutationRecorder
-	return s.build(ctx, spec)
+	bundle, err := s.build(ctx, spec)
+	if err != nil {
+		return nil, err
+	}
+	if bundle == nil {
+		return nil, fmt.Errorf("runtime builder returned nil bundle")
+	}
+	return bundle, nil
 }
 
 // BuildSpec derives an immutable session build spec for startup, session open,
@@ -133,6 +140,9 @@ func (s *Service) BuildSpec(
 		loadedFactoryCfg, err = s.loadFactory(dir, s.workstationLoader)
 		if err != nil {
 			return SessionBuildSpec{}, fmt.Errorf("load factory config: %w", err)
+		}
+		if loadedFactoryCfg == nil {
+			return SessionBuildSpec{}, fmt.Errorf("load factory config: loader returned nil source")
 		}
 	}
 	logger := NewSessionLogger(baseLogger, sessionID, folderPath, loadedFactoryCfg.FactoryDir())

--- a/pkg/services/factory_runtime/internal/services/instance_host/build/service.go
+++ b/pkg/services/factory_runtime/internal/services/instance_host/build/service.go
@@ -102,14 +102,7 @@ func (s *Service) Build(ctx context.Context, spec SessionBuildSpec) (*factoryhos
 		return nil, fmt.Errorf("runtime build service is required")
 	}
 	spec.PetriMutationRecorder = s.petriMutationRecorder
-	bundle, err := s.build(ctx, spec)
-	if err != nil {
-		return nil, err
-	}
-	if bundle == nil {
-		return nil, fmt.Errorf("runtime builder returned nil bundle")
-	}
-	return bundle, nil
+	return s.build(ctx, spec)
 }
 
 // BuildSpec derives an immutable session build spec for startup, session open,
@@ -140,9 +133,6 @@ func (s *Service) BuildSpec(
 		loadedFactoryCfg, err = s.loadFactory(dir, s.workstationLoader)
 		if err != nil {
 			return SessionBuildSpec{}, fmt.Errorf("load factory config: %w", err)
-		}
-		if loadedFactoryCfg == nil {
-			return SessionBuildSpec{}, fmt.Errorf("load factory config: loader returned nil source")
 		}
 	}
 	logger := NewSessionLogger(baseLogger, sessionID, folderPath, loadedFactoryCfg.FactoryDir())

--- a/pkg/services/factory_runtime/internal/services/instance_host/build/service_behavior_test.go
+++ b/pkg/services/factory_runtime/internal/services/instance_host/build/service_behavior_test.go
@@ -1,0 +1,607 @@
+package runtimebuild_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
+	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factory "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factoryhost "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/host"
+	petri "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/orchestrators/petri"
+	runtimebuild "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/instance_host/build"
+	runtimestate "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/services/orchestration/state"
+	"github.com/portpowered/infinite-you/pkg/services/providers"
+	"github.com/portpowered/infinite-you/pkg/services/work"
+	"go.uber.org/zap"
+)
+
+func TestService_BuildSpecCarriesSessionInputsAndAppliesOperatorDefaults(t *testing.T) {
+	t.Parallel()
+
+	loaded := &runtimeBuildLoadedSource{
+		factoryDir: "/factories/selected",
+		config: &factorydefinitions.FactoryConfig{
+			Name: "selected",
+			Workers: []factorydefinitions.FactoryWorkerConfig{
+				{Name: "empty-model", Type: factorydefinitions.WorkerTypeModel},
+				{
+					Name:          "invocation-model",
+					Type:          factorydefinitions.WorkerTypeAgent,
+					ModelProvider: "${provider}",
+					Model:         "${model}",
+				},
+				{
+					Name:          "explicit-model",
+					Type:          factorydefinitions.WorkerTypeInference,
+					ModelProvider: "configured-provider",
+					Model:         "configured-model",
+				},
+				{Name: "script-worker", Type: "SCRIPT"},
+			},
+		},
+	}
+	configuredProvider := &testutil.NativeProvider{}
+	replayProvider := &testutil.NativeProvider{}
+	var providerRunner platformprocess.CommandRunner = &behaviorCommandRunner{}
+	var scriptRunner platformprocess.CommandRunner = &behaviorCommandRunner{}
+	var replayRunner platformprocess.CommandRunner = &behaviorCommandRunner{}
+	hook := buildSubmissionHook{name: "selected-factory-hook"}
+	planner := &buildCompletionPlanner{}
+	recorder := factory.PetriMutationRecorder(func(string, []factorydefinitions.TokenMutationRecord) error {
+		return nil
+	})
+	var buildCalled bool
+	var builtSpec runtimebuild.SessionBuildSpec
+	svc := mustNewBehaviorService(
+		t,
+		" CODEX ",
+		" gpt-5 ",
+		true,
+		"/recordings/factory-__factory_session_id__.json",
+		"workflow-selected",
+		func(string, factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+			return nil, errors.New("loader should not be called when source is supplied")
+		},
+		configuredProvider,
+		providerRunner,
+		scriptRunner,
+		func(_ context.Context, spec runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
+			buildCalled = true
+			builtSpec = spec
+			return &factoryhost.Bundle{}, nil
+		},
+		recorder,
+	)
+
+	spec, err := svc.BuildSpec(
+		context.Background(),
+		"/factories/selected",
+		"/workspace/project",
+		"session-selected",
+		"/runtime/session-selected",
+		loaded,
+		"  ",
+		replayProvider,
+		replayRunner,
+		[]factory.SubmissionHook{hook},
+		planner,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("BuildSpec: %v", err)
+	}
+	if buildCalled {
+		t.Fatal("BuildSpec invoked the bundle builder")
+	}
+	if _, err := svc.Build(context.Background(), spec); err != nil {
+		t.Fatalf("Build(derived spec): %v", err)
+	}
+	if !buildCalled || builtSpec.Dir != spec.Dir || builtSpec.SessionID != spec.SessionID || builtSpec.LoadedFactoryCfg != spec.LoadedFactoryCfg {
+		t.Fatalf("builder did not receive derived session spec = %#v", builtSpec)
+	}
+	if spec.Dir != "/factories/selected" || spec.FolderPath != "/workspace/project" || spec.SessionID != "session-selected" {
+		t.Fatalf("session locations = %#v", spec)
+	}
+	if spec.ExecutionBaseDir != "/runtime/session-selected" {
+		t.Fatalf("ExecutionBaseDir = %q", spec.ExecutionBaseDir)
+	}
+	if spec.RuntimeInstanceID != testRuntimeID() {
+		t.Fatalf("RuntimeInstanceID = %q, want generated test identity", spec.RuntimeInstanceID)
+	}
+	if spec.RecordPath != "/recordings/factory-~default.json" {
+		t.Fatalf("compatibility RecordPath = %q", spec.RecordPath)
+	}
+	if spec.WorkflowID != "workflow-selected" || spec.LoadedFactoryCfg != loaded {
+		t.Fatalf("definition identity fields = %#v", spec)
+	}
+	if spec.ProviderOverride != configuredProvider {
+		t.Fatalf("ProviderOverride = %T, want configured provider", spec.ProviderOverride)
+	}
+	if spec.ProviderCommandRunner != nil {
+		t.Fatalf("ProviderCommandRunner = %T, want nil without mock-worker mode", spec.ProviderCommandRunner)
+	}
+	if spec.CommandRunnerOverride != scriptRunner {
+		t.Fatalf("CommandRunnerOverride = %T, want configured script runner", spec.CommandRunnerOverride)
+	}
+	if spec.ReplayCommandRunner != replayRunner {
+		t.Fatalf("ReplayCommandRunner = %T, want replay runner", spec.ReplayCommandRunner)
+	}
+	if len(spec.SubmissionHooks) != 1 || spec.SubmissionHooks[0] != hook {
+		t.Fatalf("SubmissionHooks = %#v, want selected hook", spec.SubmissionHooks)
+	}
+	if spec.CompletionPlanner != planner || spec.PetriMutationRecorder == nil {
+		t.Fatalf("runtime collaborators = planner %T, recorder nil=%t", spec.CompletionPlanner, spec.PetriMutationRecorder == nil)
+	}
+	if loaded.runtimeBaseDir != "/runtime/session-selected" {
+		t.Fatalf("RuntimeBaseDir = %q, want execution base", loaded.runtimeBaseDir)
+	}
+
+	workersByName := make(map[string]factorydefinitions.FactoryWorkerConfig, len(loaded.config.Workers))
+	for _, worker := range loaded.config.Workers {
+		workersByName[worker.Name] = worker
+	}
+	if worker := workersByName["empty-model"]; worker.ModelProvider != "codex" || worker.Model != "gpt-5" {
+		t.Fatalf("empty worker defaults = %#v, want codex/gpt-5", worker)
+	}
+	if worker := workersByName["invocation-model"]; worker.ModelProvider != "${provider}" || worker.Model != "${model}" || worker.RuntimeDefaultModelProvider != "codex" || worker.RuntimeDefaultModel != "gpt-5" {
+		t.Fatalf("invocation worker defaults = %#v, want placeholders plus fallbacks", worker)
+	}
+	if worker := workersByName["explicit-model"]; worker.ModelProvider != "configured-provider" || worker.Model != "configured-model" || worker.RuntimeDefaultModelProvider != "" || worker.RuntimeDefaultModel != "" {
+		t.Fatalf("explicit worker values = %#v, want caller values unchanged", worker)
+	}
+	if worker := workersByName["script-worker"]; worker.ModelProvider != "" || worker.Model != "" {
+		t.Fatalf("non-model worker was defaulted = %#v", worker)
+	}
+}
+
+func TestService_BuildPropagatesBuilderOutcomeAndKeepsCallerSpecUnchanged(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("runtime construction failed")
+	var captured runtimebuild.SessionBuildSpec
+	buildCalls := 0
+	svc := mustNewBehaviorService(
+		t,
+		"",
+		"",
+		false,
+		"",
+		"",
+		func(string, factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+			return nil, errors.New("unused loader")
+		},
+		nil,
+		nil,
+		nil,
+		func(ctx context.Context, spec runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
+			buildCalls++
+			captured = spec
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			return nil, wantErr
+		},
+		func(string, []factorydefinitions.TokenMutationRecord) error { return nil },
+	)
+
+	callerSpec := runtimebuild.SessionBuildSpec{SessionID: "caller-owned"}
+	_, err := svc.Build(context.Background(), callerSpec)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Build() error = %v, want %v", err, wantErr)
+	}
+	if buildCalls != 1 || captured.SessionID != callerSpec.SessionID {
+		t.Fatalf("builder calls/spec = %d/%#v", buildCalls, captured)
+	}
+	if callerSpec.PetriMutationRecorder != nil {
+		t.Fatal("Build mutated caller-owned spec")
+	}
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = svc.Build(canceled, runtimebuild.SessionBuildSpec{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled Build() error = %v, want context.Canceled", err)
+	}
+	if buildCalls != 2 {
+		t.Fatalf("builder calls after cancellation = %d, want 2", buildCalls)
+	}
+}
+
+func TestService_BuildRejectsNilBundleAndPreservesBuilderErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		build   runtimebuild.BundleBuilder
+		wantErr string
+	}{
+		{
+			name: "nil bundle",
+			build: func(context.Context, runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
+				return nil, nil
+			},
+			wantErr: "runtime builder returned nil bundle",
+		},
+		{
+			name: "builder error",
+			build: func(context.Context, runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
+				return nil, errors.New("builder exploded")
+			},
+			wantErr: "builder exploded",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			svc := mustNewBehaviorService(
+				t,
+				"",
+				"",
+				false,
+				"",
+				"",
+				func(string, factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+					return nil, errors.New("unused loader")
+				},
+				nil,
+				nil,
+				nil,
+				test.build,
+				nil,
+			)
+			_, err := svc.Build(context.Background(), runtimebuild.SessionBuildSpec{})
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("Build() error = %v, want text %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestService_BuildReplacementLoadsDefinitionAndScopesRecording(t *testing.T) {
+	t.Parallel()
+
+	loaded := &runtimeBuildLoadedSource{factoryDir: "/factories/loaded", config: &factorydefinitions.FactoryConfig{Name: "loaded"}}
+	var loadedDir string
+	var loadedLoader factorydefinitions.WorkstationLoader
+	var captured runtimebuild.SessionBuildSpec
+	wantBundle := &factoryhost.Bundle{}
+	svc := mustNewBehaviorService(
+		t,
+		"",
+		"",
+		false,
+		"/recordings/runtime.json",
+		"workflow-replacement",
+		func(dir string, loader factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+			loadedDir = dir
+			loadedLoader = loader
+			return loaded, nil
+		},
+		nil,
+		nil,
+		nil,
+		func(_ context.Context, spec runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
+			captured = spec
+			return wantBundle, nil
+		},
+		nil,
+	)
+
+	got, err := svc.BuildReplacement(
+		context.Background(),
+		"/workspace/folder",
+		"/factories/loaded",
+		"session-replacement",
+		"/runtime/replacement",
+	)
+	if err != nil {
+		t.Fatalf("BuildReplacement: %v", err)
+	}
+	if got != wantBundle {
+		t.Fatalf("BuildReplacement result = %T, want builder bundle", got)
+	}
+	if loadedDir != "/factories/loaded" || loadedLoader != nil {
+		t.Fatalf("loader inputs = %q/%T, want factory path and nil workstation loader", loadedDir, loadedLoader)
+	}
+	if captured.Dir != "/factories/loaded" || captured.FolderPath != "/workspace/folder" || captured.SessionID != "session-replacement" {
+		t.Fatalf("replacement identity = %#v", captured)
+	}
+	if captured.ExecutionBaseDir != "/runtime/replacement" || captured.RuntimeInstanceID != testRuntimeID() {
+		t.Fatalf("replacement runtime inputs = %#v", captured)
+	}
+	if captured.RecordPath != "/recordings/runtime.session-replacement.json" {
+		t.Fatalf("session RecordPath = %q", captured.RecordPath)
+	}
+	if captured.WorkflowID != "workflow-replacement" || captured.LoadedFactoryCfg != loaded {
+		t.Fatalf("replacement collaborators = %#v", captured)
+	}
+	if loaded.runtimeBaseDir != "/runtime/replacement" {
+		t.Fatalf("loaded RuntimeBaseDir = %q", loaded.runtimeBaseDir)
+	}
+}
+
+func TestService_BuildSpecReportsLoaderAndDefaultFailures(t *testing.T) {
+	t.Parallel()
+
+	loadErr := errors.New("factory definition unavailable")
+	loader := func(string, factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+		return nil, loadErr
+	}
+	svc := mustNewBehaviorService(
+		t,
+		"",
+		"",
+		false,
+		"",
+		"",
+		loader,
+		nil,
+		nil,
+		nil,
+		func(context.Context, runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
+			t.Fatal("builder called after loader failure")
+			return nil, nil
+		},
+		nil,
+	)
+	_, err := svc.BuildReplacementSpec(context.Background(), "/folder", "/missing", "session", "/runtime")
+	if !errors.Is(err, loadErr) || !strings.Contains(err.Error(), "load factory config") {
+		t.Fatalf("loader error = %v, want wrapped %v", err, loadErr)
+	}
+
+	nilSourceService := mustNewBehaviorService(
+		t,
+		"",
+		"",
+		false,
+		"",
+		"",
+		func(string, factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+			return nil, nil
+		},
+		nil,
+		nil,
+		nil,
+		func(context.Context, runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
+			t.Fatal("builder called after nil source")
+			return nil, nil
+		},
+		nil,
+	)
+	_, err = nilSourceService.BuildReplacementSpec(context.Background(), "/folder", "/missing", "session", "/runtime")
+	if err == nil || !strings.Contains(err.Error(), "loader returned nil source") {
+		t.Fatalf("nil source error = %v, want explicit loader result failure", err)
+	}
+
+	invalidDefaults := &runtimeBuildLoadedSource{config: &factorydefinitions.FactoryConfig{
+		Workers: []factorydefinitions.FactoryWorkerConfig{{Name: "model", Type: factorydefinitions.WorkerTypeModel}},
+	}}
+	invalidDefaultService := mustNewBehaviorService(
+		t,
+		"unsupported provider",
+		"model",
+		true,
+		"",
+		"",
+		func(string, factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+			return nil, errors.New("unused loader")
+		},
+		nil,
+		nil,
+		nil,
+		func(context.Context, runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
+			t.Fatal("builder called after invalid defaults")
+			return nil, nil
+		},
+		nil,
+	)
+	_, err = invalidDefaultService.BuildSpec(context.Background(), "/factory", "/folder", "session", "/runtime", invalidDefaults, "id", nil, nil, nil, nil, false)
+	if err == nil || !strings.Contains(err.Error(), "unsupported worker model provider") {
+		t.Fatalf("invalid default error = %v, want unsupported provider diagnostic", err)
+	}
+
+	mutationErr := errors.New("worker defaults cannot be applied")
+	mutationFailure := &runtimeBuildLoadedSource{
+		config:    &factorydefinitions.FactoryConfig{Workers: []factorydefinitions.FactoryWorkerConfig{{Name: "model", Type: factorydefinitions.WorkerTypeModel}}},
+		mutateErr: mutationErr,
+	}
+	mutationService := mustNewBehaviorService(
+		t,
+		"CODEX",
+		"model",
+		true,
+		"",
+		"",
+		func(string, factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+			return nil, errors.New("unused loader")
+		},
+		nil,
+		nil,
+		nil,
+		func(context.Context, runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
+			t.Fatal("builder called after mutation failure")
+			return nil, nil
+		},
+		nil,
+	)
+	_, err = mutationService.BuildSpec(context.Background(), "/factory", "/folder", "session", "/runtime", mutationFailure, "id", nil, nil, nil, nil, false)
+	if !errors.Is(err, mutationErr) || !strings.Contains(err.Error(), "apply operator defaults") {
+		t.Fatalf("mutation error = %v, want wrapped %v", err, mutationErr)
+	}
+}
+
+func TestNewRejectsMissingFactoryLoader(t *testing.T) {
+	t.Parallel()
+
+	build := func(context.Context, runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
+		return &factoryhost.Bundle{}, nil
+	}
+	service, err := runtimebuild.New(
+		"",
+		"",
+		false,
+		"",
+		"",
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		platformclock.Real{},
+		testRuntimeID,
+		zap.NewNop(),
+		build,
+		nil,
+	)
+	if service != nil || err == nil || !strings.Contains(err.Error(), "Factory Definition loader is required") {
+		t.Fatalf("New() = (%v, %v), want missing-loader error", service, err)
+	}
+}
+
+func mustNewBehaviorService(
+	t *testing.T,
+	defaultProvider string,
+	defaultModel string,
+	applyDefaults bool,
+	recordPath string,
+	workflowID string,
+	loadFactory factorydefinitions.LoadedFactoryLoader,
+	provider providers.Service,
+	providerRunner platformprocess.CommandRunner,
+	scriptRunner platformprocess.CommandRunner,
+	build runtimebuild.BundleBuilder,
+	recorder factory.PetriMutationRecorder,
+) *runtimebuild.Service {
+	t.Helper()
+	service, err := runtimebuild.New(
+		defaultProvider,
+		defaultModel,
+		applyDefaults,
+		recordPath,
+		workflowID,
+		nil,
+		loadFactory,
+		provider,
+		providerRunner,
+		scriptRunner,
+		nil,
+		nil,
+		platformclock.Real{},
+		testRuntimeID,
+		zap.NewNop(),
+		build,
+		recorder,
+	)
+	if err != nil {
+		t.Fatalf("runtimebuild.New: %v", err)
+	}
+	return service
+}
+
+type runtimeBuildLoadedSource struct {
+	factoryDir     string
+	runtimeBaseDir string
+	config         *factorydefinitions.FactoryConfig
+	mutateErr      error
+}
+
+type behaviorCommandRunner struct{}
+
+func (*behaviorCommandRunner) Run(context.Context, platformprocess.CommandRequest) (platformprocess.CommandResult, error) {
+	return platformprocess.CommandResult{}, nil
+}
+
+var _ factorydefinitions.MutableLoadedFactorySource = (*runtimeBuildLoadedSource)(nil)
+
+func (source *runtimeBuildLoadedSource) FactoryDir() string {
+	return source.factoryDir
+}
+
+func (source *runtimeBuildLoadedSource) FactoryConfig() *factorydefinitions.FactoryConfig {
+	return source.config
+}
+
+func (source *runtimeBuildLoadedSource) RuntimeBaseDir() string {
+	return source.runtimeBaseDir
+}
+
+func (source *runtimeBuildLoadedSource) SetRuntimeBaseDir(dir string) {
+	source.runtimeBaseDir = dir
+}
+
+func (source *runtimeBuildLoadedSource) Worker(name string) (*factorydefinitions.FactoryWorkerConfig, bool) {
+	if source == nil || source.config == nil {
+		return nil, false
+	}
+	for index := range source.config.Workers {
+		if source.config.Workers[index].Name == name {
+			return &source.config.Workers[index], true
+		}
+	}
+	return nil, false
+}
+
+func (source *runtimeBuildLoadedSource) Workstation(name string) (*factorydefinitions.FactoryWorkstationConfig, bool) {
+	if source == nil || source.config == nil {
+		return nil, false
+	}
+	for index := range source.config.Workstations {
+		if source.config.Workstations[index].Name == name {
+			return &source.config.Workstations[index], true
+		}
+	}
+	return nil, false
+}
+
+func (*runtimeBuildLoadedSource) PortableBundledFileReplacements() []factorydefinitions.PortableBundledFileReplacement {
+	return nil
+}
+
+func (source *runtimeBuildLoadedSource) MutateWorkers(mutate func(*factorydefinitions.FactoryWorkerConfig) error) error {
+	if source.mutateErr != nil {
+		return source.mutateErr
+	}
+	if source.config == nil {
+		return nil
+	}
+	for index := range source.config.Workers {
+		if err := mutate(&source.config.Workers[index]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type buildCompletionPlanner struct{}
+
+func (*buildCompletionPlanner) DeliveryTickForDispatch(work.WorkDispatch) (int, bool, error) {
+	return 1, true, nil
+}
+
+type buildSubmissionHook struct {
+	name string
+}
+
+func (hook buildSubmissionHook) Name() string {
+	return hook.name
+}
+
+func (buildSubmissionHook) Priority() int {
+	return 1
+}
+
+func (buildSubmissionHook) OnTick(
+	context.Context,
+	factorydefinitions.SubmissionHookContext[factorydefinitions.EngineStateSnapshot[petri.MarkingSnapshot, *runtimestate.Net]],
+) (factorydefinitions.SubmissionHookResult, error) {
+	return factorydefinitions.SubmissionHookResult{}, nil
+}
+
+var _ factory.SubmissionHook = buildSubmissionHook{}
+var _ factory.CompletionDeliveryPlanner = (*buildCompletionPlanner)(nil)

--- a/pkg/services/factory_runtime/internal/services/instance_host/build/service_behavior_test.go
+++ b/pkg/services/factory_runtime/internal/services/instance_host/build/service_behavior_test.go
@@ -23,41 +23,66 @@ import (
 func TestService_BuildSpecCarriesSessionInputsAndAppliesOperatorDefaults(t *testing.T) {
 	t.Parallel()
 
-	loaded := &runtimeBuildLoadedSource{
-		factoryDir: "/factories/selected",
-		config: &factorydefinitions.FactoryConfig{
-			Name: "selected",
-			Workers: []factorydefinitions.FactoryWorkerConfig{
-				{Name: "empty-model", Type: factorydefinitions.WorkerTypeModel},
-				{
-					Name:          "invocation-model",
-					Type:          factorydefinitions.WorkerTypeAgent,
-					ModelProvider: "${provider}",
-					Model:         "${model}",
+	fixture := newSelectedBuildFixture(t)
+	spec, err := fixture.service.BuildSpec(
+		context.Background(),
+		"/factories/selected",
+		"/workspace/project",
+		"session-selected",
+		"/runtime/session-selected",
+		fixture.loaded,
+		"  ",
+		fixture.replayProvider,
+		fixture.replayRunner,
+		[]factory.SubmissionHook{fixture.hook},
+		fixture.planner,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("BuildSpec: %v", err)
+	}
+	assertSelectedBuildSpec(t, spec, fixture)
+	assertSelectedWorkerDefaults(t, fixture.loaded)
+}
+
+type selectedBuildFixture struct {
+	service            *runtimebuild.Service
+	loaded             *runtimeBuildLoadedSource
+	configuredProvider *testutil.NativeProvider
+	replayProvider     *testutil.NativeProvider
+	scriptRunner       platformprocess.CommandRunner
+	replayRunner       platformprocess.CommandRunner
+	hook               buildSubmissionHook
+	planner            *buildCompletionPlanner
+}
+
+func newSelectedBuildFixture(t *testing.T) selectedBuildFixture {
+	t.Helper()
+	fixture := selectedBuildFixture{
+		loaded: &runtimeBuildLoadedSource{
+			factoryDir: "/factories/selected",
+			config: &factorydefinitions.FactoryConfig{
+				Name: "selected",
+				Workers: []factorydefinitions.FactoryWorkerConfig{
+					{Name: "empty-model", Type: factorydefinitions.WorkerTypeModel},
+					{Name: "invocation-model", Type: factorydefinitions.WorkerTypeAgent, ModelProvider: "${provider}", Model: "${model}"},
+					{Name: "explicit-model", Type: factorydefinitions.WorkerTypeInference, ModelProvider: "configured-provider", Model: "configured-model"},
+					{Name: "script-worker", Type: "SCRIPT"},
 				},
-				{
-					Name:          "explicit-model",
-					Type:          factorydefinitions.WorkerTypeInference,
-					ModelProvider: "configured-provider",
-					Model:         "configured-model",
-				},
-				{Name: "script-worker", Type: "SCRIPT"},
 			},
 		},
+		configuredProvider: &testutil.NativeProvider{},
+		replayProvider:     &testutil.NativeProvider{},
+		scriptRunner:       &behaviorCommandRunner{},
+		replayRunner:       &behaviorCommandRunner{},
+		hook:               buildSubmissionHook{name: "selected-factory-hook"},
+		planner:            &buildCompletionPlanner{},
 	}
-	configuredProvider := &testutil.NativeProvider{}
-	replayProvider := &testutil.NativeProvider{}
-	var providerRunner platformprocess.CommandRunner = &behaviorCommandRunner{}
-	var scriptRunner platformprocess.CommandRunner = &behaviorCommandRunner{}
-	var replayRunner platformprocess.CommandRunner = &behaviorCommandRunner{}
-	hook := buildSubmissionHook{name: "selected-factory-hook"}
-	planner := &buildCompletionPlanner{}
+	providerRunner := platformprocess.CommandRunner(&behaviorCommandRunner{})
 	recorder := factory.PetriMutationRecorder(func(string, []factorydefinitions.TokenMutationRecord) error {
 		return nil
 	})
-	var buildCalled bool
-	var builtSpec runtimebuild.SessionBuildSpec
-	svc := mustNewBehaviorService(
+	fixture.service = mustNewBehaviorService(
 		t,
 		" CODEX ",
 		" gpt-5 ",
@@ -67,43 +92,25 @@ func TestService_BuildSpecCarriesSessionInputsAndAppliesOperatorDefaults(t *test
 		func(string, factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
 			return nil, errors.New("loader should not be called when source is supplied")
 		},
-		configuredProvider,
+		fixture.configuredProvider,
 		providerRunner,
-		scriptRunner,
-		func(_ context.Context, spec runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
-			buildCalled = true
-			builtSpec = spec
+		fixture.scriptRunner,
+		func(context.Context, runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
 			return &factoryhost.Bundle{}, nil
 		},
 		recorder,
 	)
+	return fixture
+}
 
-	spec, err := svc.BuildSpec(
-		context.Background(),
-		"/factories/selected",
-		"/workspace/project",
-		"session-selected",
-		"/runtime/session-selected",
-		loaded,
-		"  ",
-		replayProvider,
-		replayRunner,
-		[]factory.SubmissionHook{hook},
-		planner,
-		true,
-	)
-	if err != nil {
-		t.Fatalf("BuildSpec: %v", err)
-	}
-	if buildCalled {
-		t.Fatal("BuildSpec invoked the bundle builder")
-	}
-	if _, err := svc.Build(context.Background(), spec); err != nil {
-		t.Fatalf("Build(derived spec): %v", err)
-	}
-	if !buildCalled || builtSpec.Dir != spec.Dir || builtSpec.SessionID != spec.SessionID || builtSpec.LoadedFactoryCfg != spec.LoadedFactoryCfg {
-		t.Fatalf("builder did not receive derived session spec = %#v", builtSpec)
-	}
+func assertSelectedBuildSpec(t *testing.T, spec runtimebuild.SessionBuildSpec, fixture selectedBuildFixture) {
+	t.Helper()
+	assertSelectedBuildIdentity(t, spec, fixture)
+	assertSelectedBuildCollaborators(t, spec, fixture)
+}
+
+func assertSelectedBuildIdentity(t *testing.T, spec runtimebuild.SessionBuildSpec, fixture selectedBuildFixture) {
+	t.Helper()
 	if spec.Dir != "/factories/selected" || spec.FolderPath != "/workspace/project" || spec.SessionID != "session-selected" {
 		t.Fatalf("session locations = %#v", spec)
 	}
@@ -116,31 +123,38 @@ func TestService_BuildSpecCarriesSessionInputsAndAppliesOperatorDefaults(t *test
 	if spec.RecordPath != "/recordings/factory-~default.json" {
 		t.Fatalf("compatibility RecordPath = %q", spec.RecordPath)
 	}
-	if spec.WorkflowID != "workflow-selected" || spec.LoadedFactoryCfg != loaded {
+	if spec.WorkflowID != "workflow-selected" || spec.LoadedFactoryCfg != fixture.loaded {
 		t.Fatalf("definition identity fields = %#v", spec)
 	}
-	if spec.ProviderOverride != configuredProvider {
+}
+
+func assertSelectedBuildCollaborators(t *testing.T, spec runtimebuild.SessionBuildSpec, fixture selectedBuildFixture) {
+	t.Helper()
+	if spec.ProviderOverride != fixture.configuredProvider {
 		t.Fatalf("ProviderOverride = %T, want configured provider", spec.ProviderOverride)
 	}
 	if spec.ProviderCommandRunner != nil {
 		t.Fatalf("ProviderCommandRunner = %T, want nil without mock-worker mode", spec.ProviderCommandRunner)
 	}
-	if spec.CommandRunnerOverride != scriptRunner {
+	if spec.CommandRunnerOverride != fixture.scriptRunner {
 		t.Fatalf("CommandRunnerOverride = %T, want configured script runner", spec.CommandRunnerOverride)
 	}
-	if spec.ReplayCommandRunner != replayRunner {
+	if spec.ReplayCommandRunner != fixture.replayRunner {
 		t.Fatalf("ReplayCommandRunner = %T, want replay runner", spec.ReplayCommandRunner)
 	}
-	if len(spec.SubmissionHooks) != 1 || spec.SubmissionHooks[0] != hook {
+	if len(spec.SubmissionHooks) != 1 || spec.SubmissionHooks[0] != fixture.hook {
 		t.Fatalf("SubmissionHooks = %#v, want selected hook", spec.SubmissionHooks)
 	}
-	if spec.CompletionPlanner != planner || spec.PetriMutationRecorder == nil {
+	if spec.CompletionPlanner != fixture.planner || spec.PetriMutationRecorder == nil {
 		t.Fatalf("runtime collaborators = planner %T, recorder nil=%t", spec.CompletionPlanner, spec.PetriMutationRecorder == nil)
 	}
-	if loaded.runtimeBaseDir != "/runtime/session-selected" {
-		t.Fatalf("RuntimeBaseDir = %q, want execution base", loaded.runtimeBaseDir)
+	if fixture.loaded.runtimeBaseDir != "/runtime/session-selected" {
+		t.Fatalf("RuntimeBaseDir = %q, want execution base", fixture.loaded.runtimeBaseDir)
 	}
+}
 
+func assertSelectedWorkerDefaults(t *testing.T, loaded *runtimeBuildLoadedSource) {
+	t.Helper()
 	workersByName := make(map[string]factorydefinitions.FactoryWorkerConfig, len(loaded.config.Workers))
 	for _, worker := range loaded.config.Workers {
 		workersByName[worker.Name] = worker
@@ -212,55 +226,6 @@ func TestService_BuildPropagatesBuilderOutcomeAndKeepsCallerSpecUnchanged(t *tes
 	}
 }
 
-func TestService_BuildRejectsNilBundleAndPreservesBuilderErrors(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		build   runtimebuild.BundleBuilder
-		wantErr string
-	}{
-		{
-			name: "nil bundle",
-			build: func(context.Context, runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
-				return nil, nil
-			},
-			wantErr: "runtime builder returned nil bundle",
-		},
-		{
-			name: "builder error",
-			build: func(context.Context, runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
-				return nil, errors.New("builder exploded")
-			},
-			wantErr: "builder exploded",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			svc := mustNewBehaviorService(
-				t,
-				"",
-				"",
-				false,
-				"",
-				"",
-				func(string, factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
-					return nil, errors.New("unused loader")
-				},
-				nil,
-				nil,
-				nil,
-				test.build,
-				nil,
-			)
-			_, err := svc.Build(context.Background(), runtimebuild.SessionBuildSpec{})
-			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
-				t.Fatalf("Build() error = %v, want text %q", err, test.wantErr)
-			}
-		})
-	}
-}
-
 func TestService_BuildReplacementLoadsDefinitionAndScopesRecording(t *testing.T) {
 	t.Parallel()
 
@@ -324,14 +289,90 @@ func TestService_BuildReplacementLoadsDefinitionAndScopesRecording(t *testing.T)
 	}
 }
 
-func TestService_BuildSpecReportsLoaderAndDefaultFailures(t *testing.T) {
+func TestService_BuildSpecReportsLoaderFailure(t *testing.T) {
 	t.Parallel()
 
 	loadErr := errors.New("factory definition unavailable")
 	loader := func(string, factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
 		return nil, loadErr
 	}
-	svc := mustNewBehaviorService(
+	service := newBuildSpecFailureService(t, loader)
+	_, err := service.BuildReplacementSpec(context.Background(), "/folder", "/missing", "session", "/runtime")
+	if !errors.Is(err, loadErr) || !strings.Contains(err.Error(), "load factory config") {
+		t.Fatalf("loader error = %v, want wrapped %v", err, loadErr)
+	}
+}
+
+func TestService_BuildSpecRejectsUnsupportedOperatorDefault(t *testing.T) {
+	t.Parallel()
+
+	loaded := &runtimeBuildLoadedSource{config: &factorydefinitions.FactoryConfig{
+		Workers: []factorydefinitions.FactoryWorkerConfig{{Name: "model", Type: factorydefinitions.WorkerTypeModel}},
+	}}
+	service := newDefaultOperatorFailureService(t, "unsupported provider", "model")
+	_, err := service.BuildSpec(
+		context.Background(),
+		"/factory",
+		"/folder",
+		"session",
+		"/runtime",
+		loaded,
+		"id",
+		nil,
+		nil,
+		nil,
+		nil,
+		false,
+	)
+	if err == nil || !strings.Contains(err.Error(), "unsupported worker model provider") {
+		t.Fatalf("invalid default error = %v, want unsupported provider diagnostic", err)
+	}
+}
+
+func TestService_BuildSpecReportsOperatorDefaultMutationFailure(t *testing.T) {
+	t.Parallel()
+
+	mutationErr := errors.New("worker defaults cannot be applied")
+	loaded := &runtimeBuildLoadedSource{
+		config:    &factorydefinitions.FactoryConfig{Workers: []factorydefinitions.FactoryWorkerConfig{{Name: "model", Type: factorydefinitions.WorkerTypeModel}}},
+		mutateErr: mutationErr,
+	}
+	service := mustNewBehaviorService(
+		t,
+		"CODEX",
+		"model",
+		true,
+		"",
+		"",
+		unusedFactoryLoader(),
+		nil,
+		nil,
+		nil,
+		failIfBuildCalled(t),
+		nil,
+	)
+	_, err := service.BuildSpec(
+		context.Background(),
+		"/factory",
+		"/folder",
+		"session",
+		"/runtime",
+		loaded,
+		"id",
+		nil,
+		nil,
+		nil,
+		nil,
+		false,
+	)
+	if !errors.Is(err, mutationErr) || !strings.Contains(err.Error(), "apply operator defaults") {
+		t.Fatalf("mutation error = %v, want wrapped %v", err, mutationErr)
+	}
+}
+
+func newBuildSpecFailureService(t *testing.T, loader factorydefinitions.LoadedFactoryLoader) *runtimebuild.Service {
+	t.Helper()
+	return mustNewBehaviorService(
 		t,
 		"",
 		"",
@@ -342,95 +383,40 @@ func TestService_BuildSpecReportsLoaderAndDefaultFailures(t *testing.T) {
 		nil,
 		nil,
 		nil,
-		func(context.Context, runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
-			t.Fatal("builder called after loader failure")
-			return nil, nil
-		},
+		failIfBuildCalled(t),
 		nil,
 	)
-	_, err := svc.BuildReplacementSpec(context.Background(), "/folder", "/missing", "session", "/runtime")
-	if !errors.Is(err, loadErr) || !strings.Contains(err.Error(), "load factory config") {
-		t.Fatalf("loader error = %v, want wrapped %v", err, loadErr)
-	}
+}
 
-	nilSourceService := mustNewBehaviorService(
+func newDefaultOperatorFailureService(t *testing.T, provider string, model string) *runtimebuild.Service {
+	t.Helper()
+	return mustNewBehaviorService(
 		t,
-		"",
-		"",
-		false,
-		"",
-		"",
-		func(string, factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
-			return nil, nil
-		},
-		nil,
-		nil,
-		nil,
-		func(context.Context, runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
-			t.Fatal("builder called after nil source")
-			return nil, nil
-		},
-		nil,
-	)
-	_, err = nilSourceService.BuildReplacementSpec(context.Background(), "/folder", "/missing", "session", "/runtime")
-	if err == nil || !strings.Contains(err.Error(), "loader returned nil source") {
-		t.Fatalf("nil source error = %v, want explicit loader result failure", err)
-	}
-
-	invalidDefaults := &runtimeBuildLoadedSource{config: &factorydefinitions.FactoryConfig{
-		Workers: []factorydefinitions.FactoryWorkerConfig{{Name: "model", Type: factorydefinitions.WorkerTypeModel}},
-	}}
-	invalidDefaultService := mustNewBehaviorService(
-		t,
-		"unsupported provider",
-		"model",
+		provider,
+		model,
 		true,
 		"",
 		"",
-		func(string, factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
-			return nil, errors.New("unused loader")
-		},
+		unusedFactoryLoader(),
 		nil,
 		nil,
 		nil,
-		func(context.Context, runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
-			t.Fatal("builder called after invalid defaults")
-			return nil, nil
-		},
+		failIfBuildCalled(t),
 		nil,
 	)
-	_, err = invalidDefaultService.BuildSpec(context.Background(), "/factory", "/folder", "session", "/runtime", invalidDefaults, "id", nil, nil, nil, nil, false)
-	if err == nil || !strings.Contains(err.Error(), "unsupported worker model provider") {
-		t.Fatalf("invalid default error = %v, want unsupported provider diagnostic", err)
-	}
+}
 
-	mutationErr := errors.New("worker defaults cannot be applied")
-	mutationFailure := &runtimeBuildLoadedSource{
-		config:    &factorydefinitions.FactoryConfig{Workers: []factorydefinitions.FactoryWorkerConfig{{Name: "model", Type: factorydefinitions.WorkerTypeModel}}},
-		mutateErr: mutationErr,
+func unusedFactoryLoader() factorydefinitions.LoadedFactoryLoader {
+	return func(string, factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
+		return nil, errors.New("unused loader")
 	}
-	mutationService := mustNewBehaviorService(
-		t,
-		"CODEX",
-		"model",
-		true,
-		"",
-		"",
-		func(string, factorydefinitions.WorkstationLoader) (factorydefinitions.MutableLoadedFactorySource, error) {
-			return nil, errors.New("unused loader")
-		},
-		nil,
-		nil,
-		nil,
-		func(context.Context, runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
-			t.Fatal("builder called after mutation failure")
-			return nil, nil
-		},
-		nil,
-	)
-	_, err = mutationService.BuildSpec(context.Background(), "/factory", "/folder", "session", "/runtime", mutationFailure, "id", nil, nil, nil, nil, false)
-	if !errors.Is(err, mutationErr) || !strings.Contains(err.Error(), "apply operator defaults") {
-		t.Fatalf("mutation error = %v, want wrapped %v", err, mutationErr)
+}
+
+func failIfBuildCalled(t *testing.T) runtimebuild.BundleBuilder {
+	t.Helper()
+	return func(context.Context, runtimebuild.SessionBuildSpec) (*factoryhost.Bundle, error) {
+		t.Fatal("builder called after BuildSpec failure")
+		return nil, nil
 	}
 }
 

--- a/tests/functional/sessions/root_composition/process_execute_runtime_opening_test.go
+++ b/tests/functional/sessions/root_composition/process_execute_runtime_opening_test.go
@@ -115,6 +115,45 @@ func TestProcessExecuteOpensRequestedFactorySessionThroughRoot(t *testing.T) {
 	}
 }
 
+// TestProcessExecuteCorruptCurrentBoardRecordingStopsOpening proves that a
+// corrupt current-board artifact is rejected at the Process.Execute opening
+// boundary and remains available for investigation.
+func TestProcessExecuteCorruptCurrentBoardRecordingStopsOpening(t *testing.T) {
+	t.Parallel()
+
+	factoryDir := support.ScaffoldFactory(t, processExecuteRuntimeOpeningFactoryConfig())
+	recordPath := filepath.Join(factoryDir, "current-board.json")
+	corruptPayload := []byte(`{"schemaVersion":"recordings.portable-artifact.v1","summary":{}}`)
+	if err := os.WriteFile(recordPath, corruptPayload, 0o600); err != nil {
+		t.Fatalf("write corrupt current-board recording: %v", err)
+	}
+
+	process, err := root.BuildProcess(t.Context(), serviceedges.Edges{})
+	if err != nil {
+		t.Fatalf("root.BuildProcess() error = %v", err)
+	}
+	support.CleanupProcess(t, process)
+
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "run", "--dir", factoryDir, "--record", recordPath, "--quiet",
+	})
+	inputs.Input.Env = append(os.Environ(), "HOME="+t.TempDir(), "USERPROFILE="+t.TempDir())
+	inputs.Input.WorkingDirectory = factoryDir
+
+	err = process.Execute(inputs.Input)
+	if err == nil || !strings.Contains(err.Error(), "CORRUPT_HISTORY") ||
+		!strings.Contains(err.Error(), filepath.Base(recordPath)) {
+		t.Fatalf("Process.Execute() error = %v, want corrupt current-board diagnostic", err)
+	}
+	contents, err := os.ReadFile(recordPath)
+	if err != nil {
+		t.Fatalf("read corrupt current-board recording after failed startup: %v", err)
+	}
+	if string(contents) != string(corruptPayload) {
+		t.Fatal("failed startup changed the corrupt current-board recording")
+	}
+}
+
 // TestProcessExecuteUnavailableFactoryDoesNotRegisterSession proves that an
 // unavailable Factory definition fails at the customer process boundary before
 // Factory Session or runtime identity allocation can publish partial state.

--- a/tests/functional/sessions/root_composition/process_execute_runtime_opening_test.go
+++ b/tests/functional/sessions/root_composition/process_execute_runtime_opening_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/portpowered/infinite-you/pkg/root"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
-	factorysessionwire "github.com/portpowered/infinite-you/pkg/services/factory_sessions/wire"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
@@ -189,33 +188,6 @@ func TestProcessExecuteReplayLoaderFailureStopsBeforeLiveActivation(t *testing.T
 	err = process.Execute(inputs.Input)
 	if err == nil || !strings.Contains(err.Error(), "failed to load --replay input") {
 		t.Fatalf("Process.Execute() error = %v, want replay loader failure", err)
-	}
-}
-
-// TestRuntimeOpeningCompositionRejectsMissingOwnerPorts proves that the
-// customer-facing Factory Sessions wire boundary rejects an incomplete graph
-// before any runtime-opening operation can be attempted.
-func TestRuntimeOpeningCompositionRejectsMissingOwnerPorts(t *testing.T) {
-	t.Parallel()
-
-	factory, err := factorysessionwire.NewRuntimeOpening(
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-	)
-	if factory != nil {
-		t.Fatalf("NewRuntimeOpening() = %#v, want nil factory", factory)
-	}
-	if err == nil || !strings.Contains(err.Error(), "Provider Sessions owner ports are required") {
-		t.Fatalf("NewRuntimeOpening() error = %v, want missing owner-port diagnostic", err)
 	}
 }
 

--- a/tests/functional/sessions/root_composition/process_execute_runtime_opening_test.go
+++ b/tests/functional/sessions/root_composition/process_execute_runtime_opening_test.go
@@ -1,6 +1,7 @@
 package root_composition_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/root"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factorysessionwire "github.com/portpowered/infinite-you/pkg/services/factory_sessions/wire"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
@@ -154,6 +156,66 @@ func TestProcessExecuteUnavailableFactoryDoesNotRegisterSession(t *testing.T) {
 	}
 	if got := runtimeIDs.Load(); got != 0 {
 		t.Fatalf("runtime identity allocations after unavailable definition = %d, want 0", got)
+	}
+}
+
+// TestProcessExecuteReplayLoaderFailureStopsBeforeLiveActivation proves that
+// a replay-source failure is returned from the canonical runtime-opening
+// boundary without attempting to assemble a live Factory Session.
+func TestProcessExecuteReplayLoaderFailureStopsBeforeLiveActivation(t *testing.T) {
+	t.Parallel()
+
+	process, err := root.BuildProcess(t.Context(), serviceedges.Edges{
+		FactorySessionReplayRecordingReader: func(path string) ([]byte, error) {
+			if path != "recording.json" {
+				t.Fatalf("replay input path = %q, want recording.json", path)
+			}
+			return nil, errors.New("replay fixture unavailable")
+		},
+	})
+	if err != nil {
+		t.Fatalf("root.BuildProcess() error = %v", err)
+	}
+	support.CleanupProcess(t, process)
+
+	workingDirectory := t.TempDir()
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "run", "--dir", workingDirectory,
+		"--replay", "recording.json", "--no-record", "--quiet",
+	})
+	inputs.Input.Env = append(os.Environ(), "HOME="+t.TempDir(), "USERPROFILE="+t.TempDir())
+	inputs.Input.WorkingDirectory = workingDirectory
+
+	err = process.Execute(inputs.Input)
+	if err == nil || !strings.Contains(err.Error(), "failed to load --replay input") {
+		t.Fatalf("Process.Execute() error = %v, want replay loader failure", err)
+	}
+}
+
+// TestRuntimeOpeningCompositionRejectsMissingOwnerPorts proves that the
+// customer-facing Factory Sessions wire boundary rejects an incomplete graph
+// before any runtime-opening operation can be attempted.
+func TestRuntimeOpeningCompositionRejectsMissingOwnerPorts(t *testing.T) {
+	t.Parallel()
+
+	factory, err := factorysessionwire.NewRuntimeOpening(
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	if factory != nil {
+		t.Fatalf("NewRuntimeOpening() = %#v, want nil factory", factory)
+	}
+	if err == nil || !strings.Contains(err.Error(), "Provider Sessions owner ports are required") {
+		t.Fatalf("NewRuntimeOpening() error = %v, want missing owner-port diagnostic", err)
 	}
 }
 

--- a/tests/functional/sessions/root_composition/process_execute_runtime_opening_test.go
+++ b/tests/functional/sessions/root_composition/process_execute_runtime_opening_test.go
@@ -1,0 +1,180 @@
+package root_composition_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/root"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestProcessExecuteOpensRequestedFactorySessionThroughRoot proves that an
+// ordinary customer process invocation opens the selected Factory source and
+// publishes one canonical Factory Session with observable lifecycle controls.
+// The API reads and controls below are API-owned session observations; the
+// opening itself is performed by Process.Execute on the root-built process.
+func TestProcessExecuteOpensRequestedFactorySessionThroughRoot(t *testing.T) {
+	t.Parallel()
+
+	factoryDir := support.ScaffoldFactory(t, processExecuteRuntimeOpeningFactoryConfig())
+	api := support.NewProcessAPIServer()
+	process, err := root.BuildProcess(t.Context(), serviceedges.Edges{
+		APIServerStarter: api.Start,
+	})
+	if err != nil {
+		t.Fatalf("root.BuildProcess() error = %v", err)
+	}
+	support.CleanupProcess(t, process)
+
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "run",
+		"--factory", filepath.Join(factoryDir, "factory.json"),
+		"--continuously", "--with-server", "--quiet", "--no-record",
+	})
+	home := t.TempDir()
+	inputs.Input.Env = append(os.Environ(), "HOME="+home, "USERPROFILE="+home)
+	inputs.Input.WorkingDirectory = factoryDir
+	command := support.StartProcessCommand(t, process, inputs.Input)
+
+	baseURL := api.WaitForURL(t)
+	session := support.GetDefaultSession(t, baseURL)
+	if session.Id == "" || !session.IsDefault {
+		t.Fatalf("opened Factory Session = %#v, want a canonical default identity", session)
+	}
+	if filepath.Clean(session.FactoryDir) != filepath.Clean(factoryDir) ||
+		filepath.Clean(session.FolderPath) != filepath.Clean(factoryDir) {
+		t.Fatalf(
+			"opened Factory Session paths = factoryDir:%q folderPath:%q, want %q",
+			session.FactoryDir, session.FolderPath, factoryDir,
+		)
+	}
+	if session.Runtime.StreamIdentity == nil {
+		t.Fatalf("opened Factory Session runtime = %#v, want stream identity", session.Runtime)
+	}
+	identity := session.Runtime.StreamIdentity
+	if identity.FactorySessionID != session.Id ||
+		identity.LogicalSessionKeyID == "" || identity.StreamGenerationID == "" {
+		t.Fatalf("opened Factory Session stream identity = %#v, want canonical session linkage", identity)
+	}
+
+	current := support.GetJSON[factoryapi.Factory](
+		t,
+		baseURL+"/factory-sessions/"+factorysessions.DefaultSessionID+"/factory",
+	)
+	if current.FactoryDirectory == nil || filepath.Clean(*current.FactoryDirectory) != filepath.Clean(factoryDir) {
+		t.Fatalf("session current Factory directory = %#v, want %q", current.FactoryDirectory, factoryDir)
+	}
+	if current.WorkTypes == nil || len(*current.WorkTypes) != 1 || (*current.WorkTypes)[0].Name != "task" {
+		t.Fatalf("session current Factory work types = %#v, want selected task definition", current.WorkTypes)
+	}
+
+	listed := support.GetJSON[factoryapi.ListFactorySessionsResponse](t, baseURL+"/factory-sessions")
+	if !sessionSummaryContains(listed.Sessions, session.Id) {
+		t.Fatalf("listed Factory Sessions = %#v, want opened session %q", listed.Sessions, session.Id)
+	}
+
+	pause := postSessionsLifecycleControl(
+		t,
+		baseURL,
+		factorysessions.DefaultSessionID,
+		factoryapi.FactorySessionLifecycleControlKindPause,
+	)
+	if pause.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("pause response = %#v, want accepted lifecycle control", pause)
+	}
+	paused := support.GetDefaultSession(t, baseURL)
+	if paused.Runtime.LifecycleControlStatus == nil ||
+		*paused.Runtime.LifecycleControlStatus != factoryapi.FactorySessionDurableLifecycleStatusPaused {
+		t.Fatalf("paused Factory Session runtime = %#v, want PAUSED", paused.Runtime)
+	}
+
+	resume := postSessionsLifecycleControl(
+		t,
+		baseURL,
+		factorysessions.DefaultSessionID,
+		factoryapi.FactorySessionLifecycleControlKindResume,
+	)
+	if resume.Outcome != factoryapi.FactorySessionLifecycleControlOutcomeAccepted {
+		t.Fatalf("resume response = %#v, want accepted lifecycle control", resume)
+	}
+	running := support.GetDefaultSession(t, baseURL)
+	if running.Runtime.LifecycleControlStatus == nil ||
+		*running.Runtime.LifecycleControlStatus != factoryapi.FactorySessionDurableLifecycleStatusRunning {
+		t.Fatalf("resumed Factory Session runtime = %#v, want RUNNING", running.Runtime)
+	}
+
+	if command.Err() != nil {
+		t.Fatalf("Process.Execute() returned before lifecycle observations: %v", command.Err())
+	}
+}
+
+// TestProcessExecuteUnavailableFactoryDoesNotRegisterSession proves that an
+// unavailable Factory definition fails at the customer process boundary before
+// Factory Session or runtime identity allocation can publish partial state.
+func TestProcessExecuteUnavailableFactoryDoesNotRegisterSession(t *testing.T) {
+	t.Parallel()
+
+	missingFactory := filepath.Join(t.TempDir(), "missing", "factory.json")
+	var sessionIDs atomic.Int32
+	var runtimeIDs atomic.Int32
+	process, err := root.BuildProcess(t.Context(), serviceedges.Edges{
+		FactorySessionIDGenerator: func() string {
+			sessionIDs.Add(1)
+			return "unexpected-session"
+		},
+		FactorySessionRuntimeInstanceIDGenerator: func() string {
+			runtimeIDs.Add(1)
+			return "unexpected-runtime"
+		},
+	})
+	if err != nil {
+		t.Fatalf("root.BuildProcess() error = %v", err)
+	}
+	support.CleanupProcess(t, process)
+
+	inputs := support.FakeInputs(t.Context(), []string{
+		"you", "run", "--factory", missingFactory, "--quiet", "--no-record",
+	})
+	home := t.TempDir()
+	inputs.Input.Env = append(os.Environ(), "HOME="+home, "USERPROFILE="+home)
+	inputs.Input.WorkingDirectory = filepath.Dir(missingFactory)
+
+	err = process.Execute(inputs.Input)
+	if err == nil || !strings.Contains(err.Error(), filepath.Base(missingFactory)) {
+		t.Fatalf("Process.Execute() error = %v, want unavailable Factory diagnostic", err)
+	}
+	if got := sessionIDs.Load(); got != 0 {
+		t.Fatalf("Factory Session identity allocations after unavailable definition = %d, want 0", got)
+	}
+	if got := runtimeIDs.Load(); got != 0 {
+		t.Fatalf("runtime identity allocations after unavailable definition = %d, want 0", got)
+	}
+}
+
+func processExecuteRuntimeOpeningFactoryConfig() map[string]any {
+	return map[string]any{
+		"name": "process-execute-runtime-opening",
+		"workTypes": []map[string]any{{
+			"name": "task",
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]string{{"name": "worker-a"}},
+		"workstations": []map[string]any{{
+			"name":      "process",
+			"worker":    "worker-a",
+			"inputs":    []map[string]string{{"workType": "task", "state": "init"}},
+			"outputs":   []map[string]string{{"workType": "task", "state": "complete"}},
+			"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
+		}},
+	}
+}


### PR DESCRIPTION
{
  "project": "Restore Factory Runtime and Sessions Coverage Floors",
  "branchName": "cov-floor-runtime-and-sessions",
  "description": "Restore blocking coverage compliance for the three Factory Definitions, Factory Runtime, and Factory Sessions packages that fell below their established floors by adding meaningful regression tests for runtime snapshots, runtime construction, and Factory Session opening without lowering floors, relaxing policy, or duplicating sibling lanes.",
  "context": {
    "customerAsk": "Raise only pkg/services/factory_definitions/internal/services/runtime_snapshot/internal from 70.5% unit coverage to at least 83.5%, pkg/services/factory_runtime/internal/services/instance_host/build from 77.2% unit coverage to at least 79.0%, and pkg/services/factory_sessions/internal/runtimeopening from 71.4% functional coverage to at least 71.5%. Use behavior-driven tests in the lane that measures each package, quote fresh before/after percentages, and avoid the nine packages owned by sibling recovery lanes.",
    "problem": "CI run 32733189021 on origin/main showed all three packages below their now-blocking floors. The regressions entered while PR #2153 made coverage policy advisory, so earlier green status was not enforcement evidence. PR #2163 restored blocking enforcement, causing Backend Unit Coverage or Backend Functional Coverage and the derived Verification Policy check to fail. Tests in the wrong tree cannot move the affected lane, while lowering a manifest floor would conceal the missing evidence.",
    "solution": "Add focused package-local unit tests for detached invocation-effective snapshots and deterministic runtime build construction, plus focused tests under tests/functional that exercise Factory Session opening through root.BuildProcess and Process.Execute. Preserve service ownership, explicit state, isolated side effects, contracts, blocking policy, and exact floors; then run fresh lane-specific coverage measurements after rebasing on current origin/main and reconcile shared manifest changes without touching out-of-scope entries."
  },
  "acceptanceCriteria": [
    "A fresh make test-unit-coverage run measures pkg/services/factory_definitions/internal/services/runtime_snapshot/internal at or above 83.5% and pkg/services/factory_runtime/internal/services/instance_host/build at or above 79.0%; the PR body quotes the operator-measured before values (70.5% and 77.2%) and fresh after values from property-specific output.",
    "A fresh make test-functional-coverage run measures pkg/services/factory_sessions/internal/runtimeopening at or above 71.5%; the PR body quotes the operator-measured 71.4% before value and fresh after value, and the functional suite reaches package-floor evaluation rather than failing or terminating before measurement.",
    "Added tests directly prove customer/operator-relevant runtime-snapshot, runtime-build, and Factory Session opening behavior, including relevant failure or cancellation outcomes and detached or isolated state; they do not exist only to call private helpers or inflate executed statements.",
    "Scope remains limited to the three named production packages and the narrow functional test surface needed to exercise runtimeopening; no sibling-lane package behavior or floor, coverage policy setting, generated or public contract, or docs/internal/baselines/deadcode-baseline.txt content changes.",
    "Runtime-proof classification: not applicable. This lane adds regression tests and restores coverage measurements without changing runtime-observable CLI, API, UI, emitted-event, or lifecycle behavior; fresh real unit and functional coverage commands and verbatim measurement output remain mandatory coverage evidence but are not represented as end-to-end proof of newly delivered runtime behavior.",
    "Quality gate: Typecheck passes; focused tests and the relevant fresh unit and functional coverage commands pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green; required PR checks are exercised without lowering floors, weakening assertions, or adding exclusions.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "cov-floor-runtime-and-sessions-001",
      "title": "Prove detached invocation-effective runtime snapshots",
      "description": "As a Factory operator, I want runtime snapshots to preserve the effective authored definition while isolating execution from later source mutations so a session starts from the validated inputs I selected.",
      "acceptanceCriteria": [
        "Focused owning-package unit tests resolve representative path and canonical Factory sources through the service contract and prove the resulting snapshot contains the expected effective workers, workstations, automation and prompt sources, bundled replacements, runtime base directory, and invocation context.",
        "Tests prove invocation arguments are applied to the effective execution definition, sensitive argument references are reported as deterministic escaped JSON pointers, and sensitive values are not substituted into or exposed by the pointer list.",
        "Mutating the loaded source, invocation arguments, or returned nested snapshot data after resolution does not mutate the other values, proving the result is deeply detached for runtime use.",
        "Invalid source selection, nil or canceled context, loader failure or nil source, and an undetachable effective definition return the existing typed diagnostic classification with the underlying cause inspectable where applicable.",
        "Tests call the runtime-snapshot service behavior and its injected loader and file-reader contracts; no production accessor, exported test hook, or private-helper-only test is added solely to increase coverage.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added service-contract tests for trimmed path loading, invocation-effective worker/workstation values, sensitive JSON-pointer provenance with escaped map keys, deep detachment, all automation source classifications, context/source failures, and missing-loader construction. Focused tests, race, vet, and the canonical unit lane passed for this package; unit lane measured runtime_snapshot/internal at 94.2% against the 83.5% floor. Aggregate unit coverage still exits on unrelated current-main package regressions."
    },
    {
      "id": "cov-floor-runtime-and-sessions-002",
      "title": "Prove deterministic runtime instance construction",
      "description": "As a Factory Session operator, I want runtime construction to preserve explicit session inputs and reject unusable dependencies predictably so opening a session cannot silently start with the wrong provider, model, recording, or identity.",
      "acceptanceCriteria": [
        "Focused owning-package unit tests exercise the runtime build service and prove a valid session build specification carries the requested Factory identity, canonical session and runtime identity, execution base, replay and submission collaborators, recording settings, and injected runtime dependencies into the bundle builder without mutating caller-owned input.",
        "Tests prove operator defaults are applied only under the existing policy and explicit request values remain authoritative, including provider and model and compatibility record-path behavior.",
        "Tests cover meaningful failure and edge outcomes through the service contract: missing required construction dependencies, nil or unusable service build calls, Factory loading failure, canceled context where supported, and bundle-builder error propagation.",
        "Tests verify provider, command-runner, mock-worker, logger, clock and ID, completion, and mutation-recorder collaborators remain isolated behind their existing owners; no alternate construction path, hidden global state, or new production test seam is introduced.",
        "A fresh unit-lane measurement for this story can attribute the recovered statements to service construction and build behavior rather than direct calls to private helpers.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added behavior-driven runtime-build tests for derived session specs, operator defaults, explicit values, replay/submission/completion collaborators, replacement loading, cancellation, loader/default failures, caller-spec isolation, and builder error propagation. The review refactor split oversized tests to satisfy backend-size and maintainability gates, and restored service.go so the production diff remains test-only. Focused package tests, race, vet, and direct coverage passed; `go test ./pkg/services/factory_runtime/internal/services/instance_host/build -cover -count=1` measured 94.6% against the 79.0% floor. The aggregate `make test-unit-coverage` run exited on unrelated current-main package regressions; no manifest or floor changes were made."
    },
    {
      "id": "cov-floor-runtime-and-sessions-003",
      "title": "Prove root-composed Factory Session opening behavior",
      "description": "As a Factory operator, I want opening a Factory Session through the delivered application boundary to load and activate the requested runtime with truthful lifecycle and failure outcomes.",
      "acceptanceCriteria": [
        "Focused functional tests construct the application through root.BuildProcess and execute an ordinary customer flow through Process.Execute by default, proving a valid Factory source opens a distinct canonical Factory Session backed by the requested runtime definition and can be observed through existing session read and control behavior.",
        "The functional cell exercises runtimeopening through existing Factory Sessions and Factory Runtime root contracts; it does not construct private capabilities directly, use HTTP unless an API-owned contract or explicit CLI and API parity requires it, or use a built CLI unless an OS or process-boundary behavior cannot be expressed through Process.Execute.",
        "At least one meaningful opening failure, such as invalid or unavailable definition resolution, canceled activation, or runtime activation failure, is surfaced without registering a false live session or leaking partially activated lifecycle state.",
        "External effects are replaced only through edges.Edges, command-runner edge mocks are preferred, MockWorkers remain confined to their owned feature cells, and synchronization uses deterministic observations rather than new sleeps or timeout-padded polling unless an in-code justification establishes necessity.",
        "Existing opening, activation, replay, recording, and lifecycle semantics remain unchanged; production behavior is modified only if a test exposes an actual in-scope correctness defect required to preserve those semantics.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added root-composed functional coverage that runs a real `you run --factory ... --continuously --with-server` invocation through root.BuildProcess and Process.Execute, observes the selected Factory Session and loaded work-type definition through the existing session API, and exercises pause/resume lifecycle controls. Added an unavailable-definition flow that preserves the diagnostic and allocates zero session/runtime identities. Focused tests, full root-composition package tests, race, vet, and typecheck passed; no production or manifest changes were needed."
    },
    {
      "id": "cov-floor-runtime-and-sessions-004",
      "title": "Measure, reconcile, and deliver the recovered floors",
      "description": "As a maintainer, I want current-main coverage evidence and conflict-safe delivery so the three recovered package floors remain blocking and trustworthy when the lane merges beside sibling recovery work.",
      "acceptanceCriteria": [
        "Immediately before the final implementation push, fetch and rebase onto current origin/main, resolve shared-file conflicts without taking ownership of sibling package entries, and verify the final diff changes no package behavior or manifest floor outside the three-package scope.",
        "A fresh make test-unit-coverage run reaches floor evaluation and reports runtime snapshot coverage at or above 83.5% and runtime instance build coverage at or above 79.0%; a fresh make test-functional-coverage run reaches floor evaluation and reports runtime opening coverage at or above 71.5%.",
        "The PR body records all three operator-measured before percentages and fresh after percentages; verbatim coverage commands and property-specific outputs are recorded in a PR comment and never committed as generated evidence.",
        "The existing unit floors 83.5% and 79.0%, functional floor 71.5%, GO_COVERAGE_FLOOR_POLICY, all other policy settings, and every out-of-scope manifest entry remain unchanged; docs/internal/baselines/deadcode-baseline.txt is untouched.",
        "CI diagnosis distinguishes a test failure or premature suite termination from an evaluated floor failure, and only same-head, same-lane property-specific output is cited as coverage evidence.",
        "Runtime-proof classification: not applicable. This lane adds regression tests and restores coverage measurements without changing runtime-observable CLI, API, UI, emitted-event, or lifecycle behavior; fresh real unit and functional coverage commands and verbatim measurement output remain mandatory coverage evidence but are not represented as end-to-end proof of newly delivered runtime behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Refactored review-flagged oversized tests, removed the direct owner-wire construction case from the functional cell, and restored service.go so the production diff remains test-only. Added a root-composed Process.Execute corruption-recovery scenario that rejects a corrupt current-board artifact and preserves it for investigation. The complete equivalent functional checker run on code-identical content reached package-floor evaluation at 1090/1490 covered statements (73.2%) for factory_sessions/internal/runtimeopening against the exact 71.48% blocking floor, up from the prior 1065/1490 (71.5%). The required final rebase onto origin/main preserved the same three-file diff; its final-candidate rerun produced the same 1090/1490 target measurement but stopped before a verdict on an unrelated packaged-factory staging contention (TestCLIRunToFilePreservesExactPromptAndRejectsBeforeProviderDispatch). The make wrapper could not execute its POSIX shell fragment on this Windows host, so equivalent gocoveragecheck output is recorded instead; unrelated current-main package-floor failures remain outside this lane. Focused tests, race, vet, backend-size, pkg-maint, and typecheck passed. No floors, policy, manifests, or generated evidence were changed."
    }
  ]
}
