### PR TITLE
auto-regenerate-shared-ci-baselines-on-main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,6 +715,14 @@ jobs:
             bin/deadcode-current.txt
           if-no-files-found: warn
           retention-days: 14
+      - name: Upload normalized deadcode evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-deadcode-evidence
+          path: bin/deadcode-current.txt
+          if-no-files-found: error
+          retention-days: 14
       - name: Publish Backend Lint inventory to the pull request
         if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v7

--- a/.github/workflows/regenerate-shared-ci-baselines.yml
+++ b/.github/workflows/regenerate-shared-ci-baselines.yml
@@ -107,6 +107,24 @@ jobs:
             fi
           done
 
+      - name: Download the delivered normalized deadcode evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf -- .artifacts/deadcode
+          mkdir -p .artifacts/deadcode
+          gh run download "$SOURCE_RUN_ID" \
+            --repo "$REPOSITORY" \
+            --name backend-deadcode-evidence \
+            --dir .artifacts/deadcode
+          mapfile -t deadcode_reports < <(find .artifacts/deadcode -type f -name deadcode-current.txt -print)
+          if [[ "${#deadcode_reports[@]}" -ne 1 || ! -s "${deadcode_reports[0]:-}" ]]; then
+            echo "::error title=Invalid deadcode evidence::Expected exactly one non-empty deadcode-current.txt from source CI run $SOURCE_RUN_ID; found ${#deadcode_reports[@]} file(s)." >&2
+            exit 1
+          fi
+          printf 'DEADCODE_REPORT_PATH=%s\n' "${deadcode_reports[0]}" >> "$GITHUB_ENV"
+          echo "Using delivered normalized deadcode report ${deadcode_reports[0]}."
+
       - name: Prepare the serialized automation branch
         id: prepare
         shell: bash
@@ -144,7 +162,8 @@ jobs:
           make regenerate-shared-ci-baselines \
             BASELINE_REGEN_ROOT=. \
             UNIT_LATENCY_BUDGET="$UNIT_BUDGET_BASELINE" \
-            UNIT_LATENCY_SAMPLES=".artifacts/unit-latency/run-1.v2.json,.artifacts/unit-latency/run-2.v2.json,.artifacts/unit-latency/run-3.v2.json"
+            UNIT_LATENCY_SAMPLES=".artifacts/unit-latency/run-1.v2.json,.artifacts/unit-latency/run-2.v2.json,.artifacts/unit-latency/run-3.v2.json" \
+            BASELINE_REGEN_DEADCODE_REPORT="$DEADCODE_REPORT_PATH"
 
       - name: Validate generated working-tree scope
         id: candidate
@@ -154,6 +173,8 @@ jobs:
 
       - name: Close an obsolete PR after a no-diff regeneration
         if: steps.prepare.outputs.reconcile == 'true' && steps.candidate.outputs.changed != 'true'
+        env:
+          BOT_BRANCH_EXISTS: ${{ steps.prepare.outputs.bot_branch_exists }}
         shell: bash
         run: |
           set -euo pipefail
@@ -170,6 +191,15 @@ jobs:
             echo "Closed obsolete shared-baseline PR #$pr_number."
           else
             echo "Shared CI baselines already match main; no commit or pull request is needed."
+          fi
+          if [[ "$BOT_BRANCH_EXISTS" == "true" ]]; then
+            gh auth setup-git --hostname github.com
+            if git ls-remote --exit-code --heads origin "$BOT_BRANCH" >/dev/null 2>&1; then
+              git push origin --delete "$BOT_BRANCH"
+              echo "Deleted obsolete shared-baseline automation branch $BOT_BRANCH."
+            else
+              echo "Shared-baseline automation branch $BOT_BRANCH was already absent."
+            fi
           fi
 
       - name: Publish or reuse the bot branch and pull request

