### PR TITLE
deflake-petri-guards-partial-completion-discovery-race

### DIFF
--- a/tests/functional/orchestration/petri/guards/guard_cases_test.go
+++ b/tests/functional/orchestration/petri/guards/guard_cases_test.go
@@ -113,17 +113,20 @@ func TestGuardTimeoutDiagnosticProducesFailedOutcome(t *testing.T) {
 func TestGuardPartialCompletionPreservesIndependentOutcome(t *testing.T) {
 	// CASE-G-008: one controlled success and one controlled error settle as
 	// independent terminal outcomes without replaying either dispatch.
-	dir := newSharedGuardScenario(t, sharedGuardSingleStepFactoryConfig(nil))
+	factoryConfig := sharedGuardSingleStepFactoryConfig(nil)
+	factoryConfig["workstations"].([]map[string]any)[0]["promptTemplate"] =
+		`guard-work={{ (index .Inputs 0).WorkID }}`
+	dir := newSharedGuardScenario(t, factoryConfig)
 	seedGuardWork(t, dir, "partial-complete", "guard-partial-complete", "task")
 	seedGuardWork(t, dir, "partial-failed", "guard-partial-failed", "task")
 	const diagnostic = "provider execution failed"
-	session := openSharedGuardSession(t, dir, sharedGuardRouteConfig{provider: sharedGuardProviderSequence(
-		sharedGuardProviderOutput("COMPLETE"),
-		sharedGuardCommandResponse{result: platformprocess.CommandResult{
+	session := openSharedGuardSession(t, dir, sharedGuardRouteConfig{provider: sharedGuardProviderByMarker(map[string]sharedGuardCommandResponse{
+		sharedGuardPartialCompleteMarker: sharedGuardProviderOutput("COMPLETE"),
+		sharedGuardPartialFailedMarker: {result: platformprocess.CommandResult{
 			Stderr:   []byte("partial guard failure"),
 			ExitCode: 31,
 		}},
-	)})
+	})})
 	supportWaitForGuardTerminal(t, session)
 	_, listed, events := readSharedGuardSession(t, session)
 

--- a/tests/functional/orchestration/petri/guards/shared_fixture_test.go
+++ b/tests/functional/orchestration/petri/guards/shared_fixture_test.go
@@ -506,6 +506,11 @@ type sharedGuardCommandResponse struct {
 	shapeProviderOutput bool
 }
 
+const (
+	sharedGuardPartialCompleteMarker = "guard-work=guard-partial-complete"
+	sharedGuardPartialFailedMarker   = "guard-work=guard-partial-failed"
+)
+
 func sharedGuardProviderOutput(content string) sharedGuardCommandResponse {
 	return sharedGuardCommandResponse{providerOutput: content, shapeProviderOutput: true}
 }
@@ -532,6 +537,148 @@ func sharedGuardProviderSequence(responses ...sharedGuardCommandResponse) shared
 			result.Stdout = sharedGuardProviderStdout(request.Command, response.providerOutput)
 		}
 		return result, response.err
+	}
+}
+
+func sharedGuardProviderByMarker(responses map[string]sharedGuardCommandResponse) sharedGuardCommandResponder {
+	markers := make([]string, 0, len(responses))
+	for marker := range responses {
+		if strings.TrimSpace(marker) != "" {
+			markers = append(markers, marker)
+		}
+	}
+	return func(ctx context.Context, request platformprocess.CommandRequest) (platformprocess.CommandResult, error) {
+		if err := ctx.Err(); err != nil {
+			return platformprocess.CommandResult{}, err
+		}
+		stdin := string(request.Stdin)
+		matchedMarker := ""
+		matchCount := 0
+		for _, marker := range markers {
+			occurrences := strings.Count(stdin, marker)
+			matchCount += occurrences
+			if occurrences == 1 {
+				matchedMarker = marker
+			}
+		}
+		if matchCount != 1 {
+			return platformprocess.CommandResult{}, fmt.Errorf(
+				"shared guard provider request must contain exactly one recognized synthetic Work marker (found %d)",
+				matchCount,
+			)
+		}
+		if err := ctx.Err(); err != nil {
+			return platformprocess.CommandResult{}, err
+		}
+		return sharedGuardProviderResponse(request, responses[matchedMarker])
+	}
+}
+
+func sharedGuardProviderResponse(
+	request platformprocess.CommandRequest,
+	response sharedGuardCommandResponse,
+) (platformprocess.CommandResult, error) {
+	result := response.result
+	result.Stdout = append([]byte(nil), result.Stdout...)
+	result.Stderr = append([]byte(nil), result.Stderr...)
+	if response.shapeProviderOutput {
+		result.Stdout = sharedGuardProviderStdout(request.Command, response.providerOutput)
+	}
+	return result, response.err
+}
+
+func TestSharedGuardProviderByMarker(t *testing.T) {
+	const privatePrompt = `{"case":"unknown","secret":"do not disclose this prompt"}`
+	responder := sharedGuardProviderByMarker(map[string]sharedGuardCommandResponse{
+		sharedGuardPartialCompleteMarker: sharedGuardProviderOutput("COMPLETE"),
+		sharedGuardPartialFailedMarker: {result: platformprocess.CommandResult{
+			Stderr:   []byte("partial guard failure"),
+			ExitCode: 31,
+		}},
+	})
+
+	tests := []struct {
+		name                string
+		stdin               string
+		cancel              bool
+		wantError           error
+		wantErrorText       string
+		wantStdoutSubstring string
+		wantStderr          string
+		wantExitCode        int
+		wantEmptyResult     bool
+	}{
+		{
+			name:            "zero recognized markers",
+			stdin:           privatePrompt,
+			wantErrorText:   "found 0",
+			wantEmptyResult: true,
+		},
+		{
+			name:                "complete marker",
+			stdin:               sharedGuardPartialCompleteMarker,
+			wantStdoutSubstring: "COMPLETE",
+		},
+		{
+			name:         "failed marker",
+			stdin:        sharedGuardPartialFailedMarker,
+			wantStderr:   "partial guard failure",
+			wantExitCode: 31,
+		},
+		{
+			name:            "multiple recognized markers",
+			stdin:           sharedGuardPartialCompleteMarker + " " + sharedGuardPartialFailedMarker,
+			wantErrorText:   "found 2",
+			wantEmptyResult: true,
+		},
+		{
+			name:            "canceled before selection",
+			stdin:           sharedGuardPartialCompleteMarker,
+			cancel:          true,
+			wantError:       context.Canceled,
+			wantEmptyResult: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			if test.cancel {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+			result, err := responder(ctx, platformprocess.CommandRequest{
+				Command: "codex",
+				Stdin:   []byte(test.stdin),
+			})
+			if test.wantError != nil {
+				if !errors.Is(err, test.wantError) {
+					t.Fatalf("responder error = %v, want %v", err, test.wantError)
+				}
+			} else if test.wantErrorText != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErrorText) {
+					t.Fatalf("responder error = %v, want text %q", err, test.wantErrorText)
+				}
+				if strings.Contains(err.Error(), test.stdin) {
+					t.Fatalf("responder error disclosed full prompt %q: %v", test.stdin, err)
+				}
+			} else if err != nil {
+				t.Fatalf("responder error = %v, want nil", err)
+			}
+			if test.wantStdoutSubstring != "" && !strings.Contains(string(result.Stdout), test.wantStdoutSubstring) {
+				t.Fatalf("responder stdout = %q, want substring %q", result.Stdout, test.wantStdoutSubstring)
+			}
+			if test.wantStderr != "" && string(result.Stderr) != test.wantStderr {
+				t.Fatalf("responder stderr = %q, want %q", result.Stderr, test.wantStderr)
+			}
+			if result.ExitCode != test.wantExitCode {
+				t.Fatalf("responder exit code = %d, want %d", result.ExitCode, test.wantExitCode)
+			}
+			if test.wantEmptyResult && (len(result.Stdout) != 0 || len(result.Stderr) != 0 || result.ExitCode != 0 || result.CancellationReason != "") {
+				t.Fatalf("responder result = %#v, want empty result", result)
+			}
+		})
 	}
 }
 
