### PR TITLE
cr2-hotfix-acp-stdio-hang

### DIFF
--- a/tests/functional/transport/acp/stdio/acp_liveness_test.go
+++ b/tests/functional/transport/acp/stdio/acp_liveness_test.go
@@ -1,0 +1,231 @@
+package stdio_test
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"runtime/pprof"
+	"sync"
+	"testing"
+	"time"
+)
+
+// These are failure ceilings for the package-owned protocol and lifecycle
+// edges. They are deliberately separate from the Go test timeout: a stalled
+// frame, signal, write, or command completion must identify its own stage and
+// fail well before the package-level process is killed without context.
+const (
+	acpFrameReadCeiling         = 10 * time.Second
+	acpFrameWriteCeiling        = 10 * time.Second
+	acpCommandCompletionCeiling = 10 * time.Second
+	acpControlSignalCeiling     = 10 * time.Second
+	acpReadAbortCeiling         = time.Second
+)
+
+var errACPWaitCeiling = errors.New("ACP stdio wait ceiling elapsed")
+
+type acpFrameReadResult struct {
+	line  string
+	bytes []byte
+	err   error
+}
+
+// acpFrameReader owns the test side of one process stdout pipe. A read is
+// performed in a short-lived goroutine so closing the OS pipe can interrupt
+// the same blocking read that was previously parked until the package
+// timeout. The result channel is buffered, allowing the read goroutine to
+// report after a diagnostic has already caused the test to stop.
+type acpFrameReader struct {
+	file     *os.File
+	reader   *bufio.Reader
+	selector string
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func newACPFrameReader(file *os.File, selector string) *acpFrameReader {
+	return &acpFrameReader{
+		file:     file,
+		reader:   bufio.NewReader(file),
+		selector: selector,
+	}
+}
+
+func (r *acpFrameReader) close() error {
+	if r == nil || r.file == nil {
+		return nil
+	}
+	r.closeOnce.Do(func() {
+		r.closeErr = r.file.Close()
+	})
+	return r.closeErr
+}
+
+func (r *acpFrameReader) readLine(t *testing.T, stage string) string {
+	t.Helper()
+	result := make(chan acpFrameReadResult, 1)
+	go func() {
+		line, err := r.reader.ReadString('\n')
+		result <- acpFrameReadResult{line: line, err: err}
+	}()
+
+	timer := time.NewTimer(acpFrameReadCeiling)
+	defer timer.Stop()
+	select {
+	case outcome := <-result:
+		if outcome.err != nil {
+			failACPStdioWait(t, r.selector, stage, "bufio.Reader.ReadString('\\n')", "newline-terminated ACP frame on process stdout", outcome.err)
+		}
+		return outcome.line
+	case <-timer.C:
+		closeErr := r.close()
+		waitForACPReadAbort(t, result, r.selector, stage, "bufio.Reader.ReadString('\\n')", "newline-terminated ACP frame on process stdout", closeErr)
+		return ""
+	}
+}
+
+func (r *acpFrameReader) readAll(t *testing.T, stage string) []byte {
+	t.Helper()
+	result := make(chan acpFrameReadResult, 1)
+	go func() {
+		payload, err := io.ReadAll(r.reader)
+		result <- acpFrameReadResult{bytes: payload, err: err}
+	}()
+
+	timer := time.NewTimer(acpFrameReadCeiling)
+	defer timer.Stop()
+	select {
+	case outcome := <-result:
+		if outcome.err != nil {
+			failACPStdioWait(t, r.selector, stage, "io.ReadAll(bufio.Reader)", "EOF on process stdout after command completion", outcome.err)
+		}
+		return outcome.bytes
+	case <-timer.C:
+		closeErr := r.close()
+		waitForACPReadAbort(t, result, r.selector, stage, "io.ReadAll(bufio.Reader)", "EOF on process stdout after command completion", closeErr)
+		return nil
+	}
+}
+
+func waitForACPReadAbort(
+	t *testing.T,
+	result <-chan acpFrameReadResult,
+	selector, stage, operation, target string,
+	closeErr error,
+) {
+	t.Helper()
+	abortTimer := time.NewTimer(acpReadAbortCeiling)
+	defer abortTimer.Stop()
+	select {
+	case <-result:
+		failACPStdioWait(t, selector, stage, operation, target, fmt.Errorf("%w; stream close error=%v; read returned after close", errACPWaitCeiling, closeErr))
+	case <-abortTimer.C:
+		failACPStdioWait(t, selector, stage, operation, target, fmt.Errorf("%w; stream close error=%v; read goroutine did not return after close", errACPWaitCeiling, closeErr))
+	}
+}
+
+// writeACPBytes applies the same package-local failure ceiling to the caller
+// side of an OS pipe. Large malformed-frame fixtures otherwise could park in
+// Write before the response reader gets a chance to report the actual stage.
+func writeACPBytes(t *testing.T, writer io.Writer, payload []byte, stage string) {
+	t.Helper()
+	result := make(chan error, 1)
+	go func() {
+		written, err := writer.Write(payload)
+		if err == nil && written != len(payload) {
+			err = io.ErrShortWrite
+		}
+		result <- err
+	}()
+
+	timer := time.NewTimer(acpFrameWriteCeiling)
+	defer timer.Stop()
+	select {
+	case err := <-result:
+		if err != nil {
+			failACPStdioWait(t, t.Name(), stage, "io.Writer.Write", "complete ACP request frame on process stdin", err)
+		}
+	case <-timer.C:
+		var closeErr error
+		if closer, ok := writer.(io.Closer); ok {
+			closeErr = closer.Close()
+		}
+		abortTimer := time.NewTimer(acpReadAbortCeiling)
+		defer abortTimer.Stop()
+		select {
+		case <-result:
+			failACPStdioWait(t, t.Name(), stage, "io.Writer.Write", "complete ACP request frame on process stdin", fmt.Errorf("%w; stream close error=%v; write returned after close", errACPWaitCeiling, closeErr))
+		case <-abortTimer.C:
+			failACPStdioWait(t, t.Name(), stage, "io.Writer.Write", "complete ACP request frame on process stdin", fmt.Errorf("%w; stream close error=%v; write goroutine did not return after close", errACPWaitCeiling, closeErr))
+		}
+	}
+}
+
+func waitForACPSignal[T any](t *testing.T, selector, stage, target string, signal <-chan T) T {
+	t.Helper()
+	timer := time.NewTimer(acpControlSignalCeiling)
+	defer timer.Stop()
+	select {
+	case value := <-signal:
+		return value
+	case <-timer.C:
+		failACPStdioWait(t, selector, stage, "channel receive", target, errACPWaitCeiling)
+		var zero T
+		return zero
+	}
+}
+
+func waitForACPCommand(t *testing.T, done <-chan struct{}, stage string, closeOnTimeout func()) {
+	t.Helper()
+	timer := time.NewTimer(acpCommandCompletionCeiling)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return
+	case <-timer.C:
+		if closeOnTimeout != nil {
+			closeOnTimeout()
+		}
+		failACPStdioWait(t, t.Name(), stage, "support.ProcessCommand.Done channel receive", "Process.Execute goroutine completion after ACP stdin EOF", errACPWaitCeiling)
+	}
+}
+
+func failACPStdioWait(t testing.TB, selector, stage, operation, target string, err error) {
+	t.Helper()
+	dump := acpGoroutineDump()
+	t.Fatalf("ACP stdio bounded wait failed: selector=%q stage=%q source_operation=%q wait_target=%q error=%v\n--- goroutine dump (debug=2; exact parked goroutine is identified by its stack) ---\n%s", selector, stage, operation, target, err, dump)
+}
+
+func acpGoroutineDump() string {
+	var dump bytes.Buffer
+	if profile := pprof.Lookup("goroutine"); profile != nil {
+		if err := profile.WriteTo(&dump, 2); err != nil {
+			return fmt.Sprintf("goroutine profile unavailable: %v", err)
+		}
+	}
+	return dump.String()
+}
+
+func readRPCFrame(t *testing.T, reader *acpFrameReader, stage string) rpcFrame {
+	t.Helper()
+	line := reader.readLine(t, stage)
+	assertLineIsProtocolFrame(t, line)
+	var frame rpcFrame
+	if err := json.Unmarshal([]byte(line), &frame); err != nil {
+		t.Fatalf("unmarshal RPC line: %v", err)
+	}
+	return frame
+}
+
+func closeACPStreamFiles(files ...*os.File) {
+	for _, file := range files {
+		if file != nil {
+			_ = file.Close()
+		}
+	}
+}

