### PR TITLE
unit-test-optimization-c02-platform-httpserver

### DIFF
--- a/pkg/platform/httpserver/diagnostics_edge_test.go
+++ b/pkg/platform/httpserver/diagnostics_edge_test.go
@@ -26,7 +26,7 @@ func TestHandlerWithPprofHandlesNilHandlerAndDirectProfileDispatch(t *testing.T)
 
 	request := httptest.NewRequest(http.MethodGet, pprofPath+"heap", nil)
 	response := httptest.NewRecorder()
-	pprofIndex(response, request)
+	pprofIndexWithWaiter(waitPprofDuration)(response, request)
 	if response.Code != http.StatusOK || response.Body.Len() == 0 {
 		t.Fatalf("direct pprof profile = (%d, %d bytes), want non-empty 200 response", response.Code, response.Body.Len())
 	}
@@ -57,7 +57,7 @@ func TestHandlerWithPprofHandlesNilHandlerAndDirectProfileDispatch(t *testing.T)
 
 func TestPprofIndexPreservesStandardHTMLLayout(t *testing.T) {
 	response := httptest.NewRecorder()
-	pprofIndex(response, httptest.NewRequest(http.MethodGet, pprofPath, nil))
+	pprofIndexWithWaiter(waitPprofDuration)(response, httptest.NewRequest(http.MethodGet, pprofPath, nil))
 
 	body := response.Body.String()
 	if !strings.Contains(body, "<ul>\n<li><div class=profile-name>") {
@@ -70,14 +70,14 @@ func TestPprofIndexPreservesStandardHTMLLayout(t *testing.T) {
 
 func TestPprofNamedReportsUnknownProfileAndDebugFormat(t *testing.T) {
 	unknownResponse := httptest.NewRecorder()
-	pprofNamed("does-not-exist").ServeHTTP(unknownResponse, httptest.NewRequest(http.MethodGet, "/debug/pprof/does-not-exist", nil))
+	pprofNamedWithWaiter("does-not-exist", waitPprofDuration).ServeHTTP(unknownResponse, httptest.NewRequest(http.MethodGet, "/debug/pprof/does-not-exist", nil))
 	if unknownResponse.Code != http.StatusNotFound || unknownResponse.Header().Get("X-Go-Pprof") != "1" ||
 		!strings.Contains(unknownResponse.Body.String(), "Unknown profile") {
 		t.Fatalf("unknown profile = (%d, %q, headers=%v), want pprof 404", unknownResponse.Code, unknownResponse.Body.String(), unknownResponse.Header())
 	}
 
 	debugResponse := httptest.NewRecorder()
-	pprofNamed("heap").ServeHTTP(debugResponse, httptest.NewRequest(http.MethodGet, "/debug/pprof/heap?debug=1&gc=1", nil))
+	pprofNamedWithWaiter("heap", waitPprofDuration).ServeHTTP(debugResponse, httptest.NewRequest(http.MethodGet, "/debug/pprof/heap?debug=1&gc=1", nil))
 	if debugResponse.Code != http.StatusOK || debugResponse.Body.Len() == 0 {
 		t.Fatalf("debug heap = (%d, %d bytes), want non-empty 200 response", debugResponse.Code, debugResponse.Body.Len())
 	}
@@ -109,7 +109,7 @@ func TestPprofDeltaReportsInvalidUnsupportedAndDebugQueries(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			request := httptest.NewRequest(http.MethodGet, "/debug/pprof/heap?"+test.query, nil)
 			response := httptest.NewRecorder()
-			servePprofDeltaProfile(response, request, test.profileName, profile, request.URL.Query().Get("seconds"))
+			servePprofDeltaProfileWithWaiter(response, request, test.profileName, profile, request.URL.Query().Get("seconds"), waitPprofDuration)
 			if response.Code != test.wantStatus || !strings.Contains(response.Body.String(), test.wantBody) {
 				t.Fatalf("delta response = (%d, %q), want %d containing %q", response.Code, response.Body.String(), test.wantStatus, test.wantBody)
 			}
@@ -180,7 +180,7 @@ func TestPprofCommandLineAndIndexHandleInjectedWriterOutcomes(t *testing.T) {
 	}
 
 	indexResponse := &failingRuntimeResponseWriter{header: make(http.Header)}
-	pprofIndex(indexResponse, httptest.NewRequest(http.MethodGet, pprofPath, nil))
+	pprofIndexWithWaiter(waitPprofDuration)(indexResponse, httptest.NewRequest(http.MethodGet, pprofPath, nil))
 	if indexResponse.writes != 1 {
 		t.Fatalf("index response writes = %d, want one failed write", indexResponse.writes)
 	}
@@ -190,54 +190,79 @@ func TestPprofCPUAndTraceApplyDefaultsAndReportActiveRuntimeEffects(t *testing.T
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	waitDurations := make([]time.Duration, 0, 2)
-	waiter := func(ctx context.Context, duration time.Duration) error {
+	waiter := recordingPprofWaiter(&waitDurations)
+
+	assertControlledPprofCPU(t, ctx, waiter)
+	assertActivePprofCPU(t, waiter)
+	assertControlledPprofTrace(t, ctx, waiter)
+	assertActivePprofTrace(t, waiter)
+	if got, want := fmt.Sprint(waitDurations), "[30s 1s]"; fmt.Sprint(waitDurations) != want {
+		t.Fatalf("controlled pprof wait durations = %s, want %s", got, want)
+	}
+}
+
+func recordingPprofWaiter(waitDurations *[]time.Duration) pprofDurationWaiter {
+	return func(ctx context.Context, duration time.Duration) error {
 		if ctx == nil {
 			return errors.New("waiter context is nil")
 		}
-		waitDurations = append(waitDurations, duration)
+		*waitDurations = append(*waitDurations, duration)
 		return ctx.Err()
 	}
+}
 
-	cpuResponse := httptest.NewRecorder()
-	pprofCPUWithWaiter(waiter)(cpuResponse, httptest.NewRequest(http.MethodGet, "/debug/pprof/profile?seconds=invalid", nil).WithContext(ctx))
-	if cpuResponse.Code != http.StatusOK || cpuResponse.Body.Len() == 0 {
-		t.Fatalf("default CPU profile = (%d, %d bytes), want non-empty 200 response", cpuResponse.Code, cpuResponse.Body.Len())
+func assertControlledPprofCPU(t *testing.T, ctx context.Context, waiter pprofDurationWaiter) {
+	t.Helper()
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/debug/pprof/profile?seconds=invalid", nil).WithContext(ctx)
+	pprofCPUWithWaiter(waiter)(response, request)
+	if response.Code != http.StatusOK || response.Body.Len() == 0 {
+		t.Fatalf("default CPU profile = (%d, %d bytes), want non-empty 200 response", response.Code, response.Body.Len())
 	}
-	cpuProfile, err := profile.Parse(bytes.NewReader(cpuResponse.Body.Bytes()))
-	if err != nil || cpuProfile == nil || len(cpuProfile.SampleType) == 0 {
-		t.Fatalf("controlled CPU profile = (%v, %+v), want parseable profile with sample types", err, cpuProfile)
+	parsed, err := profile.Parse(bytes.NewReader(response.Body.Bytes()))
+	if err != nil || parsed == nil || len(parsed.SampleType) == 0 {
+		t.Fatalf("controlled CPU profile = (%v, %+v), want parseable profile with sample types", err, parsed)
 	}
+}
 
+func assertActivePprofCPU(t *testing.T, waiter pprofDurationWaiter) {
+	t.Helper()
 	if err := runtimepprof.StartCPUProfile(io.Discard); err != nil {
 		t.Fatalf("start active CPU profile: %v", err)
 	}
-	activeCPUResponse := httptest.NewRecorder()
-	pprofCPUWithWaiter(waiter)(activeCPUResponse, httptest.NewRequest(http.MethodGet, "/debug/pprof/profile", nil))
-	runtimepprof.StopCPUProfile()
-	if activeCPUResponse.Code != http.StatusInternalServerError || !strings.Contains(activeCPUResponse.Body.String(), "CPU profiling") {
-		t.Fatalf("active CPU profile = (%d, %q), want pprof 500 error", activeCPUResponse.Code, activeCPUResponse.Body.String())
-	}
+	defer runtimepprof.StopCPUProfile()
 
-	traceResponse := httptest.NewRecorder()
-	pprofTraceWithWaiter(waiter)(traceResponse, httptest.NewRequest(http.MethodGet, "/debug/pprof/trace?seconds=invalid", nil).WithContext(ctx))
-	if traceResponse.Code != http.StatusOK || traceResponse.Body.Len() == 0 {
-		t.Fatalf("default trace = (%d, %d bytes), want non-empty 200 response", traceResponse.Code, traceResponse.Body.Len())
+	response := httptest.NewRecorder()
+	pprofCPUWithWaiter(waiter)(response, httptest.NewRequest(http.MethodGet, "/debug/pprof/profile", nil))
+	if response.Code != http.StatusInternalServerError || !strings.Contains(response.Body.String(), "CPU profiling") {
+		t.Fatalf("active CPU profile = (%d, %q), want pprof 500 error", response.Code, response.Body.String())
 	}
-	if !bytes.HasPrefix(traceResponse.Body.Bytes(), []byte("go ")) {
-		t.Fatalf("controlled trace prefix = %q, want Go trace framing", traceResponse.Body.Bytes()[:min(3, traceResponse.Body.Len())])
-	}
+}
 
+func assertControlledPprofTrace(t *testing.T, ctx context.Context, waiter pprofDurationWaiter) {
+	t.Helper()
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/debug/pprof/trace?seconds=invalid", nil).WithContext(ctx)
+	pprofTraceWithWaiter(waiter)(response, request)
+	if response.Code != http.StatusOK || response.Body.Len() == 0 {
+		t.Fatalf("default trace = (%d, %d bytes), want non-empty 200 response", response.Code, response.Body.Len())
+	}
+	if !bytes.HasPrefix(response.Body.Bytes(), []byte("go ")) {
+		t.Fatalf("controlled trace prefix = %q, want Go trace framing", response.Body.Bytes()[:min(3, response.Body.Len())])
+	}
+}
+
+func assertActivePprofTrace(t *testing.T, waiter pprofDurationWaiter) {
+	t.Helper()
 	if err := runtimetrace.Start(io.Discard); err != nil {
 		t.Fatalf("start active trace: %v", err)
 	}
-	activeTraceResponse := httptest.NewRecorder()
-	pprofTraceWithWaiter(waiter)(activeTraceResponse, httptest.NewRequest(http.MethodGet, "/debug/pprof/trace", nil))
-	runtimetrace.Stop()
-	if activeTraceResponse.Code != http.StatusInternalServerError || !strings.Contains(activeTraceResponse.Body.String(), "tracing") {
-		t.Fatalf("active trace = (%d, %q), want pprof 500 error", activeTraceResponse.Code, activeTraceResponse.Body.String())
-	}
-	if got, want := fmt.Sprint(waitDurations), "[30s 1s]"; fmt.Sprint(waitDurations) != want {
-		t.Fatalf("controlled pprof wait durations = %s, want %s", got, want)
+	defer runtimetrace.Stop()
+
+	response := httptest.NewRecorder()
+	pprofTraceWithWaiter(waiter)(response, httptest.NewRequest(http.MethodGet, "/debug/pprof/trace", nil))
+	if response.Code != http.StatusInternalServerError || !strings.Contains(response.Body.String(), "tracing") {
+		t.Fatalf("active trace = (%d, %q), want pprof 500 error", response.Code, response.Body.String())
 	}
 }
 

--- a/pkg/platform/httpserver/diagnostics_edge_test.go
+++ b/pkg/platform/httpserver/diagnostics_edge_test.go
@@ -1,6 +1,7 @@
 package httpserver
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -14,6 +15,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/pprof/profile"
 )
 
 func TestHandlerWithPprofHandlesNilHandlerAndDirectProfileDispatch(t *testing.T) {
@@ -26,6 +29,29 @@ func TestHandlerWithPprofHandlesNilHandlerAndDirectProfileDispatch(t *testing.T)
 	pprofIndex(response, request)
 	if response.Code != http.StatusOK || response.Body.Len() == 0 {
 		t.Fatalf("direct pprof profile = (%d, %d bytes), want non-empty 200 response", response.Code, response.Body.Len())
+	}
+
+	waitCalls := 0
+	controlled := handlerWithPprof(http.NotFoundHandler(), true, nil, func(ctx context.Context, duration time.Duration) error {
+		if ctx == nil {
+			t.Fatal("controlled pprof waiter received nil context")
+		}
+		if duration != time.Second {
+			t.Fatalf("controlled pprof wait duration = %s, want 1s", duration)
+		}
+		waitCalls++
+		return nil
+	})
+	controlledResponse := httptest.NewRecorder()
+	controlled.ServeHTTP(controlledResponse, httptest.NewRequest(http.MethodGet, pprofPath+"heap?seconds=1", nil))
+	if controlledResponse.Code != http.StatusOK || controlledResponse.Body.Len() == 0 {
+		t.Fatalf("controlled heap delta = (%d, %d bytes), want non-empty 200 response", controlledResponse.Code, controlledResponse.Body.Len())
+	}
+	if _, err := profile.Parse(bytes.NewReader(controlledResponse.Body.Bytes())); err != nil {
+		t.Fatalf("parse controlled heap delta: %v", err)
+	}
+	if waitCalls != 1 {
+		t.Fatalf("controlled pprof waiter calls = %d, want 1", waitCalls)
 	}
 }
 
@@ -99,21 +125,30 @@ func TestPprofDeltaReportsDeadlineAndCancellation(t *testing.T) {
 	if profile == nil {
 		t.Fatal("runtime heap profile is unavailable")
 	}
+	waiter := func(ctx context.Context, _ time.Duration) error {
+		if ctx == nil {
+			return errors.New("waiter context is nil")
+		}
+		return ctx.Err()
+	}
 
 	deadlineContext, cancelDeadline := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 	defer cancelDeadline()
 	deadlineRequest := httptest.NewRequest(http.MethodGet, "/debug/pprof/heap", nil).WithContext(deadlineContext)
 	deadlineResponse := httptest.NewRecorder()
-	servePprofDeltaProfile(deadlineResponse, deadlineRequest, "heap", profile, "1")
+	servePprofDeltaProfileWithWaiter(deadlineResponse, deadlineRequest, "heap", profile, "1", waiter)
 	if deadlineResponse.Code != http.StatusRequestTimeout || !strings.Contains(deadlineResponse.Body.String(), context.DeadlineExceeded.Error()) {
 		t.Fatalf("deadline delta = (%d, %q), want 408 deadline error", deadlineResponse.Code, deadlineResponse.Body.String())
+	}
+	if err := waitPprofDuration(nil, time.Second); err == nil || err.Error() != "pprof duration wait: context is required" {
+		t.Fatalf("nil pprof wait context error = %v, want explicit context-required error", err)
 	}
 
 	canceledContext, cancel := context.WithCancel(context.Background())
 	cancel()
 	canceledRequest := httptest.NewRequest(http.MethodGet, "/debug/pprof/heap", nil).WithContext(canceledContext)
 	canceledResponse := httptest.NewRecorder()
-	servePprofDeltaProfile(canceledResponse, canceledRequest, "heap", profile, "1")
+	servePprofDeltaProfileWithWaiter(canceledResponse, canceledRequest, "heap", profile, "1", waiter)
 	if canceledResponse.Code != http.StatusInternalServerError || !strings.Contains(canceledResponse.Body.String(), context.Canceled.Error()) {
 		t.Fatalf("canceled delta = (%d, %q), want 500 cancellation error", canceledResponse.Code, canceledResponse.Body.String())
 	}
@@ -126,7 +161,9 @@ func TestPprofDeltaStopsOnWriterFailure(t *testing.T) {
 	}
 	response := &failingRuntimeResponseWriter{header: make(http.Header)}
 	request := httptest.NewRequest(http.MethodGet, "/debug/pprof/heap", nil)
-	servePprofDeltaProfile(response, request, "heap", profile, "1")
+	servePprofDeltaProfileWithWaiter(response, request, "heap", profile, "1", func(context.Context, time.Duration) error {
+		return nil
+	})
 	if response.writes != 1 {
 		t.Fatalf("delta response writes = %d, want one failed write", response.writes)
 	}
@@ -152,37 +189,55 @@ func TestPprofCommandLineAndIndexHandleInjectedWriterOutcomes(t *testing.T) {
 func TestPprofCPUAndTraceApplyDefaultsAndReportActiveRuntimeEffects(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
+	waitDurations := make([]time.Duration, 0, 2)
+	waiter := func(ctx context.Context, duration time.Duration) error {
+		if ctx == nil {
+			return errors.New("waiter context is nil")
+		}
+		waitDurations = append(waitDurations, duration)
+		return ctx.Err()
+	}
 
 	cpuResponse := httptest.NewRecorder()
-	pprofCPU(cpuResponse, httptest.NewRequest(http.MethodGet, "/debug/pprof/profile?seconds=invalid", nil).WithContext(ctx))
+	pprofCPUWithWaiter(waiter)(cpuResponse, httptest.NewRequest(http.MethodGet, "/debug/pprof/profile?seconds=invalid", nil).WithContext(ctx))
 	if cpuResponse.Code != http.StatusOK || cpuResponse.Body.Len() == 0 {
 		t.Fatalf("default CPU profile = (%d, %d bytes), want non-empty 200 response", cpuResponse.Code, cpuResponse.Body.Len())
+	}
+	cpuProfile, err := profile.Parse(bytes.NewReader(cpuResponse.Body.Bytes()))
+	if err != nil || cpuProfile == nil || len(cpuProfile.SampleType) == 0 {
+		t.Fatalf("controlled CPU profile = (%v, %+v), want parseable profile with sample types", err, cpuProfile)
 	}
 
 	if err := runtimepprof.StartCPUProfile(io.Discard); err != nil {
 		t.Fatalf("start active CPU profile: %v", err)
 	}
 	activeCPUResponse := httptest.NewRecorder()
-	pprofCPU(activeCPUResponse, httptest.NewRequest(http.MethodGet, "/debug/pprof/profile", nil))
+	pprofCPUWithWaiter(waiter)(activeCPUResponse, httptest.NewRequest(http.MethodGet, "/debug/pprof/profile", nil))
 	runtimepprof.StopCPUProfile()
 	if activeCPUResponse.Code != http.StatusInternalServerError || !strings.Contains(activeCPUResponse.Body.String(), "CPU profiling") {
 		t.Fatalf("active CPU profile = (%d, %q), want pprof 500 error", activeCPUResponse.Code, activeCPUResponse.Body.String())
 	}
 
 	traceResponse := httptest.NewRecorder()
-	pprofTrace(traceResponse, httptest.NewRequest(http.MethodGet, "/debug/pprof/trace?seconds=invalid", nil).WithContext(ctx))
+	pprofTraceWithWaiter(waiter)(traceResponse, httptest.NewRequest(http.MethodGet, "/debug/pprof/trace?seconds=invalid", nil).WithContext(ctx))
 	if traceResponse.Code != http.StatusOK || traceResponse.Body.Len() == 0 {
 		t.Fatalf("default trace = (%d, %d bytes), want non-empty 200 response", traceResponse.Code, traceResponse.Body.Len())
+	}
+	if !bytes.HasPrefix(traceResponse.Body.Bytes(), []byte("go ")) {
+		t.Fatalf("controlled trace prefix = %q, want Go trace framing", traceResponse.Body.Bytes()[:min(3, traceResponse.Body.Len())])
 	}
 
 	if err := runtimetrace.Start(io.Discard); err != nil {
 		t.Fatalf("start active trace: %v", err)
 	}
 	activeTraceResponse := httptest.NewRecorder()
-	pprofTrace(activeTraceResponse, httptest.NewRequest(http.MethodGet, "/debug/pprof/trace", nil))
+	pprofTraceWithWaiter(waiter)(activeTraceResponse, httptest.NewRequest(http.MethodGet, "/debug/pprof/trace", nil))
 	runtimetrace.Stop()
 	if activeTraceResponse.Code != http.StatusInternalServerError || !strings.Contains(activeTraceResponse.Body.String(), "tracing") {
 		t.Fatalf("active trace = (%d, %q), want pprof 500 error", activeTraceResponse.Code, activeTraceResponse.Body.String())
+	}
+	if got, want := fmt.Sprint(waitDurations), "[30s 1s]"; fmt.Sprint(waitDurations) != want {
+		t.Fatalf("controlled pprof wait durations = %s, want %s", got, want)
 	}
 }
 

--- a/pkg/platform/httpserver/pprof.go
+++ b/pkg/platform/httpserver/pprof.go
@@ -65,10 +65,6 @@ func handlerWithPprof(
 	return mux
 }
 
-func pprofIndex(writer http.ResponseWriter, request *http.Request) {
-	pprofIndexWithWaiter(waitPprofDuration)(writer, request)
-}
-
 func pprofIndexWithWaiter(waiter pprofDurationWaiter) http.HandlerFunc {
 	if waiter == nil {
 		waiter = waitPprofDuration
@@ -183,10 +179,6 @@ Profile Descriptions:
 	return err
 }
 
-func pprofNamed(name string) http.Handler {
-	return pprofNamedWithWaiter(name, waitPprofDuration)
-}
-
 func pprofNamedWithWaiter(name string, waiter pprofDurationWaiter) http.Handler {
 	if waiter == nil {
 		waiter = waitPprofDuration
@@ -218,16 +210,6 @@ func pprofNamedWithWaiter(name string, waiter pprofDurationWaiter) http.Handler 
 		}
 		_ = profile.WriteTo(writer, debug)
 	})
-}
-
-func servePprofDeltaProfile(
-	writer http.ResponseWriter,
-	request *http.Request,
-	name string,
-	profile *runtimepprof.Profile,
-	secondsValue string,
-) {
-	servePprofDeltaProfileWithWaiter(writer, request, name, profile, secondsValue, waitPprofDuration)
 }
 
 func servePprofDeltaProfileWithWaiter(
@@ -320,10 +302,6 @@ func pprofCmdline(commandLineReader CommandLineReader) http.HandlerFunc {
 	}
 }
 
-func pprofCPU(writer http.ResponseWriter, request *http.Request) {
-	pprofCPUWithWaiter(waitPprofDuration)(writer, request)
-}
-
 func pprofCPUWithWaiter(waiter pprofDurationWaiter) http.HandlerFunc {
 	if waiter == nil {
 		waiter = waitPprofDuration
@@ -343,10 +321,6 @@ func pprofCPUWithWaiter(waiter pprofDurationWaiter) http.HandlerFunc {
 		defer runtimepprof.StopCPUProfile()
 		_ = waiter(request.Context(), time.Duration(seconds)*time.Second)
 	}
-}
-
-func pprofTrace(writer http.ResponseWriter, request *http.Request) {
-	pprofTraceWithWaiter(waitPprofDuration)(writer, request)
 }
 
 func pprofTraceWithWaiter(waiter pprofDurationWaiter) http.HandlerFunc {

--- a/pkg/platform/httpserver/pprof.go
+++ b/pkg/platform/httpserver/pprof.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"html"
 	"io"
@@ -22,6 +23,8 @@ import (
 
 const pprofPath = "/debug/pprof/"
 
+type pprofDurationWaiter func(context.Context, time.Duration) error
+
 // HandlerWithPprof adds the standard Go pprof routes to one HTTP handler when
 // explicitly requested. The private mux keeps this server's registration
 // local; the serving path does not use the process-wide DefaultServeMux.
@@ -31,55 +34,76 @@ const pprofPath = "/debug/pprof/"
 // the same standard runtime profile and trace implementations while keeping
 // every HTTP route scoped to this server's mux.
 func HandlerWithPprof(handler http.Handler, enabled bool, commandLineReader CommandLineReader) http.Handler {
+	return handlerWithPprof(handler, enabled, commandLineReader, waitPprofDuration)
+}
+
+func handlerWithPprof(
+	handler http.Handler,
+	enabled bool,
+	commandLineReader CommandLineReader,
+	waiter pprofDurationWaiter,
+) http.Handler {
 	if !enabled || handler == nil {
 		return handler
 	}
+	if waiter == nil {
+		waiter = waitPprofDuration
+	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc(pprofPath, pprofIndex)
+	mux.HandleFunc(pprofPath, pprofIndexWithWaiter(waiter))
 	mux.HandleFunc(pprofPath+"cmdline", pprofCmdline(commandLineReader))
-	mux.HandleFunc(pprofPath+"profile", pprofCPU)
+	mux.HandleFunc(pprofPath+"profile", pprofCPUWithWaiter(waiter))
 	mux.HandleFunc(pprofPath+"symbol", pprofSymbol)
-	mux.HandleFunc(pprofPath+"trace", pprofTrace)
+	mux.HandleFunc(pprofPath+"trace", pprofTraceWithWaiter(waiter))
 	for _, profile := range []string{
 		"allocs", "block", "goroutine", "heap", "mutex", "threadcreate",
 	} {
-		mux.Handle(pprofPath+profile, pprofNamed(profile))
+		mux.Handle(pprofPath+profile, pprofNamedWithWaiter(profile, waiter))
 	}
 	mux.Handle("/", handler)
 	return mux
 }
 
 func pprofIndex(writer http.ResponseWriter, request *http.Request) {
-	if name, found := strings.CutPrefix(request.URL.Path, pprofPath); found && name != "" {
-		pprofNamed(name).ServeHTTP(writer, request)
-		return
-	}
+	pprofIndexWithWaiter(waitPprofDuration)(writer, request)
+}
 
-	writer.Header().Set("X-Content-Type-Options", "nosniff")
-	writer.Header().Set("Content-Type", "text/html; charset=utf-8")
-
-	profiles := make([]pprofEntry, 0, len(runtimepprof.Profiles())+4)
-	for _, profile := range runtimepprof.Profiles() {
-		name := profile.Name()
-		profiles = append(profiles, pprofEntry{
-			Name:  name,
-			Href:  name,
-			Desc:  pprofDescriptions[name],
-			Count: profile.Count(),
-		})
+func pprofIndexWithWaiter(waiter pprofDurationWaiter) http.HandlerFunc {
+	if waiter == nil {
+		waiter = waitPprofDuration
 	}
-	for _, name := range []string{"cmdline", "profile", "symbol", "trace"} {
-		profiles = append(profiles, pprofEntry{
-			Name: name,
-			Href: name,
-			Desc: pprofDescriptions[name],
-		})
-	}
-	sort.Slice(profiles, func(i, j int) bool { return profiles[i].Name < profiles[j].Name })
+	return func(writer http.ResponseWriter, request *http.Request) {
+		if name, found := strings.CutPrefix(request.URL.Path, pprofPath); found && name != "" {
+			pprofNamedWithWaiter(name, waiter).ServeHTTP(writer, request)
+			return
+		}
 
-	if err := writePprofIndex(writer, profiles); err != nil {
-		return
+		writer.Header().Set("X-Content-Type-Options", "nosniff")
+		writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+		profiles := make([]pprofEntry, 0, len(runtimepprof.Profiles())+4)
+		for _, profile := range runtimepprof.Profiles() {
+			name := profile.Name()
+			profiles = append(profiles, pprofEntry{
+				Name:  name,
+				Href:  name,
+				Desc:  pprofDescriptions[name],
+				Count: profile.Count(),
+			})
+		}
+		for _, name := range []string{"cmdline", "profile", "symbol", "trace"} {
+			profiles = append(profiles, pprofEntry{
+				Name: name,
+				Href: name,
+				Desc: pprofDescriptions[name],
+			})
+		}
+		sort.Slice(profiles, func(i, j int) bool { return profiles[i].Name < profiles[j].Name })
+
+		if err := writePprofIndex(writer, profiles); err != nil {
+			return
+		}
 	}
 }
 
@@ -160,6 +184,13 @@ Profile Descriptions:
 }
 
 func pprofNamed(name string) http.Handler {
+	return pprofNamedWithWaiter(name, waitPprofDuration)
+}
+
+func pprofNamedWithWaiter(name string, waiter pprofDurationWaiter) http.Handler {
+	if waiter == nil {
+		waiter = waitPprofDuration
+	}
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.Header().Set("X-Content-Type-Options", "nosniff")
 		profile := runtimepprof.Lookup(name)
@@ -168,7 +199,7 @@ func pprofNamed(name string) http.Handler {
 			return
 		}
 		if seconds := request.FormValue("seconds"); seconds != "" {
-			servePprofDeltaProfile(writer, request, name, profile, seconds)
+			servePprofDeltaProfileWithWaiter(writer, request, name, profile, seconds, waiter)
 			return
 		}
 
@@ -196,6 +227,20 @@ func servePprofDeltaProfile(
 	profile *runtimepprof.Profile,
 	secondsValue string,
 ) {
+	servePprofDeltaProfileWithWaiter(writer, request, name, profile, secondsValue, waitPprofDuration)
+}
+
+func servePprofDeltaProfileWithWaiter(
+	writer http.ResponseWriter,
+	request *http.Request,
+	name string,
+	profile *runtimepprof.Profile,
+	secondsValue string,
+	waiter pprofDurationWaiter,
+) {
+	if waiter == nil {
+		waiter = waitPprofDuration
+	}
 	seconds, err := strconv.ParseInt(secondsValue, 10, 64)
 	if err != nil || seconds <= 0 {
 		pprofError(writer, http.StatusBadRequest, `invalid value for "seconds" - must be a positive integer`)
@@ -217,17 +262,13 @@ func servePprofDeltaProfile(
 		return
 	}
 
-	timer := time.NewTimer(time.Duration(seconds) * time.Second)
-	defer timer.Stop()
-	select {
-	case <-request.Context().Done():
-		if request.Context().Err() == context.DeadlineExceeded {
-			pprofError(writer, http.StatusRequestTimeout, request.Context().Err().Error())
-		} else {
-			pprofError(writer, http.StatusInternalServerError, request.Context().Err().Error())
+	if err := waiter(request.Context(), time.Duration(seconds)*time.Second); err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, context.DeadlineExceeded) {
+			status = http.StatusRequestTimeout
 		}
+		pprofError(writer, status, err.Error())
 		return
-	case <-timer.C:
 	}
 
 	after, err := collectPprofProfile(profile)
@@ -280,43 +321,66 @@ func pprofCmdline(commandLineReader CommandLineReader) http.HandlerFunc {
 }
 
 func pprofCPU(writer http.ResponseWriter, request *http.Request) {
-	writer.Header().Set("X-Content-Type-Options", "nosniff")
-	seconds, err := strconv.ParseInt(request.FormValue("seconds"), 10, 64)
-	if seconds <= 0 || err != nil {
-		seconds = 30
+	pprofCPUWithWaiter(waitPprofDuration)(writer, request)
+}
+
+func pprofCPUWithWaiter(waiter pprofDurationWaiter) http.HandlerFunc {
+	if waiter == nil {
+		waiter = waitPprofDuration
 	}
-	writer.Header().Set("Content-Type", "application/octet-stream")
-	writer.Header().Set("Content-Disposition", `attachment; filename="profile"`)
-	if err := runtimepprof.StartCPUProfile(writer); err != nil {
-		pprofError(writer, http.StatusInternalServerError, fmt.Sprintf("Could not enable CPU profiling: %s", err))
-		return
+	return func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("X-Content-Type-Options", "nosniff")
+		seconds, err := strconv.ParseInt(request.FormValue("seconds"), 10, 64)
+		if seconds <= 0 || err != nil {
+			seconds = 30
+		}
+		writer.Header().Set("Content-Type", "application/octet-stream")
+		writer.Header().Set("Content-Disposition", `attachment; filename="profile"`)
+		if err := runtimepprof.StartCPUProfile(writer); err != nil {
+			pprofError(writer, http.StatusInternalServerError, fmt.Sprintf("Could not enable CPU profiling: %s", err))
+			return
+		}
+		defer runtimepprof.StopCPUProfile()
+		_ = waiter(request.Context(), time.Duration(seconds)*time.Second)
 	}
-	defer runtimepprof.StopCPUProfile()
-	waitPprofDuration(request, time.Duration(seconds)*time.Second)
 }
 
 func pprofTrace(writer http.ResponseWriter, request *http.Request) {
-	writer.Header().Set("X-Content-Type-Options", "nosniff")
-	seconds, err := strconv.ParseFloat(request.FormValue("seconds"), 64)
-	if seconds <= 0 || err != nil {
-		seconds = 1
-	}
-	writer.Header().Set("Content-Type", "application/octet-stream")
-	writer.Header().Set("Content-Disposition", `attachment; filename="trace"`)
-	if err := runtimetrace.Start(writer); err != nil {
-		pprofError(writer, http.StatusInternalServerError, fmt.Sprintf("Could not enable tracing: %s", err))
-		return
-	}
-	defer runtimetrace.Stop()
-	waitPprofDuration(request, time.Duration(seconds*float64(time.Second)))
+	pprofTraceWithWaiter(waitPprofDuration)(writer, request)
 }
 
-func waitPprofDuration(request *http.Request, duration time.Duration) {
+func pprofTraceWithWaiter(waiter pprofDurationWaiter) http.HandlerFunc {
+	if waiter == nil {
+		waiter = waitPprofDuration
+	}
+	return func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("X-Content-Type-Options", "nosniff")
+		seconds, err := strconv.ParseFloat(request.FormValue("seconds"), 64)
+		if seconds <= 0 || err != nil {
+			seconds = 1
+		}
+		writer.Header().Set("Content-Type", "application/octet-stream")
+		writer.Header().Set("Content-Disposition", `attachment; filename="trace"`)
+		if err := runtimetrace.Start(writer); err != nil {
+			pprofError(writer, http.StatusInternalServerError, fmt.Sprintf("Could not enable tracing: %s", err))
+			return
+		}
+		defer runtimetrace.Stop()
+		_ = waiter(request.Context(), time.Duration(seconds*float64(time.Second)))
+	}
+}
+
+func waitPprofDuration(ctx context.Context, duration time.Duration) error {
+	if ctx == nil {
+		return errors.New("pprof duration wait: context is required")
+	}
 	timer := time.NewTimer(duration)
 	defer timer.Stop()
 	select {
 	case <-timer.C:
-	case <-request.Context().Done():
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/pkg/platform/httpserver/pprof_test.go
+++ b/pkg/platform/httpserver/pprof_test.go
@@ -3,15 +3,25 @@ package httpserver
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/pprof/profile"
+)
+
+const (
+	pprofTestRequestTimeout = 10 * time.Second
+	pprofRealWaitMinimum    = 900 * time.Millisecond
+	pprofRealWaitMaximum    = 5 * time.Second
 )
 
 func TestHandlerWithPprofIsOptInAndUsesStandardRoutes(t *testing.T) {
@@ -23,24 +33,38 @@ func TestHandlerWithPprofIsOptInAndUsesStandardRoutes(t *testing.T) {
 	commandLineReader := CommandLineReader(func() []string { return []string{"you", "test"} })
 
 	disabled := httptest.NewServer(HandlerWithPprof(handler, false, commandLineReader))
-	defer disabled.Close()
-	assertDisabledPprofRoutes(t, disabled)
+	defer closePprofTestServer(disabled)
+	assertDisabledPprofRoutes(t, disabled, notFoundBody)
 
-	enabled := httptest.NewServer(HandlerWithPprof(handler, true, commandLineReader))
-	defer enabled.Close()
+	waitDurations := make([]time.Duration, 0, 3)
+	controlledWaiter := func(ctx context.Context, duration time.Duration) error {
+		if ctx == nil {
+			return errors.New("controlled pprof waiter: context is required")
+		}
+		waitDurations = append(waitDurations, duration)
+		return nil
+	}
+	enabled := httptest.NewServer(handlerWithPprof(handler, true, commandLineReader, controlledWaiter))
+	defer closePprofTestServer(enabled)
 	assertEnabledPprofRoutes(t, enabled)
+	if want := []time.Duration{time.Second, time.Second, time.Second}; !reflect.DeepEqual(waitDurations, want) {
+		t.Fatalf("controlled pprof wait durations = %v, want %v", waitDurations, want)
+	}
+
+	assertRealPprofRoute(t, handler, commandLineReader)
 }
 
-func assertDisabledPprofRoutes(t *testing.T, server *httptest.Server) {
+func assertDisabledPprofRoutes(t *testing.T, server *httptest.Server, wantBody string) {
 	t.Helper()
 	for _, path := range []string{
-		"/debug/pprof/", "/debug/pprof/heap", "/debug/pprof/allocs", "/debug/pprof/profile",
-		"/debug/pprof/trace", "/debug/pprof/goroutine", "/debug/pprof/cmdline",
-		"/debug/pprof/symbol",
+		"/debug/pprof/", "/debug/pprof/allocs", "/debug/pprof/block", "/debug/pprof/goroutine",
+		"/debug/pprof/heap", "/debug/pprof/mutex", "/debug/pprof/threadcreate",
+		"/debug/pprof/profile?seconds=1", "/debug/pprof/trace?seconds=1",
+		"/debug/pprof/cmdline", "/debug/pprof/symbol",
 	} {
 		response := getPprofTestResponse(t, server.URL+path)
-		if response.StatusCode != http.StatusNotFound {
-			t.Fatalf("disabled GET %s status = %d, want %d", path, response.StatusCode, http.StatusNotFound)
+		if response.StatusCode != http.StatusNotFound || string(response.Body) != wantBody {
+			t.Fatalf("disabled GET %s = (%d, %q), want application 404 body %q", path, response.StatusCode, response.Body, wantBody)
 		}
 	}
 }
@@ -55,21 +79,34 @@ func assertEnabledPprofRoutes(t *testing.T, server *httptest.Server) {
 func assertEnabledPprofIndexAndRoutes(t *testing.T, server *httptest.Server) {
 	t.Helper()
 	index := getPprofTestResponse(t, server.URL+"/debug/pprof/")
-	if index.StatusCode != http.StatusOK || !strings.Contains(string(index.Body), "heap") {
-		t.Fatalf("enabled pprof index = (%d, %q), want HTTP 200 with heap profile", index.StatusCode, index.Body)
+	if index.StatusCode != http.StatusOK {
+		t.Fatalf("enabled pprof index status = %d, want %d", index.StatusCode, http.StatusOK)
+	}
+	assertPprofResponseHeaders(t, index, "text/html; charset=utf-8", "")
+	indexBody := string(index.Body)
+	for _, name := range []string{
+		"allocs", "block", "cmdline", "goroutine", "heap", "mutex", "profile", "symbol", "threadcreate", "trace",
+	} {
+		link := fmt.Sprintf("<a href='%s?debug=1'>%s</a>", name, name)
+		if !strings.Contains(indexBody, link) || !strings.Contains(indexBody, name+":") {
+			t.Fatalf("enabled pprof index is missing route/description for %q: %q", name, indexBody)
+		}
 	}
 
-	for _, path := range []string{
-		"/debug/pprof/allocs", "/debug/pprof/goroutine", "/debug/pprof/cmdline",
-		"/debug/pprof/symbol",
-	} {
-		response := getPprofTestResponse(t, server.URL+path)
-		if response.StatusCode != http.StatusOK || len(response.Body) == 0 {
-			t.Fatalf("enabled GET %s = (%d, %q), want non-empty HTTP 200 response", path, response.StatusCode, response.Body)
-		}
-		if path == "/debug/pprof/cmdline" && string(response.Body) != "you\x00test" {
-			t.Fatalf("enabled cmdline = %q, want injected command line", response.Body)
-		}
+	commandLine := getPprofTestResponse(t, server.URL+"/debug/pprof/cmdline")
+	if commandLine.StatusCode != http.StatusOK || string(commandLine.Body) != "you\x00test" {
+		t.Fatalf("enabled cmdline = (%d, %q), want injected command line", commandLine.StatusCode, commandLine.Body)
+	}
+	assertPprofResponseHeaders(t, commandLine, "text/plain; charset=utf-8", "")
+
+	pc := reflect.ValueOf(pprofSymbol).Pointer()
+	symbol := getPprofTestResponse(t, fmt.Sprintf("%s/debug/pprof/symbol?0x%x+0", server.URL, pc))
+	if symbol.StatusCode != http.StatusOK || !strings.Contains(string(symbol.Body), "num_symbols: 1") {
+		t.Fatalf("enabled symbol = (%d, %q), want symbol response", symbol.StatusCode, symbol.Body)
+	}
+	assertPprofResponseHeaders(t, symbol, "text/plain; charset=utf-8", "")
+	if function := runtime.FuncForPC(pc); function != nil && !strings.Contains(string(symbol.Body), function.Name()) {
+		t.Fatalf("enabled symbol body = %q, want function %q", symbol.Body, function.Name())
 	}
 }
 
@@ -77,6 +114,7 @@ func assertEnabledPprofProfiles(t *testing.T, server *httptest.Server) {
 	t.Helper()
 	assertEnabledPprofHeap(t, server)
 	assertEnabledPprofNamedProfiles(t, server)
+	assertEnabledPprofCPU(t, server)
 	assertEnabledPprofHeapDelta(t, server)
 }
 
@@ -86,6 +124,7 @@ func assertEnabledPprofHeap(t *testing.T, server *httptest.Server) {
 	if heap.StatusCode != http.StatusOK || len(heap.Body) == 0 {
 		t.Fatalf("enabled pprof heap = (%d, body length %d), want non-empty HTTP 200 response", heap.StatusCode, len(heap.Body))
 	}
+	assertPprofResponseHeaders(t, heap, "application/octet-stream", `attachment; filename="heap"`)
 	heapProfile, err := profile.Parse(bytes.NewReader(heap.Body))
 	if err != nil {
 		t.Fatalf("parse enabled pprof heap profile: %v", err)
@@ -96,29 +135,44 @@ func assertEnabledPprofHeap(t *testing.T, server *httptest.Server) {
 func assertEnabledPprofNamedProfiles(t *testing.T, server *httptest.Server) {
 	t.Helper()
 	for _, test := range []struct {
-		path string
-		name string
+		path          string
+		name          string
+		requireSample bool
 	}{
-		{path: "/debug/pprof/goroutine", name: "goroutine"},
-		{path: "/debug/pprof/allocs", name: "allocs"},
-		{path: "/debug/pprof/profile?seconds=1", name: "CPU"},
+		{path: "/debug/pprof/goroutine", name: "goroutine", requireSample: true},
+		{path: "/debug/pprof/allocs", name: "allocs", requireSample: true},
+		{path: "/debug/pprof/block", name: "block"},
+		{path: "/debug/pprof/mutex", name: "mutex"},
+		{path: "/debug/pprof/threadcreate", name: "threadcreate"},
 	} {
 		response := getPprofTestResponse(t, server.URL+test.path)
 		if response.StatusCode != http.StatusOK || len(response.Body) == 0 {
 			t.Fatalf("enabled GET %s = (%d, body length %d), want non-empty HTTP 200 response", test.path, response.StatusCode, len(response.Body))
 		}
+		assertPprofResponseHeaders(t, response, "application/octet-stream", fmt.Sprintf(`attachment; filename="%s"`, test.name))
 		parsed, err := profile.Parse(bytes.NewReader(response.Body))
 		if err != nil {
 			t.Fatalf("parse enabled %s profile: %v", test.name, err)
 		}
-		if test.name == "CPU" {
-			if len(parsed.SampleType) == 0 {
-				t.Fatalf("%s profile has no sample types", test.name)
-			}
-		} else {
-			assertParsedPprofProfile(t, test.name, parsed)
+		assertPprofProfileSampleTypes(t, test.name, parsed)
+		if test.requireSample && len(parsed.Sample) == 0 {
+			t.Fatalf("%s profile has no samples", test.name)
 		}
 	}
+}
+
+func assertEnabledPprofCPU(t *testing.T, server *httptest.Server) {
+	t.Helper()
+	response := getPprofTestResponse(t, server.URL+"/debug/pprof/profile?seconds=1")
+	if response.StatusCode != http.StatusOK || len(response.Body) == 0 {
+		t.Fatalf("enabled CPU profile = (%d, body length %d), want non-empty HTTP 200 response", response.StatusCode, len(response.Body))
+	}
+	assertPprofResponseHeaders(t, response, "application/octet-stream", `attachment; filename="profile"`)
+	parsed, err := profile.Parse(bytes.NewReader(response.Body))
+	if err != nil {
+		t.Fatalf("parse enabled CPU profile: %v", err)
+	}
+	assertPprofProfileSampleTypes(t, "CPU", parsed)
 }
 
 func assertEnabledPprofHeapDelta(t *testing.T, server *httptest.Server) {
@@ -127,35 +181,61 @@ func assertEnabledPprofHeapDelta(t *testing.T, server *httptest.Server) {
 	if delta.StatusCode != http.StatusOK || len(delta.Body) == 0 {
 		t.Fatalf("enabled heap delta = (%d, body length %d), want non-empty HTTP 200 response", delta.StatusCode, len(delta.Body))
 	}
-	if !strings.Contains(delta.ContentDisposition, "heap-delta") {
-		t.Fatalf("enabled heap delta Content-Disposition = %q, want heap-delta filename", delta.ContentDisposition)
-	}
+	assertPprofResponseHeaders(t, delta, "application/octet-stream", `attachment; filename="heap-delta"`)
 	parsedDelta, err := profile.Parse(bytes.NewReader(delta.Body))
 	if err != nil {
 		t.Fatalf("parse enabled heap delta profile: %v", err)
 	}
-	if parsedDelta == nil || len(parsedDelta.SampleType) == 0 {
-		t.Fatalf("heap delta profile = %+v, want a valid profile with sample types", parsedDelta)
+	assertPprofProfileSampleTypes(t, "heap delta", parsedDelta)
+	if parsedDelta.DurationNanos != int64(time.Second) {
+		t.Fatalf("heap delta duration = %d ns, want %d ns", parsedDelta.DurationNanos, int64(time.Second))
 	}
 }
 
 func assertEnabledPprofTrace(t *testing.T, server *httptest.Server) {
 	t.Helper()
-	for _, path := range []string{"/debug/pprof/trace?seconds=1"} {
-		response := getPprofTestResponse(t, server.URL+path)
-		if response.StatusCode != http.StatusOK || len(response.Body) == 0 {
-			t.Fatalf("enabled GET %s = (%d, body length %d), want non-empty HTTP 200 response", path, response.StatusCode, len(response.Body))
-		}
+	response := getPprofTestResponse(t, server.URL+"/debug/pprof/trace?seconds=1")
+	if response.StatusCode != http.StatusOK || len(response.Body) == 0 {
+		t.Fatalf("enabled trace = (%d, body length %d), want non-empty HTTP 200 response", response.StatusCode, len(response.Body))
 	}
+	assertPprofResponseHeaders(t, response, "application/octet-stream", `attachment; filename="trace"`)
+	if !bytes.HasPrefix(response.Body, []byte("go ")) {
+		t.Fatalf("enabled trace prefix = %q, want Go trace framing", response.Body[:min(3, len(response.Body))])
+	}
+}
+
+func assertRealPprofRoute(t *testing.T, handler http.Handler, commandLineReader CommandLineReader) {
+	t.Helper()
+	server := httptest.NewServer(HandlerWithPprof(handler, true, commandLineReader))
+	defer closePprofTestServer(server)
+
+	started := time.Now()
+	response := getPprofTestResponse(t, server.URL+"/debug/pprof/profile?seconds=1")
+	elapsed := time.Since(started)
+	if elapsed < pprofRealWaitMinimum || elapsed > pprofRealWaitMaximum {
+		t.Fatalf("real pprof CPU request elapsed = %s, want between %s and %s", elapsed, pprofRealWaitMinimum, pprofRealWaitMaximum)
+	}
+	if response.StatusCode != http.StatusOK || len(response.Body) == 0 {
+		t.Fatalf("real pprof CPU response = (%d, body length %d), want non-empty HTTP 200 response", response.StatusCode, len(response.Body))
+	}
+	assertPprofResponseHeaders(t, response, "application/octet-stream", `attachment; filename="profile"`)
+	parsed, err := profile.Parse(bytes.NewReader(response.Body))
+	if err != nil {
+		t.Fatalf("parse real pprof CPU profile: %v", err)
+	}
+	assertPprofProfileSampleTypes(t, "real CPU", parsed)
 }
 
 func TestHandlerWithPprofDoesNotPolluteDefaultServeMux(t *testing.T) {
 	server := httptest.NewServer(http.DefaultServeMux)
-	defer server.Close()
+	defer closePprofTestServer(server)
 
 	response := getPprofTestResponse(t, server.URL+"/debug/pprof/heap")
-	if response.StatusCode != http.StatusNotFound {
-		t.Fatalf("default mux pprof status = %d, want %d", response.StatusCode, http.StatusNotFound)
+	if response.StatusCode != http.StatusNotFound || string(response.Body) != "404 page not found\n" {
+		t.Fatalf("default mux pprof = (%d, %q), want isolated standard 404", response.StatusCode, response.Body)
+	}
+	if response.ContentType != "text/plain; charset=utf-8" {
+		t.Fatalf("default mux pprof Content-Type = %q, want text/plain; charset=utf-8", response.ContentType)
 	}
 }
 
@@ -164,12 +244,28 @@ func TestStarterWithListenerServesPprofOnlyWhenRequested(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
+	defer listener.Close()
 	commandLineReader := CommandLineReader(func() []string { return []string{"you", "test"} })
 	starter := StarterWithListener(listener, nil, commandLineReader)
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	exit := make(chan error, 1)
 	bound := make(chan struct{})
+	finished := false
+	defer func() {
+		cancel()
+		if finished {
+			return
+		}
+		select {
+		case err := <-exit:
+			if err != nil {
+				t.Errorf("starter cleanup: %v", err)
+			}
+		case <-time.After(pprofTestRequestTimeout):
+			t.Errorf("starter cleanup timed out")
+		}
+	}()
 	go func() {
 		exit <- starter(ctx, StartRequest{
 			Handler: http.NotFoundHandler(),
@@ -181,7 +277,7 @@ func TestStarterWithListenerServesPprofOnlyWhenRequested(t *testing.T) {
 	case <-bound:
 	case err := <-exit:
 		t.Fatalf("starter exited before binding: %v", err)
-	case <-time.After(5 * time.Second):
+	case <-time.After(pprofTestRequestTimeout):
 		t.Fatal("timed out waiting for starter binding")
 	}
 
@@ -189,41 +285,84 @@ func TestStarterWithListenerServesPprofOnlyWhenRequested(t *testing.T) {
 	if response.StatusCode != http.StatusOK || len(response.Body) == 0 {
 		t.Fatalf("starter pprof heap = (%d, %q), want non-empty HTTP 200 response", response.StatusCode, response.Body)
 	}
+	assertPprofResponseHeaders(t, response, "application/octet-stream", `attachment; filename="heap"`)
+	parsed, err := profile.Parse(bytes.NewReader(response.Body))
+	if err != nil {
+		t.Fatalf("parse starter pprof heap: %v", err)
+	}
+	assertParsedPprofProfile(t, "starter heap", parsed)
+
 	cancel()
 	if err := <-exit; err != nil {
 		t.Fatalf("starter cancellation: %v", err)
 	}
+	finished = true
 	client := &http.Client{Timeout: time.Second}
+	defer client.CloseIdleConnections()
 	shutdownResponse, shutdownErr := client.Get("http://" + listener.Addr().String() + "/debug/pprof/heap")
-	if shutdownErr == nil {
+	if shutdownResponse != nil {
 		_ = shutdownResponse.Body.Close()
+	}
+	if shutdownErr == nil {
 		t.Fatal("pprof-enabled starter still served a profile after cancellation")
 	}
 }
 
-func getPprofTestResponse(t *testing.T, url string) struct {
+type pprofTestResponse struct {
 	StatusCode         int
 	Body               []byte
+	ContentType        string
 	ContentDisposition string
-} {
-	t.Helper()
-	response, err := http.Get(url)
-	if err != nil {
-		t.Fatalf("GET %s: %v", url, err)
-	}
-	defer response.Body.Close()
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Fatalf("read GET %s: %v", url, err)
-	}
-	return struct {
-		StatusCode         int
-		Body               []byte
-		ContentDisposition string
-	}{StatusCode: response.StatusCode, Body: body, ContentDisposition: response.Header.Get("Content-Disposition")}
+	ContentTypeOptions string
 }
 
-func assertParsedPprofProfile(t *testing.T, name string, parsed *profile.Profile) {
+func closePprofTestServer(server *httptest.Server) {
+	server.CloseClientConnections()
+	server.Close()
+}
+
+func getPprofTestResponse(t *testing.T, url string) pprofTestResponse {
+	t.Helper()
+	client := &http.Client{Timeout: pprofTestRequestTimeout}
+	defer client.CloseIdleConnections()
+	response, err := client.Get(url)
+	if err != nil {
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	body, readErr := io.ReadAll(response.Body)
+	closeErr := response.Body.Close()
+	if readErr != nil {
+		t.Fatalf("read GET %s: %v", url, readErr)
+	}
+	if closeErr != nil {
+		t.Fatalf("close GET %s response body: %v", url, closeErr)
+	}
+	return pprofTestResponse{
+		StatusCode:         response.StatusCode,
+		Body:               body,
+		ContentType:        response.Header.Get("Content-Type"),
+		ContentDisposition: response.Header.Get("Content-Disposition"),
+		ContentTypeOptions: response.Header.Get("X-Content-Type-Options"),
+	}
+}
+
+func assertPprofResponseHeaders(t *testing.T, response pprofTestResponse, wantContentType, wantDisposition string) {
+	t.Helper()
+	if response.ContentType != wantContentType {
+		t.Fatalf("pprof Content-Type = %q, want %q", response.ContentType, wantContentType)
+	}
+	if response.ContentDisposition != wantDisposition {
+		t.Fatalf("pprof Content-Disposition = %q, want %q", response.ContentDisposition, wantDisposition)
+	}
+	if response.ContentTypeOptions != "nosniff" {
+		t.Fatalf("pprof X-Content-Type-Options = %q, want nosniff", response.ContentTypeOptions)
+	}
+}
+
+func assertPprofProfileSampleTypes(t *testing.T, name string, parsed *profile.Profile) {
 	t.Helper()
 	if parsed == nil {
 		t.Fatalf("%s profile is nil", name)
@@ -231,6 +370,11 @@ func assertParsedPprofProfile(t *testing.T, name string, parsed *profile.Profile
 	if len(parsed.SampleType) == 0 {
 		t.Fatalf("%s profile has no sample types", name)
 	}
+}
+
+func assertParsedPprofProfile(t *testing.T, name string, parsed *profile.Profile) {
+	t.Helper()
+	assertPprofProfileSampleTypes(t, name, parsed)
 	if len(parsed.Sample) == 0 {
 		t.Fatalf("%s profile has no samples", name)
 	}


### PR DESCRIPTION
{
  "project": "unit-test-optimization-c02-platform-httpserver",
  "branchName": "unit-test-optimization-c02-platform-httpserver",
  "description": "Reduce deterministic pkg/platform/httpserver latency by controlling duration-only pprof waits while preserving one real production-duration stdlib witness, exact profile/route assertions, HTTP listener lifecycle behavior, resource isolation, and reproducible performance evidence.",
  "context": {
    "customerAsk": "Contract unit-test-optimization-v1: reduce the consistently expensive 50-test pkg/platform/httpserver package by consolidating or injecting bounded pprof-duration work and eliminating redundant real-time waits while retaining representative real stdlib pprof parsing/routing evidence and all listener lifecycle, cancellation, shutdown-grace, port-isolation, diagnostics, and DefaultServeMux-isolation contracts. Validate focused, race, ten shuffled repetitions, lane audit, and three-run same-machine pre/post performance without running or claiming the global final reference-CI gate; preserve recovered commits and artifacts.",
    "problem": "The package's accepted 4.477-second median is dominated by three serial one-second pprof route requests and a separate one-second heap-delta writer-failure wait, even though most assertions need real collectors, parsers, routing, errors, and cleanup rather than elapsed time.",
    "solution": "First freeze the exact 50-ID behavior map and a fresh same-machine three-run baseline. Then introduce one package-private duration waiter whose production default remains real, move duration-only assertions to controlled completion while retaining real runtime collectors/parsers, keep exactly one serialized real one-second public-route witness, and promote the result through focused, race, shuffle, lifecycle, performance, lane-audit, and read-only clean-room gates."
  },
  "acceptanceCriteria": [
    "Given pprof disabled or enabled, every index, heap/allocs/goroutine/cmdline/symbol, CPU, heap-delta, and trace route retains its routing, header, content, parsing, error, cancellation, and opt-in behavior through the correct local-real or explicitly controlled dependency edge; no assertion is status-only.",
    "Exactly one documented serialized real one-second pprof sample proves public production-wait compatibility; all other duration-only waits are controlled without replacing real runtime collectors, encoders, parsers, or merge behavior.",
    "All listener binding, selected-port observation, loopback restriction, terminal listener failure, cancellation, graceful SSE flush, forced close, listener-stop polling, runtime diagnostics, and default-mux isolation behaviors remain observably unchanged.",
    "Every HTTP client, response body, listener, server, handler, timer, channel, runtime sampler, and goroutine is deterministically released on success, failure, cancellation, and test assertion paths; any parallel test uses an isolated OS-assigned listener and passes explicit race evidence.",
    "The accepted 4.469s, 4.477s, and 4.481s v2 package evidence and exact 50-ID inventory remain preserved and read-only, and fresh same-machine pre/post reports include identity, commands, wall/package/test timing, median, minimum, maximum, range/spread, inventory reconciliation, and separate real-sampling time.",
    "Three uncached same-machine final runs improve median wall time by at least 35% from the fresh pre-change median and no final run exceeds 110% of final median; a comparison to the accepted 4.477s median is also reported without mixing identities.",
    "GATE-LIFECYCLE-004: go test -count=1 ./pkg/platform/httpserver passes and proves the complete mapped package behavior.",
    "GATE-RACE-004: go test -race -count=1 ./pkg/platform/httpserver passes and proves no detected shared-memory race.",
    "GATE-SHUFFLE-005: go test -shuffle=on -count=10 ./pkg/platform/httpserver passes and proves order and isolation reproducibility.",
    "GATE-AUDIT-007: make test-lane-audit passes and proves canonical lane assignment.",
    "No exported Go, HTTP/OpenAPI, CLI, event, persisted, configuration, diagnostics JSON, generated, production-duration, production shutdown, security/privacy, accessibility/localization, or operational contract changes; no excluded surface or recovered artifact is modified.",
    "VAL-001 reports through factory/docs/standards/validation-loopback-template.md, independently executes the highest applicable local-real runtime proof, records each criterion and unproven edge, and makes no silent repair.",
    "The global final reference-CI gate is neither run nor claimed; terminal current-head CI, conflict resolution, and merge remain owned by REVIEW-001.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "behaviorLanes": [
    {
      "id": "BEH-001",
      "name": "Fast, faithful opt-in pprof diagnostics",
      "description": "Enabled and disabled routes retain parse, content, header, error, and cancellation behavior through real stdlib collectors while redundant elapsed waits are removed."
    },
    {
      "id": "BEH-002",
      "name": "Deterministic HTTP listener lifecycle",
      "description": "Binding, cancellation, graceful flush, forced close, listener observation, port isolation, diagnostics, and resource ownership remain deterministic under focused, race, and shuffled execution."
    },
    {
      "id": "BEH-003",
      "name": "Reproducible package-latency evidence",
      "description": "Exact inventory and same-machine pre/post distributions demonstrate a material, stable improvement without assertion loss or mixed machine identities."
    }
  ],
  "contractChanges": [],
  "userStories": [
    {
      "id": "unit-test-optimization-c02-platform-httpserver-001",
      "title": "Freeze the 50-test behavior and same-machine timing baseline",
      "description": "Record an assertion-level ownership map and three fresh uncached pre-change samples before any structural mutation, while verifying preserved recovery commits read-only.",
      "parentBehavior": "BEH-003 — Reproducible package-latency evidence",
      "outcome": "A read-only 50-ID assertion map and same-machine timing distribution establish the reviewable baseline without changing package code or recovered evidence.",
      "dependencies": [],
      "sharedSurfaceOwner": "This story exclusively owns pre-change logs, timing summaries, the assertion map, and read-only recovery verification. No mutation or competing load may run during capture; recovered artifacts and package sources remain untouched.",
      "scope": {
        "in": [
          "Verify all six preserved commit objects",
          "Inventory all 50 test and subtest IDs",
          "Map route/state, success/failure assertion, dependency fidelity, resource owner, and intended final owner",
          "Capture three uncached runs and isolated pprof timing on the final-measurement machine"
        ],
        "out": [
          "Code edits",
          "Recovered artifact edits",
          "Fourth accepted sample",
          "Silent sample replacement",
          "Global unit-lane or final reference-CI run"
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given the unmodified base, when the inventory run completes, then exactly the 50 IDs listed in the Markdown plan execute and every ID maps to its observable assertion, applicable failure behavior, dependency fidelity, cleanup owner, and intended final owner.",
        "Given three consecutive uncached runs, when timings are summarized, then all exit zero on one recorded Go/OS/architecture/CPU identity and report wall, package, per-test, median, minimum, maximum, range, percent spread, and exact inventory.",
        "Given the pprof timing breakdown, then separate CPU, heap-delta, trace, writer-failure, listener-lifecycle, and other package time is observable; no result is inferred from source scanning alone.",
        "Given the preserved IDs b4a8ba2c7, 3bce9985a, 7d766f36c, b3c1ad198, 6f41e62a3, and 429a5422b, then read-only Git object checks succeed and no preserved ref or artifact is modified.",
        "Given an invalid or interrupted sample, then its output and cause are retained and no more than one replacement is accepted before a delta-plan request."
      ],
      "verification": {
        "behavioralWitness": "All 50 current tests execute through their existing local handlers and listeners and produce an assertion-level ownership map plus a comparable timing distribution.",
        "executableSpineEffect": "establish",
        "requiredEvidence": [
          {
            "scope": "integration",
            "dependencyFidelity": "local_real",
            "procedure": "Record go version, go env GOOS GOARCH, CPU/machine identity, and git rev-parse HEAD; run go test -json -count=1 ./pkg/platform/httpserver three times with independent wall timing; extract run/pass IDs and per-test/package elapsed values; run focused pprof tests once for timing attribution; verify each preserved commit explicitly with git cat-file -e b4a8ba2c7^{commit}, git cat-file -e 3bce9985a^{commit}, git cat-file -e 7d766f36c^{commit}, git cat-file -e b3c1ad198^{commit}, git cat-file -e 6f41e62a3^{commit}, and git cat-file -e 429a5422b^{commit}.",
            "propertyProved": "Current executable behavior, exact inventory, bottleneck attribution, comparable pre-change distribution, and preserved evidence reachability.",
            "propertyNotProved": "The internal seam, final behavior, race safety, shuffle stability, or improvement."
          }
        ],
        "highestFeasibleLevel": "Package integration with local-real HTTP/runtime dependencies; no customer process or remote boundary is relevant.",
        "remainingUnprovenEdges": [
          {
            "edge": "Internal controlled wait",
            "gateId": "GATE-SEAM-002"
          },
          {
            "edge": "Production pprof route fidelity",
            "gateId": "GATE-PPROF-003"
          },
          {
            "edge": "Final performance",
            "gateId": "GATE-PERF-006"
          }
        ]
      },
      "paidValidation": null,
      "priority": 1,
      "passes": true,
      "notes": "2026-08-26 baseline captured in progress.txt at unchanged HEAD 5748eca459935e78fa9d93aa370fa4bfbf00b4d2: three sequential local-real runs exited 0 with exactly 50 passing test-event IDs on Go 1.25.0 Windows/amd64; wall median/min/max 5.49512s/5.35543s/6.92865s and package median/min/max 4.544s/4.514s/4.589s. Focused pprof run exited 0; route matrix was 3.02-3.06s, writer-failure delta 1.00-1.01s, active CPU/trace 0.41-0.42s. All six preserved commit objects passed read-only cat-file checks and tracked status stayed clean. The local prd.md supplies the referenced Markdown plan, and read-only inspection of commit 429a5422b confirmed the accepted httpserver v2 package artifacts at 4.469s, 4.477s, and 4.481s with the same 50 IDs."
    },
    {
      "id": "unit-test-optimization-c02-platform-httpserver-002",
      "title": "Make pprof duration completion controllable without changing production time",
      "description": "Introduce one package-private wait dependency for CPU, trace, and delta handlers; keep public production construction on real elapsed waiting and use deterministic controlled completion only in owner-local tests.",
      "parentBehavior": "BEH-001 — Fast, faithful opt-in pprof diagnostics",
      "outcome": "One internal waiter is canonical for all duration-dependent pprof handlers, with unchanged public behavior and deterministic content/failure coverage.",
      "dependencies": [
        "unit-test-optimization-c02-platform-httpserver-001"
      ],
      "sharedSurfaceOwner": "This story exclusively owns pkg/platform/httpserver/pprof.go and direct seam tests. Story 003 waits because both govern runtime-global samplers and shared pprof test helpers.",
      "scope": {
        "in": [
          "Narrow package-private waiter",
          "Production real implementation",
          "CPU, trace, and delta migration",
          "Controlled success, cancellation, deadline, writer-failure, and active-effect tests",
          "Timer and sampler cleanup"
        ],
        "out": [
          "Exported API or response changes",
          "Fake runtime collector or parser",
          "Production duration reduction",
          "Listener or shutdown changes",
          "Real-route consolidation owned by story 003"
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given public production handler construction, when CPU, trace, or delta requests specify a duration, then the real waiter honors that duration or request cancellation and observable route behavior remains unchanged.",
        "Given a controlled completion, when CPU, trace, and heap-delta handlers run, then real runtime output is produced and existing parser, content, and header assertions complete without a real-duration sleep.",
        "Given invalid or unsupported seconds, incompatible debug, deadline, cancellation, active CPU or trace effects, or a failing writer, when the handler runs, then existing status, error text, headers, and one-terminal-write behavior are preserved with no leaked timer or sampler.",
        "Given a nil or canceled context boundary currently supported by the handler path, then failure behavior is explicit and no goroutine remains blocked.",
        "The focused pprof suite passes and proves named content, parsing, cancellation, and failure properties rather than status alone."
      ],
      "verification": {
        "behavioralWitness": "Real runtime CPU, trace, and profile bytes plus delta merge reach the same parsers and error assertions while a controlled waiter releases duration-only branches immediately.",
        "executableSpineEffect": "preserve",
        "requiredEvidence": [
          {
            "scope": "unit and integration",
            "dependencyFidelity": "controlled",
            "procedure": "Run go test -count=1 ./pkg/platform/httpserver -run '^(TestPprof|TestHandlerWithPprof)'; additionally run the controlled cancellation, active-sampler, invalid-query, and writer-failure cases individually with verbose output.",
            "propertyProved": "Internal wait selection, unchanged response semantics, real collector/parser use, deterministic cancellation/failure, and cleanup without elapsed seconds.",
            "propertyNotProved": "Public production waiter across a real one-second local HTTP request, listener lifecycle, race safety, shuffle stability, or package threshold."
          }
        ],
        "highestFeasibleLevel": "Package integration with real runtime collectors and a controlled time edge; GATE-PPROF-003 owns the production real-time boundary.",
        "remainingUnprovenEdges": [
          {
            "edge": "Production waiter and route",
            "gateId": "GATE-PPROF-003"
          },
          {
            "edge": "Listener lifecycle",
            "gateId": "GATE-LIFECYCLE-004"
          },
          {
            "edge": "Race safety",
            "gateId": "GATE-RACE-004"
          },
          {
            "edge": "Order independence",
            "gateId": "GATE-SHUFFLE-005"
          },
          {
            "edge": "Final performance",
            "gateId": "GATE-PERF-006"
          }
        ]
      },
      "paidValidation": null,
      "priority": 2,
      "passes": true,
      "notes": "Implemented the package-private pprofDurationWaiter seam in pkg/platform/httpserver/pprof.go. HandlerWithPprof retains the exported signature and production real-timer default; private index, named-profile, CPU, trace, and delta paths share the injected waiter. Owner-local diagnostics tests now prove controlled heap-delta parsing, CPU profile parsing, trace framing, exact requested durations, deadline/cancellation mapping, nil-context failure, writer failure, and active-sampler behavior without duration-only sleeps. Focused suite, individually named invalid/cancellation/writer/active cases, full package test, and go vet pass. Remaining edges: race, shuffled repetitions, final performance, lane audit, and clean-room validation."
    },
    {
      "id": "unit-test-optimization-c02-platform-httpserver-003",
      "title": "Retain one representative real pprof route witness and full content fidelity",
      "description": "Restructure the enabled and disabled pprof route proof so all routes keep real collector, parser, content, and error evidence while exactly one serialized one-second request proves the production waiter through local HTTP.",
      "parentBehavior": "BEH-001 — Fast, faithful opt-in pprof diagnostics",
      "outcome": "One isolated local server proves the complete route matrix and real stdlib output, with one minimum real-duration compatibility sample and deterministic cleanup.",
      "dependencies": [
        "unit-test-optimization-c02-platform-httpserver-002"
      ],
      "sharedSurfaceOwner": "This story exclusively owns pprof_test.go and pprof overlap in diagnostics_edge_test.go and host_test.go. Runtime-global CPU and trace cases remain serial; listener-only parallelism requires isolated listeners and race proof.",
      "scope": {
        "in": [
          "Enabled and disabled index, heap, allocs, goroutine, cmdline, symbol, CPU, heap-delta, and trace routes",
          "Parser, content, header, and error assertions",
          "One real one-second production-wait witness",
          "Private and DefaultServeMux isolation",
          "Server, client, response-body, listener, sampler, and goroutine cleanup",
          "50-ID assertion-map reconciliation"
        ],
        "out": [
          "Status-only assertions",
          "Simultaneous runtime-global samplers",
          "Remote HTTP or fixed ports",
          "Public behavior or production shutdown changes",
          "Unrelated host or listener rewrites"
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given pprof disabled, when every standard route is requested, then the underlying application 404 behavior remains visible and no pprof route leaks onto http.DefaultServeMux.",
        "Given pprof enabled, when index, heap, allocs, goroutine, cmdline, symbol, CPU, heap-delta, and trace are requested, then the correct route, content type/disposition, injected command line, symbol content, real profile parsability/sample types, delta filename/duration, and trace framing are asserted; no check is status-only.",
        "Given the one documented real-duration request, when it traverses public handler construction, then it runs for the requested one-second production interval within a bounded tolerance, yields valid real stdlib output, and closes body, server, listener, and sampler deterministically.",
        "Given all other duration-sensitive cases, when controlled completion is used, then they preserve real collector, encoder, parser, and merge dependency fidelity and finish without real-time waits.",
        "Given the baseline assertion map, when final inventory is reconciled, then all 50 IDs have a retained or stronger behavioral owner and every rename, addition, or removal is explicitly justified."
      ],
      "verification": {
        "behavioralWitness": "A client reaches the private mux over local real HTTP and validates all opt-in and opt-out routes, real runtime artifacts, one production-duration sample, and complete cleanup.",
        "executableSpineEffect": "increase_fidelity",
        "requiredEvidence": [
          {
            "scope": "integration",
            "dependencyFidelity": "local_real",
            "procedure": "Run the full opt-in route test verbosely, the isolated real-duration test verbosely with -count=3 for bounded reproducibility, the DefaultServeMux isolation test, and go test -count=1 ./pkg/platform/httpserver.",
            "propertyProved": "Production route wiring, one real wait, real stdlib collectors and encoders, Google pprof parsing, private mux isolation, route content, and deterministic local resource cleanup.",
            "propertyNotProved": "Race safety, ten-order reproducibility, final three-run threshold, lane audit, or hosted CI."
          }
        ],
        "highestFeasibleLevel": "Package integration and local-real; the production boundary is local net/http and runtime diagnostics, so remote or full-product execution adds no material property.",
        "remainingUnprovenEdges": [
          {
            "edge": "Shared-memory race",
            "gateId": "GATE-RACE-004"
          },
          {
            "edge": "Order isolation",
            "gateId": "GATE-SHUFFLE-005"
          },
          {
            "edge": "Complete listener lifecycle",
            "gateId": "GATE-LIFECYCLE-004"
          },
          {
            "edge": "Final performance",
            "gateId": "GATE-PERF-006"
          },
          {
            "edge": "Clean-checkout integration",
            "gateId": "VAL-001"
          }
        ]
      },
      "paidValidation": null,
      "priority": 3,
      "passes": true,
      "notes": "Implemented in commit ad8830d19. The retained route test now sends every disabled and enabled standard route through local HTTP, asserts application 404 bodies, index links/descriptions and headers, injected command-line and symbol content, real Google pprof parsing/sample types, delta filename and one-second duration metadata, trace framing, and deterministic client/server/listener cleanup. All duration-sensitive matrix requests use the package-private controlled waiter; exactly one public HandlerWithPprof CPU request uses the production waiter and measured 0.90-5.00s bounds. Focused pprof suite, three real-witness repetitions, full package test, go vet, and exact 50-ID inventory all passed. Remaining edges: race, shuffled repetitions, final performance, lane audit, and clean-room validation in story 004."
    },
    {
      "id": "unit-test-optimization-c02-platform-httpserver-004",
      "title": "Prove integrated lifecycle fidelity, stable latency, and delivery readiness",
      "description": "Promote the final package through focused, race, ten-shuffle, lifecycle, three-run performance, lane-audit, clean-room, and implementation-delivery gates without claiming the excluded global final reference-CI result.",
      "parentBehavior": "BEH-001, BEH-002, and BEH-003 — Integrated diagnostics, lifecycle, and reproducible performance",
      "outcome": "The final head passes every named behavioral gate, meets the 35% median and 10% spread thresholds with exact inventory reconciliation, emits a read-only validation report, and reaches canonical implementation handoff.",
      "dependencies": [
        "unit-test-optimization-c02-platform-httpserver-003"
      ],
      "sharedSurfaceOwner": "This story exclusively owns final timing, assertion reconciliation, loopback report, and delivery evidence. It performs no silent repair; independent review owns terminal CI, conflicts, and merge.",
      "scope": {
        "in": [
          "Focused package behavior",
          "Race and ten shuffled repetitions",
          "Lifecycle and resource audit",
          "Three final uncached same-machine samples",
          "Exact pre/post and 50-ID comparison",
          "make test-lane-audit",
          "Read-only VAL-001 report",
          "Push, PR open, CI start, and blocking-feedback handoff"
        ],
        "out": [
          "Global final reference-CI gate",
          "Terminal CI polling or re-check",
          "Conflict resolution or merge",
          "Silent loopback repair",
          "New optimization or unrelated suites",
          "Recovered artifact mutation"
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given the final tree, when go test -count=1 ./pkg/platform/httpserver runs, then every mapped pprof, runtime, listener, binding, cancellation, graceful-shutdown, forced-close, diagnostics, and default-mux behavior passes with content and property-specific assertions.",
        "Given go test -race -count=1 ./pkg/platform/httpserver, then it exits zero and proves no detected shared-memory race across isolated listeners, handlers, observers, waits, or runtime-effect serialization.",
        "Given go test -shuffle=on -count=10 ./pkg/platform/httpserver, then all ten iterations pass with no fixed-port collision, DefaultServeMux contamination, sampler overlap, leaked resource, or order dependency.",
        "Given three final uncached same-machine runs, when compared with story 001, then final median is at least 35% lower, no final run exceeds 110% of final median, all wall/package/test timings and spread are recorded, and real pprof sampling time is separately identified under normal, shuffle, and race execution.",
        "Given the accepted v2 50-ID baseline and story 001 map, then final inventory and assertion ownership reconcile exactly with no skipped, deleted, status-only, cached, or weakened behavior.",
        "Given make test-lane-audit, then it exits zero and its output proves this package remains assigned to the canonical test lane; no global final reference-CI gate is run or claimed.",
        "Given a clean checkout of final head, when VAL-001 executes, then its report follows factory/docs/standards/validation-loopback-template.md, evaluates every project criterion and unproven edge, checks evidence usability and cleanup, makes no repair, and returns a delta-plan request for any FAIL or BLOCKED result.",
        "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
      ],
      "verification": {
        "behavioralWitness": "From a clean final checkout, the complete package executes through real local listeners and runtime collectors, one real production-duration pprof request, all failure and lifecycle paths, race and shuffled stress, and a reproducible three-run latency comparison.",
        "executableSpineEffect": "promote",
        "requiredEvidence": [
          {
            "scope": "integration and delivery end-to-end",
            "dependencyFidelity": "local_real",
            "procedure": "Run go test -count=1 ./pkg/platform/httpserver; go test -race -count=1 ./pkg/platform/httpserver; go test -shuffle=on -count=10 ./pkg/platform/httpserver; three timed go test -json -count=1 ./pkg/platform/httpserver runs; focused real-witness timing under ordinary, shuffle, and race modes; make test-lane-audit; then execute VAL-001, push final head, open the PR, start CI, and address blocking feedback.",
            "propertyProved": "Integrated HTTP, pprof, and lifecycle behavior; local-real dependency compatibility; race, order, isolation, and resource safety; inventory fidelity; measurable performance and reproducibility; lane ownership; clean-room usability; and implementation handoff.",
            "propertyNotProved": "Other machine classes, remote networking, production load, terminal CI, conflict resolution, merge, or the excluded global final reference-CI gate."
          }
        ],
        "highestFeasibleLevel": "Package-level integration and end-to-end through the actual local HTTP and runtime boundaries. A broader application runtime is not applicable because exported and product behavior and composition are unchanged and the owned surface excludes it.",
        "remainingUnprovenEdges": [
          {
            "edge": "Terminal current-head CI, conflicts, and merge",
            "gateId": "REVIEW-001"
          },
          {
            "edge": "Other machine classes and global final reference-CI unit-lane result",
            "gateId": "OUT-OF-SCOPE-NO-CLAIM"
          }
        ]
      },
      "paidValidation": null,
      "priority": 4,
      "passes": false,
      "notes": ""
    }
  ]
}
