### PR TITLE
factory: drop source-plan identity ceremony, track revisions as addenda

### DIFF
--- a/factory/docs/projects.md
+++ b/factory/docs/projects.md
@@ -45,8 +45,10 @@ fields default: `projectRoot` defaults to `docs/temp/<project-name>/`,
 `contractRevision` defaults to `<project-name>-v1`, and when `acceptance` is
 omitted the acceptance criteria are the acceptance-criteria section of the
 source plan, extracted verbatim by the Project Lead at bootstrap. The source
-plan file is the source of truth either way. The meta-planner must not create
-or populate `projectRoot`. Separate Projects have separate roots and no Work
+plan file is the source of truth either way. Contract or plan revisions are
+recorded as dated addenda in `addenda.md` under the Project root; that file
+is the Project's revision history. The meta-planner must not create or
+populate `projectRoot`. Separate Projects have separate roots and no Work
 relation unless their outcomes have a real semantic dependency.
 
 Minimal admission — point a Project at a plan file and let it run end to end:

--- a/factory/workstations/project-lead/AGENTS.md
+++ b/factory/workstations/project-lead/AGENTS.md
@@ -37,6 +37,7 @@ Bootstrap ownership as follows:
 - `state.md`: compact current hypothesis, active cycle, risks, failures, and
   next decision;
 - `progress.md`: append-only cycle log;
+- `addenda.md`: append-only contract/plan revision history (dated addenda);
 - `validation/`: clean-room probe reports and benchmark artifacts.
 
 The runtime Project Work and Factory Events are authoritative for scheduling
@@ -48,17 +49,21 @@ projection of the payload's `request`, `acceptance`, `contractRevision`, and
 referenced source plan. A minimal admission is valid: when the payload does not
 enumerate acceptance criteria inline, extract them verbatim from the source
 plan's acceptance-criteria section into `acceptance.md`, and record the source
-plan path plus its current git blob identity (`git rev-parse HEAD:<path>`)
-there. The source plan file is the source of truth for the Project; the
-Project directory and every derived PRD are execution artifacts aligned to it.
-Do not invent or weaken criteria. After bootstrap,
-never rewrite, relax, reinterpret, or remove those two files. On every later
-cycle, verify that they still agree with the Project payload. If the admitted
-contract is incomplete, conflicts with the source plan, has drifted on disk, or
-needs amendment, record the proposed delta in `state.md` and emit a `blocked`
-cycle for meta-planner/operator review. Only the operator may accept a contract
-revision. Work completed against a weaker criterion does not satisfy the
-admitted contract.
+plan path there. The source plan file on disk is the source of truth for the
+Project; the Project directory and every derived PRD are execution artifacts
+aligned to it. No hash, blob, or other identity command is required or
+expected. Do not invent or weaken criteria. After bootstrap, never relax,
+reinterpret, or remove those two files on your own judgment. On every later
+cycle, re-read the source plan. If its content has changed since the current
+projection, append a dated entry to `addenda.md` in the Project root (date,
+who, what changed, why), update the projections to match, and continue —
+`addenda.md` is the Project's append-only contract revision history. Escalate
+instead — record the proposed delta in `state.md` and emit a `blocked` cycle
+for meta-planner/operator review — only when the admitted contract is
+incomplete or self-contradictory, the payload conflicts with the source plan,
+or a plan change invalidates already-merged work in a way that needs an
+operator decision. Work completed against a weaker criterion does not satisfy
+the admitted contract.
 
 ## Interrupted-session recovery
 


### PR DESCRIPTION
## Summary

- The project-lead bootstrap rule required recording the source plan's
  current git blob identity (`git rev-parse HEAD:<path>`). That is
  unsatisfiable for operator-local plans under gitignored `docs/temp`, and
  the stability-cleanup pilot blocked on cycle 1 because of it.
- Removes the identity-ceremony requirement entirely. The source plan file
  on disk remains the source of truth; contract/plan revisions are now
  recorded as dated addenda in `addenda.md` under the Project root, an
  append-only revision history, per operator direction.
- Escalation to a `blocked` cycle is narrowed to real contradictions
  (incomplete/self-contradictory contract, payload conflicting with the
  source plan) or a plan change that invalidates already-merged work —
  not routine drift, which is now just an addendum.
- `factory/docs/projects.md` gets a matching one-sentence pointer to
  `addenda.md` as the Project's revision history.

## Test plan

- Docs-only change; no build or generated artifacts affected.
- `bin/you.exe` is not present in this worktree, so `factory config
  validate` was skipped per task instructions (docs-only change).
- Verified `git diff --stat` shows exactly the two intended files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpRR5cVUvsNPe1adcBRNq1
