### PR TITLE
test(factory_transformation): bounded package-local concurrency cuts focused median 44.9%

### DIFF
--- a/tests/functional/runtime_api/factory_transformation/api_current_factory_put_docs_test.go
+++ b/tests/functional/runtime_api/factory_transformation/api_current_factory_put_docs_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestCurrentFactoryEvents_InitialStructureIncludesBundledFileContent(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	if err := os.WriteFile(
 		filepath.Join(rootDir, interfaces.FactoryConfigFile),
@@ -39,6 +41,8 @@ func TestCurrentFactoryEvents_InitialStructureIncludesBundledFileContent(t *test
 }
 
 func TestCurrentFactoryPUT_DocsCreateEditRenameDeleteRoundTrip(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 
@@ -126,6 +130,8 @@ func TestCurrentFactoryPUT_DocsCreateEditRenameDeleteRoundTrip(t *testing.T) {
 }
 
 func TestCurrentFactoryPUT_DocsSaveEmitsFactoryChangeWithBundledFilesAndVersion(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 
@@ -157,6 +163,8 @@ func TestCurrentFactoryPUT_DocsSaveEmitsFactoryChangeWithBundledFilesAndVersion(
 }
 
 func TestCurrentFactoryPUT_RejectsInvalidDocTargets(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 
@@ -191,6 +199,8 @@ func TestCurrentFactoryPUT_RejectsInvalidDocTargets(t *testing.T) {
 }
 
 func TestCurrentFactoryPUT_RejectsDuplicateDocTargetPaths(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 
@@ -214,6 +224,8 @@ func TestCurrentFactoryPUT_RejectsDuplicateDocTargetPaths(t *testing.T) {
 }
 
 func TestCurrentFactoryPUT_ShellEscapedBundledInlineReplayReturnsPayloadInvalid(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 

--- a/tests/functional/runtime_api/factory_transformation/api_current_factory_put_layout_test.go
+++ b/tests/functional/runtime_api/factory_transformation/api_current_factory_put_layout_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestCurrentFactoryEvents_ExposePortableLayoutOnInitialStructureAndFactoryChange(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	if err := os.WriteFile(
 		filepath.Join(rootDir, interfaces.FactoryConfigFile),
@@ -82,6 +84,8 @@ func TestCurrentFactoryEvents_ExposePortableLayoutOnInitialStructureAndFactoryCh
 
 // backendsizecheck:ignore-function this end-to-end current-factory layout round-trip test keeps save, reload, persistence, and runtime assertions on one contract seam.
 func TestCurrentFactoryPUT_PreservesPortableLayoutThroughSaveReloadAndRuntimeExecution(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	if err := os.WriteFile(
 		filepath.Join(rootDir, interfaces.FactoryConfigFile),
@@ -189,6 +193,8 @@ func TestCurrentFactoryPUT_PreservesPortableLayoutThroughSaveReloadAndRuntimeExe
 }
 
 func TestCurrentFactoryPUT_PrunesStaleLayoutWithoutReturningEphemeralLayoutMetadata(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	if err := os.WriteFile(
 		filepath.Join(rootDir, interfaces.FactoryConfigFile),
@@ -214,6 +220,8 @@ func TestCurrentFactoryPUT_PrunesStaleLayoutWithoutReturningEphemeralLayoutMetad
 }
 
 func TestCurrentFactoryPUT_AcceptsLayoutNodeMissingSize(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	if err := os.WriteFile(
 		filepath.Join(rootDir, interfaces.FactoryConfigFile),
@@ -285,6 +293,8 @@ func TestCurrentFactoryPUT_AcceptsLayoutNodeMissingSize(t *testing.T) {
 }
 
 func TestCurrentFactoryPUT_AcceptsLayoutForKnownBundledDocNode(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 
@@ -329,6 +339,8 @@ func TestCurrentFactoryPUT_AcceptsLayoutForKnownBundledDocNode(t *testing.T) {
 }
 
 func TestCurrentFactoryPUT_RejectsLayoutForUnknownBundledDocNode(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 

--- a/tests/functional/runtime_api/factory_transformation/api_current_factory_put_layout_variants_test.go
+++ b/tests/functional/runtime_api/factory_transformation/api_current_factory_put_layout_variants_test.go
@@ -18,6 +18,8 @@ type portableLayoutVariantExpectation struct {
 }
 
 func TestCurrentFactoryPUT_AcceptsPortableLayoutMultipleNodesWithSize(t *testing.T) {
+	t.Parallel()
+
 	runCurrentFactoryPUTPortableLayoutVariant(t, portableLayoutVariantExpectation{
 		nodes: []map[string]any{
 			{
@@ -60,6 +62,8 @@ func TestCurrentFactoryPUT_AcceptsPortableLayoutMultipleNodesWithSize(t *testing
 }
 
 func TestCurrentFactoryPUT_AcceptsPortableLayoutEdgeWithOneWaypoint(t *testing.T) {
+	t.Parallel()
+
 	runCurrentFactoryPUTPortableLayoutVariant(t, portableLayoutVariantExpectation{
 		nodes: layoutVariantSizedNodes(),
 		edges: []map[string]any{{
@@ -81,6 +85,8 @@ func TestCurrentFactoryPUT_AcceptsPortableLayoutEdgeWithOneWaypoint(t *testing.T
 }
 
 func TestCurrentFactoryPUT_AcceptsPortableLayoutEdgeWithMultipleWaypoints(t *testing.T) {
+	t.Parallel()
+
 	runCurrentFactoryPUTPortableLayoutVariant(t, portableLayoutVariantExpectation{
 		nodes: layoutVariantSizedNodes(),
 		edges: []map[string]any{{
@@ -108,6 +114,8 @@ func TestCurrentFactoryPUT_AcceptsPortableLayoutEdgeWithMultipleWaypoints(t *tes
 }
 
 func TestCurrentFactoryPUT_AcceptsPortableLayoutMultipleNodesWithoutSize(t *testing.T) {
+	t.Parallel()
+
 	runCurrentFactoryPUTPortableLayoutVariant(t, portableLayoutVariantExpectation{
 		nodes: []map[string]any{
 			{"id": "workstation:plan-task", "position": map[string]any{"x": 144, "y": 288}},

--- a/tests/functional/runtime_api/factory_transformation/api_current_factory_put_session_import_test.go
+++ b/tests/functional/runtime_api/factory_transformation/api_current_factory_put_session_import_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestCurrentFactoryPUT_NonDefaultSessionImportIsolatesDefaultFactoryAndMaterializesBundledFiles(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 	createNamedFactoryFixture(

--- a/tests/functional/runtime_api/factory_transformation/api_current_factory_put_test.go
+++ b/tests/functional/runtime_api/factory_transformation/api_current_factory_put_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestCurrentFactoryPUT_SaveEditableCurrentFactoryDefinitionEmitsCanonicalFactoryChangeEvent(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 
@@ -50,6 +52,8 @@ func TestCurrentFactoryPUT_SaveEditableCurrentFactoryDefinitionEmitsCanonicalFac
 }
 
 func TestCurrentFactoryPUT_FactoryChangeVersionsAdvanceOnEverySave(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 
@@ -80,6 +84,8 @@ func TestCurrentFactoryPUT_FactoryChangeVersionsAdvanceOnEverySave(t *testing.T)
 }
 
 func TestCurrentFactoryPUT_SaveDefaultFactoryDefinitionPersistsAndRunsReplacement(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	if err := os.WriteFile(
 		filepath.Join(rootDir, interfaces.FactoryConfigFile),
@@ -133,6 +139,8 @@ func TestCurrentFactoryPUT_SaveDefaultFactoryDefinitionPersistsAndRunsReplacemen
 }
 
 func TestCurrentFactoryPUT_DefaultFactoryAcceptsFullCurrentFactoryReadbackDocument(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	if err := os.WriteFile(
 		filepath.Join(rootDir, interfaces.FactoryConfigFile),
@@ -193,6 +201,8 @@ func TestCurrentFactoryPUT_DefaultFactoryAcceptsFullCurrentFactoryReadbackDocume
 }
 
 func TestCurrentFactoryPUT_DefaultFactoryMaterializesBundledFilesAndReturns(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	if err := os.WriteFile(
 		filepath.Join(rootDir, interfaces.FactoryConfigFile),
@@ -276,6 +286,8 @@ func TestCurrentFactoryPUT_DefaultFactoryMaterializesBundledFilesAndReturns(t *t
 }
 
 func TestCurrentFactoryPUT_SessionScopedNamedFactoryTransformationReadbackIsIsolated(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 	createNamedFactoryFixture(
@@ -322,6 +334,8 @@ func TestCurrentFactoryPUT_SessionScopedNamedFactoryTransformationReadbackIsIsol
 }
 
 func TestCurrentFactoryPUT_ReturnsMultipleTopologyValidationTargets(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 
@@ -372,6 +386,8 @@ func TestCurrentFactoryPUT_ReturnsMultipleTopologyValidationTargets(t *testing.T
 }
 
 func TestCurrentFactoryPUT_ReturnsCanonicalTopologyValidationTargets(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 
@@ -411,6 +427,8 @@ func TestCurrentFactoryPUT_ReturnsCanonicalTopologyValidationTargets(t *testing.
 }
 
 func TestCurrentFactoryPUT_RejectsTypeCountCollisionBeforePersistingDefaultFactory(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	if err := os.WriteFile(
 		filepath.Join(rootDir, interfaces.FactoryConfigFile),
@@ -488,6 +506,8 @@ func TestCurrentFactoryPUT_RejectsTypeCountCollisionBeforePersistingDefaultFacto
 }
 
 func TestCurrentFactoryPUT_RequiresAdvancedSaveVersion(t *testing.T) {
+	t.Parallel()
+
 	// One FunctionalAPIServer for the whole advanced-version matrix. Each row
 	// restores a deterministic "alpha"/"task" baseline before asserting so a
 	// successful save (or rejected stale write) cannot contaminate later rows.

--- a/tests/functional/runtime_api/factory_transformation/api_import_replace_current_split_layout_test.go
+++ b/tests/functional/runtime_api/factory_transformation/api_import_replace_current_split_layout_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestFactoryTransformation_ReplaceCurrentImportMatchesCreateNamedSplitLayout(t *testing.T) {
+	t.Parallel()
+
 	replaceRoot := t.TempDir()
 	if err := os.WriteFile(
 		filepath.Join(replaceRoot, interfaces.FactoryConfigFile),

--- a/tests/functional/runtime_api/factory_transformation/api_named_factory_layout_test.go
+++ b/tests/functional/runtime_api/factory_transformation/api_named_factory_layout_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestFactoryTransformation_CreateNamedFactoryPreservesPortableLayoutThroughActivationAndReadback(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 
@@ -46,6 +48,8 @@ func TestFactoryTransformation_CreateNamedFactoryPreservesPortableLayoutThroughA
 }
 
 func TestFactoryTransformation_UpsertNamedFactoryReplacePreservesPortableLayout(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 

--- a/tests/functional/runtime_api/factory_transformation/api_named_factory_test.go
+++ b/tests/functional/runtime_api/factory_transformation/api_named_factory_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestFactoryTransformation_CreateNamedFactoryReadbackAndWorkSurface(t *testing.T) {
+	t.Parallel()
+
 	support.SkipLongFunctional(t, "slow named-factory API sweep")
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
@@ -47,6 +49,8 @@ func TestFactoryTransformation_CreateNamedFactoryReadbackAndWorkSurface(t *testi
 }
 
 func TestFactoryTransformation_NamedFactoryPortableFilesReadBackThroughCanonicalContract(t *testing.T) {
+	t.Parallel()
+
 	support.SkipLongFunctional(t, "slow named-factory API sweep")
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
@@ -71,6 +75,8 @@ func TestFactoryTransformation_NamedFactoryPortableFilesReadBackThroughCanonical
 }
 
 func TestFactoryTransformation_CreateNamedFactory_ReturnsBobOnFailureTarget(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 
@@ -115,6 +121,8 @@ func TestFactoryTransformation_CreateNamedFactory_ReturnsBobOnFailureTarget(t *t
 }
 
 func TestFactoryTransformation_CreateNamedFactory_ReturnsMultipleTopologyValidationTargets(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 
@@ -157,6 +165,8 @@ func TestFactoryTransformation_CreateNamedFactory_ReturnsMultipleTopologyValidat
 }
 
 func TestFactoryTransformation_CreateNamedFactoryEmitsCanonicalFactoryChangeEvent(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 

--- a/tests/functional/runtime_api/factory_transformation/api_session_factory_save_version_test.go
+++ b/tests/functional/runtime_api/factory_transformation/api_session_factory_save_version_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestSessionFactoryPUT_UpsertCreateAllowsOmittedVersion(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 	server := startFactoryTransformationServer(t, rootDir)
@@ -25,6 +27,8 @@ func TestSessionFactoryPUT_UpsertCreateAllowsOmittedVersion(t *testing.T) {
 }
 
 func TestSessionFactoryPUT_UpsertReplaceRejectsStaleVersion(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 	server := startFactoryTransformationServer(t, rootDir)
@@ -54,6 +58,8 @@ func TestSessionFactoryPUT_UpsertReplaceRejectsStaleVersion(t *testing.T) {
 }
 
 func TestSessionFactoryPUT_UpsertReplaceDoesNotReturnAlreadyExists(t *testing.T) {
+	t.Parallel()
+
 	rootDir := t.TempDir()
 	seedNamedFactoryRoot(t, rootDir, "alpha", "alpha-task")
 	server := startFactoryTransformationServer(t, rootDir)


### PR DESCRIPTION
{
  "project": "Reduce latency of the runtime_api/factory_transformation functional Go package",
  "branchName": "fpkg-runtime-api-factory-transformation-package-latency",
  "description": "Reduce the focused median latency of tests/functional/runtime_api/factory_transformation through bounded package-local concurrency while preserving every current assembled Factory/API/persistence behavior and deletion-only constraint.",
  "context": {
    "customerAsk": "Produce exactly one package-scoped task, worktree, branch, and PR that materially lowers focused latency while preserving current Factory PUT/save/import/layout/version/validation behavior and the migration package's deletion-only constraints. Three comparable before and after executions of go test -json -p=1 -parallel=2 -short ./tests/functional/runtime_api/factory_transformation -count=1 -timeout=300s must pass with a material median reduction, and a behavior/edge matrix must account for every current test and HTTP/Factory persistence observation.",
    "problem": "INV-001 measured 27.835s, 32.727s, and 38.485s at origin/main commit 584f10528e6ef3c8c4719dbc556b412584f37c7c (32.727s median); 37 active short top-level tests remain almost entirely serial even though their Factory roots, processes, API servers, invocation environments, state, and cleanup are independently owned.",
    "solution": "First characterize all 39 top-level tests and 11 nested cases and capture three exact-command baselines. Then enable t.Parallel only for proven-isolated top-level scenarios in existing package files, retain nested stateful matrices serial, and accept the change only when three passing after samples improve the median by at least 10% or 500ms and bounded correctness, non-short, deletion-only, scope, cleanup, and clean-room gates pass. Stop with structured evidence if a material safe improvement needs any shared, production, contract, generated, sibling, new-file, or new-scenario change."
  },
  "acceptanceCriteria": [
    "Three comparable pre-change and three comparable final-head executions of go test -json -p=1 -parallel=2 -short ./tests/functional/runtime_api/factory_transformation -count=1 -timeout=300s each exit 0, and PERF-FPKG-001 records a final median at least 10% or 500ms lower, all raw timings, medians, absolute and percentage delta, environment, and commits.",
    "The complete 39-top-level-test and 11-nested-case behavior matrix reconciles before and after; the short runs plus LONG-FPKG-001 prove every current HTTP status/body, Factory/Factory Event, Factory Session, Work, version, layout/validation, and filesystem persistence observation without deleted, skipped, moved, or weakened assertions.",
    "ISO-FPKG-001 passes twice at -parallel=2 with independent roots, processes, servers, state, deterministic Windows-compatible cleanup, no timeout padding, sleep, or retry masking, and no leaked-process or cross-test contamination symptom.",
    "Existing malformed, invalid, duplicate, stale, and missing-version behaviors retain their exact 400/409 error codes, validation targets, and asserted non-mutation/recovery outcomes.",
    "STRUCT-FPKG-001, SCOPE-FPKG-001, and the applicable touched-Go quality gate confirm the deletion-only inventory and existing file set are unchanged, only existing files in tests/functional/runtime_api/factory_transformation changed, generated/contracts remain untouched, and the named functional suite property rather than merely compilation was measured.",
    "SEC-FPKG-001 records zero paid or remote calls, no credentials or sensitive transcripts in evidence, no cross-test state disclosure, at most six timing samples, and no more than 30 minutes focused local verification.",
    "Rollout is one package-local PR with no feature flag or migration; any unsafe, failing, noisy, or sub-material implementation is abandoned or reverted, and remeasure-wave-1-merged-main owns merged full-lane and cross-package verification.",
    "LOOP-FPKG-001 independently validates the final head from a clean environment, reports each criterion using factory/docs/standards/validation-loopback-template.md, includes persistence/reload and operational cleanup evidence, and returns a delta-plan request without silently repairing any FAIL or BLOCKED finding.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "behaviorLanes": [
    {
      "id": "FPKG",
      "behavior": "Maintainers receive faster functional confidence while each package's distinct assembled behavior remains proven.",
      "currentBehavior": "The exact package has 39 top-level tests and 11 nested cases. Under -short two long named-Factory sweeps skip, one pure validation test is already parallel, and the remaining assembled tests execute almost entirely serially despite per-test temporary Factory roots and servers. INV-001 measured a 32.727-second median.",
      "targetBehavior": "At most two proven-isolated top-level scenarios execute concurrently through their own root-built process, HTTP server, Factory state, persistence root, and cleanup; nested mutations remain serial; every current observation remains proven; the exact focused command has three passing after samples whose median improves by at least 10% or 500ms.",
      "executableSpine": "go test -> test-owned t.TempDir Factory root -> support.StartFunctionalAPIServer -> root.BuildProcess/pkg.wire -> Process.Execute you run --with-server -> Factory Definitions/Sessions/Runtime/Recordings and HTTP -> unchanged API, Factory Event, Work, version, layout, validation, and filesystem assertions -> independent cleanup.",
      "coverageInventory": [
        {
          "test": "TestCurrentFactoryEvents_InitialStructureIncludesBundledFileContent",
          "short": "run",
          "behavior": "Initial Factory Event exposes DOC and SCRIPT bundled inline content from factory.json.",
          "edge": "local-real application/API/events/disk with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_DocsCreateEditRenameDeleteRoundTrip",
          "short": "run",
          "behavior": "PUT create/edit/rename/delete, GET reload, portable file contents, and removed-file absence agree.",
          "edge": "local-real HTTP and disk with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_DocsSaveEmitsFactoryChangeWithBundledFilesAndVersion",
          "short": "run",
          "behavior": "Save emits a later Factory Change with saved version and bundled DOC/SCRIPT content.",
          "edge": "local-real HTTP/events with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_RejectsInvalidDocTargets",
          "short": "run: 3 serial rows",
          "behavior": "Outside-root, non-canonical, and escaping doc targets each return 400.",
          "edge": "local-real HTTP validation with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_RejectsDuplicateDocTargetPaths",
          "short": "run",
          "behavior": "Duplicate doc target paths return 400.",
          "edge": "local-real HTTP validation with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_ShellEscapedBundledInlineReplayReturnsPayloadInvalid",
          "short": "run",
          "behavior": "Malformed shell-escaped JSON returns 400 BAD_REQUEST with factory.payload.invalid.",
          "edge": "local-real raw HTTP decode with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryEvents_ExposePortableLayoutOnInitialStructureAndFactoryChange",
          "short": "run",
          "behavior": "Initial and later Factory Change events preserve exact portable layout values.",
          "edge": "local-real events and HTTP save with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_PreservesPortableLayoutThroughSaveReloadAndRuntimeExecution",
          "short": "run",
          "behavior": "PUT, GET, persisted factory.json, and accepted Work preserve and use portable layout/replacement topology.",
          "edge": "local-real HTTP/disk/runtime work with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_PrunesStaleLayoutWithoutReturningEphemeralLayoutMetadata",
          "short": "run",
          "behavior": "Save prunes stale layout on disk and GET omits ephemeral layout metadata.",
          "edge": "local-real HTTP/disk with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_AcceptsLayoutNodeMissingSize",
          "short": "run",
          "behavior": "PUT accepts a known layout node with omitted size and returns nil size.",
          "edge": "local-real HTTP with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_AcceptsLayoutForKnownBundledDocNode",
          "short": "run",
          "behavior": "Known bundled DOC node saves and reloads with exact id, size, and inline content.",
          "edge": "local-real HTTP/disk materialization with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_RejectsLayoutForUnknownBundledDocNode",
          "short": "run",
          "behavior": "Unknown bundled DOC node returns 400 INVALID_FACTORY and factory.layout.unknownNodeReference.",
          "edge": "local-real HTTP validation with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_PrePersistLayoutFailureRetainsStructuredPath",
          "short": "run",
          "behavior": "Pure validation returns factory.layout.invalidGeometry with exact annotation width path.",
          "edge": "pure pre-persist validation"
        },
        {
          "test": "TestCurrentFactoryPUT_AcceptsPortableLayoutMultipleNodesWithSize",
          "short": "run",
          "behavior": "Two sized nodes save, reload, and persist exact dimensions.",
          "edge": "local-real HTTP/disk with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_AcceptsPortableLayoutEdgeWithOneWaypoint",
          "short": "run",
          "behavior": "One edge waypoint saves, reloads, and persists exact coordinates and count.",
          "edge": "local-real HTTP/disk with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_AcceptsPortableLayoutEdgeWithMultipleWaypoints",
          "short": "run",
          "behavior": "Multiple waypoints save, reload, and persist order, coordinates, and count.",
          "edge": "local-real HTTP/disk with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_AcceptsPortableLayoutMultipleNodesWithoutSize",
          "short": "run",
          "behavior": "Sizeless nodes save/reload with nil sizes and persist without size keys.",
          "edge": "local-real HTTP/disk with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_NonDefaultSessionImportIsolatesDefaultFactoryAndMaterializesBundledFiles",
          "short": "run",
          "behavior": "Beta session import changes only beta, leaves alpha bytes/state unchanged, materializes stripped portable files, and both session/default Work types remain accepted.",
          "edge": "local-real sessions/HTTP/disk/work with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_SaveEditableCurrentFactoryDefinitionEmitsCanonicalFactoryChangeEvent",
          "short": "run",
          "behavior": "PUT response and later Factory Change expose edited work type and workstation under alpha.",
          "edge": "local-real HTTP/events with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_FactoryChangeVersionsAdvanceOnEverySave",
          "short": "run",
          "behavior": "Two saves produce matching Factory Change versions and increment logical version each time.",
          "edge": "local-real HTTP/events with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_SaveDefaultFactoryDefinitionPersistsAndRunsReplacement",
          "short": "run",
          "behavior": "Default PUT/GET changes topology, new Work returns 201 with trace, old type returns 400, and split files reload as root-runtime.",
          "edge": "local-real HTTP/disk/work with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_DefaultFactoryAcceptsFullCurrentFactoryReadbackDocument",
          "short": "run",
          "behavior": "Raw GET logical version is string; full readback PUT/GET succeeds and new Work is accepted.",
          "edge": "local-real raw/typed HTTP/work with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_DefaultFactoryMaterializesBundledFilesAndReturns",
          "short": "run",
          "behavior": "Bounded PUT returns, materializes helper/script, strips inline persistence, reloads topology, and accepts Work.",
          "edge": "local-real HTTP/disk/work with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_SessionScopedNamedFactoryTransformationReadbackIsIsolated",
          "short": "run",
          "behavior": "Beta session changes beta only; old beta type fails and default alpha name/type/work remain valid.",
          "edge": "local-real sessions/HTTP/work with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_ReturnsMultipleTopologyValidationTargets",
          "short": "run",
          "behavior": "Invalid current Factory returns 400 INVALID_FACTORY/bad-request with duplicate worker, dangling worker, and dangling place targets.",
          "edge": "local-real HTTP validation with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_ReturnsCanonicalTopologyValidationTargets",
          "short": "run",
          "behavior": "Invalid route returns canonical dangling-place target subject, id, and location.",
          "edge": "local-real HTTP validation with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_RejectsTypeCountCollisionBeforePersistingDefaultFactory",
          "short": "run",
          "behavior": "Conflicting outputs return 400 target; GET version and work type remain unchanged.",
          "edge": "local-real HTTP/persistence non-mutation with controlled worker edge"
        },
        {
          "test": "TestCurrentFactoryPUT_RequiresAdvancedSaveVersion",
          "short": "run: 8 serial rows",
          "behavior": "Four stale orderings and three missing-version shapes return STALE_FACTORY_VERSION and keep task; one advanced version succeeds to story; each row restores baseline.",
          "edge": "local-real HTTP version/state with controlled worker edge"
        },
        {
          "test": "TestFactoryTransformation_ReplaceCurrentImportMatchesCreateNamedSplitLayout",
          "short": "run",
          "behavior": "REPLACE_CURRENT and named create materialize equivalent split paths and stripped factory.json, with workstation body in AGENTS.md.",
          "edge": "two local-real servers and disk equivalence with controlled worker edge"
        },
        {
          "test": "TestFactoryTransformation_CreateNamedFactoryPreservesPortableLayoutThroughActivationAndReadback",
          "short": "run",
          "behavior": "Named create/current GET/persisted JSON retain layout and activated Work returns 201.",
          "edge": "local-real HTTP/disk/work with controlled worker edge"
        },
        {
          "test": "TestFactoryTransformation_UpsertNamedFactoryReplacePreservesPortableLayout",
          "short": "run",
          "behavior": "Fresh-version named upsert replacement returns and reads back the same layout.",
          "edge": "local-real HTTP/version with controlled worker edge"
        },
        {
          "test": "TestFactoryTransformation_CreateNamedFactoryReadbackAndWorkSurface",
          "short": "skip; targeted non-short",
          "behavior": "Beta create activates/readbacks beta, beta Work returns 201 with trace, and legacy alpha Work returns 400 BAD_REQUEST.",
          "edge": "local-real HTTP/work with controlled worker edge"
        },
        {
          "test": "TestFactoryTransformation_NamedFactoryPortableFilesReadBackThroughCanonicalContract",
          "short": "skip; targeted non-short",
          "behavior": "Create response redacts inline DOC/SCRIPT, current GET restores them, portable files match, and persisted JSON strips inline content.",
          "edge": "local-real HTTP/disk with controlled worker edge"
        },
        {
          "test": "TestFactoryTransformation_CreateNamedFactory_ReturnsBobOnFailureTarget",
          "short": "run",
          "behavior": "Invalid named Factory returns 400 INVALID_FACTORY/bad-request with workstation bob ON_FAILURE target.",
          "edge": "local-real HTTP validation with controlled worker edge"
        },
        {
          "test": "TestFactoryTransformation_CreateNamedFactory_ReturnsMultipleTopologyValidationTargets",
          "short": "run",
          "behavior": "Invalid named Factory returns all duplicate and dangling target codes.",
          "edge": "local-real HTTP validation with controlled worker edge"
        },
        {
          "test": "TestFactoryTransformation_CreateNamedFactoryEmitsCanonicalFactoryChangeEvent",
          "short": "run",
          "behavior": "Named create emits a later-tick Factory Change for beta/beta-task.",
          "edge": "local-real HTTP/events with controlled worker edge"
        },
        {
          "test": "TestSessionFactoryPUT_UpsertCreateAllowsOmittedVersion",
          "short": "run",
          "behavior": "Named upsert create without version succeeds with assigned logical version and work type.",
          "edge": "local-real HTTP/version with controlled worker edge"
        },
        {
          "test": "TestSessionFactoryPUT_UpsertReplaceRejectsStaleVersion",
          "short": "run",
          "behavior": "Same-version named replace returns 409 STALE_FACTORY_VERSION and GET remains beta-task.",
          "edge": "local-real HTTP/state non-mutation with controlled worker edge"
        },
        {
          "test": "TestSessionFactoryPUT_UpsertReplaceDoesNotReturnAlreadyExists",
          "short": "run",
          "behavior": "Fresh-version named replace succeeds as beta/beta-replaced with advanced version and current activation.",
          "edge": "local-real HTTP/version with controlled worker edge"
        }
      ],
      "remainingUnprovenEdges": [
        {
          "edge": "Merged full functional-lane effect and cross-package regressions",
          "gateId": "remeasure-wave-1-merged-main"
        },
        {
          "edge": "Any public contract change",
          "gateId": "new-plan-with-native-current-proposed-shapes"
        },
        {
          "edge": "Real provider availability and execution",
          "gateId": "existing-provider-integration-release-gates"
        },
        {
          "edge": "All scheduler and data-race interleavings beyond bounded repetitions",
          "gateId": "existing-CI-race-lanes-when-applicable"
        }
      ]
    }
  ],
  "contractChanges": [],
  "userStories": [
    {
      "id": "fpkg-runtime-api-factory-transformation-package-latency-001",
      "title": "Preserve Factory transformation behavior with materially faster focused execution",
      "description": "Characterize the existing 39 top-level tests and 11 nested cases, capture three exact-command baselines, add bounded t.Parallel scheduling only to proven-isolated top-level scenarios in existing exact-package files, and retain the change only after the same assembled Factory/API/persistence behavior passes with a material median reduction.",
      "parentBehavior": "FPKG — maintainers receive faster functional confidence while each package's distinct assembled behavior remains proven.",
      "outcome": "Existing isolated top-level scenarios use bounded package-local concurrency and retain every current observation, yielding three passing post-change samples with a median at least 10% or 500ms below three comparable passing pre-change samples.",
      "dependencies": [
        "INV-001 complete on 584f10528e6ef3c8c4719dbc556b412584f37c7c"
      ],
      "sharedSurfaceOwner": "This story exclusively owns existing files in tests/functional/runtime_api/factory_transformation. tests/functional/internal/support, pkg/**, api/**, generated HTTP types, sibling functional/unit packages, Makefile, CI, coverage/deletion-only baselines, and new files/scenarios are read-only; any required edit there is a structured blocker.",
      "scope": {
        "in": [
          "Three pre-edit exact-command timing samples and complete 39-test/11-subtest behavior/edge characterization",
          "Package-local t.Parallel scheduling in existing _test.go files only where temporary roots, processes, servers, invocation environments, state, and cleanup are independent",
          "Serial nested mutations including advanced-version baseline restoration and invalid-doc-target rows",
          "Unchanged HTTP, Factory Event, Factory Session, Work, version, layout, validation-target, and filesystem persistence assertions",
          "Three post-edit exact timing samples, repeated short correctness, targeted non-short proof, deletion-only structure/scope/quality gates, and clean-room loopback",
          "Windows-compatible dynamic-port and process/directory cleanup verification"
        ],
        "out": [
          "New, deleted, renamed, or moved files or scenarios",
          "Sibling functional or unit edits and tests/functional/internal/support changes",
          "Production, OpenAPI, CLI, event, persistence-schema, configuration, generated, Makefile, CI, or baseline changes",
          "Shared server harnesses, package splitting, lower-fidelity replacement tests, or internal state snapshots",
          "Assertion or coverage weakening, skip expansion, timeout padding, sleeps, polling, retries, or package-global mutable fixtures",
          "Paid or remote calls, provider-real claims, whole-functional-lane claims, or reconstruction of the retired packaged/fix PRD"
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given the unmodified package in the assigned environment, when the exact focused command runs three times before editing, then all three runs exit 0 and evidence records environment, commit, raw durations, and median.",
        "Given final package-local scheduling, when the same exact command runs three times, then all three runs exit 0 and the post-change median is at least 10% or 500ms lower than the comparable pre-change median.",
        "Given all 39 current top-level tests and 11 nested cases, when short samples plus the targeted two-test non-short command execute, then every matrix row remains at its current cadence and every HTTP, Factory Event, Factory Session, Work, version, layout, validation, and persistence observation remains asserted without weakening.",
        "Given concurrent top-level execution at -parallel=2, when the focused package runs with -count=2, then both repetitions exit 0 with independent roots, server URLs, state, and cleanup and without timeouts, sleeps, retry masking, or leaked-process errors.",
        "Given stale, missing, malformed, invalid-layout, invalid-topology, invalid-doc, and duplicate-target inputs, when existing tests run, then the same 400/409 codes, targets, and unchanged-state outcomes remain observable.",
        "Given the final diff, when make pkg-structure, changed-path inventory, and assertion/matrix review run, then the deletion-only 39-test and existing-file inventory is unchanged, only existing exact-package files changed, and no test, assertion, observation, or coverage floor was deleted, skipped, moved, or weakened.",
        "Given any need for shared support, production, contract, generated, sibling-package, new-file, or new-scenario work, implementation stops and returns structured evidence instead of expanding scope.",
        "LOOP-FPKG-001 runs from a clean environment against the final head, uses factory/docs/standards/validation-loopback-template.md, records PASS/FAIL/BLOCKED per project criterion, and never silently repairs a defect.",
        "The named suite tests/functional/runtime_api/factory_transformation passes at the declared short, repeat, and targeted non-short procedures and proves the matrix at local-real assembled Factory/API/persistence fidelity with the existing controlled worker edge; generic Tests pass text is insufficient."
      ],
      "verification": {
        "behavioralWitness": "Three comparable before and after executions of go test -json -p=1 -parallel=2 -short ./tests/functional/runtime_api/factory_transformation -count=1 -timeout=300s pass with a material median reduction, and the 39-row/11-subtest behavior/edge matrix accounts for every current test and HTTP/Factory persistence observation.",
        "executableSpineEffect": "preserve",
        "requiredEvidence": [
          {
            "scope": "functional",
            "dependencyFidelity": "local_real",
            "cadence": "once before structural change",
            "cost": "free, three of six timing samples",
            "procedure": "Record commit, Windows/architecture, Go version, environment/cache policy, and run go test -json -p=1 -parallel=2 -short ./tests/functional/runtime_api/factory_transformation -count=1 -timeout=300s three separate times before editing; reconcile go test -list/source inventory to the 39-row and 11-subtest matrix.",
            "propertyProved": "Current package behavior exits successfully in three comparable exact-command executions, and every existing test and observation is characterized before scheduling changes.",
            "propertyNotProved": "Post-change safety, improvement, long tests skipped under -short, whole-lane behavior, or remote provider behavior."
          },
          {
            "scope": "functional",
            "dependencyFidelity": "local_real",
            "cadence": "final head",
            "cost": "free, three of six timing samples",
            "procedure": "Run go test -json -p=1 -parallel=2 -short ./tests/functional/runtime_api/factory_transformation -count=1 -timeout=300s three separate times on the final head; require exit 0 for every sample and compute raw medians, absolute delta, and percentage delta.",
            "propertyProved": "Every active short behavior passes at local-real assembled Factory/API/persistence fidelity and the focused median improves by at least 10% or 500ms.",
            "propertyNotProved": "The two long skipped tests, repeated cleanup, sibling packages, merged-main lane effect, or real provider behavior."
          },
          {
            "scope": "functional",
            "dependencyFidelity": "local_real",
            "cadence": "final head",
            "cost": "free with bounded local resources",
            "procedure": "Run go test -json -p=1 -parallel=2 -short ./tests/functional/runtime_api/factory_transformation -count=2 -timeout=300s.",
            "propertyProved": "Two repeated concurrent executions preserve independent root/process/server/session ownership, observations, and deterministic cleanup without scheduling-induced failures.",
            "propertyNotProved": "All possible interleavings, full race freedom, whole-lane latency, or remote edges."
          },
          {
            "scope": "functional",
            "dependencyFidelity": "local_real",
            "cadence": "final head",
            "cost": "free with bounded local resources",
            "procedure": "Run go test -json -p=1 -parallel=2 ./tests/functional/runtime_api/factory_transformation -run 'TestFactoryTransformation_(CreateNamedFactoryReadbackAndWorkSurface|NamedFactoryPortableFilesReadBackThroughCanonicalContract)$' -count=1 -timeout=300s.",
            "propertyProved": "The two existing long named-Factory tests intentionally omitted by -short retain their activation, work-surface, portable-file, redaction, readback, and persistence behavior.",
            "propertyNotProved": "Latency of the short package command or behavior outside these two tests."
          },
          {
            "scope": "functional",
            "dependencyFidelity": "controlled",
            "cadence": "final head and per PR",
            "cost": "free",
            "procedure": "Run make pkg-structure; inspect git diff --name-only and reconcile every assertion/matrix row; run the applicable touched-Go formatting/lint gate; record property-specific output.",
            "propertyProved": "Deletion-only file/Test inventory, exact-package scope, assertion preservation, generated/contract non-change, and applicable Go/test construction rules remain satisfied.",
            "propertyNotProved": "Runtime behavior or performance by itself; this evidence is paired with the functional commands."
          },
          {
            "scope": "functional",
            "dependencyFidelity": "local_real",
            "cadence": "final independent loopback",
            "cost": "free; may reuse only same-head same-environment final evidence",
            "procedure": "From a clean environment on the final head, execute or independently verify the exact focused, repeat, targeted non-short, structure, scope, privacy, and cleanup gates and write a report using factory/docs/standards/validation-loopback-template.md. Mark every project criterion PASS/FAIL/BLOCKED; on FAIL/BLOCKED emit the required delta-plan request and do not edit implementation.",
            "propertyProved": "The delivered final head satisfies the highest planned integrated runtime proof for the exact package, including behavior, material latency, persistence/reload, isolation, cleanup, scope, and reporting responsibilities.",
            "propertyNotProved": "Merged-main full-lane effect, cross-package regressions, public contract changes, or paid/remote provider behavior."
          }
        ],
        "highestFeasibleLevel": {
          "scope": "functional",
          "dependencyFidelity": "local_real",
          "reason": "The existing package assembles the real local application through root.BuildProcess and Process.Execute and crosses the real HTTP, Factory Session, Factory Definitions/Runtime/Recordings, Work, and disposable filesystem persistence boundaries. The existing worker edge is controlled, and provider-real behavior is neither asserted nor authorized. The final story itself performs the highest planned integrated runtime proof."
        },
        "remainingUnprovenEdges": [
          {
            "edge": "Merged full functional-lane effect and cross-package regressions",
            "gateId": "remeasure-wave-1-merged-main"
          },
          {
            "edge": "Any required public contract or configuration change",
            "gateId": "new-plan-with-native-current-proposed-shapes"
          },
          {
            "edge": "Real provider availability and execution",
            "gateId": "existing-provider-integration-release-gates"
          },
          {
            "edge": "All scheduler and data-race interleavings beyond bounded repetitions",
            "gateId": "existing-CI-race-lanes-when-applicable"
          }
        ]
      },
      "paidValidation": {
        "applicable": false,
        "trigger": "Not applicable; paid and remote validation are prohibited.",
        "maximumCalls": 0,
        "maximumCost": "$0",
        "maximumDuration": "0s paid validation; 30 minutes total focused local verification",
        "fixtureAndOutputValidator": "Existing checked-in package fixtures; Go test exit/status/assertions and timing median computation validate local output.",
        "evidenceReuseKey": "Local only: final commit, Go version, Windows version and architecture, exact command flags, 39-test/11-subtest inventory, environment/cache policy, and fixture revision."
      },
      "priority": 1,
      "passes": true,
      "notes": "Implemented: bounded t.Parallel on 37 isolated top-level tests across 9 existing files; nested matrices serial. Pre median 30.425s (77.634 cold/30.425/28.259) vs post median 16.759s (16.743/16.759/16.872) at final head 4d5f850d7: -13.666s (-44.9%). -count=2 short and targeted non-short runs exit 0. make pkg-structure PASS; diff limited to exact-package test files."
    }
  ]
}