--- a/.github/workflows/regenerate-shared-ci-baselines.yml
+++ b/.github/workflows/regenerate-shared-ci-baselines.yml
@@ -1,0 +1,256 @@
+name: Regenerate Shared CI Baselines
+
+# CI's Backend Unit Latency job is the source of the three real hosted samples.
+# Waiting for its completed workflow_run keeps regeneration tied to delivered
+# checks instead of racing an in-progress main push or inventing local samples.
+# The source run may fail because a baseline is stale; artifact and generator
+# validation, rather than the source conclusion alone, decide publication.
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: shared-ci-baseline-regeneration
+  cancel-in-progress: true
+
+jobs:
+  reconcile:
+    name: Reconcile shared CI baselines
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    env:
+      # This must be a repository-approved dedicated bot or GitHub App token
+      # with contents:write, pull-requests:write, and actions:read. A separate
+      # credential is required because GITHUB_TOKEN-created pushes do not start
+      # the normal pull_request CI workflow.
+      GH_TOKEN: ${{ secrets.SHARED_BASELINE_BOT_TOKEN }}
+      REPOSITORY: ${{ github.repository }}
+      DEFAULT_BRANCH: main
+      BOT_BRANCH: automation/shared-ci-baselines
+      DEADCODE_BASELINE: docs/internal/baselines/deadcode-baseline.txt
+      UNIT_BUDGET_BASELINE: docs/internal/baselines/go-unit-lane-latency-budget.v1.json
+      SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+      SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+      SOURCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+    steps:
+      - name: Validate the completed source CI identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event.workflow_run.name }}" != "CI" ]]; then
+            echo "::error title=Unexpected source workflow::Expected CI, received ${{ github.event.workflow_run.name }}" >&2
+            exit 1
+          fi
+          if [[ "${{ github.event.workflow_run.head_branch }}" != "$DEFAULT_BRANCH" ]]; then
+            echo "::error title=Unexpected source branch::Expected $DEFAULT_BRANCH, received ${{ github.event.workflow_run.head_branch }}" >&2
+            exit 1
+          fi
+          if [[ "${{ github.event.workflow_run.conclusion }}" != "success" ]]; then
+            echo "::warning title=Source CI was not green::CI run $SOURCE_RUN_ID concluded with ${{ github.event.workflow_run.conclusion }}; publication still requires complete valid hosted evidence."
+          fi
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error title=Missing bot credential::Configure SHARED_BASELINE_BOT_TOKEN as the approved bot/App credential; no branch or pull request was created." >&2
+            exit 1
+          fi
+          if [[ ! "$SOURCE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error title=Invalid source revision::Expected a complete commit SHA, received $SOURCE_SHA" >&2
+            exit 1
+          fi
+
+      - name: Check out the delivered main revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Set up Go from go.mod
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download the exact unit-latency evidence from source CI
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf -- .artifacts/unit-latency
+          mkdir -p .artifacts/unit-latency
+          gh run download "$SOURCE_RUN_ID" \
+            --repo "$REPOSITORY" \
+            --name backend-unit-latency-evidence \
+            --dir .artifacts/unit-latency
+          for ordinal in 1 2 3; do
+            sample=".artifacts/unit-latency/run-${ordinal}.v2.json"
+            if [[ ! -s "$sample" ]]; then
+              echo "::error title=Missing unit-latency evidence::Expected non-empty $sample from source CI run $SOURCE_RUN_ID" >&2
+              exit 1
+            fi
+          done
+
+      - name: Prepare the serialized automation branch
+        id: prepare
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --force origin "refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"
+          current_main_sha="$(git rev-parse "origin/$DEFAULT_BRANCH")"
+          if [[ "$current_main_sha" != "$SOURCE_SHA" ]]; then
+            echo "::notice title=Superseded baseline run::main moved to $current_main_sha while this source run was completing; newer CI owns reconciliation."
+            echo "reconcile=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git ls-remote --exit-code --heads origin "$BOT_BRANCH" >/dev/null 2>&1; then
+            git fetch --force origin "refs/heads/$BOT_BRANCH:refs/remotes/origin/$BOT_BRANCH"
+            bot_branch_exists=true
+            bot_branch_sha="$(git rev-parse "origin/$BOT_BRANCH")"
+          else
+            bot_branch_exists=false
+            bot_branch_sha=""
+          fi
+          git switch --detach "$SOURCE_SHA"
+          git switch -C "$BOT_BRANCH" "$SOURCE_SHA"
+          echo "main_sha=$current_main_sha" >> "$GITHUB_OUTPUT"
+          echo "bot_branch_exists=$bot_branch_exists" >> "$GITHUB_OUTPUT"
+          echo "bot_branch_sha=$bot_branch_sha" >> "$GITHUB_OUTPUT"
+          echo "reconcile=true" >> "$GITHUB_OUTPUT"
+
+      - name: Regenerate both shared baselines from delivered checks
+        if: steps.prepare.outputs.reconcile == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          make regenerate-shared-ci-baselines \
+            BASELINE_REGEN_ROOT=. \
+            UNIT_LATENCY_BUDGET="$UNIT_BUDGET_BASELINE" \
+            UNIT_LATENCY_SAMPLES=".artifacts/unit-latency/run-1.v2.json,.artifacts/unit-latency/run-2.v2.json,.artifacts/unit-latency/run-3.v2.json"
+
+      - name: Validate generated working-tree scope
+        id: candidate
+        if: steps.prepare.outputs.reconcile == 'true'
+        shell: bash
+        run: node scripts/ci/shared-baseline-regeneration-workflow.mjs validate-working-tree --github-output "$GITHUB_OUTPUT"
+
+      - name: Close an obsolete PR after a no-diff regeneration
+        if: steps.prepare.outputs.reconcile == 'true' && steps.candidate.outputs.changed != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          pr_json="$(gh pr list --repo "$REPOSITORY" --state open --base "$DEFAULT_BRANCH" --head "$BOT_BRANCH" --json number,url --limit 10)"
+          pr_count="$(jq 'length' <<<"$pr_json")"
+          if [[ "$pr_count" -gt 1 ]]; then
+            echo "::error title=Duplicate baseline PRs::Found $pr_count open PRs for $BOT_BRANCH; refusing to select one." >&2
+            exit 1
+          fi
+          if [[ "$pr_count" == "1" ]]; then
+            pr_number="$(jq -r '.[0].number' <<<"$pr_json")"
+            gh pr close "$pr_number" --repo "$REPOSITORY" \
+              --comment "The latest successful main CI run regenerated no changes; this reconciliation is no longer needed."
+            echo "Closed obsolete shared-baseline PR #$pr_number."
+          else
+            echo "Shared CI baselines already match main; no commit or pull request is needed."
+          fi
+
+      - name: Publish or reuse the bot branch and pull request
+        if: steps.prepare.outputs.reconcile == 'true' && steps.candidate.outputs.changed == 'true'
+        shell: bash
+        env:
+          MAIN_SHA: ${{ steps.prepare.outputs.main_sha }}
+          BOT_BRANCH_EXISTS: ${{ steps.prepare.outputs.bot_branch_exists }}
+          BOT_BRANCH_SHA: ${{ steps.prepare.outputs.bot_branch_sha }}
+          CHANGED_PATHS: ${{ steps.candidate.outputs.paths }}
+        run: |
+          set -euo pipefail
+          node scripts/ci/shared-baseline-regeneration-workflow.mjs validate-working-tree --require-changes
+
+          candidate_matches_remote=false
+          if [[ "$BOT_BRANCH_EXISTS" == "true" ]]; then
+            remote_paths="$(git diff --name-only "$MAIN_SHA" "origin/$BOT_BRANCH" | sort -u)"
+            if printf '%s\n' "$remote_paths" | node scripts/ci/shared-baseline-regeneration-workflow.mjs validate-paths >/dev/null; then
+              candidate_matches_remote=true
+              for path in "$DEADCODE_BASELINE" "$UNIT_BUDGET_BASELINE"; do
+                if ! git diff --quiet "origin/$BOT_BRANCH" -- "$path"; then
+                  candidate_matches_remote=false
+                  break
+                fi
+              done
+            fi
+          fi
+
+          if [[ "$candidate_matches_remote" == "true" ]]; then
+            echo "Existing bot branch already contains the exact generated candidate; no second commit will be created."
+            git reset --hard "$MAIN_SHA"
+            commit_sha="$BOT_BRANCH_SHA"
+          else
+            git fetch --force origin "refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"
+            latest_main_sha="$(git rev-parse "origin/$DEFAULT_BRANCH")"
+            if [[ "$latest_main_sha" != "$MAIN_SHA" ]]; then
+              echo "::notice title=Superseded baseline candidate::main moved to $latest_main_sha before publication; newer CI owns reconciliation."
+              exit 0
+            fi
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add -- "$DEADCODE_BASELINE" "$UNIT_BUDGET_BASELINE"
+            node scripts/ci/shared-baseline-regeneration-workflow.mjs validate-staged
+            git commit -m "$SHARED_BASELINE_PR_TITLE"
+            gh auth setup-git --hostname github.com
+            if [[ -n "$BOT_BRANCH_SHA" ]]; then
+              git push --force-with-lease="refs/heads/$BOT_BRANCH:$BOT_BRANCH_SHA" origin "$BOT_BRANCH:$BOT_BRANCH"
+            else
+              git push --force-with-lease origin "$BOT_BRANCH:$BOT_BRANCH"
+            fi
+            commit_sha="$(git rev-parse HEAD)"
+          fi
+
+          git fetch --force origin "refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"
+          latest_main_sha="$(git rev-parse "origin/$DEFAULT_BRANCH")"
+          if [[ "$latest_main_sha" != "$MAIN_SHA" ]]; then
+            echo "::notice title=Superseded published candidate::main moved to $latest_main_sha before PR reconciliation; newer CI owns the fixed branch."
+            exit 0
+          fi
+
+          pr_json="$(gh pr list --repo "$REPOSITORY" --state open --base "$DEFAULT_BRANCH" --head "$BOT_BRANCH" --json number,url --limit 10)"
+          pr_count="$(jq 'length' <<<"$pr_json")"
+          if [[ "$pr_count" -gt 1 ]]; then
+            echo "::error title=Duplicate baseline PRs::Found $pr_count open PRs for $BOT_BRANCH; refusing to select one." >&2
+            exit 1
+          fi
+          pr_body="$(node scripts/ci/shared-baseline-regeneration-workflow.mjs render-body \
+            --source-sha "$MAIN_SHA" \
+            --commit-sha "$commit_sha" \
+            --run-url "$SOURCE_RUN_URL" \
+            --paths "$CHANGED_PATHS")"
+          if [[ "$pr_count" == "1" ]]; then
+            pr_number="$(jq -r '.[0].number' <<<"$pr_json")"
+            gh pr edit "$pr_number" --repo "$REPOSITORY" \
+              --title "$SHARED_BASELINE_PR_TITLE" --body "$pr_body"
+          else
+            pr_url="$(gh pr create --repo "$REPOSITORY" --base "$DEFAULT_BRANCH" --head "$BOT_BRANCH" \
+              --title "$SHARED_BASELINE_PR_TITLE" --body "$pr_body")"
+            pr_number="$(gh pr view "$pr_url" --repo "$REPOSITORY" --json number --jq '.number')"
+          fi
+
+          pr_metadata="$(gh pr view "$pr_number" --repo "$REPOSITORY" --json baseRefName,headRefName,headRefOid,isDraft,files)"
+          if [[ "$(jq -r '.baseRefName' <<<"$pr_metadata")" != "$DEFAULT_BRANCH" || "$(jq -r '.headRefName' <<<"$pr_metadata")" != "$BOT_BRANCH" ]]; then
+            echo "::error title=Unexpected baseline PR refs::PR #$pr_number does not target $DEFAULT_BRANCH from $BOT_BRANCH." >&2
+            exit 1
+          fi
+          if [[ "$(jq -r '.headRefOid' <<<"$pr_metadata")" != "$commit_sha" ]]; then
+            echo "::error title=Stale baseline PR head::PR #$pr_number does not point to generated commit $commit_sha." >&2
+            exit 1
+          fi
+          remote_paths="$(jq -r '.files[].path' <<<"$pr_metadata" | sort -u)"
+          printf '%s\n' "$remote_paths" | node scripts/ci/shared-baseline-regeneration-workflow.mjs validate-paths
+          if [[ "$(jq -r '.isDraft' <<<"$pr_metadata")" == "true" ]]; then
+            gh pr ready "$pr_number" --repo "$REPOSITORY"
+          fi
+          echo "Requesting auto-merge for baseline PR #$pr_number after verifying its generated head and file scope."
+          gh pr merge "$pr_number" --repo "$REPOSITORY" --auto --squash --delete-branch --match-head-commit "$commit_sha"

--- a/.github/workflows/regenerate-shared-ci-baselines.yml
+++ b/.github/workflows/regenerate-shared-ci-baselines.yml
@@ -36,6 +36,7 @@ jobs:
       REPOSITORY: ${{ github.repository }}
       DEFAULT_BRANCH: main
       BOT_BRANCH: automation/shared-ci-baselines
+      SHARED_BASELINE_PR_TITLE: "chore(ci): reconcile shared CI baselines"
       DEADCODE_BASELINE: docs/internal/baselines/deadcode-baseline.txt
       UNIT_BUDGET_BASELINE: docs/internal/baselines/go-unit-lane-latency-budget.v1.json
       SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -128,10 +129,12 @@ jobs:
           fi
           git switch --detach "$SOURCE_SHA"
           git switch -C "$BOT_BRANCH" "$SOURCE_SHA"
-          echo "main_sha=$current_main_sha" >> "$GITHUB_OUTPUT"
-          echo "bot_branch_exists=$bot_branch_exists" >> "$GITHUB_OUTPUT"
-          echo "bot_branch_sha=$bot_branch_sha" >> "$GITHUB_OUTPUT"
-          echo "reconcile=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "main_sha=$current_main_sha"
+            echo "bot_branch_exists=$bot_branch_exists"
+            echo "bot_branch_sha=$bot_branch_sha"
+            echo "reconcile=true"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Regenerate both shared baselines from delivered checks
         if: steps.prepare.outputs.reconcile == 'true'

--- a/.github/workflows/regenerate-shared-ci-baselines.yml
+++ b/.github/workflows/regenerate-shared-ci-baselines.yml
@@ -41,6 +41,8 @@ jobs:
       SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
       SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
       SOURCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+      SOURCE_EVENT: ${{ github.event.workflow_run.event }}
+      SOURCE_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
     steps:
       - name: Validate the completed source CI identity
         shell: bash
@@ -48,6 +50,14 @@ jobs:
           set -euo pipefail
           if [[ "${{ github.event.workflow_run.name }}" != "CI" ]]; then
             echo "::error title=Unexpected source workflow::Expected CI, received ${{ github.event.workflow_run.name }}" >&2
+            exit 1
+          fi
+          if [[ "$SOURCE_EVENT" != "push" ]]; then
+            echo "::error title=Unexpected source event::Expected a push-triggered CI run, received $SOURCE_EVENT" >&2
+            exit 1
+          fi
+          if [[ "$SOURCE_REPOSITORY" != "$REPOSITORY" ]]; then
+            echo "::error title=Unexpected source repository::Expected $REPOSITORY, received $SOURCE_REPOSITORY" >&2
             exit 1
           fi
           if [[ "${{ github.event.workflow_run.head_branch }}" != "$DEFAULT_BRANCH" ]]; then

--- a/.github/workflows/regenerate-shared-ci-baselines.yml
+++ b/.github/workflows/regenerate-shared-ci-baselines.yml
@@ -28,11 +28,12 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      # This must be a repository-approved dedicated bot or GitHub App token
-      # with contents:write, pull-requests:write, and actions:read. A separate
-      # credential is required because GITHUB_TOKEN-created pushes do not start
-      # the normal pull_request CI workflow.
-      GH_TOKEN: ${{ secrets.SHARED_BASELINE_BOT_TOKEN }}
+      # GH_TOKEN is a GitHub App installation token minted per run (see the
+      # "Mint the baseline bot installation token" and "Export the bot
+      # credential for later steps" steps below) from the BASELINE_BOT_APP_ID
+      # and BASELINE_BOT_APP_PRIVATE_KEY secrets. A separate credential is
+      # still required because GITHUB_TOKEN-created pushes and pull requests
+      # do not start the normal pull_request CI workflow.
       REPOSITORY: ${{ github.repository }}
       DEFAULT_BRANCH: main
       BOT_BRANCH: automation/shared-ci-baselines
@@ -45,6 +46,25 @@ jobs:
       SOURCE_EVENT: ${{ github.event.workflow_run.event }}
       SOURCE_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
     steps:
+      - name: Mint the baseline bot installation token
+        id: bot-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BASELINE_BOT_APP_ID }}
+          private-key: ${{ secrets.BASELINE_BOT_APP_PRIVATE_KEY }}
+
+      - name: Export the bot credential for later steps
+        shell: bash
+        env:
+          BOT_TOKEN: ${{ steps.bot-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$BOT_TOKEN" ]]; then
+            echo "::error title=Missing bot credential::App token minting returned empty; check BASELINE_BOT_APP_ID/BASELINE_BOT_APP_PRIVATE_KEY and the App installation on this repository." >&2
+            exit 1
+          fi
+          echo "GH_TOKEN=$BOT_TOKEN" >> "$GITHUB_ENV"
+
       - name: Validate the completed source CI identity
         shell: bash
         run: |
@@ -69,7 +89,7 @@ jobs:
             echo "::warning title=Source CI was not green::CI run $SOURCE_RUN_ID concluded with ${{ github.event.workflow_run.conclusion }}; publication still requires complete valid hosted evidence."
           fi
           if [[ -z "${GH_TOKEN:-}" ]]; then
-            echo "::error title=Missing bot credential::Configure SHARED_BASELINE_BOT_TOKEN as the approved bot/App credential; no branch or pull request was created." >&2
+            echo "::error title=Missing bot credential::App token minting did not produce a credential; check BASELINE_BOT_APP_ID/BASELINE_BOT_APP_PRIVATE_KEY and the App installation; no branch or pull request was created." >&2
             exit 1
           fi
           if [[ ! "$SOURCE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then

--- a/Makefile
+++ b/Makefile
@@ -505,7 +505,7 @@ readme-check:
 test: test-unit test-ci-workflows
 
 test-ci-workflows:
-	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs scripts/ci/lane-budget.test.mjs scripts/ci/unit-latency-workflow.test.mjs scripts/ci/backend-lint-report.test.mjs scripts/ci/backend-lint-workflow.test.mjs scripts/ci/functional-coverage-comment.test.mjs scripts/ci/functional-coverage-verdict.test.mjs scripts/ci/unit-coverage-report.test.mjs scripts/ci/workflow-lint.test.mjs scripts/ci/published-backend-conformance-workflow.test.mjs scripts/localai-backend-artifact-workflow.test.mjs
+	$(NODE) --test scripts/default-pipeline.test.mjs scripts/development-package-workflow.test.mjs scripts/verification-policy.test.mjs scripts/ci/lane-budget.test.mjs scripts/ci/unit-latency-workflow.test.mjs scripts/ci/backend-lint-report.test.mjs scripts/ci/backend-lint-workflow.test.mjs scripts/ci/functional-coverage-comment.test.mjs scripts/ci/functional-coverage-verdict.test.mjs scripts/ci/unit-coverage-report.test.mjs scripts/ci/workflow-lint.test.mjs scripts/ci/shared-baseline-regeneration-workflow.test.mjs scripts/ci/published-backend-conformance-workflow.test.mjs scripts/localai-backend-artifact-workflow.test.mjs
 
 test-full:
 	$(GO) test ./... -timeout $(GO_TEST_TIMEOUT)

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,8 @@ UNIT_DEFAULT_JOBS ?= $(GO_LANE_BUDGET)
 UNIT_TIMING_OUTPUT ?=
 UNIT_LATENCY_BUDGET ?= docs/internal/baselines/go-unit-lane-latency-budget.v1.json
 UNIT_LATENCY_SAMPLES ?= .artifacts/unit-latency/run-1.v2.json,.artifacts/unit-latency/run-2.v2.json,.artifacts/unit-latency/run-3.v2.json
+BASELINE_REGEN_ROOT ?= .
+BASELINE_REGEN_DEADCODE_REPORT ?=
 FUNCTIONAL_LONG_TAGS ?= functionallong
 FUNCTIONAL_LONG_PACKAGES := ./tests/functional/...
 FUNCTIONAL_LONG_COMPILE_PACKAGES := $(FUNCTIONAL_LONG_PACKAGES) ./pkg/services/models/internal/backendconformance
@@ -235,7 +237,7 @@ endef
 .PHONY: default default-pipeline-banner build install bundle-api print-go-parallelism
 .PHONY: fmt fmt-check vet deps deps-tidy clean init typecheck release lint
 
-.PHONY: test test-full test-unit test-unit-fresh test-unit-latency-budget test-ci-workflows test-lane-audit test-maintenance test-integration test-contract test-stress test-release
+.PHONY: test test-full test-unit test-unit-fresh test-unit-latency-budget regenerate-shared-ci-baselines test-ci-workflows test-lane-audit test-maintenance test-integration test-contract test-stress test-release
 .PHONY: test-functional test-functional-fresh test-functional-long test-functional-long-compile test-backend-functional functional-boundary-check functional-test-viz
 .PHONY: test-ui-browser-integration test-ui-storybook-integration test-ui-durable-session-real-backend test-ui-performance ui-component-test
 .PHONY: test-unit-coverage test-functional-coverage coverage-help test-backend-coverage test-coverage-go test-race
@@ -516,6 +518,9 @@ test-unit-fresh:
 
 test-unit-latency-budget:
 	$(GO) run ./cmd/unitlanebudget -budget "$(UNIT_LATENCY_BUDGET)" -samples "$(UNIT_LATENCY_SAMPLES)"
+
+regenerate-shared-ci-baselines:
+	$(GO) run ./cmd/unitlanebudget -mode regenerate -root "$(BASELINE_REGEN_ROOT)" -budget "$(UNIT_LATENCY_BUDGET)" -samples "$(UNIT_LATENCY_SAMPLES)" $(if $(strip $(BASELINE_REGEN_DEADCODE_REPORT)),-deadcode-report "$(BASELINE_REGEN_DEADCODE_REPORT)",)
 
 # Merge-base-aware changed-test flake prevention. The caller must provide the
 # pull-request base ref/SHA; the command resolves its merge-base with head,

--- a/cmd/unitlanebudget/main.go
+++ b/cmd/unitlanebudget/main.go
@@ -8,9 +8,11 @@ import (
 )
 
 type budgetConfig struct {
-	budgetPath string
-	samples    string
-	mode       string
+	budgetPath     string
+	samples        string
+	mode           string
+	root           string
+	deadcodeReport string
 }
 
 var stdoutWriter io.Writer = os.Stdout
@@ -25,8 +27,11 @@ func main() {
 
 func run() error {
 	cfg := parseConfig()
-	if cfg.mode != "final" && cfg.mode != "baseline" {
-		return checkerError(fmt.Errorf("mode: expected final or baseline, actual %q", cfg.mode))
+	if cfg.mode != "final" && cfg.mode != "baseline" && cfg.mode != "regenerate" {
+		return checkerError(fmt.Errorf("mode: expected final, baseline, or regenerate, actual %q", cfg.mode))
+	}
+	if cfg.mode == "regenerate" {
+		return regenerateSharedBaselines(cfg)
 	}
 	paths, err := splitSamplePaths(cfg.samples)
 	if err != nil {
@@ -60,7 +65,9 @@ func parseConfig() budgetConfig {
 	cfg := budgetConfig{}
 	flag.StringVar(&cfg.budgetPath, "budget", "docs/internal/baselines/go-unit-lane-latency-budget.v1.json", "unit-lane latency budget JSON path")
 	flag.StringVar(&cfg.samples, "samples", "", "comma-separated v2 timing summary paths")
-	flag.StringVar(&cfg.mode, "mode", "final", "validation mode: final or baseline")
+	flag.StringVar(&cfg.mode, "mode", "final", "validation mode: final, baseline, or regenerate")
+	flag.StringVar(&cfg.root, "root", ".", "repository root for regeneration inputs and outputs")
+	flag.StringVar(&cfg.deadcodeReport, "deadcode-report", "", "normalized deadcode report to use; runs the pinned analyzer when omitted")
 	flag.Parse()
 	return cfg
 }

--- a/cmd/unitlanebudget/regenerate.go
+++ b/cmd/unitlanebudget/regenerate.go
@@ -1,0 +1,364 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"slices"
+	"strings"
+)
+
+const (
+	regeneratedDeadcodeBaselinePath = "docs/internal/baselines/deadcode-baseline.txt"
+	regeneratedUnitBudgetPath       = "docs/internal/baselines/go-unit-lane-latency-budget.v1.json"
+	regenerationDeadcodeTool        = "golang.org/x/tools/cmd/deadcode@v0.25.1"
+	regenerationRunnerProvider      = "github-actions"
+	regenerationRunnerImage         = "ubuntu-24.04"
+	regenerationRunnerOS            = "linux"
+	regenerationRunnerArchitecture  = "amd64"
+)
+
+var (
+	runRegenerationDeadcode     = runDeadcodeForRegeneration
+	regenerationExecCommand     = exec.Command
+	regenerationPositionPattern = regexp.MustCompile(`:(\d+):(\d+):`)
+)
+
+type regenerationPaths struct {
+	deadcode string
+	budget   string
+}
+
+func regenerateSharedBaselines(cfg budgetConfig) error {
+	paths, err := resolveRegenerationPaths(cfg.root, cfg.budgetPath)
+	if err != nil {
+		return regenerationError(err)
+	}
+	samplePaths, err := splitSamplePaths(cfg.samples)
+	if err != nil {
+		return regenerationError(err)
+	}
+	samples, err := loadTimingSamples(samplePaths)
+	if err != nil {
+		return regenerationError(err)
+	}
+	if err := validateHostedRegenerationSamples(samples); err != nil {
+		return regenerationError(err)
+	}
+
+	budget, err := loadLatencyBudget(paths.budget)
+	if err != nil {
+		return regenerationError(err)
+	}
+	deadcodeReport, err := loadRegenerationDeadcodeReport(cfg.root, cfg.deadcodeReport)
+	if err != nil {
+		return regenerationError(err)
+	}
+	updatedBudget, err := regeneratedBudget(budget, samples[0])
+	if err != nil {
+		return regenerationError(err)
+	}
+	budgetData, err := renderRegeneratedBudget(updatedBudget)
+	if err != nil {
+		return regenerationError(err)
+	}
+	if err := validateLatencyBudgetDocument(budgetSchemaPath(paths.budget), budgetData); err != nil {
+		return regenerationError(fmt.Errorf("generated budget schema validation: %w", err))
+	}
+
+	if err := publishRegeneratedBaselines(paths, []byte(deadcodeReport), budgetData); err != nil {
+		return regenerationError(err)
+	}
+	return nil
+}
+
+func regenerationError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("shared baseline regeneration failed: %w\nRerun: make regenerate-shared-ci-baselines", err)
+}
+
+func resolveRegenerationPaths(root, budgetPath string) (regenerationPaths, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		root = "."
+	}
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return regenerationPaths{}, fmt.Errorf("resolve repository root %q: %w", root, err)
+	}
+	expectedBudget := filepath.Join(root, filepath.FromSlash(regeneratedUnitBudgetPath))
+	configuredBudget := strings.TrimSpace(budgetPath)
+	if configuredBudget == "" {
+		return regenerationPaths{}, fmt.Errorf("budget output: expected %s, actual empty", regeneratedUnitBudgetPath)
+	}
+	if !filepath.IsAbs(configuredBudget) {
+		configuredBudget = filepath.Join(root, configuredBudget)
+	}
+	configuredBudget, err = filepath.Abs(configuredBudget)
+	if err != nil {
+		return regenerationPaths{}, fmt.Errorf("resolve budget output %q: %w", budgetPath, err)
+	}
+	if !samePath(configuredBudget, expectedBudget) {
+		return regenerationPaths{}, fmt.Errorf("refusing budget output %q; regeneration may write only %s", budgetPath, regeneratedUnitBudgetPath)
+	}
+	paths := regenerationPaths{
+		deadcode: filepath.Join(root, filepath.FromSlash(regeneratedDeadcodeBaselinePath)),
+		budget:   configuredBudget,
+	}
+	for _, output := range []struct {
+		name string
+		path string
+	}{
+		{name: "deadcode baseline", path: paths.deadcode},
+		{name: "unit budget", path: paths.budget},
+	} {
+		info, statErr := os.Lstat(output.path)
+		if statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+			return regenerationPaths{}, fmt.Errorf("refusing %s symlink %q", output.name, output.path)
+		}
+		if statErr != nil && !os.IsNotExist(statErr) {
+			return regenerationPaths{}, fmt.Errorf("inspect %s %q: %w", output.name, output.path, statErr)
+		}
+	}
+	return paths, nil
+}
+
+func samePath(left, right string) bool {
+	left = filepath.Clean(left)
+	right = filepath.Clean(right)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(left, right)
+	}
+	return left == right
+}
+
+func validateHostedRegenerationSamples(samples []timingSummary) error {
+	if _, err := validateBaseline(samples); err != nil {
+		return err
+	}
+	var problems validationProblems
+	for index, sample := range samples {
+		runner := sample.Run.Runner
+		prefix := fmt.Sprintf("sample %d hosted runner", index+1)
+		if runner.Provider != regenerationRunnerProvider {
+			problems.add("%s provider: expected %q, actual %q", prefix, regenerationRunnerProvider, runner.Provider)
+		}
+		if runner.Image != regenerationRunnerImage {
+			problems.add("%s image: expected %q, actual %q", prefix, regenerationRunnerImage, runner.Image)
+		}
+		if runner.OS != regenerationRunnerOS {
+			problems.add("%s os: expected %q, actual %q", prefix, regenerationRunnerOS, runner.OS)
+		}
+		if runner.Architecture != regenerationRunnerArchitecture {
+			problems.add("%s architecture: expected %q, actual %q", prefix, regenerationRunnerArchitecture, runner.Architecture)
+		}
+	}
+	return problems.err()
+}
+
+func regeneratedBudget(budget latencyBudget, sample timingSummary) (latencyBudget, error) {
+	packages, tests := inventories(sample)
+	if len(packages) == 0 || len(tests) == 0 {
+		return latencyBudget{}, fmt.Errorf("reference inventory: expected nonempty package and test inventories")
+	}
+	updated := budget
+	updated.Reference.BaseCommit = sample.Run.Commit
+	updated.Reference.RunnerImage = sample.Run.Runner.Image
+	updated.Reference.GoVersion = sample.Run.GoVersion
+	updated.Reference.UnitDefaultJobs = sample.Run.UnitDefaultJobs
+	updated.Reference.ComputedLaneBudget = sample.Run.ComputedLaneBudget
+	updated.Reference.PackageInventory = packages
+	updated.Reference.TestInventory = tests
+	var problems validationProblems
+	validateBudgetShape(&problems, updated)
+	if err := problems.err(); err != nil {
+		return latencyBudget{}, err
+	}
+	return updated, nil
+}
+
+func renderRegeneratedBudget(budget latencyBudget) ([]byte, error) {
+	data, err := json.MarshalIndent(budget, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("render generated budget: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func loadRegenerationDeadcodeReport(root, reportPath string) (string, error) {
+	var (
+		report []byte
+		err    error
+	)
+	if strings.TrimSpace(reportPath) != "" {
+		path := reportPath
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(root, path)
+		}
+		report, err = os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("read normalized deadcode report %q: %w", reportPath, err)
+		}
+	} else {
+		var generated string
+		generated, err = runRegenerationDeadcode(root)
+		if err != nil {
+			return "", err
+		}
+		report = []byte(generated)
+	}
+	return normalizeRegeneratedDeadcode(string(report)), nil
+}
+
+func runDeadcodeForRegeneration(root string) (string, error) {
+	command := regenerationExecCommand("go", "run", regenerationDeadcodeTool, "./...")
+	command.Dir = root
+	command.Env = regenerationDeadcodeEnv()
+	var commandOutput bytes.Buffer
+	var commandErrors bytes.Buffer
+	command.Stdout = &commandOutput
+	command.Stderr = &commandErrors
+	if err := command.Run(); err != nil {
+		diagnostic := strings.TrimSpace(commandErrors.String())
+		if diagnostic != "" {
+			return "", fmt.Errorf("run deadcode: %w\n%s", err, diagnostic)
+		}
+		return "", fmt.Errorf("run deadcode: %w", err)
+	}
+	if commandErrors.Len() > 0 {
+		_, _ = io.Copy(stderrWriter, &commandErrors)
+	}
+	return commandOutput.String(), nil
+}
+
+func regenerationDeadcodeEnv() []string {
+	env := os.Environ()
+	for index, entry := range env {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok && name == "GODEBUG" {
+			env[index] = "GODEBUG=" + ensureRegenerationGoTypesAlias(value)
+			return env
+		}
+	}
+	return append(env, "GODEBUG=gotypesalias=1")
+}
+
+func ensureRegenerationGoTypesAlias(value string) string {
+	parts := strings.Split(value, ",")
+	flags := make([]string, 0, len(parts)+1)
+	found := false
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		name, _, ok := strings.Cut(part, "=")
+		if ok && name == "gotypesalias" {
+			flags = append(flags, "gotypesalias=1")
+			found = true
+			continue
+		}
+		flags = append(flags, part)
+	}
+	if !found {
+		flags = append(flags, "gotypesalias=1")
+	}
+	return strings.Join(flags, ",")
+}
+
+func normalizeRegeneratedDeadcode(report string) string {
+	report = strings.ReplaceAll(report, "\r\n", "\n")
+	report = strings.ReplaceAll(report, "\r", "\n")
+	report = strings.ReplaceAll(report, "\\", "/")
+	report = strings.TrimSpace(report)
+	if report == "" {
+		return ""
+	}
+	lines := strings.Split(report, "\n")
+	for index, line := range lines {
+		lines[index] = regenerationPositionPattern.ReplaceAllString(strings.TrimSpace(line), ":")
+	}
+	slices.Sort(lines)
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func publishRegeneratedBaselines(paths regenerationPaths, deadcodeData, budgetData []byte) error {
+	currentDeadcode, err := os.ReadFile(paths.deadcode)
+	if err != nil {
+		return fmt.Errorf("read deadcode baseline before publish: %w", err)
+	}
+	currentBudget, err := os.ReadFile(paths.budget)
+	if err != nil {
+		return fmt.Errorf("read unit budget before publish: %w", err)
+	}
+	changes := []struct {
+		name string
+		path string
+		data []byte
+	}{
+		{name: "deadcode baseline", path: paths.deadcode, data: deadcodeData},
+		{name: "unit budget", path: paths.budget, data: budgetData},
+	}
+	changed := make([]struct {
+		name string
+		path string
+		data []byte
+	}, 0, len(changes))
+	for index, candidate := range changes {
+		current := currentDeadcode
+		if index == 1 {
+			current = currentBudget
+		}
+		if bytes.Equal(current, candidate.data) {
+			continue
+		}
+		changed = append(changed, candidate)
+	}
+	if len(changed) == 0 {
+		fmt.Fprintln(stdoutWriter, "[agent-factory:baselines] shared baselines already match")
+		return nil
+	}
+	for _, candidate := range changed {
+		if err := atomicReplaceRegeneratedFile(candidate.path, candidate.data); err != nil {
+			return fmt.Errorf("publish %s: %w", candidate.name, err)
+		}
+	}
+	fmt.Fprintf(stdoutWriter, "[agent-factory:baselines] regenerated %d baseline file(s)\n", len(changed))
+	return nil
+}
+
+func atomicReplaceRegeneratedFile(path string, data []byte) error {
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".shared-baseline-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0o644); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("set temporary file mode: %w", err)
+	}
+	if _, err := temporary.Write(data); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("write temporary file: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary file: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		if removeErr := os.Remove(path); removeErr != nil {
+			return fmt.Errorf("replace destination: %w (remove existing: %v)", err, removeErr)
+		}
+		if retryErr := os.Rename(temporaryPath, path); retryErr != nil {
+			return fmt.Errorf("rename replacement: %w", retryErr)
+		}
+	}
+	return nil
+}

