### PR TITLE
Review detects and process executes stale-head rebases

### DIFF
--- a/factory/workstations/process/AGENTS.md
+++ b/factory/workstations/process/AGENTS.md
@@ -59,6 +59,14 @@ scope growth, and hand work to review.
 - Sync with origin/main ONLY immediately before your final push, when GitHub
   reports a real conflict, or when the reviewer asks. New commits on main are
   not by themselves a reason for another sync pass.
+- When review feedback says to "rebase onto origin/main" or identifies a
+  "stale head," treat that as an explicit reviewer-requested rebase. In the
+  same iteration, run `git fetch origin && git rebase origin/main`, resolve
+  every conflict and continue the rebase, then push the resulting new commit
+  SHA. Rerunning CI, posting a comment, waiting, or pushing an unchanged head
+  does not address this feedback. This is a concrete application of the
+  reviewer-request exception above and does not broaden routine synchronization
+  beyond the final-push, real-conflict, or reviewer-request cases.
 - prd.json and progress.txt are untracked worktree scaffolding and must NEVER
   appear in your PR diff. Never `git add -f` them. If your branch already
   tracks them from an old base, `git rm` them during your next rebase.

--- a/factory/workstations/review/AGENTS.md
+++ b/factory/workstations/review/AGENTS.md
@@ -224,6 +224,32 @@ If you believe that the PR is complete and the CI passes, please merge the PR.
 
 If the PR has merge conflicts, please tell the processor to fix the merge conflicts and rebase and push the changes.
 
+#### Required-check and stale-head routing
+
+Before deciding to merge, never run `gh pr merge --admin` or use an
+administrative/bypass flag to force a merge past a failing required status
+check. A required status check is enforced by the repository ruleset, so an
+administrator cannot make a failing head eligible by bypassing it; the PR
+needs a new head on which the required checks pass.
+
+Classify a required-check failure as **stale-head-only** only when every
+failing required check is explained by commits merged since the PR head and
+there is no unresolved content-level blocker. Verify that condition against
+`origin/main` before routing it, using a behind-main merge-base and/or a
+failure signature that is already fixed on the current `origin/main` checks.
+Do not call a check stale merely because the PR is old, main has advanced, or
+one check happens to be green on main while another failure remains
+unexplained.
+
+When, and only when, every failing required check meets that stale-head-only
+test, post a PR conversation comment with this exact instruction:
+
+> Rebase onto origin/main and push a new head -- git fetch origin && git rebase origin/main, resolve conflicts, then push. This is a stale-head issue, not a content defect.
+
+Then end through the **REJECTED** route so process receives concrete rebase
+and push work in the same iteration. Do not merely note staleness, hold,
+waive the check, or attempt the merge yourself.
+
 ### Step 7 - respond back
 
 End your final response with exactly one review routing marker, alone on the


