### PR TITLE
Clarify stale-head routing precedence over convergence hold

### DIFF
--- a/factory/workstations/review/AGENTS.md
+++ b/factory/workstations/review/AGENTS.md
@@ -218,7 +218,15 @@ remains.
 Route a converged repeat review as a HOLD. If the head has not moved since
 your last pass and you have no NEW independent finding — including the case
 where you are only re-confirming a blocker set the executor was already told
-about — end with `<CONTINUE>` and post no new PR comment. The hold now
+about — end with `<CONTINUE>` and post no new PR comment.
+
+Exception — a hold is ONLY for waiting states. If the head is unchanged,
+every required check is terminal and green, and no unfixed previously-flagged
+blocker remains, do NOT hold: that is exactly the Step 4.2 merge bar, so
+proceed to Step 6 and merge. Holding a finished green head burns the lane's
+round-trip budget for nothing and will eventually kill a healthy lane
+(observed live 2026-08-28: six lanes died to silent review→ci-wait→review
+cycling on clean green PRs). The hold now
 re-enters through the `ci-wait` gate (task returns to `awaiting-ci`, not
 straight back to review), so the loop pauses on CI state instead of spinning.
 Re-sending an unchanged blocker set is a no-op that hands the processor
@@ -228,6 +236,13 @@ delivering concrete executor work the executor does not already have: the
 first time you raise a blocker set, or a new blocker on a head pushed since
 your last pass. Holds are bounded by the review visit cap, so a genuinely
 stuck lane still surfaces without you forcing a rejection.
+
+Exception: before treating a required-check failure as an unchanged,
+already-told-to blocker under this rule, first run the stale-head-only
+classification in Step 6 (Required-check and stale-head routing) below -- a
+stale-head-only failure is not covered by this convergence rule even on a
+repeat pass, because the explicit rebase instruction is concrete executor
+work the executor has not yet been given by review.
 
 ### Step 5 - handle feedback
 
@@ -246,14 +261,29 @@ If you believe that the PR is complete and the CI passes, please merge the PR.
 
 If the PR has merge conflicts, please tell the processor to fix the merge conflicts and rebase and push the changes.
 
-Never run `gh pr merge --admin` or any administrative/bypass flag past a failing
-required status check: required checks are enforced by the repository ruleset,
-so a bypass cannot make a failing head eligible — the PR needs a new head on
-which the required checks pass. When every failing required check is explained
-by commits merged to `origin/main` since the PR head (verify against
-`origin/main`; do not call a check stale merely because the PR is old), post
-this exact comment and end through the **REJECTED** route so process receives
-concrete work:
+#### Required-check and stale-head routing
+
+This classification runs regardless of, and before, the Step 4.2
+convergence/hold decision.
+
+Before deciding to merge, never run `gh pr merge --admin` or use an
+administrative/bypass flag to force a merge past a failing required status
+check. A required status check is enforced by the repository ruleset, so an
+administrator cannot make a failing head eligible by bypassing it; the PR
+needs a new head on which the required checks pass.
+
+Classify a required-check failure as **stale-head-only** only when every
+failing required check is explained by commits merged since the PR head and
+there is no unresolved content-level blocker. Verify that condition against
+`origin/main` before routing it, using a behind-main merge-base and/or a
+failure signature that is already fixed on the current `origin/main` checks.
+Do not call a check stale merely because the PR is old, main has advanced, or
+one check happens to be green on main while another failure remains
+unexplained.
+
+When, and only when, every failing required check meets that stale-head-only
+test, post a PR conversation comment with this exact instruction and end
+through the **REJECTED** route so process receives concrete work:
 
 > Rebase onto origin/main and push a new head -- git fetch origin && git rebase origin/main, resolve conflicts, then push. This is a stale-head issue, not a content defect.
 


