### PR TITLE
portable-link-escape-linux-contract

### DIFF
--- a/pkg/services/factory_definitions/internal/services/snapshots_portability/portableconfig/integrationtests/portable_bundled_files_integration_test.go
+++ b/pkg/services/factory_definitions/internal/services/snapshots_portability/portableconfig/integrationtests/portable_bundled_files_integration_test.go
@@ -631,7 +631,7 @@ func TestLoadPortableBundledFiles_RejectsFilesystemLinkEscapeWithoutEscapedWrite
 	if err == nil {
 		t.Fatal("expected LoadRuntimeConfig to reject filesystem-link escape target")
 	}
-	if !strings.Contains(err.Error(), "cannot escape the expand target through filesystem links") {
+	if !strings.Contains(err.Error(), "cannot escape the materialization target through filesystem links") {
 		t.Fatalf("error = %q, want filesystem-link escape validation message", err.Error())
 	}
 	if !strings.Contains(err.Error(), "factory/scripts/execute-story.ps1") {


### PR DESCRIPTION
{
  "project": "Reconcile the portable bundled-file link-escape contract on Linux",
  "branchName": "portable-link-escape-linux-contract",
  "description": "Align the existing portableconfig Linux integration oracle with the unchanged materialization-target diagnostic while preserving the real filesystem-link escape, exact offending target, fail-closed rejection, and no-escaped-write security witness. Independently validate the delivered head through the complete registered integration lane, then hand review the terminal CI, conflict-resolution, and merge responsibilities.",
  "context": {
    "customerAsk": "Restore a trustworthy Linux integration witness for portable bundled-file materialization: a real filesystem link that escapes the destination must still be rejected, and the integration assertion must match the current customer-facing diagnostic contract so the newly required Backend Integration gate can pass without weakening the security behavior.",
    "sourcePlan": null,
    "problem": "Current Linux runtime behavior correctly rejects an external filesystem link before writing and reports that the target cannot escape the materialization target through filesystem links, but TestLoadPortableBundledFiles_RejectsFilesystemLinkEscapeWithoutEscapedWrite expects the stale phrase expand target and fails the registered portableconfig integration package.",
    "solution": "Change only the stale portableconfig test oracle to require the owning materialization-target diagnostic, retain every real-link, rejection, target, and no-write assertion, prove the result on a real Linux filesystem at focused, package, and registered integration scope, and use a read-only clean-room loopback before review drives the lane-owned Backend Integration and Verification Policy checks to green and merges the PR."
  },
  "acceptanceCriteria": [
    "Given a portable Factory whose bundled output path traverses a real filesystem link outside the materialization destination, when runtime config loads on Linux, then loading fails before any escaped write and the error identifies both the link-escape condition and factory/scripts/execute-story.ps1; LINUX-FOCUSED and VAL-001 provide direct evidence.",
    "Given current main and the exact integration package, when its tests run on Linux, then TestLoadPortableBundledFiles_RejectsFilesystemLinkEscapeWithoutEscapedWrite passes without a platform skip or weakened assertion; PORTABLECONFIG-PACKAGE provides direct evidence.",
    "The production diagnostic remains materialization target, no public or persisted contract changes, and the change stays inside the portableconfig lease; focused diff review and the exact contract excerpts provide evidence.",
    "make test-integration passes on the delivered head and proves all currently registered integration packages execute successfully; BACKEND-INTEGRATION-LOCAL and VAL-001 provide evidence.",
    "The lane's own Backend Integration check is terminal green and the derivative Verification Policy rollup is green on the current PR head; BACKEND-INTEGRATION-PR and VERIFICATION-POLICY-PR evidence is recorded in a PR comment.",
    "Clean-room validation reports PASS using factory/docs/standards/validation-loopback-template.md, or reports FAIL or BLOCKED with a delta-plan request and no silent repair.",
    "Blocking review comments and conflicts are resolved, the PR is merged, and only then is the Factory lane complete under DELIVERY-REVIEW.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "behaviorLanes": [
    {
      "id": "BEH-001",
      "title": "Trustworthy Linux portable-link escape witness",
      "behavior": "The required Backend Integration gate executes the registered integration package and reliably proves portable Factory materialization rejects filesystem-link escapes.",
      "behavioralWitness": "On Linux, the existing portableconfig integration test creates a real external symlink, rejects the escape, names factory/scripts/execute-story.ps1, proves the external file is absent, and then passes through the complete registered integration lane.",
      "executableSpine": "Portable Factory fixture -> Factory Definitions runtime load -> real Linux filesystem link resolution -> fail-closed diagnostic -> no outside write.",
      "tasks": [
        "portable-link-escape-linux-contract-001",
        "portable-link-escape-linux-contract-002"
      ]
    }
  ],
  "realDependencyBudget": {
    "dependency": "Linux filesystem symlink semantics and GitHub-hosted Backend Integration",
    "maximumCost": "$0",
    "maximumDuration": "One normal PR CI run plus one evidence-based retry only when the failure is classified as infrastructure.",
    "maximumPaidCalls": 0,
    "requiredFidelity": "A real Linux filesystem link with no mock and no Linux skip.",
    "evidenceReuseKey": "Concatenate the PR head SHA, portableconfig-link-escape-v1, github-actions-ubuntu, real-symlink, factory/scripts/execute-story.ps1, and the CI workflow hash."
  },
  "qualityGates": [
    {
      "id": "LINUX-FOCUSED",
      "scope": "integration",
      "dependencyFidelity": "local_real",
      "cadence": "per change",
      "cost": "free"
    },
    {
      "id": "PORTABLECONFIG-PACKAGE",
      "scope": "integration",
      "dependencyFidelity": "local_real",
      "cadence": "per change",
      "cost": "free"
    },
    {
      "id": "BACKEND-INTEGRATION-LOCAL",
      "scope": "integration",
      "dependencyFidelity": "local_real",
      "cadence": "per change",
      "cost": "free"
    },
    {
      "id": "BACKEND-INTEGRATION-PR",
      "scope": "integration",
      "dependencyFidelity": "local_real filesystem on GitHub-hosted Linux",
      "cadence": "per PR",
      "cost": "bounded free runner use"
    },
    {
      "id": "VERIFICATION-POLICY-PR",
      "scope": "integration rollup",
      "dependencyFidelity": "controlled CI check graph",
      "cadence": "per PR",
      "cost": "bounded free runner use"
    },
    {
      "id": "VAL-001",
      "scope": "integration",
      "dependencyFidelity": "local_real",
      "cadence": "per PR before review handoff",
      "cost": "free"
    }
  ],
  "contractChanges": [
    {
      "name": "Portable filesystem-link escape runtime diagnostic",
      "authoredSource": "pkg/platform/portablefiles/materialize.go, ValidateFilesystemPath",
      "format": "text",
      "classification": "unchanged",
      "current": "target location \"factory/scripts/execute-story.ps1\" cannot escape the materialization target through filesystem links",
      "proposed": "target location \"factory/scripts/execute-story.ps1\" cannot escape the materialization target through filesystem links",
      "compatibility": "The runtime diagnostic does not change. Wrapped Factory Definitions errors may add operation context, but the link-escape condition and target literal remain observable. There is no migration or compatibility interval.",
      "generatedOutputs": [],
      "consumers": [
        "Factory Definitions portable materialization callers",
        "Customers receiving wrapped portable Factory load errors",
        "The portableconfig Linux integration witness"
      ]
    },
    {
      "name": "Linux portableconfig diagnostic oracle",
      "authoredSource": "pkg/services/factory_definitions/internal/services/snapshots_portability/portableconfig/integrationtests/portable_bundled_files_integration_test.go, TestLoadPortableBundledFiles_RejectsFilesystemLinkEscapeWithoutEscapedWrite",
      "format": "go",
      "classification": "compatible test-oracle correction",
      "current": "if !strings.Contains(err.Error(), \"cannot escape the expand target through filesystem links\") {\n\tt.Fatalf(\"error = %q, want filesystem-link escape validation message\", err.Error())\n}",
      "proposed": "if !strings.Contains(err.Error(), \"cannot escape the materialization target through filesystem links\") {\n\tt.Fatalf(\"error = %q, want filesystem-link escape validation message\", err.Error())\n}",
      "compatibility": "Only the stale integration oracle changes. The correction does not broaden accepted errors or change production behavior.",
      "generatedOutputs": [],
      "consumers": [
        "Focused portableconfig Linux test",
        "Portableconfig integration package",
        "make test-integration",
        "Backend Integration",
        "Verification Policy"
      ]
    }
  ],
  "userStories": [
    {
      "id": "portable-link-escape-linux-contract-001",
      "title": "Align and prove the Linux link-escape diagnostic oracle",
      "description": "As a Linux integration runner, I need the existing real-symlink witness to recognize the owning materialization-target diagnostic so it proves the security behavior instead of failing on stale vocabulary.",
      "parentBehavior": "BEH-001 — The required Backend Integration gate executes the registered integration package and reliably proves portable Factory materialization rejects filesystem-link escapes.",
      "outcome": "One focused, revertible portableconfig test correction recognizes the owning diagnostic while retaining the real-link, exact-target, rejection, and no-write security assertions.",
      "sourcePlanRef": null,
      "dependencies": [],
      "sharedSurfaceOwner": "This story exclusively owns pkg/services/factory_definitions/internal/services/snapshots_portability/portableconfig/**. per-package-compute-reduction-c02-integration-ci retains exclusive ownership of .github/workflows/ci.yml and Makefile.",
      "scope": {
        "in": [
          "Update the single stale diagnostic substring in TestLoadPortableBundledFiles_RejectsFilesystemLinkEscapeWithoutEscapedWrite.",
          "Preserve the production Factory Definitions composition, os.Symlink fixture, non-nil rejection, exact target assertion, and no-escaped-write assertion.",
          "Run the focused test and complete portableconfig integration package on a real Linux filesystem.",
          "Retain any Windows no-symlink-privilege result as diagnostic evidence only."
        ],
        "out": [
          "Production pkg/platform/portablefiles changes.",
          "Workflow, Makefile, cmd, script, generated-file, or unrelated Factory Definitions changes.",
          "Linux skips, mocked links, generic error assertions, and broad cleanup.",
          "Re-kicking or superseding PR #2527."
        ]
      },
      "contractChanges": [
        {
          "name": "Linux portableconfig diagnostic oracle",
          "authoredSource": "pkg/services/factory_definitions/internal/services/snapshots_portability/portableconfig/integrationtests/portable_bundled_files_integration_test.go, TestLoadPortableBundledFiles_RejectsFilesystemLinkEscapeWithoutEscapedWrite",
          "format": "go",
          "classification": "compatible test-oracle correction",
          "current": "if !strings.Contains(err.Error(), \"cannot escape the expand target through filesystem links\") {\n\tt.Fatalf(\"error = %q, want filesystem-link escape validation message\", err.Error())\n}",
          "proposed": "if !strings.Contains(err.Error(), \"cannot escape the materialization target through filesystem links\") {\n\tt.Fatalf(\"error = %q, want filesystem-link escape validation message\", err.Error())\n}",
          "compatibility": "Only the stale integration oracle changes. The correction does not broaden accepted errors or change production behavior.",
          "generatedOutputs": [],
          "consumers": [
            "Focused portableconfig Linux test",
            "Portableconfig integration package",
            "make test-integration",
            "Backend Integration",
            "Verification Policy"
          ]
        }
      ],
      "acceptanceCriteria": [
        "Given the real Linux symlink fixture, when runtime configuration loads, then loading fails with cannot escape the materialization target through filesystem links and factory/scripts/execute-story.ps1, and no external script exists.",
        "Given Linux symlink creation fails, when the test initializes, then the test fails and does not skip.",
        "Given current valid portable bundled-file cases, when the complete portableconfig integration package runs, then they pass unchanged.",
        "The named LINUX-FOCUSED and PORTABLECONFIG-PACKAGE suites pass and their evidence records the exact property each proves."
      ],
      "verification": {
        "behavioralWitness": "On Linux, TestLoadPortableBundledFiles_RejectsFilesystemLinkEscapeWithoutEscapedWrite creates a real external symlink, rejects the escape, names factory/scripts/execute-story.ps1, and proves the external file is absent.",
        "executableSpineEffect": "preserve",
        "requiredEvidence": [
          {
            "scope": "integration",
            "dependencyFidelity": "local_real",
            "cadence": "per change",
            "cost": "free",
            "procedure": "On Linux run: go test ./pkg/services/factory_definitions/internal/services/snapshots_portability/portableconfig/integrationtests -run '^TestLoadPortableBundledFiles_RejectsFilesystemLinkEscapeWithoutEscapedWrite$' -count=1 -v",
            "propertyProved": "The real filesystem link is rejected for the intended link-escape cause, the offending target is named, and no escaped write occurs.",
            "propertyNotProved": "Other portableconfig cases, hosted CI wiring, required-check policy, merge state, or other operating systems."
          },
          {
            "scope": "integration",
            "dependencyFidelity": "local_real",
            "cadence": "per change",
            "cost": "free",
            "procedure": "On Linux run: go test -short ./pkg/services/factory_definitions/internal/services/snapshots_portability/portableconfig/integrationtests -count=1",
            "propertyProved": "The corrected witness and all existing owning-package integration cases pass together.",
            "propertyNotProved": "Other registered integration packages, GitHub job selection, policy rollup, or merge state."
          }
        ],
        "highestFeasibleLevel": "Package integration with a local real Linux filesystem. No customer transport changes, so a CLI end-to-end test would not add relevant dependency fidelity.",
        "remainingUnprovenEdges": [
          {
            "edge": "Hosted Linux execution on the lane's own head",
            "gateId": "BACKEND-INTEGRATION-PR"
          },
          {
            "edge": "Derivative required-check policy rollup",
            "gateId": "VERIFICATION-POLICY-PR"
          },
          {
            "edge": "Cross-platform behavior outside Linux",
            "gateId": "EXISTING-PLATFORM-SUITES"
          }
        ]
      },
      "paidValidation": {
        "applicable": false,
        "trigger": "Not applicable to this local story.",
        "maximumCalls": 0,
        "maximumCost": "$0",
        "maximumDuration": "Focused and package test duration only, with no wall-clock acceptance threshold.",
        "fixtureAndOutputValidator": "Existing real-symlink fixture with rejection, materialization-target phrase, factory/scripts/execute-story.ps1, and no-write assertions.",
        "evidenceReuseKey": "Concatenate the delivered commit SHA, portableconfig-link-escape-v1, local-linux, real-symlink, and factory/scripts/execute-story.ps1."
      },
      "priority": 1,
      "passes": true,
      "notes": "PASS on commit 30ef94be06. Ubuntu WSL2 focused command exited 0 and passed TestLoadPortableBundledFiles_RejectsFilesystemLinkEscapeWithoutEscapedWrite; the real symlink was rejected with the unchanged materialization-target diagnostic, exact factory/scripts/execute-story.ps1 target, and no escaped write. Ubuntu package command exited 0 with all portableconfig integration cases passing. Windows host diagnostic exited 0 with the existing symlink-privilege skip and was not used as acceptance evidence. Remaining edges: registered make test-integration, clean-room loopback, hosted Backend Integration/Verification Policy, and delivery review."
    },
    {
      "id": "portable-link-escape-linux-contract-002",
      "title": "Validate the registered Linux integration spine from a clean environment",
      "description": "As an independent validator, I need to rerun the corrected real-link witness and the complete registered integration lane from a clean Linux checkout so review receives evidence from the delivered artifact rather than the implementation workspace.",
      "parentBehavior": "BEH-001 — The required Backend Integration gate executes the registered integration package and reliably proves portable Factory materialization rejects filesystem-link escapes.",
      "outcome": "A read-only clean-room report proves the corrected witness and full registered integration lane on the delivered head, or returns a delta-plan request without silently repairing defects.",
      "sourcePlanRef": null,
      "dependencies": [
        "portable-link-escape-linux-contract-001"
      ],
      "sharedSurfaceOwner": "This story is read-only and owns only the validation-loopback report. It does not edit portableconfig, .github/workflows/ci.yml, Makefile, or PR #2527.",
      "scope": {
        "in": [
          "Use a clean Linux checkout of the delivered head with real symlink support.",
          "Run the focused witness, complete portableconfig integration package, and make test-integration.",
          "Inspect that the delivered test retains the rejection, exact target, real link, and no-write assertions.",
          "Report PASS, FAIL, or BLOCKED for every project criterion using factory/docs/standards/validation-loopback-template.md."
        ],
        "out": [
          "Silent defect repair or implementation edits.",
          "Workflow or Makefile changes.",
          "Terminal CI polling, conflict resolution, or PR merge.",
          "Claims about unexecuted operating systems."
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given a clean Linux checkout of the delivered head, when the focused witness runs, then it passes without a Linux skip and proves rejection, cause, target, and no escaped write.",
        "Given the same checkout, when the portableconfig package and make test-integration run, then both pass and the report identifies the properties proved and remaining unproven edges.",
        "Given any validation defect, when the loopback completes, then it reports FAIL or BLOCKED with a delta-plan request and makes no repair.",
        "VAL-001 uses the canonical factory/docs/standards/validation-loopback-template.md report shape."
      ],
      "verification": {
        "behavioralWitness": "From a clean Linux checkout, run the actual named real-symlink test and then the complete registered backend integration target without a platform skip.",
        "executableSpineEffect": "promote",
        "requiredEvidence": [
          {
            "scope": "integration",
            "dependencyFidelity": "local_real",
            "cadence": "per PR before review handoff",
            "cost": "free",
            "procedure": "From a clean Linux checkout run the focused story-001 command, go test -short ./pkg/services/factory_definitions/internal/services/snapshots_portability/portableconfig/integrationtests -count=1, and make test-integration. Record commit, environment, exit codes, output, dependencies, and cost in the validation report.",
            "propertyProved": "The delivered head preserves the real-link security witness and passes every integration package registered by the current Makefile.",
            "propertyNotProved": "The lane's hosted required-check selection, Verification Policy result, conflict state, or merge state."
          }
        ],
        "highestFeasibleLevel": "Integrated registered backend lane with a real local Linux filesystem. This is the highest relevant runtime proof because the changed behavior is below CLI and API presentation and has no remote dependency.",
        "remainingUnprovenEdges": [
          {
            "edge": "Hosted Backend Integration execution on the current PR head",
            "gateId": "BACKEND-INTEGRATION-PR"
          },
          {
            "edge": "Verification Policy rollup on the current PR head",
            "gateId": "VERIFICATION-POLICY-PR"
          },
          {
            "edge": "Terminal required CI, conflict resolution, and merge",
            "gateId": "DELIVERY-REVIEW"
          }
        ]
      },
      "paidValidation": {
        "applicable": false,
        "trigger": "Not applicable. This loopback is local and free.",
        "maximumCalls": 0,
        "maximumCost": "$0",
        "maximumDuration": "One clean run of each named command, without an absolute timing threshold.",
        "fixtureAndOutputValidator": "Existing real-symlink fixture with exact error cause, target, and no-write assertions.",
        "evidenceReuseKey": "Concatenate the delivered commit SHA, portableconfig-link-escape-v1, clean-linux, make-test-integration, and real-symlink."
      },
      "priority": 2,
      "passes": true,
      "notes": "PASS on source SHA 30ef94be06. Read-only clean-room validation used a Git archive of the exact delivered head, extracted into native Linux /tmp on Ubuntu 24.04.1 LTS under WSL2 with Go 1.25.0 and GNU Make 4.3. The focused real-symlink witness exited 0 with no skip; the portableconfig package exited 0; and make test-integration exited 0 with every registered package/command passing. Source inspection retained the real symlink, unchanged materialization-target diagnostic, exact factory/scripts/execute-story.ps1 target, fail-closed rejection, and no-escaped-write assertions, with no stale expand-target oracle. Canonical report: C:/Users/andre/AppData/Local/Temp/portable-link-escape-linux-contract-validation-report.md. Remaining edges: hosted Backend Integration/Verification Policy, final push and CI start, review, conflicts, and merge."
    }
  ]
}
