### PR TITLE
fix(worker-sessions): bound unscoped list attribution

### DIFF
--- a/pkg/services/worker_sessions/transports/cli/list.go
+++ b/pkg/services/worker_sessions/transports/cli/list.go
@@ -312,7 +312,11 @@ type CLIError struct {
 	// Phase carries the typed interrupt boundary for interrupt-specific JSON
 	// diagnostics. Other Worker Sessions operations leave it empty.
 	Phase string
-	Cause error
+	// Family and Response preserve a server-owned list failure when one crossed
+	// the HTTP boundary. Local command failures leave Response nil.
+	Family   factoryapi.ErrorFamily
+	Response *factoryapi.ErrorResponse
+	Cause    error
 }
 
 func (err *CLIError) Error() string {
@@ -346,6 +350,30 @@ func (err *CLIError) CLIErrorMessage() string {
 	return err.Message
 }
 
+func (err *CLIError) CLIErrorFamily() factoryapi.ErrorFamily {
+	if err == nil {
+		return ""
+	}
+	if err.Response != nil {
+		return err.Response.Family
+	}
+	return err.Family
+}
+
+func (err *CLIError) CLIErrorResponse() factoryapi.ErrorResponse {
+	if err == nil {
+		return factoryapi.ErrorResponse{}
+	}
+	if err.Response != nil {
+		return *err.Response
+	}
+	return factoryapi.ErrorResponse{
+		Code:    factoryapi.ErrorResponseCode(err.Code),
+		Family:  err.Family,
+		Message: err.Message,
+	}
+}
+
 func newCLIError(code, message string, cause error) *CLIError {
 	return &CLIError{Code: code, Message: message, Cause: cause}
 }
@@ -360,6 +388,9 @@ func emitCLIError(config ListConfig, jsonOutput bool, err error) error {
 		output = config.Diagnostics
 	}
 	if output == nil {
+		return err
+	}
+	if clidiag.WriteFailure(output, err) {
 		return err
 	}
 	payload := struct {
@@ -392,20 +423,32 @@ func cliErrorMessage(err error) string {
 }
 
 func workerSessionsHTTPError(response *http.Response, status int, topLevel bool) error {
-	if apiError, ok := clihttp.DecodeAPIError(response); ok {
-		code := strings.TrimSpace(string(apiError.Code))
-		if status == http.StatusNotFound {
-			if topLevel {
-				code = "WORKER_SESSION_NOT_FOUND"
-			} else {
-				code = "WORK_NOT_FOUND"
+	if response != nil && response.Body != nil {
+		defer response.Body.Close()
+		if apiError, ok := clihttp.DecodeAPIError(response); ok || apiError.Code != "" || apiError.Family != "" {
+			code := strings.TrimSpace(string(apiError.Code))
+			if code == "" {
+				code = listHTTPFallbackCode(status, topLevel)
+			}
+			message := strings.TrimSpace(apiError.Message)
+			if message == "" {
+				message = fmt.Sprintf("worker session list failed (%d)", status)
+			}
+			apiError.Code = factoryapi.ErrorResponseCode(code)
+			apiError.Message = message
+			return &CLIError{
+				Code:     code,
+				Message:  message,
+				Family:   apiError.Family,
+				Response: &apiError,
 			}
 		}
-		if code == "" {
-			code = "WORKER_SESSION_LIST_FAILED"
-		}
-		return newCLIError(code, apiError.Message, nil)
 	}
+	code := listHTTPFallbackCode(status, topLevel)
+	return newCLIError(code, fmt.Sprintf("worker session list failed (%d)", status), nil)
+}
+
+func listHTTPFallbackCode(status int, topLevel bool) string {
 	code := "WORKER_SESSION_LIST_FAILED"
 	if status == http.StatusNotFound {
 		if topLevel {
@@ -414,7 +457,7 @@ func workerSessionsHTTPError(response *http.Response, status int, topLevel bool)
 			code = "WORK_NOT_FOUND"
 		}
 	}
-	return newCLIError(code, fmt.Sprintf("worker session list failed (%d)", status), nil)
+	return code
 }
 
 func renderList(output io.Writer, result factoryapi.ListWorkerSessionsResponse) error {

--- a/pkg/services/worker_sessions/transports/cli/list_test.go
+++ b/pkg/services/worker_sessions/transports/cli/list_test.go
@@ -254,15 +254,59 @@ func TestListJSONMissingWorkReturnsStableMachineReadableError(t *testing.T) {
 		t.Fatal("List() error = nil, want missing Work error")
 	}
 	var typed *CLIError
-	if !errors.As(err, &typed) || typed.Code != "WORK_NOT_FOUND" {
-		t.Fatalf("error = %v, want CLIError code WORK_NOT_FOUND", err)
+	if !errors.As(err, &typed) || typed.Code != "NOT_FOUND" {
+		t.Fatalf("error = %v, want CLIError code NOT_FOUND", err)
 	}
 	var payload map[string]string
 	if decodeErr := json.Unmarshal(output.Bytes(), &payload); decodeErr != nil {
 		t.Fatalf("decode error JSON: %v; output=%q", decodeErr, output.String())
 	}
-	if payload["code"] != "WORK_NOT_FOUND" || payload["message"] != "work not found" {
-		t.Fatalf("error payload = %#v, want stable code/message", payload)
+	if payload["code"] != "NOT_FOUND" || payload["family"] != "NOT_FOUND" || payload["message"] != "work not found" {
+		t.Fatalf("error payload = %#v, want server code/family/message", payload)
+	}
+}
+
+func TestListPreservesTopLevelServerFailureDetails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/worker-sessions" {
+			t.Fatalf("request path = %q, want /worker-sessions", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(factoryapi.ErrorResponse{
+			Code:    factoryapi.ErrorResponseCodeWORKERSESSIONRECORDINGUNAVAILABLE,
+			Family:  factoryapi.ErrorFamilyInternalServerError,
+			Message: "safe Worker Session list diagnostic",
+		})
+	}))
+	defer server.Close()
+
+	var output bytes.Buffer
+	err := NewList(testHTTPProtocol(t))(ListConfig{
+		Context: context.Background(), Server: server.URL, OutputFormat: "json", Output: &output,
+	})
+	if err == nil {
+		t.Fatal("List() error = nil, want typed server failure")
+	}
+	var typed *CLIError
+	if !errors.As(err, &typed) {
+		t.Fatalf("error = %T %v, want Worker Sessions CLIError", err, err)
+	}
+	if typed.Code != string(factoryapi.ErrorResponseCodeWORKERSESSIONRECORDINGUNAVAILABLE) ||
+		typed.CLIErrorFamily() != factoryapi.ErrorFamilyInternalServerError ||
+		typed.CLIErrorMessage() != "safe Worker Session list diagnostic" {
+		t.Fatalf("typed server details = code %q family %q message %q", typed.Code, typed.CLIErrorFamily(), typed.CLIErrorMessage())
+	}
+	if strings.Contains(output.String(), "FACTORY_UNREACHABLE") {
+		t.Fatalf("output incorrectly substituted unreachable error: %q", output.String())
+	}
+	var response factoryapi.ErrorResponse
+	if decodeErr := json.Unmarshal(output.Bytes(), &response); decodeErr != nil {
+		t.Fatalf("decode error response: %v; output=%q", decodeErr, output.String())
+	}
+	if response.Code != factoryapi.ErrorResponseCodeWORKERSESSIONRECORDINGUNAVAILABLE ||
+		response.Family != factoryapi.ErrorFamilyInternalServerError ||
+		response.Message != "safe Worker Session list diagnostic" {
+		t.Fatalf("server error response = %#v, want preserved details", response)
 	}
 }
 

--- a/pkg/services/worker_sessions/transports/http/adapter.go
+++ b/pkg/services/worker_sessions/transports/http/adapter.go
@@ -696,8 +696,8 @@ func (a *Adapter) ListTopLevelWorkerSessions(
 	maxResults *int,
 	nextToken *string,
 ) (factoryapi.ListWorkerSessionsResponse, error) {
-	if a == nil || a.observations == nil {
-		return factoryapi.ListWorkerSessionsResponse{}, errors.New("Worker Sessions service is required")
+	if a == nil || a.observations == nil || a.work == nil {
+		return factoryapi.ListWorkerSessionsResponse{}, errors.New("Worker Sessions and Work services are required")
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -730,14 +730,17 @@ func (a *Adapter) ListTopLevelWorkerSessions(
 }
 
 // resolveWorkAttribution enriches a Worker Session list without making Work
-// state part of the Worker Sessions service contract. A missing Work read is
-// an unavailable optional fact: the stable Work ID remains visible and the
-// list continues. Context cancellation remains authoritative.
+// state part of the Worker Sessions service contract. Work is listed once per
+// distinct Factory Session in the bounded observation page, rather than once
+// per observation. A missing Work read is an unavailable optional fact: the
+// stable Work ID remains visible and the list continues. Context cancellation
+// remains authoritative.
 func (a *Adapter) resolveWorkAttribution(
 	ctx context.Context,
 	observations []workersessions.Observation,
 ) (map[string]workerSessionWorkAttribution, error) {
 	attribution := make(map[string]workerSessionWorkAttribution, len(observations))
+	batches := make(map[string]*workAttributionBatch)
 	for _, observation := range observations {
 		if len(observation.WorkIDs) == 0 || strings.TrimSpace(observation.WorkIDs[0]) == "" {
 			continue
@@ -747,20 +750,65 @@ func (a *Adapter) resolveWorkAttribution(
 		if sessionID == "" {
 			sessionID = workers.DefaultSessionID
 		}
-		workModel, err := a.work.GetWork(ctx, sessionID, workID)
+		batch := batches[sessionID]
+		if batch == nil {
+			batch = &workAttributionBatch{
+				workIDs:              make(map[string]struct{}),
+				workerSessionIDsByID: make(map[string][]string),
+			}
+			batches[sessionID] = batch
+		}
+		batch.workIDs[workID] = struct{}{}
+		batch.workerSessionIDsByID[workID] = append(batch.workerSessionIDsByID[workID], observation.WorkerSessionID)
+		attribution[observation.WorkerSessionID] = workerSessionWorkAttribution{WorkID: workID}
+	}
+
+	sessionIDs := make([]string, 0, len(batches))
+	for sessionID := range batches {
+		sessionIDs = append(sessionIDs, sessionID)
+	}
+	sort.Strings(sessionIDs)
+	for _, sessionID := range sessionIDs {
+		batch := batches[sessionID]
+		workModelResult, err := a.work.ListWork(ctx, sessionID, work.ListOptions{
+			MaxResults: maxWorkAttributionResults(len(batch.workIDs)),
+		})
 		if err != nil {
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
-			attribution[observation.WorkerSessionID] = workerSessionWorkAttribution{WorkID: workID}
 			continue
 		}
-		attribution[observation.WorkerSessionID] = workerSessionWorkAttribution{
-			WorkID:   workID,
-			WorkName: workModel.Name,
+		for _, workModel := range workModelResult.Results {
+			setWorkAttributionName(attribution, batch.workerSessionIDsByID[workModel.WorkID], workModel.Name)
+			setWorkAttributionName(attribution, batch.workerSessionIDsByID[workModel.CursorID], workModel.Name)
 		}
 	}
 	return attribution, nil
+}
+
+type workAttributionBatch struct {
+	workIDs              map[string]struct{}
+	workerSessionIDsByID map[string][]string
+}
+
+func maxWorkAttributionResults(workIDCount int) int {
+	if workIDCount < work.DefaultListMaxResults {
+		return work.DefaultListMaxResults
+	}
+	return workIDCount
+}
+
+func setWorkAttributionName(
+	attribution map[string]workerSessionWorkAttribution,
+	workerSessionIDs []string,
+	workName string,
+) {
+	for _, workerSessionID := range workerSessionIDs {
+		entry := attribution[workerSessionID]
+		entry.WorkName = workName
+		attribution[workerSessionID] = entry
+	}
 }
 
 // GetTopLevelWorkerSessionObservation resolves one Worker Session using only

--- a/pkg/services/worker_sessions/transports/http/handler.go
+++ b/pkg/services/worker_sessions/transports/http/handler.go
@@ -141,6 +141,15 @@ func (h *Handler) ListWorkerSessions(
 	}
 	response, err := h.adapter.ListTopLevelWorkerSessions(r.Context(), scope, states, maxResults, nextToken)
 	if err != nil {
+		if h.logger != nil {
+			h.logger.Error(
+				"list Worker Sessions failed",
+				zap.String("operation", "worker_sessions.list"),
+				zap.String("scope", scope),
+				zap.Int("state_count", len(states)),
+				zap.Error(err),
+			)
+		}
 		h.writeMappedError(w, err)
 		return
 	}

--- a/pkg/services/worker_sessions/transports/http/handler_test.go
+++ b/pkg/services/worker_sessions/transports/http/handler_test.go
@@ -968,21 +968,12 @@ func decodeSSEFrames(t *testing.T, body string) []sseTestFrame {
 
 type workServiceStub struct {
 	work.Service
-	getErr         error
-	getResult      work.ReadModel
-	getResults     map[string]work.ReadModel
-	getCallCount   *int
-	listErr        error
-	listResult     work.ListResult
-	listCallCount  *int
-	listSessionIDs *[]string
-	listMaxResults *[]int
+	getErr     error
+	getResult  work.ReadModel
+	getResults map[string]work.ReadModel
 }
 
 func (s workServiceStub) GetWork(_ context.Context, _, workID string) (work.ReadModel, error) {
-	if s.getCallCount != nil {
-		*s.getCallCount = *s.getCallCount + 1
-	}
 	if s.getErr != nil {
 		return work.ReadModel{}, s.getErr
 	}
@@ -993,29 +984,6 @@ func (s workServiceStub) GetWork(_ context.Context, _, workID string) (work.Read
 		return s.getResult, nil
 	}
 	return work.ReadModel{WorkID: "known-work"}, nil
-}
-
-func (s workServiceStub) ListWork(_ context.Context, sessionID string, options work.ListOptions) (work.ListResult, error) {
-	if s.listCallCount != nil {
-		*s.listCallCount = *s.listCallCount + 1
-	}
-	if s.listSessionIDs != nil {
-		*s.listSessionIDs = append(*s.listSessionIDs, sessionID)
-	}
-	if s.listMaxResults != nil {
-		*s.listMaxResults = append(*s.listMaxResults, options.MaxResults)
-	}
-	if s.listErr != nil {
-		return work.ListResult{}, s.listErr
-	}
-	if s.listResult.Results != nil || s.listResult.MaxResults != 0 || s.listResult.NextToken != "" || s.listResult.Counts != nil {
-		return s.listResult, nil
-	}
-	results := make([]work.ReadModel, 0, len(s.getResults))
-	for _, result := range s.getResults {
-		results = append(results, result)
-	}
-	return work.ListResult{Results: results}, nil
 }
 
 var _ observationService = (*fakeObservationService)(nil)

--- a/pkg/services/worker_sessions/transports/http/handler_test.go
+++ b/pkg/services/worker_sessions/transports/http/handler_test.go
@@ -968,12 +968,16 @@ func decodeSSEFrames(t *testing.T, body string) []sseTestFrame {
 
 type workServiceStub struct {
 	work.Service
-	getErr     error
-	getResult  work.ReadModel
-	getResults map[string]work.ReadModel
+	getErr       error
+	getResult    work.ReadModel
+	getResults   map[string]work.ReadModel
+	getCallCount *int
 }
 
 func (s workServiceStub) GetWork(_ context.Context, _, workID string) (work.ReadModel, error) {
+	if s.getCallCount != nil {
+		*s.getCallCount = *s.getCallCount + 1
+	}
 	if s.getErr != nil {
 		return work.ReadModel{}, s.getErr
 	}

--- a/pkg/services/worker_sessions/transports/http/handler_test.go
+++ b/pkg/services/worker_sessions/transports/http/handler_test.go
@@ -968,10 +968,15 @@ func decodeSSEFrames(t *testing.T, body string) []sseTestFrame {
 
 type workServiceStub struct {
 	work.Service
-	getErr       error
-	getResult    work.ReadModel
-	getResults   map[string]work.ReadModel
-	getCallCount *int
+	getErr         error
+	getResult      work.ReadModel
+	getResults     map[string]work.ReadModel
+	getCallCount   *int
+	listErr        error
+	listResult     work.ListResult
+	listCallCount  *int
+	listSessionIDs *[]string
+	listMaxResults *[]int
 }
 
 func (s workServiceStub) GetWork(_ context.Context, _, workID string) (work.ReadModel, error) {
@@ -988,6 +993,29 @@ func (s workServiceStub) GetWork(_ context.Context, _, workID string) (work.Read
 		return s.getResult, nil
 	}
 	return work.ReadModel{WorkID: "known-work"}, nil
+}
+
+func (s workServiceStub) ListWork(_ context.Context, sessionID string, options work.ListOptions) (work.ListResult, error) {
+	if s.listCallCount != nil {
+		*s.listCallCount = *s.listCallCount + 1
+	}
+	if s.listSessionIDs != nil {
+		*s.listSessionIDs = append(*s.listSessionIDs, sessionID)
+	}
+	if s.listMaxResults != nil {
+		*s.listMaxResults = append(*s.listMaxResults, options.MaxResults)
+	}
+	if s.listErr != nil {
+		return work.ListResult{}, s.listErr
+	}
+	if s.listResult.Results != nil || s.listResult.MaxResults != 0 || s.listResult.NextToken != "" || s.listResult.Counts != nil {
+		return s.listResult, nil
+	}
+	results := make([]work.ReadModel, 0, len(s.getResults))
+	for _, result := range s.getResults {
+		results = append(results, result)
+	}
+	return work.ListResult{Results: results}, nil
 }
 
 var _ observationService = (*fakeObservationService)(nil)

--- a/pkg/services/worker_sessions/transports/http/list_handler_test.go
+++ b/pkg/services/worker_sessions/transports/http/list_handler_test.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,6 +14,8 @@ import (
 	workersessions "github.com/portpowered/infinite-you/pkg/services/worker_sessions"
 	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestListWorkerSessionsTranslatesPositiveLimit(t *testing.T) {
@@ -100,6 +104,38 @@ func TestListWorkerSessionsMapsInvalidScopeAndStateErrors(t *testing.T) {
 	}
 }
 
+func TestListWorkerSessionsMapsAndLogsBackendFailure(t *testing.T) {
+	core, logs := observer.New(zapcore.ErrorLevel)
+	service := &fakeObservationService{topLevelErr: errors.New("recording projection failed")}
+	handler := NewHandler(NewAdapter(service, workServiceStub{}), zap.New(core))
+	recorder := httptest.NewRecorder()
+	scope := factoryapi.ListWorkerSessionsParamsScope("all")
+	handler.ListWorkerSessions(
+		recorder,
+		httptest.NewRequest(http.MethodGet, "/worker-sessions?scope=all", nil),
+		factoryapi.ListWorkerSessionsParams{Scope: &scope},
+	)
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response factoryapi.ErrorResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if response.Code != factoryapi.ErrorResponseCodeINTERNALERROR || response.Message != "failed to list Worker Sessions" {
+		t.Fatalf("error response = %#v, want safe typed list failure", response)
+	}
+	entries := logs.All()
+	if len(entries) != 1 || entries[0].Message != "list Worker Sessions failed" {
+		t.Fatalf("log entries = %#v, want one list failure entry", entries)
+	}
+	fields := entries[0].ContextMap()
+	if fields["operation"] != "worker_sessions.list" || fields["scope"] != "all" || fields["state_count"] != int64(0) {
+		t.Fatalf("log fields = %#v, want safe operation context", fields)
+	}
+}
+
 func invalidScopeParams() factoryapi.ListWorkerSessionsParams {
 	scope := factoryapi.ListWorkerSessionsParamsScope("unexpected")
 	return factoryapi.ListWorkerSessionsParams{Scope: &scope}
@@ -143,7 +179,7 @@ func TestListWorkerSessionsProjectsFleetAttributionAndUnavailableFacts(t *testin
 	assertFleetObservationFacts(t, response)
 }
 
-func TestListWorkerSessionsCharacterizesPerObservationWorkAttributionReads(t *testing.T) {
+func TestListWorkerSessionsBatchesWorkAttributionReadsByFactorySession(t *testing.T) {
 	started := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
 	workerSessionIDs := []string{"fleet-worker-a", "fleet-worker-b", "fleet-worker-c"}
 	observations := make([]workersessions.Observation, len(workerSessionIDs))
@@ -158,10 +194,14 @@ func TestListWorkerSessionsCharacterizesPerObservationWorkAttributionReads(t *te
 		}
 	}
 	service := &fakeObservationService{topLevelResult: workersessions.ListWorkerSessionObservationsResult{Observations: observations}}
-	workReads := 0
+	workListReads := 0
+	workGetReads := 0
+	workListMaxResults := []int{}
 	workReader := workServiceStub{
-		getResults:   fleetWorkResults(),
-		getCallCount: &workReads,
+		getResults:     fleetWorkResults(),
+		getCallCount:   &workGetReads,
+		listCallCount:  &workListReads,
+		listMaxResults: &workListMaxResults,
 	}
 	recorder := httptest.NewRecorder()
 	NewHandler(NewAdapter(service, workReader), zap.NewNop()).ListWorkerSessions(
@@ -180,9 +220,81 @@ func TestListWorkerSessionsCharacterizesPerObservationWorkAttributionReads(t *te
 	if len(response.Sessions) != len(observations) {
 		t.Fatalf("session count = %d, want %d", len(response.Sessions), len(observations))
 	}
-	if workReads != len(observations) {
-		t.Fatalf("Work attribution reads = %d, want one read per returned observation in the current path", workReads)
+	if workListReads != 1 {
+		t.Fatalf("Work list reads = %d, want one bounded read for the shared Factory Session", workListReads)
 	}
+	if len(workListMaxResults) != 1 || workListMaxResults[0] != work.DefaultListMaxResults {
+		t.Fatalf("Work list max results = %#v, want one default bounded page", workListMaxResults)
+	}
+	if workGetReads != 0 {
+		t.Fatalf("Work get reads = %d, want no per-observation reads", workGetReads)
+	}
+}
+
+func TestListWorkerSessionsWorkAttributionScalesWithoutPerObservationReads(t *testing.T) {
+	started := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	const observationCount = 100
+	observations := make([]workersessions.Observation, 0, observationCount)
+	workResults := make(map[string]work.ReadModel, observationCount)
+	for index := 0; index < observationCount; index++ {
+		workID := fmt.Sprintf("work-%03d", index)
+		workerSessionID := fmt.Sprintf("worker-session-%03d", index)
+		observations = append(observations, workersessions.Observation{
+			WorkerSessionID:  workerSessionID,
+			FactorySessionID: "~default",
+			WorkIDs:          []string{workID},
+			AttemptID:        "attempt-" + workerSessionID,
+			State:            workersessions.StateCompleted,
+			StartedAt:        &started,
+		})
+		workResults[workID] = work.ReadModel{WorkID: workID, Name: "Work " + workID}
+	}
+	service := &fakeObservationService{topLevelResult: workersessions.ListWorkerSessionObservationsResult{Observations: observations}}
+	workListReads := 0
+	workGetReads := 0
+	workListMaxResults := []int{}
+	workReader := workServiceStub{
+		getCallCount:   &workGetReads,
+		listCallCount:  &workListReads,
+		listMaxResults: &workListMaxResults,
+		listResult:     work.ListResult{Results: readModels(workResults)},
+	}
+	recorder := httptest.NewRecorder()
+	NewHandler(NewAdapter(service, workReader), zap.NewNop()).ListWorkerSessions(
+		recorder,
+		httptest.NewRequest(http.MethodGet, "/worker-sessions", nil),
+		factoryapi.ListWorkerSessionsParams{},
+	)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response factoryapi.ListWorkerSessionsResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Sessions) != observationCount {
+		t.Fatalf("session count = %d, want %d", len(response.Sessions), observationCount)
+	}
+	if workListReads != 1 || workGetReads != 0 {
+		t.Fatalf("Work reads = list:%d get:%d, want one list and no gets", workListReads, workGetReads)
+	}
+	if len(workListMaxResults) != 1 || workListMaxResults[0] != observationCount {
+		t.Fatalf("Work list max results = %#v, want one page sized to the bounded observation set", workListMaxResults)
+	}
+	for _, observation := range response.Sessions {
+		if observation.WorkName == nil || *observation.WorkName == "" {
+			t.Fatalf("observation %q missing Work attribution: %#v", observation.WorkerSessionId, observation)
+		}
+	}
+}
+
+func readModels(results map[string]work.ReadModel) []work.ReadModel {
+	models := make([]work.ReadModel, 0, len(results))
+	for _, result := range results {
+		models = append(models, result)
+	}
+	return models
 }
 
 func fleetWorkResults() map[string]work.ReadModel {

--- a/pkg/services/worker_sessions/transports/http/list_handler_test.go
+++ b/pkg/services/worker_sessions/transports/http/list_handler_test.go
@@ -143,6 +143,48 @@ func TestListWorkerSessionsProjectsFleetAttributionAndUnavailableFacts(t *testin
 	assertFleetObservationFacts(t, response)
 }
 
+func TestListWorkerSessionsCharacterizesPerObservationWorkAttributionReads(t *testing.T) {
+	started := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	workerSessionIDs := []string{"fleet-worker-a", "fleet-worker-b", "fleet-worker-c"}
+	observations := make([]workersessions.Observation, len(workerSessionIDs))
+	for index, workerSessionID := range workerSessionIDs {
+		observations[index] = workersessions.Observation{
+			WorkerSessionID:  workerSessionID,
+			FactorySessionID: "~default",
+			WorkIDs:          []string{"work-a"},
+			AttemptID:        "attempt-" + workerSessionID,
+			State:            workersessions.StateCompleted,
+			StartedAt:        &started,
+		}
+	}
+	service := &fakeObservationService{topLevelResult: workersessions.ListWorkerSessionObservationsResult{Observations: observations}}
+	workReads := 0
+	workReader := workServiceStub{
+		getResults:   fleetWorkResults(),
+		getCallCount: &workReads,
+	}
+	recorder := httptest.NewRecorder()
+	NewHandler(NewAdapter(service, workReader), zap.NewNop()).ListWorkerSessions(
+		recorder,
+		httptest.NewRequest(http.MethodGet, "/worker-sessions", nil),
+		factoryapi.ListWorkerSessionsParams{},
+	)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response factoryapi.ListWorkerSessionsResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Sessions) != len(observations) {
+		t.Fatalf("session count = %d, want %d", len(response.Sessions), len(observations))
+	}
+	if workReads != len(observations) {
+		t.Fatalf("Work attribution reads = %d, want one read per returned observation in the current path", workReads)
+	}
+}
+
 func fleetWorkResults() map[string]work.ReadModel {
 	return map[string]work.ReadModel{
 		"work-a": {WorkID: "work-a", Name: "Build API"},

--- a/pkg/services/worker_sessions/transports/http/list_handler_test.go
+++ b/pkg/services/worker_sessions/transports/http/list_handler_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,7 +23,7 @@ func TestListWorkerSessionsTranslatesPositiveLimit(t *testing.T) {
 	limit := factoryapi.WorkerSessionLimit(2)
 	service := &fakeObservationService{topLevelResult: workersessions.ListWorkerSessionObservationsResult{Observations: []workersessions.Observation{}}}
 	recorder := httptest.NewRecorder()
-	NewHandler(NewAdapter(service, workServiceStub{}), zap.NewNop()).ListWorkerSessions(
+	NewHandler(NewAdapter(service, listWorkServiceStub{}), zap.NewNop()).ListWorkerSessions(
 		recorder,
 		httptest.NewRequest(http.MethodGet, "/worker-sessions?limit=2", nil),
 		factoryapi.ListWorkerSessionsParams{Limit: &limit},
@@ -40,7 +41,7 @@ func TestListWorkerSessionsRejectsNonPositiveLimit(t *testing.T) {
 	limit := factoryapi.WorkerSessionLimit(0)
 	service := &fakeObservationService{}
 	recorder := httptest.NewRecorder()
-	NewHandler(NewAdapter(service, workServiceStub{}), zap.NewNop()).ListWorkerSessions(
+	NewHandler(NewAdapter(service, listWorkServiceStub{}), zap.NewNop()).ListWorkerSessions(
 		recorder,
 		httptest.NewRequest(http.MethodGet, "/worker-sessions?limit=0", nil),
 		factoryapi.ListWorkerSessionsParams{Limit: &limit},
@@ -64,7 +65,7 @@ func TestListWorkerSessionsRejectsNonPositiveLimit(t *testing.T) {
 func TestListWorkerSessionsReturnsTopLevelEmptyCollection(t *testing.T) {
 	service := &fakeObservationService{topLevelResult: workersessions.ListWorkerSessionObservationsResult{Observations: []workersessions.Observation{}, MaxResults: 50}}
 	recorder := httptest.NewRecorder()
-	NewHandler(NewAdapter(service, workServiceStub{}), zap.NewNop()).ListWorkerSessions(
+	NewHandler(NewAdapter(service, listWorkServiceStub{}), zap.NewNop()).ListWorkerSessions(
 		recorder,
 		httptest.NewRequest(http.MethodGet, "/worker-sessions", nil),
 		factoryapi.ListWorkerSessionsParams{},
@@ -94,7 +95,7 @@ func TestListWorkerSessionsMapsInvalidScopeAndStateErrors(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			service := &fakeObservationService{topLevelErr: testCase.err}
 			recorder := httptest.NewRecorder()
-			NewHandler(NewAdapter(service, workServiceStub{}), zap.NewNop()).ListWorkerSessions(
+			NewHandler(NewAdapter(service, listWorkServiceStub{}), zap.NewNop()).ListWorkerSessions(
 				recorder,
 				httptest.NewRequest(http.MethodGet, "/worker-sessions", nil),
 				testCase.params,
@@ -107,7 +108,7 @@ func TestListWorkerSessionsMapsInvalidScopeAndStateErrors(t *testing.T) {
 func TestListWorkerSessionsMapsAndLogsBackendFailure(t *testing.T) {
 	core, logs := observer.New(zapcore.ErrorLevel)
 	service := &fakeObservationService{topLevelErr: errors.New("recording projection failed")}
-	handler := NewHandler(NewAdapter(service, workServiceStub{}), zap.New(core))
+	handler := NewHandler(NewAdapter(service, listWorkServiceStub{}), zap.New(core))
 	recorder := httptest.NewRecorder()
 	scope := factoryapi.ListWorkerSessionsParamsScope("all")
 	handler.ListWorkerSessions(
@@ -163,7 +164,7 @@ func assertBadRequestResponse(t *testing.T, recorder *httptest.ResponseRecorder)
 func TestListWorkerSessionsProjectsFleetAttributionAndUnavailableFacts(t *testing.T) {
 	service := fleetObservationService()
 	recorder := httptest.NewRecorder()
-	NewHandler(NewAdapter(service, workServiceStub{getResults: fleetWorkResults()}), zap.NewNop()).ListWorkerSessions(
+	NewHandler(NewAdapter(service, listWorkServiceStub{getResults: fleetWorkResults()}), zap.NewNop()).ListWorkerSessions(
 		recorder,
 		httptest.NewRequest(http.MethodGet, "/worker-sessions", nil),
 		factoryapi.ListWorkerSessionsParams{},
@@ -197,7 +198,7 @@ func TestListWorkerSessionsBatchesWorkAttributionReadsByFactorySession(t *testin
 	workListReads := 0
 	workGetReads := 0
 	workListMaxResults := []int{}
-	workReader := workServiceStub{
+	workReader := listWorkServiceStub{
 		getResults:     fleetWorkResults(),
 		getCallCount:   &workGetReads,
 		listCallCount:  &workListReads,
@@ -253,7 +254,7 @@ func TestListWorkerSessionsWorkAttributionScalesWithoutPerObservationReads(t *te
 	workListReads := 0
 	workGetReads := 0
 	workListMaxResults := []int{}
-	workReader := workServiceStub{
+	workReader := listWorkServiceStub{
 		getCallCount:   &workGetReads,
 		listCallCount:  &workListReads,
 		listMaxResults: &workListMaxResults,
@@ -378,3 +379,53 @@ func assertFleetUnavailableObservation(t *testing.T, observation factoryapi.Work
 		t.Fatalf("unavailable optional facts = %#v, want explicit nulls", observation)
 	}
 }
+
+type listWorkServiceStub struct {
+	work.Service
+	getErr         error
+	getResults     map[string]work.ReadModel
+	getCallCount   *int
+	listErr        error
+	listResult     work.ListResult
+	listCallCount  *int
+	listSessionIDs *[]string
+	listMaxResults *[]int
+}
+
+func (s listWorkServiceStub) GetWork(_ context.Context, _, workID string) (work.ReadModel, error) {
+	if s.getCallCount != nil {
+		*s.getCallCount = *s.getCallCount + 1
+	}
+	if s.getErr != nil {
+		return work.ReadModel{}, s.getErr
+	}
+	if result, ok := s.getResults[workID]; ok {
+		return result, nil
+	}
+	return work.ReadModel{WorkID: "known-work"}, nil
+}
+
+func (s listWorkServiceStub) ListWork(_ context.Context, sessionID string, options work.ListOptions) (work.ListResult, error) {
+	if s.listCallCount != nil {
+		*s.listCallCount = *s.listCallCount + 1
+	}
+	if s.listSessionIDs != nil {
+		*s.listSessionIDs = append(*s.listSessionIDs, sessionID)
+	}
+	if s.listMaxResults != nil {
+		*s.listMaxResults = append(*s.listMaxResults, options.MaxResults)
+	}
+	if s.listErr != nil {
+		return work.ListResult{}, s.listErr
+	}
+	if s.listResult.Results != nil || s.listResult.MaxResults != 0 || s.listResult.NextToken != "" || s.listResult.Counts != nil {
+		return s.listResult, nil
+	}
+	results := make([]work.ReadModel, 0, len(s.getResults))
+	for _, result := range s.getResults {
+		results = append(results, result)
+	}
+	return work.ListResult{Results: results}, nil
+}
+
+var _ work.Service = listWorkServiceStub{}

--- a/tests/functional/provider_sessions/cli/worker_sessions_cli_test.go
+++ b/tests/functional/provider_sessions/cli/worker_sessions_cli_test.go
@@ -678,14 +678,18 @@ func assertFailedWorkerSession(t *testing.T, ctx context.Context, process suppor
 func assertMissingWorkerSessionOutcomes(t *testing.T, ctx context.Context, process support.Process, env []string, factoryDir, baseURL string) {
 	t.Helper()
 	cases := []struct {
-		name string
-		args []string
-		code string
+		name    string
+		args    []string
+		code    string
+		family  string
+		message string
 	}{
 		{
-			name: "list missing Work",
-			args: []string{"worker-sessions", "list", "--work-id", "work-missing-from-cli", "--output", "json"},
-			code: "WORK_NOT_FOUND",
+			name:    "list missing Work",
+			args:    []string{"worker-sessions", "list", "--work-id", "work-missing-from-cli", "--output", "json"},
+			code:    "NOT_FOUND",
+			family:  "NOT_FOUND",
+			message: "work not found",
 		},
 		{
 			name: "show missing session",
@@ -707,6 +711,12 @@ func assertMissingWorkerSessionOutcomes(t *testing.T, ctx context.Context, proce
 			output := inputs.Stdout() + inputs.Stderr() + err.Error()
 			if !strings.Contains(output, test.code) {
 				t.Fatalf("missing Worker Session operation omitted %s: %s", test.code, output)
+			}
+			if test.family != "" && !strings.Contains(output, test.family) {
+				t.Fatalf("missing Worker Session operation omitted family %s: %s", test.family, output)
+			}
+			if test.message != "" && !strings.Contains(output, test.message) {
+				t.Fatalf("missing Worker Session operation omitted message %q: %s", test.message, output)
 			}
 		})
 	}


### PR DESCRIPTION
{
  "project": "Repair Bare Worker Sessions Listing",
  "branchName": "worker-sessions-list-unscoped-fix",
  "description": "Diagnose and repair the bare you worker-sessions list path so it returns real Worker Session rows quickly against a healthy daemon, preserves the working Work-scoped form and useful typed failures, and remains bounded without changing the already-fixed Factory Sessions read surfaces.",
  "context": {
    "customerAsk": "Make bare you worker-sessions list reliably return real Worker Session rows against a locally built CLI and real daemon, in seconds rather than tens of seconds, while preserving --work-id behavior. Investigate the exact HTTP and service failure first, capture daemon stderr, fix the confirmed root cause, and add direct unscoped-list regression coverage near Worker Sessions.",
    "problem": "Across independent healthy daemons, the unscoped command consistently reports FACTORY_UNREACHABLE while work and Factory Session reads and the Work-scoped Worker Sessions list succeed against the same daemon. Existing related latency fixes and tests do not cover this top-level Worker Sessions path, and the generic failure does not reveal whether its cause is a missing binding, backend error, or timeout.",
    "solution": "Trace and measure the delivered bare CLI to GET /worker-sessions to Worker Sessions service path, classify the real failure from HTTP and daemon evidence, correct only the confirmed binding, backend, or latency defect, preserve list-specific typed error detail, and prove the bounded behavior with focused automated coverage plus a built-artifact real-daemon runtime exercise."
  },
  "acceptanceCriteria": [
    "Against one freshly built CLI and real daemon without --with-mock-workers that contains actual Worker Session records, bare you worker-sessions list exits successfully and returns every expected real row once, while you worker-sessions list --work-id <id> continues to succeed against the same daemon.",
    "The PR records the bare command's exact GET /worker-sessions request, HTTP status and body, corresponding daemon stderr diagnostic, elapsed time, and a same-daemon healthy control, explicitly classifies the original defect before selecting the correction, and does not change /factory-sessions/~default/work, /factory-sessions, /{id}, or /{id}/status behavior.",
    "The unscoped list retains deterministic ordering, filters, bounded opaque pagination, successful empty results, and optional Work attribution; its first page completes in under 10 seconds and no more than five times the same-window /factory-sessions/~default/work control, with direct scale evidence preventing an O(result-count) replay, reconstruction, or remote Work-read sequence when latency is the confirmed cause.",
    "Genuine list failures produce safe typed server diagnostics and preserve available underlying code, family, and message through the Worker Sessions list-owned boundary instead of substituting FACTORY_UNREACHABLE; this lane does not edit the shared central CLI error handler and records the cli-error-detail-passthrough dependency if that shared owner is the only remaining detail-loss point.",
    "Runtime proof classification: this lane changes runtime-observable CLI and API behavior, so runtime proof is applicable. Build the real delivered you artifact, run it against a real daemon without --with-mock-workers, create or reach real Worker Session rows, exercise both the bare CLI command and GET /worker-sessions end to end, and record the verbatim build, start, and probe commands and outputs, including timings and daemon stderr. Green tests, an inspected diff, or implementer assertions alone do not satisfy this proof.",
    "Quality gate: Typecheck passes; focused Worker Sessions service, HTTP, CLI, and functional/integration tests pass; relevant broader Go/API verification passes; and there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "worker-sessions-list-unscoped-fix-001",
      "title": "Diagnose and pin the bare-list failure",
      "description": "As a maintainer, I want the unscoped command's real request, server failure, and latency captured at the delivered boundary so that the corrective change addresses the actual defect rather than a nearby symptom.",
      "acceptanceCriteria": [
        "A freshly built CLI and real daemon reproduce or conclusively disprove the reported bare-command failure while a same-daemon healthy control and the --work-id form establish that the daemon and scoped Worker Sessions path are responsive.",
        "The evidence captures the verbatim command, GET /worker-sessions status and body, elapsed time, and corresponding daemon stderr entry, then classifies the failure as missing or unavailable binding, masked backend error, latency or timeout, or a documented combination.",
        "A focused regression at the lowest integration boundary that previously allowed the defect demonstrates the unscoped request with real Worker Session state and would fail for the diagnosed cause; it asserts observable response or command behavior rather than route or registration inventory.",
        "The diagnosis confirms that /factory-sessions/~default/work, /factory-sessions, /{id}, and /{id}/status behavior is outside this lane and identifies any shared CLI error-handler dependency without modifying that shared owner.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Diagnosis complete. The delivered public binding is present: a freshly built you artifact against a real daemon without --with-mock-workers returned HTTP 200 for GET /worker-sessions with a real Worker Session row, and the same daemon's Work-scoped list succeeded. The reproduced failure used a single 250-work FACTORY_REQUEST_BATCH on the same script-worker daemon: direct GET http://127.0.0.1:17439/worker-sessions produced no status or body before curl's 5-second deadline; the delivered command `you --server http://127.0.0.1:17439 --verbose worker-sessions list --output json` exited 1 after 10240 ms and rendered exactly `FACTORY_UNREACHABLE: factory not reachable at http://127.0.0.1:17439/worker-sessions` in diagnostics JSON (`{\"code\":\"FACTORY_UNREACHABLE\",\"message\":\"factory not reachable at http://127.0.0.1:17439/worker-sessions\"}`). The same daemon's `GET /factory-sessions/~default/work` returned HTTP 200 in 342 ms, and `worker-sessions list --work-id batch-timeout-scale-batch-timeout-scale-1 --output json` exited 0 in 1171 ms with one row. A healthy one-row control returned GET /worker-sessions HTTP 200 in 3 ms with a complete JSON body and the bare CLI exited 0 in 260 ms; the 50-row probe returned HTTP 200 in 922 ms and bare CLI exit 0 in 1529 ms. Daemon stderr contained only real script-worker `command_runner.completed` / `factory_runtime.dispatch_result` `missing_executable` diagnostics, not an HTTP/list failure. Classification: confirmed latency/timeout caused by the HTTP adapter's per-observation Work.GetWork attribution read after the bounded Worker Sessions page; not a missing binding. Characterization coverage was added in pkg/services/worker_sessions/transports/http/list_handler_test.go and passes with the existing path. Factory Session read surfaces /factory-sessions/~default/work, /factory-sessions, /{id}, and /{id}/status were not changed. Focused Worker Sessions service, HTTP, CLI, and fleet functional tests pass."
    },
    {
      "id": "worker-sessions-list-unscoped-fix-002",
      "title": "Restore bounded unscoped listing end to end",
      "description": "As an operator, I want bare you worker-sessions list to return the fleet's real Worker Sessions quickly and preserve useful failure detail so that I can inspect and diagnose Worker activity without per-Work polling or daemon-log archaeology.",
      "acceptanceCriteria": [
        "The confirmed root cause is corrected on the existing GET /worker-sessions path, or the missing top-level operation is added only if diagnosis proves it unavailable; the CLI bare form succeeds and returns each expected real session once while --work-id <id> remains compatible.",
        "The unscoped result preserves deterministic ordering, state and origin filters, opaque bounded pagination, successful empty pages, and available Work attribution; no failure or latency fix silently relaxes those public behaviors.",
        "The first page completes in under 10 seconds and no more than five times the elapsed time of the same-daemon /factory-sessions/~default/work control. When the diagnosis is latency or timeout, focused scale evidence proves the fix avoids an O(result-count) sequence of replay, reconstruction, or remote Work reads.",
        "A genuine backend failure is logged with safe operation context and a typed cause. The Worker Sessions list-specific CLI and HTTP path preserves available error code, family, and message; the shared central CLI error handler and unrelated command families are not changed in this lane.",
        "Focused Worker Sessions service, HTTP, and CLI tests plus a functional or integration scenario cover the bare unscoped command specifically, actual returned rows, empty and paginated behavior relevant to the fix, the working scoped control, and the diagnosed failure regression without --with-mock-workers, arbitrary sleeps, or topology and meta-test assertions.",
        "Authored OpenAPI and generated clients are changed and regenerated only if diagnosis proves the public contract is missing or incorrect; an implementation-only correction does not churn otherwise-correct contracts or unrelated generated output.",
        "Runtime proof classification: this lane changes runtime-observable CLI and API behavior, so runtime proof is applicable. Build the real delivered you artifact, run it against a real daemon without --with-mock-workers, create or reach real Worker Session rows, exercise both the bare CLI command and GET /worker-sessions end to end, and record the verbatim build, start, and probe commands and outputs, including timings and daemon stderr. Green tests, an inspected diff, or implementer assertions alone do not satisfy this proof.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented and verified. The existing GET /worker-sessions path now batches optional Work attribution through one bounded Work.ListWork call per distinct Factory Session instead of one Work.GetWork call per observation; ordering, filters, cursors, empty pages, Work IDs, and the --work-id form remain covered. HTTP list failures now log safe operation context, and the list-owned CLI preserves server ErrorResponse code, family, and message without changing the shared central CLI handler. Focused Worker Sessions service/HTTP/CLI tests, HTTP scale and typed-failure regressions, vet, and TestWorkerSessionsFleetListCLIConcurrent pass. A freshly built artifact ran a real daemon from the SCRIPT_WORKER fixture without --with-mock-workers, accepted a real Work, and produced one real Worker Session: GET /worker-sessions returned 200 in 58 ms, bare worker-sessions list exited 0 in 213 ms with Work attribution, and --work-id exited 0 in 258 ms. The fixture's Windows echo command records a typed missing_executable worker failure; daemon stderr contains the corresponding command_runner.completed and factory_runtime.dispatch_result diagnostics, not an HTTP/list failure. No authored OpenAPI or generated clients were changed. The broader pkg/transports/cli baseline run still has pre-existing help/inventory drift and an existing boundary-inventory failure outside this diff; no fixtures were changed. Runtime command/output details are recorded verbatim in progress.txt."
    }
  ]
}
