### PR TITLE
fix(providers): price current Codex models

### DIFF
--- a/pkg/services/providers/wire/pricing.go
+++ b/pkg/services/providers/wire/pricing.go
@@ -16,30 +16,56 @@ func NewPriceTableReader() (providers.PriceTableReaderFunc, error) {
 }
 
 // defaultPriceTable is the only shipped pricing data source. The observed
-// provider/model inventory came from the live 2026-08-22 metrics day: the
-// factory used codex/gpt-5-codex for 192 rows and codex/OMNIVOICE_Q4_K_M for 12
-// rows. The local voice model remains intentionally absent because no
-// authoritative token price was found; fixture-only pairs are absent too.
+// provider/model inventory came from the live 2026-08-22 metrics day, while the
+// current Codex catalog also exposes the GPT-5.6 identities below. The local
+// voice model remains intentionally absent because no authoritative token price
+// was found; fixture-only pairs are absent too.
 //
 // Source: https://developers.openai.com/api/docs/models/gpt-5-codex
 // Source as-of: 2026-08-21. The source publishes $1.25 input, $0.125 cached
 // input, and $10 output per million tokens. It does not publish a separate
 // reasoning-output rate, so equality with output is explicit in the data.
 func defaultPriceTable() providers.PriceTable {
-	reasoningRate := "10"
-	cachedInputRate := "0.125"
 	return providers.PriceTable{
 		Currency: providers.PriceTableCurrencyUSD,
-		Models: []providers.PriceTableModel{{
-			Provider:                        providers.IDCodex,
-			Model:                           "gpt-5-codex",
-			InputPerMillionTokens:           "1.25",
-			OutputPerMillionTokens:          "10",
-			CachedInputPerMillionTokens:     &cachedInputRate,
-			ReasoningOutputPerMillionTokens: &reasoningRate,
-			SourceURL:                       "https://developers.openai.com/api/docs/models/gpt-5-codex",
-			AsOfDate:                        "2026-08-21",
-			EqualRateClasses:                []providers.PriceClass{providers.PriceClassReasoningOutput},
-		}},
+		Models: []providers.PriceTableModel{
+			defaultCodexPriceModel("gpt-5-codex", "1.25", "0.125", "10", "https://developers.openai.com/api/docs/models/gpt-5-codex", "2026-08-21"),
+			// Source: https://developers.openai.com/api/docs/models/gpt-5.6-sol
+			// Source as-of: 2026-08-26. The source publishes $4 input, $0.40
+			// cached input, and $20 output per million tokens. It documents that
+			// the gpt-5.6 alias routes to gpt-5.6-sol and publishes no distinct
+			// reasoning-output rate.
+			defaultCodexPriceModel("gpt-5.6", "4", "0.40", "20", "https://developers.openai.com/api/docs/models/gpt-5.6-sol", "2026-08-26"),
+			// Source: https://developers.openai.com/api/docs/models/gpt-5.6-sol
+			// Source as-of: 2026-08-26. The source publishes $4 input, $0.40
+			// cached input, and $20 output per million tokens, with no distinct
+			// reasoning-output rate.
+			defaultCodexPriceModel("gpt-5.6-sol", "4", "0.40", "20", "https://developers.openai.com/api/docs/models/gpt-5.6-sol", "2026-08-26"),
+			// Source: https://developers.openai.com/api/docs/models/gpt-5.6-terra
+			// Source as-of: 2026-08-26. The source publishes $2 input, $0.20
+			// cached input, and $12 output per million tokens, with no distinct
+			// reasoning-output rate.
+			defaultCodexPriceModel("gpt-5.6-terra", "2", "0.20", "12", "https://developers.openai.com/api/docs/models/gpt-5.6-terra", "2026-08-26"),
+			// Source: https://developers.openai.com/api/docs/models/gpt-5.6-luna
+			// Source as-of: 2026-08-26. The source publishes $0.20 input, $0.02
+			// cached input, and $1.20 output per million tokens, with no distinct
+			// reasoning-output rate.
+			defaultCodexPriceModel("gpt-5.6-luna", "0.20", "0.02", "1.20", "https://developers.openai.com/api/docs/models/gpt-5.6-luna", "2026-08-26"),
+		},
+	}
+}
+
+func defaultCodexPriceModel(model, input, cachedInput, output, sourceURL, asOfDate string) providers.PriceTableModel {
+	reasoningOutput := output
+	return providers.PriceTableModel{
+		Provider:                        providers.IDCodex,
+		Model:                           model,
+		InputPerMillionTokens:           input,
+		OutputPerMillionTokens:          output,
+		CachedInputPerMillionTokens:     &cachedInput,
+		ReasoningOutputPerMillionTokens: &reasoningOutput,
+		SourceURL:                       sourceURL,
+		AsOfDate:                        asOfDate,
+		EqualRateClasses:                []providers.PriceClass{providers.PriceClassReasoningOutput},
 	}
 }