@@ -705,7 +852,11 @@ func newSharedGuardScenario(t *testing.T, config map[string]any) string {
 		if name == "" || strings.EqualFold(kind, string(factoryinterfaces.WorkstationTypeLogical)) {
 			continue
 		}
-		support.WriteWorkstationConfig(t, dir, name, "---\ntype: MODEL_WORKSTATION\n---\nDo the work.\n")
+		body := "Do the work."
+		if promptTemplate, ok := workstation["promptTemplate"].(string); ok && strings.TrimSpace(promptTemplate) != "" {
+			body = promptTemplate
+		}
+		support.WriteWorkstationConfig(t, dir, name, "---\ntype: MODEL_WORKSTATION\n---\n"+body+"\n")
 	}
 	return dir
 }


### PR DESCRIPTION
{
  "project": "Deflake Petri Guard Partial-Completion Outcome Assignment",
  "branchName": "deflake-petri-guards-partial-completion-discovery-race",
  "description": "Make TestGuardPartialCompletionPreservesIndependentOutcome deterministic by binding its controlled provider success and failure to stable Work-specific request markers instead of concurrent command-arrival order, then promote the unchanged public behavior through focused repeat/race/package, clean-room, PR-CI, and post-merge main gates without changing production discovery, unrelated guard tests, PR #2453, or session-scope metrics.",
  "context": {
    "customerAsk": "Deflake tests/functional/orchestration/petri/guards TestGuardPartialCompletionPreservesIndependentOutcome, which alternates failure and success on main and blocks Backend Functional Coverage/Verification Policy. Measure the local failure rate with -count=20; inspect logicaltarget/discovery.go:91 and test setup; use deterministic synchronization rather than sleep/retry; do not weaken, skip, or quarantine assertions; change production discovery/registration ordering only if investigation proves the same gap affects real sessions; confirm zero failures in the same -count=20 loop and observe at least two consecutive green Backend Functional Coverage runs on main after merge. Scope excludes unrelated Petri guard tests, PR #2453 session-scope metrics work, and port 7438.",
    "sourcePlan": null,
    "problem": "The partial-completion functional scenario sends two independent Work items through concurrent production dispatch but assigns its controlled provider success and failure by command-arrival index, so scheduling can give the intended complete Work the failure. Local characterization twice observed 19 passes and 1 failure in 20; the captured failure mapped guard-partial-complete to failed. Discovery errors at logicaltarget/discovery.go:91 named inputs/workers/workstations child-directory probes, occurred during passing iterations, and did not prevent the default Factory Session from opening, so the reproduced failure is not evidence of session registration/persistence ordering.",
    "solution": "Keep the production-composed root.BuildProcess/Process.Execute, Factory Session HTTP, runtime, Work, and Factory Event spine unchanged. At the injected controlled ProviderCommandRunner edge, require exactly one stable synthetic Work marker already present in CommandRequest.Stdin and select that Work's declared response independent of arrival order; fail closed for missing/ambiguous markers or cancellation. Validate the exact public outcome locally, from a clean final artifact, on final-head PR CI, and in two consecutive post-merge main Backend Functional Coverage runs under their owning stages."
  },
  "acceptanceCriteria": [
    "Given either concurrent command-arrival order, TestGuardPartialCompletionPreservesIndependentOutcome maps guard-partial-complete to complete and guard-partial-failed to failed, emits exactly one accepted and one failed dispatch response with the expected provider execution failed diagnostic, and records exactly two provider calls with no replay (FTM-001 through FTM-003 and FTM-007)",
    "Missing, ambiguous, and canceled controlled requests fail closed without arbitrary response selection, full-prompt disclosure, sleeps, retries, skips, quarantines, or weakened assertions (FTM-004 through FTM-006; GATE-HELPER-001)",
    "GATE-FOCUSED-001 runs go test -count=20 -run '^TestGuardPartialCompletionPreservesIndependentOutcome$' ./tests/functional/orchestration/petri/guards/... and reports 20 passes and zero failures",
    "GATE-RACE-001 reports no Go race in the focused scenario and GATE-PACKAGE-001 passes go test -count=1 ./tests/functional/orchestration/petri/guards/..., preserving every unchanged guard case and shared-process cleanup",
    "GATE-LINT-001 passes make lint, proving repository lint/package/boundary conformance; no generated contract artifact changes",
    "No production discovery code, unrelated Petri guard test, session-scope metrics surface, PR #2453 content, or port 7438 is touched",
    "Performance evidence preserves the one-process/two-provider-call topology and records the PR package result directionally; local wall-clock noise is diagnostic rather than a stop condition, and a materially non-improving PR package result receives one bounded optimization pass",
    "Security/privacy remains limited to synthetic marker diagnostics and isolated temporary roots, with zero remote calls and a $0 paid-validation budget",
    "GATE-CLEANROOM-001 validates the exact final committed artifact using factory/docs/standards/validation-loopback-template.md and reports failures with a delta-plan request without silently repairing defects",
    "GATE-PR-CI-001 records terminal green final-head Backend Functional Coverage and Verification Policy evidence in a PR comment; review merges only after blocking criteria pass",
    "GATE-MAIN-002 records two consecutive green post-merge main Backend Functional Coverage runs; the first red run stops the gate and produces evidence rather than being ignored",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "behaviorLanes": [
    {
      "id": "BEH-001",
      "name": "Deterministic independent partial completion",
      "outcome": "Two concurrently dispatched independent Work items retain their declared success/failure outcomes by identity, with exact public states, events, failure diagnostic, and no replay."
    },
    {
      "id": "BEH-002",
      "name": "Delivery and post-merge confidence",
      "outcome": "The final artifact proves BEH-001 from a clean environment, passes owned PR gates, and remains green in two consecutive post-merge main Backend Functional Coverage runs."
    }
  ],
  "contractChanges": [],
  "userStories": [
    {
      "id": "deflake-petri-guards-partial-completion-discovery-race-001",
      "title": "Preserve independent partial outcomes under any dispatch arrival order",
      "description": "As a maintainer relying on the Petri guard functional lane, I want the controlled provider response for each concurrent Work item selected by stable request identity so scheduling order cannot reverse the scenario's intended complete and failed outcomes.",
      "parentBehavior": "BEH-001 \u2014 Deterministic independent partial completion",
      "sourcePlanRef": null,
      "outcome": "The one flaky scenario uses a strict, package-local identity-keyed controlled responder and deterministically proves the unchanged public partial-completion behavior.",
      "dependencies": [],
      "sharedSurfaceOwner": "This story exclusively owns TestGuardPartialCompletionPreservesIndependentOutcome in tests/functional/orchestration/petri/guards/guard_cases_test.go and the smallest relevant controlled-responder/helper region in shared_fixture_test.go; it owns no production discovery, other guard case, PR #2453, metrics, generated, or UI surface.",
      "scope": {
        "in": [
          "Inspect the actual platformprocess.CommandRequest.Stdin and select a stable unique synthetic Work marker already carried by the fixture",
          "Add or use strict marker-keyed controlled response selection that requires exactly one recognized marker and checks cancellation",
          "Retain or strengthen exact public Work state, Factory Event outcome/diagnostic, exactly-two-call, and no-replay assertions",
          "Add direct fail-closed helper coverage for zero/one/multiple marker and canceled-context behavior when a reusable helper is introduced",
          "Run focused repeat, focused race, and complete Petri guard package evidence"
        ],
        "out": [
          "Production discovery, Factory Session registration, runtime contract, or synchronization changes without contradictory new evidence",
          "Other Petri guard test changes or assertion rewrites",
          "Retries, sleeps, timeout padding, serialization of independent dispatch, skips, quarantines, or weakened assertions",
          "PR #2453 and session-scope metrics work",
          "OpenAPI, CLI, event, persisted-schema, configuration, UI, generated artifact, or documentation feature changes",
          "Any use of port 7438"
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given either provider command arrival order, when the controlled edge receives the two uniquely marked requests, then guard-partial-complete receives success and reaches complete while guard-partial-failed receives the declared failure and reaches failed (FTM-001 through FTM-003)",
        "Given a request with zero or multiple recognized markers, when the strict matcher evaluates it, then it returns an actionable synthetic-marker error without selecting a response by sequence/map order or exposing the full prompt (FTM-004 and FTM-005; GATE-HELPER-001)",
        "Given cancellation before response selection, when the responder is invoked, then cancellation propagates and no success is fabricated (FTM-006)",
        "Given both Work items settle, when public Work/Event projections and edge history are read, then there are exactly two calls and responses, one accepted and one failed, the expected provider execution failed diagnostic, and no replay (FTM-007)",
        "GATE-FOCUSED-001 reports 20 passes and zero failures; GATE-RACE-001 reports no Go race; GATE-PACKAGE-001 preserves every unchanged guard case and zero leaked routes"
      ],
      "verification": {
        "behavioralWitness": "The public Work list maps guard-partial-complete to complete and guard-partial-failed to failed; public dispatch responses contain one accepted and one failed outcome with provider execution failed; provider call count equals two across 20 consecutive executions.",
        "executableSpineEffect": "preserve",
        "requiredEvidence": [
          {
            "gateId": "GATE-HELPER-001",
            "scope": "unit",
            "dependencyFidelity": "controlled",
            "cadence": "per change",
            "cost": "free",
            "procedure": "Add the focused zero/one/multiple marker and canceled-context cases under TestSharedGuardProviderByMarker and run go test -count=1 -run '^TestSharedGuardProviderByMarker$' ./tests/functional/orchestration/petri/guards/....",
            "propertyProved": "Strict response selection is identity-keyed, cancellation-aware, and fail-closed.",
            "propertyNotProved": "Production runtime integration."
          },
          {
            "gateId": "GATE-FOCUSED-001",
            "scope": "functional",
            "dependencyFidelity": "controlled external edge with local-real production composition, filesystem, and loopback HTTP",
            "cadence": "per change and clean room",
            "cost": "bounded local CPU",
            "procedure": "go test -count=20 -run '^TestGuardPartialCompletionPreservesIndependentOutcome$' ./tests/functional/orchestration/petri/guards/...",
            "propertyProved": "Twenty consecutive complete runtime journeys preserve exact partial outcomes, call cardinality, and cleanup without an observed flake.",
            "propertyNotProved": "All possible schedules or other guard cases."
          },
          {
            "gateId": "GATE-RACE-001",
            "scope": "functional/race",
            "dependencyFidelity": "controlled external edge with local-real production composition",
            "cadence": "per PR and risk-triggered locally",
            "cost": "bounded local CPU",
            "procedure": "go test -race -count=1 -run '^TestGuardPartialCompletionPreservesIndependentOutcome$' ./tests/functional/orchestration/petri/guards/...",
            "propertyProved": "No Go race report in the exercised focused scenario/helper path.",
            "propertyNotProved": "Semantic races outside the focused path."
          },
          {
            "gateId": "GATE-PACKAGE-001",
            "scope": "functional",
            "dependencyFidelity": "controlled external edges with local-real production composition",
            "cadence": "per PR",
            "cost": "bounded local CPU",
            "procedure": "go test -count=1 ./tests/functional/orchestration/petri/guards/...",
            "propertyProved": "Unchanged Petri guard cases and shared-process cleanup still pass.",
            "propertyNotProved": "Repository-wide CI selection or post-merge main behavior."
          }
        ],
        "highestFeasibleLevel": "Functional with a controlled external provider edge and otherwise local-real production composition; a remote provider would add cost and nondeterminism without proving fixture identity routing.",
        "remainingUnprovenEdges": [
          {
            "edge": "Clean final artifact independence from the implementation workspace",
            "gateId": "GATE-CLEANROOM-001"
          },
          {
            "edge": "Final-head repository CI selection and policy",
            "gateId": "GATE-PR-CI-001"
          },
          {
            "edge": "Post-merge main stability",
            "gateId": "GATE-MAIN-002"
          }
        ]
      },
      "paidValidation": {
        "applicable": false,
        "trigger": "Not applicable; fixture identity routing needs no remote dependency.",
        "maximumCalls": 0,
        "maximumCostUSD": 0,
        "maximumDuration": "0 remote minutes",
        "fixtureAndOutputValidator": "Local controlled provider command edge plus public Work and Factory Event assertions.",
        "evidenceReuseKey": null
      },
      "priority": 1,
      "passes": true,
      "notes": "Implemented strict WorkID-marker response selection and target-specific prompt rendering. Helper, focused count=20, focused race, and complete Petri guard package gates pass; production discovery and unrelated guard cases remain unchanged."
    },
    {
      "id": "deflake-petri-guards-partial-completion-discovery-race-002",
      "title": "Promote the deterministic scenario through clean-room, PR, and post-merge gates",
      "description": "As an independent validator and reviewer, I want the exact committed artifact exercised from a clean worktree and through repository-owned PR and main gates so the local fixture correction is proven at the highest applicable integrated runtime level.",
      "parentBehavior": "BEH-002 \u2014 Delivery and post-merge confidence",
      "sourcePlanRef": null,
      "outcome": "A read-only clean-room report validates the final head, implementation hands off after starting CI, review drives PR gates and merge, and review/factory operations records two consecutive green post-merge main functional runs.",
      "dependencies": [
        "deflake-petri-guards-partial-completion-discovery-race-001"
      ],
      "sharedSurfaceOwner": "Validation owns no code surface and is read-only. Implementation owns final push, PR open/start-CI, and blocking review fixes; review owns terminal CI, conflicts, and merge; review/factory operations owns the two-run post-merge main observation.",
      "scope": {
        "in": [
          "Clean detached-worktree focused count=20, focused race, complete Petri guard package, and make lint evidence at the exact final SHA",
          "A validation-loopback report using factory/docs/standards/validation-loopback-template.md",
          "Final-head Backend Functional Coverage and Verification Policy evidence in a PR comment under review ownership",
          "Two consecutive post-merge main Backend Functional Coverage run IDs, SHAs, and green results under review/factory-operations ownership"
        ],
        "out": [
          "Silent repair during clean-room validation",
          "Implementation polling or rechecking CI after its canonical finish line",
          "Unauthorized empty commits or workflow mutations solely to manufacture main runs",
          "Production discovery cleanup, unrelated flake repair, PR #2453, session-scope metrics, paid providers, and port 7438"
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given the final committed SHA in a clean detached worktree, when GATE-CLEANROOM-001 runs the focused count=20, focused race, complete package, and lint procedures, then the report records PASS for deterministic public outcomes, unchanged guard behavior, cleanup, and structural checks without modifying files",
        "Given a clean-room failure or contradiction, when validation concludes, then it emits the validation template's finding and delta-plan request and does not silently repair implementation",
        "Given the final PR head, when review completes, then Backend Functional Coverage and Verification Policy are terminal green for that exact head and evidence is recorded in a PR comment (GATE-PR-CI-001)",
        "Given the PR is merged, when the next two consecutive authorized main Backend Functional Coverage runs complete, then both are green; any red run stops GATE-MAIN-002 and produces evidence rather than being ignored",
        "The canonical implementation/review delivery criterion is followed exactly"
      ],
      "verification": {
        "behavioralWitness": "From a clean final artifact, 20 consecutive public Factory Session journeys retain the intended Work-ID outcomes and exact response/call cardinality, the complete Petri guard package passes, and the merged main then produces two consecutive green Backend Functional Coverage runs.",
        "executableSpineEffect": "promote",
        "requiredEvidence": [
          {
            "gateId": "GATE-CLEANROOM-001",
            "scope": "functional",
            "dependencyFidelity": "controlled external edge with local-real production composition, filesystem, and loopback HTTP",
            "cadence": "once on final implementation head",
            "cost": "bounded local CPU",
            "procedure": "From a clean detached worktree at the final SHA run go test -count=20 -run '^TestGuardPartialCompletionPreservesIndependentOutcome$' ./tests/functional/orchestration/petri/guards/..., go test -race -count=1 -run '^TestGuardPartialCompletionPreservesIndependentOutcome$' ./tests/functional/orchestration/petri/guards/..., go test -count=1 ./tests/functional/orchestration/petri/guards/..., and make lint; write the read-only report with factory/docs/standards/validation-loopback-template.md.",
            "propertyProved": "Final committed artifact reproducibility, focused stability/race behavior, unchanged package behavior, cleanup, and lint/boundary conformance.",
            "propertyNotProved": "PR-host selection or post-merge main stability."
          },
          {
            "gateId": "GATE-PR-CI-001",
            "scope": "CI functional/integration",
            "dependencyFidelity": "repository CI controlled edges",
            "cadence": "final PR head",
            "cost": "bounded CI resources",
            "procedure": "Review inspects the exact final-head Backend Functional Coverage package row/artifacts and terminal Verification Policy, then records URLs, SHA, outcomes, and the directional package result in a PR comment.",
            "propertyProved": "The repository-selected final PR head passes the required functional coverage and policy gates.",
            "propertyNotProved": "Post-merge main stability."
          },
          {
            "gateId": "GATE-MAIN-002",
            "scope": "CI integration",
            "dependencyFidelity": "repository CI controlled edges",
            "cadence": "post-merge",
            "cost": "bounded CI resources",
            "procedure": "After merge, review/factory operations records the next two consecutive authorized main Backend Functional Coverage run IDs, SHAs, package outcomes, and green conclusions; stop and report on the first red run.",
            "propertyProved": "The merged change survives two consecutive main Backend Functional Coverage executions.",
            "propertyNotProved": "Remote provider behavior or future unrelated main changes."
          }
        ],
        "highestFeasibleLevel": "Repository functional CI and post-merge main integration. Real remote dependencies are not applicable to a controlled-edge fixture race.",
        "remainingUnprovenEdges": [
          {
            "edge": "Production discovery or registration behavior if a new failing trace contradicts the reproduced controlled-edge cause",
            "gateId": "DELTA-PLAN-001"
          }
        ]
      },
      "paidValidation": {
        "applicable": false,
        "trigger": "Not applicable; repository CI uses controlled provider edges.",
        "maximumCalls": 0,
        "maximumCostUSD": 0,
        "maximumDuration": "0 remote minutes",
        "fixtureAndOutputValidator": "Repository CI controlled edges plus public Work and Factory Event assertions.",
        "evidenceReuseKey": null
      },
      "priority": 2,
      "passes": false,
      "notes": "Clean-room final SHA 7cdc48600f7ec8b3d05cb5fc3faf9aaac607f031 passed focused count=20, focused race, and complete Petri guard package gates. make lint exited 2 because clean-room UI dependencies (@biomejs/biome and knip) were unavailable and Go deadcode baseline drifted 3074 versus 3072; all three failures reproduced on untouched origin/main SHA 8be2317b1c. No diff-caused lint regression or shared-baseline/UI change is in scope. PR-CI terminal evidence and two post-merge main runs remain review/factory-operations-owned."
    }
  ],
  "operatorAmendment1": "OPERATOR AMENDMENT (2026-08-30): you OWN the fix for TestGuardPartialCompletionPreservesIndependentOutcome. A sibling lane (deflake-functional-orchestration-petri-guards) is running a package-wide contended attribution campaign in the SAME package but has been explicitly forbidden from touching your test or the responder-binding behavior; its deliverable is an evidence ledger under docs/internal/development/functional-test-deflake/ plus fixes for OTHER tests only. Rebase onto origin/main before your final push and expect that ledger file to possibly appear there - it is not yours and not a conflict with your scope."
}
