### PR TITLE
ci: deflake durable-session browser harness readiness timeout

### DIFF
--- a/tests/functional/internal/support/cmd/browser_api_harness/main.go
+++ b/tests/functional/internal/support/cmd/browser_api_harness/main.go
@@ -25,6 +25,7 @@ import (
 const (
 	startupTimeout           = 10 * time.Second
 	projectWorkflowDirectory = ".claude/workflows"
+	startupDiagnosticPrefix  = "[browser-api-harness] phase="
 )
 
 type readyPayload struct {
@@ -45,9 +46,11 @@ type harnessConfig struct {
 
 func main() {
 	cfg := parseHarnessConfig()
+	startupPhase("process-started")
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
+	startupPhase("workflow-project-preparation-started")
 	projectRoot, cleanupProjectRoot, err := prepareWorkflowProjectRoot(
 		cfg.executionBaseDir,
 		cfg.workflowFixture,
@@ -57,6 +60,7 @@ func main() {
 		fatalf("prepare workflow project root: %v", err)
 	}
 	defer cleanupProjectRoot()
+	startupPhase("workflow-project-preparation-complete")
 
 	ready := make(chan struct{})
 	edges := serviceedges.Edges{
@@ -67,12 +71,15 @@ func main() {
 			return serveInjectedHTTP(serverCtx, cfg.apiPort, request.Handler, ready)
 		},
 	}
+	startupPhase("root-process-build-started")
 	process, err := support.BuildProcessWithContext(ctx, edges)
 	if err != nil {
 		fatalf("build root process: %v", err)
 	}
+	startupPhase("root-process-build-complete")
 	processDone := make(chan error, 1)
 	go func() {
+		startupPhase("root-process-execution-started")
 		processDone <- process.Execute(root.Input{
 			Args: []string{
 				"you", "run",
@@ -100,7 +107,9 @@ func main() {
 		fatalf("timed out waiting for root process API")
 	}
 
+	startupPhase("api-bound")
 	waitForHTTPReady(cfg.apiPort)
+	startupPhase("api-ready")
 
 	startRequest := factoryapi.FactorySessionExecutionRequest{
 		RequestId: cfg.requestID,
@@ -113,6 +122,7 @@ func main() {
 	if err != nil {
 		fatalf("start durable factory session (%s): %v", cfg.startMode, err)
 	}
+	startupPhase("durable-session-started")
 
 	if err := json.NewEncoder(os.Stdout).Encode(readyPayload{
 		APIPort:   cfg.apiPort,
@@ -121,6 +131,7 @@ func main() {
 	}); err != nil {
 		fatalf("encode ready payload: %v", err)
 	}
+	startupPhase("ready-payload-written")
 
 	<-ctx.Done()
 	waitForExit(processDone)
@@ -141,6 +152,10 @@ func parseHarnessConfig() harnessConfig {
 	flag.Parse()
 	validateHarnessConfig(cfg)
 	return cfg
+}
+
+func startupPhase(phase string) {
+	_, _ = fmt.Fprintf(os.Stderr, "%s%s\n", startupDiagnosticPrefix, phase)
 }
 
 func validateHarnessConfig(cfg harnessConfig) {

--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -1072,6 +1072,8 @@ const browserBuildCacheKey = "__agentFactoryBrowserIntegrationBuildComplete";
 const browserProcessStateKey = "__agentFactoryBrowserIntegrationBrowserState";
 const browserPreviewStateKey = "__agentFactoryBrowserIntegrationPreviewState";
 const repoProcessGroupKey = Symbol("repoProcessGroup");
+const repoProcessSpawnedKey = Symbol("repoProcessSpawned");
+const repoProcessErrorKey = Symbol("repoProcessError");
 let browserArtifactSequence = 0;
 let sharedBrowserPorts = null;
 export const exportCoverImagePath = path.resolve(
@@ -1362,6 +1364,7 @@ function spawnRuntime(args, extraEnv = {}, options = {}) {
     shell: false,
     stdio: "pipe",
   });
+  trackRepoProcess(child);
   child[repoProcessGroupKey] = process.platform !== "win32";
   return child;
 }
@@ -1374,7 +1377,18 @@ function spawnRepoProcess(command, args, options = {}) {
     shell: false,
     stdio: ["ignore", "pipe", "pipe"],
   });
+  trackRepoProcess(child);
   child[repoProcessGroupKey] = process.platform !== "win32";
+  return child;
+}
+
+function trackRepoProcess(child) {
+  child.once("spawn", () => {
+    child[repoProcessSpawnedKey] = true;
+  });
+  child.once("error", (error) => {
+    child[repoProcessErrorKey] = error;
+  });
   return child;
 }
 
@@ -1711,6 +1725,7 @@ export function waitForRealBackendHarnessReadiness({
     }
 
     function rejectWithProcessError(error) {
+      child[repoProcessErrorKey] = error;
       settleFailure(
         new Error(`Real backend browser harness process error: ${error}`),
       );
@@ -1861,18 +1876,60 @@ async function runRuntime(
   }
 }
 
+function waitForProcessTermination(child) {
+  if (
+    !child ||
+    child.exitCode !== null ||
+    child.signalCode !== null ||
+    (child[repoProcessErrorKey] && !child[repoProcessSpawnedKey])
+  ) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      child.off("exit", settle);
+      child.off("error", settle);
+      child.off("close", settle);
+      resolve();
+    };
+
+    child.once("exit", settle);
+    child.once("error", settle);
+    child.once("close", settle);
+
+    if (
+      child.exitCode !== null ||
+      child.signalCode !== null ||
+      (child[repoProcessErrorKey] && !child[repoProcessSpawnedKey])
+    ) {
+      settle();
+    }
+  });
+}
+
 async function stopProcess(child) {
-  if (!child || child.exitCode !== null || child.signalCode !== null) {
+  if (
+    !child ||
+    child.exitCode !== null ||
+    child.signalCode !== null ||
+    (child[repoProcessErrorKey] && !child[repoProcessSpawnedKey])
+  ) {
     return;
   }
 
-  const exited = once(child, "exit");
+  const exited = waitForProcessTermination(child);
   if (process.platform === "win32") {
     const killer = spawn("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
       shell: false,
       stdio: "ignore",
     });
-    await once(killer, "exit");
+    await waitForProcessTermination(killer);
     await exited;
     return;
   }
@@ -2816,6 +2873,8 @@ export async function startRealBackendBrowserHarness({
   resolveGoCache = resolveGoCacheEnvironment,
   spawnProcess = spawnRepoProcess,
   startMode = "sync",
+  createTemporaryHome = () =>
+    mkdtemp(path.join(tmpdir(), "you-browser-backend-")),
   workflowFixture,
   workflowName,
 } = {}) {
@@ -2838,9 +2897,7 @@ export async function startRealBackendBrowserHarness({
     "phase=temporary-home-setup started",
   );
   const temporaryHomeStartedAt = now();
-  const customerHome = await mkdtemp(
-    path.join(tmpdir(), "you-browser-backend-"),
-  );
+  const customerHome = await createTemporaryHome();
   writeRealBackendHarnessDiagnostic(
     diagnosticWriter,
     `phase=temporary-home-setup complete elapsed=${formatRealBackendHarnessDuration(Math.max(0, now() - temporaryHomeStartedAt))}`,

--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -34,6 +34,12 @@ const realBackendHarnessProcessStartedMarker =
 const realBackendHarnessDiagnosticLimit = 8_192;
 const realBackendHarnessDiagnosticTruncationMarker =
   "[earlier diagnostics truncated]";
+const realBackendHarnessSource =
+  "./tests/functional/internal/support/cmd/browser_api_harness";
+const realBackendHarnessArtifactDirectoryPrefix = "you-browser-api-harness-";
+
+export const realBackendHarnessArtifactEnvironmentVariable =
+  "AGENT_FACTORY_REAL_BACKEND_HARNESS_PATH";
 
 export const previewHost = "127.0.0.1";
 export const buildTimeoutMs = 600_000;
@@ -1435,6 +1441,7 @@ export function createRealBackendHarnessStartupTiming(
     cacheReuseBeforeResolution: null,
     firstReadyPayloadMs: null,
     harnessCompilationSetupMs: null,
+    executionMode: null,
     processLaunchMs: null,
     processSpawnedAt: null,
     processStartedAt: null,
@@ -1451,6 +1458,7 @@ function publicRealBackendHarnessStartupTiming(timing) {
     cacheReuseBeforeResolution: timing.cacheReuseBeforeResolution,
     firstReadyPayloadMs: timing.firstReadyPayloadMs,
     harnessCompilationSetupMs: timing.harnessCompilationSetupMs,
+    executionMode: timing.executionMode,
     processLaunchMs: timing.processLaunchMs,
     totalStartupMs: timing.totalStartupMs,
   };
@@ -1459,6 +1467,7 @@ function publicRealBackendHarnessStartupTiming(timing) {
 export function formatRealBackendHarnessStartupTiming(timing) {
   return [
     `${realBackendHarnessDiagnosticPrefix} timing`,
+    `execution-mode=${timing?.executionMode ?? "unavailable"}`,
     `cache-resolution=${formatRealBackendHarnessDuration(timing?.cacheResolutionMs)}`,
     `harness-compilation-setup=${formatRealBackendHarnessDuration(timing?.harnessCompilationSetupMs)}`,
     `process-launch=${formatRealBackendHarnessDuration(timing?.processLaunchMs)}`,
@@ -1544,10 +1553,10 @@ function recordRealBackendHarnessStartupPhase(timing, phase, now, writer) {
   }
 
   timing.processStartedAt = now;
-  timing.harnessCompilationSetupMs = Math.max(
-    0,
-    now - (timing.processSpawnedAt ?? timing.startedAt),
-  );
+  timing.harnessCompilationSetupMs =
+    timing.executionMode === "prebuilt-artifact"
+      ? 0
+      : Math.max(0, now - (timing.processSpawnedAt ?? timing.startedAt));
   writeRealBackendHarnessDiagnostic(
     writer,
     `phase=harness-process-started elapsed=${formatRealBackendHarnessDuration(timing.harnessCompilationSetupMs)}`,
@@ -1876,6 +1885,296 @@ async function stopProcess(child) {
     child.kill("SIGTERM");
   }
   await exited;
+}
+
+function observeRealBackendHarnessCommandOutput({
+  child,
+  diagnosticWriter,
+  secrets,
+  phase,
+}) {
+  let captured = "";
+  const flushers = [];
+
+  function attachStream(stream, label) {
+    if (!stream) {
+      return;
+    }
+
+    let pendingLine = "";
+    const observeLine = (line) => {
+      const safeLine = sanitizeRealBackendHarnessDiagnostic(line, secrets);
+      captured = appendBoundedRealBackendHarnessDiagnostic(
+        captured,
+        `${label} ${safeLine}\n`,
+      );
+      if (safeLine.trim().length > 0) {
+        writeRealBackendHarnessDiagnostic(
+          diagnosticWriter,
+          `${phase} ${label} ${safeLine.trim()}`,
+        );
+      }
+    };
+    const observeChunk = (chunk) => {
+      pendingLine += chunk.toString();
+      const lines = pendingLine.split(/\r?\n/);
+      pendingLine = lines.pop() ?? "";
+      for (const line of lines) {
+        observeLine(line);
+      }
+    };
+
+    stream.on("data", observeChunk);
+    flushers.push(() => {
+      if (pendingLine.length > 0) {
+        observeLine(pendingLine);
+        pendingLine = "";
+      }
+    });
+  }
+
+  attachStream(child.stdout, "child-stdout");
+  attachStream(child.stderr, "child-stderr");
+
+  return () => {
+    for (const flush of flushers) {
+      flush();
+    }
+    return captured;
+  };
+}
+
+async function runRealBackendHarnessCommand({
+  args,
+  command,
+  diagnosticWriter,
+  extraEnv,
+  secrets,
+  spawnProcess = spawnRepoProcess,
+  timeoutMs,
+}) {
+  let child;
+  try {
+    child = spawnProcess(command, args, { extraEnv });
+  } catch (error) {
+    return { error };
+  }
+
+  const readCapturedOutput = observeRealBackendHarnessCommandOutput({
+    child,
+    diagnosticWriter,
+    phase: "phase=harness-build",
+    secrets,
+  });
+  const exited = new Promise((resolve) => {
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+    child.once("error", (error) => resolve({ error }));
+  });
+  let timeoutHandle;
+  const timedOut = new Promise((resolve) => {
+    timeoutHandle = setTimeout(() => resolve({ timedOut: true }), timeoutMs);
+  });
+
+  let result;
+  try {
+    result = await Promise.race([exited, timedOut]);
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+
+  if (result.timedOut) {
+    let stopError = null;
+    try {
+      await stopProcess(child);
+    } catch (error) {
+      stopError = error;
+    }
+    return {
+      ...result,
+      capturedOutput: readCapturedOutput(),
+      stopError,
+    };
+  }
+
+  return {
+    ...result,
+    capturedOutput: readCapturedOutput(),
+  };
+}
+
+function resolveRealBackendHarnessArtifactPath(harnessPath) {
+  const configuredPath =
+    harnessPath ?? process.env[realBackendHarnessArtifactEnvironmentVariable];
+  if (typeof configuredPath !== "string" || configuredPath.trim() === "") {
+    return null;
+  }
+
+  const resolvedPath = path.resolve(configuredPath);
+  if (!existsSync(resolvedPath)) {
+    throw new Error(
+      `Configured real backend browser harness artifact is missing; expected a built file at ${resolvedPath}.`,
+    );
+  }
+  return resolvedPath;
+}
+
+export async function buildRealBackendBrowserHarness({
+  artifactDirectory: configuredArtifactDirectory = null,
+  diagnosticWriter = process.stderr,
+  now = () => performance.now(),
+  resolveGoCache = resolveGoCacheEnvironment,
+  spawnProcess = spawnRepoProcess,
+} = {}) {
+  let artifactDirectory = configuredArtifactDirectory;
+  let ownsArtifactDirectory = false;
+  let artifactPath = null;
+  let cleaned = false;
+
+  const cleanup = async () => {
+    if (cleaned || !artifactDirectory) {
+      return;
+    }
+    cleaned = true;
+    writeRealBackendHarnessDiagnostic(
+      diagnosticWriter,
+      "phase=harness-artifact-cleanup started",
+    );
+    if (ownsArtifactDirectory) {
+      await rm(artifactDirectory, { force: true, recursive: true });
+    } else if (artifactPath) {
+      await rm(artifactPath, { force: true });
+    }
+    writeRealBackendHarnessDiagnostic(
+      diagnosticWriter,
+      "phase=harness-artifact-cleanup complete",
+    );
+  };
+
+  try {
+    if (artifactDirectory === null) {
+      artifactDirectory = await mkdtemp(
+        path.join(tmpdir(), realBackendHarnessArtifactDirectoryPrefix),
+      );
+      ownsArtifactDirectory = true;
+    } else {
+      artifactDirectory = path.resolve(artifactDirectory);
+      await mkdir(artifactDirectory, { recursive: true });
+    }
+    artifactPath = path.join(
+      artifactDirectory,
+      process.platform === "win32"
+        ? "browser_api_harness.exe"
+        : "browser_api_harness",
+    );
+
+    const buildStartedAt = now();
+    writeRealBackendHarnessDiagnostic(
+      diagnosticWriter,
+      "phase=harness-build started command=go build browser-api-harness",
+    );
+    const goCache = resolveGoCache({ diagnosticWriter, now });
+    const result = await runRealBackendHarnessCommand({
+      args: [
+        "build",
+        "-buildvcs=false",
+        "-o",
+        artifactPath,
+        realBackendHarnessSource,
+      ],
+      command: "go",
+      diagnosticWriter,
+      extraEnv: {
+        CGO_ENABLED: process.env.CGO_ENABLED ?? "0",
+        ...goCache.environment,
+      },
+      secrets: [artifactPath, ...Object.values(goCache.environment)],
+      spawnProcess,
+      timeoutMs: buildTimeoutMs,
+    });
+    const buildElapsedMs = Math.max(0, now() - buildStartedAt);
+
+    if (result.timedOut) {
+      throw new Error(
+        [
+          "Real backend browser harness build timed out.",
+          "phase=harness-build",
+          `command=go build browser-api-harness elapsed=${formatRealBackendHarnessDuration(buildElapsedMs)}`,
+          result.stopError
+            ? `stop-error=${sanitizeRealBackendHarnessDiagnostic(result.stopError.message)}`
+            : null,
+          result.capturedOutput?.trim()
+            ? `captured-output=${result.capturedOutput.trim()}`
+            : null,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+      );
+    }
+
+    if (result.error) {
+      throw new Error(
+        [
+          "Real backend browser harness build could not start.",
+          "phase=harness-build",
+          `command=go build browser-api-harness elapsed=${formatRealBackendHarnessDuration(buildElapsedMs)}`,
+          `error=${sanitizeRealBackendHarnessDiagnostic(result.error.message ?? result.error)}`,
+          result.capturedOutput?.trim()
+            ? `captured-output=${result.capturedOutput.trim()}`
+            : null,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+      );
+    }
+
+    if (result.code !== 0) {
+      throw new Error(
+        [
+          "Real backend browser harness build failed.",
+          "phase=harness-build",
+          `command=go build browser-api-harness code=${result.code ?? "null"} signal=${result.signal ?? "null"} elapsed=${formatRealBackendHarnessDuration(buildElapsedMs)}`,
+          result.capturedOutput?.trim()
+            ? `captured-output=${result.capturedOutput.trim()}`
+            : "captured-output=<none>",
+        ].join("\n"),
+      );
+    }
+
+    const artifactStats = await stat(artifactPath).catch(() => null);
+    if (!artifactStats?.isFile()) {
+      throw new Error(
+        [
+          "Real backend browser harness build completed without producing an executable artifact.",
+          "phase=harness-build",
+          `command=go build browser-api-harness elapsed=${formatRealBackendHarnessDuration(buildElapsedMs)}`,
+        ].join("\n"),
+      );
+    }
+
+    writeRealBackendHarnessDiagnostic(
+      diagnosticWriter,
+      `phase=harness-build complete elapsed=${formatRealBackendHarnessDuration(buildElapsedMs)} cache-reuse=${formatGoCacheReuse(goCache.cacheReuse)}`,
+    );
+    return {
+      artifactPath,
+      buildTimings: {
+        cacheResolutionMs: goCache.elapsedMs,
+        cacheReuse: goCache.cacheReuse,
+        cacheReuseBeforeResolution: goCache.cacheReuseBeforeResolution,
+        harnessBuildMs: buildElapsedMs,
+      },
+      cleanup,
+    };
+  } catch (error) {
+    try {
+      await cleanup();
+    } catch (cleanupError) {
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}\nphase=harness-artifact-cleanup error=${sanitizeRealBackendHarnessDiagnostic(cleanupError.message ?? cleanupError)}`,
+      );
+    }
+    throw error;
+  }
 }
 
 async function waitForURL(url, timeoutMs = readyTimeoutMs) {
@@ -2504,8 +2803,11 @@ export async function startRealBackendBrowserHarness({
   apiPort,
   diagnosticWriter = process.stderr,
   factoryDir = path.resolve(packageRoot, "..", "factory"),
+  harnessPath = null,
   now = () => performance.now(),
   requestID = "req-browser-runtime-001",
+  resolveGoCache = resolveGoCacheEnvironment,
+  spawnProcess = spawnRepoProcess,
   startMode = "sync",
   workflowFixture,
   workflowName,
@@ -2516,8 +2818,11 @@ export async function startRealBackendBrowserHarness({
     );
   }
 
+  const artifactPath = resolveRealBackendHarnessArtifactPath(harnessPath);
+  const executionMode = artifactPath ? "prebuilt-artifact" : "go-run-fallback";
   const timing = createRealBackendHarnessStartupTiming(now());
-  const goCache = resolveGoCacheEnvironment({ diagnosticWriter, now });
+  timing.executionMode = executionMode;
+  const goCache = resolveGoCache({ diagnosticWriter, now });
   timing.cacheResolutionMs = goCache.elapsedMs;
   timing.cacheReuse = goCache.cacheReuse;
   timing.cacheReuseBeforeResolution = goCache.cacheReuseBeforeResolution;
@@ -2537,14 +2842,13 @@ export async function startRealBackendBrowserHarness({
   try {
     writeRealBackendHarnessDiagnostic(
       diagnosticWriter,
-      "phase=process-launch started",
+      `phase=process-launch started mode=${executionMode}`,
     );
     const processLaunchStartedAt = now();
-    child = spawnRepoProcess(
-      "go",
+    child = spawnProcess(
+      artifactPath ?? "go",
       [
-        "run",
-        "./tests/functional/internal/support/cmd/browser_api_harness",
+        ...(artifactPath ? [] : ["run", realBackendHarnessSource]),
         "--api-port",
         String(apiPort),
         "--factory-dir",
@@ -2589,6 +2893,7 @@ export async function startRealBackendBrowserHarness({
     now,
     secrets: [
       customerHome,
+      artifactPath ?? "",
       factoryDir,
       requestID,
       workflowFixture,
@@ -2617,6 +2922,7 @@ export async function startRealBackendBrowserHarness({
     now,
     secrets: [
       customerHome,
+      artifactPath ?? "",
       factoryDir,
       requestID,
       workflowFixture,

--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -37,6 +37,12 @@ const realBackendHarnessDiagnosticTruncationMarker =
 const realBackendHarnessSource =
   "./tests/functional/internal/support/cmd/browser_api_harness";
 const realBackendHarnessArtifactDirectoryPrefix = "you-browser-api-harness-";
+const realBackendHarnessCleanupOptions = {
+  force: true,
+  maxRetries: 8,
+  recursive: true,
+  retryDelay: 100,
+};
 
 export const realBackendHarnessArtifactEnvironmentVariable =
   "AGENT_FACTORY_REAL_BACKEND_HARNESS_PATH";
@@ -1860,16 +1866,17 @@ async function stopProcess(child) {
     return;
   }
 
+  const exited = once(child, "exit");
   if (process.platform === "win32") {
     const killer = spawn("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
       shell: false,
       stdio: "ignore",
     });
     await once(killer, "exit");
+    await exited;
     return;
   }
 
-  const exited = once(child, "exit");
   if (child[repoProcessGroupKey]) {
     // Commands such as `go run` launch the compiled program as a child process.
     // Terminate the process group so that child cannot retain the shared API
@@ -2040,9 +2047,9 @@ export async function buildRealBackendBrowserHarness({
       "phase=harness-artifact-cleanup started",
     );
     if (ownsArtifactDirectory) {
-      await rm(artifactDirectory, { force: true, recursive: true });
+      await rm(artifactDirectory, realBackendHarnessCleanupOptions);
     } else if (artifactPath) {
-      await rm(artifactPath, { force: true });
+      await rm(artifactPath, realBackendHarnessCleanupOptions);
     }
     writeRealBackendHarnessDiagnostic(
       diagnosticWriter,
@@ -2883,7 +2890,7 @@ export async function startRealBackendBrowserHarness({
       );
     });
   } catch (error) {
-    await rm(customerHome, { force: true, recursive: true });
+    await rm(customerHome, realBackendHarnessCleanupOptions);
     throw error;
   }
 
@@ -2911,7 +2918,7 @@ export async function startRealBackendBrowserHarness({
     try {
       await stopProcess(child);
     } finally {
-      await rm(customerHome, { force: true, recursive: true });
+      await rm(customerHome, realBackendHarnessCleanupOptions);
     }
   }
   const ready = waitForRealBackendHarnessReadiness({

--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -2,6 +2,7 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
+import { existsSync, readdirSync } from "node:fs";
 import {
   mkdir,
   mkdtemp,
@@ -13,6 +14,7 @@ import {
 import http from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import process from "node:process";
 import readline from "node:readline";
 import { setTimeout as delay } from "node:timers/promises";
@@ -25,6 +27,13 @@ import { runSharedBrowserBuild } from "./browser-build-lock.mjs";
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.resolve(dirname, "..");
 const replayFixtureDirectory = path.join(dirname, "fixtures");
+
+const realBackendHarnessDiagnosticPrefix = "[real-backend-browser-harness]";
+const realBackendHarnessProcessStartedMarker =
+  "[browser-api-harness] phase=process-started";
+const realBackendHarnessDiagnosticLimit = 8_192;
+const realBackendHarnessDiagnosticTruncationMarker =
+  "[earlier diagnostics truncated]";
 
 export const previewHost = "127.0.0.1";
 export const buildTimeoutMs = 600_000;
@@ -1357,23 +1366,444 @@ function spawnRepoProcess(command, args, options = {}) {
   return child;
 }
 
-function resolveGoCacheEnvironment() {
+function writeRealBackendHarnessDiagnostic(writer, message) {
+  const line = message.startsWith(realBackendHarnessDiagnosticPrefix)
+    ? `${message}\n`
+    : `${realBackendHarnessDiagnosticPrefix} ${message}\n`;
+  if (typeof writer === "function") {
+    writer(line);
+    return;
+  }
+  writer?.write?.(line);
+}
+
+function formatRealBackendHarnessDuration(elapsedMs) {
+  return Number.isFinite(elapsedMs)
+    ? `${elapsedMs.toFixed(1)}ms`
+    : "unavailable";
+}
+
+function cacheDirectoryReuseState(cachePath, name) {
+  if (typeof cachePath !== "string" || cachePath.length === 0) {
+    return "not-overridden";
+  }
+
+  try {
+    if (!existsSync(cachePath)) {
+      return "missing";
+    }
+
+    const entries = readdirSync(cachePath);
+    if (name === "GOPATH") {
+      return "available";
+    }
+    if (name === "GOMODCACHE") {
+      const moduleEntries = entries.filter((entry) => entry !== "cache");
+      if (moduleEntries.length === 0) {
+        return "empty";
+      }
+      if (moduleEntries.length === 1 && moduleEntries[0] === "golang.org") {
+        const goModuleEntries = readdirSync(path.join(cachePath, "golang.org"));
+        if (
+          goModuleEntries.length === 1 &&
+          goModuleEntries[0].startsWith("toolchain@")
+        ) {
+          return "toolchain-only";
+        }
+      }
+      return "populated";
+    }
+    return entries.length > 0 ? "populated" : "empty";
+  } catch {
+    return "unreadable";
+  }
+}
+
+function formatGoCacheReuse(cacheReuse) {
+  return ["GOCACHE", "GOMODCACHE", "GOPATH"]
+    .map((name) => `${name}:${cacheReuse?.[name] ?? "unavailable"}`)
+    .join(",");
+}
+
+export function createRealBackendHarnessStartupTiming(
+  startedAt = performance.now(),
+) {
+  return {
+    applicationStartupMs: null,
+    cacheResolutionMs: null,
+    cacheReuse: null,
+    cacheReuseBeforeResolution: null,
+    firstReadyPayloadMs: null,
+    harnessCompilationSetupMs: null,
+    processLaunchMs: null,
+    processSpawnedAt: null,
+    processStartedAt: null,
+    startedAt,
+    totalStartupMs: null,
+  };
+}
+
+function publicRealBackendHarnessStartupTiming(timing) {
+  return {
+    applicationStartupMs: timing.applicationStartupMs,
+    cacheResolutionMs: timing.cacheResolutionMs,
+    cacheReuse: timing.cacheReuse,
+    cacheReuseBeforeResolution: timing.cacheReuseBeforeResolution,
+    firstReadyPayloadMs: timing.firstReadyPayloadMs,
+    harnessCompilationSetupMs: timing.harnessCompilationSetupMs,
+    processLaunchMs: timing.processLaunchMs,
+    totalStartupMs: timing.totalStartupMs,
+  };
+}
+
+export function formatRealBackendHarnessStartupTiming(timing) {
+  return [
+    `${realBackendHarnessDiagnosticPrefix} timing`,
+    `cache-resolution=${formatRealBackendHarnessDuration(timing?.cacheResolutionMs)}`,
+    `harness-compilation-setup=${formatRealBackendHarnessDuration(timing?.harnessCompilationSetupMs)}`,
+    `process-launch=${formatRealBackendHarnessDuration(timing?.processLaunchMs)}`,
+    `application-startup=${formatRealBackendHarnessDuration(timing?.applicationStartupMs)}`,
+    `first-ready-payload=${formatRealBackendHarnessDuration(timing?.firstReadyPayloadMs)}`,
+    `total=${formatRealBackendHarnessDuration(timing?.totalStartupMs)}`,
+    `cache-reuse-before=${formatGoCacheReuse(timing?.cacheReuseBeforeResolution)}`,
+    `cache-reuse-after=${formatGoCacheReuse(timing?.cacheReuse)}`,
+  ].join(" ");
+}
+
+function sanitizeRealBackendHarnessDiagnostic(text, secrets = []) {
+  let safeText = String(text ?? "");
+  for (const secret of secrets) {
+    if (typeof secret === "string" && secret.length > 0) {
+      safeText = safeText.split(secret).join("<redacted>");
+    }
+  }
+
+  safeText = safeText
+    .replace(
+      /(?:[A-Za-z]:[\\/]|\/(?:Users|home|runner|tmp|private|var|workspace|workspaces)\/)[^\s"'`]+/g,
+      "<path>",
+    )
+    .replace(
+      /\b(authorization|api[-_]?key|password|secret|token)\s*[:=]\s*\S+/gi,
+      "$1=<redacted>",
+    )
+    .replace(
+      /\b(payload|body|request|response|content|prompt|output)\s*[:=]\s*.+$/gi,
+      "$1=<redacted>",
+    );
+
+  if (safeText.length <= realBackendHarnessDiagnosticLimit) {
+    return safeText;
+  }
+
+  const suffixLimit =
+    realBackendHarnessDiagnosticLimit -
+    realBackendHarnessDiagnosticTruncationMarker.length -
+    1;
+  return `${realBackendHarnessDiagnosticTruncationMarker}\n${safeText.slice(-suffixLimit)}`;
+}
+
+function appendBoundedRealBackendHarnessDiagnostic(previous, next) {
+  const combined = `${previous}${next}`;
+  if (combined.length <= realBackendHarnessDiagnosticLimit) {
+    return combined;
+  }
+
+  const suffixLimit =
+    realBackendHarnessDiagnosticLimit -
+    realBackendHarnessDiagnosticTruncationMarker.length -
+    1;
+  return `${realBackendHarnessDiagnosticTruncationMarker}\n${combined.slice(-suffixLimit)}`;
+}
+
+function startupPhaseFromDiagnosticLine(line) {
+  const normalizedLine = line.trim();
+  if (normalizedLine === realBackendHarnessProcessStartedMarker) {
+    return "process-started";
+  }
+
+  const match = /^\[browser-api-harness\] phase=([a-z-]+)$/.exec(
+    normalizedLine,
+  );
+  return match?.[1] ?? null;
+}
+
+function currentRealBackendHarnessStartupPhase(timing) {
+  if (timing?.firstReadyPayloadMs !== null) {
+    return "ready-payload";
+  }
+  if (timing?.processStartedAt === null) {
+    return "harness-compilation/setup";
+  }
+  return "application-startup";
+}
+
+function recordRealBackendHarnessStartupPhase(timing, phase, now, writer) {
+  if (phase !== "process-started" || timing.processStartedAt !== null) {
+    return;
+  }
+
+  timing.processStartedAt = now;
+  timing.harnessCompilationSetupMs = Math.max(
+    0,
+    now - (timing.processSpawnedAt ?? timing.startedAt),
+  );
+  writeRealBackendHarnessDiagnostic(
+    writer,
+    `phase=harness-process-started elapsed=${formatRealBackendHarnessDuration(timing.harnessCompilationSetupMs)}`,
+  );
+}
+
+function observeRealBackendHarnessStderr({
+  child,
+  diagnosticWriter,
+  now,
+  secrets,
+  timing,
+}) {
+  let captured = "";
+  let pendingLine = "";
+
+  const observeLine = (line) => {
+    captured = appendBoundedRealBackendHarnessDiagnostic(captured, `${line}\n`);
+    const safeLine = sanitizeRealBackendHarnessDiagnostic(line, secrets).trim();
+    if (safeLine.length > 0) {
+      writeRealBackendHarnessDiagnostic(
+        diagnosticWriter,
+        `child-stderr ${safeLine}`,
+      );
+    }
+
+    const phase = startupPhaseFromDiagnosticLine(line);
+    if (phase) {
+      recordRealBackendHarnessStartupPhase(
+        timing,
+        phase,
+        now(),
+        diagnosticWriter,
+      );
+    }
+  };
+
+  const observeChunk = (chunk) => {
+    const text = chunk.toString();
+    pendingLine += text;
+    const lines = pendingLine.split(/\r?\n/);
+    pendingLine = lines.pop() ?? "";
+    for (const line of lines) {
+      observeLine(line);
+    }
+  };
+
+  child.stderr?.on("data", observeChunk);
+  child.stderr?.on("end", () => {
+    if (pendingLine.length > 0) {
+      observeLine(pendingLine);
+      pendingLine = "";
+    }
+  });
+
+  return () => {
+    if (pendingLine.length > 0) {
+      observeLine(pendingLine);
+      pendingLine = "";
+    }
+    return captured;
+  };
+}
+
+function annotateRealBackendHarnessReadinessError(
+  error,
+  timing,
+  getCapturedStderr,
+  secrets,
+) {
+  const safeErrorMessage = sanitizeRealBackendHarnessDiagnostic(
+    error.message,
+    secrets,
+  ).trim();
+  const capturedStderr = sanitizeRealBackendHarnessDiagnostic(
+    getCapturedStderr(),
+    secrets,
+  ).trim();
+  return new Error(
+    [
+      safeErrorMessage,
+      `phase=${currentRealBackendHarnessStartupPhase(timing)}`,
+      formatRealBackendHarnessStartupTiming(timing),
+      capturedStderr.length > 0 ? `captured-stderr=${capturedStderr}` : null,
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  );
+}
+
+export function waitForRealBackendHarnessReadiness({
+  child,
+  diagnosticWriter = process.stderr,
+  getCapturedStderr = () => "",
+  lineReader,
+  now = () => performance.now(),
+  secrets = [],
+  timeoutMs = readyTimeoutMs,
+  timing,
+} = {}) {
+  if (!child || !lineReader || !timing) {
+    throw new TypeError(
+      "waitForRealBackendHarnessReadiness requires child, lineReader, and timing.",
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      settleFailure(
+        new Error(
+          "Timed out waiting for real backend browser harness readiness.",
+        ),
+      );
+    }, timeoutMs);
+
+    function cleanupListeners() {
+      clearTimeout(timeout);
+      child.off("exit", rejectWithProcessExit);
+      child.off("error", rejectWithProcessError);
+      lineReader.off("line", resolveReadyLine);
+    }
+
+    function settleFailure(error) {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanupListeners();
+      reject(
+        annotateRealBackendHarnessReadinessError(
+          error,
+          timing,
+          getCapturedStderr,
+          secrets,
+        ),
+      );
+    }
+
+    function rejectWithProcessExit(code, signal) {
+      settleFailure(
+        new Error(
+          `Real backend browser harness exited before readiness: code=${code ?? "null"} signal=${signal ?? "null"}`,
+        ),
+      );
+    }
+
+    function rejectWithProcessError(error) {
+      settleFailure(
+        new Error(`Real backend browser harness process error: ${error}`),
+      );
+    }
+
+    function resolveReadyLine(line) {
+      let payload;
+      try {
+        payload = JSON.parse(line);
+      } catch (error) {
+        settleFailure(
+          new Error(
+            `Failed to parse real backend browser harness ready payload (${error.message}); received stdout line length=${line.length}`,
+          ),
+        );
+        return;
+      }
+
+      if (
+        !payload ||
+        typeof payload !== "object" ||
+        typeof payload.apiOrigin !== "string" ||
+        typeof payload.sessionId !== "string"
+      ) {
+        settleFailure(
+          new Error(
+            "Real backend browser harness ready payload did not contain apiOrigin and sessionId strings.",
+          ),
+        );
+        return;
+      }
+
+      const readyAt = now();
+      timing.firstReadyPayloadMs = Math.max(
+        0,
+        readyAt - (timing.processSpawnedAt ?? timing.startedAt),
+      );
+      timing.applicationStartupMs =
+        timing.processStartedAt === null
+          ? null
+          : Math.max(0, readyAt - timing.processStartedAt);
+      timing.totalStartupMs = Math.max(0, readyAt - timing.startedAt);
+      writeRealBackendHarnessDiagnostic(
+        diagnosticWriter,
+        formatRealBackendHarnessStartupTiming(timing),
+      );
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanupListeners();
+      resolve(payload);
+    }
+
+    child.once("exit", rejectWithProcessExit);
+    child.once("error", rejectWithProcessError);
+    lineReader.once("line", resolveReadyLine);
+  });
+}
+
+function resolveGoCacheEnvironment({
+  diagnosticWriter = process.stderr,
+  now = () => performance.now(),
+} = {}) {
+  const startedAt = now();
+  writeRealBackendHarnessDiagnostic(
+    diagnosticWriter,
+    "phase=cache-resolution started",
+  );
   const names = ["GOCACHE", "GOMODCACHE", "GOPATH"];
+  const cacheReuseBeforeResolution = Object.fromEntries(
+    names.map((name) => [
+      name,
+      cacheDirectoryReuseState(process.env[name], name),
+    ]),
+  );
   const result = spawnSync("go", ["env", "-json", ...names], {
     encoding: "utf8",
     shell: false,
   });
   if (result.status !== 0) {
     throw new Error(
-      `Failed to resolve Go cache paths for real backend browser harness: ${result.stderr.trim()}`,
+      `Failed to resolve Go cache paths for real backend browser harness: ${sanitizeRealBackendHarnessDiagnostic(result.stderr)}`,
     );
   }
   const values = JSON.parse(result.stdout);
-  return Object.fromEntries(
+  const environment = Object.fromEntries(
     names
       .filter((name) => typeof values[name] === "string" && values[name] !== "")
       .map((name) => [name, values[name]]),
   );
+  const cacheReuse = Object.fromEntries(
+    names.map((name) => [
+      name,
+      cacheDirectoryReuseState(environment[name], name),
+    ]),
+  );
+  const elapsedMs = Math.max(0, now() - startedAt);
+  writeRealBackendHarnessDiagnostic(
+    diagnosticWriter,
+    `phase=cache-resolution complete elapsed=${formatRealBackendHarnessDuration(elapsedMs)} cache-reuse-before=${formatGoCacheReuse(cacheReuseBeforeResolution)} cache-reuse-after=${formatGoCacheReuse(cacheReuse)}`,
+  );
+  return {
+    cacheReuse,
+    cacheReuseBeforeResolution,
+    elapsedMs,
+    environment,
+  };
 }
 
 async function runRuntime(
@@ -2072,7 +2502,9 @@ export async function openBrowserPage(options = {}) {
 
 export async function startRealBackendBrowserHarness({
   apiPort,
+  diagnosticWriter = process.stderr,
   factoryDir = path.resolve(packageRoot, "..", "factory"),
+  now = () => performance.now(),
   requestID = "req-browser-runtime-001",
   startMode = "sync",
   workflowFixture,
@@ -2084,12 +2516,30 @@ export async function startRealBackendBrowserHarness({
     );
   }
 
-  const goCacheEnvironment = resolveGoCacheEnvironment();
+  const timing = createRealBackendHarnessStartupTiming(now());
+  const goCache = resolveGoCacheEnvironment({ diagnosticWriter, now });
+  timing.cacheResolutionMs = goCache.elapsedMs;
+  timing.cacheReuse = goCache.cacheReuse;
+  timing.cacheReuseBeforeResolution = goCache.cacheReuseBeforeResolution;
+  writeRealBackendHarnessDiagnostic(
+    diagnosticWriter,
+    "phase=temporary-home-setup started",
+  );
+  const temporaryHomeStartedAt = now();
   const customerHome = await mkdtemp(
     path.join(tmpdir(), "you-browser-backend-"),
   );
+  writeRealBackendHarnessDiagnostic(
+    diagnosticWriter,
+    `phase=temporary-home-setup complete elapsed=${formatRealBackendHarnessDuration(Math.max(0, now() - temporaryHomeStartedAt))}`,
+  );
   let child;
   try {
+    writeRealBackendHarnessDiagnostic(
+      diagnosticWriter,
+      "phase=process-launch started",
+    );
+    const processLaunchStartedAt = now();
     child = spawnRepoProcess(
       "go",
       [
@@ -2111,20 +2561,41 @@ export async function startRealBackendBrowserHarness({
       {
         extraEnv: {
           CGO_ENABLED: process.env.CGO_ENABLED ?? "0",
-          ...goCacheEnvironment,
+          ...goCache.environment,
           HOME: customerHome,
           USERPROFILE: customerHome,
         },
       },
     );
+    child.once("spawn", () => {
+      timing.processSpawnedAt = now();
+      timing.processLaunchMs = Math.max(
+        0,
+        timing.processSpawnedAt - processLaunchStartedAt,
+      );
+      writeRealBackendHarnessDiagnostic(
+        diagnosticWriter,
+        `phase=process-launch complete elapsed=${formatRealBackendHarnessDuration(timing.processLaunchMs)}`,
+      );
+    });
   } catch (error) {
     await rm(customerHome, { force: true, recursive: true });
     throw error;
   }
 
-  let stderr = "";
-  child.stderr?.on("data", (chunk) => {
-    stderr += chunk.toString();
+  const readCapturedStderr = observeRealBackendHarnessStderr({
+    child,
+    diagnosticWriter,
+    now,
+    secrets: [
+      customerHome,
+      factoryDir,
+      requestID,
+      workflowFixture,
+      workflowName,
+      ...Object.values(goCache.environment),
+    ],
+    timing,
   });
 
   const lineReader = readline.createInterface({
@@ -2138,38 +2609,22 @@ export async function startRealBackendBrowserHarness({
       await rm(customerHome, { force: true, recursive: true });
     }
   }
-  const ready = new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      reject(
-        new Error(
-          `Timed out waiting for real backend browser harness readiness.\n${stderr.trim()}`,
-        ),
-      );
-    }, readyTimeoutMs);
-
-    function rejectWithProcessExit(code, signal) {
-      clearTimeout(timeout);
-      reject(
-        new Error(
-          `Real backend browser harness exited before readiness: code=${code ?? "null"} signal=${signal ?? "null"}\n${stderr.trim()}`,
-        ),
-      );
-    }
-
-    child.once("exit", rejectWithProcessExit);
-    lineReader.once("line", (line) => {
-      clearTimeout(timeout);
-      child.off("exit", rejectWithProcessExit);
-      try {
-        resolve(JSON.parse(line));
-      } catch (error) {
-        reject(
-          new Error(
-            `Failed to parse real backend browser harness ready payload: ${line}\n${error.message}\n${stderr.trim()}`,
-          ),
-        );
-      }
-    });
+  const ready = waitForRealBackendHarnessReadiness({
+    child,
+    diagnosticWriter,
+    getCapturedStderr: readCapturedStderr,
+    lineReader,
+    now,
+    secrets: [
+      customerHome,
+      factoryDir,
+      requestID,
+      workflowFixture,
+      workflowName,
+      ...Object.values(goCache.environment),
+    ],
+    timeoutMs: readyTimeoutMs,
+    timing,
   });
 
   try {
@@ -2177,6 +2632,7 @@ export async function startRealBackendBrowserHarness({
     return {
       apiOrigin: payload.apiOrigin,
       sessionID: payload.sessionId,
+      startupTimings: publicRealBackendHarnessStartupTiming(timing),
       stop: stopHarness,
     };
   } catch (error) {

--- a/ui/integration/browser-test-harness.real-backend-setup.integration.test.mjs
+++ b/ui/integration/browser-test-harness.real-backend-setup.integration.test.mjs
@@ -1,11 +1,16 @@
 // @vitest-environment node
 
+import { EventEmitter } from "node:events";
+
 import { describe, expect, it } from "vitest";
 
 import {
+  createRealBackendHarnessStartupTiming,
   findAvailablePort,
+  formatRealBackendHarnessStartupTiming,
   startRealBackendBrowserHarness,
   waitForPortAvailable,
+  waitForRealBackendHarnessReadiness,
 } from "./browser-test-harness.mjs";
 
 async function fetchJSON(url) {
@@ -17,6 +22,83 @@ async function fetchJSON(url) {
 }
 
 describe("real backend durable session setup", () => {
+  it("reports phase timing when a valid readiness payload arrives", async () => {
+    const child = new EventEmitter();
+    const lineReader = new EventEmitter();
+    const diagnostics = [];
+    const timing = createRealBackendHarnessStartupTiming();
+    timing.processSpawnedAt = timing.startedAt;
+    timing.processStartedAt = timing.startedAt;
+
+    const ready = waitForRealBackendHarnessReadiness({
+      child,
+      diagnosticWriter: (line) => diagnostics.push(line),
+      lineReader,
+      timing,
+      timeoutMs: 100,
+    });
+    lineReader.emit(
+      "line",
+      JSON.stringify({
+        apiOrigin: "http://127.0.0.1:43123",
+        sessionId: "dur-sess-test",
+      }),
+    );
+
+    await expect(ready).resolves.toMatchObject({
+      apiOrigin: "http://127.0.0.1:43123",
+      sessionId: "dur-sess-test",
+    });
+    expect(timing.firstReadyPayloadMs).toEqual(expect.any(Number));
+    expect(timing.applicationStartupMs).toEqual(expect.any(Number));
+    expect(diagnostics.join(" ")).toContain("first-ready-payload=");
+    expect(formatRealBackendHarnessStartupTiming(timing)).toContain(
+      "cache-resolution=unavailable",
+    );
+  });
+
+  it("reports phase timing when the harness exits before readiness", async () => {
+    const child = new EventEmitter();
+    const lineReader = new EventEmitter();
+    const timing = createRealBackendHarnessStartupTiming();
+    timing.processSpawnedAt = timing.startedAt;
+
+    const ready = waitForRealBackendHarnessReadiness({
+      child,
+      getCapturedStderr: () => "customer-home=C:\\Users\\andre\\secret",
+      lineReader,
+      timing,
+      timeoutMs: 100,
+    });
+    child.emit("exit", 1, null);
+
+    const failure = await ready.catch((error) => error);
+    expect(failure).toBeInstanceOf(Error);
+    expect(failure.message).toMatch(
+      /exited before readiness:[\s\S]*phase=harness-compilation\/setup[\s\S]*cache-resolution=unavailable/,
+    );
+    expect(failure.message).not.toContain("C:\\Users\\andre\\secret");
+  });
+
+  it("reports phase timing when readiness reaches its deadline", async () => {
+    const child = new EventEmitter();
+    const lineReader = new EventEmitter();
+    const timing = createRealBackendHarnessStartupTiming();
+    timing.processSpawnedAt = timing.startedAt;
+
+    await expect(
+      waitForRealBackendHarnessReadiness({
+        child,
+        getCapturedStderr: () => "startup diagnostic",
+        lineReader,
+        timing,
+        timeoutMs: 5,
+      }),
+    ).rejects.toThrow(
+      /Timed out waiting for real backend browser harness readiness[\s\S]*phase=harness-compilation\/setup[\s\S]*captured-stderr=startup diagnostic/,
+    );
+  });
+
   it("starts a real backend and seeds one inspectable dur-sess-* JavaScript factory session", async () => {
     const apiPort = await findAvailablePort();
     const backend = await startRealBackendBrowserHarness({

--- a/ui/integration/browser-test-harness.real-backend-setup.integration.test.mjs
+++ b/ui/integration/browser-test-harness.real-backend-setup.integration.test.mjs
@@ -90,6 +90,18 @@ function fakeHarnessProcess(spawnCalls) {
   };
 }
 
+function fakeSpawnErrorHarnessProcess() {
+  const child = new EventEmitter();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.exitCode = null;
+  child.signalCode = null;
+  queueMicrotask(() => {
+    child.emit("error", new Error("spawn failed"));
+  });
+  return child;
+}
+
 async function fetchJSON(url) {
   const response = await fetch(url);
   if (!response.ok) {
@@ -177,6 +189,56 @@ describe("real backend durable session setup", () => {
         "phase=process-launch started mode=prebuilt-artifact",
       );
       await backend.stop();
+    } finally {
+      await rm(artifactDirectory, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects promptly and cleans up the temporary home after a spawn error", async () => {
+    const artifactDirectory = await mkdtemp(
+      path.join(os.tmpdir(), "you-browser-api-harness-test-"),
+    );
+    const artifactPath = path.join(artifactDirectory, "browser_api_harness");
+    await writeFile(artifactPath, "prebuilt browser api harness");
+    let customerHome = null;
+    const startPromise = startRealBackendBrowserHarness({
+      apiPort: 43123,
+      createTemporaryHome: async () => {
+        customerHome = await mkdtemp(
+          path.join(os.tmpdir(), "you-browser-backend-spawn-error-test-"),
+        );
+        return customerHome;
+      },
+      harnessPath: artifactPath,
+      resolveGoCache: fakeGoCache,
+      spawnProcess: fakeSpawnErrorHarnessProcess,
+      workflowFixture: "agent-run-fake-child.workflow.js",
+      workflowName: "agent-run-fake-child",
+    });
+
+    try {
+      const failure = await new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error("spawn-error cleanup did not settle promptly"));
+        }, 1_000);
+        startPromise.then(
+          () => {
+            clearTimeout(timeout);
+            reject(new Error("spawn-error setup unexpectedly became ready"));
+          },
+          (error) => {
+            clearTimeout(timeout);
+            resolve(error);
+          },
+        );
+      });
+
+      expect(failure).toBeInstanceOf(Error);
+      expect(failure.message).toMatch(
+        /Real backend browser harness process error: Error: spawn failed[\s\S]*phase=harness-compilation\/setup/,
+      );
+      expect(customerHome).not.toBeNull();
+      expect(existsSync(customerHome)).toBe(false);
     } finally {
       await rm(artifactDirectory, { force: true, recursive: true });
     }

--- a/ui/integration/browser-test-harness.real-backend-setup.integration.test.mjs
+++ b/ui/integration/browser-test-harness.real-backend-setup.integration.test.mjs
@@ -1,10 +1,16 @@
 // @vitest-environment node
 
 import { EventEmitter } from "node:events";
+import { existsSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
 
 import { describe, expect, it } from "vitest";
 
 import {
+  buildRealBackendBrowserHarness,
   createRealBackendHarnessStartupTiming,
   findAvailablePort,
   formatRealBackendHarnessStartupTiming,
@@ -12,6 +18,77 @@ import {
   waitForPortAvailable,
   waitForRealBackendHarnessReadiness,
 } from "./browser-test-harness.mjs";
+
+function fakeGoCache() {
+  return {
+    cacheReuse: {
+      GOCACHE: "populated",
+      GOMODCACHE: "populated",
+      GOPATH: "available",
+    },
+    cacheReuseBeforeResolution: {
+      GOCACHE: "populated",
+      GOMODCACHE: "populated",
+      GOPATH: "available",
+    },
+    elapsedMs: 2,
+    environment: {
+      GOCACHE: "C:\\cache\\go-build",
+      GOMODCACHE: "C:\\cache\\gomodcache",
+      GOPATH: "C:\\cache\\gopath",
+    },
+  };
+}
+
+function fakeProcess({ code = 0, stderr = "" } = {}) {
+  return (_command, args) => {
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.exitCode = null;
+    child.signalCode = null;
+    if (code === 0) {
+      const outputPath = args[args.indexOf("-o") + 1];
+      writeFileSync(outputPath, "prebuilt browser api harness");
+    }
+    queueMicrotask(() => {
+      if (stderr) {
+        child.stderr.end(stderr);
+      } else {
+        child.stderr.end();
+      }
+      child.stdout.end();
+      child.exitCode = code;
+      child.emit("exit", code, null);
+    });
+    return child;
+  };
+}
+
+function fakeHarnessProcess(spawnCalls) {
+  return (command, args) => {
+    spawnCalls.push({ args, command });
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.exitCode = null;
+    child.signalCode = null;
+    queueMicrotask(() => {
+      child.emit("spawn");
+      child.stderr.write("[browser-api-harness] phase=process-started\n");
+      child.stdout.write(
+        `${JSON.stringify({
+          apiOrigin: "http://127.0.0.1:43123",
+          sessionId: "dur-sess-prebuilt",
+        })}\n`,
+      );
+      child.stderr.end();
+      child.stdout.end();
+      child.exitCode = 0;
+    });
+    return child;
+  };
+}
 
 async function fetchJSON(url) {
   const response = await fetch(url);
@@ -21,7 +98,90 @@ async function fetchJSON(url) {
   return response.json();
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: this focused suite owns all startup lifecycle paths and the one real setup proof.
 describe("real backend durable session setup", () => {
+  it("builds one prebuilt artifact and removes it through idempotent cleanup", async () => {
+    const diagnostics = [];
+    const artifact = await buildRealBackendBrowserHarness({
+      diagnosticWriter: (line) => diagnostics.push(line),
+      resolveGoCache: fakeGoCache,
+      spawnProcess: fakeProcess({ stderr: "compiler setup complete" }),
+    });
+
+    expect(existsSync(artifact.artifactPath)).toBe(true);
+    expect(artifact.buildTimings.harnessBuildMs).toEqual(expect.any(Number));
+    expect(diagnostics.join(" ")).toContain("phase=harness-build complete");
+    expect(diagnostics.join(" ")).toContain(
+      "child-stderr compiler setup complete",
+    );
+
+    await artifact.cleanup();
+    await artifact.cleanup();
+    expect(existsSync(artifact.artifactPath)).toBe(false);
+  });
+
+  it("reports a build failure as harness-build and cleans the partial artifact", async () => {
+    let artifactPath = null;
+    const diagnostics = [];
+    const spawnProcess = (command, args) => {
+      artifactPath = args[args.indexOf("-o") + 1];
+      return fakeProcess({
+        code: 1,
+        stderr: "compile failed at C:\\Users\\andre\\private\\token=secret",
+      })(command, args);
+    };
+
+    await expect(
+      buildRealBackendBrowserHarness({
+        diagnosticWriter: (line) => diagnostics.push(line),
+        resolveGoCache: fakeGoCache,
+        spawnProcess,
+      }),
+    ).rejects.toThrow(
+      /Real backend browser harness build failed[\s\S]*phase=harness-build[\s\S]*captured-output=child-stderr compile failed at <path>/,
+    );
+    expect(artifactPath).not.toBeNull();
+    expect(existsSync(artifactPath)).toBe(false);
+    expect(diagnostics.join(" ")).not.toContain("C:\\Users\\andre\\private");
+  });
+
+  it("launches a supplied prebuilt artifact without go run", async () => {
+    const artifactDirectory = await mkdtemp(
+      path.join(os.tmpdir(), "you-browser-api-harness-test-"),
+    );
+    const artifactPath = path.join(artifactDirectory, "browser_api_harness");
+    await writeFile(artifactPath, "prebuilt browser api harness");
+    const spawnCalls = [];
+    const diagnostics = [];
+    const apiPort = 43123;
+
+    try {
+      const backend = await startRealBackendBrowserHarness({
+        apiPort,
+        diagnosticWriter: (line) => diagnostics.push(line),
+        harnessPath: artifactPath,
+        resolveGoCache: fakeGoCache,
+        spawnProcess: fakeHarnessProcess(spawnCalls),
+        workflowFixture: "agent-run-fake-child.workflow.js",
+        workflowName: "agent-run-fake-child",
+      });
+
+      expect(spawnCalls).toHaveLength(1);
+      expect(spawnCalls[0].command).toBe(path.resolve(artifactPath));
+      expect(spawnCalls[0].args).not.toContain("run");
+      expect(backend.startupTimings).toMatchObject({
+        executionMode: "prebuilt-artifact",
+        harnessCompilationSetupMs: 0,
+      });
+      expect(diagnostics.join(" ")).toContain(
+        "phase=process-launch started mode=prebuilt-artifact",
+      );
+      await backend.stop();
+    } finally {
+      await rm(artifactDirectory, { force: true, recursive: true });
+    }
+  });
+
   it("reports phase timing when a valid readiness payload arrives", async () => {
     const child = new EventEmitter();
     const lineReader = new EventEmitter();
@@ -96,6 +256,26 @@ describe("real backend durable session setup", () => {
       }),
     ).rejects.toThrow(
       /Timed out waiting for real backend browser harness readiness[\s\S]*phase=harness-compilation\/setup[\s\S]*captured-stderr=startup diagnostic/,
+    );
+  });
+
+  it("reports malformed readiness output with phase timing", async () => {
+    const child = new EventEmitter();
+    const lineReader = new EventEmitter();
+    const timing = createRealBackendHarnessStartupTiming();
+    timing.processSpawnedAt = timing.startedAt;
+    timing.processStartedAt = timing.startedAt;
+
+    const ready = waitForRealBackendHarnessReadiness({
+      child,
+      lineReader,
+      timing,
+      timeoutMs: 100,
+    });
+    lineReader.emit("line", "not-json");
+
+    await expect(ready).rejects.toThrow(
+      /Failed to parse real backend browser harness ready payload[\s\S]*phase=application-startup/,
     );
   });
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,6 +32,7 @@
     "check:biome-output-exclusions": "node --test scripts/biome-output-exclusions.test.mjs",
     "lint": "bun run check:biome-output-exclusions && biome lint . && bun run check:localized-copy && bun run check:semantic-colors && node scripts/check-tailwind-spacing-tokens.mjs && node scripts/check-feature-root-files.mjs && node scripts/check-feature-folder-file-count.mjs && node scripts/check-feature-boundary.mjs && bun run check:factory-graph-renderer-path && bun run check:factory-graph-host-parity && node scripts/check-shared-ui-boundary.mjs && bun run check:test-lanes && bun run check:public-package-boundaries && bun run check:packaged-factories-boundary && node scripts/check-button-usage.mjs && node scripts/check-feature-form-control-usage.mjs && node scripts/check-dashboard-expand-disclosure.mjs && bun run check:inline-component-class-usage",
     "link:public-package-dependencies": "node scripts/link-public-package-dependencies.mjs",
+    "measure:real-backend-browser-harness": "node scripts/measure-real-backend-browser-harness.mjs",
     "loadtest:agent-fails-memory": "bun scripts/loadtest-agent-fails-memory.ts",
     "profile:recording-browser": "node scripts/profile-recording-browser.mjs",
     "publish:public-packages": "node scripts/public-package-publish.mjs --action publish",

--- a/ui/scripts/measure-real-backend-browser-harness.mjs
+++ b/ui/scripts/measure-real-backend-browser-harness.mjs
@@ -1,0 +1,192 @@
+// @vitest-environment node
+
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import {
+  findAvailablePort,
+  startRealBackendBrowserHarness,
+  waitForPortAvailable,
+} from "../integration/browser-test-harness.mjs";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(dirname, "..", "..");
+const cacheDirectoryPrefix = "you-browser-harness-measurement-";
+const defaultRunsPerCondition = 1;
+// One extra Go runner matches the lane's normal shared-runner pressure while
+// leaving the measurement process enough CPU to report its own startup phases.
+const defaultContentionJobs = 1;
+const measurementConditions = ["cold", "warm", "contended"];
+const measurementEnvironmentNames = [
+  "GOCACHE",
+  "GOMODCACHE",
+  "GOPATH",
+  "GOTOOLCHAIN",
+];
+
+function numericOption(args, name, fallback, minimum) {
+  const prefix = `--${name}=`;
+  const value = args
+    .find((arg) => arg.startsWith(prefix))
+    ?.slice(prefix.length);
+  if (value === undefined) {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < minimum) {
+    throw new Error(`--${name} must be an integer >= ${minimum}.`);
+  }
+  return parsed;
+}
+
+function selectedConditions(args) {
+  const requested = args
+    .find((arg) => arg.startsWith("--conditions="))
+    ?.slice("--conditions=".length)
+    .split(",")
+    .filter(Boolean);
+  const conditions = requested ?? measurementConditions;
+  const invalid = conditions.filter(
+    (condition) => !measurementConditions.includes(condition),
+  );
+  if (invalid.length > 0) {
+    throw new Error(
+      `--conditions contains unsupported values: ${invalid.join(", ")}.`,
+    );
+  }
+  return conditions;
+}
+
+function environmentWithMeasurementCaches(cacheRoot) {
+  return {
+    ...process.env,
+    GOCACHE: path.join(cacheRoot, "go-build"),
+    GOMODCACHE: path.join(cacheRoot, "gomodcache"),
+    GOPATH: path.join(cacheRoot, "gopath"),
+    GOTOOLCHAIN: "auto",
+  };
+}
+
+function restoreEnvironment(originalEnvironment) {
+  for (const name of measurementEnvironmentNames) {
+    const originalValue = originalEnvironment[name];
+    if (originalValue === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = originalValue;
+    }
+  }
+}
+
+function applyEnvironment(measurementEnvironment) {
+  for (const name of measurementEnvironmentNames) {
+    process.env[name] = measurementEnvironment[name];
+  }
+}
+
+function spawnContentionJob(measurementEnvironment) {
+  return new Promise((resolve) => {
+    const child = spawn(
+      "go",
+      [
+        "test",
+        "./tests/functional/internal/support/cmd/browser_api_harness",
+        "-run",
+        "^$",
+        "-count=1",
+      ],
+      {
+        cwd: repositoryRoot,
+        env: measurementEnvironment,
+        shell: false,
+        stdio: "ignore",
+      },
+    );
+    child.once("error", (error) => resolve({ error }));
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+async function runMeasurement(condition, runNumber, contentionJobs) {
+  const cacheRoot = process.env.GO_BROWSER_HARNESS_MEASUREMENT_ROOT;
+  if (condition === "cold") {
+    await rm(cacheRoot, { force: true, recursive: true });
+    await mkdir(cacheRoot, { recursive: true });
+  }
+  const measurementEnvironment = environmentWithMeasurementCaches(cacheRoot);
+  applyEnvironment(measurementEnvironment);
+
+  const contention =
+    condition === "contended"
+      ? Array.from({ length: contentionJobs }, () =>
+          spawnContentionJob(measurementEnvironment),
+        )
+      : [];
+  const apiPort = await findAvailablePort();
+  let backend;
+  try {
+    backend = await startRealBackendBrowserHarness({
+      apiPort,
+      requestID: `req-browser-harness-measurement-${condition}-${runNumber}`,
+      startMode: "sync",
+      workflowFixture: "agent-run-fake-child.workflow.js",
+      workflowName: "agent-run-fake-child",
+    });
+    console.log(
+      `[real-backend-browser-harness-measurement] condition=${condition} run=${runNumber} ${JSON.stringify(backend.startupTimings)}`,
+    );
+  } finally {
+    await backend?.stop().catch(() => {});
+    await waitForPortAvailable("127.0.0.1", apiPort, 5_000, 50).catch(() => {});
+    await Promise.all(contention);
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const conditions = selectedConditions(args);
+  const runs = numericOption(args, "runs", defaultRunsPerCondition, 1);
+  const contentionJobs = numericOption(
+    args,
+    "contention-jobs",
+    defaultContentionJobs,
+    1,
+  );
+  const originalEnvironment = {
+    GOCACHE: process.env.GOCACHE,
+    GOMODCACHE: process.env.GOMODCACHE,
+    GOPATH: process.env.GOPATH,
+    GOTOOLCHAIN: process.env.GOTOOLCHAIN,
+  };
+  const cacheRoot = await mkdtemp(path.join(os.tmpdir(), cacheDirectoryPrefix));
+  process.env.GO_BROWSER_HARNESS_MEASUREMENT_ROOT = cacheRoot;
+
+  try {
+    for (const condition of conditions) {
+      if (condition === "warm" && !conditions.includes("cold")) {
+        console.log(
+          "[real-backend-browser-harness-measurement] warm condition uses an initially empty isolated cache; include cold first for a populated-cache comparison.",
+        );
+      }
+      for (let runNumber = 1; runNumber <= runs; runNumber += 1) {
+        await runMeasurement(condition, runNumber, contentionJobs);
+      }
+    }
+  } finally {
+    restoreEnvironment(originalEnvironment);
+    delete process.env.GO_BROWSER_HARNESS_MEASUREMENT_ROOT;
+    await rm(cacheRoot, { force: true, recursive: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(
+    `[real-backend-browser-harness-measurement] failed: ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exitCode = 1;
+});

--- a/ui/scripts/run-durable-session-real-backend-integration-with-timings.mjs
+++ b/ui/scripts/run-durable-session-real-backend-integration-with-timings.mjs
@@ -1,9 +1,39 @@
+import {
+  buildRealBackendBrowserHarness,
+  realBackendHarnessArtifactEnvironmentVariable,
+} from "../integration/browser-test-harness.mjs";
 import { runFocusedBrowserIntegration } from "./ui-integration-runner.mjs";
 import {
   durableSessionRealBackendIntegrationFiles,
   durableSessionRealBackendIntegrationPhaseName,
 } from "./ui-integration-targets.mjs";
 
-runFocusedBrowserIntegration(durableSessionRealBackendIntegrationFiles, {
-  phaseName: durableSessionRealBackendIntegrationPhaseName,
+async function main() {
+  const artifact = await buildRealBackendBrowserHarness();
+  const previousArtifactPath =
+    process.env[realBackendHarnessArtifactEnvironmentVariable];
+  process.env[realBackendHarnessArtifactEnvironmentVariable] =
+    artifact.artifactPath;
+
+  try {
+    runFocusedBrowserIntegration(durableSessionRealBackendIntegrationFiles, {
+      exitOnFailure: false,
+      phaseName: durableSessionRealBackendIntegrationPhaseName,
+    });
+  } finally {
+    if (previousArtifactPath === undefined) {
+      delete process.env[realBackendHarnessArtifactEnvironmentVariable];
+    } else {
+      process.env[realBackendHarnessArtifactEnvironmentVariable] =
+        previousArtifactPath;
+    }
+    await artifact.cleanup();
+  }
+}
+
+main().catch((error) => {
+  console.error(
+    `[real-backend-browser-harness] ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exitCode = 1;
 });

--- a/ui/scripts/ui-integration-runner.mjs
+++ b/ui/scripts/ui-integration-runner.mjs
@@ -54,6 +54,7 @@ export function formatPhaseElapsed(phaseName, elapsedMs) {
 }
 
 function runVitestIntegrationPass({
+  exitOnFailure = true,
   vitestArgs,
   phaseName,
   slowFileSummaryTitle,
@@ -89,7 +90,13 @@ function runVitestIntegrationPass({
 
   const status = result.status ?? 1;
   if (status !== 0) {
-    process.exit(status);
+    if (exitOnFailure) {
+      process.exit(status);
+      return;
+    }
+    throw new Error(
+      `${phaseName} failed with exit status ${status}; see the Vitest output above.`,
+    );
   }
 }
 
@@ -98,6 +105,7 @@ export function runBrowserIntegration(options = {}) {
     vitestArgs: buildBrowserIntegrationVitestArgs(),
     phaseName: browserIntegrationPhaseName,
     slowFileSummaryTitle: "Browser integration slowest test files",
+    exitOnFailure: options.exitOnFailure,
     spawn: options.spawn,
   });
 }
@@ -108,6 +116,7 @@ export function runFocusedBrowserIntegration(files, options = {}) {
     phaseName:
       options.phaseName ??
       `Focused browser integration Vitest pass (${files.length} files)`,
+    exitOnFailure: options.exitOnFailure,
     slowFileSummaryTitle: "Focused browser integration slowest test files",
     spawn: options.spawn,
   });

--- a/ui/scripts/ui-integration-runner.test.mjs
+++ b/ui/scripts/ui-integration-runner.test.mjs
@@ -118,3 +118,21 @@ test("runFocusedBrowserIntegration runs only the requested integration files", (
   log.mockRestore();
   exit.mockRestore();
 });
+
+test("runFocusedBrowserIntegration can throw failures for cleanup-safe callers", () => {
+  const spawn = vi.fn(() => ({
+    status: 1,
+    stdout: "failed integration output",
+  }));
+  const exit = vi.spyOn(process, "exit").mockImplementation(() => {});
+
+  expect(() =>
+    runFocusedBrowserIntegration(durableSessionRealBackendIntegrationFiles, {
+      exitOnFailure: false,
+      spawn,
+    }),
+  ).toThrow(/Focused browser integration Vitest pass \(2 files\) failed/);
+  expect(exit).not.toHaveBeenCalled();
+
+  exit.mockRestore();
+});


### PR DESCRIPTION
{
  "project": "Deflake Durable-Session Browser Harness Readiness",
  "branchName": "ci-deflake-durable-session-browser-harness-readiness-timeout",
  "description": "Deflake the required UI Backend Integration lane by measuring the real browser API harness startup phases, moving confirmed compilation work outside the runtime readiness window and executing one prebuilt artifact per target run, surfacing live phase-aware diagnostics, and proving the exact delivered Make target remains reliably beneath its readiness budget without weakening durable-session coverage or required checks.",
  "context": {
    "customerAsk": "Deflake the main-blocking `Timed out waiting for real backend browser harness readiness` failure owned by `ui/integration/browser-test-harness.mjs`, the `ui-durable-session-real-backend-integration-test` Make target, and its `UI Backend Integration` CI step. Confirm the bottleneck before changing behavior, prefer compile-once/execute-prebuilt when compilation is responsible, retain strong required checks, and demonstrate reliability with repeated real-job evidence or a measured startup distribution.",
    "problem": "`startRealBackendBrowserHarness` invokes `go run` and waits 90 seconds for the process's first stdout line. Five recent main runs produced neither stdout nor stderr before timing out, interleaved with passing runs of the same lane. The pattern is a shared CI flake, likely but not yet proven to be cold Go compilation under contention. Because Verification Policy aggregates this required job and cannot be bypassed, the flake blocks unrelated correct pull requests from merging.",
    "solution": "Measure cache resolution, build/setup, process launch, and first-ready-line latency under cold, warm, and CI-comparable contended conditions. If compilation is the bottleneck, build the real browser API harness once per Make-target execution outside readiness timing and launch that artifact for all scenarios; otherwise fix the measured cause and justify any timeout change with observed headroom. Stream safe phase-aware diagnostics, preserve lifecycle and readiness semantics, and validate the exact real-artifact target repeatedly."
  },
  "acceptanceCriteria": [
    "CI-comparable cold-cache, warm-cache, and contended measurements distinguish Go cache resolution, build/setup duration, process launch, and time to the first valid readiness payload; the evidence states whether this job receives a reusable warm GOCACHE/GOMODCACHE and identifies the actual bottleneck.",
    "The measured bottleneck is removed from or made reliably bounded within the readiness path: when compilation is responsible, the real harness is built once per Make-target execution outside the 90-second readiness window and each browser scenario launches that artifact instead of `go run`; any different fix or timeout change is tied to measured cause and documented safety margin rather than a blind increase.",
    "Harness setup and startup emit safe, phase-aware diagnostics continuously to the CI log, preserve the first-stdout-line JSON readiness contract, report early exit and timeout context, and always stop child processes and remove temporary homes/artifacts on success or failure.",
    "The exact `make ui-durable-session-real-backend-integration-test` path continues to execute all three real durable-session browser scenarios without skips, retries that hide failures, weakened assertions, or changes to UI Backend Integration/Verification Policy; no application/product code or parked-lane work is changed.",
    "Runtime-proof classification: this lane changes runtime-observable CI lifecycle behavior. Build the real delivered browser API harness artifact, exercise the delivered behavior end to end through `make ui-durable-session-real-backend-integration-test`, and record the verbatim commands and output. Prove either at least five executions on an otherwise-unchanged head with zero readiness timeouts or a measured before/after distribution whose reported p99 and maximum show a real, justified margin below the readiness budget. Green tests, an inspected diff, or implementer claims alone do not satisfy this proof.",
    "Quality gates pass: typecheck and focused harness/integration tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green; the required PR checks include successful UI Backend Integration and Verification Policy results.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The worker/reviewer cycle continues until all required CI is terminal and passing, every blocking PR conversation is explicitly addressed, conflicts and shared-file churn are resolved, and the PR is merged. Review also records the post-merge main run showing UI Backend Integration and Verification Policy passing on the merge commit and initiates remediation if that validation fails."
  ],
  "userStories": [
    {
      "id": "ci-deflake-durable-session-browser-harness-readiness-timeout-001",
      "title": "Identify the readiness bottleneck with phase timing",
      "description": "As a CI maintainer, I need cold, warm, and contended harness-startup timing so the fix addresses the phase that actually exhausts the readiness budget.",
      "acceptanceCriteria": [
        "A CI-comparable diagnostic run reports separate durations for Go cache resolution, harness compilation/setup, process launch, and receipt of the first valid JSON readiness payload.",
        "Measurements cover cold and warm GOCACHE/GOMODCACHE conditions plus representative concurrent runner load, without changing the durable-session scenarios' pass/fail behavior.",
        "Evidence states the resolved cache reuse characteristics for this job and identifies whether compilation, process startup, or a later initialization phase consumes the budget.",
        "Timing output is emitted during the run and contains no customer-home path, credentials, request payload contents, or other sensitive data.",
        "Focused tests prove phase timing is produced on ready, early-exit, and timeout paths without replacing behavioral assertions with implementation-inventory checks.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added monotonic cache-resolution, go-run compilation/setup, process-launch, application-startup, and first-ready-payload timings with safe phase/stderr diagnostics. The isolated matrix measured cold, warm, and one-runner-contended conditions; cold initial caches were missing and toolchain bootstrap dominated, while warm/contended caches were reusable. Focused lifecycle tests cover ready, early exit, timeout, and redaction; exact make target passed all 3 durable scenarios plus setup, and UI typecheck passed."
    },
    {
      "id": "ci-deflake-durable-session-browser-harness-readiness-timeout-002",
      "title": "Launch the real harness through the evidence-selected startup path",
      "description": "As a contributor, I need the real backend harness to become ready within a predictable budget so unrelated pull requests are not blocked by compilation or another measured setup delay.",
      "acceptanceCriteria": [
        "When story 001 confirms compilation as the bottleneck, the Make target builds the real browser_api_harness once before readiness timing starts and all durable-session browser scenarios execute that artifact rather than invoking `go run`; if another cause is proven, the implementation fixes that measured cause and records why the compile-once path is not applicable.",
        "A harness build failure fails before browser execution with its command phase and actionable captured output, rather than being mislabeled as a readiness timeout.",
        "Runtime readiness timing begins only when the built harness process is launched and still requires its first valid stdout line within the configured budget.",
        "The ready JSON payload, arguments, environment isolation, exit handling, process-group shutdown, temporary customer-home cleanup, and artifact cleanup remain correct on success, early exit, malformed readiness output, timeout, and test failure.",
        "No timeout is raised unless measured before/after data establishes a safe value and explains the retained margin; test skips, automatic reruns, and relaxed durable-session assertions are not used as the fix.",
        "Focused tests cover successful prebuild/launch, build failure, early process exit, malformed readiness output, readiness timeout, and cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added a single real browser_api_harness go build before the focused Make-target browser run, passed the resulting platform executable to every durable-session scenario, retained the first stdout JSON readiness contract and isolated HOME/USERPROFILE, and added distinct build failure diagnostics with bounded sanitized output. Focused tests cover successful prebuild/launch, build failure and cleanup, early exit, malformed readiness, and timeout; typecheck, lint, Go harness tests, and the exact make target pass (3 durable scenarios, 11 focused tests)."
    },
    {
      "id": "ci-deflake-durable-session-browser-harness-readiness-timeout-003",
      "title": "Surface live diagnostics and prove durable CI readiness",
      "description": "As a reviewer, I need actionable live startup output and repeated proof from the delivered path so I can distinguish a fixed flake from a one-off passing run.",
      "acceptanceCriteria": [
        "Build/setup phase transitions and safe child stderr are written to the CI log as they occur; stdout diagnostics do not consume or precede the harness's first-line JSON readiness payload, and timeout/early-exit errors include phase, elapsed time, exit facts, and bounded captured context.",
        "The exact Make target executes the three named real durable-session browser scenarios and preserves their loading, summary, dispatch-detail, and artifact-detail assertions without skips, hidden retries, or product-code changes.",
        "Runtime-proof classification: this lane changes runtime-observable CI lifecycle behavior. Build the real delivered browser API harness artifact, exercise the delivered behavior end to end through `make ui-durable-session-real-backend-integration-test`, and record the verbatim commands and output. Prove either at least five executions on an otherwise-unchanged head with zero readiness timeouts or a measured before/after distribution whose reported p99 and maximum show a real, justified margin below the readiness budget. Green tests, an inspected diff, or implementer claims alone do not satisfy this proof.",
        "Required PR evidence identifies the change's own UI Backend Integration and Verification Policy results; CI-run evidence is posted in a PR comment and is never committed.",
        "No application/product code in pkg/services/recordings or pkg/services/factory_sessions and none of the five parked lanes is changed; UI Backend Integration and Verification Policy remain enabled and required.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Live build/setup transitions and sanitized child stderr remain on stderr while the first stdout line stays the validated readiness JSON payload; timeout/early-exit errors include phase, elapsed timings, exit facts, and bounded captured context. The exact command `make ui-durable-session-real-backend-integration-test` ran five times on commit 0b19aac37 after hardening Windows process-tree shutdown and bounded temporary-home/artifact removal retries: 5/5 exit 0, each run reported 2 files and 11 tests passed, and cleanup completed. Prebuilt-artifact readiness first-ready-payload timings ranged from 854.8 ms to 2,965.5 ms (max 2,965.5 ms versus the 90,000 ms budget). UI typecheck, full UI lint, focused lifecycle/runner tests, and the Go harness package test passed; no product or parked-lane files changed."
    }
  ]
}