--- a/cmd/unitlanebudget/regenerate_test.go
+++ b/cmd/unitlanebudget/regenerate_test.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestRegenerateSharedBaselinesUpdatesOwnedFilesAndIsIdempotent(t *testing.T) {
+	fixture, samples := newRegenerationFixture(t)
+	for index := range samples {
+		samples[index].Run.Commit = strings.Repeat("b", 40)
+		samples[index].Packages[1].Tests = append(samples[index].Packages[1].Tests, "TestBeta/new")
+		slices.Sort(samples[index].Packages[1].Tests)
+		samples[index].TestCount++
+	}
+	writeRegenerationSamples(t, fixture.samplePaths, samples)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	withRegenerationWriters(t, stdout, stderr)
+	originalRunner := runRegenerationDeadcode
+	callCount := 0
+	runRegenerationDeadcode = func(string) (string, error) {
+		callCount++
+		return "pkg\\zeta.go:12:4: New finding\r\npkg\\alpha.go:3:2: Old finding\n", nil
+	}
+	t.Cleanup(func() { runRegenerationDeadcode = originalRunner })
+
+	cfg := regenerationConfig(fixture)
+	if err := regenerateSharedBaselines(cfg); err != nil {
+		t.Fatalf("first regeneration: %v", err)
+	}
+	firstDeadcode, err := os.ReadFile(fixture.deadcodePath)
+	if err != nil {
+		t.Fatalf("read regenerated deadcode baseline: %v", err)
+	}
+	firstBudget, err := os.ReadFile(fixture.budgetPath)
+	if err != nil {
+		t.Fatalf("read regenerated unit budget: %v", err)
+	}
+	if got := string(firstDeadcode); got != "pkg/alpha.go: Old finding\npkg/zeta.go: New finding\n" {
+		t.Fatalf("deadcode baseline = %q, want normalized generated report", got)
+	}
+	updated, err := loadLatencyBudget(fixture.budgetPath)
+	if err != nil {
+		t.Fatalf("load regenerated unit budget: %v", err)
+	}
+	packages, tests := inventories(samples[0])
+	if !slices.Equal(updated.Reference.PackageInventory, packages) || !slices.Equal(updated.Reference.TestInventory, tests) {
+		t.Fatalf("regenerated inventory = %d packages/%d tests, want %d/%d", len(updated.Reference.PackageInventory), len(updated.Reference.TestInventory), len(packages), len(tests))
+	}
+	if updated.Reference.BaseCommit != strings.Repeat("b", 40) || updated.Reference.RunnerImage != "ubuntu-24.04" || updated.Reference.GoVersion != "go1.25.0" || updated.Reference.UnitDefaultJobs != 2 || updated.Reference.ComputedLaneBudget != 2 {
+		t.Fatalf("regenerated identity = %+v, want identity from hosted samples", updated.Reference)
+	}
+	if !slices.Equal(updated.Reference.Samples, fixture.originalBudget.Reference.Samples) || updated.Reference.MedianWallSeconds != fixture.originalBudget.Reference.MedianWallSeconds || updated.Policy != fixture.originalBudget.Policy {
+		t.Fatal("regeneration changed historical timing or policy fields")
+	}
+
+	stdout.Reset()
+	if err := regenerateSharedBaselines(cfg); err != nil {
+		t.Fatalf("second regeneration: %v", err)
+	}
+	secondDeadcode, _ := os.ReadFile(fixture.deadcodePath)
+	secondBudget, _ := os.ReadFile(fixture.budgetPath)
+	if !bytes.Equal(firstDeadcode, secondDeadcode) || !bytes.Equal(firstBudget, secondBudget) {
+		t.Fatal("second regeneration changed identical baseline inputs")
+	}
+	if callCount != 2 || !strings.Contains(stdout.String(), "already match") {
+		t.Fatalf("second regeneration output = %q, deadcode calls = %d; want idempotent no-diff result", stdout.String(), callCount)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("regeneration stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRegenerateSharedBaselinesRejectsInvalidSamplesBeforePublishing(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func([]timingSummary)
+		want   string
+	}{
+		{name: "incomplete", mutate: func(samples []timingSummary) { samples[0].Complete = false }, want: "complete: expected true"},
+		{name: "cached", mutate: func(samples []timingSummary) { samples[0].Packages[0].Cache = unitTimingCacheCached }, want: "cache: expected \"executed\""},
+		{name: "unknown cache", mutate: func(samples []timingSummary) { samples[0].Packages[0].Cache = unitTimingCacheUnknown }, want: "cache: expected \"executed\""},
+		{name: "runner image", mutate: func(samples []timingSummary) {
+			for index := range samples {
+				samples[index].Run.Runner.Image = "ubuntu-22.04"
+			}
+		}, want: "hosted runner image"},
+		{name: "identity", mutate: func(samples []timingSummary) { samples[1].Run.Commit = strings.Repeat("c", 40) }, want: "identity: expected"},
+		{name: "inventory", mutate: func(samples []timingSummary) { samples[1].Packages[0].Tests[0] = "TestDifferent" }, want: "test inventory: expected"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture, samples := newRegenerationFixture(t)
+			testCase.mutate(samples)
+			writeRegenerationSamples(t, fixture.samplePaths, samples)
+			originalRunner := runRegenerationDeadcode
+			deadcodeCalls := 0
+			runRegenerationDeadcode = func(string) (string, error) {
+				deadcodeCalls++
+				return "new report\n", nil
+			}
+			t.Cleanup(func() { runRegenerationDeadcode = originalRunner })
+
+			cfg := regenerationConfig(fixture)
+			err := regenerateSharedBaselines(cfg)
+			if err == nil || !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("regeneration error = %v, want substring %q", err, testCase.want)
+			}
+			if deadcodeCalls != 0 {
+				t.Fatalf("deadcode calls = %d, want validation before generation", deadcodeCalls)
+			}
+			assertRegenerationFixtureUnchanged(t, fixture)
+		})
+	}
+}
+
+func TestRegenerateSharedBaselinesDeadcodeFailurePreservesBothBaselines(t *testing.T) {
+	fixture, samples := newRegenerationFixture(t)
+	writeRegenerationSamples(t, fixture.samplePaths, samples)
+	originalRunner := runRegenerationDeadcode
+	runRegenerationDeadcode = func(string) (string, error) {
+		return "", errors.New("deadcode analyzer exited 23")
+	}
+	t.Cleanup(func() { runRegenerationDeadcode = originalRunner })
+
+	err := regenerateSharedBaselines(regenerationConfig(fixture))
+	if err == nil || !strings.Contains(err.Error(), "deadcode analyzer exited 23") {
+		t.Fatalf("regeneration error = %v, want deadcode diagnostic", err)
+	}
+	assertRegenerationFixtureUnchanged(t, fixture)
+}
+
+func TestRegenerateSharedBaselinesRejectsOutputOutsideAllowlist(t *testing.T) {
+	fixture, samples := newRegenerationFixture(t)
+	writeRegenerationSamples(t, fixture.samplePaths, samples)
+	originalBudget, err := os.ReadFile(fixture.budgetPath)
+	if err != nil {
+		t.Fatalf("read fixture budget: %v", err)
+	}
+	outside := filepath.Join(fixture.root, "outside.json")
+	cfg := regenerationConfig(fixture)
+	cfg.budgetPath = outside
+	if err := regenerateSharedBaselines(cfg); err == nil || !strings.Contains(err.Error(), "may write only") {
+		t.Fatalf("regeneration error = %v, want output allowlist failure", err)
+	}
+	if _, err := os.Stat(outside); !os.IsNotExist(err) {
+		t.Fatalf("outside output stat error = %v, want no output", err)
+	}
+	currentBudget, _ := os.ReadFile(fixture.budgetPath)
+	if !bytes.Equal(originalBudget, currentBudget) {
+		t.Fatal("allowlist rejection changed the owned budget")
+	}
+}
+
+func TestRunDeadcodeForRegenerationUsesPinnedToolAndAliasEnvironment(t *testing.T) {
+	originalExec := regenerationExecCommand
+	t.Cleanup(func() { regenerationExecCommand = originalExec })
+	t.Setenv("GODEBUG", "gocachehash=1,gotypesalias=0")
+	t.Setenv("GO_WANT_REGENERATION_DEADCODE_HELPER", "1")
+	t.Setenv("REGENERATION_DEADCODE_HELPER_STDOUT", "pkg/foo.go: Example\n")
+	var captured *exec.Cmd
+	regenerationExecCommand = func(name string, args ...string) *exec.Cmd {
+		captured = fakeRegenerationDeadcodeCommand(name, args...)
+		return captured
+	}
+
+	root := t.TempDir()
+	report, err := runDeadcodeForRegeneration(root)
+	if err != nil {
+		t.Fatalf("runDeadcodeForRegeneration() error = %v", err)
+	}
+	if report != "pkg/foo.go: Example\n" {
+		t.Fatalf("deadcode report = %q, want helper output", report)
+	}
+	if captured == nil || len(captured.Args) < 5 || captured.Args[len(captured.Args)-4] != "go" || captured.Args[len(captured.Args)-3] != "run" || captured.Args[len(captured.Args)-2] != regenerationDeadcodeTool || captured.Args[len(captured.Args)-1] != "./..." {
+		t.Fatalf("deadcode command = %v, want pinned analyzer invocation", captured)
+	}
+	if captured.Dir != root {
+		t.Fatalf("deadcode command directory = %q, want %q", captured.Dir, root)
+	}
+	if !regenerationEnvContains(captured.Env, "GODEBUG=gocachehash=1,gotypesalias=1") {
+		t.Fatalf("deadcode command environment = %v, want gotypesalias enabled", captured.Env)
+	}
+}
+
+func TestRegenerationDeadcodeHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_REGENERATION_DEADCODE_HELPER") != "1" {
+		return
+	}
+	fmt.Fprint(os.Stdout, os.Getenv("REGENERATION_DEADCODE_HELPER_STDOUT"))
+	fmt.Fprint(os.Stderr, os.Getenv("REGENERATION_DEADCODE_HELPER_STDERR"))
+	os.Exit(0)
+}
+
+type regenerationFixture struct {
+	root               string
+	deadcodePath       string
+	budgetPath         string
+	samplePaths        []string
+	originalDeadcode   []byte
+	originalBudget     latencyBudget
+	originalBudgetData []byte
+}
+
+func newRegenerationFixture(t *testing.T) (regenerationFixture, []timingSummary) {
+	t.Helper()
+	root := t.TempDir()
+	deadcodePath := filepath.Join(root, filepath.FromSlash(regeneratedDeadcodeBaselinePath))
+	budgetPath := filepath.Join(root, filepath.FromSlash(regeneratedUnitBudgetPath))
+	writeRegenerationSchema(t, budgetPath)
+	originalBudget := comparableBudget([]float64{100, 101, 102}, 101)
+	originalBudgetData, err := renderRegeneratedBudget(originalBudget)
+	if err != nil {
+		t.Fatalf("render fixture budget: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(budgetPath), 0o755); err != nil {
+		t.Fatalf("create budget directory: %v", err)
+	}
+	if err := os.WriteFile(budgetPath, originalBudgetData, 0o644); err != nil {
+		t.Fatalf("write fixture budget: %v", err)
+	}
+	originalDeadcode := []byte("pkg/old.go: Old finding\r\n")
+	if err := os.MkdirAll(filepath.Dir(deadcodePath), 0o755); err != nil {
+		t.Fatalf("create deadcode directory: %v", err)
+	}
+	if err := os.WriteFile(deadcodePath, originalDeadcode, 0o644); err != nil {
+		t.Fatalf("write fixture deadcode baseline: %v", err)
+	}
+	samplePaths := make([]string, requiredSamples)
+	for index := range samplePaths {
+		samplePaths[index] = filepath.Join(root, fmt.Sprintf("sample-%d.v2.json", index+1))
+	}
+	return regenerationFixture{
+		root: root, deadcodePath: deadcodePath, budgetPath: budgetPath, samplePaths: samplePaths,
+		originalDeadcode: originalDeadcode, originalBudget: originalBudget, originalBudgetData: originalBudgetData,
+	}, comparableSamples(10, 10, 10)
+}
+
+func writeRegenerationSchema(t *testing.T, budgetPath string) {
+	t.Helper()
+	source := filepath.Join("..", "..", filepath.FromSlash(latencyBudgetSchemaPath))
+	data, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatalf("read budget schema: %v", err)
+	}
+	directory := filepath.Dir(budgetPath)
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		t.Fatalf("create budget schema directory: %v", err)
+	}
+	path := filepath.Join(directory, filepath.Base(filepath.FromSlash(latencyBudgetSchemaPath)))
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write budget schema: %v", err)
+	}
+}
+
+func writeRegenerationSamples(t *testing.T, paths []string, samples []timingSummary) {
+	t.Helper()
+	for index, sample := range samples {
+		data, err := json.MarshalIndent(sample, "", "  ")
+		if err != nil {
+			t.Fatalf("render sample %d: %v", index+1, err)
+		}
+		if err := os.WriteFile(paths[index], append(data, '\n'), 0o644); err != nil {
+			t.Fatalf("write sample %d: %v", index+1, err)
+		}
+	}
+}
+
+func regenerationConfig(fixture regenerationFixture) budgetConfig {
+	return budgetConfig{
+		root:       fixture.root,
+		budgetPath: regeneratedUnitBudgetPath,
+		samples:    strings.Join(fixture.samplePaths, ","),
+	}
+}
+
+func withRegenerationWriters(t *testing.T, stdout, stderr *bytes.Buffer) {
+	t.Helper()
+	originalStdout, originalStderr := stdoutWriter, stderrWriter
+	stdoutWriter, stderrWriter = stdout, stderr
+	t.Cleanup(func() {
+		stdoutWriter, stderrWriter = originalStdout, originalStderr
+	})
+}
+
+func assertRegenerationFixtureUnchanged(t *testing.T, fixture regenerationFixture) {
+	t.Helper()
+	deadcode, err := os.ReadFile(fixture.deadcodePath)
+	if err != nil {
+		t.Fatalf("read deadcode baseline after failed regeneration: %v", err)
+	}
+	if !bytes.Equal(deadcode, fixture.originalDeadcode) {
+		t.Fatalf("deadcode after failed regeneration = %q, want original %q", deadcode, fixture.originalDeadcode)
+	}
+	budget, err := os.ReadFile(fixture.budgetPath)
+	if err != nil {
+		t.Fatalf("read budget after failed regeneration: %v", err)
+	}
+	if !bytes.Equal(budget, fixture.originalBudgetData) {
+		t.Fatal("unit budget changed after failed regeneration")
+	}
+}
+
+func fakeRegenerationDeadcodeCommand(name string, args ...string) *exec.Cmd {
+	helperArgs := append([]string{"-test.run=TestRegenerationDeadcodeHelperProcess", "--", name}, args...)
+	command := exec.Command(os.Args[0], helperArgs...)
+	command.Env = regenerationDeadcodeEnv()
+	return command
+}
+
+func regenerationEnvContains(environment []string, want string) bool {
+	for _, entry := range environment {
+		if entry == want {
+			return true
+		}
+	}
+	return false
+}

