### PR TITLE
deflake-worker-sessions-sibling-stress-flakes

### DIFF
--- a/pkg/services/worker_sessions/internal/service/fakes_test.go
+++ b/pkg/services/worker_sessions/internal/service/fakes_test.go
@@ -350,6 +350,68 @@ func newEventsAppender() events.Service {
 	return svc
 }
 
+// terminalAppendObserver preserves the real in-memory Events implementation
+// while exposing a signal after a targeted Worker Session terminal record has
+// been committed. The controlled Workers boundary returns before Worker
+// Sessions commits that record, so waiting for the boundary alone is not a
+// sufficient observation point for a terminal Get assertion.
+type terminalAppendObserver struct {
+	events.Service
+
+	mu      sync.Mutex
+	signals map[events.Topic]chan struct{}
+	once    map[events.Topic]*sync.Once
+}
+
+func newTerminalAppendObserver(inner events.Service, topics ...events.Topic) *terminalAppendObserver {
+	observer := &terminalAppendObserver{
+		Service: inner,
+		signals: make(map[events.Topic]chan struct{}, len(topics)),
+		once:    make(map[events.Topic]*sync.Once, len(topics)),
+	}
+	for _, topic := range topics {
+		observer.signals[topic] = make(chan struct{})
+		observer.once[topic] = &sync.Once{}
+	}
+	return observer
+}
+
+func (o *terminalAppendObserver) Append(ctx context.Context, req events.AppendRequest) (events.AppendResult, error) {
+	result, err := o.Service.Append(ctx, req)
+	if err != nil || !isWorkerSessionTerminalAppend(req) {
+		return result, err
+	}
+
+	o.mu.Lock()
+	signal := o.signals[req.Topic]
+	once := o.once[req.Topic]
+	o.mu.Unlock()
+	if signal != nil && once != nil {
+		once.Do(func() { close(signal) })
+	}
+	return result, nil
+}
+
+func (o *terminalAppendObserver) waitForTerminalAppend(t *testing.T, topic events.Topic) {
+	t.Helper()
+	o.mu.Lock()
+	signal, registered := o.signals[topic]
+	o.mu.Unlock()
+	if !registered {
+		t.Fatalf("terminal append signal for topic %q is not registered", topic)
+	}
+	if err := waitControlledSignal(signal, controlledBoundaryWaitTimeout); err != nil {
+		t.Fatalf("terminal append for topic %q: %v", topic, err)
+	}
+}
+
+func isWorkerSessionTerminalAppend(req events.AppendRequest) bool {
+	return req.SourceType == "worker_session_lifecycle" &&
+		req.SourceSequence == 2 &&
+		req.SourceEventID == "terminal" &&
+		req.SchemaID == "workers.draft.v1"
+}
+
 // brokenEventsAppender is a controlled EventsAppender test double whose
 // Append always fails, used to prove Start's before-handoff publication
 // barrier explicitly fails the attempt and never reaches Workers.
