### PR TITLE
c09 repair functional coverage cache critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,9 +412,9 @@ jobs:
           FUNCTIONAL_GOCOVERAGE_EXIT_FILE: .artifacts/functional-test-viz/gocoveragecheck-exit-code.txt
           FUNCTIONAL_COVERAGE_VERDICT_FILE: .artifacts/functional-test-viz/functional-coverage-verdict.txt
           FUNCTIONAL_COVERAGE_BUILD_DIAGNOSTICS: .artifacts/functional-test-viz/coverage-build-diagnostics.json
-          FUNCTIONAL_COVERAGE_ACTION_CACHE_PRIMARY_KEY: ${{ steps.functional-go-build-cache.outputs.cache-primary-key }}
-          FUNCTIONAL_COVERAGE_ACTION_CACHE_MATCHED_KEY: ${{ steps.functional-go-build-cache.outputs.cache-matched-key }}
-          FUNCTIONAL_COVERAGE_ACTION_CACHE_EXACT_HIT: ${{ steps.functional-go-build-cache.outputs.cache-hit }}
+      FUNCTIONAL_COVERAGE_ACTION_CACHE_PRIMARY_KEY: ${{ steps.functional-go-build-cache.outputs.cache-primary-key }}
+      FUNCTIONAL_COVERAGE_ACTION_CACHE_MATCHED_KEY: ${{ steps.functional-go-build-cache.outputs.cache-matched-key }}
+      FUNCTIONAL_COVERAGE_ACTION_CACHE_EXACT_HIT: ${{ steps.functional-go-build-cache.outputs.cache-hit || 'false' }}
           INFINITE_YOU_RUN_ACPX_REAL_CLIENT: "1"
           INFINITE_YOU_REQUIRE_ACPX_REAL_CLIENT: "1"
           INFINITE_YOU_ACPX_EVIDENCE_OUTPUT: ${{ github.workspace }}/.artifacts/functional-test-viz/real-acpx-evidence.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,9 +412,9 @@ jobs:
           FUNCTIONAL_GOCOVERAGE_EXIT_FILE: .artifacts/functional-test-viz/gocoveragecheck-exit-code.txt
           FUNCTIONAL_COVERAGE_VERDICT_FILE: .artifacts/functional-test-viz/functional-coverage-verdict.txt
           FUNCTIONAL_COVERAGE_BUILD_DIAGNOSTICS: .artifacts/functional-test-viz/coverage-build-diagnostics.json
-      FUNCTIONAL_COVERAGE_ACTION_CACHE_PRIMARY_KEY: ${{ steps.functional-go-build-cache.outputs.cache-primary-key }}
-      FUNCTIONAL_COVERAGE_ACTION_CACHE_MATCHED_KEY: ${{ steps.functional-go-build-cache.outputs.cache-matched-key }}
-      FUNCTIONAL_COVERAGE_ACTION_CACHE_EXACT_HIT: ${{ steps.functional-go-build-cache.outputs.cache-hit || 'false' }}
+          FUNCTIONAL_COVERAGE_ACTION_CACHE_PRIMARY_KEY: ${{ steps.functional-go-build-cache.outputs.cache-primary-key }}
+          FUNCTIONAL_COVERAGE_ACTION_CACHE_MATCHED_KEY: ${{ steps.functional-go-build-cache.outputs.cache-matched-key }}
+          FUNCTIONAL_COVERAGE_ACTION_CACHE_EXACT_HIT: ${{ steps.functional-go-build-cache.outputs.cache-hit || 'false' }}
           INFINITE_YOU_RUN_ACPX_REAL_CLIENT: "1"
           INFINITE_YOU_REQUIRE_ACPX_REAL_CLIENT: "1"
           INFINITE_YOU_ACPX_EVIDENCE_OUTPUT: ${{ github.workspace }}/.artifacts/functional-test-viz/real-acpx-evidence.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,21 +254,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
-      - name: Restore functional coverage Go cache
-        if: matrix.suite == 'functional'
-        id: functional-go-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: functional-coverage-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            functional-coverage-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-
-      - uses: actions/setup-node@v4
-        if: matrix.suite == 'functional'
-        with:
-          node-version: ${{ env.NODE_VERSION }}
       - name: Select functional runner parallelism
         if: matrix.suite == 'functional'
         id: functional-parallelism
@@ -278,6 +263,26 @@ jobs:
           functional_jobs=12
           echo "Functional CI runner: logical_cpus=${runner_cpus:-unknown} jobs=$functional_jobs"
           echo "jobs=$functional_jobs" >> "$GITHUB_OUTPUT"
+      - name: Restore functional Go module cache
+        if: matrix.suite == 'functional'
+        id: functional-go-module-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: functional-modules-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}
+      - name: Restore functional coverage Go build cache
+        if: matrix.suite == 'functional'
+        id: functional-go-build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: functional-coverage-build-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-jobs-${{ steps.functional-parallelism.outputs.jobs }}-${{ hashFiles('.github/workflows/ci.yml', 'Makefile', 'go.mod', 'go.sum', 'cmd/**/*.go', 'internal/**/*.go', 'pkg/**/*.go', 'tests/functional/**/*.go', 'tests/functional/functional-quarantine.json', 'docs/internal/baselines/go-functional-coverage-package-minimums.json') }}
+          restore-keys: |
+            functional-coverage-build-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-jobs-${{ steps.functional-parallelism.outputs.jobs }}-
+      - uses: actions/setup-node@v4
+        if: matrix.suite == 'functional'
+        with:
+          node-version: ${{ env.NODE_VERSION }}
       - name: Run backend coverage
         if: matrix.suite == 'unit'
         run: make test-unit-coverage
@@ -407,9 +412,18 @@ jobs:
           FUNCTIONAL_GOCOVERAGE_EXIT_FILE: .artifacts/functional-test-viz/gocoveragecheck-exit-code.txt
           FUNCTIONAL_COVERAGE_VERDICT_FILE: .artifacts/functional-test-viz/functional-coverage-verdict.txt
           FUNCTIONAL_COVERAGE_BUILD_DIAGNOSTICS: .artifacts/functional-test-viz/coverage-build-diagnostics.json
+          FUNCTIONAL_COVERAGE_ACTION_CACHE_PRIMARY_KEY: ${{ steps.functional-go-build-cache.outputs.cache-primary-key }}
+          FUNCTIONAL_COVERAGE_ACTION_CACHE_MATCHED_KEY: ${{ steps.functional-go-build-cache.outputs.cache-matched-key }}
+          FUNCTIONAL_COVERAGE_ACTION_CACHE_EXACT_HIT: ${{ steps.functional-go-build-cache.outputs.cache-hit }}
           INFINITE_YOU_RUN_ACPX_REAL_CLIENT: "1"
           INFINITE_YOU_REQUIRE_ACPX_REAL_CLIENT: "1"
           INFINITE_YOU_ACPX_EVIDENCE_OUTPUT: ${{ github.workspace }}/.artifacts/functional-test-viz/real-acpx-evidence.json
+      - name: Save functional coverage Go build cache
+        if: always() && matrix.suite == 'functional' && steps.functional-go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.functional-go-build-cache.outputs.cache-primary-key }}
       - name: Upload Linux quarantine package evidence
         if: always() && matrix.suite == 'functional'
         uses: actions/upload-artifact@v4

--- a/cmd/gocoveragecheck/coverage_build_diagnostics.go
+++ b/cmd/gocoveragecheck/coverage_build_diagnostics.go
@@ -89,6 +89,11 @@ type coverageBuildTraceSummary struct {
 	classifiable     bool
 }
 