### PR DESCRIPTION
{
  "project": "Review Detects, Process Executes Rebase",
  "branchName": "review-detects-process-executes-rebase",
  "description": "Update the review and process workstation instructions so review identifies stale-head-only required-check failures, rejects them with an explicit rebase-and-push instruction, never attempts an admin bypass, and process performs the requested rebase and pushes a new SHA in the same iteration. This is a docs-only change limited to the two owning workstation instruction files.",
  "context": {
    "customerAsk": "Split stale-head recovery responsibility explicitly: review detects and routes the condition, while process executes the requested rebase and push. Preserve the implementation/review ownership boundary and prohibit admin-bypass merge attempts for failing required status checks.",
    "problem": "PR #2210 and an earlier PR #2281 attempt stalled on stale heads whose required-check failures were already resolved by newer commits on main. Review cannot push a new head, and an administrative merge cannot satisfy a required-status-check ruleset, but the current instructions permit waiver, bypass, or unchanged-head loops instead of concrete executor work.",
    "solution": "Teach review to verify stale-head-only failures, prohibit bypass merges, and reject with an exact rebase-and-push PR comment. Teach process that explicit rebase or stale-head feedback is satisfied only by fetching, rebasing onto origin/main, resolving conflicts, and pushing a new commit SHA in the same iteration."
  },
  "acceptanceCriteria": [
    "Near review Step 6, the reviewer instructions prohibit gh pr merge --admin and any bypass flag from being used to force a merge past a failing required status check; they explain that the ruleset requires a new passing head.",
    "When every failing required check is attributable to a stale head and there is no unresolved content-level blocker, review verifies the condition against origin/main, posts a PR conversation comment instructing: \"Rebase onto origin/main and push a new head -- git fetch origin && git rebase origin/main, resolve conflicts, then push. This is a stale-head issue, not a content defect.\", and ends through the REJECTED route so process receives concrete work rather than a hold.",
    "When review feedback contains language such as \"rebase onto origin/main\" or \"stale head,\" process must actually fetch, rebase, resolve conflicts, and push a new commit SHA in the same iteration; rerunning CI, posting a comment, or waiting cannot satisfy the feedback.",
    "The implementation PR changes only factory/workstations/review/AGENTS.md and factory/workstations/process/AGENTS.md; no other workstation instructions, prompt-template plumbing, product code, or port 7438 usage changes are included.",
    "Runtime-proof classification: Not applicable. This lane changes documentation/prompt instructions only and does not change runtime-observable CLI, API, UI, emitted-event, or runtime-lifecycle behavior; record this one-line reason as the non-blocking runtime-proof result.",
    "Final quality gate: Typecheck passes; Tests pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Verification also confirms the reviewer language contains admin near required status check, the processor language contains rebase onto origin/main near the sync rule, and the implementation diff contains only the two allowed files.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "review-detects-process-executes-rebase-001",
      "title": "Route stale-head-only failures to process",
      "description": "As a review workstation operator, I want review to distinguish a stale-head-only required-check failure from a content defect so the lane returns the exact branch update that can unblock it.",
      "acceptanceCriteria": [
        "Review never runs gh pr merge --admin or another bypass flag to force a merge past a failing required status check and explains why a new passing head is required.",
        "Review classifies a failure as stale-head-only only when every failing required check is explained by commits merged since the PR head, using a behind-main merge-base and/or a failure signature already fixed on main, and no content-level blocker remains.",
        "For that condition, review posts the exact rebase-and-push instruction from the project criteria and uses the REJECTED route; it does not merely note staleness, hold, waive the check, or attempt the merge itself.",
        "The rule is placed near Step 6 so it governs the merge decision.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Updated review Step 6 to prohibit admin/bypass merges, require origin/main evidence and no content blocker before stale-head classification, post the exact rebase instruction, and route through REJECTED. Direct text inspection, make test, and make typecheck passed."
    },
    {
      "id": "review-detects-process-executes-rebase-002",
      "title": "Execute reviewer-requested rebases",
      "description": "As a process workstation operator, I want explicit stale-head or rebase feedback to require a real branch update so the next review sees a new head that can run required checks against current main.",
      "acceptanceCriteria": [
        "Review feedback matching language such as rebase onto origin/main or stale head requires process to run git fetch origin && git rebase origin/main, resolve any conflicts, and push a new commit SHA in the same iteration.",
        "Rerunning CI, posting a comment, or waiting without a new pushed SHA is explicitly not accepted as addressing the feedback.",
        "The new requirement tightens the existing sync-with-main rule without broadening routine synchronization beyond final push, a real conflict, or a reviewer request.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Updated the process sync rule to require git fetch origin && git rebase origin/main, conflict resolution, and a new pushed SHA in the same iteration for explicit rebase/stale-head feedback; rerunning CI, commenting, waiting, or leaving the head unchanged is insufficient. Direct text inspection, make test (exit 0; 108 pass, 1 skip), and make typecheck (exit 0) passed."
    },
    {
      "id": "review-detects-process-executes-rebase-003",
      "title": "Verify the bounded instruction contract",
      "description": "As a maintainer, I want the final change verified as a narrowly scoped instruction update so unrelated workstation or product behavior cannot enter the lane.",
      "acceptanceCriteria": [
        "The implementation diff contains only factory/workstations/review/AGENTS.md and factory/workstations/process/AGENTS.md, with no changes to other workstation instructions, prompt-template plumbing, or product code, and no use of port 7438.",
        "Direct text inspection confirms admin and required status check appear together in the review merge guidance, and rebase onto origin/main appears in the process sync guidance; this verifies the workstation contract itself and does not add a meta-test to the product suite.",
        "Runtime-proof classification: Not applicable. This lane changes documentation/prompt instructions only and does not change runtime-observable CLI, API, UI, emitted-event, or runtime-lifecycle behavior; record this one-line reason as the non-blocking runtime-proof result.",
        "Typecheck passes",
        "Tests pass",
        "There are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Verified the implementation diff contains only factory/workstations/review/AGENTS.md and factory/workstations/process/AGENTS.md, with no port 7438 usage. Direct inspection confirmed admin is prohibited near required status check in review guidance and rebase onto origin/main is present in process sync guidance. Runtime-proof classification: Not applicable because this lane changes documentation/prompt instructions only and does not change runtime-observable CLI, API, UI, emitted-event, or runtime-lifecycle behavior. make test passed (108 pass, 1 skip), make typecheck passed, and all make lint targets passed except the pre-existing deadcode baseline mismatch (3,101 current findings vs 3,103 baseline), reproduced at origin/main; no new lint violations were introduced."
    }
  ]
}