### PR DESCRIPTION
{
  "project": "Route Stale-Head Review Before Convergence Hold",
  "branchName": "review-stale-head-routing-precedes-convergence-hold",
  "description": "Clarify the review workstation instructions so stale-head-only required-check failure classification runs before the repeat-review convergence/hold decision. Add reciprocal precedence references to the existing Step 4.2 and Step 6 rules in factory/workstations/review/AGENTS.md without changing either rule's substance or any other workstation file.",
  "context": {
    "customerAsk": "Make the ordering between the existing Step 4.2 convergence/hold rule and Step 6 required-check stale-head routing unambiguous. A stale-head-only required-check failure must be evaluated under Step 6 before Step 4.2 can silently hold an unchanged repeat review, while preserving both existing rules and limiting implementation to factory/workstations/review/AGENTS.md.",
    "problem": "Step 4.2 appears before Step 6 and tells review to hold silently when the head and blocker set are unchanged. Step 6 separately requires review to classify a required-check failure already fixed on current main and return a stale-head-only case with an explicit rebase instruction. With no precedence cross-reference, observed repeat reviews on stale PR heads have selected the earlier hold rule and never supplied process with the concrete rebase work.",
    "solution": "Add the customer-supplied exception to Step 4.2 directing review to run the Step 6 stale-head-only classification first, and add a reciprocal sentence at the start of the Step 6 stale-head-routing section stating that classification runs regardless of and before Step 4.2. Preserve all other wording and behavior."
  },
  "acceptanceCriteria": [
    "Step 4.2 contains the requested explicit exception adjacent to its convergence/HOLD language, directs review to run the Step 6 Required-check and stale-head routing classification first, and states that a stale-head-only failure is outside the convergence rule because review has not yet supplied the concrete rebase work.",
    "The Step 6 stale-head-routing section contains a reciprocal precedence sentence at its start stating that this classification runs regardless of, and before, the Step 4.2 convergence/hold decision; a reviewer following the document therefore routes a stale-head-only repeat failure through the existing explicit-rebase path rather than silently holding it.",
    "The implementation diff changes only factory/workstations/review/AGENTS.md; it does not change process/AGENTS.md, another workstation file, or the substance of either existing rule beyond the two cross-reference/precedence additions.",
    "Runtime proof classification — Not applicable: this lane only clarifies reviewer workstation instructions and changes no runtime-observable CLI, API, UI, emitted event, or runtime lifecycle behavior.",
    "Quality gates complete: Typecheck passes; applicable tests and documentation checks pass without adding meta-tests; lint reports no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green. Review also confirms the focused diff and both reciprocal references with direct text inspection/search.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit. The worker/reviewer cycle continues until required CI is terminal and passing, all blocking PR conversation feedback is explicitly addressed, merge conflicts are resolved, and the PR is actually merged."
  ],
  "userStories": [
    {
      "id": "review-stale-head-routing-precedes-convergence-hold-001",
      "title": "Make stale-head routing precede convergence hold",
      "description": "As a review worker, I want the stale-head-only classification to take precedence over the repeat-review convergence decision so that a PR failing only because its head is stale receives the existing concrete rebase instruction instead of another silent hold.",
      "acceptanceCriteria": [
        "Step 4.2 includes this exception without altering the surrounding rule's substance: ‘Exception: before treating a required-check failure as an unchanged, already-told-to blocker under this rule, first run the stale-head-only classification in Step 6 (Required-check and stale-head routing) below -- a stale-head-only failure is not covered by this convergence rule even on a repeat pass, because the explicit rebase instruction is concrete executor work the executor has not yet been given by review.’",
        "The opening of the Step 6 stale-head-routing section reciprocally states that its classification runs regardless of, and before, the Step 4.2 convergence/hold decision.",
        "When the head is unchanged and a required check fails only because fixes already exist on current main, a reviewer following the instructions reaches the existing Step 6 stale-head-only route and supplies its explicit rebase instruction; unchanged blocker sets that are not stale-head-only remain governed by Step 4.2.",
        "Direct inspection/search finds Exception adjacent to Step 4.2's HOLD language and finds the reciprocal precedence sentence adjacent to Required-check and stale-head routing; this is review evidence, not a new source-scanning or topology test.",
        "The implementation diff contains no change outside factory/workstations/review/AGENTS.md and no unrelated wording cleanup.",
        "Runtime proof classification — Not applicable: this lane only clarifies reviewer workstation instructions and changes no runtime-observable CLI, API, UI, emitted event, or runtime lifecycle behavior.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented the exact Step 4.2 exception and reciprocal Step 6 precedence sentence in factory/workstations/review/AGENTS.md. Focused text inspection and diff-scope checks pass; runtime proof is not applicable to this documentation-only change."
    }
  ]
}