+type coverageBuildTraceEvent struct {
+	Action string `json:"Action"`
+	Output string `json:"Output"`
+}
+
 type coverageBuildDiagnosticRun struct {
 	diagnostics     coverageBuildDiagnosticsJSON
 	identityErr     error
@@ -271,26 +276,28 @@ func parseCoverageBuildTrace(trace string) (coverageBuildTraceSummary, error) {
 	scanner := bufio.NewScanner(strings.NewReader(trace))
 	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
 	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
-		if strings.HasPrefix(line, "WORK=") {
-			workSeen = true
-			continue
-		}
-		if isCoverageBuildToolCommand(line, "compile") {
-			summary.compilerCommands++
-			traceActivity = true
-			continue
-		}
-		if isCoverageBuildToolCommand(line, "link") {
-			summary.linkerCommands++
-			traceActivity = true
-			continue
-		}
-		if isCoverageBuildTraceActivity(line) {
-			traceActivity = true
+		for _, outputLine := range coverageBuildTraceOutputLines(scanner.Text()) {
+			line := strings.TrimSpace(outputLine)
+			if line == "" {
+				continue
+			}
+			if strings.HasPrefix(line, "WORK=") {
+				workSeen = true
+				continue
+			}
+			if isCoverageBuildToolCommand(line, "compile") {
+				summary.compilerCommands++
+				traceActivity = true
+				continue
+			}
+			if isCoverageBuildToolCommand(line, "link") {
+				summary.linkerCommands++
+				traceActivity = true
+				continue
+			}
+			if isCoverageBuildTraceActivity(line) {
+				traceActivity = true
+			}
 		}
 	}
 	summary.buildActions = summary.compilerCommands + summary.linkerCommands
@@ -302,6 +309,14 @@ func parseCoverageBuildTrace(trace string) (coverageBuildTraceSummary, error) {
 	}
 	summary.classifiable = true
 	return summary, nil
+}
+
+func coverageBuildTraceOutputLines(line string) []string {
+	var event coverageBuildTraceEvent
+	if err := json.Unmarshal([]byte(line), &event); err == nil && event.Action == "build-output" {
+		return strings.Split(event.Output, "\n")
+	}
+	return []string{line}
 }
 
 func isCoverageBuildToolCommand(line, tool string) bool {

--- a/cmd/gocoveragecheck/coverage_build_diagnostics.go
+++ b/cmd/gocoveragecheck/coverage_build_diagnostics.go
@@ -8,19 +8,36 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
-	"time"
 )
 
-const coverageBuildDiagnosticsSchemaVersion = 1
+const coverageBuildDiagnosticsSchemaVersion = 2
 
 const (
 	coverageBuildDiagnosticsStatusComplete = "complete"
 	coverageBuildDiagnosticsStatusFailed   = "failed"
+)
+
+const (
+	coverageBuildCacheReuseExactInvocationHit  = "exact-invocation-hit"
+	coverageBuildCacheReuseCompileWorkObserved = "compile-work-observed"
+	coverageBuildCacheReuseUnverified          = "cache-reuse-unverified"
+	coverageBuildCacheReuseUnclassifiable      = "unclassifiable"
+	coverageBuildCacheReuseCommandFailed       = "command-failed"
+	coverageBuildCacheReuseIdentityInvalid     = "cache-identity-invalid"
+)
+
+const (
+	coverageBuildCommandResultPassed = "passed"
+	coverageBuildCommandResultFailed = "failed"
+)
+
+const (
+	coverageBuildActionCachePrimaryKeyEnv = "FUNCTIONAL_COVERAGE_ACTION_CACHE_PRIMARY_KEY"
+	coverageBuildActionCacheMatchedKeyEnv = "FUNCTIONAL_COVERAGE_ACTION_CACHE_MATCHED_KEY"
+	coverageBuildActionCacheExactHitEnv   = "FUNCTIONAL_COVERAGE_ACTION_CACHE_EXACT_HIT"
 )
 
 var coverageBuildToolCommandPattern = map[string]*regexp.Regexp{
@@ -29,110 +46,94 @@ var coverageBuildToolCommandPattern = map[string]*regexp.Regexp{
 }
 
 // coverageBuildDiagnosticsJSON is a versioned, non-canonical observation of
-// the coverage build. It intentionally contains counts and timings only; the
-// raw -x trace is useful while a command runs but is too noisy and may expose
-// paths that do not belong in a retained artifact.
+// the authoritative coverage invocation. It intentionally contains counts
+// and timings only; the raw -x trace is useful while a command runs but is
+// too noisy and may expose paths that do not belong in a retained artifact.
 type coverageBuildDiagnosticsJSON struct {
-	SchemaVersion          int                      `json:"schemaVersion"`
-	GoVersion              string                   `json:"goVersion"`
-	CoverageInvocationHash string                   `json:"coverageInvocationHash"`
-	CompileProbe           coverageCompileProbeJSON `json:"compileProbe"`
-	TestRunWallSeconds     float64                  `json:"testRunWallSeconds"`
-	TotalMeasuredSeconds   float64                  `json:"totalMeasuredSeconds"`
-	Status                 string                   `json:"status"`
+	SchemaVersion          int                               `json:"schemaVersion"`
+	GoVersion              string                            `json:"goVersion"`
+	CoverageInvocationHash string                            `json:"coverageInvocationHash"`
+	ActionCache            coverageActionCacheJSON           `json:"actionCache"`
+	CoverageInvocation     coverageInvocationDiagnosticsJSON `json:"coverageInvocation"`
+	TotalMeasuredSeconds   float64                           `json:"totalMeasuredSeconds"`
+	Status                 string                            `json:"status"`
 }
 
-type coverageCompileProbeJSON struct {
+type coverageActionCacheJSON struct {
+	PrimaryKey      string `json:"primaryKey"`
+	MatchedKey      string `json:"matchedKey"`
+	ExactPrimaryHit bool   `json:"exactPrimaryHit"`
+}
+
+type coverageInvocationDiagnosticsJSON struct {
 	WallSeconds      float64 `json:"wallSeconds"`
 	ExpectedPackages int     `json:"expectedPackages"`
 	CompilerCommands int     `json:"compilerCommands"`
 	LinkerCommands   int     `json:"linkerCommands"`
-	InferredHits     int     `json:"inferredHits"`
-	Misses           int     `json:"misses"`
+	BuildActions     int     `json:"buildActions"`
+	CacheReuse       string  `json:"cacheReuse"`
+	CommandResult    string  `json:"commandResult"`
+}
+
+type coverageActionCacheIdentity struct {
+	primaryKey      string
+	matchedKey      string
+	exactPrimaryHit bool
+	configured      bool
+}
+
+type coverageBuildTraceSummary struct {
+	compilerCommands int
+	linkerCommands   int
+	buildActions     int
+	classifiable     bool
 }
 
 type coverageBuildDiagnosticRun struct {
-	diagnostics coverageBuildDiagnosticsJSON
+	diagnostics     coverageBuildDiagnosticsJSON
+	identityErr     error
+	initialWriteErr error
 }
 
-// runCoverageBuildProbe runs the compile-only form of every existing
-// coverage invocation. The existing plan remains the source of truth for
-// package selection and coverage flags, so the probe cannot accidentally
-// select a different test corpus or alter the real test run.
-func runCoverageBuildProbe(cfg config, plan coverageInvocationPlan, testPackages []string) (*coverageBuildDiagnosticRun, error) {
+// prepareCoverageBuildDiagnostic enables tracing on the planned coverage
+// command and creates the in-progress schema-v2 document. It does not run a
+// second command: the caller executes the same plan used for coverage and
+// supplies its output to finalizeCoverageBuildDiagnostics.
+func prepareCoverageBuildDiagnostic(cfg config, plan *coverageInvocationPlan, testPackages []string) (*coverageBuildDiagnosticRun, error) {
 	outputPath := strings.TrimSpace(cfg.coverageBuildDiagnosticsOutput)
 	if outputPath == "" {
 		return nil, nil
 	}
+	if err := addCoverageBuildDiagnosticFlags(plan); err != nil {
+		return nil, err
+	}
 
-	run := newCoverageBuildDiagnosticRun(plan, testPackages)
+	run := newCoverageBuildDiagnosticRun(*plan, testPackages)
 	run.diagnostics.Status = coverageBuildDiagnosticsStatusFailed
-	if err := writeCoverageBuildDiagnostics(outputPath, run.diagnostics); err != nil {
-		return nil, fmt.Errorf("prepare coverage build diagnostics output: %w", err)
-	}
-	run.diagnostics.Status = coverageBuildDiagnosticsStatusComplete
-	started := time.Now()
-	probeDir := filepath.Join(filepath.Dir(outputPath), "compile-probe-bin")
-	if err := os.RemoveAll(probeDir); err != nil {
-		return nil, runFailedCoverageBuildDiagnostic(
-			outputPath,
-			run,
-			started,
-			"",
-			fmt.Errorf("clear coverage compile probe directory: %w", err),
-		)
-	}
-	if err := os.MkdirAll(probeDir, 0o755); err != nil {
-		return nil, runFailedCoverageBuildDiagnostic(
-			outputPath,
-			run,
-			started,
-			"",
-			fmt.Errorf("create coverage compile probe directory: %w", err),
-		)
-	}
-	defer func() { _ = os.RemoveAll(probeDir) }()
-
-	var trace strings.Builder
-	probeIndex := 0
-	for _, invocation := range plan.invocations {
-		probes, buildErr := buildCoverageCompileProbeInvocations(invocation, probeDir)
-		if buildErr != nil {
-			return nil, runFailedCoverageBuildDiagnostic(outputPath, run, started, trace.String(), buildErr)
-		}
-		for _, probe := range probes {
-			stdout, stderr, commandErr := runCommand(probe)
-			appendCoverageBuildTrace(&trace, stdout, stderr)
-			if commandErr != nil {
-				failure := coverageBuildProbeFailure(probeIndex, len(probes), commandErr, stdout, stderr)
-				return nil, runFailedCoverageBuildDiagnostic(outputPath, run, started, trace.String(), failure)
-			}
-			probeIndex++
-		}
-	}
-
-	run.diagnostics.CompileProbe.WallSeconds = roundTimingSeconds(time.Since(started).Seconds())
-	probe, err := parseCoverageBuildTrace(trace.String(), run.diagnostics.CompileProbe.ExpectedPackages)
-	if err != nil {
-		return nil, runFailedCoverageBuildDiagnostic(outputPath, run, started, trace.String(), err)
-	}
-	run.diagnostics.CompileProbe.CompilerCommands = probe.CompilerCommands
-	run.diagnostics.CompileProbe.LinkerCommands = probe.LinkerCommands
-	run.diagnostics.CompileProbe.InferredHits = probe.InferredHits
-	run.diagnostics.CompileProbe.Misses = probe.Misses
+	run.initialWriteErr = writeCoverageBuildDiagnostics(outputPath, run.diagnostics)
 	return run, nil
 }
 
 func newCoverageBuildDiagnosticRun(plan coverageInvocationPlan, testPackages []string) *coverageBuildDiagnosticRun {
-	return &coverageBuildDiagnosticRun{diagnostics: coverageBuildDiagnosticsJSON{
-		SchemaVersion:          coverageBuildDiagnosticsSchemaVersion,
-		GoVersion:              runtime.Version(),
-		CoverageInvocationHash: coverageInvocationHash(plan),
-		CompileProbe: coverageCompileProbeJSON{
-			ExpectedPackages: expectedCoveragePackageCount(testPackages),
+	identity, identityErr := coverageActionCacheIdentityFromEnvironment()
+	return &coverageBuildDiagnosticRun{
+		diagnostics: coverageBuildDiagnosticsJSON{
+			SchemaVersion:          coverageBuildDiagnosticsSchemaVersion,
+			GoVersion:              runtime.Version(),
+			CoverageInvocationHash: coverageInvocationHash(plan),
+			ActionCache: coverageActionCacheJSON{
+				PrimaryKey:      identity.primaryKey,
+				MatchedKey:      identity.matchedKey,
+				ExactPrimaryHit: identity.exactPrimaryHit,
+			},
+			CoverageInvocation: coverageInvocationDiagnosticsJSON{
+				ExpectedPackages: expectedCoveragePackageCount(testPackages),
+				CacheReuse:       coverageBuildCacheReuseUnclassifiable,
+			},
+			Status: coverageBuildDiagnosticsStatusFailed,
 		},
-		Status: coverageBuildDiagnosticsStatusComplete,
-	}}
+		identityErr: identityErr,
+	}
 }
 
 func expectedCoveragePackageCount(packages []string) int {
@@ -146,124 +147,106 @@ func expectedCoveragePackageCount(packages []string) int {
 	return len(seen)
 }
 
-func buildCoverageCompileProbeInvocations(invocation commandInvocation, outputDir string) ([]commandInvocation, error) {
-	packages, err := coverageInvocationPackageArgs(invocation.args)
-	if err != nil {
-		return nil, err
-	}
-
-	type probePackageGroup struct {
-		names    map[string]struct{}
-		packages []string
-	}
-	groups := make([]probePackageGroup, 0, len(packages))
-	for _, packageArg := range packages {
-		packageName := path.Base(strings.TrimSuffix(strings.TrimSpace(packageArg), "/"))
-		if packageName == "." || packageName == "..." || packageName == "" {
-			packageName = packageArg
-		}
-		groupIndex := -1
-		for index := range groups {
-			if _, exists := groups[index].names[packageName]; !exists {
-				groupIndex = index
-				break
-			}
-		}
-		if groupIndex == -1 {
-			groupIndex = len(groups)
-			groups = append(groups, probePackageGroup{names: make(map[string]struct{})})
-		}
-		groups[groupIndex].names[packageName] = struct{}{}
-		groups[groupIndex].packages = append(groups[groupIndex].packages, packageArg)
-	}
-
-	probes := make([]commandInvocation, 0, len(groups))
-	for _, group := range groups {
-		probe, err := buildCoverageCompileProbeInvocation(invocation, outputDir, group.packages)
+func addCoverageBuildDiagnosticFlags(plan *coverageInvocationPlan) error {
+	for index := range plan.invocations {
+		invocation := &plan.invocations[index]
+		packageStart, err := coverageInvocationPackageStart(invocation.args)
 		if err != nil {
-			return nil, err
+			return fmt.Errorf("prepare coverage build diagnostics for invocation %d: %w", index+1, err)
 		}
-		probes = append(probes, probe)
+
+		args := append([]string(nil), invocation.args[:packageStart]...)
+		if !coverageInvocationHasFlag(args, "-x") {
+			args = append(args, "-x")
+		}
+		if !coverageInvocationHasFlag(args, "-json") {
+			args = append(args, "-json")
+		}
+		args = append(args, invocation.args[packageStart:]...)
+		invocation.args = args
 	}
-	return probes, nil
+	return nil
 }
 
-func buildCoverageCompileProbeInvocation(invocation commandInvocation, outputDir string, selectedPackages []string) (commandInvocation, error) {
-	if len(invocation.args) == 0 || invocation.args[0] != "test" {
-		return commandInvocation{}, errors.New("prepare coverage compile probe: expected a go test invocation")
-	}
-	packageStart, packages, err := coverageInvocationPackageArgsWithStart(invocation.args)
-	if err != nil {
-		return commandInvocation{}, err
-	}
-	if len(selectedPackages) == 0 {
-		selectedPackages = packages
-	}
-	args := []string{"test", "-c", "-o", outputDir, "-x"}
-	for index := 1; index < packageStart; index++ {
-		arg := invocation.args[index]
-		switch {
-		case arg == "-json":
-			continue
-		case arg == "-coverprofile":
-			if index+1 >= packageStart {
-				return commandInvocation{}, errors.New("prepare coverage compile probe: -coverprofile has no value")
-			}
-			index++
-			continue
-		case strings.HasPrefix(arg, "-coverprofile="):
-			continue
-		default:
-			args = append(args, arg)
+func coverageInvocationHasFlag(args []string, wanted string) bool {
+	for _, arg := range args {
+		if arg == wanted {
+			return true
 		}
 	}
-	args = append(args, selectedPackages...)
-	return commandInvocation{
-		name: invocation.name,
-		args: args,
-		env:  invocation.env,
-		dir:  invocation.dir,
-	}, nil
+	return false
 }
 
-func coverageInvocationPackageArgs(args []string) ([]string, error) {
-	_, packages, err := coverageInvocationPackageArgsWithStart(args)
-	return packages, err
-}
-
-func coverageInvocationPackageArgsWithStart(args []string) (int, []string, error) {
+func coverageInvocationPackageStart(args []string) (int, error) {
 	if len(args) == 0 || args[0] != "test" {
-		return 0, nil, errors.New("prepare coverage compile probe: expected a go test invocation")
+		return 0, errors.New("expected a go test invocation")
 	}
 	for index := 1; index < len(args); index++ {
 		arg := args[index]
 		switch {
 		case arg == "-coverprofile":
-			if index+2 > len(args) {
-				return 0, nil, errors.New("prepare coverage compile probe: -coverprofile has no value")
+			if index+1 >= len(args) {
+				return 0, errors.New("coverage invocation -coverprofile has no value")
 			}
-			packageStart := index + 2
-			if packageStart < len(args) && args[packageStart] == "-json" {
-				packageStart++
-			}
-			return coverageInvocationPackageArgsFromStart(args, packageStart)
+			return coverageInvocationPackageStartAfterFlags(args, index+2)
 		case strings.HasPrefix(arg, "-coverprofile="):
-			packageStart := index + 1
-			if packageStart < len(args) && args[packageStart] == "-json" {
-				packageStart++
-			}
-			return coverageInvocationPackageArgsFromStart(args, packageStart)
+			return coverageInvocationPackageStartAfterFlags(args, index+1)
 		}
 	}
-	return 0, nil, errors.New("prepare coverage compile probe: coverage invocation has no -coverprofile argument")
+	return 0, errors.New("coverage invocation has no -coverprofile argument")
 }
 
-func coverageInvocationPackageArgsFromStart(args []string, packageStart int) (int, []string, error) {
-	if packageStart >= len(args) {
-		return 0, nil, errors.New("prepare coverage compile probe: coverage invocation has no test packages")
+func coverageInvocationPackageStartAfterFlags(args []string, packageStart int) (int, error) {
+	for packageStart < len(args) && (args[packageStart] == "-json" || args[packageStart] == "-x") {
+		packageStart++
 	}
-	packages := append([]string(nil), args[packageStart:]...)
-	return packageStart, packages, nil
+	if packageStart >= len(args) {
+		return 0, errors.New("coverage invocation has no test packages")
+	}
+	return packageStart, nil
+}
+
+func coverageActionCacheIdentityFromEnvironment() (coverageActionCacheIdentity, error) {
+	primaryKey, primarySet := os.LookupEnv(coverageBuildActionCachePrimaryKeyEnv)
+	matchedKey, matchedSet := os.LookupEnv(coverageBuildActionCacheMatchedKeyEnv)
+	exactHit, exactSet := os.LookupEnv(coverageBuildActionCacheExactHitEnv)
+	identity := coverageActionCacheIdentity{
+		primaryKey: strings.TrimSpace(primaryKey),
+		matchedKey: strings.TrimSpace(matchedKey),
+		configured: primarySet || matchedSet || exactSet,
+	}
+	if !identity.configured {
+		return identity, nil
+	}
+	if !primarySet || identity.primaryKey == "" {
+		return identity, fmt.Errorf("coverage build diagnostics: %s is missing", coverageBuildActionCachePrimaryKeyEnv)
+	}
+	if primaryKey != identity.primaryKey || strings.ContainsAny(primaryKey, "\r\n") {
+		return identity, fmt.Errorf("coverage build diagnostics: %s is malformed", coverageBuildActionCachePrimaryKeyEnv)
+	}
+	if matchedKey != identity.matchedKey || strings.ContainsAny(matchedKey, "\r\n") {
+		return identity, fmt.Errorf("coverage build diagnostics: %s is malformed", coverageBuildActionCacheMatchedKeyEnv)
+	}
+	if !exactSet {
+		return identity, fmt.Errorf("coverage build diagnostics: %s is missing", coverageBuildActionCacheExactHitEnv)
+	}
+	var exactPrimaryHit bool
+	switch strings.ToLower(strings.TrimSpace(exactHit)) {
+	case "true":
+		exactPrimaryHit = true
+	case "false":
+		exactPrimaryHit = false
+	default:
+		return identity, fmt.Errorf("coverage build diagnostics: %s must be true or false", coverageBuildActionCacheExactHitEnv)
+	}
+	if exactPrimaryHit && (identity.matchedKey == "" || identity.matchedKey != identity.primaryKey) {
+		return identity, errors.New("coverage build diagnostics: exact cache hit identity is inconsistent")
+	}
+	if !exactPrimaryHit && identity.matchedKey == identity.primaryKey {
+		return identity, errors.New("coverage build diagnostics: non-exact cache result matches the primary key")
+	}
+	identity.exactPrimaryHit = exactPrimaryHit
+	return identity, nil
 }
 
 func appendCoverageBuildTrace(trace *strings.Builder, stdout, stderr string) {
@@ -281,12 +264,8 @@ func appendCoverageBuildTrace(trace *strings.Builder, stdout, stderr string) {
 	}
 }
 
-func parseCoverageBuildTrace(trace string, expectedPackages int) (coverageCompileProbeJSON, error) {
-	if expectedPackages < 1 {
-		return coverageCompileProbeJSON{}, errors.New("classify coverage compile probe: no expected test packages")
-	}
-
-	var compilerCommands, linkerCommands int
+func parseCoverageBuildTrace(trace string) (coverageBuildTraceSummary, error) {
+	var summary coverageBuildTraceSummary
 	workSeen := false
 	traceActivity := false
 	scanner := bufio.NewScanner(strings.NewReader(trace))
@@ -301,12 +280,12 @@ func parseCoverageBuildTrace(trace string, expectedPackages int) (coverageCompil
 			continue
 		}
 		if isCoverageBuildToolCommand(line, "compile") {
-			compilerCommands++
+			summary.compilerCommands++
 			traceActivity = true
 			continue
 		}
 		if isCoverageBuildToolCommand(line, "link") {
-			linkerCommands++
+			summary.linkerCommands++
 			traceActivity = true
 			continue
 		}
@@ -314,25 +293,15 @@ func parseCoverageBuildTrace(trace string, expectedPackages int) (coverageCompil
 			traceActivity = true
 		}
 	}
+	summary.buildActions = summary.compilerCommands + summary.linkerCommands
 	if err := scanner.Err(); err != nil {
-		return coverageCompileProbeJSON{}, fmt.Errorf("classify coverage compile probe trace: %w", err)
+		return summary, fmt.Errorf("classify coverage build trace: %w", err)
 	}
 	if !workSeen || !traceActivity {
-		return coverageCompileProbeJSON{}, errors.New("classify coverage compile probe: unclassifiable go test -x trace")
+		return summary, errors.New("classify coverage build trace: unclassifiable go test -x trace")
 	}
-
-	misses := compilerCommands + linkerCommands
-	inferredHits := expectedPackages - misses
-	if inferredHits < 0 {
-		inferredHits = 0
-	}
-	return coverageCompileProbeJSON{
-		ExpectedPackages: expectedPackages,
-		CompilerCommands: compilerCommands,
-		LinkerCommands:   linkerCommands,
-		InferredHits:     inferredHits,
-		Misses:           misses,
-	}, nil
+	summary.classifiable = true
+	return summary, nil
 }
 
 func isCoverageBuildToolCommand(line, tool string) bool {
@@ -381,63 +350,68 @@ func canonicalCoverageInvocationArgs(args []string) []string {
 	return canonical
 }
 
-func runFailedCoverageBuildDiagnostic(outputPath string, run *coverageBuildDiagnosticRun, started time.Time, trace string, cause error) error {
-	run.diagnostics.Status = coverageBuildDiagnosticsStatusFailed
-	run.diagnostics.CompileProbe.WallSeconds = roundTimingSeconds(time.Since(started).Seconds())
-	// The test invocation never starts after a failed probe, so the observed
-	// compile-only interval is also the complete measured interval. Keep it in
-	// the failed artifact without presenting the observation as complete.
-	run.diagnostics.TotalMeasuredSeconds = run.diagnostics.CompileProbe.WallSeconds
-	if parsed, err := parseCoverageBuildTrace(trace, run.diagnostics.CompileProbe.ExpectedPackages); err == nil {
-		run.diagnostics.CompileProbe.CompilerCommands = parsed.CompilerCommands
-		run.diagnostics.CompileProbe.LinkerCommands = parsed.LinkerCommands
-		run.diagnostics.CompileProbe.InferredHits = parsed.InferredHits
-		run.diagnostics.CompileProbe.Misses = parsed.Misses
+func classifyCoverageBuildTrace(summary coverageBuildTraceSummary, identity coverageActionCacheIdentity, identityErr error, traceErr error, commandErr error) string {
+	if summary.buildActions > 0 {
+		return coverageBuildCacheReuseCompileWorkObserved
 	}
-	writeErr := writeCoverageBuildDiagnostics(outputPath, run.diagnostics)
-	return errors.Join(cause, writeErr)
+	if traceErr != nil {
+		return coverageBuildCacheReuseUnclassifiable
+	}
+	if commandErr != nil {
+		return coverageBuildCacheReuseCommandFailed
+	}
+	if identityErr != nil {
+		return coverageBuildCacheReuseIdentityInvalid
+	}
+	if identity.configured && identity.exactPrimaryHit && identity.primaryKey != "" && identity.primaryKey == identity.matchedKey {
+		return coverageBuildCacheReuseExactInvocationHit
+	}
+	return coverageBuildCacheReuseUnverified
 }
 
-func coverageBuildProbeFailure(index, total int, commandErr error, stdout, stderr string) error {
-	detail := mergeGoTestFailureDetail(stderr, stdout)
-	if detail == "" {
-		return fmt.Errorf("run coverage compile probe (%d/%d): %w", index+1, total, commandErr)
+func finalizeCoverageBuildDiagnostics(run *coverageBuildDiagnosticRun, outputPath string, wallSeconds float64, trace string, commandErr error) error {
+	wallSeconds = roundTimingSeconds(wallSeconds)
+	run.diagnostics.CoverageInvocation.WallSeconds = wallSeconds
+	run.diagnostics.TotalMeasuredSeconds = wallSeconds
+	if commandErr == nil {
+		run.diagnostics.CoverageInvocation.CommandResult = coverageBuildCommandResultPassed
+	} else {
+		run.diagnostics.CoverageInvocation.CommandResult = coverageBuildCommandResultFailed
 	}
-	return fmt.Errorf("run coverage compile probe (%d/%d): %w\n%s", index+1, total, commandErr, trimCoverageBuildFailureDetail(detail))
-}
 
-func trimCoverageBuildFailureDetail(detail string) string {
-	const maxDetail = 8 * 1024
-	if len(detail) <= maxDetail {
-		return detail
+	parsed, traceErr := parseCoverageBuildTrace(trace)
+	run.diagnostics.CoverageInvocation.CompilerCommands = parsed.compilerCommands
+	run.diagnostics.CoverageInvocation.LinkerCommands = parsed.linkerCommands
+	run.diagnostics.CoverageInvocation.BuildActions = parsed.buildActions
+	identity, identityErr := coverageActionCacheIdentityFromEnvironment()
+	if run.identityErr == nil {
+		run.identityErr = identityErr
 	}
-	const marker = "\n... coverage compile trace omitted ...\n"
-	half := (maxDetail - len(marker)) / 2
-	return detail[:half] + marker + detail[len(detail)-half:]
-}
-
-func finalizeCoverageBuildDiagnostics(run *coverageBuildDiagnosticRun, outputPath string, testRunWallSeconds float64) error {
-	run.diagnostics.TestRunWallSeconds = roundTimingSeconds(testRunWallSeconds)
-	run.diagnostics.TotalMeasuredSeconds = roundTimingSeconds(
-		run.diagnostics.CompileProbe.WallSeconds + run.diagnostics.TestRunWallSeconds,
+	run.diagnostics.CoverageInvocation.CacheReuse = classifyCoverageBuildTrace(
+		parsed,
+		identity,
+		run.identityErr,
+		traceErr,
+		commandErr,
 	)
 	run.diagnostics.Status = coverageBuildDiagnosticsStatusComplete
-	if err := writeCoverageBuildDiagnostics(outputPath, run.diagnostics); err != nil {
-		return err
+	if commandErr != nil || traceErr != nil || run.identityErr != nil || run.initialWriteErr != nil {
+		run.diagnostics.Status = coverageBuildDiagnosticsStatusFailed
 	}
-	fmt.Fprintf(
+
+	writeErr := writeCoverageBuildDiagnostics(outputPath, run.diagnostics)
+	_, summaryErr := fmt.Fprintf(
 		stdoutWriter,
-		"Coverage build diagnostic: compile=%.3fs test=%.3fs total=%.3fs compiler=%d linker=%d inferred-hits=%d misses=%d status=%s\n",
-		run.diagnostics.CompileProbe.WallSeconds,
-		run.diagnostics.TestRunWallSeconds,
-		run.diagnostics.TotalMeasuredSeconds,
-		run.diagnostics.CompileProbe.CompilerCommands,
-		run.diagnostics.CompileProbe.LinkerCommands,
-		run.diagnostics.CompileProbe.InferredHits,
-		run.diagnostics.CompileProbe.Misses,
+		"Coverage build diagnostic: wall=%.3fs compiler=%d linker=%d build-actions=%d cache-reuse=%s command-result=%s status=%s\n",
+		run.diagnostics.CoverageInvocation.WallSeconds,
+		run.diagnostics.CoverageInvocation.CompilerCommands,
+		run.diagnostics.CoverageInvocation.LinkerCommands,
+		run.diagnostics.CoverageInvocation.BuildActions,
+		run.diagnostics.CoverageInvocation.CacheReuse,
+		run.diagnostics.CoverageInvocation.CommandResult,
 		run.diagnostics.Status,
 	)
-	return nil
+	return errors.Join(run.initialWriteErr, run.identityErr, traceErr, writeErr, summaryErr)
 }
 
 func writeCoverageBuildDiagnostics(path string, diagnostics coverageBuildDiagnosticsJSON) error {

--- a/cmd/gocoveragecheck/coverage_build_diagnostics_test.go
+++ b/cmd/gocoveragecheck/coverage_build_diagnostics_test.go
@@ -37,6 +37,23 @@ func TestParseCoverageBuildTraceAcceptsZeroActionTrace(t *testing.T) {
 	}
 }
 
+func TestParseCoverageBuildTraceAcceptsJSONBuildOutput(t *testing.T) {
+	trace := strings.Join([]string{
+		`{"Action":"build-output","Output":"WORK=/tmp/go-build\n"}`,
+		`{"Action":"build-output","Output":"mkdir -p $WORK/b001/\n"}`,
+		`{"Action":"build-output","Output":"\"/go/pkg/tool/linux_amd64/compile\" -o \"$WORK/b001/_pkg_.a\"\n"}`,
+		`{"Action":"build-output","Output":"\"/go/pkg/tool/linux_amd64/link\" -o \"$WORK/b001/example.test\"\n"}`,
+	}, "\n")
+
+	got, err := parseCoverageBuildTrace(trace)
+	if err != nil {
+		t.Fatalf("parseCoverageBuildTrace() error = %v", err)
+	}
+	if !got.classifiable || got.compilerCommands != 1 || got.linkerCommands != 1 || got.buildActions != 2 {
+		t.Fatalf("JSON trace summary = %+v, want one compiler, one linker, and two build actions", got)
+	}
+}
+
 func TestParseCoverageBuildTraceRejectsUnclassifiableTrace(t *testing.T) {
 	_, err := parseCoverageBuildTrace("compiler output without go test -x markers")
 	if err == nil || !strings.Contains(err.Error(), "unclassifiable go test -x trace") {

--- a/cmd/gocoveragecheck/coverage_build_diagnostics_test.go
+++ b/cmd/gocoveragecheck/coverage_build_diagnostics_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func TestParseCoverageBuildTraceCountsCompilerAndLinkerActions(t *testing.T) {
-	t.Parallel()
-
 	trace := strings.Join([]string{
 		"WORK=/tmp/go-build",
 		"mkdir -p $WORK/b001/",
@@ -20,118 +18,59 @@ func TestParseCoverageBuildTraceCountsCompilerAndLinkerActions(t *testing.T) {
 		`"/go/pkg/tool/linux_amd64/link" -o "$WORK/b001/example.test"`,
 	}, "\n")
 
-	got, err := parseCoverageBuildTrace(trace, 4)
+	got, err := parseCoverageBuildTrace(trace)
 	if err != nil {
 		t.Fatalf("parseCoverageBuildTrace() error = %v", err)
 	}
-	if got.CompilerCommands != 1 || got.LinkerCommands != 1 {
-		t.Fatalf("action counts = %+v, want one compiler and linker action", got)
-	}
-	if got.Misses != 2 || got.InferredHits != 2 || got.ExpectedPackages != 4 {
-		t.Fatalf("cache inference = %+v, want misses=2 inferredHits=2 expectedPackages=4", got)
+	if !got.classifiable || got.compilerCommands != 1 || got.linkerCommands != 1 || got.buildActions != 2 {
+		t.Fatalf("trace summary = %+v, want one compiler, one linker, and two build actions", got)
 	}
 }
 
-func TestParseCoverageBuildTraceAcceptsAllHitTrace(t *testing.T) {
-	t.Parallel()
-
-	got, err := parseCoverageBuildTrace("WORK=/tmp/go-build\nmkdir -p $WORK/b001/\n", 3)
+func TestParseCoverageBuildTraceAcceptsZeroActionTrace(t *testing.T) {
+	got, err := parseCoverageBuildTrace("WORK=/tmp/go-build\nmkdir -p $WORK/b001/\n")
 	if err != nil {
-		t.Fatalf("parseCoverageBuildTrace() error = %v, want cached trace to be classifiable", err)
+		t.Fatalf("parseCoverageBuildTrace() error = %v, want classifiable zero-action trace", err)
 	}
-	if got.CompilerCommands != 0 || got.LinkerCommands != 0 || got.Misses != 0 || got.InferredHits != 3 {
-		t.Fatalf("cached trace summary = %+v, want all three actions inferred as hits", got)
+	if !got.classifiable || got.compilerCommands != 0 || got.linkerCommands != 0 || got.buildActions != 0 {
+		t.Fatalf("zero-action trace summary = %+v", got)
 	}
 }
 
 func TestParseCoverageBuildTraceRejectsUnclassifiableTrace(t *testing.T) {
-	t.Parallel()
-
-	_, err := parseCoverageBuildTrace("compiler output without go test -x markers", 1)
+	_, err := parseCoverageBuildTrace("compiler output without go test -x markers")
 	if err == nil || !strings.Contains(err.Error(), "unclassifiable go test -x trace") {
 		t.Fatalf("parseCoverageBuildTrace() error = %v, want unclassifiable trace diagnostic", err)
 	}
 }
 
-func TestBuildCoverageCompileProbeInvocationPreservesCoverageShape(t *testing.T) {
-	t.Parallel()
-
-	invocation, err := buildCoverageCompileProbeInvocation(commandInvocation{
-		name: "go",
-		args: []string{
-			"test",
-			"-coverpkg=github.com/example/project/pkg/...",
-			"-p=8",
-			"-short",
-			"-covermode=count",
-			"-timeout=10m",
-			"-json",
-			"-coverprofile=/tmp/coverage.out",
-			"-run=TestSubmit",
-			"./tests/functional/work",
-		},
-	}, filepath.Join(t.TempDir(), "compile-probe-bin"), nil)
-	if err != nil {
-		t.Fatalf("buildCoverageCompileProbeInvocation() error = %v", err)
+func TestAddCoverageBuildDiagnosticFlagsInstrumentsExactCoverageInvocation(t *testing.T) {
+	plan := diagnosticCoveragePlan()
+	if err := addCoverageBuildDiagnosticFlags(&plan); err != nil {
+		t.Fatalf("addCoverageBuildDiagnosticFlags() error = %v", err)
 	}
 
-	if got, want := invocation.args[:5], []string{"test", "-c", "-o", invocation.args[3], "-x"}; !slicesEqual(got, want) {
-		t.Fatalf("probe prefix = %v, want %v", got, want)
+	if len(plan.invocations) != 1 {
+		t.Fatalf("invocation count = %d, want one", len(plan.invocations))
 	}
-	for _, forbidden := range []string{"-json", "-coverprofile=/tmp/coverage.out", "-count=1", "-parallel"} {
-		if slicesContains(invocation.args, forbidden) {
-			t.Fatalf("probe args = %v, must not contain %q", invocation.args, forbidden)
-		}
+	args := plan.invocations[0].args
+	if slicesContains(args, "-c") {
+		t.Fatalf("diagnostic args = %v, must not compile a probe", args)
 	}
-	for _, required := range []string{"-coverpkg=github.com/example/project/pkg/...", "-p=8", "-covermode=count", "-timeout=10m", "-run=TestSubmit", "./tests/functional/work"} {
-		if !slicesContains(invocation.args, required) {
-			t.Fatalf("probe args = %v, missing preserved argument %q", invocation.args, required)
-		}
+	if countArgs(args, "-x") != 1 || countArgs(args, "-json") != 1 {
+		t.Fatalf("diagnostic args = %v, want one -x and one -json", args)
+	}
+	if !helperHasArgPrefix(args, "-coverprofile=") || !slicesContains(args, "example/tests/functional/work") {
+		t.Fatalf("diagnostic args = %v, lost coverage profile or package selection", args)
+	}
+	if indexOf(args, "-x") > indexOf(args, "example/tests/functional/work") || indexOf(args, "-json") > indexOf(args, "example/tests/functional/work") {
+		t.Fatalf("diagnostic flags must precede package arguments: %v", args)
 	}
 }
 
-func TestBuildCoverageCompileProbeInvocationsSplitDuplicatePackageNames(t *testing.T) {
-	t.Parallel()
+func TestCoverageBuildDiagnosticRunWritesSchemaV2FromOneExactInvocation(t *testing.T) {
+	setActionCacheIdentity(t, "build-key", "build-key", "true")
 
-	probes, err := buildCoverageCompileProbeInvocations(commandInvocation{
-		name: "go",
-		args: []string{
-			"test",
-			"-run=TestSubmit",
-			"-coverprofile=coverage.out",
-			"-json",
-			"github.com/example/recordings/process",
-			"github.com/example/transport/process",
-			"github.com/example/transport/stdio",
-		},
-	}, filepath.Join(t.TempDir(), "compile-probe-bin"))
-	if err != nil {
-		t.Fatalf("buildCoverageCompileProbeInvocations() error = %v", err)
-	}
-	if len(probes) != 2 {
-		t.Fatalf("probe count = %d, want two unique-basename groups", len(probes))
-	}
-
-	for _, probe := range probes {
-		processCount := 0
-		for _, packagePath := range []string{
-			"github.com/example/recordings/process",
-			"github.com/example/transport/process",
-		} {
-			if slicesContains(probe.args, packagePath) {
-				processCount++
-			}
-		}
-		if processCount > 1 {
-			t.Fatalf("probe args = %v, duplicate process basenames remain in one command", probe.args)
-		}
-	}
-	if !slicesContains(probes[0].args, "github.com/example/transport/stdio") {
-		t.Fatalf("first probe args = %v, distinct basename was not packed with the first group", probes[0].args)
-	}
-}
-
-func TestCoverageBuildDiagnosticRunWritesCompleteSummaryAndCleansBinaries(t *testing.T) {
 	originalRunner := commandRunner
 	originalStdout := stdoutWriter
 	originalStderr := stderrWriter
@@ -146,38 +85,21 @@ func TestCoverageBuildDiagnosticRunWritesCompleteSummaryAndCleansBinaries(t *tes
 	stdoutWriter = &stdout
 	stderrWriter = &stderr
 	var invocations []commandInvocation
-	var probeDir string
 	commandRunner = func(invocation commandInvocation) (string, string, error) {
 		invocations = append(invocations, invocation)
 		if slicesContains(invocation.args, "-c") {
-			probeDir = argumentAfter(invocation.args, "-o")
-			if err := os.WriteFile(filepath.Join(probeDir, "fake.test"), []byte("binary"), 0o600); err != nil {
-				return "", "", err
-			}
-			return strings.Join([]string{
-				"WORK=/tmp/go-build",
-				"mkdir -p $WORK/b001/",
-				`"/go/pkg/tool/linux_amd64/compile" -o "$WORK/b001/_pkg_.a" -p example.test`,
-				`"/go/pkg/tool/linux_amd64/link" -o "$WORK/b001/example.test"`,
-			}, "\n"), "", nil
+			return "", "", errors.New("compile probe must not run")
 		}
-		if !helperHasArgPrefix(invocation.args, "-coverprofile=") {
-			return "", "", errors.New("unexpected coverage test invocation")
+		if countArgs(invocation.args, "-x") != 1 || countArgs(invocation.args, "-json") != 1 {
+			return "", "", errors.New("diagnostics must instrument the coverage command")
 		}
-		return "coverage test ran once\n", "", nil
+		return "coverage test ran once\n", "WORK=/tmp/go-build\nmkdir -p $WORK/b001/\n", nil
 	}
 
 	diagnosticPath := filepath.Join(t.TempDir(), "coverage-build-diagnostics.json")
-	plan := coverageInvocationPlan{
-		invocations: []commandInvocation{{
-			name: "go",
-			args: []string{"test", "-coverpkg=example/pkg/...", "-coverprofile=coverage.out", "example/tests/functional/work"},
-		}},
-		cleanup: func() error { return nil },
-	}
 	if err := executeCoverageInvocationPlan(
 		config{coverageBuildDiagnosticsOutput: diagnosticPath},
-		plan,
+		diagnosticCoveragePlan(),
 		[]string{"example/tests/functional/work"},
 		filepath.Join(t.TempDir(), "coverage.out"),
 		".",
@@ -188,125 +110,148 @@ func TestCoverageBuildDiagnosticRunWritesCompleteSummaryAndCleansBinaries(t *tes
 		t.Fatalf("executeCoverageInvocationPlan() error = %v", err)
 	}
 
-	if len(invocations) != 2 {
-		t.Fatalf("go invocations = %d, want one compile probe and one test run", len(invocations))
+	if len(invocations) != 1 {
+		t.Fatalf("go invocations = %d, want one authoritative coverage invocation", len(invocations))
 	}
-	if _, err := os.Stat(probeDir); !os.IsNotExist(err) {
-		t.Fatalf("compile probe directory still exists, stat error = %v", err)
-	}
-	diagnostics := readCoverageBuildDiagnostics(t, diagnosticPath)
+	diagnostics, raw := readCoverageBuildDiagnostics(t, diagnosticPath)
 	if diagnostics.Status != coverageBuildDiagnosticsStatusComplete {
 		t.Fatalf("diagnostic status = %q, want complete", diagnostics.Status)
 	}
-	if diagnostics.SchemaVersion != coverageBuildDiagnosticsSchemaVersion || diagnostics.GoVersion == "" || !strings.HasPrefix(diagnostics.CoverageInvocationHash, "sha256:") {
-		t.Fatalf("diagnostic identity = %+v, want version, Go version, and sha256 hash", diagnostics)
+	if diagnostics.SchemaVersion != 2 || diagnostics.GoVersion == "" || !strings.HasPrefix(diagnostics.CoverageInvocationHash, "sha256:") {
+		t.Fatalf("diagnostic identity = %+v, want schema v2, Go version, and invocation hash", diagnostics)
 	}
-	if diagnostics.CompileProbe.ExpectedPackages != 1 || diagnostics.CompileProbe.CompilerCommands != 1 || diagnostics.CompileProbe.LinkerCommands != 1 || diagnostics.CompileProbe.Misses != 2 {
-		t.Fatalf("compile probe summary = %+v, want observed command counts", diagnostics.CompileProbe)
+	if diagnostics.ActionCache.PrimaryKey != "build-key" || diagnostics.ActionCache.MatchedKey != "build-key" || !diagnostics.ActionCache.ExactPrimaryHit {
+		t.Fatalf("action-cache identity = %+v, want an exact primary hit", diagnostics.ActionCache)
 	}
-	if diagnostics.CompileProbe.WallSeconds < 0 || diagnostics.TestRunWallSeconds < 0 || diagnostics.TotalMeasuredSeconds < diagnostics.TestRunWallSeconds {
-		t.Fatalf("diagnostic timings = %+v, want non-negative sequential measurements", diagnostics)
+	invocation := diagnostics.CoverageInvocation
+	if invocation.ExpectedPackages != 1 || invocation.CompilerCommands != 0 || invocation.LinkerCommands != 0 || invocation.BuildActions != 0 {
+		t.Fatalf("coverage invocation summary = %+v, want one zero-action invocation", invocation)
 	}
-	if !strings.Contains(stdout.String(), "Coverage build diagnostic:") || stderr.Len() != 0 {
+	if invocation.CacheReuse != coverageBuildCacheReuseExactInvocationHit || invocation.CommandResult != coverageBuildCommandResultPassed {
+		t.Fatalf("coverage invocation classification = %+v, want exact hit and passed", invocation)
+	}
+	if invocation.WallSeconds < 0 || diagnostics.TotalMeasuredSeconds != invocation.WallSeconds {
+		t.Fatalf("diagnostic timing = %+v, want one authoritative wall measurement", diagnostics)
+	}
+	for _, forbidden := range []string{"compileProbe", "inferredHits", "misses", "testRunWallSeconds"} {
+		if strings.Contains(raw, forbidden) {
+			t.Fatalf("schema-v2 diagnostic retains removed field %q: %s", forbidden, raw)
+		}
+	}
+	if !strings.Contains(stdout.String(), "cache-reuse=exact-invocation-hit") || stderr.Len() != 0 {
 		t.Fatalf("diagnostic streams = stdout %q stderr %q, want concise stdout evidence only", stdout.String(), stderr.String())
 	}
 }
 
-func TestCoverageBuildDiagnosticFailureStopsTestAndWritesFailedSummary(t *testing.T) {
+func TestCoverageBuildDiagnosticReportsObservedCompileWorkWithoutInferredHits(t *testing.T) {
+	setActionCacheIdentity(t, "build-key", "older-key", "false")
+
 	originalRunner := commandRunner
 	t.Cleanup(func() { commandRunner = originalRunner })
-
-	callCount := 0
-	var probeDir string
 	commandRunner = func(invocation commandInvocation) (string, string, error) {
-		callCount++
-		if !slicesContains(invocation.args, "-c") {
-			return "", "", errors.New("coverage test must not start after probe failure")
-		}
-		probeDir = argumentAfter(invocation.args, "-o")
-		return "WORK=/tmp/go-build\nmkdir -p $WORK/b001/\n", "original compiler failure", errors.New("exit status 2")
+		return "coverage test ran once\n", strings.Join([]string{
+			"WORK=/tmp/go-build",
+			"mkdir -p $WORK/b001/",
+			`"/go/pkg/tool/linux_amd64/compile" -o "$WORK/b001/_pkg_.a" -p example.test`,
+			`"/go/pkg/tool/linux_amd64/link" -o "$WORK/b001/example.test"`,
+		}, "\n"), nil
 	}
 
 	diagnosticPath := filepath.Join(t.TempDir(), "coverage-build-diagnostics.json")
-	plan := coverageInvocationPlan{
-		invocations: []commandInvocation{{
-			name: "go",
-			args: []string{"test", "-coverpkg=example/pkg/...", "-coverprofile=coverage.out", "example/tests/functional/work"},
-		}},
-		cleanup: func() error { return nil },
+	if err := executeCoverageInvocationPlan(config{coverageBuildDiagnosticsOutput: diagnosticPath}, diagnosticCoveragePlan(), []string{"example/tests/functional/work"}, "coverage.out", ".", nil, "run coverage", nil); err != nil {
+		t.Fatalf("executeCoverageInvocationPlan() error = %v", err)
 	}
-	err := executeCoverageInvocationPlan(
-		config{coverageBuildDiagnosticsOutput: diagnosticPath},
-		plan,
-		[]string{"example/tests/functional/work"},
-		"coverage.out",
-		".",
-		nil,
-		"run coverage",
-		nil,
-	)
-	if err == nil || !strings.Contains(err.Error(), "original compiler failure") {
-		t.Fatalf("executeCoverageInvocationPlan() error = %v, want original compiler failure", err)
+	diagnostics, raw := readCoverageBuildDiagnostics(t, diagnosticPath)
+	if diagnostics.CoverageInvocation.CompilerCommands != 1 || diagnostics.CoverageInvocation.LinkerCommands != 1 || diagnostics.CoverageInvocation.BuildActions != 2 {
+		t.Fatalf("coverage invocation summary = %+v, want observed compiler/linker actions", diagnostics.CoverageInvocation)
 	}
-	if callCount != 1 {
-		t.Fatalf("go invocation count = %d, want probe only", callCount)
+	if diagnostics.CoverageInvocation.CacheReuse != coverageBuildCacheReuseCompileWorkObserved {
+		t.Fatalf("cache reuse = %q, want compile-work-observed", diagnostics.CoverageInvocation.CacheReuse)
 	}
-	if _, err := os.Stat(probeDir); !os.IsNotExist(err) {
-		t.Fatalf("failed compile probe directory still exists, stat error = %v", err)
-	}
-	diagnostics := readCoverageBuildDiagnostics(t, diagnosticPath)
-	if diagnostics.Status != coverageBuildDiagnosticsStatusFailed {
-		t.Fatalf("diagnostic status = %q, want failed", diagnostics.Status)
-	}
-	if diagnostics.TestRunWallSeconds != 0 || diagnostics.TotalMeasuredSeconds != diagnostics.CompileProbe.WallSeconds {
-		t.Fatalf("failed diagnostic timings = %+v, want no test timing and compile-only total", diagnostics)
+	if strings.Contains(raw, "inferredHits") || strings.Contains(raw, "misses") {
+		t.Fatalf("diagnostic contains inferred cache arithmetic: %s", raw)
 	}
 }
 
-func TestCoverageBuildDiagnosticUnclassifiableTraceStopsTest(t *testing.T) {
+func TestCoverageBuildDiagnosticFailureDoesNotClaimExactReuse(t *testing.T) {
+	setActionCacheIdentity(t, "build-key", "build-key", "true")
+
 	originalRunner := commandRunner
 	t.Cleanup(func() { commandRunner = originalRunner })
-
-	callCount := 0
 	commandRunner = func(invocation commandInvocation) (string, string, error) {
-		callCount++
-		if !slicesContains(invocation.args, "-c") {
-			return "", "", errors.New("coverage test must not start after an unclassifiable probe")
-		}
-		return "WORK=/tmp/go-build\n", "", nil
+		return "WORK=/tmp/go-build\nmkdir -p $WORK/b001/\n", "original test failure", errors.New("exit status 1")
 	}
 
 	diagnosticPath := filepath.Join(t.TempDir(), "coverage-build-diagnostics.json")
-	plan := coverageInvocationPlan{
-		invocations: []commandInvocation{{
-			name: "go",
-			args: []string{"test", "-coverpkg=example/pkg/...", "-coverprofile=coverage.out", "example/tests/functional/work"},
-		}},
-		cleanup: func() error { return nil },
+	err := executeCoverageInvocationPlan(config{coverageBuildDiagnosticsOutput: diagnosticPath}, diagnosticCoveragePlan(), []string{"example/tests/functional/work"}, "coverage.out", ".", nil, "run coverage", nil)
+	if err == nil || !strings.Contains(err.Error(), "original test failure") {
+		t.Fatalf("executeCoverageInvocationPlan() error = %v, want original test failure", err)
 	}
-	err := executeCoverageInvocationPlan(
-		config{coverageBuildDiagnosticsOutput: diagnosticPath},
-		plan,
-		[]string{"example/tests/functional/work"},
-		"coverage.out",
-		".",
-		nil,
-		"run coverage",
-		nil,
-	)
+	diagnostics, _ := readCoverageBuildDiagnostics(t, diagnosticPath)
+	if diagnostics.Status != coverageBuildDiagnosticsStatusFailed || diagnostics.CoverageInvocation.CommandResult != coverageBuildCommandResultFailed {
+		t.Fatalf("failed diagnostic = %+v, want failed command and artifact", diagnostics)
+	}
+	if diagnostics.CoverageInvocation.CacheReuse == coverageBuildCacheReuseExactInvocationHit {
+		t.Fatalf("failed diagnostic claimed exact reuse: %+v", diagnostics.CoverageInvocation)
+	}
+}
+
+func TestCoverageBuildDiagnosticMalformedIdentityIsFailClosed(t *testing.T) {
+	setActionCacheIdentity(t, "build-key", "different-key", "true")
+
+	originalRunner := commandRunner
+	t.Cleanup(func() { commandRunner = originalRunner })
+	commandRunner = func(invocation commandInvocation) (string, string, error) {
+		return "WORK=/tmp/go-build\nmkdir -p $WORK/b001/\n", "", nil
+	}
+
+	diagnosticPath := filepath.Join(t.TempDir(), "coverage-build-diagnostics.json")
+	err := executeCoverageInvocationPlan(config{coverageBuildDiagnosticsOutput: diagnosticPath}, diagnosticCoveragePlan(), []string{"example/tests/functional/work"}, "coverage.out", ".", nil, "run coverage", nil)
+	if err == nil || !strings.Contains(err.Error(), "exact cache hit identity is inconsistent") {
+		t.Fatalf("executeCoverageInvocationPlan() error = %v, want invalid identity", err)
+	}
+	diagnostics, _ := readCoverageBuildDiagnostics(t, diagnosticPath)
+	if diagnostics.ActionCache.ExactPrimaryHit || diagnostics.CoverageInvocation.CacheReuse == coverageBuildCacheReuseExactInvocationHit {
+		t.Fatalf("malformed identity produced exact reuse: %+v / %+v", diagnostics.ActionCache, diagnostics.CoverageInvocation)
+	}
+}
+
+func TestCoverageBuildDiagnosticUnclassifiableTraceIsFailClosed(t *testing.T) {
+	originalRunner := commandRunner
+	t.Cleanup(func() { commandRunner = originalRunner })
+	commandRunner = func(invocation commandInvocation) (string, string, error) {
+		return "coverage test ran once\n", "", nil
+	}
+
+	diagnosticPath := filepath.Join(t.TempDir(), "coverage-build-diagnostics.json")
+	err := executeCoverageInvocationPlan(config{coverageBuildDiagnosticsOutput: diagnosticPath}, diagnosticCoveragePlan(), []string{"example/tests/functional/work"}, "coverage.out", ".", nil, "run coverage", nil)
 	if err == nil || !strings.Contains(err.Error(), "unclassifiable go test -x trace") {
 		t.Fatalf("executeCoverageInvocationPlan() error = %v, want unclassifiable trace diagnostic", err)
 	}
-	if callCount != 1 {
-		t.Fatalf("go invocation count = %d, want probe only", callCount)
-	}
-	diagnostics := readCoverageBuildDiagnostics(t, diagnosticPath)
-	if diagnostics.Status != coverageBuildDiagnosticsStatusFailed {
-		t.Fatalf("diagnostic status = %q, want failed", diagnostics.Status)
+	diagnostics, _ := readCoverageBuildDiagnostics(t, diagnosticPath)
+	if diagnostics.Status != coverageBuildDiagnosticsStatusFailed || diagnostics.CoverageInvocation.CacheReuse == coverageBuildCacheReuseExactInvocationHit {
+		t.Fatalf("unclassifiable diagnostic = %+v, want failed non-exact result", diagnostics)
 	}
 }
 
-func TestCoverageBuildDiagnosticDisabledPreservesSingleTestInvocation(t *testing.T) {
+func TestCoverageBuildDiagnosticWriterFailurePreservesCoverageFailure(t *testing.T) {
+	originalRunner := commandRunner
+	t.Cleanup(func() { commandRunner = originalRunner })
+	commandRunner = func(invocation commandInvocation) (string, string, error) {
+		return "WORK=/tmp/go-build\nmkdir -p $WORK/b001/\n", "original coverage failure", errors.New("exit status 2")
+	}
+
+	outputDirectory := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outputDirectory, "child"), []byte("keep"), 0o600); err != nil {
+		t.Fatalf("prepare diagnostic output directory: %v", err)
+	}
+	err := executeCoverageInvocationPlan(config{coverageBuildDiagnosticsOutput: outputDirectory}, diagnosticCoveragePlan(), []string{"example/tests/functional/work"}, "coverage.out", ".", nil, "run coverage", nil)
+	if err == nil || !strings.Contains(err.Error(), "original coverage failure") || !strings.Contains(err.Error(), "write coverage build diagnostics json") {
+		t.Fatalf("executeCoverageInvocationPlan() error = %v, want coverage and writer failures", err)
+	}
+}
+
+func TestCoverageBuildDiagnosticDisabledPreservesSingleUntracedInvocation(t *testing.T) {
 	originalRunner := commandRunner
 	t.Cleanup(func() { commandRunner = originalRunner })
 
@@ -315,24 +260,41 @@ func TestCoverageBuildDiagnosticDisabledPreservesSingleTestInvocation(t *testing
 		invocations = append(invocations, invocation)
 		return "", "", nil
 	}
-	plan := coverageInvocationPlan{
-		invocations: []commandInvocation{{
-			name: "go",
-			args: []string{"test", "-coverpkg=example/pkg/...", "-coverprofile=coverage.out", "example/tests/functional/work"},
-		}},
-		cleanup: func() error { return nil },
-	}
-	if err := executeCoverageInvocationPlan(config{}, plan, []string{"example/tests/functional/work"}, "coverage.out", ".", nil, "run coverage", nil); err != nil {
+	diagnosticPath := filepath.Join(t.TempDir(), "coverage-build-diagnostics.json")
+	if err := executeCoverageInvocationPlan(config{}, diagnosticCoveragePlan(), []string{"example/tests/functional/work"}, "coverage.out", ".", nil, "run coverage", nil); err != nil {
 		t.Fatalf("executeCoverageInvocationPlan() error = %v", err)
 	}
-	if len(invocations) != 1 || slicesContains(invocations[0].args, "-c") {
-		t.Fatalf("default diagnostic invocations = %+v, want one unchanged test invocation", invocations)
+	if len(invocations) != 1 || slicesContains(invocations[0].args, "-x") || slicesContains(invocations[0].args, "-json") || slicesContains(invocations[0].args, "-c") {
+		t.Fatalf("disabled diagnostic invocations = %+v, want one unchanged untraced invocation", invocations)
+	}
+	if _, err := os.Stat(diagnosticPath); !os.IsNotExist(err) {
+		t.Fatalf("disabled diagnostic file exists, stat error = %v", err)
+	}
+}
+
+func TestCoverageActionCacheIdentityAcceptsPrefixAndMissResults(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		matched string
+		hit     string
+	}{
+		{name: "prefix", matched: "older-key", hit: "false"},
+		{name: "miss", matched: "", hit: "false"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setActionCacheIdentity(t, "build-key", tc.matched, tc.hit)
+			identity, err := coverageActionCacheIdentityFromEnvironment()
+			if err != nil {
+				t.Fatalf("coverageActionCacheIdentityFromEnvironment() error = %v", err)
+			}
+			if !identity.configured || identity.primaryKey != "build-key" || identity.matchedKey != tc.matched || identity.exactPrimaryHit {
+				t.Fatalf("identity = %+v, want non-exact %s result", identity, tc.name)
+			}
+		})
 	}
 }
 
 func TestCoverageInvocationHashIgnoresProfilePath(t *testing.T) {
-	t.Parallel()
-
 	left := coverageInvocationPlan{invocations: []commandInvocation{{name: "go", args: []string{"test", "-coverprofile=/tmp/left.out", "./tests/functional"}}}}
 	right := coverageInvocationPlan{invocations: []commandInvocation{{name: "go", args: []string{"test", "-coverprofile=/tmp/right.out", "./tests/functional"}}}}
 	if coverageInvocationHash(left) != coverageInvocationHash(right) {
@@ -340,7 +302,24 @@ func TestCoverageInvocationHashIgnoresProfilePath(t *testing.T) {
 	}
 }
 
-func readCoverageBuildDiagnostics(t *testing.T, path string) coverageBuildDiagnosticsJSON {
+func diagnosticCoveragePlan() coverageInvocationPlan {
+	return coverageInvocationPlan{
+		invocations: []commandInvocation{{
+			name: "go",
+			args: []string{"test", "-coverpkg=example/pkg/...", "-coverprofile=coverage.out", "example/tests/functional/work"},
+		}},
+		cleanup: func() error { return nil },
+	}
+}
+
+func setActionCacheIdentity(t *testing.T, primary, matched, exact string) {
+	t.Helper()
+	t.Setenv(coverageBuildActionCachePrimaryKeyEnv, primary)
+	t.Setenv(coverageBuildActionCacheMatchedKeyEnv, matched)
+	t.Setenv(coverageBuildActionCacheExactHitEnv, exact)
+}
+
+func readCoverageBuildDiagnostics(t *testing.T, path string) (coverageBuildDiagnosticsJSON, string) {
 	t.Helper()
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -350,26 +329,24 @@ func readCoverageBuildDiagnostics(t *testing.T, path string) coverageBuildDiagno
 	if err := json.Unmarshal(data, &diagnostics); err != nil {
 		t.Fatalf("decode coverage build diagnostics: %v", err)
 	}
-	return diagnostics
+	return diagnostics, string(data)
 }
 
-func argumentAfter(args []string, name string) string {
-	for index, arg := range args[:len(args)-1] {
-		if arg == name {
-			return args[index+1]
+func countArgs(args []string, wanted string) int {
+	count := 0
+	for _, arg := range args {
+		if arg == wanted {
+			count++
 		}
 	}
-	return ""
+	return count
 }
 
-func slicesEqual(left, right []string) bool {
-	if len(left) != len(right) {
-		return false
-	}
-	for index := range left {
-		if left[index] != right[index] {
-			return false
+func indexOf(args []string, wanted string) int {
+	for index, arg := range args {
+		if arg == wanted {
+			return index
 		}
 	}
-	return true
+	return len(args)
 }

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -332,9 +332,9 @@ func runGoTestCoverageLane(cfg config, commonArgs []string, testPackages []strin
 }
 
 func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, testPackages []string, profilePath string, repoRoot string, coverPackages []string, failurePrefix string, expectedFunctionalInventory *functionalTestInventory) error {
-	buildDiagnosticRun, probeErr := runCoverageBuildProbe(cfg, plan, testPackages)
-	if probeErr != nil {
-		return errors.Join(probeErr, plan.cleanup())
+	buildDiagnosticRun, diagnosticSetupErr := prepareCoverageBuildDiagnostic(cfg, &plan, testPackages)
+	if diagnosticSetupErr != nil {
+		return errors.Join(diagnosticSetupErr, plan.cleanup())
 	}
 
 	started := time.Now()
@@ -345,6 +345,8 @@ func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, test
 	var stdout strings.Builder
 	var stderr strings.Builder
 	var laneErr error
+	var coverageCommandErr error
+	var coverageBuildTrace strings.Builder
 	succeeded := make([]bool, len(plan.invocations))
 	testFailureObserved := false
 	failedTestCount := 0
@@ -352,8 +354,12 @@ func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, test
 	for index, invocation := range plan.invocations {
 		batchStdout, batchStderr, commandErr := runCommand(invocation)
 		commandErr = errors.Join(commandErr, flushFunctionalStreamWriter(invocation.stdoutWriter))
+		if buildDiagnosticRun != nil {
+			appendCoverageBuildTrace(&coverageBuildTrace, batchStdout, batchStderr)
+		}
 		appendCoverageOutput(&stdout, batchStdout)
 		appendCoverageOutput(&stderr, batchStderr)
+		coverageCommandErr = errors.Join(coverageCommandErr, commandErr)
 		if commandErr == nil {
 			succeeded[index] = true
 			continue
@@ -383,6 +389,8 @@ func executeCoverageInvocationPlan(cfg config, plan coverageInvocationPlan, test
 			buildDiagnosticRun,
 			strings.TrimSpace(cfg.coverageBuildDiagnosticsOutput),
 			wallSeconds,
+			coverageBuildTrace.String(),
+			coverageCommandErr,
 		)
 	}
 
@@ -689,7 +697,7 @@ func configureCoverageInvocationObservation(plan *coverageInvocationPlan, observ
 // by line, so its buffer is returned unchanged. The functional lane uses a
 // quiet streaming reporter and is rendered by coverageFailureDetail instead.
 func coverageFailureDetailStdout(cfg config, stdout string) string {
-	if cfg.stream || strings.TrimSpace(cfg.timingOutput) == "" {
+	if cfg.stream || (strings.TrimSpace(cfg.timingOutput) == "" && strings.TrimSpace(cfg.coverageBuildDiagnosticsOutput) == "") {
 		return stdout
 	}
 	return renderGoTestEventOutput(stdout)

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -241,7 +241,7 @@ func parseConfig() config {
 	flag.StringVar(&cfg.varianceAnnotations, "variance-annotations", "", "optional validated JSON annotations to append to a variance report")
 	flag.StringVar(&cfg.jsonOutput, "json-output", "", "optional path for a deterministic machine-readable coverage summary JSON document")
 	flag.StringVar(&cfg.timingOutput, "timing-output", "", "optional path for a deterministic machine-readable functional package timing summary JSON document, captured from the same go test run")
-	flag.StringVar(&cfg.coverageBuildDiagnosticsOutput, "coverage-build-diagnostics-output", "", "optional path for a coverage compile-probe cache diagnostic JSON document")
+	flag.StringVar(&cfg.coverageBuildDiagnosticsOutput, "coverage-build-diagnostics-output", "", "optional path for a coverage build-cache diagnostic JSON document")
 	flag.Float64Var(&cfg.min, "min", 0, "minimum total statement coverage percentage")
 	flag.StringVar(&cfg.packageBaseline, "package-baseline", "", "newline-delimited list of backend packages temporarily exempt from the per-package minimum coverage gate; defaults by suite")
 	flag.Float64Var(&cfg.packageMin, "package-min", defaultPackageCoverageMin, "minimum statement coverage required for each non-baselined backend package")

--- a/scripts/ci/functional-coverage-workflow.test.mjs
+++ b/scripts/ci/functional-coverage-workflow.test.mjs
@@ -88,11 +88,18 @@ test("functional coverage forwards restore identity and saves only non-exact bui
 					name +
 					": ${{ steps.functional-go-build-cache.outputs." +
 					output +
+					(name === "EXACT_HIT" ? " || 'false'" : "") +
 					" }}",
 			),
 			`${name} restore identity is not forwarded to the coverage step`,
 		);
 	}
+	assert.ok(
+		supervisor.includes(
+			"FUNCTIONAL_COVERAGE_ACTION_CACHE_EXACT_HIT: ${{ steps.functional-go-build-cache.outputs.cache-hit || 'false' }}",
+		),
+		"a cache miss must reach diagnostics as an explicit false exact-hit value",
+	);
 
 	assert.match(save, /if: always\(\) && matrix\.suite == 'functional' && steps\.functional-go-build-cache\.outputs\.cache-hit != 'true'/);
 	assert.match(save, /uses: actions\/cache\/save@v4/);

--- a/scripts/ci/functional-coverage-workflow.test.mjs
+++ b/scripts/ci/functional-coverage-workflow.test.mjs
@@ -20,12 +20,14 @@ function stepSection(job, marker, nextMarker) {
 	return job.slice(start, end >= 0 ? end : job.length);
 }
 
-test("functional coverage uses an isolated cache while unit setup-go remains unchanged", () => {
+test("functional coverage separates module and source-sensitive build caches", () => {
 	const workflow = readFileSync(workflowPath, "utf8");
 	const job = jobSection(workflow, "backend-coverage");
 	const unitSetup = stepSection(job, "      - uses: actions/setup-go@v5\n        if: matrix.suite == 'unit'", "      - uses: actions/setup-go@v5");
-	const functionalSetup = stepSection(job, "      - uses: actions/setup-go@v5\n        if: matrix.suite == 'functional'", "      - name: Restore functional coverage Go cache");
-	const functionalCache = stepSection(job, "      - name: Restore functional coverage Go cache", "      - uses: actions/setup-node@v4");
+	const functionalSetup = stepSection(job, "      - uses: actions/setup-go@v5\n        if: matrix.suite == 'functional'", "      - name: Select functional runner parallelism");
+	const functionalParallelism = stepSection(job, "      - name: Select functional runner parallelism", "      - name: Restore functional Go module cache");
+	const moduleCache = stepSection(job, "      - name: Restore functional Go module cache", "      - name: Restore functional coverage Go build cache");
+	const buildCache = stepSection(job, "      - name: Restore functional coverage Go build cache", "      - uses: actions/setup-node@v4");
 
 	assert.match(unitSetup, /go-version: \$\{\{ env\.GO_VERSION \}\}/);
 	assert.match(unitSetup, /cache: true/);
@@ -33,22 +35,69 @@ test("functional coverage uses an isolated cache while unit setup-go remains unc
 
 	assert.match(functionalSetup, /go-version: \$\{\{ env\.GO_VERSION \}\}/);
 	assert.match(functionalSetup, /cache: false/);
-	assert.match(functionalCache, /if: matrix\.suite == 'functional'/);
-	assert.match(functionalCache, /id: functional-go-cache/);
-	assert.match(functionalCache, /uses: actions\/cache@v4/);
-	assert.match(functionalCache, /~\/go\/pkg\/mod/);
-	assert.match(functionalCache, /~\/\.cache\/go-build/);
+	assert.match(functionalParallelism, /functional_jobs=12/);
+	assert.match(functionalParallelism, /jobs=\$functional_jobs/);
+
+	assert.match(moduleCache, /if: matrix\.suite == 'functional'/);
+	assert.match(moduleCache, /id: functional-go-module-cache/);
+	assert.match(moduleCache, /uses: actions\/cache@v4/);
+	assert.match(moduleCache, /path: ~\/go\/pkg\/mod/);
+	assert.doesNotMatch(moduleCache, /~\/\.cache\/go-build/);
 	assert.match(
-		functionalCache,
-		/key: functional-coverage-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-go-\$\{\{ env\.GO_VERSION \}\}-\$\{\{ hashFiles\('go\.sum'\) \}\}/,
+		moduleCache,
+		/key: functional-modules-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-go-\$\{\{ env\.GO_VERSION \}\}-\$\{\{ hashFiles\('go\.sum'\) \}\}/,
+	);
+
+	assert.match(buildCache, /if: matrix\.suite == 'functional'/);
+	assert.match(buildCache, /id: functional-go-build-cache/);
+	assert.match(buildCache, /uses: actions\/cache\/restore@v4/);
+	assert.match(buildCache, /path: ~\/\.cache\/go-build/);
+	assert.doesNotMatch(buildCache, /~\/go\/pkg\/mod/);
+	assert.match(
+		buildCache,
+		/key: functional-coverage-build-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-go-\$\{\{ env\.GO_VERSION \}\}-jobs-\$\{\{ steps\.functional-parallelism\.outputs\.jobs \}\}-\$\{\{ hashFiles\('\.github\/workflows\/ci\.yml', 'Makefile', 'go\.mod', 'go\.sum', 'cmd\/\*\*\/\*\.go', 'internal\/\*\*\/\*\.go', 'pkg\/\*\*\/\*\.go', 'tests\/functional\/\*\*\/\*\.go', 'tests\/functional\/functional-quarantine\.json', 'docs\/internal\/baselines\/go-functional-coverage-package-minimums\.json'\) \}\}/,
 	);
 	assert.ok(
-		functionalCache.includes(
-			"restore-keys: |\n            functional-coverage-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-\n",
+		buildCache.includes(
+			"restore-keys: |\n            functional-coverage-build-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-jobs-${{ steps.functional-parallelism.outputs.jobs }}-\n",
 		),
-		"functional cache restore key must stay in the functional namespace",
+		"functional build cache restore key must retain jobs and the functional build namespace",
 	);
 	assert.equal((job.match(/uses: actions\/cache@v4/g) ?? []).length, 1);
+	assert.equal((job.match(/uses: actions\/cache\/restore@v4/g) ?? []).length, 1);
+	assert.equal((job.match(/uses: actions\/cache\/save@v4/g) ?? []).length, 1);
+	assert.doesNotMatch(job, /functional-coverage-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-go-\$\{\{ env\.GO_VERSION \}\}-\$\{\{ hashFiles\('go\.sum'\) \}\}/);
+});
+
+test("functional coverage forwards restore identity and saves only non-exact build restores", () => {
+	const workflow = readFileSync(workflowPath, "utf8");
+	const job = jobSection(workflow, "backend-coverage");
+	const supervisorMarker = "      - name: Run Linux functional coverage with concurrent quarantine verification";
+	const saveMarker = "      - name: Save functional coverage Go build cache";
+	const supervisor = stepSection(job, supervisorMarker, saveMarker);
+	const save = stepSection(job, saveMarker, "      - name: Upload Linux quarantine package evidence");
+
+	for (const [name, output] of [
+		["PRIMARY_KEY", "cache-primary-key"],
+		["MATCHED_KEY", "cache-matched-key"],
+		["EXACT_HIT", "cache-hit"],
+	]) {
+		assert.ok(
+			supervisor.includes(
+				"FUNCTIONAL_COVERAGE_ACTION_CACHE_" +
+					name +
+					": ${{ steps.functional-go-build-cache.outputs." +
+					output +
+					" }}",
+			),
+			`${name} restore identity is not forwarded to the coverage step`,
+		);
+	}
+
+	assert.match(save, /if: always\(\) && matrix\.suite == 'functional' && steps\.functional-go-build-cache\.outputs\.cache-hit != 'true'/);
+	assert.match(save, /uses: actions\/cache\/save@v4/);
+	assert.match(save, /path: ~\/\.cache\/go-build/);
+	assert.match(save, /key: \$\{\{ steps\.functional-go-build-cache\.outputs\.cache-primary-key \}\}/);
 });
 
 test("functional coverage joins quarantine after concurrent execution and publishes both status paths", () => {


### PR DESCRIPTION
{
  "project": "c09-repair-functional-coverage-cache-critical-path-on-main",
  "branchName": "c09-repair-functional-coverage-cache-critical-path-on-main",
  "description": "Remove the duplicate functional coverage compile probe, make build-cache reuse evidence describe the exact coverage invocation, bind the hosted Go build cache to its authored inputs while preserving C13 jobs 12, and validate the first natural post-merge main run against the complete inventory and 329.4-second threshold.",
  "context": {
    "customerAsk": "Repair the functional coverage cache/compile path so a restored cache is demonstrably reused by the exact coverage invocation, or remove an avoidable cold/double compile from the critical path while retaining explicit diagnostics. Preserve the complete 149-package, 1,067-test inventory, coverage collection, package-floor evaluation, pinned real ACP evidence, fail-closed behavior, and jobs selection. Produce machine-readable evidence that distinguishes a true exact-invocation cache hit from a cold compile.",
    "sourcePlan": null,
    "problem": "At final c09 main commit 8182adba688abc185810fd11e2fbf264746ed29e, run 33264193119 restored 572,378,475 bytes from an exact broad cache key but still executed 359 compiler and 147 linker commands in a 181.502-second compile probe before a 304.519-second coverage invocation, producing a 486.021-second measured path.",
    "solution": "Trace the authoritative coverage invocation instead of running go test -c, replace invalid inferred-hit arithmetic with schema-v2 action-cache and executed-build evidence, split stable module caching from source-sensitive build caching, and use required PR CI plus the first natural post-merge main run for remote-real proof. Preserve the accepted C13 jobs-12 policy and every complete-suite gate."
  },
  "acceptanceCriteria": [
    "The implementation base and merged head contain C13 merge 848d1d3047; functional_jobs=12 remains unchanged and reaches the authoritative go test -p=12 invocation.",
    "Diagnostics-enabled coverage executes exactly one authoritative go test command and does not run go test -c or create compile-probe binaries.",
    "Schema v2 records action-cache primary, matched, and exact identity; invocation hash; compiler, linker, and build-action counts; cache classification; command result; and authoritative compile-plus-test wall without inferred-hit arithmetic.",
    "Exact invocation reuse is claimed only for a classifiable zero-action trace with consistent exact-cache identity; any executed build action is reported as compile work.",
    "Required PR CI shows directional compile-plus-test improvement from 486.021 seconds while preserving the complete functional gate; a non-improving result receives one bounded optimization pass.",
    "The first natural post-merge main run executes all 149 packages and 1,067 tests at jobs 12 and measures compile-plus-test at no more than 329.4 seconds.",
    "The same main run preserves coverage collection, package-floor evaluation, quarantine validation, pinned real ACP evidence, package/test failure attribution, critical-path timing, and fail-closed verdicts.",
    "All four formerly contention-failing packages appear and pass at jobs 12 in the first-main artifact.",
    "Failure behavior remains explicit for bad identity, cache miss or outage, save denial, compile or test failure, quarantine failure, timeout, partial completion, concurrency, cancellation, and recovery.",
    "Security and privacy remain unchanged: raw build traces, paths, source, payloads, credentials, and secrets are not retained; paid calls remain zero.",
    "GATE-DIAG is satisfied by go test ./cmd/gocoveragecheck -count=1 for exact-invocation diagnostics; GATE-WORKFLOW is satisfied by make test-ci-workflows, actionlint .github/workflows/ci.yml, and the named Node suites for cache, jobs, and supervisor wiring; GATE-PR is satisfied by the required PR Backend Functional Coverage run; GATE-MAIN is satisfied by the first natural post-merge main run.",
    "A clean-room validator reports through factory/docs/standards/validation-loopback-template.md, uses the first natural main run, does not rerun or repair, and requests a delta plan on FAIL or BLOCKED.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "behaviorLanes": [
    {
      "id": "BEH-C09-SINGLE-PASS",
      "behavior": "Backend Functional Coverage produces coverage, test outcomes, and truthful build-cache diagnostics from one authoritative invocation.",
      "actors": ["contributor", "reviewer", "GitHub Actions"],
      "success": "One jobs-12 coverage invocation emits the existing behavioral artifacts and schema-v2 build evidence without a compile probe.",
      "failure": "Malformed identity, unclassifiable trace, compilation, linking, or testing remains attributable and cannot produce a false reuse claim.",
      "gates": ["GATE-DIAG", "GATE-PR"]
    },
    {
      "id": "BEH-C09-CACHE-IDENTITY",
      "behavior": "The functional build cache has source-sensitive identity and reports exact, prefix, or missing restoration independently from Go build work.",
      "actors": ["GitHub Actions", "reviewer"],
      "success": "Cache identity and executed build actions agree or expose their disagreement, while module and build caches remain independently scoped.",
      "failure": "Cache miss, outage, or save denial cannot skip correctness gates or be mislabeled as exact invocation reuse.",
      "gates": ["GATE-WORKFLOW", "GATE-PR"]
    },
    {
      "id": "BEH-C09-POST-MERGE",
      "behavior": "The first natural post-merge main run preserves the complete jobs-12 gate and completes compile-plus-test within 329.4 seconds.",
      "actors": ["reviewer", "loopback validator", "GitHub Actions"],
      "success": "The merged main job runs 149 packages and 1,067 tests with all required gates and four contention rows green at or below 329.4 seconds.",
      "failure": "Missing, stale, contradictory, red, or slow evidence produces a read-only FAIL or BLOCKED report and delta-plan request without a rerun.",
      "gates": ["REVIEW-CI", "GATE-MAIN", "GATE-LOOPBACK"]
    }
  ],
  "contractChanges": [
    {
      "name": "Functional cache identity and diagnostic environment",
      "authoredSource": ".github/workflows/ci.yml, jobs.backend-coverage.steps for the functional matrix cell",
      "format": "yaml",
      "classification": "compatible internal configuration change",
      "current": "steps:\n  - uses: actions/setup-go@v5\n    if: matrix.suite == 'functional'\n    with:\n      go-version: ${{ env.GO_VERSION }}\n      cache: false\n  - name: Restore functional coverage Go cache\n    if: matrix.suite == 'functional'\n    id: functional-go-cache\n    uses: actions/cache@v4\n    with:\n      path: |\n        ~/go/pkg/mod\n        ~/.cache/go-build\n      key: functional-coverage-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}\n      restore-keys: |\n        functional-coverage-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-\n  - uses: actions/setup-node@v4\n    if: matrix.suite == 'functional'\n    with:\n      node-version: ${{ env.NODE_VERSION }}\n  - name: Select functional runner parallelism\n    if: matrix.suite == 'functional'\n    id: functional-parallelism\n    shell: bash\n    run: |\n      runner_cpus=\"$(nproc 2>/dev/null || true)\"\n      functional_jobs=12\n      echo \"Functional CI runner: logical_cpus=${runner_cpus:-unknown} jobs=$functional_jobs\"\n      echo \"jobs=$functional_jobs\" >> \"$GITHUB_OUTPUT\"\n  - name: Run Linux functional coverage with concurrent quarantine verification\n    if: matrix.suite == 'functional'\n    timeout-minutes: 75\n    shell: bash\n    run: bash scripts/ci/run-functional-coverage-with-quarantine.sh\n    env:\n      FUNCTIONAL_DEFAULT_JOBS: ${{ steps.functional-parallelism.outputs.jobs }}\n      FUNCTIONAL_COVERAGE_BUILD_DIAGNOSTICS: .artifacts/functional-test-viz/coverage-build-diagnostics.json",
      "proposed": "steps:\n  - uses: actions/setup-go@v5\n    if: matrix.suite == 'functional'\n    with:\n      go-version: ${{ env.GO_VERSION }}\n      cache: false\n  - name: Select functional runner parallelism\n    if: matrix.suite == 'functional'\n    id: functional-parallelism\n    shell: bash\n    run: |\n      runner_cpus=\"$(nproc 2>/dev/null || true)\"\n      functional_jobs=12\n      echo \"Functional CI runner: logical_cpus=${runner_cpus:-unknown} jobs=$functional_jobs\"\n      echo \"jobs=$functional_jobs\" >> \"$GITHUB_OUTPUT\"\n  - name: Restore functional Go module cache\n    if: matrix.suite == 'functional'\n    id: functional-go-module-cache\n    uses: actions/cache@v4\n    with:\n      path: ~/go/pkg/mod\n      key: functional-modules-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}\n  - name: Restore functional coverage Go build cache\n    if: matrix.suite == 'functional'\n    id: functional-go-build-cache\n    uses: actions/cache/restore@v4\n    with:\n      path: ~/.cache/go-build\n      key: functional-coverage-build-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-jobs-${{ steps.functional-parallelism.outputs.jobs }}-${{ hashFiles('.github/workflows/ci.yml', 'Makefile', 'go.mod', 'go.sum', 'cmd/**/*.go', 'internal/**/*.go', 'pkg/**/*.go', 'tests/functional/**/*.go', 'tests/functional/functional-quarantine.json', 'docs/internal/baselines/go-functional-coverage-package-minimums.json') }}\n      restore-keys: |\n        functional-coverage-build-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-jobs-${{ steps.functional-parallelism.outputs.jobs }}-\n  - uses: actions/setup-node@v4\n    if: matrix.suite == 'functional'\n    with:\n      node-version: ${{ env.NODE_VERSION }}\n  - name: Run Linux functional coverage with concurrent quarantine verification\n    if: matrix.suite == 'functional'\n    timeout-minutes: 75\n    shell: bash\n    run: bash scripts/ci/run-functional-coverage-with-quarantine.sh\n    env:\n      FUNCTIONAL_DEFAULT_JOBS: ${{ steps.functional-parallelism.outputs.jobs }}\n      FUNCTIONAL_COVERAGE_BUILD_DIAGNOSTICS: .artifacts/functional-test-viz/coverage-build-diagnostics.json\n      FUNCTIONAL_COVERAGE_ACTION_CACHE_PRIMARY_KEY: ${{ steps.functional-go-build-cache.outputs.cache-primary-key }}\n      FUNCTIONAL_COVERAGE_ACTION_CACHE_MATCHED_KEY: ${{ steps.functional-go-build-cache.outputs.cache-matched-key }}\n      FUNCTIONAL_COVERAGE_ACTION_CACHE_EXACT_HIT: ${{ steps.functional-go-build-cache.outputs.cache-hit }}\n  - name: Save functional coverage Go build cache\n    if: always() && matrix.suite == 'functional' && steps.functional-go-build-cache.outputs.cache-hit != 'true'\n    uses: actions/cache/save@v4\n    with:\n      path: ~/.cache/go-build\n      key: ${{ steps.functional-go-build-cache.outputs.cache-primary-key }}",
      "compatibility": "Jobs 12 is unchanged. The module cache remains go.sum-based; the Go build cache adds jobs and authored build-input identity. Prefix restores remain valid seeds but are not exact hits. Rollback restores the combined cache block without reverting C13.",
      "generatedOutputs": [],
      "consumers": ["GitHub Actions cache", "Backend Functional Coverage functional matrix cell", "cmd/gocoveragecheck diagnostic", "reviewers", "post-merge loopback"]
    },
    {
      "name": "Optional gocoveragecheck diagnostic execution",
      "authoredSource": "cmd/gocoveragecheck/main.go, coverage_invocation.go, and coverage_build_diagnostics.go",
      "format": "text",
      "classification": "breaking internal diagnostic semantic change under the existing flag",
      "current": "go run ./cmd/gocoveragecheck \\\n  -suite functional \\\n  -stream \\\n  -jobs 12 \\\n  -coverage-build-diagnostics-output .artifacts/functional-test-viz/coverage-build-diagnostics.json \\\n  -profile .artifacts/functional-test-viz/coverage.out \\\n  -timing-output .artifacts/functional-test-viz/functional-timing-summary.json \\\n  -short=false\n\ngo test -c -o .artifacts/functional-test-viz/compile-probe-bin/ -x <coverage flags> <selected packages>\ngo test <coverage flags> -json -coverprofile=<profile> <selected packages>",
      "proposed": "go run ./cmd/gocoveragecheck \\\n  -suite functional \\\n  -stream \\\n  -jobs 12 \\\n  -coverage-build-diagnostics-output .artifacts/functional-test-viz/coverage-build-diagnostics.json \\\n  -profile .artifacts/functional-test-viz/coverage.out \\\n  -timing-output .artifacts/functional-test-viz/functional-timing-summary.json \\\n  -short=false\n\ngo test -x <coverage flags> -json -coverprofile=<profile> <selected packages>",
      "compatibility": "The flag and output path remain stable. Enabled behavior changes from probe plus test to one traced coverage invocation; disabled behavior remains one untraced invocation. Raw traces are ephemeral, and unclassifiable traces cannot claim reuse.",
      "generatedOutputs": [],
      "consumers": ["cmd/functionaltestviz", "Backend Functional Coverage", "coverage timing and verdict writers"]
    },
    {
      "name": "Coverage-build diagnostic JSON v2",
      "authoredSource": "cmd/gocoveragecheck/coverage_build_diagnostics.go",
      "format": "json",
      "classification": "versioned breaking internal diagnostic artifact change",
      "current": "{\n  \"schemaVersion\": 1,\n  \"goVersion\": \"go1.25.0\",\n  \"coverageInvocationHash\": \"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\",\n  \"compileProbe\": {\n    \"wallSeconds\": 181.502,\n    \"expectedPackages\": 149,\n    \"compilerCommands\": 359,\n    \"linkerCommands\": 147,\n    \"inferredHits\": 0,\n    \"misses\": 506\n  },\n  \"testRunWallSeconds\": 304.519,\n  \"totalMeasuredSeconds\": 486.021,\n  \"status\": \"complete\"\n}",
      "proposed": "{\n  \"schemaVersion\": 2,\n  \"goVersion\": \"go1.25.0\",\n  \"coverageInvocationHash\": \"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\",\n  \"actionCache\": {\n    \"primaryKey\": \"functional-coverage-build-Linux-X64-go-1.25.0-jobs-12-0123456789abcdef\",\n    \"matchedKey\": \"functional-coverage-build-Linux-X64-go-1.25.0-jobs-12-fedcba9876543210\",\n    \"exactPrimaryHit\": false\n  },\n  \"coverageInvocation\": {\n    \"wallSeconds\": 304.519,\n    \"expectedPackages\": 149,\n    \"compilerCommands\": 359,\n    \"linkerCommands\": 147,\n    \"buildActions\": 506,\n    \"cacheReuse\": \"compile-work-observed\",\n    \"commandResult\": \"passed\"\n  },\n  \"totalMeasuredSeconds\": 304.519,\n  \"status\": \"complete\"\n}",
      "compatibility": "Schema version 2 removes compileProbe, inferredHits, misses, and testRunWallSeconds; replaces them with actionCache and exact coverageInvocation evidence; and defines totalMeasuredSeconds as the single authoritative invocation wall. Consumers must branch on schemaVersion.",
      "generatedOutputs": [],
      "consumers": ["functional-test-diagnostics artifact", "PR reviewer", "post-merge loopback"]
    }
  ],
  "userStories": [
    {
      "id": "c09-repair-functional-coverage-cache-critical-path-on-main-001",
      "title": "Produce truthful diagnostics from one coverage invocation",
      "description": "Replace the compile-probe-plus-test diagnostic with ephemeral tracing on the authoritative coverage invocation and write schema v2 from that exact command.",
      "parentBehavior": "BEH-C09-SINGLE-PASS",
      "outcome": "The existing diagnostic flag produces truthful action-cache and build-action evidence without launching go test -c, while coverage, timing, streaming, and failures retain their existing behavior.",
      "sourcePlanRef": null,
      "dependencies": [],
      "sharedSurfaceOwner": "This story exclusively owns cmd/gocoveragecheck diagnostic behavior and schema; C13 retains jobs policy and story 002 owns workflow cache configuration.",
      "scope": {
        "in": [
          "Replace probe tests with exact-invocation tests",
          "Add action-cache identity parsing and validation",
          "Write schema v2 and remove inferred-hit arithmetic",
          "Preserve timing, coverage, stream, and failure behavior",
          "Remove compile-probe construction, grouping, binaries, and cleanup"
        ],
        "out": [
          "Workflow cache changes",
          "Hosted CI",
          "Functional package tests or fixtures",
          "Jobs, floors, quarantine, ACP, or product contracts"
        ]
      },
      "contractChanges": [
        {
          "name": "Optional gocoveragecheck diagnostic execution",
          "authoredSource": "cmd/gocoveragecheck/main.go, coverage_invocation.go, and coverage_build_diagnostics.go",
          "format": "text",
          "classification": "breaking internal diagnostic semantic change under the existing flag",
          "current": "go run ./cmd/gocoveragecheck \\\n  -suite functional \\\n  -stream \\\n  -jobs 12 \\\n  -coverage-build-diagnostics-output .artifacts/functional-test-viz/coverage-build-diagnostics.json \\\n  -profile .artifacts/functional-test-viz/coverage.out \\\n  -timing-output .artifacts/functional-test-viz/functional-timing-summary.json \\\n  -short=false\n\ngo test -c -o .artifacts/functional-test-viz/compile-probe-bin/ -x <coverage flags> <selected packages>\ngo test <coverage flags> -json -coverprofile=<profile> <selected packages>",
          "proposed": "go run ./cmd/gocoveragecheck \\\n  -suite functional \\\n  -stream \\\n  -jobs 12 \\\n  -coverage-build-diagnostics-output .artifacts/functional-test-viz/coverage-build-diagnostics.json \\\n  -profile .artifacts/functional-test-viz/coverage.out \\\n  -timing-output .artifacts/functional-test-viz/functional-timing-summary.json \\\n  -short=false\n\ngo test -x <coverage flags> -json -coverprofile=<profile> <selected packages>",
          "compatibility": "The flag and output path remain stable; enabled execution becomes one traced coverage invocation, disabled execution remains unchanged, and raw trace is not retained.",
          "generatedOutputs": [],
          "consumers": ["cmd/functionaltestviz", "Backend Functional Coverage"]
        },
        {
          "name": "Coverage-build diagnostic JSON v2",
          "authoredSource": "cmd/gocoveragecheck/coverage_build_diagnostics.go",
          "format": "json",
          "classification": "versioned breaking internal diagnostic artifact change",
          "current": "{\n  \"schemaVersion\": 1,\n  \"goVersion\": \"go1.25.0\",\n  \"coverageInvocationHash\": \"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\",\n  \"compileProbe\": {\n    \"wallSeconds\": 181.502,\n    \"expectedPackages\": 149,\n    \"compilerCommands\": 359,\n    \"linkerCommands\": 147,\n    \"inferredHits\": 0,\n    \"misses\": 506\n  },\n  \"testRunWallSeconds\": 304.519,\n  \"totalMeasuredSeconds\": 486.021,\n  \"status\": \"complete\"\n}",
          "proposed": "{\n  \"schemaVersion\": 2,\n  \"goVersion\": \"go1.25.0\",\n  \"coverageInvocationHash\": \"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\",\n  \"actionCache\": {\n    \"primaryKey\": \"functional-coverage-build-Linux-X64-go-1.25.0-jobs-12-0123456789abcdef\",\n    \"matchedKey\": \"functional-coverage-build-Linux-X64-go-1.25.0-jobs-12-fedcba9876543210\",\n    \"exactPrimaryHit\": false\n  },\n  \"coverageInvocation\": {\n    \"wallSeconds\": 304.519,\n    \"expectedPackages\": 149,\n    \"compilerCommands\": 359,\n    \"linkerCommands\": 147,\n    \"buildActions\": 506,\n    \"cacheReuse\": \"compile-work-observed\",\n    \"commandResult\": \"passed\"\n  },\n  \"totalMeasuredSeconds\": 304.519,\n  \"status\": \"complete\"\n}",
          "compatibility": "Internal consumers must branch on schemaVersion; no generated or product consumer exists.",
          "generatedOutputs": [],
          "consumers": ["functional-test-diagnostics artifact", "reviewer", "loopback"]
        }
      ],
      "acceptanceCriteria": [
        "Given diagnostics enabled, when the runner executes, then exactly one coverage go test invocation contains -x, -json, and -coverprofile and produces the existing timing and coverage outputs.",
        "Given a classifiable zero-action trace with consistent exact-cache identity, when schema v2 is written, then cacheReuse is exact-invocation-hit and build actions are zero.",
        "Given any compiler or linker command, when schema v2 is written, then cacheReuse is compile-work-observed and no inferred hit is reported.",
        "Given a test failure, malformed cache identity, unclassifiable trace, or writer failure, when diagnostics finalize, then the original failure remains attributable and no false exact-hit status is emitted.",
        "Given diagnostics disabled, when coverage runs, then one unchanged untraced invocation runs and no diagnostic file is created.",
        "go test ./cmd/gocoveragecheck -count=1 passes and proves single invocation, classification, schema, failure, and default compatibility behavior."
      ],
      "verification": {
        "behavioralWitness": "A package test captures one real-shaped coverage invocation and decodes schema v2 with cache classification matching its trace.",
        "executableSpineEffect": "establish",
        "requiredEvidence": [
          {
            "scope": "unit/package integration",
            "dependencyFidelity": "controlled",
            "cadence": "per change",
            "cost": "free",
            "procedure": "Run go test ./cmd/gocoveragecheck -count=1.",
            "propertyProved": "Exact command shape, parser and classifier rules, one invocation, schema v2, failure preservation, and disabled compatibility.",
            "propertyNotProved": "GitHub cache identity, complete functional inventory, hosted timing, or ACP artifact behavior."
          }
        ],
        "highestFeasibleLevel": "Package integration with the production command planner and controlled command runner; hosted fidelity belongs to story 002.",
        "remainingUnprovenEdges": [
          {"edge": "Real cache restore and complete suite", "gateId": "GATE-PR"},
          {"edge": "Post-merge threshold", "gateId": "GATE-MAIN"}
        ]
      },
      "paidValidation": {
        "trigger": "Not applicable",
        "maximumCalls": 0,
        "maximumCost": "$0",
        "maximumDuration": "No paid duration",
        "fixtureAndOutputValidator": "Controlled command traces decoded against schema v2",
        "evidenceReuseKey": "Task head, cmd/gocoveragecheck package hash, and Go version"
      },
      "priority": "high",
      "passes": true,
      "notes": "Implemented the single traced authoritative coverage invocation and schema-v2 diagnostics with validated cache identity, observed build-action classification, fail-closed error handling, and unchanged disabled behavior. Verified with go test ./cmd/gocoveragecheck -count=1 (pass, 50.077s). Hosted cache/complete-suite evidence remains owned by stories 002 and 003."
    },
    {
      "id": "c09-repair-functional-coverage-cache-critical-path-on-main-002",
      "title": "Bind the build cache to its inputs and prove the PR critical path",
      "description": "Split module and build caching, make build identity source-sensitive, forward exact restore identity into schema v2, and prove the complete gate on required PR CI.",
      "parentBehavior": "BEH-C09-CACHE-IDENTITY",
      "outcome": "Required PR CI shows one complete jobs-12 coverage invocation with truthful cache evidence, preserved gates, and directional compile-plus-test improvement.",
      "sourcePlanRef": null,
      "dependencies": ["c09-repair-functional-coverage-cache-critical-path-on-main-001"],
      "sharedSurfaceOwner": "This story exclusively owns the functional cache block, cache diagnostic environment, and focused workflow contract tests; C13 retains jobs ownership and no functional package test is in scope.",
      "scope": {
        "in": [
          "Split stable module and source-sensitive Go build caches",
          "Include jobs 12 and authored build inputs in build identity",
          "Forward primary, matched, and exact-hit restore values",
          "Save warmed build primary after non-exact restore",
          "Update focused workflow and command contract tests",
          "Inspect required PR CI once and perform one bounded optimization pass only when non-improving"
        ],
        "out": [
          "Jobs changes",
          "Supervisor semantic changes",
          "Functional package tests, inventory, quarantine, floors, or ACP fixtures",
          "Other workflow jobs",
          "Manufactured hosted reruns"
        ]
      },
      "contractChanges": [
        {
          "name": "Functional cache identity and diagnostic environment",
          "authoredSource": ".github/workflows/ci.yml, jobs.backend-coverage.steps for the functional matrix cell",
          "format": "yaml",
          "classification": "compatible internal configuration change",
          "current": "steps:\n  - uses: actions/setup-go@v5\n    if: matrix.suite == 'functional'\n    with:\n      go-version: ${{ env.GO_VERSION }}\n      cache: false\n  - name: Restore functional coverage Go cache\n    if: matrix.suite == 'functional'\n    id: functional-go-cache\n    uses: actions/cache@v4\n    with:\n      path: |\n        ~/go/pkg/mod\n        ~/.cache/go-build\n      key: functional-coverage-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}\n      restore-keys: |\n        functional-coverage-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-\n  - uses: actions/setup-node@v4\n    if: matrix.suite == 'functional'\n    with:\n      node-version: ${{ env.NODE_VERSION }}\n  - name: Select functional runner parallelism\n    if: matrix.suite == 'functional'\n    id: functional-parallelism\n    shell: bash\n    run: |\n      runner_cpus=\"$(nproc 2>/dev/null || true)\"\n      functional_jobs=12\n      echo \"Functional CI runner: logical_cpus=${runner_cpus:-unknown} jobs=$functional_jobs\"\n      echo \"jobs=$functional_jobs\" >> \"$GITHUB_OUTPUT\"\n  - name: Run Linux functional coverage with concurrent quarantine verification\n    if: matrix.suite == 'functional'\n    timeout-minutes: 75\n    shell: bash\n    run: bash scripts/ci/run-functional-coverage-with-quarantine.sh\n    env:\n      FUNCTIONAL_DEFAULT_JOBS: ${{ steps.functional-parallelism.outputs.jobs }}\n      FUNCTIONAL_COVERAGE_BUILD_DIAGNOSTICS: .artifacts/functional-test-viz/coverage-build-diagnostics.json",
          "proposed": "steps:\n  - uses: actions/setup-go@v5\n    if: matrix.suite == 'functional'\n    with:\n      go-version: ${{ env.GO_VERSION }}\n      cache: false\n  - name: Select functional runner parallelism\n    if: matrix.suite == 'functional'\n    id: functional-parallelism\n    shell: bash\n    run: |\n      runner_cpus=\"$(nproc 2>/dev/null || true)\"\n      functional_jobs=12\n      echo \"Functional CI runner: logical_cpus=${runner_cpus:-unknown} jobs=$functional_jobs\"\n      echo \"jobs=$functional_jobs\" >> \"$GITHUB_OUTPUT\"\n  - name: Restore functional Go module cache\n    if: matrix.suite == 'functional'\n    id: functional-go-module-cache\n    uses: actions/cache@v4\n    with:\n      path: ~/go/pkg/mod\n      key: functional-modules-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}\n  - name: Restore functional coverage Go build cache\n    if: matrix.suite == 'functional'\n    id: functional-go-build-cache\n    uses: actions/cache/restore@v4\n    with:\n      path: ~/.cache/go-build\n      key: functional-coverage-build-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-jobs-${{ steps.functional-parallelism.outputs.jobs }}-${{ hashFiles('.github/workflows/ci.yml', 'Makefile', 'go.mod', 'go.sum', 'cmd/**/*.go', 'internal/**/*.go', 'pkg/**/*.go', 'tests/functional/**/*.go', 'tests/functional/functional-quarantine.json', 'docs/internal/baselines/go-functional-coverage-package-minimums.json') }}\n      restore-keys: |\n        functional-coverage-build-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-jobs-${{ steps.functional-parallelism.outputs.jobs }}-\n  - uses: actions/setup-node@v4\n    if: matrix.suite == 'functional'\n    with:\n      node-version: ${{ env.NODE_VERSION }}\n  - name: Run Linux functional coverage with concurrent quarantine verification\n    if: matrix.suite == 'functional'\n    timeout-minutes: 75\n    shell: bash\n    run: bash scripts/ci/run-functional-coverage-with-quarantine.sh\n    env:\n      FUNCTIONAL_DEFAULT_JOBS: ${{ steps.functional-parallelism.outputs.jobs }}\n      FUNCTIONAL_COVERAGE_BUILD_DIAGNOSTICS: .artifacts/functional-test-viz/coverage-build-diagnostics.json\n      FUNCTIONAL_COVERAGE_ACTION_CACHE_PRIMARY_KEY: ${{ steps.functional-go-build-cache.outputs.cache-primary-key }}\n      FUNCTIONAL_COVERAGE_ACTION_CACHE_MATCHED_KEY: ${{ steps.functional-go-build-cache.outputs.cache-matched-key }}\n      FUNCTIONAL_COVERAGE_ACTION_CACHE_EXACT_HIT: ${{ steps.functional-go-build-cache.outputs.cache-hit }}\n  - name: Save functional coverage Go build cache\n    if: always() && matrix.suite == 'functional' && steps.functional-go-build-cache.outputs.cache-hit != 'true'\n    uses: actions/cache/save@v4\n    with:\n      path: ~/.cache/go-build\n      key: ${{ steps.functional-go-build-cache.outputs.cache-primary-key }}",
          "compatibility": "Jobs 12 remains unchanged; module cache stays dependency-based; build cache adds source and invocation identity; prefix restore is a seed only; rollback restores the combined block.",
          "generatedOutputs": [],
          "consumers": ["GitHub Actions cache", "Backend Functional Coverage", "cmd/gocoveragecheck diagnostic", "reviewer"]
        },
        {
          "name": "Coverage-build diagnostic JSON v2",
          "authoredSource": "cmd/gocoveragecheck/coverage_build_diagnostics.go",
          "format": "json",
          "classification": "versioned breaking internal diagnostic artifact change",
          "current": "{\n  \"schemaVersion\": 1,\n  \"goVersion\": \"go1.25.0\",\n  \"coverageInvocationHash\": \"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\",\n  \"compileProbe\": {\n    \"wallSeconds\": 181.502,\n    \"expectedPackages\": 149,\n    \"compilerCommands\": 359,\n    \"linkerCommands\": 147,\n    \"inferredHits\": 0,\n    \"misses\": 506\n  },\n  \"testRunWallSeconds\": 304.519,\n  \"totalMeasuredSeconds\": 486.021,\n  \"status\": \"complete\"\n}",
          "proposed": "{\n  \"schemaVersion\": 2,\n  \"goVersion\": \"go1.25.0\",\n  \"coverageInvocationHash\": \"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\",\n  \"actionCache\": {\n    \"primaryKey\": \"functional-coverage-build-Linux-X64-go-1.25.0-jobs-12-0123456789abcdef\",\n    \"matchedKey\": \"functional-coverage-build-Linux-X64-go-1.25.0-jobs-12-fedcba9876543210\",\n    \"exactPrimaryHit\": false\n  },\n  \"coverageInvocation\": {\n    \"wallSeconds\": 304.519,\n    \"expectedPackages\": 149,\n    \"compilerCommands\": 359,\n    \"linkerCommands\": 147,\n    \"buildActions\": 506,\n    \"cacheReuse\": \"compile-work-observed\",\n    \"commandResult\": \"passed\"\n  },\n  \"totalMeasuredSeconds\": 304.519,\n  \"status\": \"complete\"\n}",
          "compatibility": "Story 002 supplies real action-cache identity to the schema-v2 writer; no generated or product consumer changes.",
          "generatedOutputs": [],
          "consumers": ["functional-test-diagnostics artifact", "reviewer", "loopback"]
        }
      ],
      "acceptanceCriteria": [
        "Given the authored workflow, when focused checks inspect it, then module and build caches are separate, jobs 12 is in the build key, and restore identity reaches the coverage step.",
        "Given an exact, prefix, missing, or denied cache result, when the PR job runs, then schema v2 and action logs agree without converting archive restoration into Go build reuse.",
        "Given required PR CI, when Backend Functional Coverage completes, then one coverage invocation runs the complete 149-package and 1,067-test selection at jobs 12 with coverage, floors, quarantine, ACP, timing, and verdict artifacts preserved.",
        "Given the PR timing, when compared with 486.021 seconds, then it improves directionally; a non-improving result receives one bounded optimization pass and no repeated rerun ritual.",
        "Given a compile, test, quarantine, timeout, cancellation, or partial failure, when reporting completes, then the job remains fail closed and existing attribution and artifacts remain available.",
        "make test-ci-workflows, actionlint .github/workflows/ci.yml, node --test scripts/ci/lane-budget.test.mjs scripts/ci/functional-coverage-workflow.test.mjs scripts/ci/functional-coverage-supervisor.test.mjs, and go test ./cmd/gocoveragecheck -count=1 pass for their named properties."
      ],
      "verification": {
        "behavioralWitness": "The PR's real Backend Functional Coverage artifacts show one traced jobs-12 invocation, cache identity, truthful classification, full inventory, preserved gates, and directional improvement.",
        "executableSpineEffect": "increase_fidelity",
        "requiredEvidence": [
          {
            "scope": "contract/integration",
            "dependencyFidelity": "local_real and controlled",
            "cadence": "per change",
            "cost": "free",
            "procedure": "Run make test-ci-workflows; actionlint .github/workflows/ci.yml; node --test scripts/ci/lane-budget.test.mjs scripts/ci/functional-coverage-workflow.test.mjs scripts/ci/functional-coverage-supervisor.test.mjs; and go test ./cmd/gocoveragecheck -count=1.",
            "propertyProved": "Valid workflow, source-sensitive cache wiring, jobs propagation, supervisor preservation, one-command diagnostics, and failure joins.",
            "propertyNotProved": "GitHub cache service, complete suite, pinned ACP artifact, or hosted latency."
          },
          {
            "scope": "end-to-end",
            "dependencyFidelity": "remote_real",
            "cadence": "required PR run",
            "cost": "bounded hosted resources; zero paid calls",
            "procedure": "Inspect the required PR Backend Functional Coverage run, logs, and uploaded artifacts once and post exact head, run, and job evidence in a PR comment.",
            "propertyProved": "Delivered cache and compile topology, complete jobs-12 behavior, diagnostics, failure behavior, and directional PR performance.",
            "propertyNotProved": "Default-branch cache scope, first-main 329.4-second threshold, or future runner variance."
          }
        ],
        "highestFeasibleLevel": "End-to-end remote-real PR CI because cache and contention properties require the actual hosted topology.",
        "remainingUnprovenEdges": [
          {"edge": "Performance and cache behavior on integrated post-merge main", "gateId": "c09-post-merge-functional-gate-correction-loopback-20260829"},
          {"edge": "Four formerly contention-failing packages at jobs 12", "gateId": "GATE-MAIN"}
        ]
      },
      "paidValidation": {
        "trigger": "Required PR CI only",
        "maximumCalls": 0,
        "maximumCost": "$0 paid-provider cost; bounded required Actions resources",
        "maximumDuration": "Existing 75-minute functional timeout",
        "fixtureAndOutputValidator": "Complete repository functional inventory, pinned ACP artifact, schema v2, and existing verdict artifacts",
        "evidenceReuseKey": "Exact PR head, workflow hash, Go version, runner identity, jobs 12, source, quarantine and floor hashes, ACP identity, run ID, and job ID"
      },
      "priority": "high",
      "passes": false,
      "notes": ""
    },
    {
      "id": "c09-repair-functional-coverage-cache-critical-path-on-main-003",
      "title": "Validate the first natural post-merge main run",
      "description": "Use a clean checkout and the first natural main run to prove the merged cache and single-invocation path against the complete inventory, four contention rows, and 329.4-second threshold without rerunning or repairing.",
      "parentBehavior": "BEH-C09-POST-MERGE",
      "outcome": "A canonical read-only validation report gives PASS, FAIL, or BLOCKED for every project criterion and requests the smallest delta plan for any failure.",
      "sourcePlanRef": null,
      "dependencies": ["c09-repair-functional-coverage-cache-critical-path-on-main-002", "REVIEW-CI merge"],
      "sharedSurfaceOwner": "The loopback is read-only and owns only its validation report; implementation owns no post-merge mutation, review owns merge, and future correction requires a new delta plan.",
      "scope": {
        "in": [
          "Clean detached checkout of merged head",
          "First natural post-merge main logs and artifacts",
          "Cache identity, invocation, timing, inventory, verdict, coverage, quarantine, ACP, and four contention-package rows",
          "Canonical validation-loopback report and delta request when needed"
        ],
        "out": [
          "Code repair",
          "Workflow dispatch or rerun",
          "New cache warming",
          "Merge work",
          "Future performance monitoring"
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given the merged head, when ancestry and workflow are inspected, then C13 merge 848d1d3047 is present and jobs 12 remains canonical.",
        "Given the first natural main run, when artifacts are inspected, then exactly one authoritative coverage invocation reports cache identity, truthful build-action classification, and compile-plus-test wall no greater than 329.4 seconds.",
        "Given the same run, when inventory and verdicts are inspected, then all 149 packages and 1,067 tests execute with coverage, package floors, quarantine, pinned ACP evidence, and fail-closed behavior preserved.",
        "Given the four formerly contention-failing package rows, when timing and outcomes are inspected, then each is present and terminal green at jobs 12.",
        "Given missing, stale, contradictory, slow, or red evidence, when validation ends, then the report is FAIL or BLOCKED with the smallest delta-plan request and no rerun or repair.",
        "The report follows factory/docs/standards/validation-loopback-template.md and records exact commit, environment, run and job, real dependencies, cost, criteria, journey, findings, verdict, and unproven edges."
      ],
      "verification": {
        "behavioralWitness": "The first natural main Backend Functional Coverage job publishes schema v2, critical-path timing, quarantine timing, complete inventory and outcomes, coverage, ACP evidence, and a terminal verdict from the merged commit.",
        "executableSpineEffect": "promote",
        "requiredEvidence": [
          {
            "scope": "end-to-end",
            "dependencyFidelity": "remote_real",
            "cadence": "first natural post-merge main run",
            "cost": "read-only use of one bounded existing hosted run; zero paid calls",
            "procedure": "Create a clean detached checkout of the merged SHA; inspect the first natural main run and job plus all required artifacts; compare the merged contracts; emit the canonical validation report; do not trigger a run.",
            "propertyProved": "Integrated post-merge main behavior, exact cache and compile classification, jobs 12, complete inventory, four contention rows, terminal verdict, and compile-plus-test at or below 329.4 seconds.",
            "propertyNotProved": "Future runner images, later source changes, or long-term cache retention."
          }
        ],
        "highestFeasibleLevel": "End-to-end hosted CI on the first post-merge main commit with the real GitHub Actions cache, Go compiler and build cache, complete functional suite, and pinned real ACP artifact; runtime proof is mandatory.",
        "remainingUnprovenEdges": [
          {"edge": "Future runner-image and cache-service drift", "gateId": "normal main monitoring and rollback owner"}
        ]
      },
      "paidValidation": {
        "trigger": "First natural post-merge main run only",
        "maximumCalls": 0,
        "maximumCost": "$0 paid-provider cost; no manufactured hosted run",
        "maximumDuration": "Existing natural workflow duration only",
        "fixtureAndOutputValidator": "Full selected inventory, pinned ACP artifact, schema v2, timing summary, coverage verdict, quarantine evidence, and critical-path timing",
        "evidenceReuseKey": "Merged SHA, main run and job IDs, workflow hash, Go and runner identity, jobs 12, source, quarantine and floor hashes, and ACP identity"
      },
      "priority": "high",
      "passes": false,
      "notes": ""
    }
  ]
}
