### PR TITLE
test(work/submission): lower focused latency via bounded package-local parallel scheduling

### DIFF
--- a/tests/functional/work/submission/http_test.go
+++ b/tests/functional/work/submission/http_test.go
@@ -53,6 +53,8 @@ func TestAPIPOSTSubmitAndQueryWork(t *testing.T) {
 // TestAPIBatchUpsertAcceptsWorksContent proves batch upsert through PUT
 // /work-requests accepts canonical works content and projects ordered content parts.
 func TestAPIBatchUpsertAcceptsWorksContent(t *testing.T) {
+	t.Parallel()
+
 	factoryDir := support.ScaffoldFactory(t, simplePipelineFactoryConfig())
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:     factoryDir,
@@ -180,6 +182,8 @@ func TestCLIWorkTypeNameReachesLiveAPIHandler(t *testing.T) {
 // endpoints so automation can submit once and inspect the resulting Work identity
 // and payload without a second transport.
 func TestAPISubmitBatchThenListAndGetWork(t *testing.T) {
+	t.Parallel()
+
 	factoryDir := support.ScaffoldFactory(t, batchInputsFactoryConfig())
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:     factoryDir,
@@ -268,6 +272,8 @@ func TestAPISubmitBatchThenListAndGetWork(t *testing.T) {
 // Request and Work identities so retries and idempotent clients do not create
 // divergent identities for the same upsert key.
 func TestAPIUpsertWorkRequestUsesCanonicalIdentity(t *testing.T) {
+	t.Parallel()
+
 	factoryDir := support.ScaffoldFactory(t, batchInputsFactoryConfig())
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:     factoryDir,
@@ -350,6 +356,8 @@ func TestAPIUpsertWorkRequestUsesCanonicalIdentity(t *testing.T) {
 // error outcome (structured 404 with NOT_FOUND family/code) rather than an opaque
 // 500 or unstructured failure body.
 func TestAPIUnknownWorkReturnsTypedNotFound(t *testing.T) {
+	t.Parallel()
+
 	factoryDir := support.ScaffoldFactory(t, batchInputsFactoryConfig())
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:     factoryDir,

--- a/tests/functional/work/submission/payload_size_http_test.go
+++ b/tests/functional/work/submission/payload_size_http_test.go
@@ -30,6 +30,7 @@ const (
 // contract preserves the Work admission diagnostic and emits no request or
 // dispatch observation for a mixed batch that contains an oversized Work.
 func TestAPIBatchUpsertRejectsOversizedWorkAtomically(t *testing.T) {
+	t.Parallel()
 	server := startPayloadSizeHTTPServer(t)
 	defer server.Stop(t)
 
@@ -82,6 +83,7 @@ func TestAPIBatchUpsertRejectsOversizedWorkAtomically(t *testing.T) {
 // payload of exactly 65,536 bytes reaches the public session-scoped Work and
 // Factory Event observations.
 func TestAPIBatchUpsertAcceptsPayloadAtInclusiveLimit(t *testing.T) {
+	t.Parallel()
 	server := startPayloadSizeHTTPServer(t)
 	defer server.Stop(t)
 

--- a/tests/functional/work/submission/stage_and_submit_test.go
+++ b/tests/functional/work/submission/stage_and_submit_test.go
@@ -23,6 +23,8 @@ const (
 // submit flow creates Work whose customer-visible content carries the staged file
 // reference and metadata returned by POST /work/staged-files.
 func TestAPIStageAndSubmitFileCreatesExpectedWork(t *testing.T) {
+	t.Parallel()
+
 	factoryDir := support.ScaffoldFactory(t, batchInputsFactoryConfig())
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:     factoryDir,

--- a/tests/functional/work/submission/structured_submission_test.go
+++ b/tests/functional/work/submission/structured_submission_test.go
@@ -15,6 +15,7 @@ import (
 // submit surface accepts a header-only structured submission and projects empty
 // customer-visible content after completion.
 func TestAPISubmitWorkAcceptsHeaderOnlyStructuredSubmission(t *testing.T) {
+	t.Parallel()
 	factoryDir := support.ScaffoldFactory(t, simplePipelineFactoryConfig())
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:     factoryDir,
@@ -52,6 +53,7 @@ func TestAPISubmitWorkAcceptsHeaderOnlyStructuredSubmission(t *testing.T) {
 // TestAPISubmitWorkRejectsEmptyStructuredSubmission proves empty structured submit
 // items return HTTP 400 through the public submit surface.
 func TestAPISubmitWorkRejectsEmptyStructuredSubmission(t *testing.T) {
+	t.Parallel()
 	factoryDir := support.ScaffoldFactory(t, simplePipelineFactoryConfig())
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:     factoryDir,
@@ -75,6 +77,7 @@ func TestAPISubmitWorkRejectsEmptyStructuredSubmission(t *testing.T) {
 // TestAPISubmitWorkAcceptsOrderedTextSubmission proves ordered structured text
 // items are preserved in the customer-visible Work content projection.
 func TestAPISubmitWorkAcceptsOrderedTextSubmission(t *testing.T) {
+	t.Parallel()
 	factoryDir := support.ScaffoldFactory(t, simplePipelineFactoryConfig())
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:     factoryDir,
@@ -117,6 +120,7 @@ func TestAPISubmitWorkAcceptsOrderedTextSubmission(t *testing.T) {
 // TestAPISubmitWorkAcceptsCanonicalContentParts proves canonical content parts on
 // POST /work are preserved in the customer-visible Work projection.
 func TestAPISubmitWorkAcceptsCanonicalContentParts(t *testing.T) {
+	t.Parallel()
 	factoryDir := support.ScaffoldFactory(t, simplePipelineFactoryConfig())
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:     factoryDir,
@@ -159,6 +163,7 @@ func TestAPISubmitWorkAcceptsCanonicalContentParts(t *testing.T) {
 // TestAPISubmitWorkAcceptsMixedTextAndImageOnSupportedRunner proves mixed text
 // and image structured submissions complete on a capability-supported runner.
 func TestAPISubmitWorkAcceptsMixedTextAndImageOnSupportedRunner(t *testing.T) {
+	t.Parallel()
 	factoryDir := support.ScaffoldFactory(t, simplePipelineFactoryConfig())
 	support.WriteAgentConfig(
 		t,
@@ -218,6 +223,7 @@ func TestAPISubmitWorkAcceptsMixedTextAndImageOnSupportedRunner(t *testing.T) {
 // TestAPISubmitWorkRejectsMixedTextAndImageOnUnsupportedRunner proves mixed text
 // and image structured submissions fail before provider launch on unsupported runners.
 func TestAPISubmitWorkRejectsMixedTextAndImageOnUnsupportedRunner(t *testing.T) {
+	t.Parallel()
 	factoryDir := support.ScaffoldFactory(t, simplePipelineFactoryConfig())
 	support.WriteAgentConfig(
 		t,
@@ -268,6 +274,7 @@ func TestAPISubmitWorkRejectsMixedTextAndImageOnUnsupportedRunner(t *testing.T) 
 // TestAPISubmitWorkRejectsForgedStructuredFileReference proves forged staged-file
 // references are rejected with HTTP 400 through the public submit surface.
 func TestAPISubmitWorkRejectsForgedStructuredFileReference(t *testing.T) {
+	t.Parallel()
 	factoryDir := support.ScaffoldFactory(t, simplePipelineFactoryConfig())
 	server := support.StartFunctionalAPIServer(t, support.FunctionalAPIServerConfig{
 		FactoryDir:     factoryDir,


### PR DESCRIPTION
## PRD

`prd.json` (project `fpkg-work-submission-package-latency`): Reduce focused latency of `tests/functional/work/submission` through bounded package-local parallel scheduling while preserving its complete Work submission, admission, content, identity, atomicity, concurrency, filesystem, and replay evidence.

## Change

Only `tests/functional/work/submission/**` changed: added `t.Parallel()` to 13 source-inspected, repeat-proven isolated top-level HTTP-only cells (7 structured submission, stage+submit, 2 payload-size, 4 batch/list/get/identity/not-found HTTP cells). Each owns a temp factory dir, ephemeral-port server (`127.0.0.1:0`), per-test edges/home/env. CLI/exec, watcher, recording/replay, cron, and blocked-dispatch cells remain sequential. No assertion, skip, build-tag, timeout, or functionalevidence.Covers change; no production/shared-harness/generated/docs changes.

## Evidence

- GATE-BASELINE (before, warm-cache comparable trio): 16.070s / 15.582s / 15.578s → median **15.582s** (go1.25.0 windows/amd64, 24 logical CPUs). A cold-build first run (~108s) was discarded as not comparable; INV-001 values were sampled on a different commit so fresh authorized before values are used.
- GATE-PERFORMANCE (after): 11.738s / 11.293s / 11.549s → median **11.549s** = **−4.033s / −25.9%**, no regression sample. Exceeds the ≥10% or ≥500ms bar.
- GATE-MATRIX: exact command passes; 22 top-level tests, 19 pass + exactly the 3 existing short skips.
- GATE-ATOMICITY: unknown-type/oversized/inclusive-limit run `-count=3` pass.
- GATE-CONTENT: content/stage/submit run `-count=3` pass.
- GATE-CONCURRENCY: blocked-ingress/dependency/canonical-identity run `-count=3` pass.
- GATE-ISOLATION: full package `-count=3` under `-parallel=2`: 58 top-level passes, 0 failures.
- GATE-LONG: tagged `functionallong` witness run: all selected watched/HTTP parity and legacy-retirement recording/replay cells pass.
- GATE-CLEANUP: no leaked server/process/port/watcher/temp-dir/handle symptoms in any terminal output above.
- GATE-SCOPE: `git diff --name-only origin/main...HEAD` shows only the four owned test files.

Review owns terminal CI and merge; VAL-001 clean-room loopback follows this handoff.
