### PR TITLE
factory: project/project-lead outer loop, agnostic admission, planning-depth standards

### DIFF
--- a/factory/docs/batch-inputs.md
+++ b/factory/docs/batch-inputs.md
@@ -43,7 +43,7 @@ When changing these factory-local docs or the checked-in example, run the
 narrow verification path from the repository root:
 
 ```sh
-go test ./pkg/services/workers/prompting -run TestPromptRenderer_ResolvesCheckedInPlannerFactoryDocs -count=1
+go test ./pkg/services/workers/internal/prompting -run TestPromptRenderer_ResolvesCheckedInPlannerFactoryDocs -count=1
 go test ./pkg/services/work/transports/cli/submit -run TestSubmitBatch_DryRunFactoryDocsBatchInputExample -count=1
 ```
 

--- a/factory/docs/overview.md
+++ b/factory/docs/overview.md
@@ -7,12 +7,12 @@ acting on validation loopback results.
 
 This factory coordinates autonomous work for **you-agent-factory**: the Go,
 OpenAPI, and React system for scheduling and orchestrating concurrent AI workers
-through the `you` CLI, backend runtime, and dashboard. The **ideafy**
-workstation is the meta-planner. It inspects live factory state, submits batches
-of `idea` work, records planner state, and schedules a `thoughts` loopback so
-planning resumes after each batch completes. The **plan** workstation turns each
-idea into a PRD. **process** and **review** executors implement and gate work in
-isolated worktrees.
+through the `you` CLI, backend runtime, and dashboard. The **ideafy** workstation
+is the meta-planner: it supervises factory health, Project admission, and stalled
+Project Leads. Each **project-lead** owns one substantial outcome, generates
+ordinary `idea` Work as a dependency graph, and independently validates completion.
+The **plan** workstation still turns each idea into a PRD. **process**, **ci-wait**,
+and **review** still implement and gate work in isolated worktrees.
 
 ## Read First
 
@@ -25,6 +25,9 @@ Before submitting work, read:
   live planner state files (local, not checked in)
 * `factory/docs/batch-inputs.md`
 * `factory/docs/batch-input-example.json`
+* `factory/docs/projects.md`
+* `docs/temp/board-lessons.md` — operator-local board-shape admonitions
+  (repo-root only; not materialized into worktrees)
 * `factory/docs/decision-envelope.md`
 * `you docs agents`
 * `you docs batch-inputs`