@@ -462,7 +524,13 @@ func (b *blockingTerminalAppendEventsAppender) release() {
 
 func TestContinue_CreatesDistinctSuccessorWithExactReferenceAndLineage(t *testing.T) {
 	boundary := newControlledBoundary()
-	registry := newControlledRegistry(t, boundary)
+	sourceTopic := workersessions.Topic("source-session")
+	successorTopic := workersessions.Topic("successor-session")
+	eventsSvc := newTerminalAppendObserver(newEventsAppender(), sourceTopic, successorTopic)
+	registry, err := newService(boundary, eventsSvc, logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("service.New() error = %v", err)
+	}
 	reference := providers.SessionRef{
 		Provider: providers.IDCodex,
 		Kind:     providers.SessionIDKind,
@@ -471,6 +539,7 @@ func TestContinue_CreatesDistinctSuccessorWithExactReferenceAndLineage(t *testin
 
 	sourceResult := startControlledSession(t, registry, boundary, "source-session", "dispatch-source")
 	boundary.complete(completedDispatchWithProviderSession("dispatch-source", reference), nil)
+	eventsSvc.waitForTerminalAppend(t, sourceTopic)
 	source := <-sourceResult
 	if source.Session.State != workersessions.StateCompleted {
 		t.Fatalf("source session = %#v, want COMPLETED", source.Session)
@@ -504,6 +573,7 @@ func TestContinue_CreatesDistinctSuccessorWithExactReferenceAndLineage(t *testin
 	assertSuccessorLineage(t, successorAfter, request, reference)
 
 	boundary.complete(completedDispatchWithProviderSession(handoff.Execution.Dispatch.DispatchID, reference), nil)
+	eventsSvc.waitForTerminalAppend(t, successorTopic)
 	finalSuccessor, err := registry.Get(context.Background(), workersessions.GetRequest{ID: request.SuccessorWorkerSessionID})
 	if err != nil {
 		t.Fatalf("Get(final successor) error = %v", err)

--- a/pkg/services/worker_sessions/internal/service/service_test.go
+++ b/pkg/services/worker_sessions/internal/service/service_test.go
@@ -626,7 +626,13 @@ func newGatedRetryExecution() *gatedRetryExecution {
 
 func TestInterrupt_CancelsExactSourceBeforeAdmittingExactSessionSuccessor(t *testing.T) {
 	boundary := newControlledBoundary()
-	registry := newControlledRegistry(t, boundary)
+	sourceTopic := workersessions.Topic("source-session")
+	successorTopic := workersessions.Topic("successor-session")
+	eventsSvc := newTerminalAppendObserver(newEventsAppender(), sourceTopic, successorTopic)
+	registry, err := newService(boundary, eventsSvc, logging.NoopLogger{})
+	if err != nil {
+		t.Fatalf("service.New() error = %v", err)
+	}
 	sourceResult, reference := prepareInterruptSource(t, registry, boundary)
 
 	request := workersessions.InterruptRequest{
@@ -639,6 +645,7 @@ func TestInterrupt_CancelsExactSourceBeforeAdmittingExactSessionSuccessor(t *tes
 	if err != nil {
 		t.Fatalf("Interrupt() error = %v", err)
 	}
+	eventsSvc.waitForTerminalAppend(t, sourceTopic)
 	assertInterruptAcceptedResult(t, result, reference)
 	cancellations := boundary.cancellations()
 	if len(cancellations) != 1 || cancellations[0].DispatchID != "dispatch-source" {
@@ -652,6 +659,7 @@ func TestInterrupt_CancelsExactSourceBeforeAdmittingExactSessionSuccessor(t *tes
 	}
 
 	boundary.complete(completedDispatchWithProviderSession(handoff.Execution.Dispatch.DispatchID, reference), nil)
+	eventsSvc.waitForTerminalAppend(t, successorTopic)
 	finalSuccessor, err := registry.Get(context.Background(), workersessions.GetRequest{ID: "successor-session"})
 	if err != nil {
 		t.Fatalf("Get(successor) error = %v", err)

--- a/pkg/services/worker_sessions/internal/service/start_test.go
+++ b/pkg/services/worker_sessions/internal/service/start_test.go
@@ -4331,16 +4331,18 @@ func TestCancel_CancellationWinningProcessExitDoesNotReclassifySessionAsProcessG
 }
 
 func TestStart_CallerCancellationDoesNotCancelServerOwnedAdmission(t *testing.T) {
+	innerEvents := newEventsAppender()
+	eventsSvc := newGatedEvents(innerEvents)
 	dispatchDone := make(chan struct{})
+	dispatchContextErr := make(chan error, 1)
 	execution := &fakeExecution{
-		admissionStarted: make(chan struct{}),
-		releaseAdmission: make(chan struct{}),
-		dispatch: func(_ context.Context, request workers.WorkstationDispatchRequest) (workers.WorkstationDispatchResult, error) {
+		dispatch: func(ctx context.Context, request workers.WorkstationDispatchRequest) (workers.WorkstationDispatchResult, error) {
+			dispatchContextErr <- ctx.Err()
 			close(dispatchDone)
 			return acceptedResult(request), nil
 		},
 	}
-	registry, err := newService(executionBoundary{execution: execution}, newEventsAppender(), nil)
+	registry, err := newService(executionBoundary{execution: execution}, eventsSvc, nil)
 	if err != nil {
 		t.Fatalf("service.New() error = %v, want nil", err)
 	}
@@ -4351,7 +4353,11 @@ func TestStart_CallerCancellationDoesNotCancelServerOwnedAdmission(t *testing.T)
 		_, startErr := registry.Start(ctx, validAsyncStartRequest("worker-start-canceled", "dispatch-start-canceled"))
 		results <- startErr
 	}()
-	waitForStartSignal(t, execution.admissionStarted, "Start did not reach the controlled admission barrier")
+	// Start reports admission only after the opening topic is ready. Gate the
+	// real readiness check so caller cancellation is observed before the
+	// server-owned handoff reaches Workers; the dispatch signal below proves
+	// that releasing readiness still allows the detached attempt to proceed.
+	waitForStartSignal(t, eventsSvc.subscribeStarted, "Start did not reach the opening-topic readiness barrier")
 	cancel()
 	select {
 	case startErr := <-results:
@@ -4362,11 +4368,17 @@ func TestStart_CallerCancellationDoesNotCancelServerOwnedAdmission(t *testing.T)
 		t.Fatal("Start did not return after caller cancellation")
 	}
 
-	close(execution.releaseAdmission)
+	close(eventsSvc.releaseSubscribe)
 	select {
 	case <-dispatchDone:
 	case <-time.After(time.Second):
 		t.Fatal("server-owned admission did not finish after caller cancellation")
+	}
+	if dispatchErr := <-dispatchContextErr; dispatchErr != nil {
+		t.Fatalf("server-owned dispatch context error = %v, want nil after caller cancellation", dispatchErr)
+	}
+	if execution.callCount() != 1 {
+		t.Fatalf("server-owned dispatch count = %d, want exactly one", execution.callCount())
 	}
 }
 


### PR DESCRIPTION
{
  "project": "Deflake three Worker Sessions sibling stress tests",
  "branchName": "deflake-worker-sessions-sibling-stress-flakes",
  "description": "Replace premature asynchronous assertions in three named Worker Sessions service tests with deterministic post-effect synchronization, preserving exact lifecycle behavior and proving the focused tests under individual repetition, combined race repetition, and an ordinary package run without widening into package-wide stress or production changes.",
  "context": {
    "customerAsk": "Deflake TestContinue_CreatesDistinctSuccessorWithExactReferenceAndLineage, TestInterrupt_CancelsExactSourceBeforeAdmittingExactSessionSuccessor, and TestStart_CallerCancellationDoesNotCancelServerOwnedAdmission after reproducing each exact failure. Own only those test functions and necessary helpers in pkg/services/worker_sessions/internal/service/{start_test.go,service_test.go,fakes_test.go}; expect test-only deterministic synchronization, use the documented production-ordering escape hatch only when a trace proves it, branch after the predecessor idempotency Start deflake, rebase onto origin/main before final push, open the PR by iteration 3, paste gate outputs in the PR description, and never wait or loop on unrelated test/infra failures.",
    "sourcePlan": null,
    "problem": "The three named package tests reproducibly fail on unchanged base under race-enabled repetition without a race-detector report because they inspect asynchronous admission, cancellation, or terminalization effects before a test-controlled causal boundary, poisoning future Worker Sessions stress and latency amplification.",
    "solution": "First capture each current-head failure and trace the missing boundary, then reuse or narrowly extend the package's channel-based wait-helper idiom so every assertion follows a signal emitted after the observed effect is recorded. Keep production and public contracts unchanged unless a trace triggers the explicit production-ordering escape hatch, and validate the rebased final head with the customer-specified focused gates plus a read-only clean-room loopback."
  },
  "acceptanceCriteria": [
    "GATE-BASELINE: before edits, each named test has an exact current-head failure output or bounded non-reproduction record plus causal-boundary analysis; any production defect invokes ESC-PROD-001 rather than silent widening.",
    "GATE-RACE-50: go test ./pkg/services/worker_sessions/internal/service -race -count=50 -run 'TestContinue_CreatesDistinctSuccessorWithExactReferenceAndLineage|TestInterrupt_CancelsExactSourceBeforeAdmittingExactSessionSuccessor|TestStart_CallerCancellationDoesNotCancelServerOwnedAdmission' exits 0 with no assertion failure or race report.",
    "GATE-CONTINUE-500: go test ./pkg/services/worker_sessions/internal/service -count=500 -run 'TestContinue_CreatesDistinctSuccessorWithExactReferenceAndLineage$' exits 0 and preserves exact reference, lineage, admission, and terminal assertions.",
    "GATE-INTERRUPT-500: go test ./pkg/services/worker_sessions/internal/service -count=500 -run 'TestInterrupt_CancelsExactSourceBeforeAdmittingExactSessionSuccessor$' exits 0 and preserves exact source cancellation, successor admission, reference, lineage, and terminal assertions.",
    "GATE-START-500: go test ./pkg/services/worker_sessions/internal/service -count=500 -run 'TestStart_CallerCancellationDoesNotCancelServerOwnedAdmission$' exits 0 and preserves caller-cancellation and server-owned-admission assertions.",
    "GATE-PACKAGE: one go test ./pkg/services/worker_sessions/internal/service run exits 0 and proves ordinary package compatibility.",
    "GATE-SCOPE: the final diff changes only the three owned test functions and necessary helpers in pkg/services/worker_sessions/internal/service/{start_test.go,service_test.go,fakes_test.go}, with no production, forbidden, generated, contract, UI, or factory change unless an explicitly authorized ESC-PROD-001 delta applies; git diff --check is clean.",
    "Performance and reliability: the change materially replaces scheduler timing assumptions with causal synchronization and the customer-specified repeat/race workloads pass; no local wall-clock threshold, variance requirement, or package-wide stress gate is imposed.",
    "Security, privacy, accessibility, localization, and cost: no customer data, credentials, network or paid calls, UI, customer copy, or localization surface changes; maximum paid cost is zero.",
    "VAL-001: an independent clean checkout of the final rebased commit runs all named gates and emits the canonical read-only validation report with exact scope, fidelity, command output, commit, verdict, and unproven edges without repairing defects; unrelated failures follow ESC-EXT-001 and do not delay PR opening.",
    "The branch contains the predecessor merge, is rebased onto current origin/main before final push, and the PR is open by implementation iteration 3 with every gate output or unrelated-failure output pasted in its description.",
    "GATE-REVIEW-CI-MERGE: review drives required CI to terminal-and-passing on the reviewed head, resolves conflicts, and merges; implementation does not poll CI after handoff.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "behaviorLanes": [
    {
      "id": "BEH-WS-STRESS",
      "behavior": "Maintainers can repeatedly exercise Continue, Interrupt, and caller-canceled Start lifecycle ordering without false failures, while exact identity, lineage, cancellation, admission, and terminal semantics remain observable.",
      "actors": [
        "repository maintainer",
        "CI worker"
      ],
      "executableSpine": "Scoped named package tests use controlled Workers and the local real in-memory Events service; characterization establishes the spine, causal signals preserve and extend it, and clean-room combined stress promotes it.",
      "successMeasures": [
        "All three individual 500-repeat gates exit 0.",
        "The combined focused race-50 gate exits 0 with no race report.",
        "One ordinary Worker Sessions service package run exits 0.",
        "The final source diff remains inside the owned test files unless the explicit escape hatch is authorized."
      ]
    }
  ],
  "contractChanges": [],
  "userStories": [
    {
      "id": "deflake-worker-sessions-sibling-stress-flakes-001",
      "title": "Capture the three current-head synchronization failures",
      "description": "As an implementer, I need exact pre-change failure and ordering evidence for each named test so the repair observes the correct causal boundary and does not mask a production defect.",
      "parentBehavior": "BEH-WS-STRESS: deterministic repeated proof of Continue, Interrupt, and caller-canceled Start lifecycle ordering.",
      "outcome": "A read-only characterization record contains one bounded scoped reproduction result per test, exact observed output, commit and exit status, the last guaranteed signal, the later asserted effect, and a test-only or production-escape-hatch classification.",
      "sourcePlanRef": null,
      "dependencies": [
        "deflake-worker-sessions-idempotency-start-test is merged and present in branch ancestry"
      ],
      "sharedSurfaceOwner": "No source surface is edited; this story owns reproduction evidence in PR/workstation metadata and hands causal-boundary findings to stories 002 and 003.",
      "scope": {
        "in": [
          "Run each named test with a bounded scoped race/repeat reproduction before source edits.",
          "Record exact command, output or bounded non-reproduction, exit status, commit, assertion, and causal trace.",
          "Classify whether the failure is a premature test assertion or the ESC-PROD-001 production-ordering escape hatch."
        ],
        "out": [
          "Source edits or committed evidence files.",
          "Package-wide race repetition as an acceptance gate.",
          "Production or public-contract changes."
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given the unchanged implementation branch, when each named test is run with a scoped race/repeat reproduction, then its exact observed failure output or bounded non-reproduction result is recorded with commit and exit status.",
        "Given each observation, when its sequence is traced, then the record names the last guaranteed signal, the later asserted effect, and the proposed deterministic post-effect signal without assuming elapsed time.",
        "Given evidence of a production ordering defect, when classification is made, then implementation stops before widening and emits ESC-PROD-001; otherwise all three are explicitly classified test-only.",
        "A reproduction that does not fail in the first bounded attempt is retained as diagnostic evidence and does not become a pre-implementation wall-clock or repeat-count blocker."
      ],
      "verification": {
        "behavioralWitness": "Exact pre-change assertion output or bounded non-reproduction linked to the asynchronous operation and missing causal boundary for each named test.",
        "executableSpineEffect": "establish",
        "requiredEvidence": [
          {
            "scope": "package integration diagnostic",
            "dependencyFidelity": "controlled Workers and local real in-memory Events",
            "cadence": "once before edits",
            "cost": "bounded resource use",
            "procedure": "Run go test ./pkg/services/worker_sessions/internal/service -race -count=50 -run 'TestContinue_CreatesDistinctSuccessorWithExactReferenceAndLineage$', go test ./pkg/services/worker_sessions/internal/service -race -count=50 -run 'TestInterrupt_CancelsExactSourceBeforeAdmittingExactSessionSuccessor$', and go test ./pkg/services/worker_sessions/internal/service -race -count=50 -run 'TestStart_CallerCancellationDoesNotCancelServerOwnedAdmission$', stopping each after exact failure capture and retaining bounded non-reproduction output when applicable.",
            "propertyProved": "The current-head observation and causal-boundary classification input for each owned test.",
            "propertyNotProved": "Repaired stability, package-wide correctness, remote provider behavior, or terminal CI."
          }
        ],
        "highestFeasibleLevel": "Package integration with race instrumentation; external-system fidelity cannot improve proof of a local test-harness observation-order gap.",
        "remainingUnprovenEdges": [
          {
            "edge": "Continue repaired repetition",
            "gateId": "GATE-CONTINUE-500"
          },
          {
            "edge": "Interrupt repaired repetition",
            "gateId": "GATE-INTERRUPT-500"
          },
          {
            "edge": "Start repaired repetition",
            "gateId": "GATE-START-500"
          },
          {
            "edge": "Combined race behavior",
            "gateId": "GATE-RACE-50"
          }
        ]
      },
      "priority": 1,
      "passes": true,
      "notes": "PASS on unchanged commit 67710223e327d02c0de93a6ad826c754fe5c1702 at 2026-08-28 00:39 -07:00. Each exact scoped -race -count=50 command exited 1 with a reproducible assertion: Continue fakes_test.go:512 observed successor RUNNING instead of COMPLETED; Interrupt service_test.go:660 observed successor RUNNING instead of COMPLETED; Start start_test.go:4359 observed nil instead of context.Canceled. Last guaranteed signals are controlled Workers return/entry; later effects are terminal projection/admission outcome. All classified test-only; no ESC-PROD-001." 
    },
    {
      "id": "deflake-worker-sessions-sibling-stress-flakes-002",
      "title": "Make Continue and Interrupt assertions observe committed controlled effects",
      "description": "As a maintainer, I want the continuation and interrupt tests to assert only after the controlled Workers boundary records the exact effect so scheduler interleavings do not create false failures.",
      "parentBehavior": "BEH-WS-STRESS: deterministic repeated proof of Continue, Interrupt, and caller-canceled Start lifecycle ordering.",
      "outcome": "The two tests use deterministic post-effect signals and retain exact identity, Provider Session reference, lineage, cancellation, admission, and terminal assertions.",
      "sourcePlanRef": null,
      "dependencies": [
        "deflake-worker-sessions-sibling-stress-flakes-001"
      ],
      "sharedSurfaceOwner": "This story exclusively owns fakes_test.go, service_test.go, and any new controlledBoundary extension/helper declared in those owned files; control_test.go is read-only, while story 003 owns start_test.go and may run in parallel.",
      "scope": {
        "in": [
          "TestContinue_CreatesDistinctSuccessorWithExactReferenceAndLineage.",
          "TestInterrupt_CancelsExactSourceBeforeAdmittingExactSessionSuccessor.",
          "Necessary deterministic test-helper changes declared in fakes_test.go or service_test.go, including an extension method on the existing controlledBoundary when useful.",
          "WS-CONT-01 and WS-INT-01 exact behavioral assertions."
        ],
        "out": [
          "Production files or public contracts.",
          "Other tests, any edit to control_test.go, or a generic harness redesign.",
          "Sleeps, polling, assertion deletion, or call-count-only weakening."
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given a completed source with one exact Provider Session reference, when Continue admits and completes the exact successor, then the returned successor is RUNNING at admission, the handoff/reference and bidirectional lineage are exact, and after the post-terminal signal Get(successor) is COMPLETED.",
        "Given an active source with an exact Provider Session association, when Interrupt cancels it and admits a successor, then exactly one cancellation for dispatch-source is observable before result assertions, the source is CANCELED with successor lineage, the successor is RUNNING with predecessor/reference, and after controlled completion it is COMPLETED.",
        "Given a missing deterministic signal, when either test waits, then it fails with a bounded operation-specific diagnostic rather than sleeping or polling.",
        "GATE-CONTINUE-500 exits 0 and proves exact continuation identity, reference, lineage, admission, and terminal behavior across 500 repetitions.",
        "GATE-INTERRUPT-500 exits 0 and proves exact cancellation-before-successor, reference, lineage, admission, and terminal behavior across 500 repetitions."
      ],
      "verification": {
        "behavioralWitness": "Exact continuation and interrupt lifecycle assertions execute only after the controlled boundary records the corresponding cancellation or terminal effect.",
        "executableSpineEffect": "preserve",
        "requiredEvidence": [
          {
            "scope": "package integration",
            "dependencyFidelity": "controlled Workers and local real in-memory Events",
            "cadence": "per Continue slice and final head",
            "cost": "bounded resource use",
            "procedure": "go test ./pkg/services/worker_sessions/internal/service -count=500 -run 'TestContinue_CreatesDistinctSuccessorWithExactReferenceAndLineage$'",
            "propertyProved": "Exact continuation identity/reference/lineage and terminal successor remain stable across 500 repetitions.",
            "propertyNotProved": "Interrupt, Start, race instrumentation, unselected package tests, or remote Workers."
          },
          {
            "scope": "package integration",
            "dependencyFidelity": "controlled Workers and local real in-memory Events",
            "cadence": "per Interrupt slice and final head",
            "cost": "bounded resource use",
            "procedure": "go test ./pkg/services/worker_sessions/internal/service -count=500 -run 'TestInterrupt_CancelsExactSourceBeforeAdmittingExactSessionSuccessor$'",
            "propertyProved": "Exact source cancellation precedes exact successor admission and terminal completion across 500 repetitions.",
            "propertyNotProved": "Continue-only and Start behavior, race instrumentation, unselected package tests, or remote Workers."
          }
        ],
        "highestFeasibleLevel": "Package integration with a controlled Workers boundary and real in-memory Events, because the defect is the test's observation boundary.",
        "remainingUnprovenEdges": [
          {
            "edge": "Combined race behavior",
            "gateId": "GATE-RACE-50"
          },
          {
            "edge": "Ordinary package regression",
            "gateId": "GATE-PACKAGE"
          },
          {
            "edge": "Clean-head integration",
            "gateId": "VAL-001"
          }
        ]
      },
      "priority": 2,
      "passes": true,
      "notes": "PASS on implementation commit 66ee839e509d18917e598caeec7a1234c04680a1 at 2026-08-28 00:46 -07:00. Added a test-only terminalAppendObserver over the real in-memory Events service; Continue and Interrupt wait for the targeted lifecycle terminal append before terminal Get assertions. GATE-CONTINUE-500 exited 0 in 0.161s, GATE-INTERRUPT-500 exited 0 in 0.166s, and focused combined -race -count=50 exited 0 in 2.588s with no race report. Exact identity, reference, lineage, cancellation, admission, and terminal assertions remain. Story 003, package gate, final clean-room validation, and delivery remain."
    },
    {
      "id": "deflake-worker-sessions-sibling-stress-flakes-003",
      "title": "Make caller-canceled Start observe server-owned admission completion",
      "description": "As a maintainer, I want caller cancellation and continuing server-owned admission observed through separate causal signals so the Start test cannot pass or fail based on scheduler timing.",
      "parentBehavior": "BEH-WS-STRESS: deterministic repeated proof of Continue, Interrupt, and caller-canceled Start lifecycle ordering.",
      "outcome": "The Start test deterministically proves context.Canceled is returned to the caller while exactly one server-owned admission proceeds after release.",
      "sourcePlanRef": null,
      "dependencies": [
        "deflake-worker-sessions-sibling-stress-flakes-001"
      ],
      "sharedSurfaceOwner": "This story exclusively owns start_test.go and start-specific helpers in that file; story 002 owns fakes_test.go/service_test.go and may run in parallel.",
      "scope": {
        "in": [
          "TestStart_CallerCancellationDoesNotCancelServerOwnedAdmission.",
          "Any necessary start-specific deterministic helper in start_test.go.",
          "WS-START-01 caller-versus-server cancellation behavior."
        ],
        "out": [
          "Start production code or new lifecycle semantics.",
          "Other Start tests or shared controlledBoundary redesign.",
          "Sleeps, polling, or weakening to goroutine completion without recorded effect."
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given Start blocked at controlled admission, when the caller cancels, then Start returns an error matching context.Canceled before admission is released.",
        "Given the canceled caller result, when controlled admission is released, then a deterministic post-effect signal proves exactly one server-owned dispatch/admission completed and was not canceled by the caller.",
        "Given a missing signal, when the test waits, then it fails with a bounded operation-specific diagnostic without sleep or polling.",
        "GATE-START-500 exits 0 and proves the caller/server context-ownership behavior across 500 repetitions."
      ],
      "verification": {
        "behavioralWitness": "Caller cancellation and subsequent server-owned dispatch completion are separately and causally observed in one test.",
        "executableSpineEffect": "extend",
        "requiredEvidence": [
          {
            "scope": "package integration",
            "dependencyFidelity": "controlled Workers and local real in-memory Events",
            "cadence": "per Start slice and final head",
            "cost": "bounded resource use",
            "procedure": "go test ./pkg/services/worker_sessions/internal/service -count=500 -run 'TestStart_CallerCancellationDoesNotCancelServerOwnedAdmission$'",
            "propertyProved": "The Start test preserves caller cancellation and server-owned admission/dispatch ownership across 500 repetitions.",
            "propertyNotProved": "Continue, Interrupt, race instrumentation, unselected package tests, or remote execution."
          }
        ],
        "highestFeasibleLevel": "Package integration with a controlled Workers boundary and real in-memory Events; higher external fidelity does not sharpen the local synchronization property.",
        "remainingUnprovenEdges": [
          {
            "edge": "Combined race behavior",
            "gateId": "GATE-RACE-50"
          },
          {
            "edge": "Ordinary package regression",
            "gateId": "GATE-PACKAGE"
          },
          {
            "edge": "Clean-head integration",
            "gateId": "VAL-001"
          }
        ]
      },
      "priority": 3,
      "passes": true,
      "notes": "PASS on implementation commit 9b594338a71ff3989b09f6f1d0ede28c12c1342f at 2026-08-28. GATE-START-500 exited 0 in 0.072s. The test gates real opening-topic readiness before caller cancellation, then observes one post-release dispatch with a non-canceled server-owned context and exact call count; no production files changed. Story 004 final validation and delivery remain."
    },
    {
      "id": "deflake-worker-sessions-sibling-stress-flakes-004",
      "title": "Validate the rebased test-only delivery and hand off the PR",
      "description": "As a reviewer, I want the exact rebased final commit independently exercised through all owned stress and compatibility gates so the opened PR carries trustworthy runtime evidence and a precise remaining-edge handoff.",
      "parentBehavior": "BEH-WS-STRESS: deterministic repeated proof of Continue, Interrupt, and caller-canceled Start lifecycle ordering.",
      "outcome": "A read-only clean-room loopback validates the final rebased head, emits the canonical report, and the pushed/open PR contains all required outputs or a mandatory unrelated-failure classification.",
      "sourcePlanRef": null,
      "dependencies": [
        "deflake-worker-sessions-sibling-stress-flakes-002",
        "deflake-worker-sessions-sibling-stress-flakes-003"
      ],
      "sharedSurfaceOwner": "Validation is read-only over source; stories 002 and 003 retain ownership of their files, and no defect may be silently repaired during loopback.",
      "scope": {
        "in": [
          "Verify predecessor ancestry and rebase onto current origin/main before final push.",
          "Run all three individual 500-repeat gates, the combined focused race-50 gate, one plain package run, and the scope/whitespace audit in a clean checkout.",
          "Emit the uncommitted validation-loopback report at validation/deflake-worker-sessions-sibling-stress-flakes-004.md and open/update the PR with all outputs or unrelated-failure evidence.",
          "Push final head and start CI before implementation handoff."
        ],
        "out": [
          "Silent source repairs during validation.",
          "Package-wide race repetition.",
          "Terminal CI polling, conflict resolution, merge, forbidden files, or remote execution."
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given the final branch, when ancestry is checked, then it contains the predecessor merge and is rebased onto current origin/main before final push.",
        "Given the clean final head, when GATE-CONTINUE-500, GATE-INTERRUPT-500, GATE-START-500, GATE-RACE-50, and GATE-PACKAGE run, then each exits 0; or an unrelated test/infra failure is documented once under ESC-EXT-001 without delaying PR handoff.",
        "Given the final diff, when GATE-SCOPE runs, then only owned test files/helpers changed, forbidden/generated/production surfaces are absent, and git diff --check is clean unless an authorized ESC-PROD-001 delta says otherwise.",
        "Given loopback completion, when the uncommitted report is emitted at validation/deflake-worker-sessions-sibling-stress-flakes-004.md through factory/docs/standards/validation-loopback-template.md, then every project criterion is PASS, FAIL, or BLOCKED with exact command/output, scope, fidelity, commit, unproven edge, verdict, and a delta-plan request for FAIL/BLOCKED; no defect is silently repaired.",
        "Given final handoff, when implementation stops, then the final head is pushed, the PR is open by iteration 3 with all gate outputs in its description, CI has started, and blocking review feedback is addressed without polling CI afterward."
      ],
      "verification": {
        "behavioralWitness": "The exact final commit completes all three individual repetition workloads, their combined race-enabled workload, and one ordinary package run while preserving the owned-file boundary.",
        "executableSpineEffect": "promote",
        "requiredEvidence": [
          {
            "scope": "clean-room package integration/stress",
            "dependencyFidelity": "clean checkout, controlled Workers, local real in-memory Events, and Go race instrumentation",
            "cadence": "once after final rebase and before final push/handoff",
            "cost": "bounded resource use",
            "procedure": "Run the three named -count=500 commands; go test ./pkg/services/worker_sessions/internal/service -race -count=50 -run 'TestContinue_CreatesDistinctSuccessorWithExactReferenceAndLineage|TestInterrupt_CancelsExactSourceBeforeAdmittingExactSessionSuccessor|TestStart_CallerCancellationDoesNotCancelServerOwnedAdmission'; go test ./pkg/services/worker_sessions/internal/service; git diff --check; and an owned-path diff audit against the rebased base.",
            "propertyProved": "The highest planned integrated runtime proof for this test-only lane on the delivered artifact, ordinary package compatibility, and the owned-source boundary.",
            "propertyNotProved": "Unselected package stress under race, remote Workers/providers, terminal CI, conflict resolution, or merge."
          },
          {
            "scope": "delivery handoff",
            "dependencyFidelity": "actual pushed Git head and open PR",
            "cadence": "once by implementation iteration 3 and at final handoff",
            "cost": "free",
            "procedure": "Paste every gate output or unrelated-failure output in the PR description; push final rebased head; verify CI has started; address blocking review feedback; stop without polling terminal CI.",
            "propertyProved": "Implementation-stage delivery ownership is satisfied and evidence survives workstation termination.",
            "propertyNotProved": "Terminal-and-passing CI or merge, which review owns."
          }
        ],
        "highestFeasibleLevel": "Clean-room package integration/stress. End-to-end customer runtime proof is not applicable because production behavior and public entry points are unchanged; the controlled concurrency boundary is the material real edge.",
        "remainingUnprovenEdges": [
          {
            "edge": "Full package race repetition outside the three named tests",
            "gateId": "EXPLICITLY-OUT-OF-SCOPE"
          },
          {
            "edge": "Remote provider or customer-entry-point runtime behavior",
            "gateId": "NOT-APPLICABLE-TEST-ONLY-LANE"
          },
          {
            "edge": "Terminal required CI, conflict resolution, and merge",
            "gateId": "GATE-REVIEW-CI-MERGE"
          }
        ]
      },
      "priority": 4,
      "passes": true,
      "notes": "PASS on final rebased commit 9b594338a71ff3989b09f6f1d0ede28c12c1342f at 2026-08-28 00:58 -07:00. origin/main 67710223e327d02c0de93a6ad826c754fe5c1702 is an ancestor; the predecessor merge is present and rebase was up to date. Independent detached clean-room gates all exited 0: Continue-500 0.222s, Interrupt-500 0.215s, Start-500 0.089s, focused race-50 3.892s with no race report, and ordinary package 0.103s. gofmt and go vet passed; owned-path audit found exactly fakes_test.go, service_test.go, and start_test.go (98 additions, 8 deletions), with git diff --check clean. Validation report emitted at validation/deflake-worker-sessions-sibling-stress-flakes-004.md; no production, generated, forbidden, or unrelated failures. Final delivery handoff complete: head pushed, PR #2375 open with the PRD and exact gate evidence in its description, CI started, and no blocking review feedback."
    }
  ]
}

## Final gate outputs

Final commit: `9b594338a71ff3989b09f6f1d0ede28c12c1342f`
Base: `origin/main` at `67710223e327d02c0de93a6ad826c754fe5c1702`; `git rebase origin/main` reported up to date and base is an ancestor.
Clean-room: detached worktree `C:\Users\andre\AppData\Local\Temp\deflake-worker-sessions-sibling-stress-clean-room-20260828`; controlled Workers and local real in-memory Events; Windows/amd64; Go 1.25.0; no paid or remote calls.

```text
go test ./pkg/services/worker_sessions/internal/service -count=500 -run 'TestContinue_CreatesDistinctSuccessorWithExactReferenceAndLineage$'
ok  github.com/portpowered/infinite-you/pkg/services/worker_sessions/internal/service  0.222s

go test ./pkg/services/worker_sessions/internal/service -count=500 -run 'TestInterrupt_CancelsExactSourceBeforeAdmittingExactSessionSuccessor$'
ok  github.com/portpowered/infinite-you/pkg/services/worker_sessions/internal/service  0.215s

go test ./pkg/services/worker_sessions/internal/service -count=500 -run 'TestStart_CallerCancellationDoesNotCancelServerOwnedAdmission$'
ok  github.com/portpowered/infinite-you/pkg/services/worker_sessions/internal/service  0.089s

go test ./pkg/services/worker_sessions/internal/service -race -count=50 -run 'TestContinue_CreatesDistinctSuccessorWithExactReferenceAndLineage|TestInterrupt_CancelsExactSourceBeforeAdmittingExactSessionSuccessor|TestStart_CallerCancellationDoesNotCancelServerOwnedAdmission'
ok  github.com/portpowered/infinite-you/pkg/services/worker_sessions/internal/service  3.892s

go test ./pkg/services/worker_sessions/internal/service
ok  github.com/portpowered/infinite-you/pkg/services/worker_sessions/internal/service  0.103s

git diff --check origin/main...HEAD
(exit 0; no output)

gofmt -l pkg/services/worker_sessions/internal/service/fakes_test.go pkg/services/worker_sessions/internal/service/service_test.go pkg/services/worker_sessions/internal/service/start_test.go
(exit 0; no output)

go vet ./pkg/services/worker_sessions/internal/service
(exit 0; no output)
```

- GATE-SCOPE: `git diff --name-status origin/main...HEAD` listed only `pkg/services/worker_sessions/internal/service/fakes_test.go`, `pkg/services/worker_sessions/internal/service/service_test.go`, and `pkg/services/worker_sessions/internal/service/start_test.go`; 98 additions/8 deletions; zero unexpected paths.
- VAL-001: all named gates above ran in the detached clean-room checkout at the final commit; no defects were repaired during loopback.
- Delivery: PR #2375 is open, required CI has started on final head `9b594338a71ff3989b09f6f1d0ede28c12c1342f`, and no blocking review feedback exists.

Unproven by implementation: full package race repetition, remote providers/customer entry points, terminal CI, conflict resolution, and merge. Review owns terminal CI and merge; implementation will not poll CI after handoff.