--- a/scripts/ci/shared-baseline-regeneration-workflow.mjs
+++ b/scripts/ci/shared-baseline-regeneration-workflow.mjs
@@ -1,0 +1,272 @@
+import { appendFileSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const SHARED_BASELINE_PATHS = Object.freeze([
+	"docs/internal/baselines/deadcode-baseline.txt",
+	"docs/internal/baselines/go-unit-lane-latency-budget.v1.json",
+]);
+
+export const SHARED_BASELINE_BOT_BRANCH = "automation/shared-ci-baselines";
+export const SHARED_BASELINE_PR_TITLE = "chore(ci): reconcile shared CI baselines";
+export const SHARED_BASELINE_COMMENT_MARKER =
+	"<!-- shared-ci-baseline-regeneration -->";
+
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+function normalizePath(path) {
+	return String(path || "")
+		.replaceAll("\\", "/")
+		.replace(/^\.\//, "")
+		.trim();
+}
+
+function sortedUnique(paths) {
+	return [...new Set(paths.map(normalizePath).filter(Boolean))].sort((left, right) =>
+		left < right ? -1 : left > right ? 1 : 0,
+	);
+}
+
+export function parsePorcelainPaths(status) {
+	const paths = [];
+	for (const line of String(status || "").split(/\r?\n/)) {
+		if (line.length < 3) continue;
+		const path = line.slice(3);
+		if (path.includes(" -> ")) {
+			paths.push(...path.split(" -> "));
+		} else {
+			paths.push(path);
+		}
+	}
+	return sortedUnique(paths);
+}
+
+export function validateAllowlistedPaths(paths, { requireChanges = false } = {}) {
+	const normalized = sortedUnique(paths);
+	const allowed = new Set(SHARED_BASELINE_PATHS);
+	const unexpected = normalized.filter((path) => !allowed.has(path));
+	if (unexpected.length > 0) {
+		throw new Error(
+			`shared baseline reconciliation may modify only ${SHARED_BASELINE_PATHS.join(", ")}; unexpected path(s): ${unexpected.join(", ")}`,
+		);
+	}
+	if (requireChanges && normalized.length === 0) {
+		throw new Error("shared baseline reconciliation expected a generated change, but the working tree is clean");
+	}
+	return normalized;
+}
+
+export function selectSourceWorkflowRun({
+	workflowName = "",
+	headBranch = "",
+	conclusion = "",
+	defaultBranch = "main",
+} = {}) {
+	if (workflowName !== "CI") {
+		return { selected: false, reason: `workflow ${workflowName || "(unknown)"} is not CI` };
+	}
+	if (headBranch !== defaultBranch) {
+		return {
+			selected: false,
+			reason: `workflow head branch ${headBranch || "(unknown)"} is not ${defaultBranch}`,
+		};
+	}
+	if (["cancelled", "timed_out", "action_required", "stale"].includes(conclusion)) {
+		return {
+			selected: false,
+			reason: `source CI conclusion is ${conclusion || "(unknown)"}; a completed run with unavailable evidence cannot be used`,
+		};
+	}
+	return {
+		selected: conclusion === "success" || conclusion === "failure",
+		reason:
+			conclusion === "failure"
+				? "completed CI failure may reflect stale baselines; the hosted artifact and generator remain the publication gates"
+				: "completed successful CI run on the default branch",
+	};
+}
+
+export function planReconciliation({
+	triggeringSha = "",
+	currentMainSha = "",
+	changedPaths = [],
+	candidateMatchesRemote = false,
+	existingPullRequest = false,
+	generationError = "",
+} = {}) {
+	if (generationError) {
+		return {
+			action: "fail",
+			publish: false,
+			reason: `generation failed before publication: ${generationError}`,
+		};
+	}
+	if (!COMMIT_SHA_PATTERN.test(triggeringSha) || !COMMIT_SHA_PATTERN.test(currentMainSha)) {
+		return {
+			action: "fail",
+			publish: false,
+			reason: "the triggering and current main revisions must both be complete commit SHAs",
+		};
+	}
+	if (triggeringSha !== currentMainSha) {
+		return {
+			action: "superseded",
+			publish: false,
+			reason: `main moved from ${triggeringSha} to ${currentMainSha}; a newer run owns reconciliation`,
+		};
+	}
+	const paths = validateAllowlistedPaths(changedPaths);
+	if (paths.length === 0) {
+		return {
+			action: existingPullRequest ? "close-existing" : "noop",
+			publish: false,
+			reason: existingPullRequest
+				? "main already contains both generated baselines; the open automation PR is obsolete"
+				: "main already contains both generated baselines",
+		};
+	}
+	if (candidateMatchesRemote) {
+		return {
+			action: existingPullRequest ? "reuse-pr" : "reuse-branch",
+			publish: false,
+			reason: "the existing automation branch already contains this exact candidate",
+		};
+	}
+	return {
+		action: "publish",
+		publish: true,
+		reason: `publish generated change(s) in ${paths.join(", ")}`,
+	};
+}
+
+export function renderPullRequestBody({
+	sourceSha,
+	commitSha,
+	runUrl,
+	changedPaths = SHARED_BASELINE_PATHS,
+} = {}) {
+	const paths = validateAllowlistedPaths(changedPaths, { requireChanges: true });
+	return [
+		SHARED_BASELINE_COMMENT_MARKER,
+		"## Automated shared CI baseline reconciliation",
+		"",
+		"This pull request was generated from the completed main-branch CI run below. Its hosted unit-latency artifact and the current deadcode report passed the generator gates. It is intentionally limited to the two self-maintaining shared baselines:",
+		"",
+		...paths.map((path) => "- " + "\x60" + path + "\x60"),
+		"",
+		`- Source main revision: \`${sourceSha}\``,
+		`- Generated branch revision: \`${commitSha}\``,
+		`- Source CI run: ${runUrl}`,
+		`- Automation branch: \`${SHARED_BASELINE_BOT_BRANCH}\``,
+		`- Pull request title: \`${SHARED_BASELINE_PR_TITLE}\``,
+		"",
+		"The branch is reconciled from the latest main revision on each run. Required repository checks own the merge gate; auto-merge is enabled after the bot verifies the PR head and file allowlist.",
+		"",
+		"<!-- This content is generated. Do not edit this pull request manually. -->",
+		"",
+	].join("\n");
+}
+
+function runGit(args) {
+	const result = spawnSync("git", args, { encoding: "utf8", windowsHide: true });
+	if (result.error) throw new Error(`unable to execute git: ${result.error.message}`);
+	if (result.status !== 0) {
+		const detail = `${result.stderr || result.stdout || ""}`.trim();
+		throw new Error(`git ${args.join(" ")} failed with exit code ${result.status}${detail ? `: ${detail}` : ""}`);
+	}
+	return result.stdout || "";
+}
+
+function writeGitHubOutput(path, values) {
+	if (!path) return;
+	for (const [key, value] of Object.entries(values)) {
+		appendFileSync(path, `${key}=${value}\n`);
+	}
+}
+
+function runValidateWorkingTree({ staged = false, requireChanges = false, githubOutput = "" } = {}) {
+	const status = staged
+		? runGit(["diff", "--cached", "--name-only"])
+		: runGit(["status", "--porcelain=v1", "--untracked-files=all"]);
+	const paths = staged ? sortedUnique(status.split(/\r?\n/)) : parsePorcelainPaths(status);
+	validateAllowlistedPaths(paths, { requireChanges });
+	writeGitHubOutput(githubOutput, {
+		changed: paths.length > 0 ? "true" : "false",
+		paths: paths.join(","),
+	});
+	process.stdout.write(
+		`SHARED_BASELINE_CHANGED=${paths.length > 0 ? "true" : "false"} paths=${paths.join(",") || "(none)"}\n`,
+	);
+}
+
+function parseArguments(args) {
+	const [command, ...rest] = args;
+	const options = { command };
+	for (let index = 0; index < rest.length; index += 1) {
+		const argument = rest[index];
+		if (argument === "--github-output") {
+			options.githubOutput = rest[++index];
+			if (!options.githubOutput) throw new Error("--github-output requires a path");
+			continue;
+		}
+		if (argument === "--require-changes") {
+			options.requireChanges = true;
+			continue;
+		}
+		if (argument === "--staged") {
+			options.staged = true;
+			continue;
+		}
+		if (argument === "--source-sha" || argument === "--commit-sha" || argument === "--run-url") {
+			options[argument.slice(2).replaceAll("-", "")] = rest[++index];
+			if (!options[argument.slice(2).replaceAll("-", "")]) throw new Error(`${argument} requires a value`);
+			continue;
+		}
+		if (argument === "--paths") {
+			options.paths = rest[++index]?.split(",") || [];
+			continue;
+		}
+		throw new Error(`Unknown argument: ${argument}`);
+	}
+	return options;
+}
+
+function runCli(args) {
+	const options = parseArguments(args);
+	if (options.command === "validate-working-tree") {
+		runValidateWorkingTree(options);
+		return;
+	}
+	if (options.command === "validate-staged") {
+		runValidateWorkingTree({ ...options, staged: true, requireChanges: true });
+		return;
+	}
+	if (options.command === "validate-paths") {
+		const paths = readFileSync(0, "utf8").split(/\r?\n/).filter(Boolean);
+		validateAllowlistedPaths(paths);
+		process.stdout.write(`SHARED_BASELINE_PATHS_OK paths=${sortedUnique(paths).join(",") || "(none)"}\n`);
+		return;
+	}
+	if (options.command === "render-body") {
+		process.stdout.write(
+			renderPullRequestBody({
+				sourceSha: options.sourcesha,
+				commitSha: options.commitsha,
+				runUrl: options.runurl,
+				changedPaths: options.paths?.length ? options.paths : SHARED_BASELINE_PATHS,
+			}),
+		);
+		return;
+	}
+	throw new Error(`Unknown command: ${options.command || "(missing)"}`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+	try {
+		runCli(process.argv.slice(2));
+	} catch (error) {
+		process.stderr.write(`shared baseline workflow: ${error.message}\n`);
+		process.exitCode = 1;
+	}
+}

--- a/scripts/ci/shared-baseline-regeneration-workflow.test.mjs
+++ b/scripts/ci/shared-baseline-regeneration-workflow.test.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 
 import {
@@ -14,7 +16,11 @@ import {
 } from "./shared-baseline-regeneration-workflow.mjs";
 
 const SHA = (character) => character.repeat(40);
-const workflow = readFileSync(".github/workflows/regenerate-shared-ci-baselines.yml", "utf8");
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const workflow = readFileSync(
+	join(repositoryRoot, ".github", "workflows", "regenerate-shared-ci-baselines.yml"),
+	"utf8",
+);
 
 test("the delivered workflow follows successful main CI and owns only the bot PR path", () => {
 	assert.match(workflow, /workflow_run:\s+workflows: \[CI\]/);

--- a/scripts/ci/shared-baseline-regeneration-workflow.test.mjs
+++ b/scripts/ci/shared-baseline-regeneration-workflow.test.mjs
@@ -21,6 +21,7 @@ const workflow = readFileSync(
 	join(repositoryRoot, ".github", "workflows", "regenerate-shared-ci-baselines.yml"),
 	"utf8",
 );
+const ciWorkflow = readFileSync(join(repositoryRoot, ".github", "workflows", "ci.yml"), "utf8");
 
 test("the delivered workflow follows successful main CI and owns only the bot PR path", () => {
 	assert.match(workflow, /workflow_run:\s+workflows: \[CI\]/);
@@ -32,6 +33,9 @@ test("the delivered workflow follows successful main CI and owns only the bot PR
 	assert.match(workflow, /SHARED_BASELINE_PR_TITLE: [\"]?chore\(ci\): reconcile shared CI baselines[\"]?/);
 	assert.match(workflow, /gh run download \"\$SOURCE_RUN_ID\"/);
 	assert.match(workflow, /backend-unit-latency-evidence/);
+	assert.match(workflow, /backend-deadcode-evidence/);
+	assert.match(workflow, /DEADCODE_REPORT_PATH/);
+	assert.match(workflow, /BASELINE_REGEN_DEADCODE_REPORT=\"\$DEADCODE_REPORT_PATH\"/);
 	assert.match(workflow, /SOURCE_EVENT: \$\{\{ github\.event\.workflow_run\.event \}\}/);
 	assert.match(workflow, /SOURCE_REPOSITORY: \$\{\{ github\.event\.workflow_run\.head_repository\.full_name \}\}/);
 	assert.match(workflow, /SOURCE_EVENT\" != \"push\"/);
@@ -40,9 +44,16 @@ test("the delivered workflow follows successful main CI and owns only the bot PR
 	assert.match(workflow, /gh pr list/);
 	assert.match(workflow, /gh pr create/);
 	assert.match(workflow, /gh pr edit/);
+	assert.match(workflow, /git push origin --delete \"\$BOT_BRANCH\"/);
 	assert.match(workflow, /gh pr merge .*--auto .*--match-head-commit/);
 	assert.match(workflow, /automation\/shared-ci-baselines/);
 	assert.doesNotMatch(workflow, /7438/);
+});
+
+test("Backend Lint publishes the normalized deadcode report consumed by reconciliation", () => {
+	assert.match(ciWorkflow, /name: backend-deadcode-evidence/);
+	assert.match(ciWorkflow, /path: bin\/deadcode-current\.txt/);
+	assert.match(ciWorkflow, /if-no-files-found: error/);
 });
 
 test("selects completed CI runs for the default branch and lets artifacts judge drift", () => {

--- a/scripts/ci/shared-baseline-regeneration-workflow.test.mjs
+++ b/scripts/ci/shared-baseline-regeneration-workflow.test.mjs
@@ -29,6 +29,7 @@ test("the delivered workflow follows successful main CI and owns only the bot PR
 	assert.match(workflow, /group: shared-ci-baseline-regeneration/);
 	assert.match(workflow, /cancel-in-progress: true/);
 	assert.match(workflow, /GH_TOKEN: \$\{\{ secrets\.SHARED_BASELINE_BOT_TOKEN \}\}/);
+	assert.match(workflow, /SHARED_BASELINE_PR_TITLE: [\"]?chore\(ci\): reconcile shared CI baselines[\"]?/);
 	assert.match(workflow, /gh run download \"\$SOURCE_RUN_ID\"/);
 	assert.match(workflow, /backend-unit-latency-evidence/);
 	assert.match(workflow, /SOURCE_EVENT: \$\{\{ github\.event\.workflow_run\.event \}\}/);

--- a/scripts/ci/shared-baseline-regeneration-workflow.test.mjs
+++ b/scripts/ci/shared-baseline-regeneration-workflow.test.mjs
@@ -25,6 +25,10 @@ test("the delivered workflow follows successful main CI and owns only the bot PR
 	assert.match(workflow, /GH_TOKEN: \$\{\{ secrets\.SHARED_BASELINE_BOT_TOKEN \}\}/);
 	assert.match(workflow, /gh run download \"\$SOURCE_RUN_ID\"/);
 	assert.match(workflow, /backend-unit-latency-evidence/);
+	assert.match(workflow, /SOURCE_EVENT: \$\{\{ github\.event\.workflow_run\.event \}\}/);
+	assert.match(workflow, /SOURCE_REPOSITORY: \$\{\{ github\.event\.workflow_run\.head_repository\.full_name \}\}/);
+	assert.match(workflow, /SOURCE_EVENT\" != \"push\"/);
+	assert.match(workflow, /SOURCE_REPOSITORY\" != \"\$REPOSITORY\"/);
 	assert.match(workflow, /make regenerate-shared-ci-baselines/);
 	assert.match(workflow, /gh pr list/);
 	assert.match(workflow, /gh pr create/);

--- a/scripts/ci/shared-baseline-regeneration-workflow.test.mjs
+++ b/scripts/ci/shared-baseline-regeneration-workflow.test.mjs
@@ -29,7 +29,10 @@ test("the delivered workflow follows successful main CI and owns only the bot PR
 	assert.match(workflow, /branches: \[main\]/);
 	assert.match(workflow, /group: shared-ci-baseline-regeneration/);
 	assert.match(workflow, /cancel-in-progress: true/);
-	assert.match(workflow, /GH_TOKEN: \$\{\{ secrets\.SHARED_BASELINE_BOT_TOKEN \}\}/);
+	assert.match(workflow, /uses: actions\/create-github-app-token@v2/);
+	assert.match(workflow, /app-id: \$\{\{ secrets\.BASELINE_BOT_APP_ID \}\}/);
+	assert.match(workflow, /private-key: \$\{\{ secrets\.BASELINE_BOT_APP_PRIVATE_KEY \}\}/);
+	assert.match(workflow, /echo \"GH_TOKEN=\$BOT_TOKEN\" >> \"\$GITHUB_ENV\"/);
 	assert.match(workflow, /SHARED_BASELINE_PR_TITLE: [\"]?chore\(ci\): reconcile shared CI baselines[\"]?/);
 	assert.match(workflow, /gh run download \"\$SOURCE_RUN_ID\"/);
 	assert.match(workflow, /backend-unit-latency-evidence/);

--- a/scripts/ci/shared-baseline-regeneration-workflow.test.mjs
+++ b/scripts/ci/shared-baseline-regeneration-workflow.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+	SHARED_BASELINE_BOT_BRANCH,
+	SHARED_BASELINE_PATHS,
+	SHARED_BASELINE_PR_TITLE,
+	parsePorcelainPaths,
+	planReconciliation,
+	renderPullRequestBody,
+	selectSourceWorkflowRun,
+	validateAllowlistedPaths,
+} from "./shared-baseline-regeneration-workflow.mjs";
+
+const SHA = (character) => character.repeat(40);
+const workflow = readFileSync(".github/workflows/regenerate-shared-ci-baselines.yml", "utf8");
+
+test("the delivered workflow follows successful main CI and owns only the bot PR path", () => {
+	assert.match(workflow, /workflow_run:\s+workflows: \[CI\]/);
+	assert.match(workflow, /types: \[completed\]/);
+	assert.match(workflow, /branches: \[main\]/);
+	assert.match(workflow, /group: shared-ci-baseline-regeneration/);
+	assert.match(workflow, /cancel-in-progress: true/);
+	assert.match(workflow, /GH_TOKEN: \$\{\{ secrets\.SHARED_BASELINE_BOT_TOKEN \}\}/);
+	assert.match(workflow, /gh run download \"\$SOURCE_RUN_ID\"/);
+	assert.match(workflow, /backend-unit-latency-evidence/);
+	assert.match(workflow, /make regenerate-shared-ci-baselines/);
+	assert.match(workflow, /gh pr list/);
+	assert.match(workflow, /gh pr create/);
+	assert.match(workflow, /gh pr edit/);
+	assert.match(workflow, /gh pr merge .*--auto .*--match-head-commit/);
+	assert.match(workflow, /automation\/shared-ci-baselines/);
+	assert.doesNotMatch(workflow, /7438/);
+});
+
+test("selects completed CI runs for the default branch and lets artifacts judge drift", () => {
+	assert.deepEqual(
+		selectSourceWorkflowRun({
+			workflowName: "CI",
+			headBranch: "main",
+			conclusion: "success",
+		}),
+		{ selected: true, reason: "completed successful CI run on the default branch" },
+	);
+	assert.equal(
+		selectSourceWorkflowRun({
+			workflowName: "CI",
+			headBranch: "main",
+			conclusion: "failure",
+		}).selected,
+		true,
+	);
+	for (const input of [
+		{ workflowName: "Other", headBranch: "main", conclusion: "success" },
+		{ workflowName: "CI", headBranch: "feature", conclusion: "success" },
+		{ workflowName: "CI", headBranch: "main", conclusion: "cancelled" },
+	]) {
+		assert.equal(selectSourceWorkflowRun(input).selected, false);
+	}
+});
+
+test("plans drift publication, no-diff cleanup, and exact-candidate reuse", () => {
+	const common = { triggeringSha: SHA("a"), currentMainSha: SHA("a") };
+	assert.equal(
+		planReconciliation({ ...common, changedPaths: [SHARED_BASELINE_PATHS[0]] }).action,
+		"publish",
+	);
+	assert.equal(planReconciliation({ ...common, changedPaths: [] }).action, "noop");
+	assert.equal(
+		planReconciliation({ ...common, changedPaths: [], existingPullRequest: true }).action,
+		"close-existing",
+	);
+	assert.equal(
+		planReconciliation({
+			...common,
+			changedPaths: [SHARED_BASELINE_PATHS[1]],
+			candidateMatchesRemote: true,
+			existingPullRequest: true,
+		}).action,
+		"reuse-pr",
+	);
+});
+
+test("supersedes an overlapping run when main moved before publication", () => {
+	const plan = planReconciliation({
+		triggeringSha: SHA("a"),
+		currentMainSha: SHA("b"),
+		changedPaths: [SHARED_BASELINE_PATHS[0]],
+	});
+	assert.deepEqual(plan, {
+		action: "superseded",
+		publish: false,
+		reason: `main moved from ${SHA("a")} to ${SHA("b")}; a newer run owns reconciliation`,
+	});
+});
+
+test("fails before publication for generation errors and invalid revisions", () => {
+	for (const plan of [
+		planReconciliation({
+			triggeringSha: SHA("a"),
+			currentMainSha: SHA("a"),
+			changedPaths: [SHARED_BASELINE_PATHS[0]],
+			generationError: "three samples are not comparable",
+		}),
+		planReconciliation({
+			triggeringSha: "not-a-sha",
+			currentMainSha: SHA("a"),
+			changedPaths: [SHARED_BASELINE_PATHS[0]],
+		}),
+	]) {
+		assert.equal(plan.action, "fail");
+		assert.equal(plan.publish, false);
+	}
+});
+
+test("parses status output and rejects every path outside the two-file allowlist", () => {
+	assert.deepEqual(
+		parsePorcelainPaths(
+			` M ${SHARED_BASELINE_PATHS[0]}\n?? ${SHARED_BASELINE_PATHS[1]}\nR  old.txt -> ${SHARED_BASELINE_PATHS[0]}\n`,
+		),
+		["old.txt", ...SHARED_BASELINE_PATHS].sort(),
+	);
+	assert.throws(
+		() => validateAllowlistedPaths([...SHARED_BASELINE_PATHS, "docs/internal/baselines/other.txt"]),
+		/unexpected path\(s\).*other\.txt/,
+	);
+	assert.throws(
+		() => validateAllowlistedPaths([], { requireChanges: true }),
+		/expected a generated change/,
+	);
+});
+
+test("renders a bot PR body with the exact generated scope", () => {
+	const body = renderPullRequestBody({
+		sourceSha: SHA("a"),
+		commitSha: SHA("b"),
+		runUrl: "https://github.example/actions/runs/42",
+		changedPaths: SHARED_BASELINE_PATHS,
+	});
+	assert.match(body, /shared-ci-baseline-regeneration/);
+	assert.match(body, new RegExp(SHARED_BASELINE_BOT_BRANCH.replace("/", "\\/")));
+	assert.ok(body.includes(SHARED_BASELINE_PR_TITLE));
+	for (const path of SHARED_BASELINE_PATHS) assert.match(body, new RegExp(path.replaceAll("/", "\\/")));
+});


### PR DESCRIPTION
{
  "project": "Auto-regenerate shared CI baselines on main",
  "branchName": "auto-regenerate-shared-ci-baselines-on-main",
  "description": "Make docs/internal/baselines/deadcode-baseline.txt and docs/internal/baselines/go-unit-lane-latency-budget.v1.json self-maintaining after every push to main by deriving their current state from the real delivered checks and upserting an idempotent bot pull request that runs required CI and auto-merges, without weakening ratchets or touching any other baseline or manifest.",
  "context": {
    "customerAsk": "Stop hand-maintaining the two named shared CI baselines. Catch either baseline up automatically after main changes, demonstrate the behavior with a real before/after drift scenario, preserve the existing strict deadcodecheck and unitlanebudget semantics, do not touch any other lint, coverage, or manifest baseline, and never touch port 7438.",
    "problem": "No workflow owns regeneration of the committed deadcode finding snapshot or Go unit-lane reference inventory after main changes. Their stale state then blocks unrelated rebased pull requests in Backend Lint, Backend Unit Latency, or Verification Policy and forces operators to diagnose main drift and file one-off reconciliation lanes.",
    "solution": "Run an isolated least-privilege maintenance path after every push to main, derive deadcode from the normalized delivered report and unit reference identity/inventory from three valid comparable hosted samples, validate deterministic candidate output, and upsert one bot-owned pull request limited to the two baseline paths. Preserve historical latency measurements, policy, schema, and both checkers' pass/fail behavior; make no-diff and repeated runs idempotent; run normal required checks; and auto-merge without human content edits."
  },
  "acceptanceCriteria": [
    "A push to main that changes the normalized deadcode finding set or Go unit-test inventory starts the maintenance path and upserts a bot-authored pull request whose content makes both named baselines match that triggering main state; no human creates the branch, pull request, or content edit.",
    "Deadcode content is derived from the delivered normalized current report. Unit-latency reference package/test inventory and applicable reference identity are derived from three real, valid, mutually comparable ubuntu-24.04 unit-lane samples, while historical timing samples, median, policy, schema, and the existing deadcodecheck/unitlanebudget pass/fail behavior remain unchanged.",
    "A no-diff run exits successfully without creating an empty commit or duplicate pull request. Overlapping pushes serialize or supersede safely, reuse one automation branch/pull request, reconcile from the latest main, and surface generation, permission, sample-validation, CI, or merge failures with actionable run output rather than publishing partial baseline data.",
    "The implementation and generated commits can modify only docs/internal/baselines/deadcode-baseline.txt and docs/internal/baselines/go-unit-lane-latency-budget.v1.json. No other lint/coverage baseline or manifest is changed; port 7438 is never used or touched; secrets are not exposed; and workflow permissions are limited to the chosen bot-PR, check, and auto-merge operations.",
    "Runtime-proof classification: applicable, because this lane changes the runtime-observable lifecycle and success/failure outcome of delivered GitHub Actions automation. Build the real delivered generator/checker artifacts, deliberately add and then remove one trivial test on a scratch branch, exercise the post-merge trigger end to end in the repository or a fork with equivalent protections, and record the verbatim commands and outputs, the actual before/after baseline diff, and the workflow run plus bot commit/PR that produced it. Green tests, an inspected diff, simulated helper output alone, or implementer assertions do not satisfy this proof. The bot pull request must run required checks, be auto-mergeable, and require no manual content edits.",
    "Quality gates pass: Typecheck passes; focused generator, idempotency, failure-path, workflow, and checker regression tests pass; no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "auto-regenerate-shared-ci-baselines-on-main-001",
      "title": "Deterministically derive both maintained baselines",
      "description": "As a repository maintainer, I want one deterministic regeneration operation for the two shared snapshots so automation can reconcile real repository state without changing either ratchet's policy.",
      "acceptanceCriteria": [
        "Given a repository state and complete real inputs, regeneration writes the normalized deadcode report to docs/internal/baselines/deadcode-baseline.txt and derives sorted, unique unit-latency reference package/test inventory and applicable reference identity from three valid, mutually comparable hosted samples.",
        "The unit-latency historical timing samples, median, policy, schema, and all non-inventory policy fields are byte-for-byte or semantically unchanged as appropriate; the existing final-mode comparator accepts the regenerated inventory without any disabled, advisory, or relaxed rule.",
        "Invalid, incomplete, cached, unknown, differently identified, or mutually inconsistent unit samples fail before either committed baseline is changed, and a deadcode-generation failure likewise leaves both outputs unchanged with an actionable diagnostic.",
        "Running regeneration twice against identical inputs produces no second diff, and regression coverage proves changes cannot escape the two owned baseline paths.",
        "No existing deadcodecheck or unitlanebudget comparison/pass-fail semantics, other baseline/manifest, or unrelated repository behavior changes; port 7438 is never used or touched.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented the deterministic regenerate mode and Make entrypoint. It validates three complete, uncached, mutually identical GitHub Actions ubuntu-24.04 samples, preserves timing/policy fields, normalizes deadcode, validates the candidate schema, publishes only the two owned baselines, and is covered by focused failure/idempotency/allowlist tests."
    },
    {
      "id": "auto-regenerate-shared-ci-baselines-on-main-002",
      "title": "Reconcile drift through an idempotent bot pull request",
      "description": "As a maintainer of active pull requests, I want every push to main to reconcile shared-baseline drift automatically so unrelated rebases do not require an operator-filed cleanup lane.",
      "acceptanceCriteria": [
        "Every push to main invokes the regeneration operation against that revision; a detected diff upserts one clearly identified bot branch and pull request containing only the two allowed baseline paths, while a no-diff run completes without a commit or pull request.",
        "The bot pull request uses a repository-approved credential that causes normal required checks to run, requests auto-merge only after those checks are eligible, and requires no manual content edit; forked pull requests and untrusted code cannot obtain write credentials.",
        "Repeated or overlapping pushes do not create duplicate pull requests, merge stale output, or loop indefinitely: the latest run regenerates from current main, safely supersedes or updates the bot branch, and the post-merge no-diff run terminates cleanly.",
        "Generation, invalid-sample, permission, required-check, conflict, and merge failures are retained in actionable workflow output and do not commit partial or cross-scope changes. Conflict reconciliation reruns generation from latest main rather than hand-merging generated content.",
        "Focused behavioral tests cover drift, no drift, repeat execution, overlapping-main movement, strict path allowlisting, and failure-before-publish while preserving existing PR ratchet behavior.",
        "Runtime-proof classification: applicable, because this lane changes the runtime-observable lifecycle and success/failure outcome of delivered GitHub Actions automation. Build the real delivered generator/checker artifacts, deliberately add and then remove one trivial test on a scratch branch, exercise the post-merge trigger end to end in the repository or a fork with equivalent protections, and record the verbatim commands and outputs, the actual before/after baseline diff, and the workflow run plus bot commit/PR that produced it. Green tests, an inspected diff, simulated helper output alone, or implementer assertions do not satisfy this proof. The bot pull request must run required checks, be auto-mergeable, and require no manual content edits.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": false,
      "notes": "Implemented the completed-main-CI artifact-driven reconciliation workflow, strict two-file allowlisting, fixed bot branch/PR upsert, overlap supersession, exact-candidate reuse, no-diff cleanup, and auto-merge request with SHARED_BASELINE_BOT_TOKEN. Focused workflow tests, actionlint, the full CI-workflow suite, unitlanebudget tests, and typecheck pass; make lint reproduces the origin/main deadcode mismatch. Remaining evidence requires a configured repository bot credential and a real protected-main scratch push/merge runtime proof."
    }
  ]
}