--- a/tests/functional/transport/acp/stdio/cli_serve_acp_controls_test.go
+++ b/tests/functional/transport/acp/stdio/cli_serve_acp_controls_test.go
@@ -1,7 +1,6 @@
 package stdio_test
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -11,7 +10,6 @@ import (
 	"slices"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	acpsdk "github.com/coder/acp-go-sdk"
 
@@ -199,8 +197,10 @@ func TestServeACP_RootBuildProcessCloseThenLoadReplaysRetainedItemIdentities(t *
 type serveACPControlHarness struct {
 	runner      *controlProviderCommandRunner
 	cwd         string
+	stdinRead   *os.File
 	stdinWrite  *os.File
-	stdout      *bufio.Reader
+	stdout      *acpFrameReader
+	stdoutRead  *os.File
 	stdoutWrite *os.File
 	command     *support.ProcessCommand
 	stderr      *bytes.Buffer
@@ -245,15 +245,23 @@ func newServeACPControlHarness(t *testing.T, runner *controlProviderCommandRunne
 		WorkingDirectory: cwd,
 	})
 
-	return &serveACPControlHarness{
+	harness := &serveACPControlHarness{
 		runner:      runner,
 		cwd:         cwd,
+		stdinRead:   stdinRead,
 		stdinWrite:  stdinWrite,
-		stdout:      bufio.NewReader(stdoutRead),
+		stdout:      newACPFrameReader(stdoutRead, t.Name()),
+		stdoutRead:  stdoutRead,
 		stdoutWrite: stdoutWrite,
 		command:     command,
 		stderr:      &stderr,
 	}
+	t.Cleanup(harness.closeStreams)
+	return harness
+}
+
+func (h *serveACPControlHarness) closeStreams() {
+	closeACPStreamFiles(h.stdinRead, h.stdinWrite, h.stdoutRead, h.stdoutWrite)
 }
 
 func (h *serveACPControlHarness) openSession(t *testing.T) string {
@@ -328,7 +336,7 @@ func (h *serveACPControlHarness) responseWithUpdates(t *testing.T, id int) (rpcF
 	wantID := fmt.Sprintf("%d", id)
 	var updates []rpcFrame
 	for {
-		frame := readRPCFrame(t, h.stdout)
+		frame := readRPCFrame(t, h.stdout, "read ACP response or session/update frame")
 		if frame.Method != "" {
 			if frame.Method != string(acpsdk.ClientMethodSessionUpdate) {
 				t.Fatalf("unexpected ACP notification method %q", frame.Method)
@@ -351,7 +359,7 @@ func (h *serveACPControlHarness) responses(t *testing.T, ids ...string) map[stri
 	}
 	responses := make(map[string]rpcFrame, len(ids))
 	for len(pending) > 0 {
-		frame := readRPCFrame(t, h.stdout)
+		frame := readRPCFrame(t, h.stdout, "read ACP response while resolving correlated requests")
 		if frame.Method != "" {
 			continue
 		}
@@ -382,7 +390,7 @@ func (h *serveACPControlHarness) responsesThroughPromptTerminal(t *testing.T, pr
 	responses := make(map[string]rpcFrame, len(pending))
 	promptTerminalSeen := false
 	for len(pending) > 0 {
-		frame := readRPCFrame(t, h.stdout)
+		frame := readRPCFrame(t, h.stdout, "read ACP response while waiting for prompt terminalization")
 		if frame.Method != "" {
 			continue
 		}
@@ -407,13 +415,9 @@ func (h *serveACPControlHarness) finish(t *testing.T) {
 	if err := h.stdinWrite.Close(); err != nil {
 		t.Fatalf("close ACP stdin: %v", err)
 	}
-	select {
-	case <-h.command.Done():
-		if err := h.command.Err(); err != nil {
-			t.Fatalf("Process.Execute(you server acp) error = %v; stderr=%s", err, h.stderr.String())
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("Process.Execute(you server acp) did not return after stdin EOF")
+	waitForACPCommand(t, h.command.Done(), "clean stdin EOF / ACP server teardown", h.closeStreams)
+	if err := h.command.Err(); err != nil {
+		t.Fatalf("Process.Execute(you server acp) error = %v; stderr=%s", err, h.stderr.String())
 	}
 	h.command.AcceptError()
 	if err := h.stdoutWrite.Close(); err != nil {
@@ -529,25 +533,17 @@ func (r *controlProviderCommandRunner) CallCount() int {
 
 func (r *controlProviderCommandRunner) waitForStart(t *testing.T, want int) {
 	t.Helper()
-	select {
-	case got := <-r.started:
-		if got != want {
-			t.Fatalf("blocked provider command call = %d, want %d", got, want)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatalf("provider command call %d did not start", want)
+	got := waitForACPSignal(t, t.Name(), fmt.Sprintf("provider command call %d start", want), "controlProviderCommandRunner.started", r.started)
+	if got != want {
+		t.Fatalf("blocked provider command call = %d, want %d", got, want)
 	}
 }
 
 func (r *controlProviderCommandRunner) waitForCancellation(t *testing.T, want int) {
 	t.Helper()
-	select {
-	case got := <-r.cancelled:
-		if got != want {
-			t.Fatalf("cancelled provider command call = %d, want %d", got, want)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatalf("provider command call %d did not observe cancellation", want)
+	got := waitForACPSignal(t, t.Name(), fmt.Sprintf("provider command call %d cancellation", want), "controlProviderCommandRunner.cancelled", r.cancelled)
+	if got != want {
+		t.Fatalf("cancelled provider command call = %d, want %d", got, want)
 	}
 }
 

--- a/tests/functional/transport/acp/stdio/cli_serve_acp_prompt_test.go
+++ b/tests/functional/transport/acp/stdio/cli_serve_acp_prompt_test.go
@@ -1,7 +1,6 @@
 package stdio_test
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -10,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	acpsdk "github.com/coder/acp-go-sdk"
 
@@ -116,8 +114,11 @@ func TestServeACP_RootBuildProcessCompletesOneFactoryPrompt(t *testing.T) {
 		Stderr:           &stderr,
 		WorkingDirectory: cwd,
 	})
+	t.Cleanup(func() {
+		closeACPStreamFiles(stdinRead, stdinWrite, stdoutRead, stdoutWrite)
+	})
 
-	stdout := bufio.NewReader(stdoutRead)
+	stdout := newACPFrameReader(stdoutRead, t.Name())
 
 	writeRPCLine(t, stdinWrite, fmt.Sprintf(
 		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":%s}`,
@@ -176,20 +177,11 @@ func TestServeACP_RootBuildProcessCompletesOneFactoryPrompt(t *testing.T) {
 	if err := stdinWrite.Close(); err != nil {
 		t.Fatalf("close stdin: %v", err)
 	}
-	// command.Done() is the deterministic completion signal (closed exactly
-	// when Process.Execute returns); the surrounding time.After is only a
-	// hang guard against a genuine regression (Execute never returning after
-	// clean stdin EOF), not a substitute for it -- 5s is generous versus this
-	// in-process fixture's actual completion time (well under 1s in
-	// practice), matching the same bounded-wait-as-hang-guard shape already
-	// used for the real production stdio server's own cancellation test.
-	select {
-	case <-command.Done():
-		if err := command.Err(); err != nil {
-			t.Fatalf("Process.Execute(you server acp) error = %v after clean stdin EOF; stderr=%s", err, stderr.String())
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("Process.Execute(you server acp) did not return after stdin EOF")
+	waitForACPCommand(t, command.Done(), "clean stdin EOF / ACP server teardown", func() {
+		closeACPStreamFiles(stdinRead, stdinWrite, stdoutRead, stdoutWrite)
+	})
+	if err := command.Err(); err != nil {
+		t.Fatalf("Process.Execute(you server acp) error = %v after clean stdin EOF; stderr=%s", err, stderr.String())
 	}
 	command.AcceptError()
 
@@ -217,10 +209,7 @@ func TestServeACP_RootBuildProcessCompletesOneFactoryPrompt(t *testing.T) {
 	if err := stdoutWrite.Close(); err != nil {
 		t.Fatalf("close stdout: %v", err)
 	}
-	remaining, readErr := io.ReadAll(stdout)
-	if readErr != nil && readErr != io.EOF {
-		t.Fatalf("read remaining stdout: %v", readErr)
-	}
+	remaining := stdout.readAll(t, "drain trailing stdout after ACP server teardown")
 	if trimmed := strings.TrimSpace(string(remaining)); trimmed != "" {
 		assertLineIsProtocolFrame(t, trimmed)
 	}
@@ -233,23 +222,7 @@ func TestServeACP_RootBuildProcessCompletesOneFactoryPrompt(t *testing.T) {
 
 func writeRPCLine(t *testing.T, w io.Writer, line string) {
 	t.Helper()
-	if _, err := w.Write([]byte(line + "\n")); err != nil {
-		t.Fatalf("write RPC line %q: %v", line, err)
-	}
-}
-
-func readRPCFrame(t *testing.T, r *bufio.Reader) rpcFrame {
-	t.Helper()
-	line, err := r.ReadString('\n')
-	if err != nil {
-		t.Fatalf("read RPC line: %v", err)
-	}
-	assertLineIsProtocolFrame(t, line)
-	var frame rpcFrame
-	if err := json.Unmarshal([]byte(line), &frame); err != nil {
-		t.Fatalf("unmarshal RPC line %q: %v", line, err)
-	}
-	return frame
+	writeACPBytes(t, w, []byte(line+"\n"), "write ACP request frame")
 }
 
 // assertLineIsProtocolFrame proves a captured stdout line parses as a
@@ -270,10 +243,10 @@ func assertLineIsProtocolFrame(t *testing.T, line string) {
 // session/update notifications the connection emits alongside it. session/new
 // advertises its available commands, so a notification can legitimately
 // precede the response it belongs to.
-func readRPCResponse(t *testing.T, r *bufio.Reader) rpcFrame {
+func readRPCResponse(t *testing.T, r *acpFrameReader) rpcFrame {
 	t.Helper()
 	for {
-		frame := readRPCFrame(t, r)
+		frame := readRPCFrame(t, r, "read ACP response or session/update frame")
 		if frame.Method == "" {
 			return frame
 		}
@@ -385,11 +358,11 @@ func seedFixtureFactory(t *testing.T, cwd string) string {
 // so a tool_call notification legitimately precedes the message. Reading a
 // single frame and asserting its shape encodes an ordering the transport never
 // guaranteed.
-func readNotificationsUntilResponse(t *testing.T, r *bufio.Reader) (rpcFrame, []acpsdk.SessionNotification) {
+func readNotificationsUntilResponse(t *testing.T, r *acpFrameReader) (rpcFrame, []acpsdk.SessionNotification) {
 	t.Helper()
 	var notifications []acpsdk.SessionNotification
 	for {
-		frame := readRPCFrame(t, r)
+		frame := readRPCFrame(t, r, "read ACP prompt response or session/update frame")
 		if frame.Method == "" {
 			return frame, notifications
 		}

--- a/tests/functional/transport/acp/stdio/cli_serve_acp_wire_log_test.go
+++ b/tests/functional/transport/acp/stdio/cli_serve_acp_wire_log_test.go
@@ -1,7 +1,6 @@
 package stdio_test
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -76,10 +75,13 @@ func TestServeACPWritesAWireTranscriptByDefault(t *testing.T) {
 		Stderr:           &stderr,
 		WorkingDirectory: cwd,
 	})
+	t.Cleanup(func() {
+		closeACPStreamFiles(stdinRead, stdinWrite, stdoutRead, stdoutWrite)
+	})
 
-	stdout := &transcriptRPCReader{reader: bufio.NewReader(stdoutRead)}
+	stdout := &transcriptRPCReader{reader: newACPFrameReader(stdoutRead, t.Name())}
 	sent := exerciseTranscriptConversation(t, home, cwd, stdinWrite, stdout)
-	finishTranscriptConversation(t, home, command, stdinWrite, stdoutWrite, runner, stdout, sent)
+	finishTranscriptConversation(t, home, command, stdinRead, stdinWrite, stdoutRead, stdoutWrite, runner, stdout, sent)
 }
 
 func newTranscriptProviderRunner() *support.ShapedProviderCommandRunner {
@@ -185,7 +187,9 @@ func finishTranscriptConversation(
 	t *testing.T,
 	home string,
 	command *support.ProcessCommand,
+	stdinRead *os.File,
 	stdinWrite *os.File,
+	stdoutRead *os.File,
 	stdoutWrite *os.File,
 	runner *support.ShapedProviderCommandRunner,
 	stdout *transcriptRPCReader,
@@ -195,7 +199,9 @@ func finishTranscriptConversation(
 	if err := stdinWrite.Close(); err != nil {
 		t.Fatalf("close stdin: %v", err)
 	}
-	<-command.Done()
+	waitForACPCommand(t, command.Done(), "clean stdin EOF / ACP server teardown", func() {
+		closeACPStreamFiles(stdinRead, stdinWrite, stdoutRead, stdoutWrite)
+	})
 	if err := command.Err(); err != nil {
 		t.Fatalf("Process.Execute(you server acp) error = %v", err)
 	}
@@ -249,24 +255,21 @@ func (functionalWireClock) Now() time.Time {
 }
 
 type transcriptRPCReader struct {
-	reader   *bufio.Reader
+	reader   *acpFrameReader
 	received []string
 	frames   int
 }
 
-func (r *transcriptRPCReader) readFrame(t *testing.T) rpcFrame {
+func (r *transcriptRPCReader) readFrame(t *testing.T, stage string) rpcFrame {
 	t.Helper()
-	raw, err := r.reader.ReadString('\n')
-	if err != nil {
-		t.Fatalf("read RPC line: %v", err)
-	}
+	raw := r.reader.readLine(t, stage)
 	line := strings.TrimSpace(raw)
 	r.received = append(r.received, line)
 	r.frames++
 	assertLineIsProtocolFrame(t, line)
 	var frame rpcFrame
 	if err := json.Unmarshal([]byte(line), &frame); err != nil {
-		t.Fatalf("unmarshal RPC line %q: %v", line, err)
+		t.Fatalf("unmarshal RPC line: %v", err)
 	}
 	return frame
 }
@@ -274,7 +277,7 @@ func (r *transcriptRPCReader) readFrame(t *testing.T) rpcFrame {
 func (r *transcriptRPCReader) readResponse(t *testing.T) rpcFrame {
 	t.Helper()
 	for {
-		frame := r.readFrame(t)
+		frame := r.readFrame(t, "read ACP response or session/update frame")
 		if frame.Method == "" {
 			return frame
 		}
@@ -288,7 +291,7 @@ func (r *transcriptRPCReader) readNotificationsUntilResponse(t *testing.T) (rpcF
 	t.Helper()
 	var notifications []acpsdk.SessionNotification
 	for {
-		frame := r.readFrame(t)
+		frame := r.readFrame(t, "read ACP prompt response or session/update frame")
 		if frame.Method == "" {
 			return frame, notifications
 		}
@@ -531,6 +534,7 @@ func TestServeACPWireTranscriptIsOwnerReadableOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("root.BuildProcess() error = %v", err)
 	}
+	support.CleanupProcess(t, process)
 
 	var stdout, stderr bytes.Buffer
 	if err := process.Execute(root.Input{


### PR DESCRIPTION
{
  "project": "batch-operator-acp-stdio-hang-20260831-cr2-hotfix-acp-stdio-hang",
  "branchName": "cr2-hotfix-acp-stdio-hang",
  "description": "Reproduce and root-cause the ACP stdio functional-package hang, bound every package-owned blocking read and teardown wait with attributable diagnostics, migrate all eight witnesses to one concurrently safe path-routed root process, and prove stability plus materially lower package compute before clean-room and review handoff.",
  "context": {
    "customerAsk": {
      "title": "Fix the transport/acp/stdio 600s hang that is redding main, then cut its 20s steady state",
      "contention": "OWNS tests/functional/transport/acp/stdio only. This lane is deliberately UNGATED because main is red and every other lane inherits the failing check. Another lane owns tests/functional/internal/support/process.go -- rebase onto origin/main before final push and do not hand-merge that file. Must not touch tests/functional/internal/support/http_observation.go.",
      "evidence": "Main CI runs 33413218060 (pass 21.501s), 33415105837 (pass 20.765s), 33417965879 (FAIL 20.407s), and 33419755005 (FAIL 601.157s at the 600s hard timeout). The package is absent from functional-quarantine.json and has 8 tests, 17 BuildProcess matches/constructions, 0 exec.Command, 0 time.Sleep, and 0 WaitFor at head.",
      "mission": "Reproduce the hang under -race with a per-test ceiling and goroutine dump, verify the cause, bound every blocking read/teardown wait, then reduce steady-state elapsed by sharing one process without serialization and provide exact behavior, classification, count, A/B, repeat, CI, and delivery evidence.",
      "nonGoals": "Do not quarantine; do not edit process.go, http_observation.go, checkers, gates, lint ratchets, quarantine, or CI workflows; fix test compute rather than the gate."
    },
    "sourcePlan": "C:/Users/andre/work/portos/infinite-you/docs/temp/ci-compute-reduction-plan.md",
    "problem": "The eight-test ACP stdio functional package has both a fast failure and an intermittent unobservable hang that kills the test binary at 600 seconds, while repeated process construction and serial topology keep normal CI elapsed near 20 seconds.",
    "solution": "On unchanged base, reproduce and causally verify the exact blocked goroutine before editing; then add package-local bounded stage-aware waits, share one root-built process through a fail-closed normalized-path provider router and connection-distinct default recorder, preserve the eight classified witnesses, and prove behavior, cleanup, race safety, repeat stability, local directional improvement, clean-room runtime behavior, and exact-head CI through the defined implementation/review split."
  },
  "acceptanceCriteria": [
    "HANG-001 reproduces the hang on unchanged base, names the exact selector, parked goroutine, source operation, and wait target, verifies causality rather than a long-lived-select artifact, and the correction turns an equivalent stall into a selector/stage failure below the package timeout.",
    "FUNC-002 preserves all eight top-level ACP witnesses and their exact success, error, cancellation, replay, transcript, ordering, and permission outcomes; no test is deleted or quarantined.",
    "The delivered PR body contains the complete eight-row A/B/C/D table and a Weakened assertions section recording the forced one-megabyte rotation/file-count assertion before/after, the named lower-level coverage, and the property no longer proven here.",
    "ROUTE-002 and CONC-002 prove one root-built process, normalized exact-path fail-closed routing, disjoint concurrent scenarios, no capacity-one lease/global mutex, no cross-route/provider/transcript contamination, and reusable state after failure or cancellation.",
    "Every package-owned blocking read and teardown wait is deterministically cancellable and bounded; bad input, dependency failure/timeout, partial completion, concurrency, cancellation, capacity, persistence, recovery, empty/EOF, duplicate, ordering, and cleanup cases have observable outcomes.",
    "Mechanical evidence reports before/after binary builds, exec.Command spawns, waits, sleeps, BuildProcess matches and actual call sites, and top-level tests; builds/exec/sleeps stay zero, actual process construction reaches one, and top-level tests remain eight.",
    "RACE-003 is green for the shared-state scope and REPEAT-003 records ten consecutive green package runs with no run above the predeclared same-host head steady-state ceiling and no leak or retained-route symptom.",
    "PERF-003 records three warm alternating same-host base/head pairs, package elapsed, summed per-test elapsed, and concurrency ratios; head is directionally faster. The PR's exact-head Backend Functional Coverage elapsed is materially below the 20.407-21.501s main range or receives one bounded optimization pass and an honest terminal report.",
    "Security/privacy review confirms fail-closed routing, no sensitive payloads in diagnostics, transcript permission preservation, temporary artifact cleanup, zero remote/paid calls, and USD 0 cost; accessibility, keyboard, responsive, visual, and localization concerns are not applicable because no UI/copy changes occur.",
    "QUALITY-003 passes the focused ACP stdio suite, the two named wiretranscript rotation tests, make functional-boundary-check, make functional-os-boundary-check, and make lint; each is cited for its measured behavior or policy property and none substitutes for the runtime witnesses.",
    "No forbidden surface changes: especially no tests/functional/internal/support/process.go, tests/functional/internal/support/http_observation.go, production, sibling test package, quarantine, checker, gate, lint ratchet, baseline, workflow, public contract, generated artifact, configuration, UI, or paid/remote change.",
    "The first independently green bounded-liveness slice is pushed and a ready non-draft PR is open by roughly the third implementation iteration with CI started and the planned evidence sections; later work updates that same PR.",
    "LOOP-004 runs on a clean final-head checkout and reports through factory/docs/standards/validation-loopback-template.md without silently repairing defects; FAIL/BLOCKED contains a delta-plan request.",
    "Before final push the branch is rebased onto current origin/main, merge-base is verified, process.go is consumed from upstream without hand-merging, and the PR is open ready rather than draft.",
    "Review owns terminal exact-head required CI, conflict resolution, the PR comment containing CI package evidence, and merge; merge is the lane-wide boundary even though the lane is scheduling-ungated.",
    "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit."
  ],
  "behaviorLanes": [
    {
      "id": "BEH-001",
      "title": "Bounded and attributable ACP stdio liveness",
      "actors": ["maintainer", "CI runner", "ACP client"],
      "outcome": "A stalled frame read or teardown identifies its test, stage, goroutine, and wait target and terminates below the package timeout without changing ACP behavior.",
      "sharedSurfaceOwner": "cr2-hotfix-acp-stdio-hang exclusively owns tests/functional/transport/acp/stdio/**."
    },
    {
      "id": "BEH-002",
      "title": "Concurrent one-process ACP stdio witnesses",
      "actors": ["eight functional scenarios", "package shared fixture"],
      "outcome": "All eight witnesses reuse one root-built process with fail-closed normalized-path provider selection and connection-isolated streams/transcripts without serialization.",
      "sharedSurfaceOwner": "Story 002 owns the package-local shared fixture/router; shared process.go and http_observation.go remain owned elsewhere and excluded."
    },
    {
      "id": "BEH-003",
      "title": "Honest stability, compute, and delivery proof",
      "actors": ["validator", "implementation worker", "reviewer", "CI"],
      "outcome": "Race, repeat, cleanup, counts, paired local timing, clean-room runtime, and exact-head CI evidence support the fix and speedup with clear implementation/review ownership.",
      "sharedSurfaceOwner": "Implementation owns local evidence and handoff; review owns terminal CI, conflicts, and merge."
    }
  ],
  "contractChanges": [],
  "testClassifications": [
    {
      "test": "TestServeACP_RootBuildProcessProviderFailureTerminalizesPrompt",
      "classification": "B",
      "obligation": "Route its failure runner by normalized factory/cwd path; preserve failure terminalization and subsequent successful prompt."
    },
    {
      "test": "TestServeACP_RootBuildProcessCancelTerminalizesOnlyCapturedPrompt",
      "classification": "B",
      "obligation": "Route its blocking runner; preserve captured-call cancellation, second prompt success, and post-completion cancel idempotency."
    },
    {
      "test": "TestServeACP_RootBuildProcessCloseStopsCapturedFactorySession",
      "classification": "B",
      "obligation": "Route its blocking runner; preserve close response, cancellation, and later usable connection/process."
    },
    {
      "test": "TestServeACP_RootBuildProcessCloseThenLoadReplaysRetainedItemIdentities",
      "classification": "B",
      "obligation": "Route both controlled calls; preserve close cancellation plus retained item identities and order on load."
    },
    {
      "test": "TestServeACP_RootBuildProcessCompletesOneFactoryPrompt",
      "classification": "B",
      "obligation": "Route shaped provider output by factory/cwd path; preserve exact assistant text, stop reason, call count, and WorkDir."
    },
    {
      "test": "TestServeACPWritesAWireTranscriptByDefault",
      "classification": "C",
      "obligation": "Preserve production-default bidirectional transcript equivalence, malformed-frame recording, and per-connection separation; remove only forced one-megabyte rotation/file-count coverage, disclose it, and cite TestTeeWriterRollsBackRejectedFrameWithRollingTranscript plus TestTeeWriterPublishesAfterRollingRotationRecord."
    },
    {
      "test": "TestServeACPDoesNotRecordFailedOutboundFrame",
      "classification": "A",
      "obligation": "Use the shared default recorder and connection-specific evidence; preserve inbound-only transcript after stdout failure."
    },
    {
      "test": "TestServeACPWireTranscriptIsOwnerReadableOnly",
      "classification": "A",
      "obligation": "Use the shared default recorder; preserve POSIX 0600 and Windows owner-read/write-compatible assertions."
    }
  ],
  "functionalTestCaseMatrix": [
    {"id":"CASE-001","kind":"happy/provider recovery","given":"A routed provider fails the first prompt and succeeds the next","when":"The client sends two prompt requests","then":"The first terminalizes with existing failure behavior and the second returns exact fixture text/end-turn on the same route","owningStory":"cr2-hotfix-acp-stdio-hang-002"},
    {"id":"CASE-002","kind":"unhappy/dependency failure","given":"The controlled provider returns an error","when":"A prompt is processed","then":"The prompt terminalizes once with existing error behavior and command/streams finish boundedly","owningStory":"cr2-hotfix-acp-stdio-hang-001, cr2-hotfix-acp-stdio-hang-002"},
    {"id":"CASE-003","kind":"unhappy/dependency timeout/cancellation","given":"The first routed provider call blocks on context","when":"The client cancels the captured prompt","then":"Only call one observes cancellation, response is cancelled, and call two later succeeds","owningStory":"cr2-hotfix-acp-stdio-hang-002"},
    {"id":"CASE-004","kind":"boundary/idempotency","given":"A prompt already completed","when":"The client sends cancel again","then":"No result changes, no extra provider call occurs, and the connection remains usable","owningStory":"cr2-hotfix-acp-stdio-hang-002"},
    {"id":"CASE-005","kind":"unhappy/close cancellation","given":"A prompt is blocked in a captured Factory Session","when":"The client sends session/close","then":"Prompt and close responses arrive in defined order, one cancellation is observed, and teardown is bounded","owningStory":"cr2-hotfix-acp-stdio-hang-001, cr2-hotfix-acp-stdio-hang-002"},
    {"id":"CASE-006","kind":"happy/recovery","given":"A blocked prompt was closed","when":"A later action uses the shared process","then":"It completes on its own route without retained cancellation","owningStory":"cr2-hotfix-acp-stdio-hang-002"},
    {"id":"CASE-007","kind":"happy/persistence recovery","given":"Two prompt items exist and the active prompt is closed","when":"The client loads the retained session","then":"Exact item identities/order replay without duplicate or cross-session items","owningStory":"cr2-hotfix-acp-stdio-hang-002"},
    {"id":"CASE-008","kind":"happy/full prompt","given":"A seeded Factory/profile and shaped provider route exist","when":"Initialize, session/new, and session/prompt run over real pipes","then":"A nonblank session, exact target, assistant text, end-turn, one call, and exact WorkDir are observed","owningStory":"cr2-hotfix-acp-stdio-hang-001, cr2-hotfix-acp-stdio-hang-002"},
    {"id":"CASE-009","kind":"boundary/ordering","given":"Tool/session updates may precede assistant text","when":"The prompt drains until its response","then":"Only allowed updates occur, exact text is concatenated, and the terminal response follows","owningStory":"cr2-hotfix-acp-stdio-hang-001, cr2-hotfix-acp-stdio-hang-002"},
    {"id":"CASE-010","kind":"unhappy/bad input/max frame","given":"Five 600KiB malformed lines cross the connection","when":"Each line is submitted","then":"Each is rejected, bounded transcript byte/prefix data is retained, and later valid frames succeed","owningStory":"cr2-hotfix-acp-stdio-hang-002"},
    {"id":"CASE-011","kind":"happy/transcript","given":"Default recording is active for one connection","when":"The full transcript conversation runs","then":"Recorded inbound/outbound frames equal actual traffic in sequence and remain connection-distinct","owningStory":"cr2-hotfix-acp-stdio-hang-002"},
    {"id":"CASE-012","kind":"unhappy/partial completion","given":"Stdout fails while initialize response is written","when":"The command executes","then":"The public connection error is returned, only inbound is recorded, and teardown is bounded","owningStory":"cr2-hotfix-acp-stdio-hang-001, cr2-hotfix-acp-stdio-hang-002"},
    {"id":"CASE-013","kind":"authorization/security","given":"A default transcript file is created","when":"Its mode is inspected","then":"POSIX is exactly 0600 or Windows retains owner-read/write-compatible permissions without logging content","owningStory":"cr2-hotfix-acp-stdio-hang-002"},
    {"id":"CASE-014","kind":"unhappy/partial frame timeout","given":"A frame lacks a newline or expected response never arrives","when":"The read ceiling expires","then":"The named selector/stage fails, command/streams/routes clean up, and a later scenario succeeds","owningStory":"cr2-hotfix-acp-stdio-hang-001"},
    {"id":"CASE-015","kind":"unhappy/teardown timeout","given":"EOF/cancel is sent but Process.Execute does not return","when":"The completion ceiling expires","then":"The named teardown fails with a goroutine dump without waiting to 600 seconds","owningStory":"cr2-hotfix-acp-stdio-hang-001"},
    {"id":"CASE-016","kind":"unhappy/missing selector","given":"A command WorkDir has no registered runner","when":"The shared router receives it","then":"It fails closed with safe route context and invokes no other runner","owningStory":"cr2-hotfix-acp-stdio-hang-002"},
    {"id":"CASE-017","kind":"boundary/duplicate selector","given":"A route is already registered","when":"Another scenario registers the same normalized key","then":"Registration is rejected without replacing the live route","owningStory":"cr2-hotfix-acp-stdio-hang-002"},
    {"id":"CASE-018","kind":"boundary/ambiguous selector","given":"A path could match overlapping or unnormalized entries","when":"The router normalizes and selects","then":"Exactly one exact route wins or lookup fails closed; prefix/map-order matching is impossible","owningStory":"cr2-hotfix-acp-stdio-hang-002"},
    {"id":"CASE-019","kind":"concurrency","given":"Disjoint routes, homes, streams, and unique markers exist","when":"ACP journeys overlap","then":"Each sees only its own provider result/transcript, overlap is observable, and race detector is quiet","owningStory":"cr2-hotfix-acp-stdio-hang-002, cr2-hotfix-acp-stdio-hang-003"},
    {"id":"CASE-020","kind":"cancellation/cleanup","given":"A scenario fails or cancels after partial setup","when":"Cleanup runs","then":"Streams, command, route, temp/session ownership release once and the shared process remains reusable","owningStory":"cr2-hotfix-acp-stdio-hang-001, cr2-hotfix-acp-stdio-hang-002, cr2-hotfix-acp-stdio-hang-003"},
    {"id":"CASE-021","kind":"capacity","given":"All eligible tests share one process","when":"The package runs without a lease/global mutex","then":"Package time falls and summed-test/package ratio demonstrates overlap rather than capacity-one serialization","owningStory":"cr2-hotfix-acp-stdio-hang-003"},
    {"id":"CASE-022","kind":"boundary/repeat","given":"The package passed once and a head ceiling is declared","when":"It runs ten consecutive times","then":"All eight selectors pass each time below that ceiling with no timeout/leak/retained-route symptom","owningStory":"cr2-hotfix-acp-stdio-hang-003"},
    {"id":"CASE-023","kind":"recovery/root-cause verification","given":"A dump names a suspected blocked operation","when":"The suspect is minimally disabled or bounded and reproduction repeats","then":"The hang changes as predicted or the suspect is dismissed as a lifetime parked goroutine","owningStory":"cr2-hotfix-acp-stdio-hang-001"},
    {"id":"CASE-024","kind":"platform","given":"Local Windows and hosted Linux execute the same ACP journey","when":"Local gates and exact-head PR CI run","then":"Platform permission behavior remains correct and CI reports a bounded package outcome","owningStory":"cr2-hotfix-acp-stdio-hang-003, cr2-hotfix-acp-stdio-hang-004"},
    {"id":"CASE-025","kind":"empty/EOF","given":"No client frames remain after clean stdin close","when":"The command drains","then":"Process.Execute returns without extra stdout protocol noise and cleanup completes within its ceiling","owningStory":"cr2-hotfix-acp-stdio-hang-001, cr2-hotfix-acp-stdio-hang-002"}
  ],
  "userStories": [
    {
      "id": "cr2-hotfix-acp-stdio-hang-001",
      "title": "Reproduce the parked goroutine and make every stdio wait bounded and attributable",
      "description": "On unchanged base, reproduce the intermittent failure under race-enabled per-selector ceilings, retain and verify the timeout dump, add only package-local deterministic cancellation and stage-aware bounds for frame reads and teardown waits, then push the first green slice and open a ready PR early.",
      "parentBehavior": "BEH-001 — Bounded and attributable ACP stdio liveness",
      "outcome": "The exact blocked selector/goroutine/wait is known and causally verified, and an equivalent stall becomes a named bounded failure with cleanup while the existing per-test executable spine remains green.",
      "sourcePlanRef": "C:/Users/andre/work/portos/infinite-you/docs/temp/ci-compute-reduction-plan.md §§1, 4-6 and 8; customer hotfix reproduction/root-cause acceptance; docs/temp/scale-program-rules.md §§1, 3, 11 and 15",
      "dependencies": [],
      "sharedSurfaceOwner": "Exclusively owns package-local diagnostics/read/teardown code under tests/functional/transport/acp/stdio/**; tests/functional/internal/support/process.go and http_observation.go are excluded and owned elsewhere.",
      "scope": {
        "in": [
          "Unchanged-base per-selector race-enabled reproduction with ceilings well below 600 seconds",
          "Timeout dump retention and exact parked-goroutine/wait-target identification",
          "Minimal causal intervention and re-measurement",
          "Package-local bounded frame reads, command completion, cancellation, pipe close, and lifecycle-stage diagnostics",
          "CASE-002, CASE-008, CASE-009, CASE-012, CASE-014, CASE-015, CASE-020, CASE-023, and CASE-025",
          "First green commit/push and ready non-draft PR by roughly the third implementation iteration with planned classification/root-cause/evidence sections"
        ],
        "out": [
          "Shared-process migration or selector router",
          "Performance claims",
          "Production/shared-support changes",
          "Timeout padding, sleeps, quarantine, checker/gate/workflow changes"
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given unchanged base, when bounded race-enabled reproduction triggers the hang, then the artifact names the exact selector, goroutine, source operation, and wait target.",
        "Given the suspect, when a minimal intervention is applied and the same reproduction repeats, then evidence confirms the predicted change or the suspect is dismissed and investigation continues.",
        "Given a missing/partial response or stalled teardown, when its ceiling expires, then the named test/stage fails below the package timeout, cancels the command, closes owned streams, and a following journey succeeds.",
        "Given all eight current journeys on the old per-test topology, when run after the liveness correction, then their exact protocol/value/error assertions remain green.",
        "Given the first independently green liveness slice, when delivered by roughly the third implementation iteration, then its commit is pushed and a ready non-draft PR is open with CI started and initial classification/root-cause/evidence sections, without waiting for early CI to finish before continuing owned work.",
        "Failure behavior: if reproduction cannot name a cause or needs an excluded surface, stop with structured evidence and operator-mailbox escalation rather than making a speculative fix."
      ],
      "verification": {
        "behavioralWitness": "A reproduced stalled read/teardown emits the named bounded failure and goroutine dump; after the verified correction, that selector and a subsequent healthy selector finish through real Process.Execute pipes.",
        "executableSpineEffect": "establish",
        "requiredEvidence": [
          {
            "scope": "functional diagnostic",
            "dependencyFidelity": "local_real root composition and OS pipes with a controlled provider command edge",
            "cadence": "before source change and risk-triggered after the minimal correction",
            "cost": "free with bounded local CPU/time",
            "procedure": "Enumerate all selectors; assign each exact listed name to PowerShell variable $selector and run go test -race -v -json -count=1 -timeout=30s -run ('^' + [regex]::Escape($selector) + '$') ./tests/functional/transport/acp/stdio, then run the full package under a bounded contention/repeat command; retain the dump and repeat the same topology after the minimal causal intervention.",
            "propertyProved": "Exact blocked selector/goroutine/wait, cause rather than correlation, bounded diagnostic failure, cleanup, and preserved ACP behavior.",
            "propertyNotProved": "Shared-process isolation, ten-run stability, elapsed reduction, hosted Linux contention, or terminal CI."
          },
          {
            "scope": "functional",
            "dependencyFidelity": "local_real per-test root processes and pipes with controlled provider edges",
            "cadence": "per change",
            "cost": "free",
            "procedure": "Run focused CASE-002/008/009/012/014/015/020/025 selectors and the complete package on the pre-sharing topology with verbose JSON output.",
            "propertyProved": "Existing eight-test protocol behavior plus bounded EOF, partial frame, outbound failure, and teardown recovery.",
            "propertyNotProved": "One-process routing or performance improvement."
          }
        ],
        "highestFeasibleLevel": "Functional through real Process.Execute and caller-owned OS pipes; a built executable is unnecessary because the defect is in this in-process functional harness.",
        "remainingUnprovenEdges": [
          {"edge":"Concurrent shared process","gateId":"CONC-002"},
          {"edge":"Race and ten-run stability","gateId":"RACE-003/REPEAT-003"},
          {"edge":"Directional elapsed reduction","gateId":"PERF-003"},
          {"edge":"Hosted Linux package outcome","gateId":"CI-REVIEW"}
        ]
      },
      "paidValidation": {
        "applicable": false,
        "trigger": "never",
        "maximumCalls": 0,
        "maximumCostUSD": 0,
        "maximumDurationMinutes": 0,
        "fixtureAndOutputValidator": "Controlled provider runners; exact ACP frames/stage errors and the Go goroutine dump.",
        "evidenceReuseKey": "commit SHA + Go version + OS/arch + selector + race/count/timeout flags"
      },
      "priority": 1,
    "passes": false,
    "notes": "Partial package-local slice implemented. On unchanged base, all eight exact selectors and the full package passed locally under go test -race -v -json -count=1 -timeout=30s on Windows/Go 1.25; the intermittent hosted hang did not reproduce locally. Historical CI run 33419755005 remains the only captured failure: tests/functional/transport/acp/stdio elapsed 601.157s after three control tests, with five selectors absent and no retained goroutine dump. Added acp_liveness_test.go so every caller-owned ACP frame read/write, control signal, command completion, trailing drain, and stream cleanup has a named stage, a 10-second package-local ceiling, owned-pipe interruption, and a debug=2 goroutine dump. Existing eight journeys, including the PR #2244 provider-failure release guard, remain unchanged in protocol/value/error assertions. Exact hosted parked goroutine and causal remeasurement remain unproven; Story 001 stays false pending that evidence. No production, shared-support, router, performance, quarantine, or forbidden-surface changes."
    },
    {
      "id": "cr2-hotfix-acp-stdio-hang-002",
      "title": "Preserve all eight ACP witnesses on one concurrent path-routed process",
      "description": "Create a package-local shared-process fixture, normalized exact-path provider router, common connection-distinct default recorder, and scenario-local streams/environment, then migrate the five B, two A, and one C witnesses without serialization.",
      "parentBehavior": "BEH-002 — Concurrent one-process ACP stdio witnesses",
      "outcome": "All eight functional journeys use one root-built process with fail-closed isolation, exact assertions, deterministic cleanup, and no capacity-one lease/global mutex.",
      "sourcePlanRef": "C:/Users/andre/work/portos/infinite-you/docs/temp/ci-compute-reduction-plan.md §§2-6 and 8-9; docs/temp/scale-program-rules.md §§1-6 and 9",
      "dependencies": ["cr2-hotfix-acp-stdio-hang-001"],
      "sharedSurfaceOwner": "Owns the package-local fixture/router and all three stdio test files; consumes but never edits tests/functional/internal/support/process.go and does not touch http_observation.go.",
      "scope": {
        "in": [
          "One shared BuildProcessWithContext construction",
          "Normalized exact-path fail-closed provider routing",
          "Connection-distinct common production-default recorder",
          "Unique per-test home/cwd/factory/stream state and safe parallel execution",
          "Migration/removal of old construction paths and complete eight-row A/B/C/D obligations",
          "CASE-001 through CASE-013, CASE-016 through CASE-021, and CASE-025"
        ],
        "out": [
          "Shared process.go or production selectors",
          "API server fixture changes",
          "Capacity-one/global scenario mutex",
          "Parallel t.Setenv",
          "Test deletion, quarantine, or class-D relocation"
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given all eight classified tests, when the package runs, then each retains the tabled assertion, all B extensions are delivered, any C weakening is disclosed, no test is deleted, and top-level count remains eight.",
        "Given disjoint concurrent scenarios, when commands execute, then exact normalized-path selection sends each request to one intended runner and never another scenario's runner or transcript.",
        "Given missing, duplicate, or ambiguous routes, when registration or lookup occurs, then it fails closed without replacing/invoking an existing route.",
        "Given provider failure, cancellation, outbound failure, partial setup, or cleanup, when the scenario ends, then streams/routes/session-local resources release and the shared process remains usable.",
        "Given mechanical counts, when measured at head, then binary builds, exec.Command, and sleeps remain zero, top-level tests remain eight, and actual process construction is one; match-style counts are also reported honestly.",
        "Failure behavior: if one-process sharing requires an excluded change or serialization, stop and return a plan delta rather than broadening scope."
      ],
      "verification": {
        "behavioralWitness": "Overlapping ACP conversations with unique markers receive their exact routed provider output and connection transcript, while failure, cancel, close/load, successful prompt, malformed input, failed stdout, and permissions assertions remain exact and the process serves a later request.",
        "executableSpineEffect": "extend",
        "requiredEvidence": [
          {
            "scope": "functional and package integration",
            "dependencyFidelity": "one local_real production-composed process and OS pipes with controlled provider router and production-default/common wire recorder",
            "cadence": "per change",
            "cost": "free",
            "procedure": "Run focused CASE-001 through CASE-021 and CASE-025 selectors, go test -v -json -count=1 -timeout=60s ./tests/functional/transport/acp/stdio, an overlap-focused selector gate, and go test -count=1 ./pkg/platform/wiretranscript -run '^(TestTeeWriterRollsBackRejectedFrameWithRollingTranscript|TestTeeWriterPublishesAfterRollingRotationRecord)$'; record exact values/order/calls/transcripts and route/resource cleanup.",
            "propertyProved": "One-process reuse, all eight ACP outcomes, route correctness/fail-closed behavior, concurrent isolation, recovery, and retained lower-level transcript rotation coverage after the disclosed C weakening.",
            "propertyNotProved": "Race freedom across schedules, ten-run stability, paired timing improvement, or hosted CI."
          },
          {
            "scope": "static/mechanical",
            "dependencyFidelity": "repository source and Go AST/search counts",
            "cadence": "once after migration",
            "cost": "free",
            "procedure": "Count top-level tests, binary-build sites, exec.Command sites, waits, sleeps, BuildProcess textual matches, and actual call expressions using identical base/head procedures.",
            "propertyProved": "No test deletion and actual removal of repeated construction/spawn/sleep work.",
            "propertyNotProved": "Runtime correctness or elapsed reduction."
          }
        ],
        "highestFeasibleLevel": "Functional through the actual CLI command tree on one shared root-built process; remote providers remain controlled because their availability is not under test.",
        "remainingUnprovenEdges": [
          {"edge":"Synchronization under race detector","gateId":"RACE-003"},
          {"edge":"Repeated cleanup and no retained state","gateId":"REPEAT-003"},
          {"edge":"Directional compute reduction","gateId":"PERF-003"},
          {"edge":"Clean final checkout","gateId":"LOOP-004"},
          {"edge":"Hosted suite contention","gateId":"CI-REVIEW"}
        ]
      },
      "paidValidation": {
        "applicable": false,
        "trigger": "never",
        "maximumCalls": 0,
        "maximumCostUSD": 0,
        "maximumDurationMinutes": 0,
        "fixtureAndOutputValidator": "Routed deterministic provider fixtures; exact ACP frames, call WorkDir/count, transcripts, permissions, and route/resource counts.",
        "evidenceReuseKey": "commit SHA + fixture/router version + Go version + OS/arch + test command"
      },
      "priority": 2,
      "passes": false,
      "notes": ""
    },
    {
      "id": "cr2-hotfix-acp-stdio-hang-003",
      "title": "Prove repeatability, race safety, cleanup, and directional compute reduction",
      "description": "Run the shared-state race gate, ten-run stability sequence, exact cleanup/count checks, and three warm alternating same-host base/head pairs with package elapsed, summed per-test time, and concurrency ratios, allowing only one bounded optimization pass on non-improvement.",
      "parentBehavior": "BEH-003 — Honest stability, compute, and delivery proof",
      "outcome": "Preserved eight-test behavior, bounded cleanup, tested synchronization, ten-run stability, and directional local compute improvement are evidenced without benchmark cherry-picking.",
      "sourcePlanRef": "C:/Users/andre/work/portos/infinite-you/docs/temp/ci-compute-reduction-plan.md §§1, 4-5 and 8; docs/temp/scale-program-rules.md §§1, 3, 7 and 15",
      "dependencies": ["cr2-hotfix-acp-stdio-hang-002"],
      "sharedSurfaceOwner": "Owns local package evidence and only package-local corrections exposed by that evidence; PR-body/comment evidence is not committed CI evidence.",
      "scope": {
        "in": [
          "Full package and overlap-focused race validation",
          "Ten consecutive executions under a predeclared warm head ceiling",
          "Route/process/stream/temp cleanup evidence",
          "Identical base/head mechanical counts",
          "Three warm alternating same-host base/head timing pairs with package/summed-test seconds and ratios",
          "One bounded package-local optimization pass if elapsed does not improve"
        ],
        "out": [
          "Portable local timing SLA or quiet-host prerequisite",
          "Sampling until favorable numbers appear",
          "Paid/remote calls or suite-wide optimization",
          "Terminal PR CI or merge",
          "Edits outside the leased package"
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given the shared fixture, when the material scope runs under -race, then no data race appears and exact route/transcript/session assertions pass.",
        "Given a declared warm head ceiling, when ten consecutive package executions run, then all are green, none exceeds it, and no route/resource/leak symptom appears.",
        "Given three alternating warm base/head pairs, when JSON is analyzed, then every package value, summed per-test value, and ratio is reported and head is directionally faster overall without a universal percentage claim.",
        "Given identical base/head count procedures, when measured, then all requested counts are reported with no hidden deletion; builds/exec/sleeps remain zero and actual construction is one.",
        "Failure behavior: if race/hang/leak persists or elapsed does not improve after one bounded pass, report exact PASS-WITH-DOCUMENTED-EXCLUSION, FAIL, or BLOCKED evidence rather than altering gates or quarantine."
      ],
      "verification": {
        "behavioralWitness": "Ten successive real-pipe package journeys and the race run finish without hang/cross-talk, while clean paired base/head evidence shows lower package compute with the same eight tests.",
        "executableSpineEffect": "increase_fidelity",
        "requiredEvidence": [
          {
            "scope": "functional race/stress",
            "dependencyFidelity": "local_real shared root process and pipes with controlled provider router",
            "cadence": "once after structural change",
            "cost": "free with bounded local CPU/time",
            "procedure": "Run go test -race -count=1 -timeout=90s ./tests/functional/transport/acp/stdio and the smallest overlap-focused selector set; retain exact output and assertions.",
            "propertyProved": "Synchronization safety for tested router/fixture/cleanup schedules and preserved concurrent behavior.",
            "propertyNotProved": "All scheduler interleavings or hosted suite contention."
          },
          {
            "scope": "functional repeat",
            "dependencyFidelity": "local_real shared root process and pipes with controlled provider router",
            "cadence": "once before handoff",
            "cost": "free; exactly ten bounded package runs",
            "procedure": "Declare the ceiling from documented warm head characterization, then execute ten separate go test -json -count=1 -timeout=60s runs and record selector/package results plus residual-resource diagnostics.",
            "propertyProved": "Ten-run bounded stability and absence of observed retained state/leaks.",
            "propertyNotProved": "Long-duration soak or remote-provider behavior."
          },
          {
            "scope": "functional performance characterization",
            "dependencyFidelity": "same-host clean detached base/head worktrees with warm caches and identical controlled dependencies",
            "cadence": "once; three alternating pairs",
            "cost": "free with bounded local CPU/time",
            "procedure": "Alternate B/H three times using identical go test -json -count=1 commands; retain all results and derive package elapsed, sum of per-test pass Elapsed fields, concurrency ratio, and identical mechanical counts.",
            "propertyProved": "Directional local package improvement, concurrency shape, and removal of expensive topology work.",
            "propertyNotProved": "Portable absolute timing or exact-head GitHub CI elapsed."
          },
          {
            "scope": "static/unit/functional quality",
            "dependencyFidelity": "repository-local",
            "cadence": "per PR",
            "cost": "free",
            "procedure": "Run gofmt/diff checks, the focused ACP stdio suite, the two named wiretranscript rotation tests, make functional-boundary-check, make functional-os-boundary-check, and make lint; cite each measured property.",
            "propertyProved": "Formatting, functional construction and OS-boundary policy, repository lint policy, focused package behavior, and the lower-level rotation property remain valid.",
            "propertyNotProved": "Exact-head CI or merge."
          }
        ],
        "highestFeasibleLevel": "Local functional/stress through the actual reusable process and pipe boundary; hosted suite fidelity remains CI-REVIEW owned.",
        "remainingUnprovenEdges": [
          {"edge":"Clean final rebased head","gateId":"LOOP-004"},
          {"edge":"Exact-head Backend Functional Coverage elapsed","gateId":"CI-REVIEW"},
          {"edge":"Terminal CI and merge","gateId":"review stage"}
        ]
      },
      "paidValidation": {
        "applicable": false,
        "trigger": "never",
        "maximumCalls": 0,
        "maximumCostUSD": 0,
        "maximumDurationMinutes": 0,
        "fixtureAndOutputValidator": "Existing controlled providers; exact ACP assertions, race output, elapsed JSON, and resource/count ledger.",
        "evidenceReuseKey": "base/head SHA + Go version + OS/arch + cache state + command + alternating order + fixture hash"
      },
      "priority": 3,
      "passes": false,
      "notes": ""
    },
    {
      "id": "cr2-hotfix-acp-stdio-hang-004",
      "title": "Validate the final rebased runtime artifact and hand off exact-head CI",
      "description": "Rebase onto current origin/main without hand-merging the excluded shared helper, validate a clean detached final-head checkout through the complete ACP stdio runtime journey, emit the canonical read-only loopback report, push/open the ready PR, start CI, and hand terminal CI/merge ownership to review.",
      "parentBehavior": "BEH-003 — Honest stability, compute, and delivery proof",
      "outcome": "The final rebased implementation head has the highest planned local-real runtime proof and a complete clean-room report, while exact-head hosted CI and merge are explicitly review-owned.",
      "sourcePlanRef": "C:/Users/andre/work/portos/infinite-you/docs/temp/ci-compute-reduction-plan.md §§5, 7-8; docs/temp/scale-program-rules.md §§7-10; factory review/validation-loopback standards",
      "dependencies": ["cr2-hotfix-acp-stdio-hang-003"],
      "sharedSurfaceOwner": "The loopback is read-only; implementation owns rebase, final push, ready PR, CI start, and blocking feedback, while review owns terminal CI, conflicts returned after handoff, PR-comment CI evidence, and merge.",
      "scope": {
        "in": [
          "Fetch and rebase onto current origin/main",
          "No hand-merge of tests/functional/internal/support/process.go",
          "Merge-base and changed-path audit",
          "Clean detached final-head full package and risk-triggered race/repeat validation",
          "Canonical validation-loopback report without repair",
          "Ready PR, CI start, blocking feedback resolution, and review handoff"
        ],
        "out": [
          "Silent loopback repairs",
          "Polling or rechecking CI after the implementation finish line",
          "Committing CI-run evidence",
          "Terminal CI adjudication, conflicts after handoff, or merge",
          "Excluded/shared path edits"
        ]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given current origin/main, when final rebase completes, then merge-base equals origin/main, excluded shared files are absent from the diff, and the package fix remains without a process.go hand-merge.",
        "Given a clean detached final-head checkout, when the validator runs the complete ACP stdio journey, then all eight selectors, bounded failure/cleanup, shared-process isolation, and applicable race/repeat evidence pass with exact outputs.",
        "Given the canonical loopback template, when validation completes, then every project criterion is PASS/FAIL/BLOCKED with evidence and unproven edge, no defect is silently repaired, and FAIL/BLOCKED includes a delta-plan request.",
        "Given implementation handoff, when work stops, then final head is pushed, the PR is ready/open, CI has started, and blocking review feedback is addressed without a terminal CI claim.",
        "Failure behavior: if rebase needs a semantic edit to process.go, loopback fails, or exact-head CI later remains non-improving after the bounded pass, report the exact blocker/delta and do not hand-merge, quarantine, or edit gates."
      ],
      "verification": {
        "behavioralWitness": "From a clean final-head checkout, the complete eight-test ACP stdio package uses one shared root process and real pipes, terminates boundedly, preserves exact behavior, and emits the canonical validation report.",
        "executableSpineEffect": "promote",
        "requiredEvidence": [
          {
            "scope": "clean-room functional end-to-end for this package",
            "dependencyFidelity": "clean local_real production composition and OS pipes with controlled provider edge",
            "cadence": "once on final rebased implementation head",
            "cost": "free with bounded local resources",
            "procedure": "Verify fetch/rebase/merge-base/diff; in a clean detached worktree run the complete package with -v -json -count=1 -timeout=60s and the smallest risk-triggered race/repeat command; fill factory/docs/standards/validation-loopback-template.md without editing the checkout.",
            "propertyProved": "Final rebased local runtime behavior, eight-test integration, bounded cleanup, package-only ownership, and report integrity.",
            "propertyNotProved": "Hosted suite contention, terminal CI, remote provider behavior, or merge."
          },
          {
            "scope": "delivery and functional CI handoff",
            "dependencyFidelity": "remote Git/PR state at exact final head; GitHub-hosted Backend Functional Coverage is review-owned",
            "cadence": "once per final head",
            "cost": "bounded hosted CI resources; zero paid provider calls",
            "procedure": "Push final rebased head, verify the PR is ready and CI started, then stop implementation after blocking feedback is addressed. Review later extracts the exact package=... elapsed=...s outcome=... line and posts it in a PR comment before terminal CI/merge adjudication.",
            "propertyProved": "Correct implementation/review finish line; review CI proves hosted package outcome and elapsed on the exact PR head.",
            "propertyNotProved": "Merge until review completes it."
          }
        ],
        "highestFeasibleLevel": "Clean-room functional execution through the real customer command/process/stdio boundary; a built executable is not applicable because the functional standard requires root.BuildProcess/Process.Execute, and the hosted suite is the final promotion.",
        "remainingUnprovenEdges": [
          {"edge":"Terminal exact-head required CI and merge","gateId":"CI-REVIEW"},
          {"edge":"Remote paid provider behavior","gateId":"not applicable: zero-call budget and no provider contract change"}
        ]
      },
      "paidValidation": {
        "applicable": false,
        "trigger": "never",
        "maximumCalls": 0,
        "maximumCostUSD": 0,
        "maximumDurationMinutes": 0,
        "fixtureAndOutputValidator": "Clean checkout, controlled provider routes, exact ACP/test outputs, loopback report, PR state, and review-owned CI package line.",
        "evidenceReuseKey": "final commit SHA + origin/main SHA + Go version + OS/arch + command + PR head SHA"
      },
      "priority": 4,
      "passes": false,
      "notes": ""
    }
  ]
}