--- a/pkg/services/providers/wire/pricing_test.go
+++ b/pkg/services/providers/wire/pricing_test.go
@@ -17,26 +17,116 @@ func TestNewPriceTableReaderPublishesObservedSourcedFacts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadPriceTable() error = %v", err)
 	}
-	if len(first.Models) != 1 {
-		t.Fatalf("price models = %#v, want only the observed authoritative pair", first.Models)
+	want := map[string]priceModelExpectation{
+		"gpt-5-codex": {
+			input: "1.25", cachedInput: "0.125", output: "10",
+			sourceURL: "https://developers.openai.com/api/docs/models/gpt-5-codex", asOfDate: "2026-08-21",
+		},
+		"gpt-5.6": {
+			input: "4", cachedInput: "0.40", output: "20",
+			sourceURL: "https://developers.openai.com/api/docs/models/gpt-5.6-sol", asOfDate: "2026-08-26",
+		},
+		"gpt-5.6-sol": {
+			input: "4", cachedInput: "0.40", output: "20",
+			sourceURL: "https://developers.openai.com/api/docs/models/gpt-5.6-sol", asOfDate: "2026-08-26",
+		},
+		"gpt-5.6-terra": {
+			input: "2", cachedInput: "0.20", output: "12",
+			sourceURL: "https://developers.openai.com/api/docs/models/gpt-5.6-terra", asOfDate: "2026-08-26",
+		},
+		"gpt-5.6-luna": {
+			input: "0.20", cachedInput: "0.02", output: "1.20",
+			sourceURL: "https://developers.openai.com/api/docs/models/gpt-5.6-luna", asOfDate: "2026-08-26",
+		},
 	}
-	model := first.Models[0]
-	if model.Provider != providers.IDCodex || model.Model != "gpt-5-codex" {
-		t.Fatalf("price identity = %#v, want codex/gpt-5-codex", model)
+	if len(first.Models) != len(want) {
+		t.Fatalf("price models = %#v, want exactly %d shipped identities", first.Models, len(want))
 	}
-	if model.SourceURL == "" || model.AsOfDate == "" {
-		t.Fatalf("price provenance = %#v, want source URL and as-of date", model)
+	seen := make(map[string]struct{}, len(first.Models))
+	for _, model := range first.Models {
+		expectation, ok := want[model.Model]
+		if !ok {
+			t.Errorf("unexpected price identity = %s/%s", model.Provider, model.Model)
+			continue
+		}
+		if _, ok := seen[model.Model]; ok {
+			t.Errorf("duplicate price identity = %s/%s", model.Provider, model.Model)
+			continue
+		}
+		seen[model.Model] = struct{}{}
+		assertPriceModel(t, model, expectation)
 	}
-	if len(model.EqualRateClasses) != 1 || model.EqualRateClasses[0] != providers.PriceClassReasoningOutput {
-		t.Fatalf("equal-rate declarations = %#v, want explicit reasoning/output equality", model.EqualRateClasses)
+	for model := range want {
+		if _, ok := seen[model]; !ok {
+			t.Errorf("missing expected price identity = codex/%s", model)
+		}
 	}
 
-	first.Models[0].Model = "mutated"
+	if _, err := first.Normalize(); err != nil {
+		t.Fatalf("reader result Normalize() error = %v", err)
+	}
+	model := findPriceModel(t, &first, "gpt-5-codex")
+	model.Model = "mutated"
+	*model.CachedInputPerMillionTokens = "mutated"
+	*model.ReasoningOutputPerMillionTokens = "mutated"
+	model.EqualRateClasses[0] = "mutated"
 	second, err := reader.ReadPriceTable()
 	if err != nil {
 		t.Fatalf("second ReadPriceTable() error = %v", err)
 	}
-	if second.Models[0].Model != "gpt-5-codex" {
-		t.Fatal("ReadPriceTable() returned aliased mutable data")
+	if len(second.Models) != len(want) {
+		t.Fatalf("second price read models = %#v, want exactly %d shipped identities", second.Models, len(want))
 	}
+	for _, model := range second.Models {
+		expectation, ok := want[model.Model]
+		if !ok {
+			t.Errorf("second read returned mutated or unexpected identity %q", model.Model)
+			continue
+		}
+		assertPriceModel(t, model, expectation)
+	}
+}
+
+type priceModelExpectation struct {
+	input, cachedInput, output string
+	sourceURL, asOfDate        string
+}
+
+func assertPriceModel(t *testing.T, model providers.PriceTableModel, expectation priceModelExpectation) {
+	t.Helper()
+	if model.Provider != providers.IDCodex {
+		t.Errorf("%s provider = %q, want %q", model.Model, model.Provider, providers.IDCodex)
+	}
+	if model.InputPerMillionTokens != expectation.input {
+		t.Errorf("%s input rate = %q, want %q", model.Model, model.InputPerMillionTokens, expectation.input)
+	}
+	if model.OutputPerMillionTokens != expectation.output {
+		t.Errorf("%s output rate = %q, want %q", model.Model, model.OutputPerMillionTokens, expectation.output)
+	}
+	if model.CachedInputPerMillionTokens == nil || *model.CachedInputPerMillionTokens != expectation.cachedInput {
+		t.Errorf("%s cached input rate = %v, want %q", model.Model, model.CachedInputPerMillionTokens, expectation.cachedInput)
+	}
+	if model.ReasoningOutputPerMillionTokens == nil || *model.ReasoningOutputPerMillionTokens != expectation.output {
+		t.Errorf("%s reasoning output rate = %v, want equal output rate %q", model.Model, model.ReasoningOutputPerMillionTokens, expectation.output)
+	}
+	if model.SourceURL != expectation.sourceURL {
+		t.Errorf("%s source URL = %q, want %q", model.Model, model.SourceURL, expectation.sourceURL)
+	}
+	if model.AsOfDate != expectation.asOfDate {
+		t.Errorf("%s as-of date = %q, want %q", model.Model, model.AsOfDate, expectation.asOfDate)
+	}
+	if len(model.EqualRateClasses) != 1 || model.EqualRateClasses[0] != providers.PriceClassReasoningOutput {
+		t.Errorf("%s equal-rate declarations = %#v, want explicit reasoning/output equality", model.Model, model.EqualRateClasses)
+	}
+}
+
+func findPriceModel(t *testing.T, table *providers.PriceTable, name string) *providers.PriceTableModel {
+	t.Helper()
+	for index := range table.Models {
+		if table.Models[index].Model == name {
+			return &table.Models[index]
+		}
+	}
+	t.Fatalf("price model %q not found", name)
+	return nil
 }


### PR DESCRIPTION
{
  "project": "Restore Cost Metrics for Current Codex Models",
  "branchName": "costs-stale-price-table-missing-current-models",
  "description": "Extend the Providers-owned immutable default price table with authoritative, dated pricing for every current Codex GPT-5.6 identity so real CLI cost metrics price current worker activity, while leaving Costs-owned traversal, aggregation, and query behavior unchanged.",
  "operatorAmendment": {
    "authorizedAt": "2026-08-28T17:10:24-07:00",
    "source": "Additional customer ask: goal 3 live/durable cost and latency verification",
    "decision": "Restore this existing task lane and retain its Providers-owned current-model price-table correction. The customer-facing runtime proof for this lane is `you metrics costs --json`; remove the contradictory requirement that generic `you metrics --json` report cost availability as available. Generic metrics availability remains Factory Visualization-owned and is outside this task. Preserve commit 8c40d0c3ac and the two-file Providers scope, rebase it onto current origin/main, verify authoritative current-model rates and focused tests, then open the existing named branch as a PR and hand it to review. Do not re-plan or broaden the lane. The separate goal-3 loopback owns the full live-and-durable Factory Session proof after its merge-commit CI prerequisites are green.",
    "retainedAcceptance": [
      "The shipped Providers price table retains codex/gpt-5-codex and prices the current codex/gpt-5.6, gpt-5.6-sol, gpt-5.6-terra, and gpt-5.6-luna identities with authoritative dated provenance and explicit equal reasoning/output rates where the source publishes no distinct reasoning rate.",
      "Focused Providers tests prove exact identities, rates, provenance, normalization, and detached reader results.",
      "A real built `you metrics costs --json` proof against representative current-model usage reports priced rows and a non-null known cost; every deliberately unpriced remaining pair is named. Generic `you metrics --json` cost availability is not an acceptance criterion for this Providers-only lane.",
      "The product diff remains limited to pkg/services/providers/wire/pricing.go and pkg/services/providers/wire/pricing_test.go, excluding Costs and Factory Visualization changes.",
      "The final branch is pushed, its PR is open, required CI has started, review drives terminal CI and merge, and CI evidence is recorded only in the PR conversation."
    ]
  },
  "context": {
    "customerAsk": "Update the stale Providers-owned default price table so current Codex worker models produce real costs, using authoritative pricing and provenance for every new entry, while avoiding the separately owned Costs query and memory-bound work.",
    "problem": "The shipped table contains only codex/gpt-5-codex, but the current factory runs gpt-5.6-luna and gpt-5.6-sol and the Codex catalog also exposes gpt-5.6 and gpt-5.6-terra. Live 2026-08-27 metrics showed 905 of 940 dispatch rows unpriced, null per-session known cost, and unavailable top-level cost despite working latency metrics.",
    "solution": "Add exact provider-published input, cached-input, output, and equal reasoning-output pricing facts for gpt-5.6, gpt-5.6-sol, gpt-5.6-terra, and gpt-5.6-luna, with authoritative model-page URLs and ISO-8601 verification dates; retain existing facts and deliberate authoritative-source exclusions, and verify the result through focused tests and the real built CLI against a real corpus."
  },
  "acceptanceCriteria": [
    "The default Providers price table retains codex/gpt-5-codex and adds codex/gpt-5.6, codex/gpt-5.6-sol, codex/gpt-5.6-terra, and codex/gpt-5.6-luna; each new entry contains the exact current input, cached-input, and output per-million-token rates published on the corresponding OpenAI model page, a real authoritative SourceURL, an ISO-8601 AsOfDate, and explicit reasoning-output/output equality when no distinct reasoning-output price is published. The gpt-5.6 alias uses the Sol facts because the provider documents that the alias routes to Sol.",
    "Focused Providers tests prove the complete expected set of shipped price identities, exact rates and provenance for the four GPT-5.6 entries, explicit equal-rate declarations, successful normalization, and detached reader results without weakening the existing gpt-5-codex assertions.",
    "On a representative corpus containing the measured current Codex pairs, you metrics costs --json reports priced_provider_models equal to encountered_provider_models minus only explicitly documented authoritative-source exclusions, reduces unpriced_rows from the measured 905/940 baseline to near zero with every remainder named, and shows at least one formerly unpriced session with a non-null known_cost. Generic you metrics --json cost availability is outside this Providers-only lane and remains Factory Visualization-owned.",
    "Scope remains limited to pkg/services/providers/wire/pricing.go and pkg/services/providers/wire/pricing_test.go; no file under pkg/services/costs/**, no traversal, aggregation, query, contract, generated, frontend, or factory configuration code changes. OMNIVOICE_Q4_K_M remains deliberately unpriced unless an authoritative token price is available, and any concurrent shared-file change is reconciled without absorbing the obs-bounded-metrics-delivery-recovery lane.",
    "Runtime-proof classification: applicable because this lane changes CLI-observable cost metrics. Build the real delivered you executable and exercise you metrics costs --server http://127.0.0.1:<live daemon> --json against the live daemon or an equivalent isolated real-corpus daemon, recording the verbatim build/run commands and outputs proving priced-model coverage, a non-null session cost, and the documented reason for every remaining unpriced pair. Generic you metrics --json cost availability is outside this Providers-only lane and remains Factory Visualization-owned. Green tests, an inspected diff, or implementer-only assertions do not satisfy this proof.",
    "Final quality gate: Typecheck passes; focused pkg/services/providers/wire tests and the narrowest relevant repository test suite pass; there are no NEW lint violations relative to current main, and the gates green on main (backend-size, pkg-maint, pkg-file-count, pkg-structure, vet) stay green.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "userStories": [
    {
      "id": "costs-stale-price-table-missing-current-models-001",
      "title": "Price current Codex activity",
      "description": "As an operator, I want current Codex worker activity to use authoritative token prices so cost metrics show real costs instead of classifying nearly every dispatch as unpriced.",
      "acceptanceCriteria": [
        "The shipped price reader returns normalized entries for the existing codex/gpt-5-codex identity and all four catalog-reachable GPT-5.6 identities: gpt-5.6, gpt-5.6-sol, gpt-5.6-terra, and gpt-5.6-luna.",
        "As verified against the provider documentation on the implementation date, Luna records input 0.20, cached input 0.02, and output 1.20; Terra records input 2, cached input 0.20, and output 12; Sol records input 4, cached input 0.40, and output 20; the gpt-5.6 alias records the same facts as Sol because it routes to Sol.",
        "Every new entry has its corresponding authoritative OpenAI model-page URL and an ISO-8601 AsOfDate; inline sourcing comments identify the source and date without inventing, averaging, or inferring a rate.",
        "Each new entry sets reasoning-output equal to output and declares PriceClassReasoningOutput in EqualRateClasses, because the published source has no distinct reasoning-output rate.",
        "The local OMNIVOICE_Q4_K_M pair remains intentionally absent unless an authoritative token price is found, and the source comment continues to explain the exclusion.",
        "Focused tests assert exact identity, rates, provenance, equal-rate semantics, normalization, and clone isolation for the expanded table.",
        "Runtime-proof classification: applicable because this story changes CLI-observable cost metrics. Build the real delivered you executable and run the real you metrics costs --server http://127.0.0.1:<live daemon> --json behavior against the live daemon or an equivalent isolated real-corpus daemon, recording verbatim commands and outputs. The evidence must show priced-model coverage equal to encountered-model coverage minus documented exclusions, near-zero unpriced rows with named reasons for any remainder, and at least one formerly unpriced session with non-null known_cost; generic you metrics --json cost availability is outside this Providers-only lane.",
        "Only pkg/services/providers/wire/pricing.go and pkg/services/providers/wire/pricing_test.go change; the Costs service and all traversal, aggregation, and query paths remain untouched.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "lastChecked": "2026-08-28 19:24 -07:00",
      "latestVerification": "2026-08-28 19:24 -07:00: Reconciled the stale project runtime criterion identified in PR #2409 so it requires only the real you metrics costs --json proof; generic you metrics --json cost availability remains explicitly outside this Providers-only lane. The existing two-file implementation, focused and full Providers tests, installed-binary replay cost probes, quality gates, final push, and open PR remain valid.",
      "currentBlocker": "None. The operator amendment removes generic you metrics --json cost availability from this Providers-only lane; review owns terminal CI and merge after PR handoff.",
      "lastIteration": "2026-08-28 19:24 -07:00: Addressed PR #2409's blocking plan contradiction by reconciling the stale top-level runtime criterion with the operator amendment. No product code changed; the complete Providers implementation remains ready for review handoff.",
      "notes": "Implementation committed as 8c40d0c3a and remains limited to pkg/services/providers/wire/pricing.go and pricing_test.go. On 2026-08-26, the official OpenAI model pages were re-verified: Sol and the gpt-5.6 alias use 4/0.40/20, Terra uses 2/0.20/12, and Luna uses 0.20/0.02/1.20 per million tokens; the existing gpt-5-codex facts remain 1.25/0.125/10. Focused provider tests, the full Providers package suite, provider vet, and prior real-CLI evidence all pass for the pricing behavior, including non-null known costs and zero unpriced rows in the representative corpus. The companion you metrics --json output still reports cost.availability=unavailable because the factory_visualization read model intentionally hard-codes that state and its tests/docs require it. The PRD requires available while its scope forbids changing that package or the metrics query path, so this story remains passes:false; no safe in-scope code change remains and operator/reviewer reconciliation of the scope or criterion is required before PR handoff. The 2026-08-26 follow-up inspected the owning accumulator and confirmed it unconditionally emits UNAVAILABLE, with no Providers-to-Visualization pricing dependency to adjust within scope. Aggregate lint retains an unrelated Go deadcode baseline drift (3101 current findings versus 3103 baseline). At 2026-08-26 18:19 -07:00, the official OpenAI model pages still confirm the four recorded rate sets and alias routing; no requirement or ownership change was available, so the blocker remains unchanged. The current follow-up confirms origin/main...HEAD still contains only the two allowed Providers files, the Visualization query still exposes only RuntimeMetricsCostUnavailable, and no PR exists; the story remains false pending explicit scope or criterion reconciliation. The latest iteration re-confirmed that metricsAccumulator.result() unconditionally emits RuntimeMetricsCostUnavailable and that no open PR or additional in-scope code path exists; no new implementation commit was created. At 2026-08-26 18:28 -07:00, gh pr list found no PR for this branch and the working tree remains clean; the same out-of-scope availability contradiction is still the only blocker. At 2026-08-26 18:29 -07:00, the branch and PR state were rechecked: the worktree is clean, origin/main...HEAD still contains only the two permitted Providers files, and no PR or CI run exists. The only unresolved criterion remains base metrics cost availability, which is owned by Factory Visualization and cannot be changed in this lane. At 2026-08-26 18:32 -07:00, the current code and GitHub state were rechecked; no permitted implementation or PR follow-up exists, so passes remains false pending explicit scope or criterion reconciliation. At 2026-08-26 18:35 -07:00, go test ./pkg/services/providers/... passed; metricsAccumulator.result() still unconditionally returns RuntimeMetricsCostUnavailable, and no in-scope implementation or PR follow-up is available. At 2026-08-26 18:48 -07:00, the owning accumulator, allowed branch diff, and GitHub state were rechecked; the same scope/criterion contradiction remains and no PR was opened. At 2026-08-26 18:55 -07:00, the current branch remains clean at the same commit, with no PR or review feedback; the contradiction is unchanged. At 2026-08-26 19:18 -07:00, the exact two-file diff, unconditional Visualization availability result, and absence of a PR or remote branch were rechecked; no safe Providers-only change remains and passes stays false pending scope or criterion reconciliation. At 2026-08-26 20:12 -07:00, an independent source and consumer inspection reached the same result: the two-file Providers implementation is complete, while base metrics availability is owned by excluded Factory Visualization code; no PR was opened because the story remains incomplete. At 2026-08-26 21:37 -07:00, GitHub was rechecked for an exact or related PR and none exists; the clean branch still has no actionable Providers-only change, so no PR was opened. At 2026-08-26 21:53 -07:00, the exact two-file diff, unconditional Factory Visualization availability result, and GitHub state were rechecked; no safe Providers-only change or PR follow-up exists, so the blocker remains unchanged. At 2026-08-27 04:55 -07:00, fresh source and GitHub checks again confirmed that the excluded Factory Visualization owner hard-codes base metrics cost availability to unavailable; no in-scope implementation, PR, CI run, or review feedback exists. At 2026-08-27 06:42 -07:00, fresh checks again confirmed the same ownership contradiction and no actionable in-scope change. At 2026-08-27 08:49 -07:00, the focused Providers, Factory Visualization, and wiring tests passed again; the code/scope and PR state are unchanged, so the availability contradiction remains the only blocker. At 2026-08-27 11:48 -07:00, source inspection, exact two-file diff inspection, and GitHub checks again confirmed that base metrics availability is owned by excluded Factory Visualization; no safe in-scope implementation or PR handoff exists. At 2026-08-27 16:42 -07:00, the clean branch remains at 8c40d0c3a with only the two permitted Providers files changed; NewPriceTableReader is consumed only by Costs, Factory Visualization still hard-codes base metrics availability to unavailable, and GitHub reports no matching PR or CI run."
    }
  ]
}