@@ -36,17 +39,37 @@ Repository context that shapes planner batches:
   Session`, `Work`, `Work Request`)
 * `docs/reference/` — packaged `you docs <topic>` contracts
 
-## Planner Loop
+## Project and Planner Loops
 
-The meta-planner operates the work queue rather than implementing every feature
-directly:
+The preferred outer loop for substantial independent outcomes is:
 
-1. Read the customer ask, factory state, project docs, and codebase.
-2. Maintain direction in `docs/temp/*` state files.
-3. Submit a batch of concrete `idea` work items.
-4. Add a `thoughts` loopback item that depends on those ideas so ideafy runs
-   again after the batch completes.
-5. Append planner progress and update the checklist after submission.
+```txt
+project:init -> project-lead -> project:waiting
+                              + idea:init (all currently well-scoped Work)
+                              + project-cycle:init (depends on every idea:complete)
+
+project:waiting + project-cycle:continue -> project:init
+project:waiting + project-cycle:complete -> project:complete
+project:waiting + project-cycle:failed   -> project:init
+project:waiting + project-cycle:blocked  -> project:blocked
+```
+
+On first dispatch, the Project Lead bootstraps its working memory under
+`docs/temp/<project-name>/` from the Project payload and source plan. Admission
+never pre-creates that directory. The lead completes a Project only after blind
+clean-room probes pass. See `factory/docs/projects.md`.
+
+The meta-planner operates above Project Leads rather than implementing every
+feature directly:
+
+1. Check session, provider, resource, automation, and dispatch liveness.
+2. Admit Project Work with one dedicated Project root and acceptance contract.
+3. Inspect active Projects for stale leads, repeated failure, or shared-surface
+   contention without taking over their healthy child Work.
+4. Repair a recoverable blocked Project or factory-level fault once and record
+   the evidence.
+5. Retain `thoughts` loopbacks for small legacy/unowned work and periodic
+   supervision.
 
 Always dry-run a batch before real submission:
 
@@ -63,6 +86,8 @@ Configured work types:
 
 ```txt
 thoughts       meta-planner loopback work
+project        independently owned end-to-end outcome
+project-cycle  dependency-held Project Lead loopback/decision
 idea           product/implementation idea submitted by ideafy
 plan           PRD planning output from an idea
 task           executor/review implementation work
@@ -76,6 +101,10 @@ Use `thoughts`, plural, for ideafy loopback.
 
 ```txt
 thoughts:init -> ideafy -> thoughts:complete
+
+project:init -> project-lead -> project:waiting + idea:init + project-cycle:init
+project-cycle:init -> decide-project-cycle -> continue|complete|blocked
+project:waiting + same-name project-cycle -> project:init|complete|blocked
 
 idea:init -> plan -> idea:to-complete + plan:init
 plan:init -> setup-workspace -> plan:complete + task:init

--- a/factory/docs/projects.md
+++ b/factory/docs/projects.md
@@ -1,0 +1,121 @@
+# Projects and Project Leads
+
+`project` Work is the outer control loop for one substantial outcome. It sits on
+top of the existing delivery graph; it does not replace `idea`, `plan`, `task`,
+CI, or `review` Work.
+
+## Ownership
+
+The meta-planner owns factory health, admission, capacity, stale-Project
+detection, and repair of factory-level failures. A Project Lead owns one Project
+request end to end: it reads current state, chooses the next idea batch, waits
+for the inner graph, validates the integrated result, and repeats until the
+Project acceptance criteria are proven.
+
+The runtime Project Work and Factory Event stream are authoritative for
+lifecycle. Project admission does not pre-create local state. On its first
+dispatch, the Project Lead bootstraps this ignored working-memory directory from
+the admitted payload and source plan:
+
+```txt
+docs/temp/<project-name>/
+  request.md
+  acceptance.md
+  state.md
+  progress.md
+  validation/
+```
+
+The Project Lead creates `request.md` and `acceptance.md` once as durable
+projections of the operator-owned Project payload. It may not edit them after
+bootstrap. `state.md`, `progress.md`, and `validation/` are Project-Lead-owned
+evidence. A required contract change is a blocked Project plus a proposed
+delta, never a silent goal rewrite.
+
+## Admission
+
+Admit each outcome as one uniquely named `project:init` Work item. Projects are
+domain-agnostic: any outcome with a source plan and provable acceptance
+criteria is admissible through the same shape, and no workstation prompt may
+carry policy specific to one Project — Project-specific policy travels in the
+payload and source plan.
+
+The payload must identify `sourcePlan` and the authorized `request`. The other
+fields default: `projectRoot` defaults to `docs/temp/<project-name>/`,
+`contractRevision` defaults to `<project-name>-v1`, and when `acceptance` is
+omitted the acceptance criteria are the acceptance-criteria section of the
+source plan, extracted verbatim by the Project Lead at bootstrap. The source
+plan file is the source of truth either way. The meta-planner must not create
+or populate `projectRoot`. Separate Projects have separate roots and no Work
+relation unless their outcomes have a real semantic dependency.
+
+Minimal admission — point a Project at a plan file and let it run end to end:
+
+```json
+{
+  "type": "FACTORY_REQUEST_BATCH",
+  "works": [
+    {
+      "name": "test-functional-improvement",
+      "workTypeName": "project",
+      "state": "init",
+      "payload": {
+        "sourcePlan": "docs/temp/test-functional-improvement.md",
+        "request": "Read the source plan and implement it end to end. Continue cycling until every acceptance criterion in the plan is independently proven."
+      }
+    }
+  ],
+  "relations": []
+}
+```
+
+A fully explicit admission may additionally pin `projectRoot`,
+`contractRevision`, an inline `acceptance` array, and a `recovery` object for
+work interrupted in a prior Factory Session.
+
+## Cycle semantics
+
+Each Project Lead response is a `FACTORY_REQUEST_BATCH` containing every
+currently known, well-scoped idea plus exactly one same-name `project-cycle`
+item. There is no Project-Lead batch-size quota. The cycle item depends on every
+emitted idea reaching `complete`, so it wakes the lead only after the existing
+planner/executor/CI/reviewer chain has converged.
+
+The lead must maximize safe throughput rather than use one umbrella idea as a
+default. It builds a dependency/collision map and emits the complete known task
+graph using package- or ownership-scoped ideas. Factory resource capacity,
+worker availability, host CPU and memory, worktree creation, and provider
+limits control active concurrency; excess emitted Work waits in the runtime.
+Known semantic or shared-surface ordering is encoded with `DEPENDS_ON` rather
+than retained as an unpublished later wave. Global baseline and final
+integration gates remain separate from package implementation lanes. A
+recovered umbrella worktree preserves prior evidence but does not force
+unrelated remaining packages through the same sequential task.
+
+For Projects whose acceptance includes measured performance, shared-host
+compute saturation is normal. Local timings prioritize and diagnose work; they
+do not gate package implementation on an idle runner, low variance, repeated
+pristine baselines, or an imported absolute threshold. A Project Lead should
+continue when a change materially uses a proven optimization shape and
+preserves observable behavior, submit the PR, and use its package-level
+latency result as the hill-climbing signal. An improving package advances; a
+non-improving package receives the next bounded optimization pass.
+
+Cycle payloads are explicit:
+
+- `continue`: re-enter the Project Lead from current repository/evidence state;
+- `complete`: mark the Project complete after independent probes pass;
+- `blocked`: hold the Project for a concrete external or factory-level issue.
+
+If a dependency fails, cascading failure moves the cycle to `failed`; the graph
+re-enters the Project Lead so it can diagnose and issue a smaller corrective
+cycle. Twelve lead visits without convergence trip the Project loop breaker and
+surface `project:blocked` to the meta-planner.
+
+## Completion
+
+Task review proves a task. Project completion proves the integrated acceptance
+contract. Before `complete`, the Project Lead runs at least two blind read-only
+probes from clean context, records their separate reports under `validation/`,
+and requires both to pass. A failing probe produces a delta cycle; it never
+silently repairs the implementation.

--- a/factory/docs/standards/plan-template.md
+++ b/factory/docs/standards/plan-template.md
@@ -154,6 +154,11 @@ every changed shape.>
 | Behavior/gate | Scope | Dependency fidelity | Cadence | Cost | Proves | Does not prove |
 | --- | --- | --- | --- | --- | --- | --- |
 
+### Functional test-case matrix [Required when functional tests change]
+
+| Case ID | Kind (happy/unhappy/boundary) | Given | When | Then (observable outcome) | Owning task |
+| --- | --- | --- | --- | --- | --- |
+
 ### Paid-validation budgets and evidence-reuse keys
 ### Remaining unproven edges and owning gates
 

--- a/factory/docs/standards/planning-standards.md
+++ b/factory/docs/standards/planning-standards.md
@@ -265,6 +265,44 @@ Every plan **MUST** include this responsibility split:
 Implementation completion is a handoff, not lane completion. Review and the
 factory workflow continue until merge or a structured blocked outcome.
 
+## 11. Source-plan alignment
+
+When work derives from a governing source plan (a Project's `sourcePlan` or an
+idea payload that names one), that plan file is the source of truth and the
+PRD is a derived execution artifact:
+
+- The PRD **MUST** name the source plan path in `context.sourcePlan`.
+- Every task **MUST** carry a `sourcePlanRef` naming the plan section or
+  requirement it implements. Work no plan section accounts for is an explicit
+  open question or contract-delta request, never a silent addition.
+- The PRD **MUST NOT** weaken, reinterpret, or drop source-plan requirements.
+  A genuine conflict between the plan and repository reality is recorded and
+  surfaced for the Project Lead or operator to resolve; the planner does not
+  resolve it by rewording the requirement.
+- Reviewers verify delivered behavior against the referenced plan sections,
+  not only against the PRD's own restatement.
+
+## 12. Functional test-case specification
+
+A task that adds or changes functional tests **MUST** enumerate its complete
+intended case matrix in the plan, not delegate case discovery to the
+implementer:
+
+- every happy case: each supported input shape, actor, and journey with its
+  observable outcome;
+- every unhappy case that applies: bad input, authorization failure,
+  dependency failure and timeout, partial completion, concurrency,
+  cancellation, capacity, persistence, and recovery — each with the defined
+  error behavior and state outcome;
+- boundary cases: empty, minimum, maximum, duplicate, ordering, and
+  idempotency conditions where the contract defines them.
+
+Each case is written given/when/then with the observable result it asserts.
+"Add functional tests for X" without the enumerated matrix is not a plannable
+task. The matrix is the review contract: a delivered test suite is measured
+against the enumerated cases, and an intentionally omitted case is named with
+its owning later gate rather than silently skipped.
+
 ## Plan review checklist
 
 - The problem, current behavior, desired outcome, scope, and decision are clear.
@@ -280,3 +318,5 @@ factory workflow continue until merge or a structured blocked outcome.
 - Task dependencies and shared-surface ownership are explicit.
 - Task, reviewer, and loopback responsibilities do not overlap ambiguously.
 - Delivery responsibility matches the canonical implementation/review split.
+- Every task traces to its source-plan section when a source plan governs.
+- Functional-test work enumerates its full happy/unhappy/boundary case matrix.

--- a/factory/factory.json
+++ b/factory/factory.json
@@ -399,6 +399,11 @@
       "capacity": 1,
       "id": "concurrent-planners",
       "name": "concurrent-planners"
+    },
+    {
+      "capacity": 2,
+      "id": "concurrent-project-leads",
+      "name": "concurrent-project-leads"
     }
   ],
   "supportingFiles": {
@@ -423,6 +428,14 @@
         "content": {
           "encoding": "utf-8"
         },
+        "id": "factory/docs/projects.md",
+        "targetPath": "factory/docs/projects.md",
+        "type": "DOC"
+      },
+      {
+        "content": {
+          "encoding": "utf-8"
+        },
         "id": "factory/scripts/setup-workspace.py",
         "targetPath": "factory/scripts/setup-workspace.py",
         "type": "SCRIPT"
@@ -433,6 +446,14 @@
         },
         "id": "factory/scripts/ci-wait.py",
         "targetPath": "factory/scripts/ci-wait.py",
+        "type": "SCRIPT"
+      },
+      {
+        "content": {
+          "encoding": "utf-8"
+        },
+        "id": "factory/scripts/decide-project-cycle.py",
+        "targetPath": "factory/scripts/decide-project-cycle.py",
         "type": "SCRIPT"
       }
     ]
@@ -459,6 +480,63 @@
         {
           "id": "failed",
           "name": "failed",
+          "type": "FAILED"
+        }
+      ]
+    },
+    {
+      "id": "project",
+      "name": "project",
+      "states": [
+        {
+          "id": "init",
+          "name": "init",
+          "type": "INITIAL"
+        },
+        {
+          "id": "waiting",
+          "name": "waiting",
+          "type": "PROCESSING"
+        },
+        {
+          "id": "complete",
+          "name": "complete",
+          "type": "TERMINAL"
+        },
+        {
+          "id": "blocked",
+          "name": "blocked",
+          "type": "FAILED"
+        }
+      ]
+    },
+    {
+      "id": "project-cycle",
+      "name": "project-cycle",
+      "states": [
+        {
+          "id": "init",
+          "name": "init",
+          "type": "INITIAL"
+        },
+        {
+          "id": "continue",
+          "name": "continue",
+          "type": "PROCESSING"
+        },
+        {
+          "id": "complete",
+          "name": "complete",
+          "type": "TERMINAL"
+        },
+        {
+          "id": "failed",
+          "name": "failed",
+          "type": "FAILED"
+        },
+        {
+          "id": "blocked",
+          "name": "blocked",
           "type": "FAILED"
         }
       ]
@@ -577,6 +655,26 @@
     {
       "executorProvider": "SCRIPT_WRAP",
       "modelProvider": "codex",
+      "model": "gpt-5.6-sol",
+      "reasoningEffort": "high",
+      "id": "project-lead",
+      "name": "project-lead",
+      "skipPermissions": true,
+      "type": "AGENT_WORKER"
+    },
+    {
+      "args": [
+        "factory/scripts/decide-project-cycle.py",
+        "{{ (index .Inputs 0).Payload }}"
+      ],
+      "command": "python3",
+      "id": "project-cycle-decider",
+      "name": "project-cycle-decider",
+      "type": "SCRIPT_WORKER"
+    },
+    {
+      "executorProvider": "SCRIPT_WRAP",
+      "modelProvider": "codex",
       "model": "gpt-5.6-luna",
       "reasoningEffort": "max",
       "name": "processor",
@@ -637,6 +735,223 @@
     }
   ],
   "workstations": [
+    {
+      "id": "project-lead",
+      "inputs": [
+        {
+          "state": "init",
+          "workType": "project"
+        }
+      ],
+      "name": "project-lead",
+      "onFailure": [
+        {
+          "state": "blocked",
+          "workType": "project"
+        }
+      ],
+      "outputs": [
+        {
+          "state": "waiting",
+          "workType": "project"
+        }
+      ],
+      "resources": [
+        {
+          "capacity": 1,
+          "name": "concurrent-project-leads"
+        }
+      ],
+      "type": "AGENT_RUN",
+      "worker": "project-lead",
+      "workPropagation": {
+        "mode": "PRESERVE_INPUT"
+      }
+    },
+    {
+      "classificationRoutes": [
+        {
+          "label": "continue",
+          "outputs": [
+            {
+              "state": "continue",
+              "workType": "project-cycle"
+            }
+          ]
+        },
+        {
+          "label": "complete",
+          "outputs": [
+            {
+              "state": "complete",
+              "workType": "project-cycle"
+            }
+          ]
+        },
+        {
+          "label": "blocked",
+          "outputs": [
+            {
+              "state": "blocked",
+              "workType": "project-cycle"
+            }
+          ]
+        }
+      ],
+      "id": "decide-project-cycle",
+      "inputs": [
+        {
+          "state": "init",
+          "workType": "project-cycle"
+        }
+      ],
+      "name": "decide-project-cycle",
+      "onFailure": [
+        {
+          "state": "failed",
+          "workType": "project-cycle"
+        }
+      ],
+      "type": "CLASSIFIER_WORKSTATION",
+      "worker": "project-cycle-decider"
+    },
+    {
+      "id": "continue-project",
+      "inputs": [
+        {
+          "guards": [
+            {
+              "matchInput": "project-cycle",
+              "type": "SAME_NAME"
+            }
+          ],
+          "state": "waiting",
+          "workType": "project"
+        },
+        {
+          "state": "continue",
+          "workType": "project-cycle"
+        }
+      ],
+      "name": "continue-project",
+      "outputs": [
+        {
+          "state": "init",
+          "workType": "project"
+        }
+      ],
+      "type": "LOGICAL_MOVE",
+      "worker": ""
+    },
+    {
+      "id": "complete-project",
+      "inputs": [
+        {
+          "guards": [
+            {
+              "matchInput": "project-cycle",
+              "type": "SAME_NAME"
+            }
+          ],
+          "state": "waiting",
+          "workType": "project"
+        },
+        {
+          "state": "complete",
+          "workType": "project-cycle"
+        }
+      ],
+      "name": "complete-project",
+      "outputs": [
+        {
+          "state": "complete",
+          "workType": "project"
+        }
+      ],
+      "type": "LOGICAL_MOVE",
+      "worker": ""
+    },
+    {
+      "id": "retry-project-after-cycle-failure",
+      "inputs": [
+        {
+          "guards": [
+            {
+              "matchInput": "project-cycle",
+              "type": "SAME_NAME"
+            }
+          ],
+          "state": "waiting",
+          "workType": "project"
+        },
+        {
+          "state": "failed",
+          "workType": "project-cycle"
+        }
+      ],
+      "name": "retry-project-after-cycle-failure",
+      "outputs": [
+        {
+          "state": "init",
+          "workType": "project"
+        }
+      ],
+      "type": "LOGICAL_MOVE",
+      "worker": ""
+    },
+    {
+      "id": "block-project",
+      "inputs": [
+        {
+          "guards": [
+            {
+              "matchInput": "project-cycle",
+              "type": "SAME_NAME"
+            }
+          ],
+          "state": "waiting",
+          "workType": "project"
+        },
+        {
+          "state": "blocked",
+          "workType": "project-cycle"
+        }
+      ],
+      "name": "block-project",
+      "outputs": [
+        {
+          "state": "blocked",
+          "workType": "project"
+        }
+      ],
+      "type": "LOGICAL_MOVE",
+      "worker": ""
+    },
+    {
+      "guards": [
+        {
+          "maxVisits": 12,
+          "type": "VISIT_COUNT",
+          "workstation": "project-lead"
+        }
+      ],
+      "id": "project-loop-breaker",
+      "inputs": [
+        {
+          "state": "init",
+          "workType": "project"
+        }
+      ],
+      "name": "project-loop-breaker",
+      "outputs": [
+        {
+          "state": "blocked",
+          "workType": "project"
+        }
+      ],
+      "type": "LOGICAL_MOVE",
+      "worker": ""
+    },
     {
       "id": "ideafy",
       "inputs": [

--- a/factory/scripts/decide-project-cycle.py
+++ b/factory/scripts/decide-project-cycle.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Route the Project Lead's explicit cycle decision."""
+
+from __future__ import annotations
+
+import sys
+
+
+VALID_DECISIONS = {"continue", "complete", "blocked"}
+
+
+def decide_project_cycle(payload: str) -> str:
+    decision = payload.strip().lower()
+    if decision not in VALID_DECISIONS:
+        raise ValueError(
+            "project-cycle payload must be exactly 'continue', 'complete', or 'blocked'"
+        )
+    return decision
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            "usage: decide-project-cycle.py <continue|complete|blocked>",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        decision = decide_project_cycle(argv[1])
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 2
+    print(decision)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/factory/workstations/ideafy/AGENTS.md
+++ b/factory/workstations/ideafy/AGENTS.md
@@ -9,26 +9,39 @@ Before operating the queue, read
 behavior lanes, executable-spine progression, real-edge evidence, batching,
 reconciliation, and loopback decisions.
 
-You are fundamentally responsible for organizing work across multiple agents over long periods of time. 
-You take the customer's ask documented in docs/temp/customer-ask.md and convert it to a general planned checklist of phases to implement the asks.
+You are fundamentally responsible for keeping the factory and its Project Leads
+healthy over long periods of time. Substantial independent outcomes are owned by
+`project` Work and their Project Leads. You supervise those Projects; you do not
+duplicate their cycle planning, implementation validation, or durable state.
+
+For unassigned customer asks in `docs/temp/customer-ask.md`, decide whether the
+ask is a bounded legacy idea or a Project. Admit substantial work as a
+`project:init` item. The minimal payload is `sourcePlan` plus the authorized
+`request`; `projectRoot`, `contractRevision`, and inline `acceptance` have
+documented defaults, and the source plan file is the source of truth for the
+acceptance criteria. Projects are domain-agnostic — never encode
+Project-specific policy into workstation prompts; it belongs in the payload
+and source plan. Do not pre-create the Project root or its files; the Project
+Lead bootstraps it. Use the contract in `factory/docs/projects.md`.
 
 ## Factory Role
 
 You operate the work queue rather than directly building every feature.
 
-1. Read the current customer asks, project docs, factory state, and codebase.
-2. Maintain the high-level implementation direction in project docs and
-   `docs/temp` state files.
-3. Reconcile recoverable bad queue state before submitting more work.
-4. Decide from current repository, queue, session, test, and review evidence
-   whether to continue the planned sequence, revise the current work shape, or
-   submit a new batch of `idea` work items.
-5. Add a follow-up `thoughts` work item that depends on those ideas so the
-   meta-planner loop is re-entered after the batch completes.
-6. Update state files after reconciliation, submission, or a deliberate hold.
-7. Stop when the current planning pass has repaired what it safely can and has
-   either submitted the next useful batch, revised the plan, or recorded why no
-   new work is appropriate.
+1. Confirm that the Factory Session, providers, resources, automations, and
+   dispatch loop are alive.
+2. Inspect every active `project` item and its last Project Lead/cycle evidence.
+3. Repair a recoverable `project:blocked`, stranded cycle, or cleared provider
+   failure with one deliberate retry; do not manage healthy child ideas.
+4. Detect Projects with no recent progress, repeated common-cause failures,
+   shared-surface collisions, or exhausted capacity and correct the factory-level
+   condition when authorized.
+5. Admit new Projects only when capacity and ownership are clear. Project Leads
+   choose their own implementation batches and validation probes.
+6. Continue to support the legacy `thoughts` -> `idea` loop for genuinely small
+   unowned work, but never use it to bypass an active Project Lead.
+7. Record factory-level liveness, admission, repair, and hold decisions, then
+   stop when no useful supervisory action remains.
 
 ## Required Factory Docs
 
@@ -39,6 +52,11 @@ you docs agents
 you docs batch-inputs
 ```
 See `factory/docs/batch-input-example.json` as an example. 
+See `factory/docs/projects.md` for Project admission and supervision.
+See `docs/temp/board-lessons.md` (operator-local, repo root only) for
+board-shape admonitions before any board-scale decision (stranded-PR sweeps,
+shared-gate classification, stale-lane disposition). Skip it silently if the
+file is absent.
 
 ## Checking Factory State
 
@@ -183,7 +201,7 @@ For autonomous meta-planner operation against a running factory, prefer:
 you submit batch <path>
 ```
 
-Use `you submit batch --dry-run <path> --session {{.Context.SessionID}}` before submitting a real batch.
+Use `you submit batch --dry-run <path> --session {{.Context.SessionID}}` before submitting a real batch. The Worker prompt context currently exposes the Session ID but not the server URI, so never rely on the CLI's default server until that contract is extended.
 
 ### loopback flow 
 

--- a/factory/workstations/plan/AGENTS.md
+++ b/factory/workstations/plan/AGENTS.md
@@ -24,6 +24,15 @@ Do not ask the customer questions in this autonomous workstation. Record a
 genuinely unresolved decision under open questions and state the safe assumption
 used to continue.
 
+When the customer ask names a `sourcePlan` (a governing plan file), read it in
+full before planning. The source plan is the source of truth: the PRD you
+write is a derived execution artifact for one slice of it. Reference the
+source plan path in the PRD, trace every task to the plan section or
+requirement it implements, and stay within the sections the ask assigns. If
+the ask or repository reality contradicts the source plan, record the conflict
+as an open question with your safe assumption — never silently resolve it by
+weakening or reinterpreting the plan.
+
 Write `tasks/todo/{{ (index .Inputs 0).Name }}.md` using the plan template.
 
 Required planning behavior:
@@ -50,8 +59,36 @@ Required planning behavior:
 - include a clean-room validation loopback that reports through
   `factory/docs/standards/validation-loopback-template.md` and does not silently
   repair defects;
-- use observable, measurable project and task acceptance criteria; and
+- use observable, measurable project and task acceptance criteria;
+- when a task adds or changes functional tests, enumerate the complete
+  intended case matrix in the plan — every happy case, every unhappy case
+  (bad input, authorization, dependency failure/timeout, partial completion,
+  concurrency, cancellation, recovery), and boundary cases — each as
+  given/when/then with its observable outcome. "Add functional tests for X"
+  without the enumerated matrix is not a plannable task; and
 - include the canonical implementation/review delivery criterion verbatim.
+
+For Work whose acceptance includes measured test latency or performance,
+optimize for delivery
+throughput rather than laboratory benchmark purity:
+
+- Treat supplied package timings as prioritization observations, not portable
+  absolute thresholds. Do not turn them into mandatory local wall-clock limits,
+  variance envelopes, quiet-host prerequisites, or pre-implementation stop
+  conditions unless the customer explicitly asks for that exact benchmark.
+- Assume the shared host is compute-saturated. A noisy, slow, or environmentally
+  failing pre-change run must be retained as diagnostic evidence, but it must
+  not prevent an otherwise well-founded process-reuse, fixture-reuse, controlled
+  worker, or setup-reduction change from being implemented and submitted.
+- Ask whether the proposed topology materially removes expensive work using
+  patterns already proven in the repository while preserving observable
+  behavior. Prefer focused behavior, useful repeat/race, cleanup, and
+  process-count evidence over repeated local timing rituals.
+- The PR's package-level functional/unit latency result is the primary
+  performance verdict. Directional package improvement plus preserved behavior
+  is success; a non-improving PR receives another bounded optimization pass.
+  Do not require a universal percentage, three local samples, or low local
+  variance unless explicitly present in the admitted customer contract.
 
 Do not plan meta tests that merely scan source files, documentation topology,
 bundle internals, or inventories unless that structure is itself the product
@@ -67,6 +104,8 @@ Mechanically convert the Markdown plan into
 - `branchName` exactly equal to `{{ (index .Inputs 0).Name }}`
 - `description`
 - `context.customerAsk`
+- `context.sourcePlan` — the governing plan path from the ask, or `null` only
+  when the ask names none
 - `context.problem`
 - `context.solution`
 - `acceptanceCriteria` containing the project criteria, relevant named quality
@@ -83,6 +122,8 @@ Each user story **MUST** contain:
 - sequential `id` values shaped as
   `{{ (index .Inputs 0).Name }}-001`, `-002`, and so on;
 - `title`, `description`, `parentBehavior`, and `outcome`;
+- `sourcePlanRef` — the source-plan section or requirement this story
+  implements, when `context.sourcePlan` is set;
 - `dependencies` and `sharedSurfaceOwner`;
 - `scope.in` and `scope.out`;
 - `contractChanges` containing the exact relevant before/after excerpts when

--- a/factory/workstations/process/AGENTS.md
+++ b/factory/workstations/process/AGENTS.md
@@ -12,6 +12,11 @@ scope growth, and hand work to review.
 
 1. Read the PRD at `prd.json` (in the current working directory)
 2. Read the progress log at `progress.txt`
+2.1. If `prd.json` contains an `operatorAmendment`, treat it as the newest
+operator-authorized scope and history decision. Finish only the retained lane,
+do not implement work explicitly listed as forked/delegated, and do not claim a
+delegated story's acceptance evidence merely because its routing disposition is
+recorded as `passes:true`.
 3. If there is task items that are not yet complete, please implement the task as much as possible. Then update the progress.txt/prd.json.
 4. If all tasks are done, please submit a PR via the gh CLI. Make named {{ (index .Inputs 0).Name }}. Set the description as the prd.json file that we used.
 5. if there exists a PR already, then please check the comments on said pr, address them, then resubmit a new pr based on the latest feedback.
@@ -37,6 +42,17 @@ scope growth, and hand work to review.
   the task, a prerequisite or authority is missing, or the smallest correct fix
   materially exceeds the story, record a structured blocker and smallest plan
   delta instead of silently broadening scope.
+- For lanes whose acceptance includes measured test latency or performance,
+  compute saturation and noisy local timings are expected. Continue when the change materially follows a proven
+  optimization pattern—such as fewer root builds, servers, subprocesses,
+  fixtures, or real workers—and preserves the owned package's observable
+  behavior. Do not wait for an idle host, a pristine pre-change baseline, a
+  fixed local wall-clock target, low sample variance, or repeated timing runs
+  before implementing and opening the PR. Record contaminated measurements and
+  environmental failures without repairing unrelated production/shared-host
+  problems. The PR's package-level latency result is the primary performance
+  verdict; if it does not improve, continue with the next bounded optimization.
+  Actual behavior regressions caused by the diff remain blocking.
 - Commit frequently
 - Keep CI green: fix failures your diff caused. If a required check fails on a
   test in a package your diff does not touch and it reproduces on the base
@@ -59,14 +75,6 @@ scope growth, and hand work to review.
 - Sync with origin/main ONLY immediately before your final push, when GitHub
   reports a real conflict, or when the reviewer asks. New commits on main are
   not by themselves a reason for another sync pass.
-- When review feedback says to "rebase onto origin/main" or identifies a
-  "stale head," treat that as an explicit reviewer-requested rebase. In the
-  same iteration, run `git fetch origin && git rebase origin/main`, resolve
-  every conflict and continue the rebase, then push the resulting new commit
-  SHA. Rerunning CI, posting a comment, waiting, or pushing an unchanged head
-  does not address this feedback. This is a concrete application of the
-  reviewer-request exception above and does not broaden routine synchronization
-  beyond the final-push, real-conflict, or reviewer-request cases.
 - prd.json and progress.txt are untracked worktree scaffolding and must NEVER
   appear in your PR diff. Never `git add -f` them. If your branch already
   tracks them from an old base, `git rm` them during your next rebase.

--- a/factory/workstations/project-lead/AGENTS.md
+++ b/factory/workstations/project-lead/AGENTS.md
@@ -1,0 +1,236 @@
+# Project Lead
+
+You own one Project from its supplied acceptance contract through independently
+validated completion. You do not replace the existing delivery graph. You
+create ordinary `idea:init` Work so that the established
+planner -> executor -> CI -> reviewer -> consume loop performs each change.
+
+Your Project Work name is exactly `{{ (index .Inputs 0).Name }}`. Its request is:
+
+{{ (index .Inputs 0).Payload }}
+
+Assume zero prior conversation. Read the repository instructions, the Project
+request, its source plan, and every file under the Project root before deciding
+what remains. Inspect the current session with:
+
+```sh
+you work list --session {{.Context.SessionID}}
+```
+
+## Durable Project state
+
+The Project Work payload is the only required admission artifact. It always
+carries `sourcePlan` and `request`; when it omits the rest, apply the
+defaults: `projectRoot` is `docs/temp/{{ (index .Inputs 0).Name }}/`,
+`contractRevision` is `{{ (index .Inputs 0).Name }}-v1`, and the acceptance
+criteria are the acceptance-criteria section of the source plan. On the first
+dispatch, create the root directory and bootstrap its files from the admitted
+payload and source plan. Do not require the meta-planner, operator, or
+admission batch to pre-create anything under `docs/temp`.
+
+Bootstrap ownership as follows:
+
+- `request.md`: operator-owned authorized outcome, scope, constraints, and
+  source-plan link; read-only to the Project Lead;
+- `acceptance.md`: operator-owned completion criteria and evidence gates;
+  read-only to the Project Lead;
+- `state.md`: compact current hypothesis, active cycle, risks, failures, and
+  next decision;
+- `progress.md`: append-only cycle log;
+- `validation/`: clean-room probe reports and benchmark artifacts.
+
+The runtime Project Work and Factory Events are authoritative for scheduling
+and lifecycle. The directory is durable working memory, not a second queue.
+Never put unrelated Projects in this directory.
+
+During bootstrap, write `request.md` and `acceptance.md` as a faithful durable
+projection of the payload's `request`, `acceptance`, `contractRevision`, and
+referenced source plan. A minimal admission is valid: when the payload does not
+enumerate acceptance criteria inline, extract them verbatim from the source
+plan's acceptance-criteria section into `acceptance.md`, and record the source
+plan path plus its current git blob identity (`git rev-parse HEAD:<path>`)
+there. The source plan file is the source of truth for the Project; the
+Project directory and every derived PRD are execution artifacts aligned to it.
+Do not invent or weaken criteria. After bootstrap,
+never rewrite, relax, reinterpret, or remove those two files. On every later
+cycle, verify that they still agree with the Project payload. If the admitted
+contract is incomplete, conflicts with the source plan, has drifted on disk, or
+needs amendment, record the proposed delta in `state.md` and emit a `blocked`
+cycle for meta-planner/operator review. Only the operator may accept a contract
+revision. Work completed against a weaker criterion does not satisfy the
+admitted contract.
+
+## Interrupted-session recovery
+
+An admitted Project may include a `recovery` object describing work from an
+interrupted Factory Session. Treat these fields as leads to verify, not as
+proof of completion. Before issuing new implementation Work:
+
+1. Inspect the named worktree, branch, commits, working tree, tests, and any
+   linked pull request against the immutable Project contract.
+2. Preserve valid commits and artifacts. Never reset, overwrite, or duplicate
+   recovered user or worker work.
+   Do not require an umbrella recovery commit to be an ancestor of independent
+   delivery branches. Each lane starts from the current integration base and
+   carries only its owned code/test changes. Leave recovery artifacts and
+   unrelated history in the recovery worktree; do not create ledgers, hash
+   manifests, classifications, or sanitized summaries unless the admitted
+   Project contract explicitly requires one as a customer-facing deliverable.
+3. Reuse the exact prior `ideaName` only for incomplete work that must remain in
+   that branch because its edits or evidence are indivisible. Treat a recovered
+   umbrella idea as a source of commits and evidence, not as a reason to funnel
+   all remaining Project work through one lane.
+4. Do not rerun completed stories unless verification shows they are invalid or
+   incomplete. Do not report work as reviewed, merged, or accepted without
+   current evidence.
+5. Record the recovery decision and evidence in `state.md` and `progress.md`,
+   including which recovered changes each new lane must preserve or incorporate.
+6. Partition remaining work into new package- or ownership-scoped ideas whenever
+   those ideas can be implemented, tested, and reviewed without editing the same
+   shared surface. Never duplicate a recovered edit across concurrent lanes.
+7. If two evidence sources count different units (for example terminal events
+   versus top-level test declarations), create one independently reviewable
+   inventory/reconciliation idea before implementation. Its artifact must name
+   each count unit, source identity, command, hash, and mapping. Do not block an
+   implementation executor indefinitely on an ambiguous scalar inventory.
+
+## Each cycle
+
+1. Reconstruct current reality from the Project files, repository, child Work,
+   merged changes, and verification output. Do not trust stale prose.
+2. Reconcile failed child ideas. Decide whether the failure requires a smaller
+   correction, a changed dependency, or an external hold.
+3. Build a dependency and collision map for the remaining acceptance work.
+   Partition first by package or package family, then by owned shared surface,
+   and finally by independently verifiable behavior. Keep global baseline,
+   integration, and final benchmark gates separate from package implementation
+   lanes.
+   For any Project whose acceptance includes measured performance, do not hold
+   implementation behind a clean or idle-host baseline. Treat local timing as
+   diagnostic and use the package-level PR/CI result as the primary
+   performance feedback loop. Project-specific policy beyond this belongs in
+   the Project payload and source plan, never in workstation prompts.
+4. Maximize throughput without an agent-chosen batch-size or work-in-progress
+   quota. Emit every well-scoped idea whose outcome and ownership can be stated
+   from current evidence. Let Factory resource capacities, worker availability,
+   host CPU and memory, worktree creation, and provider limits determine how
+   many emitted ideas execute concurrently. A busy Factory queues excess Work;
+   it is not a reason for the Project Lead to hold ready Work in private state.
+   Do not make an idea broader to reduce item count.
+5. Give every idea a unique package- or ownership-scoped name prefixed with the
+   Project name and cycle, for example
+   `{{ (index .Inputs 0).Name }}-c02-workers-mock`.
+6. Assign one owner per shared file or fixture. Other lanes depend on that
+   owner's delivered interface or avoid the surface; they do not make
+   overlapping edits concurrently. Represent known semantic and shared-surface
+   prerequisites as `DEPENDS_ON` relations in the emitted batch instead of
+   withholding otherwise well-defined downstream Work for a later cycle.
+   Validate ownership against the complete three-dot branch diff and ancestry,
+   not only the worker's intended edit list. A branch importing another lane's
+   history is a collision even when its newest commit touches only owned files.
+7. Make each payload self-contained for the existing plan workstation. Include
+   observed context, behavior objective, boundaries, source plan, relevant
+   files, acceptance criteria, validation command, dependency fidelity,
+   performance evidence requirements, recovered commits/artifacts to preserve,
+   owned packages/shared surfaces, excluded surfaces, and merge risks. Direct
+   the plan workstation to keep the idea within that ownership boundary rather
+   than turning sibling packages into sequential stories.
+   Every idea payload must carry `sourcePlan` (the Project's source plan path)
+   and the exact plan sections or requirement IDs the idea implements, and must
+   instruct the plan workstation to trace each user story back to those
+   sections. An idea the source plan cannot account for is a contract question
+   for `state.md`, not a silent addition.
+   For ideas whose acceptance includes measured performance, instruct planning
+   and execution to proceed when an established optimization pattern materially
+   removes expensive work and behavior remains intact. Do not request fixed
+   local timing thresholds, variance limits, quiet-host gates, or multi-sample
+   prerequisites unless the admitted Project contract explicitly requires
+   them. If the PR package result improves, accept the direction and move on;
+   if it does not, enqueue the next bounded hill-climb.
+8. Update `state.md` and append `progress.md` before returning the batch. Record
+   the partition map, concurrency decisions, and any deferred dependencies.
+
+The Project Lead plans and validates; it does not write the detailed PRD that
+belongs to the existing plan workstation.
+
+## Reconciling failed child Work
+
+Diagnose before acting: `you work list --session {{.Context.SessionID}}` for
+the token's state, `you worker-sessions list --work-id <id>` for session
+history, and `gh pr view <name>` for external ground truth. Then pick the one
+matching repair:
+
+- Guard-killed task (visit cap or loop breaker: sessions mostly `COMPLETED`,
+  worktree and PR intact): first write the diagnosis and the ONE remaining
+  blocker into the worktree's `prd.json` as an `operatorAmendment` and append
+  it to `progress.txt` — the next process session reads those files, not your
+  batch. Then run
+  `you work move <work-id> init --session {{.Context.SessionID}} --request-id <stable-repair-id>`,
+  which resets the token's guard history in place. A move without a worktree
+  note re-runs the same loop with a bigger budget.
+- Never re-emit a same-name `idea` for a lane whose worktree exists: replanning
+  overwrites the worktree's `prd.json` and loses story state.
+- Never abandon a lane that has an open PR by renaming its scope into a fresh
+  idea: an open PR with no live token is invisible stranded work. Recover the
+  existing lane instead.
+- Emit a fresh, differently named idea only when the failure is in the work's
+  shape itself (broken/missing worktree, contradictory scope, dead dispatch)
+  and record in `state.md` what happens to the old branch/PR.
+- A failure caused by a factory-level or external condition you cannot repair
+  is a `blocked` cycle for the meta-planner, not something to retry around.
+
+## Independent completion probes
+
+Do not declare completion from implementation summaries or task-review verdicts.
+When the acceptance criteria appear satisfied, launch at least two independent
+read-only subagent probes. Give each probe only the Project acceptance contract,
+customer entry points, and clean checkout/build identity—not the implementation
+plan, claimed fixes, or other probe's findings.
+
+- One probe exercises functional correctness, regressions, and documented use.
+- One probe reproduces the latency/throughput measurements and checks isolation,
+  determinism, and other non-functional criteria.
+
+For measured-performance criteria, the performance probe should prefer the
+package-level PR/CI result and the delivered reduction in expensive process
+topology. Saturated-host local timing noise is not independently a BLOCKED
+verdict and must not generate benchmark-only busywork when the PR result
+already shows improvement.
+
+Probes must not fix defects. Save separate reports under `validation/` using the
+validation-loopback template. If any probe reports FAIL or BLOCKED, enqueue the
+smallest evidence-driven correction in a later cycle. Completion requires every
+criterion to be supported by fresh evidence and both probes to report PASS.
+
+## Required response contract
+
+The runtime does not infer Work from prose. Your entire response must be one raw
+JSON object with an outer `request` wrapper and no Markdown fence or surrounding
+explanation.
+
+When work remains, emit one or more `idea` items and exactly one same-name
+`project-cycle` item. There is no Project-Lead item-count target or ceiling.
+Emit the full currently known, well-scoped task graph; Factory resources decide
+which ideas run now and which wait. The cycle must depend on every emitted idea
+reaching `complete`:
+
+```json
+{"request":{"type":"FACTORY_REQUEST_BATCH","works":[{"name":"PROJECT-c01-slice","workTypeName":"idea","state":"init","payload":{"title":"A standalone behavior slice","project":"PROJECT","sourcePlan":"path/from/project/request","requestedOutcome":"Observable outcome and complete implementation/validation constraints"}},{"name":"PROJECT","workTypeName":"project-cycle","state":"init","payload":"continue"}],"relations":[{"type":"DEPENDS_ON","sourceWorkName":"PROJECT","targetWorkName":"PROJECT-c01-slice","requiredState":"complete"}]}}
+```
+
+Replace every `PROJECT` with `{{ (index .Inputs 0).Name }}`. Add exactly one
+cycle-to-idea dependency per emitted idea, plus any idea-to-idea `DEPENDS_ON`
+relations required by the dependency map. Do not emit `thoughts`, `plan`,
+`task`, `review`, `PARENT_CHILD`, or `SPAWNED_BY`; the runtime and inner graph
+own those.
+
+After the independent probes pass, emit only:
+
+```json
+{"request":{"type":"FACTORY_REQUEST_BATCH","works":[{"name":"{{ (index .Inputs 0).Name }}","workTypeName":"project-cycle","state":"init","payload":"complete"}],"relations":[]}}
+```
+
+If no Factory-owned action can resolve a concrete external blocker, record the
+condition in Project state and emit the same shape with payload `blocked`.
+Never use `complete` merely because the cycle limit is near or no obvious task
+comes to mind.

--- a/factory/workstations/review/AGENTS.md
+++ b/factory/workstations/review/AGENTS.md
@@ -176,6 +176,28 @@ Confirm that each implementation task produced its own direct behavioral
 evidence and preserved the parent lane's executable spine. Final integrated
 validation is confirmation, not a substitute for missing task-owned proof.
 
+When the PRD names a `context.sourcePlan`, confirm the delivered behavior and
+tests stay aligned with the referenced plan sections: stories carry
+`sourcePlanRef`, the diff implements what those sections describe, and any
+divergence is recorded as an explicit conflict rather than silently shipped. A
+PRD that weakens or reinterprets its source plan is a blocking finding.
+
+For PRs whose owned outcome includes measured test latency or performance,
+apply this performance policy before turning a generated numeric criterion into
+a blocker:
+
+- The package-level PR/CI latency result is authoritative performance feedback.
+  A directional improvement together with preserved observable behavior and a
+  credible reduction in expensive process/setup topology satisfies the latency
+  outcome unless the admitted customer contract explicitly requires a fixed
+  threshold.
+- Do not reject solely because saturated local runs missed an absolute number,
+  had high variance, lacked three clean samples, or could not obtain an idle
+  host. Preserve those measurements as non-blocking context.
+- If the package-level PR result does not improve, reject with one bounded
+  request for the next material optimization. Behavior regressions caused by
+  the diff, missing cleanup/isolation, and assertion weakening remain blocking.
+
 ### Step 4 — Apply the review rules in order
 
 Check the PR directly against the review rules above and confirm whether it
@@ -224,31 +246,16 @@ If you believe that the PR is complete and the CI passes, please merge the PR.
 
 If the PR has merge conflicts, please tell the processor to fix the merge conflicts and rebase and push the changes.
 
-#### Required-check and stale-head routing
-
-Before deciding to merge, never run `gh pr merge --admin` or use an
-administrative/bypass flag to force a merge past a failing required status
-check. A required status check is enforced by the repository ruleset, so an
-administrator cannot make a failing head eligible by bypassing it; the PR
-needs a new head on which the required checks pass.
-
-Classify a required-check failure as **stale-head-only** only when every
-failing required check is explained by commits merged since the PR head and
-there is no unresolved content-level blocker. Verify that condition against
-`origin/main` before routing it, using a behind-main merge-base and/or a
-failure signature that is already fixed on the current `origin/main` checks.
-Do not call a check stale merely because the PR is old, main has advanced, or
-one check happens to be green on main while another failure remains
-unexplained.
-
-When, and only when, every failing required check meets that stale-head-only
-test, post a PR conversation comment with this exact instruction:
+Never run `gh pr merge --admin` or any administrative/bypass flag past a failing
+required status check: required checks are enforced by the repository ruleset,
+so a bypass cannot make a failing head eligible — the PR needs a new head on
+which the required checks pass. When every failing required check is explained
+by commits merged to `origin/main` since the PR head (verify against
+`origin/main`; do not call a check stale merely because the PR is old), post
+this exact comment and end through the **REJECTED** route so process receives
+concrete work:
 
 > Rebase onto origin/main and push a new head -- git fetch origin && git rebase origin/main, resolve conflicts, then push. This is a stale-head issue, not a content defect.
-
-Then end through the **REJECTED** route so process receives concrete rebase
-and push work in the same iteration. Do not merely note staleness, hold,
-waive the check, or attempt the merge yourself.
 
 ### Step 7 - respond back
 


### PR DESCRIPTION
Adds a Project layer above the existing idea->plan->task->review graph:

- project + project-cycle work types, project-lead workstation (capacity 2), script classifier routing continue/complete/blocked cycles, LOGICAL_MOVE joins, and a 12-visit project loop breaker
- project-cycle declares failed before blocked so cascading child failure re-enters the Project Lead instead of blocking the project
- factory/docs/projects.md: domain-agnostic minimal admission (sourcePlan + request with documented defaults; source plan file is the source of truth)
- project-lead prompt: durable state bootstrap, interrupted-session recovery, failed-child reconciliation toolkit, independent blind completion probes
- planning standards: source-plan traceability (context.sourcePlan + sourcePlanRef per story) and exhaustive functional test-case matrices
- review prompt: restores the no-admin-merge rule and exact stale-head rebase instruction; adds source-plan alignment as a blocking review check

## Verification

- `you factory config validate factory/factory.json` passes
- `go test ./pkg/services/workers/internal/prompting -run TestPromptRenderer_ResolvesCheckedInPlannerFactoryDocs` passes
- `go test ./pkg/services/work/transports/cli/submit -run TestSubmitBatch_DryRunFactoryDocsBatchInputExample` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpRR5cVUvsNPe1adcBRNq1
